### PR TITLE
feat(history-service): tag Cassandra spans with room_id

### DIFF
--- a/bot-message-worker/roomspan.go
+++ b/bot-message-worker/roomspan.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// tracerName identifies this service's spans in the global tracer provider.
+const tracerName = "github.com/hmchangw/chat/bot-message-worker"
+
+// startRoomSpan opens a child span named op tagged with the room id and returns
+// the span's context. The gocql query spans the o11y observer emits for writes
+// run under this context nest beneath it, so a Cassandra trace carries the room
+// it served — room_id is otherwise only a query argument the query spans don't
+// expose. Callers defer span.End().
+func (s *CassandraStore) startRoomSpan(ctx context.Context, op, roomID string) (context.Context, trace.Span) {
+	ctx, span := s.tracer.Start(ctx, op)
+	span.SetAttributes(attribute.String("room_id", roomID))
+	return ctx, span
+}

--- a/bot-message-worker/roomspan.go
+++ b/bot-message-worker/roomspan.go
@@ -10,13 +10,21 @@ import (
 // tracerName identifies this service's spans in the global tracer provider.
 const tracerName = "github.com/hmchangw/chat/bot-message-worker"
 
-// startRoomSpan opens a child span named op tagged with the room id and returns
-// the span's context. The gocql query spans the o11y observer emits for writes
-// run under this context nest beneath it, so a Cassandra trace carries the room
-// it served — room_id is otherwise only a query argument the query spans don't
-// expose. Callers defer span.End().
-func (s *CassandraStore) startRoomSpan(ctx context.Context, op, roomID string) (context.Context, trace.Span) {
+// startSpan opens a child span named op tagged with the room and/or message id
+// and returns the span's context. The gocql query spans the o11y observer emits
+// for writes run under this context nest beneath it, so a Cassandra trace
+// carries the room and message it served — both are otherwise only query
+// arguments the query spans don't expose. Either id may be empty to omit it.
+// Callers defer span.End().
+func (s *CassandraStore) startSpan(ctx context.Context, op, roomID, messageID string) (context.Context, trace.Span) {
 	ctx, span := s.tracer.Start(ctx, op)
-	span.SetAttributes(attribute.String("room_id", roomID))
+	attrs := make([]attribute.KeyValue, 0, 2)
+	if roomID != "" {
+		attrs = append(attrs, attribute.String("room_id", roomID))
+	}
+	if messageID != "" {
+		attrs = append(attrs, attribute.String("message_id", messageID))
+	}
+	span.SetAttributes(attrs...)
 	return ctx, span
 }

--- a/bot-message-worker/roomspan_test.go
+++ b/bot-message-worker/roomspan_test.go
@@ -39,10 +39,10 @@ func TestNewCassandraStore_SetsTracer(t *testing.T) {
 	assert.NotNil(t, s.tracer, "NewCassandraStore must default the tracer so production spans record")
 }
 
-func TestCassandraStore_startRoomSpan_TagsRoomID(t *testing.T) {
+func TestCassandraStore_startSpan_TagsRoomAndMessageID(t *testing.T) {
 	s, recorder := recordingStore(t)
 
-	ctx, span := s.startRoomSpan(context.Background(), "cassandra.SaveMessage", "room-9")
+	ctx, span := s.startSpan(context.Background(), "cassandra.SaveMessage", "room-9", "msg-1")
 	span.End()
 
 	assert.Equal(t,
@@ -57,13 +57,16 @@ func TestCassandraStore_startRoomSpan_TagsRoomID(t *testing.T) {
 	roomID, ok := spanAttr(ended[0], "room_id")
 	require.True(t, ok, "span must carry a room_id attribute")
 	assert.Equal(t, "room-9", roomID)
+	messageID, ok := spanAttr(ended[0], "message_id")
+	require.True(t, ok, "span must carry a message_id attribute")
+	assert.Equal(t, "msg-1", messageID)
 }
 
-func TestCassandraStore_startRoomSpan_NestsUnderParent(t *testing.T) {
+func TestCassandraStore_startSpan_NestsUnderParent(t *testing.T) {
 	s, recorder := recordingStore(t)
 
 	parentCtx, parent := s.tracer.Start(context.Background(), "consume")
-	_, child := s.startRoomSpan(parentCtx, "cassandra.SaveThreadMessage", "room-3")
+	_, child := s.startSpan(parentCtx, "cassandra.SaveThreadMessage", "room-3", "msg-2")
 	child.End()
 	parent.End()
 

--- a/bot-message-worker/roomspan_test.go
+++ b/bot-message-worker/roomspan_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/hmchangw/chat/pkg/msgbucket"
+)
+
+// recordingStore returns a CassandraStore whose tracer feeds an in-memory
+// recorder, so span assertions run without a global provider.
+func recordingStore(t *testing.T) (*CassandraStore, *tracetest.SpanRecorder) {
+	t.Helper()
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(recorder),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	return &CassandraStore{tracer: tp.Tracer("test")}, recorder
+}
+
+func spanAttr(span sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, a := range span.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+func TestNewCassandraStore_SetsTracer(t *testing.T) {
+	s := NewCassandraStore(nil, msgbucket.Sizer{}, nil)
+	assert.NotNil(t, s.tracer, "NewCassandraStore must default the tracer so production spans record")
+}
+
+func TestCassandraStore_startRoomSpan_TagsRoomID(t *testing.T) {
+	s, recorder := recordingStore(t)
+
+	ctx, span := s.startRoomSpan(context.Background(), "cassandra.SaveMessage", "room-9")
+	span.End()
+
+	assert.Equal(t,
+		span.SpanContext().SpanID(),
+		oteltrace.SpanFromContext(ctx).SpanContext().SpanID(),
+		"returned ctx must carry the started span",
+	)
+
+	ended := recorder.Ended()
+	require.Len(t, ended, 1)
+	assert.Equal(t, "cassandra.SaveMessage", ended[0].Name())
+	roomID, ok := spanAttr(ended[0], "room_id")
+	require.True(t, ok, "span must carry a room_id attribute")
+	assert.Equal(t, "room-9", roomID)
+}
+
+func TestCassandraStore_startRoomSpan_NestsUnderParent(t *testing.T) {
+	s, recorder := recordingStore(t)
+
+	parentCtx, parent := s.tracer.Start(context.Background(), "consume")
+	_, child := s.startRoomSpan(parentCtx, "cassandra.SaveThreadMessage", "room-3")
+	child.End()
+	parent.End()
+
+	var childSpan sdktrace.ReadOnlySpan
+	for _, sp := range recorder.Ended() {
+		if sp.Name() == "cassandra.SaveThreadMessage" {
+			childSpan = sp
+		}
+	}
+	require.NotNil(t, childSpan)
+	assert.Equal(t,
+		parent.SpanContext().SpanID(),
+		childSpan.Parent().SpanID(),
+		"room span must nest under the caller's span so query spans inherit room context",
+	)
+}

--- a/bot-message-worker/store_cassandra.go
+++ b/bot-message-worker/store_cassandra.go
@@ -65,7 +65,7 @@ func NewCassandraStore(sess *gocql.Session, bucket msgbucket.Sizer, cipher atres
 
 // SaveMessage inserts into messages_by_room + messages_by_id via one UnloggedBatch.
 func (s *CassandraStore) SaveMessage(ctx context.Context, msg *model.Message, siteID string) error {
-	ctx, span := s.startRoomSpan(ctx, "cassandra.SaveMessage", msg.RoomID)
+	ctx, span := s.startSpan(ctx, "cassandra.SaveMessage", msg.RoomID, msg.ID)
 	defer span.End()
 
 	if s.cipher != nil {
@@ -146,7 +146,7 @@ func (s *CassandraStore) saveEncrypted(ctx context.Context, msg *model.Message, 
 // SaveThreadMessage inserts into messages_by_id + thread_messages_by_thread, mirroring to
 // messages_by_room when TShow is true, then blind-SETs tcount/tlm from a bounded partition COUNT.
 func (s *CassandraStore) SaveThreadMessage(ctx context.Context, msg *model.Message, siteID, threadRoomID string) error {
-	ctx, span := s.startRoomSpan(ctx, "cassandra.SaveThreadMessage", msg.RoomID)
+	ctx, span := s.startSpan(ctx, "cassandra.SaveThreadMessage", msg.RoomID, msg.ID)
 	defer span.End()
 
 	if s.cipher != nil {

--- a/bot-message-worker/store_cassandra.go
+++ b/bot-message-worker/store_cassandra.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/gocql/gocql"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/hmchangw/chat/pkg/atrest"
 	"github.com/hmchangw/chat/pkg/model"
@@ -54,14 +56,18 @@ type CassandraStore struct {
 	sess   *gocql.Session
 	bucket msgbucket.Sizer
 	cipher atrest.Cipher
+	tracer trace.Tracer
 }
 
 func NewCassandraStore(sess *gocql.Session, bucket msgbucket.Sizer, cipher atrest.Cipher) *CassandraStore {
-	return &CassandraStore{sess: sess, bucket: bucket, cipher: cipher}
+	return &CassandraStore{sess: sess, bucket: bucket, cipher: cipher, tracer: otel.Tracer(tracerName)}
 }
 
 // SaveMessage inserts into messages_by_room + messages_by_id via one UnloggedBatch.
 func (s *CassandraStore) SaveMessage(ctx context.Context, msg *model.Message, siteID string) error {
+	ctx, span := s.startRoomSpan(ctx, "cassandra.SaveMessage", msg.RoomID)
+	defer span.End()
+
 	if s.cipher != nil {
 		return s.saveEncrypted(ctx, msg, siteID)
 	}
@@ -140,6 +146,9 @@ func (s *CassandraStore) saveEncrypted(ctx context.Context, msg *model.Message, 
 // SaveThreadMessage inserts into messages_by_id + thread_messages_by_thread, mirroring to
 // messages_by_room when TShow is true, then blind-SETs tcount/tlm from a bounded partition COUNT.
 func (s *CassandraStore) SaveThreadMessage(ctx context.Context, msg *model.Message, siteID, threadRoomID string) error {
+	ctx, span := s.startRoomSpan(ctx, "cassandra.SaveThreadMessage", msg.RoomID)
+	defer span.End()
+
 	if s.cipher != nil {
 		return s.saveThreadEncrypted(ctx, msg, siteID, threadRoomID)
 	}

--- a/history-service/internal/cassrepo/messages_by_id.go
+++ b/history-service/internal/cassrepo/messages_by_id.go
@@ -17,6 +17,9 @@ const maxConcurrentIDReads = 16
 const messageByIDQuery = "SELECT " + baseColumns + ", pinned_at, pinned_by FROM messages_by_id"
 
 func (r *Repository) GetMessageByID(ctx context.Context, messageID string) (*models.Message, error) {
+	ctx, span := r.startSpan(ctx, "cassrepo.GetMessageByID", "", messageID)
+	defer span.End()
+
 	iter := r.session.Query(
 		messageByIDQuery+` WHERE message_id = ? LIMIT 1`,
 		messageID,

--- a/history-service/internal/cassrepo/messages_by_room.go
+++ b/history-service/internal/cassrepo/messages_by_room.go
@@ -75,7 +75,7 @@ func (r *Repository) scanMessagesUpTo(ctx context.Context) func(iter *gocql.Iter
 }
 
 func (r *Repository) GetMessagesBefore(ctx context.Context, roomID string, before time.Time, floor time.Time, pageReq PageRequest) (Page[models.Message], error) {
-	ctx, span := r.startRoomSpan(ctx, "cassrepo.GetMessagesBefore", roomID)
+	ctx, span := r.startSpan(ctx, "cassrepo.GetMessagesBefore", roomID, "")
 	defer span.End()
 
 	floorBucket := r.bucket.Of(floor)
@@ -108,7 +108,7 @@ func (r *Repository) GetMessagesBefore(ctx context.Context, roomID string, befor
 }
 
 func (r *Repository) GetMessagesBetweenDesc(ctx context.Context, roomID string, since, before time.Time, pageReq PageRequest) (Page[models.Message], error) {
-	ctx, span := r.startRoomSpan(ctx, "cassrepo.GetMessagesBetweenDesc", roomID)
+	ctx, span := r.startSpan(ctx, "cassrepo.GetMessagesBetweenDesc", roomID, "")
 	defer span.End()
 
 	floorBucket := r.bucket.Of(since)
@@ -158,7 +158,7 @@ func (r *Repository) GetMessagesBetweenDesc(ctx context.Context, roomID string, 
 }
 
 func (r *Repository) GetMessagesAfter(ctx context.Context, roomID string, after time.Time, ceiling time.Time, pageReq PageRequest) (Page[models.Message], error) {
-	ctx, span := r.startRoomSpan(ctx, "cassrepo.GetMessagesAfter", roomID)
+	ctx, span := r.startSpan(ctx, "cassrepo.GetMessagesAfter", roomID, "")
 	defer span.End()
 
 	ceilingBucket := r.bucket.Of(ceiling)
@@ -191,7 +191,7 @@ func (r *Repository) GetMessagesAfter(ctx context.Context, roomID string, after 
 }
 
 func (r *Repository) GetAllMessagesAsc(ctx context.Context, roomID string, floor time.Time, ceiling time.Time, pageReq PageRequest) (Page[models.Message], error) {
-	ctx, span := r.startRoomSpan(ctx, "cassrepo.GetAllMessagesAsc", roomID)
+	ctx, span := r.startSpan(ctx, "cassrepo.GetAllMessagesAsc", roomID, "")
 	defer span.End()
 
 	ceilingBucket := r.bucket.Of(ceiling)

--- a/history-service/internal/cassrepo/messages_by_room.go
+++ b/history-service/internal/cassrepo/messages_by_room.go
@@ -75,6 +75,9 @@ func (r *Repository) scanMessagesUpTo(ctx context.Context) func(iter *gocql.Iter
 }
 
 func (r *Repository) GetMessagesBefore(ctx context.Context, roomID string, before time.Time, floor time.Time, pageReq PageRequest) (Page[models.Message], error) {
+	ctx, span := r.startRoomSpan(ctx, "cassrepo.GetMessagesBefore", roomID)
+	defer span.End()
+
 	floorBucket := r.bucket.Of(floor)
 	startBucket, initialPageState, err := startBucketFromCursor(pageReq, walkDesc, r.bucket.Of(before), floorBucket)
 	if err != nil {
@@ -105,6 +108,9 @@ func (r *Repository) GetMessagesBefore(ctx context.Context, roomID string, befor
 }
 
 func (r *Repository) GetMessagesBetweenDesc(ctx context.Context, roomID string, since, before time.Time, pageReq PageRequest) (Page[models.Message], error) {
+	ctx, span := r.startRoomSpan(ctx, "cassrepo.GetMessagesBetweenDesc", roomID)
+	defer span.End()
+
 	floorBucket := r.bucket.Of(since)
 	startBucket, initialPageState, err := startBucketFromCursor(pageReq, walkDesc, r.bucket.Of(before), floorBucket)
 	if err != nil {
@@ -152,6 +158,9 @@ func (r *Repository) GetMessagesBetweenDesc(ctx context.Context, roomID string, 
 }
 
 func (r *Repository) GetMessagesAfter(ctx context.Context, roomID string, after time.Time, ceiling time.Time, pageReq PageRequest) (Page[models.Message], error) {
+	ctx, span := r.startRoomSpan(ctx, "cassrepo.GetMessagesAfter", roomID)
+	defer span.End()
+
 	ceilingBucket := r.bucket.Of(ceiling)
 	startBucket, initialPageState, err := startBucketFromCursor(pageReq, walkAsc, r.bucket.Of(after), ceilingBucket)
 	if err != nil {
@@ -182,6 +191,9 @@ func (r *Repository) GetMessagesAfter(ctx context.Context, roomID string, after 
 }
 
 func (r *Repository) GetAllMessagesAsc(ctx context.Context, roomID string, floor time.Time, ceiling time.Time, pageReq PageRequest) (Page[models.Message], error) {
+	ctx, span := r.startRoomSpan(ctx, "cassrepo.GetAllMessagesAsc", roomID)
+	defer span.End()
+
 	ceilingBucket := r.bucket.Of(ceiling)
 	startBucket, initialPageState, err := startBucketFromCursor(pageReq, walkAsc, r.bucket.Of(floor), ceilingBucket)
 	if err != nil {

--- a/history-service/internal/cassrepo/pin.go
+++ b/history-service/internal/cassrepo/pin.go
@@ -63,7 +63,7 @@ func pinBatchTables(withRoomRow bool) string {
 // half-apply on coordinator failure is possible (caller-side heal in
 // service/pin.go).
 func (r *Repository) PinMessage(ctx context.Context, msg *models.Message, pinnedAt time.Time, pinnedBy models.Participant) error { //nolint:gocritic // hugeParam: Participant is passed by value to match the service.MessageWriter interface
-	ctx, span := r.startRoomSpan(ctx, "cassrepo.PinMessage", msg.RoomID)
+	ctx, span := r.startSpan(ctx, "cassrepo.PinMessage", msg.RoomID, msg.MessageID)
 	defer span.End()
 
 	batch := r.session.NewBatch(gocql.UnloggedBatch).WithContext(ctx)
@@ -89,7 +89,7 @@ func (r *Repository) UnpinMessage(ctx context.Context, msg *models.Message) erro
 	if msg.PinnedAt == nil {
 		return fmt.Errorf("unpin message %s: PinnedAt is nil", msg.MessageID)
 	}
-	ctx, span := r.startRoomSpan(ctx, "cassrepo.UnpinMessage", msg.RoomID)
+	ctx, span := r.startSpan(ctx, "cassrepo.UnpinMessage", msg.RoomID, msg.MessageID)
 	defer span.End()
 
 	batch := r.session.NewBatch(gocql.UnloggedBatch).WithContext(ctx)
@@ -109,7 +109,7 @@ func (r *Repository) UnpinMessage(ctx context.Context, msg *models.Message) erro
 
 // GetPinnedMessages returns one page of pins for a room (redaction is service-side).
 func (r *Repository) GetPinnedMessages(ctx context.Context, roomID string, pageReq PageRequest) (Page[models.Message], error) {
-	ctx, span := r.startRoomSpan(ctx, "cassrepo.GetPinnedMessages", roomID)
+	ctx, span := r.startSpan(ctx, "cassrepo.GetPinnedMessages", roomID, "")
 	defer span.End()
 
 	builder := NewQueryBuilder(r.session.Query(pinnedByRoomQuery, roomID).WithContext(ctx)).
@@ -143,7 +143,7 @@ func (r *Repository) GetPinnedMessages(ctx context.Context, roomID string, pageR
 
 // GetAllPinnedMessages returns every pin for a room (internal: cap + orphan scan need it all).
 func (r *Repository) GetAllPinnedMessages(ctx context.Context, roomID string) ([]models.Message, error) {
-	ctx, span := r.startRoomSpan(ctx, "cassrepo.GetAllPinnedMessages", roomID)
+	ctx, span := r.startSpan(ctx, "cassrepo.GetAllPinnedMessages", roomID, "")
 	defer span.End()
 
 	iter := r.session.Query(pinnedByRoomQuery, roomID).WithContext(ctx).Iter()

--- a/history-service/internal/cassrepo/pin.go
+++ b/history-service/internal/cassrepo/pin.go
@@ -63,6 +63,9 @@ func pinBatchTables(withRoomRow bool) string {
 // half-apply on coordinator failure is possible (caller-side heal in
 // service/pin.go).
 func (r *Repository) PinMessage(ctx context.Context, msg *models.Message, pinnedAt time.Time, pinnedBy models.Participant) error { //nolint:gocritic // hugeParam: Participant is passed by value to match the service.MessageWriter interface
+	ctx, span := r.startRoomSpan(ctx, "cassrepo.PinMessage", msg.RoomID)
+	defer span.End()
+
 	batch := r.session.NewBatch(gocql.UnloggedBatch).WithContext(ctx)
 	batch.Query(pinMsgByID, pinnedAt, pinnedBy, msg.MessageID)
 	batch.Query(insertPinnedMsg,
@@ -86,6 +89,9 @@ func (r *Repository) UnpinMessage(ctx context.Context, msg *models.Message) erro
 	if msg.PinnedAt == nil {
 		return fmt.Errorf("unpin message %s: PinnedAt is nil", msg.MessageID)
 	}
+	ctx, span := r.startRoomSpan(ctx, "cassrepo.UnpinMessage", msg.RoomID)
+	defer span.End()
+
 	batch := r.session.NewBatch(gocql.UnloggedBatch).WithContext(ctx)
 	batch.Query(unpinMsgByID, msg.MessageID)
 	batch.Query(deletePinnedRow, msg.RoomID, *msg.PinnedAt, msg.MessageID)
@@ -103,6 +109,9 @@ func (r *Repository) UnpinMessage(ctx context.Context, msg *models.Message) erro
 
 // GetPinnedMessages returns one page of pins for a room (redaction is service-side).
 func (r *Repository) GetPinnedMessages(ctx context.Context, roomID string, pageReq PageRequest) (Page[models.Message], error) {
+	ctx, span := r.startRoomSpan(ctx, "cassrepo.GetPinnedMessages", roomID)
+	defer span.End()
+
 	builder := NewQueryBuilder(r.session.Query(pinnedByRoomQuery, roomID).WithContext(ctx)).
 		WithPageSize(pageReq.PageSize).
 		WithCursor(pageReq.Cursor)
@@ -134,6 +143,9 @@ func (r *Repository) GetPinnedMessages(ctx context.Context, roomID string, pageR
 
 // GetAllPinnedMessages returns every pin for a room (internal: cap + orphan scan need it all).
 func (r *Repository) GetAllPinnedMessages(ctx context.Context, roomID string) ([]models.Message, error) {
+	ctx, span := r.startRoomSpan(ctx, "cassrepo.GetAllPinnedMessages", roomID)
+	defer span.End()
+
 	iter := r.session.Query(pinnedByRoomQuery, roomID).WithContext(ctx).Iter()
 	rows := make([]models.Message, 0)
 	for {

--- a/history-service/internal/cassrepo/reactions.go
+++ b/history-service/internal/cassrepo/reactions.go
@@ -31,6 +31,9 @@ func (r *Repository) AddReaction(ctx context.Context, msg *models.Message, key m
 	if msg.ThreadParentID != "" && msg.ThreadRoomID == "" {
 		return fmt.Errorf("react thread message %s: ThreadParentID %q is set but ThreadRoomID is empty", msg.MessageID, msg.ThreadParentID)
 	}
+	ctx, span := r.startRoomSpan(ctx, "cassrepo.AddReaction", msg.RoomID)
+	defer span.End()
+
 	reactedAt := reactor.ReactedAt
 
 	batch := r.session.NewBatch(gocql.UnloggedBatch).WithContext(ctx)
@@ -55,6 +58,8 @@ func (r *Repository) RemoveReaction(ctx context.Context, msg *models.Message, ke
 	if msg.ThreadParentID != "" && msg.ThreadRoomID == "" {
 		return fmt.Errorf("unreact thread message %s: ThreadParentID %q is set but ThreadRoomID is empty", msg.MessageID, msg.ThreadParentID)
 	}
+	ctx, span := r.startRoomSpan(ctx, "cassrepo.RemoveReaction", msg.RoomID)
+	defer span.End()
 
 	batch := r.session.NewBatch(gocql.UnloggedBatch).WithContext(ctx)
 	batch.Query(removeReactionMsgByID, key, msg.MessageID)

--- a/history-service/internal/cassrepo/reactions.go
+++ b/history-service/internal/cassrepo/reactions.go
@@ -31,7 +31,7 @@ func (r *Repository) AddReaction(ctx context.Context, msg *models.Message, key m
 	if msg.ThreadParentID != "" && msg.ThreadRoomID == "" {
 		return fmt.Errorf("react thread message %s: ThreadParentID %q is set but ThreadRoomID is empty", msg.MessageID, msg.ThreadParentID)
 	}
-	ctx, span := r.startRoomSpan(ctx, "cassrepo.AddReaction", msg.RoomID)
+	ctx, span := r.startSpan(ctx, "cassrepo.AddReaction", msg.RoomID, msg.MessageID)
 	defer span.End()
 
 	reactedAt := reactor.ReactedAt
@@ -58,7 +58,7 @@ func (r *Repository) RemoveReaction(ctx context.Context, msg *models.Message, ke
 	if msg.ThreadParentID != "" && msg.ThreadRoomID == "" {
 		return fmt.Errorf("unreact thread message %s: ThreadParentID %q is set but ThreadRoomID is empty", msg.MessageID, msg.ThreadParentID)
 	}
-	ctx, span := r.startRoomSpan(ctx, "cassrepo.RemoveReaction", msg.RoomID)
+	ctx, span := r.startSpan(ctx, "cassrepo.RemoveReaction", msg.RoomID, msg.MessageID)
 	defer span.End()
 
 	batch := r.session.NewBatch(gocql.UnloggedBatch).WithContext(ctx)

--- a/history-service/internal/cassrepo/repository.go
+++ b/history-service/internal/cassrepo/repository.go
@@ -2,10 +2,15 @@ package cassrepo
 
 import (
 	"github.com/gocql/gocql"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/hmchangw/chat/pkg/atrest"
 	"github.com/hmchangw/chat/pkg/msgbucket"
 )
+
+// tracerName identifies this package's spans in the global tracer provider.
+const tracerName = "github.com/hmchangw/chat/history-service/internal/cassrepo"
 
 // Repository wraps a Cassandra session with the bucket sizer + read-walk
 // configuration shared by all queries against bucketed message tables, plus
@@ -15,6 +20,7 @@ type Repository struct {
 	bucket     msgbucket.Sizer
 	maxBuckets int
 	cipher     atrest.Cipher // nil when ATREST_ENABLED=false
+	tracer     trace.Tracer
 }
 
 // NewRepository wires a session, bucket sizer, max-walk depth, and (optional)
@@ -28,5 +34,6 @@ func NewRepository(session *gocql.Session, bucket msgbucket.Sizer, maxBuckets in
 		bucket:     bucket,
 		maxBuckets: maxBuckets,
 		cipher:     cipher,
+		tracer:     otel.Tracer(tracerName),
 	}
 }

--- a/history-service/internal/cassrepo/roomspan.go
+++ b/history-service/internal/cassrepo/roomspan.go
@@ -1,0 +1,19 @@
+package cassrepo
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// startRoomSpan opens a child span named op tagged with the room id and returns
+// the span's context. The gocql query spans the o11y observer emits for queries
+// run under this context nest beneath it, so a Cassandra trace carries the room
+// it served — the missing key for per-room debugging, since room_id is a query
+// argument the query spans don't expose on their own. Callers defer span.End().
+func (r *Repository) startRoomSpan(ctx context.Context, op, roomID string) (context.Context, trace.Span) {
+	ctx, span := r.tracer.Start(ctx, op)
+	span.SetAttributes(attribute.String("room_id", roomID))
+	return ctx, span
+}

--- a/history-service/internal/cassrepo/roomspan.go
+++ b/history-service/internal/cassrepo/roomspan.go
@@ -7,13 +7,23 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// startRoomSpan opens a child span named op tagged with the room id and returns
-// the span's context. The gocql query spans the o11y observer emits for queries
-// run under this context nest beneath it, so a Cassandra trace carries the room
-// it served — the missing key for per-room debugging, since room_id is a query
-// argument the query spans don't expose on their own. Callers defer span.End().
-func (r *Repository) startRoomSpan(ctx context.Context, op, roomID string) (context.Context, trace.Span) {
+// startSpan opens a child span named op tagged with the room and/or message id
+// and returns the span's context. The gocql query spans the o11y observer emits
+// for queries run under this context nest beneath it, so a Cassandra trace
+// carries the room and message it served — the missing keys for per-room and
+// per-message debugging, since both are query arguments the query spans don't
+// expose. Either id may be empty to omit it (room-range reads pass an empty
+// message id; message-id point reads pass an empty room). Callers defer
+// span.End().
+func (r *Repository) startSpan(ctx context.Context, op, roomID, messageID string) (context.Context, trace.Span) {
 	ctx, span := r.tracer.Start(ctx, op)
-	span.SetAttributes(attribute.String("room_id", roomID))
+	attrs := make([]attribute.KeyValue, 0, 2)
+	if roomID != "" {
+		attrs = append(attrs, attribute.String("room_id", roomID))
+	}
+	if messageID != "" {
+		attrs = append(attrs, attribute.String("message_id", messageID))
+	}
+	span.SetAttributes(attrs...)
 	return ctx, span
 }

--- a/history-service/internal/cassrepo/roomspan_test.go
+++ b/history-service/internal/cassrepo/roomspan_test.go
@@ -1,0 +1,83 @@
+package cassrepo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/hmchangw/chat/pkg/msgbucket"
+)
+
+// recordingRepo returns a Repository whose tracer feeds an in-memory recorder,
+// so span assertions run without a real tracer provider or global state.
+func recordingRepo(t *testing.T) (*Repository, *tracetest.SpanRecorder) {
+	t.Helper()
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(recorder),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	return &Repository{tracer: tp.Tracer("test")}, recorder
+}
+
+func attrValue(span sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, a := range span.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+func TestNewRepository_SetsTracer(t *testing.T) {
+	r := NewRepository(nil, msgbucket.Sizer{}, 0, nil)
+	assert.NotNil(t, r.tracer, "NewRepository must default the tracer so production spans record")
+}
+
+func TestRepository_startRoomSpan_TagsRoomID(t *testing.T) {
+	r, recorder := recordingRepo(t)
+
+	ctx, span := r.startRoomSpan(context.Background(), "cassrepo.GetMessagesBefore", "room-42")
+	span.End()
+
+	// The returned context carries the span so nested query spans parent to it.
+	assert.Equal(t,
+		span.SpanContext().SpanID(),
+		oteltrace.SpanFromContext(ctx).SpanContext().SpanID(),
+		"returned ctx must carry the started span",
+	)
+
+	ended := recorder.Ended()
+	require.Len(t, ended, 1)
+	assert.Equal(t, "cassrepo.GetMessagesBefore", ended[0].Name())
+	roomID, ok := attrValue(ended[0], "room_id")
+	require.True(t, ok, "span must carry a room_id attribute")
+	assert.Equal(t, "room-42", roomID)
+}
+
+func TestRepository_startRoomSpan_NestsUnderParent(t *testing.T) {
+	r, recorder := recordingRepo(t)
+
+	parentCtx, parent := r.tracer.Start(context.Background(), "handler")
+	_, child := r.startRoomSpan(parentCtx, "cassrepo.PinMessage", "room-7")
+	child.End()
+	parent.End()
+
+	var childSpan sdktrace.ReadOnlySpan
+	for _, s := range recorder.Ended() {
+		if s.Name() == "cassrepo.PinMessage" {
+			childSpan = s
+		}
+	}
+	require.NotNil(t, childSpan)
+	assert.Equal(t,
+		parent.SpanContext().SpanID(),
+		childSpan.Parent().SpanID(),
+		"room span must nest under the caller's span so query spans inherit room context",
+	)
+}

--- a/history-service/internal/cassrepo/roomspan_test.go
+++ b/history-service/internal/cassrepo/roomspan_test.go
@@ -39,10 +39,10 @@ func TestNewRepository_SetsTracer(t *testing.T) {
 	assert.NotNil(t, r.tracer, "NewRepository must default the tracer so production spans record")
 }
 
-func TestRepository_startRoomSpan_TagsRoomID(t *testing.T) {
+func TestRepository_startSpan_TagsRoomAndMessageID(t *testing.T) {
 	r, recorder := recordingRepo(t)
 
-	ctx, span := r.startRoomSpan(context.Background(), "cassrepo.GetMessagesBefore", "room-42")
+	ctx, span := r.startSpan(context.Background(), "cassrepo.PinMessage", "room-42", "msg-1")
 	span.End()
 
 	// The returned context carries the span so nested query spans parent to it.
@@ -54,17 +54,37 @@ func TestRepository_startRoomSpan_TagsRoomID(t *testing.T) {
 
 	ended := recorder.Ended()
 	require.Len(t, ended, 1)
-	assert.Equal(t, "cassrepo.GetMessagesBefore", ended[0].Name())
+	assert.Equal(t, "cassrepo.PinMessage", ended[0].Name())
 	roomID, ok := attrValue(ended[0], "room_id")
 	require.True(t, ok, "span must carry a room_id attribute")
 	assert.Equal(t, "room-42", roomID)
+	messageID, ok := attrValue(ended[0], "message_id")
+	require.True(t, ok, "span must carry a message_id attribute")
+	assert.Equal(t, "msg-1", messageID)
 }
 
-func TestRepository_startRoomSpan_NestsUnderParent(t *testing.T) {
+func TestRepository_startSpan_OmitsEmptyMessageID(t *testing.T) {
+	r, recorder := recordingRepo(t)
+
+	// Room-range reads (bucket walks) serve no single message, so message_id
+	// is empty and must be omitted rather than written blank.
+	_, span := r.startSpan(context.Background(), "cassrepo.GetMessagesBefore", "room-42", "")
+	span.End()
+
+	ended := recorder.Ended()
+	require.Len(t, ended, 1)
+	roomID, ok := attrValue(ended[0], "room_id")
+	require.True(t, ok)
+	assert.Equal(t, "room-42", roomID)
+	_, ok = attrValue(ended[0], "message_id")
+	assert.False(t, ok, "an empty message id must be omitted, not written as an empty attribute")
+}
+
+func TestRepository_startSpan_NestsUnderParent(t *testing.T) {
 	r, recorder := recordingRepo(t)
 
 	parentCtx, parent := r.tracer.Start(context.Background(), "handler")
-	_, child := r.startRoomSpan(parentCtx, "cassrepo.PinMessage", "room-7")
+	_, child := r.startSpan(parentCtx, "cassrepo.PinMessage", "room-7", "msg-2")
 	child.End()
 	parent.End()
 

--- a/history-service/internal/cassrepo/write.go
+++ b/history-service/internal/cassrepo/write.go
@@ -235,7 +235,7 @@ func (r *Repository) UpdateMessageContent(ctx context.Context, msg *models.Messa
 	if msg.ThreadParentID != "" && msg.ThreadRoomID == "" {
 		return fmt.Errorf("edit thread message %s: ThreadParentID %q is set but ThreadRoomID is empty", msg.MessageID, msg.ThreadParentID)
 	}
-	ctx, span := r.startRoomSpan(ctx, "cassrepo.UpdateMessageContent", msg.RoomID)
+	ctx, span := r.startSpan(ctx, "cassrepo.UpdateMessageContent", msg.RoomID, msg.MessageID)
 	defer span.End()
 
 	// The service layer's findMessage already gates existence and the
@@ -293,7 +293,7 @@ func (r *Repository) SoftDeleteMessage(ctx context.Context, msg *models.Message,
 	if msg.ThreadParentID != "" && msg.ThreadRoomID == "" {
 		return time.Time{}, false, nil, nil, fmt.Errorf("delete thread message %s: ThreadParentID %q is set but ThreadRoomID is empty", msg.MessageID, msg.ThreadParentID)
 	}
-	ctx, span := r.startRoomSpan(ctx, "cassrepo.SoftDeleteMessage", msg.RoomID)
+	ctx, span := r.startSpan(ctx, "cassrepo.SoftDeleteMessage", msg.RoomID, msg.MessageID)
 	defer span.End()
 
 	isThreadParent := msg.TCount != nil && *msg.TCount > 0

--- a/history-service/internal/cassrepo/write.go
+++ b/history-service/internal/cassrepo/write.go
@@ -235,6 +235,8 @@ func (r *Repository) UpdateMessageContent(ctx context.Context, msg *models.Messa
 	if msg.ThreadParentID != "" && msg.ThreadRoomID == "" {
 		return fmt.Errorf("edit thread message %s: ThreadParentID %q is set but ThreadRoomID is empty", msg.MessageID, msg.ThreadParentID)
 	}
+	ctx, span := r.startRoomSpan(ctx, "cassrepo.UpdateMessageContent", msg.RoomID)
+	defer span.End()
 
 	// The service layer's findMessage already gates existence and the
 	// not-deleted check before this is reached, and a message is only edited
@@ -291,6 +293,8 @@ func (r *Repository) SoftDeleteMessage(ctx context.Context, msg *models.Message,
 	if msg.ThreadParentID != "" && msg.ThreadRoomID == "" {
 		return time.Time{}, false, nil, nil, fmt.Errorf("delete thread message %s: ThreadParentID %q is set but ThreadRoomID is empty", msg.MessageID, msg.ThreadParentID)
 	}
+	ctx, span := r.startRoomSpan(ctx, "cassrepo.SoftDeleteMessage", msg.RoomID)
+	defer span.End()
 
 	isThreadParent := msg.TCount != nil && *msg.TCount > 0
 

--- a/message-worker/roomspan.go
+++ b/message-worker/roomspan.go
@@ -10,13 +10,20 @@ import (
 // tracerName identifies this service's spans in the global tracer provider.
 const tracerName = "github.com/hmchangw/chat/message-worker"
 
-// startRoomSpan opens a child span named op tagged with the room id and returns
-// the span's context. The gocql query spans the o11y observer emits for writes
-// run under this context nest beneath it, so a Cassandra trace carries the room
-// it served — room_id is otherwise only a query argument the query spans don't
-// expose. Callers defer span.End().
-func (s *CassandraStore) startRoomSpan(ctx context.Context, op, roomID string) (context.Context, trace.Span) {
+// startSpan opens a child span named op tagged with the room and/or message id
+// so the gocql query spans the o11y observer emits under this context nest
+// beneath it and carry the ids in the trace — otherwise they are only query
+// arguments the query spans don't expose. Either id may be empty to omit it
+// (reads keyed only by message_id pass an empty room). Callers defer span.End().
+func (s *CassandraStore) startSpan(ctx context.Context, op, roomID, messageID string) (context.Context, trace.Span) {
 	ctx, span := s.tracer.Start(ctx, op)
-	span.SetAttributes(attribute.String("room_id", roomID))
+	attrs := make([]attribute.KeyValue, 0, 2)
+	if roomID != "" {
+		attrs = append(attrs, attribute.String("room_id", roomID))
+	}
+	if messageID != "" {
+		attrs = append(attrs, attribute.String("message_id", messageID))
+	}
+	span.SetAttributes(attrs...)
 	return ctx, span
 }

--- a/message-worker/roomspan.go
+++ b/message-worker/roomspan.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// tracerName identifies this service's spans in the global tracer provider.
+const tracerName = "github.com/hmchangw/chat/message-worker"
+
+// startRoomSpan opens a child span named op tagged with the room id and returns
+// the span's context. The gocql query spans the o11y observer emits for writes
+// run under this context nest beneath it, so a Cassandra trace carries the room
+// it served — room_id is otherwise only a query argument the query spans don't
+// expose. Callers defer span.End().
+func (s *CassandraStore) startRoomSpan(ctx context.Context, op, roomID string) (context.Context, trace.Span) {
+	ctx, span := s.tracer.Start(ctx, op)
+	span.SetAttributes(attribute.String("room_id", roomID))
+	return ctx, span
+}

--- a/message-worker/roomspan_test.go
+++ b/message-worker/roomspan_test.go
@@ -39,10 +39,10 @@ func TestNewCassandraStore_SetsTracer(t *testing.T) {
 	assert.NotNil(t, s.tracer, "NewCassandraStore must default the tracer so production spans record")
 }
 
-func TestCassandraStore_startRoomSpan_TagsRoomID(t *testing.T) {
+func TestCassandraStore_startSpan_TagsRoomAndMessageID(t *testing.T) {
 	s, recorder := recordingStore(t)
 
-	ctx, span := s.startRoomSpan(context.Background(), "cassandra.SaveMessage", "room-9")
+	ctx, span := s.startSpan(context.Background(), "cassandra.SaveMessage", "room-9", "msg-1")
 	span.End()
 
 	assert.Equal(t,
@@ -57,13 +57,31 @@ func TestCassandraStore_startRoomSpan_TagsRoomID(t *testing.T) {
 	roomID, ok := spanAttr(ended[0], "room_id")
 	require.True(t, ok, "span must carry a room_id attribute")
 	assert.Equal(t, "room-9", roomID)
+	messageID, ok := spanAttr(ended[0], "message_id")
+	require.True(t, ok, "span must carry a message_id attribute")
+	assert.Equal(t, "msg-1", messageID)
 }
 
-func TestCassandraStore_startRoomSpan_NestsUnderParent(t *testing.T) {
+func TestCassandraStore_startSpan_OmitsEmptyRoom(t *testing.T) {
+	s, recorder := recordingStore(t)
+
+	_, span := s.startSpan(context.Background(), "cassandra.GetMessageSender", "", "msg-7")
+	span.End()
+
+	ended := recorder.Ended()
+	require.Len(t, ended, 1)
+	messageID, ok := spanAttr(ended[0], "message_id")
+	require.True(t, ok, "span must carry message_id when only the message is known")
+	assert.Equal(t, "msg-7", messageID)
+	_, ok = spanAttr(ended[0], "room_id")
+	assert.False(t, ok, "an empty room id must be omitted, not written as an empty attribute")
+}
+
+func TestCassandraStore_startSpan_NestsUnderParent(t *testing.T) {
 	s, recorder := recordingStore(t)
 
 	parentCtx, parent := s.tracer.Start(context.Background(), "consume")
-	_, child := s.startRoomSpan(parentCtx, "cassandra.SaveThreadMessage", "room-3")
+	_, child := s.startSpan(parentCtx, "cassandra.SaveThreadMessage", "room-3", "msg-2")
 	child.End()
 	parent.End()
 

--- a/message-worker/roomspan_test.go
+++ b/message-worker/roomspan_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/hmchangw/chat/pkg/msgbucket"
+)
+
+// recordingStore returns a CassandraStore whose tracer feeds an in-memory
+// recorder, so span assertions run without a global provider.
+func recordingStore(t *testing.T) (*CassandraStore, *tracetest.SpanRecorder) {
+	t.Helper()
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(recorder),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	return &CassandraStore{tracer: tp.Tracer("test")}, recorder
+}
+
+func spanAttr(span sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, a := range span.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+func TestNewCassandraStore_SetsTracer(t *testing.T) {
+	s := NewCassandraStore(nil, msgbucket.Sizer{}, nil)
+	assert.NotNil(t, s.tracer, "NewCassandraStore must default the tracer so production spans record")
+}
+
+func TestCassandraStore_startRoomSpan_TagsRoomID(t *testing.T) {
+	s, recorder := recordingStore(t)
+
+	ctx, span := s.startRoomSpan(context.Background(), "cassandra.SaveMessage", "room-9")
+	span.End()
+
+	assert.Equal(t,
+		span.SpanContext().SpanID(),
+		oteltrace.SpanFromContext(ctx).SpanContext().SpanID(),
+		"returned ctx must carry the started span",
+	)
+
+	ended := recorder.Ended()
+	require.Len(t, ended, 1)
+	assert.Equal(t, "cassandra.SaveMessage", ended[0].Name())
+	roomID, ok := spanAttr(ended[0], "room_id")
+	require.True(t, ok, "span must carry a room_id attribute")
+	assert.Equal(t, "room-9", roomID)
+}
+
+func TestCassandraStore_startRoomSpan_NestsUnderParent(t *testing.T) {
+	s, recorder := recordingStore(t)
+
+	parentCtx, parent := s.tracer.Start(context.Background(), "consume")
+	_, child := s.startRoomSpan(parentCtx, "cassandra.SaveThreadMessage", "room-3")
+	child.End()
+	parent.End()
+
+	var childSpan sdktrace.ReadOnlySpan
+	for _, sp := range recorder.Ended() {
+		if sp.Name() == "cassandra.SaveThreadMessage" {
+			childSpan = sp
+		}
+	}
+	require.NotNil(t, childSpan)
+	assert.Equal(t,
+		parent.SpanContext().SpanID(),
+		childSpan.Parent().SpanID(),
+		"room span must nest under the caller's span so query spans inherit room context",
+	)
+}

--- a/message-worker/store_cassandra.go
+++ b/message-worker/store_cassandra.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/gocql/gocql"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/hmchangw/chat/pkg/atrest"
 	"github.com/hmchangw/chat/pkg/model"
@@ -60,10 +62,11 @@ type CassandraStore struct {
 	cassSession *gocql.Session
 	bucket      msgbucket.Sizer
 	cipher      atrest.Cipher // nil when ATREST_ENABLED=false
+	tracer      trace.Tracer
 }
 
 func NewCassandraStore(session *gocql.Session, bucket msgbucket.Sizer, cipher atrest.Cipher) *CassandraStore {
-	return &CassandraStore{cassSession: session, bucket: bucket, cipher: cipher}
+	return &CassandraStore{cassSession: session, bucket: bucket, cipher: cipher, tracer: otel.Tracer(tracerName)}
 }
 
 // SaveMessage inserts msg into both messages_by_room and messages_by_id via a
@@ -77,6 +80,9 @@ func NewCassandraStore(session *gocql.Session, bucket msgbucket.Sizer, cipher at
 // the legacy plaintext columns are left null. When s.cipher is nil the
 // legacy plaintext batch runs unchanged.
 func (s *CassandraStore) SaveMessage(ctx context.Context, msg *model.Message, sender *cassParticipant, siteID string) error {
+	ctx, span := s.startRoomSpan(ctx, "cassandra.SaveMessage", msg.RoomID)
+	defer span.End()
+
 	if s.cipher != nil {
 		return s.saveMessageEncrypted(ctx, msg, sender, siteID)
 	}
@@ -168,6 +174,9 @@ func (s *CassandraStore) saveMessageEncrypted(ctx context.Context, msg *model.Me
 // countAndSetParentTcount derives tcount from a COUNT query and blind-SETs it,
 // which is idempotent on redelivery without any CAS.
 func (s *CassandraStore) SaveThreadMessage(ctx context.Context, msg *model.Message, sender *cassParticipant, siteID string, threadRoomID string) (*int, error) {
+	ctx, span := s.startRoomSpan(ctx, "cassandra.SaveThreadMessage", msg.RoomID)
+	defer span.End()
+
 	if s.cipher != nil {
 		return s.saveThreadMessageEncrypted(ctx, msg, sender, siteID, threadRoomID)
 	}
@@ -377,6 +386,9 @@ func (s *CassandraStore) countAndSetParentTcount(ctx context.Context, msg *model
 // IF EXISTS prevents phantom rows on missing parents; misses log at ERROR
 // because a silent miss permanently breaks thread reads for that parent.
 func (s *CassandraStore) UpdateParentMessageThreadRoomID(ctx context.Context, parentMessageID, roomID string, parentCreatedAt time.Time, threadRoomID string) error {
+	ctx, span := s.startRoomSpan(ctx, "cassandra.UpdateParentMessageThreadRoomID", roomID)
+	defer span.End()
+
 	parentBucket := s.bucket.Of(parentCreatedAt)
 
 	applied, err := s.cassSession.Query(

--- a/message-worker/store_cassandra.go
+++ b/message-worker/store_cassandra.go
@@ -80,7 +80,7 @@ func NewCassandraStore(session *gocql.Session, bucket msgbucket.Sizer, cipher at
 // the legacy plaintext columns are left null. When s.cipher is nil the
 // legacy plaintext batch runs unchanged.
 func (s *CassandraStore) SaveMessage(ctx context.Context, msg *model.Message, sender *cassParticipant, siteID string) error {
-	ctx, span := s.startRoomSpan(ctx, "cassandra.SaveMessage", msg.RoomID)
+	ctx, span := s.startSpan(ctx, "cassandra.SaveMessage", msg.RoomID, msg.ID)
 	defer span.End()
 
 	if s.cipher != nil {
@@ -174,7 +174,7 @@ func (s *CassandraStore) saveMessageEncrypted(ctx context.Context, msg *model.Me
 // countAndSetParentTcount derives tcount from a COUNT query and blind-SETs it,
 // which is idempotent on redelivery without any CAS.
 func (s *CassandraStore) SaveThreadMessage(ctx context.Context, msg *model.Message, sender *cassParticipant, siteID string, threadRoomID string) (*int, error) {
-	ctx, span := s.startRoomSpan(ctx, "cassandra.SaveThreadMessage", msg.RoomID)
+	ctx, span := s.startSpan(ctx, "cassandra.SaveThreadMessage", msg.RoomID, msg.ID)
 	defer span.End()
 
 	if s.cipher != nil {
@@ -386,7 +386,7 @@ func (s *CassandraStore) countAndSetParentTcount(ctx context.Context, msg *model
 // IF EXISTS prevents phantom rows on missing parents; misses log at ERROR
 // because a silent miss permanently breaks thread reads for that parent.
 func (s *CassandraStore) UpdateParentMessageThreadRoomID(ctx context.Context, parentMessageID, roomID string, parentCreatedAt time.Time, threadRoomID string) error {
-	ctx, span := s.startRoomSpan(ctx, "cassandra.UpdateParentMessageThreadRoomID", roomID)
+	ctx, span := s.startSpan(ctx, "cassandra.UpdateParentMessageThreadRoomID", roomID, parentMessageID)
 	defer span.End()
 
 	parentBucket := s.bucket.Of(parentCreatedAt)
@@ -432,6 +432,9 @@ func (s *CassandraStore) UpdateParentMessageThreadRoomID(ctx context.Context, pa
 // when the row is absent so the caller can drop an unverifiable quote. MessageLink
 // and Attachments are left to the caller.
 func (s *CassandraStore) GetQuotedParentSnapshot(ctx context.Context, messageID string) (*cassandra.QuotedParentMessage, bool, error) {
+	ctx, span := s.startSpan(ctx, "cassandra.GetQuotedParentSnapshot", "", messageID)
+	defer span.End()
+
 	var (
 		roomID                string
 		sender                cassandra.Participant
@@ -485,6 +488,9 @@ func (s *CassandraStore) GetQuotedParentSnapshot(ctx context.Context, messageID 
 // GetMessageCreatedAt point-reads created_at from messages_by_id. Returns
 // (zero, false, nil) when absent; a Cassandra failure errors so the worker NAKs.
 func (s *CassandraStore) GetMessageCreatedAt(ctx context.Context, messageID string) (time.Time, bool, error) {
+	ctx, span := s.startSpan(ctx, "cassandra.GetMessageCreatedAt", "", messageID)
+	defer span.End()
+
 	var createdAt time.Time
 	if err := s.cassSession.Query(
 		`SELECT created_at FROM messages_by_id WHERE message_id = ? LIMIT 1`,
@@ -501,6 +507,9 @@ func (s *CassandraStore) GetMessageCreatedAt(ctx context.Context, messageID stri
 // GetMessageSender reads the sender UDT from messages_by_id for the given message ID.
 // Returns an error if the message does not exist.
 func (s *CassandraStore) GetMessageSender(ctx context.Context, messageID string) (*cassParticipant, error) {
+	ctx, span := s.startSpan(ctx, "cassandra.GetMessageSender", "", messageID)
+	defer span.End()
+
 	var sender cassParticipant
 	if err := s.cassSession.Query(
 		`SELECT sender FROM messages_by_id WHERE message_id = ? LIMIT 1`,


### PR DESCRIPTION
The o11y gocql observer emits a CLIENT span per query but exposes no
per-query attribute hook, so the room a read/write served never reaches
the trace — room_id is only a query argument. Wrap each room-scoped
cassrepo operation in a span carrying room_id (mirroring pkg/atrest's
convention) so the nested query spans inherit it, making per-room
history debugging possible.

Covers the room-scoped reads (message bucket walks, pinned reads) and
writes (pin/unpin, reactions, edit, soft-delete). Methods keyed only by
message_id or thread_room_id are left untouched — no room_id in hand.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FQEQfhp7ETVk8t4oB6FD2T

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distributed tracing across message storage and history operations.
  * Traces now include relevant room and message context, supporting improved request visibility and operation tracking.
  * Added parent-child span propagation for clearer end-to-end performance analysis.

* **Tests**
  * Added coverage validating trace creation, attributes, context propagation, and nested spans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->