### PR TITLE
feat: room preview denormalization (Phase 2) implementation

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -991,7 +991,7 @@ an earlier survivor; a room with only ineligible messages omits `previewMessage`
 |---|---|---|
 | `messageId` | string | |
 | `sender` | [Participant](#participant) | `chineseName` is the sender's company name; `displayName` is the composed render-ready name (a bot sender's is its app name). |
-| `content` | string | The full message body; the client truncates for display. |
+| `content` | string | Message content snippet, capped at 500 runes (longer bodies are truncated). |
 | `createdAt` | string | RFC 3339 timestamp. |
 | `attachments` | [Attachment](#attachment)[] | Optional. Omitted when the message has none. |
 | `mentions` | [Participant](#participant)[] | Optional. Mentioned users as wire Participants. Omitted when none. |

--- a/docs/superpowers/specs/2026-08-05-room-preview-denormalization-design.md
+++ b/docs/superpowers/specs/2026-08-05-room-preview-denormalization-design.md
@@ -1,0 +1,328 @@
+# Room Preview Denormalization (Phase 2) — Design
+
+**Date:** 2026-08-05 (consolidated 2026-08-06)
+**Status:** Implemented — see [Implementation status](#implementation-status).
+**Predecessor:** `2026-08-03-room-preview-read-performance-design.md` (Phase 1 landed in
+`#173`/`#175`; this is the concrete Phase 2, pursued by explicit user decision rather
+than the metrics gate).
+
+This document describes the design as it now stands. It replaces four append-only
+amendments whose chronology had made the current shape hard to read; the reasoning
+they carried is preserved in the [Decision log](#decision-log).
+
+## Goal
+
+Make a room-list preview cheap to resolve by memoizing it on the room doc, so the
+common case stops walking Cassandra.
+
+The unit of cost being attacked is **the walk**, not the RPC. Resolving a preview
+today scans `messages_by_room` backwards from the tail across bucketed partitions,
+skipping ineligible messages (system type, deleted, hidden thread replies) up to a
+250-message budget — per room, for every room in a list. One NATS round-trip
+carrying a batch is cheap by comparison. A room list of 1000 rooms therefore costs
+~1000 walks and one RPC; this design removes the walks and keeps the RPC.
+
+## Starting state (before this design)
+
+- `user-service.enrichLastMessage` issues one `rooms.get` per site, including local.
+- `history-service.resolvePreview` walks Cassandra per room, fronted by an in-process
+  `previewCache`, and `warmBackPreview` persists the result to the room doc — but
+  **nothing reads that field back.** The walk runs on every cache miss regardless.
+- `broadcast-worker` is the sole writer of `rooms.lastMsgAt/lastMsgId/lastMentionAllAt`,
+  buffered through `coalescingStore` and flushed as one unordered `BulkWrite` per
+  `LAST_MSG_FLUSH_INTERVAL` (250ms).
+- `handleUpdated`/`handleDeleted` receive the post-mutation preview on the canonical
+  event (`MessageEvent.PreviewMessage`, computed by `previewAfterMutation`) and relay
+  it to clients. That relay is pre-existing and stays.
+
+## Design
+
+history-service is the **sole writer and sole reader** of the stored preview.
+broadcast-worker and user-service are untouched by this feature.
+
+### 1. Room document shape
+
+| Field | Type | Notes |
+|---|---|---|
+| `previewMeta` | subdocument | Plaintext: `messageId`, `sender`, `createdAt`, `mentions`, `visibleTo` |
+| `previewCiphertext` | binary | Seals `Content` + `Attachments` |
+| `previewNonce` | binary | AES-GCM nonce |
+| `previewKeyEpoch` | int | Preview DEK epoch that produced the ciphertext |
+| `previewForMsgId` | string | Freshness key — see §3 |
+| `previewAsOf` | int64 | Write-ordering watermark (epoch ms) |
+
+All are `json:"-"`: clients receive a preview through the `rooms.get` reply and
+message events, never through `Room`. `previewAsOf` stays plaintext because it
+carries no body content and the guarded update pipeline must compare it server-side.
+
+### 2. Encryption — seal the body, leave the metadata clear
+
+Encrypt exactly the two fields `atrest.SplitForEncryption` classifies as sensitive,
+through the existing `atrest.EncryptedFields`:
+
+- **Sealed:** `Content` → `Msg`; `Attachments` → `Attachments`, marshalled back to
+  the `[][]byte` form Cassandra stores natively, so this is a round-trip rather than
+  a re-encoding.
+- **Clear (`previewMeta`):** `messageId`, `sender`, `createdAt`, `mentions`,
+  `visibleTo` — precisely what Cassandra leaves unencrypted. message-worker's
+  `toMentionSet` already writes sender and mentions to plaintext columns, so this
+  introduces no classification the system does not already make.
+
+`pkg/preview.Seal`/`Open` implement the split. `pkg/atrest` is unchanged.
+
+**Why this matters:** the room doc previously held up to 500 runes of message body
+in cleartext, bypassing the encryption that nulls those columns in Cassandra. atrest
+distributes trust across three stores — Cassandra holds ciphertext, Mongo holds
+Vault-wrapped DEKs, Vault holds the KEK — so read access to any one alone yields
+nothing. Plaintext previews broke that: Mongo access alone would have yielded the
+latest 500 runes of every room, no key required.
+
+### 3. Freshness — identity, not timestamps
+
+A stored preview is current iff `previewForMsgId == lastMsgId`.
+
+`previewForMsgId` is **the newest message id the resolving walk OBSERVED in
+Cassandra**. It is *not* `previewMeta.messageId` — the two differ whenever the newest
+message is ineligible and skipped, which is the ordinary case for a room whose last
+activity was a system message.
+
+It must be stamped from what the walk saw, never from the `lastMsgId` read out of
+Mongo. broadcast-worker and message-worker are unordered consumers of
+MESSAGES-CANONICAL, so the room doc can name a message Cassandra does not hold yet;
+trusting it would claim freshness for a state never observed, and because the ID
+equality would then hold, the error would not self-heal until the next message.
+
+Timestamps were rejected for this: millisecond granularity cannot distinguish two
+messages in the same millisecond, and an ineligible newest message makes
+`previewAsOf < lastMsgAt` permanently true, leaving the room forever residual.
+
+### 4. Write path
+
+history-service writes the preview in two places, both sealing first:
+
+- **Warm-back**, after a walk resolves a preview on the read path. Best-effort:
+  failures log and continue.
+- **Post-mutation**, directly in the edit/delete handlers. `previewAfterMutation`
+  already computes the preview for the client event; the write is added alongside.
+  It first reads the stored preview and returns it untouched when the mutated
+  message is not the preview — the common case, since most edits and deletes target
+  an older message. Only a mutation that actually hits the preview walks: an edit
+  cannot change eligibility, and a delete needs the walk to find the predecessor.
+  This replaces routing the outcome through the canonical event for broadcast-worker
+  to persist, so `MessageEvent.PreviewGone` is removed.
+
+Both apply `pkg/preview.GuardedSetFields`, an aggregation-pipeline `$set` that lands
+only when `asOf >= $ifNull($previewAsOf, 0)` and advances `previewAsOf` with it.
+`GuardedClearFields` mirrors it with `$$REMOVE`, still advancing the watermark so a
+redelivered older write cannot resurrect a cleared preview. Both iterate one
+`previewDocFields` list so they cannot drift apart and strand a fragment — a nonce
+and epoch describing a ciphertext that no longer exists.
+
+Mutations need this explicit write because `lastMsgId` changes only on message
+creation: editing or deleting the current preview message is invisible to the
+freshness check in §3.
+
+### 5. Read path
+
+`resolvePreview` consults the room doc before walking. The preview fields join the
+projection of the `GetRoomTimesByIDs` batch read, so the doc read costs no extra
+round-trip beyond the room-times read `rooms.get` already needs.
+
+**Correction to the original design:** that batch read used to cover only the rooms
+whose `RoomTimeHint` was missing or unusable. It now covers **every** requested room.
+user-service hints every room that has a `lastMsgAt` — that is, every room a preview
+matters for — so the old scoping would have skipped the doc read exactly where it pays
+off. `RoomTimeHint` also carries no `lastMsgId`, so a hinted room has nothing to run the
+§3 identity check against. Hints still win for the walk bounds, so no room pays a
+per-room `GetRoomTimes` it did not pay before; the change is one batch read per
+`rooms.get` instead of one covering a subset. Extending the hint to carry `lastMsgId`
+was rejected: it would put this feature back into user-service, which the design keeps
+untouched.
+
+```
+fresh (previewForMsgId == lastMsgId AND previewKeyEpoch == configured) → Open, return
+otherwise                                                              → walk, warm-back, return
+```
+
+`previewCache` stays in front. Epoch mismatch and decrypt failure both degrade to a
+walk — previews are derived data, so a failure to decrypt is a cache miss, not data
+loss — but must log distinctly: an epoch mismatch is expected during rotation, a
+same-epoch decrypt failure is not.
+
+Because the reader is history-service, **cross-site rooms benefit equally**: a remote
+room's doc lives in the remote site's Mongo, which user-service can never read but
+that site's history-service can.
+
+### 6. Key management
+
+**Scope: one preview DEK per site**, id `preview:{siteID}:{epoch}`. Per-room DEKs are
+the wrong granularity here — preview reads are driven by membership enumeration
+(`subscription.list` touches up to `MAX_SUBSCRIPTION_LIMIT` = 1000 rooms, dormant ones
+included), which is exactly the one-shot cold-tail scan `dekCache`'s 2Q algorithm is
+built to resist rather than serve. Each dormant room would miss, costing a Mongo read
+plus a single-key Vault `Unwrap` (`KeyWrapper.Unwrap` has no batch form), and would
+never promote to 2Q's frequent segment, so the next list pays again. One site key is
+unwrapped once at process start and cached permanently.
+
+Accepted trade-off: previews lose per-room cryptographic isolation. Compromise of the
+preview DEK exposes every room's 500-rune preview in that site. Full message history
+keeps its per-room DEKs.
+
+**Provisioning: no human step.** Reuse the existing atrest DEK lifecycle with the
+sentinel id in place of a roomID. `GenerateDataKey` mints the DEK inside Vault;
+`DEKStore.Upsert` uses `$setOnInsert` so the first writer wins atomically; `createDEK`
+re-reads and adopts the winner's key on a lost race; `singleflight` collapses the
+per-process stampede. That protocol is already correct for a shared key as written.
+The colon in the sentinel cannot collide with a room id (base62 / hex / concatenations
+thereof) — pin with a test.
+
+**Storage: separate collection, shared KEK.** The wrapped preview DEK lives in a
+dedicated `preview_deks` collection, not `atrest.CollectionName`; wiring is
+`db.Collection("preview_deks")` at the call site with `NewMongoDEKStore` unchanged.
+Both are wrapped by the existing `chat-kek`. The split collection is operational
+rather than cryptographic: losing a preview DEK is a cache miss, losing a room DEK is
+permanent history loss, and co-locating them invites identical backup and retention
+treatment for records that deserve different handling.
+
+**Rotation: lazy, no migration.** `PREVIEW_KEY_EPOCH` (int, `envDefault:"1"`) is set
+identically across history-service instances and selects the sentinel id. Rotation is
+an ops action — bump the value, redeploy — and process restart is what invalidates the
+cached DEK, which deliberately avoids inventing an invalidation protocol. Readers on a
+different epoch treat the preview as absent and re-resolve, so no reader ever needs a
+retired DEK. During a rolling deploy both epochs are live and previews churn
+self-correctingly, bounded by the rollout window; rotate at low traffic.
+
+**Nonce budget.** `atrest.Encrypt` uses random 96-bit GCM nonces, so NIST SP 800-38D's
+2³²-invocations-per-key guidance applies. A per-room DEK never approaches it because
+usage is partitioned; one site-wide key reaches it sooner. Collision probability is
+`~q²/2⁹⁷` and degrades quadratically (≈1.2e-10 at 2³², ≈7.6e-6 at 2⁴⁰) — a margin to
+preserve, not a cliff. Rotation handles it, which is why the key is not bucketed.
+
+A GCM nonce collision is silent: both messages decrypt and authenticate normally. It
+leaks `P₁ ⊕ P₂` — recoverable, since the payload is structured and an attacker can
+plant a known preview by posting in any room they belong to — and permits recovery of
+the GHASH subkey `H = E_K(0¹²⁸)`, extending forgery to every nonce under that key.
+**The preview DEK must therefore never be reused for message bodies.**
+
+## Known hazards
+
+- **Best-effort writes can be lost.** Warm-back and post-mutation writes are
+  warn-and-continue with the event acked regardless, so a Mongo failure leaves a stale
+  preview until the next message changes `lastMsgId`.
+- **`visibleTo` is unresolved.** One preview is stored per room but consumed per
+  member. When the `visibleTo` write path lands, a partially-visible last message will
+  be served to every member, and no freshness check can detect it — the value is not
+  stale, merely not per-user. Decide before that path ships.
+- **Cold-start batch cap.** `maxRoomsGetBatch` is 100 while `MAX_SUBSCRIPTION_LIMIT`
+  is 1000, so a large list can exceed it. Pre-existing on `main` and tracked
+  separately, but a cold cache makes it easier to hit.
+
+## Out of scope
+
+- Chunking `rooms.get` at the 100-room batch limit (pre-existing; its own PR).
+- Populating `PreviewMessage.VisibleTo`'s write path.
+- `forwardSource` on the preview (TODO #106).
+
+## Decision log
+
+Alternatives considered and rejected, with the reason each failed.
+
+**Where the preview is read.** Four shapes were compared: status quo; eager write by
+broadcast-worker with user-service reading the doc; warm-back-only with user-service
+reading; and the chosen shape, history-service reading its own doc.
+
+Reading in user-service was rejected because it puts decryption in the front-line
+service, which would need Vault unwrap capability on the same `chat-kek` that protects
+room DEKs — making a Mongo collection grant the only barrier against full history
+disclosure from a user-service compromise. It also cannot help cross-site rooms, whose
+docs are remote. Eager write additionally requires new atrest wiring in
+broadcast-worker, on its highest-throughput path.
+
+The cost of the chosen shape is that `rooms.get` still fires on every list, so the
+original "zero RPCs for a local list" goal is not met — the RPC becomes cheap rather
+than absent. Given the walk dominates, that was judged the right trade. Eager write
+remains the answer if a NATS round-trip ever cannot fit the latency budget.
+
+**Encrypting the preview as one opaque blob** was specified first and proved
+unbuildable: `atrest.Cipher.Encrypt` accepts only the fixed, message-shaped
+`EncryptedFields`, so a single blob would mean adding a generic seal to a shared
+security package for one caller. The hybrid in §2 uses atrest as designed.
+
+**A separate `room_previews` collection** adds a second read on the read path and a
+second write target, with no isolation benefit since the room doc is already written
+per flush.
+
+**Cache-only** (longer Phase 1b TTL, or Valkey) still costs an RPC per list, is cold
+after restarts, and is per-instance.
+
+**Eager write in message-worker** — deferred, not rejected. The "eager write" option
+above was evaluated against broadcast-worker, which was the weaker candidate.
+message-worker is the better one: it already wires atrest (so the preview DEK is no
+new trust boundary there, unlike user-service), already resolves sender and mentions,
+already writes to Mongo, and writes the Cassandra row itself — so its `previewForMsgId`
+is observed by construction and the §3 unordered-consumer hazard disappears on that path.
+
+It also does not need a walk on insert, which is the objection that sinks the
+broadcast-worker variant: if message-worker writes the preview only when the new
+message is *eligible* and skips otherwise, the stored preview is the newest eligible
+message by induction, and the watermark already handles out-of-order delivery.
+
+Deferred anyway, for four reasons:
+
+1. **It is additive, not alternative.** The walk, seal, guard and freshness key all
+   survive — for delete-of-the-preview (the replacement is an arbitrarily older
+   message), for cold rooms, and because best-effort writes get lost and need a
+   self-healing signal. Eager write is A plus a second writer plus the DEK in a
+   second service.
+2. **It needs a backfill.** Eager writing only populates rooms that receive a new
+   message; every room that exists today would show a blank list entry until
+   migrated — and that migration is the walk, once per room, all at once. Warm-back
+   gets the same coverage spread across real demand.
+3. **It does more writes, not fewer.** A warm-back write requires both a message and
+   a subsequent read, so its count is bounded above by the eager count. The extra
+   cost is one Cassandra point read (`lastMsgWalkFirstPage = 1`), traded for strictly
+   fewer writes to the contended `rooms` collection.
+4. **It lands on the ingest hot path.** message-worker runs `MAX_WORKERS` (default
+   100) concurrent handlers; a per-message seal plus an uncoalesced room-doc write is
+   exactly the cost broadcast-worker coalesces at 250ms to avoid.
+
+**Revisit when** measured `subscription.list` p99 is dominated by the inline Cassandra
+point reads on the rooms.get path. That is the one thing eager write genuinely buys —
+a read path with no Cassandra in it — and it is observable rather than speculative.
+
+**Per-subscription fan-out** — writing the preview onto every member's subscription —
+was never considered: O(members) writes per message. Everything here is per-room, so a
+10,000-member room costs the same single write as a two-person DM.
+
+## Implementation status
+
+**Implemented.** Steps 1–6 are done and the code now matches this document.
+
+1. ✅ `broadcast-worker/` and `user-service/` reverted, and byte-identical to `main`,
+   so neither carries any part of this feature.
+2. ✅ `pkg/model` reshaped: the §1 room fields, `PreviewMeta` added,
+   `MessageEvent.PreviewGone` dropped, `PreviewMessage` back to a pure wire type.
+3. ✅ `pkg/preview` rebuilt around `Sealed`, with `Key`, `Seal`/`Open`, and guards that
+   iterate one `previewDocFields` list. Tests were written first.
+4. ✅ Preview DEK wired: `PREVIEW_KEY_EPOCH` (validated `>= 1`), the `preview_deks`
+   collection off the existing Vault wrapper, cipher threaded into `NewRoomRepo`.
+   `NewRoomRepo(db, nil, key)` disables preview storage rather than falling back to
+   plaintext.
+5. ✅ history-service is the sole writer: warm-back on the read path, direct
+   store/clear in the edit/delete handlers.
+6. ✅ `resolvePreview` serves a current stored preview and skips the walk. See the
+   correction in §5 about which rooms the batch read covers.
+
+Verification status: `make lint` clean, `make test` green repo-wide, `make sast-gosec`
+clean, `make generate` re-run. `pkg/preview` is at 98% statement coverage. Not yet run
+in this environment: `make test-integration` (needs Docker), `govulncheck` (its
+vulnerability database is blocked by the sandbox's egress policy), and `semgrep` (the
+container's Python `cryptography` bindings are broken). All three run in CI.
+
+### Still open
+
+`visibleTo` (see Known hazards) is unresolved and this work does not resolve it. The
+sealed preview stores the single `visibleTo` the walk found, exactly as the read path
+already returned it, so the behaviour is unchanged from `main` — but the field is now
+memoized, which means a partially-visible last message would be served to every member
+until `lastMsgId` moves. **Decide before the `visibleTo` write path ships.**

--- a/history-service/cmd/main.go
+++ b/history-service/cmd/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hmchangw/chat/pkg/natsrouter"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
+	"github.com/hmchangw/chat/pkg/preview"
 	"github.com/hmchangw/chat/pkg/shutdown"
 	"github.com/hmchangw/chat/pkg/userstore"
 )
@@ -128,8 +129,9 @@ func main() {
 	}
 
 	var (
-		cipher       atrest.Cipher
-		vaultWrapper atrest.KeyWrapperCloser
+		cipher        atrest.Cipher
+		previewCipher atrest.Cipher
+		vaultWrapper  atrest.KeyWrapperCloser
 	)
 	if cfg.Atrest.Enabled {
 		w, err := atrest.NewVaultKeyWrapper(ctx, cfg.Vault)
@@ -143,12 +145,26 @@ func main() {
 		dekColl := mongoClient.Database(cfg.Mongo.DB).Collection(atrest.CollectionName,
 			options.Collection().SetReadPreference(readpref.Primary()))
 		cipher = atrest.NewCipher(w, atrest.NewMongoDEKStore(dekColl), cfg.Atrest)
+
+		// A SEPARATE cipher over its own DEK collection, sharing the KEK. The
+		// preview key must never seal message bodies: it sees far more GCM
+		// invocations than a per-room DEK, and a nonce collision under it would
+		// expose the GHASH subkey for everything it protects.
+		// Pinned to primary for the same reason as the message DEKs above, and
+		// more acutely: history-service mints the preview DEK on first use and
+		// reads it back immediately, so a lagging secondary would miss the key
+		// it just wrote.
+		previewDEKColl := mongoClient.Database(cfg.Mongo.DB).Collection(mongorepo.PreviewDEKCollection,
+			options.Collection().SetReadPreference(readpref.Primary()))
+		previewCipher = atrest.NewCipher(w, atrest.NewMongoDEKStore(previewDEKColl), cfg.Atrest)
 	}
+
+	previewKey := preview.Key{SiteID: cfg.SiteID, Epoch: cfg.PreviewKeyEpoch}
 
 	cassRepo := cassrepo.NewRepository(cassSession, bucketSizer, cfg.MessageReadMaxBuckets, cipher)
 	db := mongoClient.Database(cfg.Mongo.DB)
 	subRepo := mongorepo.NewSubscriptionRepo(db)
-	roomRepo := mongorepo.NewRoomRepo(db)
+	roomRepo := mongorepo.NewRoomRepo(db, previewCipher, previewKey)
 	threadRoomRepo := mongorepo.NewThreadRoomRepo(db)
 	threadSubRepo := mongorepo.NewThreadSubscriptionRepo(db)
 	userStore := userstore.NewMongoStore(db.Collection("users"))

--- a/history-service/internal/config/config.go
+++ b/history-service/internal/config/config.go
@@ -93,6 +93,12 @@ type Config struct {
 	PreviewCacheSize int           `env:"HISTORY_PREVIEW_CACHE_SIZE" envDefault:"50000"`
 	PreviewCacheTTL  time.Duration `env:"HISTORY_PREVIEW_CACHE_TTL"  envDefault:"10s"`
 
+	// PreviewKeyEpoch selects the site preview DEK (preview:{siteID}:{epoch}).
+	// Rotation is an ops action — bump and redeploy; the restart is what drops the
+	// cached DEK. Set it identically across instances: during a rolling deploy both
+	// epochs are live and previews churn self-correctingly.
+	PreviewKeyEpoch int `env:"PREVIEW_KEY_EPOCH" envDefault:"1"`
+
 	Atrest atrest.Config      // env vars are already prefixed ATREST_*
 	Vault  atrest.VaultConfig // env vars are already prefixed (VAULT_*, ATREST_VAULT_*)
 
@@ -134,6 +140,11 @@ func validate(cfg *Config) error {
 	}
 	if cfg.PreviewCacheTTL < 0 {
 		return fmt.Errorf("HISTORY_PREVIEW_CACHE_TTL must be >= 0, got %s", cfg.PreviewCacheTTL)
+	}
+	// Part of a DEK id, so a non-positive value mints a sentinel rotation could
+	// never move forward from.
+	if cfg.PreviewKeyEpoch < 1 {
+		return fmt.Errorf("PREVIEW_KEY_EPOCH must be >= 1, got %d", cfg.PreviewKeyEpoch)
 	}
 	if _, err := mongoutil.ParseReadPreference(cfg.Mongo.ReadPreference); err != nil {
 		return fmt.Errorf("MONGO_READ_PREFERENCE: %w", err)

--- a/history-service/internal/config/config_test.go
+++ b/history-service/internal/config/config_test.go
@@ -20,6 +20,7 @@ func baseValid() Config {
 		RoomCacheTTL:     10 * time.Second,
 		PreviewCacheSize: 50000,
 		PreviewCacheTTL:  10 * time.Second,
+		PreviewKeyEpoch:  1,
 		MaxConcurrency:   256,
 		RequestTimeout:   10 * time.Second,
 		Mongo: MongoConfig{
@@ -148,6 +149,22 @@ func TestValidate_RejectsNegativePreviewCacheTTL(t *testing.T) {
 	err := validate(&cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "HISTORY_PREVIEW_CACHE_TTL")
+}
+
+// The epoch is part of a DEK id (preview:{siteID}:{epoch}), so a non-positive
+// value would mint a sentinel that rotation could never move forward from.
+func TestValidate_RejectsNonPositivePreviewKeyEpoch(t *testing.T) {
+	for _, epoch := range []int{0, -1} {
+		cfg := baseValid()
+		cfg.PreviewKeyEpoch = epoch
+		require.Error(t, validate(&cfg))
+	}
+}
+
+func TestValidate_AcceptsPreviewKeyEpochAboveOne(t *testing.T) {
+	cfg := baseValid()
+	cfg.PreviewKeyEpoch = 7
+	require.NoError(t, validate(&cfg))
 }
 
 func TestValidate_RejectsInvalidReadPreference(t *testing.T) {

--- a/history-service/internal/mongorepo/room.go
+++ b/history-service/internal/mongorepo/room.go
@@ -3,25 +3,41 @@ package mongorepo
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 
+	"github.com/hmchangw/chat/pkg/atrest"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/pkg/preview"
 )
 
 const roomsCollection = "rooms"
 
-// RoomRepo reads room metadata from MongoDB.
+// PreviewDEKCollection holds the wrapped per-site preview DEKs. Separate from
+// atrest.CollectionName though both share the KEK — the split is operational:
+// losing a preview DEK is a cache miss, losing a room DEK is permanent history
+// loss, and co-locating them invites identical backup treatment.
+const PreviewDEKCollection = "preview_deks"
+
+// RoomRepo reads room metadata and owns the stored preview — the only place the
+// preview cipher is applied, so callers above it never hold a key.
 type RoomRepo struct {
-	rooms *mongoutil.Collection[model.Room]
+	rooms  *mongoutil.Collection[model.Room]
+	cipher atrest.Cipher // nil when ATREST_ENABLED=false — previews are then not stored
+	key    preview.Key
 }
 
-func NewRoomRepo(db *mongo.Database) *RoomRepo {
+// NewRoomRepo builds the repo. A nil cipher (ATREST_ENABLED=false) disables
+// preview storage rather than falling back to plaintext.
+func NewRoomRepo(db *mongo.Database, cipher atrest.Cipher, key preview.Key) *RoomRepo {
 	return &RoomRepo{
-		rooms: mongoutil.NewCollection[model.Room](db.Collection(roomsCollection)),
+		rooms:  mongoutil.NewCollection[model.Room](db.Collection(roomsCollection)),
+		cipher: cipher,
+		key:    key,
 	}
 }
 
@@ -57,23 +73,41 @@ func (r *RoomRepo) GetRoomTimes(ctx context.Context, roomID string) (lastMsgAt, 
 	return lastMsgAt, room.CreatedAt, nil
 }
 
-// RoomTimes holds the two room timestamps GetRoomTimesByIDs projects.
+// RoomTimes is what GetRoomTimesByIDs projects per room: the bucket-walk
+// timestamps, plus the memoized preview when one is stored and current.
 type RoomTimes struct {
 	LastMsgAt time.Time
 	CreatedAt time.Time
+	// Preview is the stored preview, already opened. Non-nil only when present,
+	// current (previewForMsgId == lastMsgId), on the configured epoch, and
+	// decryptable; anything else is nil and the caller walks Cassandra.
+	Preview *model.PreviewMessage
 }
 
 // GetRoomTimesByIDs batches GetRoomTimes across ids into a single $in query,
 // returning a map keyed by room ID. Rooms absent from Mongo are simply absent
 // from the map (not an error). Empty ids returns an empty, non-nil map with no query.
+//
+// The stored preview rides the same read, so serving a memoized preview costs
+// no extra round-trip beyond the room-times read the caller already needs.
 func (r *RoomRepo) GetRoomTimesByIDs(ctx context.Context, ids []string) (map[string]RoomTimes, error) {
 	out := make(map[string]RoomTimes, len(ids))
 	if len(ids) == 0 {
 		return out, nil
 	}
+	// lastMsgId rides along because freshness is an identity check against it
+	// (see pkg/preview and the design's §3).
 	rooms, err := r.rooms.FindMany(ctx,
 		bson.M{"_id": bson.M{"$in": ids}},
-		mongoutil.WithProjection(bson.M{"_id": 1, "lastMsgAt": 1, "createdAt": 1}),
+		mongoutil.WithProjection(bson.M{
+			"_id": 1, "lastMsgAt": 1, "createdAt": 1,
+			"lastMsgId":         1,
+			"previewMeta":       1,
+			"previewCiphertext": 1,
+			"previewNonce":      1,
+			"previewKeyEpoch":   1,
+			"previewForMsgId":   1,
+		}),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get room times for %d rooms: %w", len(ids), err)
@@ -84,9 +118,86 @@ func (r *RoomRepo) GetRoomTimesByIDs(ctx context.Context, ids []string) (map[str
 		if room.LastMsgAt != nil {
 			lastMsgAt = *room.LastMsgAt
 		}
-		out[room.ID] = RoomTimes{LastMsgAt: lastMsgAt, CreatedAt: room.CreatedAt}
+		out[room.ID] = RoomTimes{
+			LastMsgAt: lastMsgAt,
+			CreatedAt: room.CreatedAt,
+			Preview:   r.openStoredPreview(ctx, room),
+		}
 	}
 	return out, nil
+}
+
+// openStoredPreview returns the room's memoized preview, or nil to make the
+// caller walk. Every rejection is a cache miss, never an error — a preview is
+// derived data, so failing to open one costs a walk and nothing else.
+func (r *RoomRepo) openStoredPreview(ctx context.Context, room *model.Room) *model.PreviewMessage {
+	if r.cipher == nil || room.PreviewMeta == nil || len(room.PreviewCiphertext) == 0 {
+		return nil
+	}
+	// Identity, not timestamps: current iff the newest message the walk observed
+	// is still the room's last message.
+	if room.PreviewForMsgID == "" || room.PreviewForMsgID != room.LastMsgID {
+		return nil
+	}
+	if room.PreviewKeyEpoch != r.key.Epoch {
+		// Expected during rotation (both epochs live across a rolling deploy), so
+		// Info — distinct from the same-epoch failure below.
+		slog.InfoContext(ctx, "stored preview on a retired key epoch, re-resolving",
+			"room_id", room.ID, "stored_epoch", room.PreviewKeyEpoch, "configured_epoch", r.key.Epoch)
+		return nil
+	}
+
+	pvw, err := preview.Open(ctx, r.cipher, r.key.SiteID, preview.Sealed{
+		Meta:       *room.PreviewMeta,
+		Ciphertext: room.PreviewCiphertext,
+		Nonce:      room.PreviewNonce,
+		KeyEpoch:   room.PreviewKeyEpoch,
+		ForMsgID:   room.PreviewForMsgID,
+	})
+	if err != nil {
+		// NOT expected: tampering, a truncated write, or a rotated-in-place DEK.
+		slog.WarnContext(ctx, "stored preview failed to decrypt on the configured epoch, re-resolving",
+			"room_id", room.ID, "epoch", room.PreviewKeyEpoch, "error", err)
+		return nil
+	}
+	return &pvw
+}
+
+// SetPreviewMessage seals pvw and stores it, watermark-guarded by asOf (see
+// pkg/preview.GuardedSetFields). A no-op when the cipher is disabled — the room
+// doc must never hold a plaintext body.
+//
+// forMsgID MUST be the newest message id the walk observed, never the lastMsgId
+// read out of Mongo; see previewWalk.NewestObservedID for why.
+//
+//nolint:gocritic // hugeParam: pvw's by-value shape is the RoomRepository.SetPreviewMessage contract shared with the mock and the readcache passthrough; the copy cost is negligible on this best-effort write path.
+func (r *RoomRepo) SetPreviewMessage(ctx context.Context, roomID string, pvw model.PreviewMessage, forMsgID string, asOf int64) error {
+	if r.cipher == nil {
+		return nil
+	}
+	sealed, err := preview.Seal(ctx, r.cipher, r.key, forMsgID, pvw)
+	if err != nil {
+		return fmt.Errorf("seal room preview %s: %w", roomID, err)
+	}
+	pipeline := mongo.Pipeline{{{Key: "$set", Value: preview.GuardedSetFields(sealed, asOf)}}}
+	if _, err := r.rooms.Raw().UpdateOne(ctx, bson.M{"_id": roomID}, pipeline); err != nil {
+		return fmt.Errorf("store room preview %s: %w", roomID, err)
+	}
+	return nil
+}
+
+// ClearPreview removes every stored preview field under the same guard,
+// advancing previewAsOf so an older redelivery cannot resurrect it. For a
+// mutation that leaves the room with no eligible message.
+func (r *RoomRepo) ClearPreview(ctx context.Context, roomID string, asOf int64) error {
+	if r.cipher == nil {
+		return nil
+	}
+	pipeline := mongo.Pipeline{{{Key: "$set", Value: preview.GuardedClearFields(asOf)}}}
+	if _, err := r.rooms.Raw().UpdateOne(ctx, bson.M{"_id": roomID}, pipeline); err != nil {
+		return fmt.Errorf("clear room preview %s: %w", roomID, err)
+	}
+	return nil
 }
 
 // GetRoomUserCount returns the room's userCount via a projected findOne.

--- a/history-service/internal/mongorepo/room_test.go
+++ b/history-service/internal/mongorepo/room_test.go
@@ -4,6 +4,7 @@ package mongorepo
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -13,11 +14,13 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo"
 
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/model/cassandra"
+	"github.com/hmchangw/chat/pkg/preview"
 )
 
 func TestRoomRepo_GetRoomTimes(t *testing.T) {
 	db := setupMongo(t)
-	repo := NewRoomRepo(db)
+	repo := newRoomRepoAtEpoch(db, 1)
 
 	createdAt := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	lastMsgAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
@@ -39,7 +42,7 @@ func TestRoomRepo_GetRoomTimes(t *testing.T) {
 
 func TestRoomRepo_GetRoomTimes_NoLastMsg(t *testing.T) {
 	db := setupMongo(t)
-	repo := NewRoomRepo(db)
+	repo := newRoomRepoAtEpoch(db, 1)
 
 	createdAt := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	_, err := db.Collection("rooms").InsertOne(context.Background(), bson.M{
@@ -58,7 +61,7 @@ func TestRoomRepo_GetRoomTimes_NoLastMsg(t *testing.T) {
 
 func TestRoomRepo_GetRoomTimes_NotFound(t *testing.T) {
 	db := setupMongo(t)
-	repo := NewRoomRepo(db)
+	repo := newRoomRepoAtEpoch(db, 1)
 
 	_, _, err := repo.GetRoomTimes(context.Background(), "no-such-room")
 	require.ErrorIs(t, err, mongo.ErrNoDocuments)
@@ -66,7 +69,7 @@ func TestRoomRepo_GetRoomTimes_NotFound(t *testing.T) {
 
 func TestRoomRepo_GetRoomTimesByIDs(t *testing.T) {
 	db := setupMongo(t)
-	repo := NewRoomRepo(db)
+	repo := newRoomRepoAtEpoch(db, 1)
 
 	createdAt1 := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	lastMsgAt1 := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
@@ -109,7 +112,7 @@ func TestRoomRepo_GetRoomTimesByIDs(t *testing.T) {
 
 func TestRoomRepo_GetRoomTimesByIDs_NoLastMsg(t *testing.T) {
 	db := setupMongo(t)
-	repo := NewRoomRepo(db)
+	repo := newRoomRepoAtEpoch(db, 1)
 
 	createdAt := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	_, err := db.Collection("rooms").InsertOne(context.Background(), bson.M{
@@ -129,7 +132,7 @@ func TestRoomRepo_GetRoomTimesByIDs_NoLastMsg(t *testing.T) {
 
 func TestRoomRepo_GetRoomTimesByIDs_Empty(t *testing.T) {
 	db := setupMongo(t)
-	repo := NewRoomRepo(db)
+	repo := newRoomRepoAtEpoch(db, 1)
 
 	got, err := repo.GetRoomTimesByIDs(context.Background(), []string{})
 	require.NoError(t, err)
@@ -139,7 +142,7 @@ func TestRoomRepo_GetRoomTimesByIDs_Empty(t *testing.T) {
 
 func TestRoomRepo_GetMinUserLastSeenAt_Set(t *testing.T) {
 	db := setupMongo(t)
-	repo := NewRoomRepo(db)
+	repo := newRoomRepoAtEpoch(db, 1)
 	ctx := context.Background()
 
 	floor := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
@@ -162,7 +165,7 @@ func TestRoomRepo_GetMinUserLastSeenAt_Set(t *testing.T) {
 
 func TestRoomRepo_GetMinUserLastSeenAt_Unset(t *testing.T) {
 	db := setupMongo(t)
-	repo := NewRoomRepo(db)
+	repo := newRoomRepoAtEpoch(db, 1)
 	ctx := context.Background()
 
 	_, err := db.Collection("rooms").InsertOne(ctx, model.Room{
@@ -182,7 +185,7 @@ func TestRoomRepo_GetMinUserLastSeenAt_Unset(t *testing.T) {
 
 func TestRoomRepo_GetMinUserLastSeenAt_MissingDocument(t *testing.T) {
 	db := setupMongo(t)
-	repo := NewRoomRepo(db)
+	repo := newRoomRepoAtEpoch(db, 1)
 	ctx := context.Background()
 
 	got, err := repo.GetMinUserLastSeenAt(ctx, "no-such-room")
@@ -196,7 +199,7 @@ func TestRoomRepo_GetRoomUserCount(t *testing.T) {
 		bson.M{"_id": "room-uc-1", "userCount": 42})
 	require.NoError(t, err)
 
-	repo := NewRoomRepo(db)
+	repo := newRoomRepoAtEpoch(db, 1)
 	count, err := repo.GetRoomUserCount(context.Background(), "room-uc-1")
 
 	require.NoError(t, err)
@@ -205,9 +208,220 @@ func TestRoomRepo_GetRoomUserCount(t *testing.T) {
 
 func TestRoomRepo_GetRoomUserCount_RoomMissing(t *testing.T) {
 	db := setupMongo(t)
-	repo := NewRoomRepo(db)
+	repo := newRoomRepoAtEpoch(db, 1)
 
 	_, err := repo.GetRoomUserCount(context.Background(), "missing")
 
 	require.ErrorIs(t, err, mongo.ErrNoDocuments)
+}
+
+// The watermark guard is shared with the clear path (pkg/preview.guardedFields):
+// a first write lands on an empty doc, and a lower asOf is rejected outright.
+func TestRoomRepo_SetPreviewMessage_WatermarkGuard(t *testing.T) {
+	db := setupMongo(t)
+	repo := newRoomRepoAtEpoch(db, 1)
+	ctx := context.Background()
+
+	_, err := db.Collection("rooms").InsertOne(ctx, bson.M{"_id": "warmback-r1", "name": "room"})
+	require.NoError(t, err)
+
+	p1 := model.PreviewMessage{MessageID: "m1", Content: "one", CreatedAt: time.UnixMilli(1000).UTC()}
+	p2 := model.PreviewMessage{MessageID: "m2", Content: "two", CreatedAt: time.UnixMilli(2000).UTC()}
+
+	// First write lands on an empty doc (no previewAsOf => guard treats it as 0).
+	require.NoError(t, repo.SetPreviewMessage(ctx, "warmback-r1", p2, "m2", 200))
+	got := readRoomDoc(t, db, "warmback-r1")
+	require.NotNil(t, got.PreviewMeta)
+	assert.Equal(t, "m2", got.PreviewMeta.MessageID)
+	assert.Equal(t, int64(200), got.PreviewAsOf)
+
+	// A lower asOf is rejected — stored preview and watermark both unchanged.
+	require.NoError(t, repo.SetPreviewMessage(ctx, "warmback-r1", p1, "m1", 100))
+	got = readRoomDoc(t, db, "warmback-r1")
+	require.NotNil(t, got.PreviewMeta)
+	assert.Equal(t, "m2", got.PreviewMeta.MessageID)
+	assert.Equal(t, int64(200), got.PreviewAsOf)
+}
+
+// The room doc must never hold a message body in the clear — that is the whole
+// reason the preview is sealed rather than stored as a plaintext subdocument.
+func TestRoomRepo_SetPreviewMessage_StoresNoPlaintextBody(t *testing.T) {
+	db := setupMongo(t)
+	repo := newRoomRepoAtEpoch(db, 1)
+	ctx := context.Background()
+
+	_, err := db.Collection("rooms").InsertOne(ctx, bson.M{"_id": "sealed-r1", "name": "room"})
+	require.NoError(t, err)
+
+	pvw := model.PreviewMessage{
+		MessageID: "m1",
+		Sender:    model.Participant{Account: "alice"},
+		Content:   "the-secret-body",
+		CreatedAt: time.UnixMilli(1000).UTC(),
+		Attachments: []cassandra.Attachment{
+			{ID: "f1", Title: "secret-attachment.png", Type: "image"},
+		},
+	}
+	require.NoError(t, repo.SetPreviewMessage(ctx, "sealed-r1", pvw, "m1", 100))
+
+	var raw bson.M
+	require.NoError(t, db.Collection("rooms").FindOne(ctx, bson.M{"_id": "sealed-r1"}).Decode(&raw))
+	dump, err := json.Marshal(raw)
+	require.NoError(t, err)
+	assert.NotContains(t, string(dump), "the-secret-body")
+	assert.NotContains(t, string(dump), "secret-attachment.png")
+	// The plaintext half is still there — it is what the freshness check needs.
+	assert.Contains(t, string(dump), "previewMeta")
+}
+
+// A stored preview is served back only when it is current: previewForMsgId must
+// still equal the room's lastMsgId.
+func TestRoomRepo_GetRoomTimesByIDs_ServesFreshStoredPreview(t *testing.T) {
+	db := setupMongo(t)
+	repo := newRoomRepoAtEpoch(db, 1)
+	ctx := context.Background()
+
+	lastMsgAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	insertPreviewRoom(t, db, "fresh-r1", lastMsgAt, "m9")
+
+	pvw := model.PreviewMessage{
+		MessageID: "m1",
+		Sender:    model.Participant{Account: "alice"},
+		Content:   "hello",
+		CreatedAt: lastMsgAt,
+		Mentions:  []model.Participant{{Account: "bob"}},
+	}
+	// Freshness key is the newest OBSERVED id (m9), not the preview's own (m1).
+	require.NoError(t, repo.SetPreviewMessage(ctx, "fresh-r1", pvw, "m9", 100))
+
+	got, err := repo.GetRoomTimesByIDs(ctx, []string{"fresh-r1"})
+	require.NoError(t, err)
+	require.NotNil(t, got["fresh-r1"].Preview)
+	assert.Equal(t, "hello", got["fresh-r1"].Preview.Content)
+	assert.Equal(t, "m1", got["fresh-r1"].Preview.MessageID)
+	assert.Equal(t, []model.Participant{{Account: "bob"}}, got["fresh-r1"].Preview.Mentions)
+}
+
+// A new message advances lastMsgId past the key the preview was stored under, so
+// the memo is stale and the caller must walk instead.
+func TestRoomRepo_GetRoomTimesByIDs_StalePreviewNotServed(t *testing.T) {
+	db := setupMongo(t)
+	repo := newRoomRepoAtEpoch(db, 1)
+	ctx := context.Background()
+
+	lastMsgAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	insertPreviewRoom(t, db, "stale-r1", lastMsgAt, "m9")
+	pvw := model.PreviewMessage{MessageID: "m1", Content: "old", CreatedAt: lastMsgAt}
+	require.NoError(t, repo.SetPreviewMessage(ctx, "stale-r1", pvw, "m9", 100))
+
+	// A newer message lands: lastMsgId moves on, previewForMsgId does not.
+	_, err := db.Collection("rooms").UpdateOne(ctx,
+		bson.M{"_id": "stale-r1"}, bson.M{"$set": bson.M{"lastMsgId": "m10"}})
+	require.NoError(t, err)
+
+	got, err := repo.GetRoomTimesByIDs(ctx, []string{"stale-r1"})
+	require.NoError(t, err)
+	assert.Nil(t, got["stale-r1"].Preview, "a superseded preview must not be served")
+}
+
+// Rotation: a reader on a different epoch treats the stored preview as absent
+// rather than reaching for a retired DEK.
+func TestRoomRepo_GetRoomTimesByIDs_EpochMismatchNotServed(t *testing.T) {
+	db := setupMongo(t)
+	ctx := context.Background()
+
+	lastMsgAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	insertPreviewRoom(t, db, "epoch-r1", lastMsgAt, "m9")
+	pvw := model.PreviewMessage{MessageID: "m1", Content: "old", CreatedAt: lastMsgAt}
+	require.NoError(t, newRoomRepoAtEpoch(db, 1).SetPreviewMessage(ctx, "epoch-r1", pvw, "m9", 100))
+
+	// Same doc, read by a process configured one epoch ahead.
+	got, err := newRoomRepoAtEpoch(db, 2).GetRoomTimesByIDs(ctx, []string{"epoch-r1"})
+	require.NoError(t, err)
+	assert.Nil(t, got["epoch-r1"].Preview)
+
+	// The original epoch still reads it, so rotation is lazy, not destructive.
+	got, err = newRoomRepoAtEpoch(db, 1).GetRoomTimesByIDs(ctx, []string{"epoch-r1"})
+	require.NoError(t, err)
+	require.NotNil(t, got["epoch-r1"].Preview)
+}
+
+// A room that never had a preview simply reports none.
+func TestRoomRepo_GetRoomTimesByIDs_NoStoredPreview(t *testing.T) {
+	db := setupMongo(t)
+	ctx := context.Background()
+
+	insertPreviewRoom(t, db, "bare-r1", time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC), "m9")
+
+	got, err := newRoomRepoAtEpoch(db, 1).GetRoomTimesByIDs(ctx, []string{"bare-r1"})
+	require.NoError(t, err)
+	assert.Nil(t, got["bare-r1"].Preview)
+}
+
+// ClearPreview must remove EVERY preview field together — leaving a nonce or an
+// epoch behind would strand a fragment describing a ciphertext that is gone —
+// while still advancing the watermark so an older redelivery can't resurrect it.
+func TestRoomRepo_ClearPreview_RemovesEveryFieldAndHoldsWatermark(t *testing.T) {
+	db := setupMongo(t)
+	repo := newRoomRepoAtEpoch(db, 1)
+	ctx := context.Background()
+
+	lastMsgAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	insertPreviewRoom(t, db, "clear-r1", lastMsgAt, "m9")
+	pvw := model.PreviewMessage{MessageID: "m1", Content: "gone soon", CreatedAt: lastMsgAt}
+	require.NoError(t, repo.SetPreviewMessage(ctx, "clear-r1", pvw, "m9", 100))
+
+	require.NoError(t, repo.ClearPreview(ctx, "clear-r1", 200))
+
+	var raw bson.M
+	require.NoError(t, db.Collection("rooms").FindOne(ctx, bson.M{"_id": "clear-r1"}).Decode(&raw))
+	for _, key := range []string{
+		"previewMeta", "previewCiphertext", "previewNonce", "previewKeyEpoch", "previewForMsgId",
+	} {
+		assert.NotContains(t, raw, key, "%s must be removed by a clear", key)
+	}
+	assert.EqualValues(t, 200, raw["previewAsOf"], "the watermark must advance on clear")
+
+	// A redelivered older write cannot resurrect the cleared preview.
+	require.NoError(t, repo.SetPreviewMessage(ctx, "clear-r1", pvw, "m9", 150))
+	require.NoError(t, db.Collection("rooms").FindOne(ctx, bson.M{"_id": "clear-r1"}).Decode(&raw))
+	assert.NotContains(t, raw, "previewMeta")
+}
+
+// With the cipher disabled (ATREST_ENABLED=false) preview storage is off entirely
+// rather than degrading to a plaintext body on the room doc.
+func TestRoomRepo_NoCipher_StoresNothing(t *testing.T) {
+	db := setupMongo(t)
+	ctx := context.Background()
+	repo := NewRoomRepo(db, nil, preview.Key{SiteID: testPreviewSite, Epoch: 1})
+
+	insertPreviewRoom(t, db, "nocipher-r1", time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC), "m9")
+	pvw := model.PreviewMessage{MessageID: "m1", Content: "plaintext", CreatedAt: time.UnixMilli(1000).UTC()}
+	require.NoError(t, repo.SetPreviewMessage(ctx, "nocipher-r1", pvw, "m9", 100))
+	require.NoError(t, repo.ClearPreview(ctx, "nocipher-r1", 200))
+
+	var raw bson.M
+	require.NoError(t, db.Collection("rooms").FindOne(ctx, bson.M{"_id": "nocipher-r1"}).Decode(&raw))
+	assert.NotContains(t, raw, "previewMeta")
+	assert.NotContains(t, raw, "previewAsOf")
+}
+
+func insertPreviewRoom(t *testing.T, db *mongo.Database, roomID string, lastMsgAt time.Time, lastMsgID string) {
+	t.Helper()
+	_, err := db.Collection("rooms").InsertOne(context.Background(), model.Room{
+		ID:        roomID,
+		SiteID:    testPreviewSite,
+		Type:      model.RoomTypeChannel,
+		CreatedAt: lastMsgAt.AddDate(0, -1, 0),
+		LastMsgAt: &lastMsgAt,
+		LastMsgID: lastMsgID,
+	})
+	require.NoError(t, err)
+}
+
+func readRoomDoc(t *testing.T, db *mongo.Database, roomID string) *model.Room {
+	t.Helper()
+	var room model.Room
+	require.NoError(t, db.Collection("rooms").FindOne(context.Background(), bson.M{"_id": roomID}).Decode(&room))
+	return &room
 }

--- a/history-service/internal/mongorepo/setup_test.go
+++ b/history-service/internal/mongorepo/setup_test.go
@@ -3,13 +3,79 @@
 package mongorepo
 
 import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/json"
 	"testing"
 
 	"go.mongodb.org/mongo-driver/v2/mongo"
 
+	"github.com/hmchangw/chat/pkg/atrest"
+	"github.com/hmchangw/chat/pkg/preview"
 	"github.com/hmchangw/chat/pkg/testutil"
 )
 
 func setupMongo(t *testing.T) *mongo.Database {
 	return testutil.MongoDB(t, "history_service_test")
+}
+
+// testPreviewCipher is a real AES-GCM cipher keyed by sha256(keyID), standing in
+// for the Vault-backed atrest.Cipher. Real crypto (not a passthrough) so these
+// tests exercise the actual seal/open round-trip and a wrong-epoch read genuinely
+// fails authentication.
+type testPreviewCipher struct{}
+
+func (testPreviewCipher) aead(keyID string) (cipher.AEAD, error) {
+	sum := sha256.Sum256([]byte(keyID))
+	block, err := aes.NewCipher(sum[:])
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}
+
+func (c testPreviewCipher) Encrypt(_ context.Context, keyID string, fields atrest.EncryptedFields) ([]byte, atrest.EncMeta, error) { //nolint:gocritic // hugeParam: matches the atrest.Cipher interface
+	plaintext, err := json.Marshal(fields)
+	if err != nil {
+		return nil, atrest.EncMeta{}, err
+	}
+	gcm, err := c.aead(keyID)
+	if err != nil {
+		return nil, atrest.EncMeta{}, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, atrest.EncMeta{}, err
+	}
+	return gcm.Seal(nil, nonce, plaintext, nil), atrest.EncMeta{Nonce: nonce}, nil
+}
+
+func (c testPreviewCipher) Decrypt(_ context.Context, keyID string, payload []byte, meta atrest.EncMeta) (atrest.EncryptedFields, error) { //nolint:gocritic // hugeParam: matches the atrest.Cipher interface
+	gcm, err := c.aead(keyID)
+	if err != nil {
+		return atrest.EncryptedFields{}, err
+	}
+	plaintext, err := gcm.Open(nil, meta.Nonce, payload, nil)
+	if err != nil {
+		return atrest.EncryptedFields{}, atrest.ErrAuthFailed
+	}
+	var out atrest.EncryptedFields
+	if err := json.Unmarshal(plaintext, &out); err != nil {
+		return atrest.EncryptedFields{}, atrest.ErrPayloadMalformed
+	}
+	return out, nil
+}
+
+func (testPreviewCipher) EnsureDEK(context.Context, string) error { return nil }
+
+const testPreviewSite = "site-A"
+
+// newRoomRepoAtEpoch builds a RoomRepo whose preview cipher is live at the given
+// key epoch, so rotation behaviour can be exercised by reading a doc back through
+// a repo on a different epoch.
+func newRoomRepoAtEpoch(db *mongo.Database, epoch int) *RoomRepo {
+	return NewRoomRepo(db, testPreviewCipher{}, preview.Key{SiteID: testPreviewSite, Epoch: epoch})
 }

--- a/history-service/internal/readcache/readcache.go
+++ b/history-service/internal/readcache/readcache.go
@@ -154,6 +154,8 @@ type RoomSource interface {
 	GetRoomTimesByIDs(ctx context.Context, ids []string) (map[string]mongorepo.RoomTimes, error)
 	GetMinUserLastSeenAt(ctx context.Context, roomID string) (*time.Time, error)
 	GetRoomUserCount(ctx context.Context, roomID string) (int, error)
+	SetPreviewMessage(ctx context.Context, roomID string, pvw pkgmodel.PreviewMessage, forMsgID string, asOf int64) error
+	ClearPreview(ctx context.Context, roomID string, asOf int64) error
 }
 
 type roomTimes struct {
@@ -218,11 +220,26 @@ func (c *RoomCache) GetRoomUserCount(ctx context.Context, roomID string) (int, e
 }
 
 // GetRoomTimesByIDs bypasses the per-key cache and delegates to the source.
-// It is a batch read for rooms without a usable caller-supplied hint, called
-// at most once per RoomsGet request — not a hot single-room path — so there is
-// no per-room caching benefit to justify the bookkeeping.
+// It is called at most once per RoomsGet request — not a hot single-room path —
+// so there is no per-room caching benefit to justify the bookkeeping. Caching
+// it would also be wrong now that it carries the stored preview: the freshness
+// check is an identity comparison against a lastMsgId that must be read live.
 func (c *RoomCache) GetRoomTimesByIDs(ctx context.Context, ids []string) (map[string]mongorepo.RoomTimes, error) {
 	return c.inner.GetRoomTimesByIDs(ctx, ids)
+}
+
+// SetPreviewMessage bypasses the cache and delegates to the source — a write,
+// not a read this cache fronts.
+//
+//nolint:gocritic // hugeParam: pvw's by-value shape matches the RoomRepository.SetPreviewMessage contract this passes through unchanged.
+func (c *RoomCache) SetPreviewMessage(ctx context.Context, roomID string, pvw pkgmodel.PreviewMessage, forMsgID string, asOf int64) error {
+	return c.inner.SetPreviewMessage(ctx, roomID, pvw, forMsgID, asOf)
+}
+
+// ClearPreview bypasses the cache and delegates to the source — a write, not a
+// read this cache fronts.
+func (c *RoomCache) ClearPreview(ctx context.Context, roomID string, asOf int64) error {
+	return c.inner.ClearPreview(ctx, roomID, asOf)
 }
 
 // previewEntry is the cached resolved room preview. found=false is never stored

--- a/history-service/internal/readcache/readcache_test.go
+++ b/history-service/internal/readcache/readcache_test.go
@@ -160,6 +160,9 @@ type fakeRoomSource struct {
 	timesByIDsIDs   []string
 	timesByIDs      map[string]mongorepo.RoomTimes
 	timesByIDsErr   error
+
+	setPreviewCalls   atomic.Int32
+	clearPreviewCalls atomic.Int32
 }
 
 func (f *fakeRoomSource) GetRoomTimes(_ context.Context, _ string) (time.Time, time.Time, error) {
@@ -183,6 +186,17 @@ func (f *fakeRoomSource) GetRoomTimesByIDs(_ context.Context, ids []string) (map
 		return nil, f.timesByIDsErr
 	}
 	return f.timesByIDs, nil
+}
+
+//nolint:gocritic // hugeParam: matches the RoomSource.SetPreviewMessage by-value contract.
+func (f *fakeRoomSource) SetPreviewMessage(_ context.Context, _ string, _ pkgmodel.PreviewMessage, _ string, _ int64) error {
+	f.setPreviewCalls.Add(1)
+	return nil
+}
+
+func (f *fakeRoomSource) ClearPreview(_ context.Context, _ string, _ int64) error {
+	f.clearPreviewCalls.Add(1)
+	return nil
 }
 
 func TestRoomCache_CachesRoomTimes(t *testing.T) {
@@ -415,4 +429,20 @@ func TestSubscriptionCache_CallerCancelReturnsCtxErr(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("caller did not return on its own ctx cancel within 2s")
 	}
+}
+
+// Preview writes are writes, not reads this cache fronts: both must reach the
+// source unchanged rather than being absorbed or cached.
+func TestRoomCache_PreviewWrites_BypassCache(t *testing.T) {
+	src := &fakeRoomSource{}
+	c, err := NewRoomCache(src, 10, time.Minute)
+	require.NoError(t, err)
+
+	require.NoError(t, c.SetPreviewMessage(context.Background(), "r1", pkgmodel.PreviewMessage{}, "m1", 100))
+	require.NoError(t, c.SetPreviewMessage(context.Background(), "r1", pkgmodel.PreviewMessage{}, "m1", 200))
+	assert.EqualValues(t, 2, src.setPreviewCalls.Load())
+
+	require.NoError(t, c.ClearPreview(context.Background(), "r1", 300))
+	require.NoError(t, c.ClearPreview(context.Background(), "r1", 400))
+	assert.EqualValues(t, 2, src.clearPreviewCalls.Load())
 }

--- a/history-service/internal/service/displayname_test.go
+++ b/history-service/internal/service/displayname_test.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/hmchangw/chat/history-service/internal/service/mocks"
+	"github.com/hmchangw/chat/pkg/displayfmt"
+)
+
+// A HistoryService built without an app store (apps == nil) must still resolve
+// display names: the pre-refactor code only touched s.apps inside an IsBot
+// branch, so a nil store was harmless. Passing s.apps.AppNameByAccount as a
+// method value evaluates the receiver eagerly and segfaults before the bot
+// check ever runs — regardless of the account.
+func TestBotAwareDisplayName_NilAppStore(t *testing.T) {
+	tests := []struct {
+		name    string
+		account string
+	}{
+		{"human account", "alice"},
+		{"bot account", "helper.bot"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &HistoryService{} // apps deliberately nil
+
+			var got string
+			require.NotPanics(t, func() {
+				got = s.botAwareDisplayName(context.Background(), "Alice", "愛麗絲", tt.account)
+			})
+			// No app store ⇒ the composed name, for bots and humans alike.
+			assert.Equal(t, displayfmt.CombineWithFallback("Alice", "愛麗絲", tt.account), got)
+		})
+	}
+}
+
+// With an app store wired, a bot account still prefers its app's display name.
+func TestBotAwareDisplayName_BotUsesAppStore(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	apps := mocks.NewMockAppStore(ctrl)
+	apps.EXPECT().AppNameByAccount(gomock.Any(), "helper.bot").Return("Helper App", nil).Times(1)
+
+	s := &HistoryService{apps: apps}
+	assert.Equal(t, "Helper App", s.botAwareDisplayName(context.Background(), "Alice", "愛麗絲", "helper.bot"))
+}

--- a/history-service/internal/service/integration_test.go
+++ b/history-service/internal/service/integration_test.go
@@ -160,6 +160,14 @@ func (stubRoomRepo) GetRoomUserCount(_ context.Context, _ string) (int, error) {
 	return 0, nil
 }
 
+func (stubRoomRepo) SetPreviewMessage(_ context.Context, _ string, _ models.PreviewMessage, _ string, _ int64) error {
+	return nil
+}
+
+func (stubRoomRepo) ClearPreview(_ context.Context, _ string, _ int64) error {
+	return nil
+}
+
 func TestEditMessage_Integration(t *testing.T) {
 	session := setupCassandra(t)
 	repo := cassrepo.NewRepository(session, msgbucket.New(24*time.Hour), 365, nil)

--- a/history-service/internal/service/messages.go
+++ b/history-service/internal/service/messages.go
@@ -638,20 +638,35 @@ func (s *HistoryService) DeleteMessage(c *natsrouter.Context, siteID string, req
 	}, nil
 }
 
-// previewAfterMutation resolves the room's current last-eligible preview (same walk as
-// subscription.list) to carry on an edit/delete fan-out. Hidden thread replies (TShow==false)
-// never appear in the room timeline, so they're skipped — clients tell those apart via the
-// event's threadParentMessageId and drive the room preview themselves. TShow==true replies do
-// appear in the room, so they still get a preview. nil for a hidden thread reply, when the room
-// has no eligible message, or on a read error.
+// previewAfterMutation resolves the room's current last-eligible preview (the same
+// walk as subscription.list), both to carry on the edit/delete fan-out and to refresh
+// the stored copy. Bypasses the preview cache so a mutation always sees fresh state.
+// Hidden thread replies (TShow==false) never appear in the room timeline and are
+// skipped; clients drive those themselves off threadParentMessageId.
+//
+// The write happens here rather than riding the canonical event because a mutation is
+// invisible to the freshness check: editing or deleting the preview message does not
+// change lastMsgId, so nothing else would ever invalidate the memoized copy.
 func (s *HistoryService) previewAfterMutation(c *natsrouter.Context, msg *models.Message, roomID string, at time.Time) *models.PreviewMessage {
 	if msg.ThreadParentID != "" && !msg.TShow {
 		return nil
 	}
-	if preview, ok := s.roomLastPreviewMessage(c, roomID, nil, at); ok {
-		return &preview
+	w := s.roomLastPreviewMessage(c, roomID, nil, at)
+	switch w.State {
+	case previewFound:
+		s.storePreview(c, roomID, "mutation", &w, at.UnixMilli())
+		return &w.Preview
+	case previewEmpty:
+		// Walk completed with no eligible survivor, so the stored preview is
+		// definitively wrong. A degraded walk never reaches here.
+		if err := s.rooms.ClearPreview(c, roomID, at.UnixMilli()); err != nil {
+			slog.WarnContext(c, "preview clear after mutation failed", "room_id", roomID,
+				"request_id", natsutil.RequestIDFromContext(c), "error", err)
+		}
+		return nil
+	default: // previewDegraded — a survivor may still exist; clearing would lose it
+		return nil
 	}
-	return nil
 }
 
 // publishCanonicalBestEffort publishes a canonical event; failures are logged and swallowed (Cassandra is source of truth).

--- a/history-service/internal/service/messages.go
+++ b/history-service/internal/service/messages.go
@@ -638,6 +638,19 @@ func (s *HistoryService) DeleteMessage(c *natsrouter.Context, siteID string, req
 	}, nil
 }
 
+// storedPreview reads the room's memoized preview, or nil when none is current.
+// Best-effort: a read failure just sends the caller down the walk it would have
+// taken anyway.
+func (s *HistoryService) storedPreview(ctx context.Context, roomID string) *models.PreviewMessage {
+	rows, err := s.rooms.GetRoomTimesByIDs(ctx, []string{roomID})
+	if err != nil {
+		slog.WarnContext(ctx, "stored preview read failed, falling back to walk", "room_id", roomID,
+			"request_id", natsutil.RequestIDFromContext(ctx), "error", err)
+		return nil
+	}
+	return rows[roomID].Preview
+}
+
 // previewAfterMutation resolves the room's current last-eligible preview (the same
 // walk as subscription.list), both to carry on the edit/delete fan-out and to refresh
 // the stored copy. Bypasses the preview cache so a mutation always sees fresh state.
@@ -650,6 +663,14 @@ func (s *HistoryService) DeleteMessage(c *natsrouter.Context, siteID string, req
 func (s *HistoryService) previewAfterMutation(c *natsrouter.Context, msg *models.Message, roomID string, at time.Time) *models.PreviewMessage {
 	if msg.ThreadParentID != "" && !msg.TShow {
 		return nil
+	}
+	// A mutation that doesn't touch the stored preview cannot change it, so the
+	// walk is skipped and the preview re-reported unchanged. This is the common
+	// case: most edits and deletes target a message that is not the room's newest
+	// eligible one. One projected room-doc read replaces a Cassandra walk plus a
+	// re-seal and re-write.
+	if stored := s.storedPreview(c, roomID); stored != nil && stored.MessageID != msg.MessageID {
+		return stored
 	}
 	w := s.roomLastPreviewMessage(c, roomID, nil, at)
 	switch w.State {

--- a/history-service/internal/service/messages_test.go
+++ b/history-service/internal/service/messages_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hmchangw/chat/history-service/internal/cassrepo"
 	"github.com/hmchangw/chat/history-service/internal/config"
 	"github.com/hmchangw/chat/history-service/internal/models"
+	"github.com/hmchangw/chat/history-service/internal/mongorepo"
 	"github.com/hmchangw/chat/history-service/internal/service"
 	"github.com/hmchangw/chat/history-service/internal/service/mocks"
 	"github.com/hmchangw/chat/pkg/errcode"
@@ -54,6 +55,10 @@ func newService(t *testing.T) (*service.HistoryService, *mocks.MockMessageReposi
 	threadRooms.EXPECT().GetMinThreadUserLastSeenAt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	// history-service is the sole preview writer, so every edit/delete now stores or
 	// clears as a side effect. Tests that assert on those use newServiceWithRoomMock.
+	// The empty room-doc read means "no stored preview", so mutations take the walk
+	// these fixtures already expect.
+	rooms.EXPECT().GetRoomTimesByIDs(gomock.Any(), gomock.Any()).
+		Return(map[string]mongorepo.RoomTimes{}, nil).AnyTimes()
 	rooms.EXPECT().SetPreviewMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	rooms.EXPECT().ClearPreview(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	return svc, msgs, subs, pub, threadRooms
@@ -2725,6 +2730,8 @@ func TestHistoryService_DeleteMessage_LastMessage_ClearsStoredPreview(t *testing
 	svc, msgs, subs, rooms, pub, _, _, _ := newServiceWithRoomMock(t)
 	c := testContext()
 	rooms.EXPECT().GetMinUserLastSeenAt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	// No stored preview, so the mutation takes the walk these fixtures assert on.
+	stubStoredPreview(rooms, "r1", nil)
 
 	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
 	hydrated := &models.Message{
@@ -2764,6 +2771,8 @@ func TestHistoryService_DeleteMessage_AllIneligibleTerminalPage_ClearsStoredPrev
 	svc, msgs, subs, rooms, pub, _, _, _ := newServiceWithRoomMock(t)
 	c := testContext()
 	rooms.EXPECT().GetMinUserLastSeenAt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	// No stored preview, so the mutation takes the walk these fixtures assert on.
+	stubStoredPreview(rooms, "r1", nil)
 
 	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
 	createdAt := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
@@ -2803,6 +2812,8 @@ func TestHistoryService_DeleteMessage_DegradedWalk_LeavesStoredPreviewAlone(t *t
 	svc, msgs, subs, rooms, pub, _, _, _ := newServiceWithRoomMock(t)
 	c := testContext()
 	rooms.EXPECT().GetMinUserLastSeenAt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	// No stored preview, so the mutation takes the walk these fixtures assert on.
+	stubStoredPreview(rooms, "r1", nil)
 
 	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
 	hydrated := &models.Message{
@@ -2840,6 +2851,8 @@ func TestHistoryService_DeleteMessage_ScanBudgetExhausted_LeavesStoredPreviewAlo
 	svc, msgs, subs, rooms, pub, _, _, _ := newServiceWithRoomMock(t)
 	c := testContext()
 	rooms.EXPECT().GetMinUserLastSeenAt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	// No stored preview, so the mutation takes the walk these fixtures assert on.
+	stubStoredPreview(rooms, "r1", nil)
 
 	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
 	createdAt := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
@@ -2920,5 +2933,141 @@ func TestHistoryService_DeleteMessage_HiddenThreadReply_LeavesStoredPreviewAlone
 	rooms.EXPECT().SetPreviewMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 	_, err := svc.DeleteMessage(c, "site-test", models.DeleteMessageRequest{MessageID: "reply-1"})
+	require.NoError(t, err)
+}
+
+// stubStoredPreview arranges the single room-doc read previewAfterMutation issues.
+func stubStoredPreview(rooms *mocks.MockRoomRepository, roomID string, p *models.PreviewMessage) {
+	rooms.EXPECT().
+		GetRoomTimesByIDs(gomock.Any(), []string{roomID}).
+		Return(map[string]mongorepo.RoomTimes{roomID: {
+			LastMsgAt: defaultRoomLastMsgAt, CreatedAt: defaultRoomCreatedAt, Preview: p,
+		}}, nil).
+		AnyTimes()
+}
+
+// Editing a message that is NOT the room's stored preview cannot change the
+// preview, so the walk must be skipped entirely — no Cassandra read, no re-write.
+// This is the common case: most edits target an older message.
+func TestHistoryService_EditMessage_NonPreviewMessage_SkipsWalk(t *testing.T) {
+	svc, msgs, subs, rooms, pub, _, _, _ := newServiceWithRoomMock(t)
+	c := testContext()
+	rooms.EXPECT().GetMinUserLastSeenAt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	stored := models.PreviewMessage{MessageID: "newest", Content: "the newest one"}
+	stubStoredPreview(rooms, "r1", &stored)
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
+	hydrated := &models.Message{
+		MessageID: "old-msg", RoomID: "r1",
+		Sender:    models.Participant{Account: "u1", ID: "u1-id"},
+		CreatedAt: time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC), Msg: "before",
+	}
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "old-msg").Return(hydrated, nil)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "after", gomock.Any()).Return(nil)
+
+	// Strict: any walk or preview write fails the test.
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	rooms.EXPECT().ClearPreview(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	pub.EXPECT().
+		Publish(gomock.Any(), subject.MsgCanonicalUpdated("site-test"), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, data []byte, _ string) error {
+			var evt model.MessageEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			// The event still reports the room's current preview — unchanged.
+			require.NotNil(t, evt.PreviewMessage)
+			assert.Equal(t, "newest", evt.PreviewMessage.MessageID)
+			return nil
+		})
+
+	_, err := svc.EditMessage(c, "site-test", models.EditMessageRequest{MessageID: "old-msg", NewMsg: "after"})
+	require.NoError(t, err)
+}
+
+// Same for delete: removing a message that isn't the preview leaves the preview
+// correct, so no walk and no write.
+func TestHistoryService_DeleteMessage_NonPreviewMessage_SkipsWalk(t *testing.T) {
+	svc, msgs, subs, rooms, pub, _, _, _ := newServiceWithRoomMock(t)
+	c := testContext()
+	rooms.EXPECT().GetMinUserLastSeenAt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	stored := models.PreviewMessage{MessageID: "newest", Content: "the newest one"}
+	stubStoredPreview(rooms, "r1", &stored)
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
+	hydrated := &models.Message{
+		MessageID: "old-msg", RoomID: "r1",
+		Sender:    models.Participant{Account: "u1", ID: "u1-id"},
+		CreatedAt: time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC), Msg: "content",
+	}
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "old-msg").Return(hydrated, nil)
+	msgs.EXPECT().
+		SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
+			return deletedAt, true, nil, nil, nil
+		})
+
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	rooms.EXPECT().ClearPreview(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	pub.EXPECT().
+		Publish(gomock.Any(), subject.MsgCanonicalDeleted("site-test"), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, data []byte, _ string) error {
+			var evt model.MessageEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			require.NotNil(t, evt.PreviewMessage)
+			assert.Equal(t, "newest", evt.PreviewMessage.MessageID)
+			return nil
+		})
+
+	_, err := svc.DeleteMessage(c, "site-test", models.DeleteMessageRequest{MessageID: "old-msg"})
+	require.NoError(t, err)
+}
+
+// Deleting the message that IS the preview must still walk — the replacement is
+// the previous eligible message, which only a walk can find.
+func TestHistoryService_DeleteMessage_ThePreviewMessage_StillWalks(t *testing.T) {
+	svc, msgs, subs, rooms, pub, _, _, _ := newServiceWithRoomMock(t)
+	c := testContext()
+	rooms.EXPECT().GetMinUserLastSeenAt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	createdAt := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	stored := models.PreviewMessage{MessageID: "msg-1", Content: "doomed"}
+	stubStoredPreview(rooms, "r1", &stored)
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
+	hydrated := &models.Message{
+		MessageID: "msg-1", RoomID: "r1",
+		Sender:    models.Participant{Account: "u1", ID: "u1-id"},
+		CreatedAt: createdAt, Msg: "doomed",
+	}
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
+	msgs.EXPECT().
+		SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
+			return deletedAt, true, nil, nil, nil
+		})
+	// The walk finds the predecessor.
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{
+			{MessageID: "older", RoomID: "r1", Msg: "survivor", CreatedAt: createdAt.Add(-time.Minute)},
+		}, false), nil).
+		Times(1)
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), "r1", gomock.Any(), "older", gomock.Any()).Return(nil).Times(1)
+
+	pub.EXPECT().
+		Publish(gomock.Any(), subject.MsgCanonicalDeleted("site-test"), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, data []byte, _ string) error {
+			var evt model.MessageEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			require.NotNil(t, evt.PreviewMessage)
+			assert.Equal(t, "older", evt.PreviewMessage.MessageID)
+			return nil
+		})
+
+	_, err := svc.DeleteMessage(c, "site-test", models.DeleteMessageRequest{MessageID: "msg-1"})
 	require.NoError(t, err)
 }

--- a/history-service/internal/service/messages_test.go
+++ b/history-service/internal/service/messages_test.go
@@ -52,6 +52,10 @@ func newService(t *testing.T) (*service.HistoryService, *mocks.MockMessageReposi
 		MinTimes(0)
 	// Permissive default: existing GetThreadMessages tests don't verify the floor field.
 	threadRooms.EXPECT().GetMinThreadUserLastSeenAt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	// history-service is the sole preview writer, so every edit/delete now stores or
+	// clears as a side effect. Tests that assert on those use newServiceWithRoomMock.
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	rooms.EXPECT().ClearPreview(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	return svc, msgs, subs, pub, threadRooms
 }
 
@@ -2711,4 +2715,210 @@ func TestHistoryService_GetMessagesByIDs_QuoteRedaction(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Messages, 1)
 	assert.Equal(t, service.UnavailableQuoteMsg, result.Messages[0].QuotedParentMessage.Msg)
+}
+
+// Deleting the room's last eligible message leaves the walk definitively empty,
+// so history-service must CLEAR the stored preview — a stale one would otherwise
+// survive, since a mutation doesn't change lastMsgId and so can't be caught by
+// the freshness check.
+func TestHistoryService_DeleteMessage_LastMessage_ClearsStoredPreview(t *testing.T) {
+	svc, msgs, subs, rooms, pub, _, _, _ := newServiceWithRoomMock(t)
+	c := testContext()
+	rooms.EXPECT().GetMinUserLastSeenAt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
+	hydrated := &models.Message{
+		MessageID: "msg-1",
+		RoomID:    "r1",
+		Sender:    models.Participant{Account: "u1", ID: "u1-id"},
+		CreatedAt: time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC),
+		Msg:       "content",
+	}
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
+	msgs.EXPECT().
+		SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
+			return deletedAt, true, nil, nil, nil
+		})
+	// Empty page: the room has no eligible survivor — definitively empty, not degraded.
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage(nil, false), nil)
+
+	pub.EXPECT().
+		Publish(gomock.Any(), subject.MsgCanonicalDeleted("site-test"), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, data []byte, _ string) error {
+			var evt model.MessageEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			assert.Nil(t, evt.PreviewMessage)
+			return nil
+		})
+	rooms.EXPECT().ClearPreview(gomock.Any(), "r1", gomock.Any()).Return(nil).Times(1)
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	_, err := svc.DeleteMessage(c, "site-test", models.DeleteMessageRequest{MessageID: "msg-1"})
+	require.NoError(t, err)
+}
+
+// A terminal all-ineligible page (HasNext=false) is also definitively empty.
+func TestHistoryService_DeleteMessage_AllIneligibleTerminalPage_ClearsStoredPreview(t *testing.T) {
+	svc, msgs, subs, rooms, pub, _, _, _ := newServiceWithRoomMock(t)
+	c := testContext()
+	rooms.EXPECT().GetMinUserLastSeenAt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
+	createdAt := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	hydrated := &models.Message{
+		MessageID: "msg-1", RoomID: "r1",
+		Sender:    models.Participant{Account: "u1", ID: "u1-id"},
+		CreatedAt: createdAt, Msg: "content",
+	}
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
+	msgs.EXPECT().
+		SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
+			return deletedAt, true, nil, nil, nil
+		})
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "msg-1", RoomID: "r1", Deleted: true, CreatedAt: createdAt}}, false), nil)
+
+	pub.EXPECT().
+		Publish(gomock.Any(), subject.MsgCanonicalDeleted("site-test"), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, data []byte, _ string) error {
+			var evt model.MessageEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			assert.Nil(t, evt.PreviewMessage)
+			return nil
+		})
+	rooms.EXPECT().ClearPreview(gomock.Any(), "r1", gomock.Any()).Return(nil).Times(1)
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	_, err := svc.DeleteMessage(c, "site-test", models.DeleteMessageRequest{MessageID: "msg-1"})
+	require.NoError(t, err)
+}
+
+// A failed history read is DEGRADED, not empty: an eligible survivor may well
+// exist, so the stored preview must be left exactly as it is — neither refreshed
+// nor cleared.
+func TestHistoryService_DeleteMessage_DegradedWalk_LeavesStoredPreviewAlone(t *testing.T) {
+	svc, msgs, subs, rooms, pub, _, _, _ := newServiceWithRoomMock(t)
+	c := testContext()
+	rooms.EXPECT().GetMinUserLastSeenAt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
+	hydrated := &models.Message{
+		MessageID: "msg-1", RoomID: "r1",
+		Sender:    models.Participant{Account: "u1", ID: "u1-id"},
+		CreatedAt: time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC), Msg: "content",
+	}
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
+	msgs.EXPECT().
+		SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
+			return deletedAt, true, nil, nil, nil
+		})
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage(nil, false), errors.New("cassandra timeout"))
+
+	pub.EXPECT().
+		Publish(gomock.Any(), subject.MsgCanonicalDeleted("site-test"), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, data []byte, _ string) error {
+			var evt model.MessageEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			assert.Nil(t, evt.PreviewMessage)
+			return nil
+		})
+	rooms.EXPECT().ClearPreview(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	_, err := svc.DeleteMessage(c, "site-test", models.DeleteMessageRequest{MessageID: "msg-1"})
+	require.NoError(t, err)
+}
+
+// Exhausting the 250-row scan budget on an unbroken ineligible run is DEGRADED:
+// an eligible message may exist beyond the budget, so no clear signal.
+func TestHistoryService_DeleteMessage_ScanBudgetExhausted_LeavesStoredPreviewAlone(t *testing.T) {
+	svc, msgs, subs, rooms, pub, _, _, _ := newServiceWithRoomMock(t)
+	c := testContext()
+	rooms.EXPECT().GetMinUserLastSeenAt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
+	createdAt := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	hydrated := &models.Message{
+		MessageID: "msg-1", RoomID: "r1",
+		Sender:    models.Participant{Account: "u1", ID: "u1-id"},
+		CreatedAt: createdAt, Msg: "content",
+	}
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
+	msgs.EXPECT().
+		SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
+			return deletedAt, true, nil, nil, nil
+		})
+	// Every page full and HasNext=true: the walk only ever stops on the budget.
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ time.Time, _ time.Time, pr cassrepo.PageRequest) (cassrepo.Page[models.Message], error) {
+			deleted := make([]models.Message, pr.PageSize)
+			for i := range deleted {
+				deleted[i] = models.Message{
+					MessageID: "d", RoomID: "r1", Deleted: true,
+					CreatedAt: createdAt.Add(-time.Duration(i) * time.Second),
+				}
+			}
+			return makePage(deleted, true), nil
+		}).AnyTimes()
+
+	pub.EXPECT().
+		Publish(gomock.Any(), subject.MsgCanonicalDeleted("site-test"), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, data []byte, _ string) error {
+			var evt model.MessageEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			assert.Nil(t, evt.PreviewMessage)
+			return nil
+		})
+	rooms.EXPECT().ClearPreview(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	_, err := svc.DeleteMessage(c, "site-test", models.DeleteMessageRequest{MessageID: "msg-1"})
+	require.NoError(t, err)
+}
+
+// A hidden thread reply never appears in the room timeline, so it must not touch
+// the stored room preview at all — no walk, no write.
+func TestHistoryService_DeleteMessage_HiddenThreadReply_LeavesStoredPreviewAlone(t *testing.T) {
+	svc, msgs, subs, rooms, pub, _, _, _ := newServiceWithRoomMock(t)
+	c := testContext()
+	rooms.EXPECT().GetMinUserLastSeenAt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
+	parentCreatedAt := time.Date(2026, 5, 10, 9, 0, 0, 0, time.UTC)
+	hydrated := &models.Message{
+		MessageID: "reply-1", RoomID: "r1",
+		Sender:                models.Participant{Account: "u1", ID: "u1-id"},
+		CreatedAt:             time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC),
+		Msg:                   "reply",
+		ThreadParentID:        "parent-1",
+		ThreadParentCreatedAt: &parentCreatedAt,
+		TShow:                 false,
+	}
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "reply-1").Return(hydrated, nil)
+	msgs.EXPECT().
+		SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
+			return deletedAt, true, nil, nil, nil
+		})
+	// No GetMessagesBefore expectation: the walk must be skipped entirely.
+
+	pub.EXPECT().
+		Publish(gomock.Any(), subject.MsgCanonicalDeleted("site-test"), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, data []byte, _ string) error {
+			var evt model.MessageEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			assert.Nil(t, evt.PreviewMessage)
+			return nil
+		})
+	rooms.EXPECT().ClearPreview(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	_, err := svc.DeleteMessage(c, "site-test", models.DeleteMessageRequest{MessageID: "reply-1"})
+	require.NoError(t, err)
 }

--- a/history-service/internal/service/mocks/mock_repository.go
+++ b/history-service/internal/service/mocks/mock_repository.go
@@ -619,6 +619,20 @@ func (m *MockRoomRepository) EXPECT() *MockRoomRepositoryMockRecorder {
 	return m.recorder
 }
 
+// ClearPreview mocks base method.
+func (m *MockRoomRepository) ClearPreview(ctx context.Context, roomID string, asOf int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClearPreview", ctx, roomID, asOf)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ClearPreview indicates an expected call of ClearPreview.
+func (mr *MockRoomRepositoryMockRecorder) ClearPreview(ctx, roomID, asOf any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearPreview", reflect.TypeOf((*MockRoomRepository)(nil).ClearPreview), ctx, roomID, asOf)
+}
+
 // GetMinUserLastSeenAt mocks base method.
 func (m *MockRoomRepository) GetMinUserLastSeenAt(ctx context.Context, roomID string) (*time.Time, error) {
 	m.ctrl.T.Helper()
@@ -678,6 +692,20 @@ func (m *MockRoomRepository) GetRoomUserCount(ctx context.Context, roomID string
 func (mr *MockRoomRepositoryMockRecorder) GetRoomUserCount(ctx, roomID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRoomUserCount", reflect.TypeOf((*MockRoomRepository)(nil).GetRoomUserCount), ctx, roomID)
+}
+
+// SetPreviewMessage mocks base method.
+func (m *MockRoomRepository) SetPreviewMessage(ctx context.Context, roomID string, pvw models.PreviewMessage, forMsgID string, asOf int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetPreviewMessage", ctx, roomID, pvw, forMsgID, asOf)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetPreviewMessage indicates an expected call of SetPreviewMessage.
+func (mr *MockRoomRepositoryMockRecorder) SetPreviewMessage(ctx, roomID, pvw, forMsgID, asOf any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPreviewMessage", reflect.TypeOf((*MockRoomRepository)(nil).SetPreviewMessage), ctx, roomID, pvw, forMsgID, asOf)
 }
 
 // MockEventPublisher is a mock of EventPublisher interface.

--- a/history-service/internal/service/reactions.go
+++ b/history-service/internal/service/reactions.go
@@ -15,6 +15,7 @@ import (
 	pkgmodel "github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/pkg/natsrouter"
+	"github.com/hmchangw/chat/pkg/preview"
 	"github.com/hmchangw/chat/pkg/subject"
 	"github.com/hmchangw/chat/pkg/userstore"
 )
@@ -170,14 +171,14 @@ func toWireParticipant(p *cassandra.Participant) pkgmodel.Participant {
 
 // botAwareDisplayName composes a render-ready name; for a bot account it prefers the
 // app's display name, degrading to the composed name on lookup miss/error.
+//
+// The lookup is built only when an app store is wired: s.apps.AppNameByAccount is a
+// method value, so Go dereferences the receiver where it is written — a nil store
+// would panic here for every account, not just the bot ones that need it.
 func (s *HistoryService) botAwareDisplayName(ctx context.Context, engName, chineseName, account string) string {
-	name := displayfmt.CombineWithFallback(engName, chineseName, account)
-	if pkgmodel.IsBot(account) {
-		if appName, err := s.apps.AppNameByAccount(ctx, account); err != nil {
-			slog.WarnContext(ctx, "app name lookup failed, using composed name", "account", account, "error", err)
-		} else if appName != "" {
-			name = appName
-		}
+	var lookup preview.AppNameLookup
+	if s.apps != nil {
+		lookup = s.apps.AppNameByAccount
 	}
-	return name
+	return preview.BotAwareDisplayName(ctx, lookup, engName, chineseName, account)
 }

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/hmchangw/chat/history-service/internal/cassrepo"
 	"github.com/hmchangw/chat/history-service/internal/models"
+	"github.com/hmchangw/chat/history-service/internal/mongorepo"
 	"github.com/hmchangw/chat/pkg/errcode"
 	pkgmodel "github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/natsrouter"
 	"github.com/hmchangw/chat/pkg/natsutil"
+	"github.com/hmchangw/chat/pkg/preview"
 )
 
 const (
@@ -49,7 +51,8 @@ func (s *HistoryService) RoomsGet(c *natsrouter.Context, req models.RoomsGetRequ
 
 	ids := dedupRoomIDs(req.RoomIDs)
 	now := time.Now().UTC()
-	metaByRoom := s.resolveRoomMetaHints(c, ids, req.Hints, now)
+	rows := s.readRoomRows(c, ids)
+	metaByRoom := s.resolveRoomMetaHints(ids, req.Hints, rows, now)
 
 	out := make(map[string]models.PreviewMessage, len(ids))
 	var mu sync.Mutex
@@ -68,7 +71,7 @@ func (s *HistoryService) RoomsGet(c *natsrouter.Context, req models.RoomsGetRequ
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
-			lm, ok := s.resolvePreview(c, roomID, metaByRoom[roomID], now)
+			lm, ok := s.resolvePreview(c, roomID, metaByRoom[roomID], rows[roomID].Preview, now)
 			if !ok {
 				return
 			}
@@ -82,44 +85,46 @@ func (s *HistoryService) RoomsGet(c *natsrouter.Context, req models.RoomsGetRequ
 	return &models.RoomsGetResponse{Rooms: out}, nil
 }
 
-// resolveRoomMetaHints maps req.Hints into a per-room *models.RoomMeta and batches ONE
-// GetRoomTimesByIDs read for the rooms whose hint doesn't resolve to a usable lastMsgAt
-// (missing entirely, or rejected by the same sanitizeLastMsgAt every per-room resolve uses).
-// A batch-read failure degrades: those rooms simply keep a nil meta, so the per-room
-// resolveRoomTimes falls back to its existing GetRoomTimes read — the batch failure never
-// fails the whole RPC.
+// readRoomRows issues the ONE batched room-doc read behind rooms.get, covering
+// every requested room rather than just the unhinted ones: RoomTimeHint carries
+// neither the memoized preview nor the lastMsgId its freshness check needs, so a
+// hinted room could otherwise never serve one — and that is every room with
+// messages.
+//
+// A read failure degrades to nil: each room falls back to its per-room
+// GetRoomTimes plus a walk. It never fails the RPC.
+func (s *HistoryService) readRoomRows(ctx context.Context, ids []string) map[string]mongorepo.RoomTimes {
+	rows, err := s.rooms.GetRoomTimesByIDs(ctx, ids)
+	if err != nil {
+		slog.WarnContext(ctx, "rooms.get batch room-doc read degraded, falling back per-room",
+			"room_count", len(ids), "request_id", natsutil.RequestIDFromContext(ctx), "error", err)
+		return nil
+	}
+	return rows
+}
+
+// resolveRoomMetaHints maps req.Hints into a per-room *models.RoomMeta, falling
+// back to the batched room-doc read (rows) for rooms whose hint doesn't resolve
+// to a usable lastMsgAt (missing entirely, or rejected by the same
+// sanitizeLastMsgAt every per-room resolve uses). A room with neither keeps a
+// nil meta, so the per-room resolveRoomTimes falls back to its own GetRoomTimes.
 func (s *HistoryService) resolveRoomMetaHints(
-	ctx context.Context,
 	ids []string,
 	hints map[string]pkgmodel.RoomTimeHint,
+	rows map[string]mongorepo.RoomTimes,
 	now time.Time,
 ) map[string]*models.RoomMeta {
 	metaByRoom := make(map[string]*models.RoomMeta, len(ids))
-	unhinted := make([]string, 0, len(ids))
 	for _, roomID := range ids {
-		hint, ok := hints[roomID]
-		if !ok || sanitizeLastMsgAt(hint.LastMsgAt, now) == nil {
-			unhinted = append(unhinted, roomID)
+		if hint, ok := hints[roomID]; ok && sanitizeLastMsgAt(hint.LastMsgAt, now) != nil {
+			metaByRoom[roomID] = &models.RoomMeta{LastMsgAt: hint.LastMsgAt, CreatedAt: hint.CreatedAt}
 			continue
 		}
-		metaByRoom[roomID] = &models.RoomMeta{LastMsgAt: hint.LastMsgAt, CreatedAt: hint.CreatedAt}
-	}
-	if len(unhinted) == 0 {
-		return metaByRoom
-	}
-
-	times, err := s.rooms.GetRoomTimesByIDs(ctx, unhinted)
-	if err != nil {
-		slog.WarnContext(ctx, "rooms.get batch room-times read degraded, falling back per-room",
-			"room_count", len(unhinted), "request_id", natsutil.RequestIDFromContext(ctx), "error", err)
-		return metaByRoom
-	}
-	for roomID, rt := range times {
-		if rt.LastMsgAt.IsZero() {
-			// Never-messaged room: nothing usable to hint. Leave the meta nil so
-			// resolveRoomTimes takes its plain meta==nil path (one full per-room
-			// GetRoomTimes, normalized directly) instead of treating a synthetic zero
-			// lastMsgAt as a "hint" and tripping the created>last consistency refetch.
+		rt, ok := rows[roomID]
+		if !ok || rt.LastMsgAt.IsZero() {
+			// Absent or never-messaged: nothing usable. A nil meta sends
+			// resolveRoomTimes down its plain per-room path, rather than treating a
+			// synthetic zero lastMsgAt as a hint and tripping the created>last refetch.
 			continue
 		}
 		last := rt.LastMsgAt.UnixMilli()
@@ -129,42 +134,112 @@ func (s *HistoryService) resolveRoomMetaHints(
 	return metaByRoom
 }
 
-// resolvePreview resolves one room's preview, serving it from the preview cache
-// when installed. The cache is positives-only, so empty rooms and read failures
-// fall through to a fresh resolve. meta is the caller/batch-resolved times hint
-// (nil when none applies); previewAfterMutation (edit/delete) keeps calling
-// roomLastPreviewMessage directly with meta=nil so mutations always see fresh state.
-func (s *HistoryService) resolvePreview(ctx context.Context, roomID string, meta *models.RoomMeta, now time.Time) (models.PreviewMessage, bool) {
-	if s.previewCache == nil {
-		return s.roomLastPreviewMessage(ctx, roomID, meta, now)
+// resolvePreview resolves one room's preview in three tiers: a current stored
+// preview (no walk), the in-process cache, then a Cassandra walk that warm-backs
+// what it finds.
+//
+// stored comes from the batch room-doc read, already freshness- and
+// epoch-checked; nil means walk. meta is the times hint (nil when none applies);
+// previewAfterMutation passes nil so mutations always see fresh state. The cache
+// is positives-only, so empty rooms and read failures re-resolve. Both walk paths
+// share one load closure, so a cache hit never re-warms.
+func (s *HistoryService) resolvePreview(ctx context.Context, roomID string, meta *models.RoomMeta, stored *models.PreviewMessage, now time.Time) (models.PreviewMessage, bool) {
+	// The point of the denormalization: the repo already checked freshness and
+	// epoch and opened it, so this is ready to serve.
+	if stored != nil {
+		return *stored, true
 	}
-	preview, ok, err := s.previewCache.Get(ctx, roomID, func(ctx context.Context) (models.PreviewMessage, bool, error) {
-		p, found := s.roomLastPreviewMessage(ctx, roomID, meta, now)
-		return p, found, nil
-	})
+	load := func(ctx context.Context) (models.PreviewMessage, bool, error) {
+		w := s.roomLastPreviewMessage(ctx, roomID, meta, now)
+		if w.State == previewFound {
+			s.storePreview(ctx, roomID, "warm_back", &w, w.Preview.CreatedAt.UnixMilli())
+		}
+		return w.Preview, w.State == previewFound, nil
+	}
+	if s.previewCache == nil {
+		p, found, _ := load(ctx)
+		return p, found
+	}
+	pvw, ok, err := s.previewCache.Get(ctx, roomID, load)
 	if err != nil {
 		// ctx cancelled while waiting on a shared load — degrade like a read miss.
 		return models.PreviewMessage{}, false
 	}
-	return preview, ok
+	return pvw, ok
 }
 
-// roomLastPreviewMessage resolves one room's latest eligible preview message at read time.
+// storePreview best-effort persists a walk-resolved preview so later reads skip
+// the walk. Shared by both writers so the skip rule cannot drift; failures cost
+// only the optimization.
+//
+// asOf stays explicit at the call site: warm-back passes the preview's own
+// createdAt (always <= any event that observed it, so it cannot outrank a
+// mutation write), a mutation passes its edit/delete time. path distinguishes the
+// two in logs.
+func (s *HistoryService) storePreview(ctx context.Context, roomID, path string, w *previewWalk, asOf int64) {
+	if w.NewestObservedID == "" {
+		// No observed id means no key to invalidate against later — skip rather
+		// than store something permanently un-invalidatable.
+		return
+	}
+	if err := s.rooms.SetPreviewMessage(ctx, roomID, w.Preview, w.NewestObservedID, asOf); err != nil {
+		slog.WarnContext(ctx, "preview store failed", "room_id", roomID, "path", path,
+			"request_id", natsutil.RequestIDFromContext(ctx), "error", err)
+	}
+}
+
+// previewResolveState separates the two ways a walk comes back empty-handed:
+// previewEmpty (completed, definitively none — safe to clear a stored preview)
+// versus previewDegraded (gave up mid-flight; a survivor may exist, so clearing
+// would lose data).
+type previewResolveState int
+
+const (
+	previewFound    previewResolveState = iota
+	previewEmpty                        // walk completed and definitively found no eligible message
+	previewDegraded                     // a read failed or the scan budget was exhausted — unknown
+)
+
+// previewWalk is one preview resolution's outcome.
+type previewWalk struct {
+	Preview models.PreviewMessage
+	// NewestObservedID is the newest message id the walk actually SAW in
+	// Cassandra, and is the freshness key every stored preview is stamped with.
+	// Empty when the walk observed nothing.
+	//
+	// It is neither of the two ids it resembles. Not Preview.MessageID: those
+	// differ whenever the newest message is ineligible and skipped, the ordinary
+	// case for a room whose last activity was a system message. And never the
+	// room doc's lastMsgId: broadcast-worker and message-worker consume
+	// MESSAGES-CANONICAL unordered, so the doc can name a message Cassandra does
+	// not hold yet — stamping that would claim freshness for a state never
+	// observed, and since the identity check would then hold, it would never
+	// self-heal.
+	NewestObservedID string
+	State            previewResolveState
+}
+
+// roomLastPreviewMessage resolves one room's latest eligible preview message at read time,
+// reporting the walk outcome three-valued (see previewResolveState) so callers that must
+// tell "definitively none" apart from "unknown" (previewAfterMutation) can.
 // meta, when non-nil, is a caller/batch-resolved room-times hint that lets resolveRoomTimes
 // skip its own Mongo read (see resolveRoomMetaHints / resolveRoomTimes); pass nil to always
-// resolve fresh (previewAfterMutation's contract). ok=false means drop the room (empty,
-// all-ineligible within the walk cap, or a read failure). Walks backward from lastMsgAt in
-// pages, skipping ineligible messages.
-func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID string, meta *models.RoomMeta, now time.Time) (models.PreviewMessage, bool) {
+// resolve fresh (previewAfterMutation's contract). Walks backward from lastMsgAt in pages,
+// skipping ineligible messages.
+func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID string, meta *models.RoomMeta, now time.Time) previewWalk {
 	lastMsgAt, createdAt, err := s.resolveRoomTimesOrError(ctx, roomID, meta, now)
 	if err != nil {
 		slog.WarnContext(ctx, "rooms.get room degraded", "room_id", roomID,
 			"request_id", natsutil.RequestIDFromContext(ctx), "error", err)
-		return models.PreviewMessage{}, false
+		return previewWalk{State: previewDegraded}
 	}
 
 	ceiling, floor := s.walkBounds(lastMsgAt, createdAt, now)
 	before := ceiling.Add(time.Millisecond)
+
+	// The walk descends from the ceiling, so the first row of the first non-empty
+	// page is the newest message this walk observed.
+	newestObservedID := ""
 
 	pageSize := lastMsgWalkFirstPage
 	scanned := 0
@@ -177,10 +252,14 @@ func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID stri
 		if err != nil {
 			slog.WarnContext(ctx, "rooms.get latest-message read degraded", "room_id", roomID,
 				"request_id", natsutil.RequestIDFromContext(ctx), "error", err)
-			return models.PreviewMessage{}, false
+			return previewWalk{NewestObservedID: newestObservedID, State: previewDegraded}
 		}
 		if len(page.Data) == 0 {
-			return models.PreviewMessage{}, false // room empty or floor reached
+			// Room empty or floor reached.
+			return previewWalk{NewestObservedID: newestObservedID, State: previewEmpty}
+		}
+		if newestObservedID == "" {
+			newestObservedID = page.Data[0].MessageID
 		}
 		for i := range page.Data {
 			m := page.Data[i]
@@ -189,19 +268,25 @@ func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID stri
 			if m.Deleted || pkgmodel.IsSystemMessageType(m.Type) {
 				continue
 			}
-			return s.toPreviewMessage(ctx, &m), true
+			return previewWalk{
+				Preview:          s.toPreviewMessage(ctx, &m),
+				NewestObservedID: newestObservedID,
+				State:            previewFound,
+			}
 		}
 		// Whole page ineligible. HasNext=false means the walk reached a terminal
-		// state (floor/empty) — stop. Otherwise grow the page and continue strictly
-		// before the oldest one seen.
+		// state (floor/empty) — stop, definitively none. Otherwise grow the page
+		// and continue strictly before the oldest one seen.
 		scanned += len(page.Data)
 		if !page.HasNext {
-			return models.PreviewMessage{}, false
+			return previewWalk{NewestObservedID: newestObservedID, State: previewEmpty}
 		}
 		before = page.Data[len(page.Data)-1].CreatedAt
 		pageSize *= lastMsgWalkGrowth
 	}
-	return models.PreviewMessage{}, false // ineligible tail longer than the scan budget
+	// Ineligible tail longer than the scan budget: an eligible message may still
+	// exist beyond it, so this is unknown — never a clear signal.
+	return previewWalk{NewestObservedID: newestObservedID, State: previewDegraded}
 }
 
 // toPreviewMessage enriches an eligible message into the room-list preview: sender and
@@ -223,15 +308,15 @@ func (s *HistoryService) toPreviewMessage(ctx context.Context, m *models.Message
 		}
 	}
 
-	return models.PreviewMessage{
+	return preview.Build(models.PreviewMessage{
 		MessageID:   m.MessageID,
 		Sender:      sender,
 		Content:     m.Msg,
-		CreatedAt:   m.CreatedAt.UTC(),
+		CreatedAt:   m.CreatedAt,
 		Attachments: m.DecodedAttachments,
 		Mentions:    mentions,
 		VisibleTo:   m.VisibleTo,
-	}
+	})
 }
 
 // dedupRoomIDs removes duplicate roomIds, preserving first-seen order.

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -23,10 +23,17 @@ import (
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/pkg/natsrouter"
+	"github.com/hmchangw/chat/pkg/preview"
 )
 
 // newRoomsService builds a service with bare mocks. rooms.get is server-to-server
 // now — no access (subscription) check — so tests only set room-time + message reads.
+// A permissive default on SetPreviewMessage lets every pre-existing fixture ignore
+// the warm-back call it now triggers on a successful walk; tests that care about
+// warm-back specifically (rooms_warmback_test.go) build their own mocks instead, so
+// their precise EXPECT()s aren't shadowed by this default (gomock matches the first
+// registered expectation, so a shared AnyTimes() here must never be the only one a
+// warm-back-specific test relies on).
 func newRoomsService(t *testing.T) (*service.HistoryService, *mocks.MockMessageRepository, *mocks.MockRoomRepository) {
 	ctrl := gomock.NewController(t)
 	msgs := mocks.NewMockMessageRepository(ctrl)
@@ -38,12 +45,14 @@ func newRoomsService(t *testing.T) (*service.HistoryService, *mocks.MockMessageR
 	users := mocks.NewMockUserStore(ctrl)
 	apps := mocks.NewMockAppStore(ctrl)
 	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true}
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg)
 	return svc, msgs, rooms
 }
 
 // newRoomsServiceWithApps also exposes the AppStore mock, needed by the preview
-// enrichment tests (bot sender → app name).
+// enrichment tests (bot sender → app name). See newRoomsService for the default
+// SetPreviewMessage stub rationale.
 func newRoomsServiceWithApps(t *testing.T) (*service.HistoryService, *mocks.MockMessageRepository, *mocks.MockRoomRepository, *mocks.MockAppStore) {
 	ctrl := gomock.NewController(t)
 	msgs := mocks.NewMockMessageRepository(ctrl)
@@ -55,12 +64,14 @@ func newRoomsServiceWithApps(t *testing.T) (*service.HistoryService, *mocks.Mock
 	users := mocks.NewMockUserStore(ctrl)
 	apps := mocks.NewMockAppStore(ctrl)
 	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true}
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg)
 	return svc, msgs, rooms, apps
 }
 
 // newRoomsServiceWithPreviewCache installs a real PreviewCache so RoomsGet routes
-// through it (cache-hit behavior on the second/third read of the same room).
+// through it (cache-hit behavior on the second/third read of the same room). See
+// newRoomsService for the default SetPreviewMessage stub rationale.
 func newRoomsServiceWithPreviewCache(t *testing.T) (*service.HistoryService, *mocks.MockMessageRepository, *mocks.MockRoomRepository) {
 	ctrl := gomock.NewController(t)
 	msgs := mocks.NewMockMessageRepository(ctrl)
@@ -74,6 +85,7 @@ func newRoomsServiceWithPreviewCache(t *testing.T) (*service.HistoryService, *mo
 	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true}
 	pc, err := readcache.NewPreviewCache(100, time.Minute)
 	require.NoError(t, err)
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg, service.WithPreviewCache(pc))
 	return svc, msgs, rooms
 }
@@ -305,8 +317,9 @@ func TestHistoryService_RoomsGet_DedupsRoomIDs(t *testing.T) {
 	assert.Len(t, resp.Rooms, 1)
 }
 
-// Content is returned in full — the client truncates for display.
-func TestHistoryService_RoomsGet_FullContent(t *testing.T) {
+// Content beyond the preview cap is truncated to a rune-safe snippet — multi-byte
+// runes must not be split mid-character.
+func TestHistoryService_RoomsGet_ContentTruncatedAtCapMultibyte(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 	long := strings.Repeat("世", 1000)
 
@@ -317,7 +330,23 @@ func TestHistoryService_RoomsGet_FullContent(t *testing.T) {
 	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
 	require.NoError(t, err)
 	require.Contains(t, resp.Rooms, "r1")
-	assert.Equal(t, long, resp.Rooms["r1"].Content)
+	assert.Equal(t, strings.Repeat("世", preview.MaxContentRunes), resp.Rooms["r1"].Content)
+}
+
+// Content beyond the preview cap is truncated to exactly preview.MaxContentRunes
+// runes — the room list renders a snippet, not the full (≤20KB) body.
+func TestHistoryService_RoomsGet_PreviewContentTruncated(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+	long := strings.Repeat("x", preview.MaxContentRunes+100)
+
+	stubRoomTimes(rooms, []string{"r1"}, roomLastMsgAt, roomCreatedAt)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: long, CreatedAt: roomLastMsgAt}}, false), nil)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "r1")
+	assert.Equal(t, strings.Repeat("x", preview.MaxContentRunes), resp.Rooms["r1"].Content)
 }
 
 // Latest message is a system message → walk back to the first non-system, non-quoted survivor.
@@ -519,12 +548,18 @@ func msPtr(t time.Time) *int64 {
 	return &ms
 }
 
-// (a) Every room carries a usable lastMsgAt hint: resolveRoomTimes never needs Mongo at
-// all, so neither the per-room GetRoomTimes nor the batched GetRoomTimesByIDs is called.
-func TestHistoryService_RoomsGet_AllHinted_NoStoreReads(t *testing.T) {
+// (a) Every room carries a usable lastMsgAt hint: the hint supplies the walk
+// bounds, so the per-room GetRoomTimes is never called. The ONE batched room-doc
+// read still happens — hinted or not, the stored preview and the lastMsgId its
+// freshness check compares against live only on the doc, and RoomTimeHint
+// carries neither.
+func TestHistoryService_RoomsGet_AllHinted_StillReadsRoomDocsOnce(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 	rooms.EXPECT().GetRoomTimes(gomock.Any(), gomock.Any()).Times(0)
-	rooms.EXPECT().GetRoomTimesByIDs(gomock.Any(), gomock.Any()).Times(0)
+	rooms.EXPECT().
+		GetRoomTimesByIDs(gomock.Any(), gomock.InAnyOrder([]string{"r1", "r2"})).
+		Return(map[string]mongorepo.RoomTimes{}, nil).
+		Times(1)
 
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{{MessageID: "m1", RoomID: "r1", Msg: "hi", CreatedAt: roomLastMsgAt}}, false), nil)
@@ -568,13 +603,13 @@ func TestHistoryService_RoomsGet_NoHints_BatchesAllIDs(t *testing.T) {
 	assert.Equal(t, "m2", resp.Rooms["r2"].MessageID)
 }
 
-// (c) Mixed hinted/unhinted: only r2 (unhinted) is in the batch call; r1's hint means it
-// never reaches Mongo at all.
-func TestHistoryService_RoomsGet_MixedHints_BatchesOnlyUnhinted(t *testing.T) {
+// (c) Mixed hinted/unhinted: one batch call still carries EVERY id, but the hint
+// still wins for r1's walk bounds, so the per-room GetRoomTimes stays unused.
+func TestHistoryService_RoomsGet_MixedHints_BatchesAllIDs(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 	rooms.EXPECT().GetRoomTimes(gomock.Any(), gomock.Any()).Times(0)
 	rooms.EXPECT().
-		GetRoomTimesByIDs(gomock.Any(), []string{"r2"}).
+		GetRoomTimesByIDs(gomock.Any(), gomock.InAnyOrder([]string{"r1", "r2"})).
 		Return(map[string]mongorepo.RoomTimes{"r2": {LastMsgAt: roomLastMsgAt, CreatedAt: roomCreatedAt}}, nil).
 		Times(1)
 

--- a/history-service/internal/service/rooms_warmback_test.go
+++ b/history-service/internal/service/rooms_warmback_test.go
@@ -1,0 +1,184 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/hmchangw/chat/history-service/internal/config"
+	"github.com/hmchangw/chat/history-service/internal/models"
+	"github.com/hmchangw/chat/history-service/internal/mongorepo"
+	readcache "github.com/hmchangw/chat/history-service/internal/readcache"
+	"github.com/hmchangw/chat/history-service/internal/service"
+	"github.com/hmchangw/chat/history-service/internal/service/mocks"
+)
+
+// newWarmBackTestService builds a service with bare mocks and installs NO default
+// SetPreviewMessage stub — unlike newRoomsService, so each test below gets full,
+// unshadowed control over that mock's EXPECT()s (gomock matches the first
+// registered expectation for a method, so a shared default would always win over
+// a specific one registered afterward inside the test body).
+func newWarmBackTestService(t *testing.T) (*service.HistoryService, *mocks.MockMessageRepository, *mocks.MockRoomRepository) {
+	ctrl := gomock.NewController(t)
+	msgs := mocks.NewMockMessageRepository(ctrl)
+	subs := mocks.NewMockSubscriptionRepository(ctrl)
+	rooms := mocks.NewMockRoomRepository(ctrl)
+	pub := mocks.NewMockEventPublisher(ctrl)
+	threadRooms := mocks.NewMockThreadRoomRepository(ctrl)
+	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
+	users := mocks.NewMockUserStore(ctrl)
+	apps := mocks.NewMockAppStore(ctrl)
+	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true}
+	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg)
+	return svc, msgs, rooms
+}
+
+// newWarmBackTestServiceWithPreviewCache is newWarmBackTestService plus a real
+// installed PreviewCache, for the cache-hit-skips-warm-back scenario.
+func newWarmBackTestServiceWithPreviewCache(t *testing.T) (*service.HistoryService, *mocks.MockMessageRepository, *mocks.MockRoomRepository) {
+	ctrl := gomock.NewController(t)
+	msgs := mocks.NewMockMessageRepository(ctrl)
+	subs := mocks.NewMockSubscriptionRepository(ctrl)
+	rooms := mocks.NewMockRoomRepository(ctrl)
+	pub := mocks.NewMockEventPublisher(ctrl)
+	threadRooms := mocks.NewMockThreadRoomRepository(ctrl)
+	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
+	users := mocks.NewMockUserStore(ctrl)
+	apps := mocks.NewMockAppStore(ctrl)
+	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true}
+	pc, err := readcache.NewPreviewCache(100, time.Minute)
+	require.NoError(t, err)
+	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg, service.WithPreviewCache(pc))
+	return svc, msgs, rooms
+}
+
+// A resolvePreview walk that finds a preview warm-backs it onto the room doc,
+// asOf == the resolved preview's own CreatedAt millis. The read itself still
+// succeeds and returns the resolved preview regardless of the warm-back outcome.
+func TestHistoryService_RoomsGet_WarmsBackResolvedPreview(t *testing.T) {
+	svc, msgs, rooms := newWarmBackTestService(t)
+
+	msgCreatedAt := roomLastMsgAt
+	stubRoomTimes(rooms, []string{"room-1"}, roomLastMsgAt, roomCreatedAt)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "room-1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{
+			{MessageID: "m1", RoomID: "room-1", Msg: "hi", CreatedAt: msgCreatedAt, Sender: models.Participant{Account: "alice"}},
+		}, false), nil)
+	rooms.EXPECT().
+		SetPreviewMessage(gomock.Any(), "room-1", gomock.Any(), gomock.Any(), msgCreatedAt.UTC().UnixMilli()).
+		DoAndReturn(func(_ context.Context, _ string, pvw models.PreviewMessage, forMsgID string, _ int64) error {
+			require.Equal(t, "m1", pvw.MessageID)
+			// Newest observed == the preview itself when the newest message is eligible.
+			require.Equal(t, "m1", forMsgID)
+			return nil
+		}).
+		Times(1)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"room-1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "room-1")
+	require.Equal(t, "m1", resp.Rooms["room-1"].MessageID)
+}
+
+// A warm-back failure is best-effort: the read must still succeed and still
+// return the resolved preview.
+func TestHistoryService_RoomsGet_WarmBackFailureDoesNotFailRead(t *testing.T) {
+	svc, msgs, rooms := newWarmBackTestService(t)
+
+	stubRoomTimes(rooms, []string{"room-1"}, roomLastMsgAt, roomCreatedAt)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "room-1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{
+			{MessageID: "m1", RoomID: "room-1", Msg: "hi", CreatedAt: roomLastMsgAt, Sender: models.Participant{Account: "alice"}},
+		}, false), nil)
+	rooms.EXPECT().
+		SetPreviewMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(errors.New("mongo down")).
+		Times(1)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"room-1"}})
+	require.NoError(t, err)
+	require.Contains(t, resp.Rooms, "room-1")
+	require.Equal(t, "m1", resp.Rooms["room-1"].MessageID)
+}
+
+// A preview served from a warm cache hit must not re-run the walk-and-warm-back
+// loader: no SetPreviewMessage call on the second (cache-hit) resolve.
+func TestHistoryService_RoomsGet_CacheHitSkipsWarmBack(t *testing.T) {
+	svc, msgs, rooms := newWarmBackTestServiceWithPreviewCache(t)
+
+	stubRoomTimesN(rooms, []string{"room-1"}, roomLastMsgAt, roomCreatedAt, 2)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "room-1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{
+			{MessageID: "m1", RoomID: "room-1", Msg: "hi", CreatedAt: roomLastMsgAt, Sender: models.Participant{Account: "alice"}},
+		}, false), nil).Times(1)
+	// Exactly one warm-back call: the priming (cache-miss) resolve. A second call
+	// here would mean the cache hit re-ran the loader — exhausting this Times(1)
+	// expectation fails the test via gomock's "unexpected call" fatal.
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), "room-1", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	resp1, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"room-1"}})
+	require.NoError(t, err)
+	require.Equal(t, "m1", resp1.Rooms["room-1"].MessageID)
+
+	resp2, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"room-1"}})
+	require.NoError(t, err)
+	require.Equal(t, "m1", resp2.Rooms["room-1"].MessageID)
+}
+
+// The freshness key is the newest message the walk OBSERVED, which is NOT the
+// preview's own id whenever the newest message is ineligible and gets skipped —
+// the ordinary case for a room whose last activity was a system message. Keying
+// on the preview's id instead would leave the memo permanently "stale" and make
+// every read re-walk.
+func TestHistoryService_RoomsGet_WarmBackKeysOnNewestObservedMessage(t *testing.T) {
+	svc, msgs, rooms := newWarmBackTestService(t)
+
+	stubRoomTimes(rooms, []string{"room-1"}, roomLastMsgAt, roomCreatedAt)
+	// Newest row is a deleted message (skipped); the eligible preview is older.
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "room-1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{
+			{MessageID: "newest", RoomID: "room-1", Deleted: true, CreatedAt: roomLastMsgAt},
+			{MessageID: "older", RoomID: "room-1", Msg: "hi", CreatedAt: roomLastMsgAt.Add(-time.Minute), Sender: models.Participant{Account: "alice"}},
+		}, false), nil)
+	rooms.EXPECT().
+		SetPreviewMessage(gomock.Any(), "room-1", gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, pvw models.PreviewMessage, forMsgID string, _ int64) error {
+			require.Equal(t, "older", pvw.MessageID, "preview is the newest ELIGIBLE message")
+			require.Equal(t, "newest", forMsgID, "freshness key is the newest OBSERVED message")
+			return nil
+		}).
+		Times(1)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"room-1"}})
+	require.NoError(t, err)
+	require.Equal(t, "older", resp.Rooms["room-1"].MessageID)
+}
+
+// A stored preview that the repo reports as current short-circuits the walk
+// entirely: no Cassandra read, no re-write. This is the whole point of the memo.
+func TestHistoryService_RoomsGet_FreshStoredPreviewSkipsWalk(t *testing.T) {
+	svc, msgs, rooms := newWarmBackTestService(t)
+
+	stored := models.PreviewMessage{
+		MessageID: "m1",
+		Content:   "from the doc",
+		CreatedAt: roomLastMsgAt,
+	}
+	rooms.EXPECT().
+		GetRoomTimesByIDs(gomock.Any(), gomock.Any()).
+		Return(map[string]mongorepo.RoomTimes{
+			"room-1": {LastMsgAt: roomLastMsgAt, CreatedAt: roomCreatedAt, Preview: &stored},
+		}, nil).
+		Times(1)
+	// Strict: any Cassandra walk or preview write fails the test.
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"room-1"}})
+	require.NoError(t, err)
+	require.Equal(t, "from the doc", resp.Rooms["room-1"].Content)
+}

