### PR TITLE
Preserve declared Content-Type through upload to Drive

### DIFF
--- a/docs/superpowers/specs/2026-07-29-drive-upload-content-type-design.md
+++ b/docs/superpowers/specs/2026-07-29-drive-upload-content-type-design.md
@@ -1,0 +1,106 @@
+# Drive Upload Content-Type — Design
+
+**Date:** 2026-07-29
+**Service:** `upload-service` (+ `pkg/drive`)
+
+## Problem
+
+`GET /api/v1/file/rooms/:roomId/file/:fileId` always responds with
+`Content-Type: application/octet-stream`, even for PNGs and PDFs.
+
+The download path is not at fault. `GetGroupImage` lifts the storage response's
+`Content-Type` (`pkg/drive/uploader.go`) and `HandleDownloadFile` hands it to
+`c.DataFromReader`; a repro driving the real `drive.Client` against a storage
+stub that returns `image/png` yields `ContentType="image/png"`, and no
+middleware in `upload-service` writes a `Content-Type` header.
+
+The type was lost at **upload** time. `UploadGroupImages` passed the
+package-level `defaultContentType` (`application/octet-stream`) as the multipart
+part's `Content-Type` for every file:
+
+```go
+req.SetMultipartField(fmt.Sprintf("files[%d].file", i), f.Filename, defaultContentType, f.File)
+```
+
+Downloads are served by a **presigned URL straight to object storage**, so the
+response header is the stored object's metadata, which Drive set when it PUT the
+object. S3/MinIO defaults that metadata to `application/octet-stream` when the
+PUT does not specify a type — nothing sniffs bytes or reads the extension. The
+bulk-upload form carries no other per-file type field (`files[i].fileName` and
+`files[i].mode` only), so the part header is the sole type signal available to
+the caller.
+
+Drive's own API reports `image/png` / `application/pdf` for the same file
+because it infers the type from the extension rather than reading stored
+metadata — hence the discrepancy.
+
+## Design
+
+Use Resty's `SetFileReader` instead of `SetMultipartField`. It takes no content
+type argument: it routes through `writeMultipartFormFile`, which reads the
+leading bytes of each part and calls `http.DetectContentType`, so every part
+declares its true media type without any caller having to supply one.
+
+```go
+req.SetFileReader(fmt.Sprintf("files[%d].file", i), f.Filename, f.File)
+```
+
+Consequences:
+
+- `drive.MultipartFile` stays `{File, Filename}` — no content-type field, and no
+  caller plumbing in `upload-service`.
+- Sniffing reads bytes, so it cannot be fooled by a wrong client-declared MIME
+  or a misleading extension.
+- Part ordering is unchanged: Resty writes `FormData` fields first, then
+  `multipartFiles` (where `SetFileReader` lands), then `multipartFields`. Only
+  one file bucket is in use, so the wire order matches the previous behavior.
+
+### Known gap: HEIC
+
+`http.DetectContentType` has no HEIC signature — HEIC is an ISO-BMFF `ftyp` box
+and Go's sniffer only recognizes the `mp4` brand. HEIC files therefore still
+store as `application/octet-stream`, despite `.heic` being in
+`drive.AllowedImageFileTypes`. This is not a regression (every format was
+octet-stream before), but it is the one accepted image format sniffing cannot
+name. Closing it would need an extension-based fallback when the sniffer returns
+octet-stream.
+
+## Scope / non-goals
+
+- **Existing Drive objects are not repaired.** Files uploaded before this change
+  remain stored as `application/octet-stream` and will keep downloading as such;
+  correcting them needs a re-upload or a Drive-side metadata migration. A
+  download-time fallback deriving the type from the filename was considered and
+  explicitly declined.
+- No download-path change; `HandleDownloadFile` continues to forward whatever
+  storage reports.
+- `upload-service` HTTP routes are not `chat.user.` NATS subjects, so
+  `docs/client-api.md` needs no update.
+- No new dependencies.
+
+## Open verification
+
+Drive performs the S3 PUT and is not in this repo, so **whether Drive forwards
+the part's `Content-Type` into that PUT is unverified.** The part header is the
+only type signal the bulk-upload API accepts, so it is the only lever available
+to a caller, but confirming the fix is load-bearing requires one manual test:
+upload a PNG through this code against dev/staging Drive, then check the
+`Content-Type` on the file endpoint (or the stored metadata behind the presigned
+URL). Unit tests and CI both stub Drive out and cannot answer this.
+
+If Drive turns out to ignore the part header, the fix has to move — Drive-side
+(infer at store time, or set `response-content-type` on the URL it signs) or
+download-side in `upload-service` (derive from `img.Filename` when storage
+reports octet-stream, which also repairs already-stored files).
+
+## Testing (TDD: Red → Green → Refactor)
+
+**`pkg/drive` (`uploader_test.go`):**
+- Each part's `Content-Type` is sniffed from its bytes: PNG, JPEG, PDF, text,
+  HEIC (→ octet-stream, documenting the gap), unrecognized binary
+  (→ octet-stream), empty body (→ `text/plain`, which is what
+  `DetectContentType` returns for no bytes).
+- Sniffing does not consume the leading bytes — the full body still reaches
+  Drive.
+- Multiple files are sniffed independently and keep their `files[i]` index
+  mapping.

