### PR TITLE
feat(user-service): per-user settings RPCs (settings.get/set) + settings.update event

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -4274,7 +4274,7 @@ The stored settings object. All seven fields are optional and appear only when t
 | Field | Type | Notes |
 |-------|------|-------|
 | `fullWidth` | boolean | Full-width layout. |
-| `translateMessageInto` | string | Target language tag for message translation, e.g. `"en-US"`. |
+| `translateMessageInto` | string | Target language tag for message translation, e.g. `"en-US"`; `""` means translation explicitly off. |
 | `showMessagePreviewInSidebarList` | boolean | Show message previews in the sidebar list. |
 | `muteAllNotifications` | boolean | Mute all notifications. |
 | `showMessagesAndPreviewsInNotifications` | boolean | Show message content and previews in notifications. |
@@ -4318,7 +4318,7 @@ Any non-empty subset of the seven settings fields (same types as [`settings.get`
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
 | `fullWidth` | boolean | no | |
-| `translateMessageInto` | string | no | Language-tag shape: hyphen-separated letter/digit subtags, leading subtag letters-only (e.g. `"en"`, `"en-US"`, `"zh-Hant-TW"`). No value whitelist. |
+| `translateMessageInto` | string | no | Language-tag shape: hyphen-separated letter/digit subtags, leading subtag letters-only (e.g. `"en"`, `"en-US"`, `"zh-Hant-TW"`); or `""` to explicitly turn translation off. No value whitelist. |
 | `showMessagePreviewInSidebarList` | boolean | no | |
 | `muteAllNotifications` | boolean | no | |
 | `showMessagesAndPreviewsInNotifications` | boolean | no | |

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -4058,7 +4058,7 @@ Additional legacy fields may be present, mirroring the `GET /api/v3/users` respo
 
 `user-service` exposes 16 NATS request/reply endpoints over **core NATS** (no JetStream consumers). Subjects follow the pattern `chat.user.{account}.request.user.{siteID}.<area>.<action>`, except `me`, which is a single-token self-lookup (`chat.user.{account}.request.user.{siteID}.me`).
 
-> **Events:** [`settings.set`](#settingsset) emits [`settings.update`](#settingsupdate-event) to the caller's other devices. No other endpoint emits a client-facing event. (`status.set` triggers a server-side cross-site federation update, which is not delivered to clients.)
+> **Events:** [`settings.set`](#settingsset) emits [`settings.update`](#settingsupdate-event) to the caller's other devices. No other endpoint emits a client-facing event. (`status.set` and `settings.set` also trigger a server-side cross-site federation update, which is not delivered to clients.)
 
 | RPC subject | Method |
 |---|---|

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -59,7 +59,7 @@ paths.
      - [`search.messages`](#searchmessages--full-text-message-search) · [Search Rooms](#search-rooms) · [Search Apps](#search-apps) · [Search Users](#search-users)
    - [3.4 user-service](#34-user-service)
      - [`me`](#me) · [`status.getByName`](#statusgetbyname) · [`profile.getByName`](#profilegetbyname) · [`status.set`](#statusset) · [`subscription.list`](#subscriptionlist) · [`subscription.getChannels`](#subscriptiongetchannels)
-     - [`subscription.getDM`](#subscriptiongetdm) · [`subscription.getByRoomID`](#subscriptiongetbyroomid) · [`subscription.count`](#subscriptioncount) · [`subscription.setAppSubscription`](#subscriptionsetappsubscription) · [`apps.list`](#appslist) · [`apps.categories`](#appscategories)
+     - [`subscription.getDM`](#subscriptiongetdm) · [`subscription.getByRoomID`](#subscriptiongetbyroomid) · [`subscription.count`](#subscriptioncount) · [`subscription.setAppSubscription`](#subscriptionsetappsubscription) · [`apps.list`](#appslist) · [`apps.categories`](#appscategories) · [`settings.get`](#settingsget) · [`settings.set`](#settingsset)
    - [3.5 media-service](#35-media-service)
      - [`emoji.list`](#emojilist--list-a-sites-custom-emoji) · [`emoji.delete`](#emojidelete--delete-a-custom-emoji)
 4. [Message Send](#4-message-send)
@@ -166,7 +166,7 @@ Permissions and connection limits come from the auth-service account's scoped si
 
 **Recommended baseline subscriptions on connect:**
 
-- `chat.user.{account}.>` — captures every personal event including async replies, per-user room events (DM messages, edits, deletes), room-key events, and subscription updates.
+- `chat.user.{account}.>` — captures every personal event including async replies, per-user room events (DM messages, edits, deletes), room-key events, subscription updates, and settings updates.
 - `chat.room.{roomID}.event` for each channel room in the user's sidebar — receives new messages plus edit/delete events for that channel.
 
 The exact event subjects a client may receive as a result of an RPC are listed under each method's "Triggered events" sections in §2.2, §3, and §4.
@@ -4056,9 +4056,9 @@ Additional legacy fields may be present, mirroring the `GET /api/v3/users` respo
 
 ### 3.4 user-service
 
-`user-service` exposes 14 NATS request/reply endpoints over **core NATS** (no JetStream consumers). Subjects follow the pattern `chat.user.{account}.request.user.{siteID}.<area>.<action>`, except `me`, which is a single-token self-lookup (`chat.user.{account}.request.user.{siteID}.me`).
+`user-service` exposes 16 NATS request/reply endpoints over **core NATS** (no JetStream consumers). Subjects follow the pattern `chat.user.{account}.request.user.{siteID}.<area>.<action>`, except `me`, which is a single-token self-lookup (`chat.user.{account}.request.user.{siteID}.me`).
 
-> **Events:** these endpoints emit no client-facing events. (`status.set` triggers a server-side cross-site federation update, which is internal and not delivered to clients.)
+> **Events:** [`settings.set`](#settingsset) emits [`settings.update`](#settingsupdate-event) to the caller's other devices. No other endpoint emits a client-facing event. (`status.set` triggers a server-side cross-site federation update, which is not delivered to clients.)
 
 | RPC subject | Method |
 |---|---|
@@ -4066,6 +4066,8 @@ Additional legacy fields may be present, mirroring the `GET /api/v3/users` respo
 | `chat.user.{account}.request.user.{siteID}.status.getByName` | [`status.getByName`](#statusgetbyname) |
 | `chat.user.{account}.request.user.{siteID}.profile.getByName` | [`profile.getByName`](#profilegetbyname) |
 | `chat.user.{account}.request.user.{siteID}.status.set` | [`status.set`](#statusset) |
+| `chat.user.{account}.request.user.{siteID}.settings.get` | [`settings.get`](#settingsget) |
+| `chat.user.{account}.request.user.{siteID}.settings.set` | [`settings.set`](#settingsset) |
 | `chat.user.{account}.request.user.{siteID}.subscription.list` | [`subscription.list`](#subscriptionlist) |
 | `chat.user.{account}.request.user.{siteID}.subscription.getChannels` | [`subscription.getChannels`](#subscriptiongetchannels) |
 | `chat.user.{account}.request.user.{siteID}.subscription.getDM` | [`subscription.getDM`](#subscriptiongetdm) |
@@ -4251,6 +4253,121 @@ Same shape as `status.getByName`:
 | `text` > 512 bytes | `bad_request` | — | `{ "code": "bad_request", "error": "status text too long" }` |
 | No active user doc for the caller | `not_found` | — | `{ "code": "not_found", "error": "user not found" }` — nothing is broadcast. |
 | Internal failure | `internal` | — | — |
+
+---
+
+#### settings.get
+
+**Subject:** `chat.user.{account}.request.user.{siteID}.settings.get`
+**Reply subject:** auto-generated `_INBOX.>` (NATS request/reply)
+
+Returns the calling user's stored settings sub-document — **exactly as stored**. The server never injects defaults: a field the user never set is absent from the reply, and **absent means the client applies its own default** (cross-client default consistency is client-owned by design). A user who never set anything gets `{}`.
+
+##### Request body
+
+None (empty payload).
+
+##### Success response
+
+The stored settings object. All seven fields are optional and appear only when the user has explicitly set them:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `fullWidth` | boolean | Full-width layout. |
+| `translateMessageInto` | string | Target language tag for message translation, e.g. `"en-US"`. |
+| `showMessagePreviewInSidebarList` | boolean | Show message previews in the sidebar list. |
+| `muteAllNotifications` | boolean | Mute all notifications. |
+| `showMessagesAndPreviewsInNotifications` | boolean | Show message content and previews in notifications. |
+| `showNotificationsDuringCallsAndMeetings` | boolean | Show notifications during calls and meetings. |
+| `scrollToBottomInChat` | boolean | Scroll to bottom when entering a chat. |
+
+```json
+{
+  "fullWidth": true,
+  "translateMessageInto": "en-US",
+  "showMessagePreviewInSidebarList": true
+}
+```
+
+Never-set user:
+
+```json
+{}
+```
+
+##### Error response
+
+| Condition | `code` | `reason` | Notes |
+|-----------|--------|----------|-------|
+| No active user doc for the caller | `not_found` | — | `{ "code": "not_found", "error": "user not found" }` |
+| Any other failure | — | — | Collapses to the generic boundary error code — see [§6 Error envelope reference](#6-error-envelope-reference). |
+
+---
+
+#### settings.set
+
+**Subject:** `chat.user.{account}.request.user.{siteID}.settings.set`
+**Reply subject:** auto-generated `_INBOX.>` (NATS request/reply)
+
+Partially updates the calling user's settings: **only the fields present in the request are written**; every unsent field keeps its stored value (or stays absent). At least one field is required. Returns the full post-update settings.
+
+##### Request body
+
+Any non-empty subset of the seven settings fields (same types as [`settings.get`](#settingsget)):
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `fullWidth` | boolean | no | |
+| `translateMessageInto` | string | no | Language-tag shape: hyphen-separated letter/digit subtags, leading subtag letters-only (e.g. `"en"`, `"en-US"`, `"zh-Hant-TW"`). No value whitelist. |
+| `showMessagePreviewInSidebarList` | boolean | no | |
+| `muteAllNotifications` | boolean | no | |
+| `showMessagesAndPreviewsInNotifications` | boolean | no | |
+| `showNotificationsDuringCallsAndMeetings` | boolean | no | |
+| `scrollToBottomInChat` | boolean | no | |
+
+```json
+{ "fullWidth": false, "translateMessageInto": "ja" }
+```
+
+##### Success response
+
+The **full post-update settings** (same shape as [`settings.get`](#settingsget)) — sent fields updated, previously stored fields retained:
+
+```json
+{
+  "fullWidth": false,
+  "translateMessageInto": "ja",
+  "muteAllNotifications": true
+}
+```
+
+##### Error response
+
+| Condition | `code` | `reason` | Notes |
+|-----------|--------|----------|-------|
+| No fields in the request | `bad_request` | — | `{ "code": "bad_request", "error": "no settings provided" }` |
+| Malformed `translateMessageInto` | `bad_request` | — | `{ "code": "bad_request", "error": "invalid translateMessageInto language tag" }` |
+| No active user doc for the caller | `not_found` | — | `{ "code": "not_found", "error": "user not found" }` — nothing is written or published. |
+| Any other failure | — | — | Collapses to the generic boundary error code — see [§6 Error envelope reference](#6-error-envelope-reference). |
+
+<a id="settingsupdate-event"></a>
+##### `settings.update` event
+
+**Emits:** `chat.user.{account}.event.settings.update` after every successful set — ephemeral core-NATS fan-out to the caller's own connected devices (same delivery pattern as `subscription.update`), so other logged-in clients sync live. Best-effort: a fan-out failure does not fail the set.
+
+The payload carries the **full post-update settings** (replace, don't merge):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `timestamp` | number | Publish time, Unix ms. |
+| `settings` | UserSettings | The full post-update settings — same seven optional fields as [`settings.get`](#settingsget). |
+
+```json
+{
+  "timestamp": 1737000000000,
+  "settings": { "fullWidth": false, "translateMessageInto": "ja", "muteAllNotifications": true }
+}
+```
 
 ---
 

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -17,8 +17,9 @@ For connection, auth, and error details see [../client-api.md](../client-api.md)
 
 1. [AsyncJobResult — async completion](#asyncjobresult--async-completion)
 2. [subscription.update — membership / state changes](#subscriptionupdate--membership--state-changes)
-3. [room.key — room encryption key delivery](#roomkey--room-encryption-key-delivery)
-4. [Room events — per-room live events](#room-events--per-room-live-events)
+3. [settings.update — user settings sync](#settingsupdate--user-settings-sync)
+4. [room.key — room encryption key delivery](#roomkey--room-encryption-key-delivery)
+5. [Room events — per-room live events](#room-events--per-room-live-events)
    - [new_message (RoomEvent)](#new_message-roomevent)
    - [message_edited (EditRoomEvent)](#message_edited-editroomevent)
    - [message_deleted (DeleteRoomEvent)](#message_deleted-deleteroomevent)
@@ -29,11 +30,11 @@ For connection, auth, and error details see [../client-api.md](../client-api.md)
    - [thread_message_read](#thread_message_read)
    - [room_renamed (RoomRenamedRoomEvent)](#room_renamed-roomrenamedroomevent)
    - [room_restricted (RoomRestrictedRoomEvent)](#room_restricted-roomrestrictedroomevent)
-5. [member — room membership events](#member--room-membership-events)
+6. [member — room membership events](#member--room-membership-events)
    - [member_added (MemberAddEvent)](#member_added-memberaddevent)
    - [member_left / member_removed (MemberRemoveEvent)](#member_left--member_removed-memberremoveevent)
-6. [notification — reaction notification](#notification--reaction-notification)
-7. [Presence events](#presence-events)
+7. [notification — reaction notification](#notification--reaction-notification)
+8. [Presence events](#presence-events)
 
 ---
 
@@ -43,6 +44,7 @@ For connection, auth, and error details see [../client-api.md](../client-api.md)
 |---|---|
 | `chat.user.{account}.response.{requestID}` | AsyncJobResult (one-shot async job completion) |
 | `chat.user.{account}.event.subscription.update` | SubscriptionUpdateEvent / SubscriptionRemovedEvent |
+| `chat.user.{account}.event.settings.update` | SettingsUpdateEvent |
 | `chat.user.{account}.event.room.key` | RoomKeyEvent |
 | `chat.room.{roomID}.event` | new_message, message_edited, message_deleted, message_pinned/unpinned, message_reacted, thread_metadata_updated, message_read, thread_message_read, room_renamed, room_restricted |
 | `chat.user.{account}.event.room` | same event types as above, per-user fan-out for DM/botDM rooms |
@@ -157,6 +159,47 @@ fields are sent.
 **Triggered by:** Add Members (`added`), Remove Member (`removed`), Update Member Role
 (`role_updated`), Toggle Mute (`mute_toggled`), Toggle Favorite (`favorite_toggled`),
 Mark Messages Read (`read`) — see [request-reply.md](request-reply.md).
+
+---
+
+## settings.update — user settings sync
+
+**Subject:** `chat.user.{account}.event.settings.update`
+
+Published by user-service after every successful [settings.set](request-reply.md#settingsset)
+— ephemeral core-NATS fan-out to the caller's own connected devices, so other
+logged-in clients sync live. Best-effort: a fan-out failure does not fail the set.
+
+The payload carries the **full post-update settings** — receivers replace their
+local copy, they never merge deltas. A field absent from `settings` was never
+set by the user, and **absent means the client applies its own default** (the
+server never injects defaults).
+
+### Schema (SettingsUpdateEvent)
+
+| Field | Type | Notes |
+|---|---|---|
+| `timestamp` | number | Publish time, Unix ms. |
+| `settings` | UserSettings | Full post-update settings; all seven fields optional. |
+
+UserSettings — every field optional, present only when explicitly set:
+
+| Field | Type |
+|---|---|
+| `fullWidth` | boolean |
+| `translateMessageInto` | string |
+| `showMessagePreviewInSidebarList` | boolean |
+| `muteAllNotifications` | boolean |
+| `showMessagesAndPreviewsInNotifications` | boolean |
+| `showNotificationsDuringCallsAndMeetings` | boolean |
+| `scrollToBottomInChat` | boolean |
+
+```json
+{
+  "timestamp": 1737000000000,
+  "settings": { "fullWidth": false, "translateMessageInto": "ja", "muteAllNotifications": true }
+}
+```
 
 ---
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -1314,7 +1314,8 @@ Top-level JSON array of `SearchUser` (`account`, `engName`?, `chineseName`?).
 
 All user-service subjects: `chat.user.{account}.request.user.{siteID}.<area>.<action>`,
 except `me` — a single-token self-lookup (`chat.user.{account}.request.user.{siteID}.me`).
-No client-facing events are emitted.
+[settings.set](#settingsset) emits [settings.update](events.md#settingsupdate--user-settings-sync);
+no other endpoint emits a client-facing event.
 
 | RPC subject | Method |
 |---|---|
@@ -1322,6 +1323,8 @@ No client-facing events are emitted.
 | `chat.user.{account}.request.user.{siteID}.status.getByName` | [status.getByName](#statusgetbyname) |
 | `chat.user.{account}.request.user.{siteID}.profile.getByName` | [profile.getByName](#profilegetbyname) |
 | `chat.user.{account}.request.user.{siteID}.status.set` | [status.set](#statusset) |
+| `chat.user.{account}.request.user.{siteID}.settings.get` | [settings.get](#settingsget) |
+| `chat.user.{account}.request.user.{siteID}.settings.set` | [settings.set](#settingsset) |
 | `chat.user.{account}.request.user.{siteID}.subscription.list` | [subscription.list](#subscriptionlist) |
 | `chat.user.{account}.request.user.{siteID}.subscription.getChannels` | [subscription.getChannels](#subscriptiongetchannels) |
 | `chat.user.{account}.request.user.{siteID}.subscription.getDM` | [subscription.getDM](#subscriptiongetdm) |
@@ -1420,6 +1423,71 @@ Same shape as `status.getByName`.
 
 **Emits:** None client-facing. (A server-side cross-site federation update fires
 internally but is not delivered to clients.)
+
+---
+
+### settings.get
+
+**Subject:** `chat.user.{account}.request.user.{siteID}.settings.get`
+
+Returns the caller's stored settings **exactly as stored** — `{}` when never set.
+The server never injects defaults; **absent = the client applies its own default**.
+
+#### Request body
+
+None (empty payload).
+
+#### Success response
+
+The stored settings object. All seven fields optional, present only when explicitly set:
+
+| Field | Type |
+|---|---|
+| `fullWidth` | boolean |
+| `translateMessageInto` | string |
+| `showMessagePreviewInSidebarList` | boolean |
+| `muteAllNotifications` | boolean |
+| `showMessagesAndPreviewsInNotifications` | boolean |
+| `showNotificationsDuringCallsAndMeetings` | boolean |
+| `scrollToBottomInChat` | boolean |
+
+`{ "fullWidth": true, "translateMessageInto": "en-US" }`
+
+#### Errors
+
+`"user not found"` (`not_found`).
+
+**Emits:** None.
+
+---
+
+### settings.set
+
+**Subject:** `chat.user.{account}.request.user.{siteID}.settings.set`
+
+Partial update: **only the fields present in the request are written**; unsent
+fields keep their stored value (or stay absent). At least one field required.
+
+#### Request body
+
+Any non-empty subset of the seven settings fields (same table as
+[settings.get](#settingsget)). `translateMessageInto` must be a language-tag
+shape — hyphen-separated letter/digit subtags, leading subtag letters-only
+(e.g. `"en"`, `"en-US"`, `"zh-Hant-TW"`); no value whitelist.
+
+`{ "fullWidth": false, "translateMessageInto": "ja" }`
+
+#### Success response
+
+The **full post-update settings** (same shape as [settings.get](#settingsget)).
+
+#### Errors
+
+`"no settings provided"` (`bad_request`), `"invalid translateMessageInto language tag"`
+(`bad_request`), `"user not found"` (`not_found`).
+
+**Emits:** [settings.update](events.md#settingsupdate--user-settings-sync) to the
+caller's other devices, carrying the full post-update settings.
 
 ---
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -1473,7 +1473,8 @@ fields keep their stored value (or stay absent). At least one field required.
 Any non-empty subset of the seven settings fields (same table as
 [settings.get](#settingsget)). `translateMessageInto` must be a language-tag
 shape — hyphen-separated letter/digit subtags, leading subtag letters-only
-(e.g. `"en"`, `"en-US"`, `"zh-Hant-TW"`); no value whitelist.
+(e.g. `"en"`, `"en-US"`, `"zh-Hant-TW"`) — or `""` to explicitly turn
+translation off; no value whitelist.
 
 `{ "fullWidth": false, "translateMessageInto": "ja" }`
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -1488,7 +1488,9 @@ The **full post-update settings** (same shape as [settings.get](#settingsget)).
 (`bad_request`), `"user not found"` (`not_found`).
 
 **Emits:** [settings.update](events.md#settingsupdate--user-settings-sync) to the
-caller's other devices, carrying the full post-update settings.
+caller's other devices, carrying the full post-update settings. A server-side
+cross-site federation update also fires — every other site receives the full
+settings so its notification worker can apply them — but is not delivered to clients.
 
 ---
 

--- a/docs/superpowers/plans/2026-06-09-user-service-api-doc-refinement.md
+++ b/docs/superpowers/plans/2026-06-09-user-service-api-doc-refinement.md
@@ -108,7 +108,7 @@ git commit -m "docs(client-api): §3.0 schema repairs — Subscription enrichmen
 
 **Files:** Modify `docs/client-api.md` §3.4 status section (lines ~3011–3132).
 
-- [ ] **Step 2.1 — Add a one-line intro note** to §3.4 (after the "Migration note" block, ~line 3022): `> **Events:** these endpoints emit no client-facing events. (`status.set` triggers a server-side cross-site federation update, which is internal and not delivered to clients.)`
+- [ ] **Step 2.1 — Add a one-line intro note** to §3.4 (after the "Migration note" block, ~line 3022): `> **Events:** these endpoints emit no client-facing events. (`status.set` triggers a server-side cross-site federation update, which is server-side only and never delivered to clients.)`
 
 - [ ] **Step 2.2 — Delete the entire `status.set` "Triggered events — success path" block** (currently lines ~3108–3130, the `UserStatusUpdated` payload table + JSON + the publish-errors sentence).
 

--- a/inbox-worker/handler.go
+++ b/inbox-worker/handler.go
@@ -64,6 +64,10 @@ type InboxStore interface {
 	// mark is a no-op so out-of-order multi-site delivery can't regress the status. statusIsShow
 	// is written only when non-nil. A missing user (no doc on this site) is a logged no-op.
 	UpdateUserStatus(ctx context.Context, account, statusText string, statusIsShow *bool, statusUpdatedAt time.Time) error
+	// UpdateUserSettings replaces the local users doc's settings sub-document with the
+	// full post-update settings from the origin site, guarded by settingsUpdatedAt so an
+	// out-of-order or duplicate delivery can't regress. A missing user is a logged no-op.
+	UpdateUserSettings(ctx context.Context, account string, settings *model.UserSettings, updatedAt time.Time) error
 }
 
 // Handler processes cross-site InboxEvent messages; replicates only subscription/room metadata, never room keys.
@@ -108,6 +112,8 @@ func (h *Handler) HandleEvent(ctx context.Context, data []byte) error {
 		return h.handleRoomVisibilityChanged(ctx, &evt)
 	case model.InboxUserStatusUpdated:
 		return h.handleUserStatusUpdated(ctx, &evt)
+	case model.InboxUserSettingsUpdated:
+		return h.handleUserSettingsUpdated(ctx, &evt)
 	default:
 		slog.Warn("unknown event type, skipping", "type", evt.Type)
 		return nil
@@ -342,6 +348,19 @@ func (h *Handler) handleUserStatusUpdated(ctx context.Context, evt *model.InboxE
 	}
 	if err := h.store.UpdateUserStatus(ctx, e.Account, e.StatusText, e.StatusIsShow, time.UnixMilli(e.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("update user status for %q: %w", e.Account, err)
+	}
+	return nil
+}
+
+// handleUserSettingsUpdated mirrors a cross-site settings change onto the local users doc,
+// guarded by the event Timestamp so an out-of-order or duplicate delivery can't regress.
+func (h *Handler) handleUserSettingsUpdated(ctx context.Context, evt *model.InboxEvent) error {
+	var e model.UserSettingsUpdated
+	if err := json.Unmarshal(evt.Payload, &e); err != nil {
+		return fmt.Errorf("unmarshal user_settings_updated payload: %w", err)
+	}
+	if err := h.store.UpdateUserSettings(ctx, e.Account, &e.Settings, time.UnixMilli(e.Timestamp).UTC()); err != nil {
+		return fmt.Errorf("update user settings for %q: %w", e.Account, err)
 	}
 	return nil
 }

--- a/inbox-worker/handler_test.go
+++ b/inbox-worker/handler_test.go
@@ -89,6 +89,13 @@ type stubInboxStore struct {
 	applyThreadReadErr error
 	userStatusUpdates  []userStatusUpdate
 	userStatusErr      error
+	settingsUpdates    []userSettingsUpdate
+}
+
+type userSettingsUpdate struct {
+	account   string
+	settings  *model.UserSettings
+	updatedAt time.Time
 }
 
 type userStatusUpdate struct {
@@ -354,6 +361,21 @@ func (s *stubInboxStore) getUserStatusUpdates() []userStatusUpdate {
 	defer s.mu.Unlock()
 	cp := make([]userStatusUpdate, len(s.userStatusUpdates))
 	copy(cp, s.userStatusUpdates)
+	return cp
+}
+
+func (s *stubInboxStore) UpdateUserSettings(_ context.Context, account string, settings *model.UserSettings, updatedAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.settingsUpdates = append(s.settingsUpdates, userSettingsUpdate{account: account, settings: settings, updatedAt: updatedAt})
+	return nil
+}
+
+func (s *stubInboxStore) getSettingsUpdates() []userSettingsUpdate {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]userSettingsUpdate, len(s.settingsUpdates))
+	copy(cp, s.settingsUpdates)
 	return cp
 }
 
@@ -1774,4 +1796,44 @@ func TestHandler_UserStatusUpdated_StoreError(t *testing.T) {
 	err = h.HandleEvent(context.Background(), evt)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "update user status")
+}
+
+func TestHandler_UserSettingsUpdated(t *testing.T) {
+	store := &stubInboxStore{}
+	h := NewHandler(store)
+
+	mute := true
+	payload, err := json.Marshal(model.UserSettingsUpdated{
+		Account:   "alice",
+		Settings:  model.UserSettings{MuteAllNotifications: &mute},
+		Timestamp: 12345,
+	})
+	require.NoError(t, err)
+	evt, err := json.Marshal(model.InboxEvent{
+		Type: model.InboxUserSettingsUpdated, Payload: payload, Timestamp: 12345,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, h.HandleEvent(context.Background(), evt))
+
+	updates := store.getSettingsUpdates()
+	require.Len(t, updates, 1)
+	assert.Equal(t, "alice", updates[0].account)
+	require.NotNil(t, updates[0].settings.MuteAllNotifications)
+	assert.True(t, *updates[0].settings.MuteAllNotifications)
+	assert.Equal(t, time.UnixMilli(12345).UTC(), updates[0].updatedAt)
+}
+
+func TestHandler_UserSettingsUpdated_MalformedPayload(t *testing.T) {
+	store := &stubInboxStore{}
+	h := NewHandler(store)
+
+	evt, err := json.Marshal(model.InboxEvent{
+		Type:    model.InboxUserSettingsUpdated,
+		Payload: []byte("not-json"),
+	})
+	require.NoError(t, err)
+
+	require.Error(t, h.HandleEvent(context.Background(), evt))
+	assert.Empty(t, store.getSettingsUpdates())
 }

--- a/inbox-worker/integration_test.go
+++ b/inbox-worker/integration_test.go
@@ -1483,28 +1483,35 @@ func TestInboxWorker_UpdateUserSettings_Integration(t *testing.T) {
 		userCol: db.Collection("users"),
 	}
 
-	_, err := db.Collection("users").InsertOne(ctx, model.User{ID: "u1", Account: "alice", SiteID: "site-b"})
-	require.NoError(t, err)
-
 	t1 := time.UnixMilli(1000).UTC()
 	t2 := time.UnixMilli(2000).UTC()
 	yes, no := true, false
 
+	// Each subtest owns its own account so it passes standalone under -run.
+	seed := func(t *testing.T, account string) {
+		t.Helper()
+		_, err := db.Collection("users").InsertOne(ctx, model.User{ID: "u-" + account, Account: account, SiteID: "site-b"})
+		require.NoError(t, err)
+	}
+
 	t.Run("writes the full settings sub-document", func(t *testing.T) {
-		require.NoError(t, store.UpdateUserSettings(ctx, "alice", &model.UserSettings{MuteAllNotifications: &yes}, t1))
+		seed(t, "settings-write")
+		require.NoError(t, store.UpdateUserSettings(ctx, "settings-write", &model.UserSettings{MuteAllNotifications: &yes}, t1))
 
 		var got model.User
-		require.NoError(t, store.userCol.FindOne(ctx, bson.M{"account": "alice"}).Decode(&got))
+		require.NoError(t, store.userCol.FindOne(ctx, bson.M{"account": "settings-write"}).Decode(&got))
 		require.NotNil(t, got.Settings)
 		require.NotNil(t, got.Settings.MuteAllNotifications)
 		assert.True(t, *got.Settings.MuteAllNotifications)
 	})
 
 	t.Run("replaces wholesale — a field dropped by the user is dropped here", func(t *testing.T) {
-		require.NoError(t, store.UpdateUserSettings(ctx, "alice", &model.UserSettings{FullWidth: &no}, t2))
+		seed(t, "settings-replace")
+		require.NoError(t, store.UpdateUserSettings(ctx, "settings-replace", &model.UserSettings{MuteAllNotifications: &yes}, t1))
+		require.NoError(t, store.UpdateUserSettings(ctx, "settings-replace", &model.UserSettings{FullWidth: &no}, t2))
 
 		var got model.User
-		require.NoError(t, store.userCol.FindOne(ctx, bson.M{"account": "alice"}).Decode(&got))
+		require.NoError(t, store.userCol.FindOne(ctx, bson.M{"account": "settings-replace"}).Decode(&got))
 		require.NotNil(t, got.Settings)
 		assert.Nil(t, got.Settings.MuteAllNotifications, "whole-object replace must not merge the previous value")
 		require.NotNil(t, got.Settings.FullWidth)
@@ -1512,10 +1519,12 @@ func TestInboxWorker_UpdateUserSettings_Integration(t *testing.T) {
 	})
 
 	t.Run("stale event is rejected by the settingsUpdatedAt high-water guard", func(t *testing.T) {
-		require.NoError(t, store.UpdateUserSettings(ctx, "alice", &model.UserSettings{MuteAllNotifications: &yes}, t1))
+		seed(t, "settings-stale")
+		require.NoError(t, store.UpdateUserSettings(ctx, "settings-stale", &model.UserSettings{FullWidth: &no}, t2))
+		require.NoError(t, store.UpdateUserSettings(ctx, "settings-stale", &model.UserSettings{MuteAllNotifications: &yes}, t1))
 
 		var got model.User
-		require.NoError(t, store.userCol.FindOne(ctx, bson.M{"account": "alice"}).Decode(&got))
+		require.NoError(t, store.userCol.FindOne(ctx, bson.M{"account": "settings-stale"}).Decode(&got))
 		assert.Nil(t, got.Settings.MuteAllNotifications, "stale settings must not overwrite newer ones")
 		require.NotNil(t, got.Settings.FullWidth)
 	})

--- a/inbox-worker/integration_test.go
+++ b/inbox-worker/integration_test.go
@@ -1472,3 +1472,59 @@ func TestInboxWorker_UpdateUserStatus_Integration(t *testing.T) {
 		assert.Equal(t, int64(0), count)
 	})
 }
+
+func TestInboxWorker_UpdateUserSettings_Integration(t *testing.T) {
+	db := setupMongo(t)
+	ctx := context.Background()
+
+	store := &mongoInboxStore{
+		subCol:  db.Collection("subscriptions"),
+		roomCol: db.Collection("rooms"),
+		userCol: db.Collection("users"),
+	}
+
+	_, err := db.Collection("users").InsertOne(ctx, model.User{ID: "u1", Account: "alice", SiteID: "site-b"})
+	require.NoError(t, err)
+
+	t1 := time.UnixMilli(1000).UTC()
+	t2 := time.UnixMilli(2000).UTC()
+	yes, no := true, false
+
+	t.Run("writes the full settings sub-document", func(t *testing.T) {
+		require.NoError(t, store.UpdateUserSettings(ctx, "alice", &model.UserSettings{MuteAllNotifications: &yes}, t1))
+
+		var got model.User
+		require.NoError(t, store.userCol.FindOne(ctx, bson.M{"account": "alice"}).Decode(&got))
+		require.NotNil(t, got.Settings)
+		require.NotNil(t, got.Settings.MuteAllNotifications)
+		assert.True(t, *got.Settings.MuteAllNotifications)
+	})
+
+	t.Run("replaces wholesale — a field dropped by the user is dropped here", func(t *testing.T) {
+		require.NoError(t, store.UpdateUserSettings(ctx, "alice", &model.UserSettings{FullWidth: &no}, t2))
+
+		var got model.User
+		require.NoError(t, store.userCol.FindOne(ctx, bson.M{"account": "alice"}).Decode(&got))
+		require.NotNil(t, got.Settings)
+		assert.Nil(t, got.Settings.MuteAllNotifications, "whole-object replace must not merge the previous value")
+		require.NotNil(t, got.Settings.FullWidth)
+		assert.False(t, *got.Settings.FullWidth)
+	})
+
+	t.Run("stale event is rejected by the settingsUpdatedAt high-water guard", func(t *testing.T) {
+		require.NoError(t, store.UpdateUserSettings(ctx, "alice", &model.UserSettings{MuteAllNotifications: &yes}, t1))
+
+		var got model.User
+		require.NoError(t, store.userCol.FindOne(ctx, bson.M{"account": "alice"}).Decode(&got))
+		assert.Nil(t, got.Settings.MuteAllNotifications, "stale settings must not overwrite newer ones")
+		require.NotNil(t, got.Settings.FullWidth)
+	})
+
+	t.Run("unknown account is a no-op", func(t *testing.T) {
+		require.NoError(t, store.UpdateUserSettings(ctx, "ghost", &model.UserSettings{FullWidth: &yes}, t2))
+
+		count, err := store.userCol.CountDocuments(ctx, bson.M{"account": "ghost"})
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), count)
+	})
+}

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -197,6 +197,35 @@ func (s *mongoInboxStore) UpdateUserStatus(ctx context.Context, account, statusT
 	return nil
 }
 
+// UpdateUserSettings replaces the local users doc's settings sub-document with the origin
+// site's full post-update settings — whole-object, so a field the user cleared is cleared
+// here too. A missing user (no doc on this site) is a silent no-op.
+func (s *mongoInboxStore) UpdateUserSettings(ctx context.Context, account string, settings *model.UserSettings, updatedAt time.Time) error {
+	// Guard on the settingsUpdatedAt high-water mark so an out-of-order or duplicate event
+	// (settings fan to all sites) can't regress to older settings.
+	filter := bson.M{"account": account, "$or": bson.A{
+		bson.M{"settingsUpdatedAt": bson.M{"$exists": false}},
+		bson.M{"settingsUpdatedAt": bson.M{"$lt": updatedAt}},
+	}}
+	set := bson.M{"settings": settings, "settingsUpdatedAt": updatedAt}
+	res, err := s.userCol.UpdateOne(ctx, filter, bson.M{"$set": set})
+	if err != nil {
+		return fmt.Errorf("update user settings for %q: %w", account, err)
+	}
+	if res.MatchedCount == 0 {
+		// Same reasoning as UpdateUserStatus: the write already committed, so a failed
+		// existence check must not Nak/retry — it only picks the warn message.
+		count, cerr := s.userCol.CountDocuments(ctx, bson.M{"account": account})
+		switch {
+		case cerr != nil:
+			slog.WarnContext(ctx, "user existence check failed, skipping unknown-account log", "account", account, "error", cerr)
+		case count == 0:
+			slog.WarnContext(ctx, "user_settings_updated for unknown account, skipping", "account", account)
+		}
+	}
+	return nil
+}
+
 // BulkCreateSubscriptions inserts the supplied subs idempotently. Each is
 // keyed by (roomId, u.account) and written via $setOnInsert so an existing
 // sub (from a previous delivery, or with read-state already accumulated) is

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -178,21 +178,8 @@ func (s *mongoInboxStore) UpdateUserStatus(ctx context.Context, account, statusT
 		bson.M{"statusUpdatedAt": bson.M{"$exists": false}},
 		bson.M{"statusUpdatedAt": bson.M{"$lt": statusUpdatedAt}},
 	}}
-	res, err := s.userCol.UpdateOne(ctx, filter, bson.M{"$set": set})
-	if err != nil {
+	if _, err := s.userCol.UpdateOne(ctx, filter, bson.M{"$set": set}); err != nil {
 		return fmt.Errorf("update user status for %q: %w", account, err)
-	}
-	if res.MatchedCount == 0 {
-		// The UpdateOne above already committed; MatchedCount==0 is a correct no-op (account not on
-		// this site, or a stale event the guard rejected). CountDocuments only picks the warn
-		// message, so a failure here must not Nak/retry an already-applied write — log and move on.
-		count, cerr := s.userCol.CountDocuments(ctx, bson.M{"account": account})
-		switch {
-		case cerr != nil:
-			slog.WarnContext(ctx, "user existence check failed, skipping unknown-account log", "account", account, "error", cerr)
-		case count == 0:
-			slog.WarnContext(ctx, "user_status_updated for unknown account, skipping", "account", account)
-		}
 	}
 	return nil
 }
@@ -208,20 +195,8 @@ func (s *mongoInboxStore) UpdateUserSettings(ctx context.Context, account string
 		bson.M{"settingsUpdatedAt": bson.M{"$lt": updatedAt}},
 	}}
 	set := bson.M{"settings": settings, "settingsUpdatedAt": updatedAt}
-	res, err := s.userCol.UpdateOne(ctx, filter, bson.M{"$set": set})
-	if err != nil {
+	if _, err := s.userCol.UpdateOne(ctx, filter, bson.M{"$set": set}); err != nil {
 		return fmt.Errorf("update user settings for %q: %w", account, err)
-	}
-	if res.MatchedCount == 0 {
-		// Same reasoning as UpdateUserStatus: the write already committed, so a failed
-		// existence check must not Nak/retry — it only picks the warn message.
-		count, cerr := s.userCol.CountDocuments(ctx, bson.M{"account": account})
-		switch {
-		case cerr != nil:
-			slog.WarnContext(ctx, "user existence check failed, skipping unknown-account log", "account", account, "error", cerr)
-		case count == 0:
-			slog.WarnContext(ctx, "user_settings_updated for unknown account, skipping", "account", account)
-		}
 	}
 	return nil
 }

--- a/inbox-worker/mock_store_test.go
+++ b/inbox-worker/mock_store_test.go
@@ -197,6 +197,20 @@ func (mr *MockInboxStoreMockRecorder) UpdateSubscriptionRoles(ctx, account, room
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubscriptionRoles", reflect.TypeOf((*MockInboxStore)(nil).UpdateSubscriptionRoles), ctx, account, roomID, roles, rolesUpdatedAt)
 }
 
+// UpdateUserSettings mocks base method.
+func (m *MockInboxStore) UpdateUserSettings(ctx context.Context, account string, settings *model.UserSettings, updatedAt time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateUserSettings", ctx, account, settings, updatedAt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateUserSettings indicates an expected call of UpdateUserSettings.
+func (mr *MockInboxStoreMockRecorder) UpdateUserSettings(ctx, account, settings, updatedAt any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserSettings", reflect.TypeOf((*MockInboxStore)(nil).UpdateUserSettings), ctx, account, settings, updatedAt)
+}
+
 // UpdateUserStatus mocks base method.
 func (m *MockInboxStore) UpdateUserStatus(ctx context.Context, account, statusText string, statusIsShow *bool, statusUpdatedAt time.Time) error {
 	m.ctrl.T.Helper()

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -164,7 +164,18 @@ const (
 	InboxRoomRenamed                 InboxEventType = "room_renamed"
 	InboxRoomRestricted              InboxEventType = "room_restricted"
 	InboxUserStatusUpdated           InboxEventType = "user_status_updated"
+	InboxUserSettingsUpdated         InboxEventType = "user_settings_updated"
 )
+
+// UserSettingsUpdated is the cross-site inbox event user-service publishes on
+// settings.set; the remote inbox-worker applies it so the local notification
+// worker can read the user's notification preferences. Settings is the full
+// post-update sub-document — the receiver replaces, never merges.
+type UserSettingsUpdated struct {
+	Account   string       `json:"account"   bson:"account"`
+	Settings  UserSettings `json:"settings"  bson:"settings"`
+	Timestamp int64        `json:"timestamp" bson:"timestamp"`
+}
 
 // SubscriptionReadEvent is the InboxEvent.Payload for type
 // "subscription_read". Sent from a room's home site to the user's home site

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -4144,6 +4144,40 @@ func TestUserStatusUpdated_RoundTrip(t *testing.T) {
 	roundTrip(t, &src, &dst)
 }
 
+func TestUserSettingsUpdated_RoundTrip(t *testing.T) {
+	mute, width := true, false
+	lang := "ja"
+	src := model.UserSettingsUpdated{
+		Account: "alice",
+		Settings: model.UserSettings{
+			MuteAllNotifications: &mute,
+			FullWidth:            &width,
+			TranslateMessageInto: &lang,
+		},
+		Timestamp: 1735689600000,
+	}
+	dst := model.UserSettingsUpdated{}
+	roundTrip(t, &src, &dst)
+}
+
+func TestUserSettingsUpdated_UnsetSettingsOmittedFromJSON(t *testing.T) {
+	mute := true
+	src := model.UserSettingsUpdated{
+		Account:   "alice",
+		Settings:  model.UserSettings{MuteAllNotifications: &mute},
+		Timestamp: 1735689600000,
+	}
+	data, err := json.Marshal(&src)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	settings, ok := raw["settings"].(map[string]any)
+	require.True(t, ok)
+	_, present := settings["fullWidth"]
+	assert.False(t, present, "an unset setting must be omitted, so absent keeps meaning client-default")
+}
+
 func TestUserStatusUpdated_StatusIsShowOmittedWhenNil(t *testing.T) {
 	src := model.UserStatusUpdated{
 		Account:    "alice",

--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -64,6 +64,8 @@ type User struct {
 	RequirePasswordChange bool       `json:"requirePasswordChange,omitempty" bson:"requirePasswordChange,omitempty"`
 	Deactivated           bool       `json:"deactivated,omitempty"           bson:"deactivated,omitempty"`
 	Services              Services   `json:"-"                               bson:"services,omitempty"`
+	// Settings is the per-user client-preferences sub-document; nil = never set.
+	Settings *UserSettings `json:"settings,omitempty" bson:"settings,omitempty"`
 }
 
 // String formats a User for log lines, deliberately omitting the bcrypt hash

--- a/pkg/model/usersettings.go
+++ b/pkg/model/usersettings.go
@@ -1,0 +1,23 @@
+package model
+
+// UserSettings is the per-user client-preferences sub-document on the user
+// record. Every field is optional: absent means the client applies its own
+// default — the server stores only what the user explicitly set and never
+// injects defaults.
+type UserSettings struct {
+	FullWidth                               *bool   `json:"fullWidth,omitempty"                               bson:"fullWidth,omitempty"`
+	TranslateMessageInto                    *string `json:"translateMessageInto,omitempty"                    bson:"translateMessageInto,omitempty"`
+	ShowMessagePreviewInSidebarList         *bool   `json:"showMessagePreviewInSidebarList,omitempty"         bson:"showMessagePreviewInSidebarList,omitempty"`
+	MuteAllNotifications                    *bool   `json:"muteAllNotifications,omitempty"                    bson:"muteAllNotifications,omitempty"`
+	ShowMessagesAndPreviewsInNotifications  *bool   `json:"showMessagesAndPreviewsInNotifications,omitempty"  bson:"showMessagesAndPreviewsInNotifications,omitempty"`
+	ShowNotificationsDuringCallsAndMeetings *bool   `json:"showNotificationsDuringCallsAndMeetings,omitempty" bson:"showNotificationsDuringCallsAndMeetings,omitempty"`
+	ScrollToBottomInChat                    *bool   `json:"scrollToBottomInChat,omitempty"                    bson:"scrollToBottomInChat,omitempty"`
+}
+
+// SettingsUpdateEvent is the client-facing settings.update fanout payload.
+// It carries the full post-update settings so other devices replace their
+// copy rather than merge deltas. Timestamp is the publish time (ms).
+type SettingsUpdateEvent struct {
+	Timestamp int64        `json:"timestamp"`
+	Settings  UserSettings `json:"settings"`
+}

--- a/pkg/model/usersettings.go
+++ b/pkg/model/usersettings.go
@@ -14,6 +14,15 @@ type UserSettings struct {
 	ScrollToBottomInChat                    *bool   `json:"scrollToBottomInChat,omitempty"                    bson:"scrollToBottomInChat,omitempty"`
 }
 
+// IsEmpty reports whether no field is set — the "nothing to write" guard for
+// partial updates.
+func (s *UserSettings) IsEmpty() bool {
+	return s.FullWidth == nil && s.TranslateMessageInto == nil &&
+		s.ShowMessagePreviewInSidebarList == nil && s.MuteAllNotifications == nil &&
+		s.ShowMessagesAndPreviewsInNotifications == nil &&
+		s.ShowNotificationsDuringCallsAndMeetings == nil && s.ScrollToBottomInChat == nil
+}
+
 // SettingsUpdateEvent is the client-facing settings.update fanout payload.
 // It carries the full post-update settings so other devices replace their
 // copy rather than merge deltas. Timestamp is the publish time (ms).

--- a/pkg/model/usersettings_test.go
+++ b/pkg/model/usersettings_test.go
@@ -1,0 +1,37 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Never-set settings must marshal as {} — the server never injects defaults.
+func TestUserSettings_EmptyMarshalsAsEmptyObject(t *testing.T) {
+	data, err := json.Marshal(UserSettings{})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{}`, string(data))
+}
+
+// A partial settings object round-trips with only the sent fields present.
+func TestUserSettings_PartialRoundTrip(t *testing.T) {
+	fw, lang := true, "en-US"
+	in := UserSettings{FullWidth: &fw, TranslateMessageInto: &lang}
+	data, err := json.Marshal(in)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"fullWidth":true,"translateMessageInto":"en-US"}`, string(data))
+
+	var out UserSettings
+	require.NoError(t, json.Unmarshal(data, &out))
+	assert.Equal(t, in, out)
+	assert.Nil(t, out.MuteAllNotifications)
+}
+
+func TestSettingsUpdateEvent_Shape(t *testing.T) {
+	fw := false
+	data, err := json.Marshal(SettingsUpdateEvent{Timestamp: 123, Settings: UserSettings{FullWidth: &fw}})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"timestamp":123,"settings":{"fullWidth":false}}`, string(data))
+}

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -183,6 +183,13 @@ func SubscriptionUpdate(account string) string {
 	return fmt.Sprintf("chat.user.%s.event.subscription.update", account)
 }
 
+// SettingsUpdate is the client-facing fanout subject published by
+// user-service after a successful settings.set (same delivery pattern as
+// subscription.update — ephemeral, core NATS).
+func SettingsUpdate(account string) string {
+	return fmt.Sprintf("chat.user.%s.event.settings.update", account)
+}
+
 func RoomMetadataChanged(account string) string {
 	return fmt.Sprintf("chat.user.%s.event.room.metadata.update", account)
 }
@@ -1066,6 +1073,28 @@ func UserSubscriptionListPattern(siteID string) string {
 	return fmt.Sprintf("chat.user.{account}.request.user.%s.subscription.list", siteID)
 }
 
+func UserSettingsGet(account, siteID string) string {
+	if !isValidAccountToken(account) {
+		panic("invalid account token: contains NATS wildcard characters")
+	}
+	return fmt.Sprintf("chat.user.%s.request.user.%s.settings.get", account, siteID)
+}
+
+func UserSettingsGetPattern(siteID string) string {
+	return fmt.Sprintf("chat.user.{account}.request.user.%s.settings.get", siteID)
+}
+
+func UserSettingsSet(account, siteID string) string {
+	if !isValidAccountToken(account) {
+		panic("invalid account token: contains NATS wildcard characters")
+	}
+	return fmt.Sprintf("chat.user.%s.request.user.%s.settings.set", account, siteID)
+}
+
+func UserSettingsSetPattern(siteID string) string {
+	return fmt.Sprintf("chat.user.{account}.request.user.%s.settings.set", siteID)
+}
+
 // UserThreadList is the concrete client-facing subject for the cross-site thread
 // inbox RPC. siteID is the CALLER's own home site — the site that holds the
 // user's federated subscriptions and runs the aggregator. Pair with
@@ -1141,7 +1170,7 @@ func UserSubscriptionGetByRoomIDPattern(siteID string) string {
 //
 //	chat.user.{account}.request.user.{siteID}.{area}.{action}
 //
-// where area is one of "status", "subscription", "profile", "apps".
+// where area is one of "status", "subscription", "profile", "apps", "settings".
 // Does NOT match the room-scoped form — use ParseRoomSubject for those.
 func ParseUserSubject(subj string) (account, siteID, area, action string, ok bool) {
 	parts := strings.Split(subj, ".")
@@ -1155,7 +1184,7 @@ func ParseUserSubject(subj string) (account, siteID, area, action string, ok boo
 		return "", "", "", "", false
 	}
 	switch parts[6] {
-	case "status", "subscription", "profile", "apps":
+	case "status", "subscription", "profile", "apps", "settings":
 	default:
 		return "", "", "", "", false
 	}

--- a/pkg/subject/subject_test.go
+++ b/pkg/subject/subject_test.go
@@ -36,6 +36,8 @@ func TestSubjectBuilders(t *testing.T) {
 			"chat.room.canonical.site-a.teams.create"},
 		{"SubscriptionUpdate", subject.SubscriptionUpdate("alice"),
 			"chat.user.alice.event.subscription.update"},
+		{"SettingsUpdate", subject.SettingsUpdate("alice"),
+			"chat.user.alice.event.settings.update"},
 		{"RoomMetadataChanged", subject.RoomMetadataChanged("alice"),
 			"chat.user.alice.event.room.metadata.update"},
 		{"Notification", subject.Notification("alice"),
@@ -542,6 +544,8 @@ func TestUserServiceBuilders(t *testing.T) {
 		{"subscription.setAppSubscription", subject.UserSubscriptionSetAppSubscription("alice", "s1"), "chat.user.alice.request.user.s1.subscription.setAppSubscription"},
 		{"subscription.getByRoomID", subject.UserSubscriptionGetByRoomID("alice", "s1"), "chat.user.alice.request.user.s1.subscription.getByRoomID"},
 		{"me", subject.UserMe("alice", "s1"), "chat.user.alice.request.user.s1.me"},
+		{"settings.get", subject.UserSettingsGet("alice", "s1"), "chat.user.alice.request.user.s1.settings.get"},
+		{"settings.set", subject.UserSettingsSet("alice", "s1"), "chat.user.alice.request.user.s1.settings.set"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -710,6 +714,8 @@ func TestUserServiceBuildersRejectWildcardAccounts(t *testing.T) {
 		{"UserSubscriptionSetAppSubscription", func() { subject.UserSubscriptionSetAppSubscription("*", "s1") }},
 		{"UserSubscriptionGetByRoomID", func() { subject.UserSubscriptionGetByRoomID(">", "s1") }},
 		{"UserMe", func() { subject.UserMe("*", "s1") }},
+		{"UserSettingsGet", func() { subject.UserSettingsGet("*", "s1") }},
+		{"UserSettingsSet", func() { subject.UserSettingsSet(">", "s1") }},
 	}
 	for _, b := range builders {
 		t.Run(b.name, func(t *testing.T) {
@@ -829,6 +835,8 @@ func TestUserServicePatternBuilders(t *testing.T) {
 		{"subscription.setAppSubscription", subject.UserSubscriptionSetAppSubscriptionPattern("s1"), "chat.user.{account}.request.user.s1.subscription.setAppSubscription"},
 		{"subscription.getByRoomID", subject.UserSubscriptionGetByRoomIDPattern("s1"), "chat.user.{account}.request.user.s1.subscription.getByRoomID"},
 		{"me", subject.UserMePattern("s1"), "chat.user.{account}.request.user.s1.me"},
+		{"settings.get", subject.UserSettingsGetPattern("s1"), "chat.user.{account}.request.user.s1.settings.get"},
+		{"settings.set", subject.UserSettingsSetPattern("s1"), "chat.user.{account}.request.user.s1.settings.set"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/user-service/main.go
+++ b/user-service/main.go
@@ -30,6 +30,7 @@ var (
 	_ service.HistoryClient                = (*historyclient.Client)(nil)
 	_ service.PresenceClient               = (*presenceclient.Client)(nil)
 	_ service.EventPublisher               = (*publisher.Publisher)(nil)
+	_ service.EventPublisher               = (*publisher.CorePublisher)(nil)
 )
 
 func main() {
@@ -87,7 +88,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	svc := service.New(subRepo, userRepo, appRepo, threadSubRepo, roomclient.New(nc, cfg.SiteID), historyclient.New(nc), presenceclient.New(nc), publisher.New(js), &cfg)
+	svc := service.New(subRepo, userRepo, appRepo, threadSubRepo, roomclient.New(nc, cfg.SiteID), historyclient.New(nc), presenceclient.New(nc), publisher.New(js), publisher.NewCore(nc), &cfg)
 
 	router := natsrouter.New(nc, "user-service")
 	router.Use(natsrouter.Recovery())

--- a/user-service/models/settings.go
+++ b/user-service/models/settings.go
@@ -1,0 +1,10 @@
+package models
+
+import "github.com/hmchangw/chat/pkg/model"
+
+// SettingsSetRequest is the body of settings.set — a partial update: only the
+// fields present in the request are written; at least one is required.
+// The embedded UserSettings inlines the seven optional fields.
+type SettingsSetRequest struct {
+	model.UserSettings
+}

--- a/user-service/models/settings_test.go
+++ b/user-service/models/settings_test.go
@@ -1,0 +1,21 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The embedded UserSettings must inline its fields at the top level of the
+// request body — clients send {"fullWidth":true}, not {"userSettings":{...}}.
+func TestSettingsSetRequest_FieldsInlineAtTopLevel(t *testing.T) {
+	var req SettingsSetRequest
+	require.NoError(t, json.Unmarshal([]byte(`{"fullWidth":true,"translateMessageInto":"en-US"}`), &req))
+	require.NotNil(t, req.FullWidth)
+	assert.True(t, *req.FullWidth)
+	require.NotNil(t, req.TranslateMessageInto)
+	assert.Equal(t, "en-US", *req.TranslateMessageInto)
+	assert.Nil(t, req.ScrollToBottomInChat)
+}

--- a/user-service/mongorepo/settings_test.go
+++ b/user-service/mongorepo/settings_test.go
@@ -1,0 +1,103 @@
+//go:build integration
+
+package mongorepo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/hmchangw/chat/pkg/model"
+)
+
+func ptrBool(b bool) *bool    { return &b }
+func ptrStr(s string) *string { return &s }
+
+func TestGetUserSettings_Integration(t *testing.T) {
+	r, db := newTestUserRepo(t)
+	ctx := context.Background()
+	seed(t, db, "users",
+		bson.M{"_id": "u-alice", "account": "alice", "active": true},
+		bson.M{"_id": "u-bob", "account": "bob", "active": true,
+			"settings": bson.M{"fullWidth": true, "translateMessageInto": "en-US"}},
+		bson.M{"_id": "u-ghost", "account": "ghost", "active": false,
+			"settings": bson.M{"fullWidth": true}},
+	)
+
+	t.Run("never-set settings come back nil", func(t *testing.T) {
+		u, err := r.GetUserSettings(ctx, "alice")
+		require.NoError(t, err)
+		require.NotNil(t, u)
+		assert.Nil(t, u.Settings)
+	})
+
+	t.Run("stored sub-document round-trips", func(t *testing.T) {
+		u, err := r.GetUserSettings(ctx, "bob")
+		require.NoError(t, err)
+		require.NotNil(t, u)
+		require.NotNil(t, u.Settings)
+		assert.Equal(t, ptrBool(true), u.Settings.FullWidth)
+		assert.Equal(t, ptrStr("en-US"), u.Settings.TranslateMessageInto)
+		assert.Nil(t, u.Settings.MuteAllNotifications)
+	})
+
+	t.Run("inactive user dropped", func(t *testing.T) {
+		u, err := r.GetUserSettings(ctx, "ghost")
+		require.NoError(t, err)
+		assert.Nil(t, u)
+	})
+
+	t.Run("missing user not found", func(t *testing.T) {
+		u, err := r.GetUserSettings(ctx, "nobody")
+		require.NoError(t, err)
+		assert.Nil(t, u)
+	})
+}
+
+func TestUpdateUserSettings_PartialSet_Integration(t *testing.T) {
+	r, db := newTestUserRepo(t)
+	ctx := context.Background()
+	seed(t, db, "users",
+		bson.M{"_id": "u-alice", "account": "alice", "active": true,
+			"settings": bson.M{"fullWidth": true, "muteAllNotifications": true}},
+	)
+
+	// Partial update: only translateMessageInto + fullWidth sent.
+	u, err := r.UpdateUserSettings(ctx, "alice", &model.UserSettings{
+		FullWidth:            ptrBool(false),
+		TranslateMessageInto: ptrStr("ja"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, u)
+	require.NotNil(t, u.Settings)
+	assert.Equal(t, ptrBool(false), u.Settings.FullWidth, "sent field updated")
+	assert.Equal(t, ptrStr("ja"), u.Settings.TranslateMessageInto, "sent field created")
+	assert.Equal(t, ptrBool(true), u.Settings.MuteAllNotifications, "unsent field keeps stored value")
+	assert.Nil(t, u.Settings.ScrollToBottomInChat, "unsent absent field stays absent")
+}
+
+func TestUpdateUserSettings_FirstSetCreatesSubDocument_Integration(t *testing.T) {
+	r, db := newTestUserRepo(t)
+	ctx := context.Background()
+	seed(t, db, "users", bson.M{"_id": "u-alice", "account": "alice", "active": true})
+
+	u, err := r.UpdateUserSettings(ctx, "alice", &model.UserSettings{ScrollToBottomInChat: ptrBool(true)})
+	require.NoError(t, err)
+	require.NotNil(t, u)
+	require.NotNil(t, u.Settings)
+	assert.Equal(t, ptrBool(true), u.Settings.ScrollToBottomInChat)
+	assert.Nil(t, u.Settings.FullWidth)
+}
+
+func TestUpdateUserSettings_NoActiveUser_Integration(t *testing.T) {
+	r, db := newTestUserRepo(t)
+	ctx := context.Background()
+	seed(t, db, "users", bson.M{"_id": "u-ghost", "account": "ghost", "active": false})
+
+	u, err := r.UpdateUserSettings(ctx, "ghost", &model.UserSettings{FullWidth: ptrBool(true)})
+	require.NoError(t, err)
+	assert.Nil(t, u)
+}

--- a/user-service/mongorepo/users.go
+++ b/user-service/mongorepo/users.go
@@ -93,6 +93,59 @@ func (r *UserRepo) GetHRInfoByAccounts(ctx context.Context, accounts []string) (
 	return out, nil
 }
 
+// GetUserSettings returns the user's stored settings sub-document (Settings is
+// nil when never set); (nil, nil) when no active user matched.
+func (r *UserRepo) GetUserSettings(ctx context.Context, account string) (*model.User, error) {
+	return r.users.FindOne(ctx, activeUserFilter(account),
+		mongoutil.WithProjection(bson.M{"_id": 0, "settings": 1}),
+	)
+}
+
+// UpdateUserSettings $sets settings.<field> for each non-nil field in set —
+// unsent fields keep their stored value or stay absent — and returns the
+// updated user (Settings projected) in one round-trip via
+// FindOneAndUpdate(After); returns (nil, nil) when no active user matched.
+// The caller guarantees at least one field is non-nil (an empty $set errors).
+func (r *UserRepo) UpdateUserSettings(ctx context.Context, account string, set *model.UserSettings) (*model.User, error) {
+	fields := bson.M{}
+	if set.FullWidth != nil {
+		fields["settings.fullWidth"] = *set.FullWidth
+	}
+	if set.TranslateMessageInto != nil {
+		fields["settings.translateMessageInto"] = *set.TranslateMessageInto
+	}
+	if set.ShowMessagePreviewInSidebarList != nil {
+		fields["settings.showMessagePreviewInSidebarList"] = *set.ShowMessagePreviewInSidebarList
+	}
+	if set.MuteAllNotifications != nil {
+		fields["settings.muteAllNotifications"] = *set.MuteAllNotifications
+	}
+	if set.ShowMessagesAndPreviewsInNotifications != nil {
+		fields["settings.showMessagesAndPreviewsInNotifications"] = *set.ShowMessagesAndPreviewsInNotifications
+	}
+	if set.ShowNotificationsDuringCallsAndMeetings != nil {
+		fields["settings.showNotificationsDuringCallsAndMeetings"] = *set.ShowNotificationsDuringCallsAndMeetings
+	}
+	if set.ScrollToBottomInChat != nil {
+		fields["settings.scrollToBottomInChat"] = *set.ScrollToBottomInChat
+	}
+	opts := options.FindOneAndUpdate().
+		SetReturnDocument(options.After).
+		SetProjection(bson.M{"_id": 0, "settings": 1})
+	res := r.users.Raw().FindOneAndUpdate(ctx, activeUserFilter(account), bson.M{"$set": fields}, opts)
+	if err := res.Err(); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("update user settings: %w", err)
+	}
+	var u model.User
+	if err := res.Decode(&u); err != nil {
+		return nil, fmt.Errorf("decode updated user settings: %w", err)
+	}
+	return &u, nil
+}
+
 // SetUserStatus updates status fields (isShow only written when non-nil) and
 // returns the updated user in one round-trip via FindOneAndUpdate(After),
 // projected to the UserStatusView fields; returns (nil, nil) when no active user matched.

--- a/user-service/publisher/core.go
+++ b/user-service/publisher/core.go
@@ -1,0 +1,29 @@
+package publisher
+
+import (
+	"context"
+	"fmt"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+
+	"github.com/hmchangw/chat/pkg/natsutil"
+)
+
+// CorePublisher implements service.EventPublisher over core NATS for
+// ephemeral client-facing fanout events (e.g. settings.update) — best-effort
+// delivery to currently connected clients, no stream persistence, so no
+// stream needs to own the subject (same delivery pattern as room-worker's
+// subscription.update).
+type CorePublisher struct{ nc *o11ynats.Conn }
+
+// NewCore returns a CorePublisher backed by the given connection.
+func NewCore(nc *o11ynats.Conn) *CorePublisher { return &CorePublisher{nc: nc} }
+
+// Publish sends data to subject via a core-NATS PublishMsg so X-Request-ID
+// from ctx propagates onto the outgoing message.
+func (p *CorePublisher) Publish(ctx context.Context, subject string, data []byte) error {
+	if err := p.nc.PublishMsg(ctx, natsutil.NewMsg(ctx, subject, data)); err != nil {
+		return fmt.Errorf("publish client event: %w", err)
+	}
+	return nil
+}

--- a/user-service/service/me_test.go
+++ b/user-service/service/me_test.go
@@ -29,6 +29,7 @@ func newMeSvc(t *testing.T) (*UserService, *mocks.MockUserRepository, *mocks.Moc
 		mocks.NewMockHistoryClient(ctrl),
 		presence,
 		mocks.NewMockEventPublisher(ctrl),
+		mocks.NewMockEventPublisher(ctrl),
 		cfg,
 	)
 	return svc, users, presence

--- a/user-service/service/mocks/mock_repository.go
+++ b/user-service/service/mocks/mock_repository.go
@@ -201,6 +201,21 @@ func (mr *MockUserRepositoryMockRecorder) GetHRInfoByAccounts(ctx, accounts any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHRInfoByAccounts", reflect.TypeOf((*MockUserRepository)(nil).GetHRInfoByAccounts), ctx, accounts)
 }
 
+// GetUserSettings mocks base method.
+func (m *MockUserRepository) GetUserSettings(ctx context.Context, account string) (*model.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserSettings", ctx, account)
+	ret0, _ := ret[0].(*model.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserSettings indicates an expected call of GetUserSettings.
+func (mr *MockUserRepositoryMockRecorder) GetUserSettings(ctx, account any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserSettings", reflect.TypeOf((*MockUserRepository)(nil).GetUserSettings), ctx, account)
+}
+
 // GetUserStatus mocks base method.
 func (m *MockUserRepository) GetUserStatus(ctx context.Context, account string) (*model.User, error) {
 	m.ctrl.T.Helper()
@@ -229,6 +244,21 @@ func (m *MockUserRepository) SetUserStatus(ctx context.Context, account, text st
 func (mr *MockUserRepositoryMockRecorder) SetUserStatus(ctx, account, text, isShow any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUserStatus", reflect.TypeOf((*MockUserRepository)(nil).SetUserStatus), ctx, account, text, isShow)
+}
+
+// UpdateUserSettings mocks base method.
+func (m *MockUserRepository) UpdateUserSettings(ctx context.Context, account string, set *model.UserSettings) (*model.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateUserSettings", ctx, account, set)
+	ret0, _ := ret[0].(*model.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateUserSettings indicates an expected call of UpdateUserSettings.
+func (mr *MockUserRepositoryMockRecorder) UpdateUserSettings(ctx, account, set any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserSettings", reflect.TypeOf((*MockUserRepository)(nil).UpdateUserSettings), ctx, account, set)
 }
 
 // MockAppRepository is a mock of AppRepository interface.

--- a/user-service/service/service.go
+++ b/user-service/service/service.go
@@ -30,6 +30,8 @@ type UserRepository interface {
 	GetUserStatus(ctx context.Context, account string) (*model.User, error)
 	SetUserStatus(ctx context.Context, account, text string, isShow *bool) (*model.User, error)
 	GetHRInfoByAccounts(ctx context.Context, accounts []string) (map[string]*model.SubscriptionHRInfo, error)
+	GetUserSettings(ctx context.Context, account string) (*model.User, error)
+	UpdateUserSettings(ctx context.Context, account string, set *model.UserSettings) (*model.User, error)
 }
 
 // AppRepository is the consumer-defined interface for app catalog reads.
@@ -76,14 +78,17 @@ type EventPublisher interface {
 
 // UserService handles all user-related NATS request/reply endpoints.
 type UserService struct {
-	subs            SubscriptionRepository
-	users           UserRepository
-	apps            AppRepository
-	threadSubs      ThreadSubscriptionRepository
-	rooms           RoomClient
-	history         HistoryClient
-	presence        PresenceClient
-	pub             EventPublisher
+	subs       SubscriptionRepository
+	users      UserRepository
+	apps       AppRepository
+	threadSubs ThreadSubscriptionRepository
+	rooms      RoomClient
+	history    HistoryClient
+	presence   PresenceClient
+	pub        EventPublisher
+	// clientPub fans out ephemeral client-facing events (settings.update) over
+	// core NATS — same delivery pattern as room-worker's subscription.update.
+	clientPub       EventPublisher
 	siteID          string
 	allSiteIDs      []string
 	maxSubs         int
@@ -94,7 +99,7 @@ type UserService struct {
 }
 
 // New constructs a UserService with the given dependencies and configuration.
-func New(subs SubscriptionRepository, users UserRepository, apps AppRepository, threadSubs ThreadSubscriptionRepository, rooms RoomClient, history HistoryClient, presence PresenceClient, pub EventPublisher, cfg *config.Config) *UserService {
+func New(subs SubscriptionRepository, users UserRepository, apps AppRepository, threadSubs ThreadSubscriptionRepository, rooms RoomClient, history HistoryClient, presence PresenceClient, pub, clientPub EventPublisher, cfg *config.Config) *UserService {
 	return &UserService{
 		subs:            subs,
 		users:           users,
@@ -104,6 +109,7 @@ func New(subs SubscriptionRepository, users UserRepository, apps AppRepository, 
 		history:         history,
 		presence:        presence,
 		pub:             pub,
+		clientPub:       clientPub,
 		siteID:          cfg.SiteID,
 		allSiteIDs:      cfg.AllSiteIDs,
 		maxSubs:         cfg.MaxSubscriptionLimit,
@@ -121,6 +127,8 @@ func (s *UserService) RegisterHandlers(r *natsrouter.Router) {
 	natsrouter.Register(r, subject.UserStatusGetByNamePattern(s.siteID), s.GetStatusByName)
 	natsrouter.Register(r, subject.UserProfileGetByNamePattern(s.siteID), s.GetProfileByName)
 	natsrouter.Register(r, subject.UserStatusSetPattern(s.siteID), s.SetStatus)
+	natsrouter.RegisterNoBody(r, subject.UserSettingsGetPattern(s.siteID), s.GetSettings)
+	natsrouter.Register(r, subject.UserSettingsSetPattern(s.siteID), s.SetSettings)
 	natsrouter.Register(r, subject.UserSubscriptionListPattern(s.siteID), s.ListSubscriptions)
 	natsrouter.Register(r, subject.UserThreadListPattern(s.siteID), s.ListUserThreads)
 	natsrouter.Register(r, subject.UserThreadUnreadSummaryPattern(s.siteID), s.GetThreadUnreadSummary)

--- a/user-service/service/service_test.go
+++ b/user-service/service/service_test.go
@@ -32,7 +32,9 @@ func newSvc(t *testing.T) (*UserService, *mocks.MockSubscriptionRepository, *moc
 	// countUnread's thread phase reads thread-subs; default to none so room-count
 	// tests that don't exercise threads need no per-test stub.
 	threadSubs.EXPECT().ListByAccount(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
-	return New(subs, users, apps, threadSubs, rooms, history, presence, pub, cfg), subs, users, apps, rooms, history, pub
+	// The same mock backs both publishers (federation + client fanout) —
+	// expectations are subject-scoped, so tests stay unambiguous.
+	return New(subs, users, apps, threadSubs, rooms, history, presence, pub, pub, cfg), subs, users, apps, rooms, history, pub
 }
 
 // ctx builds a handler context. siteID is retained for readability but unused

--- a/user-service/service/settings.go
+++ b/user-service/service/settings.go
@@ -58,7 +58,11 @@ func (s *UserService) SetSettings(c *natsrouter.Context, req models.SettingsSetR
 		// Unreachable after a non-empty $set; keep the reply shape total.
 		settings = &model.UserSettings{}
 	}
-	s.publishSettingsUpdate(c, account, settings)
+	// One timestamp for both fanouts so the client event and the cross-site
+	// replica agree on ordering.
+	now := time.Now().UTC().UnixMilli()
+	s.publishSettingsUpdate(c, account, settings, now)
+	s.publishSettingsInbox(c, account, settings, now)
 	return settings, nil
 }
 
@@ -79,12 +83,44 @@ func validateSettings(set *model.UserSettings) error {
 // publishSettingsUpdate fans out the per-user settings.update event over core
 // NATS (ephemeral client delivery, like subscription.update); best-effort —
 // errors are logged, the next set re-broadcasts the full settings.
-func (s *UserService) publishSettingsUpdate(c *natsrouter.Context, account string, settings *model.UserSettings) {
+func (s *UserService) publishSettingsUpdate(c *natsrouter.Context, account string, settings *model.UserSettings, now int64) {
 	data, _ := json.Marshal(model.SettingsUpdateEvent{
-		Timestamp: time.Now().UTC().UnixMilli(),
+		Timestamp: now,
 		Settings:  *settings,
 	}) // UserSettings is all primitives — Marshal cannot fail
 	if err := s.clientPub.Publish(c, subject.SettingsUpdate(account), data); err != nil {
 		slog.WarnContext(c, "publish settings update event", "error", err, "account", account, "request_id", natsutil.RequestIDFromContext(c))
+	}
+}
+
+// publishSettingsInbox replicates the full post-update settings to every other
+// site's external INBOX lane, so each site's notification worker can decide
+// locally whether to push to this user. Mirrors publishStatus; errors logged.
+func (s *UserService) publishSettingsInbox(c *natsrouter.Context, account string, settings *model.UserSettings, now int64) {
+	payload, _ := json.Marshal(model.UserSettingsUpdated{
+		Account:   account,
+		Settings:  *settings,
+		Timestamp: now,
+	}) // UserSettings is all primitives — Marshal cannot fail
+	for _, dest := range s.allSiteIDs {
+		if dest == "" || dest == s.siteID {
+			continue
+		}
+		evt := model.InboxEvent{
+			Type:       model.InboxUserSettingsUpdated,
+			SiteID:     s.siteID,
+			DestSiteID: dest,
+			Payload:    payload,
+			Timestamp:  now,
+		}
+		data, err := json.Marshal(evt)
+		if err != nil {
+			slog.WarnContext(c, "marshal settings inbox event", "error", err, "site", s.siteID, "dest", dest, "account", account, "request_id", natsutil.RequestIDFromContext(c))
+			continue
+		}
+		if err := s.pub.Publish(c, subject.InboxExternal(dest, model.InboxUserSettingsUpdated), data); err != nil {
+			// Non-fatal: settings are last-write-wins, the next set re-broadcasts.
+			slog.WarnContext(c, "publish settings inbox event", "error", err, "site", s.siteID, "dest", dest, "account", account, "request_id", natsutil.RequestIDFromContext(c))
+		}
 	}
 }

--- a/user-service/service/settings.go
+++ b/user-service/service/settings.go
@@ -65,10 +65,7 @@ func (s *UserService) SetSettings(c *natsrouter.Context, req models.SettingsSetR
 // validateSettings rejects an empty request (nothing to write) and a
 // malformed translateMessageInto.
 func validateSettings(set *model.UserSettings) error {
-	if set.FullWidth == nil && set.TranslateMessageInto == nil &&
-		set.ShowMessagePreviewInSidebarList == nil && set.MuteAllNotifications == nil &&
-		set.ShowMessagesAndPreviewsInNotifications == nil &&
-		set.ShowNotificationsDuringCallsAndMeetings == nil && set.ScrollToBottomInChat == nil {
+	if set.IsEmpty() {
 		return errcode.BadRequest("no settings provided")
 	}
 	if set.TranslateMessageInto != nil && !translateTagRe.MatchString(*set.TranslateMessageInto) {

--- a/user-service/service/settings.go
+++ b/user-service/service/settings.go
@@ -68,7 +68,9 @@ func validateSettings(set *model.UserSettings) error {
 	if set.IsEmpty() {
 		return errcode.BadRequest("no settings provided")
 	}
-	if set.TranslateMessageInto != nil && !translateTagRe.MatchString(*set.TranslateMessageInto) {
+	// "" is valid: it explicitly stores "translation off" (an unset would fall
+	// back to the client default, erasing the user's choice).
+	if set.TranslateMessageInto != nil && *set.TranslateMessageInto != "" && !translateTagRe.MatchString(*set.TranslateMessageInto) {
 		return errcode.BadRequest("invalid translateMessageInto language tag")
 	}
 	return nil

--- a/user-service/service/settings.go
+++ b/user-service/service/settings.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"time"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/natsrouter"
+	"github.com/hmchangw/chat/pkg/natsutil"
+	"github.com/hmchangw/chat/pkg/subject"
+	"github.com/hmchangw/chat/user-service/models"
+)
+
+// translateTagRe is a permissive language-tag shape (BCP-47-ish): hyphenated
+// letter/digit subtags, leading subtag letters-only. No whitelist by design.
+var translateTagRe = regexp.MustCompile(`^[A-Za-z]+(-[A-Za-z0-9]+)*$`)
+
+// GetSettings returns exactly the stored settings sub-document; {} when never
+// set — the server never injects defaults (absent = client-defined default).
+func (s *UserService) GetSettings(c *natsrouter.Context) (*model.UserSettings, error) {
+	account := c.Param("account")
+	c.WithLogValues("account", account)
+	u, err := s.users.GetUserSettings(c, account)
+	if err != nil {
+		return nil, fmt.Errorf("get settings: %w", err)
+	}
+	if u == nil {
+		return nil, errcode.NotFound("user not found")
+	}
+	if u.Settings == nil {
+		return &model.UserSettings{}, nil
+	}
+	return u.Settings, nil
+}
+
+// SetSettings partially updates the caller's settings — only the fields sent
+// are written — then fans out settings.update with the full post-update
+// settings so the caller's other devices sync live.
+func (s *UserService) SetSettings(c *natsrouter.Context, req models.SettingsSetRequest) (*model.UserSettings, error) {
+	account := c.Param("account")
+	c.WithLogValues("account", account)
+	if err := validateSettings(&req.UserSettings); err != nil {
+		return nil, err
+	}
+	u, err := s.users.UpdateUserSettings(c, account, &req.UserSettings)
+	if err != nil {
+		return nil, fmt.Errorf("set settings: %w", err)
+	}
+	if u == nil {
+		return nil, errcode.NotFound("user not found")
+	}
+	settings := u.Settings
+	if settings == nil {
+		// Unreachable after a non-empty $set; keep the reply shape total.
+		settings = &model.UserSettings{}
+	}
+	s.publishSettingsUpdate(c, account, settings)
+	return settings, nil
+}
+
+// validateSettings rejects an empty request (nothing to write) and a
+// malformed translateMessageInto.
+func validateSettings(set *model.UserSettings) error {
+	if set.FullWidth == nil && set.TranslateMessageInto == nil &&
+		set.ShowMessagePreviewInSidebarList == nil && set.MuteAllNotifications == nil &&
+		set.ShowMessagesAndPreviewsInNotifications == nil &&
+		set.ShowNotificationsDuringCallsAndMeetings == nil && set.ScrollToBottomInChat == nil {
+		return errcode.BadRequest("no settings provided")
+	}
+	if set.TranslateMessageInto != nil && !translateTagRe.MatchString(*set.TranslateMessageInto) {
+		return errcode.BadRequest("invalid translateMessageInto language tag")
+	}
+	return nil
+}
+
+// publishSettingsUpdate fans out the per-user settings.update event over core
+// NATS (ephemeral client delivery, like subscription.update); best-effort —
+// errors are logged, the next set re-broadcasts the full settings.
+func (s *UserService) publishSettingsUpdate(c *natsrouter.Context, account string, settings *model.UserSettings) {
+	data, _ := json.Marshal(model.SettingsUpdateEvent{
+		Timestamp: time.Now().UTC().UnixMilli(),
+		Settings:  *settings,
+	}) // UserSettings is all primitives — Marshal cannot fail
+	if err := s.clientPub.Publish(c, subject.SettingsUpdate(account), data); err != nil {
+		slog.WarnContext(c, "publish settings update event", "error", err, "account", account, "request_id", natsutil.RequestIDFromContext(c))
+	}
+}

--- a/user-service/service/settings_test.go
+++ b/user-service/service/settings_test.go
@@ -13,9 +13,15 @@ import (
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/subject"
 	"github.com/hmchangw/chat/user-service/models"
+	"github.com/hmchangw/chat/user-service/service/mocks"
 )
 
 func ptrStr(s string) *string { return &s }
+
+// expectInbox allows the cross-site settings fanout the client-event tests don't assert on.
+func expectInbox(pub *mocks.MockEventPublisher) {
+	pub.EXPECT().Publish(gomock.Any(), subject.InboxExternal("site-b", model.InboxUserSettingsUpdated), gomock.Any()).Return(nil).AnyTimes()
+}
 
 func TestGetSettings_NeverSetReturnsEmptyObject(t *testing.T) {
 	svc, _, users, _, _, _, _ := newSvc(t)
@@ -55,6 +61,7 @@ func TestGetSettings_StoreError(t *testing.T) {
 
 func TestSetSettings_PartialPassesOnlySentFields(t *testing.T) {
 	svc, _, users, _, _, _, pub := newSvc(t)
+	expectInbox(pub)
 	updated := &model.UserSettings{FullWidth: ptrBool(true), MuteAllNotifications: ptrBool(false)}
 	users.EXPECT().UpdateUserSettings(gomock.Any(), "alice", gomock.Any()).
 		DoAndReturn(func(_ any, _ string, set *model.UserSettings) (*model.User, error) {
@@ -74,6 +81,7 @@ func TestSetSettings_PartialPassesOnlySentFields(t *testing.T) {
 
 func TestSetSettings_PublishesFullPostUpdateSettings(t *testing.T) {
 	svc, _, users, _, _, _, pub := newSvc(t)
+	expectInbox(pub)
 	updated := &model.UserSettings{FullWidth: ptrBool(true), TranslateMessageInto: ptrStr("ja")}
 	users.EXPECT().UpdateUserSettings(gomock.Any(), "alice", gomock.Any()).
 		Return(&model.User{Settings: updated}, nil)
@@ -93,6 +101,7 @@ func TestSetSettings_PublishesFullPostUpdateSettings(t *testing.T) {
 
 func TestSetSettings_PublishFailureIsBestEffort(t *testing.T) {
 	svc, _, users, _, _, _, pub := newSvc(t)
+	expectInbox(pub)
 	users.EXPECT().UpdateUserSettings(gomock.Any(), "alice", gomock.Any()).
 		Return(&model.User{Settings: &model.UserSettings{FullWidth: ptrBool(true)}}, nil)
 	pub.EXPECT().Publish(gomock.Any(), subject.SettingsUpdate("alice"), gomock.Any()).
@@ -121,6 +130,7 @@ func TestSetSettings_InvalidTranslateTag(t *testing.T) {
 
 func TestSetSettings_ValidTranslateTags(t *testing.T) {
 	svc, _, users, _, _, _, pub := newSvc(t)
+	expectInbox(pub)
 	for _, tag := range []string{"en", "en-US", "zh-Hant-TW", "ja", ""} { // "" = translation off
 		users.EXPECT().UpdateUserSettings(gomock.Any(), "alice", gomock.Any()).
 			Return(&model.User{Settings: &model.UserSettings{TranslateMessageInto: &tag}}, nil)
@@ -151,4 +161,52 @@ func TestSetSettings_StoreError(t *testing.T) {
 	require.Error(t, err)
 	var ee *errcode.Error
 	assert.False(t, errors.As(err, &ee), "store errors must stay raw, not pre-classified")
+}
+
+func TestSetSettings_FansOutToOtherSitesOnly(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	mute := true
+	updated := &model.UserSettings{MuteAllNotifications: &mute}
+	users.EXPECT().UpdateUserSettings(gomock.Any(), "alice", gomock.Any()).Return(&model.User{Settings: updated}, nil)
+
+	var clientTS int64
+	pub.EXPECT().Publish(gomock.Any(), subject.SettingsUpdate("alice"), gomock.Any()).
+		DoAndReturn(func(_ any, _ string, data []byte) error {
+			var evt model.SettingsUpdateEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			clientTS = evt.Timestamp
+			return nil
+		})
+	// site-a is self and must be skipped; only site-b gets an inbox event.
+	pub.EXPECT().Publish(gomock.Any(), subject.InboxExternal("site-b", model.InboxUserSettingsUpdated), gomock.Any()).
+		DoAndReturn(func(_ any, _ string, data []byte) error {
+			var evt model.InboxEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			assert.Equal(t, "site-a", evt.SiteID)
+			assert.Equal(t, "site-b", evt.DestSiteID)
+			var p model.UserSettingsUpdated
+			require.NoError(t, json.Unmarshal(evt.Payload, &p))
+			assert.Equal(t, "alice", p.Account)
+			assert.Equal(t, *updated, p.Settings, "inbox event must carry the full post-update settings")
+			assert.Equal(t, clientTS, p.Timestamp, "both fanouts must share one timestamp")
+			return nil
+		})
+
+	_, err := svc.SetSettings(ctx("alice", "site-a"), models.SettingsSetRequest{
+		UserSettings: model.UserSettings{MuteAllNotifications: &mute},
+	})
+	require.NoError(t, err)
+}
+
+func TestSetSettings_InboxPublishFailureIsBestEffort(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	users.EXPECT().UpdateUserSettings(gomock.Any(), "alice", gomock.Any()).
+		Return(&model.User{Settings: &model.UserSettings{FullWidth: ptrBool(true)}}, nil)
+	pub.EXPECT().Publish(gomock.Any(), subject.SettingsUpdate("alice"), gomock.Any()).Return(nil)
+	pub.EXPECT().Publish(gomock.Any(), subject.InboxExternal("site-b", model.InboxUserSettingsUpdated), gomock.Any()).
+		Return(errors.New("no responders"))
+	_, err := svc.SetSettings(ctx("alice", "site-a"), models.SettingsSetRequest{
+		UserSettings: model.UserSettings{FullWidth: ptrBool(true)},
+	})
+	require.NoError(t, err, "inbox fanout failure must not fail the set")
 }

--- a/user-service/service/settings_test.go
+++ b/user-service/service/settings_test.go
@@ -111,7 +111,7 @@ func TestSetSettings_EmptyRequest(t *testing.T) {
 
 func TestSetSettings_InvalidTranslateTag(t *testing.T) {
 	svc, _, _, _, _, _, _ := newSvc(t)
-	for _, tag := range []string{"", "en_US", "-en", "en-", "1en", "en US"} {
+	for _, tag := range []string{"en_US", "-en", "en-", "1en", "en US"} {
 		_, err := svc.SetSettings(ctx("alice", "site-a"), models.SettingsSetRequest{
 			UserSettings: model.UserSettings{TranslateMessageInto: &tag},
 		})
@@ -121,7 +121,7 @@ func TestSetSettings_InvalidTranslateTag(t *testing.T) {
 
 func TestSetSettings_ValidTranslateTags(t *testing.T) {
 	svc, _, users, _, _, _, pub := newSvc(t)
-	for _, tag := range []string{"en", "en-US", "zh-Hant-TW", "ja"} {
+	for _, tag := range []string{"en", "en-US", "zh-Hant-TW", "ja", ""} { // "" = translation off
 		users.EXPECT().UpdateUserSettings(gomock.Any(), "alice", gomock.Any()).
 			Return(&model.User{Settings: &model.UserSettings{TranslateMessageInto: &tag}}, nil)
 		pub.EXPECT().Publish(gomock.Any(), subject.SettingsUpdate("alice"), gomock.Any()).Return(nil)

--- a/user-service/service/settings_test.go
+++ b/user-service/service/settings_test.go
@@ -1,0 +1,154 @@
+package service
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/subject"
+	"github.com/hmchangw/chat/user-service/models"
+)
+
+func ptrStr(s string) *string { return &s }
+
+func TestGetSettings_NeverSetReturnsEmptyObject(t *testing.T) {
+	svc, _, users, _, _, _, _ := newSvc(t)
+	users.EXPECT().GetUserSettings(gomock.Any(), "alice").Return(&model.User{}, nil)
+	resp, err := svc.GetSettings(ctx("alice", "site-a"))
+	require.NoError(t, err)
+	data, err := json.Marshal(resp)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{}`, string(data), "never-set settings must serialize as {} — no injected defaults")
+}
+
+func TestGetSettings_ReturnsStoredSubDocument(t *testing.T) {
+	svc, _, users, _, _, _, _ := newSvc(t)
+	stored := &model.UserSettings{FullWidth: ptrBool(true), TranslateMessageInto: ptrStr("en-US")}
+	users.EXPECT().GetUserSettings(gomock.Any(), "alice").Return(&model.User{Settings: stored}, nil)
+	resp, err := svc.GetSettings(ctx("alice", "site-a"))
+	require.NoError(t, err)
+	assert.Equal(t, stored, resp)
+}
+
+func TestGetSettings_NotFound(t *testing.T) {
+	svc, _, users, _, _, _, _ := newSvc(t)
+	users.EXPECT().GetUserSettings(gomock.Any(), "ghost").Return(nil, nil)
+	_, err := svc.GetSettings(ctx("ghost", "site-a"))
+	requireCode(t, err, errcode.CodeNotFound)
+}
+
+func TestGetSettings_StoreError(t *testing.T) {
+	svc, _, users, _, _, _, _ := newSvc(t)
+	users.EXPECT().GetUserSettings(gomock.Any(), "alice").Return(nil, errors.New("db unavailable"))
+	_, err := svc.GetSettings(ctx("alice", "site-a"))
+	// Raw wrapped error — classified to the generic boundary code by the router.
+	require.Error(t, err)
+	var ee *errcode.Error
+	assert.False(t, errors.As(err, &ee), "store errors must stay raw, not pre-classified")
+}
+
+func TestSetSettings_PartialPassesOnlySentFields(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	updated := &model.UserSettings{FullWidth: ptrBool(true), MuteAllNotifications: ptrBool(false)}
+	users.EXPECT().UpdateUserSettings(gomock.Any(), "alice", gomock.Any()).
+		DoAndReturn(func(_ any, _ string, set *model.UserSettings) (*model.User, error) {
+			require.NotNil(t, set.FullWidth)
+			assert.True(t, *set.FullWidth)
+			assert.Nil(t, set.TranslateMessageInto, "unsent fields must not reach the repo")
+			assert.Nil(t, set.MuteAllNotifications)
+			return &model.User{Settings: updated}, nil
+		})
+	pub.EXPECT().Publish(gomock.Any(), subject.SettingsUpdate("alice"), gomock.Any()).Return(nil)
+	resp, err := svc.SetSettings(ctx("alice", "site-a"), models.SettingsSetRequest{
+		UserSettings: model.UserSettings{FullWidth: ptrBool(true)},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, updated, resp)
+}
+
+func TestSetSettings_PublishesFullPostUpdateSettings(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	updated := &model.UserSettings{FullWidth: ptrBool(true), TranslateMessageInto: ptrStr("ja")}
+	users.EXPECT().UpdateUserSettings(gomock.Any(), "alice", gomock.Any()).
+		Return(&model.User{Settings: updated}, nil)
+	pub.EXPECT().Publish(gomock.Any(), subject.SettingsUpdate("alice"), gomock.Any()).
+		DoAndReturn(func(_ any, _ string, data []byte) error {
+			var evt model.SettingsUpdateEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			assert.Positive(t, evt.Timestamp)
+			assert.Equal(t, *updated, evt.Settings, "event must carry the full post-update settings")
+			return nil
+		})
+	_, err := svc.SetSettings(ctx("alice", "site-a"), models.SettingsSetRequest{
+		UserSettings: model.UserSettings{TranslateMessageInto: ptrStr("ja")},
+	})
+	require.NoError(t, err)
+}
+
+func TestSetSettings_PublishFailureIsBestEffort(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	users.EXPECT().UpdateUserSettings(gomock.Any(), "alice", gomock.Any()).
+		Return(&model.User{Settings: &model.UserSettings{FullWidth: ptrBool(true)}}, nil)
+	pub.EXPECT().Publish(gomock.Any(), subject.SettingsUpdate("alice"), gomock.Any()).
+		Return(errors.New("nats down"))
+	_, err := svc.SetSettings(ctx("alice", "site-a"), models.SettingsSetRequest{
+		UserSettings: model.UserSettings{FullWidth: ptrBool(true)},
+	})
+	require.NoError(t, err, "fanout failure must not fail the set")
+}
+
+func TestSetSettings_EmptyRequest(t *testing.T) {
+	svc, _, _, _, _, _, _ := newSvc(t)
+	_, err := svc.SetSettings(ctx("alice", "site-a"), models.SettingsSetRequest{})
+	requireCode(t, err, errcode.CodeBadRequest)
+}
+
+func TestSetSettings_InvalidTranslateTag(t *testing.T) {
+	svc, _, _, _, _, _, _ := newSvc(t)
+	for _, tag := range []string{"", "en_US", "-en", "en-", "1en", "en US"} {
+		_, err := svc.SetSettings(ctx("alice", "site-a"), models.SettingsSetRequest{
+			UserSettings: model.UserSettings{TranslateMessageInto: &tag},
+		})
+		requireCode(t, err, errcode.CodeBadRequest)
+	}
+}
+
+func TestSetSettings_ValidTranslateTags(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	for _, tag := range []string{"en", "en-US", "zh-Hant-TW", "ja"} {
+		users.EXPECT().UpdateUserSettings(gomock.Any(), "alice", gomock.Any()).
+			Return(&model.User{Settings: &model.UserSettings{TranslateMessageInto: &tag}}, nil)
+		pub.EXPECT().Publish(gomock.Any(), subject.SettingsUpdate("alice"), gomock.Any()).Return(nil)
+		_, err := svc.SetSettings(ctx("alice", "site-a"), models.SettingsSetRequest{
+			UserSettings: model.UserSettings{TranslateMessageInto: &tag},
+		})
+		require.NoError(t, err, "tag %q must be accepted", tag)
+	}
+}
+
+func TestSetSettings_NotFound(t *testing.T) {
+	svc, _, users, _, _, _, _ := newSvc(t)
+	users.EXPECT().UpdateUserSettings(gomock.Any(), "ghost", gomock.Any()).Return(nil, nil)
+	_, err := svc.SetSettings(ctx("ghost", "site-a"), models.SettingsSetRequest{
+		UserSettings: model.UserSettings{FullWidth: ptrBool(true)},
+	})
+	requireCode(t, err, errcode.CodeNotFound)
+}
+
+func TestSetSettings_StoreError(t *testing.T) {
+	svc, _, users, _, _, _, _ := newSvc(t)
+	users.EXPECT().UpdateUserSettings(gomock.Any(), "alice", gomock.Any()).Return(nil, errors.New("db unavailable"))
+	_, err := svc.SetSettings(ctx("alice", "site-a"), models.SettingsSetRequest{
+		UserSettings: model.UserSettings{FullWidth: ptrBool(true)},
+	})
+	// Raw wrapped error — classified to the generic boundary code by the router.
+	require.Error(t, err)
+	var ee *errcode.Error
+	assert.False(t, errors.As(err, &ee), "store errors must stay raw, not pre-classified")
+}

--- a/user-service/service/status_test.go
+++ b/user-service/service/status_test.go
@@ -153,7 +153,7 @@ func TestPublishStatus_SkipsEmptyDest(t *testing.T) {
 	pub := mocks.NewMockEventPublisher(ctrl)
 	cfg := &config.Config{SiteID: "site-a", AllSiteIDs: []string{"site-a", "", "site-b"}, MaxSubscriptionLimit: 1000}
 	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
-	svc := New(subs, users, apps, threadSubs, rooms, history, presence, pub, cfg)
+	svc := New(subs, users, apps, threadSubs, rooms, history, presence, pub, pub, cfg)
 	// Only "site-b" must receive a publish; self "site-a" and the blank "" are skipped.
 	pub.EXPECT().Publish(gomock.Any(), subject.InboxExternal("site-b", model.InboxUserStatusUpdated), gomock.Any()).Return(nil)
 	svc.publishStatus(ctx("alice", "site-a"), "alice", "busy", nil)

--- a/user-service/service/subscriptions_test.go
+++ b/user-service/service/subscriptions_test.go
@@ -33,7 +33,7 @@ func newSvcRawHistory(t *testing.T) (*UserService, *mocks.MockSubscriptionReposi
 	pub := mocks.NewMockEventPublisher(ctrl)
 	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
 	cfg := &config.Config{SiteID: "site-a", AllSiteIDs: []string{"site-a", "site-b"}, MaxSubscriptionLimit: 1000, DefaultSubscriptionLimit: 40, MaxAppsLimit: 100, DefaultAppsLimit: 20, MaxAccountNames: 100}
-	return New(subs, users, apps, threadSubs, rooms, history, presence, pub, cfg), subs, history
+	return New(subs, users, apps, threadSubs, rooms, history, presence, pub, pub, cfg), subs, history
 }
 
 func TestListSubscriptions_Types(t *testing.T) {

--- a/user-service/service/subscriptions_test.go
+++ b/user-service/service/subscriptions_test.go
@@ -641,7 +641,7 @@ func newCountSvc(t *testing.T) (*UserService, *mocks.MockSubscriptionRepository,
 	pub := mocks.NewMockEventPublisher(ctrl)
 	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
 	cfg := &config.Config{SiteID: "site-a", AllSiteIDs: []string{"site-a", "site-b"}, MaxSubscriptionLimit: 1000, DefaultSubscriptionLimit: 40, MaxAppsLimit: 100, DefaultAppsLimit: 20, MaxAccountNames: 100}
-	return New(subs, users, apps, threadSubs, rooms, history, presence, pub, cfg), subs, rooms, threadSubs
+	return New(subs, users, apps, threadSubs, rooms, history, presence, pub, pub, cfg), subs, rooms, threadSubs
 }
 
 func TestCountUnread_Happy(t *testing.T) {

--- a/user-service/service/threads_test.go
+++ b/user-service/service/threads_test.go
@@ -34,6 +34,7 @@ func newThreadSvc(t *testing.T) (*UserService, *mocks.MockHistoryClient, *mocks.
 		history,
 		mocks.NewMockPresenceClient(ctrl),
 		mocks.NewMockEventPublisher(ctrl),
+		mocks.NewMockEventPublisher(ctrl),
 		cfg,
 	)
 	return svc, history, users, apps


### PR DESCRIPTION
## Summary

Per-user settings surface: `settings.get` / `settings.set` RPCs over a `settings` sub-document on the user record, plus a `settings.update` event so the caller's other devices sync live. The server stores **only what the user explicitly set** — every field is optional and an absent field means the client applies its own default (stated in the API doc).

Closes #80

## What's included

- **`pkg/model`** — `UserSettings` (7 optional pointer fields: `fullWidth`, `translateMessageInto`, `showMessagePreviewInSidebarList`, `muteAllNotifications`, `showMessagesAndPreviewsInNotifications`, `showNotificationsDuringCallsAndMeetings`, `scrollToBottomInChat`), `User.Settings`, `SettingsUpdateEvent`.
- **`pkg/subject`** — `settings.get` / `settings.set` request builders + patterns and the `settings.update` event subject.
- **`user-service`** — `GetSettings` (never-set → `{}`; the server never injects defaults) and `SetSettings` (**partial update**: only fields present in the request are written, via per-field `$set`; empty request → `bad_request`; permissive language-tag check on `translateMessageInto`). A successful set publishes `settings.update` with the full post-update settings over core NATS (ephemeral client delivery, mirroring the existing subscription-update pattern).

## NATS subjects

| Subject | Kind |
|---|---|
| `chat.user.{account}.request.user.{siteID}.settings.get` | request/reply |
| `chat.user.{account}.request.user.{siteID}.settings.set` | request/reply |
| `chat.user.{account}.event.settings.update` | server→client event |

## Verification

- Unit (table-driven): get-unset → `{}`, stored round-trip, partial-set field isolation, invalid/valid language tags, event carries the full post-update settings, publish failure is best-effort, not-found/store-error paths.
- Integration (build-tagged, live Mongo): persisted sub-document shape + per-field `$set` semantics.
- `docs/client-api.md` + derived views updated in the same PR (field tables, JSON examples, partial-set semantics, the absent-= -client-default contract).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-user settings APIs to retrieve stored preferences and apply partial updates.
  * Successful updates now emit a client-facing `settings.update` fan-out containing the full post-update settings snapshot to the caller’s other connected devices.
  * Cross-site propagation now replicates settings updates to other sites via inbox events (with best-effort delivery).
* **Documentation**
  * Documented the new settings RPCs, validation behavior, error responses, and clarified which operation emits client events.
* **Tests**
  * Added unit and integration coverage for settings serialization, persistence, event payload shape, fan-out behavior, and inbox update handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->