--- a/history-service/internal/service/service.go
+++ b/history-service/internal/service/service.go
@@ -61,12 +61,21 @@ type SubscriptionRepository interface {
 // RoomRepository reads room metadata required by history handlers:
 // MinUserLastSeenAt as a per-user read-receipt floor surfaced to clients,
 // GetRoomTimes (lastMsgAt, createdAt) for bucket-walk bounds, and
-// GetRoomTimesByIDs, the batched ($in) form for resolving many rooms at once.
+// GetRoomTimesByIDs, the batched ($in) form — which also carries each room's
+// memoized preview, already freshness-checked and opened, so a room list can skip
+// the Cassandra walk.
 type RoomRepository interface {
 	GetMinUserLastSeenAt(ctx context.Context, roomID string) (*time.Time, error)
 	GetRoomTimes(ctx context.Context, roomID string) (lastMsgAt, createdAt time.Time, err error)
 	GetRoomTimesByIDs(ctx context.Context, ids []string) (map[string]mongorepo.RoomTimes, error)
 	GetRoomUserCount(ctx context.Context, roomID string) (int, error)
+	// SetPreviewMessage seals and stores a walk-resolved preview, guarded by asOf
+	// so it fills empty docs but never regresses a newer write. forMsgID is the
+	// freshness key; see previewWalk.NewestObservedID. Errors are best-effort.
+	SetPreviewMessage(ctx context.Context, roomID string, pvw models.PreviewMessage, forMsgID string, asOf int64) error
+	// ClearPreview removes the stored preview under the same guard, for a mutation
+	// that leaves the room with no eligible message.
+	ClearPreview(ctx context.Context, roomID string, asOf int64) error
 }
 
 // EventPublisher publishes events to NATS with a Nats-Msg-Id dedup header.

--- a/pkg/model/message.go
+++ b/pkg/model/message.go
@@ -103,11 +103,13 @@ type RoomsGetRequest struct {
 	Hints map[string]RoomTimeHint `json:"hints,omitempty"`
 }
 
-// PreviewMessage is a room's most-recent eligible message, resolved at read time and
-// enriched for the room-list preview. Content is the full message body; the client
-// truncates for display. Sender/mentions carry render-ready wire Participants (a bot
-// sender's displayName is its app name). Shared wire type: history-service's rooms.get
-// RPC produces it, user-service's subscription.list embeds it (SubscriptionRoom.PreviewMessage).
+// PreviewMessage is a room's most-recent eligible message, enriched for the
+// room-list preview. Content is a snippet capped at preview.MaxContentRunes
+// (500 runes) — no longer the full body. Sender/mentions carry render-ready
+// wire Participants (a bot sender's displayName is its app name). Purely a wire
+// type: history-service's rooms.get RPC produces it and user-service's
+// subscription.list embeds it. It is never stored — the room doc holds the
+// split PreviewMeta + sealed body instead.
 type PreviewMessage struct {
 	MessageID   string                 `json:"messageId"`
 	Sender      Participant            `json:"sender"`
@@ -119,6 +121,18 @@ type PreviewMessage struct {
 	// follow-up, so it's empty until that lands.
 	VisibleTo string `json:"visibleTo,omitempty"`
 	// TODO(#106): forwardSource — wired after the Forwarded snapshot merges.
+}
+
+// PreviewMeta is the plaintext half of a stored room preview: precisely the fields
+// Cassandra leaves unencrypted, so persisting them makes no new classification. The
+// user-authored half is sealed into Room.PreviewCiphertext. Storage-only — clients
+// always receive a PreviewMessage.
+type PreviewMeta struct {
+	MessageID string        `json:"messageId"           bson:"messageId"`
+	Sender    Participant   `json:"sender"              bson:"sender"`
+	CreatedAt time.Time     `json:"createdAt"           bson:"createdAt"`
+	Mentions  []Participant `json:"mentions,omitempty"  bson:"mentions,omitempty"`
+	VisibleTo string        `json:"visibleTo,omitempty" bson:"visibleTo,omitempty"`
 }
 
 // RoomsGetResponse maps each requested roomId that has a resolvable last message to

--- a/pkg/model/room.go
+++ b/pkg/model/room.go
@@ -12,14 +12,33 @@ const (
 )
 
 type Room struct {
-	ID                string     `json:"id" bson:"_id"`
-	Name              string     `json:"name" bson:"name"`
-	Type              RoomType   `json:"type" bson:"type"`
-	SiteID            string     `json:"siteId" bson:"siteId"`
-	UserCount         int        `json:"userCount" bson:"userCount"`
-	AppCount          int        `json:"appCount" bson:"appCount"`
-	LastMsgAt         *time.Time `json:"lastMsgAt,omitempty" bson:"lastMsgAt,omitempty"`
-	LastMsgID         string     `json:"lastMsgId" bson:"lastMsgId"`
+	ID        string     `json:"id" bson:"_id"`
+	Name      string     `json:"name" bson:"name"`
+	Type      RoomType   `json:"type" bson:"type"`
+	SiteID    string     `json:"siteId" bson:"siteId"`
+	UserCount int        `json:"userCount" bson:"userCount"`
+	AppCount  int        `json:"appCount" bson:"appCount"`
+	LastMsgAt *time.Time `json:"lastMsgAt,omitempty" bson:"lastMsgAt,omitempty"`
+	LastMsgID string     `json:"lastMsgId" bson:"lastMsgId"`
+	// PreviewMeta is the plaintext half of the memoized room-list preview —
+	// exactly what Cassandra also leaves unencrypted. history-service is the sole
+	// writer and reader of every Preview* field here.
+	PreviewMeta *PreviewMeta `json:"-" bson:"previewMeta,omitempty"`
+	// PreviewCiphertext seals Content and Attachments under the site preview DEK,
+	// so Mongo access alone never yields message bodies.
+	PreviewCiphertext []byte `json:"-" bson:"previewCiphertext,omitempty"`
+	// PreviewNonce is the AES-GCM nonce for PreviewCiphertext.
+	PreviewNonce []byte `json:"-" bson:"previewNonce,omitempty"`
+	// PreviewKeyEpoch is the DEK epoch that produced the ciphertext. A reader on
+	// another epoch treats the preview as absent, so none needs a retired DEK.
+	PreviewKeyEpoch int `json:"-" bson:"previewKeyEpoch,omitempty"`
+	// PreviewForMsgID is the freshness key: the newest message id the walk
+	// OBSERVED in Cassandra, not PreviewMeta.MessageID. The preview is current
+	// iff it equals LastMsgID.
+	PreviewForMsgID string `json:"-" bson:"previewForMsgId,omitempty"`
+	// PreviewAsOf is the write-ordering watermark (epoch ms). Plaintext because
+	// the guarded update pipeline compares it server-side.
+	PreviewAsOf       int64      `json:"-" bson:"previewAsOf,omitempty"`
 	LastMentionAllAt  *time.Time `json:"lastMentionAllAt,omitempty" bson:"lastMentionAllAt,omitempty"`
 	MinUserLastSeenAt *time.Time `json:"minUserLastSeenAt,omitempty" bson:"minUserLastSeenAt,omitempty"`
 	CreatedAt         time.Time  `json:"createdAt" bson:"createdAt"`

--- a/pkg/model/room_preview_test.go
+++ b/pkg/model/room_preview_test.go
@@ -1,0 +1,137 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// toMap converts bson.D or bson.M to bson.M for consistent type handling
+func toMap(v interface{}) bson.M {
+	switch val := v.(type) {
+	case bson.M:
+		return val
+	case bson.D:
+		result := make(bson.M)
+		for _, elem := range val {
+			result[elem.Key] = elem.Value
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+func samplePreviewRoom() Room {
+	created := time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC)
+	return Room{
+		ID: "room-1",
+		PreviewMeta: &PreviewMeta{
+			MessageID: "m1",
+			Sender:    Participant{Account: "alice", EngName: "Alice", DisplayName: "Alice A"},
+			CreatedAt: created,
+			Mentions:  []Participant{{Account: "bob"}},
+			VisibleTo: "alice",
+		},
+		PreviewCiphertext: []byte{0xde, 0xad, 0xbe, 0xef},
+		PreviewNonce:      []byte{0x01, 0x02, 0x03},
+		PreviewKeyEpoch:   2,
+		PreviewForMsgID:   "m2",
+		PreviewAsOf:       1754388000000,
+	}
+}
+
+// The stored preview must persist under camelCase BSON keys — the doc shape
+// history-service's projection reads back — and round-trip losslessly.
+func TestRoom_PreviewFields_BSONRoundTrip(t *testing.T) {
+	room := samplePreviewRoom()
+
+	raw, err := bson.Marshal(room)
+	require.NoError(t, err)
+
+	var doc bson.M
+	require.NoError(t, bson.Unmarshal(raw, &doc))
+
+	metaVal, ok := doc["previewMeta"]
+	require.True(t, ok, "previewMeta key missing: %v", doc)
+	meta := toMap(metaVal)
+	require.NotNil(t, meta, "previewMeta could not be converted to map")
+
+	assert.Equal(t, "m1", meta["messageId"])
+	assert.Contains(t, meta, "createdAt")
+	assert.Contains(t, meta, "sender")
+	assert.Equal(t, "alice", meta["visibleTo"])
+
+	// The sealed body is never stored in the clear: no content/attachments key
+	// may appear anywhere in the plaintext meta subdocument.
+	assert.NotContains(t, meta, "content")
+	assert.NotContains(t, meta, "attachments")
+
+	assert.Contains(t, doc, "previewCiphertext")
+	assert.Contains(t, doc, "previewNonce")
+	assert.EqualValues(t, 2, doc["previewKeyEpoch"])
+	assert.Equal(t, "m2", doc["previewForMsgId"])
+	assert.EqualValues(t, 1754388000000, doc["previewAsOf"])
+
+	var back Room
+	require.NoError(t, bson.Unmarshal(raw, &back))
+	assert.Equal(t, room.PreviewMeta, back.PreviewMeta)
+	assert.Equal(t, room.PreviewCiphertext, back.PreviewCiphertext)
+	assert.Equal(t, room.PreviewNonce, back.PreviewNonce)
+	assert.Equal(t, room.PreviewKeyEpoch, back.PreviewKeyEpoch)
+	assert.Equal(t, room.PreviewForMsgID, back.PreviewForMsgID)
+	assert.Equal(t, room.PreviewAsOf, back.PreviewAsOf)
+}
+
+// Every stored preview field is storage-only: clients receive a preview through
+// the rooms.get reply and message events, never through Room.
+func TestRoom_PreviewFields_NotInJSON(t *testing.T) {
+	b, err := json.Marshal(samplePreviewRoom())
+	require.NoError(t, err)
+
+	for _, key := range []string{
+		"previewMeta", "previewCiphertext", "previewNonce",
+		"previewKeyEpoch", "previewForMsgId", "previewAsOf",
+	} {
+		assert.NotContains(t, string(b), key, "%s must not be serialized to clients", key)
+	}
+}
+
+// An unwarmed room stores no preview fragment at all — omitempty must keep
+// every key out of the document rather than writing zero values.
+func TestRoom_PreviewFields_OmittedWhenUnset(t *testing.T) {
+	raw, err := bson.Marshal(Room{ID: "room-1"})
+	require.NoError(t, err)
+
+	var doc bson.M
+	require.NoError(t, bson.Unmarshal(raw, &doc))
+
+	for _, key := range []string{
+		"previewMeta", "previewCiphertext", "previewNonce",
+		"previewKeyEpoch", "previewForMsgId", "previewAsOf",
+	} {
+		assert.NotContains(t, doc, key)
+	}
+}
+
+// PreviewMeta carries precisely the fields Cassandra leaves unencrypted.
+func TestPreviewMeta_BSONRoundTrip(t *testing.T) {
+	meta := PreviewMeta{
+		MessageID: "m1",
+		Sender:    Participant{Account: "alice"},
+		CreatedAt: time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC),
+		Mentions:  []Participant{{Account: "bob"}, {Account: "carol"}},
+		VisibleTo: "alice",
+	}
+
+	raw, err := bson.Marshal(meta)
+	require.NoError(t, err)
+
+	var back PreviewMeta
+	require.NoError(t, bson.Unmarshal(raw, &back))
+	assert.Equal(t, meta, back)
+}

--- a/pkg/preview/preview.go
+++ b/pkg/preview/preview.go
@@ -1,0 +1,124 @@
+// Package preview builds, seals and stores the room-list preview. Every path
+// that produces one runs through here — history-service's read-time walk, its
+// warm-back, and its post-mutation writes — so the shape is identical
+// regardless of origin.
+//
+// A stored preview is split: the metadata Cassandra also leaves unencrypted
+// stays clear so the freshness check and the guarded write can work
+// server-side, while the user-authored body is sealed under a per-site DEK
+// (see Seal). Writes land through the watermark-guarded field sets so an
+// out-of-order redelivery cannot overwrite a newer preview.
+package preview
+
+import (
+	"context"
+	"log/slog"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/hmchangw/chat/pkg/displayfmt"
+	"github.com/hmchangw/chat/pkg/model"
+)
+
+// MaxContentRunes caps PreviewMessage.Content: the room list renders a snippet,
+// so persisting/shipping the full (≤20KB) body is pure waste.
+const MaxContentRunes = 500
+
+// Build normalizes a composed preview into its wire/storage form, truncating
+// content and forcing the timestamp to UTC. Callers assemble the raw fields;
+// taking model.PreviewMessage itself (rather than a parallel params struct)
+// keeps a newly added field from silently defaulting on every write path.
+// Sender must arrive with DisplayName already bot-aware resolved
+// (BotAwareDisplayName).
+//
+//nolint:gocritic // hugeParam: PreviewMessage is the stored/wire shape itself; by-value keeps callers simple and the copy cost is negligible.
+func Build(p model.PreviewMessage) model.PreviewMessage {
+	p.Content = truncateContent(p.Content)
+	p.CreatedAt = p.CreatedAt.UTC()
+	return p
+}
+
+// truncateContent caps s at MaxContentRunes runes (never splitting a rune).
+func truncateContent(s string) string {
+	// Byte length bounds rune count, so the common short message needs no scan.
+	if len(s) <= MaxContentRunes {
+		return s
+	}
+	r := []rune(s)
+	if len(r) <= MaxContentRunes {
+		// Multi-byte but within the cap — return s rather than re-encoding it.
+		return s
+	}
+	// string() copies, which is the point: slicing s would alias its backing
+	// array, pinning a whole 20KB body behind a 500-rune snippet for as long as
+	// the preview sits in the cache.
+	return string(r[:MaxContentRunes])
+}
+
+// AppNameLookup resolves a bot account's app display name; ("", nil) means no
+// app matches.
+type AppNameLookup func(ctx context.Context, botAccount string) (string, error)
+
+// BotAwareDisplayName composes a render-ready name; for a bot account it
+// prefers the app's display name, degrading to the composed name on
+// miss/error/nil lookup.
+func BotAwareDisplayName(ctx context.Context, lookup AppNameLookup, engName, chineseName, account string) string {
+	name := displayfmt.CombineWithFallback(engName, chineseName, account)
+	if model.IsBot(account) && lookup != nil {
+		if appName, err := lookup(ctx, account); err != nil {
+			slog.WarnContext(ctx, "app name lookup failed, using composed name", "account", account, "error", err)
+		} else if appName != "" {
+			name = appName
+		}
+	}
+	return name
+}
+
+// previewDocFields is the one list of room-doc keys making up a stored preview.
+// Both write paths iterate it so they cannot drift and strand a fragment — a
+// nonce and epoch describing a ciphertext that no longer exists. previewAsOf is
+// absent by design: it is the watermark, and advances on every landing write.
+var previewDocFields = []string{
+	"previewMeta",
+	"previewCiphertext",
+	"previewNonce",
+	"previewKeyEpoch",
+	"previewForMsgId",
+}
+
+// guardedFields builds the watermark-guarded $set shared by the set and clear
+// paths: each field becomes onPass[field] when asOf >= the stored previewAsOf
+// (missing => 0; ties => last writer wins), and previewAsOf advances with it.
+func guardedFields(asOf int64, onPass map[string]any) bson.M {
+	cond := bson.M{"$gte": bson.A{asOf, bson.M{"$ifNull": bson.A{"$previewAsOf", 0}}}}
+	out := bson.M{"previewAsOf": bson.M{"$cond": bson.A{cond, asOf, "$previewAsOf"}}}
+	for _, f := range previewDocFields {
+		out[f] = bson.M{"$cond": bson.A{cond, onPass[f], "$" + f}}
+	}
+	return out
+}
+
+// GuardedSetFields returns the $set fields applying s+asOf under the watermark
+// guard. $literal keeps a "$"-prefixed value (e.g. a display name) from being
+// evaluated as a field path.
+//
+//nolint:gocritic // hugeParam: Sealed is the stored shape itself; by-value matches Seal/Open.
+func GuardedSetFields(s Sealed, asOf int64) bson.M {
+	return guardedFields(asOf, map[string]any{
+		"previewMeta":       bson.M{"$literal": s.Meta},
+		"previewCiphertext": bson.M{"$literal": s.Ciphertext},
+		"previewNonce":      bson.M{"$literal": s.Nonce},
+		"previewKeyEpoch":   bson.M{"$literal": s.KeyEpoch},
+		"previewForMsgId":   bson.M{"$literal": s.ForMsgID},
+	})
+}
+
+// GuardedClearFields REMOVES every stored preview field under the same guard,
+// still advancing previewAsOf so an older redelivery cannot resurrect it.
+func GuardedClearFields(asOf int64) bson.M {
+	onPass := make(map[string]any, len(previewDocFields))
+	for _, f := range previewDocFields {
+		onPass[f] = "$$REMOVE"
+	}
+	return guardedFields(asOf, onPass)
+}

--- a/pkg/preview/preview_test.go
+++ b/pkg/preview/preview_test.go
@@ -1,0 +1,169 @@
+package preview
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/hmchangw/chat/pkg/model"
+)
+
+func TestTruncateContent(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"short passes through", "hello", "hello"},
+		{"exactly at cap unchanged", strings.Repeat("a", MaxContentRunes), strings.Repeat("a", MaxContentRunes)},
+		{"over cap truncated", strings.Repeat("a", MaxContentRunes+1), strings.Repeat("a", MaxContentRunes)},
+		{"multi-byte runes counted as runes not bytes", strings.Repeat("好", MaxContentRunes+3), strings.Repeat("好", MaxContentRunes)},
+		// 3 bytes per rune, so this is 3x over the cap in BYTES but exactly at it
+		// in runes: it must come back untouched.
+		{"multi-byte exactly at cap unchanged", strings.Repeat("好", MaxContentRunes), strings.Repeat("好", MaxContentRunes)},
+		{"multi-byte over the byte cap but under the rune cap", strings.Repeat("好", 200), strings.Repeat("好", 200)},
+		{"empty stays empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, truncateContent(tt.in))
+		})
+	}
+}
+
+func TestBuild_TruncatesAndNormalizesUTC(t *testing.T) {
+	loc, err := time.LoadLocation("Asia/Taipei")
+	require.NoError(t, err)
+	long := strings.Repeat("x", MaxContentRunes+50)
+	got := Build(model.PreviewMessage{
+		MessageID: "m1",
+		Sender:    model.Participant{Account: "alice"},
+		Content:   long,
+		CreatedAt: time.Date(2026, 8, 5, 18, 0, 0, 0, loc),
+		VisibleTo: "alice",
+	})
+	assert.Equal(t, "m1", got.MessageID)
+	assert.Equal(t, strings.Repeat("x", MaxContentRunes), got.Content)
+	assert.Equal(t, time.UTC, got.CreatedAt.Location())
+	assert.Equal(t, "alice", got.VisibleTo)
+}
+
+func TestBotAwareDisplayName(t *testing.T) {
+	appName := func(name string, err error) AppNameLookup {
+		return func(context.Context, string) (string, error) { return name, err }
+	}
+	tests := []struct {
+		name    string
+		account string
+		lookup  AppNameLookup
+		want    string
+	}{
+		// displayfmt.CombineWithFallback(eng, chinese, account) composes the
+		// human name; assert against its real output for ("Alice","愛麗絲",...).
+		{"human ignores lookup", "alice", appName("ShouldNotAppear", nil), ""},
+		{"bot uses app name", "helper.bot", appName("Helper App", nil), "Helper App"},
+		{"bot lookup error falls back composed", "helper.bot", appName("", errors.New("db down")), ""},
+		{"bot empty app name falls back composed", "helper.bot", appName("", nil), ""},
+		{"nil lookup falls back composed", "helper.bot", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BotAwareDisplayName(context.Background(), tt.lookup, "Alice", "愛麗絲", tt.account)
+			if tt.want == "" {
+				// Fallback path: must equal the composed name, not the app name.
+				composed := BotAwareDisplayName(context.Background(), nil, "Alice", "愛麗絲", "alice")
+				assert.Equal(t, composed, got)
+				assert.NotContains(t, got, "ShouldNotAppear")
+			} else {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+// NOTE: "helper.bot" carries model.IsBot's recognized suffix (".bot").
+
+// assertGuard checks the shared watermark rule: asOf >= $ifNull(previewAsOf, 0).
+func assertGuard(t *testing.T, cond bson.A, asOf int64) {
+	t.Helper()
+	gte := cond[0].(bson.M)["$gte"].(bson.A)
+	assert.EqualValues(t, asOf, gte[0])
+	ifNull := gte[1].(bson.M)["$ifNull"].(bson.A)
+	assert.Equal(t, "$previewAsOf", ifNull[0])
+	assert.EqualValues(t, 0, ifNull[1])
+}
+
+func TestGuardedSetFields_Shape(t *testing.T) {
+	sealed := Sealed{
+		Meta:       model.PreviewMeta{MessageID: "m1", Sender: model.Participant{DisplayName: "$notAFieldPath"}},
+		Ciphertext: []byte{0x01},
+		Nonce:      []byte{0x02},
+		KeyEpoch:   3,
+		ForMsgID:   "m2",
+	}
+	fields := GuardedSetFields(sealed, 1754388000000)
+
+	require.Contains(t, fields, "previewAsOf")
+	for _, f := range previewDocFields {
+		require.Contains(t, fields, f)
+
+		cond := fields[f].(bson.M)["$cond"].(bson.A)
+		// Every stored value is $literal-wrapped so a "$"-prefixed string is
+		// never evaluated as an aggregation field path.
+		_, hasLiteral := cond[1].(bson.M)["$literal"]
+		assert.True(t, hasLiteral, "%s must be $literal-wrapped", f)
+		// Guard failure leaves the existing value untouched.
+		assert.Equal(t, "$"+f, cond[2], "%s must be preserved when the guard fails", f)
+		assertGuard(t, cond, 1754388000000)
+	}
+
+	asOfCond := fields["previewAsOf"].(bson.M)["$cond"].(bson.A)
+	assert.EqualValues(t, 1754388000000, asOfCond[1])
+	assert.Equal(t, "$previewAsOf", asOfCond[2])
+}
+
+func TestGuardedClearFields_Shape(t *testing.T) {
+	fields := GuardedClearFields(1754388000000)
+
+	require.Contains(t, fields, "previewAsOf")
+	for _, f := range previewDocFields {
+		require.Contains(t, fields, f)
+
+		cond := fields[f].(bson.M)["$cond"].(bson.A)
+		assert.Equal(t, "$$REMOVE", cond[1], "%s must be dropped, not written empty", f)
+		assert.Equal(t, "$"+f, cond[2], "%s must be preserved when the guard fails", f)
+		assertGuard(t, cond, 1754388000000)
+	}
+
+	// previewAsOf still advances on clear, so a redelivered older write can't
+	// resurrect the cleared preview.
+	asOfCond := fields["previewAsOf"].(bson.M)["$cond"].(bson.A)
+	assert.EqualValues(t, 1754388000000, asOfCond[1])
+	assert.Equal(t, "$previewAsOf", asOfCond[2])
+}
+
+// Set and clear must touch exactly the same keys, or a partial clear strands a
+// fragment: a nonce and epoch describing a ciphertext that no longer exists.
+func TestGuardedSetAndClear_CoverIdenticalFields(t *testing.T) {
+	set := GuardedSetFields(Sealed{}, 1)
+	clear := GuardedClearFields(1)
+
+	setKeys := make([]string, 0, len(set))
+	for k := range set {
+		setKeys = append(setKeys, k)
+	}
+	clearKeys := make([]string, 0, len(clear))
+	for k := range clear {
+		clearKeys = append(clearKeys, k)
+	}
+	assert.ElementsMatch(t, setKeys, clearKeys)
+
+	// And both cover the canonical list plus the watermark itself.
+	assert.Len(t, setKeys, len(previewDocFields)+1)
+}

--- a/pkg/preview/seal.go
+++ b/pkg/preview/seal.go
@@ -1,0 +1,133 @@
+package preview
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/hmchangw/chat/pkg/atrest"
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/model/cassandra"
+)
+
+// Key identifies the preview DEK: one per site per epoch, shared by every room.
+// Per-room keys are the wrong granularity — preview reads enumerate up to 1000
+// rooms at once, the cold-tail scan atrest's 2Q DEK cache resists rather than
+// serves.
+//
+// This key must never seal message bodies: it sees far more GCM invocations than
+// a per-room DEK, and a nonce collision would leak the GHASH subkey for
+// everything under it.
+type Key struct {
+	SiteID string
+	Epoch  int
+}
+
+// ID renders the sentinel atrest takes in place of a roomID. The colon cannot
+// collide with a room id (base62, 32-char hex, or a concat of those).
+func (k Key) ID() string {
+	return "preview:" + k.SiteID + ":" + strconv.Itoa(k.Epoch)
+}
+
+// Sealed is a stored room preview: the plaintext half Cassandra also leaves
+// unencrypted, plus the sealed body and the material to open it.
+//
+// ForMsgID is the freshness key, supplied by the caller — the newest message id
+// the walk OBSERVED, not Meta.MessageID.
+type Sealed struct {
+	Meta       model.PreviewMeta
+	Ciphertext []byte
+	Nonce      []byte
+	KeyEpoch   int
+	ForMsgID   string
+}
+
+// marshalAttachment is a seam over json.Marshal keeping encodeAttachments' error
+// path reachable in tests; marshalling a plain Attachment cannot fail in practice.
+var marshalAttachment = json.Marshal
+
+// Seal splits p into plaintext meta and an encrypted body, sealing the two fields
+// atrest treats as user-authored (Content, Attachments) under k. The rest stays
+// clear — message-worker already writes it to plaintext Cassandra columns.
+//
+//nolint:gocritic // hugeParam: PreviewMessage is the wire shape itself; by-value keeps callers simple and the copy cost is negligible.
+func Seal(ctx context.Context, c atrest.Cipher, k Key, forMsgID string, p model.PreviewMessage) (Sealed, error) {
+	atts, err := encodeAttachments(p.Attachments)
+	if err != nil {
+		return Sealed{}, fmt.Errorf("encode preview attachments: %w", err)
+	}
+
+	ciphertext, meta, err := c.Encrypt(ctx, k.ID(), atrest.EncryptedFields{
+		Msg:         p.Content,
+		Attachments: atts,
+	})
+	if err != nil {
+		return Sealed{}, fmt.Errorf("seal preview body: %w", err)
+	}
+
+	return Sealed{
+		Meta: model.PreviewMeta{
+			MessageID: p.MessageID,
+			Sender:    p.Sender,
+			CreatedAt: p.CreatedAt,
+			Mentions:  p.Mentions,
+			VisibleTo: p.VisibleTo,
+		},
+		Ciphertext: ciphertext,
+		Nonce:      meta.Nonce,
+		KeyEpoch:   k.Epoch,
+		ForMsgID:   forMsgID,
+	}, nil
+}
+
+// Open is the inverse of Seal. The DEK comes from s.KeyEpoch, so a reader on a
+// different epoch never reaches a retired key; callers check the epoch first.
+//
+//nolint:gocritic // hugeParam: Sealed is the stored shape itself; by-value matches Seal's signature.
+func Open(ctx context.Context, c atrest.Cipher, siteID string, s Sealed) (model.PreviewMessage, error) {
+	k := Key{SiteID: siteID, Epoch: s.KeyEpoch}
+
+	fields, err := c.Decrypt(ctx, k.ID(), s.Ciphertext, atrest.EncMeta{Nonce: s.Nonce})
+	if err != nil {
+		return model.PreviewMessage{}, fmt.Errorf("open preview body: %w", err)
+	}
+
+	atts, skipped := cassandra.DecodeAttachments(fields.Attachments)
+	if skipped > 0 {
+		// Derived data: a mangled blob costs a render detail, not the preview.
+		// Worth logging — we sealed these, so a skip means storage corruption.
+		slog.WarnContext(ctx, "preview attachment blob undecodable",
+			"messageId", s.Meta.MessageID, "skipped", skipped)
+	}
+
+	return model.PreviewMessage{
+		MessageID:   s.Meta.MessageID,
+		Sender:      s.Meta.Sender,
+		Content:     fields.Msg,
+		CreatedAt:   s.Meta.CreatedAt,
+		Attachments: atts,
+		Mentions:    s.Meta.Mentions,
+		VisibleTo:   s.Meta.VisibleTo,
+	}, nil
+}
+
+// encodeAttachments marshals each attachment into the [][]byte form atrest stores
+// natively. Unlike cassandra.EncodeAttachments it fails the batch rather than
+// skipping a bad element: a dropped attachment in a sealed preview is
+// indistinguishable downstream from one that never existed.
+func encodeAttachments(atts []cassandra.Attachment) ([][]byte, error) {
+	if len(atts) == 0 {
+		return nil, nil
+	}
+	out := make([][]byte, 0, len(atts))
+	for i := range atts {
+		b, err := marshalAttachment(atts[i])
+		if err != nil {
+			return nil, fmt.Errorf("attachment %d: %w", i, err)
+		}
+		out = append(out, b)
+	}
+	return out, nil
+}

--- a/pkg/preview/seal_test.go
+++ b/pkg/preview/seal_test.go
@@ -1,0 +1,241 @@
+package preview
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/atrest"
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/model/cassandra"
+)
+
+// fakeCipher is a real AES-GCM cipher keyed by sha256(keyID), so a wrong-key
+// open fails authentication for the same reason the production cipher would.
+type fakeCipher struct {
+	encErr error
+	decErr error
+}
+
+func aeadFor(keyID string) (cipher.AEAD, error) {
+	sum := sha256.Sum256([]byte(keyID))
+	block, err := aes.NewCipher(sum[:])
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}
+
+func (f fakeCipher) Encrypt(_ context.Context, keyID string, fields atrest.EncryptedFields) ([]byte, atrest.EncMeta, error) { //nolint:gocritic // hugeParam: matches the atrest.Cipher interface
+	if f.encErr != nil {
+		return nil, atrest.EncMeta{}, f.encErr
+	}
+	plaintext, err := json.Marshal(fields)
+	if err != nil {
+		return nil, atrest.EncMeta{}, err
+	}
+	gcm, err := aeadFor(keyID)
+	if err != nil {
+		return nil, atrest.EncMeta{}, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, atrest.EncMeta{}, err
+	}
+	return gcm.Seal(nil, nonce, plaintext, nil), atrest.EncMeta{Nonce: nonce}, nil
+}
+
+func (f fakeCipher) Decrypt(_ context.Context, keyID string, payload []byte, meta atrest.EncMeta) (atrest.EncryptedFields, error) { //nolint:gocritic // hugeParam: matches the atrest.Cipher interface
+	if f.decErr != nil {
+		return atrest.EncryptedFields{}, f.decErr
+	}
+	gcm, err := aeadFor(keyID)
+	if err != nil {
+		return atrest.EncryptedFields{}, err
+	}
+	plaintext, err := gcm.Open(nil, meta.Nonce, payload, nil)
+	if err != nil {
+		return atrest.EncryptedFields{}, atrest.ErrAuthFailed
+	}
+	var out atrest.EncryptedFields
+	if err := json.Unmarshal(plaintext, &out); err != nil {
+		return atrest.EncryptedFields{}, atrest.ErrPayloadMalformed
+	}
+	return out, nil
+}
+
+func (f fakeCipher) EnsureDEK(context.Context, string) error { return nil }
+
+func samplePreview() model.PreviewMessage {
+	return model.PreviewMessage{
+		MessageID: "msg-1",
+		Sender:    model.Participant{Account: "alice", EngName: "Alice", DisplayName: "Alice A"},
+		Content:   "the quick brown fox",
+		CreatedAt: time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC),
+		Attachments: []cassandra.Attachment{{
+			ID: "f1", Title: "pic.png", Type: "image", TitleLink: "/f1",
+			FileType: "image/png", ImageURL: "/f1/img", ImageSize: 42,
+			ImageDimensions: &cassandra.ImageDimensions{Width: 10, Height: 20},
+		}},
+		Mentions:  []model.Participant{{Account: "bob"}},
+		VisibleTo: "alice",
+	}
+}
+
+func TestKey_ID(t *testing.T) {
+	assert.Equal(t, "preview:site-a:1", Key{SiteID: "site-a", Epoch: 1}.ID())
+	assert.Equal(t, "preview:site-a:7", Key{SiteID: "site-a", Epoch: 7}.ID())
+
+	// A different epoch must select a different DEK, or rotation is a no-op.
+	assert.NotEqual(t, Key{SiteID: "s", Epoch: 1}.ID(), Key{SiteID: "s", Epoch: 2}.ID())
+
+	// The sentinel must not collide with a room id. Room ids are base62
+	// (channel/message), 32-char hex (UUIDv7), or a concat of two of those —
+	// none can contain a colon.
+	assert.Contains(t, Key{SiteID: "s", Epoch: 1}.ID(), ":")
+}
+
+func TestSeal_Open_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	key := Key{SiteID: "site-a", Epoch: 1}
+	pvw := samplePreview()
+
+	sealed, err := Seal(ctx, fakeCipher{}, key, "msg-2", pvw)
+	require.NoError(t, err)
+
+	// Freshness key is what the caller observed, independent of the preview's
+	// own message id.
+	assert.Equal(t, "msg-2", sealed.ForMsgID)
+	assert.Equal(t, 1, sealed.KeyEpoch)
+	assert.NotEmpty(t, sealed.Ciphertext)
+	assert.NotEmpty(t, sealed.Nonce)
+
+	got, err := Open(ctx, fakeCipher{}, key.SiteID, sealed)
+	require.NoError(t, err)
+	assert.Equal(t, pvw, got)
+}
+
+func TestSeal_RoundTripWithoutAttachments(t *testing.T) {
+	ctx := context.Background()
+	key := Key{SiteID: "site-a", Epoch: 1}
+	pvw := samplePreview()
+	pvw.Attachments = nil
+
+	sealed, err := Seal(ctx, fakeCipher{}, key, "msg-1", pvw)
+	require.NoError(t, err)
+
+	got, err := Open(ctx, fakeCipher{}, key.SiteID, sealed)
+	require.NoError(t, err)
+	assert.Equal(t, pvw, got)
+	assert.Nil(t, got.Attachments)
+}
+
+// The body must leave the process sealed: neither the plaintext meta nor the
+// ciphertext may expose Content or attachment titles.
+func TestSeal_BodyNeverStoredInClear(t *testing.T) {
+	sealed, err := Seal(context.Background(), fakeCipher{}, Key{SiteID: "site-a", Epoch: 1}, "msg-1", samplePreview())
+	require.NoError(t, err)
+
+	// Meta carries exactly the fields Cassandra leaves unencrypted.
+	assert.Equal(t, "msg-1", sealed.Meta.MessageID)
+	assert.Equal(t, "alice", sealed.Meta.Sender.Account)
+	assert.Equal(t, []model.Participant{{Account: "bob"}}, sealed.Meta.Mentions)
+	assert.Equal(t, "alice", sealed.Meta.VisibleTo)
+
+	assert.False(t, bytes.Contains(sealed.Ciphertext, []byte("the quick brown fox")),
+		"message body must not survive in the ciphertext")
+	assert.False(t, bytes.Contains(sealed.Ciphertext, []byte("pic.png")),
+		"attachment title must not survive in the ciphertext")
+}
+
+// Meta.MessageID is the preview's own id, which differs from ForMsgID whenever
+// the newest message was ineligible and skipped by the walk.
+func TestSeal_MetaMessageIDIsIndependentOfForMsgID(t *testing.T) {
+	sealed, err := Seal(context.Background(), fakeCipher{}, Key{SiteID: "s", Epoch: 1}, "newest-99", samplePreview())
+	require.NoError(t, err)
+
+	assert.Equal(t, "msg-1", sealed.Meta.MessageID)
+	assert.Equal(t, "newest-99", sealed.ForMsgID)
+}
+
+func TestOpen_WrongKey(t *testing.T) {
+	ctx := context.Background()
+	sealed, err := Seal(ctx, fakeCipher{}, Key{SiteID: "site-a", Epoch: 1}, "msg-1", samplePreview())
+	require.NoError(t, err)
+
+	t.Run("different epoch", func(t *testing.T) {
+		wrong := sealed
+		wrong.KeyEpoch = 2 // selects preview:site-a:2, a different DEK
+		_, err := Open(ctx, fakeCipher{}, "site-a", wrong)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, atrest.ErrAuthFailed)
+	})
+
+	t.Run("different site", func(t *testing.T) {
+		_, err := Open(ctx, fakeCipher{}, "site-b", sealed)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, atrest.ErrAuthFailed)
+	})
+}
+
+// A mangled attachment blob costs a render detail, not the whole preview:
+// previews are derived data, so Open degrades rather than failing.
+func TestOpen_UndecodableAttachmentSkipped(t *testing.T) {
+	ctx := context.Background()
+	key := Key{SiteID: "site-a", Epoch: 1}
+
+	ciphertext, meta, err := fakeCipher{}.Encrypt(ctx, key.ID(), atrest.EncryptedFields{
+		Msg:         "hello",
+		Attachments: [][]byte{[]byte("{not json")},
+	})
+	require.NoError(t, err)
+
+	got, err := Open(ctx, fakeCipher{}, key.SiteID, Sealed{
+		Meta:       model.PreviewMeta{MessageID: "m1"},
+		Ciphertext: ciphertext,
+		Nonce:      meta.Nonce,
+		KeyEpoch:   key.Epoch,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "hello", got.Content)
+	assert.Empty(t, got.Attachments)
+}
+
+func TestSeal_AttachmentMarshalError(t *testing.T) {
+	boom := errors.New("marshal exploded")
+	orig := marshalAttachment
+	marshalAttachment = func(any) ([]byte, error) { return nil, boom }
+	t.Cleanup(func() { marshalAttachment = orig })
+
+	_, err := Seal(context.Background(), fakeCipher{}, Key{SiteID: "s", Epoch: 1}, "msg-1", samplePreview())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, boom)
+}
+
+func TestSeal_CipherError(t *testing.T) {
+	boom := errors.New("vault down")
+	_, err := Seal(context.Background(), fakeCipher{encErr: boom}, Key{SiteID: "s", Epoch: 1}, "msg-1", samplePreview())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, boom)
+}
+
+func TestOpen_CipherError(t *testing.T) {
+	ctx := context.Background()
+	sealed, err := Seal(ctx, fakeCipher{}, Key{SiteID: "s", Epoch: 1}, "msg-1", samplePreview())
+	require.NoError(t, err)
+
+	boom := errors.New("vault down")
+	_, err = Open(ctx, fakeCipher{decErr: boom}, "s", sealed)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, boom)
+}

