### PR TITLE
feat: add NewMeetingsClient honoring Config.ProxyURL

### DIFF
--- a/docs/msgraph-client.md
+++ b/docs/msgraph-client.md
@@ -24,6 +24,7 @@ derive organizer/attendee addresses):
 | `TEAMS_CLIENT_ID` | App registration (client) id |
 | `TEAMS_CLIENT_SECRET` | App registration client secret |
 | `TEAMS_EMAIL_DOMAIN` | Domain appended to an `account` to form an email (`account@domain`); defaults to `dev.local` for local/dev |
+| `GRAPH_PROXY_URL` | Optional. Routes the meetings Graph client through this proxy (scheme+host, e.g. `http://proxy.corp:8080`), overriding `HTTPS_PROXY`/`HTTP_PROXY`. Empty falls back to the standard proxy env vars. |
 
 When the Teams credentials are unset, the deep-link call RPCs still work (they
 need only `TEAMS_EMAIL_DOMAIN`); the meetings RPC returns a not-configured
@@ -50,6 +51,10 @@ otherwise creates one. `room-service` sets `externalId` to a stable per-room key
 (`siteID:roomID`), so repeated or concurrent `teams.meeting` calls for the same
 room return the same meeting. `externalId` is required — the client rejects an
 empty value.
+
+room-service constructs this client via `NewMeetingsClient(cfg)`, which honors
+`Config.ProxyURL` (from `GRAPH_PROXY_URL`) and fails fast on a malformed proxy
+value at startup.
 
 ## Listing users (paginated)
 

