### PR TITLE
feat(message-worker): MODE toggle for Teams-migration batch (+ MESSAGES-TEAMS stream)

### DIFF
--- a/docs/nats-subject-naming.md
+++ b/docs/nats-subject-naming.md
@@ -168,6 +168,18 @@ The single source of truth for downstream consumers (broadcast-worker, notificat
 
 Stream wildcard: `chat.msg.canonical.{siteID}.>`
 
+### MESSAGES-TEAMS Stream (`MESSAGES-TEAMS-{siteID}`)
+
+Server-only backend stream for the Teams-migration message-batch feed. Separate from
+MESSAGES-CANONICAL so message-worker's teams mode (`MODE=teams`) and default mode each
+bind their own stream/durable.
+
+| Subject Pattern | Publisher | Consumer | Purpose |
+|-----------------|-----------|----------|---------|
+| `chat.teams.msg.canonical.{siteID}.batch` | External Teams migration process | message-worker (teams mode), search-sync-worker | Teams-migration message batch |
+
+Stream wildcard: `chat.teams.msg.canonical.{siteID}.>`
+
 ### FANOUT Stream (`FANOUT-{siteID}`)
 
 | Subject Pattern | Publisher | Consumer | Purpose |

--- a/message-worker/bootstrap.go
+++ b/message-worker/bootstrap.go
@@ -31,31 +31,35 @@ type streamManager interface {
 	Stream(ctx context.Context, name string) (o11ynats.Stream, error)
 }
 
-// bootstrapStreams handles the JetStream MESSAGES-CANONICAL stream this
-// service uses. When enabled (dev/integration), it creates the stream via
-// CreateOrUpdateStream. When disabled (production), it verifies the stream
-// exists via Stream() and returns an error if it doesn't — fail-fast so a
-// misprovisioned deploy surfaces at startup rather than at first publish.
+// bootstrapStreams handles the JetStream stream this mode consumes — MESSAGES-
+// CANONICAL for default mode, MESSAGES-TEAMS for teams mode. When enabled
+// (dev/integration), it creates the stream via CreateOrUpdateStream. When disabled
+// (production), it verifies the stream exists via Stream() and returns an error if
+// it doesn't — fail-fast so a misprovisioned deploy surfaces at startup rather than
+// at first publish.
 //
-// Ownership rule: this helper sets only the stream schema (Name + Subjects)
-// from pkg/stream.MessagesCanonical. Federation config belongs to ops/IaC and
-// is layered on in production. App code never sets it.
-func bootstrapStreams(ctx context.Context, js streamManager, siteID string, enabled bool) error {
-	canonicalCfg := stream.MessagesCanonical(siteID)
+// Ownership rule: this helper sets only the stream schema (Name + Subjects) from
+// pkg/stream. Federation config belongs to ops/IaC and is layered on in production.
+// App code never sets it.
+func bootstrapStreams(ctx context.Context, js streamManager, siteID, mode string, enabled bool) error {
+	cfg := stream.MessagesCanonical(siteID)
+	if mode == "teams" {
+		cfg = stream.MessagesTeams(siteID)
+	}
 	if enabled {
 		if _, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
-			Name:     canonicalCfg.Name,
-			Subjects: canonicalCfg.Subjects,
+			Name:     cfg.Name,
+			Subjects: cfg.Subjects,
 		}); err != nil {
-			return fmt.Errorf("create MESSAGES-CANONICAL stream: %w", err)
+			return fmt.Errorf("create %s stream: %w", cfg.Name, err)
 		}
 		return nil
 	}
 	// Production path: verify the stream exists. Fail fast if it doesn't —
 	// ops/IaC owns provisioning, and a missing stream means the deploy is
 	// broken before the first publish or consume.
-	if _, err := js.Stream(ctx, canonicalCfg.Name); err != nil {
-		return fmt.Errorf("verify MESSAGES-CANONICAL stream: %w", err)
+	if _, err := js.Stream(ctx, cfg.Name); err != nil {
+		return fmt.Errorf("verify %s stream: %w", cfg.Name, err)
 	}
 	return nil
 }

--- a/message-worker/bootstrap_test.go
+++ b/message-worker/bootstrap_test.go
@@ -38,6 +38,7 @@ func (f *fakeStreamManager) Stream(_ context.Context, name string) (o11ynats.Str
 func TestBootstrapStreams(t *testing.T) {
 	tests := []struct {
 		name        string
+		mode        string
 		enabled     bool
 		existing    map[string]bool
 		failOn      string
@@ -47,35 +48,53 @@ func TestBootstrapStreams(t *testing.T) {
 	}{
 		{
 			name:        "disabled - verifies existing stream",
+			mode:        "default",
 			enabled:     false,
 			existing:    map[string]bool{"MESSAGES-CANONICAL-test": true},
 			wantCreated: nil,
 		},
 		{
 			name:       "disabled - fails when stream missing",
+			mode:       "default",
 			enabled:    false,
 			existing:   map[string]bool{},
-			wantErrSub: "verify MESSAGES-CANONICAL stream",
+			wantErrSub: "verify MESSAGES-CANONICAL-test stream",
 		},
 		{
 			name:        "enabled - creates MESSAGES-CANONICAL",
+			mode:        "default",
 			enabled:     true,
 			existing:    map[string]bool{},
 			wantCreated: []string{"MESSAGES-CANONICAL-test"},
 		},
 		{
 			name:       "enabled - wraps MESSAGES-CANONICAL creator error",
+			mode:       "default",
 			enabled:    true,
 			existing:   map[string]bool{},
 			failOn:     "MESSAGES-CANONICAL-test",
 			failErr:    errors.New("nats down"),
-			wantErrSub: "create MESSAGES-CANONICAL stream",
+			wantErrSub: "create MESSAGES-CANONICAL-test stream",
+		},
+		{
+			name:        "teams mode disabled - verifies MESSAGES-TEAMS",
+			mode:        "teams",
+			enabled:     false,
+			existing:    map[string]bool{"MESSAGES-TEAMS-test": true},
+			wantCreated: nil,
+		},
+		{
+			name:        "teams mode enabled - creates MESSAGES-TEAMS",
+			mode:        "teams",
+			enabled:     true,
+			existing:    map[string]bool{},
+			wantCreated: []string{"MESSAGES-TEAMS-test"},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			fake := &fakeStreamManager{failOn: tc.failOn, failErr: tc.failErr, existing: tc.existing}
-			err := bootstrapStreams(context.Background(), fake, "test", tc.enabled)
+			err := bootstrapStreams(context.Background(), fake, "test", tc.mode, tc.enabled)
 			if tc.wantErrSub != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErrSub)

--- a/message-worker/consumer_config_test.go
+++ b/message-worker/consumer_config_test.go
@@ -18,7 +18,7 @@ func TestBuildConsumerConfig(t *testing.T) {
 			MaxDeliver:    5,
 			MaxWaiting:    512,
 			MaxAckPending: 1000,
-		}, "site-a")
+		}, "default", "site-a")
 
 		assert.Equal(t, "message-worker", cc.Durable)
 		assert.Equal(t, 1000, cc.MaxAckPending)
@@ -35,7 +35,7 @@ func TestBuildConsumerConfig(t *testing.T) {
 			MaxDeliver:    3,
 			MaxWaiting:    256,
 			MaxAckPending: 500,
-		}, "site-a")
+		}, "default", "site-a")
 
 		assert.Equal(t, "message-worker", cc.Durable)
 		assert.Equal(t, 500, cc.MaxAckPending)