--- a/search-service/integration_index_test.go
+++ b/search-service/integration_index_test.go
@@ -6,11 +6,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hmchangw/chat/pkg/testutil"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/hmchangw/chat/pkg/testutil"
 )
 
 // EnsureIndexes must not conflict with the canonical UNIQUE users.account_1 index


### PR DESCRIPTION
## Summary

Memoizes each room's last eligible preview message on the Mongo room doc so the common
room-list read stops walking Cassandra.

The cost being attacked is **the walk**, not the RPC. Resolving a preview scans
`messages_by_room` backwards from the tail across bucketed partitions, skipping
ineligible messages (system type, deleted, hidden thread replies) up to a 250-message
budget — per room, for every room in a list. A 1000-room list costs ~1000 walks and one
RPC. This removes the walks and keeps the RPC.

Design doc: `docs/superpowers/specs/2026-08-05-room-preview-denormalization-design.md`,
which also carries the decision log for how this arrived at the shape below.

## Shape

**`history-service` owns the preview outright — sole writer, sole reader.** The stored
preview is an internal memo of that service's own walk, never a field other services
read. This is what keeps the change small: no cross-service write contract, no read
flag, no coordination between a writer worker and a reader service. `broadcast-worker/`
and `user-service/` are untouched by this PR.

**The body is encrypted at rest; the metadata is not.** Messages are already encrypted
in Cassandra, so persisting a plaintext copy of the body in Mongo would have created
exposure the system does not otherwise accept. The preview is therefore split:

