### PR TITLE
message-worker: cut per-reply DB work on the thread-reply hot path

### DIFF
--- a/message-worker/handler.go
+++ b/message-worker/handler.go
@@ -131,17 +131,21 @@ func (h *Handler) processMessage(ctx context.Context, data []byte, isMigration b
 
 		// Resolve (or create) the thread room first so we have the threadRoomID
 		// before persisting the message to Cassandra.
-		threadRoomID, err := h.handleThreadRoomAndSubscriptions(ctx, &evt.Message, evt.SiteID, user, isMigration)
+		threadRoomID, replierLastSeenAdvanced, err := h.handleThreadRoomAndSubscriptions(ctx, &evt.Message, evt.SiteID, user, isMigration)
 		if err != nil {
 			return fmt.Errorf("handle thread room and subscriptions: %w", err)
 		}
 		// Replying implies the replier read up to their own reply: advance their thread
-		// lastSeenAt so the read-floor doesn't count them (#396). Best-effort. Runs on
-		// migration too ($max only moves forward → lands on the replier's last reply).
-		if err := h.threadStore.AdvanceThreadSubscriptionLastSeen(ctx, threadRoomID, evt.Message.UserAccount, evt.Message.CreatedAt); err != nil {
-			slog.WarnContext(ctx, "advance replier thread lastSeenAt failed",
-				"error", err, "thread_room_id", threadRoomID, "account", evt.Message.UserAccount,
-				"request_id", natsutil.RequestIDFromContext(ctx))
+		// lastSeenAt so the read-floor doesn't count them (#396). The hot subsequent-reply
+		// path folds this into the replier's subscription upsert (one write instead of two),
+		// reporting replierLastSeenAdvanced=true; this standalone $max covers the paths that
+		// write no replier subscription (migration, self-reply, system message). Best-effort.
+		if !replierLastSeenAdvanced {
+			if err := h.threadStore.AdvanceThreadSubscriptionLastSeen(ctx, threadRoomID, evt.Message.UserAccount, evt.Message.CreatedAt); err != nil {
+				slog.WarnContext(ctx, "advance replier thread lastSeenAt failed",
+					"error", err, "thread_room_id", threadRoomID, "account", evt.Message.UserAccount,
+					"request_id", natsutil.RequestIDFromContext(ctx))
+			}
 		}
 		if err := h.markThreadMentions(ctx, &evt.Message, threadRoomID, evt.SiteID, isMigration); err != nil {
 			return fmt.Errorf("mark thread mentions: %w", err)
@@ -246,14 +250,18 @@ func debugFlowPersisted(ctx context.Context, messageID string, thread bool) {
 		"message_id", messageID, "thread", thread)
 }
 
-// handleThreadRoomAndSubscriptions creates the ThreadRoom on first reply and
-// inserts ThreadSubscriptions for the parent author and replier. On subsequent
-// replies it upserts both subscriptions and bumps the room's last-message pointer.
-// It returns the threadRoomID so the caller can pass it to SaveThreadMessage.
+// handleThreadRoomAndSubscriptions resolves the ThreadRoom via a single upserting
+// EnsureThreadRoom call (one round trip, no failed insert on the hot path). On the first
+// reply (EnsureThreadRoom created the room) it inserts ThreadSubscriptions for the parent
+// author and replier; on subsequent replies it upserts only the replier's subscription
+// (the parent author's was created on the first reply) and bumps the last-message pointer.
+// It returns the threadRoomID so the caller can pass it to SaveThreadMessage, and a bool
+// reporting whether the replier's lastSeenAt was already advanced as part of that
+// subscription write (so the caller can skip the standalone $max).
 //
 // `replier` may be nil for system messages with no real user (rare in thread
 // paths); subscriptions for the replier are skipped in that case.
-func (h *Handler) handleThreadRoomAndSubscriptions(ctx context.Context, msg *model.Message, eventSiteID string, replier *model.User, isMigration bool) (string, error) {
+func (h *Handler) handleThreadRoomAndSubscriptions(ctx context.Context, msg *model.Message, eventSiteID string, replier *model.User, isMigration bool) (string, bool, error) {
 	now := msg.CreatedAt
 
 	var parentCreatedAt time.Time
@@ -273,15 +281,16 @@ func (h *Handler) handleThreadRoomAndSubscriptions(ctx context.Context, msg *mod
 		UpdatedAt:             now,
 	}
 
-	err := h.threadStore.CreateThreadRoom(ctx, &threadRoom)
-	switch {
-	case err == nil:
-		return threadRoom.ID, h.handleFirstThreadReply(ctx, msg, eventSiteID, threadRoom.ID, replier, now, isMigration)
-	case errors.Is(err, errThreadRoomExists):
-		return h.handleSubsequentThreadReply(ctx, msg, eventSiteID, replier, now, isMigration)
-	default:
-		return "", fmt.Errorf("create thread room: %w", err)
+	existingRoom, created, err := h.threadStore.EnsureThreadRoom(ctx, &threadRoom)
+	if err != nil {
+		return "", false, fmt.Errorf("ensure thread room: %w", err)
 	}
+	if created {
+		// First reply (once per thread): it advances the replier's lastSeenAt via the standalone
+		// $max in the caller, so it reports replierLastSeenAdvanced=false.
+		return existingRoom.ID, false, h.handleFirstThreadReply(ctx, msg, eventSiteID, existingRoom.ID, replier, now, isMigration)
+	}
+	return h.handleSubsequentThreadReply(ctx, msg, eventSiteID, existingRoom, replier, now, isMigration)
 }
 
 // handleFirstThreadReply runs after the thread room has just been created.
@@ -357,45 +366,37 @@ func (h *Handler) handleFirstThreadReply(ctx context.Context, msg *model.Message
 	return nil
 }
 
-// handleSubsequentThreadReply runs when CreateThreadRoom reported an existing room.
-// Upserts subscriptions for both the parent author and the replier (idempotent
-// on redelivery), then bumps the room's last-message pointer. Returns the
-// existing thread room ID so the caller can pass it to SaveThreadMessage.
-// Subscription.SiteID is the room's site (eventSiteID); owner-site routing
-// for the cross-site publish happens via separate lookups.
-func (h *Handler) handleSubsequentThreadReply(ctx context.Context, msg *model.Message, eventSiteID string, replier *model.User, now time.Time, isMigration bool) (string, error) {
-	existingRoom, err := h.threadStore.GetThreadRoomByParentMessageID(ctx, msg.ThreadParentMessageID)
-	if err != nil {
-		return "", fmt.Errorf("get existing thread room: %w", err)
-	}
-
+// handleSubsequentThreadReply runs when the thread room already existed (resolved by the
+// caller's EnsureThreadRoom and passed in as existingRoom, so no second fetch is needed).
+// It upserts only the replier's subscription — folding the replier's own lastSeenAt
+// advance into that single write (#396) — then bumps the room's last-message pointer.
+// The parent author's subscription is intentionally NOT re-upserted here: it was
+// created on the first reply, so re-writing it on every subsequent reply is a no-op
+// write on the hottest collection (thread_subscriptions). Trade-off: a crash between
+// the first reply's room creation and its parent InsertThreadSubscription would leave
+// the parent unsubscribed for this thread — a narrow window not worth a per-reply write
+// to self-heal.
+//
+// Returns the existing thread room ID and whether the replier's lastSeenAt was
+// advanced as part of the subscription write (false on the migration / self-reply /
+// nil-replier paths, where the caller's standalone $max handles it instead).
+// Subscription.SiteID is the room's site (eventSiteID); the replier's own home site
+// (replier.SiteID) drives cross-site inbox routing without an extra lookup.
+func (h *Handler) handleSubsequentThreadReply(ctx context.Context, msg *model.Message, eventSiteID string, existingRoom *model.ThreadRoom, replier *model.User, now time.Time, isMigration bool) (string, bool, error) {
 	// Migrated replies: resolve the parent for replyAccounts, but skip all thread_subscription writes (collections owns them).
 	parentFound := true
+	replierLastSeenAdvanced := false
 	parentSender, err := h.store.GetMessageSender(ctx, msg.ThreadParentMessageID)
 	switch {
 	case err == nil:
-		if !isMigration {
-			parentOwnerSite, lookupErr := h.lookupOwnerSiteID(ctx, parentSender.ID, "subsequent-reply parent")
-			if lookupErr != nil {
-				return "", fmt.Errorf("lookup parent owner site: %w", lookupErr)
+		if !isMigration && replier != nil && msg.UserID != parentSender.ID {
+			replierSub := h.buildThreadSubscription(msg, existingRoom.ID, msg.UserID, msg.UserAccount, eventSiteID, now)
+			if err := h.threadStore.UpsertThreadSubscriptionAdvancingLastSeen(ctx, replierSub, msg.CreatedAt); err != nil {
+				return "", false, fmt.Errorf("upsert replier thread subscription: %w", err)
 			}
-			parentSub := h.buildThreadSubscription(msg, existingRoom.ID, parentSender.ID, parentSender.Account, eventSiteID, now)
-			if err := h.threadStore.UpsertThreadSubscription(ctx, parentSub); err != nil {
-				return "", fmt.Errorf("upsert parent author thread subscription: %w", err)
-			}
-			if parentOwnerSite != "" {
-				if err := h.publishThreadSubInboxIfRemote(ctx, parentSub, parentOwnerSite, msg.ID); err != nil {
-					return "", fmt.Errorf("publish parent thread subscription inbox: %w", err)
-				}
-			}
-			if replier != nil && msg.UserID != parentSender.ID {
-				replierSub := h.buildThreadSubscription(msg, existingRoom.ID, msg.UserID, msg.UserAccount, eventSiteID, now)
-				if err := h.threadStore.UpsertThreadSubscription(ctx, replierSub); err != nil {
-					return "", fmt.Errorf("upsert replier thread subscription: %w", err)
-				}
-				if err := h.publishThreadSubInboxIfRemote(ctx, replierSub, replier.SiteID, msg.ID); err != nil {
-					return "", fmt.Errorf("publish replier thread subscription inbox: %w", err)
-				}
+			replierLastSeenAdvanced = true
+			if err := h.publishThreadSubInboxIfRemote(ctx, replierSub, replier.SiteID, msg.ID); err != nil {
+				return "", false, fmt.Errorf("publish replier thread subscription inbox: %w", err)
 			}
 		}
 	case errors.Is(err, errMessageNotFound):
@@ -406,15 +407,16 @@ func (h *Handler) handleSubsequentThreadReply(ctx context.Context, msg *model.Me
 			"request_id", natsutil.RequestIDFromContext(ctx))
 		if !isMigration && replier != nil {
 			replierSub := h.buildThreadSubscription(msg, existingRoom.ID, msg.UserID, msg.UserAccount, eventSiteID, now)
-			if err := h.threadStore.UpsertThreadSubscription(ctx, replierSub); err != nil {
-				return "", fmt.Errorf("upsert replier thread subscription: %w", err)
+			if err := h.threadStore.UpsertThreadSubscriptionAdvancingLastSeen(ctx, replierSub, msg.CreatedAt); err != nil {
+				return "", false, fmt.Errorf("upsert replier thread subscription: %w", err)
 			}
+			replierLastSeenAdvanced = true
 			if err := h.publishThreadSubInboxIfRemote(ctx, replierSub, replier.SiteID, msg.ID); err != nil {
-				return "", fmt.Errorf("publish replier thread subscription inbox: %w", err)
+				return "", false, fmt.Errorf("publish replier thread subscription inbox: %w", err)
 			}
 		}
 	default:
-		return "", fmt.Errorf("get parent message sender: %w", err)
+		return "", false, fmt.Errorf("get parent message sender: %w", err)
 	}
 
 	// Update lastMsg pointer AND merge replier + parent author into replyAccounts in one write.
@@ -426,35 +428,16 @@ func (h *Handler) handleSubsequentThreadReply(ctx context.Context, msg *model.Me
 		replyAccounts = append(replyAccounts, parentSender.Account)
 	}
 	if err := h.threadStore.UpdateThreadRoomLastMessage(ctx, existingRoom.ID, msg.ID, replyAccounts, now); err != nil {
-		return "", fmt.Errorf("update thread room last message: %w", err)
+		return "", false, fmt.Errorf("update thread room last message: %w", err)
 	}
 
-	// Re-stamp handles redelivery: first attempt may have created the thread room
-	// but crashed before the stamp landed. IF EXISTS in the store prevents phantom rows.
-	switch {
-	case parentFound && msg.ThreadParentMessageCreatedAt != nil:
-		if err := h.store.UpdateParentMessageThreadRoomID(ctx, msg.ThreadParentMessageID, msg.RoomID, *msg.ThreadParentMessageCreatedAt, existingRoom.ID); err != nil {
-			return "", fmt.Errorf("stamp thread_room_id on parent message: %w", err)
-		}
-	case !parentFound:
-		slog.ErrorContext(ctx, "subsequent thread reply: parent not found in messages_by_id, thread_room_id stamp skipped",
-			"request_id", natsutil.RequestIDFromContext(ctx),
-			"replyID", msg.ID,
-			"parentMessageID", msg.ThreadParentMessageID,
-			"threadRoomID", existingRoom.ID,
-			"room_id", msg.RoomID,
-		)
-	default: // msg.ThreadParentMessageCreatedAt == nil
-		slog.ErrorContext(ctx, "subsequent thread reply: ThreadParentMessageCreatedAt is nil, parent thread_room_id stamp skipped",
-			"request_id", natsutil.RequestIDFromContext(ctx),
-			"replyID", msg.ID,
-			"parentMessageID", msg.ThreadParentMessageID,
-			"threadRoomID", existingRoom.ID,
-			"room_id", msg.RoomID,
-		)
-	}
+	// The parent message's thread_room_id is stamped once, on the first reply
+	// (handleFirstThreadReply). It never changes for a thread, so re-stamping it on every
+	// subsequent reply is a redundant Cassandra write — skipped here. Trade-off: if the
+	// first reply created the room but crashed before its stamp landed, the parent stays
+	// unstamped (no per-reply self-heal) — a narrow window not worth a write on every reply.
 
-	return existingRoom.ID, nil
+	return existingRoom.ID, replierLastSeenAdvanced, nil
 }
 
 // lookupOwnerSiteID resolves a user's home site by ID.

--- a/message-worker/handler_test.go
+++ b/message-worker/handler_test.go
@@ -218,18 +218,16 @@ func TestHandler_ProcessMessage(t *testing.T) {
 			setupMocks: func(store *MockStore, us *MockUserStore, ts *MockThreadStore) {
 				us.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
 				// handleThreadRoomAndSubscriptions runs first to resolve the threadRoomID.
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(errThreadRoomExists)
-				ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-1").
-					Return(&model.ThreadRoom{ID: "tr-1"}, nil)
-				// Subsequent-reply path: upsert parent and replier subscriptions.
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-1"}, false, nil)
+				// Subsequent-reply path: parent sender is still read for the replyAccounts merge,
+				// but the parent author's subscription is NOT re-upserted (created on the first
+				// reply) and no parent owner-site lookup runs.
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-1").
 					Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
-				us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
-					Return(&model.User{ID: "u-parent", Account: "parent-user", SiteID: "site-a"}, nil)
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
+				// Single combined write for the replier: creates the sub if missing and advances
+				// its lastSeenAt — replaces the old UpsertThreadSubscription + AdvanceThreadSubscriptionLastSeen.
+				ts.EXPECT().UpsertThreadSubscriptionAdvancingLastSeen(gomock.Any(), gomock.Any(), now).Return(nil)
 				ts.EXPECT().UpdateThreadRoomLastMessage(gomock.Any(), "tr-1", "msg-2", gomock.Any(), now).Return(nil)
-				ts.EXPECT().AdvanceThreadSubscriptionLastSeen(gomock.Any(), "tr-1", "alice", now).Return(nil)
 				// SaveThreadMessage receives the resolved threadRoomID.
 				store.EXPECT().SaveThreadMessage(gomock.Any(), &threadMsg, &expectedSender, "site-a", "tr-1").Return((*int)(nil), nil)
 			},
@@ -240,17 +238,11 @@ func TestHandler_ProcessMessage(t *testing.T) {
 			setupMocks: func(store *MockStore, us *MockUserStore, ts *MockThreadStore) {
 				us.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
 				// handleThreadRoomAndSubscriptions runs before SaveThreadMessage.
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(errThreadRoomExists)
-				ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-1").
-					Return(&model.ThreadRoom{ID: "tr-1"}, nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-1"}, false, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-1").
 					Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
-				us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
-					Return(&model.User{ID: "u-parent", Account: "parent-user", SiteID: "site-a"}, nil)
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
+				ts.EXPECT().UpsertThreadSubscriptionAdvancingLastSeen(gomock.Any(), gomock.Any(), now).Return(nil)
 				ts.EXPECT().UpdateThreadRoomLastMessage(gomock.Any(), "tr-1", "msg-2", gomock.Any(), now).Return(nil)
-				ts.EXPECT().AdvanceThreadSubscriptionLastSeen(gomock.Any(), "tr-1", "alice", now).Return(nil)
 				store.EXPECT().SaveThreadMessage(gomock.Any(), &threadMsg, &expectedSender, "site-a", "tr-1").
 					Return((*int)(nil), errors.New("cassandra: write timeout"))
 			},
@@ -324,7 +316,7 @@ func TestHandler_ProcessMessage(t *testing.T) {
 					Return([]model.User{*bobUser}, nil)
 				us.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
 				// First-reply path: create the thread room.
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-ensured"}, true, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-1").
 					Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
 				us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
@@ -356,7 +348,7 @@ func TestHandler_ProcessMessage(t *testing.T) {
 				us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"alice"}).
 					Return([]model.User{*user}, nil)
 				us.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-ensured"}, true, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-1").
 					Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
 				us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
@@ -374,7 +366,7 @@ func TestHandler_ProcessMessage(t *testing.T) {
 			setupMocks: func(store *MockStore, us *MockUserStore, ts *MockThreadStore) {
 				// No account lookup — @all bypasses the user-by-accounts query.
 				us.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-ensured"}, true, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-1").
 					Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
 				us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
@@ -393,7 +385,7 @@ func TestHandler_ProcessMessage(t *testing.T) {
 				us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"bob"}).
 					Return([]model.User{*bobUser}, nil)
 				us.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-ensured"}, true, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-1").
 					Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
 				us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
@@ -417,7 +409,7 @@ func TestHandler_ProcessMessage(t *testing.T) {
 				us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"bob"}).
 					Return([]model.User{*bobUser}, nil)
 				us.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-ensured"}, true, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-1").
 					Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
 				us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
@@ -439,7 +431,7 @@ func TestHandler_ProcessMessage(t *testing.T) {
 			migration: true,
 			setupMocks: func(store *MockStore, us *MockUserStore, ts *MockThreadStore) {
 				us.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-ensured"}, true, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-1").
 					Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
 				// No InsertThreadSubscription / owner-site lookup / MarkThreadSubscriptionMention — all suppressed for migrated events.
@@ -454,9 +446,7 @@ func TestHandler_ProcessMessage(t *testing.T) {
 			migration: true,
 			setupMocks: func(store *MockStore, us *MockUserStore, ts *MockThreadStore) {
 				us.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(errThreadRoomExists)
-				ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-1").
-					Return(&model.ThreadRoom{ID: "tr-1"}, nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-1"}, false, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-1").
 					Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
 				// No UpsertThreadSubscription/owner-site lookup; replyAccounts + lastMsg pointer still written (thread_rooms, not subs).
@@ -474,7 +464,7 @@ func TestHandler_ProcessMessage(t *testing.T) {
 				us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"bob"}).
 					Return([]model.User{*bobUser}, nil)
 				us.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-ensured"}, true, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-1").
 					Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
 				// MarkThreadSubscriptionMention + InsertThreadSubscription must NOT be called.
@@ -541,18 +531,11 @@ func TestHandler_ProcessMessage_ThreadReply_PublishesBadgeEvent(t *testing.T) {
 
 	mockStore.EXPECT().GetMessageCreatedAt(gomock.Any(), gomock.Any()).Return(parentCreatedAt, true, nil).AnyTimes()
 	mockUserStore.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
-	mockThreadStore.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(errThreadRoomExists)
-	mockThreadStore.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-		Return(&model.ThreadRoom{ID: "tr-99"}, nil)
+	mockThreadStore.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-99"}, false, nil)
 	mockStore.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 		Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
-	mockStore.EXPECT().UpdateParentMessageThreadRoomID(gomock.Any(), "msg-parent", "r1", parentCreatedAt, "tr-99").Return(nil)
-	mockUserStore.EXPECT().FindUserByID(gomock.Any(), "u-parent").
-		Return(&model.User{ID: "u-parent", Account: "parent-user", SiteID: "site-a"}, nil)
-	mockThreadStore.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
-	mockThreadStore.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
+	mockThreadStore.EXPECT().UpsertThreadSubscriptionAdvancingLastSeen(gomock.Any(), gomock.Any(), now).Return(nil)
 	mockThreadStore.EXPECT().UpdateThreadRoomLastMessage(gomock.Any(), "tr-99", "msg-reply", gomock.Any(), now).Return(nil)
-	mockThreadStore.EXPECT().AdvanceThreadSubscriptionLastSeen(gomock.Any(), "tr-99", "alice", now).Return(nil)
 	// SaveThreadMessage returns a non-nil tcount (simulates first write or redelivery recovery).
 	mockStore.EXPECT().SaveThreadMessage(gomock.Any(), &threadMsg, &expectedSender, "site-a", "tr-99").
 		Return(&expectedTcount, nil)
@@ -609,14 +592,11 @@ func TestHandler_ProcessMessage_MigratedThreadReply_SuppressesBadgeAndOutbox(t *
 	mockThreadStore.EXPECT().AddReplyAccounts(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	mockUserStore.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
-	// No GetMessageCreatedAt: the migrated event carries the parent createdAt.
-	mockThreadStore.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(errThreadRoomExists)
-	mockThreadStore.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-		Return(&model.ThreadRoom{ID: "tr-99"}, nil)
+	mockStore.EXPECT().GetMessageCreatedAt(gomock.Any(), "msg-parent").Return(parentCreatedAt, true, nil)
+	mockThreadStore.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-99"}, false, nil)
 	mockStore.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 		Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
-	// No UpsertThreadSubscription, no owner-site lookup. lastMsg pointer kept.
-	mockStore.EXPECT().UpdateParentMessageThreadRoomID(gomock.Any(), "msg-parent", "r1", parentCreatedAt, "tr-99").Return(nil)
+	// No UpsertThreadSubscription, no owner-site lookup, no re-stamp (subsequent reply). lastMsg pointer kept.
 	mockThreadStore.EXPECT().UpdateThreadRoomLastMessage(gomock.Any(), "tr-99", "msg-reply", gomock.Any(), now).Return(nil)
 	// SaveThreadMessage returns a non-nil tcount — in the live path this would trigger the badge.
 	mockStore.EXPECT().SaveThreadMessage(gomock.Any(), &threadMsg, &expectedSender, "site-a", "tr-99").
@@ -649,54 +629,74 @@ func TestHandler_ProcessMessage_ThreadReply_AdvancesReplierLastSeen(t *testing.T
 	}
 	data, _ := json.Marshal(model.MessageEvent{Message: threadMsg, SiteID: "site-a", Timestamp: now.UnixMilli()})
 
-	// subsequent-reply scaffolding shared by both subtests (known threadRoomID for exact-arg assert).
+	// subsequent-reply scaffolding shared by the subtests (known threadRoomID for exact-arg assert).
+	// On the non-migration hot path the replier's lastSeenAt is advanced as part of a single
+	// combined UpsertThreadSubscriptionAdvancingLastSeen(replierSub, msg.CreatedAt) write — the
+	// `now` matcher on the third arg is the #396 assertion. Migration writes no replier sub, so
+	// the standalone AdvanceThreadSubscriptionLastSeen handles it (asserted per-subtest).
 	setupSubsequentReply := func(store *MockStore, us *MockUserStore, ts *MockThreadStore, migration bool) {
 		us.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
 		store.EXPECT().GetMessageCreatedAt(gomock.Any(), "msg-parent").Return(parentCreatedAt, true, nil)
-		ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(errThreadRoomExists)
-		ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").Return(&model.ThreadRoom{ID: "tr-77"}, nil)
+		ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-77"}, false, nil)
 		store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
-		store.EXPECT().UpdateParentMessageThreadRoomID(gomock.Any(), "msg-parent", "r1", parentCreatedAt, "tr-77").Return(nil)
 		if !migration {
-			us.EXPECT().FindUserByID(gomock.Any(), "u-parent").Return(&model.User{ID: "u-parent", Account: "parent-user", SiteID: "site-a"}, nil)
-			ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+			ts.EXPECT().UpsertThreadSubscriptionAdvancingLastSeen(gomock.Any(), gomock.Any(), now).Return(nil)
 		}
 		ts.EXPECT().UpdateThreadRoomLastMessage(gomock.Any(), "tr-77", "msg-reply", gomock.Any(), now).Return(nil)
 		ts.EXPECT().AddReplyAccounts(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		store.EXPECT().SaveThreadMessage(gomock.Any(), gomock.Any(), gomock.Any(), "site-a", "tr-77").Return((*int)(nil), nil)
 	}
 
-	t.Run("normal reply advances replier", func(t *testing.T) {
+	t.Run("normal reply advances replier via combined upsert", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		store, us, ts := NewMockStore(ctrl), NewMockUserStore(ctrl), NewMockThreadStore(ctrl)
+		// No standalone AdvanceThreadSubscriptionLastSeen: a strict mock would fail if it were
+		// still issued on top of the combined write set up above.
 		setupSubsequentReply(store, us, ts, false)
-		ts.EXPECT().AdvanceThreadSubscriptionLastSeen(gomock.Any(), "tr-77", "alice", now).Return(nil)
 
 		h := NewHandler(store, us, ts, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil })
 		require.NoError(t, h.processMessage(context.Background(), data, false))
 	})
 
-	t.Run("migration reply also advances", func(t *testing.T) {
+	t.Run("migration reply advances via standalone $max", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		store, us, ts := NewMockStore(ctrl), NewMockUserStore(ctrl), NewMockThreadStore(ctrl)
 		setupSubsequentReply(store, us, ts, true)
-		// Advance runs on migration too ($max only moves forward) — mliu33 review on #398.
+		// Migration writes no replier subscription, so the standalone advance carries #396
+		// ($max only moves forward) — mliu33 review on #398.
 		ts.EXPECT().AdvanceThreadSubscriptionLastSeen(gomock.Any(), "tr-77", "alice", now).Return(nil)
 
 		h := NewHandler(store, us, ts, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil })
 		require.NoError(t, h.processMessage(context.Background(), data, true))
 	})
 
-	t.Run("advance failure is swallowed — reply still persists (best-effort)", func(t *testing.T) {
+	t.Run("standalone advance failure is swallowed — migrated reply still persists (best-effort)", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		store, us, ts := NewMockStore(ctrl), NewMockUserStore(ctrl), NewMockThreadStore(ctrl)
-		setupSubsequentReply(store, us, ts, false)
-		// AdvanceThreadSubscriptionLastSeen errors → logged + swallowed; SaveThreadMessage
+		setupSubsequentReply(store, us, ts, true)
+		// Standalone AdvanceThreadSubscriptionLastSeen errors → logged + swallowed; SaveThreadMessage
 		// in setupSubsequentReply still runs and processMessage returns nil (#398 CodeRabbit).
 		ts.EXPECT().AdvanceThreadSubscriptionLastSeen(gomock.Any(), "tr-77", "alice", now).Return(errors.New("mongo down"))
 
 		h := NewHandler(store, us, ts, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil })
-		require.NoError(t, h.processMessage(context.Background(), data, false))
+		require.NoError(t, h.processMessage(context.Background(), data, true))
+	})
+
+	t.Run("combined replier upsert failure NAKs the reply", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		store, us, ts := NewMockStore(ctrl), NewMockUserStore(ctrl), NewMockThreadStore(ctrl)
+		us.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
+		store.EXPECT().GetMessageCreatedAt(gomock.Any(), "msg-parent").Return(parentCreatedAt, true, nil)
+		ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-77"}, false, nil)
+		store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
+		// The combined write owns the replier's lastSeen on the hot path, so unlike the old
+		// best-effort standalone advance, its failure NAKs (the sub must exist for correctness).
+		ts.EXPECT().UpsertThreadSubscriptionAdvancingLastSeen(gomock.Any(), gomock.Any(), now).Return(errors.New("mongo down"))
+		ts.EXPECT().AddReplyAccounts(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		// SaveThreadMessage must NOT run — the upsert error aborts before persistence.
+
+		h := NewHandler(store, us, ts, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil })
+		require.Error(t, h.processMessage(context.Background(), data, false))
 	})
 }
 
@@ -732,14 +732,14 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			msg:    msg,
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, room *model.ThreadRoom) error {
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, room *model.ThreadRoom) (*model.ThreadRoom, bool, error) {
 						assert.Equal(t, "msg-parent", room.ParentMessageID)
 						assert.Equal(t, "r1", room.RoomID)
 						assert.Equal(t, "site-a", room.SiteID)
 						assert.Equal(t, "msg-reply", room.LastMsgID)
 						assert.Equal(t, []string{"replier"}, room.ReplyAccounts)
-						return nil
+						return room, true, nil
 					})
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 					Return(parentSender, nil)
@@ -768,7 +768,7 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			msg:    msg,
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-ensured"}, true, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 					Return(nil, fmt.Errorf("wrap: %w", errMessageNotFound))
 			},
@@ -787,7 +787,7 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			},
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-ensured"}, true, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 					Return(parentSender, nil)
 				ts.EXPECT().InsertThreadSubscription(gomock.Any(), gomock.Any()).
@@ -806,7 +806,7 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			msg:    msg,
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-ensured"}, true, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 					Return(nil, errors.New("cassandra: read timeout"))
 			},
@@ -817,7 +817,7 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			msg:    msg,
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-ensured"}, true, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 					Return(parentSender, nil)
 				ts.EXPECT().InsertThreadSubscription(gomock.Any(), gomock.Any()).
@@ -834,7 +834,7 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			msg:    msg,
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-ensured"}, true, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 					Return(parentSender, nil)
 				// Parent insert succeeds
@@ -850,40 +850,28 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:   "subsequent reply — upserts parent and replier subscriptions and updates last message",
+			name:   "subsequent reply — upserts only the replier subscription and updates last message",
 			msg:    msg,
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).
-					Return(errThreadRoomExists)
-				ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-					Return(&model.ThreadRoom{ID: "tr-existing"}, nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-existing"}, false, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 					Return(parentSender, nil)
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, sub *model.ThreadSubscription) error {
-						assert.Equal(t, "tr-existing", sub.ThreadRoomID)
-						assert.Equal(t, "u-parent", sub.UserID)
-						assert.Nil(t, sub.LastSeenAt, "parent's LastSeenAt should be nil on init")
-						return nil
-					})
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, sub *model.ThreadSubscription) error {
+				// Parent author's sub is NOT re-upserted (created on first reply); only the
+				// replier's combined upsert+lastSeen write runs, with at=msg.CreatedAt.
+				ts.EXPECT().UpsertThreadSubscriptionAdvancingLastSeen(gomock.Any(), gomock.Any(), now).
+					DoAndReturn(func(_ context.Context, sub *model.ThreadSubscription, _ time.Time) error {
 						assert.Equal(t, "tr-existing", sub.ThreadRoomID)
 						assert.Equal(t, "u-replier", sub.UserID)
-						assert.Nil(t, sub.LastSeenAt, "replier's LastSeenAt should be nil on init")
+						assert.Nil(t, sub.LastSeenAt, "replier's struct LastSeenAt stays nil; $max sets it server-side")
 						return nil
 					})
 				ts.EXPECT().UpdateThreadRoomLastMessage(gomock.Any(), "tr-existing", "msg-reply", gomock.Any(), now).
 					Return(nil)
 			},
-			extraUserStoreSetup: func(us *MockUserStore) {
-				us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
-					Return(&model.User{ID: "u-parent", Account: "parent-user", SiteID: "site-a"}, nil)
-			},
 		},
 		{
-			name: "subsequent reply — same user as parent — upserts one subscription and updates last message",
+			name: "subsequent reply — same user as parent — writes no subscription, only updates last message",
 			msg: &model.Message{
 				ID:                    "msg-reply",
 				RoomID:                "r1",
@@ -895,23 +883,13 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			},
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).
-					Return(errThreadRoomExists)
-				ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-					Return(&model.ThreadRoom{ID: "tr-existing"}, nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-existing"}, false, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 					Return(parentSender, nil)
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, sub *model.ThreadSubscription) error {
-						assert.Equal(t, "u-parent", sub.UserID)
-						return nil
-					})
+				// replier == parent author: no replier sub write here (the caller's standalone
+				// $max advances the self-replier's lastSeen instead).
 				ts.EXPECT().UpdateThreadRoomLastMessage(gomock.Any(), "tr-existing", "msg-reply", gomock.Any(), now).
 					Return(nil)