--- a/docs/superpowers/plans/2026-07-23-room-service-msgraph-proxy.md
+++ b/docs/superpowers/plans/2026-07-23-room-service-msgraph-proxy.md
@@ -1,0 +1,286 @@
+# room-service Graph meetings proxy — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let room-service route its Microsoft Graph *meetings* calls through an explicit proxy configured via `GRAPH_PROXY_URL`, overriding the ambient `HTTPS_PROXY`/`HTTP_PROXY` env vars.
+
+**Architecture:** Add an error-returning `msgraph.NewMeetingsClient` constructor that wraps the existing `New` + `applyProxyURL` (mirroring `NewUserListerClient`), so the meetings client honors `Config.ProxyURL` and fails fast on a malformed value. room-service gains a `GRAPH_PROXY_URL` config passed through as `ProxyURL`.
+
+**Tech Stack:** Go 1.25, `net/http` transport proxying, `caarlos0/env` config, `stretchr/testify` assertions.
+
+## Global Constraints
+
+- Go 1.25; monorepo, single root `go.mod`. Services are flat `package main` dirs at repo root.
+- Always use `make` targets — never raw `go` commands. Tests run with `-race` via the Makefile.
+- TDD: Red → Green → Refactor → Commit. Write the failing test first and confirm it fails before implementing.
+- Error wrapping: `fmt.Errorf("short description: %w", err)`; never bare `err`. (The msgraph `applyProxyURL` helper already does this — no new error strings needed beyond reuse.)
+- Config: env vars via `caarlos0/env` into a typed struct; `SCREAMING_SNAKE_CASE`; provide `envDefault` for non-secret optional config; never `os.Getenv` directly.
+- Never log tokens/secrets; `proxyURL.Redacted()` is already used by `applyProxyURL` for the invalid-URL message.
+- Minimum 80% coverage; cover error paths and edge cases. `pkg/` exported funcs need test cases.
+- Commit message footer (both lines, verbatim):
+  ```
+  Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01YG6jRt3et6XhesnSRM21rr
+  ```
+
+---
+
+### Task 1: `msgraph.NewMeetingsClient` constructor
+
+**Files:**
+- Modify: `pkg/msgraph/msgraph.go` (add `NewMeetingsClient`; update `Config.ProxyURL` docstring near lines 126–130)
+- Test: `pkg/msgraph/msgraph_test.go` (add 4 new tests; extend `TestGraphClients_InvalidProxyURL` near lines 448–463)
+
+**Interfaces:**
+- Consumes: existing `New(cfg Config, opts ...Option) Client` (returns `*graphClient`), `applyProxyURL(hc *http.Client, rawProxyURL string) error`, `WithHTTPClient`, `stubRoundTripper` (defined in the test file).
+- Produces: `func NewMeetingsClient(cfg Config, opts ...Option) (Client, error)` — honors `cfg.ProxyURL`; returns a non-nil error on a malformed proxy URL or a custom (non-`*http.Transport`) RoundTripper; no-op when `ProxyURL` is empty. Consumed by Task 2.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `pkg/msgraph/msgraph_test.go` (imports `net/http`, `testify/assert`, `testify/require` are already present in the file):
+
+```go
+func TestNewMeetingsClient_RoutesThroughProxy(t *testing.T) {
+	c, err := NewMeetingsClient(
+		Config{TenantID: "t", ClientID: "c", ClientSecret: "s", ProxyURL: "http://proxy.corp:8080"},
+	)
+	require.NoError(t, err)
+	g := c.(*graphClient)
+	tr, ok := g.httpClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, tr.Proxy, "proxy must be configured on the transport")
+
+	req, err := http.NewRequest(http.MethodGet, "https://graph.microsoft.com/v1.0/me", nil)
+	require.NoError(t, err)
+	proxyURL, err := tr.Proxy(req)
+	require.NoError(t, err)
+	require.NotNil(t, proxyURL)
+	assert.Equal(t, "http://proxy.corp:8080", proxyURL.String())
+}
+
+func TestNewMeetingsClient_EmptyProxyIsNoOp(t *testing.T) {
+	c, err := NewMeetingsClient(Config{TenantID: "t", ClientID: "c", ClientSecret: "s"})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+}
+
+func TestNewMeetingsClient_TLSInsecureAndProxyCompose(t *testing.T) {
+	c, err := NewMeetingsClient(Config{
+		TenantID:              "t",
+		ClientID:              "c",
+		ClientSecret:          "s",
+		TLSInsecureSkipVerify: true,
+		ProxyURL:              "http://proxy.corp:8080",
+	})
+	require.NoError(t, err)
+	g := c.(*graphClient)
+	tr, ok := g.httpClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, tr.TLSClientConfig)
+	assert.True(t, tr.TLSClientConfig.InsecureSkipVerify, "TLS-insecure must survive proxy application")
+	require.NotNil(t, tr.Proxy, "proxy must be configured alongside TLS-insecure")
+}
+
+func TestNewMeetingsClient_ProxyRejectsCustomRoundTripper(t *testing.T) {
+	_, err := NewMeetingsClient(
+		Config{TenantID: "t", ClientID: "c", ClientSecret: "s", ProxyURL: "http://proxy.corp:8080"},
+		WithHTTPClient(&http.Client{Transport: stubRoundTripper{}}),
+	)
+	require.Error(t, err)
+}
+```
+
+Then extend the existing `TestGraphClients_InvalidProxyURL` (lines 451–463) to also assert `NewMeetingsClient` fails. Add this inside the `t.Run` body, alongside the existing `NewChatsClient`/`NewChatMembersClient`/`NewUserListerClient` assertions:
+
+```go
+			_, err = NewMeetingsClient(cfg)
+			require.Error(t, err)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `make test SERVICE=msgraph` (or `cd` scope via the Makefile's SERVICE var)
+Expected: FAIL — `undefined: NewMeetingsClient`.
+
+- [ ] **Step 3: Add the constructor**
+
+In `pkg/msgraph/msgraph.go`, add `NewMeetingsClient` immediately after `New` (after line 260). Copy the `NewUserListerClient` shape:
+
+```go
+// NewMeetingsClient returns an app-only meetings client that honors
+// cfg.ProxyURL (unlike New, which ignores it and relies on the standard proxy
+// env vars). It mirrors NewUserListerClient: it applies the proxy after
+// construction and reports an invalid value at construction rather than
+// surfacing an opaque per-request error.
+//
+//nolint:gocritic // hugeParam: startup-only constructor; Config passed by value is intentional.
+func NewMeetingsClient(cfg Config, opts ...Option) (Client, error) {
+	g := New(cfg, opts...).(*graphClient)
+	if err := applyProxyURL(g.httpClient, cfg.ProxyURL); err != nil {
+		return nil, err
+	}
+	return g, nil
+}
+```
+
+- [ ] **Step 4: Update the `Config.ProxyURL` docstring**
+
+In `pkg/msgraph/msgraph.go`, the `ProxyURL` field comment (lines 126–130) currently reads:
+
+```go
+	// ProxyURL, when non-empty, routes the client's HTTP requests through this
+	// proxy (overriding HTTPS_PROXY/HTTP_PROXY). Honored by the presence, chats,
+	// chat-members and user-lister clients — each NewXxxClient applies it and
+	// reports an invalid value at construction. The directory and meetings clients
+	// (NewDirectoryClient / New) ignore it and rely on the standard proxy env
+	// vars. Must include a scheme and host (e.g. "http://proxy.corp:8080").
+	ProxyURL string
+```
+
+Replace it with (the meetings client now honors it via `NewMeetingsClient`; the bare `New` still ignores it):
+
+```go
+	// ProxyURL, when non-empty, routes the client's HTTP requests through this
+	// proxy (overriding HTTPS_PROXY/HTTP_PROXY). Honored by the presence, chats,
+	// chat-members, user-lister and meetings clients — each NewXxxClient
+	// (NewPresenceClient / NewChatsClient / NewChatMembersClient /
+	// NewUserListerClient / NewMeetingsClient) applies it and reports an invalid
+	// value at construction. The bare New and NewDirectoryClient constructors
+	// ignore it and rely on the standard proxy env vars. Must include a scheme
+	// and host (e.g. "http://proxy.corp:8080").
+	ProxyURL string
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `make test SERVICE=msgraph`
+Expected: PASS — all four new tests and the extended `TestGraphClients_InvalidProxyURL` green.
+
+- [ ] **Step 6: Lint**
+
+Run: `make lint`
+Expected: no new findings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pkg/msgraph/msgraph.go pkg/msgraph/msgraph_test.go
+git commit -m "feat(msgraph): add NewMeetingsClient honoring Config.ProxyURL
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01YG6jRt3et6XhesnSRM21rr"
+```
+
+---
+
+### Task 2: room-service config + wiring + docs
+
+**Files:**
+- Modify: `room-service/main.go` (add `GraphProxyURL` config field after line 58; switch construction block lines 156–162 to `NewMeetingsClient` with error handling)
+- Modify: `docs/msgraph-client.md` (add `GRAPH_PROXY_URL` to the config table; note the meetings client honors `ProxyURL`)
+
+**Interfaces:**
+- Consumes: `msgraph.NewMeetingsClient(cfg Config, opts ...Option) (Client, error)` from Task 1.
+- Produces: nothing consumed by later tasks (terminal wiring).
+
+- [ ] **Step 1: Add the config field**
+
+In `room-service/main.go`, immediately after the `GraphUserAgent` field (line 58), add:
+
+```go
+	// GraphProxyURL, when set, routes the meetings Graph client through this
+	// proxy explicitly (overriding HTTPS_PROXY/HTTP_PROXY). Must include a scheme
+	// and host, e.g. "http://proxy.corp:8080". Empty falls back to the standard
+	// proxy env vars.
+	GraphProxyURL string `env:"GRAPH_PROXY_URL" envDefault:""`
+```
+
+- [ ] **Step 2: Switch construction to `NewMeetingsClient`**
+
+In `room-service/main.go`, replace the current construction (lines 156–162):
+
+```go
+		graphClient = msgraph.New(msgraph.Config{
+			TenantID:              cfg.TeamsTenantID,
+			ClientID:              cfg.TeamsClientID,
+			ClientSecret:          cfg.TeamsClientSecret,
+			TLSInsecureSkipVerify: cfg.TeamsTLSInsecure,
+			UserAgent:             cfg.GraphUserAgent,
+		})
+```
+
+with (add `ProxyURL`, capture and check the error using the `err` already in scope from `main`):
+
+```go
+		graphClient, err = msgraph.NewMeetingsClient(msgraph.Config{
+			TenantID:              cfg.TeamsTenantID,
+			ClientID:              cfg.TeamsClientID,
+			ClientSecret:          cfg.TeamsClientSecret,
+			TLSInsecureSkipVerify: cfg.TeamsTLSInsecure,
+			ProxyURL:              cfg.GraphProxyURL,
+			UserAgent:             cfg.GraphUserAgent,
+		})
+		if err != nil {
+			slog.Error("build graph meetings client", "error", err)
+			os.Exit(1)
+		}
+```
+
+Note: `graphClient` is declared as `var graphClient msgraph.Client` (line 151) and `err` is already in scope from `main`'s earlier `cfg, err := ...`; use `=` (not `:=`) so neither is shadowed.
+
+- [ ] **Step 3: Verify the build compiles**
+
+Run: `make build SERVICE=room-service`
+Expected: builds cleanly (this is the green check for the wiring — a `:=` shadow, wrong type, or unhandled error would fail compilation).
+
+- [ ] **Step 4: Run room-service unit tests**
+
+Run: `make test SERVICE=room-service`
+Expected: PASS — existing handler/helper tests unaffected. (No new config-parse unit test is added: room-service's `config` carries `required` env vars, `main_test.go` is integration-tagged, and the `GRAPH_PROXY_URL` env tag / pass-through is fully covered by Task 1's constructor tests plus this compile check — no forced integration test per the spec.)
+
+- [ ] **Step 5: Update `docs/msgraph-client.md`**
+
+In the config table (lines 21–26), add a row after the `TEAMS_EMAIL_DOMAIN` row:
+
+```md
+| `GRAPH_PROXY_URL` | Optional. Routes the meetings Graph client through this proxy (scheme+host, e.g. `http://proxy.corp:8080`), overriding `HTTPS_PROXY`/`HTTP_PROXY`. Empty falls back to the standard proxy env vars. |
+```
+
+In the "Creating a meeting (idempotent)" section, append a sentence at the end (after line 52):
+
+```md
+
+room-service constructs this client via `NewMeetingsClient(cfg)`, which honors
+`Config.ProxyURL` (from `GRAPH_PROXY_URL`) and fails fast on a malformed proxy
+value at startup.
+```
+
+- [ ] **Step 6: Confirm no client-api docs change is needed**
+
+No `docs/client-api.md` edit: no client-facing NATS/HTTP handler request or response schema changed (only startup config + client construction). Nothing to do — this step is a checkpoint, not an edit.
+
+- [ ] **Step 7: Lint**
+
+Run: `make lint`
+Expected: no new findings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add room-service/main.go docs/msgraph-client.md
+git commit -m "feat(room-service): route Graph meetings client through GRAPH_PROXY_URL
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01YG6jRt3et6XhesnSRM21rr"
+```
+
+---
+
+## Final verification (after both tasks)
+
+- [ ] `make test SERVICE=msgraph` — green
+- [ ] `make test SERVICE=room-service` — green
+- [ ] `make build SERVICE=room-service` — builds
+- [ ] `make lint` — clean
+- [ ] `make sast` — no medium+ findings (SAST is a blocking CI gate)
+- [ ] Push: `git push -u origin claude/room-service-proxy-msgraph-8h739h` (retry on network error with backoff 2s/4s/8s/16s)

