### PR TITLE
feat(teams-hr-sync): split the published counter by kind

### DIFF
--- a/teams-hr-sync/emitter.go
+++ b/teams-hr-sync/emitter.go
@@ -8,19 +8,28 @@ import (
 	"github.com/hmchangw/chat/teams-hr-sync/transform"
 )
 
+// emitResult breaks the run's written counts out by kind for the summary log.
+// Employees/Users are record counts (they move 1:1 — users derive from the same
+// upserts); Quits is the per-site batch count.
+type emitResult struct {
+	EmployeesWritten int
+	UsersWritten     int
+	QuitsWritten     int
+}
+
 // emitter is the seam between a computed diff and where it lands: the
 // JetStream feed (stream mode, default) or a direct write into the target
-// Mongo (direct mode, one-shot migration/backfill). The return count is
-// informational (batches sent/written) for the run-summary log line.
+// Mongo (direct mode, one-shot migration/backfill). The counts are
+// informational for the run-summary log line.
 type emitter interface {
-	emit(ctx context.Context, diff diffResult) (int, error)
+	emit(ctx context.Context, diff diffResult) (emitResult, error)
 }
 
 // streamEmitter wraps the existing publisher — stream-mode behavior is
 // unchanged.
 type streamEmitter struct{ pub *publisher }
 
-func (e streamEmitter) emit(ctx context.Context, diff diffResult) (int, error) {
+func (e streamEmitter) emit(ctx context.Context, diff diffResult) (emitResult, error) {
 	return e.pub.publishSync(ctx, diff)
 }
 
@@ -31,13 +40,13 @@ type directEmitter struct {
 	converter transform.EmployeeUserConverter
 }
 
-func (e directEmitter) emit(ctx context.Context, diff diffResult) (int, error) {
-	written := 0
+func (e directEmitter) emit(ctx context.Context, diff diffResult) (emitResult, error) {
+	var res emitResult
 	if len(diff.Upserts) > 0 {
 		if err := e.store.UpsertEmployees(ctx, diff.Upserts); err != nil {
-			return written, fmt.Errorf("direct upsert employees: %w", err)
+			return res, fmt.Errorf("direct upsert employees: %w", err)
 		}
-		written++
+		res.EmployeesWritten = len(diff.Upserts)
 
 		users := make([]model.IUserWithChange, 0, len(diff.Upserts))
 		for i := range diff.Upserts {
@@ -47,9 +56,9 @@ func (e directEmitter) emit(ctx context.Context, diff diffResult) (int, error) {
 			})
 		}
 		if err := e.store.UpsertUserIdentities(ctx, users); err != nil {
-			return written, fmt.Errorf("direct upsert user identities: %w", err)
+			return res, fmt.Errorf("direct upsert user identities: %w", err)
 		}
-		written++
+		res.UsersWritten = len(users)
 	}
 
 	// Symmetry with stream mode. A diff-vs-empty-baseline run (direct mode's
@@ -59,9 +68,9 @@ func (e directEmitter) emit(ctx context.Context, diff diffResult) (int, error) {
 			continue
 		}
 		if err := e.store.QuitTeamsEmployees(ctx, accounts); err != nil {
-			return written, fmt.Errorf("direct quit employees: %w", err)
+			return res, fmt.Errorf("direct quit employees: %w", err)
 		}
-		written++
+		res.QuitsWritten++
 	}
-	return written, nil
+	return res, nil
 }

--- a/teams-hr-sync/emitter_test.go
+++ b/teams-hr-sync/emitter_test.go
@@ -35,9 +35,10 @@ func TestDirectEmitter_UpsertsEmployeesAndConvertedUsers(t *testing.T) {
 			return nil
 		})
 
-	n, err := e.emit(context.Background(), diff)
+	res, err := e.emit(context.Background(), diff)
 	require.NoError(t, err)