-			},
-			extraUserStoreSetup: func(us *MockUserStore) {
-				us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
-					Return(&model.User{ID: "u-parent", Account: "parent-user", SiteID: "site-a"}, nil)
 			},
 		},
 		{
@@ -919,14 +897,11 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			msg:    msg,
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).
-					Return(errThreadRoomExists)
-				ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-					Return(&model.ThreadRoom{ID: "tr-existing"}, nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-existing"}, false, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 					Return(nil, fmt.Errorf("wrap: %w", errMessageNotFound))
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, sub *model.ThreadSubscription) error {
+				ts.EXPECT().UpsertThreadSubscriptionAdvancingLastSeen(gomock.Any(), gomock.Any(), now).
+					DoAndReturn(func(_ context.Context, sub *model.ThreadSubscription, _ time.Time) error {
 						assert.Equal(t, "u-replier", sub.UserID)
 						return nil
 					})
@@ -935,14 +910,12 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			},
 		},
 		{
-			name:   "subsequent reply — GetThreadRoomByParentMessageID fails — returns error",
+			name:   "EnsureThreadRoom fails — returns error",
 			msg:    msg,
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).
-					Return(errThreadRoomExists)
-				ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-					Return(nil, errors.New("mongo: connection refused"))
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).
+					Return(nil, false, errors.New("mongo: connection refused"))
 			},
 			wantErr: true,
 		},
