### PR TITLE
refactor(user): replace deactivated flag with active *bool (missing = active)

### DIFF
--- a/admin-frontend/src/api/admin/admin.test.ts
+++ b/admin-frontend/src/api/admin/admin.test.ts
@@ -33,7 +33,7 @@ const USER = {
   engName: 'Alice',
   chineseName: '爱丽丝',
   roles: ['admin'],
-  deactivated: false,
+  active: true,
   requirePasswordChange: false,
 }
 
@@ -67,7 +67,7 @@ describe('listUsers', () => {
     expect(url).toBe('http://localhost:8082/v1/admin/users')
   })
 
-  it('defaults roles/deactivated/requirePasswordChange when the server omits zero-valued fields', async () => {
+  it('defaults roles/active/requirePasswordChange when the server omits zero-valued fields', async () => {
     stubFetch(200, {
       users: [{ id: 'u-2', account: 'bob', siteId: 'site-1' }],
       total: 1,
@@ -82,7 +82,7 @@ describe('listUsers', () => {
       engName: '',
       chineseName: '',
       roles: [],
-      deactivated: false,
+      active: true,
       requirePasswordChange: false,
     })
   })
@@ -171,13 +171,13 @@ describe('updateUser', () => {
   it('PATCHes /v1/admin/users/:account with the partial patch body', async () => {
     const fetchMock = stubFetch(200, { status: 'ok' })
 
-    await updateUser('tok', 'u-1', { deactivated: true })
+    await updateUser('tok', 'u-1', { active: false })
 
     const [url, init] = fetchMock.mock.calls[0]
     expect(url).toBe('http://localhost:8082/v1/admin/users/u-1')
     expect(init.method).toBe('PATCH')
     expect(init.headers.Authorization).toBe('Bearer tok')
-    expect(JSON.parse(init.body)).toEqual({ deactivated: true })
+    expect(JSON.parse(init.body)).toEqual({ active: false })
   })
 })
 

--- a/admin-frontend/src/api/admin/index.ts
+++ b/admin-frontend/src/api/admin/index.ts
@@ -13,7 +13,7 @@ export interface AdminUser {
   engName: string
   chineseName: string
   roles: string[]
-  deactivated: boolean
+  active: boolean
   requirePasswordChange: boolean
 }
 
@@ -58,7 +58,7 @@ export interface UpdateUserPatch {
   engName?: string
   chineseName?: string
   roles?: string[]
-  deactivated?: boolean
+  active?: boolean
 }
 
 export interface SetPasswordInput {
@@ -83,7 +83,7 @@ interface UserViewWire {
   engName?: string
   chineseName?: string
   roles?: string[]
-  deactivated?: boolean
+  active?: boolean
   requirePasswordChange?: boolean
 }
 
@@ -95,7 +95,7 @@ function normalizeUser(raw: UserViewWire): AdminUser {
     engName: raw.engName ?? '',
     chineseName: raw.chineseName ?? '',
     roles: raw.roles ?? [],
-    deactivated: raw.deactivated ?? false,
+    active: raw.active ?? true,
     requirePasswordChange: raw.requirePasswordChange ?? false,
   }
 }

--- a/admin-frontend/src/components/UsersConsole/EditUserDialog/EditUserDialog.jsx
+++ b/admin-frontend/src/components/UsersConsole/EditUserDialog/EditUserDialog.jsx
@@ -16,7 +16,7 @@ export default function EditUserDialog({ authToken, user, onClose, onUpdated }) 
   const [engName, setEngName] = useState(user.engName)
   const [chineseName, setChineseName] = useState(user.chineseName)
   const [roles, setRoles] = useState(user.roles)
-  const [active, setActive] = useState(user.active)
+  const [deactivated, setDeactivated] = useState(!user.active)
   const [confirmingDeactivate, setConfirmingDeactivate] = useState(false)
   const [error, setError] = useState(null)
   const [submitting, setSubmitting] = useState(false)
@@ -34,7 +34,7 @@ export default function EditUserDialog({ authToken, user, onClose, onUpdated }) 
     if (trimmedEngName !== user.engName) patch.engName = trimmedEngName
     if (trimmedChineseName !== user.chineseName) patch.chineseName = trimmedChineseName
     if (!sameRoles(roles, user.roles)) patch.roles = roles
-    if (active !== user.active) patch.active = active
+    if (deactivated !== !user.active) patch.active = !deactivated
     return patch
   }
 
@@ -110,10 +110,10 @@ export default function EditUserDialog({ authToken, user, onClose, onUpdated }) 
         <label className="dialog-checkbox">
           <input
             type="checkbox"
-            checked={!active}
+            checked={deactivated}
             onChange={(e) => {
               setConfirmingDeactivate(false)
-              setActive(!e.target.checked)
+              setDeactivated(e.target.checked)
             }}
             disabled={submitting}
           />

--- a/admin-frontend/src/components/UsersConsole/EditUserDialog/EditUserDialog.jsx
+++ b/admin-frontend/src/components/UsersConsole/EditUserDialog/EditUserDialog.jsx
@@ -16,7 +16,7 @@ export default function EditUserDialog({ authToken, user, onClose, onUpdated }) 
   const [engName, setEngName] = useState(user.engName)
   const [chineseName, setChineseName] = useState(user.chineseName)
   const [roles, setRoles] = useState(user.roles)
-  const [deactivated, setDeactivated] = useState(user.deactivated)
+  const [active, setActive] = useState(user.active)
   const [confirmingDeactivate, setConfirmingDeactivate] = useState(false)
   const [error, setError] = useState(null)
   const [submitting, setSubmitting] = useState(false)
@@ -34,7 +34,7 @@ export default function EditUserDialog({ authToken, user, onClose, onUpdated }) 
     if (trimmedEngName !== user.engName) patch.engName = trimmedEngName
     if (trimmedChineseName !== user.chineseName) patch.chineseName = trimmedChineseName
     if (!sameRoles(roles, user.roles)) patch.roles = roles
-    if (deactivated !== user.deactivated) patch.deactivated = deactivated
+    if (active !== user.active) patch.active = active
     return patch
   }
 
@@ -59,7 +59,7 @@ export default function EditUserDialog({ authToken, user, onClose, onUpdated }) 
       onClose()
       return
     }
-    if (patch.deactivated === true && !confirmingDeactivate) {
+    if (patch.active === false && !confirmingDeactivate) {
       setConfirmingDeactivate(true)
       return
     }
@@ -110,10 +110,10 @@ export default function EditUserDialog({ authToken, user, onClose, onUpdated }) 
         <label className="dialog-checkbox">
           <input
             type="checkbox"
-            checked={deactivated}
+            checked={!active}
             onChange={(e) => {
               setConfirmingDeactivate(false)
-              setDeactivated(e.target.checked)
+              setActive(!e.target.checked)
             }}
             disabled={submitting}
           />

--- a/admin-frontend/src/components/UsersConsole/EditUserDialog/EditUserDialog.test.jsx
+++ b/admin-frontend/src/components/UsersConsole/EditUserDialog/EditUserDialog.test.jsx
@@ -18,7 +18,7 @@ const USER = {
   engName: 'Alice',
   chineseName: '',
   roles: ['user'],
-  deactivated: false,
+  active: true,
   requirePasswordChange: false,
 }
 
@@ -51,22 +51,22 @@ describe('EditUserDialog', () => {
     expect(updateUser).not.toHaveBeenCalled()
     expect(screen.getByText(/confirm/i)).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
-    await waitFor(() => expect(updateUser).toHaveBeenCalledWith('tok', 'alice', { deactivated: true }))
+    await waitFor(() => expect(updateUser).toHaveBeenCalledWith('tok', 'alice', { active: false }))
   })
 
-  it('does not require confirmation when reactivating an already-deactivated user', async () => {
+  it('does not require confirmation when reactivating an inactive user', async () => {
     updateUser.mockResolvedValue(undefined)
     render(
       <EditUserDialog
         authToken="tok"
-        user={{ ...USER, deactivated: true }}
+        user={{ ...USER, active: false }}
         onClose={vi.fn()}
         onUpdated={vi.fn()}
       />,
     )
     fireEvent.click(screen.getByRole('checkbox', { name: /^deactivated$/i }))
     fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
-    await waitFor(() => expect(updateUser).toHaveBeenCalledWith('tok', 'alice', { deactivated: false }))
+    await waitFor(() => expect(updateUser).toHaveBeenCalledWith('tok', 'alice', { active: true }))
   })
 
   it('logs the admin out instead of showing a banner on invalid_token', async () => {

--- a/admin-frontend/src/components/UsersConsole/SessionsDialog/SessionsDialog.test.jsx
+++ b/admin-frontend/src/components/UsersConsole/SessionsDialog/SessionsDialog.test.jsx
@@ -18,7 +18,7 @@ const USER = {
   engName: '',
   chineseName: '',
   roles: [],
-  deactivated: false,
+  active: true,
   requirePasswordChange: false,
 }
 

--- a/admin-frontend/src/components/UsersConsole/SetPasswordDialog/SetPasswordDialog.test.jsx
+++ b/admin-frontend/src/components/UsersConsole/SetPasswordDialog/SetPasswordDialog.test.jsx
@@ -18,7 +18,7 @@ const USER = {
   engName: '',
   chineseName: '',
   roles: [],
-  deactivated: false,
+  active: true,
   requirePasswordChange: false,
 }
 

--- a/admin-frontend/src/components/UsersConsole/UserTable/UserTable.jsx
+++ b/admin-frontend/src/components/UsersConsole/UserTable/UserTable.jsx
@@ -30,10 +30,10 @@ export default function UserTable({ users, loading, onEdit, onSetPassword, onSes
             <td>
               <span
                 className={`users-status-badge ${
-                  user.deactivated ? 'is-deactivated' : 'is-active'
+                  user.active ? 'is-active' : 'is-inactive'
                 }`}
               >
-                {user.deactivated ? 'Deactivated' : 'Active'}
+                {user.active ? 'Active' : 'Deactivated'}
               </span>
             </td>
             <td className="users-table-actions">

--- a/admin-frontend/src/components/UsersConsole/UserTable/style.css
+++ b/admin-frontend/src/components/UsersConsole/UserTable/style.css
@@ -36,7 +36,7 @@
   color: var(--status-success);
 }
 
-.users-status-badge.is-deactivated {
+.users-status-badge.is-inactive {
   background: var(--status-error-bg);
   color: var(--status-error);
 }

--- a/admin-frontend/src/components/UsersConsole/UsersPage/UsersPage.test.jsx
+++ b/admin-frontend/src/components/UsersConsole/UsersPage/UsersPage.test.jsx
@@ -38,7 +38,7 @@ const USER = {
   engName: 'Alice',
   chineseName: '爱丽丝',
   roles: ['admin'],
-  deactivated: false,
+  active: true,
   requirePasswordChange: false,
 }
 

--- a/admin-service/handler.go
+++ b/admin-service/handler.go
@@ -56,7 +56,7 @@ type userView struct {
 	StatusText            string           `json:"statusText,omitempty"`
 	Roles                 []model.UserRole `json:"roles,omitempty"`
 	RequirePasswordChange bool             `json:"requirePasswordChange,omitempty"`
-	Deactivated           bool             `json:"deactivated,omitempty"`
+	Active                bool             `json:"active"`
 }
 
 // toView converts a model.User to the projected userView (no Services/bcrypt).
@@ -80,7 +80,7 @@ func toView(u *model.User) userView {
 		StatusText:            u.StatusText,
 		Roles:                 u.Roles,
 		RequirePasswordChange: u.RequirePasswordChange,
-		Deactivated:           u.Deactivated,
+		Active:                u.IsActive(),
 	}
 }
 
@@ -247,7 +247,7 @@ type updateUserRequest struct {
 	EngName     *string           `json:"engName"`
 	ChineseName *string           `json:"chineseName"`
 	Roles       *[]model.UserRole `json:"roles"`
-	Deactivated *bool             `json:"deactivated"`
+	Active      *bool             `json:"active"`
 }
 
 // updateUser handles PATCH /v1/admin/users/:account — applies partial updates to a user.
@@ -267,16 +267,16 @@ func (h *Handler) updateUser(c *gin.Context) {
 	// leave a disabled account with a still-valid session. Every other patch
 	// (name/roles) stays a plain, non-transactional update.
 	//
-	// Mixing deactivated=true with other field edits in the same PATCH is
+	// Mixing active=false with other field edits in the same PATCH is
 	// rejected: the deactivate branch would silently drop the other fields,
 	// and the client (admin console) sends deactivation as a distinct action,
-	// so mixed patches indicate a client bug. Reactivation (deactivated=false)
+	// so mixed patches indicate a client bug. Reactivation (active=true)
 	// combined with other fields goes through the normal UpdateUser branch
 	// below — no session revoke needed.
-	if req.Deactivated != nil && *req.Deactivated {
+	if req.Active != nil && !*req.Active {
 		if req.EngName != nil || req.ChineseName != nil || req.Roles != nil {
 			errhttp.Write(ctx, c, errcode.BadRequest(
-				"deactivated=true cannot be combined with other field updates in a single PATCH",
+				"active=false cannot be combined with other field updates in a single PATCH",
 				errcode.WithReason(errcode.AdminMixedDeactivatePatch)))
 			return
 		}
@@ -303,8 +303,8 @@ func (h *Handler) updateUser(c *gin.Context) {
 	}
 
 	details := map[string]string{}
-	if req.Deactivated != nil {
-		details["deactivated"] = strconv.FormatBool(*req.Deactivated)
+	if req.Active != nil {
+		details["active"] = strconv.FormatBool(*req.Active)
 	}
 	h.audit(ctx, c, "user.update", "", account, details)
 

--- a/admin-service/handler_test.go
+++ b/admin-service/handler_test.go
@@ -479,6 +479,26 @@ func TestHandler_getUser(t *testing.T) {
 				assertNoSecret(t, raw)
 				assert.Equal(t, "u1", body["id"])
 				assert.Equal(t, "alice", body["account"])
+				assert.Equal(t, true, body["active"], "missing active field must read as active")
+				_, has := body["deactivated"]
+				assert.False(t, has, "deactivated must be gone from the wire")
+			},
+		},
+		{
+			name:   "inactive user – active=false in view",
+			userID: "u1b",
+			setupMock: func(m *MockAdminStore) {
+				inactive := false
+				m.EXPECT().GetUserByAccount(gomock.Any(), "site-A", "u1b").Return(&model.User{
+					ID:      "u1b",
+					Account: "mallory",
+					SiteID:  "site-A",
+					Active:  &inactive,
+				}, nil)
+			},
+			wantStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body map[string]any, raw []byte) {
+				assert.Equal(t, false, body["active"])
 			},
 		},
 		{
@@ -556,17 +576,17 @@ func TestHandler_updateUser(t *testing.T) {
 			wantStatus: http.StatusOK,
 		},
 		{
-			name:   "deactivating user – atomic DeactivateAndRevoke",
+			name:   "deactivating user (active=false) – atomic DeactivateAndRevoke",
 			userID: "u2",
 			body: map[string]any{
-				"deactivated": true,
+				"active": false,
 			},
 			setupMock: func(m *MockAdminStore) {
 				m.EXPECT().DeactivateAndRevoke(gomock.Any(), "site-A", "u2").Return(nil)
 				m.EXPECT().AppendAudit(gomock.Any(), gomock.Any()).
 					DoAndReturn(func(_ context.Context, e *AuditEntry) error {
 						assert.Equal(t, "user.update", e.Action)
-						assert.Equal(t, "true", e.Details["deactivated"])
+						assert.Equal(t, "false", e.Details["active"])
 						return nil
 					})
 			},
@@ -609,10 +629,10 @@ func TestHandler_updateUser(t *testing.T) {
 			wantReason: string(errcode.AdminUserNotFound),
 		},
 		{
-			name:   "deactivated=false – plain update",
+			name:   "active=true – plain update (reactivate)",
 			userID: "u5",
 			body: map[string]any{
-				"deactivated": false,
+				"active": true,
 			},
 			setupMock: func(m *MockAdminStore) {
 				m.EXPECT().UpdateUser(gomock.Any(), "site-A", "u5", gomock.Any()).Return(nil)
@@ -621,13 +641,13 @@ func TestHandler_updateUser(t *testing.T) {
 			wantStatus: http.StatusOK,
 		},
 		{
-			name:   "deactivated=true with explicit pointer serialised",
+			name:   "active=false with explicit pointer serialised",
 			userID: "u6",
 			body: func() map[string]any {
 				type body struct {
-					Deactivated *bool `json:"deactivated"`
+					Active *bool `json:"active"`
 				}
-				b, _ := json.Marshal(body{Deactivated: &trueVal})
+				b, _ := json.Marshal(body{Active: &falseVal})
 				var m map[string]any
 				_ = json.Unmarshal(b, &m)
 				return m
@@ -639,11 +659,11 @@ func TestHandler_updateUser(t *testing.T) {
 			wantStatus: http.StatusOK,
 		},
 		{
-			name:   "deactivated=true + engName rejected as mixed patch",
+			name:   "active=false + engName rejected as mixed patch",
 			userID: "u7",
 			body: map[string]any{
-				"deactivated": true,
-				"engName":     "Would Be Dropped",
+				"active":  false,
+				"engName": "Would Be Dropped",
 			},
 			// no DeactivateAndRevoke / UpdateUser / AppendAudit — must reject before any write
 			setupMock:  func(m *MockAdminStore) {},
@@ -651,25 +671,25 @@ func TestHandler_updateUser(t *testing.T) {
 			wantReason: string(errcode.AdminMixedDeactivatePatch),
 		},
 		{
-			name:   "deactivated=true + roles rejected as mixed patch",
+			name:   "active=false + roles rejected as mixed patch",
 			userID: "u8",
 			body: map[string]any{
-				"deactivated": true,
-				"roles":       []string{"admin"},
+				"active": false,
+				"roles":  []string{"admin"},
 			},
 			setupMock:  func(m *MockAdminStore) {},
 			wantStatus: http.StatusBadRequest,
 			wantReason: string(errcode.AdminMixedDeactivatePatch),
 		},
 		{
-			name:   "deactivated=false + engName still goes through UpdateUser (reactivate + edit is fine)",
+			name:   "active=true + engName still goes through UpdateUser (reactivate + edit is fine)",
 			userID: "u9",
 			body: func() map[string]any {
 				type body struct {
-					Deactivated *bool  `json:"deactivated"`
-					EngName     string `json:"engName"`
+					Active  *bool  `json:"active"`
+					EngName string `json:"engName"`
 				}
-				b, _ := json.Marshal(body{Deactivated: &falseVal, EngName: "Reactivated Rita"})
+				b, _ := json.Marshal(body{Active: &trueVal, EngName: "Reactivated Rita"})
 				var m map[string]any
 				_ = json.Unmarshal(b, &m)
 				return m
@@ -725,7 +745,7 @@ func TestHandler_updateUser_DeactivateAndRevoke_TxError_Returns500(t *testing.T)
 	r := setupRouter(h)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPatch, "/users/u2b", bodyBytes(t, map[string]any{"deactivated": true}))
+	req := httptest.NewRequest(http.MethodPatch, "/users/u2b", bodyBytes(t, map[string]any{"active": false}))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
 

--- a/admin-service/integration_test.go
+++ b/admin-service/integration_test.go
@@ -198,17 +198,17 @@ func TestIntegration_UpdateUser(t *testing.T) {
 		assert.Equal(t, []model.UserRole{model.UserRoleAdmin}, got.Roles)
 	})
 
-	t.Run("update deactivated on this path does not touch sessions (handler routes Deactivated=true to DeactivateAndRevoke instead)", func(t *testing.T) {
+	t.Run("update active on this path does not touch sessions (handler routes active=false to DeactivateAndRevoke instead)", func(t *testing.T) {
 		sessStore := session.NewMongoStore(db)
 		seedSession(t, db, session.Session{ID: "eve-sess-1", UserID: u.ID, Account: u.Account, SiteID: "site-a", IssuedAt: 1})
 
-		deact := true
-		err := st.UpdateUser(ctx, "site-a", u.Account, UserUpdate{Deactivated: &deact})
+		inactive := false
+		err := st.UpdateUser(ctx, "site-a", u.Account, UserUpdate{Active: &inactive})
 		require.NoError(t, err)
 
 		got, err := st.GetUserByAccount(ctx, "site-a", u.Account)
 		require.NoError(t, err)
-		assert.True(t, got.Deactivated)
+		assert.False(t, got.IsActive())
 
 		sessions, err := sessStore.ListForAccount(ctx, "site-a", u.Account)
 		require.NoError(t, err)
@@ -343,7 +343,7 @@ func TestIntegration_DeactivateAndRevoke(t *testing.T) {
 	}
 	require.NoError(t, st.CreateUser(ctx, u))
 
-	t.Run("sets deactivated=true and kills every session for the account atomically", func(t *testing.T) {
+	t.Run("sets active=false and kills every session for the account atomically", func(t *testing.T) {
 		sessStore := session.NewMongoStore(db)
 		seedSession(t, db, session.Session{ID: "gwen-sess-1", UserID: u.ID, Account: u.Account, SiteID: "site-a", IssuedAt: 1})
 		seedSession(t, db, session.Session{ID: "gwen-sess-2", UserID: u.ID, Account: u.Account, SiteID: "site-a", IssuedAt: 2})
@@ -352,13 +352,14 @@ func TestIntegration_DeactivateAndRevoke(t *testing.T) {
 		require.NoError(t, err)
 
 		var raw struct {
-			Deactivated bool `bson:"deactivated"`
+			Active *bool `bson:"active"`
 		}
 		err = db.Collection("users").FindOne(ctx, bson.M{"_id": u.ID},
-			options.FindOne().SetProjection(bson.M{"deactivated": 1}),
+			options.FindOne().SetProjection(bson.M{"active": 1}),
 		).Decode(&raw)
 		require.NoError(t, err)
-		assert.True(t, raw.Deactivated)
+		require.NotNil(t, raw.Active, "deactivation must write an explicit active:false")
+		assert.False(t, *raw.Active)
 
 		sessions, err := sessStore.ListForAccount(ctx, "site-a", u.Account)
 		require.NoError(t, err)

--- a/admin-service/login.go
+++ b/admin-service/login.go
@@ -91,9 +91,9 @@ func (h *Handler) handleLogin(c *gin.Context) {
 		return
 	}
 
-	// Deactivated check after password verify — keeps timing indistinguishable
+	// Active check after password verify — keeps timing indistinguishable
 	// from wrong-password, so bots can't probe accounts.
-	if u.Deactivated {
+	if !u.IsActive() {
 		h.loginDenied(c, ctx, req.Username)
 		return
 	}

--- a/admin-service/login_test.go
+++ b/admin-service/login_test.go
@@ -141,15 +141,16 @@ func TestHandleLogin_InvalidCredentials_Cases(t *testing.T) {
 			body: map[string]string{"username": "p_alice", "password": "wrong"},
 		},
 		{
-			name: "deactivated admin",
+			name: "inactive admin",
 			setup: func(t *testing.T) (AdminStore, session.Store) {
 				ctrl := gomock.NewController(t)
 				st := NewMockAdminStore(ctrl)
+				inactive := false
 				st.EXPECT().GetUserForAuth(gomock.Any(), "site-a", "p_alice").Return(&model.User{
 					ID: "u1", Account: "p_alice", SiteID: "site-a",
-					Roles:       []model.UserRole{model.UserRoleAdmin},
-					Deactivated: true,
-					Services:    model.Services{Password: model.PasswordCredentials{Bcrypt: mustHash(t, "right")}},
+					Roles:    []model.UserRole{model.UserRoleAdmin},
+					Active:   &inactive,
+					Services: model.Services{Password: model.PasswordCredentials{Bcrypt: mustHash(t, "right")}},
 				}, nil)
 				return st, &fakeSessionStore{}
 			},

--- a/admin-service/store.go
+++ b/admin-service/store.go
@@ -17,7 +17,7 @@ type UserUpdate struct {
 	EngName     *string
 	ChineseName *string
 	Roles       *[]model.UserRole
-	Deactivated *bool
+	Active      *bool
 }
 
 // AuditEntry records one mutating admin action. Details holds non-secret context
@@ -48,7 +48,7 @@ type AdminStore interface {
 	GetUserByAccount(ctx context.Context, siteID, account string) (*model.User, error)
 	// GetUserForAuth loads a user for password-verification paths (login and
 	// self-service change-password). Returns credential fields (services.password.bcrypt,
-	// roles, deactivated, requirePasswordChange, id, siteId, account) — the ONLY
+	// roles, active, requirePasswordChange, id, siteId, account) — the ONLY
 	// reads of the bcrypt hash in this service. Never call from admin management
 	// endpoints; those must use GetUserByAccount which scrubs the hash.
 	GetUserForAuth(ctx context.Context, siteID, account string) (*model.User, error)
@@ -63,7 +63,7 @@ type AdminStore interface {
 	// writes run in a single Mongo transaction — requires a replica set.
 	UpdateUserPasswordAndRevoke(ctx context.Context, siteID, account, bcryptHash string, requireChange bool, exceptSessionID string) error
 
-	// DeactivateAndRevoke atomically sets deactivated=true on the user AND
+	// DeactivateAndRevoke atomically sets active=false on the user AND
 	// deletes every session for the account. Runs in one Mongo transaction.
 	// Called only for the deactivate branch of updateUser; other UpdateUser
 	// patches (name/roles) stay non-transactional.

--- a/admin-service/store_mongo.go
+++ b/admin-service/store_mongo.go
@@ -77,7 +77,7 @@ var userProjection = bson.M{
 	"statusText":            1,
 	"roles":                 1,
 	"requirePasswordChange": 1,
-	"deactivated":           1,
+	"active":                1,
 }
 
 func (s *storeMongo) SearchUsers(ctx context.Context, siteID, q string, page, limit int) ([]model.User, int64, error) {
@@ -143,7 +143,7 @@ var userAuthProjection = bson.M{
 	"siteId":                1,
 	"roles":                 1,
 	"requirePasswordChange": 1,
-	"deactivated":           1,
+	"active":                1,
 	"services":              1,
 }
 
@@ -184,8 +184,8 @@ func (s *storeMongo) UpdateUser(ctx context.Context, siteID, account string, fie
 	if fields.Roles != nil {
 		set["roles"] = *fields.Roles
 	}
-	if fields.Deactivated != nil {
-		set["deactivated"] = *fields.Deactivated
+	if fields.Active != nil {
+		set["active"] = *fields.Active
 	}
 	if len(set) == 0 {
 		return nil
@@ -194,7 +194,7 @@ func (s *storeMongo) UpdateUser(ctx context.Context, siteID, account string, fie
 	filter := bson.M{"account": account, "siteId": siteID}
 
 	// Deactivation no longer flows through UpdateUser — the handler routes
-	// Deactivated=true to DeactivateAndRevoke instead so the user-flag flip
+	// active=false to DeactivateAndRevoke instead so the user-flag flip
 	// and session-purge run in one Mongo transaction. UpdateUser stays
 	// non-transactional for the remaining patch fields (roles, names).
 	result, err := s.users.UpdateOne(ctx, filter, bson.M{"$set": set})
@@ -256,14 +256,14 @@ func (s *storeMongo) UpdateUserPasswordAndRevoke(ctx context.Context, siteID, ac
 	})
 }
 
-// DeactivateAndRevoke atomically sets deactivated=true on the user and
+// DeactivateAndRevoke atomically sets active=false on the user and
 // deletes every session for the account, so a disabled account can't keep a
 // live token. Requires a replica set.
 func (s *storeMongo) DeactivateAndRevoke(ctx context.Context, siteID, account string) error {
 	filter := bson.M{"account": account, "siteId": siteID}
 
 	return s.withTransaction(ctx, func(ctx context.Context) error {
-		result, err := s.users.UpdateOne(ctx, filter, bson.M{"$set": bson.M{"deactivated": true}})
+		result, err := s.users.UpdateOne(ctx, filter, bson.M{"$set": bson.M{"active": false}})
 		if err != nil {
 			return fmt.Errorf("deactivate user: %w", err)
 		}

--- a/botplatform-service/handler.go
+++ b/botplatform-service/handler.go
@@ -122,8 +122,8 @@ func (h *handler) HandleLogin(c *gin.Context) {
 		return
 	}
 
-	// Deactivation check runs after password verify so timing matches wrong-password.
-	if u.Deactivated {
+	// Active check runs after password verify so timing matches wrong-password.
+	if !u.IsActive() {
 		h.denied(c, ctx, req.Username, "invalid_credentials")
 		return
 	}
@@ -166,7 +166,7 @@ func (h *handler) HandleLogin(c *gin.Context) {
 				ID:                    u.ID,
 				Username:              u.Account,
 				Name:                  u.DisplayName(),
-				Active:                !u.Deactivated,
+				Active:                u.IsActive(),
 				Roles:                 roleStrs,
 				RequirePasswordChange: u.RequirePasswordChange,
 			},

--- a/botplatform-service/handler_test.go
+++ b/botplatform-service/handler_test.go
@@ -402,13 +402,14 @@ func TestHandleLogin_UniformErrorBody_NoEnumeration(t *testing.T) {
 			username: "alice", password: "secret",
 		},
 		{
-			name: "deactivated account",
+			name: "inactive account",
 			setupMock: func(st *MockBotplatformStore) {
+				inactive := false
 				u := &model.User{
 					ID: "u2", Account: "deact.uniform.bot", SiteID: "site-a",
-					Roles:       []model.UserRole{model.UserRoleBot},
-					Services:    model.Services{Password: model.PasswordCredentials{Bcrypt: bcryptOf(t, "correct")}},
-					Deactivated: true,
+					Roles:    []model.UserRole{model.UserRoleBot},
+					Services: model.Services{Password: model.PasswordCredentials{Bcrypt: bcryptOf(t, "correct")}},
+					Active:   &inactive,
 				}
 				st.EXPECT().FindUserByAccount(gomock.Any(), "deact.uniform.bot").Return(u, nil)
 			},
@@ -472,16 +473,18 @@ func TestSessionHash_Stable(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestHandleLogin_DeactivatedAccountRejected verifies that a deactivated
-// account with otherwise-valid credentials (correct role, site, and password)
-// is rejected with the same uniform 401 invalid_credentials as wrong-password /
-// unknown-account, and that no session is inserted. It also verifies that an
-// active (non-deactivated) account's login response carries me.active == true.
-func TestHandleLogin_DeactivatedAccountRejected(t *testing.T) {
-	t.Run("deactivated account returns uniform 401, no session", func(t *testing.T) {
+// TestHandleLogin_InactiveAccountRejected verifies that an inactive account
+// (stored active:false) with otherwise-valid credentials (correct role, site,
+// and password) is rejected with the same uniform 401 invalid_credentials as
+// wrong-password / unknown-account, and that no session is inserted. It also
+// verifies that an account with no stored active field counts as active and
+// its login response carries me.active == true.
+func TestHandleLogin_InactiveAccountRejected(t *testing.T) {
+	t.Run("inactive account returns uniform 401, no session", func(t *testing.T) {
 		r, st, _ := newTestRouter(t)
 		u := botUser(t, "deact0000000000ab", "deact.bot", "site-a", "correct")
-		u.Deactivated = true
+		inactive := false
+		u.Active = &inactive
 		st.EXPECT().FindUserByAccount(gomock.Any(), "deact.bot").Return(u, nil)
 		// No InsertSession call expected — must be rejected before session creation.
 
@@ -490,13 +493,13 @@ func TestHandleLogin_DeactivatedAccountRejected(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "invalid_credentials")
 	})
 
-	t.Run("active account me.active is true", func(t *testing.T) {
+	t.Run("missing active field counts as active — me.active is true", func(t *testing.T) {
 		rawToken := strings.Repeat("m", 43)
 		r, st, h := newTestRouter(t)
 		h.tokenGen = fixedTokenGen(rawToken)
 		h.now = stubClock(1)
 		u := botUser(t, "active000000000ab", "active.bot", "site-a", "correct")
-		// Deactivated defaults to false — active account.
+		// Active stays nil — a missing field must read as active.
 		st.EXPECT().FindUserByAccount(gomock.Any(), "active.bot").Return(u, nil)
 		st.EXPECT().InsertSession(gomock.Any(), gomock.Any()).Return(nil)
 		st.EXPECT().DeleteSessionsBeyondCap(gomock.Any(), u.Account, 100).Return(int64(0), nil)
@@ -506,6 +509,6 @@ func TestHandleLogin_DeactivatedAccountRejected(t *testing.T) {
 
 		var resp loginResponse
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		assert.True(t, resp.Data.Me.Active, "me.active must be true for a non-deactivated account")
+		assert.True(t, resp.Data.Me.Active, "me.active must be true when the stored field is absent")
 	})
 }

--- a/botplatform-service/store_mongo.go
+++ b/botplatform-service/store_mongo.go
@@ -36,7 +36,7 @@ func (s *storeMongo) FindUserByAccount(ctx context.Context, account string) (*mo
 			"roles":                 1,
 			"requirePasswordChange": 1,
 			"services.password":     1,
-			"deactivated":           1,
+			"active":                1,
 		})).Decode(&u)
 	if err != nil {
 		return nil, fmt.Errorf("find user by account: %w", err)

--- a/docs/active-field-backfill.md
+++ b/docs/active-field-backfill.md
@@ -1,0 +1,47 @@
+# One-time backfill: `users.deactivated` → `users.active`
+
+**Required alongside the deploy of the active-field migration** (the PR that
+replaced `model.User.Deactivated` with `Active *bool`). Run once per site,
+against each site's operational MongoDB.
+
+## Why
+
+Before the migration, deactivations performed through admin-service wrote
+`deactivated: true`. After it, every reader (admin-service, botplatform-service,
+media-service, user-service) looks only at `active`, where a missing field means
+**active**. Without this backfill, any account disabled via the old admin path
+is silently reactivated.
+
+## Commands (mongosh, per site database)
+
+```js
+// Preserve old deactivations under the new field, drop the old one.
+db.users.updateMany(
+  { deactivated: true },
+  { $set: { active: false }, $unset: { deactivated: "" } }
+)
+
+// Clean up any remaining deactivated:false leftovers.
+db.users.updateMany(
+  { deactivated: { $exists: true } },
+  { $unset: { deactivated: "" } }
+)
+```
+
+Both commands are idempotent — safe to re-run. Order matters only in that the
+first must run before the second (the second would otherwise discard
+`deactivated: true` markers before they are converted).
+
+## Verification
+
+```js
+db.users.countDocuments({ deactivated: { $exists: true } }) // must be 0
+db.users.countDocuments({ active: false })                  // == previously deactivated accounts
+```
+
+## Timing
+
+Running it **before** the deploy is also safe: pre-migration user-service
+already filters on `active: {$ne: false}`, and the old admin-service only ever
+read `deactivated` for accounts it had itself deactivated. Run it after the
+deploy only if no admin deactivations happen in the gap.

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -6469,7 +6469,7 @@ Returns a paged list of users scoped to the admin's site.
       "engName": "Alice",
       "chineseName": "愛麗絲",
       "roles": ["admin"],
-      "deactivated": false,
+      "active": true,
       "requirePasswordChange": false
     }
   ],
@@ -6518,7 +6518,7 @@ Creates a new user account. The `siteId` is always forced to the admin-service's
   "engName": "Bob",
   "chineseName": "鮑勃",
   "roles": [],
-  "deactivated": false,
+  "active": true,
   "requirePasswordChange": true
 }
 ```
@@ -6542,7 +6542,7 @@ Returns a single [UserView](#userview) by account. The account is resolved withi
   "engName": "Alice",
   "chineseName": "愛麗絲",
   "roles": ["admin"],
-  "deactivated": false,
+  "active": true,
   "requirePasswordChange": false
 }
 ```
@@ -6552,7 +6552,7 @@ Returns a single [UserView](#userview) by account. The account is resolved withi
 **Endpoint:** `PATCH /v1/admin/users/:account`
 **Auth:** `Authorization: Bearer <authToken>`, admin role + same-site required.
 
-Applies partial updates to a user. All fields are optional; omitting a field leaves it unchanged. When `deactivated` is set to `true`, all active sessions for the user are revoked immediately.
+Applies partial updates to a user. All fields are optional; omitting a field leaves it unchanged. When `active` is set to `false`, all active sessions for the user are revoked immediately.
 
 #### Request body
 
@@ -6561,10 +6561,10 @@ Applies partial updates to a user. All fields are optional; omitting a field lea
 | `engName` | string | no | New English display name. |
 | `chineseName` | string | no | New Chinese display name. |
 | `roles` | string[] | no | Replaces the user's roles array. |
-| `deactivated` | boolean | no | Set to `true` to deactivate (all sessions revoked); `false` to reactivate. |
+| `active` | boolean | no | Set to `false` to deactivate (all sessions revoked); `true` to reactivate. |
 
 ```json
-{ "roles": ["admin"], "deactivated": false }
+{ "roles": ["admin"], "active": true }
 ```
 
 #### Success response
@@ -6822,7 +6822,7 @@ Projected user record returned by all admin user endpoints. The `services` / bcr
 | `statusText` | string | Custom status text. Omitted when empty. |
 | `roles` | string[] | Role tags, e.g. `["admin"]`. Omitted when empty. |
 | `requirePasswordChange` | boolean | First-login password-change flag. Omitted when `false`. |
-| `deactivated` | boolean | Whether the account is deactivated. Omitted when `false`. |
+| `active` | boolean | Whether the account is active. Always present; a user doc with no stored flag reads as `true`. |
 
 ### SessionView
 

--- a/docs/superpowers/specs/2026-07-26-active-field-migration-design.md
+++ b/docs/superpowers/specs/2026-07-26-active-field-migration-design.md
@@ -100,15 +100,10 @@ targets the field, not the English word.
 ### Data note (ops)
 
 Any doc that got `deactivated: true` from the old admin-service path is currently — and
-will remain — treated as active by readers. To preserve those deactivations, ops should
-run once per site before or after deploy:
-
-```js
-db.users.updateMany({deactivated: true}, {$set: {active: false}, $unset: {deactivated: ""}})
-db.users.updateMany({deactivated: {$exists: true}}, {$unset: {deactivated: ""}})
-```
-
-No code-level migration is needed; readers never look at `deactivated` after this PR.
+will remain — treated as active by readers. To preserve those deactivations, ops must
+run the one-time backfill documented in `docs/active-field-backfill.md` (the runbook is
+the authoritative copy). No code-level migration is needed; readers never look at
+`deactivated` after this PR.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-07-26-active-field-migration-design.md
+++ b/docs/superpowers/specs/2026-07-26-active-field-migration-design.md
@@ -1,0 +1,122 @@
+# Active-Field Migration Design
+
+**Date:** 2026-07-26
+**Status:** Approved (autonomous session — decisions recorded below)
+
+## Problem
+
+`pkg/model.User` carries `Deactivated bool` (`bson:"deactivated"`), but the rest of the
+system has already converged on the opposite-polarity `active` field:
+
+- `user-service` filters users with `active: {$ne: false}` (missing = active) and its
+  integration tests seed `active: true/false` docs.
+- The company-wide user sync and the data-migration transformer treat deactivation as
+  `active: false` (`data-migration/oplog-collections-transformer/users.go`).
+- Client-facing derived views (`botplatform` login `me.active`, media-service drive
+  members `active`) already speak `active`.
+
+This split is a live inconsistency: a deactivation performed through admin-service
+writes `deactivated: true`, which user-service ignores entirely — the user keeps
+resolving as active there. Unifying on `active` is therefore a correctness fix, not
+just a rename.
+
+## Requirements
+
+1. New field `Active *bool` on `model.User`; a missing/nil field means **active**.
+2. The field is not serialized to the frontend (`json:"-"` on the model).
+3. All code and living docs replace `deactivated` with `active`; no dual-field state.
+
+## Approaches Considered
+
+- **A. Clean cut (chosen):** switch storage, model, admin wire contract, and
+  admin-frontend to `active` in one PR. The monorepo owns every reader and writer, and
+  user-service already reads only `active`, so there is nothing to stay compatible with.
+- **B. Storage-only:** store `active` but keep the admin API field named `deactivated`.
+  Rejected — leaves `deactivated` in code and docs, contrary to the unification goal.
+- **C. Dual-write window:** write both fields for one release. Rejected — buys nothing
+  (no external consumer of `deactivated`) and adds cleanup debt.
+
+## Design
+
+### pkg/model
+
+```go
+Active *bool `json:"-" bson:"active,omitempty"`
+```
+
+- Replaces `Deactivated bool`. `json:"-"` keeps it out of every client payload;
+  `bson` `omitempty` drops the nil pointer so "never set" stays absent in Mongo.
+- New nil-safe helper, the single source of truth for the missing-means-active rule:
+
+```go
+// IsActive reports whether the user is active. A nil user, nil field, or
+// explicit true all count as active — only a stored active:false deactivates.
+func (u *User) IsActive() bool
+```
+
+All former `u.Deactivated` readers become `!u.IsActive()`; derived wire fields
+(`me.active`, drive-member `active`) become `u.IsActive()`.
+
+### Storage (Mongo)
+
+- admin-service `DeactivateAndRevoke` sets `active: false` (method name keeps the verb —
+  the action is still deactivation).
+- admin-service `UpdateUser` / `UserUpdate` carries `Active *bool`; reactivation writes
+  `active: true` (an explicit true, equivalent to absent per the read rule).
+- Projections that listed `deactivated: 1` (admin-service `userProjection`,
+  `userAuthProjection`; botplatform `FindUserByAccount`; media-service `UserByAccount`)
+  list `active: 1`.
+- user-service is already correct; only comments change.
+
+### Admin API wire contract (admin-service + admin-frontend)
+
+- `UserView.deactivated` (omitted-when-false) → `active` (always present, from
+  `IsActive()`).
+- `PATCH /v1/admin/users/:account` body field `deactivated *bool` → `active *bool`.
+  `active: false` is the deactivate branch (transactional flag-flip + session revoke;
+  cannot be mixed with other fields — reason code `mixed_deactivate_patch` is
+  unchanged); `active: true` reactivates via the plain update branch and may be
+  combined with other fields.
+- Audit details key `deactivated` → `active` (value is the boolean sent).
+- admin-frontend: `UserView.active: boolean` (adapter default `raw.active ?? true`),
+  `UpdateUserPatch.active?: boolean`, table badge and edit-dialog checkbox derive from
+  `active` (UI copy may still say "Deactivated" — that is prose, not a field), CSS
+  class `is-deactivated` → `is-inactive`.
+
+### Login gates
+
+botplatform-service and admin-service login handlers deny when `!u.IsActive()`, at the
+same post-password-verify position (timing posture unchanged).
+
+### Docs
+
+`docs/client-api.md` §9 (UserView table, 9.1–9.4 examples and field tables) moves to
+`active`. Derived views (`docs/client-api/request-reply.md`, `events.md`) contain no
+`deactivated` field references — no change. Historical specs/plans under
+`docs/superpowers/` are session records and are left untouched. Prose uses of the verb
+"deactivate/deactivated" (e.g. login-denial descriptions) remain — the migration
+targets the field, not the English word.
+
+### Data note (ops)
+
+Any doc that got `deactivated: true` from the old admin-service path is currently — and
+will remain — treated as active by readers. To preserve those deactivations, ops should
+run once per site before or after deploy:
+
+```js
+db.users.updateMany({deactivated: true}, {$set: {active: false}, $unset: {deactivated: ""}})
+db.users.updateMany({deactivated: {$exists: true}}, {$unset: {deactivated: ""}})
+```
+
+No code-level migration is needed; readers never look at `deactivated` after this PR.
+
+## Testing
+
+- `pkg/model`: table-driven `IsActive` tests (nil user, nil field, true, false); BSON
+  round-trip preserving `active: false`; JSON marshal never emits `active`.
+- admin-service: handler tests move to the `active` field (mixed-patch guard now keyed
+  on `active: false`); login test uses an inactive user; integration tests assert
+  `active: false` lands in Mongo and sessions are revoked.
+- botplatform-service / media-service: existing deactivated-account tests re-expressed
+  with `Active` pointer; `me.active` / member `active` derived from `IsActive()`.
+- admin-frontend: vitest suites updated to the `active` wire field.

--- a/docs/superpowers/specs/2026-07-26-active-field-migration-design.md
+++ b/docs/superpowers/specs/2026-07-26-active-field-migration-design.md
@@ -49,8 +49,9 @@ Active *bool `json:"-" bson:"active,omitempty"`
 - New nil-safe helper, the single source of truth for the missing-means-active rule:
 
 ```go
-// IsActive reports whether the user is active. A nil user, nil field, or
-// explicit true all count as active — only a stored active:false deactivates.
+// IsActive reports whether the user is active. A nil user is not active; a
+// nil (missing) field or explicit true counts as active — only a stored
+// active:false deactivates.
 func (u *User) IsActive() bool
 ```
 

--- a/hr-sync-worker/store.go
+++ b/hr-sync-worker/store.go
@@ -27,7 +27,7 @@ type Store interface {
 	UpsertEmployees(ctx context.Context, employees []model.IEmployeeWithChange) error
 	// UpsertUserIdentities upserts users by employeeId, writing IDENTITY FIELDS
 	// ONLY (account, siteId, engName, chineseName, employeeId). It must never
-	// touch roles/services/password/deactivated/status fields — users is the
+	// touch roles/services/password/active/status fields — users is the
 	// live auth store.
 	UpsertUserIdentities(ctx context.Context, users []model.IUserWithChange) error
 	// QuitTeamsEmployees deletes hr_employee rows for the given accounts.

--- a/media-service/drive.go
+++ b/media-service/drive.go
@@ -108,7 +108,7 @@ func (h *handler) HandleDriveMembers(c *gin.Context) {
 			ID:       user.ID,
 			Username: user.Account,
 			Name:     user.DisplayName(),
-			Active:   !user.Deactivated,
+			Active:   user.IsActive(),
 		}}
 		resp.Data.Count = 1
 	}

--- a/media-service/drive_test.go
+++ b/media-service/drive_test.go
@@ -130,11 +130,12 @@ func TestHandleDriveMembers_NonMember(t *testing.T) {
 	assert.Empty(t, body.Data.Members)
 }
 
-func TestHandleDriveMembers_MemberDeactivated_ActiveFalse(t *testing.T) {
+func TestHandleDriveMembers_MemberInactive_ActiveFalse(t *testing.T) {
 	r, store, _ := newTestRouter(t)
+	inactive := false
 	store.EXPECT().RoomSite(gomock.Any(), "room1").Return("s1", model.RoomTypeChannel, "General", true, nil)
 	store.EXPECT().UserByAccount(gomock.Any(), "alice").
-		Return(&model.User{ID: "u_1", Account: "alice", Deactivated: true}, true, nil)
+		Return(&model.User{ID: "u_1", Account: "alice", Active: &inactive}, true, nil)
 	store.EXPECT().RoomMember(gomock.Any(), "room1", "alice").Return(true, nil)
 
 	w := doDriveMembers(t, r, "?roomId=room1&accountName=alice")

--- a/media-service/store.go
+++ b/media-service/store.go
@@ -21,7 +21,7 @@ type avatarStore interface {
 	// local subscriptions. found=false when no local subscription exists.
 	RoomSite(ctx context.Context, roomID string) (siteID string, roomType model.RoomType, name string, found bool, err error)
 	// UserByAccount returns a user's identity fields (id, account, names,
-	// deactivated) for the drive.members probe. found=false when no user record
+	// active) for the drive.members probe. found=false when no user record
 	// exists for account.
 	UserByAccount(ctx context.Context, account string) (*model.User, bool, error)
 	// RoomMember reports whether account holds a subscription to roomID.

--- a/media-service/store_mongo.go
+++ b/media-service/store_mongo.go
@@ -80,7 +80,7 @@ func (s *mongoStore) RoomSite(ctx context.Context, roomID string) (string, model
 func (s *mongoStore) UserByAccount(ctx context.Context, account string) (*model.User, bool, error) {
 	var u model.User
 	err := s.users.FindOne(ctx, bson.M{"account": account},
-		options.FindOne().SetProjection(bson.M{"_id": 1, "account": 1, "engName": 1, "chineseName": 1, "deactivated": 1})).Decode(&u)
+		options.FindOne().SetProjection(bson.M{"_id": 1, "account": 1, "engName": 1, "chineseName": 1, "active": 1})).Decode(&u)
 	if errors.Is(err, mongo.ErrNoDocuments) {
 		return nil, false, nil
 	}

--- a/pkg/errcode/codes_admin.go
+++ b/pkg/errcode/codes_admin.go
@@ -8,5 +8,5 @@ const (
 	AdminAccountExists        Reason = "account_exists"         // 409: duplicate account on create
 	AdminInvalidCredentials   Reason = "invalid_credentials"    // 401: /v1/login denied (unknown / wrong password / not admin / deactivated)
 	AdminOldPasswordMismatch  Reason = "old_password_mismatch"  // 401: /v1/password/change oldPassword wrong
-	AdminMixedDeactivatePatch Reason = "mixed_deactivate_patch" // 400: PATCH mixes deactivated=true with other field updates
+	AdminMixedDeactivatePatch Reason = "mixed_deactivate_patch" // 400: PATCH mixes active=false with other field updates
 )

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -163,11 +163,59 @@ func TestUserJSON_WithStatus(t *testing.T) {
 	roundTrip(t, &u, &model.User{})
 }
 
-func TestUser_DeactivatedRoundTrip(t *testing.T) {
-	u := model.User{ID: "u1", Account: "alice", SiteID: "site-local", Deactivated: true}
-	got := &model.User{}
-	roundTrip(t, &u, got)
-	assert.True(t, got.Deactivated)
+func TestUser_IsActive(t *testing.T) {
+	activeTrue := true
+	activeFalse := false
+	tests := []struct {
+		name string
+		u    *model.User
+		want bool
+	}{
+		{"nil user", nil, true},
+		{"missing field", &model.User{ID: "u1", Account: "alice"}, true},
+		{"explicit true", &model.User{ID: "u1", Account: "alice", Active: &activeTrue}, true},
+		{"explicit false", &model.User{ID: "u1", Account: "alice", Active: &activeFalse}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.u.IsActive())
+		})
+	}
+}
+
+func TestUser_ActiveBSONRoundTrip(t *testing.T) {
+	activeFalse := false
+	u := model.User{ID: "u1", Account: "alice", SiteID: "site-local", Active: &activeFalse}
+	data, err := bson.Marshal(&u)
+	require.NoError(t, err)
+	var got model.User
+	require.NoError(t, bson.Unmarshal(data, &got))
+	require.NotNil(t, got.Active)
+	assert.False(t, *got.Active)
+	assert.False(t, got.IsActive())
+}
+
+func TestUser_ActiveOmittedFromBSONWhenNil(t *testing.T) {
+	u := model.User{ID: "u1", Account: "alice", SiteID: "site-local"}
+	data, err := bson.Marshal(&u)
+	require.NoError(t, err)
+	var raw bson.M
+	require.NoError(t, bson.Unmarshal(data, &raw))
+	_, has := raw["active"]
+	assert.False(t, has, "nil Active must be omitted from BSON")
+}
+
+func TestUser_ActiveNeverSerializedToJSON(t *testing.T) {
+	activeFalse := false
+	u := model.User{ID: "u1", Account: "alice", SiteID: "site-local", Active: &activeFalse}
+	data, err := json.Marshal(&u)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	_, hasActive := raw["active"]
+	assert.False(t, hasActive, "active must never reach a JSON payload")
+	_, hasDeactivated := raw["deactivated"]
+	assert.False(t, hasDeactivated, "deactivated must be gone from JSON payloads")
 }
 
 func TestRoomJSON(t *testing.T) {

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -171,7 +171,7 @@ func TestUser_IsActive(t *testing.T) {
 		u    *model.User
 		want bool
 	}{
-		{"nil user", nil, true},
+		{"nil user", nil, false},
 		{"missing field", &model.User{ID: "u1", Account: "alice"}, true},
 		{"explicit true", &model.User{ID: "u1", Account: "alice", Active: &activeTrue}, true},
 		{"explicit false", &model.User{ID: "u1", Account: "alice", Active: &activeFalse}, false},

--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -63,8 +63,11 @@ type User struct {
 	StatusText            string     `json:"statusText"                      bson:"statusText"`
 	Roles                 []UserRole `json:"roles,omitempty"                 bson:"roles,omitempty"`
 	RequirePasswordChange bool       `json:"requirePasswordChange,omitempty" bson:"requirePasswordChange,omitempty"`
-	Deactivated           bool       `json:"deactivated,omitempty"           bson:"deactivated,omitempty"`
-	Services              Services   `json:"-"                               bson:"services,omitempty"`
+	// Active is the account-enabled flag: nil (field absent) or true means the
+	// account is active; only a stored active:false deactivates. `json:"-"` keeps
+	// it out of every outbound payload — read it via IsActive.
+	Active   *bool    `json:"-" bson:"active,omitempty"`
+	Services Services `json:"-" bson:"services,omitempty"`
 	// Settings is the per-user client-preferences sub-document; nil = never set.
 	Settings *UserSettings `json:"settings,omitempty" bson:"settings,omitempty"`
 }
@@ -75,6 +78,14 @@ type User struct {
 func (u User) String() string {
 	return fmt.Sprintf("User{ID:%q Account:%q SiteID:%q Roles:%v}",
 		u.ID, u.Account, u.SiteID, u.Roles)
+}
+
+// IsActive reports whether the user's account is active. A nil user, a nil
+// (missing) Active field, or an explicit true all count as active — only a
+// stored active:false deactivates. Single source of truth for the
+// missing-means-active rule.
+func (u *User) IsActive() bool {
+	return u == nil || u.Active == nil || *u.Active
 }
 
 // IsPlatformAdmin reports whether u holds the platform admin role. Nil-safe.

--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -80,12 +80,12 @@ func (u User) String() string {
 		u.ID, u.Account, u.SiteID, u.Roles)
 }
 
-// IsActive reports whether the user's account is active. A nil user, a nil
-// (missing) Active field, or an explicit true all count as active — only a
-// stored active:false deactivates. Single source of truth for the
-// missing-means-active rule.
+// IsActive reports whether the user's account is active. A nil user is not
+// active; on an existing user a nil (missing) Active field or an explicit true
+// counts as active — only a stored active:false deactivates. Single source of
+// truth for the missing-means-active rule.
 func (u *User) IsActive() bool {
-	return u == nil || u.Active == nil || *u.Active
+	return u != nil && (u.Active == nil || *u.Active)
 }
 
 // IsPlatformAdmin reports whether u holds the platform admin role. Nil-safe.

--- a/user-service/mongorepo/users.go
+++ b/user-service/mongorepo/users.go
@@ -49,7 +49,7 @@ func (r *UserRepo) EnsureIndexes(ctx context.Context) error {
 	return fmt.Errorf("create user index: %w", err)
 }
 
-// activeUserFilter matches non-deactivated users. Missing `active` is treated as active ({$ne:false}); only explicit false excludes.
+// activeUserFilter matches active users. Missing `active` is treated as active ({$ne:false}); only explicit false excludes.
 func activeUserFilter(account string) bson.M {
 	return bson.M{"account": account, "active": bson.M{"$ne": false}}
 }


### PR DESCRIPTION
## Summary

Unifies the user account-enabled flag on a single `active` field, replacing `deactivated` everywhere. This is a correctness fix, not just a rename: the operational DB convention was already `active` (the company-wide sync writes `active:false`, and user-service filters on `active: {$ne: false}`), so a deactivation performed through admin-service wrote a `deactivated` flag that user-service ignored entirely — the account kept resolving as active there.

Design spec: `docs/superpowers/specs/2026-07-26-active-field-migration-design.md`.

## Changes

**Model (`pkg/model`)**
- `User.Deactivated bool` → `User.Active *bool` with `json:"-" bson:"active,omitempty"` — never serialized to clients; a nil/missing field means **active**.
- New nil-safe `(*User).IsActive()` helper is the single source of truth for the missing-means-active rule; all former `u.Deactivated` readers now go through it. A nil `*User` reads as **not** active (fail-closed); on an existing user, a missing field or explicit true reads as active.

**admin-service**
- Wire contract: `UserView.deactivated` (omitted-when-false) → `active` (always present); `PATCH /v1/admin/users/:account` takes `active` instead of `deactivated`. `active:false` routes to the transactional `DeactivateAndRevoke` branch (flag flip + session revoke, mixed patches still rejected with `mixed_deactivate_patch`); `active:true` reactivates via the plain update branch.
- Storage: `DeactivateAndRevoke` sets `active:false`; projections and `UserUpdate` renamed; audit detail key `deactivated` → `active`.
- Login denies with `!u.IsActive()` at the same post-password-verify position (timing posture unchanged).

**botplatform-service / media-service**
- Projections read `active`; login gate uses `IsActive()`; the derived wire fields (`me.active`, drive-member `active`) are computed from it.

**admin-frontend**
- API types and adapter use `active` (`raw.active ?? true` on the wire adapter); user-table badge and edit-dialog checkbox derive from it (UI copy still says "Deactivated"); CSS class `is-deactivated` → `is-inactive`.

**Docs**
- `docs/client-api.md` §9 field tables and examples moved to `active` (derived views contain no field-level admin docs — no drift).
- New ops runbook `docs/active-field-backfill.md`: the one-time, idempotent `users.deactivated` → `users.active` backfill that must run once per site so pre-existing deactivations aren't silently lost.

## Deploy note

⚠️ Run the backfill in `docs/active-field-backfill.md` once per site alongside this deploy — without it, accounts disabled via the old admin path read as active.

## Testing

- TDD throughout (red-green per package): new `IsActive` table tests (including nil-user → false), BSON round-trip/omission tests, JSON never-serialized test; admin-service handler/login/integration tests re-expressed against `active` (including a new inactive-user view case); botplatform and media tests cover inactive accounts and the missing-field-counts-as-active path.
- `make lint`: 0 issues. Full `make test` (race): all packages pass. `go vet -tags integration` on touched services: clean (Docker unavailable in this environment, so integration tests were compile-checked only). gosec + govulncheck: clean.
- admin-frontend: 117/117 vitest tests pass, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwJReZqqouhLWkH7BwwsHf



## Summary by CodeRabbit

* **New Features**
  * User account status is now represented consistently as **Active** across administration, login, media, and user-management experiences.
  * Admins can activate or deactivate users using the updated account-status controls.
  * Deactivating a user continues to revoke active sessions immediately.
  * Missing status values default to active.

* **Bug Fixes**
  * Prevented deactivation requests from being combined with other user updates.

* **Documentation**
  * Updated API guidance and added migration instructions for existing account-status data.
