### PR TITLE
fix(room-worker,inbox-worker): scrub thread state on member removal (#308)

### DIFF
--- a/inbox-worker/handler.go
+++ b/inbox-worker/handler.go
@@ -30,6 +30,10 @@ type InboxStore interface {
 	// redelivered until member_added lands (federation race).
 	UpdateSubscriptionRoles(ctx context.Context, account, roomID string, roles []model.Role, rolesUpdatedAt time.Time) error
 	DeleteSubscriptionsByAccounts(ctx context.Context, roomID string, accounts []string) error
+	// DeleteThreadSubscriptions removes the accounts' per-thread read-state docs
+	// in roomID on a federated removal (#308). This site holds no thread_rooms
+	// (replyAccounts lives only at the room's home site), so nothing else to clean.
+	DeleteThreadSubscriptions(ctx context.Context, roomID string, accounts []string) error
 	FindUsersByAccounts(ctx context.Context, accounts []string) ([]model.User, error)
 	// UpdateSubscriptionRead sets lastSeenAt and alert on the subscription
 	// keyed by (roomID, account). Idempotent and order-safe: the write
@@ -215,6 +219,10 @@ func (h *Handler) handleMemberRemoved(ctx context.Context, evt *model.InboxEvent
 	}
 	if err := h.store.DeleteSubscriptionsByAccounts(ctx, memberEvt.RoomID, memberEvt.Accounts); err != nil {
 		return fmt.Errorf("delete subscriptions for room %s: %w", memberEvt.RoomID, err)
+	}
+	// Scrub the removed accounts' thread read-state on this site too (#308).
+	if err := h.store.DeleteThreadSubscriptions(ctx, memberEvt.RoomID, memberEvt.Accounts); err != nil {
+		return fmt.Errorf("delete thread subscriptions for room %s: %w", memberEvt.RoomID, err)
 	}
 	return nil
 }

--- a/inbox-worker/handler_test.go
+++ b/inbox-worker/handler_test.go
@@ -132,13 +132,18 @@ func (s *stubInboxStore) UpsertRoom(ctx context.Context, room *model.Room) error
 	return nil
 }
 
