### PR TITLE
Add GET /api/v1/drive.members endpoint to media-service

### DIFF
--- a/docs/superpowers/specs/2026-07-17-drive-members-endpoint-design.md
+++ b/docs/superpowers/specs/2026-07-17-drive-members-endpoint-design.md
@@ -1,0 +1,220 @@
+# Design: `GET /api/v1/drive.members` (media-service)
+
+Date: 2026-07-17
+Service: `media-service`
+Branch: `claude/drive-members-endpoint-jj7z5p`
+
+## 1. Purpose
+
+Add an HTTP endpoint to `media-service` that, given a room and an account,
+reports whether that account is a member of the room and returns the room's
+name and type. It is a single-account membership probe: the response either
+lists that one account (member) or an empty list (not a member), with a
+hardcoded `count` of 1 or 0.
+
+## 2. Endpoint
+
+```
+GET /api/v1/drive.members?roomId=<roomId>&accountName=<accountName>
+```
+
+- Unauthenticated, consistent with the other `media-service` HTTP routes
+  (registered in `routes.go`).
+- Both query params are required.
+
+### 2.1 Query parameters
+
+| Param | Type | Required | Notes |
+|-------|------|----------|-------|
+| `roomId` | string | yes | Room identifier. |
+| `accountName` | string | yes | Account (login) name to probe. |
+
+## 3. Behavior
+
+1. If `roomId` is missing/blank → error `MISSING_PARAMETER` (400).
+2. If `accountName` is missing/blank → error `MISSING_PARAMETER` (400).
+3. Look up the room by `roomId` (any one of its local subscriptions). If no
+   room exists → error `ROOM_NOT_FOUND` (404). Otherwise capture `roomName`
+   and `roomType`.
+4. Look up the account globally in the `users` collection. If no such user
+   exists → error `ACCOUNT_NOT_FOUND` (404). Otherwise capture the user's
+   `_id`, `account`, display name, and active flag.
+5. Check whether a subscription exists for `(roomId, account)`:
+   - **Member** → `members` = `[{ _id, username, name, active }]`, `count` = 1.
+   - **Not a member** → `members` = `[]`, `count` = 0.
+6. Any store/infra failure during steps 3–5 → error `INTERNAL_ERROR` (500).
+
+"Account not in the room" (step 5, not a member) is a **success** with
+`count: 0`. "Account does not exist at all" (step 4) is an **error**. These are
+distinct: non-membership is judged from `subscriptions`, account existence from
+`users`.
+
+## 4. Responses
+
+### 4.1 Success (`200`)
+
+Wrapper: `{ success, data }`.
+
+```json
+{
+  "success": true,
+  "data": {
+    "members": [
+      { "_id": "u_123", "username": "alice", "name": "Alice Chan", "active": true }
+    ],
+    "count": 1,
+    "roomName": "General",
+    "roomType": "channel"
+  }
+}
+```
+
+Non-member:
+
+```json
+{
+  "success": true,
+  "data": {
+    "members": [],
+    "count": 0,
+    "roomName": "General",
+    "roomType": "channel"
+  }
+}
+```
+
+- `count` is hardcoded (0 or 1) — it is not `len(members)` computed generically;
+  it mirrors the single probed account's membership.
+- `members` is always initialized to an empty slice so it serializes as `[]`,
+  never `null`.
+
+### 4.2 Member object field mapping
+
+| JSON field | Source (`model.User`) |
+|------------|-----------------------|
+| `_id` | `User.ID` |
+| `username` | `User.Account` |
+| `name` | `User.DisplayName()` (documented "for Drive ownership metadata") |
+| `active` | `!User.Deactivated` |
+
+### 4.3 Errors (`4xx` / `5xx`)
+
+Bespoke envelope (NOT the house `errcode`/`errhttp` envelope, because this
+endpoint follows a `{success,...}` contract end-to-end):
+
+```json
+{ "success": false, "error": "roomId is required", "errorType": "ROOM_NOT_FOUND" }
+```
+
+| Condition | HTTP | `errorType` | `error` (example) |
+|-----------|------|-------------|-------------------|
+| `roomId` missing/blank | 400 | `MISSING_PARAMETER` | `roomId is required` |
+| `accountName` missing/blank | 400 | `MISSING_PARAMETER` | `accountName is required` |
+| Room not found | 404 | `ROOM_NOT_FOUND` | `room not found` |
+| Account not found | 404 | `ACCOUNT_NOT_FOUND` | `account not found` |
+| Store/infra failure | 500 | `INTERNAL_ERROR` | `internal error` |
+
+`error` carries a human-readable message; `errorType` is the machine-branchable
+discriminator. Internal error messages never leak infra detail (the store's
+wrapped error is logged server-side, not returned).
+
+## 5. Implementation
+
+### 5.1 New file: `media-service/drive.go`
+
+- `HandleDriveMembers(c *gin.Context)` — the handler above.
+- Response structs (handler-local; this is an HTTP-only payload, not a
+  `pkg/model` NATS type):
+  ```go
+  type driveMember struct {
+      ID       string `json:"_id"`
+      Username string `json:"username"`
+      Name     string `json:"name"`
+      Active   bool   `json:"active"`
+  }
+  type driveMembersData struct {
+      Members  []driveMember  `json:"members"`
+      Count    int            `json:"count"`
+      RoomName string         `json:"roomName"`
+      RoomType model.RoomType `json:"roomType"`
+  }
+  type driveMembersResponse struct {
+      Success bool             `json:"success"`
+      Data    driveMembersData `json:"data"`
+  }
+  type driveErrorResponse struct {
+      Success   bool   `json:"success"`
+      Error     string `json:"error"`
+      ErrorType string `json:"errorType"`
+  }
+  ```
+- A small local helper writes the error envelope:
+  ```go
+  func writeDriveError(c *gin.Context, status int, errorType, msg string)
+  ```
+  Store failures are logged once server-side (`slog.ErrorContext`) with the
+  wrapped error, then returned to the client as the generic `INTERNAL_ERROR`.
+
+### 5.2 Route registration: `media-service/routes.go`
+
+```go
+r.GET("/api/v1/drive.members", h.HandleDriveMembers)
+```
+
+### 5.3 Store changes: `media-service/store.go` (+ `store_mongo.go`)
+
+Reuse the existing `RoomSite(ctx, roomID) (siteID, roomType, name, found, err)`
+for room existence + `roomName` + `roomType` (siteID is ignored here).
+
+Add two methods to the `avatarStore` interface:
+
+```go
+// UserByAccount returns a user's identity fields for the drive.members probe.
+// found=false when no user record exists for account.
+UserByAccount(ctx context.Context, account string) (*model.User, bool, error)
+
+// RoomMember reports whether account has a subscription to roomID.
+RoomMember(ctx context.Context, roomID, account string) (bool, error)
+```
+
+`store_mongo.go` implementations:
+- `UserByAccount` — `users.FindOne({account})` projecting
+  `_id, account, engName, chineseName, deactivated`; `ErrNoDocuments` →
+  `(nil, false, nil)`.
+- `RoomMember` — `subscriptions.FindOne({roomId, "u.account": account})`
+  projecting `_id` only (existence check); `ErrNoDocuments` →
+  `(false, nil)`.
+
+Both follow the existing store conventions (explicit projection, explicit
+`ErrNoDocuments` handling, `fmt.Errorf("...: %w", err)` wrapping).
+
+Regenerate the mock after the interface change: `make generate SERVICE=media-service`.
+
+## 6. Testing (TDD)
+
+New `media-service/drive_test.go`, table-driven, using the existing
+`MockavatarStore` test harness (`newTestRouter`). Cases:
+
+- missing `roomId` → 400 / `MISSING_PARAMETER`
+- missing `accountName` → 400 / `MISSING_PARAMETER`
+- room not found → 404 / `ROOM_NOT_FOUND`
+- account not found → 404 / `ACCOUNT_NOT_FOUND`
+- member → 200, `count: 1`, `members` has one object with correct
+  `_id/username/name/active`, correct `roomName`/`roomType`
+- non-member → 200, `count: 0`, `members: []`
+- `RoomSite` store error → 500 / `INTERNAL_ERROR`
+- `UserByAccount` store error → 500 / `INTERNAL_ERROR`
+- `RoomMember` store error → 500 / `INTERNAL_ERROR`
+- `active` reflects `Deactivated` (deactivated user → `active: false`)
+- `name` falls back to account when name fields are absent (via `DisplayName()`)
+
+Assertions verify the JSON body shape (including `members: []` not `null`) and
+HTTP status. Red → Green → Refactor; commit when green.
+
+## 7. Out of scope / notes
+
+- No `docs/client-api.md` update: that rule covers `chat.user.*` NATS subjects
+  and `auth-service` HTTP routes, not `media-service` HTTP routes.
+- No cross-cluster redirect (unlike the avatar handlers): this is a metadata
+  probe, not a blob fetch.
+- No new dependencies.

