### PR TITLE
feat: per-user customizable chatlist sections

### DIFF
--- a/docs/chatlist-section-ordering.md
+++ b/docs/chatlist-section-ordering.md
@@ -35,7 +35,7 @@ approaches the limit.
 
 `sectionMidpoint(prev, next)` is the pure core:
 
-```
+```go
 mid := (prev + next) / 2
 return mid, mid <= prev || mid >= next   // second value = exhausted
 ```

--- a/docs/chatlist-section-ordering.md
+++ b/docs/chatlist-section-ordering.md
@@ -1,0 +1,88 @@
+# Within-section room ordering — fractional index + rebalance
+
+How a chat's manual position inside a custom section is stored, computed, and kept
+stable. Applies to the per-room order **within** a section; the section list order
+itself is a separate string-id permutation (`ChatlistState.sectionOrder`) and is not
+affected by anything here.
+
+## Model
+
+Each subscription carries a `sectionOrder float64` — its manual position inside its
+section (`pkg/model/subscription.go`). Positions use **fractional (midpoint) indexing**:
+a chat placed between two neighbors gets a value strictly between theirs, so a single
+move rewrites one row instead of renumbering the whole section.
+
+- **Append** (no anchor): `max(section) + 1`.
+- **After `afterRoomId`**: midpoint of that room's order and the next-higher order; if it's
+  the tail, `prev + 1`.
+- **Before `beforeRoomId`** (top-insertion): midpoint of that room's order and the
+  next-lower order; if it's the head, `next - 1`.
+
+Placement is computed by `ComputeSectionOrder` (`room-service/store_mongo.go`), two small
+indexed reads in the midpoint case. `afterRoomId`/`beforeRoomId` are mutually exclusive;
+a stale anchor (room not in this section) falls back to append.
+
+## Precision limit (and why size is not the axis)
+
+`float64` has a ~52-bit mantissa. Each midpoint insert into the **same gap** halves that
+gap; after ~50 consecutive inserts into the identical slot the gap is too small to hold a
+distinct midpoint. This depends only on repeated same-slot inserts — **not** on how many
+rooms the section holds. 10k rooms appended are 10k clean integers with zero precision
+pressure; only an adversarial "insert at the exact same spot over and over" pattern
+approaches the limit.
+
+## Exhaustion detection
+
+`sectionMidpoint(prev, next)` is the pure core:
+
+```
+mid := (prev + next) / 2
+return mid, mid <= prev || mid >= next   // second value = exhausted
+```
+
+`exhausted` is true the instant the computed midpoint rounds onto a neighbor — exact
+detection, evaluated **before** the value is ever written. It is unit-tested at the
+boundary.
+
+## Rebalance
+
+When a move computes `exhausted`, the handler rebalances the affected section **first,
+then recomputes** the position (`room-service/handler.go`, `chat.move` path), so no
+collapsed value is ever stored — there is no bad-order window.
+
+`RebalanceSection` (`room-service/store_mongo.go`):
+
+1. Load every subscription in `(account, sectionId)`, sorted by current `sectionOrder`
+   ascending (projected to `roomId` only) — the rooms in their current display order.
+2. Renumber: room at index `i` → `sectionOrder = i+1`. Relative order is preserved (we
+   sorted first); only the gaps reset to integer spacing. `[1, 2, 2.5, 2.625, 3]` → `[1,
+   2, 3, 4, 5]`.
+3. Apply as one **unordered `BulkWrite`** — a single round trip.
+4. The handler recomputes the move against the freshly spaced section; the target gap is
+   now a clean integer gap with ~50 inserts of fresh headroom.
+
+**Bounds:** scoped to one `(account, sectionId)` pair — never touches other sections,
+other users, or the section string-order. Cost O(section size), triggered ~once per 50
+same-slot inserts into a given section. Invisible to the user: the visible order is
+unchanged, the triggering move just carries one extra write of latency.
+
+## Client contract
+
+- The client sends only the **anchor** (`afterRoomId` / `beforeRoomId`); the backend owns
+  the float and the rebalance. Clients never compute order values.
+- **Do not treat a cached `sectionOrder` float as stable across a move.** A rebalance
+  renumbers a section's siblings but emits a move event only for the moved room, so a
+  client's cached sibling values can go stale. Relative order is preserved, so display
+  stays correct; for an authoritative refresh, re-read the section (the keyset-paginated
+  read returns current values). Order by the sequence, not by comparing cached floats.
+- **Concurrent inserts** into the same gap from two devices can momentarily produce two
+  equal floats; the section read's keyset cursor tiebreaks on `(sortKey, _id)`, so pages
+  stay stable and the pair gets a deterministic order.
+
+## Why fractional + rebalance (vs. string/lexorank)
+
+A string/lexorank scheme is unbounded (keys grow, never rebalance) but heavier keys and a
+larger change. Float + bounded rebalance handles the only failure mode (repeated same-slot
+inserts) at this scale for a much smaller footprint, with the sort/pagination path staying
+numeric. Widening the initial spacing would buy a few more inserts per gap but isn't worth
+the added complexity given the rebalance already covers the edge.

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -936,6 +936,8 @@ it is absent on every other action.
 | `alert` | boolean | Whether the room has an unread alert for the user. Authoritative subscription state maintained by the write path (set on new message, cleared on read receipt); **not** modified by read enrichment. |
 | `muted` | boolean | Whether the user muted the room. |
 | `favorite` | boolean | Whether the user favorited the room. |
+| `sectionId` | string | Optional. The custom chatlist section this room is in; absent = no custom section (the client derives a built-in placement). Set/cleared via [Move Chat to Section](#move-chat-to-section). |
+| `sectionOrder` | number | Optional. Manual fractional position within `sectionId`'s section; honored only when that section's `sortMode == "custom"`. |
 | `open` | boolean | Sidebar-visibility flag; false hides the room from subscription.list. |
 | `isSubscribed` | boolean | Optional. Whether the user is actively subscribed. |
 | `historySharedSince` | RFC3339 timestamp | Optional. Boundary before which prior history is shared. |
@@ -2135,6 +2137,51 @@ See [Error envelope](#6-error-envelope-reference). Common errors:
 ##### Cross-site behaviour
 
 When the requester's home site differs from the room's site, `room-service` emits an `OutboxEvent` on the OUTBOX stream and `outbox-worker` forwards the cross-site `subscription_favorite_toggled` event (at-least-once) to `chat.inbox.{userSite}.external.subscription_favorite_toggled`. `inbox-worker` on the user's home site mirrors the flip onto the local `Subscription` document. Missing-subscription on the home site (e.g., a federation race) is a silent no-op — no NACK, no redelivery loop.
+
+---
+
+#### Move Chat to Section
+
+**Subject:** `chat.user.{account}.request.room.{roomID}.{siteID}.chat.move`
+**Reply subject:** auto-generated `_INBOX.>` (NATS request/reply)
+
+- `{siteID}` must be the room's **origin `siteID`** (the site that owns the room), not the caller's own site.
+
+Synchronous RPC. Assigns a chat to a custom chatlist section and sets its manual order, or removes it from its section. Membership + order live on the **subscription** (`sectionId` / `sectionOrder`) — the exact storage + fanout model as `favorite.toggle`, so the per-user section overlay never carries per-chat data (see [Chatlist Sections](#chatlist-sections)). `room-service` writes one subscription, replies with the result, and fans out a `subscription.update` (`action: "section_moved"`).
+
+**Order key.** `sectionOrder` is a `float64`. `afterRoomId` places the chat just after that room (midpoint between its order and the next member's); `beforeRoomId` places it just before that room (top-insertion when the target is the section head); omit both to append (last + 1). `afterRoomId` and `beforeRoomId` are mutually exclusive — supplying both is rejected. A single move is one subscription write. When repeated inserts into one gap exhaust float precision, `room-service` transparently re-spaces that section's members and retries — the client sees nothing.
+
+##### Request body
+
+| Field | Type | Notes |
+|---|---|---|
+| `sectionId` | string \| null | The custom section to move the chat into. `null` (or JSON `null`) removes it from its section (falls back to a derived built-in). A **built-in** id (`favorites`/`apps`/`teams`/`chats`) is rejected — built-in membership is derived, not user-set. |
+| `afterRoomId` | string | Optional. Place the chat just after this room within the section. Omit to append at the end. Mutually exclusive with `beforeRoomId`. |
+| `beforeRoomId` | string | Optional. Place the chat just before this room within the section (top-insertion when it is the section head). Mutually exclusive with `afterRoomId`. |
+
+##### Success response
+
+| Field | Type | Notes |
+|---|---|---|
+| `status` | string | Always `"ok"`. |
+| `sectionId` | string | Omitted on a remove. The section the chat is now in. |
+| `sectionOrder` | number | Omitted on a remove. The chat's new manual position. |
+
+```json
+{ "status": "ok", "sectionId": "0192...uuid", "sectionOrder": 3.5 }
+```
+
+##### Error response
+
+See [Error envelope](#6-error-envelope-reference). Common errors:
+
+- reason `chatlist_builtin_target` — `sectionId` is a built-in section.
+- reason `chatlist_section_not_found` — `sectionId` is empty.
+- `"only room members can list members"` — the user has no subscription in the room.
+
+##### Triggered events — success path
+
+**`chat.user.{account}.event.subscription.update`** — `action: "section_moved"`; `subscription` carries the updated `sectionId` / `sectionOrder`. Cross-site, the `subscription_section_moved` inbox event mirrors it onto the user's home-site subscription (HWM-guarded by `sectionUpdatedAt`), the same lane `favorite_toggled` uses.
 
 ---
 
@@ -4393,6 +4440,12 @@ See [Error envelope](#6-error-envelope-reference).
 | `chat.user.{account}.request.user.{siteID}.status.set` | [`status.set`](#statusset) |
 | `chat.user.{account}.request.user.{siteID}.settings.get` | [`settings.get`](#settingsget) |
 | `chat.user.{account}.request.user.{siteID}.settings.set` | [`settings.set`](#settingsset) |
+| `chat.user.{account}.request.user.{siteID}.chatlist.get` | [`chatlist.get`](#chatlist-sections) |
+| `chat.user.{account}.request.user.{siteID}.chatlist.section.create` | [`chatlist.section.create`](#chatlist-sections) |
+| `chat.user.{account}.request.user.{siteID}.chatlist.section.rename` | [`chatlist.section.rename`](#chatlist-sections) |
+| `chat.user.{account}.request.user.{siteID}.chatlist.section.delete` | [`chatlist.section.delete`](#chatlist-sections) |
+| `chat.user.{account}.request.user.{siteID}.chatlist.section.reorder` | [`chatlist.section.reorder`](#chatlist-sections) |
+| `chat.user.{account}.request.user.{siteID}.chatlist.section.setsortmode` | [`chatlist.section.setSortMode`](#chatlist-sections) |
 | `chat.user.{account}.request.user.{siteID}.subscription.list` | [`subscription.list`](#subscriptionlist) |
 | `chat.user.{account}.request.user.{siteID}.subscription.getChannels` | [`subscription.getChannels`](#subscriptiongetchannels) |
 | `chat.user.{account}.request.user.{siteID}.subscription.getDM` | [`subscription.getDM`](#subscriptiongetdm) |
@@ -4700,6 +4753,72 @@ The payload carries the **full post-update settings** (replace, don't merge):
   "settings": { "fullWidth": false, "translateMessageInto": "ja", "muteAllNotifications": true }
 }
 ```
