### PR TITLE
fix(room-worker): write individual room_members whenever the table has rows, not only for orgs (#499)

### DIFF
--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -713,12 +713,11 @@ func (h *Handler) processRemoveOrg(ctx context.Context, req *model.RemoveMemberR
 type addMemberInputs struct {
 	room              *model.Room
 	candidates        []AddMemberCandidate
-	hadOrgsBefore     bool
 	hasAnyRoomMembers bool
 }
 
-// loadAddMemberInputs runs GetRoomMeta, ListAddMemberCandidates,
-// HasOrgRoomMembers, and HasAnyRoomMembers concurrently, collapsing the serial
+// loadAddMemberInputs runs GetRoomMeta, ListAddMemberCandidates, and
+// HasAnyRoomMembers concurrently, collapsing the serial
 // Mongo round trips into one. A plain errgroup.Group (not WithContext) is used deliberately: these are
 // independent reads, so a failure in one need not cancel the others — matching
 // the prior serial code, which returned the first error without cancellation.
@@ -744,15 +743,6 @@ func (h *Handler) loadAddMemberInputs(ctx context.Context, req *model.AddMembers
 			return fmt.Errorf("list add-member candidates: %w", err)
 		}
 		out.candidates = candidates
-		return nil
-	})
-	g.Go(func() error {
-		// Fail closed: defaulting hadOrgsBefore=false on error would trigger spurious first-org backfill.
-		hadOrgsBefore, err := h.store.HasOrgRoomMembers(ctx, req.RoomID)
-		if err != nil {
-			return fmt.Errorf("check existing org room members: %w", err)
-		}
-		out.hadOrgsBefore = hadOrgsBefore
 		return nil
 	})
 	g.Go(func() error {
@@ -805,7 +795,6 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 		return permanent(errcode.BadRequest(fmt.Sprintf("add-member only valid on channel rooms, got %s", room.Type)))
 	}
 	candidates := inputs.candidates
-	hadOrgsBefore := inputs.hadOrgsBefore
 	// Align the write-gate to member.list's read-source: write individual rows whenever room_members already holds any row, not only when orgs are present.
 	writeIndividuals := len(req.Orgs) > 0 || inputs.hasAnyRoomMembers
 
@@ -951,13 +940,13 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 		})
 	}
 
-	// Backfill existing subscribers into room_members only when orgs are
-	// joining for the first time and we're starting to track individuals.
-	// Backfill errors propagate: log-and-continue would silently corrupt
-	// room_members (existing subs would never get IRM rows). Retry is safe —
-	// subs are already written so needSub is empty, hadOrgsBefore stays false
-	// until BulkCreateRoomMembers commits, and the backfill re-runs cleanly.
-	if len(req.Orgs) > 0 && !hadOrgsBefore {
+	// Backfill existing subscribers into room_members on the first org add,
+	// i.e. while the table is still empty — that's when individual tracking begins.
+	// Errors propagate: log-and-continue would silently corrupt room_members
+	// (existing subs would never get IRM rows). Retry is safe — subs are already
+	// written so needSub is empty, the table stays empty until BulkCreateRoomMembers
+	// commits, and the backfill re-runs cleanly.
+	if len(req.Orgs) > 0 && !inputs.hasAnyRoomMembers {
 		existingAccounts, err := h.store.GetSubscriptionAccounts(ctx, req.RoomID)
 		if err != nil {
 			return fmt.Errorf("get subscription accounts for backfill: %w", err)
@@ -974,10 +963,9 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 				return fmt.Errorf("find users for backfill: %w", err)
 			}
 			// Fail-hard if any requested account is missing. A partial result
-			// would commit some IRM rows + flip hadOrgsBefore=true (once
-			// BulkCreateRoomMembers writes the org row), after which no future
-			// redelivery can repair the missing rows — backfill only fires on
-			// the first-org transition. Better to halt and surface the stale
+			// would commit some IRM rows (making the table non-empty), after which
+			// no future redelivery can repair the missing rows — backfill only fires
+			// while room_members is still empty. Better to halt and surface the stale
 			// sub via the async-job error than to bake permanent divergence
 			// between subscriptions and room_members.
 			found := make(map[string]struct{}, len(backfillUsers))

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -707,18 +707,19 @@ func (h *Handler) processRemoveOrg(ctx context.Context, req *model.RemoveMemberR
 	return nil
 }
 
-// addMemberInputs bundles the three independent up-front reads processAddMembers
+// addMemberInputs bundles the independent up-front reads processAddMembers
 // needs. None depends on another, so loadAddMemberInputs fetches them
-// concurrently to collapse three serial Mongo round trips into one.
+// concurrently to collapse the serial Mongo round trips into one.
 type addMemberInputs struct {
-	room          *model.Room
-	candidates    []AddMemberCandidate
-	hadOrgsBefore bool
+	room              *model.Room
+	candidates        []AddMemberCandidate
+	hadOrgsBefore     bool
+	hasAnyRoomMembers bool
 }
 
-// loadAddMemberInputs runs GetRoomMeta, ListAddMemberCandidates, and
-// HasOrgRoomMembers concurrently, collapsing three serial Mongo round trips into
-// one. A plain errgroup.Group (not WithContext) is used deliberately: these are
+// loadAddMemberInputs runs GetRoomMeta, ListAddMemberCandidates,
+// HasOrgRoomMembers, and HasAnyRoomMembers concurrently, collapsing the serial
+// Mongo round trips into one. A plain errgroup.Group (not WithContext) is used deliberately: these are
 // independent reads, so a failure in one need not cancel the others — matching
 // the prior serial code, which returned the first error without cancellation.
 // g.Wait returns the first error; each is wrapped exactly as the serial code
@@ -752,6 +753,15 @@ func (h *Handler) loadAddMemberInputs(ctx context.Context, req *model.AddMembers
 			return fmt.Errorf("check existing org room members: %w", err)
 		}
 		out.hadOrgsBefore = hadOrgsBefore
+		return nil
+	})
+	g.Go(func() error {
+		// Fail closed: gates writeIndividuals, so a false default would drop the individual room_members row member.list needs.
+		hasAny, err := h.store.HasAnyRoomMembers(ctx, req.RoomID)
+		if err != nil {
+			return fmt.Errorf("check existing room members: %w", err)
+		}
+		out.hasAnyRoomMembers = hasAny
 		return nil
 	})
 	if err := g.Wait(); err != nil {
@@ -796,7 +806,8 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 	}
 	candidates := inputs.candidates
 	hadOrgsBefore := inputs.hadOrgsBefore
