### PR TITLE
Search: propagate delete/edit to ES, attachment/tcard search with render payloads

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -3751,6 +3751,8 @@ See [Error envelope](#6-error-envelope-reference).
 
 **Cross-site results:** results may include messages from rooms hosted on remote sites (the index is searched across the local and remote clusters). The `siteId` on each `SearchMessage` identifies the originating site; there is no client opt-in/opt-out.
 
+**Searched fields:** one query matches message text (`content`), attachment text (`attachmentText` — every attachment's file name and description pooled into one field), and tcard data (`cardData`, the card's data document indexed verbatim as text). All terms of the query must match within a single one of these fields (`multi_match` with `AND`) — a query mixing a word from the message text with a word from a filename matches neither field and returns no hit; a query mixing a filename word with a description word DOES match, since both live in `attachmentText`.
+
 ##### Request body
 
 ```json
@@ -3784,7 +3786,22 @@ See [Error envelope](#6-error-envelope-reference).
       "editedAt": "2026-04-01T12:05:00Z",
       "updatedAt": "2026-04-01T12:06:00Z",
       "threadParentMessageId": "p0",
-      "threadParentMessageCreatedAt": "2026-04-01T11:58:00Z"
+      "threadParentMessageCreatedAt": "2026-04-01T11:58:00Z",
+      "attachments": [
+        {
+          "id": "file-abc",
+          "title": "q3-report.pdf",
+          "type": "file",
+          "description": "Quarterly numbers",
+          "titleLink": "api/v1/file/rooms/r1/file/file-abc?drive_host=https://drive.example.com",
+          "titleLinkDownload": true,
+          "fileType": "application/pdf"
+        }
+      ],
+      "card": {
+        "template": "expense-approval-v1",
+        "data": "eyJhbW91bnQiOjQyfQ=="
+      }
     }
   ],
   "total": 42
@@ -3810,6 +3827,10 @@ See [Error envelope](#6-error-envelope-reference).
 | `updatedAt` | RFC3339 timestamp (nullable) | omitted when the message has never been mutated server-side (edit, soft-delete, etc.) |
 | `threadParentMessageId` | string | omitted when not a thread reply |
 | `threadParentMessageCreatedAt` | RFC3339 timestamp (nullable) | omitted when not a thread reply |
+| `attachments` | [Attachment](#attachment)[] | omitted when the message has no attachments |
+| `card` | [MessageCard](#messagecard) | omitted when the message carries no tcard |
+
+`attachments` and `card` are the message's payloads mirrored as-is from the index (same wire shape as history reads — decoded `Attachment` objects; `card.data` is base64-encoded bytes), so the client can render a hit (file row, tcard) without a follow-up history-service load.
 
 Display fields (user name, room name) are intentionally NOT carried in the response. Clients resolve them via their own subscription cache, subscription enrichment (HRInfo), or [profile.getByName](#profilegetbyname) (§3.4).
 
@@ -7013,7 +7034,7 @@ Attachments are rejected as `unknown_field` — bots send text and cards only.
 | 403 | `forbidden` | `not_a_room_member` | Bot has no subscription to `roomID`. |
 | 404 | `not_found` | `room_not_found` | Room disappeared between subscription lookup and forward. |
 | 409 | `conflict` | `in_flight` | Duplicate op detected inside the idempotency window. |
-| 429 | `resource_exhausted` | `rate_limited_caller` \| `rate_limited_global` | Per-caller or global RPM cap exceeded. |
+| 429 | `too_many_requests` | `rate_limited_caller` \| `rate_limited_global` | Per-caller or global RPM cap exceeded. |
 | 503 | `unavailable` | `handler_timeout` | Downstream NATS request timed out (3 s budget). |
 
 ---

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -1207,7 +1207,8 @@ search-service on that site.
 **Reply:** auto-generated `_INBOX.>` (NATS request/reply)
 
 Full-text message search. Auto-scoped to rooms the user is a member of. May include
-messages from remote sites.
+messages from remote sites. One query matches message text, attachment text (file
+names + descriptions, pooled into one searched field), and tcard data.
 
 > **Breaking change (v2):** Response changed from `{total, results}` to `{messages, total}`.
 > The `results` field no longer exists.
@@ -1228,10 +1229,17 @@ messages from remote sites.
 | `messages` | SearchMessage[] | Per-hit projection. |
 | `total` | integer | Total matching hits (may exceed `messages.length`). |
 
+All terms of the query must match within a single searched field (`multi_match`
+with `AND`) — terms split across e.g. message text and a filename match nothing.
+
 `SearchMessage` fields: `messageId`, `roomId`, `siteId`, `userAccount`, `content`,
 `createdAt`, `editedAt` (nullable), `updatedAt` (nullable), `threadParentMessageId`
-(omitted when not a reply), `threadParentMessageCreatedAt` (omitted when not a reply).
-All sourced from ES — no Mongo round-trip.
+(omitted when not a reply), `threadParentMessageCreatedAt` (omitted when not a reply),
+`attachments` (`Attachment[]`, omitted when the message has no attachments),
+`card` (`MessageCard`, omitted when the message carries no tcard).
+All sourced from ES — no Mongo round-trip. `attachments`/`card` mirror the message
+payloads as-is (same wire shape as history reads) so hits render without a follow-up
+history load.
 
 #### Errors
 

--- a/docs/superpowers/plans/2026-07-21-search-delete-tcard-file.md
+++ b/docs/superpowers/plans/2026-07-21-search-delete-tcard-file.md
@@ -1,0 +1,842 @@
+# Search delete/edit correctness + tcard & file search — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> Spec: `docs/superpowers/specs/2026-07-21-search-delete-tcard-file-design.md` (binding).
+> This plan targets the spec's FINAL design (verbatim `cardData`; no reconcile tooling —
+> see Task 5's removal note). The branch already implements it; the plan doubles as the
+> audit reference — compare shipped code against each task.
+
+**Goal:** Deleted/edited messages propagate to Elasticsearch, and file-attachment + tcard data become searchable — with zero RPC/API flow changes.
+
+**Architecture:** Event-driven, three seams: `history-service` enriches the `.updated` canonical events it already publishes; `search-sync-worker` maps canonical events to externally-versioned ES actions (full-replace on create/update, delete on delete, skip slim events) and indexes the new fields; `search-service` widens its `multi_match` and returns render payloads on hits.
+
+**Tech Stack:** Go 1.25, NATS JetStream, Elasticsearch via `pkg/searchengine`, `go.uber.org/mock`, testify, testcontainers via `pkg/testutil`.
+
+## Global Constraints
+
+- TDD Red-Green-Refactor for every behavior change; run tests via `make test SERVICE=<name>` (race detector included) — never raw `go` commands. Sole exception: coverage runs use raw `go test -coverprofile` per CLAUDE.md §Coverage (the wrapper has no coverage mode).
+- No RPC/API contract changes; every `SearchMessage` addition is `omitempty` (additive).
+- Integration tests: `//go:build integration`, containers from `pkg/testutil`, per-test isolation.
+- Errors wrapped with context (`fmt.Errorf("…: %w", err)`); `log/slog` JSON only; never log message/card bodies.
+- ES ordering invariant: every index/delete action carries `evt.Timestamp` as external version (spec "Ordering invariant").
+- Client-facing response changes must update `docs/client-api.md` + `docs/client-api/request-reply.md` in the same PR (CLAUDE.md rule).
+- Branch `claude/search-deletion-tcard-file-dwnnnk`; commit per task; push with `git push -u origin <branch>`.
+
+---
+
+### Task 1: search-sync-worker — event allowlist + attachment/card ES fields
+
+**Files:**
+- Modify: `search-sync-worker/messages.go` (BuildAction skip logic ~line 91; `MessageSearchIndex` ~line 129; `newMessageSearchIndex` ~line 145)
+- Test: `search-sync-worker/messages_test.go`
+- Test (integration): `search-sync-worker/integration_test.go`, `search-sync-worker/testdata/events.json`
+
+**Interfaces:**
+- Consumes: `model.MessageEvent` (`pkg/model/event.go:30`), `cassandra.DecodeAttachments(raw [][]byte) ([]Attachment, int)` (`pkg/model/cassandra/attachment.go:48`), `cassandra.Card{Template string, Data []byte}`.
+- Produces (Task 4 depends on these exact JSON names): searched ES doc fields `attachmentText` (one string: titles + descriptions joined), `cardData` (`text,custom_analyzer`); render-only fields `attachments` (full `Attachment` objects) and `card` (template + data), both `object`/`enabled:false`; helper `actionableEvent(e model.EventType) bool`.
+
+- [ ] **Step 1: Write the failing tests** (append to `messages_test.go`; add `"github.com/hmchangw/chat/pkg/model/cassandra"` to imports)
+
+```go
+// Slim events (no content) must never take the full-doc-replace upsert path:
+// a pinned/unpinned event would wipe content (and attachment/card fields) from
+// the indexed document, and an unpin after delete would resurrect a stub doc.
+func TestMessageCollection_BuildAction_SlimEventsSkipped(t *testing.T) {
+	coll := newMessageCollection("msgs-v1", time.Time{}, false)
+
+	mkEvent := func(eventType model.EventType) []byte {
+		evt := model.MessageEvent{
+			Event: eventType,
+			Message: model.Message{
+				ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+				CreatedAt: time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
+			},
+			SiteID: "site-a", Timestamp: 100,
+		}
+		data, err := json.Marshal(evt)
+		require.NoError(t, err)
+		return data
+	}
+
+	tests := []struct {
+		name  string
+		event model.EventType
+	}{
+		{"pinned skipped", model.EventPinned},
+		{"unpinned skipped", model.EventUnpinned},
+		{"thread_reply_added skipped", model.EventThreadReplyAdded},
+		{"unknown future type skipped", model.EventType("archived")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actions, err := coll.BuildAction(mkEvent(tt.event))
+			require.NoError(t, err)
+			assert.Empty(t, actions, "event %q must not produce an ES action", tt.event)
+		})
+	}
+}
+
+func TestBuildDocument_AttachmentFields(t *testing.T) {
+	ts := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	mkBlob := func(t *testing.T, a cassandra.Attachment) []byte {
+		b, err := json.Marshal(a)
+		require.NoError(t, err)
+		return b
+	}
+
+	t.Run("titles, descriptions and file types are indexed", func(t *testing.T) {
+		evt := &model.MessageEvent{
+			Event: model.EventCreated,
+			Message: model.Message{
+				ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+				Content: "see attached", CreatedAt: ts,
+				Attachments: [][]byte{
+					mkBlob(t, cassandra.Attachment{ID: "f1", Title: "q3-report.pdf", Description: "Quarterly numbers", FileType: "application/pdf"}),
+					mkBlob(t, cassandra.Attachment{ID: "f2", Title: "team.png", FileType: "image/png"}),
+				},
+			},
+			SiteID: "site-a", Timestamp: 100,
+		}
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal(buildDocument(evt), &doc))
+		assert.Equal(t, "q3-report.pdf Quarterly numbers team.png", doc["attachmentText"])
+		atts := doc["attachments"].([]any) // full objects ride along, render-only
+		require.Len(t, atts, 2)
+		assert.Equal(t, "q3-report.pdf", atts[0].(map[string]any)["title"])
+	})
+
+	t.Run("malformed blob is skipped, valid ones kept", func(t *testing.T) {
+		evt := &model.MessageEvent{
+			Event: model.EventCreated,
+			Message: model.Message{
+				ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+				Content: "x", CreatedAt: ts,
+				Attachments: [][]byte{
+					[]byte("{not json"),
+					mkBlob(t, cassandra.Attachment{ID: "f1", Title: "ok.txt", FileType: "text/plain"}),
+				},
+			},
+			SiteID: "site-a", Timestamp: 100,
+		}
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal(buildDocument(evt), &doc))
+		assert.Equal(t, "ok.txt", doc["attachmentText"])
+	})
+
+	t.Run("no attachments omits the fields", func(t *testing.T) {
+		evt := &model.MessageEvent{
+			Event: model.EventCreated,
+			Message: model.Message{
+				ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+				Content: "x", CreatedAt: ts,
+			},
+			SiteID: "site-a", Timestamp: 100,
+		}
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal(buildDocument(evt), &doc))
+		for _, key := range []string{"attachmentText", "attachments"} {
+			_, present := doc[key]
+			assert.False(t, present, "%s should be omitted when there are no attachments", key)
+		}
+	})
+}
+
+func TestBuildDocument_CardFields(t *testing.T) {
+	ts := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	t.Run("card template and stringified card data are indexed", func(t *testing.T) {
+		data := `{"type":"AdaptiveCard","body":[{"type":"TextBlock","text":"Expense request from Bob"},{"title":"Amount","value":"$120"}]}`
+		evt := &model.MessageEvent{
+			Event: model.EventCreated,
+			Message: model.Message{
+				ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+				CreatedAt: ts,
+				Card: &cassandra.Card{
+					Template: "expense-approval-v1",
+					Data:     []byte(data),
+				},
+				CardAction: &cassandra.CardAction{
+					Verb: "approve", Text: "Approve the expense", DisplayText: "Bob approved",
+				},
+			},
+			SiteID: "site-a", Timestamp: 100,
+		}
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal(buildDocument(evt), &doc))
+		assert.Equal(t, data, doc["cardData"], "card data is indexed verbatim as text")
+		card := doc["card"].(map[string]any) // full object rides along, render-only
+		assert.Equal(t, "expense-approval-v1", card["template"])
+	})
+
+	t.Run("no card omits the fields", func(t *testing.T) {
+		evt := &model.MessageEvent{
+			Event: model.EventCreated,
+			Message: model.Message{
+				ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+				Content: "x", CreatedAt: ts,
+			},
+			SiteID: "site-a", Timestamp: 100,
+		}
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal(buildDocument(evt), &doc))
+		for _, key := range []string{"card", "cardData"} {
+			_, present := doc[key]
+			assert.False(t, present, "%s should be omitted when there is no card", key)
+		}
+	})
+
+	t.Run("card with empty data indexes template only", func(t *testing.T) {
+		evt := &model.MessageEvent{
+			Event: model.EventCreated,
+			Message: model.Message{
+				ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+				CreatedAt: ts,
+				Card:      &cassandra.Card{Template: "welcome-v1"},
+			},
+			SiteID: "site-a", Timestamp: 100,
+		}
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal(buildDocument(evt), &doc))
+		assert.Equal(t, "welcome-v1", doc["card"].(map[string]any)["template"])
+		_, present := doc["cardData"]
+		assert.False(t, present, "empty card data should be omitted")
+	})
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `make test SERVICE=search-sync-worker`
+Expected: FAIL — SlimEventsSkipped subtests get 1 action instead of 0; `doc["attachmentText"]`/`doc["cardData"]` are `<nil>`.
+
+- [ ] **Step 3: Implement in `messages.go`**
+
+Replace the `EventReacted` skip in `BuildAction` with:
+
+```go
+	// Only full-content events may touch the index. Slim events (reacted,
+	// pinned, unpinned, thread_reply_added, and any future type) carry no
+	// content: letting them take the full-doc-replace upsert path would wipe
+	// content/attachment/card fields — and an unpin after a delete would
+	// resurrect a stub document. The unstamped "" event is the legacy replay
+	// form of created and stays indexable.
+	if !actionableEvent(evt.Event) {
+		return nil, nil
+	}
+```
+
+Add below the `--- Message-specific internals ---` marker:
+
+```go
+// actionableEvent reports whether an event type produces a bulk action at
+// all — index/replace (created, updated, legacy "") or delete (deleted).
+func actionableEvent(e model.EventType) bool {
+	switch e {
+	case model.EventCreated, model.EventUpdated, model.EventDeleted, "":
+		return true
+	default:
+		return false
+	}
+}
+```
+
+Extend `MessageSearchIndex` (below `TShow`):
+
+```go
+	// Searched attachment/tcard projections (ES maps arrays implicitly).
+	// CardData is the card's data doc indexed verbatim — no expansion.
+	AttachmentText string `json:"attachmentText,omitempty" es:"text,custom_analyzer"`
+	CardData               string   `json:"cardData,omitempty"               es:"text,custom_analyzer"`
+
+	// Render payloads stored as-is (never indexed) so search hits can be
+	// rendered on the frontend without a history-service lookup.
+	Attachments []cassandra.Attachment `json:"attachments,omitempty" es:"object_disabled"`
+	Card        *cassandra.Card        `json:"card,omitempty"        es:"object_disabled"`
+```
+
+(`es:"object_disabled"` is a template.go extension expanding to `{"type":"object","enabled":false}` — stored in `_source`, never indexed.)
+
+Populate at the end of `newMessageSearchIndex` (before `return doc`; add `pkg/model/cassandra` import):
+
+```go
+	// Lenient decode: a malformed blob is skipped by DecodeAttachments; one
+	// bad attachment must not block indexing the rest of the message.
+	attachments, _ := cassandra.DecodeAttachments(evt.Message.Attachments)
+	doc.Attachments = attachments
+	var attachmentText []string
+	for i := range attachments {
+		a := &attachments[i]
+		if a.Title != "" {
+			attachmentText = append(attachmentText, a.Title)
+		}
+		if a.Description != "" {
+			attachmentText = append(attachmentText, a.Description)
+		}
+	}
+	doc.AttachmentText = strings.Join(attachmentText, " ")
+
+	if evt.Message.Card != nil {
+		doc.Card = evt.Message.Card
+		doc.CardData = string(evt.Message.Card.Data)
+	}
+```
+
+(Loop indexes by pointer — gocritic `rangeValCopy` fires on the 248-byte `Attachment` value copy.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `make test SERVICE=search-sync-worker`
+Expected: `ok github.com/hmchangw/chat/search-sync-worker` — new tests pass, `TestMessageCollection_BuildAction_ReactedSkipped` still passes (reacted remains skipped via the allowlist).
+
+- [ ] **Step 5: Extend the integration fixture** (`testdata/events.json` + `integration_test.go`)
+
+Append to `events.json` (after the existing deleted event; attachment blob is base64 of `{"title":"q3-report.pdf","description":"Quarterly numbers","fileType":"application/pdf"}`):
+
+```json
+{
+  "event": "created",
+  "message": {
+    "id": "msg-006", "roomId": "room-2", "userId": "u1", "userAccount": "alice",
+    "content": "see the attached report", "createdAt": "2026-02-11T09:00:00Z",
+    "attachments": ["eyJ0aXRsZSI6InEzLXJlcG9ydC5wZGYiLCJkZXNjcmlwdGlvbiI6IlF1YXJ0ZXJseSBudW1iZXJzIiwiZmlsZVR5cGUiOiJhcHBsaWNhdGlvbi9wZGYifQ=="],
+    "card": {
+      "template": "expense-approval-v1",
+      "data": "eyJ0eXBlIjoiQWRhcHRpdmVDYXJkIiwiYm9keSI6W3sidHlwZSI6IlRleHRCbG9jayIsInRleHQiOiJFeHBlbnNlIHJlcXVlc3QgZnJvbSBCb2IifV19"
+    },
+    "cardAction": {"verb": "approve", "displayText": "Approved by Alice"}
+  },
+  "siteId": "site-test", "timestamp": 1000008
+},
+{
+  "event": "pinned",
+  "message": {"id": "msg-001", "roomId": "room-1", "userId": "u1", "userAccount": "alice", "createdAt": "2026-01-15T10:30:00Z"},
+  "siteId": "site-test", "timestamp": 1000009
+},
+{
+  "event": "unpinned",
+  "message": {"id": "msg-002", "roomId": "room-1", "userId": "u2", "userAccount": "bob", "createdAt": "2026-01-15T10:31:00Z"},
+  "siteId": "site-test", "timestamp": 1000010
+}
+```
+
+In `TestSearchSyncIntegration`: route `EventPinned`/`EventUnpinned` to `subject.MsgCanonicalPinned/Unpinned`; bump doc-count expectations (total 5, February 3); assert msg-001 keeps `"hello world (edited)"` after the pin, msg-002 stays absent after the unpin, msg-006 carries the searched projections + the full `attachments`/`card` objects + `cardData` containing `"Expense request from Bob"`; add `searchHitsMultiField` (multi_match `bool_prefix`/`AND` over `["content","attachmentText","cardData"]`) and assert one hit each for `"q3-report.pdf"`, `"Quarterly"`, `"Expense request"`.
+
+- [ ] **Step 6: Verify + commit**
+
+Run: `go vet -tags integration ./search-sync-worker/ && make test SERVICE=search-sync-worker` → PASS. Where Docker is available: `make test-integration SERVICE=search-sync-worker` → `ok` (~35–50s).
+
+```bash
+git add search-sync-worker
+git commit -m "search-sync-worker: skip slim events; index attachment + tcard fields"
+```
+
+---
+
+### Task 2: pkg/searchengine — UpdateMapping + startup mapping push
+
+**Files:**
+- Modify: `pkg/searchengine/searchengine.go` (interface), `pkg/searchengine/adapter.go`
+- Modify: `search-sync-worker/collection.go` (interface), `search-sync-worker/messages.go`, `search-sync-worker/inbox_stream.go`, `search-sync-worker/spotlight_org.go` (no-op stubs), `search-sync-worker/main.go` (startup loop after template upsert)
+- Test: `pkg/searchengine/adapter_test.go`, `pkg/searchengine/integration_test.go`, `search-sync-worker/messages_test.go`, `search-sync-worker/handler_test.go` (test-stub collections gain the method)
+
+**Interfaces:**
+- Produces: `SearchEngine.UpdateMapping(ctx context.Context, indexPattern string, body json.RawMessage) error`; `Collection.MappingUpdate() (indexPattern string, body json.RawMessage)` — empty pattern/nil body = no update. Only `messageCollection` returns a real update.
+
+- [ ] **Step 1: Write the failing tests**
+
+`pkg/searchengine/adapter_test.go`:
+
+```go
+func TestAdapter_UpdateMapping(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var capturedBody string
+		ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+			assert.Equal(t, http.MethodPut, req.Method)
+			assert.Equal(t, "/messages-site1-*/_mapping", req.URL.Path)
+			assert.Equal(t, "true", req.URL.Query().Get("allow_no_indices"))
+			assert.Equal(t, "true", req.URL.Query().Get("ignore_unavailable"))
+			assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
+			body, _ := io.ReadAll(req.Body)
+			capturedBody = string(body)
+			return jsonResponse(200, `{"acknowledged": true}`), nil
+		}}
+		a := newAdapter(ft)
+		body := json.RawMessage(`{"properties":{"cardData":{"type":"text"}}}`)
+		err := a.UpdateMapping(context.Background(), "messages-site1-*", body)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(body), capturedBody)
+	})
+
+	t.Run("error status", func(t *testing.T) {
+		ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(400, `{"error":"mapper_parsing_exception"}`), nil
+		}}
+		a := newAdapter(ft)
+		err := a.UpdateMapping(context.Background(), "messages-*", json.RawMessage(`{}`))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "400")
+	})
+
+	t.Run("empty pattern rejected", func(t *testing.T) {
+		a := newAdapter(&fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+			t.Fatal("no request expected for empty pattern")
+			return nil, nil
+		}})
+		err := a.UpdateMapping(context.Background(), "", json.RawMessage(`{}`))
+		assert.Error(t, err)
+	})
+}
+```
+
+`search-sync-worker/messages_test.go`:
+
+```go
+// Index templates only apply to indices created after the template change, so
+// the collection must expose an additive mapping update for existing monthly
+// indices — otherwise new fields stay unmapped (dynamic:false drops them)
+// until the next month rolls over.
+func TestMessageCollection_MappingUpdate(t *testing.T) {
+	coll := newMessageCollection("messages-site1-v1", time.Time{}, false)
+	pattern, body := coll.MappingUpdate()
+	assert.Equal(t, "messages-site1-*", pattern, "pattern must strip the version suffix like the template's index_patterns")
+	require.NotNil(t, body)
+
+	var parsed struct {
+		Properties map[string]any `json:"properties"`
+	}
+	require.NoError(t, json.Unmarshal(body, &parsed))
+	assert.Contains(t, parsed.Properties, "attachmentText")
+	assert.Contains(t, parsed.Properties, "cardData")
+	assert.Contains(t, parsed.Properties, "content", "full property set keeps the update idempotent")
+	// Render payloads are stored but never indexed: object + enabled:false.
+	for _, key := range []string{"attachments", "card"} {
+		prop := parsed.Properties[key].(map[string]any)
+		assert.Equal(t, "object", prop["type"], key)
+		assert.Equal(t, false, prop["enabled"], key)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `make test SERVICE=pkg/searchengine && make test SERVICE=search-sync-worker`
+Expected: build FAIL — `a.UpdateMapping undefined`, `coll.MappingUpdate undefined`.
+
+- [ ] **Step 3: Implement**
+
+`pkg/searchengine/adapter.go` (beside `PutScript`):
+
+```go
+// UpdateMapping PUTs an additive mapping body onto every index matching the
+// pattern. Index templates only apply at index creation, so new fields must
+// also be pushed onto already-existing indices. `allow_no_indices` +
+// `ignore_unavailable` make the call a no-op on a fresh cluster.
+func (a *httpAdapter) UpdateMapping(ctx context.Context, indexPattern string, body json.RawMessage) error {
+	if indexPattern == "" {
+		return fmt.Errorf("update mapping: index pattern required")
+	}
+	path := fmt.Sprintf("/%s/_mapping?allow_no_indices=true&ignore_unavailable=true", indexPattern)
+	resp, err := a.do(ctx, "indices.put_mapping", indexPattern, func(ctx context.Context) (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut, path, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	})
+	if err != nil {
+		return fmt.Errorf("update mapping: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("update mapping: status %d, read body: %w", resp.StatusCode, readErr)
+		}
+		return fmt.Errorf("update mapping: status %d, body: %s", resp.StatusCode, respBody)
+	}
+	return nil
+}
+```
+
+Interface method on `SearchEngine` (`searchengine.go`, beside `PutScript`) with the same doc comment. `search-sync-worker/collection.go` — add to `Collection`:
+
+```go
+	// MappingUpdate returns an index pattern and an additive mapping body
+	// (`{"properties": ...}`) to PUT onto already-existing indices at startup.
+	// Index templates only apply to indices created afterwards, so collections
+	// with rolling (e.g. monthly) indices must push schema additions onto the
+	// live ones too. Empty pattern / nil body means no update is needed.
+	MappingUpdate() (indexPattern string, body json.RawMessage)
+```
+
+`messages.go`:
+
+```go
+// MappingUpdate pushes the full (idempotent) property set onto existing
+// monthly indices; the same pattern the template targets.
+func (c *messageCollection) MappingUpdate() (string, json.RawMessage) {
+	// Error discarded: input is a static map of literals, marshal cannot fail.
+	body, _ := json.Marshal(map[string]any{"properties": messageTemplateProperties()})
+	return searchindex.IndexPattern(c.indexPrefix), body
+}
+```
+
+No-op stubs: `inboxMemberCollection` (covers spotlight + user-room) and `spotlightOrgCollection` return `"", nil` (pinned by `TestSpotlightCollection_MappingUpdate_NoOp` / `TestSpotlightOrg_MappingUpdate_NoOp`); the stub collections in `handler_test.go` gain one-line `MappingUpdate` methods. `main.go`, after the template-upsert loop, calls an extracted `pushMappings` helper (unit-tested in `main_test.go` with a fake engine — pushes only collections with a mapping, propagates engine errors):
+
+```go
+	if err := pushMappings(ctx, engine, collections); err != nil {
+		slog.Error("update index mapping failed", "error", err)
+		os.Exit(1)
+	}
+
+// pushMappings PUTs each collection's additive mapping onto its existing
+// indices — templates govern only new indices, so without this new fields
+// stay unmapped (dynamic:false) until the next monthly rollover.
+func pushMappings(ctx context.Context, engine searchengine.SearchEngine, collections []Collection) error {
+	for _, coll := range collections {
+		pattern, body := coll.MappingUpdate()
+		if pattern == "" || body == nil {
+			continue
+		}
+		if err := engine.UpdateMapping(ctx, pattern, body); err != nil {
+			return fmt.Errorf("update mapping %s: %w", pattern, err)
+		}
+		slog.Info("index mapping updated", "pattern", pattern)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Integration case** (`pkg/searchengine/integration_test.go`)
+
+```go
+func TestUpdateMapping_AppliesToExistingIndex(t *testing.T) {
+	esURL := testutil.Elasticsearch(t)
+	index := testutil.ElasticsearchIndex(t, "searchenginemap")
+
+	ctx := context.Background()
+	engine, err := New(ctx, Config{Backend: "elasticsearch", URL: esURL})
+	require.NoError(t, err)
+
+	// Materialize the index by writing a doc, then push a new field mapping.
+	_, err = engine.Bulk(ctx, []BulkAction{{
+		Action: ActionIndex, Index: index, DocID: "d1", Version: 1,
+		Doc: json.RawMessage(`{"content":"x"}`),
+	}})
+	require.NoError(t, err)
+
+	err = engine.UpdateMapping(ctx, index, json.RawMessage(`{"properties":{"cardData":{"type":"text"}}}`))
+	require.NoError(t, err)
+
+	mapping, err := engine.GetIndexMapping(ctx, index)
+	require.NoError(t, err)
+	assert.Contains(t, string(mapping), `"cardData"`)
+
+	// A pattern matching nothing must be a no-op, not an error.
+	err = engine.UpdateMapping(ctx, "no-such-index-pattern-*", json.RawMessage(`{"properties":{"x":{"type":"keyword"}}}`))
+	assert.NoError(t, err)
+}
+```
+
+- [ ] **Step 5: Verify + commit**
+
+Run: `make test SERVICE=pkg/searchengine && make test SERVICE=search-sync-worker && go vet -tags integration ./pkg/searchengine/` → PASS.
+
+```bash
+git add pkg/searchengine search-sync-worker
+git commit -m "searchengine: UpdateMapping API; push message mapping onto existing indices"
+```
+
+---
+
+### Task 3: history-service — enrich `.updated` canonical events
+
+**Files:**
+- Modify: `history-service/internal/service/messages.go` (EditMessage canonical event, ~line 421)
+- Modify: `history-service/internal/service/migration.go` (MigrationEditMessage, ~line 24)
+- Test: `history-service/internal/service/messages_test.go`, `history-service/internal/service/migration_test.go`
+
+**Interfaces:**
+- Consumes: Task 1's full-doc replace semantics; `models.Message` (= `cassandra.Message`) with decrypted `Attachments [][]byte`, `Card`, `CardAction` (cassrepo read path applies `atrest.ApplyDecryptedFields`).
+- Produces: `.updated` events carrying `Attachments`/`Card` (`CardAction` deliberately excluded — no `.updated` consumer reads it); migration edit resolves the row via `s.msgReader.GetMessageByID` before updating (matching the migration delete path).
+
+- [ ] **Step 1: Write the failing tests**
+
+`messages_test.go`:
+
+```go
+// The .updated event is a full-doc replace for search-sync-worker: it must
+// carry the message's attachments and card, or the re-index wipes those
+// fields from the search document.
+func TestHistoryService_EditMessage_CarriesAttachmentsAndCard(t *testing.T) {
+	svc, msgs, subs, pub, _ := newService(t)
+	c := testContext()
+
+	attachments := [][]byte{[]byte(`{"title":"q3.pdf","description":"numbers","fileType":"application/pdf"}`)}
+	card := &models.Card{Template: "expense-v1", Data: []byte(`{"text":"hi"}`)}
+	cardAction := &models.CardAction{Verb: "approve", DisplayText: "Approved by Ann"}
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
+	hydrated := &models.Message{
+		MessageID:   "msg-1",
+		RoomID:      "r1",
+		Sender:      models.Participant{Account: "u1", ID: "u1-id"},
+		CreatedAt:   time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC),
+		Msg:         "original content",
+		Attachments: attachments,
+		Card:        card,
+		CardAction:  cardAction,
+	}
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "updated content", gomock.Any()).Return(nil)
+
+	pub.EXPECT().
+		Publish(gomock.Any(), subject.MsgCanonicalUpdated("site-test"), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, data []byte, _ string) error {
+			var evt model.MessageEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			assert.Equal(t, attachments, evt.Message.Attachments)
+			require.NotNil(t, evt.Message.Card)
+			assert.Equal(t, card.Template, evt.Message.Card.Template)
+			assert.Equal(t, card.Data, evt.Message.Card.Data)
+			// CardAction stays off the wire: no .updated consumer reads it,
+			// and its Data blob would inflate every edit event.
+			assert.Nil(t, evt.Message.CardAction)
+			return nil
+		})
+
+	_, err := svc.EditMessage(c, "site-test", models.EditMessageRequest{
+		MessageID: "msg-1",
+		NewMsg:    "updated content",
+	})
+	require.NoError(t, err)
+}
+```
+
+`migration_test.go` — extend `TestHistoryService_MigrationEditMessage_Success` with a `GetMessageByID` expectation returning a hydrated row (sender `bob`/`bob-id`, attachments, card `legacy-card-v1`) and assert the published event carries `UserAccount`/`UserID`/`Attachments`/`Card`; change `_AbsentRowRetries` to expect `GetMessageByID → (nil, nil)` with `UpdateMessageContent` `Times(0)` and a NotFound error; add `GetMessageByID` to `_WriterError`. Guard tests: `_AlreadyDeletedAcksOK` (deleted row → OK ack, no update, no publish), `_RoomMismatchRejected` (row owned by another room → NotFound, no update), `_ReaderErrorPropagates`, `_RowVanishesRetries` (writer returns wrapped `ErrMessageNotFound` → retryable NotFound).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `make test SERVICE=history-service/internal/service`
+Expected: 4 FAILs (missing fields on published events; missing mock expectations).
+
+- [ ] **Step 3: Implement**
+
+`messages.go` — add two lines to the `canonicalEvt.Message` literal in `EditMessage` (and extend the comment: the full doc is required or re-index wipes fields). `CardAction` is deliberately NOT carried — no `.updated` consumer reads it:
+
+```go
+			Attachments:                  msg.Attachments,
+			Card:                         msg.Card,
+```
+
+`migration.go` — `MigrationEditMessage` resolves the row first (replaces the locator-only flow):
+
+```go
+	// Resolve the full row first (like the delete path): the .updated event is
+	// a full-doc replace for search-sync-worker, so it must carry sender,
+	// attachments and card — a slim locator-only event would wipe those fields
+	// from the search document. The resolved row is also the more accurate
+	// UPDATE locator (thread/pin routing fields present).
+	msg, err := s.msgReader.GetMessageByID(c, req.MessageID)
+	if err != nil {
+		return nil, fmt.Errorf("migration edit %q: %w", req.MessageID, err)
+	}
+	if msg == nil {
+		// Edit-before-insert race: the row isn't persisted yet. Surface a
+		// retryable NotFound (4xx, Nak) so the benign race doesn't log as 5xx.
+		return nil, errcode.NotFound("message not yet persisted, retry")
+	}
+	// Edit-after-delete replay: ack idempotently — updating would republish
+	// .updated with a fresh version and resurrect the doc in search.
+	if msg.Deleted {
+		return &model.MigrationAck{OK: true}, nil
+	}
+	// Locator sanity: a transformer bug with a wrong RoomID must not edit
+	// whatever row happens to own the message ID.
+	if req.RoomID != "" && msg.RoomID != req.RoomID {
+		return nil, errcode.NotFound("message not found in room")
+	}
+
+	if err := s.msgWriter.UpdateMessageContent(c, msg, req.Content, req.EditedAt); err != nil {
+		// Row vanished between read and update (hard-missing on the
+		// cipher-path read) — benign, retryable.
+		if errors.Is(err, cassrepo.ErrMessageNotFound) {
+			return nil, errcode.NotFound("message row missing, retry")
+		}
+		return nil, fmt.Errorf("migration edit message %s: %w", req.MessageID, err)
+	}
+```
+
+and build the event from `msg` (ID/RoomID/CreatedAt/Sender fields/Attachments/Card/ThreadParent fields/TShow — no CardAction) with `Content: req.Content`, `EditedAt`/`UpdatedAt` = `req.EditedAt`.
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `make test SERVICE=history-service` → all `ok`.
+
+```bash
+git add history-service
+git commit -m "history-service: carry attachments/card (and sender) on .updated canonical events"
+```
+
+---
+
+### Task 4: search-service — query + response
+
+**Files:**
+- Modify: `search-service/query_messages.go` (multi_match fields, ~line 46), `search-service/response.go` (`messageSearchHit`, `toSearchMessage`), `pkg/model/search.go` (`SearchMessage`)
+- Modify: `docs/client-api.md` (search.messages section), `docs/client-api/request-reply.md`
+- Test: `search-service/query_messages_test.go`, `search-service/response_test.go`, `pkg/model/model_test.go`, `search-service/integration_messages_test.go`
+
+**Interfaces:**
+- Consumes: Task 1's ES field names.
+- Produces: `model.SearchMessage` gains `Attachments []Attachment` and `Card *Card` (aliases of the cassandra types), both `omitempty` — the message's render payloads mirrored as-is (same wire shape as history reads) so hits render without a follow-up history load.
+
+- [ ] **Step 1: Write the failing tests**
+
+`query_messages_test.go`:
+
+```go
+// One query box searches message text, file names/descriptions and tcard
+// data together.
+func TestBuildMessageQuery_SearchesAttachmentAndCardFields(t *testing.T) {
+	req := model.SearchMessagesRequest{Query: "report", Size: 25}
+	raw, err := buildMessageQuery(req, "alice", nil, 365*24*time.Hour, "user-room")
+	require.NoError(t, err)
+
+	q := parseQuery(t, raw)
+	musts := q["query"].(map[string]any)["bool"].(map[string]any)["must"].([]any)
+	require.Len(t, musts, 1)
+	mm := musts[0].(map[string]any)["multi_match"].(map[string]any)
+	assert.Equal(t, "report", mm["query"])
+	assert.Equal(t, "bool_prefix", mm["type"])
+	assert.Equal(t, "AND", mm["operator"])
+	assert.Equal(t,
+		[]any{"content", "attachmentText", "cardData"},
+		mm["fields"])
+}
+```
+
+`response_test.go`:
+
+```go
+// Full attachment objects and the card ride the hit so the client can render
+// the result (file row, tcard) without a history-service lookup.
+func TestToSearchMessage_AttachmentAndCardFieldsCopied(t *testing.T) {
+	hit := messageSearchHit{
+		MessageID:   "m1",
+		RoomID:      "r1",
+		UserAccount: "alice",
+		Attachments: []model.Attachment{
+			{ID: "f1", Title: "q3-report.pdf", Description: "Quarterly numbers", FileType: "application/pdf", TitleLink: "api/v1/file/rooms/r1/file/f1", TitleLinkDownload: true},
+			{ID: "f2", Title: "team.png", FileType: "image/png"},
+		},
+		Card: &model.Card{Template: "expense-approval-v1", Data: []byte(`{"amount":42}`)},
+	}
+	got := toSearchMessage(&hit)
+	require.Len(t, got.Attachments, 2)
+	assert.Equal(t, "q3-report.pdf", got.Attachments[0].Title)
+	require.NotNil(t, got.Card)
+	assert.Equal(t, "expense-approval-v1", got.Card.Template)
+}
+
+// A text-only hit must not grow attachment/card keys on the wire.
+func TestToSearchMessage_AttachmentAndCardOmittedWhenAbsent(t *testing.T) {
+	hit := messageSearchHit{MessageID: "m1", RoomID: "r1", UserAccount: "alice", Content: "hello"}
+	got := toSearchMessage(&hit)
+
+	data, err := json.Marshal(got)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	for _, key := range []string{"attachments", "card"} {
+		_, present := raw[key]
+		assert.False(t, present, "%s should be omitted when empty", key)
+	}
+}
+```
+
+`pkg/model/model_test.go`: extend `TestSearchMessageJSON` "full" case with `Attachments`/`Card` + a subtest asserting they're omitted when empty.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `make test SERVICE=search-service && make test SERVICE=pkg/model`
+Expected: build FAIL — `SearchMessage has no field Attachments` etc.
+
+- [ ] **Step 3: Implement**
+
+`pkg/model/attachment.go` — add `Card = cassandra.Card` to the alias block. `pkg/model/search.go` — append to `SearchMessage`:
+
+```go
+	// Render payloads mirrored as-is from the message (same wire shape as
+	// history reads) so the client can render hits without a second lookup.
+	Attachments []Attachment `json:"attachments,omitempty"`
+	Card        *Card        `json:"card,omitempty"`
+```
+
+`response.go` — mirror both fields on `messageSearchHit` (same JSON tags) and copy them in `toSearchMessage`. `query_messages.go`:
+
+```go
+							// Message text plus file-attachment names/descriptions
+							// and tcard data — one query box covers all of them.
+							"fields": []string{"content", "attachmentText", "cardData"},
+```
+
+Docs: `client-api.md` search.messages — "Searched fields" paragraph (content, attachmentText, cardData verbatim), response JSON example + `attachments`/`card` field-table rows (linking the shared [Attachment]/[MessageCard] schemas) with omission rules; `request-reply.md` — same fields in the compact list.
+
+- [ ] **Step 4: End-to-end guarantee test** (`integration_messages_test.go`, real ES + real NATS)
+
+Seed with the worker's exact externally-versioned write shapes and search through the real RPC — this pins the spec's ordering invariant:
+
+```go
+	// m1: created (v=1000) then edited (full replace, v=2000, new content + attachment).
+	// m2: created (v=1000) then deleted (v=2000).
+	// Then a stale replay of m2's create (v=1000) MUST 409 against the tombstone.
+	staleResults := mustBulk(searchengine.BulkAction{Action: searchengine.ActionIndex, Index: index, DocID: "m2", Version: 1000,
+		Doc: msgDoc("m2", "secret that must vanish", nil)})
+	require.Equal(t, http.StatusConflict, staleResults[0].Status, "stale replay must hit the external-version tombstone")
+```
+
+Subtests: `search("edited words")` → exactly m1 with post-edit content; `search("original words")` → 0 hits; `search("secret")` → 0 hits; `search("q3")` → m1 via `attachmentText`. The index MUST be created from a production-equivalent template (`messageTestTemplate()` extended with the new fields) — ES dynamic mapping types `roomId` as `text`, which silently breaks the terms-lookup room gate. Seed the caller's user-room doc for the terms lookup.
+
+- [ ] **Step 5: Verify + commit**
+
+Run: `make test SERVICE=search-service && make test SERVICE=pkg/model && go vet -tags integration ./search-service/` → PASS. With Docker: `make test-integration SERVICE=search-service` → `ok` (~100s).
+
+```bash
+git add search-service pkg/model docs/client-api.md docs/client-api/request-reply.md
+git commit -m "search-service: search + return attachment/tcard fields"
+```
+
+---
+
+### Task 5: search-sync-worker — reconcile mode (REMOVED by owner decision)
+
+> **2026-07-22:** A fully-built `-reconcile` one-shot mode (search_after ES scan →
+> Cassandra `messages_by_id` verification → bulk delete, with dry-run default,
+> `RECONCILE_MIN_AGE` grace window and bounded-concurrency checks) was removed from
+> the branch. Rationale: pre-pipeline deletions are out of scope, and once a
+> `.deleted` event is published the worker's Nak/retry makes the ES delete
+> at-least-once. The accepted residual gap — a publish-side drop after the Cassandra
+> soft-delete commits — is recorded in the spec's "Stale deleted docs" decision.
+
+---
+
+
+### Task 6: Full verification
+
+- [ ] **Step 1:** `make lint` → `0 issues.`
+- [ ] **Step 2:** `make test` → every package `ok`, no FAIL lines.
+- [ ] **Step 3:** `make sast-gosec` → no findings (govulncheck/semgrep in CI if the sandbox blocks their feeds).
+- [ ] **Step 4:** Integration suites (Docker required): `make test-integration SERVICE=search-sync-worker` (~35–50s), `make test-integration SERVICE=search-service` (~100s), `make test-integration SERVICE=history-service` (~80s), `make test-integration SERVICE=pkg/searchengine` (~20s) → all `ok`.
+- [ ] **Step 5:** Coverage spot-check (raw `go test` per the Global Constraints exception): `go test -coverprofile=cov.out ./search-sync-worker/ ./search-service/ ./history-service/internal/service/ && go tool cover -func=cov.out | grep total` — new functions ≥80% (handlers in `history-service/internal/service` sit >90%).
+- [ ] **Step 6:** Push: `git push -u origin claude/search-deletion-tcard-file-dwnnnk`. No PR unless requested.
+
+## Rollout notes
+
+- Deploy `search-sync-worker` first — startup pushes the new mapping onto existing monthly indices; docs indexed before the deploy lack the new fields until edited/replayed (spec limitation).
+- `search-service` deploy order-independent: query references fields that may be empty; response additions are `omitempty`.
+- Documents deleted before this deploy keep their search docs (owner decision — no reconcile tooling; see spec "Stale deleted docs").

--- a/docs/superpowers/specs/2026-07-21-search-delete-tcard-file-design.md
+++ b/docs/superpowers/specs/2026-07-21-search-delete-tcard-file-design.md
@@ -1,0 +1,170 @@
+# Search: delete/edit correctness + tcard & file (attachment) search — Design
+
+## Problem
+
+1. Messages soft-deleted via `history-service` (hidden from history RPCs) still appear in
+   search results.
+2. Tcard data (`Card`/`CardAction` on messages) and file attachment data (`Title` = filename,
+   `Description`) are not searchable — only `content` is indexed in Elasticsearch.
+
+## Findings
+
+- The forward sync path already exists at HEAD: `history-service` publishes
+  `chat.msg.canonical.{siteID}.deleted` / `.updated`, and `search-sync-worker` maps
+  `EventDeleted` → ES delete, `EventUpdated` → full-doc re-index
+  (`search-sync-worker/messages.go`). Lingering search hits therefore come from
+  (a) messages deleted before this pipeline shipped/deployed, and/or (b) the best-effort
+  canonical publish being dropped (`publishCanonicalBestEffort` logs and swallows failures).
+- Live bug: `EventPinned`/`EventUnpinned` canonical events carry no `content`
+  (`history-service/internal/service/pin.go`) yet take the full-doc-replace upsert path in
+  the sync worker — pinning a message wipes its content from the search index, and
+  unpinning a soft-deleted pin resurrects a stub document.
+
+## Design
+
+### Sync worker (`search-sync-worker`)
+
+- **Event allowlist** in `BuildAction`: upsert on `EventCreated` / `EventUpdated` / legacy
+  unstamped `""`; delete on `EventDeleted`; skip everything else (`Reacted`, `Pinned`,
+  `Unpinned`, `ThreadReplyAdded`, future types). Fixes the pin wipe/resurrect bug and is
+  future-proof against new slim event types.
+- **Ordering invariant (external versioning)**: every index/delete action carries the
+  event's timestamp as the ES external version. An edit is a full-document replace at a
+  higher version; a delete leaves a tombstone at `deletedAt`, so a stale redelivered
+  create/update (older version) is rejected with 409 — which the flush path treats as
+  success. Delete protection holds as long as the tombstone's version metadata lives:
+  ES garbage-collects it after `index.gc_deletes` (default 60s), after which a late
+  redelivered create would be accepted again. Accepted for now (owner decision,
+  2026-07-23 — no template change ships); if the window ever proves material, ops
+  can raise `index.gc_deletes` dynamically to exceed JetStream redelivery/backoff.
+  Known limitation: two distinct events stamped in the same millisecond tie on version,
+  so the second is 409-dropped (e.g. an edit in the same ms as the create keeps the old
+  content). Accepted — publishes are sequential per message in `history-service`, so
+  the window is sub-millisecond in practice, and the next event heals the doc; a
+  timestamp+sequence version scheme was considered and rejected as producer-side
+  churn disproportionate to the sub-ms risk.
+- **New ES fields** on `MessageSearchIndex`:
+
+  | Field | JSON | ES type |
+  |---|---|---|
+  | `AttachmentText string` | `attachmentText` | `text,custom_analyzer` (searched — every attachment's title + description joined into one string, so AND terms may mix both) |
+  | `CardData string` | `cardData` | `text,custom_analyzer` (searched, never returned) |
+  | `Attachments []cassandra.Attachment` | `attachments` | `object`, `enabled:false` (render-only) |
+  | `Card *cassandra.Card` | `card` | `object`, `enabled:false` (render-only) |
+
+  Render payloads (owner decision, 2026-07-22): the whole `Attachment` objects and the
+  `card` (template + data) are stored as-is — `enabled:false`, so ES keeps them in
+  `_source` without indexing — and returned on hits so the frontend can render results
+  (file row, tcard) without a history-service load. Search still touches only the flat
+  analyzed projections above. Accepted trade-off: a carded doc stores the card body
+  twice (`cardData` raw text + `card.data` base64) — full-text search needs the
+  analyzed copy, lossless render needs the object; hits ship only the latter.
+- Attachments decoded from the event's raw `[][]byte` blobs via the existing lenient
+  `cassandra.DecodeAttachments`.
+- **Create-path card gap (known)**: no in-repo `.created` producer sets `Message.Card` —
+  `SendMessageRequest` has no card field and the oplog transformer maps neither card
+  field, so live tcard messages become card-searchable only via the enriched `.updated`
+  path (edit/migration replay). Indexing on `.created` is forward-compatible with
+  external producers whose events carry `card`; wiring cards into the send path is a
+  product decision deferred out of this branch.
+- **Card data indexing** (owner decision, 2026-07-22, replaces the earlier allowlist
+  extraction): `Card.Data` is indexed **verbatim** as analyzed text (`cardData`);
+  `CardAction` is not indexed. Accepted trade-off: structural JSON tokens (keys,
+  type names) become searchable noise — accepted for simplicity. A template-expansion
+  "rendered display text" approach was fully designed and then explicitly rejected;
+  its spec/plan documents were removed from the branch.
+- **Mapping rollout**: index templates only apply to future monthly indices, so worker
+  startup additionally PUTs the additive mapping onto existing `messages-*` indices
+  (`allow_no_indices=true&ignore_unavailable=true`). Components: a new
+  `pkg/searchengine.UpdateMapping(pattern, properties)` on the shared ES adapter (sole
+  addition to that pre-existing package) and a `Collection.MappingUpdate()` hook that
+  only the rolling-index messages collection implements. All changes are additive — no
+  index version bump or reindex. Docs indexed before this change lack the new fields
+  until the message is edited or a backfill replay occurs.
+  Ops note: the mapping push fails startup (exit 1 → crash-loop) if a pushed field
+  conflicts with an existing index's mapping. That is intentional fail-fast: only
+  additive changes are allowed on this path; a type change requires an index version
+  bump (new indices + reindex), never an in-place mapping fight.
+
+### Event source (`history-service`)
+
+- The `.updated` canonical event additionally carries `Attachments` and `Card`
+  (`CardAction` deliberately excluded — no `.updated` consumer reads it and its `Data`
+  blob would inflate every edit event)
+  (the handler already holds the full row), so the full-doc re-index cannot wipe the new
+  fields. Applies to both the client edit path and the migration edit path — the latter
+  now resolves the full row first (like the migration delete path), which also fixes
+  migrated edits erasing `userAccount`/`userId` from the index. Delete events are
+  unchanged (the document is removed).
+
+### Query + response (`search-service`)
+
+- `multi_match` fields become `["content", "attachmentText", "cardData"]` (same
+  `bool_prefix` + `AND` semantics; pooling titles+descriptions into one field lets an
+  AND query mix words from both — owner decision, 2026-07-23).
+- `SearchMessage` gains `attachments []Attachment` and `card *Card` (owner decision,
+  2026-07-22, superseding the earlier flat-projection wire shape): the render payloads
+  mirrored as-is from the ES doc — same wire shape as history reads (`card.data` is
+  base64 bytes) — so the frontend renders hits without a follow-up history load. Both
+  `omitempty`; documented in `docs/client-api.md` and derived views. `cardData` stays
+  search-only (`_source`-excluded); the returned card carries the data instead.
+
+### Stale deleted docs (no reconciliation — decision)
+
+- **No reconcile tooling ships** (owner decision, 2026-07-22, reversing the earlier
+  reconcile-mode design): documents deleted before this pipeline existed are out of
+  scope, and once a `.deleted` event is in MESSAGES_CANONICAL, the worker's Nak/retry
+  makes the ES delete at-least-once. The accepted residual gap is a publish-side drop:
+  the Cassandra soft-delete commits before `publishCanonicalBestEffort`, so a JetStream
+  publish failure (stream ack timeout / no quorum / limits, while request/reply still
+  works) leaves the doc searchable with no retry path. Judged rare enough to accept;
+  the fallback if it ever matters is a durable (outbox-style) canonical publish.
+
+## Verification
+
+- TDD throughout (unit tests written first per CLAUDE.md). Key end-to-end guarantees are
+  pinned by integration tests against real containers:
+  - `search-sync-worker`: delete removes the doc, edit replaces content, pin/unpin
+    neither wipes nor resurrects, attachment/card fields land in ES and match via the
+    production `multi_match` shape.
+  - `search-service` (`TestIntegration_SearchMessages_EditedAndDeletedDocs`): through the
+    real NATS RPC and query builder — edited messages found only with post-edit content,
+    deleted messages return zero hits, a stale replayed create 409s against the delete
+    tombstone and stays gone.
+- Integration tests seed indices with production-equivalent keyword/text mappings —
+  ES dynamic mapping types `roomId` as `text`, which silently breaks the
+  terms-lookup room gate (found on first real run).
+
+## Alternatives considered
+
+1. **Separate typed ES fields** (chosen) — precise, boostable, response can expose what
+   matched.
+2. Single catch-all `searchText` field — simpler query but loses field-level control;
+   changing composition later forces a reindex.
+3. Nested attachment/card sub-documents — nested-query cost with no current need (YAGNI).
+
+For stale docs: a `-reconcile` one-shot mode (ES scan verified against Cassandra
+`messages_by_id`) was fully built and then removed by owner decision — pre-pipeline
+deletions don't matter, and the event flow's Nak/retry covers everything downstream of
+a published event.
+
+## Out of scope
+
+Scope decision (owner, 2026-07-21): keep every RPC/API flow unchanged — this work is a
+search enhancement only. Delete/edit must propagate to Elasticsearch; tcard and file
+data become extra searchable fields. The following surveyed gaps were reviewed and
+explicitly deferred:
+
+- Durable (non-best-effort) canonical publish — Cassandra remains the source of truth;
+  a publish-side drop (delete committed, event never published) leaves a stale search
+  doc with no recovery path — accepted (see "Stale deleted docs" decision above).
+- Backfilling attachment/card fields for historical documents (including legacy tcard
+  messages, which never flowed through the client send path — they stay unsearchable
+  by card data until edited or replayed).
+- Purging legacy plaintext columns (`msg`, `attachments`, `card`, `card_action`,
+  `quoted_parent_message`) on soft-delete — pre-encryption rows keep content at rest
+  behind `deleted=true`; encrypted rows are purged via `enc_payload=null`.
+- Deleting Drive/MinIO file bodies when their message is deleted (needs a reference
+  story for quoted messages sharing the same fileId, and per-site Drive routing).
+- Retracting quoted-message snapshots when the quoted original is deleted (quotes copy
+  content by value).

--- a/history-service/internal/service/messages.go
+++ b/history-service/internal/service/messages.go
@@ -413,11 +413,8 @@ func (s *HistoryService) EditMessage(c *natsrouter.Context, siteID string, req m
 
 	editedAtMs := editedAt.UnixMilli()
 
-	// Carry the fields downstream actually reads: search-sync-worker reindexes
-	// by Content/EditedAt/UpdatedAt; broadcast-worker emits a slim
-	// MessageEditedPayload of {ID, Content, EditedBy, EditedAt, UpdatedAt} and
-	// routes thread-reply edits via ThreadParentMessageID + TShow.
-	// Mentions intentionally omitted — broadcast-worker re-resolves from Content.
+	// search-sync-worker reindexes the FULL doc, so attachments/card must ride
+	// along or edits wipe them. Mentions omitted: broadcast-worker re-resolves.
 	canonicalEvt := model.MessageEvent{
 		Event: model.EventUpdated,
 		Message: model.Message{
@@ -426,6 +423,8 @@ func (s *HistoryService) EditMessage(c *natsrouter.Context, siteID string, req m
 			UserID:                       msg.Sender.ID,
 			UserAccount:                  msg.Sender.Account,
 			Content:                      req.NewMsg,
+			Attachments:                  msg.Attachments,
+			Card:                         msg.Card,
 			CreatedAt:                    msg.CreatedAt,
 			EditedAt:                     &editedAt,
 			UpdatedAt:                    &editedAt,

--- a/history-service/internal/service/messages_test.go
+++ b/history-service/internal/service/messages_test.go
@@ -1280,6 +1280,52 @@ func TestHistoryService_EditMessage_PublishesCanonicalUpdatedEvent(t *testing.T)
 	require.NotNil(t, resp)
 }
 
+// .updated is a full-doc replace: it must carry attachments and card,
+// or the re-index wipes those fields from the search document.
+func TestHistoryService_EditMessage_CarriesAttachmentsAndCard(t *testing.T) {
+	svc, msgs, subs, pub, _ := newService(t)
+	c := testContext()
+
+	attachments := [][]byte{[]byte(`{"title":"q3.pdf","description":"numbers","fileType":"application/pdf"}`)}
+	card := &models.Card{Template: "expense-v1", Data: []byte(`{"text":"hi"}`)}
+	cardAction := &models.CardAction{Verb: "approve", DisplayText: "Approved by Ann"}
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
+	hydrated := &models.Message{
+		MessageID:   "msg-1",
+		RoomID:      "r1",
+		Sender:      models.Participant{Account: "u1", ID: "u1-id"},
+		CreatedAt:   time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC),
+		Msg:         "original content",
+		Attachments: attachments,
+		Card:        card,
+		CardAction:  cardAction,
+	}
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "updated content", gomock.Any()).Return(nil)
+
+	pub.EXPECT().
+		Publish(gomock.Any(), subject.MsgCanonicalUpdated("site-test"), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, data []byte, _ string) error {
+			var evt model.MessageEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			assert.Equal(t, attachments, evt.Message.Attachments)
+			require.NotNil(t, evt.Message.Card)
+			assert.Equal(t, card.Template, evt.Message.Card.Template)
+			assert.Equal(t, card.Data, evt.Message.Card.Data)
+			// CardAction stays off the wire: no .updated consumer reads it,
+			// and its Data blob would inflate every edit event.
+			assert.Nil(t, evt.Message.CardAction)
+			return nil
+		})
+
+	_, err := svc.EditMessage(c, "site-test", models.EditMessageRequest{
+		MessageID: "msg-1",
+		NewMsg:    "updated content",
+	})
+	require.NoError(t, err)
+}
+
 // Canonical publish is best-effort — a failure must not roll back the edit (Cassandra is the source of truth).
 func TestHistoryService_EditMessage_PublishFailureDoesNotFailRPC(t *testing.T) {
 	svc, msgs, subs, pub, _ := newService(t)

--- a/history-service/internal/service/migration.go
+++ b/history-service/internal/service/migration.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/hmchangw/chat/history-service/internal/cassrepo"
-	"github.com/hmchangw/chat/history-service/internal/models"
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/natsrouter"
@@ -25,16 +24,33 @@ import (
 func (s *HistoryService) MigrationEditMessage(c *natsrouter.Context, siteID string, req model.MigrationEditRequest) (*model.MigrationAck, error) { //nolint:gocritic // hugeParam: req is passed by value to satisfy the natsrouter.Register handler signature
 	c.WithLogValues("room_id", req.RoomID, "message_id", req.MessageID)
 
-	locator := &models.Message{
-		MessageID: req.MessageID,
-		RoomID:    req.RoomID,
-		CreatedAt: req.CreatedAt,
+	// Resolve the row first: .updated is a full-doc replace needing sender/
+	// attachments/card, and the row is the accurate UPDATE locator.
+	msg, err := s.msgReader.GetMessageByID(c, req.MessageID)
+	if err != nil {
+		return nil, fmt.Errorf("migration edit %q: %w", req.MessageID, err)
 	}
-	if err := s.msgWriter.UpdateMessageContent(c, locator, req.Content, req.EditedAt); err != nil {
-		// Edit-before-insert race: the row isn't persisted yet, so the UPDATE matched nothing.
-		// Map to NotFound (4xx, retryable Nak) so this benign race doesn't log as internal/5xx.
+	if msg == nil {
+		// Edit-before-insert race: the row isn't persisted yet. Surface a
+		// retryable NotFound (4xx, Nak) so the benign race doesn't log as 5xx.
+		return nil, errcode.NotFound("message not yet persisted, retry")
+	}
+	// Edit-after-delete replay: ack idempotently — updating would republish
+	// .updated with a fresh version and resurrect the doc in search.
+	if msg.Deleted {
+		return &model.MigrationAck{OK: true}, nil
+	}
+	// Locator sanity: a transformer bug with a wrong RoomID must not edit
+	// whatever row happens to own the message ID.
+	if req.RoomID != "" && msg.RoomID != req.RoomID {
+		return nil, errcode.NotFound("message not found in room")
+	}
+
+	if err := s.msgWriter.UpdateMessageContent(c, msg, req.Content, req.EditedAt); err != nil {
+		// Row vanished between read and update (hard-missing on the
+		// cipher-path read) — benign, retryable.
 		if errors.Is(err, cassrepo.ErrMessageNotFound) {
-			return nil, errcode.NotFound("message not yet persisted, retry")
+			return nil, errcode.NotFound("message row missing, retry")
 		}
 		return nil, fmt.Errorf("migration edit message %s: %w", req.MessageID, err)
 	}
@@ -43,12 +59,19 @@ func (s *HistoryService) MigrationEditMessage(c *natsrouter.Context, siteID stri
 	evt := model.MessageEvent{
 		Event: model.EventUpdated,
 		Message: model.Message{
-			ID:        req.MessageID,
-			RoomID:    req.RoomID,
-			CreatedAt: req.CreatedAt,
-			Content:   req.Content,
-			EditedAt:  &editedAt,
-			UpdatedAt: &editedAt,
+			ID:                           msg.MessageID,
+			RoomID:                       msg.RoomID,
+			UserID:                       msg.Sender.ID,
+			UserAccount:                  msg.Sender.Account,
+			CreatedAt:                    msg.CreatedAt,
+			Content:                      req.Content,
+			Attachments:                  msg.Attachments,
+			Card:                         msg.Card,
+			EditedAt:                     &editedAt,
+			UpdatedAt:                    &editedAt,
+			ThreadParentMessageID:        msg.ThreadParentID,
+			ThreadParentMessageCreatedAt: msg.ThreadParentCreatedAt,
+			TShow:                        msg.TShow,
 		},
 		SiteID: siteID,
 		// Event-level Timestamp is publish-time, not the source editedAt (the domain timestamp inside Message).

--- a/history-service/internal/service/migration_test.go
+++ b/history-service/internal/service/migration_test.go
@@ -20,7 +20,8 @@ import (
 	"github.com/hmchangw/chat/pkg/subject"
 )
 
-// migrationLocator matches a *models.Message whose MessageID/RoomID/CreatedAt equal the request's.
+// migrationLocator matches the resolved row passed to the writer by its
+// MessageID/RoomID/CreatedAt identity.
 func migrationLocator(messageID, roomID string, createdAt time.Time) gomock.Matcher {
 	return gomock.Cond(func(x any) bool {
 		m, ok := x.(*models.Message)
@@ -37,6 +38,20 @@ func TestHistoryService_MigrationEditMessage_Success(t *testing.T) {
 
 	createdAt := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
 	editedAt := time.Date(2026, 5, 15, 9, 0, 0, 0, time.UTC)
+
+	// Row resolved first so .updated carries sender+attachments+card;
+	// a slim event would wipe those (full-doc replace in search-sync-worker).
+	attachments := [][]byte{[]byte(`{"title":"legacy.pdf","fileType":"application/pdf"}`)}
+	hydrated := &models.Message{
+		MessageID:   "msg-1",
+		RoomID:      "r1",
+		CreatedAt:   createdAt,
+		Sender:      models.Participant{Account: "bob", ID: "bob-id"},
+		Msg:         "old body",
+		Attachments: attachments,
+		Card:        &models.Card{Template: "legacy-card-v1"},
+	}
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
 
 	msgs.EXPECT().
 		UpdateMessageContent(gomock.Any(), migrationLocator("msg-1", "r1", createdAt), "new body", editedAt).
@@ -55,6 +70,11 @@ func TestHistoryService_MigrationEditMessage_Success(t *testing.T) {
 			require.NotNil(t, evt.Message.EditedAt)
 			assert.True(t, evt.Message.EditedAt.Equal(editedAt))
 			assert.Equal(t, "site-test", evt.SiteID)
+			assert.Equal(t, "bob", evt.Message.UserAccount)
+			assert.Equal(t, "bob-id", evt.Message.UserID)
+			assert.Equal(t, attachments, evt.Message.Attachments)
+			require.NotNil(t, evt.Message.Card)
+			assert.Equal(t, "legacy-card-v1", evt.Message.Card.Template)
 			// Event-level Timestamp is publish-time (now), distinct from the historical
 			// domain editedAt carried inside Message.
 			assert.Greater(t, evt.Timestamp, editedAt.UnixMilli())
@@ -74,11 +94,98 @@ func TestHistoryService_MigrationEditMessage_Success(t *testing.T) {
 	assert.True(t, ack.OK)
 }
 
+// Edit-after-delete replay must ack idempotently: an unconditional update
+// would republish .updated with a fresh version and resurrect the doc in ES.
+func TestHistoryService_MigrationEditMessage_AlreadyDeletedAcksOK(t *testing.T) {
+	svc, msgs, _, pub, _ := newService(t)
+	c := testContext()
+
+	createdAt := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").
+		Return(&models.Message{MessageID: "msg-1", RoomID: "r1", CreatedAt: createdAt, Deleted: true}, nil)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	pub.EXPECT().PublishMigration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	ack, err := svc.MigrationEditMessage(c, "site-test", model.MigrationEditRequest{
+		MessageID: "msg-1", RoomID: "r1", CreatedAt: createdAt,
+		Content: "new body", EditedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ack)
+	assert.True(t, ack.OK)
+}
+
+// A transformer bug sending a mismatched RoomID must not edit whatever row
+// owns the message ID.
+func TestHistoryService_MigrationEditMessage_RoomMismatchRejected(t *testing.T) {
+	svc, msgs, _, pub, _ := newService(t)
+	c := testContext()
+
+	createdAt := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").
+		Return(&models.Message{MessageID: "msg-1", RoomID: "r-actual", CreatedAt: createdAt}, nil)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	pub.EXPECT().PublishMigration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	ack, err := svc.MigrationEditMessage(c, "site-test", model.MigrationEditRequest{
+		MessageID: "msg-1", RoomID: "r-other", CreatedAt: createdAt,
+		Content: "new body", EditedAt: time.Now().UTC(),
+	})
+	require.Error(t, err)
+	assert.Nil(t, ack)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.CodeNotFound, ec.Code)
+}
+
+func TestHistoryService_MigrationEditMessage_ReaderErrorPropagates(t *testing.T) {
+	svc, msgs, _, pub, _ := newService(t)
+	c := testContext()
+
+	readerErr := errors.New("cassandra down")
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(nil, readerErr)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	pub.EXPECT().PublishMigration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	_, err := svc.MigrationEditMessage(c, "site-test", model.MigrationEditRequest{
+		MessageID: "msg-1", RoomID: "r1", CreatedAt: time.Now().UTC(),
+		Content: "new body", EditedAt: time.Now().UTC(),
+	})
+	require.ErrorIs(t, err, readerErr, "reader failure must stay on the %w chain")
+}
+
+// Row vanished between the read and the keyed UPDATE (hard-missing on the
+// cipher-path read) — must map to a retryable NotFound, not a 5xx.
+func TestHistoryService_MigrationEditMessage_RowVanishesRetries(t *testing.T) {
+	svc, msgs, _, pub, _ := newService(t)
+	c := testContext()
+
+	createdAt := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").
+		Return(&models.Message{MessageID: "msg-1", RoomID: "r1", CreatedAt: createdAt}, nil)
+	msgs.EXPECT().
+		UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(fmt.Errorf("edit message msg-1: %w", cassrepo.ErrMessageNotFound))
+	pub.EXPECT().PublishMigration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	ack, err := svc.MigrationEditMessage(c, "site-test", model.MigrationEditRequest{
+		MessageID: "msg-1", RoomID: "r1", CreatedAt: createdAt,
+		Content: "new body", EditedAt: time.Now().UTC(),
+	})
+	require.Error(t, err)
+	assert.Nil(t, ack)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.CodeNotFound, ec.Code)
+}
+
 func TestHistoryService_MigrationEditMessage_WriterError(t *testing.T) {
 	svc, msgs, _, pub, _ := newService(t)
 	c := testContext()
 
 	createdAt := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").
+		Return(&models.Message{MessageID: "msg-1", RoomID: "r1", CreatedAt: createdAt}, nil)
 	msgs.EXPECT().
 		UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(errors.New("cassandra down"))
@@ -212,9 +319,12 @@ func TestHistoryService_MigrationEditMessage_AbsentRowRetries(t *testing.T) {
 	c := testContext()
 
 	createdAt := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	// Insert not yet persisted: the row lookup comes back empty, so no
+	// update and no publish happen.
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-5").Return(nil, nil)
 	msgs.EXPECT().
 		UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(fmt.Errorf("edit message msg-5: %w", cassrepo.ErrMessageNotFound))
+		Times(0)
 	pub.EXPECT().PublishMigration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 	ack, err := svc.MigrationEditMessage(c, "site-test", model.MigrationEditRequest{

--- a/pkg/model/attachment.go
+++ b/pkg/model/attachment.go
@@ -8,4 +8,5 @@ import "github.com/hmchangw/chat/pkg/model/cassandra"
 type (
 	Attachment      = cassandra.Attachment
 	ImageDimensions = cassandra.ImageDimensions
+	Card            = cassandra.Card
 )

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -2116,8 +2116,23 @@ func TestSearchMessageJSON(t *testing.T) {
 			EditedAt:              &edited,
 			UpdatedAt:             &updated,
 			ThreadParentMessageID: "p1",
+			Attachments: []model.Attachment{{
+				ID: "f1", Title: "q3.pdf", Description: "numbers",
+				Type: "file", FileType: "application/pdf",
+				TitleLink: "api/v1/file/rooms/r1/file/f1", TitleLinkDownload: true,
+			}},
+			Card: &model.Card{Template: "expense-v1", Data: []byte(`{"amount":42}`)},
 		}
 		roundTrip(t, &msg, &model.SearchMessage{})
+	})
+
+	t.Run("attachment and card fields omitted when empty", func(t *testing.T) {
+		msg := model.SearchMessage{MessageID: "m1", RoomID: "r1", Content: "hi"}
+		data, err := json.Marshal(&msg)
+		require.NoError(t, err)
+		for _, key := range []string{"attachments", "card"} {
+			assert.NotContains(t, string(data), `"`+key+`"`)
+		}
 	})
 
 	t.Run("optional fields omitted when zero", func(t *testing.T) {

--- a/pkg/model/search.go
+++ b/pkg/model/search.go
@@ -39,6 +39,11 @@ type SearchMessage struct {
 	UpdatedAt                    *time.Time `json:"updatedAt,omitempty"`
 	ThreadParentMessageID        string     `json:"threadParentMessageId,omitempty"`
 	ThreadParentMessageCreatedAt *time.Time `json:"threadParentMessageCreatedAt,omitempty"`
+
+	// Render payloads mirrored as-is from the message (same wire shape as
+	// history reads) so the client can render hits without a second lookup.
+	Attachments []Attachment `json:"attachments,omitempty"`
+	Card        *Card        `json:"card,omitempty"`
 }
 
 // SearchRoomsRequest is the NATS payload for

--- a/pkg/searchengine/adapter.go
+++ b/pkg/searchengine/adapter.go
@@ -212,6 +212,36 @@ func (a *httpAdapter) UpsertTemplate(ctx context.Context, name string, body json
 	return nil
 }
 
+// UpdateMapping PUTs an additive mapping onto every index matching pattern
+// (templates apply only at creation); a no-op on a fresh cluster.
+func (a *httpAdapter) UpdateMapping(ctx context.Context, indexPattern string, body json.RawMessage) error {
+	if indexPattern == "" {
+		return fmt.Errorf("update mapping: index pattern required")
+	}
+	path := fmt.Sprintf("/%s/_mapping?allow_no_indices=true&ignore_unavailable=true", indexPattern)
+	resp, err := a.do(ctx, "indices.put_mapping", indexPattern, func(ctx context.Context) (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut, path, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	})
+	if err != nil {
+		return fmt.Errorf("update mapping: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("update mapping: status %d, read body: %w", resp.StatusCode, readErr)
+		}
+		return fmt.Errorf("update mapping: status %d, body: %s", resp.StatusCode, respBody)
+	}
+	return nil
+}
+
 func (a *httpAdapter) PutScript(ctx context.Context, id string, body json.RawMessage) error {
 	resp, err := a.do(ctx, "put_script", "", func(ctx context.Context) (*http.Request, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPut, fmt.Sprintf("/_scripts/%s", id), bytes.NewReader(body))

--- a/pkg/searchengine/adapter_test.go
+++ b/pkg/searchengine/adapter_test.go
@@ -235,6 +235,46 @@ func TestAdapter_PutScript(t *testing.T) {
 	})
 }
 
+func TestAdapter_UpdateMapping(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var capturedBody string
+		ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+			assert.Equal(t, http.MethodPut, req.Method)
+			assert.Equal(t, "/messages-site1-*/_mapping", req.URL.Path)
+			assert.Equal(t, "true", req.URL.Query().Get("allow_no_indices"))
+			assert.Equal(t, "true", req.URL.Query().Get("ignore_unavailable"))
+			assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
+			body, _ := io.ReadAll(req.Body)
+			capturedBody = string(body)
+			return jsonResponse(200, `{"acknowledged": true}`), nil
+		}}
+		a := newAdapter(ft)
+		body := json.RawMessage(`{"properties":{"cardData":{"type":"text"}}}`)
+		err := a.UpdateMapping(context.Background(), "messages-site1-*", body)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(body), capturedBody)
+	})
+
+	t.Run("error status", func(t *testing.T) {
+		ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(400, `{"error":"mapper_parsing_exception"}`), nil
+		}}
+		a := newAdapter(ft)
+		err := a.UpdateMapping(context.Background(), "messages-*", json.RawMessage(`{}`))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "400")
+	})
+
+	t.Run("empty pattern rejected", func(t *testing.T) {
+		a := newAdapter(&fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+			t.Fatal("no request expected for empty pattern")
+			return nil, nil
+		}})
+		err := a.UpdateMapping(context.Background(), "", json.RawMessage(`{}`))
+		assert.Error(t, err)
+	})
+}
+
 func TestAdapter_Search(t *testing.T) {
 	t.Run("single index", func(t *testing.T) {
 		var capturedPath, capturedMethod, capturedBody string

--- a/pkg/searchengine/integration_test.go
+++ b/pkg/searchengine/integration_test.go
@@ -63,6 +63,33 @@ func TestNew_WithObservability_RecordsESSemanticSpan(t *testing.T) {
 	assert.Equal(t, index, attrValue(search.Attributes, "db.elasticsearch.path_parts.index"))
 }
 
+func TestSearchEngine_UpdateMapping_AppliesToExistingIndex(t *testing.T) {
+	esURL := testutil.Elasticsearch(t)
+	index := testutil.ElasticsearchIndex(t, "searchenginemap")
+
+	ctx := context.Background()
+	engine, err := New(ctx, Config{Backend: "elasticsearch", URL: esURL})
+	require.NoError(t, err)
+
+	// Materialize the index by writing a doc, then push a new field mapping.
+	_, err = engine.Bulk(ctx, []BulkAction{{
+		Action: ActionIndex, Index: index, DocID: "d1", Version: 1,
+		Doc: json.RawMessage(`{"content":"x"}`),
+	}})
+	require.NoError(t, err)
+
+	err = engine.UpdateMapping(ctx, index, json.RawMessage(`{"properties":{"cardData":{"type":"text"}}}`))
+	require.NoError(t, err)
+
+	mapping, err := engine.GetIndexMapping(ctx, index)
+	require.NoError(t, err)
+	assert.Contains(t, string(mapping), `"cardData"`)
+
+	// A pattern matching nothing must be a no-op, not an error.
+	err = engine.UpdateMapping(ctx, "no-such-index-pattern-*", json.RawMessage(`{"properties":{"x":{"type":"keyword"}}}`))
+	assert.NoError(t, err)
+}
+
 func spanNames(spans tracetest.SpanStubs) []string {
 	names := make([]string, len(spans))
 	for i := range spans {

--- a/pkg/searchengine/searchengine.go
+++ b/pkg/searchengine/searchengine.go
@@ -65,6 +65,10 @@ type SearchEngine interface {
 	// repeat the same script body once per action.
 	PutScript(ctx context.Context, id string, body json.RawMessage) error
 
+	// UpdateMapping PUTs an additive `{"properties":...}` onto every index
+	// matching pattern; templates apply only at creation, existing indices need this.
+	UpdateMapping(ctx context.Context, indexPattern string, body json.RawMessage) error
+
 	GetIndexMapping(ctx context.Context, index string) (json.RawMessage, error)
 
 	// Search executes a `_search` against the comma-joined list of indices

--- a/pkg/searchindex/version.go
+++ b/pkg/searchindex/version.go
@@ -27,3 +27,9 @@ func StripVersionBase(name string) string {
 	base, _, _ := StripVersion(name)
 	return base
 }
+
+// IndexPattern returns the wildcard covering every index of prefix's base, e.g.
+// "messages-a-v2" → "messages-a-*"; template and mapping push share it to avoid drift.
+func IndexPattern(prefix string) string {
+	return StripVersionBase(prefix) + "-*"
+}

--- a/pkg/searchindex/version_test.go
+++ b/pkg/searchindex/version_test.go
@@ -81,3 +81,16 @@ func TestStripVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestIndexPattern(t *testing.T) {
+	tests := []struct{ prefix, want string }{
+		{"messages-site1-v1", "messages-site1-*"},
+		{"messages-site1", "messages-site1-*"},
+		{"msgs-v12", "msgs-*"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.prefix, func(t *testing.T) {
+			assert.Equal(t, tt.want, IndexPattern(tt.prefix))
+		})
+	}
+}

--- a/search-service/integration_ccs_test.go
+++ b/search-service/integration_ccs_test.go
@@ -167,8 +167,10 @@ func buildTestTemplate(pattern string, properties map[string]any) json.RawMessag
 	return data
 }
 
-func messageTestTemplate() json.RawMessage {
-	return buildTestTemplate("messages-*", map[string]any{
+// messageTestTemplate mirrors the worker's prod message-index mapping; the
+// caller-supplied pattern keeps fixtures from governing each other's indices.
+func messageTestTemplate(pattern string) json.RawMessage {
+	return buildTestTemplate(pattern, map[string]any{
 		"messageId":   map[string]any{"type": "keyword"},
 		"roomId":      map[string]any{"type": "keyword"},
 		"siteId":      map[string]any{"type": "keyword"},
@@ -181,9 +183,15 @@ func messageTestTemplate() json.RawMessage {
 			},
 		},
 		"createdAt":                    map[string]any{"type": "date"},
+		"editedAt":                     map[string]any{"type": "date"},
+		"updatedAt":                    map[string]any{"type": "date"},
 		"threadParentMessageId":        map[string]any{"type": "keyword"},
 		"threadParentMessageCreatedAt": map[string]any{"type": "date"},
 		"tshow":                        map[string]any{"type": "boolean"},
+		"attachmentText":               map[string]any{"type": "text"},
+		"cardData":                     map[string]any{"type": "text"},
+		"attachments":                  map[string]any{"type": "object", "enabled": false},
+		"card":                         map[string]any{"type": "object", "enabled": false},
 	})
 }
 
@@ -254,9 +262,9 @@ func waitForRemoteConnected(t *testing.T, localURL, remoteName string, timeout t
 func (f *ccsFixture) installTemplates(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
-	require.NoError(t, f.localES.UpsertTemplate(ctx, "messages_template", messageTestTemplate()),
+	require.NoError(t, f.localES.UpsertTemplate(ctx, "messages_template", messageTestTemplate("messages-*")),
 		"upsert messages_template on local")
-	require.NoError(t, f.remoteES.UpsertTemplate(ctx, "messages_template", messageTestTemplate()),
+	require.NoError(t, f.remoteES.UpsertTemplate(ctx, "messages_template", messageTestTemplate("messages-*")),
 		"upsert messages_template on remote")
 	// user-room is local-only per the search-service architecture.
 	require.NoError(t, f.localES.UpsertTemplate(ctx, "user_room_template", userRoomTestTemplate()),

--- a/search-service/integration_messages_test.go
+++ b/search-service/integration_messages_test.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -22,6 +23,7 @@ import (
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/searchengine"
 	"github.com/hmchangw/chat/pkg/subject"
+	"github.com/hmchangw/chat/pkg/testutil"
 )
 
 type messagesV2Fixture struct {
@@ -41,7 +43,11 @@ func setupMessagesV2Fixture(t *testing.T) *messagesV2Fixture {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"hits":{"total":{"value":1},"hits":[{"_source":{` +
 			`"messageId":"m1","roomId":"r1","siteId":"site-a","userId":"u1",` +
