### PR TITLE
feat: converge migrated Teams external user identity (deterministic _id, account-keyed upsert)

### DIFF
--- a/hr-sync-worker/integration_test.go
+++ b/hr-sync-worker/integration_test.go
@@ -72,9 +72,9 @@ func TestWorker_EndToEnd(t *testing.T) {
 	js, err := jetstream.New(nc)
 	require.NoError(t, err)
 
-	// pre-existing user with auth fields the identity upsert must not touch
-	// carries employeeId E1 — the identity upsert keys on it, so this row is
-	// the one alice's upsert must update in place (not a fresh insert).
+	// pre-existing user with auth fields the identity upsert must not touch;
+	// keyed by account (alice), so alice's upsert updates this row in place
+	// (not a fresh insert).
 	_, err = db.Collection(UserCollection).InsertOne(ctx,
 		bson.M{"_id": "u-alice", "account": "alice", "employeeId": "E1", "siteId": "old-site", "roles": []string{"admin"}, "services": bson.M{"password": bson.M{"bcrypt": "hash"}}})
 	require.NoError(t, err)
@@ -98,12 +98,12 @@ func TestWorker_EndToEnd(t *testing.T) {
 	publishJSON(t, js, "chat.hr.site-a.users.upsert", []model.IUserWithChange{
 		{User: model.User{Account: "alice", SiteID: "site-a", EngName: "Name alice", EmployeeID: "E1"}, ChangeType: model.IChangeTypeNewHire},
 		{User: model.User{Account: "carol", SiteID: "site-a", ChineseName: "卡蘿", EmployeeID: "E2"}, ChangeType: model.IChangeTypeNewHire},
-		// publisher-owned _id (Teams migration): honored on insert so every site
-		// converges on the same one, rather than each minting a per-site _id
-		{User: model.User{ID: "mig-id-1", Account: "mgrace", SiteID: "site-a", EmployeeID: "mig-id-1"}, ChangeType: model.IChangeTypeNewHire},
-		// no employeeId → skipped, never written (an empty key would match and
-		// clobber every other keyless row); the count assertion below proves it
-		{User: model.User{Account: "keyless", SiteID: "site-a"}, ChangeType: model.IChangeTypeNewHire},
+		// migrated external (Teams): no employeeId, publisher-owned deterministic
+		// _id honored on insert so every site converges on the same one
+		{User: model.User{ID: "mig-id-1", Account: "mgrace", SiteID: "site-a"}, ChangeType: model.IChangeTypeNewHire},
+		// no account → skipped, never written (account is the key; an empty one
+		// would clobber other rows); the count assertion below proves it
+		{User: model.User{SiteID: "site-a"}, ChangeType: model.IChangeTypeNewHire},
 	})
 
 	awaitCount(t, ctx, db, EmployeeCollection, bson.M{}, 2)
@@ -124,6 +124,7 @@ func TestWorker_EndToEnd(t *testing.T) {
 	var mgrace bson.M
 	require.NoError(t, db.Collection(UserCollection).FindOne(ctx, bson.M{"account": "mgrace"}).Decode(&mgrace))
 	assert.Equal(t, "mig-id-1", mgrace["_id"], "publisher-supplied _id is honored, not regenerated")
+	assert.Nil(t, mgrace["employeeId"], "migrated externals carry no employeeId")
 
 	// re-delivery (same batches again) → no dupes
 	publishJSON(t, js, "chat.hr.site-a.employees.upsert", batch)

--- a/hr-sync-worker/store.go
+++ b/hr-sync-worker/store.go
@@ -25,9 +25,9 @@ const (
 type Store interface {
 	// UpsertEmployees replaces hr_employee docs keyed by employeeId.
 	UpsertEmployees(ctx context.Context, employees []model.IEmployeeWithChange) error
-	// UpsertUserIdentities upserts users by employeeId, writing IDENTITY FIELDS
-	// ONLY (account, siteId, engName, chineseName, employeeId). It must never
-	// touch roles/services/password/active/status fields — users is the
+	// UpsertUserIdentities upserts users by account, writing IDENTITY FIELDS
+	// ONLY (siteId, engName, chineseName, and employeeId when present). It must
+	// never touch roles/services/password/active/status fields — users is the
 	// live auth store.
 	UpsertUserIdentities(ctx context.Context, users []model.IUserWithChange) error
 	// QuitTeamsEmployees deletes hr_employee rows for the given accounts.
@@ -70,10 +70,10 @@ func (s *MongoStore) UpsertUserIdentities(ctx context.Context, users []model.IUs
 	models := make([]mongo.WriteModel, 0, len(users))
 	for i := range users {
 		u := &users[i].User
-		// employeeId is the identity key; an empty one would match every other
-		// keyless row and clobber it, so skip rather than corrupt.
-		if u.EmployeeID == "" {
-			slog.WarnContext(ctx, "skip user identity upsert: empty employeeId")
+		// account is the identity key (globally unique); it covers HR-feed users
+		// and migrated externals alike, and an empty one would clobber other rows.
+		if u.Account == "" {
+			slog.WarnContext(ctx, "skip user identity upsert: empty account")
 			continue
 		}
 		// A publisher that owns the _id (the Teams migration resolver, deterministic
@@ -83,19 +83,21 @@ func (s *MongoStore) UpsertUserIdentities(ctx context.Context, users []model.IUs
 		if idOnInsert == "" {
 			idOnInsert = idgen.GenerateUUIDv7()
 		}
+		// Migrated externals carry no employeeId (they aren't employees); only set
+		// it for HR-feed users that have one, so an external's row stays clean.
+		set := bson.M{"siteId": u.SiteID, "engName": u.EngName, "chineseName": u.ChineseName}
+		if u.EmployeeID != "" {
+			set["employeeId"] = u.EmployeeID
+		}
 		models = append(models, mongo.NewUpdateOneModel().
-			SetFilter(bson.M{"employeeId": u.EmployeeID}).
+			SetFilter(bson.M{"account": u.Account}).
 			SetUpdate(bson.M{
-				"$set": bson.M{
-					"account": u.Account, "siteId": u.SiteID,
-					"engName": u.EngName, "chineseName": u.ChineseName,
-					"employeeId": u.EmployeeID,
-				},
+				"$set":         set,
 				"$setOnInsert": bson.M{"_id": idOnInsert},
 			}).
 			SetUpsert(true))
 	}
-	// All inputs had an empty employeeId → nothing to write; BulkWrite errors on
+	// All inputs had an empty account → nothing to write; BulkWrite errors on
 	// an empty slice (mongo.ErrEmptySlice), so no-op cleanly instead.
 	if len(models) == 0 {
 		return nil

--- a/message-worker/hridentity.go
+++ b/message-worker/hridentity.go
@@ -3,12 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"log/slog"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 
-	"github.com/hmchangw/chat/pkg/idgen"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
 )
@@ -51,37 +49,4 @@ func (s *mongoHRIdentityStore) FindUserByAccount(ctx context.Context, account st
 		return nil, fmt.Errorf("find user by account: %w", err)
 	}
 	return u, nil // FindOne yields (nil,nil) on no match
-}
-
-// UpsertUserIdentities builds the $set doc by hand (never a full-doc replace) so a
-// migrated identity write can't wipe roles/password/services on the live auth store.
-func (s *mongoHRIdentityStore) UpsertUserIdentities(ctx context.Context, users []model.IUserWithChange) error {
-	models := make([]mongo.WriteModel, 0, len(users))
-	for i := range users {
-		u := &users[i].User
-		if u.Account == "" {
-			// account is the identity key; an empty one would clobber every keyless row.
-			slog.WarnContext(ctx, "skip user identity upsert: empty account")
-			continue
-		}
-		models = append(models, mongo.NewUpdateOneModel().
-			// account is globally unique (users has a unique index on it), so it alone keys
-			// the identity. Migrated Teams users carry no employeeId — it is left unset.
-			SetFilter(bson.M{"account": u.Account}).
-			SetUpdate(bson.M{
-				"$set": bson.M{
-					"siteId": u.SiteID, "engName": u.EngName, "chineseName": u.ChineseName,
-				},
-				// Fresh UUIDv7 _id on insert — the persisted UserID search-sync reads back by account.
-				"$setOnInsert": bson.M{"_id": idgen.GenerateUUIDv7()},
-			}).
-			SetUpsert(true))
-	}
-	if len(models) == 0 {
-		return nil // BulkWrite errors on an empty slice; no-op cleanly.
-	}
-	if _, err := s.users.BulkWrite(ctx, models); err != nil {
-		return fmt.Errorf("bulk upsert user identities: %w", err)
-	}
-	return nil
 }

--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"github.com/hmchangw/chat/pkg/health"
 	"github.com/hmchangw/chat/pkg/jobguard"
 	"github.com/hmchangw/chat/pkg/logctx"
+	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
 	"github.com/hmchangw/chat/pkg/msgbucket"
 	"github.com/hmchangw/chat/pkg/natsutil"
@@ -181,7 +183,19 @@ func main() {
 	// for a one-shot job). Its batches are transformed + written straight to
 	// Cassandra — never re-published, so broadcast/notification stay silent;
 	// search-sync indexes off the same .teams.batch subject.
-	teamsMigration := newTeamsBatchHandler(store, newMongoHRIdentityStore(db), cfg.SiteID)
+	// The migration only runs against the central site, so cfg.SiteID here is the
+	// central site — the same one HR-sync's own users.upsert publishes to.
+	teamsMigration := newTeamsBatchHandler(store, newMongoHRIdentityStore(db), cfg.SiteID,
+		func(ctx context.Context, users []model.IUserWithChange) error {
+			data, err := json.Marshal(users)
+			if err != nil {
+				return fmt.Errorf("marshal user identity fanout: %w", err)
+			}
+			if _, err := js.PublishMsg(ctx, natsutil.NewMsg(ctx, subject.OrgSyncUsersUpsert(cfg.SiteID), data)); err != nil {
+				return fmt.Errorf("publish user identity fanout: %w", err)
+			}
+			return nil
+		})
 	teamsBatchSubj := subject.MsgCanonicalTeamsBatch(cfg.SiteID)
 
 	go func() {

--- a/message-worker/mock_hridentity_test.go
+++ b/message-worker/mock_hridentity_test.go
@@ -109,17 +109,3 @@ func (mr *MockHRIdentityStoreMockRecorder) FindUserByAccount(ctx, account any) *
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindUserByAccount", reflect.TypeOf((*MockHRIdentityStore)(nil).FindUserByAccount), ctx, account)
 }
-
-// UpsertUserIdentities mocks base method.
-func (m *MockHRIdentityStore) UpsertUserIdentities(ctx context.Context, users []model.IUserWithChange) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpsertUserIdentities", ctx, users)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpsertUserIdentities indicates an expected call of UpsertUserIdentities.
-func (mr *MockHRIdentityStoreMockRecorder) UpsertUserIdentities(ctx, users any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertUserIdentities", reflect.TypeOf((*MockHRIdentityStore)(nil).UpsertUserIdentities), ctx, users)
-}

--- a/message-worker/teamsbatch.go
+++ b/message-worker/teamsbatch.go
@@ -31,9 +31,9 @@ type teamsBatchHandler struct {
 	tr       MessageTransformer
 }
 
-func newTeamsBatchHandler(store Store, hrStore HRIdentityStore, siteID string) *teamsBatchHandler {
+func newTeamsBatchHandler(store Store, hrStore HRIdentityStore, siteID string, publishUsers func(ctx context.Context, users []model.IUserWithChange) error) *teamsBatchHandler {
 	cache, _ := lru.New[string, resolvedSender](teamsSenderCacheSize) // errors only on size<=0
-	resolver := newSenderResolver(hrStore, siteID, cache)
+	resolver := newSenderResolver(hrStore, siteID, cache, publishUsers)
 	return &teamsBatchHandler{
 		store:    store,
 		siteID:   siteID,

--- a/message-worker/teamsbatch_integration_test.go
+++ b/message-worker/teamsbatch_integration_test.go
@@ -39,7 +39,8 @@ func TestTeamsBatch_Integration(t *testing.T) {
 	require.NoError(t, err)
 
 	store := NewCassandraStore(cass, msgbucket.New(24*time.Hour), nil)
-	teams := newTeamsBatchHandler(store, newMongoHRIdentityStore(mongoDB), "site-a")
+	teams := newTeamsBatchHandler(store, newMongoHRIdentityStore(mongoDB), "site-a",
+		func(context.Context, []model.IUserWithChange) error { return nil })
 
 	raw := mustJSON(teamsmigrate.Message{
 		ID: "tm-1", RoomID: "room-1", MessageType: "message",

--- a/message-worker/teamssender.go
+++ b/message-worker/teamssender.go
@@ -7,6 +7,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 
 	"github.com/hmchangw/chat/pkg/displayfmt"
+	"github.com/hmchangw/chat/pkg/idgen"
 	"github.com/hmchangw/chat/pkg/model"
 )
 
@@ -32,21 +33,19 @@ type HRIdentityStore interface {
 	AccountByTeamsID(ctx context.Context, teamsUserID string) (string, error)
 	// FindUserByAccount returns the single user with account (globally unique), or (nil,nil).
 	FindUserByAccount(ctx context.Context, account string) (*model.User, error)
-	// UpsertUserIdentities $sets IDENTITY FIELDS ONLY (siteId, engName, chineseName)
-	// keyed by account; it never touches roles/services/password.
-	UpsertUserIdentities(ctx context.Context, users []model.IUserWithChange) error
 }
 
 // senderResolver reuses the #70 HR store to map Teams users to nextgen identities.
 // The cache is process-wide (injected), shared across every batch the handler runs.
 type senderResolver struct {
-	store  HRIdentityStore
-	siteID string
-	cache  *lru.Cache[string, resolvedSender]
+	store        HRIdentityStore
+	siteID       string
+	cache        *lru.Cache[string, resolvedSender]
+	publishUsers func(ctx context.Context, users []model.IUserWithChange) error
 }
 
-func newSenderResolver(store HRIdentityStore, siteID string, cache *lru.Cache[string, resolvedSender]) *senderResolver {
-	return &senderResolver{store: store, siteID: siteID, cache: cache}
+func newSenderResolver(store HRIdentityStore, siteID string, cache *lru.Cache[string, resolvedSender], publishUsers func(ctx context.Context, users []model.IUserWithChange) error) *senderResolver {
+	return &senderResolver{store: store, siteID: siteID, cache: cache, publishUsers: publishUsers}
 }
 
 // resolve order: (1) map the AAD id to its account via teams_user — the globally-unique
@@ -79,24 +78,18 @@ func (r *senderResolver) resolve(ctx context.Context, teamsUserID, displayName s
 		return s, nil
 	}
 
-	// Create a keyless external user: displayName lands in chineseName to mirror the HR
-	// mapping (teams-hr-sync writes it there); the upsert mints a fresh UUIDv7 _id.
-	nu := model.User{Account: account, SiteID: r.siteID, ChineseName: displayName}
-	if err := r.store.UpsertUserIdentities(ctx, []model.IUserWithChange{{User: nu}}); err != nil {
-		return resolvedSender{}, fmt.Errorf("upsert user identity: %w", err)
+	// New external user: the publisher owns a deterministic _id (Graph-id hash) so
+	// this person is one identity at every site (hr-sync-worker keys on account).
+	// No employeeId — externals aren't employees. displayName lands in chineseName
+	// to mirror the HR mapping. Nothing is written locally first, so a redelivery
+	// re-derives the same _id instead of splitting the user.
+	id := idgen.DeterministicID([]byte(teamsUserID))
+	nu := model.User{ID: id, Account: account, SiteID: r.siteID, ChineseName: displayName}
+	iuc := model.IUserWithChange{User: nu, ChangeType: model.IChangeTypeNewHire}
+	if err := r.publishUsers(ctx, []model.IUserWithChange{iuc}); err != nil {
+		return resolvedSender{}, fmt.Errorf("publish user identity fanout: %w", err)
 	}
-	// Read back by account so the sender carries the minted UserID; a nil read-back is
-	// defensive-only (the row was just written).
-	created, err := r.store.FindUserByAccount(ctx, account)
-	if err != nil {
-		return resolvedSender{}, fmt.Errorf("read back created identity: %w", err)
-	}
-	var s resolvedSender
-	if created != nil {
-		s = senderFromUser(created)
-	} else {
-		s = resolvedSender{Account: account, ChineseName: displayName, DisplayName: displayfmt.CombineWithFallback("", displayName, account)}
-	}
+	s := senderFromUser(&nu)
 	r.cache.Add(teamsUserID, s)
 	return s, nil
 }

--- a/message-worker/teamssender_test.go
+++ b/message-worker/teamssender_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/hmchangw/chat/pkg/idgen"
 	"github.com/hmchangw/chat/pkg/model"
 )
 
@@ -17,6 +18,16 @@ func testSenderCache(t *testing.T) *lru.Cache[string, resolvedSender] {
 	c, err := lru.New[string, resolvedSender](8)
 	require.NoError(t, err)
 	return c
+}
+
+// noPublish fails the test if the create path (which alone should publish) is
+// hit unexpectedly.
+func noPublish(t *testing.T) func(context.Context, []model.IUserWithChange) error {
+	t.Helper()
+	return func(context.Context, []model.IUserWithChange) error {
+		t.Fatal("publishUsers called unexpectedly")
+		return nil
+	}
 }
 
 func TestSenderResolver_AccountHit(t *testing.T) {
@@ -29,7 +40,7 @@ func TestSenderResolver_AccountHit(t *testing.T) {
 	)
 	// account found → no upsert.
 
-	r := newSenderResolver(store, "s1", testSenderCache(t))
+	r := newSenderResolver(store, "s1", testSenderCache(t), noPublish(t))
 	got, err := r.resolve(context.Background(), "graph-1", "愛麗絲")
 	require.NoError(t, err)
 	assert.Equal(t, "alice", got.Account)
@@ -37,32 +48,41 @@ func TestSenderResolver_AccountHit(t *testing.T) {
 	assert.Equal(t, "Alice 愛麗絲", got.DisplayName) // engName and chineseName combined
 }
 
-func TestSenderResolver_NoUserCreates(t *testing.T) {
+func TestSenderResolver_NoUserPublishesDeterministicIdentity(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockHRIdentityStore(ctrl)
-	created := &model.User{ID: "new-uid", Account: "bob", SiteID: "s1", ChineseName: "Bob"}
-	// Order: account resolved → users miss → upsert (no employeeId) → read back the created row.
+	wantID := idgen.DeterministicID([]byte("graph-2"))
+	// Order: account resolved → users miss → publish (no local write, no read-back).
 	gomock.InOrder(
 		store.EXPECT().AccountByTeamsID(gomock.Any(), "graph-2").Return("bob", nil),
 		store.EXPECT().FindUserByAccount(gomock.Any(), "bob").Return(nil, nil),
-		store.EXPECT().UpsertUserIdentities(gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, users []model.IUserWithChange) error {
-				require.Len(t, users, 1)
-				assert.Equal(t, "bob", users[0].Account)
-				assert.Empty(t, users[0].EmployeeID, "migrated users carry no employeeId")
-				assert.Equal(t, "Bob", users[0].ChineseName)
-				assert.Equal(t, "s1", users[0].SiteID)
-				return nil
-			}),
-		store.EXPECT().FindUserByAccount(gomock.Any(), "bob").Return(created, nil),
 	)
 
-	r := newSenderResolver(store, "s1", testSenderCache(t))
+	var published []model.IUserWithChange
+	publishCalls := 0
+	publish := func(_ context.Context, users []model.IUserWithChange) error {
+		publishCalls++
+		published = users
+		return nil
+	}
+
+	r := newSenderResolver(store, "s1", testSenderCache(t), publish)
 	got, err := r.resolve(context.Background(), "graph-2", "Bob")
 	require.NoError(t, err)
 	assert.Equal(t, "bob", got.Account)
-	assert.Equal(t, "new-uid", got.UserID, "created sender carries the minted UserID")
+	assert.Equal(t, wantID, got.UserID, "sender carries the deterministic _id set by the publisher")
 	assert.Equal(t, "Bob", got.DisplayName)
+
+	// The publisher owns a deterministic _id (Graph-id hash) so every site's
+	// hr-sync-worker converges on the same identity; no employeeId.
+	assert.Equal(t, 1, publishCalls, "the new external user must be fanned out")
+	require.Len(t, published, 1)
+	assert.Equal(t, "bob", published[0].Account)
+	assert.Equal(t, wantID, published[0].ID)
+	assert.Empty(t, published[0].EmployeeID, "externals aren't employees — no employeeId")
+	assert.Equal(t, "Bob", published[0].ChineseName)
+	assert.Equal(t, "s1", published[0].SiteID)
+	assert.Equal(t, model.IChangeTypeNewHire, published[0].ChangeType)
 }
 
 func TestSenderResolver_NoTeamsUserErrors(t *testing.T) {
@@ -70,7 +90,7 @@ func TestSenderResolver_NoTeamsUserErrors(t *testing.T) {
 	store := NewMockHRIdentityStore(ctrl)
 	store.EXPECT().AccountByTeamsID(gomock.Any(), "graph-x").Return("", nil) // no teams_user record
 
-	r := newSenderResolver(store, "s1", testSenderCache(t))
+	r := newSenderResolver(store, "s1", testSenderCache(t), noPublish(t))
 	_, err := r.resolve(context.Background(), "graph-x", "Nobody")
 	require.Error(t, err)
 }
@@ -84,7 +104,7 @@ func TestSenderResolver_CacheHitSkipsStore(t *testing.T) {
 		store.EXPECT().FindUserByAccount(gomock.Any(), "al").Return(&model.User{Account: "al"}, nil).Times(1),
 	)
 
-	r := newSenderResolver(store, "s1", testSenderCache(t))
+	r := newSenderResolver(store, "s1", testSenderCache(t), noPublish(t))
 	for i := 0; i < 2; i++ {
 		got, err := r.resolve(context.Background(), "graph-1", "Al")
 		require.NoError(t, err)
@@ -93,7 +113,7 @@ func TestSenderResolver_CacheHitSkipsStore(t *testing.T) {
 }
 
 func TestSenderResolver_EmptyTeamsIDErrors(t *testing.T) {
-	r := newSenderResolver(NewMockHRIdentityStore(gomock.NewController(t)), "s1", testSenderCache(t))
+	r := newSenderResolver(NewMockHRIdentityStore(gomock.NewController(t)), "s1", testSenderCache(t), noPublish(t))
 	_, err := r.resolve(context.Background(), "", "x")
 	require.Error(t, err)
 }

--- a/room-worker/teamsroomcreate.go
+++ b/room-worker/teamsroomcreate.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/roomkeystore"
 	"github.com/hmchangw/chat/pkg/subject"
-	"github.com/hmchangw/chat/pkg/teamsmigrate"
 )
 
 // processTeamsRoomCreate reconciles each chat in a Teams room-creation batch
@@ -180,11 +179,11 @@ func (h *Handler) resolveMember(ctx context.Context, account, graphID string) (*
 		return nil, fmt.Errorf("get user: %w", err)
 	}
 
-	// _id == employeeId == the deterministic Graph-id hash, so this person is one
-	// identity whether resolved here or via the HR feed, and hr-sync-worker keys
-	// its upsert on the (now non-empty) employeeId.
-	id := teamsmigrate.EmployeeIDFromGraphID(graphID)
-	nu := model.User{ID: id, Account: account, SiteID: h.siteID, EmployeeID: id}
+	// A deterministic _id from the Graph id means this person maps to one identity
+	// at every site (hr-sync-worker keys the upsert on account). No employeeId —
+	// migrated externals aren't employees.
+	id := idgen.DeterministicID([]byte(graphID))
+	nu := model.User{ID: id, Account: account, SiteID: h.siteID}
 	if h.publishUsers != nil {
 		iuc := model.IUserWithChange{User: nu, ChangeType: model.IChangeTypeNewHire}
 		if err := h.publishUsers(ctx, []model.IUserWithChange{iuc}); err != nil {

--- a/room-worker/teamsroomcreate_test.go
+++ b/room-worker/teamsroomcreate_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/hmchangw/chat/pkg/idgen"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/roomkeysender"
 	"github.com/hmchangw/chat/pkg/roomkeystore"
 	"github.com/hmchangw/chat/pkg/subject"
-	"github.com/hmchangw/chat/pkg/teamsmigrate"
 )
 
 func newTeamsTestHandler(t *testing.T, store *MockSubscriptionStore) (*Handler, *[]publishedMsg) {
@@ -66,14 +66,14 @@ func TestProcessTeamsRoomCreate_AddOnly(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
 	h, published := newTeamsTestHandler(t, store)
-	carolID := teamsmigrate.EmployeeIDFromGraphID("aad3")
+	carolID := idgen.DeterministicID([]byte("aad3"))
 	h.publishUsers = func(_ context.Context, users []model.IUserWithChange) error {
 		require.Len(t, users, 1, "only the unknown member is published")
-		// The publisher owns _id == employeeId (deterministic Graph-id hash) so every
-		// site's hr-sync-worker upserts the same identity.
+		// The publisher owns a deterministic _id (Graph-id hash) so every site's
+		// hr-sync-worker upserts the same identity; no employeeId — not an employee.
 		assert.Equal(t, "carol", users[0].Account)
 		assert.Equal(t, carolID, users[0].ID)
-		assert.Equal(t, carolID, users[0].EmployeeID)
+		assert.Empty(t, users[0].EmployeeID, "externals aren't employees — no employeeId")
 		return nil
 	}
 
@@ -288,14 +288,14 @@ func TestResolveMember_PublishesDeterministicIdentity(t *testing.T) {
 	store := NewMockSubscriptionStore(ctrl)
 	h, _ := newTeamsTestHandler(t, store)
 
-	wantID := teamsmigrate.EmployeeIDFromGraphID("aad-erin")
+	wantID := idgen.DeterministicID([]byte("aad-erin"))
 	var fanoutCalled bool
 	h.publishUsers = func(_ context.Context, users []model.IUserWithChange) error {
 		fanoutCalled = true
 		require.Len(t, users, 1)
 		assert.Equal(t, "erin", users[0].Account)
 		assert.Equal(t, wantID, users[0].ID)
-		assert.Equal(t, wantID, users[0].EmployeeID)
+		assert.Empty(t, users[0].EmployeeID, "externals aren't employees — no employeeId")
 		assert.Equal(t, model.IChangeTypeNewHire, users[0].ChangeType)
 		return nil
 	}
@@ -305,7 +305,7 @@ func TestResolveMember_PublishesDeterministicIdentity(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, fanoutCalled)
 	assert.Equal(t, wantID, got.ID)
-	assert.Equal(t, wantID, got.EmployeeID)
+	assert.Empty(t, got.EmployeeID)
 	assert.Equal(t, "site-a", got.SiteID)
 }
 


### PR DESCRIPTION
## Summary

A migrated Teams external user (a sender/member with no HR record) was resolved by writing a user locally **and** publishing a fanout, each site minting its own random `_id` — so the same person split across sites.

Per review, the identity is now publisher-owned and converges:

- The resolver — both the **message sender** (`message-worker`) and the **room-creation member** (`room-worker`) paths — sets a **deterministic `_id`** from the Graph id (`idgen.DeterministicID`) and publishes it. **Nothing is written locally first**, so a redelivery re-derives the same `_id` instead of splitting the user.
- Migrated externals carry **no `employeeId`** — they aren't employees.
- `hr-sync-worker` `UpsertUserIdentities` now upserts by **`account`** (the globally-unique key that covers HR-feed users and externals alike), honoring the publisher-supplied `_id` on insert (empty → mint per-site, unchanged for the HR feed).

Refs #124. Follows up the merged #132 (room-creation consumer) with the identity alignment mliu33 asked for.

## Changes

- `message-worker/teamssender.go` — resolver sets deterministic `_id`, no `employeeId`, publish-first, no local write; removes the now-dead local `UpsertUserIdentities` (interface, impl `hridentity.go`, mock).
- `room-worker/teamsroomcreate.go` — same in `resolveMember`: deterministic `_id`, no `employeeId`.
- `hr-sync-worker/store.go` — `UpsertUserIdentities` keys on `account` (was `employeeId`); sets `employeeId` only when present; `$setOnInsert` honors the published `_id`.

## NATS subjects

- Publishes: `chat.hr.{siteID}.users.upsert` (external-user fanout, publish-first). Consumed by every site's `hr-sync-worker`.

## Verification

- `chat-lint` 0 issues; `gosec` (matches CI sast) clean; `message-worker` + `room-worker` + `hr-sync-worker` unit tests green; integration tests compile (`go vet -tags integration`), including an `hr-sync-worker` integration case asserting a migrated external (no `employeeId`) is upserted account-keyed with the publisher-supplied `_id` honored, and an empty-account row skipped.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Teams migration identity handling with stable user identities.
  * Newly discovered external users are published for synchronization and retain normalized employee information.
* **Bug Fixes**
  * Existing identities are updated instead of duplicated.
  * Records without required account information are skipped.
  * Migrated external users no longer receive an employee ID incorrectly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->