### PR TITLE
Add older-message pagination (scroll-up to load history)

### DIFF
--- a/chat-frontend/src/components/MainApp/ChatPage/RoomMessageArea/RoomMessageArea.jsx
+++ b/chat-frontend/src/components/MainApp/ChatPage/RoomMessageArea/RoomMessageArea.jsx
@@ -16,6 +16,9 @@ export default function RoomMessageArea({ room, onThread, onReply }) {
     hasLoadedHistory,
     historyError,
     loadHistory,
+    loadOlder,
+    hasMoreOlder,
+    loadingOlder,
     bufferMode,
     pendingCount,
     focusMessageId,
@@ -34,10 +37,15 @@ export default function RoomMessageArea({ room, onThread, onReply }) {
     loadHistory().catch(() => {})
   }, [room, loadHistory])
 
+  // Auto-scroll to the bottom on a NEW message (the last id changes) or the
+  // initial load. Keyed on the last message's id — NOT the whole `messages`
+  // array — so prepending an older page (which changes the FIRST id, not the
+  // last) doesn't yank the user back down to the live tail while they read.
+  const lastMsgId = messages.length ? messages[messages.length - 1].id : null
   useEffect(() => {
     if (bufferMode === BUFFER_MODE.HISTORICAL) return
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages, bufferMode])
+  }, [lastMsgId, bufferMode])
 
   useEffect(() => {
     if (bufferMode === BUFFER_MODE.LIVE) {
@@ -107,6 +115,9 @@ export default function RoomMessageArea({ room, onThread, onReply }) {
         onDelete={handleDelete}
         onJumpToMessage={(msgId) => jumpToMessage?.(msgId)?.catch?.(() => {})}
         onFocusConsumed={() => dispatch({ type: 'FOCUS_CLEARED', roomId: room.id })}
+        onLoadOlder={() => loadOlder?.()?.catch?.(() => {})}
+        hasMoreOlder={hasMoreOlder}
+        loadingOlder={loadingOlder}
         bottomRef={bottomRef}
       />
       {bufferMode === BUFFER_MODE.HISTORICAL && pendingCount > 0 && (

--- a/chat-frontend/src/components/shared/MessageList/MessageList.jsx
+++ b/chat-frontend/src/components/shared/MessageList/MessageList.jsx
@@ -1,7 +1,12 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useLayoutEffect, useRef } from 'react'
 import MessageRow from './MessageRow/MessageRow'
 import SystemMessage from './SystemMessage/SystemMessage'
 import './style.css'
+
+/** Scroll distance from the top (px) at which we trigger an older-page load.
+ *  A small band above 0 so the fetch starts just before the user hits the
+ *  very top, hiding the request latency. */
+const LOAD_OLDER_THRESHOLD_PX = 120
 
 export default function MessageList({
   messages,
@@ -18,6 +23,9 @@ export default function MessageList({
   onEdit,
   onDelete,
   onJumpToMessage,
+  onLoadOlder,
+  hasMoreOlder,
+  loadingOlder,
   bottomRef,
   ariaLive,
   onRetry,
@@ -28,6 +36,39 @@ export default function MessageList({
   const listRef = useRef(null)
   const localBottomRef = useRef(null)
   const effectiveBottomRef = bottomRef ?? localBottomRef
+
+  // Scroll-position anchor captured at the moment an older-page load is
+  // triggered, so the useLayoutEffect below can keep the viewport pinned to
+  // the same message once the older block is prepended (otherwise the growing
+  // content above the viewport would shove the reading position downward).
+  const olderAnchorRef = useRef(null)
+  const prevFirstIdRef = useRef(null)
+
+  const handleScroll = () => {
+    const el = listRef.current
+    if (!el || !onLoadOlder || !hasMoreOlder || loadingOlder) return
+    if (el.scrollTop <= LOAD_OLDER_THRESHOLD_PX) {
+      // Capture BEFORE the prepend so we can restore the offset after.
+      olderAnchorRef.current = { scrollHeight: el.scrollHeight, scrollTop: el.scrollTop }
+      onLoadOlder()
+    }
+  }
+
+  // After an older page prepends (first message id changed), restore the
+  // scroll position by the height the prepend added. Runs synchronously
+  // before paint so the user never sees a jump. Skips live appends (which
+  // change the LAST id, not the first) via the first-id guard.
+  useLayoutEffect(() => {
+    const el = listRef.current
+    const firstId = messages[0]?.id ?? null
+    const anchor = olderAnchorRef.current
+    if (el && anchor && firstId !== prevFirstIdRef.current) {
+      const delta = el.scrollHeight - anchor.scrollHeight
+      if (delta > 0) el.scrollTop = anchor.scrollTop + delta
+      olderAnchorRef.current = null
+    }
+    prevFirstIdRef.current = firstId
+  }, [messages])
 
   useEffect(() => {
     if (!focusMessageId || !listRef.current) return
@@ -56,8 +97,10 @@ export default function MessageList({
     <div
       className="message-list"
       ref={listRef}
+      onScroll={onLoadOlder ? handleScroll : undefined}
       {...(ariaLive ? { 'aria-live': ariaLive } : {})}
     >
+      {loadingOlder && <div className="message-loading-older">Loading earlier messages…</div>}
       {historyLoading && <div className="message-loading">Loading messages…</div>}
       {historyError && <div className="message-error">{historyError}</div>}
       {visibleMessages.map((msg) => {

--- a/chat-frontend/src/components/shared/MessageList/MessageList.test.jsx
+++ b/chat-frontend/src/components/shared/MessageList/MessageList.test.jsx
@@ -65,3 +65,88 @@ describe('MessageList', () => {
     expect(screen.getByTestId('row-r1').getAttribute('data-context')).toBe('thread')
   })
 })
+
+describe('MessageList: load-older-on-scroll', () => {
+  function scrollList(container, scrollTop) {
+    const list = container.querySelector('.message-list')
+    // jsdom has no layout — assign the properties the handler reads.
+    Object.defineProperty(list, 'scrollTop', { value: scrollTop, writable: true, configurable: true })
+    Object.defineProperty(list, 'scrollHeight', { value: 1000, writable: true, configurable: true })
+    list.dispatchEvent(new Event('scroll', { bubbles: true }))
+    return list
+  }
+
+  it('calls onLoadOlder when scrolled near the top and more older exist', () => {
+    const onLoadOlder = vi.fn()
+    const { container } = render(
+      <MessageList
+        messages={msgs}
+        hasLoadedHistory
+        context="main"
+        onLoadOlder={onLoadOlder}
+        hasMoreOlder
+      />,
+    )
+    scrollList(container, 10)
+    expect(onLoadOlder).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT call onLoadOlder when already loading', () => {
+    const onLoadOlder = vi.fn()
+    const { container } = render(
+      <MessageList
+        messages={msgs}
+        hasLoadedHistory
+        context="main"
+        onLoadOlder={onLoadOlder}
+        hasMoreOlder
+        loadingOlder
+      />,
+    )
+    scrollList(container, 10)
+    expect(onLoadOlder).not.toHaveBeenCalled()
+  })
+
+  it('does NOT call onLoadOlder when there are no more older messages', () => {
+    const onLoadOlder = vi.fn()
+    const { container } = render(
+      <MessageList
+        messages={msgs}
+        hasLoadedHistory
+        context="main"
+        onLoadOlder={onLoadOlder}
+        hasMoreOlder={false}
+      />,
+    )
+    scrollList(container, 10)
+    expect(onLoadOlder).not.toHaveBeenCalled()
+  })
+
+  it('does NOT call onLoadOlder when scrolled well below the top', () => {
+    const onLoadOlder = vi.fn()
+    const { container } = render(
+      <MessageList
+        messages={msgs}
+        hasLoadedHistory
+        context="main"
+        onLoadOlder={onLoadOlder}
+        hasMoreOlder
+      />,
+    )
+    scrollList(container, 800)
+    expect(onLoadOlder).not.toHaveBeenCalled()
+  })
+
+  it('renders the older-loading indicator when loadingOlder is true', () => {
+    render(
+      <MessageList
+        messages={msgs}
+        hasLoadedHistory
+        context="main"
+        hasMoreOlder
+        loadingOlder
+      />,
+    )
+    expect(screen.getByText(/earlier messages/i)).toBeInTheDocument()
+  })
+})

--- a/chat-frontend/src/components/shared/MessageList/style.css
+++ b/chat-frontend/src/components/shared/MessageList/style.css
@@ -8,6 +8,7 @@
 }
 
 .message-loading,
+.message-loading-older,
 .message-error {
   padding: var(--space-md);
   text-align: center;

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.test.jsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.test.jsx
@@ -494,24 +494,23 @@ describe('RoomEventsProvider jumpToMessage / resetToLiveTail', () => {
 
     function Probe() {
       const { messages, focusMessageId, bufferMode, jumpToMessage } = useRoomEvents('r1')
+      const { summaries } = useRoomSummaries()
       return (
         <div>
           <button onClick={() => jumpToMessage('m11').catch(() => {})}>jump</button>
           <div data-testid="messages">{messages.map((m) => m.id).join(',')}</div>
           <div data-testid="focus">{focusMessageId ?? ''}</div>
           <div data-testid="mode">{bufferMode}</div>
+          <div data-testid="summaries">{summaries.length}</div>
         </div>
       )
     }
 
     render(wrap(<Probe />, nats))
-    // Wait for rooms list to load so summary is present (so jumpToMessage uses room siteId)
-    await waitFor(() =>
-      expect(request).toHaveBeenCalledWith(
-        'chat.user.alice.request.user.site-A.subscription.list',
-        { type: 'rooms', offset: 0, limit: PAGE_LIMIT },
-      )
-    )
+    // Wait for the bootstrap reply to land in state.summaries — not merely for
+    // the request to be issued — so jumpToMessage reads the room's site-B
+    // siteId rather than racing the reply and falling back to the user's site.
+    await waitFor(() => expect(screen.getByTestId('summaries').textContent).toBe('1'))
 
     await act(async () => {
       screen.getByText('jump').click()
@@ -1481,5 +1480,104 @@ describe('RoomEventsProvider missing-key path', () => {
 
     expect(ensureKey).not.toHaveBeenCalled()
     expect(decrypt).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('RoomEventsProvider loadOlderHistory (older-message pagination)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  // Server ships newest-first. Build a newest-first block of `n` messages
+  // whose timestamps ascend with the id index (m0 oldest … m<n-1> newest).
+  function serverPage(prefix, n, baseMinute = 0) {
+    const asc = Array.from({ length: n }, (_, i) => ({
+      id: `${prefix}${i}`,
+      roomId: 'a',
+      content: `${prefix}${i}`,
+      createdAt: new Date(Date.UTC(2026, 3, 17, 8, baseMinute + i, 0)).toISOString(),
+      sender: { account: 'bob' },
+    }))
+    return asc.reverse() // newest-first, as history-service returns
+  }
+
+  function OlderProbe() {
+    const { messages, loadHistory, loadOlder, hasMoreOlder, loadingOlder } = useRoomEvents('a')
+    return (
+      <div>
+        <button onClick={() => loadHistory()}>load</button>
+        <button onClick={() => loadOlder()?.catch?.(() => {})}>older</button>
+        <div data-testid="messages">{messages.map((m) => m.id).join(',')}</div>
+        <div data-testid="hasMore">{String(hasMoreOlder)}</div>
+        <div data-testid="loadingOlder">{String(loadingOlder)}</div>
+      </div>
+    )
+  }
+
+  it('prepends an older page, fetched with a `before` cursor at the current top', async () => {
+    // Initial page is FULL (50) → hasMoreOlder true. Older page follows.
+    const first = serverPage('n', 50, 10) // n0 (08:10) … n49 (08:59)
+    const older = serverPage('o', 3, 0) // o0 (08:00) … o2 (08:02)
+    const request = vi.fn().mockImplementation((subject, payload) => {
+      if (subject.includes('.msg.history')) {
+        return Promise.resolve({ messages: payload?.before ? older : first })
+      }
+      if (subject.endsWith('.subscription.list')) return Promise.resolve({ subscriptions: [] })
+      throw new Error('unexpected subject: ' + subject)
+    })
+    const nats = mockNats({ request })
+
+    render(wrap(<OlderProbe />, nats))
+    await act(async () => { screen.getByText('load').click() })
+    await waitFor(() => expect(screen.getByTestId('hasMore').textContent).toBe('true'))
+    // Buffer starts at the newest page, oldest-first.
+    expect(screen.getByTestId('messages').textContent.startsWith('n0,n1')).toBe(true)
+
+    await act(async () => { screen.getByText('older').click() })
+    await waitFor(() =>
+      expect(screen.getByTestId('messages').textContent.startsWith('o0,o1,o2,n0')).toBe(true),
+    )
+
+    // The older fetch used `before` = the oldest loaded message's epoch millis.
+    const beforeCursor = new Date(Date.UTC(2026, 3, 17, 8, 10, 0)).getTime()
+    expect(request).toHaveBeenCalledWith(
+      'chat.user.alice.request.room.a.site-A.msg.history',
+      { limit: 50, before: beforeCursor },
+    )
+    // Older page was short (3 < 50) → no more older remain.
+    await waitFor(() => expect(screen.getByTestId('hasMore').textContent).toBe('false'))
+  })
+
+  it('no-ops when the initial page was short (hasMoreOlder false)', async () => {
+    const first = serverPage('n', 5, 10) // short page → reached start
+    const request = vi.fn().mockImplementation((subject) => {
+      if (subject.includes('.msg.history')) return Promise.resolve({ messages: first })
+      if (subject.endsWith('.subscription.list')) return Promise.resolve({ subscriptions: [] })
+      throw new Error('unexpected subject: ' + subject)
+    })
+    const nats = mockNats({ request })
+
+    render(wrap(<OlderProbe />, nats))
+    await act(async () => { screen.getByText('load').click() })
+    await waitFor(() => expect(screen.getByTestId('hasMore').textContent).toBe('false'))
+
+    const historyCallsBefore = request.mock.calls.filter((c) => c[0].includes('.msg.history')).length
+    await act(async () => { screen.getByText('older').click() })
+    const historyCallsAfter = request.mock.calls.filter((c) => c[0].includes('.msg.history')).length
+    // loadOlder must not fire a second history RPC.
+    expect(historyCallsAfter).toBe(historyCallsBefore)
+  })
+
+  it('no-ops before the initial history has loaded', async () => {
+    const request = vi.fn().mockImplementation((subject) => {
+      if (subject.endsWith('.subscription.list')) return Promise.resolve({ subscriptions: [] })
+      if (subject.includes('.msg.history')) return Promise.resolve({ messages: [] })
+      throw new Error('unexpected subject: ' + subject)
+    })
+    const nats = mockNats({ request })
+
+    render(wrap(<OlderProbe />, nats))
+    // Click older WITHOUT loading first.
+    await act(async () => { screen.getByText('older').click() })
+    const historyCalls = request.mock.calls.filter((c) => c[0].includes('.msg.history')).length
+    expect(historyCalls).toBe(0)
   })
 })

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
@@ -29,7 +29,15 @@ interface RoomBufferState {
   bufferMode: 'live' | 'historical'
   pendingLiveMessages: Message[]
   focusMessageId: string | null
+  /** True while more older messages may exist above the buffer. */
+  hasMoreOlder: boolean
+  /** True while an older-page fetch is in flight (drives the top spinner). */
+  loadingOlder: boolean
 }
+
+/** Page size for both the initial history load and each older page. A
+ *  returned page of exactly this size means older messages may follow. */
+const HISTORY_PAGE_SIZE = 50
 
 /** Sidebar summary — derived from `model.Room` + the user's
  *  Subscription. Only the fields the sidebar / chat header read. */
@@ -94,6 +102,7 @@ interface RoomEventsContextValue {
   state: RoomEventsState
   dispatch: Dispatch<{ type: string; [k: string]: unknown }>
   loadHistory: (roomId: string) => Promise<unknown> | void
+  loadOlderHistory: (roomId: string) => Promise<unknown> | void
   setActiveRoom: (roomId: string | null) => void
   jumpToMessage: (roomId: string, messageId: string) => Promise<void> | void
   resetToLiveTail: (roomId: string) => void
@@ -120,6 +129,7 @@ export function RoomEventsProvider({ children }: { children: ReactNode }) {
   ]
 
   const inflightHistory = useRef(new Map<string, Promise<unknown>>())
+  const inflightOlder = useRef(new Map<string, Promise<unknown>>())
   const stateRef = useRef(state)
   stateRef.current = state
 
@@ -164,12 +174,14 @@ export function RoomEventsProvider({ children }: { children: ReactNode }) {
       const gen = currentGeneration()
       const promise = (async () => {
         try {
-          const resp = await fetchMessageHistory(nats, { roomId, siteId: user.siteId, limit: 50 })
+          const resp = await fetchMessageHistory(nats, { roomId, siteId: user.siteId, limit: HISTORY_PAGE_SIZE })
           // history-service ships newest-first; the UI reads chronological.
           // Normalisation to the broadcast `Message` shape now happens inside
           // the api op.
           const asc = [...(resp.messages ?? [])].reverse()
-          if (currentGeneration() === gen) dispatch({ type: 'HISTORY_LOADED', roomId, messages: asc })
+          // A full page back ⇒ there may be older messages to paginate to.
+          const hasMoreOlder = (resp.messages?.length ?? 0) >= HISTORY_PAGE_SIZE
+          if (currentGeneration() === gen) dispatch({ type: 'HISTORY_LOADED', roomId, messages: asc, hasMoreOlder })
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err)
           if (currentGeneration() === gen) dispatch({ type: 'HISTORY_FAILED', roomId, error: message })
@@ -179,6 +191,49 @@ export function RoomEventsProvider({ children }: { children: ReactNode }) {
         }
       })()
       inflightHistory.current.set(roomId, promise)
+      return promise
+    },
+    [user, nats, currentGeneration],
+  )
+
+  // Fetch the page of messages immediately older than the buffer's current
+  // top, prepending them. Triggered by MessageList when the user scrolls near
+  // the top. No-ops until the initial history has loaded, when nothing older
+  // remains, or when a fetch is already in flight (coalesced via inflightOlder).
+  const loadOlderHistory = useCallback(
+    async (roomId: string) => {
+      if (!user || !roomId) return
+      const rs = stateRef.current.roomState[roomId]
+      if (!rs || !rs.hasLoadedHistory) return
+      if (rs.loadingOlder || !rs.hasMoreOlder) return
+      if (inflightOlder.current.has(roomId)) return inflightOlder.current.get(roomId)
+      const oldest = rs.messages[0]
+      if (!oldest) return
+      // `before` is an exclusive cursor (history-service: created_at < before),
+      // so the oldest loaded message's own timestamp fetches strictly older rows.
+      const before = new Date(oldest.createdAt).getTime()
+      if (!Number.isFinite(before)) return
+      const summary = stateRef.current.summaries.find((r) => r.id === roomId)
+      const siteId = summary?.siteId ?? user.siteId
+
+      const gen = currentGeneration()
+      dispatch({ type: 'HISTORY_OLDER_LOADING', roomId })
+      const promise = (async () => {
+        try {
+          const resp = await fetchMessageHistory(nats, { roomId, siteId, limit: HISTORY_PAGE_SIZE, before })
+          const asc = [...(resp.messages ?? [])].reverse()
+          const hasMoreOlder = (resp.messages?.length ?? 0) >= HISTORY_PAGE_SIZE
+          if (currentGeneration() === gen) {
+            dispatch({ type: 'HISTORY_OLDER_LOADED', roomId, messages: asc, hasMoreOlder })
+          }
+        } catch (err) {
+          if (currentGeneration() === gen) dispatch({ type: 'HISTORY_OLDER_FAILED', roomId })
+          throw err
+        } finally {
+          inflightOlder.current.delete(roomId)
+        }
+      })()
+      inflightOlder.current.set(roomId, promise)
       return promise
     },
     [user, nats, currentGeneration],
@@ -239,6 +294,7 @@ export function RoomEventsProvider({ children }: { children: ReactNode }) {
       state,
       dispatch,
       loadHistory,
+      loadOlderHistory,
       setActiveRoom,
       jumpToMessage,
       resetToLiveTail,
@@ -249,6 +305,7 @@ export function RoomEventsProvider({ children }: { children: ReactNode }) {
       state,
       dispatch,
       loadHistory,
+      loadOlderHistory,
       setActiveRoom,
       jumpToMessage,
       resetToLiveTail,
@@ -267,9 +324,14 @@ function useRoomEventsInternal(): RoomEventsContextValue {
 }
 
 export function useRoomEvents(roomId: string | null | undefined) {
-  const { state, dispatch, loadHistory, jumpToMessage, resetToLiveTail } = useRoomEventsInternal()
+  const { state, dispatch, loadHistory, loadOlderHistory, jumpToMessage, resetToLiveTail } =
+    useRoomEventsInternal()
   const room = roomId ? state.roomState[roomId] : undefined
   const load = useCallback(() => (roomId ? loadHistory(roomId) : undefined), [loadHistory, roomId])
+  const loadOlder = useCallback(
+    () => (roomId ? loadOlderHistory(roomId) : undefined),
+    [loadOlderHistory, roomId],
+  )
   const jump = useCallback(
     (messageId: string) => (roomId ? jumpToMessage(roomId, messageId) : undefined),
     [jumpToMessage, roomId],
@@ -281,6 +343,9 @@ export function useRoomEvents(roomId: string | null | undefined) {
       hasLoadedHistory: !!room?.hasLoadedHistory,
       historyError: room?.historyError ?? null,
       loadHistory: load,
+      loadOlder,
+      hasMoreOlder: room?.hasMoreOlder ?? true,
+      loadingOlder: !!room?.loadingOlder,
       bufferMode: room?.bufferMode ?? BUFFER_MODE.LIVE,
       pendingCount: room?.pendingLiveMessages?.length ?? 0,
       focusMessageId: room?.focusMessageId ?? null,
@@ -288,7 +353,7 @@ export function useRoomEvents(roomId: string | null | undefined) {
       resetToLiveTail: reset,
       dispatch,
     }),
-    [room, load, jump, reset, dispatch],
+    [room, load, loadOlder, jump, reset, dispatch],
   )
 }
 

--- a/chat-frontend/src/context/RoomEventsContext/reducer.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.js
@@ -157,6 +157,12 @@ function emptyRoomState() {
     bufferMode: BUFFER_MODE.LIVE,
     pendingLiveMessages: [],
     focusMessageId: null,
+    // Older-message pagination. `hasMoreOlder` starts true (unknown ⇒
+    // assume there may be older history) and is set from the fetched
+    // page's fullness once history loads. `loadingOlder` guards the
+    // in-flight older-page fetch and drives the top spinner.
+    hasMoreOlder: true,
+    loadingOlder: false,
   }
 }
 
@@ -488,7 +494,59 @@ export function roomEventsReducer(state, action) {
             messages: merged,
             hasLoadedHistory: true,
             historyError: null,
+            // Whether a full first page came back (⇒ older pages may follow).
+            // Absent action field leaves the prior value untouched.
+            hasMoreOlder: action.hasMoreOlder ?? prev.hasMoreOlder,
+            loadingOlder: false,
           },
+        },
+      }
+    }
+    case 'HISTORY_OLDER_LOADING': {
+      const prev = state.roomState[action.roomId] ?? emptyRoomState()
+      return {
+        ...state,
+        roomState: {
+          ...state.roomState,
+          [action.roomId]: { ...prev, loadingOlder: true, historyError: null },
+        },
+      }
+    }
+    case 'HISTORY_OLDER_LOADED': {
+      const prev = state.roomState[action.roomId] ?? emptyRoomState()
+      // Prepend the older block ahead of the current buffer, deduping any id
+      // already present. Unlike the live tail, older pages are NOT trimmed to
+      // MAX_CACHED from the front — trimming the front would discard exactly
+      // the messages the user paginated up to see. The buffer is allowed to
+      // grow while the user is actively browsing older history.
+      const existingIds = new Set(prev.messages.map((m) => m.id))
+      const older = (action.messages ?? []).filter((m) => !existingIds.has(m.id))
+      const messages = older.length ? [...older, ...prev.messages] : prev.messages
+      return {
+        ...state,
+        roomState: {
+          ...state.roomState,
+          [action.roomId]: {
+            ...prev,
+            messages,
+            loadingOlder: false,
+            hasMoreOlder: !!action.hasMoreOlder,
+            historyError: null,
+          },
+        },
+      }
+    }
+    case 'HISTORY_OLDER_FAILED': {
+      const prev = state.roomState[action.roomId] ?? emptyRoomState()
+      // Only stop the spinner. Leave hasMoreOlder untouched so the next
+      // scroll-to-top retries, and don't hoist the failure into the
+      // room-wide historyError banner — a failed older page shouldn't blank
+      // the messages the user is already reading.
+      return {
+        ...state,
+        roomState: {
+          ...state.roomState,
+          [action.roomId]: { ...prev, loadingOlder: false },
         },
       }
     }
@@ -517,6 +575,10 @@ export function roomEventsReducer(state, action) {
             bufferMode: BUFFER_MODE.HISTORICAL,
             focusMessageId: action.focusMessageId ?? null,
             pendingLiveMessages: [],
+            // A jumped-to window sits in the middle of history — older
+            // messages exist above it, so re-enable upward pagination.
+            hasMoreOlder: true,
+            loadingOlder: false,
           },
         },
       }

--- a/chat-frontend/src/context/RoomEventsContext/reducer.test.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.test.js
@@ -1604,3 +1604,132 @@ describe('roomEventsReducer: readSeq (post-mark-read refetch trigger)', () => {
     expect(next.readSeq).toBe(1)
   })
 })
+
+// Helper: build an ascending block of history messages m<start>..m<end>.
+function histBlock(ids, roomId = 'a') {
+  return ids.map((id, i) => ({
+    id,
+    roomId,
+    content: id,
+    createdAt: new Date(Date.UTC(2026, 3, 17, 8, i, 0)).toISOString(),
+    sender: { account: 'bob' },
+  }))
+}
+
+describe('roomEventsReducer: older-message pagination', () => {
+  it('HISTORY_LOADED records hasMoreOlder from the action', () => {
+    const next = roomEventsReducer(initialState, {
+      type: 'HISTORY_LOADED',
+      roomId: 'a',
+      messages: histBlock(['m1', 'm2']),
+      hasMoreOlder: true,
+    })
+    expect(next.roomState.a.hasMoreOlder).toBe(true)
+    expect(next.roomState.a.loadingOlder).toBe(false)
+  })
+
+  it('a fresh room state defaults hasMoreOlder true / loadingOlder false', () => {
+    const next = roomEventsReducer(initialState, {
+      type: 'HISTORY_LOADED',
+      roomId: 'a',
+      messages: histBlock(['m1']),
+      hasMoreOlder: false,
+    })
+    // hasMoreOlder reflects the action; loadingOlder starts false.
+    expect(next.roomState.a.hasMoreOlder).toBe(false)
+    expect(next.roomState.a.loadingOlder).toBe(false)
+  })
+
+  it('HISTORY_OLDER_LOADING flips loadingOlder true and clears historyError', () => {
+    const loaded = roomEventsReducer(initialState, {
+      type: 'HISTORY_LOADED',
+      roomId: 'a',
+      messages: histBlock(['m5', 'm6']),
+      hasMoreOlder: true,
+    })
+    const next = roomEventsReducer(loaded, { type: 'HISTORY_OLDER_LOADING', roomId: 'a' })
+    expect(next.roomState.a.loadingOlder).toBe(true)
+    expect(next.roomState.a.historyError).toBe(null)
+  })
+
+  it('HISTORY_OLDER_LOADED prepends the older block ahead of existing messages', () => {
+    const loaded = roomEventsReducer(initialState, {
+      type: 'HISTORY_LOADED',
+      roomId: 'a',
+      messages: histBlock(['m5', 'm6']),
+      hasMoreOlder: true,
+    })
+    const loading = roomEventsReducer(loaded, { type: 'HISTORY_OLDER_LOADING', roomId: 'a' })
+    const next = roomEventsReducer(loading, {
+      type: 'HISTORY_OLDER_LOADED',
+      roomId: 'a',
+      messages: histBlock(['m3', 'm4']),
+      hasMoreOlder: true,
+    })
+    expect(next.roomState.a.messages.map((m) => m.id)).toEqual(['m3', 'm4', 'm5', 'm6'])
+    expect(next.roomState.a.loadingOlder).toBe(false)
+    expect(next.roomState.a.hasMoreOlder).toBe(true)
+  })
+
+  it('HISTORY_OLDER_LOADED dedupes ids already present', () => {
+    const loaded = roomEventsReducer(initialState, {
+      type: 'HISTORY_LOADED',
+      roomId: 'a',
+      messages: histBlock(['m4', 'm5']),
+      hasMoreOlder: true,
+    })
+    const next = roomEventsReducer(loaded, {
+      type: 'HISTORY_OLDER_LOADED',
+      roomId: 'a',
+      messages: histBlock(['m3', 'm4']), // m4 overlaps
+      hasMoreOlder: false,
+    })
+    expect(next.roomState.a.messages.map((m) => m.id)).toEqual(['m3', 'm4', 'm5'])
+    expect(next.roomState.a.hasMoreOlder).toBe(false)
+  })
+
+  it('HISTORY_OLDER_LOADED does NOT trim the front (keeps older beyond the live cap)', () => {
+    // Seed a full-cap buffer of newest messages, then prepend older ones.
+    const newest = histBlock(Array.from({ length: 200 }, (_, i) => `n${i}`))
+    const loaded = roomEventsReducer(initialState, {
+      type: 'HISTORY_LOADED',
+      roomId: 'a',
+      messages: newest,
+      hasMoreOlder: true,
+    })
+    const older = histBlock(['o1', 'o2', 'o3'])
+    const next = roomEventsReducer(loaded, {
+      type: 'HISTORY_OLDER_LOADED',
+      roomId: 'a',
+      messages: older,
+      hasMoreOlder: true,
+    })
+    expect(next.roomState.a.messages.length).toBe(203)
+    expect(next.roomState.a.messages.slice(0, 3).map((m) => m.id)).toEqual(['o1', 'o2', 'o3'])
+  })
+
+  it('HISTORY_OLDER_FAILED clears loadingOlder and keeps hasMoreOlder for retry', () => {
+    const loaded = roomEventsReducer(initialState, {
+      type: 'HISTORY_LOADED',
+      roomId: 'a',
+      messages: histBlock(['m5']),
+      hasMoreOlder: true,
+    })
+    const loading = roomEventsReducer(loaded, { type: 'HISTORY_OLDER_LOADING', roomId: 'a' })
+    const next = roomEventsReducer(loading, { type: 'HISTORY_OLDER_FAILED', roomId: 'a' })
+    expect(next.roomState.a.loadingOlder).toBe(false)
+    expect(next.roomState.a.hasMoreOlder).toBe(true)
+  })
+
+  it('REPLACE_ROOM_BUFFER (jump) resets hasMoreOlder true so a jumped window can page up', () => {
+    const next = roomEventsReducer(initialState, {
+      type: 'REPLACE_ROOM_BUFFER',
+      roomId: 'a',
+      messages: histBlock(['j1', 'j2']),
+      focusMessageId: 'j1',
+    })
+    expect(next.roomState.a.hasMoreOlder).toBe(true)
+    expect(next.roomState.a.loadingOlder).toBe(false)
+    expect(next.roomState.a.bufferMode).toBe(BUFFER_MODE.HISTORICAL)
+  })
+})


### PR DESCRIPTION
## Summary

The room view fetched only the newest 50 messages on open and never paginated: `fetchMessageHistory` exposed a `before` cursor but no consumer used it, and there was no scroll-up affordance. Anything older than the first page was unreachable in the message list. This PR adds scroll-up "load older" pagination.

(Follow-up to #143, which added subscription-list pagination and is already merged. This is the separate message-history pagination change.)

## Key changes

**Reducer** (`reducer.js`)
- New per-room flags `hasMoreOlder` / `loadingOlder` and actions `HISTORY_OLDER_LOADING` / `_LOADED` / `_FAILED`.
- `HISTORY_OLDER_LOADED` prepends the older block ahead of the buffer and deduplicates by id. Unlike the live tail, prepended pages are **not** trimmed to `MAX_CACHED` from the front — trimming the front would discard exactly the messages the user paginated up to see.
- `HISTORY_LOADED` / `REPLACE_ROOM_BUFFER` seed `hasMoreOlder` (a full first page ⇒ more may follow; a jumped-to window always has older messages above it).

**Context thunk** (`RoomEventsContext.tsx`)
- `loadOlderHistory` fetches with `before` = the oldest loaded message's timestamp — an exclusive cursor server-side (`created_at < before`), so no overlap. Coalesces in-flight loads via a per-room map and honours the connection-generation guard.
- Exposed through `useRoomEvents` as `loadOlder` / `hasMoreOlder` / `loadingOlder`.

**UI** (`MessageList.jsx`, `RoomMessageArea.jsx`)
- MessageList triggers `loadOlder` when scrolled near the top and pins the scroll position across the prepend via a `useLayoutEffect` anchor, so the viewport doesn't jump.
- RoomMessageArea's bottom-auto-scroll now keys on the **last** message id, so an older prepend no longer yanks the user back to the live tail (a new message still scrolls to bottom).
- Top "Loading earlier messages…" indicator.

## Testing

- 17 new tests (reducer action transitions, thunk cursor/dedup/no-op guards, scroll-trigger gating) written test-first.
- Also hardens a pre-existing race in the `jumpToMessage` test: it waited only for the bootstrap request to be *issued*, not for `state.summaries` to populate, so `jumpToMessage` could read the wrong `siteId`. Now gated on the summary landing; confirmed stable across repeated runs.
- Full suite (797 tests) passes; `npm run typecheck` clean; production build clean.

## Notes

Page size is `HISTORY_PAGE_SIZE = 50` for both the initial and older loads; the server caps history at 100/page. Each scroll-up fetches up to 50 — easy to raise if fewer round-trips are preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAQw3KevmrftY1BwfKxp6J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic loading of earlier room messages when scrolling near the top.
  * Added a loading indicator while older messages are retrieved.
  * Preserved the current view position when older history is added.
  * Prevented loading more history when no additional messages are available.

* **Bug Fixes**
  * Prevented newly loaded older messages from unexpectedly scrolling the view to the latest message.

* **Tests**
  * Added coverage for older-message loading, pagination states, deduplication, and scroll behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->