### PR TITLE
feat: client-settable message type (important)

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -5587,6 +5587,7 @@ The same subject and request body cover three send variants: plain message, thre
 | `threadParentMessageId` | string | no | Set when posting a thread reply. Must be a valid 20-char base62 message ID. |
 | `tshow` | boolean | no | The "Also send to channel" option. Only meaningful on a thread reply (`threadParentMessageId` set): the reply is persisted into the parent room's channel timeline as well as the thread (dual-write into `messages_by_room` in addition to `thread_messages_by_thread` + `messages_by_id`), and is surfaced with `tshow: true` on the persisted message. On a non-thread send the flag is **ignored and normalized to `false`** — the request is not rejected. |
 | `quotedParentMessageId` | string | no | Set when posting a quoted message. The gatekeeper fetches the authoritative parent snapshot from message history and embeds it in the persisted message. If that fetch fails *transiently* (history briefly unavailable), the message is not dropped: the gatekeeper inserts a placeholder snapshot for live delivery (body `"Content temporarily unavailable"`), and `message-worker` re-projects the authoritative snapshot (or drops the quote) from history before the durable write, so the placeholder never persists. A genuinely missing/forbidden parent is still rejected. |
+| `type` | string | no | Optional client-settable message type. The only accepted value is `"important"` (an important message — previews and notifies like a normal message). Any other value, including a system type (`room_created`, etc.), is rejected with `bad_request`. Omitted = a normal message. |
 
 ##### Plain message
 
@@ -5678,6 +5679,7 @@ Delivered on `chat.user.{account}.response.{requestId}`. See [Error envelope](#6
 | `invalid message ID "…": must be a 20-char base62 string` | `bad_request` | — | `id` is not valid base62. |
 | `invalid thread parent message ID "…": …` | `bad_request` | — | `threadParentMessageId` is not a valid message ID. |
 | `content must not be empty` | `bad_request` | — | Empty `content`. |
+| `invalid message type "…"` | `bad_request` | — | `type` is set to something other than `"important"` (e.g. a system type). |
 | `content exceeds maximum size of 20480 bytes` | `bad_request` | — | `content` > 20 KiB. |
 | `not subscribed` | `forbidden` | `not_subscribed` | Sender is not a member of the room. |
 | `posting is restricted to owners and admins in this room` | `forbidden` | `large_room_post_restricted` | Non-owner/admin/bot posting a top-level message in a room above the large-room threshold (thread replies are exempt). |

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -316,7 +316,7 @@ Cassandra projection).
 | `threadParentMessageId` | string | Optional. Set for a thread reply. |
 | `threadParentMessageCreatedAt` | string | Optional. RFC 3339. Server-resolved best-effort; absent when unresolved at send time. |
 | `tshow` | boolean | Optional. Whether a thread reply is also shown in the parent room. |
