### PR TITLE
Reshape search message sender/room enrichment: hr + compact appInfo

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -3905,12 +3905,15 @@ See [Error envelope](#6-error-envelope-reference).
         "data": "eyJhbW91bnQiOjQyfQ=="
       },
       "tshow": true,
-      "sender": { "account": "alice", "displayName": "Alice Wong" },
+      "sender": {
+        "account": "alice",
+        "hr": { "account": "alice", "chineseName": "王愛麗", "engName": "Alice Wong" }
+      },
       "room": {
         "id": "r1",
         "name": "Bob Chan",
         "type": "dm",
-        "hrInfo": { "account": "bob", "name": "陳大文", "engName": "Bob Chan" }
+        "hrInfo": { "account": "bob", "chineseName": "陳大文", "engName": "Bob Chan" }
       }
     }
   ],
@@ -3940,8 +3943,8 @@ See [Error envelope](#6-error-envelope-reference).
 | `attachments` | [Attachment](#attachment)[] | omitted when the message has no attachments |
 | `card` | [MessageCard](#messagecard) | omitted when the message carries no tcard |
 | `tshow` | boolean | omitted when false — set on a thread reply that is also shown in the parent channel timeline |
-| `sender` | [MessageSender](#messagesender) | present on every hit; `account` always set, `displayName` best-effort |
-| `room` | [MessageRoom](#messageroom) | present on every hit; `id` always set, `name`/`type`/`hrInfo` best-effort |
+| `sender` | [MessageSender](#messagesender) | present on every hit; `account` always set, `hr`/`appInfo` best-effort |
+| `room` | [MessageRoom](#messageroom) | present on every hit; `id` always set, `name`/`type`/`hrInfo`/`appInfo` best-effort |
 
 `attachments` and `card` are the message's payloads mirrored as-is from the index (same wire shape as history reads — decoded `Attachment` objects; `card.data` is base64-encoded bytes), so the client can render a hit (file row, tcard) without a follow-up history-service load.
 
@@ -3952,7 +3955,8 @@ See [Error envelope](#6-error-envelope-reference).
 | Field | Type | Notes |
 |---|---|---|
 | `account` | string | sender's account |
-| `displayName` | string | engName+chineseName (fallback account); the app's display name for a bot sender. Omitted when empty. |
+| `hr` | [MessageHRInfo](#messagehrinfo) | human senders only; omitted when the users lookup missed |
+| `appInfo` | [MessageAppInfo](#messageappinfo) | bot senders only (`isSubscribed` never set here); omitted when the apps lookup missed |
 
 ##### MessageRoom
 
@@ -3961,7 +3965,25 @@ See [Error envelope](#6-error-envelope-reference).
 | `id` | string | roomId |
 | `name` | string | app name (`botDM`) / counterpart display name (`dm`) / canonical room name (`channel`, `discussion`). Omitted when unresolved. |
 | `type` | string | `channel` \| `dm` \| `botDM` \| `discussion`. Omitted when the caller has no subscription for the room. |
-| `hrInfo` | [SubscriptionHRInfo](#subscriptionhrinfo) | present **only for `dm` rooms** |
+| `hrInfo` | [MessageHRInfo](#messagehrinfo) | present **only for `dm` rooms** |
+| `appInfo` | [MessageAppInfo](#messageappinfo) | present **only for `botDM` rooms**; `isSubscribed` always set here |
+
+##### MessageHRInfo
+
+| Field | Type | Notes |
+|---|---|---|
+| `account` | string | HR-directory account |
+| `chineseName` | string | omitted when empty |
+| `engName` | string | omitted when empty |
+
+##### MessageAppInfo
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string | app document id |
+| `name` | string | app display name |
+| `assistantName` | string | bot account (`assistant.name`) |
+| `isSubscribed` | boolean | `room.appInfo` only — the caller's subscription state for the bot (explicit `true`/`false`); absent on `sender.appInfo` |
 
 ##### Error response
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -1270,8 +1270,12 @@ with `AND`) — terms split across e.g. message text and a filename match nothin
 (omitted when not a reply), `threadParentMessageCreatedAt` (omitted when not a reply),
 `attachments` (`Attachment[]`, omitted when the message has no attachments),
 `card` (`MessageCard`, omitted when the message carries no tcard),
-`tshow` (boolean, omitted when false), `sender` (`{account, displayName}`),
-`room` (`{id, name, type, hrInfo?}` — `hrInfo` only for `dm`).
+`tshow` (boolean, omitted when false),
+`sender` (`{account, hr?, appInfo?}` — `hr` `{account, chineseName, engName}` for
+human senders, `appInfo` `{id, name, assistantName}` for bot senders),
+`room` (`{id, name, type, hrInfo?, appInfo?}` — `hrInfo` `{account, chineseName,
+engName}` only for `dm`, `appInfo` `{id, name, assistantName, isSubscribed}` only
+for `botDM`).
 Base fields are sourced from ES; `room`/`sender` are resolved server-side (best-effort,
 individual fields omitted when unresolved). `attachments`/`card` mirror the message
 payloads as-is (same wire shape as history reads) so hits render without a follow-up

--- a/docs/superpowers/plans/2026-07-31-search-sender-room-appinfo.md
+++ b/docs/superpowers/plans/2026-07-31-search-sender-room-appinfo.md
@@ -1,0 +1,477 @@
+# Search Sender/Room AppInfo Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reshape `search.messages` hit enrichment — `sender` carries `hr` (humans) / `appInfo` (bots) instead of `displayName`; `room` regains a compact `appInfo` for botDM (with `isSubscribed`) and rekeys dm `hrInfo` to `chineseName`.
+
+**Architecture:** New compact wire types `MessageHRInfo` / `MessageAppInfo` in `pkg/model`; `search-service/enrich.go` maps its three existing batched Mongo lookups onto them. Zero new queries — only two projection tweaks (`isSubscribed` on subscriptions, explicit `_id` on apps).
+
+**Tech Stack:** Go 1.25, mongo-driver v2, testify, per CLAUDE.md all commands via `make`.
+
+**Spec:** `docs/superpowers/specs/2026-07-31-search-sender-room-appinfo-design.md`
+
+## Global Constraints
+
+- TDD Red-Green-Refactor for every task; run tests via `make test SERVICE=<name>` (never raw `go test`).
+- Docker is unavailable in this environment: integration-tagged tests are compile-checked with `go vet -tags integration ./search-service/` and executed by CI.
+- Client-facing response structs changed → `docs/client-api.md` **and** `docs/client-api/request-reply.md` must be updated in the same PR.
+- No store interface signature changes → no `make generate` needed.
+- Branch: `claude/search-message-sender-room-appinfo`; commits per task.
+
+---
+
+### Task 1: Compact model types + reshaped sender/room structs
+
+**Files:**
+- Modify: `pkg/model/search.go` (MessageSender/MessageRoom + new types)
+- Test: `pkg/model/model_test.go` (`TestSearchMessageEnrichmentJSON`, new `TestMessageAppInfoJSON`)
+
+**Interfaces:**
+- Produces: `model.MessageHRInfo{Account, ChineseName, EngName string}`, `model.MessageAppInfo{ID, Name, AssistantName string; IsSubscribed *bool}`, `model.MessageSender{Account string; HR *MessageHRInfo; AppInfo *MessageAppInfo}`, `model.MessageRoom{ID, Name string; Type RoomType; HRInfo *MessageHRInfo; AppInfo *MessageAppInfo}` — Task 3 populates these.
+
+- [ ] **Step 1: Rewrite the enrichment JSON tests (failing)**
+
+Replace `TestSearchMessageEnrichmentJSON` in `pkg/model/model_test.go` and add an appInfo test:
+
+```go
+func TestSearchMessageEnrichmentJSON(t *testing.T) {
+	subscribed := true
+	m := model.SearchMessage{
+		MessageID:   "m1",
+		RoomID:      "r1",
+		SiteID:      "site-a",
+		UserAccount: "alice",
+		Content:     "hi",
+		CreatedAt:   time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+		TShow:       true,
+		Sender: &model.MessageSender{
+			Account: "alice",
+			HR:      &model.MessageHRInfo{Account: "alice", ChineseName: "愛麗絲", EngName: "Alice Wang"},
+		},
+		Room: &model.MessageRoom{
+			ID:      "r1",
+			Name:    "Weather App",
+			Type:    model.RoomTypeBotDM,
+			AppInfo: &model.MessageAppInfo{ID: "app-1", Name: "Weather App", AssistantName: "weather.bot", IsSubscribed: &subscribed},
+		},
+	}
+	roundTrip(t, &m, &model.SearchMessage{})
+
+	// dm room: hrInfo serializes chineseName (not the legacy "name" key).
+	b, err := json.Marshal(model.MessageRoom{
+		ID: "r2", Type: model.RoomTypeDM,
+		HRInfo: &model.MessageHRInfo{Account: "bob", ChineseName: "陳", EngName: "Bob Chan"},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"chineseName":"陳"`)
+	assert.NotContains(t, string(b), `"appInfo"`)
+
+	// omitempty: a zero-value SearchMessage must not emit room/sender/tshow keys.
+	b, err = json.Marshal(model.SearchMessage{MessageID: "x"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), "\"room\"")
+	assert.NotContains(t, string(b), "\"sender\"")
+	assert.NotContains(t, string(b), "\"tshow\"")
+}
+
+func TestMessageAppInfoJSON(t *testing.T) {
+	// Sender variant: IsSubscribed nil → key absent.
+	b, err := json.Marshal(model.MessageSender{
+		Account: "weather.bot",
+		AppInfo: &model.MessageAppInfo{ID: "app-1", Name: "Weather App", AssistantName: "weather.bot"},
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), "isSubscribed")
+	assert.NotContains(t, string(b), "displayName")
+	assert.NotContains(t, string(b), `"hr"`)
+
+	// Room variant: explicit false must serialize (pointer, not omitted).
+	unsubscribed := false
+	b, err = json.Marshal(model.MessageAppInfo{ID: "app-1", Name: "W", AssistantName: "w.bot", IsSubscribed: &unsubscribed})
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"isSubscribed":false`)
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `make test SERVICE=pkg/model`
+Expected: compile FAIL (`unknown field HR`, `MessageHRInfo` undefined).
+
+- [ ] **Step 3: Implement the model changes**
+
+In `pkg/model/search.go`, replace the `MessageRoom` and `MessageSender` types:
+
+```go
+// MessageRoom is the enriched room object attached to a SearchMessage.
+// Type is the room type from the caller's subscription. HRInfo is set only
+// for dm rooms; AppInfo only for botDM rooms. Name is the app name (botDM),
+// the counterpart's display name (dm), or the canonical room name (channel/
+// discussion, from the RoomsInfoBatch RPC).
+type MessageRoom struct {
+	ID      string          `json:"id"`
+	Name    string          `json:"name,omitempty"`
+	Type    RoomType        `json:"type,omitempty"`
+	HRInfo  *MessageHRInfo  `json:"hrInfo,omitempty"`
+	AppInfo *MessageAppInfo `json:"appInfo,omitempty"`
+}
+
+// MessageSender is the enriched author object attached to a SearchMessage.
+// HR is set for human senders, AppInfo for bot senders; both are omitted
+// when the lookup missed — the client renders the display name.
+type MessageSender struct {
+	Account string          `json:"account"`
+	HR      *MessageHRInfo  `json:"hr,omitempty"`
+	AppInfo *MessageAppInfo `json:"appInfo,omitempty"`
+}
+
+// MessageHRInfo is the compact HR record on search sender/room objects.
+type MessageHRInfo struct {
+	Account     string `json:"account"`
+	ChineseName string `json:"chineseName,omitempty"`
+	EngName     string `json:"engName,omitempty"`
+}
+
+// MessageAppInfo is the compact app record on search sender/room objects.
+// IsSubscribed is set only on room.appInfo (botDM) — explicit true/false from
+// the caller's subscription row — and stays nil (absent) on sender.appInfo.
+type MessageAppInfo struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	AssistantName string `json:"assistantName"`
+	IsSubscribed  *bool  `json:"isSubscribed,omitempty"`
+}
+```
+
+NOTE: `search-service/enrich.go` still references `DisplayName` and builds `SubscriptionHRInfo` — it breaks compilation here. Patch it minimally in the same step so the repo compiles (full rewrite is Task 3): in the hit loop replace the `out[i].Sender = ...` assignment and DM branch with
+
+```go
+		out[i].Sender = &model.MessageSender{Account: hits[i].UserAccount}
+		room := &model.MessageRoom{ID: rid}
+		if meta, ok := subs[rid]; ok {
+			room.Type = meta.RoomType
+			switch meta.RoomType {
+			case model.RoomTypeDM:
+				if hr, ok := users[meta.Name]; ok {
+					room.HRInfo = &model.MessageHRInfo{Account: hr.Account, ChineseName: hr.ChineseName, EngName: hr.EngName}
+					room.Name = displayfmt.CombineWithFallback(hr.EngName, hr.ChineseName, meta.Name)
+				} else {
+					room.Name = meta.Name
+				}
+```
+
+and delete the now-unused `resolveSenderName` (and its `displayfmt` usage stays for the DM branch). Delete the sender-related assertions in `search-service/enrich_test.go` that reference `DisplayName` (they are rewritten in Task 3).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `make test SERVICE=pkg/model && make test SERVICE=search-service`
+Expected: PASS (search-service tests trimmed of DisplayName assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/model/search.go pkg/model/model_test.go search-service/enrich.go search-service/enrich_test.go
+git commit -m "Add compact MessageHRInfo/MessageAppInfo search wire types"
+```
+
+---
+
+### Task 2: Store projections — isSubscribed + explicit app _id
+
+**Files:**
+- Modify: `search-service/store.go` (`SubscriptionMeta`), `search-service/store_mongo.go`
+- Test: `search-service/integration_enrich_test.go`
+
+**Interfaces:**
+- Produces: `SubscriptionMeta{RoomType model.RoomType; Name string; IsSubscribed bool}`; `AppsByAssistantNames` map values carry `ID`, `Name`, `Assistant.Name` (all other App fields zero). Task 3 consumes both.
+
+- [ ] **Step 1: Extend the integration test (failing on CI, compile-checked here)**
+
+In `integration_enrich_test.go`, extend the subscriptions fixture (`s2` gains `"isSubscribed": true`) and the assertions:
+
+```go
+		bson.M{"_id": "s2", "u": bson.M{"account": "alice"}, "roomId": "rBot", "roomType": "botDM", "name": "helper.bot", "isSubscribed": true},
+```
+
+```go
+	assert.True(t, subs["rBot"].IsSubscribed)
+	assert.False(t, subs["rDM"].IsSubscribed) // absent in fixture → zero value
+```
+
+and for apps:
+
+```go
+	assert.Equal(t, "app-1", apps["helper.bot"].ID)
+	assert.Equal(t, "helper.bot", apps["helper.bot"].Assistant.Name)
+```
+
+- [ ] **Step 2: Implement**
+
+`store.go`:
+
+```go
+// SubscriptionMeta is the caller's subscription projection used for enrichment:
+// the room type, the join-key Name (DM counterpart account / botDM bot
+// account), and the botDM IsSubscribed flag.
+type SubscriptionMeta struct {
+	RoomType     model.RoomType
+	Name         string
+	IsSubscribed bool
+}
+```
+
+`store_mongo.go` — `SubscriptionsByRoomIDs`: projection `bson.M{"roomId": 1, "roomType": 1, "name": 1, "isSubscribed": 1}`, row struct gains `IsSubscribed bool \`bson:"isSubscribed"\``, map fill passes it through. `AppsByAssistantNames`: projection becomes `bson.M{"_id": 1, "name": 1, "assistant.name": 1}` (makes the default `_id` inclusion explicit) and the doc comment says the map values carry only ID/Name/Assistant.Name.
+
+- [ ] **Step 3: Verify**
+
+Run: `make test SERVICE=search-service && go vet -tags integration ./search-service/`
+Expected: PASS / clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add search-service/store.go search-service/store_mongo.go search-service/integration_enrich_test.go
+git commit -m "Project isSubscribed and app id for search enrichment"
+```
+
+---
+
+### Task 3: Enrichment rewrite
+
+**Files:**
+- Modify: `search-service/enrich.go`
+- Test: `search-service/enrich_test.go`
+
+**Interfaces:**
+- Consumes: Task 1 model types, Task 2 `SubscriptionMeta.IsSubscribed` + app `ID`.
+- Produces: `buildSender(account string, users map[string]HRUser, apps map[string]model.App) *model.MessageSender` (unexported helper).
+
+- [ ] **Step 1: Rewrite the enrichment tests (failing)**
+
+Replace the sender/botDM-related tests in `enrich_test.go`:
+
+```go
+func TestEnrichMessages_DM(t *testing.T) {
+	m := &fakeMongo{
+		subs:  map[string]SubscriptionMeta{"rDM": {RoomType: model.RoomTypeDM, Name: "bob"}},
+		users: map[string]HRUser{"bob": {Account: "bob", EngName: "Bob Chan", ChineseName: "陳"}, "alice": {Account: "alice", EngName: "Alice", ChineseName: "愛麗絲"}},
+	}
+	h := enrichHandler(m, &fakeRoom{})
+	out := h.enrichMessages(context.Background(), "alice", []messageSearchHit{hit("m1", "rDM", "site-a", "alice")})
+	require.Len(t, out, 1)
+	require.NotNil(t, out[0].Room)
+	assert.Equal(t, model.RoomTypeDM, out[0].Room.Type)
+	assert.Equal(t, "Bob Chan 陳", out[0].Room.Name)
+	require.NotNil(t, out[0].Room.HRInfo)
+	assert.Equal(t, &model.MessageHRInfo{Account: "bob", ChineseName: "陳", EngName: "Bob Chan"}, out[0].Room.HRInfo)
+	assert.Nil(t, out[0].Room.AppInfo)
+	// human sender: account + hr, no appInfo
+	require.NotNil(t, out[0].Sender)
+	assert.Equal(t, "alice", out[0].Sender.Account)
+	assert.Equal(t, &model.MessageHRInfo{Account: "alice", ChineseName: "愛麗絲", EngName: "Alice"}, out[0].Sender.HR)
+	assert.Nil(t, out[0].Sender.AppInfo)
+}
+
+func TestEnrichMessages_BotDM(t *testing.T) {
+	m := &fakeMongo{
+		subs: map[string]SubscriptionMeta{"rBot": {RoomType: model.RoomTypeBotDM, Name: "helper.bot", IsSubscribed: true}},
+		apps: map[string]model.App{"helper.bot": {ID: "app1", Name: "Helper", Assistant: &model.AppAssistant{Name: "helper.bot"}}},
+	}
+	h := enrichHandler(m, &fakeRoom{})
+	// sender is the bot itself
+	out := h.enrichMessages(context.Background(), "alice", []messageSearchHit{hit("m1", "rBot", "site-a", "helper.bot")})
+	require.NotNil(t, out[0].Room)
+	assert.Equal(t, model.RoomTypeBotDM, out[0].Room.Type)
+	assert.Equal(t, "Helper", out[0].Room.Name)
+	assert.Nil(t, out[0].Room.HRInfo)
+	require.NotNil(t, out[0].Room.AppInfo)
+	assert.Equal(t, "app1", out[0].Room.AppInfo.ID)
+	assert.Equal(t, "Helper", out[0].Room.AppInfo.Name)
+	assert.Equal(t, "helper.bot", out[0].Room.AppInfo.AssistantName)
+	require.NotNil(t, out[0].Room.AppInfo.IsSubscribed)
+	assert.True(t, *out[0].Room.AppInfo.IsSubscribed)
+	// bot sender: account + appInfo (no isSubscribed), no hr
+	require.NotNil(t, out[0].Sender.AppInfo)
+	assert.Equal(t, &model.MessageAppInfo{ID: "app1", Name: "Helper", AssistantName: "helper.bot"}, out[0].Sender.AppInfo)
+	assert.Nil(t, out[0].Sender.HR)
+}
+
+func TestEnrichMessages_BotDM_Unsubscribed(t *testing.T) {
+	m := &fakeMongo{
+		subs: map[string]SubscriptionMeta{"rBot": {RoomType: model.RoomTypeBotDM, Name: "helper.bot", IsSubscribed: false}},
+		apps: map[string]model.App{"helper.bot": {ID: "app1", Name: "Helper"}},
+	}
+	h := enrichHandler(m, &fakeRoom{})
+	out := h.enrichMessages(context.Background(), "alice", []messageSearchHit{hit("m1", "rBot", "site-a", "alice")})
+	require.NotNil(t, out[0].Room.AppInfo)
+	require.NotNil(t, out[0].Room.AppInfo.IsSubscribed)
+	assert.False(t, *out[0].Room.AppInfo.IsSubscribed)
+	// explicit false serializes on the room object
+	b, err := json.Marshal(out[0].Room)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"isSubscribed":false`)
+}
+
+func TestEnrichMessages_BotDM_AppLookupMiss(t *testing.T) {
+	m := &fakeMongo{
+		subs: map[string]SubscriptionMeta{"rBot": {RoomType: model.RoomTypeBotDM, Name: "helper.bot", IsSubscribed: true}},
+	}
+	h := enrichHandler(m, &fakeRoom{})
+	out := h.enrichMessages(context.Background(), "alice", []messageSearchHit{hit("m1", "rBot", "site-a", "helper.bot")})
+	// no app doc → name falls back to the subscription name, no half-empty appInfo
+	assert.Equal(t, "helper.bot", out[0].Room.Name)
+	assert.Nil(t, out[0].Room.AppInfo)
+	assert.Nil(t, out[0].Sender.AppInfo)
+	assert.Equal(t, "helper.bot", out[0].Sender.Account)
+}
+```
+
+Update the surviving tests to the new shape: in `TestEnrichMessages_DegradesOnAllErrors`, `TestEnrichMessages_NilMongoDegrades`, `TestEnrichMessages_NilMongoAndRoomDegrades` replace `assert.Equal(t, "alice", out[0].Sender.DisplayName)` with
+
+```go
+	assert.Equal(t, "alice", out[0].Sender.Account)
+	assert.Nil(t, out[0].Sender.HR)
+```
+
+and in `TestEnrichMessages_ChannelUsesRoomBatch` keep the room assertions, adding `assert.Nil(t, out[0].Room.AppInfo)`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `make test SERVICE=search-service`
+Expected: FAIL — sender `hr`/`appInfo` never populated, `room.AppInfo` nil.
+
+- [ ] **Step 3: Implement**
+
+In `enrich.go`, replace the sender assignment in the hit loop with `out[i].Sender = buildSender(hits[i].UserAccount, users, apps)`, fill the botDM branch:
+
+```go
+			case model.RoomTypeBotDM:
+				if app, ok := apps[meta.Name]; ok {
+					isSubscribed := meta.IsSubscribed
+					room.AppInfo = &model.MessageAppInfo{ID: app.ID, Name: app.Name, AssistantName: meta.Name, IsSubscribed: &isSubscribed}
+					room.Name = app.Name
+				} else {
+					room.Name = meta.Name
+				}
+```
+
+and replace `resolveSenderName` with:
+
+```go
+// buildSender assembles the sender object: hr for human senders, appInfo for
+// bot senders; either is omitted when its lookup missed — the client renders
+// the display name.
+func buildSender(account string, users map[string]HRUser, apps map[string]model.App) *model.MessageSender {
+	s := &model.MessageSender{Account: account}
+	if model.IsBot(account) {
+		if app, ok := apps[account]; ok {
+			s.AppInfo = &model.MessageAppInfo{ID: app.ID, Name: app.Name, AssistantName: account}
+		}
+	} else if hr, ok := users[account]; ok {
+		s.HR = &model.MessageHRInfo{Account: hr.Account, ChineseName: hr.ChineseName, EngName: hr.EngName}
+	}
+	return s
+}
+```
+
+(`model.IsBot("")` is false and the users map has no `""` key, so the empty-account hit degrades to `{account: ""}` with no lookup branch.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `make test SERVICE=search-service`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add search-service/enrich.go search-service/enrich_test.go
+git commit -m "Enrich search sender/room with compact hr and appInfo objects"
+```
+
+---
+
+### Task 4: Client API docs
+
+**Files:**
+- Modify: `docs/client-api.md` (Search Messages §: `SearchMessage` field table rows for `sender`/`room`, `MessageSender`/`MessageRoom` tables, new `MessageHRInfo`/`MessageAppInfo` tables, JSON example if present)
+- Modify: `docs/client-api/request-reply.md` (Search Messages schema lines)
+
+- [ ] **Step 1: Rewrite the canonical tables**
+
+`MessageSender`:
+
+```markdown
+| Field | Type | Notes |
+|---|---|---|
+| `account` | string | sender's account |
+| `hr` | [MessageHRInfo](#messagehrinfo) | human senders only; omitted when the users lookup missed |
+| `appInfo` | [MessageAppInfo](#messageappinfo) | bot senders only (`isSubscribed` never set here); omitted when the apps lookup missed |
+```
+
+`MessageRoom`:
+
+```markdown
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string | roomId |
+| `name` | string | app name (`botDM`) / counterpart display name (`dm`) / canonical room name (`channel`, `discussion`). Omitted when unresolved. |
+| `type` | string | `channel` \| `dm` \| `botDM` \| `discussion`. Omitted when the caller has no subscription for the room. |
+| `hrInfo` | [MessageHRInfo](#messagehrinfo) | present **only for `dm` rooms** |
+| `appInfo` | [MessageAppInfo](#messageappinfo) | present **only for `botDM` rooms**; `isSubscribed` always set here |
+```
+
+New tables:
+
+```markdown
+##### MessageHRInfo
+
+| Field | Type | Notes |
+|---|---|---|
+| `account` | string | HR-directory account |
+| `chineseName` | string | omitted when empty |
+| `engName` | string | omitted when empty |
+
+##### MessageAppInfo
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string | app document id |
+| `name` | string | app display name |
+| `assistantName` | string | bot account (`assistant.name`) |
+| `isSubscribed` | boolean | `room.appInfo` only — the caller's subscription state for the bot; absent on `sender.appInfo` |
+```
+
+Also update the `SearchMessage` table rows for `sender` (`account` always set, `hr`/`appInfo` best-effort) and `room` (`name`/`type`/`hrInfo`/`appInfo` best-effort), and the JSON success example if the section carries one.
+
+- [ ] **Step 2: Mirror in the derived view**
+
+In `request-reply.md`, the `SearchMessage` schema line becomes:
+
+```markdown
+`tshow` (boolean, omitted when false),
+`sender` (`{account, hr?, appInfo?}` — `hr` `{account, chineseName, engName}` for
+human senders, `appInfo` `{id, name, assistantName}` for bot senders),
+`room` (`{id, name, type, hrInfo?, appInfo?}` — `hrInfo` `{account, chineseName,
+engName}` only for `dm`, `appInfo` `{id, name, assistantName, isSubscribed}` only
+for `botDM`).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/client-api.md docs/client-api/request-reply.md
+git commit -m "Document reshaped search sender/room enrichment objects"
+```
+
+---
+
+### Task 5: Verification, simplify pass, PR
+
+- [ ] Run `make test` (full, `-race`) — all packages pass.
+- [ ] Run `make lint` — 0 issues.
+- [ ] Run `go vet -tags integration ./search-service/` — clean.
+- [ ] Run `make sast` — gosec/govulncheck/semgrep pass.
+- [ ] Run the `simplify` skill over the branch diff; apply fixes; re-run `make test SERVICE=search-service && make test SERVICE=pkg/model`.
+- [ ] Final self-review of `git diff main...HEAD` against the spec.
+- [ ] Ensure `docs/reviews/` is empty on the branch.
+- [ ] Push `claude/search-message-sender-room-appinfo`, open the PR (base `main`).

--- a/docs/superpowers/specs/2026-07-31-search-sender-room-appinfo-design.md
+++ b/docs/superpowers/specs/2026-07-31-search-sender-room-appinfo-design.md
@@ -117,8 +117,11 @@ false after unsubscribing while the room row remains).
 - `SubscriptionsByRoomIDs`: projection adds `isSubscribed`; `SubscriptionMeta`
   gains `IsSubscribed bool`.
 - `AppsByAssistantNames`: projection becomes `{_id, name, assistant.name}`
-  (adds `_id` for `appInfo.id`; everything else still excluded).
-- No interface signature changes; no new store methods; no new queries.
+  (adds `_id` for `appInfo.id`; everything else still excluded), and the
+  method returns a dedicated `AppRef{ID, Name, AssistantName}` projection
+  struct (mirroring `SubscriptionMeta`/`HRUser`) instead of hollow
+  `model.App` values.
+- No new store methods; no new queries.
 
 ## Docs
 

--- a/docs/superpowers/specs/2026-07-31-search-sender-room-appinfo-design.md
+++ b/docs/superpowers/specs/2026-07-31-search-sender-room-appinfo-design.md
@@ -1,0 +1,146 @@
+# Search message response: sender/room enrichment redesign
+
+**Date:** 2026-07-31
+**Service:** `search-service` (`search.messages` RPC)
+**Builds on:** PR #160 (removed the fat `appInfo` object from `room`)
+
+## Goal
+
+Reshape the `sender` and `room` enrichment objects on each `search.messages`
+hit:
+
+- `sender` carries a compact `hr` object for human senders and a compact
+  `appInfo` object for bot senders. The server-composed `displayName` is
+  removed — the client renders the name.
+- `room` regains an `appInfo` object for `botDM` rooms (compact, not the old
+  fat `AppSubscription`), including an `isSubscribed` flag from the caller's
+  own subscription row. `dm` rooms keep `hrInfo`, rekeyed to `chineseName`.
+- No new queries: the existing three batched Mongo lookups and the per-site
+  room-name RPC fan-out are reused; only projections change.
+
+## Wire schema
+
+New compact types in `pkg/model/search.go`:
+
+```go
+// MessageHRInfo is the compact HR record on search sender/room objects.
+type MessageHRInfo struct {
+	Account     string `json:"account"`
+	ChineseName string `json:"chineseName,omitempty"`
+	EngName     string `json:"engName,omitempty"`
+}
+
+// MessageAppInfo is the compact app record on search sender/room objects.
+// IsSubscribed is set only on room.appInfo (botDM): explicit true/false there,
+// absent on sender.appInfo.
+type MessageAppInfo struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	AssistantName string `json:"assistantName"`
+	IsSubscribed  *bool  `json:"isSubscribed,omitempty"`
+}
+
+type MessageSender struct {
+	Account string          `json:"account"`
+	HR      *MessageHRInfo  `json:"hr,omitempty"`      // human senders only
+	AppInfo *MessageAppInfo `json:"appInfo,omitempty"` // bot senders only
+}
+
+type MessageRoom struct {
+	ID      string          `json:"id"`
+	Name    string          `json:"name,omitempty"`
+	Type    RoomType        `json:"type,omitempty"`
+	HRInfo  *MessageHRInfo  `json:"hrInfo,omitempty"`  // dm rooms only
+	AppInfo *MessageAppInfo `json:"appInfo,omitempty"` // botDM rooms only
+}
+```
+
+Breaking changes (search response only; other payloads untouched):
+
+- `sender.displayName` removed.
+- `room.hrInfo` switches from `SubscriptionHRInfo` (chinese name under
+  `"name"`) to `MessageHRInfo` (`"chineseName"`).
+
+### Example payloads
+
+Human sender, dm room:
+
+```json
+{
+  "sender": {
+    "account": "alice",
+    "hr": {"account": "alice", "chineseName": "愛麗絲", "engName": "Alice Wang"}
+  },
+  "room": {
+    "id": "r1", "name": "Bob Chan 陳", "type": "dm",
+    "hrInfo": {"account": "bob", "chineseName": "陳", "engName": "Bob Chan"}
+  }
+}
+```
+
+Bot sender, botDM room:
+
+```json
+{
+  "sender": {
+    "account": "weather.site-a.bot",
+    "appInfo": {"id": "app-1", "name": "Weather App", "assistantName": "weather.site-a.bot"}
+  },
+  "room": {
+    "id": "r2", "name": "Weather App", "type": "botDM",
+    "appInfo": {"id": "app-1", "name": "Weather App", "assistantName": "weather.site-a.bot", "isSubscribed": true}
+  }
+}
+```
+
+Channel (default): `room = {id, name, type}` — unchanged.
+
+## Enrichment rules (`search-service/enrich.go`)
+
+Per hit, all best-effort (a lookup miss degrades the field, never fails the
+response):
+
+| Case | Result |
+|---|---|
+| Sender, human | `hr` from the batched users lookup; miss → `{account}` only |
+| Sender, bot (`model.IsBot`) | `appInfo{id,name,assistantName}` from the batched apps lookup; miss → `{account}` only |
+| Room, `dm` | `name` = combined counterpart display name (fallback counterpart account); `hrInfo` in new shape; users miss → `name` = counterpart account, no `hrInfo` |
+| Room, `botDM` | `name` = `app.Name` (fallback subscription name); `appInfo` with `IsSubscribed` (pointer, always set) from the caller's subscription row; apps miss → no `appInfo`, `name` = subscription name |
+| Room, channel/unknown | `{id, name, type}` via the room-name RPC — unchanged |
+
+`isSubscribed` semantics: the `isSubscribed` boolean on the caller's own
+subscription document for the botDM room (true while actively subscribed,
+false after unsubscribing while the room row remains).
+
+## Store changes (`search-service`)
+
+- `SubscriptionsByRoomIDs`: projection adds `isSubscribed`; `SubscriptionMeta`
+  gains `IsSubscribed bool`.
+- `AppsByAssistantNames`: projection becomes `{_id, name, assistant.name}`
+  (adds `_id` for `appInfo.id`; everything else still excluded).
+- No interface signature changes; no new store methods; no new queries.
+
+## Docs
+
+- `docs/client-api.md`: rewrite the `MessageSender` / `MessageRoom` tables,
+  add `MessageHRInfo` / `MessageAppInfo` tables, update the JSON example.
+- `docs/client-api/request-reply.md`: mirror the schema line.
+
+## Testing (TDD)
+
+- Unit (`enrich_test.go`): human sender → `hr`; bot sender → `appInfo`; dm
+  room `hrInfo` new keys; botDM room `appInfo` with `isSubscribed` true and
+  false; apps-miss botDM (no `appInfo`, fallback name); users-miss dm;
+  channel unchanged; marshaled JSON contains no `displayName`, and no
+  `isSubscribed` under `sender.appInfo`.
+- Model (`pkg/model/model_test.go`): round-trip + omitempty for the new
+  types.
+- Integration (`integration_enrich_test.go`): apps projection returns `_id` +
+  `name` + `assistant.name` only; subscriptions projection captures
+  `isSubscribed`.
+
+## Out of scope
+
+- Any change to `SubscriptionHRInfo` or DM-subscription payloads elsewhere.
+- Any change to search indexing, room-name RPC, or other search RPCs
+  (`search.rooms`, `search.apps`, ...).

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -4964,6 +4964,7 @@ func TestTranslateResult_JSON(t *testing.T) {
 }
 
 func TestSearchMessageEnrichmentJSON(t *testing.T) {
+	subscribed := true
 	m := model.SearchMessage{
 		MessageID:   "m1",
 		RoomID:      "r1",
@@ -4972,20 +4973,50 @@ func TestSearchMessageEnrichmentJSON(t *testing.T) {
 		Content:     "hi",
 		CreatedAt:   time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
 		TShow:       true,
-		Sender:      &model.MessageSender{Account: "alice", DisplayName: "Alice Wong"},
+		Sender: &model.MessageSender{
+			Account: "alice",
+			HR:      &model.MessageHRInfo{Account: "alice", ChineseName: "愛麗絲", EngName: "Alice Wang"},
+		},
 		Room: &model.MessageRoom{
-			ID:     "r1",
-			Name:   "Bob Chan",
-			Type:   model.RoomTypeDM,
-			HRInfo: &model.SubscriptionHRInfo{Account: "bob", Name: "陳", EngName: "Bob Chan"},
+			ID:      "r1",
+			Name:    "Weather App",
+			Type:    model.RoomTypeBotDM,
+			AppInfo: &model.MessageAppInfo{ID: "app-1", Name: "Weather App", AssistantName: "weather.bot", IsSubscribed: &subscribed},
 		},
 	}
 	roundTrip(t, &m, &model.SearchMessage{})
 
+	// dm room: hrInfo serializes chineseName (not the legacy "name" key).
+	b, err := json.Marshal(model.MessageRoom{
+		ID: "r2", Type: model.RoomTypeDM,
+		HRInfo: &model.MessageHRInfo{Account: "bob", ChineseName: "陳", EngName: "Bob Chan"},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"chineseName":"陳"`)
+	assert.NotContains(t, string(b), `"appInfo"`)
+
 	// omitempty: a zero-value SearchMessage must not emit room/sender/tshow keys.
-	b, err := json.Marshal(model.SearchMessage{MessageID: "x"})
+	b, err = json.Marshal(model.SearchMessage{MessageID: "x"})
 	require.NoError(t, err)
 	assert.NotContains(t, string(b), "\"room\"")
 	assert.NotContains(t, string(b), "\"sender\"")
 	assert.NotContains(t, string(b), "\"tshow\"")
+}
+
+func TestMessageAppInfoJSON(t *testing.T) {
+	// Sender variant: IsSubscribed nil → key absent; no displayName/hr keys.
+	b, err := json.Marshal(model.MessageSender{
+		Account: "weather.bot",
+		AppInfo: &model.MessageAppInfo{ID: "app-1", Name: "Weather App", AssistantName: "weather.bot"},
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), "isSubscribed")
+	assert.NotContains(t, string(b), "displayName")
+	assert.NotContains(t, string(b), `"hr"`)
+
+	// Room variant: explicit false must serialize (pointer, not omitted).
+	unsubscribed := false
+	b, err = json.Marshal(model.MessageAppInfo{ID: "app-1", Name: "W", AssistantName: "w.bot", IsSubscribed: &unsubscribed})
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"isSubscribed":false`)
 }

--- a/pkg/model/search.go
+++ b/pkg/model/search.go
@@ -53,22 +53,41 @@ type SearchMessage struct {
 
 // MessageRoom is the enriched room object attached to a SearchMessage.
 // Type is the room type from the caller's subscription. HRInfo is set only
-// for dm rooms. Name is the app name (botDM), the counterpart's display
-// name (dm), or the canonical room name (channel/discussion, from the
-// RoomsInfoBatch RPC).
+// for dm rooms; AppInfo only for botDM rooms. Name is the app name (botDM),
+// the counterpart's display name (dm), or the canonical room name (channel/
+// discussion, from the RoomsInfoBatch RPC).
 type MessageRoom struct {
-	ID     string              `json:"id"`
-	Name   string              `json:"name,omitempty"`
-	Type   RoomType            `json:"type,omitempty"`
-	HRInfo *SubscriptionHRInfo `json:"hrInfo,omitempty"`
+	ID      string          `json:"id"`
+	Name    string          `json:"name,omitempty"`
+	Type    RoomType        `json:"type,omitempty"`
+	HRInfo  *MessageHRInfo  `json:"hrInfo,omitempty"`
+	AppInfo *MessageAppInfo `json:"appInfo,omitempty"`
 }
 
 // MessageSender is the enriched author object attached to a SearchMessage.
-// DisplayName is the human display name (engName+chineseName, fallback account)
-// or, for a bot sender, the app's display name.
+// HR is set for human senders, AppInfo for bot senders; both are omitted
+// when the lookup missed — the client renders the display name.
 type MessageSender struct {
+	Account string          `json:"account"`
+	HR      *MessageHRInfo  `json:"hr,omitempty"`
+	AppInfo *MessageAppInfo `json:"appInfo,omitempty"`
+}
+
+// MessageHRInfo is the compact HR record on search sender/room objects.
+type MessageHRInfo struct {
 	Account     string `json:"account"`
-	DisplayName string `json:"displayName,omitempty"`
+	ChineseName string `json:"chineseName,omitempty"`
+	EngName     string `json:"engName,omitempty"`
+}
+
+// MessageAppInfo is the compact app record on search sender/room objects.
+// IsSubscribed is set only on room.appInfo (botDM) — explicit true/false from
+// the caller's subscription row — and stays nil (absent) on sender.appInfo.
+type MessageAppInfo struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	AssistantName string `json:"assistantName"`
+	IsSubscribed  *bool  `json:"isSubscribed,omitempty"`
 }
 
 // SearchRoomsRequest is the NATS payload for

--- a/search-service/enrich.go
+++ b/search-service/enrich.go
@@ -107,17 +107,14 @@ func (h *handler) enrichMessages(ctx context.Context, account string, hits []mes
 
 	for i := range hits {
 		rid := hits[i].RoomID
-		out[i].Sender = &model.MessageSender{
-			Account:     hits[i].UserAccount,
-			DisplayName: resolveSenderName(hits[i].UserAccount, users, apps),
-		}
+		out[i].Sender = &model.MessageSender{Account: hits[i].UserAccount}
 		room := &model.MessageRoom{ID: rid}
 		if meta, ok := subs[rid]; ok {
 			room.Type = meta.RoomType
 			switch meta.RoomType {
 			case model.RoomTypeDM:
 				if hr, ok := users[meta.Name]; ok {
-					room.HRInfo = &model.SubscriptionHRInfo{Account: hr.Account, Name: hr.ChineseName, EngName: hr.EngName}
+					room.HRInfo = &model.MessageHRInfo{Account: hr.Account, ChineseName: hr.ChineseName, EngName: hr.EngName}
 					room.Name = displayfmt.CombineWithFallback(hr.EngName, hr.ChineseName, meta.Name)
 				} else {
 					room.Name = meta.Name
@@ -173,24 +170,6 @@ func (h *handler) fetchRoomNames(ctx context.Context, bySite map[string][]string
 	}
 	wg.Wait()
 	return names
-}
-
-// resolveSenderName returns the sender's display name: the app name for a bot
-// account, else engName+chineseName (fallback account) from the users map.
-func resolveSenderName(account string, users map[string]HRUser, apps map[string]model.App) string {
-	if account == "" {
-		return ""
-	}
-	if model.IsBot(account) {
-		if app, ok := apps[account]; ok && app.Name != "" {
-			return app.Name
-		}
-		return account
-	}
-	if hr, ok := users[account]; ok {
-		return displayfmt.CombineWithFallback(hr.EngName, hr.ChineseName, account)
-	}
-	return account
 }
 
 func keysOf(m map[string]struct{}) []string {

--- a/search-service/enrich.go
+++ b/search-service/enrich.go
@@ -93,7 +93,7 @@ func (h *handler) enrichMessages(ctx context.Context, account string, hits []mes
 			users = u
 		}
 	}
-	apps := map[string]model.App{}
+	apps := map[string]AppRef{}
 	if h.mongo != nil && len(botAccounts) > 0 {
 		a, err := h.mongo.AppsByAssistantNames(ctx, keysOf(botAccounts))
 		if err != nil {
@@ -105,24 +105,25 @@ func (h *handler) enrichMessages(ctx context.Context, account string, hits []mes
 
 	roomNames := h.fetchRoomNames(ctx, channelRoomsBySite)
 
-	for i := range hits {
-		rid := hits[i].RoomID
-		out[i].Sender = buildSender(hits[i].UserAccount, users, apps)
+	// Room and sender objects are per-room / per-account, not per-hit: build
+	// each distinct one once and share the pointer across hits.
+	rooms := make(map[string]*model.MessageRoom, len(roomIDSet))
+	for rid := range roomIDSet {
 		room := &model.MessageRoom{ID: rid}
 		if meta, ok := subs[rid]; ok {
 			room.Type = meta.RoomType
 			switch meta.RoomType {
 			case model.RoomTypeDM:
 				if hr, ok := users[meta.Name]; ok {
-					room.HRInfo = &model.MessageHRInfo{Account: hr.Account, ChineseName: hr.ChineseName, EngName: hr.EngName}
+					room.HRInfo = hrInfoOf(hr)
 					room.Name = displayfmt.CombineWithFallback(hr.EngName, hr.ChineseName, meta.Name)
 				} else {
 					room.Name = meta.Name
 				}
 			case model.RoomTypeBotDM:
 				if app, ok := apps[meta.Name]; ok {
-					isSubscribed := meta.IsSubscribed
-					room.AppInfo = &model.MessageAppInfo{ID: app.ID, Name: app.Name, AssistantName: meta.Name, IsSubscribed: &isSubscribed}
+					room.AppInfo = appInfoOf(app)
+					room.AppInfo.IsSubscribed = &meta.IsSubscribed
 					room.Name = app.Name
 				} else {
 					room.Name = meta.Name
@@ -133,7 +134,18 @@ func (h *handler) enrichMessages(ctx context.Context, account string, hits []mes
 		} else {
 			room.Name = roomNames[rid]
 		}
-		out[i].Room = room
+		rooms[rid] = room
+	}
+	senders := make(map[string]*model.MessageSender, len(senderSet)+1)
+	for i := range hits {
+		acct := hits[i].UserAccount
+		s, ok := senders[acct]
+		if !ok {
+			s = buildSender(acct, users, apps)
+			senders[acct] = s
+		}
+		out[i].Sender = s
+		out[i].Room = rooms[hits[i].RoomID]
 	}
 	return out
 }
@@ -177,16 +189,24 @@ func (h *handler) fetchRoomNames(ctx context.Context, bySite map[string][]string
 // buildSender assembles the sender object: hr for human senders, appInfo for
 // bot senders; either is omitted when its lookup missed — the client renders
 // the display name.
-func buildSender(account string, users map[string]HRUser, apps map[string]model.App) *model.MessageSender {
+func buildSender(account string, users map[string]HRUser, apps map[string]AppRef) *model.MessageSender {
 	s := &model.MessageSender{Account: account}
 	if model.IsBot(account) {
 		if app, ok := apps[account]; ok {
-			s.AppInfo = &model.MessageAppInfo{ID: app.ID, Name: app.Name, AssistantName: account}
+			s.AppInfo = appInfoOf(app)
 		}
 	} else if hr, ok := users[account]; ok {
-		s.HR = &model.MessageHRInfo{Account: hr.Account, ChineseName: hr.ChineseName, EngName: hr.EngName}
+		s.HR = hrInfoOf(hr)
 	}
 	return s
+}
+
+func hrInfoOf(hr HRUser) *model.MessageHRInfo {
+	return &model.MessageHRInfo{Account: hr.Account, ChineseName: hr.ChineseName, EngName: hr.EngName}
+}
+
+func appInfoOf(app AppRef) *model.MessageAppInfo {
+	return &model.MessageAppInfo{ID: app.ID, Name: app.Name, AssistantName: app.AssistantName}
 }
 
 func keysOf(m map[string]struct{}) []string {

--- a/search-service/enrich.go
+++ b/search-service/enrich.go
@@ -107,7 +107,7 @@ func (h *handler) enrichMessages(ctx context.Context, account string, hits []mes
 
 	for i := range hits {
 		rid := hits[i].RoomID
-		out[i].Sender = &model.MessageSender{Account: hits[i].UserAccount}
+		out[i].Sender = buildSender(hits[i].UserAccount, users, apps)
 		room := &model.MessageRoom{ID: rid}
 		if meta, ok := subs[rid]; ok {
 			room.Type = meta.RoomType
@@ -121,6 +121,8 @@ func (h *handler) enrichMessages(ctx context.Context, account string, hits []mes
 				}
 			case model.RoomTypeBotDM:
 				if app, ok := apps[meta.Name]; ok {
+					isSubscribed := meta.IsSubscribed
+					room.AppInfo = &model.MessageAppInfo{ID: app.ID, Name: app.Name, AssistantName: meta.Name, IsSubscribed: &isSubscribed}
 					room.Name = app.Name
 				} else {
 					room.Name = meta.Name
@@ -170,6 +172,21 @@ func (h *handler) fetchRoomNames(ctx context.Context, bySite map[string][]string
 	}
 	wg.Wait()
 	return names
+}
+
+// buildSender assembles the sender object: hr for human senders, appInfo for
+// bot senders; either is omitted when its lookup missed — the client renders
+// the display name.
+func buildSender(account string, users map[string]HRUser, apps map[string]model.App) *model.MessageSender {
+	s := &model.MessageSender{Account: account}
+	if model.IsBot(account) {
+		if app, ok := apps[account]; ok {
+			s.AppInfo = &model.MessageAppInfo{ID: app.ID, Name: app.Name, AssistantName: account}
+		}
+	} else if hr, ok := users[account]; ok {
+		s.HR = &model.MessageHRInfo{Account: hr.Account, ChineseName: hr.ChineseName, EngName: hr.EngName}
+	}
+	return s
 }
 
 func keysOf(m map[string]struct{}) []string {

--- a/search-service/enrich_test.go
+++ b/search-service/enrich_test.go
@@ -41,7 +41,7 @@ func hit(id, room, site, sender string) messageSearchHit {
 func TestEnrichMessages_DM(t *testing.T) {
 	m := &fakeMongo{
 		subs:  map[string]SubscriptionMeta{"rDM": {RoomType: model.RoomTypeDM, Name: "bob"}},
-		users: map[string]HRUser{"bob": {Account: "bob", EngName: "Bob Chan", ChineseName: "陳"}, "alice": {Account: "alice", EngName: "Alice", ChineseName: ""}},
+		users: map[string]HRUser{"bob": {Account: "bob", EngName: "Bob Chan", ChineseName: "陳"}, "alice": {Account: "alice", EngName: "Alice", ChineseName: "愛麗絲"}},
 	}
 	h := enrichHandler(m, &fakeRoom{})
 	out := h.enrichMessages(context.Background(), "alice", []messageSearchHit{hit("m1", "rDM", "site-a", "alice")})
@@ -49,16 +49,29 @@ func TestEnrichMessages_DM(t *testing.T) {
 	require.NotNil(t, out[0].Room)
 	assert.Equal(t, model.RoomTypeDM, out[0].Room.Type)
 	assert.Equal(t, "Bob Chan 陳", out[0].Room.Name)
-	require.NotNil(t, out[0].Room.HRInfo)
-	assert.Equal(t, "陳", out[0].Room.HRInfo.ChineseName)
-	assert.Equal(t, "Bob Chan", out[0].Room.HRInfo.EngName)
+	assert.Equal(t, &model.MessageHRInfo{Account: "bob", ChineseName: "陳", EngName: "Bob Chan"}, out[0].Room.HRInfo)
+	assert.Nil(t, out[0].Room.AppInfo)
+	// human sender: account + hr, no appInfo
 	require.NotNil(t, out[0].Sender)
+	assert.Equal(t, "alice", out[0].Sender.Account)
+	assert.Equal(t, &model.MessageHRInfo{Account: "alice", ChineseName: "愛麗絲", EngName: "Alice"}, out[0].Sender.HR)
+	assert.Nil(t, out[0].Sender.AppInfo)
+}
+
+func TestEnrichMessages_DM_UsersLookupMiss(t *testing.T) {
+	m := &fakeMongo{subs: map[string]SubscriptionMeta{"rDM": {RoomType: model.RoomTypeDM, Name: "bob"}}}
+	h := enrichHandler(m, &fakeRoom{})
+	out := h.enrichMessages(context.Background(), "alice", []messageSearchHit{hit("m1", "rDM", "site-a", "alice")})
+	// no user doc → name falls back to the counterpart account, no hrInfo/hr
+	assert.Equal(t, "bob", out[0].Room.Name)
+	assert.Nil(t, out[0].Room.HRInfo)
+	assert.Nil(t, out[0].Sender.HR)
 	assert.Equal(t, "alice", out[0].Sender.Account)
 }
 
 func TestEnrichMessages_BotDM(t *testing.T) {
 	m := &fakeMongo{
-		subs: map[string]SubscriptionMeta{"rBot": {RoomType: model.RoomTypeBotDM, Name: "helper.bot"}},
+		subs: map[string]SubscriptionMeta{"rBot": {RoomType: model.RoomTypeBotDM, Name: "helper.bot", IsSubscribed: true}},
 		apps: map[string]model.App{"helper.bot": {ID: "app1", Name: "Helper", Assistant: &model.AppAssistant{Name: "helper.bot"}}},
 	}
 	h := enrichHandler(m, &fakeRoom{})
@@ -68,10 +81,44 @@ func TestEnrichMessages_BotDM(t *testing.T) {
 	assert.Equal(t, model.RoomTypeBotDM, out[0].Room.Type)
 	assert.Equal(t, "Helper", out[0].Room.Name)
 	assert.Nil(t, out[0].Room.HRInfo)
-	// the room carries only the app's name — no appInfo enrichment
+	require.NotNil(t, out[0].Room.AppInfo)
+	assert.Equal(t, "app1", out[0].Room.AppInfo.ID)
+	assert.Equal(t, "Helper", out[0].Room.AppInfo.Name)
+	assert.Equal(t, "helper.bot", out[0].Room.AppInfo.AssistantName)
+	require.NotNil(t, out[0].Room.AppInfo.IsSubscribed)
+	assert.True(t, *out[0].Room.AppInfo.IsSubscribed)
+	// bot sender: account + appInfo (no isSubscribed), no hr
+	assert.Equal(t, &model.MessageAppInfo{ID: "app1", Name: "Helper", AssistantName: "helper.bot"}, out[0].Sender.AppInfo)
+	assert.Nil(t, out[0].Sender.HR)
+}
+
+func TestEnrichMessages_BotDM_Unsubscribed(t *testing.T) {
+	m := &fakeMongo{
+		subs: map[string]SubscriptionMeta{"rBot": {RoomType: model.RoomTypeBotDM, Name: "helper.bot", IsSubscribed: false}},
+		apps: map[string]model.App{"helper.bot": {ID: "app1", Name: "Helper"}},
+	}
+	h := enrichHandler(m, &fakeRoom{})
+	out := h.enrichMessages(context.Background(), "alice", []messageSearchHit{hit("m1", "rBot", "site-a", "alice")})
+	require.NotNil(t, out[0].Room.AppInfo)
+	require.NotNil(t, out[0].Room.AppInfo.IsSubscribed)
+	assert.False(t, *out[0].Room.AppInfo.IsSubscribed)
+	// explicit false serializes on the room object
 	b, err := json.Marshal(out[0].Room)
 	require.NoError(t, err)
-	assert.NotContains(t, string(b), "appInfo")
+	assert.Contains(t, string(b), `"isSubscribed":false`)
+}
+
+func TestEnrichMessages_BotDM_AppLookupMiss(t *testing.T) {
+	m := &fakeMongo{
+		subs: map[string]SubscriptionMeta{"rBot": {RoomType: model.RoomTypeBotDM, Name: "helper.bot", IsSubscribed: true}},
+	}
+	h := enrichHandler(m, &fakeRoom{})
+	out := h.enrichMessages(context.Background(), "alice", []messageSearchHit{hit("m1", "rBot", "site-a", "helper.bot")})
+	// no app doc → name falls back to the subscription name, no half-empty appInfo
+	assert.Equal(t, "helper.bot", out[0].Room.Name)
+	assert.Nil(t, out[0].Room.AppInfo)
+	assert.Nil(t, out[0].Sender.AppInfo)
+	assert.Equal(t, "helper.bot", out[0].Sender.Account)
 }
 
 func TestEnrichMessages_ChannelUsesRoomBatch(t *testing.T) {
@@ -87,6 +134,7 @@ func TestEnrichMessages_ChannelUsesRoomBatch(t *testing.T) {
 	assert.Equal(t, model.RoomTypeChannel, out[0].Room.Type)
 	assert.Equal(t, "General", out[0].Room.Name)
 	assert.Nil(t, out[0].Room.HRInfo)
+	assert.Nil(t, out[0].Room.AppInfo)
 	assert.Equal(t, 1, r.calls)
 }
 

--- a/search-service/enrich_test.go
+++ b/search-service/enrich_test.go
@@ -50,11 +50,10 @@ func TestEnrichMessages_DM(t *testing.T) {
 	assert.Equal(t, model.RoomTypeDM, out[0].Room.Type)
 	assert.Equal(t, "Bob Chan 陳", out[0].Room.Name)
 	require.NotNil(t, out[0].Room.HRInfo)
-	assert.Equal(t, "陳", out[0].Room.HRInfo.Name)
+	assert.Equal(t, "陳", out[0].Room.HRInfo.ChineseName)
 	assert.Equal(t, "Bob Chan", out[0].Room.HRInfo.EngName)
 	require.NotNil(t, out[0].Sender)
 	assert.Equal(t, "alice", out[0].Sender.Account)
-	assert.Equal(t, "Alice", out[0].Sender.DisplayName)
 }
 
 func TestEnrichMessages_BotDM(t *testing.T) {
@@ -73,8 +72,6 @@ func TestEnrichMessages_BotDM(t *testing.T) {
 	b, err := json.Marshal(out[0].Room)
 	require.NoError(t, err)
 	assert.NotContains(t, string(b), "appInfo")
-	// bot sender display name = app name
-	assert.Equal(t, "Helper", out[0].Sender.DisplayName)
 }
 
 func TestEnrichMessages_ChannelUsesRoomBatch(t *testing.T) {
@@ -113,7 +110,7 @@ func TestEnrichMessages_DegradesOnAllErrors(t *testing.T) {
 	// still returns the base message; room present with id, sender falls back to account
 	require.NotNil(t, out[0].Room)
 	assert.Equal(t, "rCh", out[0].Room.ID)
-	assert.Equal(t, "alice", out[0].Sender.DisplayName) // fallback to account
+	assert.Equal(t, "alice", out[0].Sender.Account)
 }
 
 func TestEnrichMessages_Empty(t *testing.T) {
@@ -136,7 +133,7 @@ func TestEnrichMessages_NilMongoDegrades(t *testing.T) {
 	assert.Equal(t, "rCh", out[0].Room.ID)
 	assert.Equal(t, "General", out[0].Room.Name) // room-name RPC still works without mongo
 	require.NotNil(t, out[0].Sender)
-	assert.Equal(t, "alice", out[0].Sender.DisplayName) // sender falls back to account
+	assert.Equal(t, "alice", out[0].Sender.Account)
 }
 
 // Neither dependency wired: base projections survive, no panic, no names.
@@ -147,5 +144,5 @@ func TestEnrichMessages_NilMongoAndRoomDegrades(t *testing.T) {
 	assert.Equal(t, "m1", out[0].MessageID)
 	require.NotNil(t, out[0].Room)
 	assert.Equal(t, "rCh", out[0].Room.ID)
-	assert.Equal(t, "alice", out[0].Sender.DisplayName)
+	assert.Equal(t, "alice", out[0].Sender.Account)
 }

--- a/search-service/enrich_test.go
+++ b/search-service/enrich_test.go
@@ -72,7 +72,7 @@ func TestEnrichMessages_DM_UsersLookupMiss(t *testing.T) {
 func TestEnrichMessages_BotDM(t *testing.T) {
 	m := &fakeMongo{
 		subs: map[string]SubscriptionMeta{"rBot": {RoomType: model.RoomTypeBotDM, Name: "helper.bot", IsSubscribed: true}},
-		apps: map[string]model.App{"helper.bot": {ID: "app1", Name: "Helper", Assistant: &model.AppAssistant{Name: "helper.bot"}}},
+		apps: map[string]AppRef{"helper.bot": {ID: "app1", Name: "Helper", AssistantName: "helper.bot"}},
 	}
 	h := enrichHandler(m, &fakeRoom{})
 	// sender is the bot itself
@@ -95,7 +95,7 @@ func TestEnrichMessages_BotDM(t *testing.T) {
 func TestEnrichMessages_BotDM_Unsubscribed(t *testing.T) {
 	m := &fakeMongo{
 		subs: map[string]SubscriptionMeta{"rBot": {RoomType: model.RoomTypeBotDM, Name: "helper.bot", IsSubscribed: false}},
-		apps: map[string]model.App{"helper.bot": {ID: "app1", Name: "Helper"}},
+		apps: map[string]AppRef{"helper.bot": {ID: "app1", Name: "Helper", AssistantName: "helper.bot"}},
 	}
 	h := enrichHandler(m, &fakeRoom{})
 	out := h.enrichMessages(context.Background(), "alice", []messageSearchHit{hit("m1", "rBot", "site-a", "alice")})

--- a/search-service/handler_test.go
+++ b/search-service/handler_test.go
@@ -235,7 +235,7 @@ type fakeMongo struct {
 	subsErr  error
 	users    map[string]HRUser
 	usersErr error
-	apps     map[string]model.App
+	apps     map[string]AppRef
 	appsErr  error
 
 	subsAccount string
@@ -283,7 +283,7 @@ func (f *fakeMongo) UsersByAccounts(_ context.Context, accounts []string) (map[s
 	return f.users, nil
 }
 
-func (f *fakeMongo) AppsByAssistantNames(_ context.Context, bots []string) (map[string]model.App, error) {
+func (f *fakeMongo) AppsByAssistantNames(_ context.Context, bots []string) (map[string]AppRef, error) {
 	f.appBots = bots
 	if f.appsErr != nil {
 		return nil, f.appsErr

--- a/search-service/handler_test.go
+++ b/search-service/handler_test.go
@@ -896,5 +896,5 @@ func TestSearchMessages_EnrichesResponse(t *testing.T) {
 	assert.Equal(t, model.RoomTypeDM, resp.Messages[0].Room.Type)
 	assert.Equal(t, "Bob Chan", resp.Messages[0].Room.Name)
 	require.NotNil(t, resp.Messages[0].Sender)
-	assert.Equal(t, "Alice", resp.Messages[0].Sender.DisplayName)
+	assert.Equal(t, "alice", resp.Messages[0].Sender.Account)
 }

--- a/search-service/integration_enrich_test.go
+++ b/search-service/integration_enrich_test.go
@@ -21,7 +21,7 @@ func TestMongoStore_EnrichLookups(t *testing.T) {
 
 	_, err := db.Collection("subscriptions").InsertMany(ctx, []any{
 		bson.M{"_id": "s1", "u": bson.M{"account": "alice"}, "roomId": "rDM", "roomType": "dm", "name": "bob"},
-		bson.M{"_id": "s2", "u": bson.M{"account": "alice"}, "roomId": "rBot", "roomType": "botDM", "name": "helper.bot"},
+		bson.M{"_id": "s2", "u": bson.M{"account": "alice"}, "roomId": "rBot", "roomType": "botDM", "name": "helper.bot", "isSubscribed": true},
 		bson.M{"_id": "s3", "u": bson.M{"account": "alice"}, "roomId": "rCh", "roomType": "channel", "name": "General"},
 		bson.M{"_id": "s4", "u": bson.M{"account": "carol"}, "roomId": "rDM", "roomType": "dm", "name": "alice"},
 	})
@@ -41,6 +41,8 @@ func TestMongoStore_EnrichLookups(t *testing.T) {
 	assert.Equal(t, "bob", subs["rDM"].Name)
 	assert.Equal(t, model.RoomTypeBotDM, subs["rBot"].RoomType)
 	assert.Equal(t, "helper.bot", subs["rBot"].Name)
+	assert.True(t, subs["rBot"].IsSubscribed)
+	assert.False(t, subs["rDM"].IsSubscribed) // absent in fixture → zero value
 	assert.Equal(t, model.RoomTypeChannel, subs["rCh"].RoomType)
 	_, missing := subs["rMissing"]
 	assert.False(t, missing)
@@ -57,7 +59,9 @@ func TestMongoStore_EnrichLookups(t *testing.T) {
 	apps, err := store.AppsByAssistantNames(ctx, []string{"helper.bot", "ghost.bot"})
 	require.NoError(t, err)
 	assert.Equal(t, "Helper", apps["helper.bot"].Name)
-	// projection: only name and assistant.name come back
+	assert.Equal(t, "app-1", apps["helper.bot"].ID)
+	assert.Equal(t, "helper.bot", apps["helper.bot"].Assistant.Name)
+	// projection: only _id, name and assistant.name come back
 	assert.Empty(t, apps["helper.bot"].Description)
 	assert.Empty(t, apps["helper.bot"].Version)
 	_, ok = apps["ghost.bot"]

--- a/search-service/integration_enrich_test.go
+++ b/search-service/integration_enrich_test.go
@@ -58,12 +58,7 @@ func TestMongoStore_EnrichLookups(t *testing.T) {
 
 	apps, err := store.AppsByAssistantNames(ctx, []string{"helper.bot", "ghost.bot"})
 	require.NoError(t, err)
-	assert.Equal(t, "Helper", apps["helper.bot"].Name)
-	assert.Equal(t, "app-1", apps["helper.bot"].ID)
-	assert.Equal(t, "helper.bot", apps["helper.bot"].Assistant.Name)
-	// projection: only _id, name and assistant.name come back
-	assert.Empty(t, apps["helper.bot"].Description)
-	assert.Empty(t, apps["helper.bot"].Version)
+	assert.Equal(t, AppRef{ID: "app-1", Name: "Helper", AssistantName: "helper.bot"}, apps["helper.bot"])
 	_, ok = apps["ghost.bot"]
 	assert.False(t, ok)
 

--- a/search-service/mock_store_test.go
+++ b/search-service/mock_store_test.go
@@ -153,10 +153,10 @@ func (m *MockMongoStore) EXPECT() *MockMongoStoreMockRecorder {
 }
 
 // AppsByAssistantNames mocks base method.
-func (m *MockMongoStore) AppsByAssistantNames(ctx context.Context, botAccounts []string) (map[string]model.App, error) {
+func (m *MockMongoStore) AppsByAssistantNames(ctx context.Context, botAccounts []string) (map[string]AppRef, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppsByAssistantNames", ctx, botAccounts)
-	ret0, _ := ret[0].(map[string]model.App)
+	ret0, _ := ret[0].(map[string]AppRef)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/search-service/store.go
+++ b/search-service/store.go
@@ -48,6 +48,13 @@ type HRUser struct {
 	ChineseName string
 }
 
+// AppRef is the apps-collection projection used to render appInfo objects.
+type AppRef struct {
+	ID            string
+	Name          string
+	AssistantName string
+}
+
 // MongoStore is the Mongo-backed store interface for search-service.
 type MongoStore interface {
 	SearchAppsByName(
@@ -64,8 +71,8 @@ type MongoStore interface {
 	// UsersByAccounts returns HR/display projections keyed by account. Missing accounts are omitted.
 	UsersByAccounts(ctx context.Context, accounts []string) (map[string]HRUser, error)
 
-	// AppsByAssistantNames returns apps keyed by their assistant.name (bot account). Missing are omitted.
-	AppsByAssistantNames(ctx context.Context, botAccounts []string) (map[string]model.App, error)
+	// AppsByAssistantNames returns app projections keyed by their assistant.name (bot account). Missing are omitted.
+	AppsByAssistantNames(ctx context.Context, botAccounts []string) (map[string]AppRef, error)
 }
 
 // RoomInfoClient fetches canonical room metadata from room-service on a given

--- a/search-service/store.go
+++ b/search-service/store.go
@@ -33,10 +33,12 @@ type UserRoomDoc struct {
 }
 
 // SubscriptionMeta is the caller's subscription projection used for enrichment:
-// the room type plus the join-key Name (DM counterpart account / botDM bot account).
+// the room type, the join-key Name (DM counterpart account / botDM bot
+// account), and the botDM IsSubscribed flag.
 type SubscriptionMeta struct {
-	RoomType model.RoomType
-	Name     string
+	RoomType     model.RoomType
+	Name         string
+	IsSubscribed bool
 }
 
 // HRUser is the users-collection projection used to render display / HR names.

--- a/search-service/store_mongo.go
+++ b/search-service/store_mongo.go
@@ -69,22 +69,23 @@ func (s *mongoStore) SubscriptionsByRoomIDs(ctx context.Context, account string,
 		return out, nil
 	}
 	filter := bson.M{"u.account": account, "roomId": bson.M{"$in": roomIDs}}
-	proj := bson.M{"roomId": 1, "roomType": 1, "name": 1}
+	proj := bson.M{"roomId": 1, "roomType": 1, "name": 1, "isSubscribed": 1}
 	cur, err := s.subscriptions.Find(ctx, filter, options.Find().SetProjection(proj))
 	if err != nil {
 		return nil, fmt.Errorf("find subscriptions: %w", err)
 	}
 	defer cur.Close(ctx)
 	var rows []struct {
-		RoomID   string         `bson:"roomId"`
-		RoomType model.RoomType `bson:"roomType"`
-		Name     string         `bson:"name"`
+		RoomID       string         `bson:"roomId"`
+		RoomType     model.RoomType `bson:"roomType"`
+		Name         string         `bson:"name"`
+		IsSubscribed bool           `bson:"isSubscribed"`
 	}
 	if err := cur.All(ctx, &rows); err != nil {
 		return nil, fmt.Errorf("decode subscriptions: %w", err)
 	}
 	for _, r := range rows {
-		out[r.RoomID] = SubscriptionMeta{RoomType: r.RoomType, Name: r.Name}
+		out[r.RoomID] = SubscriptionMeta{RoomType: r.RoomType, Name: r.Name, IsSubscribed: r.IsSubscribed}
 	}
 	return out, nil
 }
@@ -117,15 +118,15 @@ func (s *mongoStore) UsersByAccounts(ctx context.Context, accounts []string) (ma
 }
 
 // AppsByAssistantNames returns apps keyed by their assistant.name (bot account).
-// Only name and assistant.name are projected — callers use the map for
-// display-name resolution only.
+// Only _id, name and assistant.name are projected — the map values back the
+// compact appInfo objects, nothing more.
 func (s *mongoStore) AppsByAssistantNames(ctx context.Context, botAccounts []string) (map[string]model.App, error) {
 	out := map[string]model.App{}
 	if len(botAccounts) == 0 {
 		return out, nil
 	}
 	filter := bson.M{"assistant.name": bson.M{"$in": botAccounts}}
-	proj := bson.M{"name": 1, "assistant.name": 1}
+	proj := bson.M{"_id": 1, "name": 1, "assistant.name": 1}
 	cur, err := s.apps.Find(ctx, filter, options.Find().SetProjection(proj))
 	if err != nil {
 		return nil, fmt.Errorf("find apps by assistant: %w", err)

--- a/search-service/store_mongo.go
+++ b/search-service/store_mongo.go
@@ -117,11 +117,9 @@ func (s *mongoStore) UsersByAccounts(ctx context.Context, accounts []string) (ma
 	return out, nil
 }
 
-// AppsByAssistantNames returns apps keyed by their assistant.name (bot account).
-// Only _id, name and assistant.name are projected — the map values back the
-// compact appInfo objects, nothing more.
-func (s *mongoStore) AppsByAssistantNames(ctx context.Context, botAccounts []string) (map[string]model.App, error) {
-	out := map[string]model.App{}
+// AppsByAssistantNames returns app projections keyed by their assistant.name (bot account).
+func (s *mongoStore) AppsByAssistantNames(ctx context.Context, botAccounts []string) (map[string]AppRef, error) {
+	out := map[string]AppRef{}
 	if len(botAccounts) == 0 {
 		return out, nil
 	}
@@ -132,13 +130,19 @@ func (s *mongoStore) AppsByAssistantNames(ctx context.Context, botAccounts []str
 		return nil, fmt.Errorf("find apps by assistant: %w", err)
 	}
 	defer cur.Close(ctx)
-	var apps []model.App
-	if err := cur.All(ctx, &apps); err != nil {
+	var rows []struct {
+		ID        string `bson:"_id"`
+		Name      string `bson:"name"`
+		Assistant struct {
+			Name string `bson:"name"`
+		} `bson:"assistant"`
+	}
+	if err := cur.All(ctx, &rows); err != nil {
 		return nil, fmt.Errorf("decode apps: %w", err)
 	}
-	for i := range apps {
-		if apps[i].Assistant != nil && apps[i].Assistant.Name != "" {
-			out[apps[i].Assistant.Name] = apps[i]
+	for _, r := range rows {
+		if r.Assistant.Name != "" {
+			out[r.Assistant.Name] = AppRef{ID: r.ID, Name: r.Name, AssistantName: r.Assistant.Name}
 		}
 	}
 	return out, nil


### PR DESCRIPTION
## Summary

Reshapes the `search.messages` hit enrichment per the approved design spec (`docs/superpowers/specs/2026-07-31-search-sender-room-appinfo-design.md`):

**Sender** — drops the server-composed `displayName`; the client renders the name from typed objects:
- Human sender: `{account, hr: {account, chineseName, engName}}`
- Bot sender: `{account, appInfo: {id, name, assistantName}}`
- Lookup miss → `{account}` only (best-effort, as before)

**Room** — regains a compact `appInfo` for `botDM` (not the old fat `AppSubscription`):
- `dm`: `{id, name, type, hrInfo: {account, chineseName, engName}}` (hrInfo rekeyed from the legacy `name` key to `chineseName`)
- `botDM`: `{id, name: app.Name, type, appInfo: {id, name, assistantName, isSubscribed}}` — `isSubscribed` is the explicit true/false from the caller's own subscription row in Mongo
- `channel`/default: `{id, name, type}` — unchanged

**Efficiency** — zero new queries. The same three batched Mongo lookups + per-site room RPC fan-out; `isSubscribed` piggybacks on the subscriptions projection and the apps lookup returns a dedicated `AppRef{ID, Name, AssistantName}` projection. Room and sender objects are now built once per distinct room/account and shared across hits instead of re-allocated per hit.

**Docs** — `docs/client-api.md` (new `MessageHRInfo`/`MessageAppInfo` tables, updated sender/room tables and JSON example) and the derived `docs/client-api/request-reply.md`.

## Testing

- TDD throughout: model round-trip/omitempty tests, enrichment table covering human/bot senders × dm/botDM (subscribed, unsubscribed, app-lookup miss, users-lookup miss)/channel, and degradation paths — each written red before its implementation.
- Integration test asserts the new projections (`AppRef` equality, `isSubscribed` captured, absent field → false).
- `make test` full suite passes with `-race`; `make lint` 0 issues; `make sast` (gosec/govulncheck/semgrep) all pass; integration tests compile-checked (`go vet -tags integration`) — Docker unavailable in this environment, CI runs them.
- A 4-angle simplify review pass (reuse/simplification/efficiency/altitude) was applied: shared `hrInfoOf`/`appInfoOf` converters, `AppRef` store projection, per-key memoization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLzp4zqvqyBaoXRgNqm7ey

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLzp4zqvqyBaoXRgNqm7ey)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search messages now include structured human-resource or app metadata for senders.
  * Direct-message rooms now provide structured HR details, while bot conversations include app information and subscription status.
  * Missing metadata gracefully falls back to available account or room details.

* **Documentation**
  * Updated client API documentation and response schemas to reflect the enriched search-message data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->