### PR TITLE
feat(chatlist): Favorites becomes a manually move-managed section

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -2100,6 +2100,8 @@ See [Error envelope](#6-error-envelope-reference). Common errors:
 
 Synchronous RPC. `room-service` flips `Subscription.favorite` for the requester in a single atomic Mongo `FindOneAndUpdate`, replies with the resulting value, and fans out a `subscription.update` event to the user's other client sessions. Used by the client to render the per-user "favorited" sidebar section; backend treats the flag as a render hint only — no downstream behaviour (notifications, routing, retention) is gated on it.
 
+Favorites membership is also manually orderable via [Move Chat to Section](#move-chat-to-section) (`sectionId: "favorites"`) — the two RPCs stay in sync: toggling favorite **off** also clears `sectionId`/`sectionOrder` when they were `"favorites"` (toggling **on** leaves any existing `sectionId` alone); moving a chat **into** `"favorites"` sets `favorite: true`, moving it to any other section (or removing it) sets `favorite: false`. Clients keep reading membership from `favorite`, unchanged.
+
 Idempotency: this is a toggle, not a set — every successful call flips the bit. Clients must debounce the user-visible action; redelivery of the same RPC will flip back.
 
 ##### Request body
@@ -2156,7 +2158,7 @@ Synchronous RPC. Assigns a chat to a custom chatlist section and sets its manual
 
 | Field | Type | Notes |
 |---|---|---|
-| `sectionId` | string \| null | The custom section to move the chat into. `null` (explicit JSON `null`) **or omitting the field entirely** both remove it from its section (falls back to a derived built-in) — the two are indistinguishable at the wire layer and handled identically. A **built-in** id (`favorites`/`apps`/`teams`/`chats`) is rejected — built-in membership is derived, not user-set. |
+| `sectionId` | string \| null | The custom section to move the chat into, or `"favorites"`. `null` (explicit JSON `null`) **or omitting the field entirely** both remove it from its section (falls back to a derived built-in, and clears `favorite` if it was set) — the two are indistinguishable at the wire layer and handled identically. The other built-in ids (`apps`/`teams`/`chats`) are rejected — their membership is derived, not user-set. `favorites` is the one built-in target: moving in sets `Subscription.favorite = true` (mirroring [Toggle Favorite](#toggle-favorite)); moving to any other section sets it `false`. |
 | `afterRoomId` | string | Optional. Place the chat just after this room within the section. Omit to append at the end. Mutually exclusive with `beforeRoomId`. |
 | `beforeRoomId` | string | Optional. Place the chat just before this room within the section (top-insertion when it is the section head). Mutually exclusive with `afterRoomId`. |
 
@@ -2176,7 +2178,7 @@ Synchronous RPC. Assigns a chat to a custom chatlist section and sets its manual
 
 See [Error envelope](#6-error-envelope-reference). Common errors:
 
-- reason `chatlist_builtin_target` — `sectionId` is a built-in section.
+- reason `chatlist_builtin_target` — `sectionId` is a built-in section other than `favorites`.
 - reason `chatlist_section_not_found` — `sectionId` is empty.
 - `"only room members can list members"` — the user has no subscription in the room.
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -620,7 +620,10 @@ clients must debounce. No request body required.
 **Reply:** auto-generated `_INBOX.>` (NATS request/reply)
 
 Synchronous RPC. Flips `Subscription.favorite`. Every successful call toggles the bit —
-clients must debounce. No request body required.
+clients must debounce. No request body required. Also orderable via
+[Move Chat to Section](#move-chat-to-section) (`sectionId: "favorites"`) — the two stay in
+sync: toggling off clears `sectionId`/`sectionOrder` if they were `"favorites"`; toggling on
+leaves any existing `sectionId` alone.
 
 #### Success response
 
@@ -650,7 +653,7 @@ mirroring favorite. Full detail + read model: [Chatlist Sections](../client-api.
 
 | Field | Type | Notes |
 |---|---|---|
-| `sectionId` | string \| null | Custom section to move into; `null` or omitting the field both remove it (indistinguishable at the wire layer). A built-in id (`favorites`/`apps`/`teams`/`chats`) is rejected. |
+| `sectionId` | string \| null | Custom section to move into, or `"favorites"`; `null` or omitting the field both remove it (indistinguishable at the wire layer) and clear `favorite` too. The other built-in ids (`apps`/`teams`/`chats`) are rejected. Moving into `"favorites"` sets `Subscription.favorite = true`; moving elsewhere sets it `false`. |
 | `afterRoomId` | string | Optional. Place just after this room; omit to append. Mutually exclusive with `beforeRoomId`. |
 | `beforeRoomId` | string | Optional. Place just before this room (top-insertion at the section head). Mutually exclusive with `afterRoomId`. |
 

--- a/docs/superpowers/plans/2026-08-09-favorites-managed-section.md
+++ b/docs/superpowers/plans/2026-08-09-favorites-managed-section.md
@@ -1,0 +1,94 @@
+# Favorites becomes a manually move-managed section
+
+Shape A2: `moveChat` accepts `sectionId: "favorites"` as a valid target (the one
+built-in exception), so favorites gets manual ordering (`sectionOrder` /
+`afterRoomId` / `beforeRoomId`) via the existing chat-move RPC instead of only the
+favorite-toggle bit. Membership stays FE-derived from `Subscription.favorite`;
+`sectionId`/`favorite` are kept mirrored in both write paths (moveChat,
+favorite.toggle) and both directions of cross-site replication.
+
+## 7-segment trace
+
+1. **Client request + `docs/client-api.md`** — no new field on `MoveChatRequest`.
+   Doc change only: `favorites` documented as a valid `sectionId` target for
+   `chat.move`, and the favorite-flag interaction on both `favorite.toggle` and
+   `chat.move`. Derived views (`docs/client-api/request-reply.md`) synced by hand.
+2. **Gatekeeper** — N/A (room-service owns both RPCs directly; no gatekeeper hop
+   for chat.move / favorite.toggle).
+3. **Canonical model / events** — no new event type. `SubscriptionSectionMovedEvent`
+   (unchanged shape: `account`, `roomId`, `sectionId`, `sectionOrder`, `timestamp`)
+   is reused; the remote inbox-worker derives the favorite mirror from
+   `sectionId == "favorites"` itself rather than the event carrying a new field.
+   Same for `SubscriptionFavoriteToggledEvent` (unchanged) — the remote mirror now
+   also clears `sectionId` server-side when favorite goes false and the stored
+   `sectionId` is `"favorites"`.
+4. **Workers** — `inbox-worker.handleSubscriptionSectionMoved` (mirrors favorite
+   on/off) and `handleSubscriptionFavoriteToggled` (mirrors the section clear) —
+   both change; no new handler.
+5. **Storage** — Mongo `subscriptions` collection:
+   - `room-service` `MoveSubscriptionSection` (origin write) now also sets
+     `favorite` (true iff target is `"favorites"`, false otherwise incl. remove).
+   - `room-service` `ToggleSubscriptionFavorite` (origin write) now also clears
+     `sectionId`/`sectionOrder` via an aggregation-pipeline `$cond` when turning
+     favorite off and the stored section was `"favorites"`.
+   - `inbox-worker` `mongoInboxStore.UpdateSubscriptionSection` and
+     `UpdateSubscriptionFavorite` mirror both of the above on the remote replica.
+   - No new index — the existing `{u.account, sectionId, sectionOrder}` section
+     index already covers `sectionId == "favorites"` rows.
+6. **Read/history path** — N/A (chatlist read model is unchanged; favorites
+   membership is still derived client-side from `favorite`, ordering from
+   `sectionOrder` when the section's `sortMode == "custom"`, same as any other
+   section).
+7. **Client-facing events** — `subscription.update` (`action: "section_moved"` /
+   `"favorite_toggled"`) already fans out the full post-write `Subscription`
+   document, so `favorite` + `sectionId` land together in one event with no
+   extra publish.
+
+## Gate: moveChat built-in check
+
+`room-service/handler.go` `moveChat` rejected every `model.IsBuiltinSection` id.
+Now: `model.IsBuiltinSection(*req.SectionID) && *req.SectionID != model.SectionFavorites`
+— favorites is the one built-in that's a valid manual target; apps/teams/chats stay
+rejected (their membership has no manual axis).
+
+## favorite.toggle ⇄ chat.move reconciliation
+
+- Move **into** favorites (`chat.move` with `sectionId: "favorites"`) → sets
+  `favorite: true` **and** `sectionId: "favorites"` + a normal `sectionOrder`
+  (append/insert via the existing `ComputeSectionOrder`/`RebalanceSection` path —
+  favorites is just another section id for ordering purposes).
+- Move **out** of favorites (`chat.move` to any other section, or a remove /
+  `sectionId: null`) → sets `favorite: false`.
+- **Toggle ON** (`favorite.toggle`) → leaves `sectionId` untouched. Membership is
+  already satisfied by the flag; a bare toggle doesn't imply a manual order, so it
+  doesn't force the chat into the ordered set. Un-ambiguous: the flag alone is
+  sufficient for FE membership rendering (per acceptance).
+- **Toggle OFF** (`favorite.toggle`) → also clears `sectionId`/`sectionOrder` when
+  they were `"favorites"`. Rationale: `favorite.toggle` off is meant to "unfavorite
+  and remove it from the section" — leaving a stale `sectionId: "favorites"` on a
+  now-unfavorited row would let the manual section resurrect the chat under
+  favorites without a value that says why, and would violate "favorite==true ⇔
+  sectionId=='favorites'" (the doc'd invariant this PR maintains). Implemented
+  atomically via an aggregation-pipeline `$set`/`$cond` in `ToggleSubscriptionFavorite`
+  (origin) and mirrored on the remote replica in `UpdateSubscriptionFavorite`
+  (inbox-worker) so both sites converge to the same shape without a race window.
+  This closes what would otherwise be a real cross-site divergence gap rather than
+  leaving it as a documented ceiling — the extra `$cond` clause is a handful of
+  lines and reuses the section index already in place, so there's no reason to skip
+  it here.
+- **Rejected alternative:** keep `sectionId` set after an unfavorite (i.e. only the
+  flag governs membership, `sectionId` is "sticky"). Rejected because it lets a
+  re-favorite later silently resurrect the OLD manual position instead of a fresh
+  append, which is surprising and undocumented — and it would mean `sectionId`
+  can point at `"favorites"` while `favorite == false`, breaking the invariant the
+  acceptance criteria states explicitly ("kept in sync").
+
+## Cross-site consistency
+
+Both `chat.move`→favorites and `favorite.toggle`→off reconcile `sectionId`/
+`favorite` **on the origin write**. The existing federation events
+(`SubscriptionSectionMovedEvent`, `SubscriptionFavoriteToggledEvent`) already carry
+enough information (`sectionId` for the move event; the toggle event's `Account`/
+`RoomID` for the favorite event, which the inbox-worker resolves against the
+*locally stored* `sectionId`) for the remote inbox-worker to reconstruct the same
+mirror without a new event field — see segment 3/4/5 above.

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -282,7 +282,8 @@ func (s *mongoInboxStore) UpdateSubscriptionMute(ctx context.Context, roomID, ac
 // UpdateSubscriptionFavorite sets favorite by (roomID, account) under a
 // favoriteUpdatedAt guard so an out-of-order or duplicate toggle cannot regress
 // favorite state. Missing-sub and guard-rejected events both leave MatchedCount
-// 0 and are silent no-ops.
+// 0 and are silent no-ops. Mirrors the origin toggle's section clear: turning
+// favorite off also drops sectionId/sectionOrder when they're "favorites".
 func (s *mongoInboxStore) UpdateSubscriptionFavorite(ctx context.Context, roomID, account string, favorite bool, favoriteUpdatedAt time.Time) error {
 	filter := bson.M{
 		"roomId":    roomID,
@@ -292,7 +293,14 @@ func (s *mongoInboxStore) UpdateSubscriptionFavorite(ctx context.Context, roomID
 			bson.M{"favoriteUpdatedAt": bson.M{"$lt": favoriteUpdatedAt}},
 		},
 	}
-	update := bson.M{"$set": bson.M{"favorite": favorite, "favoriteUpdatedAt": favoriteUpdatedAt}}
+	set := bson.M{"favorite": favorite, "favoriteUpdatedAt": favoriteUpdatedAt}
+	var update any = bson.M{"$set": set}
+	if !favorite {
+		clearFavSection := bson.M{"$eq": bson.A{"$sectionId", model.SectionFavorites}}
+		set["sectionId"] = bson.M{"$cond": bson.A{clearFavSection, "$$REMOVE", "$sectionId"}}
+		set["sectionOrder"] = bson.M{"$cond": bson.A{clearFavSection, "$$REMOVE", "$sectionOrder"}}
+		update = mongo.Pipeline{bson.D{{Key: "$set", Value: set}}}
+	}
 	res, err := s.subCol.UpdateOne(ctx, filter, update)
 	if err != nil {
 		return fmt.Errorf("update subscription favorite for %q in room %q: %w", account, roomID, err)
@@ -306,7 +314,9 @@ func (s *mongoInboxStore) UpdateSubscriptionFavorite(ctx context.Context, roomID
 // UpdateSubscriptionSection sets sectionId+sectionOrder (or clears both when
 // sectionID==nil, a remove) by (roomID, account) under a sectionUpdatedAt guard so
 // an out-of-order or duplicate move cannot regress. A guard-rejected event is a
-// silent no-op; a missing sub NAKs so it retries after the sub replicates.
+// silent no-op; a missing sub NAKs so it retries after the sub replicates. Mirrors
+// favorite alongside, same as the origin write: true only when sectionID ==
+// "favorites", false otherwise (including a remove).
 func (s *mongoInboxStore) UpdateSubscriptionSection(ctx context.Context, roomID, account string, sectionID *string, order float64, updatedAt time.Time) error {
 	filter := bson.M{
 		"roomId":    roomID,
@@ -319,11 +329,17 @@ func (s *mongoInboxStore) UpdateSubscriptionSection(ctx context.Context, roomID,
 	var update bson.M
 	if sectionID == nil {
 		update = bson.M{
-			"$set":   bson.M{"sectionUpdatedAt": updatedAt},
+			"$set":   bson.M{"sectionUpdatedAt": updatedAt, "favorite": false, "favoriteUpdatedAt": updatedAt},
 			"$unset": bson.M{"sectionId": "", "sectionOrder": ""},
 		}
 	} else {
-		update = bson.M{"$set": bson.M{"sectionId": *sectionID, "sectionOrder": order, "sectionUpdatedAt": updatedAt}}
+		update = bson.M{"$set": bson.M{
+			"sectionId":         *sectionID,
+			"sectionOrder":      order,
+			"sectionUpdatedAt":  updatedAt,
+			"favorite":          *sectionID == model.SectionFavorites,
+			"favoriteUpdatedAt": updatedAt,
+		}}
 	}
 	res, err := s.subCol.UpdateOne(ctx, filter, update)
 	if err != nil {

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -2226,7 +2226,9 @@ func (h *Handler) favoriteToggle(c *natsrouter.Context) (*model.FavoriteToggleRe
 // favorite.toggle: one sub write + one subscription-update fanout + one cross-site
 // federation event, HWM-guarded by sectionUpdatedAt. Built-in section ids are
 // rejected — their membership is derived client-side (the migration-only "teams"
-// stamp is written directly at the sub-create, not via this RPC).
+// stamp is written directly at the sub-create, not via this RPC) — EXCEPT
+// favorites, which is manually move-managed: moving into it sets
+// subscription.favorite (store.MoveSubscriptionSection mirrors the flag).
 func (h *Handler) moveChat(c *natsrouter.Context, req model.MoveChatRequest) (*model.MoveChatResponse, error) { //nolint:gocritic // hugeParam: req is passed by value to satisfy the natsrouter.Register handler signature
 	var ctx context.Context = c
 	account := c.Param("account")
@@ -2236,11 +2238,12 @@ func (h *Handler) moveChat(c *natsrouter.Context, req model.MoveChatRequest) (*m
 		if *req.SectionID == "" {
 			return nil, errcode.BadRequest("sectionId is empty", errcode.WithReason(errcode.UserChatlistSectionNotFound))
 		}
-		if model.IsBuiltinSection(*req.SectionID) {
+		if model.IsBuiltinSection(*req.SectionID) && *req.SectionID != model.SectionFavorites {
 			// static built-in check only. A custom section's *existence*
 			// is not verified here (that would couple room-service to the
 			// user-service registry on every move) — orphan tolerance renders an
-			// unknown sectionId under Chats client-side.
+			// unknown sectionId under Chats client-side. Favorites is the one
+			// built-in that's a valid moveChat target (see func comment).
 			return nil, errcode.BadRequest("cannot move a chat into a built-in section", errcode.WithReason(errcode.UserChatlistBuiltinTarget))
 		}
 		if req.AfterRoomID != "" && req.BeforeRoomID != "" {

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -6075,6 +6075,49 @@ func TestHandler_FavoriteToggle_CorePublishFailureIsNonFatal(t *testing.T) {
 // needRebalance path: RebalanceSection renumbers every sibling in the
 // section, so moveChat must fan out one section_moved subscription.update
 // (+ cross-site federation event) per rewritten row, not just the moved one.
+// TestHandler_MoveChat_RejectsNonFavoriteBuiltin locks the moveChat gate: every
+// built-in EXCEPT favorites is still rejected before any store call.
+func TestHandler_MoveChat_RejectsNonFavoriteBuiltin(t *testing.T) {
+	for _, id := range []string{model.SectionApps, model.SectionTeams, model.SectionChats} {
+		t.Run(id, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			store := NewMockRoomStore(ctrl) // no EXPECT() calls: must reject before touching the store
+			h := &Handler{store: store, siteID: "site-a"}
+
+			sectionID := id
+			_, err := h.moveChat(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.MoveChatRequest{SectionID: &sectionID})
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestHandler_MoveChat_AllowsFavorites is the mirror: "favorites" is a built-in
+// id but must pass the gate and reach the normal store path like any custom
+// section (favorite-flag mirroring itself lives in the store layer).
+func TestHandler_MoveChat_AllowsFavorites(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockRoomStore(ctrl)
+
+	store.EXPECT().
+		ComputeSectionOrder(gomock.Any(), "alice", model.SectionFavorites, "", "").
+		Return(1.0, false, nil)
+	store.EXPECT().
+		MoveSubscriptionSection(gomock.Any(), "r1", "alice", gomock.Any(), 1.0, gomock.Any()).
+		Return(&model.Subscription{User: model.SubscriptionUser{ID: "u1", Account: "alice"}, RoomID: "r1", SiteID: "site-a", SectionId: strPtr(model.SectionFavorites), SectionOrder: 1, Favorite: true}, nil)
+	store.EXPECT().GetUserSiteID(gomock.Any(), "alice").Return("site-a", nil)
+
+	h := &Handler{
+		store: store, siteID: "site-a",
+		publishCore: func(context.Context, string, []byte) error { return nil },
+	}
+
+	sectionID := model.SectionFavorites
+	resp, err := h.moveChat(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), model.MoveChatRequest{SectionID: &sectionID})
+	require.NoError(t, err)
+	require.NotNil(t, resp.SectionID)
+	assert.Equal(t, model.SectionFavorites, *resp.SectionID)
+}
+
 func TestHandler_MoveChat_Rebalance_PublishesAndFederatesAllRows(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockRoomStore(ctrl)

--- a/room-service/store.go
+++ b/room-service/store.go
@@ -133,13 +133,17 @@ type RoomStore interface {
 	ToggleSubscriptionMute(ctx context.Context, roomID, account string, muteUpdatedAt time.Time) (*model.Subscription, error)
 	// ToggleSubscriptionFavorite atomically flips favorite via a single FindOneAndUpdate,
 	// stamping favoriteUpdatedAt so the origin doc carries the same high-water mark the
-	// federated event publishes (inbox-worker guards remote applies against it).
+	// federated event publishes (inbox-worker guards remote applies against it). Toggling
+	// OFF also clears sectionId/sectionOrder when they were "favorites".
 	// Returns the post-flip subscription, or model.ErrSubscriptionNotFound (wrapped) when no match.
 	ToggleSubscriptionFavorite(ctx context.Context, roomID, account string, favoriteUpdatedAt time.Time) (*model.Subscription, error)
 	// MoveSubscriptionSection sets sectionId+sectionOrder (or clears both when
 	// sectionID==nil, a remove) on (roomID, account), stamping sectionUpdatedAt as
-	// the high-water mark the federated event carries. Returns the post-write
-	// subscription, or model.ErrSubscriptionNotFound (wrapped) when no match.
+	// the high-water mark the federated event carries. Also mirrors
+	// subscription.favorite: true when sectionID == "favorites", false otherwise
+	// (including a remove) — favorites membership stays derived from the flag.
+	// Returns the post-write subscription, or model.ErrSubscriptionNotFound
+	// (wrapped) when no match.
 	MoveSubscriptionSection(ctx context.Context, roomID, account string, sectionID *string, order float64, sectionUpdatedAt time.Time) (*model.Subscription, error)
 	// ComputeSectionOrder returns the fractional sectionOrder for placing (account's)
 	// chat within sectionID: just after afterRoomID, just before beforeRoomID (for

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -1143,30 +1143,42 @@ func (s *MongoStore) ToggleSubscriptionMute(ctx context.Context, roomID, account
 // ToggleSubscriptionFavorite flips favorite. $ifNull treats an absent field as
 // false so legacy docs toggle to true on first call. favoriteUpdatedAt is stamped
 // from the same instant the caller publishes as the event timestamp, keeping the
-// origin doc and every federated replica on one high-water mark.
+// origin doc and every federated replica on one high-water mark. Toggling OFF also
+// clears sectionId/sectionOrder when they were "favorites" (moveChat's manual
+// section membership follows the flag); toggling ON leaves sectionId alone.
 func (s *MongoStore) ToggleSubscriptionFavorite(ctx context.Context, roomID, account string, favoriteUpdatedAt time.Time) (*model.Subscription, error) {
+	turningOff := bson.M{"$and": bson.A{
+		bson.M{"$eq": bson.A{bson.M{"$ifNull": bson.A{"$favorite", false}}, true}},
+		bson.M{"$eq": bson.A{"$sectionId", model.SectionFavorites}},
+	}}
 	return s.findOneAndUpdateSub(ctx, roomID, account, "toggle favorite", bson.M{
 		"favorite":          bson.M{"$not": bson.A{bson.M{"$ifNull": bson.A{"$favorite", false}}}},
 		"favoriteUpdatedAt": favoriteUpdatedAt,
+		"sectionId":         bson.M{"$cond": bson.A{turningOff, "$$REMOVE", "$sectionId"}},
+		"sectionOrder":      bson.M{"$cond": bson.A{turningOff, "$$REMOVE", "$sectionOrder"}},
 	})
 }
 
 // MoveSubscriptionSection sets sectionId+sectionOrder (sectionID != nil) or clears
 // both (sectionID == nil, a remove) on one subscription, stamping sectionUpdatedAt
 // as the high-water mark. Classic update (not the $set pipeline) so a remove can
-// $unset. Returns the post-write sub or model.ErrSubscriptionNotFound (wrapped).
+// $unset. favorite is mirrored alongside: true only when sectionID == "favorites",
+// false otherwise (a remove un-favorites too) — see model.SectionFavorites.
+// Returns the post-write sub or model.ErrSubscriptionNotFound (wrapped).
 func (s *MongoStore) MoveSubscriptionSection(ctx context.Context, roomID, account string, sectionID *string, order float64, sectionUpdatedAt time.Time) (*model.Subscription, error) {
 	var update bson.M
 	if sectionID == nil {
 		update = bson.M{
-			"$set":   bson.M{"sectionUpdatedAt": sectionUpdatedAt},
+			"$set":   bson.M{"sectionUpdatedAt": sectionUpdatedAt, "favorite": false, "favoriteUpdatedAt": sectionUpdatedAt},
 			"$unset": bson.M{"sectionId": "", "sectionOrder": ""},
 		}
 	} else {
 		update = bson.M{"$set": bson.M{
-			"sectionId":        *sectionID,
-			"sectionOrder":     order,
-			"sectionUpdatedAt": sectionUpdatedAt,
+			"sectionId":         *sectionID,
+			"sectionOrder":      order,
+			"sectionUpdatedAt":  sectionUpdatedAt,
+			"favorite":          *sectionID == model.SectionFavorites,
+			"favoriteUpdatedAt": sectionUpdatedAt,
 		}}
 	}
 	opts := options.FindOneAndUpdate().SetReturnDocument(options.After)


### PR DESCRIPTION
## Summary

Favorites becomes a manually move-managed section: `chat.move` now accepts
`sectionId: "favorites"` (the one built-in exception — `apps`/`teams`/`chats` stay
rejected), so a favorited chat can be manually ordered like any custom section.
`favorite.toggle` and `chat.move` stay reconciled in both directions, and both
replication paths (origin + cross-site) mirror the flag. FE membership is
unchanged — it still reads only `Subscription.favorite`.

## What's included

- `moveChat`: `sectionId == "favorites"` passes the built-in gate; the other
  built-ins are still rejected.
- Moving a chat **into** `favorites` sets `favorite: true` and `sectionId` +
  `sectionOrder` via the existing `ComputeSectionOrder`/`RebalanceSection` path.
  Moving it to any other section, or removing it, sets `favorite: false`.
- `favorite.toggle` **off** also clears `sectionId`/`sectionOrder` when they were
  `"favorites"` (atomic aggregation-pipeline update); toggle **on** leaves
  `sectionId` untouched.
- Cross-site mirrors added in `inbox-worker` for both paths, so a remote replica
  converges to the same `favorite`/`sectionId` shape as the origin write.
- `docs/client-api.md` + `docs/client-api/request-reply.md` updated to document
  `favorites` as a valid `chat.move` target and the flag interaction.
- Design doc: `docs/superpowers/plans/2026-08-09-favorites-managed-section.md`.

## Changes

- `room-service/handler.go` — `moveChat` built-in gate now excepts `favorites`.
- `room-service/store.go`, `room-service/store_mongo.go` — `MoveSubscriptionSection`
  mirrors `favorite`; `ToggleSubscriptionFavorite` clears `sectionId`/`sectionOrder`
  on toggle-off via an aggregation-pipeline `$cond`.
- `inbox-worker/main.go` — `UpdateSubscriptionSection` mirrors `favorite`;
  `UpdateSubscriptionFavorite` mirrors the section clear on toggle-off.
- `room-service/handler_test.go` — gate tests: favorites allowed, other
  built-ins still rejected.

## Verification

- `go vet ./room-service/... ./inbox-worker/... ./user-service/... ./pkg/model/...`
  and `go vet -tags integration` (same set) both clean.
- `golangci-lint` (repo-pinned) clean, 0 issues.
- `go test ./room-service/... ./inbox-worker/... ./user-service/... ./pkg/model/...`
  green.

🤖 Generated with Claude Code