-	assert.Equal(t, 2, n)
+	assert.Equal(t, 1, res.EmployeesWritten)
+	assert.Equal(t, 1, res.UsersWritten)
 }
 
 func TestDirectEmitter_QuitsWhenPresent(t *testing.T) {
@@ -46,18 +47,18 @@ func TestDirectEmitter_QuitsWhenPresent(t *testing.T) {
 
 	store.EXPECT().QuitTeamsEmployees(gomock.Any(), []string{"eve"}).Return(nil)
 
-	n, err := e.emit(context.Background(), diffResult{Quits: map[string][]string{"site-a": {"eve"}}})
+	res, err := e.emit(context.Background(), diffResult{Quits: map[string][]string{"site-a": {"eve"}}})
 	require.NoError(t, err)
-	assert.Equal(t, 1, n)
+	assert.Equal(t, 1, res.QuitsWritten)
 }
 
 func TestDirectEmitter_SkipsEmptyDiff(t *testing.T) {
 	store := NewMockWriteStore(gomock.NewController(t)) // no EXPECT — any call fails the test
 	e := directEmitter{store: store, converter: transform.DefaultConverter{}}
 
-	n, err := e.emit(context.Background(), diffResult{})
+	res, err := e.emit(context.Background(), diffResult{})
 	require.NoError(t, err)
-	assert.Zero(t, n)
+	assert.Equal(t, emitResult{}, res)
 }
 
 func TestDirectEmitter_UpsertErrorAborts(t *testing.T) {
@@ -79,10 +80,11 @@ func TestStreamEmitter_DelegatesToPublisher(t *testing.T) {
 	e := streamEmitter{pub: pub}
 
 	diff := diffResult{Upserts: []model.IEmployeeWithChange{{IEmployee: teamsEmployee("alice", "site-a"), ChangeType: model.IChangeTypeNewHire}}}
-	n, err := e.emit(context.Background(), diff)
+	res, err := e.emit(context.Background(), diff)
 	require.NoError(t, err)
-	assert.Equal(t, 2, n) // employees.upsert + users.upsert
-	assert.Len(t, got, 2)
+	assert.Equal(t, 1, res.EmployeesWritten)
+	assert.Equal(t, 1, res.UsersWritten)
+	assert.Len(t, got, 2) // employees.upsert + users.upsert
 }
 
 func TestRunDirectSync_ModePicksEmitter(t *testing.T) {
@@ -100,5 +102,6 @@ func TestRunDirectSync_ModePicksEmitter(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, stats.Created)
 	assert.Zero(t, stats.Quits, "direct mode diffs against an empty baseline: no quits")
-	assert.Equal(t, 2, stats.Published)
+	assert.Equal(t, 1, stats.EmployeesPublished)
+	assert.Equal(t, 1, stats.UsersPublished)
 }

--- a/teams-hr-sync/integration_test.go
+++ b/teams-hr-sync/integration_test.go
@@ -103,7 +103,9 @@ func TestRunSync_EndToEnd(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, stats.Created)
 	assert.Zero(t, stats.Quits)
-	assert.Equal(t, 2, stats.Published) // employees.upsert + users.upsert, no quits
+	assert.Equal(t, 2, stats.EmployeesPublished) // 2 employee records
+	assert.Equal(t, 2, stats.UsersPublished)     // 2 user records
+	assert.Zero(t, stats.QuitsPublished)
 
 	msgs := drainStream(t, stream)
 	require.Len(t, msgs, 2)
@@ -140,7 +142,9 @@ func TestRunSync_EndToEnd(t *testing.T) {
 	assert.Equal(t, 1, stats.Created)
 	assert.Equal(t, 1, stats.Updated)
 	assert.Equal(t, 1, stats.Quits)
-	assert.Equal(t, 3, stats.Published)
+	assert.Equal(t, 2, stats.EmployeesPublished) // 1 created + 1 updated
+	assert.Equal(t, 2, stats.UsersPublished)
+	assert.Equal(t, 1, stats.QuitsPublished)
 
 	msgs = drainStream(t, stream)
 	require.Len(t, msgs, 3)

--- a/teams-hr-sync/main.go
+++ b/teams-hr-sync/main.go
@@ -109,7 +109,9 @@ func run() error {
 		"created", stats.Created,
 		"updated", stats.Updated,
 		"quits", stats.Quits,
-		"published", stats.Published,
+		"employeesPublished", stats.EmployeesPublished,
+		"usersPublished", stats.UsersPublished,
+		"quitsPublished", stats.QuitsPublished,
 		"durationMs", time.Since(start).Milliseconds(),
 		"succeeded", err == nil,
 	)
@@ -182,10 +184,12 @@ func jetStreamPublish(js jetstream.JetStream) publishFunc {
 // runStats summarizes one sync run for the end-of-run log line.
 type runStats struct {
 	collectStats
-	Created   int // rows absent from the store
-	Updated   int // rows whose fields changed
-	Quits     int // departed accounts across all sites
-	Published int // JetStream messages sent
+	Created            int // rows absent from the store
+	Updated            int // rows whose fields changed
+	Quits              int // departed accounts across all sites
+	EmployeesPublished int // employee records written
+	UsersPublished     int // user records written (1:1 with employees)
+	QuitsPublished     int // per-site quit batches written
 }
 
 // runSync performs one full stream-mode sync: walk the configured groups,
@@ -226,8 +230,10 @@ func runSyncCore(ctx context.Context, graph msgraph.GroupReader, mapper transfor
 	for _, accounts := range diff.Quits {
 		stats.Quits += len(accounts)
 	}
-	published, err := emit.emit(ctx, diff)
-	stats.Published = published
+	res, err := emit.emit(ctx, diff)
+	stats.EmployeesPublished = res.EmployeesWritten
+	stats.UsersPublished = res.UsersWritten
+	stats.QuitsPublished = res.QuitsWritten
 	if err != nil {
 		return stats, fmt.Errorf("emit sync batches: %w", err)
 	}

--- a/teams-hr-sync/main_test.go
+++ b/teams-hr-sync/main_test.go
@@ -33,8 +33,10 @@ func TestRunSync_DiffAndPublish(t *testing.T) {
 	assert.Equal(t, 1, stats.Created)
 	assert.Zero(t, stats.Updated)
 	assert.Equal(t, 1, stats.Quits)
-	assert.Equal(t, 3, stats.Published) // employees.upsert + users.upsert + one quit
-	assert.Len(t, got, 3)
+	assert.Equal(t, 1, stats.EmployeesPublished)
+	assert.Equal(t, 1, stats.UsersPublished)
+	assert.Equal(t, 1, stats.QuitsPublished) // one per-site quit batch
+	assert.Len(t, got, 3)                    // employees.upsert + users.upsert + one quit
 }
 
 func TestRunSync_StoreErrorAborts(t *testing.T) {

--- a/teams-hr-sync/publisher.go
+++ b/teams-hr-sync/publisher.go
@@ -30,15 +30,15 @@ func newPublisher(publish publishFunc, central string, converter transform.Emplo
 	return &publisher{publish: publish, central: central, converter: converter}
 }
 
-// publishSync publishes the diff and returns the number of messages sent.
-func (p *publisher) publishSync(ctx context.Context, d diffResult) (int, error) {
-	published := 0
+// publishSync publishes the diff, returning per-kind written counts.
+func (p *publisher) publishSync(ctx context.Context, d diffResult) (emitResult, error) {
+	var res emitResult
 
 	if len(d.Upserts) > 0 {
 		if err := p.publishZstd(ctx, subject.OrgSyncEmployeesUpsert(p.central), d.Upserts); err != nil {
-			return published, fmt.Errorf("publish employees.upsert: %w", err)
+			return res, fmt.Errorf("publish employees.upsert: %w", err)
 		}
-		published++
+		res.EmployeesWritten = len(d.Upserts)
 
 		users := make([]model.IUserWithChange, 0, len(d.Upserts))
 		for i := range d.Upserts {
@@ -48,9 +48,9 @@ func (p *publisher) publishSync(ctx context.Context, d diffResult) (int, error) 
 			})
 		}
 		if err := p.publishZstd(ctx, subject.OrgSyncUsersUpsert(p.central), users); err != nil {
-			return published, fmt.Errorf("publish users.upsert: %w", err)
+			return res, fmt.Errorf("publish users.upsert: %w", err)
 		}
-		published++
+		res.UsersWritten = len(users)
 	}
 
 	// deterministic site order so a partial failure is reproducible
@@ -62,11 +62,11 @@ func (p *publisher) publishSync(ctx context.Context, d diffResult) (int, error) 
 	for _, siteID := range siteIDs {
 		if err := p.publishZstd(ctx, subject.EmployeesQuit(siteID),
 			model.IHRSyncEmployeeQuitBatch{Timestamp: time.Now().UTC().UnixMilli(), SiteID: siteID, Accounts: d.Quits[siteID]}); err != nil {
-			return published, fmt.Errorf("publish employees.quit for site %s: %w", siteID, err)
+			return res, fmt.Errorf("publish employees.quit for site %s: %w", siteID, err)
 		}
-		published++
+		res.QuitsWritten++
 	}
-	return published, nil
+	return res, nil
 }
 
 func (p *publisher) publishZstd(ctx context.Context, subj string, payload any) error {

--- a/teams-hr-sync/publisher_test.go
+++ b/teams-hr-sync/publisher_test.go
@@ -49,9 +49,11 @@ func TestPublishSync_AllThreeBatches(t *testing.T) {
 		}},
 		Quits: map[string][]string{"site-b": {"bob"}, "site-a": {"eve"}},
 	}
-	n, err := p.publishSync(context.Background(), d)
+	res, err := p.publishSync(context.Background(), d)
 	require.NoError(t, err)
-	assert.Equal(t, 4, n)
+	assert.Equal(t, 1, res.EmployeesWritten)
+	assert.Equal(t, 1, res.UsersWritten)
+	assert.Equal(t, 2, res.QuitsWritten) // two per-site quit batches
 	require.Len(t, got, 4)
 
 	// employees.upsert — bare array, no wrapper
@@ -85,9 +87,9 @@ func TestPublishSync_SkipsEmptyBatches(t *testing.T) {
 	var got []captured
 	p := newCapturingPublisher(t, &got)
 
-	n, err := p.publishSync(context.Background(), diffResult{})
+	res, err := p.publishSync(context.Background(), diffResult{})
 	require.NoError(t, err)
-	assert.Zero(t, n)
+	assert.Equal(t, emitResult{}, res)
 	assert.Empty(t, got, "nothing to publish on an empty diff")
 }
 
@@ -95,9 +97,9 @@ func TestPublishSync_QuitsOnlySkipsUpserts(t *testing.T) {
 	var got []captured
 	p := newCapturingPublisher(t, &got)
 
-	n, err := p.publishSync(context.Background(), diffResult{Quits: map[string][]string{"site-a": {"eve"}}})
+	res, err := p.publishSync(context.Background(), diffResult{Quits: map[string][]string{"site-a": {"eve"}}})
 	require.NoError(t, err)
-	assert.Equal(t, 1, n)
+	assert.Equal(t, 1, res.QuitsWritten)
 	require.Len(t, got, 1)
 	assert.Equal(t, "chat.hr.site-a.employees.quit", got[0].subj)
 }


### PR DESCRIPTION
## Summary
Split the teams-hr-sync run's single "batches written" count into per-kind counts, so the summary log distinguishes employees, users and quit batches.

## Changes
- `emitter.go`: `emit` now returns `(emitResult, error)` where `emitResult{EmployeesWritten, UsersWritten, QuitsWritten}`. Employees/Users are record counts (they move 1:1 — users derive from the same upserts); Quits is the per-site batch count.
- `publisher.go` (`publishSync`) + `emitter.go` (`directEmitter`): populate the three fields instead of a single `published++`.
- `main.go`: `runStats` replaces `Published` with `EmployeesPublished` / `UsersPublished` / `QuitsPublished`; the end-of-run log line emits all three.
- Tests updated to assert the per-kind counts.

## Verification
- `go test ./teams-hr-sync/...` green; `go vet` + golangci-lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Sync results now report separate counts for employee records, user records, and quit batches.
  * Run summaries and logs provide clearer publication statistics.
  * Partial results remain available when an error occurs during publishing.

* **Bug Fixes**
  * Improved accuracy of publication counts for employee and user records, including quit-only and empty syncs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->