@@ -951,53 +924,22 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			msg:    msg,
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).
-					Return(errThreadRoomExists)
-				ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-					Return(&model.ThreadRoom{ID: "tr-existing"}, nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-existing"}, false, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 					Return(nil, errors.New("cassandra: read timeout"))
 			},
 			wantErr: true,
 		},
 		{
-			name:   "subsequent reply — UpsertThreadSubscription for parent fails — returns error",
+			name:   "subsequent reply — replier subscription upsert fails — returns error",
 			msg:    msg,
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).
-					Return(errThreadRoomExists)
-				ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-					Return(&model.ThreadRoom{ID: "tr-existing"}, nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-existing"}, false, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 					Return(parentSender, nil)
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).
+				ts.EXPECT().UpsertThreadSubscriptionAdvancingLastSeen(gomock.Any(), gomock.Any(), now).
 					Return(errors.New("mongo: write error"))
-			},
-			extraUserStoreSetup: func(us *MockUserStore) {
-				us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
-					Return(&model.User{ID: "u-parent", Account: "parent-user", SiteID: "site-a"}, nil)
-			},
-			wantErr: true,
-		},
-		{
-			name:   "subsequent reply — UpsertThreadSubscription for replier fails — returns error",
-			msg:    msg,
-			siteID: "site-a",
-			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).
-					Return(errThreadRoomExists)
-				ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-					Return(&model.ThreadRoom{ID: "tr-existing"}, nil)
-				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
-					Return(parentSender, nil)
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).
-					Return(errors.New("mongo: write error"))
-			},
-			extraUserStoreSetup: func(us *MockUserStore) {
-				us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
-					Return(&model.User{ID: "u-parent", Account: "parent-user", SiteID: "site-a"}, nil)
 			},
 			wantErr: true,
 		},
