### PR TITLE
perf(history): small first page for room preview, escalate past ineligible tail

### DIFF
--- a/history-service/internal/config/config.go
+++ b/history-service/internal/config/config.go
@@ -47,6 +47,8 @@ type Config struct {
 	MessageReadMaxBuckets   int             `env:"MESSAGE_READ_MAX_BUCKETS"    envDefault:"122"`
 	MessageHistoryFloorDays int             `env:"MESSAGE_HISTORY_FLOOR_DAYS"  envDefault:"365"`
 	LargeRoomThreshold      int             `env:"LARGE_ROOM_THRESHOLD"        envDefault:"500"`
+	PreviewFirstPageSize    int             `env:"PREVIEW_FIRST_PAGE_SIZE"     envDefault:"3"`
+	PreviewWalkPageSize     int             `env:"PREVIEW_WALK_PAGE_SIZE"      envDefault:"50"`
 	MaxPinnedPerRoom        int             `env:"MAX_PINNED_PER_ROOM"         envDefault:"10"`
 	PinEnabled              bool            `env:"PIN_ENABLED"                 envDefault:"true"`
 

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -16,8 +16,7 @@ import (
 const (
 	maxRoomsGetBatch       = 100 // mirrors maxGetByIDsBatchSize
 	maxRoomsGetConcurrency = 16  // mirrors cassrepo.maxConcurrentIDReads
-	lastMsgWalkPageSize    = 50  // messages scanned per walk-back page
-	lastMsgWalkMaxPages    = 5   // ponytail: cap the ineligible-tail walk; a room with >250 trailing ineligible messages just shows no last message
+	lastMsgWalkMaxPages    = 6   // ineligible-tail walk cap: small first page + 5 full = ~253 msgs, preserving the prior 250-message coverage
 )
 
 // RoomsGet handles chat.server.request.history.{siteID}.rooms.get: for each requested
@@ -76,14 +75,16 @@ func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID stri
 		return models.PreviewMessage{}, false
 	}
 
-	pageReq, err := parsePageRequest("", lastMsgWalkPageSize)
-	if err != nil {
-		return models.PreviewMessage{}, false
-	}
 	ceiling, floor := s.walkBounds(lastMsgAt, createdAt, now)
 	before := ceiling.Add(time.Millisecond)
 
+	// Small first read; escalate to a full page only past a system/deleted tail.
+	pageSize := s.previewFirstPage
 	for range lastMsgWalkMaxPages {
+		pageReq, err := parsePageRequest("", pageSize)
+		if err != nil {
+			return models.PreviewMessage{}, false
+		}
 		page, err := s.msgReader.GetMessagesBefore(ctx, roomID, before, floor, pageReq)
 		if err != nil {
 			slog.WarnContext(ctx, "rooms.get latest-message read degraded", "room_id", roomID,
@@ -105,10 +106,11 @@ func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID stri
 		// Whole page ineligible (deleted/system). A short page means the walk
 		// is exhausted (no older messages) — stop. Otherwise page again strictly
 		// before the oldest one seen.
-		if len(page.Data) < lastMsgWalkPageSize {
+		if len(page.Data) < pageSize {
 			return models.PreviewMessage{}, false
 		}
 		before = page.Data[len(page.Data)-1].CreatedAt
+		pageSize = s.previewWalkPage // head was all-ineligible: read a full page next
 	}
 	return models.PreviewMessage{}, false // ineligible tail longer than the walk cap
 }

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -1,6 +1,7 @@
 package service_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/hmchangw/chat/history-service/internal/cassrepo"
 	"github.com/hmchangw/chat/history-service/internal/config"
 	"github.com/hmchangw/chat/history-service/internal/models"
 	"github.com/hmchangw/chat/history-service/internal/service"
@@ -32,7 +34,7 @@ func newRoomsService(t *testing.T) (*service.HistoryService, *mocks.MockMessageR
 	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
 	users := mocks.NewMockUserStore(ctrl)
 	apps := mocks.NewMockAppStore(ctrl)
-	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true}
+	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, PreviewFirstPageSize: 3, PreviewWalkPageSize: 50, MaxPinnedPerRoom: 10, PinEnabled: true}
 	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg)
 	return svc, msgs, rooms
 }
@@ -49,7 +51,7 @@ func newRoomsServiceWithApps(t *testing.T) (*service.HistoryService, *mocks.Mock
 	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
 	users := mocks.NewMockUserStore(ctrl)
 	apps := mocks.NewMockAppStore(ctrl)
-	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true}
+	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, PreviewFirstPageSize: 3, PreviewWalkPageSize: 50, MaxPinnedPerRoom: 10, PinEnabled: true}
 	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg)
 	return svc, msgs, rooms, apps
 }
@@ -187,6 +189,43 @@ func TestHistoryService_RoomsGet_SkipsSystemTail(t *testing.T) {
 			{MessageID: "m2", RoomID: "r1", Type: model.MessageTypeRoomRenamed, CreatedAt: roomLastMsgAt},
 			{MessageID: "m1", RoomID: "r1", Msg: "alive", CreatedAt: roomLastMsgAt.Add(-time.Minute)},
 		}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "r1")
