### PR TITLE
feat: Support adding/removing bot to the room

### DIFF
--- a/auth-service/handler.go
+++ b/auth-service/handler.go
@@ -241,7 +241,7 @@ func (h *AuthHandler) handleSession(ctx context.Context, c *gin.Context, req aut
 	}
 	// NATS subject slots are single-token, so dotted bot accounts
 	// (`botname.shortsiteid.bot`) collapse to underscores; others pass through.
-	natsAccount := strings.ReplaceAll(p.Account, ".", "_")
+	natsAccount := subject.EncodeAccount(p.Account)
 	if !subject.IsValidAccountToken(natsAccount) {
 		errhttp.Write(ctx, c, errcode.BadRequest("account contains invalid characters"))
 		return

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -1132,7 +1132,7 @@ Platform admins (`model.UserRoleAdmin`, same site) bypass the room owner/member 
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `roomId` | string | no | Optional; the server derives the room ID from the subject and ignores any non-matching value. |
-| `users` | string[] | no | Internal user IDs (or accounts) to add directly. |
+| `users` | string[] | no | Internal user IDs (or accounts) to add directly. May include bot accounts (`.bot` suffix / `p_` prefix): each listed bot must resolve to an app with an **enabled assistant** and live on the **local site**, else the request is rejected (see Error response). Bots join as plain members, count toward the room's `appCount` (not `userCount` or the capacity cap), and receive the `room.key` event on their encoded per-user subject (see [§5](#5-room-encryption)) — but no `subscription.update`. |
 | `orgs` | string[] | no | Org IDs to add (expanded server-side to all org members). |
 | `channels` | array<ChannelRef> | no | Other channels to add as bulk sources. Each entry is `{ "roomId": string, "siteId": string }`. |
 | `history.mode` | string | no | `"none"` (default) or `"all"` — controls whether new members see history before they joined. |
@@ -1162,7 +1162,7 @@ The fields `requesterId`, `requesterAccount`, and `timestamp` on the Go `AddMemb
 
 ##### Error response
 
-See [Error envelope](#6-error-envelope-reference). Returned synchronously when validation or authorization fails (e.g. requester not in room, room is full, room is restricted and requester is not owner, or a `users` entry is a bot — rejected with `"bots cannot be added to a channel"`). Any `orgs` entry that matches zero users (no user with `sectId == orgId` or `deptId == orgId`) is rejected with `org "<orgId>": invalid org`, and any `users` entry that has no matching user document is rejected with `user "<account>": user not found` (each wrapped with the offending account/org ID) — in both cases the request is not queued and no members are added.
+See [Error envelope](#6-error-envelope-reference). Returned synchronously when validation or authorization fails (e.g. requester not in room, room is full, room is restricted and requester is not owner). A `users` entry that is a bot is rejected with `"bot not available"` (`bot_not_available`) when it has no app record or its assistant is disabled, and with `"cross-site bots cannot be added to a channel"` (`bot_cross_site`) when the bot's home site differs from the room's site. Any `orgs` entry that matches zero users (no user with `sectId == orgId` or `deptId == orgId`) is rejected with `org "<orgId>": invalid org`, and any `users` entry that has no matching user document is rejected with `user "<account>": user not found` (each wrapped with the offending account/org ID) — in both cases the request is not queued and no members are added. Bots resolved from `channels` / `orgs` expansion are silently filtered (only explicitly listed bots are added).
 
 ```json
 { "code": "conflict", "reason": "max_room_size_reached", "error": "room is at maximum capacity" }
@@ -1186,7 +1186,7 @@ Error example (e.g. requester not in room):
 }
 ```
 
-**2. `chat.user.{newMember}.event.subscription.update`** — one event per **newly subscribed** member (not the requester, not existing members, not org→individual upgrades).
+**2. `chat.user.{newMember}.event.subscription.update`** — one event per **newly subscribed** human member (not the requester, not existing members, not org→individual upgrades). Bot members receive none.
 
 ###### `subscription.update` event
 
@@ -1220,7 +1220,7 @@ On `added` / `role_updated` / `mute_toggled` / `favorite_toggled` the embedded `
 }
 ```
 
-**3. `chat.user.{newMember}.event.room.key`** — a `RoomKeyEvent` per newly-subscribed account (channels). Existing members do not receive a duplicate. See [§5 Room Encryption](#5-room-encryption).
+**3. `chat.user.{newMember}.event.room.key`** — a `RoomKeyEvent` per newly-subscribed member (channels). Existing members do not receive a duplicate. See [§5 Room Encryption](#5-room-encryption).
 
 **4. `chat.room.{roomID}.event.member`** — a `MemberAddEvent` (`type: "member_added"`) published once whenever the room's member list actually changes: a new account joins, a genuinely new org is added, or an existing org member is upgraded to an individual membership (see the no-op note below for what does **not** fire). Delivered to clients subscribed to `chat.room.>` for the room.
 
@@ -1285,7 +1285,7 @@ Exactly one of `account` or `orgId` must be set. The fields `requester`, `roomTy
 
 ##### Error response
 
