### PR TITLE
history-service: parallel empty-bucket skip for paginated reads

### DIFF
--- a/history-service/cmd/main.go
+++ b/history-service/cmd/main.go
@@ -66,6 +66,8 @@ func main() {
 	slog.Info("message bucket configured",
 		"hours", cfg.MessageBucketHours,
 		"maxBuckets", cfg.MessageReadMaxBuckets,
+		"readBucketConcurrency", cfg.MessageReadBucketConcurrency,
+		"readEscalateAfter", cfg.MessageReadEscalateAfter,
 		"historyFloorDays", cfg.MessageHistoryFloorDays,
 		"largeRoomThreshold", cfg.LargeRoomThreshold,
 		"maxPinnedPerRoom", cfg.MaxPinnedPerRoom,
@@ -132,7 +134,8 @@ func main() {
 		cipher = atrest.NewCipher(w, atrest.NewMongoDEKStore(dekColl), cfg.Atrest)
 	}
 
-	cassRepo := cassrepo.NewRepository(cassSession, bucketSizer, cfg.MessageReadMaxBuckets, cipher)
+	cassRepo := cassrepo.NewRepository(cassSession, bucketSizer, cfg.MessageReadMaxBuckets, cipher,
+		cassrepo.WithReadConcurrency(cfg.MessageReadBucketConcurrency, cfg.MessageReadEscalateAfter))
 	db := mongoClient.Database(cfg.Mongo.DB)
 	subRepo := mongorepo.NewSubscriptionRepo(db)
 	roomRepo := mongorepo.NewRoomRepo(db)

--- a/history-service/internal/cassrepo/messages_by_room.go
+++ b/history-service/internal/cassrepo/messages_by_room.go
@@ -95,7 +95,7 @@ func (r *Repository) GetMessagesBefore(ctx context.Context, roomID string, befor
 	}
 
 	res, err := fillPage[models.Message](
-		ctx, r.bucket, walkDesc, startBucket, floorBucket, r.maxBuckets,
+		ctx, r.bucket, walkDesc, startBucket, floorBucket, r.walkCfg,
 		pageReq.PageSize, initialPageState, queryFn, r.scanMessagesUpTo(ctx),
 	)
 	if err != nil {
@@ -142,7 +142,7 @@ func (r *Repository) GetMessagesBetweenDesc(ctx context.Context, roomID string, 
 	}
 
 	res, err := fillPage[models.Message](
-		ctx, r.bucket, walkDesc, startBucket, floorBucket, r.maxBuckets,
+		ctx, r.bucket, walkDesc, startBucket, floorBucket, r.walkCfg,
 		pageReq.PageSize, initialPageState, queryFn, r.scanMessagesUpTo(ctx),
 	)
 	if err != nil {
@@ -172,7 +172,7 @@ func (r *Repository) GetMessagesAfter(ctx context.Context, roomID string, after 
 	}
 
 	res, err := fillPage[models.Message](
-		ctx, r.bucket, walkAsc, startBucket, ceilingBucket, r.maxBuckets,
+		ctx, r.bucket, walkAsc, startBucket, ceilingBucket, r.walkCfg,
 		pageReq.PageSize, initialPageState, queryFn, r.scanMessagesUpTo(ctx),
 	)
 	if err != nil {
@@ -196,7 +196,7 @@ func (r *Repository) GetAllMessagesAsc(ctx context.Context, roomID string, floor
 	}
 
 	res, err := fillPage[models.Message](
-		ctx, r.bucket, walkAsc, startBucket, ceilingBucket, r.maxBuckets,
+		ctx, r.bucket, walkAsc, startBucket, ceilingBucket, r.walkCfg,
 		pageReq.PageSize, initialPageState, queryFn, r.scanMessagesUpTo(ctx),
 	)
 	if err != nil {

--- a/history-service/internal/cassrepo/repository.go
+++ b/history-service/internal/cassrepo/repository.go
@@ -11,22 +11,45 @@ import (
 // configuration shared by all queries against bucketed message tables, plus
 // an optional at-rest Cipher for encrypted message bodies.
 type Repository struct {
-	session    *gocql.Session
-	bucket     msgbucket.Sizer
-	maxBuckets int
-	cipher     atrest.Cipher // nil when ATREST_ENABLED=false
+	session *gocql.Session
+	bucket  msgbucket.Sizer
+	walkCfg walkConfig
+	cipher  atrest.Cipher // nil when ATREST_ENABLED=false
+}
+
+// Option customizes a Repository at construction time.
+type Option func(*Repository)
+
+// WithReadConcurrency enables the parallel empty-bucket skip on paginated reads:
+// after escalateAfter consecutive empty buckets, up to concurrency buckets are
+// probed concurrently. Values <=1 / <=0 leave the walk strictly serial (the
+// default), so this is opt-in and byte-compatible with the serial behavior.
+func WithReadConcurrency(concurrency, escalateAfter int) Option {
+	return func(r *Repository) {
+		if concurrency > 1 {
+			r.walkCfg.concurrency = concurrency
+		}
+		if escalateAfter > 0 {
+			r.walkCfg.escalateAfter = escalateAfter
+		}
+	}
 }
 
 // NewRepository wires a session, bucket sizer, max-walk depth, and (optional)
 // at-rest Cipher. maxBuckets caps how far a paginated read walks through empty
 // buckets before returning a non-terminal cursor. cipher may be nil; when nil
 // the read path treats encountered enc_payload rows as a configuration error
-// and the write path uses legacy plaintext columns.
-func NewRepository(session *gocql.Session, bucket msgbucket.Sizer, maxBuckets int, cipher atrest.Cipher) *Repository {
-	return &Repository{
-		session:    session,
-		bucket:     bucket,
-		maxBuckets: maxBuckets,
-		cipher:     cipher,
+// and the write path uses legacy plaintext columns. Reads default to a serial
+// bucket walk; pass WithReadConcurrency to enable parallel empty-bucket skips.
+func NewRepository(session *gocql.Session, bucket msgbucket.Sizer, maxBuckets int, cipher atrest.Cipher, opts ...Option) *Repository {
+	r := &Repository{
+		session: session,
+		bucket:  bucket,
+		walkCfg: walkConfig{maxBuckets: maxBuckets, concurrency: 1, escalateAfter: 0},
+		cipher:  cipher,
 	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }

--- a/history-service/internal/cassrepo/walker.go
+++ b/history-service/internal/cassrepo/walker.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/gocql/gocql"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/hmchangw/chat/pkg/msgbucket"
 )
@@ -85,98 +86,168 @@ func (r pageResult[T]) toPage() Page[T] {
 // letting callers apply a per-call predicate (e.g. created_at < before) only where needed.
 type bucketQueryFn func(bucket int64, firstBucket bool) *gocql.Query
 
-// fillPage walks buckets in the given direction starting at startBucket,
-// issuing one query per bucket and accumulating rows into out until pageSize
-// is reached or maxBuckets is exhausted. The first bucket may resume from a
-// caller-supplied gocql page state; later buckets always start fresh.
+// walkConfig bounds a bucket walk. concurrency<=1 (or escalateAfter<=0) keeps
+// the walk strictly serial — byte-identical to the original one-bucket-per-RTT
+// behavior. With concurrency>1 the walk escalates to a parallel empty-bucket
+// skip after escalateAfter consecutive empty buckets (see walkBuckets).
+type walkConfig struct {
+	maxBuckets    int // hard cap on buckets traversed before returning a non-terminal cursor
+	concurrency   int // max buckets probed concurrently once escalated; <=1 disables parallelism
+	escalateAfter int // consecutive empty buckets that trigger the parallel skip; <=0 disables
+}
+
+// bucketResult is one bucket's contribution to a page. nextPageState is non-nil
+// iff the bucket was truncated at the requested limit with rows still remaining
+// — the signal that the page filled mid-bucket and must resume here.
+type bucketResult[T any] struct {
+	rows          []T
+	nextPageState []byte
+}
+
+// bucketFetcher reads up to `limit` rows from a single bucket, resuming from
+// pageState (nil = start of bucket). It fully drains the bucket up to `limit`,
+// so a non-nil nextPageState means "limit reached, more rows remain here".
+// firstBucket lets the gocql adapter apply the first-step predicate. A non-nil
+// error aborts the whole walk.
+type bucketFetcher[T any] func(ctx context.Context, bucket int64, firstBucket bool, pageState []byte, limit int) (bucketResult[T], error)
+
+// walkBuckets walks buckets in the given direction from startBucket, calling
+// fetch once per bucket and accumulating rows until pageSize is reached, the
+// floor is crossed, or maxBuckets is exhausted.
 //
-// scan must consume up to `remaining` rows from iter and return them; it is
-// responsible for stopping when full. A non-nil error return aborts the walk
-// immediately — the bucket advance and any further queries are skipped, and
-// the accumulated rows are discarded. This is how scan signals a fatal per-row
-// error (e.g. a decrypt failure) up to the caller.
+// Serial mode reproduces the original one-bucket-at-a-time walk exactly. Once
+// cfg.escalateAfter consecutive empty buckets are seen (and cfg.concurrency>1),
+// it escalates: it probes up to cfg.concurrency buckets CONCURRENTLY to skip
+// runs of empty buckets quickly. Crucially, the parallel path only ever commits
+// to skipping EMPTY buckets — the first bucket that yields rows is handed back
+// to the serial path, so the page contents and resume cursor always come from a
+// single exact-limit read. This keeps parallel output byte-identical to serial
+// (proven by the differential test) while collapsing N sequential RTTs over
+// sparse history into ~N/concurrency rounds.
 //
 // floorBucket bounds the walk: DESC stops when bucket < floorBucket; ASC stops
 // when bucket > floorBucket. To disable floor-based termination, callers pass
 // math.MinInt64 (DESC) or math.MaxInt64 (ASC).
-func fillPage[T any](
+func walkBuckets[T any](
 	ctx context.Context,
 	sizer msgbucket.Sizer,
 	direction walkDirection,
 	startBucket int64,
 	floorBucket int64,
-	maxBuckets int,
+	cfg walkConfig,
 	pageSize int,
 	initialPageState []byte,
-	queryFn bucketQueryFn,
-	scan func(iter *gocql.Iter, remaining int) ([]T, error),
+	fetch bucketFetcher[T],
 ) (pageResult[T], error) {
 	out := make([]T, 0, pageSize)
 	bucket := startBucket
 	pageState := initialPageState
 	walked := 0
+	emptyRun := 0
+	parallel := false
 
-	advance := func() {
+	step := func(b int64) int64 {
 		if direction == walkDesc {
-			bucket = sizer.Prev(bucket)
-		} else {
-			bucket = sizer.Next(bucket)
+			return sizer.Prev(b)
 		}
+		return sizer.Next(b)
 	}
-
 	floorCrossed := func(b int64) bool {
 		if direction == walkDesc {
 			return b < floorBucket
 		}
 		return b > floorBucket
 	}
+	parallelEnabled := cfg.concurrency > 1 && cfg.escalateAfter > 0
 
-	for len(out) < pageSize && walked < maxBuckets {
+	for len(out) < pageSize && walked < cfg.maxBuckets {
 		if floorCrossed(bucket) {
 			return pageResult[T]{Rows: out, NextCursor: "", HasNext: false}, nil
 		}
 
-		q := queryFn(bucket, walked == 0).WithContext(ctx)
-		q = q.PageSize(pageSize - len(out))
-		if pageState != nil {
-			q = q.PageState(pageState)
-		}
+		if parallel {
+			// Build a batch of buckets to probe concurrently, bounded by the
+			// remaining bucket budget and the floor.
+			batch := make([]int64, 0, cfg.concurrency)
+			for b := bucket; len(batch) < cfg.concurrency && walked+len(batch) < cfg.maxBuckets && !floorCrossed(b); b = step(b) {
+				batch = append(batch, b)
+			}
+			if len(batch) == 0 {
+				break // floor or maxBuckets reached at a bucket boundary
+			}
 
-		iter := q.Iter()
-		rows, scanErr := scan(iter, pageSize-len(out))
-		out = append(out, rows...)
-		nextPageState := iter.PageState()
-		if err := iter.Close(); err != nil {
-			return pageResult[T]{}, fmt.Errorf("scan bucket %d: %w", bucket, err)
-		}
-		// A scan error (e.g. a per-row decrypt failure) is fatal: discard the
-		// accumulated rows and abort the walk so a later bucket can't overwrite
-		// the error or serve a partial page.
-		if scanErr != nil {
-			return pageResult[T]{}, fmt.Errorf("scan bucket %d: %w", bucket, scanErr)
-		}
+			results := make([]bucketResult[T], len(batch))
+			g, gctx := errgroup.WithContext(ctx)
+			for i := range batch {
+				g.Go(func() error {
+					// firstBucket is always false here: escalation needs >=1 prior
+					// empty bucket, so walked>0 and this is never the first step.
+					res, err := fetch(gctx, batch[i], false, nil, pageSize)
+					if err != nil {
+						return err
+					}
+					results[i] = res
+					return nil
+				})
+			}
+			if err := g.Wait(); err != nil {
+				return pageResult[T]{}, err
+			}
 
-		if len(nextPageState) > 0 && len(out) < pageSize {
-			// More rows in this bucket but page not yet full — continue draining.
-			pageState = nextPageState
+			firstData := -1
+			for i := range results {
+				if len(results[i].rows) > 0 {
+					firstData = i
+					break
+				}
+			}
+			if firstData < 0 {
+				// Whole batch empty: commit to skipping all of it, stay parallel.
+				for range batch {
+					bucket = step(bucket)
+				}
+				walked += len(batch)
+				continue
+			}
+			// Skip the empties before the data bucket; hand the data bucket back
+			// to the serial path (the speculatively-read rows beyond it are
+			// discarded — they get re-walked exactly once with precise limits).
+			for j := 0; j < firstData; j++ {
+				bucket = step(bucket)
+			}
+			walked += firstData
+			parallel = false
+			emptyRun = 0
+			pageState = nil
 			continue
 		}
-		if len(nextPageState) > 0 && len(out) >= pageSize {
+
+		// Serial step.
+		res, err := fetch(ctx, bucket, walked == 0, pageState, pageSize-len(out))
+		if err != nil {
+			return pageResult[T]{}, err
+		}
+		out = append(out, res.rows...)
+		if res.nextPageState != nil {
 			// Page filled mid-bucket — cursor resumes here on next call.
-			cursor, encErr := encodeBucketCursor(bucket, nextPageState)
+			cursor, encErr := encodeBucketCursor(bucket, res.nextPageState)
 			if encErr != nil {
 				return pageResult[T]{}, fmt.Errorf("encode resume cursor at bucket %d: %w", bucket, encErr)
 			}
-			return pageResult[T]{
-				Rows:       out,
-				NextCursor: cursor,
-				HasNext:    true,
-			}, nil
+			return pageResult[T]{Rows: out, NextCursor: cursor, HasNext: true}, nil
 		}
 
+		if len(res.rows) == 0 {
+			emptyRun++
+		} else {
+			emptyRun = 0
+		}
 		pageState = nil
-		advance()
+		bucket = step(bucket)
 		walked++
+		if parallelEnabled && emptyRun >= cfg.escalateAfter {
+			parallel = true
+		}
 	}
 
 	if floorCrossed(bucket) {
@@ -187,9 +258,58 @@ func fillPage[T any](
 	if encErr != nil {
 		return pageResult[T]{}, fmt.Errorf("encode resume cursor at bucket %d: %w", bucket, encErr)
 	}
-	return pageResult[T]{
-		Rows:       out,
-		NextCursor: cursor,
-		HasNext:    true,
-	}, nil
+	return pageResult[T]{Rows: out, NextCursor: cursor, HasNext: true}, nil
+}
+
+// fillPage adapts a gocql query/scan pair to walkBuckets: it builds a
+// bucketFetcher that drains one bucket up to `limit` rows across gocql pages,
+// then delegates the bucket traversal (serial or escalating-parallel per cfg)
+// to walkBuckets. The fetcher preserves the original semantics — a fatal scan
+// error (e.g. a per-row decrypt failure) aborts the whole walk.
+func fillPage[T any](
+	ctx context.Context,
+	sizer msgbucket.Sizer,
+	direction walkDirection,
+	startBucket int64,
+	floorBucket int64,
+	cfg walkConfig,
+	pageSize int,
+	initialPageState []byte,
+	queryFn bucketQueryFn,
+	scan func(iter *gocql.Iter, remaining int) ([]T, error),
+) (pageResult[T], error) {
+	fetch := func(fctx context.Context, bucket int64, firstBucket bool, pageState []byte, limit int) (bucketResult[T], error) {
+		rows := make([]T, 0, limit)
+		ps := pageState
+		for len(rows) < limit {
+			q := queryFn(bucket, firstBucket).WithContext(fctx).PageSize(limit - len(rows))
+			if ps != nil {
+				q = q.PageState(ps)
+			}
+			iter := q.Iter()
+			got, scanErr := scan(iter, limit-len(rows))
+			rows = append(rows, got...)
+			nextPageState := iter.PageState()
+			if err := iter.Close(); err != nil {
+				return bucketResult[T]{}, fmt.Errorf("scan bucket %d: %w", bucket, err)
+			}
+			if scanErr != nil {
+				return bucketResult[T]{}, fmt.Errorf("scan bucket %d: %w", bucket, scanErr)
+			}
+			if len(nextPageState) > 0 && len(rows) < limit {
+				// More rows in this bucket but limit not yet reached — keep draining.
+				ps = nextPageState
+				continue
+			}
+			if len(nextPageState) > 0 {
+				// Limit reached mid-bucket — signal a resume point.
+				return bucketResult[T]{rows: rows, nextPageState: nextPageState}, nil
+			}
+			// Bucket exhausted.
+			return bucketResult[T]{rows: rows, nextPageState: nil}, nil
+		}
+		return bucketResult[T]{rows: rows, nextPageState: nil}, nil
+	}
+
+	return walkBuckets[T](ctx, sizer, direction, startBucket, floorBucket, cfg, pageSize, initialPageState, fetch)
 }

--- a/history-service/internal/cassrepo/walker_parallel_test.go
+++ b/history-service/internal/cassrepo/walker_parallel_test.go
@@ -1,0 +1,239 @@
+package cassrepo
+
+import (
+	"context"
+	"encoding/binary"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/msgbucket"
+)
+
+// fakeFetcher serves rows from an in-memory map[bucket][]int, honoring `limit`
+// and an opaque 4-byte big-endian offset pageState — mirroring gocql's
+// PageSize/PageState contract so the walk orchestration can be exercised
+// without Cassandra. nextPageState is non-nil iff the bucket was truncated at
+// `limit` with rows still remaining.
+func fakeFetcher(data map[int64][]int, calls *[]int64, mu *sync.Mutex) bucketFetcher[int] {
+	return func(_ context.Context, bucket int64, _ bool, pageState []byte, limit int) (bucketResult[int], error) {
+		if calls != nil {
+			mu.Lock()
+			*calls = append(*calls, bucket)
+			mu.Unlock()
+		}
+		rows := data[bucket]
+		offset := 0
+		if len(pageState) == 4 {
+			offset = int(binary.BigEndian.Uint32(pageState))
+		}
+		if offset > len(rows) {
+			offset = len(rows)
+		}
+		end := offset + limit
+		if end > len(rows) {
+			end = len(rows)
+		}
+		out := append([]int(nil), rows[offset:end]...)
+		var next []byte
+		if end < len(rows) {
+			next = make([]byte, 4)
+			binary.BigEndian.PutUint32(next, uint32(end)) // #nosec G115 -- bounded by len(rows)
+		}
+		return bucketResult[int]{rows: out, nextPageState: next}, nil
+	}
+}
+
+// paginateAll drives walkBuckets to completion, threading each page's cursor
+// into the next call, and returns the per-page row slices.
+func paginateAll(t *testing.T, sizer msgbucket.Sizer, dir walkDirection, start, floor int64, cfg walkConfig, pageSize int, fetch bucketFetcher[int]) [][]int {
+	t.Helper()
+	var pages [][]int
+	bucket := start
+	var ps []byte
+	for i := 0; ; i++ {
+		require.Less(t, i, 10000, "pagination did not terminate")
+		res, err := walkBuckets[int](context.Background(), sizer, dir, bucket, floor, cfg, pageSize, ps, fetch)
+		require.NoError(t, err)
+		pages = append(pages, res.Rows)
+		if !res.HasNext {
+			break
+		}
+		b, nps, err := decodeBucketCursor(res.NextCursor)
+		require.NoError(t, err)
+		bucket, ps = b, nps
+	}
+	return pages
+}
+
+// TestWalkBuckets_ParallelMatchesSerial is the differential test: for the same
+// data, a parallel (concurrency>1) walk must produce byte-identical pages to a
+// serial (concurrency=1) walk, across both directions, varied gap densities,
+// and varied page sizes. This is the core correctness guarantee.
+func TestWalkBuckets_ParallelMatchesSerial(t *testing.T) {
+	sizer := msgbucket.New(72 * time.Hour)
+	win := sizer.WindowMs()
+
+	directions := []struct {
+		name string
+		dir  walkDirection
+	}{
+		{"desc", walkDesc},
+		{"asc", walkAsc},
+	}
+
+	for _, seed := range []int64{1, 7, 42, 1234, 99999} {
+		for _, gapPct := range []int{0, 50, 85, 97} {
+			for _, pageSize := range []int{1, 5, 20, 50} {
+				// #nosec G404 -- deterministic test fixtures, not security-sensitive
+				rng := rand.New(rand.NewSource(seed + int64(gapPct) + int64(pageSize)))
+				const spanBuckets = 250
+				data := map[int64][]int{}
+				id := 0
+				for idx := 0; idx <= spanBuckets; idx++ {
+					if rng.Intn(100) < gapPct {
+						continue // empty bucket
+					}
+					n := 1 + rng.Intn(6)
+					rows := make([]int, 0, n)
+					for k := 0; k < n; k++ {
+						id++
+						rows = append(rows, id)
+					}
+					data[int64(idx)*win] = rows
+				}
+
+				for _, d := range directions {
+					var start, floor int64
+					if d.dir == walkDesc {
+						start, floor = int64(spanBuckets)*win, 0
+					} else {
+						start, floor = 0, int64(spanBuckets)*win
+					}
+					serialCfg := walkConfig{maxBuckets: 100000, concurrency: 1, escalateAfter: 0}
+					parCfg := walkConfig{maxBuckets: 100000, concurrency: 4, escalateAfter: 3}
+
+					serial := paginateAll(t, sizer, d.dir, start, floor, serialCfg, pageSize, fakeFetcher(data, nil, nil))
+					par := paginateAll(t, sizer, d.dir, start, floor, parCfg, pageSize, fakeFetcher(data, nil, nil))
+
+					assert.Equalf(t, serial, par,
+						"seed=%d gap=%d page=%d dir=%s: parallel pages diverged from serial", seed, gapPct, pageSize, d.name)
+				}
+			}
+		}
+	}
+}
+
+// TestWalkBuckets_EscalatesAndHandsBackToSerial proves the parallel path
+// actually runs: after escalateAfter consecutive empties it batch-probes ahead,
+// then re-reads the first data bucket on the serial path (so the data bucket is
+// fetched twice — once speculatively, once for the exact-limit page).
+func TestWalkBuckets_EscalatesAndHandsBackToSerial(t *testing.T) {
+	sizer := msgbucket.New(72 * time.Hour)
+	win := sizer.WindowMs()
+	dataBucket := int64(5) * win
+	data := map[int64][]int{dataBucket: {101, 102, 103}}
+
+	var calls []int64
+	var mu sync.Mutex
+	cfg := walkConfig{maxBuckets: 100, concurrency: 4, escalateAfter: 2}
+	res, err := walkBuckets[int](context.Background(), sizer, walkDesc, int64(20)*win, 0, cfg, 10, nil, fakeFetcher(data, &calls, &mu))
+	require.NoError(t, err)
+
+	assert.Equal(t, []int{101, 102, 103}, res.Rows)
+	assert.False(t, res.HasNext, "walk reaching the floor must terminate without a cursor")
+
+	count := 0
+	for _, b := range calls {
+		if b == dataBucket {
+			count++
+		}
+	}
+	assert.GreaterOrEqualf(t, count, 2, "data bucket should be probed in a batch then re-read serially; calls=%v", calls)
+}
+
+// TestWalkBuckets_RespectsMaxBuckets confirms a walk over empties stops after
+// exactly maxBuckets, with identical stop position for serial and parallel.
+func TestWalkBuckets_RespectsMaxBuckets(t *testing.T) {
+	sizer := msgbucket.New(72 * time.Hour)
+	win := sizer.WindowMs()
+	start := int64(100) * win
+	data := map[int64][]int{} // entirely empty
+
+	for _, concurrency := range []int{1, 4} {
+		cfg := walkConfig{maxBuckets: 5, concurrency: concurrency, escalateAfter: 2}
+		res, err := walkBuckets[int](context.Background(), sizer, walkDesc, start, 0, cfg, 10, nil, fakeFetcher(data, nil, nil))
+		require.NoError(t, err)
+		assert.Empty(t, res.Rows, "concurrency=%d", concurrency)
+		require.True(t, res.HasNext, "concurrency=%d: capped walk must signal more", concurrency)
+		b, _, err := decodeBucketCursor(res.NextCursor)
+		require.NoError(t, err)
+		assert.Equal(t, start-5*win, b, "concurrency=%d: must stop exactly maxBuckets in", concurrency)
+	}
+}
+
+// TestWalkBuckets_StopsAtFloor confirms floor termination yields no cursor.
+func TestWalkBuckets_StopsAtFloor(t *testing.T) {
+	sizer := msgbucket.New(72 * time.Hour)
+	win := sizer.WindowMs()
+	data := map[int64][]int{} // empty
+
+	for _, concurrency := range []int{1, 4} {
+		cfg := walkConfig{maxBuckets: 1000, concurrency: concurrency, escalateAfter: 2}
+		res, err := walkBuckets[int](context.Background(), sizer, walkDesc, int64(8)*win, 0, cfg, 10, nil, fakeFetcher(data, nil, nil))
+		require.NoError(t, err)
+		assert.Empty(t, res.Rows)
+		assert.False(t, res.HasNext, "concurrency=%d: reaching floor must terminate", concurrency)
+		assert.Empty(t, res.NextCursor, "concurrency=%d", concurrency)
+	}
+}
+
+// TestWalkBuckets_BatchRunsConcurrently proves the escalated batch is fetched
+// in parallel, not sequentially: the batch fetchers rendezvous at a barrier
+// that only releases once `concurrency` of them are simultaneously in flight.
+// The channel is the synchronization primitive; time.After is only a
+// deadlock failsafe so a serial regression fails (slowly) instead of hanging.
+func TestWalkBuckets_BatchRunsConcurrently(t *testing.T) {
+	sizer := msgbucket.New(72 * time.Hour)
+	win := sizer.WindowMs()
+	const concurrency = 4
+
+	var inFlight, maxInFlight int32
+	var skipFirst sync.Once
+	var releaseOnce sync.Once
+	release := make(chan struct{})
+
+	fetch := func(_ context.Context, _ int64, _ bool, _ []byte, _ int) (bucketResult[int], error) {
+		// The single pre-escalation serial empty must not join the barrier.
+		skipped := false
+		skipFirst.Do(func() { skipped = true })
+		if !skipped {
+			n := atomic.AddInt32(&inFlight, 1)
+			for {
+				m := atomic.LoadInt32(&maxInFlight)
+				if n <= m || atomic.CompareAndSwapInt32(&maxInFlight, m, n) {
+					break
+				}
+			}
+			if n >= concurrency {
+				releaseOnce.Do(func() { close(release) })
+			}
+			select {
+			case <-release:
+			case <-time.After(500 * time.Millisecond):
+			}
+			atomic.AddInt32(&inFlight, -1)
+		}
+		return bucketResult[int]{}, nil // every bucket empty
+	}
+
+	cfg := walkConfig{maxBuckets: 12, concurrency: concurrency, escalateAfter: 1}
+	_, err := walkBuckets[int](context.Background(), sizer, walkDesc, int64(50)*win, 0, cfg, 10, nil, fetch)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, int(atomic.LoadInt32(&maxInFlight)), 2, "escalated batch must fetch buckets concurrently")
+}

--- a/history-service/internal/config/config.go
+++ b/history-service/internal/config/config.go
@@ -46,9 +46,18 @@ type Config struct {
 	MessageBucketHours      int             `env:"MESSAGE_BUCKET_HOURS"        envDefault:"72"`
 	MessageReadMaxBuckets   int             `env:"MESSAGE_READ_MAX_BUCKETS"    envDefault:"122"`
 	MessageHistoryFloorDays int             `env:"MESSAGE_HISTORY_FLOOR_DAYS"  envDefault:"365"`
-	LargeRoomThreshold      int             `env:"LARGE_ROOM_THRESHOLD"        envDefault:"500"`
-	MaxPinnedPerRoom        int             `env:"MAX_PINNED_PER_ROOM"         envDefault:"10"`
-	PinEnabled              bool            `env:"PIN_ENABLED"                 envDefault:"true"`
+
+	// Paginated-read bucket-walk concurrency. Concurrency=1 keeps reads strictly
+	// serial (one bucket per round-trip). Concurrency>1 lets a read probe that
+	// many buckets in parallel after EscalateAfter consecutive empty buckets,
+	// collapsing long empty-bucket walks (sparse rooms / deep lookback) into
+	// fewer round-trips. Keep concurrency below CASSANDRA_NUM_CONNS to avoid
+	// self-inflicted connection-pool exhaustion.
+	MessageReadBucketConcurrency int  `env:"MESSAGE_READ_BUCKET_CONCURRENCY" envDefault:"1"`
+	MessageReadEscalateAfter     int  `env:"MESSAGE_READ_ESCALATE_AFTER"     envDefault:"4"`
+	LargeRoomThreshold           int  `env:"LARGE_ROOM_THRESHOLD"        envDefault:"500"`
+	MaxPinnedPerRoom             int  `env:"MAX_PINNED_PER_ROOM"         envDefault:"10"`
+	PinEnabled                   bool `env:"PIN_ENABLED"                 envDefault:"true"`
 
 	// Subscription access-check cache. Only positive subscriptions are cached,
 	// so the TTL bounds how long revoked access can stay readable. Set size or
@@ -97,6 +106,12 @@ func validate(cfg *Config) error {
 	}
 	if cfg.RoomCacheTTL < 0 {
 		return fmt.Errorf("HISTORY_ROOM_CACHE_TTL must be >= 0, got %s", cfg.RoomCacheTTL)
+	}
+	if cfg.MessageReadBucketConcurrency < 1 {
+		return fmt.Errorf("MESSAGE_READ_BUCKET_CONCURRENCY must be >= 1, got %d", cfg.MessageReadBucketConcurrency)
+	}
+	if cfg.MessageReadEscalateAfter < 1 {
+		return fmt.Errorf("MESSAGE_READ_ESCALATE_AFTER must be >= 1, got %d", cfg.MessageReadEscalateAfter)
 	}
 	return nil
 }

--- a/history-service/internal/config/config_test.go
+++ b/history-service/internal/config/config_test.go
@@ -13,11 +13,29 @@ import (
 // validate() doesn't touch them.
 func baseValid() Config {
 	return Config{
-		SubCacheSize:  100000,
-		SubCacheTTL:   2 * time.Minute,
-		RoomCacheSize: 50000,
-		RoomCacheTTL:  10 * time.Second,
+		SubCacheSize:                 100000,
+		SubCacheTTL:                  2 * time.Minute,
+		RoomCacheSize:                50000,
+		RoomCacheTTL:                 10 * time.Second,
+		MessageReadBucketConcurrency: 1,
+		MessageReadEscalateAfter:     4,
 	}
+}
+
+func TestValidate_RejectsBucketConcurrencyBelowOne(t *testing.T) {
+	cfg := baseValid()
+	cfg.MessageReadBucketConcurrency = 0
+	err := validate(&cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MESSAGE_READ_BUCKET_CONCURRENCY")
+}
+
+func TestValidate_RejectsEscalateAfterBelowOne(t *testing.T) {
+	cfg := baseValid()
+	cfg.MessageReadEscalateAfter = 0
+	err := validate(&cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MESSAGE_READ_ESCALATE_AFTER")
 }
 
 func TestValidate_AcceptsDefaults(t *testing.T) {


### PR DESCRIPTION
Paginated history reads walk Cassandra buckets one synchronous round-trip
at a time (fillPage). For sparse rooms or deep lookback this is N sequential
RTTs to fill a single page — the dominant read-latency cost, and a
connection-pool starvation risk under concurrency.

Decouple the walk orchestration from the gocql fetch so it is unit-testable,
then add an opt-in parallel mode: after a run of consecutive empty buckets a
read probes several buckets concurrently to skip the run. The parallel path
only ever commits to skipping EMPTY buckets — the first bucket that yields
rows is handed back to the serial path, so page contents and the resume
cursor always come from a single exact-limit read. This keeps parallel output
byte-identical to serial (proven by a differential test) while collapsing long
empty-bucket walks into ~N/concurrency rounds.

- walker.go: extract walkBuckets (serial + escalating-parallel) over a
  bucketFetcher abstraction; fillPage becomes the gocql adapter, behavior
  unchanged at concurrency=1.
- repository.go: WithReadConcurrency functional option; serial remains the
  default so existing callers are unaffected.
- config: MESSAGE_READ_BUCKET_CONCURRENCY (default 1 = off) and
  MESSAGE_READ_ESCALATE_AFTER (default 4), validated and logged at startup.
- tests: serial-vs-parallel differential (both directions, varied density and
  page size), escalation/hand-back, maxBuckets cap, floor termination, and a
  barrier test proving the batch fetches concurrently.

Co-Authored-By: Claude Opus 4.8 
Claude-Session: https://claude.ai/code/session_01LEUfLtmkFZr3EzjiVWCVPJ