### PR TITLE
perf(history-service): single-query room-preview reads (Phase 1)

### DIFF
--- a/docs/superpowers/plans/2026-08-03-room-preview-read-performance.md
+++ b/docs/superpowers/plans/2026-08-03-room-preview-read-performance.md
@@ -1,0 +1,681 @@
+# Room-list Preview Read Performance (Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the local-site `subscription.list` fast by removing the per-room Cassandra over-walk on history-service's `rooms.get` path and caching the resolved preview — with zero changes to the message write path.
+
+**Architecture:** Two independent read-side wins in history-service, plus instrumentation. (1a) `roomLastPreviewMessage` currently asks `GetMessagesBefore` for a fixed 50-row page but uses only the first eligible row, so `fillPage` over-walks older/empty buckets to fill 50; switch to a tiny first page that grows geometrically only when the newest rows are ineligible. (1b) Front the per-room preview resolve with a short-TTL LRU+singleflight cache reusing the existing `readcache` machinery. (1c) Add a `rooms.get` batch-size metric; the cache hit/miss metric comes free from `cachemetrics`. Phase 2 (denormalization) is explicitly out of scope — see the design spec.
+
+**Tech Stack:** Go 1.25, gocql (Cassandra), `go.uber.org/mock` + `stretchr/testify`, OpenTelemetry metrics via `pkg/cachemetrics` and `go.opentelemetry.io/otel`.
+
+**Design spec:** `docs/superpowers/specs/2026-08-03-room-preview-read-performance-design.md` (Phase 1).
+
+## Global Constraints
+
+- Go 1.25. Use `make` targets only — never raw `go` commands. Key: `make test SERVICE=history-service`, `make lint`, `make test-integration SERVICE=history-service`.
+- TDD: write the failing test first, confirm it fails, implement minimally, confirm green, commit.
+- Minimum 80% coverage on touched packages; all tests run under `-race` (the Makefile handles it).
+- Errors wrapped with context (`fmt.Errorf("…: %w", err)`); structured `log/slog` only; no `fmt.Println`.
+- No client-facing wire change in Phase 1 → **no `docs/client-api.md` edit**.
+- No store-interface change → **no `make generate`** needed.
+- `roomLastPreviewMessage` is shared by the `rooms.get` read path AND `previewAfterMutation` (edit/delete). Task 1 changes it; the full history-service unit suite must stay green.
+- Each commit message ends with the two trailers this session requires:
+  `Co-Authored-By: Claude <noreply@anthropic.com>` and the `Claude-Session:` line.
+
+---
+
+## File Structure
+
+- `history-service/internal/service/rooms.go` — Task 1 (walk fix in `roomLastPreviewMessage`, new walk constants) + Task 3 (`resolvePreview` helper, `RoomsGet` uses it) + Task 4 (batch-size record).
+- `history-service/internal/service/rooms_test.go` — Tasks 1, 3 unit tests.
+- `history-service/internal/service/service.go` — Task 3 (`PreviewCache` interface, `Option`, `WithPreviewCache`, field, variadic `New`).
+- `history-service/internal/service/metrics.go` — Task 4 (new file: batch-size histogram).
+- `history-service/internal/readcache/readcache.go` — Task 2 (`PreviewCache` type).
+- `history-service/internal/readcache/readcache_test.go` — Task 2 tests.
+- `history-service/internal/config/config.go` — Task 3 (`PreviewCacheSize`/`PreviewCacheTTL` + validate guards).
+- `history-service/cmd/main.go` — Task 3 (construct cache, pass `WithPreviewCache`).
+
+---
+
+## Task 1: Fix the preview-walk over-fetch
+
+Replace the fixed 50-row × 5-page walk in `roomLastPreviewMessage` with a small-first-page geometric escalation. Common case (newest message eligible) becomes a single Cassandra query; the ≤250-message ineligible-skip budget is preserved. Exhaustion is detected via the walker's `page.HasNext` (authoritative terminal signal), which keeps the existing single-page tests green.
+
+**Files:**
+- Modify: `history-service/internal/service/rooms.go:16-21` (constants), `:71-114` (`roomLastPreviewMessage`)
+- Test: `history-service/internal/service/rooms_test.go`
+
+**Interfaces:**
+- Consumes: `s.msgReader.GetMessagesBefore(ctx, roomID, before, floor, cassrepo.PageRequest) (cassrepo.Page[models.Message], error)`; `cassrepo.PageRequest{PageSize int}`; `cassrepo.Page[T]{Data []T; HasNext bool}`; `makePage(msgs []models.Message, hasNext bool) cassrepo.Page[models.Message]` (test helper, `messages_test.go:130`).
+- Produces: `roomLastPreviewMessage(ctx, roomID, now) (models.PreviewMessage, bool)` — signature unchanged.
+
+- [ ] **Step 1: Write the failing test — eligible newest resolves in a single query**
+
+Add to `rooms_test.go`. This asserts the first `GetMessagesBefore` is issued with `PageSize == 1` and that exactly one read happens when the newest message is eligible:
+
+```go
+func TestHistoryService_RoomsGet_EligibleNewest_SingleQuery(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+
+	var sizes []int
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ time.Time, _ time.Time, pr cassrepo.PageRequest) (cassrepo.Page[models.Message], error) {
+			sizes = append(sizes, pr.PageSize)
+			return makePage([]models.Message{
+				{MessageID: "m1", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt, Sender: models.Participant{Account: "alice"}},
+			}, false), nil
+		}).Times(1)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "r1")
+	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
+	assert.Equal(t, []int{1}, sizes, "first (and only) walk page must be size 1")
+}
+```
+
+Add the imports `"context"` and `"github.com/hmchangw/chat/history-service/internal/cassrepo"` to `rooms_test.go` if not already present.
+
+- [ ] **Step 2: Run the test — confirm it fails**
+
+Run: `make test SERVICE=history-service`
+Expected: FAIL — current code requests `PageSize == 50`, so `sizes` is `[50]`, not `[1]`.
+
+- [ ] **Step 3: Implement the walk fix**
+
+In `rooms.go`, replace the walk constants (`:16-21`):
+
+```go
+const (
+	maxRoomsGetBatch       = 100 // mirrors maxGetByIDsBatchSize
+	maxRoomsGetConcurrency = 16  // mirrors cassrepo.maxConcurrentIDReads
+
+	// Preview walk: fetch a tiny first page so the common case (newest message
+	// eligible) costs one Cassandra query instead of over-walking older buckets
+	// to fill a 50-row page whose extra rows are unused. Grow geometrically only
+	// to skip a run of ineligible (deleted/system) messages; lastMsgWalkMaxScan
+	// preserves the previous 50×5 = 250 ineligible-skip budget before giving up.
+	lastMsgWalkFirstPage = 1
+	lastMsgWalkGrowth    = 8
+	lastMsgWalkMaxScan   = 250
+)
+```
+
+Replace `roomLastPreviewMessage` (`:71-114`) with:
+
+```go
+func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID string, now time.Time) (models.PreviewMessage, bool) {
+	lastMsgAt, createdAt, err := s.resolveRoomTimesOrError(ctx, roomID, nil, now)
+	if err != nil {
+		slog.WarnContext(ctx, "rooms.get room degraded", "room_id", roomID,
+			"request_id", natsutil.RequestIDFromContext(ctx), "error", err)
+		return models.PreviewMessage{}, false
+	}
+
+	ceiling, floor := s.walkBounds(lastMsgAt, createdAt, now)
+	before := ceiling.Add(time.Millisecond)
+
+	pageSize := lastMsgWalkFirstPage
+	scanned := 0
+	for scanned < lastMsgWalkMaxScan {
+		if remaining := lastMsgWalkMaxScan - scanned; pageSize > remaining {
+			pageSize = remaining
+		}
+		page, err := s.msgReader.GetMessagesBefore(ctx, roomID, before, floor, cassrepo.PageRequest{PageSize: pageSize})
+		if err != nil {
+			slog.WarnContext(ctx, "rooms.get latest-message read degraded", "room_id", roomID,
+				"request_id", natsutil.RequestIDFromContext(ctx), "error", err)
+			return models.PreviewMessage{}, false
+		}
+		if len(page.Data) == 0 {
+			return models.PreviewMessage{}, false // room empty or floor reached
+		}
+		for i := range page.Data {
+			m := page.Data[i]
+			// System and deleted messages aren't representative room content — skip to the
+			// previous eligible message. Quoted replies ARE eligible (normal user content).
+			if m.Deleted || pkgmodel.IsSystemMessageType(m.Type) {
+				continue
+			}
+			return s.toPreviewMessage(ctx, &m), true
+		}
+		// Whole page ineligible. HasNext=false means the walk reached a terminal
+		// state (floor/empty) — stop. Otherwise grow the page and continue strictly
+		// before the oldest one seen.
+		scanned += len(page.Data)
+		if !page.HasNext {
+			return models.PreviewMessage{}, false
+		}
+		before = page.Data[len(page.Data)-1].CreatedAt
+		pageSize *= lastMsgWalkGrowth
+	}
+	return models.PreviewMessage{}, false // ineligible tail longer than the scan budget
+}
+```
+
+Add `"github.com/hmchangw/chat/history-service/internal/cassrepo"` to `rooms.go`'s imports. Remove the now-unused `parsePageRequest` call that was in this function (the helper stays in `utils.go` for other callers).
+
+- [ ] **Step 4: Run tests — confirm the new test and all existing rooms tests pass**
+
+Run: `make test SERVICE=history-service`
+Expected: PASS. The existing `SkipsDeletedTail`, `SkipsSystemTail`, `AllDeletedOmitted`, `EmptyRoomOmitted`, `LatestMessage`, `FullContent` tests stay green — they return single pages with `hasNext=false`, so the new `!page.HasNext` exhaustion check behaves identically.
+
+- [ ] **Step 5: Write the failing test — geometric escalation across ineligible pages**
+
+```go
+func TestHistoryService_RoomsGet_EscalatesPastIneligibleTail(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+
+	var sizes []int
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ time.Time, _ time.Time, pr cassrepo.PageRequest) (cassrepo.Page[models.Message], error) {
+			sizes = append(sizes, pr.PageSize)
+			if pr.PageSize == 1 {
+				// Newest is deleted; more remains (HasNext=true) → escalate.
+				return makePage([]models.Message{
+					{MessageID: "d1", RoomID: "r1", Deleted: true, CreatedAt: roomLastMsgAt},
+				}, true), nil
+			}
+			// Next (larger) page reaches the eligible survivor.
+			return makePage([]models.Message{
+				{MessageID: "m1", RoomID: "r1", Msg: "alive", CreatedAt: roomLastMsgAt.Add(-time.Minute), Sender: models.Participant{Account: "alice"}},
+			}, false), nil
+		}).Times(2)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "r1")
+	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
+	assert.Equal(t, []int{1, 8}, sizes, "page size grows 1 → 8 on an ineligible first page")
+}
+```
+
+- [ ] **Step 6: Run tests — confirm pass**
+
+Run: `make test SERVICE=history-service`
+Expected: PASS (implementation from Step 3 already supports escalation).
+
+- [ ] **Step 7: Lint and commit**
+
+Run: `make lint`
+Then:
+```bash
+git add history-service/internal/service/rooms.go history-service/internal/service/rooms_test.go
+git commit -m "perf(history-service): single-query preview walk with geometric escalation"
+```
+
+---
+
+## Task 2: `readcache.PreviewCache`
+
+Add a positives-only LRU+TTL+singleflight cache for the resolved per-room preview, reusing the existing `ttlCache` primitive and `cachemetrics` (which yields hit/miss/error metrics for free).
+
+**Files:**
+- Modify: `history-service/internal/readcache/readcache.go` (append the new type)
+- Test: `history-service/internal/readcache/readcache_test.go`
+
+**Interfaces:**
+- Consumes: unexported `ttlCache[V]`, `newTTLCache[V](size, ttl, cachemetrics.Recorder)`, `cachemetrics.For(cache, tier string) Recorder`, `pkgmodel.PreviewMessage` — all already in the package.
+- Produces: `NewPreviewCache(size int, ttl time.Duration) (*PreviewCache, error)`; `(*PreviewCache).Get(ctx context.Context, roomID string, load func(context.Context) (pkgmodel.PreviewMessage, bool, error)) (pkgmodel.PreviewMessage, bool, error)`.
+
+- [ ] **Step 1: Write the failing test — positive cached, negative not cached**
+
+Add to `readcache_test.go`:
+
+```go
+func TestPreviewCache_CachesPositiveNotNegative(t *testing.T) {
+	pc, err := readcache.NewPreviewCache(100, time.Minute)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// Positive: loader runs once, second Get is a hit.
+	posCalls := 0
+	load := func(context.Context) (pkgmodel.PreviewMessage, bool, error) {
+		posCalls++
+		return pkgmodel.PreviewMessage{MessageID: "m1"}, true, nil
+	}
+	p, ok, err := pc.Get(ctx, "r1", load)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "m1", p.MessageID)
+	_, _, _ = pc.Get(ctx, "r1", load)
+	assert.Equal(t, 1, posCalls, "positive result is cached")
+
+	// Negative (found=false): never cached, loader runs every time.
+	negCalls := 0
+	negLoad := func(context.Context) (pkgmodel.PreviewMessage, bool, error) {
+		negCalls++
+		return pkgmodel.PreviewMessage{}, false, nil
+	}
+	_, ok, _ = pc.Get(ctx, "r2", negLoad)
+	require.False(t, ok)
+	_, _, _ = pc.Get(ctx, "r2", negLoad)
+	assert.Equal(t, 2, negCalls, "negative result is not cached")
+}
+
+func TestPreviewCache_ErrorNotCachedAndPropagated(t *testing.T) {
+	pc, err := readcache.NewPreviewCache(100, time.Minute)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	wantErr := errors.New("cassandra down")
+	calls := 0
+	load := func(context.Context) (pkgmodel.PreviewMessage, bool, error) {
+		calls++
+		return pkgmodel.PreviewMessage{}, false, wantErr
+	}
+	_, _, err = pc.Get(ctx, "r1", load)
+	require.ErrorIs(t, err, wantErr)
+	_, _, _ = pc.Get(ctx, "r1", load)
+	assert.Equal(t, 2, calls, "errors are not cached")
+}
+```
+
+Ensure `readcache_test.go` imports `"context"`, `"errors"`, `"time"`, testify, `pkgmodel "github.com/hmchangw/chat/pkg/model"`, and the `readcache` package (match the existing test file's import style — it may be `package readcache` internal or `readcache_test`; follow whatever is already there).
+
+- [ ] **Step 2: Run the test — confirm it fails**
+
+Run: `make test SERVICE=history-service` (or `go test` via the Makefile target for the package)
+Expected: FAIL — `NewPreviewCache` undefined.
+
+- [ ] **Step 3: Implement `PreviewCache`**
+
+Append to `readcache.go`:
+
+```go
+// previewEntry is the cached resolved room preview. found=false is never stored
+// (positives-only), so an empty room / read miss re-resolves each time — cheap
+// after the single-query preview walk, and it keeps stale "no preview" out of
+// the cache.
+type previewEntry struct {
+	preview pkgmodel.PreviewMessage
+	found   bool
+}
+
+// PreviewCache caches the resolved last-eligible preview message per room.
+// lastMsgAt advances on every message, so the configured TTL bounds how stale a
+// preview can be; the room list also carries lastMsgAt and clients update open
+// rooms from real-time delivery. Positives-only, singleflight-deduped.
+type PreviewCache struct {
+	cache *ttlCache[previewEntry]
+}
+
+// NewPreviewCache builds a preview cache of size entries with the given TTL.
+// size and ttl must be positive.
+func NewPreviewCache(size int, ttl time.Duration) (*PreviewCache, error) {
+	c, err := newTTLCache[previewEntry](size, ttl, cachemetrics.For("history_room_preview", "l1"))
+	if err != nil {
+		return nil, err
+	}
+	return &PreviewCache{cache: c}, nil
+}
+
+// Get returns the cached preview for roomID or invokes load on miss. Only a
+// found preview is cached; a not-found result (empty room) and errors are
+// returned to the caller but not stored.
+func (c *PreviewCache) Get(ctx context.Context, roomID string, load func(context.Context) (pkgmodel.PreviewMessage, bool, error)) (pkgmodel.PreviewMessage, bool, error) {
+	entry, err := c.cache.getOrLoad(ctx, roomID, func(ctx context.Context) (previewEntry, bool, error) {
+		p, found, err := load(ctx)
+		if err != nil {
+			return previewEntry{}, false, err
+		}
+		return previewEntry{preview: p, found: found}, found, nil
+	})
+	if err != nil {
+		return pkgmodel.PreviewMessage{}, false, err
+	}
+	return entry.preview, entry.found, nil
+}
+```
+
+- [ ] **Step 4: Run tests — confirm pass**
+
+Run: `make test SERVICE=history-service`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing test — singleflight dedups concurrent misses**
+
+```go
+func TestPreviewCache_SingleflightDedupsConcurrentMisses(t *testing.T) {
+	pc, err := readcache.NewPreviewCache(100, time.Minute)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	var calls int32
+	start := make(chan struct{})
+	load := func(context.Context) (pkgmodel.PreviewMessage, bool, error) {
+		atomic.AddInt32(&calls, 1)
+		<-start // hold all callers inside the loader until released
+		return pkgmodel.PreviewMessage{MessageID: "m1"}, true, nil
+	}
+
+	const n = 8
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() { defer wg.Done(); _, _, _ = pc.Get(ctx, "r1", load) }()
+	}
+	// Give goroutines time to coalesce on the same key, then release.
+	time.Sleep(20 * time.Millisecond)
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "concurrent misses coalesce to one load")
+}
+```
+
+Add imports `"sync"` and `"sync/atomic"` to the test file. (The `time.Sleep` here is a test-only coordination aid for exercising concurrency, not production goroutine synchronization.)
+
+- [ ] **Step 6: Run tests — confirm pass**
+
+Run: `make test SERVICE=history-service`
+Expected: PASS (singleflight is provided by the underlying `ttlCache`).
+
+- [ ] **Step 7: Lint and commit**
+
+Run: `make lint`
+```bash
+git add history-service/internal/readcache/readcache.go history-service/internal/readcache/readcache_test.go
+git commit -m "feat(history-service): add positives-only room preview readcache"
+```
+
+---
+
+## Task 3: Wire the preview cache into the service, config, and main
+
+Add an optional `PreviewCache` dependency to `HistoryService` (variadic option — no churn to existing `New` callers), route `RoomsGet` through it, add env config, and construct it in `main.go`.
+
+**Files:**
+- Modify: `history-service/internal/service/service.go` (interface, option, field, variadic `New`)
+- Modify: `history-service/internal/service/rooms.go` (`resolvePreview`; `RoomsGet` uses it)
+- Modify: `history-service/internal/config/config.go` (env fields + validate)
+- Modify: `history-service/cmd/main.go` (construct + pass option)
+- Test: `history-service/internal/service/rooms_test.go`
+
+**Interfaces:**
+- Consumes: `readcache.NewPreviewCache` (Task 2); `models.PreviewMessage` (alias of `pkgmodel.PreviewMessage`, so `*readcache.PreviewCache` satisfies the service interface).
+- Produces: `service.PreviewCache` interface; `service.Option`; `service.WithPreviewCache(pc PreviewCache) Option`; `New(..., opts ...Option)`; `(*HistoryService).resolvePreview(ctx, roomID, now) (models.PreviewMessage, bool)`.
+
+- [ ] **Step 1: Write the failing test — installed cache serves the second read**
+
+Add a cache-enabled service helper and test to `rooms_test.go`:
+
+```go
+func newRoomsServiceWithPreviewCache(t *testing.T) (*service.HistoryService, *mocks.MockMessageRepository, *mocks.MockRoomRepository) {
+	ctrl := gomock.NewController(t)
+	msgs := mocks.NewMockMessageRepository(ctrl)
+	subs := mocks.NewMockSubscriptionRepository(ctrl)
+	rooms := mocks.NewMockRoomRepository(ctrl)
+	pub := mocks.NewMockEventPublisher(ctrl)
+	threadRooms := mocks.NewMockThreadRoomRepository(ctrl)
+	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
+	users := mocks.NewMockUserStore(ctrl)
+	apps := mocks.NewMockAppStore(ctrl)
+	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true}
+	pc, err := readcache.NewPreviewCache(100, time.Minute)
+	require.NoError(t, err)
+	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg, service.WithPreviewCache(pc))
+	return svc, msgs, rooms
+}
+
+func TestHistoryService_RoomsGet_PreviewCacheHitSkipsRead(t *testing.T) {
+	svc, msgs, rooms := newRoomsServiceWithPreviewCache(t)
+
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil).Times(1)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{
+			{MessageID: "m1", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt, Sender: models.Participant{Account: "alice"}},
+		}, false), nil).Times(1)
+
+	for i := 0; i < 3; i++ {
+		resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+		require.NoError(t, err)
+		require.Equal(t, "m1", resp.Rooms["r1"].MessageID)
+	}
+	// Times(1) on both reads asserts the 2nd and 3rd calls were cache hits.
+}
+```
+
+Add `readcache "github.com/hmchangw/chat/history-service/internal/readcache"` to the test imports.
+
+- [ ] **Step 2: Run the test — confirm it fails**
+
+Run: `make test SERVICE=history-service`
+Expected: FAIL — `service.WithPreviewCache` / variadic `New` undefined (compile error).
+
+- [ ] **Step 3: Add the option and field to `service.go`**
+
+In `service.go`, add near the other interface definitions:
+
+```go
+// PreviewCache fronts the per-room preview resolve on the rooms.get read path.
+// Positives are cached; not-found and errors pass through. *readcache.PreviewCache
+// satisfies it.
+type PreviewCache interface {
+	Get(ctx context.Context, roomID string, load func(context.Context) (models.PreviewMessage, bool, error)) (models.PreviewMessage, bool, error)
+}
+
+// Option configures optional HistoryService dependencies.
+type Option func(*HistoryService)
+
+// WithPreviewCache installs a room-preview cache used by RoomsGet. Without it,
+// previews resolve directly (uncached).
+func WithPreviewCache(pc PreviewCache) Option {
+	return func(s *HistoryService) { s.previewCache = pc }
+}
+```
+
+Add the field to the `HistoryService` struct:
+
+```go
+	previewCache PreviewCache
+```
+
+Change `New` to accept and apply options (append `opts ...Option` to the signature; existing zero-option callers keep compiling):
+
+```go
+func New(
+	msgs MessageRepository,
+	subs SubscriptionRepository,
+	rooms RoomRepository,
+	pub EventPublisher,
+	threadRooms ThreadRoomRepository,
+	threadSubs ThreadSubscriptionRepository,
+	users UserStore,
+	apps AppStore,
+	cfg *config.Config,
+	opts ...Option,
+) *HistoryService {
+	s := &HistoryService{
+		// ... existing field assignments unchanged ...
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+```
+
+- [ ] **Step 4: Add `resolvePreview` and use it in `RoomsGet`**
+
+In `rooms.go`, add:
+
+```go
+// resolvePreview resolves one room's preview, serving it from the preview cache
+// when installed. The cache is positives-only, so empty rooms and read failures
+// fall through to a fresh resolve. previewAfterMutation (edit/delete) keeps
+// calling roomLastPreviewMessage directly so mutations always see fresh state.
+func (s *HistoryService) resolvePreview(ctx context.Context, roomID string, now time.Time) (models.PreviewMessage, bool) {
+	if s.previewCache == nil {
+		return s.roomLastPreviewMessage(ctx, roomID, now)
+	}
+	preview, ok, err := s.previewCache.Get(ctx, roomID, func(ctx context.Context) (models.PreviewMessage, bool, error) {
+		p, found := s.roomLastPreviewMessage(ctx, roomID, now)
+		return p, found, nil
+	})
+	if err != nil {
+		// ctx cancelled while waiting on a shared load — degrade like a read miss.
+		return models.PreviewMessage{}, false
+	}
+	return preview, ok
+}
+```
+
+In `RoomsGet`, change the goroutine body from `lm, ok := s.roomLastPreviewMessage(c, roomID, now)` to:
+
+```go
+			lm, ok := s.resolvePreview(c, roomID, now)
+```
+
+- [ ] **Step 5: Run tests — confirm pass**
+
+Run: `make test SERVICE=history-service`
+Expected: PASS — the cache-hit test now sees a single read; all other tests (nil cache → direct resolve) unchanged.
+
+- [ ] **Step 6: Add config fields and validation**
+
+In `config/config.go`, after the `RoomCache*` fields:
+
+```go
+	// Room-list preview cache (resolved last-eligible message per room).
+	// Positives-only; lastMsgAt volatility ⇒ short TTL. Set size or ttl to 0 to disable.
+	PreviewCacheSize int           `env:"HISTORY_PREVIEW_CACHE_SIZE" envDefault:"50000"`
+	PreviewCacheTTL  time.Duration `env:"HISTORY_PREVIEW_CACHE_TTL"  envDefault:"10s"`
+```
+
+In `validate`, add:
+
+```go
+	if cfg.PreviewCacheSize < 0 {
+		return fmt.Errorf("HISTORY_PREVIEW_CACHE_SIZE must be >= 0, got %d", cfg.PreviewCacheSize)
+	}
+	if cfg.PreviewCacheTTL < 0 {
+		return fmt.Errorf("HISTORY_PREVIEW_CACHE_TTL must be >= 0, got %s", cfg.PreviewCacheTTL)
+	}
+```
+
+If `config` has a unit test file, add a case asserting a negative `PreviewCacheSize`/`PreviewCacheTTL` fails `validate`, mirroring the existing `RoomCache` validation tests.
+
+- [ ] **Step 7: Wire the cache in `main.go`**
+
+In `cmd/main.go`, just before the `svc := service.New(...)` line (`:173`):
+
+```go
+	var opts []service.Option
+	if cfg.PreviewCacheSize > 0 && cfg.PreviewCacheTTL > 0 {
+		pc, err := readcache.NewPreviewCache(cfg.PreviewCacheSize, cfg.PreviewCacheTTL)
+		if err != nil {
+			slog.Error("init preview cache failed", "error", err)
+			os.Exit(1)
+		}
+		opts = append(opts, service.WithPreviewCache(pc))
+		slog.Info("preview cache enabled", "size", cfg.PreviewCacheSize, "ttl", cfg.PreviewCacheTTL)
+	}
+```
+
+Change the constructor call to pass `opts...`:
+
+```go
+	svc := service.New(cassRepo, subSource, roomSource, pub, threadRoomRepo, threadSubRepo, userStore, appRepo, &cfg, opts...)
+```
+
+- [ ] **Step 8: Build, lint, and commit**
+
+Run: `make build SERVICE=history-service && make lint && make test SERVICE=history-service`
+Expected: all green.
+```bash
+git add history-service/internal/service/service.go history-service/internal/service/rooms.go \
+        history-service/internal/config/config.go history-service/cmd/main.go \
+        history-service/internal/service/rooms_test.go
+git commit -m "feat(history-service): route rooms.get preview through optional readcache"
+```
+
+---
+
+## Task 4: `rooms.get` batch-size instrumentation
+
+Record the number of distinct rooms per `rooms.get` request as an OpenTelemetry histogram. Combined with the preview cache's free hit/miss counters, this sizes the Phase-2 decision (cache miss rate + batch size → history-service/Cassandra QPS). Walk-depth instrumentation is deferred (it needs cassrepo plumbing — see the design spec's Out-of-scope note).
+
+**Files:**
+- Create: `history-service/internal/service/metrics.go`
+- Modify: `history-service/internal/service/rooms.go` (record after dedup in `RoomsGet`)
+
+**Interfaces:**
+- Consumes: `go.opentelemetry.io/otel`, `go.opentelemetry.io/otel/metric`, `go.opentelemetry.io/otel/metric/noop`.
+- Produces: package-level `roomsGetBatchSize metric.Int64Histogram`.
+
+- [ ] **Step 1: Create the histogram instrument**
+
+Create `history-service/internal/service/metrics.go`:
+
+```go
+package service
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// roomsGetBatchSize records the number of distinct rooms per rooms.get request.
+// Paired with the history_room_preview cache hit/miss counters, it sizes the
+// history-service read load that the Phase-2 denormalization would remove.
+var roomsGetBatchSize metric.Int64Histogram
+
+func init() {
+	h, err := otel.Meter("history-service").Int64Histogram(
+		"history_rooms_get_batch_size",
+		metric.WithDescription("Distinct rooms per rooms.get request."),
+	)
+	if err != nil {
+		// Fall back to a no-op instrument so recording is always safe even if the
+		// global meter provider rejects instrument creation at init time.
+		h, _ = noop.NewMeterProvider().Meter("history-service").Int64Histogram("history_rooms_get_batch_size")
+	}
+	roomsGetBatchSize = h
+}
+```
+
+- [ ] **Step 2: Record the batch size in `RoomsGet`**
+
+In `rooms.go`, in `RoomsGet`, immediately after `ids := dedupRoomIDs(req.RoomIDs)`:
+
+```go
+	roomsGetBatchSize.Record(c, int64(len(ids)))
+```
+
+- [ ] **Step 3: Build and verify it compiles**
+
+Run: `make build SERVICE=history-service`
+Expected: PASS. (No new unit test — the instrument is a no-op without a meter provider; behavior is unchanged and asserting on OTel exports in a unit test adds no value. Existing `RoomsGet` tests still pass.)
+
+- [ ] **Step 4: Run the full suite and lint**
+
+Run: `make test SERVICE=history-service && make lint`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add history-service/internal/service/metrics.go history-service/internal/service/rooms.go
+git commit -m "feat(history-service): record rooms.get batch-size metric"
+```
+
+---
+
+## Final verification
+
+- [ ] Run `make test SERVICE=history-service` — all unit tests green under `-race`.
+- [ ] Run `make lint` — clean.
+- [ ] Run `make test-integration SERVICE=history-service` — the cassrepo/service integration tests (real Cassandra walk) still resolve previews correctly with the new small-page escalation.
+- [ ] Confirm coverage on `history-service/internal/service` and `history-service/internal/readcache` ≥ 80% (`go test -coverprofile` via the Makefile).
+- [ ] Push the branch and stop — Phase 2 remains gated on the metrics from 1c/1b per the design spec.
+
+## Self-review notes
+
+- **Spec coverage:** 1a → Task 1; 1b → Tasks 2–3; 1c → Task 4 (batch size + free cache hit/miss; walk-depth explicitly deferred). Exit criteria are a runtime/measurement decision, not code.
+- **No write-path change** — broadcast-worker, message-worker, user-service untouched; matches the "zero-write Phase 1" constraint.
+- **Type consistency:** `models.PreviewMessage` is a type alias of `pkgmodel.PreviewMessage`, so `readcache.PreviewCache.Get` (typed `pkgmodel.PreviewMessage`) satisfies `service.PreviewCache` (typed `models.PreviewMessage`). `cassrepo.PageRequest{PageSize}` and `cassrepo.Page{Data, HasNext}` names match the repository source.
+- **Shared function caution:** Task 1 changes `roomLastPreviewMessage`, used by both `RoomsGet` and `previewAfterMutation`; the full suite is run in Task 1 Step 4 and the final verification.

--- a/docs/superpowers/plans/2026-08-03-room-preview-read-performance.md
+++ b/docs/superpowers/plans/2026-08-03-room-preview-read-performance.md
@@ -344,10 +344,13 @@ func TestPreviewCache_SingleflightDedupsConcurrentMisses(t *testing.T) {
 	ctx := context.Background()
 
 	var calls int32
-	start := make(chan struct{})
+	started := make(chan struct{}, 1) // the leader loader signals it has entered
+	start := make(chan struct{})      // then blocks here until released
 	load := func(context.Context) (pkgmodel.PreviewMessage, bool, error) {
-		atomic.AddInt32(&calls, 1)
-		<-start // hold all callers inside the loader until released
+		if atomic.AddInt32(&calls, 1) == 1 {
+			started <- struct{}{}
+		}
+		<-start // hold the leader inside the loader so followers coalesce onto its flight
 		return pkgmodel.PreviewMessage{MessageID: "m1"}, true, nil
 	}
 
@@ -357,16 +360,15 @@ func TestPreviewCache_SingleflightDedupsConcurrentMisses(t *testing.T) {
 	for i := 0; i < n; i++ {
 		go func() { defer wg.Done(); _, _, _ = pc.Get(ctx, "r1", load) }()
 	}
-	// Give goroutines time to coalesce on the same key, then release.
-	time.Sleep(20 * time.Millisecond)
-	close(start)
+	<-started    // first loader has entered the flight
+	close(start) // release it
 	wg.Wait()
 
-	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "concurrent misses coalesce to one load")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "concurrent misses for the same key should load once")
 }
 ```
 
