### PR TITLE
[Fix] teams.create: derive room id, type, and name from the chat id

### DIFF
--- a/room-worker/teamsroomcreate.go
+++ b/room-worker/teamsroomcreate.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/hmchangw/chat/pkg/errcode"
@@ -46,10 +47,18 @@ func (h *Handler) reconcileTeamsRoom(ctx context.Context, chat *model.TeamsRoomC
 		return errors.New("chat has no id")
 	}
 
+	// A Teams chat id (…@thread.v2 / …@unq.gbl.spaces) can't be a room id — its
+	// dots/@ break NATS subject tokenisation — so derive a base62 id from it
+	// deterministically (same id on every redelivery). Name falls back to the
+	// members when the chat has no topic (a DM or an unnamed group).
+	name := chat.Name
+	if name == "" {
+		name = composeMigratedRoomName(chat.Members)
+	}
 	room := &model.Room{
-		ID:        chat.ID, // chat id is the room id — idempotent on redelivery
-		Name:      chat.Name,
-		Type:      model.RoomTypeChannel,
+		ID:        idgen.DeterministicID([]byte(chat.ID)),
+		Name:      name,
+		Type:      roomTypeFromTeamsChatID(chat.ID),
 		SiteID:    h.siteID,
 		Origin:    model.OriginTeams,
 		CreatedAt: chat.CreatedDateTime.UTC(),
@@ -163,6 +172,31 @@ func (h *Handler) reconcileTeamsRoom(ctx context.Context, chat *model.TeamsRoomC
 		return fmt.Errorf("federate departed members: %w", err)
 	}
 	return nil
+}
+
+// teamsDMChatIDSuffix marks a Teams 1:1 chat id; group/meeting ids end in @thread.v2.
+const teamsDMChatIDSuffix = "@unq.gbl.spaces"
+
+// roomTypeFromTeamsChatID classifies a migrated room by the Teams chat id suffix:
+// a 1:1 (…@unq.gbl.spaces) is a DM, anything else (group/meeting) a channel.
+func roomTypeFromTeamsChatID(chatID string) model.RoomType {
+	if strings.HasSuffix(chatID, teamsDMChatIDSuffix) {
+		return model.RoomTypeDM
+	}
+	return model.RoomTypeChannel
+}
+
+// composeMigratedRoomName joins the members' display names with ", " — the room
+// name for a DM or an unnamed group (a chat with no Teams topic). Isolated so the
+// format is a one-place change.
+func composeMigratedRoomName(members []model.TeamsRoomCreateMember) string {
+	names := make([]string, 0, len(members))
+	for _, m := range members {
+		if m.DisplayName != "" {
+			names = append(names, m.DisplayName)
+		}
+	}
+	return strings.Join(names, ", ")
 }
 
 // resolveMember returns account's user, publishing a new identity when none

--- a/room-worker/teamsroomcreate_test.go
+++ b/room-worker/teamsroomcreate_test.go
@@ -79,7 +79,7 @@ func TestProcessTeamsRoomCreate_AddOnly(t *testing.T) {
 	}
 
 	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