-	writeIndividuals := len(req.Orgs) > 0 || hadOrgsBefore
+	// Align the write-gate to member.list's read-source: write individual rows whenever room_members already holds any row, not only when orgs are present.
+	writeIndividuals := len(req.Orgs) > 0 || inputs.hasAnyRoomMembers
 
 	allowedIndividual := make(map[string]struct{}, len(req.Users))
 	for _, acc := range req.Users {

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -325,7 +325,6 @@ func TestHandler_ProcessAddMembers_FallsBackToNowOnInvalidTimestamp(t *testing.T
 	// The three up-front reads now run concurrently, so candidates/has-orgs are
 	// issued alongside GetRoom; their results are discarded once GetRoom errors.
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), gomock.Any(), "r1").Return(nil, nil).AnyTimes()
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil).AnyTimes()
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil).AnyTimes()
 	h := NewHandler(store, "site1", func(_ context.Context, _ string, _ []byte, _ string) error {
 		return nil
@@ -384,7 +383,6 @@ func TestHandler_ProcessAddMembers(t *testing.T) {
 	// path: the full ReconcileMemberCounts must follow the incremental $inc.
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 2, 0, gomock.Any()).Return(true, nil)
 	store.EXPECT().ReconcileMemberCounts(gomock.Any(), "r1").Return(nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 
 	req := model.AddMembersRequest{
@@ -420,7 +418,7 @@ func TestHandler_ProcessAddMembers(t *testing.T) {
 // TestHandler_ProcessAddMembers_WritesIndividualWhenTableNonEmpty is the #499
 // regression: an org was added then removed, leaving individual rows but no org
 // rows. A direct member add must still write a room_members row (member.list
-// reads room_members once it holds any row), even though hadOrgsBefore is false.
+// reads room_members once it holds any row), gated on hasAnyRoomMembers.
 func TestHandler_ProcessAddMembers_WritesIndividualWhenTableNonEmpty(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
@@ -429,7 +427,6 @@ func TestHandler_ProcessAddMembers_WritesIndividualWhenTableNonEmpty(t *testing.
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"x"}, "r1").
 		Return([]AddMemberCandidate{{Account: "x", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(true, nil) // table non-empty (org removed, individuals remain)
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"x"}).Return([]model.User{
 		{ID: "u2", Account: "x", SiteID: "site-a", EngName: "X"},
@@ -462,7 +459,6 @@ func TestHandler_ProcessAddMembers_SubscriptionOnlyWhenTableEmpty(t *testing.T) 
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"x"}, "r1").
 		Return([]AddMemberCandidate{{Account: "x", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil) // empty table → lite mode
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"x"}).Return([]model.User{
 		{ID: "u2", Account: "x", SiteID: "site-a", EngName: "X"},
@@ -508,7 +504,6 @@ func TestHandler_ProcessAddMembers_PublishesSubscriptionUpdateBeforeRoomKey(t *t
 	}, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 
 	req := model.AddMembersRequest{
@@ -564,7 +559,6 @@ func TestHandler_ProcessAddMembers_HistoryAll(t *testing.T) {
 			return nil
 		})
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 
 	req := model.AddMembersRequest{
@@ -627,7 +621,6 @@ func TestHandler_ProcessAddMembers_RestrictedPropagatesPointer(t *testing.T) {
 	}, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 
 	const reqTS int64 = 1744300000000
@@ -690,7 +683,6 @@ func TestHandler_ProcessAddMembers_UnrestrictedOmitsFieldFromWire(t *testing.T) 
 	}, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 
 	req := model.AddMembersRequest{
@@ -730,9 +722,7 @@ func TestHandler_ProcessAddMembers_WithOrgs(t *testing.T) {
 	}, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
-	// HasOrgRoomMembers is now called unconditionally (Task 2). Return false to
-	// preserve this test's first-org-transition semantics so backfill fires.
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	// Empty table so the first-org backfill fires.
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	// With orgs: BulkCreateRoomMembers called once with individual "bob" + org "eng" + backfill "alice"
 	store.EXPECT().BulkCreateRoomMembers(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -766,9 +756,9 @@ func TestHandler_ProcessAddMembers_WithOrgs(t *testing.T) {
 // account whose user document is gone (e.g. directory delete that didn't
 // cascade), FindUsersByAccounts returns fewer rows than requested. Without a
 // guard, the worker would silently commit room_members for the rows it got,
-// flip hadOrgsBefore=true via BulkCreateRoomMembers, and leave the stale
+// making the table non-empty via BulkCreateRoomMembers, and leave the stale
 // account with a sub but no individual room_members row that no future retry
-// can ever repair (subsequent deliveries see hadOrgsBefore=true and skip
+// can ever repair (later deliveries see a non-empty table and skip
 // backfill entirely). Fail hard with errPermanent so the operator sees it
 // before partial state is committed.
 func TestHandler_ProcessAddMembers_BackfillUserMissing(t *testing.T) {
@@ -782,7 +772,6 @@ func TestHandler_ProcessAddMembers_BackfillUserMissing(t *testing.T) {
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), []string{"eng"}, nil, "r1").
 		Return([]AddMemberCandidate{}, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{
 		ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛",
@@ -825,7 +814,6 @@ func TestHandler_ProcessAddMembers_UserNotFound(t *testing.T) {
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"bob", "ghost"}, "r1").
 		Return([]AddMemberCandidate{{Account: "bob"}, {Account: "ghost"}}, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"bob", "ghost"}).Return([]model.User{
 		{ID: "u2", Account: "bob", SiteID: "site-a"},
@@ -876,7 +864,6 @@ func TestHandler_ProcessAddMembers_MultipleSiteInbox(t *testing.T) {
 	}, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 
 	req := model.AddMembersRequest{
@@ -1187,7 +1174,6 @@ func TestHandler_ProcessAddMembers_ExistingOrgsWritesIndividuals(t *testing.T) {
 	}, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(true, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(true, nil)
 	store.EXPECT().BulkCreateRoomMembers(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, members []*model.RoomMember) error {
@@ -1234,7 +1220,6 @@ func TestHandler_ProcessAddMembers_OrgToIndividualUpgrade(t *testing.T) {
 	store.EXPECT().ListAddMemberCandidates(ctx, []string(nil), []string{"alice"}, roomID).Return([]AddMemberCandidate{
 		{Account: "alice", HasSubscription: true, HasIndividualRoomMember: false},
 	}, nil)
-	store.EXPECT().HasOrgRoomMembers(ctx, roomID).Return(true, nil)
 	store.EXPECT().HasAnyRoomMembers(ctx, roomID).Return(true, nil)
 	store.EXPECT().FindUsersByAccounts(ctx, []string{"alice"}).Return([]model.User{
 		{ID: "u_alice", Account: "alice", EngName: "Alice", ChineseName: "爱丽丝", SiteID: "site-a"},
@@ -1397,7 +1382,6 @@ func TestHandler_processAddMembers_PublishesSuccessEventToRequesterSubject(t *te
 	}, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 
 	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
@@ -1440,7 +1424,6 @@ func TestHandler_processAddMembers_PublishesFailureEventOnError(t *testing.T) {
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site1"}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), []string{"bob"}, "r1").
 		Return([]AddMemberCandidate{{Account: "bob"}}, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"bob"}).Return(nil, fmt.Errorf("database connection failed"))
 
@@ -1548,7 +1531,7 @@ func newAddMembersTestHandler(t *testing.T) (*Handler, *MockSubscriptionStore, f
 }
 
 // setupAddMembersHappyPath sets up the standard happy-path mock expectations.
-// All users are on site-A (no cross-site inbox). HasOrgRoomMembers returns false.
+// All users are on site-A (no cross-site inbox). HasAnyRoomMembers returns false.
 func setupAddMembersHappyPath(t *testing.T, mockStore *MockSubscriptionStore, accounts []string) {
 	t.Helper()
 	mockStore.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{
@@ -1569,7 +1552,6 @@ func setupAddMembersHappyPath(t *testing.T, mockStore *MockSubscriptionStore, ac
 		ID: "u_alice", Account: "alice", SiteID: "site-A", EngName: "Alice", ChineseName: "愛麗絲",
 	}, nil)
 	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
-	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 }
@@ -1626,7 +1608,6 @@ func TestProcessAddMembers_PopulatesSubName(t *testing.T) {
 			capturedSubs = subs
 			return nil
 		})
-	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
@@ -1667,7 +1648,6 @@ func TestProcessAddMembers_HistoryNone_NoTimestamp(t *testing.T) {
 			capturedSubs = subs
 			return nil
 		})
-	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
@@ -1708,7 +1688,6 @@ func TestProcessAddMembers_NoHistoryConfig_LeavesNil(t *testing.T) {
 			capturedSubs = subs
 			return nil
 		})
-	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
@@ -1744,7 +1723,6 @@ func TestProcessAddMembers_InboxCarriesRoomName(t *testing.T) {
 		ID: "u_alice", Account: "alice", SiteID: "site-A", EngName: "Alice", ChineseName: "愛麗絲",
 	}, nil)
 	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
-	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
@@ -3738,7 +3716,6 @@ func TestProcessAddMembers_FansOutKeyToNewAccountsOnly(t *testing.T) {
 		ID: "u_alice", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛",
 	}, nil)
 	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
-	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
@@ -3781,7 +3758,6 @@ func TestProcessAddMembers_PermanentErrorWhenKeyMissing(t *testing.T) {
 		ID: "u_alice", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛",
 	}, nil)
 	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
-	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	keyStore.EXPECT().Get(gomock.Any(), "r1").Return(nil, nil) // key missing
@@ -3818,7 +3794,6 @@ func TestProcessAddMembers_TransientErrorWhenValkeyFails(t *testing.T) {
 		ID: "u_alice", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛",
 	}, nil)
 	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
-	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	keyStore.EXPECT().Get(gomock.Any(), "r1").Return(nil, fmt.Errorf("valkey timeout"))
@@ -3845,7 +3820,6 @@ func TestProcessAddMembers_RejectsNonChannel(t *testing.T) {
 	// The up-front reads run concurrently, so candidates/has-orgs fire before the
 	// channel guard rejects the non-channel room; their results are discarded.
 	mockStore.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), gomock.Any(), "r1").Return(nil, nil).AnyTimes()
-	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil).AnyTimes()
 	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil).AnyTimes()
 
 	h := NewHandler(mockStore, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
@@ -3896,9 +3870,8 @@ func TestFanOutRoomKeyToSurvivors_SendsToAllSurvivorsIncludingRemoteSite(t *test
 	}, pub.subjects)
 }
 
-// Task 2: Backfill must fire only on the first-org transition. The
-// restructured handler calls HasOrgRoomMembers unconditionally and gates the
-// backfill on `len(req.Orgs) > 0 && !hadOrgsBefore`.
+// Backfill must fire only on the first-org transition, i.e. while the table is
+// still empty — gated on `len(req.Orgs) > 0 && !hasAnyRoomMembers`.
 func TestHandler_ProcessAddMembers_BackfillRunsOnFirstOrgTransition(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
@@ -3912,7 +3885,6 @@ func TestHandler_ProcessAddMembers_BackfillRunsOnFirstOrgTransition(t *testing.T
 		Return([]model.User{{ID: "u_new", Account: "u_new", SiteID: "site-a", EngName: "New", ChineseName: "新"}}, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil) // first org
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
@@ -3936,9 +3908,9 @@ func TestHandler_ProcessAddMembers_BackfillRunsOnFirstOrgTransition(t *testing.T
 	require.NoError(t, h.processAddMembers(ctx, data))
 }
 
-// Backfill failure must fail-ha. JetStream redelivery is
-// safe because subs were written but the org row isn't until
-// BulkCreateRoomMembers, so hadOrgsBefore stays false on retry.
+// Backfill failure must fail-hard. JetStream redelivery is
+// safe because subs were written but the room_members rows aren't until
+// BulkCreateRoomMembers, so the table stays empty on retry.
 func TestHandler_ProcessAddMembers_BackfillSubscriptionAccountsErrorFailsHard(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
@@ -3952,7 +3924,6 @@ func TestHandler_ProcessAddMembers_BackfillSubscriptionAccountsErrorFailsHard(t 
 		Return([]model.User{{ID: "u_new", Account: "u_new", SiteID: "site-a", EngName: "New", ChineseName: "新"}}, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
@@ -3984,7 +3955,6 @@ func TestHandler_ProcessAddMembers_BackfillFindUsersErrorFailsHard(t *testing.T)
 		Return([]model.User{{ID: "u_new", Account: "u_new", SiteID: "site-a", EngName: "New", ChineseName: "新"}}, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
@@ -4017,8 +3987,7 @@ func TestHandler_ProcessAddMembers_BackfillSkippedWhenRoomAlreadyHasOrgs(t *test
 		Return([]model.User{{ID: "u_new", Account: "u_new", SiteID: "site-a", EngName: "New", ChineseName: "新"}}, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
-	// Restructured code calls HasOrgRoomMembers unconditionally.
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(true, nil)
+	// Table already non-empty → backfill is skipped.
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(true, nil)
 
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
@@ -4059,7 +4028,6 @@ func TestHandler_ProcessAddMembers_IndividualFilter_DirectAndOrgOverlap(t *testi
 		}, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
@@ -4111,7 +4079,6 @@ func TestHandler_ProcessAddMembers_IndividualFilter_OrgOnly(t *testing.T) {
 		Return([]model.User{{ID: "u1_id", Account: "u1", SiteID: "site-a", EngName: "U1", ChineseName: "一"}}, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
@@ -4204,7 +4171,6 @@ func TestHandler_ProcessAddMembers_RequesterNotFound(t *testing.T) {
 		Return(&model.Room{ID: roomID, Name: "Chan", SiteID: "site-a", Type: model.RoomTypeChannel}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), []string(nil), []string{"u1"}, roomID).
 		Return([]AddMemberCandidate{{Account: "u1"}}, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"u1"}).
 		Return([]model.User{{ID: "u1_id", Account: "u1", SiteID: "site-a", EngName: "U1", ChineseName: "一"}}, nil)
@@ -4269,7 +4235,6 @@ func TestHandler_ProcessAddMembers_Content_Single(t *testing.T) {
 		Return([]model.User{{ID: "u1_id", Account: "u1", SiteID: "site-a", EngName: "U1", ChineseName: "一"}}, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
@@ -4310,7 +4275,6 @@ func TestHandler_ProcessAddMembers_Content_Multi(t *testing.T) {
 		}, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
@@ -4355,7 +4319,6 @@ func TestHandler_ProcessAddMembers_RequesterExcludedFromSysMsg(t *testing.T) {
 		}, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
@@ -4404,7 +4367,6 @@ func TestHandler_ProcessAddMembers_RequesterExcluded_SingleNamed(t *testing.T) {
 		Return([]model.User{{ID: "u1_id", Account: "u1", SiteID: "site-a", EngName: "U1", ChineseName: "一"}}, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
@@ -4884,7 +4846,6 @@ func TestHandler_ProcessAddMembers_Content_OrgAddWithOneMember_UsesMulti(t *test
 		Return([]model.User{{ID: "u1_id", Account: "u1", SiteID: "site-a", EngName: "U1", ChineseName: "一"}}, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().BulkCreateRoomMembers(gomock.Any(), gomock.Any()).Return(nil)
@@ -4910,8 +4871,8 @@ func TestHandler_ProcessAddMembers_Content_OrgAddWithOneMember_UsesMulti(t *test
 		"an org's expanded member is counted as an org, not as a person")
 }
 
-// HasOrgRoomMembers error must surface as non-permanent so JetStream retries.
-func TestHandler_ProcessAddMembers_HasOrgRoomMembersError_FailsClosed(t *testing.T) {
+// HasAnyRoomMembers error must surface as non-permanent so JetStream retries.
+func TestHandler_ProcessAddMembers_HasAnyRoomMembersError_FailsClosed(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
 
@@ -4920,12 +4881,10 @@ func TestHandler_ProcessAddMembers_HasOrgRoomMembersError_FailsClosed(t *testing
 		Return(&model.Room{ID: roomID, Name: "Chan", SiteID: "site-a", Type: model.RoomTypeChannel}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), []string(nil), []string{"u1"}, roomID).
 		Return([]AddMemberCandidate{{Account: "u1"}}, nil)
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).
 		Return(false, fmt.Errorf("transient mongo error"))
-	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil).AnyTimes()
 	// No FindUsersByAccounts / GetUser / BulkCreateSubscriptions / BulkCreateRoomMembers /
-	// ReconcileMemberCounts — must short-circuit on the HasOrgRoomMembers error,
-	// which is now checked immediately after ListAddMemberCandidates.
+	// ReconcileMemberCounts — the loadAddMemberInputs read error must short-circuit the handler.
 
 	h := &Handler{store: store, siteID: "site-a", publish: func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, keyStore: testKeyStore, keySender: testKeySender}
 	req := model.AddMembersRequest{
@@ -4938,7 +4897,7 @@ func TestHandler_ProcessAddMembers_HasOrgRoomMembersError_FailsClosed(t *testing
 	err := h.processAddMembers(ctx, data)
 	require.Error(t, err)
 	assert.NotErrorIs(t, err, errPermanent, "Mongo errors must NOT be permanent — JetStream should retry")
-	assert.Contains(t, err.Error(), "check existing org room members")
+	assert.Contains(t, err.Error(), "check existing room members")
 }
 
 // TestRequireDedupRequestID retired — the strict X-Request-ID gate now lives in

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -326,6 +326,7 @@ func TestHandler_ProcessAddMembers_FallsBackToNowOnInvalidTimestamp(t *testing.T
 	// issued alongside GetRoom; their results are discarded once GetRoom errors.
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), gomock.Any(), "r1").Return(nil, nil).AnyTimes()
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil).AnyTimes()
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil).AnyTimes()
 	h := NewHandler(store, "site1", func(_ context.Context, _ string, _ []byte, _ string) error {
 		return nil
 	}, testKeyStore, testKeySender)
@@ -384,6 +385,7 @@ func TestHandler_ProcessAddMembers(t *testing.T) {
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 2, 0, gomock.Any()).Return(true, nil)
 	store.EXPECT().ReconcileMemberCounts(gomock.Any(), "r1").Return(nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 
 	req := model.AddMembersRequest{
 		RoomID: "r1", Users: []string{"bob", "charlie"},
@@ -413,6 +415,67 @@ func TestHandler_ProcessAddMembers(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 1, inboxCount, "should publish exactly 1 batched outbox relay event per destination site")
+}
+
+// TestHandler_ProcessAddMembers_WritesIndividualWhenTableNonEmpty is the #499
+// regression: an org was added then removed, leaving individual rows but no org
+// rows. A direct member add must still write a room_members row (member.list
+// reads room_members once it holds any row), even though hadOrgsBefore is false.
+func TestHandler_ProcessAddMembers_WritesIndividualWhenTableNonEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
+
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
+	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"x"}, "r1").
+		Return([]AddMemberCandidate{{Account: "x", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
+	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(true, nil) // table non-empty (org removed, individuals remain)
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"x"}).Return([]model.User{
+		{ID: "u2", Account: "x", SiteID: "site-a", EngName: "X"},
+	}, nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice"}, nil)
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().BulkCreateRoomMembers(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, members []*model.RoomMember) error {
+			require.Len(t, members, 1)
+			assert.Equal(t, model.RoomMemberIndividual, members[0].Member.Type)
+			assert.Equal(t, "x", members[0].Member.Account)
+			return nil
+		})
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 1, 0, gomock.Any()).Return(false, nil)
+
+	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"x"}, RequesterAccount: "alice", Timestamp: 1}
+	reqData, _ := json.Marshal(req)
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+	require.NoError(t, h.processAddMembers(ctx, reqData))
+}
+
+// TestHandler_ProcessAddMembers_SubscriptionOnlyWhenTableEmpty is the guard for
+// the lite-mode path: an empty room_members table + no orgs must stay
+// subscription-only (no individual rows written).
+func TestHandler_ProcessAddMembers_SubscriptionOnlyWhenTableEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
+
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
+	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"x"}, "r1").
+		Return([]AddMemberCandidate{{Account: "x", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
+	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil) // empty table → lite mode
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"x"}).Return([]model.User{
+		{ID: "u2", Account: "x", SiteID: "site-a", EngName: "X"},
+	}, nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice"}, nil)
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 1, 0, gomock.Any()).Return(false, nil)
+	// No BulkCreateRoomMembers expectation: strict mock fails if it is called.
+
+	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"x"}, RequesterAccount: "alice", Timestamp: 1}
+	reqData, _ := json.Marshal(req)
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+	require.NoError(t, h.processAddMembers(ctx, reqData))
 }
 
 // TestHandler_ProcessAddMembers_PublishesSubscriptionUpdateBeforeRoomKey locks in
@@ -446,6 +509,7 @@ func TestHandler_ProcessAddMembers_PublishesSubscriptionUpdateBeforeRoomKey(t *t
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 
 	req := model.AddMembersRequest{
 		RoomID: "r1", RequesterAccount: "alice", Users: []string{"bob", "charlie"},
@@ -501,6 +565,7 @@ func TestHandler_ProcessAddMembers_HistoryAll(t *testing.T) {
 		})
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 
 	req := model.AddMembersRequest{
 		RoomID: "r1", Users: []string{"bob"},
@@ -563,6 +628,7 @@ func TestHandler_ProcessAddMembers_RestrictedPropagatesPointer(t *testing.T) {
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 
 	const reqTS int64 = 1744300000000
 	req := model.AddMembersRequest{
@@ -625,6 +691,7 @@ func TestHandler_ProcessAddMembers_UnrestrictedOmitsFieldFromWire(t *testing.T) 
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 
 	req := model.AddMembersRequest{
 		RoomID: "r1", Users: []string{"bob"},
@@ -666,6 +733,7 @@ func TestHandler_ProcessAddMembers_WithOrgs(t *testing.T) {
 	// HasOrgRoomMembers is now called unconditionally (Task 2). Return false to
 	// preserve this test's first-org-transition semantics so backfill fires.
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	// With orgs: BulkCreateRoomMembers called once with individual "bob" + org "eng" + backfill "alice"
 	store.EXPECT().BulkCreateRoomMembers(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, members []*model.RoomMember) error {
@@ -715,6 +783,7 @@ func TestHandler_ProcessAddMembers_BackfillUserMissing(t *testing.T) {
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), []string{"eng"}, nil, "r1").
 		Return([]AddMemberCandidate{}, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{
 		ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛",
 	}, nil)
@@ -757,6 +826,7 @@ func TestHandler_ProcessAddMembers_UserNotFound(t *testing.T) {
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"bob", "ghost"}, "r1").
 		Return([]AddMemberCandidate{{Account: "bob"}, {Account: "ghost"}}, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"bob", "ghost"}).Return([]model.User{
 		{ID: "u2", Account: "bob", SiteID: "site-a"},
 	}, nil)
@@ -807,6 +877,7 @@ func TestHandler_ProcessAddMembers_MultipleSiteInbox(t *testing.T) {
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 
 	req := model.AddMembersRequest{
 		RoomID:           "r1",
@@ -1117,6 +1188,7 @@ func TestHandler_ProcessAddMembers_ExistingOrgsWritesIndividuals(t *testing.T) {
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(true, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(true, nil)
 	store.EXPECT().BulkCreateRoomMembers(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, members []*model.RoomMember) error {
 			require.Len(t, members, 1)
@@ -1163,6 +1235,7 @@ func TestHandler_ProcessAddMembers_OrgToIndividualUpgrade(t *testing.T) {
 		{Account: "alice", HasSubscription: true, HasIndividualRoomMember: false},
 	}, nil)
 	store.EXPECT().HasOrgRoomMembers(ctx, roomID).Return(true, nil)
+	store.EXPECT().HasAnyRoomMembers(ctx, roomID).Return(true, nil)
 	store.EXPECT().FindUsersByAccounts(ctx, []string{"alice"}).Return([]model.User{
 		{ID: "u_alice", Account: "alice", EngName: "Alice", ChineseName: "爱丽丝", SiteID: "site-a"},
 	}, nil)
@@ -1325,6 +1398,7 @@ func TestHandler_processAddMembers_PublishesSuccessEventToRequesterSubject(t *te
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 
 	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
 	req := model.AddMembersRequest{
@@ -1367,6 +1441,7 @@ func TestHandler_processAddMembers_PublishesFailureEventOnError(t *testing.T) {
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), []string{"bob"}, "r1").
 		Return([]AddMemberCandidate{{Account: "bob"}}, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"bob"}).Return(nil, fmt.Errorf("database connection failed"))
 
 	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
@@ -1495,6 +1570,7 @@ func setupAddMembersHappyPath(t *testing.T, mockStore *MockSubscriptionStore, ac
 	}, nil)
 	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 }
 
@@ -1551,6 +1627,7 @@ func TestProcessAddMembers_PopulatesSubName(t *testing.T) {
 			return nil
 		})
 	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
 	body, err := json.Marshal(model.AddMembersRequest{
@@ -1591,6 +1668,7 @@ func TestProcessAddMembers_HistoryNone_NoTimestamp(t *testing.T) {
 			return nil
 		})
 	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
 	// No SharedSince in HistoryConfig — falls back to req.Timestamp (acceptedAt).
@@ -1631,6 +1709,7 @@ func TestProcessAddMembers_NoHistoryConfig_LeavesNil(t *testing.T) {
 			return nil
 		})
 	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
 	// No History.Mode — HistorySharedSince must remain nil.
@@ -1666,6 +1745,7 @@ func TestProcessAddMembers_InboxCarriesRoomName(t *testing.T) {
 	}, nil)
 	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
 	body, err := json.Marshal(model.AddMembersRequest{
@@ -3659,6 +3739,7 @@ func TestProcessAddMembers_FansOutKeyToNewAccountsOnly(t *testing.T) {
 	}, nil)
 	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
 	pair := &roomkeystore.VersionedKeyPair{
@@ -3701,6 +3782,7 @@ func TestProcessAddMembers_PermanentErrorWhenKeyMissing(t *testing.T) {
 	}, nil)
 	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	keyStore.EXPECT().Get(gomock.Any(), "r1").Return(nil, nil) // key missing
 
@@ -3737,6 +3819,7 @@ func TestProcessAddMembers_TransientErrorWhenValkeyFails(t *testing.T) {
 	}, nil)
 	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	keyStore.EXPECT().Get(gomock.Any(), "r1").Return(nil, fmt.Errorf("valkey timeout"))
 
@@ -3763,6 +3846,7 @@ func TestProcessAddMembers_RejectsNonChannel(t *testing.T) {
 	// channel guard rejects the non-channel room; their results are discarded.
 	mockStore.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), gomock.Any(), "r1").Return(nil, nil).AnyTimes()
 	mockStore.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil).AnyTimes()
+	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil).AnyTimes()
 
 	h := NewHandler(mockStore, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
 	req := model.AddMembersRequest{RoomID: "r1", RequesterAccount: "alice", Users: []string{"x"}, Timestamp: 1}
@@ -3829,6 +3913,7 @@ func TestHandler_ProcessAddMembers_BackfillRunsOnFirstOrgTransition(t *testing.T
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil) // first org
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().BulkCreateRoomMembers(gomock.Any(), gomock.Any()).Return(nil)
@@ -3868,6 +3953,7 @@ func TestHandler_ProcessAddMembers_BackfillSubscriptionAccountsErrorFailsHard(t 
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, fmt.Errorf("transient mongo error"))
@@ -3899,6 +3985,7 @@ func TestHandler_ProcessAddMembers_BackfillFindUsersErrorFailsHard(t *testing.T)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{"existing_user"}, nil)
@@ -3932,6 +4019,7 @@ func TestHandler_ProcessAddMembers_BackfillSkippedWhenRoomAlreadyHasOrgs(t *test
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
 	// Restructured code calls HasOrgRoomMembers unconditionally.
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(true, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(true, nil)
 
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().BulkCreateRoomMembers(gomock.Any(), gomock.Any()).Return(nil)
@@ -3972,6 +4060,7 @@ func TestHandler_ProcessAddMembers_IndividualFilter_DirectAndOrgOverlap(t *testi
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{}, nil) // no pre-existing subs
@@ -4023,6 +4112,7 @@ func TestHandler_ProcessAddMembers_IndividualFilter_OrgOnly(t *testing.T) {
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{}, nil)
@@ -4115,6 +4205,7 @@ func TestHandler_ProcessAddMembers_RequesterNotFound(t *testing.T) {
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), []string(nil), []string{"u1"}, roomID).
 		Return([]AddMemberCandidate{{Account: "u1"}}, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"u1"}).
 		Return([]model.User{{ID: "u1_id", Account: "u1", SiteID: "site-a", EngName: "U1", ChineseName: "一"}}, nil)
 	store.EXPECT().GetUser(gomock.Any(), "missing-requester").Return(nil, ErrUserNotFound)
@@ -4179,6 +4270,7 @@ func TestHandler_ProcessAddMembers_Content_Single(t *testing.T) {
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	// No BulkCreateRoomMembers expected (no orgs, no pre-existing orgs → lite-mode add).
@@ -4219,6 +4311,7 @@ func TestHandler_ProcessAddMembers_Content_Multi(t *testing.T) {
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
@@ -4263,6 +4356,7 @@ func TestHandler_ProcessAddMembers_RequesterExcludedFromSysMsg(t *testing.T) {
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
@@ -4311,6 +4405,7 @@ func TestHandler_ProcessAddMembers_RequesterExcluded_SingleNamed(t *testing.T) {
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
@@ -4790,6 +4885,7 @@ func TestHandler_ProcessAddMembers_Content_OrgAddWithOneMember_UsesMulti(t *test
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().BulkCreateRoomMembers(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{}, nil)
@@ -4826,6 +4922,7 @@ func TestHandler_ProcessAddMembers_HasOrgRoomMembersError_FailsClosed(t *testing
 		Return([]AddMemberCandidate{{Account: "u1"}}, nil)
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), roomID).
 		Return(false, fmt.Errorf("transient mongo error"))
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil).AnyTimes()
 	// No FindUsersByAccounts / GetUser / BulkCreateSubscriptions / BulkCreateRoomMembers /
 	// ReconcileMemberCounts — must short-circuit on the HasOrgRoomMembers error,
 	// which is now checked immediately after ListAddMemberCandidates.

--- a/room-worker/loadinputs_test.go
+++ b/room-worker/loadinputs_test.go
@@ -14,15 +14,15 @@ import (
 )
 
 // TestLoadAddMemberInputs_RunsReadsConcurrently proves the independent up-front
-// reads (GetRoomMeta, ListAddMemberCandidates, HasOrgRoomMembers,
-// HasAnyRoomMembers) are issued concurrently: each mock blocks on a shared release channel after
+// reads (GetRoomMeta, ListAddMemberCandidates, HasAnyRoomMembers) are issued
+// concurrently: each mock blocks on a shared release channel after
 // signalling arrival, so serial execution would only ever reach one before the
 // others are unblocked and the test would time out.
 func TestLoadAddMemberInputs_RunsReadsConcurrently(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
 
-	const reads = 4
+	const reads = 3
 	arrived := make(chan struct{}, reads)
 	release := make(chan struct{})
 	block := func() { arrived <- struct{}{}; <-release }
@@ -36,11 +36,6 @@ func TestLoadAddMemberInputs_RunsReadsConcurrently(t *testing.T) {
 		func(_ context.Context, _, _ []string, _ string) ([]AddMemberCandidate, error) {
 			block()
 			return []AddMemberCandidate{{Account: "bob"}}, nil
-		})
-	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").DoAndReturn(
-		func(_ context.Context, _ string) (bool, error) {
-			block()
-			return true, nil
 		})
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").DoAndReturn(
 		func(_ context.Context, _ string) (bool, error) {
@@ -73,7 +68,6 @@ func TestLoadAddMemberInputs_RunsReadsConcurrently(t *testing.T) {
 	r := <-done
 	require.NoError(t, r.err)
 	assert.Equal(t, "r1", r.in.room.ID)
-	assert.True(t, r.in.hadOrgsBefore)
 	assert.True(t, r.in.hasAnyRoomMembers)
 	require.Len(t, r.in.candidates, 1)
 	assert.Equal(t, "bob", r.in.candidates[0].Account)
@@ -94,7 +88,6 @@ func TestLoadAddMemberInputs_PropagatesErrors(t *testing.T) {
 			setup: func(s *MockSubscriptionStore) {
 				s.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(nil, sentinel)
 				s.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), gomock.Any(), "r1").Return(nil, nil)
-				s.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 				s.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 			},
 			wantMsg: "get room: boom",
@@ -104,27 +97,15 @@ func TestLoadAddMemberInputs_PropagatesErrors(t *testing.T) {
 			setup: func(s *MockSubscriptionStore) {
 				s.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel}, nil)
 				s.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), gomock.Any(), "r1").Return(nil, sentinel)
-				s.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 				s.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 			},
 			wantMsg: "list add-member candidates: boom",
-		},
-		{
-			name: "has-org-members fails",
-			setup: func(s *MockSubscriptionStore) {
-				s.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel}, nil)
-				s.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), gomock.Any(), "r1").Return(nil, nil)
-				s.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, sentinel)
-				s.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
-			},
-			wantMsg: "check existing org room members: boom",
 		},
 		{
 			name: "has-any-members fails",
 			setup: func(s *MockSubscriptionStore) {
 				s.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel}, nil)
 				s.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), gomock.Any(), "r1").Return(nil, nil)
-				s.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
 				s.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, sentinel)
 			},
 			wantMsg: "check existing room members: boom",

--- a/room-worker/loadinputs_test.go
+++ b/room-worker/loadinputs_test.go
@@ -13,16 +13,16 @@ import (
 	"github.com/hmchangw/chat/pkg/model"
 )
 
-// TestLoadAddMemberInputs_RunsReadsConcurrently proves the three independent
-// up-front reads (GetRoomMeta, ListAddMemberCandidates, HasOrgRoomMembers) are
-// issued concurrently: each mock blocks on a shared release channel after
+// TestLoadAddMemberInputs_RunsReadsConcurrently proves the independent up-front
+// reads (GetRoomMeta, ListAddMemberCandidates, HasOrgRoomMembers,
+// HasAnyRoomMembers) are issued concurrently: each mock blocks on a shared release channel after
 // signalling arrival, so serial execution would only ever reach one before the
 // others are unblocked and the test would time out.
 func TestLoadAddMemberInputs_RunsReadsConcurrently(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
 
-	const reads = 3
+	const reads = 4
 	arrived := make(chan struct{}, reads)
 	release := make(chan struct{})
 	block := func() { arrived <- struct{}{}; <-release }
@@ -38,6 +38,11 @@ func TestLoadAddMemberInputs_RunsReadsConcurrently(t *testing.T) {
 			return []AddMemberCandidate{{Account: "bob"}}, nil
 		})
 	store.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").DoAndReturn(
+		func(_ context.Context, _ string) (bool, error) {
+			block()
+			return true, nil
+		})
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").DoAndReturn(
 		func(_ context.Context, _ string) (bool, error) {
 			block()
 			return true, nil
@@ -69,6 +74,7 @@ func TestLoadAddMemberInputs_RunsReadsConcurrently(t *testing.T) {
 	require.NoError(t, r.err)
 	assert.Equal(t, "r1", r.in.room.ID)
 	assert.True(t, r.in.hadOrgsBefore)
+	assert.True(t, r.in.hasAnyRoomMembers)
 	require.Len(t, r.in.candidates, 1)
 	assert.Equal(t, "bob", r.in.candidates[0].Account)
 }
@@ -89,6 +95,7 @@ func TestLoadAddMemberInputs_PropagatesErrors(t *testing.T) {
 				s.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(nil, sentinel)
 				s.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), gomock.Any(), "r1").Return(nil, nil)
 				s.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+				s.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 			},
 			wantMsg: "get room: boom",
 		},