-Add imports `"sync"` and `"sync/atomic"` to the test file. (The `time.Sleep` here is a test-only coordination aid for exercising concurrency, not production goroutine synchronization.)
+Add imports `"sync"` and `"sync/atomic"` to the test file. This mirrors the existing `TestSubscriptionCache_SingleflightDedupesConcurrentMisses`: a loader-entry channel deterministically releases the leader once it is in-flight — no `time.Sleep`, per the coding guideline against timing-based goroutine synchronization.
 
 - [ ] **Step 6: Run tests — confirm pass**
 

--- a/docs/superpowers/specs/2026-08-03-room-preview-read-performance-design.md
+++ b/docs/superpowers/specs/2026-08-03-room-preview-read-performance-design.md
@@ -96,10 +96,13 @@ concurrent misses for the same room.
 
 ### 1c. Instrument (prerequisite for deciding on Phase 2)
 
-The service emits no DB-level signal today (noted in the 2026-05-28 perf spec). Add:
-- `rooms.get` per-room latency + Cassandra queries-per-preview (buckets walked),
-- preview cache hit/miss,
-- `rooms.get` batch size (N) distribution.
+The service emits no DB-level signal today (noted in the 2026-05-28 perf spec).
+Phase 1 adds:
+- preview cache hit/miss/error (via `cachemetrics`),
+- `rooms.get` batch size (N) distribution (`history_rooms_get_batch_size`).
+
+Deferred — add only if the two above prove insufficient for the Phase-2 decision:
+- `rooms.get` per-room latency + Cassandra queries-per-preview (buckets walked).
 
 This turns the Phase-2 decision into an evidence-based one and quantifies whether the
 assumed write concern is even relevant.

