### PR TITLE
Route member events through the local/global room subject split

### DIFF
--- a/.semgrep/room-subject.yml
+++ b/.semgrep/room-subject.yml
@@ -3,10 +3,11 @@ rules:
     languages: [go]
     severity: ERROR
     message: >
-      Publish a channel room's .event through the service's publishRoomEvent
-      helper, which fans out over subject.RoomEventTargets(id, crossSite,
-      routeMode). Passing a subject built inline by subject.RoomEvent /
-      RoomMsgStream / RoomMetadataUpdate to a publish call skips the
+      Publish a channel room's .event / .event.member through the service's
+      publishRoomEvent / publishMemberEvent helper, which fans out over
+      subject.RoomEventTargets / RoomMemberEventTargets(roomID, crossSite,
+      crossSiteAt, mode, now). Passing a subject built inline by subject.RoomEvent /
+      RoomMsgStream / RoomMetadataUpdate / RoomMemberEvent to a publish call skips the
       ROOM_SUBJECT_MODE global/local routing, so same-site rooms silently miss
       delivery once local mode is enabled (and dual mode loses its global
       safety-net publish). See pkg/subject.RoomEventTargets and each service's
@@ -28,3 +29,6 @@ rules:
           - pattern: $X.publish($CTX, subject.RoomEvent(...), ...)
           - pattern: $X.publish($CTX, subject.RoomMsgStream(...), ...)
           - pattern: $X.publish($CTX, subject.RoomMetadataUpdate(...), ...)
