### PR TITLE
Handle transient infra failures with backoff in JetStream processing

### DIFF
--- a/message-gatekeeper/handler.go
+++ b/message-gatekeeper/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/errcode/errnats"
 	"github.com/hmchangw/chat/pkg/idgen"
+	"github.com/hmchangw/chat/pkg/jsretry"
 	"github.com/hmchangw/chat/pkg/logctx"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/model/cassandra"
@@ -141,9 +142,10 @@ func (h *Handler) HandleJetStreamMsg(ctx context.Context, msg jetstream.Msg) {
 			// flow terminal for the infra path; the Error line below carries the cause.
 			slog.Log(ctx, logctx.LevelFlow, "gatekeeper nak", "phase", "nak", "request_id", req.RequestID)
 			slog.ErrorContext(ctx, "process message failed (infra)", "error", err, "account", account, "room_id", roomID)
-			if err := msg.Nak(); err != nil {
-				slog.Error("failed to nack message", "error", err)
-			}
+			// Transient infra failure: back off redelivery rather than instant-Nak
+			// (which could burn through MaxDeliver on a brief outage). Already logged
+			// above, so settle quietly.
+			jsretry.SettleQuiet(ctx, msg, jsretry.DefaultBackoff, err)
 		}
 		return
 	}

--- a/message-gatekeeper/handler_test.go
+++ b/message-gatekeeper/handler_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hmchangw/chat/pkg/errcode/errnats"
 	"github.com/hmchangw/chat/pkg/errcode/errtest"
 	"github.com/hmchangw/chat/pkg/idgen"
