### PR TITLE
chat-frontend: fix persistent [encrypted message] + render the latest message format

### DIFF
--- a/chat-frontend/src/api/auth/oidcClient.js
+++ b/chat-frontend/src/api/auth/oidcClient.js
@@ -73,3 +73,19 @@ export async function renewSsoToken() {
   }
   return user.access_token
 }
+
+/**
+ * Read the current stored SSO access token (no renewal, no redirect). Used to
+ * authenticate protected media HTTP calls (upload / setCookie). Returns null
+ * when there's no OIDC session — e.g. dev-mode login, which has no access
+ * token; those callers must handle the null.
+ */
+export async function getAccessToken() {
+  try {
+    const mgr = getOidcManager()
+    const user = await mgr.getUser()
+    return user?.access_token ?? null
+  } catch {
+    return null
+  }
+}

--- a/chat-frontend/src/api/index.ts
+++ b/chat-frontend/src/api/index.ts
@@ -30,12 +30,14 @@ export { requestRoomKey } from './requestRoomKey'
 export { searchMessages } from './searchMessages'
 export { searchRooms } from './searchRooms'
 export { sendMessage } from './sendMessage'
+export { setMediaCookie } from './setMediaCookie'
 export { subscribeToRoomEvents } from './subscribeToRoomEvents'
 export { subscribeToRoomMetadataUpdates } from './subscribeToRoomMetadataUpdates'
 export { subscribeToRoomKeyEvents } from './subscribeToRoomKeyEvents'
 export { subscribeToSubscriptionUpdates } from './subscribeToSubscriptionUpdates'
 export { subscribeToUserRoomEvents } from './subscribeToUserRoomEvents'
 export { updateMemberRole } from './updateMemberRole'
+export { uploadImage } from './uploadImage'
 
 // Transport-level error utilities that callers legitimately need.
 // `_transport/` stays internal otherwise.

--- a/chat-frontend/src/api/sendMessage/index.ts
+++ b/chat-frontend/src/api/sendMessage/index.ts
@@ -8,6 +8,9 @@ export interface SendMessagePayload {
   quotedParentMessageId?: string
   threadParentMessageId?: string
   threadParentMessageCreatedAt?: number
+  /** Base64-encoded Attachment JSON blobs (see lib/attachment.encodeAttachment).
+   *  Max 1 today; content may be empty when attachments are present. */
+  attachments?: string[]
 }
 
 export interface SendMessageArgs {

--- a/chat-frontend/src/api/setMediaCookie/index.test.ts
+++ b/chat-frontend/src/api/setMediaCookie/index.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setMediaCookie } from './index'
+
+describe('setMediaCookie', () => {
+  beforeEach(() => vi.stubGlobal('fetch', vi.fn()))
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('POSTs the ssoToken to the setCookie endpoint with credentials and resolves true', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: true } as Response)
+    const ok = await setMediaCookie({ baseUrl: 'https://media.test/', ssoToken: 'tok' })
+    expect(ok).toBe(true)
+    const [url, init] = vi.mocked(fetch).mock.calls[0]
+    expect(url).toBe('https://media.test/api/v1/file/setCookie')
+    expect(init?.method).toBe('POST')
+    expect((init?.headers as Record<string, string>).ssoToken).toBe('tok')
+    expect(init?.credentials).toBe('include')
+  })
+
+  it('resolves false (no throw) when inputs are missing or the request fails', async () => {
+    expect(await setMediaCookie({ baseUrl: '', ssoToken: 'tok' })).toBe(false)
+    expect(await setMediaCookie({ baseUrl: 'https://x', ssoToken: '' })).toBe(false)
+    expect(fetch).not.toHaveBeenCalled()
+
+    vi.mocked(fetch).mockRejectedValue(new Error('network'))
+    expect(await setMediaCookie({ baseUrl: 'https://x', ssoToken: 'tok' })).toBe(false)
+  })
+})

--- a/chat-frontend/src/api/setMediaCookie/index.ts
+++ b/chat-frontend/src/api/setMediaCookie/index.ts
@@ -1,0 +1,27 @@
+export interface SetMediaCookieArgs {
+  /** Media gateway origin (NatsContext user.baseUrl). */
+  baseUrl: string
+  /** SSO access token (from getAccessToken). */
+  ssoToken: string
+}
+
+/**
+ * Establish the media download session cookie so header-less `<img>` / `<a>`
+ * requests to the protected file endpoint authenticate. The backend's
+ * setCookie route reads the ssoToken header and issues it back as an ssoToken
+ * cookie. Best-effort: resolves false (never throws) on missing inputs or any
+ * failure — the caller treats it as advisory.
+ */
+export async function setMediaCookie({ baseUrl, ssoToken }: SetMediaCookieArgs): Promise<boolean> {
+  if (!baseUrl || !ssoToken) return false
+  try {
+    const resp = await fetch(`${baseUrl.replace(/\/+$/, '')}/api/v1/file/setCookie`, {
+      method: 'POST',
+      headers: { ssoToken },
+      credentials: 'include',
+    })
+    return resp.ok
+  } catch {
+    return false
+  }
+}

--- a/chat-frontend/src/api/types.ts
+++ b/chat-frontend/src/api/types.ts
@@ -197,8 +197,15 @@ export interface Message {
   sysMsgData?: string
   sender?: Participant
   userAccount?: string
+  /** Server-composed render-ready sender name (engName + chineseName +
+   *  account fallback). Preferred over sender.* for display. */
+  userDisplayName?: string
   mentions?: Participant[]
   quotedParentMessage?: QuotedParentMessage
+  /** RFC3339 pin time; present on pinned messages. */
+  pinnedAt?: string
+  /** The actor who pinned the message. */
+  pinnedBy?: Participant
   threadParentMessageId?: string
   threadParentMessageCreatedAt?: string
   /** Outgoing local-only flag — set by optimistic appenders. Never

--- a/chat-frontend/src/api/types.ts
+++ b/chat-frontend/src/api/types.ts
@@ -147,6 +147,13 @@ export interface Participant {
   siteId?: string
 }
 
+/** One reactor on a message reaction. Mirrors the wire `reactionUser`
+ *  (cassandra.Reactions.MarshalJSON): account + server-composed displayName. */
+export interface ReactionUser {
+  account: string
+  displayName: string
+}
+
 /** Pixel size of an uploaded image. Mirrors cassandra.ImageDimensions. */
 export interface ImageDimensions {
   width: number
@@ -235,6 +242,9 @@ export interface Message {
   mentions?: Participant[]
   /** Decoded attachment objects (image/audio/video/file). */
   attachments?: Attachment[]
+  /** Reactions grouped by shortcode → reactors (server emits map<emoji,
+   *  ReactionUser[]>, sorted oldest-first). */
+  reactions?: Record<string, ReactionUser[]>
   quotedParentMessage?: QuotedParentMessage
   /** RFC3339 pin time; present on pinned messages. */
   pinnedAt?: string

--- a/chat-frontend/src/api/types.ts
+++ b/chat-frontend/src/api/types.ts
@@ -113,6 +113,9 @@ export interface User {
   engName?: string
   chineseName?: string
   employeeId?: string
+  /** Media/API gateway origin (portal baseUrl). Set on connect; used to build
+   *  absolute attachment URLs and authenticate media uploads/downloads. */
+  baseUrl?: string
 }
 
 /** Mirrors model.Room. Timestamps come down as RFC-3339 strings.
@@ -184,6 +187,9 @@ export interface Attachment {
   videoUrl?: string
   videoType?: string
   videoSize?: number
+  /** Client-only: a local object URL for an optimistic just-sent image.
+   *  Never arrives from the server; preferred as the <img> src when present. */
+  localUrl?: string
 }
 
 /** Cassandra's QuotedParentMessage shape — what gets embedded on a

--- a/chat-frontend/src/api/types.ts
+++ b/chat-frontend/src/api/types.ts
@@ -147,6 +147,38 @@ export interface Participant {
   siteId?: string
 }
 
+/** Pixel size of an uploaded image. Mirrors cassandra.ImageDimensions. */
+export interface ImageDimensions {
+  width: number
+  height: number
+}
+
+/** Render-ready descriptor for an uploaded file. Mirrors
+ *  pkg/model/cassandra.Attachment. Media-specific fields are present only for
+ *  the matching MIME family. `titleLink` is a path RELATIVE to the media
+ *  gateway base URL. */
+export interface Attachment {
+  id: string
+  title: string
+  type: string
+  description?: string
+  titleLink: string
+  titleLinkDownload?: boolean
+  fileType?: string
+  imageUrl?: string
+  imageType?: string
+  imageSize?: number
+  imageDimensions?: ImageDimensions
+  /** Base64 32×32 blurred JPEG placeholder (image only). */
+  imagePreview?: string
+  audioUrl?: string
+  audioType?: string
+  audioSize?: number
+  videoUrl?: string
+  videoType?: string
+  videoSize?: number
+}
+
 /** Cassandra's QuotedParentMessage shape — what gets embedded on a
  *  reply's `quotedParentMessage` field. Note the legacy `messageId`
  *  and `msg` field names (server-side cassandra schema, distinct from
@@ -201,6 +233,8 @@ export interface Message {
    *  account fallback). Preferred over sender.* for display. */
   userDisplayName?: string
   mentions?: Participant[]
+  /** Decoded attachment objects (image/audio/video/file). */
+  attachments?: Attachment[]
   quotedParentMessage?: QuotedParentMessage
   /** RFC3339 pin time; present on pinned messages. */
   pinnedAt?: string

--- a/chat-frontend/src/api/uploadImage/index.test.ts
+++ b/chat-frontend/src/api/uploadImage/index.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { uploadImage } from './index'
+
+vi.mock('../auth/oidcClient', () => ({ getAccessToken: vi.fn() }))
+import { getAccessToken } from '../auth/oidcClient'
+
+const nats = { user: { account: 'alice', baseUrl: 'https://media.test' } } as never
+
+describe('uploadImage', () => {
+  beforeEach(() => {
+    vi.mocked(getAccessToken).mockResolvedValue('tok-123')
+    vi.stubGlobal('fetch', vi.fn())
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('POSTs multipart to the upload/file endpoint with the ssoToken header and returns the attachment', async () => {
+    const att = { id: 'f1', title: 'pic.png', type: 'file', titleLink: 'api/v1/file/rooms/r1/file/f1', fileType: 'image/png' }
+    vi.mocked(fetch).mockResolvedValue({ ok: true, json: async () => ({ success: true, attachments: [att] }) } as Response)
+
+    const file = new File([new Uint8Array([1, 2, 3])], 'pic.png', { type: 'image/png' })
+    const out = await uploadImage(nats, { roomId: 'r1', file })
+
+    expect(out).toEqual(att)
+    const [url, init] = vi.mocked(fetch).mock.calls[0]
+    expect(url).toBe('https://media.test/api/v1/file/rooms/r1/upload/file')
+    expect(init?.method).toBe('POST')
+    expect((init?.headers as Record<string, string>).ssoToken).toBe('tok-123')
+    expect(init?.body).toBeInstanceOf(FormData)
+    expect((init?.body as FormData).get('file')).toBe(file)
+  })
+
+  it('throws when there is no access token', async () => {
+    vi.mocked(getAccessToken).mockResolvedValue(null)
+    const file = new File(['x'], 'p.png', { type: 'image/png' })
+    await expect(uploadImage(nats, { roomId: 'r1', file })).rejects.toThrow(/authenticat/i)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('throws when the server rejects the upload', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: false, status: 413 } as Response)
+    const file = new File(['x'], 'p.png', { type: 'image/png' })
+    await expect(uploadImage(nats, { roomId: 'r1', file })).rejects.toThrow(/413/)
+  })
+
+  it('throws when the reply carries no attachment', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: true, json: async () => ({ success: true, attachments: [] }) } as Response)
+    const file = new File(['x'], 'p.png', { type: 'image/png' })
+    await expect(uploadImage(nats, { roomId: 'r1', file })).rejects.toThrow(/no attachment/i)
+  })
+})

--- a/chat-frontend/src/api/uploadImage/index.ts
+++ b/chat-frontend/src/api/uploadImage/index.ts
@@ -1,0 +1,40 @@
+import type { Attachment, Nats } from '../types'
+import { getAccessToken } from '../auth/oidcClient'
+
+export interface UploadImageArgs {
+  roomId: string
+  file: File
+}
+
+interface UploadFileReply {
+  success?: boolean
+  attachments?: Attachment[]
+}
+
+/**
+ * Upload one image for a room and return its render-ready Attachment.
+ *
+ * Uses the protected upload endpoint (`POST {baseUrl}/api/v1/file/rooms/:roomId/
+ * upload/file`), authenticated with the SSO access token in the `ssoToken`
+ * header. The returned Attachment is what the caller base64-encodes into a
+ * `msg.send` `attachments` entry. Rejects if there's no media base URL, no
+ * access token (e.g. dev-mode login), or the server rejects the file.
+ */
+export async function uploadImage({ user }: Nats, { roomId, file }: UploadImageArgs): Promise<Attachment> {
+  const baseUrl = user?.baseUrl
+  if (!baseUrl) throw new Error('no media base URL for upload')
+  const token = await getAccessToken()
+  if (!token) throw new Error('not authenticated for upload')
+
+  const form = new FormData()
+  form.append('file', file)
+
+  const url = `${baseUrl.replace(/\/+$/, '')}/api/v1/file/rooms/${encodeURIComponent(roomId)}/upload/file`
+  const resp = await fetch(url, { method: 'POST', headers: { ssoToken: token }, body: form })
+  if (!resp.ok) throw new Error(`image upload failed: ${resp.status}`)
+
+  const data = (await resp.json()) as UploadFileReply
+  const att = data.attachments?.[0]
+  if (!att) throw new Error('image upload returned no attachment')
+  return att
+}

