### PR TITLE
feat(user-service): count rooms with unread threads in subscription.count

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -4630,7 +4630,7 @@ Returns the count of active subscriptions, optionally filtered to unread rooms o
 
 | Field    | Type    | Required | Notes |
 |----------|---------|----------|-------|
-| `unread` | boolean | no       | When `true`, returns the number of active rooms with unread messages. When `false` or absent, returns the total active-subscription count. |
+| `unread` | boolean | no       | When `true`, returns the number of active rooms with unread messages or unread followed threads. When `false` or absent, returns the total active-subscription count. |
 
 ```json
 { "unread": true }
@@ -4647,6 +4647,8 @@ Returns the count of active subscriptions, optionally filtered to unread rooms o
 ```
 
 **Unread count behavior:** when `unread: true`, the service fetches the active subscriptions and splits them by site. **Local** subscriptions are counted directly from the room baseline carried on the `$lookup` (comparing the room's `lastMsgAt` against the subscription's `lastSeenAt`) — no RPC is made. Only **cross-site** subscriptions trigger a per-site `GetRoomsInfo` RPC, run in **parallel**. The count **degrades per-site** (matching `subscription.list` enrichment): if a cross-site RPC fails, that site's subscriptions are **skipped** — omitted from the count and logged as a warning — while local subscriptions and the sites that did respond still contribute. The result is a best-effort count that may under-report while a remote site is unreachable, rather than the full active-subscription total.
+
+**Threads:** a room also counts as unread if it has at least one unread followed thread, even when its own messages are all read — at most **+1 per room** (existence, not a per-thread count). Muted rooms are excluded (as with room-level unread), and only rooms within the fetched active-subscription page are considered. For message-read rooms, thread last-activity is resolved per owning site and degrades best-effort: if a site's thread lookup fails, its rooms are simply not bumped.
 
 ##### Error response
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -1538,7 +1538,8 @@ botDM). Soft-deleted rooms excluded.
 
 #### Request body
 
-`{ "unread": true }` — when `true`, returns active rooms with unread messages.
+`{ "unread": true }` — when `true`, returns active rooms with unread messages or unread
+followed threads (at most +1 per room; muted excluded).
 
 #### Success response
 