-| `type` | string | Optional. System-message type. |
+| `type` | string | Optional. Message type — a server-set system type (`room_created`, etc.) or the client-settable `"important"`. Absent for a normal message. |
 | `sysMsgData` | string | Optional. Base64-encoded raw JSON payload for system messages. |
 | `quotedParentMessage` | [QuotedParentMessage](../client-api.md#quotedparentmessage) | Optional. |
 | `pinnedAt` | string | Optional. RFC 3339. |

--- a/docs/superpowers/plans/2026-07-22-preview-message-enrichment.md
+++ b/docs/superpowers/plans/2026-07-22-preview-message-enrichment.md
@@ -13,7 +13,7 @@ bot app name — on top of the #104 system/quoted skip. Design: `../specs/2026-0
 ## File Structure
 
 - Modify: `pkg/model/message.go` — `LastMessage` → `PreviewMessage` (enriched); `RoomsGetResponse`.
-- Modify: `pkg/model/subscription.go` — `SubscriptionRoom.LastMessage` type.
+- Modify: `pkg/model/subscription.go` — `SubscriptionRoom.PreviewMessage` type.
 - Modify: `history-service/internal/models/message.go` — type alias.
 - Modify: `history-service/internal/service/rooms.go` — `toPreviewMessage` mapper.
 - Modify: `history-service/internal/service/reactions.go` — extract `botAwareDisplayName`.
@@ -26,7 +26,7 @@ bot app name — on top of the #104 system/quoted skip. Design: `../specs/2026-0
 ### Task 1: Wire type + rename
 
 - [ ] Add `attachments`/`mentions`/`visibleTo` to a renamed `PreviewMessage` (sender = wire `Participant`); `// TODO(#106): forwardSource`.
-- [ ] Ripple `LastMessage` → `PreviewMessage` across the alias + `user-service` consumers; keep the `SubscriptionRoom.LastMessage` field name.
+- [ ] Ripple `LastMessage` → `PreviewMessage` across the alias + `user-service` consumers; the field is `SubscriptionRoom.PreviewMessage` (renamed per review).
 - [ ] `go build ./...` clean.
 
 ### Task 2: Enrichment mapper

--- a/docs/superpowers/specs/2026-07-22-preview-message-enrichment-design.md
+++ b/docs/superpowers/specs/2026-07-22-preview-message-enrichment-design.md
@@ -4,7 +4,7 @@
 
 ## Problem
 
-The room-list preview (`rooms.get` → `SubscriptionRoom.LastMessage`) carried only
+The room-list preview (`rooms.get` → `SubscriptionRoom.PreviewMessage`) carried only
 `{messageId, sender, content, createdAt}`, and `sender` was the raw `cassandra.Participant`
 (`id`/`account` only). The frontend can't render an attachment icon, mentioned names, or a
 bot's app name from that. Every needed source field is already read by the walk's
@@ -35,7 +35,7 @@ Replace the minimal `LastMessage` wire type with a dedicated **`PreviewMessage`*
 - No Cassandra/Mongo schema or projection change (columns already projected).
 - The `LastMessage` → `PreviewMessage` rename ripples through the shared wire type and its
   consumers (history models alias, `user-service` `RoomsGet` signature + `SubscriptionRoom`
-  field, historyclient, mocks). The `SubscriptionRoom.LastMessage` **field name is kept**;
+  field, historyclient, mocks). The `SubscriptionRoom.PreviewMessage` **field** (renamed from `LastMessage` per review);
   only its type changes.
 
 ## Out of scope

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -102,7 +102,7 @@ func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID stri
 			}
 			return s.toPreviewMessage(ctx, &m), true
 		}
