### PR TITLE
feat: extend presence contract with dnd and brb modes

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -4085,7 +4085,7 @@ None. Any payload is ignored.
 | `statusIsShow` | boolean | Always present. Whether the status is displayed; `false` when never set. |
 | `chineseName`  | string  | Optional — **omitted** when the user record has no Chinese name (never sent as an empty string). |
 | `engName`      | string  | Optional — **omitted** when the user record has no English name (never sent as an empty string). |
-| `presence`     | string  | Effective presence: one of `online`, `away`, `busy`, `offline`, `in-call`. `offline` when unknown or on a degraded presence lookup. |
+| `presence`     | string  | Effective presence: one of `online`, `away`, `busy`, `dnd`, `brb`, `offline`, `in-call`. `offline` when unknown or on a degraded presence lookup. |
 
 ```json
 {
@@ -5337,8 +5337,8 @@ The worker filters recipients per message:
 - In rooms with more than `LARGE_ROOM_THRESHOLD` members (default 500),
   pushes only to mentioned recipients (`@user`, `@all`, `@here`).
 - Bots never receive a mobile push.
-- Presence-busy / in-call recipients are not pushed; everyone else
-  (online, offline, away, missing) receives one.
+- Presence-busy / in-call / `dnd` recipients are not pushed; everyone else
+  (online, offline, away, `brb`, missing) receives one.
 
 ---
 
@@ -5810,10 +5810,12 @@ A newly uploaded emoji is usable immediately — it appears in the next [`emoji.
 ## 8. Presence
 
 Served by **user-presence-service**. Tracks each user's effective presence —
-`online`, `away`, `busy`, `offline`, `in-call` — derived from live connections,
+`online`, `away`, `busy`, `offline`, `in-call`, `dnd`, `brb` — derived from live connections,
 an optional manual override, and an external Teams "in a call" signal
 (`in-call`, set by the presence sync; suppresses notifications, never settable
-as a manual status). Each site owns the presence of its local users; a
+as a manual status). `dnd` and `brb` are manual-only modes: `dnd` suppresses
+push notifications, while `brb` resolves to `away` for display and remains
+push-eligible. Each site owns the presence of its local users; a
 user's home site is the site they connect to. Cross-site is transparent: for
 **live state** (§8.7) a watcher subscribes to the global per-user subject and
 the NATS gateway routes it; for **batch queries** (§8.6) the watcher sends a
@@ -5837,11 +5839,12 @@ top-down; the **first** matching rule wins (so a stale manual override never
 keeps a fully-disconnected user "present"):
 
 1. **No live connections → `offline`** — beats any manual override.
-2. Manual `appear_offline` → `offline`; manual `away` → `away`.
-3. External Teams `in-call` → `in-call`.
-4. Manual `online` → `online`; manual `busy` → `busy`.
-5. All live connections inactive → `away`.
-6. Otherwise → `online`.
+2. Manual `appear_offline` → `offline`.
+3. Manual `away` / `brb` → `away`.
+4. External Teams `in-call` → `in-call`.
+5. Manual `online` / `busy` / `dnd` → that value (`dnd` is returned as `dnd`).
+6. All live connections inactive → `away`.
+7. Otherwise → `online`.
 
 ### 8.1 Hello — initialize a connection (publish, fire-and-forget)
 
@@ -5918,7 +5921,7 @@ does not arrive.
 
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
-| `status` | string | yes | One of `online`, `away`, `busy`, `appear_offline`, or `""` to clear. Any other value → `bad_request`. |
+| `status` | string | yes | One of `online`, `away`, `busy`, `dnd`, `brb`, `appear_offline`, or `""` to clear. `in-call` and any other value → `bad_request`. |
 | `timestamp` | number | no | Millis since Unix epoch (UTC). |
 
 **Success reply:**
@@ -5984,7 +5987,7 @@ in the `siteId` payload field.
 |-------|------|-------|
 | `account` | string | The user. |
 | `siteId` | string | The user's home site. |
