### PR TITLE
fix: walk back room last-message fields on last-message delete

### DIFF
--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -502,6 +502,19 @@ func (h *Handler) handleDeleted(ctx context.Context, evt *model.MessageEvent) er
 	if err := h.publishMutation(ctx, room, model.RoomEventMessageDeleted, msg.ID, &del); err != nil {
 		return fmt.Errorf("publish delete mutation for room %s message %s: %w", room.ID, msg.ID, err)
 	}
+	// Walk the room's denormalized last-message fields back off the deleted message when it was the
+	// room's current last — otherwise room.lastMsgAt (subscription.list sort key) and the preview
+	// keep pointing at a deleted message. NewRoomLastRecomputed gates it (unset ⇒ hidden thread
+	// reply, read degrade, or old producer ⇒ leave the fields as-is). Best-effort: the field is
+	// decorative and self-heals on the next message, so a write blip mustn't redeliver the fan-out.
+	if evt.NewRoomLastRecomputed && msg.ID == room.LastMsgID {
+		setMentionAll := mention.Parse(msg.Content).MentionAll // lastMentionAllAt shifts only if the deleted msg was @all
+		if err := h.store.SetRoomLastMessage(ctx, room.ID, evt.NewRoomLastMsgID, evt.NewRoomLastMsgAt, setMentionAll, evt.NewRoomLastMentionAllAt); err != nil {
+			slog.ErrorContext(ctx, "walk back room last message failed",
+				"error", err, "room_id", room.ID, "message_id", msg.ID,
+				"request_id", natsutil.RequestIDFromContext(ctx))
+		}
+	}
 	// TShow=true thread replies appear in the main room (handled by publishMutation
 	// above) but still count toward the thread's reply-count badge. Since
 	// handleThreadDeleted is bypassed for TShow=true, we publish the badge update here.

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -901,6 +901,103 @@ func TestHandleDeleted_OmitsPreviewWhenNil(t *testing.T) {
 		"a nil preview must be omitted from the fan-out, not sent as null")
 }
 