-See [Error envelope](#6-error-envelope-reference). Returned synchronously when validation or authorization fails (e.g. neither or both of `account`/`orgId` set, requester is not an owner, target is the last member, or org member cannot leave individually).
+See [Error envelope](#6-error-envelope-reference). Returned synchronously when validation or authorization fails (e.g. neither or both of `account`/`orgId` set, requester is not an owner, target is the last member, or org member cannot leave individually). The last-member guard counts **human** members only: removing the last human is rejected even when bot members remain, while removing a bot never trips the guard.
 
 ```json
 { "code": "bad_request", "error": "exactly one of account or orgId must be set" }
@@ -1295,7 +1295,7 @@ See [Error envelope](#6-error-envelope-reference). Returned synchronously when v
 
 **1. `chat.user.{requesterAccount}.response.{requestID}`** — an [`AsyncJobResult`](#asyncjobresult) to the requester when the removal finishes (requires `X-Request-ID`). `operation` is `"room.member.remove"` for single-account removal, `"room.member.remove_org"` for org removal.
 
-**2. `chat.user.{removedAccount}.event.subscription.update`** — one per removed account, `action: "removed"`. The payload is a dedicated `SubscriptionRemovedEvent` (not the full `SubscriptionUpdateEvent`): its `subscription` carries **only** `roomId`, `roomType`, and `u` so no zero-valued `Subscription` fields are sent. On the **org-removal** path `userId` is omitted (only `subscription.u.account` is set).
+**2. `chat.user.{removedAccount}.event.subscription.update`** — one per removed human account, `action: "removed"` (bot members receive none). The payload is a dedicated `SubscriptionRemovedEvent` (not the full `SubscriptionUpdateEvent`): its `subscription` carries **only** `roomId`, `roomType`, and `u` so no zero-valued `Subscription` fields are sent. On the **org-removal** path `userId` is omitted (only `subscription.u.account` is set).
 
 | Field | Type | Notes |
 |---|---|---|
@@ -1394,6 +1394,7 @@ See [Error envelope](#6-error-envelope-reference). Returned synchronously when v
 - Promote attempt when the target is already an owner.
 - Demote attempt when the target is not an owner.
 - Last-owner guard: an owner cannot demote themselves if they are the only owner.
+- Promote attempt on a bot account — rejected with `"bots cannot be room owners"` (demoting a bot stays allowed).
 - Promote attempt on an org-only member (individual subscription required).
 
 ```json
@@ -5634,8 +5635,9 @@ Clients are already authorized for `chat.user.{theirAccount}.>` and receive key 
 #### When clients receive `RoomKeyEvent`s
 
 - **Room creation (channels only):** sent to every initial member. DM/botDM rooms carry no key, so creation fires no `RoomKeyEvent`.
-- **Add member (channels only):** sent to each newly-added account; existing members do not receive a duplicate event.
+- **Add member (channels only):** sent to each newly-added member; existing members do not receive a duplicate event.
 - **Remove member (channels only):** the server rotates the room key. Surviving members receive a new `RoomKeyEvent` with an incremented `version`. The removed account stops receiving events for the room.
+- **Bot members** are key-holders: they receive the `RoomKeyEvent` like any member, addressed to the bot's **encoded** per-user subject (a dotted `.bot` account maps to a single NATS subject token — the form its JWT is scoped to). Bots do **not** receive `subscription.update` (no sidebar client consumes it).
 
 Removed members keep prior keys for decrypting historical messages but cannot decrypt anything published after the rotation.
 
@@ -5755,12 +5757,14 @@ Every error response — NATS reply subjects, JetStream async results, and HTTP 
 | `not_room_member` | forbidden | room-service / room-worker (actor not a member) |
 | `not_room_owner` | forbidden | room-service role/admin paths |
 | `last_owner_cannot_leave` | conflict | room-service leave |
-| `bot_in_channel` | bad_request | room-service member-add (bot in a channel room) |
-| `bot_not_available` | not_found | room-service member-add (unknown bot) |
+| `bot_in_channel` | bad_request | room-service create-channel (bot listed in a channel create request) |
+| `bot_not_available` | not_found | room-service member-add (bot with no app record or disabled assistant) and create-botDM (assistant disabled) |
+| `bot_cross_site` | bad_request | room-service member-add (bot's home site differs from the room's site) |
+| `bot_cannot_be_owner` | bad_request | room-service role-update (promote a bot to owner) |
 | `user_not_found` | not_found | room-service / room-worker (account does not resolve to a user) |
 | `invalid_org` | bad_request | room-service create/add (orgId does not resolve to any users) |
 | `self_dm` | bad_request | room-service create (DM to yourself) |
-| `last_member_cannot_remove` | conflict | room-service remove-member (would empty the room) |
+| `last_member_cannot_remove` | conflict | room-service remove-member (would remove the last human member; bots don't count) |
 | `target_not_member` | bad_request | room-service role-update (target is not a room member) |
 | `already_owner` | conflict | room-service role-update (promote a current owner) |
 | `cannot_demote_last_owner` | conflict | room-service role-update (demote the last owner) |

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -207,7 +207,8 @@ UserSettings — every field optional, present only when explicitly set:
 
 **Subject:** `chat.user.{account}.event.room.key`
 
-Delivers the AES-256-GCM room key to channel members. Fired at create, add, and remove.
+Delivers the AES-256-GCM room key to **human** channel members — bot members never
+receive a key. Fired at create, add, and remove.
 DM/botDM rooms are never encrypted and emit no key event.
 
 | Field | Type | Notes |
@@ -229,7 +230,7 @@ DM/botDM rooms are never encrypted and emit no key event.
 **When fired:**
 
 - **Create Room (channel):** one event per initial enrolled member.
-- **Add Members (channel):** one event per newly-subscribed account; existing members receive no duplicate.
+- **Add Members (channel):** one event per newly-subscribed member; existing members receive no duplicate. Bots receive the key on their encoded per-user subject (see §5 in the canonical doc).
 - **Remove Member (channel):** the key is rotated; every surviving member receives a new event with `version` incremented. The removed account stops receiving events.
 
 **Initial key bootstrap on (re)connect:** live events fire only when keys change.

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -320,8 +320,8 @@ Async-job RPC. `X-Request-ID` recommended (required to receive `AsyncJobResult`)
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `roomId` | string | no | Optional echo; server derives from subject. |
-| `users` | string[] | no | Internal user IDs or accounts to add. |
-| `orgs` | string[] | no | Org IDs to add (expanded to all members). |
+| `users` | string[] | no | Internal user IDs or accounts to add. May include bots (`.bot` / `p_`): each must have an enabled app assistant and a local home site; bots join as members, count toward `appCount`, and get the `room.key` (on their encoded per-user subject) but no `subscription.update`. |
+| `orgs` | string[] | no | Org IDs to add (expanded to all members; never resolves bots). |
 | `channels` | [ChannelRef](../client-api.md#channelref)[] | no | Bulk source channels. |
 | `history.mode` | string | no | `"none"` (default) or `"all"` — controls history visibility for new members. |
 
@@ -331,14 +331,14 @@ Async-job RPC. `X-Request-ID` recommended (required to receive `AsyncJobResult`)
 
 #### Errors
 
-Synchronous: requester not in room, room full, restricted + not owner, bots in channel,
-user/org not found.
+Synchronous: requester not in room, room full, restricted + not owner, bot not
+available (no app record / disabled assistant / cross-site bot), user/org not found.
 
 ```json
 { "code": "conflict", "reason": "max_room_size_reached", "error": "room is at maximum capacity" }
 ```
 
-**Emits:** [`AsyncJobResult`](events.md#asyncjobresult--async-completion) (`operation: "room.member.add"`), [`subscription.update`](events.md#subscriptionupdate--membership--state-changes) (`action: "added"` — one per newly subscribed member), [`room.key`](events.md#roomkey--room-encryption-key-delivery) (channel rooms), [`member_added`](events.md#member_added-memberaddevent) (on `chat.room.{roomID}.event.member`), `new_message` system message (`members_added`) → [events.md](events.md#new_message-roomevent)
+**Emits:** [`AsyncJobResult`](events.md#asyncjobresult--async-completion) (`operation: "room.member.add"`), [`subscription.update`](events.md#subscriptionupdate--membership--state-changes) (`action: "added"` — one per newly subscribed human member; bots receive none), [`room.key`](events.md#roomkey--room-encryption-key-delivery) (channel rooms — every new member, bots included, on the encoded per-user subject), [`member_added`](events.md#member_added-memberaddevent) (on `chat.room.{roomID}.event.member`), `new_message` system message (`members_added`) → [events.md](events.md#new_message-roomevent)
 
 ---
 
@@ -366,9 +366,10 @@ Exactly one of `account` or `orgId` must be set.
 #### Errors
 
 Synchronous: neither/both of `account`/`orgId` set; requester not an owner; target is
-last member; org member cannot leave individually.
+last **human** member (bots don't count, and a bot target skips the guard); org member
+cannot leave individually.
 
-**Emits:** [`AsyncJobResult`](events.md#asyncjobresult--async-completion) (`operation: "room.member.remove"` or `"room.member.remove_org"`), [`subscription.update`](events.md#subscriptionupdate--membership--state-changes) (`action: "removed"` — one per removed account), [`room.key`](events.md#roomkey--room-encryption-key-delivery) (channel rooms — key rotated; surviving members receive new event), [`member_left` / `member_removed`](events.md#member_left--member_removed-memberremoveevent) (on `chat.room.{roomID}.event.member`), `new_message` system message → [events.md](events.md#new_message-roomevent)
+**Emits:** [`AsyncJobResult`](events.md#asyncjobresult--async-completion) (`operation: "room.member.remove"` or `"room.member.remove_org"`), [`subscription.update`](events.md#subscriptionupdate--membership--state-changes) (`action: "removed"` — one per removed human account; bots receive none), [`room.key`](events.md#roomkey--room-encryption-key-delivery) (channel rooms — key rotated; surviving members receive new event), [`member_left` / `member_removed`](events.md#member_left--member_removed-memberremoveevent) (on `chat.room.{roomID}.event.member`), `new_message` system message → [events.md](events.md#new_message-roomevent)
 
 ---
 
@@ -393,7 +394,7 @@ last member; org member cannot leave individually.
 
 #### Errors
 
-Not an owner; target not a member; invalid `newRole`; already owner (promote); not owner (demote); last-owner guard; org-only member cannot be promoted.
+Not an owner; target not a member; invalid `newRole`; already owner (promote); bot account cannot be promoted to owner (demote stays allowed); not owner (demote); last-owner guard; org-only member cannot be promoted.
 
 **Emits:** [`subscription.update`](events.md#subscriptionupdate--membership--state-changes) (`action: "role_updated"` — to the target user only) → [events.md](events.md#subscriptionupdate--membership--state-changes)
 

--- a/pkg/errcode/codes_room.go
+++ b/pkg/errcode/codes_room.go
@@ -8,6 +8,8 @@ const (
 	RoomLastOwnerCannotLeave      Reason = "last_owner_cannot_leave"
 	RoomBotInChannel              Reason = "bot_in_channel"
 	RoomBotNotAvailable           Reason = "bot_not_available"
+	RoomBotCrossSite              Reason = "bot_cross_site"
+	RoomBotCannotBeOwner          Reason = "bot_cannot_be_owner"
 	RoomUserNotFound              Reason = "user_not_found"
 	RoomInvalidOrg                Reason = "invalid_org"
 	RoomSelfDM                    Reason = "self_dm"

--- a/pkg/errcode/codes_test.go
+++ b/pkg/errcode/codes_test.go
@@ -8,6 +8,7 @@ import (
 var allReasons = []Reason{
 	RoomMaxSizeReached, RoomNotMember, RoomNotOwner,
 	RoomLastOwnerCannotLeave, RoomBotInChannel, RoomBotNotAvailable,
+	RoomBotCrossSite, RoomBotCannotBeOwner,
 	RoomUserNotFound, RoomInvalidOrg,
 	RoomSelfDM, RoomLastMemberCannotRemove, RoomTargetNotMember,
 	RoomAlreadyOwner, RoomCannotDemoteLastOwner, RoomPromoteRequiresIndividual,

--- a/pkg/pipelines/integration_test.go
+++ b/pkg/pipelines/integration_test.go
@@ -91,3 +91,48 @@ func TestOrgDisplayUsers(t *testing.T) {
 		assert.Empty(t, got)
 	})
 }
+
+func TestMatchCandidatesFilterWithDirectBots_Mongo(t *testing.T) {
+	users := testutil.MongoDB(t, "pipelines_botfilter").Collection("users")
+	ctx := context.Background()
+
+	// org1 contains a human and a bot; weather.bot and p_hook exist outside orgs.
+	_, err := users.InsertMany(ctx, []any{
+		bson.M{"_id": "u1", "account": "alice", "sectId": "org1"},
+		bson.M{"_id": "u2", "account": "orgbound.bot", "sectId": "org1"},
+		bson.M{"_id": "u3", "account": "weather.bot"},
+		bson.M{"_id": "u4", "account": "p_hook"},
+		bson.M{"_id": "u5", "account": "bob"},
+	})
+	require.NoError(t, err)
+
+	fetch := func(t *testing.T, filter bson.M) []string {
+		t.Helper()
+		cursor, err := users.Find(ctx, filter)
+		require.NoError(t, err)
+		var rows []struct {
+			Account string `bson:"account"`
+		}
+		require.NoError(t, cursor.All(ctx, &rows))
+		got := make([]string, len(rows))
+		for i, r := range rows {
+			got[i] = r.Account
+		}
+		return got
+	}
+
+	t.Run("direct bots match, org-covered bots stay excluded", func(t *testing.T) {
+		got := fetch(t, MatchCandidatesFilterWithDirectBots([]string{"org1"}, []string{"weather.bot", "p_hook", "bob"}, ""))
+		assert.ElementsMatch(t, []string{"alice", "weather.bot", "p_hook", "bob"}, got)
+	})
+
+	t.Run("excludeAccount still applies on top", func(t *testing.T) {
+		got := fetch(t, MatchCandidatesFilterWithDirectBots([]string{"org1"}, []string{"weather.bot"}, "alice"))
+		assert.ElementsMatch(t, []string{"weather.bot"}, got)
+	})
+
+	t.Run("legacy filter keeps excluding direct bots", func(t *testing.T) {
+		got := fetch(t, MatchCandidatesFilter([]string{"org1"}, []string{"weather.bot", "bob"}, ""))
+		assert.ElementsMatch(t, []string{"alice", "bob"}, got)
+	})
+}

--- a/pkg/pipelines/member.go
+++ b/pkg/pipelines/member.go
@@ -1,8 +1,10 @@
 // Package pipelines holds shared MongoDB candidate-resolution helpers used by
-// more than one service — both the query predicate (MatchCandidatesFilter) and
-// the companion read (SubscribedAccounts). Centralizing them keeps room-service
-// (capacity check) and room-worker (candidate resolution) in lock-step on org
-// expansion, bot exclusion, and the already-subscribed subtraction.
+// more than one service — the query predicates (MatchCandidatesFilter and its
+// direct-bots variant) and the companion read (SubscribedAccounts).
+// Centralizing them keeps room-service and room-worker in lock-step on org
+// expansion and the already-subscribed subtraction; bot handling deliberately
+// differs per caller (capacity/create exclude bots everywhere, member.add
+// resolution admits explicitly listed ones — see each predicate's doc).
 package pipelines
 
 import (
@@ -41,4 +43,26 @@ func MatchCandidatesFilter(orgIDs, directAccounts []string, excludeAccount strin
 		accountFilter["$ne"] = excludeAccount
 	}
 	return bson.M{"$or": orFilter, "account": accountFilter}
+}
+
+// MatchCandidatesFilterWithDirectBots narrows the bot exclusion to the org
+// arms: directly named accounts may be bots (member.add validated them), while
+// org expansion stays bot-free. Same non-empty-input contract.
+func MatchCandidatesFilterWithDirectBots(orgIDs, directAccounts []string, excludeAccount string) bson.M {
+	notBot := bson.M{"$not": bson.Regex{Pattern: botOrPseudoAccountRegex, Options: ""}}
+	orFilter := bson.A{}
+	if len(orgIDs) > 0 {
+		orFilter = append(orFilter,
+			bson.M{"sectId": bson.M{"$in": orgIDs}, "account": notBot},
+			bson.M{"deptId": bson.M{"$in": orgIDs}, "account": notBot},
+		)
+	}
+	if len(directAccounts) > 0 {
+		orFilter = append(orFilter, bson.M{"account": bson.M{"$in": directAccounts}})
+	}
+	filter := bson.M{"$or": orFilter}
+	if excludeAccount != "" {
+		filter["account"] = bson.M{"$ne": excludeAccount}
+	}
+	return filter
 }

--- a/pkg/pipelines/member_test.go
+++ b/pkg/pipelines/member_test.go
@@ -49,3 +49,32 @@ func TestMatchCandidatesFilter(t *testing.T) {
 		assert.True(t, hasNot, "bot filter is retained alongside $ne")
 	})
 }
+
+func TestMatchCandidatesFilterWithDirectBots(t *testing.T) {
+	botNot := bson.M{"$not": bson.Regex{Pattern: botOrPseudoAccountRegex, Options: ""}}
+
+	t.Run("org arms keep the bot exclusion, direct arm does not", func(t *testing.T) {
+		f := MatchCandidatesFilterWithDirectBots([]string{"org1"}, []string{"alice", "weather.bot"}, "")
+		or, ok := f["$or"].(bson.A)
+		require.True(t, ok, "$or must be a bson.A")
+		assert.Equal(t, bson.A{
+			bson.M{"sectId": bson.M{"$in": []string{"org1"}}, "account": botNot},
+			bson.M{"deptId": bson.M{"$in": []string{"org1"}}, "account": botNot},
+			bson.M{"account": bson.M{"$in": []string{"alice", "weather.bot"}}},
+		}, or)
+		_, hasTopAccount := f["account"]
+		assert.False(t, hasTopAccount, "no top-level account filter without excludeAccount")
+	})
+
+	t.Run("accounts only produces a single unfiltered arm", func(t *testing.T) {
+		f := MatchCandidatesFilterWithDirectBots(nil, []string{"helper.bot"}, "")
+		assert.Equal(t, bson.A{bson.M{"account": bson.M{"$in": []string{"helper.bot"}}}}, f["$or"])
+	})
+
+	t.Run("excludeAccount adds a top-level $ne only", func(t *testing.T) {
+		f := MatchCandidatesFilterWithDirectBots([]string{"org1"}, nil, "exclude-me")
+		acct, ok := f["account"].(bson.M)
+		require.True(t, ok)
+		assert.Equal(t, bson.M{"$ne": "exclude-me"}, acct)
+	})
+}

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -6,6 +6,16 @@ import (
 	"unicode"
 )
 
+// EncodeAccount maps an account to its NATS subject-token form by replacing the
+// dot separators a dotted account (e.g. a ".bot" account) would otherwise spill
+// across subject tokens. This is the SAME transform auth-service applies when
+// minting a principal's NATS JWT, so a per-user subject built from the encoded
+// form matches the {account} token the principal's JWT is scoped to. A no-op for
+// accounts without dots (all plain human accounts).
+func EncodeAccount(account string) string {
+	return strings.ReplaceAll(account, ".", "_")
+}
+
 // IsValidAccountToken reports whether s can serve as the {account} token of a
 // NATS subject: non-empty, no '.'/'*'/'>' runes, no whitespace or control runes.
 func IsValidAccountToken(s string) bool {
@@ -282,7 +292,9 @@ func UserRoomEvent(account string) string {
 }
 
 func RoomKeyUpdate(account string) string {
-	return fmt.Sprintf("chat.user.%s.event.room.key", account)
+	// Encode the account so the subject matches the {account} token the
+	// recipient's NATS JWT is scoped to (a dotted ".bot" account spans tokens).
+	return fmt.Sprintf("chat.user.%s.event.room.key", EncodeAccount(account))
 }
 
 // --- Room CRUD request builders ---

--- a/pkg/subject/subject_test.go
+++ b/pkg/subject/subject_test.go
@@ -62,6 +62,8 @@ func TestSubjectBuilders(t *testing.T) {
 		{"UserRoomEvent", subject.UserRoomEvent("alice"), "chat.user.alice.event.room"},
 		{"RoomKeyUpdate", subject.RoomKeyUpdate("alice"),
 			"chat.user.alice.event.room.key"},
+		{"RoomKeyUpdate_dotted_bot_encoded", subject.RoomKeyUpdate("weather.bot"),
+			"chat.user.weather_bot.event.room.key"},
 		{"MemberRemove", subject.MemberRemove("alice", "r1", "site-a"),
 			"chat.user.alice.request.room.r1.site-a.member.remove"},
 		{"MemberAdd", subject.MemberAdd("alice", "r1", "site-a"),
@@ -198,6 +200,15 @@ func TestSubjectBuilders(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestEncodeAccount(t *testing.T) {
+	// Dotless accounts are untouched; dotted (".bot") accounts collapse to a
+	// single subject token, matching how auth-service mints the NATS JWT.
+	assert.Equal(t, "alice", subject.EncodeAccount("alice"))
+	assert.Equal(t, "weather_bot", subject.EncodeAccount("weather.bot"))
+	assert.Equal(t, "a_b_c_bot", subject.EncodeAccount("a.b.c.bot"))
+	assert.Equal(t, "p_hook", subject.EncodeAccount("p_hook"))
 }
 
 func TestParseUserRoomSubject(t *testing.T) {

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -669,15 +669,22 @@ func (h *Handler) removeMember(c *natsrouter.Context, req model.RemoveMemberRequ
 				return nil, errOnlyOwnersCanRemove
 			}
 		}
-		counts, err := h.store.CountMembersAndOwners(ctx, roomID)
-		if err != nil {
-			return nil, fmt.Errorf("count members: %w", err)
-		}
-		if counts.MemberCount <= 1 {
-			return nil, errCannotRemoveLastMember
-		}
-		if hasRole(target.Subscription.Roles, model.RoleOwner) && counts.OwnerCount <= 1 {
-			return nil, errLastOwnerCannotLeave
+		// Bot targets skip the last-member guard (can't orphan humans); the guard
+		// counts humans only. The last-owner guard stays generic — a legacy
+		// bot-owner must still not strand the room ownerless.
+		targetIsBot := model.IsBot(req.Account) || model.IsPlatformAdminAccount(req.Account)
+		targetIsOwner := hasRole(target.Subscription.Roles, model.RoleOwner)
+		if !targetIsBot || targetIsOwner {
+			counts, err := h.store.CountMembersAndOwners(ctx, roomID)
+			if err != nil {
+				return nil, fmt.Errorf("count members: %w", err)
+			}
+			if !targetIsBot && counts.HumanCount <= 1 {
+				return nil, errCannotRemoveLastMember
+			}
+			if targetIsOwner && counts.OwnerCount <= 1 {
+				return nil, errLastOwnerCannotLeave
+			}
 		}
 	} else {
 		// Owner-removes-org: only the requester's owner role matters here; org members resolved downstream.
@@ -715,6 +722,11 @@ func (h *Handler) updateRole(c *natsrouter.Context, req model.UpdateRoleRequest)
 	req.RoomID = roomID
 	if req.NewRole != model.RoleOwner && req.NewRole != model.RoleMember {
 		return nil, errInvalidRole
+	}
+	// Promote-only guard: demoting a legacy bot-owner back to member stays
+	// allowed so operators can repair such rooms.
+	if req.NewRole == model.RoleOwner && (model.IsBot(req.Account) || model.IsPlatformAdminAccount(req.Account)) {
+		return nil, errBotCannotBeOwner
 	}
 	room, err := h.store.GetRoom(ctx, roomID)
 	if err != nil {
@@ -860,12 +872,31 @@ func (h *Handler) addMembers(c *natsrouter.Context, req model.AddMembersRequest)
 		return nil, errRoomIDMismatch
 	}
 
-	// Reject direct bots up front — mirrors classifyAndValidate in
-	// create-channel: a client that explicitly lists a bot must see a hard
-	// error rather than a silent drop.
-	for _, a := range req.Users {
-		if model.IsBot(a) || model.IsPlatformAdminAccount(a) {
-			return nil, errBotInChannel
+	// Explicitly listed bots are admitted (create-channel still rejects them).
+	// Each must resolve to an enabled app assistant and be same-site (the feed
+	// is site-local). Deduped so a repeated bot costs one validation.
+	for _, a := range dedup(req.Users) {
+		if !model.IsBot(a) && !model.IsPlatformAdminAccount(a) {
+			continue
+		}
+		app, err := h.store.GetApp(ctx, a)
+		if err != nil {
+			if errors.Is(err, ErrAppNotFound) {
+				return nil, errBotNotAvailable
+			}
+			return nil, fmt.Errorf("get app for bot %s: %w", a, err)
+		}
+		if app.Assistant == nil || !app.Assistant.Enabled {
+			return nil, errBotNotAvailable
+		}
+		botSiteID, err := h.store.GetUserSiteID(ctx, a)
+		if err != nil {
+			return nil, fmt.Errorf("get bot siteId: %w", err)
+		}
+		// Empty siteId is treated as local (legacy bot docs); a phantom account
+		// is still rejected later by validateMembershipRefs.
+		if botSiteID != "" && botSiteID != h.siteID {
+			return nil, errBotCrossSite
 		}
 	}
 

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -594,7 +594,7 @@ func TestHandler_RemoveMember_SelfLeave_Success(t *testing.T) {
 	store.EXPECT().GetSubscriptionWithMembership(gomock.Any(), "r1", "alice").
 		Return(&SubscriptionWithMembership{Subscription: sub, HasIndividualMembership: true}, nil)
 	store.EXPECT().CountMembersAndOwners(gomock.Any(), "r1").
-		Return(&RoomCounts{MemberCount: 3, OwnerCount: 2}, nil)
+		Return(&RoomCounts{MemberCount: 3, HumanCount: 3, OwnerCount: 2}, nil)
 
 	var publishedSubj string
 	var publishedData []byte
@@ -658,7 +658,7 @@ func TestHandler_RemoveMember_SelfLeave_NoOrgs_Allowed(t *testing.T) {
 	store.EXPECT().GetSubscriptionWithMembership(gomock.Any(), "r1", "alice").
 		Return(&SubscriptionWithMembership{Subscription: sub}, nil)
 	store.EXPECT().CountMembersAndOwners(gomock.Any(), "r1").
-		Return(&RoomCounts{MemberCount: 2, OwnerCount: 1}, nil)
+		Return(&RoomCounts{MemberCount: 2, HumanCount: 2, OwnerCount: 1}, nil)
 
 	var publishedData []byte
 	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, func(ctx context.Context, _ string, data []byte, _ string) error {
@@ -697,7 +697,7 @@ func TestHandler_RemoveMember_LastOwner_Rejected(t *testing.T) {
 				store.EXPECT().GetSubscription(gomock.Any(), tc.requester, "r1").Return(ownerSub, nil)
 			}
 			store.EXPECT().CountMembersAndOwners(gomock.Any(), "r1").
-				Return(&RoomCounts{MemberCount: 3, OwnerCount: 1}, nil)
+				Return(&RoomCounts{MemberCount: 3, HumanCount: 3, OwnerCount: 1}, nil)
 			handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
 			_, err := handler.removeMember(ctxParams(map[string]string{"account": tc.requester, "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "alice"})
 			require.Error(t, err)
@@ -717,7 +717,7 @@ func TestHandler_RemoveMember_LastMember_Rejected(t *testing.T) {
 	store.EXPECT().GetSubscriptionWithMembership(gomock.Any(), "r1", "alice").
 		Return(&SubscriptionWithMembership{Subscription: sub, HasIndividualMembership: true}, nil)
 	store.EXPECT().CountMembersAndOwners(gomock.Any(), "r1").
-		Return(&RoomCounts{MemberCount: 1, OwnerCount: 0}, nil)
+		Return(&RoomCounts{MemberCount: 1, HumanCount: 1, OwnerCount: 0}, nil)
 	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
 	_, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "alice"})
 	require.Error(t, err)
@@ -740,7 +740,7 @@ func TestHandler_RemoveMember_OwnerRemovesOther_Success(t *testing.T) {
 		Return(&SubscriptionWithMembership{Subscription: targetSub, HasIndividualMembership: true}, nil)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").Return(ownerSub, nil)
 	store.EXPECT().CountMembersAndOwners(gomock.Any(), "r1").
-		Return(&RoomCounts{MemberCount: 3, OwnerCount: 1}, nil)
+		Return(&RoomCounts{MemberCount: 3, HumanCount: 3, OwnerCount: 1}, nil)
 	var publishedData []byte
 	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, func(ctx context.Context, subj string, data []byte, _ string) error {
 		publishedData = data
@@ -892,7 +892,7 @@ func TestHandler_RemoveMember_PublishError(t *testing.T) {
 	store.EXPECT().GetSubscriptionWithMembership(gomock.Any(), "r1", "alice").
 		Return(&SubscriptionWithMembership{Subscription: sub, HasIndividualMembership: true}, nil)
 	store.EXPECT().CountMembersAndOwners(gomock.Any(), "r1").
-		Return(&RoomCounts{MemberCount: 3, OwnerCount: 2}, nil)
+		Return(&RoomCounts{MemberCount: 3, HumanCount: 3, OwnerCount: 2}, nil)
 	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, func(_ context.Context, _ string, _ []byte, _ string) error {
 		return fmt.Errorf("nats down")
 	}, nil, nil, 0)
@@ -1076,10 +1076,127 @@ func TestHandler_AddMembers_EmptyAfterResolve(t *testing.T) {
 	assert.Equal(t, "accepted", resp.Status)
 }
 
-func TestHandler_AddMembers_RejectsDirectBot(t *testing.T) {
+func TestHandler_AddMembers_ExplicitBot(t *testing.T) {
+	enabledApp := &model.App{ID: "app1", Name: "Weather", Assistant: &model.AppAssistant{Enabled: true, Name: "weather.bot"}}
+
+	tests := []struct {
+		name            string
+		botAccount      string
+		setupMocks      func(store *MockRoomStore)
+		wantErr         error
+		wantErrContains string
+		wantPublish     bool
+	}{
+		{
+			name:       "enabled local bot is accepted",
+			botAccount: "weather.bot",
+			setupMocks: func(store *MockRoomStore) {
+				store.EXPECT().GetApp(gomock.Any(), "weather.bot").Return(enabledApp, nil)
+				store.EXPECT().GetUserSiteID(gomock.Any(), "weather.bot").Return("site-a", nil)
+				expectAllAccountsExist(store)
+			},
+			wantPublish: true,
+		},
+		{
+			name:       "platform-admin pseudo account accepted like a bot",
+			botAccount: "p_hook",
+			setupMocks: func(store *MockRoomStore) {
+				store.EXPECT().GetApp(gomock.Any(), "p_hook").Return(
+					&model.App{ID: "app2", Assistant: &model.AppAssistant{Enabled: true, Name: "p_hook"}}, nil)
+				store.EXPECT().GetUserSiteID(gomock.Any(), "p_hook").Return("", nil)
+				expectAllAccountsExist(store)
+			},
+			wantPublish: true,
+		},
+		{
+			name:       "unknown app rejected",
+			botAccount: "weather.bot",
+			setupMocks: func(store *MockRoomStore) {
+				store.EXPECT().GetApp(gomock.Any(), "weather.bot").Return(nil, ErrAppNotFound)
+			},
+			wantErr: errBotNotAvailable,
+		},
+		{
+			name:       "disabled assistant rejected",
+			botAccount: "weather.bot",
+			setupMocks: func(store *MockRoomStore) {
+				store.EXPECT().GetApp(gomock.Any(), "weather.bot").Return(
+					&model.App{ID: "app1", Assistant: &model.AppAssistant{Enabled: false, Name: "weather.bot"}}, nil)
+			},
+			wantErr: errBotNotAvailable,
+		},
+		{
+			name:       "cross-site bot rejected",
+			botAccount: "weather.bot",
+			setupMocks: func(store *MockRoomStore) {
+				store.EXPECT().GetApp(gomock.Any(), "weather.bot").Return(enabledApp, nil)
+				store.EXPECT().GetUserSiteID(gomock.Any(), "weather.bot").Return("site-b", nil)
+			},
+			wantErr: errBotCrossSite,
+		},
+		{
+			name:       "GetApp infra error collapses to internal",
+			botAccount: "weather.bot",
+			setupMocks: func(store *MockRoomStore) {
+				store.EXPECT().GetApp(gomock.Any(), "weather.bot").Return(nil, errors.New("mongo timeout"))
+			},
+			wantErrContains: "get app for bot",
+		},
+		{
+			name:       "GetUserSiteID infra error collapses to internal",
+			botAccount: "weather.bot",
+			setupMocks: func(store *MockRoomStore) {
+				store.EXPECT().GetApp(gomock.Any(), "weather.bot").Return(enabledApp, nil)
+				store.EXPECT().GetUserSiteID(gomock.Any(), "weather.bot").Return("", errors.New("mongo timeout"))
+			},
+			wantErrContains: "get bot siteId",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			store := NewMockRoomStore(ctrl)
+			store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").Return(&model.Subscription{
+				User:  model.SubscriptionUser{ID: "u1", Account: "alice"},
+				Roles: []model.Role{model.RoleOwner},
+			}, nil)
+			store.EXPECT().GetRoom(gomock.Any(), "r1").Return(&model.Room{
+				ID: "r1", Type: model.RoomTypeChannel, UserCount: 1,
+			}, nil)
+			tc.setupMocks(store)
+
+			var publishedPayload []byte
+			h := &Handler{store: store, siteID: "site-a", maxRoomSize: 1000,
+				publishToStream: func(_ context.Context, _ string, data []byte, _ string) error {
+					publishedPayload = data
+					return nil
+				},
+			}
+			_, err := h.addMembers(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.AddMembersRequest{Users: []string{tc.botAccount}})
+			if tc.wantErr != nil || tc.wantErrContains != "" {
+				require.Error(t, err)
+				if tc.wantErr != nil {
+					assert.True(t, errors.Is(err, tc.wantErr), "want %v, got %v", tc.wantErr, err)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(t, err.Error(), tc.wantErrContains)
+				}
+				assert.Nil(t, publishedPayload)
+				return
+			}
+			require.NoError(t, err)
+			require.True(t, tc.wantPublish)
+			var published model.AddMembersRequest
+			require.NoError(t, json.Unmarshal(publishedPayload, &published))
+			assert.Contains(t, published.Users, tc.botAccount)
+		})
+	}
+}
+
+// A bot listed twice costs one GetApp + one GetUserSiteID (dedup before validate).
+func TestHandler_AddMembers_DuplicateBot_ValidatedOnce(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockRoomStore(ctrl)
-
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").Return(&model.Subscription{
 		User:  model.SubscriptionUser{ID: "u1", Account: "alice"},
 		Roles: []model.Role{model.RoleOwner},
@@ -1087,16 +1204,103 @@ func TestHandler_AddMembers_RejectsDirectBot(t *testing.T) {
 	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(&model.Room{
 		ID: "r1", Type: model.RoomTypeChannel, UserCount: 1,
 	}, nil)
+	store.EXPECT().GetApp(gomock.Any(), "weather.bot").Times(1).Return(
+		&model.App{ID: "app1", Assistant: &model.AppAssistant{Enabled: true, Name: "weather.bot"}}, nil)
+	store.EXPECT().GetUserSiteID(gomock.Any(), "weather.bot").Times(1).Return("site-a", nil)
+	expectAllAccountsExist(store)
 
 	h := &Handler{store: store, siteID: "site-a", maxRoomSize: 1000,
 		publishToStream: func(_ context.Context, _ string, _ []byte, _ string) error { return nil },
 	}
-	req := model.AddMembersRequest{
-		Users: []string{"weather.bot"},
+	_, err := h.addMembers(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}),
+		model.AddMembersRequest{Users: []string{"weather.bot", "weather.bot"}})
+	require.NoError(t, err)
+}
+
+// For a bot-owner target the last-member guard is skipped but the last-owner
+// guard still fires — a sole bot-owner cannot be stranded.
+func TestHandler_RemoveMember_BotOwnerTarget_LastOwnerGuardApplies(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockRoomStore(ctrl)
+	botOwnerSub := &model.Subscription{
+		ID: "s9", User: model.SubscriptionUser{ID: "u9", Account: "weather.bot", IsBot: true},
+		RoomID: "r1", Roles: []model.Role{model.RoleOwner},
 	}
-	_, err := h.addMembers(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), req)
+	requesterSub := &model.Subscription{
+		ID: "s1", User: model.SubscriptionUser{ID: "u1", Account: "alice"},
+		RoomID: "r1", Roles: []model.Role{model.RoleOwner},
+	}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel}, nil)
+	store.EXPECT().GetSubscriptionWithMembership(gomock.Any(), "r1", "weather.bot").
+		Return(&SubscriptionWithMembership{Subscription: botOwnerSub, HasIndividualMembership: true}, nil)
+	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").Return(requesterSub, nil)
+	// Owner target → counts fetched; last-owner guard fires on OwnerCount<=1.
+	store.EXPECT().CountMembersAndOwners(gomock.Any(), "r1").
+		Return(&RoomCounts{MemberCount: 2, HumanCount: 1, OwnerCount: 1}, nil)
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	_, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}),
+		model.RemoveMemberRequest{RoomID: "r1", Account: "weather.bot"})
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, errBotInChannel))
+	assert.True(t, errors.Is(err, errLastOwnerCannotLeave))
+}
+
+func TestHandler_RemoveMember_BotTarget_SkipsMemberGuards(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockRoomStore(ctrl)
+	botSub := &model.Subscription{
+		ID: "s9", User: model.SubscriptionUser{ID: "u9", Account: "weather.bot", IsBot: true},
+		RoomID: "r1", Roles: []model.Role{model.RoleMember},
+	}
+	ownerSub := &model.Subscription{
+		ID: "s1", User: model.SubscriptionUser{ID: "u1", Account: "alice"},
+		RoomID: "r1", Roles: []model.Role{model.RoleOwner},
+	}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel}, nil)
+	store.EXPECT().GetSubscriptionWithMembership(gomock.Any(), "r1", "weather.bot").
+		Return(&SubscriptionWithMembership{Subscription: botSub, HasIndividualMembership: true}, nil)
+	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").Return(ownerSub, nil)
+	// No CountMembersAndOwners expectation: a non-owner bot target skips the guard.
+	var publishedData []byte
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, func(_ context.Context, _ string, data []byte, _ string) error {
+		publishedData = data
+		return nil
+	}, nil, nil, 0)
+	resp, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "weather.bot"})
+	require.NoError(t, err)
+	assert.Equal(t, "accepted", resp.Status)
+	var published model.RemoveMemberRequest
+	require.NoError(t, json.Unmarshal(publishedData, &published))
+	assert.Equal(t, "weather.bot", published.Account)
+}
+
+func TestHandler_RemoveMember_LastHumanWithBotsPresent_Rejected(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockRoomStore(ctrl)
+	sub := &model.Subscription{
+		ID: "s1", User: model.SubscriptionUser{ID: "u1", Account: "alice"},
+		RoomID: "r1", Roles: []model.Role{model.RoleMember},
+	}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel}, nil)
+	store.EXPECT().GetSubscriptionWithMembership(gomock.Any(), "r1", "alice").
+		Return(&SubscriptionWithMembership{Subscription: sub, HasIndividualMembership: true}, nil)
+	// Two subs (alice + a bot) but one human: removing the last human is blocked.
+	store.EXPECT().CountMembersAndOwners(gomock.Any(), "r1").
+		Return(&RoomCounts{MemberCount: 2, HumanCount: 1, OwnerCount: 1}, nil)
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	_, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "alice"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errCannotRemoveLastMember))
+}
+
+func TestHandler_UpdateRole_BotPromotion_Rejected(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockRoomStore(ctrl)
+	// The bot check fires before any store read, so no store expectations.
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	_, err := handler.updateRole(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}),
+		model.UpdateRoleRequest{RoomID: "r1", Account: "weather.bot", NewRole: model.RoleOwner})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errBotCannotBeOwner))
 }
 
 func TestHandler_AddMembers_SilentlyFiltersBotsFromChannelRefs(t *testing.T) {

--- a/room-service/helper.go
+++ b/room-service/helper.go
@@ -43,9 +43,13 @@ var (
 	errPromoteRequiresIndividual = errcode.BadRequest("only individual members can be promoted to owner", errcode.WithReason(errcode.RoomPromoteRequiresIndividual))
 
 	// Sentinels for create-room validation.
-	errEmptyCreateRequest  = errcode.BadRequest("request must include at least one of users, orgs, channels, or name")
-	errBotInChannel        = errcode.BadRequest("bots cannot be added to a channel", errcode.WithReason(errcode.RoomBotInChannel))
-	errBotNotAvailable     = errcode.NotFound("bot not available", errcode.WithReason(errcode.RoomBotNotAvailable))
+	errEmptyCreateRequest = errcode.BadRequest("request must include at least one of users, orgs, channels, or name")
+	errBotInChannel       = errcode.BadRequest("bots cannot be added to a channel", errcode.WithReason(errcode.RoomBotInChannel))
+	errBotNotAvailable    = errcode.NotFound("bot not available", errcode.WithReason(errcode.RoomBotNotAvailable))
+	// member.add admits only same-site bots — the join/leave feed is site-local.
+	errBotCrossSite = errcode.BadRequest("cross-site bots cannot be added to a channel", errcode.WithReason(errcode.RoomBotCrossSite))
+	// Bots hold plain member roles only.
+	errBotCannotBeOwner    = errcode.BadRequest("bots cannot be room owners", errcode.WithReason(errcode.RoomBotCannotBeOwner))
 	errInvalidUserData     = errcode.BadRequest("user is missing required name fields")
 	errChannelNameRequired = errcode.BadRequest("channel name is required")
 	errChannelNameTooLong  = errcode.BadRequest("channel name must be at most 100 characters")

--- a/room-service/helper_test.go
+++ b/room-service/helper_test.go
@@ -82,6 +82,8 @@ func TestSentinelCodesAndReasons(t *testing.T) {
 		{"empty create request", errEmptyCreateRequest, errcode.CodeBadRequest, ""},
 		{"bot in channel", errBotInChannel, errcode.CodeBadRequest, errcode.RoomBotInChannel},
 		{"bot not available", errBotNotAvailable, errcode.CodeNotFound, errcode.RoomBotNotAvailable},
+		{"bot cross-site", errBotCrossSite, errcode.CodeBadRequest, errcode.RoomBotCrossSite},
+		{"bot cannot be owner", errBotCannotBeOwner, errcode.CodeBadRequest, errcode.RoomBotCannotBeOwner},
 		{"invalid user data", errInvalidUserData, errcode.CodeBadRequest, ""},
 		{"channel name required", errChannelNameRequired, errcode.CodeBadRequest, ""},
 		{"channel name too long", errChannelNameTooLong, errcode.CodeBadRequest, ""},

--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -275,13 +275,15 @@ func TestMongoStore_CountMembersAndOwners_Integration(t *testing.T) {
 		model.Subscription{ID: "s2", User: model.SubscriptionUser{ID: "u2", Account: "bob"}, RoomID: "r1", Roles: []model.Role{model.RoleOwner, model.RoleMember}},
 		model.Subscription{ID: "s3", User: model.SubscriptionUser{ID: "u3", Account: "carol"}, RoomID: "r1", Roles: []model.Role{model.RoleMember}},
 		model.Subscription{ID: "s4", User: model.SubscriptionUser{ID: "u4", Account: "dave"}, RoomID: "r2", Roles: []model.Role{model.RoleOwner}},
+		model.Subscription{ID: "s5", User: model.SubscriptionUser{ID: "u5", Account: "weather.bot", IsBot: true}, RoomID: "r1", Roles: []model.Role{model.RoleMember}},
 	})
 	require.NoError(t, err)
 
-	t.Run("counts members and owners", func(t *testing.T) {
+	t.Run("counts members, humans and owners — bots excluded from humans", func(t *testing.T) {
 		counts, err := store.CountMembersAndOwners(ctx, "r1")
 		require.NoError(t, err)
-		assert.Equal(t, 3, counts.MemberCount)
+		assert.Equal(t, 4, counts.MemberCount)
+		assert.Equal(t, 3, counts.HumanCount, "bot sub must not count as human")
 		assert.Equal(t, 2, counts.OwnerCount)
 	})
 
@@ -289,6 +291,7 @@ func TestMongoStore_CountMembersAndOwners_Integration(t *testing.T) {
 		counts, err := store.CountMembersAndOwners(ctx, "r2")
 		require.NoError(t, err)
 		assert.Equal(t, 1, counts.MemberCount)
+		assert.Equal(t, 1, counts.HumanCount, "legacy sub without isBot counts as human")
 		assert.Equal(t, 1, counts.OwnerCount)
 	})
 

--- a/room-service/store.go
+++ b/room-service/store.go
@@ -28,10 +28,12 @@ type SubscriptionWithMembership struct {
 	HasOrgMembership        bool
 }
 
-// RoomCounts is the result of CountMembersAndOwners — member and owner counts
-// for a single room, computed in one aggregation.
+// RoomCounts is the result of CountMembersAndOwners. HumanCount excludes bot
+// subs (u.isBot) so the last-member guard blocks removing the last human even
+// when bots remain; docs missing the flag count as human.
 type RoomCounts struct {
 	MemberCount int
+	HumanCount  int
 	OwnerCount  int
 }
 

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -396,6 +396,11 @@ func (s *MongoStore) CountMembersAndOwners(ctx context.Context, roomID string) (
 		{{Key: "$match", Value: bson.M{"roomId": roomID}}},
 		{{Key: "$facet", Value: bson.M{
 			"members": bson.A{bson.M{"$count": "count"}},
+			// $ne true also matches pre-flag legacy subs (counted as humans).
+			"humans": bson.A{
+				bson.M{"$match": bson.M{"u.isBot": bson.M{"$ne": true}}},
+				bson.M{"$count": "count"},
+			},
 			"owners": bson.A{
 				bson.M{"$match": bson.M{"roles": model.RoleOwner}},
 				bson.M{"$count": "count"},
@@ -412,6 +417,9 @@ func (s *MongoStore) CountMembersAndOwners(ctx context.Context, roomID string) (
 		Members []struct {
 			Count int `bson:"count"`
 		} `bson:"members"`
+		Humans []struct {
+			Count int `bson:"count"`
+		} `bson:"humans"`
 		Owners []struct {
 			Count int `bson:"count"`
 		} `bson:"owners"`
@@ -428,6 +436,9 @@ func (s *MongoStore) CountMembersAndOwners(ctx context.Context, roomID string) (
 	counts := &RoomCounts{}
 	if len(result.Members) > 0 {
 		counts.MemberCount = result.Members[0].Count
+	}
+	if len(result.Humans) > 0 {
+		counts.HumanCount = result.Humans[0].Count
 	}
 	if len(result.Owners) > 0 {
 		counts.OwnerCount = result.Owners[0].Count

--- a/room-worker/bootstrap.go
+++ b/room-worker/bootstrap.go
@@ -51,9 +51,8 @@ func bootstrapStreams(ctx context.Context, js streamManager, siteID string, enab
 		}
 		return nil
 	}
-	// Production path: verify the stream exists. Fail fast if it doesn't —
-	// ops/IaC owns provisioning, and a missing stream means the deploy is
-	// broken before the first publish or consume.
+	// Verify the ROOMS stream this service CONSUMES — fail fast if ops didn't
+	// provision it.
 	if _, err := js.Stream(ctx, roomsCfg.Name); err != nil {
 		return fmt.Errorf("verify ROOMS stream: %w", err)
 	}

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -380,9 +380,8 @@ func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.Remove
 	}
 	h.bustRoomMeta(ctx, req.RoomID)
 
-	// Rotate after delete + reconcile; GetSubscriptionAccounts returns the
-	// post-deletion survivor accounts (projected — fan-out only needs accounts,
-	// not full subscription docs).
+	// Rotate after delete + reconcile; survivors are the post-deletion accounts.
+	// Bots hold keys too, so a bot removal rotates like any other member.
 	survivorAccounts, listErr := h.store.GetSubscriptionAccounts(ctx, req.RoomID)
 	if listErr != nil {
 		return fmt.Errorf("list survivors for key fan-out (room %s): %w", req.RoomID, listErr)
@@ -393,20 +392,23 @@ func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.Remove
 
 	now := time.Now().UTC()
 
-	// Subscription update event. RoomType is fixed to channel: room-service
-	// rejects member.remove for any other room kind.
-	subEvt := model.SubscriptionRemovedEvent{
-		UserID: user.ID,
-		Subscription: model.RemovedSubscriptionRef{
-			RoomID:   req.RoomID,
-			RoomType: model.RoomTypeChannel,
-			U:        model.SubscriptionUser{ID: user.ID, Account: req.Account},
-		},
-		Action:    "removed",
-		Timestamp: now.UnixMilli(),
+	// Subscription update event (channel-only handler). Skipped for bots: they
+	// have no client consuming it on the per-user subject.
+	targetIsBot := model.IsBot(req.Account) || model.IsPlatformAdminAccount(req.Account)
+	if !targetIsBot {
+		subEvt := model.SubscriptionRemovedEvent{
+			UserID: user.ID,
+			Subscription: model.RemovedSubscriptionRef{
+				RoomID:   req.RoomID,
+				RoomType: model.RoomTypeChannel,
+				U:        model.SubscriptionUser{ID: user.ID, Account: req.Account},
+			},
+			Action:    "removed",
+			Timestamp: now.UnixMilli(),
+		}
+		subEvtData, _ := json.Marshal(subEvt)
+		h.publishSubscriptionUpdate(ctx, req.Account, subEvtData)
 	}
-	subEvtData, _ := json.Marshal(subEvt)
-	h.publishSubscriptionUpdate(ctx, req.Account, subEvtData)
 
 	// Member change event
 	evtType := model.MessageTypeMemberLeft
@@ -599,8 +601,12 @@ func (h *Handler) processRemoveOrg(ctx context.Context, req *model.RemoveMemberR
 
 	now := time.Now().UTC()
 
-	// Publish per-account subscription update and collect cross-site accounts
+	// Non-bot members get a per-account subscription.update; bots are skipped
+	// (no client consuming it on the per-user subject).
 	for _, m := range toRemove {
+		if model.IsBot(m.Account) || model.IsPlatformAdminAccount(m.Account) {
+			continue
+		}
 		subEvt := model.SubscriptionRemovedEvent{
 			Subscription: model.RemovedSubscriptionRef{
 				RoomID:   req.RoomID,
@@ -1043,8 +1049,11 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 	h.bustRoomMeta(ctx, req.RoomID)
 
 	// Publish subscription.update BEFORE room.key so clients have a sub entry to store the key under.
-	// Channel-only handler: roomName is the already-fetched channel name.
+	// Bots are skipped: no client consuming it on the per-user subject.
 	for _, sub := range subs {
+		if sub.User.IsBot {
+			continue
+		}
 		subEvt := model.SubscriptionUpdateEvent{
 			UserID:       sub.User.ID,
 			Subscription: *sub,
@@ -2273,6 +2282,10 @@ func (h *Handler) buildAndFanOutRoomKey(ctx context.Context, roomID string, pair
 // evt is taken by pointer so the 80-byte struct isn't copied per fan-out call;
 // callers must not mutate it after passing it in.
 func (h *Handler) fanOutKey(ctx context.Context, roomID string, accounts []string, evt *model.RoomKeyEvent) {
+	// Bots receive room keys like any member: the key subject is built via
+	// subject.RoomKeyUpdate, which encodes the account (dots→underscores) so a
+	// dotted ".bot" account maps to the single subject token its NATS JWT is
+	// scoped to (chat.user.weather_bot.>) — no raw-subject spill, no disclosure.
 	if len(accounts) == 0 {
 		return
 	}

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -145,6 +145,49 @@ func TestHandler_ProcessRemoveMember_SelfLeave_IndividualOnly(t *testing.T) {
 	}
 }
 
+// TestHandler_ProcessRemoveMember_BotTarget_RotatesButNoSubUpdate: removing a bot
+// now rotates the room key like any member (bots hold keys) — GetSubscriptionAccounts
+// is called for the survivor fan-out — but still publishes no per-user
+// subscription.update to the bot's subject (bots have no sidebar client).
+func TestHandler_ProcessRemoveMember_BotTarget_RotatesButNoSubUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+
+	const (
+		roomID    = "room-1"
+		botAcct   = "weather.bot"
+		requester = "alice"
+		siteID    = "site-a"
+	)
+
+	store.EXPECT().GetUserWithMembership(gomock.Any(), roomID, botAcct).Return(&UserWithMembership{
+		User: model.User{ID: "u_bot", Account: botAcct, SiteID: siteID, EngName: "Weather"},
+	}, nil)
+	store.EXPECT().DeleteSubscription(gomock.Any(), roomID, botAcct).Return(int64(1), nil)
+	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u_bot").Return(nil)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	// Rotation now runs for a bot removal too — the survivor fan-out reads accounts.
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
+	store.EXPECT().GetUser(gomock.Any(), requester).Return(&model.User{ID: "u1", Account: requester, SiteID: siteID, EngName: "Alice"}, nil)
+
+	var published []publishedMsg
+	h := NewHandler(store, siteID, func(_ context.Context, subj string, data []byte, _ string) error {
+		published = append(published, publishedMsg{subj: subj, data: data})
+		return nil
+	}, testKeyStore, testKeySender)
+
+	req := model.RemoveMemberRequest{RoomID: roomID, Requester: requester, Account: botAcct, Timestamp: 1, RoomType: model.RoomTypeChannel}
+	data, _ := json.Marshal(req)
+	require.NoError(t, h.processRemoveMember(context.Background(), data))
+
+	subjSet := map[string]bool{}
+	for _, p := range published {
+		subjSet[p.subj] = true
+	}
+	assert.False(t, subjSet[subject.SubscriptionUpdate(botAcct)], "bot must NOT get a subscription.update on removal")
+	assert.True(t, subjSet[subject.MemberEvent(roomID)], "member event still fires for the removal")
+}
+
 func TestHandler_ProcessRemoveMember_SelfLeave_DualMembership(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
@@ -591,6 +634,57 @@ func TestHandler_ProcessAddMembers_PublishesSubscriptionUpdateBeforeRoomKey(t *t
 			"account %s: subscription.update (idx %d) must precede room.key (idx %d)",
 			account, subIdx, keyIdx)
 	}
+}
+
+// TestHandler_ProcessAddMembers_BotGetsKeyNotSubUpdate locks in the delivery
+// model: a bot member DOES receive room.key — on its encoded per-user subject
+// (subject.RoomKeyUpdate encodes weather.bot → chat.user.weather_bot.event.room.key,
+// the token its NATS JWT is scoped to) — but gets NO subscription.update (no
+// sidebar client to consume it). A human added in the same batch gets both.
+func TestHandler_ProcessAddMembers_BotGetsKeyNotSubUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+
+	pub := &mockPublisher{}
+	publish := func(_ context.Context, subj string, data []byte, _ string) error {
+		return pub.Publish(subj, data)
+	}
+	h := NewHandler(store, "site-a", publish, testKeyStore, roomkeysender.NewSender(pub))
+
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
+	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"bob", "weather.bot"}, "r1").
+		Return([]AddMemberCandidate{
+			{Account: "bob", HasSubscription: false, HasIndividualRoomMember: false},
+			{Account: "weather.bot", HasSubscription: false, HasIndividualRoomMember: false},
+		}, nil)
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"bob", "weather.bot"}).Return([]model.User{
+		{ID: "u2", Account: "bob", SiteID: "site-a", EngName: "Bob"},
+		{ID: "u3", Account: "weather.bot", SiteID: "site-a", EngName: "Weather"},
+	}, nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{
+		ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice",
+	}, nil)
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
+
+	req := model.AddMembersRequest{
+		RoomID: "r1", RequesterAccount: "alice", Users: []string{"bob", "weather.bot"},
+		History:   model.HistoryConfig{Mode: model.HistoryModeNone},
+		Timestamp: 1,
+	}
+	reqData, _ := json.Marshal(req)
+	require.NoError(t, h.processAddMembers(natsutil.WithRequestID(context.Background(), testRequestID), reqData))
+
+	published := map[string]bool{}
+	for _, s := range pub.subjects {
+		published[s] = true
+	}
+	assert.True(t, published[subject.SubscriptionUpdate("bob")], "human must get subscription.update")
+	assert.True(t, published[subject.RoomKeyUpdate("bob")], "human must get room.key")
+	// RoomKeyUpdate encodes the account, so this is chat.user.weather_bot.event.room.key.
+	assert.True(t, published[subject.RoomKeyUpdate("weather.bot")], "bot gets room.key on its encoded subject")
+	assert.False(t, published[subject.SubscriptionUpdate("weather.bot")], "bot has no sidebar → no subscription.update")
 }
 
 func TestHandler_ProcessAddMembers_HistoryAll(t *testing.T) {

--- a/room-worker/integration_test.go
+++ b/room-worker/integration_test.go
@@ -681,17 +681,36 @@ func TestMongoStore_ListAddMemberCandidates_Integration(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	got, err := store.ListAddMemberCandidates(ctx, []string{"org-eng"}, nil, roomID)
-	require.NoError(t, err)
-
-	byAccount := map[string]AddMemberCandidate{}
-	for _, c := range got {
-		byAccount[c.Account] = c
+	collect := func(t *testing.T, orgIDs, direct []string) map[string]AddMemberCandidate {
+		t.Helper()
+		got, err := store.ListAddMemberCandidates(ctx, orgIDs, direct, roomID)
+		require.NoError(t, err)
+		byAccount := map[string]AddMemberCandidate{}
+		for _, c := range got {
+			byAccount[c.Account] = c
+		}
+		return byAccount
 	}
-	require.Len(t, byAccount, 3, "bot dave.bot must be excluded")
-	assert.Equal(t, AddMemberCandidate{Account: "alice", HasSubscription: false, HasIndividualRoomMember: false}, byAccount["alice"])
-	assert.Equal(t, AddMemberCandidate{Account: "bob", HasSubscription: true, HasIndividualRoomMember: false}, byAccount["bob"], "bug scenario: sub exists, IRM does not")
-	assert.Equal(t, AddMemberCandidate{Account: "carol", HasSubscription: true, HasIndividualRoomMember: true}, byAccount["carol"])
+
+	t.Run("org expansion excludes bots", func(t *testing.T) {
+		byAccount := collect(t, []string{"org-eng"}, nil)
+		require.Len(t, byAccount, 3, "org-covered bot dave.bot must be excluded")
+		assert.Equal(t, AddMemberCandidate{Account: "alice", HasSubscription: false, HasIndividualRoomMember: false}, byAccount["alice"])
+		assert.Equal(t, AddMemberCandidate{Account: "bob", HasSubscription: true, HasIndividualRoomMember: false}, byAccount["bob"], "bug scenario: sub exists, IRM does not")
+		assert.Equal(t, AddMemberCandidate{Account: "carol", HasSubscription: true, HasIndividualRoomMember: true}, byAccount["carol"])
+	})
+
+	t.Run("explicitly listed bot resolves via the direct-only path", func(t *testing.T) {
+		byAccount := collect(t, nil, []string{"dave.bot"})
+		require.Len(t, byAccount, 1)
+		assert.Equal(t, AddMemberCandidate{Account: "dave.bot", HasSubscription: false, HasIndividualRoomMember: false}, byAccount["dave.bot"])
+	})
+
+	t.Run("explicitly listed bot resolves alongside org expansion", func(t *testing.T) {
+		byAccount := collect(t, []string{"org-eng"}, []string{"dave.bot"})
+		require.Len(t, byAccount, 4, "direct bot admitted, org arms still bot-free")
+		assert.Contains(t, byAccount, "dave.bot")
+	})
 }
 
 // newIntegrationHandler creates a Handler wired to the given store and siteID with a no-op publish function.

--- a/room-worker/store.go
+++ b/room-worker/store.go
@@ -128,9 +128,9 @@ type SubscriptionStore interface {
 	// modified, so the handler reconciles against the existing doc and reuses it.
 	CreateRoom(ctx context.Context, room *model.Room, key *roomkeystore.RoomKeyPair) (inserted bool, err error)
 
-	// ListNewMembersForNewRoom is the empty-roomID variant of the
-	// ListAddMemberCandidates candidate resolution — same dedup + bot filter,
-	// no "already-subscribed" pruning since the room doesn't exist yet.
+	// ListNewMembersForNewRoom is the create-time candidate resolution — keeps
+	// the full bot exclusion (create-channel rejects bots) and skips the
+	// already-subscribed pruning since the room doesn't exist yet.
 	// excludeAccount drops one account from the candidate set; create-channel
 	// passes the requester's account so they aren't materialized as a regular
 	// member in addition to being added separately as the owner.

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -570,22 +570,19 @@ func (s *MongoStore) ListAddMemberCandidates(ctx context.Context, orgIDs, direct
 	type candidate struct{ ID, Account string }
 	var candidates []candidate
 	if len(orgIDs) == 0 {
-		// Direct accounts only: resolve via the user reader (cache-friendly) and
-		// filter bots in Go — avoids the users query and the $not regex entirely.
+		// Direct accounts only, cache-friendly. Bots are NOT filtered here —
+		// room-service already validated the explicitly-listed ones.
 		users, err := s.userReader.FindUsersByAccounts(ctx, directAccounts)
 		if err != nil {
 			return nil, fmt.Errorf("find add-member candidate users: %w", err)
 		}
 		for i := range users {
-			if model.IsBot(users[i].Account) || model.IsPlatformAdminAccount(users[i].Account) {
-				continue
-			}
 			candidates = append(candidates, candidate{ID: users[i].ID, Account: users[i].Account})
 		}
 	} else {
-		// Org expansion needs the sectId/deptId query on the users collection,
-		// which the by-account reader cannot serve.
-		filter := pipelines.MatchCandidatesFilter(orgIDs, directAccounts, "")
+		// Org expansion needs the sectId/deptId query. WithDirectBots admits
+		// listed bots while keeping the org arms bot-free.
+		filter := pipelines.MatchCandidatesFilterWithDirectBots(orgIDs, directAccounts, "")
 		cursor, err := s.users.Find(ctx, filter, options.Find().SetProjection(bson.M{"account": 1, "_id": 1}))
 		if err != nil {
 			return nil, fmt.Errorf("find add-member candidates: %w", err)

--- a/search-sync-worker/spotlight.go
+++ b/search-sync-worker/spotlight.go
@@ -69,6 +69,10 @@ func (c *spotlightCollection) BuildAction(data []byte) ([]searchengine.BulkActio
 		if account == "" {
 			return nil, fmt.Errorf("build spotlight action: empty account at index %d", i)
 		}
+		// Bots are channel members but not searchable principals — skip them.
+		if model.IsBot(account) || model.IsPlatformAdminAccount(account) {
+			continue
+		}
 		docID := fmt.Sprintf("%s_%s", account, payload.RoomID)
 
 		switch evt.Type {

--- a/search-sync-worker/spotlight_test.go
+++ b/search-sync-worker/spotlight_test.go
@@ -150,6 +150,29 @@ func TestSpotlightCollection_BuildAction_MemberAdded(t *testing.T) {
 	assert.Equal(t, "site-a", doc["siteId"])
 }
 
+func TestSpotlightCollection_BuildAction_SkipsBots(t *testing.T) {
+	coll := newSpotlightCollection("spotlight-site-a-v1-chat", false)
+	payload := baseInboxMemberEvent()
+	payload.Accounts = []string{"alice", "weather.bot", "p_hook"}
+	data := makeInboxMemberEvent(t, model.InboxMemberAdded, payload, 1000)
+
+	actions, err := coll.BuildAction(data)
+	require.NoError(t, err)
+	require.Len(t, actions, 1, "bot and pseudo accounts must not be indexed")
+	assert.Equal(t, "alice_r-eng", actions[0].DocID)
+}
+
+func TestSpotlightCollection_BuildAction_AllBots_NoActions(t *testing.T) {
+	coll := newSpotlightCollection("spotlight-site-a-v1-chat", false)
+	payload := baseInboxMemberEvent()
+	payload.Accounts = []string{"weather.bot"}
+	data := makeInboxMemberEvent(t, model.InboxMemberAdded, payload, 1000)
+
+	actions, err := coll.BuildAction(data)
+	require.NoError(t, err, "an all-bot event is a clean no-op, not an error")
+	assert.Empty(t, actions)
+}
+
 func TestSpotlightCollection_BuildAction_MemberRemoved(t *testing.T) {
 	coll := newSpotlightCollection("spotlight-site-a-v1-chat", false)
 	payload := baseInboxMemberEvent()

--- a/search-sync-worker/user_room.go
+++ b/search-sync-worker/user_room.go
@@ -159,6 +159,10 @@ func (c *userRoomCollection) BuildAction(data []byte) ([]searchengine.BulkAction
 		if account == "" {
 			return nil, fmt.Errorf("build user-room action: empty account at index %d", i)
 		}
+		// Bots are channel members but not searchable principals — skip them.
+		if model.IsBot(account) || model.IsPlatformAdminAccount(account) {
+			continue
+		}
 
 		switch evt.Type {
 		case model.InboxMemberAdded:

--- a/search-sync-worker/user_room_test.go
+++ b/search-sync-worker/user_room_test.go
@@ -138,6 +138,29 @@ func TestUserRoomCollection_BuildAction_MemberAdded(t *testing.T) {
 	assert.NotEmpty(t, upsert["createdAt"])
 }
 
+func TestUserRoomCollection_BuildAction_SkipsBots(t *testing.T) {
+	coll := newUserRoomCollection("user-room-site-a")
+	payload := baseInboxMemberEvent()
+	payload.Accounts = []string{"alice", "weather.bot", "p_hook"}
+	data := makeInboxMemberEvent(t, model.InboxMemberAdded, payload, 1000)
+
+	actions, err := coll.BuildAction(data)
+	require.NoError(t, err)
+	require.Len(t, actions, 1, "bot and pseudo accounts must not enter the user-room index")
+	assert.Equal(t, "alice", actions[0].DocID)
+}
+
+func TestUserRoomCollection_BuildAction_AllBots_NoActions(t *testing.T) {
+	coll := newUserRoomCollection("user-room-site-a")
+	payload := baseInboxMemberEvent()
+	payload.Accounts = []string{"weather.bot"}
+	data := makeInboxMemberEvent(t, model.InboxMemberAdded, payload, 1000)
+
+	actions, err := coll.BuildAction(data)
+	require.NoError(t, err, "an all-bot event is a clean no-op, not an error")
+	assert.Empty(t, actions)
+}
+
 func TestUserRoomCollection_BuildAction_MemberAdded_Restricted(t *testing.T) {
 	coll := newUserRoomCollection("user-room-site-a")
 	payload := baseInboxMemberEvent()

--- a/user-service/service/enrich_test.go
+++ b/user-service/service/enrich_test.go
@@ -453,3 +453,35 @@ func TestApplyRoomInfo_ComputesHasGroupMention_CrossSite(t *testing.T) {
 		})
 	}
 }
+
+// Bots are key-holders, so a bot/pseudo principal listing its own subscriptions
+// keeps the room-key material in the enriched bootstrap, exactly like a human.
+func TestEnrichWithRoomInfo_BotRequester_KeepsKeyMaterial(t *testing.T) {
+	secret := make([]byte, roomKeySecretLen)
+	for i := range secret {
+		secret[i] = 0x42
+	}
+	mkSubs := func() []model.EnrichedSubscription {
+		return []model.EnrichedSubscription{{
+			Subscription: model.Subscription{
+				ID: "s1", RoomID: "r1", SiteID: "site-a",
+				RoomType: model.RoomTypeChannel,
+			},
+			RoomName:    "general",
+			RoomKeyPriv: append([]byte(nil), secret...),
+			RoomKeyVer:  3,
+		}}
+	}
+	svc := &UserService{siteID: "site-a"}
+
+	for _, requester := range []string{"p_hook", "weather.bot", "alice"} {
+		t.Run(requester+" keeps the key", func(t *testing.T) {
+			got := svc.enrichWithRoomInfoAndLastMsg(ctx(requester, "site-a"), mkSubs(), false, false)
+			require.Len(t, got, 1)
+			require.NotNil(t, got[0].Room)
+			require.NotNil(t, got[0].Room.PrivateKey, "key material is no longer stripped for bots")
+			assert.NotEmpty(t, *got[0].Room.PrivateKey)
+			require.NotNil(t, got[0].Room.KeyVersion)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Lets a channel owner **add and remove a bot** the same way as a human member, reusing the existing `member.add` / `member.remove` machinery in `room-service` and `room-worker`. A bot is a first-class channel member — subscription, membership events, member counts, removal — with no parallel path.

Bots differ from humans only where a product or correctness reason forces it:
- they can't be promoted to room owner;
- they're excluded from user/people search (bots have their own "add apps" search); and
- they're **not** sent the per-user runtime delivery events (`room.key`, `subscription.update`).

That last point is deliberate and security-relevant: those events publish to the raw `chat.user.{account}.event.…` subject, and a **dotted** bot account (`weather.bot`) can't use that subject safely or functionally — the bot's own client is scoped to the auth-encoded `chat.user.weather_bot.>` (`auth-service` collapses dots to underscores), so it never receives the raw `chat.user.weather.bot.…` subject, and that raw subject **would** be wildcard-readable by a principal scoped to `chat.user.weather.>`. Delivering key/message events to bots correctly needs the encoded delivery lane and is separate follow-up work.

## What changed

**`room-service` (validation &amp; guards)**
- `member.add` admits explicitly-listed bots, validating each (deduped): must be an **enabled** app assistant (`bot_not_available`) and **same-site** (`bot_cross_site`). Channel *creation* still rejects bots (`bot_in_channel`).
- Last-member guard counts **humans only**; `role.update` / owner promotion rejects bots (`bot_cannot_be_owner`).
- `getRoomKey` rejects bot/pseudo requesters (pull-side counterpart of the key exclusion).

**`room-worker`**
- Bot candidates resolve through the normal add/remove flow; a bot counts toward the room's app count (vs user count).
- Bots are excluded from per-user room-key fan-out and rotation (single choke point in `fanOutKey`) and from the `subscription.update` fan-out. A removed bot never held the key, so its removal skips rotation.

**`pkg/pipelines`**
- `MatchCandidatesFilterWithDirectBots` admits directly-invited bots while keeping org-expansion arms bot-free.

**`search-sync-worker`**
- Skips bot/pseudo accounts in user-room and spotlight indexing.

**`user-service`**
- Strips room-key material from a bot's own subscription-list response (pull-side).

## API impact

`docs/client-api.md` and the derived request-reply / events views updated:
- `member.add` validates explicit bots (`bot_not_available` / `bot_cross_site`).
- `member.remove` last-member guard is human-only.
- `role.update` rejects promoting a bot to owner (`bot_cannot_be_owner`).

## Testing

- Unit tests (TDD) across every touched package — bot add/remove happy paths, cross-site + disabled-bot rejection, duplicate-bot validated-once, last-human / owner guards, the direct-bot candidate filter, the search-index skip, and the key/sub exclusion (a bot gets neither `room.key` nor `subscription.update`; a bot removal skips rotation; `getRoomKey` and the subscription-list bootstrap both withhold key material from bots).
- `make lint` clean; `go test -race` green per package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bots can be added to rooms when their assistant is enabled and hosted on the room’s local site.
  * Bots count toward app membership but do not receive subscription updates.
  * Bots receive room-key updates through encoded per-account subjects.
  * Bots cannot be promoted to room owners.
  * Removing bots no longer triggers last-human-member restrictions.

* **Bug Fixes**
  * Improved bot validation, cross-site error reporting, and duplicate handling.
  * Excluded bots from spotlight and user-room search indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->