### PR TITLE
feat(threadcount): drop the 99 cap 

### DIFF
--- a/docs/cassandra_message_model.md
+++ b/docs/cassandra_message_model.md
@@ -143,7 +143,7 @@ CREATE TABLE IF NOT EXISTS messages_by_room(
   sender FROZEN<"Participant">,
   site_id TEXT,
   sys_msg_data BLOB,
-  tcount INT, // bounded non-deleted thread reply count, capped at 99 (pkg/threadcount.Cap); FE renders >= 99 as "99+"
+  tcount INT, // exact non-deleted thread reply count (pkg/threadcount)
   thread_last_msg_at TIMESTAMP, // timestamp of most recent thread reply; null until first reply
   thread_parent_created_at TIMESTAMP, // for FE to query thread parent message when also sent to channel (tshow=true)
   thread_parent_id TEXT,
@@ -258,7 +258,7 @@ CREATE TABLE IF NOT EXISTS messages_by_id(
   sender FROZEN<"Participant">,
   site_id TEXT,
   sys_msg_data BLOB,
-  tcount INT, // bounded non-deleted thread reply count, capped at 99 (pkg/threadcount.Cap); FE renders >= 99 as "99+"
+  tcount INT, // exact non-deleted thread reply count (pkg/threadcount)
   thread_last_msg_at TIMESTAMP, // timestamp of most recent thread reply; null until first reply
   thread_parent_created_at TIMESTAMP,
   thread_parent_id TEXT,

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -2804,7 +2804,7 @@ Used by every history-service method that returns messages. Mirrors the Cassandr
 | `card` | [MessageCard](#messagecard) | Optional. |
 | `cardAction` | [MessageCardAction](#messagecardaction) | Optional. |
 | `tshow` | boolean | Optional. Whether a thread reply is also shown in the parent room. |
-| `tcount` | number | Optional. Number of non-deleted replies on a thread parent, capped at 99; a value of 99 means "99 or more". |
+| `tcount` | number | Optional. Exact number of non-deleted replies on a thread parent. |
 | `threadLastMsgAt` | string (ISO 8601) | Optional. Timestamp of the most recent reply in the thread. Absent if no replies or not a thread parent. |
 | `threadParentId` | string | Optional. Set when this message is a thread reply. |
 | `threadParentCreatedAt` | string | Optional. RFC 3339. |
@@ -5493,7 +5493,7 @@ Returns the user's thread subscriptions across **all sites** as one globally-ord
 | `hasMention` | boolean | The user was @-mentioned in the thread. |
 | `unread` | boolean | `true` when `lastMsgAt` is newer than `lastSeenAt` (or the thread was never opened). |
 | `lastMsgAt` | number | UTC ms of the thread's last activity — the global sort key. |
-| `tcount` | number | Non-deleted reply count, capped at 99 — `99` means "99 or more". Always present; `0` also covers threads whose count was never written — migrated threads, and briefly a just-created thread whose first reply has not yet been counted. During a mixed-version rollout, rows from a not-yet-upgraded site read `0` (their leaf omits the field), and the key is absent entirely behind a not-yet-upgraded aggregator. |
+| `tcount` | number | Exact non-deleted reply count. Always present; `0` also covers threads whose count was never written — migrated threads, and briefly a just-created thread whose first reply has not yet been counted. During a mixed-version rollout, rows from a not-yet-upgraded site read `0` (their leaf omits the field), and the key is absent entirely behind a not-yet-upgraded aggregator. |
 | `parentMessage` | [Message](#message-schema) | Optional. The hydrated parent message. |
 | `lastMessage` | [Message](#message-schema) | Optional. The hydrated last reply. |
 | `hrInfo` | [SubscriptionHRInfo](#subscriptionhrinfo) | Optional. Present **only on `dm` rows** — the counterpart's HR record, resolved from `roomName`. Omitted when the directory lookup degrades. |
@@ -6248,7 +6248,7 @@ Pushed by `broadcast-worker` whenever a thread reply is **created** (`action: "r
 | `roomId` | string | The room the thread lives in. |
 | `siteId` | string | |
 | `parentMessageId` | string | The thread parent message's ID. Clients use this to locate the message in their cache and update its badge. |
-| `newTcount` | number | Authoritative reply count for the parent message, capped at 99 (99 means "99 or more"). Replaces any locally-computed count — do not delta. |
+| `newTcount` | number | Authoritative exact reply count for the parent message. Replaces any locally-computed count — do not delta. |
 | `newThreadLastMsgAt` | string (ISO 8601) | Optional. Timestamp of the most recent surviving thread reply. Absent when `newTcount` is 0 (all replies deleted). |
 | `action` | string | `"reply_added"` or `"reply_deleted"`. |
 | `replyMessageId` | string | The reply that was added or deleted. |

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -662,7 +662,7 @@ independently.
 | `eventTimestamp` | number | Optional. Epoch ms (UTC). When message-worker published the canonical event. Prefer over `timestamp` for ordering. |
 | `parentMessageId` | string | The thread parent message's ID. Use to locate the message in your cache and update its badge. |
 | `replyMessageId` | string | The reply that was added or deleted. |
-| `newTcount` | number | Authoritative reply count for the parent message, capped at 99 (99 means "99 or more"). Apply directly — do not delta. |
+| `newTcount` | number | Authoritative exact reply count for the parent message. Apply directly — do not delta. |
 | `newThreadLastMsgAt` | string (ISO 8601) | Optional. Timestamp of the most recent surviving thread reply. Absent when `newTcount` is 0. |
 | `action` | string | `"reply_added"` or `"reply_deleted"`. |
 

--- a/history-service/internal/cassrepo/write.go
+++ b/history-service/internal/cassrepo/write.go
@@ -370,12 +370,11 @@ func (r *Repository) SoftDeleteMessage(ctx context.Context, msg *models.Message,
 	return deletedAt, true, newTcount, newTlm, nil
 }
 
-// countThreadReplies returns the bounded, soft-delete-aware reply count and the
+// countThreadReplies returns the exact, soft-delete-aware reply count and the
 // latest surviving reply's created_at (tlm; nil when none survive) for the
 // thread. It delegates to pkg/threadcount so this delete-path writer and the
-// message-worker add-path writer compute an identical, identically-capped count
-// (see pkg/threadcount.Cap). tlm is the newest survivor — the partition's DESC
-// clustering order surfaces it within the bounded scan.
+// message-worker add-path writer compute an identical count. tlm is the newest
+// survivor — the partition's DESC clustering order surfaces it first.
 func (r *Repository) countThreadReplies(ctx context.Context, threadRoomID string) (int, *time.Time, error) {
 	return threadcount.CountAndLatest(ctx, r.session, threadRoomID)
 }

--- a/history-service/internal/cassrepo/write_integration_test.go
+++ b/history-service/internal/cassrepo/write_integration_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hmchangw/chat/pkg/atrest"
 	cassmodel "github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/pkg/msgbucket"
-	"github.com/hmchangw/chat/pkg/threadcount"
 )
 
 func TestRepository_UpdateMessageContent_TopLevel(t *testing.T) {
@@ -1749,12 +1748,15 @@ func TestRepository_SoftDeleteMessage_TShowThreadReply(t *testing.T) {
 	assert.True(t, gotDeleted, "TShow reply soft-delete must propagate to the messages_by_room copy")
 }
 
-func TestRepository_countThreadReplies_CapsAtThreadcountCap(t *testing.T) {
+// A thread well past the old 99 ceiling counts exactly, and tlm is still the
+// newest reply — the DESC clustering order surfaces it first.
+func TestRepository_countThreadReplies_LongThreadExact(t *testing.T) {
 	ctx := context.Background()
 	session := setupCassandra(t)
 
+	const replies = 150
 	base := time.Now().UTC()
-	for i := 0; i < threadcount.Cap+10; i++ {
+	for i := 0; i < replies; i++ {
 		require.NoError(t, session.Query(
 			`INSERT INTO thread_messages_by_thread (thread_room_id, created_at, message_id) VALUES (?, ?, ?)`,
 			"thread-1", base.Add(time.Duration(i)*time.Millisecond), fmt.Sprintf("reply-%d", i),
@@ -1764,10 +1766,8 @@ func TestRepository_countThreadReplies_CapsAtThreadcountCap(t *testing.T) {
 	repo := NewRepository(session, msgbucket.New(24*time.Hour), 10, nil)
 	n, tlm, err := repo.countThreadReplies(ctx, "thread-1")
 	require.NoError(t, err)
-	assert.Equal(t, threadcount.Cap, n)
-	// Even over Cap, tlm must be the newest reply — the DESC clustering order
-	// surfaces it first, so the bounded scan still observes the true maximum.
+	assert.Equal(t, replies, n)
 	require.NotNil(t, tlm)
-	newest := base.Add(time.Duration(threadcount.Cap+9) * time.Millisecond)
+	newest := base.Add(time.Duration(replies-1) * time.Millisecond)
 	assert.Equal(t, newest.UnixMilli(), tlm.UnixMilli())
 }

--- a/message-worker/integration_test.go
+++ b/message-worker/integration_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/pkg/msgbucket"
 	"github.com/hmchangw/chat/pkg/testutil"
-	"github.com/hmchangw/chat/pkg/threadcount"
 	"github.com/hmchangw/chat/pkg/userstore"
 )
 
@@ -2025,12 +2024,15 @@ func TestCassandraStore_SaveThreadMessage_TShowPersistedInThread(t *testing.T) {
 	})
 }
 
-func TestCassandraStore_countThreadReplies_CapsAtThreadcountCap(t *testing.T) {
+// A thread well past the old 99 ceiling counts exactly — the add path reports
+// the true reply total, not a badge value.
+func TestCassandraStore_countThreadReplies_LongThreadExact(t *testing.T) {
 	ctx := context.Background()
 	cassSession := setupCassandra(t)
 
+	const replies = 150
 	base := time.Now().UTC()
-	for i := 0; i < threadcount.Cap+10; i++ {
+	for i := 0; i < replies; i++ {
 		require.NoError(t, cassSession.Query(
 			`INSERT INTO thread_messages_by_thread (thread_room_id, created_at, message_id) VALUES (?, ?, ?)`,
 			"thread-1", base.Add(time.Duration(i)*time.Millisecond), fmt.Sprintf("reply-%d", i),
@@ -2040,7 +2042,7 @@ func TestCassandraStore_countThreadReplies_CapsAtThreadcountCap(t *testing.T) {
 	store := NewCassandraStore(cassSession, msgbucket.New(24*time.Hour), nil)
 	n, err := store.countThreadReplies(ctx, "thread-1")
 	require.NoError(t, err)
-	assert.Equal(t, threadcount.Cap, n)
+	assert.Equal(t, replies, n)
 }
 
 func TestAdvanceThreadSubscriptionLastSeen_OnlyAdvances(t *testing.T) {

--- a/message-worker/store_cassandra.go
+++ b/message-worker/store_cassandra.go
@@ -326,10 +326,9 @@ func buildCassandraMessage(msg *model.Message) cassandra.Message {
 	return cm
 }
 
-// countThreadReplies returns the bounded, soft-delete-aware reply count for the
+// countThreadReplies returns the exact, soft-delete-aware reply count for the
 // thread. It delegates to pkg/threadcount so this add-path writer and the
-// history-service delete-path writer compute an identical, identically-capped
-// value (see pkg/threadcount.Cap).
+// history-service delete-path writer compute an identical value.
 func (s *CassandraStore) countThreadReplies(ctx context.Context, threadRoomID string) (int, error) {
 	return threadcount.Count(ctx, s.cassSession, threadRoomID)
 }

--- a/pkg/model/threadlist.go
+++ b/pkg/model/threadlist.go
@@ -22,8 +22,8 @@ type ThreadListItem struct {
 	// key for the inbox. Reply count is surfaced as TCount below.
 	LastMsgAt int64 `json:"lastMsgAt" bson:"lastMsgAt"`
 
-	// TCount is the parent's non-deleted reply count, capped at pkg/threadcount.Cap
-	// (99 = "99 or more"). Always serialized; 0 when the column was never written.
+	// TCount is the parent's exact non-deleted reply count. Always serialized;
+	// 0 when the column was never written.
 	TCount int `json:"tcount" bson:"tcount"`
 
 	// Hydrated message bodies, subject to the thread access window. Carried opaque:

--- a/pkg/threadcount/count.go
+++ b/pkg/threadcount/count.go
@@ -1,11 +1,6 @@
-// Package threadcount derives the thread reply-count badge (tcount) from the
-// Cassandra thread_messages_by_thread partition. Counting stops at Cap, so the
-// per-write cost is bounded to ~Cap surviving rows (plus any soft-deleted rows
-// clustered ahead of them) rather than the whole partition. message-worker
-// (reply-add path) uses Count; history-service (reply-delete path) uses
-// CountAndLatest, which also returns the latest surviving reply's timestamp.
-// Both share the same Cap, so the two authoritative writers of tcount can never
-// compute different counts.
+// Package threadcount derives the exact thread reply count (tcount) from the
+// Cassandra thread_messages_by_thread partition. Shared by message-worker
+// (reply-add) and history-service (reply-delete) so the two writers can't diverge.
 package threadcount
 
 import (
@@ -16,43 +11,37 @@ import (
 	"github.com/gocql/gocql"
 )
 
-// Cap is the maximum value Count returns. A thread with more than Cap
-// non-deleted replies reports exactly Cap; the frontend renders tcount >= Cap as
-// "Cap+". 99 keeps virtually all real threads exact while bounding the per-write
-// partition read to ~Cap rows.
-const Cap = 99
+const (
+	// Rows per round trip (gocql pages by row count, not bytes) — bounds memory per
+	// fetch, not the total counted. Both projected columns are fixed-width.
+	cassPageSize = 5000
 
-// Count returns min(non-deleted replies in threadRoomID's partition, Cap).
-//
-// It is CountAndLatest without the latest-survivor timestamp — the add path
-// (message-worker) needs only the count. created_at is a clustering key, so
-// selecting it for the discarded timestamp adds no meaningful read cost, and
-// sharing one scan keeps the two writers' counts provably identical.
+	// Ceiling on a whole scan: above gocql's 10s per-round-trip timeout so a slow
+	// page still completes, below the 25s shutdown budget so it can't outlive shutdown.
+	scanTimeout = 15 * time.Second
+)
+
+// Count returns the number of non-deleted replies in threadRoomID's partition.
 func Count(ctx context.Context, session *gocql.Session, threadRoomID string) (int, error) {
 	n, _, err := CountAndLatest(ctx, session, threadRoomID)
 	return n, err
 }
 
-// CountAndLatest returns min(non-deleted replies in threadRoomID's partition,
-// Cap) and the created_at of the latest non-deleted reply (nil when none
-// survive), from a single bounded scan. The delete path (history-service) needs
-// both: removing a reply can change the count and the thread-last-message
-// timestamp (tlm).
-//
-// It scans thread_messages_by_thread in clustering order and stops once the
-// non-deleted tally reaches Cap, so the read materializes at most ~Cap rows
-// (plus any soft-deleted rows interspersed before them). No CQL LIMIT is used:
-// soft-deleted rows (deleted = true) live in the partition, so a hard LIMIT
-// could return Cap rows of which some are deleted and undercount the live total.
-// The deleted column may be NULL (message-worker does not write it on INSERT),
-// so NULL is treated as not-deleted. The partition's DESC clustering order
-// (created_at DESC) places the latest surviving reply first, so the bounded scan
-// still observes the true maximum created_at. session must have its Keyspace set.
+// CountAndLatest returns the exact non-deleted reply count and the latest surviving
+// reply's created_at (nil when none survive). Scans the full partition under
+// scanTimeout, so cost grows with thread length; session must have its Keyspace set.
 func CountAndLatest(ctx context.Context, session *gocql.Session, threadRoomID string) (int, *time.Time, error) {
+	// Backstop for an unbounded partition: no caller sets a deadline, and gocql's
+	// timeout is per round trip, not per scan. Only ever shortens a caller's ctx.
+	ctx, cancel := context.WithTimeout(ctx, scanTimeout)
+	defer cancel()
+
+	// No LIMIT/COUNT(*): soft-deleted rows live in the partition and must be
+	// walked past rather than counted.
 	iter := session.Query(
 		`SELECT deleted, created_at FROM thread_messages_by_thread WHERE thread_room_id = ?`,
 		threadRoomID,
-	).WithContext(ctx).PageSize(Cap).Iter()
+	).WithContext(ctx).PageSize(cassPageSize).Iter()
 
 	var (
 		deleted   *bool
@@ -60,7 +49,8 @@ func CountAndLatest(ctx context.Context, session *gocql.Session, threadRoomID st
 		latest    *time.Time
 	)
 	n := 0
-	for n < Cap && iter.Scan(&deleted, &createdAt) {
+	for iter.Scan(&deleted, &createdAt) {
+		// message-worker omits deleted on INSERT, so NULL means not-deleted.
 		if deleted == nil || !*deleted {
 			n++
 			if latest == nil || createdAt.After(*latest) {

--- a/pkg/threadcount/integration_test.go
+++ b/pkg/threadcount/integration_test.go
@@ -40,18 +40,25 @@ func setupThreadTable(t *testing.T) *gocql.Session {
 // seedReplies inserts count rows for threadRoomID. message_id is prefixed so two
 // calls in the same thread never collide on the (created_at, message_id) key.
 // deleted may be nil to mimic message-worker's INSERT, which never writes it.
+// Chunked UnloggedBatch: every row lands in the one partition, so this is a
+// single-partition write, and the paging tests seed thousands of rows.
 func seedReplies(t *testing.T, sess *gocql.Session, threadRoomID, idPrefix string, count int, deleted *bool) {
 	t.Helper()
+	const chunk = 100
 	base := time.Now().UTC()
-	for i := 0; i < count; i++ {
-		require.NoError(t, sess.Query(
-			`INSERT INTO thread_messages_by_thread (thread_room_id, created_at, message_id, deleted) VALUES (?, ?, ?, ?)`,
-			threadRoomID, base.Add(time.Duration(i)*time.Millisecond), fmt.Sprintf("%s-%d", idPrefix, i), deleted,
-		).Exec())
+	for start := 0; start < count; start += chunk {
+		batch := sess.NewBatch(gocql.UnloggedBatch)
+		for i := start; i < start+chunk && i < count; i++ {
+			batch.Query(
+				`INSERT INTO thread_messages_by_thread (thread_room_id, created_at, message_id, deleted) VALUES (?, ?, ?, ?)`,
+				threadRoomID, base.Add(time.Duration(i)*time.Millisecond), fmt.Sprintf("%s-%d", idPrefix, i), deleted,
+			)
+		}
+		require.NoError(t, sess.ExecuteBatch(batch))
 	}
 }
 
-func TestCount_UnderCap_Exact(t *testing.T) {
+func TestCount_ShortThread_Exact(t *testing.T) {
 	ctx := context.Background()
 	sess := setupThreadTable(t)
 	seedReplies(t, sess, "thread-1", "live", 5, nil)
@@ -61,14 +68,17 @@ func TestCount_UnderCap_Exact(t *testing.T) {
 	assert.Equal(t, 5, n)
 }
 
-func TestCount_OverCap_ReturnsCap(t *testing.T) {
+// A thread longer than one driver page is still counted exactly: the scan pages
+// to the end of the partition rather than stopping at any ceiling.
+func TestCount_LongerThanOnePage_ExactCount(t *testing.T) {
 	ctx := context.Background()
 	sess := setupThreadTable(t)
-	seedReplies(t, sess, "thread-1", "live", Cap+10, nil)
+	total := cassPageSize + 25
+	seedReplies(t, sess, "thread-1", "live", total, nil)
 
 	n, err := Count(ctx, sess, "thread-1")
 	require.NoError(t, err)
-	assert.Equal(t, Cap, n)
+	assert.Equal(t, total, n)
 }
 
 func TestCount_ExcludesDeleted(t *testing.T) {
@@ -83,20 +93,21 @@ func TestCount_ExcludesDeleted(t *testing.T) {
 	assert.Equal(t, 10, n)
 }
 
-// TestCount_ExcludesDeleted_OverCap locks in the no-CQL-LIMIT guarantee: with
-// soft-deleted rows interspersed AND a live total above Cap, the scan must page
-// past the deleted rows to reach Cap live ones and still return exactly Cap. A
-// hard LIMIT Cap would undercount here by counting deleted rows toward the limit.
-func TestCount_ExcludesDeleted_OverCap(t *testing.T) {
+// Locks in the no-CQL-LIMIT guarantee: with soft-deleted rows interspersed
+// across more than one page, the scan must walk past them and still return the
+// exact live total. A hard LIMIT would undercount by spending the limit on
+// deleted rows.
+func TestCount_ExcludesDeleted_MultiPage(t *testing.T) {
 	ctx := context.Background()
 	sess := setupThreadTable(t)
 	deleted := true
-	seedReplies(t, sess, "thread-1", "del", Cap, &deleted)
-	seedReplies(t, sess, "thread-1", "live", Cap+5, nil)
+	live := cassPageSize + 5
+	seedReplies(t, sess, "thread-1", "del", 200, &deleted)
+	seedReplies(t, sess, "thread-1", "live", live, nil)
 
 	n, err := Count(ctx, sess, "thread-1")
 	require.NoError(t, err)
-	assert.Equal(t, Cap, n)
+	assert.Equal(t, live, n)
 }
 
 func TestCount_EmptyPartition_Zero(t *testing.T) {
@@ -161,13 +172,28 @@ func TestCountAndLatest_AllDeleted_NilLatest(t *testing.T) {
 	assert.Nil(t, latest)
 }
 
-func TestCountAndLatest_OverCap_ReturnsCap(t *testing.T) {
+func TestCountAndLatest_LongThread_ExactCount(t *testing.T) {
 	ctx := context.Background()
 	sess := setupThreadTable(t)
-	seedReplies(t, sess, "thread-1", "live", Cap+10, nil)
+	const replies = 150
+	seedReplies(t, sess, "thread-1", "live", replies, nil)
 
 	n, latest, err := CountAndLatest(ctx, sess, "thread-1")
 	require.NoError(t, err)
-	assert.Equal(t, Cap, n)
+	assert.Equal(t, replies, n)
 	require.NotNil(t, latest)
+}
+
+// The internal scanTimeout must not mask a caller's own cancellation, and an
+// aborted scan must surface an error rather than leak the rows counted so far.
+func TestCountAndLatest_CanceledContext_NoPartialCount(t *testing.T) {
+	sess := setupThreadTable(t)
+	seedReplies(t, sess, "thread-1", "live", 10, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	n, latest, err := CountAndLatest(ctx, sess, "thread-1")
+	require.Error(t, err)
+	assert.Equal(t, 0, n)
+	assert.Nil(t, latest)
 }


### PR DESCRIPTION
Count/CountAndLatest scanned only until the live tally hit Cap=99, so any longer thread reported exactly 99 and clients rendered "99+". The count is now exact: the scan pages to the end of the partition.

Trade-off, stated plainly: Cap also bounded the per-write partition read. Every thread reply add and delete recomputes tcount, so that read is now linear in the thread's length instead of ~99 rows, making writes progressively more expensive as a thread grows. PageSize still bounds per-round-trip memory, not the total scanned. If this shows up on the hot path, an incremental counter is the fix, not a re-introduced ceiling.

Updates both authoritative writers' comments (message-worker add path, history-service delete path), the client-API docs for tcount and newTcount, the derived events view, and the Cassandra schema doc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thread reply counts now show the exact number of non-deleted replies, including threads with more than 99 replies.
  * Reply count updates and thread metadata now provide authoritative exact totals.

* **Bug Fixes**
  * Soft-deleted replies are excluded consistently while active replies are fully counted.
  * Long-thread counting now reports complete totals and avoids returning partial results when canceled.

* **Documentation**
  * Updated API and data model documentation to reflect exact reply-count behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->