### PR TITLE
perf(user-service): scope thread-sub read to pending rooms in unread count

### DIFF
--- a/user-service/mongorepo/threadsubscriptions.go
+++ b/user-service/mongorepo/threadsubscriptions.go
@@ -44,12 +44,35 @@ func (r *ThreadSubscriptionRepo) EnsureIndexes(ctx context.Context) error {
 // ListByAccount returns the account's newest maxThreadSubscriptions accessible
 // thread-subs (across every site), newest-first, each carrying its room type.
 func (r *ThreadSubscriptionRepo) ListByAccount(ctx context.Context, account string) ([]model.ThreadUnreadRow, error) {
+	return r.list(ctx, account, nil)
+}
+
+// ListByAccountInRooms returns the account's accessible thread-subs whose parent room
+// is in roomIDs — the read-room candidates for the unread count. Filtering by room in
+// the query (rather than fetching all thread-subs and filtering client-side) returns
+// fewer documents and scopes the newest-N cap to the candidate rooms, so a candidate
+// room's thread can't be crowded out of the cap by threads in other rooms. Returns nil
+// for an empty roomIDs list.
+func (r *ThreadSubscriptionRepo) ListByAccountInRooms(ctx context.Context, account string, roomIDs []string) ([]model.ThreadUnreadRow, error) {
+	if len(roomIDs) == 0 {
+		return nil, nil
+	}
+	return r.list(ctx, account, roomIDs)
+}
+
+// list runs the account's accessible-thread-sub aggregation, newest-first, optionally
+// restricted to parent rooms in roomIDs (nil ⇒ all rooms).
+func (r *ThreadSubscriptionRepo) list(ctx context.Context, account string, roomIDs []string) ([]model.ThreadUnreadRow, error) {
 	// $lookup justification: the join reads three facts off the account's
 	// subscription row — membership (access gate), unsubscribed-app status, and
 	// roomType (DM tally) — and applies the gate BEFORE the limit so an
 	// inaccessible thread can't crowd out a live one. Both keys are indexed.
+	match := bson.M{"userAccount": account}
+	if roomIDs != nil {
+		match["roomId"] = bson.M{"$in": roomIDs}
+	}
 	pipeline := bson.A{
-		bson.M{"$match": bson.M{"userAccount": account}},
+		bson.M{"$match": match},
 		bson.M{"$sort": bson.D{{Key: "createdAt", Value: -1}}},
 		bson.M{"$lookup": bson.M{
 			"from": subscriptionsCollection,

--- a/user-service/mongorepo/threadsubscriptions_test.go
+++ b/user-service/mongorepo/threadsubscriptions_test.go
@@ -140,3 +140,42 @@ func TestThreadSubscriptionRepo_ListByAccount_NewestCappedAndOrdered(t *testing.
 		assert.NotEqual(t, "0000", r.ThreadRoomID)
 	}
 }
+
+// ListByAccountInRooms restricts the read to threads whose parent room is in the given
+// list, applying the same membership/app gate; an empty room list short-circuits to none.
+func TestThreadSubscriptionRepo_ListByAccountInRooms(t *testing.T) {
+	db := testutil.MongoDB(t, "user_service_threadsubs_inrooms")
+	ctx := context.Background()
+	_, err := db.Collection("thread_subscriptions").InsertMany(ctx, []interface{}{
+		model.ThreadSubscription{ID: "1", ThreadRoomID: "tr1", RoomID: "r1", UserAccount: "alice", SiteID: "site-a"},
+		model.ThreadSubscription{ID: "2", ThreadRoomID: "tr2", RoomID: "r2", UserAccount: "alice", SiteID: "site-a"},
+		model.ThreadSubscription{ID: "3", ThreadRoomID: "tr3", RoomID: "r3", UserAccount: "alice", SiteID: "site-a"},
+	})
+	require.NoError(t, err)
+	_, err = db.Collection("subscriptions").InsertMany(ctx, []interface{}{
+		sub("s1", "alice", "r1", model.RoomTypeChannel, false),
+		sub("s2", "alice", "r2", model.RoomTypeChannel, false),
+		sub("s3", "alice", "r3", model.RoomTypeChannel, false),
+	})
+	require.NoError(t, err)
+
+	repo := NewThreadSubscriptionRepo(db)
+
+	// Only threads in the requested rooms come back.
+	rows, err := repo.ListByAccountInRooms(ctx, "alice", []string{"r1", "r3"})
+	require.NoError(t, err)
+	byThread := map[string]model.ThreadUnreadRow{}
+	for _, r := range rows {
+		byThread[r.ThreadRoomID] = r
+	}
+	require.Len(t, rows, 2)
+	assert.Contains(t, byThread, "tr1")
+	assert.Contains(t, byThread, "tr3")
+	assert.Equal(t, "r1", byThread["tr1"].RoomID)
+	assert.NotContains(t, byThread, "tr2") // r2 not requested
+
+	// Empty room list short-circuits without querying.
+	empty, err := repo.ListByAccountInRooms(ctx, "alice", nil)
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+}

--- a/user-service/service/mocks/mock_repository.go
+++ b/user-service/service/mocks/mock_repository.go
@@ -598,3 +598,18 @@ func (mr *MockThreadSubscriptionRepositoryMockRecorder) ListByAccount(ctx, accou
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByAccount", reflect.TypeOf((*MockThreadSubscriptionRepository)(nil).ListByAccount), ctx, account)
 }
+
+// ListByAccountInRooms mocks base method.
+func (m *MockThreadSubscriptionRepository) ListByAccountInRooms(ctx context.Context, account string, roomIDs []string) ([]model.ThreadUnreadRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListByAccountInRooms", ctx, account, roomIDs)
+	ret0, _ := ret[0].([]model.ThreadUnreadRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListByAccountInRooms indicates an expected call of ListByAccountInRooms.
+func (mr *MockThreadSubscriptionRepositoryMockRecorder) ListByAccountInRooms(ctx, account, roomIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByAccountInRooms", reflect.TypeOf((*MockThreadSubscriptionRepository)(nil).ListByAccountInRooms), ctx, account, roomIDs)
+}

--- a/user-service/service/service.go
+++ b/user-service/service/service.go
@@ -54,6 +54,7 @@ type RoomClient interface {
 // the thread-unread badge.
 type ThreadSubscriptionRepository interface {
 	ListByAccount(ctx context.Context, account string) ([]model.ThreadUnreadRow, error)
+	ListByAccountInRooms(ctx context.Context, account string, roomIDs []string) ([]model.ThreadUnreadRow, error)
 }
 
 // HistoryClient is the consumer-defined interface for per-site history-service

--- a/user-service/service/service_test.go
+++ b/user-service/service/service_test.go
@@ -29,9 +29,9 @@ func newSvc(t *testing.T) (*UserService, *mocks.MockSubscriptionRepository, *moc
 	// ListSubscriptions now enriches last-message via history.RoomsGet; default it to a
 	// no-op so list tests that don't exercise last-message need no per-test stub.
 	history.EXPECT().RoomsGet(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
-	// countUnread's thread phase reads thread-subs; default to none so room-count
-	// tests that don't exercise threads need no per-test stub.
-	threadSubs.EXPECT().ListByAccount(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	// countUnread's thread phase reads pending rooms' thread-subs; default to none so
+	// room-count tests that don't exercise threads need no per-test stub.
+	threadSubs.EXPECT().ListByAccountInRooms(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	// The same mock backs both publishers (federation + client fanout) —
 	// expectations are subject-scoped, so tests stay unambiguous.
 	return New(subs, users, apps, threadSubs, rooms, history, presence, pub, pub, cfg), subs, users, apps, rooms, history, pub

--- a/user-service/service/subscriptions.go
+++ b/user-service/service/subscriptions.go
@@ -667,21 +667,26 @@ func (s *UserService) countUnread(ctx context.Context, account string, total int
 }
 
 // countThreadOnlyUnread returns how many pendingRooms (rooms already READ at the message
-// level, roomID -> siteID) have >=1 unread followed thread — at most +1 per room. Thread
-// last-activity is resolved per owning site via GetThreadRoomInfoBatch, degrading like the
-// room pass: a failed site contributes nothing. A ListByAccount failure logs and returns 0
-// so a thread-subsystem hiccup never discards the established room-level count.
+// level, roomID -> siteID) have >=1 unread followed thread — at most +1 per room. Only the
+// pending rooms' thread-subs are read (scoped in the query), then thread last-activity is
+// resolved per owning site via GetThreadRoomInfoBatch, degrading like the room pass: a
+// failed site contributes nothing. A thread-sub read failure logs and returns 0 so a
+// thread-subsystem hiccup never discards the established room-level count.
 func (s *UserService) countThreadOnlyUnread(ctx context.Context, account string, pendingRooms map[string]string) int {
 	if len(pendingRooms) == 0 {
 		return 0
 	}
-	rows, err := s.threadSubs.ListByAccount(ctx, account)
+	roomIDs := make([]string, 0, len(pendingRooms))
+	for roomID := range pendingRooms {
+		roomIDs = append(roomIDs, roomID)
+	}
+	rows, err := s.threadSubs.ListByAccountInRooms(ctx, account, roomIDs)
 	if err != nil {
 		slog.WarnContext(ctx, "unread count: thread subscriptions read failed", "account", account, "request_id", natsutil.RequestIDFromContext(ctx), "error", err)
 		return 0
 	}
 
-	// Keep only threads whose parent room is a pending (read) candidate; group by owning site.
+	// Rows are already scoped to the pending rooms by the query; group by owning site.
 	type threadCand struct {
 		roomID     string
 		lastSeenAt *time.Time
@@ -689,9 +694,6 @@ func (s *UserService) countThreadOnlyUnread(ctx context.Context, account string,
 	idsBySite := map[string][]string{}
 	byThread := make(map[string]threadCand, len(rows))
 	for i := range rows {
-		if _, ok := pendingRooms[rows[i].RoomID]; !ok {
-			continue
-		}
 		idsBySite[rows[i].SiteID] = append(idsBySite[rows[i].SiteID], rows[i].ThreadRoomID)
 		byThread[rows[i].ThreadRoomID] = threadCand{roomID: rows[i].RoomID, lastSeenAt: rows[i].LastSeenAt}
 	}

--- a/user-service/service/subscriptions_test.go
+++ b/user-service/service/subscriptions_test.go
@@ -804,8 +804,8 @@ func TestCountUnread_ReadRoomBumpedByUnreadThread(t *testing.T) {
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
 		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
 	}, nil)
-	// One followed thread in r1, unread (thread lastMsgAt 200 > lastSeen 100).
-	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
+	// Only the pending (read) room r1 is queried; it has one unread followed thread.
+	threadSubs.EXPECT().ListByAccountInRooms(gomock.Any(), "alice", []string{"r1"}).Return([]model.ThreadUnreadRow{
 		{ThreadRoomID: "tr1", RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen},
 	}, nil)
 	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), "site-a", []string{"tr1"}).
@@ -825,8 +825,8 @@ func TestCountUnread_AlreadyUnreadRoomNotDoubleCounted(t *testing.T) {
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
 		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &newer},
 	}, nil)
-	// Every room already unread ⇒ pendingRooms empty ⇒ ListByAccount never called.
-	threadSubs.EXPECT().ListByAccount(gomock.Any(), gomock.Any()).Times(0)
+	// Every room already unread ⇒ pendingRooms empty ⇒ no thread-sub read.
+	threadSubs.EXPECT().ListByAccountInRooms(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	yes := true
 	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
@@ -843,7 +843,7 @@ func TestCountUnread_MultipleUnreadThreadsCountOnce(t *testing.T) {
 		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
 	}, nil)
 	// Three unread threads, all in r1 → +1 total.
-	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
+	threadSubs.EXPECT().ListByAccountInRooms(gomock.Any(), "alice", []string{"r1"}).Return([]model.ThreadUnreadRow{
 		{ThreadRoomID: "tr1", RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen},
 		{ThreadRoomID: "tr2", RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen},
 		{ThreadRoomID: "tr3", RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen},
@@ -869,10 +869,9 @@ func TestCountUnread_ThreadInRoomOutsidePageIgnored(t *testing.T) {
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
 		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
 	}, nil)
-	// Thread lives in rX, which is NOT in the fetched page → must be filtered out, no batch call.
-	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
-		{ThreadRoomID: "trX", RoomID: "rX", SiteID: "site-a", LastSeenAt: &seen},
-	}, nil)
+	// The thread read is scoped to the pending room list — only r1 is queried, so a
+	// thread in some other room (rX) is never fetched. Repo returns no threads for r1.
+	threadSubs.EXPECT().ListByAccountInRooms(gomock.Any(), "alice", []string{"r1"}).Return(nil, nil)
 	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	yes := true
 	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
@@ -892,7 +891,7 @@ func TestCountUnread_CrossSiteThreadResolution(t *testing.T) {
 	rooms.EXPECT().GetRoomsInfo(gomock.Any(), "site-b", []string{"r1"}).
 		Return([]model.RoomInfo{{RoomID: "r1", Found: true, LastMsgAt: &older}}, nil)
 	// A followed thread in r1 on site-b, unread → resolved via the site-b batch.
-	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
+	threadSubs.EXPECT().ListByAccountInRooms(gomock.Any(), "alice", []string{"r1"}).Return([]model.ThreadUnreadRow{
 		{ThreadRoomID: "tr1", RoomID: "r1", SiteID: "site-b", LastSeenAt: &seen},
 	}, nil)
 	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), "site-b", []string{"tr1"}).
@@ -911,7 +910,7 @@ func TestCountUnread_ThreadBatchFailureDegrades(t *testing.T) {
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
 		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
 	}, nil)
-	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
+	threadSubs.EXPECT().ListByAccountInRooms(gomock.Any(), "alice", []string{"r1"}).Return([]model.ThreadUnreadRow{
 		{ThreadRoomID: "tr1", RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen},
 	}, nil)
 	// Thread resolution fails → room un-bumped, count degrades to 0, no error.
@@ -932,7 +931,7 @@ func TestCountUnread_ThreadListErrorDegrades(t *testing.T) {
 		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
 	}, nil)
 	// Local thread-sub read fails → degrade to the room-level count (0), never error.
-	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return(nil, errors.New("db down"))
+	threadSubs.EXPECT().ListByAccountInRooms(gomock.Any(), "alice", []string{"r1"}).Return(nil, errors.New("db down"))
 	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	yes := true
 	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
@@ -950,11 +949,9 @@ func TestCountUnread_MutedRoomThreadExcluded(t *testing.T) {
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1).Return([]model.EnrichedSubscription{
 		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
 	}, nil)
-	// A thread in the muted room "rMuted" is returned by ListByAccount but its room is
-	// not in the page → filtered out, no batch, no bump.
-	threadSubs.EXPECT().ListByAccount(gomock.Any(), "alice").Return([]model.ThreadUnreadRow{
-		{ThreadRoomID: "trM", RoomID: "rMuted", SiteID: "site-a", LastSeenAt: &seen},
-	}, nil)
+	// The muted room is not in the fetched page, so it's not in the pending-room list;
+	// only r1 is queried and it has no threads. The muted room can never bump.
+	threadSubs.EXPECT().ListByAccountInRooms(gomock.Any(), "alice", []string{"r1"}).Return(nil, nil)
 	rooms.EXPECT().GetThreadRoomInfoBatch(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	yes := true
 	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})


### PR DESCRIPTION
## Summary

Follow-up to #74 (merged). Addresses @mliu33's review suggestion: instead of fetching **all** of an account's thread subscriptions and filtering by room in Go, `countThreadOnlyUnread` now reads only the pending (message-read) rooms' thread-subs directly in the Mongo query.

## Changes

- **`ListByAccountInRooms(account, roomIDs)`** — new repo method (interface + Mongo impl) that adds `roomId: {$in: roomIDs}` to the thread-sub aggregation. Shares a private `list(...)` helper with `ListByAccount` (same access gate, sort, cap, projection).
- **`countThreadOnlyUnread`** — passes the pending-room IDs and consumes the pre-scoped rows; the previous client-side room filter is removed.
- Mock, `newSvc` default, the count unit tests, and a new `ListByAccountInRooms` integration test updated accordingly.

## Why

- Fewer documents returned from Mongo (only threads in candidate rooms).
- The newest-N (500) cap is now scoped to the candidate rooms, so a read room's unread thread can no longer be crowded out of the cap by threads in already-unread rooms — a small correctness win on top of the performance one.

## Behavior / API

No client-facing change — `subscription.count` returns the same value. Request/response contract (`{count}`) is unchanged, so no `docs/client-api.md` edit.

## Verification

- Unit tests pass with `-race` (service + model)
- Full `user-service` build clean (real repo satisfies the extended interface)
- `make lint` — 0 issues
- The new `ListByAccountInRooms` integration test compiles under `-tags=integration`; it requires Docker/CI to execute (not available in the authoring environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1KpWHPKcQmNo2ugynwCPf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thread unread counts can now be retrieved specifically for selected rooms.
  * Unread thread processing is scoped to relevant rooms for more targeted results.

* **Bug Fixes**
  * Prevented thread subscriptions from unrelated rooms from affecting unread counts.
  * Empty room selections now return no thread results immediately.

* **Tests**
  * Added coverage for room-specific filtering, empty selections, and unread-count error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->