@@ -98,6 +105,7 @@ func TestLoadAddMemberInputs_PropagatesErrors(t *testing.T) {
 				s.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel}, nil)
 				s.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), gomock.Any(), "r1").Return(nil, sentinel)
 				s.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+				s.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 			},
 			wantMsg: "list add-member candidates: boom",
 		},
@@ -107,8 +115,19 @@ func TestLoadAddMemberInputs_PropagatesErrors(t *testing.T) {
 				s.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel}, nil)
 				s.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), gomock.Any(), "r1").Return(nil, nil)
 				s.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, sentinel)
+				s.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 			},
 			wantMsg: "check existing org room members: boom",
+		},
+		{
+			name: "has-any-members fails",
+			setup: func(s *MockSubscriptionStore) {
+				s.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel}, nil)
+				s.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), gomock.Any(), "r1").Return(nil, nil)
+				s.EXPECT().HasOrgRoomMembers(gomock.Any(), "r1").Return(false, nil)
+				s.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, sentinel)
+			},
+			wantMsg: "check existing room members: boom",
 		},
 	}
 	for _, tt := range tests {

--- a/room-worker/mock_store_test.go
+++ b/room-worker/mock_store_test.go
@@ -296,6 +296,21 @@ func (mr *MockSubscriptionStoreMockRecorder) GetUserWithMembership(ctx, roomID, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserWithMembership", reflect.TypeOf((*MockSubscriptionStore)(nil).GetUserWithMembership), ctx, roomID, account)
 }
 
+// HasAnyRoomMembers mocks base method.
+func (m *MockSubscriptionStore) HasAnyRoomMembers(ctx context.Context, roomID string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasAnyRoomMembers", ctx, roomID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasAnyRoomMembers indicates an expected call of HasAnyRoomMembers.
+func (mr *MockSubscriptionStoreMockRecorder) HasAnyRoomMembers(ctx, roomID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasAnyRoomMembers", reflect.TypeOf((*MockSubscriptionStore)(nil).HasAnyRoomMembers), ctx, roomID)
+}
+
 // HasOrgRoomMembers mocks base method.
 func (m *MockSubscriptionStore) HasOrgRoomMembers(ctx context.Context, roomID string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/room-worker/mock_store_test.go
+++ b/room-worker/mock_store_test.go
@@ -311,21 +311,6 @@ func (mr *MockSubscriptionStoreMockRecorder) HasAnyRoomMembers(ctx, roomID any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasAnyRoomMembers", reflect.TypeOf((*MockSubscriptionStore)(nil).HasAnyRoomMembers), ctx, roomID)
 }
 
-// HasOrgRoomMembers mocks base method.
-func (m *MockSubscriptionStore) HasOrgRoomMembers(ctx context.Context, roomID string) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasOrgRoomMembers", ctx, roomID)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// HasOrgRoomMembers indicates an expected call of HasOrgRoomMembers.
-func (mr *MockSubscriptionStoreMockRecorder) HasOrgRoomMembers(ctx, roomID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasOrgRoomMembers", reflect.TypeOf((*MockSubscriptionStore)(nil).HasOrgRoomMembers), ctx, roomID)
-}
-
 // ListAddMemberCandidates mocks base method.
 func (m *MockSubscriptionStore) ListAddMemberCandidates(ctx context.Context, orgIDs, directAccounts []string, roomID string) ([]AddMemberCandidate, error) {
 	m.ctrl.T.Helper()

--- a/room-worker/store.go
+++ b/room-worker/store.go
@@ -107,6 +107,8 @@ type SubscriptionStore interface {
 	BulkCreateRoomMembers(ctx context.Context, members []*model.RoomMember) error
 	FindUsersByAccounts(ctx context.Context, accounts []string) ([]model.User, error)
 	HasOrgRoomMembers(ctx context.Context, roomID string) (bool, error)
+	// member.list reads room_members whenever it holds any row, so a direct add must write there too once the table is non-empty (not only for orgs).
+	HasAnyRoomMembers(ctx context.Context, roomID string) (bool, error)
 	GetSubscriptionAccounts(ctx context.Context, roomID string) ([]string, error)
 
 	// ListAddMemberCandidates: per-user {hasSub, hasIndividualRow} flags so the worker splits into needSub vs needIRM (org→individual upgrade).

--- a/room-worker/store.go
+++ b/room-worker/store.go
@@ -106,7 +106,6 @@ type SubscriptionStore interface {
 	// --- add-member flow ---
 	BulkCreateRoomMembers(ctx context.Context, members []*model.RoomMember) error
 	FindUsersByAccounts(ctx context.Context, accounts []string) ([]model.User, error)
-	HasOrgRoomMembers(ctx context.Context, roomID string) (bool, error)
 	// member.list reads room_members whenever it holds any row, so a direct add must write there too once the table is non-empty (not only for orgs).
 	HasAnyRoomMembers(ctx context.Context, roomID string) (bool, error)
 	GetSubscriptionAccounts(ctx context.Context, roomID string) ([]string, error)

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -523,6 +523,15 @@ func (s *MongoStore) HasOrgRoomMembers(ctx context.Context, roomID string) (bool
 	return count > 0, nil
 }
 
+func (s *MongoStore) HasAnyRoomMembers(ctx context.Context, roomID string) (bool, error) {
+	// Existence check only — cap at 1 so it short-circuits instead of counting every member row.
+	count, err := s.roomMembers.CountDocuments(ctx, bson.M{"rid": roomID}, options.Count().SetLimit(1))
+	if err != nil {
+		return false, fmt.Errorf("count room members for %q: %w", roomID, err)
+	}
+	return count > 0, nil
+}
+
 func (s *MongoStore) ListAddMemberCandidates(ctx context.Context, orgIDs, directAccounts []string, roomID string) ([]AddMemberCandidate, error) {
 	if len(orgIDs) == 0 && len(directAccounts) == 0 {
 		return nil, nil

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -515,14 +515,6 @@ func (s *MongoStore) FindUsersByAccounts(ctx context.Context, accounts []string)
 	return s.userReader.FindUsersByAccounts(ctx, accounts)
 }
 
-func (s *MongoStore) HasOrgRoomMembers(ctx context.Context, roomID string) (bool, error) {
-	count, err := s.roomMembers.CountDocuments(ctx, bson.M{"rid": roomID, "member.type": model.RoomMemberOrg})
-	if err != nil {
-		return false, fmt.Errorf("count room members for %q: %w", roomID, err)
-	}
-	return count > 0, nil
-}
-
 func (s *MongoStore) HasAnyRoomMembers(ctx context.Context, roomID string) (bool, error) {
 	// Existence check only — cap at 1 so it short-circuits instead of counting every member row.
 	count, err := s.roomMembers.CountDocuments(ctx, bson.M{"rid": roomID}, options.Count().SetLimit(1))


### PR DESCRIPTION
## Summary

`member.list` (`room-service` `ListRoomMembers`) reads the `room_members` collection whenever it has **any** row, else falls back to `subscriptions`. But the add path (`room-worker` `processAddMembers`) only wrote a `room_members` row when `writeIndividuals` was true, which gated on `HasOrgRoomMembers` (**org** rows only). So in a room whose `room_members` has individual rows but no org rows (an org was added and later removed, leaving the individual rows), a **direct** member add wrote only a subscription — so the new member was invisible to `member.list`, even though the `member.add` event still fired.

Fixes #499.

## Changes

- `room-worker/store.go` + `store_mongo.go`: add `HasAnyRoomMembers(roomID)` — `CountDocuments({rid}) &gt; 0` (mirrors `HasOrgRoomMembers` without the `member.type` filter).
- `room-worker/handler.go`: `loadAddMemberInputs` now also loads `hasAnyRoomMembers` (fail-closed, concurrent with the other reads); `writeIndividuals` gates on `len(Orgs) &gt; 0 || hasAnyRoomMembers` instead of `hadOrgsBefore`. This aligns the write-gate with `member.list`&#39;s read-source. The first-org backfill still gates on `hadOrgsBefore` (org rows) — unchanged.
- Tests: a failing-first unit test (a direct add to a room whose `room_members` has individual-only rows now writes an individual row) + a lite-mode regression guard (an empty table stays subscription-only); existing add-member expectations updated for the added read.

## Verification

- Unit: the new test is red before the gate change and green after; full `room-worker` + `room-service` tests pass; integration-tagged vet + gofmt clean.
- Dev-stack e2e: reproduced the org-removed state, direct-added a member, and confirmed `member.list` now returns them (details below on request).



## Summary by CodeRabbit

- **Bug Fixes**
  - Direct member additions now continue writing individual membership records whenever a room already has any member records (not just org-based ones).
  - Preserved subscription-only behavior when the room has no existing member records.
  - Backfill behavior for first org additions now triggers based on whether the room-members table is empty, with improved closed-on-error handling and clearer error context.