### PR TITLE
fix(history-service): emit surviving thread last-message time on reply delete

### DIFF
--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -2739,16 +2739,19 @@ func TestHandleThreadDeleted_ChannelRoom_WithBadgeUpdate(t *testing.T) {
 	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
 	deletedAt := msgTime.Add(time.Minute)
 	tcount := 4
+	// tlm = the newest surviving reply's createdAt, carried on the canonical delete event.
+	survivingTlm := msgTime.Add(-time.Hour)
 
 	room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}
 	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
 	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{"bob": {}}, nil)
 
 	evt := model.MessageEvent{
-		Event:     model.EventDeleted,
-		SiteID:    "site-a",
-		Timestamp: deletedAt.UnixMilli(),
-		NewTCount: &tcount,
+		Event:              model.EventDeleted,
+		SiteID:             "site-a",
+		Timestamp:          deletedAt.UnixMilli(),
+		NewTCount:          &tcount,
+		NewThreadLastMsgAt: &survivingTlm,
 		Message: model.Message{
 			ID:                    "reply-1",
 			RoomID:                "r1",
@@ -2775,6 +2778,8 @@ func TestHandleThreadDeleted_ChannelRoom_WithBadgeUpdate(t *testing.T) {
 			require.NoError(t, json.Unmarshal(r.data, &tmEvt))
 			assert.Equal(t, model.ThreadActionReplyDeleted, tmEvt.Action)
 			assert.Equal(t, 4, tmEvt.NewTCount)
+			require.NotNil(t, tmEvt.NewThreadLastMsgAt, "badge must forward the surviving thread last-message time on delete")
+			assert.True(t, tmEvt.NewThreadLastMsgAt.Equal(survivingTlm), "NewThreadLastMsgAt must equal the newest surviving reply's createdAt")
 			sawBadge = true
 		} else {
 			var roomEvt model.DeleteRoomEvent

--- a/history-service/internal/cassrepo/write.go
+++ b/history-service/internal/cassrepo/write.go
@@ -285,9 +285,11 @@ func (r *Repository) UpdateMessageContent(ctx context.Context, msg *models.Messa
 // SoftDeleteMessage uses a Cassandra LWT on messages_by_id as a one-shot gate so only
 // the winning goroutine runs mirror-table updates and tcount decrement, preventing double-decrement.
 // `IF deleted != true` matches NULL (message-worker never writes deleted) and false, excluding true.
-func (r *Repository) SoftDeleteMessage(ctx context.Context, msg *models.Message, deletedAt time.Time) (time.Time, bool, *int, error) {
+// The returned newThreadLastMsgAt is the newest surviving reply's createdAt (nil when none survive),
+// so the caller can publish it on the canonical event without a second read.
+func (r *Repository) SoftDeleteMessage(ctx context.Context, msg *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
 	if msg.ThreadParentID != "" && msg.ThreadRoomID == "" {
-		return time.Time{}, false, nil, fmt.Errorf("delete thread message %s: ThreadParentID %q is set but ThreadRoomID is empty", msg.MessageID, msg.ThreadParentID)
+		return time.Time{}, false, nil, nil, fmt.Errorf("delete thread message %s: ThreadParentID %q is set but ThreadRoomID is empty", msg.MessageID, msg.ThreadParentID)
 	}
 
 	isThreadParent := msg.TCount != nil && *msg.TCount > 0
@@ -303,7 +305,7 @@ func (r *Repository) SoftDeleteMessage(ctx context.Context, msg *models.Message,
 		deletedAt, msg.MessageID,
 	).WithContext(ctx).ScanCAS(&current)
 	if err != nil {
-		return time.Time{}, false, nil, fmt.Errorf("cas update messages_by_id for message %s: %w", msg.MessageID, err)
+		return time.Time{}, false, nil, nil, fmt.Errorf("cas update messages_by_id for message %s: %w", msg.MessageID, err)
 	}
 	if !applied {
 		// Concurrent delete won. Read the existing updated_at so the caller
@@ -315,11 +317,11 @@ func (r *Repository) SoftDeleteMessage(ctx context.Context, msg *models.Message,
 		).WithContext(ctx).Scan(&existing); err != nil {
 			if errors.Is(err, gocql.ErrNotFound) {
 				// Row vanished between the CAS and the follow-up SELECT — abnormal race.
-				return time.Time{}, false, nil, fmt.Errorf("message %s vanished after cas miss: %w", msg.MessageID, gocql.ErrNotFound)
+				return time.Time{}, false, nil, nil, fmt.Errorf("message %s vanished after cas miss: %w", msg.MessageID, gocql.ErrNotFound)
 			}
-			return time.Time{}, false, nil, fmt.Errorf("read updated_at after cas miss for message %s: %w", msg.MessageID, err)
+			return time.Time{}, false, nil, nil, fmt.Errorf("read updated_at after cas miss for message %s: %w", msg.MessageID, err)
 		}
-		return existing, false, nil, nil
+		return existing, false, nil, nil, nil
 	}
 
 	msgByRoomQ := deleteMsgByRoom
@@ -333,11 +335,11 @@ func (r *Repository) SoftDeleteMessage(ctx context.Context, msg *models.Message,
 
 	if msg.ThreadParentID == "" {
 		if err := r.deleteInMessagesByRoom(ctx, msgByRoomQ, msg, deletedAt); err != nil {
-			return time.Time{}, false, nil, fmt.Errorf("update messages_by_room for message %s in room %s: %w", msg.MessageID, msg.RoomID, err)
+			return time.Time{}, false, nil, nil, fmt.Errorf("update messages_by_room for message %s in room %s: %w", msg.MessageID, msg.RoomID, err)
 		}
 	} else {
 		if err := r.session.Query(threadMsgQ, deletedAt, msg.ThreadRoomID, msg.CreatedAt, msg.MessageID).WithContext(ctx).Exec(); err != nil {
-			return time.Time{}, false, nil, fmt.Errorf("update thread_messages_by_thread for message %s thread %s: %w", msg.MessageID, msg.ThreadRoomID, err)
+			return time.Time{}, false, nil, nil, fmt.Errorf("update thread_messages_by_thread for message %s thread %s: %w", msg.MessageID, msg.ThreadRoomID, err)
 		}
 		// A TShow ("also send to channel") thread reply is dual-written into
 		// messages_by_room at create time; soft-delete must also hit that copy
@@ -345,27 +347,27 @@ func (r *Repository) SoftDeleteMessage(ctx context.Context, msg *models.Message,
 		// thread delete — same shape as the PinnedAt branch below.
 		if msg.TShow {
 			if err := r.deleteInMessagesByRoom(ctx, msgByRoomQ, msg, deletedAt); err != nil {
-				return time.Time{}, false, nil, fmt.Errorf("update messages_by_room for tshow thread message %s in room %s: %w", msg.MessageID, msg.RoomID, err)
+				return time.Time{}, false, nil, nil, fmt.Errorf("update messages_by_room for tshow thread message %s in room %s: %w", msg.MessageID, msg.RoomID, err)
 			}
 		}
 	}
 
 	if msg.PinnedAt != nil {
 		if err := r.deleteInPinnedMessagesByRoom(ctx, pinnedMsgQ, msg, deletedAt); err != nil {
-			return time.Time{}, false, nil, fmt.Errorf("update pinned_messages_by_room for message %s in room %s: %w", msg.MessageID, msg.RoomID, err)
+			return time.Time{}, false, nil, nil, fmt.Errorf("update pinned_messages_by_room for message %s in room %s: %w", msg.MessageID, msg.RoomID, err)
 		}
 	}
 
 	if msg.ThreadParentID == "" {
-		return deletedAt, true, nil, nil
+		return deletedAt, true, nil, nil, nil
 	}
-	newTcount, err := r.countAndSetParentTcount(ctx, msg)
+	newTcount, newTlm, err := r.countAndSetParentTcount(ctx, msg)
 	if err != nil {
 		// The LWT delete already committed — return applied=true so callers correctly
 		// identify this as a count-set failure rather than a concurrent-winner race.
-		return deletedAt, true, nil, fmt.Errorf("count and set parent tcount for message %s: %w", msg.MessageID, err)
+		return deletedAt, true, nil, nil, fmt.Errorf("count and set parent tcount for message %s: %w", msg.MessageID, err)
 	}
-	return deletedAt, true, newTcount, nil
+	return deletedAt, true, newTcount, newTlm, nil
 }
 
 // countThreadReplies returns the bounded, soft-delete-aware reply count and the
@@ -400,17 +402,17 @@ func (r *Repository) setParentTcountAndTlm(ctx context.Context, msg *models.Mess
 }
 
 // countAndSetParentTcount recomputes tcount+tlm from the surviving rows and sets both.
-// Returns (nil, nil) when ThreadParentCreatedAt is unset; tlm nil when no replies survive.
-func (r *Repository) countAndSetParentTcount(ctx context.Context, msg *models.Message) (*int, error) {
+// Returns (nil, nil, nil) when ThreadParentCreatedAt is unset; tlm nil when no replies survive.
+func (r *Repository) countAndSetParentTcount(ctx context.Context, msg *models.Message) (*int, *time.Time, error) {
 	if msg.ThreadParentCreatedAt == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	n, tlm, err := r.countThreadReplies(ctx, msg.ThreadRoomID)
 	if err != nil {
-		return nil, fmt.Errorf("count thread replies: %w", err)
+		return nil, nil, fmt.Errorf("count thread replies: %w", err)
 	}
 	if err := r.setParentTcountAndTlm(ctx, msg, n, tlm); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return &n, nil
+	return &n, tlm, nil
 }

--- a/history-service/internal/cassrepo/write_integration_test.go
+++ b/history-service/internal/cassrepo/write_integration_test.go
@@ -222,7 +222,7 @@ func TestRepository_SoftDeleteMessage_TopLevel(t *testing.T) {
 		ThreadParentID: "",
 	}
 	deletedAt := createdAt.Add(time.Minute)
-	_, applied, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
+	_, applied, _, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
 	require.NoError(t, err)
 	require.True(t, applied, "first delete should apply")
 
@@ -297,7 +297,7 @@ func TestRepository_SoftDeleteMessage_ThreadReply(t *testing.T) {
 		ThreadRoomID:          threadRoomID,
 	}
 	deletedAt := replyCreatedAt.Add(time.Minute)
-	_, applied, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
+	_, applied, _, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
 	require.NoError(t, err)
 	require.True(t, applied, "first delete should apply")
 
@@ -369,7 +369,7 @@ func TestRepository_SoftDeleteMessage_Pinned(t *testing.T) {
 		PinnedAt:       &pinnedAt,
 	}
 	deletedAt := createdAt.Add(time.Minute)
-	_, applied, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
+	_, applied, _, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
 	require.NoError(t, err)
 	require.True(t, applied, "first delete should apply")
 
@@ -450,13 +450,15 @@ func TestRepository_SoftDeleteMessage_DecrementsParentTcount(t *testing.T) {
 		ThreadParentCreatedAt: &parentCreatedAtPtr,
 		ThreadRoomID:          threadRoomID,
 	}
-	_, applied, newTcount, err := repo.SoftDeleteMessage(ctx, msg, replyCreatedAt.Add(time.Minute))
+	_, applied, newTcount, newTlm, err := repo.SoftDeleteMessage(ctx, msg, replyCreatedAt.Add(time.Minute))
 	require.NoError(t, err)
 	require.True(t, applied, "first delete should apply")
-	// SoftDeleteMessage returns the COUNT of non-deleted thread replies so the
+	// SoftDeleteMessage returns the COUNT and tlm of non-deleted thread replies so the
 	// caller can publish a ThreadMetadataUpdatedEvent without an extra round-trip.
 	require.NotNil(t, newTcount, "newTcount must be non-nil after a successful thread-reply delete")
 	assert.Equal(t, 2, *newTcount, "tcount = non-deleted COUNT (3 seeded - 1 deleted = 2)")
+	require.NotNil(t, newTlm, "newTlm must be non-nil while survivors remain")
+	assert.True(t, newTlm.Equal(survivor2At), "newTlm must equal the newest surviving reply's createdAt")
 
 	// Both tables' tcount should now be 2.
 	var gotTcount int
@@ -520,9 +522,13 @@ func TestRepository_SoftDeleteMessage_UpdatesParentTlm(t *testing.T) {
 		ThreadParentCreatedAt: &parentCreatedAtPtr,
 		ThreadRoomID:          threadRoomID,
 	}
-	_, applied, _, err := repo.SoftDeleteMessage(ctx, msg, replyAt.Add(time.Minute))
+	_, applied, _, newTlm, err := repo.SoftDeleteMessage(ctx, msg, replyAt.Add(time.Minute))
 	require.NoError(t, err)
 	require.True(t, applied)
+
+	// Returned tlm must match the persisted survivor max.
+	require.NotNil(t, newTlm, "returned newTlm must be non-nil while a survivor remains")
+	assert.True(t, newTlm.Equal(survivorAt), "returned newTlm must equal the newest surviving reply's createdAt")
 
 	// tlm must equal survivorAt (the max created_at among surviving replies).
 	var gotTlm *time.Time
@@ -584,11 +590,12 @@ func TestRepository_SoftDeleteMessage_ClearsTlmOnLastReplyDelete(t *testing.T) {
 		ThreadParentCreatedAt: &parentCreatedAtPtr,
 		ThreadRoomID:          threadRoomID,
 	}
-	_, applied, newTcount, err := repo.SoftDeleteMessage(ctx, msg, replyAt.Add(time.Minute))
+	_, applied, newTcount, newTlm, err := repo.SoftDeleteMessage(ctx, msg, replyAt.Add(time.Minute))
 	require.NoError(t, err)
 	require.True(t, applied)
 	require.NotNil(t, newTcount)
 	assert.Equal(t, 0, *newTcount, "tcount must be 0 after deleting last reply")
+	assert.Nil(t, newTlm, "returned newTlm must be nil after the last reply is deleted")
 
 	// tlm must be NULL on the parent.
 	var gotTlm *time.Time
@@ -633,7 +640,7 @@ func TestRepository_SoftDeleteMessage_TopLevelDoesNotTouchTcount(t *testing.T) {
 		Sender:         sender,
 		ThreadParentID: "",
 	}
-	_, applied, _, err := repo.SoftDeleteMessage(ctx, msg, createdAt.Add(time.Minute))
+	_, applied, _, _, err := repo.SoftDeleteMessage(ctx, msg, createdAt.Add(time.Minute))
 	require.NoError(t, err)
 	require.True(t, applied, "first delete should apply")
 
@@ -700,7 +707,7 @@ func TestRepository_SoftDeleteMessage_MissingThreadRoomID_ReturnsError(t *testin
 		ThreadParentID: "m-parent",
 		ThreadRoomID:   "",
 	}
-	_, _, _, err := repo.SoftDeleteMessage(ctx, msg, createdAt.Add(time.Minute))
+	_, _, _, _, err := repo.SoftDeleteMessage(ctx, msg, createdAt.Add(time.Minute))
 	require.Error(t, err, "expected error when ThreadRoomID is empty for a thread reply")
 
 	// Validation must fire before any DB write — messages_by_id must be unchanged.
@@ -767,7 +774,7 @@ func TestRepository_SoftDeleteMessage_LWTGatesDoubleDecrement(t *testing.T) {
 
 	// First delete: LWT applies (deleted was NULL → matches != true).
 	firstAt := replyCreatedAt.Add(time.Minute)
-	gotAt1, applied1, _, err := repo.SoftDeleteMessage(ctx, msg, firstAt)
+	gotAt1, applied1, _, _, err := repo.SoftDeleteMessage(ctx, msg, firstAt)
 	require.NoError(t, err)
 	require.True(t, applied1, "first delete must apply (deleted was NULL)")
 	assert.Equal(t, firstAt.UnixMilli(), gotAt1.UnixMilli())
@@ -790,7 +797,7 @@ func TestRepository_SoftDeleteMessage_LWTGatesDoubleDecrement(t *testing.T) {
 	// hydrated msg (Deleted=false) to simulate a stale read; the repo's CAS
 	// is authoritative.
 	secondAt := firstAt.Add(time.Second)
-	gotAt2, applied2, _, err := repo.SoftDeleteMessage(ctx, msg, secondAt)
+	gotAt2, applied2, _, _, err := repo.SoftDeleteMessage(ctx, msg, secondAt)
 	require.NoError(t, err)
 	require.False(t, applied2, "second delete must NOT apply — deleted is already true")
 	assert.Equal(t, firstAt.UnixMilli(), gotAt2.UnixMilli(), "actualDeletedAt should reflect the winning goroutine's timestamp")
@@ -878,7 +885,7 @@ func TestRepository_SoftDeleteMessage_RoundTrip(t *testing.T) {
 		ThreadParentID: "",
 	}
 	deletedAt := createdAt.Add(time.Minute)
-	gotAt, applied, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
+	gotAt, applied, _, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
 	require.NoError(t, err)
 	require.True(t, applied)
 	assert.Equal(t, deletedAt.UnixMilli(), gotAt.UnixMilli())
@@ -908,7 +915,7 @@ func TestRepository_SoftDeleteMessage_RowCreatedByLWT(t *testing.T) {
 	}
 	deletedAt := msg.CreatedAt.Add(time.Minute)
 
-	_, _, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
+	_, _, _, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
 	require.NoError(t, err, "SoftDeleteMessage must not return an error on a non-existent row")
 }
 
@@ -947,7 +954,7 @@ func TestRepository_SoftDeleteMessage_ThreadParent_SetsTypeRemoved(t *testing.T)
 	}
 
 	deletedAt := createdAt.Add(time.Minute)
-	_, applied, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
+	_, applied, _, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
 	require.NoError(t, err)
 	require.True(t, applied)
 
@@ -1001,7 +1008,7 @@ func TestRepository_SoftDeleteMessage_NonThreadParent_NoTypeChange(t *testing.T)
 	}
 
 	deletedAt := createdAt.Add(time.Minute)
-	_, applied, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
+	_, applied, _, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
 	require.NoError(t, err)
 	require.True(t, applied)
 
@@ -1055,7 +1062,7 @@ func TestRepository_SoftDeleteMessage_ReplyThreadParent_SetsTypeRemoved(t *testi
 	}
 
 	deletedAt := createdAt.Add(time.Minute)
-	_, applied, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
+	_, applied, _, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
 	require.NoError(t, err)
 	require.True(t, applied)
 
@@ -1269,7 +1276,7 @@ func TestDeleteMessage_NullsEncryptedColumns(t *testing.T) {
 		"m1", now, roomID, payload, &cassmodel.EncMeta{Nonce: meta.Nonce}, "site-a",
 	).Exec())
 
-	_, applied, _, err := repo.SoftDeleteMessage(ctx, &models.Message{
+	_, applied, _, _, err := repo.SoftDeleteMessage(ctx, &models.Message{
 		RoomID: roomID, MessageID: "m1", CreatedAt: now,
 	}, now.Add(time.Minute))
 	require.NoError(t, err)
@@ -1717,7 +1724,7 @@ func TestRepository_SoftDeleteMessage_TShowThreadReply(t *testing.T) {
 		TShow:                 true,
 	}
 	deletedAt := replyCreatedAt.Add(time.Minute)
-	_, applied, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
+	_, applied, _, _, err := repo.SoftDeleteMessage(ctx, msg, deletedAt)
 	require.NoError(t, err)
 	require.True(t, applied, "first delete should apply")
 

--- a/history-service/internal/service/messages.go
+++ b/history-service/internal/service/messages.go
@@ -480,7 +480,7 @@ func (s *HistoryService) DeleteMessage(c *natsrouter.Context, siteID string, req
 	}
 
 	deletedAt := time.Now().UTC()
-	actualDeletedAt, applied, newTcount, err := s.msgWriter.SoftDeleteMessage(c, msg, deletedAt)
+	actualDeletedAt, applied, newTcount, newThreadLastMsgAt, err := s.msgWriter.SoftDeleteMessage(c, msg, deletedAt)
 	if err != nil {
 		return nil, fmt.Errorf("deleting message %s: %w", req.MessageID, err)
 	}
@@ -508,9 +508,10 @@ func (s *HistoryService) DeleteMessage(c *natsrouter.Context, siteID string, req
 			ThreadParentMessageCreatedAt: msg.ThreadParentCreatedAt,
 			TShow:                        msg.TShow,
 		},
-		SiteID:    siteID,
-		Timestamp: deletedAtMs,
-		NewTCount: newTcount,
+		SiteID:             siteID,
+		Timestamp:          deletedAtMs,
+		NewTCount:          newTcount,
+		NewThreadLastMsgAt: newThreadLastMsgAt,
 	}
 	s.publishCanonicalBestEffort(c, subject.MsgCanonicalDeleted(siteID), &canonicalEvt)
 

--- a/history-service/internal/service/messages_test.go
+++ b/history-service/internal/service/messages_test.go
@@ -1524,7 +1524,7 @@ func TestHistoryService_DeleteMessage_SoftDeleteFails(t *testing.T) {
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "m-abc").Return(hydrated, nil)
 	msgs.EXPECT().
 		SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
-		Return(time.Time{}, false, (*int)(nil), fmt.Errorf("cassandra timeout"))
+		Return(time.Time{}, false, (*int)(nil), (*time.Time)(nil), fmt.Errorf("cassandra timeout"))
 
 	// No Publish expected when the UPDATE fails.
 
@@ -1552,7 +1552,7 @@ func TestHistoryService_DeleteMessage_ConcurrentDeleteSkipsPublish(t *testing.T)
 	winnerWrote := time.Date(2026, 4, 28, 9, 0, 0, 0, time.UTC)
 	msgs.EXPECT().
 		SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
-		Return(winnerWrote, false, (*int)(nil), nil)
+		Return(winnerWrote, false, (*int)(nil), (*time.Time)(nil), nil)
 
 	// Critically, NO Publish call is expected — gomock will fail the test if
 	// the handler tries to publish on the LWT-not-applied path.
@@ -1580,8 +1580,8 @@ func TestHistoryService_DeleteMessage_PublishFails(t *testing.T) {
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "m-abc").Return(hydrated, nil)
 	msgs.EXPECT().
 		SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, error) {
-			return deletedAt, true, nil, nil
+		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
+			return deletedAt, true, nil, nil, nil
 		})
 
 	pub.EXPECT().
@@ -1610,8 +1610,8 @@ func TestHistoryService_DeleteMessage_PublishesCanonicalDeletedEvent(t *testing.
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
 	msgs.EXPECT().
 		SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, error) {
-			return deletedAt, true, nil, nil
+		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
+			return deletedAt, true, nil, nil, nil
 		})
 
 	pub.EXPECT().
@@ -1694,8 +1694,8 @@ func TestHistoryService_DeleteMessage_ThreadReply_CarriesThreadFields(t *testing
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "reply-1").Return(hydrated, nil)
 	msgs.EXPECT().
 		SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, error) {
-			return deletedAt, true, nil, nil
+		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
+			return deletedAt, true, nil, nil, nil
 		})
 
 	pub.EXPECT().
@@ -1731,8 +1731,8 @@ func TestHistoryService_DeleteMessage_PassesDedupMessageID(t *testing.T) {
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
 	msgs.EXPECT().
 		SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, error) {
-			return deletedAt, true, nil, nil
+		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
+			return deletedAt, true, nil, nil, nil
 		})
 
 	pub.EXPECT().
@@ -1769,10 +1769,11 @@ func TestHistoryService_DeleteMessage_ThreadReply_PublishesThreadMetadataEvent(t
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "reply-1").Return(hydrated, nil)
 
 	newTcount := 4
+	newTlm := time.Date(2026, 5, 14, 12, 30, 0, 0, time.UTC)
 	msgs.EXPECT().
 		SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, error) {
-			return deletedAt, true, &newTcount, nil
+		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
+			return deletedAt, true, &newTcount, &newTlm, nil
 		})
 
 	pub.EXPECT().