-	store.EXPECT().ListByRoom(gomock.Any(), "chat1").Return(nil, nil)
+	store.EXPECT().ListByRoom(gomock.Any(), gomock.Any()).Return(nil, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a"}, nil)
 	store.EXPECT().GetUser(gomock.Any(), "carol").Return(nil, ErrUserNotFound)
 	store.EXPECT().GetUser(gomock.Any(), "dave").Return(&model.User{ID: "u4", Account: "dave", SiteID: "site-b"}, nil)
@@ -87,14 +87,14 @@ func TestProcessTeamsRoomCreate_AddOnly(t *testing.T) {
 		func(_ context.Context, subs []*model.Subscription) error {
 			require.Len(t, subs, 3)
 			for _, s := range subs {
-				assert.Equal(t, "chat1", s.RoomID)
+				assert.Equal(t, idgen.DeterministicID([]byte("chat1")), s.RoomID)
 				assert.Equal(t, model.RoomTypeChannel, s.RoomType)
 				assert.Equal(t, []model.Role{model.RoleMember}, s.Roles)
 				assert.Equal(t, model.OriginTeams, s.Origin)
 			}
 			return nil
 		})
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), "chat1").Return(nil)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), gomock.Any()).Return(nil)
 
 	chat := model.TeamsRoomCreateChat{
 		ID:   "chat1",
@@ -133,10 +133,10 @@ func TestProcessTeamsRoomCreate_FansOutRoomKeyToAddedMembers(t *testing.T) {
 	h := NewHandler(store, "site-a", publish, testKeyStore, roomkeysender.NewSender(pub))
 
 	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
-	store.EXPECT().ListByRoom(gomock.Any(), "chat1").Return(nil, nil)
+	store.EXPECT().ListByRoom(gomock.Any(), gomock.Any()).Return(nil, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a"}, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), "chat1").Return(nil)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), gomock.Any()).Return(nil)
 
 	chat := model.TeamsRoomCreateChat{
 		ID: "chat1", Name: "Project Sync",
@@ -156,7 +156,7 @@ func TestProcessTeamsRoomCreate_DedupsDuplicateAccounts(t *testing.T) {
 	h, _ := newTeamsTestHandler(t, store)
 
 	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
-	store.EXPECT().ListByRoom(gomock.Any(), "chat1").Return(nil, nil)
+	store.EXPECT().ListByRoom(gomock.Any(), gomock.Any()).Return(nil, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a"}, nil) // exactly once
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, subs []*model.Subscription) error {
@@ -164,7 +164,7 @@ func TestProcessTeamsRoomCreate_DedupsDuplicateAccounts(t *testing.T) {
 			assert.Equal(t, "alice", subs[0].User.Account)
 			return nil
 		})
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), "chat1").Return(nil)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), gomock.Any()).Return(nil)
 
 	chat := model.TeamsRoomCreateChat{
 		ID: "chat1",
@@ -184,12 +184,12 @@ func TestProcessTeamsRoomCreate_HardRemoveOnly(t *testing.T) {
 	h, published := newTeamsTestHandler(t, store)
 
 	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
-	store.EXPECT().ListByRoom(gomock.Any(), "chat1").Return([]model.Subscription{
+	store.EXPECT().ListByRoom(gomock.Any(), gomock.Any()).Return([]model.Subscription{
 		{User: model.SubscriptionUser{Account: "alice"}, RoomID: "chat1", SiteID: "site-a"},
 		{User: model.SubscriptionUser{Account: "bob"}, RoomID: "chat1", SiteID: "site-b"},
 	}, nil)
-	store.EXPECT().DeleteSubscriptionsByAccounts(gomock.Any(), "chat1", []string{"bob"}).Return(int64(1), nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), "chat1").Return(nil)
+	store.EXPECT().DeleteSubscriptionsByAccounts(gomock.Any(), gomock.Any(), []string{"bob"}).Return(int64(1), nil)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), gomock.Any()).Return(nil)
 
 	chat := model.TeamsRoomCreateChat{
 		ID:      "chat1",
@@ -218,7 +218,7 @@ func TestProcessTeamsRoomCreate_IdempotentNoOp(t *testing.T) {
 	h, published := newTeamsTestHandler(t, store)
 
 	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
-	store.EXPECT().ListByRoom(gomock.Any(), "chat1").Return([]model.Subscription{
+	store.EXPECT().ListByRoom(gomock.Any(), gomock.Any()).Return([]model.Subscription{
 		{User: model.SubscriptionUser{Account: "alice"}, RoomID: "chat1", SiteID: "site-a"},
 	}, nil)
 
@@ -242,15 +242,15 @@ func TestProcessTeamsRoomCreate_PerChatIsolation(t *testing.T) {
 	// chat "bad" errors at CreateRoom; chat "good" proceeds normally.
 	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, room *model.Room, _ *roomkeystore.RoomKeyPair) (bool, error) {
-			if room.ID == "bad" {
+			if room.ID == idgen.DeterministicID([]byte("bad")) {
 				return false, assert.AnError
 			}
 			return true, nil
 		}).Times(2)
-	store.EXPECT().ListByRoom(gomock.Any(), "good").Return(nil, nil)
+	store.EXPECT().ListByRoom(gomock.Any(), gomock.Any()).Return(nil, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a"}, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), "good").Return(nil)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), gomock.Any()).Return(nil)
 
 	chats := []model.TeamsRoomCreateChat{
 		{ID: "bad", Members: []model.TeamsRoomCreateMember{{ID: "x", Account: "zoe"}}},
@@ -313,6 +313,70 @@ func TestResolveMember_PublishesDeterministicIdentity(t *testing.T) {
 	assert.Equal(t, "site-a", got.SiteID)
 }
 
+func TestRoomTypeFromTeamsChatID(t *testing.T) {
+	cases := []struct {
+		name, id string
+		want     model.RoomType
+	}{
+		{"1:1 dm", "19:abc@unq.gbl.spaces", model.RoomTypeDM},
+		{"group", "19:abc@thread.v2", model.RoomTypeChannel},
+		{"meeting", "19:meeting_abc@thread.v2", model.RoomTypeChannel},
+		{"no suffix", "chat1", model.RoomTypeChannel},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, roomTypeFromTeamsChatID(tc.id))
+		})
+	}
+}
+
+func TestComposeMigratedRoomName(t *testing.T) {
+	assert.Equal(t, "Alice 愛麗絲, Bob 鮑伯", composeMigratedRoomName([]model.TeamsRoomCreateMember{
+		{Account: "alice", DisplayName: "Alice 愛麗絲"},
+		{Account: "bob", DisplayName: "Bob 鮑伯"},
+	}))
+	assert.Equal(t, "Alice 愛麗絲", composeMigratedRoomName([]model.TeamsRoomCreateMember{
+		{Account: "alice", DisplayName: "Alice 愛麗絲"},
+		{Account: "ghost", DisplayName: ""}, // unresolved member — no name to add
+	}))
+	assert.Empty(t, composeMigratedRoomName(nil))
+}
+
+// TestReconcileTeamsRoom_DerivesIdTypeName: a 1:1 chat (@unq.gbl.spaces, no topic)
+// becomes a DM room with a base62 id derived from the chat id and a name composed
+// from the two members' display names.
+func TestReconcileTeamsRoom_DerivesIdTypeName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	h, _ := newTeamsTestHandler(t, store)
+	chatID := "19:dm-abc@unq.gbl.spaces"
+	wantRoomID := idgen.DeterministicID([]byte(chatID))
+
+	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, room *model.Room, _ *roomkeystore.RoomKeyPair) (bool, error) {
+			assert.Equal(t, wantRoomID, room.ID, "id derived from chat id, not the raw Teams id")
+			assert.Equal(t, model.RoomTypeDM, room.Type, "@unq.gbl.spaces → dm")
+			assert.Equal(t, "Alice 愛麗絲, Bob 鮑伯", room.Name, "no topic → composed member names")
+			return true, nil
+		})
+	store.EXPECT().ListByRoom(gomock.Any(), wantRoomID).Return(nil, nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a"}, nil)
+	store.EXPECT().GetUser(gomock.Any(), "bob").Return(&model.User{ID: "u2", Account: "bob", SiteID: "site-a"}, nil)
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), wantRoomID).Return(nil)
+
+	chat := model.TeamsRoomCreateChat{
+		ID:   chatID,
+		Name: "",
+		Members: []model.TeamsRoomCreateMember{
+			{ID: "aad-a", Account: "alice", DisplayName: "Alice 愛麗絲"},
+			{ID: "aad-b", Account: "bob", DisplayName: "Bob 鮑伯"},
+		},
+		CreatedDateTime: time.Unix(0, 0).UTC(),
+	}
+	require.NoError(t, h.processTeamsRoomCreate(context.Background(), teamsCreateEvent(chat)))
+}
+
 // TestProcessTeamsRoomCreate_MalformedBatch: an unparsable envelope is Permanent
 // (poison) — never redelivered.
 func TestProcessTeamsRoomCreate_MalformedBatch(t *testing.T) {
@@ -362,10 +426,10 @@ func TestProcessTeamsRoomCreate_StampsMigrationHeader(t *testing.T) {
 	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender)
 
 	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
-	store.EXPECT().ListByRoom(gomock.Any(), "chat1").Return(nil, nil)
+	store.EXPECT().ListByRoom(gomock.Any(), gomock.Any()).Return(nil, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a"}, nil)
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), "chat1").Return(nil)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), gomock.Any()).Return(nil)
 
 	chat := model.TeamsRoomCreateChat{
 		ID:      "chat1",


### PR DESCRIPTION
## Summary
Fix migrated Teams room creation in `room-worker`: a raw Teams chat id can't be used as a room id, and a 1:1 (or unnamed group) was created as a nameless channel.

Closes #149.

> **Stacked on #147** (member `displayName`). The diff below temporarily includes #147's commits; it will be rebased onto `main` once #147 merges, leaving only this PR's changes. Kept as a draft until then.

## Changes
- **`room._id`** = `idgen.DeterministicID(chat.ID)` — a Teams id (`…@thread.v2` / `…@unq.gbl.spaces`) contains `.`/`@` that break NATS subject tokenisation; derive a clean base62 id deterministically (same id on every redelivery, so JetStream redelivery stays idempotent).
- **Type** from the chat-id suffix (`roomTypeFromTeamsChatID`): `@unq.gbl.spaces` → `dm`, everything else (group / meeting) → `channel`.
- **Name**: the Teams topic when set; otherwise composed from the members' display names joined `", "` (`composeMigratedRoomName`) — for a DM or an unnamed group. Isolated in one helper so the format is a one-place change.

## Verification
- Unit: `roomTypeFromTeamsChatID` (dm / group / meeting / no-suffix), `composeMigratedRoomName` (join, skip-empty, empty), and a reconcile test asserting the derived id + `dm` type + composed name; full `room-worker` suite green.
- `go vet` clean; golangci-lint 0 issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migrated Teams rooms now receive consistent room identifiers.
  * Teams 1:1 chats are recognized as direct-message rooms; other chats are treated as channel rooms.
  * Rooms without a provided name now use member display names as a fallback.

* **Bug Fixes**
  * Improved room reconciliation for migrated Teams chats, including unnamed direct messages and membership-related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->