### PR TITLE
Local/global room subjects: address review feedback + configurable grace window

### DIFF
--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -35,35 +35,37 @@ type encryptionConfig struct {
 }
 
 type config struct {
-	NatsURL              string                  `env:"NATS_URL"                  envDefault:"nats://localhost:4222"`
-	NatsCredsFile        string                  `env:"NATS_CREDS_FILE"           envDefault:""`
-	SiteID               string                  `env:"SITE_ID"                   envDefault:"default"`
-	MongoURI             string                  `env:"MONGO_URI"                 envDefault:"mongodb://localhost:27017"`
-	MongoDB              string                  `env:"MONGO_DB"                  envDefault:"chat"`
-	MongoUsername        string                  `env:"MONGO_USERNAME"            envDefault:""`
-	MongoPassword        string                  `env:"MONGO_PASSWORD"            envDefault:""`
-	MaxWorkers           int                     `env:"MAX_WORKERS"               envDefault:"100"`
-	LastMsgFlushInterval time.Duration           `env:"LAST_MSG_FLUSH_INTERVAL"   envDefault:"250ms"`
-	UserCacheSize        int                     `env:"USER_CACHE_SIZE"           envDefault:"10000"`
-	UserCacheTTL         time.Duration           `env:"USER_CACHE_TTL"            envDefault:"5m"`
-	RoomMetaCacheSize    int                     `env:"ROOM_META_CACHE_SIZE"      envDefault:"10000"`
-	RoomMetaCacheTTL     time.Duration           `env:"ROOM_META_CACHE_TTL"       envDefault:"2m"`
-	RoomKeyGracePeriod   time.Duration           `env:"ROOM_KEY_GRACE_PERIOD"     envDefault:"24h"`
-	RoomKeyCacheTTL      time.Duration           `env:"ROOM_KEY_CACHE_TTL"        envDefault:"10m"`
-	RoomKeyCacheSize     int                     `env:"ROOM_KEY_CACHE_SIZE"       envDefault:"50000"`
-	RoomMetaL2TTL        time.Duration           `env:"ROOM_META_L2_TTL"          envDefault:"15m"`
-	ValkeyAddrs          []string                `env:"VALKEY_ADDRS"              envSeparator:","`
-	ValkeyPassword       string                  `env:"VALKEY_PASSWORD"           envDefault:""`
-	ValkeyKeyGracePeriod time.Duration           `env:"VALKEY_KEY_GRACE_PERIOD" envDefault:"24h"`
-	HealthAddr           string                  `env:"HEALTH_ADDR"              envDefault:":8081"`
-	PProfEnabled         bool                    `env:"PPROF_ENABLED" envDefault:"false"`
-	MetricsAddr          string                  `env:"METRICS_ADDR"             envDefault:":9090"`
-	Mode                 stream.Pipeline         `env:"MODE,required"` // user | bot; drives all stream/subject wiring via pkg/stream.Resolve
-	RoomSubjectMode      string                  `env:"ROOM_SUBJECT_MODE"        envDefault:"global"`
-	Consumer             stream.ConsumerSettings `envPrefix:"CONSUMER_"`
-	Bootstrap            bootstrapConfig         `envPrefix:"BOOTSTRAP_"`
-	Encryption           encryptionConfig        `envPrefix:"ENCRYPTION_"`
-	DebugLog             logctx.Config           `envPrefix:"DEBUG_LOG_"`
+	NatsURL              string          `env:"NATS_URL"                  envDefault:"nats://localhost:4222"`
+	NatsCredsFile        string          `env:"NATS_CREDS_FILE"           envDefault:""`
+	SiteID               string          `env:"SITE_ID"                   envDefault:"default"`
+	MongoURI             string          `env:"MONGO_URI"                 envDefault:"mongodb://localhost:27017"`
+	MongoDB              string          `env:"MONGO_DB"                  envDefault:"chat"`
+	MongoUsername        string          `env:"MONGO_USERNAME"            envDefault:""`
+	MongoPassword        string          `env:"MONGO_PASSWORD"            envDefault:""`
+	MaxWorkers           int             `env:"MAX_WORKERS"               envDefault:"100"`
+	LastMsgFlushInterval time.Duration   `env:"LAST_MSG_FLUSH_INTERVAL"   envDefault:"250ms"`
+	UserCacheSize        int             `env:"USER_CACHE_SIZE"           envDefault:"10000"`
+	UserCacheTTL         time.Duration   `env:"USER_CACHE_TTL"            envDefault:"5m"`
+	RoomMetaCacheSize    int             `env:"ROOM_META_CACHE_SIZE"      envDefault:"10000"`
+	RoomMetaCacheTTL     time.Duration   `env:"ROOM_META_CACHE_TTL"       envDefault:"2m"`
+	RoomKeyGracePeriod   time.Duration   `env:"ROOM_KEY_GRACE_PERIOD"     envDefault:"24h"`
+	RoomKeyCacheTTL      time.Duration   `env:"ROOM_KEY_CACHE_TTL"        envDefault:"10m"`
+	RoomKeyCacheSize     int             `env:"ROOM_KEY_CACHE_SIZE"       envDefault:"50000"`
+	RoomMetaL2TTL        time.Duration   `env:"ROOM_META_L2_TTL"          envDefault:"15m"`
+	ValkeyAddrs          []string        `env:"VALKEY_ADDRS"              envSeparator:","`
+	ValkeyPassword       string          `env:"VALKEY_PASSWORD"           envDefault:""`
+	ValkeyKeyGracePeriod time.Duration   `env:"VALKEY_KEY_GRACE_PERIOD" envDefault:"24h"`
+	HealthAddr           string          `env:"HEALTH_ADDR"              envDefault:":8081"`
+	PProfEnabled         bool            `env:"PPROF_ENABLED" envDefault:"false"`
+	MetricsAddr          string          `env:"METRICS_ADDR"             envDefault:":9090"`
+	Mode                 stream.Pipeline `env:"MODE,required"` // user | bot; drives all stream/subject wiring via pkg/stream.Resolve
+	RoomSubjectMode      string          `env:"ROOM_SUBJECT_MODE"        envDefault:"global"`
+	// RoomLocalityGrace: post-flip dual-publish window. Must match across all publisher services.
+	RoomLocalityGrace time.Duration           `env:"ROOM_LOCALITY_GRACE"      envDefault:"168h"`
+	Consumer          stream.ConsumerSettings `envPrefix:"CONSUMER_"`
+	Bootstrap         bootstrapConfig         `envPrefix:"BOOTSTRAP_"`
+	Encryption        encryptionConfig        `envPrefix:"ENCRYPTION_"`
+	DebugLog          logctx.Config           `envPrefix:"DEBUG_LOG_"`
 	// AdminAcctPrefix overrides the platform-admin account prefix (ADMIN_ACCT_PREFIX); keep it identical across services.
 	AdminAcctPrefix string `env:"ADMIN_ACCT_PREFIX" envDefault:"p_admin"`
 }