+	"github.com/hmchangw/chat/pkg/jsretry"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/pkg/natsutil"
@@ -1783,11 +1784,12 @@ func TestHandler_sendReply(t *testing.T) {
 // ---- HandleJetStreamMsg coverage ----
 
 type fakeJSMsg struct {
-	subject string
-	data    []byte
-	headers nats.Header
-	acked   bool
-	naked   bool
+	subject  string
+	data     []byte
+	headers  nats.Header
+	acked    bool
+	naked    bool
+	nakDelay time.Duration
 }
 
 func (m *fakeJSMsg) Metadata() (*jetstream.MsgMetadata, error) { return nil, nil }
@@ -1798,7 +1800,7 @@ func (m *fakeJSMsg) Reply() string                             { return "" }
 func (m *fakeJSMsg) Ack() error                                { m.acked = true; return nil }
 func (m *fakeJSMsg) DoubleAck(context.Context) error           { m.acked = true; return nil }
 func (m *fakeJSMsg) Nak() error                                { m.naked = true; return nil }
-func (m *fakeJSMsg) NakWithDelay(time.Duration) error          { m.naked = true; return nil }
+func (m *fakeJSMsg) NakWithDelay(d time.Duration) error        { m.naked = true; m.nakDelay = d; return nil }
 func (m *fakeJSMsg) InProgress() error                         { return nil }
 func (m *fakeJSMsg) Term() error                               { return nil }
 func (m *fakeJSMsg) TermWithReason(string) error               { return nil }
@@ -1834,6 +1836,31 @@ func TestHandleJetStreamMsg_InvalidSubject_Acks(t *testing.T) {
 	h.HandleJetStreamMsg(context.Background(), msg)
 	assert.True(t, msg.acked, "invalid subject must Ack — not retryable")
 	assert.False(t, msg.naked)
+}
+
+// A transient infra failure (bare, non-errcode error) must NakWithDelay using
+// the jsretry backoff schedule — not an instant Nak that could burn through
+// MaxDeliver during a brief outage. Metadata() is nil here, so jsretry falls
+// back to the first backoff entry.
+func TestHandleJetStreamMsg_InfraError_NaksWithBackoff(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	store.EXPECT().
+		GetSubscription(gomock.Any(), "alice", "room-1").
+		Return(nil, fmt.Errorf("connection refused"))
+
+	h := NewHandler(store, nil, makePublishFunc(nil, nil),
+		func(context.Context, *nats.Msg) error { return nil }, "site-a", nil, 500, 1, 8192, "")
+
+	req := model.SendMessageRequest{ID: idgen.GenerateMessageID(), Content: "hello", RequestID: "01970a4f-8c2d-7c9a-abcd-e0123456789f"}
+	data, _ := json.Marshal(req)
+	msg := &fakeJSMsg{subject: "chat.user.alice.room.room-1.site-a.msg.send", data: data}
+
+	h.HandleJetStreamMsg(context.Background(), msg)
+
+	assert.False(t, msg.acked, "infra failure must not Ack")
+	assert.True(t, msg.naked, "infra failure must Nak for redelivery")
+	assert.Equal(t, jsretry.DefaultBackoff[0], msg.nakDelay, "infra Nak must use the jsretry backoff delay, not an instant Nak")
 }
 
 // TestHandler_processMessage_RequestTShowMapsToTShow verifies the

--- a/message-worker/integration_test.go
+++ b/message-worker/integration_test.go
@@ -1074,6 +1074,41 @@ func TestThreadStoreMongo_UpdateThreadRoomLastMessage(t *testing.T) {
 	assert.Contains(t, got.ReplyAccounts, "bob", "replier account should be added to ReplyAccounts")
 }
 
+// TestThreadStoreMongo_UpdateThreadRoomLastMessage_StaleDoesNotRegress verifies
+// the monotonicity guard: an out-of-order (retried or concurrently-processed)
+// reply whose lastMsgAt is older than the stored pointer must NOT regress
+// lastMsgAt/lastMsgId, while its author is still merged into replyAccounts
+// (which is order-independent).
+func TestThreadStoreMongo_UpdateThreadRoomLastMessage_StaleDoesNotRegress(t *testing.T) {
+	ctx := context.Background()
+	db := setupMongo(t)
+	store := newThreadStoreMongo(db)
+	require.NoError(t, store.EnsureIndexes(ctx))
+
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	room := &model.ThreadRoom{
+		ID:              "tr-stale",
+		ParentMessageID: "msg-parent-stale",
+		RoomID:          "r-1",
+		SiteID:          "site-a",
+		LastMsgAt:       now,
+		LastMsgID:       "msg-newest",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	require.NoError(t, store.CreateThreadRoom(ctx, room))
+
+	older := now.Add(-5 * time.Minute)
+	err := store.UpdateThreadRoomLastMessage(ctx, "tr-stale", "msg-older", []string{"carol"}, older)
+	require.NoError(t, err)
+
+	got, err := store.GetThreadRoomByParentMessageID(ctx, "msg-parent-stale")
+	require.NoError(t, err)
+	assert.Equal(t, "msg-newest", got.LastMsgID, "stale reply must not regress lastMsgId")
+	assert.Equal(t, now, got.LastMsgAt.UTC().Truncate(time.Millisecond), "stale reply must not regress lastMsgAt")
+	assert.Contains(t, got.ReplyAccounts, "carol", "stale reply author must still be merged into ReplyAccounts")
+}
+
 func TestCassandraStore_SaveThreadMessage_IncrementsParentTcount(t *testing.T) {
 	cassSession := setupCassandra(t)
 	store := NewCassandraStore(cassSession, msgbucket.New(24*time.Hour), nil)

--- a/message-worker/store_mongo.go
+++ b/message-worker/store_mongo.go
@@ -143,17 +143,24 @@ func (s *threadStoreMongo) MarkThreadSubscriptionMention(ctx context.Context, su
 }
 
 func (s *threadStoreMongo) UpdateThreadRoomLastMessage(ctx context.Context, threadRoomID, lastMsgID string, replyAccounts []string, lastMsgAt time.Time) error {
-	update := bson.M{
-		"$set": bson.M{
-			"lastMsgAt": lastMsgAt,
-			"lastMsgId": lastMsgID,
-			"updatedAt": lastMsgAt,
-		},
+	// Guard the last-message pointer with $cond so an out-of-order reply (a
+	// retry, or one processed concurrently ahead of an earlier sibling) whose
+	// lastMsgAt is older than the stored value cannot regress the pointer.
+	// replyAccounts is order-independent, so it is always merged via $setUnion.
+	// A single aggregation-pipeline update keeps this to one round-trip.
+	newer := bson.M{"$gt": bson.A{lastMsgAt, "$lastMsgAt"}}
+	set := bson.M{
+		"lastMsgAt": bson.M{"$cond": bson.A{newer, lastMsgAt, "$lastMsgAt"}},
+		"lastMsgId": bson.M{"$cond": bson.A{newer, lastMsgID, "$lastMsgId"}},
+		"updatedAt": bson.M{"$cond": bson.A{newer, lastMsgAt, "$updatedAt"}},
 	}
 	if len(replyAccounts) > 0 {
-		update["$addToSet"] = bson.M{"replyAccounts": bson.M{"$each": replyAccounts}}
+		set["replyAccounts"] = bson.M{
+			"$setUnion": bson.A{bson.M{"$ifNull": bson.A{"$replyAccounts", bson.A{}}}, replyAccounts},
+		}
 	}
-	if _, err := s.threadRooms.UpdateOne(ctx, bson.M{"_id": threadRoomID}, update); err != nil {
+	pipeline := mongo.Pipeline{bson.D{{Key: "$set", Value: set}}}
+	if _, err := s.threadRooms.UpdateOne(ctx, bson.M{"_id": threadRoomID}, pipeline); err != nil {
 		return fmt.Errorf("update thread room last message: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Summary
Improve resilience to transient infrastructure failures during JetStream message processing by using exponential backoff on redelivery instead of instant negative acknowledgment, which could exhaust `MaxDeliver` during brief outages. Also add a monotonicity guard to thread room last-message tracking to prevent out-of-order replies from regressing the pointer.

## Key Changes

### message-gatekeeper: Backoff on transient infra failures
- Import `jsretry` package for backoff scheduling
- Replace instant `msg.Nak()` with `jsretry.SettleQuiet()` when a transient infra error (non-errcode) occurs during message processing
- This uses the `jsretry.DefaultBackoff` schedule to delay redelivery, preventing rapid retry storms that could burn through `MaxDeliver` during a brief outage
- Add test `TestHandleJetStreamMsg_InfraError_NaksWithBackoff` to verify infra failures use backoff delay instead of instant Nak

### message-worker: Monotonicity guard for thread room last-message pointer
- Refactor `UpdateThreadRoomLastMessage` to use MongoDB aggregation-pipeline update with `$cond` operators
- Guard `lastMsgAt` and `lastMsgId` updates so an out-of-order reply (retry or concurrent processing) whose timestamp is older than the stored value cannot regress the pointer
- Merge `replyAccounts` via `$setUnion` (order-independent) instead of `$addToSet` to ensure consistent behavior in the aggregation pipeline
- Add test `TestThreadStoreMongo_UpdateThreadRoomLastMessage_StaleDoesNotRegress` to verify stale replies do not regress the pointer while still being merged into reply accounts

## Implementation Details
- `jsretry.SettleQuiet()` handles the backoff logic and logs are already emitted before the call, so settlement is quiet
- The aggregation-pipeline update keeps the last-message update to a single round-trip, improving atomicity
- Both changes address failure modes in distributed async processing: transient infra failures and out-of-order message delivery

https://claude.ai/code/session_01C1BxH1hihMsa5NbrU1JJ6H