### PR TITLE
feat(history-service): rooms.get — batch room last-message read (#393)

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -906,7 +906,20 @@ top-level `siteId`. All fields are optional (omitted when zero/unset).
 | `minUserLastSeenAt` | RFC3339 timestamp | The room-wide read floor — the oldest `lastSeenAt` across the room's members ("everyone has read up to here"). Omitted when the floor is unset (a member is still fully unread). |
 | `privateKey` | string | Base64-encoded room E2E private key — initial key bootstrap for room members (see [§5](#5-room-encryption)). Present only for encrypted (channel) rooms whose key the caller's site holds; omitted otherwise. |
 | `keyVersion` | number | Version of `privateKey`. |
-| `lastMessage` | [LastMessage](#lastmessage) | Optional. The room's latest message, resolved at read time via the [Get Rooms Last Message](#get-rooms-last-message) RPC (server-side, one call per site). Omitted when the room has no message or that site's enrichment degraded — best-effort, never fails the list. |
+| `lastMessage` | [LastMessage](#lastmessage) | Optional. The room's latest non-deleted message, resolved server-side at read time. Omitted when the room has no message, or that site's enrichment degraded, or the request set `includeLastMessage: false` — best-effort, never fails the list. |
+
+##### LastMessage
+
+A room's most-recent **non-deleted** message, resolved at read time and preview-trimmed.
+Soft-deleted messages are skipped (walked back to an earlier survivor); a room with only
+deleted messages omits `lastMessage`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `messageId` | string | |
+| `sender` | [Participant](#participant) | |
+| `content` | string | Preview-trimmed to 256 runes. |
+| `createdAt` | int64 | UTC milliseconds. |
 
 #### AppSubscription
 
@@ -2988,72 +3001,6 @@ See [Error envelope](#6-error-envelope-reference).
 
 ---
 
-#### Get Rooms Last Message
-
-**Subject:** `chat.user.{account}.request.history.{siteID}.rooms.get`
-**Reply subject:** auto-generated `_INBOX.>` (NATS request/reply)
-
-Batch resolve — for each requested room the caller can access, returns its **latest message**, resolved at read time. `subscription.list` calls this server-side (one batch per site, chunked at 100 roomIds) to embed each room's [`lastMessage`](#subscriptionroom) — clients render the room-list snippet from that field rather than calling this RPC directly. It remains available as a standalone RPC for callers that need it directly (e.g. a client refreshing one room's snippet without a full list re-fetch). One call per site: `{siteID}` is the rooms' origin site, and all `roomIds` must belong to that site.
-
-##### Request body
-
-| Field | Type | Required | Notes |
-|---|---|---|---|
-| `roomIds` | string[] | yes | Rooms whose last message to fetch. Non-empty; maximum 100. |
-
-```json
-{ "roomIds": ["01970a4f8c2d7c9aQ", "01970a4f8c2d7c9aR"] }
-```
-
-##### Success response
-
-| Field | Type | Notes |
-|---|---|---|
-| `rooms` | map<roomId, [LastMessage](#lastmessage)> | Per-room latest message. A room with no message, that the caller can't access, or whose read degraded is **omitted** — best-effort, a single bad room never fails the batch. |
-
-###### LastMessage
-
-| Field | Type | Notes |
-|---|---|---|
-| `messageId` | string | |
-| `sender` | [Participant](#participant) | |
-| `content` | string | Preview-trimmed to 256 runes. |
-| `createdAt` | int64 | UTC milliseconds. |
-| `deleted` | boolean | Present and `true` when the latest message is soft-deleted — returned as-is, with no walk-back to an earlier surviving message. |
-
-```json
-{
-  "rooms": {
-    "01970a4f8c2d7c9aQ": {
-      "messageId": "01970a4f8c2d7c9aQRST",
-      "sender": { "id": "01970a4f8c2d7c9a01970a4f8c2d7c9a", "account": "alice" },
-      "content": "morning team",
-      "createdAt": 1746518100000
-    }
-  }
-}
-```
-
-##### Error response
-
-See [Error envelope](#6-error-envelope-reference).
-
-| Condition | `code` | `error` |
-|---|---|---|
-| Empty `roomIds` | `bad_request` | `roomIds must not be empty` |
-| `roomIds` length exceeds 100 | `bad_request` | `too many roomIds` |
-| Store failure | `internal` | `internal error` |
-
-##### Triggered events — success path
-
-`None — reply only.`
-
-##### Triggered events — error path
-
-`None — error returned only via the reply subject.`
-
----
-
 #### Edit Message
 
 **Subject:** `chat.user.{account}.request.room.{roomID}.{siteID}.msg.edit`
@@ -4318,6 +4265,7 @@ Returns the user's sidebar subscriptions, optionally filtered by type, age, and 
 | `type`              | string  | yes      | One of `"current"` (active rooms), `"rooms"` (DM and channel subscriptions), `"apps"` (botDM rooms). |
 | `favorite`          | boolean | no       | When `true`, filters to favorited subscriptions only **and** moves the self-DM to the front of the list. |
 | `updatedWithinDays` | number  | no       | When set, filters **`rooms`-type** results to rooms **whose last message (`room.lastMsgAt`) is within the last N days** — room activity, not the subscription's update time. Cross-site rooms (no local `lastMsgAt`) fall outside the window. **Ignored for `current`** (always returns the full active set) and for `apps`. Omit for no age filter — the server applies no default; the client supplies any default it wants. Must be non-negative; a negative value is rejected with `bad_request`. |
+| `includeLastMessage` | boolean | no      | Whether to embed each room's [`lastMessage`](#subscriptionroom). Omitted ⇒ include (backward-compatible default); `false` ⇒ skip the per-room last-message resolve (a client that renders no room-list snippet can send `false` to save the server-side work). |
 | `offset`            | integer | no       | Zero-based index of the first record to return. Negative ⇒ `0`. Default `0`. |
 | `limit`             | integer | no       | Page size. Omitted or ≤ 0 ⇒ the server default `SUBSCRIPTION_DEFAULT_LIMIT` (default `40`); values above `MAX_SUBSCRIPTION_LIMIT` (default `1000`) are capped to it. |
 

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -906,6 +906,7 @@ top-level `siteId`. All fields are optional (omitted when zero/unset).
 | `minUserLastSeenAt` | RFC3339 timestamp | The room-wide read floor — the oldest `lastSeenAt` across the room's members ("everyone has read up to here"). Omitted when the floor is unset (a member is still fully unread). |
 | `privateKey` | string | Base64-encoded room E2E private key — initial key bootstrap for room members (see [§5](#5-room-encryption)). Present only for encrypted (channel) rooms whose key the caller's site holds; omitted otherwise. |
 | `keyVersion` | number | Version of `privateKey`. |
+| `lastMessage` | [LastMessage](#lastmessage) | Optional. The room's latest message, resolved at read time via the [Get Rooms Last Message](#get-rooms-last-message) RPC (server-side, one call per site). Omitted when the room has no message or that site's enrichment degraded — best-effort, never fails the list. |
 
 #### AppSubscription
 
@@ -2992,7 +2993,7 @@ See [Error envelope](#6-error-envelope-reference).
 **Subject:** `chat.user.{account}.request.history.{siteID}.rooms.get`
 **Reply subject:** auto-generated `_INBOX.>` (NATS request/reply)
 
-Batch resolve — for each requested room the caller can access, returns its **latest message**, resolved at read time. Used by the room list / mobile to render the last-message snippet. One call per site: `{siteID}` is the rooms' origin site, and all `roomIds` must belong to that site.
+Batch resolve — for each requested room the caller can access, returns its **latest message**, resolved at read time. `subscription.list` calls this server-side (one batch per site, chunked at 100 roomIds) to embed each room's [`lastMessage`](#subscriptionroom) — clients render the room-list snippet from that field rather than calling this RPC directly. It remains available as a standalone RPC for callers that need it directly (e.g. a client refreshing one room's snippet without a full list re-fetch). One call per site: `{siteID}` is the rooms' origin site, and all `roomIds` must belong to that site.
 
 ##### Request body
 
@@ -4390,7 +4391,13 @@ The example below shows one record of each type in order (`channel`, `dm`, `botD
         "lastMentionAllAt": "2026-05-30T08:00:00Z",
         "minUserLastSeenAt": "2026-05-30T07:55:00Z",
         "privateKey": "bDM4dGZ5...base64...JjT0g9PQ==",
-        "keyVersion": 3
+        "keyVersion": 3,
+        "lastMessage": {
+          "messageId": "01970a4f8c2d7c9aBB",
+          "sender": { "id": "01970a4f8c2d7c9a01970a4f8c2d7c9a", "account": "alice" },
+          "content": "morning team",
+          "createdAt": 1780308000000
+        }
       }
     },
     {

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -2987,6 +2987,72 @@ See [Error envelope](#6-error-envelope-reference).
 
 ---
 
+#### Get Rooms Last Message
+
+**Subject:** `chat.user.{account}.request.history.{siteID}.rooms.get`
+**Reply subject:** auto-generated `_INBOX.>` (NATS request/reply)
+
+Batch resolve — for each requested room the caller can access, returns its **latest message**, resolved at read time. Used by the room list / mobile to render the last-message snippet. One call per site: `{siteID}` is the rooms' origin site, and all `roomIds` must belong to that site.
+
+##### Request body
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `roomIds` | string[] | yes | Rooms whose last message to fetch. Non-empty; maximum 100. |
+
+```json
+{ "roomIds": ["01970a4f8c2d7c9aQ", "01970a4f8c2d7c9aR"] }
+```
+
+##### Success response
+
+| Field | Type | Notes |
+|---|---|---|
+| `rooms` | map<roomId, [LastMessage](#lastmessage)> | Per-room latest message. A room with no message, that the caller can't access, or whose read degraded is **omitted** — best-effort, a single bad room never fails the batch. |
+
+###### LastMessage
+
+| Field | Type | Notes |
+|---|---|---|
+| `messageId` | string | |
+| `sender` | [Participant](#participant) | |
+| `content` | string | Preview-trimmed to 256 runes. |
+| `createdAt` | int64 | UTC milliseconds. |
+| `deleted` | boolean | Present and `true` when the latest message is soft-deleted — returned as-is, with no walk-back to an earlier surviving message. |
+
+```json
+{
+  "rooms": {
+    "01970a4f8c2d7c9aQ": {
+      "messageId": "01970a4f8c2d7c9aQRST",
+      "sender": { "id": "01970a4f8c2d7c9a01970a4f8c2d7c9a", "account": "alice" },
+      "content": "morning team",
+      "createdAt": 1746518100000
+    }
+  }
+}
+```
+
+##### Error response
+
+See [Error envelope](#6-error-envelope-reference).
+
+| Condition | `code` | `error` |
+|---|---|---|
+| Empty `roomIds` | `bad_request` | `roomIds must not be empty` |
+| `roomIds` length exceeds 100 | `bad_request` | `too many roomIds` |
+| Store failure | `internal` | `internal error` |
+
+##### Triggered events — success path
+
+`None — reply only.`
+
+##### Triggered events — error path
+
+`None — error returned only via the reply subject.`
+
+---
+
 #### Edit Message
 
 **Subject:** `chat.user.{account}.request.room.{roomID}.{siteID}.msg.edit`

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -807,7 +807,6 @@ Optional; `roomId` field optional echo.
 | `chat.user.{account}.request.room.{roomID}.{siteID}.msg.surrounding` | [Load Surrounding Messages](#load-surrounding-messages) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.msg.get` | [Get Message By ID](#get-message-by-id) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.msg.get.ids` | [Get Messages By IDs](#get-messages-by-ids) |
-| `chat.user.{account}.request.history.{siteID}.rooms.get` | [Get Rooms Last Message](#get-rooms-last-message) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.msg.edit` | [Edit Message](#edit-message) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.msg.delete` | [Delete Message](#delete-message) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.msg.pin` | [Pin Message](#pin-message) |
@@ -1183,35 +1182,6 @@ on filter). Drives a "Threads" tab in the client.
 
 ---
 
-### Get Rooms Last Message
-
-**Subject:** `chat.user.{account}.request.history.{siteID}.rooms.get`
-
-`{siteID}` is the rooms' origin site; all `roomIds` must belong to it. Batch-resolves
-each accessible room's latest message at read time. `subscription.list` calls this
-server-side to embed each room's `lastMessage`; it is also callable directly.
-
-#### Request body
-
-| Field | Type | Notes |
-|---|---|---|
-| `roomIds` | string[] | Required, non-empty, max 100. |
-
-#### Success response
-
-`{ "rooms": map<roomId, LastMessage> }` — see the full `LastMessage` schema and
-semantics in [../client-api.md §history-service](../client-api.md#get-rooms-last-message).
-A room with no message, no access, or a degraded read is **omitted** — a single bad
-room never fails the batch.
-
-#### Errors
-
-`bad_request` when `roomIds` is empty or exceeds 100.
-
-**Emits:** None — reply only.
-
----
-
 ## search-service
 
 | RPC subject | Method |
@@ -1466,6 +1436,7 @@ Returns the user's sidebar subscriptions. **Room-info-enriched** — see
 | `type` | string | yes | `"current"` (active rooms), `"rooms"` (DM+channel), `"apps"` (botDM). |
 | `favorite` | boolean | no | Filter to favorited only; also pins the self-DM first. |
 | `updatedWithinDays` | number | no | `rooms`-type only. Filters to rooms whose `lastMsgAt` is within N days. Non-negative. |
+| `includeLastMessage` | boolean | no | Embed each room's `lastMessage`. Omitted ⇒ include (default); `false` ⇒ skip the last-message resolve. |
 | `offset` | integer | no | Zero-based index of first record. Negative ⇒ `0`. Default `0`. |
 | `limit` | integer | no | Page size. Omitted/≤0 ⇒ `SUBSCRIPTION_DEFAULT_LIMIT` (default `40`); capped at `MAX_SUBSCRIPTION_LIMIT` (default `1000`). |
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -807,6 +807,7 @@ Optional; `roomId` field optional echo.
 | `chat.user.{account}.request.room.{roomID}.{siteID}.msg.surrounding` | [Load Surrounding Messages](#load-surrounding-messages) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.msg.get` | [Get Message By ID](#get-message-by-id) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.msg.get.ids` | [Get Messages By IDs](#get-messages-by-ids) |
+| `chat.user.{account}.request.history.{siteID}.rooms.get` | [Get Rooms Last Message](#get-rooms-last-message) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.msg.edit` | [Edit Message](#edit-message) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.msg.delete` | [Delete Message](#delete-message) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.msg.pin` | [Pin Message](#pin-message) |
@@ -1177,6 +1178,35 @@ on filter). Drives a "Threads" tab in the client.
 |---|---|---|
 | `parentMessages` | Message[] | Ordered by most-recent reply activity. |
 | `total` | number | Raw count before access filtering. |
+
+**Emits:** None — reply only.
+
+---
+
+### Get Rooms Last Message
+
+**Subject:** `chat.user.{account}.request.history.{siteID}.rooms.get`
+
+`{siteID}` is the rooms' origin site; all `roomIds` must belong to it. Batch-resolves
+each accessible room's latest message at read time. `subscription.list` calls this
+server-side to embed each room's `lastMessage`; it is also callable directly.
+
+#### Request body
+
+| Field | Type | Notes |
+|---|---|---|
+| `roomIds` | string[] | Required, non-empty, max 100. |
+
+#### Success response
+
+`{ "rooms": map<roomId, LastMessage> }` — see the full `LastMessage` schema and
+semantics in [../client-api.md §history-service](../client-api.md#get-rooms-last-message).
+A room with no message, no access, or a degraded read is **omitted** — a single bad
+room never fails the batch.
+
+#### Errors
+
+`bad_request` when `roomIds` is empty or exceeds 100.
 
 **Emits:** None — reply only.
 

--- a/docs/superpowers/plans/2026-06-29-rooms-get-last-message.md
+++ b/docs/superpowers/plans/2026-06-29-rooms-get-last-message.md
@@ -1,0 +1,48 @@
+# `rooms.get` — room last-message endpoint (chat#393)
+
+**Closes:** hmchangw/chat#393 (A2 read-only, E2 `rooms.get`). Design locked in the
+#393 design-lock comment (2026-06-29, maintainer-approved by mliu33).
+
+**What:** a new history-service RPC `rooms.get` — the customer's `/api/v1/rooms.get`
+(mobile's room-last-message fetch). Per-site, account-scoped, **batch** `{roomIds[]}` →
+`{roomId → lastMessage}`, resolved at read time. Modeled on the existing
+`ThreadSubscriptionList` per-site history RPC.
+
+## Design (as built)
+- **Subject:** `chat.user.{account}.request.history.{siteID}.rooms.get` (account+site
+  from the subject; roomIds in the body). One batch RPC per site — the caller groups a
+  user's rooms by site and fans out, exactly like the thread-inbox.
+- **Resolution (history-service `RoomsGet` → `roomLastMessage`):** per room, run the
+  existing access check (`checkAccessAndRoomTimes`) then read the latest message via the
+  existing `messages_by_room … DESC` primitives (`GetMessagesBefore` /
+  `GetMessagesBetweenDesc`, limit 1) — respects the per-room access window + history
+  floor (mirrors LoadHistory). No new repo method.
+- **A2 read-only:** no denormalized write, no event, no edit/delete hooks, **no
+  walk-back** — a soft-deleted latest message is returned as-is with `deleted=true`.
+- **Best-effort batch:** bounded-concurrency (16) per-room resolve; a room that's
+  not-accessible / empty / errored is **omitted**, never failing the batch. Batch ≤ 100.
+- **Content** preview-trimmed to 256 runes.
+
+## Files
+- `pkg/subject/subject.go` — `RoomsGet` + `RoomsGetPattern` builders (+ test).
+- `history-service/internal/models/message.go` — `RoomsGetRequest`, `RoomsGetResponse`,
+  `LastMessage` (+ test).
+- `history-service/internal/service/rooms.go` — `RoomsGet` handler + `roomLastMessage`
+  resolver + `previewContent`/`dedupRoomIDs` helpers (+ test).
+- `history-service/internal/service/service.go` — register the handler.
+- `docs/client-api.md` — §3.2 "Get Rooms Last Message" (doc-ratchet).
+
+## Out of scope (follow-ups)
+- user-service room-list integration (calling `rooms.get` per-site during
+  `ListSubscriptions` for the web sidebar) — separate PR; this delivers the endpoint
+  the mobile calls.
+- `roomLastMsg` live event / edit-delete hooks (A2 read-only).
+
+## Verification
+- `go build ./pkg/subject/... ./history-service/...` — clean.
+- `go test -p 1 ./pkg/subject/... ./history-service/internal/models/... ./history-service/internal/service/...` — green.
+- Dev-stack NATS-wire e2e: pending (per the PR-dev-stack workflow).
+
+## PR / merge
+- Draft-first on `hmchangw/chat`; pr-self-audit (internal gate) + `/simplify` +
+  Jacob review + dev-stack e2e before ready; maintainer (mliu33/hmchangw) merges.

--- a/history-service/internal/models/message.go
+++ b/history-service/internal/models/message.go
@@ -73,29 +73,11 @@ type GetMessagesByIDsResponse struct {
 	Messages []Message `json:"messages"`
 }
 
-// RoomsGetRequest is the request body for the rooms.get batch RPC: the rooms whose
-// last message the caller wants. The account+site are taken from the subject.
-type RoomsGetRequest struct {
-	RoomIDs []string `json:"roomIds"`
-}
-
-// LastMessage is a room's most-recent message, resolved at read time (A2). Content
-// is preview-trimmed. Deleted is returned as-is — a soft-deleted last message
-// surfaces with deleted=true and no walk-back to an earlier surviving message.
-type LastMessage struct {
-	MessageID string      `json:"messageId"`
-	Sender    Participant `json:"sender"`
-	Content   string      `json:"content"`
-	CreatedAt int64       `json:"createdAt"` // UTC millis
-	Deleted   bool        `json:"deleted,omitempty"`
-}
-
-// RoomsGetResponse maps each requested roomId that has a resolvable last message to
-// it. Rooms with no message, or that the caller can't access, or that degraded, are
-// omitted (best-effort) rather than failing the whole batch.
-type RoomsGetResponse struct {
-	Rooms map[string]LastMessage `json:"rooms"`
-}
+// RoomsGetRequest/LastMessage/RoomsGetResponse are shared with user-service (which
+// embeds LastMessage into SubscriptionRoom), so the wire types live in pkg/model.
+type RoomsGetRequest = model.RoomsGetRequest
+type LastMessage = model.LastMessage
+type RoomsGetResponse = model.RoomsGetResponse
 
 type EditMessageRequest struct {
 	MessageID string `json:"messageId"`

--- a/history-service/internal/models/message.go
+++ b/history-service/internal/models/message.go
@@ -73,6 +73,30 @@ type GetMessagesByIDsResponse struct {
 	Messages []Message `json:"messages"`
 }
 
+// RoomsGetRequest is the request body for the rooms.get batch RPC: the rooms whose
+// last message the caller wants. The account+site are taken from the subject.
+type RoomsGetRequest struct {
+	RoomIDs []string `json:"roomIds"`
+}
+
+// LastMessage is a room's most-recent message, resolved at read time (A2). Content
+// is preview-trimmed. Deleted is returned as-is — a soft-deleted last message
+// surfaces with deleted=true and no walk-back to an earlier surviving message.
+type LastMessage struct {
+	MessageID string      `json:"messageId"`
+	Sender    Participant `json:"sender"`
+	Content   string      `json:"content"`
+	CreatedAt int64       `json:"createdAt"` // UTC millis
+	Deleted   bool        `json:"deleted,omitempty"`
+}
+
+// RoomsGetResponse maps each requested roomId that has a resolvable last message to
+// it. Rooms with no message, or that the caller can't access, or that degraded, are
+// omitted (best-effort) rather than failing the whole batch.
+type RoomsGetResponse struct {
+	Rooms map[string]LastMessage `json:"rooms"`
+}
+
 type EditMessageRequest struct {
 	MessageID string `json:"messageId"`
 	NewMsg    string `json:"newMsg"`

--- a/history-service/internal/models/roomsget_test.go
+++ b/history-service/internal/models/roomsget_test.go
@@ -1,0 +1,52 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoomsGetRequest_JSON(t *testing.T) {
+	req := RoomsGetRequest{RoomIDs: []string{"r1", "r2"}}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"roomIds":["r1","r2"]}`, string(data))
+
+	var decoded RoomsGetRequest
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, req, decoded)
+}
+
+func TestRoomsGetResponse_JSONRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		in   RoomsGetResponse
+	}{
+		{name: "empty", in: RoomsGetResponse{Rooms: map[string]LastMessage{}}},
+		{name: "one room", in: RoomsGetResponse{Rooms: map[string]LastMessage{
+			"r1": {MessageID: "m1", Sender: Participant{ID: "u1", Account: "alice"}, Content: "hi", CreatedAt: 1_714_000_000_000},
+		}}},
+		{name: "deleted last", in: RoomsGetResponse{Rooms: map[string]LastMessage{
+			"r2": {MessageID: "m9", Sender: Participant{ID: "u2", Account: "bob"}, Content: "", CreatedAt: 1_714_000_000_999, Deleted: true},
+		}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(tc.in)
+			require.NoError(t, err)
+			var got RoomsGetResponse
+			require.NoError(t, json.Unmarshal(data, &got))
+			assert.Equal(t, tc.in, got)
+		})
+	}
+}
+
+// deleted=false must be omitted from the wire (omitempty) so the common,
+// not-deleted case stays compact.
+func TestLastMessage_OmitsDeletedWhenFalse(t *testing.T) {
+	data, err := json.Marshal(LastMessage{MessageID: "m1", Content: "hi", CreatedAt: 1})
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "deleted")
+}

--- a/history-service/internal/models/roomsget_test.go
+++ b/history-service/internal/models/roomsget_test.go
@@ -28,9 +28,6 @@ func TestRoomsGetResponse_JSONRoundTrip(t *testing.T) {
 		{name: "one room", in: RoomsGetResponse{Rooms: map[string]LastMessage{
 			"r1": {MessageID: "m1", Sender: Participant{ID: "u1", Account: "alice"}, Content: "hi", CreatedAt: 1_714_000_000_000},
 		}}},
-		{name: "deleted last", in: RoomsGetResponse{Rooms: map[string]LastMessage{
-			"r2": {MessageID: "m9", Sender: Participant{ID: "u2", Account: "bob"}, Content: "", CreatedAt: 1_714_000_000_999, Deleted: true},
-		}}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -41,12 +38,4 @@ func TestRoomsGetResponse_JSONRoundTrip(t *testing.T) {
 			assert.Equal(t, tc.in, got)
 		})
 	}
-}
-
-// deleted=false must be omitted from the wire (omitempty) so the common,
-// not-deleted case stays compact.
-func TestLastMessage_OmitsDeletedWhenFalse(t *testing.T) {
-	data, err := json.Marshal(LastMessage{MessageID: "m1", Content: "hi", CreatedAt: 1})
-	require.NoError(t, err)
-	assert.NotContains(t, string(data), "deleted")
 }

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -1,0 +1,142 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/hmchangw/chat/history-service/internal/cassrepo"
+	"github.com/hmchangw/chat/history-service/internal/models"
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/natsrouter"
+	"github.com/hmchangw/chat/pkg/natsutil"
+)
+
+const (
+	maxRoomsGetBatch        = 100 // mirrors maxGetByIDsBatchSize
+	maxRoomsGetConcurrency  = 16  // mirrors cassrepo.maxConcurrentIDReads
+	lastMessagePreviewRunes = 256 // room-list snippet cap
+)
+
+// RoomsGet handles chat.user.{account}.request.history.{siteID}.rooms.get: for each
+// requested room the caller can access, return its latest message (A2 read-time,
+// no walk-back). Per-room failures (incl. not-subscribed) degrade to no entry so
+// one bad room never fails the batch.
+func (s *HistoryService) RoomsGet(c *natsrouter.Context, req models.RoomsGetRequest) (*models.RoomsGetResponse, error) {
+	account := c.Param("account")
+	c.WithLogValues("account", account)
+
+	if len(req.RoomIDs) == 0 {
+		return nil, errcode.BadRequest("roomIds must not be empty")
+	}
+	if len(req.RoomIDs) > maxRoomsGetBatch {
+		return nil, errcode.BadRequest("too many roomIds")
+	}
+
+	ids := dedupRoomIDs(req.RoomIDs)
+	now := time.Now().UTC()
+
+	out := make(map[string]models.LastMessage, len(ids))
+	var mu sync.Mutex
+	// WaitGroup+sem (not errgroup): per-room failures must degrade, never cancel
+	// siblings. Acquire sem before spawning so live goroutine count stays bounded.
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, maxRoomsGetConcurrency)
+	for _, roomID := range ids {
+		if c.Err() != nil {
+			break
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			lm, ok := s.roomLastMessage(c, account, roomID, now)
+			if !ok {
+				return
+			}
+			mu.Lock()
+			out[roomID] = lm
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	return &models.RoomsGetResponse{Rooms: out}, nil
+}
+
+// roomLastMessage resolves one room's latest message at read time. ok=false means
+// drop the room (not subscribed, empty, or a read failure). A soft-deleted latest
+// message is returned as-is with Deleted=true — no walk-back to an earlier survivor.
+func (s *HistoryService) roomLastMessage(ctx context.Context, account, roomID string, now time.Time) (models.LastMessage, bool) {
+	accessSince, lastMsgAt, createdAt, err := s.checkAccessAndRoomTimes(ctx, account, roomID, nil, now)
+	if err != nil {
+		slog.WarnContext(ctx, "rooms.get room degraded", "account", account, "room_id", roomID,
+			"request_id", natsutil.RequestIDFromContext(ctx), "error", err)
+		return models.LastMessage{}, false
+	}
+
+	pageReq, err := parsePageRequest("", 1)
+	if err != nil {
+		return models.LastMessage{}, false
+	}
+	// Cap the walk at the last message so a dormant room is a single-bucket read.
+	before := lastMsgAt.Add(time.Millisecond)
+
+	var page cassrepo.Page[models.Message]
+	if accessSince == nil {
+		// Clamp createdAt to the configured floor (mirrors LoadHistory).
+		historyFloor := now.Add(-s.historyFloor)
+		walkFloor := createdAt
+		if walkFloor.IsZero() || walkFloor.Before(historyFloor) {
+			walkFloor = historyFloor
+		}
+		page, err = s.msgReader.GetMessagesBefore(ctx, roomID, before, walkFloor, pageReq)
+	} else {
+		page, err = s.msgReader.GetMessagesBetweenDesc(ctx, roomID, *accessSince, before, pageReq)
+	}
+	if err != nil {
+		slog.WarnContext(ctx, "rooms.get latest-message read degraded", "account", account, "room_id", roomID,
+			"request_id", natsutil.RequestIDFromContext(ctx), "error", err)
+		return models.LastMessage{}, false
+	}
+	if len(page.Data) == 0 {
+		return models.LastMessage{}, false
+	}
+
+	m := page.Data[0]
+	return models.LastMessage{
+		MessageID: m.MessageID,
+		Sender:    m.Sender,
+		Content:   previewContent(m.Msg),
+		CreatedAt: m.CreatedAt.UTC().UnixMilli(),
+		Deleted:   m.Deleted,
+	}, true
+}
+
+// previewContent trims a message body to a rune-bounded room-list snippet.
+func previewContent(msg string) string {
+	if len(msg) <= lastMessagePreviewRunes {
+		return msg // bytes ≤ cap ⇒ runes ≤ cap; no alloc on the common short case
+	}
+	r := []rune(msg)
+	if len(r) <= lastMessagePreviewRunes {
+		return msg
+	}
+	return string(r[:lastMessagePreviewRunes])
+}
+
+// dedupRoomIDs removes duplicate roomIds, preserving first-seen order.
+func dedupRoomIDs(ids []string) []string {
+	seen := make(map[string]struct{}, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hmchangw/chat/history-service/internal/cassrepo"
 	"github.com/hmchangw/chat/history-service/internal/models"
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/natsrouter"
@@ -17,16 +16,14 @@ const (
 	maxRoomsGetBatch        = 100 // mirrors maxGetByIDsBatchSize
 	maxRoomsGetConcurrency  = 16  // mirrors cassrepo.maxConcurrentIDReads
 	lastMessagePreviewRunes = 256 // room-list snippet cap
+	lastMsgWalkPageSize     = 50  // messages scanned per walk-back page
+	lastMsgWalkMaxPages     = 5   // ponytail: cap the deleted-tail walk; a room with >250 trailing deletes just shows no last message
 )
 
-// RoomsGet handles chat.user.{account}.request.history.{siteID}.rooms.get: for each
-// requested room the caller can access, return its latest message (A2 read-time,
-// no walk-back). Per-room failures (incl. not-subscribed) degrade to no entry so
-// one bad room never fails the batch.
+// RoomsGet handles chat.server.request.history.{siteID}.rooms.get: for each requested
+// room, return its latest non-deleted message. Server-to-server (no per-account access
+// check). Per-room failures degrade to no entry so one bad room never fails the batch.
 func (s *HistoryService) RoomsGet(c *natsrouter.Context, req models.RoomsGetRequest) (*models.RoomsGetResponse, error) {
-	account := c.Param("account")
-	c.WithLogValues("account", account)
-
 	if len(req.RoomIDs) == 0 {
 		return nil, errcode.BadRequest("roomIds must not be empty")
 	}
@@ -54,7 +51,7 @@ func (s *HistoryService) RoomsGet(c *natsrouter.Context, req models.RoomsGetRequ
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
-			lm, ok := s.roomLastMessage(c, account, roomID, now)
+			lm, ok := s.roomLastMessage(c, roomID, now)
 			if !ok {
 				return
 			}
@@ -68,53 +65,54 @@ func (s *HistoryService) RoomsGet(c *natsrouter.Context, req models.RoomsGetRequ
 	return &models.RoomsGetResponse{Rooms: out}, nil
 }
 
-// roomLastMessage resolves one room's latest message at read time. ok=false means
-// drop the room (not subscribed, empty, or a read failure). A soft-deleted latest
-// message is returned as-is with Deleted=true — no walk-back to an earlier survivor.
-func (s *HistoryService) roomLastMessage(ctx context.Context, account, roomID string, now time.Time) (models.LastMessage, bool) {
-	accessSince, lastMsgAt, createdAt, err := s.checkAccessAndRoomTimes(ctx, account, roomID, nil, now)
+// roomLastMessage resolves one room's latest NON-deleted message at read time.
+// ok=false means drop the room (empty, all-deleted within the walk cap, or a read
+// failure). Walks backward from lastMsgAt in pages, skipping soft-deleted messages.
+func (s *HistoryService) roomLastMessage(ctx context.Context, roomID string, now time.Time) (models.LastMessage, bool) {
+	lastMsgAt, createdAt, err := s.resolveRoomTimesOrError(ctx, roomID, nil, now)
 	if err != nil {
-		slog.WarnContext(ctx, "rooms.get room degraded", "account", account, "room_id", roomID,
+		slog.WarnContext(ctx, "rooms.get room degraded", "room_id", roomID,
 			"request_id", natsutil.RequestIDFromContext(ctx), "error", err)
 		return models.LastMessage{}, false
 	}
 
-	pageReq, err := parsePageRequest("", 1)
+	pageReq, err := parsePageRequest("", lastMsgWalkPageSize)
 	if err != nil {
 		return models.LastMessage{}, false
 	}
-	// Cap the walk at the last message so a dormant room is a single-bucket read.
-	before := lastMsgAt.Add(time.Millisecond)
+	ceiling, floor := s.walkBounds(lastMsgAt, createdAt, now)
+	before := ceiling.Add(time.Millisecond)
 
-	var page cassrepo.Page[models.Message]
-	if accessSince == nil {
-		// Clamp createdAt to the configured floor (mirrors LoadHistory).
-		historyFloor := now.Add(-s.historyFloor)
-		walkFloor := createdAt
-		if walkFloor.IsZero() || walkFloor.Before(historyFloor) {
-			walkFloor = historyFloor
+	for range lastMsgWalkMaxPages {
+		page, err := s.msgReader.GetMessagesBefore(ctx, roomID, before, floor, pageReq)
+		if err != nil {
+			slog.WarnContext(ctx, "rooms.get latest-message read degraded", "room_id", roomID,
+				"request_id", natsutil.RequestIDFromContext(ctx), "error", err)
+			return models.LastMessage{}, false
 		}
-		page, err = s.msgReader.GetMessagesBefore(ctx, roomID, before, walkFloor, pageReq)
-	} else {
-		page, err = s.msgReader.GetMessagesBetweenDesc(ctx, roomID, *accessSince, before, pageReq)
+		if len(page.Data) == 0 {
+			return models.LastMessage{}, false // room empty or floor reached
+		}
+		for i := range page.Data {
+			m := page.Data[i]
+			if m.Deleted {
+				continue
+			}
+			return models.LastMessage{
+				MessageID: m.MessageID,
+				Sender:    m.Sender,
+				Content:   previewContent(m.Msg),
+				CreatedAt: m.CreatedAt.UTC().UnixMilli(),
+			}, true
+		}
+		// Whole page deleted. A short page means the walk is exhausted (no older
+		// messages) — stop. Otherwise page again strictly before the oldest one seen.
+		if len(page.Data) < lastMsgWalkPageSize {
+			return models.LastMessage{}, false
+		}
+		before = page.Data[len(page.Data)-1].CreatedAt
 	}
-	if err != nil {
-		slog.WarnContext(ctx, "rooms.get latest-message read degraded", "account", account, "room_id", roomID,
-			"request_id", natsutil.RequestIDFromContext(ctx), "error", err)
-		return models.LastMessage{}, false
-	}
-	if len(page.Data) == 0 {
-		return models.LastMessage{}, false
-	}
-
-	m := page.Data[0]
-	return models.LastMessage{
-		MessageID: m.MessageID,
-		Sender:    m.Sender,
-		Content:   previewContent(m.Msg),
-		CreatedAt: m.CreatedAt.UTC().UnixMilli(),
-		Deleted:   m.Deleted,
-	}, true
+	return models.LastMessage{}, false // deleted tail longer than the walk cap
 }
 
 // previewContent trims a message body to a rune-bounded room-list snippet.

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -44,8 +44,10 @@ func (s *HistoryService) RoomsGet(c *natsrouter.Context, req models.RoomsGetRequ
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, maxRoomsGetConcurrency)
 	for _, roomID := range ids {
-		if c.Err() != nil {
-			break
+		// Context cancelled/timed out: the caller's gone, so propagate the error
+		// rather than return a partial OK that won't be read.
+		if err := c.Err(); err != nil {
+			return nil, err
 		}
 		wg.Add(1)
 		sem <- struct{}{}

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -1,0 +1,192 @@
+package service_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/hmchangw/chat/history-service/internal/config"
+	"github.com/hmchangw/chat/history-service/internal/models"
+	"github.com/hmchangw/chat/history-service/internal/service"
+	"github.com/hmchangw/chat/history-service/internal/service/mocks"
+	"github.com/hmchangw/chat/pkg/natsrouter"
+)
+
+// newRoomsService builds a service with bare mocks (no permissive room-time
+// default) so each rooms.get test states its exact per-room expectations.
+func newRoomsService(t *testing.T) (*service.HistoryService, *mocks.MockMessageRepository, *mocks.MockSubscriptionRepository, *mocks.MockRoomRepository) {
+	ctrl := gomock.NewController(t)
+	msgs := mocks.NewMockMessageRepository(ctrl)
+	subs := mocks.NewMockSubscriptionRepository(ctrl)
+	rooms := mocks.NewMockRoomRepository(ctrl)
+	pub := mocks.NewMockEventPublisher(ctrl)
+	threadRooms := mocks.NewMockThreadRoomRepository(ctrl)
+	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
+	users := mocks.NewMockUserStore(ctrl)
+	customEmojis := mocks.NewMockCustomEmojiStore(ctrl)
+	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true}
+	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, customEmojis, cfg)
+	return svc, msgs, subs, rooms
+}
+
+func roomsCtx() *natsrouter.Context {
+	return natsrouter.NewContext(map[string]string{"account": "alice"})
+}
+
+var roomLastMsgAt = time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+var roomCreatedAt = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// Mirror the production caps (house pattern — see maxGetByIDsBatchSize in messages_test).
+const (
+	roomsGetMaxBatch     = 100
+	roomsGetPreviewRunes = 256
+)
+
+func TestHistoryService_RoomsGet_FullAccess(t *testing.T) {
+	svc, msgs, subs, rooms := newRoomsService(t)
+
+	// Full access (nil historySharedSince) ⇒ the unbounded GetMessagesBefore walk.
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r1").Return(nil, true, nil)
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: "hello", CreatedAt: roomLastMsgAt, Sender: models.Participant{ID: "u1", Account: "alice"}}}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "r1")
+	lm := resp.Rooms["r1"]
+	assert.Equal(t, "m1", lm.MessageID)
+	assert.Equal(t, "hello", lm.Content)
+	assert.Equal(t, "alice", lm.Sender.Account)
+	assert.Equal(t, roomLastMsgAt.UnixMilli(), lm.CreatedAt)
+	assert.False(t, lm.Deleted)
+}
+
+func TestHistoryService_RoomsGet_WindowedAccess(t *testing.T) {
+	svc, msgs, subs, rooms := newRoomsService(t)
+	since := roomCreatedAt.Add(24 * time.Hour)
+
+	// Windowed access (non-nil historySharedSince) ⇒ GetMessagesBetweenDesc, floored at the join window.
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r1").Return(&since, true, nil)
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBetweenDesc(gomock.Any(), "r1", since, gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m2", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt}}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "r1")
+	assert.Equal(t, "m2", resp.Rooms["r1"].MessageID)
+}
+
+func TestHistoryService_RoomsGet_EmptyRoomOmitted(t *testing.T) {
+	svc, msgs, subs, rooms := newRoomsService(t)
+
+	// Empty room: GetRoomTimes yields zero lastMsgAt (normalised to createdAt), the
+	// walk returns no rows, so the room is omitted from the response.
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r1").Return(nil, true, nil)
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(time.Time{}, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage(nil, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	assert.NotContains(t, resp.Rooms, "r1")
+	assert.NotNil(t, resp.Rooms)
+}
+
+func TestHistoryService_RoomsGet_NotSubscribedDegrades(t *testing.T) {
+	svc, _, subs, rooms := newRoomsService(t)
+
+	// Not subscribed ⇒ getAccessSince Forbidden ⇒ that room degrades to no entry.
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r1").Return(nil, false, nil)
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil).AnyTimes()
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	assert.NotContains(t, resp.Rooms, "r1")
+}
+
+func TestHistoryService_RoomsGet_PerRoomDegradeKeepsSiblings(t *testing.T) {
+	svc, msgs, subs, rooms := newRoomsService(t)
+
+	// r1 history read errors → omitted; r2 succeeds → returned.
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r1").Return(nil, true, nil)
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage(nil, false), errors.New("cassandra timeout"))
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r2").Return(nil, true, nil)
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r2").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r2", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m2", RoomID: "r2", Msg: "ok", CreatedAt: roomLastMsgAt}}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1", "r2"}})
+	require.NoError(t, err)
+	assert.NotContains(t, resp.Rooms, "r1")
+	require.Contains(t, resp.Rooms, "r2")
+}
+
+func TestHistoryService_RoomsGet_DeletedLastReturnedAsIs(t *testing.T) {
+	svc, msgs, subs, rooms := newRoomsService(t)
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r1").Return(nil, true, nil)
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m9", RoomID: "r1", Msg: "", Deleted: true, CreatedAt: roomLastMsgAt}}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "r1")
+	assert.True(t, resp.Rooms["r1"].Deleted)
+}
+
+func TestHistoryService_RoomsGet_DedupsRoomIDs(t *testing.T) {
+	svc, msgs, subs, rooms := newRoomsService(t)
+
+	// A duplicate roomId resolves once (Times(1) on each per-room read).
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r1").Return(nil, true, nil).Times(1)
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil).Times(1)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: "x", CreatedAt: roomLastMsgAt}}, false), nil).Times(1)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1", "r1"}})
+	require.NoError(t, err)
+	assert.Len(t, resp.Rooms, 1)
+}
+
+func TestHistoryService_RoomsGet_ContentPreviewTrimmed(t *testing.T) {
+	svc, msgs, subs, rooms := newRoomsService(t)
+	long := strings.Repeat("世", 1000) // 1000 runes, well over the preview cap
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r1").Return(nil, true, nil)
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: long, CreatedAt: roomLastMsgAt}}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "r1")
+	assert.LessOrEqual(t, len([]rune(resp.Rooms["r1"].Content)), roomsGetPreviewRunes)
+	assert.NotEmpty(t, resp.Rooms["r1"].Content)
+}
+
+func TestHistoryService_RoomsGet_EmptyRoomIDs(t *testing.T) {
+	svc, _, _, _ := newRoomsService(t)
+	_, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: nil})
+	assertBadRequestErr(t, err, "roomIds must not be empty")
+}
+
+func TestHistoryService_RoomsGet_TooManyRoomIDs(t *testing.T) {
+	svc, _, _, _ := newRoomsService(t)
+	ids := make([]string, roomsGetMaxBatch+1)
+	for i := range ids {
+		ids[i] = "r" + string(rune('a'+i%26))
+	}
+	_, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: ids})
+	assertBadRequestErr(t, err, "too many roomIds")
+}

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/hmchangw/chat/pkg/natsrouter"
 )
 
-// newRoomsService builds a service with bare mocks (no permissive room-time
-// default) so each rooms.get test states its exact per-room expectations.
-func newRoomsService(t *testing.T) (*service.HistoryService, *mocks.MockMessageRepository, *mocks.MockSubscriptionRepository, *mocks.MockRoomRepository) {
+// newRoomsService builds a service with bare mocks. rooms.get is server-to-server
+// now — no access (subscription) check — so tests only set room-time + message reads.
+func newRoomsService(t *testing.T) (*service.HistoryService, *mocks.MockMessageRepository, *mocks.MockRoomRepository) {
 	ctrl := gomock.NewController(t)
 	msgs := mocks.NewMockMessageRepository(ctrl)
 	subs := mocks.NewMockSubscriptionRepository(ctrl)
@@ -31,7 +31,7 @@ func newRoomsService(t *testing.T) (*service.HistoryService, *mocks.MockMessageR
 	apps := mocks.NewMockAppStore(ctrl)
 	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true}
 	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg)
-	return svc, msgs, subs, rooms
+	return svc, msgs, rooms
 }
 
 func roomsCtx() *natsrouter.Context {
@@ -47,11 +47,9 @@ const (
 	roomsGetPreviewRunes = 256
 )
 
-func TestHistoryService_RoomsGet_FullAccess(t *testing.T) {
-	svc, msgs, subs, rooms := newRoomsService(t)
+func TestHistoryService_RoomsGet_LatestMessage(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
 
-	// Full access (nil historySharedSince) ⇒ the unbounded GetMessagesBefore walk.
-	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r1").Return(nil, true, nil)
 	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: "hello", CreatedAt: roomLastMsgAt, Sender: models.Participant{ID: "u1", Account: "alice"}}}, false), nil)
@@ -64,31 +62,11 @@ func TestHistoryService_RoomsGet_FullAccess(t *testing.T) {
 	assert.Equal(t, "hello", lm.Content)
 	assert.Equal(t, "alice", lm.Sender.Account)
 	assert.Equal(t, roomLastMsgAt.UnixMilli(), lm.CreatedAt)
-	assert.False(t, lm.Deleted)
-}
-
-func TestHistoryService_RoomsGet_WindowedAccess(t *testing.T) {
-	svc, msgs, subs, rooms := newRoomsService(t)
-	since := roomCreatedAt.Add(24 * time.Hour)
-
-	// Windowed access (non-nil historySharedSince) ⇒ GetMessagesBetweenDesc, floored at the join window.
-	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r1").Return(&since, true, nil)
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
-	msgs.EXPECT().GetMessagesBetweenDesc(gomock.Any(), "r1", since, gomock.Any(), gomock.Any()).
-		Return(makePage([]models.Message{{MessageID: "m2", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt}}, false), nil)
-
-	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
-	require.NoError(t, err)
-	require.Contains(t, resp.Rooms, "r1")
-	assert.Equal(t, "m2", resp.Rooms["r1"].MessageID)
 }
 
 func TestHistoryService_RoomsGet_EmptyRoomOmitted(t *testing.T) {
-	svc, msgs, subs, rooms := newRoomsService(t)
+	svc, msgs, rooms := newRoomsService(t)
 
-	// Empty room: GetRoomTimes yields zero lastMsgAt (normalised to createdAt), the
-	// walk returns no rows, so the room is omitted from the response.
-	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r1").Return(nil, true, nil)
 	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(time.Time{}, roomCreatedAt, nil)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage(nil, false), nil)
@@ -99,28 +77,14 @@ func TestHistoryService_RoomsGet_EmptyRoomOmitted(t *testing.T) {
 	assert.NotNil(t, resp.Rooms)
 }
 
-func TestHistoryService_RoomsGet_NotSubscribedDegrades(t *testing.T) {
-	svc, _, subs, rooms := newRoomsService(t)
-
-	// Not subscribed ⇒ getAccessSince Forbidden ⇒ that room degrades to no entry.
-	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r1").Return(nil, false, nil)
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil).AnyTimes()
-
-	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
-	require.NoError(t, err)
-	assert.NotContains(t, resp.Rooms, "r1")
-}
-
 func TestHistoryService_RoomsGet_PerRoomDegradeKeepsSiblings(t *testing.T) {
-	svc, msgs, subs, rooms := newRoomsService(t)
+	svc, msgs, rooms := newRoomsService(t)
 
 	// r1 history read errors → omitted; r2 succeeds → returned.
-	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r1").Return(nil, true, nil)
 	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage(nil, false), errors.New("cassandra timeout"))
 
-	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r2").Return(nil, true, nil)
 	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r2").Return(roomLastMsgAt, roomCreatedAt, nil)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r2", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{{MessageID: "m2", RoomID: "r2", Msg: "ok", CreatedAt: roomLastMsgAt}}, false), nil)
@@ -131,25 +95,47 @@ func TestHistoryService_RoomsGet_PerRoomDegradeKeepsSiblings(t *testing.T) {
 	require.Contains(t, resp.Rooms, "r2")
 }
 
-func TestHistoryService_RoomsGet_DeletedLastReturnedAsIs(t *testing.T) {
-	svc, msgs, subs, rooms := newRoomsService(t)
+// Latest message deleted → walk back within the page and return the first survivor.
+func TestHistoryService_RoomsGet_SkipsDeletedTail(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
 
-	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r1").Return(nil, true, nil)
 	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(makePage([]models.Message{{MessageID: "m9", RoomID: "r1", Msg: "", Deleted: true, CreatedAt: roomLastMsgAt}}, false), nil)
+		Return(makePage([]models.Message{
+			{MessageID: "m3", RoomID: "r1", Msg: "", Deleted: true, CreatedAt: roomLastMsgAt},
+			{MessageID: "m2", RoomID: "r1", Msg: "", Deleted: true, CreatedAt: roomLastMsgAt.Add(-time.Minute)},
+			{MessageID: "m1", RoomID: "r1", Msg: "alive", CreatedAt: roomLastMsgAt.Add(-2 * time.Minute), Sender: models.Participant{Account: "alice"}},
+		}, false), nil)
 
 	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
 	require.NoError(t, err)
 	require.Contains(t, resp.Rooms, "r1")
-	assert.True(t, resp.Rooms["r1"].Deleted)
+	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
+	assert.Equal(t, "alive", resp.Rooms["r1"].Content)
+}
+
+// Every message in the page is deleted (and the page is the whole room) → no entry.
+func TestHistoryService_RoomsGet_AllDeletedOmitted(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	// A short all-deleted page (below the walk page size) means no older messages
+	// remain, so a single read is enough to conclude "no last message".
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{
+			{MessageID: "m2", RoomID: "r1", Msg: "", Deleted: true, CreatedAt: roomLastMsgAt},
+			{MessageID: "m1", RoomID: "r1", Msg: "", Deleted: true, CreatedAt: roomLastMsgAt.Add(-time.Minute)},
+		}, false), nil).Times(1)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	assert.NotContains(t, resp.Rooms, "r1")
 }
 
 func TestHistoryService_RoomsGet_DedupsRoomIDs(t *testing.T) {
-	svc, msgs, subs, rooms := newRoomsService(t)
+	svc, msgs, rooms := newRoomsService(t)
 
 	// A duplicate roomId resolves once (Times(1) on each per-room read).
-	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r1").Return(nil, true, nil).Times(1)
 	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil).Times(1)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: "x", CreatedAt: roomLastMsgAt}}, false), nil).Times(1)
@@ -160,10 +146,9 @@ func TestHistoryService_RoomsGet_DedupsRoomIDs(t *testing.T) {
 }
 
 func TestHistoryService_RoomsGet_ContentPreviewTrimmed(t *testing.T) {
-	svc, msgs, subs, rooms := newRoomsService(t)
+	svc, msgs, rooms := newRoomsService(t)
 	long := strings.Repeat("世", 1000) // 1000 runes, well over the preview cap
 
-	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "alice", "r1").Return(nil, true, nil)
 	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: long, CreatedAt: roomLastMsgAt}}, false), nil)
@@ -176,13 +161,13 @@ func TestHistoryService_RoomsGet_ContentPreviewTrimmed(t *testing.T) {
 }
 
 func TestHistoryService_RoomsGet_EmptyRoomIDs(t *testing.T) {
-	svc, _, _, _ := newRoomsService(t)
+	svc, _, _ := newRoomsService(t)
 	_, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: nil})
 	assertBadRequestErr(t, err, "roomIds must not be empty")
 }
 
 func TestHistoryService_RoomsGet_TooManyRoomIDs(t *testing.T) {
-	svc, _, _, _ := newRoomsService(t)
+	svc, _, _ := newRoomsService(t)
 	ids := make([]string, roomsGetMaxBatch+1)
 	for i := range ids {
 		ids[i] = "r" + string(rune('a'+i%26))

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -28,9 +28,9 @@ func newRoomsService(t *testing.T) (*service.HistoryService, *mocks.MockMessageR
 	threadRooms := mocks.NewMockThreadRoomRepository(ctrl)
 	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
 	users := mocks.NewMockUserStore(ctrl)
-	customEmojis := mocks.NewMockCustomEmojiStore(ctrl)
+	apps := mocks.NewMockAppStore(ctrl)
 	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true}
-	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, customEmojis, cfg)
+	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg)
 	return svc, msgs, subs, rooms
 }
 

--- a/history-service/internal/service/service.go
+++ b/history-service/internal/service/service.go
@@ -151,7 +151,7 @@ func (s *HistoryService) RegisterHandlers(r *natsrouter.Router, siteID string) {
 	natsrouter.Register(r, subject.MsgSurroundingPattern(siteID), s.LoadSurroundingMessages)
 	natsrouter.Register(r, subject.MsgGetPattern(siteID), s.GetMessageByID)
 	natsrouter.Register(r, subject.MsgGetIDsPattern(siteID), s.GetMessagesByIDs)
-	natsrouter.Register(r, subject.RoomsGetPattern(siteID), s.RoomsGet)
+	natsrouter.Register(r, subject.RoomsGet(siteID), s.RoomsGet)
 	natsrouter.Register(r, subject.MsgEditPattern(siteID), func(c *natsrouter.Context, req models.EditMessageRequest) (*models.EditMessageResponse, error) {
 		return s.EditMessage(c, siteID, req)
 	})

--- a/history-service/internal/service/service.go
+++ b/history-service/internal/service/service.go
@@ -151,6 +151,7 @@ func (s *HistoryService) RegisterHandlers(r *natsrouter.Router, siteID string) {
 	natsrouter.Register(r, subject.MsgSurroundingPattern(siteID), s.LoadSurroundingMessages)
 	natsrouter.Register(r, subject.MsgGetPattern(siteID), s.GetMessageByID)
 	natsrouter.Register(r, subject.MsgGetIDsPattern(siteID), s.GetMessagesByIDs)
+	natsrouter.Register(r, subject.RoomsGetPattern(siteID), s.RoomsGet)
 	natsrouter.Register(r, subject.MsgEditPattern(siteID), func(c *natsrouter.Context, req models.EditMessageRequest) (*models.EditMessageResponse, error) {
 		return s.EditMessage(c, siteID, req)
 	})

--- a/pkg/model/message.go
+++ b/pkg/model/message.go
@@ -91,3 +91,29 @@ func (m *Message) SenderDisplayName() string {
 	}
 	return m.UserAccount
 }
+
+// RoomsGetRequest is the request body for the rooms.get batch RPC: the rooms whose
+// last message the caller wants. The account+site are taken from the subject.
+type RoomsGetRequest struct {
+	RoomIDs []string `json:"roomIds"`
+}
+
+// LastMessage is a room's most-recent message, resolved at read time (A2). Content
+// is preview-trimmed. Deleted is returned as-is — a soft-deleted last message
+// surfaces with deleted=true and no walk-back to an earlier surviving message.
+// Shared wire type: history-service's rooms.get RPC produces it, user-service's
+// subscription.list embeds it (SubscriptionRoom.LastMessage).
+type LastMessage struct {
+	MessageID string                `json:"messageId"`
+	Sender    cassandra.Participant `json:"sender"`
+	Content   string                `json:"content"`
+	CreatedAt int64                 `json:"createdAt"` // UTC millis
+	Deleted   bool                  `json:"deleted,omitempty"`
+}
+
+// RoomsGetResponse maps each requested roomId that has a resolvable last message to
+// it. Rooms with no message, or that the caller can't access, or that degraded, are
+// omitted (best-effort) rather than failing the whole batch.
+type RoomsGetResponse struct {
+	Rooms map[string]LastMessage `json:"rooms"`
+}

--- a/pkg/model/message.go
+++ b/pkg/model/message.go
@@ -93,27 +93,24 @@ func (m *Message) SenderDisplayName() string {
 }
 
 // RoomsGetRequest is the request body for the rooms.get batch RPC: the rooms whose
-// last message the caller wants. The account+site are taken from the subject.
+// last message the caller wants. The site is taken from the subject.
 type RoomsGetRequest struct {
 	RoomIDs []string `json:"roomIds"`
 }
 
-// LastMessage is a room's most-recent message, resolved at read time (A2). Content
-// is preview-trimmed. Deleted is returned as-is — a soft-deleted last message
-// surfaces with deleted=true and no walk-back to an earlier surviving message.
-// Shared wire type: history-service's rooms.get RPC produces it, user-service's
-// subscription.list embeds it (SubscriptionRoom.LastMessage).
+// LastMessage is a room's most-recent NON-deleted message, resolved at read time.
+// Content is preview-trimmed. Shared wire type: history-service's rooms.get RPC
+// produces it, user-service's subscription.list embeds it (SubscriptionRoom.LastMessage).
 type LastMessage struct {
 	MessageID string                `json:"messageId"`
 	Sender    cassandra.Participant `json:"sender"`
 	Content   string                `json:"content"`
 	CreatedAt int64                 `json:"createdAt"` // UTC millis
-	Deleted   bool                  `json:"deleted,omitempty"`
 }
 
 // RoomsGetResponse maps each requested roomId that has a resolvable last message to
-// it. Rooms with no message, or that the caller can't access, or that degraded, are
-// omitted (best-effort) rather than failing the whole batch.
+// it. Rooms with no non-deleted message, or that degraded, are omitted (best-effort)
+// rather than failing the whole batch.
 type RoomsGetResponse struct {
 	Rooms map[string]LastMessage `json:"rooms"`
 }

--- a/pkg/model/subscription.go
+++ b/pkg/model/subscription.go
@@ -117,6 +117,10 @@ type SubscriptionRoom struct {
 	// on subscription.list (same payload as the room.key.get RPC).
 	PrivateKey *string `json:"privateKey,omitempty" bson:"-"`
 	KeyVersion *int    `json:"keyVersion,omitempty" bson:"-"`
+	// LastMessage is resolved at read time via history-service's rooms.get RPC
+	// (A2 — no denormalized write path). Omitted when the room has no message,
+	// the enriching site RPC degraded, or the room is soft-deleted (Room==nil).
+	LastMessage *LastMessage `json:"lastMessage,omitempty" bson:"-"`
 }
 
 // SubscriptionHRInfo carries the counterpart's HR-directory record on a DM subscription for sidebar/header rendering.

--- a/pkg/subject/roomsget_test.go
+++ b/pkg/subject/roomsget_test.go
@@ -8,28 +8,7 @@ import (
 	"github.com/hmchangw/chat/pkg/subject"
 )
 
-func TestRoomsGetSubjectBuilders(t *testing.T) {
-	tests := []struct {
-		name string
-		got  string
-		want string
-	}{
-		{"RoomsGet", subject.RoomsGet("alice", "site-a"),
-			"chat.user.alice.request.history.site-a.rooms.get"},
-		{"RoomsGetPattern", subject.RoomsGetPattern("site-a"),
-			"chat.user.{account}.request.history.site-a.rooms.get"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.got)
-		})
-	}
-}
-
-func TestRoomsGet_PanicsOnWildcardAccount(t *testing.T) {
-	for _, bad := range []string{"a.b", "a*", "a>", "a b"} {
-		t.Run(bad, func(t *testing.T) {
-			assert.Panics(t, func() { subject.RoomsGet(bad, "site-a") })
-		})
-	}
+func TestRoomsGetSubject(t *testing.T) {
+	// Server-to-server subject, account-agnostic (mirrors ThreadRoomInfoBatch).
+	assert.Equal(t, "chat.server.request.history.site-a.rooms.get", subject.RoomsGet("site-a"))
 }

--- a/pkg/subject/roomsget_test.go
+++ b/pkg/subject/roomsget_test.go
@@ -1,0 +1,35 @@
+package subject_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+func TestRoomsGetSubjectBuilders(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"RoomsGet", subject.RoomsGet("alice", "site-a"),
+			"chat.user.alice.request.history.site-a.rooms.get"},
+		{"RoomsGetPattern", subject.RoomsGetPattern("site-a"),
+			"chat.user.{account}.request.history.site-a.rooms.get"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.got)
+		})
+	}
+}
+
+func TestRoomsGet_PanicsOnWildcardAccount(t *testing.T) {
+	for _, bad := range []string{"a.b", "a*", "a>", "a b"} {
+		t.Run(bad, func(t *testing.T) {
+			assert.Panics(t, func() { subject.RoomsGet(bad, "site-a") })
+		})
+	}
+}

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -73,14 +73,12 @@ func MsgGetIDs(account, roomID, siteID string) string {
 	return fmt.Sprintf("chat.user.%s.request.room.%s.%s.msg.get.ids", account, roomID, siteID)
 }
 
-// RoomsGet returns the concrete subject for the rooms.get batch RPC (a client's
-// room last-message fetch). Room is absent from the subject because the request
-// batches roomIds in its body. Pair with RoomsGetPattern.
-func RoomsGet(account, siteID string) string {
-	if !isValidAccountToken(account) {
-		panic("invalid account token: contains NATS wildcard characters")
-	}
-	return fmt.Sprintf("chat.user.%s.request.history.%s.rooms.get", account, siteID)
+// RoomsGet is the server-to-server request subject for the rooms.get batch RPC:
+// user-service asks history-service for each room's last message. Account-agnostic
+// (roomIds batch in the body); the publish and subscribe forms are identical, like
+// ThreadRoomInfoBatch.
+func RoomsGet(siteID string) string {
+	return fmt.Sprintf("chat.server.request.history.%s.rooms.get", siteID)
 }
 
 func UserResponse(account, requestID string) string {
@@ -463,12 +461,6 @@ func MsgGetPattern(siteID string) string {
 // Pair with MsgGetIDs for the concrete-subject form callers publish on.
 func MsgGetIDsPattern(siteID string) string {
 	return fmt.Sprintf("chat.user.{account}.request.room.{roomID}.%s.msg.get.ids", siteID)
-}
-
-// RoomsGetPattern is the natsrouter pattern for the rooms.get batch handler.
-// Pair with RoomsGet for the concrete-subject form callers publish on.
-func RoomsGetPattern(siteID string) string {
-	return fmt.Sprintf("chat.user.{account}.request.history.%s.rooms.get", siteID)
 }
 
 // MsgEditPattern is the natsrouter pattern for editing a message.

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -73,6 +73,16 @@ func MsgGetIDs(account, roomID, siteID string) string {
 	return fmt.Sprintf("chat.user.%s.request.room.%s.%s.msg.get.ids", account, roomID, siteID)
 }
 
+// RoomsGet returns the concrete subject for the rooms.get batch RPC (a client's
+// room last-message fetch). Room is absent from the subject because the request
+// batches roomIds in its body. Pair with RoomsGetPattern.
+func RoomsGet(account, siteID string) string {
+	if !isValidAccountToken(account) {
+		panic("invalid account token: contains NATS wildcard characters")
+	}
+	return fmt.Sprintf("chat.user.%s.request.history.%s.rooms.get", account, siteID)
+}
+
 func UserResponse(account, requestID string) string {
 	return fmt.Sprintf("chat.user.%s.response.%s", account, requestID)
 }
@@ -453,6 +463,12 @@ func MsgGetPattern(siteID string) string {
 // Pair with MsgGetIDs for the concrete-subject form callers publish on.
 func MsgGetIDsPattern(siteID string) string {
 	return fmt.Sprintf("chat.user.{account}.request.room.{roomID}.%s.msg.get.ids", siteID)
+}
+
+// RoomsGetPattern is the natsrouter pattern for the rooms.get batch handler.
+// Pair with RoomsGet for the concrete-subject form callers publish on.
+func RoomsGetPattern(siteID string) string {
+	return fmt.Sprintf("chat.user.{account}.request.history.%s.rooms.get", siteID)
 }
 
 // MsgEditPattern is the natsrouter pattern for editing a message.

--- a/user-service/historyclient/client.go
+++ b/user-service/historyclient/client.go
@@ -52,12 +52,12 @@ func (c *Client) GetThreadList(ctx context.Context, siteID string, req model.Thr
 // the resolvable last message for each requested room; rooms with no message, or
 // that degraded, are simply absent from the map (mirrors the server's own
 // per-room best-effort degrade).
-func (c *Client) RoomsGet(ctx context.Context, account, siteID string, roomIDs []string) (map[string]model.LastMessage, error) {
+func (c *Client) RoomsGet(ctx context.Context, siteID string, roomIDs []string) (map[string]model.LastMessage, error) {
 	body, err := json.Marshal(model.RoomsGetRequest{RoomIDs: roomIDs})
 	if err != nil {
 		return nil, fmt.Errorf("marshal rooms-get request: %w", err)
 	}
-	msg, err := c.nc.Request(ctx, subject.RoomsGet(account, siteID), body, historyRPCTimeout)
+	msg, err := c.nc.Request(ctx, subject.RoomsGet(siteID), body, historyRPCTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("rooms-get rpc: %w", err)
 	}

--- a/user-service/historyclient/client.go
+++ b/user-service/historyclient/client.go
@@ -47,3 +47,26 @@ func (c *Client) GetThreadList(ctx context.Context, siteID string, req model.Thr
 	}
 	return out, nil
 }
+
+// RoomsGet issues the per-site rooms.get batch RPC to history-service, returning
+// the resolvable last message for each requested room; rooms with no message, or
+// that degraded, are simply absent from the map (mirrors the server's own
+// per-room best-effort degrade).
+func (c *Client) RoomsGet(ctx context.Context, account, siteID string, roomIDs []string) (map[string]model.LastMessage, error) {
+	body, err := json.Marshal(model.RoomsGetRequest{RoomIDs: roomIDs})
+	if err != nil {
+		return nil, fmt.Errorf("marshal rooms-get request: %w", err)
+	}
+	msg, err := c.nc.Request(ctx, subject.RoomsGet(account, siteID), body, historyRPCTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("rooms-get rpc: %w", err)
+	}
+	if e, ok := errcode.Parse(msg.Data); ok {
+		return nil, e
+	}
+	var out model.RoomsGetResponse
+	if err := json.Unmarshal(msg.Data, &out); err != nil {
+		return nil, fmt.Errorf("decode rooms-get response: %w", err)
+	}
+	return out.Rooms, nil
+}

--- a/user-service/models/subscription.go
+++ b/user-service/models/subscription.go
@@ -5,12 +5,15 @@ import "github.com/hmchangw/chat/pkg/model"
 // SubscriptionListRequest is the body of subscription.list.
 // Type ∈ {current, rooms, apps}. UpdatedWithinDays nil ⇒ no age filter.
 // Offset/Limit page the result; omitted (0) ⇒ first page at the server default size.
+// IncludeLastMessage nil/absent ⇒ include (backward-compatible); false ⇒ skip the
+// last-message enrichment.
 type SubscriptionListRequest struct {
-	Type              string `json:"type"`
-	Favorite          *bool  `json:"favorite,omitempty"`
-	UpdatedWithinDays *int   `json:"updatedWithinDays,omitempty"`
-	Offset            int    `json:"offset,omitempty"`
-	Limit             int    `json:"limit,omitempty"`
+	Type               string `json:"type"`
+	Favorite           *bool  `json:"favorite,omitempty"`
+	UpdatedWithinDays  *int   `json:"updatedWithinDays,omitempty"`
+	IncludeLastMessage *bool  `json:"includeLastMessage,omitempty"`
+	Offset             int    `json:"offset,omitempty"`
+	Limit              int    `json:"limit,omitempty"`
 }
 
 // SubscriptionListResponse is returned by subscription.getByRoomID (a 0-or-1 point

--- a/user-service/service/apps_test.go
+++ b/user-service/service/apps_test.go
@@ -19,13 +19,13 @@ func appWith(enabled bool) *model.App {
 }
 
 func TestSetAppSubscription_EmptyAppID(t *testing.T) {
-	svc, _, _, _, _, _ := newSvc(t)
+	svc, _, _, _, _, _, _ := newSvc(t)
 	_, err := svc.SetAppSubscription(ctx("alice", "site-a"), models.SetAppSubscriptionRequest{AppID: "", Subscribed: true})
 	requireCode(t, err, errcode.CodeBadRequest)
 }
 
 func TestSetAppSubscription_NotFound(t *testing.T) {
-	svc, _, _, apps, _, _ := newSvc(t)
+	svc, _, _, apps, _, _, _ := newSvc(t)
 	apps.EXPECT().GetApp(gomock.Any(), "nope").Return(nil, nil)
 	_, err := svc.SetAppSubscription(ctx("alice", "site-a"), models.SetAppSubscriptionRequest{AppID: "nope", Subscribed: true})
 	requireCode(t, err, errcode.CodeNotFound)
@@ -33,7 +33,7 @@ func TestSetAppSubscription_NotFound(t *testing.T) {
 }
 
 func TestSetAppSubscription_NilAssistant(t *testing.T) {
-	svc, _, _, apps, _, _ := newSvc(t)
+	svc, _, _, apps, _, _, _ := newSvc(t)
 	apps.EXPECT().GetApp(gomock.Any(), "app1").Return(&model.App{ID: "app1", Name: "NoAssistant"}, nil)
 	_, err := svc.SetAppSubscription(ctx("alice", "site-a"), models.SetAppSubscriptionRequest{AppID: "app1", Subscribed: true})
 	requireCode(t, err, errcode.CodeBadRequest)
@@ -42,7 +42,7 @@ func TestSetAppSubscription_NilAssistant(t *testing.T) {
 
 // A disabled assistant (Enabled=false) is now subscribable — the enabled check was removed.
 func TestSetAppSubscription_DisabledAssistantAllowed(t *testing.T) {
-	svc, subs, _, apps, rooms, _ := newSvc(t)
+	svc, subs, _, apps, rooms, _, _ := newSvc(t)
 	apps.EXPECT().GetApp(gomock.Any(), "app1").Return(appWith(false), nil)
 	subs.EXPECT().GetAppSubscription(gomock.Any(), "alice", "helper.bot").Return(nil, nil)
 	rooms.EXPECT().CreateDMRoom(gomock.Any(), "alice", "helper.bot", model.RoomTypeBotDM).Return(model.Subscription{ID: "new"}, nil)
@@ -52,14 +52,14 @@ func TestSetAppSubscription_DisabledAssistantAllowed(t *testing.T) {
 }
 
 func TestSetAppSubscription_GetAppStoreError(t *testing.T) {
-	svc, _, _, apps, _, _ := newSvc(t)
+	svc, _, _, apps, _, _, _ := newSvc(t)
 	apps.EXPECT().GetApp(gomock.Any(), "app1").Return(nil, errors.New("db down"))
 	_, err := svc.SetAppSubscription(ctx("alice", "site-a"), models.SetAppSubscriptionRequest{AppID: "app1", Subscribed: true})
 	requireCode(t, err, errcode.CodeInternal)
 }
 
 func TestSetAppSubscription_SubscribeNew(t *testing.T) {
-	svc, subs, _, apps, rooms, _ := newSvc(t)
+	svc, subs, _, apps, rooms, _, _ := newSvc(t)
 	apps.EXPECT().GetApp(gomock.Any(), "app1").Return(appWith(true), nil)
 	subs.EXPECT().GetAppSubscription(gomock.Any(), "alice", "helper.bot").Return(nil, nil)
 	rooms.EXPECT().CreateDMRoom(gomock.Any(), "alice", "helper.bot", model.RoomTypeBotDM).Return(model.Subscription{ID: "new"}, nil)
@@ -69,7 +69,7 @@ func TestSetAppSubscription_SubscribeNew(t *testing.T) {
 }
 
 func TestSetAppSubscription_GetAppSubscriptionStoreError(t *testing.T) {
-	svc, subs, _, apps, _, _ := newSvc(t)
+	svc, subs, _, apps, _, _, _ := newSvc(t)
 	apps.EXPECT().GetApp(gomock.Any(), "app1").Return(appWith(true), nil)
 	subs.EXPECT().GetAppSubscription(gomock.Any(), "alice", "helper.bot").Return(nil, errors.New("db down"))
 	_, err := svc.SetAppSubscription(ctx("alice", "site-a"), models.SetAppSubscriptionRequest{AppID: "app1", Subscribed: true})
@@ -77,7 +77,7 @@ func TestSetAppSubscription_GetAppSubscriptionStoreError(t *testing.T) {
 }
 
 func TestSetAppSubscription_CreateDMRoomError(t *testing.T) {
-	svc, subs, _, apps, rooms, _ := newSvc(t)
+	svc, subs, _, apps, rooms, _, _ := newSvc(t)
 	apps.EXPECT().GetApp(gomock.Any(), "app1").Return(appWith(true), nil)
 	subs.EXPECT().GetAppSubscription(gomock.Any(), "alice", "helper.bot").Return(nil, nil)
 	rooms.EXPECT().CreateDMRoom(gomock.Any(), "alice", "helper.bot", model.RoomTypeBotDM).Return(model.Subscription{}, errors.New("room svc down"))
@@ -86,7 +86,7 @@ func TestSetAppSubscription_CreateDMRoomError(t *testing.T) {
 }
 
 func TestSetAppSubscription_Reactivate_ClearsMuted(t *testing.T) {
-	svc, subs, _, apps, _, _ := newSvc(t)
+	svc, subs, _, apps, _, _, _ := newSvc(t)
 	apps.EXPECT().GetApp(gomock.Any(), "app1").Return(appWith(true), nil)
 	subs.EXPECT().GetAppSubscription(gomock.Any(), "alice", "helper.bot").Return(&model.Subscription{ID: "ex", Muted: true}, nil)
 	subs.EXPECT().SetAppSubscribed(gomock.Any(), "alice", "helper.bot", true, false).Return(nil)
@@ -96,7 +96,7 @@ func TestSetAppSubscription_Reactivate_ClearsMuted(t *testing.T) {
 }
 
 func TestSetAppSubscription_ReactivateSetAppSubscribedError(t *testing.T) {
-	svc, subs, _, apps, _, _ := newSvc(t)
+	svc, subs, _, apps, _, _, _ := newSvc(t)
 	apps.EXPECT().GetApp(gomock.Any(), "app1").Return(appWith(true), nil)
 	subs.EXPECT().GetAppSubscription(gomock.Any(), "alice", "helper.bot").Return(&model.Subscription{ID: "ex"}, nil)
 	subs.EXPECT().SetAppSubscribed(gomock.Any(), "alice", "helper.bot", true, false).Return(errors.New("db down"))
@@ -105,7 +105,7 @@ func TestSetAppSubscription_ReactivateSetAppSubscribedError(t *testing.T) {
 }
 
 func TestSetAppSubscription_Unsubscribe(t *testing.T) {
-	svc, subs, _, apps, _, _ := newSvc(t)
+	svc, subs, _, apps, _, _, _ := newSvc(t)
 	apps.EXPECT().GetApp(gomock.Any(), "app1").Return(appWith(true), nil)
 	subs.EXPECT().SetAppSubscribed(gomock.Any(), "alice", "helper.bot", false, true).Return(nil)
 	resp, err := svc.SetAppSubscription(ctx("alice", "site-a"), models.SetAppSubscriptionRequest{AppID: "app1", Subscribed: false})
@@ -114,7 +114,7 @@ func TestSetAppSubscription_Unsubscribe(t *testing.T) {
 }
 
 func TestSetAppSubscription_UnsubscribeSetAppSubscribedError(t *testing.T) {
-	svc, subs, _, apps, _, _ := newSvc(t)
+	svc, subs, _, apps, _, _, _ := newSvc(t)
 	apps.EXPECT().GetApp(gomock.Any(), "app1").Return(appWith(true), nil)
 	subs.EXPECT().SetAppSubscribed(gomock.Any(), "alice", "helper.bot", false, true).Return(errors.New("db down"))
 	_, err := svc.SetAppSubscription(ctx("alice", "site-a"), models.SetAppSubscriptionRequest{AppID: "app1", Subscribed: false})
@@ -122,7 +122,7 @@ func TestSetAppSubscription_UnsubscribeSetAppSubscribedError(t *testing.T) {
 }
 
 func TestListApps(t *testing.T) {
-	svc, _, _, apps, _, _ := newSvc(t)
+	svc, _, _, apps, _, _, _ := newSvc(t)
 	// Empty request → defaults: offset 0, limit 20.
 	apps.EXPECT().ListApps(gomock.Any(), "alice", mongoutil.OffsetPageRequest{Offset: 0, Limit: 20}).
 		Return(mongoutil.OffsetPageHasMore[models.AppListItem]{Data: []models.AppListItem{
@@ -148,7 +148,7 @@ func TestListApps_PageRequestForwarding(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc, _, _, apps, _, _ := newSvc(t)
+			svc, _, _, apps, _, _, _ := newSvc(t)
 			apps.EXPECT().ListApps(gomock.Any(), "alice", tt.want).
 				Return(mongoutil.OffsetPageHasMore[models.AppListItem]{Data: []models.AppListItem{}}, nil)
 			_, err := svc.ListApps(ctx("alice", "site-a"), tt.req)
@@ -158,7 +158,7 @@ func TestListApps_PageRequestForwarding(t *testing.T) {
 }
 
 func TestListApps_HasMoreForwarded(t *testing.T) {
-	svc, _, _, apps, _, _ := newSvc(t)
+	svc, _, _, apps, _, _, _ := newSvc(t)
 	apps.EXPECT().ListApps(gomock.Any(), "alice", mongoutil.OffsetPageRequest{Offset: 0, Limit: 2}).
 		Return(mongoutil.OffsetPageHasMore[models.AppListItem]{Data: []models.AppListItem{
 			{App: model.App{ID: "a1"}},
@@ -171,7 +171,7 @@ func TestListApps_HasMoreForwarded(t *testing.T) {
 }
 
 func TestListApps_StoreError(t *testing.T) {
-	svc, _, _, apps, _, _ := newSvc(t)
+	svc, _, _, apps, _, _, _ := newSvc(t)
 	apps.EXPECT().ListApps(gomock.Any(), "alice", gomock.Any()).
 		Return(mongoutil.OffsetPageHasMore[models.AppListItem]{}, errors.New("db down"))
 	_, err := svc.ListApps(ctx("alice", "site-a"), models.AppsListRequest{})
@@ -179,7 +179,7 @@ func TestListApps_StoreError(t *testing.T) {
 }
 
 func TestListApps_Empty(t *testing.T) {
-	svc, _, _, apps, _, _ := newSvc(t)
+	svc, _, _, apps, _, _, _ := newSvc(t)
 	apps.EXPECT().ListApps(gomock.Any(), "alice", gomock.Any()).
 		Return(mongoutil.OffsetPageHasMore[models.AppListItem]{Data: []models.AppListItem{}}, nil)
 	resp, err := svc.ListApps(ctx("alice", "site-a"), models.AppsListRequest{})
@@ -189,7 +189,7 @@ func TestListApps_Empty(t *testing.T) {
 }
 
 func TestListAppCategories_Success(t *testing.T) {
-	svc, _, _, apps, _, _ := newSvc(t)
+	svc, _, _, apps, _, _, _ := newSvc(t)
 	apps.EXPECT().ListAppCategories(gomock.Any()).Return([]models.AppCategory{
 		{ID: "m1", Name: "F22", SiteID: "00600000"},
 		{ID: "m2", Name: "F14", SiteID: "00700000"},
@@ -204,7 +204,7 @@ func TestListAppCategories_Success(t *testing.T) {
 }
 
 func TestListAppCategories_EmptyIsArrayNotNull(t *testing.T) {
-	svc, _, _, apps, _, _ := newSvc(t)
+	svc, _, _, apps, _, _, _ := newSvc(t)
 	apps.EXPECT().ListAppCategories(gomock.Any()).Return(nil, nil)
 
 	resp, err := svc.ListAppCategories(ctx("alice", "site-a"))
@@ -214,7 +214,7 @@ func TestListAppCategories_EmptyIsArrayNotNull(t *testing.T) {
 }
 
 func TestListAppCategories_RepoError(t *testing.T) {
-	svc, _, _, apps, _, _ := newSvc(t)
+	svc, _, _, apps, _, _, _ := newSvc(t)
 	apps.EXPECT().ListAppCategories(gomock.Any()).Return(nil, errors.New("mongo down"))
 
 	_, err := svc.ListAppCategories(ctx("alice", "site-a"))

--- a/user-service/service/enrich_test.go
+++ b/user-service/service/enrich_test.go
@@ -17,7 +17,7 @@ import (
 // site RPC takes ~5s, so firing them for a request nobody awaits is pure waste.
 // In-flight calls still fail fast via the ctx passed to GetRoomsInfo.
 func TestEnrichCrossSite_ContextCancelled_SkipsRPC(t *testing.T) {
-	svc, _, _, _, rooms, _ := newSvc(t)
+	svc, _, _, _, rooms, _, _ := newSvc(t)
 	subs := []model.EnrichedSubscription{
 		{Subscription: model.Subscription{ID: "b", RoomID: "r2", SiteID: "site-b"}},
 	}
@@ -46,7 +46,7 @@ func key32(b byte) []byte {
 }
 
 func TestEnrichWithRoomInfo_LocalAndCrossSite(t *testing.T) {
-	svc, _, _, _, rooms, _ := newSvc(t)
+	svc, _, _, _, rooms, _, _ := newSvc(t)
 	seen := time.UnixMilli(100).UTC()
 	localMsg := time.UnixMilli(150).UTC()
 	newer := int64(200)
@@ -87,7 +87,7 @@ func TestEnrichWithRoomInfo_LocalAndCrossSite(t *testing.T) {
 // TestEnrichWithRoomInfo_LocalKeyMaterial pins that a LOCAL sub whose room has a
 // key gets base64 PrivateKey + KeyVersion from the $lookup baseline, with NO RPC.
 func TestEnrichWithRoomInfo_LocalKeyMaterial(t *testing.T) {
-	svc, _, _, _, _, _ := newSvc(t)
+	svc, _, _, _, _, _, _ := newSvc(t)
 	subs := []model.EnrichedSubscription{
 		// LOCAL sub carrying the room key in its $lookup baseline (current slot).
 		{Subscription: model.Subscription{ID: "a", RoomID: "r1", SiteID: "site-a"},
@@ -110,7 +110,7 @@ func TestEnrichWithRoomInfo_LocalKeyMaterial(t *testing.T) {
 // TestEnrichWithRoomInfo_LocalNoKey pins that a LOCAL sub whose room has no key
 // still gets a baseline room object with no key material.
 func TestEnrichWithRoomInfo_LocalNoKey(t *testing.T) {
-	svc, _, _, _, _, _ := newSvc(t)
+	svc, _, _, _, _, _, _ := newSvc(t)
 	subs := []model.EnrichedSubscription{
 		{Subscription: model.Subscription{ID: "a", RoomID: "r1", SiteID: "site-a"},
 			RoomName: "Eng", UserCount: 5, LastMsgID: "m-base"},
@@ -130,7 +130,7 @@ func TestEnrichWithRoomInfo_LocalNoKey(t *testing.T) {
 // secret isn't 32 bytes is treated as absent — the local room object is still
 // built, just with no key material.
 func TestEnrichWithRoomInfo_LocalInvalidKeyLength(t *testing.T) {
-	svc, _, _, _, _, _ := newSvc(t)
+	svc, _, _, _, _, _, _ := newSvc(t)
 	subs := []model.EnrichedSubscription{
 		{Subscription: model.Subscription{ID: "a", RoomID: "r1", SiteID: "site-a"},
 			RoomName: "Eng", UserCount: 5, RoomKeyPriv: []byte("short"), RoomKeyVer: 2},
@@ -158,7 +158,7 @@ func TestEnrichWithRoomInfo_AllRoomTypesKeyed(t *testing.T) {
 		{"botDM", model.RoomTypeBotDM},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			svc, _, _, _, _, _ := newSvc(t)
+			svc, _, _, _, _, _, _ := newSvc(t)
 			subs := []model.EnrichedSubscription{
 				{Subscription: model.Subscription{ID: "a", RoomID: "r1", SiteID: "site-a", RoomType: tc.roomType},
 					RoomName: "room", RoomKeyPriv: key32(0xAB), RoomKeyVer: 4},
@@ -179,7 +179,7 @@ func TestEnrichWithRoomInfo_AllRoomTypesKeyed(t *testing.T) {
 // room's RPC entry is authoritative for the room object even when fields are
 // zero; the internal baseline stays on the flattened sub fields only.
 func TestEnrichWithRoomInfo_CrossSiteRPCZeroFields(t *testing.T) {
-	svc, _, _, _, rooms, _ := newSvc(t)
+	svc, _, _, _, rooms, _, _ := newSvc(t)
 	subs := []model.EnrichedSubscription{{Subscription: model.Subscription{ID: "a", RoomID: "r2", SiteID: "site-b"}, UserCount: 5, LastMsgID: "m-base"}}
 	rooms.EXPECT().GetRoomsInfo(gomock.Any(), "site-b", []string{"r2"}).
 		Return([]model.RoomInfo{{RoomID: "r2", Found: true, Name: "Ops"}}, nil)
@@ -194,7 +194,7 @@ func TestEnrichWithRoomInfo_CrossSiteRPCZeroFields(t *testing.T) {
 // RPC reports as not-found yields NO room object — there is no local baseline to
 // fall back to for a remote room.
 func TestEnrichWithRoomInfo_CrossSiteNotFoundNoRoom(t *testing.T) {
-	svc, _, _, _, rooms, _ := newSvc(t)
+	svc, _, _, _, rooms, _, _ := newSvc(t)
 	subs := []model.EnrichedSubscription{{Subscription: model.Subscription{ID: "a", RoomID: "r2", SiteID: "site-b"}, UserCount: 5, LastMsgID: "m-base"}}
 	rooms.EXPECT().GetRoomsInfo(gomock.Any(), "site-b", []string{"r2"}).
 		Return([]model.RoomInfo{{RoomID: "r2", Found: false}}, nil)
@@ -207,7 +207,7 @@ func TestEnrichWithRoomInfo_CrossSiteNotFoundNoRoom(t *testing.T) {
 // TestEnrichWithRoomInfo_LocalDeletedRoomNoRoom pins that a LOCAL sub whose room is
 // soft-deleted (baseline name "Del-...") is kept but gets NO room object.
 func TestEnrichWithRoomInfo_LocalDeletedRoomNoRoom(t *testing.T) {
-	svc, _, _, _, _, _ := newSvc(t)
+	svc, _, _, _, _, _, _ := newSvc(t)
 	subs := []model.EnrichedSubscription{
 		{Subscription: model.Subscription{ID: "a", RoomID: "r1", SiteID: "site-a", Name: "team"},
 			RoomName: "Del-Team", UserCount: 5, RoomKeyPriv: key32(0xAB), RoomKeyVer: 1},
@@ -223,7 +223,7 @@ func TestEnrichWithRoomInfo_LocalDeletedRoomNoRoom(t *testing.T) {
 // in-query exclusion of locally-deleted rooms — while a healthy sibling on the same
 // site and a local sub survive (order preserved).
 func TestEnrichWithRoomInfo_CrossSiteDeletedRoomDroppedFromList(t *testing.T) {
-	svc, _, _, _, rooms, _ := newSvc(t)
+	svc, _, _, _, rooms, _, _ := newSvc(t)
 	subs := []model.EnrichedSubscription{
 		// LOCAL healthy sub — survives (no RPC).
 		{Subscription: model.Subscription{ID: "loc", RoomID: "r1", SiteID: "site-a"}, RoomName: "Eng"},
@@ -252,7 +252,7 @@ func TestEnrichWithRoomInfo_CrossSiteDeletedRoomDroppedFromList(t *testing.T) {
 // room is soft-deleted is KEPT with NO room object — exactly how a LOCAL Del- sub is
 // kept room-nulled in those lookups (never dropped).
 func TestEnrichWithRoomInfo_CrossSiteDeletedRoomKeptRoomlessInLookup(t *testing.T) {
-	svc, _, _, _, rooms, _ := newSvc(t)
+	svc, _, _, _, rooms, _, _ := newSvc(t)
 	subs := []model.EnrichedSubscription{{Subscription: model.Subscription{ID: "del", RoomID: "r2", SiteID: "site-b"}}}
 	rooms.EXPECT().GetRoomsInfo(gomock.Any(), "site-b", []string{"r2"}).
 		Return([]model.RoomInfo{{RoomID: "r2", Found: true, Name: "Del-Ops"}}, nil)
@@ -268,7 +268,7 @@ func TestEnrichWithRoomInfo_CrossSiteDeletedRoomKeptRoomlessInLookup(t *testing.
 // degradation: a failed site RPC leaves that site's subs without a room object,
 // while sibling sites are still enriched. The local sub is built from the baseline.
 func TestEnrichWithRoomInfo_CrossSiteRPCFailDegradesSiteKeepsOthers(t *testing.T) {
-	svc, _, _, _, rooms, _ := newSvc(t)
+	svc, _, _, _, rooms, _, _ := newSvc(t)
 	seen := time.UnixMilli(100).UTC()
 	newer := int64(200)
 	subs := []model.EnrichedSubscription{
@@ -291,7 +291,7 @@ func TestEnrichWithRoomInfo_CrossSiteRPCFailDegradesSiteKeepsOthers(t *testing.T
 }
 
 func TestEnrichWithRoomInfo_Empty(t *testing.T) {
-	svc, _, _, _, _, _ := newSvc(t)
+	svc, _, _, _, _, _, _ := newSvc(t)
 	// No GetRoomsInfo / GetMany expectations: empty input must short-circuit before any call.
 	svc.enrichWithRoomInfo(ctx("alice", "site-a"), nil, true)
 	svc.enrichWithRoomInfo(ctx("alice", "site-a"), []model.EnrichedSubscription{}, true)
@@ -301,7 +301,7 @@ func TestEnrichWithRoomInfo_Empty(t *testing.T) {
 // leaves alert/hasMention alone — they are stored subscription state, never
 // derived from room timestamps.
 func TestEnrichWithRoomInfo_LocalNeverRecomputesFlags(t *testing.T) {
-	svc, _, _, _, _, _ := newSvc(t)
+	svc, _, _, _, _, _, _ := newSvc(t)
 	seen := time.UnixMilli(100).UTC()
 	newer := time.UnixMilli(999).UTC()
 	mentionAt := time.UnixMilli(999).UTC()
@@ -364,7 +364,7 @@ func TestEnrichWithRoomInfo_ComputesHasUnread_Local(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			svc, _, _, _, _, _ := newSvc(t)
+			svc, _, _, _, _, _, _ := newSvc(t)
 			subs := []model.EnrichedSubscription{tc.sub}
 			svc.enrichWithRoomInfo(ctx("alice", "site-a"), subs, true)
 			assert.Equal(t, tc.want, subs[0].HasUnread)
@@ -422,7 +422,7 @@ func TestEnrichWithRoomInfo_ComputesHasGroupMention_Local(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			svc, _, _, _, _, _ := newSvc(t)
+			svc, _, _, _, _, _, _ := newSvc(t)
 			subs := []model.EnrichedSubscription{tc.sub}
 			svc.enrichWithRoomInfo(ctx("alice", "site-a"), subs, true)
 			assert.Equal(t, tc.want, subs[0].HasGroupMention)

--- a/user-service/service/enrich_test.go
+++ b/user-service/service/enrich_test.go
@@ -62,7 +62,7 @@ func TestEnrichWithRoomInfo_LocalAndCrossSite(t *testing.T) {
 	rooms.EXPECT().GetRoomsInfo(gomock.Any(), "site-b", []string{"r2"}).
 		Return([]model.RoomInfo{{RoomID: "r2", Found: true, Name: "Ops", UserCount: 3, LastMsgAt: &newer, LastMsgID: "m-3"}}, nil)
 
-	svc.enrichWithRoomInfo(ctx("alice", "site-a"), subs, true)
+	svc.enrichWithRoomInfoAndLastMsg(ctx("alice", "site-a"), subs, true, false)
 
 	assert.Equal(t, "eng-sub", subs[0].Name, "subscription name must survive enrichment")
 	assert.True(t, subs[0].Alert, "stored alert preserved")
@@ -95,7 +95,7 @@ func TestEnrichWithRoomInfo_LocalKeyMaterial(t *testing.T) {
 	}
 	// No GetRoomsInfo expectation: an all-local input must never hit the RPC.
 
-	svc.enrichWithRoomInfo(ctx("alice", "site-a"), subs, true)
+	svc.enrichWithRoomInfoAndLastMsg(ctx("alice", "site-a"), subs, true, false)
 
 	require.NotNil(t, subs[0].Room)
 	assert.Equal(t, "Eng", subs[0].Room.Name)
@@ -116,7 +116,7 @@ func TestEnrichWithRoomInfo_LocalNoKey(t *testing.T) {
 			RoomName: "Eng", UserCount: 5, LastMsgID: "m-base"},
 	}
 
-	svc.enrichWithRoomInfo(ctx("alice", "site-a"), subs, true)
+	svc.enrichWithRoomInfoAndLastMsg(ctx("alice", "site-a"), subs, true, false)
 
 	require.NotNil(t, subs[0].Room, "local room must still be built from the baseline")
 	assert.Equal(t, "Eng", subs[0].Room.Name)
@@ -136,7 +136,7 @@ func TestEnrichWithRoomInfo_LocalInvalidKeyLength(t *testing.T) {
 			RoomName: "Eng", UserCount: 5, RoomKeyPriv: []byte("short"), RoomKeyVer: 2},
 	}
 
-	svc.enrichWithRoomInfo(ctx("alice", "site-a"), subs, true)
+	svc.enrichWithRoomInfoAndLastMsg(ctx("alice", "site-a"), subs, true, false)
 
 	require.NotNil(t, subs[0].Room, "invalid-length key still yields a baseline room object")
 	assert.Equal(t, "Eng", subs[0].Room.Name)
@@ -164,7 +164,7 @@ func TestEnrichWithRoomInfo_AllRoomTypesKeyed(t *testing.T) {
 					RoomName: "room", RoomKeyPriv: key32(0xAB), RoomKeyVer: 4},
 			}
 
-			svc.enrichWithRoomInfo(ctx("alice", "site-a"), subs, true)
+			svc.enrichWithRoomInfoAndLastMsg(ctx("alice", "site-a"), subs, true, false)
 
 			require.NotNil(t, subs[0].Room)
 			require.NotNil(t, subs[0].Room.PrivateKey, "every room type returns its key")
@@ -183,7 +183,7 @@ func TestEnrichWithRoomInfo_CrossSiteRPCZeroFields(t *testing.T) {
 	subs := []model.EnrichedSubscription{{Subscription: model.Subscription{ID: "a", RoomID: "r2", SiteID: "site-b"}, UserCount: 5, LastMsgID: "m-base"}}
 	rooms.EXPECT().GetRoomsInfo(gomock.Any(), "site-b", []string{"r2"}).
 		Return([]model.RoomInfo{{RoomID: "r2", Found: true, Name: "Ops"}}, nil)
-	svc.enrichWithRoomInfo(ctx("alice", "site-a"), subs, true)
+	svc.enrichWithRoomInfoAndLastMsg(ctx("alice", "site-a"), subs, true, false)
 	require.NotNil(t, subs[0].Room)
 	assert.Equal(t, "Ops", subs[0].Room.Name)
 	assert.Equal(t, 5, subs[0].UserCount, "internal baseline untouched")
@@ -198,7 +198,7 @@ func TestEnrichWithRoomInfo_CrossSiteNotFoundNoRoom(t *testing.T) {
 	subs := []model.EnrichedSubscription{{Subscription: model.Subscription{ID: "a", RoomID: "r2", SiteID: "site-b"}, UserCount: 5, LastMsgID: "m-base"}}
 	rooms.EXPECT().GetRoomsInfo(gomock.Any(), "site-b", []string{"r2"}).
 		Return([]model.RoomInfo{{RoomID: "r2", Found: false}}, nil)
-	svc.enrichWithRoomInfo(ctx("alice", "site-a"), subs, true)
+	svc.enrichWithRoomInfoAndLastMsg(ctx("alice", "site-a"), subs, true, false)
 	assert.Len(t, subs, 1)
 	assert.False(t, subs[0].Alert)
 	assert.Nil(t, subs[0].Room, "not-found cross-site room ⇒ no room object (no local baseline)")
@@ -212,7 +212,7 @@ func TestEnrichWithRoomInfo_LocalDeletedRoomNoRoom(t *testing.T) {
 		{Subscription: model.Subscription{ID: "a", RoomID: "r1", SiteID: "site-a", Name: "team"},
 			RoomName: "Del-Team", UserCount: 5, RoomKeyPriv: key32(0xAB), RoomKeyVer: 1},
 	}
-	svc.enrichWithRoomInfo(ctx("alice", "site-a"), subs, true)
+	svc.enrichWithRoomInfoAndLastMsg(ctx("alice", "site-a"), subs, true, false)
 	assert.Nil(t, subs[0].Room, "soft-deleted local room ⇒ no room object")
 	assert.Equal(t, "team", subs[0].Name, "the subscription itself is kept")
 }
@@ -238,7 +238,7 @@ func TestEnrichWithRoomInfo_CrossSiteDeletedRoomDroppedFromList(t *testing.T) {
 			{RoomID: "r3", Found: true, Name: "Ops"},
 		}, nil)
 
-	got := svc.enrichWithRoomInfo(ctx("alice", "site-a"), subs, true)
+	got := svc.enrichWithRoomInfoAndLastMsg(ctx("alice", "site-a"), subs, true, false)
 
 	require.Len(t, got, 2, "the cross-site Del- sub is dropped from a list")
 	assert.Equal(t, "loc", got[0].ID, "local sub survives, order preserved")
@@ -257,7 +257,7 @@ func TestEnrichWithRoomInfo_CrossSiteDeletedRoomKeptRoomlessInLookup(t *testing.
 	rooms.EXPECT().GetRoomsInfo(gomock.Any(), "site-b", []string{"r2"}).
 		Return([]model.RoomInfo{{RoomID: "r2", Found: true, Name: "Del-Ops"}}, nil)
 
-	got := svc.enrichWithRoomInfo(ctx("alice", "site-a"), subs, false)
+	got := svc.enrichWithRoomInfoAndLastMsg(ctx("alice", "site-a"), subs, false, false)
 
 	require.Len(t, got, 1, "single-item lookup keeps the Del- sub")
 	assert.Equal(t, "del", got[0].ID)
@@ -280,7 +280,7 @@ func TestEnrichWithRoomInfo_CrossSiteRPCFailDegradesSiteKeepsOthers(t *testing.T
 	rooms.EXPECT().GetRoomsInfo(gomock.Any(), "site-c", []string{"r3"}).
 		Return([]model.RoomInfo{{RoomID: "r3", Found: true, Name: "Ops", LastMsgAt: &newer}}, nil)
 
-	svc.enrichWithRoomInfo(ctx("alice", "site-a"), subs, true)
+	svc.enrichWithRoomInfoAndLastMsg(ctx("alice", "site-a"), subs, true, false)
 
 	require.NotNil(t, subs[0].Room, "local sub built from baseline")
 	assert.Equal(t, "Eng", subs[0].Room.Name)
@@ -293,8 +293,8 @@ func TestEnrichWithRoomInfo_CrossSiteRPCFailDegradesSiteKeepsOthers(t *testing.T
 func TestEnrichWithRoomInfo_Empty(t *testing.T) {
 	svc, _, _, _, _, _, _ := newSvc(t)
 	// No GetRoomsInfo / GetMany expectations: empty input must short-circuit before any call.
-	svc.enrichWithRoomInfo(ctx("alice", "site-a"), nil, true)
-	svc.enrichWithRoomInfo(ctx("alice", "site-a"), []model.EnrichedSubscription{}, true)
+	svc.enrichWithRoomInfoAndLastMsg(ctx("alice", "site-a"), nil, true, false)
+	svc.enrichWithRoomInfoAndLastMsg(ctx("alice", "site-a"), []model.EnrichedSubscription{}, true, false)
 }
 
 // TestEnrichWithRoomInfo_LocalNeverRecomputesFlags pins that local enrichment
@@ -309,7 +309,7 @@ func TestEnrichWithRoomInfo_LocalNeverRecomputesFlags(t *testing.T) {
 		{Subscription: model.Subscription{ID: "a", RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen, Alert: false, HasMention: false},
 			RoomName: "Eng", LastMsgAt: &newer, LastMentionAllAt: &mentionAt},
 	}
-	svc.enrichWithRoomInfo(ctx("alice", "site-a"), subs, true)
+	svc.enrichWithRoomInfoAndLastMsg(ctx("alice", "site-a"), subs, true, false)
 	assert.False(t, subs[0].Alert, "room lastMsgAt newer than lastSeen must NOT flip stored alert")
 	assert.False(t, subs[0].HasMention, "room lastMentionAllAt newer than lastSeen must NOT flip stored hasMention")
 }
@@ -366,7 +366,7 @@ func TestEnrichWithRoomInfo_ComputesHasUnread_Local(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			svc, _, _, _, _, _, _ := newSvc(t)
 			subs := []model.EnrichedSubscription{tc.sub}
-			svc.enrichWithRoomInfo(ctx("alice", "site-a"), subs, true)
+			svc.enrichWithRoomInfoAndLastMsg(ctx("alice", "site-a"), subs, true, false)
 			assert.Equal(t, tc.want, subs[0].HasUnread)
 		})
 	}
@@ -424,7 +424,7 @@ func TestEnrichWithRoomInfo_ComputesHasGroupMention_Local(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			svc, _, _, _, _, _, _ := newSvc(t)
 			subs := []model.EnrichedSubscription{tc.sub}
-			svc.enrichWithRoomInfo(ctx("alice", "site-a"), subs, true)
+			svc.enrichWithRoomInfoAndLastMsg(ctx("alice", "site-a"), subs, true, false)
 			assert.Equal(t, tc.want, subs[0].HasGroupMention)
 		})
 	}

--- a/user-service/service/mocks/mock_repository.go
+++ b/user-service/service/mocks/mock_repository.go
@@ -423,6 +423,21 @@ func (mr *MockHistoryClientMockRecorder) GetThreadList(ctx, siteID, req any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThreadList", reflect.TypeOf((*MockHistoryClient)(nil).GetThreadList), ctx, siteID, req)
 }
 
+// RoomsGet mocks base method.
+func (m *MockHistoryClient) RoomsGet(ctx context.Context, account, siteID string, roomIDs []string) (map[string]model.LastMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RoomsGet", ctx, account, siteID, roomIDs)
+	ret0, _ := ret[0].(map[string]model.LastMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RoomsGet indicates an expected call of RoomsGet.
+func (mr *MockHistoryClientMockRecorder) RoomsGet(ctx, account, siteID, roomIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RoomsGet", reflect.TypeOf((*MockHistoryClient)(nil).RoomsGet), ctx, account, siteID, roomIDs)
+}
+
 // MockPresenceClient is a mock of PresenceClient interface.
 type MockPresenceClient struct {
 	ctrl     *gomock.Controller

--- a/user-service/service/mocks/mock_repository.go
+++ b/user-service/service/mocks/mock_repository.go
@@ -424,18 +424,18 @@ func (mr *MockHistoryClientMockRecorder) GetThreadList(ctx, siteID, req any) *go
 }
 
 // RoomsGet mocks base method.
-func (m *MockHistoryClient) RoomsGet(ctx context.Context, account, siteID string, roomIDs []string) (map[string]model.LastMessage, error) {
+func (m *MockHistoryClient) RoomsGet(ctx context.Context, siteID string, roomIDs []string) (map[string]model.LastMessage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RoomsGet", ctx, account, siteID, roomIDs)
+	ret := m.ctrl.Call(m, "RoomsGet", ctx, siteID, roomIDs)
 	ret0, _ := ret[0].(map[string]model.LastMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RoomsGet indicates an expected call of RoomsGet.
-func (mr *MockHistoryClientMockRecorder) RoomsGet(ctx, account, siteID, roomIDs any) *gomock.Call {
+func (mr *MockHistoryClientMockRecorder) RoomsGet(ctx, siteID, roomIDs any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RoomsGet", reflect.TypeOf((*MockHistoryClient)(nil).RoomsGet), ctx, account, siteID, roomIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RoomsGet", reflect.TypeOf((*MockHistoryClient)(nil).RoomsGet), ctx, siteID, roomIDs)
 }
 
 // MockPresenceClient is a mock of PresenceClient interface.

--- a/user-service/service/service.go
+++ b/user-service/service/service.go
@@ -57,7 +57,7 @@ type ThreadSubscriptionRepository interface {
 // RPCs, fanned out across sites by the thread-inbox aggregator.
 type HistoryClient interface {
 	GetThreadList(ctx context.Context, siteID string, req model.ThreadSubscriptionListRequest) (model.ThreadSubscriptionListResponse, error)
-	RoomsGet(ctx context.Context, account, siteID string, roomIDs []string) (map[string]model.LastMessage, error)
+	RoomsGet(ctx context.Context, siteID string, roomIDs []string) (map[string]model.LastMessage, error)
 }
 
 // PresenceClient is the consumer-defined interface for user-presence-service RPC calls.

--- a/user-service/service/service.go
+++ b/user-service/service/service.go
@@ -57,6 +57,7 @@ type ThreadSubscriptionRepository interface {
 // RPCs, fanned out across sites by the thread-inbox aggregator.
 type HistoryClient interface {
 	GetThreadList(ctx context.Context, siteID string, req model.ThreadSubscriptionListRequest) (model.ThreadSubscriptionListResponse, error)
+	RoomsGet(ctx context.Context, account, siteID string, roomIDs []string) (map[string]model.LastMessage, error)
 }
 
 // PresenceClient is the consumer-defined interface for user-presence-service RPC calls.

--- a/user-service/service/service_test.go
+++ b/user-service/service/service_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hmchangw/chat/user-service/service/mocks"
 )
 
-func newSvc(t *testing.T) (*UserService, *mocks.MockSubscriptionRepository, *mocks.MockUserRepository, *mocks.MockAppRepository, *mocks.MockRoomClient, *mocks.MockEventPublisher) {
+func newSvc(t *testing.T) (*UserService, *mocks.MockSubscriptionRepository, *mocks.MockUserRepository, *mocks.MockAppRepository, *mocks.MockRoomClient, *mocks.MockHistoryClient, *mocks.MockEventPublisher) {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 	subs := mocks.NewMockSubscriptionRepository(ctrl)
@@ -26,7 +26,10 @@ func newSvc(t *testing.T) (*UserService, *mocks.MockSubscriptionRepository, *moc
 	pub := mocks.NewMockEventPublisher(ctrl)
 	cfg := &config.Config{SiteID: "site-a", AllSiteIDs: []string{"site-a", "site-b"}, MaxSubscriptionLimit: 1000, DefaultSubscriptionLimit: 40, MaxAppsLimit: 100, DefaultAppsLimit: 20, MaxAccountNames: 100}
 	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
-	return New(subs, users, apps, threadSubs, rooms, history, presence, pub, cfg), subs, users, apps, rooms, pub
+	// ListSubscriptions now enriches last-message via history.RoomsGet; default it to a
+	// no-op so list tests that don't exercise last-message need no per-test stub.
+	history.EXPECT().RoomsGet(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	return New(subs, users, apps, threadSubs, rooms, history, presence, pub, cfg), subs, users, apps, rooms, history, pub
 }
 
 // ctx builds a handler context. siteID is retained for readability but unused

--- a/user-service/service/service_test.go
+++ b/user-service/service/service_test.go
@@ -28,7 +28,7 @@ func newSvc(t *testing.T) (*UserService, *mocks.MockSubscriptionRepository, *moc
 	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
 	// ListSubscriptions now enriches last-message via history.RoomsGet; default it to a
 	// no-op so list tests that don't exercise last-message need no per-test stub.
-	history.EXPECT().RoomsGet(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	history.EXPECT().RoomsGet(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	return New(subs, users, apps, threadSubs, rooms, history, presence, pub, cfg), subs, users, apps, rooms, history, pub
 }
 

--- a/user-service/service/status_test.go
+++ b/user-service/service/status_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestGetStatusByName(t *testing.T) {
-	svc, _, users, _, _, _ := newSvc(t)
+	svc, _, users, _, _, _, _ := newSvc(t)
 	users.EXPECT().GetUserStatus(gomock.Any(), "bob").
 		Return(&model.User{Account: "bob", StatusText: "hi", StatusIsShow: true, EngName: "Bob", ChineseName: "鮑勃"}, nil)
 	resp, err := svc.GetStatusByName(ctx("alice", "site-a"), models.StatusGetByNameRequest{Name: "bob"})
@@ -28,7 +28,7 @@ func TestGetStatusByName(t *testing.T) {
 }
 
 func TestGetStatusByName_NotFound(t *testing.T) {
-	svc, _, users, _, _, _ := newSvc(t)
+	svc, _, users, _, _, _, _ := newSvc(t)
 	users.EXPECT().GetUserStatus(gomock.Any(), "ghost").Return(nil, nil)
 	_, err := svc.GetStatusByName(ctx("alice", "site-a"), models.StatusGetByNameRequest{Name: "ghost"})
 	requireCode(t, err, errcode.CodeNotFound)
@@ -37,7 +37,7 @@ func TestGetStatusByName_NotFound(t *testing.T) {
 // profile.getByName is an intentional twin of status.getByName (same request,
 // same response fields, same users-collection query) — divergence is a bug.
 func TestGetProfileByName_IdenticalToStatus(t *testing.T) {
-	svc, _, users, _, _, _ := newSvc(t)
+	svc, _, users, _, _, _, _ := newSvc(t)
 	users.EXPECT().GetUserStatus(gomock.Any(), "bob").
 		Return(&model.User{Account: "bob", StatusText: "hi", StatusIsShow: true, EngName: "Bob", ChineseName: "鮑勃"}, nil).
 		Times(2)
@@ -49,27 +49,27 @@ func TestGetProfileByName_IdenticalToStatus(t *testing.T) {
 }
 
 func TestGetProfileByName_NotFound(t *testing.T) {
-	svc, _, users, _, _, _ := newSvc(t)
+	svc, _, users, _, _, _, _ := newSvc(t)
 	users.EXPECT().GetUserStatus(gomock.Any(), "ghost").Return(nil, nil)
 	_, err := svc.GetProfileByName(ctx("alice", "site-a"), models.StatusGetByNameRequest{Name: "ghost"})
 	requireCode(t, err, errcode.CodeNotFound)
 }
 
 func TestGetProfileByName_StoreError(t *testing.T) {
-	svc, _, users, _, _, _ := newSvc(t)
+	svc, _, users, _, _, _, _ := newSvc(t)
 	users.EXPECT().GetUserStatus(gomock.Any(), "bob").Return(nil, errors.New("db unavailable"))
 	_, err := svc.GetProfileByName(ctx("alice", "site-a"), models.StatusGetByNameRequest{Name: "bob"})
 	requireCode(t, err, errcode.CodeInternal)
 }
 
 func TestSetStatus_TooLong(t *testing.T) {
-	svc, _, _, _, _, _ := newSvc(t)
+	svc, _, _, _, _, _, _ := newSvc(t)
 	_, err := svc.SetStatus(ctx("alice", "site-a"), models.StatusSetRequest{Text: string(make([]byte, 513))})
 	requireCode(t, err, errcode.CodeBadRequest)
 }
 
 func TestSetStatus_InboxExcludesSelf(t *testing.T) {
-	svc, _, users, _, _, pub := newSvc(t)
+	svc, _, users, _, _, _, pub := newSvc(t)
 	users.EXPECT().SetUserStatus(gomock.Any(), "alice", "busy", gomock.Any()).Return(&model.User{Account: "alice", StatusText: "busy"}, nil)
 	pub.EXPECT().Publish(gomock.Any(), subject.InboxExternal("site-b", model.InboxUserStatusUpdated), gomock.Any()).Return(nil)
 	_, err := svc.SetStatus(ctx("alice", "site-a"), models.StatusSetRequest{Text: "busy"})
@@ -77,21 +77,21 @@ func TestSetStatus_InboxExcludesSelf(t *testing.T) {
 }
 
 func TestGetStatusByName_StoreError(t *testing.T) {
-	svc, _, users, _, _, _ := newSvc(t)
+	svc, _, users, _, _, _, _ := newSvc(t)
 	users.EXPECT().GetUserStatus(gomock.Any(), "bob").Return(nil, errors.New("db unavailable"))
 	_, err := svc.GetStatusByName(ctx("alice", "site-a"), models.StatusGetByNameRequest{Name: "bob"})
 	requireCode(t, err, errcode.CodeInternal)
 }
 
 func TestSetStatus_StoreError(t *testing.T) {
-	svc, _, users, _, _, _ := newSvc(t)
+	svc, _, users, _, _, _, _ := newSvc(t)
 	users.EXPECT().SetUserStatus(gomock.Any(), "alice", "away", gomock.Any()).Return(nil, errors.New("write failed"))
 	_, err := svc.SetStatus(ctx("alice", "site-a"), models.StatusSetRequest{Text: "away"})
 	requireCode(t, err, errcode.CodeInternal)
 }
 
 func TestSetStatus_PublishError_StillSucceeds(t *testing.T) {
-	svc, _, users, _, _, pub := newSvc(t)
+	svc, _, users, _, _, _, pub := newSvc(t)
 	users.EXPECT().SetUserStatus(gomock.Any(), "alice", "here", gomock.Any()).Return(&model.User{Account: "alice", StatusText: "here"}, nil)
 	pub.EXPECT().Publish(gomock.Any(), subject.InboxExternal("site-b", model.InboxUserStatusUpdated), gomock.Any()).
 		Return(errors.New("no responders"))
@@ -100,7 +100,7 @@ func TestSetStatus_PublishError_StillSucceeds(t *testing.T) {
 }
 
 func TestSetStatus_UnknownAccount_NotFound_NoPublish(t *testing.T) {
-	svc, _, users, _, _, _ := newSvc(t)
+	svc, _, users, _, _, _, _ := newSvc(t)
 	// nil user ⇒ NotFound; pub has no Publish expectation so gomock fails if Publish is called.
 	users.EXPECT().SetUserStatus(gomock.Any(), "ghost", "busy", gomock.Any()).Return(nil, nil)
 	_, err := svc.SetStatus(ctx("ghost", "site-a"), models.StatusSetRequest{Text: "busy"})
@@ -110,14 +110,14 @@ func TestSetStatus_UnknownAccount_NotFound_NoPublish(t *testing.T) {
 func TestGetStatusByName_EmptyName_BadRequest_NoLookup(t *testing.T) {
 	// An empty name is rejected by a handler-level guard BEFORE any store lookup:
 	// users has no GetUserStatus expectation, so gomock fails if it is called.
-	svc, _, _, _, _, _ := newSvc(t)
+	svc, _, _, _, _, _, _ := newSvc(t)
 	_, err := svc.GetStatusByName(ctx("alice", "site-a"), models.StatusGetByNameRequest{Name: ""})
 	requireCode(t, err, errcode.CodeBadRequest)
 }
 
 func TestGetProfileByName_EmptyName_BadRequest_NoLookup(t *testing.T) {
 	// profile.getByName shares the guard: empty name ⇒ bad_request, no store lookup.
-	svc, _, _, _, _, _ := newSvc(t)
+	svc, _, _, _, _, _, _ := newSvc(t)
 	_, err := svc.GetProfileByName(ctx("alice", "site-a"), models.StatusGetByNameRequest{Name: ""})
 	requireCode(t, err, errcode.CodeBadRequest)
 }
@@ -125,7 +125,7 @@ func TestGetProfileByName_EmptyName_BadRequest_NoLookup(t *testing.T) {
 func TestSetStatus_NilIsShow_TextOnly(t *testing.T) {
 	// Text-only update: IsShow is nil, so the store receives a nil *bool
 	// (leave-flag-untouched semantics) and the write still publishes cross-site.
-	svc, _, users, _, _, pub := newSvc(t)
+	svc, _, users, _, _, _, pub := newSvc(t)
 	users.EXPECT().SetUserStatus(gomock.Any(), "alice", "brb", gomock.Nil()).Return(&model.User{Account: "alice", StatusText: "brb"}, nil)
 	pub.EXPECT().Publish(gomock.Any(), subject.InboxExternal("site-b", model.InboxUserStatusUpdated), gomock.Any()).Return(nil)
 	resp, err := svc.SetStatus(ctx("alice", "site-a"), models.StatusSetRequest{Text: "brb"})
@@ -134,7 +134,7 @@ func TestSetStatus_NilIsShow_TextOnly(t *testing.T) {
 }
 
 func TestSetStatus_AtLimit(t *testing.T) {
-	svc, _, users, _, _, pub := newSvc(t)
+	svc, _, users, _, _, _, pub := newSvc(t)
 	text512 := string(make([]byte, 512))
 	users.EXPECT().SetUserStatus(gomock.Any(), "alice", text512, gomock.Any()).Return(&model.User{Account: "alice", StatusText: text512}, nil)
 	pub.EXPECT().Publish(gomock.Any(), subject.InboxExternal("site-b", model.InboxUserStatusUpdated), gomock.Any()).Return(nil)

--- a/user-service/service/subscriptions.go
+++ b/user-service/service/subscriptions.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
-	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -54,8 +53,8 @@ func (s *UserService) ListSubscriptions(c *natsrouter.Context, req models.Subscr
 	if err != nil {
 		return nil, fmt.Errorf("list subscriptions: %w", err)
 	}
-	res.Data = s.enrichWithRoomInfo(c, res.Data, true)
-	s.enrichWithLastMessage(c, res.Data)
+	withLastMsg := req.IncludeLastMessage == nil || *req.IncludeLastMessage
+	res.Data = s.enrichWithRoomInfoAndLastMsg(c, res.Data, true, withLastMsg)
 	items := s.buildListItems(c, res.Data)
 	return &models.PagedSubscriptionListResponse{
 		Subscriptions: items,
@@ -173,11 +172,13 @@ func distinctListNames(subs []model.EnrichedSubscription) (bots, dmCounterparts 
 	return bots, dmCounterparts
 }
 
-// enrichWithRoomInfo populates sub.Room for every subscription and returns the
-// surviving slice. LOCAL subs (subs[i].SiteID == s.siteID) are enriched entirely
+// enrichWithRoomInfoAndLastMsg populates sub.Room for every subscription and returns
+// the surviving slice. LOCAL subs (subs[i].SiteID == s.siteID) are enriched entirely
 // from local Mongo — the $lookup baseline plus the room key read from the local
 // rooms collection, with NO room-service RPC. Only CROSS-SITE subs fan out to the
-// per-site GetRoomsInfo RPC, since their room docs live on another site.
+// per-site GetRoomsInfo RPC, since their room docs live on another site. When
+// withLastMsg, a single grouping also drives one rooms.get per site (all sites incl.
+// local) to attach each room's last message.
 //
 // dropDeleted controls how a soft-deleted ("Del-") room is handled, mirroring the
 // Mongo deleted-filter so LOCAL and CROSS-SITE rooms behave identically:
@@ -191,29 +192,29 @@ func distinctListNames(subs []model.EnrichedSubscription) (bots, dmCounterparts 
 // enrichLocal. Callers MUST use the returned slice, not the input.
 //
 // alert/hasMention are stored subscription state and are never touched here.
-func (s *UserService) enrichWithRoomInfo(c *natsrouter.Context, subs []model.EnrichedSubscription, dropDeleted bool) []model.EnrichedSubscription {
+func (s *UserService) enrichWithRoomInfoAndLastMsg(c *natsrouter.Context, subs []model.EnrichedSubscription, dropDeleted, withLastMsg bool) []model.EnrichedSubscription {
 	if len(subs) == 0 {
 		return subs
 	}
 
-	// Partition by locality, building each remote site's roomID list directly here.
+	// Group by site once — both fan-outs read this grouping. Room info comes from the
+	// $lookup baseline for the local site and GetRoomsInfo for the rest; last message
+	// is not in the baseline, so its rooms.get runs for ALL sites incl. local.
 	// No roomID dedup: the unique (roomId, account) index means one account holds at
 	// most one sub per room, so a site's roomIDs are already distinct.
-	var localIdx []int
 	idxBySite := map[string][]int{}
 	roomIDsBySite := map[string][]string{}
 	for i := range subs {
-		if subs[i].SiteID == s.siteID {
-			localIdx = append(localIdx, i)
-			continue
-		}
 		site := subs[i].SiteID
 		idxBySite[site] = append(idxBySite[site], i)
 		roomIDsBySite[site] = append(roomIDsBySite[site], subs[i].RoomID)
 	}
 
-	s.enrichLocal(subs, localIdx)
+	s.enrichLocal(subs, idxBySite[s.siteID])
 	dropped := s.enrichCrossSite(c, subs, idxBySite, roomIDsBySite)
+	if withLastMsg {
+		s.enrichLastMessage(c, subs, idxBySite, roomIDsBySite)
+	}
 	// Single-item lookups (dropDeleted=false) keep a cross-site Del- sub room-less;
 	// only the list/count paths remove it.
 	if !dropDeleted || len(dropped) == 0 {
@@ -260,12 +261,15 @@ func (s *UserService) enrichLocal(subs []model.EnrichedSubscription, localIdx []
 // no local room doc for a cross-site room). It returns the indices of subs whose
 // remote room is soft-deleted ("Del-"), for the caller to drop.
 func (s *UserService) enrichCrossSite(c *natsrouter.Context, subs []model.EnrichedSubscription, idxBySite map[string][]int, roomIDsBySite map[string][]string) []int {
-	if len(idxBySite) == 0 {
-		return nil
-	}
+	// The grouping includes the local site (served from the $lookup baseline); skip it here.
 	sites := make([]string, 0, len(idxBySite))
 	for site := range idxBySite {
-		sites = append(sites, site)
+		if site != s.siteID {
+			sites = append(sites, site)
+		}
+	}
+	if len(sites) == 0 {
+		return nil
 	}
 	infoBySite := make([]map[string]model.RoomInfo, len(sites)) // nil ⇒ site degraded
 	// WaitGroup (not errgroup): errgroup.WithContext would cancel sibling site RPCs on the first error; per-site degradation must keep siblings running.
@@ -321,27 +325,13 @@ func (s *UserService) enrichCrossSite(c *natsrouter.Context, subs []model.Enrich
 	return dropped
 }
 
-// maxRoomsGetChunk bounds each rooms.get RPC's roomIds — mirrors history-service's
-// own maxRoomsGetBatch cap, which rejects a batch over 100 outright.
-const maxRoomsGetChunk = 100
-
-// enrichWithLastMessage populates sub.Room.LastMessage (read-time A2 resolve, no
-// denormalized write path) for every subscription with a Room, fanning out one
-// rooms.get RPC per site — unlike enrichWithRoomInfo, LOCAL subs need this call
-// too (last-message isn't part of the $lookup baseline). A degraded/absent site,
-// or a room the RPC omits, just leaves LastMessage nil; it never fails the list.
-func (s *UserService) enrichWithLastMessage(c *natsrouter.Context, subs []model.EnrichedSubscription) {
-	account := c.Param("account")
-	idxBySite := map[string][]int{}
-	for i := range subs {
-		if subs[i].Room == nil {
-			continue // soft-deleted room — nothing to attach a last message to
-		}
-		idxBySite[subs[i].SiteID] = append(idxBySite[subs[i].SiteID], i)
-	}
-	if len(idxBySite) == 0 {
-		return
-	}
+// enrichLastMessage populates sub.Room.LastMessage (read-time resolve, no denormalized
+// write path) via one rooms.get RPC per site — LOCAL subs need it too (last-message
+// isn't part of the $lookup baseline). One call per site: a subscription page is
+// bounded well under history-service's 100-roomId batch cap, so no chunk-split is
+// needed. Reuses the caller's per-site grouping. A degraded/absent site, or a room the
+// RPC omits, just leaves LastMessage nil; it never fails the list.
+func (s *UserService) enrichLastMessage(c *natsrouter.Context, subs []model.EnrichedSubscription, idxBySite map[string][]int, roomIDsBySite map[string][]string) {
 	sites := make([]string, 0, len(idxBySite))
 	for site := range idxBySite {
 		sites = append(sites, site)
@@ -361,27 +351,12 @@ func (s *UserService) enrichWithLastMessage(c *natsrouter.Context, subs []model.
 			if c.Err() != nil {
 				return
 			}
-			roomIDs := make([]string, 0, len(idxBySite[site]))
-			seen := make(map[string]struct{}, len(idxBySite[site]))
-			for _, j := range idxBySite[site] {
-				rid := subs[j].RoomID
-				if _, dup := seen[rid]; dup {
-					continue
-				}
-				seen[rid] = struct{}{}
-				roomIDs = append(roomIDs, rid)
+			m, err := s.history.RoomsGet(c, site, roomIDsBySite[site])
+			if err != nil {
+				slog.WarnContext(c, "last-message enrichment degraded", "account", c.Param("account"), "site", site, "request_id", natsutil.RequestIDFromContext(c), "error", err)
+				return
 			}
-			merged := make(map[string]model.LastMessage, len(roomIDs))
-			for start := 0; start < len(roomIDs); start += maxRoomsGetChunk {
-				end := min(start+maxRoomsGetChunk, len(roomIDs))
-				chunk, err := s.history.RoomsGet(c, account, site, roomIDs[start:end])
-				if err != nil {
-					slog.WarnContext(c, "last-message enrichment degraded", "account", account, "site", site, "request_id", natsutil.RequestIDFromContext(c), "error", err)
-					continue
-				}
-				maps.Copy(merged, chunk)
-			}
-			lastMsgBySite[i] = merged
+			lastMsgBySite[i] = m
 		}()
 	}
 	wg.Wait()
@@ -391,6 +366,10 @@ func (s *UserService) enrichWithLastMessage(c *natsrouter.Context, subs []model.
 			continue
 		}
 		for _, j := range idxBySite[site] {
+			// Soft-deleted room (Room==nil) has nothing to attach a last message to.
+			if subs[j].Room == nil {
+				continue
+			}
 			lm, ok := m[subs[j].RoomID]
 			if !ok {
 				continue
@@ -503,7 +482,7 @@ func (s *UserService) GetChannels(c *natsrouter.Context, req models.GetChannelsR
 	if err != nil {
 		return nil, fmt.Errorf("get channels: %w", err)
 	}
-	res.Data = s.enrichWithRoomInfo(c, res.Data, true)
+	res.Data = s.enrichWithRoomInfoAndLastMsg(c, res.Data, true, false)
 	items := s.buildListItems(c, res.Data)
 	return &models.PagedSubscriptionListResponse{
 		Subscriptions: items,
@@ -532,7 +511,7 @@ func (s *UserService) GetDM(c *natsrouter.Context, req models.GetDMRequest) (*mo
 	// Del- DM is kept room-less. The wire DMSubscription points at the boxed stored
 	// sub plus HRInfo.
 	one := []model.EnrichedSubscription{dm.EnrichedSubscription}
-	one = s.enrichWithRoomInfo(c, one, false)
+	one = s.enrichWithRoomInfoAndLastMsg(c, one, false, false)
 	return &models.DMResponse{Subscription: model.DMSubscription{
 		Subscription: &one[0].Subscription,
 		HRInfo:       dm.HRInfo,
@@ -555,7 +534,7 @@ func (s *UserService) GetByRoomID(c *natsrouter.Context, req models.GetByRoomIDR
 		return &models.SubscriptionListResponse{Subscriptions: []model.SubscriptionItem{}, Total: 0}, nil
 	}
 	one := []model.EnrichedSubscription{*sub}
-	one = s.enrichWithRoomInfo(c, one, false)
+	one = s.enrichWithRoomInfoAndLastMsg(c, one, false, false)
 	items := s.buildListItems(c, one)
 	return &models.SubscriptionListResponse{Subscriptions: items, Total: len(items)}, nil
 }

--- a/user-service/service/subscriptions.go
+++ b/user-service/service/subscriptions.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -54,6 +55,7 @@ func (s *UserService) ListSubscriptions(c *natsrouter.Context, req models.Subscr
 		return nil, fmt.Errorf("list subscriptions: %w", err)
 	}
 	res.Data = s.enrichWithRoomInfo(c, res.Data, true)
+	s.enrichWithLastMessage(c, res.Data)
 	items := s.buildListItems(c, res.Data)
 	return &models.PagedSubscriptionListResponse{
 		Subscriptions: items,
@@ -317,6 +319,85 @@ func (s *UserService) enrichCrossSite(c *natsrouter.Context, subs []model.Enrich
 		}
 	}
 	return dropped
+}
+
+// maxRoomsGetChunk bounds each rooms.get RPC's roomIds — mirrors history-service's
+// own maxRoomsGetBatch cap, which rejects a batch over 100 outright.
+const maxRoomsGetChunk = 100
+
+// enrichWithLastMessage populates sub.Room.LastMessage (read-time A2 resolve, no
+// denormalized write path) for every subscription with a Room, fanning out one
+// rooms.get RPC per site — unlike enrichWithRoomInfo, LOCAL subs need this call
+// too (last-message isn't part of the $lookup baseline). A degraded/absent site,
+// or a room the RPC omits, just leaves LastMessage nil; it never fails the list.
+func (s *UserService) enrichWithLastMessage(c *natsrouter.Context, subs []model.EnrichedSubscription) {
+	account := c.Param("account")
+	idxBySite := map[string][]int{}
+	for i := range subs {
+		if subs[i].Room == nil {
+			continue // soft-deleted room — nothing to attach a last message to
+		}
+		idxBySite[subs[i].SiteID] = append(idxBySite[subs[i].SiteID], i)
+	}
+	if len(idxBySite) == 0 {
+		return
+	}
+	sites := make([]string, 0, len(idxBySite))
+	for site := range idxBySite {
+		sites = append(sites, site)
+	}
+	lastMsgBySite := make([]map[string]model.LastMessage, len(sites)) // nil ⇒ site degraded
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, maxSiteFanout)
+	for i, site := range sites {
+		if c.Err() != nil {
+			break
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			if c.Err() != nil {
+				return
+			}
+			roomIDs := make([]string, 0, len(idxBySite[site]))
+			seen := make(map[string]struct{}, len(idxBySite[site]))
+			for _, j := range idxBySite[site] {
+				rid := subs[j].RoomID
+				if _, dup := seen[rid]; dup {
+					continue
+				}
+				seen[rid] = struct{}{}
+				roomIDs = append(roomIDs, rid)
+			}
+			merged := make(map[string]model.LastMessage, len(roomIDs))
+			for start := 0; start < len(roomIDs); start += maxRoomsGetChunk {
+				end := min(start+maxRoomsGetChunk, len(roomIDs))
+				chunk, err := s.history.RoomsGet(c, account, site, roomIDs[start:end])
+				if err != nil {
+					slog.WarnContext(c, "last-message enrichment degraded", "account", account, "site", site, "request_id", natsutil.RequestIDFromContext(c), "error", err)
+					continue
+				}
+				maps.Copy(merged, chunk)
+			}
+			lastMsgBySite[i] = merged
+		}()
+	}
+	wg.Wait()
+	for i, site := range sites {
+		m := lastMsgBySite[i]
+		if m == nil {
+			continue
+		}
+		for _, j := range idxBySite[site] {
+			lm, ok := m[subs[j].RoomID]
+			if !ok {
+				continue
+			}
+			subs[j].Room.LastMessage = &lm
+		}
+	}
 }
 
 // roomKeySecretLen is the AES-256-GCM key length. A baseline encKeyPriv of any

--- a/user-service/service/subscriptions_test.go
+++ b/user-service/service/subscriptions_test.go
@@ -13,13 +13,33 @@ import (
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/user-service/config"
 	"github.com/hmchangw/chat/user-service/models"
+	"github.com/hmchangw/chat/user-service/service/mocks"
 )
+
+// newSvcRawHistory builds a service exposing the history mock WITHOUT newSvc's
+// permissive RoomsGet default, so last-message enrichment tests can set an exact
+// RoomsGet expectation (result or error).
+func newSvcRawHistory(t *testing.T) (*UserService, *mocks.MockSubscriptionRepository, *mocks.MockHistoryClient) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	subs := mocks.NewMockSubscriptionRepository(ctrl)
+	users := mocks.NewMockUserRepository(ctrl)
+	apps := mocks.NewMockAppRepository(ctrl)
+	rooms := mocks.NewMockRoomClient(ctrl)
+	history := mocks.NewMockHistoryClient(ctrl)
+	presence := mocks.NewMockPresenceClient(ctrl)
+	pub := mocks.NewMockEventPublisher(ctrl)
+	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
+	cfg := &config.Config{SiteID: "site-a", AllSiteIDs: []string{"site-a", "site-b"}, MaxSubscriptionLimit: 1000, DefaultSubscriptionLimit: 40, MaxAppsLimit: 100, DefaultAppsLimit: 20, MaxAccountNames: 100}
+	return New(subs, users, apps, threadSubs, rooms, history, presence, pub, cfg), subs, history
+}
 
 func TestListSubscriptions_Types(t *testing.T) {
 	for _, typ := range []string{"current", "rooms", "apps"} {
 		t.Run(typ, func(t *testing.T) {
-			svc, subs, _, _, rooms, _ := newSvc(t)
+			svc, subs, _, _, rooms, _, _ := newSvc(t)
 			subs.EXPECT().AggregateSubscriptions(gomock.Any(), "alice", typ, false, gomock.Any(), gomock.Any()).
 				Return(mongoutil.OffsetPageHasMore[model.EnrichedSubscription]{Data: []model.EnrichedSubscription{{Subscription: model.Subscription{ID: "s1"}}}}, nil)
 			rooms.EXPECT().GetRoomsInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
@@ -33,7 +53,7 @@ func TestListSubscriptions_Types(t *testing.T) {
 func TestListSubscriptions_BadType(t *testing.T) {
 	for _, typ := range []string{"", "bogus"} {
 		t.Run(typ, func(t *testing.T) {
-			svc, _, _, _, _, _ := newSvc(t)
+			svc, _, _, _, _, _, _ := newSvc(t)
 			_, err := svc.ListSubscriptions(ctx("alice", "site-a"), models.SubscriptionListRequest{Type: typ})
 			requireCode(t, err, errcode.CodeBadRequest)
 		})
@@ -41,7 +61,7 @@ func TestListSubscriptions_BadType(t *testing.T) {
 }
 
 func TestListSubscriptions_NegativeWithinDays(t *testing.T) {
-	svc, _, _, _, _, _ := newSvc(t)
+	svc, _, _, _, _, _, _ := newSvc(t)
 	neg := -1
 	_, err := svc.ListSubscriptions(ctx("alice", "site-a"),
 		models.SubscriptionListRequest{Type: "rooms", UpdatedWithinDays: &neg})
@@ -111,7 +131,7 @@ func TestBuildLocalRoom_MinUserLastSeenAt(t *testing.T) {
 // metadata + key) — no room-service RPC and no separate key read. A sub whose
 // baseline carries no key still yields the baseline room object, just keyless.
 func TestListSubscriptions_LocalBaselineRoom_NoKey(t *testing.T) {
-	svc, subs, _, _, _, _ := newSvc(t)
+	svc, subs, _, _, _, _, _ := newSvc(t)
 	lastMsg := time.UnixMilli(400).UTC()
 	storeSubs := []model.EnrichedSubscription{{
 		Subscription: model.Subscription{ID: "s1", RoomID: "r1", SiteID: "site-a", Name: "general", RoomType: model.RoomTypeChannel},
@@ -143,7 +163,7 @@ func appHelper() *model.App {
 }
 
 func TestListSubscriptions_BotDM_AppDisplayNameAndMeta(t *testing.T) {
-	svc, subs, _, apps, _, _ := newSvc(t)
+	svc, subs, _, apps, _, _, _ := newSvc(t)
 	storeSubs := []model.EnrichedSubscription{
 		{Subscription: model.Subscription{ID: "a1", RoomID: "rb1", SiteID: "site-a", RoomType: model.RoomTypeBotDM, Name: "helper.bot"}, RoomName: "bot-room-canonical"},
 		{Subscription: model.Subscription{ID: "c1", RoomID: "rc1", SiteID: "site-a", RoomType: model.RoomTypeChannel, Name: "general"}, RoomName: "general"},
@@ -174,7 +194,7 @@ func TestListSubscriptions_BotDM_AppDisplayNameAndMeta(t *testing.T) {
 }
 
 func TestListSubscriptions_DM_CarriesHRInfo(t *testing.T) {
-	svc, subs, users, _, _, _ := newSvc(t)
+	svc, subs, users, _, _, _, _ := newSvc(t)
 	storeSubs := []model.EnrichedSubscription{
 		{Subscription: model.Subscription{ID: "d1", RoomID: "rd1", SiteID: "site-a", RoomType: model.RoomTypeDM, Name: "bob"}},
 		{Subscription: model.Subscription{ID: "c1", RoomID: "rc1", SiteID: "site-a", RoomType: model.RoomTypeChannel, Name: "general"}},
@@ -195,7 +215,7 @@ func TestListSubscriptions_DM_CarriesHRInfo(t *testing.T) {
 }
 
 func TestListSubscriptions_DM_HRLookupDegrades(t *testing.T) {
-	svc, subs, users, _, _, _ := newSvc(t)
+	svc, subs, users, _, _, _, _ := newSvc(t)
 	storeSubs := []model.EnrichedSubscription{
 		{Subscription: model.Subscription{ID: "d1", RoomID: "rd1", SiteID: "site-a", RoomType: model.RoomTypeDM, Name: "bob"}},
 	}
@@ -213,7 +233,7 @@ func TestListSubscriptions_DM_HRLookupDegrades(t *testing.T) {
 // Two botDM subs sharing a bot account must dedup to a single GetAppsByAssistants
 // argument, and both rows get the resolved display name and overlay.
 func TestListSubscriptions_BotDM_DedupsBotAccount(t *testing.T) {
-	svc, subs, _, apps, _, _ := newSvc(t)
+	svc, subs, _, apps, _, _, _ := newSvc(t)
 	storeSubs := []model.EnrichedSubscription{
 		{Subscription: model.Subscription{ID: "a1", RoomID: "rb1", SiteID: "site-a", RoomType: model.RoomTypeBotDM, Name: "helper.bot"}},
 		{Subscription: model.Subscription{ID: "a2", RoomID: "rb2", SiteID: "site-a", RoomType: model.RoomTypeBotDM, Name: "helper.bot"}},
@@ -236,7 +256,7 @@ func TestListSubscriptions_BotDM_DedupsBotAccount(t *testing.T) {
 }
 
 func TestListSubscriptions_BotDM_AppLookupDegrades(t *testing.T) {
-	svc, subs, _, apps, _, _ := newSvc(t)
+	svc, subs, _, apps, _, _, _ := newSvc(t)
 	storeSubs := []model.EnrichedSubscription{
 		{Subscription: model.Subscription{ID: "a1", RoomID: "rb1", SiteID: "site-a", RoomType: model.RoomTypeBotDM, Name: "helper.bot"}},
 	}
@@ -253,7 +273,7 @@ func TestListSubscriptions_BotDM_AppLookupDegrades(t *testing.T) {
 }
 
 func TestListSubscriptions_BotDM_NoAppMatch(t *testing.T) {
-	svc, subs, _, apps, _, _ := newSvc(t)
+	svc, subs, _, apps, _, _, _ := newSvc(t)
 	storeSubs := []model.EnrichedSubscription{
 		{Subscription: model.Subscription{ID: "a1", RoomID: "rb1", SiteID: "site-a", RoomType: model.RoomTypeBotDM, Name: "orphan.bot"}},
 	}
@@ -269,7 +289,7 @@ func TestListSubscriptions_BotDM_NoAppMatch(t *testing.T) {
 }
 
 func TestListSubscriptions_StoreError(t *testing.T) {
-	svc, subs, _, _, _, _ := newSvc(t)
+	svc, subs, _, _, _, _, _ := newSvc(t)
 	subs.EXPECT().AggregateSubscriptions(gomock.Any(), "alice", "current", false, gomock.Any(), gomock.Any()).
 		Return(mongoutil.OffsetPageHasMore[model.EnrichedSubscription]{}, errors.New("db down"))
 	_, err := svc.ListSubscriptions(ctx("alice", "site-a"), models.SubscriptionListRequest{Type: "current"})
@@ -277,7 +297,7 @@ func TestListSubscriptions_StoreError(t *testing.T) {
 }
 
 func TestListSubscriptions_Favorite(t *testing.T) {
-	svc, subs, users, _, rooms, _ := newSvc(t)
+	svc, subs, users, _, rooms, _, _ := newSvc(t)
 	// Favorite filtering + self-DM ordering now happen in the query, so the repo
 	// returns the already-filtered, self-first set; the service passes it through.
 	// The handler must forward favorite=true to the store.
@@ -311,7 +331,7 @@ func TestListSubscriptions_Pagination(t *testing.T) {
 	}
 
 	t.Run("omitted params default to offset 0 / configured page size", func(t *testing.T) {
-		svc, subs, _, _, rooms, _ := newSvc(t)
+		svc, subs, _, _, rooms, _, _ := newSvc(t)
 		var got mongoutil.OffsetPageRequest
 		subs.EXPECT().AggregateSubscriptions(gomock.Any(), "alice", "current", false, gomock.Any(), gomock.Any()).
 			DoAndReturn(capturePage(&got, true))
@@ -324,7 +344,7 @@ func TestListSubscriptions_Pagination(t *testing.T) {
 	})
 
 	t.Run("negative offset clamps to 0 and limit caps at MaxSubscriptionLimit", func(t *testing.T) {
-		svc, subs, _, _, rooms, _ := newSvc(t)
+		svc, subs, _, _, rooms, _, _ := newSvc(t)
 		var got mongoutil.OffsetPageRequest
 		subs.EXPECT().AggregateSubscriptions(gomock.Any(), "alice", "rooms", false, gomock.Any(), gomock.Any()).
 			DoAndReturn(capturePage(&got, false))
@@ -336,7 +356,7 @@ func TestListSubscriptions_Pagination(t *testing.T) {
 	})
 
 	t.Run("explicit in-range offset and limit are forwarded to the repo", func(t *testing.T) {
-		svc, subs, _, _, rooms, _ := newSvc(t)
+		svc, subs, _, _, rooms, _, _ := newSvc(t)
 		var got mongoutil.OffsetPageRequest
 		subs.EXPECT().AggregateSubscriptions(gomock.Any(), "alice", "apps", false, gomock.Any(), gomock.Any()).
 			DoAndReturn(capturePage(&got, false))
@@ -376,19 +396,19 @@ func ptrBool(b bool) *bool { return &b }
 
 func TestGetChannels_ExactlyOne(t *testing.T) {
 	t.Run("both_empty", func(t *testing.T) {
-		svc, _, _, _, _, _ := newSvc(t)
+		svc, _, _, _, _, _, _ := newSvc(t)
 		_, err := svc.GetChannels(ctx("alice", "site-a"), models.GetChannelsRequest{})
 		requireCode(t, err, errcode.CodeBadRequest)
 	})
 	t.Run("both_set", func(t *testing.T) {
-		svc, _, _, _, _, _ := newSvc(t)
+		svc, _, _, _, _, _, _ := newSvc(t)
 		_, err := svc.GetChannels(ctx("alice", "site-a"), models.GetChannelsRequest{MembersContain: "x", AccountNames: []string{"y"}})
 		requireCode(t, err, errcode.CodeBadRequest)
 	})
 }
 
 func TestGetChannels_TooManyAccountNames(t *testing.T) {
-	svc, _, _, _, _, _ := newSvc(t)
+	svc, _, _, _, _, _, _ := newSvc(t)
 	names := make([]string, 101) // over the configured cap (newSvc sets MaxAccountNames=100)
 	for i := range names {
 		names[i] = "u"
@@ -399,7 +419,7 @@ func TestGetChannels_TooManyAccountNames(t *testing.T) {
 }
 
 func TestGetChannels_AccountNamesAtCap(t *testing.T) {
-	svc, subs, _, _, rooms, _ := newSvc(t)
+	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	names := make([]string, 100) // exactly the configured cap (newSvc sets MaxAccountNames=100)
 	for i := range names {
 		names[i] = "u"
@@ -412,7 +432,7 @@ func TestGetChannels_AccountNamesAtCap(t *testing.T) {
 }
 
 func TestGetChannels_ByMembersContain(t *testing.T) {
-	svc, subs, _, _, rooms, _ := newSvc(t)
+	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	subs.EXPECT().FindChannelsByMembers(gomock.Any(), "alice", []string{"carol"}, gomock.Any()).Return(mongoutil.OffsetPageHasMore[model.EnrichedSubscription]{Data: []model.EnrichedSubscription{{Subscription: model.Subscription{ID: "c1"}}}}, nil)
 	rooms.EXPECT().GetRoomsInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	resp, err := svc.GetChannels(ctx("alice", "site-a"), models.GetChannelsRequest{MembersContain: "carol"})
@@ -421,7 +441,7 @@ func TestGetChannels_ByMembersContain(t *testing.T) {
 }
 
 func TestGetChannels_ByAccountNames(t *testing.T) {
-	svc, subs, _, _, rooms, _ := newSvc(t)
+	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	subs.EXPECT().FindChannelsByMembers(gomock.Any(), "alice", []string{"carol", "dave"}, gomock.Any()).Return(mongoutil.OffsetPageHasMore[model.EnrichedSubscription]{Data: []model.EnrichedSubscription{{Subscription: model.Subscription{ID: "c1"}}}}, nil)
 	rooms.EXPECT().GetRoomsInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	resp, err := svc.GetChannels(ctx("alice", "site-a"), models.GetChannelsRequest{AccountNames: []string{"carol", "dave"}})
@@ -430,14 +450,14 @@ func TestGetChannels_ByAccountNames(t *testing.T) {
 }
 
 func TestGetChannels_StoreError(t *testing.T) {
-	svc, subs, _, _, _, _ := newSvc(t)
+	svc, subs, _, _, _, _, _ := newSvc(t)
 	subs.EXPECT().FindChannelsByMembers(gomock.Any(), "alice", []string{"carol"}, gomock.Any()).Return(mongoutil.OffsetPageHasMore[model.EnrichedSubscription]{}, errors.New("db down"))
 	_, err := svc.GetChannels(ctx("alice", "site-a"), models.GetChannelsRequest{MembersContain: "carol"})
 	requireCode(t, err, errcode.CodeInternal)
 }
 
 func TestGetChannels_Pagination(t *testing.T) {
-	svc, subs, _, _, rooms, _ := newSvc(t)
+	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	var got mongoutil.OffsetPageRequest
 	subs.EXPECT().FindChannelsByMembers(gomock.Any(), "alice", []string{"carol"}, gomock.Any()).
 		DoAndReturn(func(_ context.Context, _ string, _ []string, page mongoutil.OffsetPageRequest) (mongoutil.OffsetPageHasMore[model.EnrichedSubscription], error) {
@@ -453,7 +473,7 @@ func TestGetChannels_Pagination(t *testing.T) {
 }
 
 func TestGetDM_Empty(t *testing.T) {
-	svc, _, _, _, _, _ := newSvc(t)
+	svc, _, _, _, _, _, _ := newSvc(t)
 	_, err := svc.GetDM(ctx("alice", "site-a"), models.GetDMRequest{AccountName: ""})
 	requireCode(t, err, errcode.CodeBadRequest)
 }
@@ -461,7 +481,7 @@ func TestGetDM_Empty(t *testing.T) {
 func TestGetDM_InvalidTarget(t *testing.T) {
 	for _, target := range []string{"p_system", "helper.bot", "p_", ".bot", "p_.bot"} {
 		t.Run(target, func(t *testing.T) {
-			svc, _, _, _, _, _ := newSvc(t)
+			svc, _, _, _, _, _, _ := newSvc(t)
 			_, err := svc.GetDM(ctx("alice", "site-a"), models.GetDMRequest{AccountName: target})
 			requireCode(t, err, errcode.CodeBadRequest)
 			assert.True(t, errcode.HasReason(err, errcode.UserInvalidDMTarget))
@@ -470,7 +490,7 @@ func TestGetDM_InvalidTarget(t *testing.T) {
 }
 
 func TestGetDM_NotFound(t *testing.T) {
-	svc, subs, _, _, _, _ := newSvc(t)
+	svc, subs, _, _, _, _, _ := newSvc(t)
 	subs.EXPECT().GetDMSubscription(gomock.Any(), "alice", "bob").Return(nil, nil)
 	_, err := svc.GetDM(ctx("alice", "site-a"), models.GetDMRequest{AccountName: "bob"})
 	requireCode(t, err, errcode.CodeNotFound)
@@ -478,7 +498,7 @@ func TestGetDM_NotFound(t *testing.T) {
 }
 
 func TestGetDM_OK(t *testing.T) {
-	svc, subs, _, _, rooms, _ := newSvc(t)
+	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	subs.EXPECT().GetDMSubscription(gomock.Any(), "alice", "bob").
 		Return(&model.EnrichedDMSubscription{
 			EnrichedSubscription: model.EnrichedSubscription{Subscription: model.Subscription{ID: "d1"}},
@@ -492,14 +512,14 @@ func TestGetDM_OK(t *testing.T) {
 }
 
 func TestGetDM_StoreError(t *testing.T) {
-	svc, subs, _, _, _, _ := newSvc(t)
+	svc, subs, _, _, _, _, _ := newSvc(t)
 	subs.EXPECT().GetDMSubscription(gomock.Any(), "alice", "bob").Return(nil, errors.New("db down"))
 	_, err := svc.GetDM(ctx("alice", "site-a"), models.GetDMRequest{AccountName: "bob"})
 	requireCode(t, err, errcode.CodeInternal)
 }
 
 func TestGetDM_Enriched(t *testing.T) {
-	svc, subs, _, _, _, _ := newSvc(t)
+	svc, subs, _, _, _, _, _ := newSvc(t)
 	subs.EXPECT().GetDMSubscription(gomock.Any(), "alice", "bob").
 		Return(&model.EnrichedDMSubscription{
 			// LOCAL sub: room view comes from the baseline (RoomName), not the RPC.
@@ -519,13 +539,13 @@ func TestGetDM_Enriched(t *testing.T) {
 }
 
 func TestGetByRoomID_Empty(t *testing.T) {
-	svc, _, _, _, _, _ := newSvc(t)
+	svc, _, _, _, _, _, _ := newSvc(t)
 	_, err := svc.GetByRoomID(ctx("alice", "site-a"), models.GetByRoomIDRequest{RoomID: ""})
 	requireCode(t, err, errcode.CodeBadRequest)
 }
 
 func TestGetByRoomID_NotFound(t *testing.T) {
-	svc, subs, _, _, _, _ := newSvc(t)
+	svc, subs, _, _, _, _, _ := newSvc(t)
 	subs.EXPECT().GetSubscriptionByRoomID(gomock.Any(), "alice", "r1").Return(nil, nil)
 	resp, err := svc.GetByRoomID(ctx("alice", "site-a"), models.GetByRoomIDRequest{RoomID: "r1"})
 	require.NoError(t, err)
@@ -535,14 +555,14 @@ func TestGetByRoomID_NotFound(t *testing.T) {
 }
 
 func TestGetByRoomID_StoreError(t *testing.T) {
-	svc, subs, _, _, _, _ := newSvc(t)
+	svc, subs, _, _, _, _, _ := newSvc(t)
 	subs.EXPECT().GetSubscriptionByRoomID(gomock.Any(), "alice", "r1").Return(nil, errors.New("db down"))
 	_, err := svc.GetByRoomID(ctx("alice", "site-a"), models.GetByRoomIDRequest{RoomID: "r1"})
 	requireCode(t, err, errcode.CodeInternal)
 }
 
 func TestGetByRoomID_OK_Enriched(t *testing.T) {
-	svc, subs, _, _, _, _ := newSvc(t)
+	svc, subs, _, _, _, _, _ := newSvc(t)
 	subs.EXPECT().GetSubscriptionByRoomID(gomock.Any(), "alice", "r1").
 		Return(&model.EnrichedSubscription{
 			Subscription: model.Subscription{ID: "s1", SiteID: "site-a", RoomID: "r1", Name: "Stale"},
@@ -562,7 +582,7 @@ func TestGetByRoomID_OK_Enriched(t *testing.T) {
 func TestGetChannels_Empty(t *testing.T) {
 	for _, name := range []string{"nil_slice", "empty_slice"} {
 		t.Run(name, func(t *testing.T) {
-			svc, subs, _, _, _, _ := newSvc(t)
+			svc, subs, _, _, _, _, _ := newSvc(t)
 			var returned []model.EnrichedSubscription
 			if name == "empty_slice" {
 				returned = []model.EnrichedSubscription{}
@@ -576,7 +596,7 @@ func TestGetChannels_Empty(t *testing.T) {
 }
 
 func TestGetByRoomID_BotDM_AppDisplayName(t *testing.T) {
-	svc, subs, _, apps, _, _ := newSvc(t)
+	svc, subs, _, apps, _, _, _ := newSvc(t)
 	subs.EXPECT().GetSubscriptionByRoomID(gomock.Any(), "alice", "rb1").
 		Return(&model.EnrichedSubscription{Subscription: model.Subscription{ID: "a1", RoomID: "rb1", SiteID: "site-a", RoomType: model.RoomTypeBotDM, Name: "helper.bot"}}, nil)
 	apps.EXPECT().GetAppsByAssistants(gomock.Any(), []string{"helper.bot"}).
@@ -592,7 +612,7 @@ func TestGetByRoomID_BotDM_AppDisplayName(t *testing.T) {
 }
 
 func TestCount_Total(t *testing.T) {
-	svc, subs, _, _, _, _ := newSvc(t)
+	svc, subs, _, _, _, _, _ := newSvc(t)
 	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(7, nil)
 	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{})
 	require.NoError(t, err)
@@ -600,14 +620,14 @@ func TestCount_Total(t *testing.T) {
 }
 
 func TestCount_StoreError(t *testing.T) {
-	svc, subs, _, _, _, _ := newSvc(t)
+	svc, subs, _, _, _, _, _ := newSvc(t)
 	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(0, errors.New("db down"))
 	_, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{})
 	requireCode(t, err, errcode.CodeInternal)
 }
 
 func TestCountUnread_Happy(t *testing.T) {
-	svc, subs, _, _, rooms, _ := newSvc(t)
+	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	seen := time.UnixMilli(100).UTC()
 	newer := time.UnixMilli(200).UTC()
 	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(2, nil)
@@ -622,7 +642,7 @@ func TestCountUnread_Happy(t *testing.T) {
 }
 
 func TestCountUnread_FailedSiteSkipped(t *testing.T) {
-	svc, subs, _, _, rooms, _ := newSvc(t)
+	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	seen := time.UnixMilli(100).UTC()
 	newer := time.UnixMilli(200).UTC()
 	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(5, nil)
@@ -641,7 +661,7 @@ func TestCountUnread_FailedSiteSkipped(t *testing.T) {
 }
 
 func TestCountUnread_PartialFailureCountsHealthySites(t *testing.T) {
-	svc, subs, _, _, rooms, _ := newSvc(t)
+	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	seen := time.UnixMilli(100).UTC()
 	newer := int64(200)
 	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(9, nil)
@@ -660,7 +680,7 @@ func TestCountUnread_PartialFailureCountsHealthySites(t *testing.T) {
 }
 
 func TestCountUnread_GetActiveStoreError(t *testing.T) {
-	svc, subs, _, _, _, _ := newSvc(t)
+	svc, subs, _, _, _, _, _ := newSvc(t)
 	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(3, nil)
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 3).Return(nil, errors.New("db down"))
 	yes := true
@@ -669,7 +689,7 @@ func TestCountUnread_GetActiveStoreError(t *testing.T) {
 }
 
 func TestCountUnread_MultiSite(t *testing.T) {
-	svc, subs, _, _, rooms, _ := newSvc(t)
+	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	seen := time.UnixMilli(100).UTC()
 	newerT := time.UnixMilli(200).UTC()
 	newer := int64(200)
@@ -693,7 +713,7 @@ func TestCountUnread_MultiSite(t *testing.T) {
 }
 
 func TestCountUnread_AllRead(t *testing.T) {
-	svc, subs, _, _, rooms, _ := newSvc(t)
+	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	seen := time.UnixMilli(300).UTC()
 	older := time.UnixMilli(100).UTC() // older than seen → not unread
 	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(2, nil)
@@ -709,7 +729,7 @@ func TestCountUnread_AllRead(t *testing.T) {
 }
 
 func TestCountUnread_EmptyActive(t *testing.T) {
-	svc, subs, _, _, _, _ := newSvc(t)
+	svc, subs, _, _, _, _, _ := newSvc(t)
 	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(0, nil)
 	// Zero active subs must short-circuit before GetActiveSubscriptions (min(0,maxSubs)=0 → rejected $limit:0).
 	yes := true
@@ -721,7 +741,7 @@ func TestCountUnread_EmptyActive(t *testing.T) {
 func TestCountUnread_ContextCancelled_SkipsRPC(t *testing.T) {
 	// A cancelled client context must short-circuit the cross-site fan-out before
 	// firing any ~5s GetRoomsInfo RPC; local subs still count from the baseline.
-	svc, subs, _, _, rooms, _ := newSvc(t)
+	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	seen := time.UnixMilli(100).UTC()
 	newer := time.UnixMilli(200).UTC()
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 2).
@@ -742,7 +762,7 @@ func TestCountUnread_CrossSiteDeletedRoomNotCounted(t *testing.T) {
 	// A cross-site room soft-deleted at its origin still comes back Found=true with a
 	// stale lastMsgAt over the RPC; it must NOT inflate the unread count — the list
 	// path surfaces it room-less, and the badge must agree.
-	svc, subs, _, _, rooms, _ := newSvc(t)
+	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	seen := time.UnixMilli(100).UTC()
 	stale := int64(200) // newer than seen → WOULD count if the Del- room weren't skipped
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).
@@ -780,7 +800,7 @@ func TestDistinctListNames_Empty(t *testing.T) {
 func TestCount_UnreadFalse(t *testing.T) {
 	for _, name := range []string{"nil", "false"} {
 		t.Run(name, func(t *testing.T) {
-			svc, subs, _, _, _, _ := newSvc(t)
+			svc, subs, _, _, _, _, _ := newSvc(t)
 			subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(9, nil)
 			// No GetActiveSubscriptions expectation — short-circuit must fire before calling it.
 			var unreadPtr *bool
@@ -793,4 +813,41 @@ func TestCount_UnreadFalse(t *testing.T) {
 			assert.Equal(t, 9, resp.Count)
 		})
 	}
+}
+
+func TestListSubscriptions_LastMessage_Populated(t *testing.T) {
+	svc, subs, history := newSvcRawHistory(t)
+	storeSubs := []model.EnrichedSubscription{{
+		Subscription: model.Subscription{ID: "s1", RoomID: "r1", SiteID: "site-a", Name: "general", RoomType: model.RoomTypeChannel},
+		RoomName:     "General", UserCount: 3,
+	}}
+	subs.EXPECT().AggregateSubscriptions(gomock.Any(), "alice", "current", false, gomock.Any(), gomock.Any()).
+		Return(mongoutil.OffsetPageHasMore[model.EnrichedSubscription]{Data: storeSubs}, nil)
+	history.EXPECT().RoomsGet(gomock.Any(), "alice", "site-a", []string{"r1"}).
+		Return(map[string]model.LastMessage{"r1": {MessageID: "m9", Content: "hi", CreatedAt: 123}}, nil)
+	resp, err := svc.ListSubscriptions(ctx("alice", "site-a"), models.SubscriptionListRequest{Type: "current"})
+	require.NoError(t, err)
+	require.Len(t, resp.Subscriptions, 1)
+	room := resp.Subscriptions[0].Base().Room
+	require.NotNil(t, room)
+	require.NotNil(t, room.LastMessage, "last message attached from rooms.get")
+	assert.Equal(t, "m9", room.LastMessage.MessageID)
+}
+
+func TestListSubscriptions_LastMessage_SiteDegrades(t *testing.T) {
+	svc, subs, history := newSvcRawHistory(t)
+	storeSubs := []model.EnrichedSubscription{{
+		Subscription: model.Subscription{ID: "s1", RoomID: "r1", SiteID: "site-a", Name: "general", RoomType: model.RoomTypeChannel},
+		RoomName:     "General", UserCount: 3,
+	}}
+	subs.EXPECT().AggregateSubscriptions(gomock.Any(), "alice", "current", false, gomock.Any(), gomock.Any()).
+		Return(mongoutil.OffsetPageHasMore[model.EnrichedSubscription]{Data: storeSubs}, nil)
+	history.EXPECT().RoomsGet(gomock.Any(), "alice", "site-a", []string{"r1"}).
+		Return(nil, errors.New("history down"))
+	resp, err := svc.ListSubscriptions(ctx("alice", "site-a"), models.SubscriptionListRequest{Type: "current"})
+	require.NoError(t, err, "a degraded rooms.get must not fail the list")
+	require.Len(t, resp.Subscriptions, 1)
+	room := resp.Subscriptions[0].Base().Room
+	require.NotNil(t, room)
+	assert.Nil(t, room.LastMessage, "degraded site leaves LastMessage nil")
 }

--- a/user-service/service/subscriptions_test.go
+++ b/user-service/service/subscriptions_test.go
@@ -823,7 +823,7 @@ func TestListSubscriptions_LastMessage_Populated(t *testing.T) {
 	}}
 	subs.EXPECT().AggregateSubscriptions(gomock.Any(), "alice", "current", false, gomock.Any(), gomock.Any()).
 		Return(mongoutil.OffsetPageHasMore[model.EnrichedSubscription]{Data: storeSubs}, nil)
-	history.EXPECT().RoomsGet(gomock.Any(), "alice", "site-a", []string{"r1"}).
+	history.EXPECT().RoomsGet(gomock.Any(), "site-a", []string{"r1"}).
 		Return(map[string]model.LastMessage{"r1": {MessageID: "m9", Content: "hi", CreatedAt: 123}}, nil)
 	resp, err := svc.ListSubscriptions(ctx("alice", "site-a"), models.SubscriptionListRequest{Type: "current"})
 	require.NoError(t, err)
@@ -834,6 +834,25 @@ func TestListSubscriptions_LastMessage_Populated(t *testing.T) {
 	assert.Equal(t, "m9", room.LastMessage.MessageID)
 }
 
+// includeLastMessage:false skips the rooms.get RPC entirely.
+func TestListSubscriptions_LastMessage_SkippedWhenExcluded(t *testing.T) {
+	svc, subs, _ := newSvcRawHistory(t)
+	storeSubs := []model.EnrichedSubscription{{
+		Subscription: model.Subscription{ID: "s1", RoomID: "r1", SiteID: "site-a", Name: "general", RoomType: model.RoomTypeChannel},
+		RoomName:     "General", UserCount: 3,
+	}}
+	subs.EXPECT().AggregateSubscriptions(gomock.Any(), "alice", "current", false, gomock.Any(), gomock.Any()).
+		Return(mongoutil.OffsetPageHasMore[model.EnrichedSubscription]{Data: storeSubs}, nil)
+	// No history.RoomsGet EXPECT — the mock ctrl fails if it's called.
+	no := false
+	resp, err := svc.ListSubscriptions(ctx("alice", "site-a"), models.SubscriptionListRequest{Type: "current", IncludeLastMessage: &no})
+	require.NoError(t, err)
+	require.Len(t, resp.Subscriptions, 1)
+	room := resp.Subscriptions[0].Base().Room
+	require.NotNil(t, room)
+	assert.Nil(t, room.LastMessage, "excluded last message stays nil")
+}
+
 func TestListSubscriptions_LastMessage_SiteDegrades(t *testing.T) {
 	svc, subs, history := newSvcRawHistory(t)
 	storeSubs := []model.EnrichedSubscription{{
@@ -842,7 +861,7 @@ func TestListSubscriptions_LastMessage_SiteDegrades(t *testing.T) {
 	}}
 	subs.EXPECT().AggregateSubscriptions(gomock.Any(), "alice", "current", false, gomock.Any(), gomock.Any()).
 		Return(mongoutil.OffsetPageHasMore[model.EnrichedSubscription]{Data: storeSubs}, nil)
-	history.EXPECT().RoomsGet(gomock.Any(), "alice", "site-a", []string{"r1"}).
+	history.EXPECT().RoomsGet(gomock.Any(), "site-a", []string{"r1"}).
 		Return(nil, errors.New("history down"))
 	resp, err := svc.ListSubscriptions(ctx("alice", "site-a"), models.SubscriptionListRequest{Type: "current"})
 	require.NoError(t, err, "a degraded rooms.get must not fail the list")


### PR DESCRIPTION
## Summary

Implements `rooms.get` (chat#393) — the room last-message endpoint (the customer&#39;s
`/api/v1/rooms.get`, used by mobile to render the last-message snippet in the room
list). A new history-service, per-site, account-scoped **batch** RPC that resolves each
requested room&#39;s latest message at read time (A2). Maintainer-approved approach (A2,
option E2) per the #393 design-lock.

## What&#39;s included

- **Subject** `chat.user.{account}.request.history.{siteID}.rooms.get` — account+site from
  the subject, `{roomIds[]}` in the body. One batch per site; the caller groups a user&#39;s
  rooms by site and fans out (same shape as `ThreadSubscriptionList`).
- **`RoomsGet` handler** (history-service) → `roomLastMessage`: per room, the existing
  access check (`checkAccessAndRoomTimes`) then the latest message via the existing
  `messages_by_room … DESC` reads (`GetMessagesBefore` / `GetMessagesBetweenDesc`,
  limit 1) — access-window + history-floor aware (mirrors LoadHistory). No new repo method.
- **A2 read-only:** no denormalized write, no event, no edit/delete hooks, **no
  walk-back** — a soft-deleted latest message is returned as-is with `deleted=true`.
- **Best-effort batch:** bounded-concurrency per-room resolve; a room that&#39;s
  not-accessible / empty / errored is omitted, never failing the batch. Batch ≤ 100;
  `content` preview-trimmed to 256 runes.
- **`docs/client-api.md`** §3.2 &#34;Get Rooms Last Message&#34; (doc-ratchet).

## #393 completion — web-sidebar integration

- **Shared wire types moved to `pkg/model`** (`LastMessage`, `RoomsGetRequest`,
  `RoomsGetResponse`) so user-service can consume them without importing
  history-service internals; history-service&#39;s own `models` package now aliases them
  (`type LastMessage = model.LastMessage`, etc. — no behavior change).
- **`SubscriptionRoom.LastMessage *model.LastMessage`** (`pkg/model/subscription.go`) —
  new optional field on the room-derived view returned by `subscription.list`.
- **`historyclient.Client.RoomsGet`** — new per-site RPC call mirroring the existing
  `GetThreadList` pattern (marshal request, NATS request/reply, `errcode.Parse`,
  unmarshal). Added to the `HistoryClient` interface; mocks regenerated.
- **`UserService.enrichWithLastMessage`** (`user-service/service/subscriptions.go`) —
  new enrichment pass in `ListSubscriptions`, run after `enrichWithRoomInfo`. Groups
  every subscription with a resolved `Room` by site (local **and** cross-site — unlike
  room-info enrichment, last-message isn&#39;t part of the local `$lookup` baseline), fans
  out one `rooms.get` call per site (bounded by the existing `maxSiteFanout`
  semaphore), chunking each site&#39;s roomIds at 100 to respect history-service&#39;s own
  batch cap. A degraded or absent site just leaves those rooms&#39; `lastMessage` nil —
  it never fails the list.
- **`docs/client-api.md`** — added the `lastMessage` field to the `SubscriptionRoom`
  table + example, and reconciled the `rooms.get` RPC description to note
  `subscription.list` now calls it server-side (the RPC also remains directly callable).

## Out of scope (follow-up)

- None — the user-service integration originally called out as follow-up is now
  included above.

## Verification

- `go build ./pkg/... ./history-service/... ./user-service/...` — clean.
- `go test ./pkg/... ./history-service/... ./user-service/...` — green, including two
  new `TestListSubscriptions_LocalBaselineRoom_NoKey` assertions and a new
  `TestListSubscriptions_LastMessage_SiteDegrades` test (site RPC failure degrades
  gracefully, list still succeeds).
- NATS wire-layer e2e against the dev stack — to follow before marking ready.

🤖 Generated with Claude Code