### PR TITLE
feat(cardaction): add bot_username to CardAction UDT

### DIFF
--- a/docker-local/cassandra/init/04-udt-card_action.cql
+++ b/docker-local/cassandra/init/04-udt-card_action.cql
@@ -5,5 +5,6 @@ CREATE TYPE IF NOT EXISTS chat."CardAction" (
   display_text  TEXT,
   hide_exec_log BOOLEAN,
   card_tmid     TEXT,
-  data          BLOB
+  data          BLOB,
+  bot_username  TEXT
 );

--- a/docker-local/cassandra/migrations/2026-08-cardaction-bot-username.cql
+++ b/docker-local/cassandra/migrations/2026-08-cardaction-bot-username.cql
@@ -1,0 +1,16 @@
+-- Add bot_username to the CardAction UDT.
+--
+-- The desktop / KR-backend client attaches a botUsername on the cardAction
+-- payload of a tcard_execute event to name the target bot for the callback.
+-- The column is optional and legacy card actions predate it (they read back
+-- as null); the change is additive and non-destructive.
+--
+-- Fresh / docker-local clusters get the field via the init script
+-- (docker-local/cassandra/init/04-udt-card_action.cql); this migration
+-- applies the same shape to a live cluster.
+--
+-- ALTER TYPE ADD is safe on a running cluster: existing rows do not need to
+-- be rewritten, and readers using the reflection-based UDT decoder ignore
+-- unknown fields on old rows.
+
+ALTER TYPE chat."CardAction" ADD bot_username TEXT;

