### PR TITLE
Make admin-account prefix configurable for read-floor & receipts

### DIFF
--- a/docs/superpowers/plans/2026-07-23-admin-acct-prefix-config.md
+++ b/docs/superpowers/plans/2026-07-23-admin-acct-prefix-config.md
@@ -1,0 +1,485 @@
+# Configurable Admin-Account Prefix (Read-Floor & Receipts) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the hardcoded `p_` admin/platform prefix used by `room-service`'s read-floor and read-receipt queries operator-configurable via `ADMIN_ACCT_PREFIX` (default `p_chatadmin_`).
+
+**Architecture:** A pure helper builds the two query-side exclusion regexes from the configured prefix (regex-escaped). `NewMongoStore` gains a functional option (`WithAdminAcctPrefix`) that overrides the built-in default; the store holds the precomputed regex strings and the four read queries reference them instead of package constants. `main.go` parses `ADMIN_ACCT_PREFIX` and passes the option.
+
+**Tech Stack:** Go 1.25, `go.mongodb.org/mongo-driver/v2`, `caarlos0/env`, `stretchr/testify`, testcontainers-go (integration).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-23-admin-acct-prefix-config-design.md`.
+- Scope is **read-state only** — the 4 methods in `room-service/store_mongo.go`. Do **not** touch `helper.go`'s `platformAdminRegex`, `pkg/model.IsPlatformAdminAccount`, or any other `p_` site.
+- The **bot filter is unchanged** (`u.isBot $ne true` / `.bot` suffix). Only the admin-prefix half becomes configurable.
+- Empty prefix ⇒ admin exclusion **disabled** (bot filter still applies). Never emit a bare `^` regex.
+- Regex-escape the configured prefix with `regexp.QuoteMeta` — a config value is never a trusted regex literal.
+- Env var: `ADMIN_ACCT_PREFIX`, `envDefault:"p_chatadmin_"`, `SCREAMING_SNAKE_CASE`, parsed via `caarlos0/env` (never `os.Getenv`).
+- Always use `make` targets. Unit: `make test SERVICE=room-service`. Integration: `make test-integration SERVICE=room-service`. Lint: `make lint`.
+- Minimum 80% coverage; cover happy path, edge (empty prefix, regex metachars), and the narrowing behavior.
+- No schema, no migration, no wire change ⇒ **no `docs/client-api.md` update** (request/response, errors, events all unchanged).
+
+> **Refinement of spec §4.2:** the spec sketched `NewMongoStore(db, adminAcctPrefix)`. This plan uses a **functional option** (`NewMongoStore(db, opts ...Option)`) instead, because `NewMongoStore(db)` has ~130 call sites in `room-service/integration_test.go`; a required positional arg would force noisy edits to all of them. The variadic option keeps every existing call compiling (they get the default) and matches the repo's established options idiom (`pkg/roommetacache`, `pkg/mongoutil`). Task 4 syncs the spec text.
+
+---
+
+## File Structure
+
+- `room-service/store_mongo.go` — Modify: add `adminAccountPatterns` helper, `Option`/`WithAdminAcctPrefix`, `defaultAdminAcctPrefix`, two `MongoStore` fields; rewrite the 4 read queries; remove `pseudoAccountRegex`/`botOrPseudoAccountRegex` constants.
+- `room-service/store_mongo_test.go` — Create: unit test for `adminAccountPatterns` (no build tag; runs under `make test`).
+- `room-service/integration_test.go` — Modify: update the admin fixtures in the two existing read tests; add prefix-config coverage (narrowing, custom prefix, empty prefix) for room and thread paths.
+- `room-service/main.go` — Modify: add `AdminAcctPrefix` config field; pass `WithAdminAcctPrefix(cfg.AdminAcctPrefix)` at the `NewMongoStore` call.
+- `room-service/deploy/docker-compose.yml` — Modify: document `ADMIN_ACCT_PREFIX` in the env block.
+- `docs/superpowers/specs/2026-07-23-admin-acct-prefix-config-design.md` — Modify: sync §4.2 constructor signature to the functional-option form.
+
+---
+
+## Task 1: Pure regex-builder helper (`adminAccountPatterns`)
+
+**Files:**
+- Modify: `room-service/store_mongo.go`
+- Test: `room-service/store_mongo_test.go` (create)
+
+**Interfaces:**
+- Produces: `func adminAccountPatterns(prefix string) (adminRegex, botOrAdminRegex string)` and `const defaultAdminAcctPrefix = "p_chatadmin_"`.
+- Consumes: existing `const botAccountRegex = ` `` `\.bot$` `` (store_mongo.go:23) and the already-imported `regexp`.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `room-service/store_mongo_test.go`:
+
+```go
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdminAccountPatterns(t *testing.T) {
+	tests := []struct {
+		name            string
+		prefix          string
+		wantAdmin       string
+		wantBotOrAdmin  string
+	}{
+		{"default admin prefix", "p_chatadmin_", "^p_chatadmin_", `(\.bot$|^p_chatadmin_)`},
+		{"legacy broad prefix", "p_", "^p_", `(\.bot$|^p_)`},
+		{"empty disables admin filter", "", "", `\.bot$`},
+		{"regex metacharacters are escaped", "p.a(", `^p\.a\(`, `(\.bot$|^p\.a\()`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAdmin, gotBotOrAdmin := adminAccountPatterns(tt.prefix)
+			assert.Equal(t, tt.wantAdmin, gotAdmin, "adminRegex")
+			assert.Equal(t, tt.wantBotOrAdmin, gotBotOrAdmin, "botOrAdminRegex")
+		})
+	}
+}
+
+func TestDefaultAdminAcctPrefix(t *testing.T) {
+	assert.Equal(t, "p_chatadmin_", defaultAdminAcctPrefix)
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `make test SERVICE=room-service`
+Expected: FAIL — compile error `undefined: adminAccountPatterns` / `undefined: defaultAdminAcctPrefix`.
+
+- [ ] **Step 3: Add the helper and default constant**
+
+In `room-service/store_mongo.go`, directly below the `botAccountPattern` var (after line 25), add:
+
+```go
+// defaultAdminAcctPrefix is the built-in ADMIN_ACCT_PREFIX default: admin
+// accounts are named p_chatadmin_*. Overridden per-store via WithAdminAcctPrefix.
+const defaultAdminAcctPrefix = "p_chatadmin_"
+
+// adminAccountPatterns builds the query-side account-exclusion regexes from a
+// configured admin-account prefix. It returns the admin-only regex (anchored,
+// for the main-room u.account guard) and the combined bot+admin regex (for the
+// flat thread_subscriptions queries). An empty prefix disables the admin-account
+// exclusion (adminRegex == ""), leaving only the bot filter. The prefix is
+// regex-escaped: a configured value must never be trusted to be a regex literal.
+func adminAccountPatterns(prefix string) (adminRegex, botOrAdminRegex string) {
+	if prefix == "" {
+		return "", botAccountRegex
+	}
+	q := regexp.QuoteMeta(prefix)
+	return "^" + q, `(\.bot$|^` + q + `)`
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `make test SERVICE=room-service`
+Expected: PASS (`TestAdminAccountPatterns`, `TestDefaultAdminAcctPrefix`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add room-service/store_mongo.go room-service/store_mongo_test.go
+git commit -m "feat(room-service): add adminAccountPatterns regex builder"
+```
+
+---
+
+## Task 2: Store option, fields, and query rewrite
+
+**Files:**
+- Modify: `room-service/store_mongo.go`
+- Test: `room-service/integration_test.go`
+
+**Interfaces:**
+- Consumes: `adminAccountPatterns`, `defaultAdminAcctPrefix` (Task 1).
+- Produces:
+  - `type Option func(*MongoStore)`
+  - `func WithAdminAcctPrefix(prefix string) Option`
+  - `func NewMongoStore(db *mongo.Database, opts ...Option) *MongoStore` (signature widened; existing zero-option calls unaffected)
+  - `MongoStore` fields `adminAcctRegex string`, `botOrAdminRegex string`.
+
+- [ ] **Step 1: Write the failing integration tests**
+
+All edits are in `room-service/integration_test.go`.
+
+(a) In `TestMongoStore_MinSubscriptionLastSeenByRoomID_Integration`, update the "padmin" fixture so the admin account matches the new default (currently `p_admin`, lines ~2145-2148):
+
+```go
+	mustInsertSub(t, db, &model.Subscription{
+		ID: "s18", User: model.SubscriptionUser{ID: "u18", Account: "p_chatadmin_admin"},
+		RoomID: "padmin", JoinedAt: earliest,
+	})
+```
+
+(b) In the same test, immediately after the "padmin" assertion block (after line ~2152, before the "no subscriptions" block), add a narrowing case — a non-admin `p_` account is now a real participant:
+
+```go
+	// Room "pwebhook-counted": a non-admin p_ account (does NOT match the default
+	// ADMIN_ACCT_PREFIX p_chatadmin_) is a real participant now. It has never read,
+	// so the strict floor is nil — proving the narrowed prefix no longer excludes
+	// every p_ account the way the old ^p_ guard did.
+	mustInsertSub(t, db, &model.Subscription{
+		ID: "s19", User: model.SubscriptionUser{ID: "u19", Account: "nina"},
+		RoomID: "pwebhook-counted", JoinedAt: earliest, LastSeenAt: &mid,
+	})
+	mustInsertSub(t, db, &model.Subscription{
+		ID: "s20", User: model.SubscriptionUser{ID: "u20", Account: "p_webhook"},
+		RoomID: "pwebhook-counted", JoinedAt: earliest,
+	})
+	got, err = store.MinSubscriptionLastSeenByRoomID(ctx, "pwebhook-counted")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+```
+
+(c) In `TestMongoStore_ListReadReceipts_Integration`, rename the admin fixture (users doc `uE` line ~2313 and sub `sE` line ~2327) from `p_ops` to `p_chatadmin_ops` so it stays excluded under the default:
+
+```go
+		bson.M{"_id": "uE", "account": "p_chatadmin_ops", "chineseName": "運維", "engName": "Ops"},
+```
+```go
+		bson.M{"_id": "sE", "roomId": "r1", "u": bson.M{"_id": "uE", "account": "p_chatadmin_ops"}, "lastSeenAt": msgTime.Add(20 * time.Minute)},
+```
+
+(d) In `TestMongoStore_MinThreadSubscriptionLastSeenByThreadRoomID_Integration`, after the "bot-parent" block (after line ~2238), add admin-excluded and non-admin-counted thread cases:
+
+```go
+	// "admin-parent": a p_chatadmin_ admin thread subscriber that never read is
+	// excluded by account, so the floor is the human's lastSeenAt.
+	mustInsertThreadSub(t, db, &model.ThreadSubscription{ID: "ts8", ThreadRoomID: "admin-parent", UserAccount: "grace", LastSeenAt: &mid})
+	mustInsertThreadSub(t, db, &model.ThreadSubscription{ID: "ts9", ThreadRoomID: "admin-parent", UserAccount: "p_chatadmin_ops"})
+	got, err = store.MinThreadSubscriptionLastSeenByThreadRoomID(ctx, "admin-parent")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.WithinDuration(t, mid, *got, time.Second)
+
+	// "pwebhook-thread": a non-admin p_ subscriber is counted now; never-read ⇒ nil.
+	mustInsertThreadSub(t, db, &model.ThreadSubscription{ID: "ts10", ThreadRoomID: "pwebhook-thread", UserAccount: "harry", LastSeenAt: &mid})
+	mustInsertThreadSub(t, db, &model.ThreadSubscription{ID: "ts11", ThreadRoomID: "pwebhook-thread", UserAccount: "p_webhook"})
+	got, err = store.MinThreadSubscriptionLastSeenByThreadRoomID(ctx, "pwebhook-thread")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+```
+
+(e) Add a dedicated test at the end of `integration_test.go` exercising the option (custom + empty prefix) on the room receipt path:
+
+```go
+func TestMongoStore_ListReadReceipts_AdminPrefixConfig_Integration(t *testing.T) {
+	ctx := context.Background()
+	db := setupMongo(t)
+	require.NoError(t, NewMongoStore(db).EnsureIndexes(ctx))
+
+	_, err := db.Collection("users").InsertMany(ctx, []any{
+		bson.M{"_id": "uB", "account": "bob", "chineseName": "鮑勃", "engName": "Bob"},
+		bson.M{"_id": "uAdm", "account": "p_chatadmin_ops", "chineseName": "運維", "engName": "Ops"},
+		bson.M{"_id": "uHook", "account": "p_webhook", "chineseName": "掛鉤", "engName": "Hook"},
+	})
+	require.NoError(t, err)
+
+	msgTime := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	_, err = db.Collection("subscriptions").InsertMany(ctx, []any{
+		bson.M{"_id": "sB", "roomId": "r1", "u": bson.M{"_id": "uB", "account": "bob"}, "lastSeenAt": msgTime.Add(time.Hour)},
+		bson.M{"_id": "sAdm", "roomId": "r1", "u": bson.M{"_id": "uAdm", "account": "p_chatadmin_ops"}, "lastSeenAt": msgTime.Add(time.Hour)},
+		bson.M{"_id": "sHook", "roomId": "r1", "u": bson.M{"_id": "uHook", "account": "p_webhook"}, "lastSeenAt": msgTime.Add(time.Hour)},
+	})
+	require.NoError(t, err)
+
+	accountsOf := func(store *MongoStore) []string {
+		rows, err := store.ListReadReceipts(ctx, "r1", msgTime, "someone-else", 100)
+		require.NoError(t, err)
+		got := make([]string, 0, len(rows))
+		for _, r := range rows {
+			got = append(got, r.Account)
+		}
+		return got
+	}
+
+	// Default prefix (p_chatadmin_): admin excluded, non-admin p_webhook counted.
+	assert.ElementsMatch(t, []string{"bob", "p_webhook"}, accountsOf(NewMongoStore(db)))
+
+	// Broad legacy prefix p_: both p_ accounts excluded.
+	assert.ElementsMatch(t, []string{"bob"}, accountsOf(NewMongoStore(db, WithAdminAcctPrefix("p_"))))
+
+	// Empty prefix: admin exclusion disabled, all three surface.
+	assert.ElementsMatch(t, []string{"bob", "p_chatadmin_ops", "p_webhook"}, accountsOf(NewMongoStore(db, WithAdminAcctPrefix(""))))
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `make test-integration SERVICE=room-service`
+Expected: FAIL — compile error `undefined: WithAdminAcctPrefix` (option not yet defined). This is the RED for this task.
+
+- [ ] **Step 3: Add the option, fields, and constructor**
+
+In `room-service/store_mongo.go`, add two fields to the `MongoStore` struct (after `teamsMeetings`, line ~36):
+
+```go
+	// adminAcctRegex excludes admin accounts (accounts matching ADMIN_ACCT_PREFIX)
+	// from read floors / receipts; "" disables the admin exclusion. botOrAdminRegex
+	// is the combined bot+admin exclusion for the flat thread_subscriptions queries.
+	adminAcctRegex  string
+	botOrAdminRegex string
+```
+
+Replace `NewMongoStore` (lines ~39-51) with:
+
+```go
+// Option configures a MongoStore at construction.
+type Option func(*MongoStore)
+
+// WithAdminAcctPrefix overrides the account prefix used to exclude admin
+// accounts from read-floor and read-receipt queries. An empty prefix disables
+// the admin-account exclusion (bot filtering still applies).
+func WithAdminAcctPrefix(prefix string) Option {
+	return func(s *MongoStore) {
+		s.adminAcctRegex, s.botOrAdminRegex = adminAccountPatterns(prefix)
+	}
+}
+
+func NewMongoStore(db *mongo.Database, opts ...Option) *MongoStore {
+	adminRegex, botOrAdminRegex := adminAccountPatterns(defaultAdminAcctPrefix)
+	s := &MongoStore{
+		rooms:               db.Collection("rooms"),
+		subscriptions:       db.Collection("subscriptions"),
+		threadSubscriptions: db.Collection("thread_subscriptions"),
+		threadRooms:         db.Collection("thread_rooms"),
+		roomMembers:         db.Collection("room_members"),
+		users:               db.Collection("users"),
+		apps:                db.Collection("apps"),
+		botCmdMenus:         db.Collection("bot_cmd_menu"),
+		teamsMeetings:       db.Collection("teams_meetings"),
+		adminAcctRegex:      adminRegex,
+		botOrAdminRegex:     botOrAdminRegex,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+```
+
+- [ ] **Step 4: Rewrite the four read queries to use the store fields**
+
+In `room-service/store_mongo.go`:
+
+Remove the now-unused constants (lines ~1118-1125): the `pseudoAccountRegex` / `botOrPseudoAccountRegex` `const (...)` block and its doc comment.
+
+`MinSubscriptionLastSeenByRoomID` — replace the `FindOne` filter (the `bson.M{"roomId": roomID, ...}` literal at line ~1160) with a conditional build:
+
+```go
+	filter := bson.M{"roomId": roomID, "u.isBot": bson.M{"$ne": true}}
+	if s.adminAcctRegex != "" {
+		filter["u.account"] = bson.M{"$not": bson.Regex{Pattern: s.adminAcctRegex}}
+	}
+	err := s.subscriptions.FindOne(ctx,
+		filter,
+		options.FindOne().
+			SetSort(bson.D{{Key: "lastSeenAt", Value: 1}}).
+			SetProjection(bson.M{"lastSeenAt": 1, "_id": 0}),
+	).Decode(&doc)
+```
+
+`ListReadReceipts` — replace the `$match` stage (lines ~1202-1209) with:
+
+```go
+	account := bson.M{"$ne": excludeAccount}
+	if s.adminAcctRegex != "" {
+		account["$not"] = bson.Regex{Pattern: s.adminAcctRegex}
+	}
+	pipeline := mongo.Pipeline{
+		{{Key: "$match", Value: bson.M{
+			"roomId":     roomID,
+			"lastSeenAt": bson.M{"$gte": since},
+			"u.account":  account,
+			"u.isBot":    bson.M{"$ne": true},
+		}}},
+```
+(Leave the `$lookup`/`$unwind`/`$replaceWith`/`$limit` stages that follow unchanged.)
+
+`MinThreadSubscriptionLastSeenByThreadRoomID` — replace the `FindOne` filter (line ~1789):
+
+```go
+		bson.M{"threadRoomId": threadRoomID, "userAccount": bson.M{"$not": bson.Regex{Pattern: s.botOrAdminRegex}}},
+```
+
+`ListThreadReadReceipts` — replace the `$match` stage (lines ~1258-1264) `userAccount` value:
+
+```go
+			"userAccount":  bson.M{"$ne": excludeAccount, "$not": bson.Regex{Pattern: s.botOrAdminRegex}},
+```
+
+- [ ] **Step 5: Run unit + integration tests to verify they pass**
+
+Run: `make test SERVICE=room-service && make test-integration SERVICE=room-service`
+Expected: PASS — Task 1 unit tests, the four updated read tests, and `TestMongoStore_ListReadReceipts_AdminPrefixConfig_Integration` all green.
+
+- [ ] **Step 6: Lint**
+
+Run: `make lint`
+Expected: 0 issues (no dangling references to the removed constants).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add room-service/store_mongo.go room-service/integration_test.go
+git commit -m "feat(room-service): configurable admin prefix in read-floor/receipt queries"
+```
+
+---
+
+## Task 3: Config wiring (`main.go` + docker-compose)
+
+**Files:**
+- Modify: `room-service/main.go`
+- Modify: `room-service/deploy/docker-compose.yml`
+
+**Interfaces:**
+- Consumes: `WithAdminAcctPrefix` (Task 2).
+- Produces: `config.AdminAcctPrefix` (env `ADMIN_ACCT_PREFIX`, default `p_chatadmin_`).
+
+- [ ] **Step 1: Add the config field**
+
+In `room-service/main.go`, in the `config` struct (after `RestrictedRoomMinMembers`, line ~43), add:
+
+```go
+	// ADMIN_ACCT_PREFIX scopes which accounts are treated as admins and excluded
+	// from read floors / receipts. Empty disables the admin exclusion (bots still
+	// excluded). See store_mongo.go adminAccountPatterns.
+	AdminAcctPrefix string `env:"ADMIN_ACCT_PREFIX" envDefault:"p_chatadmin_"`
+```
+
+- [ ] **Step 2: Pass the option at store construction**
+
+In `room-service/main.go`, replace line ~131:
+
+```go
+	store := NewMongoStore(db, WithAdminAcctPrefix(cfg.AdminAcctPrefix))
+```
+
+- [ ] **Step 3: Verify the service builds**
+
+Run: `make build SERVICE=room-service`
+Expected: builds cleanly.
+
+- [ ] **Step 4: Document the env var in docker-compose**
+
+In `room-service/deploy/docker-compose.yml`, in the `room-service.environment` list (after `MAX_BATCH_SIZE=500`, line ~22), add:
+
+```yaml
+      # Accounts matching this prefix are treated as admins and excluded from
+      # read floors / receipts. Empty disables the admin exclusion (bots still
+      # excluded). Default p_chatadmin_.
+      - ADMIN_ACCT_PREFIX=p_chatadmin_
+```
+
+- [ ] **Step 5: Run the full room-service suite + lint**
+
+Run: `make test SERVICE=room-service && make lint`
+Expected: PASS, 0 lint issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add room-service/main.go room-service/deploy/docker-compose.yml
+git commit -m "feat(room-service): wire ADMIN_ACCT_PREFIX config"
+```
+
+---
+
+## Task 4: Sync the spec, and verify no client-API drift
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-23-admin-acct-prefix-config-design.md`
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Update spec §4.2 to the functional-option form**
+
+In the spec, replace the §4.2 `NewMongoStore(db, adminAcctPrefix)` sketch with the shipped signature and note the rationale:
+
+```markdown
+### 4.2 Store construction
+
+`NewMongoStore` gains a functional option rather than a positional arg, because
+it has ~130 zero-arg call sites in tests; the variadic option keeps them
+compiling and matches the repo's options idiom:
+
+    func NewMongoStore(db *mongo.Database, opts ...Option) *MongoStore
+
+Default prefix is `p_chatadmin_`; `main.go` overrides via
+`NewMongoStore(db, WithAdminAcctPrefix(cfg.AdminAcctPrefix))`.
+```
+
+- [ ] **Step 2: Confirm no `docs/client-api.md` change is required**
+
+Read the read-receipt RPC section of `docs/client-api.md` (§ "Read Message Receipts", around line 2063) and the `minUserLastSeenAt` field rows (lines ~912, ~3628). Confirm none document the `p_` exclusion rule as a wire contract — they describe sender-exclusion and floor semantics only. No request/response field, error case, or event changes, so no client-api edit is needed.
+
+Run: `grep -n "p_\|ADMIN_ACCT_PREFIX" docs/client-api.md`
+Expected: only unrelated `p_admin`/`p_` mentions (auth examples, mentionable, DM) — none in the read-receipt contract. If any read-receipt wire contract *did* mention the `p_` exclusion, update it; otherwise leave `docs/client-api.md` untouched.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-07-23-admin-acct-prefix-config-design.md
+git commit -m "docs: sync admin-prefix spec to functional-option constructor"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §2 goal (`ADMIN_ACCT_PREFIX`, default `p_chatadmin_`) → Task 3.
+- §3 four affected queries → Task 2 Step 4.
+- §4.1 config field → Task 3 Step 1. §4.2 store construction → Task 2 Step 3 (option). §4.3 regex builder → Task 1.
+- §5.1/§5.2 conditional match building → Task 2 Step 4. §5.3 empty-prefix disables → Task 1 (helper) + Task 2 (conditional predicates) + Task 2 Step 1(e) empty-prefix test.
+- §6 out-of-scope untouched → Global Constraints (no edits to helper.go / pkg/model).
+- §7 testing: unit helper → Task 1; four integration tests extended → Task 2 Step 1(a-d); narrowing/custom/empty coverage → Task 2 Step 1(b,d,e); call-site updates → not needed (variadic option).
+- §8 rollout (no schema/wire) → Task 4 Step 2. §8 docker-compose → Task 3 Step 4.
+
+**Placeholder scan:** none — every code and test step shows full content.
+
+**Type consistency:** `adminAccountPatterns(prefix string) (adminRegex, botOrAdminRegex string)`, `WithAdminAcctPrefix(prefix string) Option`, `Option func(*MongoStore)`, fields `adminAcctRegex`/`botOrAdminRegex`, const `defaultAdminAcctPrefix` — names/signatures identical across Tasks 1–3. Store fields set in `WithAdminAcctPrefix` and read in all four queries match.

--- a/docs/superpowers/specs/2026-07-23-admin-acct-prefix-config-design.md
+++ b/docs/superpowers/specs/2026-07-23-admin-acct-prefix-config-design.md
@@ -1,0 +1,239 @@
+# Configurable admin-account prefix for read-floor & receipts — design
+
+**Date:** 2026-07-23
+**Branch:** `claude/read-receipt-filter-config-6jc5yl`
+**Status:** Draft (pending author review)
+**Author:** co-authored with Claude
+
+> **Assumptions made while drafting** (clarifying questions were declined; flag
+> any you disagree with on review):
+> 1. **Scope is read-state only.** Only the four read-floor / read-receipt
+>    queries in `room-service` switch to the config value. The other `p_` users
+>    (`helper.go`'s `platformAdminRegex` for mention autocomplete,
+>    `model.IsPlatformAdminAccount` for DM/botDM classification) are **left on
+>    `p_`** — they are separate concerns (see §6).
+> 2. **Narrowing is intended.** The default changes the excluded set from *any*
+>    `p_` account to only `p_chatadmin_` accounts. Non-admin `p_*` accounts
+>    (e.g. `p_admin`, platform/webhook accounts) that are **not** flagged
+>    `isBot` will start being **counted** in read floors and receipts again.
+>    This is the point of the change; the risk note is in §8.
+> 3. **Empty prefix disables the admin filter** rather than failing fast or
+>    matching everything (see §5.3).
+
+## 1. Background
+
+PR #78 excluded bots from the main-room read-floor (`rooms.minUserLastSeenAt`)
+and read receipts (`u.isBot != true`). PR #88 extended the exclusion to
+**threads** and to **admin/platform accounts** by adding a query-side `p_`
+prefix guard. The exclusion currently hardcodes the prefix as two package-level
+regex constants in `room-service/store_mongo.go`:
+
+```go
+const (
+    pseudoAccountRegex      = `^p_`          // p_ platform/admin accounts
+    botOrPseudoAccountRegex = `(\.bot$|^p_)` // bots + p_ accounts
+)
+```
+
+The prefix `p_` is broad: it matches every platform and webhook account, not
+just admins. We want the admin exclusion to be operator-configurable and, by
+default, scoped to true admin accounts (`p_chatadmin_`).
+
+## 2. Goal
+
+Replace the hardcoded `p_` prefix used by the read-floor / read-receipt queries
+with a config variable:
+
+| Env var | Default | Applies to |
+|---------|---------|-----------|
+| `ADMIN_ACCT_PREFIX` | `p_chatadmin_` | `room-service` read-floor & read-receipt queries only |
+
+The bot filter (`.bot` suffix / `u.isBot`) is **unchanged** — only the `p_`
+half becomes configurable.
+
+## 3. Affected queries (`room-service/store_mongo.go`)
+
+All four are the query-side non-human exclusion; only the admin-prefix portion
+changes.
+
+| Method | Bot filter (unchanged) | Admin filter (was `^p_`) |
+|--------|------------------------|--------------------------|
+| `MinSubscriptionLastSeenByRoomID` (room floor) | `u.isBot $ne true` | `u.account $not /^<prefix>/` |
+| `ListReadReceipts` (room receipts) | `u.isBot $ne true` | `u.account $not /^<prefix>/` |
+| `MinThreadSubscriptionLastSeenByThreadRoomID` (thread floor) | via combined regex | `userAccount $not /(\.bot$\|^<prefix>)/` |
+| `ListThreadReadReceipts` (thread receipts) | via combined regex | `userAccount $not /(\.bot$\|^<prefix>)/` |
+
+Main-room queries detect bots via the stored `u.isBot` flag and the admin prefix
+via a separate `u.account` predicate. Thread queries carry no `isBot` flag, so
+they detect both bot and admin via one combined regex.
+
+## 4. Configuration & wiring
+
+### 4.1 Config (`room-service/main.go`)
+
+Add to the `config` struct, parsed by `caarlos0/env` like every other field:
+
+```go
+AdminAcctPrefix string `env:"ADMIN_ACCT_PREFIX" envDefault:"p_chatadmin_"`
+```
+
+### 4.2 Store construction
+
+`NewMongoStore` gains a **functional option** rather than a positional arg,
+because it has ~130 zero-arg call sites in `room-service/integration_test.go`; a
+required positional arg would force noisy edits to all of them. The variadic
+option keeps every existing call compiling (they get the default) and matches
+the repo's options idiom (`pkg/roommetacache`, `pkg/mongoutil`). The two regex
+strings are precomputed once at construction (the prefix is fixed for the
+process lifetime — no per-query cost):
+
+```go
+type Option func(*MongoStore)
+
+func WithAdminAcctPrefix(prefix string) Option {
+    return func(s *MongoStore) {
+        s.adminAcctRegex, s.botOrAdminRegex = adminAccountPatterns(prefix)
+    }
+}
+
+func NewMongoStore(db *mongo.Database, opts ...Option) *MongoStore {
+    adminRegex, botOrAdminRegex := adminAccountPatterns(defaultAdminAcctPrefix)
+    s := &MongoStore{
+        // ...existing collections...
+        adminAcctRegex:  adminRegex,      // e.g. "^p_chatadmin_"; "" => no admin exclusion
+        botOrAdminRegex: botOrAdminRegex, // e.g. "(\.bot$|^p_chatadmin_)"
+    }
+    for _, opt := range opts {
+        opt(s)
+    }
+    return s
+}
+```
+
+Default prefix is `p_chatadmin_` (`defaultAdminAcctPrefix`); `main.go` overrides
+via `store := NewMongoStore(db, WithAdminAcctPrefix(cfg.AdminAcctPrefix))`.
+
+### 4.3 Regex builder (pure, unit-tested)
+
+The `pseudoAccountRegex` / `botOrPseudoAccountRegex` constants are **removed** and
+replaced by a pure helper. It reuses the existing `botAccountRegex` (`\.bot$`)
+constant and **regex-escapes** the operator-supplied prefix (`p_chatadmin_` is
+already regex-literal, but a config value must never be trusted to be — an
+unescaped `.` or `(` would silently change matching):
+
+```go
+// adminAccountPatterns builds the query-side account exclusion regexes from a
+// configured admin-account prefix. An empty prefix disables the admin-account
+// exclusion (adminRegex==""), leaving only the bot filter in effect.
+func adminAccountPatterns(prefix string) (adminRegex, botOrAdminRegex string) {
+    if prefix == "" {
+        return "", botAccountRegex // `\.bot$` — bots only
+    }
+    q := regexp.QuoteMeta(prefix)
+    return "^" + q, `(\.bot$|^` + q + `)`
+}
+```
+
+## 5. Query construction detail
+
+### 5.1 Main-room (`MinSubscriptionLastSeenByRoomID`, `ListReadReceipts`)
+
+The `u.isBot $ne true` predicate always stays. The admin-prefix predicate is
+added **only when `adminAcctRegex != ""`**:
+
+```go
+match := bson.M{"roomId": roomID, "u.isBot": bson.M{"$ne": true}}
+if s.adminAcctRegex != "" {
+    match["u.account"] = bson.M{"$not": bson.Regex{Pattern: s.adminAcctRegex}}
+}
+```
+
+For `ListReadReceipts`, the admin predicate shares the `u.account` field with the
+existing `$ne excludeAccount`, so when the prefix is set:
+`"u.account": bson.M{"$ne": excludeAccount, "$not": bson.Regex{Pattern: s.adminAcctRegex}}`,
+and when empty: `"u.account": bson.M{"$ne": excludeAccount}`.
+
+### 5.2 Thread (`MinThreadSubscriptionLastSeenByThreadRoomID`, `ListThreadReadReceipts`)
+
+Use the combined `s.botOrAdminRegex` directly. Because the bot half is always
+present, `botOrAdminRegex` is never empty, so no conditional is needed:
+`"userAccount": bson.M{"$not": bson.Regex{Pattern: s.botOrAdminRegex}}` (plus
+`$ne excludeAccount` in the receipt list).
+
+### 5.3 Empty-prefix semantics
+
+If an operator sets `ADMIN_ACCT_PREFIX=` (empty), the admin exclusion is
+**disabled** — the bot filter still applies. This deliberately avoids the failure
+mode where an empty prefix would produce the anchored regex `^`, which matches
+*every* account and would wrongly exclude the whole room from its own read floor.
+We prefer "disable the feature" over "fail startup" because an empty prefix is a
+coherent operator intent (no admin accounts to exclude), not a malformed value.
+
+## 6. Out of scope (intentional divergence)
+
+These keep the literal `p_` prefix and are **not** touched:
+
+- `room-service/helper.go` `platformAdminRegex = ^p_` — mention-autocomplete
+  hides `p_` accounts (`subscription.mentionable`).
+- `pkg/model` `IsPlatformAdminAccount` (`^p_`) — DM/botDM classification,
+  channel-membership guards, `filterBots`.
+
+Rationale: the request is specifically about read-state (`minLastSeenAt` /
+read receipts). Admin *mentionability* and *DM classification* are unrelated
+policies; folding them into the same knob would change DM and mention behavior
+and widen the blast radius across `pkg/model` and several services. If a single
+unified admin marker is desired later, that is a separate, larger change. The
+divergence (read-state on `p_chatadmin_`, other concerns on `p_`) is documented
+here so it is not mistaken for drift.
+
+## 7. Testing (TDD)
+
+Red → green → refactor, per project rules; keep coverage at/above the 80% floor.
+
+- **Unit — `adminAccountPatterns` (new, `store_mongo_test.go` or a focused
+  helper test):** table-driven over
+  - `p_chatadmin_` → `("^p_chatadmin_", "(\.bot$|^p_chatadmin_)")`
+  - `""` → `("", "\.bot$")` (admin exclusion disabled)
+  - a prefix with regex metacharacters (e.g. `p.admin(`) → escaped via
+    `QuoteMeta`, verified to match literally and not as a regex.
+- **Integration — extend the four `room-service` tests** (the ones PR #78/#88
+  already touch) using the default prefix:
+  - `p_chatadmin_alice` (isBot=false) → **excluded** from room floor & receipts
+    and thread floor & receipts.
+  - `p_somewebhook` (isBot=false, does **not** match `p_chatadmin_`) → now
+    **counted** (the narrowing — the regression-relevant case; asserts the new
+    default really is narrower than `p_`).
+  - `helper.bot` → still excluded (bot filter unchanged).
+  - Ordinary human members → still counted.
+  - (Optional) a case constructing the store with a **custom** prefix and one
+    with the **empty** prefix, asserting the admin filter is honored / disabled
+    respectively.
+- Update any existing `NewMongoStore(db)` call sites in tests to pass a prefix.
+
+## 8. Rollout / risk
+
+- **No schema, no migration, no wire change.** Pure config + query change.
+  Request/response payloads, error cases, and emitted events are unchanged, so
+  no `docs/client-api.md` (or its derived views) update is required — the read
+  receipt / floor RPC contracts are untouched. Client-api examples elsewhere use
+  `p_admin` illustratively; reconciling that prose is optional and left to the
+  author.
+- **Self-correcting.** Floors are recomputed on every `message.read` /
+  `thread.read`, so any room/thread whose stored `minUserLastSeenAt` was
+  computed under the old `p_` rule converges to the new value on the next read —
+  no backfill needed.
+- **Narrowing regression risk (assumption #2).** If non-admin `p_*` accounts
+  that are **not** `isBot` exist in production (e.g. `p_admin`, platform/webhook
+  accounts), they will re-enter read floors and receipts. If that is undesirable,
+  the mitigation is to keep `ADMIN_ACCT_PREFIX=p_` in that deployment (the config
+  makes this a per-environment choice) or to ensure such accounts are `isBot`.
+- **Local dev.** Add `ADMIN_ACCT_PREFIX` to `room-service/deploy/docker-compose.yml`
+  (optional, it has a default) so the value is visible to operators; no CI
+  pipeline change needed.
+
+## 9. Open questions
+
+1. Confirm assumption #1 (read-state only) vs. unifying all `p_` admin checks.
+2. Confirm assumption #2 (narrowing to `p_chatadmin_` is intended, including the
+   re-inclusion of non-admin `p_*` non-bot accounts).
+3. Confirm assumption #3 (empty prefix disables the admin filter).

--- a/room-service/deploy/docker-compose.yml
+++ b/room-service/deploy/docker-compose.yml
@@ -20,6 +20,10 @@ services:
       - MONGO_DB=chat
       - MAX_ROOM_SIZE=1000
       - MAX_BATCH_SIZE=500
+      # Accounts matching this prefix are treated as admins and excluded from
+      # read floors / receipts. Empty disables the admin exclusion (bots still
+      # excluded). Default p_chatadmin_.
+      - ADMIN_ACCT_PREFIX=p_chatadmin_
       # Room keys live in the MongoDB rooms collection; this grace window keeps a
       # rotated-out previous key valid for decrypt.
       - ROOM_KEY_GRACE_PERIOD=24h

--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -2143,13 +2143,29 @@ func TestMongoStore_MinSubscriptionLastSeenByRoomID_Integration(t *testing.T) {
 		RoomID: "padmin", JoinedAt: earliest, LastSeenAt: &mid,
 	})
 	mustInsertSub(t, db, &model.Subscription{
-		ID: "s18", User: model.SubscriptionUser{ID: "u18", Account: "p_admin"},
+		ID: "s18", User: model.SubscriptionUser{ID: "u18", Account: "p_chatadmin_admin"},
 		RoomID: "padmin", JoinedAt: earliest,
 	})
 	got, err = store.MinSubscriptionLastSeenByRoomID(ctx, "padmin")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.WithinDuration(t, mid, *got, time.Second)
+
+	// Room "pwebhook-counted": a non-admin p_ account (does NOT match the default
+	// ADMIN_ACCT_PREFIX p_chatadmin_) is a real participant now. It has never read,
+	// so the strict floor is nil — proving the narrowed prefix no longer excludes
+	// every p_ account the way the old ^p_ guard did.
+	mustInsertSub(t, db, &model.Subscription{
+		ID: "s19", User: model.SubscriptionUser{ID: "u19", Account: "nina"},
+		RoomID: "pwebhook-counted", JoinedAt: earliest, LastSeenAt: &mid,
+	})
+	mustInsertSub(t, db, &model.Subscription{
+		ID: "s20", User: model.SubscriptionUser{ID: "u20", Account: "p_webhook"},
+		RoomID: "pwebhook-counted", JoinedAt: earliest,
+	})
+	got, err = store.MinSubscriptionLastSeenByRoomID(ctx, "pwebhook-counted")
+	require.NoError(t, err)
+	assert.Nil(t, got)
 
 	// Room with no subscriptions at all → nil.
 	got, err = store.MinSubscriptionLastSeenByRoomID(ctx, "empty")
@@ -2236,6 +2252,22 @@ func TestMongoStore_MinThreadSubscriptionLastSeenByThreadRoomID_Integration(t *t
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.WithinDuration(t, mid, *got, time.Second)
+
+	// "admin-parent": a p_chatadmin_ admin thread subscriber that never read is
+	// excluded by account, so the floor is the human's lastSeenAt.
+	mustInsertThreadSub(t, db, &model.ThreadSubscription{ID: "ts8", ThreadRoomID: "admin-parent", UserAccount: "grace", LastSeenAt: &mid})
+	mustInsertThreadSub(t, db, &model.ThreadSubscription{ID: "ts9", ThreadRoomID: "admin-parent", UserAccount: "p_chatadmin_ops"})
+	got, err = store.MinThreadSubscriptionLastSeenByThreadRoomID(ctx, "admin-parent")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.WithinDuration(t, mid, *got, time.Second)
+
+	// "pwebhook-thread": a non-admin p_ subscriber is counted now; never-read ⇒ nil.
+	mustInsertThreadSub(t, db, &model.ThreadSubscription{ID: "ts10", ThreadRoomID: "pwebhook-thread", UserAccount: "harry", LastSeenAt: &mid})
+	mustInsertThreadSub(t, db, &model.ThreadSubscription{ID: "ts11", ThreadRoomID: "pwebhook-thread", UserAccount: "p_webhook"})
+	got, err = store.MinThreadSubscriptionLastSeenByThreadRoomID(ctx, "pwebhook-thread")
+	require.NoError(t, err)
+	assert.Nil(t, got)
 }
 
 func TestMongoStore_UpdateThreadRoomMinUserLastSeenAt_Integration(t *testing.T) {
@@ -2310,7 +2342,7 @@ func TestMongoStore_ListReadReceipts_Integration(t *testing.T) {
 		bson.M{"_id": "uB", "account": "bob", "chineseName": "鮑勃", "engName": "Bob"},
 		bson.M{"_id": "uC", "account": "carol", "chineseName": "卡羅", "engName": "Carol"},
 		bson.M{"_id": "uD", "account": "dave.bot", "chineseName": "戴夫", "engName": "Dave"},
-		bson.M{"_id": "uE", "account": "p_ops", "chineseName": "運維", "engName": "Ops"},
+		bson.M{"_id": "uE", "account": "p_chatadmin_ops", "chineseName": "運維", "engName": "Ops"},
 	})
 	require.NoError(t, err)
 
@@ -2321,15 +2353,15 @@ func TestMongoStore_ListReadReceipts_Integration(t *testing.T) {
 		bson.M{"_id": "sC", "roomId": "r1", "u": bson.M{"_id": "uC", "account": "carol"}, "lastSeenAt": msgTime.Add(-time.Minute)},
 		// A bot that has read well past the message must never appear as a reader.
 		bson.M{"_id": "sD", "roomId": "r1", "u": bson.M{"_id": "uD", "account": "dave.bot", "isBot": true}, "lastSeenAt": msgTime.Add(30 * time.Minute)},
-		// A p_ platform/admin account (isBot=false) must also be excluded — this
-		// exercises the u.account $not ^p_ predicate, since isBot alone would
-		// surface p_ops.
-		bson.M{"_id": "sE", "roomId": "r1", "u": bson.M{"_id": "uE", "account": "p_ops"}, "lastSeenAt": msgTime.Add(20 * time.Minute)},
+		// An admin account (ADMIN_ACCT_PREFIX, isBot=false) must also be excluded —
+		// this exercises the u.account $not /^p_chatadmin_/ predicate, since isBot
+		// alone would surface p_chatadmin_ops.
+		bson.M{"_id": "sE", "roomId": "r1", "u": bson.M{"_id": "uE", "account": "p_chatadmin_ops"}, "lastSeenAt": msgTime.Add(20 * time.Minute)},
 	})
 	require.NoError(t, err)
 
 	// Only bob qualifies: alice is the sender, carol read before the message,
-	// dave.bot is a bot, and p_ops is a p_ platform/admin account (both excluded
+	// dave.bot is a bot, and p_chatadmin_ops is an admin account (both excluded
 	// despite having read after the message).
 	rows, err := store.ListReadReceipts(ctx, "r1", msgTime, "alice", 100)
 	require.NoError(t, err)
@@ -4014,4 +4046,44 @@ func TestMongoStore_ClearSubscriptionThreadUnreadForAccount_Integration(t *testi
 	require.NoError(t, db.Collection("subscriptions").FindOne(ctx, bson.M{"_id": "sB1"}).Decode(&bobRaw))
 	assert.Equal(t, []string{"p9"}, bobRaw.ThreadUnread)
 	assert.True(t, bobRaw.Alert)
+}
+
+func TestMongoStore_ListReadReceipts_AdminPrefixConfig_Integration(t *testing.T) {
+	ctx := context.Background()
+	db := setupMongo(t)
+	require.NoError(t, NewMongoStore(db).EnsureIndexes(ctx))
+
+	_, err := db.Collection("users").InsertMany(ctx, []any{
+		bson.M{"_id": "uB", "account": "bob", "chineseName": "鮑勃", "engName": "Bob"},
+		bson.M{"_id": "uAdm", "account": "p_chatadmin_ops", "chineseName": "運維", "engName": "Ops"},
+		bson.M{"_id": "uHook", "account": "p_webhook", "chineseName": "掛鉤", "engName": "Hook"},
+	})
+	require.NoError(t, err)
+
+	msgTime := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	_, err = db.Collection("subscriptions").InsertMany(ctx, []any{
+		bson.M{"_id": "sB", "roomId": "r1", "u": bson.M{"_id": "uB", "account": "bob"}, "lastSeenAt": msgTime.Add(time.Hour)},
+		bson.M{"_id": "sAdm", "roomId": "r1", "u": bson.M{"_id": "uAdm", "account": "p_chatadmin_ops"}, "lastSeenAt": msgTime.Add(time.Hour)},
+		bson.M{"_id": "sHook", "roomId": "r1", "u": bson.M{"_id": "uHook", "account": "p_webhook"}, "lastSeenAt": msgTime.Add(time.Hour)},
+	})
+	require.NoError(t, err)
+
+	accountsOf := func(store *MongoStore) []string {
+		rows, err := store.ListReadReceipts(ctx, "r1", msgTime, "someone-else", 100)
+		require.NoError(t, err)
+		got := make([]string, 0, len(rows))
+		for _, r := range rows {
+			got = append(got, r.Account)
+		}
+		return got
+	}
+
+	// Default prefix (p_chatadmin_): admin excluded, non-admin p_webhook counted.
+	assert.ElementsMatch(t, []string{"bob", "p_webhook"}, accountsOf(NewMongoStore(db)))
+
+	// Broad legacy prefix p_: both p_ accounts excluded.
+	assert.ElementsMatch(t, []string{"bob"}, accountsOf(NewMongoStore(db, WithAdminAcctPrefix("p_"))))
+
+	// Empty prefix: admin exclusion disabled, all three surface.
+	assert.ElementsMatch(t, []string{"bob", "p_chatadmin_ops", "p_webhook"}, accountsOf(NewMongoStore(db, WithAdminAcctPrefix(""))))
 }

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -41,6 +41,10 @@ type config struct {
 	PProfEnabled             bool            `env:"PPROF_ENABLED" envDefault:"false"`
 	Bootstrap                bootstrapConfig `envPrefix:"BOOTSTRAP_"`
 	RestrictedRoomMinMembers int             `env:"RESTRICTED_ROOM_MIN_MEMBERS" envDefault:"5"`
+	// ADMIN_ACCT_PREFIX scopes which accounts are treated as admins and excluded
+	// from read floors / receipts. Empty disables the admin exclusion (bots still
+	// excluded). See store_mongo.go adminAccountPatterns.
+	AdminAcctPrefix string `env:"ADMIN_ACCT_PREFIX" envDefault:"p_chatadmin_"`
 	// Microsoft Teams integration. Teams* credentials are required only for the
 	// meetings RPC (Graph onlineMeeting create); the deep-link RPCs use only
 	// EmailDomain. When TenantID/ClientID/ClientSecret are unset the meetings RPC
@@ -133,7 +137,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	store := NewMongoStore(db)
+	store := NewMongoStore(db, WithAdminAcctPrefix(cfg.AdminAcctPrefix))
 	// Bounded timeout so a hung createIndexes surfaces at startup.
 	ensureCtx, ensureCancel := context.WithTimeout(ctx, 30*time.Second)
 	if err := store.EnsureIndexes(ensureCtx); err != nil {

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -24,6 +24,24 @@ const botAccountRegex = `\.bot$`
 
 var botAccountPattern = regexp.MustCompile(botAccountRegex)
 
+// defaultAdminAcctPrefix is the built-in ADMIN_ACCT_PREFIX default: admin
+// accounts are named p_chatadmin_*. Overridden per-store via WithAdminAcctPrefix.
+const defaultAdminAcctPrefix = "p_chatadmin_"
+
+// adminAccountPatterns builds the query-side account-exclusion regexes from a
+// configured admin-account prefix. It returns the admin-only regex (anchored,
+// for the main-room u.account guard) and the combined bot+admin regex (for the
+// flat thread_subscriptions queries). An empty prefix disables the admin-account
+// exclusion (adminRegex == ""), leaving only the bot filter. The prefix is
+// regex-escaped: a configured value must never be trusted to be a regex literal.
+func adminAccountPatterns(prefix string) (adminRegex, botOrAdminRegex string) {
+	if prefix == "" {
+		return "", botAccountRegex
+	}
+	q := regexp.QuoteMeta(prefix)
+	return "^" + q, `(\.bot$|^` + q + `)`
+}
+
 type MongoStore struct {
 	rooms               *mongo.Collection
 	subscriptions       *mongo.Collection
@@ -34,10 +52,28 @@ type MongoStore struct {
 	apps                *mongo.Collection
 	botCmdMenus         *mongo.Collection
 	teamsMeetings       *mongo.Collection
+	// adminAcctRegex excludes admin accounts (accounts matching ADMIN_ACCT_PREFIX)
+	// from read floors / receipts; "" disables the admin exclusion. botOrAdminRegex
+	// is the combined bot+admin exclusion for the flat thread_subscriptions queries.
+	adminAcctRegex  string
+	botOrAdminRegex string
 }
 
-func NewMongoStore(db *mongo.Database) *MongoStore {
-	return &MongoStore{
+// Option configures a MongoStore at construction.
+type Option func(*MongoStore)
+
+// WithAdminAcctPrefix overrides the account prefix used to exclude admin
+// accounts from read-floor and read-receipt queries. An empty prefix disables
+// the admin-account exclusion (bot filtering still applies).
+func WithAdminAcctPrefix(prefix string) Option {
+	return func(s *MongoStore) {
+		s.adminAcctRegex, s.botOrAdminRegex = adminAccountPatterns(prefix)
+	}
+}
+
+func NewMongoStore(db *mongo.Database, opts ...Option) *MongoStore {
+	adminRegex, botOrAdminRegex := adminAccountPatterns(defaultAdminAcctPrefix)
+	s := &MongoStore{
 		rooms:               db.Collection("rooms"),
 		subscriptions:       db.Collection("subscriptions"),
 		threadSubscriptions: db.Collection("thread_subscriptions"),
@@ -47,7 +83,13 @@ func NewMongoStore(db *mongo.Database) *MongoStore {
 		apps:                db.Collection("apps"),
 		botCmdMenus:         db.Collection("bot_cmd_menu"),
 		teamsMeetings:       db.Collection("teams_meetings"),
+		adminAcctRegex:      adminRegex,
+		botOrAdminRegex:     botOrAdminRegex,
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // EnsureIndexes creates the indexes that back the read paths in this service
@@ -1115,28 +1157,19 @@ func (s *MongoStore) GetUserSiteID(ctx context.Context, account string) (string,
 	return doc.SiteID, nil
 }
 
-// pseudoAccountRegex matches p_ accounts, which represent both platform and
-// admin accounts. botOrPseudoAccountRegex additionally matches ".bot" accounts.
-// They are the query-side equivalents of model.IsPlatformAdminAccount / IsBot,
-// used to exclude non-human participants from read state directly by account.
-const (
-	pseudoAccountRegex      = `^p_`
-	botOrPseudoAccountRegex = `(\.bot$|^p_)`
-)
-
 // MinSubscriptionLastSeenByRoomID returns the room's strict read floor: the
 // minimum lastSeenAt across the room's ordinary-member subscriptions, but only
 // when EVERY such subscription has a usable lastSeenAt (> zero). If any has no
 // usable lastSeenAt — missing, null, or the BSON zero date, i.e. a member who
 // was invited but has never opened the room — it returns nil, meaning "not
 // everyone has read yet". It also returns nil for a room with no subscriptions.
-// Bots (u.isBot) and p_ platform/admin accounts (u.account prefix) are excluded,
-// so a passive bot/admin never freezes the floor and a botDM resolves to the
+// Bots (u.isBot) and admin accounts (ADMIN_ACCT_PREFIX) are excluded, so a
+// passive bot/admin never freezes the floor and a botDM resolves to the
 // human's lastSeenAt. A room with only such subscriptions resolves to nil. The
 // caller $unsets rooms.minUserLastSeenAt on a nil result.
 func (s *MongoStore) MinSubscriptionLastSeenByRoomID(ctx context.Context, roomID string) (*time.Time, error) {
 	// The whole result is determined by a single document: the room's ordinary
-	// (non-bot, non-p_) subscription with the smallest lastSeenAt. The
+	// (non-bot, non-admin) subscription with the smallest lastSeenAt. The
 	// (roomId, lastSeenAt) index
 	// (non-sparse, so missing fields are indexed as null) returns the room's
 	// subscriptions in ascending lastSeenAt order, and BSON sorts missing/null
@@ -1147,17 +1180,22 @@ func (s *MongoStore) MinSubscriptionLastSeenByRoomID(ctx context.Context, roomID
 	//   - smallest value is a real post-zero date → every member has read and
 	//     that value IS the minimum → the floor.
 	// The (roomId, lastSeenAt) index still serves the sort; the u.isBot and
-	// u.account predicates are applied as residual filters (bots/p_ are few per
+	// u.account predicates are applied as residual filters (bots/admins are few per
 	// room), so this stays a bounded index seek on the message-read hot path
 	// rather than the prior full-room $group scan.
 	var doc struct {
 		LastSeenAt time.Time `bson:"lastSeenAt"`
 	}
+	// u.isBot excludes bots (and admin subs stamped locally); the u.account $not
+	// /^<prefix>/ predicate additionally excludes admin accounts (ADMIN_ACCT_PREFIX)
+	// whose isBot may be unset (e.g. cross-site mirror subs), no stored flag needed.
+	// An empty configured prefix disables the admin-account predicate.
+	filter := bson.M{"roomId": roomID, "u.isBot": bson.M{"$ne": true}}
+	if s.adminAcctRegex != "" {
+		filter["u.account"] = bson.M{"$not": bson.Regex{Pattern: s.adminAcctRegex}}
+	}
 	err := s.subscriptions.FindOne(ctx,
-		// u.isBot excludes bots (and p_ subs stamped locally); the u.account $not
-		// ^p_ predicate additionally excludes p_ platform/admin accounts whose
-		// isBot may be unset (e.g. cross-site mirror subs), no stored flag needed.
-		bson.M{"roomId": roomID, "u.isBot": bson.M{"$ne": true}, "u.account": bson.M{"$not": bson.Regex{Pattern: pseudoAccountRegex}}},
+		filter,
 		options.FindOne().
 			SetSort(bson.D{{Key: "lastSeenAt", Value: 1}}).
 			SetProjection(bson.M{"lastSeenAt": 1, "_id": 0}),
@@ -1198,14 +1236,19 @@ func (s *MongoStore) ListReadReceipts(
 	excludeAccount string,
 	limit int,
 ) ([]ReadReceiptRow, error) {
+	// Bots (u.isBot) and admin accounts (ADMIN_ACCT_PREFIX) are never surfaced as
+	// readers, in addition to excluding the sender. An empty configured prefix
+	// disables the admin-account predicate (sender exclusion still applies).
+	account := bson.M{"$ne": excludeAccount}
+	if s.adminAcctRegex != "" {
+		account["$not"] = bson.Regex{Pattern: s.adminAcctRegex}
+	}
 	pipeline := mongo.Pipeline{
 		{{Key: "$match", Value: bson.M{
 			"roomId":     roomID,
 			"lastSeenAt": bson.M{"$gte": since},
-			// Bots (u.isBot) and p_ platform/admin accounts (u.account prefix) are
-			// never surfaced as readers, in addition to excluding the sender.
-			"u.account": bson.M{"$ne": excludeAccount, "$not": bson.Regex{Pattern: pseudoAccountRegex}},
-			"u.isBot":   bson.M{"$ne": true},
+			"u.account":  account,
+			"u.isBot":    bson.M{"$ne": true},
 		}}},
 		{{Key: "$lookup", Value: bson.M{
 			"from": "users",
@@ -1258,9 +1301,9 @@ func (s *MongoStore) ListThreadReadReceipts(
 		{{Key: "$match", Value: bson.M{
 			"threadRoomId": threadRoomID,
 			"lastSeenAt":   bson.M{"$gte": since},
-			// Bot (".bot") and p_ platform/admin subscribers are never surfaced as
-			// readers, in addition to excluding the sender.
-			"userAccount": bson.M{"$ne": excludeAccount, "$not": bson.Regex{Pattern: botOrPseudoAccountRegex}},
+			// Bot (".bot") and admin (ADMIN_ACCT_PREFIX) subscribers are never
+			// surfaced as readers, in addition to excluding the sender.
+			"userAccount": bson.M{"$ne": excludeAccount, "$not": bson.Regex{Pattern: s.botOrAdminRegex}},
 		}}},
 		{{Key: "$lookup", Value: bson.M{
 			"from": "users",
@@ -1771,9 +1814,9 @@ func (s *MongoStore) GetThreadRoomByID(ctx context.Context, threadRoomID string)
 // MinThreadSubscriptionLastSeenByThreadRoomID returns the thread room's strict
 // read floor: the minimum lastSeenAt across the thread's ordinary-member
 // thread_subscriptions for threadRoomID, but only when every such subscriber has
-// a usable lastSeenAt (> zero). Bot (".bot") and p_ platform/admin subscribers
-// are excluded by account, so a bot that authored a threaded message cannot
-// freeze the floor via its never-read parent-author subscription.
+// a usable lastSeenAt (> zero). Bot (".bot") and admin (ADMIN_ACCT_PREFIX)
+// subscribers are excluded by account, so a bot that authored a threaded message
+// cannot freeze the floor via its never-read parent-author subscription.
 // Returns nil when any subscriber has never read, or when there are no subscribers.
 // The (threadRoomId, lastSeenAt) index (non-sparse) returns the smallest value
 // first — a missing/null/zero lastSeenAt sorts before real dates, so the first
@@ -1783,10 +1826,10 @@ func (s *MongoStore) MinThreadSubscriptionLastSeenByThreadRoomID(ctx context.Con
 		LastSeenAt time.Time `bson:"lastSeenAt"`
 	}
 	err := s.threadSubscriptions.FindOne(ctx,
-		// Bot/p_ thread subs don't hold the floor: excluded by account so a bot
+		// Bot/admin thread subs don't hold the floor: excluded by account so a bot
 		// that authored a threaded message can't freeze it via its never-read
 		// parent-author subscription.
-		bson.M{"threadRoomId": threadRoomID, "userAccount": bson.M{"$not": bson.Regex{Pattern: botOrPseudoAccountRegex}}},
+		bson.M{"threadRoomId": threadRoomID, "userAccount": bson.M{"$not": bson.Regex{Pattern: s.botOrAdminRegex}}},
 		options.FindOne().
 			SetSort(bson.D{{Key: "lastSeenAt", Value: 1}}).
 			SetProjection(bson.M{"lastSeenAt": 1, "_id": 0}),

--- a/room-service/store_mongo_test.go
+++ b/room-service/store_mongo_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdminAccountPatterns(t *testing.T) {
+	tests := []struct {
+		name           string
+		prefix         string
+		wantAdmin      string
+		wantBotOrAdmin string
+	}{
+		{"default admin prefix", "p_chatadmin_", "^p_chatadmin_", `(\.bot$|^p_chatadmin_)`},
+		{"legacy broad prefix", "p_", "^p_", `(\.bot$|^p_)`},
+		{"empty disables admin filter", "", "", `\.bot$`},
+		{"regex metacharacters are escaped", "p.a(", `^p\.a\(`, `(\.bot$|^p\.a\()`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAdmin, gotBotOrAdmin := adminAccountPatterns(tt.prefix)
+			assert.Equal(t, tt.wantAdmin, gotAdmin, "adminRegex")
+			assert.Equal(t, tt.wantBotOrAdmin, gotBotOrAdmin, "botOrAdminRegex")
+		})
+	}
+}
+
+func TestDefaultAdminAcctPrefix(t *testing.T) {
+	assert.Equal(t, "p_chatadmin_", defaultAdminAcctPrefix)
+}


### PR DESCRIPTION
## Summary

Replace the hardcoded `p_` prefix used by read-floor and read-receipt queries in `room-service` with a configurable environment variable, defaulting to `p_chatadmin_` to narrow the exclusion from all platform accounts to only admin accounts.

## Changes

- **Design document** (`docs/superpowers/specs/2026-07-23-admin-acct-prefix-config-design.md`): Comprehensive specification covering:
  - Configuration via `ADMIN_ACCT_PREFIX` env var (default: `p_chatadmin_`)
  - Affected queries: `MinSubscriptionLastSeenByRoomID`, `ListReadReceipts`, `MinThreadSubscriptionLastSeenByThreadRoomID`, `ListThreadReadReceipts`
  - Pure helper function `adminAccountPatterns()` to build regexes from operator-supplied prefix with proper escaping
  - Query construction detail for main-room (conditional predicate) and thread (combined regex) queries
  - Empty-prefix semantics: disables admin exclusion rather than failing or matching everything
  - Intentional scope: read-state only; mention-autocomplete and DM classification remain on hardcoded `p_`
  - Testing strategy (unit + integration) and rollout/risk analysis
  - Narrowing regression risk: non-admin `p_*` non-bot accounts will re-enter read floors/receipts

## Implementation Notes

- **No schema/migration required**: Pure config + query change; read receipts/floors are recomputed on every read event, so convergence is automatic
- **Regex escaping**: The helper uses `regexp.QuoteMeta()` to safely handle operator-supplied prefixes with metacharacters
- **Backward compatibility**: Default `p_chatadmin_` is narrower than the current `p_`, intentionally re-including non-admin platform accounts (the point of the change)
- **Out of scope**: `platformAdminRegex` (mention-autocomplete) and `IsPlatformAdminAccount` (DM classification) remain on literal `p_` to avoid blast radius across `pkg/model` and other services

https://claude.ai/code/session_017XVxGTVmW7nZDRL2ZvfdCh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a design specification for configuring the admin-account exclusion prefix used by read-floor and read-receipt queries.
  * Documented the default prefix, optional disabling behavior, affected query areas, testing approach, rollout considerations, and out-of-scope behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->