### PR TITLE
Exclude bots & p_ (platform/admin) accounts from read-floor & receipts, incl. threads

### DIFF
--- a/docs/superpowers/specs/2026-07-20-read-exempt-threads-and-admins-design.md
+++ b/docs/superpowers/specs/2026-07-20-read-exempt-threads-and-admins-design.md
@@ -1,0 +1,85 @@
+# Exclude bots & admins from read-floor and receipts, incl. threads — design
+
+**Date:** 2026-07-20
+**Branch:** `claude/bot-user-distinction-ln46az`
+**Status:** Approved (revised per PR #88 review)
+**Author:** co-authored with Claude
+
+> **Revision (per review):** an earlier draft added a persisted `readExempt`
+> flag (bot OR p_ OR admin-role). Review feedback (mliu33) was that no stored
+> field is needed and it complicates the data migration: `p_` accounts already
+> represent both platform and admin accounts, so the exclusion can be done
+> **directly by account** in the read queries. This document reflects that
+> simpler approach.
+
+## 1. Background
+
+PR #78 excluded bots from the **main-room** read-floor (`rooms.minUserLastSeenAt`)
+and read receipts by filtering `u.isBot != true`. Two gaps remained:
+
+1. **Threads.** `MinThreadSubscriptionLastSeenByThreadRoomID` and
+   `ListThreadReadReceipts` still counted bots. A bot that authors a message a
+   human threads a reply to becomes the thread's parent-author subscriber
+   (`buildThreadSubscription`, `LastSeenAt: nil`) and pins the thread floor at
+   nil forever. (Raised by mliu33 on PR #78.)
+2. **Admins.** Admin accounts use the `p_` prefix
+   (`IsPlatformAdminAccount`); their user doc carries `roles:[user]`. They were
+   not excluded from read state.
+
+## 2. Approach
+
+Exclude non-human participants **by account, in the read queries** — no stored
+flag, no stamping, no migration:
+
+- **Bots** — `.bot` suffix.
+- **Platform/admin accounts** — `p_` prefix (covers both platform and admin).
+
+Two query-side regex constants in `room-service/store_mongo.go` (the query
+equivalents of `model.IsBot` / `model.IsPlatformAdminAccount`):
+
+```go
+const (
+    pseudoAccountRegex      = `^p_`        // p_ platform/admin accounts
+    botOrPseudoAccountRegex = `(\.bot$|^p_)` // bots + p_ accounts
+)
+```
+
+## 3. Query changes (`room-service/store_mongo.go`)
+
+Main-room subscriptions already carry `u.isBot` (stamped at creation for
+`.bot`/`p_`), so those queries keep `u.isBot $ne true` and add a `p_`-account
+guard for subs whose `isBot` may be unset (e.g. cross-site mirror subs, which are
+not stamped). Thread subscriptions carry no flag, so they filter purely by
+account.
+
+- `MinSubscriptionLastSeenByRoomID` / `ListReadReceipts`:
+  `u.isBot $ne true` **and** `u.account $not /^p_/`.
+- `MinThreadSubscriptionLastSeenByThreadRoomID` / `ListThreadReadReceipts`:
+  `userAccount $not /(\.bot$|^p_)/`.
+
+The read-receipt `$match` combines the `p_` guard with the existing
+`$ne excludeAccount` on the same account field. Indexing is unchanged: the
+`(roomId, lastSeenAt)` / `(threadRoomId, lastSeenAt)` indexes serve the sort; the
+account/isBot predicates are residual filters (few such subs per room).
+
+## 4. What this removes
+
+No changes to `pkg/model` (no new field), `room-worker`, `inbox-worker`, or
+`message-worker` — subscription/thread-subscription creation is untouched, and
+the cross-site mirror is unchanged (the room's origin site already holds every
+subscription, including remote members, so the account filter covers them at
+query time). No data migration.
+
+## 5. Testing (TDD)
+
+Extend the four `room-service` integration tests: a `p_` account (isBot=false)
+excluded from the main-room floor and receipts; a `.bot` account excluded from
+the thread floor and receipts; ordinary members still counted. Existing PR #78
+bot cases continue to pass via the retained `u.isBot` predicate. Coverage stays
+at/above the 80% floor.
+
+## 6. Rollout / risk
+
+- **Backward compatible.** Pure query change; no schema, no field, no migration.
+- **Behavior:** rooms/threads with a bot or `p_` member stop being frozen by that
+  member; floors recompute on the next read.

--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -2133,6 +2133,24 @@ func TestMongoStore_MinSubscriptionLastSeenByRoomID_Integration(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, got)
 
+	// Room "padmin": a human who has read plus a p_ platform/admin account
+	// (isBot=false) who has never read. The p_ account is excluded by account
+	// prefix, so the floor is the human's lastSeenAt — this exercises the
+	// u.account $not ^p_ predicate, since the isBot predicate alone would count
+	// the p_ account and resolve nil.
+	mustInsertSub(t, db, &model.Subscription{
+		ID: "s17", User: model.SubscriptionUser{ID: "u17", Account: "mona"},
+		RoomID: "padmin", JoinedAt: earliest, LastSeenAt: &mid,
+	})
+	mustInsertSub(t, db, &model.Subscription{
+		ID: "s18", User: model.SubscriptionUser{ID: "u18", Account: "p_admin"},
+		RoomID: "padmin", JoinedAt: earliest,
+	})
+	got, err = store.MinSubscriptionLastSeenByRoomID(ctx, "padmin")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.WithinDuration(t, mid, *got, time.Second)
+
 	// Room with no subscriptions at all → nil.
 	got, err = store.MinSubscriptionLastSeenByRoomID(ctx, "empty")
 	require.NoError(t, err)
@@ -2208,6 +2226,16 @@ func TestMongoStore_MinThreadSubscriptionLastSeenByThreadRoomID_Integration(t *t
 	got, err = store.MinThreadSubscriptionLastSeenByThreadRoomID(ctx, "no-subs")
 	require.NoError(t, err)
 	assert.Nil(t, got)
+
+	// "bot-parent": a human who has read plus a bot (".bot") parent-author who has
+	// never read. The bot is excluded by account, so it must not freeze the thread
+	// floor → floor is the human's lastSeenAt.
+	mustInsertThreadSub(t, db, &model.ThreadSubscription{ID: "ts6", ThreadRoomID: "bot-parent", UserAccount: "frank", LastSeenAt: &mid})
+	mustInsertThreadSub(t, db, &model.ThreadSubscription{ID: "ts7", ThreadRoomID: "bot-parent", UserAccount: "helper.bot"})
+	got, err = store.MinThreadSubscriptionLastSeenByThreadRoomID(ctx, "bot-parent")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.WithinDuration(t, mid, *got, time.Second)
 }
 
 func TestMongoStore_UpdateThreadRoomMinUserLastSeenAt_Integration(t *testing.T) {
@@ -2282,6 +2310,7 @@ func TestMongoStore_ListReadReceipts_Integration(t *testing.T) {
 		bson.M{"_id": "uB", "account": "bob", "chineseName": "鮑勃", "engName": "Bob"},
 		bson.M{"_id": "uC", "account": "carol", "chineseName": "卡羅", "engName": "Carol"},
 		bson.M{"_id": "uD", "account": "dave.bot", "chineseName": "戴夫", "engName": "Dave"},
+		bson.M{"_id": "uE", "account": "p_ops", "chineseName": "運維", "engName": "Ops"},
 	})
 	require.NoError(t, err)
 
@@ -2292,11 +2321,16 @@ func TestMongoStore_ListReadReceipts_Integration(t *testing.T) {
 		bson.M{"_id": "sC", "roomId": "r1", "u": bson.M{"_id": "uC", "account": "carol"}, "lastSeenAt": msgTime.Add(-time.Minute)},
 		// A bot that has read well past the message must never appear as a reader.
 		bson.M{"_id": "sD", "roomId": "r1", "u": bson.M{"_id": "uD", "account": "dave.bot", "isBot": true}, "lastSeenAt": msgTime.Add(30 * time.Minute)},
+		// A p_ platform/admin account (isBot=false) must also be excluded — this
+		// exercises the u.account $not ^p_ predicate, since isBot alone would
+		// surface p_ops.
+		bson.M{"_id": "sE", "roomId": "r1", "u": bson.M{"_id": "uE", "account": "p_ops"}, "lastSeenAt": msgTime.Add(20 * time.Minute)},
 	})
 	require.NoError(t, err)
 
-	// Only bob qualifies: alice is the sender, carol read before the message, and
-	// dave.bot is a bot (excluded despite having read after the message).
+	// Only bob qualifies: alice is the sender, carol read before the message,
+	// dave.bot is a bot, and p_ops is a p_ platform/admin account (both excluded
+	// despite having read after the message).
 	rows, err := store.ListReadReceipts(ctx, "r1", msgTime, "alice", 100)
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
@@ -2320,6 +2354,7 @@ func TestMongoStore_ListThreadReadReceipts_Integration(t *testing.T) {
 		bson.M{"_id": "uA", "account": "alice", "chineseName": "愛麗絲", "engName": "Alice"},
 		bson.M{"_id": "uB", "account": "bob", "chineseName": "鮑勃", "engName": "Bob"},
 		bson.M{"_id": "uC", "account": "carol", "chineseName": "卡羅", "engName": "Carol"},
+		bson.M{"_id": "uD", "account": "helper.bot", "chineseName": "機器", "engName": "Helper"},
 	})
 	require.NoError(t, err)
 