--- a/chat-frontend/src/components/MainApp/ChatPage/RoomMessageInput/RoomMessageInput.jsx
+++ b/chat-frontend/src/components/MainApp/ChatPage/RoomMessageInput/RoomMessageInput.jsx
@@ -2,7 +2,8 @@ import { useEffect, useRef, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import { useNats } from '@/context/NatsContext'
 import { useRoomDispatch } from '@/context/RoomEventsContext'
-import { sendMessage } from '@/api'
+import { sendMessage, uploadImage } from '@/api'
+import { encodeAttachment } from '@/lib/attachment'
 import { generateMessageID } from '@/lib/idgen'
 import { roomPrefix, roomDisplayName } from '@/lib/roomFormat'
 import MessageInputForm from '@/components/shared/MessageInputForm/MessageInputForm'
@@ -12,35 +13,43 @@ export default function RoomMessageInput({ room, quotedTarget, onClearQuote }) {
   const { user } = nats
   const dispatch = useRoomDispatch()
   const [text, setText] = useState('')
+  // { file, url } — url is a local object URL for the compose-time preview.
+  const [pendingImage, setPendingImage] = useState(null)
+  const [sending, setSending] = useState(false)
   const inputRef = useRef(null)
 
-  // Auto-focus the input when a quote is freshly staged (e.g., user clicked
-  // Reply on a message) so they can start typing immediately without an
-  // extra click. Re-runs whenever the staged target changes id.
   useEffect(() => {
     if (quotedTarget?.id) {
       inputRef.current?.focus()
     }
   }, [quotedTarget?.id])
 
+  // Revoke the preview object URL when it's replaced or the input unmounts.
+  useEffect(() => {
+    const url = pendingImage?.url
+    return () => {
+      if (url) URL.revokeObjectURL(url)
+    }
+  }, [pendingImage?.url])
+
   const placeholder = room
     ? `Message ${roomPrefix(room.type)}${roomDisplayName(room)}`
     : 'Select a room...'
-  const disabled = !room || !user
+  const disabled = !room || !user || sending
 
-  const handleSubmit = () => {
-    if (disabled || !text.trim()) return
-    const id = generateMessageID()
+  const pickImage = (file) => {
+    if (!file || !file.type?.startsWith('image/')) return
+    setPendingImage({ file, url: URL.createObjectURL(file) })
+  }
+  const clearImage = () => setPendingImage(null)
+
+  const handleSubmit = async () => {
     const content = text.trim()
-    const payload = {
-      id,
-      content,
-      requestId: uuidv4(),
-    }
-    // Build an optimistic message that mirrors the server's broadcast shape
-    // (so MessageRow / QuotedBlock render it identically). The snapshot uses
-    // the server-side cassandra.QuotedParentMessage field names (messageId,
-    // sender.engName, msg) so a later broadcast for the same id is a no-op.
+    if (!room || !user || sending) return
+    if (!content && !pendingImage) return
+
+    const id = generateMessageID()
+    const payload = { id, content, requestId: uuidv4() }
     const optimistic = {
       id,
       content,
@@ -56,9 +65,33 @@ export default function RoomMessageInput({ room, quotedTarget, onClearQuote }) {
         msg: quotedTarget.content,
       }
     }
+
+    // Upload the image (if any) BEFORE optimistic insert — we need the server
+    // Attachment to send, and a failed upload must not leave a dangling row.
+    if (pendingImage) {
+      setSending(true)
+      let attachment
+      try {
+        attachment = await uploadImage(nats, { roomId: room.id, file: pendingImage.file })
+      } catch (err) {
+        setSending(false)
+        // eslint-disable-next-line no-console
+        console.warn('image upload failed:', err?.message ?? err)
+        return
+      }
+      setSending(false)
+      payload.attachments = [encodeAttachment(attachment)]
+      // Show the actual image immediately via a local object URL (a fresh one,
+      // owned by the message — the preview URL is revoked when we clear the
+      // composer below). The server echo carries the same Attachment and
+      // renders from the gateway URL.
+      optimistic.attachments = [{ ...attachment, localUrl: URL.createObjectURL(pendingImage.file) }]
+    }
+
     dispatch({ type: 'MESSAGE_SENT_LOCAL', roomId: room.id, message: optimistic })
     sendMessage(nats, { roomId: room.id, siteId: user.siteId, payload })
     setText('')
+    setPendingImage(null) // effect revokes the preview object URL
     onClearQuote?.()
   }
 
@@ -72,6 +105,9 @@ export default function RoomMessageInput({ room, quotedTarget, onClearQuote }) {
       disabled={disabled}
       quotedTarget={quotedTarget}
       onClearQuote={onClearQuote}
+      onPickImage={pickImage}
+      pendingImage={pendingImage ? { name: pendingImage.file.name, url: pendingImage.url } : null}
+      onClearImage={clearImage}
     />
   )
 }

--- a/chat-frontend/src/components/MainApp/ChatPage/RoomMessageInput/RoomMessageInput.test.jsx
+++ b/chat-frontend/src/components/MainApp/ChatPage/RoomMessageInput/RoomMessageInput.test.jsx
@@ -1,22 +1,39 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import RoomMessageInput from './RoomMessageInput'
 
 const publish = vi.fn()
 const dispatch = vi.fn()
 vi.mock('@/context/NatsContext', () => ({
-  useNats: () => ({ user: { account: 'alice', siteId: 's1' }, publish }),
+  useNats: () => ({ user: { account: 'alice', siteId: 's1', baseUrl: 'https://media.test' }, publish }),
 }))
 vi.mock('@/context/RoomEventsContext', () => ({
   useRoomDispatch: () => dispatch,
 }))
 vi.mock('@/lib/idgen', () => ({ generateMessageID: () => '12345678901234567890' }))
 vi.mock('uuid', () => ({ v4: () => 'req-uuid' }))
+// Keep the real sendMessage (→ publish) but stub the HTTP uploadImage.
+vi.mock('@/api', async (orig) => ({ ...(await orig()), uploadImage: vi.fn() }))
+import { uploadImage } from '@/api'
 
 const room = { id: 'r1', name: 'general', type: 'channel' }
 
+function pickFile(container, file) {
+  const fileInput = container.querySelector('input[type="file"]')
+  fireEvent.change(fileInput, { target: { files: [file] } })
+}
+
 describe('RoomMessageInput', () => {
-  beforeEach(() => { publish.mockClear(); dispatch.mockClear() })
+  beforeEach(() => {
+    publish.mockClear()
+    dispatch.mockClear()
+    vi.mocked(uploadImage).mockReset()
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:preview'),
+      revokeObjectURL: vi.fn(),
+    })
+  })
 
   it('renders the form disabled when no room is selected', () => {
     render(<RoomMessageInput room={null} />)
@@ -95,6 +112,39 @@ describe('RoomMessageInput', () => {
         _local: true,
       }),
     }))
+  })
+
+  it('uploads a picked image and sends it as a base64 attachment (empty text allowed)', async () => {
+    const att = { id: 'f1', title: 'p.png', type: 'file', titleLink: 'api/v1/file/rooms/r1/file/f1', fileType: 'image/png' }
+    vi.mocked(uploadImage).mockResolvedValue(att)
+    const { container } = render(<RoomMessageInput room={room} />)
+    pickFile(container, new File(['x'], 'p.png', { type: 'image/png' }))
+    // Preview chip shows the picked image name.
+    expect(await screen.findByText('p.png')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /^Send$/ }))
+
+    await waitFor(() => expect(publish).toHaveBeenCalled())
+    expect(uploadImage).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ roomId: 'r1', file: expect.any(File) }),
+    )
+    const [, payload] = publish.mock.calls[0]
+    expect(payload.attachments).toHaveLength(1)
+    expect(typeof payload.attachments[0]).toBe('string')
+    // Optimistic message carries the attachment with a local preview URL.
+    const optimistic = dispatch.mock.calls.find((c) => c[0]?.type === 'MESSAGE_SENT_LOCAL')[0].message
+    expect(optimistic.attachments[0]).toMatchObject({ id: 'f1', localUrl: expect.any(String) })
+  })
+
+  it('does not send when the image upload fails', async () => {
+    vi.mocked(uploadImage).mockRejectedValue(new Error('413'))
+    const { container } = render(<RoomMessageInput room={room} />)
+    pickFile(container, new File(['x'], 'p.png', { type: 'image/png' }))
+    fireEvent.click(screen.getByRole('button', { name: /^Send$/ }))
+    await waitFor(() => expect(uploadImage).toHaveBeenCalled())
+    expect(publish).not.toHaveBeenCalled()
+    expect(dispatch).not.toHaveBeenCalled()
   })
 
   it('optimistic message carries a server-shaped quotedParentMessage snapshot', () => {

--- a/chat-frontend/src/components/shared/MessageAttachments/MessageAttachments.jsx
+++ b/chat-frontend/src/components/shared/MessageAttachments/MessageAttachments.jsx
@@ -34,9 +34,10 @@ function AttachmentItem({ att, baseUrl }) {
   const preview = att.imagePreview ? `data:image/jpeg;base64,${att.imagePreview}` : undefined
 
   if (kind === 'image') {
-    // Load the full image from the gateway URL when we have a base; if it
-    // fails (auth/network) fall back to the embedded blurred preview so the
-    // attachment always renders something inline. No base at all → preview.
+    // Prefer a local object URL (an optimistic just-sent image) so the sender
+    // sees it instantly; otherwise load from the gateway URL, falling back to
+    // the embedded blurred preview if that fails (auth/network) or is absent.
+    const src = att.localUrl || href || preview
     return (
       <a
         className="attachment attachment-image"
@@ -47,7 +48,7 @@ function AttachmentItem({ att, baseUrl }) {
       >
         <img
           className="attachment-image-img"
-          src={href || preview}
+          src={src}
           alt={att.title || 'image attachment'}
           loading="lazy"
           width={att.imageDimensions?.width || undefined}

--- a/chat-frontend/src/components/shared/MessageAttachments/MessageAttachments.jsx
+++ b/chat-frontend/src/components/shared/MessageAttachments/MessageAttachments.jsx
@@ -1,0 +1,82 @@
+import { attachmentKind, attachmentSize, formatFileSize, mediaUrl } from '@/lib/attachment'
+import './style.css'
+
+const KIND_ICON = { image: '🖼️', audio: '🎵', video: '🎬', file: '📎' }
+const KIND_LABEL = { image: 'Image', audio: 'Audio', video: 'Video', file: 'File' }
+
+/**
+ * Render a message's attachments: images inline (with a blurred-preview
+ * fallback), everything else as a download chip. `baseUrl` is the media gateway
+ * origin; image/download URLs are built from it + the attachment's relative
+ * titleLink. Those URLs hit the protected file endpoint — establishing the
+ * download session (the ssoToken cookie the backend's setCookie route issues
+ * for header-less <img>/<a> requests) is a follow-up; until then the inline
+ * image degrades to the embedded preview on load failure.
+ *
+ * @param {object} props
+ * @param {import('@/api/types').Attachment[]} [props.attachments]
+ * @param {string} [props.baseUrl]
+ */
+export default function MessageAttachments({ attachments, baseUrl }) {
+  if (!attachments?.length) return null
+  return (
+    <div className="message-attachments">
+      {attachments.map((att, i) => (
+        <AttachmentItem key={att.id || i} att={att} baseUrl={baseUrl} />
+      ))}
+    </div>
+  )
+}
+
+function AttachmentItem({ att, baseUrl }) {
+  const kind = attachmentKind(att)
+  const href = mediaUrl(baseUrl, att.titleLink)
+  const preview = att.imagePreview ? `data:image/jpeg;base64,${att.imagePreview}` : undefined
+
+  if (kind === 'image') {
+    // Load the full image from the gateway URL when we have a base; if it
+    // fails (auth/network) fall back to the embedded blurred preview so the
+    // attachment always renders something inline. No base at all → preview.
+    return (
+      <a
+        className="attachment attachment-image"
+        href={href || undefined}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={att.title}
+      >
+        <img
+          className="attachment-image-img"
+          src={href || preview}
+          alt={att.title || 'image attachment'}
+          loading="lazy"
+          width={att.imageDimensions?.width || undefined}
+          height={att.imageDimensions?.height || undefined}
+          onError={(e) => {
+            if (preview && e.currentTarget.src !== preview) e.currentTarget.src = preview
+          }}
+        />
+      </a>
+    )
+  }
+
+  const sizeText = formatFileSize(attachmentSize(att))
+  const sub = [KIND_LABEL[kind], sizeText].filter(Boolean).join(' · ')
+  return (
+    <a
+      className={`attachment attachment-file attachment-${kind}`}
+      href={href || undefined}
+      target="_blank"
+      rel="noopener noreferrer"
+      download={att.title || undefined}
+    >
+      <span className="attachment-icon" aria-hidden="true">
+        {KIND_ICON[kind]}
+      </span>
+      <span className="attachment-meta">
+        <span className="attachment-title">{att.title || 'attachment'}</span>
+        {sub && <span className="attachment-sub">{sub}</span>}
+      </span>
+    </a>
+  )
+}

--- a/chat-frontend/src/components/shared/MessageAttachments/MessageAttachments.test.jsx
+++ b/chat-frontend/src/components/shared/MessageAttachments/MessageAttachments.test.jsx
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import MessageAttachments from './MessageAttachments'
+
+const BASE = 'https://site.example.com'
+
+describe('MessageAttachments', () => {
+  it('renders nothing when there are no attachments', () => {
+    const { container } = render(<MessageAttachments attachments={[]} baseUrl={BASE} />)
+    expect(container.firstChild).toBeNull()
+    const { container: c2 } = render(<MessageAttachments baseUrl={BASE} />)
+    expect(c2.firstChild).toBeNull()
+  })
+
+  it('renders an image attachment as an <img> pointing at the absolute gateway URL', () => {
+    const att = {
+      id: 'f1',
+      title: 'photo.png',
+      type: 'file',
+      titleLink: 'api/v1/file/rooms/r1/file/f1',
+      imageUrl: 'api/v1/file/rooms/r1/file/f1',
+      fileType: 'image/png',
+    }
+    render(<MessageAttachments attachments={[att]} baseUrl={BASE} />)
+    const img = screen.getByRole('img', { name: 'photo.png' })
+    expect(img).toHaveAttribute('src', `${BASE}/api/v1/file/rooms/r1/file/f1`)
+  })
+
+  it('falls back to the base64 imagePreview when no gateway base is available', () => {
+    const att = {
+      id: 'f2',
+      title: 'pic.jpg',
+      type: 'file',
+      titleLink: 'api/v1/file/rooms/r1/file/f2',
+      fileType: 'image/jpeg',
+      imagePreview: 'QUJD',
+    }
+    render(<MessageAttachments attachments={[att]} baseUrl="" />)
+    expect(screen.getByRole('img', { name: 'pic.jpg' })).toHaveAttribute(
+      'src',
+      'data:image/jpeg;base64,QUJD',
+    )
+  })
+
+  it('falls back to the blurred preview when the full image fails to load', () => {
+    const att = {
+      id: 'f5',
+      title: 'photo.png',
+      type: 'file',
+      titleLink: 'api/v1/file/rooms/r1/file/f5',
+      imageUrl: 'api/v1/file/rooms/r1/file/f5',
+      fileType: 'image/png',
+      imagePreview: 'QUJD',
+    }
+    render(<MessageAttachments attachments={[att]} baseUrl={BASE} />)
+    const img = screen.getByRole('img', { name: 'photo.png' })
+    expect(img).toHaveAttribute('src', `${BASE}/api/v1/file/rooms/r1/file/f5`)
+    fireEvent.error(img)
+    expect(img).toHaveAttribute('src', 'data:image/jpeg;base64,QUJD')
+  })
+
+  it('renders a non-image attachment as a download chip with title, size and link', () => {
+    const att = {
+      id: 'f3',
+      title: 'report.pdf',
+      type: 'file',
+      titleLink: 'api/v1/file/rooms/r1/file/f3',
+      fileType: 'application/pdf',
+    }
+    render(<MessageAttachments attachments={[att]} baseUrl={BASE} />)
+    const link = screen.getByRole('link', { name: /report\.pdf/ })
+    expect(link).toHaveAttribute('href', `${BASE}/api/v1/file/rooms/r1/file/f3`)
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(screen.getByText('report.pdf')).toBeInTheDocument()
+  })
+
+  it('shows a human-readable size for a sized file', () => {
+    const att = {
+      id: 'f4',
+      title: 'clip.mp4',
+      type: 'file',
+      titleLink: 'api/v1/file/rooms/r1/file/f4',
+      videoUrl: 'api/v1/file/rooms/r1/file/f4',
+      videoSize: 5 * 1048576,
+      fileType: 'video/mp4',
+    }
+    render(<MessageAttachments attachments={[att]} baseUrl={BASE} />)
+    expect(screen.getByText(/5\.0 MB/)).toBeInTheDocument()
+  })
+})

--- a/chat-frontend/src/components/shared/MessageAttachments/index.jsx
+++ b/chat-frontend/src/components/shared/MessageAttachments/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './MessageAttachments'

--- a/chat-frontend/src/components/shared/MessageAttachments/style.css
+++ b/chat-frontend/src/components/shared/MessageAttachments/style.css
@@ -1,0 +1,61 @@
+.message-attachments {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1, 4px);
+  margin-top: var(--space-1, 4px);
+}
+
+.attachment {
+  text-decoration: none;
+  color: inherit;
+}
+
+.attachment-image {
+  display: inline-block;
+  max-width: 320px;
+}
+
+.attachment-image-img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius-md, 8px);
+  background: var(--bg-muted, rgba(127, 127, 127, 0.12));
+}
+
+.attachment-file {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2, 8px);
+  max-width: 320px;
+  padding: var(--space-2, 8px);
+  border: 1px solid var(--border, rgba(127, 127, 127, 0.3));
+  border-radius: var(--radius-md, 8px);
+  background: var(--bg-surface, transparent);
+}
+
+.attachment-file:hover {
+  background: var(--bg-muted, rgba(127, 127, 127, 0.12));
+}
+
+.attachment-icon {
+  font-size: var(--text-lg, 1.125rem);
+}
+
+.attachment-meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.attachment-title {
+  color: var(--accent);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.attachment-sub {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}

--- a/chat-frontend/src/components/shared/MessageContent/MessageContent.jsx
+++ b/chat-frontend/src/components/shared/MessageContent/MessageContent.jsx
@@ -1,0 +1,50 @@
+import { useMemo } from 'react'
+import { parseMessageContent } from '@/lib/messageContent'
+import './style.css'
+
+/**
+ * Render a message body with inline @mentions and links highlighted.
+ * Plain-text segments render verbatim (React escapes them); newlines are
+ * preserved by the caller's `white-space: pre-wrap`.
+ *
+ * @param {object} props
+ * @param {string} props.content
+ * @param {{ account?: string, engName?: string }[]} [props.mentions]
+ * @param {string} [props.selfAccount] current user's account — self-mentions
+ *   get an extra class so the reader's own name stands out.
+ */
+export default function MessageContent({ content, mentions, selfAccount }) {
+  const segments = useMemo(() => parseMessageContent(content, mentions), [content, mentions])
+  const self = selfAccount ? String(selfAccount).toLowerCase() : null
+
+  return (
+    <>
+      {segments.map((seg, i) => {
+        if (seg.type === 'mention') {
+          const classes = ['mention']
+          if (seg.all) classes.push('mention-all')
+          if (!seg.all && self && seg.account === self) classes.push('mention-self')
+          return (
+            <span key={i} className={classes.join(' ')} data-account={seg.account}>
+              @{seg.display}
+            </span>
+          )
+        }
+        if (seg.type === 'link') {
+          return (
+            <a
+              key={i}
+              className="message-link"
+              href={seg.href}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {seg.text}
+            </a>
+          )
+        }
+        return <span key={i}>{seg.text}</span>
+      })}
+    </>
+  )
+}

--- a/chat-frontend/src/components/shared/MessageContent/MessageContent.jsx
+++ b/chat-frontend/src/components/shared/MessageContent/MessageContent.jsx
@@ -3,9 +3,10 @@ import { parseMessageContent } from '@/lib/messageContent'
 import './style.css'
 
 /**
- * Render a message body with inline @mentions and links highlighted.
- * Plain-text segments render verbatim (React escapes them); newlines are
- * preserved by the caller's `white-space: pre-wrap`.
+ * Render a message body with inline @mentions, links, and a markdown subset
+ * (bold / italic / strikethrough / inline code / fenced code blocks)
+ * highlighted. Plain-text runs render verbatim (React escapes them); newlines
+ * are preserved by the caller's `white-space: pre-wrap`.
  *
  * @param {object} props
  * @param {string} props.content
@@ -14,37 +15,52 @@ import './style.css'
  *   get an extra class so the reader's own name stands out.
  */
 export default function MessageContent({ content, mentions, selfAccount }) {
-  const segments = useMemo(() => parseMessageContent(content, mentions), [content, mentions])
+  const nodes = useMemo(() => parseMessageContent(content, mentions), [content, mentions])
   const self = selfAccount ? String(selfAccount).toLowerCase() : null
+  return <>{renderNodes(nodes, self)}</>
+}
 
-  return (
-    <>
-      {segments.map((seg, i) => {
-        if (seg.type === 'mention') {
-          const classes = ['mention']
-          if (seg.all) classes.push('mention-all')
-          if (!seg.all && self && seg.account === self) classes.push('mention-self')
-          return (
-            <span key={i} className={classes.join(' ')} data-account={seg.account}>
-              @{seg.display}
-            </span>
-          )
-        }
-        if (seg.type === 'link') {
-          return (
-            <a
-              key={i}
-              className="message-link"
-              href={seg.href}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {seg.text}
-            </a>
-          )
-        }
-        return <span key={i}>{seg.text}</span>
-      })}
-    </>
-  )
+function renderNodes(nodes, self, keyPrefix = '') {
+  return nodes.map((node, i) => renderNode(node, `${keyPrefix}${i}`, self))
+}
+
+function renderNode(node, key, self) {
+  switch (node.type) {
+    case 'mention': {
+      const classes = ['mention']
+      if (node.all) classes.push('mention-all')
+      if (!node.all && self && node.account === self) classes.push('mention-self')
+      return (
+        <span key={key} className={classes.join(' ')} data-account={node.account}>
+          @{node.display}
+        </span>
+      )
+    }
+    case 'link':
+      return (
+        <a key={key} className="message-link" href={node.href} target="_blank" rel="noopener noreferrer">
+          {node.text}
+        </a>
+      )
+    case 'code':
+      return (
+        <code key={key} className="message-code">
+          {node.text}
+        </code>
+      )
+    case 'codeblock':
+      return (
+        <pre key={key} className="message-codeblock">
+          <code>{node.text}</code>
+        </pre>
+      )
+    case 'strong':
+      return <strong key={key}>{renderNodes(node.children, self, `${key}-`)}</strong>
+    case 'em':
+      return <em key={key}>{renderNodes(node.children, self, `${key}-`)}</em>
+    case 'del':
+      return <del key={key}>{renderNodes(node.children, self, `${key}-`)}</del>
+    default:
+      return <span key={key}>{node.text}</span>
+  }
 }

--- a/chat-frontend/src/components/shared/MessageContent/MessageContent.test.jsx
+++ b/chat-frontend/src/components/shared/MessageContent/MessageContent.test.jsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import MessageContent from './MessageContent'
+
+describe('MessageContent', () => {
+  it('renders plain text', () => {
+    render(<MessageContent content="hello world" mentions={[]} />)
+    expect(screen.getByText('hello world')).toBeInTheDocument()
+  })
+
+  it('renders a resolved mention as a highlighted span with the display name', () => {
+    render(<MessageContent content="hi @alice" mentions={[{ account: 'alice', engName: 'Alice Lee' }]} />)
+    const el = screen.getByText('@Alice Lee')
+    expect(el).toHaveClass('mention')
+    expect(el).not.toHaveClass('mention-self')
+    expect(el.dataset.account).toBe('alice')
+  })
+
+  it('marks a self-mention distinctly', () => {
+    render(
+      <MessageContent
+        content="@alice ping"
+        mentions={[{ account: 'alice', engName: 'Alice' }]}
+        selfAccount="alice"
+      />,
+    )
+    expect(screen.getByText('@Alice')).toHaveClass('mention-self')
+  })
+
+  it('styles @all as a group mention', () => {
+    render(<MessageContent content="@all hey" mentions={[]} />)
+    const el = screen.getByText('@all')
+    expect(el).toHaveClass('mention')
+    expect(el).toHaveClass('mention-all')
+  })
+
+  it('renders URLs as safe external links', () => {
+    render(<MessageContent content="see https://example.com/x" mentions={[]} />)
+    const a = screen.getByRole('link', { name: 'https://example.com/x' })
+    expect(a).toHaveAttribute('href', 'https://example.com/x')
+    expect(a).toHaveAttribute('target', '_blank')
+    expect(a).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('renders nothing for empty content', () => {
+    const { container } = render(<MessageContent content="" mentions={[]} />)
+    expect(container.textContent).toBe('')
+  })
+})

--- a/chat-frontend/src/components/shared/MessageContent/MessageContent.test.jsx
+++ b/chat-frontend/src/components/shared/MessageContent/MessageContent.test.jsx
@@ -46,4 +46,28 @@ describe('MessageContent', () => {
     const { container } = render(<MessageContent content="" mentions={[]} />)
     expect(container.textContent).toBe('')
   })
+
+  it('renders bold, italic and strikethrough markdown', () => {
+    const { container } = render(<MessageContent content="**b** *i* ~~s~~" mentions={[]} />)
+    expect(container.querySelector('strong')).toHaveTextContent('b')
+    expect(container.querySelector('em')).toHaveTextContent('i')
+    expect(container.querySelector('del')).toHaveTextContent('s')
+  })
+
+  it('renders inline code and fenced code blocks', () => {
+    const { container } = render(<MessageContent content={'`x` more'} mentions={[]} />)
+    expect(container.querySelector('code')).toHaveTextContent('x')
+
+    const { container: c2 } = render(<MessageContent content={'```\nx = 1\n```'} mentions={[]} />)
+    expect(c2.querySelector('pre')).toHaveTextContent('x = 1')
+  })
+
+  it('renders a mention nested inside bold', () => {
+    const { container } = render(
+      <MessageContent content="**@alice**" mentions={[{ account: 'alice', engName: 'Alice' }]} />,
+    )
+    const strong = container.querySelector('strong')
+    expect(strong).toBeInTheDocument()
+    expect(strong.querySelector('.mention')).toHaveTextContent('@Alice')
+  })
 })

--- a/chat-frontend/src/components/shared/MessageContent/index.jsx
+++ b/chat-frontend/src/components/shared/MessageContent/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './MessageContent'

--- a/chat-frontend/src/components/shared/MessageContent/style.css
+++ b/chat-frontend/src/components/shared/MessageContent/style.css
@@ -1,0 +1,27 @@
+.mention {
+  color: var(--mention);
+  font-weight: 600;
+}
+
+.mention-all {
+  color: var(--mention-all);
+}
+
+/* The reader's own name — stronger emphasis via the mention-all accent so a
+   self-mention is easy to spot in a busy channel. */
+.mention-self {
+  color: var(--mention-all);
+  background: var(--accent-soft);
+  border-radius: var(--radius-sm, 4px);
+  padding: 0 2px;
+}
+
+.message-link {
+  color: var(--accent);
+  text-decoration: underline;
+  word-break: break-word;
+}
+
+.message-link:hover {
+  color: var(--accent-hover);
+}

--- a/chat-frontend/src/components/shared/MessageContent/style.css
+++ b/chat-frontend/src/components/shared/MessageContent/style.css
@@ -25,3 +25,28 @@
 .message-link:hover {
   color: var(--accent-hover);
 }
+
+.message-code {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.9em;
+  padding: 0 4px;
+  border-radius: var(--radius-sm, 4px);
+  background: var(--bg-muted, rgba(127, 127, 127, 0.16));
+}
+
+.message-codeblock {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.9em;
+  margin: var(--space-1, 4px) 0;
+  padding: var(--space-2, 8px);
+  border-radius: var(--radius-md, 8px);
+  background: var(--bg-muted, rgba(127, 127, 127, 0.16));
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.message-codeblock code {
+  font-family: inherit;
+  background: none;
+  padding: 0;
+}

--- a/chat-frontend/src/components/shared/MessageInputForm/MessageInputForm.jsx
+++ b/chat-frontend/src/components/shared/MessageInputForm/MessageInputForm.jsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import QuotedBlock from '../QuotedBlock/QuotedBlock'
 import './style.css'
 
@@ -10,11 +11,19 @@ export default function MessageInputForm({
   quotedTarget,
   onClearQuote,
   inputRef,
+  // Image attach (optional — only the room composer wires these).
+  onPickImage,
+  pendingImage,
+  onClearImage,
 }) {
+  const fileInputRef = useRef(null)
+
+  const hasImage = !!pendingImage
+  const canSubmit = !disabled && ((value && value.trim().length > 0) || hasImage)
+
   const handleSubmit = (e) => {
     e?.preventDefault?.()
-    if (disabled) return
-    if (!value || !value.trim()) return
+    if (!canSubmit) return
     onSubmit()
   }
 
@@ -25,14 +34,54 @@ export default function MessageInputForm({
     }
   }
 
-  const canSubmit = !disabled && value && value.trim().length > 0
+  const handleFileChange = (e) => {
+    const file = e.target.files?.[0]
+    if (file) onPickImage?.(file)
+    // Reset so picking the same file again re-fires change.
+    e.target.value = ''
+  }
 
   return (
     <form className="message-input-form" onSubmit={handleSubmit}>
       {quotedTarget && (
         <QuotedBlock variant="chip" snapshot={quotedTarget} onClear={onClearQuote} />
       )}
+      {pendingImage && (
+        <div className="message-input-attachment">
+          <img className="message-input-attachment-thumb" src={pendingImage.url} alt={pendingImage.name} />
+          <span className="message-input-attachment-name">{pendingImage.name}</span>
+          <button
+            type="button"
+            className="message-input-attachment-remove"
+            aria-label="Remove image"
+            onClick={onClearImage}
+          >
+            ✕
+          </button>
+        </div>
+      )}
       <div className="message-input-row">
+        {onPickImage && (
+          <>
+            <button
+              type="button"
+              className="message-input-attach-btn"
+              aria-label="Attach image"
+              disabled={disabled}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              🖼️
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              className="message-input-file"
+              hidden
+              onChange={handleFileChange}
+            />
+          </>
+        )}
         <input
           ref={inputRef}
           type="text"

--- a/chat-frontend/src/components/shared/MessageInputForm/MessageInputForm.test.jsx
+++ b/chat-frontend/src/components/shared/MessageInputForm/MessageInputForm.test.jsx
@@ -51,4 +51,45 @@ describe('MessageInputForm', () => {
     fireEvent.click(screen.getByRole('button', { name: /clear quoted message/i }))
     expect(onClearQuote).toHaveBeenCalled()
   })
+
+  it('shows the attach button only when onPickImage is provided, and forwards the picked file', () => {
+    const onPickImage = vi.fn()
+    const { rerender, container } = render(
+      <MessageInputForm value="" onChange={() => {}} onSubmit={() => {}} placeholder="x" />,
+    )
+    expect(screen.queryByRole('button', { name: /attach image/i })).not.toBeInTheDocument()
+
+    rerender(
+      <MessageInputForm value="" onChange={() => {}} onSubmit={() => {}} placeholder="x" onPickImage={onPickImage} />,
+    )
+    expect(screen.getByRole('button', { name: /attach image/i })).toBeInTheDocument()
+    const file = new File(['x'], 'p.png', { type: 'image/png' })
+    fireEvent.change(container.querySelector('input[type="file"]'), { target: { files: [file] } })
+    expect(onPickImage).toHaveBeenCalledWith(file)
+  })
+
+  it('renders the pending image chip and allows removal; Send is enabled with an image but empty text', () => {
+    const onClearImage = vi.fn()
+    const onSubmit = vi.fn()
+    render(
+      <MessageInputForm
+        value=""
+        onChange={() => {}}
+        onSubmit={onSubmit}
+        placeholder="x"
+        onPickImage={() => {}}
+        pendingImage={{ name: 'p.png', url: 'blob:preview' }}
+        onClearImage={onClearImage}
+      />,
+    )
+    expect(screen.getByText('p.png')).toBeInTheDocument()
+    // Empty text but a pending image → Send enabled.
+    const send = screen.getByRole('button', { name: /^send$/i })
+    expect(send).not.toBeDisabled()
+    fireEvent.click(send)
+    expect(onSubmit).toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: /remove image/i }))
+    expect(onClearImage).toHaveBeenCalled()
+  })
 })

--- a/chat-frontend/src/components/shared/MessageInputForm/style.css
+++ b/chat-frontend/src/components/shared/MessageInputForm/style.css
@@ -102,3 +102,44 @@
 }
 .message-input-form button[type='submit']:hover:not(:disabled) { background: var(--accent-hover); }
 .message-input-form button[type='submit']:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.message-input-attach-btn {
+  flex: 0 0 auto;
+  padding: 0 var(--space-sm, 8px);
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: var(--text-lg, 1.125rem);
+  line-height: 1;
+}
+.message-input-attach-btn:hover:not(:disabled) { background: var(--bg-muted, rgba(127,127,127,0.12)); }
+.message-input-attach-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.message-input-attachment {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm, 8px);
+  padding: var(--space-xs, 4px) 0;
+}
+.message-input-attachment-thumb {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: var(--radius-sm, 4px);
+}
+.message-input-attachment-name {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 220px;
+}
+.message-input-attachment-remove {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}

