### PR TITLE
feat/make update event include hrInfo/appInfo for the counter person

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -1271,6 +1271,8 @@ Shared by Add Members, Remove Member, and Update Member Role.
 | `subscription` | [Subscription](#subscription) | For `added` / `role_updated`: the full Subscription record. On `added` it additionally embeds a populated `room` object ([SubscriptionRoom](#subscriptionroom)) — `previewMessage` always omitted; `privateKey`/`keyVersion` present only for encrypted channel rooms. For `removed`: a [RemovedSubscriptionRef](#removedsubscriptionref) lean ref (see Remove Member). |
 | `action` | string | `"added"`, `"removed"`, `"role_updated"`, `"mute_toggled"`, `"favorite_toggled"`, `"opened"`, or `"read"`. |
 | `roomName` | string | Per-subscriber display label, set only where the server already has the name. On `added`: `channel` → room name; `dm` → counterpart's display name (`engName` + `chineseName`, falling back to account); `botDM` → the bot's app name. On `role_updated`: the channel name. Omitted (`omitempty`) on `mute_toggled` / `favorite_toggled` / `opened` / `read`, and absent on `removed`. |
+| `hrInfo` | [CounterpartHRInfo](#counterparthrinfo) | The DM counterpart's HR record, so the client can render the new sidebar row without a `subscription.list` refetch. Sent on `added` `dm` / `botDM` events when the counterpart account does **not** end in `.bot` — i.e. to both sides of a `dm`, and to the bot's own copy of a `botDM`. On a self-DM (note-to-self) the counterpart is the recipient, so the event carries their own record. Omitted on `channel` / `discussion` rooms and when the user lookup missed. |
+| `appInfo` | [CounterpartAppInfo](#counterpartappinfo) | The counterpart's app record, sent on `added` `botDM` events when the counterpart account ends in `.bot` — i.e. to the human member. Mutually exclusive with `hrInfo`; omitted when the app lookup missed. |
 | `timestamp` | number | Epoch ms (UTC). |
 
 On `added` / `role_updated` / `mute_toggled` / `favorite_toggled` / `opened` the embedded `Subscription` serializes its ID as `id` (not `_id`) and the user under `u` (not `user`). Non-`omitempty` fields (`id`, `u`, `roomId`, `siteId`, `roles`, `name`, `roomType`, `joinedAt`, `hasMention`, `alert`, `muted`, `favorite`, `open`) are always present — and the envelope's `roomName` is `omitempty`: set on `added` / `role_updated`, omitted on `mute_toggled` / `favorite_toggled` / `opened` / `read`. On `added` the nested `room` object matches a `subscription.list` row (minus `previewMessage`), so clients can render the sidebar entry — and store the room key — from this single event. `removed` events use a dedicated lean payload (`SubscriptionRemovedEvent`) whose `subscription` carries **only** `roomId`, `roomType`, and `u` — no zero-valued `Subscription` fields are sent.
@@ -1306,6 +1308,40 @@ On `added` / `role_updated` / `mute_toggled` / `favorite_toggled` / `opened` the
 }
 ```
 
+On a newly created **DM** the event additionally carries the counterpart's `hrInfo` — everything the client needs to render the sidebar row on its own:
+
+```json
+{
+  "userId": "01970a4f8c2d7c9a01970a4f8c2d7c9a",
+  "subscription": {
+    "id": "01970a4f8c2d7c9a01970a4f8c2d7c9c",
+    "u": { "id": "01970a4f8c2d7c9a01970a4f8c2d7c9a", "account": "alice", "isBot": false },
+    "roomId": "01970a4f8c2d7c9a01970a4f8c2d7c9b",
+    "roomType": "dm",
+    "siteId": "siteA",
+    "roles": null,
+    "name": "bob",
+    "joinedAt": "2026-05-06T08:01:23Z",
+    "room": { "siteId": "siteA", "crossSite": false, "userCount": 2 }
+  },
+  "action": "added",
+  "roomName": "Bob Chan 陳大文",
+  "hrInfo": { "account": "bob", "chineseName": "陳大文", "engName": "Bob Chan" },
+  "timestamp": 1778054483000
+}
+```
+
+For a **botDM**, the human member's event carries `appInfo` instead (the bot's own copy of the event carries the human's `hrInfo`):
+
+```json
+{
+  "action": "added",
+  "roomName": "Helper Bot",
+  "appInfo": { "id": "01970a4f8c2d7c9aA1", "name": "Helper Bot", "assistantName": "helper.bot" },
+  "timestamp": 1778054483000
+}
+```
+
 **3.** ~~`chat.user.{newMember}.event.room.key`~~ — **no longer fired on add.** The room key is delivered inline on the `added` event above (`subscription.room.privateKey` / `keyVersion`); `room.key` events now fire only on key rotation (member removal). See [§5 Room Encryption](#5-room-encryption).
 
 **4. `chat.room.{roomID}.event.member` / `chat.local.room.{roomID}.event.member`** — a `MemberAddEvent` (`type: "member_added"`) published once whenever the room's member list actually changes: a new account joins, a genuinely new org is added, or an existing org member is upgraded to an individual membership (see the no-op note below for what does **not** fire). Routed on the room's namespace exactly like `chat.room.{roomID}.event` — pick the subject by the room's `crossSite` flag (`chat.local.room.{roomID}.event.member` when `crossSite: false`, `chat.room.{roomID}.event.member` when `crossSite: true`/unknown). Delivered to clients subscribed to the room on that namespace.
@@ -1327,6 +1363,28 @@ The event carries no separate account list — member identities are in `members
 
 > [!NOTE]
 > **No-op:** when the request changes nothing — every requested account already subscribed, no org member upgraded to an individual membership, and every requested org already present — the requester still gets an `AsyncJobResult` with `status: "ok"` but **no** `subscription.update` / `member_added` events follow. In particular, **re-adding an already-present org is a no-op**. An **org→individual upgrade** (an existing org member added individually) is **not** a no-op: `member_added` fires with that individual in `members`, but no `members_added` system message is posted (no one newly joined).
+
+###### CounterpartHRInfo
+
+| Field | Type | Notes |
+|---|---|---|
+| `account` | string | Counterpart's account. |
+| `chineseName` | string | Counterpart's native (Chinese) name. Omitted when empty. |
+| `engName` | string | Counterpart's English name. Omitted when empty. |
+
+> Both name fields are `omitempty`, so a directory record with neither yields `{"account": "..."}` alone — and `roomName` then falls back to the account.
+>
+> Same wire shape as the search hit's [MessageHRInfo](#messagehrinfo). The key is `chineseName` here, whereas [SubscriptionHRInfo](#subscriptionhrinfo) — the `hrInfo` nested on a `subscription.list` DM row — still uses the legacy `name`.
+>
+> **This divergence is deliberate.** PR #165 scoped the `chineseName` rekey to "search response only; other payloads untouched", deliberately leaving `subscription.list` on the legacy key. New and reshaped surfaces take `chineseName`; existing ones are not rekeyed. A client must therefore **not** reuse one `hrInfo` parser across the event and the list — it would silently drop the name on one of them.
+
+###### CounterpartAppInfo
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string | App ID. |
+| `name` | string | App display name. Empty string when the app document has no name — `roomName` then falls back to the bot account. |
+| `assistantName` | string | The bot account the app answers on. |
 
 ##### Triggered events — error path
 

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -107,6 +107,8 @@ Two shapes exist — discriminated by `action`:
 | `subscription` | [Subscription](../client-api.md#subscription) | Full Subscription record for `added` / `role_updated` / `mute_toggled` / `favorite_toggled` / `section_moved` / `opened` / `read`. On `added` it additionally embeds a populated `room` object ([SubscriptionRoom](../client-api.md#subscriptionroom)) — `previewMessage` always omitted; `privateKey`/`keyVersion` present only for encrypted channel rooms — so clients can render the sidebar entry and store the room key from this single event. On `section_moved`, `sectionId` / `sectionOrder` carry the new placement (both absent = removed from its section). On `read`, `hasMention` and `hasGroupMention` are both `false` — reading the room clears both. |
 | `action` | string | `"added"`, `"role_updated"`, `"mute_toggled"`, `"favorite_toggled"`, `"section_moved"`, `"opened"`, or `"read"`. |
 | `roomName` | string | Per-subscriber display label. On `added`: channel name / DM counterpart's display name / bot app name. On `role_updated`: the channel name. Omitted on `mute_toggled` / `favorite_toggled` / `section_moved` / `opened` / `read`. |
+| `hrInfo` | [CounterpartHRInfo](../client-api.md#counterparthrinfo) | `{account, chineseName, engName}` — the DM counterpart's HR record, so a newly created DM renders from this event alone. Sent on `added` `dm` / `botDM` when the counterpart account does **not** end in `.bot`; on a self-DM it carries the recipient's own record. Both name fields are `omitempty`. Omitted on `channel` / `discussion` rooms and on a lookup miss. |
+| `appInfo` | [CounterpartAppInfo](../client-api.md#counterpartappinfo) | `{id, name, assistantName}` — the counterpart's app record, sent on `added` `botDM` when the counterpart account ends in `.bot`. `name` is empty when the app document has none, and `roomName` then falls back to the bot account. Mutually exclusive with `hrInfo`; omitted on a lookup miss. |
 | `timestamp` | number | Epoch ms (UTC). |
 
 ```json
@@ -136,6 +138,30 @@ Two shapes exist — discriminated by `action`:
   },
   "action": "added",
   "roomName": "engineering-announcements",
+  "timestamp": 1778054483000
+}
+```
+
+A newly created **DM** carries the counterpart's `hrInfo`; a **botDM** carries `appInfo`
+on the human member's copy (the bot's copy carries the human's `hrInfo`):
+
+```json
+{
+  "userId": "01970a4f8c2d7c9a01970a4f8c2d7c9a",
+  "subscription": {
+    "id": "01970a4f8c2d7c9a01970a4f8c2d7c9c",
+    "u": { "id": "01970a4f8c2d7c9a01970a4f8c2d7c9a", "account": "alice", "isBot": false },
+    "roomId": "01970a4f8c2d7c9a01970a4f8c2d7c9b",
+    "roomType": "dm",
+    "siteId": "siteA",
+    "roles": null,
+    "name": "bob",
+    "joinedAt": "2026-05-06T08:01:23Z",
+    "room": { "siteId": "siteA", "crossSite": false, "userCount": 2 }
+  },
+  "action": "added",
+  "roomName": "Bob Chan 陳大文",
+  "hrInfo": { "account": "bob", "chineseName": "陳大文", "engName": "Bob Chan" },
   "timestamp": 1778054483000
 }
 ```

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -78,7 +78,27 @@ type SubscriptionUpdateEvent struct {
 	Subscription Subscription `json:"subscription"`
 	Action       string       `json:"action"` // "added" | "removed" | "role_updated" | "mute_toggled" | "favorite_toggled" | "read"
 	RoomName     string       `json:"roomName,omitempty"`
-	Timestamp    int64        `json:"timestamp" bson:"timestamp"`
+	// The DM counterpart, resolved at publish time alongside RoomName. Mutually
+	// exclusive, "added" dm/botDM only, both nil on a lookup miss (best-effort).
+	HRInfo    *CounterpartHRInfo  `json:"hrInfo,omitempty"`
+	AppInfo   *CounterpartAppInfo `json:"appInfo,omitempty"`
+	Timestamp int64               `json:"timestamp" bson:"timestamp"`
+}
+
+// CounterpartHRInfo is the DM counterpart's HR record on a subscription.update.
+// Kept apart from MessageHRInfo so search-only fields can't widen this event.
+type CounterpartHRInfo struct {
+	Account     string `json:"account"`
+	ChineseName string `json:"chineseName,omitempty"`
+	EngName     string `json:"engName,omitempty"`
+}
+
+// CounterpartAppInfo is the botDM counterpart's app record on a subscription.update.
+// AssistantName is the bot account the app answers on.
+type CounterpartAppInfo struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	AssistantName string `json:"assistantName"`
 }
 
 // CanonicalMemberEventMuted is the only event type currently published on this stream.

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -1235,6 +1235,110 @@ func TestSubscriptionUpdateEventJSON(t *testing.T) {
 	}
 }
 
+func TestSubscriptionUpdateEventCounterpartJSON(t *testing.T) {
+	base := model.Subscription{
+		ID:       "s1",
+		User:     model.SubscriptionUser{ID: "u1", Account: "alice"},
+		RoomID:   "r1",
+		SiteID:   "site-a",
+		JoinedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	tests := []struct {
+		name     string
+		src      model.SubscriptionUpdateEvent
+		wantKeys []string
+		absent   []string
+	}{
+		{
+			name: "dm carries hrInfo",
+			src: model.SubscriptionUpdateEvent{
+				UserID:       "u1",
+				Subscription: base,
+				Action:       "added",
+				RoomName:     "Bob Chan",
+				HRInfo:       &model.CounterpartHRInfo{Account: "bob", ChineseName: "陳大文", EngName: "Bob Chan"},
+				Timestamp:    1735689600000,
+			},
+			wantKeys: []string{`"hrInfo"`, `"account":"bob"`, `"chineseName":"陳大文"`, `"engName":"Bob Chan"`},
+			absent:   []string{`"appInfo"`},
+		},
+		{
+			name: "botDM carries appInfo",
+			src: model.SubscriptionUpdateEvent{
+				UserID:       "u1",
+				Subscription: base,
+				Action:       "added",
+				RoomName:     "Helper",
+				AppInfo:      &model.CounterpartAppInfo{ID: "app-1", Name: "Helper", AssistantName: "helper.bot"},
+				Timestamp:    1735689600000,
+			},
+			wantKeys: []string{`"appInfo"`, `"id":"app-1"`, `"name":"Helper"`, `"assistantName":"helper.bot"`},
+			absent:   []string{`"hrInfo"`},
+		},
+		{
+			name: "both omitted when unresolved",
+			src: model.SubscriptionUpdateEvent{
+				UserID:       "u1",
+				Subscription: base,
+				Action:       "added",
+				Timestamp:    1735689600000,
+			},
+			absent: []string{`"hrInfo"`, `"appInfo"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(&tt.src)
+			require.NoError(t, err)
+			for _, k := range tt.wantKeys {
+				assert.Contains(t, string(data), k)
+			}
+			for _, k := range tt.absent {
+				assert.NotContains(t, string(data), k)
+			}
+			var dst model.SubscriptionUpdateEvent
+			require.NoError(t, json.Unmarshal(data, &dst))
+			assert.Equal(t, tt.src, dst)
+		})
+	}
+}
+
+// Payloads written before hrInfo/appInfo existed must still decode — both fields
+// are omitempty pointers, so absent and explicit null both mean "no counterpart".
+func TestSubscriptionUpdateEventCounterpartDecodesLegacyPayload(t *testing.T) {
+	for _, raw := range []string{
+		`{"userId":"u1","action":"added","roomName":"eng","timestamp":1735689600000}`,
+		`{"userId":"u1","action":"added","hrInfo":null,"appInfo":null,"timestamp":1735689600000}`,
+	} {
+		var evt model.SubscriptionUpdateEvent
+		require.NoError(t, json.Unmarshal([]byte(raw), &evt))
+		assert.Nil(t, evt.HRInfo)
+		assert.Nil(t, evt.AppInfo)
+	}
+}
+
+func TestCounterpartHRInfoJSON(t *testing.T) {
+	src := model.CounterpartHRInfo{Account: "bob", ChineseName: "陳大文", EngName: "Bob Chan"}
+	roundTrip(t, &src, &model.CounterpartHRInfo{})
+
+	// Both names are omitempty; a directory record without them keeps only account.
+	data, err := json.Marshal(model.CounterpartHRInfo{Account: "dave"})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"account":"dave"}`, string(data))
+}
+
+func TestCounterpartAppInfoJSON(t *testing.T) {
+	src := model.CounterpartAppInfo{ID: "app-1", Name: "Helper Bot", AssistantName: "helper.bot"}
+	roundTrip(t, &src, &model.CounterpartAppInfo{})
+
+	// No field is omitempty, so a nameless app still ships all three keys.
+	data, err := json.Marshal(model.CounterpartAppInfo{ID: "app-2", AssistantName: "solo.bot"})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"id":"app-2","name":"","assistantName":"solo.bot"}`, string(data))
+}
+
 func TestInboxEventJSON(t *testing.T) {
 	src := model.InboxEvent{
 		Type:       "member_added",

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -2104,9 +2104,9 @@ func validateSyncCreateDMShape(req *model.SyncCreateDMRequest) error {
 	return nil
 }
 
-// resolveSubUpdateRoomName computes a subscription.update's roomName: the room name for
-// channels; for dm/botDM, app.Name when the counterpart is a bot account, else its display name.
-func (h *Handler) resolveSubUpdateRoomName(ctx context.Context, sub *model.Subscription, userByAccount map[string]*model.User) string {
+// resolveSubUpdateCounterpart computes a subscription.update's roomName plus the
+// counterpart: appInfo for a bot, hrInfo for a human, neither elsewhere. Best-effort.
+func (h *Handler) resolveSubUpdateCounterpart(ctx context.Context, sub *model.Subscription, userByAccount map[string]*model.User) (string, *model.CounterpartHRInfo, *model.CounterpartAppInfo) {
 	switch sub.RoomType {
 	case model.RoomTypeDM, model.RoomTypeBotDM:
 		cp := sub.Name
@@ -2115,21 +2115,36 @@ func (h *Handler) resolveSubUpdateRoomName(ctx context.Context, sub *model.Subsc
 		// resolves via the user map.
 		if model.IsBot(cp) {
 			app, err := h.store.GetApp(ctx, cp)
-			if err == nil && app.Name != "" {
-				return app.Name
+			if err != nil {
+				// ErrAppNotFound is discarded silently by decision: the account fallback
+				// is a fine label and the miss is not actionable per event.
+				if !errors.Is(err, ErrAppNotFound) {
+					slog.WarnContext(ctx, "resolve counterpart: GetApp failed; roomName falls back to bot account, appInfo omitted",
+						"request_id", natsutil.RequestIDFromContext(ctx), "botAccount", cp, "error", err)
+				}
+				return cp, nil, nil
 			}
-			if err != nil && !errors.Is(err, ErrAppNotFound) {
-				slog.WarnContext(ctx, "resolve roomName: GetApp failed, using account fallback",
-					"request_id", natsutil.RequestIDFromContext(ctx), "botAccount", cp, "error", err)
+			// AssistantName is cp by construction — GetApp filters on assistant.name == cp,
+			// and the doc can't supply it anyway (projection leaves Assistant nil).
+			appInfo := &model.CounterpartAppInfo{ID: app.ID, Name: app.Name, AssistantName: cp}
+			if app.Name == "" {
+				// Apps are always named, so this is a bad document; ship appInfo for its
+				// id but log which one, since roomName and appInfo.name now disagree.
+				slog.WarnContext(ctx, "resolve counterpart: app has no name; roomName falls back to bot account, appInfo.name empty",
+					"request_id", natsutil.RequestIDFromContext(ctx), "botAccount", cp, "app_id", app.ID)
+				return cp, nil, appInfo
 			}
-			return cp
+			return app.Name, nil, appInfo
 		}
 		if u, ok := userByAccount[cp]; ok {
-			return displayName(u)
+			hr := &model.CounterpartHRInfo{Account: u.Account, ChineseName: u.ChineseName, EngName: u.EngName}
+			return displayName(u), hr, nil
 		}
-		return cp
+		// Map miss is silent by decision — callers build it from users they already
+		// fetched, so the account fallback covers it.
+		return cp, nil, nil
 	default:
-		return sub.Name
+		return sub.Name, nil, nil
 	}
 }
 
@@ -2154,11 +2169,14 @@ func (h *Handler) publishSubscriptionAdded(ctx context.Context, subs []*model.Su
 	for _, sub := range subs {
 		subCopy := *sub
 		subCopy.Room = subRoom
+		roomName, hrInfo, appInfo := h.resolveSubUpdateCounterpart(ctx, sub, userByAccount)
 		evt := model.SubscriptionUpdateEvent{
 			UserID:       sub.User.ID,
 			Subscription: subCopy,
 			Action:       "added",
-			RoomName:     h.resolveSubUpdateRoomName(ctx, sub, userByAccount),
+			RoomName:     roomName,
+			HRInfo:       hrInfo,
+			AppInfo:      appInfo,
 			Timestamp:    tsMillis,
 		}
 		data, err := json.Marshal(evt)

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -3221,9 +3221,10 @@ func TestProcessCreateRoom_BotDM_HasIsSubscribed(t *testing.T) {
 			return capturedSubs[0], capturedSubs[1], nil
 		})
 
-	// finishCreateRoom calls resolveSubUpdateRoomName per sub; the human sub has
+	// finishCreateRoom calls resolveSubUpdateCounterpart per sub; the human sub has
 	// Name="helper.bot" (RoomTypeBotDM), so GetApp is invoked once.
-	mockStore.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(&model.App{Name: "Helper Bot"}, nil)
+	// Assistant left nil to match the real store's {"name":1} projection.
+	mockStore.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(&model.App{ID: "app-helper", Name: "Helper Bot"}, nil)
 
 	mockStore.EXPECT().ReconcileMemberCounts(gomock.Any(), "room-bot-1").Return(nil)
 
@@ -3260,6 +3261,9 @@ func TestProcessCreateRoom_BotDM_HasIsSubscribed(t *testing.T) {
 		}
 	}
 	assert.Equal(t, "Helper Bot", humanEvt.RoomName)
+	// ...and the app it is now talking to, so the client renders the row without a refetch.
+	assert.Equal(t, &model.CounterpartAppInfo{ID: "app-helper", Name: "Helper Bot", AssistantName: "helper.bot"}, humanEvt.AppInfo)
+	assert.Nil(t, humanEvt.HRInfo)
 
 	// bot (helper.bot) subscription.update must carry the human's display name,
 	// delivered on the bot's ENCODED per-user subject (helper.bot → helper_bot).
@@ -3274,6 +3278,8 @@ func TestProcessCreateRoom_BotDM_HasIsSubscribed(t *testing.T) {
 		}
 	}
 	assert.Equal(t, "Alice A 艾麗斯", botEvt.RoomName)
+	assert.Equal(t, &model.CounterpartHRInfo{Account: "alice", ChineseName: "艾麗斯", EngName: "Alice A"}, botEvt.HRInfo)
+	assert.Nil(t, botEvt.AppInfo)
 }
 
 // ---- Task 34: Channel branch tests ----
@@ -3948,6 +3954,11 @@ func TestHandleSyncCreateDM_SelfDM(t *testing.T) {
 	assert.Nil(t, evt.Subscription.Room.PrivateKey, "self-DM rooms are keyless — no key fields")
 	require.NotNil(t, evt.Subscription.Room.CrossSite)
 	assert.False(t, *evt.Subscription.Room.CrossSite)
+
+	// A self-DM's counterpart is the recipient, so the event carries their own record
+	// — a documented contract (docs/client-api.md) with no other test behind it.
+	assert.Equal(t, &model.CounterpartHRInfo{Account: "alice", ChineseName: "愛麗絲", EngName: "Alice"}, evt.HRInfo)
+	assert.Nil(t, evt.AppInfo)
 }
 
 func TestHandleSyncCreateDM_SelfDM_StoreErrors(t *testing.T) {
@@ -6876,9 +6887,10 @@ func TestHandler_bustRoomMeta_FailOpen(t *testing.T) {
 	assert.Equal(t, []string{roommetacache.MetaKey("r123")}, fake.dels)
 }
 
-func TestHandler_resolveSubUpdateRoomName(t *testing.T) {
+func TestHandler_resolveSubUpdateCounterpart(t *testing.T) {
 	alice := &model.User{Account: "alice", EngName: "Alice", ChineseName: "愛麗絲"}
 	users := map[string]*model.User{"alice": alice}
+	aliceHR := &model.CounterpartHRInfo{Account: "alice", ChineseName: "愛麗絲", EngName: "Alice"}
 
 	tests := []struct {
 		name      string
@@ -6886,9 +6898,11 @@ func TestHandler_resolveSubUpdateRoomName(t *testing.T) {
 		userMap   map[string]*model.User
 		setupMock func(s *MockSubscriptionStore)
 		want      string
+		wantHR    *model.CounterpartHRInfo
+		wantApp   *model.CounterpartAppInfo
 	}{
 		{
-			name: "channel uses sub.Name",
+			name: "channel uses sub.Name and carries no counterpart",
 			sub:  model.Subscription{RoomType: model.RoomTypeChannel, Name: "general"},
 			want: "general",
 		},
@@ -6897,31 +6911,68 @@ func TestHandler_resolveSubUpdateRoomName(t *testing.T) {
 			sub:     model.Subscription{RoomType: model.RoomTypeDM, Name: "alice"},
 			userMap: users,
 			want:    "Alice 愛麗絲",
+			wantHR:  aliceHR,
 		},
 		{
-			name:    "dm counterpart missing from map falls back to account",
+			name:    "dm counterpart missing from map falls back to account and omits hrInfo",
 			sub:     model.Subscription{RoomType: model.RoomTypeDM, Name: "carol"},
 			userMap: users,
 			want:    "carol",
 		},
 		{
-			name: "botDM resolves app name",
-			sub:  model.Subscription{RoomType: model.RoomTypeBotDM, Name: "helper.bot"},
-			setupMock: func(s *MockSubscriptionStore) {
-				s.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(&model.App{Name: "Helper Bot"}, nil)
-			},
-			want: "Helper Bot",
+			// Self-DM: buildSelfDMSub names the sub after the owner, so the "counterpart"
+			// is the recipient. A cp == sub.User.Account guard would break the documented
+			// contract without this row.
+			name:    "self-DM carries the recipient's own hrInfo",
+			sub:     model.Subscription{RoomType: model.RoomTypeDM, Name: "alice", User: model.SubscriptionUser{Account: "alice"}},
+			userMap: users,
+			want:    "Alice 愛麗絲",
+			wantHR:  aliceHR,
 		},
 		{
-			name: "botDM GetApp error falls back to bot account",
-			sub:  model.Subscription{RoomType: model.RoomTypeBotDM, Name: "broken.bot"},
+			// Degraded directory: user exists but has no names.
+			name:    "dm counterpart with no names still carries hrInfo",
+			sub:     model.Subscription{RoomType: model.RoomTypeDM, Name: "dave"},
+			userMap: map[string]*model.User{"dave": {Account: "dave"}},
+			want:    "dave",
+			wantHR:  &model.CounterpartHRInfo{Account: "dave"},
+		},
+		{
+			// Assistant nil as in production; assistantName comes from the queried account.
+			name: "botDM resolves app name and appInfo",
+			sub:  model.Subscription{RoomType: model.RoomTypeBotDM, Name: "helper.bot"},
+			setupMock: func(s *MockSubscriptionStore) {
+				s.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(&model.App{ID: "app-1", Name: "Helper Bot"}, nil)
+			},
+			want:    "Helper Bot",
+			wantApp: &model.CounterpartAppInfo{ID: "app-1", Name: "Helper Bot", AssistantName: "helper.bot"},
+		},
+		{
+			// The bot IS in userByAccount in production (FindUsersByAccounts returns it),
+			// so this pins that a failed app lookup does NOT silently fall back to the
+			// user map — a bot counterpart must never yield hrInfo.
+			name:    "botDM GetApp error omits appInfo and does not fall back to the user map",
+			sub:     model.Subscription{RoomType: model.RoomTypeBotDM, Name: "broken.bot"},
+			userMap: map[string]*model.User{"broken.bot": {Account: "broken.bot", EngName: "Broken Bot"}},
 			setupMock: func(s *MockSubscriptionStore) {
 				s.EXPECT().GetApp(gomock.Any(), "broken.bot").Return(nil, ErrAppNotFound)
 			},
 			want: "broken.bot",
 		},
 		{
-			name: "botDM GetApp infra error falls back to bot account",
+			// IsBot beats the map: a .bot counterpart present in userByAccount still
+			// takes the app path, never the human one.
+			name:    "botDM bot counterpart present in the map still resolves as an app",
+			sub:     model.Subscription{RoomType: model.RoomTypeBotDM, Name: "helper.bot"},
+			userMap: map[string]*model.User{"helper.bot": {Account: "helper.bot", EngName: "Helper Bot User"}},
+			setupMock: func(s *MockSubscriptionStore) {
+				s.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(&model.App{ID: "app-9", Name: "Helper Bot"}, nil)
+			},
+			want:    "Helper Bot",
+			wantApp: &model.CounterpartAppInfo{ID: "app-9", Name: "Helper Bot", AssistantName: "helper.bot"},
+		},
+		{
+			name: "botDM GetApp infra error falls back to bot account and omits appInfo",
 			sub:  model.Subscription{RoomType: model.RoomTypeBotDM, Name: "flaky.bot"},
 			setupMock: func(s *MockSubscriptionStore) {
 				s.EXPECT().GetApp(gomock.Any(), "flaky.bot").Return(nil, context.DeadlineExceeded)
@@ -6929,30 +6980,34 @@ func TestHandler_resolveSubUpdateRoomName(t *testing.T) {
 			want: "flaky.bot",
 		},
 		{
-			name: "botDM empty app name falls back to bot account",
+			name: "botDM empty app name falls back for roomName but still carries appInfo",
 			sub:  model.Subscription{RoomType: model.RoomTypeBotDM, Name: "nameless.bot"},
 			setupMock: func(s *MockSubscriptionStore) {
-				s.EXPECT().GetApp(gomock.Any(), "nameless.bot").Return(&model.App{Name: ""}, nil)
+				s.EXPECT().GetApp(gomock.Any(), "nameless.bot").Return(&model.App{ID: "app-3", Name: ""}, nil)
 			},
-			want: "nameless.bot",
+			want:    "nameless.bot",
+			wantApp: &model.CounterpartAppInfo{ID: "app-3", Name: "", AssistantName: "nameless.bot"},
 		},
 		{
 			name:    "botDM bot-side sub resolves human from map",
 			sub:     model.Subscription{RoomType: model.RoomTypeBotDM, Name: "alice"},
 			userMap: users,
 			want:    "Alice 愛麗絲",
+			wantHR:  aliceHR,
 		},
 		{
 			name:    "botDM p_ counterpart resolves as a user from map (has a user record)",
 			sub:     model.Subscription{RoomType: model.RoomTypeBotDM, Name: "p_admin"},
 			userMap: map[string]*model.User{"p_admin": {Account: "p_admin", EngName: "Pat", ChineseName: "派特"}},
 			want:    "Pat 派特",
+			wantHR:  &model.CounterpartHRInfo{Account: "p_admin", ChineseName: "派特", EngName: "Pat"},
 		},
 		{
 			name:    "botDM platform-admin pseudo-account resolves via user map, not GetApp",
 			sub:     model.Subscription{RoomType: model.RoomTypeBotDM, Name: "p_adminsiteA"},
 			userMap: map[string]*model.User{"p_adminsiteA": {Account: "p_adminsiteA", EngName: "Admin", ChineseName: "管理"}},
 			want:    "Admin 管理",
+			wantHR:  &model.CounterpartHRInfo{Account: "p_adminsiteA", ChineseName: "管理", EngName: "Admin"},
 		},
 		{
 			name:    "botDM p_ counterpart missing from map falls back to account",
@@ -6970,8 +7025,10 @@ func TestHandler_resolveSubUpdateRoomName(t *testing.T) {
 				tt.setupMock(store)
 			}
 			h := &Handler{store: store}
-			got := h.resolveSubUpdateRoomName(context.Background(), &tt.sub, tt.userMap)
+			got, hr, app := h.resolveSubUpdateCounterpart(context.Background(), &tt.sub, tt.userMap)
 			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantHR, hr)
+			assert.Equal(t, tt.wantApp, app)
 		})
 	}
 }
@@ -7041,6 +7098,64 @@ func TestServerCreateDM_BotDM_SetsAppNameForHuman(t *testing.T) {
 
 	assert.Equal(t, "Helper Bot", decodeSubUpdate(t, capture.captured, "alice").RoomName)
 	assert.Equal(t, "Alice", decodeSubUpdate(t, capture.captured, "helper.bot").RoomName)
+}
+
+// The "added" event must identify the counterpart so the client renders the
+// sidebar row without a subscription.list refetch.
+func TestServerCreateDM_DM_SetsCounterpartHRInfo(t *testing.T) {
+	h, store, capture := newSyncDMTestHandler(t)
+
+	requester := &model.User{ID: "u-alice", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛麗絲"}
+	other := &model.User{ID: "u-bob", Account: "bob", SiteID: "site-a", EngName: "Bob Chan", ChineseName: "陳大文"}
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return([]model.User{*requester, *other}, nil)
+	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().FindDMSubscriptionPair(gomock.Any(), gomock.Any(), "alice").Return(
+		&model.Subscription{User: model.SubscriptionUser{ID: "u-alice", Account: "alice"}, RoomType: model.RoomTypeDM, Name: "bob"},
+		&model.Subscription{User: model.SubscriptionUser{ID: "u-bob", Account: "bob"}, RoomType: model.RoomTypeDM, Name: "alice"},
+		nil)
+
+	req := model.SyncCreateDMRequest{RoomType: model.RoomTypeDM, RequesterAccount: "alice", OtherAccount: "bob"}
+	_, err := h.serverCreateDM(dmCtx(), req)
+	require.NoError(t, err)
+
+	// Each side gets the *other* person's HR record.
+	aliceEvt := decodeSubUpdate(t, capture.captured, "alice")
+	assert.Equal(t, &model.CounterpartHRInfo{Account: "bob", ChineseName: "陳大文", EngName: "Bob Chan"}, aliceEvt.HRInfo)
+	assert.Nil(t, aliceEvt.AppInfo, "human counterpart carries no appInfo")
+
+	bobEvt := decodeSubUpdate(t, capture.captured, "bob")
+	assert.Equal(t, &model.CounterpartHRInfo{Account: "alice", ChineseName: "愛麗絲", EngName: "Alice"}, bobEvt.HRInfo)
+	assert.Nil(t, bobEvt.AppInfo)
+}
+
+func TestServerCreateDM_BotDM_SetsCounterpartAppInfo(t *testing.T) {
+	h, store, capture := newSyncDMTestHandler(t)
+
+	requester := &model.User{ID: "u-alice", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛麗絲"}
+	bot := &model.User{ID: "u-bot", Account: "helper.bot", SiteID: "site-a"}
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return([]model.User{*requester, *bot}, nil)
+	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().FindDMSubscriptionPair(gomock.Any(), gomock.Any(), "alice").Return(
+		&model.Subscription{User: model.SubscriptionUser{ID: "u-alice", Account: "alice"}, RoomType: model.RoomTypeBotDM, Name: "helper.bot"},
+		&model.Subscription{User: model.SubscriptionUser{ID: "u-bot", Account: "helper.bot"}, RoomType: model.RoomTypeBotDM, Name: "alice"},
+		nil)
+	// Assistant left nil to match the real store's {"name":1} projection.
+	store.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(&model.App{ID: "app-1", Name: "Helper Bot"}, nil)
+
+	req := model.SyncCreateDMRequest{RoomType: model.RoomTypeBotDM, RequesterAccount: "alice", OtherAccount: "helper.bot"}
+	_, err := h.serverCreateDM(dmCtx(), req)
+	require.NoError(t, err)
+
+	// Human side sees the app; bot side sees the human.
+	humanEvt := decodeSubUpdate(t, capture.captured, "alice")
+	assert.Equal(t, &model.CounterpartAppInfo{ID: "app-1", Name: "Helper Bot", AssistantName: "helper.bot"}, humanEvt.AppInfo)
+	assert.Nil(t, humanEvt.HRInfo, "bot counterpart carries no hrInfo")
+
+	botEvt := decodeSubUpdate(t, capture.captured, "helper.bot")
+	assert.Equal(t, &model.CounterpartHRInfo{Account: "alice", ChineseName: "愛麗絲", EngName: "Alice"}, botEvt.HRInfo)
+	assert.Nil(t, botEvt.AppInfo)
 }
 
 func TestSubscriptionRoomFor(t *testing.T) {

--- a/room-worker/integration_test.go
+++ b/room-worker/integration_test.go
@@ -2398,6 +2398,10 @@ func TestMongoStore_GetApp_Integration(t *testing.T) {
 	app, err := store.GetApp(ctx, "helper.bot")
 	require.NoError(t, err)
 	assert.Equal(t, "Helper Bot", app.Name)
+	// Both projected fields feed appInfo; dropping _id would ship appInfo.id empty.
+	assert.Equal(t, "app1", app.ID)
+	// Not projected despite being in the document — appInfo.assistantName relies on this.
+	assert.Nil(t, app.Assistant)
 
 	_, err = store.GetApp(ctx, "missing.bot")
 	assert.ErrorIs(t, err, ErrAppNotFound)

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -210,11 +210,12 @@ func (s *MongoStore) GetUser(ctx context.Context, account string) (*model.User, 
 
 // GetApp reads the apps collection, which room-service owns and indexes
 // (assistant.name); room-worker only reads it and creates no index of its own.
-// Projects only name — the one field callers use (the botDM roomName).
+// Projects name + _id (both feed subscription.update's appInfo); Assistant is not
+// projected and so is always nil on the result.
 func (s *MongoStore) GetApp(ctx context.Context, botAccount string) (*model.App, error) {
 	var a model.App
 	err := s.apps.FindOne(ctx, bson.M{"assistant.name": botAccount},
-		options.FindOne().SetProjection(bson.M{"name": 1})).Decode(&a)
+		options.FindOne().SetProjection(bson.M{"name": 1, "_id": 1})).Decode(&a)
 	if errors.Is(err, mongo.ErrNoDocuments) {
 		return nil, ErrAppNotFound
 	}


### PR DESCRIPTION
## What

A newly created DM's `added` `subscription.update` carried the room view (`subscription.room`) but nothing identifying the person on the other side, so the client could not render the new sidebar row without refetching `subscription.list`.

This adds two fields to `SubscriptionUpdateEvent`, populated on `added` `dm`/`botDM` events:

| Field | Shape | Delivered to |
|---|---|---|
| `hrInfo` | `{account, chineseName, engName}` | both sides of a DM; the **bot's** copy of a botDM |
| `appInfo` | `{id, name, assistantName}` | the **human** member of a botDM |

Both are `omitempty` and mutually exclusive, so channel and discussion events are byte-identical to before.

## How

`resolveSubUpdateRoomName` became `resolveSubUpdateCounterpart`, returning `(roomName, hrInfo, appInfo)`. It reuses the lookups the fan-out already performed to compute `roomName` — the `GetApp` call for bot counterparts and the `userByAccount` map for humans — so **no extra queries**. Both create paths share this fan-out, so the async `room.create` worker and the server-server sync DM RPC are covered by one change.

Resolution is best-effort, matching how `roomName` already degraded: a lookup miss yields the account fallback and omits the field.

## Design decisions

- **Top-level on the event, not nested in `subscription`.** Nesting would make `Subscription.hrInfo` shadow `DMSubscription.hrInfo` at marshal time — the same JSON key carrying two different shapes depending on source. `roomName` is the existing precedent for a publish-time-resolved field on the envelope.
- **New `Counterpart*` types rather than reusing `Message*`.** The shapes match `MessageHRInfo`/`MessageAppInfo` from #165, but the contracts evolve independently — `MessageAppInfo.IsSubscribed` is exactly the kind of search-only field that must not silently widen this event.
- **`chineseName`, not the legacy `name`.** Follows #165, which scoped the rekey to "search response only; other payloads untouched". `subscription.list`'s `SubscriptionHRInfo` deliberately keeps `name`. This is now recorded in `docs/client-api.md` with a warning that one parser cannot serve both.
- **Backend only.** Same scope as #165, which shipped breaking wire changes without touching `chat-frontend`. This change is purely additive, so nothing that compiles today stops compiling. The frontend types still need `roomName`/`hrInfo`/`appInfo` added before the feature is usable end-to-end — worth tracking separately.

## Docs

`docs/client-api.md` gains both fields, the `CounterpartHRInfo`/`CounterpartAppInfo` tables, and DM + botDM examples; the derived `docs/client-api/events.md` mirrors it. `request-reply.md` needed no change — it links to the events view rather than duplicating the schema.

## Notes for the reviewer

- `GetApp` projects only `{"name": 1}`, so `appInfo.id` works solely because Mongo returns `_id` implicitly, and `app.Assistant` is always nil. `assistantName` comes from the queried bot account, which the query filter (`assistant.name == account`) guarantees. `TestMongoStore_GetApp_Integration` pins both facts, so adding an `_id: 0` exclusion later fails loudly instead of shipping an empty id.
- An app document with no name is a data defect; the resolver now WARNs with the app id rather than silently emitting an empty `appInfo.name`.

## Verification

- `make lint` — 0 issues
- `make test` — 104 packages ok, 0 failures
- `make test-integration SERVICE=room-worker` — 269 passed, 0 skipped, 0 failed
- `make sast-gosec` — 0 findings; repo-local `.semgrep` rules clean (`govulncheck` and the semgrep registry ruleset are network-blocked locally and run in CI)
- Coverage on changed code: `resolveSubUpdateCounterpart` 100%, `publishSubscriptionAdded` 83.3%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Subscription update events now include optional counterpart details for direct messages and bot direct messages.
  - Human counterpart information may include account and bilingual names.
  - Bot counterpart information may include app ID, name, and assistant name.
  - Event examples and API schemas document metadata delivery rules and fallback behavior.

- **Bug Fixes**
  - Improved counterpart resolution when directory or app information is unavailable.
  - Preserved app IDs while omitting unavailable assistant details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->