+func toSet(accounts []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(accounts))
+	for _, a := range accounts {
+		set[a] = struct{}{}
+	}
+	return set
+}
+
 func (s *stubInboxStore) DeleteSubscriptionsByAccounts(_ context.Context, roomID string, accounts []string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	want := make(map[string]struct{}, len(accounts))
-	for _, a := range accounts {
-		want[a] = struct{}{}
-	}
+	want := toSet(accounts)
 	filtered := s.subscriptions[:0]
 	for i := range s.subscriptions {
 		if s.subscriptions[i].RoomID == roomID {
@@ -149,6 +154,23 @@ func (s *stubInboxStore) DeleteSubscriptionsByAccounts(_ context.Context, roomID
 		filtered = append(filtered, s.subscriptions[i])
 	}
 	s.subscriptions = filtered
+	return nil
+}
+
+func (s *stubInboxStore) DeleteThreadSubscriptions(_ context.Context, roomID string, accounts []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	want := toSet(accounts)
+	filtered := s.threadSubs[:0]
+	for i := range s.threadSubs {
+		if s.threadSubs[i].RoomID == roomID {
+			if _, match := want[s.threadSubs[i].UserAccount]; match {
+				continue
+			}
+		}
+		filtered = append(filtered, s.threadSubs[i])
+	}
+	s.threadSubs = filtered
 	return nil
 }
 
@@ -995,6 +1017,39 @@ func TestHandleEvent_MemberRemoved(t *testing.T) {
 
 	subs := store.getSubscriptions()
 	assert.Empty(t, subs)
+}
+
+func TestHandleEvent_MemberRemoved_CleansThreadSubscriptions(t *testing.T) {
+	store := &stubInboxStore{}
+	h := NewHandler(store)
+
+	store.mu.Lock()
+	store.subscriptions = append(store.subscriptions, model.Subscription{
+		ID: "s1", User: model.SubscriptionUser{ID: "u2", Account: "bob"}, RoomID: "r1", SiteID: "site-a",
+	})
+	store.threadSubs = append(store.threadSubs,
+		model.ThreadSubscription{ID: "ts1", RoomID: "r1", UserAccount: "bob", ThreadRoomID: "tr1"},
+		model.ThreadSubscription{ID: "ts2", RoomID: "r1", UserAccount: "alice", ThreadRoomID: "tr1"},
+		model.ThreadSubscription{ID: "ts3", RoomID: "r2", UserAccount: "bob", ThreadRoomID: "tr2"},
+	)
+	store.mu.Unlock()
+
+	memberEvt := model.MemberRemoveEvent{Type: "member-removed", RoomID: "r1", Accounts: []string{"bob"}, SiteID: "site-a"}
+	payload, _ := json.Marshal(memberEvt)
+	evt := model.InboxEvent{Type: "member_removed", SiteID: "site-a", DestSiteID: "site-b", Payload: payload, Timestamp: time.Now().UnixMilli()}
+	data, _ := json.Marshal(evt)
+
+	require.NoError(t, h.HandleEvent(context.Background(), data))
+
+	// bob's thread sub in r1 removed; alice (r1) and bob (r2) untouched.
+	remaining := store.getThreadSubs()
+	ids := make(map[string]bool, len(remaining))
+	for _, ts := range remaining {
+		ids[ts.ID] = true
+	}
+	assert.False(t, ids["ts1"], "bob's thread sub in r1 must be deleted")
+	assert.True(t, ids["ts2"], "alice's thread sub must remain")
+	assert.True(t, ids["ts3"], "bob's thread sub in another room must remain")
 }
 
 func TestHandleEvent_MemberRemoved_InvalidPayload(t *testing.T) {

--- a/inbox-worker/integration_test.go
+++ b/inbox-worker/integration_test.go
@@ -225,8 +225,9 @@ func TestInboxWorker_BulkCreateSubscriptions_IdempotentUpsert(t *testing.T) {
 func TestInboxWorker_MemberRemoved_Integration(t *testing.T) {
 	db := setupMongo(t)
 	store := &mongoInboxStore{
-		subCol:  db.Collection("subscriptions"),
-		roomCol: db.Collection("rooms"),
+		subCol:       db.Collection("subscriptions"),
+		roomCol:      db.Collection("rooms"),
+		threadSubCol: db.Collection("thread_subscriptions"),
 	}
 	h := NewHandler(store)
 
@@ -236,6 +237,13 @@ func TestInboxWorker_MemberRemoved_Integration(t *testing.T) {
 		ID: "s1", User: model.SubscriptionUser{ID: "u1", Account: "bob"},
 		RoomID: "r1", SiteID: "site-a", Roles: []model.Role{model.RoleMember},
 		JoinedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	// bob's thread sub in r1 must be scrubbed; his sub in another room must survive.
+	_, err = store.threadSubCol.InsertMany(ctx, []interface{}{
+		model.ThreadSubscription{ID: "ts1", RoomID: "r1", UserAccount: "bob", ThreadRoomID: "tr1"},
+		model.ThreadSubscription{ID: "ts2", RoomID: "r2", UserAccount: "bob", ThreadRoomID: "tr2"},
 	})
 	require.NoError(t, err)
 
@@ -255,6 +263,15 @@ func TestInboxWorker_MemberRemoved_Integration(t *testing.T) {
 	count, err := store.subCol.CountDocuments(ctx, bson.M{"u._id": "u1", "roomId": "r1"})
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), count)
+
+	// thread_subscriptions scrubbed for r1 (#308); the r2 sub is untouched, so a
+	// wrong roomId/userAccount filter would fail one of these assertions.
+	tsGone, err := store.threadSubCol.CountDocuments(ctx, bson.M{"roomId": "r1", "userAccount": "bob"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), tsGone)
+	tsKept, err := store.threadSubCol.CountDocuments(ctx, bson.M{"roomId": "r2", "userAccount": "bob"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), tsKept)
 
 	// No publish — room-worker handles user notification via NATS supercluster.
 }

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -148,6 +148,17 @@ func (s *mongoInboxStore) DeleteSubscriptionsByAccounts(ctx context.Context, roo
 	return nil
 }
 
+func (s *mongoInboxStore) DeleteThreadSubscriptions(ctx context.Context, roomID string, accounts []string) error {
+	if len(accounts) == 0 {
+		return nil
+	}
+	_, err := s.threadSubCol.DeleteMany(ctx, bson.M{"roomId": roomID, "userAccount": bson.M{"$in": accounts}})
+	if err != nil {
+		return fmt.Errorf("delete thread subscriptions in room %q: %w", roomID, err)
+	}
+	return nil
+}
+
 func (s *mongoInboxStore) FindUsersByAccounts(ctx context.Context, accounts []string) ([]model.User, error) {
 	if len(accounts) == 0 {
 		return nil, nil

--- a/inbox-worker/mock_store_test.go
+++ b/inbox-worker/mock_store_test.go
@@ -126,6 +126,20 @@ func (mr *MockInboxStoreMockRecorder) DeleteSubscriptionsByAccounts(ctx, roomID,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSubscriptionsByAccounts", reflect.TypeOf((*MockInboxStore)(nil).DeleteSubscriptionsByAccounts), ctx, roomID, accounts)
 }
 
+// DeleteThreadSubscriptions mocks base method.
+func (m *MockInboxStore) DeleteThreadSubscriptions(ctx context.Context, roomID string, accounts []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteThreadSubscriptions", ctx, roomID, accounts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteThreadSubscriptions indicates an expected call of DeleteThreadSubscriptions.
+func (mr *MockInboxStoreMockRecorder) DeleteThreadSubscriptions(ctx, roomID, accounts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteThreadSubscriptions", reflect.TypeOf((*MockInboxStore)(nil).DeleteThreadSubscriptions), ctx, roomID, accounts)
+}
+
 // FindUsersByAccounts mocks base method.
 func (m *MockInboxStore) FindUsersByAccounts(ctx context.Context, accounts []string) ([]model.User, error) {
 	m.ctrl.T.Helper()

--- a/room-worker/debug_log_test.go
+++ b/room-worker/debug_log_test.go
@@ -134,6 +134,7 @@ func TestProcessRemoveMember_DebugEdge(t *testing.T) {
 		store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u1").Return(nil).AnyTimes()
 		store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil).AnyTimes()
 		store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil).AnyTimes()
+		expectThreadCleanupAny(store)
 		h := NewHandler(store, siteID, func(context.Context, string, []byte, string) error { return nil }, testKeyStore, testKeySender)
 		req := model.RemoveMemberRequest{RoomID: roomID, Requester: account, Account: account, Timestamp: 1, RoomType: model.RoomTypeChannel}
 		data, _ := json.Marshal(req)

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -340,6 +340,17 @@ func (h *Handler) rotateAndFanOut(ctx context.Context, roomID string, currentPai
 	return nil
 }
 
+// cleanupThreadMembership scrubs departed accounts from roomID's replyAccounts and thread_subscriptions (#308); no-op on empty.
+func (h *Handler) cleanupThreadMembership(ctx context.Context, roomID string, accounts []string) error {
+	if err := h.store.PullThreadFollowers(ctx, roomID, accounts); err != nil {
+		return fmt.Errorf("pull thread followers after remove: %w", err)
+	}
+	if err := h.store.DeleteThreadSubscriptions(ctx, roomID, accounts); err != nil {
+		return fmt.Errorf("delete thread subscriptions after remove: %w", err)
+	}
+	return nil
+}
+
 func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.RemoveMemberRequest, currentPair *roomkeystore.VersionedKeyPair) (err error) {
 	if req.Timestamp <= 0 {
 		req.Timestamp = time.Now().UTC().UnixMilli()
@@ -373,6 +384,12 @@ func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.Remove
 	// Individual-only: delete sub, reconcile userCount, publish leave/removed events.
 	if _, err := h.store.DeleteSubscription(ctx, req.RoomID, req.Account); err != nil {
 		return fmt.Errorf("delete subscription: %w", err)
+	}
+
+	// Individual-only branch (dual-members returned above), so the account has
+	// truly left: scrub its thread footprint (#308).
+	if err := h.cleanupThreadMembership(ctx, req.RoomID, []string{req.Account}); err != nil {
+		return err
 	}
 
 	if err := h.store.ReconcileMemberCounts(ctx, req.RoomID); err != nil {
@@ -572,6 +589,11 @@ func (h *Handler) processRemoveOrg(ctx context.Context, req *model.RemoveMemberR
 	if len(accounts) > 0 {
 		if _, err := h.store.DeleteSubscriptionsByAccounts(ctx, req.RoomID, accounts); err != nil {
 			return fmt.Errorf("delete subscriptions by accounts: %w", err)
+		}
+		// accounts is exactly the set that truly lost membership (survivors
+		// filtered out above), so scrub their thread footprint too (#308).
+		if err := h.cleanupThreadMembership(ctx, req.RoomID, accounts); err != nil {
+			return err
 		}
 	}
 

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -65,6 +65,7 @@ func TestHandler_ProcessRemoveMember_FallsBackToNowOnInvalidTimestamp(t *testing
 func TestHandler_ProcessRemoveMember_SelfLeave_IndividualOnly(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
+	expectThreadCleanupAny(store)
 
 	const (
 		roomID  = "room-1"
@@ -191,6 +192,76 @@ func TestHandler_ProcessRemoveMember_SelfLeave_DualMembership(t *testing.T) {
 	assert.Empty(t, published, "expected no publishes for dual-membership self-leave")
 }
 
+// expectThreadCleanupAny registers loose expectations for the post-removal
+// thread-state cleanup (#308) for tests that exercise a removal path but don't
+// assert on the cleanup itself.
+func expectThreadCleanupAny(store *MockSubscriptionStore) {
+	store.EXPECT().PullThreadFollowers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	store.EXPECT().DeleteThreadSubscriptions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+}
+
+func TestHandler_ProcessRemoveIndividual_CleansThreadState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+
+	const (
+		roomID  = "room-1"
+		account = "alice"
+		siteID  = "site-a"
+	)
+
+	userResult := &UserWithMembership{
+		User:             model.User{ID: "u1", Account: account, SiteID: siteID, EngName: "Alice", ChineseName: "愛"},
+		HasOrgMembership: false,
+	}
+	store.EXPECT().GetUserWithMembership(gomock.Any(), roomID, account).Return(userResult, nil)
+	store.EXPECT().DeleteSubscription(gomock.Any(), roomID, account).Return(int64(1), nil)
+	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u1").Return(nil)
+	// The departed member must be scrubbed from thread followers + subs (#308).
+	store.EXPECT().PullThreadFollowers(gomock.Any(), roomID, []string{account}).Return(nil)
+	store.EXPECT().DeleteThreadSubscriptions(gomock.Any(), roomID, []string{account}).Return(nil)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
+
+	h := NewHandler(store, siteID, func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
+	req := model.RemoveMemberRequest{RoomID: roomID, Requester: account, Account: account, Timestamp: 1, RoomType: model.RoomTypeChannel}
+	data, _ := json.Marshal(req)
+	require.NoError(t, h.processRemoveMember(context.Background(), data))
+}
+
+func TestHandler_ProcessRemoveOrg_CleansThreadStateForRemovedOnly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+
+	const (
+		roomID    = "room-1"
+		orgID     = "org-1"
+		requester = "alice"
+		siteID    = "site-a"
+	)
+
+	// carol + dave truly leave; eve survives via individual membership (not scrubbed).
+	orgMembers := []OrgMemberStatus{
+		{Account: "carol", SiteID: siteID, Name: "Engineering", HasIndividualMembership: false},
+		{Account: "dave", SiteID: siteID, Name: "Engineering", HasIndividualMembership: false},
+		{Account: "eve", SiteID: siteID, Name: "Engineering", HasIndividualMembership: true},
+	}
+	store.EXPECT().GetOrgMembersWithIndividualStatus(gomock.Any(), roomID, orgID).Return(orgMembers, nil)
+	store.EXPECT().DeleteSubscriptionsByAccounts(gomock.Any(), roomID, gomock.InAnyOrder([]string{"carol", "dave"})).Return(int64(2), nil)
+	// Thread cleanup targets exactly the departed accounts — not eve.
+	store.EXPECT().PullThreadFollowers(gomock.Any(), roomID, gomock.InAnyOrder([]string{"carol", "dave"})).Return(nil)
+	store.EXPECT().DeleteThreadSubscriptions(gomock.Any(), roomID, gomock.InAnyOrder([]string{"carol", "dave"})).Return(nil)
+	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberOrg, orgID).Return(nil)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
+	store.EXPECT().GetUser(gomock.Any(), requester).Return(&model.User{ID: "u_alice", Account: requester, SiteID: siteID, EngName: "Alice", ChineseName: "愛"}, nil)
+
+	h := NewHandler(store, siteID, func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
+	req := model.RemoveMemberRequest{RoomID: roomID, Requester: requester, OrgID: orgID, Timestamp: 1000, RoomType: model.RoomTypeChannel}
+	data, _ := json.Marshal(req)
+	require.NoError(t, h.processRemoveMember(context.Background(), data))
+}
+
 func TestHandler_ProcessRemoveMember_DualMembership_OwnerDemoted(t *testing.T) {
 	// Dual-member who also holds the owner role must be demoted when their
 	// individual source is removed — org members cannot be owners.
@@ -249,6 +320,7 @@ func TestHandler_ProcessRemoveMember_DualMembership_OwnerDemoted(t *testing.T) {
 func TestHandler_ProcessRemoveMember_OwnerRemovesIndividual(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
+	expectThreadCleanupAny(store)
 
 	const (
 		roomID    = "room-1"
@@ -1223,6 +1295,7 @@ func TestHandler_ProcessAddMembers_MultipleSiteInbox(t *testing.T) {
 func TestHandler_ProcessRemoveMember_OwnerRemovesOrg(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
+	expectThreadCleanupAny(store)
 
 	const (
 		roomID    = "room-1"
@@ -1293,6 +1366,7 @@ func TestHandler_ProcessRemoveMember_OwnerRemovesOrg(t *testing.T) {
 func TestHandler_ProcessRemoveMember_CrossSiteInbox(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
+	expectThreadCleanupAny(store)
 
 	const (
 		roomID    = "room-1"
@@ -1451,6 +1525,7 @@ func TestHandler_ProcessRemoveIndividual_DeleteSubscriptionError(t *testing.T) {
 func TestHandler_ProcessRemoveIndividual_ReconcileMemberCountsError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
+	expectThreadCleanupAny(store)
 	store.EXPECT().
 		GetUserWithMembership(gomock.Any(), "r1", "alice").
 		Return(&UserWithMembership{
@@ -1640,6 +1715,7 @@ func TestHandler_ProcessAddMembers_OrgReAddAlreadyPresent_NoEvent(t *testing.T) 
 func TestHandler_ProcessRemoveIndividual_InboxFailurePropagates(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
+	expectThreadCleanupAny(store)
 
 	const (
 		roomID    = "room-1"
@@ -1685,6 +1761,7 @@ func TestHandler_ProcessRemoveIndividual_InboxFailurePropagates(t *testing.T) {
 func TestHandler_ProcessRemoveOrg_InboxFailurePropagates(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
+	expectThreadCleanupAny(store)
 
 	const (
 		roomID     = "room-1"
@@ -4884,6 +4961,7 @@ func TestHandler_PublishChannelSysMessages_EmptySkipsMembersAdded(t *testing.T) 
 func TestHandler_ProcessRemoveIndividual_SelfLeave_Content(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
+	expectThreadCleanupAny(store)
 
 	roomID := "r1"
 	store.EXPECT().GetUserWithMembership(gomock.Any(), roomID, "bob").
@@ -4916,6 +4994,7 @@ func TestHandler_ProcessRemoveIndividual_SelfLeave_Content(t *testing.T) {
 func TestHandler_ProcessRemoveIndividual_RemovedByOther_Content(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
+	expectThreadCleanupAny(store)
 
 	roomID := "r1"
 	store.EXPECT().GetUserWithMembership(gomock.Any(), roomID, "bob").

--- a/room-worker/integration_test.go
+++ b/room-worker/integration_test.go
@@ -129,6 +129,57 @@ func TestMongoStore_Integration(t *testing.T) {
 	}
 }
 
+func TestMongoStore_ThreadCleanup_Integration(t *testing.T) {
+	db := setupMongo(t)
+	store := NewMongoStore(db)
+	ctx := context.Background()
+
+	// Two threads in r1; one in r2 which must stay untouched.
+	_, err := db.Collection("thread_rooms").InsertMany(ctx, []interface{}{
+		bson.M{"_id": "tr1", "roomId": "r1", "parentMessageId": "p1", "replyAccounts": []string{"alice", "bob", "carol"}},
+		bson.M{"_id": "tr2", "roomId": "r1", "parentMessageId": "p2", "replyAccounts": []string{"bob", "dave"}},
+		bson.M{"_id": "tr3", "roomId": "r2", "parentMessageId": "p3", "replyAccounts": []string{"bob"}},
+	})
+	require.NoError(t, err)
+	_, err = db.Collection("thread_subscriptions").InsertMany(ctx, []interface{}{
+		bson.M{"_id": "ts1", "roomId": "r1", "userAccount": "bob", "threadRoomId": "tr1"},
+		bson.M{"_id": "ts2", "roomId": "r1", "userAccount": "carol", "threadRoomId": "tr1"},
+		bson.M{"_id": "ts3", "roomId": "r1", "userAccount": "alice", "threadRoomId": "tr2"},
+		bson.M{"_id": "ts4", "roomId": "r2", "userAccount": "bob", "threadRoomId": "tr3"},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, store.PullThreadFollowers(ctx, "r1", []string{"bob", "carol"}))
+	require.NoError(t, store.DeleteThreadSubscriptions(ctx, "r1", []string{"bob", "carol"}))
+
+	replyAccounts := func(id string) []string {
+		var doc struct {
+			ReplyAccounts []string `bson:"replyAccounts"`
+		}
+		require.NoError(t, db.Collection("thread_rooms").FindOne(ctx, bson.M{"_id": id}).Decode(&doc))
+		return doc.ReplyAccounts
+	}
+	// bob + carol pulled from r1's threads; survivors kept; r2 thread untouched.
+	assert.Equal(t, []string{"alice"}, replyAccounts("tr1"))
+	assert.Equal(t, []string{"dave"}, replyAccounts("tr2"))
+	assert.Equal(t, []string{"bob"}, replyAccounts("tr3"))
+
+	count := func(filter bson.M) int64 {
+		n, err := db.Collection("thread_subscriptions").CountDocuments(ctx, filter)
+		require.NoError(t, err)
+		return n
+	}
+	// bob + carol thread subs in r1 deleted; alice (r1) and bob (r2) remain.
+	assert.Equal(t, int64(0), count(bson.M{"roomId": "r1", "userAccount": bson.M{"$in": []string{"bob", "carol"}}}))
+	assert.Equal(t, int64(1), count(bson.M{"roomId": "r1", "userAccount": "alice"}))
+	assert.Equal(t, int64(1), count(bson.M{"roomId": "r2", "userAccount": "bob"}))
+
+	// Empty account list is a no-op.
+	require.NoError(t, store.PullThreadFollowers(ctx, "r1", nil))
+	require.NoError(t, store.DeleteThreadSubscriptions(ctx, "r1", nil))
+	assert.Equal(t, []string{"alice"}, replyAccounts("tr1"))
+}
+
 // TestMongoStore_ApplyMemberCountDelta covers the add-member hot path: the $inc
 // applies the delta atomically, and reconcileDue follows the per-room TTL —
 // true when never reconciled or once the TTL has elapsed, false within it.

--- a/room-worker/mock_store_test.go
+++ b/room-worker/mock_store_test.go
@@ -146,6 +146,20 @@ func (mr *MockSubscriptionStoreMockRecorder) DeleteSubscriptionsByAccounts(ctx, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSubscriptionsByAccounts", reflect.TypeOf((*MockSubscriptionStore)(nil).DeleteSubscriptionsByAccounts), ctx, roomID, accounts)
 }
 
+// DeleteThreadSubscriptions mocks base method.
+func (m *MockSubscriptionStore) DeleteThreadSubscriptions(ctx context.Context, roomID string, accounts []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteThreadSubscriptions", ctx, roomID, accounts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteThreadSubscriptions indicates an expected call of DeleteThreadSubscriptions.
+func (mr *MockSubscriptionStoreMockRecorder) DeleteThreadSubscriptions(ctx, roomID, accounts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteThreadSubscriptions", reflect.TypeOf((*MockSubscriptionStore)(nil).DeleteThreadSubscriptions), ctx, roomID, accounts)
+}
+
 // ExistingOrgMembers mocks base method.
 func (m *MockSubscriptionStore) ExistingOrgMembers(ctx context.Context, roomID string, orgIDs []string) (map[string]struct{}, error) {
 	m.ctrl.T.Helper()
@@ -385,6 +399,20 @@ func (m *MockSubscriptionStore) ListNewMembersForNewRoom(ctx context.Context, or
 func (mr *MockSubscriptionStoreMockRecorder) ListNewMembersForNewRoom(ctx, orgIDs, accounts, excludeAccount any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNewMembersForNewRoom", reflect.TypeOf((*MockSubscriptionStore)(nil).ListNewMembersForNewRoom), ctx, orgIDs, accounts, excludeAccount)
+}
+
+// PullThreadFollowers mocks base method.
+func (m *MockSubscriptionStore) PullThreadFollowers(ctx context.Context, roomID string, accounts []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PullThreadFollowers", ctx, roomID, accounts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PullThreadFollowers indicates an expected call of PullThreadFollowers.
+func (mr *MockSubscriptionStoreMockRecorder) PullThreadFollowers(ctx, roomID, accounts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullThreadFollowers", reflect.TypeOf((*MockSubscriptionStore)(nil).PullThreadFollowers), ctx, roomID, accounts)
 }
 
 // ReconcileMemberCounts mocks base method.

--- a/room-worker/store.go
+++ b/room-worker/store.go
@@ -104,6 +104,10 @@ type SubscriptionStore interface {
 	DeleteSubscriptionsByAccounts(ctx context.Context, roomID string, accounts []string) (int64, error)
 	DeleteRoomMember(ctx context.Context, roomID string, memberType model.RoomMemberType, memberID string) error
 
+	// --- thread-state cleanup (remove flow): scrub departed accounts so they no longer fan out as followers (#308); no-op on empty ---
+	PullThreadFollowers(ctx context.Context, roomID string, accounts []string) error
+	DeleteThreadSubscriptions(ctx context.Context, roomID string, accounts []string) error
+
 	// --- add-member flow ---
 	// BulkCreateRoomMembers upserts each row on the (rid, member.type, member.id) unique key — a re-add/redelivery is an idempotent no-op.
 	BulkCreateRoomMembers(ctx context.Context, members []*model.RoomMember) error

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -20,11 +20,13 @@ import (
 )
 
 type MongoStore struct {
-	subscriptions *mongo.Collection
-	rooms         *mongo.Collection
-	roomMembers   *mongo.Collection
-	users         *mongo.Collection
-	apps          *mongo.Collection
+	subscriptions       *mongo.Collection
+	rooms               *mongo.Collection
+	roomMembers         *mongo.Collection
+	users               *mongo.Collection
+	apps                *mongo.Collection
+	threadRooms         *mongo.Collection
+	threadSubscriptions *mongo.Collection
 	// userReader serves point lookups (GetUser, FindUsersByAccounts) and the
 	// direct-account candidate fast path. Defaults to an uncached read of the
 	// users collection; EnableUserCache wraps it in an LRU+TTL cache. The
@@ -39,12 +41,14 @@ type MongoStore struct {
 
 func NewMongoStore(db *mongo.Database) *MongoStore {
 	return &MongoStore{
-		subscriptions: db.Collection("subscriptions"),
-		rooms:         db.Collection("rooms"),
-		roomMembers:   db.Collection("room_members"),
-		users:         db.Collection("users"),
-		apps:          db.Collection("apps"),
-		userReader:    userstore.NewMongoStore(db.Collection("users")),
+		subscriptions:       db.Collection("subscriptions"),
+		rooms:               db.Collection("rooms"),
+		roomMembers:         db.Collection("room_members"),
+		users:               db.Collection("users"),
+		apps:                db.Collection("apps"),
+		threadRooms:         db.Collection("thread_rooms"),
+		threadSubscriptions: db.Collection("thread_subscriptions"),
+		userReader:          userstore.NewMongoStore(db.Collection("users")),
 	}
 }
 
@@ -469,6 +473,35 @@ func (s *MongoStore) DeleteRoomMember(ctx context.Context, roomID string, member
 	_, err := s.roomMembers.DeleteOne(ctx, bson.M{"rid": roomID, "member.type": memberType, "member.id": memberID})
 	if err != nil {
 		return fmt.Errorf("delete room member: %w", err)
+	}
+	return nil
+}
+
+// PullThreadFollowers removes accounts from replyAccounts of every thread room in roomID, so departed members stop fanning out (#308).
+func (s *MongoStore) PullThreadFollowers(ctx context.Context, roomID string, accounts []string) error {
+	if len(accounts) == 0 {
+		return nil
+	}
+	_, err := s.threadRooms.UpdateMany(ctx,
+		bson.M{"roomId": roomID},
+		bson.M{"$pull": bson.M{"replyAccounts": bson.M{"$in": accounts}}},
+	)
+	if err != nil {
+		return fmt.Errorf("pull thread followers for room %q: %w", roomID, err)
+	}
+	return nil
+}
+
+// DeleteThreadSubscriptions deletes the accounts' per-thread read-state docs in roomID (#308).
+func (s *MongoStore) DeleteThreadSubscriptions(ctx context.Context, roomID string, accounts []string) error {
+	if len(accounts) == 0 {
+		return nil
+	}
+	_, err := s.threadSubscriptions.DeleteMany(ctx,
+		bson.M{"roomId": roomID, "userAccount": bson.M{"$in": accounts}},
+	)
+	if err != nil {
+		return fmt.Errorf("delete thread subscriptions for room %q: %w", roomID, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem

`replyAccounts` is append-only; nothing ever removed an entry. When a user left a room their `subscriptions` doc was deleted but they stayed in `replyAccounts` (and their `thread_subscriptions` lingered), so they remained a thread "follower" indefinitely and kept receiving live thread replies.

## Change

Scrub thread state on **every removal path that truly ends membership**, so thread follower state no longer outlives room membership:

- **`room-worker`** (home site, owns `thread_rooms`): after the individual-only and org removal paths delete the subscription, `$pull` the departed accounts from `replyAccounts` across the room's threads (`PullThreadFollowers`) and delete their `thread_subscriptions` (`DeleteThreadSubscriptions`). The org path reuses the already-computed "truly removed" set, so dual-membership / sibling-org survivors are never scrubbed.
- **`inbox-worker`** (remote site, holds no `thread_rooms`): on a federated `member_removed` event, delete the removed accounts' `thread_subscriptions` too.

Both new store methods are no-ops on empty input and scoped to `(roomId, userAccount)`, so a user's thread state in other rooms is never touched.

## Testing
- Unit tests (TDD) for each removal path — including the dual-member / sibling-org "not scrubbed" cases and the federated `thread_subscriptions` cleanup.
- Integration tests for the new store methods (`$pull` and delete, with cross-room isolation and empty-input no-op).
- `go vet` clean; unit and integration suites green.

## Relationship to #309 (PR #108)
This is the **source-side** half of the thread-reachability invariant "a non-member must not receive a room's thread events": it keeps the follower data honest. The complementary **delivery-side** gate — intersecting channel thread fan-out recipients with current membership — was split into its own PR (#108, #309). The two are independent at the code level (disjoint services) and can merge in either order; together they close the leak from both ends.

> Note: previously this PR also contained the #309 fan-out gate (`broadcast-worker`). That change was split out into PR #108 so each issue lands independently.

## Summary by CodeRabbit

* **Bug Fixes**
  * When members leave rooms, thread follower data and per-thread read-state subscriptions are cleaned up, reducing stale notifications and read-state inconsistencies (with correct handling for individual vs. org removal, and dual-membership / sibling-org survivors preserved).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed departed members’ thread followers and read-state data when they leave a room.
  * Limited cleanup to affected accounts and rooms, preserving data for remaining members and other rooms.
  * Applied the same cleanup when members are removed individually or through organization-level changes.
* **Tests**
  * Added coverage for individual, organization, inbox, and MongoDB-backed removal scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->