### PR TITLE
feat(admin-service): on-duty room toggle

### DIFF
--- a/admin-service/config.go
+++ b/admin-service/config.go
@@ -1,6 +1,15 @@
 package main
 
-import "github.com/caarlos0/env/v11"
+import (
+	"fmt"
+	"time"
+
+	"github.com/caarlos0/env/v11"
+)
+
+// httpWriteTimeout bounds a response write; RoomRPCTimeout must stay under it so
+// the handler always wins the race against net/http closing the connection.
+const httpWriteTimeout = 30 * time.Second
 
 type Config struct {
 	Port                  string `env:"PORT" envDefault:"8082"`
@@ -11,12 +20,25 @@ type Config struct {
 	MongoPassword         string `env:"MONGO_PASSWORD"`
 	BcryptCost            int    `env:"BCRYPT_COST" envDefault:"10"`
 	SessionsMaxPerAccount int    `env:"SESSIONS_MAX_PER_ACCOUNT" envDefault:"100"`
+	// NatsURL backs the room-service RPC behind the duty toggle. Required: the
+	// toggle has no fallback transport, so a missing value must fail at startup.
+	NatsURL       string `env:"NATS_URL,required"`
+	NatsCredsFile string `env:"NATS_CREDS_FILE"`
+	// RoomRPCTimeout must stay below the HTTP server's WriteTimeout, or net/http
+	// closes the connection before the handler can answer.
+	RoomRPCTimeout time.Duration `env:"ROOM_RPC_TIMEOUT" envDefault:"5s"`
 }
 
 func loadConfig() (Config, error) {
 	var c Config
 	if err := env.Parse(&c); err != nil {
 		return Config{}, err
+	}
+	if c.RoomRPCTimeout <= 0 {
+		return Config{}, fmt.Errorf("invalid ROOM_RPC_TIMEOUT %s: must be > 0", c.RoomRPCTimeout)
+	}
+	if c.RoomRPCTimeout >= httpWriteTimeout {
+		return Config{}, fmt.Errorf("invalid ROOM_RPC_TIMEOUT %s: must be below the %s HTTP write timeout", c.RoomRPCTimeout, httpWriteTimeout)
 	}
 	return c, nil
 }

--- a/admin-service/config_test.go
+++ b/admin-service/config_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -10,14 +11,62 @@ import (
 func TestLoadConfig_Defaults(t *testing.T) {
 	t.Setenv("SITE_ID", "site-local")
 	t.Setenv("MONGO_URI", "mongodb://x")
+	t.Setenv("NATS_URL", "nats://x:4222")
 	cfg, err := loadConfig()
 	require.NoError(t, err)
 	assert.Equal(t, "8082", cfg.Port)
 	assert.Equal(t, "chat", cfg.MongoDB)
 	assert.Equal(t, 10, cfg.BcryptCost)
+	assert.Equal(t, 5*time.Second, cfg.RoomRPCTimeout)
 }
 
 func TestLoadConfig_RequiresSiteAndMongo(t *testing.T) {
 	_, err := loadConfig()
 	assert.Error(t, err)
+}
+
+// NATS_URL is required: the room RPC has no fallback transport, so a missing
+// value must fail at startup rather than at the first duty toggle.
+func TestLoadConfig_RequiresNatsURL(t *testing.T) {
+	t.Setenv("SITE_ID", "site-local")
+	t.Setenv("MONGO_URI", "mongodb://x")
+	_, err := loadConfig()
+	assert.Error(t, err)
+}
+
+func TestLoadConfig_RoomRPCTimeoutOverride(t *testing.T) {
+	t.Setenv("SITE_ID", "site-local")
+	t.Setenv("MONGO_URI", "mongodb://x")
+	t.Setenv("NATS_URL", "nats://x:4222")
+	t.Setenv("ROOM_RPC_TIMEOUT", "12s")
+	cfg, err := loadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, 12*time.Second, cfg.RoomRPCTimeout)
+}
+
+// A non-positive timeout yields an already-expired context, so every toggle
+// would fail; a timeout at or above the HTTP write timeout lets net/http close
+// the connection before the handler can answer. Both must fail at startup.
+func TestLoadConfig_RejectsUnusableRoomRPCTimeout(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "zero", value: "0s"},
+		{name: "negative", value: "-1s"},
+		{name: "equal to write timeout", value: "30s"},
+		{name: "above write timeout", value: "45s"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SITE_ID", "site-local")
+			t.Setenv("MONGO_URI", "mongodb://x")
+			t.Setenv("NATS_URL", "nats://x:4222")
+			t.Setenv("ROOM_RPC_TIMEOUT", tc.value)
+			_, err := loadConfig()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "ROOM_RPC_TIMEOUT")
+		})
+	}
 }

--- a/admin-service/deploy/docker-compose.yml
+++ b/admin-service/deploy/docker-compose.yml
@@ -15,8 +15,13 @@ services:
       - SITE_ID=site-local
       - MONGO_URI=mongodb://mongodb:27017
       - MONGO_DB=chat
+      - NATS_URL=nats://nats:4222
+      - NATS_CREDS_FILE=/etc/nats/backend.creds
+      - ROOM_RPC_TIMEOUT=5s
       - BCRYPT_COST=10
       - SESSIONS_MAX_PER_ACCOUNT=100
+    volumes:
+      - ../../docker-local/backend.creds:/etc/nats/backend.creds:ro
     networks:
       - chat-local
 

--- a/admin-service/handler.go
+++ b/admin-service/handler.go
@@ -19,16 +19,20 @@ import (
 	"github.com/hmchangw/chat/pkg/session"
 )
 
-// Handler wires the AdminStore, session.Store, and Config into HTTP handler methods.
+// Handler wires the AdminStore, session.Store, Config, and room-service RPC
+// client into HTTP handler methods.
 type Handler struct {
 	store    AdminStore
 	sessions session.Store
 	cfg      Config
+	roomRPC  roomRequester
 }
 