--- a/pkg/drive/uploader.go
+++ b/pkg/drive/uploader.go
@@ -66,7 +66,7 @@ func (c *Client) UploadGroupImages(userID, username, email, groupID, origin stri
 		"email":    email,
 	}
 	for i, f := range files {
-		req.SetMultipartField(fmt.Sprintf("files[%d].file", i), f.Filename, defaultContentType, f.File)
+		req.SetFileReader(fmt.Sprintf("files[%d].file", i), f.Filename, f.File)
 		formData[fmt.Sprintf("files[%d].fileName", i)] = f.Filename
 		formData[fmt.Sprintf("files[%d].mode", i)] = "Normal"
 	}

--- a/pkg/drive/uploader_test.go
+++ b/pkg/drive/uploader_test.go
@@ -62,6 +62,128 @@ func TestClient_UploadGroupImages(t *testing.T) {
 	}
 }
 
+// partContentTypeServer captures the Content-Type of every uploaded file part,
+// keyed by the part's form field name.
+func partContentTypeServer(t *testing.T, got map[string]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// #nosec G120 -- test httptest server with a fixed 10MiB bound; not exposed to untrusted traffic
+		if err := r.ParseMultipartForm(10 << 20); err != nil {
+			t.Errorf("parse multipart form: %v", err)
+		}
+		for field, headers := range r.MultipartForm.File {
+			got[field] = headers[0].Header.Get("Content-Type")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[]`)
+	}))
+}
+
+// Magic-byte prefixes are all http.DetectContentType needs to classify a part.
+const (
+	pngMagic  = "\x89PNG\r\n\x1a\n....."
+	jpegMagic = "\xff\xd8\xff....."
+	pdfMagic  = "%PDF-1.7\n....."
+	// HEIC is an ISO-BMFF 'ftyp' box. Go's sniffer only recognizes the mp4 brand,
+	// so heic falls through to octet-stream — the one format sniffing can't name.
+	heicMagic = "\x00\x00\x00\x18ftypheic\x00\x00\x00\x00mif1heic"
+)
+
+// The part Content-Type is sniffed from the leading bytes, so the true media type
+// reaches Drive without any caller having to declare it.
+func TestClient_UploadGroupImages_SniffsPartContentType(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		body     string
+		want     string
+	}{
+		{name: "png", filename: "a.png", body: pngMagic, want: "image/png"},
+		{name: "jpeg", filename: "a.jpg", body: jpegMagic, want: "image/jpeg"},
+		{name: "pdf", filename: "a.pdf", body: pdfMagic, want: "application/pdf"},
+		{name: "text", filename: "a.txt", body: "hello there", want: "text/plain; charset=utf-8"},
+		{name: "heic sniffs as octet-stream", filename: "a.heic", body: heicMagic, want: defaultContentType},
+		{name: "unrecognized binary", filename: "a.bin", body: "\x07\x08\x09\x00\x01\x02\x03", want: defaultContentType},
+		// DetectContentType treats no bytes as text, not octet-stream.
+		{name: "empty body sniffs as text", filename: "a.bin", body: "", want: "text/plain; charset=utf-8"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := map[string]string{}
+			srv := partContentTypeServer(t, got)
+			defer srv.Close()
+
+			c := NewClient(&Config{URL: srv.URL, Token: "tok"})
+			_, err := c.UploadGroupImages("alice", "Alice", "a@x.com", "r1", "site-x",
+				[]MultipartFile{{File: fakeMultipart(tt.body), Filename: tt.filename}})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got["files[0].file"] != tt.want {
+				t.Fatalf("part content type = %q, want %q", got["files[0].file"], tt.want)
+			}
+		})
+	}
+}
+
+// Sniffing must not consume the leading bytes: Drive has to receive the whole file.
+func TestClient_UploadGroupImages_SniffPreservesFullBody(t *testing.T) {
+	body := pngMagic + strings.Repeat("payload", 200)
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// #nosec G120 -- test httptest server with a fixed 10MiB bound; not exposed to untrusted traffic
+		if err := r.ParseMultipartForm(10 << 20); err != nil {
+			t.Errorf("parse multipart form: %v", err)
+		}
+		f, err := r.MultipartForm.File["files[0].file"][0].Open()
+		if err != nil {
+			t.Errorf("open part: %v", err)
+			return
+		}
+		defer f.Close()
+		b, err := io.ReadAll(f)
+		if err != nil {
+			t.Errorf("read part: %v", err)
+		}
+		got = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(&Config{URL: srv.URL, Token: "tok"})
+	_, err := c.UploadGroupImages("alice", "Alice", "a@x.com", "r1", "site-x",
+		[]MultipartFile{{File: fakeMultipart(body), Filename: "a.png"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != body {
+		t.Fatalf("part body = %d bytes, want %d (sniffing must not swallow the prefix)", len(got), len(body))
+	}
+}
+
+// Multiple files must each be sniffed independently and keep their index mapping.
+func TestClient_UploadGroupImages_SniffsEachPartIndependently(t *testing.T) {
+	got := map[string]string{}
+	srv := partContentTypeServer(t, got)
+	defer srv.Close()
+
+	c := NewClient(&Config{URL: srv.URL, Token: "tok"})
+	_, err := c.UploadGroupImages("alice", "Alice", "a@x.com", "r1", "site-x", []MultipartFile{
+		{File: fakeMultipart(pngMagic), Filename: "a.png"},
+		{File: fakeMultipart(pdfMagic), Filename: "b.pdf"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got["files[0].file"] != "image/png" {
+		t.Fatalf("part 0 content type = %q, want image/png", got["files[0].file"])
+	}
+	if got["files[1].file"] != "application/pdf" {
+		t.Fatalf("part 1 content type = %q, want application/pdf", got["files[1].file"])
+	}
+}
+
 func TestClient_UploadGroupImages_ServerError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/testutil/cassandra.go
+++ b/pkg/testutil/cassandra.go
@@ -68,8 +68,16 @@ func ensureCassandraSession() (string, *gocql.Session, error) {
 		cluster.Timeout = 30 * time.Second
 		// Cassandra in Docker reports its rpc_address as the container's internal IP; skip discovery to use the mapped port.
 		cluster.DisableInitialHostLookup = true
-		s, err := cluster.CreateSession()
-		if err != nil {
+		// The "Starting listening for CQL clients" log line fires before the port
+		// reliably completes a handshake: under CI load Cassandra accepts the
+		// connection and immediately closes it, which gocql reports as "unable to
+		// discover protocol version: EOF". Retry until it genuinely answers.
+		var s *gocql.Session
+		if err := retryUntil(2*time.Minute, func() error {
+			var sessErr error
+			s, sessErr = cluster.CreateSession()
+			return sessErr
+		}); err != nil {
 			_ = container.Terminate(ctx)
 			cassInitErr = fmt.Errorf("create cassandra session: %w", err)
 			return

--- a/pkg/testutil/retry.go
+++ b/pkg/testutil/retry.go
@@ -1,0 +1,25 @@
+package testutil
+
+import "time"
+
+// retryPollInterval is the pause between retryUntil attempts.
+const retryPollInterval = 100 * time.Millisecond
+
+// retryUntil calls fn until it succeeds or timeout elapses, returning fn's last
+// error. fn always runs at least once, so a non-positive timeout still yields one
+// attempt, and fn is never attempted once the deadline has passed. For container
+// readiness checks where a wait strategy has fired but the service is not yet answering.
+func retryUntil(timeout time.Duration, fn func() error) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return err
+		}
+		time.Sleep(min(remaining, retryPollInterval))
+	}
+}

--- a/pkg/testutil/retry_test.go
+++ b/pkg/testutil/retry_test.go
@@ -1,0 +1,83 @@
+package testutil
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	errFirstAttempt = errors.New("first attempt failed")
+	errLaterAttempt = errors.New("later attempt failed")
+)
+
+func TestRetryUntil_SucceedsFirstAttempt(t *testing.T) {
+	calls := 0
+	err := retryUntil(time.Second, func() error {
+		calls++
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls, "a succeeding fn must not be retried")
+}
+
+func TestRetryUntil_SucceedsAfterTransientFailures(t *testing.T) {
+	calls := 0
+	err := retryUntil(5*time.Second, func() error {
+		calls++
+		if calls < 3 {
+			return errFirstAttempt
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+func TestRetryUntil_ReturnsLastErrorOnTimeout(t *testing.T) {
+	const timeout = 250 * time.Millisecond
+	calls := 0
+	var lastCall time.Time
+	start := time.Now()
+	err := retryUntil(timeout, func() error {
+		calls++
+		lastCall = time.Now()
+		if calls == 1 {
+			return errFirstAttempt
+		}
+		return errLaterAttempt
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errLaterAttempt, "must surface the last error")
+	assert.NotErrorIs(t, err, errFirstAttempt, "must not surface the first error")
+	assert.Greater(t, calls, 1, "should have retried before giving up")
+	// A failure just before the deadline must not buy a full extra poll interval.
+	assert.False(t, lastCall.After(start.Add(timeout+20*time.Millisecond)),
+		"fn must not be attempted after the deadline")
+}
+
+// A non-positive timeout must still attempt once rather than never calling fn.
+func TestRetryUntil_RunsAtLeastOnce(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{name: "zero timeout", timeout: 0},
+		{name: "negative timeout", timeout: -time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			err := retryUntil(tt.timeout, func() error {
+				calls++
+				return errFirstAttempt
+			})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, errFirstAttempt)
+			assert.Equal(t, 1, calls)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Downloads via `GET /api/v1/file/rooms/:roomId/file/:fileId` always responded `application/octet-stream`, even for PNGs and PDFs. The type was lost at **upload** time: `drive.UploadGroupImages` passed the `defaultContentType` constant (`application/octet-stream`) as every multipart part's `Content-Type`, and downloads are served by a presigned URL straight to object storage — so the response header is the stored object's metadata, which Drive set from that part header when it PUT the object.

Each upload part now declares its **real** media type, so downloads serve the correct `Content-Type`.

## Changes

- **`pkg/drive/uploader.go`** — Replace `SetMultipartField(..., defaultContentType, ...)` with Resty's `SetFileReader`. It takes no content-type argument: it reads each part's leading bytes and calls `http.DetectContentType`, so the true media type reaches Drive without any caller declaring one. `MultipartFile` stays `{File, Filename}` — no new field, no `upload-service` plumbing. Byte sniffing also can't be fooled by a wrong client-declared MIME or a renamed extension.
- **`pkg/drive/uploader_test.go`** — `partContentTypeServer` helper plus table-driven coverage: PNG/JPEG/PDF/text sniff to their real types, HEIC and unrecognized binary fall back to octet-stream, empty body sniffs as `text/plain` (what `DetectContentType` returns for no bytes); a separate test asserts sniffing doesn't consume the leading bytes (full body still reaches Drive) and that multiple files keep their independent `files[i]` index mapping.
- **`docs/superpowers/specs/2026-07-29-drive-upload-content-type-design.md`** — Design doc: the problem, the `SetFileReader` solution, the HEIC gap, scope/non-goals, and the one open verification (whether Drive forwards the part header into its S3 PUT).

### Test infrastructure (`pkg/testutil`)

Included so CI's full integration suite runs clean:

- **`cassandra.go` / `retry.go`** — `history-service/internal/service` integration tests intermittently failed with `gocql: unable to create session: unable to discover protocol version: EOF`. Cassandra emits its "Starting listening for CQL clients" log line (the wait strategy's trigger) before the CQL port reliably completes a handshake; under CI load the port accepts then immediately closes the connection, and because the shared container is memoized behind `sync.Once`, that one failure took all five tests in the package down instantly. `CreateSession` now retries until the port genuinely answers (2-minute ceiling, 100 ms poll), via a `retryUntil` helper that follows the deadline-loop convention already used by the Valkey and NATS/Vault readiness checks.
- **`retry_test.go`** — `retryUntil` is pure logic in the default build, so its backoff semantics are unit-tested directly (first-attempt success, transient failures, last-error-on-timeout via `errors.Is`, at-least-once on non-positive timeout, and no attempt past the deadline) rather than only exercised through containers.

## Known gaps / scope

- **HEIC** still stores as `application/octet-stream` — `http.DetectContentType` has no HEIC signature (HEIC is an ISO-BMFF `ftyp` box; Go only recognizes the `mp4` brand). Not a regression — every format was octet-stream before. Closing it would need an extension-based fallback used *only* when sniffing returns octet-stream, to keep byte detection authoritative.
- **Existing Drive objects are not repaired** — files uploaded before this change keep their octet-stream metadata; correcting them needs a re-upload or a Drive-side metadata migration.
- **No download-path change** — `HandleDownloadFile` continues to forward whatever storage reports.
- Whether Drive forwards the part's `Content-Type` into its S3 PUT is **unverified** (Drive is not in this repo; unit tests and CI stub it out). The design doc records how to settle it in dev/staging and where the fix would move if Drive ignores the header.

https://claude.ai/code/session_01TDggsPDHR2R5LRjx1oRSHy

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multipart upload handling so PNG, JPEG, and PDF files are detected from their actual bytes and downloaded with the correct media type (instead of a generic binary type).
  - Preserves the full uploaded data without truncation and ensures each multipart item is sniffed and indexed independently.
  - HEIC and other unknown/empty payloads may still fall back to the generic binary type.
- **Tests**
  - Added multipart content-type sniffing, full-body integrity, and multi-part indexing coverage.
- **Documentation**
  - Added a design spec outlining the content-type behavior and verification approach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Drive uploads so each image/document part infers its content type from its bytes, leading to downloads with the correct media type for PNG, JPEG, and PDF (unknown/HEIC/empty may still fall back to a generic binary type).
  - Ensures multipart uploads are sniffed without altering/truncating the uploaded data and that each part maps to the correct file.
- **Tests**
  - Added coverage for per-part content-type detection, full-body integrity, and correct multi-part indexing.
- **Documentation**
  - Added a design spec describing the content-type behavior and verification plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->