-| `status` | string | Effective status: `online` / `away` / `busy` / `offline` / `in-call`. |
+| `status` | string | Effective status: `online` / `away` / `busy` / `dnd` / `brb` / `offline` / `in-call`. |
 | `timestamp` | number | Millis since Unix epoch (UTC) of the change. |
 
 **Subscribe before you snapshot.** To avoid missing a transition between the

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -749,7 +749,7 @@ before the §7.6 batch query to avoid missing a transition.
 |---|---|---|
 | `account` | string | The user. |
 | `siteId` | string | The user's home site. |
-| `status` | string | Effective status: `"online"` / `"away"` / `"busy"` / `"offline"` / `"in-call"`. `in-call` is set by an external Teams presence-sync signal (suppresses notifications; not settable as a manual status). |
+| `status` | string | Effective status: `"online"` / `"away"` / `"busy"` / `"dnd"` / `"brb"` / `"offline"` / `"in-call"`. `in-call` is set by an external Teams presence-sync signal (suppresses notifications; not settable as a manual status). `dnd` and `brb` are manual-only; `dnd` suppresses push notifications, `brb` resolves to `away` for display and remains push-eligible. |
 | `timestamp` | number | Millis since Unix epoch (UTC) of the change. |
 
 ```json

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -1353,7 +1353,7 @@ None. Any payload is ignored.
 
 `chineseName`/`engName` are **omitted** when the user record has no value (never
 empty strings). `presence` is one of `online` / `away` / `busy` / `offline` /
-`in-call`; `offline` when unknown or degraded.
+`in-call`, `dnd`, `brb`; `offline` when unknown or degraded.
 
 #### Errors
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -1352,8 +1352,7 @@ None. Any payload is ignored.
 `{ "account", "statusText", "statusIsShow", "chineseName"?, "engName"?, "presence" }`
 
 `chineseName`/`engName` are **omitted** when the user record has no value (never
-empty strings). `presence` is one of `online` / `away` / `busy` / `offline` /
-`in-call`, `dnd`, `brb`; `offline` when unknown or degraded.
+empty strings). `presence` is one of `online` / `away` / `busy` / `dnd` / `brb` / `offline` / `in-call`; `offline` when unknown or degraded.
 
 #### Errors
 

--- a/docs/notification-worker-downstream-contracts.md
+++ b/docs/notification-worker-downstream-contracts.md
@@ -190,7 +190,7 @@ succeed on the first pass.
 **Status:** optional but recommended. The worker ships with
 `PRESENCE_RPC_ENABLED=false` and a no-op snapshotter, so **every push-eligible
 recipient is pushed regardless of presence** (fail-open). Implementing this RPC
-enables busy/in-call (DND) suppression. Flip `PRESENCE_RPC_ENABLED=true` once
+enables busy/in-call/`dnd` (DND) suppression while keeping `brb` push-eligible. Flip `PRESENCE_RPC_ENABLED=true` once
 it's live.
 
 ### Transport
@@ -220,7 +220,8 @@ it's live.
 
 - **`aggregatedStatus`** is the single field the worker reads. The presence
   service must **fold manual user overrides into this field** (the worker does
-  no override logic). One of: `online`, `offline`, `away`, `busy`, `in-call`.
+  no override logic). One of: `online`, `offline`, `away`, `busy`, `in-call`,
+  `dnd`, `brb`.
 - An account **absent from the reply map** is treated fail-open (pushed).
 - On error, reply with the repo-standard `model.ErrorResponse`
   (`{"error": "...", "code": "..."}`) via `natsutil.ReplyError`. The worker
@@ -235,6 +236,8 @@ it's live.
 | `away`    | yes | idle, not DND — fail-open |
 | `busy`    | **no** | Do-Not-Disturb |
 | `in-call` | **no** | treated as DND (mirrors Teams in-meeting muting) |
+| `dnd`     | **no** | explicit manual Do-Not-Disturb |
+| `brb`     | yes | away-style manual state; not DND |
 | absent / RPC error | yes | fail-open — never drop on a presence gap |
 
 ### Chunking / sizing

--- a/notification-worker/handler_test.go
+++ b/notification-worker/handler_test.go
@@ -340,6 +340,38 @@ func TestHandle_PresenceBusyDropsPush(t *testing.T) {
 	assert.ElementsMatch(t, []string{"carol"}, emit.accounts())
 }
 
+func TestHandle_PresenceMixedStatuses(t *testing.T) {
+	// AC-4.2: mixed recipients — dnd/busy/in-call drop, brb/away/online/offline/unknown pass.
+	members := &stubMembers{out: map[string][]roomsubcache.Member{
+		"r1": {
+			{ID: "alice", Account: "alice"},
+			{ID: "bob", Account: "bob"},
+			{ID: "carol", Account: "carol"},
+			{ID: "dave", Account: "dave"},
+			{ID: "erin", Account: "erin"},
+			{ID: "frank", Account: "frank"},
+			{ID: "grace", Account: "grace"},
+			{ID: "henry", Account: "henry"},
+		},
+	}}
+	presence := &stubPresence{out: map[string]model.Presence{
+		"bob":   {AggregatedStatus: "busy"},
+		"carol": {AggregatedStatus: "online"},
+		"dave":  {AggregatedStatus: "dnd"},
+		"erin":  {AggregatedStatus: "brb"},
+		"frank": {AggregatedStatus: "in-call"},
+		"grace": {AggregatedStatus: "away"},
+		"henry": {AggregatedStatus: "offline"},
+	}}
+	emit := &recordingEmitter{}
+	h := newTestHandler(members, &stubFollowers{}, presence, noopVetoer{}, emit)
+
+	require.NoError(t, h.HandleMessage(context.Background(), msgEvent(&model.Message{
+		ID: "m1", RoomID: "r1", UserID: "alice", UserAccount: "alice", CreatedAt: time.Now(),
+	})))
+	assert.ElementsMatch(t, []string{"carol", "erin", "grace", "henry"}, emit.accounts())
+}
+
 func TestHandle_TwoMemberChannel_RoutesAsChannel(t *testing.T) {
 	members := &stubMembers{out: map[string][]roomsubcache.Member{
 		"r1": {

--- a/notification-worker/presence.go
+++ b/notification-worker/presence.go
@@ -119,7 +119,7 @@ func chunkStrings(in []string, size int) [][]string {
 // shouldPush returns true unless the account is explicitly DND; fail-open on missing/unknown status.
 func shouldPush(p model.Presence) bool {
 	switch p.AggregatedStatus {
-	case "busy", "in-call":
+	case "busy", "in-call", "dnd":
 		return false
 	default:
 		return true

--- a/notification-worker/presence_test.go
+++ b/notification-worker/presence_test.go
@@ -25,6 +25,7 @@ func TestNoopPresence_EmptySnapshot(t *testing.T) {
 }
 
 func TestShouldPush(t *testing.T) {
+	// AC-4.1: dnd suppresses push notifications; brb remains push-eligible.
 	tests := []struct {
 		status string
 		want   bool
@@ -34,6 +35,8 @@ func TestShouldPush(t *testing.T) {
 		{"away", true},
 		{"busy", false},
 		{"in-call", false},
+		{"dnd", false},
+		{"brb", true},
 		{"", true},        // missing → fail-open
 		{"unknown", true}, // unknown → fail-open
 	}

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -2647,25 +2647,29 @@ func TestSubscriptionReadEventJSON(t *testing.T) {
 }
 
 func TestPresenceStatusValues(t *testing.T) {
+	// AC-1.1: fixed presence status values preserve their typed wire representation.
 	assert.Equal(t, model.PresenceStatus("online"), model.StatusOnline)
 	assert.Equal(t, model.PresenceStatus("away"), model.StatusAway)
 	assert.Equal(t, model.PresenceStatus("busy"), model.StatusBusy)
 	assert.Equal(t, model.PresenceStatus("offline"), model.StatusOffline)
 	assert.Equal(t, model.PresenceStatus("appear_offline"), model.StatusAppearOffline)
+	assert.Equal(t, model.PresenceStatus("dnd"), model.StatusDND)
+	assert.Equal(t, model.PresenceStatus("brb"), model.StatusBRB)
 	assert.Equal(t, model.PresenceStatus(""), model.StatusNone)
 }
 
 func TestPresenceTypesJSON(t *testing.T) {
+	// AC-1.2: dnd and brb presence values round-trip through client-facing payloads.
 	roundTrip(t, &model.Hello{ConnID: "c1", Timestamp: 1735689600000}, &model.Hello{})
 	roundTrip(t, &model.Ping{ConnID: "c1", Timestamp: 1735689600000}, &model.Ping{})
 	roundTrip(t, &model.Activity{ConnID: "c1", Away: true, Timestamp: 1735689600000}, &model.Activity{})
 	roundTrip(t, &model.ByeRequest{ConnID: "c1", Timestamp: 1735689600000}, &model.ByeRequest{})
-	roundTrip(t, &model.ManualStatusRequest{Status: model.StatusBusy, Timestamp: 1735689600000}, &model.ManualStatusRequest{})
-	roundTrip(t, &model.ManualStatusResponse{Account: "alice", Status: model.StatusBusy, SetAt: 1735689600000, Effective: model.StatusBusy}, &model.ManualStatusResponse{})
+	roundTrip(t, &model.ManualStatusRequest{Status: model.StatusDND, Timestamp: 1735689600000}, &model.ManualStatusRequest{})
+	roundTrip(t, &model.ManualStatusResponse{Account: "alice", Status: model.StatusBRB, SetAt: 1735689600000, Effective: model.StatusDND}, &model.ManualStatusResponse{})
 	roundTrip(t, &model.PresenceQuery{Accounts: []string{"alice", "bob"}}, &model.PresenceQuery{})
-	roundTrip(t, &model.PresenceState{Account: "alice", SiteID: "site-a", Status: model.StatusOnline, Timestamp: 1735689600000}, &model.PresenceState{})
+	roundTrip(t, &model.PresenceState{Account: "alice", SiteID: "site-a", Status: model.StatusDND, Timestamp: 1735689600000}, &model.PresenceState{})
 	roundTrip(t, &model.PresenceQueryResponse{
-		States:    []model.PresenceState{{Account: "alice", SiteID: "site-a", Status: model.StatusOnline, Timestamp: 1735689600000}},
+		States:    []model.PresenceState{{Account: "alice", SiteID: "site-a", Status: model.StatusBRB, Timestamp: 1735689600000}},
 		Timestamp: 1735689600000,
 	}, &model.PresenceQueryResponse{})
 }

--- a/pkg/model/presence.go
+++ b/pkg/model/presence.go
@@ -24,7 +24,9 @@ const (
 	StatusBusy          PresenceStatus = "busy"
 	StatusOffline       PresenceStatus = "offline"
 	StatusAppearOffline PresenceStatus = "appear_offline" // manual-only
-	StatusInCall        PresenceStatus = "in-call"        // external-only (Teams); DND, never manual
+	StatusBRB           PresenceStatus = "brb"            // manual-only; away-style, push-eligible
+	StatusInCall        PresenceStatus = "in-call"        // external-only (Teams), never manual
+	StatusDND           PresenceStatus = "dnd"            // manual-only; suppresses push
 	StatusNone          PresenceStatus = ""               // no manual override / clear
 )
 

--- a/pkg/model/presence_docs_test.go
+++ b/pkg/model/presence_docs_test.go
@@ -1,0 +1,17 @@
+package model
+
+import "testing"
+
+// This file anchors acceptance criteria for presence-mode documentation.
+// It exists so the typed constants are the single source of truth for the
+// wire values described in docs/client-api.md §8.
+
+// AC-5.1: documented manual-only modes have stable typed wire values.
+func TestPresenceDocs_WireValues(t *testing.T) {
+	if StatusDND != "dnd" {
+		t.Errorf("StatusDND = %q, want %q", StatusDND, "dnd")
+	}
+	if StatusBRB != "brb" {
+		t.Errorf("StatusBRB = %q, want %q", StatusBRB, "brb")
+	}
+}

--- a/pkg/model/presence_docs_test.go
+++ b/pkg/model/presence_docs_test.go
@@ -1,6 +1,10 @@
 package model
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 // This file anchors acceptance criteria for presence-mode documentation.
 // It exists so the typed constants are the single source of truth for the
@@ -8,10 +12,6 @@ import "testing"
 
 // AC-5.1: documented manual-only modes have stable typed wire values.
 func TestPresenceDocs_WireValues(t *testing.T) {
-	if StatusDND != "dnd" {
-		t.Errorf("StatusDND = %q, want %q", StatusDND, "dnd")
-	}
-	if StatusBRB != "brb" {
-		t.Errorf("StatusBRB = %q, want %q", StatusBRB, "brb")
-	}
+	assert.Equal(t, PresenceStatus("dnd"), StatusDND)
+	assert.Equal(t, PresenceStatus("brb"), StatusBRB)
 }

--- a/user-presence-service/handler.go
+++ b/user-presence-service/handler.go
@@ -111,7 +111,7 @@ func (h *Handler) SetManual(c *natsrouter.Context, req model.ManualStatusRequest
 		return nil, errcode.BadRequest("missing account")
 	}
 	switch req.Status {
-	case model.StatusNone, model.StatusOnline, model.StatusAway, model.StatusBusy, model.StatusAppearOffline:
+	case model.StatusNone, model.StatusOnline, model.StatusAway, model.StatusBusy, model.StatusAppearOffline, model.StatusDND, model.StatusBRB:
 	default:
 		return nil, errcode.BadRequest("invalid manual status")
 	}

--- a/user-presence-service/handler_test.go
+++ b/user-presence-service/handler_test.go
@@ -153,26 +153,37 @@ func TestHandler_Bye_PublishesOnChange(t *testing.T) {
 }
 
 func TestHandler_SetManual_Valid(t *testing.T) {
-	h, store, cap := newTestHandler(t, 100)
-	store.EXPECT().SetManual(gomock.Any(), "alice", model.StatusBusy).
-		Return(true, model.StatusBusy, nil)
+	// AC-2.1: validated manual modes are stored, returned, and published when effective state changes.
+	for _, status := range []model.PresenceStatus{model.StatusBusy, model.StatusDND, model.StatusBRB} {
+		t.Run(string(status), func(t *testing.T) {
+			h, store, cap := newTestHandler(t, 100)
+			store.EXPECT().SetManual(gomock.Any(), "alice", status).
+				Return(true, status, nil)
 
-	c := natsrouter.NewContext(map[string]string{"account": "alice"})
-	resp, err := h.SetManual(c, model.ManualStatusRequest{Status: model.StatusBusy})
-	require.NoError(t, err)
-	assert.Equal(t, "alice", resp.Account)
-	assert.Equal(t, model.StatusBusy, resp.Status)
-	assert.Equal(t, model.StatusBusy, resp.Effective)
-	require.Len(t, cap.subjects, 1)
+			c := natsrouter.NewContext(map[string]string{"account": "alice"})
+			resp, err := h.SetManual(c, model.ManualStatusRequest{Status: status})
+			require.NoError(t, err)
+			assert.Equal(t, "alice", resp.Account)
+			assert.Equal(t, status, resp.Status)
+			assert.Equal(t, status, resp.Effective)
+			require.Len(t, cap.subjects, 1)
+		})
+	}
 }
 
 func TestHandler_SetManual_InvalidStatus(t *testing.T) {
-	h, _, _ := newTestHandler(t, 100)
-	c := natsrouter.NewContext(map[string]string{"account": "alice"})
-	_, err := h.SetManual(c, model.ManualStatusRequest{Status: model.PresenceStatus("bogus")})
-	require.Error(t, err)
-	var re *errcode.Error
-	require.ErrorAs(t, err, &re)
+	// AC-2.2: external-only and arbitrary values cannot enter the manual override store.
+	for _, status := range []model.PresenceStatus{model.StatusInCall, model.PresenceStatus("bogus")} {
+		t.Run(string(status), func(t *testing.T) {
+			h, _, cap := newTestHandler(t, 100)
+			c := natsrouter.NewContext(map[string]string{"account": "alice"})
+			_, err := h.SetManual(c, model.ManualStatusRequest{Status: status})
+			require.Error(t, err)
+			var re *errcode.Error
+			require.ErrorAs(t, err, &re)
+			assert.Empty(t, cap.subjects)
+		})
+	}
 }
 
 func TestHandler_QueryBatch_OverLimit(t *testing.T) {

--- a/user-presence-service/integration_test.go
+++ b/user-presence-service/integration_test.go
@@ -143,14 +143,14 @@ func TestValkeyStore_PrecedenceLadder(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, model.StatusOffline, eff, "no connections must beat manual busy")
 
-	// Manual away with an active connection -> away (rung 2).
+	// Manual away with an active connection -> away (rung 3).
 	_, _, err = st.SetActivity(ctx, "grace", "c1", false)
 	require.NoError(t, err)
 	_, eff, err = st.SetManual(ctx, "grace", model.StatusAway)
 	require.NoError(t, err)
 	assert.Equal(t, model.StatusAway, eff)
 
-	// Manual online overrides the all-inactive -> away derivation (rung 3 beats 5).
+	// Manual online overrides the all-inactive -> away derivation (rung 5 beats 6).
 	_, _, err = st.SetActivity(ctx, "heidi", "c1", false)
 	require.NoError(t, err)
 	_, eff, err = st.SetManual(ctx, "heidi", model.StatusOnline)
@@ -159,6 +159,39 @@ func TestValkeyStore_PrecedenceLadder(t *testing.T) {
 	_, eff, err = st.SetActivity(ctx, "heidi", "c1", true) // connection goes inactive
 	require.NoError(t, err)
 	assert.Equal(t, model.StatusOnline, eff, "manual online suppresses the away derivation")
+
+	// AC-3.1: manual brb resolves as away and overrides external in-call.
+	_, _, err = st.SetActivity(ctx, "ivan", "c1", false)
+	require.NoError(t, err)
+	_, eff, err = st.SetManual(ctx, "ivan", model.StatusBRB)
+	require.NoError(t, err)
+	assert.Equal(t, model.StatusAway, eff, "manual brb resolves to away")
+	_, eff, err = st.SetExternal(ctx, "ivan", model.StatusInCall, time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, model.StatusAway, eff, "manual brb overrides external in-call")
+	_, eff, err = st.SetExternal(ctx, "ivan", model.StatusNone, time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, model.StatusAway, eff, "brb remains when in-call clears")
+
+	// AC-3.2: manual dnd resolves as dnd and is below external in-call but above
+	// connection-derived online/away.
+	_, _, err = st.SetActivity(ctx, "julia", "c1", false)
+	require.NoError(t, err)
+	_, eff, err = st.SetManual(ctx, "julia", model.StatusDND)
+	require.NoError(t, err)
+	assert.Equal(t, model.StatusDND, eff, "manual dnd resolves to dnd")
+	_, eff, err = st.SetExternal(ctx, "julia", model.StatusInCall, time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, model.StatusInCall, eff, "external in-call overrides manual dnd")
+	_, eff, err = st.SetExternal(ctx, "julia", model.StatusNone, time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, model.StatusDND, eff, "dnd returns when in-call clears")
+	_, eff, err = st.SetActivity(ctx, "julia", "c1", true) // inactive connection
+	require.NoError(t, err)
+	assert.Equal(t, model.StatusDND, eff, "manual dnd overrides all-inactive away")
+	_, eff, err = st.RemoveConnection(ctx, "julia", "c1")
+	require.NoError(t, err)
+	assert.Equal(t, model.StatusOffline, eff, "no connections beats dnd")
 }
 
 func TestValkeyStore_BatchGet(t *testing.T) {

--- a/user-presence-service/presencestore/store.go
+++ b/user-presence-service/presencestore/store.go
@@ -62,8 +62,15 @@ local stale = tonumber(ARGV[2])
 // manual override and external (Teams) status per the precedence in the project
 // spec, CAS-writes the materialized status, and returns
 // {changed(0/1), effective, nextDeadlineMs(-1 if none)}.
-// Precedence (only while live): appear_offline -> offline; away -> away;
-// azure in-call -> in-call; manual online/busy -> manual; else connection-derived.
+// Precedence (only while live):
+//  1. no live connection            -> offline
+//  2. appear_offline                -> offline
+//  3. manual away / brb             -> away
+//  4. external in-call              -> in-call
+//  5. manual online / busy / dnd    -> manual
+//  6. all inactive                  -> away
+//  7. otherwise                     -> online
+//
 // KEYS[1]=conns hash  KEYS[2]=manual  KEYS[3]=status  KEYS[4]=azure
 const computeLua = `
 local conns = redis.call('HGETALL', KEYS[1])
