### PR TITLE
thread.list: carry message bodies as opaque json.RawMessage

### DIFF
--- a/docs/superpowers/plans/2026-07-23-user-service-opaque-thread-messages.md
+++ b/docs/superpowers/plans/2026-07-23-user-service-opaque-thread-messages.md
@@ -1,0 +1,392 @@
+# Opaque thread.list Message Bodies — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Carry `ThreadListItem.ParentMessage`/`LastMessage` as opaque `json.RawMessage` so `user-service` forwards thread.list message bodies without decoding `cassandra.Message.Reactions` (a struct-keyed map with no JSON decoder), and have `history-service` emit them pre-marshaled.
+
+**Architecture:** Retype the two shared fields on `pkg/model.ThreadListItem` from `*cassandra.Message` to `json.RawMessage`. `history-service` (`buildThreadItems`) marshals each typed body to bytes at build time; `user-service` needs no production change — the raw bytes pass through decode and re-encode untouched. The client-facing wire JSON is byte-for-byte unchanged (still the full `Message` object), so no docs edit is required.
+
+**Tech Stack:** Go 1.25, `encoding/json` (stdlib), `stretchr/testify`, `go.uber.org/mock`. Tests run via `make test SERVICE=<name>` (race detector on by default).
+
+## Global Constraints
+
+- Go 1.25; monorepo, single root `go.mod`. Always use `make` targets, never raw `go`.
+- TDD: Red → Green → Refactor → Commit for every change. Never write implementation before its test.
+- `encoding/json` on both edited paths (history-service thread-list build + user-service historyclient decode both already use stdlib `encoding/json`, not sonic). Do not introduce sonic here.
+- Error handling: never ignore a returned error; wrap infra errors with `fmt.Errorf("...: %w", err)`; log with `log/slog` structured fields (never interpolated). No secrets/bodies in logs.
+- `models.Message` (in `history-service/internal/models`) is a type alias of `cassandra.Message`; `models.Reactions`/`models.ReactionKey`/`models.ReactorInfo` alias the `cassandra` types. Use the `models.*` aliases inside history-service tests.
+- Minimum 80% coverage; cover happy path + the reactions regression path.
+- **Compilation coupling:** retyping the shared field (Task 1) intentionally breaks `history-service` compilation until Task 2 lands. Execute Task 1 → Task 2 → Task 3 in order; only the full suite at Task 3 is expected green repo-wide.
+
+---
+
+### Task 1: Retype `ThreadListItem` message bodies to `json.RawMessage`
+
+**Files:**
+- Modify: `pkg/model/threadlist.go` (imports + the two body fields, ~lines 1-3 and 26-28)
+- Test: `pkg/model/threadlist_test.go` (rewrite `TestThreadListItemJSON_WithMessages`; add reactions regression test)
+
+**Interfaces:**
+- Consumes: nothing (leaf change).
+- Produces: `model.ThreadListItem.ParentMessage` and `.LastMessage` are now `json.RawMessage` (`type RawMessage []byte`). Producers assign marshaled `*cassandra.Message` bytes; consumers read raw bytes. `omitempty` omits nil/empty.
+
+- [ ] **Step 1: Rewrite the failing tests (Red)**
+
+In `pkg/model/threadlist_test.go`, add `"time"` to the import block (it already imports `encoding/json`, `testing`, `testify/assert`, `testify/require`, `pkg/model`, `pkg/model/cassandra`).
+
+Replace the existing `TestThreadListItemJSON_WithMessages` with:
+
+```go
+// The hydrated parent/last message bodies are carried opaque and survive a JSON
+// round trip; user-service forwards these bytes without decoding the Message.
+func TestThreadListItemJSON_WithMessages(t *testing.T) {
+	parent, err := json.Marshal(&cassandra.Message{MessageID: "msg-parent", RoomID: "room-1", Msg: "anyone?"})
+	require.NoError(t, err)
+	last, err := json.Marshal(&cassandra.Message{MessageID: "msg-last", RoomID: "room-1", Msg: "on it"})
+	require.NoError(t, err)
+	src := model.ThreadListItem{
+		SiteID: "site-a", RoomID: "room-1", ThreadRoomID: "thr-1",
+		ParentMessageID: "msg-parent", LastMsgAt: 1746518400000,
+		ParentMessage: parent, LastMessage: last,
+	}
+	data, err := json.Marshal(&src)
+	require.NoError(t, err)
+	var dst model.ThreadListItem
+	require.NoError(t, json.Unmarshal(data, &dst))
+	require.NotNil(t, dst.ParentMessage)
+	require.NotNil(t, dst.LastMessage)
+	var gotParent, gotLast cassandra.Message
+	require.NoError(t, json.Unmarshal(dst.ParentMessage, &gotParent))
+	require.NoError(t, json.Unmarshal(dst.LastMessage, &gotLast))
+	assert.Equal(t, "msg-parent", gotParent.MessageID)
+	assert.Equal(t, "on it", gotLast.Msg)
+}
+
+// Regression: a parent/last body carrying reactions must round-trip through
+// ThreadListItem without a decode error. The old *cassandra.Message field failed
+// here because Reactions is a struct-keyed map with no JSON decoder.
+func TestThreadListItemJSON_MessageWithReactions_RoundTrips(t *testing.T) {
+	body, err := json.Marshal(&cassandra.Message{
+		MessageID: "msg-parent", RoomID: "room-1", Msg: "anyone?",
+		Reactions: cassandra.Reactions{
+			{Emoji: "👍", UserAccount: "bob"}: {Account: "bob", EngName: "Bob Chen", ReactedAt: time.UnixMilli(1746518400000).UTC()},
+		},
+	})
+	require.NoError(t, err)
+	src := model.ThreadListItem{
+		SiteID: "site-a", RoomID: "room-1", ThreadRoomID: "thr-1",
+		ParentMessageID: "msg-parent", LastMsgAt: 1746518400000,
+		ParentMessage: body, LastMessage: body,
+	}
+	data, err := json.Marshal(&src)
+	require.NoError(t, err)
+	var dst model.ThreadListItem
+	require.NoError(t, json.Unmarshal(data, &dst)) // must NOT error on reactions
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(dst.ParentMessage, &got))
+	assert.Equal(t, "msg-parent", got["messageId"])
+	reactions, ok := got["reactions"].(map[string]any)
+	require.True(t, ok, "reactions must survive in the forwarded body")
+	assert.Contains(t, reactions, "👍")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (Red)**
+
+Run: `make test SERVICE=model` (or `go test ./pkg/model/` if there is no per-package make target — the plan expects the model package to be reachable; if `SERVICE=model` is unknown, run the repo's model test path per the Makefile).
+
+Expected: **compile failure** — `ParentMessage`/`LastMessage` are still `*cassandra.Message`, so assigning a `[]byte`/`json.RawMessage` and unmarshaling `dst.ParentMessage` do not type-check.
+
+- [ ] **Step 3: Retype the fields (Green)**
+
+In `pkg/model/threadlist.go`, change the import line
+
+```go
+import "github.com/hmchangw/chat/pkg/model/cassandra"
+```
+
+to
+
+```go
+import "encoding/json"
+```
+
+and replace the two body fields (currently `*cassandra.Message`) with:
+
+```go
+	// Hydrated message bodies, subject to the thread access window. Carried opaque:
+	// history-service emits them pre-marshaled from *cassandra.Message and user-service
+	// forwards them to the client verbatim, never decoding the Message (avoids parsing
+	// Reactions, whose struct-keyed map has no JSON decoder).
+	ParentMessage json.RawMessage `json:"parentMessage,omitempty" bson:"parentMessage,omitempty"`
+	LastMessage   json.RawMessage `json:"lastMessage,omitempty"   bson:"lastMessage,omitempty"`
+```
+
+(`cassandra` is used nowhere else in this file, so the import swap is complete.)
+
+- [ ] **Step 4: Run tests to verify they pass (Green)**
+
+Run: the same model test command from Step 2.
+Expected: **PASS**, including `TestThreadListItemJSON_WithMessages`, `TestThreadListItemJSON_MessageWithReactions_RoundTrips`, and the untouched `TestThreadListItemJSON_OmitsNilLastSeenAt` (still asserts `parentMessage` omitted when nil — `omitempty` on `json.RawMessage` omits nil).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/model/threadlist.go pkg/model/threadlist_test.go
+git commit -m "model(thread.list): carry parent/last message bodies as json.RawMessage
+
+Retype ThreadListItem.ParentMessage/LastMessage from *cassandra.Message to
+json.RawMessage so consumers forward the bodies without decoding the Message.
+Reactions is a struct-keyed map with no JSON decoder, so the old typed field
+failed to decode any body carrying reactions. Wire form unchanged.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Pre-marshal bodies in history-service `buildThreadItems`
+
+**Files:**
+- Modify: `history-service/internal/service/threads.go` (add `encoding/json` import; the two assignments in `buildThreadItems`, currently `item.ParentMessage = &parent` / `item.LastMessage = &last`, ~lines 241-242)
+- Test: `history-service/internal/service/threadlist_test.go` (decode raw bytes in existing assertions; add reactions case + a decode helper)
+
+**Interfaces:**
+- Consumes: `model.ThreadListItem.ParentMessage`/`.LastMessage` as `json.RawMessage` (Task 1).
+- Produces: `buildThreadItems` sets each field to `json.Marshal(&msg)` bytes, or skips the row on marshal error. `ListThreadSubscriptions` response items carry pre-marshaled bodies.
+
+- [ ] **Step 1: Update the tests (Red)**
+
+In `history-service/internal/service/threadlist_test.go`, add `"encoding/json"` to the import block.
+
+Add a decode helper near the top of the file (after imports):
+
+```go
+func decodeThreadMsg(t *testing.T, raw json.RawMessage) models.Message {
+	t.Helper()
+	var m models.Message
+	require.NoError(t, json.Unmarshal(raw, &m))
+	return m
+}
+```
+
+In `TestHistoryService_ListThreadSubscriptions_Success`, replace the parent/last body assertions:
+
+```go
+	require.NotNil(t, first.ParentMessage)
+	assert.Equal(t, "p1", first.ParentMessage.MessageID)
+	require.NotNil(t, first.ParentMessage.TCount)
+	assert.Equal(t, 4, *first.ParentMessage.TCount) // reply count rides on the parent
+	require.NotNil(t, first.LastMessage)
+	assert.Equal(t, "m1", first.LastMessage.MessageID)
+```
+
+with:
+
+```go
+	require.NotNil(t, first.ParentMessage)
+	parent := decodeThreadMsg(t, first.ParentMessage)
+	assert.Equal(t, "p1", parent.MessageID)
+	require.NotNil(t, parent.TCount)
+	assert.Equal(t, 4, *parent.TCount) // reply count rides on the parent
+	require.NotNil(t, first.LastMessage)
+	assert.Equal(t, "m1", decodeThreadMsg(t, first.LastMessage).MessageID)
+```
+
+Add a reactions regression case (place it after `TestHistoryService_ListThreadSubscriptions_Success`):
+
+```go
+// A parent carrying reactions still builds and its body rides through as the
+// grouped-by-emoji wire form (guards the user-service forward path).
+func TestHistoryService_ListThreadSubscriptions_ParentWithReactions(t *testing.T) {
+	svc, msgs, _, _, threadSubs := newThreadListService(t)
+	base := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	rows := []mongorepo.ThreadSubRow{
+		{ThreadRoomID: "tr-1", RoomID: "r1", SiteID: "site-a", ParentMessageID: "p1", LastMsgID: "m1", LastMsgAt: base.Add(5 * time.Hour)},
+	}
+	threadSubs.EXPECT().ListUserThreadSubscriptions(gomock.Any(), "alice", gomock.Any(), gomock.Any(), gomock.Any()).Return(rows, false, nil)
+	msgs.EXPECT().GetMessagesByIDs(gomock.Any(), gomock.Any()).Return([]models.Message{
+		{MessageID: "p1", RoomID: "r1", Msg: "parent", Reactions: models.Reactions{
+			{Emoji: "👍", UserAccount: "bob"}: {Account: "bob", EngName: "Bob Chen", ReactedAt: base},
+		}},
+		{MessageID: "m1", RoomID: "r1", Msg: "last"},
+	}, nil)
+
+	resp, err := svc.ListThreadSubscriptions(testContext(), pkgmodel.ThreadSubscriptionListRequest{Account: "alice", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, resp.Items, 1)
+	assert.Equal(t, "p1", decodeThreadMsg(t, resp.Items[0].ParentMessage).MessageID)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(resp.Items[0].ParentMessage, &raw))
+	reactions, ok := raw["reactions"].(map[string]any)
+	require.True(t, ok, "reactions must be present in the built body")
+	assert.Contains(t, reactions, "👍")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (Red)**
+
+Run: `make test SERVICE=history-service`
+Expected: **compile failure** in `buildThreadItems` (`item.ParentMessage = &parent` assigns `*models.Message` to a `json.RawMessage` field) and in the updated test (`first.ParentMessage.MessageID` no longer type-checks). This is the coupling flagged in Global Constraints — Task 1 already retyped the field.
+
+- [ ] **Step 3: Pre-marshal in `buildThreadItems` (Green)**
+
+In `history-service/internal/service/threads.go`, add `"encoding/json"` to the import block (alongside `fmt`, `log/slog`, `time`).
+
+Replace the two assignments:
+
+```go
+		item.ParentMessage = &parent
+		item.LastMessage = &last
+```
+
+with:
+
+```go
+		parentJSON, err := json.Marshal(&parent)
+		if err != nil {
+			slog.WarnContext(c, "thread-list: marshaling parent message, skipping row",
+				"request_id", natsutil.RequestIDFromContext(c),
+				"thread_room_id", row.ThreadRoomID, "parent_message_id", row.ParentMessageID, "error", err)
+			continue
+		}
+		lastJSON, err := json.Marshal(&last)
+		if err != nil {
+			slog.WarnContext(c, "thread-list: marshaling last message, skipping row",
+				"request_id", natsutil.RequestIDFromContext(c),
+				"thread_room_id", row.ThreadRoomID, "last_message_id", row.LastMsgID, "error", err)
+			continue
+		}
+		item.ParentMessage = parentJSON
+		item.LastMessage = lastJSON
+```
+
+Note: this sits inside the per-row loop after the existing `if !hasParent || !hasLast { continue }` guard and before `items = append(items, item)`, so a row is only appended once both bodies marshal — mirroring the existing "skip half-hydrated rows" rule. `c` is the `*natsrouter.Context` (a `context.Context`), valid for `slog.WarnContext`; `natsutil` is already imported.
+
+- [ ] **Step 4: Run tests to verify they pass (Green)**
+
+Run: `make test SERVICE=history-service`
+Expected: **PASS**, including `TestHistoryService_ListThreadSubscriptions_Success`, `_ParentWithReactions`, and the existing missing-parent/ordering cases (they don't read the body).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add history-service/internal/service/threads.go history-service/internal/service/threadlist_test.go
+git commit -m "history-service(thread.list): emit parent/last bodies pre-marshaled
+
+buildThreadItems now marshals each hydrated message to json.RawMessage bytes,
+skipping the row with a warning on the (effectively impossible) marshal error,
+consistent with the existing skip-half-hydrated-row rule.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: user-service forward-through regression test + full verification
+
+**Files:**
+- Test: `user-service/service/threads_test.go` (add one forward-through test; no production change)
+- Verify only: `user-service/historyclient/client.go`, `user-service/service/threads.go` (confirm no edit needed), `docs/client-api.md` (confirm no diff)
+
+**Interfaces:**
+- Consumes: `model.ThreadListItem` with `json.RawMessage` bodies (Task 1); `MockHistoryClient.GetThreadList` returning them.
+- Produces: nothing new — asserts existing `ListUserThreads` forwards bytes unchanged.
+
+- [ ] **Step 1: Add the failing/forward test (Red)**
+
+In `user-service/service/threads_test.go`, add `"encoding/json"` and `"github.com/hmchangw/chat/pkg/model/cassandra"` to the import block.
+
+Add:
+
+```go
+// A message body carrying reactions is aggregated and forwarded verbatim: the
+// old typed field would have failed the leaf-response decode inside historyclient;
+// with json.RawMessage the bytes pass straight through the merge and re-encode.
+func TestUserService_ListUserThreads_ForwardsMessageBodiesWithReactions(t *testing.T) {
+	svc, history, _, _ := newThreadSvc(t)
+	body, err := json.Marshal(&cassandra.Message{
+		MessageID: "p1", RoomID: "r1", Msg: "parent",
+		Reactions: cassandra.Reactions{
+			{Emoji: "👍", UserAccount: "bob"}: {Account: "bob", EngName: "Bob Chen"},
+		},
+	})
+	require.NoError(t, err)
+	items := []model.ThreadListItem{{
+		SiteID: "site-a", RoomID: "r1", RoomType: model.RoomTypeChannel, ThreadRoomID: "tr-1",
+		ParentMessageID: "p1", LastMsgAt: 100, ParentMessage: body, LastMessage: body,
+	}}
+	expectThreadList(history, "site-a", items, false)
+	expectThreadList(history, "site-b", nil, false)
+
+	resp, err := svc.ListUserThreads(ctx("alice", "site-a"), model.ThreadListRequest{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, resp.Items, 1)
+	// Bytes forwarded unchanged — no re-encode, no reactions parse.
+	assert.Equal(t, []byte(body), []byte(resp.Items[0].ParentMessage))
+	assert.Equal(t, []byte(body), []byte(resp.Items[0].LastMessage))
+}
+```
+
+(`RoomTypeChannel` takes the no-op enrichment branch, so no `users`/`apps` mock expectations are needed. Both fan-out sites `site-a`/`site-b` must be stubbed — see `newThreadSvc`'s `AllSiteIDs`.)
+
+- [ ] **Step 2: Run test to verify it passes (Green — additive)**
+
+Run: `make test SERVICE=user-service`
+Expected: **PASS**. `user-service` has no production change; this test compiles against the Task 1 field type and documents the forward-through contract. If it fails to compile, the missing imports from Step 1 are the cause.
+
+- [ ] **Step 3: Confirm no production change is required in user-service**
+
+Verify by reading, not editing:
+- `user-service/historyclient/client.go` `GetThreadList` does `json.Unmarshal(msg.Data, &out)` into `model.ThreadSubscriptionListResponse` — with `json.RawMessage` fields this now copies bytes instead of parsing (this is the code path the bug lived on; the pkg/model round-trip test in Task 1 exercises the same stdlib unmarshal into the same type).
+- `user-service/service/threads.go` `ListUserThreads` reads only `LastMsgAt`, `ThreadRoomID`, `RoomName`, `RoomType` — never the bodies.
+
+Expected: no edits.
+
+- [ ] **Step 4: Confirm docs need no change**
+
+Run: `git diff --stat docs/` (expect empty) and inspect `docs/client-api.md` around "List User Threads" / "ThreadListItem": `parentMessage`/`lastMessage` are typed `[Message](#message-schema)`, which stays accurate because the wire bytes are still a `cassandra.Message` marshal. No edit to `docs/client-api.md`, `docs/client-api/request-reply.md`, or `docs/client-api/events.md`.
+
+Expected: no docs diff.
+
+- [ ] **Step 5: Full verification**
+
+```bash
+make test SERVICE=model
+make test SERVICE=history-service
+make test SERVICE=user-service
+make lint
+```
+
+Expected: all green; lint clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add user-service/service/threads_test.go
+git commit -m "user-service(thread.list): regression test for opaque body forwarding
+
+Asserts ListUserThreads forwards a reaction-carrying message body verbatim
+through the cross-site merge without re-encoding or parsing. No production
+change: historyclient now copies the json.RawMessage bytes instead of decoding
+the Message.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Retype `ThreadListItem` bodies to `json.RawMessage` → Task 1. ✓
+- history-service emits pre-marshaled → Task 2. ✓
+- user-service no production change / forward-through → Task 3 (test + verify). ✓
+- Marshal-error → skip row with warn → Task 2 Step 3. ✓
+- Reactions regression coverage at all three levels → Task 1 (model round-trip), Task 2 (builder), Task 3 (aggregator forward). ✓
+- Wire-preserving, no docs diff → Task 3 Step 4. ✓
+- Scope limited to thread.list (no `RoomsGet`/`model.LastMessage` change) → no task touches them. ✓
+
+**Placeholder scan:** No TBD/TODO; all steps show concrete code and commands.
+
+**Type consistency:** `json.RawMessage` used consistently for both fields across all tasks. `decodeThreadMsg` returns `models.Message` (alias of `cassandra.Message`). `models.Reactions`/`cassandra.Reactions` used per package. `ctx(account, site)`, `expectThreadList`, `newThreadSvc`, `newThreadListService`, `testContext`, `intPtr`, `ptrTime` all match existing helpers in their respective test files.

--- a/docs/superpowers/specs/2026-07-23-user-service-opaque-thread-messages-design.md
+++ b/docs/superpowers/specs/2026-07-23-user-service-opaque-thread-messages-design.md
@@ -1,0 +1,204 @@
+# Opaque `json.RawMessage` for thread.list parent/last message bodies
+
+**Date:** 2026-07-23
+**Branch:** `claude/user-service-opaque-messages-gjmv61`
+**Status:** Approved design, pending review
+
+## Problem
+
+`ListUserThreads` in `user-service` (NATS `chat.user.{account}.request.user.{siteID}.thread.list`)
+is a cross-site aggregator: it fans the leaf RPC
+`chat.server.request.thread.{siteID}.subscription.list` out to every site's
+`history-service`, merges the pages into one globally-ordered page, and returns it.
+
+Each leaf item is a `pkgmodel.ThreadListItem`, a **shared** wire type carrying two
+hydrated message bodies:
+
+```go
+ParentMessage *cassandra.Message `json:"parentMessage,omitempty" bson:"parentMessage,omitempty"`
+LastMessage   *cassandra.Message `json:"lastMessage,omitempty"   bson:"lastMessage,omitempty"`
+```
+
+`history-service` **builds** these (typed, from Cassandra); `user-service` **decodes**
+the leaf response into `ThreadSubscriptionListResponse` and **forwards** the bodies to
+the client verbatim. `user-service` reads only `LastMsgAt`, `ThreadRoomID`, `RoomName`,
+and `RoomType` from each item (for sort + DM/botDM enrichment) — it **never reads the
+message bodies**.
+
+`cassandra.Message` embeds:
+
+```go
+Reactions Reactions `json:"reactions,omitempty" cql:"reactions"`
+// Reactions = map[ReactionKey]ReactorInfo, ReactionKey = struct{Emoji, UserAccount string}
+```
+
+`Reactions` has a custom `MarshalJSON` (emits `map<emoji, [{account, displayName}]>`)
+but **no `UnmarshalJSON`**. Go's `encoding/json` cannot decode into a map with a struct
+key. So when `user-service` decodes a leaf response in which any parent or last message
+carries reactions, `json.Unmarshal` **fails outright** and that entire site's page is
+dropped (marked `failed`/`unavailable`). This is not merely wasted work — it is a
+latent correctness bug on a client-facing RPC: threads on any site holding a reacted
+parent/last message silently disappear from the inbox for that page.
+
+The fix removes the decode entirely on the path that never needs it: `user-service`
+should carry the two bodies as opaque bytes and forward them untouched.
+
+## Goal
+
+- `user-service` carries `ParentMessage`/`LastMessage` through the `thread.list`
+  aggregation as opaque `json.RawMessage`, never parsing the message body (and thus
+  never touching the un-decodable `Reactions` map).
+- `history-service` emits the two fields pre-marshaled.
+- The client-facing wire JSON is **byte-for-byte unchanged** — still the full `Message`
+  object under `parentMessage` / `lastMessage`.
+
+## Non-goals
+
+- No change to `Reactions` (no new `UnmarshalJSON`; the grouped-by-emoji wire form is
+  lossy and cannot rebuild the struct-keyed map — irrelevant here since nothing on this
+  path needs to read it back).
+- No change to `RoomsGet` / `model.LastMessage` (`pkg/model/message.go`) or any other
+  RPC. Scope is the `thread.list` path (`ThreadListItem`) only.
+- No change to how `history-service` reads messages from Cassandra or builds the typed
+  `models.Message`.
+
+## Approach
+
+Retype the two shared fields to `json.RawMessage`; `history-service` pre-marshals the
+typed body into bytes at build time; `user-service` forwards the bytes unchanged.
+
+### 1. `pkg/model/threadlist.go`
+
+```go
+// Hydrated message bodies, subject to the thread access window. Carried opaque:
+// user-service forwards these to the client verbatim and never decodes them (avoids
+// parsing cassandra.Message.Reactions, whose struct-keyed map has no JSON decoder).
+// history-service emits them pre-marshaled from *cassandra.Message.
+ParentMessage json.RawMessage `json:"parentMessage,omitempty" bson:"parentMessage,omitempty"`
+LastMessage   json.RawMessage `json:"lastMessage,omitempty"   bson:"lastMessage,omitempty"`
+```
+
+`json.RawMessage` marshals verbatim and "decodes" by copying bytes, so:
+
+- `history-service` marshaling the item emits the same `parentMessage`/`lastMessage`
+  JSON as today (the raw bytes it stored are a `cassandra.Message` marshal).
+- `user-service` decoding the leaf response stores the bytes without parsing; re-marshaling
+  the merged page re-emits them verbatim.
+
+`omitempty` on `json.RawMessage` omits nil/empty slices, preserving the current
+"absent when not hydrated" behavior. `buildThreadItems` always sets both (it skips rows
+missing either), so in practice both are always present.
+
+`bson` tags are retained for struct symmetry; this type is a wire DTO and is not
+persisted, so the `bson`-side behavior is immaterial.
+
+### 2. `history-service/internal/service/threads.go` (`buildThreadItems`)
+
+Today:
+
+```go
+item.ParentMessage = &parent
+item.LastMessage = &last
+```
+
+New: marshal each typed body (`models.Message` = alias of `cassandra.Message`) to bytes
+and assign. A marshal failure **skips the row** with a warning — consistent with the
+existing "a row we can't fully hydrate is skipped rather than surfaced half-empty" rule
+directly above (`if !hasParent || !hasLast { continue }`), so one bad body never fails the
+whole page:
+
+```go
+parentJSON, err := json.Marshal(&parent)
+if err != nil {
+    slog.WarnContext(c, "thread-list: marshaling parent message, skipping row",
+        "request_id", natsutil.RequestIDFromContext(c),
+        "thread_room_id", row.ThreadRoomID, "parent_message_id", row.ParentMessageID, "error", err)
+    continue
+}
+lastJSON, err := json.Marshal(&last)
+if err != nil {
+    slog.WarnContext(c, "thread-list: marshaling last message, skipping row",
+        "request_id", natsutil.RequestIDFromContext(c),
+        "thread_room_id", row.ThreadRoomID, "last_message_id", row.LastMsgID, "error", err)
+    continue
+}
+item.ParentMessage = parentJSON
+item.LastMessage = lastJSON
+```
+
+`history-service` uses `encoding/json` on this path (not sonic), and
+`Reactions.MarshalJSON` is a valid encoder — marshal here is effectively infallible, but
+the guard keeps the page resilient and satisfies the "never ignore errors" rule. The
+marshal is done in the per-row loop after the `hasParent`/`hasLast` check, so the item is
+only appended once both bodies are in hand.
+
+### 3. `user-service`
+
+**No production code change.** `historyclient.GetThreadList` already `json.Unmarshal`s the
+leaf response into `model.ThreadSubscriptionListResponse`; with `json.RawMessage` fields the
+two bodies are copied as bytes instead of parsed. `ListUserThreads` merges items and
+re-marshals `ThreadListResponse`, re-emitting the bytes verbatim. Removing the parse is the
+entire point — it is what makes a reacted parent/last message no longer fail the page.
+
+## Wire compatibility & docs
+
+The client-facing JSON is unchanged: `parentMessage`/`lastMessage` still serialize as the
+full `Message` object (the stored bytes are a `cassandra.Message` marshal). `docs/client-api.md`
+§ *List User Threads* → *ThreadListItem* describes both fields as type
+`[Message](#message-schema)`, which remains accurate; the derived views
+(`docs/client-api/request-reply.md`, `docs/client-api/events.md`) likewise need no change.
+No doc edit is required. (This is a wire-preserving retype of a server-to-server carrier,
+not a change to the client-visible schema.)
+
+## Testing (TDD — Red first)
+
+### `pkg/model/threadlist_test.go`
+
+- **Rewrite `TestThreadListItemJSON_WithMessages`**: build the item with `json.RawMessage`
+  bodies (a marshaled `cassandra.Message`), round-trip through `json.Marshal`/`Unmarshal`,
+  and assert the raw bytes on the far side decode to a `cassandra.Message` with the expected
+  `messageId`/`msg`.
+- **New `TestThreadListItemJSON_MessageWithReactions_RoundTrips`** (regression for the bug):
+  build a `cassandra.Message` **carrying a non-empty `Reactions` map**, marshal it, wrap the
+  bytes as the item's `ParentMessage`/`LastMessage`, then `json.Marshal` the item and
+  `json.Unmarshal` back into a `ThreadListItem` — this must **not error** (the old typed field
+  would have failed on the reactions decode), and the re-emitted `parentMessage.reactions`
+  must equal the grouped-by-emoji wire form.
+- `TestThreadSubscriptionListResponseJSON` and the omit-nil cases stay green unchanged.
+
+### `history-service/internal/service/threadlist_test.go`
+
+- Update assertions that read the typed field (e.g. `first.ParentMessage.MessageID`,
+  `*first.ParentMessage.TCount`, `first.LastMessage.MessageID`): `json.Unmarshal` the
+  `json.RawMessage` into a `cassandra.Message` first, then assert on the decoded value.
+- **New case**: a stubbed parent/last message that carries reactions — assert
+  `buildThreadItems` still includes the row and the raw `parentMessage` bytes contain the
+  grouped reactions form.
+- Existing "missing parent/last ⇒ row skipped" and ordering cases stay as-is (they don't read
+  the body).
+
+### `user-service/service/threads_test.go`
+
+- **New/confirmed case**: a mocked `HistoryClient.GetThreadList` (or a fake leaf reply the
+  client decodes) returning items whose `ParentMessage`/`LastMessage` are marshaled messages
+  **carrying reactions**; assert `ListUserThreads` aggregates and returns them without marking
+  the site `unavailable`, and the forwarded bytes are unchanged. This is the end-to-end guard
+  for the actual bug.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `pkg/model/threadlist.go` | Retype `ParentMessage`/`LastMessage` to `json.RawMessage`; add `encoding/json` import; update field doc comment |
+| `pkg/model/threadlist_test.go` | Rewrite `_WithMessages`; add reactions round-trip regression test |
+| `history-service/internal/service/threads.go` | Pre-marshal both bodies in `buildThreadItems`; skip-with-warn on marshal error |
+| `history-service/internal/service/threadlist_test.go` | Decode raw bytes in assertions; add reactions case |
+| `user-service/service/threads_test.go` | Add reactions forward-through regression test (no production change) |
+
+## Verification
+
+- `make test SERVICE=user-service`, `make test SERVICE=history-service`, and the `pkg/model`
+  package tests pass with `-race` (the Makefile default).
+- `make lint` clean.
+- No `docs/client-api.md` diff (wire-preserving); confirm by inspecting the emitted
+  `parentMessage`/`lastMessage` JSON in the new tests matches the pre-change bytes.

--- a/history-service/internal/service/threadlist_test.go
+++ b/history-service/internal/service/threadlist_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -18,6 +19,15 @@ import (
 	"github.com/hmchangw/chat/pkg/errcode"
 	pkgmodel "github.com/hmchangw/chat/pkg/model"
 )
+
+// decodeThreadMsg decodes an opaque ThreadListItem body back into a message for
+// assertion; the RPC carries these bodies as pre-marshaled json.RawMessage.
+func decodeThreadMsg(t *testing.T, raw json.RawMessage) models.Message {
+	t.Helper()
+	var m models.Message
+	require.NoError(t, json.Unmarshal(raw, &m))
+	return m
+}
 
 func newThreadListService(t *testing.T) (
 	*service.HistoryService,
@@ -72,16 +82,47 @@ func TestHistoryService_ListThreadSubscriptions_Success(t *testing.T) {
 	require.NotNil(t, first.LastSeenAt)
 	assert.Equal(t, base.Add(2*time.Hour).UnixMilli(), *first.LastSeenAt)
 	require.NotNil(t, first.ParentMessage)
-	assert.Equal(t, "p1", first.ParentMessage.MessageID)
-	require.NotNil(t, first.ParentMessage.TCount)
-	assert.Equal(t, 4, *first.ParentMessage.TCount) // reply count rides on the parent
+	parent := decodeThreadMsg(t, first.ParentMessage)
+	assert.Equal(t, "p1", parent.MessageID)
+	require.NotNil(t, parent.TCount)
+	assert.Equal(t, 4, *parent.TCount) // reply count rides on the parent
 	require.NotNil(t, first.LastMessage)
-	assert.Equal(t, "m1", first.LastMessage.MessageID)
+	assert.Equal(t, "m1", decodeThreadMsg(t, first.LastMessage).MessageID)
 	assert.True(t, first.Unread) // lastMsgAt 5h > lastSeenAt 2h
 
 	second := resp.Items[1]
 	assert.Nil(t, second.LastSeenAt)
 	assert.True(t, second.Unread) // never-seen ⇒ unread
+}
+
+// A parent carrying reactions still builds and its body rides through as the
+// grouped-by-emoji wire form (guards the user-service forward path).
+func TestHistoryService_ListThreadSubscriptions_ParentWithReactions(t *testing.T) {
+	svc, msgs, _, _, threadSubs := newThreadListService(t)
+	base := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	rows := []mongorepo.ThreadSubRow{
+		{ThreadRoomID: "tr-1", RoomID: "r1", SiteID: "site-a", ParentMessageID: "p1", LastMsgID: "m1", LastMsgAt: base.Add(5 * time.Hour)},
+	}
+	threadSubs.EXPECT().ListUserThreadSubscriptions(gomock.Any(), "alice", gomock.Any(), gomock.Any(), gomock.Any()).Return(rows, false, nil)
+	msgs.EXPECT().GetMessagesByIDs(gomock.Any(), gomock.Any()).Return([]models.Message{
+		{MessageID: "p1", RoomID: "r1", Msg: "parent", Reactions: models.Reactions{
+			{Emoji: "👍", UserAccount: "bob"}: {Account: "bob", EngName: "Bob Chen", ReactedAt: base},
+		}},
+		{MessageID: "m1", RoomID: "r1", Msg: "last"},
+	}, nil)
+
+	resp, err := svc.ListThreadSubscriptions(testContext(), pkgmodel.ThreadSubscriptionListRequest{Account: "alice", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, resp.Items, 1)
+	// The body is carried opaque; a reactions-bearing body cannot be decoded back
+	// into a Message (that is exactly the parse this change avoids), so assert on
+	// the raw wire JSON only — messageId plus the grouped-by-emoji reactions form.
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(resp.Items[0].ParentMessage, &raw))
+	assert.Equal(t, "p1", raw["messageId"])
+	reactions, ok := raw["reactions"].(map[string]any)
+	require.True(t, ok, "reactions must be present in the built body")
+	assert.Contains(t, reactions, "👍")
 }
 
 func TestHistoryService_ListThreadSubscriptions_Empty(t *testing.T) {

--- a/history-service/internal/service/threads.go
+++ b/history-service/internal/service/threads.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"time"
@@ -238,8 +239,22 @@ func (s *HistoryService) buildThreadItems(c *natsrouter.Context, rows []mongorep
 			ms := row.LastSeenAt.UTC().UnixMilli()
 			item.LastSeenAt = &ms
 		}
-		item.ParentMessage = &parent
-		item.LastMessage = &last
+		parentJSON, err := json.Marshal(&parent)
+		if err != nil {
+			slog.WarnContext(c, "thread-list: marshaling parent message, skipping row",
+				"request_id", natsutil.RequestIDFromContext(c),
+				"thread_room_id", row.ThreadRoomID, "parent_message_id", row.ParentMessageID, "error", err)
+			continue
+		}
+		lastJSON, err := json.Marshal(&last)
+		if err != nil {
+			slog.WarnContext(c, "thread-list: marshaling last message, skipping row",
+				"request_id", natsutil.RequestIDFromContext(c),
+				"thread_room_id", row.ThreadRoomID, "last_message_id", row.LastMsgID, "error", err)
+			continue
+		}
+		item.ParentMessage = parentJSON
+		item.LastMessage = lastJSON
 		items = append(items, item)
 	}
 	return items, nil

--- a/pkg/model/threadlist.go
+++ b/pkg/model/threadlist.go
@@ -1,6 +1,6 @@
 package model
 
-import "github.com/hmchangw/chat/pkg/model/cassandra"
+import "encoding/json"
 
 // ThreadListItem is one row of a user's cross-site thread inbox: a thread the
 // user is subscribed to, enriched with its parent and last message plus the
@@ -22,9 +22,12 @@ type ThreadListItem struct {
 	// key for the inbox. Reply count rides on ParentMessage.TCount.
 	LastMsgAt int64 `json:"lastMsgAt" bson:"lastMsgAt"`
 
-	// Hydrated message bodies, subject to the thread access window.
-	ParentMessage *cassandra.Message `json:"parentMessage,omitempty" bson:"parentMessage,omitempty"`
-	LastMessage   *cassandra.Message `json:"lastMessage,omitempty"   bson:"lastMessage,omitempty"`
+	// Hydrated message bodies, subject to the thread access window. Carried opaque:
+	// history-service emits them pre-marshaled from *cassandra.Message and user-service
+	// forwards them to the client verbatim, never decoding the Message (avoids parsing
+	// Reactions, whose struct-keyed map has no JSON decoder).
+	ParentMessage json.RawMessage `json:"parentMessage,omitempty" bson:"parentMessage,omitempty"`
+	LastMessage   json.RawMessage `json:"lastMessage,omitempty"   bson:"lastMessage,omitempty"`
 
 	// HRInfo carries the DM counterpart's HR-directory record (native + English
 	// name). The user-service aggregator resolves it from RoomName (which holds the

--- a/pkg/model/threadlist_test.go
+++ b/pkg/model/threadlist_test.go
@@ -3,6 +3,7 @@ package model_test
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,10 +64,13 @@ func TestThreadListItemJSON_OmitsNilLastSeenAt(t *testing.T) {
 	assert.False(t, hasParent, "nil parentMessage must be omitted")
 }
 
-// The hydrated parent/last message bodies survive a JSON round trip.
+// The hydrated parent/last message bodies are carried opaque and survive a JSON
+// round trip; user-service forwards these bytes without decoding the Message.
 func TestThreadListItemJSON_WithMessages(t *testing.T) {
-	parent := &cassandra.Message{MessageID: "msg-parent", RoomID: "room-1", Msg: "anyone?"}
-	last := &cassandra.Message{MessageID: "msg-last", RoomID: "room-1", Msg: "on it"}
+	parent, err := json.Marshal(&cassandra.Message{MessageID: "msg-parent", RoomID: "room-1", Msg: "anyone?"})
+	require.NoError(t, err)
+	last, err := json.Marshal(&cassandra.Message{MessageID: "msg-last", RoomID: "room-1", Msg: "on it"})
+	require.NoError(t, err)
 	src := model.ThreadListItem{
 		SiteID: "site-a", RoomID: "room-1", ThreadRoomID: "thr-1",
 		ParentMessageID: "msg-parent", LastMsgAt: 1746518400000,
@@ -78,8 +82,39 @@ func TestThreadListItemJSON_WithMessages(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &dst))
 	require.NotNil(t, dst.ParentMessage)
 	require.NotNil(t, dst.LastMessage)
-	assert.Equal(t, "msg-parent", dst.ParentMessage.MessageID)
-	assert.Equal(t, "on it", dst.LastMessage.Msg)
+	var gotParent, gotLast cassandra.Message
+	require.NoError(t, json.Unmarshal(dst.ParentMessage, &gotParent))
+	require.NoError(t, json.Unmarshal(dst.LastMessage, &gotLast))
+	assert.Equal(t, "msg-parent", gotParent.MessageID)
+	assert.Equal(t, "on it", gotLast.Msg)
+}
+
+// Regression: a parent/last body carrying reactions must round-trip through
+// ThreadListItem without a decode error. The old *cassandra.Message field failed
+// here because Reactions is a struct-keyed map with no JSON decoder.
+func TestThreadListItemJSON_MessageWithReactions_RoundTrips(t *testing.T) {
+	body, err := json.Marshal(&cassandra.Message{
+		MessageID: "msg-parent", RoomID: "room-1", Msg: "anyone?",
+		Reactions: cassandra.Reactions{
+			{Emoji: "👍", UserAccount: "bob"}: {Account: "bob", EngName: "Bob Chen", ReactedAt: time.UnixMilli(1746518400000).UTC()},
+		},
+	})
+	require.NoError(t, err)
+	src := model.ThreadListItem{
+		SiteID: "site-a", RoomID: "room-1", ThreadRoomID: "thr-1",
+		ParentMessageID: "msg-parent", LastMsgAt: 1746518400000,
+		ParentMessage: body, LastMessage: body,
+	}
+	data, err := json.Marshal(&src)
+	require.NoError(t, err)
+	var dst model.ThreadListItem
+	require.NoError(t, json.Unmarshal(data, &dst)) // must NOT error on reactions
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(dst.ParentMessage, &got))
+	assert.Equal(t, "msg-parent", got["messageId"])
+	reactions, ok := got["reactions"].(map[string]any)
+	require.True(t, ok, "reactions must survive in the forwarded body")
+	assert.Contains(t, reactions, "👍")
 }
 
 func TestThreadSubscriptionListRequestJSON(t *testing.T) {

--- a/user-service/service/threads_test.go
+++ b/user-service/service/threads_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/user-service/config"
 	"github.com/hmchangw/chat/user-service/service/mocks"
 )
@@ -49,6 +51,33 @@ func item(site, threadRoomID string, lastMsgAt int64) model.ThreadListItem {
 func expectThreadList(history *mocks.MockHistoryClient, site string, items []model.ThreadListItem, hasMore bool) {
 	history.EXPECT().GetThreadList(gomock.Any(), site, gomock.Any()).
 		Return(model.ThreadSubscriptionListResponse{Items: items, HasMore: hasMore}, nil)
+}
+
+// A message body carrying reactions is aggregated and forwarded verbatim: the
+// old typed field would have failed the leaf-response decode inside historyclient;
+// with json.RawMessage the bytes pass straight through the merge and re-encode.
+func TestUserService_ListUserThreads_ForwardsMessageBodiesWithReactions(t *testing.T) {
+	svc, history, _, _ := newThreadSvc(t)
+	body, err := json.Marshal(&cassandra.Message{
+		MessageID: "p1", RoomID: "r1", Msg: "parent",
+		Reactions: cassandra.Reactions{
+			{Emoji: "👍", UserAccount: "bob"}: {Account: "bob", EngName: "Bob Chen"},
+		},
+	})
+	require.NoError(t, err)
+	items := []model.ThreadListItem{{
+		SiteID: "site-a", RoomID: "r1", RoomType: model.RoomTypeChannel, ThreadRoomID: "tr-1",
+		ParentMessageID: "p1", LastMsgAt: 100, ParentMessage: body, LastMessage: body,
+	}}
+	expectThreadList(history, "site-a", items, false)
+	expectThreadList(history, "site-b", nil, false)
+
+	resp, err := svc.ListUserThreads(ctx("alice", "site-a"), model.ThreadListRequest{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, resp.Items, 1)
+	// Bytes forwarded unchanged — no re-encode, no reactions parse.
+	assert.Equal(t, body, []byte(resp.Items[0].ParentMessage))
+	assert.Equal(t, body, []byte(resp.Items[0].LastMessage))
 }
 
 func TestUserService_ListUserThreads_MergeAcrossSites(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a latent correctness bug in `user-service`'s `ListUserThreads` RPC where threads with reacted parent or last messages silently disappear from the inbox. The root cause: `cassandra.Message.Reactions` is a struct-keyed map with no `UnmarshalJSON`, so decoding a leaf response carrying reactions fails and marks the entire site unavailable.

The fix removes the decode entirely on the path that never needs it: retype `ThreadListItem.ParentMessage` and `.LastMessage` from `*cassandra.Message` to `json.RawMessage`, have `history-service` pre-marshal the bodies at build time, and let `user-service` forward the bytes untouched. The client-facing wire JSON is byte-for-byte unchanged — still the full `Message` object.

## Changes

- **`pkg/model/threadlist.go`**: Retype `ParentMessage` and `LastMessage` fields to `json.RawMessage`; swap import from `cassandra` to `encoding/json`. Wire form unchanged; `omitempty` preserves "absent when not hydrated" behavior.

- **`pkg/model/threadlist_test.go`**: Rewrite `TestThreadListItemJSON_WithMessages` to build items with marshaled bodies and assert round-trip fidelity. Add `TestThreadListItemJSON_MessageWithReactions_RoundTrips` regression test — verifies a reactions-bearing body survives JSON marshal/unmarshal without error (the old typed field would have failed here).

- **`history-service/internal/service/threads.go`**: In `buildThreadItems`, marshal each hydrated `models.Message` to `json.RawMessage` bytes before assignment. Skip the row with a warning on marshal error (effectively infallible but guards resilience; consistent with existing "skip half-hydrated rows" rule).

- **`history-service/internal/service/threadlist_test.go`**: Add `decodeThreadMsg` helper to unmarshal opaque bodies in assertions. Update existing assertions to decode before reading typed fields. Add `TestHistoryService_ListThreadSubscriptions_ParentWithReactions` to verify reactions-bearing bodies build and carry through as grouped-by-emoji wire form.

- **`user-service/service/threads_test.go`**: Add `TestUserService_ListUserThreads_ForwardsMessageBodiesWithReactions` regression test — asserts a reactions-bearing body aggregates and forwards verbatim without marking the site unavailable. No production change: `historyclient.GetThreadList` now copies `json.RawMessage` bytes instead of parsing.

## Implementation Details

- **TDD**: All tests written first (Red), then implementation (Green). Compilation coupling intentional: Task 1 retyping breaks `history-service` until Task 2 lands; full suite green only at Task 3.
- **Error handling**: Marshal failures in `buildThreadItems` logged with `slog.WarnContext` (structured fields, no secrets), row skipped to keep page resilient.
- **Coverage**: Happy path + reactions regression at all three levels (model round-trip, builder, aggregator forward). Minimum 80% coverage maintained.
- **Docs**: No change to `docs/client-api.md` — wire-preserving retype of a server-to-server carrier; client sees the same `Message` object under `parentMessage`/`lastMessage`.

All tests pass with race detector; `make lint` clean.

https://claude.ai/code/session_012qe55SeznCzmAoMdtrHa3n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread list reliability for messages containing reactions.
  * Preserved parent and latest message content unchanged when forwarding thread data.
  * Prevented affected thread entries from being omitted due to message reaction data.
* **Documentation**
  * Added implementation and design documentation for reliable message forwarding in thread lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->