--- a/docs/superpowers/specs/2026-07-23-room-service-msgraph-proxy-design.md
+++ b/docs/superpowers/specs/2026-07-23-room-service-msgraph-proxy-design.md
@@ -1,0 +1,146 @@
+# room-service Graph proxy — design
+
+**Date:** 2026-07-23
+**Status:** Approved (pending spec review)
+
+## Problem
+
+room-service builds its Microsoft Graph client via `msgraph.New(...)` — the
+**meetings** client, backing the `onlineMeeting` create RPC. By design, `New`
+(and `NewDirectoryClient`) **ignore** `Config.ProxyURL` and rely on the ambient
+`HTTPS_PROXY`/`HTTP_PROXY` env vars (see the `Config.ProxyURL` docstring in
+`pkg/msgraph/msgraph.go`). Only the error-returning constructors
+(`NewUserListerClient`, `NewPresenceClient`, `NewChatsClient`,
+`NewChatMembersClient`) call `applyProxyURL` and honor an explicit proxy.
+
+In environments where Graph egress must go through a specific corporate proxy
+(overriding the ambient env vars), room-service has no way to configure it. We
+want a `GRAPH_PROXY_URL` config on room-service that is passed through to the
+meetings client.
+
+## Goal
+
+Allow room-service to route its Graph meetings calls through an explicit proxy,
+configured via `GRAPH_PROXY_URL`, overriding `HTTPS_PROXY`/`HTTP_PROXY`. Match
+the convention already used by `teams-user-sync` and `user-presence-service`
+(both expose `GRAPH_PROXY_URL` → `Config.ProxyURL`).
+
+## Approach
+
+Chosen approach: **new error-returning constructor** `msgraph.NewMeetingsClient`.
+This mirrors the existing `NewUserListerClient` / `NewPresenceClient` pattern —
+constructors that honor `ProxyURL` return an error so a malformed proxy URL
+fails fast at construction rather than surfacing as an opaque per-request error.
+`New` keeps its documented proxy-unaware behavior (it returns no error and so
+cannot fail-fast).
+
+Rejected alternatives:
+- *Make `New` honor `ProxyURL` directly* — `New` returns no error, so a bad URL
+  could only surface per-request; also silently changes `NewDirectoryClient`
+  behavior.
+- *A `WithProxyURL` functional Option* — Options can't return errors, so an
+  invalid proxy URL would be silently swallowed, inconsistent with the
+  fail-fast pattern used everywhere else in the package.
+
+## Changes
+
+### 1. `pkg/msgraph/msgraph.go` — `NewMeetingsClient`
+
+```go
+// NewMeetingsClient returns an app-only meetings client that honors
+// cfg.ProxyURL (unlike New, which ignores it and relies on the standard proxy
+// env vars). It mirrors NewUserListerClient: it applies the proxy after
+// construction and reports an invalid value at construction rather than
+// surfacing an opaque per-request error.
+func NewMeetingsClient(cfg Config, opts ...Option) (Client, error) {
+	g := New(cfg, opts...).(*graphClient)
+	if err := applyProxyURL(g.httpClient, cfg.ProxyURL); err != nil {
+		return nil, err
+	}
+	return g, nil
+}
+```
+
+- Reuses the existing `applyProxyURL` helper — no new proxy logic.
+- `applyProxyURL` → `mutableTransport` *clones* the transport, so a
+  `TLSInsecureSkipVerify` transport installed by `New` is preserved; TLS-insecure
+  and proxy compose. An empty `ProxyURL` is a no-op. A custom
+  (non-`*http.Transport`) RoundTripper causes a fail-fast error.
+- Update the `Config.ProxyURL` docstring: add `NewMeetingsClient` to the list of
+  constructors that honor it; `New` / `NewDirectoryClient` still ignore it.
+
+### 2. `room-service/main.go` — config + wiring
+
+- Add config field, docstring matching the two sibling services:
+
+  ```go
+  // GraphProxyURL, when set, routes the meetings Graph client through this
+  // proxy explicitly (overriding HTTPS_PROXY/HTTP_PROXY). Must include a scheme
+  // and host, e.g. "http://proxy.corp:8080". Empty falls back to the standard
+  // proxy env vars.
+  GraphProxyURL string `env:"GRAPH_PROXY_URL" envDefault:""`
+  ```
+
+- In the Graph-client construction block, swap `msgraph.New(...)` for
+  `msgraph.NewMeetingsClient(...)`, pass `ProxyURL: cfg.GraphProxyURL`, and
+  handle the returned error with the existing fail-fast startup style
+  (`slog.Error(...)` + `os.Exit(1)`):
+
+  ```go
+  graphClient, err = msgraph.NewMeetingsClient(msgraph.Config{
+      TenantID:              cfg.TeamsTenantID,
+      ClientID:              cfg.TeamsClientID,
+      ClientSecret:          cfg.TeamsClientSecret,
+      TLSInsecureSkipVerify: cfg.TeamsTLSInsecure,
+      ProxyURL:              cfg.GraphProxyURL,
+      UserAgent:             cfg.GraphUserAgent,
+  })
+  if err != nil {
+      slog.Error("build graph meetings client", "error", err)
+      os.Exit(1)
+  }
+  ```
+
+  (`graphClient` is declared as `var graphClient msgraph.Client` outside the
+  block; introduce the `err` binding as needed without shadowing it.)
+
+## Tests (TDD — Red first)
+
+### `pkg/msgraph/msgraph_test.go`
+
+- `NewMeetingsClient` routes requests through a configured proxy: assert
+  `g.httpClient.Transport.(*http.Transport).Proxy` is non-nil when `ProxyURL` is
+  set, and returns the configured proxy URL. Mirror
+  `TestNewChatsClient_MaxIdleConnsSurvivesProxy` (options survive proxy
+  application) for the meetings constructor.
+- Empty `ProxyURL` is a no-op (proxy falls back to `ProxyFromEnvironment` /
+  transport default; construction succeeds).
+- TLS-insecure + proxy compose: `TLSInsecureSkipVerify: true` + a `ProxyURL`
+  yields a transport with both `TLSClientConfig.InsecureSkipVerify` and `Proxy`
+  set.
+- Custom RoundTripper + `ProxyURL` fails fast (mirror
+  `TestNewChatsClient_ProxyRejectsCustomRoundTripper`).
+- Extend `TestGraphClients_InvalidProxyURL` to include `NewMeetingsClient` in the
+  set of constructors asserted to fail on a malformed proxy value.
+
+### `room-service`
+
+room-service's `main_test.go` is integration-tagged and has no config-parse unit
+test today. If a lightweight config-parse assertion is warranted, add a
+`config`-parsing test that confirms `GRAPH_PROXY_URL` maps to `GraphProxyURL`
+(guarding the env tag), following whatever unit-test pattern fits without a
+container. Otherwise the field is exercised via the msgraph constructor tests
+plus a compile-time wiring check; no forced integration test.
+
+## Docs
+
+- `docs/msgraph-client.md`: note `NewMeetingsClient` honors `ProxyURL` (add it to
+  the constructor list alongside the presence/chats/user-lister clients).
+- No `docs/client-api.md` change — no client-facing NATS/HTTP handler request or
+  response schema changes.
+
+## Out of scope (YAGNI)
+
+- Changing `New` / `NewDirectoryClient` proxy behavior.
+- The deep-link RPCs (they use only `EmailDomain`, never call Graph).
+- Any change to the presence/chats/members/user-lister proxy paths.

