### PR TITLE
Filter member statuses by statusIsShow opt-in flag

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -1679,7 +1679,7 @@ See [Error envelope](#6-error-envelope-reference). Common errors: `"only room me
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `limit` | number | no | Upper bound on returned rows. When omitted, the server uses `min(3, room.userCount)` (an empty room returns an empty list); when supplied, must be `> 0` and `<= room.userCount`. Fewer rows may come back — members with an empty `statusText` are omitted (see `members`). |
+| `limit` | number | no | Upper bound on returned rows. When omitted, the server uses `min(3, room.userCount)` (an empty room returns an empty list); when supplied, must be `> 0` and `<= room.userCount`. Fewer rows may come back — members with an empty `statusText` or with `statusIsShow=false` are omitted (see `members`). |
 
 ```json
 { "limit": 5 }
@@ -1689,7 +1689,7 @@ See [Error envelope](#6-error-envelope-reference). Common errors: `"only room me
 
 | Field | Type | Notes |
 |---|---|---|
-| `members` | array<MemberStatus> | One entry per room subscription **with a non-empty `statusText`**, projected from the joined `users` document. Members without a status set are omitted. |
+| `members` | array<MemberStatus> | One entry per room subscription **with a non-empty `statusText` and `statusIsShow=true`**, projected from the joined `users` document. Members without a status set, or who have opted out of surfacing it (`statusIsShow=false`), are omitted. |
 
 `MemberStatus`:
 
@@ -1698,7 +1698,7 @@ See [Error envelope](#6-error-envelope-reference). Common errors: `"only room me
 | `account` | string | The user's account. |
 | `engName` | string | English display name. |
 | `chineseName` | string | Chinese display name. |
-| `statusIsShow` | boolean | Whether the user has chosen to surface their status text. |
+| `statusIsShow` | boolean | Whether the user has chosen to surface their status text. Always `true` — members with `statusIsShow=false` are omitted from `members`. |
 | `statusText` | string | Free-form presence text (e.g. `"available"`, `"in a meeting"`); always non-empty — members without a status are omitted from `members`. |
 
 ```json

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -481,7 +481,7 @@ platform admin. Channel rooms only.
 
 #### Success response
 
-`{ "members": MemberStatus[] }` — members with non-empty `statusText` only.
+`{ "members": MemberStatus[] }` — members with non-empty `statusText` and `statusIsShow=true` only.
 See `MemberStatus` schema in [../client-api.md §3.1](../client-api.md#get-member-statuses).
 
 #### Errors

--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -3776,7 +3776,7 @@ func TestMongoStore_ListMemberStatuses_Integration(t *testing.T) {
 		store := NewMongoStore(db)
 		for i := 0; i < 5; i++ {
 			acct := fmt.Sprintf("user%d", i)
-			mustInsertUser(t, db, &model.User{ID: "u-" + acct, Account: acct, EngName: acct, ChineseName: acct, StatusText: acct})
+			mustInsertUser(t, db, &model.User{ID: "u-" + acct, Account: acct, EngName: acct, ChineseName: acct, StatusIsShow: true, StatusText: acct})
 			mustInsertSub(t, db, &model.Subscription{
 				ID: "sub-" + acct, User: model.SubscriptionUser{ID: "u-" + acct, Account: acct},
 				RoomID: "r1", SiteID: "site-a",
@@ -3791,7 +3791,7 @@ func TestMongoStore_ListMemberStatuses_Integration(t *testing.T) {
 		db := setupMongo(t)
 		store := NewMongoStore(db)
 		mustInsertUser(t, db, &model.User{
-			ID: "u-alice", Account: "alice", EngName: "Alice", ChineseName: "愛", StatusText: "x",
+			ID: "u-alice", Account: "alice", EngName: "Alice", ChineseName: "愛", StatusIsShow: true, StatusText: "x",
 		})
 		mustInsertSub(t, db, &model.Subscription{
 			ID: "sub-a", User: model.SubscriptionUser{ID: "u-alice", Account: "alice"},
@@ -3827,7 +3827,7 @@ func TestMongoStore_ListMemberStatuses_Integration(t *testing.T) {
 		// Then 3 live subs.
 		for i := 0; i < 3; i++ {
 			acct := fmt.Sprintf("live%d", i)
-			mustInsertUser(t, db, &model.User{ID: "u-" + acct, Account: acct, EngName: acct, StatusText: acct})
+			mustInsertUser(t, db, &model.User{ID: "u-" + acct, Account: acct, EngName: acct, StatusIsShow: true, StatusText: acct})
 			mustInsertSub(t, db, &model.Subscription{
 				ID:     fmt.Sprintf("sub-live%d", i),
 				User:   model.SubscriptionUser{ID: "u-" + acct, Account: acct},

--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -3638,7 +3638,7 @@ func TestMongoStore_ListMemberStatuses_Integration(t *testing.T) {
 		})
 		mustInsertUser(t, db, &model.User{
 			ID: "u-bob", Account: "bob", EngName: "Bob Chen", ChineseName: "陳博",
-			StatusIsShow: false, StatusText: "in a meeting",
+			StatusIsShow: true, StatusText: "in a meeting",
 		})
 		mustInsertSub(t, db, &model.Subscription{
 			ID: "sub-a", User: model.SubscriptionUser{ID: "u-alice", Account: "alice"},
@@ -3662,8 +3662,63 @@ func TestMongoStore_ListMemberStatuses_Integration(t *testing.T) {
 		}, byAcct["alice"])
 		assert.Equal(t, model.MemberStatus{
 			Account: "bob", EngName: "Bob Chen", ChineseName: "陳博",
-			StatusIsShow: false, StatusText: "in a meeting",
+			StatusIsShow: true, StatusText: "in a meeting",
 		}, byAcct["bob"])
+	})
+
+	t.Run("members with statusIsShow=false are excluded", func(t *testing.T) {
+		db := setupMongo(t)
+		store := NewMongoStore(db)
+		mustInsertUser(t, db, &model.User{
+			ID: "u-alice", Account: "alice", EngName: "Alice", ChineseName: "愛",
+			StatusIsShow: true, StatusText: "available",
+		})
+		// Non-empty statusText but the user has not opted to surface it; must be dropped.
+		mustInsertUser(t, db, &model.User{
+			ID: "u-bob", Account: "bob", EngName: "Bob", ChineseName: "博",
+			StatusIsShow: false, StatusText: "in a meeting",
+		})
+		mustInsertSub(t, db, &model.Subscription{
+			ID: "sub-a", User: model.SubscriptionUser{ID: "u-alice", Account: "alice"},
+			RoomID: "r1", SiteID: "site-a",
+		})
+		mustInsertSub(t, db, &model.Subscription{
+			ID: "sub-b", User: model.SubscriptionUser{ID: "u-bob", Account: "bob"},
+			RoomID: "r1", SiteID: "site-a",
+		})
+
+		got, err := store.ListMemberStatuses(ctx, "r1", 5)
+		require.NoError(t, err)
+		require.Len(t, got, 1, "member with statusIsShow=false must be excluded")
+		assert.Equal(t, "alice", got[0].Account)
+	})
+
+	t.Run("member whose user doc lacks statusIsShow is excluded", func(t *testing.T) {
+		db := setupMongo(t)
+		store := NewMongoStore(db)
+		mustInsertUser(t, db, &model.User{
+			ID: "u-alice", Account: "alice", EngName: "Alice", ChineseName: "愛",
+			StatusIsShow: true, StatusText: "available",
+		})
+		// Legacy doc: statusText present but no statusIsShow field at all — decodes
+		// as false, so it must be dropped like an explicit false.
+		_, err := db.Collection("users").InsertOne(ctx, bson.M{
+			"_id": "u-carol", "account": "carol", "engName": "Carol", "statusText": "busy",
+		})
+		require.NoError(t, err)
+		mustInsertSub(t, db, &model.Subscription{
+			ID: "sub-a", User: model.SubscriptionUser{ID: "u-alice", Account: "alice"},
+			RoomID: "r1", SiteID: "site-a",
+		})
+		mustInsertSub(t, db, &model.Subscription{
+			ID: "sub-c", User: model.SubscriptionUser{ID: "u-carol", Account: "carol"},
+			RoomID: "r1", SiteID: "site-a",
+		})
+
+		got, err := store.ListMemberStatuses(ctx, "r1", 5)
+		require.NoError(t, err)
+		require.Len(t, got, 1, "member whose user doc lacks statusIsShow must be excluded")
+		assert.Equal(t, "alice", got[0].Account)
 	})
 
 	t.Run("members with empty statusText are excluded", func(t *testing.T) {

--- a/room-service/store.go
+++ b/room-service/store.go
@@ -74,8 +74,10 @@ type RoomStore interface {
 	// ListMemberStatuses returns up to `limit` members of roomID, each
 	// projected from the corresponding users document as {account, engName,
 	// chineseName, statusIsShow, statusText}. Subscriptions whose user
-	// document is missing are dropped. Caller is responsible for the limit
-	// cap (handler enforces > 0 and <= room.UserCount).
+	// document is missing, whose statusText is empty, or whose statusIsShow is
+	// false (opted out of surfacing their status) are dropped — every returned
+	// row has statusIsShow=true. Caller is responsible for the limit cap
+	// (handler enforces > 0 and <= room.UserCount).
 	ListMemberStatuses(ctx context.Context, roomID string, limit int) ([]model.MemberStatus, error)
 	// ListMentionableSubscriptions returns up to `limit` mentionable members
 	// of roomID (users + apps), excluding excludeAccount, whose searchable

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -1477,7 +1477,8 @@ func (s *MongoStore) ListActiveCmdMenus(ctx context.Context, assistantNames []st
 }
 
 // ListMemberStatuses returns up to limit members of roomID (projected from the joined
-// user doc); orphan subs and empty-statusText members are dropped before the post-join $limit.
+// user doc); orphan subs, empty-statusText members, and members with statusIsShow=false
+// (opted out of surfacing their status) are dropped before the post-join $limit.
 func (s *MongoStore) ListMemberStatuses(ctx context.Context, roomID string, limit int) ([]model.MemberStatus, error) {
 	pipeline := mongo.Pipeline{
 		{{Key: "$match", Value: bson.M{"roomId": roomID}}},
@@ -1504,8 +1505,13 @@ func (s *MongoStore) ListMemberStatuses(ctx context.Context, roomID string, limi
 		}}},
 		{{Key: "$unwind", Value: bson.M{"path": "$user", "preserveNullAndEmptyArrays": false}}},
 		{{Key: "$replaceWith", Value: "$user"}},
-		// Exclude members with no status set; an empty statusText is not a presence to surface.
-		{{Key: "$match", Value: bson.M{"statusText": bson.M{"$nin": bson.A{"", nil}}}}},
+		// Exclude members who aren't surfacing a status: an empty statusText is not
+		// a presence to show, and statusIsShow=false (incl. legacy docs missing the
+		// field, which decode as false) means the user opted out of surfacing it.
+		{{Key: "$match", Value: bson.M{
+			"statusText":   bson.M{"$nin": bson.A{"", nil}},
+			"statusIsShow": true,
+		}}},
 		{{Key: "$limit", Value: int64(limit)}},
 	}
 	cursor, err := s.subscriptions.Aggregate(ctx, pipeline)


### PR DESCRIPTION
## Summary
Enforce the `statusIsShow` flag when listing member statuses in a room. Members who have opted out of surfacing their status (`statusIsShow=false`) are now excluded from the `ListMemberStatuses` response, even if they have a non-empty `statusText`. This includes legacy user documents that lack the `statusIsShow` field entirely (which decode as `false`).

## Changes

- **store_mongo.go**: Updated the aggregation pipeline in `ListMemberStatuses` to filter on `statusIsShow: true` in addition to the existing non-empty `statusText` check. Updated the method's documentation to clarify that members with `statusIsShow=false` are dropped before the post-join limit.

- **store.go**: Updated the `ListMemberStatuses` interface documentation to clarify that subscriptions with `statusIsShow=false` are dropped and that every returned row has `statusIsShow=true`.

- **integration_test.go**: 
  - Fixed the existing test case to set `StatusIsShow: true` for Bob (aligning with the test's intent to verify status display).
  - Added two new test cases:
    - `"members with statusIsShow=false are excluded"` — verifies that members with an explicit `statusIsShow=false` are omitted from results.
    - `"member whose user doc lacks statusIsShow is excluded"` — verifies that legacy documents missing the `statusIsShow` field (decoding as `false`) are also omitted.

- **docs/client-api.md**: Updated API documentation to clarify that members with `statusIsShow=false` are omitted from the `members` array, and that the `statusIsShow` field in `MemberStatus` is always `true` (since members with `false` are filtered out).

- **docs/client-api/request-reply.md**: Updated success response documentation to note that only members with `statusIsShow=true` are returned.

## Implementation Details

The MongoDB aggregation pipeline now includes `statusIsShow: true` in the `$match` stage that filters members before applying the limit. This ensures:
- Members who explicitly opted out (`statusIsShow=false`) are excluded.
- Legacy documents missing the field (which decode as `false` in Go) are also excluded.
- The filtering happens before the `$limit`, so the limit applies only to members who meet both criteria (non-empty status text AND opted in).

https://claude.ai/code/session_01CqafXQZhtyc2PXUcdJxnRK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Member status results now exclude users who hide their status or have no visible status text (`statusIsShow` must be true and `statusText` must be non-empty).
  * Visible-status filtering is applied before enforcing the requested limit, so results match what’s actually reportable.

* **Documentation**
  * Updated “Get Member Statuses” API documentation to clarify returned fields and omission behavior (including legacy documents where `statusIsShow` is missing).

* **Tests**
  * Expanded integration coverage for status visibility opt-out and legacy omission scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->