### PR TITLE
Apply MAX_CONCURRENCY admission cap across request/reply services

### DIFF
--- a/media-service/config.go
+++ b/media-service/config.go
@@ -86,6 +86,11 @@ type config struct {
 
 	// AdminAcctPrefix overrides the platform-admin account prefix (ADMIN_ACCT_PREFIX); keep it identical across services.
 	AdminAcctPrefix string `env:"ADMIN_ACCT_PREFIX" envDefault:"p_admin"`
+
+	// MaxConcurrency caps in-flight request handlers so a burst is shed at the
+	// door (ErrUnavailable) instead of piling unbounded work onto MongoDB/MinIO.
+	// 0 disables the cap (unbounded spawn).
+	MaxConcurrency int `env:"MAX_CONCURRENCY" envDefault:"256"`
 }
 
 // clusterBaseURL returns the configured base URL for a site, or "" if unknown.

--- a/media-service/config_test.go
+++ b/media-service/config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/caarlos0/env/v11"
@@ -61,6 +62,31 @@ func TestConfig_EmojiAndNATSDefaults(t *testing.T) {
 	assert.Equal(t, int64(262144), cfg.EmojiMaxUploadBytes)
 	assert.Equal(t, 512, cfg.EmojiMaxDimension)
 	assert.False(t, cfg.EmojiDeleteEnabled)
+}
+
+func TestConfig_MaxConcurrency(t *testing.T) {
+	t.Setenv("SITE_ID", "s1")
+	t.Setenv("CLUSTER_DOMAINS", `[{"siteID":"s1","domain":"http://localhost:8080"}]`)
+	t.Setenv("EMPLOYEE_PHOTO_BASE_URL", "https://photos.example.com")
+	t.Setenv("MONGO_URI", "mongodb://localhost:27017")
+	t.Setenv("MINIO_ENDPOINT", "localhost:9000")
+	t.Setenv("MINIO_ACCESS_KEY", "k")
+	t.Setenv("MINIO_SECRET_KEY", "s")
+	t.Setenv("NATS_URL", "nats://localhost:4222")
+
+	t.Run("default", func(t *testing.T) {
+		require.NoError(t, os.Unsetenv("MAX_CONCURRENCY"))
+		cfg, err := env.ParseAs[config]()
+		require.NoError(t, err)
+		assert.Equal(t, 256, cfg.MaxConcurrency)
+	})
+
+	t.Run("override", func(t *testing.T) {
+		t.Setenv("MAX_CONCURRENCY", "64")
+		cfg, err := env.ParseAs[config]()
+		require.NoError(t, err)
+		assert.Equal(t, 64, cfg.MaxConcurrency)
+	})
 }
 
 func TestConfig_NATSURLRequired(t *testing.T) {

--- a/media-service/main.go
+++ b/media-service/main.go
@@ -76,7 +76,13 @@ func run() error {
 
 	h := newHandler(store, store, blobs, &cfg)
 
-	router := natsrouter.New(nc, "media-service")
+	// Bound in-flight handlers so a burst is shed at the door (ErrUnavailable)
+	// instead of piling unbounded work onto MongoDB/MinIO. MAX_CONCURRENCY=0 disables.
+	var routerOpts []natsrouter.Option
+	if cfg.MaxConcurrency > 0 {
+		routerOpts = append(routerOpts, natsrouter.WithMaxConcurrency(cfg.MaxConcurrency))
+	}
+	router := natsrouter.New(nc, "media-service", routerOpts...)
 	router.Use(natsrouter.Recovery(), natsrouter.RequestID(), natsrouter.Logging())
 	registerEmojiNATS(router, h, cfg.SiteID)
 

--- a/room-service/config_test.go
+++ b/room-service/config_test.go
@@ -51,6 +51,32 @@ func TestLegacyRoomOrigins_EnvParse(t *testing.T) {
 	assert.Error(t, err, "malformed JSON must fail startup, not be silently ignored")
 }
 
+func TestConfig_MaxConcurrency(t *testing.T) {
+	t.Setenv("NATS_URL", "nats://localhost:4222")
+	t.Setenv("MONGO_URI", "mongodb://localhost:27017")
+
+	t.Run("default", func(t *testing.T) {
+		require.NoError(t, os.Unsetenv("MAX_CONCURRENCY"))
+		cfg, err := env.ParseAs[config]()
+		require.NoError(t, err)
+		assert.Equal(t, 256, cfg.MaxConcurrency)
+	})
+
+	t.Run("override", func(t *testing.T) {
+		t.Setenv("MAX_CONCURRENCY", "64")
+		cfg, err := env.ParseAs[config]()
+		require.NoError(t, err)
+		assert.Equal(t, 64, cfg.MaxConcurrency)
+	})
+
+	t.Run("zero_disables", func(t *testing.T) {
+		t.Setenv("MAX_CONCURRENCY", "0")
+		cfg, err := env.ParseAs[config]()
+		require.NoError(t, err)
+		assert.Equal(t, 0, cfg.MaxConcurrency)
+	})
+}
+
 func TestConfig_RoomSubjectMode(t *testing.T) {
 	t.Setenv("NATS_URL", "nats://localhost:4222")
 	t.Setenv("MONGO_URI", "mongodb://localhost:27017")

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -78,6 +78,10 @@ type config struct {
 	RoomSubjectMode string `env:"ROOM_SUBJECT_MODE" envDefault:"global"`
 	// RoomLocalityGrace: post-flip dual-publish window. Must match across all publisher services.
 	RoomLocalityGrace time.Duration `env:"ROOM_LOCALITY_GRACE" envDefault:"168h"`
+	// MaxConcurrency caps in-flight request handlers so a burst is shed at the
+	// door (ErrUnavailable) instead of piling unbounded work onto MongoDB. 0
+	// disables the cap (unbounded spawn).
+	MaxConcurrency int `env:"MAX_CONCURRENCY" envDefault:"256"`
 }
 
 // legacyRoomOrigin maps a site to its legacy origin URL (incl. scheme).
@@ -267,7 +271,13 @@ func main() {
 	handler.roomMembersLimit = cfg.RoomMembersLimit
 	handler.roomMembersCallLimit = cfg.RoomMembersCallLimit
 
-	router := natsrouter.New(nc, "room-service")
+	// Bound in-flight handlers so a burst is shed at the door (ErrUnavailable)
+	// instead of piling unbounded work onto MongoDB. MAX_CONCURRENCY=0 disables.
+	var routerOpts []natsrouter.Option
+	if cfg.MaxConcurrency > 0 {
+		routerOpts = append(routerOpts, natsrouter.WithMaxConcurrency(cfg.MaxConcurrency))
+	}
+	router := natsrouter.New(nc, "room-service", routerOpts...)
 	router.Use(natsrouter.Recovery(), natsrouter.RequestID(), natsrouter.Logging())
 	handler.Register(router)
 

--- a/search-service/config_test.go
+++ b/search-service/config_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/caarlos0/env/v11"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setRequiredSearchEnv seeds every required env var so env.ParseAs succeeds and
+// the test can assert on the optional MAX_CONCURRENCY knob in isolation.
+func setRequiredSearchEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("SITE_ID", "site-a")
+	t.Setenv("SEARCH_URL", "http://localhost:9200")
+	t.Setenv("SEARCH_USER_ROOM_INDEX", "userroom-site-a-v1")
+	t.Setenv("SEARCH_SPOTLIGHT_INDEX", "spotlight-site-a-v1")
+	t.Setenv("SEARCH_SPOTLIGHT_ORG_INDEX", "spotlightorg-site-a-v1")
+	t.Setenv("VALKEY_ADDRS", "localhost:7000")
+	t.Setenv("NATS_URL", "nats://localhost:4222")
+	t.Setenv("MONGO_URI", "mongodb://localhost:27017")
+	t.Setenv("USERS_API_URL", "http://localhost:8080")
+}
+
+func TestConfig_MaxConcurrency(t *testing.T) {
+	setRequiredSearchEnv(t)
+
+	t.Run("default", func(t *testing.T) {
+		require.NoError(t, os.Unsetenv("MAX_CONCURRENCY"))
+		cfg, err := env.ParseAs[Config]()
+		require.NoError(t, err)
+		assert.Equal(t, 256, cfg.MaxConcurrency)
+	})
+
+	t.Run("override", func(t *testing.T) {
+		t.Setenv("MAX_CONCURRENCY", "64")
+		cfg, err := env.ParseAs[Config]()
+		require.NoError(t, err)
+		assert.Equal(t, 64, cfg.MaxConcurrency)
+	})
+}

--- a/search-service/main.go
+++ b/search-service/main.go
@@ -91,6 +91,10 @@ type Config struct {
 	Mongo    MongoConfig    `envPrefix:"MONGO_"`
 	UsersAPI UsersAPIConfig `envPrefix:"USERS_API_"`
 	DebugLog logctx.Config  `envPrefix:"DEBUG_LOG_"`
+	// MaxConcurrency caps in-flight request handlers so a burst is shed at the
+	// door (ErrUnavailable) instead of piling unbounded work onto Elasticsearch/
+	// MongoDB. 0 disables the cap (unbounded spawn).
+	MaxConcurrency int `env:"MAX_CONCURRENCY" envDefault:"256"`
 }
 
 func main() {
@@ -195,7 +199,14 @@ func main() {
 	})
 	handler.room = newRoomClient(nc)
 
-	router := natsrouter.New(nc, "search-service")
+	// Bound in-flight handlers so a burst is shed at the door (ErrUnavailable)
+	// instead of piling unbounded work onto Elasticsearch/MongoDB.
+	// MAX_CONCURRENCY=0 disables.
+	var routerOpts []natsrouter.Option
+	if cfg.MaxConcurrency > 0 {
+		routerOpts = append(routerOpts, natsrouter.WithMaxConcurrency(cfg.MaxConcurrency))
+	}
+	router := natsrouter.New(nc, "search-service", routerOpts...)
 	router.Use(natsrouter.RequestID())
 	router.Use(natsrouter.Recovery())
 	router.Use(natsrouter.Logging())

--- a/translation-service/config_test.go
+++ b/translation-service/config_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/caarlos0/env/v11"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setRequiredTranslationEnv seeds the required env so env.ParseAs succeeds and
+// the test can assert on the optional MAX_CONCURRENCY knob in isolation.
+func setRequiredTranslationEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("SITE_ID", "site-a")
+	t.Setenv("TRANSLATION_BACKEND", "mock")
+	t.Setenv("NATS_URL", "nats://localhost:4222")
+}
+
+func TestConfig_MaxConcurrencyDefault(t *testing.T) {
+	setRequiredTranslationEnv(t)
+
+	cfg, err := env.ParseAs[Config]()
+	require.NoError(t, err)
+	assert.Equal(t, 100, cfg.MaxConcurrency, "MAX_CONCURRENCY defaults to 100 (preserving the prior MAX_WORKERS default)")
+}
+
+func TestConfig_MaxConcurrencyOverride(t *testing.T) {
+	setRequiredTranslationEnv(t)
+	t.Setenv("MAX_CONCURRENCY", "42")
+
+	cfg, err := env.ParseAs[Config]()
+	require.NoError(t, err)
+	assert.Equal(t, 42, cfg.MaxConcurrency)
+}

--- a/translation-service/main.go
+++ b/translation-service/main.go
@@ -31,8 +31,11 @@ type Config struct {
 	J1Token        string        `env:"TRANSLATION_J1_TOKEN"         envDefault:""`
 	HTTPTimeout    time.Duration `env:"TRANSLATION_HTTP_TIMEOUT"     envDefault:"30s"`
 	TokenSkew      time.Duration `env:"TRANSLATION_TOKEN_SKEW"       envDefault:"60s"`
-	MaxWorkers     int           `env:"MAX_WORKERS"                  envDefault:"100"`
-	NATS           NATSConfig    `envPrefix:"NATS_"`
+	// MaxConcurrency caps in-flight request handlers so a slow translate backend
+	// can't accumulate goroutines and outbound connections without ceiling. 0
+	// disables the cap (unbounded spawn).
+	MaxConcurrency int        `env:"MAX_CONCURRENCY"              envDefault:"100"`
+	NATS           NATSConfig `envPrefix:"NATS_"`
 }
 
 // newTranslator selects the backend. The stream backend fails fast when its
@@ -94,7 +97,12 @@ func main() {
 	// Cap in-flight handlers so a slow translate backend can't accumulate goroutines
 	// and outbound connections without ceiling; on saturation the router replies
 	// errcode.Unavailable("service busy") so the caller can retry immediately.
-	router := natsrouter.Default(nc, "translation-service", natsrouter.WithMaxConcurrency(cfg.MaxWorkers))
+	// MAX_CONCURRENCY=0 disables the cap (unbounded spawn).
+	var routerOpts []natsrouter.Option
+	if cfg.MaxConcurrency > 0 {
+		routerOpts = append(routerOpts, natsrouter.WithMaxConcurrency(cfg.MaxConcurrency))
+	}
+	router := natsrouter.Default(nc, "translation-service", routerOpts...)
 	natsrouter.Register(router, subject.TranslateRequestPattern(cfg.SiteID), handler.Translate)
 
 	slog.Info("translation-service running", "site", cfg.SiteID, "backend", cfg.Backend)

--- a/user-service/config/config.go
+++ b/user-service/config/config.go
@@ -32,6 +32,10 @@ type Config struct {
 	DefaultAppsLimit         int           `env:"APPS_DEFAULT_LIMIT" envDefault:"20"`
 	MaxAccountNames          int           `env:"MAX_ACCOUNT_NAMES"      envDefault:"100"`
 	HandlerTimeout           time.Duration `env:"HANDLER_TIMEOUT"        envDefault:"15s"`
+	// MaxConcurrency caps in-flight request handlers so a burst is shed at the
+	// door (ErrUnavailable) instead of piling unbounded work onto MongoDB. 0
+	// disables the cap (unbounded spawn).
+	MaxConcurrency int `env:"MAX_CONCURRENCY" envDefault:"256"`
 	// OIDC settings for the SSO token vault — optional as a unit: unset OIDC_ISSUER_URL disables the endpoints; the rest is validated in Load.
 	OIDCIssuerURL string `env:"OIDC_ISSUER_URL" envDefault:""`
 	// OIDCAudiences must include the access-token `aud` — refresh re-verifies the minted
@@ -69,6 +73,9 @@ func Load() (Config, error) {
 	}
 	if cfg.DefaultAppsLimit > cfg.MaxAppsLimit {
 		return Config{}, fmt.Errorf("APPS_DEFAULT_LIMIT (%d) must be <= APPS_MAX_LIMIT (%d)", cfg.DefaultAppsLimit, cfg.MaxAppsLimit)
+	}
+	if cfg.MaxConcurrency < 0 {
+		return Config{}, fmt.Errorf("MAX_CONCURRENCY must be >= 0, got %d", cfg.MaxConcurrency)
 	}
 	if cfg.OIDCIssuerURL != "" {
 		if len(cfg.OIDCAudiences) == 0 {

--- a/user-service/config/config_test.go
+++ b/user-service/config/config_test.go
@@ -41,6 +41,35 @@ func TestLoad_Defaults(t *testing.T) {
 	require.Equal(t, 100, cfg.MaxAppsLimit)
 	require.Equal(t, 20, cfg.DefaultAppsLimit)
 	require.Equal(t, 15*time.Second, cfg.HandlerTimeout)
+	require.Equal(t, 256, cfg.MaxConcurrency)
+}
+
+func TestLoad_MaxConcurrency(t *testing.T) {
+	t.Setenv("MONGO_URI", "mongodb://x")
+	t.Setenv("NATS_URL", "nats://x")
+	t.Setenv("SITE_ID", "site-a")
+
+	t.Run("override", func(t *testing.T) {
+		t.Setenv("MAX_CONCURRENCY", "64")
+		cfg, err := Load()
+		require.NoError(t, err)
+		require.Equal(t, 64, cfg.MaxConcurrency)
+	})
+
+	// 0 is the documented disable value (unbounded spawn) and must validate.
+	t.Run("zero_disables", func(t *testing.T) {
+		t.Setenv("MAX_CONCURRENCY", "0")
+		cfg, err := Load()
+		require.NoError(t, err)
+		require.Equal(t, 0, cfg.MaxConcurrency)
+	})
+
+	t.Run("negative_rejected", func(t *testing.T) {
+		t.Setenv("MAX_CONCURRENCY", "-1")
+		_, err := Load()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "MAX_CONCURRENCY")
+	})
 }
 
 func TestLoad_MissingRequired(t *testing.T) {

--- a/user-service/main.go
+++ b/user-service/main.go
@@ -111,7 +111,13 @@ func main() {
 
 	svc := service.New(subRepo, userRepo, appRepo, threadSubRepo, roomclient.New(nc, cfg.SiteID), historyclient.New(nc), presenceclient.New(nc), publisher.New(js), publisher.NewCore(nc), ssoTokenRepo, tokenValidator, tokenRefresher, &cfg)
 
-	router := natsrouter.New(nc, "user-service")
+	// Bound in-flight handlers so a burst is shed at the door (ErrUnavailable)
+	// instead of piling unbounded work onto MongoDB. MAX_CONCURRENCY=0 disables.
+	var routerOpts []natsrouter.Option
+	if cfg.MaxConcurrency > 0 {
+		routerOpts = append(routerOpts, natsrouter.WithMaxConcurrency(cfg.MaxConcurrency))
+	}
+	router := natsrouter.New(nc, "user-service", routerOpts...)
 	router.Use(natsrouter.Recovery())
 	// RequestID must precede any handler that reads request_id from ctx —
 	// otherwise Classify's log line records an empty value.


### PR DESCRIPTION
## Summary

The `natsrouter` admission-control cap (`WithMaxConcurrency`) was wired inconsistently across NATS request/reply services. A review found:

- Only `history-service`, `bot-message-handler`, and `bot-room-service` applied it via `MAX_CONCURRENCY`.
- `translation-service` applied a cap but keyed it off `MAX_WORKERS` — which everywhere else in the repo means the JetStream pull-worker pool size, so setting `MAX_CONCURRENCY` on it had no effect.
- Four services fronting constrained MongoDB/Elasticsearch/MinIO pools (`room-service`, `user-service`, `media-service`, `search-service`) ran the router unbounded — the same risk profile `history-service` was hardened against.

This PR makes the knob consistent.

## Changes

**translation-service** — rename `MaxWorkers`/`MAX_WORKERS` → `MaxConcurrency`/`MAX_CONCURRENCY` (default `100` preserved, so no behavior change beyond the env-var name). Gate the router option on `> 0` so `MAX_CONCURRENCY=0` disables cleanly without the non-positive `slog.Warn`.

**room-service, user-service, media-service, search-service** — add a `MaxConcurrency` config field (env `MAX_CONCURRENCY`, default `256`, matching `history-service`) and wire `WithMaxConcurrency` gated on `> 0`. `user-service` also rejects a negative `MAX_CONCURRENCY` in `config.Load`.

In every service, `0` disables the cap (unbounded spawn).

## Cap coverage after this change

| Service | Before | After |
|---|---|---|
| history-service, bot-message-handler, bot-room-service | `MAX_CONCURRENCY` | unchanged |
| translation-service | capped via `MAX_WORKERS` | `MAX_CONCURRENCY` |
| room-service, user-service, media-service, search-service | unbounded | `MAX_CONCURRENCY` (default 256) |
| user-presence-service, room-worker | unbounded | left as-is (mostly `RegisterVoid` / minimal RPC surface) |

## Behavioral note

Default `256` turns admission control **on** for the four previously-unbounded services. Under a genuine burst they now shed excess requests with `errcode.Unavailable("service busy")` instead of piling onto the DB pool — the intended hardening (mirrors `history-service`). Callers should retry on `unavailable`. If preferred, these could instead default to `0` (off) and be enabled per-environment.

## Testing

- Added config tests (TDD: written first, confirmed failing, then implemented) covering default value, env override, and — for `user-service` — negative rejection.
- `make test` passes for all five services.
- `make lint` → `0 issues`.

No client-facing handler schemas or `pkg/model` structs changed, so `docs/client-api.md` needs no update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FuTiFb7nRq549k9MFrsCdh)_