-// newHandler constructs a Handler with the given stores and config.
-func newHandler(store AdminStore, sessions session.Store, cfg Config) *Handler { //nolint:gocritic // hugeParam: Config is a startup value copied once at construction
-	return &Handler{store: store, sessions: sessions, cfg: cfg}
+// newHandler constructs a Handler with the given stores, config, and room RPC.
+// A nil rpc is tolerated so tests that never touch a room route need not build
+// one; the duty handler answers 503 rather than dereferencing it.
+func newHandler(store AdminStore, sessions session.Store, cfg Config, rpc roomRequester) *Handler { //nolint:gocritic // hugeParam: Config is a startup value copied once at construction
+	return &Handler{store: store, sessions: sessions, cfg: cfg, roomRPC: rpc}
 }
 
 // nowMillis returns the current UTC time in unix milliseconds. Injected as a

--- a/admin-service/handler_test.go
+++ b/admin-service/handler_test.go
@@ -342,7 +342,7 @@ func TestHandler_createUser(t *testing.T) {
 			m := NewMockAdminStore(ctrl)
 			tc.setupMock(m)
 
-			h := newHandler(m, emptySessionStore(), testCfg())
+			h := newHandler(m, emptySessionStore(), testCfg(), nil)
 			r := setupRouter(h)
 
 			w := httptest.NewRecorder()
@@ -434,7 +434,7 @@ func TestHandler_listUsers(t *testing.T) {
 			m := NewMockAdminStore(ctrl)
 			tc.setupMock(m)
 
-			h := newHandler(m, emptySessionStore(), testCfg())
+			h := newHandler(m, emptySessionStore(), testCfg(), nil)
 			r := setupRouter(h)
 
 			w := httptest.NewRecorder()
@@ -526,7 +526,7 @@ func TestHandler_getUser(t *testing.T) {
 			m := NewMockAdminStore(ctrl)
 			tc.setupMock(m)
 
-			h := newHandler(m, emptySessionStore(), testCfg())
+			h := newHandler(m, emptySessionStore(), testCfg(), nil)
 			r := setupRouter(h)
 
 			w := httptest.NewRecorder()
@@ -713,7 +713,7 @@ func TestHandler_updateUser(t *testing.T) {
 				tc.setupSessions(sess)
 			}
 
-			h := newHandler(m, sess, testCfg())
+			h := newHandler(m, sess, testCfg(), nil)
 			r := setupRouter(h)
 
 			w := httptest.NewRecorder()
@@ -741,7 +741,7 @@ func TestHandler_updateUser_DeactivateAndRevoke_TxError_Returns500(t *testing.T)
 	m.EXPECT().DeactivateAndRevoke(gomock.Any(), "site-A", "u2b").Return(fmt.Errorf("mongo dead"))
 	// no AppendAudit expectation — must not fire
 
-	h := newHandler(m, emptySessionStore(), testCfg())
+	h := newHandler(m, emptySessionStore(), testCfg(), nil)
 	r := setupRouter(h)
 
 	w := httptest.NewRecorder()
@@ -866,7 +866,7 @@ func TestHandler_listSessions(t *testing.T) {
 				tc.setupSessions(sess)
 			}
 
-			h := newHandler(m, sess, testCfg())
+			h := newHandler(m, sess, testCfg(), nil)
 			r := setupSessionRouter(h)
 
 			w := httptest.NewRecorder()
@@ -946,7 +946,7 @@ func TestHandler_revokeAllSessions(t *testing.T) {
 				tc.setupSessions(sess)
 			}
 
-			h := newHandler(m, sess, testCfg())
+			h := newHandler(m, sess, testCfg(), nil)
 			r := setupSessionRouter(h)
 
 			w := httptest.NewRecorder()
@@ -1028,7 +1028,7 @@ func TestHandler_revokeSession(t *testing.T) {
 				tc.setupSessions(sess)
 			}
 
-			h := newHandler(m, sess, testCfg())
+			h := newHandler(m, sess, testCfg(), nil)
 			r := setupSessionRouter(h)
 
 			w := httptest.NewRecorder()
@@ -1105,7 +1105,7 @@ func TestHandler_listAudit(t *testing.T) {
 			m := NewMockAdminStore(ctrl)
 			tc.setupMock(m)
 
-			h := newHandler(m, emptySessionStore(), testCfg())
+			h := newHandler(m, emptySessionStore(), testCfg(), nil)
 			r := setupSessionRouter(h)
 
 			w := httptest.NewRecorder()
@@ -1129,7 +1129,7 @@ func TestHandler_healthz(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	m := NewMockAdminStore(ctrl)
 
-	h := newHandler(m, emptySessionStore(), testCfg())
+	h := newHandler(m, emptySessionStore(), testCfg(), nil)
 	r := setupSessionRouter(h)
 
 	w := httptest.NewRecorder()
@@ -1147,7 +1147,7 @@ func TestHandler_readyz(t *testing.T) {
 		m := NewMockAdminStore(ctrl)
 		m.EXPECT().Ping(gomock.Any()).Return(nil)
 
-		h := newHandler(m, emptySessionStore(), testCfg())
+		h := newHandler(m, emptySessionStore(), testCfg(), nil)
 		r := setupSessionRouter(h)
 
 		w := httptest.NewRecorder()
@@ -1164,7 +1164,7 @@ func TestHandler_readyz(t *testing.T) {
 		m := NewMockAdminStore(ctrl)
 		m.EXPECT().Ping(gomock.Any()).Return(fmt.Errorf("mongo unreachable"))
 
-		h := newHandler(m, emptySessionStore(), testCfg())
+		h := newHandler(m, emptySessionStore(), testCfg(), nil)
 		r := setupSessionRouter(h)
 
 		w := httptest.NewRecorder()
@@ -1279,7 +1279,7 @@ func TestHandler_setPassword(t *testing.T) {
 				tc.setupSessions(sess)
 			}
 
-			h := newHandler(m, sess, testCfg())
+			h := newHandler(m, sess, testCfg(), nil)
 			r := setupRouter(h)
 
 			w := httptest.NewRecorder()
@@ -1308,7 +1308,7 @@ func TestHandler_setPassword_TxError_Returns500(t *testing.T) {
 		Return(fmt.Errorf("mongo dead"))
 	// no AppendAudit expectation — must not fire
 
-	h := newHandler(m, emptySessionStore(), testCfg())
+	h := newHandler(m, emptySessionStore(), testCfg(), nil)
 	r := setupRouter(h)
 
 	w := httptest.NewRecorder()

--- a/admin-service/integration_test.go
+++ b/admin-service/integration_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	testutil.RunTestsWithPrewarm(m, testutil.EnsureMongoReplicaSet)
+	testutil.RunTestsWithPrewarm(m, testutil.EnsureMongoReplicaSet, testutil.EnsureNATS)
 }
 
 // seedSession inserts a session row directly into the shared sessions
@@ -602,7 +602,7 @@ func TestLoginAndChangePasswordEndToEnd(t *testing.T) {
 	require.NoError(t, store.EnsureIndexes(context.Background()))
 
 	cfg := Config{SiteID: "site-a", BcryptCost: 4, SessionsMaxPerAccount: 100}
-	h := newHandler(store, sessions, cfg)
+	h := newHandler(store, sessions, cfg, nil)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.New()

--- a/admin-service/login_test.go
+++ b/admin-service/login_test.go
@@ -25,7 +25,7 @@ import (
 func loginRouter(t *testing.T, adminStore AdminStore, sessions session.Store, cfg Config) *gin.Engine { //nolint:gocritic // hugeParam: Config is a test-local value, cheap to copy per call
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	h := newHandler(adminStore, sessions, cfg)
+	h := newHandler(adminStore, sessions, cfg, nil)
 	r.POST("/v1/login", h.handleLogin)
 	return r
 }
@@ -373,7 +373,7 @@ func TestHandleLogin_TimingConsistent(t *testing.T) {
 func changePasswordRouter(t *testing.T, adminStore AdminStore, sessions session.Store, cfg Config) *gin.Engine { //nolint:gocritic // hugeParam: Config is a test-local value, cheap to copy per call
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	h := newHandler(adminStore, sessions, cfg)
+	h := newHandler(adminStore, sessions, cfg, nil)
 	r.POST("/v1/password/change", requireAdmin(sessions, cfg.SiteID), h.handleChangePassword)
 	return r
 }

--- a/admin-service/main.go
+++ b/admin-service/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hmchangw/chat/pkg/ginutil"
 	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
 	"github.com/hmchangw/chat/pkg/session"
 	"github.com/hmchangw/chat/pkg/shutdown"
@@ -55,7 +56,12 @@ func run() error {
 		return fmt.Errorf("ensure session indexes: %w", err)
 	}
 
-	h := newHandler(st, sessStore, cfg)
+	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)
+	if err != nil {
+		return fmt.Errorf("connect nats: %w", err)
+	}
+
+	h := newHandler(st, sessStore, cfg, nc)
 
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
@@ -70,7 +76,7 @@ func run() error {
 		Addr:         fmt.Sprintf(":%s", cfg.Port),
 		Handler:      r,
 		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 30 * time.Second,
+		WriteTimeout: httpWriteTimeout,
 	}
 
 	srvErr := make(chan error, 1)
@@ -86,6 +92,12 @@ func run() error {
 			func(ctx context.Context) error {
 				slog.Info("shutting down admin-service")
 				err := srv.Shutdown(ctx)
+				// srv.Shutdown has already waited out any in-flight toggle, so
+				// Drain (which returns immediately and finishes in the background)
+				// only closes the idle connection.
+				if drainErr := nc.NatsConn().Drain(); drainErr != nil {
+					slog.Warn("drain nats", "error", drainErr)
+				}
 				mongoutil.Disconnect(ctx, mongoClient)
 				return err
 			},

--- a/admin-service/room_onduty.go
+++ b/admin-service/room_onduty.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/nats-io/nats.go"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/errcode/errhttp"
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/natsutil"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+// roomRequester issues a synchronous request/reply against room-service. Shaped
+// around messages so *o11ynats.Conn satisfies it and carries headers outbound.
+type roomRequester interface {
+	RequestMsg(ctx context.Context, msg *nats.Msg, timeout time.Duration) (*nats.Msg, error)
+}
+
+// roomOnDutyRequest is the duty-toggle body; OnDuty is a pointer so an absent
+// field is rejected while an explicit false is accepted.
+type roomOnDutyRequest struct {
+	OnDuty       *bool  `json:"onDuty" binding:"required"`
+	OwnerAccount string `json:"ownerAccount"`
+}
+
+// setRoomOnDuty maps the boolean onto the room's restricted + externalAccess
+// flags via room-service. The room is told nothing — see roomRestricted.
+func (h *Handler) setRoomOnDuty(c *gin.Context) {
+	// Seed the correlation id so Classify's log line for a failure carries it —
+	// with no audit row, the logs are the only trace of a duty switch.
+	ctx := errcode.WithLogValues(c.Request.Context(), "request_id", c.GetString("request_id"))
+
+	if h.roomRPC == nil {
+		errhttp.Write(ctx, c, errcode.Unavailable("room service client not configured"))
+		return
+	}
+
+	var req roomOnDutyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errhttp.Write(ctx, c, errcode.BadRequest("invalid request body",
+			errcode.WithReason(errcode.AuthMissingFields)))
+		return
+	}
+	onDuty := *req.OnDuty
+	// Trim before the guard, or a whitespace-only account clears it and comes back
+	// from room-service as "not a member" instead of a precise 400.
+	ownerAccount := strings.TrimSpace(req.OwnerAccount)
+
+	// room-service rejects this anyway; failing here names the missing field.
+	if onDuty && ownerAccount == "" {
+		errhttp.Write(ctx, c, errcode.BadRequest("ownerAccount is required when turning duty on",
+			errcode.WithReason(errcode.AuthMissingFields)))
+		return
+	}
+
+	roomID := c.Param("roomId")
+	owner := ""
+	if onDuty {
+		owner = ownerAccount
+	}
+
+	// Timestamp is left zero on purpose: room-service stamps it on acceptance and
+	// overwrites whatever arrives, so setting it here would only look meaningful.
+	payload, err := json.Marshal(model.RoomRestrictedRequest{
+		RoomID:         roomID,
+		Restricted:     onDuty,
+		ExternalAccess: onDuty,
+		OwnerAccount:   owner,
+		Account:        principalFrom(c).Account,
+	})
+	if err != nil {
+		errhttp.Write(ctx, c, fmt.Errorf("marshal room restricted request: %w", err))
+		return
+	}
+
+	// NewMsg carries X-Request-ID from ctx so the correlation id survives the hop.
+	msg := natsutil.NewMsg(ctx, subject.RoomRestricted(h.cfg.SiteID), payload)
+	reply, err := h.roomRPC.RequestMsg(ctx, msg, h.cfg.RoomRPCTimeout)
+	if err != nil {
+		// room-service has no deadline of its own, so a timeout may still have
+		// applied the write: 503 invites a retry of an idempotent call. Canceled
+		// belongs here too — a client hang-up is not an internal fault and must
+		// not log at ERROR.
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) ||
+			errors.Is(err, nats.ErrTimeout) || errors.Is(err, nats.ErrNoResponders) {
+			errhttp.Write(ctx, c, errcode.Unavailable("room service unavailable", errcode.WithCause(err)))
+			return
+		}
+		errhttp.Write(ctx, c, fmt.Errorf("room restricted rpc: %w", err))
+		return
+	}
+	if reply == nil {
+		errhttp.Write(ctx, c, fmt.Errorf("room restricted rpc returned no reply"))
+		return
+	}
+
+	if remote, ok := errcode.Parse(reply.Data); ok {
+		// Parse does not validate Code, so a foreign envelope collapses to internal.
+		if !remote.Code.Valid() {
+			errhttp.Write(ctx, c, fmt.Errorf("room restricted rpc returned unknown code %q", remote.Code))
+			return
+		}
+		errhttp.Write(ctx, c, remote)
+		return
+	}
+
+	// Parse also returns false for an empty or truncated body, which is not success.
+	var status model.StatusWithRequestReply
+	if err := json.Unmarshal(reply.Data, &status); err != nil || status.Status != "ok" {
+		errhttp.Write(ctx, c, fmt.Errorf("room restricted rpc returned an unrecognized reply"))
+		return
+	}
+
+	// No h.audit call, unlike every other mutating handler here: the operation is
+	// specified as leaving no record under its own name. room-service logs the
+	// change (actor, room, flags, owner) and that is the intended trail.
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}

--- a/admin-service/room_onduty_integration_test.go
+++ b/admin-service/room_onduty_integration_test.go
@@ -1,0 +1,254 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/errcode/errnats"
+	"github.com/hmchangw/chat/pkg/ginutil"
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/natsutil"
+	"github.com/hmchangw/chat/pkg/session"
+	"github.com/hmchangw/chat/pkg/sessiontoken"
+	"github.com/hmchangw/chat/pkg/subject"
+	"github.com/hmchangw/chat/pkg/testutil"
+)
+
+// onDutyRig is the full stack on a real NATS, with a stub room-service responder.
+type onDutyRig struct {
+	router     *gin.Engine
+	authToken  string
+	received   chan model.RoomRestrictedRequest
+	gotHeaders chan string
+}
+
+// newOnDutyRig wires Mongo, an admin session, NATS, and a stub responder.
+func newOnDutyRig(t *testing.T, siteID string, reply func(model.RoomRestrictedRequest) []byte) *onDutyRig {
+	t.Helper()
+	ctx := context.Background()
+
+	db := testutil.MongoDBReplicaSet(t, "adminonduty")
+	sessions := session.NewMongoStore(db)
+	require.NoError(t, sessions.EnsureIndexes(ctx))
+	store := newStoreMongo(db)
+	require.NoError(t, store.EnsureIndexes(ctx))
+
+	const authToken = "onduty-test-token"
+	seedSession(t, db, session.Session{
+		ID:       sessiontoken.Hash(authToken),
+		UserID:   "u-admin",
+		Account:  "p_admin",
+		SiteID:   siteID,
+		Roles:    []string{string(model.UserRoleAdmin)},
+		IssuedAt: 1,
+	})
+
+	url := testutil.NATS(t)
+	gotHeaders := make(chan string, 16)
+
+	serverConn, err := nats.Connect(url)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = serverConn.Drain() })
+
+	// Buffered and written non-blocking so a failed subtest cannot wedge the
+	// responder, and with it the next subtest, on a full channel.
+	received := make(chan model.RoomRestrictedRequest, 16)
+	sub, err := serverConn.Subscribe(subject.RoomRestricted(siteID), func(m *nats.Msg) {
+		var req model.RoomRestrictedRequest
+		if err := json.Unmarshal(m.Data, &req); err != nil {
+			_ = m.Respond(errnats.MarshalQuiet(errcode.BadRequest("unmarshal")))
+			return
+		}
+		select {
+		case gotHeaders <- m.Header.Get(natsutil.RequestIDHeader):
+		default:
+		}
+		select {
+		case received <- req:
+		default:
+		}
+		_ = m.Respond(reply(req))
+	})
+	require.NoError(t, err)
+	require.NoError(t, serverConn.Flush())
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	clientConn, err := natsutil.Connect(ctx, url, "", nil, nil, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clientConn.NatsConn().Drain() })
+
+	cfg := Config{SiteID: siteID, BcryptCost: 4, SessionsMaxPerAccount: 100, RoomRPCTimeout: 5 * time.Second}
+	h := newHandler(store, sessions, cfg, clientConn)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	// Mirrors main.go: without it the X-Request-ID never reaches the NATS message.
+	r.Use(ginutil.RequestID())
+	registerRoutes(r, h, sessions, cfg.SiteID)
+
+	return &onDutyRig{router: r, authToken: authToken, received: received, gotHeaders: gotHeaders}
+}
+
+// drain clears both channels so a subtest never reads a message left behind by a
+// sibling that failed before consuming its own.
+func (rig *onDutyRig) drain() {
+	for len(rig.received) > 0 {
+		<-rig.received
+	}
+	for len(rig.gotHeaders) > 0 {
+		<-rig.gotHeaders
+	}
+}
+
+func (rig *onDutyRig) post(t *testing.T, roomID, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/rooms/"+roomID+"/onduty", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+rig.authToken)
+	req.Header.Set(natsutil.RequestIDHeader, "01970a4f-8c2d-7c9a-abcd-e0123456789f")
+	w := httptest.NewRecorder()
+	rig.router.ServeHTTP(w, req)
+	return w
+}
+
+func okEnvelope(t *testing.T) []byte {
+	t.Helper()
+	b, err := json.Marshal(model.StatusWithRequestReply{Status: "ok", RequestID: "req-1"})
+	require.NoError(t, err)
+	return b
+}
+
+// Route, admin middleware and the NATS round-trip must all line up.
+func TestIntegration_SetRoomOnDuty_EndToEnd(t *testing.T) {
+	rig := newOnDutyRig(t, "site-a", func(model.RoomRestrictedRequest) []byte { return okEnvelope(t) })
+
+	t.Run("on sets both flags", func(t *testing.T) {
+		rig.drain()
+		w := rig.post(t, "r1", `{"onDuty":true,"ownerAccount":"alice"}`)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		sent := <-rig.received
+		assert.Equal(t, "r1", sent.RoomID)
+		assert.True(t, sent.Restricted)
+		assert.True(t, sent.ExternalAccess)
+		assert.Equal(t, "alice", sent.OwnerAccount, "turning on designates the room owner")
+		assert.Equal(t, "p_admin", sent.Account)
+	})
+
+	t.Run("off clears both flags", func(t *testing.T) {
+		rig.drain()
+		w := rig.post(t, "r1", `{"onDuty":false}`)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		sent := <-rig.received
+		assert.False(t, sent.Restricted)
+		assert.False(t, sent.ExternalAccess)
+		assert.Empty(t, sent.OwnerAccount, "turning off must not reshuffle roles")
+	})
+
+	t.Run("correlation id reaches room-service", func(t *testing.T) {
+		rig.drain()
+		w := rig.post(t, "r1", `{"onDuty":true,"ownerAccount":"alice"}`)
+		require.Equal(t, http.StatusOK, w.Code)
+		<-rig.received
+
+		assert.Equal(t, "01970a4f-8c2d-7c9a-abcd-e0123456789f", <-rig.gotHeaders,
+			"X-Request-ID must survive the HTTP→NATS hop")
+	})
+}
+
+// A typed error from room-service keeps its status across the real transport.
+func TestIntegration_SetRoomOnDuty_RemoteErrorStatus(t *testing.T) {
+	rig := newOnDutyRig(t, "site-b", func(model.RoomRestrictedRequest) []byte {
+		return errnats.MarshalQuiet(errcode.Conflict("not enough members to restrict (need at least 5)"))
+	})
+
+	w := rig.post(t, "r1", `{"onDuty":true,"ownerAccount":"alice"}`)
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), "not enough members")
+}
+
+// A responder that receives and never answers, so the RPC genuinely runs out of
+// RoomRPCTimeout rather than short-circuiting on ErrNoResponders.
+func TestIntegration_SetRoomOnDuty_RPCTimeout(t *testing.T) {
+	ctx := context.Background()
+
+	db := testutil.MongoDBReplicaSet(t, "ondutytimeout")
+	sessions := session.NewMongoStore(db)
+	require.NoError(t, sessions.EnsureIndexes(ctx))
+	store := newStoreMongo(db)
+	require.NoError(t, store.EnsureIndexes(ctx))
+
+	const authToken = "onduty-timeout-token"
+	seedSession(t, db, session.Session{
+		ID: sessiontoken.Hash(authToken), UserID: "u-admin", Account: "p_admin",
+		SiteID: "site-c", Roles: []string{string(model.UserRoleAdmin)}, IssuedAt: 1,
+	})
+
+	url := testutil.NATS(t)
+
+	// Subscribe without responding: NATS sees a responder, so the client waits out
+	// the deadline instead of failing fast with ErrNoResponders.
+	deafConn, err := nats.Connect(url)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = deafConn.Drain() })
+	sub, err := deafConn.Subscribe(subject.RoomRestricted("site-c"), func(*nats.Msg) {})
+	require.NoError(t, err)
+	require.NoError(t, deafConn.Flush())
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	clientConn, err := natsutil.Connect(ctx, url, "", nil, nil, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clientConn.NatsConn().Drain() })
+
+	const rpcTimeout = 300 * time.Millisecond
+	cfg := Config{SiteID: "site-c", BcryptCost: 4, SessionsMaxPerAccount: 100, RoomRPCTimeout: rpcTimeout}
+	h := newHandler(store, sessions, cfg, clientConn)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	registerRoutes(r, h, sessions, cfg.SiteID)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/rooms/r1/onduty", strings.NewReader(`{"onDuty":true,"ownerAccount":"alice"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+authToken)
+	w := httptest.NewRecorder()
+
+	start := time.Now()
+	r.ServeHTTP(w, req)
+	elapsed := time.Since(start)
+
+	// 503, not 500: the write may have landed, so the console should retry.
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.NotContains(t, w.Body.String(), "nats", "transport cause must not reach the client")
+	// Bracketed both ways: at least the deadline proves it really waited (not a
+	// fast ErrNoResponders), and well under it proves RoomRPCTimeout is honoured.
+	assert.GreaterOrEqual(t, elapsed, rpcTimeout, "must wait out RoomRPCTimeout, not fail fast")
+	assert.Less(t, elapsed, 5*time.Second, "must give up on RoomRPCTimeout, not a default")
+}
+
+// Without a valid admin session the request never reaches NATS.
+func TestIntegration_SetRoomOnDuty_RequiresAdminSession(t *testing.T) {
+	rig := newOnDutyRig(t, "site-d", func(model.RoomRestrictedRequest) []byte { return okEnvelope(t) })
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/rooms/r1/onduty", strings.NewReader(`{"onDuty":true,"ownerAccount":"alice"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	rig.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Empty(t, rig.received, "unauthenticated request must not issue an RPC")
+}

