### PR TITLE
feat(graphmock): serve users, user-chats, chat-members surfaces

### DIFF
--- a/tools/graphmock/README.md
+++ b/tools/graphmock/README.md
@@ -1,7 +1,8 @@
 # graphmock
 
-Fixture-driven mock of the Microsoft Graph surface the HR sync uses. Dev/e2e
-only — accepts any credentials.
+Fixture-driven mock of the Microsoft Graph surface the Teams sync stages use
+(HR sync, user sync, chat sync, member sync). Dev/e2e only — accepts any
+credentials.
 
 ## Endpoints
 
@@ -9,9 +10,15 @@ only — accepts any credentials.
 |---|---|
 | `POST /{tenant}/oauth2/v2.0/token` | Static fake app token |
 | `GET /v1.0/groups/{id}` | Group profile (404 on unknown id) |
-| `GET /v1.0/groups/{id}/members` | Members, honoring `$top` + emitting self-pointing `@odata.nextLink` pages |
+| `GET /v1.0/groups/{id}/members` | Group members, paged (`$top` + `@odata.nextLink`) |
+| `GET /v1.0/users` | Directory users, paged (`$top` + `@odata.nextLink`) |
+| `GET /v1.0/users/{id}/chats` | Chats the user is a member of (members inline), paged |
+| `GET /v1.0/chats/{id}/members` | Chat members, paged (404 on unknown id) |
 | `PUT /__fixtures` / `GET /__fixtures` | Replace / read the in-memory dataset at runtime |
 | `GET /healthz` | 200 |
+
+All list endpoints honor `$top` and emit a self-pointing `@odata.nextLink` so
+real Graph clients exercise their pager.
 
 Point the sync at it: `GRAPH_BASE_URL=http://host:8080/v1.0`,
 `GRAPH_TOKEN_URL=http://host:8080/t/oauth2/v2.0/token`.
@@ -22,15 +29,26 @@ Point the sync at it: `GRAPH_BASE_URL=http://host:8080/v1.0`,
 
 ## Fixture schema
 
-See `fixtures.sample.json` — groups with raw member objects; user members
-carry `"@odata.type": "#microsoft.graph.user"` plus the identity `$select`
-fields, non-user members (nested groups, devices) exercise the skip path:
+See `fixtures.sample.json`. Three top-level arrays:
+
+- `groups[]` — with raw member objects; user members carry
+  `"@odata.type": "#microsoft.graph.user"` plus the identity `$select` fields,
+  non-user members (nested groups, devices) exercise the skip path.
+- `users[]` — directory users (`id`, `userPrincipalName`, `displayName`, …).
+- `chats[]` — `id`, `chatType`, `topic`, `createdDateTime`,
+  `lastUpdatedDateTime`, and `members[]` (`userId` + optional
+  `visibleHistoryStartDateTime`). `GET /users/{id}/chats` returns chats whose
+  `members` include that user; `GET /chats/{id}/members` returns a chat's members.
 
 ```json
 {"groups": [{"id": "g1", "displayName": "…", "description": "…",
   "members": [{"@odata.type": "#microsoft.graph.user", "id": "u1",
     "userPrincipalName": "…", "displayName": "…", "givenName": "…",
-    "surname": "…", "employeeId": "…"}]}]}
+    "surname": "…", "employeeId": "…"}]}],
+ "users": [{"id": "u1", "userPrincipalName": "…", "displayName": "…"}],
+ "chats": [{"id": "19:c1", "chatType": "group", "topic": "…",
+   "createdDateTime": "2026-01-02T03:04:05Z", "lastUpdatedDateTime": "2026-06-01T00:00:00Z",
+   "members": [{"userId": "u1", "visibleHistoryStartDateTime": "2026-01-02T03:04:05Z"}]}]}
 ```
 
 `PUT /__fixtures` with the same schema swaps the dataset mid-run (e.g. to

--- a/tools/graphmock/fixtures.sample.json
+++ b/tools/graphmock/fixtures.sample.json
@@ -21,5 +21,23 @@
         {"@odata.type": "#microsoft.graph.user", "id": "u6", "userPrincipalName": "frank.kao@corp.example", "displayName": "法蘭克", "givenName": "Frank", "surname": "Kao", "employeeId": "EMP006"}
       ]
     }
