### PR TITLE
Implement concurrent bucket fetching for history pagination

### DIFF
--- a/history-service/internal/cassrepo/messages_by_room.go
+++ b/history-service/internal/cassrepo/messages_by_room.go
@@ -74,6 +74,22 @@ func (r *Repository) scanMessagesUpTo(ctx context.Context) func(iter *gocql.Iter
 	}
 }
 
+// fillMessagePage runs a bucketed message-table walk with the repository's
+// shared walk parameters (bucket sizer, max-walk depth, fan-out, row scan) bound
+// in, so each reader supplies only what varies: direction, bounds, and the
+// per-bucket query builder. A new walk-level parameter is then a one-line change
+// here rather than an edit at every reader.
+func (r *Repository) fillMessagePage(ctx context.Context, direction walkDirection, startBucket, floorBucket int64, pageReq PageRequest, initialPageState []byte, queryFn bucketQueryFn) (Page[models.Message], error) {
+	res, err := fillPage[models.Message](
+		ctx, r.bucket, direction, startBucket, floorBucket, r.maxBuckets,
+		pageReq.PageSize, initialPageState, r.walkFanout, queryFn, r.scanMessagesUpTo(ctx),
+	)
+	if err != nil {
+		return Page[models.Message]{}, err
+	}
+	return res.toPage(), nil
+}
+
 func (r *Repository) GetMessagesBefore(ctx context.Context, roomID string, before time.Time, floor time.Time, pageReq PageRequest) (Page[models.Message], error) {
 	floorBucket := r.bucket.Of(floor)
 	startBucket, initialPageState, err := startBucketFromCursor(pageReq, walkDesc, r.bucket.Of(before), floorBucket)
@@ -94,14 +110,11 @@ func (r *Repository) GetMessagesBefore(ctx context.Context, roomID string, befor
 		)
 	}
 
-	res, err := fillPage[models.Message](
-		ctx, r.bucket, walkDesc, startBucket, floorBucket, r.maxBuckets,
-		pageReq.PageSize, initialPageState, queryFn, r.scanMessagesUpTo(ctx),
-	)
+	page, err := r.fillMessagePage(ctx, walkDesc, startBucket, floorBucket, pageReq, initialPageState, queryFn)
 	if err != nil {
 		return Page[models.Message]{}, fmt.Errorf("get messages before: %w", err)
 	}
-	return res.toPage(), nil
+	return page, nil
 }
 
 func (r *Repository) GetMessagesBetweenDesc(ctx context.Context, roomID string, since, before time.Time, pageReq PageRequest) (Page[models.Message], error) {
@@ -141,14 +154,11 @@ func (r *Repository) GetMessagesBetweenDesc(ctx context.Context, roomID string, 
 		}
 	}
 
-	res, err := fillPage[models.Message](
-		ctx, r.bucket, walkDesc, startBucket, floorBucket, r.maxBuckets,
-		pageReq.PageSize, initialPageState, queryFn, r.scanMessagesUpTo(ctx),
-	)
+	page, err := r.fillMessagePage(ctx, walkDesc, startBucket, floorBucket, pageReq, initialPageState, queryFn)
 	if err != nil {
 		return Page[models.Message]{}, fmt.Errorf("get messages between desc: %w", err)
 	}
-	return res.toPage(), nil
+	return page, nil
 }
 
 func (r *Repository) GetMessagesAfter(ctx context.Context, roomID string, after time.Time, ceiling time.Time, pageReq PageRequest) (Page[models.Message], error) {
@@ -171,14 +181,11 @@ func (r *Repository) GetMessagesAfter(ctx context.Context, roomID string, after 
 		)
 	}
 
-	res, err := fillPage[models.Message](
-		ctx, r.bucket, walkAsc, startBucket, ceilingBucket, r.maxBuckets,
-		pageReq.PageSize, initialPageState, queryFn, r.scanMessagesUpTo(ctx),
-	)
+	page, err := r.fillMessagePage(ctx, walkAsc, startBucket, ceilingBucket, pageReq, initialPageState, queryFn)
 	if err != nil {
 		return Page[models.Message]{}, fmt.Errorf("get messages after: %w", err)
 	}
-	return res.toPage(), nil
+	return page, nil
 }
 
 func (r *Repository) GetAllMessagesAsc(ctx context.Context, roomID string, floor time.Time, ceiling time.Time, pageReq PageRequest) (Page[models.Message], error) {
@@ -195,12 +202,9 @@ func (r *Repository) GetAllMessagesAsc(ctx context.Context, roomID string, floor
 		)
 	}
 
-	res, err := fillPage[models.Message](
-		ctx, r.bucket, walkAsc, startBucket, ceilingBucket, r.maxBuckets,
-		pageReq.PageSize, initialPageState, queryFn, r.scanMessagesUpTo(ctx),
-	)
+	page, err := r.fillMessagePage(ctx, walkAsc, startBucket, ceilingBucket, pageReq, initialPageState, queryFn)
 	if err != nil {
 		return Page[models.Message]{}, fmt.Errorf("get all messages asc: %w", err)
 	}
-	return res.toPage(), nil
+	return page, nil
 }

--- a/history-service/internal/cassrepo/repository.go
+++ b/history-service/internal/cassrepo/repository.go
@@ -7,6 +7,15 @@ import (
 	"github.com/hmchangw/chat/pkg/msgbucket"
 )
 
+// defaultWalkFanout caps how many buckets a bucketed-table read fetches
+// concurrently once the walk fans out past its start bucket. It trades a bounded
+// amount of speculative over-read for turning a long serial run of sparse/empty
+// buckets into a few concurrent round-trips. It is kept at or below the per-host
+// connection count in pkg/cassutil (default 8, CASSANDRA_NUMCONNS) so a single
+// walk stays within one host's pool — if that connection count is lowered below
+// this, revisit this value too.
+const defaultWalkFanout = 8
+
 // Repository wraps a Cassandra session with the bucket sizer + read-walk
 // configuration shared by all queries against bucketed message tables, plus
 // an optional at-rest Cipher for encrypted message bodies.
@@ -14,6 +23,7 @@ type Repository struct {
 	session    *gocql.Session
 	bucket     msgbucket.Sizer
 	maxBuckets int
+	walkFanout int
 	cipher     atrest.Cipher // nil when ATREST_ENABLED=false
 }
 
