### PR TITLE
feat(msgraph): send User-Agent on app-only Graph requests

### DIFF
--- a/docs/superpowers/plans/2026-07-20-msgraph-app-only-user-agent.md
+++ b/docs/superpowers/plans/2026-07-20-msgraph-app-only-user-agent.md
@@ -1,0 +1,308 @@
+# App-only Graph client User-Agent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every request the shared app-only `msgraph` client sends carry a configurable `User-Agent` header (browser-string default), so room-service Teams meeting calls can pass a fronting proxy/WAF like the presence client already does.
+
+**Architecture:** Add a resolved `userAgent` field to `graphClient` (from `Config.UserAgent`, falling back to the shared `defaultUserAgent`), and set the header explicitly at all four request sites — mirroring the existing `presence.go` pattern (Approach A). Wire a `GRAPH_USER_AGENT` env var through room-service into `msgraph.Config.UserAgent`.
+
+**Tech Stack:** Go 1.25, `net/http`, `net/http/httptest` (tests), `caarlos0/env` (config), testify.
+
+Spec: `docs/superpowers/specs/2026-07-20-msgraph-app-only-user-agent-design.md`
+
+## Global Constraints
+
+- Go 1.25; single root `go.mod`. No new third-party dependencies.
+- Always use `make` targets, never raw `go`. Unit tests: `make test SERVICE=<name>` runs with `-race`.
+- TDD Red-Green-Refactor is mandatory: failing test first, confirm it fails, then minimal implementation.
+- Minimum 80% package coverage; target 90%+ for `pkg/` code.
+- Never log tokens/secrets. Config from env via `caarlos0/env` only — no `os.Getenv`. Use `envDefault` for non-critical config.
+- Follow existing patterns; keep changes minimal and focused.
+- No `docs/client-api.md` change — this is an outbound HTTP header to Microsoft Graph, not a `chat.user.` RPC schema change.
+- Commit author/committer identity must be `Claude <noreply@anthropic.com>` (`git config user.email noreply@anthropic.com && git config user.name Claude`).
+
+---
+
+## File Structure
+
+- `pkg/msgraph/msgraph.go` — app-only `graphClient`: new `userAgent` field, resolution in `New`, header set at four sites, `defaultUserAgent` constant moved here, `Config.UserAgent` doc updated.
+- `pkg/msgraph/presence.go` — remove the `defaultUserAgent` constant declaration (now defined in `msgraph.go`, same package); no other change.
+- `pkg/msgraph/msgraph_test.go` — new User-Agent assertions (default, override, directory, list-users).
+- `room-service/main.go` — new `GraphUserAgent` config field + wiring into `msgraph.New`.
+
+---
+
+## Task 1: App-only Graph client sends a User-Agent header
+
+**Files:**
+- Modify: `pkg/msgraph/msgraph.go` (struct field, `New`, four request sites, moved constant, `Config.UserAgent` doc)
+- Modify: `pkg/msgraph/presence.go` (remove moved `defaultUserAgent` constant)
+- Test: `pkg/msgraph/msgraph_test.go`
+
+**Interfaces:**
+- Consumes: existing `Config.UserAgent string` field; existing package-level `defaultUserAgent` string constant (relocated, value unchanged); existing `New(cfg Config, opts ...Option) Client`, `NewDirectoryClient`, `NewUserListerClient`; test helpers `newTestClient(tokenURL, baseURL)`, `newTestDirectory(tokenURL, baseURL)`.
+- Produces: after `New`, the returned `*graphClient` has a non-empty `userAgent`; all outbound requests (token, `CreateOnlineMeeting`, `ResolveAccountIDs`, `ListUsers`) send `User-Agent: <resolved>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these four tests to `pkg/msgraph/msgraph_test.go`:
+
+```go
+func TestCreateOnlineMeeting_SendsDefaultUserAgent(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, defaultUserAgent, r.Header.Get("User-Agent"), "token request must carry User-Agent")
+		_ = json.NewEncoder(w).Encode(tokenResponse{AccessToken: "tok", ExpiresIn: 3600}) // #nosec G117 -- test mock OAuth token
+	}))
+	defer tokenSrv.Close()
+
+	graphSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, defaultUserAgent, r.Header.Get("User-Agent"), "meeting request must carry User-Agent")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(OnlineMeeting{ID: "m1", JoinURL: "https://join/1"})
+	}))
+	defer graphSrv.Close()
+
+	c := newTestClient(tokenSrv.URL, graphSrv.URL)
+	_, err := c.CreateOnlineMeeting(context.Background(), CreateOnlineMeetingRequest{
+		ExternalID:     "room-key-1",
+		Subject:        "Standup",
+		OrganizerEmail: "alice@corp.com",
+	})
+	require.NoError(t, err)
+}
+
+func TestCreateOnlineMeeting_UserAgentOverride(t *testing.T) {
+	const custom = "chat-room-service/9.9"
+	graphSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, custom, r.Header.Get("User-Agent"))
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(OnlineMeeting{ID: "m1", JoinURL: "https://join/1"})
+	}))
+	defer graphSrv.Close()
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, custom, r.Header.Get("User-Agent"))
+		_ = json.NewEncoder(w).Encode(tokenResponse{AccessToken: "tok", ExpiresIn: 3600}) // #nosec G117 -- test mock OAuth token
+	}))
+	defer tokenSrv.Close()
+
+	c := New(
+		Config{TenantID: "t", ClientID: "c", ClientSecret: "s", UserAgent: custom},
+		WithTokenURL(tokenSrv.URL), WithBaseURL(graphSrv.URL),
+	)
+	_, err := c.CreateOnlineMeeting(context.Background(), CreateOnlineMeetingRequest{
+		ExternalID: "room-key-1", OrganizerEmail: "alice@corp.com",
+	})
+	require.NoError(t, err)
+}
+
+func TestResolveAccountIDs_SendsUserAgent(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, defaultUserAgent, r.Header.Get("User-Agent"))
+		_ = json.NewEncoder(w).Encode(tokenResponse{AccessToken: "tok", ExpiresIn: 3600}) // #nosec G117 -- test mock OAuth token
+	}))
+	defer tokenSrv.Close()
+	graphSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, defaultUserAgent, r.Header.Get("User-Agent"), "directory request must carry User-Agent")
+		_ = json.NewEncoder(w).Encode(map[string]any{"value": []GraphUser{
+			{ID: "ida", UserPrincipalName: "alice@corp.com"},
+		}})
+	}))
+	defer graphSrv.Close()
+
+	c := newTestDirectory(tokenSrv.URL, graphSrv.URL)
+	_, err := c.ResolveAccountIDs(context.Background(), []string{"alice"})
+	require.NoError(t, err)
+}
+
+func TestListUsers_SendsUserAgent(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"tok","expires_in":3600}`))
+	}))
+	defer tokenSrv.Close()
+	graphSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, defaultUserAgent, r.Header.Get("User-Agent"), "list-users request must carry User-Agent")
+		_, _ = w.Write([]byte(`{"value":[{"id":"u1","userPrincipalName":"alice@corp.example"}]}`))
+	}))
+	defer graphSrv.Close()
+
+	lister := NewUserListerClient(
+		Config{TenantID: "t", ClientID: "c", ClientSecret: "s"},
+		WithBaseURL(graphSrv.URL), WithTokenURL(tokenSrv.URL),
+	)
+	err := lister.ListUsers(context.Background(), 500, func([]GraphUser) error { return nil })
+	require.NoError(t, err)
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `make test SERVICE=msgraph`
+Expected: FAIL — the four new tests fail their `User-Agent` assertions (empty string ≠ `defaultUserAgent`/custom), because the app-only client sends no explicit `User-Agent`. Existing tests still pass.
+
+- [ ] **Step 3: Move `defaultUserAgent` into `msgraph.go`**
+
+In `pkg/msgraph/presence.go`, delete the constant declaration (lines ~38–44):
+
+```go
+// defaultUserAgent is sent on presence requests when Config.UserAgent is empty.
+// Microsoft Graph rejects requests without a User-Agent header, and a fronting
+// corporate proxy/WAF commonly rejects non-browser agents; a desktop-browser
+// string is the value most likely to pass both. Override per-environment via
+// Config.UserAgent (GRAPH_USER_AGENT) since a pinned browser version ages.
+const defaultUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+	"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36"
+```
+
+In `pkg/msgraph/msgraph.go`, add it to the existing `const (...)` block (the one holding `defaultGraphBaseURL`, `graphScope`, `tokenExpirySkew` at lines ~122–128) with a generalized comment:
+
+```go
+	// defaultUserAgent is sent on every app-only and presence Graph request when
+	// Config.UserAgent is empty. Microsoft Graph rejects requests without a
+	// User-Agent header, and a fronting corporate proxy/WAF commonly rejects
+	// non-browser agents; a desktop-browser string is the value most likely to
+	// pass both. Override per-environment via Config.UserAgent (GRAPH_USER_AGENT)
+	// since a pinned browser version ages.
+	defaultUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+		"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36"
+```
+
+- [ ] **Step 4: Add the `userAgent` field and resolve it in `New`**
+
+In `pkg/msgraph/msgraph.go`, add a field to the `graphClient` struct (after `chatsPageSize int`, before the `mu sync.Mutex` block):
+
+```go
+	// userAgent is the resolved User-Agent header sent on every request
+	// (Config.UserAgent, or defaultUserAgent when empty).
+	userAgent string
+```
+
+In `New`, after the `g := &graphClient{...}` literal and before the `for _, opt := range opts` loop, resolve it (`UserAgent` is not an `Option`, so there is no ordering constraint against `opts`):
+
+```go
+	ua := cfg.UserAgent
+	if ua == "" {
+		ua = defaultUserAgent
+	}
+	g.userAgent = ua
+```
+
+- [ ] **Step 5: Set the header at all four request sites**
+
+In `pkg/msgraph/msgraph.go`, add `req.Header.Set("User-Agent", g.userAgent)` (use the local request variable's actual name) alongside the existing header sets:
+
+1. `accessToken` — after `req.Header.Set("Content-Type", "application/x-www-form-urlencoded")`:
+```go
+	req.Header.Set("User-Agent", g.userAgent)
+```
+2. `CreateOnlineMeeting` — the request var is `httpReq`; after `httpReq.Header.Set("Content-Type", "application/json")`:
+```go
+	httpReq.Header.Set("User-Agent", g.userAgent)
+```
+3. `resolveChunk` — after `req.Header.Set("ConsistencyLevel", "eventual")`:
+```go
+	req.Header.Set("User-Agent", g.userAgent)
+```
+4. `fetchUsersPage` — after `req.Header.Set("Authorization", "Bearer "+token)`:
+```go
+	req.Header.Set("User-Agent", g.userAgent)
+```
+
+- [ ] **Step 6: Update the `Config.UserAgent` doc comment**
+
+In `pkg/msgraph/msgraph.go`, replace the `UserAgent` field's doc comment (currently "Honored only by the presence client...") so it reflects both clients. `ProxyURL`'s doc is unchanged (still presence-only):
+
+```go
+	// UserAgent overrides the User-Agent header sent on every Graph request. When
+	// empty the client falls back to defaultUserAgent (a browser string). Honored
+	// by both the app-only client (New) and the presence client
+	// (NewPresenceClient). Set this to whatever a fronting proxy/WAF expects when
+	// the default is rejected.
+	UserAgent string
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `make test SERVICE=msgraph`
+Expected: PASS — the four new tests pass and all pre-existing `msgraph` tests (including `presence_test.go`, which still references `defaultUserAgent`) still pass.
+
+- [ ] **Step 8: Lint**
+
+Run: `make lint`
+Expected: no new findings in `pkg/msgraph`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add pkg/msgraph/msgraph.go pkg/msgraph/presence.go pkg/msgraph/msgraph_test.go
+git commit -m "feat(msgraph): send User-Agent on app-only Graph requests"
+```
+
+---
+
+## Task 2: Wire `GRAPH_USER_AGENT` through room-service
+
+**Files:**
+- Modify: `room-service/main.go` (config field + `msgraph.New` wiring)
+
+**Interfaces:**
+- Consumes: `msgraph.Config.UserAgent` (from Task 1); existing `msgraph.New(msgraph.Config{...})` call block in `main.go` (lines ~152–157); existing `Config` struct with the `Teams*` fields (lines ~48–54).
+- Produces: `GRAPH_USER_AGENT` env var populates `cfg.GraphUserAgent`, passed to the Graph client so room-service's meeting requests use it (empty → browser default).
+
+- [ ] **Step 1: Add the config field**
+
+In `room-service/main.go`, add to the `Config` struct immediately after `TeamsTLSInsecure` (line ~54):
+
+```go
+	// GraphUserAgent overrides the User-Agent header on Graph requests (meetings
+	// path). Empty falls back to the msgraph browser default. Named GRAPH_USER_AGENT
+	// for consistency with user-presence-service.
+	GraphUserAgent string `env:"GRAPH_USER_AGENT" envDefault:""`
+```
+
+- [ ] **Step 2: Wire it into the Graph client**
+
+In `room-service/main.go`, add the field to the existing `msgraph.New(msgraph.Config{...})` literal (after `TLSInsecureSkipVerify: cfg.TeamsTLSInsecure,`, line ~156):
+
+```go
+			UserAgent: cfg.GraphUserAgent,
+```
+
+- [ ] **Step 3: Verify the service builds**
+
+Run: `make build SERVICE=room-service`
+Expected: builds cleanly (no compile errors).
+
+- [ ] **Step 4: Run room-service unit tests**
+
+Run: `make test SERVICE=room-service`
+Expected: PASS — existing tests unaffected (config field is a struct-tag/env pass-through; no new unit test needed, consistent with other `Config` fields).
+
+- [ ] **Step 5: Lint**
+
+Run: `make lint`
+Expected: no new findings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add room-service/main.go
+git commit -m "feat(room-service): wire GRAPH_USER_AGENT into Graph client"
+```
+
+---
+
+## Final verification
+
+- [ ] Run `make test SERVICE=msgraph` and `make test SERVICE=room-service` — both green.
+- [ ] Run `make lint` — clean.
+- [ ] Confirm `git grep -n "req.Header.Set(\"User-Agent\""` (and `httpReq.Header.Set`) shows the header at all four `msgraph.go` sites plus the two `presence.go` sites.
+- [ ] Push: `git push -u origin claude/session-oajhpp`.
+
+## Spec coverage check
+
+- Whole-app-only scope → Task 1 Step 5 (four sites) + tests covering token, meeting, directory, list-users.
+- Browser-string default reused + moved constant → Task 1 Steps 3–4.
+- `GRAPH_USER_AGENT` env var → Task 2 Steps 1–2.
+- Approach A (explicit per-site set) → Task 1 Step 5.
+- Doc updates (`Config.UserAgent`, moved constant comment) → Task 1 Steps 3, 6.
+- Non-goals honored: no `ProxyURL` for app-only client; no `docs/client-api.md` change.

