### PR TITLE
docs(load-testing): add SLI/SLO spec (system/sli-slo.md)

### DIFF
--- a/docs/load-testing/README.md
+++ b/docs/load-testing/README.md
@@ -6,6 +6,9 @@ component-specific and system-wide test plans.
 
 ## Current Plans
 
+- [`system/sli-slo.md`](system/sli-slo.md) is the platform's user-facing
+  SLI/SLO specification — the acceptance criteria all system-level load tests
+  assert against.
 - [`cassandra/soak-test-plan.md`](cassandra/soak-test-plan.md) is the
   authoritative specification for the Cassandra Run A pre-production soak.
 - [`cassandra/run-a-implementation-plan.md`](cassandra/run-a-implementation-plan.md)

--- a/docs/load-testing/system/sli-slo.md
+++ b/docs/load-testing/system/sli-slo.md
@@ -8,9 +8,11 @@
 | **Approval date** | — |
 | **Revisit date** | ~6 weeks after approval (end of calibration, §0.2) |
 
-Companions: `o11y-metrics-inventory.md`, `o11y-trace-design.md`,
-`o11y-performance-and-sampling.md`. Error budget policy: placeholder
-(`o11y-error-budget-policy.md`, to be written).
+Companions (o11y specs): `../../specs/o11y/o11y-metrics-inventory.md`,
+`../../specs/o11y/o11y-trace-design.md`,
+`../../specs/o11y/o11y-performance-and-sampling.md`. Error budget policy:
+placeholder (`o11y-error-budget-policy.md`, to be written). Load-test alignment:
+`../end-to-end-load-test-plan.md` (§10 here is the summary; the plan owns execution).
 
 ---
 
@@ -113,7 +115,7 @@ material; read receipts / unread badges → dashboard, v2 candidate (§8 P7).
 |---|---|---|---|---|
 | SLO-1a | J1 | canonical message persisted to Cassandra / **canonical messages published** | 99.9% | 🔧 P2 · approximate (lag-enforced) |
 | SLO-1b | J1 | **channel** room-subject broadcast **enqueue-accepted** (local core-NATS, single publish) / **canonical messages routed to the room-subject path** (`broadcast_path=room_subject`) | 99.9% | 🔧 P2 · approximate · enqueue-only (see §2) |
-| SLO-2 | J1 | room-subject broadcast published **within 1 s** of canonical acceptance (late = bad) / canonical messages on the room-subject path (`broadcast_path=room_subject`) | 99% | 🔧 P2 · approximate |
+| SLO-2 | J1 | room-subject broadcast **enqueue-accepted within 1 s** of canonical acceptance (late = bad) / canonical messages on the room-subject path (`broadcast_path=room_subject`) | 99% | 🔧 P2 · approximate · enqueue-only |
 | SLO-3 | J2 | successful login **within 1 s** / eligible login attempts | 99% | ✅ (auth leg — proxy) |
 | SLO-4 | J2 | channel load succeeds **within 500 ms** / eligible channel loads | 95% | 🔧 P1 |
 | SLO-5 | J2 | thread open succeeds **within 300 ms** / eligible thread opens | 99% | 🔧 P1 |
@@ -173,7 +175,7 @@ a protocol-receive prober (loadgen) and a render prober (browser) — neither is
   `room_subject`, else DM/BotDM → `dm`. This matters because a **channel thread
   reply** (`TShow=false`) is a channel room yet routes to per-account thread
   fan-out, **not** `publishChannelEvent` — a `room_type="channel"` denominator
-  would count it while no `broadcast_channel_publish_total` fires, wrongly
+  would count it while no `broadcast_channel_enqueue_total` fires, wrongly
   depressing SLO-1b/2. (gatekeeper resolves room type at the emit site to set the
   label; `thread`/`dm` slices are v1-unscored.)
   - **SLO-1a** uses the **all-`broadcast_path` total** (persistence covers every message).
@@ -181,7 +183,7 @@ a protocol-receive prober (loadgen) and a render prober (browser) — neither is
     excludes the `thread`/`dm` routes (see below).
 - **Numerators**, one outcome per logical message (approximate — see §0.1):
   - `messages_persisted_total{outcome}` (message-worker) → SLO-1a.
-  - `broadcast_channel_publish_total{outcome=ok|failed}` (broadcast-worker) →
+  - `broadcast_channel_enqueue_total{outcome=ok|failed}` (broadcast-worker) →
     SLO-1b. **A channel broadcast is a single room-subject publish, not a
     per-recipient fan-out.** `publishChannelEvent` does one
     `nc.PublishMsg(subject.RoomEvent(roomID), …)` and NATS fans out to subscribers
@@ -203,11 +205,13 @@ a protocol-receive prober (loadgen) and a render prober (browser) — neither is
     loops accounts with a `failed` count), which v1 does not score; those and the
     true per-recipient *delivery* outcome are the **observational last mile**
     (declared) / v2 (§8 P7).
