### PR TITLE
fix(translation): surface upstream 5XX/transport failures as errcode.Unavailable

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -5743,7 +5743,8 @@ See [Error envelope](#6-error-envelope-reference). The reply carries the `{ code
 | `bad_request` | `empty_text` | `text` is empty. |
 | `bad_request` | `unsupported_lang` | `targetLang` does not resolve to a supported language (outside the [Supported languages](#supported-languages) set, or a bare `zh` with no script/region). |
 | `unavailable` | — | Handler saturation — the concurrency cap is full; retry. |
-| `internal` | — | Translation backend failure. The raw cause is logged server-side, never returned. |
+| `unavailable` | `upstream_unavailable` | The third-party translation backend returned a 5XX or was unreachable (transport failure). Clients should show a "translation service temporarily unavailable" message and allow a retry. |
+| `internal` | — | Other translation backend failure (e.g. malformed stream, 4XX, non-success returnCode). The raw cause is logged server-side, never returned. |
 
 ```json
 {

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -2091,7 +2091,7 @@ with a `TranslateResult`, or the standard error envelope on failure.
 
 #### Error response
 
-Standard `{ code, reason?, error }` envelope. Key errors: `empty_text` (`bad_request`) for empty `text`; `unsupported_lang` (`bad_request`) for a `targetLang` outside the set; `unavailable` under handler saturation; `internal` for a backend failure. See [../client-api.md §3.6](../client-api.md#36-translation-service).
+Standard `{ code, reason?, error }` envelope. Key errors: `empty_text` (`bad_request`) for empty `text`; `unsupported_lang` (`bad_request`) for a `targetLang` outside the set; `unavailable` under handler saturation; `unavailable` / `upstream_unavailable` when the third-party backend returns a 5XX or is unreachable; `internal` for other backend failures. See [../client-api.md §3.6](../client-api.md#36-translation-service).
 
 **Emits:** none — the reply is the only output.
 

--- a/pkg/errcode/codes_translation.go
+++ b/pkg/errcode/codes_translation.go
@@ -3,6 +3,7 @@ package errcode
 // Translation-service client-facing reasons. Attached via WithReason so the
 // frontend can branch on the specific validation failure.
 const (
-	TranslateUnsupportedLang Reason = "unsupported_lang" // 400: targetLang not in the allowed set
-	TranslateEmptyText       Reason = "empty_text"       // 400: text is empty
+	TranslateUnsupportedLang     Reason = "unsupported_lang"     // 400: targetLang not in the allowed set
+	TranslateEmptyText           Reason = "empty_text"           // 400: text is empty
+	TranslateUpstreamUnavailable Reason = "upstream_unavailable" // 503: third-party translation backend returned 5XX or was unreachable
 )

--- a/translation-service/translator_stream.go
+++ b/translation-service/translator_stream.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-resty/resty/v2"
 
+	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/restyutil"
 )
 
@@ -90,7 +91,10 @@ func (t *streamTranslator) translateOnce(ctx context.Context, text, targetLang, 
 		SetDoNotParseResponse(true).
 		Post("")
 	if err != nil {
-		return "", false, fmt.Errorf("translate request: %w", err)
+		// Transport failure (connection refused / timeout / no response) — the
+		// third-party backend is unreachable, not our bug.
+		return "", false, errcode.Unavailable("translation upstream unavailable",
+			errcode.WithReason(errcode.TranslateUpstreamUnavailable), errcode.WithCause(err))
 	}
 	body := resp.RawBody()
 	defer body.Close()
@@ -139,6 +143,12 @@ readLoop:
 		// No SSE payload — the response is an error body, possibly a JWT rejection.
 		if isJWTFailure(nonSSE.String()) {
 			return "", true, nil
+		}
+		if resp.StatusCode() >= 500 {
+			// Upstream 5XX — third-party backend is down, not our bug. Only the
+			// numeric status is safe to surface; never the (untrusted) body.
+			return "", false, errcode.Unavailable("translation upstream unavailable",
+				errcode.WithReason(errcode.TranslateUpstreamUnavailable))
 		}
 		return "", false, fmt.Errorf("translate backend error (status %d)", resp.StatusCode())
 	}

--- a/translation-service/translator_stream.go
+++ b/translation-service/translator_stream.go
@@ -99,6 +99,13 @@ func (t *streamTranslator) translateOnce(ctx context.Context, text, targetLang, 
 	body := resp.RawBody()
 	defer body.Close()
 
+	// A 5XX is an outage regardless of body — classify before parsing, so a 5XX
+	// carrying data/JWT-shaped content can't read as success or trigger a refresh.
+	if s := resp.StatusCode(); s >= 500 && s < 600 {
+		return "", false, errcode.Unavailable("translation upstream unavailable",
+			errcode.WithReason(errcode.TranslateUpstreamUnavailable))
+	}
+
 	reader := bufio.NewReader(body)
 	var merged strings.Builder
 	var nonSSE strings.Builder // accumulates a non-SSE body (potential error JSON)
@@ -135,7 +142,10 @@ readLoop:
 			if readErr == io.EOF {
 				break readLoop
 			}
-			return "", false, fmt.Errorf("read stream: %w", readErr)
+			// Transport drop mid-stream (reset/timeout after headers) — same
+			// upstream-unavailable class as a failed request.
+			return "", false, errcode.Unavailable("translation upstream unavailable",
+				errcode.WithReason(errcode.TranslateUpstreamUnavailable), errcode.WithCause(readErr))
 		}
 	}
 
@@ -143,12 +153,6 @@ readLoop:
 		// No SSE payload — the response is an error body, possibly a JWT rejection.
 		if isJWTFailure(nonSSE.String()) {
 			return "", true, nil
-		}
-		if resp.StatusCode() >= 500 {
-			// Upstream 5XX — third-party backend is down, not our bug. Only the
-			// numeric status is safe to surface; never the (untrusted) body.
-			return "", false, errcode.Unavailable("translation upstream unavailable",
-				errcode.WithReason(errcode.TranslateUpstreamUnavailable))
 		}
 		return "", false, fmt.Errorf("translate backend error (status %d)", resp.StatusCode())
 	}

--- a/translation-service/translator_stream_test.go
+++ b/translation-service/translator_stream_test.go
@@ -255,3 +255,52 @@ func TestStreamTranslator_TransportErrorUnavailable(t *testing.T) {
 	assert.Equal(t, errcode.CodeUnavailable, ec.Code)
 	assert.Equal(t, errcode.TranslateUpstreamUnavailable, ec.Reason)
 }
+
+// A 5XX carrying valid-looking SSE data must still classify as Unavailable — the
+// status is checked before the body is parsed, so no translation leaks out.
+func TestStreamTranslator_Upstream5xxWithDataUnavailable(t *testing.T) {
+	tSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = io.WriteString(w, "data: {\"returnCode\":0,\"returnData\":{\"translation\":\"leak\"}}\ndata: [DONE]\n")
+	}))
+	defer tSrv.Close()
+
+	tr := streamTranslatorTo(t, tSrv.URL)
+	out, err := tr.Translate(context.Background(), "hi", "en")
+	require.Error(t, err)
+	assert.Empty(t, out) // the 5XX must not surface the "translation"
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.CodeUnavailable, ec.Code)
+	assert.Equal(t, errcode.TranslateUpstreamUnavailable, ec.Reason)
+}
+
+// A connection drop mid-stream (a non-EOF read error after headers arrive)
+// classifies as Unavailable, same as an up-front transport failure.
+func TestStreamTranslator_MidStreamDropUnavailable(t *testing.T) {
+	tSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		// 200 promising more body than we send, then abrupt close → the client's
+		// stream read fails with io.ErrUnexpectedEOF mid-stream.
+		_, _ = io.WriteString(conn, "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: 4096\r\n\r\n")
+		_, _ = io.WriteString(conn, ": keep-alive partial line without a newline")
+		_ = conn.Close()
+	}))
+	defer tSrv.Close()
+
+	tr := streamTranslatorTo(t, tSrv.URL)
+	_, err := tr.Translate(context.Background(), "hi", "en")
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.CodeUnavailable, ec.Code)
+	assert.Equal(t, errcode.TranslateUpstreamUnavailable, ec.Reason)
+}

--- a/translation-service/translator_stream_test.go
+++ b/translation-service/translator_stream_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/errcode"
 )
 
 // sseServer writes each line verbatim with the SSE framing the client expects.
@@ -91,6 +93,9 @@ func TestStreamTranslator_NonSuccessCodeErrors(t *testing.T) {
 	_, err := tr.Translate(context.Background(), "hi", "en")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "96500")
+	// A returnCode rejection is a normal backend reply, not an upstream outage.
+	var ec *errcode.Error
+	assert.NotErrorAs(t, err, &ec)
 }
 
 func TestStreamTranslator_MissingDoneErrors(t *testing.T) {
@@ -201,11 +206,12 @@ func TestStreamTranslator_RefreshErrorAfterJWTFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "refresh access token after jwt failure")
 }
 
-// A non-JWT error body with no SSE data surfaces a sanitized backend error.
+// A non-JWT 4XX error body with no SSE data surfaces a sanitized backend error
+// (not Unavailable — a 4XX is a caller/backend-contract issue, not an outage).
 func TestStreamTranslator_BackendErrorNonJWT(t *testing.T) {
 	tSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = io.WriteString(w, `<html>internal server error</html>`) // not SSE, not JWT JSON
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `<html>bad request</html>`) // not SSE, not JWT JSON
 	}))
 	defer tSrv.Close()
 
@@ -213,4 +219,39 @@ func TestStreamTranslator_BackendErrorNonJWT(t *testing.T) {
 	_, err := tr.Translate(context.Background(), "hi", "en")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "translate backend error")
+	var ec *errcode.Error
+	assert.NotErrorAs(t, err, &ec)
+}
+
+// An upstream 5XX with no SSE data classifies as errcode.Unavailable so the
+// client can show a "third-party unavailable" message instead of a generic error.
+func TestStreamTranslator_Upstream5xxUnavailable(t *testing.T) {
+	tSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = io.WriteString(w, `<html>upstream down</html>`) // not SSE, not JWT JSON
+	}))
+	defer tSrv.Close()
+
+	tr := streamTranslatorTo(t, tSrv.URL)
+	_, err := tr.Translate(context.Background(), "hi", "en")
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.CodeUnavailable, ec.Code)
+	assert.Equal(t, errcode.TranslateUpstreamUnavailable, ec.Reason)
+}
+
+// A transport failure (backend unreachable) classifies as errcode.Unavailable.
+func TestStreamTranslator_TransportErrorUnavailable(t *testing.T) {
+	tSrv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := tSrv.URL
+	tSrv.Close() // connections to url are now refused
+
+	tr := streamTranslatorTo(t, url)
+	_, err := tr.Translate(context.Background(), "hi", "en")
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.CodeUnavailable, ec.Code)
+	assert.Equal(t, errcode.TranslateUpstreamUnavailable, ec.Reason)
 }


### PR DESCRIPTION
## Summary

When the third-party translation backend is down — a transport failure (connection refused / timeout) or a 5XX response — `translation-service` returned a raw `fmt.Errorf`, which collapses to `internal` at the NATS boundary. The client then can't distinguish "third-party service is down" from "our bug."

This classifies those two upstream-failure cases as `errcode.Unavailable` with a new `upstream_unavailable` reason, so the client can show a "translation service temporarily unavailable" message and offer a retry. All other failures (malformed stream, 4XX, non-success `returnCode`, missing `[DONE]`) are unchanged and still collapse to `internal`.

## Changes

- `pkg/errcode/codes_translation.go` — add `TranslateUpstreamUnavailable Reason = "upstream_unavailable"` (same wire value already used by other services' upstream-outage cases).
- `translation-service/translator_stream.go` `translateOnce`:
  - transport error (no response) → `errcode.Unavailable(..., WithReason(TranslateUpstreamUnavailable), WithCause(err))`.
  - non-SSE error body with `StatusCode() >= 500` → `errcode.Unavailable(..., WithReason(TranslateUpstreamUnavailable))` (status code only; the untrusted body is never surfaced or logged as a cause). Sub-5XX keeps the existing sanitized `translate backend error (status N)`.
- `docs/client-api.md` §3.6 + `docs/client-api/request-reply.md` — document the new `unavailable` / `upstream_unavailable` error case.
- Tests — upstream 503 and transport failure assert `CodeUnavailable` + the reason via `errors.As`; a non-JWT 4XX and a non-success `returnCode` assert they are NOT classified as `Unavailable`.

## Verification

- `go test ./translation-service/... ./pkg/errcode/...` — pass.
- Lint (golangci-lint) on the touched packages — 0 issues.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Translation backend outages and unreachable services are now reported as `unavailable` with an `upstream_unavailable` reason.
  - Other backend failures, including malformed responses and client-side errors, continue to be reported as `internal`.
  - Underlying failure details remain protected from end users.

- **Documentation**
  - Updated translation error references to reflect the refined error classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->