--- a/docs/superpowers/specs/2026-07-20-msgraph-app-only-user-agent-design.md
+++ b/docs/superpowers/specs/2026-07-20-msgraph-app-only-user-agent-design.md
@@ -1,0 +1,121 @@
+# Design: User-Agent header on the app-only Microsoft Graph client
+
+**Date:** 2026-07-20
+**Status:** Approved (pending implementation)
+**Area:** `pkg/msgraph`, `room-service`
+
+## Problem
+
+The shared app-only Microsoft Graph client in `pkg/msgraph/msgraph.go` (constructed
+by `msgraph.New`) sets no explicit `User-Agent` header on any of its outbound
+requests. It relies on Go's `net/http` default, `Go-http-client/1.1`.
+
+room-service's Teams meeting RPC (`teamsMeeting` in `room-service/handler_teams.go`)
+calls `graphClient.CreateOnlineMeeting`, so its Graph traffic goes out with that
+default agent. In deployments where Microsoft Graph is fronted by a corporate
+proxy/WAF that rejects non-browser agents, those requests can be blocked.
+
+The presence client (`pkg/msgraph/presence.go`, an ROPC-grant client) already
+solves this: it sends a configurable `User-Agent`, defaulting to a desktop-browser
+string (`defaultUserAgent`), because it is expected to sit behind such a proxy/WAF.
+The app-only client should get the same capability so the room-service Teams path
+(and the other app-only surfaces) can pass the same fronting infrastructure.
+
+## Goal
+
+Every request the app-only `graphClient` makes carries a `User-Agent` header that:
+
+- Is overridable per-environment via existing `Config.UserAgent`.
+- Falls back to the shared browser-string `defaultUserAgent` when the override is empty.
+
+## Non-goals
+
+- No `ProxyURL` support for the app-only client — `Config.ProxyURL` remains honored
+  only by the presence client (`NewPresenceClient`).
+- No change to the `teamsMeeting` NATS RPC request/response contract. This is an
+  outbound HTTP header to Microsoft Graph, not a client-facing (`chat.user.`)
+  schema change, so **`docs/client-api.md` is not touched**.
+- No new default behavior when Graph is reached directly: the browser string is a
+  value Graph already accepts, so direct-to-Graph deployments are unaffected.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Scope | Whole app-only client | The header is set on every `graphClient` request (token fetch, `CreateOnlineMeeting`, `ResolveAccountIDs`, `ListUsers`), not just the meeting call, so all consumers benefit and there is one consistent code path. |
+| Default value | Reuse browser `defaultUserAgent` | Matches presence behavior; the browser string is the value most likely to pass both Graph and a fronting proxy/WAF. |
+| Env var name | `GRAPH_USER_AGENT` | Cross-service consistency with `user-presence-service` (which already uses `GRAPH_USER_AGENT`), even though room-service otherwise uses the `TEAMS_` prefix. |
+| Injection style | Explicit `req.Header.Set` per request site (Approach A) | Mirrors the existing `presence.go` pattern (resolved `userAgent` field + explicit set); lowest risk; CLAUDE.md requires following existing patterns. Rejected: a `RoundTripper` wrapper (composes awkwardly with the existing `TLSInsecureSkipVerify` transport cloning) and a shared `newRequest` helper (broader refactor than needed). |
+
+## Changes
+
+### 1. `pkg/msgraph/msgraph.go` — the client
+
+- Add a `userAgent string` field to the `graphClient` struct.
+- In `New`, resolve it once, mirroring `NewPresenceClient`:
+  ```go
+  ua := cfg.UserAgent
+  if ua == "" {
+      ua = defaultUserAgent
+  }
+  g.userAgent = ua
+  ```
+  `UserAgent` is not an `Option`, so the value depends only on `cfg`; resolve it
+  when `g` is constructed (before returning), no ordering constraint against the
+  `opts` loop.
+- Add `req.Header.Set("User-Agent", g.userAgent)` at all four request sites:
+  - `accessToken` — token fetch to `login.microsoftonline.com`.
+  - `CreateOnlineMeeting` — the room-service Teams meeting path.
+  - `resolveChunk` — backs `ResolveAccountIDs`.
+  - `fetchUsersPage` — backs `ListUsers`.
+- Move the `defaultUserAgent` constant from `presence.go` into `msgraph.go` and
+  generalize its doc comment (it is no longer presence-specific; both clients use
+  it). `presence.go` keeps referencing `defaultUserAgent` unchanged — same package.
+- Update the `Config.UserAgent` doc comment: it is now honored by both the app-only
+  client (`New`) and the presence client (`NewPresenceClient`). `Config.ProxyURL`
+  documentation stays presence-only.
+
+### 2. `room-service/main.go` — wiring
+
+- Add a config field near the `Teams*` fields:
+  ```go
+  GraphUserAgent string `env:"GRAPH_USER_AGENT" envDefault:""`
+  ```
+- Pass it through in the existing `msgraph.New(msgraph.Config{...})` block:
+  ```go
+  UserAgent: cfg.GraphUserAgent,
+  ```
+
+### 3. Tests — TDD, Red first
+
+Per CLAUDE.md, write failing tests before implementation. Add to
+`pkg/msgraph/msgraph_test.go`, using the existing `httptest.Server` +
+`WithBaseURL`/`WithTokenURL` pattern and asserting `r.Header.Get("User-Agent")`:
+
+- `CreateOnlineMeeting` sends `defaultUserAgent` when `Config.UserAgent` is empty.
+- `CreateOnlineMeeting` sends the custom value when `Config.UserAgent` is set.
+- The OAuth token request carries the `User-Agent` header.
+- A directory (`ResolveAccountIDs`) or list-users (`ListUsers`) test asserts the
+  header, covering `resolveChunk` / `fetchUsersPage`.
+
+These mirror the existing presence UA tests in `presence_test.go`
+(`TestGetPresencesByUserId_*`, including the default and override cases).
+
+room-service needs no new unit test for the wiring itself (a struct-tag/env pass-
+through), consistent with how other `Config` fields are treated.
+
+## Risks
+
+Minimal. The only behavioral change is the outbound `User-Agent` value flipping
+from `Go-http-client/1.1` to the browser string (or a configured override).
+Microsoft Graph accepts both, so no regression for direct-to-Graph deployments;
+proxy/WAF-fronted deployments gain the ability to pass. The change is one struct
+field, one resolution block, four one-line header sets, one config field, and one
+wiring line, plus tests.
+
+## Affected files
+
+- `pkg/msgraph/msgraph.go` (client + moved constant + doc comments)
+- `pkg/msgraph/presence.go` (remove the moved `defaultUserAgent` constant)
+- `pkg/msgraph/msgraph_test.go` (new UA assertions)
+- `room-service/main.go` (config field + wiring)

