### PR TITLE
perf(history-service): batch room-times reads + caller hints for rooms.get

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -2652,7 +2652,7 @@ The paginated read RPCs (Load History, Load Next, Load Surrounding, Get Thread M
 - `meta.lastMsgAt` — the room's most-recent-message time, as the client knows it from the room summary (the same `lastMsgAt` carried on `RoomEvent`s / the sidebar). **A valid `lastMsgAt` alone is sufficient to skip the lookup.** Use the room's last-activity timestamp; for an empty room use its `createdAt`.
 - `meta.createdAt` — the room's creation time from the room summary. Optional refinement: when present it floors the scan at the room's creation time instead of the server's default history window; when omitted the server still skips the lookup and simply uses that default floor.
 
-Both are **hints, not authority**: the server sanitizes them (ignores values that are negative, in the future, or mutually inconsistent) and falls back to a MongoDB fetch only when `lastMsgAt` is missing or fails sanitization. A client that does not have `lastMsgAt` should omit `meta` entirely — correctness is unaffected, only an extra lookup is incurred.
+Both are **hints, not authority**: the server sanitizes each (values that are negative or in the future are ignored) and falls back to a MongoDB fetch when `lastMsgAt` is missing or fails sanitization — or when both are supplied but mutually inconsistent (a `createdAt` later than `lastMsgAt`), which triggers a re-fetch to resolve the inconsistency. A client that does not have `lastMsgAt` should omit `meta` entirely — correctness is unaffected, only an extra lookup is incurred.
 
 Common error envelopes across these RPCs (see §6 for the full shape):
 

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -2644,15 +2644,15 @@ The paginated read RPCs (Load History, Load Next, Load Surrounding, Get Thread M
 
 | Field | Type | Notes |
 |---|---|---|
-| `lastMsgAt` | number | Optional. Room's most-recent-message time, UTC ms. |
-| `createdAt` | number | Optional. Room's creation time, UTC ms. |
+| `lastMsgAt` | number | Optional. Room's most-recent-message time, UTC ms. Supplying a valid value is what lets the server skip its MongoDB lookup. |
+| `createdAt` | number | Optional. Room's creation time, UTC ms. A refinement only — narrows the scan's lower bound; its absence never forces a lookup. |
 
-**What to pass for `meta`:** the server needs the room's `lastMsgAt` and `createdAt` to pick the Cassandra time-bucket window to scan. `meta` lets the client supply the values it already holds so the server can skip a MongoDB lookup:
+**What to pass for `meta`:** the server uses the room's `lastMsgAt` to pick the Cassandra time-bucket window to scan (and, when given, `createdAt` as the scan's lower bound). `meta` lets the client supply the values it already holds so the server can skip a MongoDB lookup:
 
-- `meta.lastMsgAt` — the room's most-recent-message time, as the client knows it from the room summary (the same `lastMsgAt` carried on `RoomEvent`s / the sidebar). Use the room's last-activity timestamp; for an empty room use its `createdAt`.
-- `meta.createdAt` — the room's creation time from the room summary.
+- `meta.lastMsgAt` — the room's most-recent-message time, as the client knows it from the room summary (the same `lastMsgAt` carried on `RoomEvent`s / the sidebar). **A valid `lastMsgAt` alone is sufficient to skip the lookup.** Use the room's last-activity timestamp; for an empty room use its `createdAt`.
+- `meta.createdAt` — the room's creation time from the room summary. Optional refinement: when present it floors the scan at the room's creation time instead of the server's default history window; when omitted the server still skips the lookup and simply uses that default floor.
 
-Both are **hints, not authority**: the server sanitizes them (ignores values that are negative, in the future, or mutually inconsistent) and falls back to a MongoDB fetch when a value is missing or fails sanitization. A client that does not have these values should omit `meta` entirely — correctness is unaffected, only an extra lookup is incurred.
+Both are **hints, not authority**: the server sanitizes them (ignores values that are negative, in the future, or mutually inconsistent) and falls back to a MongoDB fetch only when `lastMsgAt` is missing or fails sanitization. A client that does not have `lastMsgAt` should omit `meta` entirely — correctness is unaffected, only an extra lookup is incurred.
 
 Common error envelopes across these RPCs (see §6 for the full shape):
 

--- a/history-service/internal/mongorepo/room.go
+++ b/history-service/internal/mongorepo/room.go
@@ -57,6 +57,38 @@ func (r *RoomRepo) GetRoomTimes(ctx context.Context, roomID string) (lastMsgAt, 
 	return lastMsgAt, room.CreatedAt, nil
 }
 
+// RoomTimes holds the two room timestamps GetRoomTimesByIDs projects.
+type RoomTimes struct {
+	LastMsgAt time.Time
+	CreatedAt time.Time
+}
+
+// GetRoomTimesByIDs batches GetRoomTimes across ids into a single $in query,
+// returning a map keyed by room ID. Rooms absent from Mongo are simply absent
+// from the map (not an error). Empty ids returns an empty, non-nil map with no query.
+func (r *RoomRepo) GetRoomTimesByIDs(ctx context.Context, ids []string) (map[string]RoomTimes, error) {
+	out := make(map[string]RoomTimes, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	rooms, err := r.rooms.FindMany(ctx,
+		bson.M{"_id": bson.M{"$in": ids}},
+		mongoutil.WithProjection(bson.M{"_id": 1, "lastMsgAt": 1, "createdAt": 1}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get room times for %d rooms: %w", len(ids), err)
+	}
+	for i := range rooms {
+		room := &rooms[i]
+		var lastMsgAt time.Time
+		if room.LastMsgAt != nil {
+			lastMsgAt = *room.LastMsgAt
+		}
+		out[room.ID] = RoomTimes{LastMsgAt: lastMsgAt, CreatedAt: room.CreatedAt}
+	}
+	return out, nil
+}
+
 // GetRoomUserCount returns the room's userCount via a projected findOne.
 // Returns mongo.ErrNoDocuments wrapped when the room does not exist —
 // callers treat that as an infrastructure error (reaching this call already

--- a/history-service/internal/mongorepo/room_test.go
+++ b/history-service/internal/mongorepo/room_test.go
@@ -64,6 +64,79 @@ func TestRoomRepo_GetRoomTimes_NotFound(t *testing.T) {
 	require.ErrorIs(t, err, mongo.ErrNoDocuments)
 }
 
+func TestRoomRepo_GetRoomTimesByIDs(t *testing.T) {
+	db := setupMongo(t)
+	repo := NewRoomRepo(db)
+
+	createdAt1 := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	lastMsgAt1 := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	createdAt2 := time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)
+	lastMsgAt2 := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+
+	rooms := []model.Room{
+		{
+			ID:        "batch-room-1",
+			SiteID:    "site-A",
+			Type:      model.RoomTypeChannel,
+			CreatedAt: createdAt1,
+			LastMsgAt: &lastMsgAt1,
+		},
+		{
+			ID:        "batch-room-2",
+			SiteID:    "site-A",
+			Type:      model.RoomTypeChannel,
+			CreatedAt: createdAt2,
+			LastMsgAt: &lastMsgAt2,
+		},
+	}
+	for _, room := range rooms {
+		_, err := db.Collection("rooms").InsertOne(context.Background(), room)
+		require.NoError(t, err)
+	}
+
+	got, err := repo.GetRoomTimesByIDs(context.Background(), []string{"batch-room-1", "batch-room-2", "missing-room"})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	assert.Equal(t, lastMsgAt1.UTC(), got["batch-room-1"].LastMsgAt.UTC())
+	assert.Equal(t, createdAt1.UTC(), got["batch-room-1"].CreatedAt.UTC())
+	assert.Equal(t, lastMsgAt2.UTC(), got["batch-room-2"].LastMsgAt.UTC())
+	assert.Equal(t, createdAt2.UTC(), got["batch-room-2"].CreatedAt.UTC())
+
+	_, missingPresent := got["missing-room"]
+	assert.False(t, missingPresent, "missing room should be omitted, not an error")
+}
+
+func TestRoomRepo_GetRoomTimesByIDs_NoLastMsg(t *testing.T) {
+	db := setupMongo(t)
+	repo := NewRoomRepo(db)
+
+	createdAt := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	_, err := db.Collection("rooms").InsertOne(context.Background(), bson.M{
+		"_id":       "batch-room-no-lastmsg",
+		"siteId":    "site-A",
+		"type":      "channel",
+		"createdAt": createdAt,
+	})
+	require.NoError(t, err)
+
+	got, err := repo.GetRoomTimesByIDs(context.Background(), []string{"batch-room-no-lastmsg"})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.True(t, got["batch-room-no-lastmsg"].LastMsgAt.IsZero(), "lastMsgAt absent -> zero time")
+	assert.Equal(t, createdAt.UTC(), got["batch-room-no-lastmsg"].CreatedAt.UTC())
+}
+
+func TestRoomRepo_GetRoomTimesByIDs_Empty(t *testing.T) {
+	db := setupMongo(t)
+	repo := NewRoomRepo(db)
+
+	got, err := repo.GetRoomTimesByIDs(context.Background(), []string{})
+	require.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
 func TestRoomRepo_GetMinUserLastSeenAt_Set(t *testing.T) {
 	db := setupMongo(t)
 	repo := NewRoomRepo(db)

--- a/history-service/internal/readcache/readcache.go
+++ b/history-service/internal/readcache/readcache.go
@@ -17,6 +17,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2/expirable"
 	"golang.org/x/sync/singleflight"
 
+	"github.com/hmchangw/chat/history-service/internal/mongorepo"
 	"github.com/hmchangw/chat/pkg/cachemetrics"
 	pkgmodel "github.com/hmchangw/chat/pkg/model"
 )
@@ -150,6 +151,7 @@ func (c *SubscriptionCache) GetSubscription(ctx context.Context, account, roomID
 // RoomSource is the room metadata reads the cache fronts.
 type RoomSource interface {
 	GetRoomTimes(ctx context.Context, roomID string) (lastMsgAt, createdAt time.Time, err error)
+	GetRoomTimesByIDs(ctx context.Context, ids []string) (map[string]mongorepo.RoomTimes, error)
 	GetMinUserLastSeenAt(ctx context.Context, roomID string) (*time.Time, error)
 	GetRoomUserCount(ctx context.Context, roomID string) (int, error)
 }
@@ -213,6 +215,14 @@ func (c *RoomCache) GetMinUserLastSeenAt(ctx context.Context, roomID string) (*t
 // large-room pin check needs the live member count, not a cached one.
 func (c *RoomCache) GetRoomUserCount(ctx context.Context, roomID string) (int, error) {
 	return c.inner.GetRoomUserCount(ctx, roomID)
+}
+
+// GetRoomTimesByIDs bypasses the per-key cache and delegates to the source.
+// It is a batch read for rooms without a usable caller-supplied hint, called
+// at most once per RoomsGet request — not a hot single-room path — so there is
+// no per-room caching benefit to justify the bookkeeping.
+func (c *RoomCache) GetRoomTimesByIDs(ctx context.Context, ids []string) (map[string]mongorepo.RoomTimes, error) {
+	return c.inner.GetRoomTimesByIDs(ctx, ids)
 }
 
 // previewEntry is the cached resolved room preview. found=false is never stored

--- a/history-service/internal/readcache/readcache_test.go
+++ b/history-service/internal/readcache/readcache_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hmchangw/chat/history-service/internal/mongorepo"
 	pkgmodel "github.com/hmchangw/chat/pkg/model"
 )
 
@@ -148,13 +149,17 @@ func TestNewSubscriptionCache_InvalidConfig(t *testing.T) {
 }
 
 type fakeRoomSource struct {
-	timesCalls   atomic.Int32
-	minSeenCalls atomic.Int32
-	lastMsgAt    time.Time
-	createdAt    time.Time
-	timesErr     error
-	minSeen      *time.Time
-	minSeenErr   error
+	timesCalls      atomic.Int32
+	minSeenCalls    atomic.Int32
+	lastMsgAt       time.Time
+	createdAt       time.Time
+	timesErr        error
+	minSeen         *time.Time
+	minSeenErr      error
+	timesByIDsCalls atomic.Int32
+	timesByIDsIDs   []string
+	timesByIDs      map[string]mongorepo.RoomTimes
+	timesByIDsErr   error
 }
 
 func (f *fakeRoomSource) GetRoomTimes(_ context.Context, _ string) (time.Time, time.Time, error) {
@@ -169,6 +174,15 @@ func (f *fakeRoomSource) GetMinUserLastSeenAt(_ context.Context, _ string) (*tim
 
 func (f *fakeRoomSource) GetRoomUserCount(_ context.Context, _ string) (int, error) {
 	return 0, nil
+}
+
+func (f *fakeRoomSource) GetRoomTimesByIDs(_ context.Context, ids []string) (map[string]mongorepo.RoomTimes, error) {
+	f.timesByIDsCalls.Add(1)
+	f.timesByIDsIDs = ids
+	if f.timesByIDsErr != nil {
+		return nil, f.timesByIDsErr
+	}
+	return f.timesByIDs, nil
 }
 
 func TestRoomCache_CachesRoomTimes(t *testing.T) {
@@ -229,6 +243,34 @@ func TestRoomCache_MinUserLastSeenAtValue(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, ts, *got)
+}
+
+func TestRoomCache_GetRoomTimesByIDs_BypassesCache(t *testing.T) {
+	want := map[string]mongorepo.RoomTimes{
+		"r1": {LastMsgAt: time.Now().UTC(), CreatedAt: time.Now().UTC().Add(-time.Hour)},
+	}
+	src := &fakeRoomSource{timesByIDs: want}
+	c, err := NewRoomCache(src, 100, time.Minute)
+	require.NoError(t, err)
+
+	got, err := c.GetRoomTimesByIDs(context.Background(), []string{"r1", "r2"})
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+
+	_, err = c.GetRoomTimesByIDs(context.Background(), []string{"r1", "r2"})
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), src.timesByIDsCalls.Load(), "batch read is never cached")
+	assert.Equal(t, []string{"r1", "r2"}, src.timesByIDsIDs)
+}
+
+func TestRoomCache_GetRoomTimesByIDs_PropagatesError(t *testing.T) {
+	wantErr := errors.New("mongo down")
+	src := &fakeRoomSource{timesByIDsErr: wantErr}
+	c, err := NewRoomCache(src, 100, time.Minute)
+	require.NoError(t, err)
+
+	_, err = c.GetRoomTimesByIDs(context.Background(), []string{"r1"})
+	require.ErrorIs(t, err, wantErr)
 }
 
 func TestSubscriptionCache_LeaderCancelDoesNotPoisonWaiters(t *testing.T) {

--- a/history-service/internal/service/integration_test.go
+++ b/history-service/internal/service/integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hmchangw/chat/history-service/internal/cassrepo"
 	"github.com/hmchangw/chat/history-service/internal/config"
 	"github.com/hmchangw/chat/history-service/internal/models"
+	"github.com/hmchangw/chat/history-service/internal/mongorepo"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/pkg/msgbucket"
@@ -149,6 +150,10 @@ func (stubRoomRepo) GetMinUserLastSeenAt(_ context.Context, _ string) (*time.Tim
 func (stubRoomRepo) GetRoomTimes(_ context.Context, _ string) (lastMsgAt, createdAt time.Time, err error) {
 	now := time.Now().UTC()
 	return now, now.AddDate(-1, 0, 0), nil
+}
+
+func (stubRoomRepo) GetRoomTimesByIDs(_ context.Context, _ []string) (map[string]mongorepo.RoomTimes, error) {
+	return map[string]mongorepo.RoomTimes{}, nil
 }
 
 func (stubRoomRepo) GetRoomUserCount(_ context.Context, _ string) (int, error) {

--- a/history-service/internal/service/messages.go
+++ b/history-service/internal/service/messages.go
@@ -648,7 +648,7 @@ func (s *HistoryService) previewAfterMutation(c *natsrouter.Context, msg *models
 	if msg.ThreadParentID != "" && !msg.TShow {
 		return nil
 	}
-	if preview, ok := s.roomLastPreviewMessage(c, roomID, at); ok {
+	if preview, ok := s.roomLastPreviewMessage(c, roomID, nil, at); ok {
 		return &preview
 	}
 	return nil

--- a/history-service/internal/service/mocks/mock_repository.go
+++ b/history-service/internal/service/mocks/mock_repository.go
@@ -650,6 +650,21 @@ func (mr *MockRoomRepositoryMockRecorder) GetRoomTimes(ctx, roomID any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRoomTimes", reflect.TypeOf((*MockRoomRepository)(nil).GetRoomTimes), ctx, roomID)
 }
 
+// GetRoomTimesByIDs mocks base method.
+func (m *MockRoomRepository) GetRoomTimesByIDs(ctx context.Context, ids []string) (map[string]mongorepo.RoomTimes, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRoomTimesByIDs", ctx, ids)
+	ret0, _ := ret[0].(map[string]mongorepo.RoomTimes)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRoomTimesByIDs indicates an expected call of GetRoomTimesByIDs.
+func (mr *MockRoomRepositoryMockRecorder) GetRoomTimesByIDs(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRoomTimesByIDs", reflect.TypeOf((*MockRoomRepository)(nil).GetRoomTimesByIDs), ctx, ids)
+}
+
 // GetRoomUserCount mocks base method.
 func (m *MockRoomRepository) GetRoomUserCount(ctx context.Context, roomID string) (int, error) {
 	m.ctrl.T.Helper()

--- a/history-service/internal/service/room_times.go
+++ b/history-service/internal/service/room_times.go
@@ -59,6 +59,12 @@ func (s *HistoryService) walkBounds(lastMsgAt, createdAt, now time.Time) (ceilin
 
 // resolveRoomTimes returns lastMsgAt/createdAt for roomID: sanitized client hints are trusted,
 // missing or invalid ones fall back to Mongo. now is injected for deterministic testing.
+//
+// A usable lastMsgAt hint is sufficient on its own to skip Mongo entirely — createdAt only
+// feeds walkBounds' floor, which is clamped to now-historyFloor, so a zero createdAt (the
+// case when no hint supplied one) simply collapses the floor to that clamp. Only a missing
+// or invalid lastMsgAt forces the per-room Mongo read (which then also fills createdAt when
+// the hint didn't supply a usable one).
 func (s *HistoryService) resolveRoomTimes(
 	ctx context.Context,
 	roomID string,
@@ -78,17 +84,18 @@ func (s *HistoryService) resolveRoomTimes(
 		}
 	}
 
-	if last == nil || created == nil {
+	if last == nil {
 		l, c, gerr := s.rooms.GetRoomTimes(ctx, roomID)
 		if gerr != nil {
 			return time.Time{}, time.Time{}, fmt.Errorf("resolve room times for %s: %w", roomID, gerr)
 		}
-		if last == nil {
-			last = &l
-		}
+		last = &l
 		if created == nil {
 			created = &c
 		}
+	}
+	if created == nil {
+		created = &time.Time{}
 	}
 
 	// A merged hint+Mongo pair can be internally inconsistent (created > last): refetch from

--- a/history-service/internal/service/room_times.go
+++ b/history-service/internal/service/room_times.go
@@ -62,9 +62,11 @@ func (s *HistoryService) walkBounds(lastMsgAt, createdAt, now time.Time) (ceilin
 //
 // A usable lastMsgAt hint is sufficient on its own to skip Mongo entirely — createdAt only
 // feeds walkBounds' floor, which is clamped to now-historyFloor, so a zero createdAt (the
-// case when no hint supplied one) simply collapses the floor to that clamp. Only a missing
-// or invalid lastMsgAt forces the per-room Mongo read (which then also fills createdAt when
-// the hint didn't supply a usable one).
+// case when no hint supplied one) simply collapses the floor to that clamp. A missing or
+// invalid lastMsgAt forces the per-room Mongo read (which then also fills createdAt when
+// the hint didn't supply a usable one). One further case forces a read: if the hint supplies
+// BOTH times but they are mutually inconsistent (createdAt later than lastMsgAt), the pair is
+// re-fetched from Mongo to resolve the inconsistency (see the consistency block below).
 func (s *HistoryService) resolveRoomTimes(
 	ctx context.Context,
 	roomID string,

--- a/history-service/internal/service/room_times_test.go
+++ b/history-service/internal/service/room_times_test.go
@@ -36,9 +36,14 @@ func TestResolveRoomTimes(t *testing.T) {
 		{name: "no meta → mongo fallback", meta: nil, mongoCalls: 1, wantLast: last, wantCreated: created},
 		{name: "both meta valid → no mongo", meta: &models.RoomMeta{LastMsgAt: tsPtr(last), CreatedAt: tsPtr(created)}, mongoCalls: 0, wantLast: last, wantCreated: created},
 		{name: "lastMsgAt missing → mongo fallback for both", meta: &models.RoomMeta{CreatedAt: tsPtr(created)}, mongoCalls: 1, wantLast: last, wantCreated: created},
-		{name: "createdAt missing → mongo fallback for both", meta: &models.RoomMeta{LastMsgAt: tsPtr(last)}, mongoCalls: 1, wantLast: last, wantCreated: created},
+		// Relaxation: a usable lastMsgAt hint alone is sufficient — createdAt only feeds
+		// walkBounds' floor (clamped to now-historyFloor), so this must NOT read Mongo;
+		// createdAt comes back zero rather than Mongo's value.
+		{name: "createdAt missing → lastMsgAt hint alone skips mongo", meta: &models.RoomMeta{LastMsgAt: tsPtr(last)}, mongoCalls: 0, wantLast: last, wantCreated: time.Time{}},
 		{name: "lastMsgAt too far in future → ignored", meta: &models.RoomMeta{LastMsgAt: tsPtr(future), CreatedAt: tsPtr(created)}, mongoCalls: 1, wantLast: last, wantCreated: created},
-		{name: "createdAt in future → ignored", meta: &models.RoomMeta{LastMsgAt: tsPtr(last), CreatedAt: tsPtr(future)}, mongoCalls: 1, wantLast: last, wantCreated: created},
+		// Same relaxation as above: lastMsgAt alone is valid, so an out-of-range createdAt
+		// hint is simply dropped (zero), not fetched from Mongo.
+		{name: "createdAt in future → ignored", meta: &models.RoomMeta{LastMsgAt: tsPtr(last), CreatedAt: tsPtr(future)}, mongoCalls: 0, wantLast: last, wantCreated: time.Time{}},
 		{name: "implausibly old values (pre-2020) → ignored", meta: &models.RoomMeta{LastMsgAt: msPtr(0), CreatedAt: msPtr(0)}, mongoCalls: 1, wantLast: last, wantCreated: created},
 		// Hint pair is internally inconsistent (createdAt > lastMsgAt). Both meta are
 		// individually sane, so they pass sanitization; the consistency-refetch path

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -45,6 +45,7 @@ func (s *HistoryService) RoomsGet(c *natsrouter.Context, req models.RoomsGetRequ
 	ids := dedupRoomIDs(req.RoomIDs)
 	roomsGetBatchSize.Record(c, int64(len(ids)))
 	now := time.Now().UTC()
+	metaByRoom := s.resolveRoomMetaHints(c, ids, req.Hints, now)
 
 	out := make(map[string]models.PreviewMessage, len(ids))
 	var mu sync.Mutex
@@ -63,7 +64,7 @@ func (s *HistoryService) RoomsGet(c *natsrouter.Context, req models.RoomsGetRequ
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
-			lm, ok := s.resolvePreview(c, roomID, now)
+			lm, ok := s.resolvePreview(c, roomID, metaByRoom[roomID], now)
 			if !ok {
 				return
 			}
@@ -77,16 +78,64 @@ func (s *HistoryService) RoomsGet(c *natsrouter.Context, req models.RoomsGetRequ
 	return &models.RoomsGetResponse{Rooms: out}, nil
 }
 
+// resolveRoomMetaHints maps req.Hints into a per-room *models.RoomMeta and batches ONE
+// GetRoomTimesByIDs read for the rooms whose hint doesn't resolve to a usable lastMsgAt
+// (missing entirely, or rejected by the same sanitizeLastMsgAt every per-room resolve uses).
+// A batch-read failure degrades: those rooms simply keep a nil meta, so the per-room
+// resolveRoomTimes falls back to its existing GetRoomTimes read — the batch failure never
+// fails the whole RPC.
+func (s *HistoryService) resolveRoomMetaHints(
+	ctx context.Context,
+	ids []string,
+	hints map[string]pkgmodel.RoomTimeHint,
+	now time.Time,
+) map[string]*models.RoomMeta {
+	metaByRoom := make(map[string]*models.RoomMeta, len(ids))
+	unhinted := make([]string, 0, len(ids))
+	for _, roomID := range ids {
+		hint, ok := hints[roomID]
+		if !ok || sanitizeLastMsgAt(hint.LastMsgAt, now) == nil {
+			unhinted = append(unhinted, roomID)
+			continue
+		}
+		metaByRoom[roomID] = &models.RoomMeta{LastMsgAt: hint.LastMsgAt, CreatedAt: hint.CreatedAt}
+	}
+	if len(unhinted) == 0 {
+		return metaByRoom
+	}
+
+	times, err := s.rooms.GetRoomTimesByIDs(ctx, unhinted)
+	if err != nil {
+		slog.WarnContext(ctx, "rooms.get batch room-times read degraded, falling back per-room",
+			"room_count", len(unhinted), "request_id", natsutil.RequestIDFromContext(ctx), "error", err)
+		return metaByRoom
+	}
+	for roomID, rt := range times {
+		if rt.LastMsgAt.IsZero() {
+			// Never-messaged room: nothing usable to hint. Leave the meta nil so
+			// resolveRoomTimes takes its plain meta==nil path (one full per-room
+			// GetRoomTimes, normalized directly) instead of treating a synthetic zero
+			// lastMsgAt as a "hint" and tripping the created>last consistency refetch.
+			continue
+		}
+		last := rt.LastMsgAt.UnixMilli()
+		created := rt.CreatedAt.UnixMilli()
+		metaByRoom[roomID] = &models.RoomMeta{LastMsgAt: &last, CreatedAt: &created}
+	}
+	return metaByRoom
+}
+
 // resolvePreview resolves one room's preview, serving it from the preview cache
 // when installed. The cache is positives-only, so empty rooms and read failures
-// fall through to a fresh resolve. previewAfterMutation (edit/delete) keeps
-// calling roomLastPreviewMessage directly so mutations always see fresh state.
-func (s *HistoryService) resolvePreview(ctx context.Context, roomID string, now time.Time) (models.PreviewMessage, bool) {
+// fall through to a fresh resolve. meta is the caller/batch-resolved times hint
+// (nil when none applies); previewAfterMutation (edit/delete) keeps calling
+// roomLastPreviewMessage directly with meta=nil so mutations always see fresh state.
+func (s *HistoryService) resolvePreview(ctx context.Context, roomID string, meta *models.RoomMeta, now time.Time) (models.PreviewMessage, bool) {
 	if s.previewCache == nil {
-		return s.roomLastPreviewMessage(ctx, roomID, now)
+		return s.roomLastPreviewMessage(ctx, roomID, meta, now)
 	}
 	preview, ok, err := s.previewCache.Get(ctx, roomID, func(ctx context.Context) (models.PreviewMessage, bool, error) {
-		p, found := s.roomLastPreviewMessage(ctx, roomID, now)
+		p, found := s.roomLastPreviewMessage(ctx, roomID, meta, now)
 		return p, found, nil
 	})
 	if err != nil {
@@ -97,10 +146,13 @@ func (s *HistoryService) resolvePreview(ctx context.Context, roomID string, now 
 }
 
 // roomLastPreviewMessage resolves one room's latest eligible preview message at read time.
-// ok=false means drop the room (empty, all-ineligible within the walk cap, or a read
-// failure). Walks backward from lastMsgAt in pages, skipping ineligible messages.
-func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID string, now time.Time) (models.PreviewMessage, bool) {
-	lastMsgAt, createdAt, err := s.resolveRoomTimesOrError(ctx, roomID, nil, now)
+// meta, when non-nil, is a caller/batch-resolved room-times hint that lets resolveRoomTimes
+// skip its own Mongo read (see resolveRoomMetaHints / resolveRoomTimes); pass nil to always
+// resolve fresh (previewAfterMutation's contract). ok=false means drop the room (empty,
+// all-ineligible within the walk cap, or a read failure). Walks backward from lastMsgAt in
+// pages, skipping ineligible messages.
+func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID string, meta *models.RoomMeta, now time.Time) (models.PreviewMessage, bool) {
+	lastMsgAt, createdAt, err := s.resolveRoomTimesOrError(ctx, roomID, meta, now)
 	if err != nil {
 		slog.WarnContext(ctx, "rooms.get room degraded", "room_id", roomID,
 			"request_id", natsutil.RequestIDFromContext(ctx), "error", err)

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -41,6 +41,11 @@ func (s *HistoryService) RoomsGet(c *natsrouter.Context, req models.RoomsGetRequ
 	if len(req.RoomIDs) > maxRoomsGetBatch {
 		return nil, errcode.BadRequest("too many roomIds")
 	}
+	// Hints are only ever consulted for the (capped) requested room IDs, so a larger
+	// map is malformed; reject it symmetrically rather than unmarshal/allocate it.
+	if len(req.Hints) > maxRoomsGetBatch {
+		return nil, errcode.BadRequest("too many hints")
+	}
 
 	ids := dedupRoomIDs(req.RoomIDs)
 	roomsGetBatchSize.Record(c, int64(len(ids)))

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hmchangw/chat/history-service/internal/cassrepo"
 	"github.com/hmchangw/chat/history-service/internal/config"
 	"github.com/hmchangw/chat/history-service/internal/models"
+	"github.com/hmchangw/chat/history-service/internal/mongorepo"
 	readcache "github.com/hmchangw/chat/history-service/internal/readcache"
 	"github.com/hmchangw/chat/history-service/internal/service"
 	"github.com/hmchangw/chat/history-service/internal/service/mocks"
@@ -86,10 +87,33 @@ var roomCreatedAt = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 // Mirror the production caps (house pattern — see maxGetByIDsBatchSize in messages_test).
 const roomsGetMaxBatch = 100
 
+// stubRoomTimes arranges the single unhinted-batch read RoomsGet issues for ids (no Hints
+// in the request), returning last/created for every id — the common happy-path room times
+// most fixtures below share. gomock.Any() on the ids arg since most tests don't care about
+// exactly which ids were batched (TestHistoryService_RoomsGet_NoHints_BatchesAllIDs asserts
+// that explicitly).
+func stubRoomTimes(rooms *mocks.MockRoomRepository, ids []string, last, created time.Time) {
+	stubRoomTimesN(rooms, ids, last, created, 1)
+}
+
+// stubRoomTimesN is stubRoomTimes with an explicit call count, for tests (e.g. the preview-cache
+// ones) that invoke RoomsGet more than once for the same unhinted room set.
+func stubRoomTimesN(rooms *mocks.MockRoomRepository, ids []string, last, created time.Time, times int) {
+	out := make(map[string]mongorepo.RoomTimes, len(ids))
+	for _, id := range ids {
+		out[id] = mongorepo.RoomTimes{LastMsgAt: last, CreatedAt: created}
+	}
+	rooms.EXPECT().GetRoomTimesByIDs(gomock.Any(), gomock.Any()).Return(out, nil).Times(times)
+}
+
 func TestHistoryService_RoomsGet_PreviewCacheHitSkipsRead(t *testing.T) {
 	svc, msgs, rooms := newRoomsServiceWithPreviewCache(t)
 
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil).Times(1)
+	// The unhinted-batch Mongo read runs once per RoomsGet call regardless of the preview
+	// cache (it's resolved up front, before the per-room cache check) — Times(3) over the 3
+	// calls below. The expensive Cassandra preview walk is what the cache actually guards,
+	// so GetMessagesBefore staying at Times(1) is what proves the 2nd/3rd calls were cache hits.
+	stubRoomTimesN(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt, 3)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{
 			{MessageID: "m1", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt, Sender: models.Participant{Account: "alice"}},
@@ -100,13 +124,12 @@ func TestHistoryService_RoomsGet_PreviewCacheHitSkipsRead(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "m1", resp.Rooms["r1"].MessageID)
 	}
-	// Times(1) on both reads asserts the 2nd and 3rd calls were cache hits.
 }
 
 func TestHistoryService_RoomsGet_LatestMessage(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: "hello", CreatedAt: roomLastMsgAt, Sender: models.Participant{ID: "u1", Account: "alice"}}}, false), nil)
 
@@ -124,7 +147,7 @@ func TestHistoryService_RoomsGet_EligibleNewest_SingleQuery(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 
 	var sizes []int
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, _ string, _ time.Time, _ time.Time, pr cassrepo.PageRequest) (cassrepo.Page[models.Message], error) {
 			sizes = append(sizes, pr.PageSize)
@@ -144,7 +167,7 @@ func TestHistoryService_RoomsGet_EscalatesPastIneligibleTail(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 
 	var sizes []int
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, _ string, _ time.Time, _ time.Time, pr cassrepo.PageRequest) (cassrepo.Page[models.Message], error) {
 			sizes = append(sizes, pr.PageSize)
@@ -177,7 +200,7 @@ func TestHistoryService_RoomsGet_ScanBudgetExhausted_NoEligibleMessage(t *testin
 	svc, msgs, rooms := newRoomsService(t)
 
 	var sizes []int
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, _ string, _ time.Time, _ time.Time, pr cassrepo.PageRequest) (cassrepo.Page[models.Message], error) {
 			sizes = append(sizes, pr.PageSize)
@@ -200,6 +223,10 @@ func TestHistoryService_RoomsGet_ScanBudgetExhausted_NoEligibleMessage(t *testin
 func TestHistoryService_RoomsGet_EmptyRoomOmitted(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 
+	// The batched read returns a zero lastMsgAt (room never messaged); sanitizeLastMsgAt
+	// rejects the zero value the same way it would reject any implausible hint, so
+	// resolveRoomTimes falls back to the per-room GetRoomTimes read for this one room.
+	stubRoomTimes(rooms, []string{"r1"}, time.Time{}, roomCreatedAt)
 	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(time.Time{}, roomCreatedAt, nil)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage(nil, false), nil)
@@ -213,12 +240,11 @@ func TestHistoryService_RoomsGet_EmptyRoomOmitted(t *testing.T) {
 func TestHistoryService_RoomsGet_PerRoomDegradeKeepsSiblings(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 
-	// r1 history read errors → omitted; r2 succeeds → returned.
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	// r1 history read errors → omitted; r2 succeeds → returned. Both are unhinted, so
+	// they share the one batched GetRoomTimesByIDs([r1, r2]) call.
+	stubRoomTimes(rooms, []string{"r1", "r2"}, roomLastMsgAt, roomCreatedAt)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage(nil, false), errors.New("cassandra timeout"))
-
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r2").Return(roomLastMsgAt, roomCreatedAt, nil)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r2", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{{MessageID: "m2", RoomID: "r2", Msg: "ok", CreatedAt: roomLastMsgAt}}, false), nil)
 
@@ -232,7 +258,7 @@ func TestHistoryService_RoomsGet_PerRoomDegradeKeepsSiblings(t *testing.T) {
 func TestHistoryService_RoomsGet_SkipsDeletedTail(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{
 			{MessageID: "m3", RoomID: "r1", Msg: "", Deleted: true, CreatedAt: roomLastMsgAt},
@@ -251,7 +277,7 @@ func TestHistoryService_RoomsGet_SkipsDeletedTail(t *testing.T) {
 func TestHistoryService_RoomsGet_AllDeletedOmitted(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
 	// A short all-deleted page (below the walk page size) means no older messages
 	// remain, so a single read is enough to conclude "no last message".
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
@@ -269,7 +295,7 @@ func TestHistoryService_RoomsGet_DedupsRoomIDs(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 
 	// A duplicate roomId resolves once (Times(1) on each per-room read).
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil).Times(1)
+	stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: "x", CreatedAt: roomLastMsgAt}}, false), nil).Times(1)
 
@@ -283,7 +309,7 @@ func TestHistoryService_RoomsGet_FullContent(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 	long := strings.Repeat("世", 1000)
 
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: long, CreatedAt: roomLastMsgAt}}, false), nil)
 
@@ -297,7 +323,7 @@ func TestHistoryService_RoomsGet_FullContent(t *testing.T) {
 func TestHistoryService_RoomsGet_SkipsSystemTail(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{
 			{MessageID: "m2", RoomID: "r1", Type: model.MessageTypeRoomRenamed, CreatedAt: roomLastMsgAt},
@@ -319,7 +345,7 @@ func TestHistoryService_RoomsGet_SkipsEachSystemTypeButKeepsImportant(t *testing
 		model.MessageTypeTeamsMeetStarted,
 	} {
 		svc, msgs, rooms := newRoomsService(t)
-		rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+		stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
 		msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(makePage([]models.Message{
 				{MessageID: "m2", RoomID: "r1", Type: st, CreatedAt: roomLastMsgAt},
@@ -334,7 +360,7 @@ func TestHistoryService_RoomsGet_SkipsEachSystemTypeButKeepsImportant(t *testing
 
 func TestHistoryService_RoomsGet_KeepsImportantMessage(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{
 			{MessageID: "m2", RoomID: "r1", Msg: "urgent", Type: model.MessageTypeImportant, CreatedAt: roomLastMsgAt},
@@ -349,7 +375,7 @@ func TestHistoryService_RoomsGet_KeepsImportantMessage(t *testing.T) {
 func TestHistoryService_RoomsGet_QuotedReplyEligible(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{
 			{MessageID: "m2", RoomID: "r1", Msg: "re: x", QuotedParentMessage: &models.QuotedParentMessage{MessageID: "m0"}, CreatedAt: roomLastMsgAt},
@@ -367,7 +393,7 @@ func TestHistoryService_RoomsGet_QuotedReplyEligible(t *testing.T) {
 func TestHistoryService_RoomsGet_MixedTailSkipsIneligible(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{
 			{MessageID: "m4", RoomID: "r1", Type: model.MessageTypeMembersAdded, CreatedAt: roomLastMsgAt},
@@ -386,7 +412,7 @@ func TestHistoryService_RoomsGet_MixedTailSkipsIneligible(t *testing.T) {
 func TestHistoryService_RoomsGet_NormalMessageUnaffected(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt}}, false), nil)
 
@@ -419,7 +445,7 @@ func TestHistoryService_RoomsGet_EnrichesPreview(t *testing.T) {
 	svc, msgs, rooms, apps := newRoomsServiceWithApps(t)
 	apps.EXPECT().AppNameByAccount(gomock.Any(), gomock.Any()).Times(0) // no bot → no lookup
 
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{{
 			MessageID:   "m1",
@@ -452,7 +478,7 @@ func TestHistoryService_RoomsGet_BotSenderAppName(t *testing.T) {
 	svc, msgs, rooms, apps := newRoomsServiceWithApps(t)
 	apps.EXPECT().AppNameByAccount(gomock.Any(), "acme.bot").Return("Acme Assistant", nil)
 
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{{
 			MessageID: "m1", RoomID: "r1", Msg: "beep", CreatedAt: roomLastMsgAt,
@@ -469,7 +495,7 @@ func TestHistoryService_RoomsGet_BotSenderAppName(t *testing.T) {
 func TestHistoryService_RoomsGet_EmptyCollectionsOmitted(t *testing.T) {
 	svc, msgs, rooms, _ := newRoomsServiceWithApps(t)
 
-	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+	stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt, Sender: models.Participant{Account: "alice"}}}, false), nil)
 
@@ -484,4 +510,128 @@ func TestHistoryService_RoomsGet_EmptyCollectionsOmitted(t *testing.T) {
 	assert.NotContains(t, string(data), "attachments")
 	assert.NotContains(t, string(data), "mentions")
 	assert.NotContains(t, string(data), "visibleTo")
+}
+
+// msPtr converts a time to the UTC-millis pointer RoomTimeHint/RoomMeta wire fields use.
+func msPtr(t time.Time) *int64 {
+	ms := t.UnixMilli()
+	return &ms
+}
+
+// (a) Every room carries a usable lastMsgAt hint: resolveRoomTimes never needs Mongo at
+// all, so neither the per-room GetRoomTimes nor the batched GetRoomTimesByIDs is called.
+func TestHistoryService_RoomsGet_AllHinted_NoStoreReads(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), gomock.Any()).Times(0)
+	rooms.EXPECT().GetRoomTimesByIDs(gomock.Any(), gomock.Any()).Times(0)
+
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt}}, false), nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r2", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m2", RoomID: "r2", Msg: "hey", CreatedAt: roomLastMsgAt}}, false), nil)
+
+	req := models.RoomsGetRequest{
+		RoomIDs: []string{"r1", "r2"},
+		Hints: map[string]model.RoomTimeHint{
+			"r1": {LastMsgAt: msPtr(roomLastMsgAt)},                                  // lastMsgAt-only hint, still sufficient
+			"r2": {LastMsgAt: msPtr(roomLastMsgAt), CreatedAt: msPtr(roomCreatedAt)}, // both fields hinted
+		},
+	}
+	resp, err := svc.RoomsGet(roomsCtx(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
+	assert.Equal(t, "m2", resp.Rooms["r2"].MessageID)
+}
+
+// (b) No hints at all: the whole id set is unhinted, batched into exactly one
+// GetRoomTimesByIDs call carrying every id; the per-room GetRoomTimes is never used.
+func TestHistoryService_RoomsGet_NoHints_BatchesAllIDs(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), gomock.Any()).Times(0)
+	rooms.EXPECT().
+		GetRoomTimesByIDs(gomock.Any(), gomock.InAnyOrder([]string{"r1", "r2"})).
+		Return(map[string]mongorepo.RoomTimes{
+			"r1": {LastMsgAt: roomLastMsgAt, CreatedAt: roomCreatedAt},
+			"r2": {LastMsgAt: roomLastMsgAt, CreatedAt: roomCreatedAt},
+		}, nil).
+		Times(1)
+
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt}}, false), nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r2", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m2", RoomID: "r2", Msg: "hey", CreatedAt: roomLastMsgAt}}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1", "r2"}})
+	require.NoError(t, err)
+	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
+	assert.Equal(t, "m2", resp.Rooms["r2"].MessageID)
+}
+
+// (c) Mixed hinted/unhinted: only r2 (unhinted) is in the batch call; r1's hint means it
+// never reaches Mongo at all.
+func TestHistoryService_RoomsGet_MixedHints_BatchesOnlyUnhinted(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), gomock.Any()).Times(0)
+	rooms.EXPECT().
+		GetRoomTimesByIDs(gomock.Any(), []string{"r2"}).
+		Return(map[string]mongorepo.RoomTimes{"r2": {LastMsgAt: roomLastMsgAt, CreatedAt: roomCreatedAt}}, nil).
+		Times(1)
+
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt}}, false), nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r2", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m2", RoomID: "r2", Msg: "hey", CreatedAt: roomLastMsgAt}}, false), nil)
+
+	req := models.RoomsGetRequest{
+		RoomIDs: []string{"r1", "r2"},
+		Hints: map[string]model.RoomTimeHint{
+			"r1": {LastMsgAt: msPtr(roomLastMsgAt)},
+			// r2 has no entry in Hints at all → unhinted.
+		},
+	}
+	resp, err := svc.RoomsGet(roomsCtx(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
+	assert.Equal(t, "m2", resp.Rooms["r2"].MessageID)
+}
+
+// (d) The batch read errors: RoomsGet still succeeds. The unhinted room falls back through
+// resolveRoomTimes' existing per-room GetRoomTimes path — the batch failure never fails the RPC.
+func TestHistoryService_RoomsGet_BatchReadError_DegradesToPerRoomFallback(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+	rooms.EXPECT().
+		GetRoomTimesByIDs(gomock.Any(), []string{"r1"}).
+		Return(nil, errors.New("mongo down")).
+		Times(1)
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil)
+
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt}}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
+}
+
+// (e) An implausible hint lastMsgAt (pre-2020 epoch) is rejected by the same
+// sanitizeLastMsgAt every per-room resolve uses, so the room is treated as unhinted and
+// goes into the batch set instead of being trusted at face value.
+func TestHistoryService_RoomsGet_ImplausibleHint_TreatedAsUnhinted(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+	bogus := int64(0) // epoch 0 (1970) — before minPlausibleEpoch
+	rooms.EXPECT().
+		GetRoomTimesByIDs(gomock.Any(), []string{"r1"}).
+		Return(map[string]mongorepo.RoomTimes{"r1": {LastMsgAt: roomLastMsgAt, CreatedAt: roomCreatedAt}}, nil).
+		Times(1)
+
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt}}, false), nil)
+
+	req := models.RoomsGetRequest{
+		RoomIDs: []string{"r1"},
+		Hints:   map[string]model.RoomTimeHint{"r1": {LastMsgAt: &bogus}},
+	}
+	resp, err := svc.RoomsGet(roomsCtx(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
 }

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -632,6 +633,40 @@ func TestHistoryService_RoomsGet_ImplausibleHint_TreatedAsUnhinted(t *testing.T)
 		Hints:   map[string]model.RoomTimeHint{"r1": {LastMsgAt: &bogus}},
 	}
 	resp, err := svc.RoomsGet(roomsCtx(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
+}
+
+// An oversized Hints map is malformed (hints are only consulted for the capped
+// RoomIDs) and is rejected symmetrically with the RoomIDs cap, before any store read.
+func TestHistoryService_RoomsGet_TooManyHints_BadRequest(t *testing.T) {
+	svc, _, _ := newRoomsService(t)
+	hints := make(map[string]model.RoomTimeHint, roomsGetMaxBatch+1)
+	for i := 0; i <= roomsGetMaxBatch; i++ {
+		hints["r"+strconv.Itoa(i)] = model.RoomTimeHint{LastMsgAt: msPtr(roomLastMsgAt)}
+	}
+	_, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}, Hints: hints})
+	assertBadRequestErr(t, err, "too many hints")
+}
+
+// A requested unhinted room that GetRoomTimesByIDs does not return (e.g. deleted
+// between the caller's list read and this resolve, so it's absent from the batch
+// result map) keeps a nil meta and falls through to the per-room GetRoomTimes path —
+// it must not be silently dropped by the batch step.
+func TestHistoryService_RoomsGet_UnhintedRoomAbsentFromBatch_FallsBackPerRoom(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+	// Batch returns an empty map: r1 is unhinted but absent from the result.
+	rooms.EXPECT().
+		GetRoomTimesByIDs(gomock.Any(), []string{"r1"}).
+		Return(map[string]mongorepo.RoomTimes{}, nil).
+		Times(1)
+	// Absent from the batch → the per-room fallback fires exactly once.
+	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(roomLastMsgAt, roomCreatedAt, nil).Times(1)
+
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt}}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
 	require.NoError(t, err)
 	assert.Equal(t, "m1", resp.Rooms["r1"].MessageID)
 }

--- a/history-service/internal/service/service.go
+++ b/history-service/internal/service/service.go
@@ -59,11 +59,13 @@ type SubscriptionRepository interface {
 }
 
 // RoomRepository reads room metadata required by history handlers:
-// MinUserLastSeenAt as a per-user read-receipt floor surfaced to clients, and
-// GetRoomTimes (lastMsgAt, createdAt) for bucket-walk bounds.
+// MinUserLastSeenAt as a per-user read-receipt floor surfaced to clients,
+// GetRoomTimes (lastMsgAt, createdAt) for bucket-walk bounds, and
+// GetRoomTimesByIDs, the batched ($in) form for resolving many rooms at once.
 type RoomRepository interface {
 	GetMinUserLastSeenAt(ctx context.Context, roomID string) (*time.Time, error)
 	GetRoomTimes(ctx context.Context, roomID string) (lastMsgAt, createdAt time.Time, err error)
+	GetRoomTimesByIDs(ctx context.Context, ids []string) (map[string]mongorepo.RoomTimes, error)
 	GetRoomUserCount(ctx context.Context, roomID string) (int, error)
 }
 

--- a/pkg/model/message.go
+++ b/pkg/model/message.go
@@ -96,10 +96,21 @@ func (m *Message) SenderDisplayName() string {
 	return m.UserAccount
 }
 
+// RoomTimeHint is an optional caller-supplied walk-bounds hint (UTC millis) for a
+// single room, letting history-service skip its own per-room room-times read.
+type RoomTimeHint struct {
+	LastMsgAt *int64 `json:"lastMsgAt,omitempty"`
+	CreatedAt *int64 `json:"createdAt,omitempty"`
+}
+
 // RoomsGetRequest is the request body for the rooms.get batch RPC: the rooms whose
 // last message the caller wants. The site is taken from the subject.
 type RoomsGetRequest struct {
 	RoomIDs []string `json:"roomIds"`
+	// Hints is an optional per-room (keyed by roomID) walk-bounds hint that lets
+	// history-service skip its per-room room-times read. Backward compatible:
+	// old callers omit it and send only RoomIDs.
+	Hints map[string]RoomTimeHint `json:"hints,omitempty"`
 }
 
 // PreviewMessage is a room's most-recent eligible message, resolved at read time and

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -575,6 +575,36 @@ func TestSendMessageRequestJSON(t *testing.T) {
 
 }
 
+func TestRoomsGetRequestJSON(t *testing.T) {
+	t.Run("with hints round-trip", func(t *testing.T) {
+		lastMsgAt := int64(1735689600000)
+		createdAt := int64(1735600000000)
+		src := model.RoomsGetRequest{
+			RoomIDs: []string{"r1", "r2"},
+			Hints: map[string]model.RoomTimeHint{
+				"r1": {LastMsgAt: &lastMsgAt, CreatedAt: &createdAt},
+				"r2": {LastMsgAt: &lastMsgAt},
+			},
+		}
+		roundTrip(t, &src, &model.RoomsGetRequest{})
+	})
+
+	t.Run("nil hints omitted", func(t *testing.T) {
+		src := model.RoomsGetRequest{RoomIDs: []string{"r1"}}
+		data, err := json.Marshal(&src)
+		require.NoError(t, err)
+
+		var raw map[string]any
+		require.NoError(t, json.Unmarshal(data, &raw))
+		_, present := raw["hints"]
+		assert.False(t, present, "hints should be omitted when nil")
+
+		var dst model.RoomsGetRequest
+		require.NoError(t, json.Unmarshal(data, &dst))
+		assert.Nil(t, dst.Hints, "absent JSON field must unmarshal to nil map")
+	})
+}
+
 func TestMessageEventJSON(t *testing.T) {
 	e := model.MessageEvent{
 		Message: model.Message{

--- a/user-service/historyclient/client.go
+++ b/user-service/historyclient/client.go
@@ -51,9 +51,12 @@ func (c *Client) GetThreadList(ctx context.Context, siteID string, req model.Thr
 // RoomsGet issues the per-site rooms.get batch RPC to history-service, returning
 // the resolvable last message for each requested room; rooms with no message, or
 // that degraded, are simply absent from the map (mirrors the server's own
-// per-room best-effort degrade).
-func (c *Client) RoomsGet(ctx context.Context, siteID string, roomIDs []string) (map[string]model.PreviewMessage, error) {
-	body, err := json.Marshal(model.RoomsGetRequest{RoomIDs: roomIDs})
+// per-room best-effort degrade). hints carries caller-known walk-bounds (e.g. the
+// room's LastMsgAt already resolved locally) so history-service can skip its own
+// room-times read for those rooms; a nil/empty map is wire-compatible with older
+// callers that only send roomIds.
+func (c *Client) RoomsGet(ctx context.Context, siteID string, roomIDs []string, hints map[string]model.RoomTimeHint) (map[string]model.PreviewMessage, error) {
+	body, err := json.Marshal(model.RoomsGetRequest{RoomIDs: roomIDs, Hints: hints})
 	if err != nil {
 		return nil, fmt.Errorf("marshal rooms-get request: %w", err)
 	}

--- a/user-service/historyclient/client_test.go
+++ b/user-service/historyclient/client_test.go
@@ -1,0 +1,126 @@
+package historyclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+// startTestNATS spins up an embedded, in-process NATS server (no Docker) for
+// request/reply unit tests.
+func startTestNATS(t *testing.T) *o11ynats.Conn {
+	t.Helper()
+	opts := &natsserver.Options{Port: -1}
+	ns, err := natsserver.NewServer(opts)
+	require.NoError(t, err)
+	ns.Start()
+	require.True(t, ns.ReadyForConnections(5*time.Second), "nats server did not become ready")
+	t.Cleanup(ns.Shutdown)
+
+	nc, err := o11ynats.Connect(context.Background(), ns.ClientURL(), noop.NewTracerProvider(), propagation.TraceContext{})
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+	return nc
+}
+
+func TestRoomsGet_Hints(t *testing.T) {
+	t.Run("non-empty hints are marshaled into the request body", func(t *testing.T) {
+		nc := startTestNATS(t)
+
+		lastMsgAt := int64(1234)
+		var gotReq model.RoomsGetRequest
+		sub, err := nc.Subscribe(context.Background(), subject.RoomsGet("site-a"), func(_ context.Context, m *nats.Msg) {
+			require.NoError(t, json.Unmarshal(m.Data, &gotReq))
+			out, _ := json.Marshal(model.RoomsGetResponse{})
+			_ = m.Respond(out)
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+		hints := map[string]model.RoomTimeHint{"r1": {LastMsgAt: &lastMsgAt}}
+		_, err = New(nc).RoomsGet(context.Background(), "site-a", []string{"r1"}, hints)
+		require.NoError(t, err)
+
+		require.Contains(t, gotReq.Hints, "r1")
+		require.NotNil(t, gotReq.Hints["r1"].LastMsgAt)
+		assert.Equal(t, lastMsgAt, *gotReq.Hints["r1"].LastMsgAt)
+	})
+
+	t.Run("nil hints are omitted from the request body", func(t *testing.T) {
+		nc := startTestNATS(t)
+
+		var gotRaw map[string]any
+		sub, err := nc.Subscribe(context.Background(), subject.RoomsGet("site-a"), func(_ context.Context, m *nats.Msg) {
+			require.NoError(t, json.Unmarshal(m.Data, &gotRaw))
+			out, _ := json.Marshal(model.RoomsGetResponse{})
+			_ = m.Respond(out)
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+		_, err = New(nc).RoomsGet(context.Background(), "site-a", []string{"r1"}, nil)
+		require.NoError(t, err)
+
+		_, present := gotRaw["hints"]
+		assert.False(t, present, "nil hints must be omitted from the wire request")
+	})
+
+	t.Run("happy path — returns preview messages from responder", func(t *testing.T) {
+		nc := startTestNATS(t)
+		sub, err := nc.Subscribe(context.Background(), subject.RoomsGet("site-a"), func(_ context.Context, m *nats.Msg) {
+			out, _ := json.Marshal(model.RoomsGetResponse{
+				Rooms: map[string]model.PreviewMessage{"r1": {MessageID: "m1"}},
+			})
+			_ = m.Respond(out)
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+		out, err := New(nc).RoomsGet(context.Background(), "site-a", []string{"r1"}, nil)
+		require.NoError(t, err)
+		require.Contains(t, out, "r1")
+		assert.Equal(t, "m1", out["r1"].MessageID)
+	})
+
+	t.Run("errcode reply — returns typed errcode error", func(t *testing.T) {
+		nc := startTestNATS(t)
+		sub, err := nc.Subscribe(context.Background(), subject.RoomsGet("site-a"), func(_ context.Context, m *nats.Msg) {
+			data, _ := json.Marshal(errcode.NotFound("room not found"))
+			_ = m.Respond(data)
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+		_, err = New(nc).RoomsGet(context.Background(), "site-a", []string{"r1"}, nil)
+		require.Error(t, err)
+		var e *errcode.Error
+		require.True(t, errors.As(err, &e))
+		assert.Equal(t, errcode.CodeNotFound, e.Code)
+	})
+
+	t.Run("no responder — returns error wrapping rooms-get rpc", func(t *testing.T) {
+		nc := startTestNATS(t)
+		// Intentionally no subscriber: nc.Request must fail with "no responders".
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		_, err := New(nc).RoomsGet(ctx, "site-a", []string{"r1"}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rooms-get rpc")
+	})
+}

--- a/user-service/service/mocks/mock_repository.go
+++ b/user-service/service/mocks/mock_repository.go
@@ -469,18 +469,18 @@ func (mr *MockHistoryClientMockRecorder) GetThreadList(ctx, siteID, req any) *go
 }
 
 // RoomsGet mocks base method.
-func (m *MockHistoryClient) RoomsGet(ctx context.Context, siteID string, roomIDs []string) (map[string]model.PreviewMessage, error) {
+func (m *MockHistoryClient) RoomsGet(ctx context.Context, siteID string, roomIDs []string, hints map[string]model.RoomTimeHint) (map[string]model.PreviewMessage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RoomsGet", ctx, siteID, roomIDs)
+	ret := m.ctrl.Call(m, "RoomsGet", ctx, siteID, roomIDs, hints)
 	ret0, _ := ret[0].(map[string]model.PreviewMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RoomsGet indicates an expected call of RoomsGet.
-func (mr *MockHistoryClientMockRecorder) RoomsGet(ctx, siteID, roomIDs any) *gomock.Call {
+func (mr *MockHistoryClientMockRecorder) RoomsGet(ctx, siteID, roomIDs, hints any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RoomsGet", reflect.TypeOf((*MockHistoryClient)(nil).RoomsGet), ctx, siteID, roomIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RoomsGet", reflect.TypeOf((*MockHistoryClient)(nil).RoomsGet), ctx, siteID, roomIDs, hints)
 }
 
 // MockPresenceClient is a mock of PresenceClient interface.

--- a/user-service/service/service.go
+++ b/user-service/service/service.go
@@ -63,7 +63,7 @@ type ThreadSubscriptionRepository interface {
 // RPCs, fanned out across sites by the thread-inbox aggregator.
 type HistoryClient interface {
 	GetThreadList(ctx context.Context, siteID string, req model.ThreadSubscriptionListRequest) (model.ThreadSubscriptionListResponse, error)
-	RoomsGet(ctx context.Context, siteID string, roomIDs []string) (map[string]model.PreviewMessage, error)
+	RoomsGet(ctx context.Context, siteID string, roomIDs []string, hints map[string]model.RoomTimeHint) (map[string]model.PreviewMessage, error)
 }
 
 // PresenceClient is the consumer-defined interface for user-presence-service RPC calls.

--- a/user-service/service/service_test.go
+++ b/user-service/service/service_test.go
@@ -32,7 +32,7 @@ func newSvc(t *testing.T) (*UserService, *mocks.MockSubscriptionRepository, *moc
 	refresher := mocks.NewMockTokenRefresher(ctrl)
 	// ListSubscriptions now enriches last-message via history.RoomsGet; default it to a
 	// no-op so list tests that don't exercise last-message need no per-test stub.
-	history.EXPECT().RoomsGet(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	history.EXPECT().RoomsGet(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	// countUnread's thread phase reads pending rooms' thread-subs; default to none so
 	// room-count tests that don't exercise threads need no per-test stub.
 	threadSubs.EXPECT().ListByAccountInRooms(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()

--- a/user-service/service/subscriptions.go
+++ b/user-service/service/subscriptions.go
@@ -324,6 +324,10 @@ func (s *UserService) enrichCrossSite(c *natsrouter.Context, subs []model.Enrich
 // bounded well under history-service's 100-roomId batch cap, so no chunk-split is
 // needed. Reuses the caller's per-site grouping. A degraded/absent site, or a room the
 // RPC omits, just leaves PreviewMessage nil; it never fails the list.
+// Each room already carrying a resolved sub.Room.LastMsgAt (set by enrichLocal/
+// enrichCrossSite, which both run before this) is passed as a hint so
+// history-service can skip its own room-times read for that room; rooms with no
+// Room (soft-deleted/degraded) contribute no hint.
 func (s *UserService) enrichLastMessage(c *natsrouter.Context, subs []model.EnrichedSubscription, idxBySite map[string][]int, roomIDsBySite map[string][]string) {
 	sites := make([]string, 0, len(idxBySite))
 	for site := range idxBySite {
@@ -344,7 +348,14 @@ func (s *UserService) enrichLastMessage(c *natsrouter.Context, subs []model.Enri
 			if c.Err() != nil {
 				return
 			}
-			m, err := s.history.RoomsGet(c, site, roomIDsBySite[site])
+			hints := map[string]model.RoomTimeHint{}
+			for _, j := range idxBySite[site] {
+				if subs[j].Room == nil || subs[j].Room.LastMsgAt == nil {
+					continue
+				}
+				hints[subs[j].RoomID] = model.RoomTimeHint{LastMsgAt: timeutil.TimeToMillis(subs[j].Room.LastMsgAt)}
+			}
+			m, err := s.history.RoomsGet(c, site, roomIDsBySite[site], hints)
 			if err != nil {
 				slog.WarnContext(c, "last-message enrichment degraded", "account", c.Param("account"), "site", site, "request_id", natsutil.RequestIDFromContext(c), "error", err)
 				return

--- a/user-service/service/subscriptions_test.go
+++ b/user-service/service/subscriptions_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/pkg/timeutil"
 	"github.com/hmchangw/chat/user-service/config"
 	"github.com/hmchangw/chat/user-service/models"
 	"github.com/hmchangw/chat/user-service/service/mocks"
@@ -1010,7 +1011,7 @@ func TestListSubscriptions_LastMessage_Populated(t *testing.T) {
 	}}
 	subs.EXPECT().AggregateSubscriptions(gomock.Any(), "alice", "current", false, gomock.Any(), gomock.Any()).
 		Return(mongoutil.OffsetPageHasMore[model.EnrichedSubscription]{Data: storeSubs}, nil)
-	history.EXPECT().RoomsGet(gomock.Any(), "site-a", []string{"r1"}).
+	history.EXPECT().RoomsGet(gomock.Any(), "site-a", []string{"r1"}, map[string]model.RoomTimeHint{}).
 		Return(map[string]model.PreviewMessage{"r1": {MessageID: "m9", Content: "hi", CreatedAt: time.Unix(123, 0).UTC()}}, nil)
 	resp, err := svc.ListSubscriptions(ctx("alice", "site-a"), models.SubscriptionListRequest{Type: "current"})
 	require.NoError(t, err)
@@ -1019,6 +1020,39 @@ func TestListSubscriptions_LastMessage_Populated(t *testing.T) {
 	require.NotNil(t, room)
 	require.NotNil(t, room.PreviewMessage, "last message attached from rooms.get")
 	assert.Equal(t, "m9", room.PreviewMessage.MessageID)
+}
+
+// enrichLastMessage must build a hint from each room's already-resolved
+// LastMsgAt (set by enrichLocal before this runs) so history-service can skip
+// its own room-times read; a room with no Room object (soft-deleted) must
+// contribute no hint entry.
+func TestListSubscriptions_LastMessage_HintsFromResolvedRoom(t *testing.T) {
+	svc, subs, history := newSvcRawHistory(t)
+	lastMsgAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	storeSubs := []model.EnrichedSubscription{
+		{
+			Subscription: model.Subscription{ID: "s1", RoomID: "r1", SiteID: "site-a", Name: "general", RoomType: model.RoomTypeChannel},
+			RoomName:     "General", UserCount: 3, LastMsgAt: &lastMsgAt,
+		},
+		{
+			// Soft-deleted: buildLocalRoom returns nil Room, so no hint for r2.
+			Subscription: model.Subscription{ID: "s2", RoomID: "r2", SiteID: "site-a", Name: "old-room", RoomType: model.RoomTypeChannel},
+			RoomName:     "Del-old-room",
+		},
+	}
+	subs.EXPECT().AggregateSubscriptions(gomock.Any(), "alice", "current", false, gomock.Any(), gomock.Any()).
+		Return(mongoutil.OffsetPageHasMore[model.EnrichedSubscription]{Data: storeSubs}, nil)
+	wantHints := map[string]model.RoomTimeHint{"r1": {LastMsgAt: timeutil.TimeToMillis(&lastMsgAt)}}
+	history.EXPECT().RoomsGet(gomock.Any(), "site-a", []string{"r1", "r2"}, wantHints).
+		Return(map[string]model.PreviewMessage{}, nil)
+
+	resp, err := svc.ListSubscriptions(ctx("alice", "site-a"), models.SubscriptionListRequest{Type: "current"})
+	require.NoError(t, err)
+	require.Len(t, resp.Subscriptions, 2, "a local soft-deleted sub is kept with no Room, not dropped")
+	room1 := resp.Subscriptions[0].Base().Room
+	require.NotNil(t, room1)
+	room2 := resp.Subscriptions[1].Base().Room
+	assert.Nil(t, room2, "soft-deleted local room has no Room object")
 }
 
 // includeLastMessage:false skips the rooms.get RPC entirely.
@@ -1048,7 +1082,7 @@ func TestListSubscriptions_LastMessage_SiteDegrades(t *testing.T) {
 	}}
 	subs.EXPECT().AggregateSubscriptions(gomock.Any(), "alice", "current", false, gomock.Any(), gomock.Any()).
 		Return(mongoutil.OffsetPageHasMore[model.EnrichedSubscription]{Data: storeSubs}, nil)
-	history.EXPECT().RoomsGet(gomock.Any(), "site-a", []string{"r1"}).
+	history.EXPECT().RoomsGet(gomock.Any(), "site-a", []string{"r1"}, map[string]model.RoomTimeHint{}).
 		Return(nil, errors.New("history down"))
 	resp, err := svc.ListSubscriptions(ctx("alice", "site-a"), models.SubscriptionListRequest{Type: "current"})
 	require.NoError(t, err, "a degraded rooms.get must not fail the list")


### PR DESCRIPTION
## Summary

Follow-up to #173. It eliminates the **per-room room-times N+1** inside history-service's `rooms.get` batch RPC (the RPC that resolves each room's last-message preview for `subscription.list`). Before this, every room in a batch — on a preview-cache miss — resolved its Cassandra walk bounds via a per-room `rooms.FindByID` (`GetRoomTimes`), i.e. N single-room Mongo finds for N rooms. This drives that to **zero Mongo room-times reads in the common path**, with a single batched query as the fallback.

Two complementary changes:

- **A — batch the misses.** For any room lacking a usable hint, history-service now does **one** `$in` query (`GetRoomTimesByIDs`) instead of N per-room finds.
- **B — caller-supplied hints.** `user-service` already loads each room's `lastMsgAt` for its own room-list response (it's the sort key, the activity-window filter, and the unread-badge input — copied straight off the `rooms` `$lookup` baseline, or from `GetRoomsInfo` for cross-site rooms). It now forwards that value as a per-room hint on `rooms.get`, so history-service skips its own read entirely — no new query, no extra round-trip. The read it was doing was re-fetching the exact `rooms.lastMsgAt` the caller already held.

## What changed

- **`pkg/model`** — `RoomsGetRequest` gains an optional `Hints map[string]RoomTimeHint` (`{lastMsgAt, createdAt}` UTC millis, `omitempty`). Backward compatible: old callers send only `roomIds`.
- **history-service `mongorepo`** — new `GetRoomTimesByIDs(ids)`: one `rooms.find({_id:{$in:ids}})` with an explicit projection, keyed by room ID (absent rooms simply absent from the map).
- **history-service `service`** — `RoomsGet` maps hints → per-room meta, collects the unhinted set, issues at most **one** `GetRoomTimesByIDs`, and threads the meta into `resolvePreview`. `resolveRoomTimes` is relaxed so a valid `lastMsgAt` hint **alone** skips the Mongo read (`createdAt` only sets the walk floor, which is already clamped to the history window; its absence defaults to that same floor — no data loss). `previewAfterMutation` stays uncached/unchanged.
- **user-service** — `historyclient.RoomsGet` + the service's `history` interface carry the hints map; `enrichLastMessage` builds it from `sub.Room.LastMsgAt` (rooms with no resolved room contribute no hint).
- **`docs/client-api.md`** — the relaxation also benefits the client-facing read RPCs (Load History / Next / Surrounding), which take the same `meta` hint: `meta.lastMsgAt` alone now skips the lookup and a missing `meta.createdAt` no longer forces a fallback. The `RoomMeta` guidance is updated to match. (`rooms.get` itself is server-to-server — no wire change there.)

## Design & scope

- **Net effect:** post-B, a `subscription.list` room-list load costs **0** room-times Mongo reads (hinted rooms need none, regardless of preview-cache hit/miss). Unhinted callers (or rooms with no resolvable `lastMsgAt`) cost exactly **one** batched `$in`, never N.
- **Degradation preserved:** a `GetRoomTimesByIDs` failure is logged and falls back to the existing per-room path — it never fails the whole RPC. Hints are sanitized server-side; a stale-but-plausible hint only ever widens the read, never returns wrong data.
- Two bounded, documented trade-offs (adjudicated in review as acceptable): the batched `$in` runs once for the unhinted set even when those rooms are preview-cache hits (post-B the unhinted set is empty); and a never-messaged room in the unhinted set costs 2 reads rather than 1 (rare — the result is still correct, and the alternative "fix" measured worse).

## Testing

- `make test SERVICE=history-service` and `make test SERVICE=user-service` — green under `-race`. New unit tests assert real store-call counts: all-hinted → zero `GetRoomTimes`/`GetRoomTimesByIDs`; no-hints → exactly one batch with all ids; mixed → one batch with only the unhinted ids; batch-error → degrades; invalid hint → treated as unhinted; plus the client marshals `hints` and `enrichLastMessage` populates them from `Room.LastMsgAt`.
- `make lint` — clean.
- Integration (`GetRoomTimesByIDs` against real Mongo) is `//go:build integration` and runs in CI — not runnable in this environment (no Docker).

## Notes

- **Depends on #173** — this branch is stacked on it (it edits the `RoomsGet` / `resolvePreview` / preview-cache code #173 introduces). Merge #173 first; GitHub will auto-retarget this PR to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QDB82Mu4219m9ENo5okXL

---
_Generated by [Claude Code](https://claude.ai/code/session_015QDB82Mu4219m9ENo5okXL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional room timestamp hints to improve room preview retrieval.
  * Added batched room metadata lookup for more efficient multi-room requests.
  * Preserved compatibility for requests without hints.

* **Performance**
  * Reduced unnecessary metadata lookups when valid timestamps are supplied.
  * Added fallback handling for missing, invalid, incomplete, or failed hints.

* **Documentation**
  * Clarified how timestamp hints affect lookup and scan-bound selection.

* **Tests**
  * Added coverage for hint serialization, batching, fallback behavior, errors, and soft-deleted rooms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->