@@ -1006,30 +948,12 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			msg:    msg,
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).
-					Return(errThreadRoomExists)
-				ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-					Return(&model.ThreadRoom{ID: "tr-existing"}, nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-existing"}, false, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 					Return(parentSender, nil)
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
+				ts.EXPECT().UpsertThreadSubscriptionAdvancingLastSeen(gomock.Any(), gomock.Any(), now).Return(nil)
 				ts.EXPECT().UpdateThreadRoomLastMessage(gomock.Any(), "tr-existing", "msg-reply", gomock.Any(), now).
 					Return(errors.New("mongo: write error"))
-			},
-			extraUserStoreSetup: func(us *MockUserStore) {
-				us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
-					Return(&model.User{ID: "u-parent", Account: "parent-user", SiteID: "site-a"}, nil)
-			},
-			wantErr: true,
-		},
-		{
-			name:   "CreateThreadRoom unexpected error — returns error",
-			msg:    msg,
-			siteID: "site-a",
-			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).
-					Return(errors.New("mongo: connection refused"))
 			},
 			wantErr: true,
 		},
@@ -1046,12 +970,9 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			},
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				var capturedRoomID string
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, room *model.ThreadRoom) error {
-						capturedRoomID = room.ID
-						return nil
-					})
+				// EnsureThreadRoom returns the resolved room; the handler stamps that room's ID.
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).
+					Return(&model.ThreadRoom{ID: "tr-stamp"}, true, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 					Return(parentSender, nil)
 				ts.EXPECT().InsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
@@ -1059,7 +980,7 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 				store.EXPECT().UpdateParentMessageThreadRoomID(
 					gomock.Any(), "msg-parent", "r1",
 					now.Add(-5*time.Minute),
-					gomock.Cond(func(x any) bool { s, ok := x.(string); return ok && s == capturedRoomID }),
+					"tr-stamp",
 				).Return(nil)
 			},
 			extraUserStoreSetup: func(us *MockUserStore) {
@@ -1080,7 +1001,7 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			},
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-ensured"}, true, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 					Return(parentSender, nil)
 				ts.EXPECT().InsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
@@ -1095,7 +1016,7 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "subsequent reply — stamps thread_room_id on parent when parentCreatedAt known",
+			name: "subsequent reply — parent not found but parentCreatedAt known — replier sub still written",
 			msg: &model.Message{
 				ID:                           "msg-reply",
 				RoomID:                       "r1",
@@ -1107,73 +1028,11 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			},
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(errThreadRoomExists)
-				ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-					Return(&model.ThreadRoom{ID: "tr-existing"}, nil)
-				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").Return(parentSender, nil)
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
-				ts.EXPECT().UpdateThreadRoomLastMessage(gomock.Any(), "tr-existing", "msg-reply", gomock.Any(), now).Return(nil)
-				store.EXPECT().UpdateParentMessageThreadRoomID(
-					gomock.Any(), "msg-parent", "r1",
-					now.Add(-5*time.Minute),
-					"tr-existing",
-				).Return(nil)
-			},
-			extraUserStoreSetup: func(us *MockUserStore) {
-				us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
-					Return(&model.User{ID: "u-parent", Account: "parent-user", SiteID: "site-a"}, nil)
-			},
-		},
-		{
-			name: "subsequent reply — UpdateParentMessageThreadRoomID fails — returns error",
-			msg: &model.Message{
-				ID:                           "msg-reply",
-				RoomID:                       "r1",
-				UserID:                       "u-replier",
-				UserAccount:                  "replier",
-				CreatedAt:                    now,
-				ThreadParentMessageID:        "msg-parent",
-				ThreadParentMessageCreatedAt: ptrTime(now.Add(-5 * time.Minute)),
-			},
-			siteID: "site-a",
-			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(errThreadRoomExists)
-				ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-					Return(&model.ThreadRoom{ID: "tr-existing"}, nil)
-				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").Return(parentSender, nil)
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
-				ts.EXPECT().UpdateThreadRoomLastMessage(gomock.Any(), "tr-existing", "msg-reply", gomock.Any(), now).Return(nil)
-				store.EXPECT().UpdateParentMessageThreadRoomID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(errors.New("cassandra: write timeout"))
-			},
-			extraUserStoreSetup: func(us *MockUserStore) {
-				us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
-					Return(&model.User{ID: "u-parent", Account: "parent-user", SiteID: "site-a"}, nil)
-			},
-			wantErr: true,
-		},
-		{
-			name: "subsequent reply — parent not found but parentCreatedAt known — skips UpdateParentMessageThreadRoomID",
-			msg: &model.Message{
-				ID:                           "msg-reply",
-				RoomID:                       "r1",
-				UserID:                       "u-replier",
-				UserAccount:                  "replier",
-				CreatedAt:                    now,
-				ThreadParentMessageID:        "msg-parent",
-				ThreadParentMessageCreatedAt: ptrTime(now.Add(-5 * time.Minute)),
-			},
-			siteID: "site-a",
-			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(errThreadRoomExists)
-				ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-					Return(&model.ThreadRoom{ID: "tr-existing"}, nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-existing"}, false, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 					Return(nil, fmt.Errorf("wrap: %w", errMessageNotFound))
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, sub *model.ThreadSubscription) error {
+				ts.EXPECT().UpsertThreadSubscriptionAdvancingLastSeen(gomock.Any(), gomock.Any(), now).
+					DoAndReturn(func(_ context.Context, sub *model.ThreadSubscription, _ time.Time) error {
 						assert.Equal(t, "u-replier", sub.UserID)
 						return nil
 					})
@@ -1187,7 +1046,7 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			msg:    msg,
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-ensured"}, true, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").Return(parentSender, nil)
 				// Parent insert still runs (independent of owner-site lookup) —
 				// only the cross-site inbox publish is gated on the lookup.
@@ -1204,61 +1063,32 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 			expectReplierInsert: true,
 		},
 		{
-			name:   "subsequent reply — parent user not found in userStore — still upserts parent + replier locally, skips parent inbox",
+			name:   "subsequent reply — does not re-upsert parent author nor look up parent owner site",
 			msg:    msg,
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).
-					Return(errThreadRoomExists)
-				ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-					Return(&model.ThreadRoom{ID: "tr-existing"}, nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-existing"}, false, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 					Return(parentSender, nil)
-				// Parent upsert still runs (independent of owner-site lookup);
-				// only the cross-site inbox publish is gated.
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, sub *model.ThreadSubscription) error {
-						assert.Equal(t, "u-parent", sub.UserID)
-						return nil
-					})
-				ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, sub *model.ThreadSubscription) error {
+				// Parent author sub was created on the first reply: it is NOT re-upserted here,
+				// and no parent owner-site FindUserByID runs. Only the replier's combined write.
+				ts.EXPECT().UpsertThreadSubscriptionAdvancingLastSeen(gomock.Any(), gomock.Any(), now).
+					DoAndReturn(func(_ context.Context, sub *model.ThreadSubscription, _ time.Time) error {
 						assert.Equal(t, "u-replier", sub.UserID)
 						return nil
 					})
 				ts.EXPECT().UpdateThreadRoomLastMessage(gomock.Any(), "tr-existing", "msg-reply", gomock.Any(), now).
 					Return(nil)
+				// No FindUserByID(u-parent): a strict mock would fail if the parent owner-site
+				// lookup were still issued on the subsequent-reply path.
 			},
-			extraUserStoreSetup: func(us *MockUserStore) {
-				us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
-					Return(nil, fmt.Errorf("wrap: %w", userstore.ErrUserNotFound))
-			},
-		},
-		{
-			name:   "subsequent reply — parent user lookup DB error — returns error",
-			msg:    msg,
-			siteID: "site-a",
-			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).
-					Return(errThreadRoomExists)
-				ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-					Return(&model.ThreadRoom{ID: "tr-existing"}, nil)
-				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
-					Return(parentSender, nil)
-				// Lookup error short-circuits — no upserts, no UpdateThreadRoomLastMessage.
-			},
-			extraUserStoreSetup: func(us *MockUserStore) {
-				us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
-					Return(nil, errors.New("mongo: connection refused"))
-			},
-			wantErr: true,
 		},
 		{
 			name:   "first reply — parent user lookup DB error — returns error",
 			msg:    msg,
 			siteID: "site-a",
 			setupMocks: func(store *MockStore, ts *MockThreadStore) {
-				ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(nil)
+				ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-ensured"}, true, nil)
 				store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").Return(parentSender, nil)
 			},
 			extraUserStoreSetup: func(us *MockUserStore) {
@@ -1288,7 +1118,7 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 				return nil
 			})
 			replier := &model.User{ID: tt.msg.UserID, Account: tt.msg.UserAccount, SiteID: "site-a"}