--- a/pkg/msgraph/msgraph.go
+++ b/pkg/msgraph/msgraph.go
@@ -112,10 +112,11 @@ type Config struct {
 	// presence client (NewPresenceClient); the app-only and directory clients
 	// ignore it. Must include a scheme and host (e.g. "http://proxy.corp:8080").
 	ProxyURL string
-	// UserAgent overrides the User-Agent header sent on presence requests. When
-	// empty the presence client falls back to defaultUserAgent. Honored only by
-	// the presence client (NewPresenceClient). Set this to whatever a fronting
-	// proxy/WAF expects (e.g. a browser string) when the default is rejected.
+	// UserAgent overrides the User-Agent header sent on every Graph request. When
+	// empty the client falls back to defaultUserAgent (a browser string). Honored
+	// by both the app-only client (New) and the presence client
+	// (NewPresenceClient). Set this to whatever a fronting proxy/WAF expects when
+	// the default is rejected.
 	UserAgent string
 }
 
@@ -125,6 +126,14 @@ const (
 	// tokenExpirySkew is subtracted from the token's reported lifetime so the
 	// cached token is refreshed before the server-side expiry.
 	tokenExpirySkew = 60 * time.Second
+	// defaultUserAgent is sent on every app-only and presence Graph request when
+	// Config.UserAgent is empty. Microsoft Graph rejects requests without a
+	// User-Agent header, and a fronting corporate proxy/WAF commonly rejects
+	// non-browser agents; a desktop-browser string is the value most likely to
+	// pass both. Override per-environment via Config.UserAgent (GRAPH_USER_AGENT)
+	// since a pinned browser version ages.
+	defaultUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+		"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36"
 )
 
 // graphClient is the live (*Client) implementation.