- `previewMeta` (message id, sender, createdAt, mentions, visibleTo) stays plaintext —
  precisely the fields Cassandra also leaves unencrypted, so storing them introduces no
  new classification.
- Content and attachments are sealed into `previewCiphertext` + `previewNonce` under a
  site preview DEK.

**The preview DEK is separate from the message DEKs, sharing one Vault KEK.** A single
site-wide key sees far more GCM invocations than a per-room DEK, and a nonce collision
under it would expose the GHASH subkey for everything that key protects — so it must
never seal message bodies. It lives in its own `preview_deks` collection off the
existing Vault wrapper, so no human ever creates or holds key material.

**Rotation is an ops action, not a background job.** `PREVIEW_KEY_EPOCH` (validated
`&gt;= 1`) selects the key. A reader on a different epoch treats the stored preview as
absent and re-resolves, so no reader ever needs a retired key and no migration is
required — previews churn self-correctingly through a rolling deploy.

## Freshness

`previewForMsgId` is the freshness key: the newest message id the resolving walk
**observed** in Cassandra. The preview is current iff it equals `room.lastMsgId`. It is
deliberately *not* `previewMeta.messageId` — the two differ whenever the newest message
is ineligible and gets skipped, and keying on the latter would re-walk forever on a room
whose newest message is a system message.

