### PR TITLE
build: move to the Go 1.26 line at 1.26.5 (+ golangci-lint v2.12.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,11 @@ permissions:
   contents: read
 
 env:
-  # Bumped to 1.25.12 for the July 2026 security release (govulncheck
-  # flagged a reachable crypto/tls (GO-2026-5856) stdlib advisory fixed
-  # in 1.25.12; 1.25.11 had covered the June GO-2026-5039/GO-2026-5037
-  # advisories).
-  GO_VERSION: "1.25.12"
-  GOLANGCI_LINT_VERSION: "v2.11.4"
+  # 1.26.5: move to the Go 1.26 minor line at its July 2026 security
+  # patch — the crypto/tls GO-2026-5856 advisory affects 1.26.0–1.26.4
+  # and is fixed in 1.26.5 (1.25.12 had the same fix on the 1.25 line).
+  GO_VERSION: "1.26.5"
+  GOLANGCI_LINT_VERSION: "v2.12.2"
 
 jobs:
   prewarm:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,7 +323,7 @@ All commands are wrapped in the root Makefile. Always use `make` targets — nev
 - Always provide `envDefault` for non-critical config (port, database name, log level); never default secrets or connection strings — mark them `required`
 
 ### Docker
-- Multi-stage Dockerfiles: `golang:1.25.12-alpine` builder, `alpine:3.21` runtime
+- Multi-stage Dockerfiles: `golang:1.26.5-alpine` builder, `alpine:3.21` runtime
 - Location: `<service>/deploy/Dockerfile`
 - Build context: repo root so `pkg/` and `go.mod` are accessible
 - Docker Compose for local dev only — include only the dependencies the service needs

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ OBS_COMPOSE      := tools/observability/docker-compose.yml
 # Go 1.25. Tracks the repo-wide Go (go.mod / ci.yml); Go fetches the
 # pinned toolchain on demand.
 GOBIN_DIR             := $(shell go env GOPATH)/bin
-TOOLS_GO_TOOLCHAIN    := go1.25.12
-GOLANGCI_LINT_VERSION := v2.11.4
+TOOLS_GO_TOOLCHAIN    := go1.26.5
+GOLANGCI_LINT_VERSION := v2.12.2
 GOSEC_VERSION         := v2.26.1
 GOVULNCHECK_VERSION   := v1.3.0
 SEMGREP_VERSION       := 1.163.0

--- a/auth-service/deploy/Dockerfile
+++ b/auth-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/auth-service/deploy/azure-pipelines.yml
+++ b/auth-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_NAME: auth-service
   REGISTRY: '$(containerRegistry)'
 

--- a/broadcast-worker/deploy/Dockerfile
+++ b/broadcast-worker/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /app
 

--- a/broadcast-worker/deploy/azure-pipelines.yml
+++ b/broadcast-worker/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_NAME: broadcast-worker
   REGISTRY: '$(containerRegistry)'
 

--- a/data-migration/oplog-collections-transformer/deploy/Dockerfile
+++ b/data-migration/oplog-collections-transformer/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /app
 

--- a/data-migration/oplog-collections-transformer/deploy/azure-pipelines.yml
+++ b/data-migration/oplog-collections-transformer/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_PATH: data-migration/oplog-collections-transformer
   IMAGE_NAME: oplog-collections-transformer
   REGISTRY: '$(containerRegistry)'

--- a/data-migration/oplog-connector/deploy/Dockerfile
+++ b/data-migration/oplog-connector/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /app
 

--- a/data-migration/oplog-connector/deploy/azure-pipelines.yml
+++ b/data-migration/oplog-connector/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_PATH: data-migration/oplog-connector
   IMAGE_NAME: oplog-connector
   REGISTRY: '$(containerRegistry)'

--- a/data-migration/oplog-direct-transfer/deploy/Dockerfile
+++ b/data-migration/oplog-direct-transfer/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /app
 

--- a/data-migration/oplog-direct-transfer/deploy/azure-pipelines.yml
+++ b/data-migration/oplog-direct-transfer/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_PATH: data-migration/oplog-direct-transfer
   IMAGE_NAME: oplog-direct-transfer
   REGISTRY: '$(containerRegistry)'

--- a/data-migration/oplog-transformer/deploy/Dockerfile
+++ b/data-migration/oplog-transformer/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /app
 

--- a/data-migration/oplog-transformer/deploy/azure-pipelines.yml
+++ b/data-migration/oplog-transformer/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_PATH: data-migration/oplog-transformer
   IMAGE_NAME: oplog-transformer
   REGISTRY: '$(containerRegistry)'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hmchangw/chat
 
-go 1.25.12
+go 1.26.5
 
 require (
 	github.com/Marz32onE/instrumentation-go/otel-nats v0.2.0

--- a/history-service/deploy/Dockerfile
+++ b/history-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/history-service/deploy/azure-pipelines.yml
+++ b/history-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_NAME: history-service
   REGISTRY: '$(containerRegistry)'
 

--- a/history-service/internal/cassrepo/utils.go
+++ b/history-service/internal/cassrepo/utils.go
@@ -122,7 +122,7 @@ func cqlFieldIndex(rt reflect.Type) map[string]int {
 // Separated from structScan so the column-matching logic is unit-testable without a live gocql iterator.
 func buildScanValues(dest any, colNames []string) (values []any, missingCol string, ok bool) {
 	rv := reflect.ValueOf(dest)
-	if rv.Kind() != reflect.Ptr || rv.Elem().Kind() != reflect.Struct {
+	if rv.Kind() != reflect.Pointer || rv.Elem().Kind() != reflect.Struct {
 		return nil, "", false
 	}
 	rv = rv.Elem()
@@ -144,7 +144,7 @@ func buildScanValues(dest any, colNames []string) (values []any, missingCol stri
 func structScan(iter *gocql.Iter, dest any) (bool, error) {
 	// Validate dest shape before touching the iterator (iter may be nil in tests).
 	rv := reflect.ValueOf(dest)
-	if rv.Kind() != reflect.Ptr || rv.Elem().Kind() != reflect.Struct {
+	if rv.Kind() != reflect.Pointer || rv.Elem().Kind() != reflect.Struct {
 		return false, nil
 	}
 

--- a/inbox-worker/deploy/Dockerfile
+++ b/inbox-worker/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /app
 

--- a/inbox-worker/deploy/azure-pipelines.yml
+++ b/inbox-worker/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_NAME: inbox-worker
   REGISTRY: '$(containerRegistry)'
 

--- a/media-service/deploy/Dockerfile
+++ b/media-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/media-service/deploy/azure-pipelines.yml
+++ b/media-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_NAME: media-service
   REGISTRY: '$(containerRegistry)'
 

--- a/message-gatekeeper/deploy/Dockerfile
+++ b/message-gatekeeper/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/message-gatekeeper/deploy/azure-pipelines.yml
+++ b/message-gatekeeper/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_NAME: message-gatekeeper
   REGISTRY: '$(containerRegistry)'
 

--- a/message-worker/deploy/Dockerfile
+++ b/message-worker/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/message-worker/deploy/azure-pipelines.yml
+++ b/message-worker/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_NAME: message-worker
   REGISTRY: '$(containerRegistry)'
 

--- a/notification-worker/deploy/Dockerfile
+++ b/notification-worker/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /app
 

--- a/notification-worker/deploy/azure-pipelines.yml
+++ b/notification-worker/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_NAME: notification-worker
   REGISTRY: '$(containerRegistry)'
 

--- a/portal-service/deploy/Dockerfile
+++ b/portal-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/portal-service/deploy/azure-pipelines.yml
+++ b/portal-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_NAME: portal-service
   REGISTRY: '$(containerRegistry)'
   # Repo-wide 80% minimum, gated like search-service's pipeline. main.go is

--- a/room-service/deploy/Dockerfile
+++ b/room-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/room-service/deploy/azure-pipelines.yml
+++ b/room-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_NAME: room-service
   REGISTRY: '$(containerRegistry)'
 

--- a/room-worker/deploy/Dockerfile
+++ b/room-worker/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/room-worker/deploy/azure-pipelines.yml
+++ b/room-worker/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_NAME: room-worker
   REGISTRY: '$(containerRegistry)'
 

--- a/search-service/deploy/Dockerfile
+++ b/search-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/search-sync-worker/deploy/Dockerfile
+++ b/search-sync-worker/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/search-sync-worker/deploy/azure-pipelines.yml
+++ b/search-sync-worker/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_NAME: search-sync-worker
   REGISTRY: '$(containerRegistry)'
 

--- a/tools/loadgen/deploy/Dockerfile
+++ b/tools/loadgen/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /app
 

--- a/tools/nats-debug/deploy/Dockerfile
+++ b/tools/nats-debug/deploy/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # ── Build stage ───────────────────────────────────────────────────────────────
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /build
 

--- a/upload-service/deploy/Dockerfile
+++ b/upload-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/user-presence-service/deploy/Dockerfile
+++ b/user-presence-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/user-presence-service/deploy/azure-pipelines.yml
+++ b/user-presence-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_NAME: user-presence-service
   REGISTRY: '$(containerRegistry)'
 

--- a/user-presence-service/sync/deploy/Dockerfile
+++ b/user-presence-service/sync/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/user-presence-service/sync/deploy/azure-pipelines.yml
+++ b/user-presence-service/sync/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_DIR: user-presence-service/sync
   IMAGE_NAME: user-presence-sync
   REGISTRY: '$(containerRegistry)'

--- a/user-service/deploy/Dockerfile
+++ b/user-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/user-service/deploy/azure-pipelines.yml
+++ b/user-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.5'
   SERVICE_NAME: user-service
   REGISTRY: '$(containerRegistry)'
 


### PR DESCRIPTION
## Summary

Follow-up to #481 (1.25.12): moves the toolchain to the **Go 1.26 minor line**.

**Why 1.26.5 and not 1.26.4:** the crypto/tls advisory **[GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856)** affects `1.26.0–1.26.4` and is only fixed in **1.26.5** on the 1.26 line (verified against the Go vulnerability database) — 1.26.4 would immediately re-fail the `sast` gate that #481 just cleared.

## Changes

- `1.25.12` → `1.26.5` across every pin: `go.mod`, CI `GO_VERSION` (+ pin comment), Makefile `TOOLS_GO_TOOLCHAIN`, all `*/deploy/Dockerfile` (`golang:1.26.5-alpine`), all `*/deploy/azure-pipelines.yml`, and the CLAUDE.md Docker convention line.
- **golangci-lint `v2.11.4` → `v2.12.2`** (ci.yml + Makefile). Required, not optional: the v2.11.4 release binary is built with go1.25 and hard-refuses a `go 1.26.x` target (`the Go language version used to build golangci-lint is lower than the targeted Go version`); v2.12.2&#39;s release workflow builds with Go 1.26.
- `reflect.Ptr` → `reflect.Pointer` (2 sites in `history-service/internal/cassrepo/utils.go`): v2.12.2&#39;s newer govet flags the deprecated alias. Semantically identical constants.

## Verification

- Full unit suite (race detector) green under go1.26.5 across all 77 packages
- golangci-lint v2.12.2 (built with go1.26.5) run over the repo: **0 issues**
- `golang:1.26.5-alpine` exists on Docker Hub (verified)
- govulncheck&#39;s vulnerability-DB fetch is egress-blocked in the dev sandbox, so the advisory clearance is validated by this PR&#39;s `sast` CI job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AZfDQqTZJMjSiQc2rp3Ww

---
_Generated by [Claude Code](https://claude.ai/code/session_019AZfDQqTZJMjSiQc2rp3Ww)_