### PR TITLE
Exclude bots from room read-floor and read-receipt queries

### DIFF
--- a/docs/superpowers/specs/2026-07-16-bot-exclusion-read-floor-and-receipts-design.md
+++ b/docs/superpowers/specs/2026-07-16-bot-exclusion-read-floor-and-receipts-design.md
@@ -1,0 +1,172 @@
+# Exclude bots from the main-room read-floor & read receipts — design
+
+**Date:** 2026-07-16
+**Branch:** `claude/bot-user-distinction-ln46az`
+**Status:** Approved (pending spec review)
+**Author:** co-authored with Claude
+
+## 1. Background
+
+The platform models bots as ordinary users. A distinction is already made — and
+is load-bearing — in two places:
+
+- **Member counts:** bot subscriptions increment `rooms.appCount`, never
+  `rooms.userCount` (`room-worker/store_mongo.go` `ReconcileMemberCounts` /
+  `ApplyMemberCountDelta`, keyed off the persisted `subscription.u.isBot` flag).
+- **Push notifications:** `EligibleForPush` short-circuits on `m.IsBot`
+  (`notification-worker/routing.go`).
+
+That distinction was **not** extended to read state. Two subscription queries in
+`room-service` treat bots as ordinary members:
+
+| # | Site | Function (`room-service/store_mongo.go`) |
+|---|------|------------------------------------------|
+| A | Room read-floor | `MinSubscriptionLastSeenByRoomID` (:1161) |
+| B | Room read receipts | `ListReadReceipts` (:1212) |
+
+**The read-floor.** `rooms.minUserLastSeenAt` is the room-wide "everyone has read
+up to here" watermark — the minimum `lastSeenAt` across the room's
+subscriptions, but only when **every** subscription has a real (post-zero)
+`lastSeenAt`; if any member has never read, the floor is `nil` ("not everyone is
+caught up"). `MinSubscriptionLastSeenByRoomID` computes it with a single index
+seek (first sub by ascending `lastSeenAt`); the existing docstring states
+outright: *"Bots are ordinary subscriptions and are counted: a botDM room (the
+bot never reads) therefore always resolves to nil."*
+
+**The bug.** A bot is a subscription with a `lastSeenAt`. A passive bot never
+issues `message.read`, so its `lastSeenAt` stays at the BSON zero date forever.
+Under the strict rule, one never-reading member forces the floor to `nil` — so
+**any room containing a passive bot reports "nobody is fully caught up"
+permanently**, even when every human has read everything. The floor never
+advances. (A bot that actively posts self-advances its own `lastSeenAt` via
+`broadcast-worker`'s `AdvanceSubscriptionLastSeen`, so the freeze is worst for
+listener bots, and total for botDMs.)
+
+**Read receipts.** `ListReadReceipts` filters only `roomId`, `lastSeenAt >=
+since`, and `u.account != sender`. There is no bot filter, so a bot that
+advanced its `lastSeenAt` (by posting) could surface as a "reader" of a message.
+
+## 2. Scope
+
+**In scope:** exclude bots from sites A and B in `room-service`, using the
+`subscription.u.isBot` flag that is already persisted and indexed.
+
+**Out of scope (explicitly not touched):**
+
+- **Threads (C/D).** `MinThreadSubscriptionLastSeenByThreadRoomID` and
+  `ListThreadReadReceipts` have the same gap, but `thread_subscriptions` stores
+  `userAccount`/`userId` flat with **no `isBot` field**. Covering threads
+  requires a schema addition + write-path stamping + a backfill migration, and
+  is deferred to its own spec.
+- Member-count and notification paths — already correct.
+- Any new client API surface: no `chat.user.*` handler registration,
+  request/response schema, error case, or event struct changes (see §6).
+
+## 3. The change
+
+Single predicate added to both queries:
+
+```
+"u.isBot": bson.M{"$ne": true}
+```
+
+`$ne: true` (not `isBot: false`) is deliberate: legacy subscription docs written
+before the `u.isBot` flag existed omit the field, and must count as **humans**.
+`$ne: true` matches missing/false/null; `isBot: false` would wrongly drop
+flagless legacy humans. This mirrors how `ReconcileMemberCounts` already derives
+the human count by subtraction rather than an equality match.
+
+### 3.1 Component A — `MinSubscriptionLastSeenByRoomID`
+
+Filter changes from `{roomId}` to `{roomId, "u.isBot": {"$ne": true}}`. The
+existing single-seek logic is otherwise unchanged: sort `lastSeenAt` ascending,
+inspect the first (now first *non-bot*) document.
+
+- **botDM behavior change (intended).** A botDM (1 human + 1 bot) previously
+  always resolved to `nil`; it now resolves to the human's `lastSeenAt`. This is
+  the correct direction and the whole point of the change.
+- **Bot-only room.** No non-bot subs → `ErrNoDocuments` → `nil` (harmless,
+  correct — there is no human read position to report).
+- The docstring's "Bots are ordinary subscriptions and are counted" paragraph is
+  corrected to describe the exclusion.
+
+### 3.2 Component B — `ListReadReceipts`
+
+`"u.isBot": {"$ne": true}` is added to the `$match` stage. A bot never appears in
+a read-receipt list even if it self-advanced its `lastSeenAt`.
+
+### 3.3 Propagation (no wiring changes)
+
+The floor's only write path is the `messageRead` handler
+(`room-service/handler.go:1262`): `UpdateSubscriptionRead` →
+`MinSubscriptionLastSeenByRoomID` (:1352) → `UpdateRoomMinUserLastSeenAt`
+(:1362). Fixing the store method flows straight into `rooms.minUserLastSeenAt`
+at the single choke point. The user-service subscription-list `$lookup` reads
+that stored field and inherits the fix for free. No handler, model, or
+cross-service change is required.
+
+## 4. Indexing
+
+Keep the existing `{roomId, lastSeenAt}` index; apply `u.isBot $ne true` as a
+residual filter. Rationale:
+
+- A `$ne` predicate does not produce tight index bounds, so a compound
+  `{roomId, u.isBot, lastSeenAt}` would force a `SORT_MERGE` of the two isBot
+  ranges rather than the clean single seek we have today — no win.
+- Rooms carry very few bots. Never-read bots (zero `lastSeenAt`) sort first, so
+  the seek may fetch those leading bot docs before reaching the first human —
+  bounded by the room's bot count (typically 0–few), negligible on the
+  message-read hot path.
+
+Honest tradeoff, documented in the code: adding the residual filter means the
+query is no longer strictly index-covered (the planner must fetch candidate docs
+to evaluate `u.isBot`). Accepted; no new index is introduced.
+
+## 5. Testing (TDD: Red → Green → Refactor)
+
+All coverage is integration-level (these are Mongo queries); the `messageRead`
+handler unit tests mock the store and are unaffected by the predicate.
+
+**A — extend `TestMongoStore_MinSubscriptionLastSeenByRoomID_Integration`
+(`integration_test.go:2003`):**
+
+- **RED (new):** humans all-read + a passive bot (`isBot:true`, zero
+  `lastSeenAt`) → floor = human minimum, **not** `nil`. (Fails pre-change.)
+- **Update `"botdm"` case (:2081):** was `nil`; now the human's `lastSeenAt`.
+- Bot with a `lastSeenAt` **later** than all humans → floor still = human
+  minimum (bot excluded from the min).
+- Bot-only room → `nil`.
+- Legacy human sub missing `u.isBot` still counts (guards the `$ne: true`
+  choice).
+
+**B — extend `TestMongoStore_ListReadReceipts_Integration`:**
+
+- A bot whose `lastSeenAt >= message time` is **excluded** from the receipt
+  list; humans past the message remain included.
+
+Coverage stays at or above the 80% floor for `room-service`; both changed
+methods keep meaningful error/edge coverage.
+
+## 6. Docs
+
+- **`docs/client-api.md`:** no schema, error, or event change — the
+  `minUserLastSeenAt` field and the read-receipt response shape are identical.
+  Only the computed semantics change. If the field's prose description warrants
+  a one-line "bots excluded" clarification it will be added, but no structural
+  edit is required, and no derived-view (`request-reply.md` / `events.md`) update
+  is triggered.
+- **Code docstrings:** update `MinSubscriptionLastSeenByRoomID` and
+  `ListReadReceipts` to state that bots are excluded (the former's current text
+  says the opposite and must be corrected).
+
+## 7. Rollout / risk
+
+- **Backward compatible.** No schema or wire change; the `u.isBot` flag already
+  exists in production and is stamped at sub-creation.
+- **Behavior shift:** rooms with a passive bot begin advancing
+  `minUserLastSeenAt` (previously pinned at `nil`), and botDM floors start
+  tracking the human. This is the intended fix; clients already handle both a
+  present and an absent floor.
+- **Self-correcting:** the floor is recomputed on every `message.read`, so the
+  corrected value lands on the next read in each affected room with no migration
+  or backfill.