@@ -2330,6 +2365,9 @@ func TestMongoStore_ListThreadReadReceipts_Integration(t *testing.T) {
 		bson.M{"_id": "tsA", "threadRoomId": "tr1", "userId": "uA", "userAccount": "alice", "lastSeenAt": msgTime.Add(time.Hour)},
 		bson.M{"_id": "tsB", "threadRoomId": "tr1", "userId": "uB", "userAccount": "bob", "lastSeenAt": msgTime.Add(time.Minute)},
 		bson.M{"_id": "tsC", "threadRoomId": "tr1", "userId": "uC", "userAccount": "carol", "lastSeenAt": msgTime.Add(-time.Minute)},
+		// A bot (".bot") thread subscriber that read past the reply must not appear
+		// as a reader (excluded by account).
+		bson.M{"_id": "tsD", "threadRoomId": "tr1", "userId": "uD", "userAccount": "helper.bot", "lastSeenAt": msgTime.Add(30 * time.Minute)},
 	})
 	require.NoError(t, err)
 

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -1115,19 +1115,29 @@ func (s *MongoStore) GetUserSiteID(ctx context.Context, account string) (string,
 	return doc.SiteID, nil
 }
 
+// pseudoAccountRegex matches p_ accounts, which represent both platform and
+// admin accounts. botOrPseudoAccountRegex additionally matches ".bot" accounts.
+// They are the query-side equivalents of model.IsPlatformAdminAccount / IsBot,
+// used to exclude non-human participants from read state directly by account.
+const (
+	pseudoAccountRegex      = `^p_`
+	botOrPseudoAccountRegex = `(\.bot$|^p_)`
+)
+
 // MinSubscriptionLastSeenByRoomID returns the room's strict read floor: the