--- a/docs/cassandra_message_model.md
+++ b/docs/cassandra_message_model.md
@@ -12,6 +12,7 @@ CREATE TYPE IF NOT EXISTS "Card"(
 #### CardAction
 ```cql
 CREATE TYPE IF NOT EXISTS "CardAction"(
+  bot_username TEXT,    // target bot for the tcard_execute callback (client-supplied on the cardAction payload); optional
   card_id TEXT,
   card_tmid TEXT,
   data BLOB,

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -2795,6 +2795,7 @@ message projection, keyed by `id`.
 | `hideExecLog` | boolean | Optional. Suppress the execution log entry. |
 | `cardTmId` | string | Optional. Card template ID. |
 | `data` | string | Optional. Base64-encoded action payload. |
+| `botUsername` | string | Optional. Username of the bot the action targets — the client sets it on a tcard_execute event so the server can route the callback. |
 
 ##### QuotedParentMessage
 

--- a/history-service/internal/cassrepo/integration_test.go
+++ b/history-service/internal/cassrepo/integration_test.go
@@ -20,7 +20,7 @@ func setupCassandra(t testing.TB) *gocql.Session {
 	for _, stmt := range []string{
 		cql(`CREATE TYPE IF NOT EXISTS %s."Participant" (id TEXT, eng_name TEXT, company_name TEXT, app_id TEXT, app_name TEXT, is_bot BOOLEAN, account TEXT)`),
 		cql(`CREATE TYPE IF NOT EXISTS %s."Card" (template TEXT, data BLOB)`),
-		cql(`CREATE TYPE IF NOT EXISTS %s."CardAction" (verb TEXT, text TEXT, card_id TEXT, display_text TEXT, hide_exec_log BOOLEAN, card_tmid TEXT, data BLOB)`),
+		cql(`CREATE TYPE IF NOT EXISTS %s."CardAction" (verb TEXT, text TEXT, card_id TEXT, display_text TEXT, hide_exec_log BOOLEAN, card_tmid TEXT, data BLOB, bot_username TEXT)`),
 		cql(`CREATE TYPE IF NOT EXISTS %s."QuotedParentMessage" (message_id TEXT, room_id TEXT, sender FROZEN<"Participant">, created_at TIMESTAMP, msg TEXT, mentions SET<FROZEN<"Participant">>, attachments LIST<BLOB>, message_link TEXT, thread_parent_id TEXT, thread_parent_created_at TIMESTAMP)`),
 		cql(`CREATE TYPE IF NOT EXISTS %s."EncMeta" (nonce BLOB)`),
 		cql(`CREATE TYPE IF NOT EXISTS %s.reaction_key (emoji TEXT, user_account TEXT)`),

--- a/history-service/internal/cassrepo/messages_by_id_integration_test.go
+++ b/history-service/internal/cassrepo/messages_by_id_integration_test.go
@@ -58,7 +58,7 @@ func TestRepository_FullRow_AllColumns(t *testing.T) {
 	sender := models.Participant{ID: "u1", EngName: "Alice", CompanyName: "Acme", AppID: "app1", AppName: "MyApp", IsBot: false, Account: "alice"}
 	mentionUser := models.Participant{ID: "u3", Account: "charlie"}
 	card := models.Card{Template: "approval", Data: []byte("card-data")}
-	cardAction := models.CardAction{Verb: "approve", Text: "Approve", CardID: "c1", DisplayText: "Click", HideExecLog: true, CardTmID: "tm1", Data: []byte("action-data")}
+	cardAction := models.CardAction{Verb: "approve", Text: "Approve", CardID: "c1", DisplayText: "Click", HideExecLog: true, CardTmID: "tm1", Data: []byte("action-data"), BotUsername: "expense-bot"}
 	quotedSender := models.Participant{ID: "u5", Account: "eve"}
 	quotedMsg := models.QuotedParentMessage{
 		MessageID: "m-quoted", RoomID: "r-full", Sender: quotedSender,
@@ -124,6 +124,7 @@ func TestRepository_FullRow_AllColumns(t *testing.T) {
 	assert.True(t, msg.CardAction.HideExecLog)
 	assert.Equal(t, "tm1", msg.CardAction.CardTmID)
 	assert.Equal(t, []byte("action-data"), msg.CardAction.Data)
+	assert.Equal(t, "expense-bot", msg.CardAction.BotUsername)
 
 	assert.True(t, msg.TShow)
 	assert.Equal(t, "m-parent", msg.ThreadParentID)

--- a/history-service/internal/cassrepo/thread_messages_integration_test.go
+++ b/history-service/internal/cassrepo/thread_messages_integration_test.go
@@ -162,7 +162,7 @@ func TestRepository_GetThreadMessages_ColumnScan(t *testing.T) {
 	sender := models.Participant{ID: "u1", EngName: "Alice", CompanyName: "Acme", AppID: "app1", AppName: "MyApp", IsBot: false, Account: "alice"}
 	mentionUser := models.Participant{ID: "u3", Account: "charlie"}
 	card := models.Card{Template: "approval", Data: []byte("card-data")}
-	cardAction := models.CardAction{Verb: "approve", Text: "Approve", CardID: "c1", DisplayText: "Click", HideExecLog: true, CardTmID: "tm1", Data: []byte("action-data")}
+	cardAction := models.CardAction{Verb: "approve", Text: "Approve", CardID: "c1", DisplayText: "Click", HideExecLog: true, CardTmID: "tm1", Data: []byte("action-data"), BotUsername: "expense-bot"}
 	quotedSender := models.Participant{ID: "u5", Account: "eve"}
 	quotedMsg := models.QuotedParentMessage{
 		MessageID: "m-quoted", RoomID: "r-thread-full", Sender: quotedSender,
@@ -237,6 +237,7 @@ func TestRepository_GetThreadMessages_ColumnScan(t *testing.T) {
 	assert.True(t, msg.CardAction.HideExecLog)
 	assert.Equal(t, "tm1", msg.CardAction.CardTmID)
 	assert.Equal(t, []byte("action-data"), msg.CardAction.Data)
+	assert.Equal(t, "expense-bot", msg.CardAction.BotUsername)
 
 	require.NotNil(t, msg.QuotedParentMessage)
 	assert.Equal(t, "m-quoted", msg.QuotedParentMessage.MessageID)

--- a/history-service/internal/service/integration_test.go
+++ b/history-service/internal/service/integration_test.go
@@ -36,7 +36,7 @@ func setupCassandra(t *testing.T) *gocql.Session {
 		cql(`CREATE TYPE IF NOT EXISTS %s."Participant" (id TEXT, eng_name TEXT, company_name TEXT, app_id TEXT, app_name TEXT, is_bot BOOLEAN, account TEXT)`),
 		cql(`CREATE TYPE IF NOT EXISTS %s."File" (id TEXT, name TEXT, type TEXT)`),
 		cql(`CREATE TYPE IF NOT EXISTS %s."Card" (template TEXT, data BLOB)`),
-		cql(`CREATE TYPE IF NOT EXISTS %s."CardAction" (verb TEXT, text TEXT, card_id TEXT, display_text TEXT, hide_exec_log BOOLEAN, card_tmid TEXT, data BLOB)`),
+		cql(`CREATE TYPE IF NOT EXISTS %s."CardAction" (verb TEXT, text TEXT, card_id TEXT, display_text TEXT, hide_exec_log BOOLEAN, card_tmid TEXT, data BLOB, bot_username TEXT)`),
 		cql(`CREATE TYPE IF NOT EXISTS %s."QuotedParentMessage" (message_id TEXT, room_id TEXT, sender FROZEN<"Participant">, created_at TIMESTAMP, msg TEXT, mentions SET<FROZEN<"Participant">>, attachments LIST<BLOB>, message_link TEXT, thread_parent_id TEXT, thread_parent_created_at TIMESTAMP)`),
 		cql(`CREATE TYPE IF NOT EXISTS %s."EncMeta" (nonce BLOB)`),
 		cql(`CREATE TYPE IF NOT EXISTS %s.reaction_key (emoji TEXT, user_account TEXT)`),

--- a/message-worker/integration_test.go
+++ b/message-worker/integration_test.go
@@ -71,7 +71,8 @@ func setupCassandra(t *testing.T) *gocql.Session {
 			display_text  TEXT,
 			hide_exec_log BOOLEAN,
 			card_tmid     TEXT,
-			data          BLOB
+			data          BLOB,
+			bot_username  TEXT
 		)`, keyspace),
 		fmt.Sprintf(`CREATE TYPE IF NOT EXISTS %s."File" (
 			id   TEXT,

--- a/pkg/model/cassandra/message.go
+++ b/pkg/model/cassandra/message.go
@@ -33,6 +33,10 @@ type CardAction struct {
 	HideExecLog bool   `json:"hideExecLog,omitempty" cql:"hide_exec_log"`
 	CardTmID    string `json:"cardTmId,omitempty"    cql:"card_tmid"`
 	Data        []byte `json:"data,omitempty"        cql:"data"`
+	// BotUsername names the bot the card action is dispatched to — the client
+	// (desktop/kr backend) sets it on the tcard_execute event so the receiving
+	// bot can route the callback. Optional: legacy card actions predate the field.
+	BotUsername string `json:"botUsername,omitempty" cql:"bot_username"`
 }
 
 // EncMeta maps to the Cassandra "EncMeta" UDT. Nonce is the 12-byte

--- a/pkg/model/cassandra/message_test.go
+++ b/pkg/model/cassandra/message_test.go
@@ -59,6 +59,7 @@ func TestCardAction_JSON(t *testing.T) {
 		HideExecLog: true,
 		CardTmID:    "tm1",
 		Data:        []byte(`{"action":"yes"}`),
+		BotUsername: "expense-bot",
 	}
 	roundTrip(t, ca)
 }
@@ -69,6 +70,21 @@ func TestCardAction_JSON_Minimal(t *testing.T) {
 	assert.Empty(t, got.Text)
 	assert.Empty(t, got.CardID)
 	assert.False(t, got.HideExecLog)
+	assert.Empty(t, got.BotUsername)
+}
+
+// TestCardAction_JSON_BotUsername pins the wire tag so oplog-transformer /
+// canonical-event JSON round-trips preserve the field.
+func TestCardAction_JSON_BotUsername(t *testing.T) {
+	ca := CardAction{Verb: "approve", BotUsername: "expense-bot"}
+	b, err := json.Marshal(ca)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"botUsername":"expense-bot"`)
+
+	ca.BotUsername = "" // omitempty ⇒ absent when empty
+	b, err = json.Marshal(ca)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), "botUsername")
 }
 
 func TestQuotedParentMessage_JSON(t *testing.T) {

--- a/tools/loadgen/history_integration_test.go
+++ b/tools/loadgen/history_integration_test.go
@@ -138,7 +138,7 @@ func provisionHistorySchema(t *testing.T, session *gocql.Session, keyspace strin
 		cql(`CREATE TYPE IF NOT EXISTS %s."Participant" (id TEXT, eng_name TEXT, company_name TEXT, app_id TEXT, app_name TEXT, is_bot BOOLEAN, account TEXT)`),
 		cql(`CREATE TYPE IF NOT EXISTS %s."File" (id TEXT, name TEXT, type TEXT)`),
 		cql(`CREATE TYPE IF NOT EXISTS %s."Card" (template TEXT, data BLOB)`),
-		cql(`CREATE TYPE IF NOT EXISTS %s."CardAction" (verb TEXT, text TEXT, card_id TEXT, display_text TEXT, hide_exec_log BOOLEAN, card_tmid TEXT, data BLOB)`),
+		cql(`CREATE TYPE IF NOT EXISTS %s."CardAction" (verb TEXT, text TEXT, card_id TEXT, display_text TEXT, hide_exec_log BOOLEAN, card_tmid TEXT, data BLOB, bot_username TEXT)`),
 		cql(`CREATE TYPE IF NOT EXISTS %s."QuotedParentMessage" (message_id TEXT, room_id TEXT, sender FROZEN<"Participant">, created_at TIMESTAMP, msg TEXT, mentions SET<FROZEN<"Participant">>, attachments LIST<BLOB>, message_link TEXT, thread_parent_id TEXT, thread_parent_created_at TIMESTAMP)`),
 	}
 	for _, stmt := range udts {


### PR DESCRIPTION
## Summary

The desktop / KR-backend client attaches a `botUsername` on the `cardAction` payload of a `tcard_execute` event to name the target bot for the callback. Without a matching column in the Cassandra `CardAction` UDT (and a JSON tag on the wire struct), the field is dropped on the canonical event and on the history read path.

- Adds `bot_username TEXT` to the `CardAction` UDT — init CQL for fresh clusters and a `docker-local/cassandra/migrations/2026-08-cardaction-bot-username.cql` for live ones (`ALTER TYPE ADD` is safe and additive).
- Adds `BotUsername` to `pkg/model/cassandra.CardAction` with `json:"botUsername,omitempty" cql:"bot_username"` so canonical / oplog-transformer JSON round-trips preserve the field and gocql's reflection-based UDT decoder binds the new column with no other code changes.
- Extends `TestCardAction_JSON` / `_Minimal` and adds a `_BotUsername` test that pins the wire tag; extends the two `cassrepo` integration tests that write-then-read the full `CardAction`.
- Updates `docs/cassandra_message_model.md` and the `MessageCardAction` table in `docs/client-api.md`. Sync-mirrored DDL in the four in-package integration test setups so isolated keyspaces match the init script.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./pkg/... ./bot-message-worker/... ./message-worker/... ./data-migration/oplog-transformer/... ./history-service/...`
- [x] `golangci-lint run` on the touched packages — 0 issues.
- [ ] Integration tests (`make test-integration`) — not run locally, will run in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_019HidfugC7G2816pnL4cYPP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Card actions can now optionally identify the target bot using a bot username.
  * The bot username is available through client-facing message data and is preserved when stored and retrieved.

* **Documentation**
  * Updated client API and message model documentation to describe the optional bot username field.

* **Tests**
  * Added coverage confirming bot usernames are serialized, persisted, retrieved, and omitted when empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->