### PR TITLE
Display full date and time in message timestamps

### DIFF
--- a/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.jsx
+++ b/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.jsx
@@ -9,9 +9,15 @@ import { useSubscription } from '@/context/RoomEventsContext'
 import { redactInaccessibleQuoteSnapshot } from '@/lib/redactQuote'
 import './style.css'
 
-function formatTime(dateStr) {
+function formatDateTime(dateStr) {
   const d = new Date(dateStr)
-  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return d.toLocaleString([], {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
 }
 
 function senderName(msg) {
@@ -89,7 +95,7 @@ export default function MessageRow({
       <div className="message-row-body">
         <div className="message-header">
           <span className="message-sender">{senderName(message)}</span>
-          <span className="message-time">{formatTime(message.createdAt)}</span>
+          <span className="message-time">{formatDateTime(message.createdAt)}</span>
           {message.editedAt && <span className="message-edited"> (edited)</span>}
           {message.pinnedAt && (
             <span

--- a/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.test.jsx
+++ b/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.test.jsx
@@ -40,6 +40,18 @@ describe('MessageRow', () => {
     expect(screen.getByText(/\d\d:\d\d/)).toBeInTheDocument()
   })
 
+  it('renders the timestamp with both date and time', () => {
+    const { container } = render(
+      <MessageRow message={msg} room={room} context="main" onThread={() => {}} onReply={() => {}} onJumpToMessage={() => {}} />
+    )
+    // createdAt is 2026-05-13T10:42:00Z — regardless of the test runner's
+    // timezone this stays within 2026, so asserting the year proves the date
+    // is rendered alongside the HH:MM time.
+    const timeEl = container.querySelector('.message-time')
+    expect(timeEl.textContent).toMatch(/2026/)
+    expect(timeEl.textContent).toMatch(/\d{1,2}:\d{2}/)
+  })
+
   it('renders the row with tabindex 0 and data-message-id', () => {
     const { container } = render(
       <MessageRow message={msg} room={room} context="main" onThread={() => {}} onReply={() => {}} onJumpToMessage={() => {}} />

--- a/chat-frontend/src/components/shared/MessageList/SystemMessage/SystemMessage.jsx
+++ b/chat-frontend/src/components/shared/MessageList/SystemMessage/SystemMessage.jsx
@@ -5,7 +5,13 @@ export default function SystemMessage({ message }) {
     <div className="system-message-row" data-message-id={message.id}>
       <span className="system-message-text">{message.content}</span>
       <time className="system-message-time" dateTime={message.createdAt}>
-        {new Date(message.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+        {new Date(message.createdAt).toLocaleString([], {
+          year: 'numeric',
+          month: 'numeric',
+          day: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+        })}
       </time>
     </div>
   )

--- a/chat-frontend/src/components/shared/MessageList/SystemMessage/SystemMessage.test.jsx
+++ b/chat-frontend/src/components/shared/MessageList/SystemMessage/SystemMessage.test.jsx
@@ -12,12 +12,16 @@ describe('SystemMessage', () => {
     expect(screen.getByText(content)).toBeInTheDocument()
   })
 
-  it('renders a timestamp alongside the text', () => {
-    render(
+  it('renders a timestamp with both date and time alongside the text', () => {
+    const { container } = render(
       <SystemMessage
         message={{ id: 'm', content: 'whatever', createdAt: '2026-05-18T10:42:00Z' }}
       />
     )
-    expect(screen.getByText(/\d{1,2}:\d{2}/)).toBeInTheDocument()
+    // 2026-05-18T10:42:00Z stays within 2026 in any timezone, so the year
+    // proves the date renders alongside the HH:MM time.
+    const timeEl = container.querySelector('.system-message-time')
+    expect(timeEl.textContent).toMatch(/2026/)
+    expect(timeEl.textContent).toMatch(/\d{1,2}:\d{2}/)
   })
 })


### PR DESCRIPTION
## Summary
Updated message timestamp formatting across the chat frontend to display both date and time instead of time only. This improves clarity when viewing messages across different days.

## Changes
- **MessageRow component**: Renamed `formatTime()` to `formatDateTime()` and updated it to use `toLocaleString()` with full date options (year, month, day) alongside the existing time format
- **SystemMessage component**: Updated inline timestamp formatting to match, displaying full date and time using `toLocaleString()`
- **Tests**: Updated corresponding test cases to verify both date (year) and time components are rendered:
  - MessageRow test now asserts the year "2026" appears in the timestamp
  - SystemMessage test updated similarly to check for both date and time presence

## Implementation Details
Both components now format timestamps using the same locale-aware approach with options for `year: 'numeric'`, `month: 'numeric'`, `day: 'numeric'`, `hour: '2-digit'`, and `minute: '2-digit'`. This ensures consistent formatting across the application and respects the user's locale settings.

https://claude.ai/code/session_01EQRfrgmsVmoCDnAorqKhV6