--- a/docs/superpowers/plans/2026-07-16-thread-aware-unread-count.md
+++ b/docs/superpowers/plans/2026-07-16-thread-aware-unread-count.md
@@ -1,0 +1,649 @@
+# Thread-Aware Unread Count Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `user-service`'s `subscription.count` (unread=true) so a room also counts as unread when it has ≥1 unread thread — at most +1 per room, read-side only.
+
+**Architecture:** After the existing room-level unread pass, collect the rooms that came out *read* (`pendingRooms`), resolve their followed threads' last-activity per owning site via `GetThreadRoomInfoBatch`, and bump each such room at most once. Existence-only, so already-unread rooms are never thread-checked and each room stops at its first unread thread. No new persisted state.
+
+**Tech Stack:** Go 1.25, NATS request/reply, MongoDB (`go.mongodb.org/mongo-driver/v2`), `go.uber.org/mock`, `testify`, testcontainers.
+
+## Global Constraints
+
+- Go 1.25; single root `go.mod`. Use `make` targets, never raw `go`.
+- TDD: write the failing test first, confirm red, then implement. Table-driven where multiple variations.
+- Unit tests in `package service` / `package mongorepo`; mocks in `service/mocks` (never hand-edit generated mocks).
+- Integration tests tagged `//go:build integration`, containers from `pkg/testutil`.
+- `unread(lastSeen *time.Time, ms *int64) bool` is the single unread predicate (`subscriptions.go:455`) — reuse it, do not reinvent.
+- `chunkStrings` and `threadInfoBatchChunk` (=500) already exist in `service/threadunread.go` (same package) — reuse.
+- `maxSiteFanout` (=8) bounds concurrent per-site RPCs — reuse.
+- Best-effort degradation: a thread read/resolution failure logs WARN with `request_id` and contributes 0; it never fails the RPC or discards the room-level count.
+- Response shape stays `{count}` — no `client-api.md` schema-table change (prose note only).
+
+---
+
+### Task 1: Add `RoomID` to `ThreadUnreadRow`
+
+**Files:**
+- Modify: `pkg/model/threadsubscription.go:32-38`
+- Test: `pkg/model/model_test.go:4300-4307`
+
+**Interfaces:**
+- Produces: `model.ThreadUnreadRow.RoomID string` (json/bson `roomId`) — consumed by Tasks 2 and 3.
+
+- [ ] **Step 1: Update the round-trip test to include `RoomID`**
+
+In `pkg/model/model_test.go`, replace `TestThreadUnreadRowJSON`:
+
+```go
+func TestThreadUnreadRowJSON(t *testing.T) {
+	seen := time.UnixMilli(1717000000000).UTC()
+	r := model.ThreadUnreadRow{
+		ThreadRoomID: "tr1", RoomID: "r1", SiteID: "site-a", RoomType: model.RoomTypeDM,
+		LastSeenAt: &seen, HasMention: true,
+	}
+	roundTrip(t, &r, &model.ThreadUnreadRow{})
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `make test SERVICE=pkg/model` (or `go test ./pkg/model/ -run TestThreadUnreadRowJSON`)
+Expected: FAIL — `unknown field RoomID in struct literal`.
+
+- [ ] **Step 3: Add the field**
+
+In `pkg/model/threadsubscription.go`, add `RoomID` to `ThreadUnreadRow`:
+
+```go
+type ThreadUnreadRow struct {
+	ThreadRoomID string     `json:"threadRoomId" bson:"threadRoomId"`
+	RoomID       string     `json:"roomId"       bson:"roomId"`
+	SiteID       string     `json:"siteId"       bson:"siteId"`
+	RoomType     RoomType   `json:"roomType"     bson:"roomType"`
+	LastSeenAt   *time.Time `json:"lastSeenAt"   bson:"lastSeenAt"`
+	HasMention   bool       `json:"hasMention"   bson:"hasMention"`
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./pkg/model/ -run TestThreadUnreadRowJSON -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/model/threadsubscription.go pkg/model/model_test.go
+git commit -m "feat(model): add RoomID to ThreadUnreadRow projection"
+```
+
+---
+
+### Task 2: Project `roomId` in `ListByAccount`
+
+**Files:**
+- Modify: `user-service/mongorepo/threadsubscriptions.go:74-81`
+- Test: `user-service/mongorepo/threadsubscriptions_test.go:26-63`
+
+**Interfaces:**
+- Consumes: `model.ThreadUnreadRow.RoomID` (Task 1).
+- Produces: `ListByAccount` rows now carry `RoomID` — consumed by Task 3.
+
+- [ ] **Step 1: Assert `RoomID` in the existing integration test**
+
+In `TestThreadSubscriptionRepo_ListByAccount`, after the existing per-site assertions (around line 57), add:
+
+```go
+	assert.Equal(t, "r1", bySite["site-a"].RoomID)
+	assert.Equal(t, "r2", bySite["site-b"].RoomID)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `make test-integration SERVICE=user-service`
+Expected: FAIL — `bySite["site-a"].RoomID` is `""` (projection does not emit `roomId` yet).
+
+- [ ] **Step 3: Add `roomId` to the projection**
+
+In `user-service/mongorepo/threadsubscriptions.go`, add one line to the final `$project`:
+
+```go
+		bson.M{"$project": bson.M{
+			"_id":          0,
+			"threadRoomId": 1,
+			"roomId":       1,
+			"siteId":       1,
+			"lastSeenAt":   1,
+			"hasMention":   1,
+			"roomType":     bson.M{"$arrayElemAt": bson.A{"$sub.roomType", 0}},
+		}},
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `make test-integration SERVICE=user-service`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add user-service/mongorepo/threadsubscriptions.go user-service/mongorepo/threadsubscriptions_test.go
+git commit -m "feat(user-service): project roomId in thread-sub ListByAccount"
+```
+
+---
+
+### Task 3: Thread-aware `countUnread`
+
+**Files:**
+- Modify: `user-service/service/subscriptions.go:560-646` (`countUnread`) + add `countThreadOnlyUnread`
+- Modify: `user-service/service/service_test.go:17-33` (`newSvc` — add ListByAccount default)
+- Test: `user-service/service/subscriptions_test.go` (new helper + new tests)
+
+**Interfaces:**
+- Consumes: `s.threadSubs.ListByAccount(ctx, account) ([]model.ThreadUnreadRow, error)`; `s.rooms.GetThreadRoomInfoBatch(ctx, siteID, ids) ([]model.ThreadRoomInfo, error)`; `unread`, `chunkStrings`, `threadInfoBatchChunk`, `maxSiteFanout`.
+- Produces: `countUnread` returns `{count}` = room-level unread + thread-only-unread rooms (each room ≤ 1).
+
+- [ ] **Step 1: Add the ListByAccount default to `newSvc` so existing count tests stay green**
+
+Existing count tests that leave rooms *read* (e.g. `TestCountUnread_MultiSite`, `TestCountUnread_AllRead`) will now reach the thread phase. Default the new call to a no-op in `newSvc` (mirrors the existing `history.RoomsGet` default). In `user-service/service/service_test.go`, after line 31:
+
+```go
+	// countUnread's thread phase reads thread-subs; default to none so room-count
+	// tests that don't exercise threads need no per-test stub.
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+```
+
+- [ ] **Step 2: Add a count-test helper exposing the thread + room mocks**
+
+In `user-service/service/subscriptions_test.go`, add:
+
+```go
+// newCountSvc builds a service exposing the subscription, room, and thread-sub
+// mocks the thread-aware unread tests drive. maxSubs is large; per-test GetActiveSubscriptions
+// stubs control the fetched page directly.
+func newCountSvc(t *testing.T) (*UserService, *mocks.MockSubscriptionRepository, *mocks.MockRoomClient, *mocks.MockThreadSubscriptionRepository) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	subs := mocks.NewMockSubscriptionRepository(ctrl)
+	users := mocks.NewMockUserRepository(ctrl)
+	apps := mocks.NewMockAppRepository(ctrl)
+	rooms := mocks.NewMockRoomClient(ctrl)
+	history := mocks.NewMockHistoryClient(ctrl)
+	presence := mocks.NewMockPresenceClient(ctrl)
+	pub := mocks.NewMockEventPublisher(ctrl)
+	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
+	cfg := &config.Config{SiteID: "site-a", AllSiteIDs: []string{"site-a", "site-b"}, MaxSubscriptionLimit: 1000, DefaultSubscriptionLimit: 40, MaxAppsLimit: 100, DefaultAppsLimit: 20, MaxAccountNames: 100}
+	return New(subs, users, apps, threadSubs, rooms, history, presence, pub, cfg), subs, rooms, threadSubs
+}
+```
+
+- [ ] **Step 3: Write the failing thread-aware tests**
+
+Add to `user-service/service/subscriptions_test.go`:
+
+```go
+func TestCountUnread_ReadRoomBumpedByUnreadThread(t *testing.T) {
+	svc, subs, rooms, threadSubs := newCountSvc(t)
+	seen := time.UnixMilli(100).UTC()
+	older := time.UnixMilli(50).UTC()
+	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(1, nil)
+	// One LOCAL room, read at the message level (lastMsgAt older than lastSeen).
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
+		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
+	}, nil)
+	// One followed thread in r1, unread (thread lastMsgAt 200 > lastSeen 100).
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
+		{ThreadRoomID: "tr1", RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen},
+	}, nil)
+	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), "site-a", []string{"tr1"}).
+		Return([]model.ThreadRoomInfo{{ThreadRoomID: "tr1", Found: true, LastMsgAt: 200}}, nil)
+	yes := true
+	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
+	require.NoError(t, err)
+	assert.Equal(t, 1, resp.Count)
+}
+
+func TestCountUnread_AlreadyUnreadRoomNotDoubleCounted(t *testing.T) {
+	svc, subs, rooms, threadSubs := newCountSvc(t)
+	seen := time.UnixMilli(100).UTC()
+	newer := time.UnixMilli(300).UTC()
+	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(1, nil)
+	// r1 is already room-level unread → must not be thread-checked, contributes exactly 1.
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
+		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &newer},
+	}, nil)
+	// Every room already unread ⇒ pendingRooms empty ⇒ ListByAccount never called.
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), gomock.Any()).Times(0)
+	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	yes := true
+	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
+	require.NoError(t, err)
+	assert.Equal(t, 1, resp.Count)
+}
+
+func TestCountUnread_MultipleUnreadThreadsCountOnce(t *testing.T) {
+	svc, subs, rooms, threadSubs := newCountSvc(t)
+	seen := time.UnixMilli(100).UTC()
+	older := time.UnixMilli(50).UTC()
+	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(1, nil)
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
+		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
+	}, nil)
+	// Three unread threads, all in r1 → +1 total.
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
+		{ThreadRoomID: "tr1", RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen},
+		{ThreadRoomID: "tr2", RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen},
+		{ThreadRoomID: "tr3", RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen},
+	}, nil)
+	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), "site-a", gomock.InAnyOrder([]string{"tr1", "tr2", "tr3"})).
+		Return([]model.ThreadRoomInfo{
+			{ThreadRoomID: "tr1", Found: true, LastMsgAt: 200},
+			{ThreadRoomID: "tr2", Found: true, LastMsgAt: 200},
+			{ThreadRoomID: "tr3", Found: true, LastMsgAt: 200},
+		}, nil)
+	yes := true
+	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
+	require.NoError(t, err)
+	assert.Equal(t, 1, resp.Count)
+}
+
+func TestCountUnread_ThreadInRoomOutsidePageIgnored(t *testing.T) {
+	svc, subs, rooms, threadSubs := newCountSvc(t)
+	seen := time.UnixMilli(100).UTC()
+	older := time.UnixMilli(50).UTC()
+	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(1, nil)
+	// Fetched page contains only r1 (read).
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
+		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
+	}, nil)
+	// Thread lives in rX, which is NOT in the fetched page → must be filtered out, no batch call.
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
+		{ThreadRoomID: "trX", RoomID: "rX", SiteID: "site-a", LastSeenAt: &seen},
+	}, nil)
+	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	yes := true
+	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
+	require.NoError(t, err)
+	assert.Equal(t, 0, resp.Count)
+}
+
+func TestCountUnread_CrossSiteThreadResolution(t *testing.T) {
+	svc, subs, rooms, threadSubs := newCountSvc(t)
+	seen := time.UnixMilli(100).UTC()
+	older := int64(50)
+	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(1, nil)
+	// r1 lives on site-b, read at the message level.
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
+		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-b", LastSeenAt: &seen}},
+	}, nil)
+	rooms.EXPECT().GetRoomsInfo(gomock.Any(), "site-b", []string{"r1"}).
+		Return([]model.RoomInfo{{RoomID: "r1", Found: true, LastMsgAt: &older}}, nil)
+	// A followed thread in r1 on site-b, unread → resolved via the site-b batch.
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
+		{ThreadRoomID: "tr1", RoomID: "r1", SiteID: "site-b", LastSeenAt: &seen},
+	}, nil)
+	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), "site-b", []string{"tr1"}).
+		Return([]model.ThreadRoomInfo{{ThreadRoomID: "tr1", Found: true, LastMsgAt: 200}}, nil)
+	yes := true
+	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
+	require.NoError(t, err)
+	assert.Equal(t, 1, resp.Count)
+}
+
+func TestCountUnread_ThreadBatchFailureDegrades(t *testing.T) {
+	svc, subs, rooms, threadSubs := newCountSvc(t)
+	seen := time.UnixMilli(100).UTC()
+	older := time.UnixMilli(50).UTC()
+	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(1, nil)
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
+		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
+	}, nil)
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
+		{ThreadRoomID: "tr1", RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen},
+	}, nil)
+	// Thread resolution fails → room un-bumped, count degrades to 0, no error.
+	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), "site-a", []string{"tr1"}).
+		Return(nil, errors.New("down"))
+	yes := true
+	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
+	require.NoError(t, err)
+	assert.Equal(t, 0, resp.Count)
+}
+
+func TestCountUnread_ThreadListErrorDegrades(t *testing.T) {
+	svc, subs, rooms, threadSubs := newCountSvc(t)
+	seen := time.UnixMilli(100).UTC()
+	older := time.UnixMilli(50).UTC()
+	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(1, nil)
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
+		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
+	}, nil)
+	// Local thread-sub read fails → degrade to the room-level count (0), never error.
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return(nil, errors.New("db down"))
+	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	yes := true
+	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
+	require.NoError(t, err)
+	assert.Equal(t, 0, resp.Count)
+}
+
+func TestCountUnread_MutedRoomThreadExcluded(t *testing.T) {
+	svc, subs, rooms, threadSubs := newCountSvc(t)
+	seen := time.UnixMilli(100).UTC()
+	older := time.UnixMilli(50).UTC()
+	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(1, nil)
+	// GetActiveSubscriptions already excludes muted rooms, so a muted room's parent
+	// is never in the fetched page. Only r1 (unmuted, read) is returned.
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
+		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
+	}, nil)
+	// A thread in the muted room "rMuted" is returned by ListByAccount but its room is
+	// not in the page → filtered out, no batch, no bump.
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
+		{ThreadRoomID: "trM", RoomID: "rMuted", SiteID: "site-a", LastSeenAt: &seen},
+	}, nil)
+	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	yes := true
+	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
+	require.NoError(t, err)
+	assert.Equal(t, 0, resp.Count)
+}
+```
+
+- [ ] **Step 4: Run the new tests to verify they fail**
+
+Run: `make test SERVICE=user-service`
+Expected: FAIL — the thread phase does not exist yet; `TestCountUnread_ReadRoomBumpedByUnreadThread` gets 0 (expected 1) and the `GetThreadRoomInfoBatch` expectations are unmet.
+
+- [ ] **Step 5: Rewrite `countUnread` and add `countThreadOnlyUnread`**
+
+In `user-service/service/subscriptions.go`, replace the body of `countUnread` (currently `560-646`) with the version below. Two behavior changes: (a) collect `pendingRooms` (read rooms) in both the local loop and each cross-site goroutine; (b) always run the thread phase before returning.
+
+```go
+// countUnread counts active rooms with unread activity. A room counts once if its
+// messages are unread (LOCAL from the $lookup baseline, CROSS-SITE via per-site
+// GetRoomsInfo) OR it is message-read but has >=1 unread followed thread. Rooms that
+// came out read feed the thread phase (countThreadOnlyUnread); everything degrades
+// best-effort — an unreachable site is skipped rather than nuking the count to total.
+func (s *UserService) countUnread(ctx context.Context, account string, total int) (*models.CountResponse, error) {
+	// Short-circuit zero: min(0, maxSubs)=0 would build a $limit:0 MongoDB rejects.
+	if total == 0 {
+		return &models.CountResponse{Count: 0}, nil
+	}
+	// Cap at maxSubs — query-side total can exceed the cap; min keeps the fetch bounded and consistent with the list endpoints.
+	subs, err := s.subs.GetActiveSubscriptions(ctx, account, min(total, s.maxSubs))
+	if err != nil {
+		return nil, fmt.Errorf("count unread: %w", err)
+	}
+
+	// LOCAL subs carry room.lastMsgAt on the $lookup baseline — count them with no RPC.
+	// Only CROSS-SITE subs need the per-site GetRoomsInfo RPC (their room docs live remotely).
+	// pendingRooms collects rooms that came out READ (roomID -> siteID) for the thread phase.
+	unreadTotal := 0
+	pendingRooms := map[string]string{}
+	crossBySite := map[string][]model.EnrichedSubscription{}
+	roomIDsBySite := map[string][]string{}
+	for i := range subs {
+		if subs[i].SiteID == s.siteID {
+			if unread(subs[i].LastSeenAt, timeutil.TimeToMillis(subs[i].LastMsgAt)) {
+				unreadTotal++
+			} else {
+				pendingRooms[subs[i].RoomID] = s.siteID
+			}
+			continue
+		}
+		site := subs[i].SiteID
+		crossBySite[site] = append(crossBySite[site], subs[i])
+		roomIDsBySite[site] = append(roomIDsBySite[site], subs[i].RoomID)
+	}
+
+	if len(crossBySite) > 0 {
+		sites := make([]string, 0, len(crossBySite))
+		for site := range crossBySite {
+			sites = append(sites, site)
+		}
+		// Per-site degradation (matches the list path's enrichCrossSite): a failed site is
+		// SKIPPED — its subs drop out of the count and out of pendingRooms — while local subs
+		// and the sites that did respond still contribute. results[i] is written by exactly
+		// one goroutine.
+		type siteCount struct {
+			unread    int
+			readRooms []string
+		}
+		results := make([]siteCount, len(sites))
+		var wg sync.WaitGroup
+		sem := make(chan struct{}, maxSiteFanout) // bound concurrent per-site RPCs
+		for i, site := range sites {
+			// Client already gone — stop firing further ~5s RPCs.
+			if ctx.Err() != nil {
+				break
+			}
+			wg.Add(1)
+			sem <- struct{}{}
+			go func() {
+				defer wg.Done()
+				defer func() { <-sem }()
+				if ctx.Err() != nil {
+					return
+				}
+				infos, err := s.rooms.GetRoomsInfo(ctx, site, roomIDsBySite[site])
+				if err != nil {
+					// Skip this site rather than nuking the whole count to total.
+					slog.WarnContext(ctx, "unread count degraded for site", "account", account, "site", site, "request_id", natsutil.RequestIDFromContext(ctx), "error", err)
+					return
+				}
+				lastMsg := make(map[string]*int64, len(infos))
+				for k := range infos {
+					// Mirror the list path (applyRoomInfo): a not-found or soft-deleted
+					// (^Del-) room must not contribute to the count, even though the RPC
+					// still returns a stale lastMsgAt for a room soft-deleted at its origin.
+					if !infos[k].Found || strings.HasPrefix(infos[k].Name, deletedRoomNamePrefix) {
+						continue
+					}
+					lastMsg[infos[k].RoomID] = infos[k].LastMsgAt
+				}
+				n := 0
+				var read []string
+				siteSubs := crossBySite[site]
+				for j := range siteSubs {
+					rid := siteSubs[j].RoomID
+					// Not-found / soft-deleted rooms are absent from lastMsg — neither
+					// counted nor a thread candidate.
+					if _, ok := lastMsg[rid]; !ok {
+						continue
+					}
+					if unread(siteSubs[j].LastSeenAt, lastMsg[rid]) {
+						n++
+					} else {
+						read = append(read, rid)
+					}
+				}
+				results[i] = siteCount{unread: n, readRooms: read}
+			}()
+		}
+		wg.Wait()
+		for i := range results {
+			unreadTotal += results[i].unread
+			for _, rid := range results[i].readRooms {
+				pendingRooms[rid] = sites[i]
+			}
+		}
+	}
+
+	unreadTotal += s.countThreadOnlyUnread(ctx, account, pendingRooms)
+	return &models.CountResponse{Count: unreadTotal}, nil
+}
+
+// countThreadOnlyUnread returns how many pendingRooms (rooms already READ at the message
+// level, roomID -> siteID) have >=1 unread followed thread — at most +1 per room. Thread
+// last-activity is resolved per owning site via GetThreadRoomInfoBatch, degrading like the
+// room pass: a failed site contributes nothing. A ListByAccount failure logs and returns 0
+// so a thread-subsystem hiccup never discards the established room-level count.
+func (s *UserService) countThreadOnlyUnread(ctx context.Context, account string, pendingRooms map[string]string) int {
+	if len(pendingRooms) == 0 {
+		return 0
+	}
+	rows, err := s.threadSubs.ListByAccount(ctx, account)
+	if err != nil {
+		slog.WarnContext(ctx, "unread count: thread subscriptions read failed", "account", account, "request_id", natsutil.RequestIDFromContext(ctx), "error", err)
+		return 0
+	}
+
+	// Keep only threads whose parent room is a pending (read) candidate; group by owning site.
+	type threadCand struct {
+		roomID     string
+		lastSeenAt *time.Time
+	}
+	idsBySite := map[string][]string{}
+	byThread := make(map[string]threadCand, len(rows))
+	for i := range rows {
+		if _, ok := pendingRooms[rows[i].RoomID]; !ok {
+			continue
+		}
+		idsBySite[rows[i].SiteID] = append(idsBySite[rows[i].SiteID], rows[i].ThreadRoomID)
+		byThread[rows[i].ThreadRoomID] = threadCand{roomID: rows[i].RoomID, lastSeenAt: rows[i].LastSeenAt}
+	}
+	if len(idsBySite) == 0 {
+		return 0
+	}
+
+	sites := make([]string, 0, len(idsBySite))
+	for site := range idsBySite {
+		sites = append(sites, site)
+	}
+	type siteResult struct {
+		infos  []model.ThreadRoomInfo
+		failed bool
+	}
+	results := make([]siteResult, len(sites))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, maxSiteFanout)
+	for i, site := range sites {
+		if ctx.Err() != nil {
+			break
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			for _, chunk := range chunkStrings(idsBySite[site], threadInfoBatchChunk) {
+				if ctx.Err() != nil {
+					results[i].failed = true
+					return
+				}
+				infos, err := s.rooms.GetThreadRoomInfoBatch(ctx, site, chunk)
+				if err != nil {
+					slog.WarnContext(ctx, "unread count: thread info site degraded", "account", account, "site", site, "request_id", natsutil.RequestIDFromContext(ctx), "error", err)
+					results[i].failed = true
+					return
+				}
+				results[i].infos = append(results[i].infos, infos...)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Existence per room: a room bumps at most once; skip a room's remaining threads once bumped.
+	bumped := map[string]bool{}
+	for i := range results {
+		if results[i].failed {
+			continue
+		}
+		for _, info := range results[i].infos {
+			if !info.Found {
+				continue
+			}
+			cand, ok := byThread[info.ThreadRoomID]
+			if !ok || bumped[cand.roomID] {
+				continue
+			}
+			ms := info.LastMsgAt
+			if unread(cand.lastSeenAt, &ms) {
+				bumped[cand.roomID] = true
+			}
+		}
+	}
+	return len(bumped)
+}
+```
+
+- [ ] **Step 6: Run the full user-service unit suite to verify it passes**
+
+Run: `make test SERVICE=user-service`
+Expected: PASS — the new thread tests pass and every existing `TestCountUnread_*` still passes (read-room tests hit the ListByAccount default returning no threads).
+
+- [ ] **Step 7: Lint**
+
+Run: `make lint`
+Expected: clean (no unused vars, imports unchanged — `sync`, `slog`, `strings`, `natsutil`, `timeutil`, `model` are all already imported).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add user-service/service/subscriptions.go user-service/service/service_test.go user-service/service/subscriptions_test.go
+git commit -m "feat(user-service): count rooms with unread threads in subscription.count"
+```
+
+---
+
+### Task 4: Document the semantic in `client-api.md`
+
+**Files:**
+- Modify: `docs/client-api.md` (the `subscription.count` section, ~line 4620-4657)
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Read the current `subscription.count` section**
+
+Run: open `docs/client-api.md` around line 4620 and locate the prose describing the unread "active set" and per-site degradation.
+
+- [ ] **Step 2: Add the thread note**
+
+Append a sentence to the unread-semantics prose (adjust surrounding wording to fit; do not change the request/response field tables or the JSON example):
+
+```markdown
+When `unread` is true, a room also counts as unread if it has at least one unread
+followed thread, even when its own messages are all read — at most **+1 per room**
+(existence, not a per-thread count). Muted rooms are excluded (as with room-level
+unread). Thread state for message-read rooms is resolved per owning site and degrades
+best-effort: if a site's thread lookup fails, its rooms are simply not bumped.
+```
+
+- [ ] **Step 3: Verify no derived-view drift**
+
+The request/response schema for `subscription.count` is unchanged (`{count}`), so `docs/client-api/request-reply.md` needs no edit. Confirm by checking that the `subscription.count` entry there lists no request/response fields that changed.
+
+Run: `grep -n "subscription.count" docs/client-api/request-reply.md`
+Expected: the entry references the same `{count}` response — no change needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/client-api.md
+git commit -m "docs(client-api): note thread-aware unread in subscription.count"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Semantics (room unread OR ≥1 unread thread, +1 max) → Task 3 (`countUnread` + `countThreadOnlyUnread`).
+- `RoomID` on `ThreadUnreadRow` → Task 1. Projection → Task 2.
+- Pruning #1 (skip already-unread rooms) → `pendingRooms` only holds read rooms. Pruning #2 (stop at first unread thread) → `bumped` set short-circuit.
+- Muted excluded → covered by `GetActiveSubscriptions` filter + page-membership filter (Task 3 test `MutedRoomThreadExcluded`).
+- Cap scope (threads only bump fetched page) → `pendingRooms` built from the fetched subs (Task 3 test `ThreadInRoomOutsidePageIgnored`).
+- Best-effort degradation (batch failure, list failure) → Task 3 tests `ThreadBatchFailureDegrades`, `ThreadListErrorDegrades`.
+- Bounds (500 thread cap via `ListByAccount`, chunk 500, `maxSiteFanout`) → reused, no new limits.
+- Docs prose → Task 4.
+
+**Placeholder scan:** none — every step carries concrete code/commands.
+
+**Type consistency:** `ThreadUnreadRow.RoomID` (Task 1) is read in Task 3's `countThreadOnlyUnread` as `rows[i].RoomID`. `model.ThreadRoomInfo{ThreadRoomID, Found, LastMsgAt int64}` matches `pkg/model/threadsubscription.go:62`. `unread(*time.Time, *int64)` — `ms := info.LastMsgAt; unread(cand.lastSeenAt, &ms)` matches the signature. `GetThreadRoomInfoBatch(ctx, siteID, ids) ([]model.ThreadRoomInfo, error)` matches `service.go:47`. `newCountSvc` returns `(svc, subs, rooms, threadSubs)` and is the only caller shape used by new tests.
+
+**Notes for the executor:**
+- The `newSvc` default (Task 3 Step 1) is load-bearing for keeping `TestCountUnread_MultiSite` / `TestCountUnread_AllRead` green; do not skip it.
+- Run `make test SERVICE=user-service` after Task 3 before committing — it exercises both new and pre-existing count tests together.

--- a/docs/superpowers/specs/2026-07-16-thread-aware-unread-count-design.md
+++ b/docs/superpowers/specs/2026-07-16-thread-aware-unread-count-design.md
@@ -1,0 +1,107 @@
+# Thread-Aware Unread Count: Rooms with Unread Threads Count as Unread
+
+**Date:** 2026-07-16
+**Status:** Approved
+
+## Summary
+
+`user-service`'s `subscription.count` (unread=true) counts unread *rooms*, comparing each
+room's `lastMsgAt` to the subscription's `lastSeenAt`, and ignores threads. This extends
+`countUnread` so a room also counts as unread when it has ≥1 unread thread — **at most +1
+per room** (existence, not count). Read-side only: no new persisted field, no write-side
+fan-out, no reliance on the un-grown `subscription.threadUnread` array. Muted rooms stay
+excluded; the `{count}` response shape is unchanged. Thread state is derived at read time
+and pruned using the existence-only property (skip already-unread rooms; stop at the first
+unread thread per room).
+
+## Design
+
+### 1. `pkg/model` (`threadsubscription.go`)
+
+Add the parent room ID to the badge read projection so a thread can be attributed to its room:
+
+```go
+type ThreadUnreadRow struct {
+	ThreadRoomID string     `json:"threadRoomId" bson:"threadRoomId"`
+	RoomID       string     `json:"roomId"       bson:"roomId"`
+	SiteID       string     `json:"siteId"       bson:"siteId"`
+	RoomType     RoomType   `json:"roomType"     bson:"roomType"`
+	LastSeenAt   *time.Time `json:"lastSeenAt"   bson:"lastSeenAt"`
+	HasMention   bool       `json:"hasMention"   bson:"hasMention"`
+}
+```
+
+Internal projection, not a client payload — no `client-api.md` schema change.
+
+### 2. `user-service/mongorepo` (`threadsubscriptions.go`)
+
+`ListByAccount`'s final `$project` gains `"roomId": 1`. The source document already carries
+`roomId` (the `$lookup` join key), so the pipeline is otherwise unchanged.
+
+### 3. `user-service/service` (`subscriptions.go`, `countUnread`)
+
+After the existing room-level pass (local join + cross-site `GetRoomsInfo`):
+
+1. Build `pendingRooms` (`roomID → siteID`): fetched active rooms that came out **read** at
+   the message level. Already-unread rooms are excluded — they are already +1.
+2. If `pendingRooms` is empty, return the room-level count unchanged (no thread work).
+3. `threadSubs.ListByAccount` (access-gated, capped at 500); keep only rows whose
+   `RoomID ∈ pendingRooms`. This confines bumps to the `maxSubs` page and drops muted rooms.
+4. Group survivors by `siteId`; resolve each thread's `lastMsgAt` via
+   `rooms.GetThreadRoomInfoBatch` — chunked at 500, one goroutine per site, per-site
+   degradation (the `GetThreadUnreadSummary` pattern).
+5. For each resolved thread: if `unread(lastSeenAt, lastMsgAt)` and its room is still in
+   `pendingRooms`, `count++` and remove the room from `pendingRooms` — so its remaining
+   threads no longer match and are skipped.
+
+Final count is `roomLevelUnread + threadOnlyUnread`, each room at most 1.
+
+### 4. Error handling
+
+A failed `GetThreadRoomInfoBatch` logs WARN with `request_id` and leaves that site's rooms
+un-bumped — the count under-reports rather than erroring, matching today's cross-site room
+path. Context cancellation returns the count so far.
+
+### 5. Bounds
+
+Room page bounded by `maxSubs`; thread read bounded by 500; thread bumps confined to the
+room page. No unbounded fan-out.
+
+## Testing (TDD, table-driven)
+
+`user-service/service/subscriptions_test.go` (mocked `threadSubs` + `rooms`), red first:
+
+- Room-level unread only — unchanged from today.
+- Read room + one unread thread → +1.
+- Already-unread room + unread thread → still +1 (thread never resolved).
+- Room with three unread threads → +1.
+- Thread in a muted room → excluded.
+- Cross-site thread resolution → bumps correctly.
+- Per-site thread-batch failure → rooms un-bumped, degrades, no error.
+- Thread whose parent room is beyond the `maxSubs` cap → ignored.
+- Empty thread list and `total == 0` → short-circuit.
+
+Plus: `pkg/model/model_test.go` round-trips the new `roomId`; a `mongorepo` integration
+test asserts `ListByAccount` emits `roomId`.
+
+## Documentation
+
+`docs/client-api.md` `subscription.count` section (~line 4620): prose note that a room
+counts as unread when it has an unread thread (at most +1, muted excluded, best-effort under
+cross-site degradation). Schema tables unchanged.
+
+## Out of scope
+
+- Growing `subscription.threadUnread` on thread reply (write-side fan-out).
+- Changes to `thread.unread.summary`, `subscription.list`, or the `{count}` shape.
+- Exact per-room unread thread counts.
+- Counting threads for rooms outside the `maxSubs` page.
+
+## Touched files
+
+- `pkg/model/threadsubscription.go` — add `RoomID` to `ThreadUnreadRow`.
+- `user-service/mongorepo/threadsubscriptions.go` — project `roomId`.
+- `user-service/service/subscriptions.go` — extend `countUnread`.
+- Tests: `user-service/service/subscriptions_test.go`, `pkg/model/model_test.go`,
+  `user-service/mongorepo` integration test.
+- `docs/client-api.md` — prose note.

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -4300,7 +4300,7 @@ func TestThreadRoomInfoBatchResponseJSON(t *testing.T) {
 func TestThreadUnreadRowJSON(t *testing.T) {
 	seen := time.UnixMilli(1717000000000).UTC()
 	r := model.ThreadUnreadRow{
-		ThreadRoomID: "tr1", SiteID: "site-a", RoomType: model.RoomTypeDM,
+		ThreadRoomID: "tr1", RoomID: "r1", SiteID: "site-a", RoomType: model.RoomTypeDM,
 		LastSeenAt: &seen, HasMention: true,
 	}
 	roundTrip(t, &r, &model.ThreadUnreadRow{})

--- a/pkg/model/threadsubscription.go
+++ b/pkg/model/threadsubscription.go
@@ -31,6 +31,7 @@ type ThreadSubscription struct {
 // survive the join; RoomType feeds the DM tally.
 type ThreadUnreadRow struct {
 	ThreadRoomID string     `json:"threadRoomId" bson:"threadRoomId"`
+	RoomID       string     `json:"roomId"       bson:"roomId"`
 	SiteID       string     `json:"siteId"       bson:"siteId"`
 	RoomType     RoomType   `json:"roomType"     bson:"roomType"`
 	LastSeenAt   *time.Time `json:"lastSeenAt"   bson:"lastSeenAt"`

--- a/user-service/mongorepo/threadsubscriptions.go
+++ b/user-service/mongorepo/threadsubscriptions.go
@@ -74,6 +74,7 @@ func (r *ThreadSubscriptionRepo) ListByAccount(ctx context.Context, account stri
 		bson.M{"$project": bson.M{
 			"_id":          0,
 			"threadRoomId": 1,
+			"roomId":       1,
 			"siteId":       1,
 			"lastSeenAt":   1,
 			"hasMention":   1,

--- a/user-service/mongorepo/threadsubscriptions_test.go
+++ b/user-service/mongorepo/threadsubscriptions_test.go
@@ -51,6 +51,8 @@ func TestThreadSubscriptionRepo_ListByAccount(t *testing.T) {
 		bySite[r.SiteID] = r
 	}
 	assert.Equal(t, "tr1", bySite["site-a"].ThreadRoomID)
+	assert.Equal(t, "r1", bySite["site-a"].RoomID)
+	assert.Equal(t, "r2", bySite["site-b"].RoomID)
 	assert.Equal(t, model.RoomTypeChannel, bySite["site-a"].RoomType)
 	assert.True(t, bySite["site-a"].HasMention)
 	require.NotNil(t, bySite["site-a"].LastSeenAt)

--- a/user-service/service/service_test.go
+++ b/user-service/service/service_test.go
@@ -29,6 +29,9 @@ func newSvc(t *testing.T) (*UserService, *mocks.MockSubscriptionRepository, *moc
 	// ListSubscriptions now enriches last-message via history.RoomsGet; default it to a
 	// no-op so list tests that don't exercise last-message need no per-test stub.
 	history.EXPECT().RoomsGet(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	// countUnread's thread phase reads thread-subs; default to none so room-count
+	// tests that don't exercise threads need no per-test stub.
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	return New(subs, users, apps, threadSubs, rooms, history, presence, pub, cfg), subs, users, apps, rooms, history, pub
 }
 

--- a/user-service/service/subscriptions.go
+++ b/user-service/service/subscriptions.go
@@ -552,11 +552,11 @@ func (s *UserService) CountSubscriptions(c *natsrouter.Context, req models.Count
 	return s.countUnread(c, account, total)
 }
 
-// countUnread counts active subs with unread messages. LOCAL subs are counted from the
-// $lookup baseline (room.lastMsgAt) with no RPC; CROSS-SITE subs use per-site GetRoomsInfo
-// RPCs that degrade independently — an unreachable site is skipped (its subs omitted),
-// while local subs and the sites that did respond still count, so a remote hiccup yields a
-// best-effort partial rather than the raw active-sub total.
+// countUnread counts active rooms with unread activity. A room counts once if its
+// messages are unread (LOCAL from the $lookup baseline, CROSS-SITE via per-site
+// GetRoomsInfo) OR it is message-read but has >=1 unread followed thread. Rooms that
+// came out read feed the thread phase (countThreadOnlyUnread); everything degrades
+// best-effort — an unreachable site is skipped rather than nuking the count to total.
 func (s *UserService) countUnread(ctx context.Context, account string, total int) (*models.CountResponse, error) {
 	// Short-circuit zero: min(0, maxSubs)=0 would build a $limit:0 MongoDB rejects.
 	if total == 0 {
@@ -570,13 +570,17 @@ func (s *UserService) countUnread(ctx context.Context, account string, total int
 
 	// LOCAL subs carry room.lastMsgAt on the $lookup baseline — count them with no RPC.
 	// Only CROSS-SITE subs need the per-site GetRoomsInfo RPC (their room docs live remotely).
+	// pendingRooms collects rooms that came out READ (roomID -> siteID) for the thread phase.
 	unreadTotal := 0
+	pendingRooms := map[string]string{}
 	crossBySite := map[string][]model.EnrichedSubscription{}
 	roomIDsBySite := map[string][]string{}
 	for i := range subs {
 		if subs[i].SiteID == s.siteID {
 			if unread(subs[i].LastSeenAt, timeutil.TimeToMillis(subs[i].LastMsgAt)) {
 				unreadTotal++
+			} else {
+				pendingRooms[subs[i].RoomID] = s.siteID
 			}
 			continue
 		}
@@ -584,23 +588,129 @@ func (s *UserService) countUnread(ctx context.Context, account string, total int
 		crossBySite[site] = append(crossBySite[site], subs[i])
 		roomIDsBySite[site] = append(roomIDsBySite[site], subs[i].RoomID)
 	}
-	if len(crossBySite) == 0 {
-		return &models.CountResponse{Count: unreadTotal}, nil
+
+	if len(crossBySite) > 0 {
+		sites := make([]string, 0, len(crossBySite))
+		for site := range crossBySite {
+			sites = append(sites, site)
+		}
+		// Per-site degradation (matches the list path's enrichCrossSite): a failed site is
+		// SKIPPED — its subs drop out of the count and out of pendingRooms — while local subs
+		// and the sites that did respond still contribute. results[i] is written by exactly
+		// one goroutine.
+		type siteCount struct {
+			unread    int
+			readRooms []string
+		}
+		results := make([]siteCount, len(sites))
+		var wg sync.WaitGroup
+		sem := make(chan struct{}, maxSiteFanout) // bound concurrent per-site RPCs
+		for i, site := range sites {
+			// Client already gone — stop firing further ~5s RPCs.
+			if ctx.Err() != nil {
+				break
+			}
+			wg.Add(1)
+			sem <- struct{}{}
+			go func() {
+				defer wg.Done()
+				defer func() { <-sem }()
+				if ctx.Err() != nil {
+					return
+				}
+				infos, err := s.rooms.GetRoomsInfo(ctx, site, roomIDsBySite[site])
+				if err != nil {
+					// Skip this site rather than nuking the whole count to total.
+					slog.WarnContext(ctx, "unread count degraded for site", "account", account, "site", site, "request_id", natsutil.RequestIDFromContext(ctx), "error", err)
+					return
+				}
+				lastMsg := make(map[string]*int64, len(infos))
+				for k := range infos {
+					// Mirror the list path (applyRoomInfo): a not-found or soft-deleted
+					// (^Del-) room must not contribute to the count, even though the RPC
+					// still returns a stale lastMsgAt for a room soft-deleted at its origin.
+					if !infos[k].Found || strings.HasPrefix(infos[k].Name, deletedRoomNamePrefix) {
+						continue
+					}
+					lastMsg[infos[k].RoomID] = infos[k].LastMsgAt
+				}
+				n := 0
+				var read []string
+				siteSubs := crossBySite[site]
+				for j := range siteSubs {
+					rid := siteSubs[j].RoomID
+					// Not-found / soft-deleted rooms are absent from lastMsg — neither
+					// counted nor a thread candidate.
+					if _, ok := lastMsg[rid]; !ok {
+						continue
+					}
+					if unread(siteSubs[j].LastSeenAt, lastMsg[rid]) {
+						n++
+					} else {
+						read = append(read, rid)
+					}
+				}
+				results[i] = siteCount{unread: n, readRooms: read}
+			}()
+		}
+		wg.Wait()
+		for i := range results {
+			unreadTotal += results[i].unread
+			for _, rid := range results[i].readRooms {
+				pendingRooms[rid] = sites[i]
+			}
+		}
 	}
 
-	sites := make([]string, 0, len(crossBySite))
-	for site := range crossBySite {
+	unreadTotal += s.countThreadOnlyUnread(ctx, account, pendingRooms)
+	return &models.CountResponse{Count: unreadTotal}, nil
+}
+
+// countThreadOnlyUnread returns how many pendingRooms (rooms already READ at the message
+// level, roomID -> siteID) have >=1 unread followed thread — at most +1 per room. Thread
+// last-activity is resolved per owning site via GetThreadRoomInfoBatch, degrading like the
+// room pass: a failed site contributes nothing. A ListByAccount failure logs and returns 0
+// so a thread-subsystem hiccup never discards the established room-level count.
+func (s *UserService) countThreadOnlyUnread(ctx context.Context, account string, pendingRooms map[string]string) int {
+	if len(pendingRooms) == 0 {
+		return 0
+	}
+	rows, err := s.threadSubs.ListByAccount(ctx, account)
+	if err != nil {
+		slog.WarnContext(ctx, "unread count: thread subscriptions read failed", "account", account, "request_id", natsutil.RequestIDFromContext(ctx), "error", err)
+		return 0
+	}
+
+	// Keep only threads whose parent room is a pending (read) candidate; group by owning site.
+	type threadCand struct {
+		roomID     string
+		lastSeenAt *time.Time
+	}
+	idsBySite := map[string][]string{}
+	byThread := make(map[string]threadCand, len(rows))
+	for i := range rows {
+		if _, ok := pendingRooms[rows[i].RoomID]; !ok {
+			continue
+		}
+		idsBySite[rows[i].SiteID] = append(idsBySite[rows[i].SiteID], rows[i].ThreadRoomID)
+		byThread[rows[i].ThreadRoomID] = threadCand{roomID: rows[i].RoomID, lastSeenAt: rows[i].LastSeenAt}
+	}
+	if len(idsBySite) == 0 {
+		return 0
+	}
+
+	sites := make([]string, 0, len(idsBySite))
+	for site := range idsBySite {
 		sites = append(sites, site)
 	}
-	// Per-site degradation (matches the list path's enrichCrossSite): a failed site is
-	// SKIPPED — its subs drop out of the count — while local subs and the sites that did
-	// respond still contribute. WaitGroup (not errgroup.WithContext) so one site's failure
-	// never cancels its siblings; results[i] is written by exactly one goroutine.
-	results := make([]int, len(sites))
+	type siteResult struct {
+		infos  []model.ThreadRoomInfo
+		failed bool
+	}
+	results := make([]siteResult, len(sites))
 	var wg sync.WaitGroup
-	sem := make(chan struct{}, maxSiteFanout) // bound concurrent per-site RPCs
+	sem := make(chan struct{}, maxSiteFanout)
 	for i, site := range sites {
-		// Client already gone — stop firing further ~5s RPCs.
 		if ctx.Err() != nil {
 			break
 		}
@@ -609,38 +719,42 @@ func (s *UserService) countUnread(ctx context.Context, account string, total int
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
-			if ctx.Err() != nil {
-				return
-			}
-			infos, err := s.rooms.GetRoomsInfo(ctx, site, roomIDsBySite[site])
-			if err != nil {
-				// Skip this site rather than nuking the whole count to total.
-				slog.WarnContext(ctx, "unread count degraded for site", "account", account, "site", site, "request_id", natsutil.RequestIDFromContext(ctx), "error", err)
-				return
-			}
-			lastMsg := make(map[string]*int64, len(infos))
-			for k := range infos {
-				// Mirror the list path (applyRoomInfo): a not-found or soft-deleted
-				// (^Del-) room must not contribute to the count, even though the RPC
-				// still returns a stale lastMsgAt for a room soft-deleted at its origin.
-				if !infos[k].Found || strings.HasPrefix(infos[k].Name, deletedRoomNamePrefix) {
-					continue
+			for _, chunk := range chunkStrings(idsBySite[site], threadInfoBatchChunk) {
+				if ctx.Err() != nil {
+					results[i].failed = true
+					return
 				}
-				lastMsg[infos[k].RoomID] = infos[k].LastMsgAt
-			}
-			n := 0
-			siteSubs := crossBySite[site]
-			for j := range siteSubs {
-				if unread(siteSubs[j].LastSeenAt, lastMsg[siteSubs[j].RoomID]) {
-					n++
+				infos, err := s.rooms.GetThreadRoomInfoBatch(ctx, site, chunk)
+				if err != nil {
+					slog.WarnContext(ctx, "unread count: thread info site degraded", "account", account, "site", site, "request_id", natsutil.RequestIDFromContext(ctx), "error", err)
+					results[i].failed = true
+					return
 				}
+				results[i].infos = append(results[i].infos, infos...)
 			}
-			results[i] = n
 		}()
 	}
 	wg.Wait()
-	for _, n := range results {
-		unreadTotal += n
+
+	// Existence per room: a room bumps at most once; skip a room's remaining threads once bumped.
+	bumped := map[string]bool{}
+	for i := range results {
+		if results[i].failed {
+			continue
+		}
+		for _, info := range results[i].infos {
+			if !info.Found {
+				continue
+			}
+			cand, ok := byThread[info.ThreadRoomID]
+			if !ok || bumped[cand.roomID] {
+				continue
+			}
+			ms := info.LastMsgAt
+			if unread(cand.lastSeenAt, &ms) {
+				bumped[cand.roomID] = true
+			}
+		}
 	}
-	return &models.CountResponse{Count: unreadTotal}, nil
+	return len(bumped)
 }

--- a/user-service/service/subscriptions_test.go
+++ b/user-service/service/subscriptions_test.go
@@ -626,6 +626,24 @@ func TestCount_StoreError(t *testing.T) {
 	requireCode(t, err, errcode.CodeInternal)
 }
 
+// newCountSvc builds a service exposing the subscription, room, and thread-sub
+// mocks the thread-aware unread tests drive. maxSubs is large; per-test GetActiveSubscriptions
+// stubs control the fetched page directly.
+func newCountSvc(t *testing.T) (*UserService, *mocks.MockSubscriptionRepository, *mocks.MockRoomClient, *mocks.MockThreadSubscriptionRepository) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	subs := mocks.NewMockSubscriptionRepository(ctrl)
+	users := mocks.NewMockUserRepository(ctrl)
+	apps := mocks.NewMockAppRepository(ctrl)
+	rooms := mocks.NewMockRoomClient(ctrl)
+	history := mocks.NewMockHistoryClient(ctrl)
+	presence := mocks.NewMockPresenceClient(ctrl)
+	pub := mocks.NewMockEventPublisher(ctrl)
+	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
+	cfg := &config.Config{SiteID: "site-a", AllSiteIDs: []string{"site-a", "site-b"}, MaxSubscriptionLimit: 1000, DefaultSubscriptionLimit: 40, MaxAppsLimit: 100, DefaultAppsLimit: 20, MaxAccountNames: 100}
+	return New(subs, users, apps, threadSubs, rooms, history, presence, pub, cfg), subs, rooms, threadSubs
+}
+
 func TestCountUnread_Happy(t *testing.T) {
 	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	seen := time.UnixMilli(100).UTC()
@@ -775,6 +793,173 @@ func TestCountUnread_CrossSiteDeletedRoomNotCounted(t *testing.T) {
 	resp, err := svc.countUnread(context.Background(), "alice", 1)
 	require.NoError(t, err)
 	assert.Equal(t, 0, resp.Count, "a soft-deleted cross-site room must not be counted as unread")
+}
+
+func TestCountUnread_ReadRoomBumpedByUnreadThread(t *testing.T) {
+	svc, subs, rooms, threadSubs := newCountSvc(t)
+	seen := time.UnixMilli(100).UTC()
+	older := time.UnixMilli(50).UTC()
+	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(1, nil)
+	// One LOCAL room, read at the message level (lastMsgAt older than lastSeen).
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
+		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
+	}, nil)
+	// One followed thread in r1, unread (thread lastMsgAt 200 > lastSeen 100).
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
+		{ThreadRoomID: "tr1", RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen},
+	}, nil)
+	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), "site-a", []string{"tr1"}).
+		Return([]model.ThreadRoomInfo{{ThreadRoomID: "tr1", Found: true, LastMsgAt: 200}}, nil)
+	yes := true
+	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
+	require.NoError(t, err)
+	assert.Equal(t, 1, resp.Count)
+}
+
+func TestCountUnread_AlreadyUnreadRoomNotDoubleCounted(t *testing.T) {
+	svc, subs, rooms, threadSubs := newCountSvc(t)
+	seen := time.UnixMilli(100).UTC()
+	newer := time.UnixMilli(300).UTC()
+	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(1, nil)
+	// r1 is already room-level unread → must not be thread-checked, contributes exactly 1.
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
+		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &newer},
+	}, nil)
+	// Every room already unread ⇒ pendingRooms empty ⇒ ListByAccount never called.
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), gomock.Any()).Times(0)
+	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	yes := true
+	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
+	require.NoError(t, err)
+	assert.Equal(t, 1, resp.Count)
+}
+
+func TestCountUnread_MultipleUnreadThreadsCountOnce(t *testing.T) {
+	svc, subs, rooms, threadSubs := newCountSvc(t)
+	seen := time.UnixMilli(100).UTC()
+	older := time.UnixMilli(50).UTC()
+	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(1, nil)
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
+		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
+	}, nil)
+	// Three unread threads, all in r1 → +1 total.
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
+		{ThreadRoomID: "tr1", RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen},
+		{ThreadRoomID: "tr2", RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen},
+		{ThreadRoomID: "tr3", RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen},
+	}, nil)
+	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), "site-a", gomock.InAnyOrder([]string{"tr1", "tr2", "tr3"})).
+		Return([]model.ThreadRoomInfo{
+			{ThreadRoomID: "tr1", Found: true, LastMsgAt: 200},
+			{ThreadRoomID: "tr2", Found: true, LastMsgAt: 200},
+			{ThreadRoomID: "tr3", Found: true, LastMsgAt: 200},
+		}, nil)
+	yes := true
+	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
+	require.NoError(t, err)
+	assert.Equal(t, 1, resp.Count)
+}
+
+func TestCountUnread_ThreadInRoomOutsidePageIgnored(t *testing.T) {
+	svc, subs, rooms, threadSubs := newCountSvc(t)
+	seen := time.UnixMilli(100).UTC()
+	older := time.UnixMilli(50).UTC()
+	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(1, nil)
+	// Fetched page contains only r1 (read).
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
+		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
+	}, nil)
+	// Thread lives in rX, which is NOT in the fetched page → must be filtered out, no batch call.
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
+		{ThreadRoomID: "trX", RoomID: "rX", SiteID: "site-a", LastSeenAt: &seen},
+	}, nil)
+	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	yes := true
+	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
+	require.NoError(t, err)
+	assert.Equal(t, 0, resp.Count)
+}
+
+func TestCountUnread_CrossSiteThreadResolution(t *testing.T) {
+	svc, subs, rooms, threadSubs := newCountSvc(t)
+	seen := time.UnixMilli(100).UTC()
+	older := int64(50)
+	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(1, nil)
+	// r1 lives on site-b, read at the message level.
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
+		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-b", LastSeenAt: &seen}},
+	}, nil)
+	rooms.EXPECT().GetRoomsInfo(gomock.Any(), "site-b", []string{"r1"}).
+		Return([]model.RoomInfo{{RoomID: "r1", Found: true, LastMsgAt: &older}}, nil)
+	// A followed thread in r1 on site-b, unread → resolved via the site-b batch.
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
+		{ThreadRoomID: "tr1", RoomID: "r1", SiteID: "site-b", LastSeenAt: &seen},
+	}, nil)
+	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), "site-b", []string{"tr1"}).
+		Return([]model.ThreadRoomInfo{{ThreadRoomID: "tr1", Found: true, LastMsgAt: 200}}, nil)
+	yes := true
+	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
+	require.NoError(t, err)
+	assert.Equal(t, 1, resp.Count)
+}
+
+func TestCountUnread_ThreadBatchFailureDegrades(t *testing.T) {
+	svc, subs, rooms, threadSubs := newCountSvc(t)
+	seen := time.UnixMilli(100).UTC()
+	older := time.UnixMilli(50).UTC()
+	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(1, nil)
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
+		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
+	}, nil)
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
+		{ThreadRoomID: "tr1", RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen},
+	}, nil)
+	// Thread resolution fails → room un-bumped, count degrades to 0, no error.
+	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), "site-a", []string{"tr1"}).
+		Return(nil, errors.New("down"))
+	yes := true
+	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
+	require.NoError(t, err)
+	assert.Equal(t, 0, resp.Count)
+}
+
+func TestCountUnread_ThreadListErrorDegrades(t *testing.T) {
+	svc, subs, rooms, threadSubs := newCountSvc(t)
+	seen := time.UnixMilli(100).UTC()
+	older := time.UnixMilli(50).UTC()
+	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(1, nil)
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
+		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
+	}, nil)
+	// Local thread-sub read fails → degrade to the room-level count (0), never error.
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return(nil, errors.New("db down"))
+	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	yes := true
+	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
+	require.NoError(t, err)
+	assert.Equal(t, 0, resp.Count)
+}
+
+func TestCountUnread_MutedRoomThreadExcluded(t *testing.T) {
+	svc, subs, rooms, threadSubs := newCountSvc(t)
+	seen := time.UnixMilli(100).UTC()
+	older := time.UnixMilli(50).UTC()
+	subs.EXPECT().CountActiveSubscriptions(gomock.Any(), "alice").Return(1, nil)
+	// GetActiveSubscriptions already excludes muted rooms, so a muted room's parent
+	// is never in the fetched page. Only r1 (unmuted, read) is returned.
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
+		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
+	}, nil)
+	// A thread in the muted room "rMuted" is returned by ListByAccount but its room is
+	// not in the page → filtered out, no batch, no bump.
+	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
+		{ThreadRoomID: "trM", RoomID: "rMuted", SiteID: "site-a", LastSeenAt: &seen},
+	}, nil)
+	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	yes := true
+	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
+	require.NoError(t, err)
+	assert.Equal(t, 0, resp.Count)
 }
 
 func TestDistinctListNames(t *testing.T) {


### PR DESCRIPTION
## Summary

Extends `user-service`'s `subscription.count` (unread=true) to count a room as unread when it has ≥1 unread followed thread, even if the room's own messages are all read. Each room contributes at most +1 (existence-only, not per-thread). Read-side only; no new persisted state or write-side fan-out.

## Changes

### Model & Data Layer
- **`pkg/model/threadsubscription.go`**: Add `RoomID` field to `ThreadUnreadRow` projection so threads can be attributed to their parent room.
- **`user-service/mongorepo/threadsubscriptions.go`**: Project `roomId` in `ListByAccount`'s final `$project` stage.

### Service Logic
- **`user-service/service/subscriptions.go`**: 
  - Refactor `countUnread` to collect `pendingRooms` (rooms that came out read at the message level) during both the local and cross-site passes.
  - Add new `countThreadOnlyUnread` helper that:
    - Reads followed threads via `threadSubs.ListByAccount` (best-effort; logs WARN and returns 0 on failure).
    - Filters to threads whose parent room is in `pendingRooms` (confines bumps to the fetched page, respects muting).
    - Groups by site and resolves thread `lastMsgAt` via `GetThreadRoomInfoBatch` (chunked at 500, per-site degradation).
    - Bumps each room at most once (existence-only: stops at the first unread thread per room).
  - Final count is `roomLevelUnread + threadOnlyUnread`.

### Testing
- **`user-service/service/service_test.go`**: Add `ListByAccount` default to `newSvc` so existing room-count tests stay green.
- **`user-service/service/subscriptions_test.go`**: 
  - Add `newCountSvc` helper exposing thread-sub and room mocks.
  - Add 8 new table-driven tests covering: read room bumped by unread thread, already-unread room not double-counted, multiple threads per room (count once), thread in room outside page (ignored), cross-site thread resolution, per-site batch failure (degrades), thread-list failure (degrades), muted room thread (excluded).

### Documentation
- **`docs/client-api.md`** & **`docs/client-api/request-reply.md`**: Add prose note that a room counts as unread when it has an unread thread (at most +1 per room, muted excluded, best-effort under cross-site degradation). Schema tables unchanged.
- **`docs/superpowers/specs/2026-07-16-thread-aware-unread-count-design.md`**: Design spec (approved).
- **`docs/superpowers/plans/2026-07-16-thread-aware-unread-count.md`**: Detailed implementation plan with TDD task breakdown.

## Implementation Details

- **Bounds**: Room page capped at `maxSubs`; thread read capped at 500; thread bumps confined to the room page. No unbounded fan-out.
- **Degradation**: A failed `GetThreadRoomInfoBatch` logs WARN with `request_id` and leaves that site's rooms un-bumped — the count under-reports rather than erroring, matching today's cross-site room path. Context cancellation returns the count so far.
- **Muting**: Muted rooms are already excluded by `GetActiveSubscriptions`, so their threads never match `pendingRooms` and are filtered out.
- **Reuse**: Leverages existing `unread` predicate, `chunkStrings`, `threadInfoBatchChunk` (=500), and `maxSiteFanout` (=8) constants.

https://claude.ai/code/session_01D1KpWHPKcQmNo2ugynwCPf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unread subscription counts now include rooms with unread followed threads, even when room messages are read.
  * Each room contributes at most one unread count for followed-thread activity.
  * Muted rooms and threads outside the active subscriptions page are excluded.

* **Bug Fixes**
  * Cross-site thread activity is resolved where available, with graceful handling when lookup services fail.

* **Documentation**
  * Updated client API documentation to describe the new unread-counting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->