### PR TITLE
Drop appInfo enrichment from search message hits

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -3939,7 +3939,7 @@ See [Error envelope](#6-error-envelope-reference).
 | `card` | [MessageCard](#messagecard) | omitted when the message carries no tcard |
 | `tshow` | boolean | omitted when false — set on a thread reply that is also shown in the parent channel timeline |
 | `sender` | [MessageSender](#messagesender) | present on every hit; `account` always set, `displayName` best-effort |
-| `room` | [MessageRoom](#messageroom) | present on every hit; `id` always set, `name`/`type`/`appInfo`/`hrInfo` best-effort |
+| `room` | [MessageRoom](#messageroom) | present on every hit; `id` always set, `name`/`type`/`hrInfo` best-effort |
 
 `attachments` and `card` are the message's payloads mirrored as-is from the index (same wire shape as history reads — decoded `Attachment` objects; `card.data` is base64-encoded bytes), so the client can render a hit (file row, tcard) without a follow-up history-service load.
 
@@ -3959,7 +3959,6 @@ See [Error envelope](#6-error-envelope-reference).
 | `id` | string | roomId |
 | `name` | string | app name (`botDM`) / counterpart display name (`dm`) / canonical room name (`channel`, `discussion`). Omitted when unresolved. |
 | `type` | string | `channel` \| `dm` \| `botDM` \| `discussion`. Omitted when the caller has no subscription for the room. |
-| `appInfo` | [AppSubscription](#appsubscription) | present **only for `botDM` rooms** |
 | `hrInfo` | [SubscriptionHRInfo](#subscriptionhrinfo) | present **only for `dm` rooms** |
 
 ##### Error response

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -1271,8 +1271,7 @@ with `AND`) — terms split across e.g. message text and a filename match nothin
 `attachments` (`Attachment[]`, omitted when the message has no attachments),
 `card` (`MessageCard`, omitted when the message carries no tcard),
 `tshow` (boolean, omitted when false), `sender` (`{account, displayName}`),
-`room` (`{id, name, type, appInfo?, hrInfo?}` — `appInfo` only for `botDM`,
-`hrInfo` only for `dm`).
+`room` (`{id, name, type, hrInfo?}` — `hrInfo` only for `dm`).
 Base fields are sourced from ES; `room`/`sender` are resolved server-side (best-effort,
 individual fields omitted when unresolved). `attachments`/`card` mirror the message
 payloads as-is (same wire shape as history reads) so hits render without a follow-up

--- a/pkg/model/search.go
+++ b/pkg/model/search.go
@@ -52,16 +52,15 @@ type SearchMessage struct {
 }
 
 // MessageRoom is the enriched room object attached to a SearchMessage.
-// Type is the room type from the caller's subscription. AppInfo is set only
-// for botDM rooms; HRInfo only for dm rooms. Name is the app name (botDM),
-// the counterpart's display name (dm), or the canonical room name (channel/
-// discussion, from the RoomsInfoBatch RPC).
+// Type is the room type from the caller's subscription. HRInfo is set only
+// for dm rooms. Name is the app name (botDM), the counterpart's display
+// name (dm), or the canonical room name (channel/discussion, from the
+// RoomsInfoBatch RPC).
 type MessageRoom struct {
-	ID      string              `json:"id"`
-	Name    string              `json:"name,omitempty"`
-	Type    RoomType            `json:"type,omitempty"`
-	AppInfo *AppSubscription    `json:"appInfo,omitempty"`
-	HRInfo  *SubscriptionHRInfo `json:"hrInfo,omitempty"`
+	ID     string              `json:"id"`
+	Name   string              `json:"name,omitempty"`
+	Type   RoomType            `json:"type,omitempty"`
+	HRInfo *SubscriptionHRInfo `json:"hrInfo,omitempty"`
 }
 
 // MessageSender is the enriched author object attached to a SearchMessage.

--- a/search-service/enrich.go
+++ b/search-service/enrich.go
@@ -124,7 +124,6 @@ func (h *handler) enrichMessages(ctx context.Context, account string, hits []mes
 				}
 			case model.RoomTypeBotDM:
 				if app, ok := apps[meta.Name]; ok {
-					room.AppInfo = model.AppSubscriptionFromApp(&app)
 					room.Name = app.Name
 				} else {
 					room.Name = meta.Name

--- a/search-service/enrich_test.go
+++ b/search-service/enrich_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -51,7 +52,6 @@ func TestEnrichMessages_DM(t *testing.T) {
 	require.NotNil(t, out[0].Room.HRInfo)
 	assert.Equal(t, "陳", out[0].Room.HRInfo.Name)
 	assert.Equal(t, "Bob Chan", out[0].Room.HRInfo.EngName)
-	assert.Nil(t, out[0].Room.AppInfo)
 	require.NotNil(t, out[0].Sender)
 	assert.Equal(t, "alice", out[0].Sender.Account)
 	assert.Equal(t, "Alice", out[0].Sender.DisplayName)
@@ -68,9 +68,11 @@ func TestEnrichMessages_BotDM(t *testing.T) {
 	require.NotNil(t, out[0].Room)
 	assert.Equal(t, model.RoomTypeBotDM, out[0].Room.Type)
 	assert.Equal(t, "Helper", out[0].Room.Name)
-	require.NotNil(t, out[0].Room.AppInfo)
-	assert.Equal(t, "app1", out[0].Room.AppInfo.AppID)
 	assert.Nil(t, out[0].Room.HRInfo)
+	// the room carries only the app's name — no appInfo enrichment
+	b, err := json.Marshal(out[0].Room)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), "appInfo")
 	// bot sender display name = app name
 	assert.Equal(t, "Helper", out[0].Sender.DisplayName)
 }
@@ -87,7 +89,6 @@ func TestEnrichMessages_ChannelUsesRoomBatch(t *testing.T) {
 	out := h.enrichMessages(context.Background(), "alice", []messageSearchHit{hit("m1", "rCh", "site-b", "alice")})
 	assert.Equal(t, model.RoomTypeChannel, out[0].Room.Type)
 	assert.Equal(t, "General", out[0].Room.Name)
-	assert.Nil(t, out[0].Room.AppInfo)
 	assert.Nil(t, out[0].Room.HRInfo)
 	assert.Equal(t, 1, r.calls)
 }

--- a/search-service/integration_enrich_test.go
+++ b/search-service/integration_enrich_test.go
@@ -31,7 +31,7 @@ func TestMongoStore_EnrichLookups(t *testing.T) {
 	})
 	require.NoError(t, err)
 	_, err = db.Collection("apps").InsertMany(ctx, []any{
-		bson.M{"_id": "app-1", "name": "Helper", "assistant": bson.M{"name": "helper.bot", "enabled": true}},
+		bson.M{"_id": "app-1", "name": "Helper", "description": "a bot", "version": "1.0", "assistant": bson.M{"name": "helper.bot", "enabled": true}},
 	})
 	require.NoError(t, err)
 
@@ -57,6 +57,9 @@ func TestMongoStore_EnrichLookups(t *testing.T) {
 	apps, err := store.AppsByAssistantNames(ctx, []string{"helper.bot", "ghost.bot"})
 	require.NoError(t, err)
 	assert.Equal(t, "Helper", apps["helper.bot"].Name)
+	// projection: only name and assistant.name come back
+	assert.Empty(t, apps["helper.bot"].Description)
+	assert.Empty(t, apps["helper.bot"].Version)
 	_, ok = apps["ghost.bot"]
 	assert.False(t, ok)
 

--- a/search-service/store_mongo.go
+++ b/search-service/store_mongo.go
@@ -117,13 +117,16 @@ func (s *mongoStore) UsersByAccounts(ctx context.Context, accounts []string) (ma
 }
 
 // AppsByAssistantNames returns apps keyed by their assistant.name (bot account).
+// Only name and assistant.name are projected — callers use the map for
+// display-name resolution only.
 func (s *mongoStore) AppsByAssistantNames(ctx context.Context, botAccounts []string) (map[string]model.App, error) {
 	out := map[string]model.App{}
 	if len(botAccounts) == 0 {
 		return out, nil
 	}
 	filter := bson.M{"assistant.name": bson.M{"$in": botAccounts}}
-	cur, err := s.apps.Find(ctx, filter)
+	proj := bson.M{"name": 1, "assistant.name": 1}
+	cur, err := s.apps.Find(ctx, filter, options.Find().SetProjection(proj))
 	if err != nil {
 		return nil, fmt.Errorf("find apps by assistant: %w", err)
 	}


### PR DESCRIPTION
## Summary

The `search.messages` response only needs the app's display name on `botDM` rooms — not the full app metadata object. This PR:

- **Removes the `appInfo` field from `model.MessageRoom`** (the enriched room object on each search hit). For `botDM` rooms, `room.name` still carries the app's display name; nothing else from the app document is returned.
- **Adds a projection to the apps Mongo lookup** — `AppsByAssistantNames` now projects only `name` + `assistant.name`, since display-name resolution (room name + bot sender name) is its only remaining consumer.
- **Updates `docs/client-api.md` and the derived `docs/client-api/request-reply.md`** to drop `appInfo` from the `MessageRoom` schema.

## Testing

- TDD: updated `TestEnrichMessages_BotDM` to assert the marshaled room contains no `appInfo` key (confirmed red before the change), then made it green.
- Extended the integration test `TestMongoStore_EnrichLookups` to assert the projection excludes non-projected fields (`description`, `version`).
- `make test` — all 102 packages pass with `-race`.
- `make lint` — 0 issues.
- `make sast` — gosec, govulncheck, and semgrep all pass.
- Integration tests compile (`go vet -tags integration`); Docker is unavailable in this environment so they could not be executed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLzp4zqvqyBaoXRgNqm7ey

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLzp4zqvqyBaoXRgNqm7ey)_