--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -2068,8 +2068,8 @@ func TestMongoStore_MinSubscriptionLastSeenByRoomID_Integration(t *testing.T) {
 	assert.Nil(t, got)
 
 	// Room "botdm": a human who has read plus a bot that never reads. Bots are
-	// not special-cased — the bot counts as an unread member, so a botDM room
-	// always resolves to nil even though the human is fully caught up.
+	// excluded from the floor, so the room resolves to the human's lastSeenAt
+	// even though the bot has no read position.
 	mustInsertSub(t, db, &model.Subscription{
 		ID: "s8", User: model.SubscriptionUser{ID: "u8", Account: "heidi"},
 		RoomID: "botdm", JoinedAt: earliest, LastSeenAt: &latest,
@@ -2079,6 +2079,56 @@ func TestMongoStore_MinSubscriptionLastSeenByRoomID_Integration(t *testing.T) {
 		RoomID: "botdm", JoinedAt: earliest,
 	})
 	got, err = store.MinSubscriptionLastSeenByRoomID(ctx, "botdm")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.WithinDuration(t, latest, *got, time.Second)
+
+	// Room "passive-bot": every human has read, but a bot member has never read.
+	// The bot must not freeze the floor at nil — the floor is the human MIN.
+	mustInsertSub(t, db, &model.Subscription{
+		ID: "s10", User: model.SubscriptionUser{ID: "u10", Account: "ivan"},
+		RoomID: "passive-bot", JoinedAt: earliest, LastSeenAt: &mid,
+	})
+	mustInsertSub(t, db, &model.Subscription{
+		ID: "s11", User: model.SubscriptionUser{ID: "u11", Account: "judy"},
+		RoomID: "passive-bot", JoinedAt: earliest, LastSeenAt: &latest,
+	})
+	mustInsertSub(t, db, &model.Subscription{
+		ID: "s12", User: model.SubscriptionUser{ID: "bot2", Account: "helper.bot", IsBot: true},
+		RoomID: "passive-bot", JoinedAt: earliest,
+	})
+	got, err = store.MinSubscriptionLastSeenByRoomID(ctx, "passive-bot")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.WithinDuration(t, mid, *got, time.Second)
+
+	// Room "bot-earlier": a bot has read EARLIER than every human. If bots were
+	// counted the floor would be the bot's (earliest) time; excluded, the floor
+	// is the human MIN (mid).
+	mustInsertSub(t, db, &model.Subscription{
+		ID: "s13", User: model.SubscriptionUser{ID: "u13", Account: "ken"},
+		RoomID: "bot-earlier", JoinedAt: earliest, LastSeenAt: &mid,
+	})
+	mustInsertSub(t, db, &model.Subscription{
+		ID: "s14", User: model.SubscriptionUser{ID: "u14", Account: "laura"},
+		RoomID: "bot-earlier", JoinedAt: earliest, LastSeenAt: &latest,
+	})
+	mustInsertSub(t, db, &model.Subscription{
+		ID: "s15", User: model.SubscriptionUser{ID: "bot3", Account: "early.bot", IsBot: true},
+		RoomID: "bot-earlier", JoinedAt: earliest, LastSeenAt: &earliest,
+	})
+	got, err = store.MinSubscriptionLastSeenByRoomID(ctx, "bot-earlier")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.WithinDuration(t, mid, *got, time.Second)
+
+	// Room "bot-only": no human members. With bots excluded there are no
+	// countable subs → nil, even though the bot itself has read.
+	mustInsertSub(t, db, &model.Subscription{
+		ID: "s16", User: model.SubscriptionUser{ID: "bot4", Account: "solo.bot", IsBot: true},
+		RoomID: "bot-only", JoinedAt: earliest, LastSeenAt: &mid,
+	})
+	got, err = store.MinSubscriptionLastSeenByRoomID(ctx, "bot-only")
 	require.NoError(t, err)
 	assert.Nil(t, got)
 
@@ -2230,6 +2280,7 @@ func TestMongoStore_ListReadReceipts_Integration(t *testing.T) {
 		bson.M{"_id": "uA", "account": "alice", "chineseName": "愛麗絲", "engName": "Alice"},
 		bson.M{"_id": "uB", "account": "bob", "chineseName": "鮑勃", "engName": "Bob"},
 		bson.M{"_id": "uC", "account": "carol", "chineseName": "卡羅", "engName": "Carol"},
+		bson.M{"_id": "uD", "account": "dave.bot", "chineseName": "戴夫", "engName": "Dave"},
 	})
 	require.NoError(t, err)
 
@@ -2238,9 +2289,13 @@ func TestMongoStore_ListReadReceipts_Integration(t *testing.T) {
 		bson.M{"_id": "sA", "roomId": "r1", "u": bson.M{"_id": "uA", "account": "alice"}, "lastSeenAt": msgTime.Add(time.Hour)},
 		bson.M{"_id": "sB", "roomId": "r1", "u": bson.M{"_id": "uB", "account": "bob"}, "lastSeenAt": msgTime.Add(time.Minute)},
 		bson.M{"_id": "sC", "roomId": "r1", "u": bson.M{"_id": "uC", "account": "carol"}, "lastSeenAt": msgTime.Add(-time.Minute)},
+		// A bot that has read well past the message must never appear as a reader.
+		bson.M{"_id": "sD", "roomId": "r1", "u": bson.M{"_id": "uD", "account": "dave.bot", "isBot": true}, "lastSeenAt": msgTime.Add(30 * time.Minute)},
 	})
 	require.NoError(t, err)
 
