### PR TITLE
Auto-install tGD framework via SessionStart hook on Claude Code web

### DIFF
--- a/.claude/hooks/tgd-install.sh
+++ b/.claude/hooks/tgd-install.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# tGD framework installer — runs at SessionStart on Claude Code on the web.
+#
+# Clones the tGD repo at a pinned release tag and runs its setup.sh, which
+# symlinks the tgd-* skills into ~/.claude/skills and the /tgd-* slash commands
+# into ~/.claude/commands. After this runs, every remote session can use the
+# tGD skills and commands immediately.
+#
+# Isolated from session-start.sh on purpose: registered as its own SessionStart
+# entry so a tGD hiccup can never break the superpowers / Go-tooling install.
+set -uo pipefail
+
+# Only run in the remote (web) environment. Local users manage their own tGD
+# install — the same guard the sibling session-start.sh uses.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Pin to a release tag rather than a moving branch — this hook auto-runs in
+# every session, so upstream changes must be an explicit version bump here,
+# mirroring how .claude/settings.json pins the 365-skills marketplace by SHA.
+TGD_VERSION="v2026.07.11.3"
+TGD_REPO="https://github.com/openclawyhwang-hub/tGD.git"
+TGD_SRC="${HOME}/.tgd-src"
+
+# Idempotent: fetch/checkout the pinned tag if the clone already exists,
+# otherwise shallow-clone it. A clone failure (e.g. network) must not break
+# session start, so we bail out cleanly instead of erroring.
+if [ -d "$TGD_SRC/.git" ]; then
+  git -C "$TGD_SRC" fetch --depth 1 origin "refs/tags/${TGD_VERSION}" 2>/dev/null \
+    && git -C "$TGD_SRC" checkout -q FETCH_HEAD 2>/dev/null \
+    || echo "tGD: refresh to ${TGD_VERSION} failed; using existing checkout" >&2
+else
+  if ! git clone --depth 1 --branch "$TGD_VERSION" "$TGD_REPO" "$TGD_SRC" 2>/dev/null; then
+    echo "tGD: clone of ${TGD_VERSION} failed; skipping install" >&2
+    exit 0
+  fi
+fi
+
+# setup.sh detects `claude` on PATH and links the core skills/commands first,
+# before its optional add-ons (CodeGraph via npm, Understand-Anything via pnpm)
+# which may fail under a restricted network. We tolerate a non-zero exit so
+# those optional failures never block the session — the core install is already
+# done by the time they run.
+bash "$TGD_SRC/setup.sh" || echo "tGD: setup.sh reported errors (optional components may have been skipped)" >&2
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,15 @@
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/tgd-install.sh",
+            "timeout": 300
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,8 @@ tmp/
 
 # Captured pprof profiles from `make profile`.
 profiles/
+
+# tGD scan artifacts — local symlinks into $TGD_DIR (CodeGraph index,
+# Understand-Anything knowledge graph); machine-local, never versioned.
+.codegraph
+.understand-anything


### PR DESCRIPTION
## What

Provisions the [tGD](https://github.com/openclawyhwang-hub/tGD) agentic-workflow framework automatically whenever a Claude Code **on the web** session starts, so its skills and slash commands are available without any manual setup.

## How

- **`.claude/hooks/tgd-install.sh`** (new) — clones the tGD repo at a **pinned release tag** (`v2026.07.11.3`) into `~/.tgd-src` and runs its `setup.sh`. That links the `tgd-*` skills into `~/.claude/skills` and the `/tgd-*` slash commands into `~/.claude/commands`.
- **`.claude/settings.json`** — registers the script as its **own** `SessionStart` entry, alongside the existing `session-start.sh`. The two run independently, so a tGD hiccup can never break the superpowers / Go-tooling install.

## Design notes

- **Remote-only** — guarded by `CLAUDE_CODE_REMOTE`, matching the sibling `session-start.sh`. Local dev is untouched.
- **Idempotent** — refreshes an existing checkout to the pinned tag, or shallow-clones if absent.
- **Failure-tolerant** — tGD&#39;s optional, network-dependent add-ons (CodeGraph via npm, Understand-Anything via pnpm) may fail under a restricted registry; the core skills/commands are linked first, and the hook exits `0` regardless so startup is never blocked.
- **Pinned, not floating** — pins a release tag rather than tracking a moving branch, since this auto-runs in every teammate&#39;s session. Upstream upgrades become an explicit one-line version bump here, mirroring how `settings.json` already pins the `365-skills` marketplace by SHA.

## Validation

Ran the hook exactly as a session would (`CLAUDE_CODE_REMOTE=true`) from a clean state:

- Hook exits **0** in ~4s (optional pnpm component failed on the restricted registry and was tolerated, as designed).
- Source checked out at exactly `v2026.07.11.3`.
- **29** `tgd-*` skills linked; symlinks resolve to the pinned `~/.tgd-src` clone.
- **7** `/tgd-*` commands present (`map`, `define`, `plan`, `develop`, `verify`, `review`, `release`).

`settings.json` validated as JSON; `tgd-install.sh` passes `bash -n`. No Go code changed, so the repo&#39;s lint/test tooling (installed by the untouched `session-start.sh`) is unaffected.

## After merge

Once this lands on `main`, **all future Claude Code web sessions** for this repo will auto-provision tGD. Start a fresh session, then drive the pipeline with `/tgd-map` → `/tgd-define` → `/tgd-plan` → `/tgd-develop` → `/tgd-verify` → `/tgd-review` → `/tgd-release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DezG27Ya8yCyknYvHZAkuk)_



## Summary by CodeRabbit

* **New Features**
  * Added automatic setup of the tGD framework when starting remote Claude Code sessions.
  * Pins installation to a specified release for consistent session environments.
  * Reuses existing installations and safely skips setup when network or optional component installation fails.
  * Configured the setup process with a five-minute timeout.