### PR TITLE
Local/global room subject separation to reduce NATS gateway interest-map memory

### DIFF
--- a/.semgrep/room-subject.yml
+++ b/.semgrep/room-subject.yml
@@ -1,0 +1,30 @@
+rules:
+  - id: room-subject-publish-must-route
+    languages: [go]
+    severity: ERROR
+    message: >
+      Publish a channel room's .event through the service's publishRoomEvent
+      helper, which fans out over subject.RoomEventTargets(id, crossSite,
+      routeMode). Passing a subject built inline by subject.RoomEvent /
+      RoomMsgStream / RoomMetadataUpdate to a publish call skips the
+      ROOM_SUBJECT_MODE global/local routing, so same-site rooms silently miss
+      delivery once local mode is enabled (and dual mode loses its global
+      safety-net publish). See pkg/subject.RoomEventTargets and each service's
+      publishRoomEvent.
+    paths:
+      exclude:
+        # Tests legitimately build room subjects inline to assert on them, and
+        # loadgen is a self-contained harness that publishes+subscribes global.
+        - "**/*_test.go"
+        - "**/tools/loadgen/**"
+    patterns:
+      - pattern-either:
+          - pattern: $X.Publish($CTX, subject.RoomEvent(...), ...)
+          - pattern: $X.Publish($CTX, subject.RoomMsgStream(...), ...)
+          - pattern: $X.Publish($CTX, subject.RoomMetadataUpdate(...), ...)
+          - pattern: $X.publishCore($CTX, subject.RoomEvent(...), ...)
+          - pattern: $X.publishCore($CTX, subject.RoomMsgStream(...), ...)
+          - pattern: $X.publishCore($CTX, subject.RoomMetadataUpdate(...), ...)
+          - pattern: $X.publish($CTX, subject.RoomEvent(...), ...)
+          - pattern: $X.publish($CTX, subject.RoomMsgStream(...), ...)
+          - pattern: $X.publish($CTX, subject.RoomMetadataUpdate(...), ...)

--- a/auth-service/handler.go
+++ b/auth-service/handler.go
@@ -303,7 +303,10 @@ func (h *AuthHandler) handleDevAuth(ctx context.Context, c *gin.Context, req aut
 // docs/client-api.md §2.1 — a platform-team template change must mirror both):
 //
 //	Pub allow: chat.user.{account}.>, _INBOX.>, chat.user.presence.*.query.batch (+allow-pub-response)
-//	Sub allow: chat.user.{account}.>, chat.room.>, _INBOX.>, chat.user.presence.state.*
+//	Sub allow: chat.user.{account}.>, chat.room.>, chat.local.room.>, _INBOX.>, chat.user.presence.state.*
+//
+// The list above is documentation only (the live grant is the platform-team
+// template); the leaf node denies chat.local.> cross-gateway, so it stays site-local.
 func (h *AuthHandler) signNATSJWT(userPubKey, account string) (string, error) {
 	uc := jwt.NewUserClaims(userPubKey)
 	uc.IssuerAccount = h.accountPubKey

--- a/broadcast-worker/debug_log_test.go
+++ b/broadcast-worker/debug_log_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hmchangw/chat/pkg/logctx"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/natsutil"
+	"github.com/hmchangw/chat/pkg/subject"
 )
 
 type recordingHandler struct {
@@ -99,7 +100,7 @@ func TestHandler_DMFanout_DebugBreadcrumbs(t *testing.T) {
 	store.EXPECT().ListSubscriptions(gomock.Any(), "dm-1").Return(testDMSubs, nil).AnyTimes()
 	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"alice"}).Return([]model.User{testUsers[0]}, nil).AnyTimes()
 
-	h := NewHandler(store, us, pub, NewMockRoomKeyProvider(ctrl), defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, NewMockRoomKeyProvider(ctrl), defaultParentFetcher, false, subject.RouteGlobal)
 	rec := installRecorder(t)
 
 	t.Run("flow rung: fan-out outcome with recipient count, no debug/trace", func(t *testing.T) {
@@ -154,7 +155,7 @@ func TestHandler_DMFanout_NoContentLeak(t *testing.T) {
 	store.EXPECT().GetRoomMeta(gomock.Any(), "dm-1").Return(metaOf(testDMRoom), nil).AnyTimes()
 	store.EXPECT().ListSubscriptions(gomock.Any(), "dm-1").Return(testDMSubs, nil).AnyTimes()
 	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"alice"}).Return([]model.User{testUsers[0]}, nil).AnyTimes()
-	h := NewHandler(store, us, &mockPublisher{}, NewMockRoomKeyProvider(ctrl), defaultParentFetcher, false)
+	h := NewHandler(store, us, &mockPublisher{}, NewMockRoomKeyProvider(ctrl), defaultParentFetcher, false, subject.RouteGlobal)
 
 	rec := installRecorder(t)
 	require.NoError(t, h.HandleMessage(admitRung("trace"), data)) // most verbose path

--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -66,9 +66,10 @@ type Handler struct {
 	parentFetcher ParentFetcher
 	encrypt       bool
 	encoder       *roomcrypto.Encoder
+	routeMode     subject.RoomRouteMode
 }
 
-func NewHandler(store Store, userStore userstore.UserStore, pub Publisher, keyStore RoomKeyProvider, parentFetcher ParentFetcher, encrypt bool) *Handler {
+func NewHandler(store Store, userStore userstore.UserStore, pub Publisher, keyStore RoomKeyProvider, parentFetcher ParentFetcher, encrypt bool, routeMode subject.RoomRouteMode) *Handler {
 	return &Handler{
 		store:         store,
 		userStore:     userStore,
@@ -77,6 +78,7 @@ func NewHandler(store Store, userStore userstore.UserStore, pub Publisher, keySt
 		parentFetcher: parentFetcher,
 		encrypt:       encrypt,
 		encoder:       roomcrypto.NewEncoder(),
+		routeMode:     routeMode,
 	}
 }
 
@@ -198,9 +200,9 @@ func (h *Handler) handleCreated(ctx context.Context, evt *model.MessageEvent) er
 
 	switch meta.Type {
 	case model.RoomTypeChannel:
-		return h.publishChannelEvent(ctx, meta, clientMsg, evt.Timestamp, resolved.MentionAll, resolved.Participants)
+		return h.publishChannelEvent(ctx, &meta, clientMsg, evt.Timestamp, resolved.MentionAll, resolved.Participants)
 	case model.RoomTypeDM, model.RoomTypeBotDM:
-		return h.publishDMEvents(ctx, meta, clientMsg, evt.Timestamp, resolved.Accounts)
+		return h.publishDMEvents(ctx, &meta, clientMsg, evt.Timestamp, resolved.Accounts)
 	default:
 		slog.WarnContext(ctx, "unknown room type, skipping fan-out",
 			"type", meta.Type,
@@ -259,7 +261,7 @@ func (h *Handler) handleThreadCreated(ctx context.Context, evt *model.MessageEve
 		// Do NOT call SetSubscriptionMentions here: TShow=false replies are invisible
 		// in the main channel, so a room-level mention badge would appear with no
 		// visible message to explain it.
-		roomEvt := buildRoomEvent(meta, clientMsg, evt.Timestamp)
+		roomEvt := buildRoomEvent(&meta, clientMsg, evt.Timestamp)
 		roomEvt.MentionAll = resolved.MentionAll
 		if len(resolved.Participants) > 0 {
 			roomEvt.Mentions = resolved.Participants
@@ -274,7 +276,7 @@ func (h *Handler) handleThreadCreated(ctx context.Context, evt *model.MessageEve
 		// owned by message-worker (markThreadMentions), so broadcast-worker doesn't
 		// touch subscriptions here. lastMsgAt is intentionally NOT updated (would
 		// wrongly mark hasUnread for non-participants).
-		return h.publishDMEvents(ctx, meta, clientMsg, evt.Timestamp, resolved.Accounts)
+		return h.publishDMEvents(ctx, &meta, clientMsg, evt.Timestamp, resolved.Accounts)
 	default:
 		slog.WarnContext(ctx, "unknown room type, skipping thread fan-out",
 			"type", meta.Type,
@@ -460,8 +462,8 @@ func (h *Handler) publishThreadMetadata(ctx context.Context, room *model.Room, n
 	}
 	switch room.Type {
 	case model.RoomTypeChannel:
-		if err := h.pub.Publish(ctx, subject.RoomEvent(room.ID), payload); err != nil {
-			return fmt.Errorf("publish thread metadata for channel room %s: %w", room.ID, err)
+		if err := h.publishRoomEvent(ctx, room.ID, room.CrossSite, room.CrossSiteAt, payload, "thread metadata"); err != nil {
+			return err
 		}
 	case model.RoomTypeDM, model.RoomTypeBotDM:
 		for _, account := range room.Accounts {
@@ -666,10 +668,7 @@ func (h *Handler) publishMutation(ctx context.Context, room *model.Room, roomEvt
 
 	switch room.Type {
 	case model.RoomTypeChannel:
-		if err := h.pub.Publish(ctx, subject.RoomEvent(room.ID), payload); err != nil {
-			return fmt.Errorf("publish %s event for room %s message %s: %w", roomEvtType, room.ID, messageID, err)
-		}
-		return nil
+		return h.publishRoomEvent(ctx, room.ID, room.CrossSite, room.CrossSiteAt, payload, fmt.Sprintf("%s event (message %s)", roomEvtType, messageID))
 
 	case model.RoomTypeDM, model.RoomTypeBotDM:
 		for _, account := range room.Accounts {
@@ -797,7 +796,7 @@ func (h *Handler) encryptRoomEvent(ctx context.Context, roomID string, clientMsg
 	return nil
 }
 
-func (h *Handler) publishChannelEvent(ctx context.Context, meta roommetacache.Meta, clientMsg *model.ClientMessage, timestamp int64, mentionAll bool, mentions []model.Participant) error {
+func (h *Handler) publishChannelEvent(ctx context.Context, meta *roommetacache.Meta, clientMsg *model.ClientMessage, timestamp int64, mentionAll bool, mentions []model.Participant) error {
 	evt := buildRoomEvent(meta, clientMsg, timestamp)
 	evt.MentionAll = mentionAll
 	if len(mentions) > 0 {
@@ -815,7 +814,20 @@ func (h *Handler) publishChannelEvent(ctx context.Context, meta roommetacache.Me
 	slog.Log(ctx, logctx.LevelFlow, "broadcast fan-out", "phase", "fanout",
 		"request_id", natsutil.RequestIDFromContext(ctx), "room_id", meta.ID,
 		"type", string(meta.Type), "delivery", "room-stream", "audience", meta.UserCount)
-	return h.pub.Publish(ctx, subject.RoomEvent(meta.ID), payload)
+	return h.publishRoomEvent(ctx, meta.ID, meta.CrossSite, meta.CrossSiteAt, payload, "channel event")
+}
+
+// publishRoomEvent fans a channel room's .event out via subject.RoomEventTargets — the
+// sanctioned path enforced by .semgrep room-subject-publish-must-route (never inline a subject).
+func (h *Handler) publishRoomEvent(ctx context.Context, roomID string, crossSite *bool, crossSiteAt *time.Time, payload []byte, op string) error {
+	now := time.Now().UTC()
+	var pubErr error
+	for _, subj := range subject.RoomEventTargets(roomID, crossSite, crossSiteAt, h.routeMode, now) {
+		if err := h.pub.Publish(ctx, subj, payload); err != nil {
+			pubErr = fmt.Errorf("publish %s for room %s to %s: %w", op, roomID, subj, err)
+		}
+	}
+	return pubErr
 }
 
 // debugFlowFanout emits the flow-rung outcome of a per-recipient fan-out:
@@ -836,7 +848,7 @@ func debugTraceDelivered(ctx context.Context, account, roomID string) {
 		"request_id", natsutil.RequestIDFromContext(ctx), "account", account, "room_id", roomID)
 }
 
-func (h *Handler) publishDMEvents(ctx context.Context, meta roommetacache.Meta, clientMsg *model.ClientMessage, timestamp int64, mentionedAccounts []string) error {
+func (h *Handler) publishDMEvents(ctx context.Context, meta *roommetacache.Meta, clientMsg *model.ClientMessage, timestamp int64, mentionedAccounts []string) error {
 	subs, err := h.store.ListSubscriptions(ctx, meta.ID)
 	if err != nil {
 		return fmt.Errorf("list subscriptions for DM room %s: %w", meta.ID, err)
@@ -886,7 +898,7 @@ func (h *Handler) publishDMEvents(ctx context.Context, meta roommetacache.Meta, 
 	return nil
 }
 
-func buildRoomEvent(meta roommetacache.Meta, clientMsg *model.ClientMessage, eventTimestamp int64) model.RoomEvent {
+func buildRoomEvent(meta *roommetacache.Meta, clientMsg *model.ClientMessage, eventTimestamp int64) model.RoomEvent {
 	return model.RoomEvent{
 		Type:           model.RoomEventNewMessage,
 		RoomID:         meta.ID,

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -23,6 +23,10 @@ import (
 	"github.com/hmchangw/chat/pkg/subject"
 )
 
+// ptrBool returns a pointer to b, for constructing tri-state *bool fields
+// (e.g. model.Room.CrossSite) in test literals.
+func ptrBool(b bool) *bool { return &b }
+
 type publishRecord struct {
 	subject string
 	data    []byte
@@ -31,13 +35,16 @@ type publishRecord struct {
 type mockPublisher struct {
 	mu      sync.Mutex
 	records []publishRecord
+	// failOn maps a subject to the error Publish should return for it; the
+	// attempt is still recorded so tests can assert every target was tried.
+	failOn map[string]error
 }
 
 func (m *mockPublisher) Publish(_ context.Context, subj string, data []byte) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.records = append(m.records, publishRecord{subject: subj, data: data})
-	return nil
+	return m.failOn[subj]
 }
 
 // stubParentFetcher is a ParentFetcher test double: FetchParent returns a fixed
@@ -171,7 +178,7 @@ func TestHandleMessage_DispatchesByEvent(t *testing.T) {
 				us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"sender"}).Return(nil, nil)
 			}
 
-			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 			err = h.HandleMessage(context.Background(), data)
 
 			if tc.wantErr {
@@ -259,12 +266,12 @@ func TestHandler_HandleMessage_ChannelRoom(t *testing.T) {
 					Return([]model.User{senderUser}, nil)
 			}
 
-			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 			err := h.HandleMessage(context.Background(), makeMessageEvent("room-1", tc.content, msgTime))
 			require.NoError(t, err)
 
 			require.Len(t, pub.records, 1)
-			assert.Equal(t, subject.RoomEvent("room-1"), pub.records[0].subject)
+			assert.Equal(t, subject.RoomEvent("room-1", true), pub.records[0].subject)
 
 			evt, msg := decryptClientMessage(t, pub.records[0].data, key)
 			assert.Equal(t, model.RoomEventNewMessage, evt.Type)
@@ -364,7 +371,7 @@ func TestHandler_HandleMessage_DMRoom(t *testing.T) {
 			}
 
 			keyStore := NewMockRoomKeyProvider(ctrl)
-			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 			err := h.HandleMessage(context.Background(), data)
 			require.NoError(t, err)
 
@@ -406,7 +413,7 @@ func TestHandler_HandleMessage_Errors(t *testing.T) {
 		us := NewMockUserStore(ctrl)
 		pub := &mockPublisher{}
 		keyStore := NewMockRoomKeyProvider(ctrl)
-		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 
 		err := h.HandleMessage(context.Background(), []byte("not json"))
 		require.Error(t, err)
@@ -425,7 +432,7 @@ func TestHandler_HandleMessage_Errors(t *testing.T) {
 		store.EXPECT().UpdateRoomLastMessage(gomock.Any(), "room-1", "msg-1", msgTime, false).Return(errors.New("not found"))
 
 		keyStore := NewMockRoomKeyProvider(ctrl)
-		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 		err := h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hello", msgTime))
 		require.Error(t, err)
 		assert.Empty(t, pub.records)
@@ -441,7 +448,7 @@ func TestHandler_HandleMessage_Errors(t *testing.T) {
 		store.EXPECT().UpdateRoomLastMessage(gomock.Any(), "room-1", "msg-1", msgTime, false).Return(errors.New("db error"))
 
 		keyStore := NewMockRoomKeyProvider(ctrl)
-		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 		err := h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hello", msgTime))
 		require.Error(t, err)
 		assert.Empty(t, pub.records)
@@ -460,7 +467,7 @@ func TestHandler_HandleMessage_Errors(t *testing.T) {
 		store.EXPECT().SetSubscriptionMentions(gomock.Any(), "room-1", gomock.Any(), gomock.Any()).Return(errors.New("db error"))
 
 		keyStore := NewMockRoomKeyProvider(ctrl)
-		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 		err := h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hey @alice", msgTime))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "set subscription mentions")
@@ -483,7 +490,7 @@ func TestHandler_HandleMessage_Errors(t *testing.T) {
 		us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"sender"}).Return(nil, nil) // sender lookup
 
 		keyStore := NewMockRoomKeyProvider(ctrl)
-		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 		err := h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hello", msgTime))
 		require.NoError(t, err)
 		assert.Empty(t, pub.records)
@@ -502,7 +509,7 @@ func TestHandler_HandleMessage_Errors(t *testing.T) {
 		store.EXPECT().ListSubscriptions(gomock.Any(), "dm-1").Return(nil, errors.New("db error"))
 
 		keyStore := NewMockRoomKeyProvider(ctrl)
-		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 		evt := model.MessageEvent{
 			Event:  model.EventCreated,
 			SiteID: "site-a",
@@ -536,7 +543,7 @@ func TestHandler_HandleMessage_Errors(t *testing.T) {
 		// Single lookup: sender is both the message author and the mentioned account, so the deduped list is just ["sender"].
 		us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"sender"}).Return([]model.User{senderUser}, nil)
 
-		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 		err := h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hey @sender", msgTime))
 		require.NoError(t, err)
 
@@ -563,7 +570,7 @@ func TestHandler_HandleMessage_Errors(t *testing.T) {
 		store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
 		us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"sender"}).Return(nil, errors.New("db error")) // sender lookup
 
-		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 		err := h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hello", msgTime))
 		require.NoError(t, err)
 
@@ -609,7 +616,7 @@ func TestHandler_HandleMessage_DMRoom_PublishError(t *testing.T) {
 	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"alice"}).Return([]model.User{testUsers[0]}, nil) // sender lookup
 
 	keyStore := NewMockRoomKeyProvider(ctrl)
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 	evt := model.MessageEvent{
 		Event:  model.EventCreated,
 		SiteID: "site-a",
@@ -642,7 +649,7 @@ func TestHandler_HandleMessage_ChannelRoom_Encryption(t *testing.T) {
 		store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
 		us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"sender"}).Return(nil, nil)
 
-		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 		err := h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hello", msgTime))
 		require.Error(t, err)
 		assert.ErrorIs(t, err, errNoCurrentKey)
@@ -663,7 +670,7 @@ func TestHandler_HandleMessage_ChannelRoom_Encryption(t *testing.T) {
 		store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
 		us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"sender"}).Return(nil, nil)
 
-		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 		err := h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hello", msgTime))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "get room key")
@@ -686,12 +693,12 @@ func TestHandler_HandleMessage_ChannelRoom_Encryption(t *testing.T) {
 		store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
 		us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"sender"}).Return([]model.User{{ID: "u-sender", Account: "sender", EngName: "Sender Lin", ChineseName: "寄件者", SiteID: "site-a"}}, nil)
 
-		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+		h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 		err := h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hello", msgTime))
 		require.NoError(t, err)
 
 		require.Len(t, pub.records, 1)
-		assert.Equal(t, subject.RoomEvent("room-1"), pub.records[0].subject)
+		assert.Equal(t, subject.RoomEvent("room-1", true), pub.records[0].subject)
 
 		// Verify plaintext metadata on the RoomEvent
 		var rawEvt map[string]any
@@ -767,7 +774,7 @@ func TestHandler_FetchAndUpdateRoom_Missing(t *testing.T) {
 		Return(fmt.Errorf("update room last message ghost-room: %w", mongo.ErrNoDocuments))
 
 	keyStore := NewMockRoomKeyProvider(ctrl)
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 
 	err := h.HandleMessage(context.Background(), makeMessageEvent("ghost-room", "hello", msgTime))
 	require.Error(t, err)
@@ -805,12 +812,12 @@ func TestHandleUpdated_ChannelRoomScopedPublish(t *testing.T) {
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	require.Len(t, pub.records, 1, "channel: single room-scoped publish")
 	c := pub.records[0]
-	assert.Equal(t, subject.RoomEvent(roomID), c.subject)
+	assert.Equal(t, subject.RoomEvent(roomID, true), c.subject)
 	var roomEvt model.EditRoomEvent
 	require.NoError(t, json.Unmarshal(c.data, &roomEvt))
 	assert.Equal(t, model.RoomEventMessageEdited, roomEvt.Type)
@@ -849,7 +856,7 @@ func TestHandleUpdated_RelaysPreviewObject(t *testing.T) {
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	require.Len(t, pub.records, 1)
@@ -886,7 +893,7 @@ func TestHandleDeleted_OmitsPreviewWhenNil(t *testing.T) {
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	require.Len(t, pub.records, 1)
@@ -922,12 +929,12 @@ func TestHandleUpdated_EncryptedChannel_EncryptsContent(t *testing.T) {
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	require.Len(t, pub.records, 1, "channel: single room-scoped publish")
 	c := pub.records[0]
-	assert.Equal(t, subject.RoomEvent(roomID), c.subject)
+	assert.Equal(t, subject.RoomEvent(roomID, true), c.subject)
 	var roomEvt model.EditRoomEvent
 	require.NoError(t, json.Unmarshal(c.data, &roomEvt))
 	assert.Empty(t, roomEvt.NewContent, "plaintext must be cleared when encrypted")
@@ -957,7 +964,7 @@ func TestHandleUpdated_MissingEditedAt_ReturnsError(t *testing.T) {
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 	err = h.HandleMessage(context.Background(), data)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing EditedAt")
@@ -992,12 +999,12 @@ func TestHandleDeleted_ChannelRoomScopedPublish(t *testing.T) {
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	require.Len(t, pub.records, 1, "channel: single room-scoped publish")
 	c := pub.records[0]
-	assert.Equal(t, subject.RoomEvent(roomID), c.subject)
+	assert.Equal(t, subject.RoomEvent(roomID, true), c.subject)
 	var roomEvt model.DeleteRoomEvent
 	require.NoError(t, json.Unmarshal(c.data, &roomEvt))
 	assert.Equal(t, model.RoomEventMessageDeleted, roomEvt.Type)
@@ -1007,6 +1014,195 @@ func TestHandleDeleted_ChannelRoomScopedPublish(t *testing.T) {
 	assert.Equal(t, "alice", roomEvt.DeletedBy)
 	assert.True(t, roomEvt.DeletedAt.Equal(deletedAt))
 	assert.True(t, roomEvt.UpdatedAt.Equal(deletedAt))
+}
+
+// buildDeletedEventData is a small helper shared by the ROOM_SUBJECT_MODE
+// routing tests below: it builds a HandleMessage-ready deleted-message
+// payload for room r1, so each test only needs to vary the handler's
+// routeMode and the room's CrossSite flag.
+func buildDeletedEventData(t *testing.T) []byte {
+	t.Helper()
+	deletedAt := time.Date(2026, 5, 14, 12, 10, 0, 0, time.UTC)
+	evt := model.MessageEvent{
+		Event:     model.EventDeleted,
+		SiteID:    "site-a",
+		Timestamp: deletedAt.UnixMilli(),
+		Message: model.Message{
+			ID:          "msg-1",
+			RoomID:      "r1",
+			UserID:      "u-alice",
+			UserAccount: "alice",
+			CreatedAt:   time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC),
+			UpdatedAt:   &deletedAt,
+		},
+	}
+	data, err := json.Marshal(&evt)
+	require.NoError(t, err)
+	return data
+}
+
+// subjectsOf extracts the recorded publish subjects, in order.
+func subjectsOf(pub *mockPublisher) []string {
+	subs := make([]string, len(pub.records))
+	for i, r := range pub.records {
+		subs[i] = r.subject
+	}
+	return subs
+}
+
+func TestBroadcast_GlobalMode_AlwaysGlobal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), buildDeletedEventData(t)))
+
+	capturedSubjects := subjectsOf(pub)
+	assert.Contains(t, capturedSubjects, "chat.room.r1.event")
+	assert.NotContains(t, capturedSubjects, "chat.local.room.r1.event")
+}
+
+func TestBroadcast_LocalMode_SameSiteUsesLocal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteLocal)
+	require.NoError(t, h.HandleMessage(context.Background(), buildDeletedEventData(t)))
+
+	capturedSubjects := subjectsOf(pub)
+	assert.Contains(t, capturedSubjects, "chat.local.room.r1.event")
+	assert.NotContains(t, capturedSubjects, "chat.room.r1.event")
+}
+
+func TestBroadcast_DualMode_SameSitePublishesBoth(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteDual)
+	require.NoError(t, h.HandleMessage(context.Background(), buildDeletedEventData(t)))
+
+	capturedSubjects := subjectsOf(pub)
+	assert.Contains(t, capturedSubjects, "chat.local.room.r1.event")
+	assert.Contains(t, capturedSubjects, "chat.room.r1.event")
+}
+
+// TestHandler_publishRoomEvent covers the routing fan-out: which target
+// subject(s) the helper publishes to for each (crossSite, routeMode) pair.
+func TestHandler_publishRoomEvent(t *testing.T) {
+	cases := []struct {
+		name      string
+		mode      subject.RoomRouteMode
+		crossSite *bool
+		want      []string
+	}{
+		{"global mode routes global", subject.RouteGlobal, ptrBool(false), []string{"chat.room.r1.event"}},
+		{"local mode same-site routes local", subject.RouteLocal, ptrBool(false), []string{"chat.local.room.r1.event"}},
+		{"local mode cross-site stays global", subject.RouteLocal, ptrBool(true), []string{"chat.room.r1.event"}},
+		{"local mode unknown stays global (fail-safe)", subject.RouteLocal, nil, []string{"chat.room.r1.event"}},
+		{"dual mode same-site publishes both", subject.RouteDual, ptrBool(false), []string{"chat.local.room.r1.event", "chat.room.r1.event"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pub := &mockPublisher{}
+			h := &Handler{pub: pub, routeMode: tc.mode}
+			require.NoError(t, h.publishRoomEvent(context.Background(), "r1", tc.crossSite, nil, []byte("{}"), "test"))
+			assert.Equal(t, tc.want, subjectsOf(pub))
+		})
+	}
+}
+
+// TestHandler_publishRoomEvent_TransitionGrace verifies that a room which just
+// flipped same-site→cross-site keeps a local copy during the grace window, so a
+// same-site member still on the local subject keeps receiving until it
+// re-subscribes.
+func TestHandler_publishRoomEvent_TransitionGrace(t *testing.T) {
+	pub := &mockPublisher{}
+	h := &Handler{pub: pub, routeMode: subject.RouteLocal}
+	flip := time.Now().UTC() // just flipped → within grace
+	require.NoError(t, h.publishRoomEvent(context.Background(), "r1", ptrBool(true), &flip, []byte("{}"), "test"))
+	assert.Equal(t, []string{"chat.local.room.r1.event", "chat.room.r1.event"}, subjectsOf(pub),
+		"during the grace window a flipped room publishes to both lanes")
+}
+
+// TestHandler_publishRoomEvent_DualPartialFailure verifies that a failure on an
+// earlier target (the local subject) does NOT abort the fan-out: the global
+// safety-net publish is still attempted, and the last error is returned so
+// JetStream redelivers.
+func TestHandler_publishRoomEvent_DualPartialFailure(t *testing.T) {
+	pub := &mockPublisher{failOn: map[string]error{"chat.local.room.r1.event": errors.New("local lane down")}}
+	h := &Handler{pub: pub, routeMode: subject.RouteDual}
+
+	err := h.publishRoomEvent(context.Background(), "r1", ptrBool(false), nil, []byte("{}"), "test")
+
+	require.Error(t, err)
+	assert.Equal(t, []string{"chat.local.room.r1.event", "chat.room.r1.event"}, subjectsOf(pub),
+		"global target must still be attempted after the local target fails")
+}
+
+func TestBroadcast_CrossSiteRoomAlwaysGlobal(t *testing.T) {
+	for _, mode := range []subject.RoomRouteMode{subject.RouteGlobal, subject.RouteDual, subject.RouteLocal} {
+		t.Run(fmt.Sprintf("mode=%d", mode), func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			store := NewMockStore(ctrl)
+			us := NewMockUserStore(ctrl)
+			pub := &mockPublisher{}
+			keyStore := NewMockRoomKeyProvider(ctrl)
+
+			room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(true)}
+			store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+
+			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, mode)
+			require.NoError(t, h.HandleMessage(context.Background(), buildDeletedEventData(t)))
+
+			capturedSubjects := subjectsOf(pub)
+			assert.Contains(t, capturedSubjects, "chat.room.r1.event")
+			assert.NotContains(t, capturedSubjects, "chat.local.room.r1.event")
+		})
+	}
+}
+
+// TestBroadcast_UnclassifiedRoomAlwaysGlobal is the fail-safe regression: a
+// room whose CrossSite is nil (never classified / not yet backfilled) must
+// route global in every mode, exactly like a confirmed cross-site room — an
+// unclassified room must never be silently treated as confirmed same-site.
+func TestBroadcast_UnclassifiedRoomAlwaysGlobal(t *testing.T) {
+	for _, mode := range []subject.RoomRouteMode{subject.RouteGlobal, subject.RouteDual, subject.RouteLocal} {
+		t.Run(fmt.Sprintf("mode=%d", mode), func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			store := NewMockStore(ctrl)
+			us := NewMockUserStore(ctrl)
+			pub := &mockPublisher{}
+			keyStore := NewMockRoomKeyProvider(ctrl)
+
+			room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"} // CrossSite unset (nil)
+			store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+
+			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, mode)
+			require.NoError(t, h.HandleMessage(context.Background(), buildDeletedEventData(t)))
+
+			capturedSubjects := subjectsOf(pub)
+			assert.Contains(t, capturedSubjects, "chat.room.r1.event")
+			assert.NotContains(t, capturedSubjects, "chat.local.room.r1.event")
+		})
+	}
 }
 
 func TestHandleDeleted_MissingUpdatedAt_ReturnsError(t *testing.T) {
@@ -1026,7 +1222,7 @@ func TestHandleDeleted_MissingUpdatedAt_ReturnsError(t *testing.T) {
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 	err = h.HandleMessage(context.Background(), data)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing UpdatedAt")
@@ -1068,7 +1264,7 @@ func TestHandleUpdated_DMRoom_FansOutToBothMembers(t *testing.T) {
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	require.Len(t, pub.records, 2, "per-user fan-out: one publish per DM member")
@@ -1123,7 +1319,7 @@ func TestHandleDeleted_DMRoom_FansOutToBothMembers(t *testing.T) {
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	require.Len(t, pub.records, 2, "per-user fan-out: one publish per DM member")
@@ -1179,7 +1375,7 @@ func TestHandleUpdated_BotDMRoom_SkipsBotAccount(t *testing.T) {
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	require.Len(t, pub.records, 1, "botDM: only the human recipient gets the live event")
@@ -1239,12 +1435,12 @@ func TestHandler_HandleMessage_ChannelEncryptionDisabled(t *testing.T) {
 			}
 
 			// nil keyStore — handler must NOT dereference it when encrypt=false
-			h := NewHandler(store, us, pub, nil, defaultParentFetcher, false)
+			h := NewHandler(store, us, pub, nil, defaultParentFetcher, false, subject.RouteGlobal)
 			err := h.HandleMessage(context.Background(), makeMessageEvent("room-1", tc.content, msgTime))
 			require.NoError(t, err)
 
 			require.Len(t, pub.records, 1)
-			assert.Equal(t, subject.RoomEvent("room-1"), pub.records[0].subject)
+			assert.Equal(t, subject.RoomEvent("room-1", true), pub.records[0].subject)
 
 			var evt model.RoomEvent
 			require.NoError(t, json.Unmarshal(pub.records[0].data, &evt))
@@ -1301,11 +1497,11 @@ func TestHandleReacted_ChannelRoomScopedPublish(t *testing.T) {
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	require.Len(t, pub.records, 2, "channel: room-scoped publish + author notification")
-	roomRec := findPublishRecord(pub.records, subject.RoomEvent(roomID))
+	roomRec := findPublishRecord(pub.records, subject.RoomEvent(roomID, true))
 	require.NotNil(t, roomRec, "room-scoped publish expected")
 	var roomEvt model.ReactRoomEvent
 	require.NoError(t, json.Unmarshal(roomRec.data, &roomEvt))
@@ -1351,7 +1547,7 @@ func TestHandleReacted_DMFanOut(t *testing.T) {
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	require.Len(t, pub.records, 3, "DM: one event per non-bot account + author notification")
@@ -1385,7 +1581,7 @@ func TestHandleReacted_MissingDelta_LogsAndDrops(t *testing.T) {
 	}
 	data, _ := json.Marshal(&evt)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 	err := h.HandleMessage(context.Background(), data)
 	require.NoError(t, err, "malformed event must be acked, not NAK-ed")
 	assert.Empty(t, pub.records)
@@ -1414,7 +1610,7 @@ func TestHandleReacted_MissingUpdatedAt_LogsAndDrops(t *testing.T) {
 	}
 	data, _ := json.Marshal(&evt)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 	err := h.HandleMessage(context.Background(), data)
 	require.NoError(t, err, "malformed event must be acked, not NAK-ed")
 	assert.Empty(t, pub.records)
@@ -1474,7 +1670,7 @@ func TestHandleReacted_AuthorNotificationPolicy(t *testing.T) {
 			data, err := json.Marshal(&evt)
 			require.NoError(t, err)
 
-			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 			require.NoError(t, h.HandleMessage(context.Background(), data))
 
 			notif := findPublishRecord(pub.records, subject.Notification(tc.authorAccount))
@@ -1536,7 +1732,7 @@ func TestHandleReacted_AuthorNotification_RoomType(t *testing.T) {
 			data, err := json.Marshal(&evt)
 			require.NoError(t, err)
 
-			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 			require.NoError(t, h.HandleMessage(context.Background(), data))
 
 			notif := findPublishRecord(pub.records, subject.Notification("bob"))
@@ -1596,10 +1792,10 @@ func TestHandleReacted_AuthorPublishFailure_RoomFanOutStillSucceeds(t *testing.T
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data),
 		"author-notify failure must not NAK the canonical event")
-	require.NotNil(t, findPublishRecord(pub.records, subject.RoomEvent(roomID)),
+	require.NotNil(t, findPublishRecord(pub.records, subject.RoomEvent(roomID, true)),
 		"room fan-out must still have published")
 }
 
@@ -1632,12 +1828,12 @@ func TestHandlePinned_ChannelRoomScopedPublish(t *testing.T) {
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	require.Len(t, pub.records, 1)
 	c := pub.records[0]
-	assert.Equal(t, subject.RoomEvent(roomID), c.subject)
+	assert.Equal(t, subject.RoomEvent(roomID, true), c.subject)
 	var roomEvt model.PinStateRoomEvent
 	require.NoError(t, json.Unmarshal(c.data, &roomEvt))
 	assert.Equal(t, model.RoomEventMessagePinned, roomEvt.Type)
@@ -1681,7 +1877,7 @@ func TestHandlePinned_DMRoom_FansOutToBothMembers(t *testing.T) {
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	require.Len(t, pub.records, 2)
@@ -1714,7 +1910,7 @@ func TestHandlePinned_MissingPinnedAt_ReturnsError(t *testing.T) {
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 	err = h.HandleMessage(context.Background(), data)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing PinnedAt")
@@ -1747,12 +1943,12 @@ func TestHandleUnpinned_ChannelRoomScopedPublish(t *testing.T) {
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	require.Len(t, pub.records, 1)
 	c := pub.records[0]
-	assert.Equal(t, subject.RoomEvent(roomID), c.subject)
+	assert.Equal(t, subject.RoomEvent(roomID, true), c.subject)
 	var roomEvt model.PinStateRoomEvent
 	require.NoError(t, json.Unmarshal(c.data, &roomEvt))
 	assert.Equal(t, model.RoomEventMessageUnpinned, roomEvt.Type)
@@ -1793,7 +1989,7 @@ func TestHandleUnpinned_DMRoom_FansOutToBothMembers(t *testing.T) {
 	data, err := json.Marshal(&evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	require.Len(t, pub.records, 2)
@@ -1928,7 +2124,7 @@ func TestHandleServerBroadcast_ThreadReplyAdded_FansOutBadge(t *testing.T) {
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	h.HandleServerBroadcast(context.Background(), data)
 
 	require.Len(t, pub.records, 1)
@@ -1974,7 +2170,7 @@ func TestHandleServerBroadcast_ThreadReplyAdded_PropagatesNewTlm(t *testing.T) {
 	data, err := json.Marshal(evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	h.HandleServerBroadcast(context.Background(), data)
 
 	require.Len(t, pub.records, 1)
@@ -2013,7 +2209,7 @@ func TestHandleServerBroadcast_ThreadReplyAdded_NilNewTlm_NoFieldInOutput(t *tes
 	data, err := json.Marshal(evt)
 	require.NoError(t, err)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	h.HandleServerBroadcast(context.Background(), data)
 
 	require.Len(t, pub.records, 1)
@@ -2051,7 +2247,7 @@ func TestHandleServerBroadcast_ThreadReplyAdded_MissingNewTCount_Skips(t *testin
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	h.HandleServerBroadcast(context.Background(), data)
 	assert.Empty(t, pub.records)
 }
@@ -2080,7 +2276,7 @@ func TestHandleServerBroadcast_ThreadReplyAdded_MissingParentMessageID_Skips(t *
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	h.HandleServerBroadcast(context.Background(), data)
 	assert.Empty(t, pub.records)
 }
@@ -2112,7 +2308,7 @@ func TestHandleServerBroadcast_ThreadReplyAdded_GetRoomError_LogsAndContinues(t 
 	data, _ := json.Marshal(evt)
 
 	// HandleServerBroadcast is fire-and-forget: errors are logged, not returned.
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	h.HandleServerBroadcast(context.Background(), data)
 	assert.Empty(t, pub.records)
 }
@@ -2151,7 +2347,7 @@ func TestHandleThreadCreated_ChannelRoom_FansOutToFollowers(t *testing.T) {
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	// bob and carol (followers) + alice (sender) included for multi-device parity
@@ -2200,7 +2396,7 @@ func TestHandleThreadCreated_ChannelRoom_NoFollowers_SendsToSenderOnly(t *testin
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 	// No other followers → sender still receives their own echo (multi-device parity).
 	require.Len(t, pub.records, 1)
@@ -2245,7 +2441,7 @@ func TestHandleThreadCreated_ChannelRoom_ParentAuthorFannedOutBeforeThreadRoomEx
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, parentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, parentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	got := map[string]bool{}
@@ -2287,7 +2483,7 @@ func TestHandleThreadCreated_DMRoom_FansOutToAllMembers(t *testing.T) {
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	require.Len(t, pub.records, 2, "DM thread reply fans out to all members")
@@ -2333,7 +2529,7 @@ func TestHandleThreadCreated_DMRoom_WithMention_NoSubscriptionWrite(t *testing.T
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 	require.Len(t, pub.records, 2)
 }
@@ -2374,7 +2570,7 @@ func TestHandleThreadCreated_ChannelExcludesRestrictedAndNonMemberMentions(t *te
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, stubParentFetcher{info: &ParentMessageInfo{CreatedAt: parentAt}}, false)
+	h := NewHandler(store, us, pub, keyStore, stubParentFetcher{info: &ParentMessageInfo{CreatedAt: parentAt}}, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	got := map[string]bool{}
@@ -2432,7 +2628,7 @@ func TestHandleThreadCreated_ChannelRoom_UsesEventParent_SkipsFetch(t *testing.T
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, parentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, parentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	got := map[string]bool{}
@@ -2485,7 +2681,7 @@ func TestHandleThreadCreated_ChannelRoom_MissingSenderAccount_FallsBackToFetch(t
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, parentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, parentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	got := map[string]bool{}
@@ -2534,7 +2730,7 @@ func TestHandleThreadUpdated_ChannelRoom_FansOutToFollowers(t *testing.T) {
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	// bob and carol (followers) + alice (sender) included for multi-device parity
@@ -2595,7 +2791,7 @@ func TestHandleThreadUpdated_ChannelExcludesRestrictedAndNonMemberMentions(t *te
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, stubParentFetcher{info: &ParentMessageInfo{CreatedAt: parentAt}}, false)
+	h := NewHandler(store, us, pub, keyStore, stubParentFetcher{info: &ParentMessageInfo{CreatedAt: parentAt}}, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	got := map[string]bool{}
@@ -2643,7 +2839,7 @@ func TestHandleThreadDeleted_ChannelExcludesRestrictedAndNonMemberMentions(t *te
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, stubParentFetcher{info: &ParentMessageInfo{CreatedAt: parentAt}}, false)
+	h := NewHandler(store, us, pub, keyStore, stubParentFetcher{info: &ParentMessageInfo{CreatedAt: parentAt}}, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	got := map[string]bool{}
@@ -2688,7 +2884,7 @@ func TestHandleThreadUpdated_ChannelRoom_GetThreadFollowersError(t *testing.T) {
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	err := h.HandleMessage(context.Background(), data)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "thread fan-out")
@@ -2731,7 +2927,7 @@ func TestHandleThreadUpdated_DMRoom_FansOutToAllMembers(t *testing.T) {
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	require.Len(t, pub.records, 2)
@@ -2783,7 +2979,7 @@ func TestHandleThreadDeleted_ChannelRoom_FansOutToFollowers(t *testing.T) {
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	// bob and carol (followers) + alice (sender) included for multi-device parity
@@ -2839,7 +3035,7 @@ func TestHandleThreadDeleted_ChannelRoom_WithBadgeUpdate(t *testing.T) {
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	// delete events to bob (follower) + alice (sender, multi-device parity) + 1 badge update (to room channel)
@@ -2847,7 +3043,7 @@ func TestHandleThreadDeleted_ChannelRoom_WithBadgeUpdate(t *testing.T) {
 	var sawBadge bool
 	deleteSubjects := map[string]bool{}
 	for _, r := range pub.records {
-		if r.subject == subject.RoomEvent("r1") {
+		if r.subject == subject.RoomEvent("r1", true) {
 			var tmEvt model.ThreadMetadataUpdatedEvent
 			require.NoError(t, json.Unmarshal(r.data, &tmEvt))
 			assert.Equal(t, model.ThreadActionReplyDeleted, tmEvt.Action)
@@ -2901,7 +3097,7 @@ func TestHandleThreadDeleted_DMRoom_FansOutToAllMembers(t *testing.T) {
 	}
 	data, _ := json.Marshal(evt)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
 	require.Len(t, pub.records, 2)
@@ -2924,7 +3120,7 @@ func TestPublishToThreadAccounts_AllFail_ReturnsError(t *testing.T) {
 	us := NewMockUserStore(ctrl)
 	keyStore := NewMockRoomKeyProvider(ctrl)
 
-	h := NewHandler(store, us, failPub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, failPub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	err := h.publishToThreadAccounts(context.Background(), []string{"alice", "bob"}, []byte(`{}`), "parent-1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "all 2 thread account publishes failed")
@@ -2939,7 +3135,7 @@ func TestPublishToThreadAccounts_PartialFail_ReturnsNil(t *testing.T) {
 	us := NewMockUserStore(ctrl)
 	keyStore := NewMockRoomKeyProvider(ctrl)
 
-	h := NewHandler(store, us, failPub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, failPub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	// alice succeeds, bob fails — partial failure must not trigger redelivery.
 	err := h.publishToThreadAccounts(context.Background(), []string{"alice", "bob"}, []byte(`{}`), "parent-1")
 	require.NoError(t, err)
@@ -2952,7 +3148,7 @@ func TestPublishToThreadAccounts_Empty_NoOp(t *testing.T) {
 	pub := &mockPublisher{}
 	keyStore := NewMockRoomKeyProvider(ctrl)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.publishToThreadAccounts(context.Background(), nil, []byte(`{}`), "parent-1"))
 	assert.Empty(t, pub.records)
 }
@@ -2999,7 +3195,7 @@ func TestHandleCreated_NonRename_NoRoomRenamedEvent(t *testing.T) {
 	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
 	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"sender"}).Return(nil, nil)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hello", msgTime)))
 
 	require.Len(t, pub.records, 1, "normal message: exactly one publish")
@@ -3021,7 +3217,7 @@ func TestHandleCreated_AdvancesSenderLastSeen(t *testing.T) {
 	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
 	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"sender"}).Return(nil, nil)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hello", msgTime)))
 }
 
@@ -3040,6 +3236,6 @@ func TestHandleCreated_AdvanceSenderLastSeen_FailureSwallowed(t *testing.T) {
 	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
 	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"sender"}).Return(nil, nil)
 
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hello", msgTime)))
 }

--- a/broadcast-worker/integration_test.go
+++ b/broadcast-worker/integration_test.go
@@ -82,7 +82,7 @@ func TestBroadcastWorker_ChannelRoom_Integration(t *testing.T) {
 	pub := &recordingPublisher{}
 	key := testRoomKey(t)
 	keyStore := &fakeRoomKeyProvider{pair: key}
-	handler := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	handler := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 
 	msgTime := time.Now().UTC().Truncate(time.Millisecond)
 	evt := model.MessageEvent{
@@ -98,7 +98,7 @@ func TestBroadcastWorker_ChannelRoom_Integration(t *testing.T) {
 
 	records := pub.getRecords()
 	require.Len(t, records, 1)
-	assert.Equal(t, subject.RoomEvent("r1"), records[0].subject)
+	assert.Equal(t, subject.RoomEvent("r1", true), records[0].subject)
 
 	roomEvt, msg := decryptClientMessage(t, records[0].data, key)
 	assert.Equal(t, "site-a", roomEvt.SiteID)
@@ -128,7 +128,7 @@ func TestBroadcastWorker_ChannelRoom_MentionAll_Integration(t *testing.T) {
 	pub := &recordingPublisher{}
 	key := testRoomKey(t)
 	keyStore := &fakeRoomKeyProvider{pair: key}
-	handler := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	handler := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 
 	msgTime := time.Now().UTC().Truncate(time.Millisecond)
 	evt := model.MessageEvent{
@@ -168,7 +168,7 @@ func TestBroadcastWorker_ChannelRoom_IndividualMention_Integration(t *testing.T)
 	pub := &recordingPublisher{}
 	key := testRoomKey(t)
 	keyStore := &fakeRoomKeyProvider{pair: key}
-	handler := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	handler := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 
 	msgTime := time.Now().UTC().Truncate(time.Millisecond)
 	evt := model.MessageEvent{
@@ -218,7 +218,7 @@ func TestBroadcastWorker_DMRoom_Integration(t *testing.T) {
 	us := userstore.NewMongoStore(db.Collection("users"))
 	pub := &recordingPublisher{}
 	keyStore := &fakeRoomKeyProvider{pair: nil}
-	handler := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true)
+	handler := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
 
 	msgTime := time.Now().UTC().Truncate(time.Millisecond)
 	evt := model.MessageEvent{
@@ -280,7 +280,7 @@ func TestBroadcastWorker_ChannelRoom_EncryptionDisabled_Integration(t *testing.T
 	pub := &recordingPublisher{}
 
 	// nil keyStore — encryption is disabled, handler must not consult it
-	handler := NewHandler(store, us, pub, nil, defaultParentFetcher, false)
+	handler := NewHandler(store, us, pub, nil, defaultParentFetcher, false, subject.RouteGlobal)
 
 	msgTime := time.Now().UTC().Truncate(time.Millisecond)
 	evt := model.MessageEvent{
@@ -296,7 +296,7 @@ func TestBroadcastWorker_ChannelRoom_EncryptionDisabled_Integration(t *testing.T
 
 	records := pub.getRecords()
 	require.Len(t, records, 1)
-	assert.Equal(t, subject.RoomEvent("rNoEnc"), records[0].subject)
+	assert.Equal(t, subject.RoomEvent("rNoEnc", true), records[0].subject)
 
 	var roomEvt model.RoomEvent
 	require.NoError(t, json.Unmarshal(records[0].data, &roomEvt))
@@ -331,7 +331,7 @@ func TestBroadcastWorker_PersistsLastMessage_Integration(t *testing.T) {
 	require.NoError(t, err)
 
 	pub := &recordingPublisher{}
-	h := NewHandler(cached, userstore.NewMongoStore(db.Collection("users")), pub, &fakeRoomKeyProvider{}, defaultParentFetcher, false)
+	h := NewHandler(cached, userstore.NewMongoStore(db.Collection("users")), pub, &fakeRoomKeyProvider{}, defaultParentFetcher, false, subject.RouteGlobal)
 
 	msgTime := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
 	evt := model.MessageEvent{

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -59,6 +59,7 @@ type config struct {
 	PProfEnabled         bool                    `env:"PPROF_ENABLED" envDefault:"false"`
 	MetricsAddr          string                  `env:"METRICS_ADDR"             envDefault:":9090"`
 	Mode                 stream.Pipeline         `env:"MODE,required"` // user | bot; drives all stream/subject wiring via pkg/stream.Resolve
+	RoomSubjectMode      string                  `env:"ROOM_SUBJECT_MODE"        envDefault:"global"`
 	Consumer             stream.ConsumerSettings `envPrefix:"CONSUMER_"`
 	Bootstrap            bootstrapConfig         `envPrefix:"BOOTSTRAP_"`
 	Encryption           encryptionConfig        `envPrefix:"ENCRYPTION_"`
@@ -80,6 +81,12 @@ func main() {
 
 	if err := model.SetPlatformAdminAccountPrefix(cfg.AdminAcctPrefix); err != nil {
 		slog.Error("invalid ADMIN_ACCT_PREFIX", "error", err)
+		os.Exit(1)
+	}
+
+	roomRouteMode, err := subject.ParseRoomRouteMode(cfg.RoomSubjectMode)
+	if err != nil {
+		slog.Error("invalid ROOM_SUBJECT_MODE", "error", err)
 		os.Exit(1)
 	}
 
@@ -189,7 +196,7 @@ func main() {
 	}
 
 	parentFetcher := newHistoryParentFetcher(nc)
-	handler := NewHandler(coalescer, us, publisher, keyProvider, parentFetcher, cfg.Encryption.Enabled)
+	handler := NewHandler(coalescer, us, publisher, keyProvider, parentFetcher, cfg.Encryption.Enabled, roomRouteMode)
 
 	// Core-NATS queue subscriber for server-broadcast events (e.g. thread tcount badge).
 	// Fire-and-forget: errors are logged inside HandleServerBroadcast; no retry path.

--- a/chat-frontend/src/api/_transport/subjects.test.js
+++ b/chat-frontend/src/api/_transport/subjects.test.js
@@ -28,8 +28,16 @@ describe('subjects', () => {
     expect(userRoomEvent('alice')).toBe('chat.user.alice.event.room')
   })
 
-  it('roomEvent still builds the per-room subject', () => {
-    expect(roomEvent('r1')).toBe('chat.room.r1.event')
+  it('roomEvent builds the global per-room subject when crossSite is true', () => {
+    expect(roomEvent('r1', true)).toBe('chat.room.r1.event')
+  })
+
+  it('roomEvent builds the local per-room subject when crossSite is false', () => {
+    expect(roomEvent('r1', false)).toBe('chat.local.room.r1.event')
+  })
+
+  it('roomEvent defaults to the global per-room subject when crossSite is undefined', () => {
+    expect(roomEvent('r1', undefined)).toBe('chat.room.r1.event')
   })
 
   it('memberAdd builds the add-member request subject', () => {

--- a/chat-frontend/src/api/_transport/subjects.ts
+++ b/chat-frontend/src/api/_transport/subjects.ts
@@ -25,8 +25,13 @@ export function msgDelete(account: string, roomId: string, siteId: string): stri
   return `chat.user.${account}.request.room.${roomId}.${siteId}.msg.delete`
 }
 
-export function roomEvent(roomId: string): string {
-  return `chat.room.${roomId}.event`
+// roomEvent builds the per-room channel-event subject. Cross-site rooms
+// stay on the global namespace (unchanged); same-site rooms route to the
+// local namespace so a down remote peer can't affect same-site delivery.
+// Fail-safe: only an explicit `false` routes to the site-local (leaf-filtered)
+// namespace; true/undefined/missing → global, matching the server-side default.
+export function roomEvent(roomId: string, crossSite: boolean): string {
+  return crossSite === false ? `chat.local.room.${roomId}.event` : `chat.room.${roomId}.event`
 }
 
 // roomCreate is the room-service create subject. The site segment is the

--- a/chat-frontend/src/api/fetchSidebarBuckets/index.ts
+++ b/chat-frontend/src/api/fetchSidebarBuckets/index.ts
@@ -177,7 +177,13 @@ async function fetchAllPages(
  *  embeds the fields we actually need under `sub.room` (userCount,
  *  lastMsgAt, lastMsgId, appCount); fields the reducer's `toSummary`
  *  doesn't read default to neutral zero/empty values so the type
- *  contract is satisfied. */
+ *  contract is satisfied.
+ *
+ *  `crossSite` is tri-state on the wire: an explicit `true`/`false` is
+ *  authoritative (global/local); ABSENT means the room's locality is
+ *  unknown/unclassified (server hasn't backfilled it yet) and defaults to
+ *  `true` (global) here — a missing flag must never be read as "safe to
+ *  route local". */
 function subToRoom(sub: DMSubscription, fallbackSiteId: string): Room {
   return {
     id: sub.roomId,
@@ -190,5 +196,6 @@ function subToRoom(sub: DMSubscription, fallbackSiteId: string): Room {
     lastMsgAt: sub.room?.lastMsgAt ?? undefined,
     createdAt: '',
     updatedAt: '',
+    crossSite: sub.room?.crossSite ?? true,
   }
 }

--- a/chat-frontend/src/api/subscribeToRoomEvents/index.ts
+++ b/chat-frontend/src/api/subscribeToRoomEvents/index.ts
@@ -1,11 +1,14 @@
 import { roomEvent } from '../_transport/subjects'
 import type { Nats, NatsSubscription, SubscriptionCallback } from '../types'
 
-/** Subscribe to a single channel's event stream. */
+/** Subscribe to a single channel's event stream. `crossSite` selects the
+ *  global (`chat.room.…`) vs local (`chat.local.room.…`) namespace —
+ *  callers must resolve it from the room object, defaulting to `true`
+ *  (global) when the flag is missing. */
 export function subscribeToRoomEvents(
   { subscribe }: Pick<Nats, 'subscribe'>,
-  { roomId }: { roomId: string },
+  { roomId, crossSite }: { roomId: string; crossSite: boolean },
   callback: SubscriptionCallback,
 ): NatsSubscription {
-  return subscribe(roomEvent(roomId), callback)
+  return subscribe(roomEvent(roomId, crossSite), callback)
 }

--- a/chat-frontend/src/api/types.ts
+++ b/chat-frontend/src/api/types.ts
@@ -30,6 +30,15 @@ export interface SubscriptionHRInfo {
 export interface SubscriptionRoom {
   siteId?: string
   name?: string
+  /** Mirrors model.Room.CrossSite — tri-state on the wire. `true` means the
+   *  room has ≥1 member whose home site differs from the room's own siteId;
+   *  `false` means the server has CONFIRMED the room is same-site; both are
+   *  authoritative. Selects the NATS namespace the client subscribes the
+   *  room's `.event` subject to (see `api/_transport/subjects.ts::roomEvent`).
+   *  ABSENT means unknown/unclassified (a pre-existing room the server
+   *  hasn't backfilled yet) — callers MUST default a missing value to `true`
+   *  (global) rather than `false`, matching the server's fail-safe. */
+  crossSite?: boolean
   userCount?: number
   appCount?: number
   lastMsgAt?: string | null
@@ -138,6 +147,10 @@ export interface Room {
   /** Set client-side on DM rooms so the sidebar has a friendly fallback
    *  while the canonical name lands via subscription.update. */
   subscriptionName?: string
+  /** Resolved (never missing) — see SubscriptionRoom.crossSite. Producers of
+   *  a `Room` MUST default a missing wire value to `true` (global) before
+   *  setting this field, so every consumer can read it directly. */
+  crossSite: boolean
 }
 
 /** Mirrors model.Participant — the embedded sender/reader on messages

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.test.jsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.test.jsx
@@ -44,6 +44,7 @@ function roomToSub(room) {
       userCount: room.userCount,
       lastMsgAt: room.lastMsgAt ?? null,
       lastMsgId: room.lastMsgId,
+      crossSite: room.crossSite,
     },
   }
 }
@@ -1012,6 +1013,119 @@ describe('RoomEventsProvider message.read wiring', () => {
   })
 })
 
+describe('RoomEventsProvider room subject routing by crossSite', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('subscribes a same-site room (crossSite:false) to the local namespace and a cross-site room (crossSite:true) to the global namespace', async () => {
+    const rooms = [
+      { id: 'L1', name: 'local-channel', type: 'channel', siteId: 'site-A', userCount: 2, lastMsgAt: null, crossSite: false },
+      { id: 'G1', name: 'global-channel', type: 'channel', siteId: 'site-A', userCount: 2, lastMsgAt: null, crossSite: true },
+    ]
+    const request = vi.fn().mockImplementation((subject, payload) => {
+      if (subject.endsWith('.subscription.list') && payload?.type === 'rooms')
+        return Promise.resolve({ subscriptions: rooms.map(roomToSub) })
+      if (subject.endsWith('.subscription.list')) return Promise.resolve({ subscriptions: [] })
+      throw new Error('unexpected request: ' + subject)
+    })
+    const subjects = []
+    const subscribe = vi.fn().mockImplementation((subject) => {
+      subjects.push(subject)
+      return { unsubscribe: vi.fn() }
+    })
+    const nats = mockNats({ request, subscribe })
+
+    render(wrap(<SummariesProbe />, nats))
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('2'))
+
+    expect(subjects).toContain('chat.local.room.L1.event')
+    expect(subjects).not.toContain('chat.room.L1.event')
+    expect(subjects).toContain('chat.room.G1.event')
+    expect(subjects).not.toContain('chat.local.room.G1.event')
+  })
+
+  it('defaults to the global namespace when crossSite is absent on the room (server fail-safe)', async () => {
+    const rooms = [
+      { id: 'M1', name: 'missing-flag-channel', type: 'channel', siteId: 'site-A', userCount: 2, lastMsgAt: null },
+    ]
+    const request = vi.fn().mockImplementation((subject, payload) => {
+      if (subject.endsWith('.subscription.list') && payload?.type === 'rooms')
+        return Promise.resolve({ subscriptions: rooms.map(roomToSub) })
+      if (subject.endsWith('.subscription.list')) return Promise.resolve({ subscriptions: [] })
+      throw new Error('unexpected request: ' + subject)
+    })
+    const subjects = []
+    const subscribe = vi.fn().mockImplementation((subject) => {
+      subjects.push(subject)
+      return { unsubscribe: vi.fn() }
+    })
+    const nats = mockNats({ request, subscribe })
+
+    render(wrap(<SummariesProbe />, nats))
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('1'))
+
+    expect(subjects).toContain('chat.room.M1.event')
+    expect(subjects).not.toContain('chat.local.room.M1.event')
+  })
+
+  it('drops the local subscription and opens the global one when a room flips crossSite false→true', async () => {
+    const request = vi.fn().mockImplementation((subject) => {
+      if (subject.endsWith('.subscription.list')) return Promise.resolve({ subscriptions: [] })
+      throw new Error('unexpected request: ' + subject)
+    })
+    const handlers = new Map()
+    const unsubs = {}
+    const subscribe = vi.fn().mockImplementation((subject, cb) => {
+      handlers.set(subject, cb)
+      const sub = { unsubscribe: vi.fn() }
+      unsubs[subject] = sub
+      return sub
+    })
+    const nats = mockNats({ request, subscribe })
+
+    render(wrap(<SummariesProbe />, nats))
+    await waitFor(() => expect(subscribe).toHaveBeenCalled())
+
+    // First "added": the room is same-site — local subject.
+    act(() => {
+      handlers.get('chat.user.alice.event.subscription.update')({
+        action: 'added',
+        subscription: {
+          roomId: 'flip1',
+          roomType: 'channel',
+          siteId: 'site-A',
+          name: 'flip-room',
+          room: { crossSite: false },
+        },
+      })
+    })
+    await waitFor(() =>
+      expect(subscribe.mock.calls.map((c) => c[0])).toContain('chat.local.room.flip1.event')
+    )
+    expect(unsubs['chat.local.room.flip1.event'].unsubscribe).not.toHaveBeenCalled()
+
+    // Server later reports the room is now cross-site — a second "added"
+    // nudge carries the updated flag. The old local sub must be dropped
+    // and the global one opened.
+    act(() => {
+      handlers.get('chat.user.alice.event.subscription.update')({
+        action: 'added',
+        subscription: {
+          roomId: 'flip1',
+          roomType: 'channel',
+          siteId: 'site-A',
+          name: 'flip-room',
+          room: { crossSite: true },
+        },
+      })
+    })
+    await waitFor(() =>
+      expect(subscribe.mock.calls.map((c) => c[0])).toContain('chat.room.flip1.event')
+    )
+    expect(unsubs['chat.local.room.flip1.event'].unsubscribe).toHaveBeenCalled()
+    expect(unsubs['chat.room.flip1.event'].unsubscribe).not.toHaveBeenCalled()
+  })
+})
+
 describe('RoomEventsProvider sidebar buckets bootstrap', () => {
   beforeEach(() => vi.clearAllMocks())
 
@@ -1480,6 +1594,70 @@ describe('RoomEventsProvider missing-key path', () => {
 
     expect(ensureKey).not.toHaveBeenCalled()
     expect(decrypt).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops a channel message whose decryption resolves after a user switch (stale-generation guard)', async () => {
+    // The real bug: alice's encrypted message is mid-decryption when the user
+    // switches to bob. The teardown sets cancelledRef=true and bob's new effect
+    // resets it to false, so the cancelledRef gate alone would let alice's late
+    // decrypt dispatch into bob's session. The generation guard must drop it.
+    let resolveDecrypt
+    const decrypt = vi.fn().mockImplementation(
+      () => new Promise((res) => { resolveDecrypt = res })
+    )
+    currentRoomKeysMock = { decrypt, hasKey: () => true, ensureKey: async () => false }
+
+    const handlers = new Map()
+    const subscribe = vi.fn().mockImplementation((subject, cb) => {
+      handlers.set(subject, cb)
+      return { unsubscribe: vi.fn() }
+    })
+    const aliceRequest = vi.fn().mockImplementation((subject, payload) => {
+      if (subject.endsWith('.subscription.list') && payload?.type === 'rooms') {
+        return Promise.resolve({
+          subscriptions: [
+            roomToSub({ id: 'r1', type: 'channel', siteId: 'site-A', userCount: 2, lastMsgId: null, crossSite: true }),
+          ],
+        })
+      }
+      if (subject.endsWith('.subscription.list')) return Promise.resolve({ subscriptions: [] })
+      throw new Error('unexpected request: ' + subject)
+    })
+    const bobRequest = vi.fn().mockImplementation((subject) => {
+      if (subject.endsWith('.subscription.list')) return Promise.resolve({ subscriptions: [] })
+      throw new Error('unexpected request: ' + subject)
+    })
+
+    const aliceNats = mockNats({ request: aliceRequest, subscribe, user: { account: 'alice', siteId: 'site-A' } })
+    const bobNats = mockNats({ request: bobRequest, subscribe, user: { account: 'bob', siteId: 'site-A' } })
+
+    let probeMessages
+    function Probe() {
+      const { messages } = useRoomEvents('r1')
+      probeMessages = messages
+      return <div data-testid="messages">{messages.map((m) => m.id).join(',')}</div>
+    }
+
+    const { rerender } = render(wrap(<Probe />, aliceNats))
+    await waitFor(() => expect(handlers.has('chat.room.r1.event')).toBe(true))
+
+    // Alice's message arrives; decryption starts but is left pending.
+    act(() => { handlers.get('chat.room.r1.event')(encEvent) })
+    await waitFor(() => expect(decrypt).toHaveBeenCalledTimes(1))
+
+    // Switch to bob: cleanup (cancelledRef=true) then a fresh effect
+    // (cancelledRef=false, generationRef bumped).
+    rerender(wrap(<Probe />, bobNats))
+    await waitFor(() => expect(bobRequest).toHaveBeenCalled())
+
+    // Alice's decrypt resolves late — the guard must drop the whole continuation.
+    await act(async () => {
+      resolveDecrypt(decryptedPayload)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(probeMessages.some((m) => m.id === 'm1')).toBe(false)
   })
 })
 

--- a/chat-frontend/src/context/RoomEventsContext/useRoomSubscriptions.js
+++ b/chat-frontend/src/context/RoomEventsContext/useRoomSubscriptions.js
@@ -119,13 +119,24 @@ export function useRoomSubscriptions(
     cancelledRef.current = false
     generationRef.current += 1
 
+    // Snapshot this effect run's generation. A logout→login (or nats reconnect)
+    // tears this effect down and starts a fresh one, which flips cancelledRef
+    // back to false and bumps the generation. A subscription callback still in
+    // flight from the PRIOR run — e.g. a channel/DM message whose decryption
+    // resolves after the teardown — would otherwise pass the cancelledRef gate
+    // (now reset) and leak a stale-session event into the new session. Gate
+    // every dispatch and every post-decryption continuation on this value so
+    // work started under one login never lands under the next.
+    const effectGeneration = generationRef.current
+    const isCurrent = () => !cancelledRef.current && generationRef.current === effectGeneration
+
     // Capture the nats value at effect-run time for the one-shot
     // listRooms() below. Long-lived callbacks read natsRef.current
     // directly so they pick up a fresh nc after a reconnect.
     const liveNats = natsRef.current
 
     const safeDispatch = (action) => {
-      if (cancelledRef.current) return
+      if (!isCurrent()) return
       dispatch(action)
     }
 
@@ -335,6 +346,11 @@ export function useRoomSubscriptions(
         // eslint-disable-next-line no-console
         console.warn('decryptAndDispatch failed; forwarding original event', err)
       }
+      // The await(s) above span the effect-teardown window: if a logout→login
+      // cycled the effect while decryption was in flight, drop the whole
+      // continuation (dispatch + thread fan-out + mark-read) so a prior
+      // session's message can't surface in the new one.
+      if (!isCurrent()) return
       finalize(decoded)
     }
 
@@ -354,9 +370,22 @@ export function useRoomSubscriptions(
       })
     })
 
-    const openChannelSub = (roomId) => {
-      if (channelSubs.current.has(roomId)) return
-      const sub = subscribeToRoomEvents(natsRef.current, { roomId }, (evt) => {
+    // `crossSite` selects the subject namespace (see subscribeToRoomEvents /
+    // roomEvent) — global `chat.room.…` when true, local `chat.local.room.…`
+    // when false. Bookkeeping is keyed on that resolved value alongside the
+    // roomId: a repeat call with the SAME crossSite is a no-op, but a call
+    // that carries a DIFFERENT crossSite (the room's cross-site status
+    // flipped between the sub that opened it and this one) tears down the
+    // stale subject's subscription and opens the new one, so a room is
+    // never double-subscribed or left on a stale namespace.
+    const openChannelSub = (roomId, crossSite) => {
+      const existing = channelSubs.current.get(roomId)
+      if (existing) {
+        if (existing.crossSite === crossSite) return
+        existing.sub.unsubscribe()
+        channelSubs.current.delete(roomId)
+      }
+      const sub = subscribeToRoomEvents(natsRef.current, { roomId, crossSite }, (evt) => {
         enqueueByRoom(evt?.roomId ?? roomId, () => {
           if (evt?.type === 'new_message') {
             return decryptAndDispatch(evt, (decoded) => {
@@ -380,13 +409,13 @@ export function useRoomSubscriptions(
           handleMutationEvent(evt)
         })
       })
-      channelSubs.current.set(roomId, sub)
+      channelSubs.current.set(roomId, { sub, crossSite })
     }
 
     const closeChannelSub = (roomId) => {
-      const sub = channelSubs.current.get(roomId)
-      if (sub) {
-        sub.unsubscribe()
+      const entry = channelSubs.current.get(roomId)
+      if (entry) {
+        entry.sub.unsubscribe()
         channelSubs.current.delete(roomId)
       }
     }
@@ -412,7 +441,11 @@ export function useRoomSubscriptions(
           subscriptionName: sub.name,
         }
         safeDispatch({ type: 'ROOM_ADDED', room })
-        if (sub.roomType === 'channel') openChannelSub(sub.roomId)
+        // crossSite is absent on this event's embedded room today (the
+        // live "added" payload carries the stored Subscription, not the
+        // read-time enrichment) — default to true (global), the server's
+        // fail-safe, rather than assume same-site.
+        if (sub.roomType === 'channel') openChannelSub(sub.roomId, sub.room?.crossSite ?? true)
       } else if (evt.action === 'removed') {
         const roomId = evt.subscription?.roomId
         if (!roomId) return
@@ -463,7 +496,7 @@ export function useRoomSubscriptions(
         }
         if (keyEntries.length > 0) seedKeysRef.current(keyEntries)
         for (const r of buckets.rooms) {
-          if (r.type === 'channel') openChannelSub(r.id)
+          if (r.type === 'channel') openChannelSub(r.id, r.crossSite)
         }
       })
       .catch((err) => {
@@ -476,7 +509,7 @@ export function useRoomSubscriptions(
       dmSub.unsubscribe()
       subUpdate.unsubscribe()
       metaUpdate.unsubscribe()
-      for (const sub of channelSubs.current.values()) sub.unsubscribe()
+      for (const entry of channelSubs.current.values()) entry.sub.unsubscribe()
       channelSubs.current.clear()
       dispatchChains.clear()
       // Cancel any in-flight mark-read trailing timer so it doesn't

--- a/docker-local/setup.sh
+++ b/docker-local/setup.sh
@@ -55,6 +55,7 @@ docker run --rm \
     nsc edit signing-key --account chatapp --sk generate --role scoped_user \
       --allow-sub "chat.user.{{tag(account)}}.>" \
       --allow-sub "chat.room.>" \
+      --allow-sub "chat.local.room.>" \
       --allow-sub "_INBOX.>" \
       --allow-sub "chat.user.presence.state.*" \
       --allow-pub "chat.user.{{tag(account)}}.>" \

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -161,7 +161,8 @@ Login is a three-step sequence: portal userInfo lookup (§2.3) resolves the user
 | Publish | `_INBOX.>` | Required for the standard NATS request/reply pattern (the auto-generated reply inbox). |
 | Publish | `chat.user.presence.*.query.batch` | Batch presence-state queries. Read-only for the state broadcast (`chat.user.presence.state.*`) — this subject is deliberately named `query` so it cannot match the state pub-rule. |
 | Subscribe | `chat.user.{account}.>` | Receives all responses, notifications, and per-user events. |
-| Subscribe | `chat.room.>` | Subscribes to per-room message streams and room events for any room the user belongs to. |
+| Subscribe | `chat.room.>` | Subscribes to per-room message streams and room events for cross-site rooms (`crossSite: true`) the user belongs to. |
+| Subscribe | `chat.local.room.>` | Subscribes to per-room message streams and room events for same-site rooms (`crossSite: false`) the user belongs to. |
 | Subscribe | `_INBOX.>` | Required to receive replies to client-issued requests. |
 | Subscribe | `chat.user.presence.state.*` | Read anyone's live presence state broadcast. |
 
@@ -170,7 +171,7 @@ Permissions and connection limits come from the auth-service account's scoped si
 **Recommended baseline subscriptions on connect:**
 
 - `chat.user.{account}.>` — captures every personal event including async replies, per-user room events (DM messages, edits, deletes), room-key events, subscription updates, and settings updates.
-- `chat.room.{roomID}.event` for each channel room in the user's sidebar — receives new messages plus edit/delete events for that channel.
+- the room-event subject for each channel room in the user's sidebar — receives new messages plus edit/delete events for that channel. Pick the subject by the room's `crossSite` flag (from `subscription.list`): `chat.room.{roomID}.event` when `crossSite: true`, `chat.local.room.{roomID}.event` when `crossSite: false`. **Absent/unknown `crossSite` defaults to the global `chat.room.{roomID}.event`** (fail-safe — a global room misrouted to the local subject would silently miss cross-site delivery).
 
 The exact event subjects a client may receive as a result of an RPC are listed under each method's "Triggered events" sections in §2.2, §3, and §4.
 
@@ -911,6 +912,7 @@ top-level `siteId`. All fields are optional (omitted when zero/unset).
 | Field | Type | Notes |
 |---|---|---|
 | `siteId` | string | The room's home site. |
+| `crossSite` | bool | Tri-state. `true` → the room's real-time events are on `chat.room.{roomId}.>` (cross-gateway); `false` → CONFIRMED same-site, on `chat.local.room.{roomId}.>` (site-local). Omitted when the room's locality is unknown/unclassified (a pre-existing room the server hasn't classified yet) — clients MUST treat a missing value as `true` (global), never as `false`. |
 | `name` | string | The room's canonical name (may differ from the subscription `name`). |
 | `userCount` | number | Member count — human members, including QA `p_` test accounts (ordinary users). |
 | `appCount` | number | App count — `.bot` bots plus the `p_admin` platform-admin pseudo-account. |

--- a/docs/superpowers/plans/2026-07-28-local-global-room-subjects.md
+++ b/docs/superpowers/plans/2026-07-28-local-global-room-subjects.md
@@ -1,0 +1,929 @@
+# Local/Global Room Subject Separation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route same-site rooms' `chat.room.{roomID}.>` events onto a leaf-filtered local namespace (`chat.local.room.{roomID}.>`) while cross-site rooms stay on the propagated global namespace, so same-site room subscriptions stop bloating the NATS supercluster gateway interest map.
+
+**Architecture:** A sticky `CrossSite` boolean on the `Room` doc (set by room-worker at the same points it federates membership) is the single source of truth. Publishers pick the namespace from it; clients read it via `subscription.list` and subscribe to the matching prefix. Global (`chat.room.>`, unchanged) is the fail-safe default; local is opt-in once the flag is proven false.
+
+**Tech Stack:** Go 1.25, NATS core + JetStream, MongoDB (`mongo-driver/v2`), `go.uber.org/mock`, `stretchr/testify`, testcontainers.
+
+## Global Constraints
+
+- Use `make` targets only, never raw `go` (`make test SERVICE=<name>`, `make lint`, `make generate SERVICE=<name>`, `make test-integration SERVICE=<name>`).
+- TDD Red-Green-Refactor for every task: failing test first, confirm it fails, minimal impl, confirm green, commit.
+- All model structs carry both `json` and `bson` tags; `camelCase` tags except `_id`.
+- NATS subjects only via `pkg/subject` builders — never raw `fmt.Sprintf` at call sites.
+- Generated mocks live in `mock_store_test.go` / `service/mocks/`; never hand-edit. Run `make generate SERVICE=<name>` after a store interface changes.
+- Minimum 80% package coverage; cover error/edge paths, not just happy path.
+- **Fail-safe invariant:** global is the safe default. Misclassifying a global room as local silently breaks remote delivery; the reverse only wastes interest. Never let a code path emit on the local prefix unless `CrossSite == false` is authoritative.
+- **Namespace mapping:** `global == true` → `chat.room.{roomID}.…` (propagated); `global == false` → `chat.local.room.{roomID}.…` (leaf-filtered). A publisher passes the room's `CrossSite` value as `global`.
+- Client-facing handler/schema changes must update `docs/client-api.md` (+ derived views) in the same PR.
+
+## Rollout Ordering (why the task order is safe)
+
+Every task through Task 11 leaves production behavior unchanged because publishers/clients still pass `global=true` (existing `chat.room.>`). The flag is populated but not yet honored. The flip to honoring it (Task 12) happens only after the backfill (Task 11) and the platform team's `chat.local.room.>` subscribe grant + leaf filter (Task 13 documents the handoff). Each task is independently deployable.
+
+## File Structure
+
+- `pkg/model/room.go` — add `Room.CrossSite`.
+- `pkg/model/subscription.go` — add `SubscriptionRoom.CrossSite`, `EnrichedSubscription.CrossSite`.
+- `pkg/model/roominfo.go` (or wherever `RoomInfo` lives) — add `RoomInfo.CrossSite`.
+- `pkg/subject/subject.go` — locality-aware `RoomEvent`/`RoomMsgStream`/`RoomMetadataUpdate`.
+- `pkg/roommetacache/roommetacache.go` — `Meta.CrossSite` + Mongo projection.
+- `room-worker/store.go` + `store_mongo.go` — `SetRoomCrossSite`.
+- `room-worker/handler.go` — set flag in `processAddMembers` + `processCreateRoom`; transition nudge; publisher routing.
+- `room-service/handler.go` — `roomsInfoBatch` returns `CrossSite`; RoomEvent publisher routing.
+- `user-service/mongorepo/subscriptions.go` — `$lookup` projects `crossSite`.
+- `user-service/service/subscriptions.go` — `buildLocalRoom`/`applyRoomInfo` map `CrossSite`.
+- `broadcast-worker/handler.go` — route RoomEvent publishes by `meta.CrossSite`.
+- `tools/data-migration/` (or a room-worker one-off) — backfill existing cross-site rooms.
+- `auth-service/handler.go`, `docs/client-api.md` (+ `docs/client-api/*`), `docker-local/setup.sh` — permission + docs.
+
+---
+
+### Task 1: Model fields
+
+**Files:**
+- Modify: `pkg/model/room.go` (`Room` struct)
+- Modify: `pkg/model/subscription.go` (`SubscriptionRoom`, `EnrichedSubscription`)
+- Modify: `RoomInfo` struct file (run `grep -rn "type RoomInfo struct" pkg/model` to confirm path)
+- Test: `pkg/model/model_test.go`
+
+**Interfaces:**
+- Produces: `model.Room.CrossSite *bool`, `model.SubscriptionRoom.CrossSite *bool`, `model.EnrichedSubscription.CrossSite *bool` (bson `crossSite`), `model.RoomInfo.CrossSite *bool` (json `crossSite`). Tri-state; nil/absent == global (fail-safe).
+
+- [ ] **Step 1: Write the failing test** — add `Room` and `SubscriptionRoom` `CrossSite` to the round-trip coverage in `pkg/model/model_test.go`. Find the existing `roundTrip` cases for `Room`/`Subscription` and add an instance with `CrossSite: true`, asserting it survives marshal/unmarshal. Example addition:
+
+```go
+func TestRoom_CrossSiteRoundTrip(t *testing.T) {
+	r := model.Room{ID: "r1", SiteID: "site-a", CrossSite: true}
+	var got model.Room
+	roundTrip(t, r, &got)
+	assert.True(t, got.CrossSite)
+
+	sr := model.SubscriptionRoom{SiteID: "site-a", CrossSite: true}
+	var gotSR model.SubscriptionRoom
+	roundTripJSON(t, sr, &gotSR) // SubscriptionRoom is json-only (bson:"-")
+	assert.True(t, gotSR.CrossSite)
+}
+```
+
+If a `roundTripJSON` helper does not exist, marshal/unmarshal with `encoding/json` inline. Confirm which round-trip helpers exist first (`grep -n "func roundTrip" pkg/model/model_test.go`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test SERVICE=model` (or `go test ./pkg/model/ -run TestRoom_CrossSiteRoundTrip` via the Makefile wrapper)
+Expected: FAIL — `CrossSite` undefined on `model.Room`.
+
+- [ ] **Step 3: Add the fields.**
+
+In `pkg/model/room.go`, inside `type Room struct`, after `ExternalAccess`:
+```go
+	// CrossSite is tri-state: nil = unclassified, &true = ≥1 member
+	// whose home site differs from SiteID, &false = confirmed same-site. Sticky:
+	// true is never cleared. Drives local vs global room-subject routing
+	// (chat.local.room.> vs chat.room.>). Missing == nil == GLOBAL (fail-safe).
+	CrossSite *bool `json:"crossSite,omitempty" bson:"crossSite,omitempty"`
+```
+
+In `pkg/model/subscription.go`, inside `type SubscriptionRoom struct` (near `SiteID`):
+```go
+	// CrossSite mirrors Room.CrossSite so the client subscribes the room to the
+	// global (chat.room.>) or local (chat.local.room.>) namespace. Tri-state;
+	// absent == nil == global (fail-safe). bson:"-": read-time only.
+	CrossSite *bool `json:"crossSite,omitempty" bson:"-"`
+```
+
+In `type EnrichedSubscription struct`, alongside the other `$addFields` room projections:
+```go
+	CrossSite *bool `json:"-" bson:"crossSite,omitempty"`
+```
+
+In `type RoomInfo struct`, after `KeyVersion`:
+```go
+	CrossSite *bool `json:"crossSite,omitempty"`
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `make test SERVICE=model`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/model/
+git commit -m "feat(model): add CrossSite room-locality flag fields"
+```
+
+---
+
+### Task 2: Locality-aware subject builders
+
+**Files:**
+- Modify: `pkg/subject/subject.go` (`RoomEvent`, `RoomMsgStream`, `RoomMetadataUpdate`)
+- Modify callers (pass `true`, no behavior change): `room-service/handler.go:1435,1809`; `broadcast-worker/handler.go:463,669,818`; `room-worker/handler.go:2234`; `tools/loadgen/daily_pool.go:54,181`
+- Test: `pkg/subject/subject_test.go`
+
+**Interfaces:**
+- Produces: `subject.RoomEvent(roomID string, global bool) string`, `subject.RoomMsgStream(roomID string, global bool) string`, `subject.RoomMetadataUpdate(roomID string, global bool) string`. `global=true` → `chat.room.{roomID}.…`; `global=false` → `chat.local.room.{roomID}.…`.
+
+- [ ] **Step 1: Write the failing test** — add to `pkg/subject/subject_test.go`:
+
+```go
+func TestRoomSubjectLocality(t *testing.T) {
+	assert.Equal(t, "chat.room.r1.event", subject.RoomEvent("r1", true))
+	assert.Equal(t, "chat.local.room.r1.event", subject.RoomEvent("r1", false))
+	assert.Equal(t, "chat.room.r1.stream.msg", subject.RoomMsgStream("r1", true))
+	assert.Equal(t, "chat.local.room.r1.stream.msg", subject.RoomMsgStream("r1", false))
+	assert.Equal(t, "chat.room.r1.event.metadata.update", subject.RoomMetadataUpdate("r1", true))
+	assert.Equal(t, "chat.local.room.r1.event.metadata.update", subject.RoomMetadataUpdate("r1", false))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test SERVICE=subject` (or the Makefile's pkg test wrapper for `pkg/subject`)
+Expected: FAIL — too many arguments to `subject.RoomEvent`.
+
+- [ ] **Step 3: Rewrite the three builders** in `pkg/subject/subject.go`:
+
+```go
+// roomBase returns the room-scoped subject root. global=true keeps the
+// gateway-propagated chat.room.{roomID} root; global=false uses the
+// chat.local.room.{roomID} root, which the leaf node denies from interest
+// advertisement (site-local delivery for same-site-only rooms).
+func roomBase(roomID string, global bool) string {
+	if global {
+		return "chat.room." + roomID
+	}
+	return "chat.local.room." + roomID
+}
+
+func RoomEvent(roomID string, global bool) string {
+	return roomBase(roomID, global) + ".event"
+}
+
+func RoomMsgStream(roomID string, global bool) string {
+	return roomBase(roomID, global) + ".stream.msg"
+}
+
+func RoomMetadataUpdate(roomID string, global bool) string {
+	return roomBase(roomID, global) + ".event.metadata.update"
+}
+```
+
+- [ ] **Step 4: Update every non-test caller to pass `true`** (behavior unchanged this task). At each site listed under Files, change e.g. `subject.RoomEvent(room.ID)` → `subject.RoomEvent(room.ID, true)`. For the loadgen subscriber sites (`daily_pool.go:54,181`) pass `true` as well (they subscribe to the global namespace for now). Update the existing subject tests that call these builders to pass `true`.
+
+- [ ] **Step 5: Run tests to verify green**
+
+Run: `make test SERVICE=subject` then `make lint`
+Expected: PASS; no unused-arg or arity errors anywhere.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/subject/ room-service/ room-worker/ broadcast-worker/ tools/loadgen/
+git commit -m "feat(subject): locality-aware room subject builders (callers pass global=true)"
+```
+
+---
+
+### Task 3: roommetacache CrossSite
+
+**Files:**
+- Modify: `pkg/roommetacache/roommetacache.go` (`Meta`, `FetchFromMongo`, the `Wrapper` doc projection near line 193)
+- Test: `pkg/roommetacache/roommetacache_test.go`
+
+**Interfaces:**
+- Produces: `roommetacache.Meta.CrossSite *bool` (json `crossSite`), populated by `FetchFromMongo` and the wrapper loader from the room doc's `crossSite`.
+
+- [ ] **Step 1: Write the failing test** — in `roommetacache_test.go`, extend the existing `FetchFromMongo` test (or add one) to insert a room doc with `crossSite: true` and assert `meta.CrossSite == true`; insert one without it and assert `false`. Mirror the harness of the existing `FetchFromMongo` test (`grep -n "FetchFromMongo" pkg/roommetacache/*_test.go`).
+
+```go
+func TestFetchFromMongo_CrossSite(t *testing.T) {
+	// ... reuse existing test's Mongo setup (testutil.MongoDB) ...
+	_, err := rooms.InsertOne(ctx, bson.M{"_id": "rG", "siteId": "site-a", "crossSite": true})
+	require.NoError(t, err)
+	meta, err := roommetacache.FetchFromMongo(ctx, rooms, "rG")
+	require.NoError(t, err)
+	assert.True(t, meta.CrossSite)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test-integration SERVICE=roommetacache` (uses testcontainers Mongo) — or the unit variant if the existing test is unit-level.
+Expected: FAIL — `CrossSite` undefined / always false.
+
+- [ ] **Step 3: Add the field + projection.**
+
+In `type Meta struct`:
+```go
+	CrossSite *bool `json:"crossSite,omitempty"`
+```
+In `FetchFromMongo`'s `SetProjection`, add `"crossSite": 1,`; in its anonymous `doc` struct add a `CrossSite *bool` field tagged `bson:"crossSite"`; in the returned `Meta{...}` add `CrossSite: doc.CrossSite,`.
+Apply the same three additions to the `Wrapper` loader's inline projection/struct near line 193-207.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `make test-integration SERVICE=roommetacache`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/roommetacache/
+git commit -m "feat(roommetacache): project room CrossSite into cached Meta"
+```
+
+---
+
+### Task 4: room-worker store SetRoomCrossSite
+
+**Files:**
+- Modify: `room-worker/store.go` (interface), `room-worker/store_mongo.go` (impl)
+- Regenerate: `room-worker/mock_store_test.go` via `make generate SERVICE=room-worker`
+- Test: `room-worker/integration_test.go`
+
+**Interfaces:**
+- Produces: `SetRoomCrossSite(ctx context.Context, roomID string) error` on room-worker's `Store` — idempotent `$set crossSite=true` (sticky; never sets false).
+
+- [ ] **Step 1: Write the failing integration test** in `room-worker/integration_test.go` (mirror an existing store integration test's setup):
+
+```go
+func TestSetRoomCrossSite_Sticky(t *testing.T) {
+	// ... existing store test harness: db := testutil.MongoDB(t, "roomworker"); store := newMongoStore(db) ...
+	_, err := db.Collection("rooms").InsertOne(ctx, bson.M{"_id": "r1", "siteId": "site-a"})
+	require.NoError(t, err)
+	require.NoError(t, store.SetRoomCrossSite(ctx, "r1"))
+	var got model.Room
+	require.NoError(t, db.Collection("rooms").FindOne(ctx, bson.M{"_id": "r1"}).Decode(&got))
+	assert.True(t, got.CrossSite)
+	// idempotent second call
+	require.NoError(t, store.SetRoomCrossSite(ctx, "r1"))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test-integration SERVICE=room-worker`
+Expected: FAIL — `store.SetRoomCrossSite` undefined.
+
+- [ ] **Step 3: Add interface method + impl + mock.**
+
+In `room-worker/store.go` add to the `Store` interface:
+```go
+	// SetRoomCrossSite marks a room global (has a cross-site member). Sticky:
+	// idempotent, only ever sets crossSite=true.
+	SetRoomCrossSite(ctx context.Context, roomID string) error
+```
+In `room-worker/store_mongo.go`:
+```go
+func (s *mongoStore) SetRoomCrossSite(ctx context.Context, roomID string) error {
+	_, err := s.rooms.UpdateOne(ctx, bson.M{"_id": roomID}, bson.M{"$set": bson.M{"crossSite": true}})
+	if err != nil {
+		return fmt.Errorf("set room crossSite %s: %w", roomID, err)
+	}
+	return nil
+}
+```
+(Confirm the collection field name — `s.rooms` — against the existing store; adjust if different.)
+Then `make generate SERVICE=room-worker`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `make test-integration SERVICE=room-worker`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add room-worker/store.go room-worker/store_mongo.go room-worker/mock_store_test.go room-worker/integration_test.go
+git commit -m "feat(room-worker): SetRoomCrossSite sticky store method"
+```
+
+---
+
+### Task 5: room-worker sets CrossSite on member add
+
+**Files:**
+- Modify: `room-worker/handler.go` (`processAddMembers`, near the `accountsBySite` build ~line 1219)
+- Test: `room-worker/handler_test.go`
+
+**Interfaces:**
+- Consumes: `Store.SetRoomCrossSite` (Task 4).
+
+- [ ] **Step 1: Write the failing unit test** in `room-worker/handler_test.go` (mirror an existing `processAddMembers`/member-add test harness with the mocked store):
+
+```go
+func TestProcessAddMembers_SetsCrossSiteForRemoteMember(t *testing.T) {
+	// harness: mockStore expects SetRoomCrossSite once when a member's site != h.siteID
+	mockStore.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
+	// ... drive processAddMembers with req adding an account whose userMap site = "site-b", h.siteID = "site-a" ...
+}
+
+func TestProcessAddMembers_SameSite_NoCrossSiteWrite(t *testing.T) {
+	// all added members on h.siteID → SetRoomCrossSite must NOT be called
+	mockStore.EXPECT().SetRoomCrossSite(gomock.Any(), gomock.Any()).Times(0)
+	// ... drive processAddMembers with only same-site accounts ...
+}
+```
+
+Copy the exact mock/handler construction from the nearest existing `processAddMembers` test.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test SERVICE=room-worker`
+Expected: FAIL — `SetRoomCrossSite` never called (missing production code).
+
+- [ ] **Step 3: Add the write** in `processAddMembers`, immediately after `accountsBySite` is built (the map already keyed by remote sites, ~line 1219-1234):
+
+```go
+	// A non-empty remote-site bucket means this room now spans sites → mark it
+	// global so room-subject routing uses chat.room.> (propagated). Sticky.
+	if len(accountsBySite) > 0 {
+		if err := h.store.SetRoomCrossSite(ctx, req.RoomID); err != nil {
+			return fmt.Errorf("mark room cross-site: %w", err)
+		}
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `make test SERVICE=room-worker`
+Expected: PASS both cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add room-worker/handler.go room-worker/handler_test.go
+git commit -m "feat(room-worker): mark room CrossSite when adding a remote member"
+```
+
+---
+
+### Task 6: room-worker sets CrossSite on room create
+
+**Files:**
+- Modify: `room-worker/handler.go` (`processCreateRoom` ~line 1404, and `buildRoom`/`CreateRoom` write ~line 1371)
+- Test: `room-worker/handler_test.go`
+
+**Interfaces:**
+- Consumes: the created `model.Room` — set `CrossSite` on the doc before `store.CreateRoom` when initial members span sites.
+
+- [ ] **Step 1: Write the failing unit test** — mirror an existing `processCreateRoom` test:
+
+```go
+func TestProcessCreateRoom_CrossSiteAtBirth(t *testing.T) {
+	// Capture the Room passed to store.CreateRoom.
+	var created *model.Room
+	mockStore.EXPECT().CreateRoom(gomock.Any(), gomock.AssignableToTypeOf(&model.Room{}), gomock.Any()).
+		DoAndReturn(func(_ context.Context, r *model.Room, _ any) (string, error) { created = r; return r.ID, nil })
+	// ... drive processCreateRoom with a DM/channel whose members include a site-b user, h.siteID=site-a ...
+	assert.True(t, created.CrossSite)
+}
+
+func TestProcessCreateRoom_SameSite_NotCrossSite(t *testing.T) {
+	// all members on site-a → created.CrossSite == false
+}
+```
+
+Adjust the `CreateRoom` mock signature to match the real one (Task 4 area shows `store.CreateRoom(ctx, room, nil)`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test SERVICE=room-worker`
+Expected: FAIL — `created.CrossSite` is false.
+
+- [ ] **Step 3: Add the computation** where `processCreateRoom` assembles the member/site set (it already resolves each member's site to fan out inbox events per remote site — reuse that resolved set). Before `store.CreateRoom`, set:
+
+```go
+	// Born global if any initial member is off-site.
+	for _, u := range members { // the resolved member users with SiteID
+		if u.SiteID != "" && u.SiteID != h.siteID {
+			room.CrossSite = true
+			break
+		}
+	}
+```
+
+Use the same member/site collection the create path already builds for its remote-site inbox fan-out (`grep -n "remoteSiteAccounts\|u.SiteID" room-worker/handler.go` within `processCreateRoom`); do not introduce a second membership read.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `make test SERVICE=room-worker`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add room-worker/handler.go room-worker/handler_test.go
+git commit -m "feat(room-worker): set CrossSite at room creation when members span sites"
+```
+
+---
+
+### Task 7: room-service roomsInfoBatch returns CrossSite
+
+**Files:**
+- Modify: `room-service/handler.go` (`roomsInfoBatch` ~line 1130-1185, and the room projection it reads)
+- Test: `room-service/handler_test.go`
+
+**Interfaces:**
+- Consumes: `model.Room.CrossSite`. Produces: `model.RoomInfo.CrossSite` in the `RoomsInfoBatch` reply.
+
+- [ ] **Step 1: Write the failing unit test** — extend the existing `roomsInfoBatch` handler test so a room with `CrossSite:true` yields `info.CrossSite == true`. Mirror the existing test's mocked room store returning `[]model.Room`.
+
+```go
+func TestRoomsInfoBatch_CarriesCrossSite(t *testing.T) {
+	mockStore.EXPECT().GetRoomsInfo(gomock.Any(), gomock.Any()).
+		Return([]model.Room{{ID: "r1", SiteID: "site-a", CrossSite: true, Name: "x"}}, nil)
+	// ... call h.roomsInfoBatch with RoomRef{RoomID:"r1"} ...
+	assert.True(t, resp.Rooms[0].CrossSite)
+}
+```
+
+Confirm the real store method name the handler uses to load rooms (`grep -n "func (h \*Handler) roomsInfoBatch" -A40 room-service/handler.go`) and that its projection includes `crossSite` (add `"crossSite": 1` if it uses an explicit projection).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test SERVICE=room-service`
+Expected: FAIL — `resp.Rooms[0].CrossSite` false.
+
+- [ ] **Step 3: Map the field** where `roomsInfoBatch` builds each `model.RoomInfo` from a `model.Room`: add `CrossSite: room.CrossSite,`. If the handler projects room fields explicitly, add `crossSite` to that projection.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `make test SERVICE=room-service`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add room-service/handler.go room-service/handler_test.go
+git commit -m "feat(room-service): return CrossSite from RoomsInfoBatch"
+```
+
+---
+
+### Task 8: user-service $lookup projects crossSite
+
+**Files:**
+- Modify: `user-service/mongorepo/subscriptions.go` (the `$addFields`/`$project` room stages, ~lines 77 and 98)
+- Test: `user-service/mongorepo/subscriptions_integration_test.go` (or the existing aggregation integration test)
+
+**Interfaces:**
+- Produces: `EnrichedSubscription.CrossSite` populated from the joined room's `crossSite`.
+
+- [ ] **Step 1: Write the failing integration test** — mirror the existing aggregation test that inserts a room + subscription and asserts enriched fields; add a room with `crossSite:true` and assert the enriched sub's `CrossSite == true`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test-integration SERVICE=user-service`
+Expected: FAIL — `CrossSite` false.
+
+- [ ] **Step 3: Add to the projection.** In the `$addFields` stage that copies `"userCount": "$room.userCount"` (~line 98) add `"crossSite": "$room.crossSite",`. If a preceding `$project`/`$lookup` pipeline (~line 77) whitelists room fields, add `"crossSite": 1` there too so `$room.crossSite` is available.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `make test-integration SERVICE=user-service`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add user-service/mongorepo/subscriptions.go user-service/mongorepo/
+git commit -m "feat(user-service): project room crossSite into enriched subscription"
+```
+
+---
+
+### Task 9: user-service enrichment maps CrossSite to client payload
+
+**Files:**
+- Modify: `user-service/service/subscriptions.go` (`buildLocalRoom` ~384, `applyRoomInfo` ~427)
+- Test: `user-service/service/subscriptions_test.go`
+
+**Interfaces:**
+- Consumes: `EnrichedSubscription.CrossSite` (Task 8), `RoomInfo.CrossSite` (Task 7). Produces: `SubscriptionRoom.CrossSite` in `subscription.list` output.
+
+- [ ] **Step 1: Write the failing unit test:**
+
+```go
+func TestBuildLocalRoom_CrossSite(t *testing.T) {
+	sub := &model.EnrichedSubscription{}
+	sub.CrossSite = true
+	sub.RoomName = "chan"
+	got := buildLocalRoom(sub)
+	require.NotNil(t, got)
+	assert.True(t, got.CrossSite)
+}
+
+func TestApplyRoomInfo_CrossSite(t *testing.T) {
+	sub := &model.Subscription{}
+	drop := applyRoomInfo(sub, &model.RoomInfo{Found: true, Name: "chan", CrossSite: true})
+	assert.False(t, drop)
+	require.NotNil(t, sub.Room)
+	assert.True(t, sub.Room.CrossSite)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test SERVICE=user-service`
+Expected: FAIL — `got.CrossSite` false.
+
+- [ ] **Step 3: Map the field** — in `buildLocalRoom`, add `CrossSite: sub.CrossSite,` to the `&model.SubscriptionRoom{...}` literal; in `applyRoomInfo`, add `CrossSite: info.CrossSite,` to its `&model.SubscriptionRoom{...}` literal.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `make test SERVICE=user-service`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add user-service/service/subscriptions.go user-service/service/subscriptions_test.go
+git commit -m "feat(user-service): surface room CrossSite in subscription.list payload"
+```
+
+---
+
+### Task 10: `pkg/subject` route-mode + `RoomEventTargets` helper
+
+**Why the gate:** publisher and client cannot deploy atomically. A plain flip breaks same-site delivery during the rollout window (server-ahead-of-client OR client-ahead-of-server both drop messages), and "client subscribes to both prefixes" would defeat the interest reduction (the global sub still propagates cross-gateway). The safe migration is a server route-mode: `global` (default, current behavior) → `dual` (local rooms published to BOTH prefixes so old and new clients both receive) → `local` (local-only; reduction achieved with the leaf filter). The client always subscribes by the `crossSite` flag.
+
+**Files:**
+- Modify: `pkg/subject/subject.go`
+- Test: `pkg/subject/subject_test.go`
+
+**Interfaces:**
+- Produces: `type RoomRouteMode int` with `RouteGlobal`/`RouteDual`/`RouteLocal`; `ParseRoomRouteMode(s string) (RoomRouteMode, error)` (accepts `"global"`/`"dual"`/`"local"`, case-insensitive); `RoomEventTargets(roomID string, crossSite bool, mode RoomRouteMode) []string` (the subject(s) a room `.event` publish must fan out to). Reuses `RoomEvent(id, global bool)` from Task 2.
+
+- [ ] **Step 1: Write the failing table test** in `pkg/subject/subject_test.go`:
+
+```go
+func TestRoomEventTargets(t *testing.T) {
+	g := "chat.room.r1.event"
+	l := "chat.local.room.r1.event"
+	// cross-site rooms are ALWAYS global, in every mode
+	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", true, subject.RouteGlobal))
+	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", true, subject.RouteDual))
+	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", true, subject.RouteLocal))
+	// same-site rooms vary by mode
+	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", false, subject.RouteGlobal))
+	assert.Equal(t, []string{l, g}, subject.RoomEventTargets("r1", false, subject.RouteDual))
+	assert.Equal(t, []string{l}, subject.RoomEventTargets("r1", false, subject.RouteLocal))
+}
+
+func TestParseRoomRouteMode(t *testing.T) {
+	for in, want := range map[string]subject.RoomRouteMode{
+		"global": subject.RouteGlobal, "dual": subject.RouteDual, "local": subject.RouteLocal,
+		"GLOBAL": subject.RouteGlobal,
+	} {
+		got, err := subject.ParseRoomRouteMode(in)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	}
+	_, err := subject.ParseRoomRouteMode("bogus")
+	require.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `make test SERVICE=subject`
+Expected: FAIL — undefined identifiers.
+
+- [ ] **Step 3: Implement** in `pkg/subject/subject.go`:
+
+```go
+// RoomRouteMode selects which namespace(s) a same-site room's events publish to.
+// Cross-site rooms are always global regardless of mode. This gates a zero-gap
+// rollout: global (current) → dual (migration) → local (reduction achieved).
+type RoomRouteMode int
+
+const (
+	RouteGlobal RoomRouteMode = iota // same-site rooms → chat.room.> (default, no behavior change)
+	RouteDual                        // same-site rooms → chat.local.room.> AND chat.room.> (migration window)
+	RouteLocal                       // same-site rooms → chat.local.room.> only (final)
+)
+
+// ParseRoomRouteMode parses the ROOM_SUBJECT_MODE env value. Unknown → error (caller defaults to global).
+func ParseRoomRouteMode(s string) (RoomRouteMode, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "global":
+		return RouteGlobal, nil
+	case "dual":
+		return RouteDual, nil
+	case "local":
+		return RouteLocal, nil
+	default:
+		return RouteGlobal, fmt.Errorf("invalid room route mode %q (want global|dual|local)", s)
+	}
+}
+
+// RoomEventTargets returns the room .event subject(s) to publish to, given the
+// room's cross-site flag and the configured route mode. Order matters for dual:
+// local first, global second (callers publish to all and fail on first error).
+func RoomEventTargets(roomID string, crossSite bool, mode RoomRouteMode) []string {
+	global := RoomEvent(roomID, true)
+	if crossSite {
+		return []string{global}
+	}
+	switch mode {
+	case RouteLocal:
+		return []string{RoomEvent(roomID, false)}
+	case RouteDual:
+		return []string{RoomEvent(roomID, false), global}
+	default:
+		return []string{global}
+	}
+}
+```
+
+(`strings` is already imported in this file; confirm.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `make test SERVICE=subject` then `make lint`
+Expected: PASS; lint clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/subject/
+git commit -m "feat(subject): RoomRouteMode + RoomEventTargets for gated local/global routing"
+```
+
+---
+
+### Task 11: broadcast-worker routes room events via the mode gate
+
+**Files:**
+- Modify: `broadcast-worker/main.go` (or its `config.go`) — add `ROOM_SUBJECT_MODE` env, parse to `RoomRouteMode`, inject into `Handler`.
+- Modify: `broadcast-worker/handler.go` (the three `subject.RoomEvent(..., true)` sites: ~463, 669, 818)
+- Test: `broadcast-worker/handler_test.go`, `broadcast-worker/config_test.go`
+
+**Interfaces:**
+- Consumes: `subject.RoomEventTargets`, `subject.ParseRoomRouteMode`, `roommetacache.Meta.CrossSite` (Task 3). The `Handler` gains a `routeMode subject.RoomRouteMode` field set in its constructor.
+
+- [ ] **Step 1: Write the failing tests** in `broadcast-worker/handler_test.go` (mirror the existing publish-capture harness; `NewHandler` gains a mode arg — thread a default of `subject.RouteGlobal` through existing test constructions):
+
+```go
+func TestBroadcast_GlobalMode_AlwaysGlobal(t *testing.T) {
+	// handler routeMode = RouteGlobal, room CrossSite=false → subject chat.room.r1.event (unchanged)
+	assert.Contains(t, capturedSubjects, "chat.room.r1.event")
+	assert.NotContains(t, capturedSubjects, "chat.local.room.r1.event")
+}
+func TestBroadcast_LocalMode_SameSiteUsesLocal(t *testing.T) {
+	// routeMode = RouteLocal, room CrossSite=false → chat.local.room.r1.event only
+	assert.Contains(t, capturedSubjects, "chat.local.room.r1.event")
+	assert.NotContains(t, capturedSubjects, "chat.room.r1.event")
+}
+func TestBroadcast_DualMode_SameSitePublishesBoth(t *testing.T) {
+	// routeMode = RouteDual, room CrossSite=false → both subjects
+	assert.Contains(t, capturedSubjects, "chat.local.room.r1.event")
+	assert.Contains(t, capturedSubjects, "chat.room.r1.event")
+}
+func TestBroadcast_CrossSiteRoomAlwaysGlobal(t *testing.T) {
+	// any mode, room CrossSite=true → chat.room.r1.event only
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `make test SERVICE=broadcast-worker`
+Expected: FAIL — `NewHandler` arity / routing not implemented.
+
+- [ ] **Step 3: Add config + route.** In config: add a `RoomSubjectMode string` field tagged `env:"ROOM_SUBJECT_MODE" envDefault:"global"`; in `main.go` parse it via `subject.ParseRoomRouteMode` (log-and-exit on error, per the fail-fast config rule) and pass the `RoomRouteMode` into `NewHandler`, stored as `h.routeMode`. Replace each of the 3 publish sites. Each currently does one `h.pub.Publish(ctx, subject.RoomEvent(id, true), payload)`; change to fan out:
+
+```go
+	for _, subj := range subject.RoomEventTargets(room.ID, room.CrossSite, h.routeMode) {
+		if err := h.pub.Publish(ctx, subj, payload); err != nil {
+			return fmt.Errorf("publish room event to %s: %w", subj, err)
+		}
+	}
+```
+
+For the site at ~818 that uses `meta` and returns the publish error directly, use `meta.ID`, `meta.CrossSite`, and return the loop's error. Confirm the `room` value at 463/669 carries `CrossSite` (it is a `model.Room` / store room struct — if a projection omits `crossSite`, add it; the metacache `Meta` already has it from Task 3).
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `make test SERVICE=broadcast-worker` (covers the sonic wire-compat suite too) then `make lint`
+Expected: PASS; lint clean. Default `global` mode ⇒ byte-identical to pre-change behavior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add broadcast-worker/
+git commit -m "feat(broadcast-worker): route room events via ROOM_SUBJECT_MODE gate"
+```
+
+---
+
+### Task 12: room-service + room-worker route their room-event publishers via the mode gate
+
+**Files:**
+- Modify: `room-service/handler.go` (`subject.RoomEvent(..., true)` at ~1435, 1809) + its config/`main.go` for `ROOM_SUBJECT_MODE`.
+- Modify: `room-worker/handler.go` (`subject.RoomEvent(..., true)` at ~2234) + its config/`main.go`.
+- Test: `room-service/handler_test.go`, `room-worker/handler_test.go`, config tests.
+
+**Interfaces:**
+- Consumes: `subject.RoomEventTargets`, `subject.ParseRoomRouteMode`, `model.Room.CrossSite`. Each service's handler gains a `routeMode subject.RoomRouteMode`.
+
+- [ ] **Step 1: Write failing tests** in each file: with the handler's `routeMode=RouteLocal` and a `CrossSite:false` room, the publisher targets `chat.local.room.{id}.event`; with `RouteGlobal` (default) it targets `chat.room.{id}.event`; a `CrossSite:true` room is always global. Capture via the injected publish func. Thread a default `RouteGlobal` into existing handler constructions.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `make test SERVICE=room-service` and `make test SERVICE=room-worker`
+Expected: FAIL.
+
+- [ ] **Step 3: Add config + route.** Add a `RoomSubjectMode string` field tagged `env:"ROOM_SUBJECT_MODE" envDefault:"global"` to each service's config, parse via `subject.ParseRoomRouteMode` in `main.go` (fail-fast), inject into the handler as `routeMode`. At each publish site replace the single `Publish(subject.RoomEvent(roomID, true), …)` with a fan-out over `subject.RoomEventTargets(roomID, room.CrossSite, h.routeMode)`, attempting every target and returning the last error (so a dual-mode local-subject failure never skips the global publish; mirror Task 11 Step 3). Confirm the room value in scope carries `CrossSite` (add to the room projection on that path if explicit).
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `make test SERVICE=room-service`, `make test SERVICE=room-worker`, `make lint`
+Expected: PASS; lint clean; default `global` preserves current behavior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add room-service/ room-worker/
+git commit -m "feat(rooms): route room-event publishers via ROOM_SUBJECT_MODE gate"
+```
+
+---
+
+### Task 13: Backfill migration for existing cross-site rooms
+
+> **DROPPED** (post-implementation decision): the deployment starts from fresh data, so there are no pre-existing unclassified rooms to migrate. Runtime classification at create/member-add covers every room. The `tools/backfill-crosssite` job was removed from this PR. This task is retained for historical context only.
+
+**Files:**
+- Create: a one-off under `data-migration/` (read that service's structure first to match its pattern).
+- Test: migration test (unit where possible; integration is testcontainers-gated in this sandbox — write + vet under `-tags integration`, note non-execution).
+
+**Interfaces:** none exported; operates directly on Mongo.
+
+**Why:** before any site runs in `local`/`dual` mode, every already-cross-site room must have `crossSite=true`, or it would misroute to the filtered local namespace (fail-safe violation).
+
+- [ ] **Step 1: Write the test first** — seed a `rooms` doc `{_id:r1, siteId:site-a}` with subscriptions whose members resolve to sites `{site-a, site-b}` (cross-site) and a second room `{_id:r2, siteId:site-a}` all on `site-a`; run the backfill; assert `r1.crossSite==true` and `r2.crossSite` unset/false.
+
+- [ ] **Step 2: Run to verify it fails** (no migration yet).
+
+- [ ] **Step 3: Implement.** For each room, determine whether any member's home site differs from `room.siteId`. First establish where a member's home site lives: `grep -rn "SiteID" pkg/model/subscription.go pkg/model/user.go` — if the subscription stores only the room-scoped `siteId`, resolve member accounts to `users` and read `user.siteId` in batches. Set `crossSite=true` in bulk (`UpdateMany`) for the matched room IDs. Idempotent and re-runnable. Follow the existing `data-migration/` job wiring (config, Mongo connect, logging).
+
+- [ ] **Step 4: Verify** — `make test`/vet as available for the migration package; `make lint`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add data-migration/
+git commit -m "feat(data-migration): backfill crossSite=true for existing cross-site rooms"
+```
+
+---
+
+### Task 14: Local→global transition nudge
+
+*(unchanged from the original plan — publishes a per-user `event.room.update` nudge to existing members when `processAddMembers` flips a room local→global, so connected clients re-subscribe. Offline/dropped clients self-correct via `subscription.list`.)*
+
+**Files:**
+- Modify: `room-worker/handler.go` (`processAddMembers` — after the Task 5 `SetRoomCrossSite` call)
+- Test: `room-worker/handler_test.go`
+
+- [ ] **Step 1: Write the failing tests:**
+
+```go
+func TestProcessAddMembers_NudgesExistingMembersOnFlip(t *testing.T) {
+	// room previously local (loaded room CrossSite=false), adding a site-b member →
+	// expect a publish on subject.UserRoomUpdate(existingMemberAccount)
+}
+func TestProcessAddMembers_NoNudgeWhenAlreadyGlobal(t *testing.T) {
+	// loaded room CrossSite=true already → no nudge
+}
+```
+
+- [ ] **Step 2: Run to verify they fail** — `make test SERVICE=room-worker`.
+
+- [ ] **Step 3: Implement**, gating on the room's prior state (already loaded before the write). Only when `!room.CrossSite && len(accountsBySite) > 0`:
+
+```go
+	if !room.CrossSite && len(accountsBySite) > 0 {
+		// Room just flipped local→global. Nudge existing members' always-on per-user
+		// tree so connected clients re-fetch subscription.list and re-subscribe to the
+		// global namespace. Best-effort: offline/dropped clients self-correct on reconnect.
+		evt := model.RoomMetadataUpdateEvent{RoomID: req.RoomID, Timestamp: now.UnixMilli()}
+		data, _ := json.Marshal(evt)
+		for _, acc := range existingMemberAccounts { // members present BEFORE this add
+			if err := h.publish(ctx, subject.UserRoomUpdate(acc), data, ""); err != nil {
+				slog.WarnContext(ctx, "room-locality nudge publish failed", "account", acc, "roomId", req.RoomID)
+			}
+		}
+	}
+```
+
+Derive `existingMemberAccounts` from the pre-add membership `loadAddMemberInputs` already reads — no new read. Confirm the client already treats `event.room.update` as a trigger to refresh its subscription list; the nudge only needs to prompt a refresh (the flag is authoritative).
+
+- [ ] **Step 4: Run to verify they pass** — `make test SERVICE=room-worker`, `make lint`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add room-worker/handler.go room-worker/handler_test.go
+git commit -m "feat(room-worker): nudge existing members when a room flips local->global"
+```
+
+---
+
+### Task 15: chat-frontend subscribes by the `crossSite` flag
+
+**Files:**
+- Modify: `chat-frontend/src/api/_transport/subjects.ts` (the `chat.room.${roomId}.event` builder at ~line 29)
+- Modify: `chat-frontend/src/context/RoomEventsContext/` (the code that subscribes per room — it must pick the subject by the room's `crossSite` flag and re-subscribe when the flag changes)
+- Test: the matching `*.test.jsx`/`*.test.ts` (vitest) — `chat-frontend/src/context/RoomEventsContext/RoomEventsContext.test.jsx` already asserts on `chat.room.g1.event` subjects; extend it.
+
+**Interfaces:**
+- Consumes: `room.crossSite` (the `SubscriptionRoom.crossSite` field now returned by `subscription.list`, Task 9). Cross-site room → `chat.room.{id}.event` (unchanged); same-site room → `chat.local.room.{id}.event`.
+
+- [ ] **Step 1: Read the frontend conventions first.** `cat chat-frontend/CLAUDE.md` and read `subjects.ts` + the RoomEventsContext subscribe logic and its existing test, so the change matches house style (this is a JS/TS + vitest codebase, not Go — use its `npm`/`vitest` scripts from `package.json`, not `make`).
+
+- [ ] **Step 2: Write the failing vitest** in `RoomEventsContext.test.jsx` (mirror the existing subject-assertion tests): given a subscription list where room `L1` has `crossSite:false` and room `G1` has `crossSite:true`, assert the context subscribes to `chat.local.room.L1.event` and `chat.room.G1.event`. Add a case: when a room's `crossSite` flips false→true on a list refresh, the context unsubscribes `chat.local.room.…` and subscribes `chat.room.…`.
+
+- [ ] **Step 3: Run to verify it fails** — `cd chat-frontend && npm test -- RoomEventsContext` (or the repo's vitest invocation).
+
+- [ ] **Step 4: Implement.** In `subjects.ts` add/adjust the builder:
+
+```ts
+export function roomEventSubject(roomId: string, crossSite: boolean): string {
+  return crossSite ? `chat.room.${roomId}.event` : `chat.local.room.${roomId}.event`
+}
+```
+
+Update RoomEventsContext to compute each room's subject via `roomEventSubject(room.id, room.crossSite)`, and key its subscribe/unsubscribe bookkeeping on the computed subject so that a `crossSite` change on a `subscription.list` refresh drops the old subscription and creates the new one. Preserve existing behavior for cross-site rooms (they resolve to the unchanged `chat.room.…` subject, so `crossSite` defaulting to falsy must NOT silently route a genuinely-global room to local — confirm the flag is present in the room object the context reads; if absent for a room, default to the GLOBAL subject, matching the server's fail-safe).
+
+- [ ] **Step 5: Run to verify it passes** — `cd chat-frontend && npm test` (run the affected suites; ensure lint/format via the frontend's own tooling, e.g. `npm run lint`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add chat-frontend/src/api/_transport/subjects.ts chat-frontend/src/context/RoomEventsContext/
+git commit -m "feat(chat-frontend): subscribe rooms to local/global namespace by crossSite"
+```
+
+---
+
+### Task 16: Permissions, docs, and rollout runbook
+
+**Files:**
+- Modify: `auth-service/handler.go` (grants comment ~line 305)
+- Modify: `docker-local/setup.sh` (dev JWT sub-allow list)
+- Modify: `docs/client-api.md` (+ `docs/client-api/request-reply.md`, `docs/client-api/events.md` if the room payload / subscription.list table appears there)
+- Create/Modify: a rollout runbook section (in the design doc or a new `docs/` note)
+
+**Interfaces:** none (config + docs).
+
+- [ ] **Step 1:** `auth-service/handler.go` — add `chat.local.room.>` to the documented `Sub allow:` line, noting the live grant is the platform-team scoped-signing-key template and the leaf node denies `chat.local.>` from gateway interest.
+
+- [ ] **Step 2:** `docker-local/setup.sh` — add `chat.local.room.>` to the dev JWT subscribe allow list so same-site delivery works locally in `local`/`dual` mode.
+
+- [ ] **Step 3:** `docs/client-api.md` — add `crossSite` (type `bool`) to the room object / `subscription.list` payload field table; document that a same-site room's `chat.room.{roomID}.>` events move to `chat.local.room.{roomID}.>`; update §2.1 to list the `chat.local.room.>` subscribe grant. Update the derived views if the table appears there.
+
+- [ ] **Step 4: Rollout runbook** — document the `ROOM_SUBJECT_MODE` migration explicitly:
+  1. Platform adds `chat.local.room.>` to the production subscribe template. (No data backfill — deployments start from fresh data; every room is classified at creation/member-add.)
+  2. Deploy all publisher services with `ROOM_SUBJECT_MODE=dual` (same-site rooms now published to BOTH prefixes — old clients on `chat.room.>` and new clients on `chat.local.room.>` both receive; zero gap).
+  3. Deploy the frontend (Task 15): clients now subscribe same-site rooms on `chat.local.room.>`.
+  4. Once frontend rollout is complete, set publishers to `ROOM_SUBJECT_MODE=local` (drop the redundant global publish for same-site rooms).
+  5. Platform enables the leaf-node deny for `chat.local.>` → interest-map reduction realized. (Safe at any point from step 4 on; harmless before.)
+  Rollback at any step: set `ROOM_SUBJECT_MODE=global` — publishers revert to the current all-global behavior; clients subscribing `chat.local.…` simply receive nothing on same-site rooms until the next `subscription.list` refresh, so pair a rollback with reverting the frontend or accept a brief same-site gap.
+
+- [ ] **Step 5: Verify + commit**
+
+Run: `make lint`; `grep -rn "chat.local.room" docs/ auth-service/ docker-local/`
+Expected: prefix present in all three; lint clean.
+
+```bash
+git add auth-service/handler.go docker-local/setup.sh docs/client-api.md docs/client-api/ docs/superpowers/
+git commit -m "docs: local/global room namespaces, chat.local.room.> grant, ROOM_SUBJECT_MODE rollout"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Subject namespace scheme → Task 2. ✓
+- `Room.CrossSite` source of truth → Tasks 1, 4, 5, 6 (+ 2 fail-safe fixes: channel & serverCreateDM create paths). ✓
+- Write path at federation points → Tasks 5 (add), 6 (create); room-worker only (room-service is an RPC front). ✓
+- Publisher routing (broadcast-worker + room-service/worker), gated → Tasks 10 (helper+mode), 11, 12. ✓
+- Client payload + subscribe → Tasks 7, 8, 9 (payload) + Task 15 (frontend subscribe). ✓
+- Transition nudge (per-user, gap-tolerant) → Task 14. ✓
+- Backfill of pre-existing cross-site rooms → Task 13. ✓
+- Auth grant + docs + rollout → Task 16. ✓
+- Non-goals (per-user tree, demote) → excluded. ✓
+
+**Rollout-safety correction (this revision):** the original plan wrongly claimed Tasks 10-11 were behavior-preserving; they are the flip, and the required client-side subscribe change was missing. Fixed by: (a) a server `ROOM_SUBJECT_MODE` gate defaulting to `global` (zero behavior change until ops opts in) with a `dual` migration mode for a zero-gap cutover; (b) an explicit chat-frontend task to subscribe by the `crossSite` flag; (c) a step-by-step rollout runbook (Task 16 Step 4). Dual-publish is used ONLY as a transient migration mode (not per-room transitions — that remains gap-tolerant per the spec).
+
+**Type consistency:** `CrossSite *bool` (tri-state; nil/absent == global fail-safe) across `Room`/`SubscriptionRoom`/`EnrichedSubscription`/`RoomInfo`/`roommetacache.Meta`. `RoomEventTargets(roomID, crossSite, mode)` and `RoomRouteMode`/`ParseRoomRouteMode` consistent across Tasks 10-12. Frontend `roomEventSubject(roomId, crossSite)` maps crossSite→global exactly as the server's `RoomEventTargets` does for the non-dual case.

--- a/docs/superpowers/specs/2026-07-28-local-global-room-subjects-design.md
+++ b/docs/superpowers/specs/2026-07-28-local-global-room-subjects-design.md
@@ -1,0 +1,266 @@
+# Local/Global Room Subject Separation
+
+**Date:** 2026-07-28
+**Status:** Design — approved for planning
+**Scope:** Phase 1 — room-scoped subjects only
+
+## Problem
+
+All chat clients connect under a **single shared NATS account** (auth-service mints
+every user JWT against one `issuer_account`; the `{account}` token in
+`chat.user.{account}.>` is an application-level subject token, not a NATS account).
+
+In a NATS supercluster, gateway **interest** propagation is per NATS account and is
+all-or-nothing: once an account flips to interest-only mode, *every* subscription in
+it is propagated into *every* peer gateway's interest map. Because all users share one
+account, each connected client's per-room subscriptions (`chat.room.{roomID}.>`) are
+replicated into every site's gateway interest map — including the large majority that
+belong to rooms whose members are all on a single site and therefore never need
+cross-site delivery. That replicated interest state is the memory pressure we want to
+remove.
+
+Cross-site real-time message delivery **currently rides core gateway interest**: a
+remote member (`bob@siteB` in `roomR@siteA`) subscribes `chat.room.roomR.>`, and
+`broadcast-worker@siteA`'s publish crosses the A→B gateway because B propagated
+interest in that subject. Same-site rooms pay the same propagation cost for no benefit.
+
+## Goal
+
+Separate client-facing **room-scoped** subjects into a **local** namespace and a
+**global** namespace so that same-site rooms' interest is *not* advertised across the
+supercluster, while cross-site rooms continue to deliver over the gateway as they do
+today.
+
+**Infrastructure boundary:** the platform/NATS team filters the designated **local**
+prefix at the **leaf node** (denies it from interest advertisement across the
+supercluster). This design covers only the **application code** that must route each
+publish and subscribe to the correct namespace and classify each room correctly.
+
+## Non-Goals (Phase 1)
+
+- Splitting the per-user subject tree (`chat.user.{account}.>`). It stays fully global,
+  unchanged. (Future enhancement.)
+- Demoting a room from global back to local (`global → local`). Rooms are **sticky
+  global**. (Future enhancement.)
+
+## Core Principles
+
+1. **Global is the fail-safe default.** Misclassifying a *global* room as *local*
+   silently breaks remote delivery (interest is filtered, the publish never crosses).
+   Misclassifying a *local* room as *global* only wastes a little interest — no
+   correctness bug. So the system defaults to global whenever unsure and only routes to
+   local when it is certain the room is same-site-only. The existing `chat.room.>`
+   subjects remain the global namespace, so any un-updated caller degrades to
+   "works, no savings."
+
+2. **The persisted flag is the source of truth; the live event is only a latency
+   optimization.** Correctness never depends on any best-effort NATS event being
+   received — only promptness does. Every client reads each room's locality from its
+   normal bootstrap (`subscription.list`); the per-user transition event merely lets an
+   already-connected client re-subscribe sooner.
+
+## Classification
+
+A room is **global iff at least one member's home site differs from `room.SiteID`**,
+otherwise **local**.
+
+Persisted as a sticky tri-state pointer on the `Room` document:
+
+```go
+// Room document (pkg/model)
+// nil = unclassified; &true = cross-site; &false = confirmed same-site.
+// Missing == nil == GLOBAL (fail-safe); only an explicit false routes local.
+CrossSite *bool `json:"crossSite,omitempty" bson:"crossSite,omitempty"`
+```
+
+Phase 1 sets an explicit true/false at every create/add path and never clears
+true (sticky global); `nil` only ever occurs on a not-yet-classified room.
+
+The classification signal already exists at the right place: room-worker/room-service
+decide to federate a `member_added` across sites at exactly the points where a member's
+site differs from the room's site. We persist that decision rather than inventing new
+logic.
+
+## Subject Namespaces
+
+The unit is the entire `chat.room.{roomID}.>` subtree — one prefix decision per room
+covers `RoomEvent`, `RoomMsgStream`, and `RoomMetadataUpdate`.
+
+| Locality | Namespace | Gateway behavior |
+|----------|-----------|------------------|
+| Global (default) | `chat.room.{roomID}.>` (unchanged) | Advertised / propagated |
+| Local | `chat.local.room.{roomID}.>` | Denied at leaf node (site-local) |
+
+`chat.local.>` is a clean top-level prefix for the leaf-node deny rule.
+
+### `pkg/subject` changes
+
+The room-scoped builders take a locality argument instead of gaining parallel
+ad-hoc builders. Proposed signature (final form — bool vs a small `Locality` type — to
+be settled in the plan; a bool is sufficient):
+
+```go
+func RoomEvent(roomID string, global bool) string
+func RoomMsgStream(roomID string, global bool) string
+func RoomMetadataUpdate(roomID string, global bool) string
+```
+
+`global == true` → `chat.room.{roomID}.…`; `global == false` →
+`chat.local.room.{roomID}.…`. All three derive from a single internal base helper so
+the prefix rule lives in one place. Table tests cover both localities for each builder.
+
+## Write Path (who sets the flag)
+
+The flag is set true at the same points that already decide cross-site federation:
+
+- **Room creation** (channel & DM) — set `crossSite=true` when the initial member set
+  spans sites. A DM between two different-site users is born global.
+- **Member add** (room-worker **and** room-service) — if the added member's site ≠
+  `room.SiteID` and the room is not already global, set `crossSite=true`.
+- **Member remove** — no-op in phase 1 (sticky).
+
+## Publisher Routing
+
+Every `chat.room.{roomID}.>` publisher reads `crossSite` and picks the prefix:
+
+- **broadcast-worker** — add `CrossSite` to `roommetacache.Meta` (and its Mongo
+  projection). The hot-path fan-out already loads this `Meta` per room, so the prefix
+  choice is a free cache read.
+- **room-service / room-worker** — the metadata-update and room-event publishers read
+  the flag from the `Room` doc they already load.
+
+Publishers default to global if the flag is absent/unknown (fail-safe).
+
+## Client Routing & Transition
+
+- **Steady state:** the client learns each room's locality from a new field on the room
+  payload returned by `subscription.list`:
+
+  ```go
+  // SubscriptionRoom (pkg/model) — tri-state; absent == nil == global (fail-safe)
+  CrossSite *bool `json:"crossSite,omitempty" bson:"-"`
+  ```
+
+  It subscribes each room to `chat.local.room.{id}.>` or `chat.room.{id}.>` accordingly.
+
+- **Transition (local → global):** when a room's flag flips, a nudge rides the
+  **per-user** room-update event (`chat.user.{account}.event.room…`), which every member
+  is always subscribed to regardless of the room's prefix — so it reaches members even
+  after the publisher stops emitting on the local prefix. On receipt the client
+  re-subscribes that room to the global prefix. The newly-added remote member reads
+  `crossSite=true` from its initial `subscription.list` and subscribes global directly.
+
+- **Offline / dropped clients self-correct on bootstrap.** An offline client isn't
+  subscribed to anything; on reconnect it re-reads `subscription.list`, sees
+  `crossSite=true`, and subscribes global from the first subscription — it never needed
+  the event. A client disconnected as a slow consumer likewise recovers via the
+  reconnect + fresh `subscription.list`.
+
+- **Transition grace window closes the flip gap server-side.** When a *previously
+  confirmed same-site* room (`crossSite==false`) flips to cross-site, the flip time is
+  recorded as `Room.CrossSiteAt`, and for `RoomLocalityGrace` (15 min) afterward every
+  publisher emits the room's `.event` to **both** the local and global subjects (see
+  `pkg/subject.RoomEventTargets`). So a same-site member still subscribed to the local
+  subject keeps receiving in real time until it re-subscribes — the gap no longer depends
+  on the best-effort nudge being delivered or on client reconcile frequency. A client that
+  migrates within the window sees zero gap; the nudge is reduced to a pure latency
+  optimization. The double-publish is bounded (only rooms actively flipping, only for the
+  window) and site-local on the leaf-filtered subject, so the steady-state interest-map
+  savings are preserved. Rooms *born* cross-site get no `CrossSiteAt` and no grace (they
+  never had a local audience). Any residual gap past the window is still recovered by the
+  client's normal history/gap fetch.
+
+### Why the nudge is a single per-user publish (not two paths)
+
+Emitting the nudge on the room's local subject *in addition to* the per-user subject was
+considered and rejected: both are core-NATS server→client deliveries over the same TCP
+connection, so they share fate. A healthy connection already receives the per-user
+nudge; an unhealthy one drops both and the client reconnects (recovering via
+`subscription.list`). Core NATS has no single-message loss mode for a still-connected
+client, so a second server-side publish adds no meaningful reliability. Any extra
+insurance belongs client-side (periodic/foreground reconciliation), outside this design.
+
+## Auth / JWT Permission (platform-team touchpoint)
+
+Client JWT `Sub allow` currently lists `chat.room.>`. It must **also** allow
+`chat.local.room.>`. This is the auth-service scoped-signing-key **template** (mirrored
+in `docker-local/setup.sh` and `docs/client-api.md §2.1`), which is infra-owned; the
+code-side comment in `auth-service/handler.go` documents the effective grants and must be
+updated to match. Flagged as a required platform-team change. Clients only *subscribe* to
+room-scoped subjects (they publish sends on the user-scoped tree), so only the
+subscribe grant changes.
+
+## Documentation
+
+- **`docs/client-api.md`:** add the `crossSite` field to the room payload, document the
+  local/global room subject namespaces, and update §2.1 with the `chat.local.room.>`
+  subscribe grant. Update the derived views (`docs/client-api/request-reply.md`,
+  `docs/client-api/events.md`) if touched.
+
+## Testing (TDD)
+
+- **`pkg/subject`:** table tests asserting both localities for `RoomEvent`,
+  `RoomMsgStream`, `RoomMetadataUpdate`.
+- **Classification write sites:** unit tests (mocked store) at room creation and member
+  add in room-worker and room-service — same-site members leave `crossSite=false`, a
+  cross-site member sets it true, and it stays true (sticky) on subsequent same-site
+  adds.
+- **broadcast-worker routing:** `crossSite` in `Meta` → publishes on the correct prefix;
+  absent flag → global (fail-safe).
+- **Client-facing payload:** `subscription.list` enrichment carries `crossSite`.
+- **Integration tests** where a store contract changes (metacache projection, room
+  write path), per the repo's testcontainers conventions.
+
+## Rollout Ordering
+
+1. Land `CrossSite` on the model + write path (defaults false; no behavior change yet).
+2. Land the `pkg/subject` locality-aware builders (callers still pass `global=true`).
+3. Wire publishers and the client payload to the flag.
+4. Platform team adds the `chat.local.room.>` subscribe grant and the leaf-node filter.
+5. Flip publishers/clients to honor the flag (local rooms move to `chat.local.room.>`).
+
+Because global is the default at every step, each stage is safe to deploy independently;
+the memory savings only begin once step 4's grant + filter and step 5 are in place.
+
+## Rollout Runbook: `ROOM_SUBJECT_MODE` migration
+
+This is the operational sequence for cutting a live deployment from all-global room
+subjects to the local/global split, driven by the `ROOM_SUBJECT_MODE` gate
+(`global` default → `dual` → `local`).
+
+1. Platform adds `chat.local.room.>` to the production subscribe template.
+   (No data backfill: deployments start from fresh data, so every room is
+   classified `crossSite` at creation/member-add by `room-worker` — there are no
+   pre-existing unclassified rooms to migrate.)
+2. Deploy all publisher services (`broadcast-worker`, `room-service`, `room-worker`)
+   with `ROOM_SUBJECT_MODE=dual` — same-site rooms are published to **both**
+   prefixes; old clients (still subscribed on `chat.room.>`) and new clients (already
+   subscribed on `chat.local.room.>`) both receive — zero gap.
+3. Deploy the updated chat-frontend (subscribes same-site rooms on
+   `chat.local.room.>`).
+4. Once the frontend rollout completes, set publishers to `ROOM_SUBJECT_MODE=local`
+   (drop the redundant global publish for same-site rooms).
+5. Platform enables the leaf-node deny for `chat.local.>` from cross-gateway interest
+   propagation → interest-map reduction realized.
+
+**Rollback:** at any step, set `ROOM_SUBJECT_MODE=global` — publishers revert to
+publishing all rooms on the global prefix only.
+
+**Per-room flip after rollout — bounded by the grace window.** A local→global room
+**flip** (a same-site room gains a cross-site member) re-routes an already-connected
+client only when it re-subscribes. The **transition grace window** (see Client Routing &
+Transition: publishers dual-publish a flipped room to both subjects for `RoomLocalityGrace`)
+makes this gapless server-side for any client that re-subscribes within the window —
+whether via the nudge or its normal reconnect / periodic `subscription.list` reconcile.
+The nudge is therefore a latency optimization, not a correctness dependency.
+
+**Client contract for the flip (for the official client, not the internal
+chat-frontend test client):** to re-route *promptly* rather than at the next reconcile,
+subscribe to `chat.user.{account}.event.room.update` (the server's
+`subject.UserRoomUpdate` nudge — distinct from the general `event.room.metadata.update`)
+and, on receipt, refresh `subscription.list` and re-subscribe the room by its new
+`crossSite`. Correctness still rests on the persisted flag + history/gap fetch, so a
+client that only reconciles periodically is still correct as long as its reconcile
+interval is within the grace window. (The chat-frontend test client does not implement
+this yet; document the subject + event in `docs/client-api.md` before the official
+client is built.)

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -1940,12 +1940,51 @@ func TestSubscriptionRoomJSON(t *testing.T) {
 		assert.Equal(t, "2025-01-04T09:10:11Z", raw["minUserLastSeenAt"], "minUserLastSeenAt must be RFC3339, not epoch millis")
 	})
 
-	t.Run("zero value omits all fields", func(t *testing.T) {
+	t.Run("zero value omits all fields including crossSite", func(t *testing.T) {
 		// #nosec G117 -- test roundtrip on a model whose PrivateKey field is part of the wire schema
 		data, err := json.Marshal(&model.SubscriptionRoom{})
 		require.NoError(t, err)
+		// A nil CrossSite (unclassified/unbackfilled room) omits the field so the
+		// frontend's `?? true` default resolves it to global (fail-safe).
 		assert.JSONEq(t, `{}`, string(data))
 	})
+}
+
+func TestRoom_CrossSiteRoundTrip(t *testing.T) {
+	r := model.Room{ID: "r1", SiteID: "site-a", CrossSite: boolPtr(true),
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	var got model.Room
+	roundTrip(t, &r, &got)
+	require.NotNil(t, got.CrossSite)
+	assert.True(t, *got.CrossSite)
+
+	sr := model.SubscriptionRoom{SiteID: "site-a", CrossSite: boolPtr(true)}
+	var gotSR model.SubscriptionRoom
+	// SubscriptionRoom is json-only (bson:"-")
+	// #nosec G117 -- serialization test; PrivateKey field is part of the wire schema and unset here
+	data, err := json.Marshal(&sr)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, &gotSR))
+	require.NotNil(t, gotSR.CrossSite)
+	assert.True(t, *gotSR.CrossSite)
+
+	// An explicit false must still serialize: the frontend routes a room to the
+	// local NATS namespace only on an explicit crossSite:false, defaulting to
+	// global when the field is absent (nil). omitempty on a *bool only omits nil,
+	// never an explicit false, so this must not be dropped.
+	// #nosec G117 -- serialization test; PrivateKey field is part of the wire schema and unset here
+	falseB, err := json.Marshal(model.SubscriptionRoom{SiteID: "site-a", CrossSite: boolPtr(false)})
+	require.NoError(t, err)
+	assert.Contains(t, string(falseB), `"crossSite":false`)
+
+	// A nil CrossSite (unclassified) must omit the field entirely — never
+	// serialize as false, which would look like a confirmed same-site room.
+	// #nosec G117 -- serialization test; PrivateKey field is part of the wire schema and unset here
+	nilB, err := json.Marshal(model.SubscriptionRoom{SiteID: "site-a"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(nilB), `"crossSite"`)
 }
 
 func TestRoomInfo_MinUserLastSeenAt(t *testing.T) {
@@ -2896,6 +2935,10 @@ func TestSearchOrgsJSON(t *testing.T) {
 		assert.Equal(t, "DIV1", org["divisionId"])
 	})
 }
+
+// boolPtr returns a pointer to b, for constructing tri-state *bool fields
+// (e.g. Room.CrossSite) in test literals.
+func boolPtr(b bool) *bool { return &b }
 
 // roundTrip marshals src to JSON, unmarshals into dst, and compares.
 func roundTrip[T any](t *testing.T, src *T, dst *T) {

--- a/pkg/model/room.go
+++ b/pkg/model/room.go
@@ -32,10 +32,25 @@ type Room struct {
 	// migration import. Server-side provenance (persisted, not client-facing);
 	// empty for natively-created rooms.
 	Origin string `json:"-" bson:"origin,omitempty"`
+	// CrossSite is tri-state, sticky: &true = ≥1 member off SiteID (route global),
+	// &false = confirmed same-site (route local), nil = unclassified → global
+	// (fail-safe). See pkg/subject.RoomEventTargets.
+	CrossSite *bool `json:"crossSite,omitempty" bson:"crossSite,omitempty"`
+	// CrossSiteAt is the flip time, set only when a confirmed same-site room
+	// (crossSite==false) first becomes cross-site. Server-side only: publishers
+	// keep a RoomLocalityGrace window after it (nil for rooms born cross-site).
+	CrossSiteAt *time.Time `json:"-" bson:"crossSiteAt,omitempty"`
 }
 
 // OriginTeams marks a room/subscription imported from the Teams migration.
 const OriginTeams = "teams"
+
+// RoutesGlobal reports whether r resolves to the global namespace (nil or true
+// CrossSite; only explicit false is local). Nil-safe mirror of the
+// pkg/subject.RoomEventTargets fail-safe; a nil room is not routed global.
+func (r *Room) RoutesGlobal() bool {
+	return r != nil && (r.CrossSite == nil || *r.CrossSite)
+}
 
 // RoomsInfoBatchRequest is the NATS request body for the batch room info RPC.
 type RoomsInfoBatchRequest struct {
@@ -56,7 +71,11 @@ type RoomInfo struct {
 	MinUserLastSeenAt *int64  `json:"minUserLastSeenAt,omitempty"`
 	PrivateKey        *string `json:"privateKey,omitempty"`
 	KeyVersion        *int    `json:"keyVersion,omitempty"`
-	Error             string  `json:"error,omitempty"`
+	// CrossSite mirrors Room.CrossSite — nil (absent) means unclassified and
+	// resolves to global on the client; only an explicit true/false is
+	// authoritative. See Room.CrossSite.
+	CrossSite *bool  `json:"crossSite,omitempty" bson:"crossSite,omitempty"`
+	Error     string `json:"error,omitempty"`
 }
 
 // RoomsInfoBatchResponse contains one entry per requested roomID, in input order.

--- a/pkg/model/subscription.go
+++ b/pkg/model/subscription.go
@@ -94,6 +94,9 @@ type EnrichedSubscription struct {
 	MinUserLastSeenAt *time.Time `json:"-" bson:"minUserLastSeenAt,omitempty"`
 	AppCount          int        `json:"-" bson:"appCount,omitempty"`
 	RoomName          string     `json:"-" bson:"roomName,omitempty"` // room canonical name (distinct from the sub's display Name)
+	// CrossSite mirrors Room.CrossSite (tri-state: nil=unclassified, &true=cross-site,
+	// &false=confirmed same-site). See Room.CrossSite.
+	CrossSite *bool `json:"-" bson:"crossSite,omitempty"`
 	// Room E2E key baseline projected from the room's encKey sub-document by the rooms
 	// $lookup (current-slot priv/ver only); used to build sub.Room.PrivateKey/KeyVersion
 	// for LOCAL subs without a second key read. Cross-site subs carry zero values (the
@@ -109,6 +112,10 @@ type EnrichedSubscription struct {
 type SubscriptionRoom struct {
 	SiteID string `json:"siteId,omitempty" bson:"-"`
 	Name   string `json:"name,omitempty" bson:"-"`
+	// CrossSite tells the client which namespace to subscribe the room on: &false →
+	// local, &true → global. omitempty drops only nil, which the client's `?? true`
+	// fail-safe resolves to global; explicit false is never dropped. bson:"-": read-time.
+	CrossSite *bool `json:"crossSite,omitempty" bson:"-"`
 	// UserCount/AppCount/LastMsgID mirror the room-service room document (model.Room).
 	UserCount int `json:"userCount,omitempty" bson:"-"`
 	AppCount  int `json:"appCount,omitempty" bson:"-"`

--- a/pkg/roommetacache/integration_test.go
+++ b/pkg/roommetacache/integration_test.go
@@ -67,6 +67,36 @@ func TestReadThrough_NilClientReadsMongo(t *testing.T) {
 	assert.Equal(t, "ops", got.Name)
 }
 
+func TestFetchFromMongo_CrossSite(t *testing.T) {
+	ctx := context.Background()
+	db := testutil.MongoDB(t, "roommetacache")
+	rooms := db.Collection("rooms")
+
+	_, err := rooms.InsertOne(ctx, bson.M{"_id": "rG", "siteId": "site-a", "crossSite": true})
+	require.NoError(t, err)
+	meta, err := FetchFromMongo(ctx, rooms, "rG")
+	require.NoError(t, err)
+	require.NotNil(t, meta.CrossSite)
+	assert.True(t, *meta.CrossSite)
+
+	_, err = rooms.InsertOne(ctx, bson.M{"_id": "rI", "siteId": "site-a", "crossSite": false})
+	require.NoError(t, err)
+	meta, err = FetchFromMongo(ctx, rooms, "rI")
+	require.NoError(t, err)
+	require.NotNil(t, meta.CrossSite)
+	assert.False(t, *meta.CrossSite)
+
+	// A room with no crossSite field at all (unclassified/unbackfilled) must
+	// decode as nil, never false — the fail-safe treats nil as global, so
+	// coercing it to false here would silently misroute a genuinely cross-site
+	// room that just hasn't been backfilled yet.
+	_, err = rooms.InsertOne(ctx, bson.M{"_id": "rH", "siteId": "site-a"})
+	require.NoError(t, err)
+	meta, err = FetchFromMongo(ctx, rooms, "rH")
+	require.NoError(t, err)
+	assert.Nil(t, meta.CrossSite)
+}
+
 func TestBustMeta_RemovesL2Entry(t *testing.T) {
 	ctx := context.Background()
 	client := setupValkey(t)

--- a/pkg/roommetacache/roommetacache.go
+++ b/pkg/roommetacache/roommetacache.go
@@ -42,6 +42,12 @@ type Meta struct {
 	Name      string         `json:"name"`
 	SiteID    string         `json:"siteId"`
 	UserCount int            `json:"userCount"`
+	// CrossSite mirrors Room.CrossSite (tri-state). omitempty so an unclassified
+	// room's L2 (Valkey) JSON entry omits it rather than caching a misleading false.
+	CrossSite *bool `json:"crossSite,omitempty"`
+	// CrossSiteAt mirrors Room.CrossSiteAt — the flip time driving the post-flip
+	// grace window (nil for rooms born cross-site). See pkg/subject.RoomEventTargets.
+	CrossSiteAt *time.Time `json:"crossSiteAt,omitempty"`
 }
 
 // Loader fetches a fresh Meta for the given roomID. The cache calls
@@ -185,26 +191,32 @@ func (w *Wrapper[S]) GetRoomMeta(ctx context.Context, roomID string) (Meta, erro
 // safe to errors.Is-check.
 func FetchFromMongo(ctx context.Context, rooms *mongo.Collection, roomID string) (Meta, error) {
 	opts := options.FindOne().SetProjection(bson.M{
-		"type":      1,
-		"name":      1,
-		"siteId":    1,
-		"userCount": 1,
+		"type":        1,
+		"name":        1,
+		"siteId":      1,
+		"userCount":   1,
+		"crossSite":   1,
+		"crossSiteAt": 1,
 	})
 	var doc struct {
-		ID        string         `bson:"_id"`
-		Type      model.RoomType `bson:"type"`
-		Name      string         `bson:"name"`
-		SiteID    string         `bson:"siteId"`
-		UserCount int            `bson:"userCount"`
+		ID          string         `bson:"_id"`
+		Type        model.RoomType `bson:"type"`
+		Name        string         `bson:"name"`
+		SiteID      string         `bson:"siteId"`
+		UserCount   int            `bson:"userCount"`
+		CrossSite   *bool          `bson:"crossSite"`
+		CrossSiteAt *time.Time     `bson:"crossSiteAt"`
 	}
 	if err := rooms.FindOne(ctx, bson.M{"_id": roomID}, opts).Decode(&doc); err != nil {
 		return Meta{}, fmt.Errorf("fetch room meta %s: %w", roomID, err)
 	}
 	return Meta{
-		ID:        doc.ID,
-		Type:      doc.Type,
-		Name:      doc.Name,
-		SiteID:    doc.SiteID,
-		UserCount: doc.UserCount,
+		ID:          doc.ID,
+		Type:        doc.Type,
+		Name:        doc.Name,
+		SiteID:      doc.SiteID,
+		UserCount:   doc.UserCount,
+		CrossSite:   doc.CrossSite,
+		CrossSiteAt: doc.CrossSiteAt,
 	}, nil
 }

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -3,8 +3,14 @@ package subject
 import (
 	"fmt"
 	"strings"
+	"time"
 	"unicode"
 )
+
+// RoomLocalityGrace bounds the local→global flip gap server-side: for this long
+// after a flip, publishers also dual-publish to the local subject so members not
+// yet re-subscribed keep receiving (vs. trusting the best-effort nudge).
+const RoomLocalityGrace = 15 * time.Minute
 
 // EncodeAccount maps an account to its NATS subject-token form by replacing the
 // dot separators a dotted account (e.g. a ".bot" account) would otherwise spill
@@ -115,12 +121,21 @@ func UserResponse(account, requestID string) string {
 	return fmt.Sprintf("chat.user.%s.response.%s", account, requestID)
 }
 
-func RoomMetadataUpdate(roomID string) string {
-	return fmt.Sprintf("chat.room.%s.event.metadata.update", roomID)
+// roomBase returns the room-scoped subject root: global=true → chat.room.{id}
+// (gateway-propagated); global=false → chat.local.room.{id} (leaf-filtered, site-local).
+func roomBase(roomID string, global bool) string {
+	if global {
+		return "chat.room." + roomID
+	}
+	return "chat.local.room." + roomID
 }
 
-func RoomMsgStream(roomID string) string {
-	return fmt.Sprintf("chat.room.%s.stream.msg", roomID)
+func RoomMetadataUpdate(roomID string, global bool) string {
+	return roomBase(roomID, global) + ".event.metadata.update"
+}
+
+func RoomMsgStream(roomID string, global bool) string {
+	return roomBase(roomID, global) + ".stream.msg"
 }
 
 func UserRoomUpdate(account string) string {
@@ -312,8 +327,59 @@ func MsgCanonicalReacted(siteID string) string {
 	return fmt.Sprintf("chat.msg.canonical.%s.reacted", siteID)
 }
 
-func RoomEvent(roomID string) string {
-	return fmt.Sprintf("chat.room.%s.event", roomID)
+func RoomEvent(roomID string, global bool) string {
+	return roomBase(roomID, global) + ".event"
+}
+
+// RoomRouteMode selects which namespace(s) a same-site room's events publish to.
+// Cross-site rooms are always global regardless of mode. This gates a zero-gap
+// rollout: global (current) → dual (migration) → local (reduction achieved).
+type RoomRouteMode int
+
+const (
+	RouteGlobal RoomRouteMode = iota // same-site rooms → chat.room.> (default, no behavior change)
+	RouteDual                        // same-site rooms → chat.local.room.> AND chat.room.> (migration window)
+	RouteLocal                       // same-site rooms → chat.local.room.> only (final)
+)
+
+// ParseRoomRouteMode parses the ROOM_SUBJECT_MODE env value. Unknown → error (caller defaults to global).
+func ParseRoomRouteMode(s string) (RoomRouteMode, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "global":
+		return RouteGlobal, nil
+	case "dual":
+		return RouteDual, nil
+	case "local":
+		return RouteLocal, nil
+	default:
+		return RouteGlobal, fmt.Errorf("invalid room route mode %q (want global|dual|local)", s)
+	}
+}
+
+// usesLocal reports whether the route mode publishes to the local subject at
+// all (dual or local). Global mode never touches the local namespace.
+func (m RoomRouteMode) usesLocal() bool { return m != RouteGlobal }
+
+// RoomEventTargets returns the .event subject(s) to publish a room event to.
+// Fail-safe: only an explicit crossSite=false routes local (nil/true → global).
+// A room flipped within RoomLocalityGrace (crossSiteAt set) also gets a local copy
+// in local/dual mode so not-yet-resubscribed members keep receiving (order: local, global).
+func RoomEventTargets(roomID string, crossSite *bool, crossSiteAt *time.Time, mode RoomRouteMode, now time.Time) []string {
+	if crossSite != nil && !*crossSite { // confirmed same-site
+		switch mode {
+		case RouteLocal:
+			return []string{RoomEvent(roomID, false)}
+		case RouteDual:
+			return []string{RoomEvent(roomID, false), RoomEvent(roomID, true)}
+		default:
+			return []string{RoomEvent(roomID, true)}
+		}
+	}
+	// nil or cross-site → global, plus a local copy during the post-flip grace window.
+	if mode.usesLocal() && crossSiteAt != nil && now.Before(crossSiteAt.Add(RoomLocalityGrace)) {
+		return []string{RoomEvent(roomID, false), RoomEvent(roomID, true)}
+	}
+	return []string{RoomEvent(roomID, true)}
 }
 
 func UserRoomEvent(account string) string {

--- a/pkg/subject/subject_test.go
+++ b/pkg/subject/subject_test.go
@@ -3,6 +3,7 @@ package subject_test
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,9 +21,9 @@ func TestSubjectBuilders(t *testing.T) {
 			"chat.user.alice.room.r1.site-a.msg.send"},
 		{"UserResponse", subject.UserResponse("alice", "req-1"),
 			"chat.user.alice.response.req-1"},
-		{"RoomMetadataUpdate", subject.RoomMetadataUpdate("r1"),
+		{"RoomMetadataUpdate", subject.RoomMetadataUpdate("r1", true),
 			"chat.room.r1.event.metadata.update"},
-		{"RoomMsgStream", subject.RoomMsgStream("r1"),
+		{"RoomMsgStream", subject.RoomMsgStream("r1", true),
 			"chat.room.r1.stream.msg"},
 		{"UserRoomUpdate", subject.UserRoomUpdate("alice"),
 			"chat.user.alice.event.room.update"},
@@ -66,7 +67,7 @@ func TestSubjectBuilders(t *testing.T) {
 			"chat.msg.canonical.site-a.deleted"},
 		{"RoomsInfoBatch", subject.RoomsInfoBatch("site-a"),
 			"chat.server.request.room.site-a.info.batch"},
-		{"RoomEvent", subject.RoomEvent("r1"), "chat.room.r1.event"},
+		{"RoomEvent", subject.RoomEvent("r1", true), "chat.room.r1.event"},
 		{"UserRoomEvent", subject.UserRoomEvent("alice"), "chat.user.alice.event.room"},
 		{"RoomKeyUpdate", subject.RoomKeyUpdate("alice"),
 			"chat.user.alice.event.room.key"},
@@ -1146,6 +1147,73 @@ func TestOpenRoom_ParseUserRoomSubject(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "alice", account)
 	assert.Equal(t, "r1", roomID)
+}
+
+func TestRoomSubjectLocality(t *testing.T) {
+	assert.Equal(t, "chat.room.r1.event", subject.RoomEvent("r1", true))
+	assert.Equal(t, "chat.local.room.r1.event", subject.RoomEvent("r1", false))
+	assert.Equal(t, "chat.room.r1.stream.msg", subject.RoomMsgStream("r1", true))
+	assert.Equal(t, "chat.local.room.r1.stream.msg", subject.RoomMsgStream("r1", false))
+	assert.Equal(t, "chat.room.r1.event.metadata.update", subject.RoomMetadataUpdate("r1", true))
+	assert.Equal(t, "chat.local.room.r1.event.metadata.update", subject.RoomMetadataUpdate("r1", false))
+}
+
+func TestRoomEventTargets(t *testing.T) {
+	g := "chat.room.r1.event"
+	l := "chat.local.room.r1.event"
+	trueP, falseP := true, false
+	now := time.Unix(1_700_000_000, 0).UTC()
+	// cross-site rooms with no flip time (born cross-site) are ALWAYS global.
+	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", &trueP, nil, subject.RouteGlobal, now))
+	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", &trueP, nil, subject.RouteDual, now))
+	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", &trueP, nil, subject.RouteLocal, now))
+	// same-site rooms vary by mode
+	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", &falseP, nil, subject.RouteGlobal, now))
+	assert.Equal(t, []string{l, g}, subject.RoomEventTargets("r1", &falseP, nil, subject.RouteDual, now))
+	assert.Equal(t, []string{l}, subject.RoomEventTargets("r1", &falseP, nil, subject.RouteLocal, now))
+	// nil (unclassified/unbackfilled) is ALWAYS global, in every mode — the
+	// fail-safe: unknown locality must never be treated as confirmed same-site.
+	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", nil, nil, subject.RouteGlobal, now))
+	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", nil, nil, subject.RouteDual, now))
+	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", nil, nil, subject.RouteLocal, now))
+}
+
+// TestRoomEventTargets_TransitionGrace covers the post-flip grace window: a room
+// that just flipped same-site→cross-site (crossSite=&true with crossSiteAt set)
+// keeps a LOCAL copy for RoomLocalityGrace when the mode uses local subjects, so
+// same-site members still on the local subject don't go dark until they
+// re-subscribe.
+func TestRoomEventTargets_TransitionGrace(t *testing.T) {
+	g := "chat.room.r1.event"
+	l := "chat.local.room.r1.event"
+	trueP := true
+	flip := time.Unix(1_700_000_000, 0).UTC()
+	within := flip.Add(subject.RoomLocalityGrace - time.Minute)
+	after := flip.Add(subject.RoomLocalityGrace + time.Minute)
+
+	// Within grace: local + global in local/dual modes.
+	assert.Equal(t, []string{l, g}, subject.RoomEventTargets("r1", &trueP, &flip, subject.RouteLocal, within))
+	assert.Equal(t, []string{l, g}, subject.RoomEventTargets("r1", &trueP, &flip, subject.RouteDual, within))
+	// Within grace but global mode: no local audience → global only.
+	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", &trueP, &flip, subject.RouteGlobal, within))
+	// After grace: global only, in every mode.
+	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", &trueP, &flip, subject.RouteLocal, after))
+	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", &trueP, &flip, subject.RouteDual, after))
+	// Exactly at the boundary is already expired (now.Before is strict).
+	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", &trueP, &flip, subject.RouteLocal, flip.Add(subject.RoomLocalityGrace)))
+}
+
+func TestParseRoomRouteMode(t *testing.T) {
+	for in, want := range map[string]subject.RoomRouteMode{
+		"global": subject.RouteGlobal, "dual": subject.RouteDual, "local": subject.RouteLocal,
+		"GLOBAL": subject.RouteGlobal,
+	} {
+		got, err := subject.ParseRoomRouteMode(in)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	}
+	_, err := subject.ParseRoomRouteMode("bogus")
+	require.Error(t, err)
 }
 
 func TestTranslateSubjects(t *testing.T) {

--- a/room-service/config_test.go
+++ b/room-service/config_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/caarlos0/env/v11"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/subject"
 )
 
 func TestLegacyRoomOrigins_UnmarshalText(t *testing.T) {
@@ -46,4 +49,44 @@ func TestLegacyRoomOrigins_EnvParse(t *testing.T) {
 	t.Setenv("LEGACY_ROOM_ORIGINS", `[{"siteID":"s1"`)
 	_, err = env.ParseAs[originsConfig]()
 	assert.Error(t, err, "malformed JSON must fail startup, not be silently ignored")
+}
+
+func TestConfig_RoomSubjectMode(t *testing.T) {
+	t.Setenv("NATS_URL", "nats://localhost:4222")
+	t.Setenv("MONGO_URI", "mongodb://localhost:27017")
+
+	cases := []struct {
+		name    string
+		env     string // "" means unset — exercise envDefault
+		want    subject.RoomRouteMode
+		wantErr bool
+	}{
+		{name: "default_is_global", env: "", want: subject.RouteGlobal},
+		{name: "explicit_global", env: "global", want: subject.RouteGlobal},
+		{name: "dual", env: "dual", want: subject.RouteDual},
+		{name: "local", env: "local", want: subject.RouteLocal},
+		{name: "invalid", env: "bogus", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Seed unconditionally so t.Setenv registers a restore of any
+			// inherited value; the default case unsets it below.
+			t.Setenv("ROOM_SUBJECT_MODE", "global")
+			if tc.env == "" {
+				require.NoError(t, os.Unsetenv("ROOM_SUBJECT_MODE"))
+			} else {
+				t.Setenv("ROOM_SUBJECT_MODE", tc.env)
+			}
+			cfg, err := env.ParseAs[config]()
+			require.NoError(t, err)
+
+			mode, err := subject.ParseRoomRouteMode(cfg.RoomSubjectMode)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, mode)
+		})
+	}
 }

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -71,9 +71,11 @@ type Handler struct {
 	teamsEmailDomain     string
 	roomMembersLimit     int
 	roomMembersCallLimit int
+	// routeMode gates the namespace(s) same-site room .event uses (ROOM_SUBJECT_MODE); cross-site is always global.
+	routeMode subject.RoomRouteMode
 }
 
-func NewHandler(store RoomStore, keyStore RoomKeyStore, memberListClient MemberListClient, msgReader MessageReader, siteID string, maxRoomSize, maxBatchSize int, memberListTimeout time.Duration, restrictedRoomMinMembers int, publishToStream func(context.Context, string, []byte, string) error, publishCore func(context.Context, string, []byte) error, legacyRoomOrigins map[string]string, maxResponseBytes int64) *Handler {
+func NewHandler(store RoomStore, keyStore RoomKeyStore, memberListClient MemberListClient, msgReader MessageReader, siteID string, maxRoomSize, maxBatchSize int, memberListTimeout time.Duration, restrictedRoomMinMembers int, publishToStream func(context.Context, string, []byte, string) error, publishCore func(context.Context, string, []byte) error, legacyRoomOrigins map[string]string, maxResponseBytes int64, routeMode subject.RoomRouteMode) *Handler {
 	return &Handler{
 		store:                    store,
 		keyStore:                 keyStore,
@@ -88,6 +90,7 @@ func NewHandler(store RoomStore, keyStore RoomKeyStore, memberListClient MemberL
 		publishCore:              publishCore,
 		legacyRoomOrigins:        legacyRoomOrigins,
 		maxResponseBytes:         maxResponseBytes,
+		routeMode:                routeMode,
 	}
 }
 
@@ -1258,6 +1261,7 @@ func (h *Handler) aggregateRoomInfo(ids []string, rooms []model.Room, keys map[s
 		entry.LastMsgAt = timePtrToMillis(r.LastMsgAt)
 		entry.LastMentionAllAt = timePtrToMillis(r.LastMentionAllAt)
 		entry.MinUserLastSeenAt = timePtrToMillis(r.MinUserLastSeenAt)
+		entry.CrossSite = r.CrossSite
 		if kp, ok := keys[id]; ok && kp != nil {
 			enc := base64.StdEncoding.EncodeToString(kp.KeyPair.PrivateKey)
 			ver := kp.Version
@@ -1400,7 +1404,7 @@ func (h *Handler) messageRead(c *natsrouter.Context) (*model.StatusReply, error)
 		// above is the source of truth; a publish failure must not fail the RPC.
 		switch room.Type {
 		case model.RoomTypeChannel:
-			h.publishChannelEvent(ctx, roomID, minTime)
+			h.publishChannelEvent(ctx, roomID, room.CrossSite, room.CrossSiteAt, minTime)
 		case model.RoomTypeDM:
 			h.publishDMEvents(ctx, roomID, minTime)
 		default:
@@ -1423,18 +1427,27 @@ func (h *Handler) buildMessageReadEvent(roomID string, floor *time.Time) model.M
 	}
 }
 
-// publishChannelEvent fans a read-floor advance out once to the channel's shared
-// room event subject. Best-effort: a marshal or publish failure is logged, not
-// returned. Used for RoomTypeChannel.
-func (h *Handler) publishChannelEvent(ctx context.Context, roomID string, floor *time.Time) {
+// publishChannelEvent fans a read-floor advance out to the channel's room event
+// subject(s) via publishRoomEvent. Best-effort: failures are logged, not returned.
+func (h *Handler) publishChannelEvent(ctx context.Context, roomID string, crossSite *bool, crossSiteAt *time.Time, floor *time.Time) {
 	evt := h.buildMessageReadEvent(roomID, floor)
 	payload, err := json.Marshal(evt)
 	if err != nil {
 		slog.Error("marshal message_read channel event failed", "error", err, "roomId", roomID)
 		return
 	}
-	if err := h.publishCore(ctx, subject.RoomEvent(roomID), payload); err != nil {
-		slog.Error("publish message_read channel event failed", "error", err, "roomId", roomID)
+	h.publishRoomEvent(ctx, roomID, crossSite, crossSiteAt, payload, "message_read")
+}
+
+// publishRoomEvent fans a channel room's .event out via subject.RoomEventTargets — the
+// sanctioned path enforced by .semgrep room-subject-publish-must-route. Best-effort.
+func (h *Handler) publishRoomEvent(ctx context.Context, roomID string, crossSite *bool, crossSiteAt *time.Time, payload []byte, op string, logArgs ...any) {
+	now := time.Now().UTC()
+	for _, subj := range subject.RoomEventTargets(roomID, crossSite, crossSiteAt, h.routeMode, now) {
+		if err := h.publishCore(ctx, subj, payload); err != nil {
+			args := append([]any{"error", err, "op", op, "roomId", roomID, "subject", subj}, logArgs...)
+			slog.Error("publish room event failed", args...)
+		}
 	}
 }
 
@@ -1779,7 +1792,7 @@ func (h *Handler) publishThreadMessageReadEvent(ctx context.Context, tr *model.T
 	}
 	switch room.Type {
 	case model.RoomTypeChannel:
-		h.publishThreadChannelEvent(ctx, tr, floor)
+		h.publishThreadChannelEvent(ctx, tr, room.CrossSite, room.CrossSiteAt, floor)
 	case model.RoomTypeDM:
 		h.publishThreadDMEvents(ctx, tr, floor)
 	default:
@@ -1799,17 +1812,15 @@ func (h *Handler) buildThreadMessageReadEvent(tr *model.ThreadRoom, floor *time.
 	}
 }
 
-// publishThreadChannelEvent fans the advance out once to the parent channel's
-// room event subject. Used for a RoomTypeChannel parent.
-func (h *Handler) publishThreadChannelEvent(ctx context.Context, tr *model.ThreadRoom, floor *time.Time) {
+// publishThreadChannelEvent fans the advance out to the parent channel's room
+// event subject(s) via publishRoomEvent. Used for a RoomTypeChannel parent.
+func (h *Handler) publishThreadChannelEvent(ctx context.Context, tr *model.ThreadRoom, crossSite *bool, crossSiteAt *time.Time, floor *time.Time) {
 	payload, err := json.Marshal(h.buildThreadMessageReadEvent(tr, floor))
 	if err != nil {
 		slog.Error("marshal thread_message_read channel event failed", "error", err, "roomId", tr.RoomID, "threadRoomId", tr.ID)
 		return
 	}
-	if err := h.publishCore(ctx, subject.RoomEvent(tr.RoomID), payload); err != nil {
-		slog.Error("publish thread_message_read channel event failed", "error", err, "roomId", tr.RoomID, "threadRoomId", tr.ID)
-	}
+	h.publishRoomEvent(ctx, tr.RoomID, crossSite, crossSiteAt, payload, "thread_message_read", "threadRoomId", tr.ID)
 }
 
 // publishThreadDMEvents fans the advance out to each DM member on their per-user

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -26,6 +26,10 @@ import (
 	"github.com/hmchangw/chat/pkg/subject"
 )
 
+// ptrBool returns a pointer to b, for constructing tri-state *bool fields
+// (e.g. model.Room.CrossSite) in test literals.
+func ptrBool(b bool) *bool { return &b }
+
 // expectAllAccountsExist registers a FindExistingAccounts expectation that
 // echoes its input back — i.e. "every account being asked about exists".
 // Used by every add-member / create-channel happy-path test that doesn't
@@ -601,7 +605,7 @@ func TestHandler_RemoveMember_SelfLeave_Success(t *testing.T) {
 		publishedSubj = subj
 		publishedData = data
 		return nil
-	}, nil, nil, 0)
+	}, nil, nil, 0, subject.RouteGlobal)
 
 	resp, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "alice"})
 	require.NoError(t, err)
@@ -638,7 +642,7 @@ func TestHandler_RemoveMember_OrgOnly_Rejected(t *testing.T) {
 			store.EXPECT().GetRoom(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel}, nil)
 			store.EXPECT().GetSubscriptionWithMembership(gomock.Any(), "r1", "alice").
 				Return(&SubscriptionWithMembership{Subscription: sub, HasOrgMembership: true}, nil)
-			handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+			handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 			_, err := handler.removeMember(ctxParams(map[string]string{"account": tc.requester, "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: tc.target})
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "org members cannot leave individually")
@@ -663,7 +667,7 @@ func TestHandler_RemoveMember_SelfLeave_NoOrgs_Allowed(t *testing.T) {
 	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, func(ctx context.Context, _ string, data []byte, _ string) error {
 		publishedData = data
 		return nil
-	}, nil, nil, 0)
+	}, nil, nil, 0, subject.RouteGlobal)
 	_, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "alice"})
 	require.NoError(t, err)
 	require.NotNil(t, publishedData)
@@ -697,7 +701,7 @@ func TestHandler_RemoveMember_LastOwner_Rejected(t *testing.T) {
 			}
 			store.EXPECT().CountMembersAndOwners(gomock.Any(), "r1").
 				Return(&RoomCounts{MemberCount: 3, HumanCount: 3, OwnerCount: 1}, nil)
-			handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+			handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 			_, err := handler.removeMember(ctxParams(map[string]string{"account": tc.requester, "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "alice"})
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "last owner")
@@ -717,7 +721,7 @@ func TestHandler_RemoveMember_LastMember_Rejected(t *testing.T) {
 		Return(&SubscriptionWithMembership{Subscription: sub, HasIndividualMembership: true}, nil)
 	store.EXPECT().CountMembersAndOwners(gomock.Any(), "r1").
 		Return(&RoomCounts{MemberCount: 1, HumanCount: 1, OwnerCount: 0}, nil)
-	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 	_, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "alice"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "last member")
@@ -737,7 +741,7 @@ func TestHandler_RemoveMember_QAPUnderscore_CountsAsHuman(t *testing.T) {
 		Return(&SubscriptionWithMembership{Subscription: sub, HasIndividualMembership: true}, nil)
 	store.EXPECT().CountMembersAndOwners(gomock.Any(), "r1").
 		Return(&RoomCounts{MemberCount: 1, HumanCount: 1, OwnerCount: 0}, nil)
-	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 	_, err := handler.removeMember(ctxParams(map[string]string{"account": "p_qa1", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "p_qa1"})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, errCannotRemoveLastMember))
@@ -764,7 +768,7 @@ func TestHandler_RemoveMember_OwnerRemovesOther_Success(t *testing.T) {
 	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, func(ctx context.Context, subj string, data []byte, _ string) error {
 		publishedData = data
 		return nil
-	}, nil, nil, 0)
+	}, nil, nil, 0, subject.RouteGlobal)
 	resp, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "bob"})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -786,7 +790,7 @@ func TestHandler_RemoveMember_NonOwnerRemovesOther_Rejected(t *testing.T) {
 	store.EXPECT().GetSubscriptionWithMembership(gomock.Any(), "r1", "bob").
 		Return(&SubscriptionWithMembership{Subscription: targetSub, HasIndividualMembership: true}, nil)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").Return(requesterSub, nil)
-	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 	_, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "bob"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only owners can remove members")
@@ -805,7 +809,7 @@ func TestHandler_RemoveMember_OwnerRemovesOrg_Success(t *testing.T) {
 	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, func(ctx context.Context, subj string, data []byte, _ string) error {
 		publishedData = data
 		return nil
-	}, nil, nil, 0)
+	}, nil, nil, 0, subject.RouteGlobal)
 	resp, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", OrgID: "eng-org"})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -818,7 +822,7 @@ func TestHandler_RemoveMember_BothAccountAndOrgID_Rejected(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockRoomStore(ctrl)
 	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel}, nil)
-	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 	_, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "bob", OrgID: "eng-org"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exactly one")
@@ -828,7 +832,7 @@ func TestHandler_RemoveMember_NeitherAccountNorOrgID_Rejected(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockRoomStore(ctrl)
 	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel}, nil)
-	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 	_, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exactly one")
@@ -837,7 +841,7 @@ func TestHandler_RemoveMember_NeitherAccountNorOrgID_Rejected(t *testing.T) {
 func TestHandler_RemoveMember_RoomIDMismatch(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockRoomStore(ctrl)
-	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 	_, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r2", Account: "alice"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "room ID mismatch")
@@ -849,7 +853,7 @@ func TestHandler_RemoveMember_GetTargetError(t *testing.T) {
 	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel}, nil)
 	store.EXPECT().GetSubscriptionWithMembership(gomock.Any(), "r1", "alice").
 		Return(nil, fmt.Errorf("db down"))
-	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 	_, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "alice"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get target subscription")
@@ -866,7 +870,7 @@ func TestHandler_RemoveMember_OwnerRemoves_RequesterLookupError(t *testing.T) {
 		Return(&SubscriptionWithMembership{Subscription: targetSub, HasIndividualMembership: true}, nil)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(nil, fmt.Errorf("db down"))
-	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 	_, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "bob"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get requester subscription")
@@ -883,7 +887,7 @@ func TestHandler_RemoveMember_CountsError(t *testing.T) {
 		Return(&SubscriptionWithMembership{Subscription: sub, HasIndividualMembership: true}, nil)
 	store.EXPECT().CountMembersAndOwners(gomock.Any(), "r1").
 		Return(nil, fmt.Errorf("db down"))
-	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 	_, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "alice"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "count members")
@@ -895,7 +899,7 @@ func TestHandler_RemoveMember_OrgPath_RequesterLookupError(t *testing.T) {
 	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel}, nil)
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(nil, fmt.Errorf("db down"))
-	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 	_, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", OrgID: "eng-org"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get requester subscription")
@@ -914,7 +918,7 @@ func TestHandler_RemoveMember_PublishError(t *testing.T) {
 		Return(&RoomCounts{MemberCount: 3, HumanCount: 3, OwnerCount: 2}, nil)
 	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, func(_ context.Context, _ string, _ []byte, _ string) error {
 		return fmt.Errorf("nats down")
-	}, nil, nil, 0)
+	}, nil, nil, 0, subject.RouteGlobal)
 	_, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "alice"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "publish to stream")
@@ -1048,7 +1052,7 @@ func TestHandler_AddMembers_RestrictedOwnerAllowed(t *testing.T) {
 	store := NewMockRoomStore(ctrl)
 
 	publish := func(_ context.Context, _ string, _ []byte, _ string) error { return nil }
-	h := NewHandler(store, nil, nil, nil, "site-a", 100, 500, 5*time.Second, 5, publish, nil, nil, 0)
+	h := NewHandler(store, nil, nil, nil, "site-a", 100, 500, 5*time.Second, 5, publish, nil, nil, 0, subject.RouteGlobal)
 
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").Return(&model.Subscription{
 		Roles: []model.Role{model.RoleOwner},
@@ -1073,7 +1077,7 @@ func TestHandler_AddMembers_EmptyAfterResolve(t *testing.T) {
 	store := NewMockRoomStore(ctrl)
 
 	publish := func(_ context.Context, _ string, _ []byte, _ string) error { return nil }
-	h := NewHandler(store, nil, nil, nil, "site-a", 100, 500, 5*time.Second, 5, publish, nil, nil, 0)
+	h := NewHandler(store, nil, nil, nil, "site-a", 100, 500, 5*time.Second, 5, publish, nil, nil, 0, subject.RouteGlobal)
 
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").Return(&model.Subscription{
 		Roles: []model.Role{model.RoleMember},
@@ -1257,7 +1261,7 @@ func TestHandler_RemoveMember_BotOwnerTarget_LastOwnerGuardApplies(t *testing.T)
 	// Owner target → counts fetched; last-owner guard fires on OwnerCount<=1.
 	store.EXPECT().CountMembersAndOwners(gomock.Any(), "r1").
 		Return(&RoomCounts{MemberCount: 2, HumanCount: 1, OwnerCount: 1}, nil)
-	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 	_, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}),
 		model.RemoveMemberRequest{RoomID: "r1", Account: "weather.bot"})
 	require.Error(t, err)
@@ -1284,7 +1288,7 @@ func TestHandler_RemoveMember_BotTarget_SkipsMemberGuards(t *testing.T) {
 	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, func(_ context.Context, _ string, data []byte, _ string) error {
 		publishedData = data
 		return nil
-	}, nil, nil, 0)
+	}, nil, nil, 0, subject.RouteGlobal)
 	resp, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "weather.bot"})
 	require.NoError(t, err)
 	assert.Equal(t, "accepted", resp.Status)
@@ -1306,7 +1310,7 @@ func TestHandler_RemoveMember_LastHumanWithBotsPresent_Rejected(t *testing.T) {
 	// Two subs (alice + a bot) but one human: removing the last human is blocked.
 	store.EXPECT().CountMembersAndOwners(gomock.Any(), "r1").
 		Return(&RoomCounts{MemberCount: 2, HumanCount: 1, OwnerCount: 1}, nil)
-	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 	_, err := handler.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.RemoveMemberRequest{RoomID: "r1", Account: "alice"})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, errCannotRemoveLastMember))
@@ -1316,7 +1320,7 @@ func TestHandler_UpdateRole_BotPromotion_Rejected(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockRoomStore(ctrl)
 	// The bot check fires before any store read, so no store expectations.
-	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 	_, err := handler.updateRole(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}),
 		model.UpdateRoleRequest{RoomID: "r1", Account: "weather.bot", NewRole: model.RoleOwner})
 	require.Error(t, err)
@@ -1327,7 +1331,7 @@ func TestHandler_UpdateRole_BotPromotion_Rejected(t *testing.T) {
 func TestHandler_UpdateRole_PlatformAdminPromotion_Rejected(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockRoomStore(ctrl)
-	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	handler := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 	_, err := handler.updateRole(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}),
 		model.UpdateRoleRequest{RoomID: "r1", Account: "p_adminsiteA", NewRole: model.RoleOwner})
 	require.Error(t, err)
@@ -2507,6 +2511,30 @@ func TestHandler_handleRoomsInfoBatch_ForwardsCounts(t *testing.T) {
 	require.Len(t, resp.Rooms, 1)
 	assert.Equal(t, 5, resp.Rooms[0].UserCount)
 	assert.Equal(t, 2, resp.Rooms[0].AppCount)
+}
+
+func TestRoomsInfoBatch_CarriesCrossSite(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockRoomStore(ctrl)
+	keyStore := NewMockRoomKeyStore(ctrl)
+
+	store.EXPECT().ListRoomsByIDs(gomock.Any(), []string{"r1", "r2", "r3"}).Return([]model.Room{
+		{ID: "r1", Name: "general", SiteID: "site-a", CrossSite: ptrBool(true)},
+		{ID: "r2", Name: "random", SiteID: "site-a", CrossSite: ptrBool(false)},
+		{ID: "r3", Name: "unclassified", SiteID: "site-a"},
+	}, nil)
+	keyStore.EXPECT().GetMany(gomock.Any(), []string{"r1", "r2", "r3"}).Return(map[string]*roomkeystore.VersionedKeyPair{}, nil)
+
+	h := &Handler{store: store, keyStore: keyStore, siteID: "site-a", maxBatchSize: 100}
+
+	resp, err := h.roomsInfoBatch(ctxParams(map[string]string{}), model.RoomsInfoBatchRequest{RoomIDs: []string{"r1", "r2", "r3"}})
+	require.NoError(t, err)
+	require.Len(t, resp.Rooms, 3)
+	require.NotNil(t, resp.Rooms[0].CrossSite)
+	assert.True(t, *resp.Rooms[0].CrossSite, "room with CrossSite=true in store must carry CrossSite=true in RoomInfo")
+	require.NotNil(t, resp.Rooms[1].CrossSite)
+	assert.False(t, *resp.Rooms[1].CrossSite, "room with CrossSite=false in store must carry CrossSite=false in RoomInfo")
+	assert.Nil(t, resp.Rooms[2].CrossSite, "unclassified room must carry a nil (absent) CrossSite in RoomInfo, never coerced to false")
 }
 
 func TestHandler_handleRoomsInfoBatch_chunking(t *testing.T) {
@@ -3864,7 +3892,7 @@ func TestHandler_handleMessageReadReceipt(t *testing.T) {
 				tt.prep(setup{store: store, reader: reader})
 			}
 
-			h := NewHandler(store, nil, nil, reader, siteID, 1000, 1000, time.Second, 5, nil, nil, nil, 0)
+			h := NewHandler(store, nil, nil, reader, siteID, 1000, 1000, time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 			got, err := h.messageReadReceipt(ctxParams(map[string]string{"account": account, "roomID": roomID}), tt.req)
 
 			if tt.wantErr != nil {
@@ -3902,7 +3930,7 @@ func TestHandler_MessageReadReceipt_UnavailablePreservesReason(t *testing.T) {
 		Return(MessageReadMeta{}, false, errcode.Unavailable("read receipts are temporarily unavailable",
 			errcode.WithReason(errcode.RoomReadReceiptsUnavailable)))
 
-	h := NewHandler(store, nil, nil, reader, siteID, 1000, 1000, time.Second, 5, nil, nil, nil, 0)
+	h := NewHandler(store, nil, nil, reader, siteID, 1000, 1000, time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 	_, err := h.messageReadReceipt(ctxParams(map[string]string{"account": account, "roomID": roomID}),
 		model.ReadReceiptRequest{MessageID: messageID})
 
@@ -4524,7 +4552,7 @@ func TestHandler_MessageThreadRead_ChannelFloorMoves_PublishesRoomEvent(t *testi
 	assert.Equal(t, "accepted", resp.Status)
 
 	require.Len(t, f.coreSubjects, 1)
-	assert.Equal(t, subject.RoomEvent("r1"), f.coreSubjects[0])
+	assert.Equal(t, subject.RoomEvent("r1", true), f.coreSubjects[0])
 	var evt model.ThreadMessageReadEvent
 	require.NoError(t, json.Unmarshal(f.coreData[0], &evt))
 	assert.Equal(t, model.RoomEventThreadMessageRead, evt.Type)
@@ -4533,6 +4561,66 @@ func TestHandler_MessageThreadRead_ChannelFloorMoves_PublishesRoomEvent(t *testi
 	require.NotNil(t, evt.MinUserLastSeenAt)
 	assert.True(t, evt.MinUserLastSeenAt.Equal(minT))
 	assert.NotZero(t, evt.Timestamp)
+}
+
+// --- publishThreadChannelEvent routing (ROOM_SUBJECT_MODE gate) ---
+
+func newThreadChannelFloorMoveFixture(t *testing.T, crossSite bool) (*threadReadFixture, *time.Time) {
+	f := newThreadReadFixture(t)
+	fullThreadReadSetup(f, baseThreadSub("alice", "r1", "p1", "tr1"))
+	minT := time.Now().UTC().Add(-10 * time.Minute)
+	expectThreadFloorAdvance(f, &minT)
+	f.store.EXPECT().GetRoom(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, CrossSite: ptrBool(crossSite)}, nil)
+	return f, &minT
+}
+
+func TestHandler_MessageThreadRead_GlobalMode_AlwaysGlobal(t *testing.T) {
+	f, _ := newThreadChannelFloorMoveFixture(t, false)
+	f.handler.routeMode = subject.RouteGlobal
+
+	_, err := f.handler.messageThreadRead(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.MessageThreadReadRequest{ThreadID: "p1"})
+	require.NoError(t, err)
+
+	require.Len(t, f.coreSubjects, 1)
+	assert.Equal(t, subject.RoomEvent("r1", true), f.coreSubjects[0])
+}
+
+func TestHandler_MessageThreadRead_LocalMode_SameSiteUsesLocal(t *testing.T) {
+	f, _ := newThreadChannelFloorMoveFixture(t, false)
+	f.handler.routeMode = subject.RouteLocal
+
+	_, err := f.handler.messageThreadRead(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.MessageThreadReadRequest{ThreadID: "p1"})
+	require.NoError(t, err)
+
+	require.Len(t, f.coreSubjects, 1)
+	assert.Equal(t, subject.RoomEvent("r1", false), f.coreSubjects[0])
+}
+
+func TestHandler_MessageThreadRead_DualMode_SameSitePublishesBoth(t *testing.T) {
+	f, _ := newThreadChannelFloorMoveFixture(t, false)
+	f.handler.routeMode = subject.RouteDual
+
+	_, err := f.handler.messageThreadRead(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.MessageThreadReadRequest{ThreadID: "p1"})
+	require.NoError(t, err)
+
+	require.Len(t, f.coreSubjects, 2)
+	assert.Equal(t, subject.RoomEvent("r1", false), f.coreSubjects[0])
+	assert.Equal(t, subject.RoomEvent("r1", true), f.coreSubjects[1])
+}
+
+func TestHandler_MessageThreadRead_CrossSiteRoomAlwaysGlobal(t *testing.T) {
+	for _, mode := range []subject.RoomRouteMode{subject.RouteGlobal, subject.RouteDual, subject.RouteLocal} {
+		t.Run(fmt.Sprintf("mode=%d", mode), func(t *testing.T) {
+			f, _ := newThreadChannelFloorMoveFixture(t, true)
+			f.handler.routeMode = mode
+
+			_, err := f.handler.messageThreadRead(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.MessageThreadReadRequest{ThreadID: "p1"})
+			require.NoError(t, err)
+
+			require.Len(t, f.coreSubjects, 1)
+			assert.Equal(t, subject.RoomEvent("r1", true), f.coreSubjects[0])
+		})
+	}
 }
 
 func TestHandler_MessageThreadRead_DMFloorMoves_PublishesPerSubscriber(t *testing.T) {
@@ -4959,7 +5047,7 @@ func TestHandler_natsGetRoomKey(t *testing.T) {
 			ks := NewMockRoomKeyStore(ctrl)
 			tc.setup(t, store, ks)
 
-			h := NewHandler(store, ks, nil, nil, siteID, 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+			h := NewHandler(store, ks, nil, nil, siteID, 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 			c := ctxParams(map[string]string{"account": account, "roomID": roomID})
 			c.Msg = &nats.Msg{Data: tc.body}
 			resp, err := h.getRoomKey(c)
@@ -4995,7 +5083,7 @@ func TestHandler_GetRoomKey_EmptyBody(t *testing.T) {
 	store.EXPECT().CheckMembership(gomock.Any(), account, roomID).Return(nil)
 	ks.EXPECT().Get(gomock.Any(), roomID).Return(sampleVersioned, nil)
 
-	h := NewHandler(store, ks, nil, nil, siteID, 1000, 500, 5*time.Second, 5, nil, nil, nil, 0)
+	h := NewHandler(store, ks, nil, nil, siteID, 1000, 500, 5*time.Second, 5, nil, nil, nil, 0, subject.RouteGlobal)
 	c := ctxParams(map[string]string{"account": account, "roomID": roomID})
 	c.Msg = &nats.Msg{Data: nil}
 	resp, err := h.getRoomKey(c)
@@ -5120,7 +5208,7 @@ func TestHandleRoomRename_Validation(t *testing.T) {
 				tt.setupStore(store)
 			}
 			h := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5,
-				func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, nil, nil, 0)
+				func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, nil, nil, 0, subject.RouteGlobal)
 
 			resp, err := h.roomRename(
 				ctxParams(map[string]string{"account": tt.account, "roomID": tt.roomID}),
@@ -5278,7 +5366,7 @@ func TestHandleRoomRestricted_Validation(t *testing.T) {
 				tt.setupStore(store)
 			}
 			h := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5,
-				func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, nil, nil, 0)
+				func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, nil, nil, 0, subject.RouteGlobal)
 
 			resp, err := h.roomRestricted(ctxParams(map[string]string{}), tt.req)
 			if tt.wantErr == nil {
@@ -5325,7 +5413,7 @@ func TestHandleRoomRestricted_MultiSite_FederatesPerDestination(t *testing.T) {
 		func(_ context.Context, subj string, data []byte, _ string) error {
 			publishes = append(publishes, pub{subj: subj, data: append([]byte(nil), data...)})
 			return nil
-		}, nil, nil, 0)
+		}, nil, nil, 0, subject.RouteGlobal)
 
 	req := model.RoomRestrictedRequest{RoomID: "r1", Account: "admin1", Restricted: false}
 	resp, err := h.roomRestricted(ctxParams(map[string]string{}), req)
@@ -6991,7 +7079,7 @@ func TestHandler_MessageRead_ChannelFloorMoves_PublishesRoomEvent(t *testing.T) 
 	// coreSubjects[0] = subscription.update for the reader; coreSubjects[1] = room floor event.
 	require.Len(t, f.coreSubjects, 2)
 	assert.Equal(t, subject.SubscriptionUpdate("alice"), f.coreSubjects[0])
-	assert.Equal(t, subject.RoomEvent("r1"), f.coreSubjects[1])
+	assert.Equal(t, subject.RoomEvent("r1", true), f.coreSubjects[1])
 	var evt model.MessageReadEvent
 	require.NoError(t, json.Unmarshal(f.coreData[1], &evt))
 	assert.Equal(t, model.RoomEventMessageRead, evt.Type)
@@ -6999,6 +7087,77 @@ func TestHandler_MessageRead_ChannelFloorMoves_PublishesRoomEvent(t *testing.T) 
 	require.NotNil(t, evt.MinUserLastSeenAt)
 	assert.True(t, evt.MinUserLastSeenAt.Equal(minT))
 	assert.NotZero(t, evt.Timestamp)
+}
+
+// --- publishChannelEvent routing (ROOM_SUBJECT_MODE gate) ---
+
+func newChannelFloorMoveFixture(t *testing.T, crossSite bool) (*messageReadFixture, time.Time) {
+	f := newMessageReadFixture(t)
+	joined := time.Now().UTC().Add(-2 * time.Hour)
+	lastSeen := joined.Add(time.Hour)
+	lastMsg := lastSeen.Add(30 * time.Minute)
+
+	f.store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").Return(&model.Subscription{
+		User:   model.SubscriptionUser{ID: "u1", Account: "alice"},
+		RoomID: "r1", SiteID: "site-a", JoinedAt: joined, LastSeenAt: &lastSeen,
+	}, nil)
+	f.store.EXPECT().UpdateSubscriptionRead(gomock.Any(), "r1", "alice", gomock.Any(), false).Return(nil)
+	f.store.EXPECT().GetUserSiteID(gomock.Any(), "alice").Return("site-a", nil)
+	f.store.EXPECT().GetRoom(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, LastMsgAt: &lastMsg, CrossSite: ptrBool(crossSite)}, nil)
+	minT := lastSeen
+	f.store.EXPECT().MinSubscriptionLastSeenByRoomID(gomock.Any(), "r1").Return(&minT, nil)
+	f.store.EXPECT().UpdateRoomMinUserLastSeenAt(gomock.Any(), "r1", &minT).Return(nil)
+	return f, minT
+}
+
+func TestHandler_MessageRead_GlobalMode_AlwaysGlobal(t *testing.T) {
+	f, _ := newChannelFloorMoveFixture(t, false)
+	f.handler.routeMode = subject.RouteGlobal
+
+	_, err := f.handler.messageRead(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+	require.NoError(t, err)
+
+	// coreSubjects[0] = subscription.update; coreSubjects[1] = room floor event.
+	require.Len(t, f.coreSubjects, 2)
+	assert.Equal(t, subject.RoomEvent("r1", true), f.coreSubjects[1])
+}
+
+func TestHandler_MessageRead_LocalMode_SameSiteUsesLocal(t *testing.T) {
+	f, _ := newChannelFloorMoveFixture(t, false)
+	f.handler.routeMode = subject.RouteLocal
+
+	_, err := f.handler.messageRead(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+	require.NoError(t, err)
+
+	require.Len(t, f.coreSubjects, 2)
+	assert.Equal(t, subject.RoomEvent("r1", false), f.coreSubjects[1])
+}
+
+func TestHandler_MessageRead_DualMode_SameSitePublishesBoth(t *testing.T) {
+	f, _ := newChannelFloorMoveFixture(t, false)
+	f.handler.routeMode = subject.RouteDual
+
+	_, err := f.handler.messageRead(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+	require.NoError(t, err)
+
+	require.Len(t, f.coreSubjects, 3)
+	assert.Equal(t, subject.RoomEvent("r1", false), f.coreSubjects[1])
+	assert.Equal(t, subject.RoomEvent("r1", true), f.coreSubjects[2])
+}
+
+func TestHandler_MessageRead_CrossSiteRoomAlwaysGlobal(t *testing.T) {
+	for _, mode := range []subject.RoomRouteMode{subject.RouteGlobal, subject.RouteDual, subject.RouteLocal} {
+		t.Run(fmt.Sprintf("mode=%d", mode), func(t *testing.T) {
+			f, _ := newChannelFloorMoveFixture(t, true)
+			f.handler.routeMode = mode
+
+			_, err := f.handler.messageRead(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+			require.NoError(t, err)
+
+			require.Len(t, f.coreSubjects, 2)
+			assert.Equal(t, subject.RoomEvent("r1", true), f.coreSubjects[1])
+		})
+	}
 }
 
 func TestHandler_MessageRead_DMFloorMoves_PublishesPerSubscriber(t *testing.T) {

--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -117,7 +117,7 @@ func TestMongoStore_GetRoom_ProjectionFields_Integration(t *testing.T) {
 	lastMentionAll := time.Now().UTC().Add(-90 * time.Minute).Truncate(time.Millisecond)
 	mustInsertRoom(t, db, &model.Room{
 		ID: "rproj", Name: "proj-room", Type: model.RoomTypeChannel, SiteID: "site-a",
-		UserCount: 7, AppCount: 3, Restricted: true, ExternalAccess: true,
+		UserCount: 7, AppCount: 3, Restricted: true, ExternalAccess: true, CrossSite: ptrBool(true),
 		LastMsgAt: &lastMsg, MinUserLastSeenAt: &minSeen, LastMsgID: "m123",
 		LastMentionAllAt: &lastMentionAll,
 	})
@@ -131,6 +131,8 @@ func TestMongoStore_GetRoom_ProjectionFields_Integration(t *testing.T) {
 	assert.Equal(t, 3, got.AppCount)
 	assert.True(t, got.Restricted)
 	assert.True(t, got.ExternalAccess)
+	require.NotNil(t, got.CrossSite, "crossSite must be in the projection (read-receipt fan-out routes on it via subject.RoomEventTargets)")
+	assert.True(t, *got.CrossSite)
 	require.NotNil(t, got.LastMsgAt)
 	assert.WithinDuration(t, lastMsg, *got.LastMsgAt, time.Second)
 	require.NotNil(t, got.MinUserLastSeenAt)
@@ -1397,7 +1399,7 @@ func TestAddMembers_SameSiteChannel_RoomMembersPath(t *testing.T) {
 		publishedData = data
 		return nil
 	}
-	handler := NewHandler(store, keyStore, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, publish, func(context.Context, string, []byte) error { return nil }, nil, 0)
+	handler := NewHandler(store, keyStore, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, publish, func(context.Context, string, []byte) error { return nil }, nil, 0, subject.RouteGlobal)
 
 	req := model.AddMembersRequest{
 		Channels: []model.ChannelRef{{RoomID: "source", SiteID: "site-a"}},
@@ -1457,7 +1459,7 @@ func TestAddMembers_SameSiteChannel_SubscriptionsFallback(t *testing.T) {
 		publishedData = data
 		return nil
 	}
-	handler := NewHandler(store, keyStore, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, publish, func(context.Context, string, []byte) error { return nil }, nil, 0)
+	handler := NewHandler(store, keyStore, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, publish, func(context.Context, string, []byte) error { return nil }, nil, 0, subject.RouteGlobal)
 
 	req := model.AddMembersRequest{Channels: []model.ChannelRef{{RoomID: "source", SiteID: "site-a"}}}
 	resp, err := handler.addMembers(ctxParams(map[string]string{"account": "alice", "roomID": "target"}), req)
@@ -1493,7 +1495,7 @@ func TestAddMembers_RequesterNotSubscribed_Rejected(t *testing.T) {
 
 	// Same-site only: nil memberListClient is safe — request fails on the same-site
 	// GetSubscription check before reaching the cross-site branch.
-	handler := NewHandler(store, keyStore, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, func(context.Context, string, []byte, string) error { return nil }, func(context.Context, string, []byte) error { return nil }, nil, 0)
+	handler := NewHandler(store, keyStore, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, func(context.Context, string, []byte, string) error { return nil }, func(context.Context, string, []byte) error { return nil }, nil, 0, subject.RouteGlobal)
 
 	req := model.AddMembersRequest{Channels: []model.ChannelRef{{RoomID: "source", SiteID: "site-a"}}}
 	_, err := handler.addMembers(ctxParams(map[string]string{"account": "alice", "roomID": "target"}), req)
@@ -1548,7 +1550,7 @@ func TestAddMembers_TwoSiteEndToEnd(t *testing.T) {
 	mustInsertSub(t, dbB, &model.Subscription{ID: "sb3", RoomID: "source", User: model.SubscriptionUser{ID: "req", Account: "alice"}})
 
 	// Site-B handler registers member.list endpoint (Register subscribes to MemberListWildcard).
-	handlerB := NewHandler(storeB, keyStore, nil, nil, "site-b", 1000, 500, 5*time.Second, 5, func(context.Context, string, []byte, string) error { return nil }, func(context.Context, string, []byte) error { return nil }, nil, 0)
+	handlerB := NewHandler(storeB, keyStore, nil, nil, "site-b", 1000, 500, 5*time.Second, 5, func(context.Context, string, []byte, string) error { return nil }, func(context.Context, string, []byte) error { return nil }, nil, 0, subject.RouteGlobal)
 	routerB := natsrouter.New(otelNCb, "room-service")
 	routerB.Use(natsrouter.RequireRequestID())
 	handlerB.Register(routerB)
@@ -1571,7 +1573,7 @@ func TestAddMembers_TwoSiteEndToEnd(t *testing.T) {
 		publishedData = data
 		return nil
 	}
-	handlerA := NewHandler(storeA, keyStore, memberListClient, nil, "site-a", 1000, 500, 5*time.Second, 5, publish, func(context.Context, string, []byte) error { return nil }, nil, 0)
+	handlerA := NewHandler(storeA, keyStore, memberListClient, nil, "site-a", 1000, 500, 5*time.Second, 5, publish, func(context.Context, string, []byte) error { return nil }, nil, 0, subject.RouteGlobal)
 
 	// Call add-members on site-A with a site-B source channel
 	req := model.AddMembersRequest{Channels: []model.ChannelRef{{RoomID: "source", SiteID: "site-b"}}}
@@ -1624,7 +1626,7 @@ func TestAddMembers_CrossSiteTimeout(t *testing.T) {
 	t.Cleanup(func() { _ = sub.Unsubscribe() })
 
 	memberListClient := NewNATSMemberListClient(nc, 200*time.Millisecond)
-	handler := NewHandler(store, keyStore, memberListClient, nil, "site-a", 1000, 500, 200*time.Millisecond, 5, func(context.Context, string, []byte, string) error { return nil }, func(context.Context, string, []byte) error { return nil }, nil, 0)
+	handler := NewHandler(store, keyStore, memberListClient, nil, "site-a", 1000, 500, 200*time.Millisecond, 5, func(context.Context, string, []byte, string) error { return nil }, func(context.Context, string, []byte) error { return nil }, nil, 0, subject.RouteGlobal)
 
 	req := model.AddMembersRequest{Channels: []model.ChannelRef{{RoomID: "source", SiteID: "site-b"}}}
 	_, err = handler.addMembers(ctxParams(map[string]string{"account": "alice", "roomID": "target"}), req)
@@ -1655,7 +1657,7 @@ func TestRoomsInfoBatchRPC_NoRequestID(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = otelNC.Drain() })
 
-	handler := NewHandler(store, keyStore, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, func(context.Context, string, []byte, string) error { return nil }, func(context.Context, string, []byte) error { return nil }, nil, 0)
+	handler := NewHandler(store, keyStore, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, func(context.Context, string, []byte, string) error { return nil }, func(context.Context, string, []byte) error { return nil }, nil, 0, subject.RouteGlobal)
 	router := natsrouter.New(otelNC, "room-service")
 	// Production-shaped base: mint, do not require.
 	router.Use(natsrouter.Recovery(), natsrouter.RequestID(), natsrouter.Logging())
@@ -1712,7 +1714,7 @@ func TestRoomsInfoBatchRPC(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = otelNC.Drain() })
 
-	handler := NewHandler(store, keyStore, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, func(context.Context, string, []byte, string) error { return nil }, func(context.Context, string, []byte) error { return nil }, nil, 0)
+	handler := NewHandler(store, keyStore, nil, nil, "site-a", 1000, 500, 5*time.Second, 5, func(context.Context, string, []byte, string) error { return nil }, func(context.Context, string, []byte) error { return nil }, nil, 0, subject.RouteGlobal)
 	router := natsrouter.New(otelNC, "room-service")
 	router.Use(natsrouter.RequireRequestID())
 	handler.Register(router)
@@ -1871,7 +1873,7 @@ func newRoomServiceHandler(t *testing.T, store *MongoStore, keyStore RoomKeyStor
 		lastData = data
 		return nil
 	}
-	h := NewHandler(store, keyStore, nil, nil, siteID, 1000, 500, 5*time.Second, 5, publish, func(context.Context, string, []byte) error { return nil }, nil, 0)
+	h := NewHandler(store, keyStore, nil, nil, siteID, 1000, 500, 5*time.Second, 5, publish, func(context.Context, string, []byte) error { return nil }, nil, 0, subject.RouteGlobal)
 	return h, func() (string, []byte) { return lastSubj, lastData }
 }
 
@@ -3356,7 +3358,7 @@ func TestIntegration_RoomRename(t *testing.T) {
 
 		keyStore := setupKeyStore(t, db)
 		h := NewHandler(store, keyStore, nil, nil, siteID, 1000, 500, 5*time.Second, 5,
-			publishToStream, func(context.Context, string, []byte) error { return nil }, nil, 0)
+			publishToStream, func(context.Context, string, []byte) error { return nil }, nil, 0, subject.RouteGlobal)
 		router := natsrouter.New(handlerNC, "room-service")
 		router.Use(natsrouter.RequireRequestID())
 		h.Register(router)
@@ -3425,7 +3427,7 @@ func TestIntegration_RoomRename(t *testing.T) {
 		keyStore := setupKeyStore(t, db)
 		h := NewHandler(store, keyStore, nil, nil, siteID, 1000, 500, 5*time.Second, 5,
 			func(context.Context, string, []byte, string) error { return nil },
-			func(context.Context, string, []byte) error { return nil }, nil, 0)
+			func(context.Context, string, []byte) error { return nil }, nil, 0, subject.RouteGlobal)
 		router := natsrouter.New(handlerNC, "room-service")
 		router.Use(natsrouter.RequireRequestID())
 		h.Register(router)
@@ -3502,7 +3504,7 @@ func TestIntegration_RoomRestricted(t *testing.T) {
 
 		keyStore := setupKeyStore(t, db)
 		h := NewHandler(store, keyStore, nil, nil, siteID, 1000, 500, 5*time.Second, 5,
-			publishToStream, func(context.Context, string, []byte) error { return nil }, nil, 0)
+			publishToStream, func(context.Context, string, []byte) error { return nil }, nil, 0, subject.RouteGlobal)
 		router := natsrouter.New(handlerNC, "room-service")
 		router.Use(natsrouter.RequireRequestID())
 		h.Register(router)
@@ -3594,7 +3596,7 @@ func TestIntegration_RoomRestricted(t *testing.T) {
 		keyStore := setupKeyStore(t, db)
 		h := NewHandler(store, keyStore, nil, nil, siteID, 1000, 500, 5*time.Second, 5,
 			func(context.Context, string, []byte, string) error { return nil },
-			func(context.Context, string, []byte) error { return nil }, nil, 0)
+			func(context.Context, string, []byte) error { return nil }, nil, 0, subject.RouteGlobal)
 		router := natsrouter.New(handlerNC, "room-service")
 		router.Use(natsrouter.RequireRequestID())
 		h.Register(router)

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hmchangw/chat/pkg/obs"
 	"github.com/hmchangw/chat/pkg/roomkeystore"
 	"github.com/hmchangw/chat/pkg/shutdown"
+	"github.com/hmchangw/chat/pkg/subject"
 )
 
 type config struct {
@@ -73,6 +74,8 @@ type config struct {
 	DebugLog logctx.Config      `envPrefix:"DEBUG_LOG_"`
 	// AdminAcctPrefix overrides the platform-admin account prefix (ADMIN_ACCT_PREFIX); keep it identical across services.
 	AdminAcctPrefix string `env:"ADMIN_ACCT_PREFIX" envDefault:"p_admin"`
+	// RoomSubjectMode: same-site room .event namespace — global (default) | dual | local. See pkg/subject.RoomRouteMode.
+	RoomSubjectMode string `env:"ROOM_SUBJECT_MODE" envDefault:"global"`
 }
 
 // legacyRoomOrigin maps a site to its legacy origin URL (incl. scheme).
@@ -123,6 +126,11 @@ func main() {
 	}
 	if cfg.RestrictedRoomMinMembers <= 0 {
 		slog.Error("invalid RESTRICTED_ROOM_MIN_MEMBERS: must be > 0", "value", cfg.RestrictedRoomMinMembers)
+		os.Exit(1)
+	}
+	roomRouteMode, err := subject.ParseRoomRouteMode(cfg.RoomSubjectMode)
+	if err != nil {
+		slog.Error("invalid ROOM_SUBJECT_MODE", "error", err)
 		os.Exit(1)
 	}
 
@@ -246,6 +254,7 @@ func main() {
 		},
 		cfg.LegacyRoomOrigins.byID,
 		nc.NatsConn().MaxPayload(),
+		roomRouteMode,
 	)
 	handler.dekProvisioner = dekProvisioner
 	handler.graphClient = graphClient

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -245,6 +245,7 @@ var roomReadProjection = bson.D{
 	{Key: "_id", Value: 1}, {Key: "type", Value: 1}, {Key: "name", Value: 1},
 	{Key: "userCount", Value: 1}, {Key: "appCount", Value: 1},
 	{Key: "restricted", Value: 1}, {Key: "externalAccess", Value: 1},
+	{Key: "crossSite", Value: 1}, {Key: "crossSiteAt", Value: 1},
 	{Key: "lastMsgAt", Value: 1}, {Key: "minUserLastSeenAt", Value: 1},
 	{Key: "lastMentionAllAt", Value: 1},
 }

--- a/room-worker/config_test.go
+++ b/room-worker/config_test.go
@@ -5,47 +5,13 @@ import (
 	"testing"
 
 	"github.com/caarlos0/env/v11"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/hmchangw/chat/pkg/stream"
 	"github.com/hmchangw/chat/pkg/subject"
 )
 
-func TestConfig_Mode(t *testing.T) {
-	cases := []struct {
-		mode    string
-		want    stream.Pipeline
-		wantErr bool
-	}{
-		{"user", stream.PipelineUser, false},
-		{"bot", stream.PipelineBot, false},
-		{"admin", "", true},
-		{"", "", true}, // required
-	}
-	for _, tc := range cases {
-		name := tc.mode
-		if name == "" {
-			name = "empty"
-		}
-		t.Run(name, func(t *testing.T) {
-			t.Setenv("MODE", tc.mode) // pin cleanup so host MODE is restored after the test
-			if tc.mode == "" {
-				require.NoError(t, os.Unsetenv("MODE")) // caarlos0/env treats "" as defined; unset to test the required check
-			}
-			cfg, err := env.ParseAs[config]()
-			if tc.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, tc.want, cfg.Mode)
-		})
-	}
-}
-
 func TestConfig_RoomSubjectMode(t *testing.T) {
-	t.Setenv("MODE", "user")
-
 	cases := []struct {
 		name    string
 		env     string // "" means unset — exercise envDefault
@@ -77,7 +43,7 @@ func TestConfig_RoomSubjectMode(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, tc.want, mode)
+			assert.Equal(t, tc.want, mode)
 		})
 	}
 }

--- a/room-worker/debug_log_test.go
+++ b/room-worker/debug_log_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hmchangw/chat/pkg/logctx"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/natsutil"
+	"github.com/hmchangw/chat/pkg/subject"
 )
 
 type recordingHandler struct {
@@ -135,7 +136,7 @@ func TestProcessRemoveMember_DebugEdge(t *testing.T) {
 		store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil).AnyTimes()
 		store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil).AnyTimes()
 		expectThreadCleanupAny(store)
-		h := NewHandler(store, siteID, func(context.Context, string, []byte, string) error { return nil }, testKeyStore, testKeySender)
+		h := NewHandler(store, siteID, func(context.Context, string, []byte, string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
 		req := model.RemoveMemberRequest{RoomID: roomID, Requester: account, Account: account, Timestamp: 1, RoomType: model.RoomTypeChannel}
 		data, _ := json.Marshal(req)
 		return h, data

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -76,9 +76,11 @@ type Handler struct {
 	// publishUsers fans a new external user identity to every site
 	// (chat.hr.{siteID}.users.upsert). Nil in tests not exercising the reconcile.
 	publishUsers func(ctx context.Context, users []model.IUserWithChange) error
+	// routeMode (ROOM_SUBJECT_MODE) gates same-site room .event namespaces; cross-site always global.
+	routeMode subject.RoomRouteMode
 }
 
-func NewHandler(store SubscriptionStore, siteID string, publish PublishFunc, keyStore RoomKeyStore, keySender *roomkeysender.Sender) *Handler {
+func NewHandler(store SubscriptionStore, siteID string, publish PublishFunc, keyStore RoomKeyStore, keySender *roomkeysender.Sender, routeMode subject.RoomRouteMode) *Handler {
 	return &Handler{
 		store:            store,
 		siteID:           siteID,
@@ -86,6 +88,7 @@ func NewHandler(store SubscriptionStore, siteID string, publish PublishFunc, key
 		keyStore:         keyStore,
 		keySender:        keySender,
 		keyFanoutWorkers: defaultKeyFanoutWorkers,
+		routeMode:        routeMode,
 	}
 }
 
@@ -174,6 +177,9 @@ func (h *Handler) publishAsyncJobResult(ctx context.Context, requesterAccount, o
 // alias for errcode.Permanent so call sites stay short — the marker type and
 // sentinel-Is shim now live in pkg/errcode (Task 20.15).
 func permanent(ec *errcode.Error) error { return errcode.Permanent(ec) }
+
+// boolPtr returns &b, to classify a new room's CrossSite definitively (never nil).
+func boolPtr(b bool) *bool { return &b }
 
 // fillAsyncError classifies jobErr once and populates the result's error
 // envelope fields. The Ack/Nak decision is INDEPENDENT of this — it stays keyed
@@ -849,6 +855,19 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 		return permanent(errcode.BadRequest(fmt.Sprintf("add-member only valid on channel rooms, got %s", room.Type)))
 	}
 	candidates := inputs.candidates
+
+	// Retry-safe: classify from the full candidate set (their home sites), not
+	// needSub, which is empty on a redelivery after a prior crashed-before-marking
+	// delivery. Must run before the early return below. SetRoomCrossSite is idempotent.
+	for _, c := range candidates {
+		if c.SiteID != "" && c.SiteID != h.siteID {
+			if err := h.store.SetRoomCrossSite(ctx, req.RoomID); err != nil {
+				return fmt.Errorf("mark room cross-site: %w", err)
+			}
+			break
+		}
+	}
+
 	// Align the write-gate to member.list's read-source: write individual rows whenever room_members already holds any row, not only when orgs are present.
 	writeIndividuals := len(req.Orgs) > 0 || inputs.hasAnyRoomMembers
 
@@ -1236,6 +1255,22 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 		}
 		accountsBySite[siteID] = append(accountsBySite[siteID], acc)
 	}
+
+	// Remote-site bucket non-empty → mark global (sticky). room.CrossSite still
+	// holds the PRIOR state (SetRoomCrossSite doesn't mutate it), so gate the nudge
+	// on RoutesGlobal(): only a previously-confirmed same-site (&false) room flips.
+	if len(accountsBySite) > 0 {
+		if err := h.store.SetRoomCrossSite(ctx, req.RoomID); err != nil {
+			return fmt.Errorf("mark room cross-site: %w", err)
+		}
+		// Bust L2 AFTER the write: an earlier bust could be undone by a concurrent
+		// refill re-caching the pre-write crossSite=false, mis-routing local for the TTL.
+		h.bustRoomMeta(ctx, req.RoomID)
+		if !room.RoutesGlobal() {
+			h.nudgeLocalToGlobalTransition(ctx, req.RoomID, actualAccounts, now)
+		}
+	}
+
 	for destSiteID, siteAccounts := range accountsBySite {
 		siteEvt := model.MemberAddEvent{
 			Type:               model.InboxMemberAdded,
@@ -1258,6 +1293,32 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 	}
 
 	return nil
+}
+
+// nudgeLocalToGlobalTransition best-effort nudges existing members (subscribers minus
+// newAccounts) to re-fetch subscription.list and re-subscribe global after a flip, via
+// their per-user tree. Pure latency opt — crossSite is source of truth, so nudge failures
+// are swallowed and clients self-correct on reconnect.
+func (h *Handler) nudgeLocalToGlobalTransition(ctx context.Context, roomID string, newAccounts []string, now time.Time) {
+	allAccounts, err := h.store.GetSubscriptionAccounts(ctx, roomID)
+	if err != nil {
+		slog.WarnContext(ctx, "room-locality nudge: list subscription accounts failed", "error", err, "room_id", roomID)
+		return
+	}
+	justAdded := make(map[string]struct{}, len(newAccounts))
+	for _, acc := range newAccounts {
+		justAdded[acc] = struct{}{}
+	}
+	evt := model.RoomMetadataUpdateEvent{RoomID: roomID, Timestamp: now.UnixMilli()}
+	data, _ := json.Marshal(evt)
+	for _, acc := range allAccounts {
+		if _, ok := justAdded[acc]; ok {
+			continue
+		}
+		if err := h.publish(ctx, subject.UserRoomUpdate(acc), data, ""); err != nil {
+			slog.WarnContext(ctx, "room-locality nudge publish failed", "error", err, "account", acc, "room_id", roomID)
+		}
+	}
 }
 
 // buildAddedMembers assembles the member.list-shaped display entries (contract: model.MemberAddEvent.Members),
@@ -1361,6 +1422,8 @@ func (h *Handler) createSelfDM(ctx context.Context, roomID string, requester *mo
 		Accounts:  []string{requester.Account},
 		CreatedAt: acceptedAt,
 		UpdatedAt: acceptedAt,
+		// A self-DM's one participant is the requester (local) → definitively same-site.
+		CrossSite: boolPtr(false),
 	}
 	// Provision the room's at-rest DEK before persisting it (same as the 2-party DM
 	// path): self-DM messages are stored encrypted in Cassandra, so a Vault outage
@@ -1495,6 +1558,19 @@ func (h *Handler) processCreateRoom(ctx context.Context, data []byte) (err error
 			return fmt.Errorf("generate room key: %w", err)
 		}
 	}
+
+	// Classify at birth — never leave CrossSite nil (nil is for pre-existing
+	// rooms). Born global if any resolved initial member is off-site. Definitive
+	// for a DM/botDM (full 2-member roster); provisional for a channel until
+	// finishCreateRoom marks it once the roster is known.
+	room.CrossSite = boolPtr(false)
+	for _, u := range []*model.User{requester, counterpart} {
+		if u != nil && u.SiteID != "" && u.SiteID != h.siteID {
+			room.CrossSite = boolPtr(true)
+			break
+		}
+	}
+
 	inserted, err := h.store.CreateRoom(ctx, room, newPair)
 	if err != nil {
 		return fmt.Errorf("create room: %w", err)
@@ -1745,6 +1821,18 @@ func (h *Handler) finishCreateRoom(ctx context.Context, req *model.CreateRoomReq
 		}
 		remoteSiteAccounts[u.SiteID] = append(remoteSiteAccounts[u.SiteID], u.Account)
 	}
+
+	// Channel members resolve only after the CreateRoom write, so mark here once
+	// known. Sticky/idempotent, so a DM/botDM reaching this pays a harmless extra call.
+	if len(remoteSiteAccounts) > 0 {
+		if err := h.store.SetRoomCrossSite(ctx, room.ID); err != nil {
+			return fmt.Errorf("mark room cross-site: %w", err)
+		}
+		// Bust the L2 room-meta cache after the write so a stale pre-write
+		// crossSite=false can't linger and mis-route this now-global room local.
+		h.bustRoomMeta(ctx, room.ID)
+	}
+
 	for destSiteID, accounts := range remoteSiteAccounts {
 		memberEvt := model.MemberAddEvent{
 			Type:               model.InboxMemberAdded,
@@ -1939,6 +2027,12 @@ func (h *Handler) serverCreateDM(c *natsrouter.Context, req model.SyncCreateDMRe
 		Accounts:  accounts,
 		CreatedAt: roomCreatedAt,
 		UpdatedAt: roomCreatedAt,
+	}
+	// Classify at birth: the 2-member roster is fully known → definitive. Local
+	// requester + remote counterpart → global; otherwise confirmed same-site.
+	room.CrossSite = boolPtr(false)
+	if other.SiteID != "" && other.SiteID != h.siteID {
+		room.CrossSite = boolPtr(true)
 	}
 	// Provision the room's at-rest DEK before persisting the room so the first
 	// message write doesn't pay the create cost. Blocking and provisioned first
@@ -2234,12 +2328,34 @@ func (h *Handler) processRoomRename(ctx context.Context, data []byte) (err error
 		ByAccount: req.Account,
 		RenamedAt: time.UnixMilli(req.Timestamp).UTC(),
 	}
-	if payload, mErr := json.Marshal(roomEvt); mErr != nil {
+	payload, mErr := json.Marshal(roomEvt)
+	if mErr != nil {
 		slog.Error("marshal room_renamed event failed", "error", mErr, "room_id", req.RoomID)
-	} else if pErr := h.publish(ctx, subject.RoomEvent(req.RoomID), payload, ""); pErr != nil {
-		slog.Error("publish room_renamed event failed", "error", pErr, "room_id", req.RoomID)
+		return nil
 	}
+	// Best-effort fan-out (must not fail the rename): default crossSite nil (→global)
+	// if unreadable. GetRoomMeta is cache-served and carries CrossSite (no extra fetch).
+	var crossSite *bool
+	var crossSiteAt *time.Time
+	if r, gErr := h.store.GetRoomMeta(ctx, req.RoomID); gErr != nil {
+		slog.Error("get room for room_renamed event routing failed", "error", gErr, "room_id", req.RoomID)
+	} else {
+		crossSite = r.CrossSite
+		crossSiteAt = r.CrossSiteAt
+	}
+	h.publishRoomEvent(ctx, req.RoomID, crossSite, crossSiteAt, payload, "room_renamed")
 	return nil
+}
+
+// publishRoomEvent fans a room .event out via subject.RoomEventTargets — the sanctioned
+// path; a .semgrep rule blocks inline room-subject publishes. Best-effort.
+func (h *Handler) publishRoomEvent(ctx context.Context, roomID string, crossSite *bool, crossSiteAt *time.Time, payload []byte, op string) {
+	now := time.Now().UTC()
+	for _, subj := range subject.RoomEventTargets(roomID, crossSite, crossSiteAt, h.routeMode, now) {
+		if err := h.publish(ctx, subj, payload, ""); err != nil {
+			slog.Error("publish room event failed", "error", err, "op", op, "room_id", roomID, "subject", subj)
+		}
+	}
 }
 
 func (h *Handler) publishSyncDMInbox(ctx context.Context, room *model.Room, requester, other *model.User, joinedAt time.Time) error {

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -36,6 +36,10 @@ type publishedMsg struct {
 	data []byte
 }
 
+// ptrBool returns a pointer to b, for constructing tri-state *bool fields
+// (e.g. model.Room.CrossSite) in test literals.
+func ptrBool(b bool) *bool { return &b }
+
 // --- processRemoveMember tests ---
 
 func TestHandler_ProcessRemoveMember_FallsBackToNowOnInvalidTimestamp(t *testing.T) {
@@ -48,7 +52,7 @@ func TestHandler_ProcessRemoveMember_FallsBackToNowOnInvalidTimestamp(t *testing
 	store.EXPECT().GetUserWithMembership(gomock.Any(), "r1", "alice").Return(nil, fmt.Errorf("db error"))
 	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error {
 		return nil
-	}, testKeyStore, testKeySender)
+	}, testKeyStore, testKeySender, subject.RouteGlobal)
 	req := model.RemoveMemberRequest{
 		RoomID:    "r1",
 		Account:   "alice",
@@ -102,7 +106,7 @@ func TestHandler_ProcessRemoveMember_SelfLeave_IndividualOnly(t *testing.T) {
 	h := NewHandler(store, siteID, func(_ context.Context, subj string, data []byte, _ string) error {
 		published = append(published, publishedMsg{subj: subj, data: data})
 		return nil
-	}, testKeyStore, testKeySender)
+	}, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	// Self-leave: Requester == Account
 	req := model.RemoveMemberRequest{RoomID: roomID, Requester: account, Account: account, Timestamp: 1, RoomType: model.RoomTypeChannel}
@@ -179,7 +183,7 @@ func TestHandler_ProcessRemoveMember_BotTarget_RotatesAndSubUpdate(t *testing.T)
 	h := NewHandler(store, siteID, func(_ context.Context, subj string, data []byte, _ string) error {
 		published = append(published, publishedMsg{subj: subj, data: data})
 		return nil
-	}, testKeyStore, testKeySender)
+	}, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	req := model.RemoveMemberRequest{RoomID: roomID, Requester: requester, Account: botAcct, Timestamp: 1, RoomType: model.RoomTypeChannel}
 	data, _ := json.Marshal(req)
@@ -230,7 +234,7 @@ func TestHandler_ProcessRemoveMember_SelfLeave_DualMembership(t *testing.T) {
 	h := NewHandler(store, siteID, func(_ context.Context, subj string, data []byte, _ string) error {
 		published = append(published, publishedMsg{subj: subj, data: data})
 		return nil
-	}, testKeyStore, testKeySender)
+	}, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	req := model.RemoveMemberRequest{RoomID: roomID, Requester: account, Account: account, Timestamp: 1, RoomType: model.RoomTypeChannel}
 	data, _ := json.Marshal(req)
@@ -272,7 +276,7 @@ func TestHandler_ProcessRemoveIndividual_CleansThreadState(t *testing.T) {
 	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 
-	h := NewHandler(store, siteID, func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
+	h := NewHandler(store, siteID, func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
 	req := model.RemoveMemberRequest{RoomID: roomID, Requester: account, Account: account, Timestamp: 1, RoomType: model.RoomTypeChannel}
 	data, _ := json.Marshal(req)
 	require.NoError(t, h.processRemoveMember(context.Background(), data))
@@ -305,7 +309,7 @@ func TestHandler_ProcessRemoveOrg_CleansThreadStateForRemovedOnly(t *testing.T) 
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 	store.EXPECT().GetUser(gomock.Any(), requester).Return(&model.User{ID: "u_alice", Account: requester, SiteID: siteID, EngName: "Alice", ChineseName: "愛"}, nil)
 
-	h := NewHandler(store, siteID, func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
+	h := NewHandler(store, siteID, func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
 	req := model.RemoveMemberRequest{RoomID: roomID, Requester: requester, OrgID: orgID, Timestamp: 1000, RoomType: model.RoomTypeChannel}
 	data, _ := json.Marshal(req)
 	require.NoError(t, h.processRemoveMember(context.Background(), data))
@@ -354,7 +358,7 @@ func TestHandler_ProcessRemoveMember_DualMembership_OwnerDemoted(t *testing.T) {
 			h := NewHandler(store, siteID, func(_ context.Context, subj string, data []byte, _ string) error {
 				published = append(published, publishedMsg{subj: subj, data: data})
 				return nil
-			}, testKeyStore, testKeySender)
+			}, testKeyStore, testKeySender, subject.RouteGlobal)
 
 			req := model.RemoveMemberRequest{RoomID: roomID, Requester: tc.requester, Account: account, Timestamp: 1, RoomType: model.RoomTypeChannel}
 			data, _ := json.Marshal(req)
@@ -412,7 +416,7 @@ func TestHandler_ProcessRemoveMember_OwnerRemovesIndividual(t *testing.T) {
 	h := NewHandler(store, siteID, func(_ context.Context, subj string, data []byte, _ string) error {
 		published = append(published, publishedMsg{subj: subj, data: data})
 		return nil
-	}, testKeyStore, testKeySender)
+	}, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	// requester != account means this is owner-removes-other
 	req := model.RemoveMemberRequest{RoomID: roomID, Requester: requester, Account: account, Timestamp: 1, RoomType: model.RoomTypeChannel}
@@ -450,7 +454,7 @@ func TestHandler_ProcessAddMembers_FallsBackToNowOnInvalidTimestamp(t *testing.T
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil).AnyTimes()
 	h := NewHandler(store, "site1", func(_ context.Context, _ string, _ []byte, _ string) error {
 		return nil
-	}, testKeyStore, testKeySender)
+	}, testKeyStore, testKeySender, subject.RouteGlobal)
 	req := model.AddMembersRequest{
 		RoomID:           "r1",
 		RequesterAccount: "alice",
@@ -473,9 +477,9 @@ func TestHandler_ProcessAddMembers(t *testing.T) {
 		published = append(published, publishedMsg{subj: subj, data: data})
 		return nil
 	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
-	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"bob", "charlie"}, "r1").
 		Return([]AddMemberCandidate{
 			{Account: "bob", HasSubscription: false, HasIndividualRoomMember: false},
@@ -506,6 +510,11 @@ func TestHandler_ProcessAddMembers(t *testing.T) {
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 2, 0, gomock.Any()).Return(true, nil)
 	store.EXPECT().ReconcileMemberCounts(gomock.Any(), "r1").Return(nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
+	// Local→global flip nudge: no pre-existing members here (bob/charlie are
+	// the only, newly-added, subscribers), so the diff against actualAccounts
+	// is empty and no nudge publish fires.
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return([]string{"bob", "charlie"}, nil)
 
 	req := model.AddMembersRequest{
 		RoomID: "r1", Users: []string{"bob", "charlie"},
@@ -544,9 +553,9 @@ func TestHandler_ProcessAddMembers(t *testing.T) {
 func TestHandler_ProcessAddMembers_WritesIndividualWhenTableNonEmpty(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
-	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
 
-	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"x"}, "r1").
 		Return([]AddMemberCandidate{{Account: "x", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(true, nil) // table non-empty (org removed, individuals remain)
@@ -576,9 +585,9 @@ func TestHandler_ProcessAddMembers_WritesIndividualWhenTableNonEmpty(t *testing.
 func TestHandler_ProcessAddMembers_SubscriptionOnlyWhenTableEmpty(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
-	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
 
-	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"x"}, "r1").
 		Return([]AddMemberCandidate{{Account: "x", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil) // empty table → lite mode
@@ -596,6 +605,305 @@ func TestHandler_ProcessAddMembers_SubscriptionOnlyWhenTableEmpty(t *testing.T) 
 	require.NoError(t, h.processAddMembers(ctx, reqData))
 }
 
+// TestProcessAddMembers_SetsCrossSiteForRemoteMember verifies that adding a
+// member whose home site differs from h.siteID marks the room global via
+// Store.SetRoomCrossSite.
+func TestProcessAddMembers_SetsCrossSiteForRemoteMember(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
+
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
+	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"x"}, "r1").
+		Return([]AddMemberCandidate{{Account: "x", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"x"}).Return([]model.User{
+		{ID: "u2", Account: "x", SiteID: "site-b", EngName: "X"},
+	}, nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice"}, nil)
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 1, 0, gomock.Any()).Return(false, nil)
+	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
+	// Local→global flip nudge: "x" is the only (newly-added) subscriber, so no
+	// pre-existing member remains after subtracting actualAccounts.
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return([]string{"x"}, nil)
+
+	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"x"}, RequesterAccount: "alice", Timestamp: 1}
+	reqData, _ := json.Marshal(req)
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+	require.NoError(t, h.processAddMembers(ctx, reqData))
+}
+
+// TestProcessAddMembers_SameSite_NoCrossSiteWrite verifies that adding only
+// same-site members never calls Store.SetRoomCrossSite.
+func TestProcessAddMembers_SameSite_NoCrossSiteWrite(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
+
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
+	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"x"}, "r1").
+		Return([]AddMemberCandidate{{Account: "x", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"x"}).Return([]model.User{
+		{ID: "u2", Account: "x", SiteID: "site-a", EngName: "X"},
+	}, nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice"}, nil)
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 1, 0, gomock.Any()).Return(false, nil)
+	store.EXPECT().SetRoomCrossSite(gomock.Any(), gomock.Any()).Times(0)
+
+	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"x"}, RequesterAccount: "alice", Timestamp: 1}
+	reqData, _ := json.Marshal(req)
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+	require.NoError(t, h.processAddMembers(ctx, reqData))
+}
+
+// TestProcessAddMembers_Redelivery_CrossSite_StillMarks is the regression test
+// for the retry-safety bug: on a JetStream redelivery, the candidate already
+// has a subscription (HasSubscription=true from a prior, crashed-before-
+// marking delivery), so needSub/needIRM are both empty and req.Orgs is empty
+// — the handler takes the "nothing to write" early return. Since the
+// candidate's home site differs from h.siteID, Store.SetRoomCrossSite must
+// still be called (classified from the stable candidate set, not needSub).
+func TestProcessAddMembers_Redelivery_CrossSite_StillMarks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
+
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
+	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"x"}, "r1").
+		Return([]AddMemberCandidate{{Account: "x", HasSubscription: true, HasIndividualRoomMember: false, SiteID: "site-b"}}, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
+	// No FindUsersByAccounts/GetUser/BulkCreateSubscriptions: the early return
+	// fires before those reads/writes — strict mock proves nothing else runs.
+
+	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"x"}, RequesterAccount: "alice", Timestamp: 1}
+	reqData, _ := json.Marshal(req)
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+	require.NoError(t, h.processAddMembers(ctx, reqData))
+}
+
+// TestProcessAddMembers_Redelivery_SameSite_NoCrossSiteWrite is the same-site
+// counterpart: a redelivery whose candidate is already subscribed AND local
+// must not call Store.SetRoomCrossSite.
+func TestProcessAddMembers_Redelivery_SameSite_NoCrossSiteWrite(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
+
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
+	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"x"}, "r1").
+		Return([]AddMemberCandidate{{Account: "x", HasSubscription: true, HasIndividualRoomMember: false, SiteID: "site-a"}}, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().SetRoomCrossSite(gomock.Any(), gomock.Any()).Times(0)
+
+	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"x"}, RequesterAccount: "alice", Timestamp: 1}
+	reqData, _ := json.Marshal(req)
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+	require.NoError(t, h.processAddMembers(ctx, reqData))
+}
+
+// TestProcessAddMembers_NudgesExistingMembersOnFlip verifies that when a room
+// FLIPS from local (CrossSite=false) to global (a remote member is added),
+// every member who was already subscribed BEFORE this add receives a
+// best-effort nudge on subject.UserRoomUpdate(account) — the always-on
+// per-user tree that prompts a connected client to re-fetch
+// subscription.list and re-subscribe to the global namespace. The
+// newly-added remote member itself must NOT be nudged (it already gets a
+// fresh subscription.update + member_added event).
+func TestProcessAddMembers_NudgesExistingMembersOnFlip(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+
+	var published []publishedMsg
+	publish := func(_ context.Context, subj string, data []byte, _ string) error {
+		published = append(published, publishedMsg{subj: subj, data: data})
+		return nil
+	}
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
+
+	// Room previously local: CrossSite is unset (false).
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
+	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"newremote"}, "r1").
+		Return([]AddMemberCandidate{{Account: "newremote", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"newremote"}).Return([]model.User{
+		{ID: "u_new", Account: "newremote", SiteID: "site-b", EngName: "New"},
+	}, nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice"}, nil)
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 1, 0, gomock.Any()).Return(false, nil)
+	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
+	// Post-write subscriber list: alice + bob were already members before this
+	// add; newremote just joined.
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return([]string{"alice", "bob", "newremote"}, nil)
+
+	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"newremote"}, RequesterAccount: "alice", Timestamp: 1}
+	reqData, _ := json.Marshal(req)
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+	require.NoError(t, h.processAddMembers(ctx, reqData))
+
+	nudged := map[string]bool{}
+	for _, p := range published {
+		if p.subj == subject.UserRoomUpdate("alice") || p.subj == subject.UserRoomUpdate("bob") || p.subj == subject.UserRoomUpdate("newremote") {
+			nudged[p.subj] = true
+		}
+	}
+	assert.True(t, nudged[subject.UserRoomUpdate("alice")], "pre-existing member alice must be nudged")
+	assert.True(t, nudged[subject.UserRoomUpdate("bob")], "pre-existing member bob must be nudged")
+	assert.False(t, nudged[subject.UserRoomUpdate("newremote")], "the newly-added member must not be nudged")
+}
+
+// TestProcessAddMembers_NoNudgeWhenAlreadyGlobal verifies that a room already
+// marked CrossSite=true (already global) never triggers the local→global
+// nudge, even though adding a remote member still calls SetRoomCrossSite
+// (sticky, idempotent).
+func TestProcessAddMembers_NoNudgeWhenAlreadyGlobal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+
+	var published []publishedMsg
+	publish := func(_ context.Context, subj string, data []byte, _ string) error {
+		published = append(published, publishedMsg{subj: subj, data: data})
+		return nil
+	}
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
+
+	// Room already global.
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(true)}, nil)
+	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"newremote"}, "r1").
+		Return([]AddMemberCandidate{{Account: "newremote", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"newremote"}).Return([]model.User{
+		{ID: "u_new", Account: "newremote", SiteID: "site-b", EngName: "New"},
+	}, nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice"}, nil)
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 1, 0, gomock.Any()).Return(false, nil)
+	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
+	// No GetSubscriptionAccounts call: the mock is strict, so any unexpected
+	// call here fails the test — this is what proves the nudge did not fire.
+
+	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"newremote"}, RequesterAccount: "alice", Timestamp: 1}
+	reqData, _ := json.Marshal(req)
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+	require.NoError(t, h.processAddMembers(ctx, reqData))
+
+	for _, p := range published {
+		assert.NotEqual(t, subject.UserRoomUpdate("alice"), p.subj, "no nudge expected when room is already global")
+	}
+}
+
+// TestProcessAddMembers_SameSiteOnly_NoNudge verifies that an add composed
+// entirely of same-site members never triggers the local→global nudge (there
+// is no flip: accountsBySite stays empty, so SetRoomCrossSite and the nudge
+// are both skipped).
+func TestProcessAddMembers_SameSiteOnly_NoNudge(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+
+	var published []publishedMsg
+	publish := func(_ context.Context, subj string, data []byte, _ string) error {
+		published = append(published, publishedMsg{subj: subj, data: data})
+		return nil
+	}
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
+
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
+	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"newlocal"}, "r1").
+		Return([]AddMemberCandidate{{Account: "newlocal", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"newlocal"}).Return([]model.User{
+		{ID: "u_new", Account: "newlocal", SiteID: "site-a", EngName: "New"},
+	}, nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice"}, nil)
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 1, 0, gomock.Any()).Return(false, nil)
+	// No SetRoomCrossSite, no GetSubscriptionAccounts: strict mock proves neither fired.
+
+	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"newlocal"}, RequesterAccount: "alice", Timestamp: 1}
+	reqData, _ := json.Marshal(req)
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+	require.NoError(t, h.processAddMembers(ctx, reqData))
+
+	for _, p := range published {
+		assert.NotEqual(t, subject.UserRoomUpdate("alice"), p.subj, "no nudge expected for a same-site-only add")
+	}
+}
+
+// TestProcessAddMembers_NudgePublishErrorDoesNotFailHandler verifies that a
+// publish failure on the best-effort nudge is logged and swallowed — it must
+// never fail the handler or block the other members' nudges.
+func TestProcessAddMembers_NudgePublishErrorDoesNotFailHandler(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+
+	var published []publishedMsg
+	publish := func(_ context.Context, subj string, data []byte, _ string) error {
+		if subj == subject.UserRoomUpdate("alice") {
+			return fmt.Errorf("nats publish failed")
+		}
+		published = append(published, publishedMsg{subj: subj, data: data})
+		return nil
+	}
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
+
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
+	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"newremote"}, "r1").
+		Return([]AddMemberCandidate{{Account: "newremote", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"newremote"}).Return([]model.User{
+		{ID: "u_new", Account: "newremote", SiteID: "site-b", EngName: "New"},
+	}, nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice"}, nil)
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 1, 0, gomock.Any()).Return(false, nil)
+	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return([]string{"alice", "bob", "newremote"}, nil)
+
+	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"newremote"}, RequesterAccount: "alice", Timestamp: 1}
+	reqData, _ := json.Marshal(req)
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+	require.NoError(t, h.processAddMembers(ctx, reqData), "a nudge publish failure must not fail the handler")
+
+	var bobNudged bool
+	for _, p := range published {
+		if p.subj == subject.UserRoomUpdate("bob") {
+			bobNudged = true
+		}
+	}
+	assert.True(t, bobNudged, "bob's nudge must still publish even though alice's failed")
+}
+
+// TestProcessAddMembers_NudgeStoreErrorDoesNotFailHandler verifies that a
+// failure reading the room's subscriber list for the nudge (best-effort) is
+// logged and swallowed rather than failing the handler.
+func TestProcessAddMembers_NudgeStoreErrorDoesNotFailHandler(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
+
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
+	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"newremote"}, "r1").
+		Return([]AddMemberCandidate{{Account: "newremote", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"newremote"}).Return([]model.User{
+		{ID: "u_new", Account: "newremote", SiteID: "site-b", EngName: "New"},
+	}, nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice"}, nil)
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 1, 0, gomock.Any()).Return(false, nil)
+	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return(nil, fmt.Errorf("mongo timeout"))
+
+	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"newremote"}, RequesterAccount: "alice", Timestamp: 1}
+	reqData, _ := json.Marshal(req)
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+	require.NoError(t, h.processAddMembers(ctx, reqData), "a nudge store-read failure must not fail the handler")
+}
+
 // Repeat direct add in a tracked room: an already-tracked individual (sub + IRM row) must NOT be
 // re-scheduled for an individual insert once the store resolves HasIndividualRoomMember — only the
 // genuinely new account gets a room_members row and an event entry.
@@ -608,7 +916,7 @@ func TestHandler_ProcessAddMembers_DirectAdd_ExistingIndividualNotReinserted(t *
 		published = append(published, publishedMsg{subj: subj, data: append([]byte(nil), data...)})
 		return nil
 	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	// veteran already has a subscription AND an individual room_members row; newbie is genuinely new.
@@ -665,9 +973,9 @@ func TestHandler_ProcessAddMembers_PublishesSubscriptionUpdateBeforeRoomKey(t *t
 	publish := func(_ context.Context, subj string, data []byte, _ string) error {
 		return pub.Publish(subj, data)
 	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, roomkeysender.NewSender(pub))
+	h := NewHandler(store, "site-a", publish, testKeyStore, roomkeysender.NewSender(pub), subject.RouteGlobal)
 
-	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"bob", "charlie"}, "r1").
 		Return([]AddMemberCandidate{
 			{Account: "bob", HasSubscription: false, HasIndividualRoomMember: false},
@@ -728,7 +1036,7 @@ func TestHandler_ProcessAddMembers_BotGetsKeyAndSubUpdate(t *testing.T) {
 	publish := func(_ context.Context, subj string, data []byte, _ string) error {
 		return pub.Publish(subj, data)
 	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, roomkeysender.NewSender(pub))
+	h := NewHandler(store, "site-a", publish, testKeyStore, roomkeysender.NewSender(pub), subject.RouteGlobal)
 
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"bob", "weather.bot"}, "r1").
@@ -773,7 +1081,7 @@ func TestHandler_ProcessAddMembers_HistoryAll(t *testing.T) {
 	store := NewMockSubscriptionStore(ctrl)
 
 	publish := func(_ context.Context, _ string, _ []byte, _ string) error { return nil }
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"bob"}, "r1").
@@ -837,9 +1145,9 @@ func TestHandler_ProcessAddMembers_RestrictedPropagatesPointer(t *testing.T) {
 		published = append(published, publishedMsg{subj: subj, data: data})
 		return nil
 	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
-	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"bob", "charlie"}, "r1").
 		Return([]AddMemberCandidate{
 			{Account: "bob"}, {Account: "charlie"},
@@ -854,6 +1162,10 @@ func TestHandler_ProcessAddMembers_RestrictedPropagatesPointer(t *testing.T) {
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
+	// Local→global flip nudge: bob/charlie are the only (newly-added)
+	// subscribers, so no pre-existing member remains after the diff.
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return([]string{"bob", "charlie"}, nil)
 
 	const reqTS int64 = 1744300000000
 	req := model.AddMembersRequest{
@@ -902,7 +1214,7 @@ func TestHandler_ProcessAddMembers_UnrestrictedOmitsFieldFromWire(t *testing.T) 
 		published = append(published, publishedMsg{subj: subj, data: data})
 		return nil
 	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"bob"}, "r1").
@@ -941,7 +1253,7 @@ func TestHandler_ProcessAddMembers_WithOrgs(t *testing.T) {
 	store := NewMockSubscriptionStore(ctrl)
 
 	publish := func(_ context.Context, _ string, _ []byte, _ string) error { return nil }
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), []string{"eng"}, []string{"bob"}, "r1").
@@ -1006,7 +1318,7 @@ func TestHandler_ProcessAddMembers_RoomEventCarriesEnrichedMembers(t *testing.T)
 		published = append(published, publishedMsg{subj: subj, data: append([]byte(nil), data...)})
 		return nil
 	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Name: "deal team", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"bob", "carol"}, "r1").
@@ -1075,9 +1387,9 @@ func TestHandler_ProcessAddMembers_WithOrgs_RoomEventMembersEnrichment(t *testin
 		published = append(published, publishedMsg{subj: subj, data: append([]byte(nil), data...)})
 		return nil
 	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
-	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Name: "deal team", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Name: "deal team", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
 	// bob is the direct add; carol joins via org expansion only (not in req.Users).
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), []string{"eng"}, []string{"bob"}, "r1").
 		Return([]AddMemberCandidate{{Account: "bob"}, {Account: "carol"}}, nil)
@@ -1106,6 +1418,10 @@ func TestHandler_ProcessAddMembers_WithOrgs_RoomEventMembersEnrichment(t *testin
 		{SectID: "eng", SectName: "Engineering", SectTCName: "工程", SectDescription: "Builds the product"},
 	}, nil)
 	store.EXPECT().ExistingOrgMembers(gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]struct{}{}, nil)
+	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
+	// Local→global flip nudge: bob/carol are the only (newly-added)
+	// subscribers, so no pre-existing member remains after the diff.
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return([]string{"bob", "carol"}, nil)
 
 	req := model.AddMembersRequest{
 		RoomID: "r1", RequesterAccount: "alice",
@@ -1176,7 +1492,7 @@ func TestHandler_ProcessAddMembers_OrgWithNoUsersFallsBackToOrgID(t *testing.T) 
 		published = append(published, publishedMsg{subj: subj, data: append([]byte(nil), data...)})
 		return nil
 	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), []string{"ghost-org"}, nil, "r1").
@@ -1219,7 +1535,7 @@ func TestHandler_ProcessAddMembers_OrgDisplayFetchErrorFailsBeforeWrites(t *test
 		published = append(published, publishedMsg{subj: subj, data: append([]byte(nil), data...)})
 		return nil
 	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), []string{"eng"}, []string{"bob"}, "r1").
@@ -1259,7 +1575,7 @@ func TestHandler_ProcessAddMembers_BackfillUserMissing(t *testing.T) {
 	store := NewMockSubscriptionStore(ctrl)
 
 	publish := func(_ context.Context, _ string, _ []byte, _ string) error { return nil }
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	// Org-only add on a room with no prior orgs → backfill fires.
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
@@ -1304,7 +1620,7 @@ func TestHandler_ProcessAddMembers_UserNotFound(t *testing.T) {
 	store := NewMockSubscriptionStore(ctrl)
 
 	publish := func(_ context.Context, _ string, _ []byte, _ string) error { return nil }
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"bob", "ghost"}, "r1").
@@ -1342,9 +1658,9 @@ func TestHandler_ProcessAddMembers_MultipleSiteInbox(t *testing.T) {
 		published = append(published, publishedMsg{subj: subj, data: data})
 		return nil
 	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
-	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"alice", "bob", "charlie"}, "r1").
 		Return([]AddMemberCandidate{
 			{Account: "alice"}, {Account: "bob"}, {Account: "charlie"},
@@ -1360,6 +1676,10 @@ func TestHandler_ProcessAddMembers_MultipleSiteInbox(t *testing.T) {
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
+	// Local→global flip nudge: alice/bob/charlie are the only (newly-added)
+	// subscribers, so no pre-existing member remains after the diff.
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return([]string{"alice", "bob", "charlie"}, nil)
 
 	req := model.AddMembersRequest{
 		RoomID:           "r1",
@@ -1435,7 +1755,7 @@ func TestHandler_ProcessRemoveMember_OwnerRemovesOrg(t *testing.T) {
 	h := NewHandler(store, siteID, func(_ context.Context, subj string, data []byte, _ string) error {
 		published = append(published, publishedMsg{subj: subj, data: data})
 		return nil
-	}, testKeyStore, testKeySender)
+	}, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	req := model.RemoveMemberRequest{RoomID: roomID, Requester: requester, OrgID: orgID, Timestamp: 1000, RoomType: model.RoomTypeChannel}
 	data, _ := json.Marshal(req)
@@ -1507,7 +1827,7 @@ func TestHandler_ProcessRemoveMember_CrossSiteInbox(t *testing.T) {
 	h := NewHandler(store, localSite, func(_ context.Context, subj string, data []byte, _ string) error {
 		published = append(published, publishedMsg{subj: subj, data: data})
 		return nil
-	}, testKeyStore, testKeySender)
+	}, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	req := model.RemoveMemberRequest{RoomID: roomID, Requester: account, Account: account, Timestamp: 1000, RoomType: model.RoomTypeChannel}
 	data, _ := json.Marshal(req)
@@ -1529,7 +1849,7 @@ func TestHandler_ProcessRemoveMember_CrossSiteInbox(t *testing.T) {
 func TestHandler_ProcessRemoveMember_UnmarshalError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
-	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	err := h.processRemoveMember(context.Background(), []byte("{not json"))
 	require.Error(t, err)
@@ -1543,7 +1863,7 @@ func TestHandler_ProcessRemoveIndividual_GetUserError(t *testing.T) {
 		GetUserWithMembership(gomock.Any(), "r1", "alice").
 		Return(nil, fmt.Errorf("db down"))
 
-	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
 	req := model.RemoveMemberRequest{RoomID: "r1", Requester: "alice", Account: "alice", Timestamp: 1000, RoomType: model.RoomTypeChannel}
 	data, _ := json.Marshal(req)
 
@@ -1565,7 +1885,7 @@ func TestHandler_ProcessRemoveIndividual_DeleteRoomMemberError(t *testing.T) {
 		DeleteRoomMember(gomock.Any(), "r1", model.RoomMemberIndividual, "u1").
 		Return(fmt.Errorf("write failed"))
 
-	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
 	req := model.RemoveMemberRequest{RoomID: "r1", Requester: "alice", Account: "alice", Timestamp: 1000, RoomType: model.RoomTypeChannel}
 	data, _ := json.Marshal(req)
 
@@ -1591,7 +1911,7 @@ func TestHandler_ProcessRemoveIndividual_DualDemoteError(t *testing.T) {
 		RemoveRole(gomock.Any(), "alice", "r1", model.RoleOwner).
 		Return(fmt.Errorf("write failed"))
 
-	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
 	req := model.RemoveMemberRequest{RoomID: "r1", Requester: "alice", Account: "alice", Timestamp: 1000, RoomType: model.RoomTypeChannel}
 	data, _ := json.Marshal(req)
 
@@ -1616,7 +1936,7 @@ func TestHandler_ProcessRemoveIndividual_DeleteSubscriptionError(t *testing.T) {
 		DeleteSubscription(gomock.Any(), "r1", "alice").
 		Return(int64(0), fmt.Errorf("write failed"))
 
-	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
 	req := model.RemoveMemberRequest{RoomID: "r1", Requester: "alice", Account: "alice", Timestamp: 1000, RoomType: model.RoomTypeChannel}
 	data, _ := json.Marshal(req)
 
@@ -1645,7 +1965,7 @@ func TestHandler_ProcessRemoveIndividual_ReconcileMemberCountsError(t *testing.T
 		ReconcileMemberCounts(gomock.Any(), "r1").
 		Return(fmt.Errorf("write failed"))
 
-	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
 	req := model.RemoveMemberRequest{RoomID: "r1", Requester: "alice", Account: "alice", Timestamp: 1000, RoomType: model.RoomTypeChannel}
 	data, _ := json.Marshal(req)
 
@@ -1659,7 +1979,7 @@ func TestHandler_ProcessAddMembers_ExistingOrgsWritesIndividuals(t *testing.T) {
 	store := NewMockSubscriptionStore(ctrl)
 
 	publish := func(_ context.Context, _ string, _ []byte, _ string) error { return nil }
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"bob"}, "r1").
@@ -1784,7 +2104,7 @@ func TestHandler_ProcessAddMembers_OrgReAddAlreadyPresent_NoEvent(t *testing.T) 
 		published = append(published, publishedMsg{subj: subj, data: append([]byte(nil), data...)})
 		return nil
 	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	// eng's members are all already subscribed → no new subs, no new individual rows.
@@ -1851,7 +2171,7 @@ func TestHandler_ProcessRemoveIndividual_InboxFailurePropagates(t *testing.T) {
 		}
 		return nil
 	}
-	h := NewHandler(store, localSite, publish, testKeyStore, testKeySender)
+	h := NewHandler(store, localSite, publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	req := model.RemoveMemberRequest{RoomID: roomID, Requester: account, Account: account, Timestamp: 1000, RoomType: model.RoomTypeChannel}
 	data, _ := json.Marshal(req)
@@ -1893,7 +2213,7 @@ func TestHandler_ProcessRemoveOrg_InboxFailurePropagates(t *testing.T) {
 		}
 		return nil
 	}
-	h := NewHandler(store, localSite, publish, testKeyStore, testKeySender)
+	h := NewHandler(store, localSite, publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	req := model.RemoveMemberRequest{RoomID: roomID, Requester: requester, OrgID: orgID, Timestamp: 1000, RoomType: model.RoomTypeChannel}
 	data, _ := json.Marshal(req)
@@ -1916,7 +2236,7 @@ func TestHandler_processAddMembers_PublishesSuccessEventToRequesterSubject(t *te
 		}
 		return nil
 	}
-	h := NewHandler(store, "site1", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site1", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site1"}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), []string{"bob"}, "r1").
@@ -1965,7 +2285,7 @@ func TestHandler_processAddMembers_PublishesFailureEventOnError(t *testing.T) {
 		}
 		return nil
 	}
-	h := NewHandler(store, "site1", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site1", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	// Mock store to fail on FindUsersByAccounts (first store operation after candidate resolution)
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site1"}, nil)
@@ -2009,7 +2329,7 @@ func TestHandler_publishAsyncJobResult_PopulatesErrorOnFailure(t *testing.T) {
 		}
 		return nil
 	}
-	h := NewHandler(nil, "site1", publish, testKeyStore, testKeySender)
+	h := NewHandler(nil, "site1", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
 	jobErr := errors.New("oops")
@@ -2032,7 +2352,7 @@ func TestHandler_publishAsyncJobResult_NoOpOnEmptyRequestID(t *testing.T) {
 		called = true
 		return nil
 	}
-	h := NewHandler(nil, "site1", publish, testKeyStore, testKeySender)
+	h := NewHandler(nil, "site1", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	// No WithRequestID on ctx → empty request ID → publish is skipped.
 	h.publishAsyncJobResult(context.Background(), "alice", model.AsyncJobOpRoomMemberAdd, "r1", nil)
@@ -2045,7 +2365,7 @@ func TestHandler_publishAsyncJobResult_NoOpOnEmptyRequester(t *testing.T) {
 		called = true
 		return nil
 	}
-	h := NewHandler(nil, "site1", publish, testKeyStore, testKeySender)
+	h := NewHandler(nil, "site1", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
 	h.publishAsyncJobResult(ctx, "", model.AsyncJobOpRoomMemberAdd, "r1", nil)
@@ -2257,9 +2577,10 @@ func TestProcessAddMembers_InboxCarriesRoomName(t *testing.T) {
 	const reqID = "0193abcd-0193-7abc-89ab-0193abcd0193"
 	ctx := natsutil.WithRequestID(context.Background(), reqID)
 
-	// Cross-site member: bob lives on site-B.
+	// Cross-site member: bob lives on site-B. Room previously confirmed
+	// same-site (CrossSite: false), so this add flips it and fires the nudge.
 	mockStore.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{
-		ID: "r1", Name: "deal team", Type: model.RoomTypeChannel, SiteID: "site-A",
+		ID: "r1", Name: "deal team", Type: model.RoomTypeChannel, SiteID: "site-A", CrossSite: ptrBool(false),
 	}, nil)
 	mockStore.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), gomock.Any(), "r1").
 		Return([]AddMemberCandidate{{Account: "bob"}}, nil)
@@ -2272,6 +2593,10 @@ func TestProcessAddMembers_InboxCarriesRoomName(t *testing.T) {
 	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+	mockStore.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
+	// Local→global flip nudge: bob is the only (newly-added) subscriber, so no
+	// pre-existing member remains after the diff.
+	mockStore.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return([]string{"bob"}, nil)
 
 	body, err := json.Marshal(model.AddMembersRequest{
 		RoomID: "r1", Users: []string{"bob"},
@@ -2660,6 +2985,98 @@ func TestProcessCreateRoom_DM_BuildsTwoSubs(t *testing.T) {
 
 	// No sys messages for DM
 	assert.Empty(t, messagesCanonical(getPublished(), "site-A"))
+}
+
+// TestProcessCreateRoom_CrossSiteAtBirth verifies that a room created with an
+// initial member whose home site differs from h.siteID is born with
+// CrossSite=true, mirroring the member-add path's SetRoomCrossSite behavior
+// (Task 5) but computed inline before the CreateRoom write instead of a
+// follow-up store call.
+func TestProcessCreateRoom_CrossSiteAtBirth(t *testing.T) {
+	h, mockStore, _ := newCreateRoomTestHandler(t)
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+
+	requester := &model.User{ID: "u_alice", Account: "alice", SiteID: "site-A"}
+	other := &model.User{ID: "u_bob", Account: "bob", SiteID: "site-B"}
+
+	mockStore.EXPECT().GetUser(gomock.Any(), "alice").Return(requester, nil)
+	mockStore.EXPECT().GetUser(gomock.Any(), "bob").Return(other, nil)
+
+	var created *model.Room
+	mockStore.EXPECT().CreateRoom(gomock.Any(), gomock.AssignableToTypeOf(&model.Room{}), gomock.Any()).
+		DoAndReturn(func(_ context.Context, r *model.Room, _ *roomkeystore.RoomKeyPair) (bool, error) {
+			created = r
+			return true, nil
+		})
+
+	var capturedSubs []*model.Subscription
+	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, subs []*model.Subscription) error {
+			capturedSubs = subs
+			return nil
+		})
+	mockStore.EXPECT().FindDMSubscriptionPair(gomock.Any(), "room-dm-xsite", "alice").
+		DoAndReturn(func(_ context.Context, _, _ string) (*model.Subscription, *model.Subscription, error) {
+			return capturedSubs[0], capturedSubs[1], nil
+		})
+	mockStore.EXPECT().ReconcileMemberCounts(gomock.Any(), "room-dm-xsite").Return(nil)
+	mockStore.EXPECT().SetRoomCrossSite(gomock.Any(), "room-dm-xsite").Return(nil)
+
+	body := makeCreateRoomBody(t, &model.CreateRoomRequest{
+		RoomID:           "room-dm-xsite",
+		RequesterAccount: "alice",
+		Users:            []string{"bob"},
+		Timestamp:        time.Now().UnixMilli(),
+	})
+	require.NoError(t, h.processCreateRoom(ctx, body))
+
+	require.NotNil(t, created)
+	require.NotNil(t, created.CrossSite)
+	assert.True(t, *created.CrossSite, "room born with a site-B member must be CrossSite at creation")
+}
+
+// TestProcessCreateRoom_SameSite_NotCrossSite verifies that a room whose
+// initial members are all on h.siteID is NOT marked CrossSite at creation.
+func TestProcessCreateRoom_SameSite_NotCrossSite(t *testing.T) {
+	h, mockStore, _ := newCreateRoomTestHandler(t)
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+
+	requester := &model.User{ID: "u_alice", Account: "alice", SiteID: "site-A"}
+	other := &model.User{ID: "u_bob", Account: "bob", SiteID: "site-A"}
+
+	mockStore.EXPECT().GetUser(gomock.Any(), "alice").Return(requester, nil)
+	mockStore.EXPECT().GetUser(gomock.Any(), "bob").Return(other, nil)
+
+	var created *model.Room
+	mockStore.EXPECT().CreateRoom(gomock.Any(), gomock.AssignableToTypeOf(&model.Room{}), gomock.Any()).
+		DoAndReturn(func(_ context.Context, r *model.Room, _ *roomkeystore.RoomKeyPair) (bool, error) {
+			created = r
+			return true, nil
+		})
+
+	var capturedSubs []*model.Subscription
+	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, subs []*model.Subscription) error {
+			capturedSubs = subs
+			return nil
+		})
+	mockStore.EXPECT().FindDMSubscriptionPair(gomock.Any(), "room-dm-samesite", "alice").
+		DoAndReturn(func(_ context.Context, _, _ string) (*model.Subscription, *model.Subscription, error) {
+			return capturedSubs[0], capturedSubs[1], nil
+		})
+	mockStore.EXPECT().ReconcileMemberCounts(gomock.Any(), "room-dm-samesite").Return(nil)
+
+	body := makeCreateRoomBody(t, &model.CreateRoomRequest{
+		RoomID:           "room-dm-samesite",
+		RequesterAccount: "alice",
+		Users:            []string{"bob"},
+		Timestamp:        time.Now().UnixMilli(),
+	})
+	require.NoError(t, h.processCreateRoom(ctx, body))
+
+	require.NotNil(t, created)
+	require.NotNil(t, created.CrossSite, "new rooms must always be classified true or false, never nil")
+	assert.False(t, *created.CrossSite, "room with all-local initial members must not be CrossSite at creation")
 }
 
 func TestProcessCreateRoom_SelfDM_BuildsSingleFavoritedSub(t *testing.T) {
@@ -3131,6 +3548,7 @@ func TestProcessCreateRoom_Channel_InboxPerRemoteSite(t *testing.T) {
 	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	mockStore.EXPECT().BulkCreateRoomMembers(gomock.Any(), gomock.Any()).Return(nil)
 	mockStore.EXPECT().ReconcileMemberCounts(gomock.Any(), "room-ch-5").Return(nil)
+	mockStore.EXPECT().SetRoomCrossSite(gomock.Any(), "room-ch-5").Return(nil)
 
 	body := makeCreateRoomBody(t, &model.CreateRoomRequest{
 		RoomID: "room-ch-5", Name: "Cross Site", RequesterAccount: "alice",
@@ -3871,6 +4289,65 @@ func TestHandleSyncCreateDM_CrossSite_NoRequestID_PayloadDerivedDedup(t *testing
 		"dedup id must be payload-derived even when no request ID was supplied")
 }
 
+// TestHandleSyncCreateDM_CrossSite_MarksRoomCrossSite verifies that a sync-DM
+// with a local requester and a remote counterpart is born CrossSite=true, so
+// its events route through the global (not leaf-filtered-local) namespace.
+func TestHandleSyncCreateDM_CrossSite_MarksRoomCrossSite(t *testing.T) {
+	h, store, _ := newSyncDMTestHandler(t)
+
+	requester := &model.User{ID: "u-alice", Account: "alice", SiteID: "site-a"}
+	other := &model.User{ID: "u-bob", Account: "bob", SiteID: "site-b"}
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return([]model.User{*requester, *other}, nil)
+	var insertedRoom *model.Room
+	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, r *model.Room, _ *roomkeystore.RoomKeyPair) (bool, error) {
+			insertedRoom = r
+			return true, nil
+		})
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().FindDMSubscriptionPair(gomock.Any(), gomock.Any(), "alice").Return(
+		&model.Subscription{User: model.SubscriptionUser{ID: "u-alice", Account: "alice"}},
+		&model.Subscription{User: model.SubscriptionUser{ID: "u-bob", Account: "bob"}},
+		nil)
+
+	req := model.SyncCreateDMRequest{RoomType: model.RoomTypeDM, RequesterAccount: "alice", OtherAccount: "bob"}
+	_, err := h.serverCreateDM(dmCtx(), req)
+	require.NoError(t, err)
+
+	require.NotNil(t, insertedRoom)
+	require.NotNil(t, insertedRoom.CrossSite)
+	assert.True(t, *insertedRoom.CrossSite, "room with a remote counterpart must be CrossSite at creation")
+}
+
+// TestHandleSyncCreateDM_SameSite_NotCrossSite verifies that a sync-DM whose
+// requester and counterpart are both local is NOT marked CrossSite.
+func TestHandleSyncCreateDM_SameSite_NotCrossSite(t *testing.T) {
+	h, store, _ := newSyncDMTestHandler(t)
+
+	requester := &model.User{ID: "u-alice", Account: "alice", SiteID: "site-a"}
+	other := &model.User{ID: "u-bob", Account: "bob", SiteID: "site-a"}
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return([]model.User{*requester, *other}, nil)
+	var insertedRoom *model.Room
+	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, r *model.Room, _ *roomkeystore.RoomKeyPair) (bool, error) {
+			insertedRoom = r
+			return true, nil
+		})
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().FindDMSubscriptionPair(gomock.Any(), gomock.Any(), "alice").Return(
+		&model.Subscription{User: model.SubscriptionUser{ID: "u-alice", Account: "alice"}},
+		&model.Subscription{User: model.SubscriptionUser{ID: "u-bob", Account: "bob"}},
+		nil)
+
+	req := model.SyncCreateDMRequest{RoomType: model.RoomTypeDM, RequesterAccount: "alice", OtherAccount: "bob"}
+	_, err := h.serverCreateDM(dmCtx(), req)
+	require.NoError(t, err)
+
+	require.NotNil(t, insertedRoom)
+	require.NotNil(t, insertedRoom.CrossSite, "new rooms must always be classified true or false, never nil")
+	assert.False(t, *insertedRoom.CrossSite, "all-same-site DM must not be CrossSite at creation")
+}
+
 func TestHandleSyncCreateDM_SameSite_NoInbox(t *testing.T) {
 	h, store, capture := newSyncDMTestHandler(t)
 
@@ -4077,6 +4554,7 @@ func TestProcessCreateRoom_DM_PublishesLocalInbox(t *testing.T) {
 		&model.Subscription{User: model.SubscriptionUser{ID: "u_bob", Account: "bob"}},
 		nil)
 	mockStore.EXPECT().ReconcileMemberCounts(gomock.Any(), "room-dm-inbox").Return(nil)
+	mockStore.EXPECT().SetRoomCrossSite(gomock.Any(), "room-dm-inbox").Return(nil)
 
 	ts := time.Now().UnixMilli()
 	body := makeCreateRoomBody(t, &model.CreateRoomRequest{
@@ -4131,6 +4609,7 @@ func TestProcessCreateRoom_Channel_PublishesLocalInbox(t *testing.T) {
 	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	mockStore.EXPECT().BulkCreateRoomMembers(gomock.Any(), gomock.Any()).Return(nil)
 	mockStore.EXPECT().ReconcileMemberCounts(gomock.Any(), "room-ch-inbox").Return(nil)
+	mockStore.EXPECT().SetRoomCrossSite(gomock.Any(), "room-ch-inbox").Return(nil)
 
 	ts := time.Now().UnixMilli()
 	body := makeCreateRoomBody(t, &model.CreateRoomRequest{
@@ -4178,6 +4657,7 @@ func TestProcessCreateRoom_Channel_PublishesCrossSiteMemberAdded(t *testing.T) {
 	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	mockStore.EXPECT().BulkCreateRoomMembers(gomock.Any(), gomock.Any()).Return(nil)
 	mockStore.EXPECT().ReconcileMemberCounts(gomock.Any(), "room-ch-xsite").Return(nil)
+	mockStore.EXPECT().SetRoomCrossSite(gomock.Any(), "room-ch-xsite").Return(nil)
 
 	body := makeCreateRoomBody(t, &model.CreateRoomRequest{
 		RoomID: "room-ch-xsite", Name: "Cross", RequesterAccount: "alice",
@@ -4205,6 +4685,69 @@ func TestProcessCreateRoom_Channel_PublishesCrossSiteMemberAdded(t *testing.T) {
 	assert.Equal(t, "site-A", inner.SiteID, "inner SiteID is the origin (room's home)")
 	assert.Equal(t, "alice", inner.RequesterAccount, "create-time member_added carries RequesterAccount for DM/botDM counterpart resolution")
 	assert.Nil(t, inner.HistorySharedSince, "create-time event must be unrestricted")
+}
+
+// TestProcessCreateRoom_Channel_CrossSiteAtCreate verifies that a channel room
+// born with an off-site initial member is marked CrossSite via the post-write
+// Store.SetRoomCrossSite call in finishCreateRoom — unlike DM/botDM, channel
+// members are only resolved after the CreateRoom write, so the room doc
+// captured by that mock cannot carry CrossSite=true itself (see
+// TestProcessCreateRoom_CrossSiteAtBirth for the DM/botDM pre-write case).
+func TestProcessCreateRoom_Channel_CrossSiteAtCreate(t *testing.T) {
+	h, mockStore, _ := newCreateRoomTestHandler(t)
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+
+	requester := &model.User{ID: "u_alice", Account: "alice", EngName: "Alice A", ChineseName: "艾麗斯", SiteID: "site-A"}
+	invited := []model.User{
+		{ID: "u_bob", Account: "bob", EngName: "Bob B", ChineseName: "鮑伯", SiteID: "site-B"},
+	}
+
+	mockStore.EXPECT().GetUser(gomock.Any(), "alice").Return(requester, nil)
+	mockStore.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+	mockStore.EXPECT().ListNewMembersForNewRoom(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{"bob"}, nil)
+	mockStore.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return(invited, nil)
+	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	mockStore.EXPECT().BulkCreateRoomMembers(gomock.Any(), gomock.Any()).Return(nil)
+	mockStore.EXPECT().ReconcileMemberCounts(gomock.Any(), "room-ch-xsite-mark").Return(nil)
+	mockStore.EXPECT().SetRoomCrossSite(gomock.Any(), "room-ch-xsite-mark").Return(nil).Times(1)
+
+	body := makeCreateRoomBody(t, &model.CreateRoomRequest{
+		RoomID: "room-ch-xsite-mark", Name: "Cross Mark", RequesterAccount: "alice",
+		Users: []string{"bob"}, Orgs: []string{"org1"},
+		ResolvedUsers: []string{"bob"}, ResolvedOrgs: []string{"org1"},
+		Timestamp: time.Now().UnixMilli(),
+	})
+	require.NoError(t, h.processCreateRoom(ctx, body))
+}
+
+// TestProcessCreateRoom_Channel_SameSite_NoCrossSiteWrite verifies that a
+// channel room whose initial members are all on h.siteID never calls
+// Store.SetRoomCrossSite.
+func TestProcessCreateRoom_Channel_SameSite_NoCrossSiteWrite(t *testing.T) {
+	h, mockStore, _ := newCreateRoomTestHandler(t)
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+
+	requester := &model.User{ID: "u_alice", Account: "alice", EngName: "Alice A", ChineseName: "艾麗斯", SiteID: "site-A"}
+	invited := []model.User{
+		{ID: "u_bob", Account: "bob", EngName: "Bob B", ChineseName: "鮑伯", SiteID: "site-A"},
+	}
+
+	mockStore.EXPECT().GetUser(gomock.Any(), "alice").Return(requester, nil)
+	mockStore.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+	mockStore.EXPECT().ListNewMembersForNewRoom(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{"bob"}, nil)
+	mockStore.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return(invited, nil)
+	mockStore.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	mockStore.EXPECT().BulkCreateRoomMembers(gomock.Any(), gomock.Any()).Return(nil)
+	mockStore.EXPECT().ReconcileMemberCounts(gomock.Any(), "room-ch-samesite-mark").Return(nil)
+	mockStore.EXPECT().SetRoomCrossSite(gomock.Any(), gomock.Any()).Times(0)
+
+	body := makeCreateRoomBody(t, &model.CreateRoomRequest{
+		RoomID: "room-ch-samesite-mark", Name: "Same Site", RequesterAccount: "alice",
+		Users: []string{"bob"}, Orgs: []string{"org1"},
+		ResolvedUsers: []string{"bob"}, ResolvedOrgs: []string{"org1"},
+		Timestamp: time.Now().UnixMilli(),
+	})
+	require.NoError(t, h.processCreateRoom(ctx, body))
 }
 
 // ---- Task 10: key-gate and fan-out tests ----
@@ -4255,7 +4798,7 @@ func TestProcessCreateRoom_KeyStoreGetError(t *testing.T) {
 		&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	keyStore.EXPECT().Get(gomock.Any(), "r1").Return(nil, fmt.Errorf("mongo timeout"))
 
-	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, keyStore, nil)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, keyStore, nil, subject.RouteGlobal)
 
 	// Name set → channel room (the only encrypted, key-bearing type).
 	req := model.CreateRoomRequest{
@@ -4303,7 +4846,7 @@ func TestProcessAddMembers_FansOutKeyToNewAccountsOnly(t *testing.T) {
 	}
 	keyStore.EXPECT().Get(gomock.Any(), "r1").Return(pair, nil)
 
-	h := NewHandler(mockStore, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, keyStore, keySender)
+	h := NewHandler(mockStore, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, keyStore, keySender, subject.RouteGlobal)
 
 	req := model.AddMembersRequest{
 		RoomID: "r1", RequesterAccount: "alice", Users: []string{"charlie"}, Timestamp: 1,
@@ -4338,7 +4881,7 @@ func TestProcessAddMembers_PermanentErrorWhenKeyMissing(t *testing.T) {
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	keyStore.EXPECT().Get(gomock.Any(), "r1").Return(nil, nil) // key missing
 
-	h := NewHandler(mockStore, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, keyStore, roomkeysender.NewSender(&mockPublisher{}))
+	h := NewHandler(mockStore, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, keyStore, roomkeysender.NewSender(&mockPublisher{}), subject.RouteGlobal)
 
 	req := model.AddMembersRequest{
 		RoomID: "r1", RequesterAccount: "alice", Users: []string{"charlie"}, Timestamp: 1,
@@ -4374,7 +4917,7 @@ func TestProcessAddMembers_TransientErrorWhenValkeyFails(t *testing.T) {
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	keyStore.EXPECT().Get(gomock.Any(), "r1").Return(nil, fmt.Errorf("valkey timeout"))
 
-	h := NewHandler(mockStore, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, keyStore, roomkeysender.NewSender(&mockPublisher{}))
+	h := NewHandler(mockStore, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, keyStore, roomkeysender.NewSender(&mockPublisher{}), subject.RouteGlobal)
 
 	req := model.AddMembersRequest{
 		RoomID: "r1", RequesterAccount: "alice", Users: []string{"charlie"}, Timestamp: 1,
@@ -4398,7 +4941,7 @@ func TestProcessAddMembers_RejectsNonChannel(t *testing.T) {
 	mockStore.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), gomock.Any(), "r1").Return(nil, nil).AnyTimes()
 	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil).AnyTimes()
 
-	h := NewHandler(mockStore, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
+	h := NewHandler(mockStore, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
 	req := model.AddMembersRequest{RoomID: "r1", RequesterAccount: "alice", Users: []string{"x"}, Timestamp: 1}
 	data, _ := json.Marshal(req)
 	err := h.processAddMembers(natsutil.WithRequestID(context.Background(), "0193abcd-0193-7abc-89ab-0193abcd0013"), data)
@@ -4412,7 +4955,7 @@ func TestProcessRemoveMember_RejectsNonChannel(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
 
-	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
 	req := model.RemoveMemberRequest{RoomID: "r1", Requester: "alice", Account: "bob", RoomType: model.RoomTypeDM}
 	data, _ := json.Marshal(req)
 	err := h.processRemoveMember(natsutil.WithRequestID(context.Background(), "req-1"), data)
@@ -4436,7 +4979,7 @@ func TestFanOutRoomKeyToSurvivors_SendsToAllSurvivorsIncludingRemoteSite(t *test
 	// (remote-carol); the caller projects these out of the subscriptions.
 	survivorAccounts := []string{"alice", "bob", "remote-carol"}
 
-	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, nil, keySender)
+	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, nil, keySender, subject.RouteGlobal)
 	h.fanOutRoomKeyToSurvivors(context.Background(), "r1", pair, survivorAccounts)
 	// alice, bob (site-a) and remote-carol (site-b) all receive the new key.
 	assert.ElementsMatch(t, []string{
@@ -5889,10 +6432,11 @@ func TestProcessRoomRename_PublishesRoomRenamedEvent(t *testing.T) {
 	store.EXPECT().UpdateSubscriptionNamesForRoom(gomock.Any(), roomID, newName, gomock.Any()).Return(nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
 	store.EXPECT().ListByRoom(gomock.Any(), roomID).Return(nil, nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), roomID).Return(&model.Room{ID: roomID}, nil)
 
 	var roomEvts [][]byte
 	publish := func(_ context.Context, subj string, data []byte, _ string) error {
-		if subj == subject.RoomEvent(roomID) {
+		if subj == subject.RoomEvent(roomID, true) {
 			roomEvts = append(roomEvts, data)
 		}
 		return nil
@@ -5939,6 +6483,7 @@ func TestProcessRoomRename_HappyPathNoRemoteSites(t *testing.T) {
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return([]model.User{
 		{Account: "alice", SiteID: "site-a"}, {Account: "bob", SiteID: "site-a"},
 	}, nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), roomID).Return(&model.Room{ID: roomID}, nil)
 
 	var publishedSubjects []string
 	publish := func(_ context.Context, subj string, _ []byte, _ string) error {
@@ -5986,6 +6531,7 @@ func TestProcessRoomRename_HappyPathWithRemoteSite(t *testing.T) {
 		{Account: "alice", SiteID: "site-a"},
 		{Account: "bob", SiteID: "site-b"},
 	}, nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), roomID).Return(&model.Room{ID: roomID}, nil)
 
 	var publishedSubjects []string
 	var inboxPayloads []model.RoomRenamedInboxPayload
@@ -6047,6 +6593,7 @@ func TestProcessRoomRename_ErrorThenOkRetrySequence(t *testing.T) {
 	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
 	// Empty subs → accounts is empty → findRemoteSitesForAccounts short-circuits (no FindUsersByAccounts call).
 	store.EXPECT().ListByRoom(gomock.Any(), "r1").Return([]model.Subscription{}, nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1"}, nil)
 
 	var asyncResults []model.AsyncJobResult
 	publish := func(_ context.Context, subj string, data []byte, _ string) error {
@@ -6071,6 +6618,119 @@ func TestProcessRoomRename_ErrorThenOkRetrySequence(t *testing.T) {
 	require.Len(t, asyncResults, 2)
 	assert.Equal(t, model.AsyncJobStatusError, asyncResults[0].Status)
 	assert.Equal(t, model.AsyncJobStatusOK, asyncResults[1].Status)
+}
+
+// --- room_renamed event routing (ROOM_SUBJECT_MODE gate) ---
+
+func newRoomRenameRoutingFixture(t *testing.T, crossSite bool) (*Handler, *MockSubscriptionStore, func() [][]byte, string) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+
+	const roomID, newName = "r1", "renamed"
+	requestID := testRequestID
+
+	store.EXPECT().UpdateRoomName(gomock.Any(), roomID, newName).Return(nil)
+	store.EXPECT().UpdateSubscriptionNamesForRoom(gomock.Any(), roomID, newName, gomock.Any()).Return(nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
+	store.EXPECT().ListByRoom(gomock.Any(), roomID).Return(nil, nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), roomID).Return(&model.Room{ID: roomID, CrossSite: ptrBool(crossSite)}, nil)
+
+	var roomEvts [][]byte
+	publish := func(_ context.Context, subj string, data []byte, _ string) error {
+		if subj == subject.RoomEvent(roomID, true) || subj == subject.RoomEvent(roomID, false) {
+			roomEvts = append(roomEvts, []byte(subj))
+		}
+		return nil
+	}
+	h := &Handler{store: store, siteID: "site-a", publish: publish}
+	return h, store, func() [][]byte { return roomEvts }, requestID
+}
+
+func roomRenameBody(t *testing.T) []byte {
+	t.Helper()
+	body, err := json.Marshal(model.RenameRoomRequest{
+		RoomID: "r1", NewName: "renamed", Account: "alice", Timestamp: 1700000000000,
+	})
+	require.NoError(t, err)
+	return body
+}
+
+func TestProcessRoomRename_GlobalMode_AlwaysGlobal(t *testing.T) {
+	h, _, evts, requestID := newRoomRenameRoutingFixture(t, false)
+	h.routeMode = subject.RouteGlobal
+	ctx := natsutil.WithRequestID(context.Background(), requestID)
+
+	require.NoError(t, h.processRoomRename(ctx, roomRenameBody(t)))
+
+	require.Len(t, evts(), 1)
+	assert.Equal(t, subject.RoomEvent("r1", true), string(evts()[0]))
+}
+
+func TestProcessRoomRename_LocalMode_SameSiteUsesLocal(t *testing.T) {
+	h, _, evts, requestID := newRoomRenameRoutingFixture(t, false)
+	h.routeMode = subject.RouteLocal
+	ctx := natsutil.WithRequestID(context.Background(), requestID)
+
+	require.NoError(t, h.processRoomRename(ctx, roomRenameBody(t)))
+
+	require.Len(t, evts(), 1)
+	assert.Equal(t, subject.RoomEvent("r1", false), string(evts()[0]))
+}
+
+func TestProcessRoomRename_DualMode_SameSitePublishesBoth(t *testing.T) {
+	h, _, evts, requestID := newRoomRenameRoutingFixture(t, false)
+	h.routeMode = subject.RouteDual
+	ctx := natsutil.WithRequestID(context.Background(), requestID)
+
+	require.NoError(t, h.processRoomRename(ctx, roomRenameBody(t)))
+
+	require.Len(t, evts(), 2)
+	assert.Equal(t, subject.RoomEvent("r1", false), string(evts()[0]))
+	assert.Equal(t, subject.RoomEvent("r1", true), string(evts()[1]))
+}
+
+func TestProcessRoomRename_CrossSiteRoomAlwaysGlobal(t *testing.T) {
+	for _, mode := range []subject.RoomRouteMode{subject.RouteGlobal, subject.RouteDual, subject.RouteLocal} {
+		t.Run(fmt.Sprintf("mode=%d", mode), func(t *testing.T) {
+			h, _, evts, requestID := newRoomRenameRoutingFixture(t, true)
+			h.routeMode = mode
+			ctx := natsutil.WithRequestID(context.Background(), requestID)
+
+			require.NoError(t, h.processRoomRename(ctx, roomRenameBody(t)))
+
+			require.Len(t, evts(), 1)
+			assert.Equal(t, subject.RoomEvent("r1", true), string(evts()[0]))
+		})
+	}
+}
+
+func TestProcessRoomRename_GetRoomFails_FallsBackToGlobal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+
+	const roomID, newName = "r1", "renamed"
+	requestID := testRequestID
+
+	store.EXPECT().UpdateRoomName(gomock.Any(), roomID, newName).Return(nil)
+	store.EXPECT().UpdateSubscriptionNamesForRoom(gomock.Any(), roomID, newName, gomock.Any()).Return(nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
+	store.EXPECT().ListByRoom(gomock.Any(), roomID).Return(nil, nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), roomID).Return(nil, errors.New("mongo down"))
+
+	var roomEvts []string
+	publish := func(_ context.Context, subj string, _ []byte, _ string) error {
+		if subj == subject.RoomEvent(roomID, true) || subj == subject.RoomEvent(roomID, false) {
+			roomEvts = append(roomEvts, subj)
+		}
+		return nil
+	}
+	h := &Handler{store: store, siteID: "site-a", publish: publish, routeMode: subject.RouteLocal}
+	ctx := natsutil.WithRequestID(context.Background(), requestID)
+
+	require.NoError(t, h.processRoomRename(ctx, roomRenameBody(t)), "GetRoom failure on the best-effort event fan-out must not fail the RPC")
+
+	require.Len(t, roomEvts, 1, "falls back to global-only, matching pre-routing behavior, when the room can't be re-fetched")
+	assert.Equal(t, subject.RoomEvent(roomID, true), roomEvts[0])
 }
 
 // --- bustRoomMeta tests ---

--- a/room-worker/integration_test.go
+++ b/room-worker/integration_test.go
@@ -746,15 +746,15 @@ func TestMongoStore_ListAddMemberCandidates_Integration(t *testing.T) {
 	t.Run("org expansion excludes bots", func(t *testing.T) {
 		byAccount := collect(t, []string{"org-eng"}, nil)
 		require.Len(t, byAccount, 3, "org-covered bot dave.bot must be excluded")
-		assert.Equal(t, AddMemberCandidate{Account: "alice", HasSubscription: false, HasIndividualRoomMember: false}, byAccount["alice"])
-		assert.Equal(t, AddMemberCandidate{Account: "bob", HasSubscription: true, HasIndividualRoomMember: false}, byAccount["bob"], "bug scenario: sub exists, IRM does not")
-		assert.Equal(t, AddMemberCandidate{Account: "carol", HasSubscription: true, HasIndividualRoomMember: true}, byAccount["carol"])
+		assert.Equal(t, AddMemberCandidate{Account: "alice", HasSubscription: false, HasIndividualRoomMember: false, SiteID: "site-a"}, byAccount["alice"])
+		assert.Equal(t, AddMemberCandidate{Account: "bob", HasSubscription: true, HasIndividualRoomMember: false, SiteID: "site-a"}, byAccount["bob"], "bug scenario: sub exists, IRM does not")
+		assert.Equal(t, AddMemberCandidate{Account: "carol", HasSubscription: true, HasIndividualRoomMember: true, SiteID: "site-a"}, byAccount["carol"])
 	})
 
 	t.Run("explicitly listed bot resolves via the direct-only path", func(t *testing.T) {
 		byAccount := collect(t, nil, []string{"dave.bot"})
 		require.Len(t, byAccount, 1)
-		assert.Equal(t, AddMemberCandidate{Account: "dave.bot", HasSubscription: false, HasIndividualRoomMember: false}, byAccount["dave.bot"])
+		assert.Equal(t, AddMemberCandidate{Account: "dave.bot", HasSubscription: false, HasIndividualRoomMember: false, SiteID: "site-a"}, byAccount["dave.bot"])
 	})
 
 	t.Run("explicitly listed bot resolves alongside org expansion", func(t *testing.T) {
@@ -768,7 +768,7 @@ func TestMongoStore_ListAddMemberCandidates_Integration(t *testing.T) {
 func newIntegrationHandler(t *testing.T, store *MongoStore, siteID string) *Handler {
 	t.Helper()
 	noopPublish := func(_ context.Context, _ string, _ []byte, _ string) error { return nil }
-	return NewHandler(store, siteID, noopPublish, testKeyStore, testKeySender)
+	return NewHandler(store, siteID, noopPublish, testKeyStore, testKeySender, subject.RouteGlobal)
 }
 
 func TestProcessCreateRoomChannelPersistsAllState(t *testing.T) {
@@ -871,7 +871,7 @@ func TestProcessCreateRoomChannel_InboxPerRemoteSite(t *testing.T) {
 		EngName: "Ian", ChineseName: "伊恩"})
 
 	cap := &publishCapture{}
-	h := NewHandler(store, "site-A", cap.fn(), testKeyStore, testKeySender)
+	h := NewHandler(store, "site-A", cap.fn(), testKeyStore, testKeySender, subject.RouteGlobal)
 	const reqID = "0193abcd-0193-7abc-89ab-0193abcd0193"
 	ctx = natsutil.WithRequestID(ctx, reqID)
 
@@ -945,7 +945,7 @@ func TestProcessCreateRoomDM_InboxToCounterpartSite(t *testing.T) {
 		EngName: "Bob", ChineseName: "鲍勃"})
 
 	cap := &publishCapture{}
-	h := NewHandler(store, "site-A", cap.fn(), testKeyStore, testKeySender)
+	h := NewHandler(store, "site-A", cap.fn(), testKeyStore, testKeySender, subject.RouteGlobal)
 	const reqID = "0193abcd-0193-7abc-89ab-0193abcd0193"
 	ctx = natsutil.WithRequestID(ctx, reqID)
 
@@ -1034,7 +1034,7 @@ func TestProcessAddMembers_InboxPerRemoteSite(t *testing.T) {
 	require.NoError(t, err)
 
 	cap := &publishCapture{}
-	h := NewHandler(store, "site-A", cap.fn(), testKeyStore, testKeySender)
+	h := NewHandler(store, "site-A", cap.fn(), testKeyStore, testKeySender, subject.RouteGlobal)
 	const reqID = "0193abcd-0193-7abc-89ab-0193abcd0193"
 	ctx = natsutil.WithRequestID(ctx, reqID)
 
@@ -1141,7 +1141,7 @@ func TestProcessAddMembers_PublishesLocalInbox_Integration(t *testing.T) {
 	})
 
 	cap := &publishCapture{}
-	h := NewHandler(store, "site-A", cap.fn(), testKeyStore, testKeySender)
+	h := NewHandler(store, "site-A", cap.fn(), testKeyStore, testKeySender, subject.RouteGlobal)
 	const reqID = "0193abcd-0193-7abc-89ab-aaaa00000001"
 	ctx = natsutil.WithRequestID(ctx, reqID)
 
@@ -1254,7 +1254,7 @@ func TestProcessAddMembers_RoomEventMembersEnrichment_Integration(t *testing.T) 
 	})
 
 	cap := &publishCapture{}
-	h := NewHandler(store, "site-A", cap.fn(), testKeyStore, testKeySender)
+	h := NewHandler(store, "site-A", cap.fn(), testKeyStore, testKeySender, subject.RouteGlobal)
 	ctx = natsutil.WithRequestID(ctx, "0193abcd-0193-7abc-89ab-aaaa00000002")
 
 	acceptedMs := time.Now().UTC().UnixMilli()
@@ -1332,7 +1332,7 @@ func TestProcessAddMembers_RoomEventMembersEnrichment_Integration(t *testing.T) 
 	// Re-adding the already-present org is a no-op: no member_added event fires
 	// (nothing changed), and the idempotent upsert inserts no duplicate org row.
 	cap2 := &publishCapture{}
-	h2 := NewHandler(store, "site-A", cap2.fn(), testKeyStore, testKeySender)
+	h2 := NewHandler(store, "site-A", cap2.fn(), testKeyStore, testKeySender, subject.RouteGlobal)
 	body2, err := json.Marshal(model.AddMembersRequest{
 		RoomID:           roomID,
 		Orgs:             []string{"eng"},
@@ -1380,7 +1380,7 @@ func TestProcessRemoveIndividual_PublishesLocalInbox_Integration(t *testing.T) {
 	require.NoError(t, err)
 
 	cap := &publishCapture{}
-	h := NewHandler(store, "site-A", cap.fn(), testKeyStore, testKeySender)
+	h := NewHandler(store, "site-A", cap.fn(), testKeyStore, testKeySender, subject.RouteGlobal)
 	const reqID = "0193abcd-0193-7abc-89ab-aaaa00000002"
 	ctx = natsutil.WithRequestID(ctx, reqID)
 
@@ -1442,7 +1442,7 @@ func TestSyncCreateDM_DM_PersistsRoomAndSubs(t *testing.T) {
 	mustInsertUser(t, db, &model.User{ID: "u-bob", Account: "bob", SiteID: siteID, EngName: "Bob", ChineseName: "鮑勃"})
 
 	cap := &publishCapture{}
-	handler := NewHandler(store, siteID, cap.fn(), testKeyStore, testKeySender)
+	handler := NewHandler(store, siteID, cap.fn(), testKeyStore, testKeySender, subject.RouteGlobal)
 
 	req := model.SyncCreateDMRequest{RoomType: model.RoomTypeDM, RequesterAccount: "alice", OtherAccount: "bob"}
 	got, err := handler.serverCreateDM(ctx, req)
@@ -1532,7 +1532,7 @@ func TestSyncCreateDM_BotDM_CrossSiteInbox(t *testing.T) {
 	mustInsertUser(t, db, &model.User{ID: "u-bot", Account: "helper.bot", SiteID: "site-B", EngName: "Helper", ChineseName: "助手"})
 
 	cap := &publishCapture{}
-	handler := NewHandler(store, siteID, cap.fn(), testKeyStore, testKeySender)
+	handler := NewHandler(store, siteID, cap.fn(), testKeyStore, testKeySender, subject.RouteGlobal)
 
 	req := model.SyncCreateDMRequest{RoomType: model.RoomTypeBotDM, RequesterAccount: "alice", OtherAccount: "helper.bot"}
 	_, err := handler.serverCreateDM(newIntegSyncDMCtx(), req)
@@ -1552,7 +1552,7 @@ func TestSyncCreateDM_RetryIdempotent(t *testing.T) {
 	mustInsertUser(t, db, &model.User{ID: "u-bob", Account: "bob", SiteID: siteID, EngName: "Bob", ChineseName: "鮑勃"})
 
 	cap := &publishCapture{}
-	handler := NewHandler(store, siteID, cap.fn(), testKeyStore, testKeySender)
+	handler := NewHandler(store, siteID, cap.fn(), testKeyStore, testKeySender, subject.RouteGlobal)
 
 	req := model.SyncCreateDMRequest{RoomType: model.RoomTypeDM, RequesterAccount: "alice", OtherAccount: "bob"}
 
@@ -1589,7 +1589,7 @@ func TestSyncCreateDM_CrossSite_InboxPayloadConverges(t *testing.T) {
 	mustInsertUser(t, db, &model.User{ID: "u-bob", Account: "bob", SiteID: "site-B", EngName: "Bob", ChineseName: "鮑勃"})
 
 	cap1 := &publishCapture{}
-	handler := NewHandler(store, siteID, cap1.fn(), testKeyStore, testKeySender)
+	handler := NewHandler(store, siteID, cap1.fn(), testKeyStore, testKeySender, subject.RouteGlobal)
 
 	req := model.SyncCreateDMRequest{RoomType: model.RoomTypeDM, RequesterAccount: "alice", OtherAccount: "bob"}
 	_, err := handler.serverCreateDM(newIntegSyncDMCtx(), req)
@@ -1619,7 +1619,7 @@ func TestSyncCreateDM_CrossSite_InboxPayloadConverges(t *testing.T) {
 	//    from the (stable) payload seed — room id + requester account + createdAt +
 	//    dest — not the request ID. JetStream INBOX dedup rejects the second emit.
 	cap2 := &publishCapture{}
-	handler2 := NewHandler(store, siteID, cap2.fn(), testKeyStore, testKeySender)
+	handler2 := NewHandler(store, siteID, cap2.fn(), testKeyStore, testKeySender, subject.RouteGlobal)
 	_, err = handler2.serverCreateDM(newIntegSyncDMCtx(), req)
 	require.NoError(t, err)
 	pubs2 := cap2.publishesOnPrefix(subject.Outbox(siteID, "site-B", model.InboxMemberAdded))
@@ -1719,7 +1719,7 @@ func TestIntegration_CreateRoom_FansOutRoomKeyEvent(t *testing.T) {
 	// Wire up the handler with real keyStore and keySender backed by embedded NATS.
 	keySender := roomkeysender.NewSender(nc)
 	noopPublish := func(_ context.Context, _ string, _ []byte, _ string) error { return nil }
-	h := NewHandler(store, "site-A", noopPublish, keyStore, keySender)
+	h := NewHandler(store, "site-A", noopPublish, keyStore, keySender, subject.RouteGlobal)
 
 	const reqID = "0193abcd-0193-7abc-89ab-0193abcd0001"
 	ctx = natsutil.WithRequestID(ctx, reqID)
@@ -1931,7 +1931,7 @@ func TestHandler_ProcessAddMembers_OrgToIndividualUpgrade_Integration(t *testing
 	db := setupMongo(t)
 	store := NewMongoStore(db)
 	cap := &publishCapture{}
-	h := NewHandler(store, "site-a", cap.fn(), testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", cap.fn(), testKeyStore, testKeySender, subject.RouteGlobal)
 
 	const roomID = "room-1"
 	mustInsertRoom(t, db, &model.Room{ID: roomID, Type: model.RoomTypeChannel, SiteID: "site-a", Name: "Room 1"})
@@ -2072,7 +2072,7 @@ func TestHandler_ProcessCreateRoom_DMConcurrentByCounterpart_Integration(t *test
 	db := setupMongo(t)
 	store := NewMongoStore(db)
 	cap := &publishCapture{}
-	h := NewHandler(store, "site-a", cap.fn(), testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", cap.fn(), testKeyStore, testKeySender, subject.RouteGlobal)
 
 	mustInsertUser(t, db, &model.User{ID: "u_alice", Account: "alice", EngName: "Alice", ChineseName: "爱", SiteID: "site-a"})
 	mustInsertUser(t, db, &model.User{ID: "u_bob", Account: "bob", EngName: "Bob", ChineseName: "鲍", SiteID: "site-a"})
@@ -2266,7 +2266,7 @@ func TestIntegration_ProcessRoomRename(t *testing.T) {
 	mustInsertUser(t, db, &model.User{ID: "u3", Account: "carol", SiteID: remoteSite})
 
 	cap := &publishCapture{}
-	h := NewHandler(store, siteID, cap.fn(), testKeyStore, testKeySender)
+	h := NewHandler(store, siteID, cap.fn(), testKeyStore, testKeySender, subject.RouteGlobal)
 	const reqID = "01970a4f-8c2d-7c9a-abcd-e0123456789a"
 	ctx = natsutil.WithRequestID(ctx, reqID)
 
@@ -2393,4 +2393,27 @@ func TestMongoStore_GetApp_Integration(t *testing.T) {
 
 	_, err = store.GetApp(ctx, "missing.bot")
 	assert.ErrorIs(t, err, ErrAppNotFound)
+}
+
+// TestSetRoomCrossSite_Sticky covers the idempotent $set crossSite=true write:
+// a fresh room without the field gets it set on first call, and a second call
+// is a no-op that leaves it true (sticky — never set back to false).
+func TestSetRoomCrossSite_Sticky(t *testing.T) {
+	db := setupMongo(t)
+	store := NewMongoStore(db)
+	ctx := context.Background()
+
+	_, err := db.Collection("rooms").InsertOne(ctx, bson.M{"_id": "r1", "siteId": "site-a"})
+	require.NoError(t, err)
+	require.NoError(t, store.SetRoomCrossSite(ctx, "r1"))
+	var got model.Room
+	require.NoError(t, db.Collection("rooms").FindOne(ctx, bson.M{"_id": "r1"}).Decode(&got))
+	require.NotNil(t, got.CrossSite)
+	assert.True(t, *got.CrossSite)
+
+	// Idempotent second call.
+	require.NoError(t, store.SetRoomCrossSite(ctx, "r1"))
+	require.NoError(t, db.Collection("rooms").FindOne(ctx, bson.M{"_id": "r1"}).Decode(&got))
+	require.NotNil(t, got.CrossSite)
+	assert.True(t, *got.CrossSite)
 }

--- a/room-worker/keyfanout_test.go
+++ b/room-worker/keyfanout_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/roomkeysender"
+	"github.com/hmchangw/chat/pkg/subject"
 )
 
 // newFanoutTestHandler builds a Handler via NewHandler so future field
@@ -21,7 +22,7 @@ import (
 // are unused by it.
 func newFanoutTestHandler(t *testing.T, keySender *roomkeysender.Sender, workers int) *Handler {
 	t.Helper()
-	h := NewHandler(nil, "test-site", nil, testKeyStore, keySender)
+	h := NewHandler(nil, "test-site", nil, testKeyStore, keySender, subject.RouteGlobal)
 	h.SetKeyFanoutWorkers(workers)
 	return h
 }

--- a/room-worker/main.go
+++ b/room-worker/main.go
@@ -72,6 +72,8 @@ type config struct {
 
 	// AdminAcctPrefix overrides the platform-admin account prefix (ADMIN_ACCT_PREFIX); keep it identical across services.
 	AdminAcctPrefix string `env:"ADMIN_ACCT_PREFIX" envDefault:"p_admin"`
+	// RoomSubjectMode: same-site room .event namespace — global (default) | dual | local. See pkg/subject.RoomRouteMode.
+	RoomSubjectMode string `env:"ROOM_SUBJECT_MODE" envDefault:"global"`
 }
 
 func main() {
@@ -92,6 +94,11 @@ func main() {
 	if cfg.RoomKeyGracePeriod <= 0 {
 		slog.Error("ROOM_KEY_GRACE_PERIOD must be a positive duration",
 			"room_key_grace_period", cfg.RoomKeyGracePeriod)
+		os.Exit(1)
+	}
+	roomRouteMode, err := subject.ParseRoomRouteMode(cfg.RoomSubjectMode)
+	if err != nil {
+		slog.Error("invalid ROOM_SUBJECT_MODE", "error", err)
 		os.Exit(1)
 	}
 
@@ -197,7 +204,7 @@ func main() {
 			return fmt.Errorf("publish to %q: %w", subj, err)
 		}
 		return nil
-	}, keyStore, keySender)
+	}, keyStore, keySender, roomRouteMode)
 	handler.SetKeyFanoutWorkers(cfg.KeyFanoutWorkers)
 	// Teams room-reconcile's external-user-identity fanout (chat.hr.{siteID}.users.upsert),
 	// mirroring message-worker's Teams sender-resolver publish (feat/migrated-user-fanout).

--- a/room-worker/mock_store_test.go
+++ b/room-worker/mock_store_test.go
@@ -443,6 +443,20 @@ func (mr *MockSubscriptionStoreMockRecorder) RemoveRole(ctx, account, roomID, ro
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRole", reflect.TypeOf((*MockSubscriptionStore)(nil).RemoveRole), ctx, account, roomID, role)
 }
 
+// SetRoomCrossSite mocks base method.
+func (m *MockSubscriptionStore) SetRoomCrossSite(ctx context.Context, roomID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetRoomCrossSite", ctx, roomID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetRoomCrossSite indicates an expected call of SetRoomCrossSite.
+func (mr *MockSubscriptionStoreMockRecorder) SetRoomCrossSite(ctx, roomID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRoomCrossSite", reflect.TypeOf((*MockSubscriptionStore)(nil).SetRoomCrossSite), ctx, roomID)
+}
+
 // UpdateRoomName mocks base method.
 func (m *MockSubscriptionStore) UpdateRoomName(ctx context.Context, roomID, newName string) error {
 	m.ctrl.T.Helper()

--- a/room-worker/store.go
+++ b/room-worker/store.go
@@ -56,6 +56,9 @@ type AddMemberCandidate struct {
 	Account                 string `bson:"account"`
 	HasSubscription         bool   `bson:"hasSubscription"`
 	HasIndividualRoomMember bool   `bson:"hasIndividualRoomMember"`
+	// SiteID is the candidate's home site (from the users lookup); lets callers
+	// classify cross-site membership from the full candidate set, redelivery-safe.
+	SiteID string `bson:"siteId"`
 }
 
 type SubscriptionStore interface {
@@ -78,10 +81,8 @@ type SubscriptionStore interface {
 	// periodic recompute (the drift safety net) restores convergence.
 	ApplyMemberCountDelta(ctx context.Context, roomID string, userDelta, appDelta int, ttl time.Duration) (reconcileDue bool, err error)
 	GetRoom(ctx context.Context, roomID string) (*model.Room, error)
-	// GetRoomMeta returns a room populated with only its stable fields
-	// (ID/Type/Name/SiteID/UserCount); CreatedAt/UpdatedAt are zero. It is the
-	// add-member hot path's read and is served from the meta cache when enabled.
-	// Callers needing time-sensitive fields (e.g. CreatedAt) must use GetRoom.
+	// GetRoomMeta returns a room with only its stable fields (CreatedAt/UpdatedAt zero),
+	// served from the meta cache when enabled. Need time-sensitive fields? Use GetRoom.
 	GetRoomMeta(ctx context.Context, roomID string) (*model.Room, error)
 	GetSubscription(ctx context.Context, account, roomID string) (*model.Subscription, error)
 	GetUser(ctx context.Context, account string) (*model.User, error)
@@ -156,6 +157,9 @@ type SubscriptionStore interface {
 	// Used by the rename processor to bucket accounts by remote site for
 	// cross-site fan-out.
 	ListByRoom(ctx context.Context, roomID string) ([]model.Subscription, error)
+
+	// SetRoomCrossSite marks a room global. Sticky/idempotent: only ever sets crossSite=true.
+	SetRoomCrossSite(ctx context.Context, roomID string) error
 }
 
 // Key store used by room-worker: reads for fan-out, writes for rotation.

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -178,11 +178,9 @@ func (s *MongoStore) GetRoom(ctx context.Context, roomID string) (*model.Room, e
 	return &room, nil
 }
 
-// GetRoomMeta returns a room populated with only its stable fields
-// (ID/Type/Name/SiteID/UserCount) — the subset the add-member hot path reads.
-// When the meta cache is enabled it is served from the in-process LRU+TTL cache;
-// otherwise it falls through to a direct Mongo read. The returned room's
-// CreatedAt/UpdatedAt are zero — callers needing those must use GetRoom.
+// GetRoomMeta returns a room with only its stable fields (CreatedAt/UpdatedAt zero),
+// served from the meta cache when enabled. Its CrossSite is the PRIOR state — before
+// processAddMembers' SetRoomCrossSite write, which the local→global nudge gates on.
 func (s *MongoStore) GetRoomMeta(ctx context.Context, roomID string) (*model.Room, error) {
 	var (
 		meta roommetacache.Meta
@@ -196,7 +194,7 @@ func (s *MongoStore) GetRoomMeta(ctx context.Context, roomID string) (*model.Roo
 	if err != nil {
 		return nil, err
 	}
-	return &model.Room{ID: meta.ID, Type: meta.Type, Name: meta.Name, SiteID: meta.SiteID, UserCount: meta.UserCount}, nil
+	return &model.Room{ID: meta.ID, Type: meta.Type, Name: meta.Name, SiteID: meta.SiteID, UserCount: meta.UserCount, CrossSite: meta.CrossSite, CrossSiteAt: meta.CrossSiteAt}, nil
 }
 
 func (s *MongoStore) GetUser(ctx context.Context, account string) (*model.User, error) {
@@ -600,8 +598,8 @@ func (s *MongoStore) ListAddMemberCandidates(ctx context.Context, orgIDs, direct
 	if len(orgIDs) == 0 && len(directAccounts) == 0 {
 		return nil, nil
 	}
-	// 1. Resolve the candidate users (account + id).
-	type candidate struct{ ID, Account string }
+	// 1. Resolve the candidate users (account + id + home site).
+	type candidate struct{ ID, Account, SiteID string }
 	var candidates []candidate
 	if len(orgIDs) == 0 {
 		// Direct accounts only, cache-friendly. Bots are NOT filtered here —
@@ -611,25 +609,26 @@ func (s *MongoStore) ListAddMemberCandidates(ctx context.Context, orgIDs, direct
 			return nil, fmt.Errorf("find add-member candidate users: %w", err)
 		}
 		for i := range users {
-			candidates = append(candidates, candidate{ID: users[i].ID, Account: users[i].Account})
+			candidates = append(candidates, candidate{ID: users[i].ID, Account: users[i].Account, SiteID: users[i].SiteID})
 		}
 	} else {
 		// Org expansion needs the sectId/deptId query. WithDirectBots admits
 		// listed bots while keeping the org arms bot-free.
 		filter := pipelines.MatchCandidatesFilterWithDirectBots(orgIDs, directAccounts, "")
-		cursor, err := s.users.Find(ctx, filter, options.Find().SetProjection(bson.M{"account": 1, "_id": 1}))
+		cursor, err := s.users.Find(ctx, filter, options.Find().SetProjection(bson.M{"account": 1, "_id": 1, "siteId": 1}))
 		if err != nil {
 			return nil, fmt.Errorf("find add-member candidates: %w", err)
 		}
 		var rows []struct {
 			ID      string `bson:"_id"`
 			Account string `bson:"account"`
+			SiteID  string `bson:"siteId"`
 		}
 		if err := cursor.All(ctx, &rows); err != nil {
 			return nil, fmt.Errorf("decode add-member candidates: %w", err)
 		}
 		for _, r := range rows {
-			candidates = append(candidates, candidate{ID: r.ID, Account: r.Account})
+			candidates = append(candidates, candidate{ID: r.ID, Account: r.Account, SiteID: r.SiteID})
 		}
 	}
 	if len(candidates) == 0 {
@@ -656,7 +655,7 @@ func (s *MongoStore) ListAddMemberCandidates(ctx context.Context, orgIDs, direct
 	for i, c := range candidates {
 		_, hasSub := subbed[c.Account]
 		_, hasIRM := irm[c.ID]
-		out[i] = AddMemberCandidate{Account: c.Account, HasSubscription: hasSub, HasIndividualRoomMember: hasIRM}
+		out[i] = AddMemberCandidate{Account: c.Account, HasSubscription: hasSub, HasIndividualRoomMember: hasIRM, SiteID: c.SiteID}
 	}
 	return out, nil
 }
@@ -756,6 +755,31 @@ func (s *MongoStore) updateChannelRoom(ctx context.Context, roomID string, updat
 	}
 	if res.MatchedCount == 0 {
 		return ErrRoomNotFound
+	}
+	return nil
+}
+
+// SetRoomCrossSite marks a room global. Sticky/idempotent: only writes crossSite=true,
+// and the `crossSite != true` filter makes a redelivery a no-op (grace never refreshed).
+//
+// crossSiteAt=$$NOW (flip time) is stamped ONLY on a confirmed-same-site
+// (crossSite==false) → true flip: only those rooms have clients on the local subject
+// needing the RoomLocalityGrace window. Unclassified/nil rooms were already global.
+func (s *MongoStore) SetRoomCrossSite(ctx context.Context, roomID string) error {
+	_, err := s.rooms.UpdateOne(ctx,
+		bson.M{"_id": roomID, "crossSite": bson.M{"$ne": true}},
+		mongo.Pipeline{
+			bson.D{{Key: "$set", Value: bson.M{
+				// $crossSite is the PRE-update value, so grace stamps only on a false→true flip.
+				"crossSiteAt": bson.M{"$cond": bson.A{
+					bson.M{"$eq": bson.A{"$crossSite", false}}, "$$NOW", "$crossSiteAt",
+				}},
+				"crossSite": true,
+			}}},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("set room crossSite %s: %w", roomID, err)
 	}
 	return nil
 }

--- a/room-worker/teamsroomcreate_test.go
+++ b/room-worker/teamsroomcreate_test.go
@@ -26,7 +26,7 @@ func newTeamsTestHandler(t *testing.T, store *MockSubscriptionStore) (*Handler, 
 		published = append(published, publishedMsg{subj: subj, data: data})
 		return nil
 	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 	return h, &published
 }
 
@@ -130,7 +130,7 @@ func TestProcessTeamsRoomCreate_FansOutRoomKeyToAddedMembers(t *testing.T) {
 	publish := func(_ context.Context, subj string, data []byte, _ string) error {
 		return pub.Publish(subj, data)
 	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, roomkeysender.NewSender(pub))
+	h := NewHandler(store, "site-a", publish, testKeyStore, roomkeysender.NewSender(pub), subject.RouteGlobal)
 
 	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 	store.EXPECT().ListByRoom(gomock.Any(), gomock.Any()).Return(nil, nil)
@@ -400,7 +400,7 @@ func TestFederateTeamsMembership_MigrationHeaderStamped(t *testing.T) {
 		gotHeader = natsutil.HeaderForContext(ctx).Get(natsutil.HeaderMigration) == natsutil.MigrationLive
 		return nil
 	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	ctx := natsutil.WithMigrationLiveContext(context.Background())
 	room := &model.Room{ID: "chat1", Name: "n", Type: model.RoomTypeChannel, SiteID: "site-a"}
@@ -423,7 +423,7 @@ func TestProcessTeamsRoomCreate_StampsMigrationHeader(t *testing.T) {
 		}
 		return nil
 	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
 	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 	store.EXPECT().ListByRoom(gomock.Any(), gomock.Any()).Return(nil, nil)

--- a/tools/loadgen/daily_pool.go
+++ b/tools/loadgen/daily_pool.go
@@ -44,6 +44,10 @@ func newDirectPool(natsURL, credsFile string, c *Collector) *directPool {
 // Channel-room broadcasts arrive on subject.RoomEvent(roomID); DM and BotDM
 // broadcasts arrive on subject.UserRoomEvent(account) — both are needed for
 // realistic IM coverage since daily presets are DM-heavy.
+//
+// Each room is subscribed on BOTH the global and local lanes so a run stays
+// mode-agnostic: under ROOM_SUBJECT_MODE=local, hard-coding the global lane would
+// silently receive nothing and report degraded latency instead of failing loudly.
 func (p *directPool) Add(u *userState) error {
 	nc, err := connectWithCreds(p.url, "loadgen-daily-"+u.ID, p.credsFile)
 	if err != nil {
@@ -51,14 +55,16 @@ func (p *directPool) Add(u *userState) error {
 	}
 	du := &directUser{id: u.ID, nc: nc}
 	for _, roomID := range u.Rooms {
-		sub, err := nc.Subscribe(subject.RoomEvent(roomID), func(m *nats.Msg) {
-			p.onBroadcast(m)
-		})
-		if err != nil {
-			_ = nc.Drain()
-			return fmt.Errorf("subscribe room %s/%s: %w", u.ID, roomID, err)
+		for _, global := range []bool{true, false} {
+			sub, err := nc.Subscribe(subject.RoomEvent(roomID, global), func(m *nats.Msg) {
+				p.onBroadcast(m)
+			})
+			if err != nil {
+				_ = nc.Drain()
+				return fmt.Errorf("subscribe room %s/%s: %w", u.ID, roomID, err)
+			}
+			du.subs = append(du.subs, sub)
 		}
-		du.subs = append(du.subs, sub)
 	}
 	// User-scoped subscription for DM broadcasts.
 	userSub, err := nc.Subscribe(subject.UserRoomEvent(u.Account), func(m *nats.Msg) {
@@ -178,8 +184,11 @@ func (p *multiplexPool) Add(u *userState) error {
 		}
 		nc := p.conns[p.nextConn%len(p.conns)]
 		p.nextConn++
-		if _, err := nc.Subscribe(subject.RoomEvent(roomID), p.route); err != nil {
-			return fmt.Errorf("multiplex subscribe %s: %w", roomID, err)
+		// Subscribe both lanes (see directPool.Add) — mode-agnostic against ROOM_SUBJECT_MODE.
+		for _, global := range []bool{true, false} {
+			if _, err := nc.Subscribe(subject.RoomEvent(roomID, global), p.route); err != nil {
+				return fmt.Errorf("multiplex subscribe %s: %w", roomID, err)
+			}
 		}
 		// Mark provisionally with refcount 0 — the second pass below will
 		// increment it. We don't increment here so a subsequent Subscribe

--- a/tools/loadgen/daily_pool_test.go
+++ b/tools/loadgen/daily_pool_test.go
@@ -34,11 +34,65 @@ func TestDirectPool_ReceivesBroadcast(t *testing.T) {
 	require.NoError(t, err)
 
 	col.RecordPublishBroadcastOnly("msg-42", time.Now())
-	require.NoError(t, ncPub.Publish(subject.RoomEvent("room-test"), data))
+	require.NoError(t, ncPub.Publish(subject.RoomEvent("room-test", true), data))
 	require.NoError(t, ncPub.Flush())
 
 	require.Eventually(t, func() bool {
 		return col.E2Count() == 1
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
+func TestDirectPool_ReceivesLocalBroadcast(t *testing.T) {
+	url := testutil.NATS(t)
+	ncPub, err := nats.Connect(url)
+	require.NoError(t, err)
+	t.Cleanup(func() { ncPub.Close() })
+
+	col := NewCollector(NewMetrics(), "test")
+	pool := newDirectPool(url, "" /*no creds: testcontainer NATS allows anonymous*/, col)
+	t.Cleanup(pool.Close)
+
+	u := &userState{ID: "u-1", Account: "user-1", Rooms: []string{"room-test"}}
+	require.NoError(t, pool.Add(u))
+
+	// Publish on the LOCAL lane (ROOM_SUBJECT_MODE=local): the pool must still
+	// receive it, proving Add subscribes both lanes rather than global only.
+	evt := model.RoomEvent{Type: model.RoomEventNewMessage, LastMsgID: "msg-42", RoomID: "room-test"}
+	data, err := json.Marshal(evt)
+	require.NoError(t, err)
+
+	col.RecordPublishBroadcastOnly("msg-42", time.Now())
+	require.NoError(t, ncPub.Publish(subject.RoomEvent("room-test", false), data))
+	require.NoError(t, ncPub.Flush())
+
+	require.Eventually(t, func() bool {
+		return col.E2Count() == 1
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
+func TestMultiplexPool_RoutesLocalBroadcastToInbox(t *testing.T) {
+	url := testutil.NATS(t)
+	ncPub, err := nats.Connect(url)
+	require.NoError(t, err)
+	t.Cleanup(func() { ncPub.Close() })
+
+	col := NewCollector(NewMetrics(), "test")
+	pool, err := newMultiplexPool(url, "" /*no creds*/, col, 2 /*pool size*/)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	uA := &userState{ID: "u-a", Account: "ua", Rooms: []string{"r-1"}}
+	require.NoError(t, pool.Add(uA))
+
+	// Publish on the LOCAL lane — the multiplex pool must route it to the inbox.
+	col.RecordPublishBroadcastOnly("msg-1", time.Now())
+	data, err := json.Marshal(model.RoomEvent{LastMsgID: "msg-1", RoomID: "r-1"})
+	require.NoError(t, err)
+	require.NoError(t, ncPub.Publish(subject.RoomEvent("r-1", false), data))
+	require.NoError(t, ncPub.Flush())
+
+	require.Eventually(t, func() bool {
+		return col.E2Count() >= 1
 	}, 2*time.Second, 20*time.Millisecond)
 }
 
@@ -61,7 +115,7 @@ func TestMultiplexPool_RoutesBroadcastToInbox(t *testing.T) {
 	col.RecordPublishBroadcastOnly("msg-1", time.Now())
 	data, err := json.Marshal(model.RoomEvent{LastMsgID: "msg-1", RoomID: "r-1"})
 	require.NoError(t, err)
-	require.NoError(t, ncPub.Publish(subject.RoomEvent("r-1"), data))
+	require.NoError(t, ncPub.Publish(subject.RoomEvent("r-1", true), data))
 	require.NoError(t, ncPub.Flush())
 
 	require.Eventually(t, func() bool {
@@ -79,7 +133,7 @@ func TestMultiplexPool_DropsCountedOnInboxFull(t *testing.T) {
 	full := make(chan *nats.Msg)
 	pool.dispatch["r-1"] = []chan *nats.Msg{full}
 
-	pool.route(&nats.Msg{Subject: subject.RoomEvent("r-1"), Data: []byte(`{"lastMsgId":"x","roomId":"r-1"}`)})
+	pool.route(&nats.Msg{Subject: subject.RoomEvent("r-1", true), Data: []byte(`{"lastMsgId":"x","roomId":"r-1"}`)})
 
 	require.Equal(t, int64(1), col.MultiplexDrops())
 }

--- a/user-service/mongorepo/subscriptions.go
+++ b/user-service/mongorepo/subscriptions.go
@@ -83,6 +83,7 @@ func roomsEnrichStages(dropDeleted bool) bson.A {
 					"createdAt":         1,
 					"encKey.priv":       1,
 					"encKey.ver":        1,
+					"crossSite":         1,
 				}},
 			},
 			"as": "room",
@@ -102,6 +103,7 @@ func roomsEnrichStages(dropDeleted bool) bson.A {
 			"minUserLastSeenAt": "$room.minUserLastSeenAt",
 			"appCount":          "$room.appCount",
 			"roomName":          "$room.name",
+			"crossSite":         "$room.crossSite",
 			// Sort key: room activity (lastMsgAt), falling back to room.createdAt for
 			// rooms with no messages. Null for cross-site/missing rooms (they sort last).
 			"__sortKey": bson.M{"$ifNull": bson.A{"$room.lastMsgAt", "$room.createdAt"}},
@@ -148,6 +150,7 @@ func roomMatchStages() []bson.D {
 					"createdAt":         1,
 					"encKey.priv":       1,
 					"encKey.ver":        1,
+					"crossSite":         1,
 				}},
 			},
 			"as": matchedRoomField,
@@ -197,6 +200,7 @@ func subscriptionProjection(extra bson.M) bson.M {
 		"minUserLastSeenAt": 1,
 		"appCount":          1,
 		"roomName":          1,
+		"crossSite":         1,
 		"encKeyPriv":        1,
 		"encKeyVer":         1,
 	}
@@ -328,6 +332,7 @@ func (r *SubscriptionRepo) FindChannelsByMembers(ctx context.Context, account st
 			"minUserLastSeenAt": bson.M{"$first": "$" + matchedRoomField + ".minUserLastSeenAt"},
 			"appCount":          bson.M{"$first": "$" + matchedRoomField + ".appCount"},
 			"roomName":          bson.M{"$first": "$" + matchedRoomField + ".name"},
+			"crossSite":         bson.M{"$first": "$" + matchedRoomField + ".crossSite"},
 			// Room E2E key baseline (current slot) — folds the key read into this join.
 			"encKeyPriv": bson.M{"$first": "$" + matchedRoomField + ".encKey.priv"},
 			"encKeyVer":  bson.M{"$first": "$" + matchedRoomField + ".encKey.ver"},

--- a/user-service/mongorepo/subscriptions_test.go
+++ b/user-service/mongorepo/subscriptions_test.go
@@ -304,6 +304,83 @@ func TestAggregateSubscriptions_ExcludesClosed(t *testing.T) {
 	assert.False(t, roomIDs["r_closed"], "explicitly closed subscription must be excluded")
 }
 
+// TestAggregateSubscriptions_CrossSite_Integration exercises the roomsEnrichStages
+// pipeline (shared by AggregateSubscriptions/GetDMSubscription/GetSubscriptionByRoomID/
+// GetActiveSubscriptions): a locally-hosted room with room.crossSite:true (≥1 remote
+// member) must decode as EnrichedSubscription.CrossSite=&true; a room without the flag
+// must decode as nil (absent → nil, resolving to global via the fail-safe — NOT false,
+// which would assert confirmed same-site). Distinct from the existing "cross-site room has no local doc"
+// cases — this room DOES have a local doc, it just has remote members.
+func TestAggregateSubscriptions_CrossSite_Integration(t *testing.T) {
+	r, db := newTestSubscriptionRepo(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	seed(t, db, "rooms",
+		bson.M{"_id": "r-xsite-flag", "name": "Federated", "siteId": "site-a", "userCount": 3, "lastMsgAt": now, "crossSite": true},
+		bson.M{"_id": "r-local-only", "name": "Local", "siteId": "site-a", "userCount": 2, "lastMsgAt": now},
+	)
+	seed(t, db, "subscriptions",
+		bson.M{"_id": "sub-xsite-flag", "u": bson.M{"_id": "u-alice", "account": "alice"}, "roomId": "r-xsite-flag",
+			"name": "Federated", "roomType": "channel", "siteId": "site-a", "_updatedAt": now, "createdAt": now},
+		bson.M{"_id": "sub-local-only", "u": bson.M{"_id": "u-alice", "account": "alice"}, "roomId": "r-local-only",
+			"name": "Local", "roomType": "channel", "siteId": "site-a", "_updatedAt": now, "createdAt": now},
+	)
+
+	page, err := r.AggregateSubscriptions(ctx, "alice", "rooms", false, nil, mongoutil.OffsetPageRequest{Offset: 0, Limit: 100})
+	require.NoError(t, err)
+	byID := map[string]bool{}
+	crossSite := map[string]*bool{}
+	for _, sub := range page.Data {
+		byID[sub.ID] = true
+		crossSite[sub.ID] = sub.CrossSite
+	}
+	require.True(t, byID["sub-xsite-flag"])
+	require.True(t, byID["sub-local-only"])
+	require.NotNil(t, crossSite["sub-xsite-flag"])
+	assert.True(t, *crossSite["sub-xsite-flag"], "room.crossSite:true must decode as EnrichedSubscription.CrossSite=true")
+	// A room with no crossSite field at all (unclassified) must decode as nil,
+	// never false — coercing it to false would defeat the fail-safe.
+	assert.Nil(t, crossSite["sub-local-only"], "room without crossSite must decode as nil (unclassified)")
+}
+
+// TestFindChannelsByMembers_CrossSite_Integration exercises the SEPARATE roomMatchStages
+// pipeline plus the terminal subscriptionProjection — an inclusion-only $project that
+// silently drops any field not explicitly whitelisted, so crossSite must be listed there
+// too even though roomsEnrichStages already carries it.
+func TestFindChannelsByMembers_CrossSite_Integration(t *testing.T) {
+	r, db := newTestSubscriptionRepo(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	seed(t, db, "rooms",
+		bson.M{"_id": "r-fed", "name": "Fed", "siteId": "site-a", "userCount": 2, "createdAt": now, "crossSite": true},
+		bson.M{"_id": "r-plain", "name": "Plain", "siteId": "site-a", "userCount": 2, "createdAt": now},
+	)
+	seed(t, db, "subscriptions",
+		bson.M{"_id": "a-fed", "u": bson.M{"_id": "u-alice", "account": "alice"}, "roomId": "r-fed",
+			"name": "Fed", "roomType": "channel", "siteId": "site-a", "createdAt": now},
+		bson.M{"_id": "c-fed", "u": bson.M{"_id": "u-carol", "account": "carol"}, "roomId": "r-fed",
+			"name": "Fed", "roomType": "channel", "siteId": "site-a", "createdAt": now},
+		bson.M{"_id": "a-plain", "u": bson.M{"_id": "u-alice", "account": "alice"}, "roomId": "r-plain",
+			"name": "Plain", "roomType": "channel", "siteId": "site-a", "createdAt": now},
+		bson.M{"_id": "c-plain", "u": bson.M{"_id": "u-carol", "account": "carol"}, "roomId": "r-plain",
+			"name": "Plain", "roomType": "channel", "siteId": "site-a", "createdAt": now},
+	)
+
+	page, err := r.FindChannelsByMembers(ctx, "alice", []string{"carol"}, mongoutil.OffsetPageRequest{Offset: 0, Limit: 100})
+	require.NoError(t, err)
+	crossSite := map[string]*bool{}
+	for _, sub := range page.Data {
+		crossSite[sub.RoomID] = sub.CrossSite
+	}
+	require.Contains(t, crossSite, "r-fed")
+	require.Contains(t, crossSite, "r-plain")
+	require.NotNil(t, crossSite["r-fed"])
+	assert.True(t, *crossSite["r-fed"], "matched room's crossSite must survive subscriptionProjection's inclusion whitelist")
+	assert.Nil(t, crossSite["r-plain"], "room without crossSite must decode as nil (unclassified), never coerced to false")
+}
+
 func TestFindChannelsByMembers_Integration(t *testing.T) {
 	r, db := newTestSubscriptionRepo(t)
 	ctx := context.Background()

--- a/user-service/service/subscriptions.go
+++ b/user-service/service/subscriptions.go
@@ -389,6 +389,7 @@ func buildLocalRoom(sub *model.EnrichedSubscription) *model.SubscriptionRoom {
 	room := &model.SubscriptionRoom{
 		SiteID:            sub.SiteID,
 		Name:              sub.RoomName,
+		CrossSite:         sub.CrossSite,
 		UserCount:         sub.UserCount,
 		AppCount:          sub.AppCount,
 		LastMsgAt:         sub.LastMsgAt,
@@ -427,6 +428,7 @@ func applyRoomInfo(sub *model.Subscription, info *model.RoomInfo) bool {
 	room := &model.SubscriptionRoom{
 		SiteID:            info.SiteID,
 		Name:              info.Name,
+		CrossSite:         info.CrossSite,
 		UserCount:         info.UserCount,
 		AppCount:          info.AppCount,
 		LastMsgAt:         timeutil.MillisToTime(info.LastMsgAt),

--- a/user-service/service/subscriptions_test.go
+++ b/user-service/service/subscriptions_test.go
@@ -1057,3 +1057,34 @@ func TestListSubscriptions_LastMessage_SiteDegrades(t *testing.T) {
 	require.NotNil(t, room)
 	assert.Nil(t, room.PreviewMessage, "degraded site leaves LastMessage nil")
 }
+
+func TestBuildLocalRoom_CrossSite(t *testing.T) {
+	sub := &model.EnrichedSubscription{}
+	sub.CrossSite = ptrBool(true)
+	sub.RoomName = "chan"
+	got := buildLocalRoom(sub)
+	require.NotNil(t, got)
+	require.NotNil(t, got.CrossSite)
+	assert.True(t, *got.CrossSite)
+}
+
+func TestApplyRoomInfo_CrossSite(t *testing.T) {
+	sub := &model.Subscription{}
+	drop := applyRoomInfo(sub, &model.RoomInfo{Found: true, Name: "chan", CrossSite: ptrBool(true)})
+	assert.False(t, drop)
+	require.NotNil(t, sub.Room)
+	require.NotNil(t, sub.Room.CrossSite)
+	assert.True(t, *sub.Room.CrossSite)
+}
+
+// TestApplyRoomInfo_CrossSite_Nil pins that an unclassified cross-site room
+// (RoomInfo.CrossSite nil) passes through as nil on the SubscriptionRoom —
+// never coerced to false — so the wire response omits the field and the
+// frontend's `?? true` default resolves it to global (fail-safe).
+func TestApplyRoomInfo_CrossSite_Nil(t *testing.T) {
+	sub := &model.Subscription{}
+	drop := applyRoomInfo(sub, &model.RoomInfo{Found: true, Name: "chan"})
+	assert.False(t, drop)
+	require.NotNil(t, sub.Room)
+	assert.Nil(t, sub.Room.CrossSite)
+}


### PR DESCRIPTION
## Why

In the NATS supercluster, gateway **interest** propagation is per-account and all-or-nothing: because every chat user shares one NATS account, each connected client's per-room subscriptions (`chat.room.{roomID}.>`) get replicated into every peer site's interest map — including the large majority of rooms whose members are all on a single site and never need cross-site delivery. That replicated interest state is the memory pressure.

This PR lets same-site rooms deliver on a **leaf-filtered local namespace** (`chat.local.room.{roomID}.event`) that the platform team excludes from cross-gateway interest, while cross-site rooms stay on the propagated global subject (`chat.room.{roomID}.event`).

## How

- **Classification** — a sticky tri-state `Room.CrossSite *bool` (nil=unclassified→global fail-safe, &true=cross-site→global, &false=same-site→local), set by `room-worker` at every create/add path (channel, DM, `serverCreateDM`, member-add), reusing the exact points where cross-site federation is already decided. Never demoted (Phase 1). Data starts from scratch, so every room is classified at creation/member-add — no backfill of pre-existing rooms is needed.
- **Propagation** — surfaced through `roommetacache`, `RoomsInfoBatch`, the user-service `$lookup` + enrichment, into the `subscription.list` room payload as `crossSite`.
- **Routing gate** — `subject.RoomEventTargets(id, crossSite, crossSiteAt, mode, now)` behind `ROOM_SUBJECT_MODE` (`global` default → `dual` → `local`), routed through a single per-service `publishRoomEvent` helper at every room-event publish site (broadcast-worker ×3, room-service ×2, room-worker rename). A `.semgrep` rule fails CI on any inline room-subject publish that bypasses the helper. Cross-site rooms are **always** global in every mode.
- **Transition grace window** — a same-site→global flip records `Room.CrossSiteAt`; for `RoomLocalityGrace` (15 min) afterward, publishers emit the room's `.event` to **both** the local and global subjects (in local/dual mode). So a same-site member still subscribed to the local subject keeps receiving in real time until it re-subscribes — the flip gap is bounded **server-side**, independent of whether the re-subscribe nudge is delivered or how often the client reconciles. Bounded to actively-flipping rooms only; rooms born cross-site get no grace.
- **Client** — `chat-frontend` (internal test client) subscribes each room to the local or global subject by the flag, with re-subscribe-on-flip and a missing→global fail-safe.

## New NATS subjects

One new **local** room-event subject is introduced alongside the existing global one. The unit is the whole `chat.local.room.{roomID}.>` subtree, but only the `.event` lane has publishers in this PR.

| Subject | Direction | Emitted for | Gateway behavior |
|---|---|---|---|
| `chat.local.room.{roomID}.event` **(new)** | server → client | Same-site rooms (`crossSite=false`): in `ROOM_SUBJECT_MODE=local`, and in `dual` (both lanes); plus a flipped room during its grace window | Denied at the leaf node from cross-gateway interest propagation → site-local |
| `chat.room.{roomID}.event` *(existing)* | server → client | Cross-site rooms, not-yet-classified rooms, and everything under the default `global` mode | Propagated across the supercluster (unchanged) |

New JWT **subscribe** grant: `chat.local.room.>` (added to the auth-service scope template and `docker-local/setup.sh`; the prod template is infra-owned). Clients only *subscribe* to room subjects — no publish grant changes. The locality-aware `stream.msg` / `event.metadata.update` builders cover the rest of the `chat.local.room.{roomID}.>` subtree but have no local publishers yet.

## What the client must do

1. **Read `crossSite`** (tri-state) on each room in the `subscription.list` payload and choose the room-event subject:
   - `true` → `chat.room.{roomID}.event` (cross-site → global)
   - `false` → `chat.local.room.{roomID}.event` (confirmed same-site → local)
   - **absent/unknown → `chat.room.{roomID}.event`** (fail-safe global — a room the server hasn't classified yet)
2. **Carry the `chat.local.room.>` subscribe grant** in the client JWT (scope-template / infra change).
3. **Re-subscribe on flip** — when a room's `crossSite` changes (a same-site room gains an off-site member → global), move its subscription to the new subject. Correctness rests on the persisted flag + history/gap fetch, so a client that reconciles `subscription.list` on reconnect / periodically is correct; the **transition grace window** keeps it gapless for any client that re-subscribes within 15 min. For *prompt* re-routing the official client should also subscribe to `chat.user.{account}.event.room.update` (the server's locality nudge — distinct from `event.room.metadata.update`) and refresh `subscription.list` on receipt.
4. **No publish change** — clients still publish sends on the user-scoped tree; only room-event *subscriptions* are affected.

Old clients that ignore `crossSite` keep working: they stay on `chat.room.>`, and with the default `global` mode (and the zero-gap `dual` window) the server keeps publishing there.

## Fail-safe invariant

Global is the safe default everywhere: misrouting a global room to local would silently drop cross-gateway delivery, so the system only routes local when `crossSite == false` is authoritative. **Default `ROOM_SUBJECT_MODE=global` makes this entire change a no-op** (byte-identical publishing) until ops opts in — safe to merge inert.

## Rollout (see the runbook in the design doc)

1. Platform: add `chat.local.room.>` to the prod subscribe template + configure the leaf-node deny for `chat.local.>`. (No data backfill — deployments start from fresh data; every room is classified at creation/member-add.)
2. Deploy publishers `global → dual` (dual publishes same-site rooms to **both** prefixes → zero-gap client migration), deploy the frontend, then `dual → local`.

**Release gate (official client, not the chat-frontend test client):** with the transition grace window, a per-room local→global flip is gapless for any client that re-subscribes within `RoomLocalityGrace`, and never loses data (persisted + backfilled). Before enabling `local` in prod, the official client must implement the flip contract in "What the client must do" §3 (bootstrap-by-`crossSite`, reconnect reconcile, gap-fetch, and ideally the nudge handler) so its reconcile interval stays within the grace window.

## Testing

- Unit tests (TDD, mocked stores) and `golangci-lint` are green tree-wide; a `.semgrep` guard rule prevents future inline room-subject publishes.
- Mongo-backed **integration tests were written and vet-checked under `-tags integration`** — CI runs them.
- Frontend: vitest suite green, typecheck + build clean.

The fail-safe invariant was verified at every publish site, create/add path, and projection. Several silent-failure bugs (two dropped `crossSite` Mongo projections, a `SubscriptionRoom.crossSite` `omitempty` that would have defeated the feature, two missing create-path classifications, a broadcast-worker early-return that skipped the dual-mode global fallback, and a room-meta cache-invalidation race on the flip) were caught and fixed.

Design + plan: `docs/superpowers/specs/2026-07-28-local-global-room-subjects-design.md`, `docs/superpowers/plans/2026-07-28-local-global-room-subjects.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKLjVmfDJQKfYgmLLofk3v

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKLjVmfDJQKfYgmLLofk3v)_