@@ -1783,6 +1784,8 @@ func TestHistoryService_DeleteMessage_ThreadReply_PublishesThreadMetadataEvent(t
 			assert.Equal(t, model.EventDeleted, evt.Event)
 			require.NotNil(t, evt.NewTCount)
 			assert.Equal(t, 4, *evt.NewTCount)
+			require.NotNil(t, evt.NewThreadLastMsgAt, "delete event must carry the surviving thread last-message time")
+			assert.True(t, evt.NewThreadLastMsgAt.Equal(newTlm), "NewThreadLastMsgAt must equal the newest surviving reply's createdAt")
 			assert.Equal(t, "reply-1", evt.Message.ID)
 			assert.Equal(t, "r1", evt.Message.RoomID)
 			assert.Equal(t, "parent-1", evt.Message.ThreadParentMessageID)
@@ -1817,8 +1820,8 @@ func TestHistoryService_DeleteMessage_ThreadReply_PublishFailsButDeleteSucceeds(
 	newTcount := 4
 	msgs.EXPECT().
 		SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, error) {
-			return deletedAt, true, &newTcount, nil
+		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
+			return deletedAt, true, &newTcount, nil, nil
 		})
 
 	pub.EXPECT().
@@ -1848,8 +1851,8 @@ func TestHistoryService_DeleteMessage_ThreadReply_NoMetadataEventWhenTCountNil(t
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "reply-1").Return(hydrated, nil)
 	msgs.EXPECT().
 		SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, error) {
-			return deletedAt, true, nil, nil
+		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
+			return deletedAt, true, nil, nil, nil
 		})
 
 	pub.EXPECT().