+	// Only bob qualifies: alice is the sender, carol read before the message, and
+	// dave.bot is a bot (excluded despite having read after the message).
 	rows, err := store.ListReadReceipts(ctx, "r1", msgTime, "alice", 100)
 	require.NoError(t, err)
 	require.Len(t, rows, 1)

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -1150,16 +1150,17 @@ func (s *MongoStore) GetUserSiteID(ctx context.Context, account string) (string,
 }
 
 // MinSubscriptionLastSeenByRoomID returns the room's strict read floor: the
-// minimum lastSeenAt across ALL of the room's subscriptions, but only when
-// EVERY subscription has a usable lastSeenAt (> zero). If any subscription has
+// minimum lastSeenAt across all of the room's non-bot subscriptions, but only
+// when EVERY such subscription has a usable lastSeenAt (> zero). If any has
 // no usable lastSeenAt — missing, null, or the BSON zero date, i.e. a member
 // who was invited but has never opened the room — it returns nil, meaning "not
 // everyone has read yet". It also returns nil for a room with no subscriptions.
-// Bots are ordinary subscriptions and are counted: a botDM room (the bot never
-// reads) therefore always resolves to nil. The caller $unsets
-// rooms.minUserLastSeenAt on a nil result.
+// Bots (u.isBot) are excluded: a passive bot never freezes the floor, and a
+// botDM resolves to the human's lastSeenAt. A room with only bot subscriptions
+// therefore resolves to nil. The caller $unsets rooms.minUserLastSeenAt on a
+// nil result.
 func (s *MongoStore) MinSubscriptionLastSeenByRoomID(ctx context.Context, roomID string) (*time.Time, error) {
-	// The whole result is determined by a single document: the room's
+	// The whole result is determined by a single document: the room's non-bot
 	// subscription with the smallest lastSeenAt. The (roomId, lastSeenAt) index
 	// (non-sparse, so missing fields are indexed as null) returns the room's
 	// subscriptions in ascending lastSeenAt order, and BSON sorts missing/null
@@ -1169,13 +1170,16 @@ func (s *MongoStore) MinSubscriptionLastSeenByRoomID(ctx context.Context, roomID
 	//     read → strict floor is nil ("not everyone has read yet");
 	//   - smallest value is a real post-zero date → every member has read and
 	//     that value IS the minimum → the floor.
-	// This replaces the prior full-room $group scan with a single (covered)
-	// index seek, which matters because this runs on the message-read hot path.
+	// The (roomId, lastSeenAt) index still serves the sort; the u.isBot != true
+	// predicate is applied as a residual filter (bots are few per room, and
+	// $ne yields no tight index bound), so this stays a bounded index seek on the
+	// message-read hot path rather than the prior full-room $group scan. $ne:true
+	// (not isBot:false) keeps legacy subs missing the flag counted as humans.
 	var doc struct {
 		LastSeenAt time.Time `bson:"lastSeenAt"`
 	}
 	err := s.subscriptions.FindOne(ctx,
-		bson.M{"roomId": roomID},
+		bson.M{"roomId": roomID, "u.isBot": bson.M{"$ne": true}},
 		options.FindOne().
 			SetSort(bson.D{{Key: "lastSeenAt", Value: 1}}).
 			SetProjection(bson.M{"lastSeenAt": 1, "_id": 0}),
@@ -1221,6 +1225,9 @@ func (s *MongoStore) ListReadReceipts(
 			"roomId":     roomID,
 			"lastSeenAt": bson.M{"$gte": since},
 			"u.account":  bson.M{"$ne": excludeAccount},
+			// Bots are never surfaced as readers ($ne:true keeps flagless legacy
+			// human subs counted).
+			"u.isBot": bson.M{"$ne": true},
 		}}},
 		{{Key: "$lookup", Value: bson.M{
 			"from": "users",


### PR DESCRIPTION
## Summary

Exclude bot subscriptions from the room-wide read-floor (`minUserLastSeenAt`) and read-receipt list calculations in `room-service`. Bots are already distinguished in member counts and push notifications; this extends that distinction to read state.

## Changes

- **`store_mongo.go`**: Add `"u.isBot": {"$ne": true}` filter to `MinSubscriptionLastSeenByRoomID` and `ListReadReceipts` queries
  - `$ne: true` (not `isBot: false`) preserves backward compatibility with legacy subscription docs that lack the `u.isBot` field, treating them as humans
  - Updated docstrings to reflect bot exclusion and correct prior documentation that stated bots were counted
  - Residual filter applied to existing `{roomId, lastSeenAt}` index; no new index added (bots are few per room, and `$ne` yields no tight index bounds)

- **`integration_test.go`**: Extend test coverage for both methods
  - `TestMongoStore_MinSubscriptionLastSeenByRoomID_Integration`: 
    - Update existing "botdm" case to expect human's `lastSeenAt` instead of `nil`
    - Add "passive-bot" case: multiple humans + never-reading bot → floor = human minimum
    - Add "bot-earlier" case: bot with earlier `lastSeenAt` than all humans → floor still = human minimum (bot excluded)
    - Add "bot-only" case: bot-only room → `nil` (no countable subscriptions)
  - `TestMongoStore_ListReadReceipts_Integration`:
    - Add bot user and subscription with `lastSeenAt` well past message time
    - Verify bot is excluded from receipt list despite having read after the message

- **`docs/superpowers/specs/2026-07-16-bot-exclusion-read-floor-and-receipts-design.md`** (new): Comprehensive design spec covering background, scope, implementation, indexing rationale, testing strategy, and rollout notes

## Implementation Details

- **Backward compatible**: No schema or wire-format change; `u.isBot` flag already exists in production
- **Self-correcting**: Floor is recomputed on every `message.read`, so corrected values land on next read in affected rooms with no migration
- **No wiring changes**: The floor's write path (`messageRead` handler → `UpdateSubscriptionRead` → `MinSubscriptionLastSeenByRoomID` → `UpdateRoomMinUserLastSeenAt`) flows the fix straight into `rooms.minUserLastSeenAt` at a single choke point; user-service subscription-list `$lookup` inherits the fix for free
- **Out of scope**: Thread read-floor and thread read-receipts deferred (require schema addition to `thread_subscriptions`)

https://claude.ai/code/session_01Lg7w9sovhKWgtki6B9LRm2