-			_, err := h.handleThreadRoomAndSubscriptions(context.Background(), tt.msg, tt.siteID, replier, false)
+			_, _, err := h.handleThreadRoomAndSubscriptions(context.Background(), tt.msg, tt.siteID, replier, false)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -1574,44 +1404,25 @@ func TestHandler_SubsequentReply_InboxPublishes(t *testing.T) {
 	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
 
 	parentSender := &cassParticipant{ID: "u-parent", Account: "parent-user"}
-	parentUserAtA := &model.User{ID: "u-parent", Account: "parent-user", SiteID: "site-a"}
-	parentUserAtC := &model.User{ID: "u-parent", Account: "parent-user", SiteID: "site-c"}
 
+	// On the subsequent-reply path only the replier's subscription is written, so only the
+	// replier's home site receives a cross-site inbox publish. The parent author's sub (and
+	// its publish) happen once, on the first reply — never re-published here. Cases therefore
+	// depend solely on the replier's site.
 	tests := []struct {
 		name              string
 		replierSite       string
-		parentUser        *model.User
 		wantPublishToSite map[string]int
 	}{
 		{
-			name:              "both local — no publish",
+			name:              "replier local — no publish",
 			replierSite:       "site-a",
-			parentUser:        parentUserAtA,
 			wantPublishToSite: map[string]int{},
 		},
 		{
-			name:              "replier remote — one publish",
+			name:              "replier remote — one publish to replier site",
 			replierSite:       "site-b",
-			parentUser:        parentUserAtA,
 			wantPublishToSite: map[string]int{"site-b": 1},
-		},
-		{
-			name:              "parent remote — one publish",
-			replierSite:       "site-a",
-			parentUser:        parentUserAtC,
-			wantPublishToSite: map[string]int{"site-c": 1},
-		},
-		{
-			name:              "both remote, different sites — two publishes",
-			replierSite:       "site-b",
-			parentUser:        parentUserAtC,
-			wantPublishToSite: map[string]int{"site-b": 1, "site-c": 1},
-		},
-		{
-			name:              "both remote, same site — two publishes to that site",
-			replierSite:       "site-b",
-			parentUser:        &model.User{ID: "u-parent", Account: "parent-user", SiteID: "site-b"},
-			wantPublishToSite: map[string]int{"site-b": 2},
 		},
 	}
 
@@ -1623,12 +1434,8 @@ func TestHandler_SubsequentReply_InboxPublishes(t *testing.T) {
 			ts := NewMockThreadStore(ctrl)
 			ts.EXPECT().AddReplyAccounts(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-			ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-				Return(&model.ThreadRoom{ID: "tr-existing"}, nil)
 			store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").Return(parentSender, nil)
-			us.EXPECT().FindUserByID(gomock.Any(), "u-parent").Return(tt.parentUser, nil)
-			ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
-			ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
+			ts.EXPECT().UpsertThreadSubscriptionAdvancingLastSeen(gomock.Any(), gomock.Any(), now).Return(nil)
 			ts.EXPECT().UpdateThreadRoomLastMessage(gomock.Any(), "tr-existing", "msg-reply", gomock.Any(), now).Return(nil)
 
 			var publishedDests []string
@@ -1651,7 +1458,8 @@ func TestHandler_SubsequentReply_InboxPublishes(t *testing.T) {
 				ThreadParentMessageID: "msg-parent",
 			}
 
-			roomID, err := h.handleSubsequentThreadReply(context.Background(), msg, "site-a", replier, now, false)
+			roomID, _, err := h.handleSubsequentThreadReply(context.Background(), msg, "site-a",
+				&model.ThreadRoom{ID: "tr-existing"}, replier, now, false)
 			require.NoError(t, err)
 			assert.Equal(t, "tr-existing", roomID)
 
@@ -1672,13 +1480,10 @@ func TestHandler_SubsequentReply_InboxPublishError_NAKs(t *testing.T) {
 	ts := NewMockThreadStore(ctrl)
 	ts.EXPECT().AddReplyAccounts(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-	ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-		Return(&model.ThreadRoom{ID: "tr-1"}, nil)
 	store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 		Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
-	us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
-		Return(&model.User{ID: "u-parent", SiteID: "site-c"}, nil)
-	ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
+	// Only the replier's combined upsert runs; its remote (site-b) inbox publish then fails.
+	ts.EXPECT().UpsertThreadSubscriptionAdvancingLastSeen(gomock.Any(), gomock.Any(), now).Return(nil)
 
 	boom := errors.New("publish boom")
 	h := NewHandler(store, us, ts, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error {
@@ -1689,8 +1494,8 @@ func TestHandler_SubsequentReply_InboxPublishError_NAKs(t *testing.T) {
 		ID: "msg-reply", RoomID: "r1", UserID: "u-replier", UserAccount: "replier",
 		CreatedAt: now, ThreadParentMessageID: "msg-parent",
 	}
-	_, err := h.handleSubsequentThreadReply(context.Background(), msg, "site-a",
-		&model.User{ID: "u-replier", SiteID: "site-b"}, now, false)
+	_, _, err := h.handleSubsequentThreadReply(context.Background(), msg, "site-a",
+		&model.ThreadRoom{ID: "tr-1"}, &model.User{ID: "u-replier", SiteID: "site-b"}, now, false)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, boom)
 }
@@ -2272,21 +2077,15 @@ func TestHandler_ProcessMessage_ThreadReplyPublish(t *testing.T) {
 		// Parent resolved from messages_by_id; the stamp below uses this value.
 		store.EXPECT().GetMessageCreatedAt(gomock.Any(), "msg-parent").Return(parentCreatedAt, true, nil)
 		us.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
-		ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(errThreadRoomExists)
-		ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-			Return(&model.ThreadRoom{ID: "tr-1"}, nil)
+		ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-1"}, false, nil)
 		store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 			Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
-		us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
-			Return(&model.User{ID: "u-parent", Account: "parent-user", SiteID: "site-a"}, nil)
-		ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
-		ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
+		// Subsequent reply: single combined replier write (folds in lastSeen); no parent
+		// re-upsert, no parent owner-site lookup, no standalone AdvanceThreadSubscriptionLastSeen.
+		ts.EXPECT().UpsertThreadSubscriptionAdvancingLastSeen(gomock.Any(), gomock.Any(), now).Return(nil)
 		ts.EXPECT().UpdateThreadRoomLastMessage(gomock.Any(), "tr-1", "msg-reply", gomock.Any(), now).Return(nil)
-		ts.EXPECT().AdvanceThreadSubscriptionLastSeen(gomock.Any(), "tr-1", "alice", now).Return(nil)
-		// parentFound && ThreadParentMessageCreatedAt != nil → stamps thread_room_id on parent.
-		store.EXPECT().UpdateParentMessageThreadRoomID(
-			gomock.Any(), "msg-parent", "r1", parentCreatedAt, "tr-1",
-		).Return(nil)
+		// Subsequent reply: the parent's thread_room_id was stamped on the first reply, so it is
+		// NOT re-stamped here (no UpdateParentMessageThreadRoomID call).
 	}
 
 	t.Run("publishes MessageEvent to canonical thread reply subject", func(t *testing.T) {
@@ -2346,22 +2145,14 @@ func TestHandler_ProcessMessage_ThreadReplyPublish(t *testing.T) {
 		carriedData, _ := json.Marshal(carriedEvt)
 
 		us.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
-		ts.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(errThreadRoomExists)
-		ts.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-			Return(&model.ThreadRoom{ID: "tr-1"}, nil)
+		ts.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-1"}, false, nil)
 		store.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 			Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
-		us.EXPECT().FindUserByID(gomock.Any(), "u-parent").
-			Return(&model.User{ID: "u-parent", Account: "parent-user", SiteID: "site-a"}, nil)
-		ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
-		ts.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
+		ts.EXPECT().UpsertThreadSubscriptionAdvancingLastSeen(gomock.Any(), gomock.Any(), now).Return(nil)
 		ts.EXPECT().UpdateThreadRoomLastMessage(gomock.Any(), "tr-1", "msg-reply", gomock.Any(), now).Return(nil)
-		ts.EXPECT().AdvanceThreadSubscriptionLastSeen(gomock.Any(), "tr-1", "alice", now).Return(nil)
-		// The stamp must use the EVENT value.
-		store.EXPECT().UpdateParentMessageThreadRoomID(
-			gomock.Any(), "msg-parent", "r1", eventValue, "tr-1",
-		).Return(nil)
-		// The persisted reply must carry the event value.
+		// The persisted reply must carry the AUTHORITATIVE parent createdAt (from Cassandra),
+		// not the wrong client value — this is the override assertion (subsequent reply does
+		// not re-stamp the parent).
 		newTcount := 1
 		store.EXPECT().SaveThreadMessage(gomock.Any(), &carriedMsg, &expectedSender, "site-a", "tr-1").
 			Return(&newTcount, nil)

--- a/message-worker/handler_test.go
+++ b/message-worker/handler_test.go
@@ -592,7 +592,8 @@ func TestHandler_ProcessMessage_MigratedThreadReply_SuppressesBadgeAndOutbox(t *
 	mockThreadStore.EXPECT().AddReplyAccounts(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	mockUserStore.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
-	mockStore.EXPECT().GetMessageCreatedAt(gomock.Any(), "msg-parent").Return(parentCreatedAt, true, nil)
+	// Event carries the parent createdAt, so the handler skips the re-resolve; tolerate 0 calls.
+	mockStore.EXPECT().GetMessageCreatedAt(gomock.Any(), "msg-parent").Return(parentCreatedAt, true, nil).AnyTimes()
 	mockThreadStore.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-99"}, false, nil)
 	mockStore.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 		Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
@@ -2321,19 +2322,14 @@ func TestHandler_ProcessMessage_ThreadReply_EventCarriedParentCreatedAt_SkipsLoo
 	mockUserStore := NewMockUserStore(ctrl)
 	mockThreadStore := NewMockThreadStore(ctrl)
 
+	// No GetMessageCreatedAt expectation is registered: the event carries the parent
+	// createdAt, so the handler must not re-resolve it from Cassandra. Any call fails the test.
 	mockUserStore.EXPECT().FindUserByID(gomock.Any(), "u-1").Return(user, nil)
-	mockThreadStore.EXPECT().CreateThreadRoom(gomock.Any(), gomock.Any()).Return(errThreadRoomExists)
-	mockThreadStore.EXPECT().GetThreadRoomByParentMessageID(gomock.Any(), "msg-parent").
-		Return(&model.ThreadRoom{ID: "tr-99"}, nil)
+	mockThreadStore.EXPECT().EnsureThreadRoom(gomock.Any(), gomock.Any()).Return(&model.ThreadRoom{ID: "tr-99"}, false, nil)
 	mockStore.EXPECT().GetMessageSender(gomock.Any(), "msg-parent").
 		Return(&cassParticipant{ID: "u-parent", Account: "parent-user"}, nil)
-	mockStore.EXPECT().UpdateParentMessageThreadRoomID(gomock.Any(), "msg-parent", "r1", parentCreatedAt, "tr-99").Return(nil)
-	mockUserStore.EXPECT().FindUserByID(gomock.Any(), "u-parent").
-		Return(&model.User{ID: "u-parent", Account: "parent-user", SiteID: "site-a"}, nil)
-	mockThreadStore.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
-	mockThreadStore.EXPECT().UpsertThreadSubscription(gomock.Any(), gomock.Any()).Return(nil)
+	mockThreadStore.EXPECT().UpsertThreadSubscriptionAdvancingLastSeen(gomock.Any(), gomock.Any(), now).Return(nil)
 	mockThreadStore.EXPECT().UpdateThreadRoomLastMessage(gomock.Any(), "tr-99", "msg-reply", gomock.Any(), now).Return(nil)
-	mockThreadStore.EXPECT().AdvanceThreadSubscriptionLastSeen(gomock.Any(), "tr-99", "alice", now).Return(nil)
 	mockStore.EXPECT().SaveThreadMessage(gomock.Any(), &threadMsg, &expectedSender, "site-a", "tr-99").
 		Return(&expectedTcount, nil)
 

--- a/message-worker/integration_test.go
+++ b/message-worker/integration_test.go
@@ -716,77 +716,7 @@ func TestHandler_Integration_ThreadReplyWithMention(t *testing.T) {
 	})
 }
 
-// A mentionee with no room subscription is not a member and must not be
-// thread-subscribed (Option B: non-member mentions are excluded).
-func TestHandler_Integration_ThreadReplyMentionNonMemberExcluded(t *testing.T) {
-	ctx := context.Background()
-
-	cassSession := setupCassandra(t)
-	db := setupMongo(t)
-
-	userCol := db.Collection("users")
-	_, err := userCol.InsertMany(ctx, []interface{}{
-		bson.M{"_id": "u-parent", "account": "parent-user", "siteId": "site-a", "engName": "Parent User", "chineseName": "家長", "employeeId": "EMP001"},
-		bson.M{"_id": "u-replier", "account": "replier", "siteId": "site-a", "engName": "Replier User", "chineseName": "回覆者", "employeeId": "EMP002"},
-		bson.M{"_id": "u-bob", "account": "bob", "siteId": "site-a", "engName": "Bob Chen", "chineseName": "鮑勃", "employeeId": "EMP003"},
-	})
-	require.NoError(t, err)
-	// NOTE: no subscriptions row for bob → he is not a room member.
-
-	store := NewCassandraStore(cassSession, msgbucket.New(24*time.Hour), nil)
-	us := userstore.NewMongoStore(userCol)
-	ts := newThreadStoreMongo(db)
-	require.NoError(t, ts.EnsureIndexes(ctx))
-	h := NewHandler(store, us, ts, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error {
-		return nil
-	})
-
-	now := time.Now().UTC().Truncate(time.Millisecond)
-
-	parentMsg := &model.Message{
-		ID: "msg-parent-nonmember", RoomID: "r-nonmember", UserID: "u-parent", UserAccount: "parent-user",
-		Content: "parent message", CreatedAt: now.Add(-1 * time.Minute),
-	}
-	require.NoError(t, store.SaveMessage(ctx, parentMsg, &cassParticipant{ID: "u-parent", Account: "parent-user"}, "site-a"))
-
-	replyEvt := model.MessageEvent{
-		Message: model.Message{
-			ID: "msg-reply-nonmember", RoomID: "r-nonmember", UserID: "u-replier", UserAccount: "replier",
-			Content: "hey @bob take a look", CreatedAt: now,
-			ThreadParentMessageID: "msg-parent-nonmember",
-		},
-		SiteID: "site-a", Timestamp: now.UnixMilli(),
-	}
-	data, err := json.Marshal(replyEvt)
-	require.NoError(t, err)
-	require.NoError(t, h.processMessage(ctx, data, false))
-
-	t.Run("bob not subscribed (non-member)", func(t *testing.T) {
-		count, err := db.Collection("thread_subscriptions").CountDocuments(ctx, bson.M{
-			"parentMessageId": "msg-parent-nonmember", "userId": "u-bob",
-		})
-		require.NoError(t, err)
-		assert.Equal(t, int64(0), count, "non-member mentionee must not be thread-subscribed")
-	})
-
-	t.Run("only parent author + replier subscribed", func(t *testing.T) {
-		count, err := db.Collection("thread_subscriptions").CountDocuments(ctx, bson.M{
-			"parentMessageId": "msg-parent-nonmember",
-		})
-		require.NoError(t, err)
-		assert.Equal(t, int64(2), count)
-	})
-
-	t.Run("bob not added to thread_rooms.replyAccounts", func(t *testing.T) {
-		var room model.ThreadRoom
-		require.NoError(t, db.Collection("thread_rooms").FindOne(ctx, bson.M{
-			"parentMessageId": "msg-parent-nonmember",
-		}).Decode(&room))
-		assert.NotContains(t, room.ReplyAccounts, "bob", "non-member mentionee must not be a thread follower")
-	})
-}
-
-func TestThreadStoreMongo_CreateThreadRoom(t *testing.T) {
+func TestThreadStoreMongo_EnsureThreadRoom(t *testing.T) {
 	ctx := context.Background()
 	db := setupMongo(t)
 	store := newThreadStoreMongo(db)
@@ -800,48 +730,42 @@ func TestThreadStoreMongo_CreateThreadRoom(t *testing.T) {
 		SiteID:          "site-a",
 		LastMsgAt:       now,
 		LastMsgID:       "msg-reply-1",
+		ReplyAccounts:   []string{"alice"},
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
 
-	t.Run("first insert succeeds", func(t *testing.T) {
-		err := store.CreateThreadRoom(ctx, room)
+	t.Run("absent room is created and reported as created", func(t *testing.T) {
+		stored, created, err := store.EnsureThreadRoom(ctx, room)
 		require.NoError(t, err)
-
-		got, err := store.GetThreadRoomByParentMessageID(ctx, "msg-parent")
-		require.NoError(t, err)
-		assert.Equal(t, "tr-1", got.ID)
-		assert.Equal(t, "msg-parent", got.ParentMessageID)
-		assert.Equal(t, "r-1", got.RoomID)
-		assert.Equal(t, "site-a", got.SiteID)
-		assert.Equal(t, "msg-reply-1", got.LastMsgID)
+		assert.True(t, created, "first call must report created=true")
+		assert.Equal(t, "tr-1", stored.ID)
+		assert.Equal(t, "msg-parent", stored.ParentMessageID)
+		assert.Equal(t, "r-1", stored.RoomID)
+		assert.Equal(t, "site-a", stored.SiteID)
+		assert.Equal(t, "msg-reply-1", stored.LastMsgID)
+		assert.Equal(t, []string{"alice"}, stored.ReplyAccounts)
 	})
 
-	t.Run("duplicate insert returns errThreadRoomExists", func(t *testing.T) {
-		dup := &model.ThreadRoom{
+	t.Run("existing room is returned without overwrite and reported as not created", func(t *testing.T) {
+		// Same parentMessageId, different candidate — must NOT replace the stored room.
+		candidate := &model.ThreadRoom{
 			ID:              "tr-2",
 			ParentMessageID: "msg-parent",
 			RoomID:          "r-1",
 			SiteID:          "site-a",
-			LastMsgAt:       now,
+			LastMsgAt:       now.Add(time.Minute),
 			LastMsgID:       "msg-reply-2",
-			CreatedAt:       now,
-			UpdatedAt:       now,
+			ReplyAccounts:   []string{"bob"},
+			CreatedAt:       now.Add(time.Minute),
+			UpdatedAt:       now.Add(time.Minute),
 		}
-		err := store.CreateThreadRoom(ctx, dup)
-		require.ErrorIs(t, err, errThreadRoomExists)
-	})
-}
-
-func TestThreadStoreMongo_GetThreadRoomByParentMessageID(t *testing.T) {
-	ctx := context.Background()
-	db := setupMongo(t)
-	store := newThreadStoreMongo(db)
-	require.NoError(t, store.EnsureIndexes(ctx))
-
-	t.Run("not found returns errThreadRoomNotFound", func(t *testing.T) {
-		_, err := store.GetThreadRoomByParentMessageID(ctx, "does-not-exist")
-		require.ErrorIs(t, err, errThreadRoomNotFound)
+		stored, created, err := store.EnsureThreadRoom(ctx, candidate)
+		require.NoError(t, err)
+		assert.False(t, created, "second call for the same parent must report created=false")
+		assert.Equal(t, "tr-1", stored.ID, "$setOnInsert must not overwrite the original room")
+		assert.Equal(t, "msg-reply-1", stored.LastMsgID)
+		assert.Equal(t, []string{"alice"}, stored.ReplyAccounts)
 	})
 }
 
@@ -1061,14 +985,16 @@ func TestThreadStoreMongo_UpdateThreadRoomLastMessage(t *testing.T) {
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
-	require.NoError(t, store.CreateThreadRoom(ctx, room))
+	_, _, err := store.EnsureThreadRoom(ctx, room)
+	require.NoError(t, err)
 
 	later := now.Add(10 * time.Minute)
-	err := store.UpdateThreadRoomLastMessage(ctx, "tr-update", "msg-5", []string{"bob"}, later)
+	err = store.UpdateThreadRoomLastMessage(ctx, "tr-update", "msg-5", []string{"bob"}, later)
 	require.NoError(t, err)
 
-	got, err := store.GetThreadRoomByParentMessageID(ctx, "msg-parent-update")
-	require.NoError(t, err)
+	var got model.ThreadRoom
+	require.NoError(t, db.Collection("thread_rooms").
+		FindOne(ctx, bson.M{"parentMessageId": "msg-parent-update"}).Decode(&got))
 	assert.Equal(t, "msg-5", got.LastMsgID)
 	assert.Equal(t, later, got.LastMsgAt.UTC().Truncate(time.Millisecond))
 	assert.Contains(t, got.ReplyAccounts, "bob", "replier account should be added to ReplyAccounts")
@@ -2074,69 +2000,64 @@ func TestAdvanceThreadSubscriptionLastSeen_OnlyAdvances(t *testing.T) {
 	require.NoError(t, store.AdvanceThreadSubscriptionLastSeen(ctx, "no-room", "nobody", t2))
 }
 
-func TestThreadStoreMongo_GetHistorySharedSince(t *testing.T) {
+func TestThreadStoreMongo_UpsertThreadSubscriptionAdvancingLastSeen(t *testing.T) {
 	ctx := context.Background()
 	db := setupMongo(t)
 	store := newThreadStoreMongo(db)
-
-	shared := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
-	_, err := db.Collection("subscriptions").InsertMany(ctx, []interface{}{
-		model.Subscription{ID: "hss-al", User: model.SubscriptionUser{ID: "u-al", Account: "alice"}, RoomID: "r-hss", HistorySharedSince: &shared},
-		model.Subscription{ID: "hss-bo", User: model.SubscriptionUser{ID: "u-bo", Account: "bob"}, RoomID: "r-hss"},
-	})
-	require.NoError(t, err)
-
-	got, err := store.GetHistorySharedSince(ctx, "r-hss", []string{"alice", "bob", "carol"})
-	require.NoError(t, err)
-	require.NotNil(t, got["alice"])
-	assert.Equal(t, shared.UnixMilli(), got["alice"].UTC().UnixMilli())
-	bobWindow, bobPresent := got["bob"]
-	require.True(t, bobPresent, "member with a nil window must still be present in the map")
-	assert.Nil(t, bobWindow, "member without window decodes to nil")
-	_, present := got["carol"]
-	assert.False(t, present, "non-member is absent from the map")
-
-	empty, err := store.GetHistorySharedSince(ctx, "r-hss", nil)
-	require.NoError(t, err)
-	assert.Empty(t, empty)
-}
-
-func TestCassandraStore_SaveThreadMessage_TShowWritesAllTables(t *testing.T) {
-	cassSession := setupCassandra(t)
-	bucket := msgbucket.New(24 * time.Hour)
-	store := NewCassandraStore(cassSession, bucket, nil)
-	ctx := context.Background()
+	require.NoError(t, store.EnsureIndexes(ctx))
 
 	now := time.Now().UTC().Truncate(time.Millisecond)
-	parentCreatedAt := now.Add(-time.Hour)
-	sender := &cassParticipant{ID: "u-1", Account: "alice"}
-	msg := &model.Message{
-		ID:                           "m-tshow",
-		RoomID:                       "r-tshow",
-		UserID:                       "u-1",
-		UserAccount:                  "alice",
-		Content:                      "visible reply",
-		CreatedAt:                    now,
-		ThreadParentMessageID:        "m-parent",
-		ThreadParentMessageCreatedAt: &parentCreatedAt,
-		TShow:                        true,
+	sub := &model.ThreadSubscription{
+		ID:              "ts-comb",
+		ParentMessageID: "msg-p",
+		RoomID:          "r-comb",
+		ThreadRoomID:    "tr-comb",
+		UserID:          "u-comb",
+		UserAccount:     "alice",
+		SiteID:          "site-a",
+		LastSeenAt:      nil,
+		CreatedAt:       now,
+		UpdatedAt:       now,
 	}
 
-	_, err := store.SaveThreadMessage(ctx, msg, sender, "site-a", "tr-tshow-1")
-	require.NoError(t, err)
+	read := func() model.ThreadSubscription {
+		var got model.ThreadSubscription
+		require.NoError(t, db.Collection("thread_subscriptions").
+			FindOne(ctx, bson.M{"threadRoomId": "tr-comb", "userAccount": "alice"}).Decode(&got))
+		return got
+	}
 
-	// The batch must land in all three tables. Assert the reply's own rows by exact
-	// key so the parent's tcount-UPDATE upsert (same partitions) can't interfere.
-	var count int
-	require.NoError(t, cassSession.Query(`SELECT COUNT(*) FROM messages_by_id WHERE message_id = ?`, "m-tshow").WithContext(ctx).Scan(&count))
-	assert.Equal(t, 1, count, "messages_by_id reply row written")
+	t.Run("insert seeds the subscription with lastSeenAt=at", func(t *testing.T) {
+		require.NoError(t, store.UpsertThreadSubscriptionAdvancingLastSeen(ctx, sub, now))
 
-	require.NoError(t, cassSession.Query(`SELECT COUNT(*) FROM thread_messages_by_thread WHERE thread_room_id = ?`, "tr-tshow-1").WithContext(ctx).Scan(&count))
-	assert.Equal(t, 1, count, "thread_messages_by_thread row written")
+		got := read()
+		assert.Equal(t, "ts-comb", got.ID)
+		assert.Equal(t, "u-comb", got.UserID)
+		require.NotNil(t, got.LastSeenAt, "lastSeenAt must be seeded by $max on insert")
+		assert.WithinDuration(t, now, got.LastSeenAt.UTC(), time.Millisecond)
+		assert.Equal(t, now, got.CreatedAt.UTC().Truncate(time.Millisecond))
+	})
 
-	var gotTShow bool
-	require.NoError(t, cassSession.Query(
-		`SELECT tshow FROM messages_by_room WHERE room_id = ? AND bucket = ? AND created_at = ? AND message_id = ?`,
-		"r-tshow", bucket.Of(now), now, "m-tshow").WithContext(ctx).Scan(&gotTShow))
-	assert.True(t, gotTShow, "tshow mirror row written to messages_by_room with tshow=true")
+	t.Run("advances lastSeenAt forward on an existing subscription without overwriting identity", func(t *testing.T) {
+		later := now.Add(time.Minute)
+		// A redelivered/duplicate insert attempt with a fresh ID must not replace the original.
+		dup := *sub
+		dup.ID = "ts-comb-dup"
+		require.NoError(t, store.UpsertThreadSubscriptionAdvancingLastSeen(ctx, &dup, later))
+
+		got := read()
+		assert.Equal(t, "ts-comb", got.ID, "$setOnInsert must not overwrite the original _id")
+		require.NotNil(t, got.LastSeenAt)
+		assert.WithinDuration(t, later, got.LastSeenAt.UTC(), time.Millisecond, "newer time advances")
+	})
+
+	t.Run("never regresses lastSeenAt", func(t *testing.T) {
+		earlier := now.Add(-time.Minute)
+		require.NoError(t, store.UpsertThreadSubscriptionAdvancingLastSeen(ctx, sub, earlier))
+
+		got := read()
+		require.NotNil(t, got.LastSeenAt)
+		assert.WithinDuration(t, now.Add(time.Minute), got.LastSeenAt.UTC(), time.Millisecond,
+			"$max must keep the later value")
+	})
 }

--- a/message-worker/mock_store_test.go
+++ b/message-worker/mock_store_test.go
@@ -201,6 +201,21 @@ func (mr *MockThreadStoreMockRecorder) EnsureThreadRoom(ctx, room any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureThreadRoom", reflect.TypeOf((*MockThreadStore)(nil).EnsureThreadRoom), ctx, room)
 }
 
+// GetHistorySharedSince mocks base method.
+func (m *MockThreadStore) GetHistorySharedSince(ctx context.Context, roomID string, accounts []string) (map[string]*time.Time, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHistorySharedSince", ctx, roomID, accounts)
+	ret0, _ := ret[0].(map[string]*time.Time)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHistorySharedSince indicates an expected call of GetHistorySharedSince.
+func (mr *MockThreadStoreMockRecorder) GetHistorySharedSince(ctx, roomID, accounts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistorySharedSince", reflect.TypeOf((*MockThreadStore)(nil).GetHistorySharedSince), ctx, roomID, accounts)
+}
+
 // InsertThreadSubscription mocks base method.
 func (m *MockThreadStore) InsertThreadSubscription(ctx context.Context, sub *model.ThreadSubscription) error {
 	m.ctrl.T.Helper()

--- a/message-worker/mock_store_test.go
+++ b/message-worker/mock_store_test.go
@@ -185,48 +185,20 @@ func (mr *MockThreadStoreMockRecorder) AdvanceThreadSubscriptionLastSeen(ctx, th
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdvanceThreadSubscriptionLastSeen", reflect.TypeOf((*MockThreadStore)(nil).AdvanceThreadSubscriptionLastSeen), ctx, threadRoomID, account, at)
 }
 
-// CreateThreadRoom mocks base method.
-func (m *MockThreadStore) CreateThreadRoom(ctx context.Context, room *model.ThreadRoom) error {
+// EnsureThreadRoom mocks base method.
+func (m *MockThreadStore) EnsureThreadRoom(ctx context.Context, room *model.ThreadRoom) (*model.ThreadRoom, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateThreadRoom", ctx, room)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateThreadRoom indicates an expected call of CreateThreadRoom.
-func (mr *MockThreadStoreMockRecorder) CreateThreadRoom(ctx, room any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateThreadRoom", reflect.TypeOf((*MockThreadStore)(nil).CreateThreadRoom), ctx, room)
-}
-
-// GetHistorySharedSince mocks base method.
-func (m *MockThreadStore) GetHistorySharedSince(ctx context.Context, roomID string, accounts []string) (map[string]*time.Time, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHistorySharedSince", ctx, roomID, accounts)
-	ret0, _ := ret[0].(map[string]*time.Time)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetHistorySharedSince indicates an expected call of GetHistorySharedSince.
-func (mr *MockThreadStoreMockRecorder) GetHistorySharedSince(ctx, roomID, accounts any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistorySharedSince", reflect.TypeOf((*MockThreadStore)(nil).GetHistorySharedSince), ctx, roomID, accounts)
-}
-
-// GetThreadRoomByParentMessageID mocks base method.
-func (m *MockThreadStore) GetThreadRoomByParentMessageID(ctx context.Context, parentMessageID string) (*model.ThreadRoom, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetThreadRoomByParentMessageID", ctx, parentMessageID)
+	ret := m.ctrl.Call(m, "EnsureThreadRoom", ctx, room)
 	ret0, _ := ret[0].(*model.ThreadRoom)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
-// GetThreadRoomByParentMessageID indicates an expected call of GetThreadRoomByParentMessageID.
-func (mr *MockThreadStoreMockRecorder) GetThreadRoomByParentMessageID(ctx, parentMessageID any) *gomock.Call {
+// EnsureThreadRoom indicates an expected call of EnsureThreadRoom.
+func (mr *MockThreadStoreMockRecorder) EnsureThreadRoom(ctx, room any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThreadRoomByParentMessageID", reflect.TypeOf((*MockThreadStore)(nil).GetThreadRoomByParentMessageID), ctx, parentMessageID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureThreadRoom", reflect.TypeOf((*MockThreadStore)(nil).EnsureThreadRoom), ctx, room)
 }
 
 // InsertThreadSubscription mocks base method.
@@ -283,4 +255,18 @@ func (m *MockThreadStore) UpsertThreadSubscription(ctx context.Context, sub *mod
 func (mr *MockThreadStoreMockRecorder) UpsertThreadSubscription(ctx, sub any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertThreadSubscription", reflect.TypeOf((*MockThreadStore)(nil).UpsertThreadSubscription), ctx, sub)
+}
+
+// UpsertThreadSubscriptionAdvancingLastSeen mocks base method.
+func (m *MockThreadStore) UpsertThreadSubscriptionAdvancingLastSeen(ctx context.Context, sub *model.ThreadSubscription, at time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertThreadSubscriptionAdvancingLastSeen", ctx, sub, at)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertThreadSubscriptionAdvancingLastSeen indicates an expected call of UpsertThreadSubscriptionAdvancingLastSeen.
+func (mr *MockThreadStoreMockRecorder) UpsertThreadSubscriptionAdvancingLastSeen(ctx, sub, at any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertThreadSubscriptionAdvancingLastSeen", reflect.TypeOf((*MockThreadStore)(nil).UpsertThreadSubscriptionAdvancingLastSeen), ctx, sub, at)
 }

--- a/message-worker/store.go
+++ b/message-worker/store.go
@@ -30,8 +30,11 @@ type Store interface {
 
 // ThreadStore defines MongoDB operations for thread room and subscription management.
 type ThreadStore interface {
-	CreateThreadRoom(ctx context.Context, room *model.ThreadRoom) error
-	GetThreadRoomByParentMessageID(ctx context.Context, parentMessageID string) (*model.ThreadRoom, error)
+	// EnsureThreadRoom returns the thread room for room.ParentMessageID, atomically creating
+	// it from room when absent — a single round trip via an upserting FindOneAndUpdate, so the
+	// hot subsequent-reply path never attempts (and fails) an insert against the unique index.
+	// created is true iff this call inserted the room (i.e. this is the first reply).
+	EnsureThreadRoom(ctx context.Context, room *model.ThreadRoom) (stored *model.ThreadRoom, created bool, err error)
 	InsertThreadSubscription(ctx context.Context, sub *model.ThreadSubscription) error
 	UpsertThreadSubscription(ctx context.Context, sub *model.ThreadSubscription) error
 	// MarkThreadSubscriptionMention flags sub as mentioned, unless the account
@@ -54,4 +57,11 @@ type ThreadStore interface {
 	// implies they've seen up to their own reply, keeping the thread read-floor
 	// (minUserLastSeenAt) from counting the replier against it (#396).
 	AdvanceThreadSubscriptionLastSeen(ctx context.Context, threadRoomID, account string, at time.Time) error
+	// UpsertThreadSubscriptionAdvancingLastSeen creates sub's (threadRoomId, userAccount)
+	// subscription when missing and advances its lastSeenAt to at via $max, in a single
+	// write. It merges UpsertThreadSubscription + AdvanceThreadSubscriptionLastSeen for the
+	// replier on the hot path: replying implies the replier has seen up to their own reply
+	// (#396), so the new sub is seeded with lastSeenAt=at and an existing one is moved
+	// forward (never backward).
+	UpsertThreadSubscriptionAdvancingLastSeen(ctx context.Context, sub *model.ThreadSubscription, at time.Time) error
 }

--- a/message-worker/store_mongo.go
+++ b/message-worker/store_mongo.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -11,11 +10,6 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/hmchangw/chat/pkg/model"
-)
-
-var (
-	errThreadRoomExists   = errors.New("thread room already exists")
-	errThreadRoomNotFound = errors.New("thread room not found")
 )
 
 type threadStoreMongo struct {
@@ -59,30 +53,34 @@ func (s *threadStoreMongo) EnsureIndexes(ctx context.Context) error {
 	return nil
 }
 
-func (s *threadStoreMongo) CreateThreadRoom(ctx context.Context, room *model.ThreadRoom) error {
-	toInsert := *room
-	if toInsert.ReplyAccounts == nil {
-		toInsert.ReplyAccounts = []string{}
+// EnsureThreadRoom resolves the thread room for room.ParentMessageID in a single round
+// trip: an upserting FindOneAndUpdate whose $setOnInsert seeds the new room only when
+// absent, returning the post-image either way. The common subsequent-reply path matches
+// the existing room (no insert, no dup-key); the first reply inserts and returns it. created
+// is reported by comparing the returned _id to the candidate's — they match only on insert.
+// A rare concurrent first-reply can still surface a duplicate-key error (two upserts racing
+// the unique parentMessageId index); we resolve it by reading the now-existing room.
+func (s *threadStoreMongo) EnsureThreadRoom(ctx context.Context, room *model.ThreadRoom) (*model.ThreadRoom, bool, error) {
+	candidate := *room
+	if candidate.ReplyAccounts == nil {
+		candidate.ReplyAccounts = []string{}
 	}
-	_, err := s.threadRooms.InsertOne(ctx, &toInsert)
+	filter := bson.M{"parentMessageId": candidate.ParentMessageID}
+	opts := options.FindOneAndUpdate().SetUpsert(true).SetReturnDocument(options.After)
+
+	var stored model.ThreadRoom
+	err := s.threadRooms.FindOneAndUpdate(ctx, filter, bson.M{"$setOnInsert": candidate}, opts).Decode(&stored)
 	if err != nil {
 		if mongo.IsDuplicateKeyError(err) {
-			return fmt.Errorf("insert thread room: %w", errThreadRoomExists)
+			// Lost the insert race to a concurrent first reply: the room now exists, read it.
+			if ferr := s.threadRooms.FindOne(ctx, filter).Decode(&stored); ferr != nil {
+				return nil, false, fmt.Errorf("read thread room after upsert race for parent %s: %w", candidate.ParentMessageID, ferr)
+			}
+			return &stored, false, nil
 		}
-		return fmt.Errorf("insert thread room: %w", err)
+		return nil, false, fmt.Errorf("ensure thread room for parent %s: %w", candidate.ParentMessageID, err)
 	}
-	return nil
-}
-
-func (s *threadStoreMongo) GetThreadRoomByParentMessageID(ctx context.Context, parentMessageID string) (*model.ThreadRoom, error) {
-	var room model.ThreadRoom
-	if err := s.threadRooms.FindOne(ctx, bson.M{"parentMessageId": parentMessageID}).Decode(&room); err != nil {
-		if errors.Is(err, mongo.ErrNoDocuments) {
-			return nil, fmt.Errorf("find thread room by parent %s: %w", parentMessageID, errThreadRoomNotFound)
-		}
-		return nil, fmt.Errorf("find thread room by parent %s: %w", parentMessageID, err)
-	}
-	return &room, nil
+	return &stored, stored.ID == candidate.ID, nil
 }
 
 func (s *threadStoreMongo) InsertThreadSubscription(ctx context.Context, sub *model.ThreadSubscription) error {
@@ -167,6 +165,35 @@ func (s *threadStoreMongo) AdvanceThreadSubscriptionLastSeen(ctx context.Context
 		bson.M{"$max": bson.M{"lastSeenAt": at}},
 	); err != nil {
 		return fmt.Errorf("advance thread lastSeenAt for %q in thread room %q: %w", account, threadRoomID, err)
+	}
+	return nil
+}
+
+// UpsertThreadSubscriptionAdvancingLastSeen creates the (threadRoomId, userAccount)
+// subscription via $setOnInsert when missing and advances its lastSeenAt to at via $max,
+// in one write. It folds UpsertThreadSubscription + AdvanceThreadSubscriptionLastSeen for
+// the replier on the hot path. lastSeenAt is owned exclusively by $max (never $setOnInsert)
+// so the two operators don't conflict: a new sub is seeded with lastSeenAt=at, an existing
+// one is moved forward only (never backward).
+func (s *threadStoreMongo) UpsertThreadSubscriptionAdvancingLastSeen(ctx context.Context, sub *model.ThreadSubscription, at time.Time) error {
+	filter := bson.M{"threadRoomId": sub.ThreadRoomID, "userAccount": sub.UserAccount}
+	update := bson.M{
+		"$setOnInsert": bson.M{
+			"_id":             sub.ID,
+			"parentMessageId": sub.ParentMessageID,
+			"roomId":          sub.RoomID,
+			"threadRoomId":    sub.ThreadRoomID,
+			"userId":          sub.UserID,
+			"userAccount":     sub.UserAccount,
+			"siteId":          sub.SiteID,
+			"hasMention":      sub.HasMention,
+			"createdAt":       sub.CreatedAt,
+			"updatedAt":       sub.UpdatedAt,
+		},
+		"$max": bson.M{"lastSeenAt": at},
+	}
+	if _, err := s.threadSubscriptions.UpdateOne(ctx, filter, update, options.UpdateOne().SetUpsert(true)); err != nil {
+		return fmt.Errorf("upsert thread subscription advancing lastSeen: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Context

Investigating high MongoDB CPU under the **thread `max-rps`** load test. This PR removes work that `message-worker` does on **every subsequent thread reply**. It&#39;s three focused reductions on the thread-reply hot path.

## What changed

**1. `thread_subscriptions` writes: 3 → 1 per reply**
- Drop the parent-author subscription re-upsert on subsequent replies — it&#39;s created once, on the first reply — along with its owner-site `FindUserByID` read.
- Fold the replier&#39;s own `lastSeenAt` `$max` into the replier subscription upsert via a new `UpsertThreadSubscriptionAdvancingLastSeen` (`$setOnInsert` + `$max` in one write, non-conflicting because `lastSeenAt` is owned solely by `$max`).
- The standalone `AdvanceThreadSubscriptionLastSeen` now runs only on paths that write no replier sub (migration, self-reply, system message).

**2. Thread-room resolution: 1 round trip (both first and subsequent replies)**
- Replace the create-first pattern (`CreateThreadRoom` → duplicate-key → `GetThreadRoomByParentMessageID`) with an upserting `EnsureThreadRoom` (`FindOneAndUpdate` with `$setOnInsert` + `ReturnDocument:After`).
- One round trip, no failed unique-index insert on the hot path; the caller distinguishes first-vs-subsequent by comparing the returned `_id` to the candidate&#39;s. A rare concurrent-first-reply dup-key is resolved with a single read.

**3. Stop re-stamping the parent&#39;s `thread_room_id` on every subsequent reply**
- It&#39;s immutable and already stamped once, on the first reply (`handleFirstThreadReply`). Removes one Cassandra write per subsequent reply.

## Trade-offs (intentional)
Narrow crash windows, not worth a per-reply write to self-heal: if a first reply creates the room but crashes before writing the parent subscription / parent stamp, those stay unset for that thread. Same class of trade-off across all three changes.

## Important finding — this does not move max RPS on its own
Profiling during the load test showed the thread `max-rps` ceiling (~500–600, with a growing consumer backlog and E1/E2 P95 creeping over SLO) is bounded by **worker concurrency, not DB CPU**: `MAX_WORKERS` and the Mongo connection pool both default to **100**, while every resource sits at **≤70%**. `drain rate ≈ MaxWorkers / per-msg-latency ≈ 100/200ms ≈ 500/s`, so the backlog grows at ~600 offered.

These changes lower per-reply Mongo/Cassandra **load**, which raises the DB ceiling **once concurrency is unblocked** — but the lever that actually moves the number is raising `MAX_WORKERS` and `maxPoolSize` together (they must move together, or the pool re-caps at 100). That&#39;s a config change, tracked separately.

## Scope &amp; testing
- Contained to `message-worker` (a `MESSAGES_CANONICAL` JetStream consumer — not a `chat.user.*` client-facing handler, so no `docs/client-api.md` change).
- `make test` (full suite, race) green; `make lint` clean; `make sast-gosec` clean; integration build compiles (`EnsureThreadRoom` + combined-upsert integration tests added).
- Rebased onto `main` (linear history, no merge commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Summary by CodeRabbit

* **New Features**
  * Improved thread reply handling to ensure thread rooms are created/reused and to update read state more precisely when replies arrive.

* **Bug Fixes**
  * Prevented subscription “last seen” timestamps from regressing or being redundantly advanced.
  * Improved reliability for thread replies when the parent message is missing and when threads are migrated.
  * Adjusted subsequent-reply subscription updates to avoid unnecessary parent-related writes.

* **Tests**
  * Updated unit and Mongo integration tests to reflect the new thread-room ensuring and combined “upsert + advance” last-seen behavior.