--- a/media-service/drive.go
+++ b/media-service/drive.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/hmchangw/chat/pkg/model"
+)
+
+// driveMember is one entry in the drive.members response.
+type driveMember struct {
+	ID       string `json:"_id"`
+	Username string `json:"username"`
+	Name     string `json:"name"`
+	Active   bool   `json:"active"`
+}
+
+type driveMembersData struct {
+	Members  []driveMember  `json:"members"`
+	Count    int            `json:"count"`
+	RoomName string         `json:"roomName"`
+	RoomType model.RoomType `json:"roomType"`
+}
+
+type driveMembersResponse struct {
+	Success bool             `json:"success"`
+	Data    driveMembersData `json:"data"`
+}
+
+type driveErrorResponse struct {
+	Success   bool   `json:"success"`
+	Error     string `json:"error"`
+	ErrorType string `json:"errorType"`
+}
+
+const (
+	errTypeMissingParameter = "MISSING_PARAMETER"
+	errTypeRoomNotFound     = "ROOM_NOT_FOUND"
+	errTypeAccountNotFound  = "ACCOUNT_NOT_FOUND"
+	errTypeInternal         = "INTERNAL_ERROR"
+)
+
+// writeDriveError writes the bespoke {success:false, error, errorType} envelope.
+func writeDriveError(c *gin.Context, status int, errorType, msg string) {
+	c.JSON(status, driveErrorResponse{Success: false, Error: msg, ErrorType: errorType})
+}
+
+// HandleDriveMembers reports whether accountName is a member of roomId, along
+// with the room's name and type. It is a single-account probe: members is
+// either empty (not a member) or the one probed account (member), with count
+// hardcoded to 0 or 1.
+func (h *handler) HandleDriveMembers(c *gin.Context) {
+	ctx := c.Request.Context()
+	roomID := c.Query("roomId")
+	account := c.Query("accountName")
+
+	if roomID == "" {
+		writeDriveError(c, http.StatusBadRequest, errTypeMissingParameter, "roomId is required")
+		return
+	}
+	if account == "" {
+		writeDriveError(c, http.StatusBadRequest, errTypeMissingParameter, "accountName is required")
+		return
+	}
+
+	_, roomType, roomName, found, err := h.store.RoomSite(ctx, roomID)
+	if err != nil {
+		slog.ErrorContext(ctx, "drive.members: room lookup failed", "error", err, "roomId", roomID)
+		writeDriveError(c, http.StatusInternalServerError, errTypeInternal, "internal error")
+		return
+	}
+	if !found {
+		writeDriveError(c, http.StatusNotFound, errTypeRoomNotFound, "room not found")
+		return
+	}
+
+	user, found, err := h.store.UserByAccount(ctx, account)
+	if err != nil {
+		slog.ErrorContext(ctx, "drive.members: user lookup failed", "error", err, "account", account)
+		writeDriveError(c, http.StatusInternalServerError, errTypeInternal, "internal error")
+		return
+	}
+	if !found {
+		writeDriveError(c, http.StatusNotFound, errTypeAccountNotFound, "account not found")
+		return
+	}
+
+	member, err := h.store.RoomMember(ctx, roomID, account)
+	if err != nil {
+		slog.ErrorContext(ctx, "drive.members: membership lookup failed", "error", err, "roomId", roomID, "account", account)
+		writeDriveError(c, http.StatusInternalServerError, errTypeInternal, "internal error")
+		return
+	}
+
+	resp := driveMembersResponse{
+		Success: true,
+		Data: driveMembersData{
+			Members:  []driveMember{},
+			Count:    0,
+			RoomName: roomName,
+			RoomType: roomType,
+		},
+	}
+	if member {
+		resp.Data.Members = []driveMember{{
+			ID:       user.ID,
+			Username: user.Account,
+			Name:     user.DisplayName(),
+			Active:   !user.Deactivated,
+		}}
+		resp.Data.Count = 1
+	}
+	c.JSON(http.StatusOK, resp)
+}

