### PR TITLE
fix(msgraph): raise list-chats read cap to 64 MiB

### DIFF
--- a/pkg/msgraph/chats.go
+++ b/pkg/msgraph/chats.go
@@ -138,7 +138,9 @@ func (g *graphClient) getThrottled(ctx context.Context, token, endpoint, operati
 		if err != nil {
 			return nil, fmt.Errorf("get chats: %w", err)
 		}
-		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<22))
+		// Bound the read so a runaway or hostile response can't exhaust memory;
+		// real list-chats pages ($top=50, members expanded) are far smaller.
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<26)) // 64 MiB
 		if closeErr := resp.Body.Close(); closeErr != nil {
 			return nil, fmt.Errorf("close chats response: %w", closeErr)
 		}

--- a/pkg/msgraph/chats_test.go
+++ b/pkg/msgraph/chats_test.go
@@ -136,6 +136,39 @@ func TestListUserChats_FollowsNextLink(t *testing.T) {
 	assert.Equal(t, "19:p2", chats[1].ID)
 }
 
+// TestListUserChats_LargeResponseDecodes verifies a realistically large
+// list-chats page — well over the old 4 MiB cap, under the 64 MiB read cap —
+// is read in full and decoded rather than truncated mid-JSON.
+func TestListUserChats_LargeResponseDecodes(t *testing.T) {
+	const n = 40000 // ~5.5 MiB of chat entries — comfortably over 4 MiB
+	var b strings.Builder
+	b.WriteString(`{"value":[`)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, `{"id":"19:chat-%d@thread.v2","chatType":"group","topic":"t",`+
+			`"createdDateTime":"2026-04-02T08:00:00Z","lastUpdatedDateTime":"2026-07-01T09:00:00Z",`+
+			`"members":[]}`, i)
+	}
+	b.WriteString(`]}`)
+	body := b.String()
+	require.Greater(t, len(body), 1<<22, "test body must exceed 4 MiB to exercise a large response")
+
+	tokenSrv := newChatsTokenServer(t)
+	graphSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer graphSrv.Close()
+
+	chats, err := newTestChats(t, tokenSrv.URL, graphSrv.URL).
+		ListUserChats(context.Background(), "aad-user-1", chatsFrom, chatsTo)
+	require.NoError(t, err)
+	require.Len(t, chats, n)
+	assert.Equal(t, "19:chat-0@thread.v2", chats[0].ID)
+	assert.Equal(t, fmt.Sprintf("19:chat-%d@thread.v2", n-1), chats[n-1].ID)
+}
+
 func TestListUserChats_RetriesOn429(t *testing.T) {
 	tokenSrv := newChatsTokenServer(t)
 	var calls int


### PR DESCRIPTION
## Summary

`ListUserChats` (`pkg/msgraph`) failed to decode large responses. In `getThrottled`, the body was read via `io.ReadAll(io.LimitReader(resp.Body, 1<<22))` — a 4 MiB cap. `io.ReadAll` treats the `LimitReader`'s EOF as a **complete, successful** read, so any page larger than 4 MiB was silently truncated mid-JSON and then failed `json.Unmarshal` with `unexpected end of JSON input` (surfaced as `decode chats response: ...`).

A `$top=50` page with `$expand=members` can exceed 4 MiB on large tenants (each expanded member is a full `aadUserConversationMember`), so this triggers in practice.

## Change

Raise the read cap from 4 MiB to **64 MiB**:

```go
- body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<22))
+ body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<26)) // 64 MiB
```

64 MiB is generous enough that real list-chats pages decode in full, while still bounding memory against a runaway or hostile response.

## Testing

- Added `TestListUserChats_LargeResponseDecodes`: serves a ~5.5 MiB valid page (over the old 4 MiB cap, under the new 64 MiB cap). Fails on the old cap (`decode chats response: unexpected end of JSON input`), passes after the change.
- `make test SERVICE=pkg/msgraph`, `make lint` (0 issues), and `make sast-gosec` all pass.

## Follow-up (separate PR)

Connection-pool tuning for the Graph client (`MaxIdleConnsPerHost` / `MaxConnsPerHost` sized to each sync job's `MAX_WORKERS`) will land in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LMohLq8LKFEZY64VzSCUX