@@ -44,12 +44,15 @@ func TestBuildConsumerConfig(t *testing.T) {
 		assert.Equal(t, 256, cc.MaxWaiting)
 	})
 
-	t.Run("filters to .created + .teams.batch, excludes edits/deletes", func(t *testing.T) {
-		cc := buildConsumerConfig(stream.ConsumerSettings{}, "site-a")
+	t.Run("default mode filters to .created only, excludes edits/deletes/teams", func(t *testing.T) {
+		cc := buildConsumerConfig(stream.ConsumerSettings{}, "default", "site-a")
 		assert.Empty(t, cc.FilterSubject, "single FilterSubject unset when using FilterSubjects")
-		assert.ElementsMatch(t,
-			[]string{subject.MsgCanonicalCreated("site-a"), subject.MsgCanonicalTeamsBatch("site-a")},
-			cc.FilterSubjects,
-			"one durable serves the live .created feed + the one-time .teams.batch migration; .updated/.deleted stay excluded")
+		assert.Equal(t, []string{subject.MsgCanonicalCreated("site-a")}, cc.FilterSubjects)
+	})
+
+	t.Run("teams mode filters to the teams batch subject on its own durable", func(t *testing.T) {
+		cc := buildConsumerConfig(stream.ConsumerSettings{}, "teams", "site-a")
+		assert.Equal(t, "message-worker-teams", cc.Durable)
+		assert.Equal(t, []string{subject.MsgTeamsCanonicalBatch("site-a")}, cc.FilterSubjects)
 	})
 }

--- a/message-worker/deploy/teams/Dockerfile
+++ b/message-worker/deploy/teams/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.25.12-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY pkg/ pkg/
+COPY message-worker/ message-worker/
+RUN CGO_ENABLED=0 go build -o /message-worker ./message-worker/
+
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates && adduser -D -u 10001 app
+COPY --from=builder /message-worker /message-worker
+USER app
+ENTRYPOINT ["/message-worker"]

--- a/message-worker/deploy/teams/azure-pipelines.yml
+++ b/message-worker/deploy/teams/azure-pipelines.yml
@@ -1,0 +1,70 @@
+trigger:
+  branches:
+    include:
+      - main
+      - develop
+  paths:
+    include:
+      - message-worker/
+      - pkg/
+
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - message-worker/
+      - pkg/
+
+variables:
+  GO_VERSION: '1.25.12'
+  SERVICE_NAME: message-worker
+  IMAGE_NAME: teams-message-worker
+  REGISTRY: '$(containerRegistry)'
+
+stages:
+  - stage: Validate
+    displayName: 'Lint & Test'
+    jobs:
+      - job: LintAndTest
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: '$(GO_VERSION)'
+            displayName: 'Install Go $(GO_VERSION)'
+
+          - script: go vet ./$(SERVICE_NAME)/... ./pkg/...
+            displayName: 'Go Vet'
+
+          - script: go test ./pkg/... -v -race -coverprofile=coverage-pkg.out
+            displayName: 'Test shared packages'
+
+          - script: go test ./$(SERVICE_NAME)/... -v -race -coverprofile=coverage-$(SERVICE_NAME).out
+            displayName: 'Test $(SERVICE_NAME)'
+
+          - script: go build -o /dev/null ./$(SERVICE_NAME)/
+            displayName: 'Build $(SERVICE_NAME)'
+
+  - stage: Build
+    displayName: 'Build & Push Image'
+    dependsOn: Validate
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+    jobs:
+      - job: BuildImage
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+          - task: Docker@2
+            inputs:
+              containerRegistry: '$(containerRegistry)'
+              repository: 'chat/$(IMAGE_NAME)'
+              command: 'buildAndPush'
+              Dockerfile: '$(SERVICE_NAME)/deploy/teams/Dockerfile'
+              buildContext: '.'
+              tags: |
+                $(Build.BuildId)
+                latest
+            displayName: 'Build & push $(IMAGE_NAME)'

--- a/message-worker/deploy/teams/docker-compose.yml
+++ b/message-worker/deploy/teams/docker-compose.yml
@@ -1,0 +1,43 @@
+name: teams-message-worker
+
+services:
+  teams-message-worker:
+    build:
+      context: ../../..
+      dockerfile: message-worker/deploy/teams/Dockerfile
+    pull_policy: build
+    environment:
+      - OTEL_SERVICE_NAME=teams-message-worker
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4318}
+      - NATS_URL=nats://nats:4222
+      - NATS_CREDS_FILE=/etc/nats/backend.creds
+      - SITE_ID=site-local
+      - MODE=teams
+      # Dev-only pprof profiling on the health port (off by default). Flip on
+      # stack-wide for a profiling session with `PPROF_ENABLED=true make up`.
+      - PPROF_ENABLED=${PPROF_ENABLED:-false}
+      - CASSANDRA_HOSTS=cassandra
+      - CASSANDRA_KEYSPACE=chat
+      - MONGO_URI=mongodb://mongodb:27017
+      - MONGO_DB=chat
+      # In-process user cache (pkg/userstore.Cache, shared with message-gatekeeper
+      # and broadcast-worker). Defaults: 10000 entries, 5m TTL.
+      - USER_CACHE_SIZE=10000
+      - USER_CACHE_TTL=5m
+      - BOOTSTRAP_STREAMS=true
+      - ATREST_ENABLED=true
+      - VAULT_ADDR=http://vault:8200
+      - VAULT_TOKEN=dev-only-token
+      - ATREST_VAULT_TRANSIT_KEY=chat-kek
+      # Dev-only X-Debug verbose logging. DEBUG_LOG_PAYLOADS gates full
+      # request/reply/consumed body capture (pair with the X-Debug-Payload header).
+      - DEBUG_LOG_PAYLOADS=${DEBUG_LOG_PAYLOADS:-false}
+      - DEBUG_LOG_RATE=${DEBUG_LOG_RATE:-50}
+    volumes:
+      - ../../../docker-local/backend.creds:/etc/nats/backend.creds:ro
+    networks:
+      - chat-local
+
+networks:
+  chat-local:
+    external: true