-// minimum lastSeenAt across all of the room's non-bot subscriptions, but only
-// when EVERY such subscription has a usable lastSeenAt (> zero). If any has
-// no usable lastSeenAt — missing, null, or the BSON zero date, i.e. a member
-// who was invited but has never opened the room — it returns nil, meaning "not
+// minimum lastSeenAt across the room's ordinary-member subscriptions, but only
+// when EVERY such subscription has a usable lastSeenAt (> zero). If any has no
+// usable lastSeenAt — missing, null, or the BSON zero date, i.e. a member who
+// was invited but has never opened the room — it returns nil, meaning "not
 // everyone has read yet". It also returns nil for a room with no subscriptions.
-// Bots (u.isBot) are excluded: a passive bot never freezes the floor, and a
-// botDM resolves to the human's lastSeenAt. A room with only bot subscriptions
-// therefore resolves to nil. The caller $unsets rooms.minUserLastSeenAt on a
-// nil result.
+// Bots (u.isBot) and p_ platform/admin accounts (u.account prefix) are excluded,
+// so a passive bot/admin never freezes the floor and a botDM resolves to the
+// human's lastSeenAt. A room with only such subscriptions resolves to nil. The
+// caller $unsets rooms.minUserLastSeenAt on a nil result.
 func (s *MongoStore) MinSubscriptionLastSeenByRoomID(ctx context.Context, roomID string) (*time.Time, error) {
-	// The whole result is determined by a single document: the room's non-bot
-	// subscription with the smallest lastSeenAt. The (roomId, lastSeenAt) index
+	// The whole result is determined by a single document: the room's ordinary
+	// (non-bot, non-p_) subscription with the smallest lastSeenAt. The
+	// (roomId, lastSeenAt) index
 	// (non-sparse, so missing fields are indexed as null) returns the room's
 	// subscriptions in ascending lastSeenAt order, and BSON sorts missing/null
 	// before the legacy zero date before real dates. So the first document by
@@ -1136,16 +1146,18 @@ func (s *MongoStore) MinSubscriptionLastSeenByRoomID(ctx context.Context, roomID
 	//     read → strict floor is nil ("not everyone has read yet");
 	//   - smallest value is a real post-zero date → every member has read and
 	//     that value IS the minimum → the floor.
-	// The (roomId, lastSeenAt) index still serves the sort; the u.isBot != true
-	// predicate is applied as a residual filter (bots are few per room, and
-	// $ne yields no tight index bound), so this stays a bounded index seek on the
-	// message-read hot path rather than the prior full-room $group scan. $ne:true
-	// (not isBot:false) keeps legacy subs missing the flag counted as humans.
+	// The (roomId, lastSeenAt) index still serves the sort; the u.isBot and
+	// u.account predicates are applied as residual filters (bots/p_ are few per
+	// room), so this stays a bounded index seek on the message-read hot path
+	// rather than the prior full-room $group scan.
 	var doc struct {
 		LastSeenAt time.Time `bson:"lastSeenAt"`
 	}
 	err := s.subscriptions.FindOne(ctx,
-		bson.M{"roomId": roomID, "u.isBot": bson.M{"$ne": true}},
+		// u.isBot excludes bots (and p_ subs stamped locally); the u.account $not
+		// ^p_ predicate additionally excludes p_ platform/admin accounts whose
+		// isBot may be unset (e.g. cross-site mirror subs), no stored flag needed.
+		bson.M{"roomId": roomID, "u.isBot": bson.M{"$ne": true}, "u.account": bson.M{"$not": bson.Regex{Pattern: pseudoAccountRegex}}},
 		options.FindOne().
 			SetSort(bson.D{{Key: "lastSeenAt", Value: 1}}).
 			SetProjection(bson.M{"lastSeenAt": 1, "_id": 0}),
@@ -1190,10 +1202,10 @@ func (s *MongoStore) ListReadReceipts(
 		{{Key: "$match", Value: bson.M{
 			"roomId":     roomID,
 			"lastSeenAt": bson.M{"$gte": since},
-			"u.account":  bson.M{"$ne": excludeAccount},
-			// Bots are never surfaced as readers ($ne:true keeps flagless legacy
-			// human subs counted).
-			"u.isBot": bson.M{"$ne": true},
+			// Bots (u.isBot) and p_ platform/admin accounts (u.account prefix) are
+			// never surfaced as readers, in addition to excluding the sender.
+			"u.account": bson.M{"$ne": excludeAccount, "$not": bson.Regex{Pattern: pseudoAccountRegex}},
+			"u.isBot":   bson.M{"$ne": true},
 		}}},
 		{{Key: "$lookup", Value: bson.M{
 			"from": "users",
@@ -1246,7 +1258,9 @@ func (s *MongoStore) ListThreadReadReceipts(
 		{{Key: "$match", Value: bson.M{
 			"threadRoomId": threadRoomID,
 			"lastSeenAt":   bson.M{"$gte": since},
-			"userAccount":  bson.M{"$ne": excludeAccount},
+			// Bot (".bot") and p_ platform/admin subscribers are never surfaced as
+			// readers, in addition to excluding the sender.
+			"userAccount": bson.M{"$ne": excludeAccount, "$not": bson.Regex{Pattern: botOrPseudoAccountRegex}},
 		}}},
 		{{Key: "$lookup", Value: bson.M{
 			"from": "users",
@@ -1755,8 +1769,11 @@ func (s *MongoStore) GetThreadRoomByID(ctx context.Context, threadRoomID string)
 }
 
 // MinThreadSubscriptionLastSeenByThreadRoomID returns the thread room's strict
-// read floor: the minimum lastSeenAt across ALL thread_subscriptions for
-// threadRoomID, but only when every subscriber has a usable lastSeenAt (> zero).
+// read floor: the minimum lastSeenAt across the thread's ordinary-member
+// thread_subscriptions for threadRoomID, but only when every such subscriber has
+// a usable lastSeenAt (> zero). Bot (".bot") and p_ platform/admin subscribers
+// are excluded by account, so a bot that authored a threaded message cannot
+// freeze the floor via its never-read parent-author subscription.
 // Returns nil when any subscriber has never read, or when there are no subscribers.
 // The (threadRoomId, lastSeenAt) index (non-sparse) returns the smallest value
 // first — a missing/null/zero lastSeenAt sorts before real dates, so the first
@@ -1766,7 +1783,10 @@ func (s *MongoStore) MinThreadSubscriptionLastSeenByThreadRoomID(ctx context.Con
 		LastSeenAt time.Time `bson:"lastSeenAt"`
 	}
 	err := s.threadSubscriptions.FindOne(ctx,
-		bson.M{"threadRoomId": threadRoomID},
+		// Bot/p_ thread subs don't hold the floor: excluded by account so a bot
+		// that authored a threaded message can't freeze it via its never-read
+		// parent-author subscription.
+		bson.M{"threadRoomId": threadRoomID, "userAccount": bson.M{"$not": bson.Regex{Pattern: botOrPseudoAccountRegex}}},
 		options.FindOne().
 			SetSort(bson.D{{Key: "lastSeenAt", Value: 1}}).
 			SetProjection(bson.M{"lastSeenAt": 1, "_id": 0}),


### PR DESCRIPTION
Follow-up to #78 (which excluded bots from the **main-room** read-floor and read receipts). Closes the two gaps raised on #78: **threads** and **admin accounts**.

## Approach (revised per review)

Exclude non-human participants **by account, in the read queries** — no stored field, no stamping, no migration. Per mliu33's review, an earlier draft added a persisted `readExempt` flag; that was dropped because `p_` accounts already represent both platform and admin accounts, so the exclusion is just an account filter:

- **Bots** — `.bot` suffix
- **Platform/admin accounts** — `p_` prefix

Two query-side regex constants in `room-service/store_mongo.go` (`^p_` and `(\.bot$|^p_)`).

## Query changes (`room-service`)
- `MinSubscriptionLastSeenByRoomID` / `ListReadReceipts`: keep `u.isBot $ne true`, add `u.account $not /^p_/`.
- `MinThreadSubscriptionLastSeenByThreadRoomID` / `ListThreadReadReceipts`: `userAccount $not /(\.bot$|^p_)/`.

Main-room keeps the `isBot` predicate (already stamped) and adds the `p_` guard for subs whose `isBot` may be unset (e.g. cross-site mirror subs); threads filter purely by account. Indexing unchanged — residual filters on the existing `(roomId, lastSeenAt)` / `(threadRoomId, lastSeenAt)` seeks.

## No schema / no migration
`pkg/model`, `room-worker`, `inbox-worker`, and `message-worker` are untouched. The room's origin site already holds every subscription (including remote members), so the query-time account filter covers them.

## Testing
Extended the four `room-service` integration tests: a `p_` account excluded from the main-room floor and receipts; a `.bot` account excluded from the thread floor and receipts; ordinary members still counted. Existing #78 bot cases still pass via the retained `isBot` predicate.

⚠️ Integration tests couldn't run locally (no Docker in the authoring environment) — CI is their first real run. Unit tests, CI-equivalent lint (0 issues), and `go vet -tags=integration` pass on the changed packages.

Design spec: `docs/superpowers/specs/2026-07-20-read-exempt-threads-and-admins-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lg7w9sovhKWgtki6B9LRm2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Read status and receipt calculations now exclude platform/admin accounts and bot accounts.
  * Human users’ read positions are no longer delayed or distorted by automated or administrative activity.
  * Improved consistency for both room conversations and threaded replies, including reader lists and pagination-related read floors.

* **Tests**
  * Added coverage for platform/admin and bot account scenarios across room and thread read tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->