### PR TITLE
feat(search): result filters — sender/date/attachment/fileType/room-member

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -3981,7 +3981,6 @@ See [Error envelope](#6-error-envelope-reference).
   "senders": ["bob", "carol"],
   "dateRange": { "start": "2026-07-01T00:00:00Z", "end": "2026-07-31T23:59:59Z" },
   "hasAttachment": true,
-  "mentionedMe": true,
   "fileTypes": ["pdf", "zip"],
   "size": 25,
   "offset": 0
@@ -3995,7 +3994,6 @@ See [Error envelope](#6-error-envelope-reference).
 | `senders` | string[] | no | Filter to messages from any of these `userAccount`s (multi-select From). |
 | `dateRange` | { start, end } | no | Filter `createdAt` to this range (RFC3339 timestamps). Either bound may be omitted to leave that side open. Date presets (today/yesterday/thisWeek/thisMonth/custom) are resolved client-side into a concrete range before sending. |
 | `hasAttachment` | boolean | no | `true` filters to messages carrying at least one attachment. |
-| `mentionedMe` | boolean | no | `true` filters to messages that mention the requesting account. |
 | `fileTypes` | string[] | no | Filter to messages with an attachment in any of these categories: `image`, `pdf`, `excel`, `powerpoint`, `word`, `zip`, `others`. This is also how file search is served — no new subject. Existing messages indexed before this field shipped are not backfilled and won't match. |
 | `size` | integer | no | Page size. Default `25`, capped at `100`. |
 | `offset` | integer | no | Page offset. Default `0`. |

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -3968,7 +3968,9 @@ See [Error envelope](#6-error-envelope-reference).
 
 **Cross-site results:** results may include messages from rooms hosted on remote sites (the index is searched across the local and remote clusters). The `siteId` on each `SearchMessage` identifies the originating site; there is no client opt-in/opt-out.
 
-**Searched fields:** one query matches message text (`content`), attachment text (`attachmentText` — every attachment's file name and description pooled into one field), and tcard data (`cardData`, the card's data document indexed verbatim as text). All terms of the query must match within a single one of these fields (`multi_match` with `AND`) — a query mixing a word from the message text with a word from a filename matches neither field and returns no hit; a query mixing a filename word with a description word DOES match, since both live in `attachmentText`.
+**Searched fields:** one query matches message text (`content`), sender display name (`userName`), attachment text (`attachmentText` — every attachment's file name and description pooled into one field), and tcard data (`cardData`, the card's data document indexed verbatim as text). All terms of the query must match within a single one of these fields (`multi_match` with `AND`) — a query mixing a word from the message text with a word from a filename matches neither field and returns no hit; a query mixing a filename word with a description word DOES match, since both live in `attachmentText`.
+
+**File search folds into this RPC** — there is no separate subject. Pass `fileTypes` to filter to messages carrying an attachment of the given categories; this is what backs the Files tab in the UI.
 
 ##### Request body
 
@@ -3976,6 +3978,11 @@ See [Error envelope](#6-error-envelope-reference).
 {
   "query": "hello world",
   "roomIds": ["r1", "r2"],
+  "senders": ["bob", "carol"],
+  "dateRange": { "start": "2026-07-01T00:00:00Z", "end": "2026-07-31T23:59:59Z" },
+  "hasAttachment": true,
+  "mentionedMe": true,
+  "fileTypes": ["pdf", "zip"],
   "size": 25,
   "offset": 0
 }
@@ -3983,8 +3990,13 @@ See [Error envelope](#6-error-envelope-reference).
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `query` | string | **yes** | Full-text query. Empty string is rejected. |
-| `roomIds` | string[] | no | Scope the search to these rooms. Omit for global search across all accessible rooms. Unknown room IDs and rooms the user cannot access are silently excluded (enforced by the ES terms-lookup + restricted-rooms floor). |
+| `query` | string | **yes** | Full-text query. Empty string is rejected. Matches `content` and `userName` (see above). |
+| `roomIds` | string[] | no | Scope the search to these rooms. Omit for global search across all accessible rooms. Unknown room IDs and rooms the user cannot access are silently excluded (enforced by the ES terms-lookup + restricted-rooms floor). A single-room ("In room") search sends a 1-element list — the field stays a list, never a single `roomId`. |
+| `senders` | string[] | no | Filter to messages from any of these `userAccount`s (multi-select From). |
+| `dateRange` | { start, end } | no | Filter `createdAt` to this range (RFC3339 timestamps). Either bound may be omitted to leave that side open. Date presets (today/yesterday/thisWeek/thisMonth/custom) are resolved client-side into a concrete range before sending. |
+| `hasAttachment` | boolean | no | `true` filters to messages carrying at least one attachment. |
+| `mentionedMe` | boolean | no | `true` filters to messages that mention the requesting account. |
+| `fileTypes` | string[] | no | Filter to messages with an attachment in any of these categories: `image`, `pdf`, `excel`, `powerpoint`, `word`, `zip`, `others`. This is also how file search is served — no new subject. Existing messages indexed before this field shipped are not backfilled and won't match. |
 | `size` | integer | no | Page size. Default `25`, capped at `100`. |
 | `offset` | integer | no | Page offset. Default `0`. |
 
@@ -4049,6 +4061,7 @@ See [Error envelope](#6-error-envelope-reference).
 | `roomId` | string | — |
 | `siteId` | string | — |
 | `userAccount` | string | — |
+| `userName` | string | omitted when the sender's display name was never composed (pre-composition predates `UserDisplayName`) |
 | `content` | string | — |
 | `createdAt` | RFC3339 timestamp | — |
 | `editedAt` | RFC3339 timestamp (nullable) | omitted when the message has never been edited |
@@ -4134,8 +4147,9 @@ See [Error envelope](#6-error-envelope-reference).
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `query` | string | **yes** | Case-insensitive prefix/substring match on room name. Whitespace-only is rejected. |
-| `roomType` | string | no | `"all"` (default), `"channel"`, or `"dm"`. The value `"app"` and any other value are rejected with `bad_request`. |
+| `query` | string | conditionally | Case-insensitive prefix/substring match on room name. Whitespace-only is treated as empty. May be omitted only when `members` is set — at least one of `query`/`members` is required. |
+| `roomType` | string | no | `"all"` (default), `"channel"`, `"dm"`, or `"app"` (currently rejected with `bad_request` — MVP-unsupported). Any other value is also rejected. |
+| `members` | string[] | no | Filter to channels containing all of these accounts (plus the requester). Resolved via user-service's `subscription.getChannels`. Works with an empty `query` — that's the "From" filter on the Chatrooms tab. |
 | `size` | number | no | Page size. Default `25`, capped at `100`. |
 | `offset` | number | no | Pagination offset. Default `0`. |
 
@@ -4144,6 +4158,13 @@ See [Error envelope](#6-error-envelope-reference).
   "query": "engineering",
   "roomType": "channel",
   "size": 20
+}
+```
+
+```json
+{
+  "members": ["bob"],
+  "roomType": "channel"
 }
 ```
 
@@ -4181,7 +4202,7 @@ See [Error envelope](#6-error-envelope-reference).
 
 | Code | Reason |
 |---|---|
-| `bad_request` | `query` is missing, empty, or whitespace-only; or `roomType` is `"app"` or an unrecognized value; or `size`/`offset` is negative. |
+| `bad_request` | both `query` and `members` are empty/omitted; or `roomType` is `"app"` or an unrecognized value; or `size`/`offset` is negative. |
 | `internal` | Elasticsearch backend failure (transient or permanent). The raw error is never leaked to the client. |
 
 ##### Triggered events — success path

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -1301,7 +1301,7 @@ separate subject.
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `query` | string | yes | Full-text query. Empty string rejected. Matches `content` and `userName`. |
+| `query` | string | yes | Full-text query. Empty string rejected. Matches `content`, `userName`, attachment text, and tcard data. |
 | `roomIds` | string[] | no | Scope to specific rooms. Unknown or inaccessible rooms silently excluded. Stays a list (single-select sends a 1-element list — no rename). |
 | `senders` | string[] | no | Filter to these `userAccount`s (multi-select From). |
 | `dateRange` | `{start, end}` | no | Filter `createdAt`; either bound may be omitted. Presets resolved client-side. |
@@ -1359,7 +1359,7 @@ ES index.
 |---|---|---|---|
 | `query` | string | conditionally | Case-insensitive prefix/substring on room name. May be omitted only when `members` is set — at least one of the two is required. |
 | `roomType` | string | no | `"all"` (default), `"channel"`, or `"dm"`. `"app"` (MVP-unsupported) and unknown values rejected. |
-| `members` | string[] | no | Filter to channels containing all of these accounts plus the requester (via `subscription.getChannels`). Works with an empty `query`. |
+| `members` | string[] | no | Filter to channels containing all of these accounts plus the requester (via `subscription.getChannels`). Works with an empty `query`, but must itself be non-empty to be a room-search criterion. |
 | `size` | number | no | Default 25, max 100. |
 | `offset` | number | no | Default 0. |
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -1306,7 +1306,6 @@ separate subject.
 | `senders` | string[] | no | Filter to these `userAccount`s (multi-select From). |
 | `dateRange` | `{start, end}` | no | Filter `createdAt`; either bound may be omitted. Presets resolved client-side. |
 | `hasAttachment` | boolean | no | `true` filters to messages with an attachment. |
-| `mentionedMe` | boolean | no | `true` filters to messages mentioning the requester. |
 | `fileTypes` | string[] | no | Filter by attachment category: `image`/`pdf`/`excel`/`powerpoint`/`word`/`zip`/`others`. Existing messages are not backfilled. |
 | `size` | integer | no | Page size. Default 25, max 100. |
 | `offset` | integer | no | Page offset. Default 0. |

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -1289,8 +1289,10 @@ search-service on that site.
 **Reply:** auto-generated `_INBOX.>` (NATS request/reply)
 
 Full-text message search. Auto-scoped to rooms the user is a member of. May include
-messages from remote sites. One query matches message text, attachment text (file
-names + descriptions, pooled into one searched field), and tcard data.
+messages from remote sites. One query matches message text, sender display name
+(`userName`), attachment text (file names + descriptions, pooled into one searched
+field), and tcard data. **File search folds into this RPC** via `fileTypes` — no
+separate subject.
 
 > **Breaking change (v2):** Response changed from `{total, results}` to `{messages, total}`.
 > The `results` field no longer exists.
@@ -1299,8 +1301,13 @@ names + descriptions, pooled into one searched field), and tcard data.
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `query` | string | yes | Full-text query. Empty string rejected. |
-| `roomIds` | string[] | no | Scope to specific rooms. Unknown or inaccessible rooms silently excluded. |
+| `query` | string | yes | Full-text query. Empty string rejected. Matches `content` and `userName`. |
+| `roomIds` | string[] | no | Scope to specific rooms. Unknown or inaccessible rooms silently excluded. Stays a list (single-select sends a 1-element list — no rename). |
+| `senders` | string[] | no | Filter to these `userAccount`s (multi-select From). |
+| `dateRange` | `{start, end}` | no | Filter `createdAt`; either bound may be omitted. Presets resolved client-side. |
+| `hasAttachment` | boolean | no | `true` filters to messages with an attachment. |
+| `mentionedMe` | boolean | no | `true` filters to messages mentioning the requester. |
+| `fileTypes` | string[] | no | Filter by attachment category: `image`/`pdf`/`excel`/`powerpoint`/`word`/`zip`/`others`. Existing messages are not backfilled. |
 | `size` | integer | no | Page size. Default 25, max 100. |
 | `offset` | integer | no | Page offset. Default 0. |
 
@@ -1314,7 +1321,8 @@ names + descriptions, pooled into one searched field), and tcard data.
 All terms of the query must match within a single searched field (`multi_match`
 with `AND`) — terms split across e.g. message text and a filename match nothing.
 
-`SearchMessage` fields: `messageId`, `roomId`, `siteId`, `userAccount`, `content`,
+`SearchMessage` fields: `messageId`, `roomId`, `siteId`, `userAccount`, `userName`
+(sender's pre-composed display name, omitted when never composed), `content`,
 `createdAt`, `editedAt` (nullable), `updatedAt` (nullable), `threadParentMessageId`
 (omitted when not a reply), `threadParentMessageCreatedAt` (omitted when not a reply),
 `attachments` (`Attachment[]`, omitted when the message has no attachments),
@@ -1350,8 +1358,9 @@ ES index.
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `query` | string | yes | Case-insensitive prefix/substring on room name. Whitespace-only rejected. |
-| `roomType` | string | no | `"all"` (default), `"channel"`, or `"dm"`. `"app"` and unknown values rejected. |
+| `query` | string | conditionally | Case-insensitive prefix/substring on room name. May be omitted only when `members` is set — at least one of the two is required. |
+| `roomType` | string | no | `"all"` (default), `"channel"`, or `"dm"`. `"app"` (MVP-unsupported) and unknown values rejected. |
+| `members` | string[] | no | Filter to channels containing all of these accounts plus the requester (via `subscription.getChannels`). Works with an empty `query`. |
 | `size` | number | no | Default 25, max 100. |
 | `offset` | number | no | Default 0. |
 

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -2397,6 +2397,49 @@ func TestSearchRoomsRequestJSON(t *testing.T) {
 	})
 }
 
+func TestSearchMessagesRequestJSON_NewFilters(t *testing.T) {
+	senders := true
+	req := model.SearchMessagesRequest{
+		Query:   "hello",
+		Senders: []string{"bob", "carol"},
+		DateRange: &model.DateRange{
+			Start: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+			End:   time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+		},
+		HasAttachment: &senders,
+		MentionedMe:   &senders,
+		FileTypes:     []string{"pdf", "zip"},
+	}
+	roundTrip(t, &req, &model.SearchMessagesRequest{})
+
+	reqBare := model.SearchMessagesRequest{Query: "hello"}
+	data, err := json.Marshal(&reqBare)
+	require.NoError(t, err)
+	for _, key := range []string{"senders", "dateRange", "hasAttachment", "mentionedMe", "fileTypes"} {
+		assert.NotContains(t, string(data), `"`+key+`"`, "%s must be omitted when unset", key)
+	}
+}
+
+func TestSearchMessageJSON_UserName(t *testing.T) {
+	msg := model.SearchMessage{MessageID: "m1", RoomID: "r1", UserName: "Alice Wong 王愛麗"}
+	roundTrip(t, &msg, &model.SearchMessage{})
+
+	bare := model.SearchMessage{MessageID: "m1", RoomID: "r1"}
+	data, err := json.Marshal(&bare)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), `"userName"`, "userName must be omitted when empty")
+}
+
+func TestSearchRoomsRequestJSON_Members(t *testing.T) {
+	req := model.SearchRoomsRequest{Members: []string{"bob", "carol"}}
+	roundTrip(t, &req, &model.SearchRoomsRequest{})
+
+	bare := model.SearchRoomsRequest{Query: "x"}
+	data, err := json.Marshal(&bare)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), `"members"`, "members must be omitted when empty")
+}
+
 func TestSearchRoomsResponseJSON(t *testing.T) {
 	resp := model.SearchRoomsResponse{
 		Rooms: []model.SearchRoom{

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -2262,6 +2262,30 @@ func TestSearchMessagesRequestJSON(t *testing.T) {
 		_, present := raw["roomIds"]
 		assert.False(t, present, "roomIds must be omitted when nil")
 	})
+
+	t.Run("dateRange omitzero drops an open (zero) bound", func(t *testing.T) {
+		start := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+		// start-only: End is zero and must be omitted (not "0001-01-01T00:00:00Z").
+		data, err := json.Marshal(&model.SearchMessagesRequest{DateRange: &model.DateRange{Start: start}})
+		require.NoError(t, err)
+		var raw map[string]any
+		require.NoError(t, json.Unmarshal(data, &raw))
+		dr := raw["dateRange"].(map[string]any)
+		_, hasStart := dr["start"]
+		_, hasEnd := dr["end"]
+		assert.True(t, hasStart, "start present")
+		assert.False(t, hasEnd, "zero end must be omitted by omitzero")
+
+		// end-only: symmetric.
+		data, err = json.Marshal(&model.SearchMessagesRequest{DateRange: &model.DateRange{End: start}})
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(data, &raw))
+		dr = raw["dateRange"].(map[string]any)
+		_, hasStart = dr["start"]
+		_, hasEnd = dr["end"]
+		assert.False(t, hasStart, "zero start must be omitted by omitzero")
+		assert.True(t, hasEnd, "end present")
+	})
 }
 
 func TestSearchMessagesResponseJSON(t *testing.T) {

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -2407,7 +2407,6 @@ func TestSearchMessagesRequestJSON_NewFilters(t *testing.T) {
 			End:   time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
 		},
 		HasAttachment: &senders,
-		MentionedMe:   &senders,
 		FileTypes:     []string{"pdf", "zip"},
 	}
 	roundTrip(t, &req, &model.SearchMessagesRequest{})
@@ -2415,7 +2414,7 @@ func TestSearchMessagesRequestJSON_NewFilters(t *testing.T) {
 	reqBare := model.SearchMessagesRequest{Query: "hello"}
 	data, err := json.Marshal(&reqBare)
 	require.NoError(t, err)
-	for _, key := range []string{"senders", "dateRange", "hasAttachment", "mentionedMe", "fileTypes"} {
+	for _, key := range []string{"senders", "dateRange", "hasAttachment", "fileTypes"} {
 		assert.NotContains(t, string(data), `"`+key+`"`, "%s must be omitted when unset", key)
 	}
 }

--- a/pkg/model/search.go
+++ b/pkg/model/search.go
@@ -12,6 +12,26 @@ type SearchMessagesRequest struct {
 	RoomIDs []string `json:"roomIds,omitempty"`
 	Size    int      `json:"size,omitempty"`
 	Offset  int      `json:"offset,omitempty"`
+
+	// Senders filters to messages from any of these userAccounts (multi-select From).
+	Senders []string `json:"senders,omitempty"`
+	// DateRange filters createdAt to [Start, End]; either bound may be zero to leave it open.
+	DateRange *DateRange `json:"dateRange,omitempty"`
+	// HasAttachment, set true, filters to messages carrying at least one attachment.
+	HasAttachment *bool `json:"hasAttachment,omitempty"`
+	// MentionedMe, set true, filters to messages that mention the requesting account.
+	MentionedMe *bool `json:"mentionedMe,omitempty"`
+	// FileTypes filters to messages with an attachment in any of these categories
+	// (image/pdf/excel/powerpoint/word/zip/others). This is also how file search
+	// folds into this RPC — no separate subject.
+	FileTypes []string `json:"fileTypes,omitempty"`
+}
+
+// DateRange bounds a createdAt filter; presets (today/thisWeek/…) are resolved
+// client-side into a concrete range before the request is sent.
+type DateRange struct {
+	Start time.Time `json:"start,omitempty"`
+	End   time.Time `json:"end,omitempty"`
 }
 
 // SearchMessagesResponse is the NATS reply for `search.messages`.
@@ -38,6 +58,9 @@ type SearchMessage struct {
 	UpdatedAt                    *time.Time `json:"updatedAt,omitempty"`
 	ThreadParentMessageID        string     `json:"threadParentMessageId,omitempty"`
 	ThreadParentMessageCreatedAt *time.Time `json:"threadParentMessageCreatedAt,omitempty"`
+	// UserName is the sender's pre-composed display name (Message.UserDisplayName),
+	// indexed so free-text query can match on sender name as well as body.
+	UserName string `json:"userName,omitempty"`
 
 	// Render payloads mirrored as-is from the message (same wire shape as
 	// history reads) so the client can render hits without a second lookup.
@@ -93,7 +116,8 @@ type MessageAppInfo struct {
 // SearchRoomsRequest is the NATS payload for
 // `chat.user.{account}.request.search.{siteID}.rooms`.
 //
-// Query is a non-empty substring match on room name (case-insensitive prefix).
+// Query is a substring match on room name (case-insensitive prefix); it may be
+// empty only when Members is set — at least one of the two is required.
 // RoomType filters by subscription type: "all" (default, same as empty),
 // "channel", or "dm". The value "app" and any other value are rejected with
 // ErrBadRequest.
@@ -102,6 +126,10 @@ type SearchRoomsRequest struct {
 	RoomType string `json:"roomType,omitempty"`
 	Size     int    `json:"size,omitempty"`
 	Offset   int    `json:"offset,omitempty"`
+	// Members filters to channels that contain all of these accounts (plus the
+	// requester), resolved via user-service subscription.getChannels. Query may
+	// be empty when Members is set — at least one of the two is required.
+	Members []string `json:"members,omitempty"`
 }
 
 // SearchRoomsResponse is the NATS reply for `search.rooms`.

--- a/pkg/model/search.go
+++ b/pkg/model/search.go
@@ -28,8 +28,11 @@ type SearchMessagesRequest struct {
 // DateRange bounds a createdAt filter; presets (today/thisWeek/…) are resolved
 // client-side into a concrete range before the request is sent.
 type DateRange struct {
-	Start time.Time `json:"start,omitempty"`
-	End   time.Time `json:"end,omitempty"`
+	// omitzero (not omitempty): a zero time.Time is a non-empty struct, so
+	// omitempty would still marshal it as "0001-01-01T00:00:00Z"; omitzero
+	// drops it so a client can leave one bound open by zeroing it.
+	Start time.Time `json:"start,omitzero"`
+	End   time.Time `json:"end,omitzero"`
 }
 
 // SearchMessagesResponse is the NATS reply for `search.messages`.

--- a/pkg/model/search.go
+++ b/pkg/model/search.go
@@ -19,8 +19,6 @@ type SearchMessagesRequest struct {
 	DateRange *DateRange `json:"dateRange,omitempty"`
 	// HasAttachment, set true, filters to messages carrying at least one attachment.
 	HasAttachment *bool `json:"hasAttachment,omitempty"`
-	// MentionedMe, set true, filters to messages that mention the requesting account.
-	MentionedMe *bool `json:"mentionedMe,omitempty"`
 	// FileTypes filters to messages with an attachment in any of these categories
 	// (image/pdf/excel/powerpoint/word/zip/others). This is also how file search
 	// folds into this RPC — no separate subject.

--- a/pkg/searchindex/filetype.go
+++ b/pkg/searchindex/filetype.go
@@ -1,0 +1,57 @@
+package searchindex
+
+import "strings"
+
+// fileTypeCategory maps an attachment's canonical lowercased MIME (Attachment.FileType)
+// to one of the search filter categories. Unrecognized/empty MIME falls back to "others"
+// rather than being dropped, so every attachment stays filterable.
+func fileTypeCategory(mime string) string {
+	switch {
+	case strings.HasPrefix(mime, "image/"):
+		return "image"
+	case mime == "application/pdf":
+		return "pdf"
+	case mime == "application/zip", mime == "application/x-zip-compressed":
+		return "zip"
+	case isExcelMIME(mime):
+		return "excel"
+	case isPowerPointMIME(mime):
+		return "powerpoint"
+	case isWordMIME(mime):
+		return "word"
+	default:
+		return "others"
+	}
+}
+
+func isExcelMIME(mime string) bool {
+	return mime == "application/vnd.ms-excel" ||
+		mime == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+}
+
+func isPowerPointMIME(mime string) bool {
+	return mime == "application/vnd.ms-powerpoint" ||
+		mime == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+}
+
+func isWordMIME(mime string) bool {
+	return mime == "application/msword" ||
+		mime == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+}
+
+// dedupeStrings returns in's distinct values in first-seen order; nil for empty input.
+func dedupeStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/pkg/searchindex/filetype_test.go
+++ b/pkg/searchindex/filetype_test.go
@@ -1,0 +1,48 @@
+package searchindex
+
+import "testing"
+
+func TestFileTypeCategory(t *testing.T) {
+	cases := []struct {
+		mime string
+		want string
+	}{
+		{"image/png", "image"},
+		{"image/jpeg", "image"},
+		{"application/pdf", "pdf"},
+		{"application/vnd.ms-excel", "excel"},
+		{"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "excel"},
+		{"application/vnd.ms-powerpoint", "powerpoint"},
+		{"application/vnd.openxmlformats-officedocument.presentationml.presentation", "powerpoint"},
+		{"application/msword", "word"},
+		{"application/vnd.openxmlformats-officedocument.wordprocessingml.document", "word"},
+		{"application/zip", "zip"},
+		{"application/x-zip-compressed", "zip"},
+		{"application/x-rar-compressed", "others"},
+		{"text/plain", "others"},
+		{"", "others"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.mime, func(t *testing.T) {
+			if got := fileTypeCategory(tc.mime); got != tc.want {
+				t.Errorf("fileTypeCategory(%q) = %q, want %q", tc.mime, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDedupeStrings(t *testing.T) {
+	got := dedupeStrings([]string{"a", "b", "a", "c", "b"})
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("dedupeStrings = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("dedupeStrings = %v, want %v", got, want)
+		}
+	}
+	if dedupeStrings(nil) != nil {
+		t.Error("dedupeStrings(nil) must return nil")
+	}
+}

--- a/pkg/searchindex/messagedoc.go
+++ b/pkg/searchindex/messagedoc.go
@@ -41,6 +41,8 @@ type MessageDoc struct {
 	// filter matches, folded into the messages index rather than a new subject.
 	FileTypes []string `json:"fileTypes,omitempty" es:"keyword"`
 	// Mentions is the deduped set of mentioned accounts (MessageFields.MentionAccounts).
+	// Indexed now; the mentionedMe filter that consumes it ships in a follow-up once
+	// mentions are resolved onto the canonical event (they currently ride empty).
 	Mentions []string `json:"mentions,omitempty" es:"keyword"`
 }
 

--- a/pkg/searchindex/messagedoc.go
+++ b/pkg/searchindex/messagedoc.go
@@ -32,6 +32,16 @@ type MessageDoc struct {
 	CardData              string                 `json:"cardData,omitempty"                      es:"text,custom_analyzer"`
 	Attachments           []cassandra.Attachment `json:"attachments,omitempty" es:"object_disabled"`
 	Card                  *cassandra.Card        `json:"card,omitempty"        es:"object_disabled"`
+	// UserName is the sender's pre-composed display name, indexed so free-text
+	// query also matches on sender name (see MessageFields.UserName).
+	UserName string `json:"userName,omitempty" es:"text,custom_analyzer"`
+	// FileTypes is the deduped set of attachment categories on this message
+	// (image/pdf/excel/powerpoint/word/zip/others), derived from Attachments'
+	// FileType MIME (see fileTypeCategory) — this is the field the "file search"
+	// filter matches, folded into the messages index rather than a new subject.
+	FileTypes []string `json:"fileTypes,omitempty" es:"keyword"`
+	// Mentions is the deduped set of mentioned accounts (MessageFields.MentionAccounts).
+	Mentions []string `json:"mentions,omitempty" es:"keyword"`
 }
 
 // MessageFields is the minimal, source-agnostic set of fields needed to
@@ -57,6 +67,10 @@ type MessageFields struct {
 	// model.Message.Attachments — decoded here via cassandra.DecodeAttachments.
 	Attachments [][]byte
 	Card        *cassandra.Card
+	// UserName is the sender's pre-composed display name (Message.UserDisplayName).
+	UserName string
+	// MentionAccounts is the list of mentioned accounts (Message.Mentions[].Account).
+	MentionAccounts []string
 }
 
 // NewMessageDoc builds the ES document for the messages index from f. The
@@ -80,11 +94,14 @@ func NewMessageDoc(f MessageFields) (MessageDoc, error) {
 		ThreadParentID:        f.ThreadParentID,
 		ThreadParentCreatedAt: f.ThreadParentCreatedAt,
 		TShow:                 f.TShow,
+		UserName:              f.UserName,
+		Mentions:              dedupeStrings(f.MentionAccounts),
 	}
 
 	attachments, skipped := cassandra.DecodeAttachments(f.Attachments)
 	doc.Attachments = attachments
 	var attachmentText []string
+	var fileTypes []string
 	for i := range attachments {
 		a := &attachments[i]
 		if a.Title != "" {
@@ -93,8 +110,10 @@ func NewMessageDoc(f MessageFields) (MessageDoc, error) {
 		if a.Description != "" {
 			attachmentText = append(attachmentText, a.Description)
 		}
+		fileTypes = append(fileTypes, fileTypeCategory(a.FileType))
 	}
 	doc.AttachmentText = strings.Join(attachmentText, " ")
+	doc.FileTypes = dedupeStrings(fileTypes)
 
 	if f.Card != nil {
 		doc.Card = f.Card

--- a/pkg/searchindex/messagedoc_test.go
+++ b/pkg/searchindex/messagedoc_test.go
@@ -83,6 +83,54 @@ func TestNewMessageDoc_CardPopulatesCardData(t *testing.T) {
 	assert.Equal(t, `{"k":"v"}`, doc.CardData)
 }
 
+func TestNewMessageDoc_UserNameAndMentionsCopied(t *testing.T) {
+	doc, err := searchindex.NewMessageDoc(searchindex.MessageFields{
+		MessageID:       "msg1",
+		UserName:        "Alice Wong 王愛麗",
+		MentionAccounts: []string{"bob", "carol", "bob"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Alice Wong 王愛麗", doc.UserName)
+	assert.Equal(t, []string{"bob", "carol"}, doc.Mentions, "mentions must be deduped")
+}
+
+func TestNewMessageDoc_FileTypesDerivedFromAttachments(t *testing.T) {
+	blob1, _ := jsonMarshal(cassandra.Attachment{Title: "invoice.pdf", FileType: "application/pdf"})
+	blob2, _ := jsonMarshal(cassandra.Attachment{Title: "logo.png", FileType: "image/png"})
+	blob3, _ := jsonMarshal(cassandra.Attachment{Title: "archive.zip", FileType: "application/zip"})
+
+	doc, err := searchindex.NewMessageDoc(searchindex.MessageFields{
+		MessageID:   "msg1",
+		Attachments: [][]byte{blob1, blob2, blob3},
+	})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"pdf", "image", "zip"}, doc.FileTypes)
+}
+
+func TestNewMessageDoc_JSONRoundTrip(t *testing.T) {
+	createdAt := time.Date(2026, 7, 24, 10, 0, 0, 0, time.UTC)
+	doc, err := searchindex.NewMessageDoc(searchindex.MessageFields{
+		MessageID:       "msg1",
+		RoomID:          "room1",
+		SiteID:          "site-a",
+		UserAccount:     "alice",
+		Content:         "hello",
+		CreatedAt:       createdAt,
+		UserName:        "Alice Wong",
+		MentionAccounts: []string{"bob"},
+		Attachments:     [][]byte{},
+	})
+	require.NoError(t, err)
+
+	data, err := json.Marshal(doc)
+	require.NoError(t, err)
+	var got searchindex.MessageDoc
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, "Alice Wong", got.UserName)
+	assert.Equal(t, []string{"bob"}, got.Mentions)
+	assert.Nil(t, got.FileTypes, "no attachments → no fileTypes")
+}
+
 func TestMessageIndexName(t *testing.T) {
 	got := searchindex.MessageIndexName("messages-a-v2", time.Date(2026, 3, 9, 0, 0, 0, 0, time.UTC))
 	assert.Equal(t, "messages-a-v2-2026-03", got)

--- a/search-service/handler.go
+++ b/search-service/handler.go
@@ -159,7 +159,7 @@ func (h *handler) searchRooms(c *natsrouter.Context, req model.SearchRoomsReques
 	// query is built to match nothing rather than falling back to unfiltered.
 	var memberRoomIDs []string
 	if len(req.Members) > 0 {
-		memberRoomIDs, err = h.members.GetChannels(ctx, account, h.cfg.SiteID, req.Members)
+		memberRoomIDs, err = h.members.getChannels(ctx, account, h.cfg.SiteID, req.Members)
 		if err != nil {
 			return nil, fmt.Errorf("resolving members: %w", err)
 		}

--- a/search-service/handler.go
+++ b/search-service/handler.go
@@ -148,6 +148,12 @@ func (h *handler) searchRooms(c *natsrouter.Context, req model.SearchRoomsReques
 	ctx, cancel := h.withRequestTimeout(c)
 	defer cancel()
 
+	// Reject an invalid roomType before the member-resolution RPC, so bad input
+	// fails fast instead of doing upstream work only to be rejected in buildRoomQuery.
+	if _, rerr := roomTypeFilterClause(req.RoomType); rerr != nil {
+		return nil, rerr
+	}
+
 	// memberRoomIDs stays nil (no filter) when Members is unset; an empty
 	// non-nil slice means no channel matched every requested member, so the
 	// query is built to match nothing rather than falling back to unfiltered.

--- a/search-service/handler.go
+++ b/search-service/handler.go
@@ -34,12 +34,13 @@ type handlerConfig struct {
 }
 
 type handler struct {
-	store SearchStore
-	mongo MongoStore
-	users SearchUsersClient
-	cache RestrictedRoomCache
-	room  RoomInfoClient
-	cfg   handlerConfig
+	store   SearchStore
+	mongo   MongoStore
+	users   SearchUsersClient
+	cache   RestrictedRoomCache
+	room    RoomInfoClient
+	members MembersClient
+	cfg     handlerConfig
 }
 
 func newHandler(store SearchStore, mongo MongoStore, users SearchUsersClient, cache RestrictedRoomCache, cfg *handlerConfig) *handler {
@@ -73,7 +74,7 @@ func (h *handler) withRequestTimeout(parent context.Context) (context.Context, c
 	return context.WithTimeout(parent, h.cfg.RequestTimeout)
 }
 
-func (h *handler) searchMessages(c *natsrouter.Context, req model.SearchMessagesRequest) (resp *model.SearchMessagesResponse, err error) {
+func (h *handler) searchMessages(c *natsrouter.Context, req model.SearchMessagesRequest) (resp *model.SearchMessagesResponse, err error) { //nolint:gocritic // hugeParam: req is passed by value to satisfy the natsrouter.Register handler signature
 	defer observeRequest(c, metricKindMessages, &err)()
 
 	account, rerr := c.Params.Require("account")
@@ -139,15 +140,26 @@ func (h *handler) searchRooms(c *natsrouter.Context, req model.SearchRoomsReques
 	}
 
 	query := strings.TrimSpace(req.Query)
-	if query == "" {
-		return nil, errcode.BadRequest("query is required")
+	if query == "" && len(req.Members) == 0 {
+		return nil, errcode.BadRequest("query or members is required")
 	}
 	req.Query = query
 
 	ctx, cancel := h.withRequestTimeout(c)
 	defer cancel()
 
-	body, err := buildRoomQuery(req, account)
+	// memberRoomIDs stays nil (no filter) when Members is unset; an empty
+	// non-nil slice means no channel matched every requested member, so the
+	// query is built to match nothing rather than falling back to unfiltered.
+	var memberRoomIDs []string
+	if len(req.Members) > 0 {
+		memberRoomIDs, err = h.members.GetChannels(ctx, account, h.cfg.SiteID, req.Members)
+		if err != nil {
+			return nil, fmt.Errorf("resolving members: %w", err)
+		}
+	}
+
+	body, err := buildRoomQuery(req, account, memberRoomIDs)
 	if err != nil {
 		// A typed errcode error (invalid roomType) passes through;
 		// anything else (marshal failure — unreachable) gets sanitized.

--- a/search-service/handler_test.go
+++ b/search-service/handler_test.go
@@ -416,11 +416,13 @@ func TestHandler_SearchRooms_MembersAllowsEmptyQuery(t *testing.T) {
 			`{"_source":{"roomId":"r1","roomName":"general","roomType":"channel","siteId":"site-a"}}]}}`),
 	}
 	h := newTestHandler(store, &fakeMongo{}, nil, newFakeCache())
-	h.members = &fakeMembers{roomIDs: []string{"r1"}}
+	fake := &fakeMembers{roomIDs: []string{"r1"}}
+	h.members = fake
 
 	resp, err := h.searchRooms(ctxWithAccount("alice"), model.SearchRoomsRequest{Members: []string{"bob"}})
 	require.NoError(t, err)
 	require.Len(t, resp.Rooms, 1)
+	assert.Equal(t, []string{"bob"}, fake.calls, "handler forwards the requested members to GetChannels")
 }
 
 func TestHandler_SearchRooms_EmptyQueryAndMembersRejected(t *testing.T) {

--- a/search-service/handler_test.go
+++ b/search-service/handler_test.go
@@ -396,6 +396,53 @@ func TestHandler_SearchRooms_NegativeSizeRejected(t *testing.T) {
 	assert.Equal(t, errcode.CodeBadRequest, rerr.Code)
 }
 
+type fakeMembers struct {
+	roomIDs []string
+	err     error
+	calls   []string // members passed on the last call, for assertions
+}
+
+func (f *fakeMembers) GetChannels(_ context.Context, _, _ string, members []string) ([]string, error) {
+	f.calls = members
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.roomIDs, nil
+}
+
+func TestHandler_SearchRooms_MembersAllowsEmptyQuery(t *testing.T) {
+	store := &fakeStore{
+		searchBody: json.RawMessage(`{"hits":{"total":{"value":1},"hits":[` +
+			`{"_source":{"roomId":"r1","roomName":"general","roomType":"channel","siteId":"site-a"}}]}}`),
+	}
+	h := newTestHandler(store, &fakeMongo{}, nil, newFakeCache())
+	h.members = &fakeMembers{roomIDs: []string{"r1"}}
+
+	resp, err := h.searchRooms(ctxWithAccount("alice"), model.SearchRoomsRequest{Members: []string{"bob"}})
+	require.NoError(t, err)
+	require.Len(t, resp.Rooms, 1)
+}
+
+func TestHandler_SearchRooms_EmptyQueryAndMembersRejected(t *testing.T) {
+	h := newTestHandler(&fakeStore{}, &fakeMongo{}, nil, newFakeCache())
+	h.members = &fakeMembers{}
+	_, err := h.searchRooms(ctxWithAccount("alice"), model.SearchRoomsRequest{})
+	require.Error(t, err)
+	var rerr *errcode.Error
+	require.True(t, errors.As(err, &rerr))
+	assert.Equal(t, errcode.CodeBadRequest, rerr.Code)
+}
+
+func TestHandler_SearchRooms_MembersRPCErrorSanitized(t *testing.T) {
+	h := newTestHandler(&fakeStore{}, &fakeMongo{}, nil, newFakeCache())
+	h.members = &fakeMembers{err: errors.New("rpc failed")}
+	_, err := h.searchRooms(ctxWithAccount("alice"), model.SearchRoomsRequest{Members: []string{"bob"}})
+	require.Error(t, err)
+	classified := errcode.Classify(context.Background(), err)
+	assert.Equal(t, errcode.CodeInternal, classified.Code)
+	assert.NotContains(t, classified.Message, "rpc failed")
+}
+
 func TestHandler_SearchRooms_UsesSpotlightIndex(t *testing.T) {
 	store := &fakeStore{}
 	h := newTestHandler(store, &fakeMongo{}, nil, newFakeCache())

--- a/search-service/handler_test.go
+++ b/search-service/handler_test.go
@@ -402,7 +402,7 @@ type fakeMembers struct {
 	calls   []string // members passed on the last call, for assertions
 }
 
-func (f *fakeMembers) GetChannels(_ context.Context, _, _ string, members []string) ([]string, error) {
+func (f *fakeMembers) getChannels(_ context.Context, _, _ string, members []string) ([]string, error) {
 	f.calls = members
 	if f.err != nil {
 		return nil, f.err
@@ -422,7 +422,7 @@ func TestHandler_SearchRooms_MembersAllowsEmptyQuery(t *testing.T) {
 	resp, err := h.searchRooms(ctxWithAccount("alice"), model.SearchRoomsRequest{Members: []string{"bob"}})
 	require.NoError(t, err)
 	require.Len(t, resp.Rooms, 1)
-	assert.Equal(t, []string{"bob"}, fake.calls, "handler forwards the requested members to GetChannels")
+	assert.Equal(t, []string{"bob"}, fake.calls, "handler forwards the requested members to getChannels")
 }
 
 func TestHandler_SearchRooms_EmptyQueryAndMembersRejected(t *testing.T) {

--- a/search-service/main.go
+++ b/search-service/main.go
@@ -207,6 +207,7 @@ func main() {
 		SpotlightOrgReadPattern: spotlightOrgReadPattern,
 	})
 	handler.room = newRoomClient(nc)
+	handler.members = newMembersClient(nc)
 
 	// Bound in-flight handlers so a burst is shed at the door (ErrUnavailable)
 	// instead of piling unbounded work onto Elasticsearch/MongoDB.

--- a/search-service/members_client.go
+++ b/search-service/members_client.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+// membersRPCTimeout bounds the subscription.getChannels round trip.
+const membersRPCTimeout = 5 * time.Second
+
+// getChannelsRequest/getChannelsResponse mirror the wire shape of user-service's
+// subscription.getChannels (user-service/models.GetChannelsRequest /
+// PagedSubscriptionListResponse). Declared locally — that package is
+// user-service-internal, not a shared pkg/model contract — and only the
+// roomId this caller needs is decoded.
+type getChannelsRequest struct {
+	AccountNames []string `json:"accountNames,omitempty"`
+}
+
+type getChannelsResponse struct {
+	Subscriptions []struct {
+		RoomID string `json:"roomId"`
+	} `json:"subscriptions"`
+}
+
+// membersClient is the NATS-backed MembersClient. It issues
+// subscription.getChannels on the REQUESTER's own account subject (a
+// server-to-server call within the same site), matching how every other
+// user-scoped RPC in this codebase is addressed.
+type membersClient struct {
+	nc *o11ynats.Conn
+}
+
+func newMembersClient(nc *o11ynats.Conn) *membersClient { return &membersClient{nc: nc} }
+
+func (c *membersClient) GetChannels(ctx context.Context, account, siteID string, members []string) ([]string, error) {
+	req, err := json.Marshal(getChannelsRequest{AccountNames: members})
+	if err != nil {
+		return nil, fmt.Errorf("marshal getChannels request: %w", err)
+	}
+	msg, err := c.nc.Request(ctx, subject.UserSubscriptionGetChannels(account, siteID), req, membersRPCTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("getChannels rpc: %w", err)
+	}
+	if e, ok := errcode.Parse(msg.Data); ok {
+		return nil, e
+	}
+	var out getChannelsResponse
+	if err := json.Unmarshal(msg.Data, &out); err != nil {
+		return nil, fmt.Errorf("decode getChannels response: %w", err)
+	}
+	roomIDs := make([]string, 0, len(out.Subscriptions))
+	for _, sub := range out.Subscriptions {
+		roomIDs = append(roomIDs, sub.RoomID)
+	}
+	return roomIDs, nil
+}

--- a/search-service/members_client.go
+++ b/search-service/members_client.go
@@ -7,58 +7,79 @@ import (
 	"time"
 
 	o11ynats "github.com/flywindy/o11y/nats"
+	"github.com/nats-io/nats.go"
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/subject"
 )
 
-// membersRPCTimeout bounds the subscription.getChannels round trip.
-const membersRPCTimeout = 5 * time.Second
+const (
+	// membersRPCTimeout bounds each subscription.getChannels round trip.
+	membersRPCTimeout = 5 * time.Second
+	// membersPageLimit is the page size per getChannels round trip; GetChannels
+	// pages until hasMore is false so a member in many rooms isn't truncated.
+	membersPageLimit = 200
+)
 
 // getChannelsRequest/getChannelsResponse mirror the wire shape of user-service's
-// subscription.getChannels (user-service/models.GetChannelsRequest /
-// PagedSubscriptionListResponse). Declared locally — that package is
-// user-service-internal, not a shared pkg/model contract — and only the
-// roomId this caller needs is decoded.
+// subscription.getChannels. Declared locally — that package is user-service-internal,
+// not a shared pkg/model contract — and only the fields this caller needs are decoded.
 type getChannelsRequest struct {
 	AccountNames []string `json:"accountNames,omitempty"`
+	Offset       int      `json:"offset,omitempty"`
+	Limit        int      `json:"limit,omitempty"`
 }
 
 type getChannelsResponse struct {
 	Subscriptions []struct {
 		RoomID string `json:"roomId"`
 	} `json:"subscriptions"`
+	HasMore bool `json:"hasMore"`
 }
 
-// membersClient is the NATS-backed MembersClient. It issues
-// subscription.getChannels on the REQUESTER's own account subject (a
-// server-to-server call within the same site), matching how every other
-// user-scoped RPC in this codebase is addressed.
+// subscriptionRequester is the narrow NATS request surface GetChannels needs;
+// *o11ynats.Conn satisfies it, and tests inject a stub.
+type subscriptionRequester interface {
+	Request(ctx context.Context, subj string, data []byte, timeout time.Duration) (*nats.Msg, error)
+}
+
+// membersClient issues subscription.getChannels on the REQUESTER's own account
+// subject (a server-to-server call within the same site).
 type membersClient struct {
-	nc *o11ynats.Conn
+	req subscriptionRequester
 }
 
-func newMembersClient(nc *o11ynats.Conn) *membersClient { return &membersClient{nc: nc} }
+func newMembersClient(nc *o11ynats.Conn) *membersClient { return &membersClient{req: nc} }
 
+// GetChannels returns every room id the members share, paging through
+// getChannels until hasMore is false so large memberships aren't truncated.
 func (c *membersClient) GetChannels(ctx context.Context, account, siteID string, members []string) ([]string, error) {
-	req, err := json.Marshal(getChannelsRequest{AccountNames: members})
-	if err != nil {
-		return nil, fmt.Errorf("marshal getChannels request: %w", err)
-	}
-	msg, err := c.nc.Request(ctx, subject.UserSubscriptionGetChannels(account, siteID), req, membersRPCTimeout)
-	if err != nil {
-		return nil, fmt.Errorf("getChannels rpc: %w", err)
-	}
-	if e, ok := errcode.Parse(msg.Data); ok {
-		return nil, e
-	}
-	var out getChannelsResponse
-	if err := json.Unmarshal(msg.Data, &out); err != nil {
-		return nil, fmt.Errorf("decode getChannels response: %w", err)
-	}
-	roomIDs := make([]string, 0, len(out.Subscriptions))
-	for _, sub := range out.Subscriptions {
-		roomIDs = append(roomIDs, sub.RoomID)
+	subj := subject.UserSubscriptionGetChannels(account, siteID)
+	var roomIDs []string
+	for offset := 0; ; {
+		body, err := json.Marshal(getChannelsRequest{AccountNames: members, Offset: offset, Limit: membersPageLimit})
+		if err != nil {
+			return nil, fmt.Errorf("marshal getChannels request: %w", err)
+		}
+		msg, err := c.req.Request(ctx, subj, body, membersRPCTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("getChannels rpc: %w", err)
+		}
+		if e, ok := errcode.Parse(msg.Data); ok {
+			return nil, e
+		}
+		var out getChannelsResponse
+		if err := json.Unmarshal(msg.Data, &out); err != nil {
+			return nil, fmt.Errorf("decode getChannels response: %w", err)
+		}
+		for _, sub := range out.Subscriptions {
+			roomIDs = append(roomIDs, sub.RoomID)
+		}
+		// Last page, or defensively an empty page while hasMore stays true.
+		if !out.HasMore || len(out.Subscriptions) == 0 {
+			break
+		}
+		offset += len(out.Subscriptions)
 	}
 	return roomIDs, nil
 }

--- a/search-service/members_client.go
+++ b/search-service/members_client.go
@@ -55,7 +55,9 @@ func newMembersClient(nc *o11ynats.Conn) *membersClient { return &membersClient{
 // getChannels until hasMore is false so large memberships aren't truncated.
 func (c *membersClient) GetChannels(ctx context.Context, account, siteID string, members []string) ([]string, error) {
 	subj := subject.UserSubscriptionGetChannels(account, siteID)
-	var roomIDs []string
+	// Non-nil so a zero-match result filters the room search to no rooms,
+	// rather than a nil slice that buildRoomQuery reads as "no member filter".
+	roomIDs := make([]string, 0)
 	for offset := 0; ; {
 		body, err := json.Marshal(getChannelsRequest{AccountNames: members, Offset: offset, Limit: membersPageLimit})
 		if err != nil {
@@ -75,9 +77,13 @@ func (c *membersClient) GetChannels(ctx context.Context, account, siteID string,
 		for _, sub := range out.Subscriptions {
 			roomIDs = append(roomIDs, sub.RoomID)
 		}
-		// Last page, or defensively an empty page while hasMore stays true.
-		if !out.HasMore || len(out.Subscriptions) == 0 {
+		if !out.HasMore {
 			break
+		}
+		// hasMore is set but the page is empty: the offset can't advance, so
+		// fail rather than silently returning a truncated member-room set.
+		if len(out.Subscriptions) == 0 {
+			return nil, fmt.Errorf("getChannels returned an empty page with hasMore set for %s", account)
 		}
 		offset += len(out.Subscriptions)
 	}

--- a/search-service/members_client.go
+++ b/search-service/members_client.go
@@ -16,7 +16,7 @@ import (
 const (
 	// membersRPCTimeout bounds each subscription.getChannels round trip.
 	membersRPCTimeout = 5 * time.Second
-	// membersPageLimit is the page size per getChannels round trip; GetChannels
+	// membersPageLimit is the page size per getChannels round trip; getChannels
 	// pages until hasMore is false so a member in many rooms isn't truncated.
 	membersPageLimit = 200
 )
@@ -37,7 +37,7 @@ type getChannelsResponse struct {
 	HasMore bool `json:"hasMore"`
 }
 
-// subscriptionRequester is the narrow NATS request surface GetChannels needs;
+// subscriptionRequester is the narrow NATS request surface getChannels needs;
 // *o11ynats.Conn satisfies it, and tests inject a stub.
 type subscriptionRequester interface {
 	Request(ctx context.Context, subj string, data []byte, timeout time.Duration) (*nats.Msg, error)
@@ -51,9 +51,9 @@ type membersClient struct {
 
 func newMembersClient(nc *o11ynats.Conn) *membersClient { return &membersClient{req: nc} }
 
-// GetChannels returns every room id the members share, paging through
+// getChannels returns every room id the members share, paging through
 // getChannels until hasMore is false so large memberships aren't truncated.
-func (c *membersClient) GetChannels(ctx context.Context, account, siteID string, members []string) ([]string, error) {
+func (c *membersClient) getChannels(ctx context.Context, account, siteID string, members []string) ([]string, error) {
 	subj := subject.UserSubscriptionGetChannels(account, siteID)
 	// Non-nil so a zero-match result filters the room search to no rooms,
 	// rather than a nil slice that buildRoomQuery reads as "no member filter".

--- a/search-service/members_client_test.go
+++ b/search-service/members_client_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubMembersRequester replays canned getChannels response pages in order and
+// records each request's decoded body.
+type stubMembersRequester struct {
+	pages [][]byte
+	calls []getChannelsRequest
+	i     int
+}
+
+func (s *stubMembersRequester) Request(_ context.Context, _ string, data []byte, _ time.Duration) (*nats.Msg, error) {
+	var req getChannelsRequest
+	_ = json.Unmarshal(data, &req)
+	s.calls = append(s.calls, req)
+	page := s.pages[s.i]
+	if s.i < len(s.pages)-1 {
+		s.i++
+	}
+	return &nats.Msg{Data: page}, nil
+}
+
+func membersPage(hasMore bool, roomIDs ...string) []byte {
+	var out getChannelsResponse
+	for _, id := range roomIDs {
+		out.Subscriptions = append(out.Subscriptions, struct {
+			RoomID string `json:"roomId"`
+		}{RoomID: id})
+	}
+	out.HasMore = hasMore
+	b, _ := json.Marshal(out)
+	return b
+}
+
+func TestMembersClient_GetChannels_PagesUntilExhausted(t *testing.T) {
+	stub := &stubMembersRequester{pages: [][]byte{
+		membersPage(true, "r1", "r2"),
+		membersPage(false, "r3"),
+	}}
+	c := &membersClient{req: stub}
+
+	rooms, err := c.GetChannels(context.Background(), "alice", "site-a", []string{"bob"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"r1", "r2", "r3"}, rooms, "all pages accumulated, not just page 1")
+	require.Len(t, stub.calls, 2, "paged twice")
+	assert.Equal(t, 0, stub.calls[0].Offset)
+	assert.Equal(t, 2, stub.calls[1].Offset, "second-page offset advances by the first page's count")
+	assert.Equal(t, []string{"bob"}, stub.calls[0].AccountNames)
+}
+
+func TestMembersClient_GetChannels_SinglePageNoExtraRoundTrip(t *testing.T) {
+	stub := &stubMembersRequester{pages: [][]byte{membersPage(false, "r1")}}
+	c := &membersClient{req: stub}
+
+	rooms, err := c.GetChannels(context.Background(), "alice", "site-a", []string{"bob"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"r1"}, rooms)
+	require.Len(t, stub.calls, 1, "no extra round trip when hasMore is false")
+}

--- a/search-service/members_client_test.go
+++ b/search-service/members_client_test.go
@@ -73,3 +73,22 @@ func TestMembersClient_GetChannels_SinglePageNoExtraRoundTrip(t *testing.T) {
 	assert.Equal(t, []string{"r1"}, rooms)
 	require.Len(t, stub.calls, 1, "no extra round trip when hasMore is false")
 }
+
+func TestMembersClient_GetChannels_ZeroMatchReturnsNonNilEmpty(t *testing.T) {
+	stub := &stubMembersRequester{pages: [][]byte{membersPage(false)}}
+	c := &membersClient{req: stub}
+
+	rooms, err := c.GetChannels(context.Background(), "alice", "site-a", []string{"bob"})
+	require.NoError(t, err)
+	require.NotNil(t, rooms, "zero-match must be non-nil so the room search filters to no rooms, not all")
+	assert.Empty(t, rooms)
+}
+
+func TestMembersClient_GetChannels_EmptyPageWithHasMoreErrors(t *testing.T) {
+	stub := &stubMembersRequester{pages: [][]byte{membersPage(true)}}
+	c := &membersClient{req: stub}
+
+	_, err := c.GetChannels(context.Background(), "alice", "site-a", []string{"bob"})
+	require.Error(t, err, "an empty page with hasMore set can't advance the offset")
+	assert.Contains(t, err.Error(), "empty page with hasMore")
+}

--- a/search-service/members_client_test.go
+++ b/search-service/members_client_test.go
@@ -9,17 +9,21 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/subject"
 )
 
 // stubMembersRequester replays canned getChannels response pages in order and
-// records each request's decoded body.
+// records each request's subject + decoded body.
 type stubMembersRequester struct {
-	pages [][]byte
-	calls []getChannelsRequest
-	i     int
+	pages    [][]byte
+	subjects []string
+	calls    []getChannelsRequest
+	i        int
 }
 
-func (s *stubMembersRequester) Request(_ context.Context, _ string, data []byte, _ time.Duration) (*nats.Msg, error) {
+func (s *stubMembersRequester) Request(_ context.Context, subj string, data []byte, _ time.Duration) (*nats.Msg, error) {
+	s.subjects = append(s.subjects, subj)
 	var req getChannelsRequest
 	_ = json.Unmarshal(data, &req)
 	s.calls = append(s.calls, req)
@@ -53,6 +57,8 @@ func TestMembersClient_GetChannels_PagesUntilExhausted(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"r1", "r2", "r3"}, rooms, "all pages accumulated, not just page 1")
 	require.Len(t, stub.calls, 2, "paged twice")
+	assert.Equal(t, subject.UserSubscriptionGetChannels("alice", "site-a"), stub.subjects[0],
+		"subject derived from the requester account + site")
 	assert.Equal(t, 0, stub.calls[0].Offset)
 	assert.Equal(t, 2, stub.calls[1].Offset, "second-page offset advances by the first page's count")
 	assert.Equal(t, []string{"bob"}, stub.calls[0].AccountNames)

--- a/search-service/members_client_test.go
+++ b/search-service/members_client_test.go
@@ -53,7 +53,7 @@ func TestMembersClient_GetChannels_PagesUntilExhausted(t *testing.T) {
 	}}
 	c := &membersClient{req: stub}
 
-	rooms, err := c.GetChannels(context.Background(), "alice", "site-a", []string{"bob"})
+	rooms, err := c.getChannels(context.Background(), "alice", "site-a", []string{"bob"})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"r1", "r2", "r3"}, rooms, "all pages accumulated, not just page 1")
 	require.Len(t, stub.calls, 2, "paged twice")
@@ -68,7 +68,7 @@ func TestMembersClient_GetChannels_SinglePageNoExtraRoundTrip(t *testing.T) {
 	stub := &stubMembersRequester{pages: [][]byte{membersPage(false, "r1")}}
 	c := &membersClient{req: stub}
 
-	rooms, err := c.GetChannels(context.Background(), "alice", "site-a", []string{"bob"})
+	rooms, err := c.getChannels(context.Background(), "alice", "site-a", []string{"bob"})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"r1"}, rooms)
 	require.Len(t, stub.calls, 1, "no extra round trip when hasMore is false")
@@ -78,7 +78,7 @@ func TestMembersClient_GetChannels_ZeroMatchReturnsNonNilEmpty(t *testing.T) {
 	stub := &stubMembersRequester{pages: [][]byte{membersPage(false)}}
 	c := &membersClient{req: stub}
 
-	rooms, err := c.GetChannels(context.Background(), "alice", "site-a", []string{"bob"})
+	rooms, err := c.getChannels(context.Background(), "alice", "site-a", []string{"bob"})
 	require.NoError(t, err)
 	require.NotNil(t, rooms, "zero-match must be non-nil so the room search filters to no rooms, not all")
 	assert.Empty(t, rooms)
@@ -88,7 +88,7 @@ func TestMembersClient_GetChannels_EmptyPageWithHasMoreErrors(t *testing.T) {
 	stub := &stubMembersRequester{pages: [][]byte{membersPage(true)}}
 	c := &membersClient{req: stub}
 
-	_, err := c.GetChannels(context.Background(), "alice", "site-a", []string{"bob"})
+	_, err := c.getChannels(context.Background(), "alice", "site-a", []string{"bob"})
 	require.Error(t, err, "an empty page with hasMore set can't advance the offset")
 	assert.Contains(t, err.Error(), "empty page with hasMore")
 }

--- a/search-service/query_messages.go
+++ b/search-service/query_messages.go
@@ -46,7 +46,7 @@ func buildMessageQuery(req model.SearchMessagesRequest, account string, restrict
 			},
 		},
 	}
-	filters = append(filters, messageFilterClauses(req, account)...)
+	filters = append(filters, messageFilterClauses(req)...)
 
 	body := map[string]any{
 		"from":             req.Offset,
@@ -87,9 +87,8 @@ func buildMessageQuery(req model.SearchMessagesRequest, account string, restrict
 }
 
 // messageFilterClauses translates the additive request-level filters
-// (senders/dateRange/hasAttachment/mentionedMe/fileTypes) into ES filter
-// clauses. mentionedMe filters on account (the requester), not a request field.
-func messageFilterClauses(req model.SearchMessagesRequest, account string) []any { //nolint:gocritic // hugeParam: req copied once per search request, not a hot path
+// (senders/dateRange/hasAttachment/fileTypes) into ES filter clauses.
+func messageFilterClauses(req model.SearchMessagesRequest) []any { //nolint:gocritic // hugeParam: req copied once per search request, not a hot path
 	var clauses []any
 	if len(req.Senders) > 0 {
 		clauses = append(clauses, map[string]any{"terms": map[string]any{"userAccount": req.Senders}})
@@ -112,9 +111,6 @@ func messageFilterClauses(req model.SearchMessagesRequest, account string) []any
 		// non-empty" — reuses the indexed keyword field instead of `exists` on
 		// the disabled `attachments` object, which isn't reliably indexed.
 		clauses = append(clauses, map[string]any{"exists": map[string]any{"field": "fileTypes"}})
-	}
-	if req.MentionedMe != nil && *req.MentionedMe {
-		clauses = append(clauses, map[string]any{"term": map[string]any{"mentions": account}})
 	}
 	if len(req.FileTypes) > 0 {
 		clauses = append(clauses, map[string]any{"terms": map[string]any{"fileTypes": req.FileTypes}})

--- a/search-service/query_messages.go
+++ b/search-service/query_messages.go
@@ -28,8 +28,25 @@ var MessageIndexPattern = []string{"messages-*", "*:messages-*"}
 // (req.RoomIDs != nil), the inline terms clause is STILL gated by the
 // terms-lookup so a caller can't reach rooms they don't belong to by
 // passing arbitrary roomIds.
-func buildMessageQuery(req model.SearchMessagesRequest, account string, restricted map[string]int64, recentWindow time.Duration, userRoomIndex string) (json.RawMessage, error) {
+func buildMessageQuery(req model.SearchMessagesRequest, account string, restricted map[string]int64, recentWindow time.Duration, userRoomIndex string) (json.RawMessage, error) { //nolint:gocritic // hugeParam: req copied once per search request, not a hot path
 	clauses := roomAccessClauses(req.RoomIDs, account, restricted, userRoomIndex)
+
+	filters := []any{
+		map[string]any{
+			"range": map[string]any{
+				"createdAt": map[string]any{
+					"gte": fmt.Sprintf("now-%s", recentWindowToGte(recentWindow)),
+				},
+			},
+		},
+		map[string]any{
+			"bool": map[string]any{
+				"should":               clauses,
+				"minimum_should_match": 1,
+			},
+		},
+	}
+	filters = append(filters, messageFilterClauses(req, account)...)
 
 	body := map[string]any{
 		"from":             req.Offset,
@@ -46,27 +63,14 @@ func buildMessageQuery(req model.SearchMessagesRequest, account string, restrict
 							"query":    req.Query,
 							"type":     "bool_prefix",
 							"operator": "AND",
-							// Message text, attachment titles+descriptions (one
-							// pooled field) and tcard data — one query box.
-							"fields": []string{"content", "attachmentText", "cardData"},
+							// Message text, sender display name, attachment
+							// titles+descriptions (one pooled field), and tcard
+							// data — one query box.
+							"fields": []string{"content", "userName", "attachmentText", "cardData"},
 						},
 					},
 				},
-				"filter": []any{
-					map[string]any{
-						"range": map[string]any{
-							"createdAt": map[string]any{
-								"gte": fmt.Sprintf("now-%s", recentWindowToGte(recentWindow)),
-							},
-						},
-					},
-					map[string]any{
-						"bool": map[string]any{
-							"should":               clauses,
-							"minimum_should_match": 1,
-						},
-					},
-				},
+				"filter": filters,
 			},
 		},
 		"sort": []any{
@@ -80,6 +84,42 @@ func buildMessageQuery(req model.SearchMessagesRequest, account string, restrict
 		return nil, fmt.Errorf("marshal message query: %w", err)
 	}
 	return data, nil
+}
+
+// messageFilterClauses translates the additive request-level filters
+// (senders/dateRange/hasAttachment/mentionedMe/fileTypes) into ES filter
+// clauses. mentionedMe filters on account (the requester), not a request field.
+func messageFilterClauses(req model.SearchMessagesRequest, account string) []any { //nolint:gocritic // hugeParam: req copied once per search request, not a hot path
+	var clauses []any
+	if len(req.Senders) > 0 {
+		clauses = append(clauses, map[string]any{"terms": map[string]any{"userAccount": req.Senders}})
+	}
+	if req.DateRange != nil {
+		rng := map[string]any{}
+		if !req.DateRange.Start.IsZero() {
+			rng["gte"] = req.DateRange.Start
+		}
+		if !req.DateRange.End.IsZero() {
+			rng["lte"] = req.DateRange.End
+		}
+		if len(rng) > 0 {
+			clauses = append(clauses, map[string]any{"range": map[string]any{"createdAt": rng}})
+		}
+	}
+	if req.HasAttachment != nil && *req.HasAttachment {
+		// fileTypes is populated 1:1 with attachments (every attachment maps to a
+		// category, "others" included), so "has an attachment" == "fileTypes is
+		// non-empty" — reuses the indexed keyword field instead of `exists` on
+		// the disabled `attachments` object, which isn't reliably indexed.
+		clauses = append(clauses, map[string]any{"exists": map[string]any{"field": "fileTypes"}})
+	}
+	if req.MentionedMe != nil && *req.MentionedMe {
+		clauses = append(clauses, map[string]any{"term": map[string]any{"mentions": account}})
+	}
+	if len(req.FileTypes) > 0 {
+		clauses = append(clauses, map[string]any{"terms": map[string]any{"fileTypes": req.FileTypes}})
+	}
+	return clauses
 }
 
 func roomAccessClauses(roomIDs []string, account string, restricted map[string]int64, userRoomIndex string) []any {

--- a/search-service/query_messages_test.go
+++ b/search-service/query_messages_test.go
@@ -259,17 +259,6 @@ func TestBuildMessageQuery_HasAttachment(t *testing.T) {
 	assert.Equal(t, "fileTypes", exists["field"])
 }
 
-func TestBuildMessageQuery_MentionedMe(t *testing.T) {
-	yes := true
-	req := model.SearchMessagesRequest{Query: "hi", MentionedMe: &yes}
-	raw, err := buildMessageQuery(req, "alice", nil, time.Hour, "user-room")
-	require.NoError(t, err)
-
-	filters := filterClauses(t, parseQuery(t, raw))
-	term := filters[2].(map[string]any)["term"].(map[string]any)
-	assert.Equal(t, "alice", term["mentions"], "mentionedMe filters on the requester's own account")
-}
-
 func TestBuildMessageQuery_FileTypes(t *testing.T) {
 	req := model.SearchMessagesRequest{Query: "hi", FileTypes: []string{"pdf", "zip"}}
 	raw, err := buildMessageQuery(req, "alice", nil, time.Hour, "user-room")
@@ -286,15 +275,14 @@ func TestBuildMessageQuery_CombinedFilters(t *testing.T) {
 		Query:         "hi",
 		Senders:       []string{"bob"},
 		HasAttachment: &yes,
-		MentionedMe:   &yes,
 		FileTypes:     []string{"image"},
 	}
 	raw, err := buildMessageQuery(req, "alice", nil, time.Hour, "user-room")
 	require.NoError(t, err)
 
-	// range + should + senders + hasAttachment + mentionedMe + fileTypes
+	// recent-window range + access should + senders + hasAttachment + fileTypes
 	filters := filterClauses(t, parseQuery(t, raw))
-	require.Len(t, filters, 6)
+	require.Len(t, filters, 5)
 }
 
 func TestRecentWindowToGte_Units(t *testing.T) {

--- a/search-service/query_messages_test.go
+++ b/search-service/query_messages_test.go
@@ -67,7 +67,7 @@ func TestBuildMessageQuery_SearchesAttachmentAndCardFields(t *testing.T) {
 	assert.Equal(t, "bool_prefix", mm["type"])
 	assert.Equal(t, "AND", mm["operator"])
 	assert.Equal(t,
-		[]any{"content", "attachmentText", "cardData"},
+		[]any{"content", "userName", "attachmentText", "cardData"},
 		mm["fields"])
 
 	// Search-only fields never ship on hits: cardData is a (possibly large)
@@ -223,6 +223,78 @@ func TestBuildMessageQuery_RecentWindowDefault(t *testing.T) {
 	rng := filters[0].(map[string]any)["range"].(map[string]any)["createdAt"].(map[string]any)
 	// Zero / negative window defaults to 1 year (365 * 24h = 8760h).
 	assert.Equal(t, "now-8760h", rng["gte"])
+}
+
+func TestBuildMessageQuery_Senders(t *testing.T) {
+	req := model.SearchMessagesRequest{Query: "hi", Senders: []string{"bob", "carol"}}
+	raw, err := buildMessageQuery(req, "alice", nil, time.Hour, "user-room")
+	require.NoError(t, err)
+
+	filters := filterClauses(t, parseQuery(t, raw))
+	senders := filters[2].(map[string]any)["terms"].(map[string]any)["userAccount"]
+	assert.ElementsMatch(t, []any{"bob", "carol"}, senders)
+}
+
+func TestBuildMessageQuery_DateRange(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC)
+	req := model.SearchMessagesRequest{Query: "hi", DateRange: &model.DateRange{Start: start, End: end}}
+	raw, err := buildMessageQuery(req, "alice", nil, time.Hour, "user-room")
+	require.NoError(t, err)
+
+	filters := filterClauses(t, parseQuery(t, raw))
+	rng := filters[2].(map[string]any)["range"].(map[string]any)["createdAt"].(map[string]any)
+	assert.Equal(t, start.Format(time.RFC3339), rng["gte"])
+	assert.Equal(t, end.Format(time.RFC3339), rng["lte"])
+}
+
+func TestBuildMessageQuery_HasAttachment(t *testing.T) {
+	yes := true
+	req := model.SearchMessagesRequest{Query: "hi", HasAttachment: &yes}
+	raw, err := buildMessageQuery(req, "alice", nil, time.Hour, "user-room")
+	require.NoError(t, err)
+
+	filters := filterClauses(t, parseQuery(t, raw))
+	exists := filters[2].(map[string]any)["exists"].(map[string]any)
+	assert.Equal(t, "fileTypes", exists["field"])
+}
+
+func TestBuildMessageQuery_MentionedMe(t *testing.T) {
+	yes := true
+	req := model.SearchMessagesRequest{Query: "hi", MentionedMe: &yes}
+	raw, err := buildMessageQuery(req, "alice", nil, time.Hour, "user-room")
+	require.NoError(t, err)
+
+	filters := filterClauses(t, parseQuery(t, raw))
+	term := filters[2].(map[string]any)["term"].(map[string]any)
+	assert.Equal(t, "alice", term["mentions"], "mentionedMe filters on the requester's own account")
+}
+
+func TestBuildMessageQuery_FileTypes(t *testing.T) {
+	req := model.SearchMessagesRequest{Query: "hi", FileTypes: []string{"pdf", "zip"}}
+	raw, err := buildMessageQuery(req, "alice", nil, time.Hour, "user-room")
+	require.NoError(t, err)
+
+	filters := filterClauses(t, parseQuery(t, raw))
+	fileTypes := filters[2].(map[string]any)["terms"].(map[string]any)["fileTypes"]
+	assert.ElementsMatch(t, []any{"pdf", "zip"}, fileTypes)
+}
+
+func TestBuildMessageQuery_CombinedFilters(t *testing.T) {
+	yes := true
+	req := model.SearchMessagesRequest{
+		Query:         "hi",
+		Senders:       []string{"bob"},
+		HasAttachment: &yes,
+		MentionedMe:   &yes,
+		FileTypes:     []string{"image"},
+	}
+	raw, err := buildMessageQuery(req, "alice", nil, time.Hour, "user-room")
+	require.NoError(t, err)
+
+	// range + should + senders + hasAttachment + mentionedMe + fileTypes
+	filters := filterClauses(t, parseQuery(t, raw))
+	require.Len(t, filters, 6)
 }
 
 func TestRecentWindowToGte_Units(t *testing.T) {

--- a/search-service/query_rooms.go
+++ b/search-service/query_rooms.go
@@ -61,6 +61,9 @@ func buildRoomQuery(req model.SearchRoomsRequest, account string, memberRoomIDs 
 		"sort": []any{
 			"_score",
 			map[string]any{"joinedAt": map[string]any{"order": "desc"}},
+			// Deterministic tie-breaker: the empty-query members path gives every
+			// hit the same _score, so equal joinedAt would otherwise page unstably.
+			map[string]any{"roomId": map[string]any{"order": "asc"}},
 		},
 	}
 

--- a/search-service/query_rooms.go
+++ b/search-service/query_rooms.go
@@ -17,10 +17,13 @@ const (
 )
 
 // buildRoomQuery composes the ES `_search` body for a subscription
-// search against the spotlight index. It returns a user-facing *errcode.Error
-// on invalid/unsupported roomType values and a plain error on marshalling
-// failures.
-func buildRoomQuery(req model.SearchRoomsRequest, account string) (json.RawMessage, error) {
+// search against the spotlight index. memberRoomIDs, when non-nil, scopes
+// results to that set (resolved upstream via subscription.getChannels for
+// req.Members) — an empty non-nil slice means "no room matched all the
+// requested members" and the query is built to match nothing.
+// It returns a user-facing *errcode.Error on invalid/unsupported roomType
+// values and a plain error on marshalling failures.
+func buildRoomQuery(req model.SearchRoomsRequest, account string, memberRoomIDs []string) (json.RawMessage, error) {
 	roomTypeFilter, rerr := roomTypeFilterClause(req.RoomType)
 	if rerr != nil {
 		return nil, rerr
@@ -32,26 +35,29 @@ func buildRoomQuery(req model.SearchRoomsRequest, account string) (json.RawMessa
 	if roomTypeFilter != nil {
 		filters = append(filters, roomTypeFilter)
 	}
+	if memberRoomIDs != nil {
+		filters = append(filters, map[string]any{"terms": map[string]any{"roomId": memberRoomIDs}})
+	}
+
+	query := map[string]any{"filter": filters}
+	if req.Query != "" {
+		query["must"] = []any{
+			map[string]any{
+				"multi_match": map[string]any{
+					"query":    req.Query,
+					"type":     "bool_prefix",
+					"operator": "AND",
+					"fields":   []string{"roomName"},
+				},
+			},
+		}
+	}
 
 	body := map[string]any{
 		"from":             req.Offset,
 		"size":             req.Size,
 		"track_total_hits": true,
-		"query": map[string]any{
-			"bool": map[string]any{
-				"must": []any{
-					map[string]any{
-						"multi_match": map[string]any{
-							"query":    req.Query,
-							"type":     "bool_prefix",
-							"operator": "AND",
-							"fields":   []string{"roomName"},
-						},
-					},
-				},
-				"filter": filters,
-			},
-		},
+		"query":            map[string]any{"bool": query},
 		"sort": []any{
 			"_score",
 			map[string]any{"joinedAt": map[string]any{"order": "desc"}},

--- a/search-service/query_rooms_test.go
+++ b/search-service/query_rooms_test.go
@@ -19,7 +19,7 @@ func subscriptionFilters(t *testing.T, q map[string]any) []any {
 
 func TestBuildSubscriptionQuery_RoomTypeAll(t *testing.T) {
 	req := model.SearchRoomsRequest{Query: "general", Size: 10, Offset: 0}
-	raw, err := buildRoomQuery(req, "alice")
+	raw, err := buildRoomQuery(req, "alice", nil)
 	require.NoError(t, err)
 
 	q := parseQuery(t, raw)
@@ -35,7 +35,7 @@ func TestBuildSubscriptionQuery_RoomTypeAll(t *testing.T) {
 
 func TestBuildSubscriptionQuery_RoomTypeExplicitAll(t *testing.T) {
 	req := model.SearchRoomsRequest{Query: "general", RoomType: "all"}
-	raw, err := buildRoomQuery(req, "alice")
+	raw, err := buildRoomQuery(req, "alice", nil)
 	require.NoError(t, err)
 
 	filters := subscriptionFilters(t, parseQuery(t, raw))
@@ -44,7 +44,7 @@ func TestBuildSubscriptionQuery_RoomTypeExplicitAll(t *testing.T) {
 
 func TestBuildSubscriptionQuery_RoomTypeChannel(t *testing.T) {
 	req := model.SearchRoomsRequest{Query: "general", RoomType: "channel"}
-	raw, err := buildRoomQuery(req, "alice")
+	raw, err := buildRoomQuery(req, "alice", nil)
 	require.NoError(t, err)
 
 	filters := subscriptionFilters(t, parseQuery(t, raw))
@@ -55,7 +55,7 @@ func TestBuildSubscriptionQuery_RoomTypeChannel(t *testing.T) {
 
 func TestBuildSubscriptionQuery_RoomTypeDM(t *testing.T) {
 	req := model.SearchRoomsRequest{Query: "alice", RoomType: "dm"}
-	raw, err := buildRoomQuery(req, "alice")
+	raw, err := buildRoomQuery(req, "alice", nil)
 	require.NoError(t, err)
 
 	filters := subscriptionFilters(t, parseQuery(t, raw))
@@ -66,7 +66,7 @@ func TestBuildSubscriptionQuery_RoomTypeDM(t *testing.T) {
 
 func TestBuildSubscriptionQuery_RoomTypeAppRejected(t *testing.T) {
 	req := model.SearchRoomsRequest{Query: "bot", RoomType: "app"}
-	_, err := buildRoomQuery(req, "alice")
+	_, err := buildRoomQuery(req, "alice", nil)
 	require.Error(t, err)
 
 	var rerr *errcode.Error
@@ -77,7 +77,7 @@ func TestBuildSubscriptionQuery_RoomTypeAppRejected(t *testing.T) {
 
 func TestBuildSubscriptionQuery_UnknownRoomTypeRejected(t *testing.T) {
 	req := model.SearchRoomsRequest{Query: "x", RoomType: "orb"}
-	_, err := buildRoomQuery(req, "alice")
+	_, err := buildRoomQuery(req, "alice", nil)
 	require.Error(t, err)
 
 	var rerr *errcode.Error
@@ -88,7 +88,7 @@ func TestBuildSubscriptionQuery_UnknownRoomTypeRejected(t *testing.T) {
 
 func TestBuildSubscriptionQuery_SortByScoreThenJoinedAtDesc(t *testing.T) {
 	req := model.SearchRoomsRequest{Query: "x"}
-	raw, err := buildRoomQuery(req, "alice")
+	raw, err := buildRoomQuery(req, "alice", nil)
 	require.NoError(t, err)
 
 	sort := parseQuery(t, raw)["sort"].([]any)
@@ -100,7 +100,7 @@ func TestBuildSubscriptionQuery_SortByScoreThenJoinedAtDesc(t *testing.T) {
 
 func TestBuildSubscriptionQuery_QueryFieldFlowsToESBody(t *testing.T) {
 	req := model.SearchRoomsRequest{Query: "engineering", Size: 5}
-	raw, err := buildRoomQuery(req, "alice")
+	raw, err := buildRoomQuery(req, "alice", nil)
 	require.NoError(t, err)
 
 	q := parseQuery(t, raw)
@@ -108,4 +108,37 @@ func TestBuildSubscriptionQuery_QueryFieldFlowsToESBody(t *testing.T) {
 	require.Len(t, must, 1)
 	mm := must[0].(map[string]any)["multi_match"].(map[string]any)
 	assert.Equal(t, "engineering", mm["query"], "Query field value must be passed as the multi_match query")
+}
+
+func TestBuildSubscriptionQuery_EmptyQueryOmitsMust(t *testing.T) {
+	req := model.SearchRoomsRequest{Members: []string{"bob"}}
+	raw, err := buildRoomQuery(req, "alice", []string{"r1"})
+	require.NoError(t, err)
+
+	q := parseQuery(t, raw)["query"].(map[string]any)["bool"].(map[string]any)
+	_, hasMust := q["must"]
+	assert.False(t, hasMust, "empty query must omit the must clause")
+}
+
+func TestBuildSubscriptionQuery_MembersAddsRoomIDFilter(t *testing.T) {
+	req := model.SearchRoomsRequest{Members: []string{"bob"}}
+	raw, err := buildRoomQuery(req, "alice", []string{"r1", "r2"})
+	require.NoError(t, err)
+
+	filters := subscriptionFilters(t, parseQuery(t, raw))
+	require.Len(t, filters, 2)
+	roomIDs := filters[1].(map[string]any)["terms"].(map[string]any)["roomId"]
+	assert.Equal(t, []any{"r1", "r2"}, roomIDs)
+}
+
+func TestBuildSubscriptionQuery_EmptyMemberMatchRejectsAll(t *testing.T) {
+	req := model.SearchRoomsRequest{Members: []string{"bob"}}
+	// memberRoomIDs non-nil but empty: no channel matched every requested member.
+	raw, err := buildRoomQuery(req, "alice", []string{})
+	require.NoError(t, err)
+
+	filters := subscriptionFilters(t, parseQuery(t, raw))
+	require.Len(t, filters, 2)
+	roomIDs := filters[1].(map[string]any)["terms"].(map[string]any)["roomId"]
+	assert.Equal(t, []any{}, roomIDs)
 }

--- a/search-service/query_rooms_test.go
+++ b/search-service/query_rooms_test.go
@@ -92,10 +92,12 @@ func TestBuildSubscriptionQuery_SortByScoreThenJoinedAtDesc(t *testing.T) {
 	require.NoError(t, err)
 
 	sort := parseQuery(t, raw)["sort"].([]any)
-	require.Len(t, sort, 2)
+	require.Len(t, sort, 3)
 	assert.Equal(t, "_score", sort[0])
 	joinedAt := sort[1].(map[string]any)["joinedAt"].(map[string]any)
 	assert.Equal(t, "desc", joinedAt["order"])
+	roomID := sort[2].(map[string]any)["roomId"].(map[string]any)
+	assert.Equal(t, "asc", roomID["order"], "deterministic tie-breaker after joinedAt")
 }
 
 func TestBuildSubscriptionQuery_QueryFieldFlowsToESBody(t *testing.T) {

--- a/search-service/response.go
+++ b/search-service/response.go
@@ -41,6 +41,7 @@ type messageSearchHit struct {
 	TShow                 bool               `json:"tshow,omitempty"`
 	Attachments           []model.Attachment `json:"attachments,omitempty"`
 	Card                  *model.Card        `json:"card,omitempty"`
+	UserName              string             `json:"userName,omitempty"`
 }
 
 // roomSearchHit is the spotlight ES `_source` shape for a room
@@ -93,6 +94,7 @@ func toSearchMessage(hit *messageSearchHit) model.SearchMessage {
 		TShow:                        hit.TShow,
 		Attachments:                  hit.Attachments,
 		Card:                         hit.Card,
+		UserName:                     hit.UserName,
 	}
 }
 

--- a/search-service/store.go
+++ b/search-service/store.go
@@ -94,5 +94,5 @@ type SearchUsersClient interface {
 // every given account plus the caller). Returns the first page of matching
 // room IDs; an empty non-nil slice means no channel matched.
 type MembersClient interface {
-	GetChannels(ctx context.Context, account, siteID string, members []string) ([]string, error)
+	getChannels(ctx context.Context, account, siteID string, members []string) ([]string, error)
 }

--- a/search-service/store.go
+++ b/search-service/store.go
@@ -88,3 +88,11 @@ type RoomInfoClient interface {
 type SearchUsersClient interface {
 	SearchUsers(ctx context.Context, query string, offset, limit int) ([]model.SearchUser, error)
 }
+
+// MembersClient resolves person→room membership for the room-search "members"
+// filter via user-service's subscription.getChannels RPC (channels containing
+// every given account plus the caller). Returns the first page of matching
+// room IDs; an empty non-nil slice means no channel matched.
+type MembersClient interface {
+	GetChannels(ctx context.Context, account, siteID string, members []string) ([]string, error)
+}

--- a/search-sync-worker/messages.go
+++ b/search-sync-worker/messages.go
@@ -309,6 +309,10 @@ func actionableEvent(e model.EventType) bool {
 
 // newMessageSearchIndex maps a MessageEvent to a search index document.
 func newMessageSearchIndex(evt *model.MessageEvent) (searchindex.MessageDoc, error) {
+	mentions := make([]string, 0, len(evt.Message.Mentions))
+	for _, p := range evt.Message.Mentions {
+		mentions = append(mentions, p.Account)
+	}
 	return searchindex.NewMessageDoc(searchindex.MessageFields{
 		MessageID:             evt.Message.ID,
 		RoomID:                evt.Message.RoomID,
@@ -324,6 +328,8 @@ func newMessageSearchIndex(evt *model.MessageEvent) (searchindex.MessageDoc, err
 		TShow:                 evt.Message.TShow,
 		Attachments:           evt.Message.Attachments,
 		Card:                  evt.Message.Card,
+		UserName:              evt.Message.UserDisplayName,
+		MentionAccounts:       mentions,
 	})
 }
 

--- a/search-sync-worker/messages_test.go
+++ b/search-sync-worker/messages_test.go
@@ -227,6 +227,26 @@ func TestNewMessageSearchIndex(t *testing.T) {
 	assert.True(t, doc.TShow)
 }
 
+func TestNewMessageSearchIndex_UserNameAndMentions(t *testing.T) {
+	evt := &model.MessageEvent{
+		Message: model.Message{
+			ID: "msg-1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+			UserDisplayName: "Alice Wong 王愛麗",
+			Content:         "hi @bob @carol",
+			CreatedAt:       time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC),
+			Mentions: []model.Participant{
+				{Account: "bob"},
+				{Account: "carol"},
+			},
+		},
+		SiteID: "site-a",
+	}
+	doc, err := newMessageSearchIndex(evt)
+	require.NoError(t, err)
+	assert.Equal(t, "Alice Wong 王愛麗", doc.UserName)
+	assert.Equal(t, []string{"bob", "carol"}, doc.Mentions)
+}
+
 // Never-edited messages must omit editedAt/updatedAt so index entries stay
 // compact for the common case.
 func TestNewMessageSearchIndex_EditedUpdatedOmittedWhenNil(t *testing.T) {


### PR DESCRIPTION
## Summary

Add filter dimensions to the message and room search RPCs so the client can filter by
room, sender, date range, attachment presence, sender name, and file type. File search
folds into the existing messages RPC via a `fileTypes` filter — **no new subject**. New
ES-indexed message-doc fields (`userName`, `fileTypes`, `mentions`) plus additive request
fields on the existing search RPCs. **No backfill** — old messages won't match the new
filter clauses.

> The `mentionedMe` filter was **deferred to a follow-up (#216)** — `@mentions` aren't
> resolved onto the canonical event yet (only message-worker resolves them, locally), so
> the filter would ship with no data to match. The `mentions` field is indexed here; the
> filter + the ingest fix land together in the follow-up.

## Changes

- `pkg/model/search.go`: `SearchMessagesRequest` +`senders`/`dateRange`/`hasAttachment`/`fileTypes`; `SearchMessage` +`userName`; `SearchRoomsRequest` +`members`; new `DateRange` type. `roomIds` stays a list (single-select sends a 1-element list — no breaking rename).
- `pkg/searchindex`: `MessageDoc`/`MessageFields` +`userName`/`fileTypes`/`mentions`; new MIME to category mapping (`image`/`pdf`/`excel`/`powerpoint`/`word`/`zip`/`others`).
- `search-sync-worker`: indexes `userName` (pre-composed display name), `mentions` (accounts), `fileTypes` (each attachment's MIME to category).
- `search-service`: new message filter clauses (senders to `terms userAccount`, dateRange to `range createdAt`, hasAttachment to `exists fileTypes`, fileTypes to `terms fileTypes`); `userName` added to the free-text match fields; room `members` filter resolved to rooms via the user-scoped `subscription.getChannels` RPC (on the requester's own account subject); the `query is required` guard relaxed for room search when `members` is set; `userName` threaded into the response.
- ES message-doc mapping updated for the new fields (auto-applied on template update). No Cassandra / Mongo change.
- `docs/client-api.md` + derived `docs/client-api/request-reply.md` updated.

## NATS subjects

No new subject. Additive request fields on the existing `search.{siteID}.messages` and
`search.{siteID}.rooms` RPCs; room search additionally calls the existing
`user.{siteID}.subscription.getChannels`.

## Verification

golangci-lint clean; unit tests across all touched packages green — query builders per new
clause + combined, MIME to category mapping (each category incl. zip + the `others`
fallback), `MessageDoc` round-trip, sync-worker field mapping, room `members` + empty-query.
The six shipping filters were also verified end-to-end on our dev stack against live
Elasticsearch.

Refs #191

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Search messages by sender name, sender, date range, attachment presence, and file type.
  - Message results may include the sender’s display name.
  - Search rooms by members, even without entering a text query.
  - File searches are supported through message search, including categorized attachment types.

- **Documentation**
  - Updated search API documentation with new filters, validation rules, examples, and response fields.
  - Clarified that room searches require a query or member filter, and invalid room types are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->