### PR TITLE
feat(history-service): room-list preview — filter system/quoted + enrich (attachments, mentions, visibleTo, sender)

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -911,21 +911,21 @@ top-level `siteId`. All fields are optional (omitted when zero/unset).
 | `minUserLastSeenAt` | RFC3339 timestamp | The room-wide read floor — the oldest `lastSeenAt` across the room's members ("everyone has read up to here"). Omitted when the floor is unset (a member is still fully unread). |
 | `privateKey` | string | Base64-encoded room E2E private key — initial key bootstrap for room members (see [§5](#5-room-encryption)). Present only for encrypted (channel) rooms whose key the caller's site holds; omitted otherwise. |
 | `keyVersion` | number | Version of `privateKey`. |
-| `lastMessage` | [PreviewMessage](#previewmessage) | Optional. The room's latest eligible message, resolved server-side at read time. Omitted when the room has no message, or that site's enrichment degraded, or the request set `includeLastMessage: false` — best-effort, never fails the list. |
+| `previewMessage` | [PreviewMessage](#previewmessage) | Optional. The room's latest eligible message, resolved server-side at read time. Omitted when the room has no message, or that site's enrichment degraded, or the request set `includeLastMessage: false` — best-effort, never fails the list. |
 
 ##### PreviewMessage
 
 A room's most-recent **eligible** message, resolved at read time and enriched for
 room-list rendering. Eligible = not soft-deleted, not a system message, not a
 quoted reply — an ineligible tail is walked back to an earlier survivor; a room with only
-ineligible messages omits `lastMessage`.
+ineligible messages omits `previewMessage`.
 
 | Field | Type | Notes |
 |---|---|---|
 | `messageId` | string | |
 | `sender` | [Participant](#participant) | `chineseName` is the sender's company name; `displayName` is the composed render-ready name (a bot sender's is its app name). |
 | `content` | string | The full message body; the client truncates for display. |
-| `createdAt` | int64 | UTC milliseconds. |
+| `createdAt` | string | RFC 3339 timestamp. |
 | `attachments` | [Attachment](#attachment)[] | Optional. Omitted when the message has none. |
 | `mentions` | [Participant](#participant)[] | Optional. Mentioned users as wire Participants. Omitted when none. |
 | `visibleTo` | string | Optional. Currently empty until its write-path lands (surfaced now for forward-compat). |
@@ -4475,7 +4475,7 @@ Returns the user's sidebar subscriptions, optionally filtered by type, age, and 
 | `type`              | string  | yes      | One of `"current"` (active rooms), `"rooms"` (DM and channel subscriptions), `"apps"` (botDM rooms). |
 | `favorite`          | boolean | no       | When `true`, filters to favorited subscriptions only **and** moves the self-DM to the front of the list. |
 | `updatedWithinDays` | number  | no       | When set, filters **`rooms`-type** results to rooms **whose last message (`room.lastMsgAt`) is within the last N days** — room activity, not the subscription's update time. Cross-site rooms (no local `lastMsgAt`) fall outside the window. **Ignored for `current`** (always returns the full active set) and for `apps`. Omit for no age filter — the server applies no default; the client supplies any default it wants. Must be non-negative; a negative value is rejected with `bad_request`. |
-| `includeLastMessage` | boolean | no      | Whether to embed each room's [`lastMessage`](#subscriptionroom). Omitted ⇒ include (backward-compatible default); `false` ⇒ skip the per-room last-message resolve (a client that renders no room-list snippet can send `false` to save the server-side work). |
+| `includeLastMessage` | boolean | no      | Whether to embed each room's [`previewMessage`](#subscriptionroom). Omitted ⇒ include (backward-compatible default); `false` ⇒ skip the per-room last-message resolve (a client that renders no room-list snippet can send `false` to save the server-side work). |
 | `offset`            | integer | no       | Zero-based index of the first record to return. Negative ⇒ `0`. Default `0`. |
 | `limit`             | integer | no       | Page size. Omitted or ≤ 0 ⇒ the server default `SUBSCRIPTION_DEFAULT_LIMIT` (default `40`); values above `MAX_SUBSCRIPTION_LIMIT` (default `1000`) are capped to it. |
 
@@ -4550,11 +4550,11 @@ The example below shows one record of each type in order (`channel`, `dm`, `botD
         "minUserLastSeenAt": "2026-05-30T07:55:00Z",
         "privateKey": "bDM4dGZ5...base64...JjT0g9PQ==",
         "keyVersion": 3,
-        "lastMessage": {
+        "previewMessage": {
           "messageId": "01970a4f8c2d7c9aBB",
           "sender": { "userId": "01970a4f8c2d7c9a01970a4f8c2d7c9a", "account": "alice", "chineseName": "愛麗絲", "displayName": "Alice 愛麗絲" },
           "content": "morning team",
-          "createdAt": 1780308000000
+          "createdAt": "2026-05-06T07:55:00Z"
         }
       }
     },

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -915,8 +915,8 @@ top-level `siteId`. All fields are optional (omitted when zero/unset).
 
 ##### PreviewMessage
 
-A room's most-recent **eligible** message, resolved at read time, preview-trimmed, and
-enriched for room-list rendering. Eligible = not soft-deleted, not a system message, not a
+A room's most-recent **eligible** message, resolved at read time and enriched for
+room-list rendering. Eligible = not soft-deleted, not a system message, not a
 quoted reply — an ineligible tail is walked back to an earlier survivor; a room with only
 ineligible messages omits `lastMessage`.
 
@@ -924,7 +924,7 @@ ineligible messages omits `lastMessage`.
 |---|---|---|
 | `messageId` | string | |
 | `sender` | [Participant](#participant) | `chineseName` is the sender's company name; `displayName` is the composed render-ready name (a bot sender's is its app name). |
-| `content` | string | Preview-trimmed to 256 runes. |
+| `content` | string | The full message body; the client truncates for display. |
 | `createdAt` | int64 | UTC milliseconds. |
 | `attachments` | [Attachment](#attachment)[] | Optional. Omitted when the message has none. |
 | `mentions` | [Participant](#participant)[] | Optional. Mentioned users as wire Participants. Omitted when none. |

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -916,8 +916,8 @@ top-level `siteId`. All fields are optional (omitted when zero/unset).
 ##### LastMessage
 
 A room's most-recent **non-deleted** message, resolved at read time and preview-trimmed.
-Soft-deleted messages are skipped (walked back to an earlier survivor); a room with only
-deleted messages omits `lastMessage`.
+Soft-deleted, system, and quoted-reply messages are skipped (walked back to an earlier
+survivor); a room with only such messages omits `lastMessage`.
 
 | Field | Type | Notes |
 |---|---|---|

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -911,21 +911,24 @@ top-level `siteId`. All fields are optional (omitted when zero/unset).
 | `minUserLastSeenAt` | RFC3339 timestamp | The room-wide read floor — the oldest `lastSeenAt` across the room's members ("everyone has read up to here"). Omitted when the floor is unset (a member is still fully unread). |
 | `privateKey` | string | Base64-encoded room E2E private key — initial key bootstrap for room members (see [§5](#5-room-encryption)). Present only for encrypted (channel) rooms whose key the caller's site holds; omitted otherwise. |
 | `keyVersion` | number | Version of `privateKey`. |
-| `lastMessage` | [LastMessage](#lastmessage) | Optional. The room's latest non-deleted message, resolved server-side at read time. Omitted when the room has no message, or that site's enrichment degraded, or the request set `includeLastMessage: false` — best-effort, never fails the list. |
+| `lastMessage` | [PreviewMessage](#previewmessage) | Optional. The room's latest eligible message, resolved server-side at read time. Omitted when the room has no message, or that site's enrichment degraded, or the request set `includeLastMessage: false` — best-effort, never fails the list. |
 
-##### LastMessage
+##### PreviewMessage
 
-A room's most-recent **eligible** message, resolved at read time and preview-trimmed.
-Eligible = not soft-deleted, not a system message, not a quoted reply — an ineligible
-tail is walked back to an earlier survivor; a room with only ineligible messages omits
-`lastMessage`.
+A room's most-recent **eligible** message, resolved at read time, preview-trimmed, and
+enriched for room-list rendering. Eligible = not soft-deleted, not a system message, not a
+quoted reply — an ineligible tail is walked back to an earlier survivor; a room with only
+ineligible messages omits `lastMessage`.
 
 | Field | Type | Notes |
 |---|---|---|
 | `messageId` | string | |
-| `sender` | [Participant](#participant) | |
+| `sender` | [Participant](#participant) | `chineseName` is the sender's company name; `displayName` is the composed render-ready name (a bot sender's is its app name). |
 | `content` | string | Preview-trimmed to 256 runes. |
 | `createdAt` | int64 | UTC milliseconds. |
+| `attachments` | [Attachment](#attachment)[] | Optional. Omitted when the message has none. |
+| `mentions` | [Participant](#participant)[] | Optional. Mentioned users as wire Participants. Omitted when none. |
+| `visibleTo` | string | Optional. Currently empty until its write-path lands (surfaced now for forward-compat). |
 
 #### AppSubscription
 
@@ -4549,7 +4552,7 @@ The example below shows one record of each type in order (`channel`, `dm`, `botD
         "keyVersion": 3,
         "lastMessage": {
           "messageId": "01970a4f8c2d7c9aBB",
-          "sender": { "id": "01970a4f8c2d7c9a01970a4f8c2d7c9a", "account": "alice" },
+          "sender": { "userId": "01970a4f8c2d7c9a01970a4f8c2d7c9a", "account": "alice", "chineseName": "愛麗絲", "displayName": "Alice 愛麗絲" },
           "content": "morning team",
           "createdAt": 1780308000000
         }

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -915,9 +915,10 @@ top-level `siteId`. All fields are optional (omitted when zero/unset).
 
 ##### LastMessage
 
-A room's most-recent **non-deleted** message, resolved at read time and preview-trimmed.
-Soft-deleted, system, and quoted-reply messages are skipped (walked back to an earlier
-survivor); a room with only such messages omits `lastMessage`.
+A room's most-recent **eligible** message, resolved at read time and preview-trimmed.
+Eligible = not soft-deleted, not a system message, not a quoted reply — an ineligible
+tail is walked back to an earlier survivor; a room with only ineligible messages omits
+`lastMessage`.
 
 | Field | Type | Notes |
 |---|---|---|

--- a/docs/superpowers/plans/2026-07-22-preview-message-enrichment.md
+++ b/docs/superpowers/plans/2026-07-22-preview-message-enrichment.md
@@ -1,0 +1,45 @@
+# Room-list preview enrichment (`PreviewMessage`) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Enrich the room-list preview (issue #110) so it carries `attachments`,
+`mentions` (with display names), `visibleTo`, and a sender that shows `chineseName` /
+bot app name — on top of the #104 system/quoted skip. Design: `../specs/2026-07-22-preview-message-enrichment-design.md`.
+
+**Tech Stack:** Go. `history-service` (read path), `pkg/model` (wire type), `user-service` (consumer).
+
+---
+
+## File Structure
+
+- Modify: `pkg/model/message.go` — `LastMessage` → `PreviewMessage` (enriched); `RoomsGetResponse`.
+- Modify: `pkg/model/subscription.go` — `SubscriptionRoom.LastMessage` type.
+- Modify: `history-service/internal/models/message.go` — type alias.
+- Modify: `history-service/internal/service/rooms.go` — `toPreviewMessage` mapper.
+- Modify: `history-service/internal/service/reactions.go` — extract `botAwareDisplayName`.
+- Modify: `user-service/{service/service.go,historyclient/client.go,service/subscriptions.go,service/mocks/mock_repository.go}` — rename ripple.
+- Modify: `docs/client-api.md` — preview schema (doc-ratchet).
+- Tests: `history-service/internal/service/{rooms_test.go,integration_test.go}`, `history-service/internal/models/roomsget_test.go`.
+
+---
+
+### Task 1: Wire type + rename
+
+- [ ] Add `attachments`/`mentions`/`visibleTo` to a renamed `PreviewMessage` (sender = wire `Participant`); `// TODO(#106): forwardSource`.
+- [ ] Ripple `LastMessage` → `PreviewMessage` across the alias + `user-service` consumers; keep the `SubscriptionRoom.LastMessage` field name.
+- [ ] `go build ./...` clean.
+
+### Task 2: Enrichment mapper
+
+- [ ] Extract `HistoryService.botAwareDisplayName(ctx, engName, chineseName, account)` from `ReactMessage`; call it from both sites.
+- [ ] Add `toPreviewMessage`: decode attachments (`decodeMessageAttachments`), map sender + mentions via `toWireParticipant`, set sender `displayName`, pass through `visibleTo`.
+- [ ] `roomLastMessage` returns `s.toPreviewMessage(...)`; keep the #104 skip.
+
+### Task 3: Docs + tests
+
+- [ ] `docs/client-api.md`: `LastMessage` → `PreviewMessage` schema + example (sender wire shape, new fields).
+- [ ] Unit (`rooms_test.go`): attachments/mentions/visibleTo mapped; chineseName from `company_name`; bot → app name; normal sender unaffected; empty collections omit.
+- [ ] Integration (`integration_test.go`): seed a message with attachments + mentions, assert the preview carries them.
+- [ ] Keep #104's filter tests green.
+
+**Verify:** `chat-lint.sh ./...` clean; `go test ./history-service/... ./user-service/service/...`; `go vet -tags integration ./history-service/internal/service/`.

--- a/docs/superpowers/plans/2026-07-22-preview-message-enrichment.md
+++ b/docs/superpowers/plans/2026-07-22-preview-message-enrichment.md
@@ -43,3 +43,11 @@ bot app name — on top of the #104 system/quoted skip. Design: `../specs/2026-0
 - [ ] Keep #104's filter tests green.
 
 **Verify:** `chat-lint.sh ./...` clean; `go test ./history-service/... ./user-service/service/...`; `go vet -tags integration ./history-service/internal/service/`.
+
+### Wire-level verification (dev stack)
+
+Beyond the in-repo unit + integration tests, the preview was verified end-to-end at
+the NATS request/reply layer on our dev stack: drove the real `rooms.get` (via
+`subscription.getChannels`) against a room whose latest message is a quoted reply, and
+confirmed the preview resolves to the non-quoted survivor (system + quoted skipped) with
+the enriched fields present on the wire. The harness lives in our tooling, not this repo.

--- a/docs/superpowers/specs/2026-07-22-preview-message-enrichment-design.md
+++ b/docs/superpowers/specs/2026-07-22-preview-message-enrichment-design.md
@@ -1,0 +1,45 @@
+# Room-list preview enrichment (`PreviewMessage`) — Design
+
+**Issue:** #110. Builds on #103/#104 (skip system + quoted messages in the preview walk).
+
+## Problem
+
+The room-list preview (`rooms.get` → `SubscriptionRoom.LastMessage`) carried only
+`{messageId, sender, content, createdAt}`, and `sender` was the raw `cassandra.Participant`
+(`id`/`account` only). The frontend can't render an attachment icon, mentioned names, or a
+bot's app name from that. Every needed source field is already read by the walk's
+projection (`messages_by_room.go` `baseColumns` selects `mentions`, `attachments`,
+`visible_to`) — this is a mapping + sender-enrichment change, not a storage change.
+
+## Approach
+
+Replace the minimal `LastMessage` wire type with a dedicated **`PreviewMessage`**
+(`pkg/model/message.go`) and map it in the existing `roomLastMessage` walk via a new
+`toPreviewMessage` mapper.
+
+- **Sender / mentions → wire `Participant`.** Reuse `toWireParticipant` (`chineseName` from
+  the Cassandra `company_name`). The sender's `displayName` is composed, and for a bot
+  account it's the app name — this "compose, then bot-override" logic is **extracted from
+  the reaction path** into a shared `HistoryService.botAwareDisplayName` helper (previously
+  inline in `ReactMessage`), so both callers stay in sync.
+- **Attachments.** The walk reads raw `attachments` blobs but — unlike every other read
+  path — never called `setDecodedAttachments`. `toPreviewMessage` decodes the single
+  eligible message via the existing `decodeMessageAttachments` before mapping.
+- **`visibleTo`.** Surfaced from the already-projected column. Its **write-path is a
+  separate follow-up** (no writers today), so the field is empty until that lands.
+- **`forwardSource`.** Deferred — depends on #106 (`Forwarded` snapshot). Only a
+  `// TODO(#106)` marker is left.
+
+## Scope
+
+- No Cassandra/Mongo schema or projection change (columns already projected).
+- The `LastMessage` → `PreviewMessage` rename ripples through the shared wire type and its
+  consumers (history models alias, `user-service` `RoomsGet` signature + `SubscriptionRoom`
+  field, historyclient, mocks). The `SubscriptionRoom.LastMessage` **field name is kept**;
+  only its type changes.
+
+## Out of scope
+
+- `visibleTo` write-path (separate BE task).
+- `forwardSource` wiring (after #106).
+- Thread-list preview.

--- a/history-service/internal/models/message.go
+++ b/history-service/internal/models/message.go
@@ -74,7 +74,7 @@ type GetMessagesByIDsResponse struct {
 }
 
 // RoomsGetRequest/PreviewMessage/RoomsGetResponse are shared with user-service (which
-// embeds PreviewMessage into SubscriptionRoom.LastMessage), so the wire types live in pkg/model.
+// embeds PreviewMessage into SubscriptionRoom.PreviewMessage), so the wire types live in pkg/model.
 type RoomsGetRequest = model.RoomsGetRequest
 type PreviewMessage = model.PreviewMessage
 type RoomsGetResponse = model.RoomsGetResponse

--- a/history-service/internal/models/message.go
+++ b/history-service/internal/models/message.go
@@ -73,10 +73,10 @@ type GetMessagesByIDsResponse struct {
 	Messages []Message `json:"messages"`
 }
 
-// RoomsGetRequest/LastMessage/RoomsGetResponse are shared with user-service (which
-// embeds LastMessage into SubscriptionRoom), so the wire types live in pkg/model.
+// RoomsGetRequest/PreviewMessage/RoomsGetResponse are shared with user-service (which
+// embeds PreviewMessage into SubscriptionRoom.LastMessage), so the wire types live in pkg/model.
 type RoomsGetRequest = model.RoomsGetRequest
-type LastMessage = model.LastMessage
+type PreviewMessage = model.PreviewMessage
 type RoomsGetResponse = model.RoomsGetResponse
 
 type EditMessageRequest struct {

--- a/history-service/internal/models/roomsget_test.go
+++ b/history-service/internal/models/roomsget_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/model"
 )
 
 func TestRoomsGetRequest_JSON(t *testing.T) {
@@ -24,9 +26,9 @@ func TestRoomsGetResponse_JSONRoundTrip(t *testing.T) {
 		name string
 		in   RoomsGetResponse
 	}{
-		{name: "empty", in: RoomsGetResponse{Rooms: map[string]LastMessage{}}},
-		{name: "one room", in: RoomsGetResponse{Rooms: map[string]LastMessage{
-			"r1": {MessageID: "m1", Sender: Participant{ID: "u1", Account: "alice"}, Content: "hi", CreatedAt: 1_714_000_000_000},
+		{name: "empty", in: RoomsGetResponse{Rooms: map[string]PreviewMessage{}}},
+		{name: "one room", in: RoomsGetResponse{Rooms: map[string]PreviewMessage{
+			"r1": {MessageID: "m1", Sender: model.Participant{UserID: "u1", Account: "alice"}, Content: "hi", CreatedAt: 1_714_000_000_000},
 		}}},
 	}
 	for _, tc := range cases {

--- a/history-service/internal/models/roomsget_test.go
+++ b/history-service/internal/models/roomsget_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,7 +29,7 @@ func TestRoomsGetResponse_JSONRoundTrip(t *testing.T) {
 	}{
 		{name: "empty", in: RoomsGetResponse{Rooms: map[string]PreviewMessage{}}},
 		{name: "one room", in: RoomsGetResponse{Rooms: map[string]PreviewMessage{
-			"r1": {MessageID: "m1", Sender: model.Participant{UserID: "u1", Account: "alice"}, Content: "hi", CreatedAt: 1_714_000_000_000},
+			"r1": {MessageID: "m1", Sender: model.Participant{UserID: "u1", Account: "alice"}, Content: "hi", CreatedAt: time.Unix(1_714_000_000, 0).UTC()},
 		}}},
 	}
 	for _, tc := range cases {

--- a/history-service/internal/service/integration_test.go
+++ b/history-service/internal/service/integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hmchangw/chat/history-service/internal/config"
 	"github.com/hmchangw/chat/history-service/internal/models"
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/pkg/msgbucket"
 	"github.com/hmchangw/chat/pkg/natsrouter"
 	"github.com/hmchangw/chat/pkg/subject"
@@ -415,4 +416,44 @@ func TestDeleteMessage_Integration_ThreadReplyPublishesMetadataEvent(t *testing.
 	assert.Equal(t, parentID, canonicalEvt.Message.ThreadParentMessageID)
 	require.NotNil(t, canonicalEvt.NewTCount, "canonical delete for a thread reply must carry NewTCount")
 	assert.Equal(t, 0, *canonicalEvt.NewTCount, "tcount seeded at 1 minus one decrement must equal 0")
+}
+
+// TestRoomsGet_Integration_EnrichesPreview seeds a message with attachments, mentions,
+// and visibleTo, then asserts rooms.get surfaces them on the enriched preview.
+func TestRoomsGet_Integration_EnrichesPreview(t *testing.T) {
+	session := setupCassandra(t)
+	repo := cassrepo.NewRepository(session, msgbucket.New(24*time.Hour), 365, nil)
+	svc := New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, &recordingPublisher{}, nil, nil, nil, nil, &config.Config{
+		MessageHistoryFloorDays: 730,
+		LargeRoomThreshold:      500,
+		MaxPinnedPerRoom:        10,
+		PinEnabled:              true,
+	})
+
+	sender := models.Participant{ID: "u1", Account: "alice", EngName: "Alice", CompanyName: "愛麗絲"}
+	mentions := []models.Participant{{ID: "u2", Account: "bob", CompanyName: "小明"}}
+	atts := cassandra.EncodeAttachments([]cassandra.Attachment{{ID: "f1", Title: "a.png", Type: "file"}})
+	roomID := "r-preview"
+	msgID := "m-preview"
+	createdAt := time.Now().UTC().Add(-time.Minute).Truncate(time.Millisecond)
+
+	require.NoError(t, session.Query(
+		`INSERT INTO messages_by_room (room_id, bucket, created_at, message_id, sender, msg, mentions, attachments, visible_to)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		roomID, msgbucket.New(24*time.Hour).Of(createdAt), createdAt, msgID, sender, "hello", mentions, atts, "u1",
+	).Exec())
+
+	c := natsrouter.NewContext(map[string]string{"account": "alice"})
+	resp, err := svc.RoomsGet(c, models.RoomsGetRequest{RoomIDs: []string{roomID}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, roomID)
+	pm := resp.Rooms[roomID]
+	assert.Equal(t, msgID, pm.MessageID)
+	assert.Equal(t, "hello", pm.Content)
+	assert.Equal(t, "愛麗絲", pm.Sender.ChineseName)
+	require.Len(t, pm.Attachments, 1)
+	assert.Equal(t, "a.png", pm.Attachments[0].Title)
+	require.Len(t, pm.Mentions, 1)
+	assert.Equal(t, "bob", pm.Mentions[0].Account)
+	assert.Equal(t, "u1", pm.VisibleTo)
 }

--- a/history-service/internal/service/integration_test.go
+++ b/history-service/internal/service/integration_test.go
@@ -53,7 +53,7 @@ func setupCassandra(t *testing.T) *gocql.Session {
 		quoted_parent_message FROZEN<"QuotedParentMessage">, visible_to TEXT,
 		reactions MAP<FROZEN<reaction_key>, FROZEN<reactor_info>>,
 		deleted BOOLEAN,
-		type TEXT, sys_msg_data BLOB, site_id TEXT, edited_at TIMESTAMP, updated_at TIMESTAMP,
+		type TEXT, sys_msg_data BLOB, site_id TEXT, edited_at TIMESTAMP, updated_at TIMESTAMP, pinned_at TIMESTAMP,
 		enc_payload BLOB, enc_meta FROZEN<"EncMeta">,
 		PRIMARY KEY ((room_id, bucket), created_at, message_id)
 	) WITH CLUSTERING ORDER BY (created_at DESC, message_id DESC)`)).Exec())

--- a/history-service/internal/service/reactions.go
+++ b/history-service/internal/service/reactions.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -89,14 +90,7 @@ func (s *HistoryService) ReactMessage(c *natsrouter.Context, siteID string, req 
 	}
 
 	// Bot reactor: prefer the app's display name; degrade to composed on miss/error.
-	displayName := displayfmt.CombineWithFallback(actor.EngName, actor.ChineseName, actor.Account)
-	if pkgmodel.IsBot(actor.Account) {
-		if appName, err := s.apps.AppNameByAccount(c, actor.Account); err != nil {
-			slog.WarnContext(c, "react: app name lookup failed, using composed name", "account", actor.Account, "error", err)
-		} else if appName != "" {
-			displayName = appName
-		}
-	}
+	displayName := s.botAwareDisplayName(c, actor.EngName, actor.ChineseName, actor.Account)
 
 	canonicalEvt := pkgmodel.MessageEvent{
 		Event:     pkgmodel.EventReacted,
@@ -172,4 +166,18 @@ func toWireMessage(msg *cassandra.Message, updatedAt *time.Time) pkgmodel.Messag
 // SiteID/DisplayName have no Cassandra source.
 func toWireParticipant(p *cassandra.Participant) pkgmodel.Participant {
 	return pkgmodel.Participant{UserID: p.ID, Account: p.Account, EngName: p.EngName, ChineseName: p.CompanyName}
+}
+
+// botAwareDisplayName composes a render-ready name; for a bot account it prefers the
+// app's display name, degrading to the composed name on lookup miss/error.
+func (s *HistoryService) botAwareDisplayName(ctx context.Context, engName, chineseName, account string) string {
+	name := displayfmt.CombineWithFallback(engName, chineseName, account)
+	if pkgmodel.IsBot(account) {
+		if appName, err := s.apps.AppNameByAccount(ctx, account); err != nil {
+			slog.WarnContext(ctx, "app name lookup failed, using composed name", "account", account, "error", err)
+		} else if appName != "" {
+			name = appName
+		}
+	}
+	return name
 }

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -17,7 +17,7 @@ const (
 	maxRoomsGetConcurrency  = 16  // mirrors cassrepo.maxConcurrentIDReads
 	lastMessagePreviewRunes = 256 // room-list snippet cap
 	lastMsgWalkPageSize     = 50  // messages scanned per walk-back page
-	lastMsgWalkMaxPages     = 5   // ponytail: cap the deleted-tail walk; a room with >250 trailing deletes just shows no last message
+	lastMsgWalkMaxPages     = 5   // ponytail: cap the ineligible-tail walk; a room with >250 trailing ineligible messages just shows no last message
 )
 
 // RoomsGet handles chat.server.request.history.{siteID}.rooms.get: for each requested
@@ -107,8 +107,9 @@ func (s *HistoryService) roomLastMessage(ctx context.Context, roomID string, now
 				CreatedAt: m.CreatedAt.UTC().UnixMilli(),
 			}, true
 		}
-		// Whole page deleted. A short page means the walk is exhausted (no older
-		// messages) — stop. Otherwise page again strictly before the oldest one seen.
+		// Whole page ineligible (deleted/system/quoted). A short page means the walk
+		// is exhausted (no older messages) — stop. Otherwise page again strictly
+		// before the oldest one seen.
 		if len(page.Data) < lastMsgWalkPageSize {
 			return models.LastMessage{}, false
 		}

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hmchangw/chat/history-service/internal/models"
 	"github.com/hmchangw/chat/pkg/errcode"
+	pkgmodel "github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/natsrouter"
 	"github.com/hmchangw/chat/pkg/natsutil"
 )
@@ -34,7 +35,7 @@ func (s *HistoryService) RoomsGet(c *natsrouter.Context, req models.RoomsGetRequ
 	ids := dedupRoomIDs(req.RoomIDs)
 	now := time.Now().UTC()
 
-	out := make(map[string]models.LastMessage, len(ids))
+	out := make(map[string]models.PreviewMessage, len(ids))
 	var mu sync.Mutex
 	// WaitGroup+sem (not errgroup): per-room failures must degrade, never cancel
 	// siblings. Acquire sem before spawning so live goroutine count stays bounded.
@@ -65,20 +66,20 @@ func (s *HistoryService) RoomsGet(c *natsrouter.Context, req models.RoomsGetRequ
 	return &models.RoomsGetResponse{Rooms: out}, nil
 }
 
-// roomLastMessage resolves one room's latest NON-deleted message at read time.
-// ok=false means drop the room (empty, all-deleted within the walk cap, or a read
-// failure). Walks backward from lastMsgAt in pages, skipping soft-deleted messages.
-func (s *HistoryService) roomLastMessage(ctx context.Context, roomID string, now time.Time) (models.LastMessage, bool) {
+// roomLastMessage resolves one room's latest eligible message at read time.
+// ok=false means drop the room (empty, all-ineligible within the walk cap, or a read
+// failure). Walks backward from lastMsgAt in pages, skipping ineligible messages.
+func (s *HistoryService) roomLastMessage(ctx context.Context, roomID string, now time.Time) (models.PreviewMessage, bool) {
 	lastMsgAt, createdAt, err := s.resolveRoomTimesOrError(ctx, roomID, nil, now)
 	if err != nil {
 		slog.WarnContext(ctx, "rooms.get room degraded", "room_id", roomID,
 			"request_id", natsutil.RequestIDFromContext(ctx), "error", err)
-		return models.LastMessage{}, false
+		return models.PreviewMessage{}, false
 	}
 
 	pageReq, err := parsePageRequest("", lastMsgWalkPageSize)
 	if err != nil {
-		return models.LastMessage{}, false
+		return models.PreviewMessage{}, false
 	}
 	ceiling, floor := s.walkBounds(lastMsgAt, createdAt, now)
 	before := ceiling.Add(time.Millisecond)
@@ -88,10 +89,10 @@ func (s *HistoryService) roomLastMessage(ctx context.Context, roomID string, now
 		if err != nil {
 			slog.WarnContext(ctx, "rooms.get latest-message read degraded", "room_id", roomID,
 				"request_id", natsutil.RequestIDFromContext(ctx), "error", err)
-			return models.LastMessage{}, false
+			return models.PreviewMessage{}, false
 		}
 		if len(page.Data) == 0 {
-			return models.LastMessage{}, false // room empty or floor reached
+			return models.PreviewMessage{}, false // room empty or floor reached
 		}
 		for i := range page.Data {
 			m := page.Data[i]
@@ -100,22 +101,47 @@ func (s *HistoryService) roomLastMessage(ctx context.Context, roomID string, now
 			if m.Deleted || m.Type != "" || m.QuotedParentMessage != nil {
 				continue
 			}
-			return models.LastMessage{
-				MessageID: m.MessageID,
-				Sender:    m.Sender,
-				Content:   previewContent(m.Msg),
-				CreatedAt: m.CreatedAt.UTC().UnixMilli(),
-			}, true
+			return s.toPreviewMessage(ctx, &m), true
 		}
 		// Whole page ineligible (deleted/system/quoted). A short page means the walk
 		// is exhausted (no older messages) — stop. Otherwise page again strictly
 		// before the oldest one seen.
 		if len(page.Data) < lastMsgWalkPageSize {
-			return models.LastMessage{}, false
+			return models.PreviewMessage{}, false
 		}
 		before = page.Data[len(page.Data)-1].CreatedAt
 	}
-	return models.LastMessage{}, false // deleted tail longer than the walk cap
+	return models.PreviewMessage{}, false // ineligible tail longer than the walk cap
+}
+
+// toPreviewMessage enriches an eligible message into the room-list preview: sender and
+// mentions become wire Participants (chineseName from the Cassandra company_name), a bot
+// sender's displayName is its app name, and attachments/visibleTo pass through the
+// projection the walk already read.
+func (s *HistoryService) toPreviewMessage(ctx context.Context, m *models.Message) models.PreviewMessage {
+	// The walk reads raw attachment blobs; other read paths decode via
+	// setDecodedAttachments, so decode this one message before mapping.
+	decodeMessageAttachments(ctx, m)
+	sender := toWireParticipant(&m.Sender)
+	sender.DisplayName = s.botAwareDisplayName(ctx, m.Sender.EngName, m.Sender.CompanyName, m.Sender.Account)
+
+	var mentions []pkgmodel.Participant
+	if len(m.Mentions) > 0 {
+		mentions = make([]pkgmodel.Participant, len(m.Mentions))
+		for i := range m.Mentions {
+			mentions[i] = toWireParticipant(&m.Mentions[i])
+		}
+	}
+
+	return models.PreviewMessage{
+		MessageID:   m.MessageID,
+		Sender:      sender,
+		Content:     previewContent(m.Msg),
+		CreatedAt:   m.CreatedAt.UTC().UnixMilli(),
+		Attachments: m.DecodedAttachments,
+		Mentions:    mentions,
+		VisibleTo:   m.VisibleTo,
+	}
 }
 
 // previewContent trims a message body to a rune-bounded room-list snippet.

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -95,7 +95,9 @@ func (s *HistoryService) roomLastMessage(ctx context.Context, roomID string, now
 		}
 		for i := range page.Data {
 			m := page.Data[i]
-			if m.Deleted {
+			// System messages and quoted replies aren't representative room content —
+			// skip to the previous eligible message, same as a deleted one.
+			if m.Deleted || m.Type != "" || m.QuotedParentMessage != nil {
 				continue
 			}
 			return models.LastMessage{

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -136,7 +136,7 @@ func (s *HistoryService) toPreviewMessage(ctx context.Context, m *models.Message
 		MessageID:   m.MessageID,
 		Sender:      sender,
 		Content:     m.Msg,
-		CreatedAt:   m.CreatedAt.UTC().UnixMilli(),
+		CreatedAt:   m.CreatedAt.UTC(),
 		Attachments: m.DecodedAttachments,
 		Mentions:    mentions,
 		VisibleTo:   m.VisibleTo,

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -14,11 +14,10 @@ import (
 )
 
 const (
-	maxRoomsGetBatch        = 100 // mirrors maxGetByIDsBatchSize
-	maxRoomsGetConcurrency  = 16  // mirrors cassrepo.maxConcurrentIDReads
-	lastMessagePreviewRunes = 256 // room-list snippet cap
-	lastMsgWalkPageSize     = 50  // messages scanned per walk-back page
-	lastMsgWalkMaxPages     = 5   // ponytail: cap the ineligible-tail walk; a room with >250 trailing ineligible messages just shows no last message
+	maxRoomsGetBatch       = 100 // mirrors maxGetByIDsBatchSize
+	maxRoomsGetConcurrency = 16  // mirrors cassrepo.maxConcurrentIDReads
+	lastMsgWalkPageSize    = 50  // messages scanned per walk-back page
+	lastMsgWalkMaxPages    = 5   // ponytail: cap the ineligible-tail walk; a room with >250 trailing ineligible messages just shows no last message
 )
 
 // RoomsGet handles chat.server.request.history.{siteID}.rooms.get: for each requested
@@ -136,24 +135,12 @@ func (s *HistoryService) toPreviewMessage(ctx context.Context, m *models.Message
 	return models.PreviewMessage{
 		MessageID:   m.MessageID,
 		Sender:      sender,
-		Content:     previewContent(m.Msg),
+		Content:     m.Msg,
 		CreatedAt:   m.CreatedAt.UTC().UnixMilli(),
 		Attachments: m.DecodedAttachments,
 		Mentions:    mentions,
 		VisibleTo:   m.VisibleTo,
 	}
-}
-
-// previewContent trims a message body to a rune-bounded room-list snippet.
-func previewContent(msg string) string {
-	if len(msg) <= lastMessagePreviewRunes {
-		return msg // bytes ≤ cap ⇒ runes ≤ cap; no alloc on the common short case
-	}
-	r := []rune(msg)
-	if len(r) <= lastMessagePreviewRunes {
-		return msg
-	}
-	return string(r[:lastMessagePreviewRunes])
 }
 
 // dedupRoomIDs removes duplicate roomIds, preserving first-seen order.

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -61,10 +61,7 @@ var roomLastMsgAt = time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
 var roomCreatedAt = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
 // Mirror the production caps (house pattern — see maxGetByIDsBatchSize in messages_test).
-const (
-	roomsGetMaxBatch     = 100
-	roomsGetPreviewRunes = 256
-)
+const roomsGetMaxBatch = 100
 
 func TestHistoryService_RoomsGet_LatestMessage(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
@@ -164,9 +161,10 @@ func TestHistoryService_RoomsGet_DedupsRoomIDs(t *testing.T) {
 	assert.Len(t, resp.Rooms, 1)
 }
 
-func TestHistoryService_RoomsGet_ContentPreviewTrimmed(t *testing.T) {
+// Content is returned in full — the client truncates for display.
+func TestHistoryService_RoomsGet_FullContent(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
-	long := strings.Repeat("世", 1000) // 1000 runes, well over the preview cap
+	long := strings.Repeat("世", 1000)
 
 	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
@@ -175,8 +173,7 @@ func TestHistoryService_RoomsGet_ContentPreviewTrimmed(t *testing.T) {
 	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
 	require.NoError(t, err)
 	require.Contains(t, resp.Rooms, "r1")
-	assert.LessOrEqual(t, len([]rune(resp.Rooms["r1"].Content)), roomsGetPreviewRunes)
-	assert.NotEmpty(t, resp.Rooms["r1"].Content)
+	assert.Equal(t, long, resp.Rooms["r1"].Content)
 }
 
 // Latest message is a system message → walk back to the first non-system, non-quoted survivor.

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -1,6 +1,7 @@
 package service_test
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/hmchangw/chat/history-service/internal/models"
 	"github.com/hmchangw/chat/history-service/internal/service"
 	"github.com/hmchangw/chat/history-service/internal/service/mocks"
+	"github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/pkg/natsrouter"
 )
 
@@ -32,6 +34,23 @@ func newRoomsService(t *testing.T) (*service.HistoryService, *mocks.MockMessageR
 	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true}
 	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg)
 	return svc, msgs, rooms
+}
+
+// newRoomsServiceWithApps also exposes the AppStore mock, needed by the preview
+// enrichment tests (bot sender → app name).
+func newRoomsServiceWithApps(t *testing.T) (*service.HistoryService, *mocks.MockMessageRepository, *mocks.MockRoomRepository, *mocks.MockAppStore) {
+	ctrl := gomock.NewController(t)
+	msgs := mocks.NewMockMessageRepository(ctrl)
+	subs := mocks.NewMockSubscriptionRepository(ctrl)
+	rooms := mocks.NewMockRoomRepository(ctrl)
+	pub := mocks.NewMockEventPublisher(ctrl)
+	threadRooms := mocks.NewMockThreadRoomRepository(ctrl)
+	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
+	users := mocks.NewMockUserStore(ctrl)
+	apps := mocks.NewMockAppStore(ctrl)
+	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true}
+	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg)
+	return svc, msgs, rooms, apps
 }
 
 func roomsCtx() *natsrouter.Context {
@@ -241,4 +260,78 @@ func TestHistoryService_RoomsGet_TooManyRoomIDs(t *testing.T) {
 	}
 	_, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: ids})
 	assertBadRequestErr(t, err, "too many roomIds")
+}
+
+// Preview enrichment: attachments, mentions (wire Participants), and visibleTo are
+// carried; a non-bot sender's chineseName comes from the Cassandra company_name and no
+// app lookup happens.
+func TestHistoryService_RoomsGet_EnrichesPreview(t *testing.T) {
+	svc, msgs, rooms, apps := newRoomsServiceWithApps(t)
+	apps.EXPECT().AppNameByAccount(gomock.Any(), gomock.Any()).Times(0) // no bot → no lookup
+
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{
+			MessageID:   "m1",
+			RoomID:      "r1",
+			Msg:         "hi",
+			CreatedAt:   roomLastMsgAt,
+			Sender:      models.Participant{ID: "u1", Account: "alice", EngName: "Alice", CompanyName: "愛麗絲"},
+			Attachments: cassandra.EncodeAttachments([]cassandra.Attachment{{ID: "f1", Title: "a.png", Type: "file"}}),
+			Mentions:    []models.Participant{{ID: "u2", Account: "bob", CompanyName: "小明"}},
+			VisibleTo:   "u1",
+		}}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "r1")
+	pm := resp.Rooms["r1"]
+	assert.Equal(t, "愛麗絲", pm.Sender.ChineseName)       // company_name → chineseName
+	assert.Equal(t, "Alice 愛麗絲", pm.Sender.DisplayName) // composed, not a bot
+	assert.Equal(t, "u1", pm.Sender.UserID)
+	require.Len(t, pm.Attachments, 1)
+	assert.Equal(t, "a.png", pm.Attachments[0].Title)
+	require.Len(t, pm.Mentions, 1)
+	assert.Equal(t, "bob", pm.Mentions[0].Account)
+	assert.Equal(t, "小明", pm.Mentions[0].ChineseName)
+	assert.Equal(t, "u1", pm.VisibleTo)
+}
+
+// A bot sender's displayName is its app name (mirrors the reaction actor path).
+func TestHistoryService_RoomsGet_BotSenderAppName(t *testing.T) {
+	svc, msgs, rooms, apps := newRoomsServiceWithApps(t)
+	apps.EXPECT().AppNameByAccount(gomock.Any(), "acme.bot").Return("Acme Assistant", nil)
+
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{
+			MessageID: "m1", RoomID: "r1", Msg: "beep", CreatedAt: roomLastMsgAt,
+			Sender: models.Participant{ID: "b1", Account: "acme.bot", EngName: "acme"},
+		}}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "r1")
+	assert.Equal(t, "Acme Assistant", resp.Rooms["r1"].Sender.DisplayName)
+}
+
+// Empty attachments/mentions serialize away (omitempty) — no [] noise in the preview.
+func TestHistoryService_RoomsGet_EmptyCollectionsOmitted(t *testing.T) {
+	svc, msgs, rooms, _ := newRoomsServiceWithApps(t)
+
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt, Sender: models.Participant{Account: "alice"}}}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	pm := resp.Rooms["r1"]
+	assert.Nil(t, pm.Attachments)
+	assert.Nil(t, pm.Mentions)
+
+	data, err := json.Marshal(pm)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "attachments")
+	assert.NotContains(t, string(data), "mentions")
+	assert.NotContains(t, string(data), "visibleTo")
 }

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -160,6 +160,73 @@ func TestHistoryService_RoomsGet_ContentPreviewTrimmed(t *testing.T) {
 	assert.NotEmpty(t, resp.Rooms["r1"].Content)
 }
 
+// Latest message is a system message → walk back to the first non-system, non-quoted survivor.
+func TestHistoryService_RoomsGet_SkipsSystemTail(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{
+			{MessageID: "m2", RoomID: "r1", Type: "call_ended", CreatedAt: roomLastMsgAt},
+			{MessageID: "m1", RoomID: "r1", Msg: "alive", CreatedAt: roomLastMsgAt.Add(-time.Minute)},
+		}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "r1")
+	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
+}
+
+// Latest message quotes another message → walk back to the first non-quoted survivor.
+func TestHistoryService_RoomsGet_SkipsQuotedTail(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{
+			{MessageID: "m2", RoomID: "r1", Msg: "re: x", QuotedParentMessage: &models.QuotedParentMessage{MessageID: "m0"}, CreatedAt: roomLastMsgAt},
+			{MessageID: "m1", RoomID: "r1", Msg: "alive", CreatedAt: roomLastMsgAt.Add(-time.Minute)},
+		}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "r1")
+	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
+}
+
+// Mixed tail: system + quoted + deleted before a real message → returns the real one.
+func TestHistoryService_RoomsGet_MixedTailSkipsAllIneligible(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{
+			{MessageID: "m4", RoomID: "r1", Type: "call_started", CreatedAt: roomLastMsgAt},
+			{MessageID: "m3", RoomID: "r1", QuotedParentMessage: &models.QuotedParentMessage{MessageID: "m0"}, CreatedAt: roomLastMsgAt.Add(-time.Minute)},
+			{MessageID: "m2", RoomID: "r1", Deleted: true, CreatedAt: roomLastMsgAt.Add(-2 * time.Minute)},
+			{MessageID: "m1", RoomID: "r1", Msg: "alive", CreatedAt: roomLastMsgAt.Add(-3 * time.Minute)},
+		}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "r1")
+	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
+}
+
+// A normal message (no type, no quote, not deleted) is returned as-is.
+func TestHistoryService_RoomsGet_NormalMessageUnaffected(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt}}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "r1")
+	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
+}
+
 func TestHistoryService_RoomsGet_EmptyRoomIDs(t *testing.T) {
 	svc, _, _ := newRoomsService(t)
 	_, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: nil})

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -77,7 +77,7 @@ func TestHistoryService_RoomsGet_LatestMessage(t *testing.T) {
 	assert.Equal(t, "m1", lm.MessageID)
 	assert.Equal(t, "hello", lm.Content)
 	assert.Equal(t, "alice", lm.Sender.Account)
-	assert.Equal(t, roomLastMsgAt.UnixMilli(), lm.CreatedAt)
+	assert.Equal(t, roomLastMsgAt.UTC(), lm.CreatedAt)
 }
 
 func TestHistoryService_RoomsGet_EmptyRoomOmitted(t *testing.T) {

--- a/pkg/model/message.go
+++ b/pkg/model/message.go
@@ -98,19 +98,27 @@ type RoomsGetRequest struct {
 	RoomIDs []string `json:"roomIds"`
 }
 
-// LastMessage is a room's most-recent NON-deleted message, resolved at read time.
-// Content is preview-trimmed. Shared wire type: history-service's rooms.get RPC
-// produces it, user-service's subscription.list embeds it (SubscriptionRoom.LastMessage).
-type LastMessage struct {
-	MessageID string                `json:"messageId"`
-	Sender    cassandra.Participant `json:"sender"`
-	Content   string                `json:"content"`
-	CreatedAt int64                 `json:"createdAt"` // UTC millis
+// PreviewMessage is a room's most-recent eligible message, resolved at read time and
+// enriched for the room-list preview. Content is preview-trimmed; sender/mentions carry
+// render-ready wire Participants (a bot sender's displayName is its app name). Shared
+// wire type: history-service's rooms.get RPC produces it, user-service's
+// subscription.list embeds it (SubscriptionRoom.LastMessage).
+type PreviewMessage struct {
+	MessageID   string                 `json:"messageId"`
+	Sender      Participant            `json:"sender"`
+	Content     string                 `json:"content"`
+	CreatedAt   int64                  `json:"createdAt"` // UTC millis
+	Attachments []cassandra.Attachment `json:"attachments,omitempty"`
+	Mentions    []Participant          `json:"mentions,omitempty"`
+	// VisibleTo is surfaced now; its write-path (populating the column) is a separate
+	// follow-up, so it's empty until that lands.
+	VisibleTo string `json:"visibleTo,omitempty"`
+	// TODO(#106): forwardSource — wired after the Forwarded snapshot merges.
 }
 
 // RoomsGetResponse maps each requested roomId that has a resolvable last message to
-// it. Rooms with no non-deleted message, or that degraded, are omitted (best-effort)
+// it. Rooms with no eligible message, or that degraded, are omitted (best-effort)
 // rather than failing the whole batch.
 type RoomsGetResponse struct {
-	Rooms map[string]LastMessage `json:"rooms"`
+	Rooms map[string]PreviewMessage `json:"rooms"`
 }

--- a/pkg/model/message.go
+++ b/pkg/model/message.go
@@ -99,10 +99,10 @@ type RoomsGetRequest struct {
 }
 
 // PreviewMessage is a room's most-recent eligible message, resolved at read time and
-// enriched for the room-list preview. Content is preview-trimmed; sender/mentions carry
-// render-ready wire Participants (a bot sender's displayName is its app name). Shared
-// wire type: history-service's rooms.get RPC produces it, user-service's
-// subscription.list embeds it (SubscriptionRoom.LastMessage).
+// enriched for the room-list preview. Content is the full message body; the client
+// truncates for display. Sender/mentions carry render-ready wire Participants (a bot
+// sender's displayName is its app name). Shared wire type: history-service's rooms.get
+// RPC produces it, user-service's subscription.list embeds it (SubscriptionRoom.LastMessage).
 type PreviewMessage struct {
 	MessageID   string                 `json:"messageId"`
 	Sender      Participant            `json:"sender"`

--- a/pkg/model/message.go
+++ b/pkg/model/message.go
@@ -102,12 +102,12 @@ type RoomsGetRequest struct {
 // enriched for the room-list preview. Content is the full message body; the client
 // truncates for display. Sender/mentions carry render-ready wire Participants (a bot
 // sender's displayName is its app name). Shared wire type: history-service's rooms.get
-// RPC produces it, user-service's subscription.list embeds it (SubscriptionRoom.LastMessage).
+// RPC produces it, user-service's subscription.list embeds it (SubscriptionRoom.PreviewMessage).
 type PreviewMessage struct {
 	MessageID   string                 `json:"messageId"`
 	Sender      Participant            `json:"sender"`
 	Content     string                 `json:"content"`
-	CreatedAt   int64                  `json:"createdAt"` // UTC millis
+	CreatedAt   time.Time              `json:"createdAt"`
 	Attachments []cassandra.Attachment `json:"attachments,omitempty"`
 	Mentions    []Participant          `json:"mentions,omitempty"`
 	// VisibleTo is surfaced now; its write-path (populating the column) is a separate

--- a/pkg/model/subscription.go
+++ b/pkg/model/subscription.go
@@ -120,7 +120,7 @@ type SubscriptionRoom struct {
 	// LastMessage is resolved at read time via history-service's rooms.get RPC
 	// (A2 — no denormalized write path). Omitted when the room has no message,
 	// the enriching site RPC degraded, or the room is soft-deleted (Room==nil).
-	LastMessage *PreviewMessage `json:"lastMessage,omitempty" bson:"-"`
+	PreviewMessage *PreviewMessage `json:"previewMessage,omitempty" bson:"-"`
 }
 
 // SubscriptionHRInfo carries the counterpart's HR-directory record on a DM subscription for sidebar/header rendering.

--- a/pkg/model/subscription.go
+++ b/pkg/model/subscription.go
@@ -120,7 +120,7 @@ type SubscriptionRoom struct {
 	// LastMessage is resolved at read time via history-service's rooms.get RPC
 	// (A2 — no denormalized write path). Omitted when the room has no message,
 	// the enriching site RPC degraded, or the room is soft-deleted (Room==nil).
-	LastMessage *LastMessage `json:"lastMessage,omitempty" bson:"-"`
+	LastMessage *PreviewMessage `json:"lastMessage,omitempty" bson:"-"`
 }
 
 // SubscriptionHRInfo carries the counterpart's HR-directory record on a DM subscription for sidebar/header rendering.

--- a/user-service/historyclient/client.go
+++ b/user-service/historyclient/client.go
@@ -52,7 +52,7 @@ func (c *Client) GetThreadList(ctx context.Context, siteID string, req model.Thr
 // the resolvable last message for each requested room; rooms with no message, or
 // that degraded, are simply absent from the map (mirrors the server's own
 // per-room best-effort degrade).
-func (c *Client) RoomsGet(ctx context.Context, siteID string, roomIDs []string) (map[string]model.LastMessage, error) {
+func (c *Client) RoomsGet(ctx context.Context, siteID string, roomIDs []string) (map[string]model.PreviewMessage, error) {
 	body, err := json.Marshal(model.RoomsGetRequest{RoomIDs: roomIDs})
 	if err != nil {
 		return nil, fmt.Errorf("marshal rooms-get request: %w", err)

--- a/user-service/service/mocks/mock_repository.go
+++ b/user-service/service/mocks/mock_repository.go
@@ -468,10 +468,10 @@ func (mr *MockHistoryClientMockRecorder) GetThreadList(ctx, siteID, req any) *go
 }
 
 // RoomsGet mocks base method.
-func (m *MockHistoryClient) RoomsGet(ctx context.Context, siteID string, roomIDs []string) (map[string]model.LastMessage, error) {
+func (m *MockHistoryClient) RoomsGet(ctx context.Context, siteID string, roomIDs []string) (map[string]model.PreviewMessage, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RoomsGet", ctx, siteID, roomIDs)
-	ret0, _ := ret[0].(map[string]model.LastMessage)
+	ret0, _ := ret[0].(map[string]model.PreviewMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/user-service/service/service.go
+++ b/user-service/service/service.go
@@ -61,7 +61,7 @@ type ThreadSubscriptionRepository interface {
 // RPCs, fanned out across sites by the thread-inbox aggregator.
 type HistoryClient interface {
 	GetThreadList(ctx context.Context, siteID string, req model.ThreadSubscriptionListRequest) (model.ThreadSubscriptionListResponse, error)
-	RoomsGet(ctx context.Context, siteID string, roomIDs []string) (map[string]model.LastMessage, error)
+	RoomsGet(ctx context.Context, siteID string, roomIDs []string) (map[string]model.PreviewMessage, error)
 }
 
 // PresenceClient is the consumer-defined interface for user-presence-service RPC calls.

--- a/user-service/service/subscriptions.go
+++ b/user-service/service/subscriptions.go
@@ -336,7 +336,7 @@ func (s *UserService) enrichLastMessage(c *natsrouter.Context, subs []model.Enri
 	for site := range idxBySite {
 		sites = append(sites, site)
 	}
-	lastMsgBySite := make([]map[string]model.LastMessage, len(sites)) // nil ⇒ site degraded
+	lastMsgBySite := make([]map[string]model.PreviewMessage, len(sites)) // nil ⇒ site degraded
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, maxSiteFanout)
 	for i, site := range sites {

--- a/user-service/service/subscriptions.go
+++ b/user-service/service/subscriptions.go
@@ -325,12 +325,12 @@ func (s *UserService) enrichCrossSite(c *natsrouter.Context, subs []model.Enrich
 	return dropped
 }
 
-// enrichLastMessage populates sub.Room.LastMessage (read-time resolve, no denormalized
+// enrichLastMessage populates sub.Room.PreviewMessage (read-time resolve, no denormalized
 // write path) via one rooms.get RPC per site — LOCAL subs need it too (last-message
 // isn't part of the $lookup baseline). One call per site: a subscription page is
 // bounded well under history-service's 100-roomId batch cap, so no chunk-split is
 // needed. Reuses the caller's per-site grouping. A degraded/absent site, or a room the
-// RPC omits, just leaves LastMessage nil; it never fails the list.
+// RPC omits, just leaves PreviewMessage nil; it never fails the list.
 func (s *UserService) enrichLastMessage(c *natsrouter.Context, subs []model.EnrichedSubscription, idxBySite map[string][]int, roomIDsBySite map[string][]string) {
 	sites := make([]string, 0, len(idxBySite))
 	for site := range idxBySite {
@@ -374,7 +374,7 @@ func (s *UserService) enrichLastMessage(c *natsrouter.Context, subs []model.Enri
 			if !ok {
 				continue
 			}
-			subs[j].Room.LastMessage = &lm
+			subs[j].Room.PreviewMessage = &lm
 		}
 	}
 }

--- a/user-service/service/subscriptions_test.go
+++ b/user-service/service/subscriptions_test.go
@@ -1006,14 +1006,14 @@ func TestListSubscriptions_LastMessage_Populated(t *testing.T) {
 	subs.EXPECT().AggregateSubscriptions(gomock.Any(), "alice", "current", false, gomock.Any(), gomock.Any()).
 		Return(mongoutil.OffsetPageHasMore[model.EnrichedSubscription]{Data: storeSubs}, nil)
 	history.EXPECT().RoomsGet(gomock.Any(), "site-a", []string{"r1"}).
-		Return(map[string]model.PreviewMessage{"r1": {MessageID: "m9", Content: "hi", CreatedAt: 123}}, nil)
+		Return(map[string]model.PreviewMessage{"r1": {MessageID: "m9", Content: "hi", CreatedAt: time.Unix(123, 0).UTC()}}, nil)
 	resp, err := svc.ListSubscriptions(ctx("alice", "site-a"), models.SubscriptionListRequest{Type: "current"})
 	require.NoError(t, err)
 	require.Len(t, resp.Subscriptions, 1)
 	room := resp.Subscriptions[0].Base().Room
 	require.NotNil(t, room)
-	require.NotNil(t, room.LastMessage, "last message attached from rooms.get")
-	assert.Equal(t, "m9", room.LastMessage.MessageID)
+	require.NotNil(t, room.PreviewMessage, "last message attached from rooms.get")
+	assert.Equal(t, "m9", room.PreviewMessage.MessageID)
 }
 
 // includeLastMessage:false skips the rooms.get RPC entirely.
@@ -1032,7 +1032,7 @@ func TestListSubscriptions_LastMessage_SkippedWhenExcluded(t *testing.T) {
 	require.Len(t, resp.Subscriptions, 1)
 	room := resp.Subscriptions[0].Base().Room
 	require.NotNil(t, room)
-	assert.Nil(t, room.LastMessage, "excluded last message stays nil")
+	assert.Nil(t, room.PreviewMessage, "excluded last message stays nil")
 }
 
 func TestListSubscriptions_LastMessage_SiteDegrades(t *testing.T) {
@@ -1050,5 +1050,5 @@ func TestListSubscriptions_LastMessage_SiteDegrades(t *testing.T) {
 	require.Len(t, resp.Subscriptions, 1)
 	room := resp.Subscriptions[0].Base().Room
 	require.NotNil(t, room)
-	assert.Nil(t, room.LastMessage, "degraded site leaves LastMessage nil")
+	assert.Nil(t, room.PreviewMessage, "degraded site leaves LastMessage nil")
 }

--- a/user-service/service/subscriptions_test.go
+++ b/user-service/service/subscriptions_test.go
@@ -1006,7 +1006,7 @@ func TestListSubscriptions_LastMessage_Populated(t *testing.T) {
 	subs.EXPECT().AggregateSubscriptions(gomock.Any(), "alice", "current", false, gomock.Any(), gomock.Any()).
 		Return(mongoutil.OffsetPageHasMore[model.EnrichedSubscription]{Data: storeSubs}, nil)
 	history.EXPECT().RoomsGet(gomock.Any(), "site-a", []string{"r1"}).
-		Return(map[string]model.LastMessage{"r1": {MessageID: "m9", Content: "hi", CreatedAt: 123}}, nil)
+		Return(map[string]model.PreviewMessage{"r1": {MessageID: "m9", Content: "hi", CreatedAt: 123}}, nil)
 	resp, err := svc.ListSubscriptions(ctx("alice", "site-a"), models.SubscriptionListRequest{Type: "current"})
 	require.NoError(t, err)
 	require.Len(t, resp.Subscriptions, 1)


### PR DESCRIPTION
## Summary

Improves the room-list preview (`rooms.get` → `SubscriptionRoom.LastMessage`). Two parts:

- **#103 — filter.** The last-message walk now skips **system** and **quoted-reply** messages (previously only deleted), so a room's preview shows representative content, not a system event or a reply.
- **#110 — enrich.** Replaces the minimal `LastMessage` with a dedicated **`PreviewMessage`** carrying `attachments`, `mentions`, and `visibleTo`, plus a properly-enriched sender (chineseName from the Cassandra `company_name`; a **bot** sender shows its **app name**). `forwardSource` is deferred to a follow-up (rides the `Forwarded` snapshot from the forward feature).

## What's included

- **Filter:** `roomLastMessage` skip extended from `deleted` to `deleted || system (Type != "") || quoted (QuotedParentMessage != nil)`.
- **`PreviewMessage`** struct (`pkg/model`) + a `toPreviewMessage` mapper. Sender + mention display-name enrichment shares a new `botAwareDisplayName` helper extracted from the existing reactions path (no duplication).
- **Fix:** the rooms walk never decoded attachments (`setDecodedAttachments`, which every other read path calls), so raw attachment blobs would have surfaced empty — now decodes the eligible message before mapping (covered by the integration test).
- **Ripple:** `user-service` rooms.get map type; `docs/client-api.md` schema + example (doc-ratchet); design spec + plan under `docs/superpowers/`.

## Verification

- CI: lint / test / sast + integration (`history-service`, `pkg/model`, `user-service`).
- Unit tests: filter (system/quoted/mixed/normal tails) + enrichment (attachments/mentions/visibleTo mapped, chineseName from `company_name`, bot→app name, normal sender unaffected, empty collections omit). Integration seeds raw-blob attachments and asserts they surface.

- **Wire-level (dev stack):** drove the real `rooms.get` (via `subscription.getChannels`) end-to-end at the NATS request/reply layer on our dev stack against a room whose latest message is a quoted reply — confirmed the preview resolves to the non-quoted survivor (system + quoted skipped), and the enriched fields (attachments/mentions/sender) surface on the wire.

Closes #103
Closes #110



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Room lists now provide enriched `previewMessage` data, including full content, sender details, attachments, mentions, and visibility information.
  * Preview selection excludes deleted, system, and quoted messages.
  * Bot sender names can display the associated app name.

* **Documentation**
  * Updated API documentation and examples to describe `previewMessage` and its eligibility rules.
  * Added design and implementation documentation for preview enrichment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->