--- a/media-service/drive_test.go
+++ b/media-service/drive_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/hmchangw/chat/pkg/model"
+)
+
+// driveMembersBody mirrors the success envelope for assertions.
+type driveMembersBody struct {
+	Success bool `json:"success"`
+	Data    struct {
+		Members []struct {
+			ID       string `json:"_id"`
+			Username string `json:"username"`
+			Name     string `json:"name"`
+			Active   bool   `json:"active"`
+		} `json:"members"`
+		Count    int    `json:"count"`
+		RoomName string `json:"roomName"`
+		RoomType string `json:"roomType"`
+	} `json:"data"`
+}
+
+// driveErrorBody mirrors the error envelope for assertions.
+type driveErrorBody struct {
+	Success   bool   `json:"success"`
+	Error     string `json:"error"`
+	ErrorType string `json:"errorType"`
+}
+
+func doDriveMembers(t *testing.T, r http.Handler, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/drive.members"+query, nil))
+	return w
+}
+
+func TestHandleDriveMembers_MissingRoomID(t *testing.T) {
+	r, _, _ := newTestRouter(t)
+	w := doDriveMembers(t, r, "?accountName=alice")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	var body driveErrorBody
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.False(t, body.Success)
+	assert.Equal(t, "MISSING_PARAMETER", body.ErrorType)
+	assert.NotEmpty(t, body.Error)
+}
+
+func TestHandleDriveMembers_MissingAccountName(t *testing.T) {
+	r, _, _ := newTestRouter(t)
+	w := doDriveMembers(t, r, "?roomId=room1")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	var body driveErrorBody
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.False(t, body.Success)
+	assert.Equal(t, "MISSING_PARAMETER", body.ErrorType)
+}
+
+func TestHandleDriveMembers_RoomNotFound(t *testing.T) {
+	r, store, _ := newTestRouter(t)
+	store.EXPECT().RoomSite(gomock.Any(), "room1").Return("", model.RoomType(""), "", false, nil)
+	w := doDriveMembers(t, r, "?roomId=room1&accountName=alice")
+	require.Equal(t, http.StatusNotFound, w.Code)
+	var body driveErrorBody
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.False(t, body.Success)
+	assert.Equal(t, "ROOM_NOT_FOUND", body.ErrorType)
+}
+
+func TestHandleDriveMembers_AccountNotFound(t *testing.T) {
+	r, store, _ := newTestRouter(t)
+	store.EXPECT().RoomSite(gomock.Any(), "room1").Return("s1", model.RoomTypeChannel, "General", true, nil)
+	store.EXPECT().UserByAccount(gomock.Any(), "alice").Return(nil, false, nil)
+	w := doDriveMembers(t, r, "?roomId=room1&accountName=alice")
+	require.Equal(t, http.StatusNotFound, w.Code)
+	var body driveErrorBody
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.False(t, body.Success)
+	assert.Equal(t, "ACCOUNT_NOT_FOUND", body.ErrorType)
+}
+
+func TestHandleDriveMembers_Member(t *testing.T) {
+	r, store, _ := newTestRouter(t)
+	store.EXPECT().RoomSite(gomock.Any(), "room1").Return("s1", model.RoomTypeChannel, "General", true, nil)
+	store.EXPECT().UserByAccount(gomock.Any(), "alice").
+		Return(&model.User{ID: "u_1", Account: "alice", EngName: "Alice", ChineseName: "Chan"}, true, nil)
+	store.EXPECT().RoomMember(gomock.Any(), "room1", "alice").Return(true, nil)
+
+	w := doDriveMembers(t, r, "?roomId=room1&accountName=alice")
+	require.Equal(t, http.StatusOK, w.Code)
+	var body driveMembersBody
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.True(t, body.Success)
+	assert.Equal(t, 1, body.Data.Count)
+	assert.Equal(t, "General", body.Data.RoomName)
+	assert.Equal(t, "channel", body.Data.RoomType)
+	require.Len(t, body.Data.Members, 1)
+	assert.Equal(t, "u_1", body.Data.Members[0].ID)
+	assert.Equal(t, "alice", body.Data.Members[0].Username)
+	assert.Equal(t, "Alice Chan", body.Data.Members[0].Name)
+	assert.True(t, body.Data.Members[0].Active)
+}
+
+func TestHandleDriveMembers_NonMember(t *testing.T) {
+	r, store, _ := newTestRouter(t)
+	store.EXPECT().RoomSite(gomock.Any(), "room1").Return("s1", model.RoomTypeChannel, "General", true, nil)
+	store.EXPECT().UserByAccount(gomock.Any(), "bob").
+		Return(&model.User{ID: "u_2", Account: "bob"}, true, nil)
+	store.EXPECT().RoomMember(gomock.Any(), "room1", "bob").Return(false, nil)
+
+	w := doDriveMembers(t, r, "?roomId=room1&accountName=bob")
+	require.Equal(t, http.StatusOK, w.Code)
+	// members must serialize as [] not null.
+	assert.Contains(t, w.Body.String(), `"members":[]`)
+	var body driveMembersBody
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.True(t, body.Success)
+	assert.Equal(t, 0, body.Data.Count)
+	assert.Equal(t, "General", body.Data.RoomName)
+	assert.Equal(t, "channel", body.Data.RoomType)
+	assert.Empty(t, body.Data.Members)
+}
+
+func TestHandleDriveMembers_MemberDeactivated_ActiveFalse(t *testing.T) {
+	r, store, _ := newTestRouter(t)
+	store.EXPECT().RoomSite(gomock.Any(), "room1").Return("s1", model.RoomTypeChannel, "General", true, nil)
+	store.EXPECT().UserByAccount(gomock.Any(), "alice").
+		Return(&model.User{ID: "u_1", Account: "alice", Deactivated: true}, true, nil)
+	store.EXPECT().RoomMember(gomock.Any(), "room1", "alice").Return(true, nil)
+
+	w := doDriveMembers(t, r, "?roomId=room1&accountName=alice")
+	require.Equal(t, http.StatusOK, w.Code)
+	var body driveMembersBody
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Len(t, body.Data.Members, 1)
+	assert.False(t, body.Data.Members[0].Active)
+	// name falls back to account when a name field is missing.
+	assert.Equal(t, "alice", body.Data.Members[0].Name)
+}
+
+func TestHandleDriveMembers_RoomSiteStoreError(t *testing.T) {
+	r, store, _ := newTestRouter(t)
+	store.EXPECT().RoomSite(gomock.Any(), "room1").Return("", model.RoomType(""), "", false, errors.New("mongo down"))
+	w := doDriveMembers(t, r, "?roomId=room1&accountName=alice")
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	var body driveErrorBody
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.False(t, body.Success)
+	assert.Equal(t, "INTERNAL_ERROR", body.ErrorType)
+	// internal detail must not leak to the client.
+	assert.NotContains(t, w.Body.String(), "mongo down")
+}
+
+func TestHandleDriveMembers_UserByAccountStoreError(t *testing.T) {
+	r, store, _ := newTestRouter(t)
+	store.EXPECT().RoomSite(gomock.Any(), "room1").Return("s1", model.RoomTypeChannel, "General", true, nil)
+	store.EXPECT().UserByAccount(gomock.Any(), "alice").Return(nil, false, errors.New("mongo down"))
+	w := doDriveMembers(t, r, "?roomId=room1&accountName=alice")
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	var body driveErrorBody
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "INTERNAL_ERROR", body.ErrorType)
+}
+
+func TestHandleDriveMembers_RoomMemberStoreError(t *testing.T) {
+	r, store, _ := newTestRouter(t)
+	store.EXPECT().RoomSite(gomock.Any(), "room1").Return("s1", model.RoomTypeChannel, "General", true, nil)
+	store.EXPECT().UserByAccount(gomock.Any(), "alice").
+		Return(&model.User{ID: "u_1", Account: "alice"}, true, nil)
+	store.EXPECT().RoomMember(gomock.Any(), "room1", "alice").Return(false, errors.New("mongo down"))
+	w := doDriveMembers(t, r, "?roomId=room1&accountName=alice")
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	var body driveErrorBody
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "INTERNAL_ERROR", body.ErrorType)
+}