+
+---
+
+#### Chatlist Sections
+
+The per-user chatlist is split into **sections**. A chat's section **membership**
+and manual **order** live on its subscription (`sectionId` / `sectionOrder`, set via
+[Move Chat to Section](#move-chat-to-section)); the section **definitions** (names,
+display order, sort mode) live in a small per-user overlay owned by `user-service`.
+So the overlay is O(number of sections), never O(number of chats) — a rename or
+reorder fans a few-KB event no matter how many chats a section holds.
+
+**Built-in sections** (membership derived client-side, never user-set): `favorites`
+(from `subscription.favorite`), `apps` (from `isBot`), `teams` (from
+`subscription.sectionId == "teams"`), `chats` (everything else — no `sectionId`, not
+favorite, not a bot). All built-ins default to `sortMode: "mostRecent"`.
+
+**sortMode**: `"custom"` (sort the section's chats by `subscription.sectionOrder`) or
+`"mostRecent"` (sort by last message — the default and fallback).
+
+##### Client read model
+
+1. Load the paginated room list ([`subscription.list`](#subscriptionlist)) — each sub
+   already carries `favorite`, `sectionId`, `sectionOrder`.
+2. Load `chatlist.get` once — the section definitions (names, order, sortMode).
+3. Group each sub: `favorites` (favorite) · `apps` (bot) · `teams` (`sectionId == "teams"`)
+   · each custom section (`sectionId == <that id>`) · `chats` (no `sectionId`, not
+   favorite/bot). A `sectionId` pointing at a section not in the definitions renders in
+   **chats** (orphan tolerance — a deleted section leaves its members orphaned, no cascade).
+4. Within a section: `sortMode == "custom"` → order by `sectionOrder`; else by last message.
+5. Live updates: `subscription.update` (a chat's membership/order changed) and
+   `chatlist.update` (a section def changed) each replace their own scope, guarded by
+   their timestamp (last-write-wins, no deltas).
+
+##### RPCs
+
+| Subject action | Body | Notes |
+|---|---|---|
+| `chatlist.get` | — (no body) | Returns the [ChatlistState](#chatliststate). Defaults (the built-ins) when never customized. |
+| `chatlist.section.create` | `{ "name": string, "sortMode"?: "custom"\|"mostRecent" }` | Adds a custom section above `chats`. `sortMode` defaults to `custom`. |
+| `chatlist.section.rename` | `{ "sectionId": string, "name": string }` | Custom sections only. |
+| `chatlist.section.delete` | `{ "sectionId": string }` | Custom sections only; members orphan to `chats`. |
+| `chatlist.section.reorder` | `{ "sectionOrder": string[] }` | A permutation of **every** section id (built-in + custom). |
+| `chatlist.section.setSortMode` | `{ "sectionId": string, "sortMode": "custom"\|"mostRecent" }` | Any section (a built-in may be flipped to `custom`). |
+
+Every mutation returns the full post-update [ChatlistState](#chatliststate) and fans out
+[`chatlist.update`](events.md#chatlistupdate--chatlist-section-sync) to the caller's other
+devices (and cross-site, HWM-guarded by `chatlistUpdatedAt`).
+
+**Section name validation** (create / rename): 1–50 characters after trimming, no
+consecutive spaces, only letters/digits (any script), spaces, or `-_./()`. Names are
+case-sensitive and unique across a user's custom sections. Errors carry a reason:
+`chatlist_invalid_name`, `chatlist_duplicate_name`, `chatlist_section_not_found`,
+`chatlist_builtin_immutable` (rename/delete a built-in), `chatlist_invalid_order`,
+`chatlist_invalid_sort_mode`.
+
+##### ChatlistState
+
+| Field | Type | Notes |
+|---|---|---|
+| `sectionOrder` | string[] | Section display order — every section id, built-in + custom. |
+| `sections` | ChatlistSection[] | The section definitions. |
+| `lastUpdatedAt` | number | Unix-millis high-water mark (last-write-wins). |
+
+**ChatlistSection**: `{ "id": string, "name": string, "builtIn": boolean, "sortMode": "custom"|"mostRecent" }`.
+There is **no** member list on a section — membership rides the subscriptions.
 
 ---
 

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -60,6 +60,7 @@ paths.
    - [3.4 user-service](#34-user-service)
      - [`me`](#me) · [`status.getByName`](#statusgetbyname) · [`profile.getByName`](#profilegetbyname) · [`status.set`](#statusset) · [`subscription.list`](#subscriptionlist) · [`subscription.getChannels`](#subscriptiongetchannels)
      - [`subscription.getDM`](#subscriptiongetdm) · [`subscription.getByRoomID`](#subscriptiongetbyroomid) · [`subscription.count`](#subscriptioncount) · [`subscription.setAppSubscription`](#subscriptionsetappsubscription) · [`apps.list`](#appslist) · [`apps.categories`](#appscategories) · [`settings.get`](#settingsget) · [`settings.set`](#settingsset)
+     - [Chatlist Sections](#chatlist-sections)
      - [`sso.set`](#ssoset) · [`sso.refresh`](#ssorefresh)
    - [3.5 media-service](#35-media-service)
      - [`emoji.list`](#emojilist--list-a-sites-custom-emoji) · [`emoji.delete`](#emojidelete--delete-a-custom-emoji)
@@ -2155,7 +2156,7 @@ Synchronous RPC. Assigns a chat to a custom chatlist section and sets its manual
 
 | Field | Type | Notes |
 |---|---|---|
-| `sectionId` | string \| null | The custom section to move the chat into. `null` (or JSON `null`) removes it from its section (falls back to a derived built-in). A **built-in** id (`favorites`/`apps`/`teams`/`chats`) is rejected — built-in membership is derived, not user-set. |
+| `sectionId` | string \| null | The custom section to move the chat into. `null` (explicit JSON `null`) **or omitting the field entirely** both remove it from its section (falls back to a derived built-in) — the two are indistinguishable at the wire layer and handled identically. A **built-in** id (`favorites`/`apps`/`teams`/`chats`) is rejected — built-in membership is derived, not user-set. |
 | `afterRoomId` | string | Optional. Place the chat just after this room within the section. Omit to append at the end. Mutually exclusive with `beforeRoomId`. |
 | `beforeRoomId` | string | Optional. Place the chat just before this room within the section (top-insertion when it is the section head). Mutually exclusive with `afterRoomId`. |
 

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -45,6 +45,7 @@ For connection, auth, and error details see [../client-api.md](../client-api.md)
 | `chat.user.{account}.response.{requestID}` | AsyncJobResult (one-shot async job completion) |
 | `chat.user.{account}.event.subscription.update` | SubscriptionUpdateEvent / SubscriptionRemovedEvent |
 | `chat.user.{account}.event.settings.update` | SettingsUpdateEvent |
+| `chat.user.{account}.event.chatlist.update` | ChatlistUpdateEvent |
 | `chat.user.{account}.event.room.key` | RoomKeyEvent |
 | `chat.room.{roomID}.event` | new_message, message_edited, message_deleted, message_pinned/unpinned, message_reacted, thread_metadata_updated, message_read, thread_message_read, room_renamed, room_restricted |
 | `chat.user.{account}.event.room` | same event types as above, per-user fan-out for DM/botDM rooms |
@@ -103,9 +104,9 @@ Two shapes exist — discriminated by `action`:
 | Field | Type | Notes |
 |---|---|---|
 | `userId` | string | The affected user's internal user ID. Omitted on the org-removal path. |
-| `subscription` | [Subscription](../client-api.md#subscription) | Full Subscription record for `added` / `role_updated` / `mute_toggled` / `favorite_toggled` / `opened` / `read`. On `added` it additionally embeds a populated `room` object ([SubscriptionRoom](../client-api.md#subscriptionroom)) — `previewMessage` always omitted; `privateKey`/`keyVersion` present only for encrypted channel rooms — so clients can render the sidebar entry and store the room key from this single event. On `read`, `hasMention` and `hasGroupMention` are both `false` — reading the room clears both. |
-| `action` | string | `"added"`, `"role_updated"`, `"mute_toggled"`, `"favorite_toggled"`, `"opened"`, or `"read"`. |
-| `roomName` | string | Per-subscriber display label. On `added`: channel name / DM counterpart's display name / bot app name. On `role_updated`: the channel name. Omitted on `mute_toggled` / `favorite_toggled` / `opened` / `read`. |
+| `subscription` | [Subscription](../client-api.md#subscription) | Full Subscription record for `added` / `role_updated` / `mute_toggled` / `favorite_toggled` / `section_moved` / `opened` / `read`. On `added` it additionally embeds a populated `room` object ([SubscriptionRoom](../client-api.md#subscriptionroom)) — `previewMessage` always omitted; `privateKey`/`keyVersion` present only for encrypted channel rooms — so clients can render the sidebar entry and store the room key from this single event. On `section_moved`, `sectionId` / `sectionOrder` carry the new placement (both absent = removed from its section). On `read`, `hasMention` and `hasGroupMention` are both `false` — reading the room clears both. |
+| `action` | string | `"added"`, `"role_updated"`, `"mute_toggled"`, `"favorite_toggled"`, `"section_moved"`, `"opened"`, or `"read"`. |
+| `roomName` | string | Per-subscriber display label. On `added`: channel name / DM counterpart's display name / bot app name. On `role_updated`: the channel name. Omitted on `mute_toggled` / `favorite_toggled` / `section_moved` / `opened` / `read`. |
 | `timestamp` | number | Epoch ms (UTC). |
 
 ```json
@@ -216,6 +217,43 @@ UserSettings — every field optional, present only when explicitly set:
 {
   "timestamp": 1737000000000,
   "settings": { "fullWidth": false, "translateMessageInto": "ja", "muteAllNotifications": true }
+}
+```
+
+---
+
+## chatlist.update — chatlist section sync
+
+**Subject:** `chat.user.{account}.event.chatlist.update`
+
+Published by user-service after every successful chatlist section-definition
+mutation ([Chatlist Sections](../client-api.md#chatlist-sections)) — ephemeral
+core-NATS fan-out to the caller's own connected devices, the same delivery pattern
+as settings.update. Best-effort. Note this carries only the section **definitions**,
+never per-chat membership — a chat moving section fires a `subscription.update`
+(`action: "section_moved"`) instead, so `chatlist.update` stays O(sections).
+
+The payload carries the **full post-update state** — receivers replace their local
+copy, they never merge deltas.
+
+### Schema (ChatlistUpdateEvent)
+
+| Field | Type | Notes |
+|---|---|---|
+| `timestamp` | number | Publish time, Unix ms (the state's high-water mark). |
+| `chatlist` | [ChatlistState](../client-api.md#chatliststate) | Full post-update section definitions. |
+
+```json
+{
+  "timestamp": 1737000000000,
+  "chatlist": {
+    "sectionOrder": ["favorites", "apps", "teams", "work", "chats"],
+    "sections": [
+      { "id": "favorites", "name": "Favorites", "builtIn": true, "sortMode": "mostRecent" },
+      { "id": "work", "name": "Work", "builtIn": false, "sortMode": "custom" }
+    ],
+    "lastUpdatedAt": 1737000000000
+  }
 }
 ```
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -649,7 +649,7 @@ mirroring favorite. Full detail + read model: [Chatlist Sections](../client-api.
 
 | Field | Type | Notes |
 |---|---|---|
-| `sectionId` | string \| null | Custom section to move into; `null` removes. A built-in id is rejected. |
+| `sectionId` | string \| null | Custom section to move into; `null` or omitting the field both remove it (indistinguishable at the wire layer). A built-in id (`favorites`/`apps`/`teams`/`chats`) is rejected. |
 | `afterRoomId` | string | Optional. Place just after this room; omit to append. Mutually exclusive with `beforeRoomId`. |
 | `beforeRoomId` | string | Optional. Place just before this room (top-insertion at the section head). Mutually exclusive with `afterRoomId`. |
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -271,6 +271,7 @@ matching `siteId`). Full schemas, examples, and error tables are in
 | `chat.user.{account}.request.room.{roomID}.{siteID}.message.thread.read` | [Mark Thread as Read](#mark-thread-as-read) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.mute.toggle` | [Toggle Mute](#toggle-mute) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.favorite.toggle` | [Toggle Favorite](#toggle-favorite) |
+| `chat.user.{account}.request.room.{roomID}.{siteID}.chat.move` | [Move Chat to Section](#move-chat-to-section) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.open` | [Open Room](#open-room) |
 | `chat.user.{account}.request.room.{roomID}.{siteID}.message.read-receipt` | [Read Message Receipts](#read-message-receipts) |
 | `chat.user.{account}.request.orgs.{orgID}.{siteID}.members` | [List Org Members](#list-org-members) |
@@ -632,6 +633,35 @@ clients must debounce. No request body required.
 `"only room members can list members"`, `"invalid favorite-toggle subject: …"`.
 
 **Emits:** [`subscription.update`](events.md#subscriptionupdate--membership--state-changes) (`action: "favorite_toggled"` — to the requester for other sessions) → [events.md](events.md)
+
+---
+
+### Move Chat to Section
+
+**Subject:** `chat.user.{account}.request.room.{roomID}.{siteID}.chat.move`
+**Reply:** auto-generated `_INBOX.>` (NATS request/reply)
+
+Synchronous RPC. Sets the subscription's `sectionId` + fractional `sectionOrder`, or
+removes it from its section (`sectionId: null`). Membership lives on the subscription,
+mirroring favorite. Full detail + read model: [Chatlist Sections](../client-api.md#chatlist-sections).
+
+#### Request body
+
+| Field | Type | Notes |
+|---|---|---|
+| `sectionId` | string \| null | Custom section to move into; `null` removes. A built-in id is rejected. |
+| `afterRoomId` | string | Optional. Place just after this room; omit to append. Mutually exclusive with `beforeRoomId`. |
+| `beforeRoomId` | string | Optional. Place just before this room (top-insertion at the section head). Mutually exclusive with `afterRoomId`. |
+
+#### Success response
+
+| Field | Type | Notes |
+|---|---|---|
+| `status` | string | Always `"ok"`. |
+| `sectionId` | string | Omitted on remove. |
+| `sectionOrder` | number | Omitted on remove. |
+
+**Emits:** [`subscription.update`](events.md#subscriptionupdate--membership--state-changes) (`action: "section_moved"`) → [events.md](events.md)
 
 ---
 
@@ -1423,6 +1453,12 @@ no other endpoint emits a client-facing event.
 | `chat.user.{account}.request.user.{siteID}.status.set` | [status.set](#statusset) |
 | `chat.user.{account}.request.user.{siteID}.settings.get` | [settings.get](#settingsget) |
 | `chat.user.{account}.request.user.{siteID}.settings.set` | [settings.set](#settingsset) |
+| `chat.user.{account}.request.user.{siteID}.chatlist.get` | [Chatlist Sections](../client-api.md#chatlist-sections) |
+| `chat.user.{account}.request.user.{siteID}.chatlist.section.create` | [Chatlist Sections](../client-api.md#chatlist-sections) |
+| `chat.user.{account}.request.user.{siteID}.chatlist.section.rename` | [Chatlist Sections](../client-api.md#chatlist-sections) |
+| `chat.user.{account}.request.user.{siteID}.chatlist.section.delete` | [Chatlist Sections](../client-api.md#chatlist-sections) |
+| `chat.user.{account}.request.user.{siteID}.chatlist.section.reorder` | [Chatlist Sections](../client-api.md#chatlist-sections) |
+| `chat.user.{account}.request.user.{siteID}.chatlist.section.setsortmode` | [Chatlist Sections](../client-api.md#chatlist-sections) |
 | `chat.user.{account}.request.user.{siteID}.subscription.list` | [subscription.list](#subscriptionlist) |
 | `chat.user.{account}.request.user.{siteID}.subscription.getChannels` | [subscription.getChannels](#subscriptiongetchannels) |
 | `chat.user.{account}.request.user.{siteID}.subscription.getDM` | [subscription.getDM](#subscriptiongetdm) |

--- a/inbox-worker/handler.go
+++ b/inbox-worker/handler.go
@@ -83,7 +83,10 @@ type InboxStore interface {
 	// UpdateUserChatlist replaces the local users doc's chatlist sub-document with the
 	// full post-update state from the origin site, guarded by chatlistUpdatedAt so an
 	// out-of-order or duplicate delivery can't regress. A missing user is a logged no-op.
-	UpdateUserChatlist(ctx context.Context, account string, chatlist *model.ChatlistState, updatedAt time.Time) error
+	// updatedAt is unix-millis (int64) — matches how user-service writes
+	// chatlistUpdatedAt (mongorepo/users.go), unlike the other Update* methods here
+	// which take time.Time.
+	UpdateUserChatlist(ctx context.Context, account string, chatlist *model.ChatlistState, updatedAt int64) error
 	// UpdateSubscriptionSection sets sectionId+sectionOrder (or clears both when
 	// sectionID==nil) on (roomID, account), guarded by sectionUpdatedAt so an
 	// out-of-order or duplicate move can't regress. A missing sub NAKs for retry.
@@ -429,7 +432,7 @@ func (h *Handler) handleUserChatlistUpdated(ctx context.Context, evt *model.Inbo
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
 		return fmt.Errorf("unmarshal user_chatlist_updated payload: %w", err)
 	}
-	if err := h.store.UpdateUserChatlist(ctx, e.Account, &e.Chatlist, time.UnixMilli(e.Timestamp).UTC()); err != nil {
+	if err := h.store.UpdateUserChatlist(ctx, e.Account, &e.Chatlist, e.Timestamp); err != nil {
 		return fmt.Errorf("update user chatlist for %q: %w", e.Account, err)
 	}
 	return nil

--- a/inbox-worker/handler.go
+++ b/inbox-worker/handler.go
@@ -80,6 +80,14 @@ type InboxStore interface {
 	// full post-update settings from the origin site, guarded by settingsUpdatedAt so an
 	// out-of-order or duplicate delivery can't regress. A missing user is a logged no-op.
 	UpdateUserSettings(ctx context.Context, account string, settings *model.UserSettings, updatedAt time.Time) error
+	// UpdateUserChatlist replaces the local users doc's chatlist sub-document with the
+	// full post-update state from the origin site, guarded by chatlistUpdatedAt so an
+	// out-of-order or duplicate delivery can't regress. A missing user is a logged no-op.
+	UpdateUserChatlist(ctx context.Context, account string, chatlist *model.ChatlistState, updatedAt time.Time) error
+	// UpdateSubscriptionSection sets sectionId+sectionOrder (or clears both when
+	// sectionID==nil) on (roomID, account), guarded by sectionUpdatedAt so an
+	// out-of-order or duplicate move can't regress. A missing sub NAKs for retry.
+	UpdateSubscriptionSection(ctx context.Context, roomID, account string, sectionID *string, order float64, updatedAt time.Time) error
 }
 
 // Handler processes cross-site InboxEvent messages; replicates only subscription/room metadata, never room keys.
@@ -130,6 +138,10 @@ func (h *Handler) HandleEvent(ctx context.Context, data []byte) error {
 		return h.handleUserStatusUpdated(ctx, &evt)
 	case model.InboxUserSettingsUpdated:
 		return h.handleUserSettingsUpdated(ctx, &evt)
+	case model.InboxUserChatlistUpdated:
+		return h.handleUserChatlistUpdated(ctx, &evt)
+	case model.InboxSubscriptionSectionMoved:
+		return h.handleSubscriptionSectionMoved(ctx, &evt)
 	default:
 		slog.Warn("unknown event type, skipping", "type", evt.Type)
 		return nil
@@ -406,6 +418,32 @@ func (h *Handler) handleUserSettingsUpdated(ctx context.Context, evt *model.Inbo
 	}
 	if err := h.store.UpdateUserSettings(ctx, e.Account, &e.Settings, time.UnixMilli(e.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("update user settings for %q: %w", e.Account, err)
+	}
+	return nil
+}
+
+// handleUserChatlistUpdated mirrors a cross-site chatlist change onto the local users doc,
+// guarded by the event Timestamp so an out-of-order or duplicate delivery can't regress.
+func (h *Handler) handleUserChatlistUpdated(ctx context.Context, evt *model.InboxEvent) error {
+	var e model.UserChatlistUpdated
+	if err := json.Unmarshal(evt.Payload, &e); err != nil {
+		return fmt.Errorf("unmarshal user_chatlist_updated payload: %w", err)
+	}
+	if err := h.store.UpdateUserChatlist(ctx, e.Account, &e.Chatlist, time.UnixMilli(e.Timestamp).UTC()); err != nil {
+		return fmt.Errorf("update user chatlist for %q: %w", e.Account, err)
+	}
+	return nil
+}
+
+// handleSubscriptionSectionMoved mirrors a room-side section move onto the user's
+// home-site subscription, guarded by sectionUpdatedAt (the event Timestamp).
+func (h *Handler) handleSubscriptionSectionMoved(ctx context.Context, evt *model.InboxEvent) error {
+	var e model.SubscriptionSectionMovedEvent
+	if err := json.Unmarshal(evt.Payload, &e); err != nil {
+		return fmt.Errorf("unmarshal subscription_section_moved payload: %w", err)
+	}
+	if err := h.store.UpdateSubscriptionSection(ctx, e.RoomID, e.Account, e.SectionID, e.SectionOrder, time.UnixMilli(e.Timestamp).UTC()); err != nil {
+		return fmt.Errorf("update subscription section for %q in room %q: %w", e.Account, e.RoomID, err)
 	}
 	return nil
 }

--- a/inbox-worker/handler_test.go
+++ b/inbox-worker/handler_test.go
@@ -111,7 +111,7 @@ type stubInboxStore struct {
 type userChatlistUpdate struct {
 	account   string
 	chatlist  *model.ChatlistState
-	updatedAt time.Time
+	updatedAt int64
 }
 
 type sectionMove struct {
@@ -454,7 +454,7 @@ func (s *stubInboxStore) UpdateUserSettings(_ context.Context, account string, s
 	return nil
 }
 
-func (s *stubInboxStore) UpdateUserChatlist(_ context.Context, account string, chatlist *model.ChatlistState, updatedAt time.Time) error {
+func (s *stubInboxStore) UpdateUserChatlist(_ context.Context, account string, chatlist *model.ChatlistState, updatedAt int64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.chatlistUpdates = append(s.chatlistUpdates, userChatlistUpdate{account: account, chatlist: chatlist, updatedAt: updatedAt})

--- a/inbox-worker/handler_test.go
+++ b/inbox-worker/handler_test.go
@@ -104,6 +104,22 @@ type stubInboxStore struct {
 	userStatusUpdates     []userStatusUpdate
 	userStatusErr         error
 	settingsUpdates       []userSettingsUpdate
+	chatlistUpdates       []userChatlistUpdate
+	sectionMoves          []sectionMove
+}
+
+type userChatlistUpdate struct {
+	account   string
+	chatlist  *model.ChatlistState
+	updatedAt time.Time
+}
+
+type sectionMove struct {
+	roomID    string
+	account   string
+	sectionID *string
+	order     float64
+	updatedAt time.Time
 }
 
 type userSettingsUpdate struct {
@@ -435,6 +451,20 @@ func (s *stubInboxStore) UpdateUserSettings(_ context.Context, account string, s
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.settingsUpdates = append(s.settingsUpdates, userSettingsUpdate{account: account, settings: settings, updatedAt: updatedAt})
+	return nil
+}
+
+func (s *stubInboxStore) UpdateUserChatlist(_ context.Context, account string, chatlist *model.ChatlistState, updatedAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.chatlistUpdates = append(s.chatlistUpdates, userChatlistUpdate{account: account, chatlist: chatlist, updatedAt: updatedAt})
+	return nil
+}
+
+func (s *stubInboxStore) UpdateSubscriptionSection(_ context.Context, roomID, account string, sectionID *string, order float64, updatedAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sectionMoves = append(s.sectionMoves, sectionMove{roomID: roomID, account: account, sectionID: sectionID, order: order, updatedAt: updatedAt})
 	return nil
 }
 

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -214,6 +214,23 @@ func (s *mongoInboxStore) UpdateUserSettings(ctx context.Context, account string
 	return nil
 }
 
+// UpdateUserChatlist replaces the local users doc's chatlist sub-document with the origin
+// site's full post-update state — whole-object, so a removed section is removed here too.
+// A missing user (no doc on this site) is a silent no-op.
+func (s *mongoInboxStore) UpdateUserChatlist(ctx context.Context, account string, chatlist *model.ChatlistState, updatedAt time.Time) error {
+	// Guard on the chatlistUpdatedAt high-water mark so an out-of-order or duplicate event
+	// (chatlist fans to all sites) can't regress to older state.
+	filter := bson.M{"account": account, "$or": bson.A{
+		bson.M{"chatlistUpdatedAt": bson.M{"$exists": false}},
+		bson.M{"chatlistUpdatedAt": bson.M{"$lt": updatedAt}},
+	}}
+	set := bson.M{"chatlist": chatlist, "chatlistUpdatedAt": updatedAt}
+	if _, err := s.userCol.UpdateOne(ctx, filter, bson.M{"$set": set}); err != nil {
+		return fmt.Errorf("update user chatlist for %q: %w", account, err)
+	}
+	return nil
+}
+
 // BulkCreateSubscriptions inserts the supplied subs idempotently. Each is
 // keyed by (roomId, u.account) and written via $setOnInsert so an existing
 // sub (from a previous delivery, or with read-state already accumulated) is
@@ -277,6 +294,38 @@ func (s *mongoInboxStore) UpdateSubscriptionFavorite(ctx context.Context, roomID
 	res, err := s.subCol.UpdateOne(ctx, filter, update)
 	if err != nil {
 		return fmt.Errorf("update subscription favorite for %q in room %q: %w", account, roomID, err)
+	}
+	if res.MatchedCount == 0 {
+		return s.naksIfSubscriptionMissing(ctx, account, roomID)
+	}
+	return nil
+}
+
+// UpdateSubscriptionSection sets sectionId+sectionOrder (or clears both when
+// sectionID==nil, a remove) by (roomID, account) under a sectionUpdatedAt guard so
+// an out-of-order or duplicate move cannot regress. A guard-rejected event is a
+// silent no-op; a missing sub NAKs so it retries after the sub replicates.
+func (s *mongoInboxStore) UpdateSubscriptionSection(ctx context.Context, roomID, account string, sectionID *string, order float64, updatedAt time.Time) error {
+	filter := bson.M{
+		"roomId":    roomID,
+		"u.account": account,
+		"$or": bson.A{
+			bson.M{"sectionUpdatedAt": bson.M{"$exists": false}},
+			bson.M{"sectionUpdatedAt": bson.M{"$lt": updatedAt}},
+		},
+	}
+	var update bson.M
+	if sectionID == nil {
+		update = bson.M{
+			"$set":   bson.M{"sectionUpdatedAt": updatedAt},
+			"$unset": bson.M{"sectionId": "", "sectionOrder": ""},
+		}
+	} else {
+		update = bson.M{"$set": bson.M{"sectionId": *sectionID, "sectionOrder": order, "sectionUpdatedAt": updatedAt}}
+	}
+	res, err := s.subCol.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return fmt.Errorf("update subscription section for %q in room %q: %w", account, roomID, err)
 	}
 	if res.MatchedCount == 0 {
 		return s.naksIfSubscriptionMissing(ctx, account, roomID)

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -216,8 +216,10 @@ func (s *mongoInboxStore) UpdateUserSettings(ctx context.Context, account string
 
 // UpdateUserChatlist replaces the local users doc's chatlist sub-document with the origin
 // site's full post-update state — whole-object, so a removed section is removed here too.
-// A missing user (no doc on this site) is a silent no-op.
-func (s *mongoInboxStore) UpdateUserChatlist(ctx context.Context, account string, chatlist *model.ChatlistState, updatedAt time.Time) error {
+// A missing user (no doc on this site) is a silent no-op. updatedAt is unix-millis
+// (int64), matching how user-service stamps chatlistUpdatedAt — keeps the field's
+// representation consistent instead of round-tripping through time.Time.
+func (s *mongoInboxStore) UpdateUserChatlist(ctx context.Context, account string, chatlist *model.ChatlistState, updatedAt int64) error {
 	// Guard on the chatlistUpdatedAt high-water mark so an out-of-order or duplicate event
 	// (chatlist fans to all sites) can't regress to older state.
 	filter := bson.M{"account": account, "$or": bson.A{

--- a/inbox-worker/mock_store_test.go
+++ b/inbox-worker/mock_store_test.go
@@ -197,6 +197,20 @@ func (mr *MockInboxStoreMockRecorder) UpdateSubscriptionNamesForRoom(ctx, roomID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubscriptionNamesForRoom", reflect.TypeOf((*MockInboxStore)(nil).UpdateSubscriptionNamesForRoom), ctx, roomID, newName, nameUpdatedAt)
 }
 
+// UpdateSubscriptionOpen mocks base method.
+func (m *MockInboxStore) UpdateSubscriptionOpen(ctx context.Context, roomID, account string, open bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateSubscriptionOpen", ctx, roomID, account, open)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateSubscriptionOpen indicates an expected call of UpdateSubscriptionOpen.
+func (mr *MockInboxStoreMockRecorder) UpdateSubscriptionOpen(ctx, roomID, account, open any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubscriptionOpen", reflect.TypeOf((*MockInboxStore)(nil).UpdateSubscriptionOpen), ctx, roomID, account, open)
+}
+
 // UpdateSubscriptionRead mocks base method.
 func (m *MockInboxStore) UpdateSubscriptionRead(ctx context.Context, roomID, account string, lastSeenAt time.Time, alert bool) error {
 	m.ctrl.T.Helper()
@@ -223,6 +237,34 @@ func (m *MockInboxStore) UpdateSubscriptionRoles(ctx context.Context, account, r
 func (mr *MockInboxStoreMockRecorder) UpdateSubscriptionRoles(ctx, account, roomID, roles, rolesUpdatedAt any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubscriptionRoles", reflect.TypeOf((*MockInboxStore)(nil).UpdateSubscriptionRoles), ctx, account, roomID, roles, rolesUpdatedAt)
+}
+
+// UpdateSubscriptionSection mocks base method.
+func (m *MockInboxStore) UpdateSubscriptionSection(ctx context.Context, roomID, account string, sectionID *string, order float64, updatedAt time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateSubscriptionSection", ctx, roomID, account, sectionID, order, updatedAt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateSubscriptionSection indicates an expected call of UpdateSubscriptionSection.
+func (mr *MockInboxStoreMockRecorder) UpdateSubscriptionSection(ctx, roomID, account, sectionID, order, updatedAt any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubscriptionSection", reflect.TypeOf((*MockInboxStore)(nil).UpdateSubscriptionSection), ctx, roomID, account, sectionID, order, updatedAt)
+}
+
+// UpdateUserChatlist mocks base method.
+func (m *MockInboxStore) UpdateUserChatlist(ctx context.Context, account string, chatlist *model.ChatlistState, updatedAt int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateUserChatlist", ctx, account, chatlist, updatedAt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateUserChatlist indicates an expected call of UpdateUserChatlist.
+func (mr *MockInboxStoreMockRecorder) UpdateUserChatlist(ctx, account, chatlist, updatedAt any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserChatlist", reflect.TypeOf((*MockInboxStore)(nil).UpdateUserChatlist), ctx, account, chatlist, updatedAt)
 }
 
 // UpdateUserSettings mocks base method.

--- a/outbox-worker/consumer_config_test.go
+++ b/outbox-worker/consumer_config_test.go
@@ -31,6 +31,7 @@ func TestBuildConcurrentConsumerConfig(t *testing.T) {
 		"chat.outbox.site-a.site-b.thread_read_all",
 		"chat.outbox.site-a.site-b.subscription_mute_toggled",
 		"chat.outbox.site-a.site-b.subscription_favorite_toggled",
+		"chat.outbox.site-a.site-b.subscription_section_moved",
 		"chat.outbox.site-a.site-b.subscription_opened",
 		"chat.outbox.site-a.site-b.room_restricted",
 		"chat.outbox.site-a.site-b.thread_subscription_upserted",

--- a/pkg/errcode/codes_user.go
+++ b/pkg/errcode/codes_user.go
@@ -6,4 +6,13 @@ const (
 	UserAppDisabled          Reason = "app_disabled"
 	UserSubscriptionNotFound Reason = "subscription_not_found"
 	UserSSOTokenNotFound     Reason = "sso_token_not_found"
+
+	// Chatlist section reasons — the client branches on each.
+	UserChatlistInvalidName      Reason = "chatlist_invalid_name"
+	UserChatlistDuplicateName    Reason = "chatlist_duplicate_name"
+	UserChatlistBuiltinImmutable Reason = "chatlist_builtin_immutable"
+	UserChatlistSectionNotFound  Reason = "chatlist_section_not_found"
+	UserChatlistInvalidOrder     Reason = "chatlist_invalid_order"
+	UserChatlistInvalidSortMode  Reason = "chatlist_invalid_sort_mode"
+	UserChatlistBuiltinTarget    Reason = "chatlist_builtin_target"
 )

--- a/pkg/model/chatlist.go
+++ b/pkg/model/chatlist.go
@@ -1,0 +1,71 @@
+package model
+
+// Built-in (product-defined) chatlist section ids. Their membership is derived
+// client-side from subscription flags — favorites from subscription.favorite,
+// apps from isBot, teams from subscription.sectionId == "teams", chats from
+// everything else. There is no server-stored member list for a built-in.
+const (
+	SectionFavorites = "favorites"
+	SectionApps      = "apps"
+	SectionTeams     = "teams"
+	SectionChats     = "chats"
+)
+
+// SortMode values. custom honors each chat's subscription.sectionOrder;
+// mostRecent sorts by last message (the default and fallback).
+const (
+	SortModeCustom     = "custom"
+	SortModeMostRecent = "mostRecent"
+)
+
+// MaxSectionName bounds a section name in runes.
+const MaxSectionName = 50
+
+// IsBuiltinSection reports whether id is a product-defined built-in section.
+func IsBuiltinSection(id string) bool {
+	switch id {
+	case SectionFavorites, SectionApps, SectionTeams, SectionChats:
+		return true
+	}
+	return false
+}
+
+// ChatlistSection is one section definition. Membership and per-chat order live
+// on the subscriptions (sectionId/sectionOrder), NOT here — the overlay carries
+// definitions only, so chatlist.update stays O(sections) not O(chats).
+type ChatlistSection struct {
+	ID       string `json:"id"       bson:"id"`
+	Name     string `json:"name"     bson:"name"`
+	BuiltIn  bool   `json:"builtIn"  bson:"builtIn"`
+	SortMode string `json:"sortMode" bson:"sortMode"`
+}
+
+// ChatlistState is the per-user section-definition overlay on the user record;
+// nil means never customized — the client falls back to DefaultChatlistState.
+// SectionOrder always covers every section id (built-in + custom).
+type ChatlistState struct {
+	SectionOrder  []string          `json:"sectionOrder"  bson:"sectionOrder"`
+	Sections      []ChatlistSection `json:"sections"      bson:"sections"`
+	LastUpdatedAt int64             `json:"lastUpdatedAt" bson:"lastUpdatedAt"`
+}
+
+// DefaultChatlistState is the server-owned starting state: the built-in sections
+// in display order, no custom sections. All built-ins default to mostRecent.
+func DefaultChatlistState() *ChatlistState {
+	return &ChatlistState{
+		SectionOrder: []string{SectionFavorites, SectionApps, SectionTeams, SectionChats},
+		Sections: []ChatlistSection{
+			{ID: SectionFavorites, Name: "Favorites", BuiltIn: true, SortMode: SortModeMostRecent},
+			{ID: SectionApps, Name: "Apps", BuiltIn: true, SortMode: SortModeMostRecent},
+			{ID: SectionTeams, Name: "Teams", BuiltIn: true, SortMode: SortModeMostRecent},
+			{ID: SectionChats, Name: "Chats", BuiltIn: true, SortMode: SortModeMostRecent},
+		},
+	}
+}
+
+// ChatlistUpdateEvent is the client-facing chatlist.update fanout payload — the
+// full post-update state, so other devices replace rather than merge.
+type ChatlistUpdateEvent struct {
+	Timestamp int64         `json:"timestamp"`
+	Chatlist  ChatlistState `json:"chatlist"`
+}

--- a/pkg/model/chatlist_test.go
+++ b/pkg/model/chatlist_test.go
@@ -1,0 +1,40 @@
+package model
+
+import "testing"
+
+func TestDefaultChatlistStateHasBuiltins(t *testing.T) {
+	st := DefaultChatlistState()
+	want := []string{SectionFavorites, SectionApps, SectionTeams, SectionChats}
+	if len(st.SectionOrder) != len(want) {
+		t.Fatalf("SectionOrder = %v, want %v", st.SectionOrder, want)
+	}
+	for i, id := range want {
+		if st.SectionOrder[i] != id {
+			t.Fatalf("SectionOrder[%d] = %q, want %q", i, st.SectionOrder[i], id)
+		}
+	}
+	if len(st.Sections) != len(want) {
+		t.Fatalf("Sections len = %d, want %d", len(st.Sections), len(want))
+	}
+	for _, s := range st.Sections {
+		if !s.BuiltIn {
+			t.Errorf("section %q should be built-in", s.ID)
+		}
+		if s.SortMode != SortModeMostRecent {
+			t.Errorf("built-in %q sortMode = %q, want mostRecent", s.ID, s.SortMode)
+		}
+	}
+}
+
+func TestIsBuiltinSection(t *testing.T) {
+	for _, id := range []string{SectionFavorites, SectionApps, SectionTeams, SectionChats} {
+		if !IsBuiltinSection(id) {
+			t.Errorf("%q should be built-in", id)
+		}
+	}
+	for _, id := range []string{"", "custom-123", "Teams", "work"} {
+		if IsBuiltinSection(id) {
+			t.Errorf("%q should NOT be built-in", id)
+		}
+	}
+}

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -143,6 +143,8 @@ const (
 	InboxRoomRestricted              InboxEventType = "room_restricted"
 	InboxUserStatusUpdated           InboxEventType = "user_status_updated"
 	InboxUserSettingsUpdated         InboxEventType = "user_settings_updated"
+	InboxUserChatlistUpdated         InboxEventType = "user_chatlist_updated"
+	InboxSubscriptionSectionMoved    InboxEventType = "subscription_section_moved"
 )
 
 // UserSettingsUpdated is the cross-site inbox event user-service publishes on settings.set, applied
@@ -500,6 +502,48 @@ type SubscriptionFavoriteToggledEvent struct {
 	RoomID    string `json:"roomId"               bson:"roomId"`
 	Favorite  bool   `json:"favorite"             bson:"favorite"`
 	Timestamp int64  `json:"timestamp"            bson:"timestamp"`
+}
+
+// MoveChatRequest is the moveChat RPC body: sectionId nil (or JSON null) removes
+// the chat from its custom section; afterRoomId places it just after that room,
+// beforeRoomId just before it (for top-insertion); append when both empty.
+// afterRoomId and beforeRoomId are mutually exclusive. roomId rides the subject,
+// like favorite.toggle.
+type MoveChatRequest struct {
+	SectionID    *string `json:"sectionId"`
+	AfterRoomID  string  `json:"afterRoomId,omitempty"`
+	BeforeRoomID string  `json:"beforeRoomId,omitempty"`
+}
+
+// MoveChatResponse is the sync reply for the moveChat RPC — the post-write
+// membership so the caller doesn't re-fetch.
+type MoveChatResponse struct {
+	Status string `json:"status"`
+	// SectionID nil (JSON omitted) means removed from its section. SectionOrder
+	// has NO omitempty — a top-insertion legitimately yields 0, and dropping it
+	// would leave the client without the new position (afterRoomId never hits 0).
+	SectionID    *string `json:"sectionId,omitempty"`
+	SectionOrder float64 `json:"sectionOrder"`
+}
+
+// SubscriptionSectionMovedEvent is the InboxEvent.Payload for type
+// "subscription_section_moved" — cross-site replica of a sectionId/sectionOrder
+// change, HWM-guarded by Timestamp (== the origin doc's sectionUpdatedAt).
+type SubscriptionSectionMovedEvent struct {
+	Account      string  `json:"account"      bson:"account"`
+	RoomID       string  `json:"roomId"       bson:"roomId"`
+	SectionID    *string `json:"sectionId"    bson:"sectionId"`
+	SectionOrder float64 `json:"sectionOrder" bson:"sectionOrder"`
+	Timestamp    int64   `json:"timestamp"    bson:"timestamp"`
+}
+
+// UserChatlistUpdated is the cross-site inbox event user-service publishes on any
+// chatlist mutation, applied by the remote inbox-worker; Chatlist is the full
+// post-update state — receiver replaces, never merges.
+type UserChatlistUpdated struct {
+	Account   string        `json:"account"   bson:"account"`
+	Chatlist  ChatlistState `json:"chatlist"  bson:"chatlist"`
+	Timestamp int64         `json:"timestamp" bson:"timestamp"`
 }
 
 // OpenRoomResponse is the sync reply for the open RPC. Open is always true.

--- a/pkg/model/subscription.go
+++ b/pkg/model/subscription.go
@@ -40,6 +40,15 @@ type Subscription struct {
 	Alert              bool             `json:"alert" bson:"alert"`
 	Muted              bool             `json:"muted" bson:"muted"`
 	Favorite           bool             `json:"favorite" bson:"favorite"`
+	// SectionId is the custom chatlist section this chat is in; nil = no custom
+	// section (the client derives a built-in placement). SectionOrder is the manual
+	// position within that section, honored only when the section's sortMode ==
+	// custom. Both mirror how favorite lives on the subscription.
+	SectionId *string `json:"sectionId,omitempty" bson:"sectionId,omitempty"`
+	// No JSON omitempty on SectionOrder: a top-inserted chat legitimately has
+	// order 0, and omitempty would drop it from the room-list/reply, losing the
+	// position. bson keeps omitempty — the write path uses an explicit $set.
+	SectionOrder float64 `json:"sectionOrder" bson:"sectionOrder,omitempty"`
 	// Open is the per-user sidebar-visibility flag. New subscriptions are born
 	// open (room-worker's newSub sets it); subscription.list excludes only rows
 	// explicitly closed (open == false). Set true by the room-service open RPC.
@@ -70,6 +79,7 @@ type Subscription struct {
 	RolesUpdatedAt    *time.Time `json:"rolesUpdatedAt,omitempty"    bson:"rolesUpdatedAt,omitempty"`
 	NameUpdatedAt     *time.Time `json:"nameUpdatedAt,omitempty"     bson:"nameUpdatedAt,omitempty"`
 	RestrictUpdatedAt *time.Time `json:"restrictUpdatedAt,omitempty" bson:"restrictUpdatedAt,omitempty"`
+	SectionUpdatedAt  *time.Time `json:"sectionUpdatedAt,omitempty"  bson:"sectionUpdatedAt,omitempty"`
 
 	// Origin identifies where the subscription came from — e.g. OriginTeams for a
 	// Teams-migration import. Server-side provenance (persisted, not client-facing);

--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -70,6 +70,8 @@ type User struct {
 	Services Services `json:"-" bson:"services,omitempty"`
 	// Settings is the per-user client-preferences sub-document; nil = never set.
 	Settings *UserSettings `json:"settings,omitempty" bson:"settings,omitempty"`
+	// Chatlist is the per-user section-definition overlay; nil = never customized.
+	Chatlist *ChatlistState `json:"chatlist,omitempty" bson:"chatlist,omitempty"`
 }
 
 // String formats a User for log lines, deliberately omitting the bcrypt hash

--- a/pkg/outbox/outbox.go
+++ b/pkg/outbox/outbox.go
@@ -25,6 +25,7 @@ var ConcurrentEventTypes = []model.InboxEventType{
 	model.InboxThreadReadAll,
 	model.InboxSubscriptionMuteToggled,
 	model.InboxSubscriptionFavoriteToggled,
+	model.InboxSubscriptionSectionMoved,
 	model.InboxSubscriptionOpened,
 	model.InboxRoomRestricted,
 	// message-worker: thread-subscription federation. Order-insensitive —

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -253,6 +253,13 @@ func SettingsUpdate(account string) string {
 	return fmt.Sprintf("chat.user.%s.event.settings.update", account)
 }
 
+// ChatlistUpdate is the client-facing fanout subject published by user-service
+// after any successful chatlist section-definition mutation (same delivery
+// pattern as settings.update — ephemeral, core NATS).
+func ChatlistUpdate(account string) string {
+	return fmt.Sprintf("chat.user.%s.event.chatlist.update", account)
+}
+
 func RoomMetadataChanged(account string) string {
 	return fmt.Sprintf("chat.user.%s.event.room.metadata.update", account)
 }
@@ -825,6 +832,13 @@ func FavoriteToggleWildcard(siteID string) string {
 	return fmt.Sprintf("chat.user.*.request.room.*.%s.favorite.toggle", siteID)
 }
 
+// MoveChat returns the concrete subject for the per-user chat.move RPC (assign a
+// chat to a chatlist section + set its manual order). roomId rides the subject,
+// like favorite.toggle.
+func MoveChat(account, roomID, siteID string) string {
+	return fmt.Sprintf("chat.user.%s.request.room.%s.%s.chat.move", account, roomID, siteID)
+}
+
 // OpenRoom returns the concrete subject for the per-user open RPC.
 func OpenRoom(account, roomID, siteID string) string {
 	return fmt.Sprintf("chat.user.%s.request.room.%s.%s.open", account, roomID, siteID)
@@ -1035,6 +1049,10 @@ func MuteTogglePattern(siteID string) string {
 
 func FavoriteTogglePattern(siteID string) string {
 	return fmt.Sprintf("chat.user.{account}.request.room.{roomID}.%s.favorite.toggle", siteID)
+}
+
+func MoveChatPattern(siteID string) string {
+	return fmt.Sprintf("chat.user.{account}.request.room.{roomID}.%s.chat.move", siteID)
 }
 
 func OpenRoomPattern(siteID string) string {
@@ -1305,6 +1323,80 @@ func UserSettingsSet(account, siteID string) string {
 
 func UserSettingsSetPattern(siteID string) string {
 	return fmt.Sprintf("chat.user.{account}.request.user.%s.settings.set", siteID)
+}
+
+// Chatlist section-definition registry subjects — get + five mutations. The
+// concrete forms panic on a wildcard account (same guard as the settings
+// helpers). Membership/order is NOT here — that rides the room-service moveChat
+// RPC onto the subscription.
+
+func UserChatlistGet(account, siteID string) string {
+	if !isValidAccountToken(account) {
+		panic("invalid account token: contains NATS wildcard characters")
+	}
+	return fmt.Sprintf("chat.user.%s.request.user.%s.chatlist.get", account, siteID)
+}
+
+func UserChatlistGetPattern(siteID string) string {
+	return fmt.Sprintf("chat.user.{account}.request.user.%s.chatlist.get", siteID)
+}
+
+func UserChatlistSectionCreate(account, siteID string) string {
+	if !isValidAccountToken(account) {
+		panic("invalid account token: contains NATS wildcard characters")
+	}
+	return fmt.Sprintf("chat.user.%s.request.user.%s.chatlist.section.create", account, siteID)
+}
+
+func UserChatlistSectionCreatePattern(siteID string) string {
+	return fmt.Sprintf("chat.user.{account}.request.user.%s.chatlist.section.create", siteID)
+}
+
+func UserChatlistSectionDelete(account, siteID string) string {
+	if !isValidAccountToken(account) {
+		panic("invalid account token: contains NATS wildcard characters")
+	}
+	return fmt.Sprintf("chat.user.%s.request.user.%s.chatlist.section.delete", account, siteID)
+}
+
+func UserChatlistSectionDeletePattern(siteID string) string {
+	return fmt.Sprintf("chat.user.{account}.request.user.%s.chatlist.section.delete", siteID)
+}
+
+func UserChatlistSectionRename(account, siteID string) string {
+	if !isValidAccountToken(account) {
+		panic("invalid account token: contains NATS wildcard characters")
+	}
+	return fmt.Sprintf("chat.user.%s.request.user.%s.chatlist.section.rename", account, siteID)
+}
+
+func UserChatlistSectionRenamePattern(siteID string) string {
+	return fmt.Sprintf("chat.user.{account}.request.user.%s.chatlist.section.rename", siteID)
+}
+
+// UserChatlistSectionReorder reorders the SECTIONS themselves (a permutation of
+// every section id).
+func UserChatlistSectionReorder(account, siteID string) string {
+	if !isValidAccountToken(account) {
+		panic("invalid account token: contains NATS wildcard characters")
+	}
+	return fmt.Sprintf("chat.user.%s.request.user.%s.chatlist.section.reorder", account, siteID)
+}
+
+func UserChatlistSectionReorderPattern(siteID string) string {
+	return fmt.Sprintf("chat.user.{account}.request.user.%s.chatlist.section.reorder", siteID)
+}
+
+// UserChatlistSectionSetSortMode sets one section's sortMode (custom|mostRecent).
+func UserChatlistSectionSetSortMode(account, siteID string) string {
+	if !isValidAccountToken(account) {
+		panic("invalid account token: contains NATS wildcard characters")
+	}
+	return fmt.Sprintf("chat.user.%s.request.user.%s.chatlist.section.setsortmode", account, siteID)
+}
+
+func UserChatlistSectionSetSortModePattern(siteID string) string {
+	return fmt.Sprintf("chat.user.{account}.request.user.%s.chatlist.section.setsortmode", siteID)
 }
 
 // UserThreadList is the concrete client-facing subject for the cross-site thread

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -2250,6 +2250,7 @@ func (h *Handler) moveChat(c *natsrouter.Context, req model.MoveChatRequest) (*m
 	now := time.Now().UTC()
 
 	var order float64
+	var rebalanced []model.Subscription
 	if req.SectionID != nil {
 		var needRebalance bool
 		var err error
@@ -2258,7 +2259,7 @@ func (h *Handler) moveChat(c *natsrouter.Context, req model.MoveChatRequest) (*m
 			return nil, fmt.Errorf("compute section order: %w", err)
 		}
 		if needRebalance {
-			if err := h.store.RebalanceSection(ctx, account, *req.SectionID); err != nil {
+			if rebalanced, err = h.store.RebalanceSection(ctx, account, *req.SectionID, now); err != nil {
 				return nil, fmt.Errorf("rebalance section: %w", err)
 			}
 			if order, _, err = h.store.ComputeSectionOrder(ctx, account, *req.SectionID, req.AfterRoomID, req.BeforeRoomID); err != nil {
@@ -2275,28 +2276,73 @@ func (h *Handler) moveChat(c *natsrouter.Context, req model.MoveChatRequest) (*m
 		return nil, fmt.Errorf("move subscription section: %w", err)
 	}
 
-	if _, err := h.publishSubscriptionUpdate(ctx, account, "section_moved", sub, "", now); err != nil {
-		return nil, err
-	}
-
 	userSiteID, err := h.store.GetUserSiteID(ctx, account)
 	if err != nil {
 		return nil, fmt.Errorf("get user siteId: %w", err)
 	}
-	if userSiteID != "" && userSiteID != h.siteID {
-		payload := model.SubscriptionSectionMovedEvent{
-			Account:      account,
-			RoomID:       roomID,
-			SectionID:    sub.SectionId,
-			SectionOrder: sub.SectionOrder,
-			Timestamp:    now.UnixMilli(),
+
+	if len(rebalanced) > 0 {
+		// RebalanceSection ran before the final MoveSubscriptionSection write, so
+		// the moved room's entry in rebalanced (if present — it's only a member of
+		// the rebalanced section pre-move when moving within the same section)
+		// still carries its intermediate integer order. Overwrite it with sub, the
+		// authoritative post-move row; if it's not present (moved in from a
+		// different section), append it so the move itself still gets published.
+		moved := false
+		for i := range rebalanced {
+			if rebalanced[i].RoomID == roomID {
+				rebalanced[i] = *sub
+				moved = true
+				break
+			}
 		}
-		payloadData, err := json.Marshal(payload)
-		if err != nil {
-			return nil, fmt.Errorf("marshal section-moved payload: %w", err)
+		if !moved {
+			rebalanced = append(rebalanced, *sub)
 		}
-		if err := h.federateOne(ctx, roomID, userSiteID, model.InboxSubscriptionSectionMoved, payloadData, roomID+":"+account, now.UnixMilli()); err != nil {
-			return nil, fmt.Errorf("federate section-moved: %w", err)
+		// A rebalance renumbered every sibling in the section, not just the moved
+		// chat — fan out one section_moved event per rewritten row (the moved row
+		// is already in this set) instead of the single-row publish below.
+		for i := range rebalanced {
+			row := &rebalanced[i]
+			if _, err := h.publishSubscriptionUpdate(ctx, account, "section_moved", row, "", now); err != nil {
+				return nil, err
+			}
+			if userSiteID != "" && userSiteID != h.siteID {
+				payload := model.SubscriptionSectionMovedEvent{
+					Account:      account,
+					RoomID:       row.RoomID,
+					SectionID:    row.SectionId,
+					SectionOrder: row.SectionOrder,
+					Timestamp:    now.UnixMilli(),
+				}
+				payloadData, err := json.Marshal(payload)
+				if err != nil {
+					return nil, fmt.Errorf("marshal section-moved payload: %w", err)
+				}
+				if err := h.federateOne(ctx, row.RoomID, userSiteID, model.InboxSubscriptionSectionMoved, payloadData, row.RoomID+":"+account, now.UnixMilli()); err != nil {
+					return nil, fmt.Errorf("federate section-moved: %w", err)
+				}
+			}
+		}
+	} else {
+		if _, err := h.publishSubscriptionUpdate(ctx, account, "section_moved", sub, "", now); err != nil {
+			return nil, err
+		}
+		if userSiteID != "" && userSiteID != h.siteID {
+			payload := model.SubscriptionSectionMovedEvent{
+				Account:      account,
+				RoomID:       roomID,
+				SectionID:    sub.SectionId,
+				SectionOrder: sub.SectionOrder,
+				Timestamp:    now.UnixMilli(),
+			}
+			payloadData, err := json.Marshal(payload)
+			if err != nil {
+				return nil, fmt.Errorf("marshal section-moved payload: %w", err)
+			}
+			if err := h.federateOne(ctx, roomID, userSiteID, model.InboxSubscriptionSectionMoved, payloadData, roomID+":"+account, now.UnixMilli()); err != nil {
+				return nil, fmt.Errorf("federate section-moved: %w", err)
+			}
 		}
 	}
 

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -103,6 +103,7 @@ func NewHandler(store RoomStore, keyStore RoomKeyStore, memberListClient MemberL
 func (h *Handler) Register(r *natsrouter.Router) {
 	natsrouter.RegisterNoBody(r, subject.MuteTogglePattern(h.siteID), h.muteToggle)
 	natsrouter.RegisterNoBody(r, subject.FavoriteTogglePattern(h.siteID), h.favoriteToggle)
+	natsrouter.Register(r, subject.MoveChatPattern(h.siteID), h.moveChat)
 	natsrouter.RegisterNoBody(r, subject.OpenRoomPattern(h.siteID), h.openRoom)
 	natsrouter.RegisterNoBody(r, subject.RoomAppTabsPattern(h.siteID), h.getRoomAppTabs)
 	natsrouter.RegisterNoBody(r, subject.RoomAppCmdMenuPattern(h.siteID), h.getRoomAppCommandMenu)
@@ -2215,6 +2216,91 @@ func (h *Handler) favoriteToggle(c *natsrouter.Context) (*model.FavoriteToggleRe
 	}
 
 	return &model.FavoriteToggleResponse{Status: "ok", Favorite: sub.Favorite}, nil
+}
+
+// moveChat assigns a chat to a chatlist section (+ manual order) or removes it
+// (sectionId == nil). Membership lives on the subscription, mirroring
+// favorite.toggle: one sub write + one subscription-update fanout + one cross-site
+// federation event, HWM-guarded by sectionUpdatedAt. Built-in section ids are
+// rejected — their membership is derived client-side (the migration-only "teams"
+// stamp is written directly at the sub-create, not via this RPC).
+func (h *Handler) moveChat(c *natsrouter.Context, req model.MoveChatRequest) (*model.MoveChatResponse, error) { //nolint:gocritic // hugeParam: req is passed by value to satisfy the natsrouter.Register handler signature
+	var ctx context.Context = c
+	account := c.Param("account")
+	roomID := c.Param("roomID")
+
+	if req.SectionID != nil {
+		if *req.SectionID == "" {
+			return nil, errcode.BadRequest("sectionId is empty", errcode.WithReason(errcode.UserChatlistSectionNotFound))
+		}
+		if model.IsBuiltinSection(*req.SectionID) {
+			// static built-in check only. A custom section's *existence*
+			// is not verified here (that would couple room-service to the
+			// user-service registry on every move) — orphan tolerance renders an
+			// unknown sectionId under Chats client-side.
+			return nil, errcode.BadRequest("cannot move a chat into a built-in section", errcode.WithReason(errcode.UserChatlistBuiltinTarget))
+		}
+		if req.AfterRoomID != "" && req.BeforeRoomID != "" {
+			return nil, errcode.BadRequest("afterRoomId and beforeRoomId are mutually exclusive")
+		}
+	}
+
+	// One instant shared by the origin write and the published event so remote
+	// replicas guard against the same high-water mark.
+	now := time.Now().UTC()
+
+	var order float64
+	if req.SectionID != nil {
+		var needRebalance bool
+		var err error
+		order, needRebalance, err = h.store.ComputeSectionOrder(ctx, account, *req.SectionID, req.AfterRoomID, req.BeforeRoomID)
+		if err != nil {
+			return nil, fmt.Errorf("compute section order: %w", err)
+		}
+		if needRebalance {
+			if err := h.store.RebalanceSection(ctx, account, *req.SectionID); err != nil {
+				return nil, fmt.Errorf("rebalance section: %w", err)
+			}
+			if order, _, err = h.store.ComputeSectionOrder(ctx, account, *req.SectionID, req.AfterRoomID, req.BeforeRoomID); err != nil {
+				return nil, fmt.Errorf("recompute section order: %w", err)
+			}
+		}
+	}
+
+	sub, err := h.store.MoveSubscriptionSection(ctx, roomID, account, req.SectionID, order, now)
+	if err != nil {
+		if errors.Is(err, model.ErrSubscriptionNotFound) {
+			return nil, errNotRoomMember
+		}
+		return nil, fmt.Errorf("move subscription section: %w", err)
+	}
+
+	if _, err := h.publishSubscriptionUpdate(ctx, account, "section_moved", sub, "", now); err != nil {
+		return nil, err
+	}
+
+	userSiteID, err := h.store.GetUserSiteID(ctx, account)
+	if err != nil {
+		return nil, fmt.Errorf("get user siteId: %w", err)
+	}
+	if userSiteID != "" && userSiteID != h.siteID {
+		payload := model.SubscriptionSectionMovedEvent{
+			Account:      account,
+			RoomID:       roomID,
+			SectionID:    sub.SectionId,
+			SectionOrder: sub.SectionOrder,
+			Timestamp:    now.UnixMilli(),
+		}
+		payloadData, err := json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("marshal section-moved payload: %w", err)
+		}
+		if err := h.federateOne(ctx, roomID, userSiteID, model.InboxSubscriptionSectionMoved, payloadData, roomID+":"+account, now.UnixMilli()); err != nil {
+			return nil, fmt.Errorf("federate section-moved: %w", err)
+		}
+	}
+
+	return &model.MoveChatResponse{Status: "ok", SectionID: sub.SectionId, SectionOrder: sub.SectionOrder}, nil
 }
 
 func (h *Handler) openRoom(c *natsrouter.Context) (*model.OpenRoomResponse, error) {

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -30,6 +30,10 @@ import (
 // (e.g. model.Room.CrossSite) in test literals.
 func ptrBool(b bool) *bool { return &b }
 
+// strPtr returns a pointer to s, for constructing *string fields
+// (e.g. model.Subscription.SectionId) in test literals.
+func strPtr(s string) *string { return &s }
+
 // expectAllAccountsExist registers a FindExistingAccounts expectation that
 // echoes its input back — i.e. "every account being asked about exists".
 // Used by every add-member / create-channel happy-path test that doesn't
@@ -5986,6 +5990,87 @@ func TestHandler_FavoriteToggle_CorePublishFailureIsNonFatal(t *testing.T) {
 
 	assert.Equal(t, "ok", resp.Status)
 	assert.True(t, resp.Favorite)
+}
+
+// TestHandler_MoveChat_Rebalance_PublishesAndFederatesAllRows covers the
+// needRebalance path: RebalanceSection renumbers every sibling in the
+// section, so moveChat must fan out one section_moved subscription.update
+// (+ cross-site federation event) per rewritten row, not just the moved one.
+func TestHandler_MoveChat_Rebalance_PublishesAndFederatesAllRows(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockRoomStore(ctrl)
+
+	store.EXPECT().
+		ComputeSectionOrder(gomock.Any(), "alice", "sec1", "", "").
+		Return(0.0, true, nil) // needRebalance
+
+	var rebalanceNow time.Time
+	store.EXPECT().
+		RebalanceSection(gomock.Any(), "alice", "sec1", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ string, now time.Time) ([]model.Subscription, error) {
+			rebalanceNow = now
+			ts := now
+			return []model.Subscription{
+				{User: model.SubscriptionUser{ID: "u-sib", Account: "alice"}, RoomID: "sibling", SiteID: "site-a", SectionId: strPtr("sec1"), SectionOrder: 1, SectionUpdatedAt: &ts},
+				{User: model.SubscriptionUser{ID: "u1", Account: "alice"}, RoomID: "r1", SiteID: "site-a", SectionId: strPtr("sec1"), SectionOrder: 2, SectionUpdatedAt: &ts},
+			}, nil
+		})
+	store.EXPECT().
+		ComputeSectionOrder(gomock.Any(), "alice", "sec1", "", "").
+		Return(3.0, false, nil) // recompute after rebalance
+
+	store.EXPECT().
+		MoveSubscriptionSection(gomock.Any(), "r1", "alice", gomock.Any(), 3.0, gomock.Any()).
+		Return(&model.Subscription{User: model.SubscriptionUser{ID: "u1", Account: "alice"}, RoomID: "r1", SiteID: "site-a", SectionId: strPtr("sec1"), SectionOrder: 3}, nil)
+	store.EXPECT().
+		GetUserSiteID(gomock.Any(), "alice").
+		Return("site-b", nil) // cross-site → federates
+
+	var coreBodies [][]byte
+	var streamSubjects []string
+	var streamBodies [][]byte
+	h := &Handler{
+		store: store, siteID: "site-a",
+		publishCore: func(_ context.Context, _ string, data []byte) error {
+			coreBodies = append(coreBodies, data)
+			return nil
+		},
+		publishToStream: func(_ context.Context, subj string, data []byte, _ string) error {
+			streamSubjects = append(streamSubjects, subj)
+			streamBodies = append(streamBodies, data)
+			return nil
+		},
+	}
+
+	sectionID := "sec1"
+	resp, err := h.moveChat(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.MoveChatRequest{SectionID: &sectionID})
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp.Status)
+	assert.Equal(t, 3.0, resp.SectionOrder)
+	assert.False(t, rebalanceNow.IsZero())
+
+	// One local publish + one federation event per rewritten row (sibling + the
+	// moved chat itself, with its FINAL order — not the rebalance's intermediate one).
+	require.Len(t, coreBodies, 2)
+	require.Len(t, streamSubjects, 2)
+
+	gotRooms := map[string]float64{}
+	for _, body := range coreBodies {
+		var evt model.SubscriptionUpdateEvent
+		require.NoError(t, json.Unmarshal(body, &evt))
+		assert.Equal(t, "section_moved", evt.Action)
+		gotRooms[evt.Subscription.RoomID] = evt.Subscription.SectionOrder
+	}
+	assert.Equal(t, map[string]float64{"sibling": 1, "r1": 3}, gotRooms, "moved chat's row must carry its final post-move order, not the rebalance intermediate")
+
+	for i, subj := range streamSubjects {
+		assert.Equal(t, subject.Outbox("site-a", "site-b", model.InboxSubscriptionSectionMoved), subj)
+		var fed model.OutboxEvent
+		require.NoError(t, json.Unmarshal(streamBodies[i], &fed))
+		var inboxEnv model.InboxEvent
+		require.NoError(t, json.Unmarshal(fed.Envelope, &inboxEnv))
+		assert.Equal(t, model.InboxSubscriptionSectionMoved, inboxEnv.Type)
+	}
 }
 
 func TestHandler_OpenRoom_Success(t *testing.T) {

--- a/room-service/mock_store_test.go
+++ b/room-service/mock_store_test.go
@@ -99,6 +99,22 @@ func (mr *MockRoomStoreMockRecorder) ClearThreadSubscriptionsForAccount(ctx, acc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearThreadSubscriptionsForAccount", reflect.TypeOf((*MockRoomStore)(nil).ClearThreadSubscriptionsForAccount), ctx, account, now)
 }
 
+// ComputeSectionOrder mocks base method.
+func (m *MockRoomStore) ComputeSectionOrder(ctx context.Context, account, sectionID, afterRoomID, beforeRoomID string) (float64, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ComputeSectionOrder", ctx, account, sectionID, afterRoomID, beforeRoomID)
+	ret0, _ := ret[0].(float64)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ComputeSectionOrder indicates an expected call of ComputeSectionOrder.
+func (mr *MockRoomStoreMockRecorder) ComputeSectionOrder(ctx, account, sectionID, afterRoomID, beforeRoomID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComputeSectionOrder", reflect.TypeOf((*MockRoomStore)(nil).ComputeSectionOrder), ctx, account, sectionID, afterRoomID, beforeRoomID)
+}
+
 // CountMembersAndOwners mocks base method.
 func (m *MockRoomStore) CountMembersAndOwners(ctx context.Context, roomID string) (*RoomCounts, error) {
 	m.ctrl.T.Helper()
@@ -549,6 +565,21 @@ func (mr *MockRoomStoreMockRecorder) MinThreadSubscriptionLastSeenByThreadRoomID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MinThreadSubscriptionLastSeenByThreadRoomID", reflect.TypeOf((*MockRoomStore)(nil).MinThreadSubscriptionLastSeenByThreadRoomID), ctx, threadRoomID)
 }
 
+// MoveSubscriptionSection mocks base method.
+func (m *MockRoomStore) MoveSubscriptionSection(ctx context.Context, roomID, account string, sectionID *string, order float64, sectionUpdatedAt time.Time) (*model.Subscription, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MoveSubscriptionSection", ctx, roomID, account, sectionID, order, sectionUpdatedAt)
+	ret0, _ := ret[0].(*model.Subscription)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MoveSubscriptionSection indicates an expected call of MoveSubscriptionSection.
+func (mr *MockRoomStoreMockRecorder) MoveSubscriptionSection(ctx, roomID, account, sectionID, order, sectionUpdatedAt any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveSubscriptionSection", reflect.TypeOf((*MockRoomStore)(nil).MoveSubscriptionSection), ctx, roomID, account, sectionID, order, sectionUpdatedAt)
+}
+
 // OpenSubscription mocks base method.
 func (m *MockRoomStore) OpenSubscription(ctx context.Context, roomID, account string) (*model.Subscription, error) {
 	m.ctrl.T.Helper()
@@ -562,6 +593,20 @@ func (m *MockRoomStore) OpenSubscription(ctx context.Context, roomID, account st
 func (mr *MockRoomStoreMockRecorder) OpenSubscription(ctx, roomID, account any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenSubscription", reflect.TypeOf((*MockRoomStore)(nil).OpenSubscription), ctx, roomID, account)
+}
+
+// RebalanceSection mocks base method.
+func (m *MockRoomStore) RebalanceSection(ctx context.Context, account, sectionID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RebalanceSection", ctx, account, sectionID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RebalanceSection indicates an expected call of RebalanceSection.
+func (mr *MockRoomStoreMockRecorder) RebalanceSection(ctx, account, sectionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RebalanceSection", reflect.TypeOf((*MockRoomStore)(nil).RebalanceSection), ctx, account, sectionID)
 }
 
 // SetOwnerRole mocks base method.

--- a/room-service/mock_store_test.go
+++ b/room-service/mock_store_test.go
@@ -596,17 +596,18 @@ func (mr *MockRoomStoreMockRecorder) OpenSubscription(ctx, roomID, account any) 
 }
 
 // RebalanceSection mocks base method.
-func (m *MockRoomStore) RebalanceSection(ctx context.Context, account, sectionID string) error {
+func (m *MockRoomStore) RebalanceSection(ctx context.Context, account, sectionID string, now time.Time) ([]model.Subscription, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RebalanceSection", ctx, account, sectionID)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "RebalanceSection", ctx, account, sectionID, now)
+	ret0, _ := ret[0].([]model.Subscription)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // RebalanceSection indicates an expected call of RebalanceSection.
-func (mr *MockRoomStoreMockRecorder) RebalanceSection(ctx, account, sectionID any) *gomock.Call {
+func (mr *MockRoomStoreMockRecorder) RebalanceSection(ctx, account, sectionID, now any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RebalanceSection", reflect.TypeOf((*MockRoomStore)(nil).RebalanceSection), ctx, account, sectionID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RebalanceSection", reflect.TypeOf((*MockRoomStore)(nil).RebalanceSection), ctx, account, sectionID, now)
 }
 
 // SetOwnerRole mocks base method.

--- a/room-service/store.go
+++ b/room-service/store.go
@@ -136,6 +136,20 @@ type RoomStore interface {
 	// federated event publishes (inbox-worker guards remote applies against it).
 	// Returns the post-flip subscription, or model.ErrSubscriptionNotFound (wrapped) when no match.
 	ToggleSubscriptionFavorite(ctx context.Context, roomID, account string, favoriteUpdatedAt time.Time) (*model.Subscription, error)
+	// MoveSubscriptionSection sets sectionId+sectionOrder (or clears both when
+	// sectionID==nil, a remove) on (roomID, account), stamping sectionUpdatedAt as
+	// the high-water mark the federated event carries. Returns the post-write
+	// subscription, or model.ErrSubscriptionNotFound (wrapped) when no match.
+	MoveSubscriptionSection(ctx context.Context, roomID, account string, sectionID *string, order float64, sectionUpdatedAt time.Time) (*model.Subscription, error)
+	// ComputeSectionOrder returns the fractional sectionOrder for placing (account's)
+	// chat within sectionID: just after afterRoomID, just before beforeRoomID (for
+	// top-insertion), or appended (max+1) when both are empty. after/before are
+	// mutually exclusive (the caller rejects both set).
+	// needRebalance flags float-precision exhaustion so the caller re-spaces first.
+	ComputeSectionOrder(ctx context.Context, account, sectionID, afterRoomID, beforeRoomID string) (order float64, needRebalance bool, err error)
+	// RebalanceSection re-spaces every (account) sub in sectionID to 1,2,3,… by
+	// current sectionOrder, restoring gap room. Bounded to one section; rare.
+	RebalanceSection(ctx context.Context, account, sectionID string) error
 	// OpenSubscription atomically sets open=true for (roomID, account) via a single
 	// FindOneAndUpdate and returns the post-update subscription, or
 	// model.ErrSubscriptionNotFound (wrapped) when no match.

--- a/room-service/store.go
+++ b/room-service/store.go
@@ -149,7 +149,10 @@ type RoomStore interface {
 	ComputeSectionOrder(ctx context.Context, account, sectionID, afterRoomID, beforeRoomID string) (order float64, needRebalance bool, err error)
 	// RebalanceSection re-spaces every (account) sub in sectionID to 1,2,3,… by
 	// current sectionOrder, restoring gap room. Bounded to one section; rare.
-	RebalanceSection(ctx context.Context, account, sectionID string) error
+	// Returns every rewritten subscription (full post-rebalance doc, sectionUpdatedAt
+	// stamped to now) so the caller can fan out one event per row — a rebalance
+	// silently renumbers siblings the client and remote sites must also learn about.
+	RebalanceSection(ctx context.Context, account, sectionID string, now time.Time) ([]model.Subscription, error)
 	// OpenSubscription atomically sets open=true for (roomID, account) via a single
 	// FindOneAndUpdate and returns the post-update subscription, or
 	// model.ErrSubscriptionNotFound (wrapped) when no match.

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -1094,6 +1094,161 @@ func (s *MongoStore) ToggleSubscriptionFavorite(ctx context.Context, roomID, acc
 	})
 }
 
+// MoveSubscriptionSection sets sectionId+sectionOrder (sectionID != nil) or clears
+// both (sectionID == nil, a remove) on one subscription, stamping sectionUpdatedAt
+// as the high-water mark. Classic update (not the $set pipeline) so a remove can
+// $unset. Returns the post-write sub or model.ErrSubscriptionNotFound (wrapped).
+func (s *MongoStore) MoveSubscriptionSection(ctx context.Context, roomID, account string, sectionID *string, order float64, sectionUpdatedAt time.Time) (*model.Subscription, error) {
+	var update bson.M
+	if sectionID == nil {
+		update = bson.M{
+			"$set":   bson.M{"sectionUpdatedAt": sectionUpdatedAt},
+			"$unset": bson.M{"sectionId": "", "sectionOrder": ""},
+		}
+	} else {
+		update = bson.M{"$set": bson.M{
+			"sectionId":        *sectionID,
+			"sectionOrder":     order,
+			"sectionUpdatedAt": sectionUpdatedAt,
+		}}
+	}
+	opts := options.FindOneAndUpdate().SetReturnDocument(options.After)
+	var result model.Subscription
+	err := s.subscriptions.FindOneAndUpdate(ctx, bson.M{"roomId": roomID, "u.account": account}, update, opts).Decode(&result)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, fmt.Errorf("move section for %q in room %q: %w", account, roomID, model.ErrSubscriptionNotFound)
+		}
+		return nil, fmt.Errorf("move section for %q in room %q: %w", account, roomID, err)
+	}
+	return &result, nil
+}
+
+// ComputeSectionOrder midpoints a new position within (account, sectionID). Two
+// small indexed reads in the placed case (the afterRoomID sub, then the next
+// higher order); one in the append case (the section max).
+func (s *MongoStore) ComputeSectionOrder(ctx context.Context, account, sectionID, afterRoomID, beforeRoomID string) (float64, bool, error) {
+	secFilter := bson.M{"u.account": account, "sectionId": sectionID}
+	if beforeRoomID != "" {
+		// Place just before beforeRoomID (top-insertion) — mirror of the after
+		// case. Next = beforeRoomID's order; Prev = the largest order strictly
+		// less than it. Stale ref → append; no prev (it's the head) → next-1.
+		var before model.Subscription
+		err := s.subscriptions.FindOne(ctx, bson.M{"roomId": beforeRoomID, "u.account": account, "sectionId": sectionID}).Decode(&before)
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			max, mErr := s.sectionOrderExtreme(ctx, secFilter, -1)
+			if mErr != nil {
+				return 0, false, mErr
+			}
+			return max + 1, false, nil
+		}
+		if err != nil {
+			return 0, false, fmt.Errorf("lookup beforeRoomID order: %w", err)
+		}
+		next := before.SectionOrder
+		prevFilter := bson.M{"u.account": account, "sectionId": sectionID, "sectionOrder": bson.M{"$lt": next}}
+		var prev model.Subscription
+		err = s.subscriptions.FindOne(ctx, prevFilter, options.FindOne().SetSort(bson.D{{Key: "sectionOrder", Value: -1}})).Decode(&prev)
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return next - 1, false, nil // head
+		}
+		if err != nil {
+			return 0, false, fmt.Errorf("lookup prev order: %w", err)
+		}
+		mid, exhausted := sectionMidpoint(prev.SectionOrder, next)
+		return mid, exhausted, nil
+	}
+	if afterRoomID == "" {
+		max, err := s.sectionOrderExtreme(ctx, secFilter, -1)
+		if err != nil {
+			return 0, false, err
+		}
+		return max + 1, false, nil
+	}
+	// Prev = afterRoomID's own order. If it isn't in this section (stale client),
+	// fall back to append rather than midpoint against nothing.
+	var after model.Subscription
+	err := s.subscriptions.FindOne(ctx, bson.M{"roomId": afterRoomID, "u.account": account, "sectionId": sectionID}).Decode(&after)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		max, mErr := s.sectionOrderExtreme(ctx, secFilter, -1)
+		if mErr != nil {
+			return 0, false, mErr
+		}
+		return max + 1, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("lookup afterRoomID order: %w", err)
+	}
+	prev := after.SectionOrder
+	// Next = the smallest order strictly greater than prev in the section.
+	nextFilter := bson.M{"u.account": account, "sectionId": sectionID, "sectionOrder": bson.M{"$gt": prev}}
+	var next model.Subscription
+	err = s.subscriptions.FindOne(ctx, nextFilter, options.FindOne().SetSort(bson.D{{Key: "sectionOrder", Value: 1}})).Decode(&next)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return prev + 1, false, nil // tail
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("lookup next order: %w", err)
+	}
+	mid, exhausted := sectionMidpoint(prev, next.SectionOrder)
+	return mid, exhausted, nil
+}
+
+// sectionMidpoint returns the value strictly between prev and next, flagging
+// exhausted when float precision has collapsed the gap (mid landed on a neighbor)
+// so the caller rebalances first. Pure — the unit-tested core of the order math.
+func sectionMidpoint(prev, next float64) (float64, bool) {
+	mid := (prev + next) / 2
+	return mid, mid <= prev || mid >= next
+}
+
+// sectionOrderExtreme returns the min (dir=1) or max (dir=-1) sectionOrder in the
+// filtered section, or 0 when the section is empty.
+func (s *MongoStore) sectionOrderExtreme(ctx context.Context, filter bson.M, dir int) (float64, error) {
+	var sub model.Subscription
+	err := s.subscriptions.FindOne(ctx, filter, options.FindOne().SetSort(bson.D{{Key: "sectionOrder", Value: dir}})).Decode(&sub)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("section order extreme: %w", err)
+	}
+	return sub.SectionOrder, nil
+}
+
+// RebalanceSection re-spaces every (account) sub in sectionID to 1,2,3,… by
+// current order. Bounded to one section, run only when a gap exhausts float
+// precision. O(section-size) load + bulk write; a section rarely gets
+// large enough to matter, and it happens only on the precision edge.
+func (s *MongoStore) RebalanceSection(ctx context.Context, account, sectionID string) error {
+	cur, err := s.subscriptions.Find(ctx,
+		bson.M{"u.account": account, "sectionId": sectionID},
+		options.Find().SetSort(bson.D{{Key: "sectionOrder", Value: 1}}).SetProjection(bson.M{"roomId": 1}),
+	)
+	if err != nil {
+		return fmt.Errorf("rebalance load section: %w", err)
+	}
+	var subs []struct {
+		RoomID string `bson:"roomId"`
+	}
+	if err := cur.All(ctx, &subs); err != nil {
+		return fmt.Errorf("rebalance decode section: %w", err)
+	}
+	if len(subs) == 0 {
+		return nil
+	}
+	models := make([]mongo.WriteModel, 0, len(subs))
+	for i, sub := range subs {
+		models = append(models, mongo.NewUpdateOneModel().
+			SetFilter(bson.M{"roomId": sub.RoomID, "u.account": account}).
+			SetUpdate(bson.M{"$set": bson.M{"sectionOrder": float64(i + 1)}}))
+	}
+	if _, err := s.subscriptions.BulkWrite(ctx, models, options.BulkWrite().SetOrdered(false)); err != nil {
+		return fmt.Errorf("rebalance bulk write: %w", err)
+	}
+	return nil
+}
+
 // OpenSubscription sets open=true. Set-not-toggle: no ordering guard is needed
 // because applying true repeatedly or out of order always converges to true.
 func (s *MongoStore) OpenSubscription(ctx context.Context, roomID, account string) (*model.Subscription, error) {

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -1134,7 +1134,8 @@ func (s *MongoStore) ComputeSectionOrder(ctx context.Context, account, sectionID
 		// case. Next = beforeRoomID's order; Prev = the largest order strictly
 		// less than it. Stale ref → append; no prev (it's the head) → next-1.
 		var before model.Subscription
-		err := s.subscriptions.FindOne(ctx, bson.M{"roomId": beforeRoomID, "u.account": account, "sectionId": sectionID}).Decode(&before)
+		err := s.subscriptions.FindOne(ctx, bson.M{"roomId": beforeRoomID, "u.account": account, "sectionId": sectionID},
+			options.FindOne().SetProjection(bson.M{"roomId": 1, "sectionOrder": 1})).Decode(&before)
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			max, mErr := s.sectionOrderExtreme(ctx, secFilter, -1)
 			if mErr != nil {
@@ -1148,7 +1149,7 @@ func (s *MongoStore) ComputeSectionOrder(ctx context.Context, account, sectionID
 		next := before.SectionOrder
 		prevFilter := bson.M{"u.account": account, "sectionId": sectionID, "sectionOrder": bson.M{"$lt": next}}
 		var prev model.Subscription
-		err = s.subscriptions.FindOne(ctx, prevFilter, options.FindOne().SetSort(bson.D{{Key: "sectionOrder", Value: -1}})).Decode(&prev)
+		err = s.subscriptions.FindOne(ctx, prevFilter, options.FindOne().SetSort(bson.D{{Key: "sectionOrder", Value: -1}}).SetProjection(bson.M{"sectionOrder": 1})).Decode(&prev)
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return next - 1, false, nil // head
 		}
@@ -1168,7 +1169,8 @@ func (s *MongoStore) ComputeSectionOrder(ctx context.Context, account, sectionID
 	// Prev = afterRoomID's own order. If it isn't in this section (stale client),
 	// fall back to append rather than midpoint against nothing.
 	var after model.Subscription
-	err := s.subscriptions.FindOne(ctx, bson.M{"roomId": afterRoomID, "u.account": account, "sectionId": sectionID}).Decode(&after)
+	err := s.subscriptions.FindOne(ctx, bson.M{"roomId": afterRoomID, "u.account": account, "sectionId": sectionID},
+		options.FindOne().SetProjection(bson.M{"roomId": 1, "sectionOrder": 1})).Decode(&after)
 	if errors.Is(err, mongo.ErrNoDocuments) {
 		max, mErr := s.sectionOrderExtreme(ctx, secFilter, -1)
 		if mErr != nil {
@@ -1183,7 +1185,7 @@ func (s *MongoStore) ComputeSectionOrder(ctx context.Context, account, sectionID
 	// Next = the smallest order strictly greater than prev in the section.
 	nextFilter := bson.M{"u.account": account, "sectionId": sectionID, "sectionOrder": bson.M{"$gt": prev}}
 	var next model.Subscription
-	err = s.subscriptions.FindOne(ctx, nextFilter, options.FindOne().SetSort(bson.D{{Key: "sectionOrder", Value: 1}})).Decode(&next)
+	err = s.subscriptions.FindOne(ctx, nextFilter, options.FindOne().SetSort(bson.D{{Key: "sectionOrder", Value: 1}}).SetProjection(bson.M{"sectionOrder": 1})).Decode(&next)
 	if errors.Is(err, mongo.ErrNoDocuments) {
 		return prev + 1, false, nil // tail
 	}
@@ -1206,7 +1208,7 @@ func sectionMidpoint(prev, next float64) (float64, bool) {
 // filtered section, or 0 when the section is empty.
 func (s *MongoStore) sectionOrderExtreme(ctx context.Context, filter bson.M, dir int) (float64, error) {
 	var sub model.Subscription
-	err := s.subscriptions.FindOne(ctx, filter, options.FindOne().SetSort(bson.D{{Key: "sectionOrder", Value: dir}})).Decode(&sub)
+	err := s.subscriptions.FindOne(ctx, filter, options.FindOne().SetSort(bson.D{{Key: "sectionOrder", Value: dir}}).SetProjection(bson.M{"sectionOrder": 1})).Decode(&sub)
 	if errors.Is(err, mongo.ErrNoDocuments) {
 		return 0, nil
 	}
@@ -1220,33 +1222,36 @@ func (s *MongoStore) sectionOrderExtreme(ctx context.Context, filter bson.M, dir
 // current order. Bounded to one section, run only when a gap exhausts float
 // precision. O(section-size) load + bulk write; a section rarely gets
 // large enough to matter, and it happens only on the precision edge.
-func (s *MongoStore) RebalanceSection(ctx context.Context, account, sectionID string) error {
+// Returns the full post-rebalance doc for every rewritten row (sectionUpdatedAt
+// stamped to now) so the caller can fan those out — every sibling's order
+// changed, not just the one being moved.
+func (s *MongoStore) RebalanceSection(ctx context.Context, account, sectionID string, now time.Time) ([]model.Subscription, error) {
 	cur, err := s.subscriptions.Find(ctx,
 		bson.M{"u.account": account, "sectionId": sectionID},
-		options.Find().SetSort(bson.D{{Key: "sectionOrder", Value: 1}}).SetProjection(bson.M{"roomId": 1}),
+		options.Find().SetSort(bson.D{{Key: "sectionOrder", Value: 1}}),
 	)
 	if err != nil {
-		return fmt.Errorf("rebalance load section: %w", err)
+		return nil, fmt.Errorf("rebalance load section: %w", err)
 	}
-	var subs []struct {
-		RoomID string `bson:"roomId"`
-	}
+	var subs []model.Subscription
 	if err := cur.All(ctx, &subs); err != nil {
-		return fmt.Errorf("rebalance decode section: %w", err)
+		return nil, fmt.Errorf("rebalance decode section: %w", err)
 	}
 	if len(subs) == 0 {
-		return nil
+		return nil, nil
 	}
 	models := make([]mongo.WriteModel, 0, len(subs))
-	for i, sub := range subs {
+	for i := range subs {
+		subs[i].SectionOrder = float64(i + 1)
+		subs[i].SectionUpdatedAt = &now
 		models = append(models, mongo.NewUpdateOneModel().
-			SetFilter(bson.M{"roomId": sub.RoomID, "u.account": account}).
-			SetUpdate(bson.M{"$set": bson.M{"sectionOrder": float64(i + 1)}}))
+			SetFilter(bson.M{"roomId": subs[i].RoomID, "u.account": account}).
+			SetUpdate(bson.M{"$set": bson.M{"sectionOrder": subs[i].SectionOrder, "sectionUpdatedAt": now}}))
 	}
 	if _, err := s.subscriptions.BulkWrite(ctx, models, options.BulkWrite().SetOrdered(false)); err != nil {
-		return fmt.Errorf("rebalance bulk write: %w", err)
+		return nil, fmt.Errorf("rebalance bulk write: %w", err)
 	}
-	return nil
+	return subs, nil
 }
 
 // OpenSubscription sets open=true. Set-not-toggle: no ordering guard is needed

--- a/room-service/store_section_order_test.go
+++ b/room-service/store_section_order_test.go
@@ -1,0 +1,28 @@
+package main
+
+import "testing"
+
+func TestSectionMidpoint(t *testing.T) {
+	cases := []struct {
+		name          string
+		prev, next    float64
+		wantExhausted bool
+	}{
+		{"wide gap", 1, 2, false},
+		{"integer gap", 4, 8, false},
+		{"tight but ok", 1, 1.0000001, false},
+		{"exhausted equal neighbors", 5, 5, true},
+		{"exhausted adjacent floats", 1, 1 + 1e-17, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mid, exhausted := sectionMidpoint(tc.prev, tc.next)
+			if exhausted != tc.wantExhausted {
+				t.Fatalf("exhausted = %v, want %v (mid=%v)", exhausted, tc.wantExhausted, mid)
+			}
+			if !exhausted && (mid <= tc.prev || mid >= tc.next) {
+				t.Fatalf("mid %v not strictly between %v and %v", mid, tc.prev, tc.next)
+			}
+		})
+	}
+}

--- a/room-service/store_section_order_test.go
+++ b/room-service/store_section_order_test.go
@@ -1,8 +1,13 @@
 package main
 
-import "testing"
+import (
+	"testing"
 
-func TestSectionMidpoint(t *testing.T) {
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreSectionOrder_SectionMidpoint(t *testing.T) {
 	cases := []struct {
 		name          string
 		prev, next    float64
@@ -17,11 +22,10 @@ func TestSectionMidpoint(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mid, exhausted := sectionMidpoint(tc.prev, tc.next)
-			if exhausted != tc.wantExhausted {
-				t.Fatalf("exhausted = %v, want %v (mid=%v)", exhausted, tc.wantExhausted, mid)
-			}
-			if !exhausted && (mid <= tc.prev || mid >= tc.next) {
-				t.Fatalf("mid %v not strictly between %v and %v", mid, tc.prev, tc.next)
+			require.Equal(t, tc.wantExhausted, exhausted, "mid=%v", mid)
+			if !exhausted {
+				assert.Greater(t, mid, tc.prev)
+				assert.Less(t, mid, tc.next)
 			}
 		})
 	}

--- a/room-worker/teamsroomcreate.go
+++ b/room-worker/teamsroomcreate.go
@@ -95,7 +95,8 @@ func (h *Handler) reconcileTeamsRoom(ctx context.Context, chat *model.TeamsRoomC
 	wantAccounts := make(map[string]struct{}, len(chat.Members))
 	memberSite := make(map[string]string, len(chat.Members)) // account -> home site, for federation
 	var newSubs []*model.Subscription
-	var addedUsers []model.User // for the room-key fan-out
+	var addedUsers []model.User        // for the room-key fan-out
+	teamsSection := model.SectionTeams // addressable built-in section id for every migrated sub
 
 	for _, member := range chat.Members {
 		if member.Account == "" {
@@ -124,6 +125,9 @@ func (h *Handler) reconcileTeamsRoom(ctx context.Context, chat *model.TeamsRoomC
 		}
 		sub := newSub(idgen.GenerateUUIDv7(), user, room, roles, room.Name, false, acceptedAt)
 		sub.Origin = model.OriginTeams
+		// Land every migrated chat in the built-in "Teams" section by default; the
+		// user re-organizes from there. No section import, no extra write.
+		sub.SectionId = &teamsSection
 		if !member.VisibleHistoryStartDateTime.IsZero() {
 			t := member.VisibleHistoryStartDateTime.UTC()
 			sub.HistorySharedSince = &t

--- a/user-service/models/chatlist.go
+++ b/user-service/models/chatlist.go
@@ -1,0 +1,35 @@
+package models
+
+// Request bodies for the chatlist section-definition RPCs. Each handler returns
+// the full post-update model.ChatlistState. Membership/order is NOT here — that
+// rides the room-service moveChat RPC onto the subscription.
+
+// ChatlistSectionCreateRequest creates a custom section. SortMode is optional
+// (defaults to custom); built-in ids and derived membership are never client-sent.
+type ChatlistSectionCreateRequest struct {
+	Name     string `json:"name"`
+	SortMode string `json:"sortMode,omitempty"`
+}
+
+// ChatlistSectionDeleteRequest removes a custom section by id.
+type ChatlistSectionDeleteRequest struct {
+	SectionID string `json:"sectionId"`
+}
+
+// ChatlistSectionRenameRequest renames a custom section.
+type ChatlistSectionRenameRequest struct {
+	SectionID string `json:"sectionId"`
+	Name      string `json:"name"`
+}
+
+// ChatlistSectionReorderRequest replaces the section display order; SectionOrder
+// must be a permutation of every current section id (built-in + custom).
+type ChatlistSectionReorderRequest struct {
+	SectionOrder []string `json:"sectionOrder"`
+}
+
+// ChatlistSectionSetSortModeRequest sets one section's sortMode (custom|mostRecent).
+type ChatlistSectionSetSortModeRequest struct {
+	SectionID string `json:"sectionId"`
+	SortMode  string `json:"sortMode"`
+}

--- a/user-service/mongorepo/users.go
+++ b/user-service/mongorepo/users.go
@@ -152,6 +152,40 @@ func (r *UserRepo) UpdateUserSettings(ctx context.Context, account string, set *
 	return &u, nil
 }
 
+// GetUserChatlist returns the user's stored chatlist sub-document (Chatlist is nil
+// when never customized); (nil, nil) when no active user matched.
+func (r *UserRepo) GetUserChatlist(ctx context.Context, account string) (*model.User, error) {
+	return r.users.FindOne(ctx, activeUserFilter(account),
+		mongoutil.WithProjection(bson.M{"_id": 0, "chatlist": 1}),
+	)
+}
+
+// UpdateUserChatlist $sets the whole chatlist sub-document (validated + applied in
+// the service layer, so the origin write is a whole-object replace) and returns the
+// updated user (Chatlist projected) in one round-trip; (nil, nil) when no active
+// user matched.
+func (r *UserRepo) UpdateUserChatlist(ctx context.Context, account string, state *model.ChatlistState) (*model.User, error) {
+	opts := options.FindOneAndUpdate().
+		SetReturnDocument(options.After).
+		SetProjection(bson.M{"_id": 0, "chatlist": 1})
+	// Stamp the top-level chatlistUpdatedAt (= state.LastUpdatedAt, the one the
+	// service shares with both fanouts) so the cross-site high-water guard sees a
+	// local edit; without it an older inbound event could regress local state.
+	res := r.users.Raw().FindOneAndUpdate(ctx, activeUserFilter(account),
+		bson.M{"$set": bson.M{"chatlist": state, "chatlistUpdatedAt": state.LastUpdatedAt}}, opts)
+	if err := res.Err(); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("update user chatlist: %w", err)
+	}
+	var u model.User
+	if err := res.Decode(&u); err != nil {
+		return nil, fmt.Errorf("decode updated user chatlist: %w", err)
+	}
+	return &u, nil
+}
+
 // SetUserStatus updates status fields (isShow only written when non-nil) and
 // returns the updated user in one round-trip via FindOneAndUpdate(After),
 // projected to the UserStatusView fields; returns (nil, nil) when no active user matched.

--- a/user-service/service/chatlist.go
+++ b/user-service/service/chatlist.go
@@ -1,0 +1,320 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/idgen"
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/natsrouter"
+	"github.com/hmchangw/chat/pkg/natsutil"
+	"github.com/hmchangw/chat/pkg/subject"
+	"github.com/hmchangw/chat/user-service/models"
+)
+
+// sectionNameAllowedPunct is the non-alphanumeric punctuation a section name may
+// contain, beyond letters/digits (any script) and single spaces.
+const sectionNameAllowedPunct = "-_./()"
+
+// GetChatlist returns the caller's stored section definitions, or the built-in
+// default when the user has never customized it.
+func (s *UserService) GetChatlist(c *natsrouter.Context) (*model.ChatlistState, error) {
+	account := c.Param("account")
+	c.WithLogValues("account", account)
+	u, err := s.users.GetUserChatlist(c, account)
+	if err != nil {
+		return nil, fmt.Errorf("get chatlist: %w", err)
+	}
+	if u == nil {
+		return nil, errcode.NotFound("user not found")
+	}
+	if u.Chatlist == nil {
+		return model.DefaultChatlistState(), nil
+	}
+	return u.Chatlist, nil
+}
+
+// CreateChatlistSection adds a custom section (name validated + unique), placing
+// it directly above the built-in "chats" section.
+func (s *UserService) CreateChatlistSection(c *natsrouter.Context, req models.ChatlistSectionCreateRequest) (*model.ChatlistState, error) {
+	account := c.Param("account")
+	c.WithLogValues("account", account)
+	name := strings.TrimSpace(req.Name)
+	if err := validateSectionName(name); err != nil {
+		return nil, err
+	}
+	sortMode := req.SortMode
+	if sortMode == "" {
+		sortMode = model.SortModeCustom
+	}
+	if err := validateSortMode(sortMode); err != nil {
+		return nil, err
+	}
+	return s.mutateChatlist(c, account, func(st *model.ChatlistState) error {
+		if hasCustomName(st, name, "") {
+			return errcode.Conflict("section name already exists", errcode.WithReason(errcode.UserChatlistDuplicateName))
+		}
+		id := idgen.GenerateUUIDv7()
+		st.Sections = append(st.Sections, model.ChatlistSection{
+			ID: id, Name: name, BuiltIn: false, SortMode: sortMode,
+		})
+		insertAboveChats(st, id)
+		return nil
+	})
+}
+
+// DeleteChatlistSection removes a custom section; chats in it fall back to their
+// derived built-in placement (orphan-tolerant — no membership cascade).
+func (s *UserService) DeleteChatlistSection(c *natsrouter.Context, req models.ChatlistSectionDeleteRequest) (*model.ChatlistState, error) {
+	account := c.Param("account")
+	c.WithLogValues("account", account)
+	return s.mutateChatlist(c, account, func(st *model.ChatlistState) error {
+		sec := findSection(st, req.SectionID)
+		if sec == nil {
+			return errcode.NotFound("section not found", errcode.WithReason(errcode.UserChatlistSectionNotFound))
+		}
+		if sec.BuiltIn {
+			return errcode.BadRequest("built-in sections cannot be removed", errcode.WithReason(errcode.UserChatlistBuiltinImmutable))
+		}
+		removeSection(st, req.SectionID)
+		return nil
+	})
+}
+
+// RenameChatlistSection renames a custom section (new name validated + unique).
+func (s *UserService) RenameChatlistSection(c *natsrouter.Context, req models.ChatlistSectionRenameRequest) (*model.ChatlistState, error) {
+	account := c.Param("account")
+	c.WithLogValues("account", account)
+	name := strings.TrimSpace(req.Name)
+	if err := validateSectionName(name); err != nil {
+		return nil, err
+	}
+	return s.mutateChatlist(c, account, func(st *model.ChatlistState) error {
+		sec := findSection(st, req.SectionID)
+		if sec == nil {
+			return errcode.NotFound("section not found", errcode.WithReason(errcode.UserChatlistSectionNotFound))
+		}
+		if sec.BuiltIn {
+			return errcode.BadRequest("built-in sections cannot be renamed", errcode.WithReason(errcode.UserChatlistBuiltinImmutable))
+		}
+		if hasCustomName(st, name, req.SectionID) {
+			return errcode.Conflict("section name already exists", errcode.WithReason(errcode.UserChatlistDuplicateName))
+		}
+		sec.Name = name
+		return nil
+	})
+}
+
+// ReorderChatlistSections replaces the section display order. The request must be
+// a permutation of every current section id (built-in + custom).
+func (s *UserService) ReorderChatlistSections(c *natsrouter.Context, req models.ChatlistSectionReorderRequest) (*model.ChatlistState, error) {
+	account := c.Param("account")
+	c.WithLogValues("account", account)
+	return s.mutateChatlist(c, account, func(st *model.ChatlistState) error {
+		if !isPermutation(st.SectionOrder, req.SectionOrder) {
+			return errcode.BadRequest("sectionOrder must list every section exactly once", errcode.WithReason(errcode.UserChatlistInvalidOrder))
+		}
+		st.SectionOrder = req.SectionOrder
+		return nil
+	})
+}
+
+// SetChatlistSectionSortMode sets one section's sortMode (custom|mostRecent).
+// Works on any section — a built-in can be flipped to custom so the client sorts
+// it by subscription.sectionOrder; only membership is off-limits on built-ins.
+func (s *UserService) SetChatlistSectionSortMode(c *natsrouter.Context, req models.ChatlistSectionSetSortModeRequest) (*model.ChatlistState, error) {
+	account := c.Param("account")
+	c.WithLogValues("account", account)
+	if err := validateSortMode(req.SortMode); err != nil {
+		return nil, err
+	}
+	return s.mutateChatlist(c, account, func(st *model.ChatlistState) error {
+		sec := findSection(st, req.SectionID)
+		if sec == nil {
+			return errcode.NotFound("section not found", errcode.WithReason(errcode.UserChatlistSectionNotFound))
+		}
+		sec.SortMode = req.SortMode
+		return nil
+	})
+}
+
+// mutateChatlist reads the caller's chatlist (default when never set), applies
+// apply (which validates + mutates), persists the whole object, and fans the full
+// post-update state out to the caller's other devices and other sites.
+// read-modify-write is whole-object last-write-wins — matches the
+// cross-site replica semantics; two concurrent same-user device edits race (rare).
+// Add an optimistic version guard if that ever bites.
+func (s *UserService) mutateChatlist(c *natsrouter.Context, account string, apply func(*model.ChatlistState) error) (*model.ChatlistState, error) {
+	u, err := s.users.GetUserChatlist(c, account)
+	if err != nil {
+		return nil, fmt.Errorf("get chatlist: %w", err)
+	}
+	if u == nil {
+		return nil, errcode.NotFound("user not found")
+	}
+	state := u.Chatlist
+	if state == nil {
+		state = model.DefaultChatlistState()
+	}
+	if err := apply(state); err != nil {
+		return nil, err
+	}
+	// One timestamp for the stored HWM and both fanouts so the client event and the
+	// cross-site replica agree on ordering.
+	now := time.Now().UTC().UnixMilli()
+	state.LastUpdatedAt = now
+	updated, err := s.users.UpdateUserChatlist(c, account, state)
+	if err != nil {
+		return nil, fmt.Errorf("update chatlist: %w", err)
+	}
+	if updated == nil {
+		return nil, errcode.NotFound("user not found")
+	}
+	result := updated.Chatlist
+	if result == nil {
+		result = state // unreachable after a $set of the whole object
+	}
+	s.publishChatlistUpdate(c, account, result, now)
+	s.publishChatlistInbox(c, account, result, now)
+	return result, nil
+}
+
+// publishChatlistUpdate fans the per-user chatlist.update event over core NATS
+// (ephemeral client delivery, like settings.update); best-effort.
+func (s *UserService) publishChatlistUpdate(c *natsrouter.Context, account string, state *model.ChatlistState, now int64) {
+	data, _ := json.Marshal(model.ChatlistUpdateEvent{Timestamp: now, Chatlist: *state}) // string fields only — Marshal cannot fail
+	if err := s.clientPub.Publish(c, subject.ChatlistUpdate(account), data); err != nil {
+		slog.WarnContext(c, "publish chatlist update event", "error", err, "account", account, "request_id", natsutil.RequestIDFromContext(c))
+	}
+}
+
+// publishChatlistInbox replicates the full post-update state to every other site's
+// external INBOX lane, HWM-guarded on the replica side. Mirrors
+// publishSettingsInbox; errors logged.
+func (s *UserService) publishChatlistInbox(c *natsrouter.Context, account string, state *model.ChatlistState, now int64) {
+	payload, _ := json.Marshal(model.UserChatlistUpdated{Account: account, Chatlist: *state, Timestamp: now}) // string fields only — Marshal cannot fail
+	for _, dest := range s.allSiteIDs {
+		if dest == "" || dest == s.siteID {
+			continue
+		}
+		evt := model.InboxEvent{
+			Type:       model.InboxUserChatlistUpdated,
+			SiteID:     s.siteID,
+			DestSiteID: dest,
+			Payload:    payload,
+			Timestamp:  now,
+		}
+		data, err := json.Marshal(evt)
+		if err != nil {
+			slog.WarnContext(c, "marshal chatlist inbox event", "error", err, "site", s.siteID, "dest", dest, "account", account, "request_id", natsutil.RequestIDFromContext(c))
+			continue
+		}
+		if err := s.pub.Publish(c, subject.InboxExternal(dest, model.InboxUserChatlistUpdated), data); err != nil {
+			// Non-fatal: whole-object last-write-wins, the next mutation re-broadcasts.
+			slog.WarnContext(c, "publish chatlist inbox event", "error", err, "site", s.siteID, "dest", dest, "account", account, "request_id", natsutil.RequestIDFromContext(c))
+		}
+	}
+}
+
+// validateSectionName enforces: 1–50 runes (after the caller trims), no
+// consecutive spaces, and only letters/digits (any script), spaces, or -_./()
+func validateSectionName(name string) error {
+	n := utf8.RuneCountInString(name)
+	if n < 1 || n > model.MaxSectionName {
+		return errcode.BadRequest("section name must be 1-50 characters", errcode.WithReason(errcode.UserChatlistInvalidName))
+	}
+	if strings.Contains(name, "  ") {
+		return errcode.BadRequest("section name has consecutive spaces", errcode.WithReason(errcode.UserChatlistInvalidName))
+	}
+	for _, r := range name {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) || r == ' ' || strings.ContainsRune(sectionNameAllowedPunct, r) {
+			continue
+		}
+		return errcode.BadRequest("section name has a disallowed character", errcode.WithReason(errcode.UserChatlistInvalidName))
+	}
+	return nil
+}
+
+// validateSortMode rejects anything but the custom|mostRecent enum.
+func validateSortMode(mode string) error {
+	if mode != model.SortModeCustom && mode != model.SortModeMostRecent {
+		return errcode.BadRequest("invalid sortMode", errcode.WithReason(errcode.UserChatlistInvalidSortMode))
+	}
+	return nil
+}
+
+// findSection returns a pointer to the section with id (mutable), or nil.
+func findSection(st *model.ChatlistState, id string) *model.ChatlistSection {
+	for i := range st.Sections {
+		if st.Sections[i].ID == id {
+			return &st.Sections[i]
+		}
+	}
+	return nil
+}
+
+// hasCustomName reports whether a custom section other than excludeID already uses
+// name (case-sensitive).
+func hasCustomName(st *model.ChatlistState, name, excludeID string) bool {
+	for i := range st.Sections {
+		sec := &st.Sections[i]
+		if !sec.BuiltIn && sec.ID != excludeID && sec.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// insertAboveChats places id immediately before the built-in "chats" section in
+// SectionOrder (appends if "chats" is somehow absent).
+func insertAboveChats(st *model.ChatlistState, id string) {
+	for i, sid := range st.SectionOrder {
+		if sid == model.SectionChats {
+			st.SectionOrder = append(st.SectionOrder[:i:i], append([]string{id}, st.SectionOrder[i:]...)...)
+			return
+		}
+	}
+	st.SectionOrder = append(st.SectionOrder, id)
+}
+
+// removeSection drops the section from both Sections and SectionOrder.
+func removeSection(st *model.ChatlistState, id string) {
+	secs := st.Sections[:0]
+	for _, sec := range st.Sections {
+		if sec.ID != id {
+			secs = append(secs, sec)
+		}
+	}
+	st.Sections = secs
+	order := st.SectionOrder[:0]
+	for _, sid := range st.SectionOrder {
+		if sid != id {
+			order = append(order, sid)
+		}
+	}
+	st.SectionOrder = order
+}
+
+// isPermutation reports whether want lists exactly the ids in have, once each.
+func isPermutation(have, want []string) bool {
+	if len(have) != len(want) {
+		return false
+	}
+	counts := make(map[string]int, len(have))
+	for _, id := range have {
+		counts[id]++
+	}
+	for _, id := range want {
+		if counts[id] == 0 {
+			return false
+		}
+		counts[id]--
+	}
+	return true
+}

--- a/user-service/service/chatlist_test.go
+++ b/user-service/service/chatlist_test.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/model"
+)
+
+func TestValidateSectionName(t *testing.T) {
+	ok := []string{"Work", "團隊", "a-b_c.d/(e)", "A B", repeat("x", 50)}
+	for _, n := range ok {
+		if err := validateSectionName(n); err != nil {
+			t.Errorf("validateSectionName(%q) = %v, want nil", n, err)
+		}
+	}
+	bad := []string{"", repeat("x", 51), "a  b", "bad!", "no@sign", "semi;colon"}
+	for _, n := range bad {
+		if err := validateSectionName(n); err == nil {
+			t.Errorf("validateSectionName(%q) = nil, want error", n)
+		} else if !errcode.HasReason(err, errcode.UserChatlistInvalidName) {
+			t.Errorf("validateSectionName(%q) reason mismatch: %v", n, err)
+		}
+	}
+}
+
+func TestValidateSortMode(t *testing.T) {
+	if err := validateSortMode(model.SortModeCustom); err != nil {
+		t.Errorf("custom rejected: %v", err)
+	}
+	if err := validateSortMode(model.SortModeMostRecent); err != nil {
+		t.Errorf("mostRecent rejected: %v", err)
+	}
+	if err := validateSortMode("weird"); err == nil {
+		t.Error("weird accepted, want error")
+	}
+}
+
+func TestIsPermutation(t *testing.T) {
+	if !isPermutation([]string{"a", "b", "c"}, []string{"c", "a", "b"}) {
+		t.Error("valid permutation rejected")
+	}
+	if isPermutation([]string{"a", "b"}, []string{"a", "a"}) {
+		t.Error("dup accepted as permutation")
+	}
+	if isPermutation([]string{"a", "b"}, []string{"a"}) {
+		t.Error("short list accepted as permutation")
+	}
+}
+
+func TestInsertAboveChatsAndRemove(t *testing.T) {
+	st := model.DefaultChatlistState()
+	insertAboveChats(st, "sec-1")
+	// sec-1 must land immediately before "chats".
+	idx := indexOf(st.SectionOrder, "sec-1")
+	if idx < 0 || st.SectionOrder[idx+1] != model.SectionChats {
+		t.Fatalf("sec-1 not above chats: %v", st.SectionOrder)
+	}
+	st.Sections = append(st.Sections, model.ChatlistSection{ID: "sec-1", Name: "S1"})
+	removeSection(st, "sec-1")
+	if indexOf(st.SectionOrder, "sec-1") >= 0 || findSection(st, "sec-1") != nil {
+		t.Fatalf("sec-1 not removed: %v", st.SectionOrder)
+	}
+}
+
+func TestHasCustomName(t *testing.T) {
+	st := &model.ChatlistState{Sections: []model.ChatlistSection{
+		{ID: "b1", Name: "Chats", BuiltIn: true},
+		{ID: "c1", Name: "Work", BuiltIn: false},
+	}}
+	if !hasCustomName(st, "Work", "") {
+		t.Error("existing custom name not detected")
+	}
+	if hasCustomName(st, "Work", "c1") {
+		t.Error("self-exclusion failed on rename")
+	}
+	if hasCustomName(st, "work", "") {
+		t.Error("name match should be case-sensitive")
+	}
+	if hasCustomName(st, "Chats", "") {
+		t.Error("built-in name should not collide with custom uniqueness")
+	}
+}
+
+func repeat(r string, n int) string {
+	out := ""
+	for i := 0; i < n; i++ {
+		out += r
+	}
+	return out
+}
+
+func indexOf(s []string, v string) int {
+	for i, x := range s {
+		if x == v {
+			return i
+		}
+	}
+	return -1
+}

--- a/user-service/service/mocks/mock_repository.go
+++ b/user-service/service/mocks/mock_repository.go
@@ -202,6 +202,21 @@ func (mr *MockUserRepositoryMockRecorder) GetHRInfoByAccounts(ctx, accounts any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHRInfoByAccounts", reflect.TypeOf((*MockUserRepository)(nil).GetHRInfoByAccounts), ctx, accounts)
 }
 
+// GetUserChatlist mocks base method.
+func (m *MockUserRepository) GetUserChatlist(ctx context.Context, account string) (*model.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserChatlist", ctx, account)
+	ret0, _ := ret[0].(*model.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserChatlist indicates an expected call of GetUserChatlist.
+func (mr *MockUserRepositoryMockRecorder) GetUserChatlist(ctx, account any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserChatlist", reflect.TypeOf((*MockUserRepository)(nil).GetUserChatlist), ctx, account)
+}
+
 // GetUserSettings mocks base method.
 func (m *MockUserRepository) GetUserSettings(ctx context.Context, account string) (*model.User, error) {
 	m.ctrl.T.Helper()
@@ -245,6 +260,21 @@ func (m *MockUserRepository) SetUserStatus(ctx context.Context, account, text st
 func (mr *MockUserRepositoryMockRecorder) SetUserStatus(ctx, account, text, isShow any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUserStatus", reflect.TypeOf((*MockUserRepository)(nil).SetUserStatus), ctx, account, text, isShow)
+}
+
+// UpdateUserChatlist mocks base method.
+func (m *MockUserRepository) UpdateUserChatlist(ctx context.Context, account string, state *model.ChatlistState) (*model.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateUserChatlist", ctx, account, state)
+	ret0, _ := ret[0].(*model.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateUserChatlist indicates an expected call of UpdateUserChatlist.
+func (mr *MockUserRepositoryMockRecorder) UpdateUserChatlist(ctx, account, state any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserChatlist", reflect.TypeOf((*MockUserRepository)(nil).UpdateUserChatlist), ctx, account, state)
 }
 
 // UpdateUserSettings mocks base method.

--- a/user-service/service/service.go
+++ b/user-service/service/service.go
@@ -34,6 +34,8 @@ type UserRepository interface {
 	GetHRInfoByAccounts(ctx context.Context, accounts []string) (map[string]*model.SubscriptionHRInfo, error)
 	GetUserSettings(ctx context.Context, account string) (*model.User, error)
 	UpdateUserSettings(ctx context.Context, account string, set *model.UserSettings) (*model.User, error)
+	GetUserChatlist(ctx context.Context, account string) (*model.User, error)
+	UpdateUserChatlist(ctx context.Context, account string, state *model.ChatlistState) (*model.User, error)
 }
 
 // AppRepository is the consumer-defined interface for app catalog reads.
@@ -156,6 +158,12 @@ func (s *UserService) RegisterHandlers(r *natsrouter.Router) {
 	natsrouter.Register(r, subject.UserStatusSetPattern(s.siteID), s.SetStatus)
 	natsrouter.RegisterNoBody(r, subject.UserSettingsGetPattern(s.siteID), s.GetSettings)
 	natsrouter.Register(r, subject.UserSettingsSetPattern(s.siteID), s.SetSettings)
+	natsrouter.RegisterNoBody(r, subject.UserChatlistGetPattern(s.siteID), s.GetChatlist)
+	natsrouter.Register(r, subject.UserChatlistSectionCreatePattern(s.siteID), s.CreateChatlistSection)
+	natsrouter.Register(r, subject.UserChatlistSectionDeletePattern(s.siteID), s.DeleteChatlistSection)
+	natsrouter.Register(r, subject.UserChatlistSectionRenamePattern(s.siteID), s.RenameChatlistSection)
+	natsrouter.Register(r, subject.UserChatlistSectionReorderPattern(s.siteID), s.ReorderChatlistSections)
+	natsrouter.Register(r, subject.UserChatlistSectionSetSortModePattern(s.siteID), s.SetChatlistSectionSortMode)
 	natsrouter.Register(r, subject.UserSubscriptionListPattern(s.siteID), s.ListSubscriptions)
 	natsrouter.Register(r, subject.UserThreadListPattern(s.siteID), s.ListUserThreads)
 	natsrouter.Register(r, subject.UserThreadUnreadSummaryPattern(s.siteID), s.GetThreadUnreadSummary)


### PR DESCRIPTION
## Summary

Per-user customizable **chatlist sections**: users group their chats into named
sections with manual ordering. A chat's section **membership** and **order** live
on its subscription (`sectionId` / `sectionOrder`) — exactly how `favorite` is
stored — while a small per-user overlay carries the section **definitions** only.
So a membership change is **one** subscription write + **one** cross-site event,
and the definition fan-out stays **O(sections), not O(chats)**.

## What's included

**Subscription-backed membership + order (room-service)**
- `Subscription.SectionId *string` / `SectionOrder float64` / `SectionUpdatedAt *time.Time`.
- `moveChat` RPC: sets `sectionId` + a **fractional** `sectionOrder`. Placement is
  `afterRoomId` (after that room), `beforeRoomId` (before it — top-insertion when
  it's the section head), or append (omit both); the two anchors are mutually
  exclusive. A bounded rebalance re-spaces the section only when float precision is
  exhausted. One call covers assign / reorder-within / move-between / remove
  (`sectionId=null`). Fans out `subscription.update` (`action:"section_moved"`) + a
  cross-site INBOX event, high-water-mark-guarded by `sectionUpdatedAt` — mirrors
  `favorite.toggle`.
- `sectionOrder` is a meaningful `float64` (a top-inserted chat is legitimately `0`),
  so it carries no `omitempty` on the wire — the client always receives the new position.

**Section-definition registry (user-service)**
- `ChatlistState{SectionOrder, Sections, LastUpdatedAt}` + `ChatlistSection{ID, Name,
  BuiltIn, SortMode}` on `User.Chatlist`, with a `chatlistUpdatedAt` HWM.
- RPCs: `chatlist.get`, `section.create` / `rename` / `delete`, `section.reorder`
  (section display order — a full permutation of every section id), `section.setSortMode`
  (`custom` | `mostRecent`).
- Fans out `chatlist.update` + a cross-site INBOX event (mirrors settings); the
  inbox-worker applies `user_chatlist_updated`.

**Built-in "teams" section**: a product constant; the Teams-migration's existing
subscription write also stamps `sub.sectionId="teams"` — no separate import or
reconcile. An unknown `sectionId` renders under the built-in Chats section
(orphan-tolerant).

**Docs** (`client-api.md`, `client-api/events.md`, `client-api/request-reply.md`):
moveChat, the six registry RPCs, the subscription's new fields, and the client
read-model grouping rules.

## NATS subjects

Request-reply:
- `chat.user.{account}.request.room.{roomID}.{siteID}.chat.move`
- `chat.user.{account}.request.user.{siteID}.chatlist.get`
- `chat.user.{account}.request.user.{siteID}.chatlist.section.{create,rename,delete,reorder,setsortmode}`

Events:
- `chat.user.{account}.event.chatlist.update` (section definitions; O(sections))
- `chat.user.{account}.event.subscription.update` — `action:"section_moved"` (per-chat membership/order)

Cross-site INBOX: `subscription_section_moved` (HWM `sectionUpdatedAt`) ·
`user_chatlist_updated` (HWM `chatlistUpdatedAt`).

## Verification

- Unit + integration tests across room-service, user-service, the outbox, and the inbox-worker.
- End-to-end on a live dev stack: every RPC (create / rename / delete / reorder /
  setSortMode / moveChat with after / before / append) plus the `section_moved` and
  `chatlist.update` fan-outs, with the moved subscription's `sectionId` / `sectionOrder`
  confirmed at rest.
- **Cross-site federation** confirmed both ways — a section move on one site applies to
  the subscription on the other under the HWM guard, and section definitions federate
  the same way.
- A full front-end walkthrough of every case (create, rename, reorder, delete →
  orphan-fallback, move in / out, move-to-top, built-in Teams landing, and a live
  cross-tab update with no reload).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable chatlist sections with creation, renaming, deletion, reordering, and sort-mode controls.
  * Added chat movement between sections, custom ordering, and removal from sections.
  * Added synchronization of chatlist and section changes across connected devices and sites.
  * Teams chats are automatically placed in the Teams section.

* **Documentation**
  * Documented chatlist APIs, events, validation rules, and fractional ordering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->