+	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
+}
+
+// A system/deleted head that fills the small first page forces one escalation to a
+// full walk-back page, which surfaces the eligible message.
+func TestHistoryService_RoomsGet_EscalatesPastSmallFirstPage(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+
+	firstPage := []models.Message{
+		{MessageID: "s3", RoomID: "r1", Type: model.MessageTypeRoomRenamed, CreatedAt: roomLastMsgAt},
+		{MessageID: "s2", RoomID: "r1", Deleted: true, CreatedAt: roomLastMsgAt.Add(-time.Minute)},
+		{MessageID: "s1", RoomID: "r1", Type: model.MessageTypeMembersAdded, CreatedAt: roomLastMsgAt.Add(-2 * time.Minute)},
+	}
+	oldest := firstPage[len(firstPage)-1].CreatedAt
+
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	gomock.InOrder(
+		// First read: the small page (size 3), all ineligible → escalate.
+		msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, _, _ time.Time, pr cassrepo.PageRequest) (cassrepo.Page[models.Message], error) {
+				assert.Equal(t, 3, pr.PageSize)
+				return makePage(firstPage, false), nil
+			}),
+		// Escalated read: full page (size 50), cursor advanced past the oldest first-page message.
+		msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", oldest, gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, before, _ time.Time, pr cassrepo.PageRequest) (cassrepo.Page[models.Message], error) {
+				assert.Equal(t, 50, pr.PageSize)
+				assert.Equal(t, oldest, before)
+				return makePage([]models.Message{
+					{MessageID: "m1", RoomID: "r1", Msg: "alive", CreatedAt: roomLastMsgAt.Add(-3 * time.Minute), Sender: models.Participant{Account: "alice"}},
+				}, false), nil
+			}),
+	)
 
 	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
 	require.NoError(t, err)

--- a/history-service/internal/service/service.go
+++ b/history-service/internal/service/service.go
@@ -114,6 +114,8 @@ type HistoryService struct {
 	apps               AppStore
 	historyFloor       time.Duration // from MESSAGE_HISTORY_FLOOR_DAYS
 	largeRoomThreshold int
+	previewFirstPage   int // PREVIEW_FIRST_PAGE_SIZE: small first walk-back read
+	previewWalkPage    int // PREVIEW_WALK_PAGE_SIZE: full walk-back page past an ineligible tail
 	maxPinnedPerRoom   int
 	pinEnabled         bool // from PIN_ENABLED env var; false disables pin/unpin globally
 }
@@ -141,6 +143,8 @@ func New(
 		apps:               apps,
 		historyFloor:       time.Duration(cfg.MessageHistoryFloorDays) * 24 * time.Hour,
 		largeRoomThreshold: cfg.LargeRoomThreshold,
+		previewFirstPage:   cfg.PreviewFirstPageSize,
+		previewWalkPage:    cfg.PreviewWalkPageSize,
 		maxPinnedPerRoom:   cfg.MaxPinnedPerRoom,
 		pinEnabled:         cfg.PinEnabled,
 	}


### PR DESCRIPTION
## Summary

`subscription.list` with `includeLastMessage` (the client room-list) resolves each room's
last-message preview by walking message history at read time. The walk read a fixed
50-message page per room — but the latest message is eligible in the vast majority of
rooms, so it materialized and decrypted 50 rows to return one. On a room-list of N
subscriptions that is N × 50 rows read/decrypted per load.

This reads a small first page (default 3) and escalates to the full walk-back page
(default 50) only when the head is entirely system/deleted. Same message is selected —
only the row count read on the common path drops (50 → 3). Both page sizes are env-tunable
(`PREVIEW_FIRST_PAGE_SIZE`, `PREVIEW_WALK_PAGE_SIZE`), mirroring the service's existing
`LARGE_ROOM_THRESHOLD`.

Addresses #171.

## Changes

- `history-service/internal/service/rooms.go`: `roomLastPreviewMessage` reads a small
  first page; on an all-ineligible full first page it escalates to the full walk-back page
  for subsequent pages. The eligible-message selection and the max-page cap are unchanged.
- `history-service/internal/config`: `PreviewFirstPageSize` (3) + `PreviewWalkPageSize`
  (50) config fields, threaded into the service.
- Regression test for the escalation path (a full ineligible first page forces one
  escalation that surfaces the eligible message).

## Verification

- `history-service` unit tests green, including the new escalation case; `go vet` and
  golangci-lint clean.
- Measured before/after on a running stack — room-list latency (`subscription.list` with
  previews) over an account whose rooms are **all large** (each ≥50 messages, so every one
  hits the walk), varying the number of rooms enriched:

  | rooms | before p50 | after p50 | delta |
  |------:|-----------:|----------:|------:|
  | 1     | 64.8 ms    | 67.4 ms   | ~0 (within round-trip noise) |
  | 5     | 93.7 ms    | 73.2 ms   | ~22% |
  | 10    | 85.1 ms    | 83.9 ms   | ~noise |
  | 20    | 102.1 ms   | 85.0 ms   | ~17% |
  | 50    | 165.0 ms   | 110.4 ms  | ~33% |
  | 100   | 243.6 ms   | 148.4 ms  | ~39% |

  The per-room delta is small at low room counts (a few ms hidden in the fixed round-trip
  + subscription read) and grows with the number of large rooms — the aggregate rows
  materialized/decrypted per load drop ~16× per large room. Same message selected;
  preview correctness unchanged, no room lost its preview.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room history previews to find the latest eligible message when the newest messages are system-generated or deleted.
  * Preview searches now expand automatically when the initial results do not contain an eligible message.

* **Configuration**
  * Added settings to control the initial preview size and expanded search page size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->