@@ -136,6 +145,9 @@ type graphClient struct {
 	// chatsPageSize is the $top for ListUserChats first-page requests;
 	// <= 0 means defaultChatsPageSize. Set via WithChatsPageSize.
 	chatsPageSize int
+	// userAgent is the resolved User-Agent header sent on every request
+	// (Config.UserAgent, or defaultUserAgent when empty).
+	userAgent string
 
 	mu      sync.Mutex
 	token   string
@@ -190,6 +202,11 @@ func New(cfg Config, opts ...Option) Client {
 			url.PathEscape(cfg.TenantID),
 		),
 	}
+	ua := cfg.UserAgent
+	if ua == "" {
+		ua = defaultUserAgent
+	}
+	g.userAgent = ua
 	for _, opt := range opts {
 		opt(g)
 	}
@@ -224,6 +241,7 @@ func (g *graphClient) accessToken(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("build token request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", g.userAgent)
 
 	resp, err := g.httpClient.Do(req)
 	if err != nil {
@@ -338,6 +356,7 @@ func (g *graphClient) resolveChunk(ctx context.Context, token string, chunk []st
 	// startsWith on userPrincipalName is served as an advanced query — request
 	// eventual consistency so Graph accepts it regardless of tenant defaults.
 	req.Header.Set("ConsistencyLevel", "eventual")
+	req.Header.Set("User-Agent", g.userAgent)
 	resp, err := g.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("get users: %w", err)
@@ -433,6 +452,7 @@ func (g *graphClient) CreateOnlineMeeting(ctx context.Context, req CreateOnlineM
 	}
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("User-Agent", g.userAgent)
 
 	resp, err := g.httpClient.Do(httpReq)
 	if err != nil {
@@ -522,6 +542,7 @@ func (g *graphClient) fetchUsersPage(ctx context.Context, token, endpoint string
 		return nil, fmt.Errorf("build list-users request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("User-Agent", g.userAgent)
 	resp, err := g.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("list users: %w", err)

--- a/pkg/msgraph/msgraph_test.go
+++ b/pkg/msgraph/msgraph_test.go
@@ -440,3 +440,88 @@ func TestListUsers_RejectsCrossOriginNextLink(t *testing.T) {
 	assert.False(t, attackerHit, "must not forward the bearer token to a foreign origin")
 	assert.Len(t, pages, 1, "first (valid) page is still delivered before the walk aborts")
 }
+
+func TestCreateOnlineMeeting_SendsDefaultUserAgent(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, defaultUserAgent, r.Header.Get("User-Agent"), "token request must carry User-Agent")
+		_ = json.NewEncoder(w).Encode(tokenResponse{AccessToken: "tok", ExpiresIn: 3600}) // #nosec G117 -- test mock OAuth token
+	}))
+	defer tokenSrv.Close()
+
+	graphSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, defaultUserAgent, r.Header.Get("User-Agent"), "meeting request must carry User-Agent")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(OnlineMeeting{ID: "m1", JoinURL: "https://join/1"})
+	}))
+	defer graphSrv.Close()
+
+	c := newTestClient(tokenSrv.URL, graphSrv.URL)
+	_, err := c.CreateOnlineMeeting(context.Background(), CreateOnlineMeetingRequest{
+		ExternalID:     "room-key-1",
+		Subject:        "Standup",
+		OrganizerEmail: "alice@corp.com",
+	})
+	require.NoError(t, err)
+}
+
+func TestCreateOnlineMeeting_UserAgentOverride(t *testing.T) {
+	const custom = "chat-room-service/9.9"
+	graphSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, custom, r.Header.Get("User-Agent"))
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(OnlineMeeting{ID: "m1", JoinURL: "https://join/1"})
+	}))
+	defer graphSrv.Close()
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, custom, r.Header.Get("User-Agent"))
+		_ = json.NewEncoder(w).Encode(tokenResponse{AccessToken: "tok", ExpiresIn: 3600}) // #nosec G117 -- test mock OAuth token
+	}))
+	defer tokenSrv.Close()
+
+	c := New(
+		Config{TenantID: "t", ClientID: "c", ClientSecret: "s", UserAgent: custom},
+		WithTokenURL(tokenSrv.URL), WithBaseURL(graphSrv.URL),
+	)
+	_, err := c.CreateOnlineMeeting(context.Background(), CreateOnlineMeetingRequest{
+		ExternalID: "room-key-1", OrganizerEmail: "alice@corp.com",
+	})
+	require.NoError(t, err)
+}
+
+func TestResolveAccountIDs_SendsUserAgent(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, defaultUserAgent, r.Header.Get("User-Agent"))
+		_ = json.NewEncoder(w).Encode(tokenResponse{AccessToken: "tok", ExpiresIn: 3600}) // #nosec G117 -- test mock OAuth token
+	}))
+	defer tokenSrv.Close()
+	graphSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, defaultUserAgent, r.Header.Get("User-Agent"), "directory request must carry User-Agent")
+		_ = json.NewEncoder(w).Encode(map[string]any{"value": []GraphUser{
+			{ID: "ida", UserPrincipalName: "alice@corp.com"},
+		}})
+	}))
+	defer graphSrv.Close()
+
+	c := newTestDirectory(tokenSrv.URL, graphSrv.URL)
+	_, err := c.ResolveAccountIDs(context.Background(), []string{"alice"})
+	require.NoError(t, err)
+}
+
+func TestListUsers_SendsUserAgent(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"tok","expires_in":3600}`))
+	}))
+	defer tokenSrv.Close()
+	graphSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, defaultUserAgent, r.Header.Get("User-Agent"), "list-users request must carry User-Agent")
+		_, _ = w.Write([]byte(`{"value":[{"id":"u1","userPrincipalName":"alice@corp.example"}]}`))
+	}))
+	defer graphSrv.Close()
+
+	lister := NewUserListerClient(
+		Config{TenantID: "t", ClientID: "c", ClientSecret: "s"},
+		WithBaseURL(graphSrv.URL), WithTokenURL(tokenSrv.URL),
+	)
+	err := lister.ListUsers(context.Background(), 500, func([]GraphUser) error { return nil })
+	require.NoError(t, err)
+}

--- a/pkg/msgraph/presence.go
+++ b/pkg/msgraph/presence.go
@@ -35,14 +35,6 @@ type PresenceReader interface {
 // maxPresenceIDs is Graph's documented per-request cap for getPresencesByUserId.
 const maxPresenceIDs = 650
 
-// defaultUserAgent is sent on presence requests when Config.UserAgent is empty.
-// Microsoft Graph rejects requests without a User-Agent header, and a fronting
-// corporate proxy/WAF commonly rejects non-browser agents; a desktop-browser
-// string is the value most likely to pass both. Override per-environment via
-// Config.UserAgent (GRAPH_USER_AGENT) since a pinned browser version ages.
-const defaultUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
-	"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36"
-
 type presenceClient struct {
 	cfg       Config
 	creds     ROPCCredentials

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -51,9 +51,13 @@ type config struct {
 	TeamsEmailDomain  string `env:"TEAMS_EMAIL_DOMAIN"       envDefault:"dev.local"`
 	// TeamsTLSInsecure disables Graph TLS verification (dev/on-prem self-signed
 	// certs only). Never enable in production.
-	TeamsTLSInsecure     bool `env:"TEAMS_TLS_INSECURE" envDefault:"false"`
-	RoomMembersLimit     int  `env:"ROOM_MEMBERS_LIMIT"       envDefault:"500"`
-	RoomMembersCallLimit int  `env:"ROOM_MEMBERS_CALL_LIMIT"  envDefault:"20"`
+	TeamsTLSInsecure bool `env:"TEAMS_TLS_INSECURE" envDefault:"false"`
+	// GraphUserAgent overrides the User-Agent header on Graph requests (meetings
+	// path). Empty falls back to the msgraph browser default. Named GRAPH_USER_AGENT
+	// for consistency with user-presence-service.
+	GraphUserAgent       string `env:"GRAPH_USER_AGENT" envDefault:""`
+	RoomMembersLimit     int    `env:"ROOM_MEMBERS_LIMIT"       envDefault:"500"`
+	RoomMembersCallLimit int    `env:"ROOM_MEMBERS_CALL_LIMIT"  envDefault:"20"`
 	// Atrest/Vault drive eager at-rest DEK provisioning at room creation.
 	// When Atrest.Enabled is false the DEK is created lazily by message-worker.
 	Atrest   atrest.Config      // env vars already prefixed ATREST_*
@@ -154,6 +158,7 @@ func main() {
 			ClientID:              cfg.TeamsClientID,
 			ClientSecret:          cfg.TeamsClientSecret,
 			TLSInsecureSkipVerify: cfg.TeamsTLSInsecure,
+			UserAgent:             cfg.GraphUserAgent,
 		})
 	}
 


### PR DESCRIPTION
## Summary

Add configurable `User-Agent` header support to the app-only Microsoft Graph client, enabling room-service Teams meeting calls to pass corporate proxy/WAF fronting that rejects non-browser agents. The presence client already had this capability; the app-only client now gets the same treatment.

## Changes

- **`pkg/msgraph/msgraph.go`**
  - Add `userAgent string` field to `graphClient` struct
  - Resolve `userAgent` in `New()` from `Config.UserAgent`, falling back to `defaultUserAgent` (browser string)
  - Move `defaultUserAgent` constant from `presence.go` and generalize its doc comment (now applies to both app-only and presence clients)
  - Set `User-Agent` header explicitly at all four request sites: token fetch (`accessToken`), meeting creation (`CreateOnlineMeeting`), directory lookup (`resolveChunk`), and user listing (`fetchUsersPage`)
  - Update `Config.UserAgent` doc comment to reflect that it is honored by both app-only and presence clients

- **`pkg/msgraph/presence.go`**
  - Remove the `defaultUserAgent` constant declaration (now defined in `msgraph.go`, same package)

- **`pkg/msgraph/msgraph_test.go`**
  - Add four new tests asserting `User-Agent` header presence:
    - `TestCreateOnlineMeeting_SendsDefaultUserAgent` — verifies default browser string on token and meeting requests
    - `TestCreateOnlineMeeting_UserAgentOverride` — verifies custom override is used when `Config.UserAgent` is set
    - `TestResolveAccountIDs_SendsUserAgent` — verifies directory requests carry the header
    - `TestListUsers_SendsUserAgent` — verifies user listing requests carry the header

- **`room-service/main.go`**
  - Add `GraphUserAgent string` config field (env: `GRAPH_USER_AGENT`, default: empty)
  - Wire it into the `msgraph.New()` call so room-service's meeting requests use the configured agent

## Implementation Details

- Follows the existing `presence.go` pattern (Approach A): resolved field + explicit per-site header sets, mirroring the presence client's implementation
- `GRAPH_USER_AGENT` env var name chosen for cross-service consistency with `user-presence-service`
- Browser string default (`Mozilla/5.0 ...`) is the value most likely to pass both Microsoft Graph and corporate proxy/WAF filters
- All four app-only request sites (token, meeting, directory, list-users) now send the header, ensuring consistent behavior across all consumers
- No change to `docs/client-api.md` — this is an outbound HTTP header to Microsoft Graph, not a client-facing RPC schema change
- Tests follow TDD pattern: failing assertions first, then minimal implementation

https://claude.ai/code/session_01DbrQYGHCQ6rLw5NB2mRrwD