`previewAsOf` is a separate write-ordering watermark, compared server-side inside the
update pipeline so a late write cannot clobber a newer one. It stays plaintext because
the guard has to evaluate it.

Reads resolve in three tiers: a current stored preview, else the walk, else degraded.
A walk that resolves persists its result best-effort (warm-back). A walk that degrades
writes nothing, so a transient Cassandra failure never overwrites good stored state.

## Write amplification

One write per room per message, not per subscription — a 10,000-member room costs the
same single write as a two-person DM.

## Reviewing this

Seven commits, each building and vetting on its own, in dependency order:

| Commit | Contents |
|---|---|
| `docs:` design spec | The design and its decision log. Read first. |
| `feat(model):` | `Room` gains the storage-only preview fields; `PreviewMeta` added; `PreviewMessage` returns to a pure wire type, never stored. |
| `feat(preview):` | `Sealed`, `Key`, `Seal`/`Open`, and watermark guards that iterate one `previewDocFields` list so set and clear cannot drift. Plus `Build`, `TruncateContent`, `BotAwareDisplayName`. |
| `feat(history-service):` persist | The preview DEK (`preview_deks`, `PREVIEW_KEY_EPOCH`, pinned to primary) and the room repo that projects/unseals. These ride together because threading the cipher changes `NewRoomRepo`'s signature. |
| `feat(history-service):` resolve | Batched read, three-tier resolve, warm-back, and delete-path clearing. |
| `docs(client-api):` | Preview content is a server-truncated 500-rune snippet. |
| `chore(search-service):` | Unrelated one-line goimports fix. |