--- a/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.jsx
+++ b/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.jsx
@@ -1,7 +1,9 @@
 import MessageActions from './MessageActions/MessageActions'
 import MessageContent from '@/components/shared/MessageContent/MessageContent'
+import MessageAttachments from '@/components/shared/MessageAttachments/MessageAttachments'
 import QuotedBlock from '@/components/shared/QuotedBlock/QuotedBlock'
 import useHoverWithDelay from '@/hooks/useHoverWithDelay'
+import { useNats } from '@/context/NatsContext'
 import { useSubscription } from '@/context/RoomEventsContext'
 import { redactInaccessibleQuoteSnapshot } from '@/lib/redactQuote'
 import './style.css'
@@ -58,6 +60,7 @@ export default function MessageRow({
   // Mirror history-service's quote redaction client-side: the live broadcast
   // path doesn't gate quote snapshots against the reader's access window, so
   // a quote of a message older than historySharedSince would otherwise leak.
+  const { user } = useNats()
   const subscription = useSubscription(room?.id)
   const quoteSnapshot = redactInaccessibleQuoteSnapshot(
     message.quotedParentMessage,
@@ -131,6 +134,9 @@ export default function MessageRow({
             </div>
           )}
         </div>
+        {message.attachments?.length > 0 && (
+          <MessageAttachments attachments={message.attachments} baseUrl={user?.baseUrl} />
+        )}
         {message.tcount > 0 && context !== 'thread' && context !== 'thread-parent' && (
           <button
             type="button"

--- a/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.jsx
+++ b/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.jsx
@@ -1,4 +1,5 @@
 import MessageActions from './MessageActions/MessageActions'
+import MessageContent from '@/components/shared/MessageContent/MessageContent'
 import QuotedBlock from '@/components/shared/QuotedBlock/QuotedBlock'
 import useHoverWithDelay from '@/hooks/useHoverWithDelay'
 import { useSubscription } from '@/context/RoomEventsContext'
@@ -89,7 +90,13 @@ export default function MessageRow({
           />
         )}
         <div className="message-bubble-wrap" {...handlers}>
-          <div className="message-bubble">{messageContent(message)}</div>
+          <div className="message-bubble">
+            <MessageContent
+              content={messageContent(message)}
+              mentions={message.mentions}
+              selfAccount={subscription?.u?.account}
+            />
+          </div>
           {hovered && (
             <div className="message-actions-host" {...handlers}>
               <MessageActions

--- a/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.jsx
+++ b/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.jsx
@@ -1,6 +1,7 @@
 import MessageActions from './MessageActions/MessageActions'
 import MessageContent from '@/components/shared/MessageContent/MessageContent'
 import MessageAttachments from '@/components/shared/MessageAttachments/MessageAttachments'
+import MessageReactions from '@/components/shared/MessageReactions/MessageReactions'
 import QuotedBlock from '@/components/shared/QuotedBlock/QuotedBlock'
 import useHoverWithDelay from '@/hooks/useHoverWithDelay'
 import { useNats } from '@/context/NatsContext'
@@ -137,6 +138,7 @@ export default function MessageRow({
         {message.attachments?.length > 0 && (
           <MessageAttachments attachments={message.attachments} baseUrl={user?.baseUrl} />
         )}
+        <MessageReactions reactions={message.reactions} selfAccount={subscription?.u?.account} />
         {message.tcount > 0 && context !== 'thread' && context !== 'thread-parent' && (
           <button
             type="button"

--- a/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.jsx
+++ b/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.jsx
@@ -12,10 +12,19 @@ function formatTime(dateStr) {
 }
 
 function senderName(msg) {
+  // userDisplayName is the server-composed render-ready name (engName +
+  // chineseName + account fallback); prefer it over the raw sender fields.
+  if (msg.userDisplayName) return msg.userDisplayName
   if (msg.sender) {
     return msg.sender.engName || msg.sender.account || msg.sender.userId || 'Unknown'
   }
   return msg.userAccount || msg.userId || 'Unknown'
+}
+
+function pinnedLabel(msg) {
+  const by = msg.pinnedBy
+  const byName = by?.engName || by?.account
+  return byName ? `Pinned by ${byName}` : 'Pinned'
 }
 
 function senderInitial(msg) {
@@ -78,6 +87,16 @@ export default function MessageRow({
           <span className="message-sender">{senderName(message)}</span>
           <span className="message-time">{formatTime(message.createdAt)}</span>
           {message.editedAt && <span className="message-edited"> (edited)</span>}
+          {message.pinnedAt && (
+            <span
+              className="message-pinned"
+              role="img"
+              aria-label={pinnedLabel(message)}
+              title={pinnedLabel(message)}
+            >
+              📌
+            </span>
+          )}
         </div>
         {/* QuotedBlock sits OUTSIDE message-bubble-wrap so hovering the
             quote doesn't trigger the action toolbar. CSS pulls it flush

--- a/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.test.jsx
+++ b/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.test.jsx
@@ -19,6 +19,11 @@ vi.mock('@/context/RoomEventsContext', () => ({
   useSubscription: () => mockSubscription,
 }))
 
+// MessageRow reads useNats for the current user's account + media base URL.
+vi.mock('@/context/NatsContext', () => ({
+  useNats: () => ({ user: { account: 'me', baseUrl: 'https://media.test' } }),
+}))
+
 const msg = {
   id: 'm1',
   content: 'hello world',
@@ -297,6 +302,22 @@ describe('MessageRow — reply-count badge', () => {
       <MessageRow message={msg} room={room} context="main" onThread={() => {}} onReply={() => {}} onJumpToMessage={() => {}} />,
     )
     expect(screen.queryByLabelText(/pinned/i)).not.toBeInTheDocument()
+  })
+
+  it('renders attachments with URLs built from the media base', () => {
+    const message = {
+      ...msg,
+      attachments: [
+        { id: 'a1', title: 'doc.pdf', type: 'file', titleLink: 'api/v1/file/rooms/r1/file/a1', fileType: 'application/pdf' },
+      ],
+    }
+    render(
+      <MessageRow message={message} room={room} context="main" onThread={() => {}} onReply={() => {}} onJumpToMessage={() => {}} />,
+    )
+    expect(screen.getByRole('link', { name: /doc\.pdf/ })).toHaveAttribute(
+      'href',
+      'https://media.test/api/v1/file/rooms/r1/file/a1',
+    )
   })
 
   it('no badge inside the thread panel even when tcount > 0', () => {

--- a/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.test.jsx
+++ b/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.test.jsx
@@ -263,6 +263,42 @@ describe('MessageRow — reply-count badge', () => {
     expect(screen.queryByRole('button', { name: /replies?/i })).not.toBeInTheDocument()
   })
 
+  it('prefers userDisplayName over sender.engName for the sender label', () => {
+    render(
+      <MessageRow
+        message={{ ...msg, userDisplayName: 'Alice Lee (愛麗絲)' }}
+        room={room}
+        context="main"
+        onThread={() => {}}
+        onReply={() => {}}
+        onJumpToMessage={() => {}}
+      />,
+    )
+    expect(screen.getByText('Alice Lee (愛麗絲)')).toBeInTheDocument()
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument()
+  })
+
+  it('shows a pinned indicator when pinnedAt is set', () => {
+    render(
+      <MessageRow
+        message={{ ...msg, pinnedAt: '2026-05-13T11:00:00Z', pinnedBy: { account: 'bob', engName: 'Bob' } }}
+        room={room}
+        context="main"
+        onThread={() => {}}
+        onReply={() => {}}
+        onJumpToMessage={() => {}}
+      />,
+    )
+    expect(screen.getByLabelText(/pinned/i)).toBeInTheDocument()
+  })
+
+  it('renders no pinned indicator on an unpinned message', () => {
+    render(
+      <MessageRow message={msg} room={room} context="main" onThread={() => {}} onReply={() => {}} onJumpToMessage={() => {}} />,
+    )
+    expect(screen.queryByLabelText(/pinned/i)).not.toBeInTheDocument()
+  })
+
   it('no badge inside the thread panel even when tcount > 0', () => {
     render(
       <MessageRow message={{ ...msg, tcount: 5 }} room={room} context="thread-parent" onThread={() => {}} onReply={() => {}} onJumpToMessage={() => {}} />

--- a/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.test.jsx
+++ b/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.test.jsx
@@ -320,6 +320,15 @@ describe('MessageRow — reply-count badge', () => {
     )
   })
 
+  it('renders reaction chips carried by the message', () => {
+    const message = { ...msg, reactions: { '👍': [{ account: 'bob', displayName: 'Bob' }] } }
+    render(
+      <MessageRow message={message} room={room} context="main" onThread={() => {}} onReply={() => {}} onJumpToMessage={() => {}} />,
+    )
+    expect(screen.getByText('👍')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+  })
+
   it('no badge inside the thread panel even when tcount > 0', () => {
     render(
       <MessageRow message={{ ...msg, tcount: 5 }} room={room} context="thread-parent" onThread={() => {}} onReply={() => {}} onJumpToMessage={() => {}} />

--- a/chat-frontend/src/components/shared/MessageList/MessageRow/style.css
+++ b/chat-frontend/src/components/shared/MessageList/MessageRow/style.css
@@ -156,6 +156,10 @@
   font-size: var(--text-xs);
   font-style: italic;
 }
+.message-pinned {
+  font-size: var(--text-xs);
+  cursor: default;
+}
 .message-row-own .message-actions-host {
   left: auto;
   right: 0;

--- a/chat-frontend/src/components/shared/MessageReactions/MessageReactions.jsx
+++ b/chat-frontend/src/components/shared/MessageReactions/MessageReactions.jsx
@@ -1,0 +1,51 @@
+import './style.css'
+
+// A shortcode that contains any non-ASCII codepoint is a literal unicode emoji
+// (render as-is); a purely ASCII shortcode is a name (e.g. acme_party) shown as
+// :name:. Resolving named/custom shortcodes to glyphs or images is a separate
+// emoji-picker / emoji.list follow-up.
+function hasGlyph(shortcode) {
+  for (let i = 0; i < shortcode.length; i += 1) {
+    if (shortcode.charCodeAt(i) > 127) return true
+  }
+  return false
+}
+
+function label(shortcode) {
+  return hasGlyph(shortcode) ? shortcode : `:${shortcode}:`
+}
+
+/**
+ * Render a message's reaction chips: one per shortcode with a reactor count and
+ * a title listing the reactors. Chips the current user reacted to are marked.
+ *
+ * @param {object} props
+ * @param {Record<string, { account: string, displayName?: string }[]>} [props.reactions]
+ * @param {string} [props.selfAccount]
+ */
+export default function MessageReactions({ reactions, selfAccount }) {
+  const entries = reactions
+    ? Object.entries(reactions).filter(([, users]) => Array.isArray(users) && users.length > 0)
+    : []
+  if (entries.length === 0) return null
+  const self = selfAccount ? String(selfAccount).toLowerCase() : null
+
+  return (
+    <ul className="message-reactions">
+      {entries.map(([shortcode, users]) => {
+        const mine = self && users.some((u) => u.account?.toLowerCase() === self)
+        const title = users.map((u) => u.displayName || u.account).join(', ')
+        return (
+          <li
+            key={shortcode}
+            className={`reaction-chip${mine ? ' reaction-chip-mine' : ''}`}
+            title={title}
+          >
+            <span className="reaction-emoji">{label(shortcode)}</span>
+            <span className="reaction-count">{users.length}</span>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/chat-frontend/src/components/shared/MessageReactions/MessageReactions.test.jsx
+++ b/chat-frontend/src/components/shared/MessageReactions/MessageReactions.test.jsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import MessageReactions from './MessageReactions'
+
+describe('MessageReactions', () => {
+  it('renders nothing when there are no reactions', () => {
+    const { container } = render(<MessageReactions reactions={undefined} />)
+    expect(container.firstChild).toBeNull()
+    const { container: c2 } = render(<MessageReactions reactions={{}} />)
+    expect(c2.firstChild).toBeNull()
+  })
+
+  it('renders a chip per shortcode with the reactor count', () => {
+    render(
+      <MessageReactions
+        reactions={{
+          '👍': [{ account: 'a', displayName: 'A' }, { account: 'b', displayName: 'B' }],
+          '🎉': [{ account: 'c', displayName: 'C' }],
+        }}
+      />,
+    )
+    expect(screen.getByText('👍')).toBeInTheDocument()
+    expect(screen.getByText('🎉')).toBeInTheDocument()
+    // counts
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+  })
+
+  it('renders an ASCII/custom shortcode as :name:', () => {
+    render(<MessageReactions reactions={{ acme_party: [{ account: 'a', displayName: 'A' }] }} />)
+    expect(screen.getByText(':acme_party:')).toBeInTheDocument()
+  })
+
+  it('lists reactor display names in the chip title', () => {
+    render(
+      <MessageReactions
+        reactions={{ '👍': [{ account: 'a', displayName: 'Alice' }, { account: 'b', displayName: 'Bob' }] }}
+      />,
+    )
+    expect(screen.getByRole('listitem')).toHaveAttribute('title', 'Alice, Bob')
+  })
+
+  it('highlights a chip the current user reacted to', () => {
+    render(
+      <MessageReactions
+        reactions={{
+          '👍': [{ account: 'me', displayName: 'Me' }],
+          '🎉': [{ account: 'other', displayName: 'Other' }],
+        }}
+        selfAccount="ME"
+      />,
+    )
+    const chips = screen.getAllByRole('listitem')
+    const mine = chips.find((c) => c.textContent.includes('👍'))
+    const notMine = chips.find((c) => c.textContent.includes('🎉'))
+    expect(mine).toHaveClass('reaction-chip-mine')
+    expect(notMine).not.toHaveClass('reaction-chip-mine')
+  })
+
+  it('skips shortcodes whose reactor list is empty', () => {
+    render(<MessageReactions reactions={{ '👍': [], '🎉': [{ account: 'a', displayName: 'A' }] }} />)
+    expect(screen.queryByText('👍')).not.toBeInTheDocument()
+    expect(screen.getByText('🎉')).toBeInTheDocument()
+  })
+})

--- a/chat-frontend/src/components/shared/MessageReactions/index.jsx
+++ b/chat-frontend/src/components/shared/MessageReactions/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './MessageReactions'

--- a/chat-frontend/src/components/shared/MessageReactions/style.css
+++ b/chat-frontend/src/components/shared/MessageReactions/style.css
@@ -1,0 +1,34 @@
+.message-reactions {
+  list-style: none;
+  margin: var(--space-1, 4px) 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1, 4px);
+}
+
+.reaction-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px var(--space-2, 8px);
+  border: 1px solid var(--border, rgba(127, 127, 127, 0.3));
+  border-radius: var(--radius-pill, 999px);
+  background: var(--bg-surface, transparent);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  cursor: default;
+}
+
+.reaction-chip-mine {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.reaction-count {
+  color: var(--text-muted);
+}
+
+.reaction-chip-mine .reaction-count {
+  color: var(--accent);
+}

--- a/chat-frontend/src/context/NatsContext/NatsContext.jsx
+++ b/chat-frontend/src/context/NatsContext/NatsContext.jsx
@@ -200,7 +200,10 @@ export function NatsProvider({ children }) {
 
       authUrlRef.current = nextAuthUrl
       ncRef.current = nc
-      setUser({ ...userInfo, siteId: portal.siteId })
+      // baseUrl is the media/API gateway origin — components build absolute
+      // attachment (image/file) URLs from it + the attachment's relative
+      // titleLink. Exposed here so MessageAttachments doesn't reach into the ref.
+      setUser({ ...userInfo, siteId: portal.siteId, baseUrl: nextAuthUrl })
       setConnected(true)
 
       // Persist the bot/admin bundle so a tab reload resumes the session.

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.test.jsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.test.jsx
@@ -1049,6 +1049,44 @@ describe('RoomEventsProvider sidebar buckets bootstrap', () => {
     expect(calls.find((c) => c.subject.endsWith('.rooms.list'))).toBeUndefined()
   })
 
+  it('seeds room keys carried by subscription.list into RoomKeysContext', async () => {
+    // subscription.list embeds the current room key under sub.room for
+    // encrypted channels. Seeding it at bootstrap means the first message in
+    // the room decrypts without a placeholder or an on-demand key fetch.
+    const seedKeys = vi.fn()
+    const prevMock = currentRoomKeysMock
+    currentRoomKeysMock = { decrypt: async () => null, hasKey: () => false, ensureKey: async () => false, seedKeys }
+    try {
+      const request = vi.fn().mockImplementation((subject, payload) => {
+        if (subject.endsWith('.subscription.list') && payload?.type === 'rooms')
+          return Promise.resolve({
+            subscriptions: [
+              {
+                roomId: 'c1',
+                roomType: 'channel',
+                name: 'c1',
+                siteId: 'site-A',
+                room: { privateKey: 'AQIDBA==', keyVersion: 4 },
+              },
+              // No room key → not seeded (plaintext DM / no key provisioned).
+              { roomId: 'd1', roomType: 'dm', name: 'd1', siteId: 'site-A' },
+            ],
+          })
+        if (subject.endsWith('.subscription.list')) return Promise.resolve({ subscriptions: [] })
+        throw new Error('unexpected subject: ' + subject)
+      })
+      const nats = mockNats({ request })
+
+      render(wrap(<SummariesProbe />, nats))
+      await waitFor(() => expect(seedKeys).toHaveBeenCalled())
+      expect(seedKeys).toHaveBeenCalledWith([
+        { roomId: 'c1', version: 4, privateKey: 'AQIDBA==' },
+      ])
+    } finally {
+      currentRoomKeysMock = prevMock
+    }
+  })
+
   it('degrades gracefully (Promise.allSettled) when one bucket RPC fails', async () => {
     // getApps rejects; getCurrent + getRooms resolve. Sidebar should
     // still bootstrap with the rooms from getRooms; the Apps bucket

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
@@ -113,7 +113,7 @@ export function RoomEventsProvider({ children }: { children: ReactNode }) {
   // where the NATS handshake has populated user/request/etc.
   const nats = useNats() as unknown as Nats
   const { user } = nats
-  const { decrypt, ensureKey } = useRoomKeys()
+  const { decrypt, ensureKey, seedKeys } = useRoomKeys()
   const [state, dispatch] = useReducer(roomEventsReducer, initialState) as unknown as [
     RoomEventsState,
     Dispatch<{ type: string; [k: string]: unknown }>,
@@ -151,6 +151,7 @@ export function RoomEventsProvider({ children }: { children: ReactNode }) {
     threadMessageMutationHandlerRef,
     decrypt,
     ensureKey,
+    seedKeys,
   )
 
   const loadHistory = useCallback(

--- a/chat-frontend/src/context/RoomEventsContext/reducer.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.js
@@ -12,6 +12,36 @@ function patchMessageById(list, messageId, patch) {
   return [...list.slice(0, idx), { ...list[idx], ...patch }, ...list.slice(idx + 1)]
 }
 
+// Apply a single reaction toggle to a message's reactions map, keyed by
+// shortcode with a list of {account, displayName}. Add is idempotent per
+// account; remove drops the account and the shortcode key when it empties.
+// Returns a new reactions object (never mutates).
+function applyReaction(reactions, { shortcode, action, account, displayName }) {
+  const next = { ...(reactions || {}) }
+  const list = next[shortcode] ? [...next[shortcode]] : []
+  const idx = list.findIndex((u) => u.account === account)
+  if (action === 'removed') {
+    if (idx < 0) return next
+    list.splice(idx, 1)
+  } else {
+    if (idx >= 0) return next
+    list.push({ account, displayName })
+  }
+  if (list.length === 0) delete next[shortcode]
+  else next[shortcode] = list
+  return next
+}
+
+// Like patchMessageById but computes the reaction patch per-matched-message.
+function patchReactionById(list, messageId, delta) {
+  if (!list || list.length === 0) return null
+  const idx = list.findIndex((m) => m.id === messageId)
+  if (idx < 0) return null
+  const msg = list[idx]
+  const reactions = applyReaction(msg.reactions, delta)
+  return [...list.slice(0, idx), { ...msg, reactions }, ...list.slice(idx + 1)]
+}
+
 export const BUFFER_MODE = {
   LIVE: 'live',
   HISTORICAL: 'historical',
@@ -653,6 +683,33 @@ export function roomEventsReducer(state, action) {
       const patch = { deleted: true }
       const messages = patchMessageById(prev.messages, action.messageId, patch)
       const pendingLiveMessages = patchMessageById(prev.pendingLiveMessages, action.messageId, patch)
+      if (!messages && !pendingLiveMessages) return state
+      return {
+        ...state,
+        roomState: {
+          ...state.roomState,
+          [action.roomId]: {
+            ...prev,
+            messages: messages ?? prev.messages,
+            pendingLiveMessages: pendingLiveMessages ?? prev.pendingLiveMessages,
+          },
+        },
+      }
+    }
+    case 'MESSAGE_REACTED': {
+      // Live `message_reacted` toggle. Mirrors MESSAGE_EDITED's dual-buffer
+      // patch so a reaction arriving while in historical mode isn't lost when
+      // pendingLiveMessages merges back.
+      const prev = state.roomState[action.roomId]
+      if (!prev) return state
+      const delta = {
+        shortcode: action.shortcode,
+        action: action.action,
+        account: action.account,
+        displayName: action.displayName,
+      }
+      const messages = patchReactionById(prev.messages, action.messageId, delta)
+      const pendingLiveMessages = patchReactionById(prev.pendingLiveMessages, action.messageId, delta)
       if (!messages && !pendingLiveMessages) return state
       return {
         ...state,

--- a/chat-frontend/src/context/RoomEventsContext/reducer.test.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.test.js
@@ -712,6 +712,66 @@ describe('MESSAGE_EDITED / MESSAGE_DELETED — live broadcast', () => {
   })
 })
 
+describe('MESSAGE_REACTED — live reaction toggles', () => {
+  const seedRoom = (msgs, pending = []) => ({
+    ...initialState,
+    roomState: {
+      r1: {
+        messages: msgs,
+        hasLoadedHistory: true, historyError: null,
+        unreadCount: 0, hasMention: false, mentionAll: false,
+        lastMsgAt: null, lastMsgId: null,
+        bufferMode: 'live', pendingLiveMessages: pending, focusMessageId: null,
+      },
+    },
+  })
+  const react = (over) => ({
+    type: 'MESSAGE_REACTED', roomId: 'r1', messageId: 'a',
+    shortcode: '👍', action: 'added', account: 'bob', displayName: 'Bob', ...over,
+  })
+
+  it('adds a reactor under the shortcode', () => {
+    const out = roomEventsReducer(seedRoom([{ id: 'a', content: 'x' }]), react())
+    expect(out.roomState.r1.messages[0].reactions).toEqual({
+      '👍': [{ account: 'bob', displayName: 'Bob' }],
+    })
+  })
+
+  it('appends a second distinct reactor to the same shortcode', () => {
+    const s1 = roomEventsReducer(seedRoom([{ id: 'a' }]), react())
+    const out = roomEventsReducer(s1, react({ account: 'carol', displayName: 'Carol' }))
+    expect(out.roomState.r1.messages[0].reactions['👍']).toEqual([
+      { account: 'bob', displayName: 'Bob' },
+      { account: 'carol', displayName: 'Carol' },
+    ])
+  })
+
+  it('is idempotent — re-adding the same account does not duplicate', () => {
+    const s1 = roomEventsReducer(seedRoom([{ id: 'a' }]), react())
+    const out = roomEventsReducer(s1, react())
+    expect(out.roomState.r1.messages[0].reactions['👍']).toHaveLength(1)
+  })
+
+  it('removes a reactor and drops the shortcode key when it empties', () => {
+    const s1 = roomEventsReducer(seedRoom([{ id: 'a' }]), react())
+    const out = roomEventsReducer(s1, react({ action: 'removed' }))
+    expect(out.roomState.r1.messages[0].reactions).toEqual({})
+  })
+
+  it('patches pendingLiveMessages when the target lives there', () => {
+    const seed = seedRoom([{ id: 'a' }], [{ id: 'p1' }])
+    const out = roomEventsReducer(seed, react({ messageId: 'p1' }))
+    expect(out.roomState.r1.pendingLiveMessages[0].reactions['👍']).toHaveLength(1)
+    expect(out.roomState.r1.messages).toBe(seed.roomState.r1.messages)
+  })
+
+  it('no-ops when the room or message is unknown', () => {
+    const seed = seedRoom([{ id: 'a' }])
+    expect(roomEventsReducer(seed, react({ roomId: 'nope' }))).toBe(seed)
+    expect(roomEventsReducer(seed, react({ messageId: 'ghost' }))).toBe(seed)
+  })
+})
+
 describe('MESSAGE_RECEIVED — server echo overwrites optimistic createdAt', () => {
   // Regression for: every thread reply silently failing message-worker's
   // IF EXISTS stamp on messages_by_id because the parent message in

--- a/chat-frontend/src/context/RoomEventsContext/useRoomSubscriptions.js
+++ b/chat-frontend/src/context/RoomEventsContext/useRoomSubscriptions.js
@@ -204,6 +204,19 @@ export function useRoomSubscriptions(
         fanThreadMutation({ kind: 'deleted', messageId })
         return true
       }
+      if (evt?.type === 'message_reacted' && evt.messageId && evt.shortcode) {
+        // ReactRoomEvent: {messageId, shortcode, action: added|removed, actor}.
+        safeDispatch({
+          type: 'MESSAGE_REACTED',
+          roomId: evt.roomId,
+          messageId: evt.messageId,
+          shortcode: evt.shortcode,
+          action: evt.action,
+          account: evt.actor?.account,
+          displayName: evt.actor?.engName || evt.actor?.account,
+        })
+        return true
+      }
       return false
     }
 

--- a/chat-frontend/src/context/RoomEventsContext/useRoomSubscriptions.js
+++ b/chat-frontend/src/context/RoomEventsContext/useRoomSubscriptions.js
@@ -59,6 +59,11 @@ const MARK_READ_DEBOUNCE_MS = 500
  *   On-demand key fetch from RoomKeysContext. Called once when the initial
  *   decrypt returns null; if it resolves true, decrypt is retried once.
  *   Defaults to a no-op that always returns false (no retry).
+ * @param {(entries: { roomId: string; version: number; privateKey: string }[]) => void} [seedKeys]
+ *   Bulk key-seed from RoomKeysContext. Called once after BUCKETS_LOADED with
+ *   the room keys `subscription.list` delivered inline, so the first message
+ *   in each encrypted room decrypts without a placeholder or an on-demand
+ *   fetch. Defaults to a no-op.
  */
 export function useRoomSubscriptions(
   nats,
@@ -68,6 +73,7 @@ export function useRoomSubscriptions(
   threadMessageMutationHandlerRef,
   decrypt = async () => null,
   ensureKey = async () => false,
+  seedKeys = () => {},
 ) {
   const { user } = nats
   // Keep a live ref to `nats` so long-lived subscription callbacks see the
@@ -83,6 +89,10 @@ export function useRoomSubscriptions(
   // Keep a live ref to `ensureKey` for the same reason.
   const ensureKeyRef = useRef(ensureKey)
   ensureKeyRef.current = ensureKey
+
+  // Keep a live ref to `seedKeys` for the same reason.
+  const seedKeysRef = useRef(seedKeys)
+  seedKeysRef.current = seedKeys
 
   // Bumped on every login (re)cycle so the provider's async fetch
   // callbacks can detect stale-generation dispatches.
@@ -427,6 +437,18 @@ export function useRoomSubscriptions(
       .then((buckets) => {
         if (cancelledRef.current) return
         safeDispatch({ type: 'BUCKETS_LOADED', ...buckets })
+        // Seed room keys delivered inline on subscription.list so the first
+        // message in each encrypted room decrypts immediately — no placeholder,
+        // no on-demand key.get RPC. Rooms without a key (plaintext DMs, or no
+        // key provisioned) simply aren't seeded.
+        const keyEntries = []
+        for (const sub of Object.values(buckets.subscriptions ?? {})) {
+          const room = sub?.room
+          if (room?.privateKey && typeof room.keyVersion === 'number') {
+            keyEntries.push({ roomId: sub.roomId, version: room.keyVersion, privateKey: room.privateKey })
+          }
+        }
+        if (keyEntries.length > 0) seedKeysRef.current(keyEntries)
         for (const r of buckets.rooms) {
           if (r.type === 'channel') openChannelSub(r.id)
         }

--- a/chat-frontend/src/context/RoomKeysContext/RoomKeysContext.test.jsx
+++ b/chat-frontend/src/context/RoomKeysContext/RoomKeysContext.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, waitFor, act } from '@testing-library/react'
 import { RoomKeysProvider, useRoomKeys } from './RoomKeysContext'
+import fixture from '../../../test/fixtures/encrypted-message.json'
 
 vi.mock('@/api', () => ({
   subscribeToRoomKeyEvents: vi.fn(),
@@ -147,6 +148,41 @@ describe('RoomKeysProvider.ensureKey', () => {
     })
     await expect(lastDecryptHook.ensureKey('r1', 0, 'site-a')).resolves.toBe(true)
     expect(requestRoomKey).toHaveBeenCalledTimes(2)
+  })
+
+  it('decrypt succeeds immediately after ensureKey resolves, before a re-render', async () => {
+    // Regression: the on-demand key fetch must rescue the very message that
+    // triggered it. useRoomSubscriptions.decryptAndDispatch awaits ensureKey
+    // and then retries decrypt in the SAME async tick — before React has
+    // flushed the KEY_RECEIVED dispatch into reducer state. If decrypt can
+    // only see keys via reducer state, the retry reads stale state, returns
+    // null, and the message falls through to the "[encrypted message]"
+    // placeholder even though the key was just fetched successfully.
+    vi.mocked(requestRoomKey).mockResolvedValueOnce({
+      roomId: 'r1',
+      version: fixture.message.version,
+      privateKey: fixture.privateKey,
+    })
+
+    render(
+      <RoomKeysProvider>
+        <Probe />
+      </RoomKeysProvider>,
+    )
+    await waitFor(() => expect(lastDecryptHook).not.toBeNull())
+
+    const ok = await lastDecryptHook.ensureKey('r1', fixture.message.version, 'site-a')
+    expect(ok).toBe(true)
+
+    // No waitFor / no act flush between ensureKey and decrypt — mirrors the
+    // real retry timing in decryptAndDispatch.
+    const plaintext = await lastDecryptHook.decrypt({
+      roomId: 'r1',
+      version: fixture.message.version,
+      nonceB64: fixture.message.nonce,
+      ciphertextB64: fixture.message.ciphertext,
+    })
+    expect(plaintext).toBe(fixture.plaintext)
   })
 
   it('short-circuits to true when the (roomId, version) is already cached', async () => {

--- a/chat-frontend/src/context/RoomKeysContext/RoomKeysContext.test.jsx
+++ b/chat-frontend/src/context/RoomKeysContext/RoomKeysContext.test.jsx
@@ -209,3 +209,75 @@ describe('RoomKeysProvider.ensureKey', () => {
     expect(requestRoomKey).toHaveBeenCalledTimes(1) // no second RPC
   })
 })
+
+describe('RoomKeysProvider.seedKeys', () => {
+  beforeEach(() => {
+    lastDecryptHook = null
+    vi.mocked(subscribeToRoomKeyEvents).mockReset()
+    vi.mocked(requestRoomKey).mockReset()
+    vi.mocked(subscribeToRoomKeyEvents).mockReturnValue({ unsubscribe: vi.fn() })
+  })
+
+  it('seeds keys from bootstrap so decrypt works without a live event or fetch', async () => {
+    // Regression: on a fresh reload the client holds no keys until a live
+    // RoomKeyEvent fires or a message forces an on-demand fetch. subscription.list
+    // already carries the current room key, so seeding it up front means the
+    // first message in a room decrypts without a placeholder or an extra RPC.
+    render(
+      <RoomKeysProvider>
+        <Probe />
+      </RoomKeysProvider>,
+    )
+    await waitFor(() => expect(lastDecryptHook).not.toBeNull())
+
+    act(() => {
+      lastDecryptHook.seedKeys([
+        { roomId: 'r1', version: fixture.message.version, privateKey: fixture.privateKey },
+      ])
+    })
+
+    const plaintext = await lastDecryptHook.decrypt({
+      roomId: 'r1',
+      version: fixture.message.version,
+      nonceB64: fixture.message.nonce,
+      ciphertextB64: fixture.message.ciphertext,
+    })
+    expect(plaintext).toBe(fixture.plaintext)
+    expect(requestRoomKey).not.toHaveBeenCalled()
+  })
+
+  it('skips entries with invalid base64 without throwing', async () => {
+    render(
+      <RoomKeysProvider>
+        <Probe />
+      </RoomKeysProvider>,
+    )
+    await waitFor(() => expect(lastDecryptHook).not.toBeNull())
+
+    act(() => {
+      lastDecryptHook.seedKeys([{ roomId: 'r1', version: 1, privateKey: '!!!not-base64!!!' }])
+    })
+
+    expect(lastDecryptHook.hasKey('r1', 1)).toBe(false)
+  })
+
+  it('ignores malformed entries (missing roomId / version / privateKey)', async () => {
+    render(
+      <RoomKeysProvider>
+        <Probe />
+      </RoomKeysProvider>,
+    )
+    await waitFor(() => expect(lastDecryptHook).not.toBeNull())
+
+    act(() => {
+      lastDecryptHook.seedKeys([
+        { roomId: '', version: 1, privateKey: fixture.privateKey },
+        { roomId: 'r1', version: undefined, privateKey: fixture.privateKey },
+        { roomId: 'r2', version: 1 },
+      ])
+    })
+
+    expect(lastDecryptHook.hasKey('r1', 1)).toBe(false)
+    expect(lastDecryptHook.hasKey('r2', 1)).toBe(false)
+  })
+})

--- a/chat-frontend/src/context/RoomKeysContext/RoomKeysContext.tsx
+++ b/chat-frontend/src/context/RoomKeysContext/RoomKeysContext.tsx
@@ -68,6 +68,14 @@ export function RoomKeysProvider({ children }: { children: React.ReactNode }) {
   // subsequent ensureKey calls short-circuit without waiting for a React
   // re-render to flush the state update into stateRef.
   const knownKeysRef = useRef<Set<string>>(new Set())
+  // Synchronous cache of raw key bytes keyed by `${roomId}|${version}`, written
+  // in lockstep with knownKeysRef. decrypt reads it FIRST so a key fetched via
+  // ensureKey can decrypt the very message that triggered the fetch: the
+  // caller (useRoomSubscriptions.decryptAndDispatch) retries decrypt in the
+  // same async tick, before React flushes KEY_RECEIVED into reducer state —
+  // reading only stateRef would still miss the just-fetched key and fall back
+  // to the "[encrypted message]" placeholder.
+  const keyBytesRef = useRef<Map<string, Uint8Array>>(new Map())
 
   const userAccount = nats.user?.account ?? null
 
@@ -103,6 +111,7 @@ export function RoomKeysProvider({ children }: { children: React.ReactNode }) {
         aesKeyCacheRef.current.delete(`${evt.roomId}|${evt.version}`)
       }
       knownKeysRef.current.add(`${evt.roomId}|${evt.version}`)
+      keyBytesRef.current.set(`${evt.roomId}|${evt.version}`, privateKey)
       dispatch({
         type: 'KEY_RECEIVED',
         roomId: evt.roomId,
@@ -117,6 +126,7 @@ export function RoomKeysProvider({ children }: { children: React.ReactNode }) {
       pendingRequestsRef.current.clear()
       failedAtRef.current.clear()
       knownKeysRef.current.clear()
+      keyBytesRef.current.clear()
       dispatch({ type: 'CLEAR_KEYS' })
     }
     // userAccount is a stable primitive (set once on login).
@@ -131,13 +141,18 @@ export function RoomKeysProvider({ children }: { children: React.ReactNode }) {
   }, [])
 
   const decrypt = useCallback(async ({ roomId, version, nonceB64, ciphertextB64 }: DecryptInput): Promise<string | null> => {
-    const entry = stateRef.current.byRoom[roomId]?.[version]
-    if (!entry) return null
-
     const cacheKey = `${roomId}|${version}`
+    // Prefer the synchronous byte cache so a key just fetched by ensureKey is
+    // usable on the immediate retry, before the KEY_RECEIVED dispatch flushes
+    // into reducer state. Fall back to reducer state for keys seeded by paths
+    // that don't touch the ref (defensive; today both writers keep them in
+    // sync).
+    const privateKey = keyBytesRef.current.get(cacheKey) ?? stateRef.current.byRoom[roomId]?.[version]?.privateKey
+    if (!privateKey) return null
+
     let pending = aesKeyCacheRef.current.get(cacheKey)
     if (!pending) {
-      pending = importAesKey(entry.privateKey)
+      pending = importAesKey(privateKey)
       aesKeyCacheRef.current.set(cacheKey, pending)
     }
     try {
@@ -190,8 +205,10 @@ export function RoomKeysProvider({ children }: { children: React.ReactNode }) {
           }
           // Mark the key as present synchronously before dispatch so
           // concurrent ensureKey callers short-circuit on the next tick
-          // without waiting for the React state flush.
+          // without waiting for the React state flush. keyBytesRef lets the
+          // caller's immediate decrypt retry read the key in this same tick.
           knownKeysRef.current.add(cacheKey)
+          keyBytesRef.current.set(cacheKey, privateKey)
           dispatch({
             type: 'KEY_RECEIVED',
             roomId,

--- a/chat-frontend/src/context/RoomKeysContext/RoomKeysContext.tsx
+++ b/chat-frontend/src/context/RoomKeysContext/RoomKeysContext.tsx
@@ -14,8 +14,21 @@ type DecryptInput = {
   ciphertextB64: string
 }
 
+/** One room key delivered at bootstrap by `subscription.list`. privateKey is
+ *  base64 (same wire shape as `RoomKeyGetResponse`). */
+type SeedKeyEntry = {
+  roomId: string
+  version: number
+  privateKey: string
+}
+
 type RoomKeysContextValue = {
   hasKey(roomId: string, version: number): boolean
+  /** Seed room keys known at bootstrap (from `subscription.list`) so the first
+   *  message in a room decrypts without waiting for a live event or an
+   *  on-demand fetch. Malformed / undecodable entries are skipped; identical
+   *  already-held keys no-op (via the reducer's bytesEqual guard). */
+  seedKeys(entries: SeedKeyEntry[]): void
   /** Returns null if the key is not (yet) known for that (roomId, version),
    *  or if decryption fails. */
   decrypt(input: DecryptInput): Promise<string | null>
@@ -84,14 +97,11 @@ export function RoomKeysProvider({ children }: { children: React.ReactNode }) {
 
     const liveNats = natsRef.current
 
-    // TODO: seed initial keys from sub.room.privateKey + sub.room.keyVersion
-    // delivered by subscription.list. The backend now populates these fields
-    // (SubscriptionRoom.PrivateKey / KeyVersion in pkg/model). Wiring them
-    // here requires exposing a seedKey() method on RoomKeysContextValue and
-    // calling it from useRoomSubscriptions.js after the BUCKETS_LOADED
-    // dispatch. Until that follow-up lands, RoomKeysContext populates from
-    // live RoomKeyEvent subscriptions only; reconnecting users re-acquire
-    // keys when a rotation or membership change next fires for each room.
+    // Initial keys are seeded from sub.room.privateKey + sub.room.keyVersion
+    // (delivered inline on subscription.list) via the `seedKeys` method, called
+    // from useRoomSubscriptions after BUCKETS_LOADED. This subscription handles
+    // the live delta: keys that rotate or are granted mid-session via
+    // RoomKeyEvent. On-demand fetches (ensureKey) cover any remaining gap.
     const sub = subscribeToRoomKeyEvents(liveNats, (raw) => {
       const evt = raw as RoomKeyEvent
       if (!evt || typeof evt.roomId !== 'string' || typeof evt.version !== 'number' || typeof evt.privateKey !== 'string') return
@@ -233,7 +243,36 @@ export function RoomKeysProvider({ children }: { children: React.ReactNode }) {
     [],
   )
 
-  const value: RoomKeysContextValue = { hasKey, decrypt, ensureKey }
+  const seedKeys = useCallback((entries: SeedKeyEntry[]) => {
+    if (!Array.isArray(entries)) return
+    for (const entry of entries) {
+      const { roomId, version, privateKey } = entry ?? {}
+      if (!roomId || typeof version !== 'number' || typeof privateKey !== 'string' || !privateKey) {
+        continue
+      }
+      let bytes: Uint8Array
+      try {
+        bytes = b64decode(privateKey)
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn('seedKeys: invalid base64 privateKey, skipping', { roomId, version }, err)
+        continue
+      }
+      const cacheKey = `${roomId}|${version}`
+      // Already hold identical bytes → nothing to do (mirrors the live-event
+      // handler's no-op path; avoids evicting a derived AES key).
+      const existing = stateRef.current.byRoom[roomId]?.[version]
+      if (existing && bytesEqual(existing.privateKey, bytes)) continue
+      // Different bytes for a version we already cached → drop the stale
+      // derived AES key so decrypt re-imports from the new bytes.
+      if (existing) aesKeyCacheRef.current.delete(cacheKey)
+      knownKeysRef.current.add(cacheKey)
+      keyBytesRef.current.set(cacheKey, bytes)
+      dispatch({ type: 'KEY_RECEIVED', roomId, version, privateKey: bytes })
+    }
+  }, [])
+
+  const value: RoomKeysContextValue = { hasKey, decrypt, ensureKey, seedKeys }
 
   return <RoomKeysContext.Provider value={value}>{children}</RoomKeysContext.Provider>
 }

--- a/chat-frontend/src/lib/attachment.js
+++ b/chat-frontend/src/lib/attachment.js
@@ -67,3 +67,18 @@ export function mediaUrl(baseUrl, relativePath) {
   if (/^https?:\/\//i.test(relativePath)) return relativePath
   return `${baseUrl.replace(/\/+$/, '')}/${relativePath.replace(/^\/+/, '')}`
 }
+
+/**
+ * Encode one Attachment as a base64 string of its JSON — the wire form of a
+ * `msg.send` `attachments` entry (the backend stores the bytes opaquely and
+ * returns decoded Attachment objects). UTF-8 safe.
+ *
+ * @param {import('../api/types').Attachment} att
+ * @returns {string}
+ */
+export function encodeAttachment(att) {
+  const bytes = new TextEncoder().encode(JSON.stringify(att))
+  let binary = ''
+  for (let i = 0; i < bytes.length; i += 1) binary += String.fromCharCode(bytes[i])
+  return btoa(binary)
+}

--- a/chat-frontend/src/lib/attachment.js
+++ b/chat-frontend/src/lib/attachment.js
@@ -1,0 +1,69 @@
+// Pure helpers for rendering message attachments. No React, no I/O.
+
+/**
+ * @typedef {'image' | 'audio' | 'video' | 'file'} AttachmentKind
+ */
+
+/**
+ * Classify an attachment. Prefers the presence of a media-specific URL (set by
+ * upload-service for the matching family), then falls back to the fileType MIME
+ * family, then to a generic file.
+ *
+ * @param {import('../api/types').Attachment | null | undefined} att
+ * @returns {AttachmentKind}
+ */
+export function attachmentKind(att) {
+  if (!att) return 'file'
+  if (att.imageUrl) return 'image'
+  if (att.audioUrl) return 'audio'
+  if (att.videoUrl) return 'video'
+  const ft = att.fileType || ''
+  if (ft.startsWith('image/')) return 'image'
+  if (ft.startsWith('audio/')) return 'audio'
+  if (ft.startsWith('video/')) return 'video'
+  return 'file'
+}
+
+/**
+ * Byte size for the attachment's media family (0 when unknown).
+ * @param {import('../api/types').Attachment | null | undefined} att
+ * @returns {number}
+ */
+export function attachmentSize(att) {
+  if (!att) return 0
+  return att.imageSize || att.audioSize || att.videoSize || 0
+}
+
+/**
+ * Human-readable byte size (e.g. "1.5 KB"). Empty string for 0/unknown so the
+ * caller can omit it entirely.
+ * @param {number} bytes
+ * @returns {string}
+ */
+export function formatFileSize(bytes) {
+  if (!bytes || bytes <= 0) return ''
+  if (bytes < 1024) return `${bytes} B`
+  const units = ['KB', 'MB', 'GB', 'TB']
+  let value = bytes / 1024
+  let unit = 0
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+  return `${value.toFixed(1)} ${units[unit]}`
+}
+
+/**
+ * Build the absolute media URL from the gateway base and a relative titleLink.
+ * `titleLink` is relative to the media gateway; an already-absolute URL passes
+ * through. Returns '' when either input is missing so callers can skip the link.
+ *
+ * @param {string | null | undefined} baseUrl
+ * @param {string | null | undefined} relativePath
+ * @returns {string}
+ */
+export function mediaUrl(baseUrl, relativePath) {
+  if (!baseUrl || !relativePath) return ''
+  if (/^https?:\/\//i.test(relativePath)) return relativePath
+  return `${baseUrl.replace(/\/+$/, '')}/${relativePath.replace(/^\/+/, '')}`
+}

--- a/chat-frontend/src/lib/attachment.test.js
+++ b/chat-frontend/src/lib/attachment.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { attachmentKind, attachmentSize, formatFileSize, mediaUrl } from './attachment'
+
+describe('attachmentKind', () => {
+  it('classifies by the present media URL', () => {
+    expect(attachmentKind({ imageUrl: 'x' })).toBe('image')
+    expect(attachmentKind({ audioUrl: 'x' })).toBe('audio')
+    expect(attachmentKind({ videoUrl: 'x' })).toBe('video')
+  })
+
+  it('falls back to the fileType MIME family', () => {
+    expect(attachmentKind({ fileType: 'image/png' })).toBe('image')
+    expect(attachmentKind({ fileType: 'audio/mpeg' })).toBe('audio')
+    expect(attachmentKind({ fileType: 'video/mp4' })).toBe('video')
+    expect(attachmentKind({ fileType: 'application/pdf' })).toBe('file')
+  })
+
+  it('defaults to file when nothing matches', () => {
+    expect(attachmentKind({})).toBe('file')
+    expect(attachmentKind(null)).toBe('file')
+  })
+})
+
+describe('attachmentSize', () => {
+  it('returns the size for the matching media family', () => {
+    expect(attachmentSize({ imageUrl: 'x', imageSize: 10 })).toBe(10)
+    expect(attachmentSize({ audioUrl: 'x', audioSize: 20 })).toBe(20)
+    expect(attachmentSize({ videoUrl: 'x', videoSize: 30 })).toBe(30)
+  })
+
+  it('returns 0 when no size is present', () => {
+    expect(attachmentSize({ fileType: 'application/pdf' })).toBe(0)
+  })
+})
+
+describe('formatFileSize', () => {
+  it('formats bytes into human units', () => {
+    expect(formatFileSize(0)).toBe('')
+    expect(formatFileSize(512)).toBe('512 B')
+    expect(formatFileSize(1024)).toBe('1.0 KB')
+    expect(formatFileSize(1536)).toBe('1.5 KB')
+    expect(formatFileSize(1048576)).toBe('1.0 MB')
+    expect(formatFileSize(5 * 1048576)).toBe('5.0 MB')
+  })
+})
+
+describe('mediaUrl', () => {
+  it('joins the gateway base with a relative titleLink', () => {
+    expect(mediaUrl('https://site.example.com', 'api/v1/file/rooms/r1/file/f1')).toBe(
+      'https://site.example.com/api/v1/file/rooms/r1/file/f1',
+    )
+  })
+
+  it('normalizes a trailing slash on the base and a leading slash on the path', () => {
+    expect(mediaUrl('https://site.example.com/', '/api/v1/file/x')).toBe(
+      'https://site.example.com/api/v1/file/x',
+    )
+  })
+
+  it('returns an empty string when base or path is missing', () => {
+    expect(mediaUrl('', 'api/v1/file/x')).toBe('')
+    expect(mediaUrl('https://site.example.com', '')).toBe('')
+  })
+
+  it('passes an already-absolute titleLink through unchanged', () => {
+    expect(mediaUrl('https://site.example.com', 'https://cdn.example.com/f')).toBe(
+      'https://cdn.example.com/f',
+    )
+  })
+})

--- a/chat-frontend/src/lib/attachment.test.js
+++ b/chat-frontend/src/lib/attachment.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { attachmentKind, attachmentSize, formatFileSize, mediaUrl } from './attachment'
+import { attachmentKind, attachmentSize, encodeAttachment, formatFileSize, mediaUrl } from './attachment'
 
 describe('attachmentKind', () => {
   it('classifies by the present media URL', () => {
@@ -66,5 +66,16 @@ describe('mediaUrl', () => {
     expect(mediaUrl('https://site.example.com', 'https://cdn.example.com/f')).toBe(
       'https://cdn.example.com/f',
     )
+  })
+})
+
+describe('encodeAttachment', () => {
+  it('round-trips an attachment through base64 JSON (UTF-8 safe)', () => {
+    const att = { id: 'f1', title: '照片.png', type: 'file', titleLink: 'api/v1/file/x' }
+    const encoded = encodeAttachment(att)
+    expect(typeof encoded).toBe('string')
+    const bytes = Uint8Array.from(atob(encoded), (c) => c.charCodeAt(0))
+    const decoded = JSON.parse(new TextDecoder().decode(bytes))
+    expect(decoded).toEqual(att)
   })
 })

--- a/chat-frontend/src/lib/messageContent.js
+++ b/chat-frontend/src/lib/messageContent.js
@@ -1,0 +1,88 @@
+// Pure tokenizer that splits a message body into inline segments for
+// rendering: plain text, @mentions, and links. No React, no I/O.
+//
+// The mention grammar mirrors the server's pkg/mention parser exactly so the
+// client highlights precisely what the backend treated as a mention:
+//   - `@` must sit at the start of the string or immediately after whitespace
+//     (so `bob@example.com` is NOT a mention),
+//   - the account token is `[0-9a-zA-Z_-]+(.[0-9a-zA-Z_-]+)*`,
+//   - `@all` (any case) is the group mention,
+//   - individual `@account` tokens are highlighted only when the server
+//     resolved them into `mentions[]` (unknown accounts render as plain text,
+//     matching pkg/mention.ResolveFromParsed dropping unknowns).
+
+const MENTION_RE = /(^|\s)@([0-9a-zA-Z_-]+(?:\.[0-9a-zA-Z_-]+)*)/g
+const URL_RE = /https?:\/\/[^\s<]+/g
+// Trailing characters that are almost always sentence punctuation, not part of
+// the URL (e.g. "see https://x.io." → the dot is text).
+const URL_TRAILING_PUNCT = /[),.;!?]+$/
+
+/**
+ * @typedef {{ type: 'text', text: string }
+ *   | { type: 'mention', account: string, all: boolean, display: string }
+ *   | { type: 'link', href: string, text: string }} Segment
+ */
+
+function mentionDisplay(participant) {
+  return participant?.engName || participant?.account || ''
+}
+
+/**
+ * Split `content` into ordered inline segments.
+ *
+ * @param {string | null | undefined} content
+ * @param {{ account?: string, engName?: string }[]} [mentions]
+ * @returns {Segment[]}
+ */
+export function parseMessageContent(content, mentions = []) {
+  if (!content) return []
+
+  const byAccount = new Map()
+  for (const p of mentions ?? []) {
+    if (p?.account) byAccount.set(p.account.toLowerCase(), p)
+  }
+
+  // Collect non-overlapping token spans (mentions + links), then emit the
+  // text between them.
+  const spans = []
+
+  MENTION_RE.lastIndex = 0
+  let m
+  while ((m = MENTION_RE.exec(content)) !== null) {
+    const lead = m[1] // '' at string start, or the single whitespace char
+    const account = m[2].toLowerCase()
+    const atStart = m.index + lead.length // index of '@'
+    const end = atStart + 1 + m[2].length // '@' + token
+    const isAll = account === 'all'
+    if (isAll) {
+      spans.push({ start: atStart, end, seg: { type: 'mention', account: 'all', all: true, display: 'all' } })
+    } else if (byAccount.has(account)) {
+      spans.push({
+        start: atStart,
+        end,
+        seg: { type: 'mention', account, all: false, display: mentionDisplay(byAccount.get(account)) },
+      })
+    }
+  }
+
+  URL_RE.lastIndex = 0
+  while ((m = URL_RE.exec(content)) !== null) {
+    const href = m[0].replace(URL_TRAILING_PUNCT, '')
+    if (!href) continue
+    spans.push({ start: m.index, end: m.index + href.length, seg: { type: 'link', href, text: href } })
+  }
+
+  // Earliest start first; on a tie prefer the longer span.
+  spans.sort((a, b) => a.start - b.start || b.end - a.end)
+
+  const segments = []
+  let cursor = 0
+  for (const span of spans) {
+    if (span.start < cursor) continue // overlaps an already-emitted span; skip
+    if (span.start > cursor) segments.push({ type: 'text', text: content.slice(cursor, span.start) })
+    segments.push(span.seg)
+    cursor = span.end
+  }
+  if (cursor < content.length) segments.push({ type: 'text', text: content.slice(cursor) })
+  return segments
+}

--- a/chat-frontend/src/lib/messageContent.js
+++ b/chat-frontend/src/lib/messageContent.js
@@ -1,88 +1,143 @@
-// Pure tokenizer that splits a message body into inline segments for
-// rendering: plain text, @mentions, and links. No React, no I/O.
+// Pure tokenizer that turns a message body into a tree of render nodes:
+// plain text, @mentions, links, and a small markdown subset (bold, italic,
+// strikethrough, inline code, fenced code blocks). No React, no I/O.
 //
-// The mention grammar mirrors the server's pkg/mention parser exactly so the
-// client highlights precisely what the backend treated as a mention:
-//   - `@` must sit at the start of the string or immediately after whitespace
-//     (so `bob@example.com` is NOT a mention),
-//   - the account token is `[0-9a-zA-Z_-]+(.[0-9a-zA-Z_-]+)*`,
-//   - `@all` (any case) is the group mention,
-//   - individual `@account` tokens are highlighted only when the server
-//     resolved them into `mentions[]` (unknown accounts render as plain text,
-//     matching pkg/mention.ResolveFromParsed dropping unknowns).
+// Node shapes:
+//   { type: 'text', text }
+//   { type: 'mention', account, all, display }
+//   { type: 'link', href, text }
+//   { type: 'code', text }                 // inline code — literal
+//   { type: 'codeblock', text }            // fenced block — literal
+//   { type: 'strong' | 'em' | 'del', children: Node[] }
+//
+// Markdown flavor is CommonMark-ish: **bold**/__bold__, *italic*/_italic_,
+// ~~strike~~, `code`, ```fenced```. Emphasis is guarded against intraword
+// matches (foo_bar, 2*3) and code spans/blocks are literal (no nested parsing).
+// The mention grammar mirrors the server's pkg/mention parser: `@` only at
+// start-or-after-whitespace, `@all` is the group mention, and individual
+// `@account` tokens are highlighted only when resolved into mentions[].
 
 const MENTION_RE = /(^|\s)@([0-9a-zA-Z_-]+(?:\.[0-9a-zA-Z_-]+)*)/g
-const URL_RE = /https?:\/\/[^\s<]+/g
-// Trailing characters that are almost always sentence punctuation, not part of
-// the URL (e.g. "see https://x.io." → the dot is text).
+const URL_RE = /https?:\/\/[^\s<]+/
 const URL_TRAILING_PUNCT = /[),.;!?]+$/
+const FENCE_RE = /```[^\n]*\n?([\s\S]*?)```/g
 
-/**
- * @typedef {{ type: 'text', text: string }
- *   | { type: 'mention', account: string, all: boolean, display: string }
- *   | { type: 'link', href: string, text: string }} Segment
- */
+// Inline markdown constructs, checked at each step. `order` breaks ties when two
+// constructs start at the same index (lower wins). Emphasis uses lookarounds so
+// intraword _ / * (foo_bar, 2*3) and the inner star of ** aren't matched.
+const INLINE_CONSTRUCTS = [
+  { type: 'code', order: 0, literal: true, re: /`([^`]+?)`/ },
+  { type: 'strong', order: 1, re: /\*\*([^*]+?)\*\*/ },
+  { type: 'strong', order: 1, re: /(?<![\w])__([^_]+?)__(?![\w])/ },
+  { type: 'del', order: 2, re: /~~([^~]+?)~~/ },
+  { type: 'em', order: 3, re: /(?<![\w*])\*([^*]+?)\*(?![\w*])/ },
+  { type: 'em', order: 3, re: /(?<![\w])_([^_]+?)_(?![\w])/ },
+]
 
 function mentionDisplay(participant) {
   return participant?.engName || participant?.account || ''
 }
 
 /**
- * Split `content` into ordered inline segments.
- *
  * @param {string | null | undefined} content
  * @param {{ account?: string, engName?: string }[]} [mentions]
- * @returns {Segment[]}
+ * @returns {object[]} render-node tree
  */
 export function parseMessageContent(content, mentions = []) {
   if (!content) return []
-
   const byAccount = new Map()
   for (const p of mentions ?? []) {
     if (p?.account) byAccount.set(p.account.toLowerCase(), p)
   }
+  return parseBlocks(content, byAccount)
+}
 
-  // Collect non-overlapping token spans (mentions + links), then emit the
-  // text between them.
-  const spans = []
-
-  MENTION_RE.lastIndex = 0
+// Pull fenced code blocks out first (literal), inline-parse everything else.
+function parseBlocks(text, byAccount) {
+  const nodes = []
+  let last = 0
+  FENCE_RE.lastIndex = 0
   let m
-  while ((m = MENTION_RE.exec(content)) !== null) {
-    const lead = m[1] // '' at string start, or the single whitespace char
-    const account = m[2].toLowerCase()
-    const atStart = m.index + lead.length // index of '@'
-    const end = atStart + 1 + m[2].length // '@' + token
-    const isAll = account === 'all'
-    if (isAll) {
-      spans.push({ start: atStart, end, seg: { type: 'mention', account: 'all', all: true, display: 'all' } })
-    } else if (byAccount.has(account)) {
-      spans.push({
-        start: atStart,
-        end,
-        seg: { type: 'mention', account, all: false, display: mentionDisplay(byAccount.get(account)) },
+  while ((m = FENCE_RE.exec(text)) !== null) {
+    if (m.index > last) nodes.push(...parseInline(text.slice(last, m.index), byAccount))
+    nodes.push({ type: 'codeblock', text: m[1].replace(/\n$/, '') })
+    last = m.index + m[0].length
+  }
+  if (last < text.length) nodes.push(...parseInline(text.slice(last), byAccount))
+  return nodes
+}
+
+// Recursively parse a run of inline text. Finds the earliest construct
+// (markdown span, link, or mention), emits the plain text before it, the
+// construct node, then recurses on the remainder.
+function parseInline(text, byAccount) {
+  if (!text) return []
+  const hit = earliestConstruct(text, byAccount)
+  if (!hit) return [{ type: 'text', text }]
+  const out = []
+  if (hit.start > 0) out.push({ type: 'text', text: text.slice(0, hit.start) })
+  out.push(hit.node)
+  return [...out, ...parseInline(text.slice(hit.end), byAccount)]
+}
+
+function earliestConstruct(text, byAccount) {
+  const candidates = []
+
+  for (const c of INLINE_CONSTRUCTS) {
+    const mm = c.re.exec(text)
+    if (!mm) continue
+    candidates.push({
+      start: mm.index,
+      end: mm.index + mm[0].length,
+      order: c.order,
+      build: () =>
+        c.literal
+          ? { type: c.type, text: mm[1] }
+          : { type: c.type, children: parseInline(mm[1], byAccount) },
+    })
+  }
+
+  const link = URL_RE.exec(text)
+  if (link) {
+    const href = link[0].replace(URL_TRAILING_PUNCT, '')
+    if (href) {
+      candidates.push({
+        start: link.index,
+        end: link.index + href.length,
+        order: 4,
+        build: () => ({ type: 'link', href, text: href }),
       })
     }
   }
 
-  URL_RE.lastIndex = 0
-  while ((m = URL_RE.exec(content)) !== null) {
-    const href = m[0].replace(URL_TRAILING_PUNCT, '')
-    if (!href) continue
-    spans.push({ start: m.index, end: m.index + href.length, seg: { type: 'link', href, text: href } })
-  }
+  const men = firstResolvedMention(text, byAccount)
+  if (men) candidates.push({ ...men, order: 5, build: () => men.node })
 
-  // Earliest start first; on a tie prefer the longer span.
-  spans.sort((a, b) => a.start - b.start || b.end - a.end)
+  if (candidates.length === 0) return null
+  candidates.sort((a, b) => a.start - b.start || a.order - b.order)
+  const best = candidates[0]
+  return { start: best.start, end: best.end, node: best.build() }
+}
 
-  const segments = []
-  let cursor = 0
-  for (const span of spans) {
-    if (span.start < cursor) continue // overlaps an already-emitted span; skip
-    if (span.start > cursor) segments.push({ type: 'text', text: content.slice(cursor, span.start) })
-    segments.push(span.seg)
-    cursor = span.end
+// First @mention token that resolves (either @all or a known account).
+function firstResolvedMention(text, byAccount) {
+  MENTION_RE.lastIndex = 0
+  let m
+  while ((m = MENTION_RE.exec(text)) !== null) {
+    const lead = m[1]
+    const account = m[2].toLowerCase()
+    const atStart = m.index + lead.length
+    const end = atStart + 1 + m[2].length
+    if (account === 'all') {
+      return { start: atStart, end, node: { type: 'mention', account: 'all', all: true, display: 'all' } }
+    }
+    if (byAccount.has(account)) {
+      return {
+        start: atStart,
+        end,
+        node: { type: 'mention', account, all: false, display: mentionDisplay(byAccount.get(account)) },
+      }
+    }
   }
-  if (cursor < content.length) segments.push({ type: 'text', text: content.slice(cursor) })
-  return segments
+  return null
 }

--- a/chat-frontend/src/lib/messageContent.test.js
+++ b/chat-frontend/src/lib/messageContent.test.js
@@ -101,3 +101,77 @@ describe('parseMessageContent', () => {
     ])
   })
 })
+
+describe('parseMessageContent — markdown', () => {
+  it('parses bold, italic and strikethrough into wrapper nodes', () => {
+    expect(parseMessageContent('**b**', [])).toEqual([
+      { type: 'strong', children: [{ type: 'text', text: 'b' }] },
+    ])
+    expect(parseMessageContent('*i*', [])).toEqual([
+      { type: 'em', children: [{ type: 'text', text: 'i' }] },
+    ])
+    expect(parseMessageContent('~~s~~', [])).toEqual([
+      { type: 'del', children: [{ type: 'text', text: 's' }] },
+    ])
+  })
+
+  it('parses inline code as a literal (no inner parsing)', () => {
+    expect(parseMessageContent('`@alice *x*`', [{ account: 'alice' }])).toEqual([
+      { type: 'code', text: '@alice *x*' },
+    ])
+  })
+
+  it('parses a fenced code block literally', () => {
+    expect(parseMessageContent('```\nx = 1\n```', [])).toEqual([
+      { type: 'codeblock', text: 'x = 1' },
+    ])
+  })
+
+  it('strips the info string off a fenced block', () => {
+    expect(parseMessageContent('```js\nconst a = 1\n```', [])).toEqual([
+      { type: 'codeblock', text: 'const a = 1' },
+    ])
+  })
+
+  it('resolves mentions nested inside emphasis', () => {
+    expect(parseMessageContent('**@alice**', [{ account: 'alice', engName: 'Alice' }])).toEqual([
+      {
+        type: 'strong',
+        children: [{ type: 'mention', account: 'alice', all: false, display: 'Alice' }],
+      },
+    ])
+  })
+
+  it('does not let underscores in a URL break the link', () => {
+    expect(parseMessageContent('see https://x.io/a_b_c done', [])).toEqual([
+      { type: 'text', text: 'see ' },
+      { type: 'link', href: 'https://x.io/a_b_c', text: 'https://x.io/a_b_c' },
+      { type: 'text', text: ' done' },
+    ])
+  })
+
+  it('does not italicize intraword underscores or asterisks', () => {
+    expect(parseMessageContent('foo_bar_baz', [])).toEqual([{ type: 'text', text: 'foo_bar_baz' }])
+    expect(parseMessageContent('2*3*4', [])).toEqual([{ type: 'text', text: '2*3*4' }])
+  })
+
+  it('mixes markdown with plain text and links', () => {
+    expect(parseMessageContent('see **bold** at https://x.io', [])).toEqual([
+      { type: 'text', text: 'see ' },
+      { type: 'strong', children: [{ type: 'text', text: 'bold' }] },
+      { type: 'text', text: ' at ' },
+      { type: 'link', href: 'https://x.io', text: 'https://x.io' },
+    ])
+  })
+
+  it('supports underscore/double-underscore emphasis at word boundaries', () => {
+    expect(parseMessageContent('a _i_ b', [])).toEqual([
+      { type: 'text', text: 'a ' },
+      { type: 'em', children: [{ type: 'text', text: 'i' }] },
+      { type: 'text', text: ' b' },
+    ])
+    expect(parseMessageContent('__b__', [])).toEqual([
+      { type: 'strong', children: [{ type: 'text', text: 'b' }] },
+    ])
+  })
+})

--- a/chat-frontend/src/lib/messageContent.test.js
+++ b/chat-frontend/src/lib/messageContent.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { parseMessageContent } from './messageContent'
+
+describe('parseMessageContent', () => {
+  it('returns an empty array for empty / nullish content', () => {
+    expect(parseMessageContent('', [])).toEqual([])
+    expect(parseMessageContent(null, [])).toEqual([])
+    expect(parseMessageContent(undefined)).toEqual([])
+  })
+
+  it('returns a single text segment when there are no inline tokens', () => {
+    expect(parseMessageContent('just plain text', [])).toEqual([
+      { type: 'text', text: 'just plain text' },
+    ])
+  })
+
+  it('highlights a resolved @mention and resolves its display name from mentions[]', () => {
+    const segs = parseMessageContent('hi @alice', [
+      { account: 'alice', engName: 'Alice Lee' },
+    ])
+    expect(segs).toEqual([
+      { type: 'text', text: 'hi ' },
+      { type: 'mention', account: 'alice', all: false, display: 'Alice Lee' },
+    ])
+  })
+
+  it('matches mentions case-insensitively but keeps the resolved display name', () => {
+    const segs = parseMessageContent('ping @Alice now', [
+      { account: 'alice', engName: 'Alice Lee' },
+    ])
+    expect(segs).toEqual([
+      { type: 'text', text: 'ping ' },
+      { type: 'mention', account: 'alice', all: false, display: 'Alice Lee' },
+      { type: 'text', text: ' now' },
+    ])
+  })
+
+  it('falls back to the account when the mention has no engName', () => {
+    const segs = parseMessageContent('@bob', [{ account: 'bob' }])
+    expect(segs).toEqual([{ type: 'mention', account: 'bob', all: false, display: 'bob' }])
+  })
+
+  it('always highlights @all as a group mention (case-insensitive), even with no mentions[]', () => {
+    expect(parseMessageContent('heads up @all', [])).toEqual([
+      { type: 'text', text: 'heads up ' },
+      { type: 'mention', account: 'all', all: true, display: 'all' },
+    ])
+    expect(parseMessageContent('@All team', [])).toEqual([
+      { type: 'mention', account: 'all', all: true, display: 'all' },
+      { type: 'text', text: ' team' },
+    ])
+  })
+
+  it('does NOT highlight an @token that is not a resolved mention', () => {
+    // Server only puts resolved users in mentions[]; an unresolved @token is
+    // plain text, mirroring pkg/mention.ResolveFromParsed dropping unknowns.
+    expect(parseMessageContent('@ghost was here', [])).toEqual([
+      { type: 'text', text: '@ghost was here' },
+    ])
+  })
+
+  it('does NOT treat an email address as a mention (needs start-or-whitespace before @)', () => {
+    expect(parseMessageContent('mail bob@example.com', [{ account: 'example', engName: 'X' }])).toEqual([
+      { type: 'text', text: 'mail bob@example.com' },
+    ])
+  })
+
+  it('linkifies http(s) URLs', () => {
+    expect(parseMessageContent('see https://example.com/x for more', [])).toEqual([
+      { type: 'text', text: 'see ' },
+      { type: 'link', href: 'https://example.com/x', text: 'https://example.com/x' },
+      { type: 'text', text: ' for more' },
+    ])
+  })
+
+  it('trims trailing sentence punctuation off a URL', () => {
+    expect(parseMessageContent('open https://example.com.', [])).toEqual([
+      { type: 'text', text: 'open ' },
+      { type: 'link', href: 'https://example.com', text: 'https://example.com' },
+      { type: 'text', text: '.' },
+    ])
+  })
+
+  it('handles multiple mentions and a link in one message', () => {
+    const segs = parseMessageContent('@alice @all https://x.io done', [
+      { account: 'alice', engName: 'Alice' },
+    ])
+    expect(segs).toEqual([
+      { type: 'mention', account: 'alice', all: false, display: 'Alice' },
+      { type: 'text', text: ' ' },
+      { type: 'mention', account: 'all', all: true, display: 'all' },
+      { type: 'text', text: ' ' },
+      { type: 'link', href: 'https://x.io', text: 'https://x.io' },
+      { type: 'text', text: ' done' },
+    ])
+  })
+
+  it('preserves newlines in text segments', () => {
+    expect(parseMessageContent('line1\nline2', [])).toEqual([
+      { type: 'text', text: 'line1\nline2' },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

Two related pieces of chat-frontend work, all frontend-only (no backend or wire-schema changes):

1. **Fix the persistent `[encrypted message]` placeholder** — messages in encrypted channels frequently rendered as `[encrypted message]` even though the room key was available/fetchable.
2. **Render the latest message format** — the UI showed only plain-text content and dropped most of what the backend's `ClientMessage` already sends (inline mentions/links, **markdown**, attachments, pinned state, `userDisplayName`). Cards are intentionally out of scope.

## Commits

### Encrypted-message fixes
- **`decrypt just-fetched room key without waiting for re-render`** — root cause of the frequent placeholder. `RoomKeysContext.decrypt` read key bytes only from reducer state via `stateRef`, which updates on the next React render. When `ensureKey` fetched a missing key on demand and the caller retried `decrypt` in the same async tick, the retry read stale state, returned `null`, and the message fell through to the placeholder — so the on-demand fetch never rescued the message that triggered it. Fixed with a synchronous key-bytes cache that `decrypt` reads first. The existing integration tests mocked `decrypt` to succeed on the second call (assuming exactly the behavior the real `decrypt` lacked), so they passed while the bug shipped; added a unit test exercising the real `decrypt` against the real `ensureKey` timing.
- **`seed room keys from subscription.list at bootstrap`** — the client started every reload with zero keys, forcing a per-room on-demand `key.get` round-trip before the first message could decrypt. `subscription.list` already delivers the current room key inline (`sub.room.privateKey`/`keyVersion`), but it was never fed into `RoomKeysContext`. Added a `seedKeys` method, called after `BUCKETS_LOADED`.

### Latest message format
- **`render inline mentions and links`** — a pure `lib/messageContent` tokenizer splits a body into text / mention / link nodes, mirroring the server's `pkg/mention` grammar exactly (`@` only at start-or-after-whitespace, `@all` is the group mention, individual `@account` highlighted only when resolved in `mentions[]`). Mentions render as highlighted spans (self-mention emphasized), URLs as safe `target=_blank rel=noopener` links.
- **`render markdown in message content`** — extends that tokenizer into a render-node tree covering a CommonMark-ish subset: `**bold**`/`__bold__`, `*italic*`/`_italic_`, `~~strike~~`, `` `inline code` ``, and ```` ```fenced``` ```` code blocks. `MessageContent` renders it recursively (emphasis wraps its children; code is literal). Mentions/links keep working, including nested inside emphasis (`**@alice**`), and are matched as first-class constructs so a URL containing `_`/`*` can't be mangled. Emphasis is guarded against intraword matches (`foo_bar`, `2*3`). Flavor is CommonMark; RocketChat-flavored single-`*` bold from migrated content renders as italic (still emphasized, never broken).
- **`use userDisplayName and show a pinned indicator`** — prefer the server-composed `userDisplayName` for the sender label; render a 📌 "Pinned by <name>" indicator when `pinnedAt` is set.
- **`render message attachments`** — added the `Attachment`/`ImageDimensions` types + `attachments` field. A pure `lib/attachment` helper (kind classification, size formatting, absolute-URL builder) and a `MessageAttachments` component: images render inline from the gateway URL and fall back to the embedded blurred base64 preview if the full image fails to load; other kinds render a titled download chip. Exposed the media gateway `baseUrl` on the NatsContext user.

## Testing
- TDD throughout (failing test → implementation for each unit).
- `npm test` — **750 passing**; `npm run typecheck` clean; `vite build` clean.

## Known follow-ups (not in this PR)
- **Authenticating protected attachment downloads.** The backend's mechanism is a one-time `POST /api/v1/file/setCookie` that issues an `ssoToken` cookie so header-less `<img>`/`<a>` loads authenticate. Wiring it is environment-sensitive (HTTPS + `SameSite=None`, and the token differs across SSO/bot auth modes) and needs a live stack to validate — until then inline images degrade gracefully to the embedded preview.
- **Text colors, reactions badges, emoji shortcodes, cards** are not rendered. Colors have no representation in the wire format (would need a backend markup convention first); the rest are separate features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rich message rendering for markdown-like formatting (bold/italic/strikethrough, inline + fenced code), clickable external links, and mention highlighting (including `@all` and self-mentions).
  * Added message attachments for images (preview + fallback), audio/video, and files (download links + readable sizes), including message pin indicators.
  * Added message reactions chips and room-key pre-seeding for faster decryption.
  * Added image sending to the room message composer (with optimistic preview), plus media upload + media-session cookie helpers.
* **Bug Fixes**
  * Improved attachment and reaction rendering behavior, and ensured live reaction toggles update both historical and live buffers correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->