### PR TITLE
fix(upload-service): env-gate the setCookie Partitioned attribute

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -454,8 +454,10 @@ Cross-origin callers must send the request with credentials (e.g. `fetch(..., { 
 Response header:
 
 ```
-Set-Cookie: ssoToken=<token>; Path=/; HttpOnly; Secure; SameSite=None; Partitioned
+Set-Cookie: ssoToken=<token>; Path=/; HttpOnly; Secure; SameSite=None
 ```
+
+`Partitioned` is env-controlled server-side (`SETCOOKIE_PARTITIONED`, default `false` — omitted) and is added only when enabled.
 
 ```json
 { "success": true }

--- a/upload-service/handler.go
+++ b/upload-service/handler.go
@@ -66,17 +66,20 @@ type Handler struct {
 	preview        previewFunc
 	nowMilli       func() int64
 	cacheMaxAge    int
+
+	setCookiePartitioned bool
 }
 
 // NewHandler wires the handler dependencies. maxImages/maxImageSize gate the image
 // endpoint; maxAttachments/maxFileSize/mimeFilter/preview gate the file endpoint; s3
-// backs the MinIO/S3 download endpoint; cacheMaxAge is its Cache-Control max-age in seconds.
+// backs the MinIO/S3 download endpoint; cacheMaxAge is its Cache-Control max-age in
+// seconds; setCookiePartitioned gates the Partitioned attribute on HandleSetCookie.
 func NewHandler(store Store, dc driveClient, s3 objectStore, maxImages, maxAttachments int, maxImageSize, maxFileSize int64,
-	mimeFilter *mediaTypeFilter, preview previewFunc, cacheMaxAge int) *Handler {
+	mimeFilter *mediaTypeFilter, preview previewFunc, cacheMaxAge int, setCookiePartitioned bool) *Handler {
 	return &Handler{
 		store: store, drive: dc, s3: s3, maxImages: maxImages, maxAttachments: maxAttachments,
 		maxImageSize: maxImageSize, maxFileSize: maxFileSize, mimeFilter: mimeFilter,
-		preview: preview, cacheMaxAge: cacheMaxAge,
+		preview: preview, cacheMaxAge: cacheMaxAge, setCookiePartitioned: setCookiePartitioned,
 		nowMilli: func() int64 { return time.Now().UTC().UnixMilli() },
 	}
 }
@@ -105,7 +108,7 @@ func (h *Handler) HandleHealth(c *gin.Context) {
 // SameSite=None + Partitioned require the hand-built http.Cookie; c.SetCookie cannot set them.
 func (h *Handler) HandleSetCookie(c *gin.Context) {
 	token := tokenFromRequest(c)
-	// #nosec G124 -- SameSite=None is required for the cross-site <img> download flow; it is mitigated by Secure + HttpOnly + Partitioned.
+	// #nosec G124 -- SameSite=None is required for the cross-site <img> download flow; mitigated by Secure + HttpOnly (and Partitioned when SETCOOKIE_PARTITIONED is enabled).
 	http.SetCookie(c.Writer, &http.Cookie{
 		Name:        ssoTokenName,
 		Value:       token,
@@ -113,7 +116,7 @@ func (h *Handler) HandleSetCookie(c *gin.Context) {
 		HttpOnly:    true,
 		Secure:      true,
 		SameSite:    http.SameSiteNoneMode,
-		Partitioned: true,
+		Partitioned: h.setCookiePartitioned,
 	})
 	c.JSON(http.StatusOK, gin.H{"success": true})
 }

--- a/upload-service/handler_setcookie_test.go
+++ b/upload-service/handler_setcookie_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestHandleSetCookie_Partitioned drives HandleSetCookie with setCookiePartitioned
+// true and false, asserting the Set-Cookie header includes/omits Partitioned while
+// Secure, HttpOnly, and SameSite=None hold in both cases.
+func TestHandleSetCookie_Partitioned(t *testing.T) {
+	tests := []struct {
+		name        string
+		partitioned bool
+	}{
+		{"partitioned enabled", true},
+		{"partitioned disabled", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewHandler(nil, nil, &fakeS3{}, testMaxImages, testMaxAttachments, testMaxImageSize, 0, nil, nil, testCacheMaxAge, tt.partitioned)
+
+			gin.SetMode(gin.TestMode)
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/file/set-cookie", nil)
+			req.Header.Set(ssoTokenName, "token-123")
+			c.Request = req
+
+			h.HandleSetCookie(c)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			cookie := w.Header().Get("Set-Cookie")
+			assert.Contains(t, cookie, "Secure")
+			assert.Contains(t, cookie, "HttpOnly")
+			assert.Contains(t, cookie, "SameSite=None")
+			if tt.partitioned {
+				assert.Contains(t, cookie, "Partitioned")
+			} else {
+				assert.NotContains(t, cookie, "Partitioned")
+			}
+		})
+	}
+}

--- a/upload-service/handler_test.go
+++ b/upload-service/handler_test.go
@@ -115,7 +115,7 @@ func okUser() *AuthenticatedUser {
 }
 
 func newHandler(store Store, dc driveClient) *Handler {
-	return NewHandler(store, dc, &fakeS3{}, testMaxImages, testMaxAttachments, testMaxImageSize, 0, nil, nil, testCacheMaxAge)
+	return NewHandler(store, dc, &fakeS3{}, testMaxImages, testMaxAttachments, testMaxImageSize, 0, nil, nil, testCacheMaxAge, true)
 }
 
 func TestUpload_MissingRoomID_400(t *testing.T) {
@@ -194,7 +194,7 @@ func TestUpload_TooManyFiles_400(t *testing.T) {
 	store := NewMockStore(ctrl)
 	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
 	store.EXPECT().GetRoomSiteID(gomock.Any(), "r1").Return("site-x", nil)
-	h := NewHandler(store, &fakeDrive{}, &fakeS3{}, 1, testMaxAttachments, testMaxImageSize, 0, nil, nil, testCacheMaxAge) // image limit 1
+	h := NewHandler(store, &fakeDrive{}, &fakeS3{}, 1, testMaxAttachments, testMaxImageSize, 0, nil, nil, testCacheMaxAge, true) // image limit 1
 	body, ct := multipartBody(t, "images", map[string][]byte{"a.png": []byte("x"), "b.png": []byte("y")})
 	c, w := newUploadCtx(t, "r1", body, ct, okUser())
 	h.HandleUploadImages(c)
@@ -230,7 +230,7 @@ func TestUpload_OversizeRejectedPerFile(t *testing.T) {
 	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
 	store.EXPECT().GetRoomSiteID(gomock.Any(), "r1").Return("site-x", nil)
 	fd := &fakeDrive{}
-	h := NewHandler(store, fd, &fakeS3{}, testMaxImages, testMaxAttachments, 4, 0, nil, nil, testCacheMaxAge) // 4-byte per-image ceiling
+	h := NewHandler(store, fd, &fakeS3{}, testMaxImages, testMaxAttachments, 4, 0, nil, nil, testCacheMaxAge, true) // 4-byte per-image ceiling
 	body, ct := multipartBody(t, "images", map[string][]byte{"a.png": []byte("0123456789")})
 	c, w := newUploadCtx(t, "r1", body, ct, okUser())
 	h.HandleUploadImages(c)
@@ -444,7 +444,7 @@ func TestHandleUploadFile_SendsUniqueName_ReturnsOriginal(t *testing.T) {
 			{Status: "success", File: drive.GroupImageObject{FileID: "f1", GroupID: "r1", Filename: "photo_1719312000000_0.png", FileSize: 3}},
 		},
 	}
-	h := NewHandler(store, fd, &fakeS3{}, 0, testMaxAttachments, 0, 100<<20, newMediaTypeFilter("", "image/svg+xml"), imagePreview, testCacheMaxAge)
+	h := NewHandler(store, fd, &fakeS3{}, 0, testMaxAttachments, 0, 100<<20, newMediaTypeFilter("", "image/svg+xml"), imagePreview, testCacheMaxAge, true)
 	h.nowMilli = func() int64 { return 1719312000000 }
 
 	body := &bytes.Buffer{}
@@ -722,7 +722,7 @@ func TestS3Download_S3Error_503(t *testing.T) {
 	store := NewMockStore(ctrl)
 	store.EXPECT().GetUpload(gomock.Any(), "f1").Return(sampleUpload(), nil)
 	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
-	h := NewHandler(store, &fakeDrive{}, &fakeS3{err: errors.New("no such key")}, testMaxImages, testMaxAttachments, testMaxImageSize, 0, nil, nil, testCacheMaxAge)
+	h := NewHandler(store, &fakeDrive{}, &fakeS3{err: errors.New("no such key")}, testMaxImages, testMaxAttachments, testMaxImageSize, 0, nil, nil, testCacheMaxAge, true)
 	c, w := newS3DownloadCtx(t, "f1", "x.pdf", okUser())
 	h.HandleDownloadMinioS3File(c)
 	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
@@ -735,7 +735,7 @@ func TestS3Download_Success_StreamsWithHeaders(t *testing.T) {
 	store.EXPECT().GetUpload(gomock.Any(), "f1").Return(sampleUpload(), nil)
 	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
 	s3 := &fakeS3{body: "PDFDATA"}
-	h := NewHandler(store, &fakeDrive{}, s3, testMaxImages, testMaxAttachments, testMaxImageSize, 0, nil, nil, testCacheMaxAge)
+	h := NewHandler(store, &fakeDrive{}, s3, testMaxImages, testMaxAttachments, testMaxImageSize, 0, nil, nil, testCacheMaxAge, true)
 	c, w := newS3DownloadCtx(t, "f1", "x.pdf", okUser())
 	h.HandleDownloadMinioS3File(c)
 
@@ -757,7 +757,7 @@ func TestS3Download_EmptyType_DefaultsOctetStream(t *testing.T) {
 	up.Type = ""
 	store.EXPECT().GetUpload(gomock.Any(), "f1").Return(up, nil)
 	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
-	h := NewHandler(store, &fakeDrive{}, &fakeS3{body: "PDFDATA"}, testMaxImages, testMaxAttachments, testMaxImageSize, 0, nil, nil, testCacheMaxAge)
+	h := NewHandler(store, &fakeDrive{}, &fakeS3{body: "PDFDATA"}, testMaxImages, testMaxAttachments, testMaxImageSize, 0, nil, nil, testCacheMaxAge, true)
 	c, w := newS3DownloadCtx(t, "f1", "x.pdf", okUser())
 	h.HandleDownloadMinioS3File(c)
 	require.Equal(t, http.StatusOK, w.Code)
@@ -806,7 +806,7 @@ func multipartTyped(t *testing.T, field, filename string, data []byte, mime stri
 }
 
 func fileHandler(store Store, fd *fakeDrive) *Handler {
-	return NewHandler(store, fd, &fakeS3{}, 0, testMaxAttachments, 0, 100<<20, newMediaTypeFilter("", "image/svg+xml"), imagePreview, testCacheMaxAge)
+	return NewHandler(store, fd, &fakeS3{}, 0, testMaxAttachments, 0, 100<<20, newMediaTypeFilter("", "image/svg+xml"), imagePreview, testCacheMaxAge, true)
 }
 
 func okFileDrive() *fakeDrive {
@@ -903,7 +903,7 @@ func TestHandleUploadFile_OverSize(t *testing.T) {
 	store := NewMockStore(ctrl)
 	store.EXPECT().IsMember(gomock.Any(), "room-1", "alice").Return(true, nil)
 	store.EXPECT().GetRoomSiteID(gomock.Any(), "room-1").Return("site-a", nil)
-	h := NewHandler(store, &fakeDrive{baseURL: "http://drive"}, &fakeS3{}, 0, testMaxAttachments, 0, 4, newMediaTypeFilter("", ""), imagePreview, testCacheMaxAge)
+	h := NewHandler(store, &fakeDrive{baseURL: "http://drive"}, &fakeS3{}, 0, testMaxAttachments, 0, 4, newMediaTypeFilter("", ""), imagePreview, testCacheMaxAge, true)
 	body, ct := multipartTyped(t, "file", "big.pdf", []byte("morethan4"), "application/pdf", nil)
 	c, w := newUploadCtx(t, "room-1", body, ct, okUser())
 	h.HandleUploadFile(c)
@@ -1014,7 +1014,7 @@ func TestHandleUploadFile_MissingFile(t *testing.T) {
 
 func TestHandler_HandleSetCookie_SetsCookieAttributes(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	h := &Handler{}
+	h := &Handler{setCookiePartitioned: true}
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/file/setCookie", nil)

--- a/upload-service/main.go
+++ b/upload-service/main.go
@@ -50,6 +50,10 @@ type config struct {
 	// FileDownloadCacheMaxAgeSeconds is the Cache-Control max-age (seconds) on the
 	// MinIO/S3 download response (default 1 year).
 	FileDownloadCacheMaxAgeSeconds int `env:"FILE_DOWNLOAD_CACHE_MAX_AGE_SECONDS" envDefault:"31536000"`
+	// SetCookiePartitioned controls the Partitioned attribute on the sso-token
+	// cookie issued by HandleSetCookie. Off by default: Partitioned breaks the
+	// top-level-navigation download; enable only where the cross-site embed flow needs CHIPS.
+	SetCookiePartitioned bool `env:"SETCOOKIE_PARTITIONED" envDefault:"false"`
 
 	OIDCIssuerURL string   `env:"OIDC_ISSUER_URL"`
 	OIDCAudiences []string `env:"OIDC_AUDIENCES" envSeparator:","`
@@ -122,7 +126,7 @@ func run() error {
 
 	mimeFilter := newMediaTypeFilter(cfg.FileUploadMediaTypeWhitelist, cfg.FileUploadMediaTypeBlacklist)
 	handler := NewHandler(store, driveClient, s3Store, cfg.MaxImages, cfg.MaxAttachments, cfg.MaxImageSizeBytes,
-		cfg.FileUploadMaxFileSize, mimeFilter, imagePreview, cfg.FileDownloadCacheMaxAgeSeconds)
+		cfg.FileUploadMaxFileSize, mimeFilter, imagePreview, cfg.FileDownloadCacheMaxAgeSeconds, cfg.SetCookiePartitioned)
 
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()


### PR DESCRIPTION
## Summary

Make the `Partitioned` attribute on the sso-token cookie (`HandleSetCookie`) configurable via an environment variable, and default it **off**. `Partitioned` (CHIPS) scopes the cookie to the top-level site it was set under, so a top-level-navigation file download to the download origin does not carry the cookie and the protected download is unauthorized. Defaulting it off unblocks that download; the flag re-enables it where the cross-site `<img>`-embed flow needs CHIPS.

## Changes

- `upload-service/main.go`: add `SetCookiePartitioned bool` config field (`env:"SETCOOKIE_PARTITIONED"`, default `false`), passed into `NewHandler`.
- `upload-service/handler.go`: add `setCookiePartitioned` to `Handler`; `HandleSetCookie` now sets `Partitioned: h.setCookiePartitioned` instead of a hardcoded `true`.
- `upload-service/handler_test.go`: thread the new constructor parameter through existing call sites; the pre-existing attribute test sets the flag explicitly to assert the enabled (Partitioned-present) path.
- `upload-service/handler_setcookie_test.go` (new): table test driving `HandleSetCookie` with the flag `true` and `false`, asserting `Partitioned` present/omitted while `Secure`, `HttpOnly`, and `SameSite=None` hold in both cases.
- `docs/client-api.md`: note that `Partitioned` is env-controlled, omitted by default, added only when enabled.

## Verification

`go build`, `go vet`, and `go test ./upload-service/...` all pass.

Closes #97


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `SETCOOKIE_PARTITIONED` configuration option to control whether SSO cookies include the `Partitioned` attribute.
  * The option defaults to disabled, preserving secure cookie attributes such as `Secure`, `HttpOnly`, and `SameSite=None`.

* **Documentation**
  * Updated the client API documentation to describe the configurable cookie behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->