-			`"userAccount":"alice","content":"hello","createdAt":"2026-04-01T12:00:00Z"}}]}}`))
+			`"userAccount":"alice","content":"hello","createdAt":"2026-04-01T12:00:00Z",` +
+			`"attachmentText":"q3.pdf numbers",` +
+			`"attachments":[{"id":"f1","title":"q3.pdf","type":"file","description":"numbers",` +
+			`"titleLink":"api/v1/file/rooms/r1/file/f1","titleLinkDownload":true,"fileType":"application/pdf"}],` +
+			`"card":{"template":"expense-v1","data":"eyJhbW91bnQiOjQyfQ=="}}}]}}`))
 	}))
 	t.Cleanup(esStub.Close)
 
@@ -85,6 +91,168 @@ func TestIntegration_SearchMessages_V2_HitProjection(t *testing.T) {
 	assert.Equal(t, "site-a", got.SiteID)
 	assert.Equal(t, "alice", got.UserAccount)
 	assert.Equal(t, "hello", got.Content)
+	require.Len(t, got.Attachments, 1)
+	assert.Equal(t, "q3.pdf", got.Attachments[0].Title)
+	assert.Equal(t, "numbers", got.Attachments[0].Description)
+	assert.Equal(t, "application/pdf", got.Attachments[0].FileType)
+	assert.Equal(t, "api/v1/file/rooms/r1/file/f1", got.Attachments[0].TitleLink)
+	require.NotNil(t, got.Card)
+	assert.Equal(t, "expense-v1", got.Card.Template)
+	assert.Equal(t, []byte(`{"amount":42}`), got.Card.Data)
+}
+
+// Queue group for the real-ES edit/delete propagation fixture — isolated so a
+// slow drain can't deliver to a sibling test's handler.
+const testQueueGroupDelCheck = "search-service-test-delcheck"
+
+// End-to-end vs real ES: after the worker's externally-versioned write sequence,
+// search finds only edited content, never deleted docs; stale replays can't resurrect.
+func TestIntegration_SearchMessages_EditedAndDeletedDocs(t *testing.T) {
+	esURL := testutil.Elasticsearch(t)
+	ctx := context.Background()
+
+	const (
+		index   = "messages-delcheck-v1-2026-01"
+		account = "delcheck-alice"
+		roomID  = "room-delcheck"
+	)
+
+	engine, err := searchengine.New(ctx, searchengine.Config{Backend: "elasticsearch", URL: esURL})
+	require.NoError(t, err)
+	// roomId must map keyword (dynamic text breaks the terms-lookup room gate);
+	// the fixture-scoped pattern keeps it from governing sibling tests.
+	require.NoError(t, engine.UpsertTemplate(ctx, "messages-delcheck-template", messageTestTemplate("messages-delcheck-*")))
+	t.Cleanup(func() {
+		targets := []string{
+			"/" + index,
+			"/_index_template/messages-delcheck-template",
+			fmt.Sprintf("/%s/_doc/%s?refresh=true", testUserRoomIndex, account),
+		}
+		for _, target := range targets {
+			req, _ := http.NewRequest(http.MethodDelete, esURL+target, nil)
+			resp, delErr := testHTTPClient.Do(req)
+			if delErr == nil {
+				resp.Body.Close()
+			}
+		}
+	})
+
+	// Room access: terms-lookup resolves the caller's rooms from this doc.
+	seedDoc(t, esURL, testUserRoomIndex, account, map[string]any{
+		"userAccount": account,
+		"rooms":       []string{roomID},
+	})
+
+	msgDoc := func(id, content string, extra map[string]any) json.RawMessage {
+		doc := map[string]any{
+			"messageId": id, "roomId": roomID, "siteId": testSiteID,
+			"userId": "u-del", "userAccount": account,
+			"content": content, "createdAt": "2026-01-15T10:30:00Z",
+		}
+		for k, v := range extra {
+			doc[k] = v
+		}
+		data, mErr := json.Marshal(doc)
+		require.NoError(t, mErr)
+		return data
+	}
+	mustBulk := func(actions ...searchengine.BulkAction) []searchengine.BulkResult {
+		results, bErr := engine.Bulk(ctx, actions)
+		require.NoError(t, bErr)
+		return results
+	}
+	okBulk := func(actions ...searchengine.BulkAction) {
+		for _, res := range mustBulk(actions...) {
+			require.Less(t, res.Status, 300, "bulk write failed: %+v", res)
+		}
+	}
+
+	// Worker write sequence: m1 created (v1000) then edited (replace, v2000,
+	// +attachment); m2 created (v1000) then deleted (v2000).
+	okBulk(searchengine.BulkAction{Action: searchengine.ActionIndex, Index: index, DocID: "m1", Version: 1000,
+		Doc: msgDoc("m1", "original words before edit", nil)})
+	okBulk(searchengine.BulkAction{Action: searchengine.ActionIndex, Index: index, DocID: "m2", Version: 1000,
+		Doc: msgDoc("m2", "secret that must vanish", nil)})
+	okBulk(searchengine.BulkAction{Action: searchengine.ActionIndex, Index: index, DocID: "m1", Version: 2000,
+		Doc: msgDoc("m1", "edited words after edit", map[string]any{
+			"editedAt": "2026-01-15T11:00:00Z", "updatedAt": "2026-01-15T11:00:00Z",
+			"attachmentText": "q3-report.pdf",
+			"attachments": []map[string]any{{
+				"id": "f1", "title": "q3-report.pdf", "type": "file",
+				"titleLink":         "api/v1/file/rooms/" + roomID + "/file/f1",
+				"titleLinkDownload": true, "fileType": "application/pdf",
+			}},
+		})})
+	okBulk(searchengine.BulkAction{Action: searchengine.ActionDelete, Index: index, DocID: "m2", Version: 2000})
+
+	// Stale redelivery of m2's create (older external version) must be
+	// version-rejected, not resurrect the doc.
+	staleResults := mustBulk(searchengine.BulkAction{Action: searchengine.ActionIndex, Index: index, DocID: "m2", Version: 1000,
+		Doc: msgDoc("m2", "secret that must vanish", nil)})
+	require.Len(t, staleResults, 1)
+	require.Equal(t, http.StatusConflict, staleResults[0].Status, "stale replay must hit the external-version tombstone")
+
+	refreshReq, err := http.NewRequest(http.MethodPost, esURL+"/"+index+"/_refresh", nil)
+	require.NoError(t, err)
+	refreshResp, err := testHTTPClient.Do(refreshReq)
+	require.NoError(t, err)
+	refreshResp.Body.Close()
+
+	// Real handler + real ES store + real NATS RPC.
+	fakeValkey := newFakeCache()
+	fakeValkey.store[account] = map[string]int64{} // no restricted rooms, cache hit
+	h := newHandler(newESStore(engine, testUserRoomIndex), nil, nil, fakeValkey, &handlerConfig{
+		SiteID:                  testSiteID,
+		DocCounts:               25,
+		MaxDocCounts:            100,
+		RestrictedRoomsCacheTTL: 5 * time.Minute,
+		RecentWindow:            10 * 365 * 24 * time.Hour,
+		RequestTimeout:          5 * time.Second,
+		UserRoomIndex:           testUserRoomIndex,
+		SpotlightReadPattern:    "spotlight-*",
+	})
+	clientNATS := setupRouter(t, testQueueGroupDelCheck, h.Register)
+
+	search := func(query string) model.SearchMessagesResponse {
+		reqBytes, mErr := json.Marshal(model.SearchMessagesRequest{Query: query})
+		require.NoError(t, mErr)
+		msg, rErr := clientNATS.Request(subject.SearchMessages(account, testSiteID), reqBytes, 5*time.Second)
+		require.NoError(t, rErr)
+		var resp model.SearchMessagesResponse
+		require.NoError(t, json.Unmarshal(msg.Data, &resp))
+		return resp
+	}
+
+	t.Run("edited message found only with updated content", func(t *testing.T) {
+		resp := search("edited words")
+		require.Len(t, resp.Messages, 1)
+		assert.Equal(t, "m1", resp.Messages[0].MessageID)
+		assert.Equal(t, "edited words after edit", resp.Messages[0].Content)
+		require.NotNil(t, resp.Messages[0].EditedAt)
+	})
+
+	t.Run("pre-edit content is gone", func(t *testing.T) {
+		resp := search("original words")
+		assert.Empty(t, resp.Messages)
+		assert.Zero(t, resp.Total)
+	})
+
+	t.Run("deleted message never surfaces, even after stale replay", func(t *testing.T) {
+		resp := search("secret")
+		assert.Empty(t, resp.Messages)
+		assert.Zero(t, resp.Total)
+	})
+
+	t.Run("attachment filename matches and hit carries the full object", func(t *testing.T) {
+		resp := search("q3")
+		require.Len(t, resp.Messages, 1)
+		assert.Equal(t, "m1", resp.Messages[0].MessageID)
+		require.Len(t, resp.Messages[0].Attachments, 1)
+		att := resp.Messages[0].Attachments[0]
+		assert.Equal(t, "q3-report.pdf", att.Title)
+		assert.Equal(t, "application/pdf", att.FileType)
+		assert.Equal(t, "api/v1/file/rooms/"+roomID+"/file/f1", att.TitleLink)
+	})
 }
 
 func TestIntegration_SearchMessages_V2_EmptyQueryReturnsBadRequest(t *testing.T) {

--- a/search-service/query_messages.go
+++ b/search-service/query_messages.go
@@ -35,6 +35,9 @@ func buildMessageQuery(req model.SearchMessagesRequest, account string, restrict
 		"from":             req.Offset,
 		"size":             req.Size,
 		"track_total_hits": true,
+		// Search-only fields never ship on hits: cardData is a large blob and
+		// attachmentText duplicates what the `attachments` objects carry.
+		"_source": map[string]any{"excludes": []string{"cardData", "attachmentText"}},
 		"query": map[string]any{
 			"bool": map[string]any{
 				"must": []any{
@@ -43,7 +46,9 @@ func buildMessageQuery(req model.SearchMessagesRequest, account string, restrict
 							"query":    req.Query,
 							"type":     "bool_prefix",
 							"operator": "AND",
-							"fields":   []string{"content"},
+							// Message text, attachment titles+descriptions (one
+							// pooled field) and tcard data — one query box.
+							"fields": []string{"content", "attachmentText", "cardData"},
 						},
 					},
 				},

--- a/search-service/query_messages_test.go
+++ b/search-service/query_messages_test.go
@@ -52,6 +52,30 @@ func TestBuildMessageQuery_GlobalUnrestricted(t *testing.T) {
 	assert.Equal(t, "rooms", lookup["path"])
 }
 
+// One query box searches message text, file names/descriptions and tcard
+// text together.
+func TestBuildMessageQuery_SearchesAttachmentAndCardFields(t *testing.T) {
+	req := model.SearchMessagesRequest{Query: "report", Size: 25}
+	raw, err := buildMessageQuery(req, "alice", nil, 365*24*time.Hour, "user-room")
+	require.NoError(t, err)
+
+	q := parseQuery(t, raw)
+	musts := q["query"].(map[string]any)["bool"].(map[string]any)["must"].([]any)
+	require.Len(t, musts, 1)
+	mm := musts[0].(map[string]any)["multi_match"].(map[string]any)
+	assert.Equal(t, "report", mm["query"])
+	assert.Equal(t, "bool_prefix", mm["type"])
+	assert.Equal(t, "AND", mm["operator"])
+	assert.Equal(t,
+		[]any{"content", "attachmentText", "cardData"},
+		mm["fields"])
+
+	// Search-only fields never ship on hits: cardData is a (possibly large)
+	// blob and the attachment projections are already inside `attachments`.
+	src := q["_source"].(map[string]any)
+	assert.Equal(t, []any{"cardData", "attachmentText"}, src["excludes"])
+}
+
 func TestBuildMessageQuery_GlobalWithRestricted(t *testing.T) {
 	req := model.SearchMessagesRequest{Query: "hi", Size: 10, Offset: 5}
 	restricted := map[string]int64{

--- a/search-service/response.go
+++ b/search-service/response.go
@@ -27,17 +27,19 @@ type rawResponse[T any] struct {
 // Fields mirror the ES messages-* index; the public reply type
 // (model.SearchMessage) is a projection of this struct with `UserID` dropped.
 type messageSearchHit struct {
-	MessageID             string     `json:"messageId"`
-	RoomID                string     `json:"roomId"`
-	SiteID                string     `json:"siteId"`
-	UserID                string     `json:"userId"`
-	UserAccount           string     `json:"userAccount"`
-	Content               string     `json:"content"`
-	CreatedAt             time.Time  `json:"createdAt"`
-	EditedAt              *time.Time `json:"editedAt,omitempty"`
-	UpdatedAt             *time.Time `json:"updatedAt,omitempty"`
-	ThreadParentID        string     `json:"threadParentMessageId,omitempty"`
-	ThreadParentCreatedAt *time.Time `json:"threadParentMessageCreatedAt,omitempty"`
+	MessageID             string             `json:"messageId"`
+	RoomID                string             `json:"roomId"`
+	SiteID                string             `json:"siteId"`
+	UserID                string             `json:"userId"`
+	UserAccount           string             `json:"userAccount"`
+	Content               string             `json:"content"`
+	CreatedAt             time.Time          `json:"createdAt"`
+	EditedAt              *time.Time         `json:"editedAt,omitempty"`
+	UpdatedAt             *time.Time         `json:"updatedAt,omitempty"`
+	ThreadParentID        string             `json:"threadParentMessageId,omitempty"`
+	ThreadParentCreatedAt *time.Time         `json:"threadParentMessageCreatedAt,omitempty"`
+	Attachments           []model.Attachment `json:"attachments,omitempty"`
+	Card                  *model.Card        `json:"card,omitempty"`
 }
 
 // roomSearchHit is the spotlight ES `_source` shape for a room
@@ -88,6 +90,8 @@ func toSearchMessage(hit *messageSearchHit) model.SearchMessage {
 		UpdatedAt:                    hit.UpdatedAt,
 		ThreadParentMessageID:        hit.ThreadParentID,
 		ThreadParentMessageCreatedAt: hit.ThreadParentCreatedAt,
+		Attachments:                  hit.Attachments,
+		Card:                         hit.Card,
 	}
 }
 

--- a/search-service/response_test.go
+++ b/search-service/response_test.go
@@ -128,6 +128,44 @@ func TestToSearchMessage_ThreadParentBothFieldsCopied(t *testing.T) {
 	assert.True(t, got.ThreadParentMessageCreatedAt.Equal(tp))
 }
 
+// Full attachment objects and the card ride the hit so the client can render
+// the result (file row, tcard) without a history-service lookup.
+func TestToSearchMessage_AttachmentAndCardFieldsCopied(t *testing.T) {
+	hit := messageSearchHit{
+		MessageID:   "m1",
+		RoomID:      "r1",
+		UserAccount: "alice",
+		Attachments: []model.Attachment{
+			{ID: "f1", Title: "q3-report.pdf", Description: "Quarterly numbers", FileType: "application/pdf", TitleLink: "api/v1/file/rooms/r1/file/f1", TitleLinkDownload: true},
+			{ID: "f2", Title: "team.png", FileType: "image/png"},
+		},
+		Card: &model.Card{Template: "expense-approval-v1", Data: []byte(`{"amount":42}`)},
+	}
+	got := toSearchMessage(&hit)
+	require.Len(t, got.Attachments, 2)
+	assert.Equal(t, "q3-report.pdf", got.Attachments[0].Title)
+	assert.Equal(t, "Quarterly numbers", got.Attachments[0].Description)
+	assert.Equal(t, "api/v1/file/rooms/r1/file/f1", got.Attachments[0].TitleLink)
+	require.NotNil(t, got.Card)
+	assert.Equal(t, "expense-approval-v1", got.Card.Template)
+	assert.Equal(t, []byte(`{"amount":42}`), got.Card.Data)
+}
+
+// A text-only hit must not grow attachment/card keys on the wire.
+func TestToSearchMessage_AttachmentAndCardOmittedWhenAbsent(t *testing.T) {
+	hit := messageSearchHit{MessageID: "m1", RoomID: "r1", UserAccount: "alice", Content: "hello"}
+	got := toSearchMessage(&hit)
+
+	data, err := json.Marshal(got)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	for _, key := range []string{"attachments", "card"} {
+		_, present := raw[key]
+		assert.False(t, present, "%s should be omitted when empty", key)
+	}
+}
+
 func TestParseRooms_HappyPath(t *testing.T) {
 	body := json.RawMessage(`{
 		"hits": {

--- a/search-sync-worker/collection.go
+++ b/search-sync-worker/collection.go
@@ -26,6 +26,9 @@ type Collection interface {
 	TemplateName() string
 	// TemplateBody returns the ES index template JSON. nil means no template.
 	TemplateBody() json.RawMessage
+	// MappingUpdate returns a pattern + additive `{"properties":...}` PUT onto
+	// existing indices at startup (rolling indices only). Empty/nil = no update.
+	MappingUpdate() (indexPattern string, body json.RawMessage)
 	// StoredScripts returns the ES stored scripts this collection depends on,
 	// keyed by script id. Each value is the full `PUT /_scripts/{id}` body.
 	// nil/empty means the collection inlines no scripts (or uses none). The

--- a/search-sync-worker/handler_test.go
+++ b/search-sync-worker/handler_test.go
@@ -315,6 +315,7 @@ func (c stubCollection) FilterSubjects(string) []string             { return nil
 func (c stubCollection) TemplateName() string                       { return "" }
 func (c stubCollection) TemplateBody() json.RawMessage              { return nil }
 func (c stubCollection) StoredScripts() map[string]json.RawMessage  { return nil }
+func (c stubCollection) MappingUpdate() (string, json.RawMessage)   { return "", nil }
 func (c stubCollection) BuildAction([]byte) ([]searchengine.BulkAction, error) {
 	return []searchengine.BulkAction{{Action: c.action, Index: "stub", DocID: "id-1"}}, nil
 }
@@ -349,6 +350,7 @@ func (c fanOutCollection) FilterSubjects(string) []string            { return ni
 func (c fanOutCollection) TemplateName() string                      { return "" }
 func (c fanOutCollection) TemplateBody() json.RawMessage             { return nil }
 func (c fanOutCollection) StoredScripts() map[string]json.RawMessage { return nil }
+func (c fanOutCollection) MappingUpdate() (string, json.RawMessage)  { return "", nil }
 func (c fanOutCollection) BuildAction([]byte) ([]searchengine.BulkAction, error) {
 	actions := make([]searchengine.BulkAction, 0, c.actionsPerMessage)
 	for i := 0; i < c.actionsPerMessage; i++ {
@@ -605,6 +607,7 @@ func (c *captureCollection) FilterSubjects(string) []string            { return 
 func (c *captureCollection) TemplateName() string                      { return "" }
 func (c *captureCollection) TemplateBody() json.RawMessage             { return nil }
 func (c *captureCollection) StoredScripts() map[string]json.RawMessage { return nil }
+func (c *captureCollection) MappingUpdate() (string, json.RawMessage)  { return "", nil }
 func (c *captureCollection) BuildAction(data []byte) ([]searchengine.BulkAction, error) {
 	c.received = append(c.received[:0], data...)
 	return nil, nil

--- a/search-sync-worker/inbox_stream.go
+++ b/search-sync-worker/inbox_stream.go
@@ -43,6 +43,12 @@ func (b *inboxMemberCollection) StoredScripts() map[string]json.RawMessage {
 	return nil
 }
 
+// MappingUpdate returns none: fixed indices are already governed by their
+// template; only rolling-index collections need startup mapping pushes.
+func (b *inboxMemberCollection) MappingUpdate() (string, json.RawMessage) {
+	return "", nil
+}
+
 // parseMemberEvent decodes an INBOX message into an InboxEvent + its
 // InboxMemberEvent payload and validates the common preconditions shared by
 // all inbox-member collections.

--- a/search-sync-worker/integration_test.go
+++ b/search-sync-worker/integration_test.go
@@ -291,6 +291,10 @@ func TestSearchSyncIntegration(t *testing.T) {
 			subj = subject.MsgCanonicalUpdated(siteID)
 		case model.EventDeleted:
 			subj = subject.MsgCanonicalDeleted(siteID)
+		case model.EventPinned:
+			subj = subject.MsgCanonicalPinned(siteID)
+		case model.EventUnpinned:
+			subj = subject.MsgCanonicalUnpinned(siteID)
 		default:
 			t.Fatalf("unsupported event type in fixture: %q", evt.Event)
 		}
@@ -321,10 +325,10 @@ func TestSearchSyncIntegration(t *testing.T) {
 	// --- Verify results in Elasticsearch ---
 	refreshIndex(t, esURL, prefix+"-*")
 
-	// Total doc count: 5 created - 1 deleted = 4
+	// Total doc count: 6 created - 1 deleted = 5 (pinned/unpinned produce no actions)
 	t.Run("total doc count", func(t *testing.T) {
 		total := countDocs(t, esURL, prefix+"-*")
-		assert.Equal(t, 4, total, "expected 4 docs total (5 created, 1 update replacing, 1 delete)")
+		assert.Equal(t, 5, total, "expected 5 docs total (6 created, 1 update replacing, 1 delete, pin/unpin skipped)")
 	})
 
 	// January index: msg-001 (updated), msg-003 → 2 docs
@@ -333,14 +337,15 @@ func TestSearchSyncIntegration(t *testing.T) {
 		assert.Equal(t, 2, janCount, "expected 2 docs in 2026-01 index")
 	})
 
-	// February index: msg-004, msg-005 → 2 docs
+	// February index: msg-004, msg-005, msg-006 → 3 docs
 	t.Run("february index count", func(t *testing.T) {
 		febCount := countDocs(t, esURL, prefix+"-2026-02")
-		assert.Equal(t, 2, febCount, "expected 2 docs in 2026-02 index")
+		assert.Equal(t, 3, febCount, "expected 3 docs in 2026-02 index")
 	})
 
-	// Verify msg-001 was updated (content should be edited version)
-	t.Run("msg-001 updated content", func(t *testing.T) {
+	// Verify msg-001 was updated (content should be edited version) and that
+	// the later pinned event did NOT wipe the document (slim events are skipped).
+	t.Run("msg-001 updated content survives pin", func(t *testing.T) {
 		doc := getDoc(t, esURL, prefix+"-2026-01", "msg-001")
 		require.NotNil(t, doc, "msg-001 should exist")
 		assert.Equal(t, "hello world (edited)", doc["content"])
@@ -348,10 +353,38 @@ func TestSearchSyncIntegration(t *testing.T) {
 		assert.Equal(t, "room-1", doc["roomId"])
 	})
 
-	// Verify msg-002 was deleted
-	t.Run("msg-002 deleted", func(t *testing.T) {
+	// Verify msg-002 was deleted and that the later unpinned event did NOT
+	// resurrect a stub document.
+	t.Run("msg-002 deleted and not resurrected by unpin", func(t *testing.T) {
 		doc := getDoc(t, esURL, prefix+"-2026-01", "msg-002")
-		assert.Nil(t, doc, "msg-002 should be deleted")
+		assert.Nil(t, doc, "msg-002 should stay deleted")
+	})
+
+	// Verify msg-006 carries the searched projections AND the render payloads.
+	t.Run("msg-006 attachment and card fields", func(t *testing.T) {
+		doc := getDoc(t, esURL, prefix+"-2026-02", "msg-006")
+		require.NotNil(t, doc, "msg-006 should exist")
+		assert.Equal(t, "q3-report.pdf Quarterly numbers", doc["attachmentText"])
+		cardData, _ := doc["cardData"].(string)
+		assert.Contains(t, cardData, "Expense request from Bob")
+
+		atts, ok := doc["attachments"].([]any)
+		require.True(t, ok, "full attachment objects must be stored")
+		require.Len(t, atts, 1)
+		att := atts[0].(map[string]any)
+		assert.Equal(t, "q3-report.pdf", att["title"])
+		assert.Equal(t, "application/pdf", att["fileType"])
+		card, ok := doc["card"].(map[string]any)
+		require.True(t, ok, "full card object must be stored")
+		assert.Equal(t, "expense-approval-v1", card["template"])
+		assert.NotEmpty(t, card["data"], "card data must be stored for rendering")
+	})
+
+	// Full-text search must now match attachment titles, descriptions and card text.
+	t.Run("search matches attachment and card fields", func(t *testing.T) {
+		assert.Equal(t, 1, searchHitsMultiField(t, esURL, prefix+"-*", "q3-report.pdf"), "filename should match")
+		assert.Equal(t, 1, searchHitsMultiField(t, esURL, prefix+"-*", "Quarterly"), "attachment description should match")
+		assert.Equal(t, 1, searchHitsMultiField(t, esURL, prefix+"-*", "Expense request"), "card text should match")
 	})
 
 	// Verify msg-003 exists with correct content
@@ -369,6 +402,35 @@ func TestSearchSyncIntegration(t *testing.T) {
 		assert.Equal(t, "february message", doc["content"])
 		assert.Equal(t, "charlie", doc["userAccount"])
 	})
+}
+
+// searchHitsMultiField mirrors the search-service message query: a multi_match
+// bool_prefix over content + attachment + card text fields.
+func searchHitsMultiField(t *testing.T, esURL, indexPattern, query string) int {
+	t.Helper()
+	body := fmt.Sprintf(`{"query":{"multi_match":{"query":%q,"type":"bool_prefix","operator":"AND","fields":["content","attachmentText","cardData"]}}}`, query)
+	u := esURLFor(t, esURL, indexPattern, "_search")
+	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewBufferString(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var result struct {
+		Hits struct {
+			Total struct {
+				Value int `json:"value"`
+			} `json:"total"`
+		} `json:"hits"`
+	}
+	require.NoError(t, json.Unmarshal(respBody, &result))
+	return result.Hits.Total.Value
 }
 
 // searchHits queries ES for docs where the content field matches the given query string.

--- a/search-sync-worker/main.go
+++ b/search-sync-worker/main.go
@@ -166,6 +166,11 @@ func main() {
 		slog.Info("index template upserted", "name", name)
 	}
 
+	if err := pushMappings(ctx, engine, collections); err != nil {
+		slog.Error("update index mapping failed", "error", err)
+		os.Exit(1)
+	}
+
 	// Register stored scripts before any consumer starts so the first scripted update already
 	// resolves the script id; idempotent across pods (PUT _scripts is last-write-wins).
 	for _, coll := range collections {
@@ -319,6 +324,22 @@ func main() {
 		// obsShutdown LAST so drain-window flush spans/logs are exported.
 		func(ctx context.Context) error { return obsShutdown(ctx) },
 	)
+}
+
+// pushMappings PUTs each collection's additive mapping onto existing indices;
+// templates cover only new ones, so new fields stay unmapped until rollover.
+func pushMappings(ctx context.Context, engine searchengine.SearchEngine, collections []Collection) error {
+	for _, coll := range collections {
+		pattern, body := coll.MappingUpdate()
+		if pattern == "" || len(body) == 0 {
+			continue
+		}
+		if err := engine.UpdateMapping(ctx, pattern, body); err != nil {
+			return fmt.Errorf("update mapping %s: %w", pattern, err)
+		}
+		slog.Info("index mapping updated", "pattern", pattern)
+	}
+	return nil
 }
 
 // runConsumer is the batch-flush consumer loop: fetchBatchSize bounds JetStream Fetch() pulls

--- a/search-sync-worker/main_test.go
+++ b/search-sync-worker/main_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/searchengine"
+)
+
+// fakeEngine implements searchengine.SearchEngine, recording UpdateMapping calls.
+type fakeEngine struct {
+	mappingPatterns []string
+	mappingErr      error
+}
+
+func (f *fakeEngine) Ping(context.Context) error { return nil }
+func (f *fakeEngine) Bulk(context.Context, []searchengine.BulkAction) ([]searchengine.BulkResult, error) {
+	return nil, nil
+}
+func (f *fakeEngine) UpsertTemplate(context.Context, string, json.RawMessage) error { return nil }
+func (f *fakeEngine) PutScript(context.Context, string, json.RawMessage) error      { return nil }
+func (f *fakeEngine) UpdateMapping(_ context.Context, pattern string, _ json.RawMessage) error {
+	f.mappingPatterns = append(f.mappingPatterns, pattern)
+	return f.mappingErr
+}
+func (f *fakeEngine) GetIndexMapping(context.Context, string) (json.RawMessage, error) {
+	return nil, nil
+}
+func (f *fakeEngine) GetDoc(context.Context, string, string) (json.RawMessage, bool, error) {
+	return nil, false, nil
+}
+func (f *fakeEngine) Search(context.Context, []string, json.RawMessage) (json.RawMessage, error) {
+	return nil, nil
+}
+
+// Only collections that expose a mapping (messages) are pushed; the fixed-
+// index collections (spotlight, spotlight-org, user-room) are skipped.
+func TestPushMappings_PushesOnlyCollectionsWithMappings(t *testing.T) {
+	eng := &fakeEngine{}
+	collections := []Collection{
+		newMessageCollection("messages-x-v1", time.Time{}, false),
+		newSpotlightCollection("spotlight-x", false),
+		newSpotlightOrgCollection("spotlight-org-x", "s1", "hr", false),
+		newUserRoomCollection("user-room-x"),
+	}
+
+	require.NoError(t, pushMappings(context.Background(), eng, collections))
+	assert.Equal(t, []string{"messages-x-*"}, eng.mappingPatterns,
+		"pattern is version-stripped so pre-bump indices are covered too")
+}
+
+// A non-nil but zero-length body is still "no update" — it must never
+// reach the mapping endpoint as an empty PUT.
+type emptyBodyMappingCollection struct{ stubCollection }
+
+func (emptyBodyMappingCollection) MappingUpdate() (string, json.RawMessage) {
+	return "messages-x-*", json.RawMessage{}
+}
+
+func TestPushMappings_SkipsEmptyBody(t *testing.T) {
+	eng := &fakeEngine{}
+	require.NoError(t, pushMappings(context.Background(), eng, []Collection{emptyBodyMappingCollection{}}))
+	assert.Empty(t, eng.mappingPatterns, "zero-length body must be skipped")
+}
+
+func TestPushMappings_PropagatesEngineError(t *testing.T) {
+	engineErr := errors.New("es down")
+	eng := &fakeEngine{mappingErr: engineErr}
+	collections := []Collection{newMessageCollection("messages-x-v1", time.Time{}, false)}
+
+	err := pushMappings(context.Background(), eng, collections)
+	require.ErrorIs(t, err, engineErr, "engine failure must stay on the %w chain")
+	assert.Contains(t, err.Error(), "messages-x-*", "error names the failing pattern")
+	assert.Equal(t, []string{"messages-x-*"}, eng.mappingPatterns)
+}

--- a/search-sync-worker/messages.go
+++ b/search-sync-worker/messages.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/pkg/searchengine"
 	"github.com/hmchangw/chat/pkg/searchindex"
 	"github.com/hmchangw/chat/pkg/stream"
@@ -87,6 +89,14 @@ func (c *messageCollection) StoredScripts() map[string]json.RawMessage {
 	return nil
 }
 
+// MappingUpdate pushes the full (idempotent) property set onto existing
+// monthly indices; the same pattern the template targets.
+func (c *messageCollection) MappingUpdate() (string, json.RawMessage) {
+	// Error discarded: input is a static map of literals, marshal cannot fail.
+	body, _ := json.Marshal(map[string]any{"properties": messageTemplateProperties()})
+	return searchindex.IndexPattern(c.indexPrefix), body
+}
+
 func (c *messageCollection) BuildAction(data []byte) ([]searchengine.BulkAction, error) {
 	var evt model.MessageEvent
 	if err := json.Unmarshal(data, &evt); err != nil {
@@ -104,8 +114,9 @@ func (c *messageCollection) BuildAction(data []byte) ([]searchengine.BulkAction,
 	if !c.syncFrom.IsZero() && evt.Message.CreatedAt.Before(c.syncFrom) {
 		return nil, nil
 	}
-	// Reactions don't change indexed content; skip rather than re-upserting the same document with a bumped updatedAt.
-	if evt.Event == model.EventReacted {
+	// Slim events (reacted/pinned/unpinned/…) carry no content: upserting them
+	// would wipe indexed fields or resurrect deleted docs. "" = legacy created.
+	if !actionableEvent(evt.Event) {
 		return nil, nil
 	}
 	c.resolveThreadParentCreatedAt(&evt)
@@ -128,8 +139,19 @@ func (c *messageCollection) resolveThreadParentCreatedAt(evt *model.MessageEvent
 
 // --- Message-specific internals ---
 
+// actionableEvent reports whether an event type produces a bulk action at
+// all — index/replace (created, updated, legacy "") or delete (deleted).
+func actionableEvent(e model.EventType) bool {
+	switch e {
+	case model.EventCreated, model.EventUpdated, model.EventDeleted, "":
+		return true
+	default:
+		return false
+	}
+}
+
 // MessageSearchIndex is the Elasticsearch document for messages, mirroring pkg/model.Message; the
-// `es` struct tag (keyword/text/date/boolean, or text,custom_analyzer) drives the template — add new Message fields here with an `es` tag and populate them in newMessageSearchIndex().
+// `es` tag (keyword/text/date/boolean, text,custom_analyzer, or object_disabled) drives the template — add new Message fields here and populate them in newMessageSearchIndex().
 type MessageSearchIndex struct {
 	MessageID   string `json:"messageId"                              es:"keyword"`
 	RoomID      string `json:"roomId"                                 es:"keyword"`
@@ -145,11 +167,22 @@ type MessageSearchIndex struct {
 	ThreadParentID        string     `json:"threadParentMessageId,omitempty"        es:"keyword"`
 	ThreadParentCreatedAt *time.Time `json:"threadParentMessageCreatedAt,omitempty" es:"date"`
 	TShow                 bool       `json:"tshow,omitempty"                        es:"boolean"`
+
+	// Searched attachment/tcard projections. AttachmentText is one string —
+	// every attachment title+description joined — so an AND query can mix
+	// words from both. CardData duplicates card.data — accepted.
+	AttachmentText string `json:"attachmentText,omitempty" es:"text,custom_analyzer"`
+	CardData       string `json:"cardData,omitempty"       es:"text,custom_analyzer"`
+
+	// Render payloads stored as-is (never indexed) so search hits can be
+	// rendered on the frontend without a history-service lookup.
+	Attachments []cassandra.Attachment `json:"attachments,omitempty" es:"object_disabled"`
+	Card        *cassandra.Card        `json:"card,omitempty"        es:"object_disabled"`
 }
 
 // newMessageSearchIndex maps a MessageEvent to a search index document.
 func newMessageSearchIndex(evt *model.MessageEvent) MessageSearchIndex {
-	return MessageSearchIndex{
+	doc := MessageSearchIndex{
 		MessageID:             evt.Message.ID,
 		RoomID:                evt.Message.RoomID,
 		SiteID:                evt.SiteID,
@@ -164,6 +197,29 @@ func newMessageSearchIndex(evt *model.MessageEvent) MessageSearchIndex {
 		ThreadParentCreatedAt: evt.Message.ThreadParentMessageCreatedAt,
 		TShow:                 evt.Message.TShow,
 	}
+
+	// Lenient decode: a malformed blob is skipped by DecodeAttachments; one
+	// bad attachment must not block indexing the rest of the message.
+	attachments, _ := cassandra.DecodeAttachments(evt.Message.Attachments)
+	doc.Attachments = attachments
+	var attachmentText []string
+	for i := range attachments {
+		a := &attachments[i]
+		if a.Title != "" {
+			attachmentText = append(attachmentText, a.Title)
+		}
+		if a.Description != "" {
+			attachmentText = append(attachmentText, a.Description)
+		}
+	}
+	doc.AttachmentText = strings.Join(attachmentText, " ")
+
+	if evt.Message.Card != nil {
+		doc.Card = evt.Message.Card
+		doc.CardData = string(evt.Message.Card.Data)
+	}
+
+	return doc
 }
 
 func indexName(prefix string, createdAt time.Time) string {
@@ -212,7 +268,7 @@ func messageTemplateBody(prefix string, devMode bool) json.RawMessage {
 		replicas = 0
 	}
 	tmpl := map[string]any{
-		"index_patterns": []string{fmt.Sprintf("%s-*", searchindex.StripVersionBase(prefix))},
+		"index_patterns": []string{searchindex.IndexPattern(prefix)},
 		"template": map[string]any{
 			"settings": map[string]any{
 				"index": map[string]any{

--- a/search-sync-worker/messages_test.go
+++ b/search-sync-worker/messages_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"reflect"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/pkg/searchengine"
 )
 
@@ -71,6 +73,31 @@ func TestMessageCollection_ConsumerName(t *testing.T) {
 func TestMessageCollection_StoredScripts(t *testing.T) {
 	coll := newMessageCollection("msgs-v1", time.Time{}, false)
 	assert.Empty(t, coll.StoredScripts(), "messages collection uses no stored scripts")
+}
+
+// Templates apply only to new indices, so existing monthly indices need the
+// additive mapping update or new fields stay unmapped until rollover.
+func TestMessageCollection_MappingUpdate(t *testing.T) {
+	coll := newMessageCollection("messages-site1-v1", time.Time{}, false)
+	pattern, body := coll.MappingUpdate()
+	assert.Equal(t, "messages-site1-*", pattern, "pattern must strip the version suffix like the template's index_patterns")
+	require.NotNil(t, body)
+
+	var parsed struct {
+		Properties map[string]any `json:"properties"`
+	}
+	require.NoError(t, json.Unmarshal(body, &parsed))
+	assert.Contains(t, parsed.Properties, "attachmentText")
+	assert.Contains(t, parsed.Properties, "cardData")
+	assert.Contains(t, parsed.Properties, "content", "full property set keeps the update idempotent")
+
+	// Render payloads are stored but never indexed: object + enabled:false.
+	for _, key := range []string{"attachments", "card"} {
+		prop, ok := parsed.Properties[key].(map[string]any)
+		require.True(t, ok, "%s must be mapped", key)
+		assert.Equal(t, "object", prop["type"], key)
+		assert.Equal(t, false, prop["enabled"], "%s must not be indexed", key)
+	}
 }
 
 func TestIndexName(t *testing.T) {
@@ -182,6 +209,12 @@ func TestMessageTemplateProperties_MatchesStruct(t *testing.T) {
 
 		esType, _, _ := strings.Cut(esTag, ",")
 		propMap := prop.(map[string]any)
+		// object_disabled expands to a stored-only object mapping.
+		if esType == "object_disabled" {
+			assert.Equal(t, "object", propMap["type"], "type mismatch for field %s", name)
+			assert.Equal(t, false, propMap["enabled"], "field %s must not be indexed", name)
+			continue
+		}
 		assert.Equal(t, esType, propMap["type"], "type mismatch for field %s", name)
 	}
 
@@ -342,6 +375,189 @@ func TestMessageCollection_BuildAction_SyncFromFilter(t *testing.T) {
 		actions, err := uncapped.BuildAction(mkEvent(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)))
 		require.NoError(t, err)
 		assert.Len(t, actions, 1)
+	})
+}
+
+// Slim (no-content) events must never upsert: pin/unpin would wipe indexed
+// fields, and unpin-after-delete would resurrect a stub doc.
+func TestMessageCollection_BuildAction_SlimEventsSkipped(t *testing.T) {
+	coll := newMessageCollection("msgs-v1", time.Time{}, false)
+
+	mkEvent := func(eventType model.EventType) []byte {
+		evt := model.MessageEvent{
+			Event: eventType,
+			Message: model.Message{
+				ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+				CreatedAt: time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
+			},
+			SiteID: "site-a", Timestamp: 100,
+		}
+		data, err := json.Marshal(evt)
+		require.NoError(t, err)
+		return data
+	}
+
+	tests := []struct {
+		name  string
+		event model.EventType
+	}{
+		{"pinned skipped", model.EventPinned},
+		{"unpinned skipped", model.EventUnpinned},
+		{"thread_reply_added skipped", model.EventThreadReplyAdded},
+		{"unknown future type skipped", model.EventType("archived")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actions, err := coll.BuildAction(mkEvent(tt.event))
+			require.NoError(t, err)
+			assert.Empty(t, actions, "event %q must not produce an ES action", tt.event)
+		})
+	}
+}
+
+func TestBuildDocument_AttachmentFields(t *testing.T) {
+	ts := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	mkBlob := func(t *testing.T, a cassandra.Attachment) []byte {
+		b, err := json.Marshal(a)
+		require.NoError(t, err)
+		return b
+	}
+
+	t.Run("searched projections and full render objects are indexed", func(t *testing.T) {
+		evt := &model.MessageEvent{
+			Event: model.EventCreated,
+			Message: model.Message{
+				ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+				Content: "see attached", CreatedAt: ts,
+				Attachments: [][]byte{
+					mkBlob(t, cassandra.Attachment{ID: "f1", Title: "q3-report.pdf", Description: "Quarterly numbers", FileType: "application/pdf", TitleLink: "api/v1/file/rooms/r1/file/f1"}),
+					mkBlob(t, cassandra.Attachment{ID: "f2", Title: "team.png", FileType: "image/png"}),
+				},
+			},
+			SiteID: "site-a", Timestamp: 100,
+		}
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal(buildDocument(evt), &doc))
+		// One string pools every title+description so AND queries can mix
+		// words from both (and across attachments of the same message).
+		assert.Equal(t, "q3-report.pdf Quarterly numbers team.png", doc["attachmentText"])
+
+		// The whole decoded objects ride along (render-only, never indexed)
+		// so search hits can display attachments without a history lookup.
+		atts, ok := doc["attachments"].([]any)
+		require.True(t, ok, "attachments must be an array of full objects")
+		require.Len(t, atts, 2)
+		first := atts[0].(map[string]any)
+		assert.Equal(t, "f1", first["id"])
+		assert.Equal(t, "q3-report.pdf", first["title"])
+		assert.Equal(t, "Quarterly numbers", first["description"])
+		assert.Equal(t, "application/pdf", first["fileType"])
+		assert.Equal(t, "api/v1/file/rooms/r1/file/f1", first["titleLink"])
+	})
+
+	t.Run("malformed blob is skipped, valid ones kept", func(t *testing.T) {
+		evt := &model.MessageEvent{
+			Event: model.EventCreated,
+			Message: model.Message{
+				ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+				Content: "x", CreatedAt: ts,
+				Attachments: [][]byte{
+					[]byte("{not json"),
+					mkBlob(t, cassandra.Attachment{ID: "f1", Title: "ok.txt", FileType: "text/plain"}),
+				},
+			},
+			SiteID: "site-a", Timestamp: 100,
+		}
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal(buildDocument(evt), &doc))
+		assert.Equal(t, "ok.txt", doc["attachmentText"])
+	})
+
+	t.Run("no attachments omits the fields", func(t *testing.T) {
+		evt := &model.MessageEvent{
+			Event: model.EventCreated,
+			Message: model.Message{
+				ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+				Content: "x", CreatedAt: ts,
+			},
+			SiteID: "site-a", Timestamp: 100,
+		}
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal(buildDocument(evt), &doc))
+		for _, key := range []string{"attachmentText", "attachments"} {
+			_, present := doc[key]
+			assert.False(t, present, "%s should be omitted when there are no attachments", key)
+		}
+	})
+}
+
+func TestBuildDocument_CardFields(t *testing.T) {
+	ts := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	t.Run("card template and stringified card data are indexed", func(t *testing.T) {
+		data := `{"type":"AdaptiveCard","body":[{"type":"TextBlock","text":"Expense request from Bob"},{"title":"Amount","value":"$120"}]}`
+		evt := &model.MessageEvent{
+			Event: model.EventCreated,
+			Message: model.Message{
+				ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+				CreatedAt: ts,
+				Card: &cassandra.Card{
+					Template: "expense-approval-v1",
+					Data:     []byte(data),
+				},
+				CardAction: &cassandra.CardAction{
+					Verb: "approve", Text: "Approve the expense", DisplayText: "Bob approved",
+				},
+			},
+			SiteID: "site-a", Timestamp: 100,
+		}
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal(buildDocument(evt), &doc))
+		assert.Equal(t, data, doc["cardData"], "card data is indexed verbatim as text")
+
+		// The card object rides along as-is (render-only) — template + data,
+		// same wire shape as history reads ([]byte data → base64 string).
+		card, ok := doc["card"].(map[string]any)
+		require.True(t, ok, "card must be the full object")
+		assert.Equal(t, "expense-approval-v1", card["template"])
+		assert.Equal(t, base64.StdEncoding.EncodeToString([]byte(data)), card["data"])
+	})
+
+	t.Run("no card omits the fields", func(t *testing.T) {
+		evt := &model.MessageEvent{
+			Event: model.EventCreated,
+			Message: model.Message{
+				ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+				Content: "x", CreatedAt: ts,
+			},
+			SiteID: "site-a", Timestamp: 100,
+		}
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal(buildDocument(evt), &doc))
+		for _, key := range []string{"card", "cardData"} {
+			_, present := doc[key]
+			assert.False(t, present, "%s should be omitted when there is no card", key)
+		}
+	})
+
+	t.Run("card with empty data carries the object but no cardData", func(t *testing.T) {
+		evt := &model.MessageEvent{
+			Event: model.EventCreated,
+			Message: model.Message{
+				ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+				CreatedAt: ts,
+				Card:      &cassandra.Card{Template: "welcome-v1"},
+			},
+			SiteID: "site-a", Timestamp: 100,
+		}
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal(buildDocument(evt), &doc))
+		card, ok := doc["card"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "welcome-v1", card["template"])
+		_, present := doc["cardData"]
+		assert.False(t, present, "empty card data should be omitted")
 	})
 }
 

--- a/search-sync-worker/spotlight.go
+++ b/search-sync-worker/spotlight.go
@@ -136,7 +136,7 @@ func spotlightTemplateBody(indexName string, devMode bool) json.RawMessage {
 		replicas = 0
 	}
 	tmpl := map[string]any{
-		"index_patterns": []string{fmt.Sprintf("%s-*", searchindex.StripVersionBase(indexName))},
+		"index_patterns": []string{searchindex.IndexPattern(indexName)},
 		"template": map[string]any{
 			"settings": map[string]any{
 				"index": map[string]any{

--- a/search-sync-worker/spotlight_org.go
+++ b/search-sync-worker/spotlight_org.go
@@ -62,6 +62,11 @@ func (c *spotlightOrgCollection) StoredScripts() map[string]json.RawMessage {
 	return nil
 }
 
+// MappingUpdate returns no update — spotlight-org writes to one fixed index.
+func (c *spotlightOrgCollection) MappingUpdate() (string, json.RawMessage) {
+	return "", nil
+}
+
 // BuildAction decodes the employees.upsert bare array (already decompressed by
 // the framework) straight into SpotlightOrgIndex — the shared org json tags mean
 // each employee object yields its nine org fields and ignores the rest, so this
@@ -142,7 +147,7 @@ func spotlightOrgTemplateBody(indexName string, devMode bool) json.RawMessage {
 		replicas = 0
 	}
 	tmpl := map[string]any{
-		"index_patterns": []string{fmt.Sprintf("%s-*", searchindex.StripVersionBase(indexName))},
+		"index_patterns": []string{searchindex.IndexPattern(indexName)},
 		"template": map[string]any{
 			"settings": map[string]any{
 				"index": map[string]any{

--- a/search-sync-worker/spotlight_org_test.go
+++ b/search-sync-worker/spotlight_org_test.go
@@ -222,3 +222,10 @@ func TestSpotlightOrg_BuildAction_Errors(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+// Spotlight-org writes to one fixed index — no additive mapping push at startup.
+func TestSpotlightOrg_MappingUpdate_NoOp(t *testing.T) {
+	pattern, body := newSpotlightOrgCollection("spotlight-org-v1", "site-a", "hr", false).MappingUpdate()
+	assert.Empty(t, pattern)
+	assert.Nil(t, body)
+}

--- a/search-sync-worker/spotlight_test.go
+++ b/search-sync-worker/spotlight_test.go
@@ -306,3 +306,10 @@ func TestSpotlightCollection_BuildAction_BulkRemove(t *testing.T) {
 		assert.Nil(t, action.Doc)
 	}
 }
+
+// Spotlight writes to one fixed index — no additive mapping push at startup.
+func TestSpotlightCollection_MappingUpdate_NoOp(t *testing.T) {
+	pattern, body := newSpotlightCollection("spotlight-site-a-v1-chat", false).MappingUpdate()
+	assert.Empty(t, pattern)
+	assert.Nil(t, body)
+}

--- a/search-sync-worker/template.go
+++ b/search-sync-worker/template.go
@@ -33,6 +33,11 @@ func esPropertiesFromStruct[T any]() map[string]any {
 		}
 
 		esType, analyzer, _ := strings.Cut(esTag, ",")
+		// object_disabled → stored in _source for rendering, never indexed.
+		if esType == "object_disabled" {
+			props[name] = map[string]any{"type": "object", "enabled": false}
+			continue
+		}
 		prop := map[string]any{"type": esType}
 		if analyzer != "" {
 			prop["analyzer"] = analyzer

--- a/search-sync-worker/testdata/events.json
+++ b/search-sync-worker/testdata/events.json
@@ -40,5 +40,36 @@
     "message": {"id": "msg-002", "roomId": "room-1", "createdAt": "2026-01-15T10:31:00Z"},
     "siteId": "site-test",
     "timestamp": 1000007
+  },
+  {
+    "event": "created",
+    "message": {
+      "id": "msg-006",
+      "roomId": "room-2",
+      "userId": "u1",
+      "userAccount": "alice",
+      "content": "see the attached report",
+      "createdAt": "2026-02-11T09:00:00Z",
+      "attachments": ["eyJ0aXRsZSI6InEzLXJlcG9ydC5wZGYiLCJkZXNjcmlwdGlvbiI6IlF1YXJ0ZXJseSBudW1iZXJzIiwiZmlsZVR5cGUiOiJhcHBsaWNhdGlvbi9wZGYifQ=="],
+      "card": {
+        "template": "expense-approval-v1",
+        "data": "eyJ0eXBlIjoiQWRhcHRpdmVDYXJkIiwiYm9keSI6W3sidHlwZSI6IlRleHRCbG9jayIsInRleHQiOiJFeHBlbnNlIHJlcXVlc3QgZnJvbSBCb2IifV19"
+      },
+      "cardAction": {"verb": "approve", "displayText": "Approved by Alice"}
+    },
+    "siteId": "site-test",
+    "timestamp": 1000008
+  },
+  {
+    "event": "pinned",
+    "message": {"id": "msg-001", "roomId": "room-1", "userId": "u1", "userAccount": "alice", "createdAt": "2026-01-15T10:30:00Z"},
+    "siteId": "site-test",
+    "timestamp": 1000009
+  },
+  {
+    "event": "unpinned",
+    "message": {"id": "msg-002", "roomId": "room-1", "userId": "u2", "userAccount": "bob", "createdAt": "2026-01-15T10:31:00Z"},
+    "siteId": "site-test",
+    "timestamp": 1000010
   }
 ]


### PR DESCRIPTION
## Summary

Deleted/edited messages now propagate correctly to Elasticsearch, file attachments and tcard data become searchable, and search hits carry render-ready payloads so the frontend can display results without a history-service lookup.

### Delete/edit correctness
- `search-sync-worker` acts only on content-bearing events (`created`/`updated`/legacy `""` upsert, `deleted` delete); slim events (`reacted`/`pinned`/`unpinned`/`thread_reply_added`) are skipped — fixes pin wiping indexed content and unpin resurrecting deleted docs.
- External versioning (version = event timestamp) makes a delete tombstone final: stale replayed creates/updates 409 and are treated as success, so a deleted message can never resurface. Once a `.deleted` event is published, the worker's Nak/retry makes the ES delete at-least-once.
- `history-service` enriches `.updated` canonical events with attachments/card/sender so the full-doc reindex can't wipe fields (`CardAction` deliberately excluded — no `.updated` consumer reads it); migration edit resolves the row first, acks edit-after-delete idempotently (no resurrection), and rejects RoomID mismatches.
- No reconcile tooling ships (owner decision): pre-pipeline deletions are out of scope and the event flow is at-least-once downstream of a published event; the rare publish-side drop is accepted and documented in the design spec.

### Search fields + render payloads
- One query matches `content`, `attachmentTitles`, `attachmentDescriptions`, and `cardData` (verbatim `card.Data`) — all terms must match within a single field (`multi_match` + `AND`).
- Hits carry the full `attachments` objects and `card` (template + data) — stored with `object`/`enabled:false` mappings (kept in `_source`, never indexed) and returned in the same wire shape as history reads.
- Search-only fields (`cardData`, `attachmentTitles`, `attachmentDescriptions`) are `_source`-excluded from hits; the card body's dual storage (analyzed text + render object) is a documented, accepted trade-off.
- `pkg/searchengine.UpdateMapping` + `Collection.MappingUpdate` push the additive mapping onto **existing** monthly indices at startup (templates only govern new ones); `pkg/searchindex.IndexPattern` shared across template/mapping sites to prevent pattern drift.

### Docs
- `docs/client-api.md` + `docs/client-api/request-reply.md` updated for the `SearchMessage` schema (hits link the shared `Attachment`/`MessageCard` tables); design spec and prospective plan under `docs/superpowers/`.

## Test plan
- [x] `make lint` — 0 issues
- [x] `make test` (all unit suites, `-race`) — green, including after rebase onto latest main (search.orgs migration)
- [x] `make sast-gosec` — clean (govulncheck/semgrep run in CI; sandbox blocks their feeds)
- [x] Integration (real ES/Cassandra/NATS containers): `search-sync-worker` (~87s), `search-service` incl. two-node CCS + edit/delete/stale-replay guarantees (~89s), `history-service` (~79s)
- [x] End-to-end invariants pinned by tests: edited message found only by post-edit content; deleted message returns zero hits; stale replay 409s against the tombstone; pin/unpin neither wipes nor resurrects; attachment filename/description and card data match via the production query shape; hits carry the full attachment/card objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017D1dRgcQJiUi72Wh5J9YA5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message search now indexes attachment titles/descriptions and card data, and returns render-ready `attachments` and `card` in results when present.
  * Startup now applies additive Elasticsearch mapping updates to existing rolling indices.
* **Bug Fixes**
  * Prevented pin/unpin and other non-content events from wiping or resurrecting message fields.
  * Improved edit/delete correctness and ordering so stale deleted messages don’t reappear.
* **Documentation**
  * Updated `search.messages` docs for exact full-text matching semantics and expanded `SearchMessage` projections.
  * Updated HTTP 429 error code mapping to `too_many_requests`.
* **Tests**
  * Expanded unit/integration coverage for attachment/card search, projections, and edited/deleted behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->