+// deleteWalkbackEvent builds a deleted-message event carrying the room last-message walk-back.
+func deleteWalkbackEvent(roomID, msgID, content string, recomputed bool, newID *string, newAt, newMentionAllAt *time.Time) model.MessageEvent {
+	deleted := time.Date(2026, 5, 14, 12, 5, 0, 0, time.UTC)
+	return model.MessageEvent{
+		Event:     model.EventDeleted,
+		SiteID:    "site-a",
+		Timestamp: deleted.UnixMilli(),
+		Message: model.Message{
+			ID: msgID, RoomID: roomID, UserID: "u-alice", UserAccount: "alice",
+			Content: content, CreatedAt: deleted.Add(-time.Hour), UpdatedAt: &deleted,
+		},
+		NewRoomLastRecomputed:   recomputed,
+		NewRoomLastMsgID:        newID,
+		NewRoomLastMsgAt:        newAt,
+		NewRoomLastMentionAllAt: newMentionAllAt,
+	}
+}
+
+// Deleting the room's current last message applies the walk-back to the room doc.
+func TestHandleDeleted_WalkbackApplied_WhenDeletedWasLast(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	pub := &mockPublisher{}
+
+	roomID := "r1"
+	store.EXPECT().GetRoom(gomock.Any(), roomID).
+		Return(&model.Room{ID: roomID, Type: model.RoomTypeChannel, SiteID: "site-a", LastMsgID: "msg-1"}, nil)
+	newID := "msg-0"
+	newAt := time.Date(2026, 5, 14, 11, 0, 0, 0, time.UTC)
+	store.EXPECT().SetRoomLastMessage(gomock.Any(), roomID, &newID, &newAt, false, (*time.Time)(nil)).Return(nil)
+
+	evt := deleteWalkbackEvent(roomID, "msg-1", "plain", true, &newID, &newAt, nil)
+	data, err := json.Marshal(&evt)
+	require.NoError(t, err)
+	h := NewHandler(store, NewMockUserStore(ctrl), pub, NewMockRoomKeyProvider(ctrl), defaultParentFetcher, true, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+}
+
+// Deleting a non-last message never touches the room's last-message fields.
+func TestHandleDeleted_WalkbackSkipped_WhenDeletedNotLast(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	pub := &mockPublisher{}
+
+	roomID := "r1"
+	store.EXPECT().GetRoom(gomock.Any(), roomID).
+		Return(&model.Room{ID: roomID, Type: model.RoomTypeChannel, SiteID: "site-a", LastMsgID: "msg-9"}, nil)
+	// No SetRoomLastMessage expectation: gomock fails the test if it is called.
+
+	newID := "msg-0"
+	newAt := time.Date(2026, 5, 14, 11, 0, 0, 0, time.UTC)
+	evt := deleteWalkbackEvent(roomID, "msg-1", "plain", true, &newID, &newAt, nil)
+	data, err := json.Marshal(&evt)
+	require.NoError(t, err)
+	h := NewHandler(store, NewMockUserStore(ctrl), pub, NewMockRoomKeyProvider(ctrl), defaultParentFetcher, true, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+}
+
+// Deleting the room's only message clears the fields (nil last-msg pointers under the guard).
+func TestHandleDeleted_WalkbackClears_WhenRoomEmptied(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	pub := &mockPublisher{}
+
+	roomID := "r1"
+	store.EXPECT().GetRoom(gomock.Any(), roomID).
+		Return(&model.Room{ID: roomID, Type: model.RoomTypeChannel, SiteID: "site-a", LastMsgID: "msg-1"}, nil)
+	store.EXPECT().SetRoomLastMessage(gomock.Any(), roomID, (*string)(nil), (*time.Time)(nil), false, (*time.Time)(nil)).Return(nil)
+
+	evt := deleteWalkbackEvent(roomID, "msg-1", "plain", true, nil, nil, nil)
+	data, err := json.Marshal(&evt)
+	require.NoError(t, err)
+	h := NewHandler(store, NewMockUserStore(ctrl), pub, NewMockRoomKeyProvider(ctrl), defaultParentFetcher, true, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+}
+
+// Deleting an @all last message flags lastMentionAllAt for update (broadcast re-parses content).
+func TestHandleDeleted_WalkbackTouchesMentionAll_WhenDeletedWasAll(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	pub := &mockPublisher{}
+
+	roomID := "r1"
+	store.EXPECT().GetRoom(gomock.Any(), roomID).
+		Return(&model.Room{ID: roomID, Type: model.RoomTypeChannel, SiteID: "site-a", LastMsgID: "msg-1"}, nil)
+	newID := "msg-0"
+	newAt := time.Date(2026, 5, 14, 11, 0, 0, 0, time.UTC)
+	mentionAllAt := time.Date(2026, 5, 14, 10, 0, 0, 0, time.UTC)
+	store.EXPECT().SetRoomLastMessage(gomock.Any(), roomID, &newID, &newAt, true, &mentionAllAt).Return(nil)
+
+	evt := deleteWalkbackEvent(roomID, "msg-1", "notice @all", true, &newID, &newAt, &mentionAllAt)
+	data, err := json.Marshal(&evt)
+	require.NoError(t, err)
+	h := NewHandler(store, NewMockUserStore(ctrl), pub, NewMockRoomKeyProvider(ctrl), defaultParentFetcher, true, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+}
+
 func TestHandleUpdated_EncryptedChannel_EncryptsContent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)

--- a/broadcast-worker/mock_store_test.go
+++ b/broadcast-worker/mock_store_test.go
@@ -132,6 +132,20 @@ func (mr *MockStoreMockRecorder) ListSubscriptions(ctx, roomID any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubscriptions", reflect.TypeOf((*MockStore)(nil).ListSubscriptions), ctx, roomID)
 }
 
+// SetRoomLastMessage mocks base method.
+func (m *MockStore) SetRoomLastMessage(ctx context.Context, roomID string, lastMsgID *string, lastMsgAt *time.Time, setMentionAll bool, mentionAllAt *time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetRoomLastMessage", ctx, roomID, lastMsgID, lastMsgAt, setMentionAll, mentionAllAt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetRoomLastMessage indicates an expected call of SetRoomLastMessage.
+func (mr *MockStoreMockRecorder) SetRoomLastMessage(ctx, roomID, lastMsgID, lastMsgAt, setMentionAll, mentionAllAt any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRoomLastMessage", reflect.TypeOf((*MockStore)(nil).SetRoomLastMessage), ctx, roomID, lastMsgID, lastMsgAt, setMentionAll, mentionAllAt)
+}
+
 // SetSubscriptionMentions mocks base method.
 func (m *MockStore) SetSubscriptionMentions(ctx context.Context, roomID string, accounts []string, msgCreatedAt time.Time) error {
 	m.ctrl.T.Helper()

--- a/broadcast-worker/store.go
+++ b/broadcast-worker/store.go
@@ -20,6 +20,11 @@ type Store interface {
 	ListSubscriptions(ctx context.Context, roomID string) ([]model.Subscription, error)
 	GetThreadFollowers(ctx context.Context, parentMessageID string) (map[string]struct{}, error)
 	UpdateRoomLastMessage(ctx context.Context, roomID, msgID string, msgAt time.Time, mentionAll bool) error
+	// SetRoomLastMessage walks a room's denormalized last-message fields back after a delete.
+	// Direct write (not coalesced) — deletes are rare. lastMsgID/lastMsgAt nil clear those fields
+	// (room emptied); setMentionAll gates lastMentionAllAt (set to mentionAllAt, cleared when nil,
+	// left untouched when setMentionAll is false).
+	SetRoomLastMessage(ctx context.Context, roomID string, lastMsgID *string, lastMsgAt *time.Time, setMentionAll bool, mentionAllAt *time.Time) error
 	// SetSubscriptionMentions flags accounts as mentioned, unless a given account
 	// already read past msgCreatedAt (lastSeenAt >= msgCreatedAt) — otherwise an
 	// async mention write can clobber a read-clear that happened first (#467).

--- a/broadcast-worker/store_mongo.go
+++ b/broadcast-worker/store_mongo.go
@@ -97,6 +97,44 @@ func (m *mongoStore) UpdateRoomLastMessage(ctx context.Context, roomID, msgID st
 	return nil
 }
 
+// SetRoomLastMessage applies the delete walk-back to a room's denormalized last-message fields.
+// Direct write (not coalesced) — deletes are rare, unlike the coalesced send path. A nil
+// lastMsgID/lastMsgAt clears those fields (the room has no surviving message). setMentionAll gates
+// lastMentionAllAt: true sets it to mentionAllAt (or clears it when mentionAllAt is nil); false
+// leaves it untouched (the deleted message was not an @all, so the room's @all floor is unchanged).
+func (m *mongoStore) SetRoomLastMessage(ctx context.Context, roomID string, lastMsgID *string, lastMsgAt *time.Time, setMentionAll bool, mentionAllAt *time.Time) error {
+	set := bson.M{}
+	unset := bson.M{}
+	if lastMsgID != nil && lastMsgAt != nil {
+		set["lastMsgId"] = *lastMsgID
+		set["lastMsgAt"] = *lastMsgAt
+		set["updatedAt"] = *lastMsgAt
+	} else {
+		set["lastMsgId"] = "" // lastMsgId has no omitempty; keep the field present as empty
+		set["updatedAt"] = time.Now().UTC()
+		unset["lastMsgAt"] = ""
+	}
+	if setMentionAll {
+		if mentionAllAt != nil {
+			set["lastMentionAllAt"] = *mentionAllAt
+		} else {
+			unset["lastMentionAllAt"] = ""
+		}
+	}
+	update := bson.M{"$set": set}
+	if len(unset) > 0 {
+		update["$unset"] = unset
+	}
+	res, err := m.roomCol.UpdateOne(ctx, bson.M{"_id": roomID}, update)
+	if err != nil {
+		return fmt.Errorf("set room last message %s: %w", roomID, err)
+	}
+	if res.MatchedCount == 0 {
+		return fmt.Errorf("set room last message %s: %w", roomID, mongo.ErrNoDocuments)
+	}
+	return nil
+}
+
 // BulkUpdateRoomLastMessage applies a batch of room.lastMsgAt/lastMsgId
 // updates in a single unordered BulkWrite. Missing rooms (MatchedCount==0
 // per model) are not surfaced — lastMsgAt is decorative and the source-of-

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -3347,7 +3347,7 @@ The payload is flat:
 }
 ```
 
-When the deleted message was the room's last eligible message, `previewMessage` is **omitted** entirely.
+When the deleted message was the room's last eligible message, `previewMessage` is **omitted** entirely. In that case the server also walks the room's denormalized last-message fields back to the latest surviving message, so the next [`subscription.list`](#subscriptionroom) reflects the correct `lastMsgAt` (room-list sort key), `lastMsgId`, and `lastMentionAllAt` — or clears them when the deleted message was the room's only one. Deleting an `@all` message likewise recomputes `lastMentionAllAt` to the latest surviving `@all` (clearing the group-mention badge when none remains).
 
 **Thread-reply deletes additionally emit a `ThreadMetadataUpdatedEvent`** (see [§4.1 Thread Metadata Event](#41-thread-metadata-event)) to update the parent message's reply-count badge. The `DeleteRoomEvent` and `ThreadMetadataUpdatedEvent` are published independently; clients must handle each on its own.
 

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -488,7 +488,7 @@ Thread-reply deletes **additionally** emit a
 }
 ```
 
-When the deleted message was the room's last eligible message, `previewMessage` is **omitted**.
+When the deleted message was the room's last eligible message, `previewMessage` is **omitted**. The server also walks the room's denormalized last-message fields back to the latest surviving message, so the next [`subscription.list`](../client-api.md#subscriptionroom) shows the correct `lastMsgAt` (room-list sort key), `lastMsgId`, and `lastMentionAllAt` — or clears them when the room is now empty. Deleting an `@all` message likewise recomputes `lastMentionAllAt` to the latest surviving `@all`.
 
 ---
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -1038,7 +1038,7 @@ Only the original sender may edit.
 **Subject:** `chat.user.{account}.request.room.{roomID}.{siteID}.msg.delete`
 **Reply:** auto-generated `_INBOX.>` (NATS request/reply)
 
-Soft-delete (row preserved for audit). Only the original sender may delete. Idempotent.
+Soft-delete (row preserved for audit). Only the original sender may delete. Idempotent. When the deleted message was the room's current last message, the room's denormalized last-message fields (`lastMsgAt`/`lastMsgId`/`lastMentionAllAt`, seen in `subscription.list`) are walked back to the latest surviving message, or cleared when the room is emptied.
 
 #### Request body
 

--- a/history-service/internal/service/messages.go
+++ b/history-service/internal/service/messages.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hmchangw/chat/history-service/internal/cassrepo"
 	"github.com/hmchangw/chat/history-service/internal/models"
 	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/mention"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/natsrouter"
 	"github.com/hmchangw/chat/pkg/natsutil"
@@ -629,7 +630,7 @@ func (s *HistoryService) DeleteMessage(c *natsrouter.Context, siteID string, req
 		NewThreadLastMsgAt: newThreadLastMsgAt,
 	}
 
-	canonicalEvt.PreviewMessage = s.previewAfterMutation(c, msg, roomID, actualDeletedAt)
+	s.fillRoomLastWalkback(c, &canonicalEvt, msg, roomID, actualDeletedAt)
 	s.publishCanonicalBestEffort(c, subject.MsgCanonicalDeleted(siteID), &canonicalEvt)
 
 	return &models.DeleteMessageResponse{
@@ -652,6 +653,36 @@ func (s *HistoryService) previewAfterMutation(c *natsrouter.Context, msg *models
 		return &preview
 	}
 	return nil
+}
+
+// fillRoomLastWalkback fills the delete event's room preview AND the room last-message walk-back
+// fields (NewRoomLast*) from a single preview walk — the room-level mirror of the thread-level
+// NewThreadLastMsgAt walk-back. A hidden thread reply never appears in the room timeline, so its
+// delete touches neither. A read degrade also leaves the walk-back off (NewRoomLastRecomputed
+// stays false) so broadcast-worker keeps the room's existing fields rather than wrongly clearing.
+func (s *HistoryService) fillRoomLastWalkback(c *natsrouter.Context, ev *model.MessageEvent, msg *models.Message, roomID string, at time.Time) {
+	if msg.ThreadParentID != "" && !msg.TShow {
+		return
+	}
+	preview, found, err := s.roomLastPreviewMessageE(c, roomID, nil, at)
+	if err != nil {
+		return
+	}
+	if found {
+		ev.PreviewMessage = &preview
+		id := preview.MessageID
+		msgAt := preview.CreatedAt
+		ev.NewRoomLastMsgID = &id
+		ev.NewRoomLastMsgAt = &msgAt
+	}
+	// found==false ⇒ room now empty ⇒ nil NewRoomLastMsg* signals a clear.
+	ev.NewRoomLastRecomputed = true
+
+	// lastMentionAllAt only shifts when the deleted message was itself an @all; broadcast-worker
+	// re-parses Message.Content to gate the apply, so the extra walk is skipped otherwise.
+	if mention.Parse(msg.Msg).MentionAll {
+		ev.NewRoomLastMentionAllAt = s.roomLastMentionAllAt(c, roomID, at)
+	}
 }
 
 // publishCanonicalBestEffort publishes a canonical event; failures are logged and swallowed (Cassandra is source of truth).

--- a/history-service/internal/service/messages_test.go
+++ b/history-service/internal/service/messages_test.go
@@ -1927,6 +1927,124 @@ func TestHistoryService_DeleteMessage_LastMessage_PublishesNilPreview(t *testing
 	require.NoError(t, err)
 }
 
+// Deleting the room's last message surfaces the room last-message walk-back: broadcast-worker
+// walks room.lastMsgAt/lastMsgId back to the surviving message the preview resolved.
+func TestHistoryService_DeleteMessage_LastMessage_SurfacesRoomWalkback(t *testing.T) {
+	svc, msgs, subs, pub, _ := newService(t)
+	c := testContext()
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
+	hydrated := &models.Message{
+		MessageID: "msg-2", RoomID: "r1",
+		Sender:    models.Participant{Account: "u1", ID: "u1-id"},
+		CreatedAt: time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC),
+		Msg:       "content",
+	}
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-2").Return(hydrated, nil)
+	msgs.EXPECT().SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
+			return deletedAt, true, nil, nil, nil
+		})
+	survivorAt := time.Date(2026, 5, 14, 11, 0, 0, 0, time.UTC)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{
+			{MessageID: "msg-1", RoomID: "r1", Sender: models.Participant{Account: "u1", ID: "u1-id"}, Msg: "prior", CreatedAt: survivorAt},
+		}, false), nil)
+
+	pub.EXPECT().Publish(gomock.Any(), subject.MsgCanonicalDeleted("site-test"), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, data []byte, _ string) error {
+			var evt model.MessageEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			assert.True(t, evt.NewRoomLastRecomputed)
+			require.NotNil(t, evt.NewRoomLastMsgID)
+			assert.Equal(t, "msg-1", *evt.NewRoomLastMsgID)
+			require.NotNil(t, evt.NewRoomLastMsgAt)
+			assert.Equal(t, survivorAt, evt.NewRoomLastMsgAt.UTC())
+			assert.Nil(t, evt.NewRoomLastMentionAllAt, "deleted message was not @all")
+			return nil
+		})
+
+	_, err := svc.DeleteMessage(c, "site-test", models.DeleteMessageRequest{MessageID: "msg-2"})
+	require.NoError(t, err)
+}
+
+// Deleting the room's only message signals a clear: Recomputed=true with nil NewRoomLastMsg*.
+func TestHistoryService_DeleteMessage_EmptyRoom_SignalsClear(t *testing.T) {
+	svc, msgs, subs, pub, _ := newService(t)
+	c := testContext()
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
+	hydrated := &models.Message{
+		MessageID: "msg-1", RoomID: "r1",
+		Sender:    models.Participant{Account: "u1", ID: "u1-id"},
+		CreatedAt: time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC),
+		Msg:       "content",
+	}
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
+	msgs.EXPECT().SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
+			return deletedAt, true, nil, nil, nil
+		})
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage(nil, false), nil)
+
+	pub.EXPECT().Publish(gomock.Any(), subject.MsgCanonicalDeleted("site-test"), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, data []byte, _ string) error {
+			var evt model.MessageEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			assert.True(t, evt.NewRoomLastRecomputed, "empty room is a confident clear, not a degrade")
+			assert.Nil(t, evt.NewRoomLastMsgID)
+			assert.Nil(t, evt.NewRoomLastMsgAt)
+			return nil
+		})
+
+	_, err := svc.DeleteMessage(c, "site-test", models.DeleteMessageRequest{MessageID: "msg-1"})
+	require.NoError(t, err)
+}
+
+// Deleting an @all message walks lastMentionAllAt back to the latest surviving @all.
+func TestHistoryService_DeleteMessage_MentionAll_RecomputesMentionAllAt(t *testing.T) {
+	svc, msgs, subs, pub, _ := newService(t)
+	c := testContext()
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
+	hydrated := &models.Message{
+		MessageID: "msg-2", RoomID: "r1",
+		Sender:    models.Participant{Account: "u1", ID: "u1-id"},
+		CreatedAt: time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC),
+		Msg:       "heads up @all",
+	}
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-2").Return(hydrated, nil)
+	msgs.EXPECT().SoftDeleteMessage(gomock.Any(), hydrated, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *models.Message, deletedAt time.Time) (time.Time, bool, *int, *time.Time, error) {
+			return deletedAt, true, nil, nil, nil
+		})
+	survivorAt := time.Date(2026, 5, 14, 11, 30, 0, 0, time.UTC)
+	olderAllAt := time.Date(2026, 5, 14, 10, 0, 0, 0, time.UTC)
+	// One page serves both walks (DESC): preview stops at the newest eligible (msg-1, not @all);
+	// the @all walk skips it and finds the older @all (msg-0).
+	page := makePage([]models.Message{
+		{MessageID: "msg-1", RoomID: "r1", Sender: models.Participant{Account: "u1", ID: "u1-id"}, Msg: "just text", CreatedAt: survivorAt},
+		{MessageID: "msg-0", RoomID: "r1", Sender: models.Participant{Account: "u1", ID: "u1-id"}, Msg: "@all earlier", CreatedAt: olderAllAt},
+	}, false)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(page, nil).AnyTimes()
+
+	pub.EXPECT().Publish(gomock.Any(), subject.MsgCanonicalDeleted("site-test"), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, data []byte, _ string) error {
+			var evt model.MessageEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			require.NotNil(t, evt.NewRoomLastMsgID)
+			assert.Equal(t, "msg-1", *evt.NewRoomLastMsgID)
+			require.NotNil(t, evt.NewRoomLastMentionAllAt, "an @all delete recomputes lastMentionAllAt")
+			assert.Equal(t, olderAllAt, evt.NewRoomLastMentionAllAt.UTC())
+			return nil
+		})
+
+	_, err := svc.DeleteMessage(c, "site-test", models.DeleteMessageRequest{MessageID: "msg-2"})
+	require.NoError(t, err)
+}
+
 // A hidden thread reply (TShow=false) edit skips the room-preview walk (no GetMessagesBefore) and
 // carries no preview; clients tell it apart via ThreadParentMessageID and drive the preview themselves.
 func TestHistoryService_EditMessage_HiddenThreadReply_SkipsPreviewWalk(t *testing.T) {

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hmchangw/chat/history-service/internal/cassrepo"
 	"github.com/hmchangw/chat/history-service/internal/models"
 	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/mention"
 	pkgmodel "github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/natsrouter"
 	"github.com/hmchangw/chat/pkg/natsutil"
@@ -156,11 +157,20 @@ func (s *HistoryService) resolvePreview(ctx context.Context, roomID string, meta
 // all-ineligible within the walk cap, or a read failure). Walks backward from lastMsgAt in
 // pages, skipping ineligible messages.
 func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID string, meta *models.RoomMeta, now time.Time) (models.PreviewMessage, bool) {
+	pm, found, _ := s.roomLastPreviewMessageE(ctx, roomID, meta, now)
+	return pm, found
+}
+
+// roomLastPreviewMessageE is roomLastPreviewMessage with the degrade cause surfaced: a non-nil
+// error means a read failed (caller must NOT treat it as an empty room), found=false with a nil
+// error means the room genuinely has no eligible message. The delete walk-back needs this split to
+// tell "clear the room's last-message fields" (empty) from "leave them" (transient read failure).
+func (s *HistoryService) roomLastPreviewMessageE(ctx context.Context, roomID string, meta *models.RoomMeta, now time.Time) (models.PreviewMessage, bool, error) {
 	lastMsgAt, createdAt, err := s.resolveRoomTimesOrError(ctx, roomID, meta, now)
 	if err != nil {
 		slog.WarnContext(ctx, "rooms.get room degraded", "room_id", roomID,
 			"request_id", natsutil.RequestIDFromContext(ctx), "error", err)
-		return models.PreviewMessage{}, false
+		return models.PreviewMessage{}, false, err
 	}
 
 	ceiling, floor := s.walkBounds(lastMsgAt, createdAt, now)
@@ -177,10 +187,10 @@ func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID stri
 		if err != nil {
 			slog.WarnContext(ctx, "rooms.get latest-message read degraded", "room_id", roomID,
 				"request_id", natsutil.RequestIDFromContext(ctx), "error", err)
-			return models.PreviewMessage{}, false
+			return models.PreviewMessage{}, false, err
 		}
 		if len(page.Data) == 0 {
-			return models.PreviewMessage{}, false // room empty or floor reached
+			return models.PreviewMessage{}, false, nil // room empty or floor reached
 		}
 		for i := range page.Data {
 			m := page.Data[i]
@@ -189,19 +199,62 @@ func (s *HistoryService) roomLastPreviewMessage(ctx context.Context, roomID stri
 			if m.Deleted || pkgmodel.IsSystemMessageType(m.Type) {
 				continue
 			}
-			return s.toPreviewMessage(ctx, &m), true
+			return s.toPreviewMessage(ctx, &m), true, nil
 		}
 		// Whole page ineligible. HasNext=false means the walk reached a terminal
 		// state (floor/empty) — stop. Otherwise grow the page and continue strictly
 		// before the oldest one seen.
 		scanned += len(page.Data)
 		if !page.HasNext {
-			return models.PreviewMessage{}, false
+			return models.PreviewMessage{}, false, nil
 		}
 		before = page.Data[len(page.Data)-1].CreatedAt
 		pageSize *= lastMsgWalkGrowth
 	}
-	return models.PreviewMessage{}, false // ineligible tail longer than the scan budget
+	return models.PreviewMessage{}, false, nil // ineligible tail longer than the scan budget
+}
+
+// roomLastMentionAllAt walks backward for the CreatedAt of the room's latest surviving @all
+// message, so a delete can walk room.lastMentionAllAt back off a deleted @all. Same page walk as
+// the preview, but the eligibility predicate is "@all mention" (parsed from content). nil means no
+// surviving @all within the scan budget — a best-effort clear, matching the preview walk's ceiling.
+func (s *HistoryService) roomLastMentionAllAt(ctx context.Context, roomID string, now time.Time) *time.Time {
+	lastMsgAt, createdAt, err := s.resolveRoomTimesOrError(ctx, roomID, nil, now)
+	if err != nil {
+		return nil
+	}
+	ceiling, floor := s.walkBounds(lastMsgAt, createdAt, now)
+	before := ceiling.Add(time.Millisecond)
+
+	pageSize := lastMsgWalkFirstPage
+	scanned := 0
+	for scanned < lastMsgWalkMaxScan {
+		pageSize = min(pageSize, lastMsgWalkMaxPage, lastMsgWalkMaxScan-scanned)
+		page, err := s.msgReader.GetMessagesBefore(ctx, roomID, before, floor, cassrepo.PageRequest{PageSize: pageSize})
+		if err != nil {
+			return nil
+		}
+		if len(page.Data) == 0 {
+			return nil
+		}
+		for i := range page.Data {
+			m := page.Data[i]
+			if m.Deleted || pkgmodel.IsSystemMessageType(m.Type) {
+				continue
+			}
+			if mention.Parse(m.Msg).MentionAll {
+				at := m.CreatedAt.UTC()
+				return &at
+			}
+		}
+		scanned += len(page.Data)
+		if !page.HasNext {
+			return nil
+		}
+		before = page.Data[len(page.Data)-1].CreatedAt
+		pageSize *= lastMsgWalkGrowth
+	}
+	return nil
 }
 
 // toPreviewMessage enriches an eligible message into the room-list preview: sender and

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -38,6 +38,18 @@ type MessageEvent struct {
 	NewTCount *int `json:"newTcount,omitempty" bson:"newTcount"`
 	// NewThreadLastMsgAt is the timestamp of the most recent surviving thread reply after this operation (nil when no replies remain).
 	NewThreadLastMsgAt *time.Time `json:"newThreadLastMsgAt,omitempty" bson:"newThreadLastMsgAt,omitempty"`
+	// Room last-message walk-back (delete only), the room-level mirror of NewThreadLastMsgAt:
+	// after a delete, history-service recomputes the room's denormalized last-message fields so
+	// broadcast-worker can walk room.lastMsgAt/lastMsgId back to the latest surviving message.
+	// NewRoomLastRecomputed gates the whole apply — false (old producer, hidden-thread-reply, or a
+	// read degrade) means "leave the room fields untouched". When true, nil NewRoomLastMsgID/At means
+	// the room is now empty ⇒ clear. NewRoomLastMentionAllAt is set only when the deleted message was
+	// itself an @all (broadcast re-parses Message.Content to decide whether to apply it); nil then clears
+	// lastMentionAllAt. bson:"-": pure producer→consumer transport, never persisted (like PreviewMessage).
+	NewRoomLastRecomputed   bool       `json:"newRoomLastRecomputed,omitempty" bson:"-"`
+	NewRoomLastMsgAt        *time.Time `json:"newRoomLastMsgAt,omitempty" bson:"-"`
+	NewRoomLastMsgID        *string    `json:"newRoomLastMsgId,omitempty" bson:"-"`
+	NewRoomLastMentionAllAt *time.Time `json:"newRoomLastMentionAllAt,omitempty" bson:"-"`
 	// QuotedParentUnverified marks a degraded QuotedParentMessage placeholder built on a transient
 	// history outage; message-worker re-projects or drops it. bson:"-" enforces never-persisted (an untagged field would round-trip).
 	QuotedParentUnverified bool `json:"quotedParentUnverified,omitempty" bson:"-"`

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -4299,6 +4299,71 @@ func TestMessageEvent_NewThreadLastMsgAt(t *testing.T) {
 	})
 }
 