--- a/pkg/msgraph/msgraph.go
+++ b/pkg/msgraph/msgraph.go
@@ -123,10 +123,12 @@ type Config struct {
 	TLSInsecureSkipVerify bool
 	// ProxyURL, when non-empty, routes the client's HTTP requests through this
 	// proxy (overriding HTTPS_PROXY/HTTP_PROXY). Honored by the presence, chats,
-	// chat-members and user-lister clients — each NewXxxClient applies it and
-	// reports an invalid value at construction. The directory and meetings clients
-	// (NewDirectoryClient / New) ignore it and rely on the standard proxy env
-	// vars. Must include a scheme and host (e.g. "http://proxy.corp:8080").
+	// chat-members, user-lister and meetings clients — each NewXxxClient
+	// (NewPresenceClient / NewChatsClient / NewChatMembersClient /
+	// NewUserListerClient / NewMeetingsClient) applies it and reports an invalid
+	// value at construction. The bare New and NewDirectoryClient constructors
+	// ignore it and rely on the standard proxy env vars. Must include a scheme
+	// and host (e.g. "http://proxy.corp:8080").
 	ProxyURL string
 	// UserAgent overrides the User-Agent header sent on every Graph request. When
 	// empty the client falls back to defaultUserAgent (a browser string). Honored
@@ -257,6 +259,21 @@ func New(cfg Config, opts ...Option) Client {
 		opt(g)
 	}
 	return g
+}
+
+// NewMeetingsClient returns an app-only meetings client that honors
+// cfg.ProxyURL (unlike New, which ignores it and relies on the standard proxy
+// env vars). It mirrors NewUserListerClient: it applies the proxy after
+// construction and reports an invalid value at construction rather than
+// surfacing an opaque per-request error.
+//
+//nolint:gocritic // hugeParam: startup-only constructor; Config passed by value is intentional.
+func NewMeetingsClient(cfg Config, opts ...Option) (Client, error) {
+	g := New(cfg, opts...).(*graphClient)
+	if err := applyProxyURL(g.httpClient, cfg.ProxyURL); err != nil {
+		return nil, err
+	}
+	return g, nil
 }
 
 // mutableTransport returns an *http.Transport for tuning hc's connection pool,

