### PR TITLE
feat(chat-frontend): customizable chatlist sections (v2 sidebar)

### DIFF
--- a/chat-frontend/src/api/_transport/chatlistMock.test.ts
+++ b/chat-frontend/src/api/_transport/chatlistMock.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  __resetChatlistMock,
+  getChatlistMock,
+  createSectionMock,
+  renameSectionMock,
+  deleteSectionMock,
+  reorderSectionsMock,
+  setSectionSortModeMock,
+  moveChatMock,
+  onChatlistUpdateMock,
+  onSectionMovedMock,
+  MockChatlistError,
+} from './chatlistMock'
+import type { DMSubscription } from '../types'
+
+beforeEach(() => __resetChatlistMock())
+
+describe('chatlistMock section defs', () => {
+  it('starts from the four built-ins', () => {
+    const s = getChatlistMock()
+    expect(s.sectionOrder).toEqual(['favorites', 'apps', 'teams', 'chats'])
+    expect(s.sections.every((x) => x.builtIn)).toBe(true)
+  })
+
+  it('creates a custom section slotted above chats and emits an update', () => {
+    const cb = vi.fn()
+    onChatlistUpdateMock(cb)
+    const s = createSectionMock('Work', 'custom')
+    const work = s.sections.find((x) => x.name === 'Work')
+    expect(work).toMatchObject({ builtIn: false, sortMode: 'custom' })
+    // slotted just before chats
+    expect(s.sectionOrder.indexOf(work!.id)).toBe(s.sectionOrder.indexOf('chats') - 1)
+    expect(cb).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a duplicate custom name', () => {
+    createSectionMock('Work')
+    expect(() => createSectionMock('Work')).toThrow(MockChatlistError)
+  })
+
+  it('rejects an invalid name', () => {
+    expect(() => createSectionMock('bad  spaces')).toThrowError(/chatlist_invalid_name/)
+  })
+
+  it('rejects rename/delete of a built-in', () => {
+    expect(() => renameSectionMock('chats', 'Nope')).toThrowError(/chatlist_builtin_immutable/)
+    expect(() => deleteSectionMock('favorites')).toThrowError(/chatlist_builtin_immutable/)
+  })
+
+  it('delete orphans members (drops membership) and removes the def', () => {
+    const s = createSectionMock('Work')
+    const id = s.sections.find((x) => x.name === 'Work')!.id
+    moveChatMock('r1', id)
+    deleteSectionMock(id)
+    expect(getChatlistMock().sections.some((x) => x.id === id)).toBe(false)
+    // moving r1 again appends at 1 (membership was cleared)
+    const res = moveChatMock('r1', createSectionMock('P').sections.find((x) => x.name === 'P')!.id)
+    expect(res.sectionOrder).toBe(1)
+  })
+
+  it('reorder rejects a non-permutation', () => {
+    expect(() => reorderSectionsMock(['favorites'])).toThrowError(/chatlist_invalid_order/)
+  })
+
+  it('setSortMode flips a built-in to custom', () => {
+    const s = setSectionSortModeMock('chats', 'custom')
+    expect(s.sections.find((x) => x.id === 'chats')!.sortMode).toBe('custom')
+  })
+})
+
+describe('chatlistMock moveChat', () => {
+  it('appends fractional order and fans section_moved', () => {
+    const cb = vi.fn()
+    onSectionMovedMock(cb)
+    const id = createSectionMock('Work').sections.find((x) => x.name === 'Work')!.id
+    expect(moveChatMock('r1', id).sectionOrder).toBe(1)
+    expect(moveChatMock('r2', id).sectionOrder).toBe(2)
+    // insert r3 after r1 → midpoint 1.5
+    expect(moveChatMock('r3', id, 'r1').sectionOrder).toBe(1.5)
+    expect(cb).toHaveBeenCalledTimes(3)
+    expect(cb.mock.calls[0][0]).toMatchObject({ action: 'section_moved' })
+  })
+
+  it('rejects a built-in target', () => {
+    expect(() => moveChatMock('r1', 'favorites')).toThrowError(/chatlist_builtin_target/)
+  })
+
+  it('remove (null) clears membership and emits with no order', () => {
+    const cb = vi.fn()
+    onSectionMovedMock(cb)
+    const id = createSectionMock('Work').sections.find((x) => x.name === 'Work')!.id
+    moveChatMock('r1', id)
+    const res = moveChatMock('r1', null)
+    expect(res).toEqual({ status: 'ok' })
+    expect(cb.mock.calls.at(-1)![0].subscription.sectionId).toBeUndefined()
+  })
+})
+
+describe('chatlistMock unsubscribe', () => {
+  it('stops delivering after unsubscribe', () => {
+    const cb = vi.fn()
+    const unsub = onChatlistUpdateMock(cb)
+    createSectionMock('A')
+    unsub()
+    createSectionMock('B')
+    expect(cb).toHaveBeenCalledOnce()
+  })
+})
+
+// seedChatlistMock is exercised via the reducer/hook wiring; a light check here.
+describe('seedChatlistMock', () => {
+  it('is a no-op-safe reseed once custom sections exist', async () => {
+    const { seedChatlistMock } = await import('./chatlistMock')
+    const subs = Array.from({ length: 8 }, (_, i) => ({
+      roomId: `r${i}`,
+      roomType: 'channel',
+      u: { id: `u${i}`, account: `a${i}` },
+    })) as unknown as DMSubscription[]
+    const first = seedChatlistMock(subs)
+    expect(Object.keys(first.membership).length).toBeGreaterThan(0)
+    const second = seedChatlistMock(subs)
+    // already seeded → returns existing membership, doesn't double-create sections
+    expect(getChatlistMock().sections.filter((s) => !s.builtIn)).toHaveLength(2)
+    expect(Object.keys(second.membership).length).toBe(Object.keys(first.membership).length)
+  })
+})

--- a/chat-frontend/src/api/_transport/chatlistMock.ts
+++ b/chat-frontend/src/api/_transport/chatlistMock.ts
@@ -39,16 +39,12 @@ const chatlistListeners = new Set<ChatlistListener>()
 const sectionMovedListeners = new Set<SectionMovedListener>()
 let idCounter = 0
 
-function now(): number {
-  return Date.now()
-}
-
 function clone(s: ChatlistState): ChatlistState {
   return { sectionOrder: [...s.sectionOrder], sections: s.sections.map((x) => ({ ...x })), lastUpdatedAt: s.lastUpdatedAt }
 }
 
 function emitChatlist(): void {
-  state.lastUpdatedAt = now()
+  state.lastUpdatedAt = Date.now()
   const snapshot = clone(state)
   chatlistListeners.forEach((cb) => cb({ timestamp: snapshot.lastUpdatedAt, chatlist: snapshot }))
 }