+func TestMessageEvent_RoomLastWalkbackFields(t *testing.T) {
+	ts := time.Date(2026, 8, 4, 10, 0, 0, 0, time.UTC)
+
+	t.Run("zero-value room walk-back fields omitted from JSON", func(t *testing.T) {
+		e := model.MessageEvent{
+			Message:   model.Message{ID: "m1", RoomID: "r1"},
+			SiteID:    "site-a",
+			Timestamp: ts.UnixMilli(),
+		}
+		data, err := json.Marshal(e)
+		require.NoError(t, err)
+		var raw map[string]any
+		require.NoError(t, json.Unmarshal(data, &raw))
+		for _, k := range []string{"newRoomLastRecomputed", "newRoomLastMsgAt", "newRoomLastMsgId", "newRoomLastMentionAllAt"} {
+			_, present := raw[k]
+			assert.Falsef(t, present, "zero-value %s must be omitted from JSON", k)
+		}
+	})
+
+	t.Run("populated room walk-back fields round-trip JSON", func(t *testing.T) {
+		id := "msg-0"
+		e := model.MessageEvent{
+			Message:                 model.Message{ID: "m1", RoomID: "r1"},
+			SiteID:                  "site-a",
+			Timestamp:               ts.UnixMilli(),
+			NewRoomLastRecomputed:   true,
+			NewRoomLastMsgAt:        &ts,
+			NewRoomLastMsgID:        &id,
+			NewRoomLastMentionAllAt: &ts,
+		}
+		data, err := json.Marshal(e)
+		require.NoError(t, err)
+		var dst model.MessageEvent
+		require.NoError(t, json.Unmarshal(data, &dst))
+		assert.True(t, dst.NewRoomLastRecomputed)
+		require.NotNil(t, dst.NewRoomLastMsgID)
+		assert.Equal(t, "msg-0", *dst.NewRoomLastMsgID)
+		require.NotNil(t, dst.NewRoomLastMsgAt)
+		assert.True(t, dst.NewRoomLastMsgAt.Equal(ts))
+		require.NotNil(t, dst.NewRoomLastMentionAllAt)
+		assert.True(t, dst.NewRoomLastMentionAllAt.Equal(ts))
+	})
+
+	t.Run("room walk-back fields are transport-only (absent from BSON)", func(t *testing.T) {
+		id := "msg-0"
+		e := model.MessageEvent{
+			Message:                 model.Message{ID: "m1", RoomID: "r1"},
+			SiteID:                  "site-a",
+			Timestamp:               ts.UnixMilli(),
+			NewRoomLastRecomputed:   true,
+			NewRoomLastMsgAt:        &ts,
+			NewRoomLastMsgID:        &id,
+			NewRoomLastMentionAllAt: &ts,
+		}
+		data, err := bson.Marshal(e)
+		require.NoError(t, err)
+		var raw bson.M
+		require.NoError(t, bson.Unmarshal(data, &raw))
+		for _, k := range []string{"newRoomLastRecomputed", "newRoomLastMsgAt", "newRoomLastMsgId", "newRoomLastMentionAllAt"} {
+			_, present := raw[k]
+			assert.Falsef(t, present, "%s uses bson:\"-\" and must never persist", k)
+		}
+	})
+}
+
 func TestThreadMetadataUpdatedEvent_NewThreadLastMsgAt(t *testing.T) {
 	ts := time.Date(2026, 6, 18, 10, 0, 0, 0, time.UTC)
 


### PR DESCRIPTION
## Summary

Deleting a room's **last** message left the room's denormalized last-message fields
(`lastMsgAt` — the `subscription.list` sort key — plus `lastMsgId` and `lastMentionAllAt`)
pointing at the now-deleted message. The room would keep sorting by, and preview, a message
that no longer exists. The send path was the only writer of these fields (coalesced), so a
delete never corrected them.

This walks the room fields back to the latest surviving message on delete — the room-level
mirror of the thread-level `newThreadLastMsgAt` walk-back the delete event already carries.
`history-service` recomputes the post-delete room state and `broadcast-worker` applies it
directly to the room document when the deleted message was the room's current last.

## Changes

- **`pkg/model/event.go`** — `MessageEvent` gains transport-only walk-back fields
  (`newRoomLastRecomputed`, `newRoomLastMsgAt`, `newRoomLastMsgId`, `newRoomLastMentionAllAt`;
  `bson:"-"`, stripped before the client). `newRoomLastRecomputed` gates the apply so a hidden
  thread reply, a read degrade, or an older producer leaves the room fields untouched (rather
  than wrongly clearing them).
- **`history-service`** — on a non-hidden-reply delete, `fillRoomLastWalkback` reuses the same
  preview walk (`roomLastPreviewMessage`, now with an error-surfacing variant to tell an empty
  room from a read failure) to source the surviving last message; an empty room signals a clear.
  When the deleted message was itself an `@all`, a bounded backward walk recomputes the latest
  surviving `@all` for `lastMentionAllAt`.
- **`broadcast-worker`** — `handleDeleted` applies the walk-back via a new direct (un-coalesced)
  `SetRoomLastMessage` store method when `msg.ID == room.LastMsgID`; nil last-message pointers
  clear the fields (room emptied). It re-parses the deleted message's content to decide whether
  `lastMentionAllAt` shifts. Best-effort — the field is decorative and self-heals on the next
  message, so a write blip never redelivers the fan-out.
- **`docs/client-api.md`, `docs/client-api/events.md`, `docs/client-api/request-reply.md`** —
  document the client-observable behavior (room re-sorts / group-mention badge clears after a
  last-message delete).

Edit ±`@all` recompute is deferred (the edit producer doesn't yet recompute `lastMentionAllAt`);
noted as out of scope here.

## Verification

- `chat-lint ./...` — 0 issues.
- `go test ./pkg/model/... ./broadcast-worker/... ./history-service/internal/service/...` — pass.
- New tests: model round-trip (fields omitted when zero, round-trip when set, absent from BSON);
  history-service delete walk-back (surviving last message, empty-room clear, `@all` recompute);
  broadcast-worker `handleDeleted` (applies when deleted was last, skips when non-last, clears
  when emptied, touches `lastMentionAllAt` only for an `@all` delete).

🤖 Generated with Claude Code