--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -29,6 +29,10 @@ import (
 )
 
 type config struct {
+	// Mode selects which stream/consumer this pod binds: "default" runs the live
+	// .created feed off MESSAGES-CANONICAL; "teams" runs the Teams-migration batch
+	// feed off MESSAGES-TEAMS. Two deploys of the same binary, gated by env only.
+	Mode               string                  `env:"MODE"                 envDefault:"default"`
 	NatsURL            string                  `env:"NATS_URL,required"`
 	NatsCredsFile      string                  `env:"NATS_CREDS_FILE"      envDefault:""`
 	SiteID             string                  `env:"SITE_ID,required"`
@@ -65,6 +69,11 @@ func main() {
 		os.Exit(1)
 	}
 	logctx.Configure(cfg.DebugLog)
+
+	if cfg.Mode != "default" && cfg.Mode != "teams" {
+		slog.Error("invalid config", "MODE", cfg.Mode, "reason", `must be "default" or "teams"`)
+		os.Exit(1)
+	}
 
 	if cfg.MessageBucketHours < 1 {
 		slog.Error("invalid config", "MESSAGE_BUCKET_HOURS", cfg.MessageBucketHours)
@@ -156,14 +165,17 @@ func main() {
 		return nil
 	})
 
-	if err := bootstrapStreams(ctx, js, cfg.SiteID, cfg.Bootstrap.Enabled); err != nil {
+	if err := bootstrapStreams(ctx, js, cfg.SiteID, cfg.Mode, cfg.Bootstrap.Enabled); err != nil {
 		slog.Error("bootstrap streams failed", "error", err)
 		os.Exit(1)
 	}
 
-	canonicalCfg := stream.MessagesCanonical(cfg.SiteID)
+	streamName := stream.MessagesCanonical(cfg.SiteID).Name
+	if cfg.Mode == "teams" {
+		streamName = stream.MessagesTeams(cfg.SiteID).Name
+	}
 
-	cons, err := js.CreateOrUpdateConsumer(ctx, canonicalCfg.Name, buildConsumerConfig(cfg.Consumer, cfg.SiteID))
+	cons, err := js.CreateOrUpdateConsumer(ctx, streamName, buildConsumerConfig(cfg.Consumer, cfg.Mode, cfg.SiteID))
 	if err != nil {
 		slog.Error("create consumer failed", "error", err)
 		os.Exit(1)
@@ -178,11 +190,11 @@ func main() {
 	sem := make(chan struct{}, cfg.MaxWorkers)
 	var wg sync.WaitGroup
 
-	// Teams migration shares this one durable consumer (both .created and
-	// .teams.batch on the canonical stream — reused rather than a second durable
-	// for a one-shot job). Its batches are transformed + written straight to
-	// Cassandra — never re-published, so broadcast/notification stay silent;
-	// search-sync indexes off the same .teams.batch subject.
+	// Built unconditionally in both modes: the consumer filter already scopes each
+	// pod to its own mode's subject, so a default-mode pod never sees teamsBatchSubj
+	// and this handler just sits unused. Batches are transformed + written straight
+	// to Cassandra — never re-published, so broadcast/notification stay silent;
+	// search-sync indexes off the same subject on its own MESSAGES-TEAMS consumer.
 	// The migration only runs against the central site, so cfg.SiteID here is the
 	// central site — the same one HR-sync's own users.upsert publishes to.
 	teamsMigration := newTeamsBatchHandler(store, newMongoHRIdentityStore(db), cfg.SiteID,
@@ -196,7 +208,7 @@ func main() {
 			}
 			return nil
 		})
-	teamsBatchSubj := subject.MsgCanonicalTeamsBatch(cfg.SiteID)
+	teamsBatchSubj := subject.MsgTeamsCanonicalBatch(cfg.SiteID)
 
 	go func() {
 		for {
@@ -270,17 +282,19 @@ func main() {
 	)
 }
 
-// buildConsumerConfig binds the single message-worker durable to the two subjects
-// it processes on the canonical stream: the live .created feed and the one-time
-// Teams migration .teams.batch feed (handler dispatches by subject). .updated and
+// buildConsumerConfig returns the durable consumer config for the given mode.
+// default mode binds only the live .created feed on MESSAGES-CANONICAL (.updated/
 // .deleted are excluded — history-service already wrote Cassandra synchronously for
-// those, so re-processing would duplicate writes.
-func buildConsumerConfig(s stream.ConsumerSettings, siteID string) jetstream.ConsumerConfig {
+// those, so re-processing would duplicate writes). teams mode binds only the Teams
+// migration batch subject on MESSAGES-TEAMS, its own durable.
+func buildConsumerConfig(s stream.ConsumerSettings, mode, siteID string) jetstream.ConsumerConfig {
 	cc := stream.DurableConsumerDefaults(s)
-	cc.Durable = "message-worker"
-	cc.FilterSubjects = []string{
-		subject.MsgCanonicalCreated(siteID),
-		subject.MsgCanonicalTeamsBatch(siteID),
+	if mode == "teams" {
+		cc.Durable = "message-worker-teams"
+		cc.FilterSubjects = []string{subject.MsgTeamsCanonicalBatch(siteID)}
+		return cc
 	}
+	cc.Durable = "message-worker"
+	cc.FilterSubjects = []string{subject.MsgCanonicalCreated(siteID)}
 	return cc
 }

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -26,6 +26,16 @@ func MessagesCanonical(siteID string) Config {
 	}
 }
 
+// MessagesTeams returns MESSAGES-TEAMS-{siteID}: the Teams-migration message-batch
+// stream, separate from MESSAGES-CANONICAL so message-worker's teams mode and the
+// live default mode each bind their own stream.
+func MessagesTeams(siteID string) Config {
+	return Config{
+		Name:     fmt.Sprintf("MESSAGES-TEAMS-%s", siteID),
+		Subjects: []string{subject.MsgTeamsCanonicalWildcard(siteID)},
+	}
+}
+
 func Rooms(siteID string) Config {
 	return Config{
 		Name:     fmt.Sprintf("ROOMS-%s", siteID),

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -305,11 +305,18 @@ func MsgCanonicalCreated(siteID string) string {
 	return fmt.Sprintf("chat.msg.canonical.%s.created", siteID)
 }
 
-// MsgCanonicalTeamsBatch is the server-only publish/consume subject for Teams
-// message-history batch migration (server-produced; message-worker consumes it off
-// the canonical stream). Lock to server identities in NATS permissions — no client access.
-func MsgCanonicalTeamsBatch(siteID string) string {
-	return fmt.Sprintf("chat.msg.canonical.%s.teams.batch", siteID)
+// MsgTeamsCanonicalBatch is the server-only publish/consume subject for Teams
+// message-history batch migration, on its own MESSAGES-TEAMS stream (server-produced;
+// message-worker in teams mode consumes it). Lock to server identities in NATS
+// permissions — no client access.
+func MsgTeamsCanonicalBatch(siteID string) string {
+	return fmt.Sprintf("chat.teams.msg.canonical.%s.batch", siteID)
+}
+
+// MsgTeamsCanonicalWildcard matches every subject on the MESSAGES-TEAMS stream for
+// a site: chat.teams.msg.canonical.{siteID}.>.
+func MsgTeamsCanonicalWildcard(siteID string) string {
+	return fmt.Sprintf("chat.teams.msg.canonical.%s.>", siteID)
 }
 
 func MsgCanonicalUpdated(siteID string) string {

--- a/pkg/subject/subject_test.go
+++ b/pkg/subject/subject_test.go
@@ -55,8 +55,10 @@ func TestSubjectBuilders(t *testing.T) {
 			"chat.inbox.site-a.internal.member_removed"},
 		{"MsgCanonicalCreated", subject.MsgCanonicalCreated("site-a"),
 			"chat.msg.canonical.site-a.created"},
-		{"MsgCanonicalTeamsBatch", subject.MsgCanonicalTeamsBatch("site-a"),
-			"chat.msg.canonical.site-a.teams.batch"},
+		{"MsgTeamsCanonicalBatch", subject.MsgTeamsCanonicalBatch("site-a"),
+			"chat.teams.msg.canonical.site-a.batch"},
+		{"MsgTeamsCanonicalWildcard", subject.MsgTeamsCanonicalWildcard("site-a"),
+			"chat.teams.msg.canonical.site-a.>"},
 		// single-token: matches the .created/.updated/... events but NOT the
 		// two-token .teams.batch envelope.
 		{"MsgCanonicalMessageWildcard", subject.MsgCanonicalMessageWildcard("site-a"),

--- a/search-sync-worker/main.go
+++ b/search-sync-worker/main.go
@@ -162,17 +162,21 @@ func main() {
 	msgColl := newMessageCollection(cfg.MsgIndexPrefix, cfg.SiteID, syncMessagesFrom, cfg.DevMode)
 	// search-service filters restricted-room access by threadParentMessageCreatedAt, so re-resolve it from the parent's indexed createdAt (the event omits it).
 	msgColl.parentResolver = newESParentResolver(engine, cfg.MsgIndexPrefix)
-	msgColl.teamsUsers = newMongoTeamsUserResolver(db)
 
 	// Second consumer over messageCollection, bound to BOT-MESSAGES-CANONICAL. isBot is derived per-doc from model.IsBot(UserAccount) so bots reuse the same index.
 	botMsgColl := newBotMessageCollection(cfg.MsgIndexPrefix, cfg.DevMode)
 	botMsgColl.parentResolver = newESParentResolver(engine, cfg.MsgIndexPrefix)
 
+	// Third consumer, bound to MESSAGES-TEAMS: message-worker's teams mode persists
+	// migrated Teams history with no .created event on the canonical stream, so this
+	// indexes off its own stream/subject rather than a filter on msgColl.
+	teamsMsgColl := newTeamsMessageCollection(cfg.MsgIndexPrefix, cfg.SiteID, cfg.DevMode)
+	teamsMsgColl.teamsUsers = newMongoTeamsUserResolver(db)
+
 	collections := []Collection{
-		// msgColl also indexes migrated Teams history off .teams.batch (message-worker
-		// persists it with no .created event) — one consumer covers both.
 		msgColl,
 		botMsgColl,
+		teamsMsgColl,
 		newSpotlightCollection(cfg.SpotlightIndex, cfg.DevMode),
 		newSpotlightOrgCollection(cfg.SpotlightOrgIndex, cfg.SiteID, cfg.HRCentralSiteID, cfg.DevMode),
 		newUserRoomCollection(cfg.UserRoomIndex, cfg.DevMode),

--- a/search-sync-worker/messages.go
+++ b/search-sync-worker/messages.go
@@ -37,35 +37,36 @@ type teamsUserResolver interface {
 }
 
 // messageCollection implements Collection for message search sync; streamCfg + consumerName are
-// parameterized so one type consumes user or bot canonical streams. syncFrom is the legacy-replay cutoff (zero disables it).
+// parameterized so one type consumes user, bot, or Teams-migration canonical streams. syncFrom is
+// the legacy-replay cutoff (zero disables it).
 type messageCollection struct {
 	indexPrefix string
 	siteID      string // for .teams.batch index docs (the normal path reads evt.SiteID per message)
 	syncFrom    time.Time
 	devMode     bool
-	// includeTeamsBatch adds the .teams.batch subject so this consumer also indexes
-	// migrated Teams history (message-worker persists it with no .created event). Only
-	// the user stream carries it; the bot stream does not.
-	includeTeamsBatch bool
-	streamCfg         func(siteID string) jetstream.StreamConfig
-	consumerName      string
-	parentResolver    parentCreatedAtResolver
-	// teamsUsers resolves migrated senders' account + user _id; nil on the bot collection
-	// (no .teams.batch) and in tests that don't exercise the teams path.
+	// teamsOnly switches this collection to the Teams-migration-only wiring: it binds
+	// MESSAGES-TEAMS instead of a canonical stream, filters to only the teams batch
+	// subject, and skips the template/mapping pushes the primary (user) collection
+	// already owns for the same indexPrefix.
+	teamsOnly      bool
+	streamCfg      func(siteID string) jetstream.StreamConfig
+	consumerName   string
+	parentResolver parentCreatedAtResolver
+	// teamsUsers resolves migrated senders' account + user _id; nil on collections that
+	// don't index Teams batches (bot) and in tests that don't exercise the teams path.
 	teamsUsers teamsUserResolver
 }
 
-// newMessageCollection binds to the user MESSAGES-CANONICAL stream and also indexes
-// migrated Teams history off .teams.batch (one consumer covers both).
+// newMessageCollection binds to the user MESSAGES-CANONICAL stream (live messages only —
+// migrated Teams history now indexes off its own consumer, see newTeamsMessageCollection).
 func newMessageCollection(indexPrefix, siteID string, syncFrom time.Time, devMode bool) *messageCollection {
 	return &messageCollection{
-		indexPrefix:       indexPrefix,
-		siteID:            siteID,
-		syncFrom:          syncFrom,
-		devMode:           devMode,
-		includeTeamsBatch: true,
-		streamCfg:         userMessagesStreamCfg,
-		consumerName:      "message-sync",
+		indexPrefix:  indexPrefix,
+		siteID:       siteID,
+		syncFrom:     syncFrom,
+		devMode:      devMode,
+		streamCfg:    userMessagesStreamCfg,
+		consumerName: "message-sync",
 	}
 }
 
@@ -79,6 +80,22 @@ func newBotMessageCollection(indexPrefix string, devMode bool) *messageCollectio
 	}
 }
 
+// newTeamsMessageCollection binds to MESSAGES-TEAMS (message-worker's teams mode
+// persists the batch with no .created event on the canonical stream, so this is a
+// separate consumer, not a filter on the user collection). Reuses messageCollection's
+// BuildAction — it already detects + indexes the teams batch shape — and skips the
+// template/mapping pushes the user collection already performs for the same indexPrefix.
+func newTeamsMessageCollection(indexPrefix, siteID string, devMode bool) *messageCollection {
+	return &messageCollection{
+		indexPrefix:  indexPrefix,
+		siteID:       siteID,
+		devMode:      devMode,
+		teamsOnly:    true,
+		streamCfg:    teamsMessagesStreamCfg,
+		consumerName: "message-sync-teams",
+	}
+}
+
 func userMessagesStreamCfg(siteID string) jetstream.StreamConfig {
 	cfg := stream.MessagesCanonical(siteID)
 	return jetstream.StreamConfig{Name: cfg.Name, Subjects: cfg.Subjects}
@@ -86,6 +103,11 @@ func userMessagesStreamCfg(siteID string) jetstream.StreamConfig {
 
 func botMessagesStreamCfg(siteID string) jetstream.StreamConfig {
 	cfg := stream.BotMessagesCanonical(siteID)
+	return jetstream.StreamConfig{Name: cfg.Name, Subjects: cfg.Subjects}
+}
+
+func teamsMessagesStreamCfg(siteID string) jetstream.StreamConfig {
+	cfg := stream.MessagesTeams(siteID)
 	return jetstream.StreamConfig{Name: cfg.Name, Subjects: cfg.Subjects}
 }
 
@@ -98,21 +120,27 @@ func (c *messageCollection) ConsumerName() string {
 }
 
 func (c *messageCollection) FilterSubjects(siteID string) []string {
-	// Single-token message events (created/updated/deleted/...). The user collection
-	// also binds the two-token `.teams.batch` migration envelope so one consumer
-	// indexes both live messages and migrated Teams history.
-	subs := []string{subject.MsgCanonicalMessageWildcard(siteID)}
-	if c.includeTeamsBatch {
-		subs = append(subs, subject.MsgCanonicalTeamsBatch(siteID))
+	if c.teamsOnly {
+		// Own stream (MESSAGES-TEAMS), own subject — no message wildcard here.
+		return []string{subject.MsgTeamsCanonicalBatch(siteID)}
 	}
-	return subs
+	// Single-token message events (created/updated/deleted/...); the teams batch
+	// subject now lives on a separate stream (see newTeamsMessageCollection).
+	return []string{subject.MsgCanonicalMessageWildcard(siteID)}
 }
 
 func (c *messageCollection) TemplateName() string {
+	if c.teamsOnly {
+		// The user collection already owns/pushes the template for this indexPrefix.
+		return ""
+	}
 	return searchindex.MessageTemplateName(c.indexPrefix)
 }
 
 func (c *messageCollection) TemplateBody() json.RawMessage {
+	if c.teamsOnly {
+		return nil
+	}
 	return searchindex.MessageTemplateBody(c.indexPrefix, c.devMode)
 }
 
@@ -122,8 +150,12 @@ func (c *messageCollection) StoredScripts() map[string]json.RawMessage {
 }
 
 // MappingUpdate pushes the full (idempotent) property set onto existing
-// monthly indices; the same pattern the template targets.
+// monthly indices; the same pattern the template targets. Skipped for the teams-only
+// collection — the user collection already pushes it for the same indexPrefix.
 func (c *messageCollection) MappingUpdate() (string, json.RawMessage) {
+	if c.teamsOnly {
+		return "", nil
+	}
 	// Error discarded: input is a static map of literals, marshal cannot fail.
 	body, _ := json.Marshal(map[string]any{"properties": searchindex.EsPropertiesFromStruct[searchindex.MessageDoc]()})
 	return searchindex.IndexPattern(c.indexPrefix), body

--- a/search-sync-worker/messages_test.go
+++ b/search-sync-worker/messages_test.go
@@ -562,16 +562,22 @@ func teamsBatch(t *testing.T, msgs ...teamsmigrate.Message) []byte {
 	return data
 }
 
-func TestMessageCollection_FilterSubjects_UserIncludesTeamsBatch(t *testing.T) {
+func TestMessageCollection_FilterSubjects(t *testing.T) {
+	// The teams batch subject now lives on its own MESSAGES-TEAMS stream/consumer —
+	// neither the user nor the bot collection binds it anymore.
 	user := newMessageCollection("msgs-v1", "site-a", time.Time{}, false)
-	assert.Equal(t, []string{
-		"chat.msg.canonical.site-a.*",
-		"chat.msg.canonical.site-a.teams.batch",
-	}, user.FilterSubjects("site-a"))
+	assert.Equal(t, []string{"chat.msg.canonical.site-a.*"}, user.FilterSubjects("site-a"))
 
-	// The bot stream carries no .teams.batch, so its collection must not bind it.
 	bot := newBotMessageCollection("msgs-v1", false)
 	assert.Equal(t, []string{"chat.msg.canonical.site-a.*"}, bot.FilterSubjects("site-a"))
+
+	teams := newTeamsMessageCollection("msgs-v1", "site-a", false)
+	assert.Equal(t, []string{"chat.teams.msg.canonical.site-a.batch"}, teams.FilterSubjects("site-a"))
+	assert.Empty(t, teams.TemplateName(), "teams-only collection skips template — the user collection already owns it")
+	assert.Nil(t, teams.TemplateBody())
+	pattern, body := teams.MappingUpdate()
+	assert.Empty(t, pattern)
+	assert.Nil(t, body)
 }
 
 // fakeTeamsUserResolver returns a fixed id→identity map (nil error).


### PR DESCRIPTION
## Summary

Process the Teams-migration message batch as a **MODE toggle inside `message-worker`**
instead of a dedicated service, and isolate the batch on a new `MESSAGES-TEAMS` stream.

One binary; a second deployment sets `MODE=teams`. Mirrors the existing user/bot mode
split used by broadcast/notification workers. (Supersedes this PR's earlier
dedicated-service approach.)

## What's included

- **`message-worker` MODE** (`default` | `teams`, `envDefault:"default"` so the existing
  deployment is unaffected):
  - `default` binds only the live `.created` feed on `MESSAGES-CANONICAL` (durable
    `message-worker`).
  - `teams` binds only the migration batch on `MESSAGES-TEAMS` (durable
    `message-worker-teams`).
  - The consumer filter scopes each pod to its own subject, so a default pod never sees
    the teams subject and vice-versa. Invalid `MODE` fails fast at startup.
- **New `MESSAGES-TEAMS-{siteID}` stream** (`chat.teams.msg.canonical.{siteID}.>`); the
  batch subject moves to `chat.teams.msg.canonical.{siteID}.batch`.
- **`search-sync-worker`** indexes the migration batch off a dedicated `MESSAGES-TEAMS`
  consumer (a JetStream consumer binds one stream, so the moved subject needs its own
  consumer).
- **Additive `message-worker/deploy/teams`** build (mirrors the broadcast-worker
  user/bot delta); the existing default build is untouched.
- Store/cipher wiring is unchanged — teams messages persist encrypted via the same store.

## NATS subjects

| Subject | Stream | Publisher | Consumers |
|---|---|---|---|
| `chat.teams.msg.canonical.{siteID}.batch` | `MESSAGES-TEAMS-{siteID}` | external migration process | message-worker (teams mode), search-sync-worker |

## Verification

- `go vet` (unit + `-tags integration`), targeted unit tests, and golangci-lint (0 issues)
  across message-worker, search-sync-worker, pkg/subject, pkg/stream.
- Dev-stack e2e (teams batch published to the new stream, persisted by the teams-mode
  worker) — see PR discussion.

🤖 Generated with Claude Code