-		// Whole page ineligible (deleted/system/quoted). A short page means the walk
+		// Whole page ineligible (deleted/system). A short page means the walk
 		// is exhausted (no older messages) — stop. Otherwise page again strictly
 		// before the oldest one seen.
 		if len(page.Data) < lastMsgWalkPageSize {

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -194,6 +194,41 @@ func TestHistoryService_RoomsGet_SkipsSystemTail(t *testing.T) {
 	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
 }
 
+// Every system type is skipped in the preview; a client type (important) is not.
+func TestHistoryService_RoomsGet_SkipsEachSystemTypeButKeepsImportant(t *testing.T) {
+	for _, st := range []string{
+		model.MessageTypeRoomCreated, model.MessageTypeMembersAdded,
+		model.MessageTypeMemberRemoved, model.MessageTypeMemberLeft,
+		model.MessageTypeRoomRenamed, model.MessageTypeRoomRestricted,
+		model.MessageTypeTeamsMeetStarted,
+	} {
+		svc, msgs, rooms := newRoomsService(t)
+		rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+		msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(makePage([]models.Message{
+				{MessageID: "m2", RoomID: "r1", Type: st, CreatedAt: roomLastMsgAt},
+				{MessageID: "m1", RoomID: "r1", Msg: "alive", CreatedAt: roomLastMsgAt.Add(-time.Minute)},
+			}, false), nil)
+
+		resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+		require.NoError(t, err)
+		assert.Equal(t, "m1", resp.Rooms["r1"].MessageID, "system type %q must be skipped", st)
+	}
+}
+
+func TestHistoryService_RoomsGet_KeepsImportantMessage(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{
+			{MessageID: "m2", RoomID: "r1", Msg: "urgent", Type: model.MessageTypeImportant, CreatedAt: roomLastMsgAt},
+		}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	assert.Equal(t, "m2", resp.Rooms["r1"].MessageID, "an important (client) message must preview")
+}
+
 // A quoted reply is normal room content and IS eligible as the preview.
 func TestHistoryService_RoomsGet_QuotedReplyEligible(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)

--- a/message-gatekeeper/handler.go
+++ b/message-gatekeeper/handler.go
@@ -285,6 +285,12 @@ func (h *Handler) processMessage(ctx context.Context, account, roomID, siteID st
 		return nil, errcode.BadRequest(fmt.Sprintf("attachments exceed maximum size of %d bytes", h.maxAttachmentBytes))
 	}
 
+	// A client may set Type only to the client-settable value(s); a system type or
+	// unknown value is rejected so a client can't forge a system event.
+	if req.Type != "" && req.Type != model.MessageTypeImportant {
+		return nil, errcode.BadRequest(fmt.Sprintf("invalid message type %q", req.Type))
+	}
+
 	// Verify subscription
 	sub, err := h.store.GetSubscription(ctx, account, roomID)
 	if err != nil {
@@ -380,6 +386,7 @@ func (h *Handler) processMessage(ctx context.Context, account, roomID, siteID st
 		TShow:                        tshow,
 		QuotedParentMessage:          quotedSnapshot,
 		Attachments:                  req.Attachments,
+		Type:                         req.Type,
 	}
 
 	// Publish MessageEvent to MESSAGES_CANONICAL. QuotedParentUnverified rides the

--- a/message-gatekeeper/handler_test.go
+++ b/message-gatekeeper/handler_test.go
@@ -832,6 +832,54 @@ func TestHandler_processMessage_RejectsInvalidQuotedParentMessageID(t *testing.T
 	assert.Equal(t, errcode.CodeBadRequest, ee.Code)
 }
 
+func TestHandler_processMessage_AcceptsImportantTypeAndSetsCanonical(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	store.EXPECT().GetSubscription(gomock.Any(), "alice", "room-1").
+		Return(&model.Subscription{User: model.SubscriptionUser{ID: "u-alice", Account: "alice"}}, nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").
+		Return(roommetacache.Meta{ID: "room-1", UserCount: 1}, nil)
+
+	var captured publishedMsg
+	pub := func(_ context.Context, msg *nats.Msg, _ ...jetstream.PublishOpt) (*jetstream.PubAck, error) {
+		captured = publishedMsg{subject: msg.Subject, data: msg.Data}
+		return &jetstream.PubAck{}, nil
+	}
+	reply := func(_ context.Context, _ *nats.Msg) error { return nil }
+	h := NewHandler(store, nil, pub, reply, "site1", nil, 500, 1, 8192, "")
+
+	req := model.SendMessageRequest{ID: idgen.GenerateMessageID(), Content: "hi", RequestID: "01970a4f-8c2d-7c9a-abcd-e0123456789f", Type: model.MessageTypeImportant}
+	_, err := h.processMessage(context.Background(), "alice", "room-1", "site1", &req)
+	require.NoError(t, err)
+
+	var evt model.MessageEvent
+	require.NoError(t, json.Unmarshal(captured.data, &evt))
+	assert.Equal(t, model.MessageTypeImportant, evt.Message.Type)
+}
+
+func TestHandler_processMessage_RejectsClientSystemAndUnknownTypes(t *testing.T) {
+	// A client must not be able to inject a system type, nor an unknown one.
+	// Validation fails before any store call, so no store expectations.
+	for _, badType := range []string{model.MessageTypeRoomCreated, "totally_unknown"} {
+		ctrl := gomock.NewController(t)
+		store := NewMockStore(ctrl)
+		pub := func(context.Context, *nats.Msg, ...jetstream.PublishOpt) (*jetstream.PubAck, error) {
+			return &jetstream.PubAck{}, nil
+		}
+		reply := func(context.Context, *nats.Msg) error { return nil }
+		h := NewHandler(store, nil, pub, reply, "site1", nil, 500, 1, 8192, "")
+
+		req := model.SendMessageRequest{ID: idgen.GenerateMessageID(), Content: "hi", RequestID: "01970a4f-8c2d-7c9a-abcd-e0123456789f", Type: badType}
+		_, err := h.processMessage(context.Background(), "alice", "room-1", "site1", &req)
+		require.Error(t, err, "type %q must be rejected", badType)
+		assert.Contains(t, err.Error(), "invalid message type")
+		var ee *errcode.Error
+		require.True(t, errors.As(err, &ee))
+		assert.Equal(t, errcode.CodeBadRequest, ee.Code)
+		ctrl.Finish()
+	}
+}
+
 func TestHandler_processMessage_PropagatesRequestIDOnCanonicalPublish(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)

--- a/message-worker/handler.go
+++ b/message-worker/handler.go
@@ -87,8 +87,10 @@ func (h *Handler) processMessage(ctx context.Context, data []byte, isMigration b
 	var sender *cassParticipant
 	user, err := h.userStore.FindUserByID(ctx, evt.Message.UserID)
 	if err != nil {
-		if evt.Message.Type != "" {
+		if model.IsSystemMessageType(evt.Message.Type) {
 			// System messages may have no real user; proceed with nil sender.
+			// A client type (e.g. important) has a real sender, so a lookup failure
+			// there falls through to the error branch like a normal message.
 			slog.WarnContext(ctx, "user not found for system message, using nil sender",
 				"user_id", evt.Message.UserID, "type", evt.Message.Type,
 				"request_id", natsutil.RequestIDFromContext(ctx))

--- a/notification-worker/handler.go
+++ b/notification-worker/handler.go
@@ -51,10 +51,12 @@ type Handler struct {
 	deps HandlerDeps
 }
 
-// isNotifiable reports whether a message type produces push notifications. Safe-by-default
-// allowlist: new system types never notify; add tcard/tcard_execute/app_execute here as they land.
+// isNotifiable reports whether a message type produces push notifications.
+// Every system type is gated out; the empty regular type and client-set types
+// (e.g. MessageTypeImportant) notify like a normal message. New system types are
+// safe-by-default as long as they join IsSystemMessageType (the single membership list).
 func isNotifiable(msgType string) bool {
-	return msgType == ""
+	return !model.IsSystemMessageType(msgType)
 }
 
 func NewHandler(deps HandlerDeps) *Handler { //nolint:gocritic // hugeParam: one-time constructor arg

--- a/notification-worker/handler_test.go
+++ b/notification-worker/handler_test.go
@@ -135,6 +135,34 @@ func msgEvent(m *model.Message) []byte { //nolint:gocritic // hugeParam: test he
 	return data
 }
 
+func TestHandle_ImportantMessageNotifies(t *testing.T) {
+	members := &stubMembers{out: map[string][]roomsubcache.Member{
+		"r1": {{ID: "alice", Account: "alice"}, {ID: "bob", Account: "bob"}},
+	}}
+	emit := &recordingEmitter{}
+	h := newTestHandler(members, &stubFollowers{}, noopPresenceSnapshotter{}, noopVetoer{}, emit)
+
+	require.NoError(t, h.HandleMessage(context.Background(), msgEvent(&model.Message{
+		ID: "m1", RoomID: "r1", UserID: "alice", UserAccount: "alice",
+		Type: model.MessageTypeImportant, CreatedAt: time.Now(),
+	})))
+	assert.Equal(t, []string{"bob"}, emit.accounts(), "important message notifies like a normal message")
+}
+
+func TestHandle_SystemMessageDoesNotNotify(t *testing.T) {
+	members := &stubMembers{out: map[string][]roomsubcache.Member{
+		"r1": {{ID: "alice", Account: "alice"}, {ID: "bob", Account: "bob"}},
+	}}
+	emit := &recordingEmitter{}
+	h := newTestHandler(members, &stubFollowers{}, noopPresenceSnapshotter{}, noopVetoer{}, emit)
+
+	require.NoError(t, h.HandleMessage(context.Background(), msgEvent(&model.Message{
+		ID: "m1", RoomID: "r1", UserID: "alice", UserAccount: "alice",
+		Type: model.MessageTypeRoomRenamed, CreatedAt: time.Now(),
+	})))
+	assert.Empty(t, emit.accounts(), "system message must not notify")
+}
+
 func TestHandle_SkipsSender(t *testing.T) {
 	members := &stubMembers{out: map[string][]roomsubcache.Member{
 		"r1": {
@@ -981,13 +1009,14 @@ func TestIsNotifiable(t *testing.T) {
 		want    bool
 	}{
 		{"regular message", "", true},
+		{"important client type", model.MessageTypeImportant, true},
 		{"room created", model.MessageTypeRoomCreated, false},
 		{"members added", model.MessageTypeMembersAdded, false},
 		{"member removed", model.MessageTypeMemberRemoved, false},
 		{"member left", model.MessageTypeMemberLeft, false},
 		{"room renamed", model.MessageTypeRoomRenamed, false},
 		{"room restricted", model.MessageTypeRoomRestricted, false},
-		{"unknown future system type", "some_future_sys_type", false},
+		{"teams meet started", model.MessageTypeTeamsMeetStarted, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -585,6 +585,14 @@ func IsSystemMessageType(t string) bool {
 }
 
 const (
+	// MessageTypeImportant is the sole client-settable message type (重要訊息).
+	// Unlike the system MessageType* values above it is set by the client, and it
+	// previews + notifies like a normal message — IsSystemMessageType returns false
+	// for it, so the "Type != \"\" ⇒ system" convention doesn't suppress it.
+	MessageTypeImportant = "important"
+)
+
+const (
 	// AsyncJobStatusOK indicates a successful async job result.
 	AsyncJobStatusOK = "ok"
 	// AsyncJobStatusError indicates a failed async job result.

--- a/pkg/model/message.go
+++ b/pkg/model/message.go
@@ -79,6 +79,10 @@ type SendMessageRequest struct {
 	// (one JSON object per element). message-gatekeeper validates and copies them
 	// onto the canonical Message.
 	Attachments [][]byte `json:"attachments,omitempty"`
+	// Type is the optional client-settable message type. The only accepted value is
+	// MessageTypeImportant; message-gatekeeper rejects any system type or unknown
+	// value so a client can't inject a system event. Empty = a normal message.
+	Type string `json:"type,omitempty"`
 }
 
 // SenderDisplayName returns the canonical render-ready name for the message's

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -4857,3 +4857,39 @@ func TestSSOToken_SecretsNeverSerialize(t *testing.T) {
 		t.Errorf("token material leaked into String(): %s", s)
 	}
 }
+
+func TestIsSystemMessageType(t *testing.T) {
+	for _, st := range []string{
+		model.MessageTypeRoomCreated, model.MessageTypeMembersAdded,
+		model.MessageTypeMemberRemoved, model.MessageTypeMemberLeft,
+		model.MessageTypeRoomRenamed, model.MessageTypeRoomRestricted,
+		model.MessageTypeTeamsMeetStarted,
+	} {
+		assert.True(t, model.IsSystemMessageType(st), "%q is a system type", st)
+	}
+	assert.False(t, model.IsSystemMessageType(""), "empty is a normal message, not system")
+	assert.False(t, model.IsSystemMessageType(model.MessageTypeImportant), "important is a client type, not system")
+	assert.False(t, model.IsSystemMessageType("unknown"), "unknown is not a system type")
+}
+
+func TestSendMessageRequest_TypeRoundTripAndOmitEmpty(t *testing.T) {
+	// omitempty: absent Type serializes to no "type" key (json + bson).
+	jbytes, err := json.Marshal(&model.SendMessageRequest{ID: "m1", Content: "hi", RequestID: "r1"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(jbytes), "type")
+
+	src := model.SendMessageRequest{ID: "m1", Content: "hi", RequestID: "r1", Type: model.MessageTypeImportant}
+	var dst model.SendMessageRequest
+	roundTrip(t, &src, &dst)
+	assert.Equal(t, model.MessageTypeImportant, dst.Type)
+}
+
+func TestMessage_TypeBSONOmitEmpty(t *testing.T) {
+	// Message.Type carries bson:"type,omitempty" — absent Type must not write the key.
+	b, err := bson.Marshal(&model.Message{ID: "m1"})
+	require.NoError(t, err)
+	var raw bson.M
+	require.NoError(t, bson.Unmarshal(b, &raw))
+	_, ok := raw["type"]
+	assert.False(t, ok, "empty Type must be absent in BSON")
+}


### PR DESCRIPTION
## Summary

Lets the client send a `type` field on send-message, adding the client-settable value `important` (重要訊息) by **reusing the existing `Message.Type` field** with a system-vs-client split. `important` is a normal deliverable message that previews and notifies like any user message — the whole point of the split is that it is **not** suppressed as a system message. Elevated notification / push-priority / pinning are out of scope (a follow-up if wanted).

Stacks on #104 (base `feat/preview-filter-system-quoted`) — #104 introduced the `Type != ""` preview skip; this PR refines it to `IsSystemMessageType`.

## Changes

- **`SendMessageRequest.Type`** (`pkg/model/message.go`) — new client-settable field, `json:"type,omitempty"`.
- **`MessageTypeImportant` + `IsSystemMessageType()`** (`pkg/model/event.go`) — the client type in a separate group from the 7 system `MessageType*` constants; the helper is membership in the 7 system types only.
- **Gatekeeper** (`message-gatekeeper/handler.go`) — validates `req.Type`: only `important` (or empty) is accepted; a system type or unknown value → `bad_request`. The validated value is set on the canonical `Message.Type`.
- **Preview filter** (`history-service/internal/service/rooms.go`) — the room-last-message skip now keys on `IsSystemMessageType(m.Type)` instead of `Type != ""`, so `important` previews while system/quoted/deleted still skip.
- **notification-worker** (`handler.go`) — `isNotifiable` now gates out system types via `IsSystemMessageType`, so `important` notifies like a normal message; system types keep their current gating.
- **message-worker** (`handler.go`) — the "no real user ⇒ nil sender" branch is now system-set-aware, so an `important` message with a user-lookup failure errors like a normal message rather than falling through as a system message.
- **No schema change** — `Type` already persists in `messages_by_room.type` (plain `TEXT`, no enum constraint) and is projected; only the value set grows.
- **Docs** — `docs/client-api.md` (the send `type` field + allowed value + error row), `docs/client-api/events.md` (the new value on the message event).

Audited every other `switch msg.Type` / `Type != ""` site: broadcast-worker, room-service, inbox-worker, search-sync-worker all branch on Room/Inbox/Member types, not message `Type` — no change needed.

## Verification

- `go test` (targeted, one package at a time): `pkg/model`, `message-gatekeeper`, `history-service/internal/service`, `notification-worker`, `message-worker` all green.
- Added unit tests: gatekeeper (important accepted + set; system/unknown rejected), `roomLastMessage` (each of the 7 system types skipped, important previews, quoted/deleted skipped), notification (important notifies, system doesn't), model round-trip (json + bson `omitempty`), `IsSystemMessageType` membership.
- golangci-lint: 0 issues.

Closes #113


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Clients can mark messages as **important** using the optional message type.
  - Important messages are preserved in room previews and delivered through notifications.
- **Bug Fixes**
  - Invalid or system message types supplied by clients are rejected with a bad-request error.
  - System messages no longer trigger notifications.
  - Sender lookup failures for non-system messages are handled correctly.
- **Documentation**
  - Updated client API and room preview documentation to describe message types and preview naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->