@@ -27,6 +37,7 @@ func NewRepository(session *gocql.Session, bucket msgbucket.Sizer, maxBuckets in
 		session:    session,
 		bucket:     bucket,
 		maxBuckets: maxBuckets,
+		walkFanout: defaultWalkFanout,
 		cipher:     cipher,
 	}
 }

--- a/history-service/internal/cassrepo/walker.go
+++ b/history-service/internal/cassrepo/walker.go
@@ -174,9 +174,12 @@ func fillPage[T any](
 //   - Wave 1 probes only the start bucket, so a dense start region fills the
 //     page in one query with no speculative reads (the same cost the old serial
 //     walk paid for busy rooms).
-//   - Once the start bucket underfills, later waves fetch up to fanout buckets at
-//     once, collapsing a long run of sparse/empty buckets from many serial
-//     round-trips into a few concurrent ones.
+//   - Once the start bucket underfills, later waves fetch several buckets at once,
+//     collapsing a long run of sparse/empty buckets from many serial round-trips
+//     into a few concurrent ones. Each wave's width adapts to the rows-per-bucket
+//     density seen so far (see adaptiveWaveWidth): sparse/empty runs widen toward
+//     fanout to skip fast, dense runs narrow toward 1 to avoid over-reading fat
+//     buckets for a small shortfall.
 //
 // Rows are always assembled in strict bucket order and the returned cursor is
 // identical to what a serial walk would produce — concurrency overlaps the I/O
@@ -231,7 +234,7 @@ func (w *bucketWalk[T]) run(ctx context.Context) (pageResult[T], error) {
 	out := make([]T, 0, w.pageSize)
 	curBucket := w.startBucket
 	walked := 0
-	waveWidth := 1 // wave 1 probes only the start bucket; widen after it underfills
+	waveWidth := 1 // wave 1 probes only the start bucket; widen adaptively after it underfills
 
 	for {
 		if w.crossedFloor(curBucket) {
@@ -263,10 +266,37 @@ func (w *bucketWalk[T]) run(ctx context.Context) (pageResult[T], error) {
 			// Contract: fewer than pageSize rows ⇒ bucket drained, safe to advance.
 		}
 
-		// Whole wave consumed, page still not full: widen and continue.
+		// Whole wave consumed, page still not full: size the next wave to the
+		// density seen so far (len(out) rows over walked buckets), then continue.
 		curBucket = w.advance(buckets[len(buckets)-1])
-		waveWidth = w.fanout
+		waveWidth = adaptiveWaveWidth(len(out), walked, w.pageSize-len(out), w.fanout)
 	}
+}
+
+// adaptiveWaveWidth sizes the next fan-out wave to how many buckets the walk
+// still expects to need: the rows still needed divided by the rows-per-bucket
+// density observed so far (empties count as zero rows), clamped to [1, fanout].
+//
+// This makes the walk self-tune to the data it's crossing: an empty/sparse run
+// (density → 0) widens toward fanout to skip fast, where over-read is cheap;
+// a dense region (buckets near a full page) narrows toward 1, so a small
+// shortfall doesn't speculatively fetch a whole fanout of fat buckets to use
+// one. Width only ever affects performance — the assembled page and cursor are
+// identical for any width (see the fan-out parity test).
+func adaptiveWaveWidth(rowsSeen, bucketsSeen, needed, fanout int) int {
+	density := rowsSeen
+	if density < 1 {
+		density = 1 // all-empty so far: treat as <1 row/bucket to widen fully
+	}
+	// ceil(needed * bucketsSeen / rowsSeen) = ceil(needed / avg-rows-per-bucket).
+	width := (needed*bucketsSeen + density - 1) / density
+	if width < 1 {
+		width = 1 // nothing observed yet (bucketsSeen==0) or none needed: at least one bucket
+	}
+	if width > fanout {
+		width = fanout
+	}
+	return width
 }
 
 // planWave lists the buckets to fetch next, starting at from and advancing,
@@ -294,7 +324,7 @@ func (w *bucketWalk[T]) fetchWave(ctx context.Context, buckets []int64) ([]bucke
 		pages[0] = p
 		return pages, nil
 	}
-	// planWave already bounds len(buckets) to the wave width (<= fanout), so the
+	// planWave/adaptiveWaveWidth already bound len(buckets) <= fanout, so the
 	// group needs no SetLimit.
 	g, gctx := errgroup.WithContext(ctx)
 	for i, bk := range buckets {

--- a/history-service/internal/cassrepo/walker.go
+++ b/history-service/internal/cassrepo/walker.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/gocql/gocql"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/hmchangw/chat/pkg/msgbucket"
 )
@@ -85,20 +86,68 @@ func (r pageResult[T]) toPage() Page[T] {
 // letting callers apply a per-call predicate (e.g. created_at < before) only where needed.
 type bucketQueryFn func(bucket int64, firstBucket bool) *gocql.Query
 
-// fillPage walks buckets in the given direction starting at startBucket,
-// issuing one query per bucket and accumulating rows into out until pageSize
-// is reached or maxBuckets is exhausted. The first bucket may resume from a
-// caller-supplied gocql page state; later buckets always start fresh.
+// bucketPage is one bucket's fetched rows plus the gocql page state needed to
+// resume mid-bucket. resumeState is non-empty only when the bucket holds more
+// rows than were returned, so the walk can distinguish "bucket drained" from
+// "page capped by limit" unambiguously.
+type bucketPage[T any] struct {
+	rows        []T
+	resumeState []byte
+}
+
+// bucketFetcher fetches up to limit fully-materialized rows from a single
+// bucket. firstBucket selects the caller's first-bucket predicate; pageState
+// resumes a partially consumed bucket. It MUST honor limit exactly — returning
+// min(limit, rowsInBucket) rows and draining short driver pages internally — so
+// that a non-empty resumeState unambiguously means "more rows remain here".
+type bucketFetcher[T any] func(ctx context.Context, bucket int64, firstBucket bool, pageState []byte, limit int) (bucketPage[T], error)
+
+// gocqlBucketFetcher adapts a bucketQueryFn + scan into a bucketFetcher backed
+// by the live session. It drains short driver pages until limit rows are
+// collected or the bucket is exhausted, preserving the original within-bucket
+// drain semantics.
 //
-// scan must consume up to `remaining` rows from iter and return them; it is
-// responsible for stopping when full. A non-nil error return aborts the walk
-// immediately — the bucket advance and any further queries are skipped, and
-// the accumulated rows are discarded. This is how scan signals a fatal per-row
-// error (e.g. a decrypt failure) up to the caller.
+// scan must consume up to `remaining` rows from iter and return them; a non-nil
+// error aborts the fetch (and, upstream, the whole walk). This is how scan
+// signals a fatal per-row error (e.g. a decrypt failure).
+func gocqlBucketFetcher[T any](
+	queryFn bucketQueryFn,
+	scan func(iter *gocql.Iter, remaining int) ([]T, error),
+) bucketFetcher[T] {
+	return func(ctx context.Context, bucket int64, firstBucket bool, pageState []byte, limit int) (bucketPage[T], error) {
+		rows := make([]T, 0, limit)
+		state := pageState
+		for len(rows) < limit {
+			q := queryFn(bucket, firstBucket).WithContext(ctx).PageSize(limit - len(rows))
+			if state != nil {
+				q = q.PageState(state)
+			}
+			iter := q.Iter()
+			got, scanErr := scan(iter, limit-len(rows))
+			rows = append(rows, got...)
+			state = iter.PageState()
+			if closeErr := iter.Close(); closeErr != nil {
+				return bucketPage[T]{}, fmt.Errorf("scan bucket %d: %w", bucket, closeErr)
+			}
+			if scanErr != nil {
+				return bucketPage[T]{}, fmt.Errorf("scan bucket %d: %w", bucket, scanErr)
+			}
+			if len(state) == 0 {
+				break // bucket fully drained
+			}
+		}
+		return bucketPage[T]{rows: rows, resumeState: state}, nil
+	}
+}
+
+// fillPage walks buckets in the given direction starting at startBucket until
+// pageSize rows are collected or maxBuckets is exhausted. It builds a live
+// gocql fetcher and delegates the traversal to walkBuckets.
 //
 // floorBucket bounds the walk: DESC stops when bucket < floorBucket; ASC stops
 // when bucket > floorBucket. To disable floor-based termination, callers pass
-// math.MinInt64 (DESC) or math.MaxInt64 (ASC).
+// math.MinInt64 (DESC) or math.MaxInt64 (ASC). fanout caps how many buckets are
+// fetched concurrently once the walk fans out.
 func fillPage[T any](
 	ctx context.Context,
 	sizer msgbucket.Sizer,
@@ -108,88 +157,225 @@ func fillPage[T any](
 	maxBuckets int,
 	pageSize int,
 	initialPageState []byte,
+	fanout int,
 	queryFn bucketQueryFn,
 	scan func(iter *gocql.Iter, remaining int) ([]T, error),
 ) (pageResult[T], error) {
-	out := make([]T, 0, pageSize)
-	bucket := startBucket
-	pageState := initialPageState
+	return walkBuckets(
+		ctx, sizer, direction, startBucket, floorBucket, maxBuckets, pageSize,
+		initialPageState, fanout, gocqlBucketFetcher(queryFn, scan),
+	)
+}
+
+// bucketWalk holds the immutable parameters of one paginated walk over a
+// bucketed table. Its run method fills a single page by fetching buckets
+// concurrently in fan-out waves:
+//
+//   - Wave 1 probes only the start bucket, so a dense start region fills the
+//     page in one query with no speculative reads (the same cost the old serial
+//     walk paid for busy rooms).
+//   - Once the start bucket underfills, later waves fetch up to fanout buckets at
+//     once, collapsing a long run of sparse/empty buckets from many serial
+//     round-trips into a few concurrent ones.
+//
+// Rows are always assembled in strict bucket order and the returned cursor is
+// identical to what a serial walk would produce — concurrency overlaps the I/O
+// only, never the ordering or pagination.
+type bucketWalk[T any] struct {
+	sizer        msgbucket.Sizer
+	direction    walkDirection
+	startBucket  int64
+	floorBucket  int64
+	maxBuckets   int
+	pageSize     int
+	initialState []byte
+	fanout       int
+	fetch        bucketFetcher[T]
+}
+
+// walkBuckets fills a page starting at startBucket. See bucketWalk for the
+// traversal strategy. A fetch error aborts the walk and is returned to the
+// caller (accumulated rows are discarded).
+func walkBuckets[T any](
+	ctx context.Context,
+	sizer msgbucket.Sizer,
+	direction walkDirection,
+	startBucket int64,
+	floorBucket int64,
+	maxBuckets int,
+	pageSize int,
+	initialPageState []byte,
+	fanout int,
+	fetch bucketFetcher[T],
+) (pageResult[T], error) {
+	if fanout < 1 {
+		fanout = 1
+	}
+	w := &bucketWalk[T]{
+		sizer:        sizer,
+		direction:    direction,
+		startBucket:  startBucket,
+		floorBucket:  floorBucket,
+		maxBuckets:   maxBuckets,
+		pageSize:     pageSize,
+		initialState: initialPageState,
+		fanout:       fanout,
+		fetch:        fetch,
+	}
+	return w.run(ctx)
+}
+
+// run drives the wave loop: check for termination, plan a wave of buckets, fetch
+// them concurrently, then assemble their rows in order until the page fills.
+func (w *bucketWalk[T]) run(ctx context.Context) (pageResult[T], error) {
+	out := make([]T, 0, w.pageSize)
+	curBucket := w.startBucket
 	walked := 0
+	waveWidth := 1 // wave 1 probes only the start bucket; widen after it underfills
 
-	advance := func() {
-		if direction == walkDesc {
-			bucket = sizer.Prev(bucket)
-		} else {
-			bucket = sizer.Next(bucket)
+	for {
+		if w.crossedFloor(curBucket) {
+			return terminalPage(out), nil
 		}
-	}
-
-	floorCrossed := func(b int64) bool {
-		if direction == walkDesc {
-			return b < floorBucket
-		}
-		return b > floorBucket
-	}
-
-	for len(out) < pageSize && walked < maxBuckets {
-		if floorCrossed(bucket) {
-			return pageResult[T]{Rows: out, NextCursor: "", HasNext: false}, nil
+		if walked >= w.maxBuckets {
+			return resumeAtBucket(out, curBucket, nil)
 		}
 
-		q := queryFn(bucket, walked == 0).WithContext(ctx)
-		q = q.PageSize(pageSize - len(out))
-		if pageState != nil {
-			q = q.PageState(pageState)
+		buckets := w.planWave(curBucket, waveWidth, walked)
+		if len(buckets) == 0 {
+			// The floor or the maxBuckets budget left no room to fetch.
+			return resumeAtBucket(out, curBucket, nil)
+		}
+		pages, err := w.fetchWave(ctx, buckets)
+		if err != nil {
+			return pageResult[T]{}, err
 		}
 
-		iter := q.Iter()
-		rows, scanErr := scan(iter, pageSize-len(out))
-		out = append(out, rows...)
-		nextPageState := iter.PageState()
-		if err := iter.Close(); err != nil {
-			return pageResult[T]{}, fmt.Errorf("scan bucket %d: %w", bucket, err)
-		}
-		// A scan error (e.g. a per-row decrypt failure) is fatal: discard the
-		// accumulated rows and abort the walk so a later bucket can't overwrite
-		// the error or serve a partial page.
-		if scanErr != nil {
-			return pageResult[T]{}, fmt.Errorf("scan bucket %d: %w", bucket, scanErr)
-		}
-
-		if len(nextPageState) > 0 && len(out) < pageSize {
-			// More rows in this bucket but page not yet full — continue draining.
-			pageState = nextPageState
-			continue
-		}
-		if len(nextPageState) > 0 && len(out) >= pageSize {
-			// Page filled mid-bucket — cursor resumes here on next call.
-			cursor, encErr := encodeBucketCursor(bucket, nextPageState)
-			if encErr != nil {
-				return pageResult[T]{}, fmt.Errorf("encode resume cursor at bucket %d: %w", bucket, encErr)
+		// Assemble in strict bucket order, stopping as soon as the page fills.
+		for i, bk := range buckets {
+			walked++
+			page := pages[i]
+			taken := min(w.pageSize-len(out), len(page.rows))
+			out = append(out, page.rows[:taken]...)
+			if len(out) == w.pageSize {
+				return w.resumeAfterFill(ctx, out, bk, page, taken)
 			}
-			return pageResult[T]{
-				Rows:       out,
-				NextCursor: cursor,
-				HasNext:    true,
-			}, nil
+			// Contract: fewer than pageSize rows ⇒ bucket drained, safe to advance.
 		}
 
-		pageState = nil
-		advance()
-		walked++
+		// Whole wave consumed, page still not full: widen and continue.
+		curBucket = w.advance(buckets[len(buckets)-1])
+		waveWidth = w.fanout
 	}
+}
 
-	if floorCrossed(bucket) {
-		return pageResult[T]{Rows: out, NextCursor: "", HasNext: false}, nil
+// planWave lists the buckets to fetch next, starting at from and advancing,
+// bounded by width, the floor, and the remaining maxBuckets budget (walked so far).
+func (w *bucketWalk[T]) planWave(from int64, width, walked int) []int64 {
+	buckets := make([]int64, 0, width)
+	for b := from; len(buckets) < width && !w.crossedFloor(b) && walked+len(buckets) < w.maxBuckets; b = w.advance(b) {
+		buckets = append(buckets, b)
 	}
-	// maxBuckets or pageSize reached at a bucket boundary — cursor points to the next bucket.
-	cursor, encErr := encodeBucketCursor(bucket, nil)
-	if encErr != nil {
-		return pageResult[T]{}, fmt.Errorf("encode resume cursor at bucket %d: %w", bucket, encErr)
+	return buckets
+}
+
+// fetchWave fetches every bucket in the wave concurrently (bounded by fanout) and
+// returns their pages in bucket order. Any fetch error aborts the wave.
+func (w *bucketWalk[T]) fetchWave(ctx context.Context, buckets []int64) ([]bucketPage[T], error) {
+	pages := make([]bucketPage[T], len(buckets))
+	// Fast path for a single-bucket wave (wave 1, and every dense/narrow wave):
+	// there is no concurrency to orchestrate, so fetch inline and skip the
+	// errgroup/goroutine allocation and join. This is the dominant traffic.
+	if len(buckets) == 1 {
+		p, err := w.fetch(ctx, buckets[0], buckets[0] == w.startBucket, w.baseState(buckets[0]), w.pageSize)
+		if err != nil {
+			return nil, err
+		}
+		pages[0] = p
+		return pages, nil
 	}
-	return pageResult[T]{
-		Rows:       out,
-		NextCursor: cursor,
-		HasNext:    true,
-	}, nil
+	// planWave already bounds len(buckets) to the wave width (<= fanout), so the
+	// group needs no SetLimit.
+	g, gctx := errgroup.WithContext(ctx)
+	for i, bk := range buckets {
+		g.Go(func() error {
+			p, err := w.fetch(gctx, bk, bk == w.startBucket, w.baseState(bk), w.pageSize)
+			if err != nil {
+				return err
+			}
+			pages[i] = p
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return pages, nil
+}
+
+// resumeAfterFill builds the cursor once the page has just filled at bucket,
+// having consumed taken of that bucket's prefetched page.rows. Three cases:
+//
+//   - taken < len(page.rows): the page filled before all prefetched rows were
+//     consumed, so re-fetch exactly taken rows to get a page state aligned to the
+//     consumed count (rather than the speculatively-prefetched count).
+//   - the bucket holds more rows than were prefetched: resume within the bucket.
+//   - the bucket drained exactly at the page boundary: resume at the next bucket,
+//     or terminate if that crosses the floor.
+func (w *bucketWalk[T]) resumeAfterFill(ctx context.Context, rows []T, bucket int64, page bucketPage[T], taken int) (pageResult[T], error) {
+	if taken < len(page.rows) {
+		aligned, err := w.fetch(ctx, bucket, bucket == w.startBucket, w.baseState(bucket), taken)
+		if err != nil {
+			return pageResult[T]{}, err
+		}
+		return resumeAtBucket(rows, bucket, aligned.resumeState)
+	}
+	if len(page.resumeState) > 0 {
+		return resumeAtBucket(rows, bucket, page.resumeState)
+	}
+	next := w.advance(bucket)
+	if w.crossedFloor(next) {
+		return terminalPage(rows), nil
+	}
+	return resumeAtBucket(rows, next, nil)
+}
+
+// advance steps one bucket in the walk direction: older for DESC, newer for ASC.
+func (w *bucketWalk[T]) advance(b int64) int64 {
+	if w.direction == walkDesc {
+		return w.sizer.Prev(b)
+	}
+	return w.sizer.Next(b)
+}
+
+// crossedFloor reports whether b has passed the walk's boundary: below floorBucket
+// for DESC, above it for ASC.
+func (w *bucketWalk[T]) crossedFloor(b int64) bool {
+	if w.direction == walkDesc {
+		return b < w.floorBucket
+	}
+	return b > w.floorBucket
+}
+
+// baseState is the page state a bucket is fetched with: only the start bucket
+// carries the caller's initial (resume) state; every other bucket starts fresh.
+func (w *bucketWalk[T]) baseState(bucket int64) []byte {
+	if bucket == w.startBucket {
+		return w.initialState
+	}
+	return nil
+}
+
+// resumeAtBucket returns a non-terminal page whose cursor resumes at bucket/state.
+func resumeAtBucket[T any](rows []T, bucket int64, state []byte) (pageResult[T], error) {
+	cursor, err := encodeBucketCursor(bucket, state)
+	if err != nil {
+		return pageResult[T]{}, fmt.Errorf("encode resume cursor at bucket %d: %w", bucket, err)
+	}
+	return pageResult[T]{Rows: rows, NextCursor: cursor, HasNext: true}, nil
+}
+
+// terminalPage returns a final page: no cursor, no more pages.
+func terminalPage[T any](rows []T) pageResult[T] {
+	return pageResult[T]{Rows: rows, NextCursor: "", HasNext: false}
 }

--- a/history-service/internal/cassrepo/walker_test.go
+++ b/history-service/internal/cassrepo/walker_test.go
@@ -431,3 +431,50 @@ func TestWalkBuckets_ActuallyFansOutConcurrently(t *testing.T) {
 	assert.GreaterOrEqual(t, store.maxInFlight, 2, "expected concurrent bucket fetches")
 	assert.Len(t, res.Rows, 8)
 }
+
+// TestAdaptiveWaveWidth pins the demand-driven width policy: width ≈ how many
+// buckets we still expect to need, derived from rows-per-bucket seen so far,
+// clamped to [1, fanout]. Low density (empties/sparse) widens; high density
+// (near-full buckets) narrows.
+func TestAdaptiveWaveWidth(t *testing.T) {
+	tests := []struct {
+		name                                  string
+		rowsSeen, bucketsSeen, needed, fanout int
+		want                                  int
+	}{
+		{"all empty so far widens to fanout", 0, 3, 20, 8, 8},
+		{"dense bucket, tiny shortfall narrows to 1", 19, 1, 1, 8, 1},
+		{"one row per bucket needs many, caps at fanout", 3, 3, 17, 8, 8},
+		{"one row per bucket, small need", 2, 2, 3, 8, 3},
+		{"exact division", 4, 2, 4, 8, 2},
+		{"caps at fanout", 1, 10, 100, 4, 4},
+		{"never below 1", 100, 1, 1, 8, 1},
+		{"no observations yet defaults to 1", 0, 0, 20, 8, 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, adaptiveWaveWidth(tc.rowsSeen, tc.bucketsSeen, tc.needed, tc.fanout))
+		})
+	}
+}
+
+// TestWalkBuckets_AdaptiveWidth_DenseUnderfillDoesNotOverfetch is the payoff of
+// adaptive widening: when the start bucket nearly fills the page, the next wave
+// must stay narrow instead of speculatively fetching a full fanout of fat data
+// buckets to satisfy a tiny shortfall. A fixed fanout=8 would touch ~9 buckets;
+// adaptive touches 2.
+func TestWalkBuckets_AdaptiveWidth_DenseUnderfillDoesNotOverfetch(t *testing.T) {
+	s := testSizer()
+	start := testStartBucket()
+	b1 := s.Prev(start)
+	store := &fakeCassandra{buckets: map[int64][]int{
+		start: seq(1, 19), // 19 of the 20 needed
+		b1:    {20, 21, 22},
+	}}
+
+	res := runDesc(t, store, start, noFloorDesc, 365, 20, 8, nil)
+
+	assert.Equal(t, seq(1, 20), res.Rows)
+	assert.LessOrEqual(t, len(store.fetchedBuckets()), 2,
+		"dense underfill must stay narrow, not fan out to fanout width; fetched=%v", store.fetchedBuckets())
+}

--- a/history-service/internal/cassrepo/walker_test.go
+++ b/history-service/internal/cassrepo/walker_test.go
@@ -1,10 +1,18 @@
 package cassrepo
 
 import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"math"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/msgbucket"
 )
 
 func TestBucketCursor_RoundTrip(t *testing.T) {
@@ -56,4 +64,370 @@ func TestBucketCursor_RejectsTruncatedFraming(t *testing.T) {
 	require.NoError(t, err)
 	_, _, err = decodeBucketCursor(encoded[:6])
 	require.Error(t, err)
+}
+
+// The tests below exercise walkBuckets — the direction-agnostic concurrent
+// bucket walk — through a fake bucketFetcher that honors the fetcher contract
+// (returns min(limit, rowsInBucket) rows; resumeState non-empty iff more rows
+// remain). The gocql-backed fetcher's short-page drain loop is covered by the
+// messages_by_room integration tests against a real cluster.
+
+func testSizer() msgbucket.Sizer { return msgbucket.New(24 * time.Hour) }
+
+// testStartBucket is an arbitrary but stable bucket to anchor a walk on.
+func testStartBucket() int64 { return testSizer().Of(time.Unix(1_700_000_000, 0).UTC()) }
+
+func encodeTestOffset(n int) []byte {
+	b := make([]byte, 4)
+	// #nosec G115 -- test offsets are small non-negative ints
+	binary.BigEndian.PutUint32(b, uint32(n))
+	return b
+}
+
+func decodeTestOffset(b []byte) int {
+	if len(b) == 0 {
+		return 0
+	}
+	return int(binary.BigEndian.Uint32(b))
+}
+
+func seq(from, to int) []int {
+	out := make([]int, 0, to-from+1)
+	for i := from; i <= to; i++ {
+		out = append(out, i)
+	}
+	return out
+}
+
+type fetchCall struct {
+	bucket    int64
+	first     bool
+	pageState []byte
+}
+
+// fakeCassandra is an in-memory bucket store implementing the fetcher contract.
+type fakeCassandra struct {
+	mu      sync.Mutex
+	buckets map[int64][]int
+	calls   []fetchCall
+
+	failOn *int64 // bucket to fail on, nil for never
+
+	// concurrency instrumentation / barrier
+	inFlight    int
+	maxInFlight int
+	barrierAt   int           // once this many fetches are concurrently in-flight, release the gate
+	gate        chan struct{} // closed when barrierAt reached; nil disables the barrier
+}
+
+func (f *fakeCassandra) fetch(ctx context.Context, bucket int64, first bool, pageState []byte, limit int) (bucketPage[int], error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, fetchCall{bucket: bucket, first: first, pageState: append([]byte(nil), pageState...)})
+	f.inFlight++
+	if f.inFlight > f.maxInFlight {
+		f.maxInFlight = f.inFlight
+	}
+	// Only fan-out (non-first) fetches participate in the barrier; the lone
+	// wave-1 start-bucket fetch (first=true) must never block on it.
+	participate := f.gate != nil && !first
+	reachedBarrier := participate && f.inFlight >= f.barrierAt
+	gate := f.gate
+	fail := f.failOn != nil && *f.failOn == bucket
+	f.mu.Unlock()
+
+	if participate {
+		if reachedBarrier {
+			// Release everyone waiting once enough goroutines are concurrently here.
+			select {
+			case <-gate:
+			default:
+				close(gate)
+			}
+		}
+		select {
+		case <-gate:
+		case <-ctx.Done():
+		}
+	}
+
+	defer func() {
+		f.mu.Lock()
+		f.inFlight--
+		f.mu.Unlock()
+	}()
+
+	if fail {
+		return bucketPage[int]{}, errors.New("boom")
+	}
+
+	rows := f.buckets[bucket]
+	offset := decodeTestOffset(pageState)
+	if offset > len(rows) {
+		offset = len(rows)
+	}
+	avail := rows[offset:]
+	take := limit
+	if take > len(avail) {
+		take = len(avail)
+	}
+	got := append([]int(nil), avail[:take]...)
+	var resume []byte
+	if offset+take < len(rows) {
+		resume = encodeTestOffset(offset + take)
+	}
+	return bucketPage[int]{rows: got, resumeState: resume}, nil
+}
+
+// fetchedBuckets returns how many times each bucket was fetched.
+func (f *fakeCassandra) fetchedBuckets() map[int64]int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := map[int64]int{}
+	for _, c := range f.calls {
+		out[c.bucket]++
+	}
+	return out
+}
+
+const noFloorDesc = math.MinInt64
+
+func runDesc(t *testing.T, store *fakeCassandra, start, floor int64, maxBuckets, pageSize, fanout int, initial []byte) pageResult[int] {
+	t.Helper()
+	res, err := walkBuckets[int](context.Background(), testSizer(), walkDesc, start, floor, maxBuckets, pageSize, initial, fanout, store.fetch)
+	require.NoError(t, err)
+	return res
+}
+
+func TestWalkBuckets_SingleDenseBucketFillsPage_NoFanout(t *testing.T) {
+	start := testStartBucket()
+	store := &fakeCassandra{buckets: map[int64][]int{start: seq(1, 30)}}
+
+	res := runDesc(t, store, start, noFloorDesc, 365, 20, 8, nil)
+
+	assert.Equal(t, seq(1, 20), res.Rows)
+	assert.True(t, res.HasNext)
+	b, ps, err := decodeBucketCursor(res.NextCursor)
+	require.NoError(t, err)
+	assert.Equal(t, start, b, "resume stays in the same bucket")
+	assert.Equal(t, 20, decodeTestOffset(ps))
+
+	// A dense start region must NOT trigger speculative fan-out.
+	assert.Equal(t, map[int64]int{start: 1}, store.fetchedBuckets())
+	assert.Equal(t, 1, store.maxInFlight)
+}
+
+func TestWalkBuckets_SingleBucketExactDrain_CursorAtNextBucket(t *testing.T) {
+	s := testSizer()
+	start := testStartBucket()
+	store := &fakeCassandra{buckets: map[int64][]int{start: seq(1, 20)}}
+
+	res := runDesc(t, store, start, noFloorDesc, 365, 20, 8, nil)
+
+	assert.Equal(t, seq(1, 20), res.Rows)
+	assert.True(t, res.HasNext)
+	b, ps, err := decodeBucketCursor(res.NextCursor)
+	require.NoError(t, err)
+	assert.Equal(t, s.Prev(start), b, "fully drained bucket resumes at the next bucket")
+	assert.Empty(t, ps)
+}
+
+func TestWalkBuckets_SparseFillAcrossBuckets_Ordered(t *testing.T) {
+	s := testSizer()
+	start := testStartBucket()
+	b1, b2 := s.Prev(start), s.Prev(s.Prev(start))
+	b3, b4 := s.Prev(b2), s.Prev(s.Prev(b2))
+	store := &fakeCassandra{buckets: map[int64][]int{
+		start: {1}, b1: {2}, b2: {3}, b3: {4}, b4: {5},
+	}}
+
+	res := runDesc(t, store, start, noFloorDesc, 365, 5, 8, nil)
+
+	assert.Equal(t, []int{1, 2, 3, 4, 5}, res.Rows, "rows must be in descending bucket order")
+	assert.True(t, res.HasNext)
+	b, ps, err := decodeBucketCursor(res.NextCursor)
+	require.NoError(t, err)
+	assert.Equal(t, s.Prev(b4), b)
+	assert.Empty(t, ps)
+
+	// No bucket other than the start bucket may receive a page state or the
+	// firstBucket flag on a fresh walk.
+	for _, c := range store.calls {
+		if c.bucket != start {
+			assert.Empty(t, c.pageState, "non-start bucket %d unexpectedly got a page state", c.bucket)
+			assert.False(t, c.first, "non-start bucket %d flagged firstBucket", c.bucket)
+		}
+	}
+}
+
+func TestWalkBuckets_MidBucketBoundary_RequeryAlignsCursor(t *testing.T) {
+	s := testSizer()
+	start := testStartBucket()
+	prev := s.Prev(start)
+	store := &fakeCassandra{buckets: map[int64][]int{
+		start: {10, 11, 12},
+		prev:  {20, 21, 22, 23, 24, 25, 26, 27, 28, 29},
+	}}
+
+	res := runDesc(t, store, start, noFloorDesc, 365, 5, 8, nil)
+
+	assert.Equal(t, []int{10, 11, 12, 20, 21}, res.Rows)
+	assert.True(t, res.HasNext)
+	b, ps, err := decodeBucketCursor(res.NextCursor)
+	require.NoError(t, err)
+	assert.Equal(t, prev, b, "page filled mid-bucket resumes in that bucket")
+	assert.Equal(t, 2, decodeTestOffset(ps), "cursor must align to the consumed rows, not the prefetched rows")
+
+	// The boundary bucket is fetched twice: once speculatively (limit=pageSize),
+	// once re-queried with the exact consumed count to obtain the aligned state.
+	assert.Equal(t, 2, store.fetchedBuckets()[prev])
+}
+
+func TestWalkBuckets_FloorTerminationReturnsPartialPage(t *testing.T) {
+	start := testStartBucket()
+	// floor == start ⇒ DESC crosses the floor at Prev(start), so the walk stops
+	// after the start bucket.
+	store := &fakeCassandra{buckets: map[int64][]int{start: {1, 2}}}
+
+	res := runDesc(t, store, start, start, 365, 5, 8, nil)
+
+	assert.Equal(t, []int{1, 2}, res.Rows)
+	assert.False(t, res.HasNext)
+	assert.Empty(t, res.NextCursor)
+	assert.Equal(t, map[int64]int{start: 1}, store.fetchedBuckets(), "must not fetch below the floor")
+}
+
+func TestWalkBuckets_MaxBucketsCapReturnsResumeCursor(t *testing.T) {
+	s := testSizer()
+	start := testStartBucket()
+	store := &fakeCassandra{buckets: map[int64][]int{}} // all empty
+
+	res := runDesc(t, store, start, noFloorDesc, 2, 5, 8, nil)
+
+	assert.Empty(t, res.Rows)
+	assert.True(t, res.HasNext, "cap reached with an unfilled page is non-terminal")
+	b, ps, err := decodeBucketCursor(res.NextCursor)
+	require.NoError(t, err)
+	assert.Equal(t, s.Prev(s.Prev(start)), b, "resume points just past the last walked bucket")
+	assert.Empty(t, ps)
+	assert.Len(t, store.calls, 2, "must fetch no more than maxBuckets buckets")
+}
+
+func TestWalkBuckets_ResumeFromInitialPageState(t *testing.T) {
+	start := testStartBucket()
+	store := &fakeCassandra{buckets: map[int64][]int{start: seq(1, 10)}}
+
+	res := runDesc(t, store, start, noFloorDesc, 365, 3, 8, encodeTestOffset(5))
+
+	assert.Equal(t, []int{6, 7, 8}, res.Rows, "walk must resume after the initial page state")
+	assert.True(t, res.HasNext)
+	b, ps, err := decodeBucketCursor(res.NextCursor)
+	require.NoError(t, err)
+	assert.Equal(t, start, b)
+	assert.Equal(t, 8, decodeTestOffset(ps))
+
+	require.NotEmpty(t, store.calls)
+	assert.Equal(t, 5, decodeTestOffset(store.calls[0].pageState), "start bucket must receive the initial page state")
+	assert.True(t, store.calls[0].first)
+}
+
+func TestWalkBuckets_EmptyWalkBelowFloorIsTerminal(t *testing.T) {
+	s := testSizer()
+	start := testStartBucket()
+	store := &fakeCassandra{buckets: map[int64][]int{}}
+
+	// floor == Prev(start): crosses at Prev(Prev(start)).
+	res := runDesc(t, store, start, s.Prev(start), 365, 5, 8, nil)
+
+	assert.Empty(t, res.Rows)
+	assert.False(t, res.HasNext)
+	assert.Empty(t, res.NextCursor)
+}
+
+func TestWalkBuckets_FetcherErrorPropagates(t *testing.T) {
+	s := testSizer()
+	start := testStartBucket()
+	failBucket := s.Prev(start)
+	store := &fakeCassandra{
+		buckets: map[int64][]int{start: {1}}, // start underfills, forcing a fan-out into the failing bucket
+		failOn:  &failBucket,
+	}
+
+	_, err := walkBuckets[int](context.Background(), s, walkDesc, start, noFloorDesc, 365, 5, nil, 8, store.fetch)
+	require.Error(t, err)
+}
+
+func TestWalkBuckets_AscendingDirectionOrdersAndResumes(t *testing.T) {
+	s := testSizer()
+	start := testStartBucket()
+	n1, n2 := s.Next(start), s.Next(s.Next(start))
+	store := &fakeCassandra{buckets: map[int64][]int{
+		start: {1}, n1: {2}, n2: {3, 4, 5},
+	}}
+	ceiling := s.Next(s.Next(s.Next(start))) // well above n2
+
+	res, err := walkBuckets[int](context.Background(), s, walkAsc, start, ceiling, 365, 4, nil, 8, store.fetch)
+	require.NoError(t, err)
+
+	assert.Equal(t, []int{1, 2, 3, 4}, res.Rows)
+	assert.True(t, res.HasNext)
+	b, ps, err := decodeBucketCursor(res.NextCursor)
+	require.NoError(t, err)
+	assert.Equal(t, n2, b, "ASC walk resumes mid-bucket in n2")
+	assert.Equal(t, 2, decodeTestOffset(ps), "two rows (3,4) consumed from n2")
+}
+
+// TestWalkBuckets_FanoutParityWithSerial is the core safety guarantee:
+// concurrency must not change the result. The same store walked at fanout 1 and
+// fanout 8 must return byte-identical rows and cursor.
+func TestWalkBuckets_FanoutParityWithSerial(t *testing.T) {
+	s := testSizer()
+	start := testStartBucket()
+	build := func() *fakeCassandra {
+		b1 := s.Prev(start)
+		b2 := s.Prev(b1)
+		b3 := s.Prev(b2)
+		return &fakeCassandra{buckets: map[int64][]int{
+			start: {1, 2},
+			b1:    {}, // empty gap
+			b2:    {3, 4, 5, 6, 7},
+			b3:    {8, 9},
+		}}
+	}
+	serial := build()
+	concurrent := build()
+
+	resSerial, err := walkBuckets[int](context.Background(), s, walkDesc, start, noFloorDesc, 365, 6, nil, 1, serial.fetch)
+	require.NoError(t, err)
+	resConc, err := walkBuckets[int](context.Background(), s, walkDesc, start, noFloorDesc, 365, 6, nil, 8, concurrent.fetch)
+	require.NoError(t, err)
+
+	assert.Equal(t, resSerial.Rows, resConc.Rows)
+	assert.Equal(t, resSerial.NextCursor, resConc.NextCursor)
+	assert.Equal(t, resSerial.HasNext, resConc.HasNext)
+	assert.Equal(t, []int{1, 2, 3, 4, 5, 6}, resConc.Rows)
+}
+
+// TestWalkBuckets_ActuallyFansOutConcurrently proves the walk issues bucket
+// queries in parallel: the fake blocks each fetch until barrierAt goroutines are
+// concurrently in-flight, so the test can only complete if the walk fetches
+// buckets concurrently. Run under -race.
+func TestWalkBuckets_ActuallyFansOutConcurrently(t *testing.T) {
+	s := testSizer()
+	start := testStartBucket()
+	buckets := map[int64][]int{start: {}} // empty start forces a fan-out wave
+	b := start
+	for i := 0; i < 8; i++ {
+		b = s.Prev(b)
+		buckets[b] = []int{i}
+	}
+	store := &fakeCassandra{buckets: buckets, barrierAt: 2, gate: make(chan struct{})}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := walkBuckets[int](ctx, s, walkDesc, start, noFloorDesc, 20, 100, nil, 8, store.fetch)
+	require.NoError(t, err)
+	require.NoError(t, ctx.Err(), "walk deadlocked: buckets were not fetched concurrently")
+
+	assert.GreaterOrEqual(t, store.maxInFlight, 2, "expected concurrent bucket fetches")
+	assert.Len(t, res.Rows, 8)
 }


### PR DESCRIPTION
## Summary

Refactor the bucketed-table page-fill logic to support concurrent bucket fetches in fan-out waves, improving pagination latency for sparse/empty bucket runs while maintaining strict row ordering and cursor alignment. The walk now probes only the start bucket initially (matching the old serial behavior for dense regions), then widens to concurrent fetches once underfill is detected.

## Key Changes

- **Extract `bucketFetcher` abstraction**: Define a new `bucketFetcher[T]` interface that encapsulates the contract for fetching up to `limit` rows from a single bucket, with internal short-page draining. This separates the I/O concern from the walk logic.

- **Implement `gocqlBucketFetcher`**: Adapt the existing gocql query + scan pattern into a `bucketFetcher` that drains short driver pages internally until the limit is reached or the bucket is exhausted. Preserves the original per-row error handling (e.g., decrypt failures abort the fetch).

- **Introduce `walkBuckets` function**: New direction-agnostic concurrent walk that:
  - Starts with a single-bucket wave (no speculative reads for dense start regions)
  - Widens to `fanout`-width waves once the start bucket underfills
  - Fetches each wave concurrently via `errgroup` with a configurable limit
  - Assembles rows in strict bucket order (no reordering despite concurrency)
  - Handles mid-bucket page boundaries by re-fetching with the exact consumed count to obtain an aligned resume cursor
  - Respects floor/ceiling bounds and maxBuckets budget

- **Update `fillPage` signature**: Add `fanout` parameter and delegate to `walkBuckets` via the new `gocqlBucketFetcher`.

- **Wire fanout configuration**: Add `defaultWalkFanout = 8` constant to `repository.go` and thread it through `GetMessagesBefore`, `GetMessagesBetweenDesc`, and `GetMessagesAfter` call sites.

- **Comprehensive test suite**: Add 13 new tests covering:
  - Single dense bucket (no fan-out)
  - Sparse fills across multiple buckets
  - Mid-bucket boundary cursor alignment
  - Floor termination
  - MaxBuckets cap
  - Resume from initial page state
  - Empty walks below floor
  - Fetcher error propagation
  - Ascending direction ordering
  - **Fanout parity**: Byte-identical results at fanout 1 vs. fanout 8 (core safety guarantee)
  - **Actual concurrency**: Proof that buckets are fetched in parallel (with barrier synchronization)

## Implementation Details

- **Wave-based fan-out**: The walk collects `waveWidth` buckets (1 initially, then `fanout`), fetches them concurrently, assembles rows in order, and repeats. This collapses sparse/empty bucket runs from many serial round-trips into a few concurrent ones.

- **Cursor alignment**: When a page fills mid-bucket, the walk re-fetches that bucket with `limit = consumed_rows` to obtain a page state aligned to the actual consumed count, not the prefetched count. This ensures the next walk resumes exactly where the previous one stopped.

- **Error handling**: Fetch errors abort the walk immediately; accumulated rows are discarded (no partial pages on error).

- **Concurrency safety**: All row assembly and cursor decisions happen serially after each wave completes; only the I/O is concurrent. The returned cursor is identical to what a serial walk would produce.

https://claude.ai/code/session_0114C2WrFiZYYECMajMtGvQf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved history retrieval speed by fetching data from multiple buckets concurrently.
  * Added adaptive read fanout controls to fill result pages more efficiently while limiting unnecessary reads.

* **Reliability**
  * Preserved message ordering, pagination, and resume behavior during concurrent retrieval.
  * Improved handling of sparse results, traversal boundaries, partial pages, and fetch errors.
  * Added consistent support for ascending and descending history traversal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->