--- a/docs/superpowers/specs/2026-08-03-room-preview-read-performance-design.md
+++ b/docs/superpowers/specs/2026-08-03-room-preview-read-performance-design.md
@@ -1,0 +1,197 @@
+# Room-list Preview Read Performance — Design
+
+**Date:** 2026-08-03
+**Status:** Approved (design); implementation pending
+**Symptom (measured by the user):** `subscription.list` on the local site is slow.
+
+## Problem
+
+`user-service.ListSubscriptions` → `enrichWithRoomInfoAndLastMsg(withLastMsg=true)`
+→ `enrichLastMessage` issues one `rooms.get` per site **including the local site**
+(`user-service/service/subscriptions.go:327`). Local room metadata otherwise comes
+entirely from the Mongo `$lookup` baseline with no RPC; the **last message is the
+sole reason a local list touches history-service at all**.
+
+Inside history-service, `RoomsGet` (`history-service/internal/service/rooms.go:26`)
+fans out to ≤16 concurrent goroutines, each calling `roomLastPreviewMessage`, which
+resolves room times (Mongo, cached) and then **walks `messages_by_room` in Cassandra**
+to find the last *eligible* message (non-deleted, non-system).
+
+### The cost is not uniform — and not what "walk" first suggests
+
+With an accurate `lastMsgAt`, the walk starts in the right partition and the **first**
+query already returns the newest message. The slowness comes from two narrower causes:
+
+1. **Over-fetch → over-walk.** `roomLastPreviewMessage` requests a **50-row page**
+   (`lastMsgWalkPageSize = 50`) but uses only the first eligible row. `fillPage`
+   (`walker.go:134`) loops `for len(out) < pageSize`, so when the newest bucket returns
+   fewer than 50 rows it **steps into older (often empty) buckets** issuing one query
+   each, trying to reach 50. A busy room (≥50 msgs in the newest 72h bucket) costs **1
+   query**; a **quiet/sparse room** (DM, low-traffic channel, dormant room) walks many
+   buckets for an answer that was in row 1 of query 1.
+2. **Ineligible tail.** The preview must skip deleted/system messages; the 50-row page
+   is sized to batch-skip such a run (up to `lastMsgWalkMaxPages=5` × 50 = 250 before
+   giving up). A long trailing run of deleted/system messages extends the walk.
+
+**Why 50 at all:** the page size exists only because eligibility is computed by
+*scanning* — the newest message by time (`lastMsgId`) may itself be a system event or
+deleted, so the reader scans back to the newest message that represents room content.
+
+### Where the pain actually is
+
+- Not every room — **busy rooms are already ~1 query.** The cost concentrates in
+  **quiet/sparse rooms** (over-walk) and **deleted-tail rooms**.
+- **The aggregate.** Every list load does N × (1 Mongo room-times read + ≥1 Cassandra
+  query), N = the whole page, **recomputed on every load** with no caching of the
+  resolved preview.
+
+## Constraint
+
+A prior decision avoided **denormalizing** the preview out of concern for **write
+traffic**. That concern was **assumed, not measured**. This design therefore leads with
+zero-write read-side wins + instrumentation, and treats denormalization as a
+flag-gated, measurement-triggered escalation — not the default.
+
+Note for context: the heavy-write shape to avoid is **per-subscription fan-out**
+(O(members) writes/message). Denormalizing onto the **single room doc** is O(1) and
+piggybacks the `lastMsgAt` write broadcast-worker already performs — a different, far
+cheaper shape. Phase 2 below only ever considers the room-doc shape.
+
+---
+
+## Phase 1 — zero-write read-side wins (do first)
+
+No message-hot-path writes. Directly attacks the two cost drivers above.
+
+### 1a. Fix the preview-walk over-fetch
+
+`roomLastPreviewMessage` needs the **first eligible** message, not a 50-row page.
+Fetch a **small first page and escalate** only when the newest rows are ineligible:
+
+- Start the walk at page size 1. If the newest row is eligible → **single query**,
+  done. This collapses the accurate-`lastMsgAt` + eligible-newest case (the common
+  case, including all sparse rooms) to one Cassandra round-trip, eliminating the
+  older-empty-bucket over-walk.
+- On a fully-ineligible page, **grow the page geometrically** (e.g. 1 → 8 → 64) and
+  continue, preserving the existing ≤250-message ineligible-skip budget without
+  1-row-at-a-time round-trips for deep deleted tails.
+- Behavior is unchanged (same eligible message returned, same 250 cap); only the
+  round-trip count for quiet/sparse rooms drops.
+
+Scope: `history-service/internal/service/rooms.go` (walk driver) — the change is local
+to the preview path; `LoadHistory` et al. keep their own page sizes.
+
+### 1b. Short-TTL read cache of the resolved preview
+
+Add a `PreviewMessage`-per-room cache to history-service's existing `readcache`
+(LRU+TTL+singleflight, already fronting `GetRoomTimes` / `GetMinUserLastSeenAt`).
+`RoomsGet` serves cached previews and only walks on miss; singleflight dedups
+concurrent misses for the same room.
+
+- **Zero write-path impact** — purely a read cache.
+- TTL bounds staleness (the newest message may lag by up to the TTL); acceptable
+  because the list also carries `lastMsgAt` and clients receive new messages in real
+  time. Pair with a short TTL (align with the existing room-times TTL).
+- Invalidation is TTL-only (per-instance), matching the existing readcache precedent.
+
+### 1c. Instrument (prerequisite for deciding on Phase 2)
+
+The service emits no DB-level signal today (noted in the 2026-05-28 perf spec). Add:
+- `rooms.get` per-room latency + Cassandra queries-per-preview (buckets walked),
+- preview cache hit/miss,
+- `rooms.get` batch size (N) distribution.
+
+This turns the Phase-2 decision into an evidence-based one and quantifies whether the
+assumed write concern is even relevant.
+
+**Phase 1 exit criteria:** if the walk fix + cache bring `subscription.list` latency
+and history-service load within target, **stop here** — no write-path change.
+
+---
+
+## Phase 2 — room-doc denormalization (flag-gated, only if measured need)
+
+Pursue only if Phase 1 metrics show the read-side is insufficient (e.g. cache hit rate
+too low because rooms churn faster than TTL, or first-load latency still dominates).
+
+### Shape
+
+Denormalize the last **eligible** preview onto the Mongo `rooms` doc, written by
+**broadcast-worker** — already the single writer of `rooms.lastMsgAt`/`lastMsgId`
+(`store_mongo.go:78`), already handling create/edit/delete (`handler.go:94`), already
+building the enriched `clientMsg` on create (`handler.go:195`). history-service already
+computes the post-mutation preview via `previewAfterMutation` and ships it on the
+canonical edit/delete events (`messages.go:647`). So the write is wiring, not new
+computation.
+
+Add to `pkg/model/room.go` `Room`:
+```go
+PreviewMessage *PreviewMessage `json:"previewMessage,omitempty" bson:"previewMessage,omitempty"`
+```
+
+### Write-cost mitigations (address the original concern head-on)
+
+- **No new write op** — fold `previewMessage` into the existing per-message
+  `UpdateRoomLastMessage`/`BulkUpdateRoomLastMessage` `$set`. The room doc is already
+  written on every message.
+- **Coalescer** (`broadcast-worker/coalescer.go`) already collapses same-room updates in
+  a window, so a hot room writes the preview once per flush, not once per message —
+  write amplification is sublinear exactly under heavy traffic.
+- **Truncated snippet** — store a capped preview `content` (a few hundred bytes) rather
+  than the full ≤20KB body; the frontend truncates for display anyway. Keeps the room
+  doc small for both the write and the `$lookup` read. (Tradeoff: the list's `content`
+  becomes a snippet, not the full body — a minor wire-behavior change to confirm.)
+- **Precise projections** — only the subscription `$lookup` baseline reads
+  `previewMessage`; other room-doc consumers keep their existing projections, so no
+  read bloat elsewhere (per CLAUDE.md's projection rule).
+
+### Write path
+
+Ordering guard on all writes via a Mongo **aggregation-pipeline update**: set
+`previewMessage` only when the incoming message time ≥ stored `previewMessage.createdAt`,
+making every writer commutative (redeliveries / warm-backs cannot regress a newer
+preview).
+
+- **Create** (`handleCreated`): write the preview from `clientMsg`, **eligible messages
+  only** (system messages advance `lastMsgAt` but leave the preview; hidden thread
+  replies are already routed to `handleThreadCreated`).
+- **Edit / Delete** (`handleUpdated`/`handleDeleted`): persist `evt.PreviewMessage`
+  (already computed upstream); a `nil` value leaves the stored preview untouched.
+
+### Read path
+
+`buildLocalRoom` (`subscriptions.go:384`) fills `room.PreviewMessage` from the baseline;
+`enrichLastMessage` **skips the local-site `rooms.get`** for rooms that carry a preview,
+falling back to `rooms.get` only for the residual (self-healing during rollout).
+
+### Rollout
+
+- **Backfill:** lazy / self-healing — a `rooms.get` fallback warms the room doc via the
+  same guarded pipeline write (a narrow, idempotent, order-safe history-service →
+  `rooms` write; broadcast-worker stays the authoritative writer). No migration job.
+- **Cross-site:** unchanged — cross-site rooms keep the per-site `rooms.get` fan-out
+  (a `GetRoomsInfo` extension is a later follow-up). This design targets the local-site
+  symptom.
+- **Flag:** the read-path skip and the write are behind a config flag so Phase 2 ships
+  dark and enables on evidence.
+
+## Testing
+
+- **Phase 1a** (`rooms_test.go` + integration): eligible-newest room → single Cassandra
+  query; sparse room no longer over-walks; deleted-tail still resolves within the 250
+  budget; identical preview to today.
+- **Phase 1b:** cache hit skips the walk; singleflight dedups concurrent misses; TTL
+  expiry re-walks; miss/hit metrics recorded.
+- **Phase 2** (if pursued): create writes an eligible/truncated preview; system message
+  leaves preview; edit/delete persist `evt.PreviewMessage`; ordering guard rejects an
+  older write; coalescer carries the newest; user-service skips `rooms.get` when a
+  baseline preview exists and falls back otherwise; warm-back is guarded + best-effort;
+  `pkg/model` `roundTrip` covers `Room.PreviewMessage`.
+- Coverage ≥ 80% on touched packages; `-race` throughout.
+
+## Out of scope / follow-ups
+
+- Cross-site preview denormalization via `GetRoomsInfo` (room-service).
+- Proactive backfill migration (lazy warm-back covers correctness if Phase 2 ships).
+- No client-facing request/response schema change in Phase 1; Phase 2's truncated
+  `content` is the only wire-visible change and is confirmed before shipping.

--- a/docs/superpowers/specs/2026-08-03-room-preview-read-performance-design.md
+++ b/docs/superpowers/specs/2026-08-03-room-preview-read-performance-design.md
@@ -124,6 +124,17 @@ computes the post-mutation preview via `previewAfterMutation` and ships it on th
 canonical edit/delete events (`messages.go:647`). So the write is wiring, not new
 computation.
 
+**Phase 2 extraction point:** the `PreviewMessage` construction logic
+(`toPreviewMessage` + `botAwareDisplayName`, currently in history-service
+`rooms.go`/`reactions.go`) is the one piece of logic Phase 1 and Phase 2 share.
+Phase 2 extracts it to a shared package (e.g. `pkg/preview`) so broadcast-worker
+builds byte-identical previews on the create path. Phase 1 deliberately does NOT
+pre-extract it (YAGNI — Phase 2 is metrics-gated and may not land). Otherwise the
+phases are one-directional: Phase 2 *calls* Phase 1's `roomLastPreviewMessage`
+(warm-back + delete-path) but does not edit it, and the Phase 1b cache coexists
+without invalidation because user-service selects the denormalized field vs
+`rooms.get` per room.
+
 Add to `pkg/model/room.go` `Room`:
 ```go
 PreviewMessage *PreviewMessage `json:"previewMessage,omitempty" bson:"previewMessage,omitempty"`

--- a/history-service/cmd/main.go
+++ b/history-service/cmd/main.go
@@ -169,8 +169,19 @@ func main() {
 		slog.Info("room cache enabled", "size", cfg.RoomCacheSize, "ttl", cfg.RoomCacheTTL)
 	}
 
+	var opts []service.Option
+	if cfg.PreviewCacheSize > 0 && cfg.PreviewCacheTTL > 0 {
+		pc, err := readcache.NewPreviewCache(cfg.PreviewCacheSize, cfg.PreviewCacheTTL)
+		if err != nil {
+			slog.Error("init preview cache failed", "error", err)
+			os.Exit(1)
+		}
+		opts = append(opts, service.WithPreviewCache(pc))
+		slog.Info("preview cache enabled", "size", cfg.PreviewCacheSize, "ttl", cfg.PreviewCacheTTL)
+	}
+
 	pub := publisher.New(js)
-	svc := service.New(cassRepo, subSource, roomSource, pub, threadRoomRepo, threadSubRepo, userStore, appRepo, &cfg)
+	svc := service.New(cassRepo, subSource, roomSource, pub, threadRoomRepo, threadSubRepo, userStore, appRepo, &cfg, opts...)
 	router := natsrouter.New(nc, "history-service")
 	router.Use(natsrouter.Recovery())
 	// RequestID must precede any handler that reads request_id from ctx —

--- a/history-service/internal/cassrepo/utils.go
+++ b/history-service/internal/cassrepo/utils.go
@@ -54,7 +54,9 @@ type PageRequest struct {
 
 const (
 	defaultCassPageSize = 50
-	maxPageSize         = 100
+	// MaxPageSize is the per-query row cap for message reads. Callers that build a
+	// PageRequest directly (bypassing ParsePageRequest) should clamp to it.
+	MaxPageSize = 100
 )
 
 // maxCursorBytes caps decoded page-state size; 512 is generous vs. real tokens (10–100 B) yet blocks pathological allocations.
@@ -69,8 +71,8 @@ func ParsePageRequest(cursorStr string, pageSize int) (PageRequest, error) {
 	if pageSize <= 0 {
 		pageSize = defaultCassPageSize
 	}
-	if pageSize > maxPageSize {
-		pageSize = maxPageSize
+	if pageSize > MaxPageSize {
+		pageSize = MaxPageSize
 	}
 	return PageRequest{Cursor: cursor, PageSize: pageSize}, nil
 }

--- a/history-service/internal/config/config.go
+++ b/history-service/internal/config/config.go
@@ -65,6 +65,11 @@ type Config struct {
 	RoomCacheSize int           `env:"HISTORY_ROOM_CACHE_SIZE" envDefault:"50000"`
 	RoomCacheTTL  time.Duration `env:"HISTORY_ROOM_CACHE_TTL"  envDefault:"10s"`
 
+	// Room-list preview cache (resolved last-eligible message per room).
+	// Positives-only; lastMsgAt volatility ⇒ short TTL. Set size or ttl to 0 to disable.
+	PreviewCacheSize int           `env:"HISTORY_PREVIEW_CACHE_SIZE" envDefault:"50000"`
+	PreviewCacheTTL  time.Duration `env:"HISTORY_PREVIEW_CACHE_TTL"  envDefault:"10s"`
+
 	Atrest atrest.Config      // env vars are already prefixed ATREST_*
 	Vault  atrest.VaultConfig // env vars are already prefixed (VAULT_*, ATREST_VAULT_*)
 
@@ -100,6 +105,12 @@ func validate(cfg *Config) error {
 	}
 	if cfg.RoomCacheTTL < 0 {
 		return fmt.Errorf("HISTORY_ROOM_CACHE_TTL must be >= 0, got %s", cfg.RoomCacheTTL)
+	}
+	if cfg.PreviewCacheSize < 0 {
+		return fmt.Errorf("HISTORY_PREVIEW_CACHE_SIZE must be >= 0, got %d", cfg.PreviewCacheSize)
+	}
+	if cfg.PreviewCacheTTL < 0 {
+		return fmt.Errorf("HISTORY_PREVIEW_CACHE_TTL must be >= 0, got %s", cfg.PreviewCacheTTL)
 	}
 	return nil
 }

--- a/history-service/internal/config/config_test.go
+++ b/history-service/internal/config/config_test.go
@@ -13,10 +13,12 @@ import (
 // validate() doesn't touch them.
 func baseValid() Config {
 	return Config{
-		SubCacheSize:  100000,
-		SubCacheTTL:   2 * time.Minute,
-		RoomCacheSize: 50000,
-		RoomCacheTTL:  10 * time.Second,
+		SubCacheSize:     100000,
+		SubCacheTTL:      2 * time.Minute,
+		RoomCacheSize:    50000,
+		RoomCacheTTL:     10 * time.Second,
+		PreviewCacheSize: 50000,
+		PreviewCacheTTL:  10 * time.Second,
 	}
 }
 
@@ -31,6 +33,8 @@ func TestValidate_AcceptsZerosAsDisable(t *testing.T) {
 	cfg.SubCacheTTL = 0
 	cfg.RoomCacheSize = 0
 	cfg.RoomCacheTTL = 0
+	cfg.PreviewCacheSize = 0
+	cfg.PreviewCacheTTL = 0
 	require.NoError(t, validate(&cfg), "zero is the documented disable value")
 }
 
@@ -64,4 +68,20 @@ func TestValidate_RejectsNegativeRoomCacheTTL(t *testing.T) {
 	err := validate(&cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "HISTORY_ROOM_CACHE_TTL")
+}
+
+func TestValidate_RejectsNegativePreviewCacheSize(t *testing.T) {
+	cfg := baseValid()
+	cfg.PreviewCacheSize = -1
+	err := validate(&cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HISTORY_PREVIEW_CACHE_SIZE")
+}
+
+func TestValidate_RejectsNegativePreviewCacheTTL(t *testing.T) {
+	cfg := baseValid()
+	cfg.PreviewCacheTTL = -1 * time.Second
+	err := validate(&cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HISTORY_PREVIEW_CACHE_TTL")
 }

--- a/history-service/internal/readcache/readcache.go
+++ b/history-service/internal/readcache/readcache.go
@@ -214,3 +214,47 @@ func (c *RoomCache) GetMinUserLastSeenAt(ctx context.Context, roomID string) (*t
 func (c *RoomCache) GetRoomUserCount(ctx context.Context, roomID string) (int, error) {
 	return c.inner.GetRoomUserCount(ctx, roomID)
 }
+
+// previewEntry is the cached resolved room preview. found=false is never stored
+// (positives-only), so an empty room / read miss re-resolves each time — cheap
+// after the single-query preview walk, and it keeps stale "no preview" out of
+// the cache.
+type previewEntry struct {
+	preview pkgmodel.PreviewMessage
+	found   bool
+}
+
+// PreviewCache caches the resolved last-eligible preview message per room.
+// lastMsgAt advances on every message, so the configured TTL bounds how stale a
+// preview can be; the room list also carries lastMsgAt and clients update open
+// rooms from real-time delivery. Positives-only, singleflight-deduped.
+type PreviewCache struct {
+	cache *ttlCache[previewEntry]
+}
+
+// NewPreviewCache builds a preview cache of size entries with the given TTL.
+// size and ttl must be positive.
+func NewPreviewCache(size int, ttl time.Duration) (*PreviewCache, error) {
+	c, err := newTTLCache[previewEntry](size, ttl, cachemetrics.For("history_room_preview", "l1"))
+	if err != nil {
+		return nil, err
+	}
+	return &PreviewCache{cache: c}, nil
+}
+
+// Get returns the cached preview for roomID or invokes load on miss. Only a
+// found preview is cached; a not-found result (empty room) and errors are
+// returned to the caller but not stored.
+func (c *PreviewCache) Get(ctx context.Context, roomID string, load func(context.Context) (pkgmodel.PreviewMessage, bool, error)) (pkgmodel.PreviewMessage, bool, error) {
+	entry, err := c.cache.getOrLoad(ctx, roomID, func(ctx context.Context) (previewEntry, bool, error) {
+		p, found, err := load(ctx)
+		if err != nil {
+			return previewEntry{}, false, err
+		}
+		return previewEntry{preview: p, found: found}, found, nil
+	})
+	if err != nil {
+		return pkgmodel.PreviewMessage{}, false, err
+	}
+	return entry.preview, entry.found, nil
+}

--- a/history-service/internal/readcache/readcache.go
+++ b/history-service/internal/readcache/readcache.go
@@ -237,7 +237,7 @@ type PreviewCache struct {
 func NewPreviewCache(size int, ttl time.Duration) (*PreviewCache, error) {
 	c, err := newTTLCache[previewEntry](size, ttl, cachemetrics.For("history_room_preview", "l1"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create preview cache: %w", err)
 	}
 	return &PreviewCache{cache: c}, nil
 }

--- a/history-service/internal/readcache/readcache_test.go
+++ b/history-service/internal/readcache/readcache_test.go
@@ -323,10 +323,13 @@ func TestPreviewCache_SingleflightDedupsConcurrentMisses(t *testing.T) {
 	ctx := context.Background()
 
 	var calls int32
-	start := make(chan struct{})
+	started := make(chan struct{}, 1) // the leader loader signals it has entered
+	start := make(chan struct{})      // then blocks here until released
 	load := func(context.Context) (pkgmodel.PreviewMessage, bool, error) {
-		atomic.AddInt32(&calls, 1)
-		<-start // hold all callers inside the loader until released
+		if atomic.AddInt32(&calls, 1) == 1 {
+			started <- struct{}{}
+		}
+		<-start // hold the leader inside the loader so followers coalesce onto its flight
 		return pkgmodel.PreviewMessage{MessageID: "m1"}, true, nil
 	}
 
@@ -336,12 +339,11 @@ func TestPreviewCache_SingleflightDedupsConcurrentMisses(t *testing.T) {
 	for i := 0; i < n; i++ {
 		go func() { defer wg.Done(); _, _, _ = pc.Get(ctx, "r1", load) }()
 	}
-	// Give goroutines time to coalesce on the same key, then release.
-	time.Sleep(20 * time.Millisecond)
-	close(start)
+	<-started    // first loader has entered the flight
+	close(start) // release it
 	wg.Wait()
 
-	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "concurrent misses coalesce to one load")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "concurrent misses for the same key should load once")
 }
 
 func TestSubscriptionCache_CallerCancelReturnsCtxErr(t *testing.T) {

--- a/history-service/internal/readcache/readcache_test.go
+++ b/history-service/internal/readcache/readcache_test.go
@@ -270,6 +270,80 @@ func TestSubscriptionCache_LeaderCancelDoesNotPoisonWaiters(t *testing.T) {
 	assert.Equal(t, int32(1), src.calls.Load(), "shared load should have populated the cache")
 }
 
+func TestPreviewCache_CachesPositiveNotNegative(t *testing.T) {
+	pc, err := NewPreviewCache(100, time.Minute)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// Positive: loader runs once, second Get is a hit.
+	posCalls := 0
+	load := func(context.Context) (pkgmodel.PreviewMessage, bool, error) {
+		posCalls++
+		return pkgmodel.PreviewMessage{MessageID: "m1"}, true, nil
+	}
+	p, ok, err := pc.Get(ctx, "r1", load)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "m1", p.MessageID)
+	_, _, _ = pc.Get(ctx, "r1", load)
+	assert.Equal(t, 1, posCalls, "positive result is cached")
+
+	// Negative (found=false): never cached, loader runs every time.
+	negCalls := 0
+	negLoad := func(context.Context) (pkgmodel.PreviewMessage, bool, error) {
+		negCalls++
+		return pkgmodel.PreviewMessage{}, false, nil
+	}
+	_, ok, _ = pc.Get(ctx, "r2", negLoad)
+	require.False(t, ok)
+	_, _, _ = pc.Get(ctx, "r2", negLoad)
+	assert.Equal(t, 2, negCalls, "negative result is not cached")
+}
+
+func TestPreviewCache_ErrorNotCachedAndPropagated(t *testing.T) {
+	pc, err := NewPreviewCache(100, time.Minute)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	wantErr := errors.New("cassandra down")
+	calls := 0
+	load := func(context.Context) (pkgmodel.PreviewMessage, bool, error) {
+		calls++
+		return pkgmodel.PreviewMessage{}, false, wantErr
+	}
+	_, _, err = pc.Get(ctx, "r1", load)
+	require.ErrorIs(t, err, wantErr)
+	_, _, _ = pc.Get(ctx, "r1", load)
+	assert.Equal(t, 2, calls, "errors are not cached")
+}
+
+func TestPreviewCache_SingleflightDedupsConcurrentMisses(t *testing.T) {
+	pc, err := NewPreviewCache(100, time.Minute)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	var calls int32
+	start := make(chan struct{})
+	load := func(context.Context) (pkgmodel.PreviewMessage, bool, error) {
+		atomic.AddInt32(&calls, 1)
+		<-start // hold all callers inside the loader until released
+		return pkgmodel.PreviewMessage{MessageID: "m1"}, true, nil
+	}
+
+	const n = 8
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() { defer wg.Done(); _, _, _ = pc.Get(ctx, "r1", load) }()
+	}
+	// Give goroutines time to coalesce on the same key, then release.
+	time.Sleep(20 * time.Millisecond)
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "concurrent misses coalesce to one load")
+}
+
 func TestSubscriptionCache_CallerCancelReturnsCtxErr(t *testing.T) {
 	ts := time.Now().UTC()
 	src := &fakeSubSource{

--- a/history-service/internal/service/metrics.go
+++ b/history-service/internal/service/metrics.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// roomsGetBatchSize records the number of distinct rooms per rooms.get request.
+// Paired with the history_room_preview cache hit/miss counters, it sizes the
+// history-service read load that the Phase-2 denormalization would remove.
+var roomsGetBatchSize metric.Int64Histogram
+
+func init() {
+	h, err := otel.Meter("history-service").Int64Histogram(
+		"history_rooms_get_batch_size",
+		metric.WithDescription("Distinct rooms per rooms.get request."),
+	)
+	if err != nil {
+		// Fall back to a no-op instrument so recording is always safe even if the
+		// global meter provider rejects instrument creation at init time.
+		h, _ = noop.NewMeterProvider().Meter("history-service").Int64Histogram("history_rooms_get_batch_size")
+	}
+	roomsGetBatchSize = h
+}

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -43,6 +43,7 @@ func (s *HistoryService) RoomsGet(c *natsrouter.Context, req models.RoomsGetRequ
 	}
 
 	ids := dedupRoomIDs(req.RoomIDs)
+	roomsGetBatchSize.Record(c, int64(len(ids)))
 	now := time.Now().UTC()
 
 	out := make(map[string]models.PreviewMessage, len(ids))

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -62,7 +62,7 @@ func (s *HistoryService) RoomsGet(c *natsrouter.Context, req models.RoomsGetRequ
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
-			lm, ok := s.roomLastPreviewMessage(c, roomID, now)
+			lm, ok := s.resolvePreview(c, roomID, now)
 			if !ok {
 				return
 			}
@@ -74,6 +74,25 @@ func (s *HistoryService) RoomsGet(c *natsrouter.Context, req models.RoomsGetRequ
 	wg.Wait()
 
 	return &models.RoomsGetResponse{Rooms: out}, nil
+}
+
+// resolvePreview resolves one room's preview, serving it from the preview cache
+// when installed. The cache is positives-only, so empty rooms and read failures
+// fall through to a fresh resolve. previewAfterMutation (edit/delete) keeps
+// calling roomLastPreviewMessage directly so mutations always see fresh state.
+func (s *HistoryService) resolvePreview(ctx context.Context, roomID string, now time.Time) (models.PreviewMessage, bool) {
+	if s.previewCache == nil {
+		return s.roomLastPreviewMessage(ctx, roomID, now)
+	}
+	preview, ok, err := s.previewCache.Get(ctx, roomID, func(ctx context.Context) (models.PreviewMessage, bool, error) {
+		p, found := s.roomLastPreviewMessage(ctx, roomID, now)
+		return p, found, nil
+	})
+	if err != nil {
+		// ctx cancelled while waiting on a shared load — degrade like a read miss.
+		return models.PreviewMessage{}, false
+	}
+	return preview, ok
 }
 
 // roomLastPreviewMessage resolves one room's latest eligible preview message at read time.

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -23,12 +23,12 @@ const (
 	// to fill a 50-row page whose extra rows are unused. Grow geometrically only
 	// to skip a run of ineligible (deleted/system) messages; lastMsgWalkMaxScan
 	// preserves the previous 50×5 = 250 ineligible-skip budget before giving up.
-	// lastMsgWalkMaxPage caps the escalation at the codebase-wide page-size cap
-	// (cassrepo.maxPageSize) so the ×8 growth never over-requests a single query.
+	// lastMsgWalkMaxPage caps the escalation at cassrepo.MaxPageSize, the
+	// codebase-wide per-query row cap, so the ×8 growth never over-requests.
 	lastMsgWalkFirstPage = 1
 	lastMsgWalkGrowth    = 8
 	lastMsgWalkMaxScan   = 250
-	lastMsgWalkMaxPage   = 100
+	lastMsgWalkMaxPage   = cassrepo.MaxPageSize
 )
 
 // RoomsGet handles chat.server.request.history.{siteID}.rooms.get: for each requested
@@ -113,12 +113,10 @@ func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID stri
 	pageSize := lastMsgWalkFirstPage
 	scanned := 0
 	for scanned < lastMsgWalkMaxScan {
-		if pageSize > lastMsgWalkMaxPage {
-			pageSize = lastMsgWalkMaxPage
-		}
-		if remaining := lastMsgWalkMaxScan - scanned; pageSize > remaining {
-			pageSize = remaining
-		}
+		// Clamp to the per-query cap and the remaining scan budget (both bounds are
+		// positive here, so order doesn't matter). The next iteration's ×8 growth
+		// starts from this clamped value.
+		pageSize = min(pageSize, lastMsgWalkMaxPage, lastMsgWalkMaxScan-scanned)
 		page, err := s.msgReader.GetMessagesBefore(ctx, roomID, before, floor, cassrepo.PageRequest{PageSize: pageSize})
 		if err != nil {
 			slog.WarnContext(ctx, "rooms.get latest-message read degraded", "room_id", roomID,
@@ -145,8 +143,6 @@ func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID stri
 			return models.PreviewMessage{}, false
 		}
 		before = page.Data[len(page.Data)-1].CreatedAt
-		// Grows from this iteration's (possibly clamped) pageSize, not the original
-		// unclamped value — so growth is not always a clean ×8 of the prior request.
 		pageSize *= lastMsgWalkGrowth
 	}
 	return models.PreviewMessage{}, false // ineligible tail longer than the scan budget

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -23,9 +23,12 @@ const (
 	// to fill a 50-row page whose extra rows are unused. Grow geometrically only
 	// to skip a run of ineligible (deleted/system) messages; lastMsgWalkMaxScan
 	// preserves the previous 50×5 = 250 ineligible-skip budget before giving up.
+	// lastMsgWalkMaxPage caps the escalation at the codebase-wide page-size cap
+	// (cassrepo.maxPageSize) so the ×8 growth never over-requests a single query.
 	lastMsgWalkFirstPage = 1
 	lastMsgWalkGrowth    = 8
 	lastMsgWalkMaxScan   = 250
+	lastMsgWalkMaxPage   = 100
 )
 
 // RoomsGet handles chat.server.request.history.{siteID}.rooms.get: for each requested
@@ -90,6 +93,9 @@ func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID stri
 	pageSize := lastMsgWalkFirstPage
 	scanned := 0
 	for scanned < lastMsgWalkMaxScan {
+		if pageSize > lastMsgWalkMaxPage {
+			pageSize = lastMsgWalkMaxPage
+		}
 		if remaining := lastMsgWalkMaxScan - scanned; pageSize > remaining {
 			pageSize = remaining
 		}
@@ -119,6 +125,8 @@ func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID stri
 			return models.PreviewMessage{}, false
 		}
 		before = page.Data[len(page.Data)-1].CreatedAt
+		// Grows from this iteration's (possibly clamped) pageSize, not the original
+		// unclamped value — so growth is not always a clean ×8 of the prior request.
 		pageSize *= lastMsgWalkGrowth
 	}
 	return models.PreviewMessage{}, false // ineligible tail longer than the scan budget

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hmchangw/chat/history-service/internal/cassrepo"
 	"github.com/hmchangw/chat/history-service/internal/models"
 	"github.com/hmchangw/chat/pkg/errcode"
 	pkgmodel "github.com/hmchangw/chat/pkg/model"
@@ -16,8 +17,15 @@ import (
 const (
 	maxRoomsGetBatch       = 100 // mirrors maxGetByIDsBatchSize
 	maxRoomsGetConcurrency = 16  // mirrors cassrepo.maxConcurrentIDReads
-	lastMsgWalkPageSize    = 50  // messages scanned per walk-back page
-	lastMsgWalkMaxPages    = 5   // ponytail: cap the ineligible-tail walk; a room with >250 trailing ineligible messages just shows no last message
+
+	// Preview walk: fetch a tiny first page so the common case (newest message
+	// eligible) costs one Cassandra query instead of over-walking older buckets
+	// to fill a 50-row page whose extra rows are unused. Grow geometrically only
+	// to skip a run of ineligible (deleted/system) messages; lastMsgWalkMaxScan
+	// preserves the previous 50×5 = 250 ineligible-skip budget before giving up.
+	lastMsgWalkFirstPage = 1
+	lastMsgWalkGrowth    = 8
+	lastMsgWalkMaxScan   = 250
 )
 
 // RoomsGet handles chat.server.request.history.{siteID}.rooms.get: for each requested
@@ -76,15 +84,16 @@ func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID stri
 		return models.PreviewMessage{}, false
 	}
 
-	pageReq, err := parsePageRequest("", lastMsgWalkPageSize)
-	if err != nil {
-		return models.PreviewMessage{}, false
-	}
 	ceiling, floor := s.walkBounds(lastMsgAt, createdAt, now)
 	before := ceiling.Add(time.Millisecond)
 
-	for range lastMsgWalkMaxPages {
-		page, err := s.msgReader.GetMessagesBefore(ctx, roomID, before, floor, pageReq)
+	pageSize := lastMsgWalkFirstPage
+	scanned := 0
+	for scanned < lastMsgWalkMaxScan {
+		if remaining := lastMsgWalkMaxScan - scanned; pageSize > remaining {
+			pageSize = remaining
+		}
+		page, err := s.msgReader.GetMessagesBefore(ctx, roomID, before, floor, cassrepo.PageRequest{PageSize: pageSize})
 		if err != nil {
 			slog.WarnContext(ctx, "rooms.get latest-message read degraded", "room_id", roomID,
 				"request_id", natsutil.RequestIDFromContext(ctx), "error", err)
@@ -102,15 +111,17 @@ func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID stri
 			}
 			return s.toPreviewMessage(ctx, &m), true
 		}
-		// Whole page ineligible (deleted/system). A short page means the walk
-		// is exhausted (no older messages) — stop. Otherwise page again strictly
+		// Whole page ineligible. HasNext=false means the walk reached a terminal
+		// state (floor/empty) — stop. Otherwise grow the page and continue strictly
 		// before the oldest one seen.
-		if len(page.Data) < lastMsgWalkPageSize {
+		scanned += len(page.Data)
+		if !page.HasNext {
 			return models.PreviewMessage{}, false
 		}
 		before = page.Data[len(page.Data)-1].CreatedAt
+		pageSize *= lastMsgWalkGrowth
 	}
-	return models.PreviewMessage{}, false // ineligible tail longer than the walk cap
+	return models.PreviewMessage{}, false // ineligible tail longer than the scan budget
 }
 
 // toPreviewMessage enriches an eligible message into the room-list preview: sender and

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -1,6 +1,7 @@
 package service_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/hmchangw/chat/history-service/internal/cassrepo"
 	"github.com/hmchangw/chat/history-service/internal/config"
 	"github.com/hmchangw/chat/history-service/internal/models"
 	"github.com/hmchangw/chat/history-service/internal/service"
@@ -79,6 +81,53 @@ func TestHistoryService_RoomsGet_LatestMessage(t *testing.T) {
 	assert.Equal(t, "hello", lm.Content)
 	assert.Equal(t, "alice", lm.Sender.Account)
 	assert.Equal(t, roomLastMsgAt.UTC(), lm.CreatedAt)
+}
+
+func TestHistoryService_RoomsGet_EligibleNewest_SingleQuery(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+
+	var sizes []int
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ time.Time, _ time.Time, pr cassrepo.PageRequest) (cassrepo.Page[models.Message], error) {
+			sizes = append(sizes, pr.PageSize)
+			return makePage([]models.Message{
+				{MessageID: "m1", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt, Sender: models.Participant{Account: "alice"}},
+			}, false), nil
+		}).Times(1)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "r1")
+	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
+	assert.Equal(t, []int{1}, sizes, "first (and only) walk page must be size 1")
+}
+
+func TestHistoryService_RoomsGet_EscalatesPastIneligibleTail(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+
+	var sizes []int
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ time.Time, _ time.Time, pr cassrepo.PageRequest) (cassrepo.Page[models.Message], error) {
+			sizes = append(sizes, pr.PageSize)
+			if pr.PageSize == 1 {
+				// Newest is deleted; more remains (HasNext=true) → escalate.
+				return makePage([]models.Message{
+					{MessageID: "d1", RoomID: "r1", Deleted: true, CreatedAt: roomLastMsgAt},
+				}, true), nil
+			}
+			// Next (larger) page reaches the eligible survivor.
+			return makePage([]models.Message{
+				{MessageID: "m1", RoomID: "r1", Msg: "alive", CreatedAt: roomLastMsgAt.Add(-time.Minute), Sender: models.Participant{Account: "alice"}},
+			}, false), nil
+		}).Times(2)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "r1")
+	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
+	assert.Equal(t, []int{1, 8}, sizes, "page size grows 1 → 8 on an ineligible first page")
 }
 
 func TestHistoryService_RoomsGet_EmptyRoomOmitted(t *testing.T) {

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -130,6 +130,36 @@ func TestHistoryService_RoomsGet_EscalatesPastIneligibleTail(t *testing.T) {
 	assert.Equal(t, []int{1, 8}, sizes, "page size grows 1 → 8 on an ineligible first page")
 }
 
+// The scan budget (250) is exhausted by an unbroken run of deleted messages,
+// each returned page full (len == PageSize) with HasNext=true, so the walk
+// never sees a terminal signal from the store — it must stop on the budget
+// itself, not loop forever. Also verifies the 100-row escalation clamp: the
+// 4th page is capped at 100 (not 512), and the 5th page is the remaining 77
+// to close out the 250 budget.
+func TestHistoryService_RoomsGet_ScanBudgetExhausted_NoEligibleMessage(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+
+	var sizes []int
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ time.Time, _ time.Time, pr cassrepo.PageRequest) (cassrepo.Page[models.Message], error) {
+			sizes = append(sizes, pr.PageSize)
+			deleted := make([]models.Message, pr.PageSize)
+			for i := range deleted {
+				deleted[i] = models.Message{
+					MessageID: "d", RoomID: "r1", Deleted: true,
+					CreatedAt: roomLastMsgAt.Add(-time.Duration(i) * time.Second),
+				}
+			}
+			return makePage(deleted, true), nil
+		}).Times(5)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	assert.NotContains(t, resp.Rooms, "r1")
+	assert.Equal(t, []int{1, 8, 64, 100, 77}, sizes, "escalation clamps at 100 then the remaining budget, terminating at the 250-row scan cap")
+}
+
 func TestHistoryService_RoomsGet_EmptyRoomOmitted(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hmchangw/chat/history-service/internal/cassrepo"
 	"github.com/hmchangw/chat/history-service/internal/config"
 	"github.com/hmchangw/chat/history-service/internal/models"
+	readcache "github.com/hmchangw/chat/history-service/internal/readcache"
 	"github.com/hmchangw/chat/history-service/internal/service"
 	"github.com/hmchangw/chat/history-service/internal/service/mocks"
 	"github.com/hmchangw/chat/pkg/model"
@@ -56,6 +57,25 @@ func newRoomsServiceWithApps(t *testing.T) (*service.HistoryService, *mocks.Mock
 	return svc, msgs, rooms, apps
 }
 
+// newRoomsServiceWithPreviewCache installs a real PreviewCache so RoomsGet routes
+// through it (cache-hit behavior on the second/third read of the same room).
+func newRoomsServiceWithPreviewCache(t *testing.T) (*service.HistoryService, *mocks.MockMessageRepository, *mocks.MockRoomRepository) {
+	ctrl := gomock.NewController(t)
+	msgs := mocks.NewMockMessageRepository(ctrl)
+	subs := mocks.NewMockSubscriptionRepository(ctrl)
+	rooms := mocks.NewMockRoomRepository(ctrl)
+	pub := mocks.NewMockEventPublisher(ctrl)
+	threadRooms := mocks.NewMockThreadRoomRepository(ctrl)
+	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
+	users := mocks.NewMockUserStore(ctrl)
+	apps := mocks.NewMockAppStore(ctrl)
+	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true}
+	pc, err := readcache.NewPreviewCache(100, time.Minute)
+	require.NoError(t, err)
+	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg, service.WithPreviewCache(pc))
+	return svc, msgs, rooms
+}
+
 func roomsCtx() *natsrouter.Context {
 	return natsrouter.NewContext(map[string]string{"account": "alice"})
 }
@@ -65,6 +85,23 @@ var roomCreatedAt = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
 // Mirror the production caps (house pattern — see maxGetByIDsBatchSize in messages_test).
 const roomsGetMaxBatch = 100
+
+func TestHistoryService_RoomsGet_PreviewCacheHitSkipsRead(t *testing.T) {
+	svc, msgs, rooms := newRoomsServiceWithPreviewCache(t)
+
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil).Times(1)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{
+			{MessageID: "m1", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt, Sender: models.Participant{Account: "alice"}},
+		}, false), nil).Times(1)
+
+	for i := 0; i < 3; i++ {
+		resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+		require.NoError(t, err)
+		require.Equal(t, "m1", resp.Rooms["r1"].MessageID)
+	}
+	// Times(1) on both reads asserts the 2nd and 3rd calls were cache hits.
+}
 
 func TestHistoryService_RoomsGet_LatestMessage(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)

--- a/history-service/internal/service/service.go
+++ b/history-service/internal/service/service.go
@@ -101,6 +101,22 @@ type AppStore interface {
 	AppNameByAccount(ctx context.Context, botAccount string) (string, error)
 }
 
+// PreviewCache fronts the per-room preview resolve on the rooms.get read path.
+// Positives are cached; not-found and errors pass through. *readcache.PreviewCache
+// satisfies it.
+type PreviewCache interface {
+	Get(ctx context.Context, roomID string, load func(context.Context) (models.PreviewMessage, bool, error)) (models.PreviewMessage, bool, error)
+}
+
+// Option configures optional HistoryService dependencies.
+type Option func(*HistoryService)
+
+// WithPreviewCache installs a room-preview cache used by RoomsGet. Without it,
+// previews resolve directly (uncached).
+func WithPreviewCache(pc PreviewCache) Option {
+	return func(s *HistoryService) { s.previewCache = pc }
+}
+
 // HistoryService handles message history queries and mutations. Transport-agnostic.
 type HistoryService struct {
 	msgReader          MessageReader
@@ -116,6 +132,7 @@ type HistoryService struct {
 	largeRoomThreshold int
 	maxPinnedPerRoom   int
 	pinEnabled         bool // from PIN_ENABLED env var; false disables pin/unpin globally
+	previewCache       PreviewCache
 }
 
 func New(
@@ -128,8 +145,9 @@ func New(
 	users UserStore,
 	apps AppStore,
 	cfg *config.Config,
+	opts ...Option,
 ) *HistoryService {
-	return &HistoryService{
+	s := &HistoryService{
 		msgReader:          msgs,
 		msgWriter:          msgs,
 		subscriptions:      subs,
@@ -144,6 +162,10 @@ func New(
 		maxPinnedPerRoom:   cfg.MaxPinnedPerRoom,
 		pinEnabled:         cfg.PinEnabled,
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // RegisterHandlers wires all NATS endpoints. Panics on subscription failure (fatal at startup).


### PR DESCRIPTION
## Summary

Phase 1 read-path optimization for `rooms.get` — the RPC that resolves each room's last-message preview for `subscription.list`. **Zero write-path changes, no client-facing wire change.** It replaces a fixed 50-row Cassandra bucket-walk with a single small query in the common case, and adds an optional short-TTL cache so repeated sidebar loads can skip the read entirely.

## What changed

- **Single-query preview walk** (`internal/service/rooms.go`): the fixed 50-row page becomes a small-first-page (1) geometric ×8 escalation, clamped to the codebase-wide 100-row/query cap, terminating on the walker's authoritative `!page.HasNext` signal and preserving the previous ≤250 ineligible-skip scan budget. The common case (newest message eligible) is now a single 1-row query instead of 50.
- **`readcache.PreviewCache`** (`internal/readcache/readcache.go`): positives-only LRU + TTL cache with singleflight, reusing the existing `ttlCache` primitive and `cachemetrics`. Only `found=true` results are cached; not-found and errors re-resolve.
- **Service wiring** (`internal/service/service.go`, `internal/config/config.go`, `cmd/main.go`): optional dependency via a backward-compatible variadic `New(..., opts ...Option)` + `WithPreviewCache`; `RoomsGet` routes through a `resolvePreview` helper. `previewAfterMutation` (edit/delete) intentionally stays **uncached** so mutations always resolve fresh state. New env: `PREVIEW_CACHE_SIZE` / `PREVIEW_CACHE_TTL` — the cache is off unless both are > 0.
- **Batch-size metric** (`internal/service/metrics.go`): a `rooms.get` distinct-room-count histogram to inform the Phase 2 go/no-go decision.

## Design & scope

Design and implementation plan are included under `docs/superpowers/`. This is Phase 1 of a deliberately phased approach: Phase 1 is read-only (this PR); Phase 2 — denormalizing the preview onto the subscription document, a write-path change — is **gated on the batch-size metric shipped here** and is out of scope. Post-mutation preview staleness is bounded by the short TTL and covered by real-time delivery to open clients — an intended, documented trade-off.

## Testing

- `make test SERVICE=history-service` — green under `-race`. New tests: size-1 single-query, 1→8 escalation past an ineligible tail, budget-exhaustion asserting the exact escalation `[1, 8, 64, 100, 77]`, cache-hit-skips-read, positives-only + singleflight dedup, and config validation.
- `make lint` — clean.
- Integration tests (`make test-integration`, testcontainers) run in CI — not runnable in this environment (no Docker), so the real-Cassandra bucket-walk should be verified by CI before merge.

## Notes

- The branch is 1 commit behind `main` (`#168`); that change touches subscription/room-worker code with no history-service overlap, so there is no conflict.
- The PR includes the design spec and the implementation plan as `docs/superpowers/` artifacts — happy to drop the plan doc if you'd prefer a leaner PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QDB82Mu4219m9ENo5okXL

---
_Generated by [Claude Code](https://claude.ai/code/session_015QDB82Mu4219m9ENo5okXL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved room-list preview retrieval with adaptive read sizing, reducing unnecessary data scans.
  * Added short-lived caching to speed up repeated room preview requests.
  * Added safeguards to limit preview scanning and maintain responsive behavior.

* **Configuration**
  * Added settings to enable, disable, and tune preview caching.

* **Monitoring**
  * Added telemetry for preview request batch sizes and cache activity.

* **Documentation & Tests**
  * Added design and implementation documentation plus coverage for caching and preview retrieval scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->