@@ -172,7 +168,7 @@ export function moveChatMock(
   const evt: SubscriptionUpdateEvent = {
     userId: 'mock',
     action: 'section_moved',
-    timestamp: now(),
+    timestamp: Date.now(),
     subscription: {
       roomId,
       sectionId: sectionId ?? undefined,

--- a/chat-frontend/src/api/_transport/chatlistMock.ts
+++ b/chat-frontend/src/api/_transport/chatlistMock.ts
@@ -1,0 +1,233 @@
+// DEV-ONLY in-memory mock of the chatlist backend (user-service + room-service
+// chat.move). Enabled via the CHATLIST_MOCK runtime flag so the grouped
+// sidebar can be demoed before the backend RPCs land. Mirrors the documented
+// wire shapes 1:1, and emits through two emitters that mirror the two real
+// subjects (chatlist.update + subscription.update/section_moved), so flipping
+// the flag off routes every op to real NATS with no consumer change.
+//
+// Not imported by production paths — every call site guards on CHATLIST_MOCK.
+
+import {
+  BUILTIN_CHATS,
+  defaultChatlistState,
+  isBuiltinSectionId,
+  validateSectionName,
+} from '@/lib/chatlist'
+import type {
+  ChatlistState,
+  ChatlistSortMode,
+  DMSubscription,
+  SubscriptionUpdateEvent,
+} from '../types'
+
+type ChatlistListener = (evt: { timestamp: number; chatlist: ChatlistState }) => void
+type SectionMovedListener = (evt: SubscriptionUpdateEvent) => void
+
+/** Wire-shaped errcode-lite thrown by the mock so callers see the same
+ *  `.reason` they'd get from the real backend envelope. */
+export class MockChatlistError extends Error {
+  reason: string
+  constructor(reason: string) {
+    super(reason)
+    this.reason = reason
+  }
+}
+
+let state: ChatlistState = defaultChatlistState()
+const membership = new Map<string, { sectionId?: string; sectionOrder?: number }>()
+const chatlistListeners = new Set<ChatlistListener>()
+const sectionMovedListeners = new Set<SectionMovedListener>()
+let idCounter = 0
+
+function now(): number {
+  return Date.now()
+}
+
+function clone(s: ChatlistState): ChatlistState {
+  return { sectionOrder: [...s.sectionOrder], sections: s.sections.map((x) => ({ ...x })), lastUpdatedAt: s.lastUpdatedAt }
+}
+
+function emitChatlist(): void {
+  state.lastUpdatedAt = now()
+  const snapshot = clone(state)
+  chatlistListeners.forEach((cb) => cb({ timestamp: snapshot.lastUpdatedAt, chatlist: snapshot }))
+}
+
+/** Reset all mock state — test helper. */
+export function __resetChatlistMock(): void {
+  state = defaultChatlistState()
+  membership.clear()
+  chatlistListeners.clear()
+  sectionMovedListeners.clear()
+  idCounter = 0
+}
+
+export function getChatlistMock(): ChatlistState {
+  return clone(state)
+}
+
+function requireCustom(sectionId: string) {
+  const sec = state.sections.find((s) => s.id === sectionId)
+  if (!sec) throw new MockChatlistError('chatlist_section_not_found')
+  if (sec.builtIn) throw new MockChatlistError('chatlist_builtin_immutable')
+  return sec
+}
+
+export function createSectionMock(name: string, sortMode: ChatlistSortMode = 'custom'): ChatlistState {
+  const v = validateSectionName(name)
+  if (!v.ok) throw new MockChatlistError(v.reason)
+  if (state.sections.some((s) => !s.builtIn && s.name === v.name))
+    throw new MockChatlistError('chatlist_duplicate_name')
+  const id = `mock-section-${++idCounter}`
+  state.sections.push({ id, name: v.name, builtIn: false, sortMode })
+  // Slot the new custom section just above the built-in Chats.
+  const chatsIdx = state.sectionOrder.indexOf(BUILTIN_CHATS)
+  state.sectionOrder.splice(chatsIdx < 0 ? state.sectionOrder.length : chatsIdx, 0, id)
+  emitChatlist()
+  return clone(state)
+}
+
+export function renameSectionMock(sectionId: string, name: string): ChatlistState {
+  const sec = requireCustom(sectionId)
+  const v = validateSectionName(name)
+  if (!v.ok) throw new MockChatlistError(v.reason)
+  if (state.sections.some((s) => !s.builtIn && s.id !== sectionId && s.name === v.name))
+    throw new MockChatlistError('chatlist_duplicate_name')
+  sec.name = v.name
+  emitChatlist()
+  return clone(state)
+}
+
+export function deleteSectionMock(sectionId: string): ChatlistState {
+  requireCustom(sectionId)
+  state.sections = state.sections.filter((s) => s.id !== sectionId)
+  state.sectionOrder = state.sectionOrder.filter((id) => id !== sectionId)
+  // Members orphan to Chats — drop their membership (derived fallback handles it).
+  membership.forEach((m, roomId) => {
+    if (m.sectionId === sectionId) membership.delete(roomId)
+  })
+  emitChatlist()
+  return clone(state)
+}
+
+export function reorderSectionsMock(sectionOrder: string[]): ChatlistState {
+  const known = new Set(state.sections.map((s) => s.id))
+  const sameSet = sectionOrder.length === known.size && sectionOrder.every((id) => known.has(id))
+  if (!sameSet) throw new MockChatlistError('chatlist_invalid_order')
+  state.sectionOrder = [...sectionOrder]
+  emitChatlist()
+  return clone(state)
+}
+
+export function setSectionSortModeMock(sectionId: string, sortMode: ChatlistSortMode): ChatlistState {
+  if (sortMode !== 'custom' && sortMode !== 'mostRecent')
+    throw new MockChatlistError('chatlist_invalid_sort_mode')
+  const sec = state.sections.find((s) => s.id === sectionId)
+  if (!sec) throw new MockChatlistError('chatlist_section_not_found')
+  sec.sortMode = sortMode
+  emitChatlist()
+  return clone(state)
+}
+
+/** Fractional order for an insert: midpoint after `afterRoomId`, else append. */
+function computeOrder(sectionId: string, afterRoomId?: string): number {
+  const orders = [...membership.entries()]
+    .filter(([, m]) => m.sectionId === sectionId && typeof m.sectionOrder === 'number')
+    .map(([roomId, m]) => ({ roomId, order: m.sectionOrder as number }))
+    .sort((a, b) => a.order - b.order)
+  if (!afterRoomId) return (orders.at(-1)?.order ?? 0) + 1
+  const idx = orders.findIndex((o) => o.roomId === afterRoomId)
+  if (idx < 0) return (orders.at(-1)?.order ?? 0) + 1
+  const prev = orders[idx].order
+  const next = orders[idx + 1]?.order
+  return next === undefined ? prev + 1 : (prev + next) / 2
+}
+
+export interface MoveChatMockResult {
+  status: 'ok'
+  sectionId?: string
+  sectionOrder?: number
+}
+
+export function moveChatMock(
+  roomId: string,
+  sectionId: string | null,
+  afterRoomId?: string,
+): MoveChatMockResult {
+  if (sectionId !== null) {
+    if (isBuiltinSectionId(sectionId)) throw new MockChatlistError('chatlist_builtin_target')
+    if (!state.sections.some((s) => s.id === sectionId))
+      throw new MockChatlistError('chatlist_section_not_found')
+  }
+  let result: MoveChatMockResult
+  if (sectionId === null) {
+    membership.delete(roomId)
+    result = { status: 'ok' }
+  } else {
+    const sectionOrder = computeOrder(sectionId, afterRoomId)
+    membership.set(roomId, { sectionId, sectionOrder })
+    result = { status: 'ok', sectionId, sectionOrder }
+  }
+  // Fan out a section_moved subscription.update, exactly as the backend would.
+  const evt: SubscriptionUpdateEvent = {
+    userId: 'mock',
+    action: 'section_moved',
+    timestamp: now(),
+    subscription: {
+      roomId,
+      sectionId: sectionId ?? undefined,
+      sectionOrder: result.sectionOrder,
+    } as DMSubscription,
+  }
+  sectionMovedListeners.forEach((cb) => cb(evt))
+  return result
+}
+
+export function onChatlistUpdateMock(cb: ChatlistListener): () => void {
+  chatlistListeners.add(cb)
+  return () => chatlistListeners.delete(cb)
+}
+
+export function onSectionMovedMock(cb: SectionMovedListener): () => void {
+  sectionMovedListeners.add(cb)
+  return () => sectionMovedListeners.delete(cb)
+}
+
+/** Demo seed: from the just-loaded subscriptions, create a couple sample
+ *  custom sections and drop a few non-favorite/non-bot rooms into them, plus
+ *  mark two rooms favorite — so the grouped sidebar shows populated sections
+ *  in a screenshot. Returns the section membership + favorite ids to patch
+ *  onto the reducer's subscriptions (the mock owns defs; the reducer owns
+ *  the sub records). Idempotent-ish: only seeds when no custom section exists. */
+export interface MockSeed {
+  membership: Record<string, { sectionId: string; sectionOrder: number }>
+  favoriteRoomIds: string[]
+}
+
+export function seedChatlistMock(subs: DMSubscription[]): MockSeed {
+  if (state.sections.some((s) => !s.builtIn)) {
+    // Already seeded — return current membership.
+    const m: MockSeed['membership'] = {}
+    membership.forEach((v, roomId) => {
+      if (v.sectionId && typeof v.sectionOrder === 'number')
+        m[roomId] = { sectionId: v.sectionId, sectionOrder: v.sectionOrder }
+    })
+    return { membership: m, favoriteRoomIds: [] }
+  }
+  const plain = subs.filter((s) => s.roomType !== 'botDM' && !s.u?.isBot && !s.favorite)
+  const work = createSectionMock('Work', 'custom')
+  const projects = createSectionMock('Projects', 'mostRecent')
+  const workId = work.sections.find((s) => s.name === 'Work')!.id
+  const projId = projects.sections.find((s) => s.name === 'Projects')!.id
+  const seededMembership: MockSeed['membership'] = {}
+  plain.slice(0, 3).forEach((s, i) => {
+    membership.set(s.roomId, { sectionId: workId, sectionOrder: i + 1 })
+    seededMembership[s.roomId] = { sectionId: workId, sectionOrder: i + 1 }
+  })
+  plain.slice(3, 5).forEach((s, i) => {
+    membership.set(s.roomId, { sectionId: projId, sectionOrder: i + 1 })
+    seededMembership[s.roomId] = { sectionId: projId, sectionOrder: i + 1 }
+  })
+  const favoriteRoomIds = plain.slice(5, 7).map((s) => s.roomId)
+  return { membership: seededMembership, favoriteRoomIds }
+}

--- a/chat-frontend/src/api/_transport/subjects.ts
+++ b/chat-frontend/src/api/_transport/subjects.ts
@@ -129,3 +129,44 @@ export function userSubscriptionList(account: string, siteId: string): string {
 export function userSubscriptionCount(account: string, siteId: string): string {
   return `chat.user.${account}.request.user.${siteId}.subscription.count`
 }
+
+// Chatlist custom-sections RPCs (user-service). The section DEFINITIONS live
+// in a small per-user overlay; a chat's section MEMBERSHIP rides its
+// subscription (see chatMove). Mirrors pkg/subject chatlist builders.
+export function chatlistGet(account: string, siteId: string): string {
+  return `chat.user.${account}.request.user.${siteId}.chatlist.get`
+}
+
+export function chatlistSectionCreate(account: string, siteId: string): string {
+  return `chat.user.${account}.request.user.${siteId}.chatlist.section.create`
+}
+
+export function chatlistSectionRename(account: string, siteId: string): string {
+  return `chat.user.${account}.request.user.${siteId}.chatlist.section.rename`
+}
+
+export function chatlistSectionDelete(account: string, siteId: string): string {
+  return `chat.user.${account}.request.user.${siteId}.chatlist.section.delete`
+}
+
+export function chatlistSectionReorder(account: string, siteId: string): string {
+  return `chat.user.${account}.request.user.${siteId}.chatlist.section.reorder`
+}
+
+export function chatlistSectionSetSortMode(account: string, siteId: string): string {
+  return `chat.user.${account}.request.user.${siteId}.chatlist.section.setsortmode`
+}
+
+// chatMove sets/clears a chat's section membership + manual order on its
+// subscription. `{siteID}` is the room's origin site, like the other
+// room-scoped RPCs. Emits subscription.update (action "section_moved").
+export function chatMove(account: string, roomId: string, siteId: string): string {
+  return `chat.user.${account}.request.room.${roomId}.${siteId}.chat.move`
+}
+
+// chatlistUpdate is the caller-fanned event carrying the full post-update
+// section definitions (ChatlistUpdateEvent). Replace-wholesale, LWW by
+// chatlist.lastUpdatedAt.
+export function chatlistUpdate(account: string): string {
+  return `chat.user.${account}.event.chatlist.update`
+}

--- a/chat-frontend/src/api/chatlist/index.test.ts
+++ b/chat-frontend/src/api/chatlist/index.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  getChatlist,
+  createChatlistSection,
+  renameChatlistSection,
+  deleteChatlistSection,
+  reorderChatlistSections,
+  setChatlistSectionSortMode,
+} from './index'
+import type { Nats } from '../types'
+
+// CHATLIST_MOCK is false by default in the test env, so these exercise the
+// real NATS-subject path — the op→subject+payload mapping.
+function fakeNats(request: unknown) {
+  return { user: { account: 'alice', siteId: 'site-A' }, request } as unknown as Nats
+}
+
+describe('chatlist api ops (real path)', () => {
+  it('getChatlist requests the chatlist.get subject with no body', async () => {
+    const request = vi.fn().mockResolvedValue({ sectionOrder: [], sections: [], lastUpdatedAt: 0 })
+    await getChatlist(fakeNats(request))
+    expect(request).toHaveBeenCalledWith('chat.user.alice.request.user.site-A.chatlist.get')
+  })
+
+  it('createChatlistSection maps name + sortMode', async () => {
+    const request = vi.fn().mockResolvedValue({})
+    await createChatlistSection(fakeNats(request), { name: 'Work', sortMode: 'custom' })
+    expect(request).toHaveBeenCalledWith(
+      'chat.user.alice.request.user.site-A.chatlist.section.create',
+      { name: 'Work', sortMode: 'custom' },
+    )
+  })
+
+  it('renameChatlistSection maps sectionId + name', async () => {
+    const request = vi.fn().mockResolvedValue({})
+    await renameChatlistSection(fakeNats(request), { sectionId: 's1', name: 'Renamed' })
+    expect(request).toHaveBeenCalledWith(
+      'chat.user.alice.request.user.site-A.chatlist.section.rename',
+      { sectionId: 's1', name: 'Renamed' },
+    )
+  })
+
+  it('deleteChatlistSection maps sectionId', async () => {
+    const request = vi.fn().mockResolvedValue({})
+    await deleteChatlistSection(fakeNats(request), 's1')
+    expect(request).toHaveBeenCalledWith(
+      'chat.user.alice.request.user.site-A.chatlist.section.delete',
+      { sectionId: 's1' },
+    )
+  })
+
+  it('reorderChatlistSections maps the full order permutation', async () => {
+    const request = vi.fn().mockResolvedValue({})
+    await reorderChatlistSections(fakeNats(request), ['favorites', 'work', 'chats'])
+    expect(request).toHaveBeenCalledWith(
+      'chat.user.alice.request.user.site-A.chatlist.section.reorder',
+      { sectionOrder: ['favorites', 'work', 'chats'] },
+    )
+  })
+
+  it('setChatlistSectionSortMode maps sectionId + sortMode', async () => {
+    const request = vi.fn().mockResolvedValue({})
+    await setChatlistSectionSortMode(fakeNats(request), { sectionId: 's1', sortMode: 'mostRecent' })
+    expect(request).toHaveBeenCalledWith(
+      'chat.user.alice.request.user.site-A.chatlist.section.setsortmode',
+      { sectionId: 's1', sortMode: 'mostRecent' },
+    )
+  })
+})

--- a/chat-frontend/src/api/chatlist/index.ts
+++ b/chat-frontend/src/api/chatlist/index.ts
@@ -1,0 +1,89 @@
+// Chatlist section-definition RPCs (user-service): get + the five section
+// mutations. Grouped in one folder because they share the ChatlistState
+// response, the mock, and the name-validation surface. Each mutation returns
+// the full post-update ChatlistState and fans out chatlist.update.
+//
+// Every op guards on CHATLIST_MOCK: mock → the in-memory store; live → the
+// real NATS subject. The live path is the default.
+
+import { CHATLIST_MOCK } from '@/lib/runtimeConfig'
+import {
+  chatlistGet,
+  chatlistSectionCreate,
+  chatlistSectionRename,
+  chatlistSectionDelete,
+  chatlistSectionReorder,
+  chatlistSectionSetSortMode,
+} from '../_transport/subjects'
+import {
+  getChatlistMock,
+  createSectionMock,
+  renameSectionMock,
+  deleteSectionMock,
+  reorderSectionsMock,
+  setSectionSortModeMock,
+} from '../_transport/chatlistMock'
+import type { Nats, ChatlistState, ChatlistSortMode } from '../types'
+
+export function getChatlist({ user, request }: Nats): Promise<ChatlistState> {
+  if (CHATLIST_MOCK) return Promise.resolve(getChatlistMock())
+  return request<ChatlistState>(chatlistGet(user.account, user.siteId))
+}
+
+export interface CreateSectionArgs {
+  name: string
+  sortMode?: ChatlistSortMode
+}
+
+export function createChatlistSection(
+  { user, request }: Nats,
+  { name, sortMode }: CreateSectionArgs,
+): Promise<ChatlistState> {
+  if (CHATLIST_MOCK) return Promise.resolve(createSectionMock(name, sortMode))
+  return request<ChatlistState>(chatlistSectionCreate(user.account, user.siteId), { name, sortMode })
+}
+
+export interface RenameSectionArgs {
+  sectionId: string
+  name: string
+}
+
+export function renameChatlistSection(
+  { user, request }: Nats,
+  { sectionId, name }: RenameSectionArgs,
+): Promise<ChatlistState> {
+  if (CHATLIST_MOCK) return Promise.resolve(renameSectionMock(sectionId, name))
+  return request<ChatlistState>(chatlistSectionRename(user.account, user.siteId), { sectionId, name })
+}
+
+export function deleteChatlistSection(
+  { user, request }: Nats,
+  sectionId: string,
+): Promise<ChatlistState> {
+  if (CHATLIST_MOCK) return Promise.resolve(deleteSectionMock(sectionId))
+  return request<ChatlistState>(chatlistSectionDelete(user.account, user.siteId), { sectionId })
+}
+
+export function reorderChatlistSections(
+  { user, request }: Nats,
+  sectionOrder: string[],
+): Promise<ChatlistState> {
+  if (CHATLIST_MOCK) return Promise.resolve(reorderSectionsMock(sectionOrder))
+  return request<ChatlistState>(chatlistSectionReorder(user.account, user.siteId), { sectionOrder })
+}
+
+export interface SetSortModeArgs {
+  sectionId: string
+  sortMode: ChatlistSortMode
+}
+
+export function setChatlistSectionSortMode(
+  { user, request }: Nats,
+  { sectionId, sortMode }: SetSortModeArgs,
+): Promise<ChatlistState> {
+  if (CHATLIST_MOCK) return Promise.resolve(setSectionSortModeMock(sectionId, sortMode))
+  return request<ChatlistState>(chatlistSectionSetSortMode(user.account, user.siteId), {
+    sectionId,
+    sortMode,
+  })
+}

--- a/chat-frontend/src/api/chatlist/index.ts
+++ b/chat-frontend/src/api/chatlist/index.ts
@@ -22,12 +22,21 @@ import {
   deleteSectionMock,
   reorderSectionsMock,
   setSectionSortModeMock,
+  seedChatlistMock,
+  type MockSeed,
 } from '../_transport/chatlistMock'
-import type { Nats, ChatlistState, ChatlistSortMode } from '../types'
+import type { Nats, ChatlistState, ChatlistSortMode, DMSubscription } from '../types'
 
 export function getChatlist({ user, request }: Nats): Promise<ChatlistState> {
   if (CHATLIST_MOCK) return Promise.resolve(getChatlistMock())
   return request<ChatlistState>(chatlistGet(user.account, user.siteId))
+}
+
+/** DEV-ONLY: seed the mock with a couple sample custom sections + memberships
+ *  from the just-loaded subscriptions, so the grouped sidebar has populated
+ *  sections to demo. No-op (returns null) when CHATLIST_MOCK is off. */
+export function seedChatlistDemo(subs: DMSubscription[]): MockSeed | null {
+  return CHATLIST_MOCK ? seedChatlistMock(subs) : null
 }
 
 export interface CreateSectionArgs {

--- a/chat-frontend/src/api/fetchSidebarBuckets/index.ts
+++ b/chat-frontend/src/api/fetchSidebarBuckets/index.ts
@@ -104,17 +104,24 @@ export async function fetchSidebarBuckets({ user, request }: Nats): Promise<Side
 
   const subscriptions: Record<string, DMSubscription> = {}
   const rooms: Room[] = []
-  const collect = (subs: DMSubscription[]) => {
+  const collect = (subs: DMSubscription[], markFavorite = false) => {
     for (const s of subs) {
       if (!s?.roomId) continue
       // Later sources overwrite earlier ones, but the three responses
       // describe the same Subscription record so collisions are benign.
-      const first = subscriptions[s.roomId] === undefined
-      subscriptions[s.roomId] = s
-      if (first) rooms.push(subToRoom(s, user.siteId))
+      // `favorite` is sticky: the favorite bucket means "favorited", so stamp
+      // it here; a later bucket's copy (which omits the flag on the current
+      // backend) must not clear it. The chatlist v2 read model derives the
+      // Favorites section from this field. Idempotent once #134 sets it natively.
+      const prev = subscriptions[s.roomId]
+      const favorite = markFavorite || s.favorite || prev?.favorite
+      const merged = favorite ? { ...s, favorite: true } : s
+      const first = prev === undefined
+      subscriptions[s.roomId] = merged
+      if (first) rooms.push(subToRoom(merged, user.siteId))
     }
   }
-  collect(favSubs)
+  collect(favSubs, true)
   collect(appSubs)
   collect(roomSubs)
   return {

--- a/chat-frontend/src/api/index.ts
+++ b/chat-frontend/src/api/index.ts
@@ -14,6 +14,7 @@
 export { addMembers } from './addMembers'
 export {
   getChatlist,
+  seedChatlistDemo,
   createChatlistSection,
   renameChatlistSection,
   deleteChatlistSection,

--- a/chat-frontend/src/api/index.ts
+++ b/chat-frontend/src/api/index.ts
@@ -12,6 +12,16 @@
 // is re-exported here.
 
 export { addMembers } from './addMembers'
+export {
+  getChatlist,
+  createChatlistSection,
+  renameChatlistSection,
+  deleteChatlistSection,
+  reorderChatlistSections,
+  setChatlistSectionSortMode,
+} from './chatlist'
+export { moveChat } from './moveChat'
+export { subscribeToChatlistUpdates } from './subscribeToChatlistUpdates'
 export { createRoom } from './createRoom'
 export { deleteMessage } from './deleteMessage'
 export { editMessage } from './editMessage'

--- a/chat-frontend/src/api/index.ts
+++ b/chat-frontend/src/api/index.ts
@@ -77,4 +77,8 @@ export type {
   HistoryConfig,
   HistoryMode,
   RoomKeyEvent,
+  ChatlistSortMode,
+  ChatlistSection,
+  ChatlistState,
+  ChatlistUpdateEvent,
 } from './types'

--- a/chat-frontend/src/api/moveChat/index.test.ts
+++ b/chat-frontend/src/api/moveChat/index.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest'
+import { moveChat } from './index'
+import type { Nats } from '../types'
+
+function fakeNats(request: unknown) {
+  return { user: { account: 'alice', siteId: 'site-A' }, request } as unknown as Nats
+}
+
+describe('moveChat (real path)', () => {
+  it('requests the room-scoped chat.move subject with sectionId + afterRoomId', async () => {
+    const request = vi.fn().mockResolvedValue({ status: 'ok', sectionId: 's1', sectionOrder: 3.5 })
+    await moveChat(fakeNats(request), {
+      roomId: 'r1',
+      siteId: 'site-B',
+      sectionId: 's1',
+      afterRoomId: 'r0',
+    })
+    expect(request).toHaveBeenCalledWith('chat.user.alice.request.room.r1.site-B.chat.move', {
+      sectionId: 's1',
+      afterRoomId: 'r0',
+    })
+  })
+
+  it('sends sectionId null to remove from section', async () => {
+    const request = vi.fn().mockResolvedValue({ status: 'ok' })
+    await moveChat(fakeNats(request), { roomId: 'r1', siteId: 'site-A', sectionId: null })
+    expect(request).toHaveBeenCalledWith('chat.user.alice.request.room.r1.site-A.chat.move', {
+      sectionId: null,
+      afterRoomId: undefined,
+    })
+  })
+})

--- a/chat-frontend/src/api/moveChat/index.ts
+++ b/chat-frontend/src/api/moveChat/index.ts
@@ -1,0 +1,36 @@
+// Move a chat into a custom chatlist section (or remove it). Room-scoped
+// synchronous RPC; membership + order live on the subscription, mirroring
+// favorite.toggle. Emits subscription.update (action "section_moved").
+//
+// Guards on CHATLIST_MOCK: mock → in-memory store; live → the real subject.
+
+import { CHATLIST_MOCK } from '@/lib/runtimeConfig'
+import { chatMove } from '../_transport/subjects'
+import { moveChatMock } from '../_transport/chatlistMock'
+import type { Nats } from '../types'
+
+export interface MoveChatArgs {
+  roomId: string
+  /** Room's origin site (like the other room-scoped RPCs). */
+  siteId: string
+  /** Custom section to move into; `null` removes it (falls back to a derived
+   *  built-in). A built-in id is rejected by the server. */
+  sectionId: string | null
+  /** Optional: place just after this room in the section; omit to append. */
+  afterRoomId?: string
+}
+
+/** Mirrors the chat.move reply. `sectionId`/`sectionOrder` omitted on remove. */
+export interface MoveChatResponse {
+  status: 'ok'
+  sectionId?: string
+  sectionOrder?: number
+}
+
+export function moveChat(
+  { user, request }: Nats,
+  { roomId, siteId, sectionId, afterRoomId }: MoveChatArgs,
+): Promise<MoveChatResponse> {
+  if (CHATLIST_MOCK) return Promise.resolve(moveChatMock(roomId, sectionId, afterRoomId))
+  return request<MoveChatResponse>(chatMove(user.account, roomId, siteId), { sectionId, afterRoomId })
+}

--- a/chat-frontend/src/api/moveChat/index.ts
+++ b/chat-frontend/src/api/moveChat/index.ts
@@ -18,6 +18,9 @@ export interface MoveChatArgs {
   sectionId: string | null
   /** Optional: place just after this room in the section; omit to append. */
   afterRoomId?: string
+  /** Optional: place just before this room (e.g. move-to-top). Mutually
+   *  exclusive with afterRoomId; server orders by whichever is set. */
+  beforeRoomId?: string
 }
 
 /** Mirrors the chat.move reply. `sectionId`/`sectionOrder` omitted on remove. */
@@ -29,8 +32,12 @@ export interface MoveChatResponse {
 
 export function moveChat(
   { user, request }: Nats,
-  { roomId, siteId, sectionId, afterRoomId }: MoveChatArgs,
+  { roomId, siteId, sectionId, afterRoomId, beforeRoomId }: MoveChatArgs,
 ): Promise<MoveChatResponse> {
   if (CHATLIST_MOCK) return Promise.resolve(moveChatMock(roomId, sectionId, afterRoomId))
-  return request<MoveChatResponse>(chatMove(user.account, roomId, siteId), { sectionId, afterRoomId })
+  return request<MoveChatResponse>(chatMove(user.account, roomId, siteId), {
+    sectionId,
+    afterRoomId,
+    beforeRoomId,
+  })
 }

--- a/chat-frontend/src/api/subscribeToChatlistUpdates/index.ts
+++ b/chat-frontend/src/api/subscribeToChatlistUpdates/index.ts
@@ -1,0 +1,22 @@
+// Subscribe to chatlist.update events — the caller-fanned section-definition
+// sync. Payload is a ChatlistUpdateEvent (full-state replace, LWW by
+// chatlist.lastUpdatedAt). Guards on CHATLIST_MOCK: mock → the in-memory
+// emitter; live → the real subject.
+
+import { CHATLIST_MOCK } from '@/lib/runtimeConfig'
+import { chatlistUpdate } from '../_transport/subjects'
+import { onChatlistUpdateMock } from '../_transport/chatlistMock'
+import type { Nats, NatsSubscription, ChatlistUpdateEvent } from '../types'
+
+export type ChatlistUpdateCallback = (event: ChatlistUpdateEvent) => void
+
+export function subscribeToChatlistUpdates(
+  { user, subscribe }: Nats,
+  callback: ChatlistUpdateCallback,
+): NatsSubscription {
+  if (CHATLIST_MOCK) {
+    const unsub = onChatlistUpdateMock(callback)
+    return { unsubscribe: unsub }
+  }
+  return subscribe(chatlistUpdate(user.account), callback as (event: unknown) => void)
+}

--- a/chat-frontend/src/api/subscribeToSubscriptionUpdates/index.ts
+++ b/chat-frontend/src/api/subscribeToSubscriptionUpdates/index.ts
@@ -1,4 +1,6 @@
+import { CHATLIST_MOCK } from '@/lib/runtimeConfig'
 import { subscriptionUpdate } from '../_transport/subjects'
+import { onSectionMovedMock } from '../_transport/chatlistMock'
 import type { Nats, NatsSubscription, SubscriptionUpdateEvent } from '../types'
 
 /** Callback fired for every `subscription.update` event addressed to
@@ -19,5 +21,16 @@ export function subscribeToSubscriptionUpdates(
   // narrower for this op — cast once at the boundary so consumers
   // (useRoomSubscriptions) get the typed event without each call site
   // re-narrowing.
-  return subscribe(subscriptionUpdate(user.account), callback as (event: unknown) => void)
+  const real = subscribe(subscriptionUpdate(user.account), callback as (event: unknown) => void)
+  if (!CHATLIST_MOCK) return real
+  // Dev-only: the chatlist mock fans section_moved through the same callback
+  // (no live backend for it yet). Additive to the real stream so real room
+  // events still flow; the whole branch is dead once the flag is off.
+  const unsubMock = onSectionMovedMock(callback)
+  return {
+    unsubscribe: () => {
+      real.unsubscribe()
+      unsubMock()
+    },
+  }
 }

--- a/chat-frontend/src/api/types.ts
+++ b/chat-frontend/src/api/types.ts
@@ -70,6 +70,17 @@ export interface Subscription {
   hasMention: boolean
   threadUnread?: string[]
   alert: boolean
+  /** Whether the user favorited the room. Drives the derived Favorites
+   *  section. Optional on the wire (absent = false). */
+  favorite?: boolean
+  /** Custom chatlist section this room is in; absent = no custom section
+   *  (the client derives a built-in placement). A `sectionId` pointing at
+   *  a section not in the definitions renders in Chats (orphan tolerance).
+   *  Set/cleared via the chat.move RPC. */
+  sectionId?: string
+  /** Manual fractional position within `sectionId`'s section; honored only
+   *  when that section's `sortMode == "custom"`. */
+  sectionOrder?: number
   /** Room-level metadata nested under `room` after enrichment by
    *  user-service. Present on `subscription.list` replies; absent on
    *  live `subscription.update` events. Default to 0 / null at the
@@ -329,11 +340,53 @@ export type SubscriptionCallback = (event: unknown) => void
 
 /** Known values of `SubscriptionUpdateEvent.action`. Backend (room-worker
  *  `handler.go`) emits `"added"` on member-add / room-create / DM-sync,
- *  `"removed"` on member-remove, and `"role_updated"` on role change.
- *  Typed as a union ∪ `string` so consumers get autocomplete for the
- *  known values but forward-compat with any new action the backend
- *  introduces. */
-export type SubscriptionUpdateAction = 'added' | 'removed' | 'role_updated' | (string & {})
+ *  `"removed"` on member-remove, `"role_updated"` on role change, and
+ *  `"section_moved"` when a chat's chatlist section membership/order
+ *  changes (the subscription carries the new `sectionId` / `sectionOrder`,
+ *  both absent = removed from its section). Typed as a union ∪ `string`
+ *  so consumers get autocomplete for the known values but forward-compat
+ *  with any new action the backend introduces. */
+export type SubscriptionUpdateAction =
+  | 'added'
+  | 'removed'
+  | 'role_updated'
+  | 'section_moved'
+  | (string & {})
+
+/** Sort mode for a chatlist section: `"custom"` orders by the members'
+ *  `subscription.sectionOrder`; `"mostRecent"` orders by last message (the
+ *  default + fallback). Mirrors the backend's section sortMode. */
+export type ChatlistSortMode = 'custom' | 'mostRecent'
+
+/** One chatlist section DEFINITION. Membership is NOT here — it rides each
+ *  subscription's `sectionId`. Built-ins (`favorites`/`apps`/`teams`/`chats`)
+ *  are derived client-side; the overlay still carries their definition so
+ *  their order + sortMode round-trip. Mirrors pkg/model.ChatlistSection. */
+export interface ChatlistSection {
+  id: string
+  name: string
+  builtIn: boolean
+  sortMode: ChatlistSortMode
+}
+
+/** The per-user chatlist section overlay — definitions + display order only,
+ *  O(sections) not O(chats). Mirrors pkg/model.ChatlistState. `sectionOrder`
+ *  is a permutation of every section id (built-in + custom). `lastUpdatedAt`
+ *  is the LWW high-water mark for the chatlist.update event. */
+export interface ChatlistState {
+  sectionOrder: string[]
+  sections: ChatlistSection[]
+  lastUpdatedAt: number
+}
+
+/** Wire shape of `chat.user.{account}.event.chatlist.update`. Carries the
+ *  FULL post-update section definitions — receivers replace their local
+ *  copy wholesale (guarded by `chatlist.lastUpdatedAt`), never merge deltas.
+ *  Mirrors pkg/model.ChatlistUpdateEvent. */
+export interface ChatlistUpdateEvent {
+  timestamp: number
+  chatlist: ChatlistState
+}
 
 /** Wire shape of `chat.user.{account}.event.subscription.update` events.
  *  Mirrors `pkg/model.SubscriptionUpdateEvent`. Subscription is typed

--- a/chat-frontend/src/components/MainApp/Sidebar/ChatlistSectionDialog/ChatlistSectionDialog.jsx
+++ b/chat-frontend/src/components/MainApp/Sidebar/ChatlistSectionDialog/ChatlistSectionDialog.jsx
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useState } from 'react'
+import { validateSectionName } from '@/lib/chatlist'
+
+const INVALID_COPY = 'Use 1–50 letters, digits, spaces or - _ . / ( ), no double spaces.'
+
+/**
+ * Create or rename a custom chatlist section. `mode` picks the title/verb;
+ * `initialName` pre-fills for rename. `onSubmit(name)` runs the RPC (the
+ * caller handles errors/close on resolve); this dialog only pre-flights the
+ * name locally so the user gets instant feedback before the round-trip.
+ */
+export default function ChatlistSectionDialog({ mode = 'create', initialName = '', onSubmit, onClose }) {
+  const [name, setName] = useState(initialName)
+  const [error, setError] = useState(null)
+  const [busy, setBusy] = useState(false)
+  const inputRef = useRef(null)
+
+  useEffect(() => {
+    inputRef.current?.focus()
+    inputRef.current?.select()
+  }, [])
+
+  const submit = async (e) => {
+    e.preventDefault()
+    const v = validateSectionName(name)
+    if (!v.ok) {
+      setError(INVALID_COPY)
+      return
+    }
+    setBusy(true)
+    setError(null)
+    try {
+      await onSubmit(v.name)
+      onClose()
+    } catch (err) {
+      setError(err?.reason === 'chatlist_duplicate_name' ? 'A section with that name already exists.' : (err?.message ?? 'Failed'))
+      setBusy(false)
+    }
+  }
+
+  const title = mode === 'rename' ? 'Rename section' : 'New section'
+  const verb = mode === 'rename' ? 'Rename' : 'Create'
+
+  return (
+    <div className="dialog-overlay" onClick={onClose}>
+      <div className="dialog" role="dialog" aria-label={title} onClick={(e) => e.stopPropagation()}>
+        <h2>{title}</h2>
+        <form onSubmit={submit}>
+          <input
+            ref={inputRef}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Section name"
+            maxLength={50}
+            aria-label="Section name"
+          />
+          {error && <div className="dialog-error">{error}</div>}
+          <div className="dialog-actions">
+            <button type="button" className="dialog-cancel" onClick={onClose} disabled={busy}>
+              Cancel
+            </button>
+            <button type="submit" className="btn btn-primary" disabled={busy}>
+              {busy ? '…' : verb}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/chat-frontend/src/components/MainApp/Sidebar/ChatlistSectionDialog/ChatlistSectionDialog.jsx
+++ b/chat-frontend/src/components/MainApp/Sidebar/ChatlistSectionDialog/ChatlistSectionDialog.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import Modal from '@/components/shared/Modal/Modal'
 import { validateSectionName } from '@/lib/chatlist'
 
 const INVALID_COPY = 'Use 1–50 letters, digits, spaces or - _ . / ( ), no double spaces.'
@@ -14,6 +15,7 @@ export default function ChatlistSectionDialog({ mode = 'create', initialName = '
   const [error, setError] = useState(null)
   const [busy, setBusy] = useState(false)
   const inputRef = useRef(null)
+  const headingId = 'chatlist-section-dialog-heading'
 
   useEffect(() => {
     inputRef.current?.focus()
@@ -42,29 +44,27 @@ export default function ChatlistSectionDialog({ mode = 'create', initialName = '
   const verb = mode === 'rename' ? 'Rename' : 'Create'
 
   return (
-    <div className="dialog-overlay" onClick={onClose}>
-      <div className="dialog" role="dialog" aria-label={title} onClick={(e) => e.stopPropagation()}>
-        <h2>{title}</h2>
-        <form onSubmit={submit}>
-          <input
-            ref={inputRef}
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="Section name"
-            maxLength={50}
-            aria-label="Section name"
-          />
-          {error && <div className="dialog-error">{error}</div>}
-          <div className="dialog-actions">
-            <button type="button" className="dialog-cancel" onClick={onClose} disabled={busy}>
-              Cancel
-            </button>
-            <button type="submit" className="btn btn-primary" disabled={busy}>
-              {busy ? '…' : verb}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+    <Modal onClose={onClose} labelledBy={headingId}>
+      <h2 id={headingId}>{title}</h2>
+      <form onSubmit={submit}>
+        <input
+          ref={inputRef}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Section name"
+          maxLength={50}
+          aria-label="Section name"
+        />
+        {error && <div className="dialog-error">{error}</div>}
+        <div className="dialog-actions">
+          <button type="button" className="dialog-cancel" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button type="submit" className="btn btn-primary" disabled={busy}>
+            {busy ? '…' : verb}
+          </button>
+        </div>
+      </form>
+    </Modal>
   )
 }

--- a/chat-frontend/src/components/MainApp/Sidebar/ChatlistSectionDialog/ChatlistSectionDialog.test.jsx
+++ b/chat-frontend/src/components/MainApp/Sidebar/ChatlistSectionDialog/ChatlistSectionDialog.test.jsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import ChatlistSectionDialog from './ChatlistSectionDialog'
+
+describe('ChatlistSectionDialog', () => {
+  it('submits a valid trimmed name and closes', async () => {
+    const onSubmit = vi.fn().mockResolvedValue()
+    const onClose = vi.fn()
+    render(<ChatlistSectionDialog mode="create" onSubmit={onSubmit} onClose={onClose} />)
+    fireEvent.change(screen.getByLabelText('Section name'), { target: { value: '  Work  ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('Work'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('blocks an invalid name locally (no RPC)', () => {
+    const onSubmit = vi.fn()
+    render(<ChatlistSectionDialog mode="create" onSubmit={onSubmit} onClose={vi.fn()} />)
+    fireEvent.change(screen.getByLabelText('Section name'), { target: { value: 'bad  name' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(screen.getByText(/1–50/)).toBeInTheDocument()
+  })
+
+  it('surfaces a duplicate-name error from the RPC', async () => {
+    const onSubmit = vi.fn().mockRejectedValue({ reason: 'chatlist_duplicate_name' })
+    render(<ChatlistSectionDialog mode="rename" initialName="Work" onSubmit={onSubmit} onClose={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
+    await waitFor(() => expect(screen.getByText(/already exists/)).toBeInTheDocument())
+  })
+})

--- a/chat-frontend/src/components/MainApp/Sidebar/ChatlistSectionDialog/index.jsx
+++ b/chat-frontend/src/components/MainApp/Sidebar/ChatlistSectionDialog/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './ChatlistSectionDialog'

--- a/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.jsx
+++ b/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.jsx
@@ -1,7 +1,15 @@
-import { useState } from 'react'
-import { useRoomSummaries, useSidebarSections } from '@/context/RoomEventsContext'
+import { lazy, Suspense, useRef, useState } from 'react'
+import {
+  useRoomSummaries,
+  useSidebarSections,
+  useChatlistActions,
+} from '@/context/RoomEventsContext'
 import { roomPrefix, roomDisplayName } from '@/lib/roomFormat'
+import { BUILTIN_CHATS, isBuiltinSectionId } from '@/lib/chatlist'
+import LazyFallback from '@/components/shared/LazyFallback'
 import './style.css'
+
+const ChatlistSectionDialog = lazy(() => import('../ChatlistSectionDialog/ChatlistSectionDialog'))
 
 function mentionBadge(summary) {
   if (summary.mentionAll) return <span className="room-badge-mention-all">!</span>
@@ -9,13 +17,24 @@ function mentionBadge(summary) {
   return null
 }
 
-function RoomItem({ room, isSelected, onSelectRoom }) {
+function RoomItem({ room, isSelected, onSelectRoom, onDragStartRoom, onDropOnRoom }) {
   const unread = room.unreadCount > 0
   const classes = ['room-item']
   if (isSelected) classes.push('room-item-selected')
   if (unread) classes.push('room-item-unread')
   return (
-    <div className={classes.join(' ')} onClick={() => onSelectRoom(room)}>
+    <div
+      className={classes.join(' ')}
+      onClick={() => onSelectRoom(room)}
+      draggable
+      onDragStart={(e) => onDragStartRoom(e, room)}
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={(e) => {
+        e.stopPropagation()
+        onDropOnRoom(room)
+      }}
+    >
+      <span className="room-drag-handle" aria-hidden="true">⋮⋮</span>
       <span className="room-name">
         {roomPrefix(room.type)}{roomDisplayName(room)}
       </span>
@@ -29,47 +48,141 @@ function RoomItem({ room, isSelected, onSelectRoom }) {
 export default function RoomList({ selectedRoomId, onSelectRoom }) {
   const { error } = useRoomSummaries()
   const sections = useSidebarSections()
+  const { createSection, renameSection, deleteSection, setSortMode, moveChatTo } = useChatlistActions()
   const [collapsed, setCollapsed] = useState({})
+  const [dialog, setDialog] = useState(null) // {mode:'create'|'rename', sectionId?, initialName?}
+  const [dragOverKey, setDragOverKey] = useState(null)
+  const dragRoomRef = useRef(null)
 
   const toggle = (key) => setCollapsed((c) => ({ ...c, [key]: !c[key] }))
 
+  // A section is a valid drop target only if a chat can actually move there:
+  // a custom section (move into) or Chats (remove from its section). The other
+  // built-ins (Favorites/Apps/Teams) are derived, not user-assignable.
+  const isDropTarget = (section) => !isBuiltinSectionId(section.key) || section.key === BUILTIN_CHATS
+
+  const dropInto = (section, afterRoomId) => {
+    const dragged = dragRoomRef.current
+    dragRoomRef.current = null
+    setDragOverKey(null)
+    if (!dragged || !isDropTarget(section)) return
+    const targetSectionId = section.key === BUILTIN_CHATS ? null : section.key
+    moveChatTo(dragged.id, dragged.siteId, targetSectionId, afterRoomId)
+  }
+
+  const onDragStartRoom = (e, room) => {
+    dragRoomRef.current = { id: room.id, siteId: room.siteId }
+    e.dataTransfer.effectAllowed = 'move'
+    e.dataTransfer.setData('text/plain', room.id)
+  }
+
   return (
     <div className="room-list">
-      <div className="room-list-header">Rooms</div>
+      <div className="room-list-header">
+        <span>Rooms</span>
+        <button
+          type="button"
+          className="btn-icon room-list-add-section"
+          aria-label="New section"
+          title="New section"
+          onClick={() => setDialog({ mode: 'create' })}
+        >
+          ＋
+        </button>
+      </div>
       {error && <div className="room-list-error">{error}</div>}
       <div className="room-list-items">
         {sections.map((section) => {
           const isCollapsed = !!collapsed[section.key]
+          const custom = !section.builtIn
           const sectionClasses = ['room-list-section']
           if (isCollapsed) sectionClasses.push('room-list-section-collapsed')
+          if (dragOverKey === section.key) sectionClasses.push('room-list-section-dragover')
           return (
-            <div key={section.key} className={sectionClasses.join(' ')}>
-              <div
-                className="room-list-section-header"
-                onClick={() => toggle(section.key)}
-              >
-                <span className="room-list-section-chevron" aria-hidden="true">▾</span>
-                {section.title}
+            <div
+              key={section.key}
+              className={sectionClasses.join(' ')}
+              onDragOver={(e) => {
+                if (!isDropTarget(section)) return
+                e.preventDefault()
+                setDragOverKey(section.key)
+              }}
+              onDragLeave={() => setDragOverKey((k) => (k === section.key ? null : k))}
+              onDrop={() => dropInto(section, undefined)}
+            >
+              <div className="room-list-section-header">
+                <span className="room-list-section-title" onClick={() => toggle(section.key)}>
+                  <span className="room-list-section-chevron" aria-hidden="true">▾</span>
+                  {section.title}
+                </span>
+                <span className="room-list-section-controls">
+                  <button
+                    type="button"
+                    className="btn-icon"
+                    aria-label={`Sort ${section.title}`}
+                    title={section.sortMode === 'custom' ? 'Sort: manual' : 'Sort: recent'}
+                    onClick={() =>
+                      setSortMode(section.key, section.sortMode === 'custom' ? 'mostRecent' : 'custom')
+                    }
+                  >
+                    {section.sortMode === 'custom' ? '⇅' : '🕘'}
+                  </button>
+                  {custom && (
+                    <>
+                      <button
+                        type="button"
+                        className="btn-icon"
+                        aria-label={`Rename ${section.title}`}
+                        title="Rename"
+                        onClick={() =>
+                          setDialog({ mode: 'rename', sectionId: section.key, initialName: section.title })
+                        }
+                      >
+                        ✎
+                      </button>
+                      <button
+                        type="button"
+                        className="btn-icon"
+                        aria-label={`Delete ${section.title}`}
+                        title="Delete"
+                        onClick={() => deleteSection(section.key)}
+                      >
+                        🗑
+                      </button>
+                    </>
+                  )}
+                </span>
               </div>
-              {!isCollapsed && section.note && (
-                <div className="room-list-section-note">{section.note}</div>
-              )}
-              {!isCollapsed && !section.note && section.rooms.length === 0 && (
+              {!isCollapsed && section.rooms.length === 0 && (
                 <div className="room-list-section-empty">No rooms</div>
               )}
-              {!isCollapsed && !section.note &&
+              {!isCollapsed &&
                 section.rooms.map((room) => (
                   <RoomItem
                     key={room.id}
                     room={room}
                     isSelected={room.id === selectedRoomId}
                     onSelectRoom={onSelectRoom}
+                    onDragStartRoom={onDragStartRoom}
+                    onDropOnRoom={(target) => dropInto(section, target.id)}
                   />
                 ))}
             </div>
           )
         })}
       </div>
+      {dialog && (
+        <Suspense fallback={<LazyFallback variant="dialog" />}>
+          <ChatlistSectionDialog
+            mode={dialog.mode}
+            initialName={dialog.initialName ?? ''}
+            onSubmit={(name) =>
+              dialog.mode === 'rename' ? renameSection(dialog.sectionId, name) : createSection(name)
+            }
+            onClose={() => setDialog(null)}
+          />
+        </Suspense>
+      )}
     </div>
   )
 }

--- a/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.jsx
+++ b/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.jsx
@@ -3,6 +3,7 @@ import {
   useRoomSummaries,
   useSidebarSections,
   useChatlistActions,
+  useChatlistSectionOrder,
 } from '@/context/RoomEventsContext'
 import { roomPrefix, roomDisplayName } from '@/lib/roomFormat'
 import { BUILTIN_CHATS, isBuiltinSectionId } from '@/lib/chatlist'
@@ -46,11 +47,14 @@ function RoomItem({ room, isSelected, onSelectRoom, onDragStartRoom, onDropOnRoo
 export default function RoomList({ selectedRoomId, onSelectRoom }) {
   const { error } = useRoomSummaries()
   const sections = useSidebarSections()
-  const { createSection, renameSection, deleteSection, setSortMode, moveChatTo } = useChatlistActions()
+  const rawSectionOrder = useChatlistSectionOrder()
+  const { createSection, renameSection, deleteSection, reorderSections, setSortMode, moveChatTo } =
+    useChatlistActions()
   const [collapsed, setCollapsed] = useState({})
   const [dialog, setDialog] = useState(null) // {mode:'create'|'rename', sectionId?, initialName?}
   const [dragOverKey, setDragOverKey] = useState(null)
   const dragRoomRef = useRef(null)
+  const dragSectionRef = useRef(null) // key of a custom section being reordered
 
   const toggle = (key) => setCollapsed((c) => ({ ...c, [key]: !c[key] }))
 
@@ -74,6 +78,28 @@ export default function RoomList({ selectedRoomId, onSelectRoom }) {
     dragRoomRef.current = { id: room.id, siteId: room.siteId }
     e.dataTransfer.effectAllowed = 'move'
     e.dataTransfer.setData('text/plain', room.id)
+  }
+
+  const onDragStartSection = (e, sectionKey) => {
+    dragSectionRef.current = sectionKey
+    e.dataTransfer.effectAllowed = 'move'
+    e.dataTransfer.setData('text/plain', sectionKey)
+  }
+
+  // Reorder custom sections: drop the dragged section header onto another custom
+  // section -> the dragged one takes that slot. The reorder RPC requires its
+  // argument to be a PERMUTATION of the current full sectionOrder (built-ins +
+  // every custom, each exactly once — else chatlist_invalid_order). So move the
+  // dragged section within the RAW stored order rather than reconstructing one.
+  const reorderSectionTo = (targetKey) => {
+    const dragged = dragSectionRef.current
+    dragSectionRef.current = null
+    setDragOverKey(null)
+    if (!dragged || dragged === targetKey) return
+    if (!rawSectionOrder.includes(dragged) || !rawSectionOrder.includes(targetKey)) return
+    const next = rawSectionOrder.filter((k) => k !== dragged)
+    next.splice(next.indexOf(targetKey), 0, dragged) // dragged goes just before the target
+    reorderSections(next)
   }
 
   return (
@@ -112,14 +138,23 @@ export default function RoomList({ selectedRoomId, onSelectRoom }) {
             >
               <div
                 className="room-list-section-header"
+                draggable={custom}
+                onDragStart={(e) => custom && onDragStartSection(e, section.key)}
                 onDragOver={(e) => {
-                  if (isDropTarget(section)) e.preventDefault()
+                  // Allow drop for a section reorder (a section is being dragged) OR
+                  // a chat move-to-top (a room is being dragged onto a droppable section).
+                  if (dragSectionRef.current || isDropTarget(section)) e.preventDefault()
                 }}
                 onDrop={(e) => {
-                  // Drop on the header = move to the TOP of the section (before its
-                  // current first room). Empty section -> before is undefined -> append.
                   e.stopPropagation()
-                  dropInto(section, { before: section.rooms[0]?.id })
+                  if (dragSectionRef.current) {
+                    // Section dropped on this header -> reorder it into this slot.
+                    reorderSectionTo(section.key)
+                  } else {
+                    // Room dropped on the header -> move to the TOP of the section
+                    // (before its current first room). Empty section -> append.
+                    dropInto(section, { before: section.rooms[0]?.id })
+                  }
                 }}
               >
                 <span className="room-list-section-title" onClick={() => toggle(section.key)}>

--- a/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.jsx
+++ b/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.jsx
@@ -59,13 +59,15 @@ export default function RoomList({ selectedRoomId, onSelectRoom }) {
   // built-ins (Favorites/Apps/Teams) are derived, not user-assignable.
   const isDropTarget = (section) => !isBuiltinSectionId(section.key) || section.key === BUILTIN_CHATS
 
-  const dropInto = (section, afterRoomId) => {
+  // anchor: {} = append; {after: roomId} = place after; {before: roomId} = place
+  // before it (move-to-top when before = the section's current first room).
+  const dropInto = (section, anchor = {}) => {
     const dragged = dragRoomRef.current
     dragRoomRef.current = null
     setDragOverKey(null)
     if (!dragged || !isDropTarget(section)) return
     const targetSectionId = section.key === BUILTIN_CHATS ? null : section.key
-    moveChatTo(dragged.id, dragged.siteId, targetSectionId, afterRoomId)
+    moveChatTo(dragged.id, dragged.siteId, targetSectionId, anchor.after, anchor.before)
   }
 
   const onDragStartRoom = (e, room) => {
@@ -106,9 +108,20 @@ export default function RoomList({ selectedRoomId, onSelectRoom }) {
                 setDragOverKey(section.key)
               }}
               onDragLeave={() => setDragOverKey((k) => (k === section.key ? null : k))}
-              onDrop={() => dropInto(section, undefined)}
+              onDrop={() => dropInto(section, {})}
             >
-              <div className="room-list-section-header">
+              <div
+                className="room-list-section-header"
+                onDragOver={(e) => {
+                  if (isDropTarget(section)) e.preventDefault()
+                }}
+                onDrop={(e) => {
+                  // Drop on the header = move to the TOP of the section (before its
+                  // current first room). Empty section -> before is undefined -> append.
+                  e.stopPropagation()
+                  dropInto(section, { before: section.rooms[0]?.id })
+                }}
+              >
                 <span className="room-list-section-title" onClick={() => toggle(section.key)}>
                   <span className="room-list-section-chevron" aria-hidden="true">▾</span>
                   {section.title}
@@ -162,7 +175,7 @@ export default function RoomList({ selectedRoomId, onSelectRoom }) {
                     isSelected={room.id === selectedRoomId}
                     onSelectRoom={onSelectRoom}
                     onDragStartRoom={onDragStartRoom}
-                    onDropOnRoom={(target) => dropInto(section, target.id)}
+                    onDropOnRoom={(target) => dropInto(section, { after: target.id })}
                   />
                 ))}
             </div>

--- a/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.jsx
+++ b/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.jsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import {
   useRoomSummaries,
   useSidebarSections,
@@ -6,10 +6,8 @@ import {
 } from '@/context/RoomEventsContext'
 import { roomPrefix, roomDisplayName } from '@/lib/roomFormat'
 import { BUILTIN_CHATS, isBuiltinSectionId } from '@/lib/chatlist'
-import LazyFallback from '@/components/shared/LazyFallback'
+import ChatlistSectionDialog from '../ChatlistSectionDialog/ChatlistSectionDialog'
 import './style.css'
-
-const ChatlistSectionDialog = lazy(() => import('../ChatlistSectionDialog/ChatlistSectionDialog'))
 
 function mentionBadge(summary) {
   if (summary.mentionAll) return <span className="room-badge-mention-all">!</span>
@@ -172,16 +170,14 @@ export default function RoomList({ selectedRoomId, onSelectRoom }) {
         })}
       </div>
       {dialog && (
-        <Suspense fallback={<LazyFallback variant="dialog" />}>
-          <ChatlistSectionDialog
-            mode={dialog.mode}
-            initialName={dialog.initialName ?? ''}
-            onSubmit={(name) =>
-              dialog.mode === 'rename' ? renameSection(dialog.sectionId, name) : createSection(name)
-            }
-            onClose={() => setDialog(null)}
-          />
-        </Suspense>
+        <ChatlistSectionDialog
+          mode={dialog.mode}
+          initialName={dialog.initialName ?? ''}
+          onSubmit={(name) =>
+            dialog.mode === 'rename' ? renameSection(dialog.sectionId, name) : createSection(name)
+          }
+          onClose={() => setDialog(null)}
+        />
       )}
     </div>
   )

--- a/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx
+++ b/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx
@@ -1,13 +1,14 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import RoomList from './RoomList'
 
 vi.mock('@/context/RoomEventsContext', () => ({
   useRoomSummaries: vi.fn(),
   useSidebarSections: vi.fn(),
+  useChatlistActions: vi.fn(),
 }))
 
-import { useRoomSummaries, useSidebarSections } from '@/context/RoomEventsContext'
+import { useRoomSummaries, useSidebarSections, useChatlistActions } from '@/context/RoomEventsContext'
 
 function summary(id, overrides = {}) {
   return {
@@ -24,119 +25,57 @@ function summary(id, overrides = {}) {
   }
 }
 
-function setupSections({ favorite = [], apps = [], channelDm = [], error = null } = {}) {
-  useRoomSummaries.mockReturnValue({
-    summaries: [...favorite, ...apps, ...channelDm],
-    setActiveRoom: vi.fn(),
-    error,
-  })
-  useSidebarSections.mockReturnValue([
-    { key: 'favorite',  title: 'Favorite',         rooms: favorite },
-    { key: 'apps',      title: 'Apps',             rooms: apps },
-    { key: 'channelDm', title: 'Channels and DMs', rooms: channelDm },
-  ])
+function section(key, rooms, over = {}) {
+  return { key, title: over.title ?? key, builtIn: over.builtIn ?? true, sortMode: over.sortMode ?? 'mostRecent', rooms }
 }
 
-describe('RoomList: three-section render', () => {
-  it('renders all three section headers when each section has rooms', () => {
-    setupSections({
-      favorite:  [summary('f1', { name: 'fav' })],
-      apps:      [summary('a1', { name: 'app',  type: 'botDM' })],
-      channelDm: [summary('c1', { name: 'gen' })],
-    })
-    render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
-    expect(screen.getByText('Favorite')).toBeInTheDocument()
-    expect(screen.getByText('Apps')).toBeInTheDocument()
-    expect(screen.getByText('Channels and DMs')).toBeInTheDocument()
-  })
+const actions = {
+  createSection: vi.fn(),
+  renameSection: vi.fn(),
+  deleteSection: vi.fn(),
+  setSortMode: vi.fn(),
+  moveChatTo: vi.fn(),
+}
 
-  it('renders sections in fixed order: Favorite, Apps, Channels and DMs', () => {
-    setupSections({
-      favorite:  [summary('f1')],
-      apps:      [summary('a1', { type: 'botDM' })],
-      channelDm: [summary('c1')],
-    })
-    const { container } = render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
-    const headers = Array.from(container.querySelectorAll('.room-list-section-header')).map(
-      (el) => el.textContent.replace(/^▾/, '')
-    )
-    expect(headers).toEqual(['Favorite', 'Apps', 'Channels and DMs'])
-  })
+function setup(sections, { error = null } = {}) {
+  const all = sections.flatMap((s) => s.rooms)
+  useRoomSummaries.mockReturnValue({ summaries: all, setActiveRoom: vi.fn(), error })
+  useSidebarSections.mockReturnValue(sections)
+  useChatlistActions.mockReturnValue(actions)
+}
 
-  it('always renders all three section headers even when a section is empty', () => {
-    setupSections({ favorite: [], apps: [], channelDm: [summary('c1')] })
-    render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
-    expect(screen.getByText('Favorite')).toBeInTheDocument()
-    expect(screen.getByText('Apps')).toBeInTheDocument()
-    expect(screen.getByText('Channels and DMs')).toBeInTheDocument()
-  })
+beforeEach(() => vi.clearAllMocks())
 
-  it('shows a "No rooms" placeholder under an empty (expanded) section', () => {
-    setupSections({ favorite: [], apps: [], channelDm: [summary('c1')] })
-    const { container } = render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
-    const emptyPlaceholders = container.querySelectorAll('.room-list-section-empty')
-    // Favorite + Apps are empty; Channels and DMs has c1.
-    expect(emptyPlaceholders.length).toBe(2)
-    expect(emptyPlaceholders[0].textContent).toBe('No rooms')
-  })
-
-  it('renders a section `note` in place of room items / empty placeholder when present', () => {
-    useRoomSummaries.mockReturnValue({ summaries: [], setActiveRoom: vi.fn(), error: null })
-    useSidebarSections.mockReturnValue([
-      { key: 'favorite',  title: 'Favorite', rooms: [], note: 'Favorites are not yet supported' },
-      { key: 'apps',      title: 'Apps',     rooms: [] },
-      { key: 'channelDm', title: 'Channels and DMs', rooms: [summary('c1')] },
+describe('RoomList: v2 grouped render', () => {
+  it('renders each provided section header + rooms', () => {
+    setup([
+      section('favorites', [summary('f1', { name: 'fav' })], { title: 'Favorites' }),
+      section('work', [summary('w1', { name: 'proj' })], { title: 'Work', builtIn: false, sortMode: 'custom' }),
+      section('chats', [summary('c1', { name: 'gen' })], { title: 'Chats' }),
     ])
-    const { container } = render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
-    // The note shows in the Favorite section…
-    expect(screen.getByText('Favorites are not yet supported')).toBeInTheDocument()
-    // …and the "No rooms" empty placeholder must NOT also render in that section
-    // (note overrides empty). Apps is still empty without a note → still shows "No rooms".
-    const notes = container.querySelectorAll('.room-list-section-note')
-    expect(notes).toHaveLength(1)
-    const empties = container.querySelectorAll('.room-list-section-empty')
-    expect(empties).toHaveLength(1)
+    render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
+    expect(screen.getByText('Favorites')).toBeInTheDocument()
+    expect(screen.getByText('Work')).toBeInTheDocument()
+    expect(screen.getByText('Chats')).toBeInTheDocument()
+    expect(screen.getByText(/# gen/)).toBeInTheDocument()
   })
 
-  it('renders a chevron in every section header that rotates when the section is collapsed', () => {
-    setupSections({
-      favorite:  [summary('f1')],
-      apps:      [summary('a1', { type: 'botDM' })],
-      channelDm: [summary('c1')],
-    })
+  it('shows a "No rooms" placeholder under an empty section', () => {
+    setup([section('work', [], { title: 'Work', builtIn: false, sortMode: 'custom' }), section('chats', [summary('c1')])])
     const { container } = render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
-    expect(container.querySelectorAll('.room-list-section-chevron').length).toBe(3)
-    // Headers start expanded — no collapsed class.
-    expect(container.querySelectorAll('.room-list-section-collapsed').length).toBe(0)
-    fireEvent.click(screen.getByText('Apps'))
-    // After click, Apps' section carries the collapsed class (rotates the chevron via CSS).
-    const collapsed = container.querySelectorAll('.room-list-section-collapsed')
-    expect(collapsed.length).toBe(1)
-    expect(collapsed[0].textContent).toContain('Apps')
+    expect(container.querySelectorAll('.room-list-section-empty').length).toBe(1)
   })
 
-  it('toggles section collapse on header click', () => {
-    setupSections({
-      favorite: [],
-      apps: [],
-      channelDm: [summary('c1', { name: 'general' })],
-    })
+  it('toggles collapse on the section title click', () => {
+    setup([section('chats', [summary('c1', { name: 'general' })])])
     render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
     expect(screen.getByText(/# general/)).toBeInTheDocument()
-    fireEvent.click(screen.getByText('Channels and DMs'))
+    fireEvent.click(screen.getByText('chats'))
     expect(screen.queryByText(/# general/)).not.toBeInTheDocument()
-    fireEvent.click(screen.getByText('Channels and DMs'))
-    expect(screen.getByText(/# general/)).toBeInTheDocument()
   })
 
-  it('preserves room item rendering: prefix, mention badge, unread badge, userCount', () => {
-    setupSections({
-      favorite: [],
-      apps: [],
-      channelDm: [
-        summary('c1', { name: 'general', unreadCount: 3, hasMention: true }),
-      ],
-    })
+  it('renders room item chrome: prefix, mention badge, unread badge, userCount', () => {
+    setup([section('chats', [summary('c1', { name: 'general', unreadCount: 3, hasMention: true })])])
     const { container } = render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
     expect(screen.getByText(/# general/)).toBeInTheDocument()
     expect(container.querySelector('.room-badge-mention')).toBeInTheDocument()
@@ -144,17 +83,92 @@ describe('RoomList: three-section render', () => {
     expect(container.querySelector('.room-meta').textContent).toBe('2')
   })
 
-  it('calls onSelectRoom when a room item is clicked', () => {
+  it('calls onSelectRoom when a room is clicked', () => {
     const onSelectRoom = vi.fn()
-    setupSections({ favorite: [summary('f1', { name: 'fav' })], apps: [], channelDm: [] })
+    setup([section('chats', [summary('c1', { name: 'gen' })])])
     render(<RoomList selectedRoomId={null} onSelectRoom={onSelectRoom} />)
-    fireEvent.click(screen.getByText(/# fav/))
-    expect(onSelectRoom).toHaveBeenCalledWith(expect.objectContaining({ id: 'f1' }))
+    fireEvent.click(screen.getByText(/# gen/))
+    expect(onSelectRoom).toHaveBeenCalledWith(expect.objectContaining({ id: 'c1' }))
   })
 
-  it('still surfaces the rooms-load error', () => {
-    setupSections({ error: 'oh no' })
+  it('surfaces the rooms-load error', () => {
+    setup([], { error: 'oh no' })
     render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
     expect(screen.getByText('oh no')).toBeInTheDocument()
+  })
+})
+
+describe('RoomList: section controls', () => {
+  it('shows rename/delete controls only on custom sections', () => {
+    setup([
+      section('chats', [summary('c1')], { title: 'Chats' }),
+      section('work', [summary('w1')], { title: 'Work', builtIn: false, sortMode: 'custom' }),
+    ])
+    render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
+    expect(screen.getByLabelText('Rename Work')).toBeInTheDocument()
+    expect(screen.getByLabelText('Delete Work')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Rename Chats')).toBeNull()
+  })
+
+  it('delete calls deleteSection with the section id', () => {
+    setup([section('work', [summary('w1')], { title: 'Work', builtIn: false, sortMode: 'custom' })])
+    render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
+    fireEvent.click(screen.getByLabelText('Delete Work'))
+    expect(actions.deleteSection).toHaveBeenCalledWith('work')
+  })
+
+  it('sort toggle flips custom↔mostRecent', () => {
+    setup([section('work', [summary('w1')], { title: 'Work', builtIn: false, sortMode: 'custom' })])
+    render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
+    fireEvent.click(screen.getByLabelText('Sort Work'))
+    expect(actions.setSortMode).toHaveBeenCalledWith('work', 'mostRecent')
+  })
+
+  it('opens the create-section dialog from the header + button', async () => {
+    setup([section('chats', [summary('c1')])])
+    render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
+    fireEvent.click(screen.getByLabelText('New section'))
+    expect(await screen.findByRole('dialog', { name: 'New section' })).toBeInTheDocument()
+  })
+})
+
+describe('RoomList: drag to move', () => {
+  it('dragging a chat and dropping on a custom section moves it there', () => {
+    setup([
+      section('work', [], { title: 'Work', builtIn: false, sortMode: 'custom' }),
+      section('chats', [summary('c1', { name: 'gen', siteId: 'site-A' })]),
+    ])
+    const { container } = render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
+    const dataTransfer = { setData: vi.fn(), getData: vi.fn(), effectAllowed: '' }
+    fireEvent.dragStart(screen.getByText(/# gen/).closest('.room-item'), { dataTransfer })
+    // The Work section is the first .room-list-section
+    const workSection = container.querySelectorAll('.room-list-section')[0]
+    fireEvent.drop(workSection)
+    expect(actions.moveChatTo).toHaveBeenCalledWith('c1', 'site-A', 'work', undefined)
+  })
+
+  it('dropping a chat on the Chats section removes it (sectionId null)', () => {
+    setup([
+      section('work', [summary('w1', { name: 'proj', siteId: 'site-A' })], { title: 'Work', builtIn: false, sortMode: 'custom' }),
+      section('chats', [summary('c1')]),
+    ])
+    const { container } = render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
+    const dataTransfer = { setData: vi.fn(), getData: vi.fn(), effectAllowed: '' }
+    fireEvent.dragStart(screen.getByText(/# proj/).closest('.room-item'), { dataTransfer })
+    const chatsSection = container.querySelectorAll('.room-list-section')[1]
+    fireEvent.drop(chatsSection)
+    expect(actions.moveChatTo).toHaveBeenCalledWith('w1', 'site-A', null, undefined)
+  })
+
+  it('dropping onto a specific room passes it as afterRoomId', () => {
+    setup([
+      section('work', [summary('w1', { name: 'proj', siteId: 'site-A' })], { title: 'Work', builtIn: false, sortMode: 'custom' }),
+      section('chats', [summary('c1', { name: 'gen', siteId: 'site-A' })]),
+    ])
+    render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
+    const dataTransfer = { setData: vi.fn(), getData: vi.fn(), effectAllowed: '' }
+    fireEvent.dragStart(screen.getByText(/# gen/).closest('.room-item'), { dataTransfer })
+    fireEvent.drop(screen.getByText(/# proj/).closest('.room-item'))
+    expect(actions.moveChatTo).toHaveBeenCalledWith('c1', 'site-A', 'work', 'w1')
   })
 })

--- a/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx
+++ b/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx
@@ -5,10 +5,16 @@ import RoomList from './RoomList'
 vi.mock('@/context/RoomEventsContext', () => ({
   useRoomSummaries: vi.fn(),
   useSidebarSections: vi.fn(),
+  useChatlistSectionOrder: vi.fn(),
   useChatlistActions: vi.fn(),
 }))
 
-import { useRoomSummaries, useSidebarSections, useChatlistActions } from '@/context/RoomEventsContext'
+import {
+  useRoomSummaries,
+  useSidebarSections,
+  useChatlistSectionOrder,
+  useChatlistActions,
+} from '@/context/RoomEventsContext'
 
 function summary(id, overrides = {}) {
   return {
@@ -33,6 +39,7 @@ const actions = {
   createSection: vi.fn(),
   renameSection: vi.fn(),
   deleteSection: vi.fn(),
+  reorderSections: vi.fn(),
   setSortMode: vi.fn(),
   moveChatTo: vi.fn(),
 }
@@ -41,6 +48,7 @@ function setup(sections, { error = null } = {}) {
   const all = sections.flatMap((s) => s.rooms)
   useRoomSummaries.mockReturnValue({ summaries: all, setActiveRoom: vi.fn(), error })
   useSidebarSections.mockReturnValue(sections)
+  useChatlistSectionOrder.mockReturnValue(sections.filter((s) => !s.builtIn).map((s) => s.key))
   useChatlistActions.mockReturnValue(actions)
 }
 
@@ -144,7 +152,7 @@ describe('RoomList: drag to move', () => {
     // The Work section is the first .room-list-section
     const workSection = container.querySelectorAll('.room-list-section')[0]
     fireEvent.drop(workSection)
-    expect(actions.moveChatTo).toHaveBeenCalledWith('c1', 'site-A', 'work', undefined)
+    expect(actions.moveChatTo).toHaveBeenCalledWith('c1', 'site-A', 'work', undefined, undefined)
   })
 
   it('dropping a chat on the Chats section removes it (sectionId null)', () => {
@@ -157,7 +165,7 @@ describe('RoomList: drag to move', () => {
     fireEvent.dragStart(screen.getByText(/# proj/).closest('.room-item'), { dataTransfer })
     const chatsSection = container.querySelectorAll('.room-list-section')[1]
     fireEvent.drop(chatsSection)
-    expect(actions.moveChatTo).toHaveBeenCalledWith('w1', 'site-A', null, undefined)
+    expect(actions.moveChatTo).toHaveBeenCalledWith('w1', 'site-A', null, undefined, undefined)
   })
 
   it('dropping onto a specific room passes it as afterRoomId', () => {
@@ -169,6 +177,6 @@ describe('RoomList: drag to move', () => {
     const dataTransfer = { setData: vi.fn(), getData: vi.fn(), effectAllowed: '' }
     fireEvent.dragStart(screen.getByText(/# gen/).closest('.room-item'), { dataTransfer })
     fireEvent.drop(screen.getByText(/# proj/).closest('.room-item'))
-    expect(actions.moveChatTo).toHaveBeenCalledWith('c1', 'site-A', 'work', 'w1')
+    expect(actions.moveChatTo).toHaveBeenCalledWith('c1', 'site-A', 'work', 'w1', undefined)
   })
 })

--- a/chat-frontend/src/components/MainApp/Sidebar/RoomList/style.css
+++ b/chat-frontend/src/components/MainApp/Sidebar/RoomList/style.css
@@ -8,12 +8,20 @@
 }
 
 .room-list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: var(--space-md) var(--space-md) var(--space-sm);
   font-weight: var(--font-semibold);
   font-size: var(--text-xs);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--text-muted);
+}
+
+.room-list-add-section {
+  font-size: var(--text-base);
+  line-height: 1;
 }
 
 .room-list-items {
@@ -46,6 +54,8 @@
 }
 
 .room-name {
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -137,18 +147,26 @@
 .room-badge-mention { background: var(--mention); }
 .room-badge-mention-all { background: var(--mention-all); }
 
-/* ── Three-section sidebar buckets ─────────────────────────────────────
-   Favorite / Apps / Channels and DMs each render under a collapsible
-   header. The header inherits the design tokens so dark + light + the
-   black-and-white theme all pick up correct foregrounds without any
-   per-theme overrides here. */
+/* ── Chatlist v2 grouped sections ──────────────────────────────────────
+   Favorites / Apps / Teams / each custom section / Chats render under a
+   collapsible header with per-section controls. Custom sections + Chats are
+   drop targets for drag-to-move. Design tokens carry all theming. */
 .room-list-section {
   margin-bottom: var(--space-sm);
+  border-radius: var(--radius-md);
+  transition: background var(--motion-fast) var(--easing),
+              box-shadow var(--motion-fast) var(--easing);
+}
+
+.room-list-section-dragover {
+  background: var(--bg-hover);
+  box-shadow: inset 0 0 0 1px var(--accent);
 }
 
 .room-list-section-header {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: var(--space-xs);
   padding: var(--space-sm) var(--space-md);
   font-weight: var(--font-semibold);
@@ -156,13 +174,46 @@
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--text-muted);
-  cursor: pointer;
   user-select: none;
+}
+
+.room-list-section-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex: 1;
+  min-width: 0;
+  cursor: pointer;
   transition: color var(--motion-fast) var(--easing);
 }
 
-.room-list-section-header:hover {
+.room-list-section-title:hover {
   color: var(--text-secondary);
+}
+
+.room-list-section-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  opacity: 0;
+  transition: opacity var(--motion-fast) var(--easing);
+}
+
+.room-list-section-header:hover .room-list-section-controls {
+  opacity: 1;
+}
+
+.room-drag-handle {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  cursor: grab;
+  opacity: 0;
+  flex-shrink: 0;
+  transition: opacity var(--motion-fast) var(--easing);
+}
+
+.room-item:hover .room-drag-handle {
+  opacity: 0.6;
 }
 
 .room-list-section-collapsed .room-list-section-header {
@@ -187,10 +238,3 @@
   color: var(--text-muted);
 }
 
-.room-list-section-note {
-  padding: var(--space-xs) var(--space-md) var(--space-sm) calc(var(--space-md) + var(--space-md));
-  font-size: var(--text-xs);
-  font-style: italic;
-  color: var(--text-muted);
-  opacity: 0.8;
-}

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.test.jsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.test.jsx
@@ -1271,90 +1271,76 @@ describe('useSidebarSections', () => {
     )
   }
 
-  it('returns three sections in fixed order', async () => {
+  it('derives Favorites / Apps / Chats from the subscription flags', async () => {
+    // Chatlist v2 read model: the favorite bucket stamps favorite → Favorites;
+    // botDM → Apps; plain rooms → Chats. Empty built-ins (Teams here) are
+    // hidden; Chats always renders.
     const nats = bootstrapNats({ buckets: { favoriteIds: ['f1'], appIds: ['a1'], channelDmIds: ['c1'] } })
     render(wrap(<SectionsProbe />, nats))
-    await waitFor(() =>
-      expect(screen.getByTestId('section-channelDm').textContent).toContain('c1')
-    )
+    await waitFor(() => expect(screen.getByTestId('section-chats').textContent).toContain('c1'))
+    expect(screen.getByTestId('section-favorites').textContent).toContain('f1')
+    expect(screen.getByTestId('section-apps').textContent).toContain('a1')
     const items = screen.getAllByRole('listitem').map((li) => li.getAttribute('data-testid'))
-    expect(items).toEqual(['section-favorite', 'section-apps', 'section-channelDm'])
+    expect(items).toEqual(['section-favorites', 'section-apps', 'section-chats'])
   })
 
-  it('puts favorited rooms in Favorite (favorite > apps > channelDm exclusivity)', async () => {
-    // a1 appears in all three bucket lists — partition exclusivity
-    // (favorite > apps > channelDm) lands it under Favorite only.
+  it('a favorited room lands in Favorites, not Apps/Chats', async () => {
+    // a1 appears in all three buckets; the favorite stamp makes favorite win.
     const nats = bootstrapNats({
       buckets: { favoriteIds: ['f1', 'a1'], appIds: ['a1'], channelDmIds: ['c1', 'a1'] },
     })
     render(wrap(<SectionsProbe />, nats))
-    await waitFor(() =>
-      expect(screen.getByTestId('section-favorite').textContent).toContain('a1')
-    )
-    expect(screen.getByTestId('section-favorite').textContent).toContain('f1')
-    expect(screen.getByTestId('section-apps').textContent).not.toContain('a1')
-    expect(screen.getByTestId('section-channelDm').textContent).not.toContain('a1')
+    await waitFor(() => expect(screen.getByTestId('section-favorites').textContent).toContain('a1'))
+    expect(screen.getByTestId('section-favorites').textContent).toContain('f1')
+    // a1 is the only app → Apps is empty and hidden. Chats still holds c1 but
+    // not a1 (favorite wins).
+    expect(screen.queryByTestId('section-apps')).toBeNull()
+    expect(screen.getByTestId('section-chats').textContent).toContain('c1')
+    expect(screen.getByTestId('section-chats').textContent).not.toContain('a1')
   })
 
-  it('puts apps in Apps (apps > channelDm exclusivity)', async () => {
+  it('bot rooms land in Apps, plain rooms in Chats', async () => {
     const nats = bootstrapNats({
       buckets: { favoriteIds: [], appIds: ['a1'], channelDmIds: ['a1', 'c1'] },
     })
     render(wrap(<SectionsProbe />, nats))
     await waitFor(() => expect(screen.getByTestId('section-apps').textContent).toContain('a1'))
-    expect(screen.getByTestId('section-channelDm').textContent).not.toContain('a1')
-    expect(screen.getByTestId('section-channelDm').textContent).toContain('c1')
+    expect(screen.getByTestId('section-chats').textContent).not.toContain('a1')
+    expect(screen.getByTestId('section-chats').textContent).toContain('c1')
   })
 
   it('only renders rooms that appear in at least one bucket RPC', async () => {
-    // With listRooms gone, summaries are derived entirely from the
-    // three subscription RPCs — a room that isn't in any of them
-    // simply doesn't exist in state.
     const nats = bootstrapNats({
       buckets: { favoriteIds: ['f1'], appIds: ['a1'], channelDmIds: ['c1'] },
     })
     render(wrap(<SectionsProbe />, nats))
-    await waitFor(() =>
-      expect(screen.getByTestId('section-channelDm').textContent).toContain('c1')
-    )
-    expect(screen.getByTestId('section-favorite').textContent).not.toContain('u1')
-    expect(screen.getByTestId('section-apps').textContent).not.toContain('u1')
-    expect(screen.getByTestId('section-channelDm').textContent).not.toContain('u1')
+    await waitFor(() => expect(screen.getByTestId('section-chats').textContent).toContain('c1'))
+    expect(screen.queryByTestId('section-chats').textContent).not.toContain('u1')
+    expect(screen.queryByTestId('section-favorites').textContent).not.toContain('u1')
   })
 
-  it('renders all three section headers empty when every bucket RPC returns nothing', async () => {
-    // Cold-start path with zero subscriptions: the user has no rooms
-    // at all. All three sections render empty (RoomList shows the
-    // "No rooms" placeholder via section.note presence is handled in
-    // RoomList tests).
+  it('renders only the (always-present) Chats section when every bucket is empty', async () => {
     const nats = bootstrapNats({
       buckets: { favoriteIds: [], appIds: [], channelDmIds: [] },
     })
     render(wrap(<SectionsProbe />, nats))
-    // Wait for the bootstrap to settle.
     await waitFor(() => expect(nats.request).toHaveBeenCalledTimes(3))
-    expect(screen.getByTestId('section-favorite').textContent).toBe('Favorite: ')
-    expect(screen.getByTestId('section-apps').textContent).toBe('Apps: ')
-    expect(screen.getByTestId('section-channelDm').textContent).toBe('Channels and DMs: ')
+    // Empty built-ins are hidden; Chats always shows (empty).
+    const items = screen.getAllByRole('listitem').map((li) => li.getAttribute('data-testid'))
+    expect(items).toEqual(['section-chats'])
+    expect(screen.getByTestId('section-chats').textContent).toBe('Chats: ')
   })
 
-  it('preserves summaries recency order within each section', async () => {
-    // bootstrapNats builds lastMsgAt from each ID's first-char code,
-    // so c1 / f1 / a1 / u1 get distinct timestamps. Within
-    // channelDm — three rooms — the order is desc by lastMsgAt.
+  it('places all plain rooms in Chats', async () => {
     const nats = bootstrapNats({
       buckets: { favoriteIds: [], appIds: [], channelDmIds: ['f1', 'c1', 'u1'] },
     })
     render(wrap(<SectionsProbe />, nats))
-    await waitFor(() =>
-      expect(screen.getByTestId('section-channelDm').textContent).toContain('c1')
-    )
-    // We don't pin the exact order here (sortByLastMsgDesc is already
-    // covered by its own reducer tests); just assert all three rendered.
-    const channelDm = screen.getByTestId('section-channelDm').textContent
-    expect(channelDm).toContain('f1')
-    expect(channelDm).toContain('c1')
-    expect(channelDm).toContain('u1')
+    await waitFor(() => expect(screen.getByTestId('section-chats').textContent).toContain('c1'))
+    const chats = screen.getByTestId('section-chats').textContent
+    expect(chats).toContain('f1')
+    expect(chats).toContain('c1')
+    expect(chats).toContain('u1')
   })
 
   it('exposes subscription name and hrInfo on each room (sub IS the room)', async () => {
@@ -1386,7 +1372,7 @@ describe('useSidebarSections', () => {
 
     function MergeProbe() {
       const sections = useSidebarSections()
-      const channelDm = sections.find((s) => s.key === 'channelDm')
+      const channelDm = sections.find((s) => s.key === 'chats')
       return (
         <ul>
           {channelDm.rooms.map((r) => (

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
@@ -482,8 +482,9 @@ export function useChatlistActions() {
         siteId: string,
         sectionId: string | null,
         afterRoomId?: string,
+        beforeRoomId?: string,
       ) => {
-        await moveChat(nats, { roomId, siteId, sectionId, afterRoomId })
+        await moveChat(nats, { roomId, siteId, sectionId, afterRoomId, beforeRoomId })
       },
     }
   }, [nats, dispatch])

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
@@ -20,6 +20,7 @@ import {
   createChatlistSection,
   renameChatlistSection,
   deleteChatlistSection,
+  reorderChatlistSections,
   setChatlistSectionSortMode,
   moveChat,
 } from '@/api'
@@ -460,6 +461,15 @@ export function useSidebarSections(): SidebarSection[] {
   }, [summaries, subscriptions, chatlist])
 }
 
+/** Raw overlay section order (the full list the backend stores — built-ins +
+ *  customs). The reorder RPC requires its argument to be a PERMUTATION of this
+ *  full list, so the reorder UI moves a section within it rather than
+ *  reconstructing an order from the derived (built-in-normalised) sections. */
+export function useChatlistSectionOrder(): string[] {
+  const { state } = useRoomEventsInternal()
+  return state.chatlist?.sectionOrder ?? []
+}
+
 /** Imperative chatlist-section actions for the sidebar UI. Each wraps its api
  *  op and applies the returned overlay locally (CHATLIST_UPDATED) — the op's
  *  own event fans to the user's OTHER devices, so the caller must apply its
@@ -475,6 +485,8 @@ export function useChatlistActions() {
       renameSection: async (sectionId: string, name: string) =>
         apply(await renameChatlistSection(nats, { sectionId, name })),
       deleteSection: async (sectionId: string) => apply(await deleteChatlistSection(nats, sectionId)),
+      reorderSections: async (sectionOrder: string[]) =>
+        apply(await reorderChatlistSections(nats, sectionOrder)),
       setSortMode: async (sectionId: string, sortMode: ChatlistSortMode) =>
         apply(await setChatlistSectionSortMode(nats, { sectionId, sortMode })),
       moveChatTo: async (

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
@@ -13,7 +13,16 @@ import { useRoomKeys } from '@/context/RoomKeysContext'
 import { BUFFER_MODE, initialState, roomEventsReducer } from './reducer'
 import { useRoomSubscriptions } from './useRoomSubscriptions'
 import { useUnreadCount as useUnreadCountQuery } from './useUnreadCount'
-import { fetchMessageHistory, fetchSurroundingMessages, markRoomRead } from '@/api'
+import {
+  fetchMessageHistory,
+  fetchSurroundingMessages,
+  markRoomRead,
+  createChatlistSection,
+  renameChatlistSection,
+  deleteChatlistSection,
+  setChatlistSectionSortMode,
+  moveChat,
+} from '@/api'
 import { deriveSidebarSections } from '@/lib/chatlist'
 import type {
   ChatlistState,
@@ -449,6 +458,35 @@ export function useSidebarSections(): SidebarSection[] {
     const sections = deriveSidebarSections(summaries, subscriptions, chatlist) as SidebarSection[]
     return sections.map((s) => ({ ...s, rooms: s.rooms.map(enrich) }))
   }, [summaries, subscriptions, chatlist])
+}
+
+/** Imperative chatlist-section actions for the sidebar UI. Each wraps its api
+ *  op and applies the returned overlay locally (CHATLIST_UPDATED) — the op's
+ *  own event fans to the user's OTHER devices, so the caller must apply its
+ *  own result. `moveChatTo` relies on the section_moved event to update state. */
+export function useChatlistActions() {
+  const nats = useNats()
+  const dispatch = useRoomDispatch()
+  return useMemo(() => {
+    const apply = (chatlist: ChatlistState) => dispatch({ type: 'CHATLIST_UPDATED', chatlist })
+    return {
+      createSection: async (name: string, sortMode?: ChatlistSortMode) =>
+        apply(await createChatlistSection(nats, { name, sortMode })),
+      renameSection: async (sectionId: string, name: string) =>
+        apply(await renameChatlistSection(nats, { sectionId, name })),
+      deleteSection: async (sectionId: string) => apply(await deleteChatlistSection(nats, sectionId)),
+      setSortMode: async (sectionId: string, sortMode: ChatlistSortMode) =>
+        apply(await setChatlistSectionSortMode(nats, { sectionId, sortMode })),
+      moveChatTo: async (
+        roomId: string,
+        siteId: string,
+        sectionId: string | null,
+        afterRoomId?: string,
+      ) => {
+        await moveChat(nats, { roomId, siteId, sectionId, afterRoomId })
+      },
+    }
+  }, [nats, dispatch])
 }
 
 /**

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
@@ -14,7 +14,16 @@ import { BUFFER_MODE, initialState, roomEventsReducer } from './reducer'
 import { useRoomSubscriptions } from './useRoomSubscriptions'
 import { useUnreadCount as useUnreadCountQuery } from './useUnreadCount'
 import { fetchMessageHistory, fetchSurroundingMessages, markRoomRead } from '@/api'
-import type { DMSubscription, Message, Nats, Room, SubscriptionHRInfo } from '@/api/types'
+import { deriveSidebarSections } from '@/lib/chatlist'
+import type {
+  ChatlistState,
+  ChatlistSortMode,
+  DMSubscription,
+  Message,
+  Nats,
+  Room,
+  SubscriptionHRInfo,
+} from '@/api/types'
 
 /** Per-room buffer state — owned by the reducer's `roomState` map. */
 interface RoomBufferState {
@@ -77,6 +86,10 @@ interface RoomEventsState {
    *  so consumers reading the map for either channel or DM rooms see
    *  hrInfo as optional without narrowing. */
   subscriptions: Record<string, DMSubscription>
+  /** Chatlist section-definition overlay (names, order, sortMode). Seeded by
+   *  CHATLIST_LOADED, replaced by CHATLIST_UPDATED (LWW). Membership rides the
+   *  subscriptions; this is O(sections). */
+  chatlist: ChatlistState
 }
 
 /** Payload for the thread-reply hook ThreadEventsProvider registers. */
@@ -401,37 +414,28 @@ export function useRegisterThreadMessageMutationHandler(): RoomEventsContextValu
   return ctx.registerThreadMessageMutationHandler
 }
 
-/** Section descriptor returned by `useSidebarSections`. */
+/** Section descriptor returned by `useSidebarSections`. `key` is the section
+ *  id (a built-in id or a custom-section id — the collapse + React key). */
 export interface SidebarSection {
-  key: 'favorite' | 'apps' | 'channelDm'
+  key: string
   title: string
+  builtIn: boolean
+  sortMode: ChatlistSortMode
   rooms: RoomSummary[]
-  /** Disabled-section banner. Rendered in place of room items when the
-   *  section is expanded — used today for the Favorite section while the
-   *  end-to-end favorite path is unimplemented (`pkg/model.Subscription`
-   *  has no Favorite field yet). */
-  note?: string
 }
 
 /**
- * Partition the room summaries into the three sidebar buckets:
- * Favorite, Apps, Channels and DMs. Bucket membership comes from the
- * `BUCKETS_LOADED` dispatch (fetched by useRoomSubscriptions on login)
- * + the per-type ROOM_ADDED / ROOM_REMOVED maintenance the reducer
- * applies.
- *
- * Returns an ordered array of `{key, title, rooms}` sections so the
- * sidebar can render headers + rows without re-deriving the split.
- *
- * Per-room subscription metadata (subscription.name + hrInfo for DMs)
- * is merged onto each room here so `roomDisplayName` resolves the user's
- * preferred name for channels and the counterpart's hrInfo for DMs
- * (only present on DMSubscription records) without the underlying
- * summary structure carrying those fields directly.
+ * Derive the grouped sidebar (Custom Sections v2 read model): Favorites ·
+ * Apps · Teams · each custom section · Chats, all derived from the per-room
+ * subscription flags (favorite / bot / sectionId) joined with the section
+ * definitions overlay (`state.chatlist`). Orphan-tolerant (a sectionId
+ * pointing at a deleted section renders in Chats). The pure grouping + sort
+ * lives in `lib/chatlist.deriveSidebarSections`; here we only join state and
+ * enrich each room with its subscription's display name + hrInfo.
  */
 export function useSidebarSections(): SidebarSection[] {
   const { state } = useRoomEventsInternal()
-  const { summaries, favoriteIds, appIds, channelDmIds, subscriptions } = state
+  const { summaries, subscriptions, chatlist } = state
   return useMemo(() => {
     const enrich = (room: RoomSummary): RoomSummary => {
       const sub = subscriptions[room.id]
@@ -442,30 +446,9 @@ export function useSidebarSections(): SidebarSection[] {
         hrInfo: sub.hrInfo ?? room.hrInfo,
       }
     }
-    const favorite: RoomSummary[] = []
-    const apps: RoomSummary[] = []
-    const channelDm: RoomSummary[] = []
-    // Cold-start safety: if all three bucket Sets are empty, the
-    // subscription.list RPCs either failed or haven't landed yet.
-    // subscription.list is independent and may have populated `summaries`
-    // already; strict partitioning would drop every one of those
-    // rooms and render an empty sidebar. Fall back to a flat list
-    // under Channels and DMs so the user can still reach their rooms;
-    // the next BUCKETS_LOADED dispatch re-partitions normally.
-    const allBucketsEmpty =
-      favoriteIds.size === 0 && appIds.size === 0 && channelDmIds.size === 0
-    for (const room of summaries) {
-      if (favoriteIds.has(room.id)) favorite.push(enrich(room))
-      else if (appIds.has(room.id)) apps.push(enrich(room))
-      else if (channelDmIds.has(room.id)) channelDm.push(enrich(room))
-      else if (allBucketsEmpty) channelDm.push(enrich(room))
-    }
-    return [
-      { key: 'favorite',  title: 'Favorite',          rooms: favorite },
-      { key: 'apps',      title: 'Apps',              rooms: apps },
-      { key: 'channelDm', title: 'Channels and DMs',  rooms: channelDm },
-    ]
-  }, [summaries, favoriteIds, appIds, channelDmIds, subscriptions])
+    const sections = deriveSidebarSections(summaries, subscriptions, chatlist) as SidebarSection[]
+    return sections.map((s) => ({ ...s, rooms: s.rooms.map(enrich) }))
+  }, [summaries, subscriptions, chatlist])
 }
 
 /**

--- a/chat-frontend/src/context/RoomEventsContext/reducer.chatlist.test.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.chatlist.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { initialState, roomEventsReducer } from './reducer'
+import { defaultChatlistState } from '@/lib/chatlist'
+
+function withSub(roomId, sub = {}) {
+  return {
+    ...initialState,
+    subscriptions: { [roomId]: { roomId, roomType: 'channel', ...sub } },
+  }
+}
+
+describe('reducer: chatlist state', () => {
+  it('defaults to the built-in overlay', () => {
+    expect(initialState.chatlist).toEqual(defaultChatlistState())
+  })
+
+  it('CHATLIST_LOADED replaces the overlay', () => {
+    const chatlist = { sectionOrder: ['favorites', 'work', 'chats'], sections: [], lastUpdatedAt: 5 }
+    const next = roomEventsReducer(initialState, { type: 'CHATLIST_LOADED', chatlist })
+    expect(next.chatlist).toBe(chatlist)
+  })
+
+  it('CHATLIST_UPDATED applies a newer overlay (LWW) and drops a stale one', () => {
+    const seeded = roomEventsReducer(initialState, {
+      type: 'CHATLIST_LOADED',
+      chatlist: { sectionOrder: [], sections: [], lastUpdatedAt: 100 },
+    })
+    const newer = { sectionOrder: ['chats'], sections: [], lastUpdatedAt: 200 }
+    const afterNew = roomEventsReducer(seeded, { type: 'CHATLIST_UPDATED', chatlist: newer })
+    expect(afterNew.chatlist).toBe(newer)
+    const stale = { sectionOrder: [], sections: [], lastUpdatedAt: 150 }
+    const afterStale = roomEventsReducer(afterNew, { type: 'CHATLIST_UPDATED', chatlist: stale })
+    expect(afterStale.chatlist).toBe(newer) // stale dropped
+  })
+})
+
+describe('reducer: SUBSCRIPTION_SECTION_MOVED', () => {
+  it('sets sectionId + sectionOrder on the sub', () => {
+    const state = withSub('r1')
+    const next = roomEventsReducer(state, {
+      type: 'SUBSCRIPTION_SECTION_MOVED',
+      roomId: 'r1',
+      sectionId: 'work',
+      sectionOrder: 3.5,
+    })
+    expect(next.subscriptions.r1).toMatchObject({ sectionId: 'work', sectionOrder: 3.5 })
+  })
+
+  it('clears both fields on a remove (undefined), not leaving the old section', () => {
+    const state = withSub('r1', { sectionId: 'work', sectionOrder: 2 })
+    const next = roomEventsReducer(state, {
+      type: 'SUBSCRIPTION_SECTION_MOVED',
+      roomId: 'r1',
+      sectionId: undefined,
+      sectionOrder: undefined,
+    })
+    expect(next.subscriptions.r1.sectionId).toBeUndefined()
+    expect(next.subscriptions.r1.sectionOrder).toBeUndefined()
+  })
+
+  it('is a no-op for an unknown room or an unchanged placement', () => {
+    const unknown = roomEventsReducer(initialState, {
+      type: 'SUBSCRIPTION_SECTION_MOVED',
+      roomId: 'nope',
+      sectionId: 'work',
+    })
+    expect(unknown).toBe(initialState)
+    const state = withSub('r1', { sectionId: 'work', sectionOrder: 2 })
+    const same = roomEventsReducer(state, {
+      type: 'SUBSCRIPTION_SECTION_MOVED',
+      roomId: 'r1',
+      sectionId: 'work',
+      sectionOrder: 2,
+    })
+    expect(same).toBe(state)
+  })
+})

--- a/chat-frontend/src/context/RoomEventsContext/reducer.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.js
@@ -1,4 +1,5 @@
 import { appendBounded, mergeById, MAX_CACHED } from '@/lib/messageBuffer'
+import { defaultChatlistState } from '@/lib/chatlist'
 
 export { MAX_CACHED }
 
@@ -83,6 +84,15 @@ export const initialState = {
    * pkg/model.Subscription (see chat-frontend/src/api/types.ts).
    */
   subscriptions: {},
+  /**
+   * The per-user chatlist section-definition overlay (ChatlistState) — the
+   * section names, display order, and sortMode. Membership is NOT here; it
+   * rides each subscription's sectionId/sectionOrder. Seeded by
+   * CHATLIST_LOADED (chatlist.get) and replaced wholesale by CHATLIST_UPDATED
+   * (chatlist.update event, last-write-wins on lastUpdatedAt). Defaults to the
+   * four derived built-ins for a never-customized user.
+   */
+  chatlist: defaultChatlistState(),
 }
 
 
@@ -309,6 +319,36 @@ export function roomEventsReducer(state, action) {
         s.id === sub.roomId ? mergeSubscriptionIntoSummary(s, sub) : s
       )
       return { ...state, summaries, subscriptions }
+    }
+    case 'SUBSCRIPTION_SECTION_MOVED': {
+      // A chat's chatlist section membership/order changed (subscription.update
+      // action "section_moved"). Unlike SUBSCRIPTION_UPSERTED's spread-merge,
+      // set BOTH fields explicitly — a remove clears them (a spread of an
+      // omitempty-absent field would leave the chat stuck in its old section).
+      const { roomId } = action
+      if (!roomId) return state
+      const prev = state.subscriptions[roomId]
+      if (!prev) return state
+      if (prev.sectionId === action.sectionId && prev.sectionOrder === action.sectionOrder) {
+        return state
+      }
+      const next = { ...prev, sectionId: action.sectionId, sectionOrder: action.sectionOrder }
+      return { ...state, subscriptions: { ...state.subscriptions, [roomId]: next } }
+    }
+    case 'CHATLIST_LOADED': {
+      // Initial section-definition overlay (chatlist.get). Replaces the
+      // built-in default wholesale.
+      if (!action.chatlist) return state
+      return { ...state, chatlist: action.chatlist }
+    }
+    case 'CHATLIST_UPDATED': {
+      // Live chatlist.update — full-state replace, last-write-wins on the
+      // overlay's high-water mark. A stale event (older lastUpdatedAt) is
+      // dropped.
+      const incoming = action.chatlist
+      if (!incoming) return state
+      if (state.chatlist && incoming.lastUpdatedAt < state.chatlist.lastUpdatedAt) return state
+      return { ...state, chatlist: incoming }
     }
     case 'ROOM_METADATA_UPDATED': {
       const existing = state.summaries.find((r) => r.id === action.roomId)

--- a/chat-frontend/src/context/RoomEventsContext/reducer.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.js
@@ -1,5 +1,5 @@
 import { appendBounded, mergeById, MAX_CACHED } from '@/lib/messageBuffer'
-import { defaultChatlistState } from '@/lib/chatlist'
+import { defaultChatlistState, sortByLastMsgDesc } from '@/lib/chatlist'
 
 export { MAX_CACHED }
 
@@ -96,13 +96,6 @@ export const initialState = {
 }
 
 
-function sortByLastMsgDesc(summaries) {
-  return [...summaries].sort((a, b) => {
-    const at = a.lastMsgAt ? new Date(a.lastMsgAt).getTime() : 0
-    const bt = b.lastMsgAt ? new Date(b.lastMsgAt).getTime() : 0
-    return bt - at
-  })
-}
 
 function toSummary(room) {
   return {

--- a/chat-frontend/src/context/RoomEventsContext/useRoomSubscriptions.js
+++ b/chat-frontend/src/context/RoomEventsContext/useRoomSubscriptions.js
@@ -2,8 +2,11 @@ import { useEffect, useMemo, useRef } from 'react'
 import {
   fetchSidebarBuckets,
   keyEntryFor,
+  getChatlist,
+  seedChatlistDemo,
   markRoomRead,
   subToRoom,
+  subscribeToChatlistUpdates,
   subscribeToRoomEvents,
   subscribeToRoomMetadataUpdates,
   subscribeToSubscriptionUpdates,
@@ -451,6 +454,16 @@ export function useRoomSubscriptions(
         if (!roomId) return
         closeChannelSub(roomId)
         safeDispatch({ type: 'ROOM_REMOVED', roomId })
+      } else if (evt.action === 'section_moved' && evt.subscription?.roomId) {
+        // A chat's chatlist section membership/order changed. Set both fields
+        // explicitly (a remove clears them) — see reducer's
+        // SUBSCRIPTION_SECTION_MOVED for why this isn't a partial merge.
+        safeDispatch({
+          type: 'SUBSCRIPTION_SECTION_MOVED',
+          roomId: evt.subscription.roomId,
+          sectionId: evt.subscription.sectionId,
+          sectionOrder: evt.subscription.sectionOrder,
+        })
       } else if (evt.subscription?.roomId) {
         // Catch-all for any other action that carries a subscription
         // payload. Today the backend emits `role_updated` (room-worker
@@ -461,6 +474,13 @@ export function useRoomSubscriptions(
         // lastSeenAt / hasMention / alert from the prior record.
         safeDispatch({ type: 'SUBSCRIPTION_UPSERTED', subscription: evt.subscription })
       }
+    })
+
+    // Live chatlist section-definition sync (chatlist.update). Full-state
+    // replace, LWW — see reducer's CHATLIST_UPDATED.
+    const chatlistUpdate = subscribeToChatlistUpdates(liveNats, (evt) => {
+      if (cancelledRef.current) return
+      if (evt?.chatlist) safeDispatch({ type: 'CHATLIST_UPDATED', chatlist: evt.chatlist })
     })
 
     const metaUpdate = subscribeToRoomMetadataUpdates(liveNats, (evt) => {
@@ -484,7 +504,32 @@ export function useRoomSubscriptions(
         // Generation check, not just cancelledRef: a slow bootstrap from a
         // prior login must not seed keys or open subs into the new session.
         if (!isCurrent()) return
+        // Dev-only: seed sample sections + membership onto the loaded subs so
+        // the grouped sidebar has populated custom sections to demo. No-op in
+        // the live path (seedChatlistDemo returns null unless CHATLIST_MOCK).
+        const seed = seedChatlistDemo(Object.values(buckets.subscriptions ?? {}))
+        if (seed) {
+          for (const [roomId, m] of Object.entries(seed.membership)) {
+            if (buckets.subscriptions[roomId]) Object.assign(buckets.subscriptions[roomId], m)
+          }
+          for (const roomId of seed.favoriteRoomIds) {
+            if (buckets.subscriptions[roomId]) buckets.subscriptions[roomId].favorite = true
+          }
+        }
         safeDispatch({ type: 'BUCKETS_LOADED', ...buckets })
+        // Load the section-definition overlay (chatlist.get). In mock mode
+        // this returns the seeded sections; live, the backend's overlay.
+        // Wrapped in Promise.resolve so it never blocks the channel-sub setup
+        // below even if the RPC layer throws synchronously.
+        Promise.resolve()
+          .then(() => getChatlist(liveNats))
+          .then((chatlist) => {
+            if (!cancelledRef.current) safeDispatch({ type: 'CHATLIST_LOADED', chatlist })
+          })
+          .catch((err) => {
+            // eslint-disable-next-line no-console
+            console.warn('chatlist.get failed:', err?.message ?? err)
+          })
         // Seed room keys delivered inline on subscription.list so the first
         // message in each encrypted room decrypts immediately — no placeholder,
         // no on-demand key.get RPC. Rooms without a key (plaintext DMs, or no
@@ -507,6 +552,7 @@ export function useRoomSubscriptions(
       dmSub.unsubscribe()
       subUpdate.unsubscribe()
       metaUpdate.unsubscribe()
+      chatlistUpdate.unsubscribe()
       for (const entry of channelSubs.current.values()) entry.sub.unsubscribe()
       channelSubs.current.clear()
       dispatchChains.clear()

--- a/chat-frontend/src/lib/chatlist.js
+++ b/chat-frontend/src/lib/chatlist.js
@@ -74,11 +74,24 @@ function sortByLastMsgDesc(rooms) {
  * @param {import('../api/types').ChatlistState} chatlist
  */
 export function deriveSidebarSections(summaries, subscriptions, chatlist) {
-  const overlay = chatlist?.sections?.length ? chatlist : defaultChatlistState()
-  const byId = new Map(overlay.sections.map((s) => [s.id, s]))
-  const order = overlay.sectionOrder.filter((id) => byId.has(id))
+  // Built-in section defs (Favorites/Apps/Teams/Chats) are ALWAYS available as
+  // derivation targets — they're derived client-side, not carried in the backend
+  // overlay (which holds only custom section defs). Merge the built-in defaults
+  // UNDER any custom overlay so favorite/bot/sectionId=='teams' rooms always have
+  // a home; without this the built-in buckets vanished the moment a custom section
+  // existed, and those rooms wrongly fell back to Chats. Order: built-ins top,
+  // custom sections (overlay order) in the middle, Chats last. Empty built-ins
+  // (Favorites/Apps/Teams) are hidden by the visibility filter below.
+  const base = defaultChatlistState()
+  const custom = chatlist?.sections?.length ? chatlist : { sectionOrder: [], sections: [] }
+  const byId = new Map()
+  for (const s of base.sections) byId.set(s.id, s)
+  for (const s of custom.sections) byId.set(s.id, s)
+  const customIds = custom.sectionOrder.filter((id) => byId.has(id) && !isBuiltinSectionId(id))
+  const order = [BUILTIN_FAVORITES, BUILTIN_APPS, BUILTIN_TEAMS, ...customIds, BUILTIN_CHATS].filter(
+    (id, i, a) => a.indexOf(id) === i,
+  )
   const buckets = new Map(order.map((id) => [id, []]))
-  if (!buckets.has(BUILTIN_CHATS)) buckets.set(BUILTIN_CHATS, [])
 
   for (const room of summaries) {
     const sub = subscriptions[room.id]

--- a/chat-frontend/src/lib/chatlist.js
+++ b/chat-frontend/src/lib/chatlist.js
@@ -44,6 +44,71 @@ export function defaultChatlistState() {
   }
 }
 
+function lastMsgTime(summary) {
+  return summary.lastMsgAt ? new Date(summary.lastMsgAt).getTime() : 0
+}
+
+function sortByLastMsgDesc(rooms) {
+  return [...rooms].sort((a, b) => lastMsgTime(b) - lastMsgTime(a))
+}
+
+/**
+ * Derive the grouped sidebar sections from the room summaries, the per-room
+ * subscriptions, and the section-definition overlay — the P3 read model.
+ *
+ * Each room lands in EXACTLY ONE section, by this precedence (mirrors the
+ * backend read model): favorite → Favorites; bot → Apps; sectionId=='teams'
+ * → Teams; sectionId==<known custom> → that section; otherwise (no sectionId,
+ * an orphaned sectionId, or a plain chat) → Chats.
+ *
+ * Within a section: `sortMode == 'custom'` orders by the members'
+ * `subscription.sectionOrder` (unordered members last); otherwise by last
+ * message, descending.
+ *
+ * Visibility: empty built-in sections (Favorites/Apps/Teams) are hidden;
+ * custom sections and Chats always render (so a custom section stays a visible
+ * drop target and Chats is the always-present home).
+ *
+ * @param {import('../context/RoomEventsContext/RoomEventsContext').RoomSummary[]} summaries
+ * @param {Record<string, import('../api/types').DMSubscription>} subscriptions
+ * @param {import('../api/types').ChatlistState} chatlist
+ */
+export function deriveSidebarSections(summaries, subscriptions, chatlist) {
+  const overlay = chatlist?.sections?.length ? chatlist : defaultChatlistState()
+  const byId = new Map(overlay.sections.map((s) => [s.id, s]))
+  const order = overlay.sectionOrder.filter((id) => byId.has(id))
+  const buckets = new Map(order.map((id) => [id, []]))
+  if (!buckets.has(BUILTIN_CHATS)) buckets.set(BUILTIN_CHATS, [])
+
+  for (const room of summaries) {
+    const sub = subscriptions[room.id]
+    const isBot = room.type === 'botDM' || !!sub?.u?.isBot
+    const sectionId = sub?.sectionId
+    let target
+    if (sub?.favorite) target = BUILTIN_FAVORITES
+    else if (isBot) target = BUILTIN_APPS
+    else if (sectionId && byId.has(sectionId)) target = sectionId
+    else target = BUILTIN_CHATS
+    if (!buckets.has(target)) target = BUILTIN_CHATS
+    buckets.get(target).push(room)
+  }
+
+  const orderOf = (room) => {
+    const o = subscriptions[room.id]?.sectionOrder
+    return typeof o === 'number' ? o : Infinity
+  }
+  const sections = order.map((id) => {
+    const def = byId.get(id)
+    const rooms = buckets.get(id) ?? []
+    const sorted =
+      def.sortMode === 'custom'
+        ? [...rooms].sort((a, b) => orderOf(a) - orderOf(b))
+        : sortByLastMsgDesc(rooms)
+    return { key: id, title: def.name, sortMode: def.sortMode, builtIn: def.builtIn, rooms: sorted }
+  })
+  return sections.filter((s) => s.rooms.length > 0 || !s.builtIn || s.key === BUILTIN_CHATS)
+}
+
 // Section name: 1–50 chars trimmed, no consecutive spaces, only
 // letters/digits (any script) / space / - _ . / ( ). Mirrors the backend
 // validator so the UI can pre-flight before the RPC round-trip.

--- a/chat-frontend/src/lib/chatlist.js
+++ b/chat-frontend/src/lib/chatlist.js
@@ -1,0 +1,61 @@
+// Pure chatlist helpers — built-in section ids, the default overlay, and
+// section-name validation. No React, no NATS. Mirrors the backend's derived
+// built-ins + name rules (docs/client-api.md "Chatlist Sections").
+
+/** Built-in section ids. Membership is derived client-side, never stored on
+ *  a subscription. Order here is the default display order (custom sections
+ *  slot in just above `chats`). */
+export const BUILTIN_FAVORITES = 'favorites'
+export const BUILTIN_APPS = 'apps'
+export const BUILTIN_TEAMS = 'teams'
+export const BUILTIN_CHATS = 'chats'
+
+export const BUILTIN_SECTION_IDS = [
+  BUILTIN_FAVORITES,
+  BUILTIN_APPS,
+  BUILTIN_TEAMS,
+  BUILTIN_CHATS,
+]
+
+const BUILTIN_TITLES = {
+  [BUILTIN_FAVORITES]: 'Favorites',
+  [BUILTIN_APPS]: 'Apps',
+  [BUILTIN_TEAMS]: 'Teams',
+  [BUILTIN_CHATS]: 'Chats',
+}
+
+export function isBuiltinSectionId(id) {
+  return BUILTIN_SECTION_IDS.includes(id)
+}
+
+/** The default overlay a never-customized user starts from: the four
+ *  built-ins, `mostRecent` sort, in canonical order.
+ *  @returns {import('../api/types').ChatlistState} */
+export function defaultChatlistState() {
+  return {
+    sectionOrder: [...BUILTIN_SECTION_IDS],
+    sections: BUILTIN_SECTION_IDS.map((id) => ({
+      id,
+      name: BUILTIN_TITLES[id],
+      builtIn: true,
+      sortMode: 'mostRecent',
+    })),
+    lastUpdatedAt: 0,
+  }
+}
+
+// Section name: 1–50 chars trimmed, no consecutive spaces, only
+// letters/digits (any script) / space / - _ . / ( ). Mirrors the backend
+// validator so the UI can pre-flight before the RPC round-trip.
+const NAME_ALLOWED = /^[\p{L}\p{N} \-_./()]+$/u
+
+/** Validate a custom-section name. Returns `{ ok: true, name }` (trimmed) or
+ *  `{ ok: false, reason }` with the same reason code the backend emits.
+ *  @returns {{ ok: true, name: string } | { ok: false, reason: string }} */
+export function validateSectionName(raw) {
+  const name = String(raw ?? '').trim()
+  if (name.length < 1 || name.length > 50) return { ok: false, reason: 'chatlist_invalid_name' }
+  if (name.includes('  ')) return { ok: false, reason: 'chatlist_invalid_name' }
+  if (!NAME_ALLOWED.test(name)) return { ok: false, reason: 'chatlist_invalid_name' }
+  return { ok: true, name }
+}

--- a/chat-frontend/src/lib/chatlist.js
+++ b/chat-frontend/src/lib/chatlist.js
@@ -48,7 +48,7 @@ function lastMsgTime(summary) {
   return summary.lastMsgAt ? new Date(summary.lastMsgAt).getTime() : 0
 }
 
-function sortByLastMsgDesc(rooms) {
+export function sortByLastMsgDesc(rooms) {
   return [...rooms].sort((a, b) => lastMsgTime(b) - lastMsgTime(a))
 }
 
@@ -88,9 +88,7 @@ export function deriveSidebarSections(summaries, subscriptions, chatlist) {
   for (const s of base.sections) byId.set(s.id, s)
   for (const s of custom.sections) byId.set(s.id, s)
   const customIds = custom.sectionOrder.filter((id) => byId.has(id) && !isBuiltinSectionId(id))
-  const order = [BUILTIN_FAVORITES, BUILTIN_APPS, BUILTIN_TEAMS, ...customIds, BUILTIN_CHATS].filter(
-    (id, i, a) => a.indexOf(id) === i,
-  )
+  const order = [BUILTIN_FAVORITES, BUILTIN_APPS, BUILTIN_TEAMS, ...customIds, BUILTIN_CHATS]
   const buckets = new Map(order.map((id) => [id, []]))
 
   for (const room of summaries) {

--- a/chat-frontend/src/lib/chatlist.test.js
+++ b/chat-frontend/src/lib/chatlist.test.js
@@ -3,8 +3,27 @@ import {
   BUILTIN_SECTION_IDS,
   isBuiltinSectionId,
   defaultChatlistState,
+  deriveSidebarSections,
   validateSectionName,
 } from './chatlist'
+
+function summary(id, over = {}) {
+  return { id, name: id, type: 'channel', lastMsgAt: '2026-04-17T10:00:00Z', ...over }
+}
+
+// overlay with one custom section "work"
+function overlayWithWork() {
+  const base = defaultChatlistState()
+  return {
+    sectionOrder: ['favorites', 'apps', 'teams', 'work', 'chats'],
+    sections: [...base.sections, { id: 'work', name: 'Work', builtIn: false, sortMode: 'custom' }],
+    lastUpdatedAt: 1,
+  }
+}
+
+function sectionsByKey(list) {
+  return Object.fromEntries(list.map((s) => [s.key, s.rooms.map((r) => r.id)]))
+}
 
 describe('defaultChatlistState', () => {
   it('is the four built-ins in canonical order, mostRecent', () => {
@@ -19,6 +38,73 @@ describe('isBuiltinSectionId', () => {
   it('true for built-ins, false for custom', () => {
     expect(isBuiltinSectionId('teams')).toBe(true)
     expect(isBuiltinSectionId('mock-section-1')).toBe(false)
+  })
+})
+
+describe('deriveSidebarSections', () => {
+  it('groups by flag precedence: favorite > bot > sectionId > chats', () => {
+    const summaries = [
+      summary('fav'),
+      summary('bot', { type: 'botDM' }),
+      summary('team'),
+      summary('work1'),
+      summary('plain'),
+    ]
+    const subs = {
+      fav: { roomId: 'fav', favorite: true, sectionId: 'work' }, // favorite wins over custom
+      bot: { roomId: 'bot', sectionId: 'work' }, // bot (by room type) wins over custom
+      team: { roomId: 'team', sectionId: 'teams' },
+      work1: { roomId: 'work1', sectionId: 'work', sectionOrder: 1 },
+      plain: { roomId: 'plain' },
+    }
+    const out = sectionsByKey(deriveSidebarSections(summaries, subs, overlayWithWork()))
+    expect(out.favorites).toEqual(['fav'])
+    expect(out.apps).toEqual(['bot'])
+    expect(out.teams).toEqual(['team'])
+    expect(out.work).toEqual(['work1'])
+    expect(out.chats).toEqual(['plain'])
+  })
+
+  it('renders an orphaned sectionId in chats', () => {
+    const summaries = [summary('r1')]
+    const subs = { r1: { roomId: 'r1', sectionId: 'deleted-section' } }
+    const out = sectionsByKey(deriveSidebarSections(summaries, subs, overlayWithWork()))
+    expect(out.chats).toEqual(['r1'])
+  })
+
+  it('sorts a custom section by sectionOrder, others by last message', () => {
+    const summaries = [
+      summary('w-b', { lastMsgAt: '2026-04-17T09:00:00Z' }),
+      summary('w-a', { lastMsgAt: '2026-04-17T12:00:00Z' }),
+      summary('c-old', { lastMsgAt: '2026-04-17T08:00:00Z' }),
+      summary('c-new', { lastMsgAt: '2026-04-17T13:00:00Z' }),
+    ]
+    const subs = {
+      'w-b': { roomId: 'w-b', sectionId: 'work', sectionOrder: 1 },
+      'w-a': { roomId: 'w-a', sectionId: 'work', sectionOrder: 2 },
+      'c-old': { roomId: 'c-old' },
+      'c-new': { roomId: 'c-new' },
+    }
+    const out = sectionsByKey(deriveSidebarSections(summaries, subs, overlayWithWork()))
+    expect(out.work).toEqual(['w-b', 'w-a']) // by sectionOrder, not last-msg
+    expect(out.chats).toEqual(['c-new', 'c-old']) // by last-msg desc
+  })
+
+  it('hides empty built-ins (except chats) but always shows custom sections', () => {
+    const summaries = [summary('plain')]
+    const subs = { plain: { roomId: 'plain' } }
+    const list = deriveSidebarSections(summaries, subs, overlayWithWork())
+    const keys = list.map((s) => s.key)
+    expect(keys).toContain('chats') // always
+    expect(keys).toContain('work') // custom, even though empty
+    expect(keys).not.toContain('favorites') // empty built-in hidden
+    expect(keys).not.toContain('apps')
+    expect(keys).not.toContain('teams')
+  })
+
+  it('falls back to the built-in overlay when none is provided', () => {
+    const out = sectionsByKey(deriveSidebarSections([summary('r1')], { r1: { roomId: 'r1' } }, undefined))
+    expect(out.chats).toEqual(['r1'])
   })
 })
 

--- a/chat-frontend/src/lib/chatlist.test.js
+++ b/chat-frontend/src/lib/chatlist.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import {
+  BUILTIN_SECTION_IDS,
+  isBuiltinSectionId,
+  defaultChatlistState,
+  validateSectionName,
+} from './chatlist'
+
+describe('defaultChatlistState', () => {
+  it('is the four built-ins in canonical order, mostRecent', () => {
+    const s = defaultChatlistState()
+    expect(s.sectionOrder).toEqual(BUILTIN_SECTION_IDS)
+    expect(s.sections.map((x) => x.sortMode)).toEqual(['mostRecent', 'mostRecent', 'mostRecent', 'mostRecent'])
+    expect(s.sections.every((x) => x.builtIn)).toBe(true)
+  })
+})
+
+describe('isBuiltinSectionId', () => {
+  it('true for built-ins, false for custom', () => {
+    expect(isBuiltinSectionId('teams')).toBe(true)
+    expect(isBuiltinSectionId('mock-section-1')).toBe(false)
+  })
+})
+
+describe('validateSectionName', () => {
+  it('accepts a trimmed valid name', () => {
+    expect(validateSectionName('  Work Chat  ')).toEqual({ ok: true, name: 'Work Chat' })
+  })
+  it('accepts non-latin letters + allowed punctuation', () => {
+    expect(validateSectionName('工作-群/組(A)')).toEqual({ ok: true, name: '工作-群/組(A)' })
+  })
+  it('rejects empty, too-long, consecutive-space, and bad chars', () => {
+    expect(validateSectionName('').ok).toBe(false)
+    expect(validateSectionName('x'.repeat(51)).ok).toBe(false)
+    expect(validateSectionName('a  b').ok).toBe(false)
+    expect(validateSectionName('bad@name').ok).toBe(false)
+  })
+})

--- a/chat-frontend/src/lib/runtimeConfig.js
+++ b/chat-frontend/src/lib/runtimeConfig.js
@@ -41,6 +41,14 @@ export const OTEL_DEPLOYMENT_ENVIRONMENT =
   import.meta.env.VITE_OTEL_DEPLOYMENT_ENVIRONMENT ||
   'local'
 
+// Dev-only: route the chatlist section RPCs/events to an in-memory mock so
+// the grouped sidebar can be demoed before the backend chatlist RPCs land.
+// Default false — production/live always uses the real NATS subjects.
+export const CHATLIST_MOCK = boolConfig(
+  runtime.CHATLIST_MOCK ?? import.meta.env.VITE_CHATLIST_MOCK,
+  false,
+)
+
 // Mirrors portal-service's BOT_LOGIN_ENABLED flag (surfaced via /api/settings
 // as botLoginEnabled). Default true: a missing flag (old portal, or a deploy
 // that hasn't wired the var yet) must not silently lock out bots that were

--- a/chat-frontend/vite.config.js
+++ b/chat-frontend/vite.config.js
@@ -14,6 +14,25 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, 'src'),
     },
+    dedupe: ['react', 'react-dom'],
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        // Force React/ReactDOM/scheduler into ONE shared chunk so the entry AND every
+        // async (React.lazy) chunk reference the SAME React module instance. Without
+        // this, Rollup's code-split produced two React instances: react-dom bound its
+        // dispatcher to one, while the lazy dialog chunks imported the other (null
+        // dispatcher) → "Invalid hook call" (#321) the moment any lazy dialog mounts
+        // (New Section, Create Room, Manage Members, …). Prod-build-only — vitest uses
+        // a single module graph, so unit tests never surfaced it. resolve.dedupe alone
+        // did not fix it (bare `react` already resolved to one copy); the dup was a
+        // chunk-boundary artifact, which a manual vendor chunk collapses.
+        manualChunks(id) {
+          if (/node_modules\/(react|react-dom|scheduler)\//.test(id)) return 'react-vendor'
+        },
+      },
+    },
   },
   server: {
     port: 3000,

--- a/docs/superpowers/plans/2026-08-01-chatlist-sections-v2-frontend.md
+++ b/docs/superpowers/plans/2026-08-01-chatlist-sections-v2-frontend.md
@@ -1,0 +1,77 @@
+# Chatlist Custom Sections v2 — frontend read-model + section management
+
+Implements the P3 client read-model from PRD #27. Wire contract per the `feat/chatlist-sections`
+backend branch (docs/client-api.md + events.md + request-reply.md). Backend RPCs are UNMERGED,
+so the FE ships against the documented shapes with a **dev-only mock adapter** that flips to live
+once the backend lands — no rework.
+
+## Wire contract (authoritative, from the backend branch docs)
+
+Subscription gains two optional fields: `sectionId?: string`, `sectionOrder?: number` (fractional).
+`favorite` is already a subscription boolean on the backend branch. Built-in sections are DERIVED
+client-side, never stored on the sub.
+
+RPCs (user-scoped `chat.user.{account}.request.user.{siteID}.…`):
+- `chatlist.get` — no body → `ChatlistState`
+- `chatlist.section.create` `{ name, sortMode? }` → ChatlistState (sortMode default `custom`)
+- `chatlist.section.rename` `{ sectionId, name }`
+- `chatlist.section.delete` `{ sectionId }` (members orphan → chats)
+- `chatlist.section.reorder` `{ sectionOrder: string[] }` (permutation of ALL section ids)
+- `chatlist.section.setsortmode` `{ sectionId, sortMode }`
+
+Move a chat (room-scoped `chat.user.{account}.request.room.{roomID}.{siteID}.chat.move`):
+- body `{ sectionId: string|null, afterRoomId?: string }` → `{ status:'ok', sectionId?, sectionOrder? }`
+- built-in target rejected (`chatlist_builtin_target`); `null` removes → derived built-in.
+
+Events:
+- `chat.user.{account}.event.chatlist.update` → `ChatlistUpdateEvent { timestamp, chatlist: ChatlistState }`
+  — full-state replace, LWW by `chatlist.lastUpdatedAt`.
+- `subscription.update` gains `action: "section_moved"`; `subscription.sectionId/sectionOrder` carry
+  the new placement (both absent = removed).
+
+Types:
+- `ChatlistState { sectionOrder: string[]; sections: ChatlistSection[]; lastUpdatedAt: number }`
+- `ChatlistSection { id: string; name: string; builtIn: boolean; sortMode: 'custom'|'mostRecent' }`
+
+Name validation (create/rename): 1–50 chars trimmed, no consecutive spaces, only
+letters/digits/space/`-_./()`, unique per user. Errors: `chatlist_invalid_name`,
+`chatlist_duplicate_name`, `chatlist_section_not_found`, `chatlist_builtin_immutable`,
+`chatlist_invalid_order`, `chatlist_invalid_sort_mode`, `chatlist_builtin_target`.
+
+## Client read model (PRD §"Client read model")
+
+1. subscription.list (existing 3-bucket fetch stays) → each sub carries favorite/sectionId/sectionOrder.
+2. chatlist.get once → section definitions.
+3. Group each sub: favorites(favorite) · apps(bot) · teams(sectionId=='teams') · each custom
+   (sectionId==id) · chats(no sectionId, not fav/bot). Orphan sectionId → chats.
+4. Within a section: sortMode 'custom' → by sectionOrder; else by last message.
+5. Live: subscription.update + chatlist.update each replace their own scope, timestamp LWW.
+
+## Integration seams (verified against current code, session 2026-08-01)
+
+- Types: `chat-frontend/src/api/types.ts` (Subscription:49, SubscriptionUpdateAction:323, add Chatlist* types).
+- Subjects: `chat-frontend/src/api/_transport/subjects.ts`.
+- Reducer: `chat-frontend/src/context/RoomEventsContext/reducer.js` (SUBSCRIPTION_UPSERTED, mergeSubscriptionIntoSummary, sortByLastMsgDesc, initialState).
+- Grouping seam: `useSidebarSections()` in `RoomEventsContext.tsx` (hardcoded 3 sections today).
+- Event wiring: `context/RoomEventsContext/useRoomSubscriptions.js` (subscribeToSubscriptionUpdates catch-all is where section_moved lands; bootstrap chatlist.get + subscribe chatlist.update).
+- Render: `components/MainApp/Sidebar/RoomList/RoomList.jsx` (already section-aware — maps `{key,title,rooms}`).
+
+## Build order (TDD, commit per layer)
+
+1. **Types + subjects** — add fields/types + subject builders. Typecheck.
+2. **API ops + mock adapter** — one folder per op (getChatlist, section CRUD ×5, moveChat, subscribeToChatlistUpdates). Mock adapter behind the barrel, toggled via runtimeConfig (`VITE_CHATLIST_MOCK` / runtime flag). op-arg→payload tests.
+3. **Reducer/state** — chatlist section-def state, carry section fields onto subs+summaries, CHATLIST_LOADED/CHATLIST_UPDATED, section_moved. Pure reducer tests.
+4. **Grouping read-model** — rewrite useSidebarSections to the derived model + within-section sort. Unit tests on the derivation.
+5. **UI** — section headers + CRUD affordances in RoomList, create/rename/delete dialog, move-chat control, native HTML5 drag reorder (within + between sections). Component tests.
+6. **Mock demo + polish** — fixture that seeds sections + membership + simulated events; `/simplify` + terse-comment pass; typecheck + test + build green; screenshots.
+
+## Delivery
+- Branch `feat/chatlist-sections-fe` off main (this clone: voldemort-frontdesk/newchat).
+- Draft PR on hmchangw/newchat → pr-self-audit (internal gate) + /simplify → surface to Jacob, wait for review → ready + `ready` label.
+- Screenshots to the frontdesk channel (no raw preview URL upstream).
+- Docs: this is FE-only; the client-api.md contract lands with backend #134. No doc-ratchet change here (no wire struct authored by us).
+
+## Mock adapter note
+The mock keeps an in-memory ChatlistState + section membership and emulates the RPC replies +
+fires chatlist.update / subscription.update(section_moved) callbacks, so the real reducer/hook
+path exercises end-to-end. Flipping the flag off routes every op to the real NATS subject.


### PR DESCRIPTION
## Summary
Frontend for per-user customizable chatlist sections — create / rename / delete custom sidebar sections, drag a chat into a section, and drag to reorder sections, with per-user manual ordering. Consumes the backend section RPCs (`chatlist.section.create/rename/delete/reorder/setSortMode`, `subscription.moveChat`) and the `subscription.update` (`section_moved`) event. The built-in buckets (Favorites / Apps / Teams / Chats) are derived client-side.

## What's included
- v2 wire types + NATS subject builders for the section RPCs (`api/types.ts`, `api/_transport/subjects.ts`)
- api ops + a dev mock adapter for the section RPCs (`api/chatlist`, `api/moveChat`, `api/_transport/chatlistMock.ts`)
- reducer state for section defs + membership; grouped sidebar derived from subscription flags (`context/RoomEventsContext`, `lib/chatlist.js`)
- sidebar UI: section CRUD dialog + native drag-to-move + drag-to-reorder (`Sidebar/RoomList`, `Sidebar/ChatlistSectionDialog`)
- subscribe to chatlist updates + `section_moved` handling (`api/subscribeToChatlistUpdates`)

## Changes
- Read model derives the grouped sidebar from subscription flags (fetch-all-then-derive). Built-in section defs stay available as derivation targets so favorite / bot / teams rooms keep a home when custom sections exist.
- Manual order via `afterRoomId` / `beforeRoomId` (`moveChat(id, siteId, sectionId, after, before)`): append / place-after / move-to-top; honored when a section's `sortMode == custom`.

## Verification
- `tsc` typecheck, unit tests (850 pass), and the production build are all green.
- Per-case UI walkthrough recorded against a live dev backend running these RPCs — all pass. Clips below.

## Known follow-up
This ships the fetch-all-then-derive read model. The per-section lazy-load optimization (paginate each section independently) needs a backend read-contract extension first: `subscription.list` currently exposes only `type` / `favorite` / `updatedWithinDays` / `offset` / `limit` — no section selector, `orderBy`, or keyset cursor. Tracked as a follow-up; out of scope here.

## Walkthrough

**Create a custom section**

https://github.com/user-attachments/assets/cb3a504c-8408-4d90-a3ff-1af9afc22da2

**Rename a custom section**

https://github.com/user-attachments/assets/eb2d0e65-ae4c-479c-bfd7-0ddeb6b1cb18

**Drag to reorder sections**

https://github.com/user-attachments/assets/dc3feec3-71c2-4169-9a3c-c3b5c77de562

**Delete a section — its chats fall back to Chats**

https://github.com/user-attachments/assets/a6fcbc25-a6fb-46fb-a0bb-ccc724fae1c8

**Drag a chat into a section**

https://github.com/user-attachments/assets/3cfce186-a7f4-4651-ae40-113ec1c64b47

**Built-in section derivation (Teams)**

https://github.com/user-attachments/assets/f1446a68-b338-4cb2-bd5b-b28f83e18009