## Verification

`make lint` (0 issues), `make test` (full suite, `-race`), `make sast` (gosec,
govulncheck, semgrep) all pass. `go vet -tags=integration ./...` is clean, and every
commit in the series builds and vets independently.

## Not in scope

- Automated key rotation — the epoch knob is deliberately manual.
- `visibleTo` remains a per-room field; whether a preview should be per-user is an open
  design question tracked separately.
- The pre-existing `rooms.get` batch-cap behaviour above 100 rooms is untouched and gets
  its own PR.

https://claude.ai/code/session_01EAJXUUvE9JtCisPHSunLGc

## Summary by CodeRabbit

- **New Features**
  - Added faster, more reliable room previews with cached results and automatic fallback when needed.
  - Preview updates remain accurate during message edits and deletions, avoiding stale results.
  - Bot previews can use configured app display names with sensible fallbacks.
  - Preview content and attachments are protected with encryption at rest.

- **Bug Fixes**
  - Preview text is consistently limited to 500 Unicode characters without splitting multibyte characters.

- **Documentation**
  - Updated the client API documentation to describe the server-generated preview snippet behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Room previews now load faster and remain up to date after message edits or deletions.
  - Preview content is safely limited to 500 characters while preserving multibyte text correctly.
  - Previews can recover gracefully when cached data is unavailable or invalid.
  - Bot display names use configured app names when available, with a fallback otherwise.

- **Bug Fixes**
  - Prevented stale or degraded preview results from overwriting valid previews.
  - Hidden thread replies remain excluded from room previews.

- **Documentation**
  - Updated the client API documentation to describe the server-generated 500-rune preview snippet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->