### PR TITLE
feat: open-room subscription flag + open RPC

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -49,7 +49,7 @@ paths.
    - [3.1 room-service](#31-room-service)
      - [Create Room](#create-room) · [Add Members](#add-members) · [Remove Member](#remove-member) · [Update Member Role](#update-member-role) · [Rename Room](#rename-room)
      - [List Members](#list-members) · [Get Member Statuses](#get-member-statuses) · [Get Mentionable Subscriptions](#get-mentionable-subscriptions) · [List Org Members](#list-org-members)
-     - [Mark Messages Read](#mark-messages-read) · [Mark Thread as Read](#mark-thread-as-read) · [Read Message Receipts](#read-message-receipts) · [Toggle Mute](#toggle-mute) · [Toggle Favorite](#toggle-favorite)
+     - [Mark Messages Read](#mark-messages-read) · [Mark Thread as Read](#mark-thread-as-read) · [Read Message Receipts](#read-message-receipts) · [Toggle Mute](#toggle-mute) · [Toggle Favorite](#toggle-favorite) · [Open Room](#open-room)
      - [Get Room App Tabs](#get-room-app-tabs) · [Get Room App Command Menu](#get-room-app-command-menu)
    - [3.2 history-service](#32-history-service)
      - [Load History](#load-history) · [Load Next Messages](#load-next-messages) · [Load Surrounding Messages](#load-surrounding-messages) · [Get Message By ID](#get-message-by-id) · [Get Messages By IDs](#get-messages-by-ids)
@@ -853,8 +853,8 @@ Room ciphertext envelope (`roomcrypto.EncryptedMessage`). See [§5 Room Encrypti
 #### Subscription
 
 A user's membership record for one room, embedded in `subscription.update`
-events on `added` / `role_updated` / `mute_toggled` / `favorite_toggled` and
-returned (enriched) by the user-service subscription endpoints. The ID
+events on `added` / `role_updated` / `mute_toggled` / `favorite_toggled` /
+`opened` and returned (enriched) by the user-service subscription endpoints. The ID
 serializes as `id` (not `_id`) and the user under `u` (not `user`). The first
 group is always present; the rest are optional (omitted when empty/unset).
 
@@ -883,6 +883,7 @@ user-service endpoints via room-service's `GetRoomsInfo` enrichment. `room` is
 | `alert` | boolean | Whether the room has an unread alert for the user. Authoritative subscription state maintained by the write path (set on new message, cleared on read receipt); **not** modified by read enrichment. |
 | `muted` | boolean | Whether the user muted the room. |
 | `favorite` | boolean | Whether the user favorited the room. |
+| `open` | boolean | Sidebar-visibility flag; false hides the room from subscription.list. |
 | `isSubscribed` | boolean | Optional. Whether the user is actively subscribed. |
 | `historySharedSince` | RFC3339 timestamp | Optional. Boundary before which prior history is shared. |
 | `lastSeenAt` | RFC3339 timestamp | Optional. The user's last-seen time in the room. |
@@ -1029,6 +1030,7 @@ and Rename Room.
 | `chat.user.{account}.request.room.{roomID}.{siteID}.message.thread.read` | [Mark Thread as Read](#mark-thread-as-read) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.mute.toggle` | [Toggle Mute](#toggle-mute) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.favorite.toggle` | [Toggle Favorite](#toggle-favorite) |
+| `chat.user.{account}.request.room.{roomID}.{siteID}.open` | [Open Room](#open-room) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.message.read-receipt` | [Read Message Receipts](#read-message-receipts) |
 | `chat.user.{account}.request.orgs.{orgID}.{siteID}.members` | [List Org Members](#list-org-members) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.app.tabs` | [Get Room App Tabs](#get-room-app-tabs) |
@@ -1209,11 +1211,11 @@ Shared by Add Members, Remove Member, and Update Member Role.
 |---|---|---|
 | `userId` | string | The affected user's internal user ID. Omitted on the org-removal path (only `subscription.u.account` is set there). |
 | `subscription` | [Subscription](#subscription) | For `added` / `role_updated`: the full Subscription record. For `removed`: a [RemovedSubscriptionRef](#removedsubscriptionref) lean ref (see Remove Member). |
-| `action` | string | `"added"`, `"removed"`, `"role_updated"`, `"mute_toggled"`, or `"favorite_toggled"`. |
-| `roomName` | string | Per-subscriber display label, set only where the server already has the name. On `added`: `channel` → room name; `dm` → counterpart's display name (`engName` + `chineseName`, falling back to account); `botDM` → the bot's app name. On `role_updated`: the channel name. Omitted (`omitempty`) on `mute_toggled` / `favorite_toggled` / `read`, and absent on `removed`. |
+| `action` | string | `"added"`, `"removed"`, `"role_updated"`, `"mute_toggled"`, `"favorite_toggled"`, or `"opened"`. |
+| `roomName` | string | Per-subscriber display label, set only where the server already has the name. On `added`: `channel` → room name; `dm` → counterpart's display name (`engName` + `chineseName`, falling back to account); `botDM` → the bot's app name. On `role_updated`: the channel name. Omitted (`omitempty`) on `mute_toggled` / `favorite_toggled` / `opened` / `read`, and absent on `removed`. |
 | `timestamp` | number | Epoch ms (UTC). |
 
-On `added` / `role_updated` / `mute_toggled` / `favorite_toggled` the embedded `Subscription` serializes its ID as `id` (not `_id`) and the user under `u` (not `user`). Non-`omitempty` fields (`id`, `u`, `roomId`, `siteId`, `roles`, `name`, `roomType`, `joinedAt`, `hasMention`, `alert`, `muted`, `favorite`) are always present — and the envelope's `roomName` is always present as a field (empty on `mute_toggled` / `favorite_toggled`). `removed` events use a dedicated lean payload (`SubscriptionRemovedEvent`) whose `subscription` carries **only** `roomId`, `roomType`, and `u` — no zero-valued `Subscription` fields are sent.
+On `added` / `role_updated` / `mute_toggled` / `favorite_toggled` / `opened` the embedded `Subscription` serializes its ID as `id` (not `_id`) and the user under `u` (not `user`). Non-`omitempty` fields (`id`, `u`, `roomId`, `siteId`, `roles`, `name`, `roomType`, `joinedAt`, `hasMention`, `alert`, `muted`, `favorite`, `open`) are always present — and the envelope's `roomName` is always present as a field (empty on `mute_toggled` / `favorite_toggled` / `opened`). `removed` events use a dedicated lean payload (`SubscriptionRemovedEvent`) whose `subscription` carries **only** `roomId`, `roomType`, and `u` — no zero-valued `Subscription` fields are sent.
 
 ```json
 {
@@ -2065,6 +2067,56 @@ See [Error envelope](#6-error-envelope-reference). Common errors:
 ##### Cross-site behaviour
 
 When the requester's home site differs from the room's site, `room-service` emits an `OutboxEvent` on the OUTBOX stream and `outbox-worker` forwards the cross-site `subscription_favorite_toggled` event (at-least-once) to `chat.inbox.{userSite}.external.subscription_favorite_toggled`. `inbox-worker` on the user's home site mirrors the flip onto the local `Subscription` document. Missing-subscription on the home site (e.g., a federation race) is a silent no-op — no NACK, no redelivery loop.
+
+---
+
+#### Open Room
+
+**Subject:** `chat.user.{account}.request.room.{roomID}.{siteID}.open`
+**Reply subject:** auto-generated `_INBOX.>` (NATS request/reply)
+
+- `{siteID}` must be the room's **origin `siteID`** (the site that owns the room), not the caller's own site.
+
+Synchronous RPC. `room-service` sets `Subscription.open` to `true` for the requester in a single atomic Mongo `FindOneAndUpdate`, replies with the resulting value, and fans out a `subscription.update` event to the user's other client sessions. Used by the client to reveal a room in the sidebar.
+
+Idempotency: this is a set, not a toggle. Every successful call sets `open` to `true`; redelivery of the same RPC is a no-op.
+
+##### Request body
+
+The subject already carries `account` and `roomID`, so no body fields are required. Clients may send `{}` or omit the body entirely; any body content is ignored.
+
+##### Success response
+
+| Field | Type | Notes |
+|---|---|---|
+| `status` | string | Always `"ok"`. |
+| `open` | boolean | Always `true`. |
+
+```json
+{ "status": "ok", "open": true }
+```
+
+##### Error response
+
+See [Error envelope](#6-error-envelope-reference). Common errors:
+
+- `"only room members can list members"` — the user has no subscription in the room (sentinel reused across membership-gated RPCs).
+- `"invalid open-room subject: …"` — the subject is malformed.
+
+##### Triggered events — success path
+
+**`chat.user.{account}.event.subscription.update`** — emitted once for the requester so other client sessions reconcile.
+
+| Field | Type | Notes |
+|---|---|---|
+| `userId` | string | The requester's internal user ID. |
+| `subscription` | [Subscription](#subscription) | The Subscription record with the updated `open`. |
+| `action` | string | `"opened"`. |
+| `timestamp` | number | Epoch ms (UTC). |
+
+##### Cross-site behaviour
+
+When the requester's home site differs from the room's site, `room-service` emits an `OutboxEvent` on the OUTBOX stream and `outbox-worker` forwards the cross-site `subscription_opened` event (at-least-once) to `chat.inbox.{userSite}.external.subscription_opened`. `inbox-worker` on the user's home site mirrors the change onto the local `Subscription` document. Missing-subscription on the home site (e.g., a federation race) is a silent no-op — no NACK, no redelivery loop.
 
 ---
 

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -2116,7 +2116,7 @@ See [Error envelope](#6-error-envelope-reference). Common errors:
 
 ##### Cross-site behaviour
 
-When the requester's home site differs from the room's site, `room-service` emits an `OutboxEvent` on the OUTBOX stream and `outbox-worker` forwards the cross-site `subscription_opened` event (at-least-once) to `chat.inbox.{userSite}.external.subscription_opened`. `inbox-worker` on the user's home site mirrors the change onto the local `Subscription` document. Missing-subscription on the home site (e.g., a federation race) is a silent no-op — no NACK, no redelivery loop.
+When the requester's home site differs from the room's site, `room-service` emits an `OutboxEvent` on the OUTBOX stream and `outbox-worker` forwards the cross-site `subscription_opened` event (at-least-once) to `chat.inbox.{userSite}.external.subscription_opened`. `inbox-worker` on the user's home site mirrors the change onto the local `Subscription` document, setting `open` to `true`. This mirror is idempotent and eventually consistent: if the home-site subscription doesn't exist yet (e.g., `subscription_opened` races ahead of the originating `member_added`), the event is redelivered until the subscription exists.
 
 ---
 

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -98,14 +98,14 @@ same transform as `room.key` delivery).
 
 Two shapes exist — discriminated by `action`:
 
-### `added` / `role_updated` / `mute_toggled` / `favorite_toggled` / `read` (SubscriptionUpdateEvent)
+### `added` / `role_updated` / `mute_toggled` / `favorite_toggled` / `opened` / `read` (SubscriptionUpdateEvent)
 
 | Field | Type | Notes |
 |---|---|---|
 | `userId` | string | The affected user's internal user ID. Omitted on the org-removal path. |
-| `subscription` | [Subscription](../client-api.md#subscription) | Full Subscription record for `added` / `role_updated` / `mute_toggled` / `favorite_toggled` / `read`. On `read`, `hasMention` and `hasGroupMention` are both `false` — reading the room clears both. |
-| `action` | string | `"added"`, `"role_updated"`, `"mute_toggled"`, `"favorite_toggled"`, or `"read"`. |
-| `roomName` | string | Per-subscriber display label. On `added`: channel name / DM counterpart's display name / bot app name. On `role_updated`: the channel name. Omitted on `mute_toggled` / `favorite_toggled` / `read`. |
+| `subscription` | [Subscription](../client-api.md#subscription) | Full Subscription record for `added` / `role_updated` / `mute_toggled` / `favorite_toggled` / `opened` / `read`. On `read`, `hasMention` and `hasGroupMention` are both `false` — reading the room clears both. |
+| `action` | string | `"added"`, `"role_updated"`, `"mute_toggled"`, `"favorite_toggled"`, `"opened"`, or `"read"`. |
+| `roomName` | string | Per-subscriber display label. On `added`: channel name / DM counterpart's display name / bot app name. On `role_updated`: the channel name. Omitted on `mute_toggled` / `favorite_toggled` / `opened` / `read`. |
 | `timestamp` | number | Epoch ms (UTC). |
 
 ```json
@@ -161,7 +161,7 @@ fields are sent.
 
 **Triggered by:** Add Members (`added`), Remove Member (`removed`), Update Member Role
 (`role_updated`), Toggle Mute (`mute_toggled`), Toggle Favorite (`favorite_toggled`),
-Mark Messages Read (`read`) — see [request-reply.md](request-reply.md).
+Open Room (`opened`), Mark Messages Read (`read`) — see [request-reply.md](request-reply.md).
 
 ---
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -253,6 +253,7 @@ matching `siteId`). Full schemas, examples, and error tables are in
 | `chat.user.{account}.request.room.{roomID}.{siteID}.message.thread.read` | [Mark Thread as Read](#mark-thread-as-read) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.mute.toggle` | [Toggle Mute](#toggle-mute) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.favorite.toggle` | [Toggle Favorite](#toggle-favorite) |
+| `chat.user.{account}.request.room.{roomID}.{siteID}.open` | [Open Room](#open-room) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.message.read-receipt` | [Read Message Receipts](#read-message-receipts) |
 | `chat.user.{account}.request.orgs.{orgID}.{siteID}.members` | [List Org Members](#list-org-members) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.app.tabs` | [Get Room App Tabs](#get-room-app-tabs) |
@@ -613,6 +614,29 @@ clients must debounce. No request body required.
 `"only room members can list members"`, `"invalid favorite-toggle subject: …"`.
 
 **Emits:** [`subscription.update`](events.md#subscriptionupdate--membership--state-changes) (`action: "favorite_toggled"` — to the requester for other sessions) → [events.md](events.md)
+
+---
+
+### Open Room
+
+**Subject:** `chat.user.{account}.request.room.{roomID}.{siteID}.open`
+**Reply:** auto-generated `_INBOX.>` (NATS request/reply)
+
+Synchronous RPC. Sets `Subscription.open` to `true`. Every successful call sets the
+bit — not a toggle. No request body required.
+
+#### Success response
+
+| Field | Type | Notes |
+|---|---|---|
+| `status` | string | Always `"ok"`. |
+| `open` | boolean | Always `true`. |
+
+#### Errors
+
+`"only room members can list members"`, `"invalid open-room subject: …"`.
+
+**Emits:** [`subscription.update`](events.md#subscriptionupdate--membership--state-changes) (`action: "opened"` — to the requester for other sessions) → [events.md](events.md)
 
 ---
 

--- a/docs/superpowers/plans/2026-07-26-open-room-subscription-flag.md
+++ b/docs/superpowers/plans/2026-07-26-open-room-subscription-flag.md
@@ -1,0 +1,644 @@
+# Open-Room Subscription Flag + `open` RPC Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-user `Subscription.open` boolean, an `open` RPC in room-service that sets it true (with cross-site federation), and exclude closed subscriptions from `subscription.list`.
+
+**Architecture:** Mirror the existing `favorite.toggle` flow end-to-end, with two differences: the RPC is a set-true (not a toggle) with no ordering guard, and new subscriptions are born `open: true`. Origin write in room-service → best-effort `subscription.update` core event → cross-site mirror via OUTBOX (`outbox-worker`) → INBOX (`inbox-worker`).
+
+**Tech Stack:** Go 1.25, NATS/JetStream, MongoDB (`mongo-driver/v2`), `natsrouter`, `go.uber.org/mock`, `testify`, testcontainers.
+
+## Global Constraints
+
+- Go 1.25. Use `make` targets only — never raw `go`. Key: `make test SERVICE=<name>`, `make generate SERVICE=<name>`, `make lint`.
+- All NATS payloads are JSON with typed `pkg/model` structs — never `map[string]interface{}`.
+- Every NATS event struct in `pkg/model` has `Timestamp int64 \`json:"timestamp" bson:"timestamp"\``, set at publish site via `time.Now().UTC().UnixMilli()`.
+- Errors: wrap with context (`fmt.Errorf("desc: %w", err)`); client-facing errors via `errcode`/room-service sentinels; never bare `err`.
+- Subjects: use `pkg/subject` builders, never raw `fmt.Sprintf` at call sites.
+- TDD: Red → Green → Refactor → Commit. Tests in `package main` (services) / `package <pkg>` (libs). Mocks in `mock_store_test.go` via `make generate` — never hand-edit.
+- Minimum 80% coverage; target 90% on new handler/store code.
+- A client-facing handler (`chat.user.…`) change updates `docs/client-api.md` **and** derived views (`docs/client-api/request-reply.md`, `docs/client-api/events.md`) in the same PR.
+- `make generate SERVICE=room-service` and `SERVICE=inbox-worker` after their store interfaces change, before testing.
+
+---
+
+### Task 1: `Subscription.open` model field + round-trip tests
+
+**Files:**
+- Modify: `pkg/model/subscription.go` (add `Open` field to `Subscription`, near `Favorite` at line 42)
+- Test: `pkg/model/model_test.go` (extend `TestSubscriptionJSON` ~line 571 and `TestSubscriptionJSON_ThreadUnreadOmittedAlertAlwaysPresent` ~line 623)
+
+**Interfaces:**
+- Produces: `model.Subscription.Open bool` (json/bson tag `open`, always serialized).
+
+- [ ] **Step 1: Write the failing test.** In `model_test.go`, in `TestSubscriptionJSON`'s constructed `Subscription`, add `Open: true` alongside `Favorite: true`. In `TestSubscriptionJSON_ThreadUnreadOmittedAlertAlwaysPresent`, after the `favorite` present-assertion (~line 651), add:
+
+```go
+openVal, hasOpen := raw["open"]
+assert.True(t, hasOpen, "open must be present in JSON even when false")
+assert.Equal(t, false, openVal)
+```
+
+- [ ] **Step 2: Run test to verify it fails.** Run: `make test SERVICE=../pkg/model` — if the model package isn't a SERVICE target, use the package path the Makefile expects; expected FAIL: `raw["open"]` missing / `Open` undefined.
+
+- [ ] **Step 3: Add the field.** In `pkg/model/subscription.go` after the `Favorite` line (42):
+
+```go
+	Favorite           bool             `json:"favorite" bson:"favorite"`
+	// Open is the per-user sidebar-visibility flag. New subscriptions are born
+	// open (room-worker's newSub sets it); subscription.list excludes only rows
+	// explicitly closed (open == false). Set true by the room-service open RPC.
+	Open               bool             `json:"open" bson:"open"`
+```
+
+- [ ] **Step 4: Run tests to verify they pass.** Run the model package tests. Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add pkg/model/subscription.go pkg/model/model_test.go
+git commit -m "feat(model): add Subscription.open sidebar-visibility flag"
+```
+
+---
+
+### Task 2: Subject builders for the `open` RPC
+
+**Files:**
+- Modify: `pkg/subject/subject.go` (add near `FavoriteToggle` ~line 701 and `FavoriteTogglePattern` ~line 909)
+- Test: `pkg/subject/subject_test.go`
+
+**Interfaces:**
+- Produces: `subject.OpenRoom(account, roomID, siteID) string`, `subject.OpenRoomWildcard(siteID) string`, `subject.OpenRoomPattern(siteID) string`.
+
+- [ ] **Step 1: Write the failing test.** In `subject_test.go`:
+
+```go
+func TestOpenRoom(t *testing.T) {
+	assert.Equal(t, "chat.user.alice.request.room.r1.site-a.open", subject.OpenRoom("alice", "r1", "site-a"))
+}
+
+func TestOpenRoomWildcard(t *testing.T) {
+	assert.Equal(t, "chat.user.*.request.room.*.site-a.open", subject.OpenRoomWildcard("site-a"))
+}
+
+func TestOpenRoomPattern(t *testing.T) {
+	assert.Equal(t, "chat.user.{account}.request.room.{roomID}.site-a.open", subject.OpenRoomPattern("site-a"))
+}
+
+func TestOpenRoom_ParseUserRoomSubject(t *testing.T) {
+	account, roomID, ok := subject.ParseUserRoomSubject(subject.OpenRoom("alice", "r1", "site-a"))
+	require.True(t, ok)
+	assert.Equal(t, "alice", account)
+	assert.Equal(t, "r1", roomID)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails.** Run: `make test SERVICE=../pkg/subject` (or the package's test target). Expected FAIL: `OpenRoom` undefined.
+
+- [ ] **Step 3: Add the builders.** After the `FavoriteToggle`/`FavoriteToggleWildcard` block (~line 708):
+
+```go
+// OpenRoom returns the concrete subject for the per-user open RPC.
+func OpenRoom(account, roomID, siteID string) string {
+	return fmt.Sprintf("chat.user.%s.request.room.%s.%s.open", account, roomID, siteID)
+}
+
+// OpenRoomWildcard is the per-site subscription pattern for the open RPC.
+func OpenRoomWildcard(siteID string) string {
+	return fmt.Sprintf("chat.user.*.request.room.*.%s.open", siteID)
+}
+```
+
+And after `FavoriteTogglePattern` (~line 911):
+
+```go
+func OpenRoomPattern(siteID string) string {
+	return fmt.Sprintf("chat.user.{account}.request.room.{roomID}.%s.open", siteID)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass.** Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add pkg/subject/subject.go pkg/subject/subject_test.go
+git commit -m "feat(subject): add open-room RPC subject builders"
+```
+
+---
+
+### Task 3: Wire model — response, inbox event, event-type const, outbox partition
+
+**Files:**
+- Modify: `pkg/model/event.go` (add const near line 134; add response + event structs near `FavoriteToggleResponse` ~line 469)
+- Modify: `pkg/outbox/outbox.go` (add to `ConcurrentEventTypes` ~line 27)
+- Test: `pkg/model/model_test.go`, `pkg/outbox/outbox_test.go` (create test if none for the partition)
+
+**Interfaces:**
+- Produces: `model.InboxSubscriptionOpened` (= `"subscription_opened"`), `model.OpenRoomResponse{Status string; Open bool}`, `model.SubscriptionOpenedEvent{Account, RoomID string; Open bool; Timestamp int64}`.
+
+- [ ] **Step 1: Write the failing tests.** In `model_test.go`:
+
+```go
+func TestOpenRoomResponseJSON(t *testing.T) {
+	r := model.OpenRoomResponse{Status: "ok", Open: true}
+	b, err := json.Marshal(r)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(b, &raw))
+	assert.Equal(t, "ok", raw["status"])
+	assert.Equal(t, true, raw["open"])
+	roundTrip(t, &r, &model.OpenRoomResponse{})
+}
+
+func TestSubscriptionOpenedEventJSON(t *testing.T) {
+	e := model.SubscriptionOpenedEvent{Account: "alice", RoomID: "r1", Open: true, Timestamp: 123}
+	roundTrip(t, &e, &model.SubscriptionOpenedEvent{})
+}
+
+func TestInboxSubscriptionOpenedConst(t *testing.T) {
+	assert.Equal(t, "subscription_opened", model.InboxSubscriptionOpened)
+}
+```
+
+In `pkg/outbox/outbox_test.go` (create if absent, `package outbox`):
+
+```go
+func TestOpenInConcurrentEventTypes(t *testing.T) {
+	found := false
+	for _, et := range outbox.ConcurrentEventTypes {
+		if et == model.InboxSubscriptionOpened {
+			found = true
+		}
+	}
+	assert.True(t, found, "subscription_opened must ride the concurrent lane")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail.** Run the `pkg/model` and `pkg/outbox` test targets. Expected FAIL: undefined identifiers.
+
+- [ ] **Step 3: Implement.** In `pkg/model/event.go`, add to the `InboxEventType` const block (after line 134):
+
+```go
+	InboxSubscriptionOpened          InboxEventType = "subscription_opened"
+```
+
+After `FavoriteToggleResponse` / `SubscriptionFavoriteToggledEvent` (~line 481):
+
+```go
+// OpenRoomResponse is the sync reply for the open RPC. Open is always true.
+type OpenRoomResponse struct {
+	Status string `json:"status"`
+	Open   bool   `json:"open"`
+}
+
+// SubscriptionOpenedEvent is the InboxEvent.Payload for type "subscription_opened".
+type SubscriptionOpenedEvent struct {
+	Account   string `json:"account"   bson:"account"`
+	RoomID    string `json:"roomId"    bson:"roomId"`
+	Open      bool   `json:"open"      bson:"open"`
+	Timestamp int64  `json:"timestamp" bson:"timestamp"`
+}
+```
+
+In `pkg/outbox/outbox.go`, add to `ConcurrentEventTypes` (after `InboxSubscriptionFavoriteToggled`, line 27):
+
+```go
+	model.InboxSubscriptionOpened,
+```
+
+- [ ] **Step 4: Run tests to verify they pass.** Expected: PASS for both packages.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add pkg/model/event.go pkg/model/model_test.go pkg/outbox/outbox.go pkg/outbox/outbox_test.go
+git commit -m "feat(model): open RPC response, inbox event, outbox partition"
+```
+
+---
+
+### Task 4: room-service store — `OpenSubscription` (interface + mock + mongo)
+
+**Files:**
+- Modify: `room-service/store.go` (add method to `RoomStore` interface near `ToggleSubscriptionFavorite` ~line 134)
+- Modify: `room-service/store_mongo.go` (add impl near `ToggleSubscriptionFavorite` ~line 1075)
+- Regenerate: `room-service/mock_store_test.go` via `make generate SERVICE=room-service`
+- Test: `room-service/integration_test.go` (add `TestMongoStore_OpenSubscription`)
+
+**Interfaces:**
+- Consumes: `MongoStore.findOneAndUpdateSub(ctx, roomID, account, op string, set bson.M)` (existing).
+- Produces: `RoomStore.OpenSubscription(ctx context.Context, roomID, account string) (*model.Subscription, error)`.
+
+- [ ] **Step 1: Write the failing integration test.** In `room-service/integration_test.go` (build tag `//go:build integration`, `package main`), mirroring the favorite integration test:
+
+```go
+func TestMongoStore_OpenSubscription(t *testing.T) {
+	db := testutil.MongoDB(t, "room-svc-open")
+	store := NewMongoStore(db, "site-a")
+	ctx := context.Background()
+
+	_, err := db.Collection("subscriptions").InsertOne(ctx, bson.M{
+		"_id": "s1", "roomId": "r1", "siteId": "site-a",
+		"u":    bson.M{"_id": "u_alice", "account": "alice"},
+		"open": false,
+	})
+	require.NoError(t, err)
+
+	sub, err := store.OpenSubscription(ctx, "r1", "alice")
+	require.NoError(t, err)
+	assert.True(t, sub.Open)
+
+	got, err := store.GetSubscription(ctx, "alice", "r1")
+	require.NoError(t, err)
+	assert.True(t, got.Open)
+
+	// Idempotent
+	sub2, err := store.OpenSubscription(ctx, "r1", "alice")
+	require.NoError(t, err)
+	assert.True(t, sub2.Open)
+
+	// Missing subscription
+	_, err = store.OpenSubscription(ctx, "missing", "alice")
+	assert.True(t, errors.Is(err, model.ErrSubscriptionNotFound))
+}
+```
+
+(Confirm `NewMongoStore` signature against the favorite integration test and match it exactly.)
+
+- [ ] **Step 2: Add the interface method.** In `room-service/store.go` after `ToggleSubscriptionFavorite` (~line 134):
+
+```go
+	// OpenSubscription atomically sets open=true for (roomID, account) via a single
+	// FindOneAndUpdate and returns the post-update subscription, or
+	// model.ErrSubscriptionNotFound (wrapped) when no match.
+	OpenSubscription(ctx context.Context, roomID, account string) (*model.Subscription, error)
+```
+
+- [ ] **Step 3: Add the mongo impl.** In `room-service/store_mongo.go` after `ToggleSubscriptionFavorite` (~line 1080):
+
+```go
+// OpenSubscription sets open=true. Set-not-toggle: no ordering guard is needed
+// because applying true repeatedly or out of order always converges to true.
+func (s *MongoStore) OpenSubscription(ctx context.Context, roomID, account string) (*model.Subscription, error) {
+	return s.findOneAndUpdateSub(ctx, roomID, account, "open subscription", bson.M{
+		"open": true,
+	})
+}
+```
+
+- [ ] **Step 4: Regenerate mocks.** Run: `make generate SERVICE=room-service`. Confirm `mock_store_test.go` gains `OpenSubscription`.
+
+- [ ] **Step 5: Run the integration test.** Run: `make test-integration SERVICE=room-service` (requires Docker). Expected: PASS. If Docker is unavailable in this environment, verify compilation via `make build SERVICE=room-service` and note the integration test is written but unrun.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add room-service/store.go room-service/store_mongo.go room-service/mock_store_test.go room-service/integration_test.go
+git commit -m "feat(room-service): OpenSubscription store method"
+```
+
+---
+
+### Task 5: room-service handler — `openRoom` RPC + registration
+
+**Files:**
+- Modify: `room-service/handler.go` (register at ~line 97; add `openRoom` near `favoriteToggle` ~line 2151)
+- Test: `room-service/handler_test.go` (add the seven-test suite, parallel to the favorite suite)
+
+**Interfaces:**
+- Consumes: `subject.OpenRoomPattern`, `h.store.OpenSubscription`, `h.store.GetUserSiteID`, `h.publishSubscriptionUpdate(ctx, account, action, sub, roomName, ts)`, `h.federateOne(ctx, roomID, destSiteID, eventType, payload, dedupSeed, ts)`, `errNotRoomMember`, `model.OpenRoomResponse`, `model.SubscriptionOpenedEvent`, `model.InboxSubscriptionOpened`.
+- Produces: `(*Handler).openRoom(c *natsrouter.Context) (*model.OpenRoomResponse, error)`.
+
+- [ ] **Step 1: Write the failing tests.** In `room-service/handler_test.go`, copy the favorite-toggle test suite and adapt. Locate the favorite tests (`TestHandler_FavoriteToggle_*`) and mirror them as `TestHandler_OpenRoom_*` per the spec's table. Key adaptations: build the subject with `subject.OpenRoom("alice","r1","site-a")`; mock `OpenSubscription` (not `ToggleSubscriptionFavorite`) to return `&model.Subscription{User: model.SubscriptionUser{ID:"u_alice",Account:"alice"}, RoomID:"r1", Open:true}`; assert `Action:"opened"` on the captured `SubscriptionUpdateEvent`; decode the cross-site `OutboxEvent` inner payload as `model.SubscriptionOpenedEvent` and assert `Open==true`, nonzero `Timestamp`, envelope `Type==model.InboxSubscriptionOpened`; not-member returns `errNotRoomMember`; store error contains `"open subscription"`; get-siteID error contains `"get user siteId"`; cross-site publishToStream failure contains `"federate opened"`; core-publish failure is non-fatal (`require.NoError`, reply `{ok,true}`). Use the exact mock/capture harness the favorite tests use.
+
+- [ ] **Step 2: Run tests to verify they fail.** Run: `make test SERVICE=room-service`. Expected FAIL: `openRoom` undefined / registration missing.
+
+- [ ] **Step 3: Register the handler.** In `room-service/handler.go` `Register`, after the favorite line (97):
+
+```go
+	natsrouter.RegisterNoBody(r, subject.OpenRoomPattern(h.siteID), h.openRoom)
+```
+
+- [ ] **Step 4: Implement the handler.** After `favoriteToggle` (~line 2201):
+
+```go
+func (h *Handler) openRoom(c *natsrouter.Context) (*model.OpenRoomResponse, error) {
+	var ctx context.Context = c
+	account := c.Param("account")
+	roomID := c.Param("roomID")
+
+	if span := trace.SpanFromContext(ctx); span.IsRecording() {
+		span.SetAttributes(
+			attribute.String("room.id", roomID),
+			attribute.String("site.id", h.siteID),
+		)
+	}
+
+	now := time.Now().UTC()
+	sub, err := h.store.OpenSubscription(ctx, roomID, account)
+	if err != nil {
+		if errors.Is(err, model.ErrSubscriptionNotFound) {
+			return nil, errNotRoomMember
+		}
+		return nil, fmt.Errorf("open subscription: %w", err)
+	}
+
+	if _, err := h.publishSubscriptionUpdate(ctx, account, "opened", sub, "", now); err != nil {
+		return nil, err
+	}
+
+	userSiteID, err := h.store.GetUserSiteID(ctx, account)
+	if err != nil {
+		return nil, fmt.Errorf("get user siteId: %w", err)
+	}
+	if userSiteID != "" && userSiteID != h.siteID {
+		payload := model.SubscriptionOpenedEvent{
+			Account:   account,
+			RoomID:    roomID,
+			Open:      sub.Open,
+			Timestamp: now.UnixMilli(),
+		}
+		payloadData, err := json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("marshal opened payload: %w", err)
+		}
+		if err := h.federateOne(ctx, roomID, userSiteID, model.InboxSubscriptionOpened, payloadData, roomID+":"+account, now.UnixMilli()); err != nil {
+			return nil, fmt.Errorf("federate opened: %w", err)
+		}
+	}
+
+	return &model.OpenRoomResponse{Status: "ok", Open: sub.Open}, nil
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass.** Run: `make test SERVICE=room-service`. Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add room-service/handler.go room-service/handler_test.go
+git commit -m "feat(room-service): open RPC handler with cross-site federation"
+```
+
+---
+
+### Task 6: room-worker — new subscriptions born open
+
+**Files:**
+- Modify: `room-worker/handler.go` (`newSub` ~line 1383)
+- Test: `room-worker/handler_test.go`
+
+**Interfaces:**
+- Consumes: `newSub(id string, user *model.User, room *model.Room, roles []model.Role, name string, isSubscribed bool, joinedAt time.Time) *model.Subscription` (existing).
+- Produces: same signature; result now has `Open: true`.
+
+- [ ] **Step 1: Write the failing test.** In `room-worker/handler_test.go`:
+
+```go
+func TestNewSub_OpenTrue(t *testing.T) {
+	user := &model.User{ID: "u_alice", Account: "alice"}
+	room := &model.Room{ID: "r1", SiteID: "site-a", Type: model.RoomTypeChannel}
+	sub := newSub("s1", user, room, nil, "general", false, time.Now())
+	assert.True(t, sub.Open, "new subscriptions must be born open")
+}
+```
+
+(Match the exact `newSub` argument order from `handler.go:1383`.)
+
+- [ ] **Step 2: Run test to verify it fails.** Run: `make test SERVICE=room-worker`. Expected FAIL: `sub.Open` is false.
+
+- [ ] **Step 3: Set the default.** In `newSub`'s returned struct literal (~line 1385), add `Open: true`:
+
+```go
+	return &model.Subscription{
+		ID:           id,
+		User:         model.SubscriptionUser{ID: user.ID, Account: user.Account, IsBot: model.IsBot(user.Account) || model.IsPlatformAdminAccount(user.Account)},
+		RoomID:       room.ID,
+		SiteID:       room.SiteID,
+		Roles:        roles,
+		Name:         name,
+		RoomType:     room.Type,
+		IsSubscribed: isSubscribed,
+		JoinedAt:     joinedAt,
+		Open:         true,
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass.** Run: `make test SERVICE=room-worker`. Expected: PASS (watch for any existing test asserting a full-struct equality on a `newSub` result — update its expected value to include `Open: true`).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add room-worker/handler.go room-worker/handler_test.go
+git commit -m "feat(room-worker): new subscriptions born open=true"
+```
+
+---
+
+### Task 7: user-service — exclude closed rooms from `subscription.list`
+
+**Files:**
+- Modify: `user-service/mongorepo/subscriptions.go` (`AggregateSubscriptions` match ~line 242; `subscriptionProjection` ~line 183)
+- Test: `user-service/mongorepo/subscriptions_test.go` (integration; check existing `//go:build integration` tests there for the harness)
+
+**Interfaces:**
+- Consumes: `SubscriptionRepo.AggregateSubscriptions(ctx, account, listType string, favorite bool, withinDays *int, page)` (existing).
+- Produces: same; now excludes `open: false` rows.
+
+- [ ] **Step 1: Write the failing integration test.** In `user-service/mongorepo/subscriptions_test.go` (match the existing test harness — likely `testutil.MongoDB` + `NewSubscriptionRepo`; also insert a matching `rooms` doc so the deleted-filter `$lookup` keeps the sub). Insert three channel subs for `alice`: one `open: true`, one `open: false`, one with no `open` key; each with a non-deleted room doc. Assert the list returns the open and missing-field rows and excludes the `open: false` row:
+
+```go
+func TestAggregateSubscriptions_ExcludesClosed(t *testing.T) {
+	// ... set up db, repo, insert rooms r_open/r_closed/r_missing (non-"Del-" names)
+	// ... insert subs: (r_open, open:true), (r_closed, open:false), (r_missing, no open field)
+	res, err := repo.AggregateSubscriptions(ctx, "alice", "rooms", false, nil, mongoutil.OffsetPageRequest{Offset: 0, Limit: 50})
+	require.NoError(t, err)
+	roomIDs := map[string]bool{}
+	for _, s := range res.Data {
+		roomIDs[s.RoomID] = true
+	}
+	assert.True(t, roomIDs["r_open"])
+	assert.True(t, roomIDs["r_missing"])
+	assert.False(t, roomIDs["r_closed"], "explicitly closed subscription must be excluded")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails.** Run: `make test-integration SERVICE=user-service`. Expected FAIL: `r_closed` present. (If Docker unavailable, note as written-but-unrun and rely on `make build`.)
+
+- [ ] **Step 3: Add the filter.** In `AggregateSubscriptions`, after the `favorite` block (~line 244), before building the pipeline:
+
+```go
+	// Exclude rooms explicitly closed by the user; a missing field (defensive)
+	// and open:true both pass. Applied to subscription.list only.
+	match["open"] = bson.M{"$ne": false}
+```
+
+- [ ] **Step 4: Surface the field on the projection.** In `subscriptionProjection` (~line 183), after `"favorite": 1,`:
+
+```go
+		"open":              1,
+```
+
+- [ ] **Step 5: Run tests to verify they pass.** Run: `make test-integration SERVICE=user-service`. Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add user-service/mongorepo/subscriptions.go user-service/mongorepo/subscriptions_test.go
+git commit -m "feat(user-service): exclude closed subscriptions from subscription.list"
+```
+
+---
+
+### Task 8: inbox-worker — mirror `subscription_opened`
+
+**Files:**
+- Modify: `inbox-worker/handler.go` (dispatch switch ~line 112; `InboxStore` interface ~line 55; add `handleSubscriptionOpened` near `handleSubscriptionFavoriteToggled` ~line 293)
+- Modify: `inbox-worker/main.go` (add `UpdateSubscriptionOpen` near `UpdateSubscriptionFavorite` ~line 267)
+- Regenerate: `inbox-worker/mock_store_test.go` via `make generate SERVICE=inbox-worker`
+- Test: `inbox-worker/handler_test.go` (extend `stubInboxStore`; three handler tests), `inbox-worker/integration_test.go` (`TestMongoInboxStore_UpdateSubscriptionOpen`)
+
+**Interfaces:**
+- Consumes: `s.naksIfSubscriptionMissing(ctx, account, roomID)` (existing), `model.SubscriptionOpenedEvent`.
+- Produces: `InboxStore.UpdateSubscriptionOpen(ctx context.Context, roomID, account string, open bool) error`, `(*Handler).handleSubscriptionOpened(ctx, evt *model.InboxEvent) error`.
+
+- [ ] **Step 1: Write the failing handler tests.** In `inbox-worker/handler_test.go`, extend `stubInboxStore` with an `UpdateSubscriptionOpen` method (mutating the in-memory sub, silent no-op on missing), then:
+
+```go
+func TestHandler_SubscriptionOpened(t *testing.T) {
+	// store seeded with sub (r1, alice, open:false)
+	// build InboxEvent{Type:"subscription_opened", Payload: json of SubscriptionOpenedEvent{Account:"alice",RoomID:"r1",Open:true,Timestamp:123}}
+	// require.NoError(t, h.HandleEvent(ctx, raw))
+	// assert seeded sub now Open==true
+}
+
+func TestHandler_SubscriptionOpened_MissingSubscriptionNoOp(t *testing.T) {
+	// empty store; payload references unknown account; HandleEvent returns nil
+}
+
+func TestHandler_SubscriptionOpened_MalformedPayload(t *testing.T) {
+	// Payload: []byte("not-json"); HandleEvent returns error
+}
+```
+
+(Mirror the exact shape of the `TestHandler_SubscriptionFavoriteToggled*` tests.)
+
+- [ ] **Step 2: Run tests to verify they fail.** Run: `make test SERVICE=inbox-worker`. Expected FAIL: undefined `handleSubscriptionOpened` / `UpdateSubscriptionOpen`.
+
+- [ ] **Step 3: Add the dispatch case.** In `inbox-worker/handler.go` after the favorite case (line 112):
+
+```go
+	case "subscription_opened":
+		return h.handleSubscriptionOpened(ctx, &evt)
+```
+
+- [ ] **Step 4: Add the interface method.** In the `InboxStore` interface after `UpdateSubscriptionFavorite` (~line 58):
+
+```go
+	// UpdateSubscriptionOpen sets open by (roomID, account). No ordering guard:
+	// set-true is idempotent. Missing sub is a silent no-op.
+	UpdateSubscriptionOpen(ctx context.Context, roomID, account string, open bool) error
+```
+
+- [ ] **Step 5: Add the handler method.** After `handleSubscriptionFavoriteToggled` (~line 303):
+
+```go
+// handleSubscriptionOpened mirrors a room-side open onto the user's home-site subscription.
+func (h *Handler) handleSubscriptionOpened(ctx context.Context, evt *model.InboxEvent) error {
+	var e model.SubscriptionOpenedEvent
+	if err := json.Unmarshal(evt.Payload, &e); err != nil {
+		return fmt.Errorf("unmarshal subscription_opened payload: %w", err)
+	}
+	if err := h.store.UpdateSubscriptionOpen(ctx, e.RoomID, e.Account, e.Open); err != nil {
+		return fmt.Errorf("update subscription open for %q in room %q: %w", e.Account, e.RoomID, err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 6: Add the mongo impl.** In `inbox-worker/main.go` after `UpdateSubscriptionFavorite` (~line 285):
+
+```go
+// UpdateSubscriptionOpen sets open by (roomID, account). No high-water guard —
+// set-true is idempotent and order-insensitive. Missing sub is a silent no-op.
+func (s *mongoInboxStore) UpdateSubscriptionOpen(ctx context.Context, roomID, account string, open bool) error {
+	res, err := s.subCol.UpdateOne(ctx,
+		bson.M{"roomId": roomID, "u.account": account},
+		bson.M{"$set": bson.M{"open": open}},
+	)
+	if err != nil {
+		return fmt.Errorf("update subscription open for %q in room %q: %w", account, roomID, err)
+	}
+	if res.MatchedCount == 0 {
+		return s.naksIfSubscriptionMissing(ctx, account, roomID)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 7: Regenerate mocks and add the integration test.** Run: `make generate SERVICE=inbox-worker`. In `inbox-worker/integration_test.go` add `TestMongoInboxStore_UpdateSubscriptionOpen` mirroring the favorite integration test: seed a sub with `open:false`, call `UpdateSubscriptionOpen(ctx,"r1","alice",true)`, assert stored `open==true`; call for a missing sub, assert no error and no doc created.
+
+- [ ] **Step 8: Run tests to verify they pass.** Run: `make test SERVICE=inbox-worker`, then `make test-integration SERVICE=inbox-worker` (Docker). Expected: PASS.
+
+- [ ] **Step 9: Commit.**
+
+```bash
+git add inbox-worker/handler.go inbox-worker/main.go inbox-worker/mock_store_test.go inbox-worker/handler_test.go inbox-worker/integration_test.go
+git commit -m "feat(inbox-worker): mirror subscription_opened cross-site event"
+```
+
+---
+
+### Task 9: Client API docs
+
+**Files:**
+- Modify: `docs/client-api.md` (new "Open Room" RPC section; `subscription.update` action enum; `Subscription` field table)
+- Modify: `docs/client-api/request-reply.md` (derived RPC view)
+- Modify: `docs/client-api/events.md` (derived events view — `subscription.update` action enum + `Subscription.open` field)
+
+**Interfaces:**
+- Consumes: the wire shapes from Tasks 1–5 (`OpenRoomResponse`, subject, `errNotRoomMember`, `action: "opened"`, `Subscription.open`).
+
+- [ ] **Step 1: Read the favorite sections.** In `docs/client-api.md`, find "Toggle Favorite" and the `subscription.update` event and `Subscription` field table. In the two derived views, find the same. These are the templates.
+
+- [ ] **Step 2: Add the "Open Room" RPC section** to `docs/client-api.md`, sibling to "Toggle Favorite": subject `chat.user.{account}.request.room.{roomID}.{siteID}.open`; empty request body; response `OpenRoomResponse` field table (`status: string`, `open: bool`) with a JSON example `{"status":"ok","open":true}`; error case `errNotRoomMember` (requester has no subscription in the room); triggered `subscription.update` event with `action: "opened"`; note the cross-site home-site mirror.
+
+- [ ] **Step 3: Extend the `subscription.update` action enum** in `docs/client-api.md` to include `"opened"`, and add `open` (bool) to the `Subscription` field table.
+
+- [ ] **Step 4: Mirror the changes** into `docs/client-api/request-reply.md` (the new RPC) and `docs/client-api/events.md` (the `subscription.update` action enum and the `Subscription.open` field), matching each file's existing style.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add docs/client-api.md docs/client-api/request-reply.md docs/client-api/events.md
+git commit -m "docs(client-api): document open RPC, opened action, Subscription.open"
+```
+
+---
+
+### Task 10: Full verification sweep
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Lint.** Run: `make lint`. Fix any findings. Expected: clean.
+
+- [ ] **Step 2: Unit tests across touched packages.** Run: `make test SERVICE=room-service`, `make test SERVICE=room-worker`, `make test SERVICE=inbox-worker`, and the `pkg/model`, `pkg/subject`, `pkg/outbox` test targets. Expected: PASS.
+
+- [ ] **Step 3: Integration tests (if Docker available).** Run: `make test-integration SERVICE=room-service`, `make test-integration SERVICE=user-service`, `make test-integration SERVICE=inbox-worker`. Expected: PASS. If Docker is unavailable, record which integration tests are written-but-unrun.
+
+- [ ] **Step 4: SAST.** Run: `make sast`. Expected: no new medium+ findings.
+
+- [ ] **Step 5: Delete session review reports.** If `docs/reviews/` has files from this session, delete them before any PR (CLAUDE.md §5). No commit needed if the directory is empty.
+
+- [ ] **Step 6: Final confirmation.** Confirm every spec section maps to a completed task: model field (T1), subject (T2), wire/outbox (T3), store (T4), handler (T5), create-default (T6), list filter (T7), inbox mirror (T8), docs (T9).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** model field → T1; subject → T2; response/event/const/outbox → T3; store `OpenSubscription` → T4; handler `openRoom` + registration + federation → T5; `newSub` create-default → T6; `subscription.list` filter + projection → T7; inbox mirror (dispatch, interface, handler, mongo, no-guard) → T8; client-api + derived views → T9; verification → T10. All covered.
+- **Placeholder scan:** all code steps carry concrete code; test-heavy steps (T5, T7, T8) reference the exact favorite-suite template to copy and list every adaptation — no vague "add tests".
+- **Type consistency:** `OpenSubscription(ctx, roomID, account)`, `UpdateSubscriptionOpen(ctx, roomID, account, open)`, `OpenRoomResponse{Status, Open}`, `SubscriptionOpenedEvent{Account, RoomID, Open, Timestamp}`, `InboxSubscriptionOpened = "subscription_opened"`, action `"opened"`, subject tail `.open` — used identically across T3–T9.

--- a/docs/superpowers/specs/2026-07-26-open-room-subscription-flag-design.md
+++ b/docs/superpowers/specs/2026-07-26-open-room-subscription-flag-design.md
@@ -1,0 +1,366 @@
+# Open-Room Subscription Flag + `open` RPC in room-service
+
+## Summary
+
+A new per-user, per-room boolean `Subscription.open` plus a client-facing NATS
+request/reply RPC, `open`, that sets `open = true` for the requester on a single
+room. `subscription.list` excludes subscriptions whose `open` is explicitly
+`false`, so an "opened" room shows in the sidebar and a "closed" room is hidden
+from the list.
+
+Architecturally mirrors `favorite.toggle` (`docs/.../2026-06-01-favorite-toggle-rpc-design.md`):
+same subject shape, same store `FindOneAndUpdate` pattern, same cross-site
+replication path through OUTBOX → INBOX. Two deliberate differences:
+
+1. **Set, not toggle.** Every call sets `open = true`. No race handling — per
+   the requirement, "just make it true every time." Applying `true` twice, or
+   out of order, always converges to `true`, so no `openUpdatedAt` high-water
+   guard is needed (unlike `favorite`/`mute`).
+2. **Default true, always present.** New subscriptions are born `open = true`.
+   The model field is a plain `bool` that is always written — there is no
+   legacy/absent-field handling (per the agreed scope: assume every
+   subscription document carries `open`).
+
+## Subscription model
+
+`pkg/model/subscription.go` gains one field on `Subscription`:
+
+```go
+Open bool `json:"open" bson:"open"`
+```
+
+Both tags always present (no `omitempty`) — `false` is serialized explicitly so
+clients can distinguish "closed" from "unknown".
+
+### Creation default (`room-worker`)
+
+`room-worker`'s single subscription constructor `newSub` sets `Open: true`, so
+**every** creation path is born open: DM, botDM, self-DM, channel-create members,
+and add-members. This is required: with a plain `bool` and no `omitempty`, a
+newly created subscription would otherwise persist `open: false` (the Go zero
+value) and be immediately excluded from `subscription.list`.
+
+`buildSelfDMSub` and the other builders need no change — they all route through
+`newSub`.
+
+## `subscription.list` filter
+
+`user-service/mongorepo/subscriptions.go`, `AggregateSubscriptions` match stage:
+
+```go
+match["open"] = bson.M{"$ne": false} // exclude only rooms explicitly closed
+```
+
+`$ne: false` includes `open: true` (and, defensively, any doc missing the
+field) and excludes only an explicit `open: false`. This mirrors the
+requirement: "exclude all subscriptions that open field exist and value is
+false."
+
+Scope: applied to the `subscription.list` RPC (`AggregateSubscriptions`) only.
+The count/active/getChannels/getDM/getByRoomID paths are unchanged. For
+consistency, `subscriptionProjection` gains `"open": 1` so the field surfaces on
+the getChannels path, but no filter is added there.
+
+## Subject
+
+- Concrete: `chat.user.{account}.request.room.{roomID}.{siteID}.open`
+- Wildcard: `chat.user.*.request.room.*.{siteID}.open`
+- Pattern (natsrouter): `chat.user.{account}.request.room.{roomID}.{siteID}.open`
+
+`{siteID}` is the room's origin site — the site that owns the room and runs the
+`room-service` handling this RPC. Subject parsing reuses
+`subject.ParseUserRoomSubject`. Queue group / router: same as the other
+room-scoped RPCs.
+
+`pkg/subject/subject.go` gains three builders mirroring the `FavoriteToggle`
+trio:
+
+```go
+func OpenRoom(account, roomID, siteID string) string {
+    return fmt.Sprintf("chat.user.%s.request.room.%s.%s.open", account, roomID, siteID)
+}
+func OpenRoomWildcard(siteID string) string {
+    return fmt.Sprintf("chat.user.*.request.room.*.%s.open", siteID)
+}
+func OpenRoomPattern(siteID string) string {
+    return fmt.Sprintf("chat.user.{account}.request.room.{roomID}.%s.open", siteID)
+}
+```
+
+## Wire Format
+
+`pkg/model/event.go`:
+
+```go
+// OpenRoomResponse is the sync reply for the open RPC. Open is always true.
+type OpenRoomResponse struct {
+    Status string `json:"status"` // always "ok" on success
+    Open   bool   `json:"open"`   // always true
+}
+
+// SubscriptionOpenedEvent is the InboxEvent.Payload for type "subscription_opened".
+type SubscriptionOpenedEvent struct {
+    Account   string `json:"account"   bson:"account"`
+    RoomID    string `json:"roomId"    bson:"roomId"`
+    Open      bool   `json:"open"      bson:"open"`
+    Timestamp int64  `json:"timestamp" bson:"timestamp"` // UnixMilli UTC
+}
+```
+
+Inbox event-type constant (`pkg/model/event.go`):
+
+```go
+InboxSubscriptionOpened InboxEventType = "subscription_opened"
+```
+
+Request body: empty. The subject already carries `account` and `roomID`; any
+body content is ignored. Registered with `natsrouter.RegisterNoBody`, like
+`favoriteToggle`.
+
+The `SubscriptionUpdateEvent.Action` enum gains `"opened"` alongside the
+existing `"added"`, `"removed"`, `"role_updated"`, `"mute_toggled"`,
+`"favorite_toggled"`.
+
+## Handler Flow
+
+`room-service/handler.go`:
+
+1. `Register` adds
+   `natsrouter.RegisterNoBody(r, subject.OpenRoomPattern(h.siteID), h.openRoom)`.
+2. `openRoom(c *natsrouter.Context) (*model.OpenRoomResponse, error)`:
+   1. `account := c.Param("account")`, `roomID := c.Param("roomID")`.
+   2. Tracing: set `room.id` and `site.id` span attributes.
+   3. `now := time.Now().UTC()`.
+   4. `sub, err := h.store.OpenSubscription(ctx, roomID, account)`.
+      - `errors.Is(err, model.ErrSubscriptionNotFound)` → `errNotRoomMember`
+        (this atomic no-match **is** the "does the user have this subscription"
+        check — no separate `GetSubscription`, same as `favorite.toggle`).
+      - Other errors → `fmt.Errorf("open subscription: %w", err)`.
+   5. `h.publishSubscriptionUpdate(ctx, account, "opened", sub, "", now)` —
+      best-effort core publish; a failure is logged, not returned.
+   6. `userSiteID, err := h.store.GetUserSiteID(ctx, account)`.
+      Error → `fmt.Errorf("get user siteId: %w", err)`.
+   7. If `userSiteID != "" && userSiteID != h.siteID`:
+      - Build `SubscriptionOpenedEvent{Account, RoomID, Open: sub.Open, Timestamp: now.UnixMilli()}`.
+      - `json.Marshal` → error wrapped `"marshal opened payload: %w"`.
+      - `h.federateOne(ctx, roomID, userSiteID, model.InboxSubscriptionOpened, payloadData, roomID+":"+account, now.UnixMilli())`.
+        Failure → `fmt.Errorf("federate opened: %w", err)` (fatal to the client;
+        federation retries on next action).
+   8. Reply `OpenRoomResponse{Status: "ok", Open: sub.Open}`.
+
+Idempotency: this is a **set** to `true`. Every successful call yields `true`.
+No dedup, no debounce required — repeated calls are harmless.
+
+## Errors
+
+Reuses the existing room-service sentinel — no new error variables:
+
+- `errNotRoomMember` (already in `room-service/helper.go`) — returned when the
+  requester has no subscription in the room.
+
+## Store
+
+### Interface (`room-service/store.go`)
+
+```go
+// OpenSubscription atomically sets open=true for (roomID, account) via a single
+// FindOneAndUpdate and returns the post-update subscription, or
+// model.ErrSubscriptionNotFound (wrapped) when no match.
+OpenSubscription(ctx context.Context, roomID, account string) (*model.Subscription, error)
+```
+
+`GetUserSiteID` already exists — reused as-is.
+
+### Mongo implementation (`room-service/store_mongo.go`)
+
+Reuses the existing `findOneAndUpdateSub` helper (same one `favorite`/`mute`
+use), with a plain `$set` (no timestamp — no high-water guard):
+
+```go
+func (s *MongoStore) OpenSubscription(ctx context.Context, roomID, account string) (*model.Subscription, error) {
+    return s.findOneAndUpdateSub(ctx, roomID, account, "open subscription", bson.M{
+        "open": true,
+    })
+}
+```
+
+`findOneAndUpdateSub` already maps `mongo.ErrNoDocuments` →
+`model.ErrSubscriptionNotFound` and returns the `options.After` post-image.
+
+### Indexes
+
+No new indexes. The existing `(roomId, "u.account")` compound index covers the
+lookup.
+
+## Cross-Site Federation
+
+Mirrors `subscription_favorite_toggled`. The room's site is the write site; the
+user's home site is the destination.
+
+### Outbox partition (`pkg/outbox/outbox.go`)
+
+Add `model.InboxSubscriptionOpened` to `ConcurrentEventTypes` (order-insensitive:
+the destination apply is an idempotent set-true, so parallel/out-of-order
+forwarding is safe). This registration is mandatory — `outbox.Publish` rejects
+any event type in neither partition.
+
+### Inbox handler (`inbox-worker`)
+
+`inbox-worker/handler.go`:
+
+1. Dispatch switch gains
+   `case "subscription_opened": return h.handleSubscriptionOpened(ctx, &evt)`.
+2. `handleSubscriptionOpened`:
+   1. Unmarshal `evt.Payload` into `SubscriptionOpenedEvent`.
+   2. `h.store.UpdateSubscriptionOpen(ctx, e.RoomID, e.Account, e.Open)`.
+
+`InboxStore` interface (`inbox-worker/handler.go`) gains:
+
+```go
+UpdateSubscriptionOpen(ctx context.Context, roomID, account string, open bool) error
+```
+
+Mongo implementation (`inbox-worker/main.go`) — plain `$set`, **no**
+`openUpdatedAt` guard (no race handling required):
+
+```go
+func (s *mongoInboxStore) UpdateSubscriptionOpen(ctx context.Context, roomID, account string, open bool) error {
+    res, err := s.subCol.UpdateOne(ctx,
+        bson.M{"roomId": roomID, "u.account": account},
+        bson.M{"$set": bson.M{"open": open}},
+    )
+    if err != nil {
+        return fmt.Errorf("update subscription open for %q in room %q: %w", account, roomID, err)
+    }
+    if res.MatchedCount == 0 {
+        return s.naksIfSubscriptionMissing(ctx, account, roomID)
+    }
+    return nil
+}
+```
+
+Missing-subscription handling reuses the existing `naksIfSubscriptionMissing`
+path (same as `UpdateSubscriptionFavorite`): a federation race where the user
+left the room between the origin write and the mirror is a silent no-op, not a
+poison-pill.
+
+### Stream ownership
+
+No `bootstrap.go` change. `OUTBOX_{site}` and `INBOX_{site}` are owned by
+ops/IaC (CLAUDE.md §6). `inbox-worker` already owns local INBOX creation in dev.
+
+## Client API Doc
+
+Per CLAUDE.md §5, the same PR updates `docs/client-api.md` and its derived views
+(`docs/client-api/request-reply.md`, `docs/client-api/events.md`):
+
+- New "Open Room" section under user-scoped RPCs, sibling to "Toggle Favorite":
+  subject, empty request body, `OpenRoomResponse`, error cases (`errNotRoomMember`),
+  triggered `subscription.update` event with `action: "opened"`, and the
+  cross-site outbox-mirror behaviour.
+- The `subscription.update` event section's `action` enum gains `"opened"`.
+- The `Subscription` field table gains `open` (bool).
+
+## Testing (TDD)
+
+### Subject builders (`pkg/subject/subject_test.go`)
+
+- `TestOpenRoom` — concrete-subject builder.
+- `TestOpenRoomWildcard` — wildcard form.
+- `TestOpenRoomPattern` — natsrouter pattern form.
+- Round-trip with `ParseUserRoomSubject` on the concrete subject.
+
+### Model round-trip (`pkg/model/model_test.go`)
+
+- Extend the `Subscription` round-trip case to populate `Open: true`.
+- Assert `"open"` is present in the JSON even when `false` (parallel to `muted`).
+- `TestOpenRoomResponseJSON` — round-trip + raw-map assertion on `{status, open}`.
+- `TestSubscriptionOpenedEventJSON` — round-trip.
+- `TestInboxSubscriptionOpenedConst` — exact string `"subscription_opened"`.
+- `TestOpenRoomInOutboxConcurrentSet` (in `pkg/outbox` test) — asserts the new
+  type is in `ConcurrentEventTypes` and accepted by `Publish`.
+
+### Handler unit tests (`room-service/handler_test.go`)
+
+Parallel to the favorite suite; each builds a `Handler` with a mocked
+`RoomStore` and captured `publishCore` / `publishToStream` closures.
+
+| Test | Setup | Asserts |
+|------|-------|---------|
+| `TestHandler_OpenRoom_Success` | store returns sub with `Open: true`, `GetUserSiteID` returns same site | Reply `{ok, true}`. One core publish on `subscription.update` with `Action: "opened"`. No stream publish. |
+| `TestHandler_OpenRoom_CrossSitePublishesOutbox` | `GetUserSiteID` returns remote site | Stream publish carries `OutboxEvent` with inner `SubscriptionOpenedEvent{Open:true, nonzero Timestamp}`, `Type=InboxSubscriptionOpened`. |
+| `TestHandler_OpenRoom_NotRoomMember` | store returns `ErrSubscriptionNotFound` | `errors.Is(err, errNotRoomMember)`; no publishes. |
+| `TestHandler_OpenRoom_StoreError` | store returns `fmt.Errorf("db down")` | Error contains `"open subscription"`; no publishes. |
+| `TestHandler_OpenRoom_GetUserSiteIDError` | open ok, `GetUserSiteID` fails | Error contains `"get user siteId"`; no stream publish. |
+| `TestHandler_OpenRoom_CrossSiteOutboxPublishFailure` | cross-site, `publishToStream` errors | Error contains `"federate opened"`. |
+| `TestHandler_OpenRoom_CorePublishFailureIsNonFatal` | same-site, `publishCore` errors | `require.NoError`; still replies `{ok, true}`. |
+
+Mocks: `make generate SERVICE=room-service` regenerates `mock_store_test.go`
+with `OpenSubscription`.
+
+### room-worker (`room-worker/handler_test.go`)
+
+- `TestNewSub_OpenTrue` (or extend an existing `newSub`/create test) — asserts
+  a subscription built by `newSub` has `Open == true`, so every create path is
+  born open.
+
+### user-service (`user-service/mongorepo/subscriptions_test.go` / integration)
+
+- `TestAggregateSubscriptions_ExcludesClosed` — a doc with `open: false` is
+  excluded from the list; `open: true` and (defensively) a doc missing the field
+  are included.
+
+### room-service integration (`room-service/integration_test.go`)
+
+`TestMongoStore_OpenSubscription`:
+1. Insert a subscription with `open: false`.
+2. `OpenSubscription` → returned `Open == true`; `GetSubscription` reads back `true`.
+3. Call again → still `true` (idempotent).
+4. `OpenSubscription("missing", account)` → `errors.Is(err, model.ErrSubscriptionNotFound)`, nil sub.
+
+### inbox-worker unit tests (`inbox-worker/handler_test.go`)
+
+Extend `stubInboxStore` with `UpdateSubscriptionOpen`.
+
+- `TestHandler_SubscriptionOpened` — happy path, store's sub has `Open == true`
+  after `HandleEvent`.
+- `TestHandler_SubscriptionOpened_MissingSubscriptionNoOp` — empty store, unknown
+  account, `HandleEvent` returns `nil`.
+- `TestHandler_SubscriptionOpened_MalformedPayload` — `Payload: []byte("not-json")`,
+  `HandleEvent` returns error (redeliver path).
+
+### inbox-worker integration (`inbox-worker/integration_test.go`)
+
+- `TestMongoInboxStore_UpdateSubscriptionOpen` — sets `open` on an existing sub;
+  missing sub is a silent no-op.
+
+### Coverage
+
+New handler/store methods hit every branch above. Expected ≥90% on new code;
+project floor 80% applies to each package.
+
+## Out of Scope
+
+- **"Close room" RPC.** Nothing in this change sets `open = false`; a close/hide
+  endpoint is separate future work. Today every subscription stays `open` unless
+  some external writer sets it false, which the list filter then honors.
+- **Frontend changes.** The frontend reads `open` off `Subscription` separately.
+- **`openUpdatedAt` / ordering guard.** Explicitly omitted — set-true is
+  idempotent and order-insensitive.
+- **Notification / broadcast / gatekeeper behaviour.** `open` is a
+  list-visibility hint only; no delivery, routing, or validation changes.
+- **Applying the filter to count/getChannels/getDM/getByRoomID.** Only
+  `subscription.list` filters on `open`.
+
+## Risks
+
+- **Create-default omission.** If `newSub` did not set `Open: true`, every new
+  subscription would persist `open: false` and vanish from lists. The
+  `TestNewSub_OpenTrue` test guards this invariant.
+- **Cross-site mirror lag.** Between the room-site write and the home-site
+  mirror, a home-site `subscription.list` returns the pre-open value. Acceptable
+  — the requester's session already got the `subscription.update` event
+  synchronously; other devices reconcile on next refetch. Same as `favorite`.
+- **Federation race silent no-op.** If the user leaves the room between the
+  origin write and the inbox mirror, the mirror silently no-ops (via
+  `naksIfSubscriptionMissing`). Same pattern as `UpdateSubscriptionFavorite`.

--- a/inbox-worker/handler.go
+++ b/inbox-worker/handler.go
@@ -57,7 +57,8 @@ type InboxStore interface {
 	// are silent no-ops. A genuinely missing sub returns an error (Nak) so the event redelivers until member_added lands.
 	UpdateSubscriptionFavorite(ctx context.Context, roomID, account string, favorite bool, favoriteUpdatedAt time.Time) error
 	// UpdateSubscriptionOpen sets open by (roomID, account). No ordering guard:
-	// set-true is idempotent. Missing sub is a silent no-op.
+	// set-true is idempotent. A genuinely missing sub returns an error (Nak) so the
+	// event redelivers until the member_added that creates the sub lands.
 	UpdateSubscriptionOpen(ctx context.Context, roomID, account string, open bool) error
 	// UpdateSubscriptionNamesForRoom sets name on every subscription in the room,
 	// each guarded by its own nameUpdatedAt so an out-of-order rename cannot regress

--- a/inbox-worker/handler.go
+++ b/inbox-worker/handler.go
@@ -182,6 +182,7 @@ func (h *Handler) handleMemberAdded(ctx context.Context, evt *model.InboxEvent) 
 			IsSubscribed:       subscriptionIsSubscribed(roomType, &user),
 			HistorySharedSince: historySharedSince,
 			JoinedAt:           joinedAt,
+			Open:               true,
 		}
 		subs = append(subs, sub)
 	}

--- a/inbox-worker/handler.go
+++ b/inbox-worker/handler.go
@@ -56,6 +56,9 @@ type InboxStore interface {
 	// favoriteUpdatedAt (the source event's publish time): older/duplicate events
 	// are silent no-ops. A genuinely missing sub returns an error (Nak) so the event redelivers until member_added lands.
 	UpdateSubscriptionFavorite(ctx context.Context, roomID, account string, favorite bool, favoriteUpdatedAt time.Time) error
+	// UpdateSubscriptionOpen sets open by (roomID, account). No ordering guard:
+	// set-true is idempotent. Missing sub is a silent no-op.
+	UpdateSubscriptionOpen(ctx context.Context, roomID, account string, open bool) error
 	// UpdateSubscriptionNamesForRoom sets name on every subscription in the room,
 	// each guarded by its own nameUpdatedAt so an out-of-order rename cannot regress
 	// a sub to a stale name. Used when a channel is renamed — replicated via the
@@ -110,6 +113,8 @@ func (h *Handler) HandleEvent(ctx context.Context, data []byte) error {
 		return h.handleSubscriptionMuteToggled(ctx, &evt)
 	case "subscription_favorite_toggled":
 		return h.handleSubscriptionFavoriteToggled(ctx, &evt)
+	case "subscription_opened":
+		return h.handleSubscriptionOpened(ctx, &evt)
 	case "thread_subscription_upserted":
 		return h.handleThreadSubscriptionUpserted(ctx, &evt)
 	case "thread_read":
@@ -298,6 +303,18 @@ func (h *Handler) handleSubscriptionFavoriteToggled(ctx context.Context, evt *mo
 	}
 	if err := h.store.UpdateSubscriptionFavorite(ctx, e.RoomID, e.Account, e.Favorite, time.UnixMilli(e.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("update subscription favorite for %q in room %q: %w", e.Account, e.RoomID, err)
+	}
+	return nil
+}
+
+// handleSubscriptionOpened mirrors a room-side open onto the user's home-site subscription.
+func (h *Handler) handleSubscriptionOpened(ctx context.Context, evt *model.InboxEvent) error {
+	var e model.SubscriptionOpenedEvent
+	if err := json.Unmarshal(evt.Payload, &e); err != nil {
+		return fmt.Errorf("unmarshal subscription_opened payload: %w", err)
+	}
+	if err := h.store.UpdateSubscriptionOpen(ctx, e.RoomID, e.Account, e.Open); err != nil {
+		return fmt.Errorf("update subscription open for %q in room %q: %w", e.Account, e.RoomID, err)
 	}
 	return nil
 }

--- a/inbox-worker/handler_test.go
+++ b/inbox-worker/handler_test.go
@@ -514,6 +514,9 @@ func TestHandleEvent_MemberAdded(t *testing.T) {
 	if sub.ID == "" {
 		t.Error("subscription ID should be non-empty (generated UUID)")
 	}
+	if !sub.Open {
+		t.Error("subscription Open = false, want true: cross-site members must be born visible in the sidebar")
+	}
 
 }
 

--- a/inbox-worker/handler_test.go
+++ b/inbox-worker/handler_test.go
@@ -41,6 +41,12 @@ type favoriteUpdate struct {
 	updatedAt time.Time
 }
 
+type openUpdate struct {
+	roomID  string
+	account string
+	open    bool
+}
+
 type nameUpdate struct {
 	roomID    string
 	newName   string
@@ -85,6 +91,7 @@ type stubInboxStore struct {
 	roleUpdates           []roleUpdate
 	muteUpdates           []muteUpdate
 	favoriteUpdates       []favoriteUpdate
+	openUpdates           []openUpdate
 	nameUpdates           []nameUpdate
 	visibilityUpdates     []visibilityUpdate
 	users                 []model.User
@@ -273,6 +280,27 @@ func (s *stubInboxStore) getFavoriteUpdates() []favoriteUpdate {
 	defer s.mu.Unlock()
 	cp := make([]favoriteUpdate, len(s.favoriteUpdates))
 	copy(cp, s.favoriteUpdates)
+	return cp
+}
+
+func (s *stubInboxStore) UpdateSubscriptionOpen(_ context.Context, roomID, account string, open bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.openUpdates = append(s.openUpdates, openUpdate{roomID: roomID, account: account, open: open})
+	for i := range s.subscriptions {
+		if s.subscriptions[i].RoomID == roomID && s.subscriptions[i].User.Account == account {
+			s.subscriptions[i].Open = open
+			return nil
+		}
+	}
+	return nil // missing-subscription → no-op
+}
+
+func (s *stubInboxStore) getOpenUpdates() []openUpdate {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]openUpdate, len(s.openUpdates))
+	copy(cp, s.openUpdates)
 	return cp
 }
 
@@ -1775,6 +1803,71 @@ func TestHandler_SubscriptionFavoriteToggled_MalformedPayload(t *testing.T) {
 
 	evt, err := json.Marshal(model.InboxEvent{
 		Type:    model.InboxSubscriptionFavoriteToggled,
+		Payload: []byte("not-json"),
+	})
+	require.NoError(t, err)
+
+	require.Error(t, h.HandleEvent(context.Background(), evt))
+}
+
+func TestHandler_SubscriptionOpened(t *testing.T) {
+	store := &stubInboxStore{
+		subscriptions: []model.Subscription{
+			{
+				ID:     "s1",
+				User:   model.SubscriptionUser{ID: "u1", Account: "alice"},
+				RoomID: "r1",
+			},
+		},
+	}
+	h := NewHandler(store)
+
+	payload, err := json.Marshal(model.SubscriptionOpenedEvent{
+		Account: "alice", RoomID: "r1", Open: true, Timestamp: 123,
+	})
+	require.NoError(t, err)
+	evt, err := json.Marshal(model.InboxEvent{
+		Type: model.InboxSubscriptionOpened, SiteID: "site-a", DestSiteID: "site-b",
+		Payload: payload, Timestamp: 123,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, h.HandleEvent(context.Background(), evt))
+
+	subs := store.getSubscriptions()
+	require.Len(t, subs, 1)
+	assert.True(t, subs[0].Open)
+
+	updates := store.getOpenUpdates()
+	require.Len(t, updates, 1)
+	assert.Equal(t, "alice", updates[0].account)
+	assert.True(t, updates[0].open)
+}
+
+func TestHandler_SubscriptionOpened_MissingSubscriptionNoOp(t *testing.T) {
+	store := &stubInboxStore{}
+	h := NewHandler(store)
+
+	payload, err := json.Marshal(model.SubscriptionOpenedEvent{
+		Account: "ghost", RoomID: "missing-room", Open: true, Timestamp: 123,
+	})
+	require.NoError(t, err)
+	evt, err := json.Marshal(model.InboxEvent{
+		Type: model.InboxSubscriptionOpened, SiteID: "site-a", DestSiteID: "site-b",
+		Payload: payload, Timestamp: 123,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, h.HandleEvent(context.Background(), evt))
+	assert.Empty(t, store.getSubscriptions())
+}
+
+func TestHandler_SubscriptionOpened_MalformedPayload(t *testing.T) {
+	store := &stubInboxStore{}
+	h := NewHandler(store)
+
+	evt, err := json.Marshal(model.InboxEvent{
+		Type:    model.InboxSubscriptionOpened,
 		Payload: []byte("not-json"),
 	})
 	require.NoError(t, err)

--- a/inbox-worker/integration_test.go
+++ b/inbox-worker/integration_test.go
@@ -383,6 +383,18 @@ func TestInbox_UpdateSubscriptionFavorite_MissingSubscriptionErrors(t *testing.T
 	assert.Contains(t, err.Error(), "subscription not found")
 }
 
+func TestInbox_UpdateSubscriptionOpen_MissingSubscriptionErrors(t *testing.T) {
+	ctx := context.Background()
+	store := newGuardStore(setupMongo(t))
+
+	// No ordering guard on open, so MatchedCount==0 can only mean a genuinely
+	// missing sub — same redeliver-until-member_added-lands contract as the
+	// other guarded subscription fields.
+	err := store.UpdateSubscriptionOpen(ctx, "missing-room", "ghost", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subscription not found")
+}
+
 func TestInboxWorker_ThreadSubscriptionUpserted_Insert_Integration(t *testing.T) {
 	db := setupMongo(t)
 	ctx := context.Background()
@@ -1376,6 +1388,23 @@ func TestInbox_UpdateSubscriptionFavorite_NewerApplies(t *testing.T) {
 	var got model.Subscription
 	require.NoError(t, store.subCol.FindOne(ctx, bson.M{"_id": "s1"}).Decode(&got))
 	assert.True(t, got.Favorite)
+}
+
+func TestInbox_UpdateSubscriptionOpen(t *testing.T) {
+	ctx := context.Background()
+	store := newGuardStore(setupMongo(t))
+
+	_, err := store.subCol.InsertOne(ctx, bson.M{
+		"_id": "s1", "roomId": "r1", "u": bson.M{"account": "alice"},
+		"open": false,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, store.UpdateSubscriptionOpen(ctx, "r1", "alice", true))
+
+	var got model.Subscription
+	require.NoError(t, store.subCol.FindOne(ctx, bson.M{"_id": "s1"}).Decode(&got))
+	assert.True(t, got.Open)
 }
 
 func TestInbox_UpdateSubscriptionNamesForRoom_OutOfOrderSkipped(t *testing.T) {

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -284,6 +284,22 @@ func (s *mongoInboxStore) UpdateSubscriptionFavorite(ctx context.Context, roomID
 	return nil
 }
 
+// UpdateSubscriptionOpen sets open by (roomID, account). No high-water guard —
+// set-true is idempotent and order-insensitive. Missing sub is a silent no-op.
+func (s *mongoInboxStore) UpdateSubscriptionOpen(ctx context.Context, roomID, account string, open bool) error {
+	res, err := s.subCol.UpdateOne(ctx,
+		bson.M{"roomId": roomID, "u.account": account},
+		bson.M{"$set": bson.M{"open": open}},
+	)
+	if err != nil {
+		return fmt.Errorf("update subscription open for %q in room %q: %w", account, roomID, err)
+	}
+	if res.MatchedCount == 0 {
+		return s.naksIfSubscriptionMissing(ctx, account, roomID)
+	}
+	return nil
+}
+
 func (s *mongoInboxStore) UpdateSubscriptionRead(ctx context.Context, roomID, account string, lastSeenAt time.Time, alert bool) error {
 	filter := bson.M{
 		"roomId":    roomID,

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -285,7 +285,9 @@ func (s *mongoInboxStore) UpdateSubscriptionFavorite(ctx context.Context, roomID
 }
 
 // UpdateSubscriptionOpen sets open by (roomID, account). No high-water guard —
-// set-true is idempotent and order-insensitive. Missing sub is a silent no-op.
+// set-true is idempotent and order-insensitive. A genuinely missing sub returns an
+// error (Nak) via naksIfSubscriptionMissing so the event redelivers until the
+// member_added that creates the sub lands.
 func (s *mongoInboxStore) UpdateSubscriptionOpen(ctx context.Context, roomID, account string, open bool) error {
 	res, err := s.subCol.UpdateOne(ctx,
 		bson.M{"roomId": roomID, "u.account": account},

--- a/outbox-worker/consumer_config_test.go
+++ b/outbox-worker/consumer_config_test.go
@@ -31,6 +31,7 @@ func TestBuildConcurrentConsumerConfig(t *testing.T) {
 		"chat.outbox.site-a.site-b.thread_read_all",
 		"chat.outbox.site-a.site-b.subscription_mute_toggled",
 		"chat.outbox.site-a.site-b.subscription_favorite_toggled",
+		"chat.outbox.site-a.site-b.subscription_opened",
 		"chat.outbox.site-a.site-b.room_restricted",
 		"chat.outbox.site-a.site-b.thread_subscription_upserted",
 	}, cc.FilterSubjects)

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -132,6 +132,7 @@ const (
 	InboxSubscriptionRead            InboxEventType = "subscription_read"
 	InboxSubscriptionMuteToggled     InboxEventType = "subscription_mute_toggled"
 	InboxSubscriptionFavoriteToggled InboxEventType = "subscription_favorite_toggled"
+	InboxSubscriptionOpened          InboxEventType = "subscription_opened"
 	InboxThreadSubscriptionUpserted  InboxEventType = "thread_subscription_upserted"
 	InboxThreadRead                  InboxEventType = "thread_read"
 	InboxThreadReadAll               InboxEventType = "thread_read_all"
@@ -478,6 +479,20 @@ type SubscriptionFavoriteToggledEvent struct {
 	RoomID    string `json:"roomId"               bson:"roomId"`
 	Favorite  bool   `json:"favorite"             bson:"favorite"`
 	Timestamp int64  `json:"timestamp"            bson:"timestamp"`
+}
+
+// OpenRoomResponse is the sync reply for the open RPC. Open is always true.
+type OpenRoomResponse struct {
+	Status string `json:"status"`
+	Open   bool   `json:"open"`
+}
+
+// SubscriptionOpenedEvent is the InboxEvent.Payload for type "subscription_opened".
+type SubscriptionOpenedEvent struct {
+	Account   string `json:"account"   bson:"account"`
+	RoomID    string `json:"roomId"    bson:"roomId"`
+	Open      bool   `json:"open"      bson:"open"`
+	Timestamp int64  `json:"timestamp" bson:"timestamp"`
 }
 
 type MemberRemoveEvent struct {

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -3297,6 +3297,26 @@ func TestInboxSubscriptionFavoriteToggledConst(t *testing.T) {
 	assert.Equal(t, model.InboxEventType("subscription_favorite_toggled"), model.InboxSubscriptionFavoriteToggled)
 }
 
+func TestOpenRoomResponseJSON(t *testing.T) {
+	r := model.OpenRoomResponse{Status: "ok", Open: true}
+	b, err := json.Marshal(r)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(b, &raw))
+	assert.Equal(t, "ok", raw["status"])
+	assert.Equal(t, true, raw["open"])
+	roundTrip(t, &r, &model.OpenRoomResponse{})
+}
+
+func TestSubscriptionOpenedEventJSON(t *testing.T) {
+	e := model.SubscriptionOpenedEvent{Account: "alice", RoomID: "r1", Open: true, Timestamp: 123}
+	roundTrip(t, &e, &model.SubscriptionOpenedEvent{})
+}
+
+func TestInboxSubscriptionOpenedConst(t *testing.T) {
+	assert.Equal(t, "subscription_opened", model.InboxSubscriptionOpened)
+}
+
 func TestSyncCreateDMRequestJSON(t *testing.T) {
 	src := model.SyncCreateDMRequest{
 		RoomType:         model.RoomTypeDM,

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -587,6 +587,7 @@ func TestSubscriptionJSON(t *testing.T) {
 			Alert:              true,
 			Muted:              true,
 			Favorite:           true,
+			Open:               true,
 		}
 		roundTrip(t, &s, &model.Subscription{})
 	})
@@ -651,6 +652,10 @@ func TestSubscriptionJSON_ThreadUnreadOmittedAlertAlwaysPresent(t *testing.T) {
 	favoriteVal, hasFavorite := raw["favorite"]
 	assert.True(t, hasFavorite, "favorite must be present in JSON even when false")
 	assert.Equal(t, false, favoriteVal)
+
+	openVal, hasOpen := raw["open"]
+	assert.True(t, hasOpen, "open must be present in JSON even when false")
+	assert.Equal(t, false, openVal)
 
 	var dst model.Subscription
 	require.NoError(t, json.Unmarshal(data, &dst))

--- a/pkg/model/subscription.go
+++ b/pkg/model/subscription.go
@@ -40,6 +40,10 @@ type Subscription struct {
 	Alert              bool             `json:"alert" bson:"alert"`
 	Muted              bool             `json:"muted" bson:"muted"`
 	Favorite           bool             `json:"favorite" bson:"favorite"`
+	// Open is the per-user sidebar-visibility flag. New subscriptions are born
+	// open (room-worker's newSub sets it); subscription.list excludes only rows
+	// explicitly closed (open == false). Set true by the room-service open RPC.
+	Open bool `json:"open" bson:"open"`
 	// Denormalized from Room.{Restricted,ExternalAccess}; the only place remote sites carry restricted state
 	// (cross-site inbox mirrors subscriptions, not Room docs). Treat missing as false.
 	Restricted     bool `json:"restricted,omitempty"     bson:"restricted,omitempty"`

--- a/pkg/outbox/outbox.go
+++ b/pkg/outbox/outbox.go
@@ -25,6 +25,7 @@ var ConcurrentEventTypes = []model.InboxEventType{
 	model.InboxThreadReadAll,
 	model.InboxSubscriptionMuteToggled,
 	model.InboxSubscriptionFavoriteToggled,
+	model.InboxSubscriptionOpened,
 	model.InboxRoomRestricted,
 	// message-worker: thread-subscription federation. Order-insensitive —
 	// inbox-worker's UpsertThreadSubscription is $setOnInsert (immutable identity)

--- a/pkg/outbox/outbox_test.go
+++ b/pkg/outbox/outbox_test.go
@@ -93,11 +93,7 @@ func TestPublish_WrapsPublishError(t *testing.T) {
 }
 
 func TestOpenInConcurrentEventTypes(t *testing.T) {
-	found := false
-	for _, et := range ConcurrentEventTypes {
-		if et == model.InboxSubscriptionOpened {
-			found = true
-		}
-	}
-	assert.True(t, found, "subscription_opened must ride the concurrent lane")
+	assert.Contains(t, ConcurrentEventTypes, model.InboxSubscriptionOpened,
+		"subscription_opened must ride the concurrent lane")
+	assert.NotContains(t, OrderedEventTypes, model.InboxSubscriptionOpened)
 }

--- a/pkg/outbox/outbox_test.go
+++ b/pkg/outbox/outbox_test.go
@@ -91,3 +91,13 @@ func TestPublish_WrapsPublishError(t *testing.T) {
 	err := Publish(context.Background(), publish, "site-a", "r1", "site-b", model.InboxSubscriptionRead, []byte(`{}`), "d", 1)
 	require.ErrorIs(t, err, assert.AnError)
 }
+
+func TestOpenInConcurrentEventTypes(t *testing.T) {
+	found := false
+	for _, et := range ConcurrentEventTypes {
+		if et == model.InboxSubscriptionOpened {
+			found = true
+		}
+	}
+	assert.True(t, found, "subscription_opened must ride the concurrent lane")
+}

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -708,6 +708,16 @@ func FavoriteToggleWildcard(siteID string) string {
 	return fmt.Sprintf("chat.user.*.request.room.*.%s.favorite.toggle", siteID)
 }
 
+// OpenRoom returns the concrete subject for the per-user open RPC.
+func OpenRoom(account, roomID, siteID string) string {
+	return fmt.Sprintf("chat.user.%s.request.room.%s.%s.open", account, roomID, siteID)
+}
+
+// OpenRoomWildcard is the per-site subscription pattern for the open RPC.
+func OpenRoomWildcard(siteID string) string {
+	return fmt.Sprintf("chat.user.*.request.room.*.%s.open", siteID)
+}
+
 // RoomAppTabs returns the concrete subject for the GetRoomAppTabs RPC.
 // Pair with RoomAppTabsWildcard for room-service's QueueSubscribe.
 func RoomAppTabs(account, roomID, siteID string) string {
@@ -908,6 +918,10 @@ func MuteTogglePattern(siteID string) string {
 
 func FavoriteTogglePattern(siteID string) string {
 	return fmt.Sprintf("chat.user.{account}.request.room.{roomID}.%s.favorite.toggle", siteID)
+}
+
+func OpenRoomPattern(siteID string) string {
+	return fmt.Sprintf("chat.user.{account}.request.room.{roomID}.%s.open", siteID)
 }
 
 func RoomRenamePattern(siteID string) string {

--- a/pkg/subject/subject_test.go
+++ b/pkg/subject/subject_test.go
@@ -1095,3 +1095,22 @@ func TestOrgSyncUsersUpsert(t *testing.T) {
 func TestEmployeesQuit(t *testing.T) {
 	assert.Equal(t, "chat.hr.site-a.employees.quit", subject.EmployeesQuit("site-a"))
 }
+
+func TestOpenRoom(t *testing.T) {
+	assert.Equal(t, "chat.user.alice.request.room.r1.site-a.open", subject.OpenRoom("alice", "r1", "site-a"))
+}
+
+func TestOpenRoomWildcard(t *testing.T) {
+	assert.Equal(t, "chat.user.*.request.room.*.site-a.open", subject.OpenRoomWildcard("site-a"))
+}
+
+func TestOpenRoomPattern(t *testing.T) {
+	assert.Equal(t, "chat.user.{account}.request.room.{roomID}.site-a.open", subject.OpenRoomPattern("site-a"))
+}
+
+func TestOpenRoom_ParseUserRoomSubject(t *testing.T) {
+	account, roomID, ok := subject.ParseUserRoomSubject(subject.OpenRoom("alice", "r1", "site-a"))
+	require.True(t, ok)
+	assert.Equal(t, "alice", account)
+	assert.Equal(t, "r1", roomID)
+}

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -95,6 +95,7 @@ func NewHandler(store RoomStore, keyStore RoomKeyStore, memberListClient MemberL
 func (h *Handler) Register(r *natsrouter.Router) {
 	natsrouter.RegisterNoBody(r, subject.MuteTogglePattern(h.siteID), h.muteToggle)
 	natsrouter.RegisterNoBody(r, subject.FavoriteTogglePattern(h.siteID), h.favoriteToggle)
+	natsrouter.RegisterNoBody(r, subject.OpenRoomPattern(h.siteID), h.openRoom)
 	natsrouter.RegisterNoBody(r, subject.RoomAppTabsPattern(h.siteID), h.getRoomAppTabs)
 	natsrouter.RegisterNoBody(r, subject.RoomAppCmdMenuPattern(h.siteID), h.getRoomAppCommandMenu)
 	natsrouter.RegisterNoBody(r, subject.OrgMembersPattern(h.siteID), h.listOrgMembers)
@@ -2198,6 +2199,54 @@ func (h *Handler) favoriteToggle(c *natsrouter.Context) (*model.FavoriteToggleRe
 	}
 
 	return &model.FavoriteToggleResponse{Status: "ok", Favorite: sub.Favorite}, nil
+}
+
+func (h *Handler) openRoom(c *natsrouter.Context) (*model.OpenRoomResponse, error) {
+	var ctx context.Context = c
+	account := c.Param("account")
+	roomID := c.Param("roomID")
+
+	if span := trace.SpanFromContext(ctx); span.IsRecording() {
+		span.SetAttributes(
+			attribute.String("room.id", roomID),
+			attribute.String("site.id", h.siteID),
+		)
+	}
+
+	now := time.Now().UTC()
+	sub, err := h.store.OpenSubscription(ctx, roomID, account)
+	if err != nil {
+		if errors.Is(err, model.ErrSubscriptionNotFound) {
+			return nil, errNotRoomMember
+		}
+		return nil, fmt.Errorf("open subscription: %w", err)
+	}
+
+	if _, err := h.publishSubscriptionUpdate(ctx, account, "opened", sub, "", now); err != nil {
+		return nil, err
+	}
+
+	userSiteID, err := h.store.GetUserSiteID(ctx, account)
+	if err != nil {
+		return nil, fmt.Errorf("get user siteId: %w", err)
+	}
+	if userSiteID != "" && userSiteID != h.siteID {
+		payload := model.SubscriptionOpenedEvent{
+			Account:   account,
+			RoomID:    roomID,
+			Open:      sub.Open,
+			Timestamp: now.UnixMilli(),
+		}
+		payloadData, err := json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("marshal opened payload: %w", err)
+		}
+		if err := h.federateOne(ctx, roomID, userSiteID, model.InboxSubscriptionOpened, payloadData, roomID+":"+account, now.UnixMilli()); err != nil {
+			return nil, fmt.Errorf("federate opened: %w", err)
+		}
+	}
+
+	return &model.OpenRoomResponse{Status: "ok", Open: sub.Open}, nil
 }
 
 // authorizeRoomAppRead allows the request iff the caller has a

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -5901,6 +5901,225 @@ func TestHandler_FavoriteToggle_CorePublishFailureIsNonFatal(t *testing.T) {
 	assert.True(t, resp.Favorite)
 }
 
+func TestHandler_OpenRoom_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockRoomStore(ctrl)
+
+	store.EXPECT().
+		OpenSubscription(gomock.Any(), "r1", "alice").
+		Return(&model.Subscription{
+			User:   model.SubscriptionUser{ID: "u_alice", Account: "alice"},
+			RoomID: "r1",
+			Open:   true,
+		}, nil)
+	store.EXPECT().
+		GetUserSiteID(gomock.Any(), "alice").
+		Return("site-a", nil)
+
+	var coreSubjects []string
+	var coreBodies [][]byte
+	h := &Handler{
+		store:  store,
+		siteID: "site-a",
+		publishToStream: func(_ context.Context, _ string, _ []byte, _ string) error {
+			t.Fatal("publishToStream must not be called for same-site open")
+			return nil
+		},
+		publishCore: func(_ context.Context, subj string, data []byte) error {
+			coreSubjects = append(coreSubjects, subj)
+			coreBodies = append(coreBodies, data)
+			return nil
+		},
+	}
+
+	resp, err := h.openRoom(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+	require.NoError(t, err)
+
+	assert.Equal(t, "ok", resp.Status)
+	assert.True(t, resp.Open)
+
+	require.Len(t, coreSubjects, 1)
+	assert.Equal(t, subject.SubscriptionUpdate("alice"), coreSubjects[0])
+
+	var evt model.SubscriptionUpdateEvent
+	require.NoError(t, json.Unmarshal(coreBodies[0], &evt))
+	assert.Equal(t, "opened", evt.Action)
+	assert.True(t, evt.Subscription.Open)
+	assert.Equal(t, "alice", evt.Subscription.User.Account)
+}
+
+func TestHandler_OpenRoom_CrossSitePublishesOutbox(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockRoomStore(ctrl)
+
+	store.EXPECT().
+		OpenSubscription(gomock.Any(), "r1", "alice").
+		Return(&model.Subscription{
+			User:   model.SubscriptionUser{ID: "u_alice", Account: "alice"},
+			RoomID: "r1",
+			Open:   true,
+		}, nil)
+	store.EXPECT().
+		GetUserSiteID(gomock.Any(), "alice").
+		Return("site-b", nil)
+
+	var streamSubj string
+	var streamData []byte
+	h := &Handler{
+		store: store, siteID: "site-a",
+		publishToStream: func(_ context.Context, s string, d []byte, _ string) error {
+			streamSubj = s
+			streamData = d
+			return nil
+		},
+		publishCore: func(_ context.Context, _ string, _ []byte) error { return nil },
+	}
+
+	_, err := h.openRoom(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+	require.NoError(t, err)
+
+	assert.Equal(t, subject.Outbox("site-a", "site-b", model.InboxSubscriptionOpened), streamSubj)
+	var fed model.OutboxEvent
+	require.NoError(t, json.Unmarshal(streamData, &fed))
+
+	var inboxEnv model.InboxEvent
+	require.NoError(t, json.Unmarshal(fed.Envelope, &inboxEnv))
+	assert.Equal(t, model.InboxSubscriptionOpened, inboxEnv.Type)
+	assert.Equal(t, "site-a", inboxEnv.SiteID)
+	assert.Equal(t, "site-b", inboxEnv.DestSiteID)
+
+	var payload model.SubscriptionOpenedEvent
+	require.NoError(t, json.Unmarshal(inboxEnv.Payload, &payload))
+	assert.Equal(t, "alice", payload.Account)
+	assert.Equal(t, "r1", payload.RoomID)
+	assert.True(t, payload.Open)
+	assert.NotZero(t, payload.Timestamp)
+}
+
+func TestHandler_OpenRoom_NotRoomMember(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockRoomStore(ctrl)
+
+	store.EXPECT().
+		OpenSubscription(gomock.Any(), "r1", "alice").
+		Return(nil, model.ErrSubscriptionNotFound)
+
+	h := &Handler{
+		store: store, siteID: "site-a",
+		publishToStream: func(_ context.Context, _ string, _ []byte, _ string) error { return nil },
+		publishCore:     func(_ context.Context, _ string, _ []byte) error { return nil },
+	}
+
+	_, err := h.openRoom(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+	assert.ErrorIs(t, err, errNotRoomMember)
+}
+
+func TestHandler_OpenRoom_StoreError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockRoomStore(ctrl)
+
+	store.EXPECT().
+		OpenSubscription(gomock.Any(), "r1", "alice").
+		Return(nil, fmt.Errorf("db down"))
+
+	h := &Handler{
+		store: store, siteID: "site-a",
+		publishToStream: func(_ context.Context, _ string, _ []byte, _ string) error { return nil },
+		publishCore:     func(_ context.Context, _ string, _ []byte) error { return nil },
+	}
+	_, err := h.openRoom(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "open subscription")
+}
+
+func TestHandler_OpenRoom_GetUserSiteIDError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockRoomStore(ctrl)
+
+	store.EXPECT().
+		OpenSubscription(gomock.Any(), "r1", "alice").
+		Return(&model.Subscription{
+			User: model.SubscriptionUser{ID: "u_alice", Account: "alice"}, RoomID: "r1",
+		}, nil)
+	store.EXPECT().
+		GetUserSiteID(gomock.Any(), "alice").
+		Return("", fmt.Errorf("mongo down"))
+
+	h := &Handler{
+		store: store, siteID: "site-a",
+		publishToStream: func(_ context.Context, _ string, _ []byte, _ string) error {
+			t.Fatal("publishToStream must not be called when GetUserSiteID fails")
+			return nil
+		},
+		publishCore: func(_ context.Context, _ string, _ []byte) error { return nil },
+	}
+
+	_, err := h.openRoom(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get user siteId")
+}
+
+func TestHandler_OpenRoom_CrossSiteOutboxPublishFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockRoomStore(ctrl)
+
+	store.EXPECT().
+		OpenSubscription(gomock.Any(), "r1", "alice").
+		Return(&model.Subscription{
+			User:   model.SubscriptionUser{ID: "u_alice", Account: "alice"},
+			RoomID: "r1",
+			Open:   true,
+		}, nil)
+	store.EXPECT().
+		GetUserSiteID(gomock.Any(), "alice").
+		Return("site-b", nil)
+
+	h := &Handler{
+		store: store, siteID: "site-a",
+		publishToStream: func(_ context.Context, _ string, _ []byte, _ string) error {
+			return fmt.Errorf("nats unavailable")
+		},
+		publishCore: func(_ context.Context, _ string, _ []byte) error { return nil },
+	}
+
+	_, err := h.openRoom(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "federate opened")
+}
+
+func TestHandler_OpenRoom_CorePublishFailureIsNonFatal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockRoomStore(ctrl)
+
+	store.EXPECT().
+		OpenSubscription(gomock.Any(), "r1", "alice").
+		Return(&model.Subscription{
+			User:   model.SubscriptionUser{ID: "u_alice", Account: "alice"},
+			RoomID: "r1",
+			Open:   true,
+		}, nil)
+	store.EXPECT().
+		GetUserSiteID(gomock.Any(), "alice").
+		Return("site-a", nil)
+
+	h := &Handler{
+		store: store, siteID: "site-a",
+		publishCore: func(_ context.Context, _ string, _ []byte) error {
+			return fmt.Errorf("core nats down")
+		},
+		publishToStream: func(_ context.Context, _ string, _ []byte, _ string) error {
+			t.Fatal("publishToStream must not be called for same-site open")
+			return nil
+		},
+	}
+
+	resp, err := h.openRoom(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+	require.NoError(t, err, "publishCore failure must be non-fatal — DB write is the source of truth")
+
+	assert.Equal(t, "ok", resp.Status)
+	assert.True(t, resp.Open)
+}
+
 func TestHandler_marshalBounded(t *testing.T) {
 	type sample struct {
 		Hello string `json:"hello"`

--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -2746,6 +2746,47 @@ func TestMongoStore_ToggleSubscriptionFavorite(t *testing.T) {
 	assert.ErrorIs(t, err, model.ErrSubscriptionNotFound)
 }
 
+func TestMongoStore_OpenSubscription(t *testing.T) {
+	db := testutil.MongoDB(t, "room-svc-open")
+	store := NewMongoStore(db)
+	ctx := context.Background()
+
+	// Insert a sub via raw BSON with open=false explicitly set.
+	rawSub := bson.M{
+		"_id":      idgen.GenerateUUIDv7(),
+		"u":        bson.M{"_id": "u1", "account": "alice", "isBot": false},
+		"roomId":   "r1",
+		"roomType": model.RoomTypeChannel,
+		"siteId":   "site-a",
+		"roles":    []model.Role{model.RoleMember},
+		"joinedAt": time.Now().UTC(),
+		"open":     false,
+	}
+	_, err := db.Collection("subscriptions").InsertOne(ctx, rawSub)
+	require.NoError(t, err)
+
+	got, err := store.OpenSubscription(ctx, "r1", "alice")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.True(t, got.Open)
+	assert.Equal(t, "alice", got.User.Account)
+	assert.Equal(t, "r1", got.RoomID)
+
+	// open is not projected by GetSubscription (no handler reads it from a read
+	// result), so verify persistence with a direct field read.
+	assert.True(t, subBoolField(t, db, "r1", "alice", "open"))
+
+	// Idempotent: set-true (not toggle), so applying it again stays true.
+	got, err = store.OpenSubscription(ctx, "r1", "alice")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.True(t, got.Open)
+
+	gotNil, err := store.OpenSubscription(ctx, "missing", "alice")
+	assert.Nil(t, gotNil)
+	assert.ErrorIs(t, err, model.ErrSubscriptionNotFound)
+}
+
 // TestMongoStore_ApplySubscriptionRestriction_StampsTimestamp asserts the origin
 // write stamps restrictUpdatedAt so the doc shares the federated event's
 // high-water mark (inbox-worker guards remote applies against it).

--- a/room-service/mock_store_test.go
+++ b/room-service/mock_store_test.go
@@ -534,6 +534,21 @@ func (mr *MockRoomStoreMockRecorder) MinThreadSubscriptionLastSeenByThreadRoomID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MinThreadSubscriptionLastSeenByThreadRoomID", reflect.TypeOf((*MockRoomStore)(nil).MinThreadSubscriptionLastSeenByThreadRoomID), ctx, threadRoomID)
 }
 
+// OpenSubscription mocks base method.
+func (m *MockRoomStore) OpenSubscription(ctx context.Context, roomID, account string) (*model.Subscription, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenSubscription", ctx, roomID, account)
+	ret0, _ := ret[0].(*model.Subscription)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenSubscription indicates an expected call of OpenSubscription.
+func (mr *MockRoomStoreMockRecorder) OpenSubscription(ctx, roomID, account any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenSubscription", reflect.TypeOf((*MockRoomStore)(nil).OpenSubscription), ctx, roomID, account)
+}
+
 // SetOwnerRole mocks base method.
 func (m *MockRoomStore) SetOwnerRole(ctx context.Context, roomID, account string, makeOwner bool, rolesUpdatedAt time.Time) (*model.Subscription, error) {
 	m.ctrl.T.Helper()

--- a/room-service/store.go
+++ b/room-service/store.go
@@ -132,6 +132,10 @@ type RoomStore interface {
 	// federated event publishes (inbox-worker guards remote applies against it).
 	// Returns the post-flip subscription, or model.ErrSubscriptionNotFound (wrapped) when no match.
 	ToggleSubscriptionFavorite(ctx context.Context, roomID, account string, favoriteUpdatedAt time.Time) (*model.Subscription, error)
+	// OpenSubscription atomically sets open=true for (roomID, account) via a single
+	// FindOneAndUpdate and returns the post-update subscription, or
+	// model.ErrSubscriptionNotFound (wrapped) when no match.
+	OpenSubscription(ctx context.Context, roomID, account string) (*model.Subscription, error)
 	// SetOwnerRole atomically grants (makeOwner=true) or revokes (makeOwner=false)
 	// the owner role on the subscription keyed by (roomID, account) via a single
 	// FindOneAndUpdate. Other roles (e.g. member) are retained. Stamps rolesUpdatedAt

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -1079,6 +1079,14 @@ func (s *MongoStore) ToggleSubscriptionFavorite(ctx context.Context, roomID, acc
 	})
 }
 
+// OpenSubscription sets open=true. Set-not-toggle: no ordering guard is needed
+// because applying true repeatedly or out of order always converges to true.
+func (s *MongoStore) OpenSubscription(ctx context.Context, roomID, account string) (*model.Subscription, error) {
+	return s.findOneAndUpdateSub(ctx, roomID, account, "open subscription", bson.M{
+		"open": true,
+	})
+}
+
 // SetOwnerRole atomically grants or revokes the owner role, returning the updated
 // subscription. Promote appends "owner" only when absent; demote filters "owner"
 // out. Any other roles (e.g. "member") are preserved and array order stays stable.

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -1392,6 +1392,7 @@ func newSub(id string, user *model.User, room *model.Room, roles []model.Role,
 		RoomType:     room.Type,
 		IsSubscribed: isSubscribed,
 		JoinedAt:     joinedAt,
+		Open:         true,
 	}
 }
 

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -2385,6 +2385,13 @@ func TestNewSubSetsAllFields(t *testing.T) {
 	assert.Equal(t, now, sub.JoinedAt)
 }
 
+func TestNewSub_OpenTrue(t *testing.T) {
+	user := &model.User{ID: "u_alice", Account: "alice"}
+	room := &model.Room{ID: "r1", SiteID: "site-a", Type: model.RoomTypeChannel}
+	sub := newSub("s1", user, room, nil, "general", false, time.Now())
+	assert.True(t, sub.Open, "new subscriptions must be born open")
+}
+
 // ---- processCreateRoom test helpers ----
 
 // newCreateRoomTestHandler builds a Handler with a mock store and capture-publish,

--- a/user-service/mongorepo/subscriptions.go
+++ b/user-service/mongorepo/subscriptions.go
@@ -181,6 +181,7 @@ func subscriptionProjection(extra bson.M) bson.M {
 		"alert":             1,
 		"muted":             1,
 		"favorite":          1,
+		"open":              1,
 		"restricted":        1,
 		"externalAccess":    1,
 		"favoriteUpdatedAt": 1,
@@ -242,6 +243,9 @@ func (r *SubscriptionRepo) AggregateSubscriptions(ctx context.Context, account, 
 	if favorite {
 		match["favorite"] = true
 	}
+	// Exclude rooms explicitly closed by the user; a missing field (defensive)
+	// and open:true both pass. Applied to subscription.list only.
+	match["open"] = bson.M{"$ne": false}
 	// roomsEnrichStages(true) drops locally soft-deleted (^Del-) rooms; cross-site
 	// rooms have no local room doc and are kept (their deletion isn't visible here).
 	pipeline := bson.A{bson.M{"$match": match}}

--- a/user-service/mongorepo/subscriptions_test.go
+++ b/user-service/mongorepo/subscriptions_test.go
@@ -274,6 +274,36 @@ func TestAggregateSubscriptions_Pagination_Integration(t *testing.T) {
 	assert.Equal(t, "c4", last.Data[0].ID)
 }
 
+func TestAggregateSubscriptions_ExcludesClosed(t *testing.T) {
+	r, db := newTestSubscriptionRepo(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	seed(t, db, "rooms",
+		bson.M{"_id": "r_open", "name": "Open", "siteId": "site-a", "userCount": 1, "lastMsgAt": now},
+		bson.M{"_id": "r_closed", "name": "Closed", "siteId": "site-a", "userCount": 1, "lastMsgAt": now},
+		bson.M{"_id": "r_missing", "name": "MissingField", "siteId": "site-a", "userCount": 1, "lastMsgAt": now},
+	)
+	seed(t, db, "subscriptions",
+		bson.M{"_id": "sub-open", "u": bson.M{"_id": "u-alice", "account": "alice"}, "roomId": "r_open",
+			"name": "Open", "roomType": "channel", "siteId": "site-a", "open": true, "_updatedAt": now, "createdAt": now},
+		bson.M{"_id": "sub-closed", "u": bson.M{"_id": "u-alice", "account": "alice"}, "roomId": "r_closed",
+			"name": "Closed", "roomType": "channel", "siteId": "site-a", "open": false, "_updatedAt": now, "createdAt": now},
+		bson.M{"_id": "sub-missing", "u": bson.M{"_id": "u-alice", "account": "alice"}, "roomId": "r_missing",
+			"name": "MissingField", "roomType": "channel", "siteId": "site-a", "_updatedAt": now, "createdAt": now},
+	)
+
+	res, err := r.AggregateSubscriptions(ctx, "alice", "rooms", false, nil, mongoutil.OffsetPageRequest{Offset: 0, Limit: 50})
+	require.NoError(t, err)
+	roomIDs := map[string]bool{}
+	for _, s := range res.Data {
+		roomIDs[s.RoomID] = true
+	}
+	assert.True(t, roomIDs["r_open"], "open:true subscription must be included")
+	assert.True(t, roomIDs["r_missing"], "subscription with no open field must be included")
+	assert.False(t, roomIDs["r_closed"], "explicitly closed subscription must be excluded")
+}
+
 func TestFindChannelsByMembers_Integration(t *testing.T) {
 	r, db := newTestSubscriptionRepo(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Adds a per-user, per-room `open` flag on subscriptions and a client-facing `open` RPC that sets it true, so a "closed" room is hidden from the sidebar and can be re-opened. Mirrors the existing `favorite.toggle` flow end-to-end, with two deliberate differences: the RPC is an idempotent **set-true** (not a toggle, no ordering guard), and new subscriptions are **born open**.

## Changes

| Area | Change |
|------|--------|
| `pkg/model` | `Subscription.open bool` (always serialized); `OpenRoomResponse`; `SubscriptionOpenedEvent`; `InboxSubscriptionOpened` const |
| `pkg/subject` | `OpenRoom` / `OpenRoomWildcard` / `OpenRoomPattern` builders (subject tail `.open`) |
| `pkg/outbox` | `subscription_opened` added to the concurrent (order-insensitive) federation lane |
| `room-service` | `OpenSubscription` store method (atomic `$set` via the shared `findOneAndUpdateSub`) + `openRoom` RPC handler with cross-site federation |
| `room-worker` | `newSub` sets `Open: true` — every origin-side create path born open |
| `user-service` | `subscription.list` excludes `open:false` via `{$ne:false}` in the aggregation |
| `inbox-worker` | mirrors `subscription_opened` onto the caller's home-site subscription |
| docs | `docs/client-api.md` + derived `request-reply.md` / `events.md` |

## RPC

`chat.user.{account}.request.room.{roomID}.{siteID}.open` — empty body, replies `{ "status": "ok", "open": true }`. The handler checks membership (no subscription → `errNotRoomMember`), sets `open=true`, publishes a best-effort `subscription.update` event with `action: "opened"`, and when the caller's home site is remote, federates a `subscription_opened` event through OUTBOX → `outbox-worker` → INBOX → `inbox-worker`.

## Born-open invariant

Because `open` is a plain `bool` with no `omitempty`, a newly created subscription would otherwise persist `open:false` and be excluded from lists. `Open: true` is therefore set at both subscription-construction sites this feature touches: `room-worker`'s `newSub` (the single choke point for all origin-side create paths) and `inbox-worker`'s `handleMemberAdded` (the create path for cross-site members' home-site docs). The data-migration transformer needs no change — it emits `member_added` events that flow through `handleMemberAdded`.

## Notes / follow-up

`bot-room-service`'s `UpsertSubscription` writes a minimal subscription doc that omits `open` (along with `roomType`, `isSubscribed`, etc.), relying on the list filter's absent-field pass-through (`$ne:false` treats a missing field as open). This is safe today; declaring `open:true` there explicitly is a small consistency follow-up left to that service's owners, since it sits outside this change and follows a different minimal-doc convention.

## Testing

- Unit tests across `pkg/model`, `pkg/subject`, `pkg/outbox`, `room-service`, `room-worker`, `inbox-worker` (7-case handler suite mirroring the favorite suite; born-open guard tests).
- Integration tests (testcontainers) for `room-service` `OpenSubscription`, `user-service` list exclusion, and `inbox-worker` mirror — all run under real Docker.
- Full race suite green, `golangci-lint` 0 issues, `make sast` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYjvgx2r3ed6kJw3mctXnh

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYjvgx2r3ed6kJw3mctXnh)_