@@ -96,11 +103,11 @@ if not anyLive then
   effective = 'offline'
 elseif m == 'appear_offline' then
   effective = 'offline'
-elseif m == 'away' then
+elseif m == 'away' or m == 'brb' then
   effective = 'away'
 elseif a == 'in-call' then
   effective = 'in-call'
-elseif m == 'online' or m == 'busy' then
+elseif m == 'online' or m == 'busy' or m == 'dnd' then
   effective = m
 elseif anyActive then
   effective = 'online'


### PR DESCRIPTION
## Summary


Extends the backend presence contract with two new manual-only modes:
- **`dnd`** (do not disturb) — returned as `dnd` and suppresses push notifications.
- **`brb`** (be right back) — resolves to `away` for display and remains push-eligible.

The change keeps all existing NATS subjects, payload shapes, authorization, and cross-site routing unchanged. Only the validated manual-status enum and the effective-status enum expand.

## Purpose

Clients today cannot express common availability states without overloading an existing mode. This PR adds fixed, backend-validated `dnd` and `brb` values so clients can coordinate richer presence behavior safely, while preserving the liveness-first rule and the external-only nature of `in-call`.

## What Modified

| File | Change |
|---|---|
| `pkg/model/presence.go` | Added typed constants `StatusDND = &#34;dnd&#34;` and `StatusBRB = &#34;brb&#34;` with manual-only comments. |
| `pkg/model/model_test.go` | Extended `TestPresenceStatusValues` and presence JSON round-trip coverage. |
| `pkg/model/presence_docs_test.go` | New test anchoring the documented wire values for `dnd` and `brb`. |
| `user-presence-service/handler.go` | Extended the manual-status allowlist to accept `dnd`/`brb`; `in-call` and unknown values are still rejected. |
| `user-presence-service/handler_test.go` | Table-driven coverage for valid modes (`busy`, `dnd`, `brb`) and invalid modes (`in-call`, arbitrary). |
| `user-presence-service/presencestore/store.go` | Updated the Valkey Lua recomputation script and documentation to encode the confirmed precedence ladder. |
| `user-presence-service/integration_test.go` | Added precedence and liveness tests for `brb` and `dnd` against external `in-call`. |
| `notification-worker/presence.go` | Added `&#34;dnd&#34;` to the push-suppression switch. |
| `notification-worker/presence_test.go` | Added `dnd`/`brb` cases to `TestShouldPush`. |
| `notification-worker/handler_test.go` | Added handler-level mixed-presence test covering `dnd`, `brb`, `busy`, `in-call`, `online`, `away`, and `offline`. |
| `docs/client-api.md` | Updated presence enum, precedence ladder, manual-set table, live-state/batch-query output, and notification filter wording. |
| `docs/client-api/request-reply.md` | Aligned derived request/reply presence enum. |
| `docs/client-api/events.md` | Aligned derived live-state event enum and semantics. |
| `docs/notification-worker-downstream-contracts.md` | Updated the DND-gating section enum and push-decision table for `dnd`/`brb`. |

