### PR TITLE
perf(room-service): index + wider gap for chatlist section ordering

### DIFF
--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -4232,3 +4232,29 @@ func TestMongoStore_ClearSubscriptionThreadUnreadForAccount_Integration(t *testi
 	assert.Equal(t, []string{"p9"}, bobRaw.ThreadUnread)
 	assert.True(t, bobRaw.Alert)
 }
+
+// RebalanceSection renumbers a section's rows spaced by 10, not 1, so later
+// midpoint inserts rarely exhaust the gap.
+func TestMongoStore_RebalanceSection_SpacesByTen(t *testing.T) {
+	ctx := context.Background()
+	db := setupMongo(t)
+	store := NewMongoStore(db)
+
+	// Three chats in one section with collapsed near-zero orders (forces a renumber).
+	for i, rid := range []string{"r1", "r2", "r3"} {
+		mustInsertSub(t, db, &model.Subscription{
+			ID:           "s" + rid,
+			User:         model.SubscriptionUser{ID: "u" + rid, Account: "alice"},
+			RoomID:       rid,
+			SectionId:    strPtr("sec1"),
+			SectionOrder: float64(i) * 0.0001,
+		})
+	}
+
+	out, err := store.RebalanceSection(ctx, "alice", "sec1", time.Now())
+	require.NoError(t, err)
+	require.Len(t, out, 3)
+	for i := range out {
+		assert.Equal(t, float64((i+1)*10), out[i].SectionOrder, "row %d spaced by 10", i)
+	}
+}

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -1134,7 +1134,7 @@ func (s *MongoStore) MoveSubscriptionSection(ctx context.Context, roomID, accoun
 // ComputeSectionOrder midpoints a new position within (account, sectionID). Two
 // small indexed reads in the placed case (the afterRoomID sub, then the next
 // higher order); one in the append case (the section max). Both afterRoomID and
-// beforeRoomID empty ⇒ append at the section end (max order + gap).
+// beforeRoomID empty ⇒ append at the section end (max order + 1).
 func (s *MongoStore) ComputeSectionOrder(ctx context.Context, account, sectionID, afterRoomID, beforeRoomID string) (float64, bool, error) {
 	secFilter := bson.M{"u.account": account, "sectionId": sectionID}
 	if beforeRoomID != "" {

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -139,6 +139,13 @@ func (s *MongoStore) EnsureIndexes(ctx context.Context) error {
 	}); err != nil {
 		return fmt.Errorf("ensure subscriptions (u.account,name) index: %w", err)
 	}
+	// Backs ComputeSectionOrder + section rebalance (filter u.account+sectionId,
+	// sort sectionOrder); without it, section moves fall back to an in-memory sort.
+	if _, err := s.subscriptions.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{{Key: "u.account", Value: 1}, {Key: "sectionId", Value: 1}, {Key: "sectionOrder", Value: 1}},
+	}); err != nil {
+		return fmt.Errorf("ensure subscriptions (u.account,sectionId,sectionOrder) index: %w", err)
+	}
 	// Backs getRoomSubscriptions: filter roomId, sort {joinedAt, _id} with
 	// skip/limit pagination. Including the sort keys lets Mongo return ordered
 	// pages from the index instead of an in-memory sort that risks the 32MB
@@ -1126,7 +1133,8 @@ func (s *MongoStore) MoveSubscriptionSection(ctx context.Context, roomID, accoun
 
 // ComputeSectionOrder midpoints a new position within (account, sectionID). Two
 // small indexed reads in the placed case (the afterRoomID sub, then the next
-// higher order); one in the append case (the section max).
+// higher order); one in the append case (the section max). Both afterRoomID and
+// beforeRoomID empty ⇒ append at the section end (max order + gap).
 func (s *MongoStore) ComputeSectionOrder(ctx context.Context, account, sectionID, afterRoomID, beforeRoomID string) (float64, bool, error) {
 	secFilter := bson.M{"u.account": account, "sectionId": sectionID}
 	if beforeRoomID != "" {
@@ -1242,7 +1250,8 @@ func (s *MongoStore) RebalanceSection(ctx context.Context, account, sectionID st
 	}
 	models := make([]mongo.WriteModel, 0, len(subs))
 	for i := range subs {
-		subs[i].SectionOrder = float64(i + 1)
+		// Space by 10, not 1, so later midpoint inserts rarely exhaust the gap and re-rebalance.
+		subs[i].SectionOrder = float64((i + 1) * 10)
 		subs[i].SectionUpdatedAt = &now
 		models = append(models, mongo.NewUpdateOneModel().
 			SetFilter(bson.M{"roomId": subs[i].RoomID, "u.account": account}).


### PR DESCRIPTION
## Summary

Two small follow-ups from the customizable-chatlist-sections review: add the compound
index backing the section-order queries, and widen the rebalance gap.

## Changes

- **Index** — add `{u.account:1, sectionId:1, sectionOrder:1}` to `EnsureIndexes`.
  `ComputeSectionOrder` and `RebalanceSection` filter `{u.account, sectionId}` and sort
  `sectionOrder`; without this index they fell back to the `{u.account, name}` index plus
  an in-memory sort.
- **Wider gap** — `RebalanceSection` now spaces orders by 10 (`(i+1)*10`) instead of 1, so
  later midpoint inserts rarely exhaust the gap and trigger another rebalance.
- **Doc** — clarify that both position refs empty appends at the section end.

## Verification

golangci-lint clean; `room-service` tests pass.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved section ordering query performance with an optimized subscription index.

* **Bug Fixes**
  * Improved section rebalancing stability by using spaced ordering values, reducing the need for frequent renumbering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->