+  ],
+  "users": [
+    {"id": "u1", "userPrincipalName": "alice.wu@corp.example", "displayName": "愛麗絲"},
+    {"id": "u2", "userPrincipalName": "bob.lin@corp.example", "displayName": "鮑伯"},
+    {"id": "u4", "userPrincipalName": "dave.huang@corp.example", "displayName": "戴夫"}
+  ],
+  "chats": [
+    {"id": "19:chat-eng", "chatType": "group", "topic": "Project X", "createdDateTime": "2026-01-02T03:04:05Z", "lastUpdatedDateTime": "2026-06-01T00:00:00Z",
+     "members": [
+       {"userId": "u1", "visibleHistoryStartDateTime": "2026-01-02T03:04:05Z"},
+       {"userId": "u2"},
+       {"userId": "u4"}
+     ]},
+    {"id": "19:chat-dm", "chatType": "oneOnOne", "topic": "", "createdDateTime": "2026-02-02T00:00:00Z", "lastUpdatedDateTime": "2026-06-02T00:00:00Z",
+     "members": [
+       {"userId": "u1"},
+       {"userId": "u2"}
+     ]}
   ]
 }

--- a/tools/graphmock/server.go
+++ b/tools/graphmock/server.go
@@ -9,11 +9,13 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// fixtures is the mock tenant dataset: groups with raw member objects
-// (kept as maps so fixtures can carry any element shape, incl. non-user
-// members).
+// fixtures is the mock tenant dataset. Groups carry raw member objects (any
+// element shape, incl. non-user members); users/chats are the surfaces the
+// user-sync, chat-sync, and member-sync stages read.
 type fixtures struct {
-	Groups []group `json:"groups"`
+	Groups []group          `json:"groups"`
+	Users  []map[string]any `json:"users"`
+	Chats  []chat           `json:"chats"`
 }
 
 type group struct {
@@ -21,6 +23,23 @@ type group struct {
 	DisplayName string           `json:"displayName"`
 	Description string           `json:"description"`
 	Members     []map[string]any `json:"members"`
+}
+
+// chat mirrors the Graph chat shape the sync reads (GET /users/{id}/chats with
+// $expand=members). Membership drives both endpoints: /users/{id}/chats returns
+// chats whose members include the user, /chats/{id}/members returns Members.
+type chat struct {
+	ID                  string       `json:"id"`
+	ChatType            string       `json:"chatType"`
+	Topic               string       `json:"topic"`
+	CreatedDateTime     string       `json:"createdDateTime"`
+	LastUpdatedDateTime string       `json:"lastUpdatedDateTime"`
+	Members             []chatMember `json:"members"`
+}
+
+type chatMember struct {
+	UserID                      string `json:"userId"`
+	VisibleHistoryStartDateTime string `json:"visibleHistoryStartDateTime,omitempty"`
 }
 
 // server holds the swappable dataset behind a mutex (PUT /__fixtures replaces
@@ -41,6 +60,17 @@ func (s *server) group(id string) (group, bool) {
 	return group{}, false
 }
 
+func (s *server) chat(id string) (chat, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, c := range s.data.Chats {
+		if c.ID == id {
+			return c, true
+		}
+	}
+	return chat{}, false
+}
+
 func newRouter(s *server) *gin.Engine {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
@@ -53,6 +83,9 @@ func newRouter(s *server) *gin.Engine {
 	v1 := r.Group("/v1.0")
 	v1.GET("/groups/:id", s.getGroup)
 	v1.GET("/groups/:id/members", s.listMembers)
+	v1.GET("/users", s.listUsers)
+	v1.GET("/users/:id/chats", s.listUserChats)
+	v1.GET("/chats/:id/members", s.listChatMembers)
 	r.GET("/__fixtures", func(c *gin.Context) {
 		s.mu.RLock()
 		defer s.mu.RUnlock()
@@ -67,7 +100,7 @@ func newRouter(s *server) *gin.Engine {
 		s.mu.Lock()
 		s.data = f
 		s.mu.Unlock()
-		c.JSON(http.StatusOK, gin.H{"groups": len(f.Groups)})
+		c.JSON(http.StatusOK, gin.H{"groups": len(f.Groups), "users": len(f.Users), "chats": len(f.Chats)})
 	})
 	return r
 }
@@ -81,15 +114,54 @@ func (s *server) getGroup(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"id": g.ID, "displayName": g.DisplayName, "description": g.Description})
 }
 
-// listMembers serves one $top-sized page and emits a self-pointing
-// @odata.nextLink (?$skip=N) so real Graph clients exercise their pager.
 func (s *server) listMembers(c *gin.Context) {
 	g, ok := s.group(c.Param("id"))
 	if !ok {
 		graphNotFound(c)
 		return
 	}
-	top := len(g.Members)
+	writePage(c, g.Members, fmt.Sprintf("/v1.0/groups/%s/members", g.ID))
+}
+
+func (s *server) listUsers(c *gin.Context) {
+	s.mu.RLock()
+	users := s.data.Users
+	s.mu.RUnlock()
+	writePage(c, users, "/v1.0/users")
+}
+
+// listUserChats returns the chats the user is a member of — Graph filters
+// server-side; the mock derives membership from each chat's Members.
+func (s *server) listUserChats(c *gin.Context) {
+	userID := c.Param("id")
+	s.mu.RLock()
+	var out []chat
+	for _, ch := range s.data.Chats {
+		for _, m := range ch.Members {
+			if m.UserID == userID {
+				out = append(out, ch)
+				break
+			}
+		}
+	}
+	s.mu.RUnlock()
+	writePage(c, out, fmt.Sprintf("/v1.0/users/%s/chats", userID))
+}
+
+func (s *server) listChatMembers(c *gin.Context) {
+	ch, ok := s.chat(c.Param("id"))
+	if !ok {
+		graphNotFound(c)
+		return
+	}
+	writePage(c, ch.Members, fmt.Sprintf("/v1.0/chats/%s/members", ch.ID))
+}
+
+// writePage serves one $top-sized page of items and emits a self-pointing
+// @odata.nextLink (?$skip=N) so real Graph clients exercise their pager. A bad
+// $top writes a 400 and returns without a body.
+func writePage[T any](c *gin.Context, items []T, path string) {
+	top := len(items)
 	if v := c.Query("$top"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n < 1 || n > 999 {
@@ -99,14 +171,13 @@ func (s *server) listMembers(c *gin.Context) {
 		top = n
 	}
 	skip, _ := strconv.Atoi(c.Query("$skip"))
-	if skip < 0 || skip > len(g.Members) {
-		skip = len(g.Members)
+	if skip < 0 || skip > len(items) {
+		skip = len(items)
 	}
-	end := min(skip+top, len(g.Members))
-	page := gin.H{"value": g.Members[skip:end]}
-	if end < len(g.Members) {
-		page["@odata.nextLink"] = fmt.Sprintf("http://%s/v1.0/groups/%s/members?$skip=%d&$top=%d",
-			c.Request.Host, g.ID, end, top)
+	end := min(skip+top, len(items))
+	page := gin.H{"value": items[skip:end]}
+	if end < len(items) {
+		page["@odata.nextLink"] = fmt.Sprintf("http://%s%s?$skip=%d&$top=%d", c.Request.Host, path, end, top)
 	}
 	c.JSON(http.StatusOK, page)
 }

--- a/tools/graphmock/server_test.go
+++ b/tools/graphmock/server_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -81,6 +82,61 @@ func TestListMembers_PagedWalkViaMsgraphClient(t *testing.T) {
 	require.Len(t, got, 3)
 	assert.Equal(t, "alice.wu@corp.example", got[0].UserPrincipalName)
 	assert.Equal(t, "EMP001", got[0].EmployeeID)
+}
+
+func TestListUsers_PagedWalkViaMsgraphClient(t *testing.T) {
+	_, srv := newTestServer(t)
+	lister, err := msgraph.NewUserListerClient(
+		msgraph.Config{TenantID: "t", ClientID: "c", ClientSecret: "s"},
+		msgraph.WithBaseURL(srv.URL+"/v1.0"),
+		msgraph.WithTokenURL(srv.URL+"/t/oauth2/v2.0/token"),
+	)
+	require.NoError(t, err)
+	var got []msgraph.GraphUser
+	pages := 0
+	require.NoError(t, lister.ListUsers(context.Background(), 2, func(users []msgraph.GraphUser) error {
+		pages++
+		got = append(got, users...)
+		return nil
+	}))
+	assert.Equal(t, 2, pages, "3 users at $top=2 walks 2 pages")
+	require.Len(t, got, 3)
+	assert.Equal(t, "alice.wu@corp.example", got[0].UserPrincipalName)
+}
+
+func TestListUserChats_ViaMsgraphClient(t *testing.T) {
+	_, srv := newTestServer(t)
+	chats, err := msgraph.NewChatsClient(
+		msgraph.Config{TenantID: "t", ClientID: "c", ClientSecret: "s"},
+		msgraph.WithBaseURL(srv.URL+"/v1.0"),
+		msgraph.WithTokenURL(srv.URL+"/t/oauth2/v2.0/token"),
+	)
+	require.NoError(t, err)
+	// u4 is a member of only the group chat; the DM has just u1+u2.
+	from := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)
+	got, err := chats.ListUserChats(context.Background(), "u4", from, to)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "19:chat-eng", got[0].ID)
+	require.Len(t, got[0].Members, 3, "chat carries its members inline (via $expand)")
+}
+
+func TestListChatMembers_ViaMsgraphClient(t *testing.T) {
+	_, srv := newTestServer(t)
+	reader, err := msgraph.NewChatMembersClient(
+		msgraph.Config{TenantID: "t", ClientID: "c", ClientSecret: "s"},
+		msgraph.WithBaseURL(srv.URL+"/v1.0"),
+		msgraph.WithTokenURL(srv.URL+"/t/oauth2/v2.0/token"),
+	)
+	require.NoError(t, err)
+	got, err := reader.ListChatMembers(context.Background(), "19:chat-eng")
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, "u1", got[0].UserID)
+
+	_, err = reader.ListChatMembers(context.Background(), "nope")
+	require.Error(t, err, "unknown chat id 404s")
 }
 
 func TestFixtureSwap(t *testing.T) {


### PR DESCRIPTION
## Summary

Extends the fixture-driven MS Graph mock (`tools/graphmock`) beyond the HR-sync
surface (token grant + groups) to the surfaces the **user-sync**, **chat-sync**,
and **member-sync** stages read. This lets the full Teams migration pipeline
(hr-sync → user-sync → chat-sync → member-sync → room-creation) run end-to-end
against the mock with **no real Teams tenant** — dev/e2e only.

## What's included

New endpoints (all paged: honor `$top`, emit self-pointing `@odata.nextLink`):

- `GET /v1.0/users` — directory users (`ListUsers`).
- `GET /v1.0/users/{id}/chats` — chats whose members include the user, members inline (`ListUserChats`, `$expand=members`).
- `GET /v1.0/chats/{id}/members` — a chat's members (`ListChatMembers`), 404 on unknown id.

Fixtures gain top-level `users[]` + `chats[]`; the `PUT /__fixtures` response now
reports all three counts. Paging is factored into one `writePage` helper shared by
every list endpoint (groups/members refactored onto it too).

## Verification

- New table tests drive each endpoint through the **real `pkg/msgraph` client**
  (`NewUserListerClient` / `NewChatsClient` / `NewChatMembersClient`) against the
  mock, exercising token + paging + membership filtering.
- `go test ./tools/graphmock/...` green; golangci-lint clean.