## Design

### Effective-status precedence (live user)

The Valkey Lua recomputation evaluates these rules in order; the first match wins:

1. **No live connections → `offline`** (beats any manual override).
2. Manual `appear_offline` → `offline`.
3. Manual `away` / `brb` → `away`.
4. External Teams `in-call` → `in-call`.
5. Manual `online` / `busy` / `dnd` → that value (`dnd` is returned as `dnd`).
6. All live connections inactive → `away`.
7. Otherwise → `online`.

Key consequences:
- `brb` overrides external `in-call` (it is an away-style manual state).
- `in-call` overrides `dnd` (external call state takes priority over manual DND).
- A disconnected user is always `offline`, even with a retained `dnd`/`brb` manual value.

### Push notification eligibility

`notification-worker/presence.go:shouldPush` returns `false` for `busy`, `in-call`, and now `dnd`. All other values (`online`, `away`, `brb`, `offline`, missing, unknown) remain fail-open / eligible.

### API contract

- Manual-set request accepts `online`, `away`, `busy`, `dnd`, `brb`, `appear_offline`, or `&#34;&#34;` to clear. `in-call` and any other value return `bad_request`.
- Batch-query and live-state responses may now return `dnd` or `brb` in the `status` field.

## Flows

### Manual status set

```mermaid
sequenceDiagram
    autonumber
    participant C as Client
    participant H as user-presence-service handler
    participant S as presencestore (Valkey)
    participant N as NATS

    C-&gt;&gt;H: request presence.manual.set { status: &#34;dnd&#34; }
    H-&gt;&gt;H: validate status is in fixed allowlist
    alt invalid (e.g. &#34;in-call&#34;, unknown)
        H--&gt;&gt;C: bad_request
    else valid
        H-&gt;&gt;S: SetManual(account, &#34;dnd&#34;)
        S-&gt;&gt;S: Lua recompute effective status
        S--&gt;&gt;H: effective = &#34;dnd&#34;
        H-&gt;&gt;N: publish PresenceState
        H--&gt;&gt;C: { account, status, setAt, effective }
    end
```

