### PR TITLE
Batch clear-all-thread-unread federation and drop clearedThreads (PR #77 follow-up)

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -5121,11 +5121,10 @@ Empty object.
 
 | Field | Type | Notes |
 |---|---|---|
-| `clearedThreads` | number | Total thread subscriptions cleared across all responding sites. `0` when nothing was unread. |
 | `unavailableSites` | string[] | Optional. Sites whose per-site clear failed; their threads may remain unread. Omitted when all responded. |
 
 ```json
-{ "clearedThreads": 7 }
+{}
 ```
 
 ##### Error response

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -1755,7 +1755,8 @@ failures degrade into `unavailableSites` rather than erroring.
 `{siteID}` is the **caller's own home site**. Clears the unread status of all of the
 user's threads across every site — the "mark all threads read" action. `user-service`
 asks each owning site's `room-service` to clear that user's thread-subscription read
-state and room-subscription thread-unread state.
+state and room-subscription thread-unread state; each remote site converges the user's
+home replica via one `thread_read_all` inbox event.
 
 #### Request body
 
@@ -1763,7 +1764,7 @@ Empty object: `{}`.
 
 #### Success response
 
-`{ "clearedThreads": number, "unavailableSites"?: string[] }` — see
+`{ "unavailableSites"?: string[] }` — see
 [../client-api.md §3.4](../client-api.md#clear-all-thread-unread). A bulk dismiss:
 clears only the requester's own read state; does not advance thread read floors or emit
 `thread_message_read`. Per-site RPC failures degrade into `unavailableSites`.

--- a/docs/superpowers/specs/2026-07-16-user-thread-read-all-rpc-design.md
+++ b/docs/superpowers/specs/2026-07-16-user-thread-read-all-rpc-design.md
@@ -240,3 +240,22 @@ failed site is recorded in `unavailableSites` and never cancels its siblings.
   right affected set/count.
 - Run `make generate` (mocks) before tests; `make lint`, `make test`, and
   `make sast` before pushing.
+
+## 11. Post-merge follow-up (PR #77 review)
+
+Review feedback (mliu33) revised the federation and response shape after the
+initial merge:
+
+- **Federation is now one batched event, not per-thread.** §4/§7's per-thread
+  `thread_read` federation is replaced by a single `thread_read_all`
+  (`InboxThreadReadAll`) event per remote peer. `inbox-worker` applies it as a
+  bulk clear on the user's home replica — advancing every one of the account's
+  thread subscriptions under a per-doc `$lt` guard and clearing every
+  subscription's `threadUnread`/`alert` — mirroring the source-site write. This
+  drops the O(threads) event volume to O(remote-sites).
+- **`ClearThreadSubscriptionsForAccount` no longer snapshots rows.** It is a
+  single account-scoped `UpdateMany`, so no Find/Update window can miss a
+  concurrently inserted row (addresses the scope-to-rows-read comment).
+- **`clearedThreads` removed from the response.** The client-facing
+  `ThreadReadAllResponse` and the internal `RoomThreadReadAllResponse` no longer
+  carry a count (not used by the frontend); success is `{ unavailableSites? }`.

--- a/inbox-worker/handler.go
+++ b/inbox-worker/handler.go
@@ -40,6 +40,11 @@ type InboxStore interface {
 	UpsertThreadSubscription(ctx context.Context, sub *model.ThreadSubscription) error
 	// ApplyThreadRead writes ThreadSubscription under a $lt lastSeenAt guard, then the Subscription only if the guard accepted.
 	ApplyThreadRead(ctx context.Context, roomID, threadRoomID, account string, newThreadUnread []string, alert bool, lastSeenAt time.Time) error
+	// ApplyThreadReadAll is the federated "mark all threads read" bulk clear on the
+	// user's home replica: it advances every one of account's thread subscriptions
+	// to lastSeenAt under a per-doc $lt guard (clearing hasMention), and clears
+	// threadUnread + alert on every subscription that still has unread threads.
+	ApplyThreadReadAll(ctx context.Context, account string, lastSeenAt time.Time) error
 	// UpdateSubscriptionMute sets muted by (roomID, account), guarded by
 	// muteUpdatedAt (the source event's publish time): older/duplicate events
 	// are silent no-ops. A genuinely missing sub returns an error (Nak) so the event redelivers until member_added lands.
@@ -106,6 +111,8 @@ func (h *Handler) HandleEvent(ctx context.Context, data []byte) error {
 		return h.handleThreadSubscriptionUpserted(ctx, &evt)
 	case "thread_read":
 		return h.handleThreadRead(ctx, &evt)
+	case model.InboxThreadReadAll:
+		return h.handleThreadReadAll(ctx, &evt)
 	case model.InboxRoomRenamed:
 		return h.handleRoomRenamed(ctx, &evt)
 	case model.InboxRoomRestricted:
@@ -313,6 +320,18 @@ func (h *Handler) handleThreadRead(ctx context.Context, evt *model.InboxEvent) e
 	if err := h.store.ApplyThreadRead(ctx, e.RoomID, e.ThreadRoomID, e.Account, e.NewThreadUnread, e.Alert, lastSeenAt); err != nil {
 		return fmt.Errorf("apply thread read (room %q, thread %q, account %q): %w",
 			e.RoomID, e.ThreadRoomID, e.Account, err)
+	}
+	return nil
+}
+
+func (h *Handler) handleThreadReadAll(ctx context.Context, evt *model.InboxEvent) error {
+	var e model.ThreadReadAllEvent
+	if err := json.Unmarshal(evt.Payload, &e); err != nil {
+		return fmt.Errorf("unmarshal thread_read_all payload: %w", err)
+	}
+	lastSeenAt := time.UnixMilli(e.LastSeenAt).UTC()
+	if err := h.store.ApplyThreadReadAll(ctx, e.Account, lastSeenAt); err != nil {
+		return fmt.Errorf("apply thread read all (account %q): %w", e.Account, err)
 	}
 	return nil
 }

--- a/inbox-worker/handler_test.go
+++ b/inbox-worker/handler_test.go
@@ -71,25 +71,32 @@ type threadRead struct {
 	lastSeenAt      time.Time
 }
 
+type threadReadAll struct {
+	account    string
+	lastSeenAt time.Time
+}
+
 type stubInboxStore struct {
-	mu                 sync.Mutex
-	subscriptions      []model.Subscription
-	bulkSubscriptions  []*model.Subscription
-	bulkCreateErr      error
-	rooms              []model.Room
-	roleUpdates        []roleUpdate
-	muteUpdates        []muteUpdate
-	favoriteUpdates    []favoriteUpdate
-	nameUpdates        []nameUpdate
-	visibilityUpdates  []visibilityUpdate
-	users              []model.User
-	subReads           []subRead
-	threadSubs         []model.ThreadSubscription
-	threadReads        []threadRead
-	applyThreadReadErr error
-	userStatusUpdates  []userStatusUpdate
-	userStatusErr      error
-	settingsUpdates    []userSettingsUpdate
+	mu                    sync.Mutex
+	subscriptions         []model.Subscription
+	bulkSubscriptions     []*model.Subscription
+	bulkCreateErr         error
+	rooms                 []model.Room
+	roleUpdates           []roleUpdate
+	muteUpdates           []muteUpdate
+	favoriteUpdates       []favoriteUpdate
+	nameUpdates           []nameUpdate
+	visibilityUpdates     []visibilityUpdate
+	users                 []model.User
+	subReads              []subRead
+	threadSubs            []model.ThreadSubscription
+	threadReads           []threadRead
+	applyThreadReadErr    error
+	threadReadAlls        []threadReadAll
+	applyThreadReadAllErr error
+	userStatusUpdates     []userStatusUpdate
+	userStatusErr         error
+	settingsUpdates       []userSettingsUpdate
 }
 
 type userSettingsUpdate struct {
@@ -284,6 +291,16 @@ func (s *stubInboxStore) ApplyThreadRead(_ context.Context, roomID, threadRoomID
 		roomID: roomID, threadRoomID: threadRoomID, account: account,
 		newThreadUnread: newThreadUnread, alert: alert, lastSeenAt: lastSeenAt,
 	})
+	return nil
+}
+
+func (s *stubInboxStore) ApplyThreadReadAll(_ context.Context, account string, lastSeenAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.applyThreadReadAllErr != nil {
+		return s.applyThreadReadAllErr
+	}
+	s.threadReadAlls = append(s.threadReadAlls, threadReadAll{account: account, lastSeenAt: lastSeenAt})
 	return nil
 }
 
@@ -1526,6 +1543,44 @@ func TestHandler_HandleEvent_ThreadRead_StoreError(t *testing.T) {
 	payload := model.ThreadReadEvent{Account: "a", RoomID: "r", ThreadRoomID: "tr", ParentMessageID: "p"}
 	inner, _ := json.Marshal(&payload)
 	outer := model.InboxEvent{Type: model.InboxThreadRead, Payload: inner}
+	data, _ := json.Marshal(&outer)
+	err := h.HandleEvent(context.Background(), data)
+	require.Error(t, err)
+}
+
+func TestHandler_HandleEvent_ThreadReadAll_Happy(t *testing.T) {
+	store := &stubInboxStore{}
+	h := NewHandler(store)
+	payload := model.ThreadReadAllEvent{Account: "alice", LastSeenAt: 1735689600000, Timestamp: 1735689600001}
+	inner, err := json.Marshal(&payload)
+	require.NoError(t, err)
+	outer := model.InboxEvent{Type: model.InboxThreadReadAll, SiteID: "site-a", DestSiteID: "site-b", Payload: inner}
+	data, err := json.Marshal(&outer)
+	require.NoError(t, err)
+
+	require.NoError(t, h.HandleEvent(context.Background(), data))
+	require.Len(t, store.threadReadAlls, 1)
+	assert.Equal(t, "alice", store.threadReadAlls[0].account)
+	assert.Equal(t, time.UnixMilli(1735689600000).UTC(), store.threadReadAlls[0].lastSeenAt)
+}
+
+func TestHandler_HandleEvent_ThreadReadAll_MalformedPayload(t *testing.T) {
+	store := &stubInboxStore{}
+	h := NewHandler(store)
+	outer := model.InboxEvent{Type: model.InboxThreadReadAll, Payload: []byte("{")}
+	data, err := json.Marshal(&outer)
+	require.NoError(t, err)
+	err = h.HandleEvent(context.Background(), data)
+	require.Error(t, err)
+	assert.Len(t, store.threadReadAlls, 0)
+}
+
+func TestHandler_HandleEvent_ThreadReadAll_StoreError(t *testing.T) {
+	store := &stubInboxStore{applyThreadReadAllErr: fmt.Errorf("boom")}
+	h := NewHandler(store)
+	payload := model.ThreadReadAllEvent{Account: "alice", LastSeenAt: 1}
+	inner, _ := json.Marshal(&payload)
+	outer := model.InboxEvent{Type: model.InboxThreadReadAll, Payload: inner}
 	data, _ := json.Marshal(&outer)
 	err := h.HandleEvent(context.Background(), data)
 	require.Error(t, err)

--- a/inbox-worker/integration_test.go
+++ b/inbox-worker/integration_test.go
@@ -730,6 +730,62 @@ func TestInboxStore_ApplyThreadRead_HappyPath(t *testing.T) {
 	assert.False(t, gotTS.HasMention)
 }
 
+func TestInboxStore_ApplyThreadReadAll_HappyPath(t *testing.T) {
+	db := setupMongo(t)
+	store := &mongoInboxStore{
+		subCol:       db.Collection("subscriptions"),
+		threadSubCol: db.Collection("thread_subscriptions"),
+	}
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	// alice: two thread subs (one older lastSeenAt, one unread/never seen) + one
+	// thread sub already read in the FUTURE (guard must not regress it).
+	_, err := db.Collection("thread_subscriptions").InsertMany(ctx, []any{
+		bson.M{"_id": "tsA1", "threadRoomId": "tr1", "roomId": "r1", "parentMessageId": "p1", "userAccount": "alice", "siteId": "site-b", "hasMention": true, "lastSeenAt": now.Add(-time.Hour)},
+		bson.M{"_id": "tsA2", "threadRoomId": "tr2", "roomId": "r2", "parentMessageId": "p2", "userAccount": "alice", "siteId": "site-b", "hasMention": false},
+		bson.M{"_id": "tsA3", "threadRoomId": "tr3", "roomId": "r3", "parentMessageId": "p3", "userAccount": "alice", "siteId": "site-b", "hasMention": true, "lastSeenAt": now.Add(time.Hour)},
+		bson.M{"_id": "tsB1", "threadRoomId": "tr9", "roomId": "r1", "parentMessageId": "p9", "userAccount": "bob", "siteId": "site-b", "hasMention": true},
+	})
+	require.NoError(t, err)
+
+	_, err = db.Collection("subscriptions").InsertMany(ctx, []any{
+		&model.Subscription{ID: "sA1", RoomID: "r1", SiteID: "site-b", User: model.SubscriptionUser{ID: "uA", Account: "alice"}, ThreadUnread: []string{"p1", "p2"}, Alert: true},
+		&model.Subscription{ID: "sB1", RoomID: "r1", SiteID: "site-b", User: model.SubscriptionUser{ID: "uB", Account: "bob"}, ThreadUnread: []string{"p9"}, Alert: true},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, store.ApplyThreadReadAll(ctx, "alice", now))
+
+	// tsA1 (older) + tsA2 (never seen) advanced to now, hasMention cleared.
+	for _, id := range []string{"tsA1", "tsA2"} {
+		var ts model.ThreadSubscription
+		require.NoError(t, db.Collection("thread_subscriptions").FindOne(ctx, bson.M{"_id": id}).Decode(&ts))
+		require.NotNil(t, ts.LastSeenAt, id)
+		assert.Equal(t, now, ts.LastSeenAt.UTC().Truncate(time.Millisecond), id)
+		assert.False(t, ts.HasMention, id)
+	}
+	// tsA3 (future read) must NOT be regressed by the guard.
+	var ts3 model.ThreadSubscription
+	require.NoError(t, db.Collection("thread_subscriptions").FindOne(ctx, bson.M{"_id": "tsA3"}).Decode(&ts3))
+	assert.Equal(t, now.Add(time.Hour), ts3.LastSeenAt.UTC().Truncate(time.Millisecond))
+
+	// alice's subscription: threadUnread unset, alert cleared.
+	var rawA model.Subscription
+	require.NoError(t, db.Collection("subscriptions").FindOne(ctx, bson.M{"_id": "sA1"}).Decode(&rawA))
+	assert.Empty(t, rawA.ThreadUnread)
+	assert.False(t, rawA.Alert)
+
+	// bob untouched.
+	var tsB model.ThreadSubscription
+	require.NoError(t, db.Collection("thread_subscriptions").FindOne(ctx, bson.M{"_id": "tsB1"}).Decode(&tsB))
+	assert.Nil(t, tsB.LastSeenAt)
+	var subB model.Subscription
+	require.NoError(t, db.Collection("subscriptions").FindOne(ctx, bson.M{"_id": "sB1"}).Decode(&subB))
+	assert.Equal(t, []string{"p9"}, subB.ThreadUnread)
+	assert.True(t, subB.Alert)
+}
+
 func TestInboxStore_ApplyThreadRead_EmptyArrayUnsetsField(t *testing.T) {
 	db := setupMongo(t)
 	store := &mongoInboxStore{

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -453,6 +453,36 @@ func (s *mongoInboxStore) ApplyThreadRead(ctx context.Context, roomID, threadRoo
 	return nil
 }
 
+// ApplyThreadReadAll is the home-replica bulk clear for the federated
+// thread_read_all event. It advances every one of account's thread subscriptions
+// to lastSeenAt under a per-doc $lt guard (so a genuinely newer read is never
+// regressed) and clears threadUnread + alert on every subscription that still has
+// unread threads. Missing docs are a no-op (the mark-all dismiss is best-effort).
+func (s *mongoInboxStore) ApplyThreadReadAll(ctx context.Context, account string, lastSeenAt time.Time) error {
+	tsFilter := bson.M{
+		"userAccount": account,
+		"$or": bson.A{
+			bson.M{"lastSeenAt": nil},
+			bson.M{"lastSeenAt": bson.M{"$lt": lastSeenAt}},
+		},
+	}
+	tsUpdate := bson.M{"$set": bson.M{
+		"lastSeenAt": lastSeenAt,
+		"updatedAt":  lastSeenAt,
+		"hasMention": false,
+	}}
+	if _, err := s.threadSubCol.UpdateMany(ctx, tsFilter, tsUpdate); err != nil {
+		return fmt.Errorf("apply thread read all on thread subscriptions for %q: %w", account, err)
+	}
+
+	subFilter := bson.M{"u.account": account, "threadUnread.0": bson.M{"$exists": true}}
+	subUpdate := bson.M{"$set": bson.M{"alert": false}, "$unset": bson.M{"threadUnread": ""}}
+	if _, err := s.subCol.UpdateMany(ctx, subFilter, subUpdate); err != nil {
+		return fmt.Errorf("apply thread read all on subscriptions for %q: %w", account, err)
+	}
+	return nil
+}
+
 // laneMsg pairs a consumed JetStream message with the per-message context
 // carrying its consumer span. The o11y/nats facade delivers (ctx, jetstream.Msg)
 // separately rather than an o11y-owned message type, so the two-lane dispatch

--- a/inbox-worker/mock_store_test.go
+++ b/inbox-worker/mock_store_test.go
@@ -70,6 +70,20 @@ func (mr *MockInboxStoreMockRecorder) ApplyThreadRead(ctx, roomID, threadRoomID,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyThreadRead", reflect.TypeOf((*MockInboxStore)(nil).ApplyThreadRead), ctx, roomID, threadRoomID, account, newThreadUnread, alert, lastSeenAt)
 }
 
+// ApplyThreadReadAll mocks base method.
+func (m *MockInboxStore) ApplyThreadReadAll(ctx context.Context, account string, lastSeenAt time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyThreadReadAll", ctx, account, lastSeenAt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyThreadReadAll indicates an expected call of ApplyThreadReadAll.
+func (mr *MockInboxStoreMockRecorder) ApplyThreadReadAll(ctx, account, lastSeenAt any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyThreadReadAll", reflect.TypeOf((*MockInboxStore)(nil).ApplyThreadReadAll), ctx, account, lastSeenAt)
+}
+
 // BulkCreateSubscriptions mocks base method.
 func (m *MockInboxStore) BulkCreateSubscriptions(ctx context.Context, subs []*model.Subscription) error {
 	m.ctrl.T.Helper()

--- a/outbox-worker/consumer_config_test.go
+++ b/outbox-worker/consumer_config_test.go
@@ -28,6 +28,7 @@ func TestBuildConcurrentConsumerConfig(t *testing.T) {
 		"chat.outbox.site-a.site-b.role_updated",
 		"chat.outbox.site-a.site-b.subscription_read",
 		"chat.outbox.site-a.site-b.thread_read",
+		"chat.outbox.site-a.site-b.thread_read_all",
 		"chat.outbox.site-a.site-b.subscription_mute_toggled",
 		"chat.outbox.site-a.site-b.subscription_favorite_toggled",
 		"chat.outbox.site-a.site-b.room_restricted",

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -161,6 +161,7 @@ const (
 	InboxSubscriptionFavoriteToggled InboxEventType = "subscription_favorite_toggled"
 	InboxThreadSubscriptionUpserted  InboxEventType = "thread_subscription_upserted"
 	InboxThreadRead                  InboxEventType = "thread_read"
+	InboxThreadReadAll               InboxEventType = "thread_read_all"
 	InboxRoomRenamed                 InboxEventType = "room_renamed"
 	InboxRoomRestricted              InboxEventType = "room_restricted"
 	InboxUserStatusUpdated           InboxEventType = "user_status_updated"
@@ -201,6 +202,18 @@ type ThreadReadEvent struct {
 	Alert           bool     `json:"alert"`
 	LastSeenAt      int64    `json:"lastSeenAt"`
 	Timestamp       int64    `json:"timestamp"`
+}
+
+// ThreadReadAllEvent is the InboxEvent.Payload for type "thread_read_all" — the
+// federated "mark all threads read" for a user. One event carries the whole
+// bulk dismiss (no per-thread list): the destination inbox-worker advances every
+// one of the account's thread subscriptions to LastSeenAt under a high-water-mark
+// guard (clearing hasMention) and clears every subscription's threadUnread/alert
+// on the user's home replica.
+type ThreadReadAllEvent struct {
+	Account    string `json:"account"`
+	LastSeenAt int64  `json:"lastSeenAt"`
+	Timestamp  int64  `json:"timestamp"`
 }
 
 type InboxEvent struct {

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -2647,14 +2647,16 @@ func TestSubscriptionReadEventJSON(t *testing.T) {
 }
 
 func TestThreadReadAllRoundTrip(t *testing.T) {
-	respFull := model.ThreadReadAllResponse{ClearedThreads: 7, UnavailableSites: []string{"site-b"}}
+	respFull := model.ThreadReadAllResponse{UnavailableSites: []string{"site-b"}}
 	roundTrip(t, &respFull, &model.ThreadReadAllResponse{})
 	respEmpty := model.ThreadReadAllResponse{}
 	roundTrip(t, &respEmpty, &model.ThreadReadAllResponse{})
 	roomReq := model.RoomThreadReadAllRequest{Account: "alice"}
 	roundTrip(t, &roomReq, &model.RoomThreadReadAllRequest{})
-	roomResp := model.RoomThreadReadAllResponse{ClearedThreads: 3}
+	roomResp := model.RoomThreadReadAllResponse{}
 	roundTrip(t, &roomResp, &model.RoomThreadReadAllResponse{})
+	ev := model.ThreadReadAllEvent{Account: "alice", LastSeenAt: 1717000000000, Timestamp: 1717000000001}
+	roundTrip(t, &ev, &model.ThreadReadAllEvent{})
 }
 
 func TestPresenceStatusValues(t *testing.T) {

--- a/pkg/model/threadsubscription.go
+++ b/pkg/model/threadsubscription.go
@@ -58,11 +58,10 @@ type ThreadUnreadSummaryResponse struct {
 type ThreadReadAllRequest struct{}
 
 // ThreadReadAllResponse is the cross-site clear-all-thread-unread result.
-// ClearedThreads sums the thread subscriptions cleared on each responding site.
 // UnavailableSites lists sites whose bulk-clear RPC failed (their threads may
-// remain unread); the overall call still succeeds.
+// remain unread); the overall call still succeeds. Success is otherwise an empty
+// object — the clear is fire-and-forget from the client's view.
 type ThreadReadAllResponse struct {
-	ClearedThreads   int      `json:"clearedThreads"`
 	UnavailableSites []string `json:"unavailableSites,omitempty"`
 }
 
@@ -72,10 +71,9 @@ type RoomThreadReadAllRequest struct {
 	Account string `json:"account"`
 }
 
-// RoomThreadReadAllResponse reports how many thread subscriptions the site cleared.
-type RoomThreadReadAllResponse struct {
-	ClearedThreads int `json:"clearedThreads"`
-}
+// RoomThreadReadAllResponse is the per-site ack. The clear either succeeds or
+// returns an error envelope; there are no payload fields.
+type RoomThreadReadAllResponse struct{}
 
 // ThreadRoomInfoBatchRequest asks room-service for a batch of thread rooms' info.
 type ThreadRoomInfoBatchRequest struct {

--- a/pkg/outbox/outbox.go
+++ b/pkg/outbox/outbox.go
@@ -22,6 +22,7 @@ var ConcurrentEventTypes = []model.InboxEventType{
 	model.InboxRoleUpdated,
 	model.InboxSubscriptionRead,
 	model.InboxThreadRead,
+	model.InboxThreadReadAll,
 	model.InboxSubscriptionMuteToggled,
 	model.InboxSubscriptionFavoriteToggled,
 	model.InboxRoomRestricted,

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -1631,7 +1631,8 @@ func (h *Handler) messageThreadRead(c *natsrouter.Context, req model.MessageThre
 // the per-site leaf of the user-service clear-all-thread-unread aggregator. Unlike
 // the single-thread path it deliberately skips the thread-room read-floor recompute
 // and thread_message_read fan-out (a bulk dismiss must not advance sender receipts).
-// For a cross-site user each cleared thread rides the existing thread_read event.
+// For a cross-site user the whole dismiss rides one thread_read_all event, which
+// inbox-worker applies as the same bulk clear on the user's home replica.
 func (h *Handler) clearAllThreadRead(c *natsrouter.Context, req model.RoomThreadReadAllRequest) (*model.RoomThreadReadAllResponse, error) {
 	var ctx context.Context = c
 	account := strings.TrimSpace(req.Account)
@@ -1643,26 +1644,21 @@ func (h *Handler) clearAllThreadRead(c *natsrouter.Context, req model.RoomThread
 	now := time.Now().UTC()
 
 	var (
-		cleared                   []model.ThreadSubscription
-		userSiteID                string
+		homeSite                  string
 		clearErr, subErr, siteErr error
 	)
 	var g errgroup.Group
 	g.Go(func() error {
-		var err error
-		cleared, err = h.store.ClearThreadSubscriptionsForAccount(ctx, account, now)
-		clearErr = err
-		return err
+		clearErr = h.store.ClearThreadSubscriptionsForAccount(ctx, account, now)
+		return clearErr
 	})
 	g.Go(func() error {
-		err := h.store.ClearSubscriptionThreadUnreadForAccount(ctx, account)
-		subErr = err
-		return err
+		subErr = h.store.ClearSubscriptionThreadUnreadForAccount(ctx, account)
+		return subErr
 	})
 	g.Go(func() error {
-		s, err := h.store.GetUserSiteID(ctx, account)
-		userSiteID, siteErr = s, err
-		return err
+		homeSite, siteErr = h.store.GetUserSiteID(ctx, account)
+		return siteErr
 	})
 	_ = g.Wait()
 	switch {
@@ -1675,32 +1671,25 @@ func (h *Handler) clearAllThreadRead(c *natsrouter.Context, req model.RoomThread
 	}
 
 	switch {
-	case userSiteID == "":
+	case homeSite == "":
 		slog.WarnContext(ctx, "user not found locally; skipping cross-site inbox", "account", account)
-	case userSiteID != h.siteID:
-		for i := range cleared {
-			row := &cleared[i]
-			payload := model.ThreadReadEvent{
-				Account:         account,
-				RoomID:          row.RoomID,
-				ThreadRoomID:    row.ThreadRoomID,
-				ParentMessageID: row.ParentMessageID,
-				NewThreadUnread: nil,
-				Alert:           false,
-				LastSeenAt:      now.UnixMilli(),
-				Timestamp:       now.UnixMilli(),
-			}
-			data, err := json.Marshal(payload)
-			if err != nil {
-				return nil, fmt.Errorf("marshal thread_read payload: %w", err)
-			}
-			if err := h.federateOne(ctx, row.RoomID, userSiteID, model.InboxThreadRead, data, row.ThreadRoomID+":"+account, now.UnixMilli()); err != nil {
-				return nil, fmt.Errorf("federate thread_read: %w", err)
-			}
+	case homeSite != h.siteID:
+		payload := model.ThreadReadAllEvent{
+			Account:    account,
+			LastSeenAt: now.UnixMilli(),
+			Timestamp:  now.UnixMilli(),
+		}
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("marshal thread_read_all payload: %w", err)
+		}
+		// Not room-scoped: one bulk-dismiss event per remote peer, deduped by request ID.
+		if err := h.federateOne(ctx, "", homeSite, model.InboxThreadReadAll, data, account, now.UnixMilli()); err != nil {
+			return nil, fmt.Errorf("federate thread_read_all: %w", err)
 		}
 	}
 
-	return &model.RoomThreadReadAllResponse{ClearedThreads: len(cleared)}, nil
+	return &model.RoomThreadReadAllResponse{}, nil
 }
 
 // recomputeThreadFloor fetches the thread room document, applies the

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -4023,53 +4023,42 @@ func TestHandler_MessageThreadRead_UpdateThreadSubscriptionError(t *testing.T) {
 
 // --- clear-all-thread-read (bulk) tests ---
 
-func unwrapThreadReadPayload(t *testing.T, outboxData []byte) model.ThreadReadEvent {
+func unwrapThreadReadAllPayload(t *testing.T, outboxData []byte) model.ThreadReadAllEvent {
 	t.Helper()
 	var fed model.OutboxEvent
 	require.NoError(t, json.Unmarshal(outboxData, &fed))
 	var env model.InboxEvent
 	require.NoError(t, json.Unmarshal(fed.Envelope, &env))
-	require.Equal(t, model.InboxThreadRead, env.Type)
-	var ev model.ThreadReadEvent
+	require.Equal(t, model.InboxThreadReadAll, env.Type)
+	var ev model.ThreadReadAllEvent
 	require.NoError(t, json.Unmarshal(env.Payload, &ev))
 	return ev
 }
 
 func TestHandler_ClearAllThreadRead_LocalUser_NoFederation(t *testing.T) {
 	f := newThreadReadFixture(t) // fixture handler is scoped to site-a
-	rows := []model.ThreadSubscription{
-		{ThreadRoomID: "tr1", RoomID: "r1", ParentMessageID: "p1"},
-		{ThreadRoomID: "tr2", RoomID: "r2", ParentMessageID: "p2"},
-	}
-	f.store.EXPECT().ClearThreadSubscriptionsForAccount(gomock.Any(), "alice", gomock.Any()).Return(rows, nil)
+	f.store.EXPECT().ClearThreadSubscriptionsForAccount(gomock.Any(), "alice", gomock.Any()).Return(nil)
 	f.store.EXPECT().ClearSubscriptionThreadUnreadForAccount(gomock.Any(), "alice").Return(nil)
 	f.store.EXPECT().GetUserSiteID(gomock.Any(), "alice").Return("site-a", nil) // user home is the handler's own site
 
-	resp, err := f.handler.clearAllThreadRead(ctxParams(map[string]string{"account": "alice"}), model.RoomThreadReadAllRequest{Account: "alice"})
+	_, err := f.handler.clearAllThreadRead(ctxParams(map[string]string{"account": "alice"}), model.RoomThreadReadAllRequest{Account: "alice"})
 	require.NoError(t, err)
-	assert.Equal(t, 2, resp.ClearedThreads)
 	assert.Equal(t, 0, f.publishCalls) // no cross-site federation for a home-local user
 }
 
-func TestHandler_ClearAllThreadRead_RemoteUser_FederatesPerThread(t *testing.T) {
+func TestHandler_ClearAllThreadRead_RemoteUser_FederatesOneEvent(t *testing.T) {
 	f := newThreadReadFixture(t)
-	rows := []model.ThreadSubscription{
-		{ThreadRoomID: "tr1", RoomID: "r1", ParentMessageID: "p1"},
-		{ThreadRoomID: "tr2", RoomID: "r2", ParentMessageID: "p2"},
-	}
-	f.store.EXPECT().ClearThreadSubscriptionsForAccount(gomock.Any(), "alice", gomock.Any()).Return(rows, nil)
+	f.store.EXPECT().ClearThreadSubscriptionsForAccount(gomock.Any(), "alice", gomock.Any()).Return(nil)
 	f.store.EXPECT().ClearSubscriptionThreadUnreadForAccount(gomock.Any(), "alice").Return(nil)
 	f.store.EXPECT().GetUserSiteID(gomock.Any(), "alice").Return("site-b", nil) // remote home
 
-	resp, err := f.handler.clearAllThreadRead(ctxParams(map[string]string{"account": "alice"}), model.RoomThreadReadAllRequest{Account: "alice"})
+	_, err := f.handler.clearAllThreadRead(ctxParams(map[string]string{"account": "alice"}), model.RoomThreadReadAllRequest{Account: "alice"})
 	require.NoError(t, err)
-	assert.Equal(t, 2, resp.ClearedThreads)
-	assert.Equal(t, 2, f.publishCalls) // one thread_read per cleared thread
+	assert.Equal(t, 1, f.publishCalls) // one bulk-dismiss event, not one per thread
 
-	ev := unwrapThreadReadPayload(t, f.publishedData) // last published payload
+	ev := unwrapThreadReadAllPayload(t, f.publishedData)
 	assert.Equal(t, "alice", ev.Account)
-	assert.False(t, ev.Alert)
-	assert.Empty(t, ev.NewThreadUnread)
+	assert.NotZero(t, ev.LastSeenAt)
 }
 
 func TestHandler_ClearAllThreadRead_EmptyAccount_BadRequest(t *testing.T) {
@@ -4082,7 +4071,7 @@ func TestHandler_ClearAllThreadRead_EmptyAccount_BadRequest(t *testing.T) {
 func TestHandler_ClearAllThreadRead_ClearThreadSubsError(t *testing.T) {
 	f := newThreadReadFixture(t)
 	f.store.EXPECT().ClearThreadSubscriptionsForAccount(gomock.Any(), "alice", gomock.Any()).
-		Return(nil, fmt.Errorf("mongo down"))
+		Return(fmt.Errorf("mongo down"))
 	f.store.EXPECT().ClearSubscriptionThreadUnreadForAccount(gomock.Any(), "alice").Return(nil).AnyTimes()
 	f.store.EXPECT().GetUserSiteID(gomock.Any(), "alice").Return("site-a", nil).AnyTimes()
 
@@ -4094,8 +4083,7 @@ func TestHandler_ClearAllThreadRead_ClearThreadSubsError(t *testing.T) {
 func TestHandler_ClearAllThreadRead_FederatePublishError(t *testing.T) {
 	f := newThreadReadFixture(t)
 	f.publishCallErr = fmt.Errorf("nats down")
-	f.store.EXPECT().ClearThreadSubscriptionsForAccount(gomock.Any(), "alice", gomock.Any()).
-		Return([]model.ThreadSubscription{{ThreadRoomID: "tr1", RoomID: "r1", ParentMessageID: "p1"}}, nil)
+	f.store.EXPECT().ClearThreadSubscriptionsForAccount(gomock.Any(), "alice", gomock.Any()).Return(nil)
 	f.store.EXPECT().ClearSubscriptionThreadUnreadForAccount(gomock.Any(), "alice").Return(nil)
 	f.store.EXPECT().GetUserSiteID(gomock.Any(), "alice").Return("site-b", nil)
 

--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -3916,17 +3916,7 @@ func TestMongoStore_ClearThreadSubscriptionsForAccount_Integration(t *testing.T)
 	})
 	require.NoError(t, err)
 
-	rows, err := store.ClearThreadSubscriptionsForAccount(ctx, "alice", now)
-	require.NoError(t, err)
-	require.Len(t, rows, 2)
-
-	got := map[string]model.ThreadSubscription{}
-	for _, r := range rows {
-		got[r.ThreadRoomID] = r
-	}
-	assert.Equal(t, "r1", got["tr1"].RoomID)
-	assert.Equal(t, "p1", got["tr1"].ParentMessageID)
-	assert.Equal(t, "r2", got["tr2"].RoomID)
+	require.NoError(t, store.ClearThreadSubscriptionsForAccount(ctx, "alice", now))
 
 	// alice's docs: lastSeenAt set to now, hasMention cleared.
 	for _, id := range []string{"tsA1", "tsA2"} {
@@ -3951,9 +3941,8 @@ func TestMongoStore_ClearThreadSubscriptionsForAccount_Empty_Integration(t *test
 	store := NewMongoStore(db)
 	require.NoError(t, store.EnsureIndexes(context.Background()))
 
-	rows, err := store.ClearThreadSubscriptionsForAccount(context.Background(), "nobody", time.Now().UTC())
-	require.NoError(t, err)
-	assert.Nil(t, rows)
+	// No rows for the account is a no-op, not an error.
+	require.NoError(t, store.ClearThreadSubscriptionsForAccount(context.Background(), "nobody", time.Now().UTC()))
 }
 
 func TestMongoStore_ClearSubscriptionThreadUnreadForAccount_Integration(t *testing.T) {

--- a/room-service/mock_store_test.go
+++ b/room-service/mock_store_test.go
@@ -86,12 +86,11 @@ func (mr *MockRoomStoreMockRecorder) ClearSubscriptionThreadUnreadForAccount(ctx
 }
 
 // ClearThreadSubscriptionsForAccount mocks base method.
-func (m *MockRoomStore) ClearThreadSubscriptionsForAccount(ctx context.Context, account string, now time.Time) ([]model.ThreadSubscription, error) {
+func (m *MockRoomStore) ClearThreadSubscriptionsForAccount(ctx context.Context, account string, now time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClearThreadSubscriptionsForAccount", ctx, account, now)
-	ret0, _ := ret[0].([]model.ThreadSubscription)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // ClearThreadSubscriptionsForAccount indicates an expected call of ClearThreadSubscriptionsForAccount.

--- a/room-service/store.go
+++ b/room-service/store.go
@@ -193,10 +193,10 @@ type RoomStore interface {
 
 	// ClearThreadSubscriptionsForAccount marks every one of account's thread
 	// subscriptions on this site as read (lastSeenAt=now, updatedAt=now,
-	// hasMention=false) and returns the affected rows (threadRoomId, roomId,
-	// parentMessageId) so the caller can federate a thread_read per thread.
-	// Returns (nil, nil) when the account has no thread subscriptions.
-	ClearThreadSubscriptionsForAccount(ctx context.Context, account string, now time.Time) ([]model.ThreadSubscription, error)
+	// hasMention=false) in a single account-scoped bulk update. The cross-site
+	// convergence rides one thread_read_all event, so no per-row snapshot is
+	// returned.
+	ClearThreadSubscriptionsForAccount(ctx context.Context, account string, now time.Time) error
 
 	// ClearSubscriptionThreadUnreadForAccount clears thread-unread state on every
 	// one of account's subscriptions that currently has unread threads: removes

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -1635,35 +1635,20 @@ func (s *MongoStore) UpdateThreadSubscriptionRead(ctx context.Context, threadRoo
 }
 
 // ClearThreadSubscriptionsForAccount marks every one of account's thread
-// subscriptions as read and returns the affected rows for federation. Projects
-// only the fields the caller federates. No order-safety guard on the source-site
-// write; the $lt guard lives on the inbox-worker side.
-func (s *MongoStore) ClearThreadSubscriptionsForAccount(ctx context.Context, account string, now time.Time) ([]model.ThreadSubscription, error) {
-	filter := bson.M{"userAccount": account}
-	cursor, err := s.threadSubscriptions.Find(ctx, filter, options.Find().SetProjection(bson.M{
-		"threadRoomId":    1,
-		"roomId":          1,
-		"parentMessageId": 1,
-		"_id":             0,
-	}))
-	if err != nil {
-		return nil, fmt.Errorf("find thread subscriptions for %q: %w", account, err)
-	}
-	var rows []model.ThreadSubscription
-	if err := cursor.All(ctx, &rows); err != nil {
-		return nil, fmt.Errorf("decode thread subscriptions for %q: %w", account, err)
-	}
-	if len(rows) == 0 {
-		return nil, nil
-	}
-	if _, err := s.threadSubscriptions.UpdateMany(ctx, filter, bson.M{"$set": bson.M{
+// subscriptions as read in one account-scoped bulk update. No order-safety guard
+// on the source-site write; the $lt guard lives on the inbox-worker side. A
+// single thread_read_all event carries the cross-site convergence, so no per-row
+// snapshot is returned (and no Find/Update window can miss a concurrently
+// inserted row).
+func (s *MongoStore) ClearThreadSubscriptionsForAccount(ctx context.Context, account string, now time.Time) error {
+	if _, err := s.threadSubscriptions.UpdateMany(ctx, bson.M{"userAccount": account}, bson.M{"$set": bson.M{
 		"lastSeenAt": now,
 		"updatedAt":  now,
 		"hasMention": false,
 	}}); err != nil {
-		return nil, fmt.Errorf("clear thread subscriptions for %q: %w", account, err)
+		return fmt.Errorf("clear thread subscriptions for %q: %w", account, err)
 	}
-	return rows, nil
+	return nil
 }
 
 // ClearSubscriptionThreadUnreadForAccount removes threadUnread and clears alert on

--- a/user-service/roomclient/client.go
+++ b/user-service/roomclient/client.go
@@ -69,25 +69,21 @@ func (c *Client) GetThreadRoomInfoBatch(ctx context.Context, siteID string, thre
 }
 
 // ClearAllThreadUnread issues the bulk clear-all-thread-unread RPC to room-service
-// on the given site; non-OK reply envelopes are relayed via errcode.Parse. Returns
-// the number of thread subscriptions cleared on that site.
-func (c *Client) ClearAllThreadUnread(ctx context.Context, siteID, account string) (int, error) {
+// on the given site; non-OK reply envelopes are relayed via errcode.Parse. The
+// reply carries no payload — success is a nil error.
+func (c *Client) ClearAllThreadUnread(ctx context.Context, siteID, account string) error {
 	req, err := json.Marshal(model.RoomThreadReadAllRequest{Account: account})
 	if err != nil {
-		return 0, fmt.Errorf("marshal clear-all-thread-unread request: %w", err)
+		return fmt.Errorf("marshal clear-all-thread-unread request: %w", err)
 	}
 	msg, err := c.nc.Request(ctx, subject.RoomThreadReadAll(siteID), req, roomRPCTimeout)
 	if err != nil {
-		return 0, fmt.Errorf("clear-all-thread-unread rpc: %w", err)
+		return fmt.Errorf("clear-all-thread-unread rpc: %w", err)
 	}
 	if e, ok := errcode.Parse(msg.Data); ok {
-		return 0, e
+		return e
 	}
-	var out model.RoomThreadReadAllResponse
-	if err := json.Unmarshal(msg.Data, &out); err != nil {
-		return 0, fmt.Errorf("decode clear-all-thread-unread response: %w", err)
-	}
-	return out.ClearedThreads, nil
+	return nil
 }
 
 // CreateDMRoom issues a DM-room creation RPC to room-worker; non-OK reply envelopes are relayed via errcode.Parse.

--- a/user-service/roomclient/client_integration_test.go
+++ b/user-service/roomclient/client_integration_test.go
@@ -190,21 +190,19 @@ func TestGetThreadRoomInfoBatch_Integration(t *testing.T) {
 }
 
 func TestClearAllThreadUnread_Integration(t *testing.T) {
-	t.Run("happy path — returns cleared count", func(t *testing.T) {
+	t.Run("happy path — nil error on success", func(t *testing.T) {
 		nc := dial(t)
 		sub, err := nc.Subscribe(context.Background(), subject.RoomThreadReadAll("site-a"), func(_ context.Context, m *nats.Msg) {
 			var req model.RoomThreadReadAllRequest
 			require.NoError(t, json.Unmarshal(m.Data, &req))
 			assert.Equal(t, "alice", req.Account)
-			out, _ := json.Marshal(model.RoomThreadReadAllResponse{ClearedThreads: 4})
+			out, _ := json.Marshal(model.RoomThreadReadAllResponse{})
 			_ = m.Respond(out)
 		})
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = sub.Unsubscribe() })
 
-		n, err := New(nc, "site-a").ClearAllThreadUnread(context.Background(), "site-a", "alice")
-		require.NoError(t, err)
-		assert.Equal(t, 4, n)
+		require.NoError(t, New(nc, "site-a").ClearAllThreadUnread(context.Background(), "site-a", "alice"))
 	})
 
 	t.Run("errcode reply relayed", func(t *testing.T) {
@@ -216,7 +214,7 @@ func TestClearAllThreadUnread_Integration(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = sub.Unsubscribe() })
 
-		_, err = New(nc, "site-a").ClearAllThreadUnread(context.Background(), "site-a", "alice")
+		err = New(nc, "site-a").ClearAllThreadUnread(context.Background(), "site-a", "alice")
 		require.Error(t, err)
 		var e *errcode.Error
 		require.True(t, errors.As(err, &e))
@@ -226,22 +224,20 @@ func TestClearAllThreadUnread_Integration(t *testing.T) {
 	t.Run("cross-site siteID routing — uses siteID param not c.siteID", func(t *testing.T) {
 		nc := dial(t)
 		sub, err := nc.Subscribe(context.Background(), subject.RoomThreadReadAll("site-b"), func(_ context.Context, m *nats.Msg) {
-			out, _ := json.Marshal(model.RoomThreadReadAllResponse{ClearedThreads: 2})
+			out, _ := json.Marshal(model.RoomThreadReadAllResponse{})
 			_ = m.Respond(out)
 		})
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = sub.Unsubscribe() })
 
-		n, err := New(nc, "site-a").ClearAllThreadUnread(context.Background(), "site-b", "alice")
-		require.NoError(t, err)
-		assert.Equal(t, 2, n)
+		require.NoError(t, New(nc, "site-a").ClearAllThreadUnread(context.Background(), "site-b", "alice"))
 	})
 
 	t.Run("no responder — returns error wrapping the rpc", func(t *testing.T) {
 		nc := dial(t)
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
-		_, err := New(nc, "site-a").ClearAllThreadUnread(ctx, "site-a", "alice")
+		err := New(nc, "site-a").ClearAllThreadUnread(ctx, "site-a", "alice")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "clear-all-thread-unread rpc")
 	})

--- a/user-service/service/mocks/mock_repository.go
+++ b/user-service/service/mocks/mock_repository.go
@@ -370,12 +370,11 @@ func (m *MockRoomClient) EXPECT() *MockRoomClientMockRecorder {
 }
 
 // ClearAllThreadUnread mocks base method.
-func (m *MockRoomClient) ClearAllThreadUnread(ctx context.Context, siteID, account string) (int, error) {
+func (m *MockRoomClient) ClearAllThreadUnread(ctx context.Context, siteID, account string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClearAllThreadUnread", ctx, siteID, account)
-	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // ClearAllThreadUnread indicates an expected call of ClearAllThreadUnread.

--- a/user-service/service/service.go
+++ b/user-service/service/service.go
@@ -47,7 +47,7 @@ type RoomClient interface {
 	GetRoomsInfo(ctx context.Context, siteID string, roomIDs []string) ([]model.RoomInfo, error)
 	CreateDMRoom(ctx context.Context, account, otherAccount string, roomType model.RoomType) (model.Subscription, error)
 	GetThreadRoomInfoBatch(ctx context.Context, siteID string, threadRoomIDs []string) ([]model.ThreadRoomInfo, error)
-	ClearAllThreadUnread(ctx context.Context, siteID, account string) (int, error)
+	ClearAllThreadUnread(ctx context.Context, siteID, account string) error
 }
 
 // ThreadSubscriptionRepository reads the local thread_subscriptions replica for

--- a/user-service/service/threadunread.go
+++ b/user-service/service/threadunread.go
@@ -142,17 +142,13 @@ func (s *UserService) ClearAllThreadUnread(c *natsrouter.Context, _ model.Thread
 		sites = append(sites, site)
 	}
 
-	type siteResult struct {
-		cleared int
-		failed  bool
-	}
-	results := make([]siteResult, len(sites))
+	failed := make([]bool, len(sites))
 
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, maxSiteFanout)
 	for i, site := range sites {
 		if c.Err() != nil {
-			results[i].failed = true
+			failed[i] = true
 			continue
 		}
 		wg.Add(1)
@@ -160,26 +156,21 @@ func (s *UserService) ClearAllThreadUnread(c *natsrouter.Context, _ model.Thread
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
-			n, err := s.rooms.ClearAllThreadUnread(c, site, account)
-			if err != nil {
+			if err := s.rooms.ClearAllThreadUnread(c, site, account); err != nil {
 				slog.WarnContext(c, "thread-read-all site degraded",
 					"account", account, "site", site,
 					"request_id", natsutil.RequestIDFromContext(c), "error", err)
-				results[i].failed = true
-				return
+				failed[i] = true
 			}
-			results[i].cleared = n
 		}()
 	}
 	wg.Wait()
 
 	resp := &model.ThreadReadAllResponse{}
 	for i, site := range sites {
-		if results[i].failed {
+		if failed[i] {
 			resp.UnavailableSites = append(resp.UnavailableSites, site)
-			continue
 		}
-		resp.ClearedThreads += results[i].cleared
 	}
 	return resp, nil
 }

--- a/user-service/service/threadunread_test.go
+++ b/user-service/service/threadunread_test.go
@@ -238,13 +238,12 @@ func TestClearAllThreadUnread_MultiSite(t *testing.T) {
 		{ThreadRoomID: "tr2", SiteID: "site-b"},
 		{ThreadRoomID: "tr3", SiteID: "site-b"},
 	}, nil)
-	rc.EXPECT().ClearAllThreadUnread(gomock.Any(), "site-a", "alice").Return(1, nil)
-	rc.EXPECT().ClearAllThreadUnread(gomock.Any(), "site-b", "alice").Return(2, nil)
+	rc.EXPECT().ClearAllThreadUnread(gomock.Any(), "site-a", "alice").Return(nil)
+	rc.EXPECT().ClearAllThreadUnread(gomock.Any(), "site-b", "alice").Return(nil)
 
 	svc := newThreadUnreadService(t, ts, rc)
 	resp, err := svc.ClearAllThreadUnread(ctx("alice", "site-a"), model.ThreadReadAllRequest{})
 	require.NoError(t, err)
-	assert.Equal(t, 3, resp.ClearedThreads)
 	assert.Empty(t, resp.UnavailableSites)
 }
 
@@ -259,7 +258,6 @@ func TestClearAllThreadUnread_NoThreads(t *testing.T) {
 	svc := newThreadUnreadService(t, ts, rc)
 	resp, err := svc.ClearAllThreadUnread(ctx("alice", "site-a"), model.ThreadReadAllRequest{})
 	require.NoError(t, err)
-	assert.Equal(t, 0, resp.ClearedThreads)
 	assert.Empty(t, resp.UnavailableSites)
 }
 
@@ -272,13 +270,12 @@ func TestClearAllThreadUnread_SiteDegrades(t *testing.T) {
 		{ThreadRoomID: "tr1", SiteID: "site-a"},
 		{ThreadRoomID: "tr2", SiteID: "site-b"},
 	}, nil)
-	rc.EXPECT().ClearAllThreadUnread(gomock.Any(), "site-a", "alice").Return(1, nil)
-	rc.EXPECT().ClearAllThreadUnread(gomock.Any(), "site-b", "alice").Return(0, fmt.Errorf("site down"))
+	rc.EXPECT().ClearAllThreadUnread(gomock.Any(), "site-a", "alice").Return(nil)
+	rc.EXPECT().ClearAllThreadUnread(gomock.Any(), "site-b", "alice").Return(fmt.Errorf("site down"))
 
 	svc := newThreadUnreadService(t, ts, rc)
 	resp, err := svc.ClearAllThreadUnread(ctx("alice", "site-a"), model.ThreadReadAllRequest{})
 	require.NoError(t, err)
-	assert.Equal(t, 1, resp.ClearedThreads)
 	assert.Equal(t, []string{"site-b"}, resp.UnavailableSites)
 }
 


### PR DESCRIPTION
Follow-up to the merged #77, addressing @mliu33's review feedback. Three changes:

## 1. Batched federation instead of per-thread
The cross-site "mark all threads read" dismiss now federates as **one** `thread_read_all` event per remote peer, replacing the one-`thread_read`-per-thread loop.

- New inbox event `model.InboxThreadReadAll` (`"thread_read_all"`) + `ThreadReadAllEvent` payload, added to the `pkg/outbox` concurrent partition.
- `room-service` publishes a single event when the user's home site is remote.
- `inbox-worker` gains `ApplyThreadReadAll`: a home-replica bulk clear that advances every one of the account's thread subscriptions under a per-doc `$lt` guard (clearing `hasMention`) and clears every subscription's `threadUnread`/`alert` — mirroring the source-site write. This drops federation volume from O(threads) to O(remote-sites).

## 2. No Find/Update snapshot gap
`ClearThreadSubscriptionsForAccount` is now a single account-scoped `UpdateMany` instead of a `Find`-then-`UpdateMany`, so a thread subscription inserted between the two calls can no longer be cleared without being accounted for. The concern is designed out rather than patched.

## 3. Dropped `clearedThreads` from the response
Removed from both the client-facing `ThreadReadAllResponse` and the internal `RoomThreadReadAllResponse` (unused by the frontend). Success is now `{ unavailableSites? }`; the roomclient and aggregator return no count.

## Docs
`docs/client-api.md` and the derived `docs/client-api/request-reply.md` reflect the new response shape; the design spec carries a "Post-merge follow-up" addendum documenting the reversal from per-thread to batched federation.

## Testing
- Full unit suite passes; lint, gosec, and govulncheck are clean.
- New/updated tests: inbox-worker `thread_read_all` apply (happy/malformed/store-error), the `$lt` guard not regressing a future read, account isolation, and room-service single-event federation.
- Integration tests (room-service, inbox-worker, user-service) run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLMQ1PMcmqvKqXbnqnQ9W8)_