### PR TITLE
feat(translation): map backend 429 to too_many_requests

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -5939,7 +5939,8 @@ See [Error envelope](#6-error-envelope-reference). The reply carries the `{ code
 | `bad_request` | `unsupported_lang` | `targetLang` does not resolve to a supported language (outside the [Supported languages](#supported-languages) set, or a bare `zh` with no script/region). |
 | `unavailable` | — | Handler saturation — the concurrency cap is full; retry. |
 | `unavailable` | `upstream_unavailable` | The third-party translation backend returned a 5XX or was unreachable (transport failure). Clients should show a "translation service temporarily unavailable" message and allow a retry. |
-| `internal` | — | Other translation backend failure (e.g. malformed stream, 4XX, non-success returnCode). The raw cause is logged server-side, never returned. |
+| `too_many_requests` | `rate_limited` | The third-party translation backend rate-limited the request (HTTP 429). The service does **not** retry; clients should back off and retry later. |
+| `internal` | — | Other translation backend failure (e.g. malformed stream, other 4XX, non-success returnCode). The raw cause is logged server-side, never returned. |
 
 ```json
 {

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -2128,7 +2128,7 @@ with a `TranslateResult`, or the standard error envelope on failure.
 
 #### Error response
 
-Standard `{ code, reason?, error }` envelope. Key errors: `empty_text` (`bad_request`) for empty `text`; `unsupported_lang` (`bad_request`) for a `targetLang` outside the set; `unavailable` under handler saturation; `unavailable` / `upstream_unavailable` when the third-party backend returns a 5XX or is unreachable; `internal` for other backend failures. See [../client-api.md §3.6](../client-api.md#36-translation-service).
+Standard `{ code, reason?, error }` envelope. Key errors: `empty_text` (`bad_request`) for empty `text`; `unsupported_lang` (`bad_request`) for a `targetLang` outside the set; `unavailable` under handler saturation; `unavailable` / `upstream_unavailable` when the third-party backend returns a 5XX or is unreachable; `too_many_requests` / `rate_limited` when the backend rate-limits (429, not retried); `internal` for other backend failures. See [../client-api.md §3.6](../client-api.md#36-translation-service).
 
 **Emits:** none — the reply is the only output.
 

--- a/pkg/errcode/codes_translation.go
+++ b/pkg/errcode/codes_translation.go
@@ -6,4 +6,5 @@ const (
 	TranslateUnsupportedLang     Reason = "unsupported_lang"     // 400: targetLang not in the allowed set
 	TranslateEmptyText           Reason = "empty_text"           // 400: text is empty
 	TranslateUpstreamUnavailable Reason = "upstream_unavailable" // 503: third-party translation backend returned 5XX or was unreachable
+	TranslateRateLimited         Reason = "rate_limited"         // 429: third-party translation backend rate-limited the request (not retried)
 )

--- a/translation-service/translator_stream.go
+++ b/translation-service/translator_stream.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -99,6 +100,12 @@ func (t *streamTranslator) translateOnce(ctx context.Context, text, targetLang, 
 	body := resp.RawBody()
 	defer body.Close()
 
+	// A 429 is a rate limit — surface too_many_requests and do NOT retry (a jwt
+	// failure would; this is not that). Classified before parsing the body.
+	if resp.StatusCode() == http.StatusTooManyRequests {
+		return "", false, errcode.TooManyRequests("translation rate limited",
+			errcode.WithReason(errcode.TranslateRateLimited))
+	}
 	// A 5XX is an outage regardless of body — classify before parsing, so a 5XX
 	// carrying data/JWT-shaped content can't read as success or trigger a refresh.
 	if s := resp.StatusCode(); s >= 500 && s < 600 {

--- a/translation-service/translator_stream_test.go
+++ b/translation-service/translator_stream_test.go
@@ -98,6 +98,28 @@ func TestStreamTranslator_NonSuccessCodeErrors(t *testing.T) {
 	assert.NotErrorAs(t, err, &ec)
 }
 
+// A 429 from the backend is a rate limit: return a too_many_requests errcode
+// (reason rate_limited) and do NOT retry (unlike a jwt failure).
+func TestStreamTranslator_RateLimitedReturnsTooManyRequests(t *testing.T) {
+	var translateCalls int32
+	tSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&translateCalls, 1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"message":"rate limit exceeded"}`)
+	}))
+	defer tSrv.Close()
+
+	tr := streamTranslatorTo(t, tSrv.URL)
+	_, err := tr.Translate(context.Background(), "hi", "en")
+	require.Error(t, err)
+
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.CodeTooManyRequests, ec.Code)
+	assert.Equal(t, errcode.TranslateRateLimited, ec.Reason)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&translateCalls)) // not retried
+}
+
 func TestStreamTranslator_MissingDoneErrors(t *testing.T) {
 	srv := sseServer(t, []string{
 		`data: {"returnCode":96200,"returnMessage":"success","returnData":{"translation":"partial"}}`,


### PR DESCRIPTION
## Summary

When the third-party translate API returns **HTTP 429 (rate limited)**, `translation-service` was falling through to a raw `translate backend error (status 429)` which collapses to `internal` at the NATS boundary. The client received:

```json
{"code":"internal","error":"internal error"}
```

That's the least useful signal for the **most common** failure — the backend is tightly rate-limited (measured ≈ 10 RPM in the test env; see #203), so 429 is the dominant error, yet it looked like a generic server bug with no "back off / retry later" hint.

`translateOnce` already maps **5XX / transport failures → `unavailable`** (added recently). This PR gives **429 its own classification** — consistent with that, but a distinct, accurate code.

## Change

`translateOnce` classifies the status **before parsing the body**: a 429 now returns `errcode.TooManyRequests` with reason `rate_limited`, and the service does **NOT retry** (only a `failed to verify jwt` response triggers the existing refresh-and-retry).

Client now receives:

```json
{"code":"too_many_requests","reason":"rate_limited","error":"translation rate limited"}
```

(HTTP category 429.)

| Backend response | Before | After |
|---|---|---|
| 429 | `internal` | **`too_many_requests` / `rate_limited`** |
| 5XX / transport / mid-stream drop | `unavailable` / `upstream_unavailable` | unchanged |
| other 4XX / malformed stream / non-success returnCode | `internal` | unchanged |

**No retry on 429** — retrying a rate-limited backend just amplifies load; the caller is told to back off instead.

## Files

- `pkg/errcode/codes_translation.go` — new reason `TranslateRateLimited` (`"rate_limited"`, 429).
- `translation-service/translator_stream.go` — 429 → `TooManyRequests(rate_limited)` (added `net/http`).
- `translation-service/translator_stream_test.go` — new test: 429 → `too_many_requests` + `rate_limited`, translate called **once** (no retry).
- `docs/client-api.md` + `docs/client-api/request-reply.md` — document the new error case (client-facing handler error surface changed).

## Testing

- `make test SERVICE=translation-service` green (`-race`); `pkg/errcode` tests green.
- `make lint` 0 issues; `make sast-gosec` PASS; `go build ./...` OK.

## Not in scope

- `Retry-After` passthrough and a translation-result cache are separate follow-ups (the higher-leverage mitigations for a 10 RPM backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2Jd3N1mNhSxjKNLcYgcgS

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2Jd3N1mNhSxjKNLcYgcgS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit handling for translation service rate limiting.
  * HTTP 429 responses now return a `too_many_requests` error with the `rate_limited` reason and are not retried.

* **Documentation**
  * Updated the translation error reference to document rate-limiting behavior.
  * Clarified that internal errors include other 4XX backend responses.

* **Tests**
  * Added coverage verifying rate-limited translation requests return the expected error without retrying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->