--- a/admin-service/room_onduty_test.go
+++ b/admin-service/room_onduty_test.go
@@ -1,0 +1,384 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/errcode/errnats"
+	"github.com/hmchangw/chat/pkg/ginutil"
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/natsutil"
+	"github.com/hmchangw/chat/pkg/session"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+// fakeRoomRPC records what the handler sent, so the toggle runs without NATS.
+type fakeRoomRPC struct {
+	calls      int
+	gotSubject string
+	gotData    []byte
+	gotHeader  nats.Header
+	gotTimeout time.Duration
+	reply      *nats.Msg
+	err        error
+}
+
+func (f *fakeRoomRPC) RequestMsg(_ context.Context, msg *nats.Msg, timeout time.Duration) (*nats.Msg, error) {
+	f.calls++
+	f.gotSubject = msg.Subject
+	f.gotData = msg.Data
+	f.gotHeader = msg.Header
+	f.gotTimeout = timeout
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.reply, nil
+}
+
+// decodeSent unmarshals the payload the handler put on the wire.
+func (f *fakeRoomRPC) decodeSent(t *testing.T) model.RoomRestrictedRequest {
+	t.Helper()
+	var sent model.RoomRestrictedRequest
+	require.NoError(t, json.Unmarshal(f.gotData, &sent))
+	return sent
+}
+
+// okReply is the success envelope room-service replies with.
+func okReply(t *testing.T) *nats.Msg {
+	t.Helper()
+	b, err := json.Marshal(model.StatusWithRequestReply{Status: "ok", RequestID: "req-1"})
+	require.NoError(t, err)
+	return &nats.Msg{Data: b}
+}
+
+// errReply builds room-service's envelope for a typed error.
+func errReply(err error) *nats.Msg {
+	return &nats.Msg{Data: errnats.MarshalQuiet(err)}
+}
+
+func onDutyTestCfg() Config {
+	cfg := testCfg()
+	cfg.RoomRPCTimeout = 3 * time.Second
+	return cfg
+}
+
+// setupOnDutyRouter wires just the duty route with a fixed admin principal.
+func setupOnDutyRouter(h *Handler) *gin.Engine {
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(ctxPrincipal, session.Session{
+			ID:      "sess-1",
+			UserID:  "admin-user-id",
+			Account: "p_admin",
+			SiteID:  "site-A",
+			Roles:   []string{"admin"},
+		})
+		c.Next()
+	})
+	r.POST("/rooms/:roomId/onduty", h.setRoomOnDuty)
+	return r
+}
+
+// doOnDuty sends a raw body so malformed JSON can be tested.
+func doOnDuty(h *Handler, roomID, body string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/rooms/"+roomID+"/onduty", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	setupOnDutyRouter(h).ServeHTTP(w, req)
+	return w
+}
+
+// Turning on designates an owner; turning off sends none, so roles survive.
+func TestSetRoomOnDuty_MapsOnDutyToBothFlags(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		want      bool
+		wantOwner string
+	}{
+		{name: "on", body: `{"onDuty":true,"ownerAccount":"alice"}`, want: true, wantOwner: "alice"},
+		{name: "off", body: `{"onDuty":false}`, want: false, wantOwner: ""},
+		{name: "off ignores a supplied owner", body: `{"onDuty":false,"ownerAccount":"alice"}`, want: false, wantOwner: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			m := NewMockAdminStore(ctrl)
+
+			rpc := &fakeRoomRPC{reply: okReply(t)}
+			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+
+			w := doOnDuty(h, "r1", tc.body)
+
+			require.Equal(t, http.StatusOK, w.Code)
+			require.Equal(t, 1, rpc.calls)
+			assert.Equal(t, subject.RoomRestricted("site-A"), rpc.gotSubject)
+			assert.Equal(t, 3*time.Second, rpc.gotTimeout)
+
+			sent := rpc.decodeSent(t)
+			assert.Equal(t, "r1", sent.RoomID)
+			assert.Equal(t, tc.want, sent.Restricted)
+			assert.Equal(t, tc.want, sent.ExternalAccess)
+			assert.Equal(t, tc.wantOwner, sent.OwnerAccount)
+			assert.Equal(t, "p_admin", sent.Account)
+		})
+	}
+}
+
+// Turning duty on without a usable owner is rejected before the round trip.
+func TestSetRoomOnDuty_OwnerRequiredWhenTurningOn(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "absent", body: `{"onDuty":true}`},
+		{name: "empty", body: `{"onDuty":true,"ownerAccount":""}`},
+		{name: "whitespace only", body: `{"onDuty":true,"ownerAccount":"   "}`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			m := NewMockAdminStore(ctrl)
+
+			rpc := &fakeRoomRPC{reply: okReply(t)}
+			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+
+			w := doOnDuty(h, "r1", tc.body)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Zero(t, rpc.calls, "no RPC may be issued without an owner")
+		})
+	}
+}
+
+// A padded account is trimmed before it goes on the wire, so room-service is not
+// asked to look up a member that cannot exist.
+func TestSetRoomOnDuty_TrimsOwnerAccount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	m := NewMockAdminStore(ctrl)
+
+	rpc := &fakeRoomRPC{reply: okReply(t)}
+	h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+
+	w := doOnDuty(h, "r1", `{"onDuty":true,"ownerAccount":"  alice  "}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "alice", rpc.decodeSent(t).OwnerAccount)
+}
+
+// A body that cannot yield a boolean must not reach the RPC.
+func TestSetRoomOnDuty_InvalidBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "malformed json", body: `{"onDuty":`},
+		{name: "missing onDuty", body: `{}`},
+		{name: "wrong type", body: `{"onDuty":"yes"}`},
+		{name: "empty body", body: ``},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			m := NewMockAdminStore(ctrl)
+
+			rpc := &fakeRoomRPC{reply: okReply(t)}
+			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+
+			w := doOnDuty(h, "r1", tc.body)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Zero(t, rpc.calls, "no RPC may be issued for an unusable body")
+		})
+	}
+}
+
+// room-service's typed errors keep their status through the HTTP boundary.
+func TestSetRoomOnDuty_DownstreamErrorsPassThrough(t *testing.T) {
+	tests := []struct {
+		name       string
+		remote     error
+		wantStatus int
+		wantReason string
+	}{
+		{
+			name:       "not a platform admin",
+			remote:     errcode.Forbidden("only admins can change room restricted state"),
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "room not found",
+			remote:     errcode.NotFound("room not found"),
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "not enough members",
+			remote:     errcode.Conflict("not enough members to restrict (need at least 5)"),
+			wantStatus: http.StatusConflict,
+		},
+		{
+			name:       "not a channel room",
+			remote:     errcode.BadRequest("restricted change is only allowed in channel rooms", errcode.WithReason(errcode.RoomNonChannelOperation)),
+			wantStatus: http.StatusBadRequest,
+			wantReason: string(errcode.RoomNonChannelOperation),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			m := NewMockAdminStore(ctrl)
+
+			rpc := &fakeRoomRPC{reply: errReply(tc.remote)}
+			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+
+			w := doOnDuty(h, "r1", `{"onDuty":true,"ownerAccount":"alice"}`)
+
+			require.Equal(t, tc.wantStatus, w.Code)
+			body := respBody(t, w)
+			assert.Equal(t, tc.remote.Error(), body["error"])
+			if tc.wantReason != "" {
+				assert.Equal(t, tc.wantReason, body["reason"])
+			}
+		})
+	}
+}
+
+// Ambiguous and retryable: the write may have landed. 503, not 500.
+func TestSetRoomOnDuty_TransportErrorIsUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "timeout", err: fmt.Errorf("nats: %w", nats.ErrTimeout)},
+		{name: "deadline exceeded", err: fmt.Errorf("rpc: %w", context.DeadlineExceeded)},
+		{name: "no responders", err: fmt.Errorf("nats: %w", nats.ErrNoResponders)},
+		{name: "client hung up", err: fmt.Errorf("rpc: %w", context.Canceled)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			m := NewMockAdminStore(ctrl)
+
+			rpc := &fakeRoomRPC{err: tc.err}
+			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+
+			w := doOnDuty(h, "r1", `{"onDuty":true,"ownerAccount":"alice"}`)
+
+			require.Equal(t, http.StatusServiceUnavailable, w.Code)
+			assert.NotContains(t, w.Body.String(), "nats", "infra cause must not reach the client")
+		})
+	}
+}
+
+// Any other transport fault is internal, with the cause not leaked.
+func TestSetRoomOnDuty_OtherTransportErrorIsInternal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	m := NewMockAdminStore(ctrl)
+
+	rpc := &fakeRoomRPC{err: fmt.Errorf("connection refused")}
+	h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+
+	w := doOnDuty(h, "r1", `{"onDuty":true,"ownerAccount":"alice"}`)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.NotContains(t, w.Body.String(), "connection refused")
+}
+
+// Neither an error envelope nor a success payload means the toggle is unproven.
+func TestSetRoomOnDuty_UnrecognizedReplyIsInternal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "empty", data: []byte{}},
+		{name: "truncated", data: []byte(`{"stat`)},
+		{name: "foreign shape", data: []byte(`{"x":1}`)},
+		{name: "wrong status", data: []byte(`{"status":"accepted"}`)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			m := NewMockAdminStore(ctrl) // strict mock: proves the handler does no store I/O
+
+			rpc := &fakeRoomRPC{reply: &nats.Msg{Data: tc.data}}
+			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+
+			w := doOnDuty(h, "r1", `{"onDuty":true,"ownerAccount":"alice"}`)
+
+			assert.Equal(t, http.StatusInternalServerError, w.Code)
+		})
+	}
+}
+
+// A Handler built without a room client answers 503 rather than panicking.
+func TestSetRoomOnDuty_NilClientIsUnavailable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	m := NewMockAdminStore(ctrl)
+
+	h := newHandler(m, emptySessionStore(), onDutyTestCfg(), nil)
+
+	w := doOnDuty(h, "r1", `{"onDuty":true,"ownerAccount":"alice"}`)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+// Without this hop the two services' logs cannot be correlated.
+func TestSetRoomOnDuty_PropagatesRequestID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	m := NewMockAdminStore(ctrl)
+
+	rpc := &fakeRoomRPC{reply: okReply(t)}
+	h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+
+	const reqID = "01970a4f-8c2d-7c9a-abcd-e0123456789f"
+	r := gin.New()
+	r.Use(ginutil.RequestID())
+	r.Use(func(c *gin.Context) {
+		c.Set(ctxPrincipal, session.Session{ID: "sess-1", UserID: "u", Account: "p_admin", SiteID: "site-A", Roles: []string{"admin"}})
+		c.Next()
+	})
+	r.POST("/rooms/:roomId/onduty", h.setRoomOnDuty)
+
+	req := httptest.NewRequest(http.MethodPost, "/rooms/r1/onduty", strings.NewReader(`{"onDuty":true,"ownerAccount":"alice"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(natsutil.RequestIDHeader, reqID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, rpc.gotHeader, "request must carry a header")
+	assert.Equal(t, reqID, rpc.gotHeader.Get(natsutil.RequestIDHeader))
+}
+
+// A foreign envelope carrying a code outside the closed set must not be
+// re-emitted verbatim — errcode.Parse does not validate it.
+func TestSetRoomOnDuty_UnknownRemoteCodeIsInternal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	m := NewMockAdminStore(ctrl)
+
+	rpc := &fakeRoomRPC{reply: &nats.Msg{Data: []byte(`{"code":"teapot","error":"i am a teapot"}`)}}
+	h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+
+	w := doOnDuty(h, "r1", `{"onDuty":true,"ownerAccount":"alice"}`)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/admin-service/routes.go
+++ b/admin-service/routes.go
@@ -20,6 +20,7 @@ func registerRoutes(r *gin.Engine, h *Handler, sessions session.Store, siteID st
 	admin.GET("/users/:account", h.getUser)
 	admin.PATCH("/users/:account", h.updateUser)
 	admin.POST("/users/:account/password", h.setPassword)
+	admin.POST("/rooms/:roomId/onduty", h.setRoomOnDuty)
 	admin.GET("/sessions", h.listSessions)
 	admin.DELETE("/sessions", h.revokeAllSessions)
 	admin.DELETE("/sessions/:sessionId", h.revokeSession)

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -1612,12 +1612,12 @@ When the synchronous reply is an error envelope, the request was rejected before
 > **Server-internal — not a client RPC.** The "Set Room Restricted" RPC (formerly "Set Room Visibility") is admin-only and lives outside the client API surface. It is a **synchronous** server-to-server NATS request/reply on `chat.server.request.room.{siteID}.restricted`. Admin tooling sends a `RoomRestrictedRequest` (`pkg/model/room.go`) carrying:
 >
 > - `roomId` — channel room to mutate
-> - `account` — the admin caller (used for the sys-message authorship + audit log)
-> - `restricted` — whether the room is members-only; on the `false → true` transition `ownerAccount` is required and that account is promoted to sole owner
+> - `account` — the admin caller; carried as `byAccount` on the room event and recorded in room-service's log line
+> - `restricted` — whether the room is members-only
 > - `externalAccess` — whether the room is reachable from outside the company network (e.g. internet-side / off-VPN clients). This is a network-access gate, NOT a cross-site federation flag
-> - `ownerAccount` — required on the unrestricted-to-restricted transition
+> - `ownerAccount` — **required** on the `false → true` transition. Whenever it is supplied together with `restricted: true` — transition or not — that account is promoted to **sole** owner and every other member is reset to plain member, so an already-restricted room can have its owner rotated. Omit it to change the flags without touching anyone's roles
 >
-> room-service does the Mongo writes, emits a single `OutboxEvent` on the OUTBOX stream (one target per remote federated site), and replies `{"status":"ok","requestId":"…"}` once the work is committed. `outbox-worker` forwards the cross-site `room_restricted` event (at-least-once) to each remote site's `chat.inbox.{remoteSiteID}.external.room_restricted`. No `AsyncJobResult` is emitted — the reply *is* the result.
+> room-service does the Mongo writes, emits one `OutboxEvent` on the OUTBOX stream per remote federated site, and replies `{"status":"ok","requestId":"…"}` once the work is committed. `outbox-worker` forwards the cross-site `room_restricted` event (at-least-once) to each remote site's `chat.inbox.{remoteSiteID}.external.room_restricted`. No `AsyncJobResult` is emitted — the reply *is* the result.
 >
 > Clients learn about the change via a **`RoomRestrictedRoomEvent`** (`type: "room_restricted"`) on the same `chat.room.{roomID}.event` stream they already subscribe to for chat messages. Like `RoomRenamedRoomEvent`, it's a flat struct with no zero-valued envelope fields:
 >
@@ -1629,7 +1629,7 @@ When the synchronous reply is an error envelope, the request was rejected before
 > | `timestamp` | number | Publish time (UTC ms). |
 > | `restricted` | bool | The new restricted state. |
 > | `externalAccess` | bool | The new external-access state. |
-> | `ownerAccount` | string | Omitted unless this was an unrestricted→restricted transition with a designated owner. |
+> | `ownerAccount` | string | The account designated sole owner by this call. Present on any restricting call that named one, including an owner rotation on an already-restricted room; omitted when none was sent. |
 > | `byAccount` | string | The admin who made the change. |
 > | `changedAt` | string | ISO-8601 timestamp of when the change was applied. |
 
@@ -2706,7 +2706,7 @@ Used by every history-service method that returns messages. Mirrors the Cassandr
 | `visibleTo` | string | Optional. Visibility scope. |
 | `reactions` | map<emoji, [ReactionUser](#reactionuser)[]> | Optional. Omitted when absent; `{}` when present but empty. |
 | `deleted` | boolean | Optional. `true` for tombstoned messages. |
-| `type` | string | Optional. System-message type when set; regular messages omit it. Known values: `"room_created"`, `"members_added"`, `"member_removed"`, `"member_left"`, `"room_renamed"`, `"room_restricted"`. For all six, `msg` is populated with a server-rendered human-readable body and `sender.account` is the responsible actor (the requester for adds/removes-by-other / room-creates / renames / restricted changes, the leaving user for self-leave). |
+| `type` | string | Optional. System-message type when set; regular messages omit it. Known values: `"room_created"`, `"members_added"`, `"member_removed"`, `"member_left"`, `"room_renamed"`. For all five, `msg` is populated with a server-rendered human-readable body and `sender.account` is the responsible actor (the requester for adds/removes-by-other / room-creates / renames, the leaving user for self-leave). `"room_restricted"` also appears on historical messages: it is no longer produced — a restriction change emits a [room event](client-api/events.md#room_restricted-roomrestrictedroomevent) instead — but rows written before that change remain readable. |
 | `sysMsgData` | string | Optional. Base64-encoded JSON payload for system messages; shape depends on `type` (see [System-message `sysMsgData` payloads](#system-message-sysmsgdata-payloads)). |
 | `siteId` | string | Optional. The site that owns the message. |
 | `editedAt` | string | Optional. RFC 3339. Set after an edit. |
@@ -7062,6 +7062,69 @@ Lets the logged-in admin change their own password. Verifies `oldPassword` again
 #### Triggered events — success path
 
 `None — HTTP-only.`
+
+#### Triggered events — error path
+
+`None.`
+
+### 9.12 Set room on-duty
+
+**Endpoint:** `POST /v1/admin/rooms/:roomId/onduty`
+**Auth:** `Authorization: Bearer <authToken>`, admin role + same-site required.
+
+Toggles a channel room's on-duty state. On-duty staff work off the company network, so `onDuty: true` narrows who may change the roster (`restricted` — only owners may add members) and permits the connection from outside (`externalAccess`); `onDuty: false` clears both. No room or subscription field named `onDuty` exists — the parameter maps onto those two flags, which are owned by room-service.
+
+**Nothing is displayed.** A restriction change publishes no system message, so no chat entry appears in the room and no notification is sent. Clients are still told: a flat `room_restricted` **room event** carries the new flags on the room's event subject, so open sessions refresh their state without a re-fetch and without rendering anything. No audit row is written — room-service's `processing room.restricted` log line, carrying actor, room, both flags and the designated owner, is the only durable server-side record.
+
+Turning duty **on** designates `ownerAccount` as the room's owner: that account becomes the sole owner and every other member is reset to plain member. Turning duty **off** sends no owner, so roles are left exactly as they are.
+
+Channel rooms only. The caller must also hold the platform `admin` user role, which room-service verifies independently of the session check.
+
+The member floor and the require-an-owner rule apply **only to the unrestricted → restricted transition**. Calling with `onDuty: true` against a room that is *already* restricted rotates the owner — the new account is still validated as a member and still becomes sole owner — but the `RESTRICTED_ROOM_MIN_MEMBERS` floor (default 5) is not re-checked.
+
+#### Request body
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `onDuty` | boolean | yes | `true` sets `restricted` and `externalAccess`; `false` clears both. An absent field is rejected; an explicit `false` is accepted. |
+| `ownerAccount` | string | when `onDuty` is `true` | Account that becomes the room's sole owner. Must be a member of the room. Surrounding whitespace is trimmed, and a whitespace-only value counts as absent. Ignored when `onDuty` is `false`. |
+
+```json
+{ "onDuty": true, "ownerAccount": "alice" }
+```
+
+#### Success response
+
+`HTTP 200`
+
+```json
+{ "status": "ok" }
+```
+
+#### Errors
+
+| Status | `code` | `reason` | Notes |
+|---|---|---|---|
+| 400 | `bad_request` | `missing_fields` | `onDuty` absent, not a boolean, body not valid JSON, or `ownerAccount` absent/blank while `onDuty` is `true`. |
+| 400 | `bad_request` | `non_channel_operation` | Target room is not a channel. |
+| 400 | `bad_request` | — | `ownerAccount` is not a member of the room. |
+| 401 | `unauthenticated` | `invalid_token` | Bearer token missing, unknown, or session not found. |
+| 403 | `forbidden` | `not_admin` | Session lacks the `admin` role or its `siteId` does not match. |
+| 403 | `forbidden` | — | Caller does not hold the platform `admin` user role (raised by room-service). |
+| 404 | `not_found` | — | Room not found. |
+| 409 | `conflict` | — | Room has fewer members than `RESTRICTED_ROOM_MIN_MEMBERS`. Only on the unrestricted → restricted transition. |
+| 500 | `internal` | — | Server-side fault; cause is logged server-side only. |
+| 503 | `unavailable` | — | room-service did not answer within `ROOM_RPC_TIMEOUT`, no responder was reachable, the client disconnected mid-call, room-service shed the request under load, or admin-service has no room-service client configured. The toggle is idempotent and may have applied — retry is safe. |
+
+#### Triggered events — success path
+
+[`room_restricted`](client-api/events.md#room_restricted-roomrestrictedroomevent) — a flat room event on the room's event subject carrying the new `restricted` / `externalAccess` values, the designated `ownerAccount`, and the acting admin. It is a state update, **not** a message: clients apply it to their local subscription and render nothing.
+
+No system message is published, so nothing appears in the room timeline and no push notification is sent.
+
+The event is published last, after every step that can still fail the call, so a non-2xx response means no event went out.
+
+For a room with members homed on other sites, room-service still fans the state change out to each remote site's inbox so their subscription copies stay in step. That is a server-to-server sync, not a client-visible event.
 
 #### Triggered events — error path
 

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -724,7 +724,14 @@ Flat event. Emitted when a channel's `restricted` / `externalAccess` flags chang
 This is a **server-internal admin RPC** — not a client-callable request. Clients receive
 the event on the same room stream they already subscribe to.
 
-**Subject:** `chat.room.{roomID}.event`.
+This is a **state update, not a message**: apply it to the local subscription and render
+nothing. No system message accompanies it, so a restriction change never appears in the room
+timeline and never notifies.
+
+**Subject:** `chat.room.{roomID}.event` — or `chat.local.room.{roomID}.event` for a
+same-site room, depending on the deployment's room-subject routing mode (see
+[client-api.md §Subscriptions](../client-api.md#2-nats-subjects)). Subscribe to whichever
+subject you already use for that room's messages.
 
 | Field | Type | Notes |
 |---|---|---|
@@ -734,9 +741,23 @@ the event on the same room stream they already subscribe to.
 | `timestamp` | number | Publish time (UTC ms). |
 | `restricted` | boolean | The new restricted state. |
 | `externalAccess` | boolean | The new external-access state. |
-| `ownerAccount` | string | Optional. Omitted unless this was an unrestricted→restricted transition with a designated owner. |
+| `ownerAccount` | string | Optional. The account designated as sole owner by this call. Present on any restricting call that named one — including an owner rotation on an already-restricted room; omitted when none was sent. |
 | `byAccount` | string | The admin who made the change. |
 | `changedAt` | string | ISO-8601 timestamp of when the change was applied. |
+
+```json
+{
+  "type": "room_restricted",
+  "roomId": "01970a4f8c2d7c9aQ",
+  "siteId": "siteA",
+  "timestamp": 1778054483000,
+  "restricted": true,
+  "externalAccess": true,
+  "ownerAccount": "alice",
+  "byAccount": "p_admin",
+  "changedAt": "2026-08-03T09:41:23Z"
+}
+```
 
 ---
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -249,9 +249,10 @@ matching `siteId`). Full schemas, examples, and error tables are in
 | `DELETE /v1/admin/sessions?account=<account>` | synchronous HTTP | Revoke all of an account's sessions (§9.7). |
 | `DELETE /v1/admin/sessions/:sessionId?account=<account>` | synchronous HTTP | Revoke a single session (§9.8). |
 | `GET /v1/admin/audit` | synchronous HTTP | List the audit log (§9.9). |
+| `POST /v1/admin/rooms/:roomId/onduty` | synchronous HTTP | Toggle a channel's on-duty state: maps the boolean onto `restricted` + `externalAccess` via room-service's restrict RPC, with `ownerAccount` required when turning on. Emits a `room_restricted` room event; no system message, so nothing is displayed (§9.12). |
 | `POST /v1/password/change` | synchronous HTTP | Logged-in admin's self-service password change (§9.11). |
 
-**Emits:** `None — HTTP-only.`
+**Emits:** None directly — HTTP-only. `POST /v1/admin/rooms/:roomId/onduty` makes room-service publish [`room_restricted`](events.md#room_restricted-roomrestrictedroomevent) on `chat.room.{roomID}.event`.
 
 ---
 

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -394,8 +394,9 @@ type RoomRenamedRoomEvent struct {
 	RenamedAt time.Time     `json:"renamedAt" bson:"renamedAt"`
 }
 
-// RoomRestrictedRoomEvent is published when a channel's restricted/externalAccess flags change;
-// OwnerAccount is set only on the unrestricted→restricted transition. Drives the client's subscription update.
+// RoomRestrictedRoomEvent is published when a channel's restricted/externalAccess flags change.
+// OwnerAccount carries whatever the caller designated — set on any restricting call, including
+// an owner rotation on an already-restricted room. Drives the client's subscription update.
 type RoomRestrictedRoomEvent struct {
 	Type           RoomEventType `json:"type" bson:"type"`
 	RoomID         string        `json:"roomId" bson:"roomId"`

--- a/pkg/model/message.go
+++ b/pkg/model/message.go
@@ -44,16 +44,6 @@ type RoomRenamedSysData struct {
 	ByAccount string `json:"byAccount" bson:"byAccount"`
 }
 
-// RoomRestrictedSysData is the JSON payload stored in Message.SysMsgData
-// for a room_restricted system message — emitted when room.restricted or
-// room.externalAccess flip.
-type RoomRestrictedSysData struct {
-	Restricted     bool   `json:"restricted"             bson:"restricted"`
-	ExternalAccess bool   `json:"externalAccess"         bson:"externalAccess"`
-	ByAccount      string `json:"byAccount"              bson:"byAccount"`
-	OwnerAccount   string `json:"ownerAccount,omitempty" bson:"ownerAccount,omitempty"`
-}
-
 // TeamsMeetStartedSysData is the JSON payload stored in Message.SysMsgData for
 // a teams_meet_started system message — emitted when a Microsoft Teams online
 // meeting is created for a room. It is also the read-back source the meetings

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -4000,13 +4000,6 @@ func TestRoomRestrictedRoomEventJSON(t *testing.T) {
 	roundTrip(t, &e, &model.RoomRestrictedRoomEvent{})
 }
 
-func TestRoomRestrictedSysDataJSON(t *testing.T) {
-	d := model.RoomRestrictedSysData{
-		Restricted: true, ExternalAccess: false, ByAccount: "admin1", OwnerAccount: "alice",
-	}
-	roundTrip(t, &d, &model.RoomRestrictedSysData{})
-}
-
 func TestRoomRenamedInboxPayloadJSON(t *testing.T) {
 	p := model.RoomRenamedInboxPayload{RoomID: "r1", NewName: "x", Timestamp: 1700000000000}
 	roundTrip(t, &p, &model.RoomRenamedInboxPayload{})

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -20,7 +20,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/hmchangw/chat/pkg/displayfmt"
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/idgen"
 	"github.com/hmchangw/chat/pkg/logctx"
@@ -1951,8 +1950,9 @@ func (h *Handler) roomRename(c *natsrouter.Context, req model.RoomRenameRequest)
 
 // roomRestricted is the sync chat.server.> RPC. Account in the body is
 // the audit identity (no subject prefix authenticates the caller — this RPC
-// is server-side admin tooling). Mongo writes + sys-message publish + inbox
-// fan-out happen inline; caller retries safely via dedup IDs.
+// is server-side admin tooling). Mongo writes and the inbox fan-out happen
+// inline and the caller retries safely via dedup IDs; the room event that ends
+// the handler is best-effort and carries none.
 func (h *Handler) roomRestricted(c *natsrouter.Context, req model.RoomRestrictedRequest) (*model.StatusWithRequestReply, error) {
 	var ctx context.Context = c
 	requestID := natsutil.RequestIDFromContext(c)
@@ -1961,10 +1961,15 @@ func (h *Handler) roomRestricted(c *natsrouter.Context, req model.RoomRestricted
 		return nil, fmt.Errorf("%w: roomId and account are required", errInvalidRestrictedSubject)
 	}
 
-	// Admin-only RPC is rare; info-level audit trail is justified.
+	// Admin-only RPC is rare; info-level audit trail is justified. No system
+	// message is published for a restriction change, so this line is the only
+	// durable record of the flags moving and who was made owner.
 	slog.Info("processing room.restricted",
 		"requester", req.Account,
 		"roomID", req.RoomID,
+		"restricted", req.Restricted,
+		"externalAccess", req.ExternalAccess,
+		"ownerAccount", req.OwnerAccount,
 		"request_id", requestID)
 
 	requesterUser, getUserErr := h.store.GetUser(ctx, req.Account)
@@ -2020,39 +2025,6 @@ func (h *Handler) roomRestricted(c *natsrouter.Context, req model.RoomRestricted
 		return nil, fmt.Errorf("apply subscription restricted: %w", err)
 	}
 
-	sysData, err := json.Marshal(model.RoomRestrictedSysData{
-		Restricted:     req.Restricted,
-		ExternalAccess: req.ExternalAccess,
-		ByAccount:      req.Account,
-		OwnerAccount:   req.OwnerAccount,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("marshal restricted sys data: %w", err)
-	}
-	requesterDisplay := displayfmt.CombineWithFallback(requesterUser.EngName, requesterUser.ChineseName, requesterUser.Account)
-	sysMsg := model.Message{
-		ID:          idgen.MessageIDFromRequestID(requestID, "room_restricted"),
-		RoomID:      req.RoomID,
-		UserAccount: req.Account,
-		Type:        model.MessageTypeRoomRestricted,
-		Content:     fmt.Sprintf("%q changed the channel restricted state", requesterDisplay),
-		SysMsgData:  sysData,
-		CreatedAt:   time.UnixMilli(req.Timestamp).UTC(),
-	}
-	msgEvt := model.MessageEvent{
-		Event:     model.EventCreated,
-		Message:   sysMsg,
-		SiteID:    h.siteID,
-		Timestamp: req.Timestamp,
-	}
-	msgEvtData, err := json.Marshal(msgEvt)
-	if err != nil {
-		return nil, fmt.Errorf("marshal sys message event: %w", err)
-	}
-	if err := h.publishToStream(ctx, subject.MsgCanonicalCreated(h.siteID), msgEvtData, natsutil.CanonicalDedupID(&msgEvt)); err != nil {
-		return nil, fmt.Errorf("publish room_restricted sys message: %w", err)
-	}
-
 	subs, err := h.store.ListSubscriptionsByRoom(ctx, req.RoomID)
 	if err != nil {
 		return nil, fmt.Errorf("list subscriptions: %w", err)
@@ -2094,6 +2066,37 @@ func (h *Handler) roomRestricted(c *natsrouter.Context, req model.RoomRestricted
 			}
 		}
 	}
+
+	// A live room event, not a system message: connected clients refresh their
+	// local restricted/externalAccess state without a re-fetch, and nothing is
+	// rendered in the timeline. The message form was removed outright — a
+	// restriction change is an administrative act, not room content — but
+	// MessageTypeRoomRestricted stays registered in pkg/model.systemMessageTypes,
+	// because rooms still hold messages of that type from before the change and
+	// they must keep being excluded from previews and pushes.
+	//
+	// Published last and best-effort: everything that can still fail the RPC has
+	// committed, so clients are never told a change the caller sees fail, and a
+	// publish failure never fails the caller.
+	roomEvt := model.RoomRestrictedRoomEvent{
+		Type:           model.RoomEventRoomRestricted,
+		RoomID:         req.RoomID,
+		SiteID:         h.siteID,
+		Timestamp:      time.Now().UTC().UnixMilli(),
+		Restricted:     req.Restricted,
+		ExternalAccess: req.ExternalAccess,
+		OwnerAccount:   req.OwnerAccount,
+		ByAccount:      req.Account,
+		ChangedAt:      time.UnixMilli(req.Timestamp).UTC(),
+	}
+	evtData, mErr := json.Marshal(roomEvt)
+	if mErr != nil {
+		slog.ErrorContext(ctx, "marshal room_restricted event failed",
+			"error", mErr, "roomID", req.RoomID, "request_id", requestID)
+		return &model.StatusWithRequestReply{Status: "ok", RequestID: requestID}, nil
+	}
+	h.publishRoomEvent(ctx, req.RoomID, room.CrossSite, room.CrossSiteAt, evtData, "room_restricted",
+		"request_id", requestID)
 
 	return &model.StatusWithRequestReply{Status: "ok", RequestID: requestID}, nil
 }

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -5366,7 +5366,9 @@ func TestHandleRoomRestricted_Validation(t *testing.T) {
 				tt.setupStore(store)
 			}
 			h := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5,
-				func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, nil, nil, 0, subject.RouteGlobal)
+				func(_ context.Context, _ string, _ []byte, _ string) error { return nil },
+				func(_ context.Context, _ string, _ []byte) error { return nil },
+				nil, 0, subject.RouteGlobal)
 
 			resp, err := h.roomRestricted(ctxParams(map[string]string{}), tt.req)
 			if tt.wantErr == nil {
@@ -5380,6 +5382,81 @@ func TestHandleRoomRestricted_Validation(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A restriction change publishes a flat room event so clients refresh their local
+// state, but no system message, so nothing is rendered in the timeline. The
+// cross-site fan-out still carries the state to remote sites.
+func TestHandleRoomRestricted_PublishesEventNotSysMessage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockRoomStore(ctrl)
+
+	store.EXPECT().GetUser(gomock.Any(), "admin1").Return(&model.User{Account: "admin1", Roles: []model.UserRole{model.UserRoleAdmin}}, nil)
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, Restricted: false, UserCount: 10}, nil)
+	store.EXPECT().CheckMembership(gomock.Any(), "owner1", "r1").Return(nil)
+	store.EXPECT().UpdateRoomVisibility(gomock.Any(), "r1", true, true).Return(nil)
+	store.EXPECT().ApplySubscriptionRestriction(gomock.Any(), "r1", true, true, "owner1", gomock.Any()).Return(nil)
+	// A member homed elsewhere, so the cross-site fan-out actually runs and the
+	// "state still propagates" half of the claim is testable.
+	store.EXPECT().ListSubscriptionsByRoom(gomock.Any(), "r1").Return([]model.Subscription{
+		{User: model.SubscriptionUser{Account: "bob"}},
+	}, nil)
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return([]model.User{
+		{Account: "bob", SiteID: "site-b"},
+	}, nil)
+
+	var published []string
+	type corePub struct {
+		subj string
+		data []byte
+	}
+	var cores []corePub
+	h := NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5,
+		func(_ context.Context, subj string, _ []byte, _ string) error {
+			published = append(published, subj)
+			return nil
+		},
+		func(_ context.Context, subj string, data []byte) error {
+			cores = append(cores, corePub{subj: subj, data: append([]byte(nil), data...)})
+			return nil
+		}, nil, 0, subject.RouteGlobal)
+
+	_, err := h.roomRestricted(ctxParams(map[string]string{}), model.RoomRestrictedRequest{
+		RoomID: "r1", Account: "admin1", Restricted: true, ExternalAccess: true,
+		OwnerAccount: "owner1",
+	})
+	require.NoError(t, err)
+
+	assert.NotContains(t, published, subject.MsgCanonicalCreated("site-a"),
+		"a restriction change must not reach the canonical message stream")
+
+	// The flat room event carries the new state to connected clients.
+	var evt *model.RoomRestrictedRoomEvent
+	for _, p := range cores {
+		if p.subj != subject.RoomEvent("r1", true) {
+			continue
+		}
+		var got model.RoomRestrictedRoomEvent
+		require.NoError(t, json.Unmarshal(p.data, &got))
+		if got.Type == model.RoomEventRoomRestricted {
+			evt = &got
+		}
+	}
+	require.NotNil(t, evt, "expected a room_restricted room event on the room subject")
+	assert.Equal(t, "r1", evt.RoomID)
+	assert.Equal(t, "site-a", evt.SiteID)
+	assert.True(t, evt.Restricted)
+	assert.True(t, evt.ExternalAccess)
+	assert.Equal(t, "owner1", evt.OwnerAccount)
+	assert.Equal(t, "admin1", evt.ByAccount)
+
+	var federated bool
+	for _, subj := range published {
+		if _, dest, e, ok := subject.ParseOutbox(subj); ok && dest == "site-b" && e == model.InboxRoomRestricted {
+			federated = true
+		}
+	}
+	assert.True(t, federated, "cross-site fan-out must still run")
 }
 
 // TestHandleRoomRestricted_MultiSite_FederatesPerDestination verifies the
@@ -5413,7 +5490,9 @@ func TestHandleRoomRestricted_MultiSite_FederatesPerDestination(t *testing.T) {
 		func(_ context.Context, subj string, data []byte, _ string) error {
 			publishes = append(publishes, pub{subj: subj, data: append([]byte(nil), data...)})
 			return nil
-		}, nil, nil, 0, subject.RouteGlobal)
+		},
+		func(_ context.Context, _ string, _ []byte) error { return nil },
+		nil, 0, subject.RouteGlobal)
 
 	req := model.RoomRestrictedRequest{RoomID: "r1", Account: "admin1", Restricted: false}
 	resp, err := h.roomRestricted(ctxParams(map[string]string{}), req)

--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -2838,6 +2838,117 @@ func TestMongoStore_ApplySubscriptionRestriction_StampsTimestamp(t *testing.T) {
 	assert.Equal(t, ts2.UnixMilli(), subTimeField(t, db, "r1", "alice", "restrictUpdatedAt").UnixMilli())
 }
 
+// seedRestrictRoom inserts one channel room's worth of subscriptions with mixed
+// roles and returns the seed so assertions can compare against it.
+func seedRestrictRoom(t *testing.T, db *mongo.Database, roomID string) []struct {
+	account string
+	roles   []model.Role
+} {
+	t.Helper()
+	seed := []struct {
+		account string
+		roles   []model.Role
+	}{
+		{account: "alice", roles: []model.Role{model.RoleOwner}},
+		{account: "bob", roles: []model.Role{model.RoleAdmin}},
+		{account: "carol", roles: []model.Role{model.RoleMember}},
+		{account: "dave", roles: []model.Role{model.RoleOwner, model.RoleMember}},
+	}
+	for i, s := range seed {
+		mustInsertSub(t, db, &model.Subscription{
+			ID:       idgen.GenerateUUIDv7(),
+			User:     model.SubscriptionUser{ID: fmt.Sprintf("u%d", i+1), Account: s.account},
+			RoomID:   roomID,
+			RoomType: model.RoomTypeChannel,
+			SiteID:   "site-a",
+			Roles:    s.roles,
+			JoinedAt: time.Now().UTC(),
+		})
+	}
+	return seed
+}
+
+// TestMongoStore_ApplySubscriptionRestriction_EmptyOwnerPreservesRoles covers the
+// branch the on-duty toggle takes. Restricting with no ownerAccount must write
+// both flags and leave every member's roles exactly as they were — including a
+// second owner and a multi-role subscription. The handler relies on this to
+// toggle duty without reshuffling who runs the room.
+func TestMongoStore_ApplySubscriptionRestriction_EmptyOwnerPreservesRoles(t *testing.T) {
+	db := testutil.MongoDB(t, "room-svc-restrict-keep-roles")
+	store := NewMongoStore(db)
+	ctx := context.Background()
+
+	seed := seedRestrictRoom(t, db, "r1")
+
+	ts := time.Now().UTC()
+	require.NoError(t, store.ApplySubscriptionRestriction(ctx, "r1", true, true, "", ts))
+
+	for _, s := range seed {
+		got, err := store.GetSubscription(ctx, s.account, "r1")
+		require.NoError(t, err)
+		assert.Equal(t, s.roles, got.Roles, "%s: roles must survive a flags-only restrict", s.account)
+		// restricted/externalAccess are not in subscriptionReadProjection, so they
+		// must be read from the stored doc — the projected struct would report false
+		// whatever was written.
+		assert.True(t, subBoolField(t, db, "r1", s.account, "restricted"), "%s: restricted must be written", s.account)
+		assert.True(t, subBoolField(t, db, "r1", s.account, "externalAccess"), "%s: externalAccess must be written", s.account)
+	}
+	assert.Equal(t, ts.UnixMilli(), subTimeField(t, db, "r1", "alice", "restrictUpdatedAt").UnixMilli())
+}
+
+// The contrast to the test above, and the reason the on-duty caller must send an
+// empty ownerAccount rather than the room's current owner: naming an account
+// rewrites the whole room to that sole owner and demotes everyone else to plain
+// member — an existing admin included.
+func TestMongoStore_ApplySubscriptionRestriction_NamedOwnerRewritesRoles(t *testing.T) {
+	db := testutil.MongoDB(t, "room-svc-restrict-rewrite-roles")
+	store := NewMongoStore(db)
+	ctx := context.Background()
+
+	seedRestrictRoom(t, db, "r1")
+
+	require.NoError(t, store.ApplySubscriptionRestriction(ctx, "r1", true, true, "bob", time.Now().UTC()))
+
+	bob, err := store.GetSubscription(ctx, "bob", "r1")
+	require.NoError(t, err)
+	assert.Equal(t, []model.Role{model.RoleOwner}, bob.Roles, "named account becomes sole owner")
+
+	for _, account := range []string{"alice", "carol", "dave"} {
+		got, err := store.GetSubscription(ctx, account, "r1")
+		require.NoError(t, err)
+		assert.Equal(t, []model.Role{model.RoleMember}, got.Roles, "%s: flattened to member by the rewrite", account)
+	}
+}
+
+// The rewrite branch refuses to run when the named owner has no subscription —
+// it would leave the room with zero owners. The flags-only branch has no such
+// guard; the handler's errOwnerAccountRequired check keeps callers out of it on
+// a false→true transition.
+func TestMongoStore_ApplySubscriptionRestriction_NamedOwnerNotSubscribed(t *testing.T) {
+	db := testutil.MongoDB(t, "room-svc-restrict-owner-missing")
+	store := NewMongoStore(db)
+	ctx := context.Background()
+
+	seed := seedRestrictRoom(t, db, "r1")
+
+	err := store.ApplySubscriptionRestriction(ctx, "r1", true, true, "nonmember", time.Now().UTC())
+	require.ErrorIs(t, err, ErrOwnerNotSubscribed)
+
+	// Rejected before any write: roles untouched and the flag never written. The
+	// seed omits `restricted` entirely, so its absence — not a stored false — is
+	// what proves nothing was applied.
+	for _, s := range seed {
+		got, gErr := store.GetSubscription(ctx, s.account, "r1")
+		require.NoError(t, gErr)
+		assert.Equal(t, s.roles, got.Roles, "%s: roles must be untouched after a rejected restrict", s.account)
+
+		var doc bson.M
+		require.NoError(t, db.Collection("subscriptions").
+			FindOne(ctx, bson.M{"roomId": "r1", "u.account": s.account}).Decode(&doc))
+		assert.NotContains(t, doc, "restricted", "%s: no flag may be written when the owner is rejected", s.account)
+	}
+}
+
 func TestMongoStore_SetOwnerRole_Integration(t *testing.T) {
 	db := testutil.MongoDB(t, "room-svc-role")
 	store := NewMongoStore(db)
@@ -3468,7 +3579,7 @@ func TestIntegration_RoomRename(t *testing.T) {
 func TestIntegration_RoomRestricted(t *testing.T) {
 	const siteID = "site-restricted"
 
-	t.Run("admin syncs restricted state — sys message published + Mongo updated", func(t *testing.T) {
+	t.Run("admin syncs restricted state — Mongo updated, room not told", func(t *testing.T) {
 		db := testutil.MongoDB(t, "room-service-restricted")
 		store := NewMongoStore(db)
 		ctx := context.Background()
@@ -3565,19 +3676,17 @@ func TestIntegration_RoomRestricted(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, updatedRoom.Restricted)
 
-		// Sys message published to canonical messages stream.
+		// A restriction change is administrative, not room content: nothing reaches
+		// the canonical message stream, so the room is never told.
 		mu.Lock()
 		var sawSysMsg bool
 		for _, p := range pubs {
 			if p.subj == subject.MsgCanonicalCreated(siteID) {
 				sawSysMsg = true
-				var msgEvt model.MessageEvent
-				require.NoError(t, json.Unmarshal(p.data, &msgEvt))
-				assert.Equal(t, model.MessageTypeRoomRestricted, msgEvt.Message.Type)
 			}
 		}
 		mu.Unlock()
-		assert.True(t, sawSysMsg, "expected room_restricted sys message to be published")
+		assert.False(t, sawSysMsg, "a restriction change must not publish a sys message")
 	})
 
 	t.Run("non-admin requester is rejected", func(t *testing.T) {

--- a/room-service/store.go
+++ b/room-service/store.go
@@ -237,9 +237,10 @@ type RoomStore interface {
 	// ApplySubscriptionRestriction writes the {restricted, externalAccess} denorm
 	// flags to every subscription of the room. When restricted=true and
 	// ownerAccount is non-empty, an aggregation-pipeline $cond also rewrites
-	// roles so only ownerAccount holds RoleOwner. Returns ErrOwnerNotSubscribed
-	// when ownerAccount has no active subscription in the room (the rewrite
-	// would leave zero owners). Stamps restrictUpdatedAt so the origin doc
+	// roles so only ownerAccount holds RoleOwner. An empty ownerAccount writes
+	// the flags alone and leaves every member's roles as they were. Returns
+	// ErrOwnerNotSubscribed when ownerAccount has no active subscription in the
+	// room (the rewrite would leave zero owners). Stamps restrictUpdatedAt so the origin doc
 	// carries the same high-water mark the federated event publishes (inbox-worker
 	// guards remote applies against it).
 	ApplySubscriptionRestriction(ctx context.Context, roomID string, restricted, externalAccess bool, ownerAccount string, restrictUpdatedAt time.Time) error

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -1709,8 +1709,9 @@ func (s *MongoStore) UpdateRoomVisibility(ctx context.Context, roomID string, re
 // flags to every subscription of the room. When restricted=true and ownerAccount
 // is non-empty, an aggregation-pipeline $cond also rewrites roles so only
 // ownerAccount holds RoleOwner — atomically, so the restrict transition cannot
-// land in a zero-owner state. Returns ErrOwnerNotSubscribed when ownerAccount
-// has no active subscription in the room.
+// land in a zero-owner state. An empty ownerAccount writes the flags alone and
+// leaves roles untouched. Returns ErrOwnerNotSubscribed when ownerAccount has no
+// active subscription in the room.
 func (s *MongoStore) ApplySubscriptionRestriction(ctx context.Context, roomID string, restricted, externalAccess bool, ownerAccount string, restrictUpdatedAt time.Time) error {
 	filter := bson.M{"roomId": roomID}
 


### PR DESCRIPTION
## What

The admin console needs a switch that puts a channel "on duty" — the mode used when staff work off-network and the room has to be locked down to a known membership.

There is no new stored state. `onDuty` is a request parameter that maps onto the room's two pre-existing flags:

| `onDuty` | `restricted` | `externalAccess` |
|---|---|---|
| `true` | `true` | `true` |
| `false` | `false` | `false` |

It is persisted nowhere — not on the room, not on a subscription, not in the audit log. The durable state is those two flags, which already existed and already drive the membership and external-access checks.

## Endpoint

```
POST /v1/admin/rooms/:roomId/onduty
Authorization: Bearer <authToken>

{ "onDuty": true, "ownerAccount": "alice" }
{ "onDuty": false }
```

admin-service does not touch Mongo for this. It calls room-service's existing restrict RPC (`chat.server.request.room.{siteID}.restricted`) over NATS request/reply, so every rule stays in one place and cross-site federation comes along for free.

**Turning duty ON:**
- admin-only — session `admin` role + matching site in admin-service, then a platform-admin check in room-service
- `ownerAccount` is required and becomes the room's sole owner
- that account must already be a member of the room
- the room needs at least 5 members (`RESTRICTED_ROOM_MIN_MEMBERS`, default 5)
- channels only

**Turning duty OFF:** same admin gate; both flags cleared on the room and on every subscription. No owner is sent, so no role is touched and the member floor does not apply.

## No announcement

A duty switch is a hidden operation. room-service no longer publishes a system message for a restriction change — not behind a flag, not for any caller. The announcement is gone outright, so nothing renders in the timeline and nothing notifies.

What it does publish is a flat `room_restricted` **room event** on `chat.room.{roomID}.event` — a state update clients apply without rendering anything. That event type was already defined, round-trip tested and documented, but had no publisher; this wires it up.

Everything else still happens: the room document and every subscription are written, and the change federates to every site that homes a member.

## Reviewer notes

Two decisions worth a second opinion:

1. **The guards are transition-scoped.** `ownerAccount`-required and the ≥5 floor only run on a `false→true` transition. Re-calling on an already-restricted room with a different owner still rotates ownership and still validates that the new owner is a member — only the floor and the require-an-owner rule skip. This is deliberate: re-running the floor would mean a duty room that dropped below five members could never change its on-call owner again, and rotating the on-call owner is the common operation.

2. **Turning duty OFF does not restore prior roles.** Turning it ON flattens every non-owner to `member`, including anyone who held `admin`. Prior roles are recorded nowhere, so that flattening is permanent. If the flow this replaces restored them on the way out, this is a missing feature rather than a port — worth confirming before merge.

## Changes

- **admin-service** — new `room_onduty.go` (handler, request validation, timed NATS RPC, error mapping), route registration, NATS wiring in `main.go` via `natsutil.Connect` with drain on shutdown, and `NATS_URL` / `ROOM_RPC_TIMEOUT` config (the timeout is validated `> 0` and below the HTTP write timeout, so the server can't cut off its own reply).
- **room-service** — the restrict handler drops the system-message publish and emits the room event instead, best-effort and last, so a publish failure never fails the caller and clients are never told about a change the caller saw fail. Flag-only updates now preserve subscription roles; a named owner still rewrites them.
- **pkg/model** — `RoomRestrictedSysData` deleted (it had no producer and no consumer once the system message went away); corrected the `ownerAccount` comment on the room event.
- **docs** — `client-api.md` §9.12 and the restrict-RPC note, plus both derived views.

## Testing

| Check | Result |
|---|---|
| `make lint` | 0 issues |
| `make test` (whole repo, `-race`) | green |
| `make test-integration SERVICE=admin-service` | green — 4 duty tests against real Mongo + NATS |
| `make test-integration SERVICE=room-service` | green — incl. 4 store-branch tests for the role-preservation split |
| `gosec` / repo-local `semgrep` | 0 findings |
| `setRoomOnDuty` coverage | 90.7% of statements |

`govulncheck` was not run locally — `vuln.go.dev` is unreachable from this environment, same as on `main`. CI covers it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint to toggle a room’s on-duty status.
  * Administrators can set restriction and external-access settings, with optional owner assignment or rotation.
  * Changes synchronize with the room service and emit room events.

* **Bug Fixes**
  * Improved handling of invalid requests, unavailable services, timeouts, and remote errors.
  * Administrative restriction changes no longer create timeline messages, notifications, or audit records.

* **Documentation**
  * Updated API and event documentation to describe owner behavior, synchronization, events, and error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->