@@ -2116,7 +2119,7 @@ func TestHistoryService_DeleteMessage_EventDeletedCarriesContent(t *testing.T) {
 	deletedAt := time.Now().UTC()
 	msgs.EXPECT().
 		SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
-		Return(deletedAt, true, (*int)(nil), nil)
+		Return(deletedAt, true, (*int)(nil), (*time.Time)(nil), nil)
 
 	pub.EXPECT().
 		Publish(gomock.Any(), subject.MsgCanonicalDeleted("site-test"), gomock.Any(), gomock.Any()).

--- a/history-service/internal/service/migration.go
+++ b/history-service/internal/service/migration.go
@@ -86,7 +86,7 @@ func (s *HistoryService) MigrationDeleteMessage(c *natsrouter.Context, siteID st
 		return &model.MigrationAck{OK: true}, nil
 	}
 
-	if _, _, _, err := s.msgWriter.SoftDeleteMessage(c, msg, req.DeletedAt); err != nil {
+	if _, _, _, _, err := s.msgWriter.SoftDeleteMessage(c, msg, req.DeletedAt); err != nil {
 		return nil, fmt.Errorf("migration delete message %s: %w", req.MessageID, err)
 	}
 

--- a/history-service/internal/service/migration_test.go
+++ b/history-service/internal/service/migration_test.go
@@ -108,7 +108,7 @@ func TestHistoryService_MigrationDeleteMessage_Success(t *testing.T) {
 		Return(&models.Message{MessageID: "msg-2", RoomID: "r1", CreatedAt: createdAt}, nil)
 	msgs.EXPECT().
 		SoftDeleteMessage(gomock.Any(), migrationLocator("msg-2", "r1", createdAt), deletedAt).
-		Return(deletedAt, true, nil, nil)
+		Return(deletedAt, true, nil, nil, nil)
 
 	pub.EXPECT().
 		PublishMigration(gomock.Any(), subject.MsgCanonicalDeleted("site-test"), gomock.Any(), gomock.Any()).
@@ -148,7 +148,7 @@ func TestHistoryService_MigrationDeleteMessage_WriterError(t *testing.T) {
 		Return(&models.Message{MessageID: "msg-2", RoomID: "r1", CreatedAt: createdAt}, nil)
 	msgs.EXPECT().
 		SoftDeleteMessage(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(time.Time{}, false, nil, errors.New("cassandra down"))
+		Return(time.Time{}, false, nil, nil, errors.New("cassandra down"))
 	pub.EXPECT().PublishMigration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 	ack, err := svc.MigrationDeleteMessage(c, "site-test", model.MigrationDeleteRequest{

--- a/history-service/internal/service/mocks/mock_repository.go
+++ b/history-service/internal/service/mocks/mock_repository.go
@@ -248,14 +248,15 @@ func (mr *MockMessageWriterMockRecorder) RemoveReaction(ctx, msg, key any) *gomo
 }
 
 // SoftDeleteMessage mocks base method.
-func (m *MockMessageWriter) SoftDeleteMessage(ctx context.Context, msg *models.Message, deletedAt time.Time) (time.Time, bool, *int, error) {
+func (m *MockMessageWriter) SoftDeleteMessage(ctx context.Context, msg *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SoftDeleteMessage", ctx, msg, deletedAt)
 	ret0, _ := ret[0].(time.Time)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(*int)
-	ret3, _ := ret[3].(error)
-	return ret0, ret1, ret2, ret3
+	ret3, _ := ret[3].(*time.Time)
+	ret4, _ := ret[4].(error)
+	return ret0, ret1, ret2, ret3, ret4
 }
 
 // SoftDeleteMessage indicates an expected call of SoftDeleteMessage.
@@ -494,14 +495,15 @@ func (mr *MockMessageRepositoryMockRecorder) RemoveReaction(ctx, msg, key any) *
 }
 
 // SoftDeleteMessage mocks base method.
-func (m *MockMessageRepository) SoftDeleteMessage(ctx context.Context, msg *models.Message, deletedAt time.Time) (time.Time, bool, *int, error) {
+func (m *MockMessageRepository) SoftDeleteMessage(ctx context.Context, msg *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SoftDeleteMessage", ctx, msg, deletedAt)
 	ret0, _ := ret[0].(time.Time)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(*int)
-	ret3, _ := ret[3].(error)
-	return ret0, ret1, ret2, ret3
+	ret3, _ := ret[3].(*time.Time)
+	ret4, _ := ret[4].(error)
+	return ret0, ret1, ret2, ret3, ret4
 }
 
 // SoftDeleteMessage indicates an expected call of SoftDeleteMessage.

--- a/history-service/internal/service/service.go
+++ b/history-service/internal/service/service.go
@@ -34,9 +34,11 @@ type MessageWriter interface {
 	// runs the mirror-table and parent-tcount work when the LWT applies.
 	// Returns the updated_at value now persisted (the deletedAt argument when
 	// applied; the existing value when a concurrent delete won the race).
-	// newTcount is non-nil when the parent's tcount was decremented via CAS;
+	// newTcount is non-nil when the parent's tcount was recomputed via CAS;
 	// nil means the CAS was skipped (e.g. parent row not found, or msg is not a thread reply).
-	SoftDeleteMessage(ctx context.Context, msg *models.Message, deletedAt time.Time) (actualDeletedAt time.Time, applied bool, newTcount *int, err error)
+	// newThreadLastMsgAt is the newest surviving reply's createdAt (nil when none survive or the
+	// CAS was skipped), letting the caller carry it on the canonical event without a second read.
+	SoftDeleteMessage(ctx context.Context, msg *models.Message, deletedAt time.Time) (actualDeletedAt time.Time, applied bool, newTcount *int, newThreadLastMsgAt *time.Time, err error)
 	PinMessage(ctx context.Context, msg *models.Message, pinnedAt time.Time, pinnedBy models.Participant) error
 	UnpinMessage(ctx context.Context, msg *models.Message) error
 	// AddReaction writes one (emoji, user_account) map-cell to every mirror; idempotent.


### PR DESCRIPTION
## Summary

When a thread reply is deleted, the client-facing `thread_metadata_updated` event carried the updated reply count (`newTcount`) but **not** the refreshed thread last-message time (`newThreadLastMsgAt`) — the field was always absent/null on the delete path.

The root cause was upstream in `history-service`, not in broadcast-worker:

- `SoftDeleteMessage` (Cassandra repo) **already** recomputed the newest surviving reply's `createdAt` (tlm) via `pkg/threadcount.CountAndLatest` and **persisted it to Cassandra** (`thread_last_msg_at` on the parent, both `messages_by_id` and `messages_by_room`).
- But it **discarded** that value before returning, propagating only `newTcount`.
- So `DeleteMessage` never set `NewThreadLastMsgAt` on the canonical `MessageEvent`, and broadcast-worker (which faithfully forwards `evt.NewThreadLastMsgAt`) sent a nil field to clients.

This PR threads the already-computed tlm out of `SoftDeleteMessage` — alongside `newTcount`, exactly mirroring the existing plumbing — and sets it on the canonical delete event. broadcast-worker already forwards the field, so the value now reaches clients on the delete badge.

## Changes

- `history-service/internal/cassrepo/write.go` — `SoftDeleteMessage` and its `countAndSetParentTcount` helper now return the surviving-max `newThreadLastMsgAt *time.Time` (nil when no replies survive or the CAS is skipped).
- `history-service/internal/service/messages.go` — `DeleteMessage` sets `NewThreadLastMsgAt` on the canonical `MessageEvent`, symmetric with `NewTCount`.
- `history-service/internal/service/service.go` — `MessageWriter` interface signature + doc updated.
- `history-service/internal/service/migration.go` — call-site updated; the migration delete path **intentionally** continues to discard the value, consistent with it emitting a bare canonical marker (it already discards `newTcount` and omits all other thread-metadata fields).
- Regenerated `mock_repository.go`.

## Cost / behavior

Zero new Cassandra work — the value was already computed and stored; it is simply no longer dropped. No client-facing struct changed: `ThreadMetadataUpdatedEvent.newThreadLastMsgAt` already exists and `docs/client-api.md` already documents it as "the most recent surviving thread reply, absent when `newTcount` is 0". This PR brings the code in line with that already-documented contract, so no docs change is required.

## Tests

- **Repo integration tests** (`write_integration_test.go`): assert the returned tlm equals the newest surviving reply's `createdAt`, and is nil after the last reply is deleted.
- **Service unit test** (`messages_test.go`): asserts the canonical delete event now carries `NewThreadLastMsgAt`.
- **broadcast-worker handler test** (`handler_test.go`): asserts the surviving tlm is forwarded on the delete badge to the client.

Unit suites for `history-service` and `broadcast-worker` pass (`-race`). Integration tests compile (require Docker, not run in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KK77s2fVFYz3TXAHSCT2XU

---
_Generated by [Claude Code](https://claude.ai/code/session_01KK77s2fVFYz3TXAHSCT2XU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a thread reply now correctly updates the thread’s latest-message timestamp.
  * Canonical deletion events now include the timestamp of the newest remaining reply.
  * Thread metadata remains accurate when deleting the last remaining reply, including resetting the reply count and latest-message timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->