+          - pattern: $X.Publish($CTX, subject.RoomMemberEvent(...), ...)
+          - pattern: $X.publishCore($CTX, subject.RoomMemberEvent(...), ...)
+          - pattern: $X.publish($CTX, subject.RoomMemberEvent(...), ...)

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -1305,7 +1305,7 @@ On `added` / `role_updated` / `mute_toggled` / `favorite_toggled` / `opened` the
 
 **3.** ~~`chat.user.{newMember}.event.room.key`~~ — **no longer fired on add.** The room key is delivered inline on the `added` event above (`subscription.room.privateKey` / `keyVersion`); `room.key` events now fire only on key rotation (member removal). See [§5 Room Encryption](#5-room-encryption).
 
-**4. `chat.room.{roomID}.event.member`** — a `MemberAddEvent` (`type: "member_added"`) published once whenever the room's member list actually changes: a new account joins, a genuinely new org is added, or an existing org member is upgraded to an individual membership (see the no-op note below for what does **not** fire). Delivered to clients subscribed to `chat.room.>` for the room.
+**4. `chat.room.{roomID}.event.member` / `chat.local.room.{roomID}.event.member`** — a `MemberAddEvent` (`type: "member_added"`) published once whenever the room's member list actually changes: a new account joins, a genuinely new org is added, or an existing org member is upgraded to an individual membership (see the no-op note below for what does **not** fire). Routed on the room's namespace exactly like `chat.room.{roomID}.event` — pick the subject by the room's `crossSite` flag (`chat.local.room.{roomID}.event.member` when `crossSite: false`, `chat.room.{roomID}.event.member` when `crossSite: true`/unknown). Delivered to clients subscribed to the room on that namespace.
 
 | Field | Type | Notes |
 |---|---|---|
@@ -1410,7 +1410,7 @@ See [Error envelope](#6-error-envelope-reference). Returned synchronously when v
 
 **3. `chat.user.{survivor}.event.room.key`** — on a channel removal the room key is **rotated**; every surviving member receives a new `RoomKeyEvent` with an incremented `version`. The removed account stops receiving key events. See [§5 Room Encryption](#5-room-encryption).
 
-**4. `chat.room.{roomID}.event.member`** — a `MemberRemoveEvent` (`type: "member_left"` for a self-leave, `"member_removed"` for a forced removal or org removal). Delivered to clients subscribed to `chat.room.>`.
+**4. `chat.room.{roomID}.event.member` / `chat.local.room.{roomID}.event.member`** — a `MemberRemoveEvent` (`type: "member_left"` for a self-leave, `"member_removed"` for a forced removal or org removal). Routed on the room's namespace by its `crossSite` flag, exactly like the add event above (`chat.local.room.{roomID}.event.member` when `crossSite: false`).
 
 | Field | Type | Notes |
 |---|---|---|

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -48,7 +48,7 @@ For connection, auth, and error details see [../client-api.md](../client-api.md)
 | `chat.user.{account}.event.room.key` | RoomKeyEvent |
 | `chat.room.{roomID}.event` | new_message, message_edited, message_deleted, message_pinned/unpinned, message_reacted, thread_metadata_updated, message_read, thread_message_read, room_renamed, room_restricted |
 | `chat.user.{account}.event.room` | same event types as above, per-user fan-out for DM/botDM rooms |
-| `chat.room.{roomID}.event.member` | member_added, member_left / member_removed |
+| `chat.room.{roomID}.event.member` (or `chat.local.room.{roomID}.event.member` for same-site rooms, by `crossSite`) | member_added, member_left / member_removed |
 | `chat.user.{account}.notification` | NotificationEvent (reaction only) |
 | `chat.user.presence.state.{account}` | PresenceState |
 
@@ -742,7 +742,9 @@ the event on the same room stream they already subscribe to.
 
 ## member — room membership events
 
-**Subject:** `chat.room.{roomID}.event.member`
+**Subject:** `chat.room.{roomID}.event.member` — routed on the room's namespace by its
+`crossSite` flag (like `chat.room.{roomID}.event`): `chat.local.room.{roomID}.event.member`
+when `crossSite: false` (same-site), `chat.room.{roomID}.event.member` when `true`/unknown.
 
 ### member_added (MemberAddEvent)
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -364,7 +364,7 @@ available (no app record / disabled assistant), user/org not found.
 { "code": "conflict", "reason": "max_room_size_reached", "error": "room is at maximum capacity" }
 ```
 
-**Emits:** [`AsyncJobResult`](events.md#asyncjobresult--async-completion) (`operation: "room.member.add"`), [`subscription.update`](events.md#subscriptionupdate--membership--state-changes) (`action: "added"` — one per newly subscribed member, bots included on their encoded per-user subject, embedding the room object incl. the room key for channels; no separate `room.key` event), [`member_added`](events.md#member_added-memberaddevent) (on `chat.room.{roomID}.event.member`), `new_message` system message (`members_added`) → [events.md](events.md#new_message-roomevent)
+**Emits:** [`AsyncJobResult`](events.md#asyncjobresult--async-completion) (`operation: "room.member.add"`), [`subscription.update`](events.md#subscriptionupdate--membership--state-changes) (`action: "added"` — one per newly subscribed member, bots included on their encoded per-user subject, embedding the room object incl. the room key for channels; no separate `room.key` event), [`member_added`](events.md#member_added-memberaddevent) (on `chat.room.{roomID}.event.member`, or `chat.local.room.{roomID}.event.member` for same-site rooms by `crossSite`), `new_message` system message (`members_added`) → [events.md](events.md#new_message-roomevent)
 
 ---
 
@@ -395,7 +395,7 @@ Synchronous: neither/both of `account`/`orgId` set; requester not an owner; targ
 last **human** member (bots don't count, and a bot target skips the guard); org member
 cannot leave individually.
 
-**Emits:** [`AsyncJobResult`](events.md#asyncjobresult--async-completion) (`operation: "room.member.remove"` or `"room.member.remove_org"`), [`subscription.update`](events.md#subscriptionupdate--membership--state-changes) (`action: "removed"` — one per removed account, bots included on their encoded per-user subject), [`room.key`](events.md#roomkey--room-encryption-key-delivery) (channel rooms — key rotated; surviving members receive new event), [`member_left` / `member_removed`](events.md#member_left--member_removed-memberremoveevent) (on `chat.room.{roomID}.event.member`), `new_message` system message → [events.md](events.md#new_message-roomevent)
+**Emits:** [`AsyncJobResult`](events.md#asyncjobresult--async-completion) (`operation: "room.member.remove"` or `"room.member.remove_org"`), [`subscription.update`](events.md#subscriptionupdate--membership--state-changes) (`action: "removed"` — one per removed account, bots included on their encoded per-user subject), [`room.key`](events.md#roomkey--room-encryption-key-delivery) (channel rooms — key rotated; surviving members receive new event), [`member_left` / `member_removed`](events.md#member_left--member_removed-memberremoveevent) (on `chat.room.{roomID}.event.member`, or `chat.local.room.{roomID}.event.member` for same-site rooms by `crossSite`), `new_message` system message → [events.md](events.md#new_message-roomevent)
 
 ---
 

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -190,10 +190,6 @@ func MemberList(account, roomID, siteID string) string {
 	return fmt.Sprintf("chat.user.%s.request.room.%s.%s.member.list", account, roomID, siteID)
 }
 
-func MemberEvent(roomID string) string {
-	return fmt.Sprintf("chat.room.%s.event.member", roomID)
-}
-
 func RoomCanonical(siteID, operation string) string {
 	return fmt.Sprintf("chat.room.canonical.%s.%s", siteID, operation)
 }
@@ -372,30 +368,57 @@ func ParseRoomRouteMode(s string) (RoomRouteMode, error) {
 	}
 }
 
-// usesLocal reports whether the route mode publishes to the local subject at
-// all (dual or local). Global mode never touches the local namespace.
-func (m RoomRouteMode) usesLocal() bool { return m != RouteGlobal }
+// UsesLocal reports whether the route mode publishes to the local subject at
+// all (dual or local). Global mode never touches the local namespace, so callers
+// can skip a locality lookup entirely — routing is global regardless of crossSite.
+func (m RoomRouteMode) UsesLocal() bool { return m != RouteGlobal }
 
-// RoomEventTargets returns the .event subject(s) to publish a room event to.
-// Fail-safe: only an explicit crossSite=false routes local (nil/true → global).
-// A room flipped within the locality grace window (crossSiteAt set) also gets a local
-// copy in local/dual mode so not-yet-resubscribed members keep receiving (order: local, global).
-func RoomEventTargets(roomID string, crossSite *bool, crossSiteAt *time.Time, mode RoomRouteMode, now time.Time) []string {
+// roomRouteGlobals returns which namespace(s) a room's per-room events route to,
+// as global flags (false=local chat.local.room.>, true=global chat.room.>), honoring
+// crossSite, mode, and the post-flip grace window. Shared by every per-room subject
+// (.event, .event.member) so they route identically. Fail-safe: only an explicit
+// crossSite=false routes local (nil/true → global). A room flipped within the locality
+// grace window (crossSiteAt set) also gets a local copy in local/dual mode so
+// not-yet-resubscribed members keep receiving (order: local, global).
+func roomRouteGlobals(crossSite *bool, crossSiteAt *time.Time, mode RoomRouteMode, now time.Time) []bool {
 	if crossSite != nil && !*crossSite { // confirmed same-site
 		switch mode {
 		case RouteLocal:
-			return []string{RoomEvent(roomID, false)}
+			return []bool{false}
 		case RouteDual:
-			return []string{RoomEvent(roomID, false), RoomEvent(roomID, true)}
+			return []bool{false, true}
 		default:
-			return []string{RoomEvent(roomID, true)}
+			return []bool{true}
 		}
 	}
 	// nil or cross-site → global, plus a local copy during the post-flip grace window.
-	if mode.usesLocal() && crossSiteAt != nil && now.Before(crossSiteAt.Add(roomLocalityGrace)) {
-		return []string{RoomEvent(roomID, false), RoomEvent(roomID, true)}
+	if mode.UsesLocal() && crossSiteAt != nil && now.Before(crossSiteAt.Add(roomLocalityGrace)) {
+		return []bool{false, true}
 	}
-	return []string{RoomEvent(roomID, true)}
+	return []bool{true}
+}
+
+// RoomEventTargets returns the .event subject(s) to publish a room event to.
+func RoomEventTargets(roomID string, crossSite *bool, crossSiteAt *time.Time, mode RoomRouteMode, now time.Time) []string {
+	globals := roomRouteGlobals(crossSite, crossSiteAt, mode, now)
+	out := make([]string, len(globals))
+	for i, g := range globals {
+		out[i] = RoomEvent(roomID, g)
+	}
+	return out
+}
+
+// RoomMemberEventTargets returns the .event.member subject(s) to publish a member
+// add/remove event to. Routes identically to RoomEventTargets so a same-site room's
+// roster events land on the local namespace and a flipped room dual-publishes during
+// the grace window — otherwise a client on the local prefix misses member events.
+func RoomMemberEventTargets(roomID string, crossSite *bool, crossSiteAt *time.Time, mode RoomRouteMode, now time.Time) []string {
+	globals := roomRouteGlobals(crossSite, crossSiteAt, mode, now)
+	out := make([]string, len(globals))
+	for i, g := range globals {
+		out[i] = RoomMemberEvent(roomID, g)
+	}
+	return out
 }
 
 func UserRoomEvent(account string) string {
@@ -875,14 +898,18 @@ func RoomCreateWildcard(siteID string) string {
 	return fmt.Sprintf("chat.user.*.request.room.%s.create", siteID)
 }
 
-func RoomMemberEvent(roomID string) string {
-	return fmt.Sprintf("chat.room.%s.event.member", roomID)
+// RoomMemberEvent returns a room's member-event subject on the given namespace:
+// global=true → chat.room.{id}.event.member; global=false → chat.local.room.{id}.event.member.
+// Route via RoomMemberEventTargets rather than calling this directly at a publish site.
+func RoomMemberEvent(roomID string, global bool) string {
+	return roomBase(roomID, global) + ".event.member"
 }
 
 // RoomMemberEventWildcard is the subscription pattern matching member events
-// (member_added / member_removed) across all rooms on this site.
-func RoomMemberEventWildcard() string {
-	return "chat.room.*.event.member"
+// (member_added / member_removed) across all rooms on this site, on the given
+// namespace. A same-site room's member events land on the local (global=false) lane.
+func RoomMemberEventWildcard(global bool) string {
+	return roomBase("*", global) + ".event.member"
 }
 
 func MsgThreadParentPattern(siteID string) string {

--- a/pkg/subject/subject_test.go
+++ b/pkg/subject/subject_test.go
@@ -77,10 +77,14 @@ func TestSubjectBuilders(t *testing.T) {
 			"chat.user.alice.request.room.r1.site-a.member.remove"},
 		{"MemberAdd", subject.MemberAdd("alice", "r1", "site-a"),
 			"chat.user.alice.request.room.r1.site-a.member.add"},
-		{"MemberEvent", subject.MemberEvent("r1"),
+		{"RoomMemberEvent global", subject.RoomMemberEvent("r1", true),
 			"chat.room.r1.event.member"},
-		{"RoomMemberEventWildcard", subject.RoomMemberEventWildcard(),
+		{"RoomMemberEvent local", subject.RoomMemberEvent("r1", false),
+			"chat.local.room.r1.event.member"},
+		{"RoomMemberEventWildcard global", subject.RoomMemberEventWildcard(true),
 			"chat.room.*.event.member"},
+		{"RoomMemberEventWildcard local", subject.RoomMemberEventWildcard(false),
+			"chat.local.room.*.event.member"},
 		{"MemberList", subject.MemberList("alice", "r1", "site-a"),
 			"chat.user.alice.request.room.r1.site-a.member.list"},
 		{"MemberListWildcard", subject.MemberListWildcard("site-a"),
@@ -1176,6 +1180,30 @@ func TestRoomEventTargets(t *testing.T) {
 	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", nil, nil, subject.RouteGlobal, now))
 	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", nil, nil, subject.RouteDual, now))
 	assert.Equal(t, []string{g}, subject.RoomEventTargets("r1", nil, nil, subject.RouteLocal, now))
+}
+
+// TestRoomMemberEventTargets verifies member events route on the same namespaces
+// as RoomEventTargets (they share roomRouteGlobals), so a client on the local
+// prefix for a same-site room receives roster events; and that a flipped room
+// dual-publishes them during the grace window.
+func TestRoomMemberEventTargets(t *testing.T) {
+	g := "chat.room.r1.event.member"
+	l := "chat.local.room.r1.event.member"
+	trueP, falseP := true, false
+	now := time.Unix(1_700_000_000, 0).UTC()
+	// same-site: local-only in local mode, both in dual, global in global.
+	assert.Equal(t, []string{l}, subject.RoomMemberEventTargets("r1", &falseP, nil, subject.RouteLocal, now))
+	assert.Equal(t, []string{l, g}, subject.RoomMemberEventTargets("r1", &falseP, nil, subject.RouteDual, now))
+	assert.Equal(t, []string{g}, subject.RoomMemberEventTargets("r1", &falseP, nil, subject.RouteGlobal, now))
+	// cross-site / nil → global fail-safe.
+	assert.Equal(t, []string{g}, subject.RoomMemberEventTargets("r1", &trueP, nil, subject.RouteLocal, now))
+	assert.Equal(t, []string{g}, subject.RoomMemberEventTargets("r1", nil, nil, subject.RouteLocal, now))
+	// flipped within grace → dual in local/dual mode so both lanes get the roster event.
+	flip := now.Add(-time.Minute)
+	assert.Equal(t, []string{l, g}, subject.RoomMemberEventTargets("r1", &trueP, &flip, subject.RouteLocal, now))
+	// past grace → global only.
+	oldFlip := now.Add(-2 * subject.DefaultRoomLocalityGrace)
+	assert.Equal(t, []string{g}, subject.RoomMemberEventTargets("r1", &trueP, &oldFlip, subject.RouteLocal, now))
 }
 
 // TestRoomEventTargets_TransitionGrace covers the post-flip grace window: a room

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -457,9 +457,8 @@ func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.Remove
 		Timestamp: now.UnixMilli(),
 	}
 	memberEvtData, _ := json.Marshal(memberEvt)
-	if err := h.publish(ctx, subject.MemberEvent(req.RoomID), memberEvtData, ""); err != nil {
-		slog.ErrorContext(ctx, "member event publish failed", "error", err, "room_id", req.RoomID)
-	}
+	crossSite, crossSiteAt := h.roomLocalityForMember(ctx, req.RoomID)
+	h.publishMemberEvent(ctx, req.RoomID, crossSite, crossSiteAt, memberEvtData, "member_removed")
 
 	// Wrapper Type collapses to member_removed even for self-leave so
 	// search-sync-worker dispatches on one MV op; inner Type is preserved.
@@ -669,9 +668,8 @@ func (h *Handler) processRemoveOrg(ctx context.Context, req *model.RemoveMemberR
 			Timestamp: now.UnixMilli(),
 		}
 		memberEvtData, _ := json.Marshal(memberEvt)
-		if err := h.publish(ctx, subject.MemberEvent(req.RoomID), memberEvtData, ""); err != nil {
-			slog.ErrorContext(ctx, "member event publish failed", "error", err, "room_id", req.RoomID)
-		}
+		crossSite, crossSiteAt := h.roomLocalityForMember(ctx, req.RoomID)
+		h.publishMemberEvent(ctx, req.RoomID, crossSite, crossSiteAt, memberEvtData, "member_removed")
 
 		internalEvt := model.InboxEvent{
 			Type:       model.InboxMemberRemoved,
@@ -1173,13 +1171,11 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 		memberAddEvt.Accounts = nil
 		memberAddEvt.Members = buildAddedMembers(&req, inputs.orgDisplayRows, userMap)
 		memberAddData, _ := json.Marshal(memberAddEvt)
-		if err := h.publish(ctx, subject.RoomMemberEvent(req.RoomID), memberAddData, ""); err != nil {
-			slog.ErrorContext(ctx, "member add event publish failed",
-				"error", err,
-				"room_id", req.RoomID,
-				"request_id", natsutil.RequestIDFromContext(ctx),
-			)
-		}
+		// Route on the room's prior locality: at a flip all existing members are still
+		// on the local subject (they re-subscribe global only after their next
+		// subscription.list), and the newly-added remote member bootstraps its roster
+		// via member.list — so prior-state routing reaches everyone who needs the delta.
+		h.publishMemberEvent(ctx, req.RoomID, room.CrossSite, room.CrossSiteAt, memberAddData, "member_added")
 
 		if len(actualAccounts) > 0 {
 			internalEvt := model.InboxEvent{
@@ -2347,6 +2343,36 @@ func (h *Handler) publishRoomEvent(ctx context.Context, roomID string, crossSite
 			slog.Error("publish room event failed", "error", err, "op", op, "room_id", roomID, "subject", subj)
 		}
 	}
+}
+
+// publishMemberEvent fans a member add/remove event out via subject.RoomMemberEventTargets
+// so it routes on the same namespace(s) as the room's .event — a same-site room's roster
+// events land on the local subject its clients subscribe to (and a flipped room dual-publishes
+// during the grace window). Sanctioned path (a .semgrep rule blocks inline publishes); best-effort.
+func (h *Handler) publishMemberEvent(ctx context.Context, roomID string, crossSite *bool, crossSiteAt *time.Time, payload []byte, op string) {
+	now := time.Now().UTC()
+	for _, subj := range subject.RoomMemberEventTargets(roomID, crossSite, crossSiteAt, h.routeMode, now) {
+		if err := h.publish(ctx, subj, payload, ""); err != nil {
+			slog.Error("publish member event failed", "error", err, "op", op, "room_id", roomID, "subject", subj)
+		}
+	}
+}
+
+// roomLocalityForMember fetches a room's crossSite/crossSiteAt for member-event routing
+// (removes don't change locality, so the cached meta is authoritative). In global mode the
+// read is skipped — routing is global regardless of crossSite. On a read error it returns
+// nil,nil — the RoomMemberEventTargets fail-safe routes global, never a silent miss.
+func (h *Handler) roomLocalityForMember(ctx context.Context, roomID string) (*bool, *time.Time) {
+	if !h.routeMode.UsesLocal() {
+		return nil, nil
+	}
+	room, err := h.store.GetRoomMeta(ctx, roomID)
+	if err != nil {
+		slog.WarnContext(ctx, "member event locality lookup failed; routing global",
+			"error", err, "room_id", roomID)
+		return nil, nil
+	}
+	return room.CrossSite, room.CrossSiteAt
 }
 
 func (h *Handler) publishSyncDMInbox(ctx context.Context, room *model.Room, requester, other *model.User, joinedAt time.Time) error {

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -125,7 +125,7 @@ func TestHandler_ProcessRemoveMember_SelfLeave_IndividualOnly(t *testing.T) {
 	}
 
 	assert.True(t, subjSet[subject.SubscriptionUpdate(account)], "expected subscription update published")
-	assert.True(t, subjSet[subject.MemberEvent(roomID)], "expected member event published")
+	assert.True(t, subjSet[subject.RoomMemberEvent(roomID, true)], "expected member event published")
 	assert.True(t, subjSet[subject.InboxInternal(siteID, model.InboxMemberRemoved)], "expected local INBOX member_removed published")
 
 	for _, p := range published {
@@ -197,7 +197,7 @@ func TestHandler_ProcessRemoveMember_BotTarget_RotatesAndSubUpdate(t *testing.T)
 	assert.True(t, subjSet[subject.SubscriptionUpdate(botAcct)], "bot gets a subscription.update on removal (FE-login capable)")
 	// Pin the encoding independently of the builder: weather.bot → weather_bot.
 	assert.True(t, subjSet["chat.user.weather_bot.event.subscription.update"], "bot subscription.update lands on its encoded per-user subject")
-	assert.True(t, subjSet[subject.MemberEvent(roomID)], "member event still fires for the removal")
+	assert.True(t, subjSet[subject.RoomMemberEvent(roomID, true)], "member event still fires for the removal")
 }
 
 func TestHandler_ProcessRemoveMember_SelfLeave_DualMembership(t *testing.T) {
@@ -430,7 +430,7 @@ func TestHandler_ProcessRemoveMember_OwnerRemovesIndividual(t *testing.T) {
 
 	// Verify the sys msg has type "member_removed"
 	for _, p := range published {
-		if p.subj == subject.MemberEvent(roomID) {
+		if p.subj == subject.RoomMemberEvent(roomID, true) {
 			var evt model.MemberRemoveEvent
 			require.NoError(t, json.Unmarshal(p.data, &evt))
 			assert.Equal(t, "member_removed", evt.Type)
@@ -657,6 +657,51 @@ func TestProcessAddMembers_SameSite_NoCrossSiteWrite(t *testing.T) {
 	reqData, _ := json.Marshal(req)
 	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
 	require.NoError(t, h.processAddMembers(ctx, reqData))
+}
+
+// TestProcessAddMembers_LocalMode_MemberEventOnLocalSubject verifies that in local
+// mode a same-site room's member_added event publishes on the local .event.member
+// subject (not the global one), so a client subscribed on the local prefix for the
+// room receives the roster update.
+func TestProcessAddMembers_LocalMode_MemberEventOnLocalSubject(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	var published []publishedMsg
+	publish := func(_ context.Context, subj string, data []byte, _ string) error {
+		published = append(published, publishedMsg{subj: subj, data: data})
+		return nil
+	}
+	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteLocal)
+
+	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
+	store.EXPECT().ListAddMemberCandidates(gomock.Any(), nil, []string{"x"}, "r1").
+		Return([]AddMemberCandidate{{Account: "x", HasSubscription: false, HasIndividualRoomMember: false, SiteID: "site-a"}}, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(false, nil)
+	expectGetRoom(store, "r1", "eng")
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"x"}).Return([]model.User{
+		{ID: "u2", Account: "x", SiteID: "site-a", EngName: "X"},
+	}, nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a", EngName: "Alice"}, nil)
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), "r1", 1, 0, gomock.Any()).Return(false, nil)
+	store.EXPECT().SetRoomCrossSite(gomock.Any(), gomock.Any()).Times(0)
+
+	req := model.AddMembersRequest{RoomID: "r1", Users: []string{"x"}, RequesterAccount: "alice", Timestamp: 1}
+	reqData, _ := json.Marshal(req)
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+	require.NoError(t, h.processAddMembers(ctx, reqData))
+
+	var gotLocal, gotGlobal bool
+	for _, p := range published {
+		switch p.subj {
+		case subject.RoomMemberEvent("r1", false):
+			gotLocal = true
+		case subject.RoomMemberEvent("r1", true):
+			gotGlobal = true
+		}
+	}
+	assert.True(t, gotLocal, "member event must publish on the local subject in local mode for a same-site room")
+	assert.False(t, gotGlobal, "member event must NOT publish on the global subject for a same-site room in local mode")
 }
 
 // TestProcessAddMembers_Redelivery_CrossSite_StillMarks is the regression test
@@ -1024,7 +1069,7 @@ func TestHandler_ProcessAddMembers_HistoryAll(t *testing.T) {
 // RoomMemberEvent(roomID). Fails the test if no such publish occurred.
 func findMemberAddEvent(t *testing.T, published []publishedMsg, roomID string) (model.MemberAddEvent, []byte) {
 	t.Helper()
-	want := subject.RoomMemberEvent(roomID)
+	want := subject.RoomMemberEvent(roomID, true)
 	for _, p := range published {
 		if p.subj != want {
 			continue
@@ -1464,7 +1509,7 @@ func TestHandler_ProcessAddMembers_OrgDisplayFetchErrorFailsBeforeWrites(t *test
 	assert.Contains(t, err.Error(), "org display")
 
 	for _, p := range published {
-		assert.NotEqual(t, subject.RoomMemberEvent("r1"), p.subj, "no room event may be published when enrichment fails")
+		assert.NotEqual(t, subject.RoomMemberEvent("r1", true), p.subj, "no room event may be published when enrichment fails")
 	}
 }
 
@@ -1681,7 +1726,7 @@ func TestHandler_ProcessRemoveMember_OwnerRemovesOrg(t *testing.T) {
 	assert.True(t, subjSet[subject.SubscriptionUpdate("carol")], "expected subscription update for carol")
 	assert.True(t, subjSet[subject.SubscriptionUpdate("dave")], "expected subscription update for dave")
 	assert.False(t, subjSet[subject.SubscriptionUpdate("eve")], "eve has individual membership, should not be removed")
-	assert.True(t, subjSet[subject.MemberEvent(roomID)], "expected member event published")
+	assert.True(t, subjSet[subject.RoomMemberEvent(roomID, true)], "expected member event published")
 
 	// Sys-message must carry sender (UserAccount = requester) and Content
 	// rendered from the org's SectName (spec §2.4). The previous version of
@@ -2035,7 +2080,7 @@ func TestHandler_ProcessAddMembers_OrgReAddAlreadyPresent_NoEvent(t *testing.T) 
 	data, _ := json.Marshal(req)
 	require.NoError(t, h.processAddMembers(natsutil.WithRequestID(context.Background(), testRequestID), data))
 
-	memberEventSubj := subject.RoomMemberEvent("r1")
+	memberEventSubj := subject.RoomMemberEvent("r1", true)
 	sysMsgSubj := subject.MsgCanonicalCreated("site-a")
 	for _, p := range published {
 		assert.NotEqual(t, memberEventSubj, p.subj, "re-add of a present org must NOT publish member_added")

--- a/room-worker/integration_test.go
+++ b/room-worker/integration_test.go
@@ -1271,7 +1271,7 @@ func TestProcessAddMembers_RoomEventMembersEnrichment_Integration(t *testing.T) 
 	require.NoError(t, err)
 	require.NoError(t, h.processAddMembers(ctx, body))
 
-	roomPubs := cap.publishesOnPrefix(subject.RoomMemberEvent(roomID))
+	roomPubs := cap.publishesOnPrefix(subject.RoomMemberEvent(roomID, true))
 	require.Len(t, roomPubs, 1, "exactly one room-scoped member_added event")
 	var evt model.MemberAddEvent
 	require.NoError(t, json.Unmarshal(roomPubs[0].data, &evt))
@@ -1346,7 +1346,7 @@ func TestProcessAddMembers_RoomEventMembersEnrichment_Integration(t *testing.T) 
 	require.NoError(t, h2.processAddMembers(
 		natsutil.WithRequestID(context.Background(), "0193abcd-0193-7abc-89ab-aaaa00000003"), body2))
 
-	assert.Empty(t, cap2.publishesOnPrefix(subject.RoomMemberEvent(roomID)),
+	assert.Empty(t, cap2.publishesOnPrefix(subject.RoomMemberEvent(roomID, true)),
 		"re-add of an already-present org fires no member_added event")
 
 	count, err := db.Collection("room_members").CountDocuments(ctx,

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -179,8 +179,8 @@ func (s *MongoStore) GetRoom(ctx context.Context, roomID string) (*model.Room, e
 }
 
 // GetRoomMeta returns a room with only its stable fields (CreatedAt/UpdatedAt zero),
-// served from the meta cache when enabled. Its CrossSite is the PRIOR state — before
-// processAddMembers' SetRoomCrossSite write, which the local→global nudge gates on.
+// served from the meta cache when enabled. In processAddMembers its CrossSite is the
+// PRIOR state (loaded before the SetRoomCrossSite write), which member-event routing relies on.
 func (s *MongoStore) GetRoomMeta(ctx context.Context, roomID string) (*model.Room, error) {
 	var (
 		meta roommetacache.Meta

--- a/tools/loadgen/main.go
+++ b/tools/loadgen/main.go
@@ -600,18 +600,29 @@ func runMembersSustained(ctx context.Context, cfg *config, args []string) int {
 	owners := OwnersByRoom(&fixtures)
 	collector := NewMemberCollector(metrics, p.Name, injectMode)
 
-	e2Sub, err := nc.NatsConn().Subscribe(subject.RoomMemberEventWildcard(), func(m *nats.Msg) {
+	memberHandler := func(m *nats.Msg) {
 		roomID, accounts, ok := ParseMemberAddEvent(m.Data)
 		if !ok {
 			return
 		}
 		collector.RecordMemberEvent(roomID, accounts, time.Now())
-	})
-	if err != nil {
-		slog.Error("subscribe e2", "error", err)
-		return 1
 	}
-	defer func() { _ = e2Sub.Unsubscribe() }()
+	// Subscribe both lanes so member-event latency is measured regardless of
+	// ROOM_SUBJECT_MODE — a same-site room's events land on the local wildcard.
+	var e2Subs []*nats.Subscription
+	for _, global := range []bool{true, false} {
+		sub, err := nc.NatsConn().Subscribe(subject.RoomMemberEventWildcard(global), memberHandler)
+		if err != nil {
+			slog.Error("subscribe e2", "error", err)
+			return 1
+		}
+		e2Subs = append(e2Subs, sub)
+	}
+	defer func() {
+		for _, s := range e2Subs {
+			_ = s.Unsubscribe()
+		}
+	}()
 
 	var publisher MemberPublisher
 	var frontdoor *frontdoorMemberPublisher
@@ -811,18 +822,29 @@ func runMembersCapacity(ctx context.Context, cfg *config, args []string) int {
 	owners := OwnersByRoom(&fixtures)
 	collector := NewMemberCollector(metrics, p.Name, injectMode)
 
-	e2Sub, err := nc.NatsConn().Subscribe(subject.RoomMemberEventWildcard(), func(m *nats.Msg) {
+	memberHandler := func(m *nats.Msg) {
 		roomID, accounts, ok := ParseMemberAddEvent(m.Data)
 		if !ok {
 			return
 		}
 		collector.RecordMemberEvent(roomID, accounts, time.Now())
-	})
-	if err != nil {
-		slog.Error("subscribe e2", "error", err)
-		return 1
 	}
-	defer func() { _ = e2Sub.Unsubscribe() }()
+	// Subscribe both lanes so member-event latency is measured regardless of
+	// ROOM_SUBJECT_MODE — a same-site room's events land on the local wildcard.
+	var e2Subs []*nats.Subscription
+	for _, global := range []bool{true, false} {
+		sub, err := nc.NatsConn().Subscribe(subject.RoomMemberEventWildcard(global), memberHandler)
+		if err != nil {
+			slog.Error("subscribe e2", "error", err)
+			return 1
+		}
+		e2Subs = append(e2Subs, sub)
+	}
+	defer func() {
+		for _, s := range e2Subs {
+			_ = s.Unsubscribe()
+		}
+	}()
 
 	var publisher MemberPublisher
 	var frontdoor *frontdoorMemberPublisher

--- a/tools/loadgen/members_integration_test.go
+++ b/tools/loadgen/members_integration_test.go
@@ -88,7 +88,9 @@ func TestMembersSustained_EndToEnd(t *testing.T) {
 			Timestamp: time.Now().UnixMilli(),
 		}
 		data, _ := json.Marshal(evt)
-		_ = nc.Publish(subject.RoomMemberEvent(req.RoomID), data)
+		// Publish on the local lane so the test exercises the local wildcard
+		// subscription + collector path added for same-site rooms.
+		_ = nc.Publish(subject.RoomMemberEvent(req.RoomID, false), data)
 		_ = msg.Ack()
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
Follow-up to #139 / #167. Closes the one room subject that was left out of the local/global split.

## The gap

`chat.room.{roomID}.event.member` (member_added / member_removed) was hard-coded to the **global** namespace and bypassed the `crossSite` routing that `chat.room.{roomID}.event` uses. But clients subscribe **per-room by `crossSite`** — same-site rooms on `chat.local.room.{roomId}.>`, cross-site on `chat.room.{roomId}.>`. So once a client is on the local prefix for a same-site room (dual/local mode), it **never received the roster event**: the structured `MemberAddEvent`/`MemberRemoveEvent` was published on a prefix it wasn't listening to. (The chat-timeline "X was added" system message still arrived — that rides the already-split `.event` as a `new_message` — so the symptom was a member-list UI that didn't refresh in real time.) Keeping member events global also left a per-room global interest for every room, partially defeating the interest-map reduction.

## Fix

Member events now route on the room's namespace exactly like `.event`:

- **`pkg/subject`** — `RoomMemberEvent(roomID, global)` builds on `roomBase`; `RoomMemberEventWildcard(global)` matches either lane. Extracted `roomRouteGlobals` so `RoomEventTargets` and the new `RoomMemberEventTargets` share **one** routing decision (crossSite + mode + grace window). Exported `RoomRouteMode.UsesLocal`.
- **`room-worker`** — the three client-facing publishes go through a new `publishMemberEvent` helper (mirrors `publishRoomEvent`). `roomLocalityForMember` skips the `GetRoomMeta` read in global mode (routing is global regardless of `crossSite`, so no extra read on today's default). The add path routes on the room's **prior** locality — at a flip all existing members are still on the local subject and the new remote member bootstraps its roster via `member.list`, so prior-state routing reaches everyone who needs the delta.
- **`.semgrep`** — the room-subject guard now also forbids inline `subject.RoomMemberEvent` publishes.
- **`loadgen`** — member-event latency probes subscribe both lanes.

## Tests / verification

- `pkg/subject`: `TestRoomMemberEventTargets` (routes identically to `.event`, dual-publishes within grace).
- `room-worker`: `TestProcessAddMembers_LocalMode_MemberEventOnLocalSubject` (local mode + same-site room → member event on the local subject, not global). Existing member-event assertions updated for the `global` arg.
- `make fmt` / `make lint` (0 issues) / `make test` (full suite, race) all pass. Semgrep YAML validated locally (not installed here — CI runs it).
- `docs/client-api.md` and the derived `events.md` / `request-reply.md` updated to document the crossSite-based member-event routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKLjVmfDJQKfYgmLLofk3v)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Room member events now route through site-local subjects for same-site rooms and global subjects for cross-site or unknown rooms.
  * Member additions and removals use the appropriate routing automatically, with safe global fallback when locality is unavailable.
* **Documentation**
  * Updated client API and event documentation to describe local and global member-event subjects.
* **Tests**
  * Expanded coverage for local, global, cross-site, transition, and fallback routing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->