### PR TITLE
feat(message-worker): durable OUTBOX federation for thread subscriptions

### DIFF
--- a/docs/superpowers/plans/2026-07-17-message-worker-thread-subscription-outbox-durability.md
+++ b/docs/superpowers/plans/2026-07-17-message-worker-thread-subscription-outbox-durability.md
@@ -1,0 +1,534 @@
+# message-worker Thread-Subscription OUTBOX Durability — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route message-worker's cross-site `thread_subscription_upserted` event through the local OUTBOX stream so a destination-site outage delays-not-drops it within retention, matching the #410 membership-federation durability guarantee.
+
+**Architecture:** Add `thread_subscription_upserted` to the OUTBOX concurrent partition (`pkg/outbox.ConcurrentEventTypes`), then change message-worker's `publishThreadSubInboxIfRemote` from a direct `InboxExternal` publish to the shared `outbox.Publish(...)` onto the local OUTBOX. `outbox-worker`'s per-destination concurrent consumer forwards it to the destination INBOX with `MaxDeliver=-1` — no code change in `outbox-worker` or `inbox-worker`, since both are event-type-generic.
+
+**Tech Stack:** Go 1.25, NATS JetStream (`nats.go/jetstream`), `pkg/outbox`, `pkg/subject`, `pkg/model`, `go.uber.org/mock`, `stretchr/testify`, `testcontainers` (integration).
+
+## Global Constraints
+
+- Go 1.25; monorepo, single `go.mod` at root; services are flat `package main` at repo root.
+- Always use `make` targets, never raw `go`: `make test SERVICE=<name>`, `make test-integration SERVICE=<name>`, `make lint`, `make sast`.
+- TDD is mandatory: Red → Green → Refactor → Commit. Never write implementation before its failing test.
+- Minimum 80% coverage per package (target 90% for handlers).
+- All NATS payloads are typed structs from `pkg/model`, never `map[string]interface{}`.
+- Never log tokens/bodies; structured `slog` key-value fields only.
+- Error wrapping: `fmt.Errorf("short description: %w", err)`; never bare `err`.
+- Commit message trailer (every commit):
+  ```
+  Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01FNMS2LV1evxmEZTKXxvFKX
+  ```
+- Work on branch `claude/gatekeeper-attachments-type-90o2hy`. Do not open a PR unless explicitly asked.
+- No store-interface changes in this plan → `make generate` (mocks) is NOT required.
+- No client-facing handler change → `docs/client-api.md` is NOT touched.
+
+---
+
+### Task 1: Add `thread_subscription_upserted` to the OUTBOX concurrent partition
+
+**Files:**
+- Modify: `pkg/outbox/outbox.go` (`ConcurrentEventTypes`, package + var docs)
+- Test: `pkg/outbox/outbox_test.go` (retarget the rejection test; add a membership assertion)
+
+**Interfaces:**
+- Consumes: `model.InboxThreadSubscriptionUpserted` (existing constant = `"thread_subscription_upserted"`), `model.InboxUserStatusUpdated` (existing constant = `"user_status_updated"`, in neither partition set — used as the new "unrouted" example).
+- Produces: `outbox.ConcurrentEventTypes` now contains `model.InboxThreadSubscriptionUpserted`, so `outbox.Publish(..., model.InboxThreadSubscriptionUpserted, ...)` is accepted rather than rejected. Task 2 relies on this.
+
+- [ ] **Step 1: Update the rejection test to use a still-unrouted type, and assert the new type is now accepted+concurrent**
+
+In `pkg/outbox/outbox_test.go`, replace `TestPublish_RejectsEventTypeOutsideThePartition` (currently uses `model.InboxThreadSubscriptionUpserted` as the rejected example — that stops being rejected after this task) and add a membership test:
+
+```go
+func TestPublish_RejectsEventTypeOutsideThePartition(t *testing.T) {
+	// user_status_updated is in neither ConcurrentEventTypes nor OrderedEventTypes.
+	err := Publish(context.Background(), func(context.Context, string, []byte, string) error { return nil },
+		"site-a", "r1", "site-b", model.InboxUserStatusUpdated, []byte(`{}`), "d", 1)
+	require.Error(t, err,
+		"an event type with no outbox-worker filter would sit in the stream unconsumed — must fail fast at the publish site")
+	assert.Contains(t, err.Error(), "filter set")
+}
+
+func TestThreadSubscriptionUpsertedIsConcurrent(t *testing.T) {
+	assert.Contains(t, ConcurrentEventTypes, model.InboxThreadSubscriptionUpserted,
+		"message-worker federates thread_subscription_upserted; it is order-insensitive at the destination "+
+			"(inbox-worker upsert is $setOnInsert + $max hasMention) so it rides the concurrent lane")
+	assert.NotContains(t, OrderedEventTypes, model.InboxThreadSubscriptionUpserted)
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `make test SERVICE=outbox` — no; `pkg/outbox` is a package, run:
+```bash
+go test ./pkg/outbox/ -run 'TestPublish_RejectsEventTypeOutsideThePartition|TestThreadSubscriptionUpsertedIsConcurrent' -v
+```
+Expected: `TestThreadSubscriptionUpsertedIsConcurrent` FAILs (`ConcurrentEventTypes` does not yet contain the type). `TestPublish_RejectsEventTypeOutsideThePartition` PASSes already (user_status_updated is unrouted) — that's fine.
+
+- [ ] **Step 3: Add the type to `ConcurrentEventTypes` and update docs**
+
+In `pkg/outbox/outbox.go`, add the entry to the slice and refresh the two doc comments:
+
+```go
+// Package outbox is the cross-site federation relay contract shared by the
+// producers (room-service, room-worker, message-worker) and the consumer
+// (outbox-worker): which event types ride which OUTBOX consumer lane, and the
+// one way to publish a relay event onto the stream.
+package outbox
+```
+
+```go
+// ConcurrentEventTypes are the OUTBOX event types forwarded by outbox-worker's
+// shared concurrent consumer. They are order-insensitive at the destination
+// (inbox-worker applies them under high-water-mark / idempotent-upsert guards),
+// so parallel forwarding is safe.
+var ConcurrentEventTypes = []model.InboxEventType{
+	model.InboxRoleUpdated,
+	model.InboxSubscriptionRead,
+	model.InboxThreadRead,
+	model.InboxSubscriptionMuteToggled,
+	model.InboxSubscriptionFavoriteToggled,
+	model.InboxRoomRestricted,
+	// message-worker: thread-subscription federation. Order-insensitive —
+	// inbox-worker's UpsertThreadSubscription is $setOnInsert (immutable identity)
+	// + $max hasMention (monotonic), so out-of-order/duplicate applies converge.
+	model.InboxThreadSubscriptionUpserted,
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+go test ./pkg/outbox/ -v
+```
+Expected: PASS (including `TestEventTypeSetsAreDisjoint`, `TestThreadSubscriptionUpsertedIsConcurrent`, and the existing `Publish` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/outbox/outbox.go pkg/outbox/outbox_test.go
+git commit -m "feat(outbox): add thread_subscription_upserted to concurrent partition
+
+message-worker will federate thread subscriptions through the OUTBOX relay;
+route the event on the order-insensitive concurrent lane.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01FNMS2LV1evxmEZTKXxvFKX"
+```
+
+---
+
+### Task 2: Route message-worker thread-subscription federation through OUTBOX
+
+**Files:**
+- Modify: `message-worker/handler.go` (`publishThreadSubInboxIfRemote`, imports)
+- Test: `message-worker/handler_test.go` (add `unwrapOutbox` helper; retarget 5 decode sites + subject assertion)
+
+**Interfaces:**
+- Consumes: `outbox.Publish(ctx, publish func(ctx,string,[]byte,string) error, originSiteID, roomID, destSiteID string, eventType model.InboxEventType, payload []byte, dedupID string, ts int64) error` (from Task 1's accepted type); `subject.Outbox(origin, dest, eventType) string`; `model.OutboxEvent{RoomID string, Envelope json.RawMessage, DedupID string, Timestamp int64}`.
+- Produces: `publishThreadSubInboxIfRemote` now publishes an `OutboxEvent` (wrapping the `InboxEvent`) to `chat.outbox.{origin}.{dest}.thread_subscription_upserted` with the dedup ID as `Nats-Msg-Id`. Signature unchanged: `func (h *Handler) publishThreadSubInboxIfRemote(ctx context.Context, sub *model.ThreadSubscription, ownerSiteID, msgID string) error`.
+
+- [ ] **Step 1: Add the `unwrapOutbox` test helper**
+
+Append to `message-worker/handler_test.go` (near the other test helpers). `json` and `model` are already imported by this file.
+
+```go
+// unwrapOutbox decodes an OutboxEvent published on the OUTBOX relay and the
+// inner InboxEvent envelope it carries. Thread-subscription federation rides
+// the durable OUTBOX (chat.outbox.…), not a direct INBOX publish.
+func unwrapOutbox(t *testing.T, data []byte) (model.OutboxEvent, model.InboxEvent) {
+	t.Helper()
+	var relay model.OutboxEvent
+	require.NoError(t, json.Unmarshal(data, &relay))
+	var env model.InboxEvent
+	require.NoError(t, json.Unmarshal(relay.Envelope, &env))
+	return relay, env
+}
+```
+
+- [ ] **Step 2: Retarget the unit tests to expect the OUTBOX subject + envelope**
+
+In `message-worker/handler_test.go`, `TestHandler_PublishThreadSubInboxIfRemote`, "remote owner …" subtest — replace the subject assertion and the decode block (currently lines ~1364 and ~1389-1399):
+
+Replace:
+```go
+		assert.Equal(t, "chat.inbox.site-b.external.thread_subscription_upserted", captured.subj)
+```
+with:
+```go
+		assert.Equal(t, subject.Outbox("site-a", "site-b", model.InboxThreadSubscriptionUpserted), captured.subj)
+		// = "chat.outbox.site-a.site-b.thread_subscription_upserted"
+```
+
+Replace the `var outer model.InboxEvent … json.Unmarshal(captured.data, &outer) …` block through the inner `ThreadSubscription` assertion with:
+```go
+		// The captured data is an OutboxEvent wrapping the InboxEvent envelope.
+		relay, outer := unwrapOutbox(t, captured.data)
+		assert.Equal(t, "r1", relay.RoomID, "OutboxEvent.RoomID is the channel room ID")
+		assert.Equal(t, captured.msgID, relay.DedupID, "OutboxEvent.DedupID equals the publish Nats-Msg-Id")
+		assert.Equal(t, model.InboxThreadSubscriptionUpserted, outer.Type)
+		assert.Equal(t, "site-a", outer.SiteID)
+		assert.Equal(t, "site-b", outer.DestSiteID)
+		assert.Greater(t, outer.Timestamp, int64(0))
+
+		var inner model.ThreadSubscription
+		require.NoError(t, json.Unmarshal(outer.Payload, &inner))
+		assert.Equal(t, *baseSub, inner)
+		assert.Equal(t, "site-a", inner.SiteID, "inner SiteID stays as the room's site")
+```
+
+Now retarget the four remaining `var outer model.InboxEvent` decode sites of thread-sub publishes:
+
+**Site A — `TestHandler_FirstReply_InboxPublishes` loop** (currently ~1501-1504), replace:
+```go
+			for _, c := range calls {
+				var outer model.InboxEvent
+				require.NoError(t, json.Unmarshal(c.data, &outer))
+				assert.Equal(t, model.InboxThreadSubscriptionUpserted, outer.Type)
+				gotByDest[outer.DestSiteID]++
+			}
+```
+with:
+```go
+			for _, c := range calls {
+				_, outer := unwrapOutbox(t, c.data)
+				assert.Equal(t, model.InboxThreadSubscriptionUpserted, outer.Type)
+				gotByDest[outer.DestSiteID]++
+			}
+```
+
+**Sites B & C — inside publish closures** (currently ~1635-1641 and ~1771-1777). Both closures return `error`, so decode the two layers inline (identical code at both sites). Replace each:
+```go
+				var outer model.InboxEvent
+				if err := json.Unmarshal(data, &outer); err != nil {
+					return err
+				}
+				publishedDests = append(publishedDests, outer.DestSiteID)
+				return nil
+```
+with:
+```go
+				var relay model.OutboxEvent
+				if err := json.Unmarshal(data, &relay); err != nil {
+					return err
+				}
+				var outer model.InboxEvent
+				if err := json.Unmarshal(relay.Envelope, &outer); err != nil {
+					return err
+				}
+				publishedDests = append(publishedDests, outer.DestSiteID)
+				return nil
+```
+
+**Site D — mention-carrying single decode** (currently ~1845-1848), replace:
+```go
+	var outer model.InboxEvent
+	require.NoError(t, json.Unmarshal(captured, &outer))
+	var sub model.ThreadSubscription
+	require.NoError(t, json.Unmarshal(outer.Payload, &sub))
+```
+with:
+```go
+	_, outer := unwrapOutbox(t, captured)
+	var sub model.ThreadSubscription
+	require.NoError(t, json.Unmarshal(outer.Payload, &sub))
+```
+
+- [ ] **Step 3: Run the message-worker tests to verify they fail**
+
+Run:
+```bash
+make test SERVICE=message-worker
+```
+Expected: FAIL — the handler still publishes to `chat.inbox.…` with a bare `InboxEvent`, so `unwrapOutbox` (expecting an `OutboxEvent` with a non-empty `Envelope`) and the new subject assertion fail.
+
+- [ ] **Step 4: Rewrite `publishThreadSubInboxIfRemote` to publish via OUTBOX**
+
+In `message-worker/handler.go`, add the import (keep the block goimports-sorted):
+```go
+	"github.com/hmchangw/chat/pkg/outbox"
+```
+
+Replace the whole `publishThreadSubInboxIfRemote` function (doc comment + body) with:
+
+```go
+// publishThreadSubInboxIfRemote federates a thread_subscription_upserted event
+// to ownerSiteID when that site differs from the local site, via the durable
+// OUTBOX relay (outbox-worker forwards it to the destination INBOX with
+// retry-forever, so a destination outage delays — never drops — the event
+// within retention). Same-site is a no-op; empty ownerSiteID is a no-op that
+// logs a warning (caller bug). ownerSiteID is the subscription owner's home
+// site — NOT sub.SiteID, which is the room's home site.
+func (h *Handler) publishThreadSubInboxIfRemote(ctx context.Context, sub *model.ThreadSubscription, ownerSiteID, msgID string) error {
+	if ownerSiteID == "" {
+		slog.WarnContext(ctx, "owner siteID empty, skipping outbox publish",
+			"threadRoomID", sub.ThreadRoomID, "user_id", sub.UserID, "msgID", msgID,
+			"request_id", natsutil.RequestIDFromContext(ctx))
+		return nil
+	}
+	// outbox.Publish also no-ops a local destination, but short-circuit here so the
+	// marshal below is skipped on the common same-site path.
+	if ownerSiteID == h.siteID {
+		return nil
+	}
+
+	payload, err := sonic.Marshal(sub)
+	if err != nil {
+		return fmt.Errorf("marshal thread subscription: %w", err)
+	}
+	// Dedup-ID seed (threadRoomID + userID + msg.ID + hasMention + destSiteID):
+	// msg.ID is stable across MESSAGES_CANONICAL redeliveries so the same publish
+	// yields the same ID; different users on the same destination differ via userID;
+	// hasMention is in the seed so a HasMention=false upsert and a later
+	// HasMention=true update get distinct dedup IDs (else stream-level dedup would
+	// swallow the mention update). It rides the OUTBOX publish as its Nats-Msg-Id
+	// AND the forward's Nats-Msg-Id at the destination.
+	dedupID := fmt.Sprintf("thread-sub-inbox:%s:%s:%s:%t:%s", sub.ThreadRoomID, sub.UserID, msgID, sub.HasMention, ownerSiteID)
+	if err := outbox.Publish(ctx, h.publish, h.siteID, sub.RoomID, ownerSiteID,
+		model.InboxThreadSubscriptionUpserted, payload, dedupID, time.Now().UTC().UnixMilli()); err != nil {
+		return fmt.Errorf("publish thread subscription outbox to %s: %w", ownerSiteID, err)
+	}
+	return nil
+}
+```
+
+Note: `subject` is still imported/used by `publishThreadReplyEvent` (`subject.ServerBroadcastThreadTCount`); `sonic`, `time`, `fmt`, `slog`, `natsutil` all remain used. `subject.InboxExternal` is no longer referenced from this function — confirm no other `handler.go` use remains (Step 5 grep).
+
+- [ ] **Step 5: Verify no dangling `InboxExternal` reference and imports are clean**
+
+Run:
+```bash
+grep -n "InboxExternal" message-worker/handler.go || echo "no InboxExternal in handler.go — good"
+```
+Expected: `no InboxExternal in handler.go — good`.
+
+- [ ] **Step 6: Run the message-worker tests to verify they pass**
+
+Run:
+```bash
+make test SERVICE=message-worker
+```
+Expected: PASS (all subtests, including same-site no-publish, empty-owner warn, dedup determinism, HasMention flip, first/subsequent-reply dest counts, and the NAK-on-publish-error path — the error still propagates because `outbox.Publish` returns the publish closure's error).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add message-worker/handler.go message-worker/handler_test.go
+git commit -m "feat(message-worker): federate thread subscriptions via OUTBOX
+
+Replace the direct InboxExternal publish in publishThreadSubInboxIfRemote
+with the durable outbox.Publish relay, so a destination-site outage delays
+(MaxDeliver=-1) rather than drops the cross-site thread subscription —
+matching #410 membership federation durability. Envelope bytes and dedup
+ID are unchanged; the event rides the order-insensitive concurrent lane.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01FNMS2LV1evxmEZTKXxvFKX"
+```
+
+---
+
+### Task 3: Integration test — thread_subscription_upserted forwarded via the concurrent lane
+
+**Files:**
+- Test: `outbox-worker/integration_test.go` (add one round-trip test with the new type)
+
+**Interfaces:**
+- Consumes: existing test helpers in the package — `startEmbeddedJetStreamNATS(t)`, `createStream(t, js, cfg)`, `buildConcurrentConsumerConfig(settings, siteID, destSiteID)`, `NewHandler(jsPublish(js))`, `stream.Outbox(siteID)`, `stream.Inbox(destSiteID)`, `subject.Outbox(...)`, `subject.InboxExternal(...)`.
+- Produces: end-to-end proof that adding `thread_subscription_upserted` to `ConcurrentEventTypes` makes `buildConcurrentConsumerConfig`'s FilterSubjects include it, so outbox-worker consumes and forwards it.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `outbox-worker/integration_test.go`, modeled on `TestIntegration_OutboxRoundTrip`:
+
+```go
+// TestIntegration_ThreadSubscriptionUpsertedForwardedViaConcurrentLane proves the
+// message-worker durability fix end-to-end: a thread_subscription_upserted relay
+// event on the OUTBOX is consumed by the per-destination concurrent consumer
+// (whose FilterSubjects derive from outbox.ConcurrentEventTypes) and forwarded to
+// the destination INBOX verbatim.
+func TestIntegration_ThreadSubscriptionUpsertedForwardedViaConcurrentLane(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		siteID     = "site-ts-origin"
+		destSiteID = "site-ts-dest"
+		roomID     = "room-ts-roundtrip"
+	)
+
+	nc := startEmbeddedJetStreamNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	outboxCfg := stream.Outbox(siteID)
+	createStream(t, js, outboxCfg)
+	createStream(t, js, stream.Inbox(destSiteID))
+
+	destSubject := subject.InboxExternal(destSiteID, model.InboxThreadSubscriptionUpserted)
+	type received struct {
+		subject string
+		data    []byte
+	}
+	var mu sync.Mutex
+	var forwarded []received
+	sub, err := nc.Subscribe(destSubject, func(msg *nats.Msg) {
+		mu.Lock()
+		forwarded = append(forwarded, received{subject: msg.Subject, data: append([]byte(nil), msg.Data...)})
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+	require.NoError(t, nc.Flush())
+
+	h := NewHandler(jsPublish(js))
+
+	innerPayload := []byte(`{"id":"sub-1","threadRoomId":"tr-1","userId":"u-bob","userAccount":"bob","roomId":"room-ts-roundtrip","siteId":"site-ts-origin","hasMention":false}`)
+	envelope, err := json.Marshal(model.InboxEvent{
+		Type:       model.InboxThreadSubscriptionUpserted,
+		SiteID:     siteID,
+		DestSiteID: destSiteID,
+		Payload:    innerPayload,
+		Timestamp:  time.Now().UTC().UnixMilli(),
+	})
+	require.NoError(t, err)
+
+	const dedupID = "thread-sub-inbox:tr-1:u-bob:msg-1:false:site-ts-dest"
+	relayEvt, err := json.Marshal(model.OutboxEvent{
+		RoomID:    roomID,
+		Envelope:  envelope,
+		DedupID:   dedupID,
+		Timestamp: time.Now().UTC().UnixMilli(),
+	})
+	require.NoError(t, err)
+
+	cons, err := js.CreateOrUpdateConsumer(ctx, outboxCfg.Name, buildConcurrentConsumerConfig(stream.ConsumerSettings{
+		AckWait: 30 * time.Second, MaxDeliver: 5, MaxWaiting: 512, MaxAckPending: 1000,
+	}, siteID, destSiteID))
+	require.NoError(t, err)
+
+	cc, err := cons.Consume(func(msg jetstream.Msg) {
+		if err := h.HandleEvent(ctx, msg.Subject(), msg.Data()); err != nil {
+			t.Errorf("HandleEvent: %v", err)
+		}
+		_ = msg.Ack()
+	})
+	require.NoError(t, err)
+	t.Cleanup(cc.Stop)
+
+	_, err = js.Publish(ctx, subject.Outbox(siteID, destSiteID, model.InboxThreadSubscriptionUpserted), relayEvt)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(forwarded) >= 1
+	}, 5*time.Second, 20*time.Millisecond, "expected one forwarded INBOX publish on the destination subject")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, forwarded, 1, "exactly one forward per target")
+	assert.Equal(t, destSubject, forwarded[0].subject)
+	assert.Equal(t, envelope, forwarded[0].data,
+		"forwarded bytes must equal the target's pre-marshaled Envelope verbatim")
+}
+```
+
+- [ ] **Step 2: Run the integration test to verify it passes (Docker required)**
+
+Run:
+```bash
+make test-integration SERVICE=outbox-worker
+```
+Expected: PASS, including the new `TestIntegration_ThreadSubscriptionUpsertedForwardedViaConcurrentLane`. (If run before Task 1's set change, the concurrent consumer would have no filter for the type and the forward would never arrive → `Eventually` times out; with Task 1 applied it passes.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add outbox-worker/integration_test.go
+git commit -m "test(outbox-worker): forward thread_subscription_upserted via concurrent lane
+
+End-to-end coverage that the new concurrent-partition type is consumed by the
+per-destination concurrent consumer and forwarded to the destination INBOX.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01FNMS2LV1evxmEZTKXxvFKX"
+```
+
+---
+
+### Task 4: Full verification
+
+**Files:** none (verification only; commit any fixups the tools require).
+
+- [ ] **Step 1: Lint**
+
+Run:
+```bash
+make lint
+```
+Expected: no findings. If goimports reorders the new `pkg/outbox` import in `message-worker/handler.go`, run `make fmt` and re-lint.
+
+- [ ] **Step 2: Unit tests (changed packages + full suite)**
+
+Run:
+```bash
+go test ./pkg/outbox/ -race
+make test SERVICE=message-worker
+make test
+```
+Expected: all PASS.
+
+- [ ] **Step 3: Coverage floor on changed packages**
+
+Run:
+```bash
+go test ./pkg/outbox/ -coverprofile=/tmp/cov-outbox.out && go tool cover -func=/tmp/cov-outbox.out | tail -1
+go test ./message-worker/ -coverprofile=/tmp/cov-mw.out && go tool cover -func=/tmp/cov-mw.out | tail -1
+```
+Expected: both ≥ 80% (message-worker handler path should stay ≥ 90%). If `publishThreadSubInboxIfRemote` branches are under-covered, the Task 2 subtests already cover same-site / empty-owner / remote / error — confirm none were dropped.
+
+- [ ] **Step 4: Integration (outbox-worker)**
+
+Run:
+```bash
+make test-integration SERVICE=outbox-worker
+```
+Expected: PASS.
+
+- [ ] **Step 5: SAST**
+
+Run:
+```bash
+make sast
+```
+Expected: no medium+ findings introduced (this change adds no new unsafe conversions, TLS, or exec).
+
+- [ ] **Step 6: Push the branch**
+
+```bash
+git push -u origin claude/gatekeeper-attachments-type-90o2hy
+```
+(Do NOT open a PR unless explicitly asked.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Spec §3.1 (concurrent lane) → Task 1 (`TestThreadSubscriptionUpsertedIsConcurrent`, doc rationale).
+- Spec §3.2 (producer reuses `outbox.Publish`, preserved payload/dedup/guards) → Task 2 (rewrite + retargeted unit tests).
+- Spec §3.3 (outbox-worker no change) → Task 3 verifies forwarding with zero outbox-worker prod change.
+- Spec §3.4 (inbox-worker no change) → no task needed; Task 3 exercises the destination path unchanged.
+- Spec §3.5 (contract bookkeeping) → Task 1 Step 3 (set + package/var docs).
+- Spec §4/§5 (durability + failure-path improvement) → behavioral, covered by Task 2's error-path test (`NAK`) + Task 3's forward test.
+- Spec §6 (testing) → Tasks 1–3 unit + integration; Task 4 coverage floor.
+- Spec §7 (out-of-scope: reconciliation, client-api docs) → none; asserted in Global Constraints.
+- Spec §8 (files touched) → matches Tasks 1–3 exactly; `main.go`/`bootstrap.go`/`outbox-worker`/`inbox-worker` prod code untouched.
+
+**Placeholder scan:** none — every code and command step is concrete.
+
+**Type consistency:** `outbox.Publish` arg order matches `pkg/outbox/outbox.go` (`ctx, publish, originSiteID, roomID, destSiteID, eventType, payload, dedupID, ts`); `model.OutboxEvent` fields (`RoomID`, `Envelope`, `DedupID`, `Timestamp`) and `model.InboxEvent` fields (`Type`, `SiteID`, `DestSiteID`, `Payload`, `Timestamp`) match `pkg/model/event.go`; `unwrapOutbox` returns `(model.OutboxEvent, model.InboxEvent)` and is used consistently; dedup seed string is byte-identical to the pre-change formula.

--- a/docs/superpowers/specs/2026-07-17-message-worker-thread-subscription-outbox-durability-design.md
+++ b/docs/superpowers/specs/2026-07-17-message-worker-thread-subscription-outbox-durability-design.md
@@ -1,0 +1,194 @@
+# message-worker Thread-Subscription Federation Durability — Adopt OUTBOX
+
+**Status:** Design — approved, not yet implemented.
+**Date:** 2026-07-17
+**Related:** `docs/design/2026-07-05-membership-federation-durability.md` (PR #410, the OUTBOX relay this extends), `pkg/outbox`, `outbox-worker`, `inbox-worker`.
+
+## 1. Problem
+
+`message-worker` federates **thread subscriptions** cross-site: when a thread reply
+involves a participant (the parent-message author or the replier) whose home site
+differs from the local site, it must tell that remote site to create/update the
+user's `ThreadSubscription` so the thread surfaces in their thread list and badge
+feed.
+
+Today `message-worker` does this with a **direct `InboxExternal` publish** to the
+remote site's INBOX (`publishThreadSubInboxIfRemote` → `subject.InboxExternal`,
+`message-worker/handler.go`), riding the MESSAGES_CANONICAL consumer's default
+`MaxDeliver=5`. This is **structurally the pre-#410 room-worker failure mode**: on
+a destination outage longer than ~5 redeliveries, the cross-site event is **dropped**
+— the local thread-subscription write already committed, so local and remote silently
+diverge with no repair.
+
+PR #410 fixed exactly this class of loss for **membership** and room-service's
+subscription-state events by routing them through a local **OUTBOX** stream that
+`outbox-worker` forwards to the destination INBOX with retry-forever
+(`MaxDeliver=-1`). `thread_subscription_upserted` was **out of scope** for #410 —
+it is in neither `outbox.ConcurrentEventTypes` nor `outbox.OrderedEventTypes`, so
+it never got the durability upgrade.
+
+**Goal:** give `message-worker`'s cross-site `thread_subscription_upserted` the same
+**delay-not-drop within retention** guarantee membership has today — a destination
+down for an hour (or a day, up to OUTBOX `MaxAge`) delays the event, never loses it.
+
+## 2. Scope
+
+**In scope:** route `thread_subscription_upserted` through the local OUTBOX so
+`outbox-worker` forwards it durably. Durability **parity with #410 as shipped**.
+
+**Explicitly out of scope (unchanged from #410's own state):**
+- **Reconciliation / anti-entropy** (beyond-retention re-derivation). §3.4 of the
+  membership design is itself unbuilt; this change does not add it for thread subs.
+  The guarantee is delay-not-drop *within* `MaxAge`, not unconditional.
+- The **thread-reply badge event** (`publishThreadReplyEvent` →
+  `chat.server.broadcast.{siteID}.thread.tcount`). It is a same-site, best-effort,
+  core-NATS badge update — deliberately not durable, and not federated. Untouched.
+- Any change to `inbox-worker` apply semantics or `outbox-worker` consumer topology.
+
+## 3. Decision: concurrent lane, reuse `outbox.Publish`
+
+### 3.1 Lane placement — concurrent (order-insensitive)
+
+`thread_subscription_upserted` joins `outbox.ConcurrentEventTypes`, **not** the FIFO
+`OrderedEventTypes` lane. Justification — the destination apply is genuinely
+order-insensitive: `inbox-worker.UpsertThreadSubscription` is
+
+- `$setOnInsert` for the immutable identity fields (`_id`, ids, `createdAt`,
+  `lastSeenAt`) — commutative; first writer wins and the values are identical across
+  events for the same `(threadRoomId, userAccount)`,
+- `$max hasMention` — monotonic; a `true` can never be regressed to `false`
+  regardless of arrival order,
+- `$set updatedAt` — a cosmetic last-write timestamp with no correctness meaning.
+
+This is also **exactly the ordering behavior the event has today** (direct
+`InboxExternal` publish is unordered/concurrent), so riding the concurrent OUTBOX
+lane is **not a regression** — it is the same delivery semantics with durable retry
+added.
+
+### 3.2 Producer — `message-worker` reuses `outbox.Publish`
+
+`publishThreadSubInboxIfRemote` stops building the `InboxEvent` envelope and
+publishing to `subject.InboxExternal`. Instead it calls the shared
+`outbox.Publish(ctx, h.publish, h.siteID, roomID, destSiteID, eventType, payload,
+dedupID, ts)`, which builds the byte-identical `InboxEvent` envelope, wraps it in an
+`OutboxEvent`, and publishes to the **local** OUTBOX at
+`chat.outbox.{origin}.{dest}.thread_subscription_upserted`.
+
+`message-worker` already holds the exact `publish` closure `outbox.Publish` needs
+(`func(ctx, subj, data, msgID)` — JetStream publish with `Nats-Msg-Id` when `msgID`
+is non-empty, core NATS otherwise), the same one `room-worker` passes to its
+`federate` helper. No new wiring in `main.go`.
+
+**Preserved unchanged:**
+- **Inner payload:** `sonic.Marshal(sub)` of the `ThreadSubscription`. `ThreadSubscription`
+  has no map fields, so sonic output is semantically equivalent to `encoding/json`,
+  and `inbox-worker` decodes it with `json.Unmarshal` regardless. The envelope itself
+  is built by `outbox.Publish` with `encoding/json` — identical to the OUTBOX
+  envelopes room-worker/room-service already send and `inbox-worker` already decodes,
+  so the sonic→shared-path switch is inherently wire-compatible.
+- **Dedup ID:** the existing seed
+  `thread-sub-inbox:{threadRoomID}:{userID}:{msgID}:{hasMention}:{destSiteID}` stays.
+  `outbox.Publish` uses it as the OUTBOX publish's `Nats-Msg-Id` (a MESSAGES_CANONICAL
+  redelivery can't double-enqueue) **and** as the forward's `Nats-Msg-Id` at the
+  destination (idempotent apply). `hasMention` stays in the seed so a
+  `HasMention=false` upsert and a later `HasMention=true` update get distinct dedup
+  IDs — otherwise stream-level dedup would swallow the mention update.
+- **Guards:** the empty-`ownerSiteID` warning (caller-bug signal) stays in
+  `message-worker` before the call. `outbox.Publish` independently no-ops on a blank
+  or local destination, so the same-site short-circuit is retained too. The
+  `isMigration` skip and the per-participant call sites (first reply, subsequent
+  reply, parent-not-found) are unchanged — only the publish primitive changes.
+
+### 3.3 Transport — `outbox-worker` (no change)
+
+`outbox-worker`'s per-destination **concurrent** consumer
+(`outbox-worker-concurrent-{dest}`, `MaxDeliver=-1`) already forwards every type in
+`outbox.ConcurrentEventTypes` by filter subject. Adding
+`thread_subscription_upserted` to that set is picked up automatically — **no code
+change in `outbox-worker`**. A down peer stalls only its own per-destination lane;
+healthy peers keep flowing.
+
+### 3.4 Destination — `inbox-worker` (no change)
+
+`handleThreadSubscriptionUpserted` already handles the type. Because forwarding is
+at-least-once and the apply is idempotent (§3.1), duplicates from a retried forward
+are absorbed by both the destination `Nats-Msg-Id` dedup and the idempotent upsert.
+
+### 3.5 Contract bookkeeping
+
+- Add `model.InboxThreadSubscriptionUpserted` to `outbox.ConcurrentEventTypes`
+  (`pkg/outbox/outbox.go`). This is the single required contract edit; `Publish`
+  rejects types in neither partition set, so this is what makes the producer call
+  legal.
+- Update the `pkg/outbox` package doc comment (and the `ConcurrentEventTypes` doc)
+  to list `message-worker` as a third producer alongside `room-service`/`room-worker`.
+
+## 4. No-loss guarantee (remote down) — inherited from #410
+
+The change places `thread_subscription_upserted` on the identical rails that give
+membership its guarantee, so the same vector table applies:
+
+| # | Loss vector | Mitigation | Status |
+|---|---|---|---|
+| 1 | Remote unreachable (target case) | Producer commits to local OUTBOX; forward Naks with `MaxDeliver=-1` → retained, delivered on recovery. | closed by this change |
+| 2 | Local OUTBOX node loss | OUTBOX is `R3 + file` (IaC precondition, shared with #410). | IaC precondition |
+| 3 | Outage longer than retention | Bounded by OUTBOX `MaxAge`; reconciliation would be needed for the unconditional guarantee — **out of scope**, same as membership. | partial (accepted) |
+| 4 | Producer crash before durable enqueue | Publish returns an error → MESSAGES_CANONICAL Naks and redelivers; local thread work re-runs idempotently and re-enqueues; stable `Nats-Msg-Id` makes it a dedup no-op. | closed by this change |
+| 5 | Poison / malformed event | Producer emits well-formed events; `outbox-worker` Ack-drops permanent with a warning (defensive). | inherited |
+
+**End-to-end invariant:** within OUTBOX retention, a remote thread subscription is
+never silently dropped when its home site is temporarily unreachable. Beyond
+retention remains an accepted gap (matching membership) until reconciliation is
+built.
+
+## 5. Failure-path improvement (bonus)
+
+Today a failed cross-site publish Naks the **whole** MESSAGES_CANONICAL message,
+re-running all local thread work (idempotent) up to `MaxDeliver=5`, then dropping it.
+After this change the publish targets the **local** OUTBOX (same-site, highly
+available), so it effectively never fails for a *remote* outage — the canonical
+message acks promptly and the cross-site concern is owned by `outbox-worker`. The
+hot path trades one cross-gateway INBOX publish for one local OUTBOX publish (same
+count, lower latency, higher availability).
+
+## 6. Testing
+
+TDD, per CLAUDE.md. New/changed coverage:
+
+- **`message-worker` unit tests** (`handler_test.go`): assert `publishThreadSubInboxIfRemote`
+  now publishes to the **OUTBOX** subject `chat.outbox.{origin}.{dest}.thread_subscription_upserted`
+  (via the captured publish closure) with the correct `Nats-Msg-Id` (dedup seed),
+  an `OutboxEvent` whose decoded `Envelope` is the expected `InboxEvent`
+  (`Type=thread_subscription_upserted`, `SiteID=origin`, `DestSiteID=dest`, payload
+  = the `ThreadSubscription`). Update the existing `CarriesAttachments`-style
+  assertions and any test asserting the old `InboxExternal` subject.
+  - Keep coverage for: same-site → no publish; empty `ownerSiteID` → warn + no
+    publish; `isMigration` → no publish; `HasMention` flip → distinct dedup IDs.
+- **`pkg/outbox` unit tests** (`outbox_test.go`): `thread_subscription_upserted` is a
+  known/accepted type (no longer rejected); it partitions into the **concurrent** set.
+- **`outbox-worker` / `inbox-worker` integration:** existing federation tests already
+  exercise the concurrent lane end-to-end; extend a table/case to include
+  `thread_subscription_upserted` so a forwarded envelope lands and upserts. No new
+  container topology.
+- **Coverage floor:** keep changed packages ≥ 80% (target 90% for handlers).
+
+## 7. Out-of-scope / follow-ups
+
+1. **Reconciliation for thread subscriptions** (unconditional, beyond-retention) —
+   tracks membership's own §3.4 follow-up.
+2. **Dead-letter + alert** for permanent poison — shared with #410's follow-up.
+3. **Client API docs:** none. `thread_subscription_upserted` is an internal
+   federation event, not a client-facing RPC or a `pkg/model` client/event struct —
+   `docs/client-api.md` and its derived views are untouched.
+
+## 8. Files touched (anticipated)
+
+- `pkg/outbox/outbox.go` — add the type to `ConcurrentEventTypes`; update producer docs.
+- `message-worker/handler.go` — rewrite `publishThreadSubInboxIfRemote` to call
+  `outbox.Publish`; import `pkg/outbox`.
+- `message-worker/handler_test.go` — retarget assertions to the OUTBOX subject/envelope.
+- `pkg/outbox/outbox_test.go` — accept + partition assertion for the new type.
+- `outbox-worker` / `inbox-worker` integration tests — add the new type to an existing case.
+- No changes to `main.go` (publish closure already present), `bootstrap.go` (OUTBOX
+  owned by `outbox-worker`, mirroring room-worker), `outbox-worker`, or `inbox-worker`
+  production code.

--- a/message-worker/handler.go
+++ b/message-worker/handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/pkg/natsutil"
+	"github.com/hmchangw/chat/pkg/outbox"
 	"github.com/hmchangw/chat/pkg/subject"
 	"github.com/hmchangw/chat/pkg/userstore"
 )
@@ -558,23 +559,22 @@ func (h *Handler) markThreadMentions(ctx context.Context, msg *model.Message, th
 	return nil
 }
 
-// publishThreadSubInboxIfRemote publishes a thread_subscription_upserted
-// inbox event to ownerSiteID when that site differs from the local site.
-// Same-site or empty ownerSiteID is a no-op (empty logs a warning — it
-// indicates a caller bug). ownerSiteID is the subscription owner's home
+// publishThreadSubInboxIfRemote federates a thread_subscription_upserted event
+// to ownerSiteID when that site differs from the local site, via the durable
+// OUTBOX relay (outbox-worker forwards it to the destination INBOX with
+// retry-forever, so a destination outage delays — never drops — the event
+// within retention). Same-site is a no-op; empty ownerSiteID is a no-op that
+// logs a warning (caller bug). ownerSiteID is the subscription owner's home
 // site — NOT sub.SiteID, which is the room's home site.
-//
-// The dedup-ID seed is (threadRoomID, userID, msgID): msg.ID is unique per
-// reply, and (msg.ID, userID) is unique within a reply, so the seed is stable
-// across MESSAGES_CANONICAL redeliveries and JetStream stream-level dedup
-// absorbs duplicates within the dedup window.
 func (h *Handler) publishThreadSubInboxIfRemote(ctx context.Context, sub *model.ThreadSubscription, ownerSiteID, msgID string) error {
 	if ownerSiteID == "" {
-		slog.WarnContext(ctx, "owner siteID empty, skipping inbox publish",
+		slog.WarnContext(ctx, "owner siteID empty, skipping outbox publish",
 			"threadRoomID", sub.ThreadRoomID, "user_id", sub.UserID, "msgID", msgID,
 			"request_id", natsutil.RequestIDFromContext(ctx))
 		return nil
 	}
+	// outbox.Publish also no-ops a local destination, but short-circuit here so the
+	// marshal below is skipped on the common same-site path.
 	if ownerSiteID == h.siteID {
 		return nil
 	}
@@ -583,30 +583,17 @@ func (h *Handler) publishThreadSubInboxIfRemote(ctx context.Context, sub *model.
 	if err != nil {
 		return fmt.Errorf("marshal thread subscription: %w", err)
 	}
-	externalEvt := model.InboxEvent{
-		Type:       model.InboxThreadSubscriptionUpserted,
-		SiteID:     h.siteID,
-		DestSiteID: ownerSiteID,
-		Payload:    payload,
-		Timestamp:  time.Now().UTC().UnixMilli(),
-	}
-	data, err := sonic.Marshal(externalEvt)
-	if err != nil {
-		return fmt.Errorf("marshal inbox event: %w", err)
-	}
-	// Dedup ID format: {payloadSeed}:{destSiteID}, where payloadSeed encodes
-	// per-publish uniqueness (threadRoomID + userID + msg.ID + hasMention).
-	// msg.ID is stable across MESSAGES_CANONICAL redeliveries → same publish
-	// always produces the same dedup ID. Different users on the same destination
-	// get different dedup IDs because their userIDs differ in the seed.
+	// Dedup-ID seed (threadRoomID + userID + msg.ID + hasMention + destSiteID):
+	// msg.ID is stable across MESSAGES_CANONICAL redeliveries so the same publish
+	// yields the same ID; different users on the same destination differ via userID;
 	// hasMention is in the seed so a HasMention=false upsert and a later
-	// HasMention=true mention update for the same (thread, user, message) get
-	// distinct dedup IDs — otherwise JetStream would drop the mention update and
-	// the flag would never cross sites.
+	// HasMention=true update get distinct dedup IDs (else stream-level dedup would
+	// swallow the mention update). It rides the OUTBOX publish as its Nats-Msg-Id
+	// AND the forward's Nats-Msg-Id at the destination.
 	dedupID := fmt.Sprintf("thread-sub-inbox:%s:%s:%s:%t:%s", sub.ThreadRoomID, sub.UserID, msgID, sub.HasMention, ownerSiteID)
-	subj := subject.InboxExternal(ownerSiteID, model.InboxThreadSubscriptionUpserted)
-	if err := h.publish(ctx, subj, data, dedupID); err != nil {
-		return fmt.Errorf("publish thread subscription inbox to %s: %w", ownerSiteID, err)
+	if err := outbox.Publish(ctx, h.publish, h.siteID, sub.RoomID, ownerSiteID,
+		model.InboxThreadSubscriptionUpserted, payload, dedupID, time.Now().UTC().UnixMilli()); err != nil {
+		return fmt.Errorf("publish thread subscription outbox to %s: %w", ownerSiteID, err)
 	}
 	return nil
 }

--- a/message-worker/handler_test.go
+++ b/message-worker/handler_test.go
@@ -1647,14 +1647,7 @@ func TestHandler_SubsequentReply_InboxPublishes(t *testing.T) {
 
 			var publishedDests []string
 			h := NewHandler(store, us, ts, "site-a", func(_ context.Context, _ string, data []byte, _ string) error {
-				var relay model.OutboxEvent
-				if err := json.Unmarshal(data, &relay); err != nil {
-					return err
-				}
-				var outer model.InboxEvent
-				if err := json.Unmarshal(relay.Envelope, &outer); err != nil {
-					return err
-				}
+				_, outer := unwrapOutbox(t, data)
 				publishedDests = append(publishedDests, outer.DestSiteID)
 				return nil
 			})
@@ -1787,14 +1780,7 @@ func TestHandler_MarkThreadMentions_InboxPublishes(t *testing.T) {
 			var publishedDests []string
 			h := NewHandler(NewMockStore(ctrl), NewMockUserStore(ctrl), ts, "site-a",
 				func(_ context.Context, _ string, data []byte, _ string) error {
-					var relay model.OutboxEvent
-					if err := json.Unmarshal(data, &relay); err != nil {
-						return err
-					}
-					var outer model.InboxEvent
-					if err := json.Unmarshal(relay.Envelope, &outer); err != nil {
-						return err
-					}
+					_, outer := unwrapOutbox(t, data)
 					publishedDests = append(publishedDests, outer.DestSiteID)
 					return nil
 				})

--- a/message-worker/handler_test.go
+++ b/message-worker/handler_test.go
@@ -1298,6 +1298,18 @@ func TestHandler_HandleThreadRoomAndSubscriptions(t *testing.T) {
 	}
 }
 
+// unwrapOutbox decodes an OutboxEvent published on the OUTBOX relay and the
+// inner InboxEvent envelope it carries. Thread-subscription federation rides
+// the durable OUTBOX (chat.outbox.…), not a direct INBOX publish.
+func unwrapOutbox(t *testing.T, data []byte) (model.OutboxEvent, model.InboxEvent) {
+	t.Helper()
+	var relay model.OutboxEvent
+	require.NoError(t, json.Unmarshal(data, &relay))
+	var env model.InboxEvent
+	require.NoError(t, json.Unmarshal(relay.Envelope, &env))
+	return relay, env
+}
+
 func TestHandler_PublishThreadSubInboxIfRemote(t *testing.T) {
 	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
 	// Subscription's SiteID is the room's site (here, site-a — the local handler).
@@ -1361,7 +1373,8 @@ func TestHandler_PublishThreadSubInboxIfRemote(t *testing.T) {
 		err := h.publishThreadSubInboxIfRemote(context.Background(), baseSub, "site-b", "msg-1")
 		require.NoError(t, err)
 		require.Equal(t, 1, captured.callCnt)
-		assert.Equal(t, "chat.inbox.site-b.external.thread_subscription_upserted", captured.subj)
+		assert.Equal(t, subject.Outbox("site-a", "site-b", model.InboxThreadSubscriptionUpserted), captured.subj)
+		// = "chat.outbox.site-a.site-b.thread_subscription_upserted"
 		assert.NotEmpty(t, captured.msgID, "dedup ID must be set")
 
 		// Same inputs → same dedup ID (stable across redeliveries).
@@ -1384,10 +1397,12 @@ func TestHandler_PublishThreadSubInboxIfRemote(t *testing.T) {
 		require.NoError(t, h3.publishThreadSubInboxIfRemote(context.Background(), baseSub, "site-b", "msg-2"))
 		assert.NotEqual(t, captured.msgID, third)
 
-		// Payload is an InboxEvent whose inner Payload decodes back to the ThreadSubscription
-		// — and the inner SiteID is unchanged (still the room's site, "site-a").
-		var outer model.InboxEvent
-		require.NoError(t, json.Unmarshal(captured.data, &outer))
+		// The captured data is an OutboxEvent wrapping the InboxEvent envelope,
+		// whose inner Payload decodes back to the ThreadSubscription — and the
+		// inner SiteID is unchanged (still the room's site, "site-a").
+		relay, outer := unwrapOutbox(t, captured.data)
+		assert.Equal(t, "r1", relay.RoomID, "OutboxEvent.RoomID is the channel room ID")
+		assert.Equal(t, captured.msgID, relay.DedupID, "OutboxEvent.DedupID equals the publish Nats-Msg-Id")
 		assert.Equal(t, model.InboxThreadSubscriptionUpserted, outer.Type)
 		assert.Equal(t, "site-a", outer.SiteID)
 		assert.Equal(t, "site-b", outer.DestSiteID)
@@ -1498,8 +1513,7 @@ func TestHandler_FirstReply_InboxPublishes(t *testing.T) {
 
 			gotByDest := map[string]int{}
 			for _, c := range calls {
-				var outer model.InboxEvent
-				require.NoError(t, json.Unmarshal(c.data, &outer))
+				_, outer := unwrapOutbox(t, c.data)
 				assert.Equal(t, model.InboxThreadSubscriptionUpserted, outer.Type)
 				gotByDest[outer.DestSiteID]++
 			}
@@ -1633,8 +1647,12 @@ func TestHandler_SubsequentReply_InboxPublishes(t *testing.T) {
 
 			var publishedDests []string
 			h := NewHandler(store, us, ts, "site-a", func(_ context.Context, _ string, data []byte, _ string) error {
+				var relay model.OutboxEvent
+				if err := json.Unmarshal(data, &relay); err != nil {
+					return err
+				}
 				var outer model.InboxEvent
-				if err := json.Unmarshal(data, &outer); err != nil {
+				if err := json.Unmarshal(relay.Envelope, &outer); err != nil {
 					return err
 				}
 				publishedDests = append(publishedDests, outer.DestSiteID)
@@ -1769,8 +1787,12 @@ func TestHandler_MarkThreadMentions_InboxPublishes(t *testing.T) {
 			var publishedDests []string
 			h := NewHandler(NewMockStore(ctrl), NewMockUserStore(ctrl), ts, "site-a",
 				func(_ context.Context, _ string, data []byte, _ string) error {
+					var relay model.OutboxEvent
+					if err := json.Unmarshal(data, &relay); err != nil {
+						return err
+					}
 					var outer model.InboxEvent
-					if err := json.Unmarshal(data, &outer); err != nil {
+					if err := json.Unmarshal(relay.Envelope, &outer); err != nil {
 						return err
 					}
 					publishedDests = append(publishedDests, outer.DestSiteID)
@@ -1842,8 +1864,7 @@ func TestHandler_MarkThreadMentions_HasMentionInPayload(t *testing.T) {
 	}
 	require.NoError(t, h.markThreadMentions(context.Background(), msg, "tr-1", "site-a", false))
 
-	var outer model.InboxEvent
-	require.NoError(t, json.Unmarshal(captured, &outer))
+	_, outer := unwrapOutbox(t, captured)
 	var sub model.ThreadSubscription
 	require.NoError(t, json.Unmarshal(outer.Payload, &sub))
 	assert.True(t, sub.HasMention, "inbox-emitted ThreadSubscription must carry HasMention=true")

--- a/outbox-worker/consumer_config_test.go
+++ b/outbox-worker/consumer_config_test.go
@@ -31,6 +31,7 @@ func TestBuildConcurrentConsumerConfig(t *testing.T) {
 		"chat.outbox.site-a.site-b.subscription_mute_toggled",
 		"chat.outbox.site-a.site-b.subscription_favorite_toggled",
 		"chat.outbox.site-a.site-b.room_restricted",
+		"chat.outbox.site-a.site-b.thread_subscription_upserted",
 	}, cc.FilterSubjects)
 	assert.Equal(t, jetstream.AckExplicitPolicy, cc.AckPolicy)
 	assert.Equal(t, jetstream.DeliverAllPolicy, cc.DeliverPolicy)

--- a/outbox-worker/integration_test.go
+++ b/outbox-worker/integration_test.go
@@ -69,14 +69,15 @@ func jsPublish(js jetstream.JetStream) PublishFunc {
 // consumed by the outbox-worker durable, HandleEvent forwards each target's
 // pre-marshaled InboxEvent to the destination site's INBOX, and the forwarded
 // bytes must equal the target's Envelope verbatim.
-func TestIntegration_OutboxRoundTrip(t *testing.T) {
+// assertConcurrentLaneForwards drives one relay event of eventType through the
+// OUTBOX per-destination concurrent consumer (config identical to main.go) and
+// asserts it is forwarded to the destination INBOX with the pre-marshaled
+// Envelope bytes intact. Shared by the round-trip tests for each
+// concurrent-partition event type. innerPayload is the pre-marshaled inner event
+// (as a producer would hand to outbox.Publish).
+func assertConcurrentLaneForwards(t *testing.T, siteID, destSiteID, roomID, eventType string, innerPayload []byte, dedupID string) {
+	t.Helper()
 	ctx := context.Background()
-
-	const (
-		siteID     = "site-fed-origin"
-		destSiteID = "site-fed-dest"
-		roomID     = "room-fed-roundtrip"
-	)
 
 	nc := startEmbeddedJetStreamNATS(t)
 	js, err := jetstream.New(nc)
@@ -90,7 +91,7 @@ func TestIntegration_OutboxRoundTrip(t *testing.T) {
 
 	// Observe the forwarded INBOX publish with a core NATS subscription on the
 	// destination subject, set up before publishing the relay event.
-	destSubject := subject.InboxExternal(destSiteID, model.InboxSubscriptionMuteToggled)
+	destSubject := subject.InboxExternal(destSiteID, eventType)
 	type received struct {
 		subject string
 		data    []byte
@@ -108,10 +109,8 @@ func TestIntegration_OutboxRoundTrip(t *testing.T) {
 
 	h := NewHandler(jsPublish(js))
 
-	// Build the pre-marshaled InboxEvent envelope room-service would produce.
-	innerPayload := []byte(`{"account":"alice","roomId":"room-fed-roundtrip"}`)
 	envelope, err := json.Marshal(model.InboxEvent{
-		Type:       model.InboxSubscriptionMuteToggled,
+		Type:       eventType,
 		SiteID:     siteID,
 		DestSiteID: destSiteID,
 		Payload:    innerPayload,
@@ -119,7 +118,6 @@ func TestIntegration_OutboxRoundTrip(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	const dedupID = "0193abcd-0193-7abc-89ab-fed000000001:site-fed-dest"
 	relayEvt, err := json.Marshal(model.OutboxEvent{
 		RoomID:    roomID,
 		Envelope:  envelope,
@@ -128,8 +126,6 @@ func TestIntegration_OutboxRoundTrip(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Create the per-destination concurrent consumer (same config as main.go) and
-	// run a consume loop that drives HandleEvent, exactly like production.
 	cons, err := js.CreateOrUpdateConsumer(ctx, outboxCfg.Name, buildConcurrentConsumerConfig(stream.ConsumerSettings{
 		AckWait: 30 * time.Second, MaxDeliver: 5, MaxWaiting: 512, MaxAckPending: 1000,
 	}, siteID, destSiteID))
@@ -145,7 +141,7 @@ func TestIntegration_OutboxRoundTrip(t *testing.T) {
 	t.Cleanup(cc.Stop)
 
 	// Publish the relay event onto the OUTBOX stream's destination-scoped subject.
-	_, err = js.Publish(ctx, subject.Outbox(siteID, destSiteID, model.InboxSubscriptionMuteToggled), relayEvt)
+	_, err = js.Publish(ctx, subject.Outbox(siteID, destSiteID, eventType), relayEvt)
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
@@ -160,6 +156,14 @@ func TestIntegration_OutboxRoundTrip(t *testing.T) {
 	assert.Equal(t, destSubject, forwarded[0].subject)
 	assert.Equal(t, envelope, forwarded[0].data,
 		"forwarded bytes must equal the target's pre-marshaled Envelope verbatim")
+}
+
+func TestIntegration_OutboxRoundTrip(t *testing.T) {
+	// The pre-marshaled InboxEvent payload room-service would produce for a mute toggle.
+	assertConcurrentLaneForwards(t, "site-fed-origin", "site-fed-dest", "room-fed-roundtrip",
+		model.InboxSubscriptionMuteToggled,
+		[]byte(`{"account":"alice","roomId":"room-fed-roundtrip"}`),
+		"0193abcd-0193-7abc-89ab-fed000000001:site-fed-dest")
 }
 
 // TestIntegration_ConcurrentLanePerDestinationIsolation proves finding #1's fix:
@@ -424,86 +428,11 @@ func TestIntegration_OrderedLaneKeepsRenameBehindMemberAdded(t *testing.T) {
 // (whose FilterSubjects derive from outbox.ConcurrentEventTypes) and forwarded to
 // the destination INBOX verbatim.
 func TestIntegration_ThreadSubscriptionUpsertedForwardedViaConcurrentLane(t *testing.T) {
-	ctx := context.Background()
-
-	const (
-		siteID     = "site-ts-origin"
-		destSiteID = "site-ts-dest"
-		roomID     = "room-ts-roundtrip"
-	)
-
-	nc := startEmbeddedJetStreamNATS(t)
-	js, err := jetstream.New(nc)
-	require.NoError(t, err)
-
-	outboxCfg := stream.Outbox(siteID)
-	createStream(t, js, outboxCfg)
-	createStream(t, js, stream.Inbox(destSiteID))
-
-	destSubject := subject.InboxExternal(destSiteID, model.InboxThreadSubscriptionUpserted)
-	type received struct {
-		subject string
-		data    []byte
-	}
-	var mu sync.Mutex
-	var forwarded []received
-	sub, err := nc.Subscribe(destSubject, func(msg *nats.Msg) {
-		mu.Lock()
-		forwarded = append(forwarded, received{subject: msg.Subject, data: append([]byte(nil), msg.Data...)})
-		mu.Unlock()
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = sub.Unsubscribe() })
-	require.NoError(t, nc.Flush())
-
-	h := NewHandler(jsPublish(js))
-
-	innerPayload := []byte(`{"id":"sub-1","threadRoomId":"tr-1","userId":"u-bob","userAccount":"bob","roomId":"room-ts-roundtrip","siteId":"site-ts-origin","hasMention":false}`)
-	envelope, err := json.Marshal(model.InboxEvent{
-		Type:       model.InboxThreadSubscriptionUpserted,
-		SiteID:     siteID,
-		DestSiteID: destSiteID,
-		Payload:    innerPayload,
-		Timestamp:  time.Now().UTC().UnixMilli(),
-	})
-	require.NoError(t, err)
-
-	const dedupID = "thread-sub-inbox:tr-1:u-bob:msg-1:false:site-ts-dest"
-	relayEvt, err := json.Marshal(model.OutboxEvent{
-		RoomID:    roomID,
-		Envelope:  envelope,
-		DedupID:   dedupID,
-		Timestamp: time.Now().UTC().UnixMilli(),
-	})
-	require.NoError(t, err)
-
-	cons, err := js.CreateOrUpdateConsumer(ctx, outboxCfg.Name, buildConcurrentConsumerConfig(stream.ConsumerSettings{
-		AckWait: 30 * time.Second, MaxDeliver: 5, MaxWaiting: 512, MaxAckPending: 1000,
-	}, siteID, destSiteID))
-	require.NoError(t, err)
-
-	cc, err := cons.Consume(func(msg jetstream.Msg) {
-		if err := h.HandleEvent(ctx, msg.Subject(), msg.Data()); err != nil {
-			t.Errorf("HandleEvent: %v", err)
-		}
-		_ = msg.Ack()
-	})
-	require.NoError(t, err)
-	t.Cleanup(cc.Stop)
-
-	_, err = js.Publish(ctx, subject.Outbox(siteID, destSiteID, model.InboxThreadSubscriptionUpserted), relayEvt)
-	require.NoError(t, err)
-
-	require.Eventually(t, func() bool {
-		mu.Lock()
-		defer mu.Unlock()
-		return len(forwarded) >= 1
-	}, 5*time.Second, 20*time.Millisecond, "expected one forwarded INBOX publish on the destination subject")
-
-	mu.Lock()
-	defer mu.Unlock()
-	require.Len(t, forwarded, 1, "exactly one forward per target")
-	assert.Equal(t, destSubject, forwarded[0].subject)
-	assert.Equal(t, envelope, forwarded[0].data,
-		"forwarded bytes must equal the target's pre-marshaled Envelope verbatim")
+	// message-worker's fix: thread_subscription_upserted must ride the concurrent
+	// lane (its FilterSubjects derive from outbox.ConcurrentEventTypes) and forward
+	// to the destination INBOX verbatim.
+	assertConcurrentLaneForwards(t, "site-ts-origin", "site-ts-dest", "room-ts-roundtrip",
+		model.InboxThreadSubscriptionUpserted,
+		[]byte(`{"id":"sub-1","threadRoomId":"tr-1","userId":"u-bob","userAccount":"bob","roomId":"room-ts-roundtrip","siteId":"site-ts-origin","hasMention":false}`),
+		"thread-sub-inbox:tr-1:u-bob:msg-1:false:site-ts-dest")
 }

--- a/outbox-worker/integration_test.go
+++ b/outbox-worker/integration_test.go
@@ -417,3 +417,93 @@ func TestIntegration_OrderedLaneKeepsRenameBehindMemberAdded(t *testing.T) {
 	assert.Equal(t, []string{model.InboxMemberAdded, model.InboxRoomRenamed}, arrivals,
 		"room_renamed must not overtake the member_added it renames")
 }
+
+// TestIntegration_ThreadSubscriptionUpsertedForwardedViaConcurrentLane proves the
+// message-worker durability fix end-to-end: a thread_subscription_upserted relay
+// event on the OUTBOX is consumed by the per-destination concurrent consumer
+// (whose FilterSubjects derive from outbox.ConcurrentEventTypes) and forwarded to
+// the destination INBOX verbatim.
+func TestIntegration_ThreadSubscriptionUpsertedForwardedViaConcurrentLane(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		siteID     = "site-ts-origin"
+		destSiteID = "site-ts-dest"
+		roomID     = "room-ts-roundtrip"
+	)
+
+	nc := startEmbeddedJetStreamNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	outboxCfg := stream.Outbox(siteID)
+	createStream(t, js, outboxCfg)
+	createStream(t, js, stream.Inbox(destSiteID))
+
+	destSubject := subject.InboxExternal(destSiteID, model.InboxThreadSubscriptionUpserted)
+	type received struct {
+		subject string
+		data    []byte
+	}
+	var mu sync.Mutex
+	var forwarded []received
+	sub, err := nc.Subscribe(destSubject, func(msg *nats.Msg) {
+		mu.Lock()
+		forwarded = append(forwarded, received{subject: msg.Subject, data: append([]byte(nil), msg.Data...)})
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+	require.NoError(t, nc.Flush())
+
+	h := NewHandler(jsPublish(js))
+
+	innerPayload := []byte(`{"id":"sub-1","threadRoomId":"tr-1","userId":"u-bob","userAccount":"bob","roomId":"room-ts-roundtrip","siteId":"site-ts-origin","hasMention":false}`)
+	envelope, err := json.Marshal(model.InboxEvent{
+		Type:       model.InboxThreadSubscriptionUpserted,
+		SiteID:     siteID,
+		DestSiteID: destSiteID,
+		Payload:    innerPayload,
+		Timestamp:  time.Now().UTC().UnixMilli(),
+	})
+	require.NoError(t, err)
+
+	const dedupID = "thread-sub-inbox:tr-1:u-bob:msg-1:false:site-ts-dest"
+	relayEvt, err := json.Marshal(model.OutboxEvent{
+		RoomID:    roomID,
+		Envelope:  envelope,
+		DedupID:   dedupID,
+		Timestamp: time.Now().UTC().UnixMilli(),
+	})
+	require.NoError(t, err)
+
+	cons, err := js.CreateOrUpdateConsumer(ctx, outboxCfg.Name, buildConcurrentConsumerConfig(stream.ConsumerSettings{
+		AckWait: 30 * time.Second, MaxDeliver: 5, MaxWaiting: 512, MaxAckPending: 1000,
+	}, siteID, destSiteID))
+	require.NoError(t, err)
+
+	cc, err := cons.Consume(func(msg jetstream.Msg) {
+		if err := h.HandleEvent(ctx, msg.Subject(), msg.Data()); err != nil {
+			t.Errorf("HandleEvent: %v", err)
+		}
+		_ = msg.Ack()
+	})
+	require.NoError(t, err)
+	t.Cleanup(cc.Stop)
+
+	_, err = js.Publish(ctx, subject.Outbox(siteID, destSiteID, model.InboxThreadSubscriptionUpserted), relayEvt)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(forwarded) >= 1
+	}, 5*time.Second, 20*time.Millisecond, "expected one forwarded INBOX publish on the destination subject")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, forwarded, 1, "exactly one forward per target")
+	assert.Equal(t, destSubject, forwarded[0].subject)
+	assert.Equal(t, envelope, forwarded[0].data,
+		"forwarded bytes must equal the target's pre-marshaled Envelope verbatim")
+}

--- a/pkg/outbox/outbox.go
+++ b/pkg/outbox/outbox.go
@@ -1,7 +1,7 @@
 // Package outbox is the cross-site federation relay contract shared by the
-// producers (room-service, room-worker) and the consumer (outbox-worker): which
-// event types ride which OUTBOX consumer lane, and the one way to publish a
-// relay event onto the stream.
+// producers (room-service, room-worker, message-worker) and the consumer
+// (outbox-worker): which event types ride which OUTBOX consumer lane, and the
+// one way to publish a relay event onto the stream.
 package outbox
 
 import (
@@ -16,8 +16,8 @@ import (
 
 // ConcurrentEventTypes are the OUTBOX event types forwarded by outbox-worker's
 // shared concurrent consumer. They are order-insensitive at the destination
-// (inbox-worker applies them under high-water-mark guards), so parallel
-// forwarding is safe.
+// (inbox-worker applies them under high-water-mark / idempotent-upsert guards),
+// so parallel forwarding is safe.
 var ConcurrentEventTypes = []model.InboxEventType{
 	model.InboxRoleUpdated,
 	model.InboxSubscriptionRead,
@@ -25,6 +25,10 @@ var ConcurrentEventTypes = []model.InboxEventType{
 	model.InboxSubscriptionMuteToggled,
 	model.InboxSubscriptionFavoriteToggled,
 	model.InboxRoomRestricted,
+	// message-worker: thread-subscription federation. Order-insensitive —
+	// inbox-worker's UpsertThreadSubscription is $setOnInsert (immutable identity)
+	// + $max hasMention (monotonic), so out-of-order/duplicate applies converge.
+	model.InboxThreadSubscriptionUpserted,
 }
 
 // OrderedEventTypes are the OUTBOX event types forwarded by outbox-worker's

--- a/pkg/outbox/outbox_test.go
+++ b/pkg/outbox/outbox_test.go
@@ -63,11 +63,19 @@ func TestPublish_NoopForEmptyOrLocalDestination(t *testing.T) {
 }
 
 func TestPublish_RejectsEventTypeOutsideThePartition(t *testing.T) {
+	// user_status_updated is in neither ConcurrentEventTypes nor OrderedEventTypes.
 	err := Publish(context.Background(), func(context.Context, string, []byte, string) error { return nil },
-		"site-a", "r1", "site-b", model.InboxThreadSubscriptionUpserted, []byte(`{}`), "d", 1)
+		"site-a", "r1", "site-b", model.InboxUserStatusUpdated, []byte(`{}`), "d", 1)
 	require.Error(t, err,
 		"an event type with no outbox-worker filter would sit in the stream unconsumed — must fail fast at the publish site")
 	assert.Contains(t, err.Error(), "filter set")
+}
+
+func TestThreadSubscriptionUpsertedIsConcurrent(t *testing.T) {
+	assert.Contains(t, ConcurrentEventTypes, model.InboxThreadSubscriptionUpserted,
+		"message-worker federates thread_subscription_upserted; it is order-insensitive at the destination "+
+			"(inbox-worker upsert is $setOnInsert + $max hasMention) so it rides the concurrent lane")
+	assert.NotContains(t, OrderedEventTypes, model.InboxThreadSubscriptionUpserted)
 }
 
 func TestPublish_RejectsEmptyDedupID(t *testing.T) {


### PR DESCRIPTION
## What & why

`message-worker` federates thread subscriptions cross-site — when a thread reply involves a participant (the parent-message author or the replier) whose home site differs from the local site, the remote site must create/update that user's `ThreadSubscription`.

It did this with a **direct INBOX publish** on the `MESSAGES_CANONICAL` consumer's default `MaxDeliver=5`. So a destination-site outage longer than ~5 redeliveries **permanently dropped** the event — the local write had already committed, leaving local and remote state diverged with no repair. This is exactly the failure mode PR #410 fixed for **membership**, which `thread_subscription_upserted` was never migrated onto.

This PR routes `thread_subscription_upserted` through the local **OUTBOX** relay, so `outbox-worker` forwards it to the destination INBOX with retry-forever (`MaxDeliver=-1`). A destination down for an hour (up to OUTBOX retention) now **delays** the event instead of dropping it.

## Changes

- **`pkg/outbox`** — add `thread_subscription_upserted` to `ConcurrentEventTypes` (the order-insensitive lane); update producer docs to include `message-worker`.
- **`message-worker`** — `publishThreadSubInboxIfRemote` now calls the shared `outbox.Publish` onto the local OUTBOX instead of a direct `InboxExternal` publish. Envelope bytes and the dedup-ID seed are unchanged.
- **Tests** — outbox-worker end-to-end forward coverage for the new type (via a shared `assertConcurrentLaneForwards` harness); message-worker unit tests retargeted to the OUTBOX envelope.

## Design decisions

- **Concurrent lane, not FIFO** — `inbox-worker.UpsertThreadSubscription` is `$setOnInsert` (immutable identity) + `$max hasMention` (monotonic), so it is genuinely order-insensitive and identical to today's (unordered) delivery semantics. No ordering regression.
- **Zero production change** to `outbox-worker`, `inbox-worker`, `main.go`, or `bootstrap.go` — the consumer is event-type-generic, and `message-worker` already held the publish closure `outbox.Publish` needs (mirrors `room-worker`'s `federate`).
- **Hot path neutral-to-better** — replaces a cross-gateway INBOX publish with a local OUTBOX publish (same count, lower latency, higher availability) on a high-throughput worker.

## Scope

Durability **parity with #410** — delay-not-drop *within* OUTBOX retention. Beyond-retention **reconciliation** for thread subscriptions is an accepted follow-up, matching membership's own (still-unbuilt) backstop. No client-facing RPC or `pkg/model` client/event struct changed, so `docs/client-api.md` is untouched.

## Testing

- `make lint` — 0 issues
- `make test` (full suite, `-race`) — pass
- `make test-integration SERVICE=outbox-worker` — pass, incl. the new concurrent-lane forward test
- `make sast` — gosec / govulncheck / semgrep all pass
- Coverage: `publishThreadSubInboxIfRemote` **91.7%**, `pkg/outbox` **86.7%**

Design & plan: `docs/superpowers/specs/2026-07-17-message-worker-thread-subscription-outbox-durability-design.md`, `docs/superpowers/plans/2026-07-17-message-worker-thread-subscription-outbox-durability.md`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNMS2LV1evxmEZTKXxvFKX