@@ -89,6 +91,7 @@ func main() {
 		slog.Error("invalid ROOM_SUBJECT_MODE", "error", err)
 		os.Exit(1)
 	}
+	subject.SetRoomLocalityGrace(cfg.RoomLocalityGrace)
 
 	ctx := context.Background()
 

--- a/docs/superpowers/plans/2026-07-28-local-global-room-subjects.md
+++ b/docs/superpowers/plans/2026-07-28-local-global-room-subjects.md
@@ -32,7 +32,7 @@ Every task through Task 11 leaves production behavior unchanged because publishe
 - `pkg/subject/subject.go` — locality-aware `RoomEvent`/`RoomMsgStream`/`RoomMetadataUpdate`.
 - `pkg/roommetacache/roommetacache.go` — `Meta.CrossSite` + Mongo projection.
 - `room-worker/store.go` + `store_mongo.go` — `SetRoomCrossSite`.
-- `room-worker/handler.go` — set flag in `processAddMembers` + `processCreateRoom`; transition nudge; publisher routing.
+- `room-worker/handler.go` — set flag in `processAddMembers` + `processCreateRoom`; publisher routing.
 - `room-service/handler.go` — `roomsInfoBatch` returns `CrossSite`; RoomEvent publisher routing.
 - `user-service/mongorepo/subscriptions.go` — `$lookup` projects `crossSite`.
 - `user-service/service/subscriptions.go` — `buildLocalRoom`/`applyRoomInfo` map `CrossSite`.
@@ -786,55 +786,16 @@ git commit -m "feat(data-migration): backfill crossSite=true for existing cross-
 
 ---
 
-### Task 14: Local→global transition nudge
+### Task 14: Local→global transition nudge — DROPPED
 