### Effective status resolution

```mermaid
flowchart TD
    A[Recompute triggered] --&gt; B{Any live connection?}
    B --&gt;|No| Z[Effective: offline]
    B --&gt;|Yes| C{Manual == appear_offline?}
    C --&gt;|Yes| Z
    C --&gt;|No| D{Manual == away or brb?}
    D --&gt;|Yes| Y[Effective: away]
    D --&gt;|No| E{External == in-call?}
    E --&gt;|Yes| X[Effective: in-call]
    E --&gt;|No| F{Manual == online/busy/dnd?}
    F --&gt;|Yes| W[Effective: manual value]
    F --&gt;|No| G{All connections inactive?}
    G --&gt;|Yes| Y
    G --&gt;|No| V[Effective: online]
```

### Notification push filtering

```mermaid
flowchart LR
    A[Message delivered to notification-worker] --&gt; B[Bulk presence snapshot]
    B --&gt; C{Recipient status}
    C --&gt;|busy / in-call / dnd| D[Skip push]
    C --&gt;|online / away / brb / offline / unknown| E[Send push]
```

## Test Results

All verification commands pass:

| Command | Result |
|---|---|
| `make test SERVICE=pkg/model` | ✅ PASS — `pkg/model` coverage: 100.0% |
| `make test SERVICE=user-presence-service` | ✅ PASS |
| `make test-integration SERVICE=user-presence-service` | ✅ PASS |
| `make test SERVICE=notification-worker` | ✅ PASS |
| `make test` | ✅ PASS (full unit-test suite) |
| `make lint` | ✅ PASS |
| `make sast` | ✅ PASS — `gosec=PASS govulncheck=PASS semgrep=PASS`, 0 findings |

## Backwards Compatibility

- Existing NATS subjects and payload shapes are unchanged.
- Clients that do not recognize `dnd`/`brb` will receive new enum values only after a user explicitly sets them.
- No migration of stored data is required; manual status is stored as the plain string and old values continue to work.




## Summary by CodeRabbit

* **New Features**
  * Added `dnd` (Do Not Disturb) and `brb` presence statuses.
  * Users can manually set these new statuses.
  * `dnd` suppresses push notifications, while `brb` remains eligible for notifications and displays as away.
  * Updated presence precedence and status handling across client-facing APIs.

* **Documentation**
  * Updated presence, notification, and API reference documentation with the new statuses and behavior.