--- a/media-service/mock_store_test.go
+++ b/media-service/mock_store_test.go
@@ -89,6 +89,21 @@ func (mr *MockavatarStoreMockRecorder) EmployeeID(ctx, account any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EmployeeID", reflect.TypeOf((*MockavatarStore)(nil).EmployeeID), ctx, account)
 }
 
+// RoomMember mocks base method.
+func (m *MockavatarStore) RoomMember(ctx context.Context, roomID, account string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RoomMember", ctx, roomID, account)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RoomMember indicates an expected call of RoomMember.
+func (mr *MockavatarStoreMockRecorder) RoomMember(ctx, roomID, account any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RoomMember", reflect.TypeOf((*MockavatarStore)(nil).RoomMember), ctx, roomID, account)
+}
+
 // RoomSite mocks base method.
 func (m *MockavatarStore) RoomSite(ctx context.Context, roomID string) (string, model.RoomType, string, bool, error) {
 	m.ctrl.T.Helper()
@@ -119,6 +134,22 @@ func (m *MockavatarStore) SetBotAvatar(ctx context.Context, av *model.Avatar) er
 func (mr *MockavatarStoreMockRecorder) SetBotAvatar(ctx, av any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBotAvatar", reflect.TypeOf((*MockavatarStore)(nil).SetBotAvatar), ctx, av)
+}
+
+// UserByAccount mocks base method.
+func (m *MockavatarStore) UserByAccount(ctx context.Context, account string) (*model.User, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UserByAccount", ctx, account)
+	ret0, _ := ret[0].(*model.User)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// UserByAccount indicates an expected call of UserByAccount.
+func (mr *MockavatarStoreMockRecorder) UserByAccount(ctx, account any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserByAccount", reflect.TypeOf((*MockavatarStore)(nil).UserByAccount), ctx, account)
 }
 
 // MockemojiStore is a mock of emojiStore interface.

--- a/media-service/routes.go
+++ b/media-service/routes.go
@@ -7,6 +7,7 @@ func registerRoutes(r *gin.Engine, h *handler) {
 	r.GET("/api/v1/avatar/room/:roomID", h.HandleRoomAvatar)
 	r.GET("/api/v1/avatar/:accountName", h.HandleAccountAvatar)
 	r.PUT("/api/v1/avatar/bot/:botName", h.HandleBotUpload) // no auth (§7a.4)
+	r.GET("/api/v1/drive.members", h.HandleDriveMembers)
 	r.GET("/api/v1/emoji/:shortcode", h.HandleEmojiGet)
 	r.PUT("/api/v1/emoji/:shortcode", h.HandleEmojiUpload) // no auth; ?uploader= is audit-only
 }

--- a/media-service/store.go
+++ b/media-service/store.go
@@ -20,6 +20,12 @@ type avatarStore interface {
 	// RoomSite returns the room's owning site, type, and name from any one of its
 	// local subscriptions. found=false when no local subscription exists.
 	RoomSite(ctx context.Context, roomID string) (siteID string, roomType model.RoomType, name string, found bool, err error)
+	// UserByAccount returns a user's identity fields (id, account, names,
+	// deactivated) for the drive.members probe. found=false when no user record
+	// exists for account.
+	UserByAccount(ctx context.Context, account string) (*model.User, bool, error)
+	// RoomMember reports whether account holds a subscription to roomID.
+	RoomMember(ctx context.Context, roomID, account string) (bool, error)
 	// Avatar looks up a custom-image doc by subject. found=false → serve default.
 	Avatar(ctx context.Context, subjectType model.AvatarSubjectType, subjectID string) (*model.Avatar, bool, error)
 	// SetBotAvatar upserts a bot's avatars doc (by _id).

--- a/media-service/store_mongo.go
+++ b/media-service/store_mongo.go
@@ -77,6 +77,31 @@ func (s *mongoStore) RoomSite(ctx context.Context, roomID string) (string, model
 	return sub.SiteID, sub.RoomType, sub.Name, true, nil
 }
 
+func (s *mongoStore) UserByAccount(ctx context.Context, account string) (*model.User, bool, error) {
+	var u model.User
+	err := s.users.FindOne(ctx, bson.M{"account": account},
+		options.FindOne().SetProjection(bson.M{"_id": 1, "account": 1, "engName": 1, "chineseName": 1, "deactivated": 1})).Decode(&u)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("find user by account: %w", err)
+	}
+	return &u, true, nil
+}
+
+func (s *mongoStore) RoomMember(ctx context.Context, roomID, account string) (bool, error) {
+	err := s.subscriptions.FindOne(ctx, bson.M{"roomId": roomID, "u.account": account},
+		options.FindOne().SetProjection(bson.M{"_id": 1})).Err()
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("find room member: %w", err)
+	}
+	return true, nil
+}
+
 func (s *mongoStore) Avatar(ctx context.Context, subjectType model.AvatarSubjectType, subjectID string) (*model.Avatar, bool, error) {
 	id := string(subjectType) + ":" + subjectID
 	var av model.Avatar


### PR DESCRIPTION
## Summary

Add a new HTTP endpoint `GET /api/v1/drive.members` to `media-service` that probes whether a given account is a member of a room, returning the room's metadata and membership status.

## Changes

- **New handler** (`media-service/drive.go`): `HandleDriveMembers` implements the single-account membership probe. Returns `{success, data}` on success with `members` (empty or one-element array), `count` (0 or 1), `roomName`, and `roomType`. Returns `{success: false, error, errorType}` on validation/lookup failures.

- **Store interface extensions** (`media-service/store.go`):
  - `UserByAccount(ctx, account)` — looks up a user by account name, returning identity fields (`_id`, `account`, display name, deactivated flag) or `(nil, false, nil)` if not found
  - `RoomMember(ctx, roomID, account)` — checks subscription existence for a room/account pair

- **MongoDB implementations** (`media-service/store_mongo.go`):
  - `UserByAccount` — queries `users` collection with explicit projection, handles `ErrNoDocuments`
  - `RoomMember` — queries `subscriptions` collection for `(roomId, u.account)` match

- **Route registration** (`media-service/routes.go`): Register `GET /api/v1/drive.members` as unauthenticated

- **Mock regeneration** (`media-service/mock_store_test.go`): Updated to include the two new store methods

- **Comprehensive test suite** (`media-service/drive_test.go`): Table-driven tests covering:
  - Missing/blank query parameters → 400 `MISSING_PARAMETER`
  - Room not found → 404 `ROOM_NOT_FOUND`
  - Account not found → 404 `ACCOUNT_NOT_FOUND`
  - Member case → 200, `count: 1`, one-element `members` array
  - Non-member case → 200, `count: 0`, empty `members` array
  - Deactivated user → `active: false`
  - Display name fallback to account when name fields absent
  - Store errors → 500 `INTERNAL_ERROR` (no detail leakage)

- **Design documentation** (`docs/superpowers/specs/2026-07-17-drive-members-endpoint-design.md`): Full specification including purpose, endpoint contract, behavior, response envelopes, implementation notes, and test cases.

## Implementation Details

- **Error envelope**: Bespoke `{success, error, errorType}` structure (not the house `errcode`/`errhttp` envelope) to maintain consistency with the endpoint's `{success, data}` contract end-to-end
- **Members serialization**: Always initialized to empty slice so JSON serializes as `[]`, never `null`
- **Membership vs. existence**: Non-membership (account exists but has no subscription) is a 200 success with `count: 0`; account non-existence is a 404 error
- **Store failures**: Logged server-side with full error context; client receives generic `INTERNAL_ERROR` message
- **User display name**: Uses `User.DisplayName()` which falls back to account when name fields are absent
- **Active flag**: Inverted from `User.Deactivated` field

https://claude.ai/code/session_01ENP3kQvfbJb1JbibBasfqo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `GET /api/v1/drive.members` endpoint to check whether an account belongs to a room.
  - Returns room details, membership status, member information, and clear success or error responses.
  - Handles missing parameters, unavailable rooms or accounts, and internal failures with appropriate status codes.

- **Documentation**
  - Added a design specification covering endpoint behavior, response formats, validation, and test scenarios.

- **Tests**
  - Added coverage for validation, membership outcomes, deactivated accounts, not-found cases, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->