--- a/pkg/msgraph/msgraph_test.go
+++ b/pkg/msgraph/msgraph_test.go
@@ -458,8 +458,59 @@ func TestGraphClients_InvalidProxyURL(t *testing.T) {
 			require.Error(t, err)
 			_, err = NewUserListerClient(cfg)
 			require.Error(t, err)
+			_, err = NewMeetingsClient(cfg)
+			require.Error(t, err)
 		})
 	}
+}
+
+func TestNewMeetingsClient_RoutesThroughProxy(t *testing.T) {
+	c, err := NewMeetingsClient(
+		Config{TenantID: "t", ClientID: "c", ClientSecret: "s", ProxyURL: "http://proxy.corp:8080"},
+	)
+	require.NoError(t, err)
+	g := c.(*graphClient)
+	tr, ok := g.httpClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, tr.Proxy, "proxy must be configured on the transport")
+
+	req, err := http.NewRequest(http.MethodGet, "https://graph.microsoft.com/v1.0/me", nil)
+	require.NoError(t, err)
+	proxyURL, err := tr.Proxy(req)
+	require.NoError(t, err)
+	require.NotNil(t, proxyURL)
+	assert.Equal(t, "http://proxy.corp:8080", proxyURL.String())
+}
+
+func TestNewMeetingsClient_EmptyProxyIsNoOp(t *testing.T) {
+	c, err := NewMeetingsClient(Config{TenantID: "t", ClientID: "c", ClientSecret: "s"})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+}
+
+func TestNewMeetingsClient_TLSInsecureAndProxyCompose(t *testing.T) {
+	c, err := NewMeetingsClient(Config{
+		TenantID:              "t",
+		ClientID:              "c",
+		ClientSecret:          "s",
+		TLSInsecureSkipVerify: true,
+		ProxyURL:              "http://proxy.corp:8080",
+	})
+	require.NoError(t, err)
+	g := c.(*graphClient)
+	tr, ok := g.httpClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, tr.TLSClientConfig)
+	assert.True(t, tr.TLSClientConfig.InsecureSkipVerify, "TLS-insecure must survive proxy application")
+	require.NotNil(t, tr.Proxy, "proxy must be configured alongside TLS-insecure")
+}
+
+func TestNewMeetingsClient_ProxyRejectsCustomRoundTripper(t *testing.T) {
+	_, err := NewMeetingsClient(
+		Config{TenantID: "t", ClientID: "c", ClientSecret: "s", ProxyURL: "http://proxy.corp:8080"},
+		WithHTTPClient(&http.Client{Transport: stubRoundTripper{}}),
+	)
+	require.Error(t, err)
 }
 
 func TestCreateOnlineMeeting_SendsDefaultUserAgent(t *testing.T) {

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -55,7 +55,12 @@ type config struct {
 	// GraphUserAgent overrides the User-Agent header on Graph requests (meetings
 	// path). Empty falls back to the msgraph browser default. Named GRAPH_USER_AGENT
 	// for consistency with user-presence-service.
-	GraphUserAgent       string `env:"GRAPH_USER_AGENT" envDefault:""`
+	GraphUserAgent string `env:"GRAPH_USER_AGENT" envDefault:""`
+	// GraphProxyURL, when set, routes the meetings Graph client through this
+	// proxy explicitly (overriding HTTPS_PROXY/HTTP_PROXY). Must include a scheme
+	// and host, e.g. "http://proxy.corp:8080". Empty falls back to the standard
+	// proxy env vars.
+	GraphProxyURL        string `env:"GRAPH_PROXY_URL" envDefault:""`
 	RoomMembersLimit     int    `env:"ROOM_MEMBERS_LIMIT"       envDefault:"500"`
 	RoomMembersCallLimit int    `env:"ROOM_MEMBERS_CALL_LIMIT"  envDefault:"20"`
 	// Atrest/Vault drive eager at-rest DEK provisioning at room creation.
@@ -153,13 +158,18 @@ func main() {
 		if cfg.TeamsTLSInsecure {
 			slog.Warn("Graph TLS verification disabled — dev/on-prem only, never production", "TEAMS_TLS_INSECURE", true)
 		}
-		graphClient = msgraph.New(msgraph.Config{
+		graphClient, err = msgraph.NewMeetingsClient(msgraph.Config{
 			TenantID:              cfg.TeamsTenantID,
 			ClientID:              cfg.TeamsClientID,
 			ClientSecret:          cfg.TeamsClientSecret,
 			TLSInsecureSkipVerify: cfg.TeamsTLSInsecure,
+			ProxyURL:              cfg.GraphProxyURL,
 			UserAgent:             cfg.GraphUserAgent,
 		})
+		if err != nil {
+			slog.Error("build graph meetings client", "error", err)
+			os.Exit(1)
+		}
 	}
 
 	// Eager at-rest DEK provisioning: when enabled, room creation provisions


### PR DESCRIPTION
## Summary

Adds explicit proxy support to room-service's Microsoft Graph meetings client via a new `msgraph.NewMeetingsClient` constructor and `GRAPH_PROXY_URL` config, allowing Graph egress to route through a corporate proxy that overrides ambient `HTTPS_PROXY`/`HTTP_PROXY` env vars.

## Changes

### `pkg/msgraph/msgraph.go`
- **New constructor `NewMeetingsClient(cfg Config, opts ...Option) (Client, error)`**: Mirrors the existing `NewUserListerClient` pattern — constructs a client via `New`, applies `cfg.ProxyURL` via the existing `applyProxyURL` helper, and returns an error on a malformed proxy URL or custom RoundTripper, enabling fail-fast startup validation.
- **Updated `Config.ProxyURL` docstring**: Now lists `NewMeetingsClient` alongside `NewPresenceClient`, `NewChatsClient`, `NewChatMembersClient`, and `NewUserListerClient` as constructors that honor the proxy setting; clarifies that bare `New` and `NewDirectoryClient` still ignore it and rely on standard proxy env vars.

### `pkg/msgraph/msgraph_test.go`
- **Four new test cases for `NewMeetingsClient`**:
  - `TestNewMeetingsClient_RoutesThroughProxy`: Verifies the transport's `Proxy` function returns the configured proxy URL.
  - `TestNewMeetingsClient_EmptyProxyIsNoOp`: Confirms empty `ProxyURL` succeeds without error.
  - `TestNewMeetingsClient_TLSInsecureAndProxyCompose`: Asserts that `TLSInsecureSkipVerify` and proxy settings coexist on the transport.
  - `TestNewMeetingsClient_ProxyRejectsCustomRoundTripper`: Confirms a custom RoundTripper with a proxy URL fails fast.
- **Extended `TestGraphClients_InvalidProxyURL`**: Added assertion that `NewMeetingsClient` fails on a malformed proxy URL, consistent with other proxy-aware constructors.

### `room-service/main.go`
- **New config field `GraphProxyURL`**: Env var `GRAPH_PROXY_URL` (optional, defaults to empty string); docstring notes it overrides `HTTPS_PROXY`/`HTTP_PROXY` and must include scheme and host.
- **Updated Graph client construction**: Switched from `msgraph.New(...)` to `msgraph.NewMeetingsClient(...)`, passing `ProxyURL: cfg.GraphProxyURL`, with error handling that logs and exits on failure (consistent with startup fail-fast pattern).

### `docs/msgraph-client.md`
- **Added `GRAPH_PROXY_URL` to config table**: Documents the new env var, its optional nature, and its effect on the meetings client.
- **Added note in "Creating a meeting" section**: Clarifies that room-service constructs the meetings client via `NewMeetingsClient`, which honors `Config.ProxyURL` and fails fast on a malformed value at startup.

## Implementation Details

- **Reuses existing `applyProxyURL` helper**: No new proxy logic; the helper already handles transport cloning (preserving TLS settings), empty-string no-ops, and custom RoundTripper rejection.
- **TDD approach**: All tests written first (red), then constructor implemented (green), then linted and committed.
- **Fail-fast validation**: Malformed proxy URLs are caught at startup via the error-returning constructor, not surfaced as opaque per-request errors.
- **Consistent with sibling services**: Matches the `GRAPH_PROXY_URL` → `Config.ProxyURL` pattern already used by `teams-user-sync` and `user-presence-service`.

## Testing

- `make test SERVICE=msgraph` — all four new tests + extended invalid-proxy test pass
- `make test SERVICE=room-service` — existing tests unaffected
- `make build SERVICE=room-service` — compiles cleanly
- `make lint` — no new findings

https://claude.ai/code/session_01YG6jRt3et6XhesnSRM21rr