### PR TITLE
feat(room-service): substitution-only buildTabURL with legacy roomType/roomOrigin template variables

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -2291,7 +2291,7 @@ Empty body (`{}` is tolerated). All inputs come from the subject.
 |---|---|---|
 | `id` | string | `apps._id`. |
 | `name` | string | `apps.channelTab.name`. |
-| `tabUrl` | string | Computed from `apps.channelTab.url.default`, which carries the full URL (no server-side base-URL rewrite). Substituted template variables: `${roomId}`, `${siteId}`, `${roomType}` (legacy room-type vocabulary: `channel`/`discussion` → `p`, `dm`/`botDM` → `d`, unknown → `p`), `${roomOrigin}` (legacy origin URL of the room's home site from `LEGACY_ROOM_ORIGINS`; empty string when the site is unconfigured). Apps whose template URL is empty or unparseable are silently skipped. |
+| `tabUrl` | string | Computed from `apps.channelTab.url.default`, which carries the full URL (no server-side base-URL rewrite). Substituted template variables: `${roomId}`, `${siteId}`, `${roomType}` (legacy room-type vocabulary: `channel`/`discussion` → `p`, `dm`/`botDM` → `d`, unknown → `p`), `${roomOrigin}` (legacy origin URL of the room's home site from `LEGACY_ROOM_ORIGINS`; empty string when the site is unconfigured). Apps whose template URL is empty, unparseable, or not an absolute http(s) URL are silently skipped. |
 | `assistant` | [AppAssistant](#appassistant) | Optional. `apps.assistant` subdocument if set. |
 
 ```json
@@ -4091,7 +4091,7 @@ See [Error envelope](#6-error-envelope-reference).
 
 | Field | Type | Notes |
 |---|---|---|
-| `default` | string | Canonical URL template with literal `${roomId}` / `${siteId}` placeholders. |
+| `default` | string | Canonical URL template with literal `${roomId}`, `${siteId}`, `${roomType}`, `${roomOrigin}` placeholders. See the Get Room App Tabs `tabUrl` row for substitution semantics. |
 
 ###### AppSponsor
 
@@ -4108,7 +4108,7 @@ See [Error envelope](#6-error-envelope-reference).
       "name": "Weather",
       "description": "Local forecasts",
       "assistant": { "enabled": true, "name": "weather.bot", "settingsUrl": "https://site-a.example.com/apps/weather/settings" },
-      "channelTab": { "enabled": true, "default": false, "name": "Weather", "url": { "default": "https://site-a.example.com/apps/weather?room=${roomId}&site=${siteId}" } },
+      "channelTab": { "enabled": true, "default": false, "name": "Weather", "url": { "default": "https://site-a.example.com/apps/weather?room=${roomId}&site=${siteId}&roomType=${roomType}&roomOrigin=${roomOrigin}" } },
       "sponsors": [{ "name": "Acme Corp", "phone": "+1-555-0100" }]
     }
   ]

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -2291,7 +2291,7 @@ Empty body (`{}` is tolerated). All inputs come from the subject.
 |---|---|---|
 | `id` | string | `apps._id`. |
 | `name` | string | `apps.channelTab.name`. |
-| `tabUrl` | string | Computed: `SITE_URL`'s scheme/host/path-prefix + `apps.channelTab.url.default`'s path; `${roomId}` and `${siteId}` are substituted. Apps whose template URL is empty or unparseable are silently skipped. |
+| `tabUrl` | string | Computed from `apps.channelTab.url.default`, which carries the full URL (no server-side base-URL rewrite). Substituted template variables: `${roomId}`, `${siteId}`, `${roomType}` (legacy room-type vocabulary: `channel`/`discussion` → `p`, `dm`/`botDM` → `d`, unknown → `p`), `${roomOrigin}` (legacy origin URL of the room's home site from `LEGACY_ROOM_ORIGINS`; empty string when the site is unconfigured). Apps whose template URL is empty or unparseable are silently skipped. |
 | `assistant` | [AppAssistant](#appassistant) | Optional. `apps.assistant` subdocument if set. |
 
 ```json
@@ -2300,7 +2300,7 @@ Empty body (`{}` is tolerated). All inputs come from the subject.
     {
       "id": "app-weather",
       "name": "Weather",
-      "tabUrl": "https://site-a.example.com/apps/weather?room=01970a4f8c2d7c9aQ",
+      "tabUrl": "https://template-a.com/apps/weather?room=01970a4f8c2d7c9aQ&roomType=p&roomOrigin=https://legacy.site-a.com",
       "assistant": { "enabled": true, "name": "weather.bot" }
     }
   ]

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -2309,7 +2309,7 @@ Empty body (`{}` is tolerated). All inputs come from the subject.
 
 ##### Error response
 
-See [Error envelope](#6-error-envelope-reference). Common errors: `"not authorized to access this room's apps"` (caller is neither a room member nor a platform admin on the room's site), `"response payload exceeds maximum size"` (rare: response would exceed the NATS server's `max_payload`).
+See [Error envelope](#6-error-envelope-reference). Common errors: `"not authorized to access this room's apps"` (caller is not a room member, or the room does not exist), `"response payload exceeds maximum size"` (rare: response would exceed the NATS server's `max_payload`).
 
 ##### Triggered events — success path
 

--- a/docs/superpowers/plans/2026-07-26-room-service-buildtaburl-legacy-mapping.md
+++ b/docs/superpowers/plans/2026-07-26-room-service-buildtaburl-legacy-mapping.md
@@ -1,0 +1,787 @@
+# room-service buildTabURL Legacy Mapping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `buildTabURL` stops rewriting tab-URL templates onto `SITE_URL` and instead substitutes four `${...}` variables into the full URL the template already carries — including new `${roomType}` (legacy room-type vocabulary) and `${roomOrigin}` (env-configured legacy origin URL per site).
+
+**Architecture:** All logic lives in `room-service` (flat `package main`). A hard-coded `legacyRoomTypes` map converts `model.RoomType` to the legacy vocabulary (fallback `"p"`). A `map[string]string` parsed from the `LEGACY_ROOM_ORIGINS` env var (native `caarlos0/env` v11 map support, `key:value,key:value`) maps a room's origin `SiteID` to its legacy origin URL (miss ⇒ empty string). `getRoomAppTabs` fetches the room doc once after authorization and passes it to `buildTabURL`. `SITE_URL` is removed entirely (its only consumer was the dropped rewrite).
+
+**Tech Stack:** Go 1.25, `caarlos0/env/v11`, `go.uber.org/mock` (existing `MockRoomStore`), testify, testcontainers (projection integration test).
+
+**Spec:** `docs/superpowers/specs/2026-07-26-room-service-buildtaburl-legacy-mapping-design.md`
+
+## Global Constraints
+
+- Branch: `claude/room-service-buildtaburl-mapping-8adzbk` — never push elsewhere.
+- Always use `make` targets, never raw `go` commands: `make test SERVICE=room-service`, `make test-integration SERVICE=room-service`, `make lint`, `make fmt`.
+- TDD red-green: run the test and see it FAIL (a compile error on an undefined symbol counts as red) before implementing.
+- Error wrapping: `fmt.Errorf("<what this function was doing>: %w", err)`; client-facing errors via `pkg/errcode` sentinels only (this change reuses existing `errAppAccessDenied`).
+- Every commit message ends with (verbatim, after a blank line):
+  ```
+  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01LoAt5zogndVghAPSyzmTJU
+  ```
+- The store interface (`store.go`) is NOT touched — `GetRoom` already exists — so `make generate` is not needed.
+- If Docker is unavailable for `make test-integration`, say so explicitly in the task result instead of claiming the integration test ran.
+
+---
+
+### Task 1: `legacyRoomType` helper
+
+**Files:**
+- Modify: `room-service/handler.go` (near `buildTabURL`, ~line 2239)
+- Test: `room-service/handler_test.go` (near `TestHandler_buildTabURL`, ~line 6080)
+
+**Interfaces:**
+- Consumes: `model.RoomType` constants from `pkg/model/room.go` (`RoomTypeChannel`, `RoomTypeDM`, `RoomTypeBotDM`, `RoomTypeDiscussion`).
+- Produces: `func legacyRoomType(t model.RoomType) string` — used by Task 2's `buildTabURL`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `room-service/handler_test.go` (above `TestHandler_buildTabURL`):
+
+```go
+func TestLegacyRoomType(t *testing.T) {
+	tests := []struct {
+		name string
+		in   model.RoomType
+		want string
+	}{
+		{name: "channel maps to p", in: model.RoomTypeChannel, want: "p"},
+		{name: "dm maps to d", in: model.RoomTypeDM, want: "d"},
+		{name: "botDM maps to d", in: model.RoomTypeBotDM, want: "d"},
+		{name: "discussion maps to p", in: model.RoomTypeDiscussion, want: "p"},
+		{name: "unknown type falls back to p", in: model.RoomType("livechat"), want: "p"},
+		{name: "empty type falls back to p", in: model.RoomType(""), want: "p"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, legacyRoomType(tt.in))
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test SERVICE=room-service`
+Expected: FAIL — compile error `undefined: legacyRoomType`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `room-service/handler.go`, directly above the `buildTabURL` doc comment:
+
+```go
+// legacyRoomTypes maps the redesigned RoomType vocabulary to the legacy
+// values pre-redesign channel-tab apps expect in their ${roomType} URL
+// template variable.
+var legacyRoomTypes = map[model.RoomType]string{
+	model.RoomTypeChannel:    "p",
+	model.RoomTypeDM:         "d",
+	model.RoomTypeBotDM:      "d",
+	model.RoomTypeDiscussion: "p",
+}
+
+// legacyRoomType returns the legacy vocabulary value for t, falling back
+// to "p" for unknown types so ${roomType} always resolves.
+func legacyRoomType(t model.RoomType) string {
+	if v, ok := legacyRoomTypes[t]; ok {
+		return v
+	}
+	return "p"
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `make test SERVICE=room-service`
+Expected: PASS (all room-service tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add room-service/handler.go room-service/handler_test.go
+git commit -m "feat(room-service): legacyRoomType map for tab-URL templates
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01LoAt5zogndVghAPSyzmTJU"
+```
+
+---
+
+### Task 2: Substitution-only `buildTabURL` + room fetch in `getRoomAppTabs` + `SITE_URL` removal
+
+**Files:**
+- Modify: `room-service/handler.go` — `Handler` struct (~line 55), `NewHandler` (~line 71), `buildTabURL` (~line 2244), `getRoomAppTabs` (~line 2269)
+- Modify: `room-service/main.go` — config struct (~line 32), `SITE_URL` validation block (~lines 98–103), `NewHandler` call (~line 218)
+- Modify: `room-service/deploy/docker-compose.yml` — remove `- SITE_URL=http://localhost:3000` (line 18)
+- Test: `room-service/handler_test.go` — `newTabsTestHandler` (~line 6060), `TestHandler_buildTabURL` (~line 6080), all `TestHandler_handleGetRoomAppTabs_*`
+
+**Interfaces:**
+- Consumes: `legacyRoomType(model.RoomType) string` from Task 1; existing `store.GetRoom(ctx, id) (*model.Room, error)` (wraps `mongo.ErrNoDocuments` on miss); existing `isURLSafeIDToken`, `errAppAccessDenied`.
+- Produces: `func (h *Handler) buildTabURL(tmpl string, room *model.Room) (string, bool)`; `Handler.legacyRoomOrigins map[string]string`; `NewHandler(..., legacyRoomOrigins map[string]string, maxResponseBytes int64)` — the 12th parameter changes from `siteURL *url.URL` to `legacyRoomOrigins map[string]string`. Every existing caller except `main.go` passes `nil` there and needs NO change (nil is valid for both types). Task 4 replaces `main.go`'s temporary `nil` with the parsed config map.
+
+- [ ] **Step 1: Rewrite `TestHandler_buildTabURL` as the failing test**
+
+Replace the entire existing `TestHandler_buildTabURL` function in `room-service/handler_test.go` with:
+
+```go
+func TestHandler_buildTabURL(t *testing.T) {
+	origins := map[string]string{
+		"site-a": "https://legacy.site-a.com",
+		"site-b": "https://legacy.site-b.com",
+	}
+	channelRoom := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}
+
+	tests := []struct {
+		name    string
+		handler *Handler
+		tmpl    string
+		room    *model.Room
+		wantURL string
+		wantOK  bool
+	}{
+		{
+			name:    "full template preserved with all four variables substituted",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://template-a.com/tab?room=${roomId}&site=${siteId}&roomType=${roomType}&roomOrigin=${roomOrigin}",
+			room:    channelRoom,
+			wantURL: "https://template-a.com/tab?room=r1&site=site-a&roomType=p&roomOrigin=https://legacy.site-a.com",
+			wantOK:  true,
+		},
+		{
+			name:    "no SITE_URL rewrite: template scheme, host and path kept verbatim",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://upstream.example.com/deep/path/${roomId}",
+			room:    channelRoom,
+			wantURL: "https://upstream.example.com/deep/path/r1",
+			wantOK:  true,
+		},
+		{
+			name:    "dm maps to d",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://t.example.com?rt=${roomType}",
+			room:    &model.Room{ID: "r1", Type: model.RoomTypeDM, SiteID: "site-a"},
+			wantURL: "https://t.example.com?rt=d",
+			wantOK:  true,
+		},
+		{
+			name:    "botDM maps to d",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://t.example.com?rt=${roomType}",
+			room:    &model.Room{ID: "r1", Type: model.RoomTypeBotDM, SiteID: "site-a"},
+			wantURL: "https://t.example.com?rt=d",
+			wantOK:  true,
+		},
+		{
+			name:    "discussion maps to p",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://t.example.com?rt=${roomType}",
+			room:    &model.Room{ID: "r1", Type: model.RoomTypeDiscussion, SiteID: "site-a"},
+			wantURL: "https://t.example.com?rt=p",
+			wantOK:  true,
+		},
+		{
+			name:    "unknown room type falls back to p",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://t.example.com?rt=${roomType}",
+			room:    &model.Room{ID: "r1", Type: model.RoomType("livechat"), SiteID: "site-a"},
+			wantURL: "https://t.example.com?rt=p",
+			wantOK:  true,
+		},
+		{
+			name:    "roomOrigin keyed by the room's own SiteID, not the local site",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://t.example.com?o=${roomOrigin}",
+			room:    &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-b"},
+			wantURL: "https://t.example.com?o=https://legacy.site-b.com",
+			wantOK:  true,
+		},
+		{
+			name:    "unmapped origin site substitutes empty string",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://t.example.com?o=${roomOrigin}&x=1",
+			room:    &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-x"},
+			wantURL: "https://t.example.com?o=&x=1",
+			wantOK:  true,
+		},
+		{
+			name:    "nil origins map substitutes empty string",
+			handler: &Handler{siteID: "site-a"},
+			tmpl:    "https://t.example.com?o=${roomOrigin}",
+			room:    channelRoom,
+			wantURL: "https://t.example.com?o=",
+			wantOK:  true,
+		},
+		{
+			name:    "empty template",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "",
+			room:    channelRoom,
+			wantOK:  false,
+		},
+		{
+			name:    "malformed template",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "://malformed",
+			room:    channelRoom,
+			wantOK:  false,
+		},
+		{
+			name:    "non-URL-safe roomID",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://t.example.com/${roomId}",
+			room:    &model.Room{ID: "r1/../../etc", Type: model.RoomTypeChannel, SiteID: "site-a"},
+			wantOK:  false,
+		},
+		{
+			name:    "non-URL-safe siteID",
+			handler: &Handler{siteID: "site/../a", legacyRoomOrigins: origins},
+			tmpl:    "https://t.example.com/${roomId}",
+			room:    channelRoom,
+			wantOK:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := tt.handler.buildTabURL(tt.tmpl, tt.room)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantURL, got)
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test SERVICE=room-service`
+Expected: FAIL — compile errors (`unknown field legacyRoomOrigins`, wrong argument count/type for `buildTabURL`).
+
+- [ ] **Step 3: Implement `buildTabURL`, `Handler` field, `NewHandler`, and the `getRoomAppTabs` room fetch**
+
+In `room-service/handler.go`:
+
+3a. In the `Handler` struct, replace the field `siteURL *url.URL` (line 55) with:
+
+```go
+	legacyRoomOrigins map[string]string
+```
+
+3b. In `NewHandler`, replace the parameter `siteURL *url.URL` with `legacyRoomOrigins map[string]string` and the struct literal line `siteURL: siteURL,` with `legacyRoomOrigins: legacyRoomOrigins,`:
+
+```go
+func NewHandler(store RoomStore, keyStore RoomKeyStore, memberListClient MemberListClient, msgReader MessageReader, siteID string, maxRoomSize, maxBatchSize int, memberListTimeout time.Duration, restrictedRoomMinMembers int, publishToStream func(context.Context, string, []byte, string) error, publishCore func(context.Context, string, []byte) error, legacyRoomOrigins map[string]string, maxResponseBytes int64) *Handler {
+```
+
+3c. Replace `buildTabURL` (function AND its doc comment) with:
+
+```go
+// buildTabURL substitutes the ${roomId}, ${siteId}, ${roomType} and
+// ${roomOrigin} template variables into a channelTab URL template. The
+// template carries the full URL — no base-URL rewrite is applied.
+// ${roomType} is the legacy room-type vocabulary (legacyRoomType);
+// ${roomOrigin} is the legacy origin URL of the room's home site, or ""
+// when unconfigured. Returns (url, true) on success; (_, false) when the
+// template is empty or unparseable, or the IDs fail the URL-safety check.
+func (h *Handler) buildTabURL(tmpl string, room *model.Room) (string, bool) {
+	if tmpl == "" {
+		return "", false
+	}
+	if !isURLSafeIDToken(room.ID) || !isURLSafeIDToken(h.siteID) {
+		return "", false
+	}
+	// Substitute BEFORE parsing so url.Parse only validates the final
+	// string and never percent-encodes the substituted values.
+	tmpl = strings.ReplaceAll(tmpl, "${roomId}", room.ID)
+	tmpl = strings.ReplaceAll(tmpl, "${siteId}", h.siteID)
+	tmpl = strings.ReplaceAll(tmpl, "${roomType}", legacyRoomType(room.Type))
+	tmpl = strings.ReplaceAll(tmpl, "${roomOrigin}", h.legacyRoomOrigins[room.SiteID])
+	if _, err := url.Parse(tmpl); err != nil {
+		return "", false
+	}
+	return tmpl, true
+}
+```
+
+3d. In `getRoomAppTabs`, after the `authorizeRoomAppRead` block, fetch the room and pass it through (replacing the old `h.buildTabURL(app.ChannelTab.URL.Default, roomID)` call):
+
+```go
+	if err := h.authorizeRoomAppRead(ctx, account, roomID); err != nil {
+		return nil, err
+	}
+
+	room, err := h.store.GetRoom(ctx, roomID)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, errAppAccessDenied
+		}
+		return nil, fmt.Errorf("get room for app tabs: %w", err)
+	}
+```
+
+and inside the loop:
+
+```go
+		tabURL, ok := h.buildTabURL(app.ChannelTab.URL.Default, room)
+```
+
+3e. `handler.go` still needs the `net/url` import (`url.Parse` remains); do NOT remove it.
+
+In `room-service/main.go`:
+
+3f. Delete the config field `SiteURL string \`env:"SITE_URL,required"\`` (line 32).
+
+3g. Delete the `SITE_URL` validation block (lines 98–103):
+
+```go
+	siteURL, err := url.Parse(cfg.SiteURL)
+	if err != nil || siteURL.Scheme == "" || siteURL.Host == "" {
+		slog.Error("invalid SITE_URL: must be an absolute URL with scheme and host",
+			"value", cfg.SiteURL, "error", err)
+		os.Exit(1)
+	}
+```
+
+3h. In the `NewHandler` call (~line 218), replace the argument `siteURL,` with `nil,` (Task 4 replaces this with the parsed origins map).
+
+3i. Remove the now-unused `"net/url"` import from `main.go`.
+
+In `room-service/deploy/docker-compose.yml`:
+
+3j. Delete the line `- SITE_URL=http://localhost:3000`.
+
+- [ ] **Step 4: Update the tab-handler tests**
+
+In `room-service/handler_test.go`:
+
+4a. Replace `newTabsTestHandler` with (note: no URL parameter):
+
+```go
+func newTabsTestHandler(t *testing.T) (*Handler, *MockRoomStore, *gomock.Controller) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	store := NewMockRoomStore(ctrl)
+	return &Handler{
+		store:             store,
+		siteID:            "site-a",
+		legacyRoomOrigins: map[string]string{"site-a": "https://legacy.site-a.com"},
+	}, store, ctrl
+}
+```
+
+4b. Update EVERY call site `newTabsTestHandler(t, "...")` → `newTabsTestHandler(t)`. Find them all with: `grep -n 'newTabsTestHandler(t,' room-service/handler_test.go` (they include the `TestHandler_handleGetRoomAppTabs_*` and `TestHandler_handleGetRoomAppCommandMenu_*` tests). Remove the `net/url` import from `handler_test.go` only if nothing else in the file uses it (check with `grep -n 'url\.' room-service/handler_test.go`).
+
+4c. Every `getRoomAppTabs` test whose flow reaches the room fetch needs a `GetRoom` expectation. Member-path tests (`GetSubscription` returns a member) add ONE `GetRoom`; the admin-path test's existing `GetRoom` expectation becomes `.Times(2)` (authorize existence gate + tab fetch). Denied tests (`_Denied`, `_DeniedNoUser`) are unchanged — they never reach the fetch. Concretely:
+
+`TestHandler_handleGetRoomAppTabs_MemberAllowed` becomes:
+
+```go
+func TestHandler_handleGetRoomAppTabs_MemberAllowed(t *testing.T) {
+	h, store, _ := newTabsTestHandler(t)
+	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
+		Return(&model.Subscription{User: model.SubscriptionUser{ID: "u1", Account: "alice"}, RoomID: "r1"}, nil)
+	store.EXPECT().GetRoom(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
+	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).Return([]model.App{
+		mockTabApp("app1", "Calendar", "https://upstream.example.com/cal/${roomId}/${siteId}?type=${roomType}&origin=${roomOrigin}"),
+	}, nil)
+
+	resp, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+	require.NoError(t, err)
+	require.Len(t, resp.Apps, 1)
+	assert.Equal(t, "app1", resp.Apps[0].ID)
+	assert.Equal(t, "Calendar", resp.Apps[0].Name)
+	assert.Equal(t, "https://upstream.example.com/cal/r1/site-a?type=p&origin=https://legacy.site-a.com", resp.Apps[0].TabURL)
+	require.NotNil(t, resp.Apps[0].Assistant)
+	assert.Equal(t, "app1.bot", resp.Apps[0].Assistant.Name)
+}
+```
+
+`TestHandler_handleGetRoomAppTabs_AdminAllowed`: change its `GetRoom` expectation to:
+
+```go
+	store.EXPECT().GetRoom(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil).Times(2)
+```
+
+`TestHandler_handleGetRoomAppTabs_EmptyResultIsEmptyArray` and `TestHandler_handleGetRoomAppTabs_SkipsAppWithNilChannelTab`: add the same single-call `GetRoom` expectation as MemberAllowed (channel room, site-a).
+
+4d. DELETE these three rewrite-era tests (the rewrite no longer exists): `TestHandler_handleGetRoomAppTabs_URLRewritePathPrefix`, `TestHandler_handleGetRoomAppTabs_URLRewriteStripsUserinfo`, `TestHandler_handleGetRoomAppTabs_URLRewritePreservesQueryAndFragment`. Replace with one preservation test:
+
+```go
+func TestHandler_handleGetRoomAppTabs_TemplateURLPreserved(t *testing.T) {
+	h, store, _ := newTabsTestHandler(t)
+	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
+		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
+	store.EXPECT().GetRoom(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
+	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).Return([]model.App{
+		mockTabApp("app1", "X", "https://template-a.com/path?room=${roomId}#tab=${siteId}"),
+	}, nil)
+
+	resp, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+	require.NoError(t, err)
+	assert.Equal(t, "https://template-a.com/path?room=r1#tab=site-a", resp.Apps[0].TabURL,
+		"template scheme/host must be preserved — no SITE_URL rewrite")
+}
+```
+
+4e. Rename `TestHandler_handleGetRoomAppTabs_URLRewriteSkipsEmptyAndMalformed` to `TestHandler_handleGetRoomAppTabs_SkipsEmptyAndMalformed` and add the single-call `GetRoom` expectation (channel room, site-a); the rest of its body is unchanged.
+
+4f. Add the two new room-fetch failure tests:
+
+```go
+func TestHandler_handleGetRoomAppTabs_RoomNotFound(t *testing.T) {
+	h, store, _ := newTabsTestHandler(t)
+	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
+		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
+	store.EXPECT().GetRoom(gomock.Any(), "r1").
+		Return(nil, fmt.Errorf("room %q not found: %w", "r1", mongo.ErrNoDocuments))
+
+	_, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+	assert.ErrorIs(t, err, errAppAccessDenied)
+}
+
+func TestHandler_handleGetRoomAppTabs_RoomFetchError(t *testing.T) {
+	h, store, _ := newTabsTestHandler(t)
+	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
+		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
+	store.EXPECT().GetRoom(gomock.Any(), "r1").
+		Return(nil, errors.New("mongo down"))
+
+	_, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, errAppAccessDenied, "infra failure must collapse to internal, not access-denied")
+}
+```
+
+(`fmt`, `errors`, and `mongo` are already imported in `handler_test.go`; verify with `grep -n '"fmt"\|"errors"\|mongo-driver' room-service/handler_test.go` and add any that are missing.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `make test SERVICE=room-service`
+Expected: PASS.
+
+- [ ] **Step 6: Verify the integration tests still compile**
+
+Run: `make lint`
+Expected: PASS (this also catches the `nil`-arg call sites in `integration_test.go`, which need no edits since `nil` is a valid `map[string]string`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add room-service/handler.go room-service/handler_test.go room-service/main.go room-service/deploy/docker-compose.yml
+git commit -m "feat(room-service): substitution-only buildTabURL with roomType/roomOrigin variables
+
+Templates now carry the full URL; the SITE_URL scheme/host rewrite and the
+SITE_URL config are removed. getRoomAppTabs fetches the room doc to supply
+the room's type and origin site.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01LoAt5zogndVghAPSyzmTJU"
+```
+
+---
+
+### Task 3: `siteId` in the GetRoom projection
+
+**Files:**
+- Modify: `room-service/store_mongo.go` — `roomReadProjection` (~line 244)
+- Test: `room-service/integration_test.go` — `TestMongoStore_GetRoom_ProjectionFields_Integration` (~line 110)
+
+**Interfaces:**
+- Consumes: existing `MongoStore.GetRoom` and the `mustInsertRoom` test helper (the fixture at ~line 118 already sets `SiteID: "site-a"`).
+- Produces: `GetRoom` results with `Room.SiteID` populated — required for Task 2's `${roomOrigin}` lookup to work against real Mongo.
+
+- [ ] **Step 1: Write the failing assertion**
+
+In `TestMongoStore_GetRoom_ProjectionFields_Integration`, after the `got.Type` assertion (line 129), add:
+
+```go
+	assert.Equal(t, "site-a", got.SiteID, "siteId must be in the projection (buildTabURL reads room.SiteID for ${roomOrigin})")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test-integration SERVICE=room-service`
+Expected: FAIL — `got.SiteID` is `""` because the projection omits `siteId`. (Requires Docker; if unavailable, run `make lint` to confirm compilation and state explicitly that the red run is deferred to CI.)
+
+- [ ] **Step 3: Add the field to the projection**
+
+In `room-service/store_mongo.go`, `roomReadProjection` becomes:
+
+```go
+var roomReadProjection = bson.D{
+	{Key: "_id", Value: 1}, {Key: "type", Value: 1}, {Key: "name", Value: 1},
+	{Key: "siteId", Value: 1},
+	{Key: "userCount", Value: 1}, {Key: "appCount", Value: 1},
+	{Key: "restricted", Value: 1}, {Key: "externalAccess", Value: 1},
+	{Key: "lastMsgAt", Value: 1}, {Key: "minUserLastSeenAt", Value: 1},
+	{Key: "lastMentionAllAt", Value: 1},
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `make test-integration SERVICE=room-service`
+Expected: PASS (same Docker caveat as Step 2).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add room-service/store_mongo.go room-service/integration_test.go
+git commit -m "feat(room-service): project siteId in GetRoom for tab-URL origin lookup
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01LoAt5zogndVghAPSyzmTJU"
+```
+
+---
+
+### Task 4: `LEGACY_ROOM_ORIGINS` config
+
+**Files:**
+- Modify: `room-service/main.go` — config struct + `NewHandler` call (`nil` → parsed map) + normalization helper
+- Modify: `room-service/deploy/docker-compose.yml` — add a dev value
+- Create: `room-service/config_test.go` (untagged unit test file, `package main`)
+
+**Interfaces:**
+- Consumes: `caarlos0/env` v11 native `map[string]string` parsing — items split on `,`, each pair split on the FIRST `:` (`strings.SplitN(pair, ":", 2)`), so URL values keep `://`. An unset or empty env var skips parsing and leaves the field `nil`.
+- Produces: `config.LegacyRoomOrigins map[string]string`; `func normalizeLegacyRoomOrigins(in map[string]string) map[string]string` (never returns nil); the handler receives the normalized map.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `room-service/config_test.go`:
+
+```go
+package main
+
+import (
+	"testing"
+
+	"github.com/caarlos0/env/v11"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeLegacyRoomOrigins(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]string
+		want map[string]string
+	}{
+		{name: "nil map yields empty map", in: nil, want: map[string]string{}},
+		{
+			name: "trims whitespace around keys and values",
+			in:   map[string]string{" site-a": " https://legacy.site-a.com "},
+			want: map[string]string{"site-a": "https://legacy.site-a.com"},
+		},
+		{
+			name: "drops entries empty after trimming",
+			in:   map[string]string{"site-a": "  ", "": "https://x.example.com"},
+			want: map[string]string{},
+		},
+		{
+			name: "clean entries pass through",
+			in: map[string]string{
+				"site-a": "https://legacy.site-a.com",
+				"site-b": "https://legacy.site-b.com",
+			},
+			want: map[string]string{
+				"site-a": "https://legacy.site-a.com",
+				"site-b": "https://legacy.site-b.com",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeLegacyRoomOrigins(tt.in))
+		})
+	}
+}
+
+// TestLegacyRoomOrigins_EnvWireFormat pins the LEGACY_ROOM_ORIGINS wire
+// format: comma-separated entries, first-colon key:value split (URL values
+// keep "://"), spaces after the colon tolerated via normalization.
+func TestLegacyRoomOrigins_EnvWireFormat(t *testing.T) {
+	type originsConfig struct {
+		LegacyRoomOrigins map[string]string `env:"LEGACY_ROOM_ORIGINS"`
+	}
+
+	t.Setenv("LEGACY_ROOM_ORIGINS", "site-a:https://legacy.site-a.com,site-b: https://legacy.site-b.com")
+	cfg, err := env.ParseAs[originsConfig]()
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"site-a": "https://legacy.site-a.com",
+		"site-b": "https://legacy.site-b.com",
+	}, normalizeLegacyRoomOrigins(cfg.LegacyRoomOrigins))
+
+	t.Setenv("LEGACY_ROOM_ORIGINS", "")
+	cfg, err = env.ParseAs[originsConfig]()
+	require.NoError(t, err, "empty value must not be a parse error")
+	assert.Empty(t, normalizeLegacyRoomOrigins(cfg.LegacyRoomOrigins))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test SERVICE=room-service`
+Expected: FAIL — compile error `undefined: normalizeLegacyRoomOrigins`.
+
+- [ ] **Step 3: Implement config field, helper, and wiring**
+
+In `room-service/main.go`:
+
+3a. Add to the `config` struct (after the `SiteID` field):
+
+```go
+	// LegacyRoomOrigins maps a room's origin siteID to the legacy origin URL
+	// substituted into channel-tab ${roomOrigin} template variables. Wire
+	// format: "site-a:https://legacy.site-a.com,site-b:https://legacy.site-b.com"
+	// (comma-separated, first-colon split — URL values keep "://"). Unset ⇒
+	// every ${roomOrigin} substitutes to "".
+	LegacyRoomOrigins map[string]string `env:"LEGACY_ROOM_ORIGINS"`
+```
+
+3b. Add the helper (package-level, near the bottom of `main.go`):
+
+```go
+// normalizeLegacyRoomOrigins trims whitespace around the keys and values of
+// the LEGACY_ROOM_ORIGINS map (tolerating "site-a: https://…" with a space
+// after the colon) and drops entries left empty after trimming.
+func normalizeLegacyRoomOrigins(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		k, v = strings.TrimSpace(k), strings.TrimSpace(v)
+		if k == "" || v == "" {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+```
+
+Add `"strings"` to `main.go` imports if not already present.
+
+3c. In the `NewHandler` call, replace the Task 2 placeholder `nil,` with:
+
+```go
+		normalizeLegacyRoomOrigins(cfg.LegacyRoomOrigins),
+```
+
+In `room-service/deploy/docker-compose.yml`:
+
+3d. Where `SITE_URL` used to be (environment list), add:
+
+```yaml
+      - LEGACY_ROOM_ORIGINS=site-local:https://legacy.localhost
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test SERVICE=room-service`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add room-service/main.go room-service/config_test.go room-service/deploy/docker-compose.yml
+git commit -m "feat(room-service): LEGACY_ROOM_ORIGINS config for tab-URL origin mapping
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01LoAt5zogndVghAPSyzmTJU"
+```
+
+---
+
+### Task 5: Client API docs
+
+**Files:**
+- Modify: `docs/client-api.md` — Get Room App Tabs `tabUrl` row (~line 2242) + success-response JSON example (~line 2245)
+
+**Interfaces:**
+- Consumes: final behavior from Tasks 1–4.
+- Produces: docs matching the shipped behavior (CLAUDE.md requires this in the same PR as any client-facing handler change).
+
+- [ ] **Step 1: Rewrite the `tabUrl` row**
+
+Replace line 2242 of `docs/client-api.md` with:
+
+```markdown
+| `tabUrl` | string | Computed from `apps.channelTab.url.default`, which carries the full URL (no server-side base-URL rewrite). Substituted template variables: `${roomId}`, `${siteId}`, `${roomType}` (legacy room-type vocabulary: `channel`/`discussion` → `p`, `dm`/`botDM` → `d`, unknown → `p`), `${roomOrigin}` (legacy origin URL of the room's home site from `LEGACY_ROOM_ORIGINS`; empty string when the site is unconfigured). Apps whose template URL is empty or unparseable are silently skipped. |
+```
+
+- [ ] **Step 2: Update the success-response example**
+
+Replace the JSON example (lines 2245–2256) with:
+
+```json
+{
+  "apps": [
+    {
+      "id": "app-weather",
+      "name": "Weather",
+      "tabUrl": "https://template-a.com/apps/weather?room=01970a4f8c2d7c9aQ&roomType=p&roomOrigin=https://legacy.site-a.com",
+      "assistant": { "enabled": true, "name": "weather.bot" }
+    }
+  ]
+}
+```
+
+- [ ] **Step 3: Verify the derived views need no change**
+
+Run: `grep -rn "tabUrl\|SITE_URL" docs/client-api/`
+Expected: no output — `docs/client-api/request-reply.md` links to the canonical schema without duplicating the `tabUrl` prose, and `events.md` is unaffected (reply-only RPC). If the grep DOES match, update the matching row(s) to the Step 1 wording.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/client-api.md
+git commit -m "docs(client-api): tabUrl template variables roomType/roomOrigin, no base-URL rewrite
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01LoAt5zogndVghAPSyzmTJU"
+```
+
+---
+
+### Task 6: Full verification and push
+
+**Files:** none created/modified unless a check fails.
+
+- [ ] **Step 1: Format and lint**
+
+Run: `make fmt && make lint`
+Expected: no diffs, lint PASS. If `make fmt` changed files, re-run `make test SERVICE=room-service`, then amend them into the most recent relevant commit or add a `style:` commit.
+
+- [ ] **Step 2: Unit tests (race detector via Makefile)**
+
+Run: `make test SERVICE=room-service`
+Expected: PASS.
+
+- [ ] **Step 3: Integration tests**
+
+Run: `make test-integration SERVICE=room-service`
+Expected: PASS. (Requires Docker; if unavailable, state that explicitly — do not claim it ran.)
+
+- [ ] **Step 4: SAST**
+
+Run: `make sast`
+Expected: PASS (no medium+ findings). The change removes an URL-rewrite and adds string substitution — no new gosec surface expected.
+
+- [ ] **Step 5: Push with retry**
+
+```bash
+git push -u origin claude/room-service-buildtaburl-mapping-8adzbk
+```
+
+On network failure retry after 2s, 4s, 8s, 16s. Do NOT create a pull request (not requested).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** type map + fallback (Task 1), substitution-only rewrite / room fetch / `errAppAccessDenied` on missing room / `SITE_URL` removal (Task 2), projection (Task 3), env config + trim normalization + nil-safe miss-to-empty (Tasks 2 & 4), docs (Task 5). Out-of-scope items in the spec (no percent-encoding, cmd-menu untouched) require no task.
+- **Type consistency:** `buildTabURL(tmpl string, room *model.Room) (string, bool)`, `legacyRoomType(model.RoomType) string`, `Handler.legacyRoomOrigins map[string]string`, `normalizeLegacyRoomOrigins(map[string]string) map[string]string` — names used identically across Tasks 1–4.
+- **Known behavior change accepted by design:** templates with userinfo (`user:pass@host`) are no longer stripped (the strip was part of the deleted rewrite; templates are admin-configured data).

--- a/docs/superpowers/specs/2026-07-26-room-service-buildtaburl-legacy-mapping-design.md
+++ b/docs/superpowers/specs/2026-07-26-room-service-buildtaburl-legacy-mapping-design.md
@@ -1,0 +1,143 @@
+# room-service: buildTabURL legacy `${roomType}` / `${roomOrigin}` substitution
+
+**Date:** 2026-07-26
+**Service:** `room-service`
+**Function:** `buildTabURL` (`room-service/handler.go`), called by `getRoomAppTabs`
+
+## Problem
+
+Channel-tab URL templates now carry a full URL (e.g.
+`https://template-a.com?roomType=${roomType}&roomOrigin=${roomOrigin}`), but
+`buildTabURL` still force-rewrites the template's scheme/host/path-prefix with
+`SITE_URL` and only knows the `${roomId}` / `${siteId}` variables. Legacy tab
+apps additionally need the room's type expressed in the *old* (pre-redesign)
+room-type vocabulary and the legacy origin URL of the room's home site.
+
+## Behavior
+
+`buildTabURL` performs **substitution only** — no base-URL rewrite. The
+template is returned with these variables replaced:
+
+| Variable | Replaced with |
+|---|---|
+| `${roomId}` | request roomID (unchanged behavior) |
+| `${siteId}` | local `h.siteID` (unchanged behavior) |
+| `${roomType}` | legacy room type mapped from `room.Type` (see table) |
+| `${roomOrigin}` | `LegacyRoomOrigins[room.SiteID]`, or `""` on miss |
+
+### Legacy room-type map (hard-coded)
+
+| new `model.RoomType` | legacy value |
+|---|---|
+| `channel` | `p` |
+| `dm` | `d` |
+| `botDM` | `d` |
+| `discussion` | `p` |
+| any other / unknown | `p` (fallback) |
+
+Package-level `var legacyRoomTypes = map[model.RoomType]string{...}` in
+`room-service/handler.go`; a lookup miss falls back to `"p"`, so
+`${roomType}` always resolves. (Derived from the reverse of
+`data-migration/oplog-collections-transformer/classify.go`, with
+channel→`p` chosen per product decision.)
+
+### Legacy room-origin map (env-configured)
+
+New config field in `room-service/main.go`:
+
+```go
+LegacyRoomOrigins map[string]string `env:"LEGACY_ROOM_ORIGINS" envDefault:""`
+```
+
+- Wire format (native `caarlos0/env` v11 map parsing, `SplitN(pair, ":", 2)`
+  so URL values keep `://`):
+  `LEGACY_ROOM_ORIGINS=site-a:https://legacy.site-a.com,site-b:https://legacy.site-b.com`
+- Startup normalization: `strings.TrimSpace` each key and value (tolerates
+  `site-a: https://legacy.site-a.com`). Empty var ⇒ empty map (valid: every
+  `${roomOrigin}` substitutes to `""`).
+- Lookup key is **`room.SiteID`** — the room's origin site, consistent with
+  `pkg/drive.GetBaseURLFromRoomOrigin`.
+- Miss policy: substitute the **empty string**; the tab is still returned
+  (e.g. `...&roomOrigin=`). No skip, no literal placeholder.
+
+### What buildTabURL keeps and drops
+
+Keeps:
+- empty template ⇒ `("", false)` (tab skipped, Warn-logged by caller)
+- URL-safety check on `roomID` and `h.siteID` (`isURLSafeIDToken`) ⇒ `false`
+- substitute **before** `url.Parse` so values aren't percent-encoded
+- final `url.Parse` validity check ⇒ malformed result ⇒ `("", false)`
+
+Drops:
+- the `siteURL.JoinPath` scheme/host/path-prefix rewrite — the substituted
+  template string is returned as-is (not re-serialized via `url.URL.String()`)
+- `Handler.siteURL` field, the `NewHandler` `siteURL` param, and the
+  `SITE_URL` env var (removed from config, `main.go` validation, and
+  `deploy/docker-compose.yml`). `buildTabURL` was its only consumer;
+  deployments still setting the env var are unaffected (ignored).
+
+## Data flow
+
+Signature becomes `buildTabURL(tmpl string, room *model.Room) (string, bool)`.
+The handler needs a `roomID` no longer as a param — the room doc carries
+`room.ID`.
+
+`getRoomAppTabs` fetches the room once via the existing `store.GetRoom`
+**after** `authorizeRoomAppRead` succeeds:
+
+- `mongo.ErrNoDocuments` ⇒ `errAppAccessDenied` (mirrors the admin-bypass
+  existence gate; a member-path race where the room vanished mid-request)
+- other error ⇒ `fmt.Errorf("get room: %w", err)` (collapses to `internal`)
+
+`authorizeRoomAppRead` is intentionally untouched — it is shared with
+`getRoomAppCommandMenu`, which does not need the room doc. The admin path
+performs one extra `GetRoom` (existence gate + tab fetch); accepted, the
+admin path is cold.
+
+`Handler` gains a `legacyRoomOrigins map[string]string` field, injected via
+`NewHandler` (replacing the removed `siteURL` param).
+
+### Projection
+
+`roomReadProjection` (`room-service/store_mongo.go`) gains
+`{Key: "siteId", Value: 1}` — `buildTabURL` reads `room.SiteID`. The
+projection drift-guard integration test is updated in the same change.
+
+## Error handling
+
+No new client-facing error cases. Existing `errAppAccessDenied` covers the
+room-missing race; infra failures stay raw-wrapped per `pkg/errcode` Tier 1.
+No secrets/URLs logged beyond existing Warn lines (appId/roomId/request_id).
+
+## Testing (TDD — red first)
+
+- `TestHandler_buildTabURL` table rewritten:
+  - each room type maps correctly (`channel`→`p`, `dm`→`d`, `botDM`→`d`,
+    `discussion`→`p`) and unknown type falls back to `p`
+  - origin hit substitutes the mapped URL; origin miss substitutes `""`
+  - full-URL template's scheme/host are **preserved** (no SITE_URL rewrite)
+  - `${roomId}` / `${siteId}` still substituted
+  - empty template, malformed template, non-URL-safe roomID/siteID ⇒ `false`
+- `getRoomAppTabs` handler tests: add `GetRoom` mock expectations; new cases
+  for room-not-found ⇒ access denied and `GetRoom` infra error.
+- `main.go` origin-map normalization: unit test for the trim helper.
+- Projection integration test: `siteId` added to the guarded field set.
+
+## Docs (same PR)
+
+- `docs/client-api.md` §Get Room App Tabs: `tabUrl` row rewritten — computed
+  from the template URL itself (no `SITE_URL` rewrite), documents all four
+  variables, legacy type map, and empty-string origin fallback; JSON example
+  updated. §App examples showing `channelTab.url.default` updated to the
+  full-URL template shape.
+- Response *schema* is unchanged, so
+  `docs/client-api/request-reply.md` / `events.md` only change if they
+  duplicate the `tabUrl` computation prose (verify during implementation).
+
+## Out of scope
+
+- No new placeholder syntax beyond `${...}`.
+- No percent-encoding of substituted values (template authors control
+  placement; existing behavior).
+- `getRoomAppCommandMenu` and all other `authorizeRoomAppRead` consumers
+  unchanged.

--- a/docs/superpowers/specs/2026-07-26-room-service-buildtaburl-legacy-mapping-design.md
+++ b/docs/superpowers/specs/2026-07-26-room-service-buildtaburl-legacy-mapping-design.md
@@ -84,17 +84,16 @@ Signature becomes `buildTabURL(tmpl string, room *model.Room) (string, bool)`.
 The handler needs a `roomID` no longer as a param — the room doc carries
 `room.ID`.
 
-`authorizeRoomAppRead` authorizes AND returns the room, narrowly projected
-via a dedicated `store.GetRoomAppRead` (`_id`, `type`, `siteId`). The room
-fetch runs concurrently with the auth checks (separate collections; a single
-joined query would need a forbidden `$lookup`):
+`authorizeRoomAppRead` is member-only and sequential: check the caller's
+subscription, then fetch and return the room, narrowly projected via a
+dedicated `store.GetRoomAppRead` (`_id`, `type`, `siteId`). The platform-admin
+bypass is removed — non-members are denied without a user lookup.
 
-- `mongo.ErrNoDocuments` ⇒ `errAppAccessDenied` on every path — room
-  existence now gates members too, not just the admin bypass
+- `mongo.ErrNoDocuments` ⇒ `errAppAccessDenied` (a missing room reads as denied)
 - other error ⇒ `fmt.Errorf("get room for app read: %w", err)` (⇒ `internal`)
 
-Exactly one room read per request on all paths. `getRoomAppCommandMenu`
-discards the returned room (`_, err :=`).
+Exactly one room read per request. `getRoomAppCommandMenu` discards the
+returned room (`_, err :=`).
 
 `Handler` gains a `legacyRoomOrigins map[string]string` field, injected via
 `NewHandler` (replacing the removed `siteURL` param).

--- a/docs/superpowers/specs/2026-07-26-room-service-buildtaburl-legacy-mapping-design.md
+++ b/docs/superpowers/specs/2026-07-26-room-service-buildtaburl-legacy-mapping-design.md
@@ -66,7 +66,8 @@ Keeps:
 - empty template ⇒ `("", false)` (tab skipped, Warn-logged by caller)
 - URL-safety check on `roomID` and `h.siteID` (`isURLSafeIDToken`) ⇒ `false`
 - substitute **before** `url.Parse` so values aren't percent-encoded
-- final `url.Parse` validity check ⇒ malformed result ⇒ `("", false)`
+- final check requires an absolute http(s) URL with a host ⇒ malformed,
+  relative, or non-http(s) result ⇒ `("", false)`
 
 Drops:
 - the `siteURL.JoinPath` scheme/host/path-prefix rewrite — the substituted

--- a/docs/superpowers/specs/2026-07-26-room-service-buildtaburl-legacy-mapping-design.md
+++ b/docs/superpowers/specs/2026-07-26-room-service-buildtaburl-legacy-mapping-design.md
@@ -83,26 +83,26 @@ Signature becomes `buildTabURL(tmpl string, room *model.Room) (string, bool)`.
 The handler needs a `roomID` no longer as a param — the room doc carries
 `room.ID`.
 
-`getRoomAppTabs` fetches the room once via the existing `store.GetRoom`
-**after** `authorizeRoomAppRead` succeeds:
+`authorizeRoomAppRead` authorizes AND returns the room, narrowly projected
+via a dedicated `store.GetRoomAppRead` (`_id`, `type`, `siteId`). The room
+fetch runs concurrently with the auth checks (separate collections; a single
+joined query would need a forbidden `$lookup`):
 
-- `mongo.ErrNoDocuments` ⇒ `errAppAccessDenied` (mirrors the admin-bypass
-  existence gate; a member-path race where the room vanished mid-request)
-- other error ⇒ `fmt.Errorf("get room: %w", err)` (collapses to `internal`)
+- `mongo.ErrNoDocuments` ⇒ `errAppAccessDenied` on every path — room
+  existence now gates members too, not just the admin bypass
+- other error ⇒ `fmt.Errorf("get room for app read: %w", err)` (⇒ `internal`)
 
-`authorizeRoomAppRead` is intentionally untouched — it is shared with
-`getRoomAppCommandMenu`, which does not need the room doc. The admin path
-performs one extra `GetRoom` (existence gate + tab fetch); accepted, the
-admin path is cold.
+Exactly one room read per request on all paths. `getRoomAppCommandMenu`
+discards the returned room (`_, err :=`).
 
 `Handler` gains a `legacyRoomOrigins map[string]string` field, injected via
 `NewHandler` (replacing the removed `siteURL` param).
 
 ### Projection
 
-`roomReadProjection` (`room-service/store_mongo.go`) gains
-`{Key: "siteId", Value: 1}` — `buildTabURL` reads `room.SiteID`. The
-projection drift-guard integration test is updated in the same change.
+A new `roomAppReadProjection` (`room-service/store_mongo.go`) backs
+`GetRoomAppRead` with only `_id`/`type`/`siteId`; `roomReadProjection`
+stays untouched. A drift-guard integration test pins the narrow set.
 
 ## Error handling
 

--- a/docs/superpowers/specs/2026-07-26-room-service-buildtaburl-legacy-mapping-design.md
+++ b/docs/superpowers/specs/2026-07-26-room-service-buildtaburl-legacy-mapping-design.md
@@ -46,15 +46,16 @@ channel→`p` chosen per product decision.)
 New config field in `room-service/main.go`:
 
 ```go
-LegacyRoomOrigins map[string]string `env:"LEGACY_ROOM_ORIGINS" envDefault:""`
+LegacyRoomOrigins legacyRoomOrigins `env:"LEGACY_ROOM_ORIGINS"`
 ```
 
-- Wire format (native `caarlos0/env` v11 map parsing, `SplitN(pair, ":", 2)`
-  so URL values keep `://`):
-  `LEGACY_ROOM_ORIGINS=site-a:https://legacy.site-a.com,site-b:https://legacy.site-b.com`
-- Startup normalization: `strings.TrimSpace` each key and value (tolerates
-  `site-a: https://legacy.site-a.com`). Empty var ⇒ empty map (valid: every
-  `${roomOrigin}` substitutes to `""`).
+- Wire format: a **JSON array** of `{siteID, origin}` objects, mirroring
+  media-service's `CLUSTER_DOMAINS` (`legacyRoomOrigins` implements
+  `encoding.TextUnmarshaler`, indexed into a siteID→URL map at parse time
+  with duplicate-siteID rejection; malformed JSON fails startup):
+  `LEGACY_ROOM_ORIGINS=[{"siteID":"site-a","origin":"https://legacy.site-a.com"}]`
+- Unset or empty var ⇒ empty map (valid: every `${roomOrigin}`
+  substitutes to `""`).
 - Lookup key is **`room.SiteID`** — the room's origin site, consistent with
   `pkg/drive.GetBaseURLFromRoomOrigin`.
 - Miss policy: substitute the **empty string**; the tab is still returned

--- a/room-service/config_test.go
+++ b/room-service/config_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/caarlos0/env/v11"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeLegacyRoomOrigins(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]string
+		want map[string]string
+	}{
+		{name: "nil map yields empty map", in: nil, want: map[string]string{}},
+		{
+			name: "trims whitespace around keys and values",
+			in:   map[string]string{" site-a": " https://legacy.site-a.com "},
+			want: map[string]string{"site-a": "https://legacy.site-a.com"},
+		},
+		{
+			name: "drops entries empty after trimming",
+			in:   map[string]string{"site-a": "  ", "": "https://x.example.com"},
+			want: map[string]string{},
+		},
+		{
+			name: "clean entries pass through",
+			in: map[string]string{
+				"site-a": "https://legacy.site-a.com",
+				"site-b": "https://legacy.site-b.com",
+			},
+			want: map[string]string{
+				"site-a": "https://legacy.site-a.com",
+				"site-b": "https://legacy.site-b.com",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeLegacyRoomOrigins(tt.in))
+		})
+	}
+}
+
+// TestLegacyRoomOrigins_EnvWireFormat pins the LEGACY_ROOM_ORIGINS wire
+// format: comma-separated entries, first-colon key:value split (URL values
+// keep "://"), spaces after the colon tolerated via normalization.
+func TestLegacyRoomOrigins_EnvWireFormat(t *testing.T) {
+	type originsConfig struct {
+		LegacyRoomOrigins map[string]string `env:"LEGACY_ROOM_ORIGINS"`
+	}
+
+	t.Setenv("LEGACY_ROOM_ORIGINS", "site-a:https://legacy.site-a.com,site-b: https://legacy.site-b.com")
+	cfg, err := env.ParseAs[originsConfig]()
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"site-a": "https://legacy.site-a.com",
+		"site-b": "https://legacy.site-b.com",
+	}, normalizeLegacyRoomOrigins(cfg.LegacyRoomOrigins))
+
+	t.Setenv("LEGACY_ROOM_ORIGINS", "")
+	cfg, err = env.ParseAs[originsConfig]()
+	require.NoError(t, err, "empty value must not be a parse error")
+	assert.Empty(t, normalizeLegacyRoomOrigins(cfg.LegacyRoomOrigins))
+}

--- a/room-service/config_test.go
+++ b/room-service/config_test.go
@@ -8,59 +8,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNormalizeLegacyRoomOrigins(t *testing.T) {
-	tests := []struct {
-		name string
-		in   map[string]string
-		want map[string]string
-	}{
-		{name: "nil map yields empty map", in: nil, want: map[string]string{}},
-		{
-			name: "trims whitespace around keys and values",
-			in:   map[string]string{" site-a": " https://legacy.site-a.com "},
-			want: map[string]string{"site-a": "https://legacy.site-a.com"},
-		},
-		{
-			name: "drops entries empty after trimming",
-			in:   map[string]string{"site-a": "  ", "": "https://x.example.com"},
-			want: map[string]string{},
-		},
-		{
-			name: "clean entries pass through",
-			in: map[string]string{
-				"site-a": "https://legacy.site-a.com",
-				"site-b": "https://legacy.site-b.com",
-			},
-			want: map[string]string{
-				"site-a": "https://legacy.site-a.com",
-				"site-b": "https://legacy.site-b.com",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, normalizeLegacyRoomOrigins(tt.in))
-		})
-	}
+func TestLegacyRoomOrigins_UnmarshalText(t *testing.T) {
+	var l legacyRoomOrigins
+	require.NoError(t, l.UnmarshalText([]byte(
+		`[{"siteID":"site-a","origin":"https://legacy.site-a.com"},`+
+			`{"siteID":"site-b","origin":"https://legacy.site-b.com"}]`)))
+	assert.Equal(t, "https://legacy.site-a.com", l.byID["site-a"])
+	assert.Equal(t, "https://legacy.site-b.com", l.byID["site-b"])
+	assert.Empty(t, l.byID["site-x"], "unconfigured site reads as empty string")
 }
 
-// TestLegacyRoomOrigins_EnvWireFormat pins the wire format: comma-separated,
-// first-colon split (URL values keep "://"), spaces tolerated via normalization.
-func TestLegacyRoomOrigins_EnvWireFormat(t *testing.T) {
+func TestLegacyRoomOrigins_UnmarshalText_Errors(t *testing.T) {
+	var l legacyRoomOrigins
+	assert.Error(t, l.UnmarshalText([]byte(`not-json`)))
+	assert.ErrorContains(t,
+		l.UnmarshalText([]byte(`[{"siteID":"s1","origin":"a"},{"siteID":"s1","origin":"b"}]`)),
+		"duplicate siteID")
+}
+
+// LEGACY_ROOM_ORIGINS is populated from a JSON env string; unset or empty is
+// valid and means every ${roomOrigin} substitutes to "".
+func TestLegacyRoomOrigins_EnvParse(t *testing.T) {
 	type originsConfig struct {
-		LegacyRoomOrigins map[string]string `env:"LEGACY_ROOM_ORIGINS"`
+		LegacyRoomOrigins legacyRoomOrigins `env:"LEGACY_ROOM_ORIGINS"`
 	}
 
-	t.Setenv("LEGACY_ROOM_ORIGINS", "site-a:https://legacy.site-a.com,site-b: https://legacy.site-b.com")
+	t.Setenv("LEGACY_ROOM_ORIGINS", `[{"siteID":"site-a","origin":"https://legacy.site-a.com"}]`)
 	cfg, err := env.ParseAs[originsConfig]()
 	require.NoError(t, err)
-	assert.Equal(t, map[string]string{
-		"site-a": "https://legacy.site-a.com",
-		"site-b": "https://legacy.site-b.com",
-	}, normalizeLegacyRoomOrigins(cfg.LegacyRoomOrigins))
+	assert.Equal(t, "https://legacy.site-a.com", cfg.LegacyRoomOrigins.byID["site-a"])
 
 	t.Setenv("LEGACY_ROOM_ORIGINS", "")
 	cfg, err = env.ParseAs[originsConfig]()
-	require.NoError(t, err, "empty value must not be a parse error")
-	assert.Empty(t, normalizeLegacyRoomOrigins(cfg.LegacyRoomOrigins))
+	require.NoError(t, err)
+	assert.Empty(t, cfg.LegacyRoomOrigins.byID)
+
+	t.Setenv("LEGACY_ROOM_ORIGINS", `[{"siteID":"s1"`)
+	_, err = env.ParseAs[originsConfig]()
+	assert.Error(t, err, "malformed JSON must fail startup, not be silently ignored")
 }

--- a/room-service/config_test.go
+++ b/room-service/config_test.go
@@ -44,9 +44,8 @@ func TestNormalizeLegacyRoomOrigins(t *testing.T) {
 	}
 }
 
-// TestLegacyRoomOrigins_EnvWireFormat pins the LEGACY_ROOM_ORIGINS wire
-// format: comma-separated entries, first-colon key:value split (URL values
-// keep "://"), spaces after the colon tolerated via normalization.
+// TestLegacyRoomOrigins_EnvWireFormat pins the wire format: comma-separated,
+// first-colon split (URL values keep "://"), spaces tolerated via normalization.
 func TestLegacyRoomOrigins_EnvWireFormat(t *testing.T) {
 	type originsConfig struct {
 		LegacyRoomOrigins map[string]string `env:"LEGACY_ROOM_ORIGINS"`

--- a/room-service/deploy/docker-compose.yml
+++ b/room-service/deploy/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - NATS_URL=nats://nats:4222
       - NATS_CREDS_FILE=/etc/nats/backend.creds
       - SITE_ID=site-local
+      - LEGACY_ROOM_ORIGINS=site-local:https://legacy.localhost
       # Dev-only pprof profiling on the health port (off by default). Flip on
       # stack-wide for a profiling session with `PPROF_ENABLED=true make up`.
       - PPROF_ENABLED=${PPROF_ENABLED:-false}

--- a/room-service/deploy/docker-compose.yml
+++ b/room-service/deploy/docker-compose.yml
@@ -15,7 +15,6 @@ services:
       # Dev-only pprof profiling on the health port (off by default). Flip on
       # stack-wide for a profiling session with `PPROF_ENABLED=true make up`.
       - PPROF_ENABLED=${PPROF_ENABLED:-false}
-      - SITE_URL=http://localhost:3000
       - MONGO_URI=mongodb://mongodb:27017
       - MONGO_DB=chat
       - MAX_ROOM_SIZE=1000

--- a/room-service/deploy/docker-compose.yml
+++ b/room-service/deploy/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - NATS_URL=nats://nats:4222
       - NATS_CREDS_FILE=/etc/nats/backend.creds
       - SITE_ID=site-local
-      - LEGACY_ROOM_ORIGINS=site-local:https://legacy.localhost
+      - 'LEGACY_ROOM_ORIGINS=[{"siteID":"site-local","origin":"https://legacy.localhost"},{"siteID":"site-a","origin":"https://legacy.site-a.example.com"},{"siteID":"site-b","origin":"https://legacy.site-b.example.com"}]'
       # Dev-only pprof profiling on the health port (off by default). Flip on
       # stack-wide for a profiling session with `PPROF_ENABLED=true make up`.
       - PPROF_ENABLED=${PPROF_ENABLED:-false}

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -2289,6 +2289,25 @@ func (h *Handler) authorizeRoomAppRead(ctx context.Context, account, roomID stri
 	return nil
 }
 
+// legacyRoomTypes maps the redesigned RoomType vocabulary to the legacy
+// values pre-redesign channel-tab apps expect in their ${roomType} URL
+// template variable.
+var legacyRoomTypes = map[model.RoomType]string{
+	model.RoomTypeChannel:    "p",
+	model.RoomTypeDM:         "d",
+	model.RoomTypeBotDM:      "d",
+	model.RoomTypeDiscussion: "p",
+}
+
+// legacyRoomType returns the legacy vocabulary value for t, falling back
+// to "p" for unknown types so ${roomType} always resolves.
+func legacyRoomType(t model.RoomType) string {
+	if v, ok := legacyRoomTypes[t]; ok {
+		return v
+	}
+	return "p"
+}
+
 // buildTabURL applies the SITE_URL-based scheme/host/path-prefix
 // rewrite and the ${roomId}/${siteId} substitution to a channelTab URL
 // template. Returns (url, true) on success; (_, false) when the

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -2253,55 +2253,46 @@ func (h *Handler) openRoom(c *natsrouter.Context) (*model.OpenRoomResponse, erro
 	return &model.OpenRoomResponse{Status: "ok", Open: sub.Open}, nil
 }
 
-// authorizeRoomAppRead allows the request iff the caller has a
-// subscription in roomID OR is a platform admin in the local users
-// collection AND the room actually exists. The room-existence check
-// gates only the admin bypass — without it, an admin could query app
-// metadata for a fabricated room ID and receive a plausible-looking
-// response (e.g. a non-empty default-tabs list, or an empty cmd-menu
-// list that looks like success). Cross-site admin authority is out of
-// scope: an admin whose users document lives on a different site is
-// denied. Returns the room doc when the admin-bypass path fetched one
-// (nil on the member path, which never needs it).
+// authorizeRoomAppRead admits room members and local platform admins iff the
+// room exists, returning the room narrowly projected via GetRoomAppRead.
 func (h *Handler) authorizeRoomAppRead(ctx context.Context, account, roomID string) (*model.Room, error) {
+	type roomResult struct {
+		room *model.Room
+		err  error
+	}
+	// Fetch concurrently with the auth checks; a joined query would need a
+	// forbidden $lookup. Buffered so the goroutine exits on early denial.
+	roomCh := make(chan roomResult, 1)
+	go func() {
+		room, err := h.store.GetRoomAppRead(ctx, roomID)
+		roomCh <- roomResult{room, err}
+	}()
+
 	sub, err := h.store.GetSubscription(ctx, account, roomID)
 	if err != nil && !errors.Is(err, model.ErrSubscriptionNotFound) {
 		return nil, fmt.Errorf("check room membership: %w", err)
 	}
-	if model.IsRoomMember(sub) {
-		return nil, nil
-	}
-	user, err := h.store.GetUser(ctx, account)
-	if err != nil && !errors.Is(err, ErrUserNotFound) {
-		return nil, fmt.Errorf("check platform admin: %w", err)
-	}
-	if !model.IsPlatformAdmin(user) {
-		return nil, errAppAccessDenied
-	}
-	// Admin bypass: verify the room exists before allowing the read.
-	// Without this, admins could query app metadata for fabricated room
-	// IDs and get plausible-looking responses. The fetched doc is returned
-	// so callers that need it (getRoomAppTabs) don't re-fetch it.
-	return h.getRoomForAppRead(ctx, roomID)
-}
-
-// getRoomForAppRead fetches roomID for the app-read RPCs, collapsing a
-// missing room to errAppAccessDenied so callers can't distinguish a
-// nonexistent room from one they're not allowed to see.
-func (h *Handler) getRoomForAppRead(ctx context.Context, roomID string) (*model.Room, error) {
-	room, err := h.store.GetRoom(ctx, roomID)
-	if err != nil {
-		if errors.Is(err, mongo.ErrNoDocuments) {
+	if !model.IsRoomMember(sub) {
+		user, err := h.store.GetUser(ctx, account)
+		if err != nil && !errors.Is(err, ErrUserNotFound) {
+			return nil, fmt.Errorf("check platform admin: %w", err)
+		}
+		if !model.IsPlatformAdmin(user) {
 			return nil, errAppAccessDenied
 		}
-		return nil, fmt.Errorf("get room for app read: %w", err)
 	}
-	return room, nil
+	// A missing room reads as denied — never reveal room existence.
+	res := <-roomCh
+	if res.err != nil {
+		if errors.Is(res.err, mongo.ErrNoDocuments) {
+			return nil, errAppAccessDenied
+		}
+		return nil, fmt.Errorf("get room for app read: %w", res.err)
+	}
+	return res.room, nil
 }
 
-// legacyRoomTypes maps the redesigned RoomType vocabulary to the legacy
-// values pre-redesign channel-tab apps expect in their ${roomType} URL
-// template variable.
+// legacyRoomTypes maps redesigned RoomTypes to the legacy ${roomType} vocabulary.
 var legacyRoomTypes = map[model.RoomType]string{
 	model.RoomTypeChannel:    "p",
 	model.RoomTypeDM:         "d",
@@ -2309,8 +2300,7 @@ var legacyRoomTypes = map[model.RoomType]string{
 	model.RoomTypeDiscussion: "p",
 }
 
-// legacyRoomType returns the legacy vocabulary value for t, falling back
-// to "p" for unknown types so ${roomType} always resolves.
+// legacyRoomType maps t to the legacy vocabulary; unknown types fall back to "p".
 func legacyRoomType(t model.RoomType) string {
 	if v, ok := legacyRoomTypes[t]; ok {
 		return v
@@ -2318,16 +2308,8 @@ func legacyRoomType(t model.RoomType) string {
 	return "p"
 }
 
-// buildTabURL substitutes the ${roomId}, ${siteId}, ${roomType} and
-// ${roomOrigin} template variables into a channelTab URL template. The
-// template carries the full URL — no base-URL rewrite is applied.
-// ${roomType} is the legacy room-type vocabulary (legacyRoomType);
-// ${roomOrigin} is the legacy origin URL of the room's home site, or ""
-// when unconfigured. Returns (url, true) on success; (_, false) when the
-// template is empty, unparseable, or not an absolute http(s) URL, or the
-// IDs fail the URL-safety check. Rejecting non-absolute-http(s) results
-// makes legacy path-only templates (from the pre-rewrite era) fail safe —
-// Warn-skipped by the caller — instead of shipping a broken URL to clients.
+// buildTabURL substitutes the ${…} variables into a full-URL channelTab template;
+// false unless absolute http(s), so legacy path-only templates fail safe.
 func (h *Handler) buildTabURL(tmpl string, room *model.Room) (string, bool) {
 	if tmpl == "" {
 		return "", false
@@ -2335,8 +2317,7 @@ func (h *Handler) buildTabURL(tmpl string, room *model.Room) (string, bool) {
 	if !isURLSafeIDToken(room.ID) || !isURLSafeIDToken(h.siteID) {
 		return "", false
 	}
-	// Substitute BEFORE parsing so url.Parse only validates the final
-	// string and never percent-encodes the substituted values.
+	// Substitute before parsing so url.Parse never percent-encodes the values.
 	tmpl = strings.ReplaceAll(tmpl, "${roomId}", room.ID)
 	tmpl = strings.ReplaceAll(tmpl, "${siteId}", h.siteID)
 	tmpl = strings.ReplaceAll(tmpl, "${roomType}", legacyRoomType(room.Type))
@@ -2366,11 +2347,6 @@ func (h *Handler) getRoomAppTabs(c *natsrouter.Context) (*model.GetRoomAppTabsRe
 	room, err := h.authorizeRoomAppRead(ctx, account, roomID)
 	if err != nil {
 		return nil, err
-	}
-	if room == nil { // member path: authorization didn't need the room doc
-		if room, err = h.getRoomForAppRead(ctx, roomID); err != nil {
-			return nil, err
-		}
 	}
 
 	apps, err := h.store.ListDefaultChannelTabApps(ctx)

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -2253,43 +2253,24 @@ func (h *Handler) openRoom(c *natsrouter.Context) (*model.OpenRoomResponse, erro
 	return &model.OpenRoomResponse{Status: "ok", Open: sub.Open}, nil
 }
 
-// authorizeRoomAppRead admits room members and local platform admins iff the
-// room exists, returning the room narrowly projected via GetRoomAppRead.
+// authorizeRoomAppRead admits room members only, returning the room narrowly
+// projected via GetRoomAppRead. A missing room reads as denied.
 func (h *Handler) authorizeRoomAppRead(ctx context.Context, account, roomID string) (*model.Room, error) {
-	type roomResult struct {
-		room *model.Room
-		err  error
-	}
-	// Fetch concurrently with the auth checks; a joined query would need a
-	// forbidden $lookup. Buffered so the goroutine exits on early denial.
-	roomCh := make(chan roomResult, 1)
-	go func() {
-		room, err := h.store.GetRoomAppRead(ctx, roomID)
-		roomCh <- roomResult{room, err}
-	}()
-
 	sub, err := h.store.GetSubscription(ctx, account, roomID)
 	if err != nil && !errors.Is(err, model.ErrSubscriptionNotFound) {
 		return nil, fmt.Errorf("check room membership: %w", err)
 	}
 	if !model.IsRoomMember(sub) {
-		user, err := h.store.GetUser(ctx, account)
-		if err != nil && !errors.Is(err, ErrUserNotFound) {
-			return nil, fmt.Errorf("check platform admin: %w", err)
-		}
-		if !model.IsPlatformAdmin(user) {
+		return nil, errAppAccessDenied
+	}
+	room, err := h.store.GetRoomAppRead(ctx, roomID)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
 			return nil, errAppAccessDenied
 		}
+		return nil, fmt.Errorf("get room for app read: %w", err)
 	}
-	// A missing room reads as denied — never reveal room existence.
-	res := <-roomCh
-	if res.err != nil {
-		if errors.Is(res.err, mongo.ErrNoDocuments) {
-			return nil, errAppAccessDenied
-		}
-		return nil, fmt.Errorf("get room for app read: %w", res.err)
-	}
-	return res.room, nil
+	return room, nil
 }
 
 // legacyRoomTypes maps redesigned RoomTypes to the legacy ${roomType} vocabulary.

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -52,7 +52,7 @@ type Handler struct {
 	publishToStream          func(ctx context.Context, subj string, data []byte, msgID string) error
 	publishCore              func(ctx context.Context, subj string, data []byte) error
 	restrictedRoomMinMembers int
-	siteURL                  *url.URL
+	legacyRoomOrigins        map[string]string
 	maxResponseBytes         int64
 
 	// Microsoft Teams integration. graphClient is nil-safe: only the meetings
@@ -72,7 +72,7 @@ type Handler struct {
 	roomMembersCallLimit int
 }
 
-func NewHandler(store RoomStore, keyStore RoomKeyStore, memberListClient MemberListClient, msgReader MessageReader, siteID string, maxRoomSize, maxBatchSize int, memberListTimeout time.Duration, restrictedRoomMinMembers int, publishToStream func(context.Context, string, []byte, string) error, publishCore func(context.Context, string, []byte) error, siteURL *url.URL, maxResponseBytes int64) *Handler {
+func NewHandler(store RoomStore, keyStore RoomKeyStore, memberListClient MemberListClient, msgReader MessageReader, siteID string, maxRoomSize, maxBatchSize int, memberListTimeout time.Duration, restrictedRoomMinMembers int, publishToStream func(context.Context, string, []byte, string) error, publishCore func(context.Context, string, []byte) error, legacyRoomOrigins map[string]string, maxResponseBytes int64) *Handler {
 	return &Handler{
 		store:                    store,
 		keyStore:                 keyStore,
@@ -85,7 +85,7 @@ func NewHandler(store RoomStore, keyStore RoomKeyStore, memberListClient MemberL
 		restrictedRoomMinMembers: restrictedRoomMinMembers,
 		publishToStream:          publishToStream,
 		publishCore:              publishCore,
-		siteURL:                  siteURL,
+		legacyRoomOrigins:        legacyRoomOrigins,
 		maxResponseBytes:         maxResponseBytes,
 	}
 }
@@ -2308,34 +2308,30 @@ func legacyRoomType(t model.RoomType) string {
 	return "p"
 }
 
-// buildTabURL applies the SITE_URL-based scheme/host/path-prefix
-// rewrite and the ${roomId}/${siteId} substitution to a channelTab URL
-// template. Returns (url, true) on success; (_, false) when the
-// template is empty, unparseable, or when siteURL is nil or the IDs
-// fail the URL-safety check.
-func (h *Handler) buildTabURL(tmpl, roomID string) (string, bool) {
+// buildTabURL substitutes the ${roomId}, ${siteId}, ${roomType} and
+// ${roomOrigin} template variables into a channelTab URL template. The
+// template carries the full URL — no base-URL rewrite is applied.
+// ${roomType} is the legacy room-type vocabulary (legacyRoomType);
+// ${roomOrigin} is the legacy origin URL of the room's home site, or ""
+// when unconfigured. Returns (url, true) on success; (_, false) when the
+// template is empty or unparseable, or the IDs fail the URL-safety check.
+func (h *Handler) buildTabURL(tmpl string, room *model.Room) (string, bool) {
 	if tmpl == "" {
 		return "", false
 	}
-	if h.siteURL == nil {
+	if !isURLSafeIDToken(room.ID) || !isURLSafeIDToken(h.siteID) {
 		return "", false
 	}
-	if !isURLSafeIDToken(roomID) || !isURLSafeIDToken(h.siteID) {
-		return "", false
-	}
-	// Substitute BEFORE parsing so url.URL.String() doesn't percent-encode
-	// the substituted values (roomID/siteID are URL-safe by construction).
-	tmpl = strings.ReplaceAll(tmpl, "${roomId}", roomID)
+	// Substitute BEFORE parsing so url.Parse only validates the final
+	// string and never percent-encodes the substituted values.
+	tmpl = strings.ReplaceAll(tmpl, "${roomId}", room.ID)
 	tmpl = strings.ReplaceAll(tmpl, "${siteId}", h.siteID)
-	u, err := url.Parse(tmpl)
-	if err != nil {
+	tmpl = strings.ReplaceAll(tmpl, "${roomType}", legacyRoomType(room.Type))
+	tmpl = strings.ReplaceAll(tmpl, "${roomOrigin}", h.legacyRoomOrigins[room.SiteID])
+	if _, err := url.Parse(tmpl); err != nil {
 		return "", false
 	}
-	joined := h.siteURL.JoinPath(u.Path)
-	joined.User = nil
-	joined.RawQuery = u.RawQuery
-	joined.Fragment = u.Fragment
-	return joined.String(), true
+	return tmpl, true
 }
 
 func (h *Handler) getRoomAppTabs(c *natsrouter.Context) (*model.GetRoomAppTabsResponse, error) {
@@ -2357,6 +2353,14 @@ func (h *Handler) getRoomAppTabs(c *natsrouter.Context) (*model.GetRoomAppTabsRe
 		return nil, err
 	}
 
+	room, err := h.store.GetRoom(ctx, roomID)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, errAppAccessDenied
+		}
+		return nil, fmt.Errorf("get room for app tabs: %w", err)
+	}
+
 	apps, err := h.store.ListDefaultChannelTabApps(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list default channel-tab apps: %w", err)
@@ -2371,7 +2375,7 @@ func (h *Handler) getRoomAppTabs(c *natsrouter.Context) (*model.GetRoomAppTabsRe
 				"request_id", natsutil.RequestIDFromContext(ctx))
 			continue
 		}
-		tabURL, ok := h.buildTabURL(app.ChannelTab.URL.Default, roomID)
+		tabURL, ok := h.buildTabURL(app.ChannelTab.URL.Default, room)
 		if !ok {
 			slog.Warn("skipping app with empty or unparseable channelTab url",
 				"appId", app.ID, "roomId", roomID,

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -2389,7 +2389,7 @@ func (h *Handler) getRoomAppTabs(c *natsrouter.Context) (*model.GetRoomAppTabsRe
 		}
 		tabURL, ok := h.buildTabURL(app.ChannelTab.URL.Default, room)
 		if !ok {
-			slog.Warn("skipping app with empty or unparseable channelTab url",
+			slog.Warn("skipping app with empty, unparseable, or non-http(s) channelTab url",
 				"appId", app.ID, "roomId", roomID,
 				"request_id", natsutil.RequestIDFromContext(ctx))
 			continue

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -2314,7 +2314,10 @@ func legacyRoomType(t model.RoomType) string {
 // ${roomType} is the legacy room-type vocabulary (legacyRoomType);
 // ${roomOrigin} is the legacy origin URL of the room's home site, or ""
 // when unconfigured. Returns (url, true) on success; (_, false) when the
-// template is empty or unparseable, or the IDs fail the URL-safety check.
+// template is empty, unparseable, or not an absolute http(s) URL, or the
+// IDs fail the URL-safety check. Rejecting non-absolute-http(s) results
+// makes legacy path-only templates (from the pre-rewrite era) fail safe —
+// Warn-skipped by the caller — instead of shipping a broken URL to clients.
 func (h *Handler) buildTabURL(tmpl string, room *model.Room) (string, bool) {
 	if tmpl == "" {
 		return "", false
@@ -2328,7 +2331,8 @@ func (h *Handler) buildTabURL(tmpl string, room *model.Room) (string, bool) {
 	tmpl = strings.ReplaceAll(tmpl, "${siteId}", h.siteID)
 	tmpl = strings.ReplaceAll(tmpl, "${roomType}", legacyRoomType(room.Type))
 	tmpl = strings.ReplaceAll(tmpl, "${roomOrigin}", h.legacyRoomOrigins[room.SiteID])
-	if _, err := url.Parse(tmpl); err != nil {
+	u, err := url.Parse(tmpl)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
 		return "", false
 	}
 	return tmpl, true

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -2261,32 +2261,42 @@ func (h *Handler) openRoom(c *natsrouter.Context) (*model.OpenRoomResponse, erro
 // response (e.g. a non-empty default-tabs list, or an empty cmd-menu
 // list that looks like success). Cross-site admin authority is out of
 // scope: an admin whose users document lives on a different site is
-// denied.
-func (h *Handler) authorizeRoomAppRead(ctx context.Context, account, roomID string) error {
+// denied. Returns the room doc when the admin-bypass path fetched one
+// (nil on the member path, which never needs it).
+func (h *Handler) authorizeRoomAppRead(ctx context.Context, account, roomID string) (*model.Room, error) {
 	sub, err := h.store.GetSubscription(ctx, account, roomID)
 	if err != nil && !errors.Is(err, model.ErrSubscriptionNotFound) {
-		return fmt.Errorf("check room membership: %w", err)
+		return nil, fmt.Errorf("check room membership: %w", err)
 	}
 	if model.IsRoomMember(sub) {
-		return nil
+		return nil, nil
 	}
 	user, err := h.store.GetUser(ctx, account)
 	if err != nil && !errors.Is(err, ErrUserNotFound) {
-		return fmt.Errorf("check platform admin: %w", err)
+		return nil, fmt.Errorf("check platform admin: %w", err)
 	}
 	if !model.IsPlatformAdmin(user) {
-		return errAppAccessDenied
+		return nil, errAppAccessDenied
 	}
 	// Admin bypass: verify the room exists before allowing the read.
 	// Without this, admins could query app metadata for fabricated room
-	// IDs and get plausible-looking responses.
-	if _, err := h.store.GetRoom(ctx, roomID); err != nil {
+	// IDs and get plausible-looking responses. The fetched doc is returned
+	// so callers that need it (getRoomAppTabs) don't re-fetch it.
+	return h.getRoomForAppRead(ctx, roomID)
+}
+
+// getRoomForAppRead fetches roomID for the app-read RPCs, collapsing a
+// missing room to errAppAccessDenied so callers can't distinguish a
+// nonexistent room from one they're not allowed to see.
+func (h *Handler) getRoomForAppRead(ctx context.Context, roomID string) (*model.Room, error) {
+	room, err := h.store.GetRoom(ctx, roomID)
+	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
-			return errAppAccessDenied
+			return nil, errAppAccessDenied
 		}
-		return fmt.Errorf("check room existence: %w", err)
+		return nil, fmt.Errorf("get room for app read: %w", err)
 	}
-	return nil
+	return room, nil
 }
 
 // legacyRoomTypes maps the redesigned RoomType vocabulary to the legacy
@@ -2353,16 +2363,14 @@ func (h *Handler) getRoomAppTabs(c *natsrouter.Context) (*model.GetRoomAppTabsRe
 		)
 	}
 
-	if err := h.authorizeRoomAppRead(ctx, account, roomID); err != nil {
+	room, err := h.authorizeRoomAppRead(ctx, account, roomID)
+	if err != nil {
 		return nil, err
 	}
-
-	room, err := h.store.GetRoom(ctx, roomID)
-	if err != nil {
-		if errors.Is(err, mongo.ErrNoDocuments) {
-			return nil, errAppAccessDenied
+	if room == nil { // member path: authorization didn't need the room doc
+		if room, err = h.getRoomForAppRead(ctx, roomID); err != nil {
+			return nil, err
 		}
-		return nil, fmt.Errorf("get room for app tabs: %w", err)
 	}
 
 	apps, err := h.store.ListDefaultChannelTabApps(ctx)
@@ -2411,7 +2419,7 @@ func (h *Handler) getRoomAppCommandMenu(c *natsrouter.Context) (*model.GetRoomAp
 		)
 	}
 
-	if err := h.authorizeRoomAppRead(ctx, account, roomID); err != nil {
+	if _, err := h.authorizeRoomAppRead(ctx, account, roomID); err != nil {
 		return nil, err
 	}
 

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -6432,6 +6432,27 @@ func TestHandler_buildTabURL(t *testing.T) {
 			room:    channelRoom,
 			wantOK:  false,
 		},
+		{
+			name:    "relative path template rejected (legacy pre-rewrite template)",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "/tab/${roomId}",
+			room:    channelRoom,
+			wantOK:  false,
+		},
+		{
+			name:    "scheme-relative template rejected",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "//upstream.example.com/tab/${roomId}",
+			room:    channelRoom,
+			wantOK:  false,
+		},
+		{
+			name:    "non-http scheme rejected",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "javascript:alert(1)",
+			room:    channelRoom,
+			wantOK:  false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -6296,6 +6296,26 @@ func mockTabApp(id, tabName, urlTemplate string) model.App {
 	}
 }
 
+func TestLegacyRoomType(t *testing.T) {
+	tests := []struct {
+		name string
+		in   model.RoomType
+		want string
+	}{
+		{name: "channel maps to p", in: model.RoomTypeChannel, want: "p"},
+		{name: "dm maps to d", in: model.RoomTypeDM, want: "d"},
+		{name: "botDM maps to d", in: model.RoomTypeBotDM, want: "d"},
+		{name: "discussion maps to p", in: model.RoomTypeDiscussion, want: "p"},
+		{name: "unknown type falls back to p", in: model.RoomType("livechat"), want: "p"},
+		{name: "empty type falls back to p", in: model.RoomType(""), want: "p"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, legacyRoomType(tt.in))
+		})
+	}
+}
+
 func TestHandler_buildTabURL(t *testing.T) {
 	validSiteURL, err := url.Parse("https://chat.example.com")
 	require.NoError(t, err)

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -6197,51 +6197,10 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 			wantErr: errAppAccessDenied,
 		},
 		{
-			name: "admin allowed (no sub, admin role, room exists) returns the fetched room",
+			name: "denied: no sub — admin role no longer grants access, GetUser never called",
 			setupMock: func(s *MockRoomStore) {
 				s.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 					Return(nil, model.ErrSubscriptionNotFound)
-				s.EXPECT().GetUser(gomock.Any(), "alice").
-					Return(&model.User{ID: "u1", Account: "alice", Roles: []model.UserRole{model.UserRoleAdmin}}, nil)
-				s.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
-					Return(&model.Room{ID: "r1"}, nil)
-			},
-			wantErr:  nil,
-			wantRoom: true,
-		},
-		{
-			name: "denied: admin role but room does not exist",
-			setupMock: func(s *MockRoomStore) {
-				s.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
-					Return(nil, model.ErrSubscriptionNotFound)
-				s.EXPECT().GetUser(gomock.Any(), "alice").
-					Return(&model.User{ID: "u1", Account: "alice", Roles: []model.UserRole{model.UserRoleAdmin}}, nil)
-				s.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
-					Return(nil, mongo.ErrNoDocuments)
-			},
-			wantErr: errAppAccessDenied,
-		},
-		{
-			name: "denied: no sub, no admin role",
-			setupMock: func(s *MockRoomStore) {
-				s.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
-					Return(nil, model.ErrSubscriptionNotFound)
-				s.EXPECT().GetUser(gomock.Any(), "alice").
-					Return(&model.User{ID: "u1", Account: "alice", Roles: []model.UserRole{model.UserRoleUser}}, nil)
-				s.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
-					Return(&model.Room{ID: "r1"}, nil).AnyTimes() // concurrent fetch, result unread on denial
-			},
-			wantErr: errAppAccessDenied,
-		},
-		{
-			name: "denied: no sub, user not found (cross-site admin path)",
-			setupMock: func(s *MockRoomStore) {
-				s.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
-					Return(nil, model.ErrSubscriptionNotFound)
-				s.EXPECT().GetUser(gomock.Any(), "alice").
-					Return(nil, ErrUserNotFound)
-				s.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
-					Return(&model.Room{ID: "r1"}, nil).AnyTimes()
 			},
 			wantErr: errAppAccessDenied,
 		},
@@ -6250,30 +6209,17 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 			setupMock: func(s *MockRoomStore) {
 				s.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 					Return(nil, errors.New("mongo unavailable"))
-				s.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
-					Return(&model.Room{ID: "r1"}, nil).AnyTimes()
 			},
 			wantErrContains: "check room membership",
 		},
 		{
-			name: "transient user-lookup error propagates",
+			name: "transient room-fetch error propagates",
 			setupMock: func(s *MockRoomStore) {
 				s.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
-					Return(nil, model.ErrSubscriptionNotFound)
-				s.EXPECT().GetUser(gomock.Any(), "alice").
-					Return(nil, errors.New("mongo unavailable"))
-				s.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
-					Return(&model.Room{ID: "r1"}, nil).AnyTimes()
-			},
-			wantErrContains: "check platform admin",
-		},
-		{
-			name: "transient room-existence error propagates (admin path)",
-			setupMock: func(s *MockRoomStore) {
-				s.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
-					Return(nil, model.ErrSubscriptionNotFound)
-				s.EXPECT().GetUser(gomock.Any(), "alice").
-					Return(&model.User{ID: "u1", Account: "alice", Roles: []model.UserRole{model.UserRoleAdmin}}, nil)
+					Return(&model.Subscription{
+						User:   model.SubscriptionUser{ID: "u1", Account: "alice"},
+						RoomID: "r1",
+					}, nil)
 				s.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
 					Return(nil, errors.New("mongo unavailable"))
 			},
@@ -6491,42 +6437,12 @@ func TestHandler_handleGetRoomAppTabs_MemberAllowed(t *testing.T) {
 	assert.Equal(t, "app1.bot", resp.Apps[0].Assistant.Name)
 }
 
-func TestHandler_handleGetRoomAppTabs_AdminAllowed(t *testing.T) {
+// Membership is the only gate now: a platform admin without a subscription
+// is denied and no user lookup happens.
+func TestHandler_handleGetRoomAppTabs_NonMemberDenied(t *testing.T) {
 	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(nil, model.ErrSubscriptionNotFound)
-	store.EXPECT().GetUser(gomock.Any(), "alice").
-		Return(&model.User{Account: "alice", Roles: []model.UserRole{model.UserRoleAdmin}}, nil)
-	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
-		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
-	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).Return([]model.App{}, nil)
-
-	resp, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
-	require.NoError(t, err)
-	assert.Empty(t, resp.Apps)
-}
-
-func TestHandler_handleGetRoomAppTabs_Denied(t *testing.T) {
-	h, store, _ := newTabsTestHandler(t)
-	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
-		Return(nil, model.ErrSubscriptionNotFound)
-	store.EXPECT().GetUser(gomock.Any(), "alice").
-		Return(&model.User{Account: "alice", Roles: []model.UserRole{model.UserRoleUser}}, nil)
-	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
-		Return(&model.Room{ID: "r1"}, nil).AnyTimes()
-
-	_, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
-	assert.ErrorIs(t, err, errAppAccessDenied)
-}
-
-func TestHandler_handleGetRoomAppTabs_DeniedNoUser(t *testing.T) {
-	h, store, _ := newTabsTestHandler(t)
-	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
-		Return(nil, model.ErrSubscriptionNotFound)
-	store.EXPECT().GetUser(gomock.Any(), "alice").
-		Return(nil, ErrUserNotFound)
-	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
-		Return(&model.Room{ID: "r1"}, nil).AnyTimes()
 
 	_, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
 	assert.ErrorIs(t, err, errAppAccessDenied)
@@ -6648,8 +6564,6 @@ func TestHandler_handleGetRoomAppTabs_ContextTimeout(t *testing.T) {
 			<-ctx.Done()
 			return nil, ctx.Err()
 		})
-	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
-		Return(&model.Room{ID: "r1"}, nil).AnyTimes()
 
 	parent, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -6734,29 +6648,10 @@ func TestHandler_handleGetRoomAppCommandMenu_MemberAllowed_BotWithoutMenu(t *tes
 	assert.Nil(t, resp.AppAssistants[0].CmdBlocks)
 }
 
-func TestHandler_handleGetRoomAppCommandMenu_AdminAllowed(t *testing.T) {
+func TestHandler_handleGetRoomAppCommandMenu_NonMemberDenied(t *testing.T) {
 	h, store := newCmdMenuTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(nil, model.ErrSubscriptionNotFound)
-	store.EXPECT().GetUser(gomock.Any(), "alice").
-		Return(&model.User{Account: "alice", Roles: []model.UserRole{model.UserRoleAdmin}}, nil)
-	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
-		Return(&model.Room{ID: "r1"}, nil)
-	store.EXPECT().ListRoomBotApps(gomock.Any(), "r1").Return([]RoomBotAppEntry{}, nil)
-
-	resp, err := h.getRoomAppCommandMenu(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
-	require.NoError(t, err)
-	assert.Len(t, resp.AppAssistants, 0)
-}
-
-func TestHandler_handleGetRoomAppCommandMenu_Denied(t *testing.T) {
-	h, store := newCmdMenuTestHandler(t)
-	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
-		Return(nil, model.ErrSubscriptionNotFound)
-	store.EXPECT().GetUser(gomock.Any(), "alice").
-		Return(&model.User{Account: "alice"}, nil)
-	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
-		Return(&model.Room{ID: "r1"}, nil).AnyTimes()
 
 	_, err := h.getRoomAppCommandMenu(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
 	assert.ErrorIs(t, err, errAppAccessDenied)
@@ -6799,8 +6694,6 @@ func TestHandler_handleGetRoomAppCommandMenu_ContextTimeout(t *testing.T) {
 			<-ctx.Done()
 			return nil, ctx.Err()
 		})
-	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
-		Return(&model.Room{ID: "r1"}, nil).AnyTimes()
 
 	parent, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -6276,13 +6275,15 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 	}
 }
 
-func newTabsTestHandler(t *testing.T, siteURL string) (*Handler, *MockRoomStore, *gomock.Controller) {
+func newTabsTestHandler(t *testing.T) (*Handler, *MockRoomStore, *gomock.Controller) {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 	store := NewMockRoomStore(ctrl)
-	u, err := url.Parse(siteURL)
-	require.NoError(t, err)
-	return &Handler{store: store, siteID: "site-a", siteURL: u}, store, ctrl
+	return &Handler{
+		store:             store,
+		siteID:            "site-a",
+		legacyRoomOrigins: map[string]string{"site-a": "https://legacy.site-a.com"},
+	}, store, ctrl
 }
 
 func mockTabApp(id, tabName, urlTemplate string) model.App {
@@ -6317,64 +6318,124 @@ func TestLegacyRoomType(t *testing.T) {
 }
 
 func TestHandler_buildTabURL(t *testing.T) {
-	validSiteURL, err := url.Parse("https://chat.example.com")
-	require.NoError(t, err)
+	origins := map[string]string{
+		"site-a": "https://legacy.site-a.com",
+		"site-b": "https://legacy.site-b.com",
+	}
+	channelRoom := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}
 
 	tests := []struct {
 		name    string
 		handler *Handler
 		tmpl    string
-		roomID  string
+		room    *model.Room
 		wantURL string
 		wantOK  bool
 	}{
 		{
-			name:    "happy path",
-			handler: &Handler{siteID: "site-a", siteURL: validSiteURL},
-			tmpl:    "https://upstream/tab/${roomId}/${siteId}",
-			roomID:  "r1",
-			wantURL: "https://chat.example.com/tab/r1/site-a",
+			name:    "full template preserved with all four variables substituted",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://template-a.com/tab?room=${roomId}&site=${siteId}&roomType=${roomType}&roomOrigin=${roomOrigin}",
+			room:    channelRoom,
+			wantURL: "https://template-a.com/tab?room=r1&site=site-a&roomType=p&roomOrigin=https://legacy.site-a.com",
+			wantOK:  true,
+		},
+		{
+			name:    "no SITE_URL rewrite: template scheme, host and path kept verbatim",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://upstream.example.com/deep/path/${roomId}",
+			room:    channelRoom,
+			wantURL: "https://upstream.example.com/deep/path/r1",
+			wantOK:  true,
+		},
+		{
+			name:    "dm maps to d",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://t.example.com?rt=${roomType}",
+			room:    &model.Room{ID: "r1", Type: model.RoomTypeDM, SiteID: "site-a"},
+			wantURL: "https://t.example.com?rt=d",
+			wantOK:  true,
+		},
+		{
+			name:    "botDM maps to d",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://t.example.com?rt=${roomType}",
+			room:    &model.Room{ID: "r1", Type: model.RoomTypeBotDM, SiteID: "site-a"},
+			wantURL: "https://t.example.com?rt=d",
+			wantOK:  true,
+		},
+		{
+			name:    "discussion maps to p",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://t.example.com?rt=${roomType}",
+			room:    &model.Room{ID: "r1", Type: model.RoomTypeDiscussion, SiteID: "site-a"},
+			wantURL: "https://t.example.com?rt=p",
+			wantOK:  true,
+		},
+		{
+			name:    "unknown room type falls back to p",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://t.example.com?rt=${roomType}",
+			room:    &model.Room{ID: "r1", Type: model.RoomType("livechat"), SiteID: "site-a"},
+			wantURL: "https://t.example.com?rt=p",
+			wantOK:  true,
+		},
+		{
+			name:    "roomOrigin keyed by the room's own SiteID, not the local site",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://t.example.com?o=${roomOrigin}",
+			room:    &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-b"},
+			wantURL: "https://t.example.com?o=https://legacy.site-b.com",
+			wantOK:  true,
+		},
+		{
+			name:    "unmapped origin site substitutes empty string",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://t.example.com?o=${roomOrigin}&x=1",
+			room:    &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-x"},
+			wantURL: "https://t.example.com?o=&x=1",
+			wantOK:  true,
+		},
+		{
+			name:    "nil origins map substitutes empty string",
+			handler: &Handler{siteID: "site-a"},
+			tmpl:    "https://t.example.com?o=${roomOrigin}",
+			room:    channelRoom,
+			wantURL: "https://t.example.com?o=",
 			wantOK:  true,
 		},
 		{
 			name:    "empty template",
-			handler: &Handler{siteID: "site-a", siteURL: validSiteURL},
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
 			tmpl:    "",
-			roomID:  "r1",
-			wantOK:  false,
-		},
-		{
-			name:    "nil siteURL",
-			handler: &Handler{siteID: "site-a"},
-			tmpl:    "https://upstream/tab/${roomId}",
-			roomID:  "r1",
-			wantOK:  false,
-		},
-		{
-			name:    "non-URL-safe roomID",
-			handler: &Handler{siteID: "site-a", siteURL: validSiteURL},
-			tmpl:    "https://upstream/tab/${roomId}",
-			roomID:  "r1/../../etc",
-			wantOK:  false,
-		},
-		{
-			name:    "non-URL-safe siteID",
-			handler: &Handler{siteID: "site/../a", siteURL: validSiteURL},
-			tmpl:    "https://upstream/tab/${roomId}",
-			roomID:  "r1",
+			room:    channelRoom,
 			wantOK:  false,
 		},
 		{
 			name:    "malformed template",
-			handler: &Handler{siteID: "site-a", siteURL: validSiteURL},
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
 			tmpl:    "://malformed",
-			roomID:  "r1",
+			room:    channelRoom,
+			wantOK:  false,
+		},
+		{
+			name:    "non-URL-safe roomID",
+			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
+			tmpl:    "https://t.example.com/${roomId}",
+			room:    &model.Room{ID: "r1/../../etc", Type: model.RoomTypeChannel, SiteID: "site-a"},
+			wantOK:  false,
+		},
+		{
+			name:    "non-URL-safe siteID",
+			handler: &Handler{siteID: "site/../a", legacyRoomOrigins: origins},
+			tmpl:    "https://t.example.com/${roomId}",
+			room:    channelRoom,
 			wantOK:  false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, ok := tt.handler.buildTabURL(tt.tmpl, tt.roomID)
+			got, ok := tt.handler.buildTabURL(tt.tmpl, tt.room)
 			assert.Equal(t, tt.wantOK, ok)
 			assert.Equal(t, tt.wantURL, got)
 		})
@@ -6382,11 +6443,13 @@ func TestHandler_buildTabURL(t *testing.T) {
 }
 
 func TestHandler_handleGetRoomAppTabs_MemberAllowed(t *testing.T) {
-	h, store, _ := newTabsTestHandler(t, "https://chat.example.com")
+	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{ID: "u1", Account: "alice"}, RoomID: "r1"}, nil)
+	store.EXPECT().GetRoom(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).Return([]model.App{
-		mockTabApp("app1", "Calendar", "https://upstream/cal/${roomId}/${siteId}/index"),
+		mockTabApp("app1", "Calendar", "https://upstream.example.com/cal/${roomId}/${siteId}?type=${roomType}&origin=${roomOrigin}"),
 	}, nil)
 
 	resp, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
@@ -6394,19 +6457,19 @@ func TestHandler_handleGetRoomAppTabs_MemberAllowed(t *testing.T) {
 	require.Len(t, resp.Apps, 1)
 	assert.Equal(t, "app1", resp.Apps[0].ID)
 	assert.Equal(t, "Calendar", resp.Apps[0].Name)
-	assert.Equal(t, "https://chat.example.com/cal/r1/site-a/index", resp.Apps[0].TabURL)
+	assert.Equal(t, "https://upstream.example.com/cal/r1/site-a?type=p&origin=https://legacy.site-a.com", resp.Apps[0].TabURL)
 	require.NotNil(t, resp.Apps[0].Assistant)
 	assert.Equal(t, "app1.bot", resp.Apps[0].Assistant.Name)
 }
 
 func TestHandler_handleGetRoomAppTabs_AdminAllowed(t *testing.T) {
-	h, store, _ := newTabsTestHandler(t, "https://chat.example.com")
+	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(nil, model.ErrSubscriptionNotFound)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{Account: "alice", Roles: []model.UserRole{model.UserRoleAdmin}}, nil)
 	store.EXPECT().GetRoom(gomock.Any(), "r1").
-		Return(&model.Room{ID: "r1"}, nil)
+		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil).Times(2)
 	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).Return([]model.App{}, nil)
 
 	resp, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
@@ -6415,7 +6478,7 @@ func TestHandler_handleGetRoomAppTabs_AdminAllowed(t *testing.T) {
 }
 
 func TestHandler_handleGetRoomAppTabs_Denied(t *testing.T) {
-	h, store, _ := newTabsTestHandler(t, "https://chat.example.com")
+	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(nil, model.ErrSubscriptionNotFound)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
@@ -6426,7 +6489,7 @@ func TestHandler_handleGetRoomAppTabs_Denied(t *testing.T) {
 }
 
 func TestHandler_handleGetRoomAppTabs_DeniedNoUser(t *testing.T) {
-	h, store, _ := newTabsTestHandler(t, "https://chat.example.com")
+	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(nil, model.ErrSubscriptionNotFound)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
@@ -6437,9 +6500,11 @@ func TestHandler_handleGetRoomAppTabs_DeniedNoUser(t *testing.T) {
 }
 
 func TestHandler_handleGetRoomAppTabs_EmptyResultIsEmptyArray(t *testing.T) {
-	h, store, _ := newTabsTestHandler(t, "https://chat.example.com")
+	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
+	store.EXPECT().GetRoom(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).Return(nil, nil)
 
 	resp, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
@@ -6451,51 +6516,28 @@ func TestHandler_handleGetRoomAppTabs_EmptyResultIsEmptyArray(t *testing.T) {
 	assert.Contains(t, string(data), `"apps":[]`)
 }
 
-func TestHandler_handleGetRoomAppTabs_URLRewritePathPrefix(t *testing.T) {
-	h, store, _ := newTabsTestHandler(t, "https://chat.example.com/chat")
+func TestHandler_handleGetRoomAppTabs_TemplateURLPreserved(t *testing.T) {
+	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
+	store.EXPECT().GetRoom(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).Return([]model.App{
-		mockTabApp("app1", "Calendar", "https://upstream/tab/${roomId}"),
+		mockTabApp("app1", "X", "https://template-a.com/path?room=${roomId}#tab=${siteId}"),
 	}, nil)
 
 	resp, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
 	require.NoError(t, err)
-	assert.Equal(t, "https://chat.example.com/chat/tab/r1", resp.Apps[0].TabURL)
+	assert.Equal(t, "https://template-a.com/path?room=r1#tab=site-a", resp.Apps[0].TabURL,
+		"template scheme/host must be preserved — no SITE_URL rewrite")
 }
 
-func TestHandler_handleGetRoomAppTabs_URLRewriteStripsUserinfo(t *testing.T) {
-	h, store, _ := newTabsTestHandler(t, "https://chat.example.com")
+func TestHandler_handleGetRoomAppTabs_SkipsEmptyAndMalformed(t *testing.T) {
+	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
-	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).Return([]model.App{
-		mockTabApp("app1", "X", "https://user:pass@upstream/path/${roomId}"),
-	}, nil)
-
-	resp, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
-	require.NoError(t, err)
-	assert.NotContains(t, resp.Apps[0].TabURL, "user")
-	assert.NotContains(t, resp.Apps[0].TabURL, "pass")
-	assert.Equal(t, "https://chat.example.com/path/r1", resp.Apps[0].TabURL)
-}
-
-func TestHandler_handleGetRoomAppTabs_URLRewritePreservesQueryAndFragment(t *testing.T) {
-	h, store, _ := newTabsTestHandler(t, "https://chat.example.com")
-	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
-		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
-	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).Return([]model.App{
-		mockTabApp("app1", "X", "https://upstream/path?room=${roomId}#tab=${siteId}"),
-	}, nil)
-
-	resp, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
-	require.NoError(t, err)
-	assert.Equal(t, "https://chat.example.com/path?room=r1#tab=site-a", resp.Apps[0].TabURL)
-}
-
-func TestHandler_handleGetRoomAppTabs_URLRewriteSkipsEmptyAndMalformed(t *testing.T) {
-	h, store, _ := newTabsTestHandler(t, "https://chat.example.com")
-	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
-		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
+	store.EXPECT().GetRoom(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).Return([]model.App{
 		mockTabApp("ok1", "OK1", "https://upstream/ok1/${roomId}"),
 		mockTabApp("empty", "Empty", ""),
@@ -6511,9 +6553,11 @@ func TestHandler_handleGetRoomAppTabs_URLRewriteSkipsEmptyAndMalformed(t *testin
 }
 
 func TestHandler_handleGetRoomAppTabs_SkipsAppWithNilChannelTab(t *testing.T) {
-	h, store, _ := newTabsTestHandler(t, "https://chat.example.com")
+	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
+	store.EXPECT().GetRoom(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	// One app has nil ChannelTab (invalid data), one is valid — only the valid one should appear.
 	appNoTab := model.App{ID: "notab", ChannelTab: nil}
 	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).Return([]model.App{
@@ -6528,9 +6572,11 @@ func TestHandler_handleGetRoomAppTabs_SkipsAppWithNilChannelTab(t *testing.T) {
 }
 
 func TestHandler_handleGetRoomAppTabs_StoreListError(t *testing.T) {
-	h, store, _ := newTabsTestHandler(t, "https://chat.example.com")
+	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
+	store.EXPECT().GetRoom(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).
 		Return(nil, errors.New("mongo down"))
 
@@ -6539,8 +6585,31 @@ func TestHandler_handleGetRoomAppTabs_StoreListError(t *testing.T) {
 	assert.Contains(t, err.Error(), "mongo down")
 }
 
+func TestHandler_handleGetRoomAppTabs_RoomNotFound(t *testing.T) {
+	h, store, _ := newTabsTestHandler(t)
+	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
+		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
+	store.EXPECT().GetRoom(gomock.Any(), "r1").
+		Return(nil, fmt.Errorf("room %q not found: %w", "r1", mongo.ErrNoDocuments))
+
+	_, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+	assert.ErrorIs(t, err, errAppAccessDenied)
+}
+
+func TestHandler_handleGetRoomAppTabs_RoomFetchError(t *testing.T) {
+	h, store, _ := newTabsTestHandler(t)
+	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
+		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
+	store.EXPECT().GetRoom(gomock.Any(), "r1").
+		Return(nil, errors.New("mongo down"))
+
+	_, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, errAppAccessDenied, "infra failure must collapse to internal, not access-denied")
+}
+
 func TestHandler_handleGetRoomAppTabs_ContextTimeout(t *testing.T) {
-	h, store, _ := newTabsTestHandler(t, "https://chat.example.com")
+	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		DoAndReturn(func(ctx context.Context, _, _ string) (*model.Subscription, error) {
 			<-ctx.Done()

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -6167,6 +6167,7 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 		setupMock       func(*MockRoomStore)
 		wantErr         error
 		wantErrContains string
+		wantRoom        bool
 	}{
 		{
 			name: "member allowed",
@@ -6180,7 +6181,7 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "admin allowed (no sub, admin role, room exists)",
+			name: "admin allowed (no sub, admin role, room exists) returns the fetched room",
 			setupMock: func(s *MockRoomStore) {
 				s.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 					Return(nil, model.ErrSubscriptionNotFound)
@@ -6189,7 +6190,8 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 				s.EXPECT().GetRoom(gomock.Any(), "r1").
 					Return(&model.Room{ID: "r1"}, nil)
 			},
-			wantErr: nil,
+			wantErr:  nil,
+			wantRoom: true,
 		},
 		{
 			name: "denied: admin role but room does not exist",
@@ -6251,7 +6253,7 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 				s.EXPECT().GetRoom(gomock.Any(), "r1").
 					Return(nil, errors.New("mongo unavailable"))
 			},
-			wantErrContains: "check room existence",
+			wantErrContains: "get room for app read",
 		},
 	}
 
@@ -6261,7 +6263,7 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 			store := NewMockRoomStore(ctrl)
 			tt.setupMock(store)
 			h := &Handler{store: store, siteID: "site-a"}
-			err := h.authorizeRoomAppRead(context.Background(), "alice", "r1")
+			room, err := h.authorizeRoomAppRead(context.Background(), "alice", "r1")
 			switch {
 			case tt.wantErrContains != "":
 				require.Error(t, err)
@@ -6270,6 +6272,11 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 				assert.NoError(t, err)
 			default:
 				assert.ErrorIs(t, err, tt.wantErr)
+			}
+			if tt.wantRoom {
+				assert.NotNil(t, room, "admin path must return the room it fetched")
+			} else {
+				assert.Nil(t, room)
 			}
 		})
 	}
@@ -6349,35 +6356,14 @@ func TestHandler_buildTabURL(t *testing.T) {
 			wantOK:  true,
 		},
 		{
+			// One non-channel case proves ${roomType} varies by room type
+			// end-to-end; exhaustive mapping coverage lives in
+			// TestLegacyRoomType.
 			name:    "dm maps to d",
 			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
 			tmpl:    "https://t.example.com?rt=${roomType}",
 			room:    &model.Room{ID: "r1", Type: model.RoomTypeDM, SiteID: "site-a"},
 			wantURL: "https://t.example.com?rt=d",
-			wantOK:  true,
-		},
-		{
-			name:    "botDM maps to d",
-			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
-			tmpl:    "https://t.example.com?rt=${roomType}",
-			room:    &model.Room{ID: "r1", Type: model.RoomTypeBotDM, SiteID: "site-a"},
-			wantURL: "https://t.example.com?rt=d",
-			wantOK:  true,
-		},
-		{
-			name:    "discussion maps to p",
-			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
-			tmpl:    "https://t.example.com?rt=${roomType}",
-			room:    &model.Room{ID: "r1", Type: model.RoomTypeDiscussion, SiteID: "site-a"},
-			wantURL: "https://t.example.com?rt=p",
-			wantOK:  true,
-		},
-		{
-			name:    "unknown room type falls back to p",
-			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
-			tmpl:    "https://t.example.com?rt=${roomType}",
-			room:    &model.Room{ID: "r1", Type: model.RoomType("livechat"), SiteID: "site-a"},
-			wantURL: "https://t.example.com?rt=p",
 			wantOK:  true,
 		},
 		{
@@ -6490,7 +6476,7 @@ func TestHandler_handleGetRoomAppTabs_AdminAllowed(t *testing.T) {
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{Account: "alice", Roles: []model.UserRole{model.UserRoleAdmin}}, nil)
 	store.EXPECT().GetRoom(gomock.Any(), "r1").
-		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil).Times(2)
+		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).Return([]model.App{}, nil)
 
 	resp, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -6170,15 +6170,31 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 		wantRoom        bool
 	}{
 		{
-			name: "member allowed",
+			name: "member allowed, room returned",
 			setupMock: func(s *MockRoomStore) {
 				s.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 					Return(&model.Subscription{
 						User:   model.SubscriptionUser{ID: "u1", Account: "alice"},
 						RoomID: "r1",
 					}, nil)
+				s.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
+					Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 			},
-			wantErr: nil,
+			wantErr:  nil,
+			wantRoom: true,
+		},
+		{
+			name: "denied: member but room vanished",
+			setupMock: func(s *MockRoomStore) {
+				s.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
+					Return(&model.Subscription{
+						User:   model.SubscriptionUser{ID: "u1", Account: "alice"},
+						RoomID: "r1",
+					}, nil)
+				s.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
+					Return(nil, fmt.Errorf("room %q not found: %w", "r1", mongo.ErrNoDocuments))
+			},
+			wantErr: errAppAccessDenied,
 		},
 		{
 			name: "admin allowed (no sub, admin role, room exists) returns the fetched room",
@@ -6187,7 +6203,7 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 					Return(nil, model.ErrSubscriptionNotFound)
 				s.EXPECT().GetUser(gomock.Any(), "alice").
 					Return(&model.User{ID: "u1", Account: "alice", Roles: []model.UserRole{model.UserRoleAdmin}}, nil)
-				s.EXPECT().GetRoom(gomock.Any(), "r1").
+				s.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
 					Return(&model.Room{ID: "r1"}, nil)
 			},
 			wantErr:  nil,
@@ -6200,7 +6216,7 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 					Return(nil, model.ErrSubscriptionNotFound)
 				s.EXPECT().GetUser(gomock.Any(), "alice").
 					Return(&model.User{ID: "u1", Account: "alice", Roles: []model.UserRole{model.UserRoleAdmin}}, nil)
-				s.EXPECT().GetRoom(gomock.Any(), "r1").
+				s.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
 					Return(nil, mongo.ErrNoDocuments)
 			},
 			wantErr: errAppAccessDenied,
@@ -6212,6 +6228,8 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 					Return(nil, model.ErrSubscriptionNotFound)
 				s.EXPECT().GetUser(gomock.Any(), "alice").
 					Return(&model.User{ID: "u1", Account: "alice", Roles: []model.UserRole{model.UserRoleUser}}, nil)
+				s.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
+					Return(&model.Room{ID: "r1"}, nil).AnyTimes() // concurrent fetch, result unread on denial
 			},
 			wantErr: errAppAccessDenied,
 		},
@@ -6222,6 +6240,8 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 					Return(nil, model.ErrSubscriptionNotFound)
 				s.EXPECT().GetUser(gomock.Any(), "alice").
 					Return(nil, ErrUserNotFound)
+				s.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
+					Return(&model.Room{ID: "r1"}, nil).AnyTimes()
 			},
 			wantErr: errAppAccessDenied,
 		},
@@ -6230,6 +6250,8 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 			setupMock: func(s *MockRoomStore) {
 				s.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 					Return(nil, errors.New("mongo unavailable"))
+				s.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
+					Return(&model.Room{ID: "r1"}, nil).AnyTimes()
 			},
 			wantErrContains: "check room membership",
 		},
@@ -6240,6 +6262,8 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 					Return(nil, model.ErrSubscriptionNotFound)
 				s.EXPECT().GetUser(gomock.Any(), "alice").
 					Return(nil, errors.New("mongo unavailable"))
+				s.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
+					Return(&model.Room{ID: "r1"}, nil).AnyTimes()
 			},
 			wantErrContains: "check platform admin",
 		},
@@ -6250,7 +6274,7 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 					Return(nil, model.ErrSubscriptionNotFound)
 				s.EXPECT().GetUser(gomock.Any(), "alice").
 					Return(&model.User{ID: "u1", Account: "alice", Roles: []model.UserRole{model.UserRoleAdmin}}, nil)
-				s.EXPECT().GetRoom(gomock.Any(), "r1").
+				s.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
 					Return(nil, errors.New("mongo unavailable"))
 			},
 			wantErrContains: "get room for app read",
@@ -6356,9 +6380,7 @@ func TestHandler_buildTabURL(t *testing.T) {
 			wantOK:  true,
 		},
 		{
-			// One non-channel case proves ${roomType} varies by room type
-			// end-to-end; exhaustive mapping coverage lives in
-			// TestLegacyRoomType.
+			// Non-channel case: ${roomType} varies end-to-end; full mapping in TestLegacyRoomType.
 			name:    "dm maps to d",
 			handler: &Handler{siteID: "site-a", legacyRoomOrigins: origins},
 			tmpl:    "https://t.example.com?rt=${roomType}",
@@ -6453,7 +6475,7 @@ func TestHandler_handleGetRoomAppTabs_MemberAllowed(t *testing.T) {
 	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{ID: "u1", Account: "alice"}, RoomID: "r1"}, nil)
-	store.EXPECT().GetRoom(gomock.Any(), "r1").
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
 		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).Return([]model.App{
 		mockTabApp("app1", "Calendar", "https://upstream.example.com/cal/${roomId}/${siteId}?type=${roomType}&origin=${roomOrigin}"),
@@ -6475,7 +6497,7 @@ func TestHandler_handleGetRoomAppTabs_AdminAllowed(t *testing.T) {
 		Return(nil, model.ErrSubscriptionNotFound)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{Account: "alice", Roles: []model.UserRole{model.UserRoleAdmin}}, nil)
-	store.EXPECT().GetRoom(gomock.Any(), "r1").
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
 		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).Return([]model.App{}, nil)
 
@@ -6490,6 +6512,8 @@ func TestHandler_handleGetRoomAppTabs_Denied(t *testing.T) {
 		Return(nil, model.ErrSubscriptionNotFound)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{Account: "alice", Roles: []model.UserRole{model.UserRoleUser}}, nil)
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1"}, nil).AnyTimes()
 
 	_, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
 	assert.ErrorIs(t, err, errAppAccessDenied)
@@ -6501,6 +6525,8 @@ func TestHandler_handleGetRoomAppTabs_DeniedNoUser(t *testing.T) {
 		Return(nil, model.ErrSubscriptionNotFound)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(nil, ErrUserNotFound)
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1"}, nil).AnyTimes()
 
 	_, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
 	assert.ErrorIs(t, err, errAppAccessDenied)
@@ -6510,7 +6536,7 @@ func TestHandler_handleGetRoomAppTabs_EmptyResultIsEmptyArray(t *testing.T) {
 	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
-	store.EXPECT().GetRoom(gomock.Any(), "r1").
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
 		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).Return(nil, nil)
 
@@ -6527,7 +6553,7 @@ func TestHandler_handleGetRoomAppTabs_TemplateURLPreserved(t *testing.T) {
 	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
-	store.EXPECT().GetRoom(gomock.Any(), "r1").
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
 		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).Return([]model.App{
 		mockTabApp("app1", "X", "https://template-a.com/path?room=${roomId}#tab=${siteId}"),
@@ -6543,7 +6569,7 @@ func TestHandler_handleGetRoomAppTabs_SkipsEmptyAndMalformed(t *testing.T) {
 	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
-	store.EXPECT().GetRoom(gomock.Any(), "r1").
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
 		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).Return([]model.App{
 		mockTabApp("ok1", "OK1", "https://upstream/ok1/${roomId}"),
@@ -6563,7 +6589,7 @@ func TestHandler_handleGetRoomAppTabs_SkipsAppWithNilChannelTab(t *testing.T) {
 	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
-	store.EXPECT().GetRoom(gomock.Any(), "r1").
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
 		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	// One app has nil ChannelTab (invalid data), one is valid — only the valid one should appear.
 	appNoTab := model.App{ID: "notab", ChannelTab: nil}
@@ -6582,7 +6608,7 @@ func TestHandler_handleGetRoomAppTabs_StoreListError(t *testing.T) {
 	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
-	store.EXPECT().GetRoom(gomock.Any(), "r1").
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
 		Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListDefaultChannelTabApps(gomock.Any()).
 		Return(nil, errors.New("mongo down"))
@@ -6596,7 +6622,7 @@ func TestHandler_handleGetRoomAppTabs_RoomNotFound(t *testing.T) {
 	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
-	store.EXPECT().GetRoom(gomock.Any(), "r1").
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
 		Return(nil, fmt.Errorf("room %q not found: %w", "r1", mongo.ErrNoDocuments))
 
 	_, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
@@ -6607,7 +6633,7 @@ func TestHandler_handleGetRoomAppTabs_RoomFetchError(t *testing.T) {
 	h, store, _ := newTabsTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
-	store.EXPECT().GetRoom(gomock.Any(), "r1").
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
 		Return(nil, errors.New("mongo down"))
 
 	_, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
@@ -6622,6 +6648,8 @@ func TestHandler_handleGetRoomAppTabs_ContextTimeout(t *testing.T) {
 			<-ctx.Done()
 			return nil, ctx.Err()
 		})
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1"}, nil).AnyTimes()
 
 	parent, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -6645,6 +6673,8 @@ func TestHandler_handleGetRoomAppCommandMenu_MemberAllowed_NoBots(t *testing.T) 
 	h, store := newCmdMenuTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1"}, nil)
 	store.EXPECT().ListRoomBotApps(gomock.Any(), "r1").Return([]RoomBotAppEntry{}, nil)
 	// ListActiveCmdMenus must NOT be called.
 
@@ -6661,6 +6691,8 @@ func TestHandler_handleGetRoomAppCommandMenu_MemberAllowed_WithMenus(t *testing.
 	h, store := newCmdMenuTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1"}, nil)
 	store.EXPECT().ListRoomBotApps(gomock.Any(), "r1").Return([]RoomBotAppEntry{
 		{AssistantName: "stocks.bot", AppName: "Stocks"},
 		{AssistantName: "weather.bot", AppName: "Weather"},
@@ -6686,6 +6718,8 @@ func TestHandler_handleGetRoomAppCommandMenu_MemberAllowed_BotWithoutMenu(t *tes
 	h, store := newCmdMenuTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1"}, nil)
 	store.EXPECT().ListRoomBotApps(gomock.Any(), "r1").Return([]RoomBotAppEntry{
 		{AssistantName: "silent.bot", AppName: "Silent"},
 	}, nil)
@@ -6706,7 +6740,7 @@ func TestHandler_handleGetRoomAppCommandMenu_AdminAllowed(t *testing.T) {
 		Return(nil, model.ErrSubscriptionNotFound)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{Account: "alice", Roles: []model.UserRole{model.UserRoleAdmin}}, nil)
-	store.EXPECT().GetRoom(gomock.Any(), "r1").
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
 		Return(&model.Room{ID: "r1"}, nil)
 	store.EXPECT().ListRoomBotApps(gomock.Any(), "r1").Return([]RoomBotAppEntry{}, nil)
 
@@ -6721,6 +6755,8 @@ func TestHandler_handleGetRoomAppCommandMenu_Denied(t *testing.T) {
 		Return(nil, model.ErrSubscriptionNotFound)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{Account: "alice"}, nil)
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1"}, nil).AnyTimes()
 
 	_, err := h.getRoomAppCommandMenu(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
 	assert.ErrorIs(t, err, errAppAccessDenied)
@@ -6730,6 +6766,8 @@ func TestHandler_handleGetRoomAppCommandMenu_StoreListRoomBotAppsError(t *testin
 	h, store := newCmdMenuTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1"}, nil)
 	store.EXPECT().ListRoomBotApps(gomock.Any(), "r1").Return(nil, errors.New("mongo down"))
 
 	_, err := h.getRoomAppCommandMenu(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
@@ -6741,6 +6779,8 @@ func TestHandler_handleGetRoomAppCommandMenu_StoreListActiveCmdMenusError(t *tes
 	h, store := newCmdMenuTestHandler(t)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1"}, nil)
 	store.EXPECT().ListRoomBotApps(gomock.Any(), "r1").Return([]RoomBotAppEntry{
 		{AssistantName: "weather.bot", AppName: "Weather"},
 	}, nil)
@@ -6759,6 +6799,8 @@ func TestHandler_handleGetRoomAppCommandMenu_ContextTimeout(t *testing.T) {
 			<-ctx.Done()
 			return nil, ctx.Err()
 		})
+	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1"}, nil).AnyTimes()
 
 	parent, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -127,7 +127,6 @@ func TestMongoStore_GetRoom_ProjectionFields_Integration(t *testing.T) {
 	assert.Equal(t, "rproj", got.ID)
 	assert.Equal(t, "proj-room", got.Name)
 	assert.Equal(t, model.RoomTypeChannel, got.Type)
-	assert.Equal(t, "site-a", got.SiteID, "siteId must be in the projection (buildTabURL reads room.SiteID for ${roomOrigin})")
 	assert.Equal(t, 7, got.UserCount)
 	assert.Equal(t, 3, got.AppCount)
 	assert.True(t, got.Restricted)
@@ -138,6 +137,26 @@ func TestMongoStore_GetRoom_ProjectionFields_Integration(t *testing.T) {
 	assert.WithinDuration(t, minSeen, *got.MinUserLastSeenAt, time.Second)
 	require.NotNil(t, got.LastMentionAllAt, "lastMentionAllAt must be in the projection (read event computes hasGroupMention from it)")
 	assert.WithinDuration(t, lastMentionAll, *got.LastMentionAllAt, time.Second)
+}
+
+// Pins the narrow app-read projection: ID/Type/SiteID populated, all else zero.
+func TestMongoStore_GetRoomAppRead_ProjectionFields_Integration(t *testing.T) {
+	ctx := context.Background()
+	db := setupMongo(t)
+	store := NewMongoStore(db)
+
+	mustInsertRoom(t, db, &model.Room{
+		ID: "rappread", Name: "proj-room", Type: model.RoomTypeChannel,
+		SiteID: "site-a", UserCount: 7,
+	})
+
+	got, err := store.GetRoomAppRead(ctx, "rappread")
+	require.NoError(t, err)
+	assert.Equal(t, "rappread", got.ID)
+	assert.Equal(t, model.RoomTypeChannel, got.Type)
+	assert.Equal(t, "site-a", got.SiteID)
+	assert.Empty(t, got.Name, "projection must exclude fields the app-read RPCs don't use")
+	assert.Zero(t, got.UserCount)
 }
 
 // TestMongoStore_GetSubscription_ProjectionFields_Integration pins the field

--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -127,6 +127,7 @@ func TestMongoStore_GetRoom_ProjectionFields_Integration(t *testing.T) {
 	assert.Equal(t, "rproj", got.ID)
 	assert.Equal(t, "proj-room", got.Name)
 	assert.Equal(t, model.RoomTypeChannel, got.Type)
+	assert.Equal(t, "site-a", got.SiteID, "siteId must be in the projection (buildTabURL reads room.SiteID for ${roomOrigin})")
 	assert.Equal(t, 7, got.UserCount)
 	assert.Equal(t, 3, got.AppCount)
 	assert.True(t, got.Restricted)

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/caarlos0/env/v11"
@@ -25,21 +26,27 @@ import (
 )
 
 type config struct {
-	NatsURL                  string          `env:"NATS_URL,required"`
-	NatsCredsFile            string          `env:"NATS_CREDS_FILE"           envDefault:""`
-	SiteID                   string          `env:"SITE_ID"                   envDefault:"site-local"`
-	MongoURI                 string          `env:"MONGO_URI,required"`
-	MongoDB                  string          `env:"MONGO_DB"                  envDefault:"chat"`
-	MongoUsername            string          `env:"MONGO_USERNAME"            envDefault:""`
-	MongoPassword            string          `env:"MONGO_PASSWORD"            envDefault:""`
-	MaxRoomSize              int             `env:"MAX_ROOM_SIZE"             envDefault:"1000"`
-	MaxBatchSize             int             `env:"MAX_BATCH_SIZE"            envDefault:"1000"`
-	MemberListTimeout        time.Duration   `env:"MEMBER_LIST_TIMEOUT"       envDefault:"5s"`
-	RoomKeyGracePeriod       time.Duration   `env:"ROOM_KEY_GRACE_PERIOD"     envDefault:"24h"`
-	HealthAddr               string          `env:"HEALTH_ADDR" envDefault:":8081"`
-	PProfEnabled             bool            `env:"PPROF_ENABLED" envDefault:"false"`
-	Bootstrap                bootstrapConfig `envPrefix:"BOOTSTRAP_"`
-	RestrictedRoomMinMembers int             `env:"RESTRICTED_ROOM_MIN_MEMBERS" envDefault:"5"`
+	NatsURL       string `env:"NATS_URL,required"`
+	NatsCredsFile string `env:"NATS_CREDS_FILE"           envDefault:""`
+	SiteID        string `env:"SITE_ID"                   envDefault:"site-local"`
+	// LegacyRoomOrigins maps a room's origin siteID to the legacy origin URL
+	// substituted into channel-tab ${roomOrigin} template variables. Wire
+	// format: "site-a:https://legacy.site-a.com,site-b:https://legacy.site-b.com"
+	// (comma-separated, first-colon split — URL values keep "://"). Unset ⇒
+	// every ${roomOrigin} substitutes to "".
+	LegacyRoomOrigins        map[string]string `env:"LEGACY_ROOM_ORIGINS"`
+	MongoURI                 string            `env:"MONGO_URI,required"`
+	MongoDB                  string            `env:"MONGO_DB"                  envDefault:"chat"`
+	MongoUsername            string            `env:"MONGO_USERNAME"            envDefault:""`
+	MongoPassword            string            `env:"MONGO_PASSWORD"            envDefault:""`
+	MaxRoomSize              int               `env:"MAX_ROOM_SIZE"             envDefault:"1000"`
+	MaxBatchSize             int               `env:"MAX_BATCH_SIZE"            envDefault:"1000"`
+	MemberListTimeout        time.Duration     `env:"MEMBER_LIST_TIMEOUT"       envDefault:"5s"`
+	RoomKeyGracePeriod       time.Duration     `env:"ROOM_KEY_GRACE_PERIOD"     envDefault:"24h"`
+	HealthAddr               string            `env:"HEALTH_ADDR" envDefault:":8081"`
+	PProfEnabled             bool              `env:"PPROF_ENABLED" envDefault:"false"`
+	Bootstrap                bootstrapConfig   `envPrefix:"BOOTSTRAP_"`
+	RestrictedRoomMinMembers int               `env:"RESTRICTED_ROOM_MIN_MEMBERS" envDefault:"5"`
 	// Microsoft Teams integration. Teams* credentials are required only for the
 	// meetings RPC (Graph onlineMeeting create); the deep-link RPCs use only
 	// EmailDomain. When TenantID/ClientID/ClientSecret are unset the meetings RPC
@@ -76,6 +83,21 @@ type config struct {
 	DebugLog logctx.Config      `envPrefix:"DEBUG_LOG_"`
 	// AdminAcctPrefix overrides the platform-admin account prefix (ADMIN_ACCT_PREFIX); keep it identical across services.
 	AdminAcctPrefix string `env:"ADMIN_ACCT_PREFIX" envDefault:"p_admin"`
+}
+
+// normalizeLegacyRoomOrigins trims whitespace around the keys and values of
+// the LEGACY_ROOM_ORIGINS map (tolerating "site-a: https://…" with a space
+// after the colon) and drops entries left empty after trimming.
+func normalizeLegacyRoomOrigins(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		k, v = strings.TrimSpace(k), strings.TrimSpace(v)
+		if k == "" || v == "" {
+			continue
+		}
+		out[k] = v
+	}
+	return out
 }
 
 func main() {
@@ -227,7 +249,7 @@ func main() {
 			}
 			return nil
 		},
-		nil,
+		normalizeLegacyRoomOrigins(cfg.LegacyRoomOrigins),
 		nc.NatsConn().MaxPayload(),
 	)
 	handler.dekProvisioner = dekProvisioner

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/caarlos0/env/v11"
@@ -29,9 +29,9 @@ type config struct {
 	NatsURL       string `env:"NATS_URL,required"`
 	NatsCredsFile string `env:"NATS_CREDS_FILE"           envDefault:""`
 	SiteID        string `env:"SITE_ID"                   envDefault:"site-local"`
-	// LegacyRoomOrigins maps room-origin siteID → legacy URL for ${roomOrigin}.
-	// Format "site-a:https://legacy.site-a.com,…" (first-colon split); unset ⇒ "".
-	LegacyRoomOrigins        map[string]string `env:"LEGACY_ROOM_ORIGINS"`
+	// LEGACY_ROOM_ORIGINS is a JSON array of {siteID, origin} objects mapping
+	// each room-origin site to the legacy URL substituted into ${roomOrigin}.
+	LegacyRoomOrigins        legacyRoomOrigins `env:"LEGACY_ROOM_ORIGINS"`
 	MongoURI                 string            `env:"MONGO_URI,required"`
 	MongoDB                  string            `env:"MONGO_DB"                  envDefault:"chat"`
 	MongoUsername            string            `env:"MONGO_USERNAME"            envDefault:""`
@@ -82,17 +82,33 @@ type config struct {
 	AdminAcctPrefix string `env:"ADMIN_ACCT_PREFIX" envDefault:"p_admin"`
 }
 
-// normalizeLegacyRoomOrigins trims keys/values ("site-a: url" tolerated), drops empties.
-func normalizeLegacyRoomOrigins(in map[string]string) map[string]string {
-	out := make(map[string]string, len(in))
-	for k, v := range in {
-		k, v = strings.TrimSpace(k), strings.TrimSpace(v)
-		if k == "" || v == "" {
-			continue
-		}
-		out[k] = v
+// legacyRoomOrigin maps a site to its legacy origin URL (incl. scheme).
+type legacyRoomOrigin struct {
+	SiteID string `json:"siteID"`
+	Origin string `json:"origin"`
+}
+
+// legacyRoomOrigins is parsed from the LEGACY_ROOM_ORIGINS env var — a JSON
+// array of {siteID, origin} objects, indexed at parse time into a siteID→URL
+// map. Implements encoding.TextUnmarshaler so caarlos0/env populates it
+// directly from the env string (same pattern as media-service CLUSTER_DOMAINS).
+type legacyRoomOrigins struct {
+	byID map[string]string
+}
+
+func (l *legacyRoomOrigins) UnmarshalText(text []byte) error {
+	var entries []legacyRoomOrigin
+	if err := json.Unmarshal(text, &entries); err != nil {
+		return fmt.Errorf("parse LEGACY_ROOM_ORIGINS json: %w", err)
 	}
-	return out
+	l.byID = make(map[string]string, len(entries))
+	for _, e := range entries {
+		if _, dup := l.byID[e.SiteID]; dup {
+			return fmt.Errorf("parse LEGACY_ROOM_ORIGINS json: duplicate siteID %q", e.SiteID)
+		}
+		l.byID[e.SiteID] = e.Origin
+	}
+	return nil
 }
 
 func main() {
@@ -244,7 +260,7 @@ func main() {
 			}
 			return nil
 		},
-		normalizeLegacyRoomOrigins(cfg.LegacyRoomOrigins),
+		cfg.LegacyRoomOrigins.byID,
 		nc.NatsConn().MaxPayload(),
 	)
 	handler.dekProvisioner = dekProvisioner

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -29,12 +29,8 @@ type config struct {
 	NatsURL       string `env:"NATS_URL,required"`
 	NatsCredsFile string `env:"NATS_CREDS_FILE"           envDefault:""`
 	SiteID        string `env:"SITE_ID"                   envDefault:"site-local"`
-	// LegacyRoomOrigins maps a room's origin siteID to the legacy origin URL
-	// substituted into channel-tab ${roomOrigin} template variables. Wire
-	// format: "site-a:https://legacy.site-a.com,site-b:https://legacy.site-b.com"
-	// (comma-separated, first-colon split — URL values keep "://"). Unset ⇒
-	// every ${roomOrigin} substitutes to "". Keyed like pkg/drive's
-	// GetBaseURLFromRoomOrigin (room-origin siteID → per-site base URL).
+	// LegacyRoomOrigins maps room-origin siteID → legacy URL for ${roomOrigin}.
+	// Format "site-a:https://legacy.site-a.com,…" (first-colon split); unset ⇒ "".
 	LegacyRoomOrigins        map[string]string `env:"LEGACY_ROOM_ORIGINS"`
 	MongoURI                 string            `env:"MONGO_URI,required"`
 	MongoDB                  string            `env:"MONGO_DB"                  envDefault:"chat"`
@@ -86,9 +82,7 @@ type config struct {
 	AdminAcctPrefix string `env:"ADMIN_ACCT_PREFIX" envDefault:"p_admin"`
 }
 
-// normalizeLegacyRoomOrigins trims whitespace around the keys and values of
-// the LEGACY_ROOM_ORIGINS map (tolerating "site-a: https://…" with a space
-// after the colon) and drops entries left empty after trimming.
+// normalizeLegacyRoomOrigins trims keys/values ("site-a: url" tolerated), drops empties.
 func normalizeLegacyRoomOrigins(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
 	for k, v := range in {

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/url"
 	"os"
 	"time"
 
@@ -29,7 +28,6 @@ type config struct {
 	NatsURL                  string          `env:"NATS_URL,required"`
 	NatsCredsFile            string          `env:"NATS_CREDS_FILE"           envDefault:""`
 	SiteID                   string          `env:"SITE_ID"                   envDefault:"site-local"`
-	SiteURL                  string          `env:"SITE_URL,required"`
 	MongoURI                 string          `env:"MONGO_URI,required"`
 	MongoDB                  string          `env:"MONGO_DB"                  envDefault:"chat"`
 	MongoUsername            string          `env:"MONGO_USERNAME"            envDefault:""`
@@ -99,13 +97,6 @@ func main() {
 	}
 	if cfg.RestrictedRoomMinMembers <= 0 {
 		slog.Error("invalid RESTRICTED_ROOM_MIN_MEMBERS: must be > 0", "value", cfg.RestrictedRoomMinMembers)
-		os.Exit(1)
-	}
-
-	siteURL, err := url.Parse(cfg.SiteURL)
-	if err != nil || siteURL.Scheme == "" || siteURL.Host == "" {
-		slog.Error("invalid SITE_URL: must be an absolute URL with scheme and host",
-			"value", cfg.SiteURL, "error", err)
 		os.Exit(1)
 	}
 
@@ -236,7 +227,7 @@ func main() {
 			}
 			return nil
 		},
-		siteURL,
+		nil,
 		nc.NatsConn().MaxPayload(),
 	)
 	handler.dekProvisioner = dekProvisioner

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -33,7 +33,8 @@ type config struct {
 	// substituted into channel-tab ${roomOrigin} template variables. Wire
 	// format: "site-a:https://legacy.site-a.com,site-b:https://legacy.site-b.com"
 	// (comma-separated, first-colon split — URL values keep "://"). Unset ⇒
-	// every ${roomOrigin} substitutes to "".
+	// every ${roomOrigin} substitutes to "". Keyed like pkg/drive's
+	// GetBaseURLFromRoomOrigin (room-origin siteID → per-site base URL).
 	LegacyRoomOrigins        map[string]string `env:"LEGACY_ROOM_ORIGINS"`
 	MongoURI                 string            `env:"MONGO_URI,required"`
 	MongoDB                  string            `env:"MONGO_DB"                  envDefault:"chat"`

--- a/room-service/mock_store_test.go
+++ b/room-service/mock_store_test.go
@@ -234,6 +234,21 @@ func (mr *MockRoomStoreMockRecorder) GetRoom(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRoom", reflect.TypeOf((*MockRoomStore)(nil).GetRoom), ctx, id)
 }
 
+// GetRoomAppRead mocks base method.
+func (m *MockRoomStore) GetRoomAppRead(ctx context.Context, id string) (*model.Room, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRoomAppRead", ctx, id)
+	ret0, _ := ret[0].(*model.Room)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRoomAppRead indicates an expected call of GetRoomAppRead.
+func (mr *MockRoomStoreMockRecorder) GetRoomAppRead(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRoomAppRead", reflect.TypeOf((*MockRoomStore)(nil).GetRoomAppRead), ctx, id)
+}
+
 // GetSubscription mocks base method.
 func (m *MockRoomStore) GetSubscription(ctx context.Context, account, roomID string) (*model.Subscription, error) {
 	m.ctrl.T.Helper()

--- a/room-service/store.go
+++ b/room-service/store.go
@@ -60,6 +60,8 @@ type RoomBotAppEntry struct {
 
 type RoomStore interface {
 	GetRoom(ctx context.Context, id string) (*model.Room, error)
+	// GetRoomAppRead fetches only _id/type/siteId; same error contract as GetRoom.
+	GetRoomAppRead(ctx context.Context, id string) (*model.Room, error)
 	ListRoomsByIDs(ctx context.Context, ids []string) ([]model.Room, error)
 	GetSubscription(ctx context.Context, account, roomID string) (*model.Subscription, error)
 	// CheckMembership verifies (account, roomID) has a subscription without

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -243,6 +243,7 @@ func (s *MongoStore) InsertTeamsMeeting(ctx context.Context, record model.TeamsM
 // handler.go; the projection-field integration test guards drift.
 var roomReadProjection = bson.D{
 	{Key: "_id", Value: 1}, {Key: "type", Value: 1}, {Key: "name", Value: 1},
+	{Key: "siteId", Value: 1},
 	{Key: "userCount", Value: 1}, {Key: "appCount", Value: 1},
 	{Key: "restricted", Value: 1}, {Key: "externalAccess", Value: 1},
 	{Key: "lastMsgAt", Value: 1}, {Key: "minUserLastSeenAt", Value: 1},

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -243,11 +243,15 @@ func (s *MongoStore) InsertTeamsMeeting(ctx context.Context, record model.TeamsM
 // handler.go; the projection-field integration test guards drift.
 var roomReadProjection = bson.D{
 	{Key: "_id", Value: 1}, {Key: "type", Value: 1}, {Key: "name", Value: 1},
-	{Key: "siteId", Value: 1},
 	{Key: "userCount", Value: 1}, {Key: "appCount", Value: 1},
 	{Key: "restricted", Value: 1}, {Key: "externalAccess", Value: 1},
 	{Key: "lastMsgAt", Value: 1}, {Key: "minUserLastSeenAt", Value: 1},
 	{Key: "lastMentionAllAt", Value: 1},
+}
+
+// roomAppReadProjection: only the fields the app-read RPCs consume.
+var roomAppReadProjection = bson.D{
+	{Key: "_id", Value: 1}, {Key: "type", Value: 1}, {Key: "siteId", Value: 1},
 }
 
 // subscriptionReadProjection is the field set GetSubscription returns — the
@@ -265,6 +269,15 @@ var subscriptionReadProjection = bson.D{
 func (s *MongoStore) GetRoom(ctx context.Context, id string) (*model.Room, error) {
 	var room model.Room
 	opts := options.FindOne().SetProjection(roomReadProjection)
+	if err := s.rooms.FindOne(ctx, bson.M{"_id": id}, opts).Decode(&room); err != nil {
+		return nil, fmt.Errorf("room %q not found: %w", id, err)
+	}
+	return &room, nil
+}
+
+func (s *MongoStore) GetRoomAppRead(ctx context.Context, id string) (*model.Room, error) {
+	var room model.Room
+	opts := options.FindOne().SetProjection(roomAppReadProjection)
 	if err := s.rooms.FindOne(ctx, bson.M{"_id": id}, opts).Decode(&room); err != nil {
 		return nil, fmt.Errorf("room %q not found: %w", id, err)
 	}


### PR DESCRIPTION
## Summary

`buildTabURL` no longer rewrites channel-tab URL templates onto `SITE_URL` — templates carry the full URL, and the server only substitutes template variables:

| Variable | Substituted with |
|---|---|
| `${roomId}` | request roomID (unchanged) |
| `${siteId}` | local site ID (unchanged) |
| `${roomType}` | **new** — legacy room-type vocabulary from the room doc: `channel`/`discussion` → `p`, `dm`/`botDM` → `d`, unknown → `p` (hard-coded map, backward compatible with pre-redesign tab apps) |
| `${roomOrigin}` | **new** — legacy origin URL of the room's *origin* site from the `LEGACY_ROOM_ORIGINS` env config; empty string when the site is unconfigured |

## Changes

- **`buildTabURL`** is substitution-only; after substitution the result must be an absolute http(s) URL with a host — legacy path-only templates (which previously relied on the removed rewrite) and unsafe schemes are Warn-skipped instead of shipped broken to clients.
- **`authorizeRoomAppRead`** is now member-only, sequential, and simple: check the caller's subscription, then fetch and return the room, narrowly projected via a new `GetRoomAppRead` store method (`_id`, `type`, `siteId` only). **The platform-admin bypass is removed** — non-members are denied without a user lookup, and a missing room reads as access-denied. One room read per request; `getRoomAppCommandMenu` shares the gate and discards the room.
- **`LEGACY_ROOM_ORIGINS`** config — a JSON array of `{siteID, origin}` objects, following the media-service `CLUSTER_DOMAINS` pattern (`encoding.TextUnmarshaler`, duplicate-siteID rejection, fail-fast on malformed JSON): `LEGACY_ROOM_ORIGINS=[{"siteID":"site-a","origin":"https://legacy.site-a.com"}]`. Unset ⇒ every `${roomOrigin}` substitutes to `""`. The docker-compose dev config carries a three-entry example.
- **`SITE_URL`** config, handler field, and `NewHandler` param removed entirely (`buildTabURL` was the only consumer); deployments still setting it are unaffected.
- **Docs**: `docs/client-api.md` — `tabUrl` and `AppChannelTabURL.default` rows and examples document all four variables and the new skip rule; the app-tabs/cmd-menu error docs no longer mention admin access.

## Test plan

- [x] TDD throughout — every behavior change landed red-first
- [x] `make test` (full repo, race detector) — all green including `tools/loadgen`
- [x] `make lint` — 0 issues
- [x] `make sast` — gosec / govulncheck / semgrep all pass
- [x] Multi-agent review: per-task spec+quality reviews, whole-branch final review, and a 4-angle simplify pass — all findings addressed
- [ ] `make test-integration SERVICE=room-service` — **deferred to CI** (Docker unavailable in the dev environment); covers the `GetRoomAppRead` projection drift-guard

## Deployment notes

- Set `LEGACY_ROOM_ORIGINS` per site in Kubernetes (JSON array format above); `SITE_URL` can be dropped from manifests.
- Any `apps` documents whose `channelTab.url.default` is still an old-style path template will have their tab Warn-skipped until migrated to a full URL — confirm template migration before/alongside deploy.
- **Behavior change:** platform admins who are not room members can no longer read a room's app tabs / command menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoAt5zogndVghAPSyzmTJU