### PR TITLE
perf(subscription.list): skip room-less subs in the last-message batch

### DIFF
--- a/user-service/service/enrich_test.go
+++ b/user-service/service/enrich_test.go
@@ -514,7 +514,7 @@ func enrichFixture(n int, site string) ([]model.EnrichedSubscription, map[string
 // history-service hard-rejects rooms.get above 100 ids AND above 100 hints, so an
 // unchunked 250-room page would come back with no previews at all.
 func TestEnrichLastMessage_ChunksBeyondBatchCap(t *testing.T) {
-	svc, _, history := newSvcRawHistory(t)
+	svc, _, _, history := newSvcRawHistory(t)
 	subs, idxBySite := enrichFixture(250, "site-a")
 
 	var mu sync.Mutex
@@ -547,7 +547,7 @@ func TestEnrichLastMessage_ChunksBeyondBatchCap(t *testing.T) {
 
 // Chunking exists to make degradation finer than per-site.
 func TestEnrichLastMessage_OneFailedChunkDegradesOnlyItsRooms(t *testing.T) {
-	svc, _, history := newSvcRawHistory(t)
+	svc, _, _, history := newSvcRawHistory(t)
 	subs, idxBySite := enrichFixture(250, "site-a")
 
 	history.EXPECT().RoomsGet(gomock.Any(), "site-a", gomock.Any(), gomock.Any()).
@@ -640,7 +640,7 @@ func TestEnrichCrossSite_OneFailedChunkDegradesOnlyItsRooms(t *testing.T) {
 // A room count cannot bound reply bytes: previews carry untruncated message
 // bodies, so a full chunk can overflow the transport. It must be split, not lost.
 func TestEnrichLastMessage_SplitsOnResponseTooLarge(t *testing.T) {
-	svc, _, history := newSvcRawHistory(t)
+	svc, _, _, history := newSvcRawHistory(t)
 	subs, idxBySite := enrichFixture(100, "site-a")
 
 	var mu sync.Mutex
@@ -674,7 +674,7 @@ func TestEnrichLastMessage_SplitsOnResponseTooLarge(t *testing.T) {
 // Splitting applies only to the payload refusal; other failures must not be
 // retried, or a shedding downstream would see the request multiply.
 func TestEnrichLastMessage_DoesNotSplitOtherErrors(t *testing.T) {
-	svc, _, history := newSvcRawHistory(t)
+	svc, _, _, history := newSvcRawHistory(t)
 	subs, idxBySite := enrichFixture(100, "site-a")
 
 	history.EXPECT().RoomsGet(gomock.Any(), "site-a", gomock.Any(), gomock.Any()).
@@ -689,7 +689,7 @@ func TestEnrichLastMessage_DoesNotSplitOtherErrors(t *testing.T) {
 
 // A half that still overflows degrades alone rather than taking the page with it.
 func TestEnrichLastMessage_KeepsTheHalfThatFits(t *testing.T) {
-	svc, _, history := newSvcRawHistory(t)
+	svc, _, _, history := newSvcRawHistory(t)
 	subs, idxBySite := enrichFixture(100, "site-a")
 
 	history.EXPECT().RoomsGet(gomock.Any(), "site-a", gomock.Any(), gomock.Any()).
@@ -729,7 +729,7 @@ func TestFanout_NormalisesNonPositive(t *testing.T) {
 // A zero fan-out would build an unbuffered semaphore and park forever, which
 // fixtures constructing UserService directly can otherwise hit.
 func TestEnrichLastMessage_UnsetFanoutDoesNotDeadlock(t *testing.T) {
-	_, _, history := newSvcRawHistory(t)
+	_, _, _, history := newSvcRawHistory(t)
 	// maxFanout deliberately left at zero, as the badge/thread fixtures build it.
 	svc := &UserService{siteID: "site-a", history: history, roomBatchChunk: 100}
 	subs, idxBySite := enrichFixture(10, "site-a")
@@ -767,7 +767,7 @@ func TestEnrichLastMessage_TruncatesPreviewContent(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc, _, history := newSvcRawHistory(t)
+			svc, _, _, history := newSvcRawHistory(t)
 			svc.previewChars = tt.chars
 			subs, idxBySite := enrichFixture(1, "site-a")
 
@@ -806,7 +806,7 @@ func TestTruncatePreviews_DetachesFromTheOriginalBody(t *testing.T) {
 // On a payload-capped transport the page's own reply shares the ceiling history
 // just hit, so splitting spends RPCs on data that can never be delivered.
 func TestEnrichLastMessage_NoSplitOnPayloadCappedTransport(t *testing.T) {
-	svc, _, history := newSvcRawHistory(t)
+	svc, _, _, history := newSvcRawHistory(t)
 	subs, idxBySite := enrichFixture(100, "site-a")
 
 	history.EXPECT().RoomsGet(gomock.Any(), "site-a", gomock.Any(), gomock.Any()).
@@ -821,7 +821,7 @@ func TestEnrichLastMessage_NoSplitOnPayloadCappedTransport(t *testing.T) {
 
 // Unbounded halving is exponential in RPCs; past the depth cap the chunk degrades.
 func TestEnrichLastMessage_BoundsSplitDepth(t *testing.T) {
-	svc, _, history := newSvcRawHistory(t)
+	svc, _, _, history := newSvcRawHistory(t)
 	subs, idxBySite := enrichFixture(100, "site-a")
 
 	var mu sync.Mutex

--- a/user-service/service/subscriptions.go
+++ b/user-service/service/subscriptions.go
@@ -331,6 +331,31 @@ func planChunks(subs []model.EnrichedSubscription, sites []string, idxBySite map
 	return jobs
 }
 
+// requestableBySite drops the rows whose sub has no Room. The last-message fan-out
+// has nothing to attach those previews to and discards them on arrival, so sending
+// their ids only crowds the 100-id cap and can split a batch that would otherwise
+// fit; a site left with none emits no chunk, which skips its RPC entirely.
+//
+// ONLY the last-message fan-out may filter this way. Room-info enrichment is what
+// POPULATES Room, so applying it there would drop every cross-site sub before the
+// RPC that resolves it and leave the whole site unenriched.
+func requestableBySite(subs []model.EnrichedSubscription, idxBySite map[string][]int) map[string][]int {
+	out := make(map[string][]int, len(idxBySite))
+	for site, rows := range idxBySite {
+		keep := make([]int, 0, len(rows))
+		for _, j := range rows {
+			if subs[j].Room == nil {
+				continue
+			}
+			keep = append(keep, j)
+		}
+		if len(keep) > 0 {
+			out[site] = keep
+		}
+	}
+	return out
+}
+
 // roomsGetSplitting fetches previews for one chunk, halving and retrying when the
 // reply will not fit the transport. A room count cannot bound reply bytes —
 // previews carry untruncated message bodies — so even a 100-room chunk can
@@ -523,7 +548,7 @@ func (s *UserService) enrichLastMessage(ctx context.Context, account string, sub
 	for site := range idxBySite {
 		sites = append(sites, site)
 	}
-	lastMsgBySite := fanOutChunks(ctx, planChunks(subs, sites, idxBySite, s.roomBatchChunk), len(sites), s.fanout(),
+	lastMsgBySite := fanOutChunks(ctx, planChunks(subs, sites, requestableBySite(subs, idxBySite), s.roomBatchChunk), len(sites), s.fanout(),
 		func(ctx context.Context, job chunkJob) (map[string]model.PreviewMessage, error) {
 			m, err := s.roomsGetSplitting(ctx, job.site, subs, job.rows, job.roomIDs, 0)
 			if err != nil {

--- a/user-service/service/subscriptions_test.go
+++ b/user-service/service/subscriptions_test.go
@@ -22,7 +22,7 @@ import (
 // newSvcRawHistory builds a service exposing the history mock WITHOUT newSvc's
 // permissive RoomsGet default, so last-message enrichment tests can set an exact
 // RoomsGet expectation (result or error).
-func newSvcRawHistory(t *testing.T) (*UserService, *mocks.MockSubscriptionRepository, *mocks.MockHistoryClient) {
+func newSvcRawHistory(t *testing.T) (*UserService, *mocks.MockSubscriptionRepository, *mocks.MockRoomClient, *mocks.MockHistoryClient) {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 	subs := mocks.NewMockSubscriptionRepository(ctrl)
@@ -34,7 +34,7 @@ func newSvcRawHistory(t *testing.T) (*UserService, *mocks.MockSubscriptionReposi
 	pub := mocks.NewMockEventPublisher(ctrl)
 	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
 	cfg := &config.Config{SiteID: "site-a", AllSiteIDs: []string{"site-a", "site-b"}, MaxSubscriptionLimit: 1000, DefaultSubscriptionLimit: 40, MaxAppsLimit: 100, DefaultAppsLimit: 20, MaxAccountNames: 100, BadgeCountCap: 10, RoomBatchChunk: 100, MaxSiteFanout: 8}
-	return New(subs, users, apps, threadSubs, rooms, history, presence, pub, pub, &fakeBadgeCache{}, nil, nil, nil, cfg), subs, history
+	return New(subs, users, apps, threadSubs, rooms, history, presence, pub, pub, &fakeBadgeCache{}, nil, nil, nil, cfg), subs, rooms, history
 }
 
 func TestListSubscriptions_Types(t *testing.T) {
@@ -1079,7 +1079,7 @@ func TestCount_UnreadFalse(t *testing.T) {
 }
 
 func TestListSubscriptions_LastMessage_Populated(t *testing.T) {
-	svc, subs, history := newSvcRawHistory(t)
+	svc, subs, _, history := newSvcRawHistory(t)
 	storeSubs := []model.EnrichedSubscription{{
 		Subscription: model.Subscription{ID: "s1", RoomID: "r1", SiteID: "site-a", Name: "general", RoomType: model.RoomTypeChannel},
 		RoomName:     "General", UserCount: 3,
@@ -1102,7 +1102,7 @@ func TestListSubscriptions_LastMessage_Populated(t *testing.T) {
 // its own room-times read; a room with no resolved LastMsgAt contributes no
 // hint entry.
 func TestListSubscriptions_LastMessage_HintsFromResolvedRoom(t *testing.T) {
-	svc, subs, history := newSvcRawHistory(t)
+	svc, subs, _, history := newSvcRawHistory(t)
 	lastMsgAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	storeSubs := []model.EnrichedSubscription{
 		{
@@ -1133,7 +1133,7 @@ func TestListSubscriptions_LastMessage_HintsFromResolvedRoom(t *testing.T) {
 
 // includeLastMessage:false skips the rooms.get RPC entirely.
 func TestListSubscriptions_LastMessage_SkippedWhenExcluded(t *testing.T) {
-	svc, subs, _ := newSvcRawHistory(t)
+	svc, subs, _, _ := newSvcRawHistory(t)
 	storeSubs := []model.EnrichedSubscription{{
 		Subscription: model.Subscription{ID: "s1", RoomID: "r1", SiteID: "site-a", Name: "general", RoomType: model.RoomTypeChannel},
 		RoomName:     "General", UserCount: 3,
@@ -1151,7 +1151,7 @@ func TestListSubscriptions_LastMessage_SkippedWhenExcluded(t *testing.T) {
 }
 
 func TestListSubscriptions_LastMessage_SiteDegrades(t *testing.T) {
-	svc, subs, history := newSvcRawHistory(t)
+	svc, subs, _, history := newSvcRawHistory(t)
 	storeSubs := []model.EnrichedSubscription{{
 		Subscription: model.Subscription{ID: "s1", RoomID: "r1", SiteID: "site-a", Name: "general", RoomType: model.RoomTypeChannel},
 		RoomName:     "General", UserCount: 3,
@@ -1346,4 +1346,82 @@ func TestListSubscriptionsFor_LiveContextSucceeds(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Len(t, resp.Subscriptions, 1)
+}
+
+// The last-message fan-out must not spend batch budget on subs with no Room: the
+// fan-in discards any preview the reply carries for them, so their ids only crowd
+// the 100-id cap. A site left with none emits no chunk, which is what skips its RPC.
+func TestRequestableBySite_SkipsRoomlessSubs(t *testing.T) {
+	withRoom := func(id, site string) model.EnrichedSubscription {
+		return model.EnrichedSubscription{Subscription: model.Subscription{RoomID: id, SiteID: site, Room: &model.SubscriptionRoom{}}}
+	}
+	roomless := func(id, site string) model.EnrichedSubscription {
+		return model.EnrichedSubscription{Subscription: model.Subscription{RoomID: id, SiteID: site}}
+	}
+
+	tests := []struct {
+		name string
+		subs []model.EnrichedSubscription
+		size int
+		want [][]string // roomIDs per emitted chunk
+	}{
+		{
+			name: "roomless subs are dropped from the batch",
+			subs: []model.EnrichedSubscription{withRoom("r1", "site-a"), roomless("r2", "site-a"), withRoom("r3", "site-a")},
+			size: 100,
+			want: [][]string{{"r1", "r3"}},
+		},
+		{
+			name: "a site with only roomless subs emits no chunk at all",
+			subs: []model.EnrichedSubscription{roomless("r1", "site-a"), roomless("r2", "site-a")},
+			size: 100,
+			want: nil,
+		},
+		// Chunk boundaries must fall on requestable rooms, not raw rows: counting the
+		// dropped id would split a batch that fits into two RPCs.
+		{
+			name: "chunking counts only requestable rooms",
+			subs: []model.EnrichedSubscription{withRoom("r1", "site-a"), roomless("r2", "site-a"), withRoom("r3", "site-a")},
+			size: 2,
+			want: [][]string{{"r1", "r3"}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			idxBySite := map[string][]int{}
+			for i := range tc.subs {
+				idxBySite[tc.subs[i].SiteID] = append(idxBySite[tc.subs[i].SiteID], i)
+			}
+			jobs := planChunks(tc.subs, []string{"site-a"}, requestableBySite(tc.subs, idxBySite), tc.size)
+			got := make([][]string, 0, len(jobs))
+			for _, j := range jobs {
+				got = append(got, j.roomIDs)
+			}
+			if tc.want == nil {
+				assert.Empty(t, got, "no requestable room must mean no chunk, hence no RPC")
+				return
+			}
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// End-to-end counterpart: a site whose subs all lack a Room issues no rooms.get at
+// all. buildLocalRoom always returns a room for a LOCAL sub, so an unresolved
+// CROSS-SITE room is how a sub ends up room-less.
+func TestListSubscriptions_LastMessage_AllRoomless_SkipsRPC(t *testing.T) {
+	svc, subs, rooms, _ := newSvcRawHistory(t)
+	storeSubs := []model.EnrichedSubscription{{
+		Subscription: model.Subscription{ID: "s2", RoomID: "r2", SiteID: "site-b", Name: "gone-room", RoomType: model.RoomTypeChannel},
+	}}
+	subs.EXPECT().AggregateSubscriptions(gomock.Any(), "alice", "current", false, gomock.Any(), gomock.Any()).
+		Return(mongoutil.OffsetPageHasMore[model.EnrichedSubscription]{Data: storeSubs}, nil)
+	rooms.EXPECT().GetRoomsInfo(gomock.Any(), "site-b", []string{"r2"}).
+		Return([]model.RoomInfo{{RoomID: "r2", Found: false}}, nil)
+	// No history.RoomsGet EXPECT — the mock ctrl fails if it is called.
+
+	resp, err := svc.ListSubscriptions(ctx("alice", "site-a"), models.SubscriptionListRequest{Type: "current"})
+	require.NoError(t, err)
+	require.Len(t, resp.Subscriptions, 1)
+	assert.Nil(t, resp.Subscriptions[0].Base().Room)
 }


### PR DESCRIPTION
## Summary

A subscription with no `Room` object is discarded by `enrichLastMessage`'s fan-in — there is nothing to attach a preview to — so sending its roomID to `rooms.get` only spends batch budget. This filters those rows out before chunking.

Two costs go away:

- **Crowding the batch.** Every unusable id counts against the 100-id cap, and can split a batch that would otherwise fit into a single RPC into two.
- **Wholly pointless RPCs.** A site whose subs are *all* room-less currently issues a full round trip whose every result the fan-in drops. It now issues none.

## Scope change

This PR previously also carried a `history-service` change — batch room-times treated as authoritative, and rooms absent from the batch skipped without a per-room read. **#222 landed both of those independently**, so that half has been dropped and this PR reduced to the `user-service` filter, which #222 did not cover.

For the record, where that work now lives on `main`:

| Was in this PR | Now on `main` (#222) |
|---|---|
| Batch times used verbatim | `walkBoundsFromRow` returns `rt.LastMsgAt, rt.CreatedAt` straight into `walkForPreview` — no sanitizer, no second read. Its comment cites #291 for the same redundant re-read. |
| Rooms absent from the batch skipped | `RoomsGet` does `case !ok: continue` over the rows map |

#222 also made `req.Hints` ignored (length-validated only) and chose to fail the RPC on a batch-read error rather than degrade — both supersede what this PR did there.

@mliu33's approval predates this reduction, so it needs a fresh look.

## The change

`requestableBySite` drops rows whose sub has no `Room`, and `enrichLastMessage` chunks that instead of the raw grouping. A site left with no requestable room emits no chunk, which is what skips its RPC.

**The filter is deliberately not inside `planChunks`**, which `enrichCrossSite` shares. Room-info enrichment is what *populates* `Room`, so filtering on it there would drop every cross-site sub before the RPC that resolves it and leave the whole site unenriched. That trap is called out in the helper's doc comment, and `TestEnrichWithRoomInfo_LocalAndCrossSite` already guards it.

## What this is worth, honestly

Modest, and smaller than it would have been before #222. An id that is absent from the room collection now costs one `$in` entry and a map miss on the callee side — not a per-room Mongo read and a `rooms.get room degraded` warn per room per request, which is what #222 removed. What remains is fewer ids per batch, fewer chunk splits, and no entirely pointless RPC.

## Tests

- `TestRequestableBySite_SkipsRoomlessSubs` — table-driven over the helper: room-less rows dropped; a site with only room-less subs emits no chunk at all; and chunk boundaries fall on requestable rooms, so a dropped id cannot split a batch that fits.
- `TestListSubscriptions_LastMessage_AllRoomless_SkipsRPC` — end-to-end: a site whose subs all lack a `Room` issues no `rooms.get`. Since `buildLocalRoom` always returns a room for a LOCAL sub (post-#353), the fixture uses a cross-site sub whose peer reports `Found: false`.
- `newSvcRawHistory` now also returns the `RoomClient` mock, so a test can stub the cross-site room-info RPC without picking up `newSvc`'s catch-all `RoomsGet` stub, which would defeat a must-not-call assertion.

## Verification

`make lint` (0 issues), `go test -race ./...` (full suite, clean), `make sast-gosec` (pass). govulncheck and semgrep could not run in the dev sandbox — no dependency or `errcode` changes here, and CI's `sast` job covers both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription message previews by excluding subscriptions without available rooms.
  * Prevented unnecessary history requests when sites have no accessible rooms.
  * Ensured roomless subscriptions do not affect request batching limits.
* **Tests**
  * Added coverage for roomless subscriptions and skipped history requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->