-*(unchanged from the original plan — publishes a per-user `event.room.update` nudge to existing members when `processAddMembers` flips a room local→global, so connected clients re-subscribe. Offline/dropped clients self-correct via `subscription.list`.)*
-
-**Files:**
-- Modify: `room-worker/handler.go` (`processAddMembers` — after the Task 5 `SetRoomCrossSite` call)
-- Test: `room-worker/handler_test.go`
-
-- [ ] **Step 1: Write the failing tests:**
-
-```go
-func TestProcessAddMembers_NudgesExistingMembersOnFlip(t *testing.T) {
-	// room previously local (loaded room CrossSite=false), adding a site-b member →
-	// expect a publish on subject.UserRoomUpdate(existingMemberAccount)
-}
-func TestProcessAddMembers_NoNudgeWhenAlreadyGlobal(t *testing.T) {
-	// loaded room CrossSite=true already → no nudge
-}
-```
-
-- [ ] **Step 2: Run to verify they fail** — `make test SERVICE=room-worker`.
-
-- [ ] **Step 3: Implement**, gating on the room's prior state (already loaded before the write). Only when `!room.CrossSite && len(accountsBySite) > 0`:
-
-```go
-	if !room.CrossSite && len(accountsBySite) > 0 {
-		// Room just flipped local→global. Nudge existing members' always-on per-user
-		// tree so connected clients re-fetch subscription.list and re-subscribe to the
-		// global namespace. Best-effort: offline/dropped clients self-correct on reconnect.
-		evt := model.RoomMetadataUpdateEvent{RoomID: req.RoomID, Timestamp: now.UnixMilli()}
-		data, _ := json.Marshal(evt)
-		for _, acc := range existingMemberAccounts { // members present BEFORE this add
-			if err := h.publish(ctx, subject.UserRoomUpdate(acc), data, ""); err != nil {
-				slog.WarnContext(ctx, "room-locality nudge publish failed", "account", acc, "roomId", req.RoomID)
-			}
-		}
-	}
-```
-
-Derive `existingMemberAccounts` from the pre-add membership `loadAddMemberInputs` already reads — no new read. Confirm the client already treats `event.room.update` as a trigger to refresh its subscription list; the nudge only needs to prompt a refresh (the flag is authoritative).
-
-- [ ] **Step 4: Run to verify they pass** — `make test SERVICE=room-worker`, `make lint`.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add room-worker/handler.go room-worker/handler_test.go
-git commit -m "feat(room-worker): nudge existing members when a room flips local->global"
-```
+Originally this task published a per-user `event.room.update` nudge to existing
+members when `processAddMembers` flipped a room local→global, so connected
+clients would re-subscribe immediately. It was **dropped in review**: mass-nudging
+every subscriber (a full room-subscriber read + a publish per member) is heavy for
+large rooms, and it is unnecessary — the transition grace window (`RoomLocalityGrace`)
+already dual-publishes to the local subject for a bounded period after a flip, so
+members still on the local lane keep receiving. Clients pick up the new `crossSite`
+value and re-subscribe on their next `subscription.list`; the flag is authoritative.
 
 ---
 
@@ -919,7 +880,7 @@ git commit -m "docs: local/global room namespaces, chat.local.room.> grant, ROOM
 - Write path at federation points → Tasks 5 (add), 6 (create); room-worker only (room-service is an RPC front). ✓
 - Publisher routing (broadcast-worker + room-service/worker), gated → Tasks 10 (helper+mode), 11, 12. ✓
 - Client payload + subscribe → Tasks 7, 8, 9 (payload) + Task 15 (frontend subscribe). ✓
-- Transition nudge (per-user, gap-tolerant) → Task 14. ✓
+- Transition gap coverage → the `RoomLocalityGrace` dual-publish window (Task 14 nudge dropped in review). ✓
 - Backfill of pre-existing cross-site rooms → Task 13. ✓
 - Auth grant + docs + rollout → Task 16. ✓
 - Non-goals (per-user tree, demote) → excluded. ✓

--- a/docs/superpowers/specs/2026-07-28-local-global-room-subjects-design.md
+++ b/docs/superpowers/specs/2026-07-28-local-global-room-subjects-design.md
@@ -161,11 +161,15 @@ Publishers default to global if the flag is absent/unknown (fail-safe).
 
 - **Transition grace window closes the flip gap server-side.** When a *previously
   confirmed same-site* room (`crossSite==false`) flips to cross-site, the flip time is
-  recorded as `Room.CrossSiteAt`, and for `RoomLocalityGrace` (15 min) afterward every
+  recorded as `Room.CrossSiteAt`, and for the locality grace window afterward every
   publisher emits the room's `.event` to **both** the local and global subjects (see
-  `pkg/subject.RoomEventTargets`). So a same-site member still subscribed to the local
-  subject keeps receiving in real time until it re-subscribes — the gap depends only on
-  the client reconnecting/reconciling within the window, not on any proactive push. The
+  `pkg/subject.RoomEventTargets`). The window is `ROOM_LOCALITY_GRACE` (default 1 week,
+  `subject.DefaultRoomLocalityGrace`) — long enough that essentially every client
+  reconnects and re-subscribes the room within it, so it decays to zero double-publishing
+  once the local audience has drained; all publisher services MUST use the same value. So
+  a same-site member still subscribed to the local subject keeps receiving in real time
+  until it re-subscribes — the gap depends only on the client reconnecting/reconciling
+  within the window, not on any proactive push. The
   double-publish is bounded (only rooms actively flipping, only for the window) and
   site-local on the leaf-filtered subject, so the steady-state interest-map savings are
   preserved. Rooms *born* cross-site get no `CrossSiteAt` and no grace (they never had a
@@ -241,18 +245,18 @@ publishing all rooms on the global prefix only.
 **Per-room flip after rollout — bounded by the grace window.** A local→global room
 **flip** (a same-site room gains a cross-site member) re-routes an already-connected
 client only when it re-subscribes. The **transition grace window** (see Client Routing &
-Transition: publishers dual-publish a flipped room to both subjects for `RoomLocalityGrace`)
-makes this gapless server-side for any client that re-subscribes within the window —
-whether via the nudge or its normal reconnect / periodic `subscription.list` reconcile.
-The nudge is therefore a latency optimization, not a correctness dependency.
+Transition: publishers dual-publish a flipped room to both subjects for the locality
+grace window) makes this gapless server-side for any client that re-subscribes within the
+window via its normal reconnect / periodic `subscription.list` reconcile. With the default
+1-week window this covers essentially every client, since clients re-read
+`subscription.list` and re-subscribe on every reconnect (network change, deploy, app
+foreground).
 
-**Client contract for the flip (for the official client, not the internal
-chat-frontend test client):** to re-route *promptly* rather than at the next reconcile,
-subscribe to `chat.user.{account}.event.room.update` (the server's
-`subject.UserRoomUpdate` nudge — distinct from the general `event.room.metadata.update`)
-and, on receipt, refresh `subscription.list` and re-subscribe the room by its new
-`crossSite`. Correctness still rests on the persisted flag + history/gap fetch, so a
-client that only reconciles periodically is still correct as long as its reconcile
-interval is within the grace window. (The chat-frontend test client does not implement
-this yet; document the subject + event in `docs/client-api.md` before the official
-client is built.)
+**Client contract for the flip:** the client re-routes when it next reads
+`subscription.list` and re-subscribes the room by its `crossSite` value — on reconnect or
+periodic reconcile. Correctness rests on the persisted flag + history/gap fetch, so a
+client is correct as long as it reconnects/reconciles within the grace window; anything
+past it is recovered by the normal history fetch. (An earlier design added a per-user
+`event.room.update` push to trigger an immediate re-subscribe; it was dropped in review —
+mass-nudging every subscriber is heavy for large rooms and the grace window already covers
+the gap.)

--- a/docs/superpowers/specs/2026-07-28-local-global-room-subjects-design.md
+++ b/docs/superpowers/specs/2026-07-28-local-global-room-subjects-design.md
@@ -143,42 +143,34 @@ Publishers default to global if the flag is absent/unknown (fail-safe).
 
   It subscribes each room to `chat.local.room.{id}.>` or `chat.room.{id}.>` accordingly.
 
-- **Transition (local → global):** when a room's flag flips, a nudge rides the
-  **per-user** room-update event (`chat.user.{account}.event.room…`), which every member
-  is always subscribed to regardless of the room's prefix — so it reaches members even
-  after the publisher stops emitting on the local prefix. On receipt the client
-  re-subscribes that room to the global prefix. The newly-added remote member reads
+- **Transition (local → global):** when a room's flag flips, the client learns the new
+  `crossSite=true` on its next `subscription.list` and re-subscribes that room to the
+  global prefix; the flag is authoritative. The newly-added remote member reads
   `crossSite=true` from its initial `subscription.list` and subscribes global directly.
+  The real-time gap for same-site members still on the local prefix is closed
+  server-side by the grace window below, so correctness never depends on a proactive
+  push. (An earlier design pushed a per-user nudge to prompt immediate re-subscribe;
+  it was dropped in review — mass-nudging every subscriber is heavy for large rooms and
+  the grace window already covers the gap.)
 
 - **Offline / dropped clients self-correct on bootstrap.** An offline client isn't
   subscribed to anything; on reconnect it re-reads `subscription.list`, sees
-  `crossSite=true`, and subscribes global from the first subscription — it never needed
-  the event. A client disconnected as a slow consumer likewise recovers via the
-  reconnect + fresh `subscription.list`.
+  `crossSite=true`, and subscribes global from the first subscription. A client
+  disconnected as a slow consumer likewise recovers via the reconnect + fresh
+  `subscription.list`.
 
 - **Transition grace window closes the flip gap server-side.** When a *previously
   confirmed same-site* room (`crossSite==false`) flips to cross-site, the flip time is
   recorded as `Room.CrossSiteAt`, and for `RoomLocalityGrace` (15 min) afterward every
   publisher emits the room's `.event` to **both** the local and global subjects (see
   `pkg/subject.RoomEventTargets`). So a same-site member still subscribed to the local
-  subject keeps receiving in real time until it re-subscribes — the gap no longer depends
-  on the best-effort nudge being delivered or on client reconcile frequency. A client that
-  migrates within the window sees zero gap; the nudge is reduced to a pure latency
-  optimization. The double-publish is bounded (only rooms actively flipping, only for the
-  window) and site-local on the leaf-filtered subject, so the steady-state interest-map
-  savings are preserved. Rooms *born* cross-site get no `CrossSiteAt` and no grace (they
-  never had a local audience). Any residual gap past the window is still recovered by the
-  client's normal history/gap fetch.
-
-### Why the nudge is a single per-user publish (not two paths)
-
-Emitting the nudge on the room's local subject *in addition to* the per-user subject was
-considered and rejected: both are core-NATS server→client deliveries over the same TCP
-connection, so they share fate. A healthy connection already receives the per-user
-nudge; an unhealthy one drops both and the client reconnects (recovering via
-`subscription.list`). Core NATS has no single-message loss mode for a still-connected
-client, so a second server-side publish adds no meaningful reliability. Any extra
-insurance belongs client-side (periodic/foreground reconciliation), outside this design.
+  subject keeps receiving in real time until it re-subscribes — the gap depends only on
+  the client reconnecting/reconciling within the window, not on any proactive push. The
+  double-publish is bounded (only rooms actively flipping, only for the window) and
+  site-local on the leaf-filtered subject, so the steady-state interest-map savings are
+  preserved. Rooms *born* cross-site get no `CrossSiteAt` and no grace (they never had a
+  local audience). Any residual gap past the window is still recovered by the client's
+  normal history/gap fetch.
 
 ## Auth / JWT Permission (platform-team touchpoint)
 

--- a/pkg/model/room.go
+++ b/pkg/model/room.go
@@ -45,13 +45,6 @@ type Room struct {
 // OriginTeams marks a room/subscription imported from the Teams migration.
 const OriginTeams = "teams"
 
-// RoutesGlobal reports whether r resolves to the global namespace (nil or true
-// CrossSite; only explicit false is local). Nil-safe mirror of the
-// pkg/subject.RoomEventTargets fail-safe; a nil room is not routed global.
-func (r *Room) RoutesGlobal() bool {
-	return r != nil && (r.CrossSite == nil || *r.CrossSite)
-}
-
 // RoomsInfoBatchRequest is the NATS request body for the batch room info RPC.
 type RoomsInfoBatchRequest struct {
 	RoomIDs []string `json:"roomIds"`

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -7,10 +7,26 @@ import (
 	"unicode"
 )
 
-// RoomLocalityGrace bounds the local→global flip gap server-side: for this long
-// after a flip, publishers also dual-publish to the local subject so members not
-// yet re-subscribed keep receiving (vs. trusting the best-effort nudge).
-const RoomLocalityGrace = 15 * time.Minute
+// DefaultRoomLocalityGrace is the default post-flip dual-publish window. For this
+// long after a room flips local→global, publishers also emit to the local subject
+// so members not yet re-subscribed keep receiving; then it closes so flipped rooms
+// stop double-publishing to the (drained) local subject. One week is long enough
+// that essentially every client reconnects and re-subscribes within it.
+const DefaultRoomLocalityGrace = 7 * 24 * time.Hour
+
+// roomLocalityGrace is the active window. Overridable once at startup via
+// SetRoomLocalityGrace (ROOM_LOCALITY_GRACE); read-only afterward. All publisher
+// services MUST configure the same value or a flipped room's dual-publish window
+// closes at different times per publisher.
+var roomLocalityGrace = DefaultRoomLocalityGrace
+
+// SetRoomLocalityGrace overrides the post-flip grace window. Call once at startup,
+// before any RoomEventTargets call; a non-positive d is ignored (keeps the default).
+func SetRoomLocalityGrace(d time.Duration) {
+	if d > 0 {
+		roomLocalityGrace = d
+	}
+}
 
 // EncodeAccount maps an account to its NATS subject-token form by replacing the
 // dot separators a dotted account (e.g. a ".bot" account) would otherwise spill
@@ -362,8 +378,8 @@ func (m RoomRouteMode) usesLocal() bool { return m != RouteGlobal }
 
 // RoomEventTargets returns the .event subject(s) to publish a room event to.
 // Fail-safe: only an explicit crossSite=false routes local (nil/true → global).
-// A room flipped within RoomLocalityGrace (crossSiteAt set) also gets a local copy
-// in local/dual mode so not-yet-resubscribed members keep receiving (order: local, global).
+// A room flipped within the locality grace window (crossSiteAt set) also gets a local
+// copy in local/dual mode so not-yet-resubscribed members keep receiving (order: local, global).
 func RoomEventTargets(roomID string, crossSite *bool, crossSiteAt *time.Time, mode RoomRouteMode, now time.Time) []string {
 	if crossSite != nil && !*crossSite { // confirmed same-site
 		switch mode {
@@ -376,7 +392,7 @@ func RoomEventTargets(roomID string, crossSite *bool, crossSiteAt *time.Time, mo
 		}
 	}
 	// nil or cross-site → global, plus a local copy during the post-flip grace window.
-	if mode.usesLocal() && crossSiteAt != nil && now.Before(crossSiteAt.Add(RoomLocalityGrace)) {
+	if mode.usesLocal() && crossSiteAt != nil && now.Before(crossSiteAt.Add(roomLocalityGrace)) {
 		return []string{RoomEvent(roomID, false), RoomEvent(roomID, true)}
 	}
 	return []string{RoomEvent(roomID, true)}

--- a/pkg/subject/subject_test.go
+++ b/pkg/subject/subject_test.go
@@ -1180,7 +1180,7 @@ func TestRoomEventTargets(t *testing.T) {
 
 // TestRoomEventTargets_TransitionGrace covers the post-flip grace window: a room
 // that just flipped same-site→cross-site (crossSite=&true with crossSiteAt set)
-// keeps a LOCAL copy for RoomLocalityGrace when the mode uses local subjects, so
+// keeps a LOCAL copy for the grace window when the mode uses local subjects, so
 // same-site members still on the local subject don't go dark until they
 // re-subscribe.
 func TestRoomEventTargets_TransitionGrace(t *testing.T) {
@@ -1188,8 +1188,8 @@ func TestRoomEventTargets_TransitionGrace(t *testing.T) {
 	l := "chat.local.room.r1.event"
 	trueP := true
 	flip := time.Unix(1_700_000_000, 0).UTC()
-	within := flip.Add(subject.RoomLocalityGrace - time.Minute)
-	after := flip.Add(subject.RoomLocalityGrace + time.Minute)
+	within := flip.Add(subject.DefaultRoomLocalityGrace - time.Minute)
+	after := flip.Add(subject.DefaultRoomLocalityGrace + time.Minute)
 
 	// Within grace: local + global in local/dual modes.
 	assert.Equal(t, []string{l, g}, subject.RoomEventTargets("r1", &trueP, &flip, subject.RouteLocal, within))
@@ -1200,7 +1200,26 @@ func TestRoomEventTargets_TransitionGrace(t *testing.T) {
 	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", &trueP, &flip, subject.RouteLocal, after))
 	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", &trueP, &flip, subject.RouteDual, after))
 	// Exactly at the boundary is already expired (now.Before is strict).
-	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", &trueP, &flip, subject.RouteLocal, flip.Add(subject.RoomLocalityGrace)))
+	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", &trueP, &flip, subject.RouteLocal, flip.Add(subject.DefaultRoomLocalityGrace)))
+}
+
+// TestSetRoomLocalityGrace verifies the startup override widens/narrows the
+// window, and that a non-positive value is ignored (keeps the default).
+func TestSetRoomLocalityGrace(t *testing.T) {
+	t.Cleanup(func() { subject.SetRoomLocalityGrace(subject.DefaultRoomLocalityGrace) })
+	g := "chat.room.r1.event"
+	l := "chat.local.room.r1.event"
+	trueP := true
+	flip := time.Unix(1_700_000_000, 0).UTC()
+
+	subject.SetRoomLocalityGrace(time.Hour)
+	// A point past the 1h override but well within the default is now expired.
+	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", &trueP, &flip, subject.RouteLocal, flip.Add(2*time.Hour)))
+	assert.Equal(t, []string{l, g}, subject.RoomEventTargets("r1", &trueP, &flip, subject.RouteLocal, flip.Add(30*time.Minute)))
+
+	// Non-positive is ignored: window stays at 1h, not reset to zero.
+	subject.SetRoomLocalityGrace(0)
+	assert.Equal(t, []string{l, g}, subject.RoomEventTargets("r1", &trueP, &flip, subject.RouteLocal, flip.Add(30*time.Minute)))
 }
 
 func TestParseRoomRouteMode(t *testing.T) {

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -76,6 +76,8 @@ type config struct {
 	AdminAcctPrefix string `env:"ADMIN_ACCT_PREFIX" envDefault:"p_admin"`
 	// RoomSubjectMode: same-site room .event namespace — global (default) | dual | local. See pkg/subject.RoomRouteMode.
 	RoomSubjectMode string `env:"ROOM_SUBJECT_MODE" envDefault:"global"`
+	// RoomLocalityGrace: post-flip dual-publish window. Must match across all publisher services.
+	RoomLocalityGrace time.Duration `env:"ROOM_LOCALITY_GRACE" envDefault:"168h"`
 }
 
 // legacyRoomOrigin maps a site to its legacy origin URL (incl. scheme).
@@ -133,6 +135,7 @@ func main() {
 		slog.Error("invalid ROOM_SUBJECT_MODE", "error", err)
 		os.Exit(1)
 	}
+	subject.SetRoomLocalityGrace(cfg.RoomLocalityGrace)
 
 	ctx := context.Background()
 

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -864,6 +864,9 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 			if err := h.store.SetRoomCrossSite(ctx, req.RoomID); err != nil {
 				return fmt.Errorf("mark room cross-site: %w", err)
 			}
+			// Bust L2 AFTER the write so a concurrent refill can't re-cache the
+			// pre-write crossSite=false and mis-route local for the TTL.
+			h.bustRoomMeta(ctx, req.RoomID)
 			break
 		}
 	}
@@ -1256,21 +1259,6 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 		accountsBySite[siteID] = append(accountsBySite[siteID], acc)
 	}
 
-	// Remote-site bucket non-empty → mark global (sticky). room.CrossSite still
-	// holds the PRIOR state (SetRoomCrossSite doesn't mutate it), so gate the nudge
-	// on RoutesGlobal(): only a previously-confirmed same-site (&false) room flips.
-	if len(accountsBySite) > 0 {
-		if err := h.store.SetRoomCrossSite(ctx, req.RoomID); err != nil {
-			return fmt.Errorf("mark room cross-site: %w", err)
-		}
-		// Bust L2 AFTER the write: an earlier bust could be undone by a concurrent
-		// refill re-caching the pre-write crossSite=false, mis-routing local for the TTL.
-		h.bustRoomMeta(ctx, req.RoomID)
-		if !room.RoutesGlobal() {
-			h.nudgeLocalToGlobalTransition(ctx, req.RoomID, actualAccounts, now)
-		}
-	}
-
 	for destSiteID, siteAccounts := range accountsBySite {
 		siteEvt := model.MemberAddEvent{
 			Type:               model.InboxMemberAdded,
@@ -1293,32 +1281,6 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 	}
 
 	return nil
-}
-
-// nudgeLocalToGlobalTransition best-effort nudges existing members (subscribers minus
-// newAccounts) to re-fetch subscription.list and re-subscribe global after a flip, via
-// their per-user tree. Pure latency opt — crossSite is source of truth, so nudge failures
-// are swallowed and clients self-correct on reconnect.
-func (h *Handler) nudgeLocalToGlobalTransition(ctx context.Context, roomID string, newAccounts []string, now time.Time) {
-	allAccounts, err := h.store.GetSubscriptionAccounts(ctx, roomID)
-	if err != nil {
-		slog.WarnContext(ctx, "room-locality nudge: list subscription accounts failed", "error", err, "room_id", roomID)
-		return
-	}
-	justAdded := make(map[string]struct{}, len(newAccounts))
-	for _, acc := range newAccounts {
-		justAdded[acc] = struct{}{}
-	}
-	evt := model.RoomMetadataUpdateEvent{RoomID: roomID, Timestamp: now.UnixMilli()}
-	data, _ := json.Marshal(evt)
-	for _, acc := range allAccounts {
-		if _, ok := justAdded[acc]; ok {
-			continue
-		}
-		if err := h.publish(ctx, subject.UserRoomUpdate(acc), data, ""); err != nil {
-			slog.WarnContext(ctx, "room-locality nudge publish failed", "error", err, "account", acc, "room_id", roomID)
-		}
-	}
 }
 
 // buildAddedMembers assembles the member.list-shaped display entries (contract: model.MemberAddEvent.Members),

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -482,8 +482,8 @@ func TestHandler_ProcessAddMembers(t *testing.T) {
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"bob", "charlie"}, "r1").
 		Return([]AddMemberCandidate{
-			{Account: "bob", HasSubscription: false, HasIndividualRoomMember: false},
-			{Account: "charlie", HasSubscription: false, HasIndividualRoomMember: false},
+			{Account: "bob", HasSubscription: false, HasIndividualRoomMember: false, SiteID: "site-a"},
+			{Account: "charlie", HasSubscription: false, HasIndividualRoomMember: false, SiteID: "site-b"},
 		}, nil)
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"bob", "charlie"}).Return([]model.User{
 		{ID: "u2", Account: "bob", SiteID: "site-a", EngName: "Bob", ChineseName: "鮑"},
@@ -511,10 +511,6 @@ func TestHandler_ProcessAddMembers(t *testing.T) {
 	store.EXPECT().ReconcileMemberCounts(gomock.Any(), "r1").Return(nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
-	// Local→global flip nudge: no pre-existing members here (bob/charlie are
-	// the only, newly-added, subscribers), so the diff against actualAccounts
-	// is empty and no nudge publish fires.
-	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return([]string{"bob", "charlie"}, nil)
 
 	req := model.AddMembersRequest{
 		RoomID: "r1", Users: []string{"bob", "charlie"},
@@ -615,7 +611,7 @@ func TestProcessAddMembers_SetsCrossSiteForRemoteMember(t *testing.T) {
 
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"x"}, "r1").
-		Return([]AddMemberCandidate{{Account: "x", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
+		Return([]AddMemberCandidate{{Account: "x", HasSubscription: false, HasIndividualRoomMember: false, SiteID: "site-b"}}, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"x"}).Return([]model.User{
 		{ID: "u2", Account: "x", SiteID: "site-b", EngName: "X"},
@@ -624,9 +620,6 @@ func TestProcessAddMembers_SetsCrossSiteForRemoteMember(t *testing.T) {
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 1, 0, gomock.Any()).Return(false, nil)
 	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
-	// Local→global flip nudge: "x" is the only (newly-added) subscriber, so no
-	// pre-existing member remains after subtracting actualAccounts.
-	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return([]string{"x"}, nil)
 
 	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"x"}, RequesterAccount: "alice", Timestamp: 1}
 	reqData, _ := json.Marshal(req)
@@ -703,205 +696,6 @@ func TestProcessAddMembers_Redelivery_SameSite_NoCrossSiteWrite(t *testing.T) {
 	reqData, _ := json.Marshal(req)
 	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
 	require.NoError(t, h.processAddMembers(ctx, reqData))
-}
-
-// TestProcessAddMembers_NudgesExistingMembersOnFlip verifies that when a room
-// FLIPS from local (CrossSite=false) to global (a remote member is added),
-// every member who was already subscribed BEFORE this add receives a
-// best-effort nudge on subject.UserRoomUpdate(account) — the always-on
-// per-user tree that prompts a connected client to re-fetch
-// subscription.list and re-subscribe to the global namespace. The
-// newly-added remote member itself must NOT be nudged (it already gets a
-// fresh subscription.update + member_added event).
-func TestProcessAddMembers_NudgesExistingMembersOnFlip(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	store := NewMockSubscriptionStore(ctrl)
-
-	var published []publishedMsg
-	publish := func(_ context.Context, subj string, data []byte, _ string) error {
-		published = append(published, publishedMsg{subj: subj, data: data})
-		return nil
-	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
-
-	// Room previously local: CrossSite is unset (false).
-	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
-	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"newremote"}, "r1").
-		Return([]AddMemberCandidate{{Account: "newremote", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
-	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
-	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"newremote"}).Return([]model.User{
-		{ID: "u_new", Account: "newremote", SiteID: "site-b", EngName: "New"},
-	}, nil)
-	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice"}, nil)
-	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
-	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 1, 0, gomock.Any()).Return(false, nil)
-	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
-	// Post-write subscriber list: alice + bob were already members before this
-	// add; newremote just joined.
-	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return([]string{"alice", "bob", "newremote"}, nil)
-
-	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"newremote"}, RequesterAccount: "alice", Timestamp: 1}
-	reqData, _ := json.Marshal(req)
-	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
-	require.NoError(t, h.processAddMembers(ctx, reqData))
-
-	nudged := map[string]bool{}
-	for _, p := range published {
-		if p.subj == subject.UserRoomUpdate("alice") || p.subj == subject.UserRoomUpdate("bob") || p.subj == subject.UserRoomUpdate("newremote") {
-			nudged[p.subj] = true
-		}
-	}
-	assert.True(t, nudged[subject.UserRoomUpdate("alice")], "pre-existing member alice must be nudged")
-	assert.True(t, nudged[subject.UserRoomUpdate("bob")], "pre-existing member bob must be nudged")
-	assert.False(t, nudged[subject.UserRoomUpdate("newremote")], "the newly-added member must not be nudged")
-}
-
-// TestProcessAddMembers_NoNudgeWhenAlreadyGlobal verifies that a room already
-// marked CrossSite=true (already global) never triggers the local→global
-// nudge, even though adding a remote member still calls SetRoomCrossSite
-// (sticky, idempotent).
-func TestProcessAddMembers_NoNudgeWhenAlreadyGlobal(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	store := NewMockSubscriptionStore(ctrl)
-
-	var published []publishedMsg
-	publish := func(_ context.Context, subj string, data []byte, _ string) error {
-		published = append(published, publishedMsg{subj: subj, data: data})
-		return nil
-	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
-
-	// Room already global.
-	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(true)}, nil)
-	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"newremote"}, "r1").
-		Return([]AddMemberCandidate{{Account: "newremote", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
-	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
-	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"newremote"}).Return([]model.User{
-		{ID: "u_new", Account: "newremote", SiteID: "site-b", EngName: "New"},
-	}, nil)
-	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice"}, nil)
-	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
-	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 1, 0, gomock.Any()).Return(false, nil)
-	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
-	// No GetSubscriptionAccounts call: the mock is strict, so any unexpected
-	// call here fails the test — this is what proves the nudge did not fire.
-
-	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"newremote"}, RequesterAccount: "alice", Timestamp: 1}
-	reqData, _ := json.Marshal(req)
-	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
-	require.NoError(t, h.processAddMembers(ctx, reqData))
-
-	for _, p := range published {
-		assert.NotEqual(t, subject.UserRoomUpdate("alice"), p.subj, "no nudge expected when room is already global")
-	}
-}
-
-// TestProcessAddMembers_SameSiteOnly_NoNudge verifies that an add composed
-// entirely of same-site members never triggers the local→global nudge (there
-// is no flip: accountsBySite stays empty, so SetRoomCrossSite and the nudge
-// are both skipped).
-func TestProcessAddMembers_SameSiteOnly_NoNudge(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	store := NewMockSubscriptionStore(ctrl)
-
-	var published []publishedMsg
-	publish := func(_ context.Context, subj string, data []byte, _ string) error {
-		published = append(published, publishedMsg{subj: subj, data: data})
-		return nil
-	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
-
-	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
-	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"newlocal"}, "r1").
-		Return([]AddMemberCandidate{{Account: "newlocal", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
-	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
-	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"newlocal"}).Return([]model.User{
-		{ID: "u_new", Account: "newlocal", SiteID: "site-a", EngName: "New"},
-	}, nil)
-	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice"}, nil)
-	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
-	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 1, 0, gomock.Any()).Return(false, nil)
-	// No SetRoomCrossSite, no GetSubscriptionAccounts: strict mock proves neither fired.
-
-	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"newlocal"}, RequesterAccount: "alice", Timestamp: 1}
-	reqData, _ := json.Marshal(req)
-	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
-	require.NoError(t, h.processAddMembers(ctx, reqData))
-
-	for _, p := range published {
-		assert.NotEqual(t, subject.UserRoomUpdate("alice"), p.subj, "no nudge expected for a same-site-only add")
-	}
-}
-
-// TestProcessAddMembers_NudgePublishErrorDoesNotFailHandler verifies that a
-// publish failure on the best-effort nudge is logged and swallowed — it must
-// never fail the handler or block the other members' nudges.
-func TestProcessAddMembers_NudgePublishErrorDoesNotFailHandler(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	store := NewMockSubscriptionStore(ctrl)
-
-	var published []publishedMsg
-	publish := func(_ context.Context, subj string, data []byte, _ string) error {
-		if subj == subject.UserRoomUpdate("alice") {
-			return fmt.Errorf("nats publish failed")
-		}
-		published = append(published, publishedMsg{subj: subj, data: data})
-		return nil
-	}
-	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
-
-	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
-	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"newremote"}, "r1").
-		Return([]AddMemberCandidate{{Account: "newremote", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
-	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
-	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"newremote"}).Return([]model.User{
-		{ID: "u_new", Account: "newremote", SiteID: "site-b", EngName: "New"},
-	}, nil)
-	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice"}, nil)
-	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
-	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 1, 0, gomock.Any()).Return(false, nil)
-	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
-	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return([]string{"alice", "bob", "newremote"}, nil)
-
-	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"newremote"}, RequesterAccount: "alice", Timestamp: 1}
-	reqData, _ := json.Marshal(req)
-	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
-	require.NoError(t, h.processAddMembers(ctx, reqData), "a nudge publish failure must not fail the handler")
-
-	var bobNudged bool
-	for _, p := range published {
-		if p.subj == subject.UserRoomUpdate("bob") {
-			bobNudged = true
-		}
-	}
-	assert.True(t, bobNudged, "bob's nudge must still publish even though alice's failed")
-}
-
-// TestProcessAddMembers_NudgeStoreErrorDoesNotFailHandler verifies that a
-// failure reading the room's subscriber list for the nudge (best-effort) is
-// logged and swallowed rather than failing the handler.
-func TestProcessAddMembers_NudgeStoreErrorDoesNotFailHandler(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	store := NewMockSubscriptionStore(ctrl)
-	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
-
-	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
-	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"newremote"}, "r1").
-		Return([]AddMemberCandidate{{Account: "newremote", HasSubscription: false, HasIndividualRoomMember: false}}, nil)
-	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
-	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"newremote"}).Return([]model.User{
-		{ID: "u_new", Account: "newremote", SiteID: "site-b", EngName: "New"},
-	}, nil)
-	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice"}, nil)
-	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
-	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 1, 0, gomock.Any()).Return(false, nil)
-	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
-	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return(nil, fmt.Errorf("mongo timeout"))
-
-	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"newremote"}, RequesterAccount: "alice", Timestamp: 1}
-	reqData, _ := json.Marshal(req)
-	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
-	require.NoError(t, h.processAddMembers(ctx, reqData), "a nudge store-read failure must not fail the handler")
 }
 
 // Repeat direct add in a tracked room: an already-tracked individual (sub + IRM row) must NOT be
@@ -1150,7 +944,7 @@ func TestHandler_ProcessAddMembers_RestrictedPropagatesPointer(t *testing.T) {
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"bob", "charlie"}, "r1").
 		Return([]AddMemberCandidate{
-			{Account: "bob"}, {Account: "charlie"},
+			{Account: "bob", SiteID: "site-a"}, {Account: "charlie", SiteID: "site-b"},
 		}, nil)
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"bob", "charlie"}).Return([]model.User{
 		{ID: "u2", Account: "bob", SiteID: "site-a", EngName: "Bob", ChineseName: "鮑"},
@@ -1163,9 +957,6 @@ func TestHandler_ProcessAddMembers_RestrictedPropagatesPointer(t *testing.T) {
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
-	// Local→global flip nudge: bob/charlie are the only (newly-added)
-	// subscribers, so no pre-existing member remains after the diff.
-	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return([]string{"bob", "charlie"}, nil)
 
 	const reqTS int64 = 1744300000000
 	req := model.AddMembersRequest{
@@ -1322,7 +1113,7 @@ func TestHandler_ProcessAddMembers_RoomEventCarriesEnrichedMembers(t *testing.T)
 
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Name: "deal team", Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"bob", "carol"}, "r1").
-		Return([]AddMemberCandidate{{Account: "bob"}, {Account: "carol"}}, nil)
+		Return([]AddMemberCandidate{{Account: "bob", SiteID: "site-a"}, {Account: "carol", SiteID: "site-a"}}, nil)
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"bob", "carol"}).Return([]model.User{
 		{ID: "u2", Account: "bob", SiteID: "site-a", EngName: "Bob", ChineseName: "鮑", SectName: "Cardiology", EmployeeID: "E-1"},
 		{ID: "u3", Account: "carol", SiteID: "site-a", EngName: "Carol", ChineseName: "卡", SectName: "Radiology", EmployeeID: "E-2"},
@@ -1392,7 +1183,7 @@ func TestHandler_ProcessAddMembers_WithOrgs_RoomEventMembersEnrichment(t *testin
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Name: "deal team", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
 	// bob is the direct add; carol joins via org expansion only (not in req.Users).
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), []string{"eng"}, []string{"bob"}, "r1").
-		Return([]AddMemberCandidate{{Account: "bob"}, {Account: "carol"}}, nil)
+		Return([]AddMemberCandidate{{Account: "bob", SiteID: "site-a"}, {Account: "carol", SiteID: "site-b"}}, nil)
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"bob", "carol"}).Return([]model.User{
 		{ID: "u2", Account: "bob", SiteID: "site-a", EngName: "Bob", ChineseName: "鮑", SectName: "Engineering", EmployeeID: "E-1"},
 		{ID: "u3", Account: "carol", SiteID: "site-b", EngName: "Carol", ChineseName: "卡", SectName: "Engineering", EmployeeID: "E-2"},
@@ -1419,9 +1210,6 @@ func TestHandler_ProcessAddMembers_WithOrgs_RoomEventMembersEnrichment(t *testin
 	}, nil)
 	store.EXPECT().ExistingOrgMembers(gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]struct{}{}, nil)
 	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
-	// Local→global flip nudge: bob/carol are the only (newly-added)
-	// subscribers, so no pre-existing member remains after the diff.
-	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return([]string{"bob", "carol"}, nil)
 
 	req := model.AddMembersRequest{
 		RoomID: "r1", RequesterAccount: "alice",
@@ -1663,7 +1451,7 @@ func TestHandler_ProcessAddMembers_MultipleSiteInbox(t *testing.T) {
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"alice", "bob", "charlie"}, "r1").
 		Return([]AddMemberCandidate{
-			{Account: "alice"}, {Account: "bob"}, {Account: "charlie"},
+			{Account: "alice", SiteID: "site-b"}, {Account: "bob", SiteID: "site-b"}, {Account: "charlie", SiteID: "site-c"},
 		}, nil)
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"alice", "bob", "charlie"}).Return([]model.User{
 		{ID: "u1", Account: "alice", SiteID: "site-b", EngName: "Alice", ChineseName: "愛"},
@@ -1677,9 +1465,6 @@ func TestHandler_ProcessAddMembers_MultipleSiteInbox(t *testing.T) {
 	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	store.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
-	// Local→global flip nudge: alice/bob/charlie are the only (newly-added)
-	// subscribers, so no pre-existing member remains after the diff.
-	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return([]string{"alice", "bob", "charlie"}, nil)
 
 	req := model.AddMembersRequest{
 		RoomID:           "r1",
@@ -2578,12 +2363,12 @@ func TestProcessAddMembers_InboxCarriesRoomName(t *testing.T) {
 	ctx := natsutil.WithRequestID(context.Background(), reqID)
 
 	// Cross-site member: bob lives on site-B. Room previously confirmed
-	// same-site (CrossSite: false), so this add flips it and fires the nudge.
+	// same-site (CrossSite: false), so this add flips it to global.
 	mockStore.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{
 		ID: "r1", Name: "deal team", Type: model.RoomTypeChannel, SiteID: "site-A", CrossSite: ptrBool(false),
 	}, nil)
 	mockStore.EXPECT().ListAddMemberCandidates(gomock.Any(), gomock.Any(), gomock.Any(), "r1").
-		Return([]AddMemberCandidate{{Account: "bob"}}, nil)
+		Return([]AddMemberCandidate{{Account: "bob", SiteID: "site-B"}}, nil)
 	mockStore.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"bob"}).Return([]model.User{
 		{ID: "u_bob", Account: "bob", SiteID: "site-B", EngName: "Bob", ChineseName: "鲍勃"},
 	}, nil)
@@ -2594,9 +2379,6 @@ func TestProcessAddMembers_InboxCarriesRoomName(t *testing.T) {
 	mockStore.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
 	mockStore.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	mockStore.EXPECT().SetRoomCrossSite(gomock.Any(), "r1").Return(nil)
-	// Local→global flip nudge: bob is the only (newly-added) subscriber, so no
-	// pre-existing member remains after the diff.
-	mockStore.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return([]string{"bob"}, nil)
 
 	body, err := json.Marshal(model.AddMembersRequest{
 		RoomID: "r1", Users: []string{"bob"},

--- a/room-worker/main.go
+++ b/room-worker/main.go
@@ -74,6 +74,8 @@ type config struct {
 	AdminAcctPrefix string `env:"ADMIN_ACCT_PREFIX" envDefault:"p_admin"`
 	// RoomSubjectMode: same-site room .event namespace — global (default) | dual | local. See pkg/subject.RoomRouteMode.
 	RoomSubjectMode string `env:"ROOM_SUBJECT_MODE" envDefault:"global"`
+	// RoomLocalityGrace: post-flip dual-publish window. Must match across all publisher services.
+	RoomLocalityGrace time.Duration `env:"ROOM_LOCALITY_GRACE" envDefault:"168h"`
 }
 
 func main() {
@@ -101,6 +103,7 @@ func main() {
 		slog.Error("invalid ROOM_SUBJECT_MODE", "error", err)
 		os.Exit(1)
 	}
+	subject.SetRoomLocalityGrace(cfg.RoomLocalityGrace)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Follow-up to #139 (already merged), addressing @mliu33's review comments on that PR plus a correctness fix to the transition window.

## Review comments addressed

**Remove `nudgeLocalToGlobalTransition`** (comment @ `room-worker/handler.go`)
The on-flip nudge did a full room-subscriber read plus a publish per member, triggering every member to refetch `subscription.list` — heavy for large rooms. Removed. Members are migrated by the grace window (below) + their normal reconnect/reconcile, not a proactive push.

**Remove the redundant second `SetRoomCrossSite`** (comment @ `room-worker/handler.go`)
`processAddMembers` marked the room cross-site twice. The early classification from the full candidate set already marks it (candidates carry `SiteID` in production) and is retry-safe, so the second mark was redundant. Deleted it and moved the L2 cache-bust into the early path. Also removed the now-unused `Room.RoutesGlobal` (only the nudge gate used it).

**`*roommetacache.Meta` pointer** (comment @ `broadcast-worker/handler.go`) — kept as-is, not a code change. The pointer exists to satisfy gocritic's `hugeParam` (the struct is 88 bytes); every caller passes `&meta` from a non-nil local returned by `GetRoomMeta` (which returns a value, never a nil pointer), so the nil-deref path the comment worried about cannot occur. Reverting to value trips the hot-path perf linter for no correctness gain.

## Grace window: configurable, default 1 week

The nudge removal exposed a real gap: the post-flip dual-publish window was a hard-coded **15 minutes**. That only bounds the local→global real-time delivery gap if every client re-subscribes within 15 min; a client connected longer without reconciling would miss real-time room broadcasts once the window closed (recoverable via history, but a real-time gap).

- Window is now `ROOM_LOCALITY_GRACE`, **default 1 week** (`subject.DefaultRoomLocalityGrace`) — long enough that essentially every client reconnects and re-subscribes within it, while still decaying to zero double-publishing once the local audience has drained.
- Wired as a process-wide startup tunable (`subject.SetRoomLocalityGrace`) in all three publisher services (`broadcast-worker`, `room-service`, `room-worker`); **all three must use the same value**.

## Tests / verification

- Updated add-member unit tests to populate candidate `SiteID` (matching production) and dropped the nudge-specific tests.
- Added `TestSetRoomLocalityGrace`; existing grace test now keys off `DefaultRoomLocalityGrace`.
- `make fmt` / `make lint` (0 issues) / `make test` (full suite, race) all pass.
- Design/plan docs updated to record the nudge drop and the configurable 1-week window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKLjVmfDJQKfYgmLLofk3v)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable room locality grace periods, defaulting to seven days.
  * Rooms can continue publishing to both local and global destinations during the transition window.
  * Reconnection and periodic subscription reconciliation now refresh room routing.

* **Bug Fixes**
  * Improved room metadata invalidation after cross-site classification changes.

* **Documentation**
  * Updated rollout guidance and transition coverage for the revised room-routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->