-  - `broadcast_channel_publish_age_seconds` = `now − evt.Timestamp` → SLO-2. **Good
-    predicate: age ≤ 1 s**; a publication later than the bound is **bad** (stays
-    in valid, not counted good). `evt.Timestamp` is the canonical event's
-    server-set timestamp (`gatekeeper handler.go`, `now.UnixMilli()`) →
-    "canonical acceptance → channel published".
+  - `broadcast_channel_enqueue_age_seconds` = `now − evt.Timestamp` → SLO-2. **Good
+    predicate: age ≤ 1 s**; an enqueue later than the bound is **bad** (stays in
+    valid, not counted good). `evt.Timestamp` is the canonical event's server-set
+    timestamp (`gatekeeper handler.go`, `now.UnixMilli()`) → SLO-2 is
+    "**canonical acceptance → local enqueue accepted within 1 s**", not true
+    publication latency — the code can only observe the `PublishMsg` return
+    (enqueue), so server-confirmed **publication** latency stays in P7.
 - **v1 scope: the room-subject path only.** DM/thread per-recipient
   partial-failure semantics are deferred; SLO-1b/2 count only
   `broadcast_path="room_subject"` canonical messages in v1 (channel non-thread
@@ -217,15 +221,25 @@ a protocol-receive prober (loadgen) and a render prober (browser) — neither is
   - **Inbound stall** (worker falling behind `MESSAGES_CANONICAL`): message-worker
     / broadcast-worker **consumer lag** (§8 P3). This is a JetStream consumer, so
     lag is observable.
-  - **Outbound enqueue loss** (SLO-1b's core-NATS hop, where lag is blind):
-    **connection-health / async-error counters** on the NATS client —
-    disconnect/reconnect events, closed-connection, `ErrorHandler` fires
-    (slow-consumer, reconnect-buffer overflow). `natsutil.Connect` already wires
-    `DisconnectErrHandler`/`ReconnectHandler`/`ClosedHandler`/`ErrorHandler`
-    (`MaxReconnects=-1`); v1 turns those log-only handlers into counters so a
-    reconnect-buffer drop surfaces even though the ratio can't see it.
-  Because the counters are core-NATS/approximate, these backstops are primary;
-  the ratios are secondary.
+  - **Outbound connection-risk backstop** (SLO-1b's core-NATS hop, where lag is
+    blind): NATS-client **connection-risk counters** — disconnect/reconnect
+    events, closed-connection, `ErrorHandler` fires. `natsutil.Connect` already
+    wires `DisconnectErrHandler`/`ReconnectHandler`/`ClosedHandler`/`ErrorHandler`
+    (`MaxReconnects=-1`); v1 turns those log-only handlers into counters. **What
+    these can and cannot prove:**
+    - A **full reconnect buffer** is *not* a silent loss — nats.go returns
+      `ErrReconnectBufExceeded` **synchronously** from `PublishMsg`, so that drop
+      is already counted as `outcome=failed` in the ratio.
+    - The disconnect/reconnect/closed callbacks only mark a **risk window**; they
+      **cannot** tell which already-enqueued messages were actually lost. And
+      `ClosedHandler` may fire on a **normal shutdown**, so expected vs unexpected
+      closes must be distinguished before alerting.
+    - Therefore **accepted-but-not-server-confirmed loss cannot be precisely
+      counted** until the server-confirmed boundary (P7) or a protocol prober
+      (§8 P6) lands. The connection-risk counters flag *when to suspect* loss, not
+      *how much*.
+  Because the counters are core-NATS/approximate, the inbound lag signal and the
+  connection-risk backstop are primary; the ratios are secondary.
 
 ### Measurement
 
@@ -425,8 +439,8 @@ required** (`sdk.Meter()` is exposed; search-service is the exemplar).
 | P | Work | Unlocks |
 |---|---|---|
 | P1 | `natsrouter` metrics middleware (`rpc_server_duration_seconds{subject_pattern, errcode_category}`) | SLO-4/5 + dashboards for all non-named RPCs |
-| P2 | J1 counters — gatekeeper `messages_canonical_published_total` (upstream denominator), message-worker persisted, broadcast-worker publications + publication-age; terminal-outcome/dedup semantics, no message-ID labels | SLO-1a/1b/2 |
-| P3 | NATS/JetStream Prometheus exporter (infra) — consumer `num_pending`/`num_ack_pending` + ack-floor (stalled-backlog signal); **plus a custom monitor** to derive oldest-pending **age** (exporter alone doesn't expose it). Recording rules must **filter `is_consumer_leader=true`** before aggregating consumer state, or clustered follower replicas double-count the series | outage backstop for 1a/1b/2/6/9 |
+| P2 | J1 counters — gatekeeper `messages_canonical_published_total` (upstream denominator), message-worker persisted, broadcast-worker `broadcast_channel_enqueue_total` + `broadcast_channel_enqueue_age_seconds`; terminal-outcome/dedup semantics, no message-ID labels | SLO-1a/1b/2 |
+| P3 | NATS/JetStream Prometheus exporter (infra) — consumer `num_pending`/`num_ack_pending` + ack-floor (stalled-backlog signal); **plus a custom monitor** to derive oldest-pending **age** (exporter alone doesn't expose it). Recording rules must **filter `{is_consumer_leader="true"}`** before aggregating consumer state, or clustered follower replicas double-count the series | outage backstop for 1a/1b/2/6/9 |
 | P4 | notification-worker push-stream handoff (**recipient-granular** accepted/recipients) · **search duration `status` label** (→ `{kind,status}`) · outbox producer-side published + forwarded-within-bound (matching label sets) · **NATS connection-health / async-error counters** (disconnect/reconnect/closed/ErrorHandler) as the SLO-1b enqueue-loss backstop | SLO-1b/6/8/9 |
 | P5 | Collector `spanmetrics` on frontend spans | observational last-mile & J2 client view |
 | P6 | **loadgen NATS-subscribe prober** (protocol receipt) + SLO assertion mode (§10) · login→connect→initial-data; sparse-journey floor; SLO-aware load asserts. **Render is out of scope here** — proves protocol receipt, not decrypt/render | protocol-receive last-mile SLI |
@@ -456,7 +470,7 @@ framework is reusable but does not yet assert against these SLOs:
 | SLO | loadgen coverage today | Gap to `ready` |
 |---|---|---|
 | SLO-1a | **partial** — soak read-back | per-message outcome accounting |
-| SLO-1b / 2 | **partial** — E2 stage correlation | channel-scoped `ok`/`failed` + publish-age accounting (protocol-receipt, not render) |
+| SLO-1b / 2 | **partial** — E2 stage correlation | channel-scoped `ok`/`failed` + enqueue-age accounting (protocol-receipt, not render) |
 | SLO-4 / 5 | **near-ready** | per-endpoint `good within bound / eligible attempts` accounting |
 | SLO-3 (auth) | **missing** — auth is a stub | HTTP login driver |
 | SLO-7 / 8 (search) | **missing** | search workload |
@@ -477,13 +491,20 @@ Two distinct thresholds, not one (the "50–70%" and "track this document" rules
 were in tension):
 
 - **Hard gate** — the run fails if it can't meet the **actual SLO predicate and
-  target** from this document (e.g. SLO-4 = 95% within 500 ms). This is what
-  "thresholds track this document" means, and it applies to **latency and
-  availability** targets alike. **Evaluate over isolated run-window counter
-  deltas** (`increase()` across the test window), **never** the 28-day production
-  aggregate — reading the rolling aggregate would let historical/background
-  traffic mask the failures produced *in this run*. Reuse the prod predicates and
-  targets; window the counters to the run.
+  target** from this document (e.g. SLO-4 = 95% within 500 ms), applied to
+  **latency and availability** targets alike. It **reuses the production
+  predicate/target**, but must **not** read the 28-day aggregate recording rule
+  directly. Two things `increase()` over the test window alone does *not* fix:
+  - **Traffic isolation.** `increase()` excludes *historical* traffic but not
+    *concurrent background* traffic on the same series. Run against a
+    **dedicated / quiescent test site (`SITE_ID`) or a separate Prometheus
+    tenant** so the counters carry only this run's events.
+  - **Async settle boundary.** An async numerator (persist, enqueue, forward) can
+    land *after* the sender stops. Structure every run as **warm-up →
+    measurement/send window → deadline/settle window**, and evaluate the ratio as
+    **denominator over the send window, numerator waited out to the max SLO
+    deadline + a scrape margin**. Sharing one end-time for both would misjudge
+    tail-end in-flight events as failures.
 - **Engineering headroom** — a separately-named, *stricter* guardrail (e.g.
   assert the latency bound at ~50–70% of the prod value) to catch regression
   before it reaches the SLO. A headroom miss warns; only a hard-gate miss fails

--- a/docs/load-testing/system/sli-slo.md
+++ b/docs/load-testing/system/sli-slo.md
@@ -205,13 +205,26 @@ a protocol-receive prober (loadgen) and a render prober (browser) — neither is
     loops accounts with a `failed` count), which v1 does not score; those and the
     true per-recipient *delivery* outcome are the **observational last mile**
     (declared) / v2 (§8 P7).
-  - `broadcast_channel_enqueue_age_seconds` = `now − evt.Timestamp` → SLO-2. **Good
-    predicate: age ≤ 1 s**; an enqueue later than the bound is **bad** (stays in
-    valid, not counted good). `evt.Timestamp` is the canonical event's server-set
-    timestamp (`gatekeeper handler.go`, `now.UnixMilli()`) → SLO-2 is
-    "**canonical acceptance → local enqueue accepted within 1 s**", not true
-    publication latency — the code can only observe the `PublishMsg` return
-    (enqueue), so server-confirmed **publication** latency stays in P7.
+  - `broadcast_channel_enqueue_age_seconds` = `broadcast-worker now − <acceptance
+    stamp>` → SLO-2. **Good predicate: age ≤ 1 s**; an enqueue later than the bound
+    is **bad** (stays in valid, not counted good). **The acceptance stamp is not yet
+    well-defined, and P2 must pin it.** The only timestamp on the envelope today is
+    `evt.Timestamp`, set in `gatekeeper handler.go` as `now.UnixMilli()` at the
+    **start of message build** (`handler.go:336`) — *before* the quote-snapshot
+    resolve, thread-parent fetch, and sender user-lookup (each a Mongo/Cassandra I/O
+    hop) and *before* the canonical `PublishMsg` (`handler.go:404`). So it sits
+    **earlier than canonical acceptance** by an unbounded, variable amount (a slow
+    lookup inflates it), which both mis-attributes gatekeeper lookup latency to the
+    broadcast leg and leaves the SLO-2 origin ill-defined. **P2 fixes the origin: a
+    dedicated canonical-acceptance timestamp captured immediately before the publish
+    call, or the JetStream metadata store timestamp** (`msg.Metadata().Timestamp`,
+    server-set when MESSAGES-CANONICAL persists the message — the true "canonical
+    accepted" instant, defined by a single clock on the stream server). Either way
+    SLO-2 measures "**canonical acceptance → local enqueue accepted within 1 s**",
+    not true publication latency: the code can only observe the `PublishMsg` return
+    (enqueue), so server-confirmed **publication** latency stays in P7. Because the
+    two ends sit in different processes, the age is a **cross-process wall-clock**
+    difference — see the clock-skew contract in Caveats.
 - **v1 scope: the room-subject path only.** DM/thread per-recipient
   partial-failure semantics are deferred; SLO-1b/2 count only
   `broadcast_path="room_subject"` canonical messages in v1 (channel non-thread
@@ -249,9 +262,22 @@ is the exemplar). 🔧 declared last-mile via P5/P6.
 
 ### Caveats
 
-- A publication is **one publish to a room subject, not N recipient deliveries**;
-  `UserCount` ≠ connected recipients. Denominators are messages/publications, not
-  recipients.
+- A channel broadcast is **one room-subject enqueue, not N recipient deliveries**;
+  `UserCount` ≠ connected recipients. Denominators are **canonical messages on the
+  room-subject path**, not recipients.
+- **Cross-process clock-skew contract (SLO-2).** `broadcast_channel_enqueue_age`
+  subtracts a gatekeeper-set stamp from broadcast-worker's `now` — two clocks on
+  two hosts — so the 1 s bound only means something if those clocks are disciplined.
+  **Requires** NTP/chrony on every node with **skew monitoring** (alert when a
+  node's offset exceeds ~10% of the bound, i.e. ~100 ms) so undetected drift can't
+  masquerade as latency. **Invalid samples** — `age < 0` (receiver clock behind
+  sender) or `age >` a sanity cap (e.g. 60 s, implying gross skew or a stale
+  redelivery, not real latency) — are **dropped from the ratio (neither good nor
+  valid) and counted in a separate `enqueue_age_invalid_total`**, never silently
+  folded into good or bad. A nonzero invalid rate is its own alert and, during a
+  load-test run, **fails the hard gate** (§10) — SLO-2 cannot be certified while
+  measurement integrity is in question. This contract is moot only once SLO-2 moves
+  to an in-process span (P7).
 - Ordering is not an SLO (JetStream orders within a stream only).
 - `published` denominator excludes gatekeeper-rejected messages per §0.1.
 
@@ -439,7 +465,7 @@ required** (`sdk.Meter()` is exposed; search-service is the exemplar).
 | P | Work | Unlocks |
 |---|---|---|
 | P1 | `natsrouter` metrics middleware (`rpc_server_duration_seconds{subject_pattern, errcode_category}`) | SLO-4/5 + dashboards for all non-named RPCs |
-| P2 | J1 counters — gatekeeper `messages_canonical_published_total` (upstream denominator), message-worker persisted, broadcast-worker `broadcast_channel_enqueue_total` + `broadcast_channel_enqueue_age_seconds`; terminal-outcome/dedup semantics, no message-ID labels | SLO-1a/1b/2 |
+| P2 | J1 counters — gatekeeper `messages_canonical_published_total` (upstream denominator), message-worker persisted, broadcast-worker `broadcast_channel_enqueue_total` + `broadcast_channel_enqueue_age_seconds`; **a well-defined SLO-2 age origin — a dedicated canonical-acceptance timestamp stamped immediately before the canonical publish, or the JetStream metadata store timestamp, replacing the build-start `evt.Timestamp`** (§2); `enqueue_age_invalid_total` for negative/skewed samples; terminal-outcome/dedup semantics, no message-ID labels | SLO-1a/1b/2 |
 | P3 | NATS/JetStream Prometheus exporter (infra) — consumer `num_pending`/`num_ack_pending` + ack-floor (stalled-backlog signal); **plus a custom monitor** to derive oldest-pending **age** (exporter alone doesn't expose it). Recording rules must **filter `{is_consumer_leader="true"}`** before aggregating consumer state, or clustered follower replicas double-count the series | outage backstop for 1a/1b/2/6/9 |
 | P4 | notification-worker push-stream handoff (**recipient-granular** accepted/recipients) · **search duration `status` label** (→ `{kind,status}`) · outbox producer-side published + forwarded-within-bound (matching label sets) · **NATS connection-risk counters** (disconnect/reconnect/closed/ErrorHandler) as the SLO-1b connection-risk backstop | SLO-1b/6/8/9 |
 | P5 | Collector `spanmetrics` on frontend spans | observational last-mile & J2 client view |
@@ -487,8 +513,13 @@ service recording rules or a NATS exporter.
 reply/broadcast is a failure, not an excluded sample) using the **same
 production source counters and good/valid predicates**, evaluated over **isolated
 run-window deltas** (not the 28-day aggregate recording rule, and not
-loadgen-local metrics). The run must also **drain/reset after warm-up** so
-warm-up completions cannot inflate the numerator.
+loadgen-local metrics). The run must also **drain in-flight work at the end of
+warm-up, then capture counter baselines** — snapshot each production counter at the
+warm-up boundary and measure the run as the *delta* from that baseline, so warm-up
+completions can't inflate the numerator. (Prometheus counters are monotonic and
+shared with any other traffic on the series — they are **never reset**;
+baseline-and-delta is the isolation mechanism, alongside the dedicated test
+`SITE_ID` / tenant above.)
 
 Two distinct thresholds, not one (the "50–70%" and "track this document" rules
 were in tension):

--- a/docs/load-testing/system/sli-slo.md
+++ b/docs/load-testing/system/sli-slo.md
@@ -205,26 +205,27 @@ a protocol-receive prober (loadgen) and a render prober (browser) — neither is
     loops accounts with a `failed` count), which v1 does not score; those and the
     true per-recipient *delivery* outcome are the **observational last mile**
     (declared) / v2 (§8 P7).
-  - `broadcast_channel_enqueue_age_seconds` = `broadcast-worker now − <acceptance
-    stamp>` → SLO-2. **Good predicate: age ≤ 1 s**; an enqueue later than the bound
-    is **bad** (stays in valid, not counted good). **The acceptance stamp is not yet
-    well-defined, and P2 must pin it.** The only timestamp on the envelope today is
-    `evt.Timestamp`, set in `gatekeeper handler.go` as `now.UnixMilli()` at the
-    **start of message build** (`handler.go:336`) — *before* the quote-snapshot
-    resolve, thread-parent fetch, and sender user-lookup (each a Mongo/Cassandra I/O
-    hop) and *before* the canonical `PublishMsg` (`handler.go:404`). So it sits
-    **earlier than canonical acceptance** by an unbounded, variable amount (a slow
-    lookup inflates it), which both mis-attributes gatekeeper lookup latency to the
-    broadcast leg and leaves the SLO-2 origin ill-defined. **P2 fixes the origin: a
-    dedicated canonical-acceptance timestamp captured immediately before the publish
-    call, or the JetStream metadata store timestamp** (`msg.Metadata().Timestamp`,
-    server-set when MESSAGES-CANONICAL persists the message — the true "canonical
-    accepted" instant, defined by a single clock on the stream server). Either way
-    SLO-2 measures "**canonical acceptance → local enqueue accepted within 1 s**",
-    not true publication latency: the code can only observe the `PublishMsg` return
-    (enqueue), so server-confirmed **publication** latency stays in P7. Because the
-    two ends sit in different processes, the age is a **cross-process wall-clock**
-    difference — see the clock-skew contract in Caveats.
+  - `broadcast_channel_enqueue_age_seconds` = `broadcast-worker now −
+    msg.Metadata().Timestamp` → SLO-2. **Good predicate: age ≤ 1 s**; an enqueue
+    later than the bound is **bad** (stays in valid, not counted good). **The SLO-2
+    origin is the JetStream metadata store timestamp** (`msg.Metadata().Timestamp`,
+    server-set when MESSAGES-CANONICAL persists the message) — the true "canonical
+    accepted" instant, defined by a single clock on the stream server, and the value
+    P2 wires the age against. It is deliberately **not** `evt.Timestamp`: that field
+    is set in `gatekeeper handler.go` as `now.UnixMilli()` at the **start of message
+    build** (`handler.go:336`) — *before* the quote-snapshot resolve, thread-parent
+    fetch, and sender user-lookup (each a Mongo/Cassandra I/O hop) and *before* the
+    canonical `PublishMsg` (`handler.go:404`) — so it sits earlier than acceptance by
+    an unbounded, variable amount (a slow lookup inflates it) and would fold
+    gatekeeper's own processing time into the broadcast SLO. **That build→publish gap
+    is kept, but as a diagnostic, not the SLO:** a separate gatekeeper-internal
+    latency signal (`evt.Timestamp` → publish) explains *why* a canonical message was
+    accepted late, without contaminating SLO-2's origin. SLO-2 still measures
+    "**canonical acceptance → local enqueue accepted within 1 s**", not true
+    publication latency: the code can only observe the `PublishMsg` return (enqueue),
+    so server-confirmed **publication** latency stays in P7. Because the two ends sit
+    in different processes, the age is a **cross-process wall-clock** difference —
+    see the clock-skew contract in Caveats.
 - **v1 scope: the room-subject path only.** DM/thread per-recipient
   partial-failure semantics are deferred; SLO-1b/2 count only
   `broadcast_path="room_subject"` canonical messages in v1 (channel non-thread
@@ -465,7 +466,7 @@ required** (`sdk.Meter()` is exposed; search-service is the exemplar).
 | P | Work | Unlocks |
 |---|---|---|
 | P1 | `natsrouter` metrics middleware (`rpc_server_duration_seconds{subject_pattern, errcode_category}`) | SLO-4/5 + dashboards for all non-named RPCs |
-| P2 | J1 counters — gatekeeper `messages_canonical_published_total` (upstream denominator), message-worker persisted, broadcast-worker `broadcast_channel_enqueue_total` + `broadcast_channel_enqueue_age_seconds`; **a well-defined SLO-2 age origin — a dedicated canonical-acceptance timestamp stamped immediately before the canonical publish, or the JetStream metadata store timestamp, replacing the build-start `evt.Timestamp`** (§2); `enqueue_age_invalid_total` for negative/skewed samples; terminal-outcome/dedup semantics, no message-ID labels | SLO-1a/1b/2 |
+| P2 | J1 counters — gatekeeper `messages_canonical_published_total` (upstream denominator), message-worker persisted, broadcast-worker `broadcast_channel_enqueue_total` + `broadcast_channel_enqueue_age_seconds` measured from the **JetStream metadata store timestamp** (the SLO-2 origin, §2), **plus a separate gatekeeper build→publish diagnostic latency (`evt.Timestamp`→publish), unscored**; `enqueue_age_invalid_total` for negative/skewed samples; terminal-outcome/dedup semantics, no message-ID labels | SLO-1a/1b/2 |
 | P3 | NATS/JetStream Prometheus exporter (infra) — consumer `num_pending`/`num_ack_pending` + ack-floor (stalled-backlog signal); **plus a custom monitor** to derive oldest-pending **age** (exporter alone doesn't expose it). Recording rules must **filter `{is_consumer_leader="true"}`** before aggregating consumer state, or clustered follower replicas double-count the series | outage backstop for 1a/1b/2/6/9 |
 | P4 | notification-worker push-stream handoff (**recipient-granular** accepted/recipients) · **search duration `status` label** (→ `{kind,status}`) · outbox producer-side published + forwarded-within-bound (matching label sets) · **NATS connection-risk counters** (disconnect/reconnect/closed/ErrorHandler) as the SLO-1b connection-risk backstop | SLO-1b/6/8/9 |
 | P5 | Collector `spanmetrics` on frontend spans | observational last-mile & J2 client view |

--- a/docs/load-testing/system/sli-slo.md
+++ b/docs/load-testing/system/sli-slo.md
@@ -220,8 +220,12 @@ a protocol-receive prober (loadgen) and a render prober (browser) — neither is
     an unbounded, variable amount (a slow lookup inflates it) and would fold
     gatekeeper's own processing time into the broadcast SLO. **That build→publish gap
     is kept, but as a diagnostic, not the SLO:** a separate gatekeeper-internal
-    latency signal (`evt.Timestamp` → publish) explains *why* a canonical message was
-    accepted late, without contaminating SLO-2's origin. SLO-2 still measures
+    latency signal explains *why* a canonical message was accepted late, without
+    contaminating SLO-2's origin. **Measure that diagnostic as a same-process
+    monotonic duration** (`time.Since(buildStartedAt)`), **not** by subtracting the
+    serialized `evt.Timestamp` — it is single-process, so a monotonic clock is both
+    correct and skew-free; wall-clock subtraction here would reintroduce the very
+    cross-clock error the diagnostic is meant to isolate. SLO-2 still measures
     "**canonical acceptance → local enqueue accepted within 1 s**", not true
     publication latency: the code can only observe the `PublishMsg` return (enqueue),
     so server-confirmed **publication** latency stays in P7. Because the two ends sit
@@ -268,18 +272,34 @@ is the exemplar). 🔧 declared last-mile via P5/P6.
   `UserCount` ≠ connected recipients. Denominators are **canonical messages on the
   room-subject path**, not recipients.
 - **Cross-process clock-skew contract (SLO-2).** `broadcast_channel_enqueue_age`
-  subtracts a gatekeeper-set stamp from broadcast-worker's `now` — two clocks on
-  two hosts — so the 1 s bound only means something if those clocks are disciplined.
-  **Requires** NTP/chrony on every node with **skew monitoring** (alert when a
-  node's offset exceeds ~10% of the bound, i.e. ~100 ms) so undetected drift can't
-  masquerade as latency. **Invalid samples** — `age < 0` (receiver clock behind
-  sender) or `age >` a sanity cap (e.g. 60 s, implying gross skew or a stale
-  redelivery, not real latency) — are **dropped from the ratio (neither good nor
-  valid) and counted in a separate `enqueue_age_invalid_total`**, never silently
-  folded into good or bad. A nonzero invalid rate is its own alert and, during a
-  load-test run, **fails the hard gate** (§10) — SLO-2 cannot be certified while
-  measurement integrity is in question. This contract is moot only once SLO-2 moves
-  to an in-process span (P7).
+  subtracts the **JetStream metadata store timestamp (set by the stream-server
+  leader)** from broadcast-worker's `now` — two clocks on two hosts — so the 1 s
+  bound only means something if those clocks are disciplined. **Requires** NTP/chrony
+  on every node with **skew monitoring** (alert when a node's offset exceeds ~10% of
+  the bound, i.e. ~100 ms) so undetected drift can't masquerade as latency. Sample
+  classification is deliberately narrow so it **cannot hide a real latency miss**:
+  - **Measurement-invalid** = a *broken reading*, not a slow one: only `age < 0`
+    (broadcast-worker clock behind the stream-server clock) or a **missing/zero
+    metadata timestamp**. These carry no usable latency, so they are **fail-closed,
+    never green**: counted in `enqueue_age_invalid_total` (its own skew/health
+    alert), and in production **kept in the denominator but excluded from the good
+    numerator** (i.e. they count against the SLO, they are *not* dropped). In a
+    load-test run any nonzero measurement-invalid rate **fails the hard gate** (§10)
+    — SLO-2 cannot be certified while the measurement itself is broken.
+  - **Every `age ≥ 0` is a valid latency sample** — `> 1 s` is **bad**, full stop,
+    **with no upper "sanity cap".** A worker backlog or slow first-processing that
+    pushes age to 30 s / 90 s / minutes is a **genuine SLO-2 failure** and must stay
+    in the denominator and out of the good numerator — capping it as "invalid" would
+    silently erase exactly the outage this SLO exists to catch.
+  - **Stale redeliveries** (a JetStream replay of an old message, whose age is large)
+    are a **duplicate-accounting** problem, handled by the **dedup / outcome ledger**
+    (P7) — *not* by a latency cap. A duplicate is deduped as a duplicate; it is never
+    reclassified as "invalid latency".
+
+  This contract stops being needed only once measurement moves to a **single-clock /
+  correlated boundary** (P7) — note a server-confirmed PubAck alone does **not**
+  qualify, since that ack can still be observed on a different clock; it must be a
+  single-clock or explicitly correlated span.
 - Ordering is not an SLO (JetStream orders within a stream only).
 - `published` denominator excludes gatekeeper-rejected messages per §0.1.
 
@@ -467,7 +487,7 @@ required** (`sdk.Meter()` is exposed; search-service is the exemplar).
 | P | Work | Unlocks |
 |---|---|---|
 | P1 | `natsrouter` metrics middleware (`rpc_server_duration_seconds{subject_pattern, errcode_category}`) | SLO-4/5 + dashboards for all non-named RPCs |
-| P2 | J1 counters — gatekeeper `messages_canonical_published_total` (upstream denominator), message-worker persisted, broadcast-worker `broadcast_channel_enqueue_total` + `broadcast_channel_enqueue_age_seconds` measured from the **JetStream metadata store timestamp** (the SLO-2 origin, §2), **plus a separate gatekeeper build→publish diagnostic latency (`evt.Timestamp`→publish), unscored**; `enqueue_age_invalid_total` for negative/skewed samples; terminal-outcome/dedup semantics, no message-ID labels | SLO-1a/1b/2 |
+| P2 | J1 counters — gatekeeper `messages_canonical_published_total` (upstream denominator), message-worker persisted, broadcast-worker `broadcast_channel_enqueue_total` + `broadcast_channel_enqueue_age_seconds` measured from the **JetStream metadata store timestamp** (the SLO-2 origin, §2), **plus a separate unscored gatekeeper build→publish diagnostic measured as a same-process monotonic duration (`time.Since(buildStartedAt)`), not by subtracting `evt.Timestamp`**; `enqueue_age_invalid_total` for **measurement-invalid only** (`age < 0` / missing metadata — no upper latency cap; large positive ages stay scored as bad, §2 Caveats); terminal-outcome/dedup semantics, no message-ID labels | SLO-1a/1b/2 |
 | P3 | NATS/JetStream Prometheus exporter (infra) — consumer `num_pending`/`num_ack_pending` + ack-floor (stalled-backlog signal); **plus a custom monitor** to derive oldest-pending **age** (exporter alone doesn't expose it). Recording rules must **filter `{is_consumer_leader="true"}`** before aggregating consumer state, or clustered follower replicas double-count the series | outage backstop for 1a/1b/2/6/9 |
 | P4 | notification-worker push-stream handoff (**recipient-granular** accepted/recipients) · **search duration `status` label** (→ `{kind,status}`) · outbox producer-side published + forwarded-within-bound (matching label sets) · **NATS connection-risk counters** (disconnect/reconnect/closed/ErrorHandler) as the SLO-1b connection-risk backstop | SLO-1b/6/8/9 |
 | P5 | Collector `spanmetrics` on frontend spans | observational last-mile & J2 client view |

--- a/docs/load-testing/system/sli-slo.md
+++ b/docs/load-testing/system/sli-slo.md
@@ -12,7 +12,7 @@ Companions (o11y specs): `../../specs/o11y/o11y-metrics-inventory.md`,
 `../../specs/o11y/o11y-trace-design.md`,
 `../../specs/o11y/o11y-performance-and-sampling.md`. Error budget policy:
 placeholder (`o11y-error-budget-policy.md`, to be written). Load-test alignment:
-`../end-to-end-load-test-plan.md` (§10 here is the summary; the plan owns execution).
+`end-to-end-load-test-plan.md` (§10 here is the summary; the plan owns execution).
 
 ---
 
@@ -128,7 +128,7 @@ material; read receipts / unread badges → dashboard, v2 candidate (§8 P7).
 user-perceived delivery, observational until a prober exists (§8 P6). See §2.
 
 Percentiles behind the bounds stay as **diagnostic** dashboard signals (p99
-publication age, p95 search, oldest-pending federation age), not SLO targets.
+enqueue age, p95 search, oldest-pending federation age), not SLO targets.
 
 ---
 
@@ -161,7 +161,7 @@ bound` (never implying an ordering the architecture lacks).
 
 A NATS PubAck is **not** delivery, and a NATS protocol receive is **not** render:
 dashboards can read green while a recipient's client shows nothing. v1 commits only
-to persistence + channel publication and names them so; the last mile is split into
+to persistence + channel enqueue-acceptance and names them so; the last mile is split into
 a protocol-receive prober (loadgen) and a render prober (browser) — neither is v1.
 
 ### Denominator & outcome contract
@@ -441,11 +441,11 @@ required** (`sdk.Meter()` is exposed; search-service is the exemplar).
 | P1 | `natsrouter` metrics middleware (`rpc_server_duration_seconds{subject_pattern, errcode_category}`) | SLO-4/5 + dashboards for all non-named RPCs |
 | P2 | J1 counters — gatekeeper `messages_canonical_published_total` (upstream denominator), message-worker persisted, broadcast-worker `broadcast_channel_enqueue_total` + `broadcast_channel_enqueue_age_seconds`; terminal-outcome/dedup semantics, no message-ID labels | SLO-1a/1b/2 |
 | P3 | NATS/JetStream Prometheus exporter (infra) — consumer `num_pending`/`num_ack_pending` + ack-floor (stalled-backlog signal); **plus a custom monitor** to derive oldest-pending **age** (exporter alone doesn't expose it). Recording rules must **filter `{is_consumer_leader="true"}`** before aggregating consumer state, or clustered follower replicas double-count the series | outage backstop for 1a/1b/2/6/9 |
-| P4 | notification-worker push-stream handoff (**recipient-granular** accepted/recipients) · **search duration `status` label** (→ `{kind,status}`) · outbox producer-side published + forwarded-within-bound (matching label sets) · **NATS connection-health / async-error counters** (disconnect/reconnect/closed/ErrorHandler) as the SLO-1b enqueue-loss backstop | SLO-1b/6/8/9 |
+| P4 | notification-worker push-stream handoff (**recipient-granular** accepted/recipients) · **search duration `status` label** (→ `{kind,status}`) · outbox producer-side published + forwarded-within-bound (matching label sets) · **NATS connection-risk counters** (disconnect/reconnect/closed/ErrorHandler) as the SLO-1b connection-risk backstop | SLO-1b/6/8/9 |
 | P5 | Collector `spanmetrics` on frontend spans | observational last-mile & J2 client view |
 | P6 | **loadgen NATS-subscribe prober** (protocol receipt) + SLO assertion mode (§10) · login→connect→initial-data; sparse-journey floor; SLO-aware load asserts. **Render is out of scope here** — proves protocol receipt, not decrypt/render | protocol-receive last-mile SLI |
 | P6b | **browser synthetic / RUM** prober — decrypt/render/state-apply | render-level declared last mile |
-| P7 | v2: **exact outcome ledger** (dedup / first-write / exhaustion via a max-delivery **advisory consumer** — makes 1a/1b/6/9 exact instead of approximate) · **SLO-1b server-confirmed publication boundary** (flush checkpoint / durable-PubAck path, replacing v1 enqueue-acceptance) · **push-service** provider delivery metrics (cross-repo) · correlated single-J1 outcome · search index freshness · member-add convergence · encrypted `key.get` · read-receipt convergence | — |
+| P7 | v2: **exact outcome ledger** (dedup / first-write / exhaustion via a max-delivery **advisory consumer** — makes 1a/1b/6/9 exact instead of approximate) · **SLO-1b/2 server-confirmed publication boundary** (flush checkpoint / durable-PubAck path, migrating both off v1 enqueue-acceptance) · **push-service** provider delivery metrics (cross-repo) · correlated single-J1 outcome · search index freshness · member-add convergence · encrypted `key.get` · read-receipt convergence | — |
 
 ---
 
@@ -470,7 +470,7 @@ framework is reusable but does not yet assert against these SLOs:
 | SLO | loadgen coverage today | Gap to `ready` |
 |---|---|---|
 | SLO-1a | **partial** — soak read-back | per-message outcome accounting |
-| SLO-1b / 2 | **partial** — E2 stage correlation | channel-scoped `ok`/`failed` + enqueue-age accounting (protocol-receipt, not render) |
+| SLO-1b / 2 | **missing (enqueue boundary)** | the enforced boundary needs the service-side `broadcast_channel_enqueue_total`/`_age_seconds`; loadgen's E2 stage correlation measures **protocol receipt** (observational — a different, downstream boundary), not the enqueue metric. Split the two explicitly. |
 | SLO-4 / 5 | **near-ready** | per-endpoint `good within bound / eligible attempts` accounting |
 | SLO-3 (auth) | **missing** — auth is a stub | HTTP login driver |
 | SLO-7 / 8 (search) | **missing** | search workload |
@@ -484,8 +484,11 @@ service recording rules or a NATS exporter.
 
 **Required before "validates":** an **SLO assertion mode** that counts
 `eligible`, `good`, and `missing-after-deadline` events (so a dropped
-reply/broadcast is a failure, not an excluded sample) and reads SLIs from the
-**same production recording rules**, not loadgen-local metrics.
+reply/broadcast is a failure, not an excluded sample) using the **same
+production source counters and good/valid predicates**, evaluated over **isolated
+run-window deltas** (not the 28-day aggregate recording rule, and not
+loadgen-local metrics). The run must also **drain/reset after warm-up** so
+warm-up completions cannot inflate the numerator.
 
 Two distinct thresholds, not one (the "50–70%" and "track this document" rules
 were in tension):

--- a/docs/load-testing/system/sli-slo.md
+++ b/docs/load-testing/system/sli-slo.md
@@ -271,7 +271,7 @@ is the exemplar). 🔧 declared last-mile via P5/P6.
 - A channel broadcast is **one room-subject enqueue, not N recipient deliveries**;
   `UserCount` ≠ connected recipients. Denominators are **canonical messages on the
   room-subject path**, not recipients.
-- **Cross-process clock-skew contract (SLO-2).** `broadcast_channel_enqueue_age`
+- **Cross-process clock-skew contract (SLO-2).** `broadcast_channel_enqueue_age_seconds`
   subtracts the **JetStream metadata store timestamp (set by the stream-server
   leader)** from broadcast-worker's `now` — two clocks on two hosts — so the 1 s
   bound only means something if those clocks are disciplined. **Requires** NTP/chrony
@@ -281,8 +281,10 @@ is the exemplar). 🔧 declared last-mile via P5/P6.
   - **Measurement-invalid** = a *broken reading*, not a slow one: only `age < 0`
     (broadcast-worker clock behind the stream-server clock) or a **missing/zero
     metadata timestamp**. These carry no usable latency, so they are **fail-closed,
-    never green**: counted in `enqueue_age_invalid_total` (its own skew/health
-    alert), and in production **kept in the denominator but excluded from the good
+    never green**: counted in
+    `broadcast_channel_enqueue_age_invalid_total{reason}` (its own skew/health
+    alert, with the bounded reasons `missing_metadata` / `negative_age`), and in
+    production **kept in the denominator but excluded from the good
     numerator** (i.e. they count against the SLO, they are *not* dropped). In a
     load-test run any nonzero measurement-invalid rate **fails the hard gate** (§10)
     — SLO-2 cannot be certified while the measurement itself is broken.
@@ -487,13 +489,13 @@ required** (`sdk.Meter()` is exposed; search-service is the exemplar).
 | P | Work | Unlocks |
 |---|---|---|
 | P1 | `natsrouter` metrics middleware (`rpc_server_duration_seconds{subject_pattern, errcode_category}`) | SLO-4/5 + dashboards for all non-named RPCs |
-| P2 | J1 counters — gatekeeper `messages_canonical_published_total` (upstream denominator), message-worker persisted, broadcast-worker `broadcast_channel_enqueue_total` + `broadcast_channel_enqueue_age_seconds` measured from the **JetStream metadata store timestamp** (the SLO-2 origin, §2), **plus a separate unscored gatekeeper build→publish diagnostic measured as a same-process monotonic duration (`time.Since(buildStartedAt)`), not by subtracting `evt.Timestamp`**; `enqueue_age_invalid_total` for **measurement-invalid only** (`age < 0` / missing metadata — no upper latency cap; large positive ages stay scored as bad, §2 Caveats); terminal-outcome/dedup semantics, no message-ID labels | SLO-1a/1b/2 |
+| P2 | J1 counters — gatekeeper `messages_canonical_published_total` (upstream denominator), message-worker persisted, broadcast-worker `broadcast_channel_enqueue_total` + `broadcast_channel_enqueue_age_seconds` measured from the **JetStream metadata store timestamp** (the SLO-2 origin, §2), **plus a separate unscored gatekeeper build→publish diagnostic measured as a same-process monotonic duration (`time.Since(buildStartedAt)`), not by subtracting `evt.Timestamp`**; `broadcast_channel_enqueue_age_invalid_total{reason}` (`missing_metadata` / `negative_age`) for **measurement-invalid only** (`age < 0` / missing metadata — no upper latency cap; large positive ages stay scored as bad, §2 Caveats); terminal-outcome/dedup semantics, no message-ID labels | SLO-1a/1b/2 |
 | P3 | NATS/JetStream Prometheus exporter (infra) — consumer `num_pending`/`num_ack_pending` + ack-floor (stalled-backlog signal); **plus a custom monitor** to derive oldest-pending **age** (exporter alone doesn't expose it). Recording rules must **filter `{is_consumer_leader="true"}`** before aggregating consumer state, or clustered follower replicas double-count the series | outage backstop for 1a/1b/2/6/9 |
 | P4 | notification-worker push-stream handoff (**recipient-granular** accepted/recipients) · **search duration `status` label** (→ `{kind,status}`) · outbox producer-side published + forwarded-within-bound (matching label sets) · **NATS connection-risk counters** (disconnect/reconnect/closed/ErrorHandler) as the SLO-1b connection-risk backstop | SLO-1b/6/8/9 |
 | P5 | Collector `spanmetrics` on frontend spans | observational last-mile & J2 client view |
 | P6 | **loadgen NATS-subscribe prober** (protocol receipt) + SLO assertion mode (§10) · login→connect→initial-data; sparse-journey floor; SLO-aware load asserts. **Render is out of scope here** — proves protocol receipt, not decrypt/render | protocol-receive last-mile SLI |
 | P6b | **browser synthetic / RUM** prober — decrypt/render/state-apply | render-level declared last mile |
-| P7 | v2: **exact outcome ledger** (dedup / first-write / exhaustion via a max-delivery **advisory consumer** — makes 1a/1b/6/9 exact instead of approximate) · **SLO-1b/2 server-confirmed publication boundary** (flush checkpoint / durable-PubAck path, migrating both off v1 enqueue-acceptance) · **push-service** provider delivery metrics (cross-repo) · correlated single-J1 outcome · search index freshness · member-add convergence · encrypted `key.get` · read-receipt convergence | — |
+| P7 | v2: **exact outcome ledger** (dedup / first-write / exhaustion via a max-delivery **advisory consumer** — makes 1a/1b/2/6/9 exact instead of approximate) · **SLO-1b/2 server-confirmed publication boundary** (flush checkpoint / durable-PubAck path, migrating both off v1 enqueue-acceptance; SLO-2 timing must use a **single-clock or explicitly correlated boundary**, not PubAck observation alone) · **push-service** provider delivery metrics (cross-repo) · correlated single-J1 outcome · search index freshness · member-add convergence · encrypted `key.get` · read-receipt convergence | — |
 
 ---
 

--- a/docs/load-testing/system/sli-slo.md
+++ b/docs/load-testing/system/sli-slo.md
@@ -12,7 +12,8 @@ Companions (o11y specs): `../../specs/o11y/o11y-metrics-inventory.md`,
 `../../specs/o11y/o11y-trace-design.md`,
 `../../specs/o11y/o11y-performance-and-sampling.md`. Error budget policy:
 placeholder (`o11y-error-budget-policy.md`, to be written). Load-test alignment:
-`end-to-end-load-test-plan.md` (§10 here is the summary; the plan owns execution).
+§10 here is the self-contained summary; a fuller `end-to-end-load-test-plan.md`
+is a **planned companion (separate PR)** that will own execution.
 
 ---
 

--- a/docs/specs/o11y/o11y-slo.md
+++ b/docs/specs/o11y/o11y-slo.md
@@ -112,7 +112,7 @@ material; read receipts / unread badges → dashboard, v2 candidate (§8 P7).
 | # | Journey | SLI = good / valid | Target | Today |
 |---|---|---|---|---|
 | SLO-1a | J1 | canonical message persisted to Cassandra / **canonical messages published** | 99.9% | 🔧 P2 · approximate (lag-enforced) |
-| SLO-1b | J1 | **channel** room-subject broadcast published ok (single publish) / **canonical messages routed to the room-subject path** (`broadcast_path=room_subject`) | 99.9% | 🔧 P2 · approximate · core-NATS boundary |
+| SLO-1b | J1 | **channel** room-subject broadcast **enqueue-accepted** (local core-NATS, single publish) / **canonical messages routed to the room-subject path** (`broadcast_path=room_subject`) | 99.9% | 🔧 P2 · approximate · enqueue-only (see §2) |
 | SLO-2 | J1 | room-subject broadcast published **within 1 s** of canonical acceptance (late = bad) / canonical messages on the room-subject path (`broadcast_path=room_subject`) | 99% | 🔧 P2 · approximate |
 | SLO-3 | J2 | successful login **within 1 s** / eligible login attempts | 99% | ✅ (auth leg — proxy) |
 | SLO-4 | J2 | channel load succeeds **within 500 ms** / eligible channel loads | 95% | 🔧 P1 |
@@ -152,7 +152,7 @@ bound` (never implying an ordering the architecture lacks).
 | Layer | Meaning | Status |
 |---|---|---|
 | **North-star / declared** | recipient received & **rendered** within bound | observational |
-| **Enforced v1** | SLO-1a persistence + SLO-1b/SLO-2 channel broadcast publication | this doc |
+| **Enforced v1** | SLO-1a persistence + SLO-1b/SLO-2 channel broadcast **enqueue-acceptance** (local core-NATS, not server-confirmed) | this doc |
 | **Observational v1.5** | frontend receive-span telemetry | §8 P5 |
 | **Protocol-receive prober v2** | loadgen NATS-subscribe prober — proves **protocol receipt**, not render | §8 P6 |
 | **Render prober v2** | browser synthetic / RUM — proves decrypt/render/state-apply | §8 P6/P7 |
@@ -188,8 +188,17 @@ a protocol-receive prober (loadgen) and a render prober (browser) — neither is
     downstream (the code comment: *"one room-stream publish… reports the room
     audience, not per-recipient deliveries"*). So the only channel outcome is
     **`ok`/`failed` of that one publish** — there is **no `all/partial/failed`**.
-    **Core-NATS boundary:** `nc.PublishMsg` is fire-and-forget — a nil return
-    means *enqueued locally*, **not** server-acknowledged. Per-recipient
+    **Core-NATS boundary — v1 measures *enqueue acceptance*, not publication.**
+    `nc.PublishMsg` is fire-and-forget: a nil return means the message was
+    *accepted into the local client's send/reconnect buffer*, **not**
+    server-confirmed (core NATS has no PubAck). During a disconnect the reconnect
+    buffer can silently drop a publish while the call still returns nil — the SLI
+    reads green and, because this outbound hop is **not** a JetStream consumer,
+    **no consumer-lag signal fires either**. So v1 names this outcome
+    `enqueue-accepted`, and its real safety net is **connection-health /
+    async-error backstops** (see below), *not* the ratio. Promoting it to true
+    "publication" needs a **server-confirmed boundary** — a flush checkpoint
+    (`FlushWithContext`) or a durable-PubAck path — tracked in §8 P7. Per-recipient
     `all/partial/failed` exists only on the **DM/thread** paths (`publishDMEvents`
     loops accounts with a `failed` count), which v1 does not score; those and the
     true per-recipient *delivery* outcome are the **observational last mile**
@@ -204,9 +213,19 @@ a protocol-receive prober (loadgen) and a render prober (browser) — neither is
   `broadcast_path="room_subject"` canonical messages in v1 (channel non-thread
   sends), so channel thread replies routed to thread fan-out are excluded from
   both numerator and denominator.
-- **Backstop (the real enforcement):** message-worker / broadcast-worker consumer
-  lag (§8 P3). Because the counters are core-NATS/approximate, lag is the
-  primary stalled-worker signal; the ratios are secondary.
+- **Backstops (the real enforcement) — two distinct signals:**
+  - **Inbound stall** (worker falling behind `MESSAGES_CANONICAL`): message-worker
+    / broadcast-worker **consumer lag** (§8 P3). This is a JetStream consumer, so
+    lag is observable.
+  - **Outbound enqueue loss** (SLO-1b's core-NATS hop, where lag is blind):
+    **connection-health / async-error counters** on the NATS client —
+    disconnect/reconnect events, closed-connection, `ErrorHandler` fires
+    (slow-consumer, reconnect-buffer overflow). `natsutil.Connect` already wires
+    `DisconnectErrHandler`/`ReconnectHandler`/`ClosedHandler`/`ErrorHandler`
+    (`MaxReconnects=-1`); v1 turns those log-only handlers into counters so a
+    reconnect-buffer drop surfaces even though the ratio can't see it.
+  Because the counters are core-NATS/approximate, these backstops are primary;
+  the ratios are secondary.
 
 ### Measurement
 
@@ -407,12 +426,12 @@ required** (`sdk.Meter()` is exposed; search-service is the exemplar).
 |---|---|---|
 | P1 | `natsrouter` metrics middleware (`rpc_server_duration_seconds{subject_pattern, errcode_category}`) | SLO-4/5 + dashboards for all non-named RPCs |
 | P2 | J1 counters — gatekeeper `messages_canonical_published_total` (upstream denominator), message-worker persisted, broadcast-worker publications + publication-age; terminal-outcome/dedup semantics, no message-ID labels | SLO-1a/1b/2 |
-| P3 | NATS/JetStream Prometheus exporter (infra) — consumer `num_pending`/`num_ack_pending` + ack-floor (stalled-backlog signal); **plus a custom monitor** to derive oldest-pending **age** (exporter alone doesn't expose it) | outage backstop for 1a/1b/2/6/9 |
-| P4 | notification-worker push-stream handoff (**recipient-granular** accepted/recipients) · **search duration `status` label** (→ `{kind,status}`) · outbox producer-side published + forwarded-within-bound (matching label sets) | SLO-6/8/9 |
+| P3 | NATS/JetStream Prometheus exporter (infra) — consumer `num_pending`/`num_ack_pending` + ack-floor (stalled-backlog signal); **plus a custom monitor** to derive oldest-pending **age** (exporter alone doesn't expose it). Recording rules must **filter `is_consumer_leader=true`** before aggregating consumer state, or clustered follower replicas double-count the series | outage backstop for 1a/1b/2/6/9 |
+| P4 | notification-worker push-stream handoff (**recipient-granular** accepted/recipients) · **search duration `status` label** (→ `{kind,status}`) · outbox producer-side published + forwarded-within-bound (matching label sets) · **NATS connection-health / async-error counters** (disconnect/reconnect/closed/ErrorHandler) as the SLO-1b enqueue-loss backstop | SLO-1b/6/8/9 |
 | P5 | Collector `spanmetrics` on frontend spans | observational last-mile & J2 client view |
 | P6 | **loadgen NATS-subscribe prober** (protocol receipt) + SLO assertion mode (§10) · login→connect→initial-data; sparse-journey floor; SLO-aware load asserts. **Render is out of scope here** — proves protocol receipt, not decrypt/render | protocol-receive last-mile SLI |
 | P6b | **browser synthetic / RUM** prober — decrypt/render/state-apply | render-level declared last mile |
-| P7 | v2: **exact outcome ledger** (dedup / first-write / exhaustion via a max-delivery **advisory consumer** — makes 1a/1b/6/9 exact instead of approximate) · **push-service** provider delivery metrics (cross-repo) · correlated single-J1 outcome · search index freshness · member-add convergence · encrypted `key.get` · read-receipt convergence | — |
+| P7 | v2: **exact outcome ledger** (dedup / first-write / exhaustion via a max-delivery **advisory consumer** — makes 1a/1b/6/9 exact instead of approximate) · **SLO-1b server-confirmed publication boundary** (flush checkpoint / durable-PubAck path, replacing v1 enqueue-acceptance) · **push-service** provider delivery metrics (cross-repo) · correlated single-J1 outcome · search index freshness · member-add convergence · encrypted `key.get` · read-receipt convergence | — |
 
 ---
 
@@ -460,7 +479,11 @@ were in tension):
 - **Hard gate** — the run fails if it can't meet the **actual SLO predicate and
   target** from this document (e.g. SLO-4 = 95% within 500 ms). This is what
   "thresholds track this document" means, and it applies to **latency and
-  availability** targets alike.
+  availability** targets alike. **Evaluate over isolated run-window counter
+  deltas** (`increase()` across the test window), **never** the 28-day production
+  aggregate — reading the rolling aggregate would let historical/background
+  traffic mask the failures produced *in this run*. Reuse the prod predicates and
+  targets; window the counters to the run.
 - **Engineering headroom** — a separately-named, *stricter* guardrail (e.g.
   assert the latency bound at ~50–70% of the prod value) to catch regression
   before it reaches the SLO. A headroom miss warns; only a hard-gate miss fails

--- a/docs/specs/o11y/o11y-slo.md
+++ b/docs/specs/o11y/o11y-slo.md
@@ -49,10 +49,19 @@ section: **SLI specification** (user-language intent, good/valid ratio) →
   denominator for persistence/publication — it keeps climbing if a worker dies,
   dropping the ratio). Where a denominator is unavoidably self-emitted (e.g.
   notifications), **consumer lag (§8 P3) is the outage backstop**, not the ratio.
-- **One terminal outcome per logical unit.** Numerators count a single terminal
-  outcome per logical message/notification/event — **not** per processing
-  attempt. Redelivery is deduped at the emit site (never a message-ID label);
+- **One terminal outcome per logical unit** *(target contract)*. Numerators aim
+  for a single terminal outcome per logical message/notification/event — **not**
+  per attempt — deduped at the emit site (never a message-ID label);
   `MaxDeliver` exhaustion (poison) is a terminal **failure**.
+- **v1 accounting is approximate where the code can't yet emit that contract.**
+  Today the pipeline lacks the hooks for exact one-outcome accounting: gatekeeper
+  ignores `PubAck.Duplicate`, Cassandra's idempotent inserts don't flag the first
+  write, `jsretry.Settle` has no exhaustion callback, and the outbox retries
+  forever (`MaxDeliver=-1`). So under redelivery/recovery, v1 counters may
+  double-count or split numerator/denominator across windows. Every SLI that
+  depends on this is marked **approximate (lag-enforced)**: the primary
+  enforcement signal is **consumer lag / oldest-pending age** (§8 P3), and the
+  ratio is a secondary indicator until an exact **outcome ledger** lands (§8 P7).
 - **Rounding**: shares ≥ 0.1% precision; latency bounds up to nearest 50 ms.
 - **Scope: per site**; federation (J5) isolated by `{origin, dest}` site.
 - **Error-budget eligibility** — a *failed valid event* is judged by whether the
@@ -95,16 +104,16 @@ material; read receipts / unread badges → dashboard, v2 candidate (§8 P7).
 
 | # | Journey | SLI = good / valid | Target | Today |
 |---|---|---|---|---|
-| SLO-1a | J1 | canonical message persisted to Cassandra / **canonical messages published** | 99.9% | 🔧 P2 |
-| SLO-1b | J1 | broadcast publication accepted by NATS / canonical messages published | 99.9% | 🔧 P2 |
-| SLO-2 | J1 | publication accepted **within 1 s** of canonical acceptance / canonical messages published | 99% | 🔧 P2 |
+| SLO-1a | J1 | canonical message persisted to Cassandra / **canonical messages published** | 99.9% | 🔧 P2 · approximate (lag-enforced) |
+| SLO-1b | J1 | **channel** broadcast fan-out published (all/partial/failed per message) / canonical channel messages published | 99.9% | 🔧 P2 · approximate · core-NATS boundary |
+| SLO-2 | J1 | channel fan-out published **within 1 s** of canonical acceptance / canonical channel messages published | 99% | 🔧 P2 · approximate |
 | SLO-3 | J2 | successful login **within 1 s** / eligible login attempts | 99% | ✅ (auth leg — proxy) |
 | SLO-4 | J2 | channel load succeeds **within 500 ms** / eligible channel loads | 95% | 🔧 P1 |
 | SLO-5 | J2 | thread open succeeds **within 300 ms** / eligible thread opens | 99% | 🔧 P1 |
-| SLO-6 | J3 | logical notification delivered to provider (within retries) / notifications requested | 99.5% | 🔧 P4 |
+| SLO-6 | J3 | push event accepted into `PUSH_NOTIFICATION` / notifiable recipients | 99.9% | 🔧 P4 · handoff only (see §4) |
 | SLO-7 | J4 | search returns ok / search requests | 99.5% | ✅ |
 | SLO-8 | J4 | **successful** search returns **within 1 s** / successful searches | 95% | 🔧 P4 (needs status label) |
-| SLO-9 | J5 | outbox event forwarded to remote INBOX **within 30 s** / outbox events published | 99% | 🔧 P4 |
+| SLO-9 | J5 | outbox event forwarded to remote INBOX **within 30 s** / outbox events published | 99% | 🔧 P4 · deadline-based · approximate |
 
 **Declared (not a numbered SLO):** *last-mile client receive/render* — the true
 user-perceived delivery, observational until a prober exists (§8 P6). See §2.
@@ -148,16 +157,25 @@ gets nothing. v1 commits only to persistence + publication and names them so.
 - **Denominator (both 1a and 1b/2): `messages_canonical_published_total`**,
   emitted by **message-gatekeeper** at the canonical publish site — upstream of
   both workers, so a dead worker drops the ratio instead of vanishing.
-- **Numerators**, one terminal outcome per logical message (dedup on redelivery;
-  `MaxDeliver` exhaustion = failure):
+- **Numerators**, one outcome per logical message (approximate — see §0.1):
   - `messages_persisted_total{outcome}` (message-worker) → SLO-1a
-  - `broadcast_publications_total{outcome}` (broadcast-worker) → SLO-1b
-  - `broadcast_publication_age_seconds` = `now − evt.Timestamp` at publish →
-    SLO-2. `evt.Timestamp` is the canonical event's server-set timestamp
-    (`gatekeeper handler.go`, `now.UnixMilli()`); both ends same-site clocks →
-    "canonical acceptance → broadcast publication".
-- **Backstop:** message-worker / broadcast-worker consumer lag (§8 P3) alerts on
-  a stalled worker before the ratio fully reflects it.
+  - `broadcast_fanout_total{outcome=all|partial|failed}` (broadcast-worker) →
+    SLO-1b. **Core-NATS boundary:** broadcast-worker publishes via
+    `nc.PublishMsg` (core NATS, fire-and-forget) — a nil return means the publish
+    call was *enqueued locally*, **not** server-acknowledged. And fan-out is
+    **per recipient** (channel emits a room event + one user-room event per
+    account; DM/thread emit per recipient), tolerating partial failure. So the
+    outcome is a **logical all/partial/failed per message**, not a single ack.
+  - `broadcast_fanout_age_seconds` = `now − evt.Timestamp` → SLO-2.
+    `evt.Timestamp` is the canonical event's server-set timestamp
+    (`gatekeeper handler.go`, `now.UnixMilli()`) → "canonical acceptance →
+    fan-out published".
+- **v1 scope: channel messages only.** DM/thread per-recipient partial-failure
+  semantics are deferred; SLO-1b/2 denominators count canonical **channel**
+  messages in v1.
+- **Backstop (the real enforcement):** message-worker / broadcast-worker consumer
+  lag (§8 P3). Because the counters are core-NATS/approximate, lag is the
+  primary stalled-worker signal; the ratios are secondary.
 
 ### Measurement
 
@@ -214,29 +232,27 @@ partition slice). Targets: §1.
 
 ## 4. J3 — Notifications
 
-**Journey.** Message arrives for an offline/away member → notification-worker →
-push provider.
+**Journey.** Message arrives for an offline/away member → notification-worker
+enqueues a push event → **push-service** (separate service, not in this repo) →
+provider → device.
 
-**SLI 6 — per logical notification, not per attempt.** `good = the logical
-notification was delivered to the provider within its retry budget` /
-`valid = notifications requested` (one per intended recipient of a canonical
-message; policy-suppressed — mutes, quiet hours — are **not** valid). Retries do
-**not** change the unit: four failed attempts then a success is **one delivered
-notification**, not `1/5`.
+**v1 measures the handoff, not provider delivery.** `notification-worker` only
+publishes `PushNotificationEvent` into the `PUSH_NOTIFICATION` stream; the actual
+provider retries and terminal delivery outcome live in the downstream
+**push-service**, which this repo does not own. So:
 
-| Instrument | Meaning |
-|---|---|
-| `notifications_requested_total` | denominator — one per logical notification (excl. suppressed) |
-| `notifications_delivered_total` | numerator — terminal success (possibly after retries) |
-| `notifications_exhausted_total{reason}` | terminal failure (retries exhausted) |
-| `notification_attempts_total` / `notifications_suppressed_total{reason}` | **diagnostic** — attempt volume, suppression |
+- **SLO-6 (enforced v1) — push-stream handoff**: `good = push event accepted into
+  PUSH_NOTIFICATION` / `valid = notifiable recipients` (policy-suppressed —
+  mutes, quiet hours — are **not** valid). Instruments in notification-worker:
+  `push_events_enqueued_total`, `push_recipients_total` (denominator),
+  `notifications_suppressed_total{reason}` (diagnostic). §8 P4.
+- **Declared (not owned here) — notification delivery**: `delivered to provider
+  within retry budget / recipients requested`, one terminal outcome per logical
+  notification, retries not changing the unit. This must be emitted by
+  **push-service** at recipient granularity — a **cross-repo dependency**, v2.
 
-Target: §1 (SLO-6). §8 P4. **Outage backstop:** notification-worker consumer lag
-— its denominator is self-emitted, so a dead worker is caught by lag, not the
-ratio.
-
-**Caveat.** Measures to provider hand-off; provider→device is out of scope. No
-latency SLO in v1.
+**Caveat.** v1 stops at the stream boundary; enqueue success does **not** mean the
+user was notified. No latency SLO in v1.
 
 ---
 
@@ -275,12 +291,17 @@ the numerator → counted as a failure, not a missing sample.
 - **Denominator: `outbox_events_published_total{dest_site, event_type}`**, emitted
   **producer-side** (room-service / room-worker at OUTBOX publish) — upstream of
   outbox-worker, so worker downtime can't suppress it.
-- **Numerator: one terminal outcome per event** — `outbox_forwarded_total
-  {dest_site}` gated on age ≤ bound (dedup redelivery; no double-count). Age =
-  `now − event.Timestamp`, both timestamps origin-side (no cross-site skew).
-- **Primary peer-down signal: `outbox_oldest_pending_age_seconds{dest_site}`**
-  (gauge) — always observable, no sampling gap; rises immediately when a peer
-  stalls. Alert on this + consumer lag, not only on the ratio.
+- **Numerator: forwarded within bound** — `outbox_forwarded_total{dest_site}`
+  gated on age ≤ bound. Age = `now − event.Timestamp`, both timestamps
+  origin-side (no cross-site skew). **Approximate:** outbox consumers use
+  `MaxDeliver=-1` (retry forever — there is no exhaustion terminal event), and
+  exact one-time forwarded accounting needs explicit dedup/Ack semantics not yet
+  in place. So the ratio is deadline-based and approximate.
+- **Primary peer-down signal: oldest-pending age** — derived from **NATS
+  consumer state** (`num_pending` / oldest un-acked) via the JetStream exporter
+  (§8 P3), **not** a worker-emitted gauge, so it stays observable when
+  outbox-worker itself is down. This gauge is the enforced peer-down signal;
+  the forwarded-within-bound ratio is secondary.
 
 **Caveats.**
 - **Budget isolated per `{origin_site, dest_site}`** — a dead peer burns only its
@@ -314,11 +335,11 @@ required** (`sdk.Meter()` is exposed; search-service is the exemplar).
 |---|---|---|
 | P1 | `natsrouter` metrics middleware (`rpc_server_duration_seconds{subject_pattern, errcode_category}`) | SLO-4/5 + dashboards for all non-named RPCs |
 | P2 | J1 counters — gatekeeper `messages_canonical_published_total` (upstream denominator), message-worker persisted, broadcast-worker publications + publication-age; terminal-outcome/dedup semantics, no message-ID labels | SLO-1a/1b/2 |
-| P3 | NATS/JetStream Prometheus exporter (infra) | consumer-lag leading indicator / outage backstop |
-| P4 | notification-worker (requested/delivered/exhausted + diagnostic attempts) · **search duration `status` label** · outbox producer-side published + forwarded + `oldest_pending_age` gauge | SLO-6/8/9 |
+| P3 | NATS/JetStream Prometheus exporter (infra) — consumer lag **and** oldest-pending age from consumer state | outage backstop for 1a/1b/2/6/9 |
+| P4 | notification-worker push-stream handoff (enqueued/recipients) · **search duration `status` label** · outbox producer-side published + forwarded-within-bound | SLO-6/8/9 |
 | P5 | Collector `spanmetrics` on frontend spans | observational last-mile & J2 client view |
-| P6 | Synthetic prober from `tools/loadgen` | declared last-mile SLI; full login→connect→initial-data; sparse-journey traffic floor |
-| P7 | v2 candidates: correlated single-J1 outcome (`persisted AND published within bound`) · search index freshness · member-add convergence · encrypted `key.get` success · unread-badge / read-receipt convergence | — |
+| P6 | Synthetic prober from `tools/loadgen` + SLO assertion mode (§10) | declared last-mile SLI; login→connect→initial-data; sparse-journey floor; SLO-aware load asserts |
+| P7 | v2: **exact outcome ledger** (dedup / first-write / exhaustion — makes 1a/1b/6/9 exact instead of approximate) · **push-service** provider delivery metrics (cross-repo) · correlated single-J1 outcome · search index freshness · member-add convergence · encrypted `key.get` · read-receipt convergence | — |
 
 ---
 
@@ -334,24 +355,35 @@ visibility only.
 
 These SLOs are the **acceptance criteria** for load tests; *capacity* = the load
 at which an SLO first breaks. The client surface is NATS (long-lived, stateful,
-bidirectional), so the driver is `tools/loadgen` (already asserts per-stage
-P95/P99 in `attribution.go`, tracks consumer lag) — not k6, whose VU/request
-model can't express cross-connection delivery; k6 fits pure-HTTP workflows only.
+bidirectional), so the driver is `tools/loadgen` — not k6, whose VU/request model
+can't express cross-connection delivery; k6 fits pure-HTTP workflows only.
 
-| Scenario | Driver | Validates |
+**Current coverage is `ready / partial / missing`, not "validates"** — the
+framework is reusable but does not yet assert against these SLOs:
+
+| SLO | loadgen coverage today | Gap to `ready` |
 |---|---|---|
-| Message pipeline, fan-out matrix (room sizes × rate ladder) | `loadgen` | SLO-1a/1b/2 |
-| Channel-load storm incl. cold/idle-room fixtures | `loadgen history` | SLO-4 |
-| Thread-open storm | `loadgen thread` | SLO-5 |
-| Login surge | k6 or simple HTTP driver | SLO-3 |
-| Federation under load + peer-down/recovery | *missing — to build* | SLO-9 |
-| Soak: redelivery, lag drift, memory | `loadgen` + P3 exporter | leading indicators |
+| SLO-1a | **partial** — soak read-back | per-message outcome accounting |
+| SLO-1b / 2 | **partial** — E2 stage correlation | per-endpoint all/partial/failed + channel scope |
+| SLO-4 / 5 | **near-ready** | per-endpoint `good within bound / eligible attempts` accounting |
+| SLO-3 (auth) | **missing** — auth is a stub | HTTP login driver |
+| SLO-7 / 8 (search) | **missing** | search workload |
+| SLO-6 (push) | **missing** | provider/push workload |
+| SLO-9 (federation) | **missing** — single-site only | multi-site + peer-down/recovery |
 
-Rules: assert at ~50–70% of the prod bound (lab margin) · loadgen thresholds must
-track this document (drift = bug) · run with `O11Y_ENABLED=true`, read SLIs from
-the same recording rules as prod (loadgen itself uses a noop tracer) · once per
-release, run master-switch on vs off to re-verify the overhead claims.
+Today loadgen's message max-RPS mode **excludes missing replies/broadcasts from
+failures**, its verdict uses successful-sample percentiles + a separate error
+rate, and its Prometheus overlay scrapes only loadgen/cAdvisor — **not** the
+service recording rules or a NATS exporter.
 
-Known gaps: federation scenario (per-peer FIFO isolation never load-verified);
-loadgen bypasses the WebSocket/browser leg (P6 prober should share its client
-code).
+**Required before "validates":** an **SLO assertion mode** that counts
+`eligible`, `good`, and `missing-after-deadline` events (so a dropped
+reply/broadcast is a failure, not an excluded sample) and reads SLIs from the
+**same production recording rules**, not loadgen-local metrics. Rules: assert at
+~50–70% of the prod bound (lab margin); thresholds track this document (drift =
+bug); run with `O11Y_ENABLED=true`; once per release, run master-switch on vs off
+to re-verify overhead.
+
+Known gaps: federation is single-site only (per-peer FIFO isolation never
+load-verified); loadgen bypasses the WebSocket/browser leg (P6 prober should
+share its client code).

--- a/docs/specs/o11y/o11y-slo.md
+++ b/docs/specs/o11y/o11y-slo.md
@@ -27,38 +27,43 @@ section: **SLI specification** (user-language intent, good/valid ratio) →
 
 ### 0.1 Conventions
 
-- **Every SLI is a ratio**: `good events / valid events`. Availability SLIs
-  gate on success; latency SLIs gate on *success **and** completion within a
-  stated bound*. **Percentiles are diagnostic only, never SLO targets** — a raw
-  percentile over a window has no good/valid ratio, so error budgets and
-  burn-rate alerts (§7) cannot be computed from it. (A latency SLO is therefore
-  written as "X% of valid requests completed within the bound", not "p99 < B".)
-- **Window**: 28-day rolling, all SLOs.
-- **Time-slice accounting**: the window is divided into **5-minute slices**.
-  - A slice with **≥ `MIN_SAMPLES` valid events** is **good** if ≥ the SLO's
-    stated share meet the SLI criterion, else **bad**.
-  - A slice with **< `MIN_SAMPLES` valid events** is **`insufficient_data`** —
-    **excluded from the denominator** (counts as neither good nor bad). It never
-    inflates compliance.
-  - **SLO = good_slices / (good_slices + bad_slices)** over the window.
-  - `MIN_SAMPLES` starts at **20** per 5-min slice (calibratable). Low-traffic
-    journeys (notifications, federation) will spend most slices in
-    `insufficient_data`; a scheduled **synthetic probe** (§8 P6) provides a
-    traffic floor so those journeys still accumulate signal.
+- **Every SLI is an event-based ratio**: `good events / valid events` over the
+  window. Availability SLIs gate on success; latency SLIs gate on *success **and**
+  completion within a stated bound*. **Percentiles are diagnostic only, never SLO
+  targets** — a raw percentile has no good/valid ratio, so error budgets and
+  burn-rate alerts (§7) cannot be computed from it. A latency SLO is written as
+  "X% of valid requests completed within the bound".
+- **Window**: 28-day rolling.
+- **Why event-based, not time-slice**: a minutes-below-threshold slice model
+  either leaves the in-slice share undefined or, with a minimum-sample gate,
+  hides sustained low-volume failures (a lane failing 19/19 every 5 min would
+  read `insufficient_data` forever). Event ratios count every real failure. **Low
+  sample size affects *alerting confidence*, not budget inclusion** — a sparse
+  window still accrues its true failures; burn-rate multi-window alerting (§7)
+  prevents a single 03:00 failure from paging. Synthetic probes (§8 P6) give
+  sparse journeys a traffic floor for signal, not for hiding failures.
+- **Outage-safe denominators.** A worker that emits its own denominator reports
+  *nothing* when it is down, turning an outage into missing data instead of
+  failures. So, wherever possible, the denominator is anchored **upstream** of
+  the measured worker (e.g. gatekeeper's canonical-published count is the
+  denominator for persistence/publication — it keeps climbing if a worker dies,
+  dropping the ratio). Where a denominator is unavoidably self-emitted (e.g.
+  notifications), **consumer lag (§8 P3) is the outage backstop**, not the ratio.
+- **One terminal outcome per logical unit.** Numerators count a single terminal
+  outcome per logical message/notification/event — **not** per processing
+  attempt. Redelivery is deduped at the emit site (never a message-ID label);
+  `MaxDeliver` exhaustion (poison) is a terminal **failure**.
 - **Rounding**: shares ≥ 0.1% precision; latency bounds up to nearest 50 ms.
-- **Scope: per site** — each site is its own failure domain and budget.
-  Federation (J5) is measured separately and isolated by `{origin, dest}` site.
-- **Error-budget eligibility** — what counts as a *failed* valid event is
-  decided by whether the request was legitimate and *expected to succeed*, not
-  by wire category alone:
+- **Scope: per site**; federation (J5) isolated by `{origin, dest}` site.
+- **Error-budget eligibility** — a *failed valid event* is judged by whether the
+  request was legitimate and *expected to succeed*, not by wire category alone:
 
-  | `errcode` (server) / HTTP | Burns budget? | Why |
+  | `errcode` / HTTP | Burns budget? | Why |
   |---|---|---|
-  | `internal`, `unavailable`, `too_many_requests` (429), server-side timeout | **Yes** | our fault: bug, overload, capacity rejection |
-  | `bad_request`, `unauthenticated`, `forbidden`, `not_found`, `conflict` (4xx) | No | legitimate user/client outcome, not a reliability failure |
+  | `internal`, `unavailable`, `too_many_requests` (429), server-side timeout | **Yes** | our fault: bug, overload, capacity |
+  | `bad_request`, `unauthenticated`, `forbidden`, `not_found`, `conflict` (4xx) | No | legitimate user/client outcome |
 
-  Excluded rows are removed from *valid events* entirely (not counted as
-  failures).
+  Excluded rows are removed from *valid events* entirely — never counted as good.
 
 ### 0.2 Calibration
 
@@ -67,11 +72,9 @@ All targets are **achievable-first starting values**. Run observationally for
 
 ### 0.3 SLO ≠ SLA
 
-**This document is internal.** If numbers are ever published externally they
-become an SLA, which must be *derived*, not copied: one notch looser than the
-internal SLO, availability-focused, with exclusions/remedies defined with
-business/legal, and only after calibration data exists. Never publish these
-numbers as-is.
+**Internal document.** Any external SLA must be *derived* (looser,
+availability-focused, exclusions/remedies with business/legal, post-calibration).
+Never publish these numbers as-is.
 
 ---
 
@@ -90,25 +93,24 @@ create, member ops, uploads, …) are dashboard-monitored, **no SLO in v1**.
 Ephemeral signals (typing, presence) are best-effort by design — never SLO
 material; read receipts / unread badges → dashboard, v2 candidate (§8 P7).
 
-| # | Journey | SLI (good / valid) | Target | Today |
+| # | Journey | SLI = good / valid | Target | Today |
 |---|---|---|---|---|
-| SLO-1a | J1 | canonical message persisted to Cassandra / eligible canonical messages | 99.9% good slices | 🔧 P2 |
-| SLO-1b | J1 | broadcast publication accepted by NATS / eligible publications | 99.9% good slices | 🔧 P2 |
-| SLO-2 | J1 | publication accepted **within 1 s** of canonical acceptance / eligible publications | 99% good slices | 🔧 P2 |
-| SLO-3 | J2 | login succeeds within 1 s / login attempts | 99% in-slice · 99.9% slices | ✅ (auth leg — proxy) |
-| SLO-4 | J2 | channel load succeeds within 500 ms / channel loads | 95% in-slice · 99.9% slices | 🔧 P1 |
-| SLO-5 | J2 | thread open succeeds within 300 ms / thread opens | 99% in-slice · 99.9% slices | 🔧 P1 |
-| SLO-6 | J3 | notification handed to provider / notifications attempted | 99.5% good slices | 🔧 P4 |
-| SLO-7 | J4 | search returns ok / search requests | 99.5% good slices | ✅ |
-| SLO-8 | J4 | **successful** search returns within 1 s / **successful** searches | 95% in-slice · 99.9% slices | ✅ |
-| SLO-9 | J5 | outbox event forwarded to remote INBOX within 30 s / all outbox events | 99% good slices | 🔧 P4 |
+| SLO-1a | J1 | canonical message persisted to Cassandra / **canonical messages published** | 99.9% | 🔧 P2 |
+| SLO-1b | J1 | broadcast publication accepted by NATS / canonical messages published | 99.9% | 🔧 P2 |
+| SLO-2 | J1 | publication accepted **within 1 s** of canonical acceptance / canonical messages published | 99% | 🔧 P2 |
+| SLO-3 | J2 | successful login **within 1 s** / eligible login attempts | 99% | ✅ (auth leg — proxy) |
+| SLO-4 | J2 | channel load succeeds **within 500 ms** / eligible channel loads | 95% | 🔧 P1 |
+| SLO-5 | J2 | thread open succeeds **within 300 ms** / eligible thread opens | 99% | 🔧 P1 |
+| SLO-6 | J3 | logical notification delivered to provider (within retries) / notifications requested | 99.5% | 🔧 P4 |
+| SLO-7 | J4 | search returns ok / search requests | 99.5% | ✅ |
+| SLO-8 | J4 | **successful** search returns **within 1 s** / successful searches | 95% | 🔧 P4 (needs status label) |
+| SLO-9 | J5 | outbox event forwarded to remote INBOX **within 30 s** / outbox events published | 99% | 🔧 P4 |
 
-**Declared (not a numbered SLO):** *last-mile client receive/render* — the
-true user-perceived delivery. Observational only until a synthetic prober
-exists; enforcement candidate v2 (§8 P6). See §2.
+**Declared (not a numbered SLO):** *last-mile client receive/render* — the true
+user-perceived delivery, observational until a prober exists (§8 P6). See §2.
 
-Percentiles behind the bounds are kept as **diagnostic** signals on dashboards
-(e.g. p99 publication age, p95 search) but are not the SLO.
+Percentiles behind the bounds stay as **diagnostic** dashboard signals (p99
+publication age, p95 search, oldest-pending federation age), not SLO targets.
 
 ---
 
@@ -116,72 +118,60 @@ Percentiles behind the bounds are kept as **diagnostic** signals on dashboards
 
 **Journey.** User sends; the message is durably stored and published so every
 connected member can see it near-instantly. frontend → `MESSAGES` → gatekeeper
-→ `MESSAGES_CANONICAL` → **message-worker** (persist to Cassandra) **and**
-**broadcast-worker** (publish fan-out). The two workers consume
-`MESSAGES_CANONICAL` **independently and in parallel** — there is no
-persisted-then-published ordering.
+→ `MESSAGES_CANONICAL` → **message-worker** (persist) **and** **broadcast-worker**
+(publish fan-out). The two workers consume `MESSAGES_CANONICAL` **independently
+and in parallel** — no persisted-then-published ordering.
 
 ### Why J1 is split (not one "delivery success")
 
-A single "delivered ∧ persisted" SLI **cannot be computed** from independent
-Prometheus counters: they can't be joined by message ID (and message ID must
-never be a metric label — unbounded cardinality), and the two outcomes land in
-different slices. So J1 is measured as **two independent ratios plus a latency
-ratio**, each with its own denominator and budget. They are **not** combined
-into an overall "delivery" number — that would still not prove the same message
-did both. A single correlated J1 budget is deferred to v2 (§8 P7) and, if built,
-must mean `persisted AND publication observed within bound` — never implying an
-ordering the architecture doesn't guarantee.
+A "delivered ∧ persisted" SLI cannot be computed from independent counters (no
+message-ID join; outcomes land separately). So J1 is **two success ratios plus a
+latency ratio**, each its own budget, **not** combined — a combined number still
+wouldn't prove the same message did both. A single correlated J1 outcome is
+deferred to v2 (§8 P7) and, if built, means `persisted AND published within
+bound` (never implying an ordering the architecture lacks).
 
 ### Delivery is layered — name each layer honestly
 
-| Layer | What it means | Status |
+| Layer | Meaning | Status |
 |---|---|---|
-| **North-star / declared** | recipient received & rendered within bound | declared SLI, observational |
+| **North-star / declared** | recipient received & rendered within bound | observational |
 | **Enforced v1** | SLO-1a persistence + SLO-1b/SLO-2 broadcast publication | this doc |
-| **Observational v1.5** | frontend receive-span telemetry (spanmetrics) | §8 P5 |
+| **Observational v1.5** | frontend receive-span telemetry | §8 P5 |
 | **Enforcement candidate v2** | synthetic prober — true last mile | §8 P6 |
 
 A NATS PubAck is **not** delivery: dashboards can read green while a recipient
-receives nothing. v1 therefore commits only to persistence + publication and
-names them as such.
+gets nothing. v1 commits only to persistence + publication and names them so.
 
-### SLIs & targets — see §1 (SLO-1a / 1b / 2)
+### Denominator & outcome contract
 
-- **SLO-1a — Message persistence success**: `good = canonical message written
-  to Cassandra` / `valid = eligible canonical messages`.
-- **SLO-1b — Broadcast publication success**: `good = fan-out publication
-  accepted by NATS` / `valid = eligible broadcast publications`.
-- **SLO-2 — Broadcast publication latency**: `good = publication accepted ≤ 1 s
-  after canonical acceptance` / same denominator as 1b. Measured
-  `now − canonicalEvent.Timestamp` at the publish site — the canonical event's
-  server-set timestamp (`gatekeeper handler.go`, `now.UnixMilli()`), read by
-  broadcast-worker as `evt.Timestamp`. Both ends are same-site server clocks.
+- **Denominator (both 1a and 1b/2): `messages_canonical_published_total`**,
+  emitted by **message-gatekeeper** at the canonical publish site — upstream of
+  both workers, so a dead worker drops the ratio instead of vanishing.
+- **Numerators**, one terminal outcome per logical message (dedup on redelivery;
+  `MaxDeliver` exhaustion = failure):
+  - `messages_persisted_total{outcome}` (message-worker) → SLO-1a
+  - `broadcast_publications_total{outcome}` (broadcast-worker) → SLO-1b
+  - `broadcast_publication_age_seconds` = `now − evt.Timestamp` at publish →
+    SLO-2. `evt.Timestamp` is the canonical event's server-set timestamp
+    (`gatekeeper handler.go`, `now.UnixMilli()`); both ends same-site clocks →
+    "canonical acceptance → broadcast publication".
+- **Backstop:** message-worker / broadcast-worker consumer lag (§8 P3) alerts on
+  a stalled worker before the ratio fully reflects it.
 
 ### Measurement
 
-- ✅ Today: nothing — specified but not enforceable (top roadmap item).
-- 🔧 **Enforcement, v1** — per-service `metrics.go` (copy the search-service /
-  data-migration pattern; `sdk.Meter()` already exposed, **no SDK change**):
-
-| Instrument | Where |
-|---|---|
-| `messages_validated_total` / `messages_rejected_total{reason}` | message-gatekeeper |
-| `messages_persisted_total{outcome}` | message-worker → SLO-1a |
-| `broadcast_publications_total{outcome}` | broadcast-worker → SLO-1b |
-| `broadcast_publication_age_seconds` (`now − evt.Timestamp`) | broadcast-worker → SLO-2 |
-
-- 🔧 Observational v1.5 / v2: frontend spanmetrics (§8 P5), synthetic prober
-  (§8 P6) — feed the *declared* last-mile SLI.
+✅ nothing today (top roadmap item). 🔧 enforcement v1 = the counters above,
+per-service `metrics.go` (`sdk.Meter()` exists, **no SDK change**; search-service
+is the exemplar). 🔧 declared last-mile via P5/P6.
 
 ### Caveats
 
-- **A publication is one publish to a room subject, not N recipient
-  deliveries.** `UserCount` is not connected-recipient count. v1 denominators
-  are *messages / publications*, not recipients — do not read SLO-1b as
-  "everyone received it".
+- A publication is **one publish to a room subject, not N recipient deliveries**;
+  `UserCount` ≠ connected recipients. Denominators are messages/publications, not
+  recipients.
 - Ordering is not an SLO (JetStream orders within a stream only).
-- `eligible` excludes gatekeeper-rejected messages per §0.1.
+- `published` denominator excludes gatekeeper-rejected messages per §0.1.
 
 ---
 
@@ -197,26 +187,27 @@ successfully within the bound* (§0.1).
 | **Enter thread** | `msg.thread` → `GetThreadMessages`: **single partition** `thread_messages_by_thread`, no walk |
 
 Separate bounds because the cost models differ (open-ended bucket walk vs one
-partition slice). Targets: §1 (SLO-3/4/5).
+partition slice). Targets: §1.
 
 ### Measurement
 
-- ✅ **Login — auth leg only (proxy).** auth-service
-  `http.server.request.duration` gives `good = status<500 ∧ ≤ 1s`. This is a
-  **proxy** for the declared app-entry journey (auth → connect → initial data);
-  the connect + initial-data legs are client-side, added via prober/spanmetrics
-  (v2). SLO-3 is labelled proxy until then.
-- 🔧 **Enter channel / thread** — blocked on the `natsrouter` metrics
-  middleware (§8 P1): `rpc_server_duration_seconds{subject_pattern,
-  errcode_category}`; the `subject_pattern` label slices both workflows from one
-  middleware. Budget eligibility per the §0.1 errcode table.
+- ✅ **Login — auth leg only (proxy).** `good = successful login (2xx) ∧ ≤ 1 s` /
+  `valid = eligible login attempts` on auth-service `http.server.request.duration`.
+  4xx (bad credentials, etc.) are **excluded from valid**, never counted as good.
+  This is a **proxy** for the declared app-entry journey (auth → connect →
+  initial data); the connect + initial-data legs are added via prober/spanmetrics
+  (v2). Labelled proxy until then.
+- 🔧 **Enter channel / thread** — the `natsrouter` metrics middleware (§8 P1):
+  `rpc_server_duration_seconds{subject_pattern, errcode_category}`; the
+  `subject_pattern` label slices both workflows from one middleware. Eligibility
+  per the §0.1 errcode table.
 - 🔧 Client-side v1.5: spanmetrics.
 
 ### Caveats
 
-- **Bucket-walk tail is structural**: a long-idle room's first load walks more
-  buckets. If calibration shows the SLO-4 miss rate dominated by walk depth, add
-  a walk-depth metric / tune `MESSAGE_BUCKET_HOURS` — don't loosen the SLO.
+- **Bucket-walk tail is structural**: if calibration shows the SLO-4 miss rate
+  dominated by walk depth, add a walk-depth metric / tune `MESSAGE_BUCKET_HOURS`
+  — don't loosen the SLO.
 - Encrypted-room `key.get` failure is user-visible — v2 SLI candidate (§8 P7).
 
 ---
@@ -226,17 +217,23 @@ partition slice). Targets: §1 (SLO-3/4/5).
 **Journey.** Message arrives for an offline/away member → notification-worker →
 push provider.
 
-**SLI 6.** `good = notification successfully handed to the provider` /
-`valid = notifications attempted`. Explicit instrument contract:
+**SLI 6 — per logical notification, not per attempt.** `good = the logical
+notification was delivered to the provider within its retry budget` /
+`valid = notifications requested` (one per intended recipient of a canonical
+message; policy-suppressed — mutes, quiet hours — are **not** valid). Retries do
+**not** change the unit: four failed attempts then a success is **one delivered
+notification**, not `1/5`.
 
 | Instrument | Meaning |
 |---|---|
-| `notifications_attempted_total` | **denominator** — one per provider hand-off attempt, **including retries** (each retry is a new attempt); **excludes** policy-suppressed |
-| `notifications_sent_total` | successful provider hand-offs (the numerator) |
-| `notifications_failed_total{reason}` | unsuccessful attempts, by reason |
-| `notifications_suppressed_total{reason}` | policy-suppressed (mutes, quiet hours) — **not** valid events |
+| `notifications_requested_total` | denominator — one per logical notification (excl. suppressed) |
+| `notifications_delivered_total` | numerator — terminal success (possibly after retries) |
+| `notifications_exhausted_total{reason}` | terminal failure (retries exhausted) |
+| `notification_attempts_total` / `notifications_suppressed_total{reason}` | **diagnostic** — attempt volume, suppression |
 
-Target: §1 (SLO-6). §8 P4.
+Target: §1 (SLO-6). §8 P4. **Outage backstop:** notification-worker consumer lag
+— its denominator is self-emitted, so a dead worker is caught by lag, not the
+ratio.
 
 **Caveat.** Measures to provider hand-off; provider→device is out of scope. No
 latency SLO in v1.
@@ -250,16 +247,16 @@ latency SLO in v1.
 
 - **SLO-7 — availability**: `good = status=ok` / `valid = all search requests`.
 - **SLO-8 — latency**: `good = successful search returns ≤ 1 s` /
-  `valid = **successful** searches`. **Latency is gated on success** so a fast
-  failure cannot improve the number (an ungated p95 rewards fast-failing).
+  `valid = successful searches`. **Gated on success** so a fast failure can't
+  improve the number.
 
-**Measurement.** ✅ Fully measurable today: `search_service_requests_total
-{type,status}`, `search_service_request_duration_seconds`
-(`…es_duration_seconds` is diagnostic). The duration histogram needs a
-`status`/outcome label to gate SLO-8; add if absent.
+**Measurement.** ✅ SLO-7 today (`search_service_requests_total{type,status}`).
+🔧 **SLO-8 is not measurable yet**: `search_service_request_duration_seconds` has
+no status/outcome label, so successful requests can't be isolated — add that
+label (§8 P4) before enforcing SLO-8. `…es_duration_seconds` stays diagnostic.
 
-**Caveat.** Index freshness (how fast a new message becomes searchable) is
-deliberately out of v1 — §8 P7.
+**Caveat.** Index freshness (how fast a new message becomes searchable) is out of
+v1 — §8 P7.
 
 ---
 
@@ -268,27 +265,30 @@ deliberately out of v1 — §8 P7.
 **Journey.** Cross-site events converge site A → site B via `OUTBOX` →
 outbox-worker → remote `INBOX` → inbox-worker.
 
-**SLO-9 — Federation forward freshness**: `good = outbox event forwarded to the
-destination INBOX within 30 s of its publish time` / `valid = all outbox
-events`. Framed as a **ratio, not a p99**, so an event that is **never**
-forwarded (a stuck peer) counts as a failure in the denominator instead of
-silently producing no sample.
+**SLI 9 — Federation forward freshness**: `good = outbox event forwarded to the
+destination INBOX within 30 s of publish` / `valid = outbox events published`. A
+never-forwarded event (stuck peer) stays in the denominator and never reaches
+the numerator → counted as a failure, not a missing sample.
 
-**Measurement.** ✅ nothing today; 🔧 in outbox-worker (§8 P4):
-`outbox_forwarded_total{dest_site, event_type}` gated on age ≤ bound,
-`outbox_events_total{dest_site, event_type}` (denominator),
-`outbox_retries_total{dest_site}`. Age = `now − event.Timestamp`, both
-timestamps on the origin site (no cross-site clock skew). A companion
-`outbox_forward_age_seconds` histogram is kept diagnostic.
+### Outage-safe contract
+
+- **Denominator: `outbox_events_published_total{dest_site, event_type}`**, emitted
+  **producer-side** (room-service / room-worker at OUTBOX publish) — upstream of
+  outbox-worker, so worker downtime can't suppress it.
+- **Numerator: one terminal outcome per event** — `outbox_forwarded_total
+  {dest_site}` gated on age ≤ bound (dedup redelivery; no double-count). Age =
+  `now − event.Timestamp`, both timestamps origin-side (no cross-site skew).
+- **Primary peer-down signal: `outbox_oldest_pending_age_seconds{dest_site}`**
+  (gauge) — always observable, no sampling gap; rises immediately when a peer
+  stalls. Alert on this + consumer lag, not only on the ratio.
 
 **Caveats.**
-- **Budget isolated per `{origin_site, dest_site}`** — a dead peer burns only
-  its own lane's budget (its FIFO parks with `MaxAckPending=1`), and the
-  per-destination forward-success ratio is the primary peer-down alert signal.
-- v1 covers the **OUTBOX relay only** (origin publish → forwarded). It does not
-  cover direct-INBOX publication paths or remote *apply* by inbox-worker; those
-  are v2 refinements (remote apply adds cross-site clock skew).
-- `member_added` rides this pipeline — the cross-site half of member-change
+- **Budget isolated per `{origin_site, dest_site}`** — a dead peer burns only its
+  own lane (FIFO parks with `MaxAckPending=1`).
+- v1 covers the **OUTBOX relay only** (origin publish → forwarded), not
+  direct-INBOX paths or remote *apply* by inbox-worker (v2; remote apply adds
+  cross-site clock skew).
+- `member_added` rides this pipeline — cross-site half of member-change
   convergence is covered; same-site half is v2 (§8 P7).
 
 ---
@@ -296,26 +296,28 @@ timestamps on the origin site (no cross-site clock skew). A companion
 ## 7. Alerting — burn rate, not thresholds
 
 After calibration, alert on error-budget burn rate (multi-window, SRE Workbook
-ch.5), now well-defined because every SLO is a good/valid ratio: **page** at
-14.4× over 1 h (+5 m), **page** at 6× over 6 h (+30 m), **ticket** at 1× over
-3 d. NATS/JetStream consumer lag (§8 P3) is the leading indicator for
-SLO-1a/1b/2/6/9 — alert on lag growth before budget burns.
+ch.5) — well-defined because every SLO is an event ratio: **page** at 14.4× over
+1 h (+5 m), **page** at 6× over 6 h (+30 m), **ticket** at 1× over 3 d. Minimum
+sample size gates *alert confidence* only (don't page on a 1/2-event window), never
+budget inclusion. **NATS/JetStream consumer lag** (§8 P3) and **oldest-pending
+age** (§6) are the leading / outage-backstop indicators for the async SLOs
+(1a/1b/2/6/9).
 
 ---
 
 ## 8. Measurement roadmap
 
 All items land in `newchat` (app code) or infra — **no flywindy/o11y SDK change
-required** (`sdk.Meter()` is exposed; search-service is the working exemplar).
+required** (`sdk.Meter()` is exposed; search-service is the exemplar).
 
 | P | Work | Unlocks |
 |---|---|---|
 | P1 | `natsrouter` metrics middleware (`rpc_server_duration_seconds{subject_pattern, errcode_category}`) | SLO-4/5 + dashboards for all non-named RPCs |
-| P2 | J1 counters: persisted / publications / publication-age (gatekeeper, message-worker, broadcast-worker) — no message-ID labels | SLO-1a/1b/2 |
-| P3 | NATS/JetStream Prometheus exporter (infra) | consumer-lag leading indicator |
-| P4 | notification-worker (attempted/sent/failed/suppressed) + outbox-worker (forwarded-within-bound / events / retries) | SLO-6/9 |
-| P5 | Collector `spanmetrics` on frontend spans | observational last-mile & J2 (client view) |
-| P6 | Synthetic prober from `tools/loadgen` | declared last-mile SLI; full login→connect→initial-data |
+| P2 | J1 counters — gatekeeper `messages_canonical_published_total` (upstream denominator), message-worker persisted, broadcast-worker publications + publication-age; terminal-outcome/dedup semantics, no message-ID labels | SLO-1a/1b/2 |
+| P3 | NATS/JetStream Prometheus exporter (infra) | consumer-lag leading indicator / outage backstop |
+| P4 | notification-worker (requested/delivered/exhausted + diagnostic attempts) · **search duration `status` label** · outbox producer-side published + forwarded + `oldest_pending_age` gauge | SLO-6/8/9 |
+| P5 | Collector `spanmetrics` on frontend spans | observational last-mile & J2 client view |
+| P6 | Synthetic prober from `tools/loadgen` | declared last-mile SLI; full login→connect→initial-data; sparse-journey traffic floor |
 | P7 | v2 candidates: correlated single-J1 outcome (`persisted AND published within bound`) · search index freshness · member-add convergence · encrypted `key.get` success · unread-badge / read-receipt convergence | — |
 
 ---
@@ -330,12 +332,11 @@ visibility only.
 
 ## 10. Load testing alignment
 
-These SLOs are the **acceptance criteria** for load tests; *capacity* = the
-load at which an SLO first breaks. The client surface is NATS (long-lived,
-stateful, bidirectional), so the driver is `tools/loadgen` (already asserts
-per-stage P95/P99 in `attribution.go`, tracks consumer lag) — not k6, whose
-VU/request model can't express cross-connection delivery; k6 fits the pure-HTTP
-workflows only.
+These SLOs are the **acceptance criteria** for load tests; *capacity* = the load
+at which an SLO first breaks. The client surface is NATS (long-lived, stateful,
+bidirectional), so the driver is `tools/loadgen` (already asserts per-stage
+P95/P99 in `attribution.go`, tracks consumer lag) — not k6, whose VU/request
+model can't express cross-connection delivery; k6 fits pure-HTTP workflows only.
 
 | Scenario | Driver | Validates |
 |---|---|---|
@@ -346,10 +347,10 @@ workflows only.
 | Federation under load + peer-down/recovery | *missing — to build* | SLO-9 |
 | Soak: redelivery, lag drift, memory | `loadgen` + P3 exporter | leading indicators |
 
-Rules: assert at ~50–70% of the prod bound (lab margin) · loadgen thresholds
-must track this document (drift = bug) · run with `O11Y_ENABLED=true` and read
-SLIs from the same recording rules as prod (loadgen itself uses a noop tracer) ·
-once per release, run master-switch on vs off to re-verify the overhead claims.
+Rules: assert at ~50–70% of the prod bound (lab margin) · loadgen thresholds must
+track this document (drift = bug) · run with `O11Y_ENABLED=true`, read SLIs from
+the same recording rules as prod (loadgen itself uses a noop tracer) · once per
+release, run master-switch on vs off to re-verify the overhead claims.
 
 Known gaps: federation scenario (per-peer FIFO isolation never load-verified);
 loadgen bypasses the WebSocket/browser leg (P6 prober should share its client

--- a/docs/specs/o11y/o11y-slo.md
+++ b/docs/specs/o11y/o11y-slo.md
@@ -51,8 +51,10 @@ section: **SLI specification** (user-language intent, good/valid ratio) →
   notifications), **consumer lag (§8 P3) is the outage backstop**, not the ratio.
 - **One terminal outcome per logical unit** *(target contract)*. Numerators aim
   for a single terminal outcome per logical message/notification/event — **not**
-  per attempt — deduped at the emit site (never a message-ID label);
-  `MaxDeliver` exhaustion (poison) is a terminal **failure**.
+  per attempt — deduped at the emit site (never a message-ID label). Two distinct
+  terminal **failures** exist and must be counted separately: an explicit
+  **permanent poison drop** (`errcode.Permanent` → Ack-and-drop, no retry) and
+  **`MaxDeliver` exhaustion** (Nak-retried until the delivery cap, then parked/dropped).
 - **v1 accounting is approximate where the code can't yet emit that contract.**
   Today the pipeline lacks the hooks for exact one-outcome accounting: gatekeeper
   ignores `PubAck.Duplicate`, Cassandra's idempotent inserts don't flag the first
@@ -105,13 +107,13 @@ material; read receipts / unread badges → dashboard, v2 candidate (§8 P7).
 | # | Journey | SLI = good / valid | Target | Today |
 |---|---|---|---|---|
 | SLO-1a | J1 | canonical message persisted to Cassandra / **canonical messages published** | 99.9% | 🔧 P2 · approximate (lag-enforced) |
-| SLO-1b | J1 | **channel** broadcast fan-out published (**good = `outcome=all`**; partial/failed both burn) / canonical channel messages published | 99.9% | 🔧 P2 · approximate · core-NATS boundary |
-| SLO-2 | J1 | channel fan-out published **within 1 s** of canonical acceptance (late = bad) / canonical channel messages published | 99% | 🔧 P2 · approximate |
+| SLO-1b | J1 | **channel** room-subject broadcast published ok (single publish) / **canonical channel messages published** (`room_type=channel`) | 99.9% | 🔧 P2 · approximate · core-NATS boundary |
+| SLO-2 | J1 | channel broadcast published **within 1 s** of canonical acceptance (late = bad) / canonical channel messages published (`room_type=channel`) | 99% | 🔧 P2 · approximate |
 | SLO-3 | J2 | successful login **within 1 s** / eligible login attempts | 99% | ✅ (auth leg — proxy) |
 | SLO-4 | J2 | channel load succeeds **within 500 ms** / eligible channel loads | 95% | 🔧 P1 |
 | SLO-5 | J2 | thread open succeeds **within 300 ms** / eligible thread opens | 99% | 🔧 P1 |
-| SLO-6 | J3 | push event accepted into `PUSH_NOTIFICATION` / notifiable recipients | 99.9% | 🔧 P4 · handoff only (see §4) |
-| SLO-7 | J4 | search returns ok / search requests | 99.5% | ✅ partial-failure · outage needs backstop (§5) |
+| SLO-6 | J3 | **recipients** accepted into `PUSH_NOTIFICATION` / notifiable recipients | 99.9% | 🔧 P4 · approximate · handoff only (see §4) |
+| SLO-7 | J4 | search returns ok / **eligible** search requests | 99.5% | ✅ partial-failure · outage needs backstop (§5) |
 | SLO-8 | J4 | **successful** search returns **within 1 s** / successful searches | 95% | 🔧 P4 (needs status label) |
 | SLO-9 | J5 | outbox event forwarded to remote INBOX **within 30 s** / outbox events published | 99% | 🔧 P4 · deadline-based · approximate |
 
@@ -144,37 +146,47 @@ bound` (never implying an ordering the architecture lacks).
 
 | Layer | Meaning | Status |
 |---|---|---|
-| **North-star / declared** | recipient received & rendered within bound | observational |
-| **Enforced v1** | SLO-1a persistence + SLO-1b/SLO-2 broadcast publication | this doc |
+| **North-star / declared** | recipient received & **rendered** within bound | observational |
+| **Enforced v1** | SLO-1a persistence + SLO-1b/SLO-2 channel broadcast publication | this doc |
 | **Observational v1.5** | frontend receive-span telemetry | §8 P5 |
-| **Enforcement candidate v2** | synthetic prober — true last mile | §8 P6 |
+| **Protocol-receive prober v2** | loadgen NATS-subscribe prober — proves **protocol receipt**, not render | §8 P6 |
+| **Render prober v2** | browser synthetic / RUM — proves decrypt/render/state-apply | §8 P6/P7 |
 
-A NATS PubAck is **not** delivery: dashboards can read green while a recipient
-gets nothing. v1 commits only to persistence + publication and names them so.
+A NATS PubAck is **not** delivery, and a NATS protocol receive is **not** render:
+dashboards can read green while a recipient's client shows nothing. v1 commits only
+to persistence + channel publication and names them so; the last mile is split into
+a protocol-receive prober (loadgen) and a render prober (browser) — neither is v1.
 
 ### Denominator & outcome contract
 
-- **Denominator (both 1a and 1b/2): `messages_canonical_published_total`**,
+- **Denominators, `room_type`-scoped:** `messages_canonical_published_total{room_type}`,
   emitted by **message-gatekeeper** at the canonical publish site — upstream of
   both workers, so a dead worker drops the ratio instead of vanishing.
+  - **SLO-1a** uses the **all-`room_type` total** (persistence covers every message).
+  - **SLO-1b/2** use the **`room_type="channel"` slice only** — v1 excludes
+    DM/thread (see below), so an unfiltered denominator would understate the ratio.
 - **Numerators**, one outcome per logical message (approximate — see §0.1):
-  - `messages_persisted_total{outcome}` (message-worker) → SLO-1a
-  - `broadcast_fanout_total{outcome=all|partial|failed}` (broadcast-worker) →
-    SLO-1b. **Good predicate: `outcome=all` only** — `partial` and `failed` both
-    burn budget (any recipient the message didn't reach is a miss). **Core-NATS
-    boundary:** broadcast-worker publishes via `nc.PublishMsg` (core NATS,
-    fire-and-forget) — a nil return means the publish call was *enqueued locally*,
-    **not** server-acknowledged. And fan-out is **per recipient** (channel emits a
-    room event + one user-room event per account; DM/thread emit per recipient),
-    tolerating partial failure. So the outcome is a **logical all/partial/failed
-    per message**, not a single ack.
-  - `broadcast_fanout_age_seconds` = `now − evt.Timestamp` → SLO-2. **Good
+  - `messages_persisted_total{outcome}` (message-worker) → SLO-1a.
+  - `broadcast_channel_publish_total{outcome=ok|failed}` (broadcast-worker) →
+    SLO-1b. **A channel broadcast is a single room-subject publish, not a
+    per-recipient fan-out.** `publishChannelEvent` does one
+    `nc.PublishMsg(subject.RoomEvent(roomID), …)` and NATS fans out to subscribers
+    downstream (the code comment: *"one room-stream publish… reports the room
+    audience, not per-recipient deliveries"*). So the only channel outcome is
+    **`ok`/`failed` of that one publish** — there is **no `all/partial/failed`**.
+    **Core-NATS boundary:** `nc.PublishMsg` is fire-and-forget — a nil return
+    means *enqueued locally*, **not** server-acknowledged. Per-recipient
+    `all/partial/failed` exists only on the **DM/thread** paths (`publishDMEvents`
+    loops accounts with a `failed` count), which v1 does not score; those and the
+    true per-recipient *delivery* outcome are the **observational last mile**
+    (declared) / v2 (§8 P7).
+  - `broadcast_channel_publish_age_seconds` = `now − evt.Timestamp` → SLO-2. **Good
     predicate: age ≤ 1 s**; a publication later than the bound is **bad** (stays
     in valid, not counted good). `evt.Timestamp` is the canonical event's
     server-set timestamp (`gatekeeper handler.go`, `now.UnixMilli()`) →
-    "canonical acceptance → fan-out published".
+    "canonical acceptance → channel published".
 - **v1 scope: channel messages only.** DM/thread per-recipient partial-failure
-  semantics are deferred; SLO-1b/2 denominators count canonical **channel**
+  semantics are deferred; SLO-1b/2 count only `room_type="channel"` canonical
   messages in v1.
 - **Backstop (the real enforcement):** message-worker / broadcast-worker consumer
   lag (§8 P3). Because the counters are core-NATS/approximate, lag is the
@@ -256,6 +268,10 @@ provider retries and terminal delivery outcome live in the downstream
   `js.PublishMsg` returns durably, `emit.go`) — a *durable stream ack*, not a
   local enqueue, so unlike SLO-1b there is no core-NATS caveat here.
   `notifications_suppressed_total{reason}` stays diagnostic. §8 P4.
+  **Approximate:** the emitter discards the `PubAck` (`emit.go` ignores
+  `PubAck.Duplicate`), so a batch redelivery can double-count already-accepted
+  recipients. Exact once-per-recipient accounting waits on the outcome ledger
+  (§8 P7); until then SLO-6 is lag-backstopped like the other async ratios.
 - **Declared (not owned here) — notification delivery**: `delivered to provider
   within retry budget / recipients requested`, one terminal outcome per logical
   notification, retries not changing the unit. This must be emitted by
@@ -271,7 +287,9 @@ user was notified. No latency SLO in v1.
 **Journey.** `chat.user.{account}.request.search.{siteId}.*` → search-service
 → Elasticsearch.
 
-- **SLO-7 — availability**: `good = status=ok` / `valid = all search requests`.
+- **SLO-7 — availability**: `good = status=ok` / `valid = eligible search
+  requests` (4xx — malformed query, unauthorized — excluded per §0.1, never
+  counted good).
 - **SLO-8 — latency**: `good = successful search returns ≤ 1 s` /
   `valid = successful searches`. **Gated on success** so a fast failure can't
   improve the number.
@@ -319,11 +337,15 @@ the numerator → counted as a failure, not a missing sample.
   `MaxDeliver=-1` (retry forever — there is no exhaustion terminal event), and
   exact one-time forwarded accounting needs explicit dedup/Ack semantics not yet
   in place. So the ratio is deadline-based and approximate.
-- **Primary peer-down signal: oldest-pending age** — derived from **NATS
-  consumer state** (`num_pending` / oldest un-acked) via the JetStream exporter
-  (§8 P3), **not** a worker-emitted gauge, so it stays observable when
-  outbox-worker itself is down. This gauge is the enforced peer-down signal;
-  the forwarded-within-bound ratio is secondary.
+- **Primary peer-down signal: consumer backlog growth.** The standard JetStream
+  Prometheus exporter exposes `num_pending` / `num_ack_pending` and sequence
+  positions (ack-floor, delivered) — **not** a wall-clock age of the oldest
+  pending message. So v1 enforces peer-down on **pending / ack-pending growth**
+  from consumer state (observable even when outbox-worker is down, since it's
+  server-side). A true **oldest-pending-age** gauge requires a **custom monitor**
+  that resolves the timestamp of the earliest un-acked stream message (§8 P3) —
+  roadmap, not "free from the exporter". Either way the backlog signal is the
+  enforced peer-down indicator; the forwarded-within-bound ratio is secondary.
 
 **Caveats.**
 - **Budget isolated per `{origin_site, dest_site}`** — a dead peer burns only its
@@ -342,9 +364,10 @@ After calibration, alert on error-budget burn rate (multi-window, SRE Workbook
 ch.5) — well-defined because every SLO is an event ratio: **page** at 14.4× over
 1 h (+5 m), **page** at 6× over 6 h (+30 m), **ticket** at 1× over 3 d. Minimum
 sample size gates *alert confidence* only (don't page on a 1/2-event window), never
-budget inclusion. **NATS/JetStream consumer lag** (§8 P3) and **oldest-pending
-age** (§6) are the leading / outage-backstop indicators for the async SLOs
-(1a/1b/2/6/9).
+budget inclusion. **NATS/JetStream consumer backlog growth**
+(`num_pending`/`num_ack_pending`, §8 P3) — and, once the custom monitor lands,
+**oldest-pending age** (§6) — are the leading / outage-backstop indicators for
+the async SLOs (1a/1b/2/6/9).
 
 ---
 
@@ -357,10 +380,11 @@ required** (`sdk.Meter()` is exposed; search-service is the exemplar).
 |---|---|---|
 | P1 | `natsrouter` metrics middleware (`rpc_server_duration_seconds{subject_pattern, errcode_category}`) | SLO-4/5 + dashboards for all non-named RPCs |
 | P2 | J1 counters — gatekeeper `messages_canonical_published_total` (upstream denominator), message-worker persisted, broadcast-worker publications + publication-age; terminal-outcome/dedup semantics, no message-ID labels | SLO-1a/1b/2 |
-| P3 | NATS/JetStream Prometheus exporter (infra) — consumer lag **and** oldest-pending age from consumer state | outage backstop for 1a/1b/2/6/9 |
+| P3 | NATS/JetStream Prometheus exporter (infra) — consumer `num_pending`/`num_ack_pending` growth; **plus a custom monitor** to derive oldest-pending **age** (exporter alone doesn't expose it) | outage backstop for 1a/1b/2/6/9 |
 | P4 | notification-worker push-stream handoff (**recipient-granular** accepted/recipients) · **search duration `status` label** · outbox producer-side published + forwarded-within-bound (matching label sets) | SLO-6/8/9 |
 | P5 | Collector `spanmetrics` on frontend spans | observational last-mile & J2 client view |
-| P6 | Synthetic prober from `tools/loadgen` + SLO assertion mode (§10) | declared last-mile SLI; login→connect→initial-data; sparse-journey floor; SLO-aware load asserts |
+| P6 | **loadgen NATS-subscribe prober** (protocol receipt) + SLO assertion mode (§10) · login→connect→initial-data; sparse-journey floor; SLO-aware load asserts. **Render is out of scope here** — proves protocol receipt, not decrypt/render | protocol-receive last-mile SLI |
+| P6b | **browser synthetic / RUM** prober — decrypt/render/state-apply | render-level declared last mile |
 | P7 | v2: **exact outcome ledger** (dedup / first-write / exhaustion — makes 1a/1b/6/9 exact instead of approximate) · **push-service** provider delivery metrics (cross-repo) · correlated single-J1 outcome · search index freshness · member-add convergence · encrypted `key.get` · read-receipt convergence | — |
 
 ---
@@ -386,7 +410,7 @@ framework is reusable but does not yet assert against these SLOs:
 | SLO | loadgen coverage today | Gap to `ready` |
 |---|---|---|
 | SLO-1a | **partial** — soak read-back | per-message outcome accounting |
-| SLO-1b / 2 | **partial** — E2 stage correlation | per-endpoint all/partial/failed + channel scope |
+| SLO-1b / 2 | **partial** — E2 stage correlation | channel-scoped `ok`/`failed` + publish-age accounting (protocol-receipt, not render) |
 | SLO-4 / 5 | **near-ready** | per-endpoint `good within bound / eligible attempts` accounting |
 | SLO-3 (auth) | **missing** — auth is a stub | HTTP login driver |
 | SLO-7 / 8 (search) | **missing** | search workload |

--- a/docs/specs/o11y/o11y-slo.md
+++ b/docs/specs/o11y/o11y-slo.md
@@ -21,29 +21,44 @@ Google's CUJ methodology ([SRE Workbook](https://sre.google/workbook/implementin
 and how chat products measure themselves (Slack's
 [Service Delivery Index](https://slack.engineering/service-delivery-index-a-driver-for-reliability/)
 tracks *send a message* / *load a channel*, not services). Each journey
-section: **SLI specification** (user-language intent, good/valid ratio —
-written against real user experience even where not yet measurable) →
+section: **SLI specification** (user-language intent, good/valid ratio) →
 **SLO target** → **Measurement** (✅ computable today / 🔧 to build; the
 **enforcement** implementation is marked) → caveats.
 
 ### 0.1 Conventions
 
+- **Every SLI is a ratio**: `good events / valid events`. Availability SLIs
+  gate on success; latency SLIs gate on *success **and** completion within a
+  stated bound*. **Percentiles are diagnostic only, never SLO targets** — a raw
+  percentile over a window has no good/valid ratio, so error budgets and
+  burn-rate alerts (§7) cannot be computed from it. (A latency SLO is therefore
+  written as "X% of valid requests completed within the bound", not "p99 < B".)
 - **Window**: 28-day rolling, all SLOs.
-- **Ratio SLOs — time-slice accounting**: 5-minute slices; a slice is *good*
-  if ≥ the stated share of its valid events meet the criterion, or it has no
-  valid events. SLO = share of good slices. (Low off-peak traffic makes pure
-  event ratios unfair; same minutes-below-threshold model as Slack SDI.)
-- **Workflow SLIs combine success and speed** (*"completed successfully within
-  the bound"*) — to the user, a failure and a 10-second success are the same.
-- **Percentiles are chosen per SLI, not uniformly p99.** Criteria: how often a
-  user performs the action (frequent → p99), event volume (sparse data → p95
-  is statistically saner), and whether the tail *is* the signal (then p99 is
-  mandatory — e.g. federation, where the tail means a stuck peer).
-- **Rounding**: ratios ≥ 0.1% precision; latency bounds up to nearest 50 ms.
+- **Time-slice accounting**: the window is divided into **5-minute slices**.
+  - A slice with **≥ `MIN_SAMPLES` valid events** is **good** if ≥ the SLO's
+    stated share meet the SLI criterion, else **bad**.
+  - A slice with **< `MIN_SAMPLES` valid events** is **`insufficient_data`** —
+    **excluded from the denominator** (counts as neither good nor bad). It never
+    inflates compliance.
+  - **SLO = good_slices / (good_slices + bad_slices)** over the window.
+  - `MIN_SAMPLES` starts at **20** per 5-min slice (calibratable). Low-traffic
+    journeys (notifications, federation) will spend most slices in
+    `insufficient_data`; a scheduled **synthetic probe** (§8 P6) provides a
+    traffic floor so those journeys still accumulate signal.
+- **Rounding**: shares ≥ 0.1% precision; latency bounds up to nearest 50 ms.
 - **Scope: per site** — each site is its own failure domain and budget.
-  Federation (J5) is measured separately.
-- **Client errors never burn budget**: `errcode` categories other than
-  `internal`, and HTTP 4xx, are excluded from valid events.
+  Federation (J5) is measured separately and isolated by `{origin, dest}` site.
+- **Error-budget eligibility** — what counts as a *failed* valid event is
+  decided by whether the request was legitimate and *expected to succeed*, not
+  by wire category alone:
+
+  | `errcode` (server) / HTTP | Burns budget? | Why |
+  |---|---|---|
+  | `internal`, `unavailable`, `too_many_requests` (429), server-side timeout | **Yes** | our fault: bug, overload, capacity rejection |
+  | `bad_request`, `unauthenticated`, `forbidden`, `not_found`, `conflict` (4xx) | No | legitimate user/client outcome, not a reliability failure |
+
+  Excluded rows are removed from *valid events* entirely (not counted as
+  failures).
 
 ### 0.2 Calibration
 
@@ -54,10 +69,9 @@ All targets are **achievable-first starting values**. Run observationally for
 
 **This document is internal.** If numbers are ever published externally they
 become an SLA, which must be *derived*, not copied: one notch looser than the
-internal SLO (breach buffer — internal miss must not equal contractual
-breach), availability-focused (external latency-percentile commitments are
-rare industry-wide), with exclusions/remedies defined with business/legal, and
-only after calibration data exists. Never publish these numbers as-is.
+internal SLO, availability-focused, with exclusions/remedies defined with
+business/legal, and only after calibration data exists. Never publish these
+numbers as-is.
 
 ---
 
@@ -65,138 +79,167 @@ only after calibration data exists. Never publish these numbers as-is.
 
 | Rank | Journey | One-liner |
 |---|---|---|
-| J1 | **Send a message** | The product: accepted, durably stored, delivered in real time |
-| J2 | **Named interactive workflows** | Login, enter channel, enter thread — what users block on |
+| J1 | **Send a message** | Accepted, durably stored, published for real-time fan-out |
+| J2 | **Named interactive workflows** | Login, enter channel, enter thread |
 | J3 | **Notifications** | Offline users still learn about messages |
 | J4 | **Search** | Find rooms and messages |
 | J5 | **Federation** | Cross-site state converges quickly |
 
-All nine SLOs (targets are starting values, §0.2). Deliberately **out of
-scope**, in three tiers:
+Targets are starting values (§0.2). Interactive RPCs not named here (room
+create, member ops, uploads, …) are dashboard-monitored, **no SLO in v1**.
+Ephemeral signals (typing, presence) are best-effort by design — never SLO
+material; read receipts / unread badges → dashboard, v2 candidate (§8 P7).
 
-- **Dashboard-only interactive RPCs** (room create, member ops, uploads,
-  pins/reactions, …): monitored via the same instrumentation, no SLO in v1.
-- **Ephemeral signals — typing indicators, presence**: best-effort *by
-  design*; loss is invisible or self-heals. Under load these are the **first
-  traffic to shed** to protect J1. Never SLO material.
-- **Read receipts / unread badges**: persisted state users notice when wrong —
-  dashboard in v1, promoted to a v2 candidate (§8 P7: unread-badge
-  convergence).
+| # | Journey | SLI (good / valid) | Target | Today |
+|---|---|---|---|---|
+| SLO-1a | J1 | canonical message persisted to Cassandra / eligible canonical messages | 99.9% good slices | 🔧 P2 |
+| SLO-1b | J1 | broadcast publication accepted by NATS / eligible publications | 99.9% good slices | 🔧 P2 |
+| SLO-2 | J1 | publication accepted **within 1 s** of canonical acceptance / eligible publications | 99% good slices | 🔧 P2 |
+| SLO-3 | J2 | login succeeds within 1 s / login attempts | 99% in-slice · 99.9% slices | ✅ (auth leg — proxy) |
+| SLO-4 | J2 | channel load succeeds within 500 ms / channel loads | 95% in-slice · 99.9% slices | 🔧 P1 |
+| SLO-5 | J2 | thread open succeeds within 300 ms / thread opens | 99% in-slice · 99.9% slices | 🔧 P1 |
+| SLO-6 | J3 | notification handed to provider / notifications attempted | 99.5% good slices | 🔧 P4 |
+| SLO-7 | J4 | search returns ok / search requests | 99.5% good slices | ✅ |
+| SLO-8 | J4 | **successful** search returns within 1 s / **successful** searches | 95% in-slice · 99.9% slices | ✅ |
+| SLO-9 | J5 | outbox event forwarded to remote INBOX within 30 s / all outbox events | 99% good slices | 🔧 P4 |
 
-| # | Journey | SLI | Criterion | Target | Measurable today |
-|---|---|---|---|---|---|
-| SLO-1 | J1 | Delivery success | delivered ∧ persisted, per delivery | 99.9% of slices good | 🔧 P2 |
-| SLO-2 | J1 | E2E delivery latency | send → broadcast delivered | **p99** < 1 s | 🔧 P2 |
-| SLO-3 | J2 | Login (app entry) | success ≤ 1 s | 99% in-slice; 99.9% of slices | ✅ (auth leg) |
-| SLO-4 | J2 | Enter channel | success ≤ 500 ms | **95%** in-slice; 99.9% of slices | 🔧 P1 |
-| SLO-5 | J2 | Enter thread | success ≤ 300 ms | 99% in-slice; 99.9% of slices | 🔧 P1 |
-| SLO-6 | J3 | Notification delivery | handed to provider | 99.5% of slices good | 🔧 P4 |
-| SLO-7 | J4 | Search availability | status=ok | 99.5% of slices good | ✅ |
-| SLO-8 | J4 | Search latency | — | **p95** < 1 s | ✅ |
-| SLO-9 | J5 | Federation freshness | publish → forwarded to remote INBOX | **p99** < 30 s | 🔧 P4 |
+**Declared (not a numbered SLO):** *last-mile client receive/render* — the
+true user-perceived delivery. Observational only until a synthetic prober
+exists; enforcement candidate v2 (§8 P6). See §2.
 
-Percentile choices: SLO-2 p99 (high volume, tail = group-chat pain); SLO-4
-95% (bucket-walk tail is structural — start looser, tighten with data); SLO-5
-99% (single partition, no excuse); SLO-8 p95 (tolerant journey); SLO-9 p99
-(tail is the stuck-peer signal).
+Percentiles behind the bounds are kept as **diagnostic** signals on dashboards
+(e.g. p99 publication age, p95 search) but are not the SLO.
 
 ---
 
 ## 2. J1 — Send a message *(flagship)*
 
-**Journey.** User sends; every connected member sees it near-instantly; the
-message survives reloads. frontend → `MESSAGES` → gatekeeper →
-`MESSAGES_CANONICAL` → message-worker (Cassandra) + broadcast-worker (fan-out).
+**Journey.** User sends; the message is durably stored and published so every
+connected member can see it near-instantly. frontend → `MESSAGES` → gatekeeper
+→ `MESSAGES_CANONICAL` → **message-worker** (persist to Cassandra) **and**
+**broadcast-worker** (publish fan-out). The two workers consume
+`MESSAGES_CANONICAL` **independently and in parallel** — there is no
+persisted-then-published ordering.
 
-**SLIs.**
-- **SLI 1 — Delivery success**: `good = delivery published ∧ message
-  persisted` / `valid = accepted messages × recipients at broadcast time`.
-  Broadcast-but-not-persisted counts as failure — integrity is non-negotiable
-  in chat (cf. [Ably's Four Pillars](https://ably.com/four-pillars-of-dependability)).
-- **SLI 2 — E2E delivery latency**: spec is sender-hits-enter → recipient
-  renders.
+### Why J1 is split (not one "delivery success")
 
-**Measurement.**
-- ✅ Today: nothing — J1 is *specified but not enforceable* (top roadmap item).
-- 🔧 **Server-side (enforcement, v1)** — per-service `metrics.go`, copying the
-  data-migration counter pattern:
+A single "delivered ∧ persisted" SLI **cannot be computed** from independent
+Prometheus counters: they can't be joined by message ID (and message ID must
+never be a metric label — unbounded cardinality), and the two outcomes land in
+different slices. So J1 is measured as **two independent ratios plus a latency
+ratio**, each with its own denominator and budget. They are **not** combined
+into an overall "delivery" number — that would still not prove the same message
+did both. A single correlated J1 budget is deferred to v2 (§8 P7) and, if built,
+must mean `persisted AND publication observed within bound` — never implying an
+ordering the architecture doesn't guarantee.
+
+### Delivery is layered — name each layer honestly
+
+| Layer | What it means | Status |
+|---|---|---|
+| **North-star / declared** | recipient received & rendered within bound | declared SLI, observational |
+| **Enforced v1** | SLO-1a persistence + SLO-1b/SLO-2 broadcast publication | this doc |
+| **Observational v1.5** | frontend receive-span telemetry (spanmetrics) | §8 P5 |
+| **Enforcement candidate v2** | synthetic prober — true last mile | §8 P6 |
+
+A NATS PubAck is **not** delivery: dashboards can read green while a recipient
+receives nothing. v1 therefore commits only to persistence + publication and
+names them as such.
+
+### SLIs & targets — see §1 (SLO-1a / 1b / 2)
+
+- **SLO-1a — Message persistence success**: `good = canonical message written
+  to Cassandra` / `valid = eligible canonical messages`.
+- **SLO-1b — Broadcast publication success**: `good = fan-out publication
+  accepted by NATS` / `valid = eligible broadcast publications`.
+- **SLO-2 — Broadcast publication latency**: `good = publication accepted ≤ 1 s
+  after canonical acceptance` / same denominator as 1b. Measured
+  `now − canonicalEvent.Timestamp` at the publish site — the canonical event's
+  server-set timestamp (`gatekeeper handler.go`, `now.UnixMilli()`), read by
+  broadcast-worker as `evt.Timestamp`. Both ends are same-site server clocks.
+
+### Measurement
+
+- ✅ Today: nothing — specified but not enforceable (top roadmap item).
+- 🔧 **Enforcement, v1** — per-service `metrics.go` (copy the search-service /
+  data-migration pattern; `sdk.Meter()` already exposed, **no SDK change**):
 
 | Instrument | Where |
 |---|---|
 | `messages_validated_total` / `messages_rejected_total{reason}` | message-gatekeeper |
-| `deliveries_total{outcome}` + `fanout_size` histogram | broadcast-worker |
-| `messages_persisted_total{outcome}` | message-worker |
-| `message_e2e_delivery_seconds` (= `now − event.Timestamp` at publish) | broadcast-worker |
+| `messages_persisted_total{outcome}` | message-worker → SLO-1a |
+| `broadcast_publications_total{outcome}` | broadcast-worker → SLO-1b |
+| `broadcast_publication_age_seconds` (`now − evt.Timestamp`) | broadcast-worker → SLO-2 |
 
-- 🔧 Client-side (observational, v1.5): collector `spanmetrics` over existing
-  frontend spans — zero frontend change; needs 100% sampling, untrusted
-  browser clocks.
-- 🔧 Synthetic prober (v2): resident canary from `tools/loadgen`; covers the
-  true last mile; candidate enforcement source for SLO-2.
+- 🔧 Observational v1.5 / v2: frontend spanmetrics (§8 P5), synthetic prober
+  (§8 P6) — feed the *declared* last-mile SLI.
 
-**Caveats.**
-- Denominator is **per delivery**, not per message — a 500-member room failure
-  weighs 500× (big-room incidents must not average away).
-- v1 measures to broadcast publish, not client render; gap tracked (§8 P6).
-- Clock skew (same-site NTP ≲10 ms) is negligible vs a 1 s bound.
+### Caveats
+
+- **A publication is one publish to a room subject, not N recipient
+  deliveries.** `UserCount` is not connected-recipient count. v1 denominators
+  are *messages / publications*, not recipients — do not read SLO-1b as
+  "everyone received it".
 - Ordering is not an SLO (JetStream orders within a stream only).
+- `eligible` excludes gatekeeper-rejected messages per §0.1.
 
 ---
 
 ## 3. J2 — Named interactive workflows
 
-The three synchronous interactions users block on, each a named workflow
-(Slack-SDI style); SLI = *completed successfully within the bound* (§0.1).
+Three synchronous interactions users block on; each SLI = *completed
+successfully within the bound* (§0.1).
 
 | Workflow | Path (verified in code) |
 |---|---|
-| **Login (app entry)** | `POST /api/v1/auth` (auth-service) → NATS connect → initial data (`subscription.list`, `rooms.get`) |
-| **Enter channel** | `msg.history` → history-service `LoadHistory`: 2 concurrent Mongo reads → Cassandra `messages_by_room`, **bucket-walk** (`cassrepo/walker.go`). `markRoomRead` / `key.get` follow, non-blocking |
+| **Login** | `POST /api/v1/auth` (auth-service) → NATS connect → initial data (`subscription.list`, `rooms.get`) |
+| **Enter channel** | `msg.history` → history-service `LoadHistory`: 2 concurrent Mongo reads → Cassandra `messages_by_room`, **bucket-walk** (`cassrepo/walker.go`) |
 | **Enter thread** | `msg.thread` → `GetThreadMessages`: **single partition** `thread_messages_by_thread`, no walk |
 
-Separate bounds because the cost models differ: channel loads walk an
-open-ended number of 72 h buckets (idle rooms walk further); thread loads are
-one partition slice.
+Separate bounds because the cost models differ (open-ended bucket walk vs one
+partition slice). Targets: §1 (SLO-3/4/5).
 
-**SLIs.** Login attempts / channel loads / thread opens completing
-successfully within the bound (bad credentials etc. are not valid events).
-Targets: see §1 table (SLO-3/4/5).
+### Measurement
 
-**Measurement.**
-- ✅ Login: auth-service `http.server.request.duration` — enforceable today
-  (`status<500 ∧ duration ≤ 1s`; verify series/label names on a live `:2112`).
-- 🔧 Channel/thread: blocked on the `natsrouter` metrics middleware (§8 P1) —
-  `rpc_server_duration_seconds{subject_pattern, errcode_category}`; the
-  `subject_pattern` label slices both workflows out of one middleware.
-- 🔧 Client-side v1.5: same spanmetrics route as J1.
+- ✅ **Login — auth leg only (proxy).** auth-service
+  `http.server.request.duration` gives `good = status<500 ∧ ≤ 1s`. This is a
+  **proxy** for the declared app-entry journey (auth → connect → initial data);
+  the connect + initial-data legs are client-side, added via prober/spanmetrics
+  (v2). SLO-3 is labelled proxy until then.
+- 🔧 **Enter channel / thread** — blocked on the `natsrouter` metrics
+  middleware (§8 P1): `rpc_server_duration_seconds{subject_pattern,
+  errcode_category}`; the `subject_pattern` label slices both workflows from one
+  middleware. Budget eligibility per the §0.1 errcode table.
+- 🔧 Client-side v1.5: spanmetrics.
 
-**Caveats.**
-- Bucket-walk tail is structural: if calibration shows p99 dominated by walk
-  depth, add a walk-depth metric / tune `MESSAGE_BUCKET_HOURS` — don't loosen
-  the SLO.
-- **App entry ≠ client cold start.** The SLO-3 spec covers the *backend legs*
-  of entering the app (auth → connect → initial data). v1 measures the auth
-  HTTP leg; the `subscription.list` / `rooms.get` legs join under the same SLO
-  once P1 lands. Full cold start (bundle download, JS boot, render/TTI)
-  depends on device and network the backend cannot fix — it is a **client-side
-  product performance metric** (P5 RUM), not a backend SLO.
+### Caveats
+
+- **Bucket-walk tail is structural**: a long-idle room's first load walks more
+  buckets. If calibration shows the SLO-4 miss rate dominated by walk depth, add
+  a walk-depth metric / tune `MESSAGE_BUCKET_HOURS` — don't loosen the SLO.
 - Encrypted-room `key.get` failure is user-visible — v2 SLI candidate (§8 P7).
 
 ---
 
 ## 4. J3 — Notifications
 
-**Journey.** Message arrives for an offline/away member → notification-worker
-→ push provider.
+**Journey.** Message arrives for an offline/away member → notification-worker →
+push provider.
 
-**SLI 6**: `good = push handed to provider` / `valid = attempts`
-(policy-suppressed — mutes, quiet hours — are not valid events). Target: §1.
+**SLI 6.** `good = notification successfully handed to the provider` /
+`valid = notifications attempted`. Explicit instrument contract:
 
-**Measurement.** ✅ nothing today; 🔧 `notifications_sent_total` /
-`_failed_total{reason}` / `_suppressed_total{reason}` (§8 P4).
+| Instrument | Meaning |
+|---|---|
+| `notifications_attempted_total` | **denominator** — one per provider hand-off attempt, **including retries** (each retry is a new attempt); **excludes** policy-suppressed |
+| `notifications_sent_total` | successful provider hand-offs (the numerator) |
+| `notifications_failed_total{reason}` | unsuccessful attempts, by reason |
+| `notifications_suppressed_total{reason}` | policy-suppressed (mutes, quiet hours) — **not** valid events |
 
-**Caveat.** Measures to provider hand-off; provider→device is out of scope.
-No latency SLO in v1.
+Target: §1 (SLO-6). §8 P4.
+
+**Caveat.** Measures to provider hand-off; provider→device is out of scope. No
+latency SLO in v1.
 
 ---
 
@@ -205,13 +248,15 @@ No latency SLO in v1.
 **Journey.** `chat.user.{account}.request.search.{siteId}.*` → search-service
 → Elasticsearch.
 
-**SLI 7 / SLI 8**: ok-response ratio; fast-response ratio. Targets: §1.
+- **SLO-7 — availability**: `good = status=ok` / `valid = all search requests`.
+- **SLO-8 — latency**: `good = successful search returns ≤ 1 s` /
+  `valid = **successful** searches`. **Latency is gated on success** so a fast
+  failure cannot improve the number (an ungated p95 rewards fast-failing).
 
-**Measurement.** ✅ Fully measurable today:
-`search_service_requests_total{type,status}`,
-`search_service_request_duration_seconds` (`…es_duration_seconds` is
-diagnostic, not an SLI). Availability and latency stay separate here (existing
-counters/histogram don't share labels; merging isn't worth re-instrumenting).
+**Measurement.** ✅ Fully measurable today: `search_service_requests_total
+{type,status}`, `search_service_request_duration_seconds`
+(`…es_duration_seconds` is diagnostic). The duration histogram needs a
+`status`/outcome label to gate SLO-8; add if absent.
 
 **Caveat.** Index freshness (how fast a new message becomes searchable) is
 deliberately out of v1 — §8 P7.
@@ -223,44 +268,55 @@ deliberately out of v1 — §8 P7.
 **Journey.** Cross-site events converge site A → site B via `OUTBOX` →
 outbox-worker → remote `INBOX` → inbox-worker.
 
-**SLI 9 — Federation freshness**: `good = forwarded to destination INBOX
-within threshold of publish time` / `valid = all outbox events`. Target: §1.
+**SLO-9 — Federation forward freshness**: `good = outbox event forwarded to the
+destination INBOX within 30 s of its publish time` / `valid = all outbox
+events`. Framed as a **ratio, not a p99**, so an event that is **never**
+forwarded (a stuck peer) counts as a failure in the denominator instead of
+silently producing no sample.
 
-**Measurement.** ✅ nothing today; 🔧 `outbox_forward_age_seconds{dest_site,
-event_type}` (both timestamps on the origin site — no cross-site skew) +
-`outbox_forwarded_total` / `outbox_retries_total{dest_site}` (§8 P4).
+**Measurement.** ✅ nothing today; 🔧 in outbox-worker (§8 P4):
+`outbox_forwarded_total{dest_site, event_type}` gated on age ≤ bound,
+`outbox_events_total{dest_site, event_type}` (denominator),
+`outbox_retries_total{dest_site}`. Age = `now − event.Timestamp`, both
+timestamps on the origin site (no cross-site clock skew). A companion
+`outbox_forward_age_seconds` histogram is kept diagnostic.
 
 **Caveats.**
-- v1 measures origin-side (publish → forwarded); remote apply is a v2
-  refinement (cross-site clock skew).
-- Per-destination: a dead peer burns only its own destination's budget (its
-  FIFO lane parks with `MaxAckPending=1`); forward-age p99 doubles as the
-  peer-down alert signal.
+- **Budget isolated per `{origin_site, dest_site}`** — a dead peer burns only
+  its own lane's budget (its FIFO parks with `MaxAckPending=1`), and the
+  per-destination forward-success ratio is the primary peer-down alert signal.
+- v1 covers the **OUTBOX relay only** (origin publish → forwarded). It does not
+  cover direct-INBOX publication paths or remote *apply* by inbox-worker; those
+  are v2 refinements (remote apply adds cross-site clock skew).
 - `member_added` rides this pipeline — the cross-site half of member-change
-  convergence is covered here; same-site half is v2 (§8 P7).
+  convergence is covered; same-site half is v2 (§8 P7).
 
 ---
 
 ## 7. Alerting — burn rate, not thresholds
 
-After calibration, alert on error-budget burn rate (multi-window, SRE
-Workbook ch.5): **page** at 14.4× over 1 h (+5 m), **page** at 6× over 6 h
-(+30 m), **ticket** at 1× over 3 d. NATS/JetStream consumer lag (§8 P3) is the
-leading indicator for SLO-1/2/6/9 — alert on lag growth before budget burns.
+After calibration, alert on error-budget burn rate (multi-window, SRE Workbook
+ch.5), now well-defined because every SLO is a good/valid ratio: **page** at
+14.4× over 1 h (+5 m), **page** at 6× over 6 h (+30 m), **ticket** at 1× over
+3 d. NATS/JetStream consumer lag (§8 P3) is the leading indicator for
+SLO-1a/1b/2/6/9 — alert on lag growth before budget burns.
 
 ---
 
 ## 8. Measurement roadmap
 
+All items land in `newchat` (app code) or infra — **no flywindy/o11y SDK change
+required** (`sdk.Meter()` is exposed; search-service is the working exemplar).
+
 | P | Work | Unlocks |
 |---|---|---|
 | P1 | `natsrouter` metrics middleware (`rpc_server_duration_seconds{subject_pattern, errcode_category}`) | SLO-4/5 + dashboards for all non-named RPCs |
-| P2 | J1 counters + `message_e2e_delivery_seconds` (gatekeeper / broadcast / message-worker) | SLO-1/2 |
+| P2 | J1 counters: persisted / publications / publication-age (gatekeeper, message-worker, broadcast-worker) — no message-ID labels | SLO-1a/1b/2 |
 | P3 | NATS/JetStream Prometheus exporter (infra) | consumer-lag leading indicator |
-| P4 | notification-worker + outbox-worker instruments | SLO-6/9 |
-| P5 | Collector `spanmetrics` on frontend spans | client-side observational SLIs |
-| P6 | Synthetic prober from `tools/loadgen` | last-mile SLO-2; full login→connect |
-| P7 | v2 candidates: search index freshness · member-add convergence (invite → subscription + room key; cross-site half already under SLO-9) · encrypted `key.get` success · unread-badge / read-receipt convergence | — |
+| P4 | notification-worker (attempted/sent/failed/suppressed) + outbox-worker (forwarded-within-bound / events / retries) | SLO-6/9 |
+| P5 | Collector `spanmetrics` on frontend spans | observational last-mile & J2 (client view) |
+| P6 | Synthetic prober from `tools/loadgen` | declared last-mile SLI; full login→connect→initial-data |
+| P7 | v2 candidates: correlated single-J1 outcome (`persisted AND published within bound`) · search index freshness · member-add convergence · encrypted `key.get` success · unread-badge / read-receipt convergence | — |
 
 ---
 
@@ -278,12 +334,12 @@ These SLOs are the **acceptance criteria** for load tests; *capacity* = the
 load at which an SLO first breaks. The client surface is NATS (long-lived,
 stateful, bidirectional), so the driver is `tools/loadgen` (already asserts
 per-stage P95/P99 in `attribution.go`, tracks consumer lag) — not k6, whose
-VU/request model can't express cross-connection E2E delivery; k6 fits the
-pure-HTTP workflows only.
+VU/request model can't express cross-connection delivery; k6 fits the pure-HTTP
+workflows only.
 
 | Scenario | Driver | Validates |
 |---|---|---|
-| Message pipeline, fan-out matrix (room sizes × rate ladder) | `loadgen` | SLO-1/2 |
+| Message pipeline, fan-out matrix (room sizes × rate ladder) | `loadgen` | SLO-1a/1b/2 |
 | Channel-load storm incl. cold/idle-room fixtures | `loadgen history` | SLO-4 |
 | Thread-open storm | `loadgen thread` | SLO-5 |
 | Login surge | k6 or simple HTTP driver | SLO-3 |
@@ -292,10 +348,9 @@ pure-HTTP workflows only.
 
 Rules: assert at ~50–70% of the prod bound (lab margin) · loadgen thresholds
 must track this document (drift = bug) · run with `O11Y_ENABLED=true` and read
-SLIs from the same recording rules as prod (loadgen itself uses a noop
-tracer) · once per release, run master-switch on vs off to re-verify the
-overhead claims.
+SLIs from the same recording rules as prod (loadgen itself uses a noop tracer) ·
+once per release, run master-switch on vs off to re-verify the overhead claims.
 
-Known gaps: federation scenario (per-peer FIFO isolation never
-load-verified); loadgen bypasses the WebSocket/browser leg (P6 prober should
-share its client code).
+Known gaps: federation scenario (per-peer FIFO isolation never load-verified);
+loadgen bypasses the WebSocket/browser leg (P6 prober should share its client
+code).

--- a/docs/specs/o11y/o11y-slo.md
+++ b/docs/specs/o11y/o11y-slo.md
@@ -325,14 +325,17 @@ the numerator → counted as a failure, not a missing sample.
 
 ### Outage-safe contract
 
-- **Denominator: `outbox_events_published_total{dest_site, event_type}`**, emitted
-  **producer-side** (room-service / room-worker at OUTBOX publish) — upstream of
-  outbox-worker, so worker downtime can't suppress it.
-- **Numerator: forwarded within bound** — `outbox_forwarded_total{dest_site,
-  event_type}` gated on age ≤ bound. **Same label set as the denominator** so the
-  ratio is `sum by(dest_site)(forwarded_within_bound) / sum by(dest_site)(published)`
-  — event_type is carried for slicing and aggregated away for the SLO. Age =
-  `now − event.Timestamp`, both timestamps origin-side (no cross-site skew).
+- **Denominator: `outbox_events_published_total{origin_site, dest_site, event_type}`**,
+  emitted **producer-side** (room-service / room-worker at OUTBOX publish) —
+  upstream of outbox-worker, so worker downtime can't suppress it.
+- **Numerator: forwarded within bound** — `outbox_forwarded_total{origin_site,
+  dest_site, event_type}` gated on age ≤ bound. **Same label set as the
+  denominator** so the ratio is
+  `sum by(origin_site, dest_site)(forwarded_within_bound) / sum by(origin_site, dest_site)(published)`
+  — `origin_site`+`dest_site` keep the budget isolated **per peer pair** (a busy
+  or failing origin can't dilute another's), `event_type` is carried for slicing
+  and aggregated away for the SLO. Age = `now − event.Timestamp`, both timestamps
+  origin-side (no cross-site skew).
   **Approximate:** outbox consumers use
   `MaxDeliver=-1` (retry forever — there is no exhaustion terminal event), and
   exact one-time forwarded accounting needs explicit dedup/Ack semantics not yet

--- a/docs/specs/o11y/o11y-slo.md
+++ b/docs/specs/o11y/o11y-slo.md
@@ -54,7 +54,8 @@ section: **SLI specification** (user-language intent, good/valid ratio) →
   per attempt — deduped at the emit site (never a message-ID label). Two distinct
   terminal **failures** exist and must be counted separately: an explicit
   **permanent poison drop** (`errcode.Permanent` → Ack-and-drop, no retry) and
-  **`MaxDeliver` exhaustion** (Nak-retried until the delivery cap, then parked/dropped).
+  **`MaxDeliver` exhaustion** (Nak-retried until the delivery cap; delivery then
+  stops and a max-delivery advisory fires — the message is not deleted, see below).
 - **v1 accounting is approximate where the code can't yet emit that contract.**
   Today the pipeline lacks the hooks for exact one-outcome accounting: gatekeeper
   ignores `PubAck.Duplicate`, Cassandra's idempotent inserts don't flag the first
@@ -67,7 +68,11 @@ section: **SLI specification** (user-language intent, good/valid ratio) →
 - **Rounding**: shares ≥ 0.1% precision; latency bounds up to nearest 50 ms.
 - **Scope: per site**; federation (J5) isolated by `{origin, dest}` site.
 - **Error-budget eligibility** — a *failed valid event* is judged by whether the
-  request was legitimate and *expected to succeed*, not by wire category alone:
+  request was legitimate and *expected to succeed*, not by wire category alone.
+  (`MaxDeliver` exhaustion does **not** delete the message — JetStream stops
+  redelivering it to that consumer, emits a max-delivery advisory, and the
+  message stays in the stream; exact terminal-failure accounting therefore needs
+  an **advisory consumer**, §8 P7, not just a `jsretry` hook.)
 
   | `errcode` / HTTP | Burns budget? | Why |
   |---|---|---|
@@ -107,8 +112,8 @@ material; read receipts / unread badges → dashboard, v2 candidate (§8 P7).
 | # | Journey | SLI = good / valid | Target | Today |
 |---|---|---|---|---|
 | SLO-1a | J1 | canonical message persisted to Cassandra / **canonical messages published** | 99.9% | 🔧 P2 · approximate (lag-enforced) |
-| SLO-1b | J1 | **channel** room-subject broadcast published ok (single publish) / **canonical channel messages published** (`room_type=channel`) | 99.9% | 🔧 P2 · approximate · core-NATS boundary |
-| SLO-2 | J1 | channel broadcast published **within 1 s** of canonical acceptance (late = bad) / canonical channel messages published (`room_type=channel`) | 99% | 🔧 P2 · approximate |
+| SLO-1b | J1 | **channel** room-subject broadcast published ok (single publish) / **canonical messages routed to the room-subject path** (`broadcast_path=room_subject`) | 99.9% | 🔧 P2 · approximate · core-NATS boundary |
+| SLO-2 | J1 | room-subject broadcast published **within 1 s** of canonical acceptance (late = bad) / canonical messages on the room-subject path (`broadcast_path=room_subject`) | 99% | 🔧 P2 · approximate |
 | SLO-3 | J2 | successful login **within 1 s** / eligible login attempts | 99% | ✅ (auth leg — proxy) |
 | SLO-4 | J2 | channel load succeeds **within 500 ms** / eligible channel loads | 95% | 🔧 P1 |
 | SLO-5 | J2 | thread open succeeds **within 300 ms** / eligible thread opens | 99% | 🔧 P1 |
@@ -159,12 +164,21 @@ a protocol-receive prober (loadgen) and a render prober (browser) — neither is
 
 ### Denominator & outcome contract
 
-- **Denominators, `room_type`-scoped:** `messages_canonical_published_total{room_type}`,
+- **Denominators, `broadcast_path`-scoped:** `messages_canonical_published_total{broadcast_path}`,
   emitted by **message-gatekeeper** at the canonical publish site — upstream of
-  both workers, so a dead worker drops the ratio instead of vanishing.
-  - **SLO-1a** uses the **all-`room_type` total** (persistence covers every message).
-  - **SLO-1b/2** use the **`room_type="channel"` slice only** — v1 excludes
-    DM/thread (see below), so an unfiltered denominator would understate the ratio.
+  both workers, so a dead worker drops the ratio instead of vanishing. The label
+  is the **fan-out route**, not the room type — `room_subject` | `thread` | `dm`,
+  classified to mirror broadcast-worker's dispatch exactly: `shouldUseThreadFanOut`
+  (`ThreadParentMessageID != "" && !TShow`) → `thread` **first**, else channel →
+  `room_subject`, else DM/BotDM → `dm`. This matters because a **channel thread
+  reply** (`TShow=false`) is a channel room yet routes to per-account thread
+  fan-out, **not** `publishChannelEvent` — a `room_type="channel"` denominator
+  would count it while no `broadcast_channel_publish_total` fires, wrongly
+  depressing SLO-1b/2. (gatekeeper resolves room type at the emit site to set the
+  label; `thread`/`dm` slices are v1-unscored.)
+  - **SLO-1a** uses the **all-`broadcast_path` total** (persistence covers every message).
+  - **SLO-1b/2** use the **`broadcast_path="room_subject"` slice only** — v1
+    excludes the `thread`/`dm` routes (see below).
 - **Numerators**, one outcome per logical message (approximate — see §0.1):
   - `messages_persisted_total{outcome}` (message-worker) → SLO-1a.
   - `broadcast_channel_publish_total{outcome=ok|failed}` (broadcast-worker) →
@@ -185,9 +199,11 @@ a protocol-receive prober (loadgen) and a render prober (browser) — neither is
     in valid, not counted good). `evt.Timestamp` is the canonical event's
     server-set timestamp (`gatekeeper handler.go`, `now.UnixMilli()`) →
     "canonical acceptance → channel published".
-- **v1 scope: channel messages only.** DM/thread per-recipient partial-failure
-  semantics are deferred; SLO-1b/2 count only `room_type="channel"` canonical
-  messages in v1.
+- **v1 scope: the room-subject path only.** DM/thread per-recipient
+  partial-failure semantics are deferred; SLO-1b/2 count only
+  `broadcast_path="room_subject"` canonical messages in v1 (channel non-thread
+  sends), so channel thread replies routed to thread fan-out are excluded from
+  both numerator and denominator.
 - **Backstop (the real enforcement):** message-worker / broadcast-worker consumer
   lag (§8 P3). Because the counters are core-NATS/approximate, lag is the
   primary stalled-worker signal; the ratios are secondary.
@@ -295,11 +311,13 @@ user was notified. No latency SLO in v1.
   improve the number.
 
 **Measurement.** ✅ SLO-7 for **partial/elevated failures**
-(`search_service_requests_total{type,status}` — the ratio catches error responses
-while traffic flows). 🔧 **SLO-8 is not measurable yet**:
-`search_service_request_duration_seconds` has no status/outcome label, so
-successful requests can't be isolated — add that label (§8 P4) before enforcing
-SLO-8. `…es_duration_seconds` stays diagnostic.
+(`search_service_requests_total{kind,status}` — note the endpoint label is
+`kind`, not `type`; the ratio catches error responses while traffic flows).
+🔧 **SLO-8 is not measurable yet**: the duration histogram
+(`search_service_request_duration_seconds`) currently carries only `{kind}`, **no
+`status`**, so successful requests can't be isolated — add `status` (giving
+`{kind,status}`, §8 P4) before enforcing SLO-8. The unlabelled duration stays
+diagnostic.
 
 **Caveats.**
 - **Full-outage blind spot.** The denominator is search-service-local, so a total
@@ -340,15 +358,21 @@ the numerator → counted as a failure, not a missing sample.
   `MaxDeliver=-1` (retry forever — there is no exhaustion terminal event), and
   exact one-time forwarded accounting needs explicit dedup/Ack semantics not yet
   in place. So the ratio is deadline-based and approximate.
-- **Primary peer-down signal: consumer backlog growth.** The standard JetStream
-  Prometheus exporter exposes `num_pending` / `num_ack_pending` and sequence
-  positions (ack-floor, delivered) — **not** a wall-clock age of the oldest
-  pending message. So v1 enforces peer-down on **pending / ack-pending growth**
-  from consumer state (observable even when outbox-worker is down, since it's
+- **Primary peer-down signal: a *stalled* backlog, not a growing one.** The
+  standard JetStream Prometheus exporter exposes `num_pending` / `num_ack_pending`
+  and sequence positions (ack-floor, delivered) — **not** a wall-clock age of the
+  oldest pending message. Growth alone is insufficient: a peer that goes down with
+  a **single** parked event shows `num_ack_pending=1` and then no further growth,
+  yet the event is stuck forever. So v1 enforces on **sustained non-zero
+  `num_pending + num_ack_pending` while the ack-floor does not advance** over the
+  same window (observable even when outbox-worker is down, since it's
   server-side). A true **oldest-pending-age** gauge requires a **custom monitor**
-  that resolves the timestamp of the earliest un-acked stream message (§8 P3) —
-  roadmap, not "free from the exporter". Either way the backlog signal is the
-  enforced peer-down indicator; the forwarded-within-bound ratio is secondary.
+  that resolves the timestamp of the earliest un-acked stream message (§8 P3) and,
+  once it lands, becomes the primary signal — roadmap, not "free from the
+  exporter". Either way this backlog/age signal is the enforced peer-down
+  indicator; the forwarded-within-bound ratio is secondary — and note the ratio
+  only holds a never-forwarded event as a failure **while it is inside the 28-day
+  window**; past that it rolls off, so the backlog/age signal is what stays.
 
 **Caveats.**
 - **Budget isolated per `{origin_site, dest_site}`** — a dead peer burns only its
@@ -367,10 +391,10 @@ After calibration, alert on error-budget burn rate (multi-window, SRE Workbook
 ch.5) — well-defined because every SLO is an event ratio: **page** at 14.4× over
 1 h (+5 m), **page** at 6× over 6 h (+30 m), **ticket** at 1× over 3 d. Minimum
 sample size gates *alert confidence* only (don't page on a 1/2-event window), never
-budget inclusion. **NATS/JetStream consumer backlog growth**
-(`num_pending`/`num_ack_pending`, §8 P3) — and, once the custom monitor lands,
-**oldest-pending age** (§6) — are the leading / outage-backstop indicators for
-the async SLOs (1a/1b/2/6/9).
+budget inclusion. A **stalled JetStream backlog** (sustained non-zero
+`num_pending`/`num_ack_pending` with a non-advancing ack-floor, §8 P3) — and,
+once the custom monitor lands, **oldest-pending age** (§6) — are the leading /
+outage-backstop indicators for the async SLOs (1a/1b/2/6/9).
 
 ---
 
@@ -383,12 +407,12 @@ required** (`sdk.Meter()` is exposed; search-service is the exemplar).
 |---|---|---|
 | P1 | `natsrouter` metrics middleware (`rpc_server_duration_seconds{subject_pattern, errcode_category}`) | SLO-4/5 + dashboards for all non-named RPCs |
 | P2 | J1 counters — gatekeeper `messages_canonical_published_total` (upstream denominator), message-worker persisted, broadcast-worker publications + publication-age; terminal-outcome/dedup semantics, no message-ID labels | SLO-1a/1b/2 |
-| P3 | NATS/JetStream Prometheus exporter (infra) — consumer `num_pending`/`num_ack_pending` growth; **plus a custom monitor** to derive oldest-pending **age** (exporter alone doesn't expose it) | outage backstop for 1a/1b/2/6/9 |
-| P4 | notification-worker push-stream handoff (**recipient-granular** accepted/recipients) · **search duration `status` label** · outbox producer-side published + forwarded-within-bound (matching label sets) | SLO-6/8/9 |
+| P3 | NATS/JetStream Prometheus exporter (infra) — consumer `num_pending`/`num_ack_pending` + ack-floor (stalled-backlog signal); **plus a custom monitor** to derive oldest-pending **age** (exporter alone doesn't expose it) | outage backstop for 1a/1b/2/6/9 |
+| P4 | notification-worker push-stream handoff (**recipient-granular** accepted/recipients) · **search duration `status` label** (→ `{kind,status}`) · outbox producer-side published + forwarded-within-bound (matching label sets) | SLO-6/8/9 |
 | P5 | Collector `spanmetrics` on frontend spans | observational last-mile & J2 client view |
 | P6 | **loadgen NATS-subscribe prober** (protocol receipt) + SLO assertion mode (§10) · login→connect→initial-data; sparse-journey floor; SLO-aware load asserts. **Render is out of scope here** — proves protocol receipt, not decrypt/render | protocol-receive last-mile SLI |
 | P6b | **browser synthetic / RUM** prober — decrypt/render/state-apply | render-level declared last mile |
-| P7 | v2: **exact outcome ledger** (dedup / first-write / exhaustion — makes 1a/1b/6/9 exact instead of approximate) · **push-service** provider delivery metrics (cross-repo) · correlated single-J1 outcome · search index freshness · member-add convergence · encrypted `key.get` · read-receipt convergence | — |
+| P7 | v2: **exact outcome ledger** (dedup / first-write / exhaustion via a max-delivery **advisory consumer** — makes 1a/1b/6/9 exact instead of approximate) · **push-service** provider delivery metrics (cross-repo) · correlated single-J1 outcome · search index freshness · member-add convergence · encrypted `key.get` · read-receipt convergence | — |
 
 ---
 
@@ -417,7 +441,7 @@ framework is reusable but does not yet assert against these SLOs:
 | SLO-4 / 5 | **near-ready** | per-endpoint `good within bound / eligible attempts` accounting |
 | SLO-3 (auth) | **missing** — auth is a stub | HTTP login driver |
 | SLO-7 / 8 (search) | **missing** | search workload |
-| SLO-6 (push) | **missing** | provider/push workload |
+| SLO-6 (push) | **missing** | `PUSH_NOTIFICATION` observer + recipient-level correlation/accounting (provider workload is push-service v2, not this boundary) |
 | SLO-9 (federation) | **missing** — single-site only | multi-site + peer-down/recovery |
 
 Today loadgen's message max-RPS mode **excludes missing replies/broadcasts from
@@ -428,10 +452,23 @@ service recording rules or a NATS exporter.
 **Required before "validates":** an **SLO assertion mode** that counts
 `eligible`, `good`, and `missing-after-deadline` events (so a dropped
 reply/broadcast is a failure, not an excluded sample) and reads SLIs from the
-**same production recording rules**, not loadgen-local metrics. Rules: assert at
-~50–70% of the prod bound (lab margin); thresholds track this document (drift =
-bug); run with `O11Y_ENABLED=true`; once per release, run master-switch on vs off
-to re-verify overhead.
+**same production recording rules**, not loadgen-local metrics.
+
+Two distinct thresholds, not one (the "50–70%" and "track this document" rules
+were in tension):
+
+- **Hard gate** — the run fails if it can't meet the **actual SLO predicate and
+  target** from this document (e.g. SLO-4 = 95% within 500 ms). This is what
+  "thresholds track this document" means, and it applies to **latency and
+  availability** targets alike.
+- **Engineering headroom** — a separately-named, *stricter* guardrail (e.g.
+  assert the latency bound at ~50–70% of the prod value) to catch regression
+  before it reaches the SLO. A headroom miss warns; only a hard-gate miss fails
+  the release. Headroom is a lab-margin device for **latency bounds**, not a
+  loosening of availability targets.
+
+Run with `O11Y_ENABLED=true`; once per release, run master-switch on vs off to
+re-verify overhead.
 
 Known gaps: federation is single-site only (per-peer FIFO isolation never
 load-verified); loadgen bypasses the WebSocket/browser leg (P6 prober should

--- a/docs/specs/o11y/o11y-slo.md
+++ b/docs/specs/o11y/o11y-slo.md
@@ -1,0 +1,301 @@
+# Service Level Objectives — chat platform
+
+| | |
+|---|---|
+| **Status** | Draft — for review |
+| **Author** | Michelle Leu |
+| **Reviewers / Approvers** | *TBD* |
+| **Approval date** | — |
+| **Revisit date** | ~6 weeks after approval (end of calibration, §0.2) |
+
+Companions: `o11y-metrics-inventory.md`, `o11y-trace-design.md`,
+`o11y-performance-and-sampling.md`. Error budget policy: placeholder
+(`o11y-error-budget-policy.md`, to be written).
+
+---
+
+## 0. How to read this
+
+SLOs are organized by **critical user journey**, not by service — following
+Google's CUJ methodology ([SRE Workbook](https://sre.google/workbook/implementing-slos/))
+and how chat products measure themselves (Slack's
+[Service Delivery Index](https://slack.engineering/service-delivery-index-a-driver-for-reliability/)
+tracks *send a message* / *load a channel*, not services). Each journey
+section: **SLI specification** (user-language intent, good/valid ratio —
+written against real user experience even where not yet measurable) →
+**SLO target** → **Measurement** (✅ computable today / 🔧 to build; the
+**enforcement** implementation is marked) → caveats.
+
+### 0.1 Conventions
+
+- **Window**: 28-day rolling, all SLOs.
+- **Ratio SLOs — time-slice accounting**: 5-minute slices; a slice is *good*
+  if ≥ the stated share of its valid events meet the criterion, or it has no
+  valid events. SLO = share of good slices. (Low off-peak traffic makes pure
+  event ratios unfair; same minutes-below-threshold model as Slack SDI.)
+- **Workflow SLIs combine success and speed** (*"completed successfully within
+  the bound"*) — to the user, a failure and a 10-second success are the same.
+- **Percentiles are chosen per SLI, not uniformly p99.** Criteria: how often a
+  user performs the action (frequent → p99), event volume (sparse data → p95
+  is statistically saner), and whether the tail *is* the signal (then p99 is
+  mandatory — e.g. federation, where the tail means a stuck peer).
+- **Rounding**: ratios ≥ 0.1% precision; latency bounds up to nearest 50 ms.
+- **Scope: per site** — each site is its own failure domain and budget.
+  Federation (J5) is measured separately.
+- **Client errors never burn budget**: `errcode` categories other than
+  `internal`, and HTTP 4xx, are excluded from valid events.
+
+### 0.2 Calibration
+
+All targets are **achievable-first starting values**. Run observationally for
+4–6 weeks, then adjust and seek approval. No paging alerts before then.
+
+### 0.3 SLO ≠ SLA
+
+**This document is internal.** If numbers are ever published externally they
+become an SLA, which must be *derived*, not copied: one notch looser than the
+internal SLO (breach buffer — internal miss must not equal contractual
+breach), availability-focused (external latency-percentile commitments are
+rare industry-wide), with exclusions/remedies defined with business/legal, and
+only after calibration data exists. Never publish these numbers as-is.
+
+---
+
+## 1. Journeys & SLOs at a glance
+
+| Rank | Journey | One-liner |
+|---|---|---|
+| J1 | **Send a message** | The product: accepted, durably stored, delivered in real time |
+| J2 | **Named interactive workflows** | Login, enter channel, enter thread — what users block on |
+| J3 | **Notifications** | Offline users still learn about messages |
+| J4 | **Search** | Find rooms and messages |
+| J5 | **Federation** | Cross-site state converges quickly |
+
+All nine SLOs (targets are starting values, §0.2). Deliberately **out of
+scope**, in three tiers:
+
+- **Dashboard-only interactive RPCs** (room create, member ops, uploads,
+  pins/reactions, …): monitored via the same instrumentation, no SLO in v1.
+- **Ephemeral signals — typing indicators, presence**: best-effort *by
+  design*; loss is invisible or self-heals. Under load these are the **first
+  traffic to shed** to protect J1. Never SLO material.
+- **Read receipts / unread badges**: persisted state users notice when wrong —
+  dashboard in v1, promoted to a v2 candidate (§8 P7: unread-badge
+  convergence).
+
+| # | Journey | SLI | Criterion | Target | Measurable today |
+|---|---|---|---|---|---|
+| SLO-1 | J1 | Delivery success | delivered ∧ persisted, per delivery | 99.9% of slices good | 🔧 P2 |
+| SLO-2 | J1 | E2E delivery latency | send → broadcast delivered | **p99** < 1 s | 🔧 P2 |
+| SLO-3 | J2 | Login (app entry) | success ≤ 1 s | 99% in-slice; 99.9% of slices | ✅ (auth leg) |
+| SLO-4 | J2 | Enter channel | success ≤ 500 ms | **95%** in-slice; 99.9% of slices | 🔧 P1 |
+| SLO-5 | J2 | Enter thread | success ≤ 300 ms | 99% in-slice; 99.9% of slices | 🔧 P1 |
+| SLO-6 | J3 | Notification delivery | handed to provider | 99.5% of slices good | 🔧 P4 |
+| SLO-7 | J4 | Search availability | status=ok | 99.5% of slices good | ✅ |
+| SLO-8 | J4 | Search latency | — | **p95** < 1 s | ✅ |
+| SLO-9 | J5 | Federation freshness | publish → forwarded to remote INBOX | **p99** < 30 s | 🔧 P4 |
+
+Percentile choices: SLO-2 p99 (high volume, tail = group-chat pain); SLO-4
+95% (bucket-walk tail is structural — start looser, tighten with data); SLO-5
+99% (single partition, no excuse); SLO-8 p95 (tolerant journey); SLO-9 p99
+(tail is the stuck-peer signal).
+
+---
+
+## 2. J1 — Send a message *(flagship)*
+
+**Journey.** User sends; every connected member sees it near-instantly; the
+message survives reloads. frontend → `MESSAGES` → gatekeeper →
+`MESSAGES_CANONICAL` → message-worker (Cassandra) + broadcast-worker (fan-out).
+
+**SLIs.**
+- **SLI 1 — Delivery success**: `good = delivery published ∧ message
+  persisted` / `valid = accepted messages × recipients at broadcast time`.
+  Broadcast-but-not-persisted counts as failure — integrity is non-negotiable
+  in chat (cf. [Ably's Four Pillars](https://ably.com/four-pillars-of-dependability)).
+- **SLI 2 — E2E delivery latency**: spec is sender-hits-enter → recipient
+  renders.
+
+**Measurement.**
+- ✅ Today: nothing — J1 is *specified but not enforceable* (top roadmap item).
+- 🔧 **Server-side (enforcement, v1)** — per-service `metrics.go`, copying the
+  data-migration counter pattern:
+
+| Instrument | Where |
+|---|---|
+| `messages_validated_total` / `messages_rejected_total{reason}` | message-gatekeeper |
+| `deliveries_total{outcome}` + `fanout_size` histogram | broadcast-worker |
+| `messages_persisted_total{outcome}` | message-worker |
+| `message_e2e_delivery_seconds` (= `now − event.Timestamp` at publish) | broadcast-worker |
+
+- 🔧 Client-side (observational, v1.5): collector `spanmetrics` over existing
+  frontend spans — zero frontend change; needs 100% sampling, untrusted
+  browser clocks.
+- 🔧 Synthetic prober (v2): resident canary from `tools/loadgen`; covers the
+  true last mile; candidate enforcement source for SLO-2.
+
+**Caveats.**
+- Denominator is **per delivery**, not per message — a 500-member room failure
+  weighs 500× (big-room incidents must not average away).
+- v1 measures to broadcast publish, not client render; gap tracked (§8 P6).
+- Clock skew (same-site NTP ≲10 ms) is negligible vs a 1 s bound.
+- Ordering is not an SLO (JetStream orders within a stream only).
+
+---
+
+## 3. J2 — Named interactive workflows
+
+The three synchronous interactions users block on, each a named workflow
+(Slack-SDI style); SLI = *completed successfully within the bound* (§0.1).
+
+| Workflow | Path (verified in code) |
+|---|---|
+| **Login (app entry)** | `POST /api/v1/auth` (auth-service) → NATS connect → initial data (`subscription.list`, `rooms.get`) |
+| **Enter channel** | `msg.history` → history-service `LoadHistory`: 2 concurrent Mongo reads → Cassandra `messages_by_room`, **bucket-walk** (`cassrepo/walker.go`). `markRoomRead` / `key.get` follow, non-blocking |
+| **Enter thread** | `msg.thread` → `GetThreadMessages`: **single partition** `thread_messages_by_thread`, no walk |
+
+Separate bounds because the cost models differ: channel loads walk an
+open-ended number of 72 h buckets (idle rooms walk further); thread loads are
+one partition slice.
+
+**SLIs.** Login attempts / channel loads / thread opens completing
+successfully within the bound (bad credentials etc. are not valid events).
+Targets: see §1 table (SLO-3/4/5).
+
+**Measurement.**
+- ✅ Login: auth-service `http.server.request.duration` — enforceable today
+  (`status<500 ∧ duration ≤ 1s`; verify series/label names on a live `:2112`).
+- 🔧 Channel/thread: blocked on the `natsrouter` metrics middleware (§8 P1) —
+  `rpc_server_duration_seconds{subject_pattern, errcode_category}`; the
+  `subject_pattern` label slices both workflows out of one middleware.
+- 🔧 Client-side v1.5: same spanmetrics route as J1.
+
+**Caveats.**
+- Bucket-walk tail is structural: if calibration shows p99 dominated by walk
+  depth, add a walk-depth metric / tune `MESSAGE_BUCKET_HOURS` — don't loosen
+  the SLO.
+- **App entry ≠ client cold start.** The SLO-3 spec covers the *backend legs*
+  of entering the app (auth → connect → initial data). v1 measures the auth
+  HTTP leg; the `subscription.list` / `rooms.get` legs join under the same SLO
+  once P1 lands. Full cold start (bundle download, JS boot, render/TTI)
+  depends on device and network the backend cannot fix — it is a **client-side
+  product performance metric** (P5 RUM), not a backend SLO.
+- Encrypted-room `key.get` failure is user-visible — v2 SLI candidate (§8 P7).
+
+---
+
+## 4. J3 — Notifications
+
+**Journey.** Message arrives for an offline/away member → notification-worker
+→ push provider.
+
+**SLI 6**: `good = push handed to provider` / `valid = attempts`
+(policy-suppressed — mutes, quiet hours — are not valid events). Target: §1.
+
+**Measurement.** ✅ nothing today; 🔧 `notifications_sent_total` /
+`_failed_total{reason}` / `_suppressed_total{reason}` (§8 P4).
+
+**Caveat.** Measures to provider hand-off; provider→device is out of scope.
+No latency SLO in v1.
+
+---
+
+## 5. J4 — Search
+
+**Journey.** `chat.user.{account}.request.search.{siteId}.*` → search-service
+→ Elasticsearch.
+
+**SLI 7 / SLI 8**: ok-response ratio; fast-response ratio. Targets: §1.
+
+**Measurement.** ✅ Fully measurable today:
+`search_service_requests_total{type,status}`,
+`search_service_request_duration_seconds` (`…es_duration_seconds` is
+diagnostic, not an SLI). Availability and latency stay separate here (existing
+counters/histogram don't share labels; merging isn't worth re-instrumenting).
+
+**Caveat.** Index freshness (how fast a new message becomes searchable) is
+deliberately out of v1 — §8 P7.
+
+---
+
+## 6. J5 — Federation
+
+**Journey.** Cross-site events converge site A → site B via `OUTBOX` →
+outbox-worker → remote `INBOX` → inbox-worker.
+
+**SLI 9 — Federation freshness**: `good = forwarded to destination INBOX
+within threshold of publish time` / `valid = all outbox events`. Target: §1.
+
+**Measurement.** ✅ nothing today; 🔧 `outbox_forward_age_seconds{dest_site,
+event_type}` (both timestamps on the origin site — no cross-site skew) +
+`outbox_forwarded_total` / `outbox_retries_total{dest_site}` (§8 P4).
+
+**Caveats.**
+- v1 measures origin-side (publish → forwarded); remote apply is a v2
+  refinement (cross-site clock skew).
+- Per-destination: a dead peer burns only its own destination's budget (its
+  FIFO lane parks with `MaxAckPending=1`); forward-age p99 doubles as the
+  peer-down alert signal.
+- `member_added` rides this pipeline — the cross-site half of member-change
+  convergence is covered here; same-site half is v2 (§8 P7).
+
+---
+
+## 7. Alerting — burn rate, not thresholds
+
+After calibration, alert on error-budget burn rate (multi-window, SRE
+Workbook ch.5): **page** at 14.4× over 1 h (+5 m), **page** at 6× over 6 h
+(+30 m), **ticket** at 1× over 3 d. NATS/JetStream consumer lag (§8 P3) is the
+leading indicator for SLO-1/2/6/9 — alert on lag growth before budget burns.
+
+---
+
+## 8. Measurement roadmap
+
+| P | Work | Unlocks |
+|---|---|---|
+| P1 | `natsrouter` metrics middleware (`rpc_server_duration_seconds{subject_pattern, errcode_category}`) | SLO-4/5 + dashboards for all non-named RPCs |
+| P2 | J1 counters + `message_e2e_delivery_seconds` (gatekeeper / broadcast / message-worker) | SLO-1/2 |
+| P3 | NATS/JetStream Prometheus exporter (infra) | consumer-lag leading indicator |
+| P4 | notification-worker + outbox-worker instruments | SLO-6/9 |
+| P5 | Collector `spanmetrics` on frontend spans | client-side observational SLIs |
+| P6 | Synthetic prober from `tools/loadgen` | last-mile SLO-2; full login→connect |
+| P7 | v2 candidates: search index freshness · member-add convergence (invite → subscription + room key; cross-site half already under SLO-9) · encrypted `key.get` success · unread-badge / read-receipt convergence | — |
+
+---
+
+## 9. Error budget policy
+
+Placeholder — separate document (`o11y-error-budget-policy.md`) once team
+consequences are agreed. Until then: breaches produce tickets and review
+visibility only.
+
+---
+
+## 10. Load testing alignment
+
+These SLOs are the **acceptance criteria** for load tests; *capacity* = the
+load at which an SLO first breaks. The client surface is NATS (long-lived,
+stateful, bidirectional), so the driver is `tools/loadgen` (already asserts
+per-stage P95/P99 in `attribution.go`, tracks consumer lag) — not k6, whose
+VU/request model can't express cross-connection E2E delivery; k6 fits the
+pure-HTTP workflows only.
+
+| Scenario | Driver | Validates |
+|---|---|---|
+| Message pipeline, fan-out matrix (room sizes × rate ladder) | `loadgen` | SLO-1/2 |
+| Channel-load storm incl. cold/idle-room fixtures | `loadgen history` | SLO-4 |
+| Thread-open storm | `loadgen thread` | SLO-5 |
+| Login surge | k6 or simple HTTP driver | SLO-3 |
+| Federation under load + peer-down/recovery | *missing — to build* | SLO-9 |
+| Soak: redelivery, lag drift, memory | `loadgen` + P3 exporter | leading indicators |
+
+Rules: assert at ~50–70% of the prod bound (lab margin) · loadgen thresholds
+must track this document (drift = bug) · run with `O11Y_ENABLED=true` and read
+SLIs from the same recording rules as prod (loadgen itself uses a noop
+tracer) · once per release, run master-switch on vs off to re-verify the
+overhead claims.
+
+Known gaps: federation scenario (per-peer FIFO isolation never
+load-verified); loadgen bypasses the WebSocket/browser leg (P6 prober should
+share its client code).

--- a/docs/specs/o11y/o11y-slo.md
+++ b/docs/specs/o11y/o11y-slo.md
@@ -105,13 +105,13 @@ material; read receipts / unread badges → dashboard, v2 candidate (§8 P7).
 | # | Journey | SLI = good / valid | Target | Today |
 |---|---|---|---|---|
 | SLO-1a | J1 | canonical message persisted to Cassandra / **canonical messages published** | 99.9% | 🔧 P2 · approximate (lag-enforced) |
-| SLO-1b | J1 | **channel** broadcast fan-out published (all/partial/failed per message) / canonical channel messages published | 99.9% | 🔧 P2 · approximate · core-NATS boundary |
-| SLO-2 | J1 | channel fan-out published **within 1 s** of canonical acceptance / canonical channel messages published | 99% | 🔧 P2 · approximate |
+| SLO-1b | J1 | **channel** broadcast fan-out published (**good = `outcome=all`**; partial/failed both burn) / canonical channel messages published | 99.9% | 🔧 P2 · approximate · core-NATS boundary |
+| SLO-2 | J1 | channel fan-out published **within 1 s** of canonical acceptance (late = bad) / canonical channel messages published | 99% | 🔧 P2 · approximate |
 | SLO-3 | J2 | successful login **within 1 s** / eligible login attempts | 99% | ✅ (auth leg — proxy) |
 | SLO-4 | J2 | channel load succeeds **within 500 ms** / eligible channel loads | 95% | 🔧 P1 |
 | SLO-5 | J2 | thread open succeeds **within 300 ms** / eligible thread opens | 99% | 🔧 P1 |
 | SLO-6 | J3 | push event accepted into `PUSH_NOTIFICATION` / notifiable recipients | 99.9% | 🔧 P4 · handoff only (see §4) |
-| SLO-7 | J4 | search returns ok / search requests | 99.5% | ✅ |
+| SLO-7 | J4 | search returns ok / search requests | 99.5% | ✅ partial-failure · outage needs backstop (§5) |
 | SLO-8 | J4 | **successful** search returns **within 1 s** / successful searches | 95% | 🔧 P4 (needs status label) |
 | SLO-9 | J5 | outbox event forwarded to remote INBOX **within 30 s** / outbox events published | 99% | 🔧 P4 · deadline-based · approximate |
 
@@ -160,16 +160,19 @@ gets nothing. v1 commits only to persistence + publication and names them so.
 - **Numerators**, one outcome per logical message (approximate — see §0.1):
   - `messages_persisted_total{outcome}` (message-worker) → SLO-1a
   - `broadcast_fanout_total{outcome=all|partial|failed}` (broadcast-worker) →
-    SLO-1b. **Core-NATS boundary:** broadcast-worker publishes via
-    `nc.PublishMsg` (core NATS, fire-and-forget) — a nil return means the publish
-    call was *enqueued locally*, **not** server-acknowledged. And fan-out is
-    **per recipient** (channel emits a room event + one user-room event per
-    account; DM/thread emit per recipient), tolerating partial failure. So the
-    outcome is a **logical all/partial/failed per message**, not a single ack.
-  - `broadcast_fanout_age_seconds` = `now − evt.Timestamp` → SLO-2.
-    `evt.Timestamp` is the canonical event's server-set timestamp
-    (`gatekeeper handler.go`, `now.UnixMilli()`) → "canonical acceptance →
-    fan-out published".
+    SLO-1b. **Good predicate: `outcome=all` only** — `partial` and `failed` both
+    burn budget (any recipient the message didn't reach is a miss). **Core-NATS
+    boundary:** broadcast-worker publishes via `nc.PublishMsg` (core NATS,
+    fire-and-forget) — a nil return means the publish call was *enqueued locally*,
+    **not** server-acknowledged. And fan-out is **per recipient** (channel emits a
+    room event + one user-room event per account; DM/thread emit per recipient),
+    tolerating partial failure. So the outcome is a **logical all/partial/failed
+    per message**, not a single ack.
+  - `broadcast_fanout_age_seconds` = `now − evt.Timestamp` → SLO-2. **Good
+    predicate: age ≤ 1 s**; a publication later than the bound is **bad** (stays
+    in valid, not counted good). `evt.Timestamp` is the canonical event's
+    server-set timestamp (`gatekeeper handler.go`, `now.UnixMilli()`) →
+    "canonical acceptance → fan-out published".
 - **v1 scope: channel messages only.** DM/thread per-recipient partial-failure
   semantics are deferred; SLO-1b/2 denominators count canonical **channel**
   messages in v1.
@@ -241,11 +244,18 @@ publishes `PushNotificationEvent` into the `PUSH_NOTIFICATION` stream; the actua
 provider retries and terminal delivery outcome live in the downstream
 **push-service**, which this repo does not own. So:
 
-- **SLO-6 (enforced v1) — push-stream handoff**: `good = push event accepted into
-  PUSH_NOTIFICATION` / `valid = notifiable recipients` (policy-suppressed —
-  mutes, quiet hours — are **not** valid). Instruments in notification-worker:
-  `push_events_enqueued_total`, `push_recipients_total` (denominator),
-  `notifications_suppressed_total{reason}` (diagnostic). §8 P4.
+- **SLO-6 (enforced v1) — push-stream handoff**: `good = recipient durably
+  accepted into PUSH_NOTIFICATION` / `valid = notifiable recipients`
+  (policy-suppressed — mutes, quiet hours — are **not** valid).
+  **Recipient-granular, both sides.** notification-worker emits **batched** push
+  events (one `PushNotificationEvent` carries N accounts, `handler.go`), so the
+  numerator counts **recipients**, not events: `push_recipients_accepted_total`
+  incremented by `len(batchAccounts)` on a successful emit, matched against
+  `push_recipients_total` (denominator). Counting events over recipients would
+  mismatch units. **"Accepted" = a JetStream `PubAck`** (the emitter's
+  `js.PublishMsg` returns durably, `emit.go`) — a *durable stream ack*, not a
+  local enqueue, so unlike SLO-1b there is no core-NATS caveat here.
+  `notifications_suppressed_total{reason}` stays diagnostic. §8 P4.
 - **Declared (not owned here) — notification delivery**: `delivered to provider
   within retry budget / recipients requested`, one terminal outcome per logical
   notification, retries not changing the unit. This must be emitted by
@@ -266,13 +276,22 @@ user was notified. No latency SLO in v1.
   `valid = successful searches`. **Gated on success** so a fast failure can't
   improve the number.
 
-**Measurement.** ✅ SLO-7 today (`search_service_requests_total{type,status}`).
-🔧 **SLO-8 is not measurable yet**: `search_service_request_duration_seconds` has
-no status/outcome label, so successful requests can't be isolated — add that
-label (§8 P4) before enforcing SLO-8. `…es_duration_seconds` stays diagnostic.
+**Measurement.** ✅ SLO-7 for **partial/elevated failures**
+(`search_service_requests_total{type,status}` — the ratio catches error responses
+while traffic flows). 🔧 **SLO-8 is not measurable yet**:
+`search_service_request_duration_seconds` has no status/outcome label, so
+successful requests can't be isolated — add that label (§8 P4) before enforcing
+SLO-8. `…es_duration_seconds` stays diagnostic.
 
-**Caveat.** Index freshness (how fast a new message becomes searchable) is out of
-v1 — §8 P7.
+**Caveats.**
+- **Full-outage blind spot.** The denominator is search-service-local, so a total
+  outage reads as *no traffic*, not failures (the §0.1 self-emitted-denominator
+  trap). SLO-7's ratio therefore covers partial degradation only; a complete
+  outage is caught by the **health-check / uptime backstop** (and the synthetic
+  prober, §8 P6), not the request ratio. Until the prober lands, pair SLO-7 with
+  a request-rate-drop / probe alert.
+- Index freshness (how fast a new message becomes searchable) is out of v1 —
+  §8 P7.
 
 ---
 
@@ -291,9 +310,12 @@ the numerator → counted as a failure, not a missing sample.
 - **Denominator: `outbox_events_published_total{dest_site, event_type}`**, emitted
   **producer-side** (room-service / room-worker at OUTBOX publish) — upstream of
   outbox-worker, so worker downtime can't suppress it.
-- **Numerator: forwarded within bound** — `outbox_forwarded_total{dest_site}`
-  gated on age ≤ bound. Age = `now − event.Timestamp`, both timestamps
-  origin-side (no cross-site skew). **Approximate:** outbox consumers use
+- **Numerator: forwarded within bound** — `outbox_forwarded_total{dest_site,
+  event_type}` gated on age ≤ bound. **Same label set as the denominator** so the
+  ratio is `sum by(dest_site)(forwarded_within_bound) / sum by(dest_site)(published)`
+  — event_type is carried for slicing and aggregated away for the SLO. Age =
+  `now − event.Timestamp`, both timestamps origin-side (no cross-site skew).
+  **Approximate:** outbox consumers use
   `MaxDeliver=-1` (retry forever — there is no exhaustion terminal event), and
   exact one-time forwarded accounting needs explicit dedup/Ack semantics not yet
   in place. So the ratio is deadline-based and approximate.
@@ -336,7 +358,7 @@ required** (`sdk.Meter()` is exposed; search-service is the exemplar).
 | P1 | `natsrouter` metrics middleware (`rpc_server_duration_seconds{subject_pattern, errcode_category}`) | SLO-4/5 + dashboards for all non-named RPCs |
 | P2 | J1 counters — gatekeeper `messages_canonical_published_total` (upstream denominator), message-worker persisted, broadcast-worker publications + publication-age; terminal-outcome/dedup semantics, no message-ID labels | SLO-1a/1b/2 |
 | P3 | NATS/JetStream Prometheus exporter (infra) — consumer lag **and** oldest-pending age from consumer state | outage backstop for 1a/1b/2/6/9 |
-| P4 | notification-worker push-stream handoff (enqueued/recipients) · **search duration `status` label** · outbox producer-side published + forwarded-within-bound | SLO-6/8/9 |
+| P4 | notification-worker push-stream handoff (**recipient-granular** accepted/recipients) · **search duration `status` label** · outbox producer-side published + forwarded-within-bound (matching label sets) | SLO-6/8/9 |
 | P5 | Collector `spanmetrics` on frontend spans | observational last-mile & J2 client view |
 | P6 | Synthetic prober from `tools/loadgen` + SLO assertion mode (§10) | declared last-mile SLI; login→connect→initial-data; sparse-journey floor; SLO-aware load asserts |
 | P7 | v2: **exact outcome ledger** (dedup / first-write / exhaustion — makes 1a/1b/6/9 exact instead of approximate) · **push-service** provider delivery metrics (cross-repo) · correlated single-J1 outcome · search index freshness · member-add convergence · encrypted `key.get` · read-receipt convergence | — |


### PR DESCRIPTION
## Summary

Adds the platform's user-facing SLI/SLO specification at
`docs/load-testing/system/sli-slo.md` — the acceptance criteria that all
system-level load tests assert against. (Moved here from `docs/specs/o11y/` to
honor the `docs/load-testing/README` intended structure: user-facing SLI/SLO
belongs under `system/`.)

**10 SLOs across 5 critical user journeys** (J1 is split — see Approach):

| Journey | SLOs |
|---|---|
| J1 Send a message | persistence 99.9% (SLO-1a) · channel broadcast **enqueue-accepted** 99.9% (SLO-1b) · enqueue ≤1s 99% (SLO-2) |
| J2 Interactive workflows | login ≤1s 99% (SLO-3) · enter channel ≤500ms 95% (SLO-4) · enter thread ≤300ms 99% (SLO-5) |
| J3 Notifications | push-stream handoff 99.9% (SLO-6) |
| J4 Search | availability 99.5% (SLO-7) · latency ≤1s 95% (SLO-8) |
| J5 Federation | forward freshness ≤30s 99% (SLO-9) |

## Approach

- **Journey-first, not service-first** (Google CUJ methodology; matches how chat
  products like Slack's Service Delivery Index measure themselves).
- **Every SLI is an event-based `good / valid` ratio** over a 28-day window.
  Percentiles are **diagnostic only, never SLO targets**. Latency SLOs are
  written as "X% of valid requests within the bound".
- **J1 is split, not one "delivery success".** The persist and publish paths
  consume `MESSAGES_CANONICAL` independently (no message-ID join), so J1 is two
  success ratios (1a persistence, 1b channel enqueue) plus a latency ratio (2) —
  each its own budget. A correlated single-J1 outcome is v2.
- **Honest v1 scoping, aligned to the code:**
  - A channel broadcast is **one core-NATS room-subject publish**; `PublishMsg`
    returns on **local enqueue**, not server-confirmed publication. SLO-1b/2 are
    therefore **enqueue-acceptance** (`broadcast_channel_enqueue_total` /
    `_age_seconds`), not publication — true publication latency is deferred to P7.
  - The denominator is `broadcast_path=room_subject`-scoped (channel thread
    replies route to thread fan-out and are excluded); per-recipient
    `all/partial/failed` lives only on DM/thread (v1-unscored).
  - Async ratios are marked **approximate (lag-enforced)**; consumer backlog /
    a connection-risk backstop are the primary signals. Denominators are anchored
    **upstream** so an outage reads as a dropped ratio, not missing data.
- **SLI spec / implementation split** — each SLI is written in user language,
  separately from what is measurable today (✅) vs on the roadmap (🔧).
- **Measurement roadmap (§8, P1–P7)** — all items land in `newchat` (app code)
  or infra; no flywindy/o11y SDK change is required.
- **Load-testing alignment (§10)** — SLOs are the acceptance criteria; driver is
  `tools/loadgen` (NATS), not k6. The hard gate reuses the production
  predicate/target over an **isolated, quiescent test site** with a
  warm-up → send → settle window (never the 28-day aggregate rule).

## Notes for reviewers

- All targets are **achievable-first starting values** — calibrated over 4–6
  weeks of observation before approval (no paging alerts until then).
- **SLO ≠ SLA**: internal document; any external SLA must be derived (looser,
  availability-focused, post-calibration).
- English is canonical. A zh-TW translation is maintained separately (Artifact),
  not part of this PR.
- Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)