### PR TITLE
[NATS Tuning] Make NATS drain actually block, and make slow consumers visible

### DIFF
--- a/admin-service/main.go
+++ b/admin-service/main.go
@@ -92,10 +92,7 @@ func run() error {
 			func(ctx context.Context) error {
 				slog.Info("shutting down admin-service")
 				err := srv.Shutdown(ctx)
-				// srv.Shutdown has already waited out any in-flight toggle, so
-				// Drain (which returns immediately and finishes in the background)
-				// only closes the idle connection.
-				if drainErr := nc.NatsConn().Drain(); drainErr != nil {
+				if drainErr := natsutil.Drain(ctx, nc); drainErr != nil {
 					slog.Warn("drain nats", "error", drainErr)
 				}
 				mongoutil.Disconnect(ctx, mongoClient)

--- a/admin-service/main.go
+++ b/admin-service/main.go
@@ -92,6 +92,8 @@ func run() error {
 			func(ctx context.Context) error {
 				slog.Info("shutting down admin-service")
 				err := srv.Shutdown(ctx)
+				// srv.Shutdown has already waited out any in-flight toggle, so the
+				// drain only has the idle connection left to flush.
 				if drainErr := natsutil.Drain(ctx, nc); drainErr != nil {
 					slog.Warn("drain nats", "error", drainErr)
 				}

--- a/bot-message-handler/main.go
+++ b/bot-message-handler/main.go
@@ -89,7 +89,7 @@ func run() error {
 
 	shutdown.Wait(ctx, 25*time.Second,
 		func(ctx context.Context) error { return router.Shutdown(ctx) },
-		func(ctx context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, mongoClient); return nil },
 		func(ctx context.Context) error { return healthStop(ctx) },
 		func(ctx context.Context) error { return obsShutdown(ctx) },

--- a/bot-message-worker/main.go
+++ b/bot-message-worker/main.go
@@ -174,7 +174,7 @@ func run() error {
 				return fmt.Errorf("worker drain: %w", dctx.Err())
 			}
 		},
-		func(_ context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(_ context.Context) error { cassSess.Close(); return nil },
 		func(_ context.Context) error {
 			if vaultWrapper != nil {

--- a/bot-room-service/main.go
+++ b/bot-room-service/main.go
@@ -106,7 +106,7 @@ func run() error {
 	slog.Info("bot-room-service running", "site", cfg.SiteID, "peers", peers)
 	shutdown.Wait(ctx, 25*time.Second,
 		func(dctx context.Context) error { return router.Shutdown(dctx) },
-		func(_ context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(dctx context.Context) error { mongoutil.Disconnect(dctx, mc); return nil },
 		func(dctx context.Context) error { return healthStop(dctx) },
 		func(dctx context.Context) error { return obsShutdown(dctx) },

--- a/botplatform-service/main.go
+++ b/botplatform-service/main.go
@@ -124,7 +124,7 @@ func run() error {
 			func(ctx context.Context) error {
 				slog.Info("shutting down botplatform-service")
 				err := srv.Shutdown(ctx)
-				if drainErr := nc.Drain(); drainErr != nil {
+				if drainErr := natsutil.Drain(ctx, nc); drainErr != nil {
 					slog.Warn("nats drain failed", "error", drainErr)
 				}
 				valkeyutil.Disconnect(valkey)

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -272,7 +272,7 @@ func main() {
 			flushCancel()
 			return nil
 		},
-		func(ctx context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 	}
 	if keyStore != nil {
 		hooks = append(hooks, func(ctx context.Context) error { return keyStore.Close() })

--- a/data-migration/oplog-collections-transformer/main.go
+++ b/data-migration/oplog-collections-transformer/main.go
@@ -180,7 +180,7 @@ func main() {
 	shutdown.Wait(ctx, 25*time.Second,
 		func(context.Context) error { cc.Stop(); return nil },
 		func(ctx context.Context) error { return healthStop(ctx) },
-		func(context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, targetClient); return nil },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, source); return nil },
 		func(ctx context.Context) error { return obsShutdown(ctx) },

--- a/data-migration/oplog-connector/main.go
+++ b/data-migration/oplog-connector/main.go
@@ -94,7 +94,7 @@ func main() {
 		func(context.Context) error { conn.beginShutdown(); return nil },
 		func(ctx context.Context) error { return conn.awaitWatchers(ctx) },
 		func(ctx context.Context) error { return healthStop(ctx) },
-		func(context.Context) error { return conn.nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, conn.nc) },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, conn.client); return nil },
 		func(ctx context.Context) error { return obsShutdown(ctx) },
 	)
@@ -231,7 +231,11 @@ func (c *connector) Close() {
 	if err := c.awaitWatchers(wctx); err != nil {
 		slog.Warn("watcher drain incomplete", "error", err)
 	}
-	_ = c.nc.Drain()
+	dctx, dcancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer dcancel()
+	if err := natsutil.Drain(dctx, c.nc); err != nil {
+		slog.Warn("nats drain incomplete", "error", err)
+	}
 	mongoutil.Disconnect(context.Background(), c.client)
 }
 

--- a/data-migration/oplog-direct-transfer/main.go
+++ b/data-migration/oplog-direct-transfer/main.go
@@ -146,7 +146,7 @@ func main() {
 	shutdown.Wait(ctx, 25*time.Second,
 		func(context.Context) error { cc.Stop(); return nil },
 		func(ctx context.Context) error { return healthStop(ctx) },
-		func(context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, targetClient); return nil },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, source); return nil },
 		func(ctx context.Context) error { return obsShutdown(ctx) },

--- a/data-migration/oplog-transformer/main.go
+++ b/data-migration/oplog-transformer/main.go
@@ -128,7 +128,7 @@ func main() {
 	shutdown.Wait(ctx, 25*time.Second,
 		func(context.Context) error { cc.Stop(); return nil },
 		func(ctx context.Context) error { return healthStop(ctx) },
-		func(context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, client); return nil },
 		func(ctx context.Context) error { return obsShutdown(ctx) },
 	)

--- a/docs/superpowers/plans/2026-08-11-nats-connection-handling.md
+++ b/docs/superpowers/plans/2026-08-11-nats-connection-handling.md
@@ -420,7 +420,10 @@ func TestSlowConsumerFields_RealSubscription(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sub.Unsubscribe() })
 
-	got := fieldMap(t, slowConsumerFields(sub))
+	dropped, ok := subDropped(sub)
+	require.True(t, ok, "a live subscription must report its drop count")
+
+	got := fieldMap(t, slowConsumerFields(sub, dropped, ok))
 
 	require.Equal(t, "slow.subject", got["subject"])
 	require.Equal(t, "slow-queue", got["queue"])
@@ -433,11 +436,16 @@ func TestSlowConsumerFields_RealSubscription(t *testing.T) {
 
 func TestSlowConsumerFields_NilSubscription(t *testing.T) {
 	require.NotPanics(t, func() {
-		got := fieldMap(t, slowConsumerFields(nil))
+		dropped, ok := subDropped(nil)
+		require.False(t, ok)
+		got := fieldMap(t, slowConsumerFields(nil, dropped, ok))
 		require.Equal(t, "unknown", got["subject"])
 	})
 }
 
+// A closed subscription must omit the counters it cannot read rather than
+// reporting a bogus zero — an ERROR line saying "messages dropped" with a
+// dropped:0 field would be worse than no field at all.
 func TestSlowConsumerFields_ClosedSubscription(t *testing.T) {
 	nc := newLocalConn(t)
 	sub, err := nc.Subscribe("closed.subject", func(*nats.Msg) {})
@@ -445,9 +453,49 @@ func TestSlowConsumerFields_ClosedSubscription(t *testing.T) {
 	require.NoError(t, sub.Unsubscribe())
 
 	require.NotPanics(t, func() {
-		got := fieldMap(t, slowConsumerFields(sub))
+		dropped, ok := subDropped(sub)
+		require.False(t, ok, "a closed subscription cannot report a drop count")
+
+		got := fieldMap(t, slowConsumerFields(sub, dropped, ok))
 		require.Equal(t, "closed.subject", got["subject"])
+		require.NotContains(t, got, "dropped")
+		require.NotContains(t, got, "pending_msgs")
+		require.NotContains(t, got, "limit_msgs")
 	})
+}
+
+// logSlowConsumer is the only function connect.go's ErrorHandler calls, so the
+// level rule and the field wiring must be verified on that path and not just on
+// the helpers beneath it.
+func TestLogSlowConsumer_LiveSubscriptionWarnsWithNoDrops(t *testing.T) {
+	nc := newLocalConn(t)
+	sub, err := nc.QueueSubscribe("live.subject", "live-queue", func(*nats.Msg) {})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	require.NotPanics(t, func() { logSlowConsumer(log, sub) })
+
+	var rec map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &rec))
+	require.Equal(t, "WARN", rec["level"], "a fresh subscription has dropped nothing yet")
+	require.Equal(t, "live.subject", rec["subject"])
+	require.Equal(t, "live-queue", rec["queue"])
+	require.Equal(t, float64(0), rec["dropped"])
+}
+
+func TestLogSlowConsumer_NilSubscriptionDoesNotPanic(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	require.NotPanics(t, func() { logSlowConsumer(log, nil) })
+
+	var rec map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &rec))
+	require.Equal(t, "WARN", rec["level"])
+	require.Equal(t, "unknown", rec["subject"])
 }
 
 func TestLogSlowConsumer_LevelSelection(t *testing.T) {
@@ -530,35 +578,65 @@ import (
 	"go.opentelemetry.io/otel/metric/noop"
 )
 
-// slowConsumerDropped counts messages dropped by a subscription that could not
-// keep up, tagged by subject and queue group.
-var slowConsumerDropped metric.Int64Counter
+// slowConsumerEvents counts slow-consumer episodes, tagged by subject and queue
+// group.
+//
+// One increment per episode — deliberately NOT the subscription's drop count.
+// Subscription.Dropped() is a cumulative total that is never reset except on
+// unsubscribe (nats.go:3770, 5574-5584), and the async error callback fires only
+// on the Active->SlowConsumer transition (nats.go:3771-3787), with sub.sc cleared
+// again on the next successful delivery (nats.go:3742). Adding Dropped() would
+// therefore re-add every earlier episode's drops on each new episode: 3 dropped
+// then 5 dropped reports 3 + 8 = 11. The callback is also dispatched through an
+// async queue (nats.go:3785), so Dropped() read inside it is not even the count
+// at episode time. Exact per-episode numbers live in the log fields.
+var slowConsumerEvents metric.Int64Counter
 
 func init() {
 	var err error
-	slowConsumerDropped, err = otel.Meter("nats").Int64Counter(
-		"nats_slow_consumer_dropped_total",
-		metric.WithDescription("Messages dropped by a NATS subscription that could not keep up, by subject and queue group"),
+	slowConsumerEvents, err = otel.Meter("nats").Int64Counter(
+		"nats_slow_consumer_events_total",
+		metric.WithDescription("Slow-consumer episodes on a NATS subscription, by subject and queue group"),
 	)
 	if err != nil {
 		// Fall back to a no-op counter so recording stays safe even if the
 		// global meter provider is not initialised at package init time.
-		slowConsumerDropped, _ = noop.NewMeterProvider().Meter("nats").
-			Int64Counter("nats_slow_consumer_dropped_total")
+		slowConsumerEvents, _ = noop.NewMeterProvider().Meter("nats").
+			Int64Counter("nats_slow_consumer_events_total")
 	}
 }
 
+// subDropped returns the subscription's cumulative drop count and whether it
+// could be read at all. sub is nil for connection-level async errors, and
+// Dropped() errors on an already-closed subscription, which happens routinely
+// during shutdown.
+func subDropped(sub *nats.Subscription) (int, bool) {
+	if sub == nil {
+		return 0, false
+	}
+	dropped, err := sub.Dropped()
+	if err != nil {
+		return 0, false
+	}
+	return dropped, true
+}
+
 // slowConsumerFields builds the slog fields describing a slow consumer.
-// Every accessor is best-effort: sub is nil for connection-level async errors,
-// and Dropped/Pending/PendingLimits all error on an already-closed
-// subscription, which happens routinely during shutdown. A diagnostic path
-// must never panic or mask the event it is reporting.
-func slowConsumerFields(sub *nats.Subscription) []any {
+//
+// dropped/ok come from a single Dropped() read made by the caller rather than a
+// second read here, so the level decision and the logged value cannot diverge:
+// if the subscription closes between two reads, the level could say ERROR
+// ("messages dropped") while the field set silently omits the dropped count.
+//
+// The remaining accessors stay best-effort — Pending/PendingLimits also error on
+// a closed subscription, and a diagnostic path must never panic or mask the
+// event it is reporting.
+func slowConsumerFields(sub *nats.Subscription, dropped int, ok bool) []any {
 	if sub == nil {
 		return []any{"subject", "unknown"}
 	}
 	fields := []any{"subject", sub.Subject, "queue", sub.Queue}
-	if dropped, err := sub.Dropped(); err == nil {
+	if ok {
 		fields = append(fields, "dropped", dropped)
 	}
 	// nbytes, not bytes — a local named bytes shadows the stdlib package and
@@ -572,29 +650,18 @@ func slowConsumerFields(sub *nats.Subscription) []any {
 	return fields
 }
 
-// subDropped returns the subscription's drop count, or 0 when it cannot be read.
-func subDropped(sub *nats.Subscription) int {
-	if sub == nil {
-		return 0
-	}
-	dropped, err := sub.Dropped()
-	if err != nil {
-		return 0
-	}
-	return dropped
-}
-
-// logSlowConsumer reports a slow consumer and records the drop count.
+// logSlowConsumer reports a slow-consumer episode and counts it.
 func logSlowConsumer(log *slog.Logger, sub *nats.Subscription) {
-	dropped := subDropped(sub)
-	logSlowConsumerAt(log, dropped, slowConsumerFields(sub))
-	if dropped > 0 && sub != nil {
-		slowConsumerDropped.Add(context.Background(), int64(dropped),
-			metric.WithAttributes(
-				attribute.String("subject", sub.Subject),
-				attribute.String("queue", sub.Queue),
-			))
+	dropped, ok := subDropped(sub)
+	logSlowConsumerAt(log, dropped, slowConsumerFields(sub, dropped, ok))
+	if sub == nil {
+		return
 	}
+	slowConsumerEvents.Add(context.Background(), 1,
+		metric.WithAttributes(
+			attribute.String("subject", sub.Subject),
+			attribute.String("queue", sub.Queue),
+		))
 }
 
 // logSlowConsumerAt picks the level: dropped messages on a core subscription are

--- a/docs/superpowers/plans/2026-08-11-nats-connection-handling.md
+++ b/docs/superpowers/plans/2026-08-11-nats-connection-handling.md
@@ -294,11 +294,19 @@ In `pkg/natsutil/connect.go`, extend the const block at line 16:
 const (
 	defaultReconnectWait = 2 * time.Second
 	// defaultDrainTimeout bounds the subscription-drain phase. Worst case is
-	// this plus drainConnection's internal FlushTimeout(5s) = 20s, which fits
-	// inside the 25s shutdown.Wait budget and the 30s Kubernetes grace period.
-	// The library default is 30s (nats.DefaultDrainTimeout), which is larger
-	// than our budget and so could never be the timeout that fires.
-	defaultDrainTimeout = 15 * time.Second
+	// this plus drainConnection's internal FlushTimeout(5s) = 15s.
+	//
+	// shutdown.Wait creates ONE context for the whole shutdown and runs the
+	// hooks sequentially over it (pkg/shutdown/shutdown.go:21-32), so this
+	// budget is shared, not per-hook: a 15s worst-case drain leaves ~10s of
+	// the 25s for every remaining hook (DB disconnects, HTTP shutdown, o11y
+	// flush), which are sub-second in practice. A drain that actually needs
+	// longer than 10s means a wedged handler — a finding to surface, not a
+	// wait to extend.
+	//
+	// The library default is 30s (nats.DefaultDrainTimeout), larger than the
+	// entire shutdown budget, so it could never be the timeout that fires.
+	defaultDrainTimeout = 10 * time.Second
 )
 ```
 
@@ -321,8 +329,8 @@ func TestConnect_SetsDrainTimeout(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(conn.NatsConn().Close)
 
-	require.Equal(t, 15*time.Second, conn.NatsConn().Opts.DrainTimeout,
-		"DrainTimeout must be under the 25s shutdown budget, not the 30s library default")
+	require.Equal(t, 10*time.Second, conn.NatsConn().Opts.DrainTimeout,
+		"DrainTimeout must leave headroom in the shared 25s shutdown budget, not the 30s library default")
 }
 ```
 
@@ -762,7 +770,7 @@ The comment described the exact trap this change removes. Leaving it would be ac
 -		if err := nc.Drain(); err != nil {
 +		// ctx is already cancelled on SIGTERM by the time this defer runs, so
 +		// the drain deadline must not be derived from it.
-+		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
++		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
 +		defer cancel()
 +		if err := natsutil.Drain(dctx, nc); err != nil {
  			slog.Error("nats drain", "error", err)
@@ -779,7 +787,7 @@ Ensure `"time"` is imported.
 -		if err := nc.Drain(); err != nil {
 +		// ctx is already cancelled on SIGTERM by the time this defer runs, so
 +		// the drain deadline must not be derived from it.
-+		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
++		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
 +		defer cancel()
 +		if err := natsutil.Drain(dctx, nc); err != nil {
  			slog.Warn("nats drain", "error", err)
@@ -858,7 +866,7 @@ directly would expire the drain immediately and silently do nothing."
 +	defer func() {
 +		// ctx is already cancelled on SIGTERM by the time this defer runs, so
 +		// the drain deadline must not be derived from it.
-+		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
++		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
 +		defer cancel()
 +		if err := natsutil.Drain(dctx, nc); err != nil {
 +			slog.Error("nats drain", "error", err)
@@ -958,7 +966,7 @@ At `oplog-connector/main.go:234`, inside the function that already does a bounde
  		slog.Warn("watcher drain incomplete", "error", err)
  	}
 -	_ = c.nc.Drain()
-+	dctx, dcancel := context.WithTimeout(context.Background(), 15*time.Second)
++	dctx, dcancel := context.WithTimeout(context.Background(), 20*time.Second)
 +	defer dcancel()
 +	if err := natsutil.Drain(dctx, c.nc); err != nil {
 +		slog.Warn("nats drain incomplete", "error", err)
@@ -1050,7 +1058,9 @@ Do not open a PR unless explicitly asked.
 
 **No wire, schema, or config change.** Nothing here is client-facing, so `docs/client-api.md` and its derived views are untouched.
 
-**Expected behavior change:** services will now take up to ~20s to exit instead of exiting instantly. That is the point — but it will look like a pod-restart regression on first deploy. A service that sits at the full 15s drain timeout has a wedged subscription handler, which is a real finding, not a bug in this change.
+**Expected behavior change:** services will now take up to ~15s to exit instead of exiting instantly. That is the point — but it will look like a pod-restart regression on first deploy. A service that sits at the full 10s drain timeout has a wedged subscription handler, which is a real finding, not a bug in this change.
+
+**On the shutdown budget:** `shutdown.Wait` creates one context for the whole shutdown and runs hooks sequentially over it (`pkg/shutdown/shutdown.go:21-32`), so the 25s is shared, not per-hook. That is why `defaultDrainTimeout` is 10s rather than 15s: worst case 10s + `drainConnection`'s internal `FlushTimeout(5s)` = 15s, leaving ~10s for the remaining hooks. The standalone deferred sites in Tasks 4-6 have no shared budget, so they wrap the drain in their own 20s context — comfortably above the 15s worst case, so the wrapper is never the binding constraint.
 
 **Deliberately out of scope**, so the omissions are not read as oversights:
 - `SetPendingLimits` tuning for `broadcast-worker` — diagnose with the new counter first, tune with real numbers second.

--- a/docs/superpowers/plans/2026-08-11-nats-connection-handling.md
+++ b/docs/superpowers/plans/2026-08-11-nats-connection-handling.md
@@ -866,7 +866,9 @@ Ensure `"time"` is imported.
 
 - [ ] **Step 5: Build, test, lint**
 
-Run: `make build SERVICE=botplatform-service && make build SERVICE=admin-service && make build SERVICE=teams-room-creation && make build SERVICE=user-presence-service`
+Run: `make build SERVICE=botplatform-service && make build SERVICE=admin-service && make build SERVICE=teams-room-creation && make build SERVICE=user-presence-service && make build SERVICE=user-presence-service/sync`
+
+The last one is not redundant: `user-presence-service` and `user-presence-service/sync` are two separate `main.go` packages under one service directory, and `make build SERVICE=user-presence-service` builds only the root. The `sync/` package is the one this task edits. (Full-repo `make test` compiles it too, but the build list should not imply coverage it does not have.)
 
 Run: `make test`
 

--- a/docs/superpowers/plans/2026-08-11-nats-connection-handling.md
+++ b/docs/superpowers/plans/2026-08-11-nats-connection-handling.md
@@ -816,19 +816,21 @@ Shape C sites are `defer`red inside a `run` function with no `shutdown.Wait` con
  				}
 ```
 
-- [ ] **Step 2: Convert `admin-service` and delete the stale comment**
+- [ ] **Step 2: Convert `admin-service` and correct the stale comment**
 
 ```go
 -				// srv.Shutdown has already waited out any in-flight toggle, so
 -				// Drain (which returns immediately and finishes in the background)
 -				// only closes the idle connection.
 -				if drainErr := nc.NatsConn().Drain(); drainErr != nil {
++				// srv.Shutdown has already waited out any in-flight toggle, so the
++				// drain only has the idle connection left to flush.
 +				if drainErr := natsutil.Drain(ctx, nc); drainErr != nil {
  					slog.Warn("drain nats", "error", drainErr)
  				}
 ```
 
-The comment described the exact trap this change removes. Leaving it would be actively misleading.
+Correct, not delete. The second clause described the exact trap this change removes and would be actively misleading if kept. The first clause — that `srv.Shutdown` has already waited out any in-flight toggle — is still true, because the ordering is unchanged, and it documents why draining here is cheap. Deleting the whole comment would take a true fact with the false one.
 
 - [ ] **Step 3: Convert `teams-room-creation`**
 
@@ -849,11 +851,16 @@ Ensure `"time"` is imported.
 
 - [ ] **Step 4: Convert `user-presence-service/sync`**
 
+Same `WithoutCancel` mechanic as Step 3, but **the reason differs and so does the comment.** This binary installs no signal handler — no `signal.Notify`, no `NotifyContext` anywhere in the package — and its `ctx` comes from `context.WithTimeout(context.Background(), cfg.RunTimeout)`. A bare SIGTERM would kill it outright without running any defer. What can leave `ctx` already `Done` here is `cfg.RunTimeout` elapsing during the run. Do not reuse Step 3's SIGTERM wording.
+
 ```go
  	defer func() {
 -		if err := nc.Drain(); err != nil {
-+		// ctx is already cancelled on SIGTERM by the time this defer runs, so
-+		// the drain deadline must not be derived from it.
++		// ctx carries the run deadline (context.WithTimeout at the top of run) and
++		// can already be Done when this defer executes, so the drain deadline must
++		// not derive from it. Unlike teams-room-creation this binary installs no
++		// signal handler — the expiry that matters here is RunTimeout elapsing
++		// during the run.
 +		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
 +		defer cancel()
 +		if err := natsutil.Drain(dctx, nc); err != nil {

--- a/docs/superpowers/plans/2026-08-11-nats-connection-handling.md
+++ b/docs/superpowers/plans/2026-08-11-nats-connection-handling.md
@@ -1,0 +1,1059 @@
+# NATS Drain + Slow Consumer Visibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `nc.Drain()` actually wait for the drain to finish before the process exits, and make NATS slow consumers visible in logs and metrics.
+
+**Architecture:** Two additions to `pkg/natsutil` — a blocking `Drain` helper that waits on the connection's CLOSED status transition, and a slow-consumer branch in the shared `nats.ErrorHandler`. Then a sweep converting 30 call sites across five distinct shapes to use the new helper.
+
+**Tech Stack:** Go 1.25, `github.com/nats-io/nats.go` v1.50.0, `github.com/flywindy/o11y/nats` v0.9.1, `go.opentelemetry.io/otel` metrics, `testify`, embedded `nats-server/v2` for tests.
+
+**Spec:** `docs/superpowers/specs/2026-08-11-nats-connection-handling-design.md`
+
+## Global Constraints
+
+- All commands go through `make` — never raw `go` commands. Tests: `make test SERVICE=pkg/natsutil`. Lint: `make lint`. Build: `make build SERVICE=<name>`.
+- All tests run with `-race` (the Makefile handles this).
+- TDD is mandatory: write the failing test, run it, confirm it fails for the right reason, then implement.
+- Coverage floor 80% repo-wide; `pkg/` targets 90%.
+- Logging is `log/slog` only, structured key-value fields, never interpolated strings.
+- Errors wrap with context: `fmt.Errorf("short description: %w", err)`. Never bare `err`.
+- Existing `pkg/natsutil` tests live in the **external** test package `package natsutil_test`. Default to that. Task 2 is the one exception — it tests unexported helpers, so its file declares `package natsutil`. Go permits both in one directory; do not convert the existing external tests.
+- Pre-commit hook runs lint and tests. Fix failures rather than bypassing.
+- No new third-party dependencies. Everything used here is already in `go.mod`.
+- Never commit `.env` files. Do not create a PR unless explicitly asked.
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `pkg/natsutil/drain.go` (create) | `Drain(ctx, conn)` — blocking drain helper |
+| `pkg/natsutil/drain_test.go` (create) | Drain behavior tests against embedded NATS |
+| `pkg/natsutil/slowconsumer.go` (create) | Slow-consumer field extraction, log-level selection, drop counter |
+| `pkg/natsutil/slowconsumer_test.go` (create) | Field extraction + level selection tests |
+| `pkg/natsutil/connect.go` (modify) | Add `DrainTimeout` default; route `ErrSlowConsumer` in `ErrorHandler` |
+| `pkg/natsutil/connect_test.go` (modify) | Assert `DrainTimeout` is applied |
+| 30 service `main.go` files (modify) | Call-site conversion, five shapes |
+
+---
+
+### Task 1: Blocking `natsutil.Drain` + drain timeout
+
+**Files:**
+- Create: `pkg/natsutil/drain.go`
+- Create: `pkg/natsutil/drain_test.go`
+- Modify: `pkg/natsutil/connect.go:16` (const block), `pkg/natsutil/connect.go:43-59` (`baseOpts`)
+- Modify: `pkg/natsutil/connect_test.go`
+
+**Interfaces:**
+- Consumes: `natsutil.Connect(ctx, url, credsFile string, tp trace.TracerProvider, prop propagation.TextMapPropagator, tracingEnabled bool, opts ...nats.Option) (*o11ynats.Conn, error)` — already exists.
+- Produces: `natsutil.Drain(ctx context.Context, conn *o11ynats.Conn) error` — every later task calls exactly this.
+
+**Background the implementer needs:**
+
+`nats.Conn.Drain()` (`nats.go@v1.50.0:6055-6075`) does not block. It flips the connection to `DRAINING_SUBS`, spawns `go nc.drainConnection()`, and returns `nil`. The real work — draining subscriptions, `FlushTimeout(5s)`, then `Close()` — happens on that goroutine. A shutdown hook that returns the result of `Drain()` therefore returns instantly and the process exits mid-drain.
+
+`o11ynats.Conn` embeds `otelnats.Conn`, whose `Drain()` (`otelnats/conn.go:222-224`) is a bare delegation to the underlying `*nats.Conn`. Reaching through `conn.NatsConn()` skips no tracing behavior.
+
+We wait on `nc.StatusChanged(nats.CLOSED)` (`nats.go:6379`) rather than a `ClosedHandler`, because `connect.go:53` already occupies the `ClosedHandler` option slot and same-kind `nats.Option`s overwrite rather than compose.
+
+This pattern is not new to the codebase. `pkg/natsrouter.Shutdown` (`router.go:246-275`) already does the same thing one level down, for subscriptions: register `StatusChanged(nats.SubscriptionClosed)` listeners on every subscription *before* calling `Drain()`, then wait on them with the caller's context. Read that function before implementing — this task is the `Conn`-level counterpart, and matching its structure keeps the two consistent.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `pkg/natsutil/drain_test.go`:
+
+```go
+package natsutil_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/hmchangw/chat/pkg/natsutil"
+)
+
+// startTestServer starts an embedded NATS server and returns its client URL.
+// Separate from startTestNATS (which hands back a raw *nats.Conn) because these
+// tests need to build a real *o11ynats.Conn through natsutil.Connect, so the
+// production option wiring — including DrainTimeout — is what gets exercised.
+func startTestServer(t *testing.T) string {
+	t.Helper()
+	ns, err := natsserver.NewServer(&natsserver.Options{Port: -1})
+	require.NoError(t, err)
+	ns.Start()
+	require.True(t, ns.ReadyForConnections(5*time.Second))
+	t.Cleanup(ns.Shutdown)
+	return ns.ClientURL()
+}
+
+func testConn(t *testing.T, url string) *o11ynats.Conn {
+	t.Helper()
+	conn, err := natsutil.Connect(context.Background(), url, "",
+		noop.NewTracerProvider(), propagation.TraceContext{}, false)
+	require.NoError(t, err)
+	return conn
+}
+
+func TestDrain_ClosesConnection(t *testing.T) {
+	conn := testConn(t, startTestServer(t))
+
+	_, err := conn.NatsConn().Subscribe("drain.test", func(*nats.Msg) {})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, natsutil.Drain(ctx, conn))
+	require.True(t, conn.NatsConn().IsClosed(),
+		"Drain must not return until the connection has reached CLOSED")
+}
+
+// The regression this whole change exists for: Drain must not return while a
+// handler is still running. Before the fix nats.Conn.Drain returned instantly
+// and this assertion fails with handlerDone still false.
+func TestDrain_WaitsForInFlightHandler(t *testing.T) {
+	url := startTestServer(t)
+	conn := testConn(t, url)
+
+	release := make(chan struct{})
+	handlerDone := make(chan struct{})
+	_, err := conn.NatsConn().Subscribe("drain.slow", func(*nats.Msg) {
+		<-release
+		close(handlerDone)
+	})
+	require.NoError(t, err)
+	require.NoError(t, conn.NatsConn().Flush())
+
+	pub := testConn(t, url)
+	require.NoError(t, pub.NatsConn().Publish("drain.slow", []byte("x")))
+	require.NoError(t, pub.NatsConn().Flush())
+
+	drained := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		drained <- natsutil.Drain(ctx, conn)
+	}()
+
+	select {
+	case <-drained:
+		t.Fatal("Drain returned while the handler was still in flight")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(release)
+	<-handlerDone
+	require.NoError(t, <-drained)
+}
+
+func TestDrain_CtxExpiredReturnsError(t *testing.T) {
+	url := startTestServer(t)
+	conn := testConn(t, url)
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	_, err := conn.NatsConn().Subscribe("drain.wedged", func(*nats.Msg) { <-release })
+	require.NoError(t, err)
+	require.NoError(t, conn.NatsConn().Flush())
+
+	pub := testConn(t, url)
+	require.NoError(t, pub.NatsConn().Publish("drain.wedged", []byte("x")))
+	require.NoError(t, pub.NatsConn().Flush())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err = natsutil.Drain(ctx, conn)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestDrain_AlreadyClosedIsNotAnError(t *testing.T) {
+	conn := testConn(t, startTestServer(t))
+	conn.NatsConn().Close()
+
+	require.NoError(t, natsutil.Drain(context.Background(), conn))
+}
+
+func TestDrain_Idempotent(t *testing.T) {
+	conn := testConn(t, startTestServer(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, natsutil.Drain(ctx, conn))
+	require.NoError(t, natsutil.Drain(ctx, conn))
+}
+
+func TestDrain_NilConnIsNotAnError(t *testing.T) {
+	require.NoError(t, natsutil.Drain(context.Background(), nil))
+}
+```
+
+Add the `o11ynats` import to the file's import block:
+
+```go
+o11ynats "github.com/flywindy/o11y/nats"
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run: `make test SERVICE=pkg/natsutil`
+
+Expected: compile failure — `undefined: natsutil.Drain`. That is the correct Red state.
+
+- [ ] **Step 3: Implement `Drain`**
+
+Create `pkg/natsutil/drain.go`:
+
+```go
+package natsutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+	"github.com/nats-io/nats.go"
+)
+
+// Drain puts the connection into the drain state and blocks until it reaches
+// CLOSED or ctx expires.
+//
+// nats.Conn.Drain only *starts* the drain — it spawns drainConnection on a
+// goroutine and returns nil immediately — so a shutdown hook that returns
+// nc.Drain() directly returns before subscriptions have drained and before the
+// final publish flush, and the process exits with buffered JetStream acks and
+// request/reply responses still in the write buffer.
+func Drain(ctx context.Context, conn *o11ynats.Conn) error {
+	if conn == nil {
+		return nil
+	}
+	nc := conn.NatsConn()
+	if nc == nil {
+		return nil
+	}
+
+	// Register the listener before calling Drain so a fast close cannot land in
+	// the gap between the two calls, and re-check IsClosed after, to cover a
+	// close that completed before the listener was in place. Together these
+	// close both sides of the race.
+	ch := nc.StatusChanged(nats.CLOSED)
+	defer nc.RemoveStatusListener(ch)
+
+	if err := nc.Drain(); err != nil {
+		switch {
+		case errors.Is(err, nats.ErrConnectionClosed):
+			return nil
+		case errors.Is(err, nats.ErrConnectionReconnecting):
+			// Drain hard-closed the connection. Buffered publishes are gone,
+			// but there was no reachable server to flush them to — a normal
+			// shutdown-during-outage, not a failure worth reporting upward.
+			slog.WarnContext(ctx, "nats drain skipped: connection reconnecting")
+			return nil
+		default:
+			return fmt.Errorf("start nats drain: %w", err)
+		}
+	}
+	if nc.IsClosed() {
+		return nil
+	}
+
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("nats drain incomplete: %w", ctx.Err())
+	}
+}
+```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `make test SERVICE=pkg/natsutil`
+
+Expected: PASS, all seven `TestDrain_*` cases.
+
+If `TestDrain_WaitsForInFlightHandler` fails, the wait logic is wrong — do not "fix" it by loosening the assertion. That test is the entire point of the change.
+
+- [ ] **Step 5: Add the drain timeout default**
+
+In `pkg/natsutil/connect.go`, extend the const block at line 16:
+
+```go
+const (
+	defaultReconnectWait = 2 * time.Second
+	// defaultDrainTimeout bounds the subscription-drain phase. Worst case is
+	// this plus drainConnection's internal FlushTimeout(5s) = 20s, which fits
+	// inside the 25s shutdown.Wait budget and the 30s Kubernetes grace period.
+	// The library default is 30s (nats.DefaultDrainTimeout), which is larger
+	// than our budget and so could never be the timeout that fires.
+	defaultDrainTimeout = 15 * time.Second
+)
+```
+
+Add to `baseOpts` (after `nats.ReconnectWait(defaultReconnectWait)` at line 46):
+
+```go
+nats.DrainTimeout(defaultDrainTimeout),
+```
+
+Caller `opts` are appended after `baseOpts` (`connect.go:60`), so a caller that genuinely needs a different value can still override.
+
+- [ ] **Step 6: Write the failing test for the drain timeout**
+
+Append to `pkg/natsutil/connect_test.go`:
+
+```go
+func TestConnect_SetsDrainTimeout(t *testing.T) {
+	conn, err := natsutil.Connect(context.Background(), startTestServer(t), "",
+		noop.NewTracerProvider(), propagation.TraceContext{}, false)
+	require.NoError(t, err)
+	t.Cleanup(conn.NatsConn().Close)
+
+	require.Equal(t, 15*time.Second, conn.NatsConn().Opts.DrainTimeout,
+		"DrainTimeout must be under the 25s shutdown budget, not the 30s library default")
+}
+```
+
+Add `"time"` to the import block if it is not already present.
+
+- [ ] **Step 7: Run the tests**
+
+Run: `make test SERVICE=pkg/natsutil`
+
+Expected: PASS. If Step 5 was skipped this fails with `30s != 15s`.
+
+- [ ] **Step 8: Lint and check coverage**
+
+Run: `make lint`
+
+Run: `go test -race -coverprofile=/tmp/claude-0/-home-user-newchat/8d24fbda-5dbb-53c0-8a07-ddeccbb30dc1/scratchpad/cover.out ./pkg/natsutil/... && go tool cover -func=/tmp/claude-0/-home-user-newchat/8d24fbda-5dbb-53c0-8a07-ddeccbb30dc1/scratchpad/cover.out | grep -E "drain.go|total:"`
+
+Expected: `drain.go` functions at 90%+, no lint findings.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add pkg/natsutil/drain.go pkg/natsutil/drain_test.go pkg/natsutil/connect.go pkg/natsutil/connect_test.go
+git commit -m "feat(natsutil): add blocking Drain and bounded DrainTimeout
+
+nats.Conn.Drain only starts the drain on a goroutine and returns nil, so
+shutdown hooks returned before subscriptions drained and the process
+exited with buffered acks and replies still in the write buffer.
+
+Drain now waits on the CLOSED status transition, bounded by the caller's
+context, and DrainTimeout is set to 15s so it fits inside the 25s
+shutdown budget rather than the 30s library default."
+```
+
+---
+
+### Task 2: Slow consumer diagnostics
+
+**Files:**
+- Create: `pkg/natsutil/slowconsumer.go`
+- Create: `pkg/natsutil/slowconsumer_test.go`
+- Modify: `pkg/natsutil/connect.go:56-58` (`ErrorHandler`)
+
+**Interfaces:**
+- Consumes: nothing from Task 1. This task is independent and may be done in either order.
+- Produces: `slowConsumerFields(sub *nats.Subscription) []any` and `logSlowConsumer(log *slog.Logger, sub *nats.Subscription)`, both unexported. No later task calls them.
+
+**Background the implementer needs:**
+
+`connect.go:56` currently throws away the `*nats.Subscription` argument:
+
+```go
+nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
+	log.Error("nats async error", "error", err)
+}),
+```
+
+So a slow consumer logs `nats async error: nats: slow consumer, messages dropped` with no subject, no queue group, and no drop count — nothing to act on or alert on.
+
+`nats.ErrSlowConsumer` (`nats.go:111`) is a plain `errors.New` sentinel, so `errors.Is` matches. `Subscription.Dropped()` (`nats.go:5574`), `Pending()` (`:5462`), and `PendingLimits()` (`:5521`) each return an error when the subscription is already closed — which happens routinely during shutdown, so every one must be handled rather than ignored. `sub` itself is nil for connection-level async errors.
+
+Log level: **ERROR** when `Dropped() > 0`, **WARN** otherwise. Dropped messages on a core NATS subscription are unrecoverable loss and should page; a slow consumer that has not yet dropped anything is a warning.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `pkg/natsutil/slowconsumer_test.go`:
+
+```go
+package natsutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/require"
+)
+
+// This file is in package natsutil (not natsutil_test) because it exercises
+// unexported helpers. The rest of the package's tests stay external.
+
+func TestSlowConsumerFields_RealSubscription(t *testing.T) {
+	nc := newLocalConn(t)
+	sub, err := nc.QueueSubscribe("slow.subject", "slow-queue", func(*nats.Msg) {})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	got := fieldMap(t, slowConsumerFields(sub))
+
+	require.Equal(t, "slow.subject", got["subject"])
+	require.Equal(t, "slow-queue", got["queue"])
+	require.Contains(t, got, "dropped")
+	require.Contains(t, got, "pending_msgs")
+	require.Contains(t, got, "pending_bytes")
+	require.Contains(t, got, "limit_msgs")
+	require.Contains(t, got, "limit_bytes")
+}
+
+func TestSlowConsumerFields_NilSubscription(t *testing.T) {
+	require.NotPanics(t, func() {
+		got := fieldMap(t, slowConsumerFields(nil))
+		require.Equal(t, "unknown", got["subject"])
+	})
+}
+
+func TestSlowConsumerFields_ClosedSubscription(t *testing.T) {
+	nc := newLocalConn(t)
+	sub, err := nc.Subscribe("closed.subject", func(*nats.Msg) {})
+	require.NoError(t, err)
+	require.NoError(t, sub.Unsubscribe())
+
+	require.NotPanics(t, func() {
+		got := fieldMap(t, slowConsumerFields(sub))
+		require.Equal(t, "closed.subject", got["subject"])
+	})
+}
+
+func TestLogSlowConsumer_LevelSelection(t *testing.T) {
+	tests := []struct {
+		name      string
+		dropped   int
+		wantLevel string
+	}{
+		{name: "no drops yet warns", dropped: 0, wantLevel: "WARN"},
+		{name: "drops are an error", dropped: 3, wantLevel: "ERROR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+			logSlowConsumerAt(log, tt.dropped, []any{"subject", "x"})
+
+			var rec map[string]any
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &rec))
+			require.Equal(t, tt.wantLevel, rec["level"])
+		})
+	}
+}
+
+func fieldMap(t *testing.T, fields []any) map[string]any {
+	t.Helper()
+	require.Zero(t, len(fields)%2, "slog fields must be key-value pairs")
+	out := make(map[string]any, len(fields)/2)
+	for i := 0; i < len(fields); i += 2 {
+		key, ok := fields[i].(string)
+		require.True(t, ok, "field key at %d is not a string", i)
+		out[key] = fields[i+1]
+	}
+	return out
+}
+```
+
+Add a `newLocalConn` helper to the same file (the existing `startTestNATS` lives in the external test package and is not reachable from here):
+
+```go
+func newLocalConn(t *testing.T) *nats.Conn {
+	t.Helper()
+	ns, err := natsserver.NewServer(&natsserver.Options{Port: -1})
+	require.NoError(t, err)
+	ns.Start()
+	require.True(t, ns.ReadyForConnections(5*time.Second))
+	t.Cleanup(ns.Shutdown)
+	nc, err := nats.Connect(ns.ClientURL())
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+	return nc
+}
+```
+
+with imports `natsserver "github.com/nats-io/nats-server/v2/server"` and `"time"`.
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run: `make test SERVICE=pkg/natsutil`
+
+Expected: compile failure — `undefined: slowConsumerFields`, `undefined: logSlowConsumerAt`.
+
+- [ ] **Step 3: Implement the helpers**
+
+Create `pkg/natsutil/slowconsumer.go`:
+
+```go
+package natsutil
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// slowConsumerDropped counts messages dropped by a subscription that could not
+// keep up, tagged by subject and queue group.
+var slowConsumerDropped metric.Int64Counter
+
+func init() {
+	var err error
+	slowConsumerDropped, err = otel.Meter("nats").Int64Counter(
+		"nats_slow_consumer_dropped_total",
+		metric.WithDescription("Messages dropped by a NATS subscription that could not keep up, by subject and queue group"),
+	)
+	if err != nil {
+		// Fall back to a no-op counter so recording stays safe even if the
+		// global meter provider is not initialised at package init time.
+		slowConsumerDropped, _ = noop.NewMeterProvider().Meter("nats").
+			Int64Counter("nats_slow_consumer_dropped_total")
+	}
+}
+
+// slowConsumerFields builds the slog fields describing a slow consumer.
+// Every accessor is best-effort: sub is nil for connection-level async errors,
+// and Dropped/Pending/PendingLimits all error on an already-closed
+// subscription, which happens routinely during shutdown. A diagnostic path
+// must never panic or mask the event it is reporting.
+func slowConsumerFields(sub *nats.Subscription) []any {
+	if sub == nil {
+		return []any{"subject", "unknown"}
+	}
+	fields := []any{"subject", sub.Subject, "queue", sub.Queue}
+	if dropped, err := sub.Dropped(); err == nil {
+		fields = append(fields, "dropped", dropped)
+	}
+	// nbytes, not bytes — a local named bytes shadows the stdlib package and
+	// trips the linter's shadow check.
+	if msgs, nbytes, err := sub.Pending(); err == nil {
+		fields = append(fields, "pending_msgs", msgs, "pending_bytes", nbytes)
+	}
+	if msgs, nbytes, err := sub.PendingLimits(); err == nil {
+		fields = append(fields, "limit_msgs", msgs, "limit_bytes", nbytes)
+	}
+	return fields
+}
+
+// subDropped returns the subscription's drop count, or 0 when it cannot be read.
+func subDropped(sub *nats.Subscription) int {
+	if sub == nil {
+		return 0
+	}
+	dropped, err := sub.Dropped()
+	if err != nil {
+		return 0
+	}
+	return dropped
+}
+
+// logSlowConsumer reports a slow consumer and records the drop count.
+func logSlowConsumer(log *slog.Logger, sub *nats.Subscription) {
+	dropped := subDropped(sub)
+	logSlowConsumerAt(log, dropped, slowConsumerFields(sub))
+	if dropped > 0 && sub != nil {
+		slowConsumerDropped.Add(context.Background(), int64(dropped),
+			metric.WithAttributes(
+				attribute.String("subject", sub.Subject),
+				attribute.String("queue", sub.Queue),
+			))
+	}
+}
+
+// logSlowConsumerAt picks the level: dropped messages on a core subscription are
+// unrecoverable loss and should page, so they log at ERROR. A slow consumer that
+// has not dropped anything yet is a warning.
+func logSlowConsumerAt(log *slog.Logger, dropped int, fields []any) {
+	if dropped > 0 {
+		log.Error("nats slow consumer, messages dropped", fields...)
+		return
+	}
+	log.Warn("nats slow consumer", fields...)
+}
+```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `make test SERVICE=pkg/natsutil`
+
+Expected: PASS.
+
+- [ ] **Step 5: Wire the handler**
+
+In `pkg/natsutil/connect.go`, replace the `ErrorHandler` at lines 56-58:
+
+```go
+nats.ErrorHandler(func(_ *nats.Conn, sub *nats.Subscription, err error) {
+	if errors.Is(err, nats.ErrSlowConsumer) {
+		logSlowConsumer(log, sub)
+		return
+	}
+	log.Error("nats async error", "error", err)
+}),
+```
+
+Add `"errors"` to the import block.
+
+- [ ] **Step 6: Run tests and lint**
+
+Run: `make test SERVICE=pkg/natsutil`
+
+Run: `make lint`
+
+Expected: PASS, no findings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pkg/natsutil/slowconsumer.go pkg/natsutil/slowconsumer_test.go pkg/natsutil/connect.go
+git commit -m "feat(natsutil): report slow consumers with subject and drop count
+
+The shared ErrorHandler discarded its *nats.Subscription argument, so a
+slow consumer logged a bare 'nats async error' with no subject, queue, or
+drop count — nothing to act on or alert on.
+
+Slow consumer events now log the subject, queue group, drop count and
+pending/limit counters, at ERROR once messages have actually been dropped
+and WARN before that, and increment nats_slow_consumer_dropped_total."
+```
+
+---
+
+### Task 3: Convert Shape A — hook lambdas (19 sites)
+
+**Files (all `Modify`):**
+
+`bot-message-handler/main.go:92`, `bot-message-worker/main.go:177`, `bot-room-service/main.go:109`, `broadcast-worker/main.go:275`, `history-service/cmd/main.go:242`, `inbox-worker/main.go:776`, `media-service/main.go:107`, `message-gatekeeper/main.go:222`, `message-worker/main.go:271`, `notification-worker/main.go:390`, `outbox-worker/main.go:186`, `push-notification-service/main.go:118`, `room-service/main.go:306`, `room-worker/main.go:312`, `search-service/main.go:265`, `search-sync-worker/main.go:351`, `translation-service/main.go:121`, `user-presence-service/main.go:163`, `user-service/main.go:146`
+
+**Interfaces:**
+- Consumes: `natsutil.Drain(ctx context.Context, conn *o11ynats.Conn) error` from Task 1.
+- Produces: nothing.
+
+**Background:** These are all inside a `shutdown.Wait(ctx, 25*time.Second, ...)` hook list. `shutdown.Wait` passes each hook a context already bounded to 25s (`pkg/shutdown/shutdown.go:22`), so the drain inherits the shutdown budget with no extra plumbing.
+
+Line numbers will drift as you edit. Locate each site by content, not by line.
+
+- [ ] **Step 1: Convert every site**
+
+Each site is one of two forms. With a named ctx:
+
+```go
+-		func(ctx context.Context) error { return nc.Drain() },
++		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
+```
+
+With a discarded ctx — the parameter must be named:
+
+```go
+-		func(_ context.Context) error { return nc.Drain() },
++		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
+```
+
+The discarded-ctx form appears at `bot-message-worker:177`, `bot-room-service:109`, `media-service:107`, `notification-worker:390`, and `push-notification-service:118`. The rest already name it.
+
+Ensure each file imports `"github.com/hmchangw/chat/pkg/natsutil"` — most already do, since they call `natsutil.Connect`.
+
+- [ ] **Step 2: Verify nothing was missed**
+
+Run: `grep -rn "return nc.Drain()" --include="*.go" . | grep -v data-migration | grep -v tools/`
+
+Expected: no output.
+
+- [ ] **Step 3: Build every touched service**
+
+Run: `make build SERVICE=bot-message-handler && make build SERVICE=bot-message-worker && make build SERVICE=bot-room-service && make build SERVICE=broadcast-worker && make build SERVICE=inbox-worker && make build SERVICE=media-service && make build SERVICE=message-gatekeeper && make build SERVICE=message-worker && make build SERVICE=notification-worker && make build SERVICE=outbox-worker && make build SERVICE=push-notification-service && make build SERVICE=room-service && make build SERVICE=room-worker && make build SERVICE=search-service && make build SERVICE=search-sync-worker && make build SERVICE=translation-service && make build SERVICE=user-presence-service && make build SERVICE=user-service`
+
+Then: `make build SERVICE=history-service`
+
+Expected: all succeed. The Makefile special-cases `history-service` to build from `./history-service/cmd/` (`Makefile:115`), so the plain service name is correct — verified.
+
+- [ ] **Step 4: Full test and lint sweep**
+
+Run: `make test`
+
+Run: `make lint`
+
+Expected: PASS, no findings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: block on NATS drain in service shutdown hooks
+
+Nineteen services returned nc.Drain() straight from their shutdown hook,
+which returned instantly and let the process exit mid-drain. Route them
+through natsutil.Drain so the hook waits, bounded by the 25s shutdown
+context each hook already receives."
+```
+
+---
+
+### Task 4: Convert Shapes B and C — inline hooks and deferred drains (4 sites)
+
+**Files:**
+- Modify: `botplatform-service/main.go:127`, `admin-service/main.go:93-99`
+- Modify: `teams-room-creation/main.go:70-74`, `user-presence-service/sync/main.go:105-109`
+
+**Interfaces:**
+- Consumes: `natsutil.Drain(ctx context.Context, conn *o11ynats.Conn) error` from Task 1.
+- Produces: nothing.
+
+**Background:** Shape B sites sit inside a hook that also shuts the HTTP server down and disconnects Mongo/Valkey, and swallow the drain error into a log line. Keep that swallow — the surrounding hook returns the HTTP server's error, and changing which error wins is a behavior change outside this spec's scope.
+
+Shape C sites are `defer`red inside a `run` function with no `shutdown.Wait` context to borrow. The subtlety that makes or breaks these: on SIGTERM the parent `ctx` is **already cancelled** by the time the deferred function runs, so deriving a timeout from it directly produces an already-expired context and the drain returns instantly — a silent no-op that looks exactly like a working fix. `context.WithoutCancel` is what prevents that.
+
+- [ ] **Step 1: Convert `botplatform-service`**
+
+```go
+-				if drainErr := nc.Drain(); drainErr != nil {
++				if drainErr := natsutil.Drain(ctx, nc); drainErr != nil {
+ 					slog.Warn("nats drain failed", "error", drainErr)
+ 				}
+```
+
+- [ ] **Step 2: Convert `admin-service` and delete the stale comment**
+
+```go
+-				// srv.Shutdown has already waited out any in-flight toggle, so
+-				// Drain (which returns immediately and finishes in the background)
+-				// only closes the idle connection.
+-				if drainErr := nc.NatsConn().Drain(); drainErr != nil {
++				if drainErr := natsutil.Drain(ctx, nc); drainErr != nil {
+ 					slog.Warn("drain nats", "error", drainErr)
+ 				}
+```
+
+The comment described the exact trap this change removes. Leaving it would be actively misleading.
+
+- [ ] **Step 3: Convert `teams-room-creation`**
+
+```go
+ 	defer func() {
+-		if err := nc.Drain(); err != nil {
++		// ctx is already cancelled on SIGTERM by the time this defer runs, so
++		// the drain deadline must not be derived from it.
++		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
++		defer cancel()
++		if err := natsutil.Drain(dctx, nc); err != nil {
+ 			slog.Error("nats drain", "error", err)
+ 		}
+ 	}()
+```
+
+Ensure `"time"` is imported.
+
+- [ ] **Step 4: Convert `user-presence-service/sync`**
+
+```go
+ 	defer func() {
+-		if err := nc.Drain(); err != nil {
++		// ctx is already cancelled on SIGTERM by the time this defer runs, so
++		// the drain deadline must not be derived from it.
++		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
++		defer cancel()
++		if err := natsutil.Drain(dctx, nc); err != nil {
+ 			slog.Warn("nats drain", "error", err)
+ 		}
+ 	}()
+```
+
+Ensure `"time"` is imported.
+
+- [ ] **Step 5: Build, test, lint**
+
+Run: `make build SERVICE=botplatform-service && make build SERVICE=admin-service && make build SERVICE=teams-room-creation && make build SERVICE=user-presence-service`
+
+Run: `make test`
+
+Run: `make lint`
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: block on NATS drain in inline and deferred shutdown paths
+
+botplatform-service and admin-service drained inline inside a combined
+shutdown hook; teams-room-creation and user-presence-service/sync drained
+from a defer in their run function. All four returned instantly.
+
+The deferred sites derive their deadline via context.WithoutCancel — the
+parent context is already cancelled on SIGTERM, so deriving from it
+directly would expire the drain immediately and silently do nothing."
+```
+
+---
+
+### Task 5: Convert Shape D — `nc.Close()` sites (2 sites)
+
+**Files:**
+- Modify: `hr-sync-worker/main.go:90-104`
+- Modify: `teams-hr-sync/main.go:139`
+
+**Interfaces:**
+- Consumes: `natsutil.Drain(ctx context.Context, conn *o11ynats.Conn) error` from Task 1.
+- Produces: nothing.
+
+**Background:** `hr-sync-worker` closes the connection inside the same hook that disconnects Mongo, after a separate hook has stopped the consumers. Between `cc.Stop()` and `Close()` there are in-flight JetStream acks in the client write buffer; `Close` drops them and those messages redeliver on the next start. CLAUDE.md's worker cleanup order is `iter.Stop()` → `wg.Wait()` → `nc.Drain()` → disconnect databases, so the drain belongs in its own hook between the consumer stop and the Mongo disconnect.
+
+`teams-hr-sync` is **not** losing data today — its `js.PublishMsg` (`main.go:179`) is synchronous and every `PubAck` is in hand before the deferred `Close` runs. Convert it for consistency and to stop the pattern being copied, not to fix a live bug.
+
+- [ ] **Step 1: Split `hr-sync-worker`'s drain into its own hook**
+
+```go
+ 	shutdown.Wait(ctx, 25*time.Second,
+ 		func(_ context.Context) error {
+ 			for _, cc := range consumeCtxs {
+ 				cc.Stop()
+ 			}
+ 			return nil
+ 		},
+ 		func(ctx context.Context) error { return healthStop(ctx) },
++		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
+ 		func(ctx context.Context) error {
+ 			mongoutil.Disconnect(ctx, mongoClient)
+-			nc.Close()
+ 			return nil
+ 		},
+ 		func(ctx context.Context) error { return obsShutdown(ctx) },
+ 	)
+```
+
+- [ ] **Step 2: Convert `teams-hr-sync`**
+
+```go
+-	defer nc.Close()
++	defer func() {
++		// ctx is already cancelled on SIGTERM by the time this defer runs, so
++		// the drain deadline must not be derived from it.
++		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
++		defer cancel()
++		if err := natsutil.Drain(dctx, nc); err != nil {
++			slog.Error("nats drain", "error", err)
++		}
++	}()
+```
+
+Ensure `"time"` and `"log/slog"` are imported.
+
+- [ ] **Step 3: Verify no stray closes remain**
+
+Run: `grep -rn "nc\.Close()" --include="*.go" . | grep -v _test | grep -v tools/`
+
+Expected: exactly one line — `pkg/testutil/nats_binary.go:68`. That is test-harness teardown, not a service shutdown path; **leave it alone**. Before this task the same grep also lists `teams-hr-sync/main.go:139` and `hr-sync-worker/main.go:100`, which are the two sites being converted here.
+
+- [ ] **Step 4: Build, test, lint**
+
+Run: `make build SERVICE=hr-sync-worker && make build SERVICE=teams-hr-sync`
+
+Run: `make test`
+
+Run: `make lint`
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: drain instead of close in hr-sync-worker and teams-hr-sync
+
+hr-sync-worker closed the connection after stopping its consumers, dropping
+buffered JetStream acks and forcing redelivery. Its drain now has its own
+hook between the consumer stop and the Mongo disconnect, matching the
+documented worker cleanup order.
+
+teams-hr-sync was not losing data — its JetStream publishes are synchronous
+and acked before the defer ran — but is converted so the pattern is not
+copied."
+```
+
+---
+
+### Task 6: Convert `data-migration` shutdown paths (5 sites)
+
+**Files:**
+- Modify: `data-migration/oplog-connector/main.go:97` and `:234`
+- Modify: `data-migration/oplog-transformer/main.go:131`
+- Modify: `data-migration/oplog-direct-transfer/main.go:149`
+- Modify: `data-migration/oplog-collections-transformer/main.go:183`
+
+**Interfaces:**
+- Consumes: `natsutil.Drain(ctx context.Context, conn *o11ynats.Conn) error` from Task 1.
+- Produces: nothing.
+
+**Background — read before touching anything here.** These four binaries contain **19** `nc.Drain()` calls. Only the 5 listed above are shutdown paths. The other **14 are startup error paths and must be left exactly as they are**:
+
+```go
+js, err := nc.JetStream()
+if err != nil {
+	slog.Error("jetstream init failed", "error", err)
+	_ = nc.Drain()
+	mongoutil.Disconnect(ctx, client)
+	os.Exit(1)
+}
+```
+
+Nothing has been published at that point, so there is nothing buffered to flush, and blocking up to 15s before an error exit is strictly worse than the current behavior. Converting them would be a regression, not a completion.
+
+The 14 to leave alone: `oplog-connector:135,140,147`; `oplog-transformer:82,108,118`; `oplog-direct-transfer:96,104,127,138`; `oplog-collections-transformer:111,119,158,169`.
+
+- [ ] **Step 1: Convert the four `shutdown.Wait` hooks**
+
+`oplog-connector:97`:
+
+```go
+-		func(context.Context) error { return conn.nc.Drain() },
++		func(ctx context.Context) error { return natsutil.Drain(ctx, conn.nc) },
+```
+
+`oplog-transformer:131`, `oplog-direct-transfer:149`, `oplog-collections-transformer:183`:
+
+```go
+-		func(context.Context) error { return nc.Drain() },
++		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
+```
+
+- [ ] **Step 2: Convert `oplog-connector`'s shutdown function**
+
+At `oplog-connector/main.go:234`, inside the function that already does a bounded `awaitWatchers`:
+
+```go
+ 	c.beginShutdown()
+ 	wctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+ 	defer cancel()
+ 	if err := c.awaitWatchers(wctx); err != nil {
+ 		slog.Warn("watcher drain incomplete", "error", err)
+ 	}
+-	_ = c.nc.Drain()
++	dctx, dcancel := context.WithTimeout(context.Background(), 15*time.Second)
++	defer dcancel()
++	if err := natsutil.Drain(dctx, c.nc); err != nil {
++		slog.Warn("nats drain incomplete", "error", err)
++	}
+ 	mongoutil.Disconnect(context.Background(), c.client)
+```
+
+This one already derives from `context.Background()`, so no `WithoutCancel` is needed.
+
+- [ ] **Step 3: Confirm the 14 error paths are untouched**
+
+Run: `grep -rn "_ = nc.Drain()" --include="*.go" data-migration | wc -l`
+
+Expected: `14`. If this prints anything else, an error path was converted by mistake — revert it.
+
+- [ ] **Step 4: Build, test, lint**
+
+Run: `make build SERVICE=data-migration/oplog-connector && make build SERVICE=data-migration/oplog-transformer && make build SERVICE=data-migration/oplog-direct-transfer && make build SERVICE=data-migration/oplog-collections-transformer`
+
+Run: `make test`
+
+Run: `make lint`
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: block on NATS drain in data-migration shutdown paths
+
+Converts the four shutdown.Wait hooks and oplog-connector's own shutdown
+function. The 14 startup error-path drains are deliberately left alone:
+they run before anything is published and are followed immediately by
+os.Exit(1), so blocking there would only delay an error exit."
+```
+
+---
+
+### Task 7: Final verification sweep
+
+**Files:** none modified.
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Confirm no unconverted drain or close sites remain outside `tools/`**
+
+Run: `grep -rn "nc\.Drain()\|nc\.Close()\|NatsConn()\.Drain()" --include="*.go" . --exclude="*_test.go" | grep -v "^./tools/" | grep -v "_ = nc.Drain()" | grep -v "^\./pkg/"`
+
+Expected: exactly one line — the comment at `outbox-worker/main.go:200`, which mentions `nc.Drain()` in prose while describing a WaitGroup race and is not a call site. Any other hit is a site the sweep missed.
+
+The grep deliberately excludes `pkg/`: `pkg/natsrouter/router.go:268` calls `Subscription.Drain()`, which is a different method with its own correct wait already implemented, and `pkg/natsutil/drain.go` is the new helper itself. Before this task's conversions the same grep returns 31 lines (25 root-service sites + 5 in `data-migration` + that one comment).
+
+- [ ] **Step 2: Full test suite with race detector**
+
+Run: `make test`
+
+Expected: PASS across all packages.
+
+- [ ] **Step 3: Lint**
+
+Run: `make lint`
+
+Expected: no findings.
+
+- [ ] **Step 4: SAST**
+
+Run: `make sast`
+
+Expected: no medium-or-higher findings. This is a blocking CI gate, so run it before pushing rather than discovering it in CI.
+
+- [ ] **Step 5: Coverage check on the new code**
+
+Run: `go test -race -coverprofile=/tmp/claude-0/-home-user-newchat/8d24fbda-5dbb-53c0-8a07-ddeccbb30dc1/scratchpad/cover.out ./pkg/natsutil/... && go tool cover -func=/tmp/claude-0/-home-user-newchat/8d24fbda-5dbb-53c0-8a07-ddeccbb30dc1/scratchpad/cover.out | grep -E "drain.go|slowconsumer.go|total:"`
+
+Expected: `drain.go` and `slowconsumer.go` functions at 90%+, package total above the 80% floor.
+
+- [ ] **Step 6: Push**
+
+```bash
+git push -u origin claude/nats-graceful-shutdown-b40zva
+```
+
+Do not open a PR unless explicitly asked.
+
+---
+
+## Notes for the reviewer
+
+**No wire, schema, or config change.** Nothing here is client-facing, so `docs/client-api.md` and its derived views are untouched.
+
+**Expected behavior change:** services will now take up to ~20s to exit instead of exiting instantly. That is the point — but it will look like a pod-restart regression on first deploy. A service that sits at the full 15s drain timeout has a wedged subscription handler, which is a real finding, not a bug in this change.
+
+**Deliberately out of scope**, so the omissions are not read as oversights:
+- `SetPendingLimits` tuning for `broadcast-worker` — diagnose with the new counter first, tune with real numbers second.
+- `tools/loadgen` (11 files) — a dev harness where a publish lost at exit changes nothing.
+- The 14 `data-migration` startup error paths (Task 6).
+- Payload size checks and `NoResponders` error mapping — PR 2, separate spec.

--- a/docs/superpowers/specs/2026-08-11-nats-connection-handling-design.md
+++ b/docs/superpowers/specs/2026-08-11-nats-connection-handling-design.md
@@ -16,7 +16,7 @@ and `NoResponders` mapping) gets its own spec.
 | `natsutil.Drain` — make graceful shutdown actually wait | new, `pkg/natsutil/drain.go` |
 | `nats.DrainTimeout` default | `pkg/natsutil/connect.go` |
 | Slow consumer diagnostics + counter | `pkg/natsutil/connect.go`, new `pkg/natsutil/slowconsumer.go` |
-| Call-site conversion | 25 root services + 4 `data-migration` binaries |
+| Call-site conversion | 25 sites in root services + 5 in `data-migration` |
 
 ### Out of scope
 
@@ -273,9 +273,31 @@ the drain immediately.
   is in hand before the defer runs. Convert for consistency and to keep the
   pattern from being copied, not to fix a live bug.
 
-**`data-migration` (4 binaries).** `oplog-connector`, `oplog-transformer`,
-`oplog-direct-transfer`, `oplog-collections-transformer`. These move real data;
-converted with the rest.
+**Shape E — startup error path (14 sites, deliberately NOT converted).**
+Across the four `data-migration` binaries, most `_ = nc.Drain()` calls look like
+this:
+
+```go
+js, err := nc.JetStream()
+if err != nil {
+	slog.Error("jetstream init failed", "error", err)
+	_ = nc.Drain()
+	mongoutil.Disconnect(ctx, client)
+	os.Exit(1)
+}
+```
+
+This is best-effort cleanup on a startup failure, followed immediately by
+`os.Exit(1)`. Nothing has been published yet, so there is nothing buffered to
+flush, and blocking up to 15s before an error exit is strictly worse than the
+current behavior. Left as-is. Listed here so a reviewer does not read the
+omission as an oversight.
+
+**`data-migration` real shutdown sites (5).** `oplog-connector:97` and `:234`,
+`oplog-transformer:131`, `oplog-direct-transfer:149`,
+`oplog-collections-transformer:183` — the `shutdown.Wait` hooks plus
+`oplog-connector`'s own shutdown function, which already does a bounded
+`awaitWatchers` before draining. These move real data; converted with the rest.
 
 ## Testing
 
@@ -291,7 +313,7 @@ TDD, red first. `pkg/natsutil` already runs an embedded NATS server in
 | Ctx expiry | wedged handler + already-expired ctx → error wrapping `context.DeadlineExceeded` |
 | Already closed | `nc.Close()` then `Drain` → nil |
 | Idempotent | second `Drain` → nil (library already guards via `isDraining`; a concurrent second caller still waits for CLOSED) |
-| No listener leak | `RemoveStatusListener` runs on every exit path |
+| Nil conn | returns nil, no panic |
 | `DrainTimeout` applied | option present on the connection |
 
 `slowconsumer_test.go`:
@@ -302,6 +324,10 @@ TDD, red first. `pkg/natsutil` already runs an embedded NATS server in
 | `nil` subscription | no panic, degraded field set |
 | Closed subscription | no panic, errors from `Dropped`/`Pending` handled |
 | Level selection | ERROR when `dropped > 0`, WARN when 0 |
+
+Listener cleanup is structural — `defer nc.RemoveStatusListener(ch)` covers every
+exit path — so it is reviewed, not separately asserted. There is no public API
+to count registered listeners.
 
 Coverage: 80% floor repo-wide, 90% target for `pkg/`.
 

--- a/docs/superpowers/specs/2026-08-11-nats-connection-handling-design.md
+++ b/docs/superpowers/specs/2026-08-11-nats-connection-handling-design.md
@@ -207,20 +207,38 @@ nats.ErrorHandler(func(_ *nats.Conn, sub *nats.Subscription, err error) {
 
 New file `pkg/natsutil/slowconsumer.go`:
 
-- `slowConsumerFields(sub *nats.Subscription) []any` — returns `subject`,
-  `queue`, `dropped`, `pending_msgs`, `pending_bytes`, `limit_msgs`,
-  `limit_bytes`. Split out from the handler purely so it is testable against a
-  real subscription. It must tolerate `sub == nil` (connection-level async
-  errors pass nil) and the errors `Dropped()`/`Pending()`/`PendingLimits()`
-  return on an already-closed subscription — a diagnostic path must never panic
-  during shutdown.
+- `subDropped(sub *nats.Subscription) (int, bool)` — one read of `Dropped()`,
+  reporting whether it could be read at all. The caller threads the result into
+  both the level decision and the field list, so a subscription that closes
+  mid-report cannot produce an ERROR line saying "messages dropped" whose field
+  set silently omits the count.
+- `slowConsumerFields(sub *nats.Subscription, dropped int, ok bool) []any` —
+  returns `subject`, `queue`, `dropped`, `pending_msgs`, `pending_bytes`,
+  `limit_msgs`, `limit_bytes`. Split out from the handler purely so it is
+  testable against a real subscription. It must tolerate `sub == nil`
+  (connection-level async errors pass nil) and the errors `Pending()` /
+  `PendingLimits()` return on an already-closed subscription, omitting what it
+  cannot read rather than reporting a bogus zero — a diagnostic path must never
+  panic during shutdown.
 - `logSlowConsumer(log *slog.Logger, sub *nats.Subscription)` — logs at **ERROR**
-  when `Dropped() > 0`, **WARN** otherwise. Dropped messages on a core NATS
-  subscription are unrecoverable loss and should page; a slow consumer that has
-  not yet dropped anything is a warning.
-- An otel counter `nats_slow_consumer_dropped_total{subject,queue}`, following
-  the `pkg/cachemetrics` shape (`otel.Meter(...)`, no-op when no MeterProvider is
-  installed) so it records unconditionally without a wiring precondition.
+  when the drop count is above zero, **WARN** otherwise. Dropped messages on a
+  core NATS subscription are unrecoverable loss and should page; a slow consumer
+  that has not yet dropped anything is a warning.
+- An otel counter `nats_slow_consumer_events_total{subject,queue}`, following
+  the `pkg/roomkeymetrics` shape (package-level var, `init()` from
+  `otel.Meter(...)`, no-op fallback) so it records unconditionally without a
+  wiring precondition.
+
+  **It counts episodes, one per callback — not messages.** `Subscription.Dropped()`
+  is a cumulative total never reset except on unsubscribe (`nats.go:3770`,
+  `:5574-5584`), and the async error callback fires only on the
+  Active→SlowConsumer transition (`nats.go:3771-3787`), with `sub.sc` cleared
+  again on the next successful delivery (`:3742`). Adding `Dropped()` per episode
+  would re-add every earlier episode's drops — 3 dropped then 5 dropped would
+  report 3 + 8 = 11. The callback is also dispatched through an async queue
+  (`:3785`), so a `Dropped()` read inside it is not even the count at episode
+  time. Exact per-episode numbers belong in the log fields, where they are read
+  once and reported accurately.
 
 ### D. Call-site conversion
 

--- a/docs/superpowers/specs/2026-08-11-nats-connection-handling-design.md
+++ b/docs/superpowers/specs/2026-08-11-nats-connection-handling-design.md
@@ -163,13 +163,22 @@ as every other hook and cannot outlive it.
 Add to `baseOpts` in `Connect`:
 
 ```go
-nats.DrainTimeout(defaultDrainTimeout), // 15 * time.Second
+nats.DrainTimeout(defaultDrainTimeout), // 10 * time.Second
 ```
 
-Worst case: 15s subscription drain + `drainConnection`'s internal
-`FlushTimeout(5s)` = 20s, inside the 25s hook budget, inside the 30s Kubernetes
-grace period. A package const rather than an env var — no service should want a
-different answer, and `Connect` already appends caller `opts` after `baseOpts`
+Worst case: 10s subscription drain + `drainConnection`'s internal
+`FlushTimeout(5s)` = 15s, inside the 25s shutdown budget, inside the 30s
+Kubernetes grace period.
+
+The 25s is **shared, not per-hook**: `shutdown.Wait` creates one context for the
+whole shutdown and runs the hooks sequentially over it
+(`pkg/shutdown/shutdown.go:21-32`). A 15s worst-case drain therefore leaves ~10s
+for every remaining hook — DB disconnects, HTTP shutdown, o11y flush — which are
+sub-second in practice. A drain that genuinely needs more than 10s means a
+wedged handler, which is a finding to surface rather than a wait to extend.
+
+A package const rather than an env var — no service should want a different
+answer, and `Connect` already appends caller `opts` after `baseOpts`
 (`connect.go:60`), so a caller that genuinely needs to override still can.
 
 ### C. Slow consumer diagnostics
@@ -249,7 +258,7 @@ scope. Delete the now-false comment at `admin-service:93-95`.
 
 ```go
 defer func() {
-	dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+	dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
 	defer cancel()
 	if err := natsutil.Drain(dctx, nc); err != nil {
 		slog.Error("nats drain", "error", err)
@@ -335,10 +344,10 @@ Coverage: 80% floor repo-wide, 90% target for `pkg/`.
 
 No wire, schema, or config change. No `docs/client-api.md` impact — nothing here
 is client-facing. Behavior change is confined to shutdown, where services will
-now take up to ~20s to exit instead of exiting instantly, and slow consumer
+now take up to ~15s to exit instead of exiting instantly, and slow consumer
 events become visible.
 
 The one risk worth watching: a service with a wedged subscription handler that
-previously exited instantly will now sit until the 15s drain timeout. That is
+previously exited instantly will now sit until the 10s drain timeout. That is
 the correct behavior — it is the signal that the handler is wedged — but it will
 look like a regression in pod restart time on first deploy. Expected, not a bug.

--- a/docs/superpowers/specs/2026-08-11-nats-connection-handling-design.md
+++ b/docs/superpowers/specs/2026-08-11-nats-connection-handling-design.md
@@ -1,0 +1,318 @@
+# NATS Connection Handling: Real Drain + Slow Consumer Visibility (PR 1 of 2)
+
+Four gaps were raised against our NATS usage: graceful shutdown, slow consumer
+warnings, payload size checks, and `NoResponders` in request/reply errors. They
+split cleanly along a seam: two are properties of the *connection* and belong in
+`pkg/natsutil`; two are call-site sweeps that touch handler code and the client
+API docs.
+
+This spec covers **PR 1** — the connection-level pair. PR 2 (payload size checks
+and `NoResponders` mapping) gets its own spec.
+
+## Scope
+
+| Change | Where |
+|--------|-------|
+| `natsutil.Drain` — make graceful shutdown actually wait | new, `pkg/natsutil/drain.go` |
+| `nats.DrainTimeout` default | `pkg/natsutil/connect.go` |
+| Slow consumer diagnostics + counter | `pkg/natsutil/connect.go`, new `pkg/natsutil/slowconsumer.go` |
+| Call-site conversion | 25 root services + 4 `data-migration` binaries |
+
+### Out of scope
+
+- **`SetPendingLimits`.** Raising the per-subscription buffer (default 512k msgs
+  / 64MB) is the actual *remedy* for fanout pressure in `broadcast-worker`. It is
+  per-subscription, so it cannot be a `Connect` default, and picking a number
+  before we can see drop counts would be guessing. Diagnose first (this spec),
+  tune second (follow-up, with real numbers).
+- **`tools/loadgen`** (11 files). A dev harness — a publish lost at exit changes
+  nothing. Converting it would triple the diff for no operational gain.
+- Payload size checks and `NoResponders` mapping — PR 2.
+
+## The bug
+
+`nc.Drain()` does not drain. From `nats.go@v1.50.0:6055-6075`:
+
+```go
+func (nc *Conn) Drain() error {
+	nc.mu.Lock()
+	if nc.isClosed() {
+		nc.mu.Unlock()
+		return ErrConnectionClosed
+	}
+	if nc.isConnecting() || nc.isReconnecting() {
+		nc.mu.Unlock()
+		nc.Close()
+		return ErrConnectionReconnecting
+	}
+	if nc.isDraining() {
+		nc.mu.Unlock()
+		return nil
+	}
+	nc.changeConnStatus(DRAINING_SUBS)
+	go nc.drainConnection()
+	nc.mu.Unlock()
+
+	return nil
+}
+```
+
+Its own doc comment names the fix: *"Use the ClosedCB option to know when the
+connection has moved from draining to closed."* Nothing in this repo does.
+
+It flips status, spawns `drainConnection` on a goroutine, and returns `nil`. All
+the real work — draining each subscription, then `FlushTimeout(5s)` to push
+buffered bytes to the server, then `Close()` — happens on that goroutine.
+
+Every service does this:
+
+```go
+func(ctx context.Context) error { return nc.Drain() },
+```
+
+The hook returns `nil` instantly. `shutdown.Wait` proceeds to the remaining
+hooks, `main` returns, the process exits, and `drainConnection` dies wherever it
+got to. What is in the client write buffer at that moment is lost: JetStream
+acks (→ redelivery), request/reply responses (→ caller timeout), OUTBOX forwards.
+
+The trap is documented at exactly one site, `admin-service/main.go:93-95`:
+
+```go
+// srv.Shutdown has already waited out any in-flight toggle, so
+// Drain (which returns immediately and finishes in the background)
+// only closes the idle connection.
+```
+
+The reasoning is locally sound — `admin-service` is HTTP-only with an idle NATS
+connection — but the behavior it describes was never generalized to the 22 sites
+where the connection is *not* idle.
+
+**Secondary:** `nats.DrainTimeout` is never set, so it defaults to 30s
+(`DefaultDrainTimeout`, `nats.go:65`). That is larger than the 25s budget and equal to
+the Kubernetes `terminationGracePeriodSeconds`, so the internal timeout can never
+be the thing that fires — SIGKILL beats it.
+
+## Design
+
+### A. `natsutil.Drain`
+
+New file `pkg/natsutil/drain.go`:
+
+```go
+// Drain puts the connection into the drain state and blocks until it reaches
+// CLOSED or ctx expires.
+//
+// nats.Conn.Drain() only *starts* the drain — it spawns drainConnection on a
+// goroutine and returns nil immediately — so a shutdown hook that calls it
+// directly returns before subscriptions have drained and before the final
+// publish flush, and the process exits with buffered acks and replies still in
+// the write buffer.
+func Drain(ctx context.Context, conn *o11ynats.Conn) error {
+	nc := conn.NatsConn()
+
+	// Register before Drain so a fast close cannot fire in the gap between the
+	// two calls; re-check IsClosed after, to cover a close that landed before
+	// the listener was in place. Together these close both sides of the race.
+	ch := nc.StatusChanged(nats.CLOSED)
+	defer nc.RemoveStatusListener(ch)
+
+	if err := nc.Drain(); err != nil {
+		switch {
+		case errors.Is(err, nats.ErrConnectionClosed):
+			return nil
+		case errors.Is(err, nats.ErrConnectionReconnecting):
+			// Drain hard-closed the connection. Buffered publishes are gone,
+			// but there was no reachable server to flush them to — this is a
+			// normal shutdown-during-outage, not a failure to report.
+			slog.WarnContext(ctx, "nats drain skipped: connection reconnecting")
+			return nil
+		default:
+			return fmt.Errorf("start nats drain: %w", err)
+		}
+	}
+	if nc.IsClosed() {
+		return nil
+	}
+
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("nats drain incomplete: %w", ctx.Err())
+	}
+}
+```
+
+Why `StatusChanged` rather than a `ClosedHandler`: `connect.go:53` already
+installs a `ClosedHandler` for logging, and `nats.Option`s of the same kind
+overwrite rather than compose. `Conn.StatusChanged` (`nats.go:6379`) is an
+independent listener registry, so it does not contend for that slot. The channel
+it returns is buffered (cap 10) and `changeConnStatus` (`nats.go:6451`) fires
+`sendStatusEvent` on every transition, so the CLOSED signal cannot be missed
+once the listener is registered.
+
+The two benign errors matter for noise: today `ErrConnectionClosed` and
+`ErrConnectionReconnecting` propagate out of the hook and surface as shutdown
+errors on ordinary restarts.
+
+`ctx` is the one `shutdown.Wait` passes, so the wait shares the same 25s budget
+as every other hook and cannot outlive it.
+
+### B. Drain timeout
+
+Add to `baseOpts` in `Connect`:
+
+```go
+nats.DrainTimeout(defaultDrainTimeout), // 15 * time.Second
+```
+
+Worst case: 15s subscription drain + `drainConnection`'s internal
+`FlushTimeout(5s)` = 20s, inside the 25s hook budget, inside the 30s Kubernetes
+grace period. A package const rather than an env var — no service should want a
+different answer, and `Connect` already appends caller `opts` after `baseOpts`
+(`connect.go:60`), so a caller that genuinely needs to override still can.
+
+### C. Slow consumer diagnostics
+
+`connect.go:56` discards the subscription:
+
+```go
+nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
+	log.Error("nats async error", "error", err)
+}),
+```
+
+A slow consumer logs `nats async error: nats: slow consumer, messages dropped`
+— no subject, no queue group, no count. Nothing to act on, nothing to alert on.
+Replace with:
+
+```go
+nats.ErrorHandler(func(_ *nats.Conn, sub *nats.Subscription, err error) {
+	if errors.Is(err, nats.ErrSlowConsumer) {
+		logSlowConsumer(log, sub)
+		return
+	}
+	log.Error("nats async error", "error", err)
+}),
+```
+
+New file `pkg/natsutil/slowconsumer.go`:
+
+- `slowConsumerFields(sub *nats.Subscription) []any` — returns `subject`,
+  `queue`, `dropped`, `pending_msgs`, `pending_bytes`, `limit_msgs`,
+  `limit_bytes`. Split out from the handler purely so it is testable against a
+  real subscription. It must tolerate `sub == nil` (connection-level async
+  errors pass nil) and the errors `Dropped()`/`Pending()`/`PendingLimits()`
+  return on an already-closed subscription — a diagnostic path must never panic
+  during shutdown.
+- `logSlowConsumer(log *slog.Logger, sub *nats.Subscription)` — logs at **ERROR**
+  when `Dropped() > 0`, **WARN** otherwise. Dropped messages on a core NATS
+  subscription are unrecoverable loss and should page; a slow consumer that has
+  not yet dropped anything is a warning.
+- An otel counter `nats_slow_consumer_dropped_total{subject,queue}`, following
+  the `pkg/cachemetrics` shape (`otel.Meter(...)`, no-op when no MeterProvider is
+  installed) so it records unconditionally without a wiring precondition.
+
+### D. Call-site conversion
+
+Four distinct shapes, not one. Each needs its own treatment.
+
+**Shape A — hook lambda (19 sites).** Mechanical:
+
+```go
+-func(ctx context.Context) error { return nc.Drain() },
++func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
+```
+
+`bot-message-handler:92`, `bot-message-worker:177`, `bot-room-service:109`,
+`broadcast-worker:275`, `history-service/cmd:242`, `inbox-worker:776`,
+`media-service:107`, `message-gatekeeper:222`, `message-worker:271`,
+`notification-worker:390`, `outbox-worker:186`, `push-notification-service:118`,
+`room-service:306`, `room-worker:312`, `search-service:265`,
+`search-sync-worker:351`, `translation-service:121`, `user-presence-service:163`,
+`user-service:146`.
+
+Note the sites taking `_ context.Context` need the parameter named to pass it on.
+
+**Shape B — inline inside a combined hook, error downgraded to a log (2 sites).**
+`botplatform-service:127`, `admin-service:98`. Both sit inside a hook that also
+shuts down the HTTP server and disconnects Mongo/Valkey, and both swallow the
+drain error into `slog.Warn`. Convert to `natsutil.Drain(ctx, nc)` in place,
+keeping the existing swallow — the surrounding hook returns the *HTTP server's*
+error, and changing which error wins is a behavior change outside this spec's
+scope. Delete the now-false comment at `admin-service:93-95`.
+
+**Shape C — `defer` in a run function (2 sites).** `teams-room-creation:71`,
+`user-presence-service/sync:106`. Same bug in a different wrapper: the deferred
+`Drain` returns instantly and `run` returns to `main`, which exits. These have no
+`shutdown.Wait` ctx to borrow, so give them a bounded one:
+
+```go
+defer func() {
+	dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+	defer cancel()
+	if err := natsutil.Drain(dctx, nc); err != nil {
+		slog.Error("nats drain", "error", err)
+	}
+}()
+```
+
+`context.WithoutCancel` is load-bearing: on SIGTERM the parent `ctx` is already
+cancelled by the time the defer runs, so deriving from it directly would expire
+the drain immediately.
+
+**Shape D — `nc.Close()` (2 sites).**
+
+- `hr-sync-worker:100` — closes after stopping consumers, inside the same hook
+  that disconnects Mongo. Between `cc.Stop()` and `Close()` there are in-flight
+  JetStream acks in the write buffer; `Close` drops them and the messages
+  redeliver. Split into its own drain hook, ordered after the consumer stop and
+  before the Mongo disconnect, per the CLAUDE.md worker cleanup order.
+- `teams-hr-sync:139` — `defer nc.Close()` in a one-shot CronJob. **Not** losing
+  data today: `js.PublishMsg` (`main.go:179`) is synchronous and every `PubAck`
+  is in hand before the defer runs. Convert for consistency and to keep the
+  pattern from being copied, not to fix a live bug.
+
+**`data-migration` (4 binaries).** `oplog-connector`, `oplog-transformer`,
+`oplog-direct-transfer`, `oplog-collections-transformer`. These move real data;
+converted with the rest.
+
+## Testing
+
+TDD, red first. `pkg/natsutil` already runs an embedded NATS server in
+`reply_test.go:40`, so all of this is testable without mocks or a container.
+
+`drain_test.go`:
+
+| Case | Assertion |
+|------|-----------|
+| Happy path | subscribe + publish, `Drain` returns nil, `nc.IsClosed()` is true on return |
+| Actually blocks | a handler held open by a channel; `Drain` must not return before it completes |
+| Ctx expiry | wedged handler + already-expired ctx → error wrapping `context.DeadlineExceeded` |
+| Already closed | `nc.Close()` then `Drain` → nil |
+| Idempotent | second `Drain` → nil (library already guards via `isDraining`; a concurrent second caller still waits for CLOSED) |
+| No listener leak | `RemoveStatusListener` runs on every exit path |
+| `DrainTimeout` applied | option present on the connection |
+
+`slowconsumer_test.go`:
+
+| Case | Assertion |
+|------|-----------|
+| Real subscription | all seven fields present and correctly typed |
+| `nil` subscription | no panic, degraded field set |
+| Closed subscription | no panic, errors from `Dropped`/`Pending` handled |
+| Level selection | ERROR when `dropped > 0`, WARN when 0 |
+
+Coverage: 80% floor repo-wide, 90% target for `pkg/`.
+
+## Rollout
+
+No wire, schema, or config change. No `docs/client-api.md` impact — nothing here
+is client-facing. Behavior change is confined to shutdown, where services will
+now take up to ~20s to exit instead of exiting instantly, and slow consumer
+events become visible.
+
+The one risk worth watching: a service with a wedged subscription handler that
+previously exited instantly will now sit until the 15s drain timeout. That is
+the correct behavior — it is the signal that the handler is wedged — but it will
+look like a regression in pod restart time on first deploy. Expected, not a bug.

--- a/docs/superpowers/specs/2026-08-11-nats-connection-handling-design.md
+++ b/docs/superpowers/specs/2026-08-11-nats-connection-handling-design.md
@@ -267,7 +267,13 @@ shuts down the HTTP server and disconnects Mongo/Valkey, and both swallow the
 drain error into `slog.Warn`. Convert to `natsutil.Drain(ctx, nc)` in place,
 keeping the existing swallow — the surrounding hook returns the *HTTP server's*
 error, and changing which error wins is a behavior change outside this spec's
-scope. Delete the now-false comment at `admin-service:93-95`.
+scope.
+
+At `admin-service:93-95`, delete only the now-false clause ("Drain … returns
+immediately and finishes in the background … only closes the idle connection").
+The first clause — that `srv.Shutdown` has already waited out any in-flight
+toggle — remains true, since the ordering is unchanged, and it documents why
+draining at that point is cheap. Keep it.
 
 **Shape C — `defer` in a run function (2 sites).** `teams-room-creation:71`,
 `user-presence-service/sync:106`. Same bug in a different wrapper: the deferred

--- a/history-service/cmd/main.go
+++ b/history-service/cmd/main.go
@@ -239,7 +239,7 @@ func main() {
 
 	shutdown.Wait(ctx, 25*time.Second,
 		func(ctx context.Context) error { return router.Shutdown(ctx) },
-		func(ctx context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, mongoClient); return nil },
 		func(ctx context.Context) error { cassutil.Close(cassSession); return nil },
 		func(ctx context.Context) error {

--- a/hr-sync-worker/main.go
+++ b/hr-sync-worker/main.go
@@ -95,9 +95,9 @@ func main() {
 			return nil
 		},
 		func(ctx context.Context) error { return healthStop(ctx) },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error {
 			mongoutil.Disconnect(ctx, mongoClient)
-			nc.Close()
 			return nil
 		},
 		func(ctx context.Context) error { return obsShutdown(ctx) },

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -773,7 +773,7 @@ func main() {
 				return fmt.Errorf("worker drain timed out: %w", ctx.Err())
 			}
 		},
-		func(ctx context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, mongoClient); return nil },
 		func(ctx context.Context) error { return healthStop(ctx) },
 		func(ctx context.Context) error { return obsShutdown(ctx) },

--- a/media-service/main.go
+++ b/media-service/main.go
@@ -104,7 +104,7 @@ func run() error {
 
 	go shutdown.Wait(ctx, 25*time.Second,
 		func(ctx context.Context) error { return router.Shutdown(ctx) },
-		func(_ context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error {
 			slog.Info("shutting down media-service")
 			return srv.Shutdown(ctx)

--- a/media-service/main.go
+++ b/media-service/main.go
@@ -102,20 +102,30 @@ func run() error {
 		WriteTimeout: 30 * time.Second,
 	}
 
-	go shutdown.Wait(ctx, 25*time.Second,
-		func(ctx context.Context) error { return router.Shutdown(ctx) },
-		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
-		func(ctx context.Context) error {
-			slog.Info("shutting down media-service")
-			return srv.Shutdown(ctx)
-		},
-		// obsShutdown LAST so all prior teardown telemetry is exported.
-		func(ctx context.Context) error { return obsShutdown(ctx) },
-	)
+	srvErr := make(chan error, 1)
+	go func() {
+		slog.Info("media-service listening", "port", cfg.Port, "site", cfg.SiteID)
+		srvErr <- srv.ListenAndServe()
+	}()
 
-	slog.Info("media-service listening", "port", cfg.Port, "site", cfg.SiteID)
-	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+	shutdownDone := make(chan struct{})
+	go func() {
+		defer close(shutdownDone)
+		shutdown.Wait(ctx, 25*time.Second,
+			func(ctx context.Context) error { return router.Shutdown(ctx) },
+			func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
+			func(ctx context.Context) error {
+				slog.Info("shutting down media-service")
+				return srv.Shutdown(ctx)
+			},
+			// obsShutdown LAST so all prior teardown telemetry is exported.
+			func(ctx context.Context) error { return obsShutdown(ctx) },
+		)
+	}()
+
+	if err := <-srvErr; err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return fmt.Errorf("listen and serve: %w", err)
 	}
+	<-shutdownDone
 	return nil
 }

--- a/message-gatekeeper/main.go
+++ b/message-gatekeeper/main.go
@@ -219,7 +219,7 @@ func main() {
 				return fmt.Errorf("worker drain timed out: %w", ctx.Err())
 			}
 		},
-		func(ctx context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, mongoClient); return nil },
 		func(ctx context.Context) error { return healthStop(ctx) },
 		func(_ context.Context) error { valkeyutil.Disconnect(metaValkey); return nil },

--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -268,7 +268,7 @@ func main() {
 				return fmt.Errorf("worker drain timed out: %w", ctx.Err())
 			}
 		},
-		func(ctx context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error { cassutil.Close(cassSession); return nil },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, mongoClient); return nil },
 		func(ctx context.Context) error {

--- a/notification-worker/main.go
+++ b/notification-worker/main.go
@@ -387,7 +387,7 @@ func main() {
 			invalCancel() // always release the context (idempotent)
 			return nil
 		},
-		func(_ context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, mongoClient); return nil },
 		func(_ context.Context) error { valkeyutil.Disconnect(valkeyClient); return nil },
 		func(ctx context.Context) error { return healthStop(ctx) },

--- a/outbox-worker/main.go
+++ b/outbox-worker/main.go
@@ -183,7 +183,7 @@ func main() {
 				return fmt.Errorf("worker drain timed out: %w", ctx.Err())
 			}
 		},
-		func(ctx context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error { return healthStop(ctx) },
 		// obsShutdown LAST so all prior teardown telemetry is exported.
 		func(ctx context.Context) error { return obsShutdown(ctx) },

--- a/pkg/natsutil/connect.go
+++ b/pkg/natsutil/connect.go
@@ -13,7 +13,15 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-const defaultReconnectWait = 2 * time.Second
+const (
+	defaultReconnectWait = 2 * time.Second
+	// defaultDrainTimeout bounds the subscription-drain phase. Worst case is
+	// this plus drainConnection's internal FlushTimeout(5s) = 20s, which fits
+	// inside the 25s shutdown.Wait budget and the 30s Kubernetes grace period.
+	// The library default is 30s (nats.DefaultDrainTimeout), which is larger
+	// than our budget and so could never be the timeout that fires.
+	defaultDrainTimeout = 15 * time.Second
+)
 
 // Connect opens a NATS connection with sensible reconnect defaults.
 // The NATS client name is taken from the HOSTNAME env var (pod name in
@@ -44,6 +52,7 @@ func Connect(ctx context.Context, url, credsFile string, tp trace.TracerProvider
 		nats.Name(name),
 		nats.MaxReconnects(-1),
 		nats.ReconnectWait(defaultReconnectWait),
+		nats.DrainTimeout(defaultDrainTimeout),
 		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
 			log.Warn("nats disconnected", "error", err)
 		}),

--- a/pkg/natsutil/connect.go
+++ b/pkg/natsutil/connect.go
@@ -16,11 +16,19 @@ import (
 const (
 	defaultReconnectWait = 2 * time.Second
 	// defaultDrainTimeout bounds the subscription-drain phase. Worst case is
-	// this plus drainConnection's internal FlushTimeout(5s) = 20s, which fits
-	// inside the 25s shutdown.Wait budget and the 30s Kubernetes grace period.
-	// The library default is 30s (nats.DefaultDrainTimeout), which is larger
-	// than our budget and so could never be the timeout that fires.
-	defaultDrainTimeout = 15 * time.Second
+	// this plus drainConnection's internal FlushTimeout(5s) = 15s.
+	//
+	// shutdown.Wait creates ONE context for the whole shutdown and runs the
+	// hooks sequentially over it (pkg/shutdown/shutdown.go:21-32), so this
+	// budget is shared, not per-hook: a 15s worst-case drain leaves ~10s of
+	// the 25s for every remaining hook (DB disconnects, HTTP shutdown, o11y
+	// flush), which are sub-second in practice. A drain that actually needs
+	// longer than 10s means a wedged handler — a finding to surface, not a
+	// wait to extend.
+	//
+	// The library default is 30s (nats.DefaultDrainTimeout), larger than the
+	// entire shutdown budget, so it could never be the timeout that fires.
+	defaultDrainTimeout = 10 * time.Second
 )
 
 // Connect opens a NATS connection with sensible reconnect defaults.

--- a/pkg/natsutil/connect.go
+++ b/pkg/natsutil/connect.go
@@ -2,6 +2,7 @@ package natsutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -70,7 +71,11 @@ func Connect(ctx context.Context, url, credsFile string, tp trace.TracerProvider
 		nats.ClosedHandler(func(_ *nats.Conn) {
 			log.Warn("nats connection closed")
 		}),
-		nats.ErrorHandler(func(_ *nats.Conn, _ *nats.Subscription, err error) {
+		nats.ErrorHandler(func(_ *nats.Conn, sub *nats.Subscription, err error) {
+			if errors.Is(err, nats.ErrSlowConsumer) {
+				logSlowConsumer(log, sub)
+				return
+			}
 			log.Error("nats async error", "error", err)
 		}),
 	}

--- a/pkg/natsutil/connect_test.go
+++ b/pkg/natsutil/connect_test.go
@@ -70,6 +70,6 @@ func TestConnect_SetsDrainTimeout(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(conn.NatsConn().Close)
 
-	require.Equal(t, 15*time.Second, conn.NatsConn().Opts.DrainTimeout,
-		"DrainTimeout must be under the 25s shutdown budget, not the 30s library default")
+	require.Equal(t, 10*time.Second, conn.NatsConn().Opts.DrainTimeout,
+		"DrainTimeout must leave headroom in the shared 25s shutdown budget, not the 30s library default")
 }

--- a/pkg/natsutil/connect_test.go
+++ b/pkg/natsutil/connect_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/propagation"
@@ -61,4 +62,14 @@ func TestConnect_PresentCredsFilePassesPrecheck(t *testing.T) {
 	_, err := natsutil.Connect(context.Background(), "nats://127.0.0.1:1", path,
 		noop.NewTracerProvider(), propagation.TraceContext{}, false)
 	require.False(t, errors.Is(err, os.ErrNotExist), "precheck should pass when file exists, got: %v", err)
+}
+
+func TestConnect_SetsDrainTimeout(t *testing.T) {
+	conn, err := natsutil.Connect(context.Background(), startTestServer(t), "",
+		noop.NewTracerProvider(), propagation.TraceContext{}, false)
+	require.NoError(t, err)
+	t.Cleanup(conn.NatsConn().Close)
+
+	require.Equal(t, 15*time.Second, conn.NatsConn().Opts.DrainTimeout,
+		"DrainTimeout must be under the 25s shutdown budget, not the 30s library default")
 }

--- a/pkg/natsutil/drain.go
+++ b/pkg/natsutil/drain.go
@@ -56,6 +56,18 @@ func Drain(ctx context.Context, conn *o11ynats.Conn) error {
 	case <-ch:
 		return nil
 	case <-ctx.Done():
+		// select picks pseudo-randomly when both cases are ready at once, so a
+		// drain that finished in the same instant ctx expired can still land
+		// here. Re-check before reporting failure so a completed drain is
+		// never misreported as incomplete.
+		select {
+		case <-ch:
+			return nil
+		default:
+		}
+		if nc.IsClosed() {
+			return nil
+		}
 		return fmt.Errorf("nats drain incomplete: %w", ctx.Err())
 	}
 }

--- a/pkg/natsutil/drain.go
+++ b/pkg/natsutil/drain.go
@@ -1,0 +1,61 @@
+package natsutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+	"github.com/nats-io/nats.go"
+)
+
+// Drain puts the connection into the drain state and blocks until it reaches
+// CLOSED or ctx expires.
+//
+// nats.Conn.Drain only *starts* the drain — it spawns drainConnection on a
+// goroutine and returns nil immediately — so a shutdown hook that returns
+// nc.Drain() directly returns before subscriptions have drained and before the
+// final publish flush, and the process exits with buffered JetStream acks and
+// request/reply responses still in the write buffer.
+func Drain(ctx context.Context, conn *o11ynats.Conn) error {
+	if conn == nil {
+		return nil
+	}
+	nc := conn.NatsConn()
+	if nc == nil {
+		return nil
+	}
+
+	// Register the listener before calling Drain so a fast close cannot land in
+	// the gap between the two calls, and re-check IsClosed after, to cover a
+	// close that completed before the listener was in place. Together these
+	// close both sides of the race.
+	ch := nc.StatusChanged(nats.CLOSED)
+	defer nc.RemoveStatusListener(ch)
+
+	if err := nc.Drain(); err != nil {
+		switch {
+		case errors.Is(err, nats.ErrConnectionClosed):
+			return nil
+		case errors.Is(err, nats.ErrConnectionReconnecting):
+			// Drain hard-closed the connection. Buffered publishes are gone,
+			// but there was no reachable server to flush them to — a normal
+			// shutdown-during-outage, not a failure worth reporting upward.
+			slog.WarnContext(ctx, "nats drain skipped: connection reconnecting")
+			return nil
+		default:
+			return fmt.Errorf("start nats drain: %w", err)
+		}
+	}
+	if nc.IsClosed() {
+		return nil
+	}
+
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("nats drain incomplete: %w", ctx.Err())
+	}
+}

--- a/pkg/natsutil/drain_test.go
+++ b/pkg/natsutil/drain_test.go
@@ -21,12 +21,23 @@ import (
 // production option wiring — including DrainTimeout — is what gets exercised.
 func startTestServer(t *testing.T) string {
 	t.Helper()
+	_, url := startTestServerWithHandle(t)
+	return url
+}
+
+// startTestServerWithHandle is startTestServer but also returns the
+// *natsserver.Server handle, for tests that need to shut the server down
+// mid-test (e.g. to drive a connection into RECONNECTING) rather than only
+// at t.Cleanup.
+func startTestServerWithHandle(t *testing.T) (*natsserver.Server, string) {
+	t.Helper()
 	ns, err := natsserver.NewServer(&natsserver.Options{Port: -1})
 	require.NoError(t, err)
 	ns.Start()
 	require.True(t, ns.ReadyForConnections(5*time.Second))
 	t.Cleanup(ns.Shutdown)
-	return ns.ClientURL()
+	url := ns.ClientURL()
+	return ns, url
 }
 
 func testConn(t *testing.T, url string) *o11ynats.Conn {
@@ -58,9 +69,11 @@ func TestDrain_WaitsForInFlightHandler(t *testing.T) {
 	url := startTestServer(t)
 	conn := testConn(t, url)
 
+	entered := make(chan struct{})
 	release := make(chan struct{})
 	handlerDone := make(chan struct{})
 	_, err := conn.NatsConn().Subscribe("drain.slow", func(*nats.Msg) {
+		close(entered)
 		<-release
 		close(handlerDone)
 	})
@@ -70,6 +83,12 @@ func TestDrain_WaitsForInFlightHandler(t *testing.T) {
 	pub := testConn(t, url)
 	require.NoError(t, pub.NatsConn().Publish("drain.slow", []byte("x")))
 	require.NoError(t, pub.NatsConn().Flush())
+
+	// pub.Flush only guarantees the server processed the PUB, not that this
+	// subscriber's readLoop has dispatched it yet. Wait for the handler to
+	// actually start before racing it against Drain, so a slow dispatch can't
+	// let Drain's sub.Drain() see an empty queue and skip the handler.
+	<-entered
 
 	drained := make(chan error, 1)
 	go func() {
@@ -109,6 +128,31 @@ func TestDrain_CtxExpiredReturnsError(t *testing.T) {
 	err = natsutil.Drain(ctx, conn)
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// The production path this covers: Connect sets MaxReconnects(-1), so a pod
+// that receives SIGTERM while NATS is unreachable sits in RECONNECTING
+// indefinitely and Drain is called against that state, not a healthy one.
+// nc.Drain() hard-closes the connection in that case (discarding the write
+// buffer) and returns ErrConnectionReconnecting rather than nil — Drain must
+// still report a clean nil, since the connection genuinely did reach CLOSED,
+// not surface the library's internal sentinel as a failure.
+func TestDrain_ReconnectingHardClosesAndReturnsNil(t *testing.T) {
+	ns, url := startTestServerWithHandle(t)
+	conn := testConn(t, url)
+
+	_, err := conn.NatsConn().Subscribe("drain.reconnecting", func(*nats.Msg) {})
+	require.NoError(t, err)
+
+	ns.Shutdown()
+	require.Eventually(t, conn.NatsConn().IsReconnecting, 5*time.Second, 10*time.Millisecond,
+		"connection must enter RECONNECTING once the server goes away")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, natsutil.Drain(ctx, conn))
+	require.True(t, conn.NatsConn().IsClosed())
 }
 
 func TestDrain_AlreadyClosedIsNotAnError(t *testing.T) {

--- a/pkg/natsutil/drain_test.go
+++ b/pkg/natsutil/drain_test.go
@@ -1,0 +1,133 @@
+package natsutil_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/hmchangw/chat/pkg/natsutil"
+)
+
+// startTestServer starts an embedded NATS server and returns its client URL.
+// Separate from startTestNATS (which hands back a raw *nats.Conn) because these
+// tests need to build a real *o11ynats.Conn through natsutil.Connect, so the
+// production option wiring — including DrainTimeout — is what gets exercised.
+func startTestServer(t *testing.T) string {
+	t.Helper()
+	ns, err := natsserver.NewServer(&natsserver.Options{Port: -1})
+	require.NoError(t, err)
+	ns.Start()
+	require.True(t, ns.ReadyForConnections(5*time.Second))
+	t.Cleanup(ns.Shutdown)
+	return ns.ClientURL()
+}
+
+func testConn(t *testing.T, url string) *o11ynats.Conn {
+	t.Helper()
+	conn, err := natsutil.Connect(context.Background(), url, "",
+		noop.NewTracerProvider(), propagation.TraceContext{}, false)
+	require.NoError(t, err)
+	return conn
+}
+
+func TestDrain_ClosesConnection(t *testing.T) {
+	conn := testConn(t, startTestServer(t))
+
+	_, err := conn.NatsConn().Subscribe("drain.test", func(*nats.Msg) {})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, natsutil.Drain(ctx, conn))
+	require.True(t, conn.NatsConn().IsClosed(),
+		"Drain must not return until the connection has reached CLOSED")
+}
+
+// The regression this whole change exists for: Drain must not return while a
+// handler is still running. Before the fix nats.Conn.Drain returned instantly
+// and this assertion fails with handlerDone still false.
+func TestDrain_WaitsForInFlightHandler(t *testing.T) {
+	url := startTestServer(t)
+	conn := testConn(t, url)
+
+	release := make(chan struct{})
+	handlerDone := make(chan struct{})
+	_, err := conn.NatsConn().Subscribe("drain.slow", func(*nats.Msg) {
+		<-release
+		close(handlerDone)
+	})
+	require.NoError(t, err)
+	require.NoError(t, conn.NatsConn().Flush())
+
+	pub := testConn(t, url)
+	require.NoError(t, pub.NatsConn().Publish("drain.slow", []byte("x")))
+	require.NoError(t, pub.NatsConn().Flush())
+
+	drained := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		drained <- natsutil.Drain(ctx, conn)
+	}()
+
+	select {
+	case <-drained:
+		t.Fatal("Drain returned while the handler was still in flight")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(release)
+	<-handlerDone
+	require.NoError(t, <-drained)
+}
+
+func TestDrain_CtxExpiredReturnsError(t *testing.T) {
+	url := startTestServer(t)
+	conn := testConn(t, url)
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	_, err := conn.NatsConn().Subscribe("drain.wedged", func(*nats.Msg) { <-release })
+	require.NoError(t, err)
+	require.NoError(t, conn.NatsConn().Flush())
+
+	pub := testConn(t, url)
+	require.NoError(t, pub.NatsConn().Publish("drain.wedged", []byte("x")))
+	require.NoError(t, pub.NatsConn().Flush())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err = natsutil.Drain(ctx, conn)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestDrain_AlreadyClosedIsNotAnError(t *testing.T) {
+	conn := testConn(t, startTestServer(t))
+	conn.NatsConn().Close()
+
+	require.NoError(t, natsutil.Drain(context.Background(), conn))
+}
+
+func TestDrain_Idempotent(t *testing.T) {
+	conn := testConn(t, startTestServer(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, natsutil.Drain(ctx, conn))
+	require.NoError(t, natsutil.Drain(ctx, conn))
+}
+
+func TestDrain_NilConnIsNotAnError(t *testing.T) {
+	require.NoError(t, natsutil.Drain(context.Background(), nil))
+}

--- a/pkg/natsutil/slowconsumer.go
+++ b/pkg/natsutil/slowconsumer.go
@@ -1,0 +1,90 @@
+package natsutil
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// slowConsumerDropped counts messages dropped by a subscription that could not
+// keep up, tagged by subject and queue group.
+var slowConsumerDropped metric.Int64Counter
+
+func init() {
+	var err error
+	slowConsumerDropped, err = otel.Meter("nats").Int64Counter(
+		"nats_slow_consumer_dropped_total",
+		metric.WithDescription("Messages dropped by a NATS subscription that could not keep up, by subject and queue group"),
+	)
+	if err != nil {
+		// Fall back to a no-op counter so recording stays safe even if the
+		// global meter provider is not initialised at package init time.
+		slowConsumerDropped, _ = noop.NewMeterProvider().Meter("nats").
+			Int64Counter("nats_slow_consumer_dropped_total")
+	}
+}
+
+// slowConsumerFields builds the slog fields describing a slow consumer.
+// Every accessor is best-effort: sub is nil for connection-level async errors,
+// and Dropped/Pending/PendingLimits all error on an already-closed
+// subscription, which happens routinely during shutdown. A diagnostic path
+// must never panic or mask the event it is reporting.
+func slowConsumerFields(sub *nats.Subscription) []any {
+	if sub == nil {
+		return []any{"subject", "unknown"}
+	}
+	fields := []any{"subject", sub.Subject, "queue", sub.Queue}
+	if dropped, err := sub.Dropped(); err == nil {
+		fields = append(fields, "dropped", dropped)
+	}
+	// nbytes, not bytes — a local named bytes shadows the stdlib package and
+	// trips the linter's shadow check.
+	if msgs, nbytes, err := sub.Pending(); err == nil {
+		fields = append(fields, "pending_msgs", msgs, "pending_bytes", nbytes)
+	}
+	if msgs, nbytes, err := sub.PendingLimits(); err == nil {
+		fields = append(fields, "limit_msgs", msgs, "limit_bytes", nbytes)
+	}
+	return fields
+}
+
+// subDropped returns the subscription's drop count, or 0 when it cannot be read.
+func subDropped(sub *nats.Subscription) int {
+	if sub == nil {
+		return 0
+	}
+	dropped, err := sub.Dropped()
+	if err != nil {
+		return 0
+	}
+	return dropped
+}
+
+// logSlowConsumer reports a slow consumer and records the drop count.
+func logSlowConsumer(log *slog.Logger, sub *nats.Subscription) {
+	dropped := subDropped(sub)
+	logSlowConsumerAt(log, dropped, slowConsumerFields(sub))
+	if dropped > 0 && sub != nil {
+		slowConsumerDropped.Add(context.Background(), int64(dropped),
+			metric.WithAttributes(
+				attribute.String("subject", sub.Subject),
+				attribute.String("queue", sub.Queue),
+			))
+	}
+}
+
+// logSlowConsumerAt picks the level: dropped messages on a core subscription are
+// unrecoverable loss and should page, so they log at ERROR. A slow consumer that
+// has not dropped anything yet is a warning.
+func logSlowConsumerAt(log *slog.Logger, dropped int, fields []any) {
+	if dropped > 0 {
+		log.Error("nats slow consumer, messages dropped", fields...)
+		return
+	}
+	log.Warn("nats slow consumer", fields...)
+}

--- a/pkg/natsutil/slowconsumer.go
+++ b/pkg/natsutil/slowconsumer.go
@@ -11,35 +11,65 @@ import (
 	"go.opentelemetry.io/otel/metric/noop"
 )
 
-// slowConsumerDropped counts messages dropped by a subscription that could not
-// keep up, tagged by subject and queue group.
-var slowConsumerDropped metric.Int64Counter
+// slowConsumerEvents counts slow-consumer episodes, tagged by subject and queue
+// group.
+//
+// One increment per episode — deliberately NOT the subscription's drop count.
+// Subscription.Dropped() is a cumulative total that is never reset except on
+// unsubscribe (nats.go:3770, 5574-5584), and the async error callback fires only
+// on the Active->SlowConsumer transition (nats.go:3771-3787), with sub.sc cleared
+// again on the next successful delivery (nats.go:3742). Adding Dropped() would
+// therefore re-add every earlier episode's drops on each new episode: 3 dropped
+// then 5 dropped reports 3 + 8 = 11. The callback is also dispatched through an
+// async queue (nats.go:3785), so Dropped() read inside it is not even the count
+// at episode time. Exact per-episode numbers live in the log fields.
+var slowConsumerEvents metric.Int64Counter
 
 func init() {
 	var err error
-	slowConsumerDropped, err = otel.Meter("nats").Int64Counter(
-		"nats_slow_consumer_dropped_total",
-		metric.WithDescription("Messages dropped by a NATS subscription that could not keep up, by subject and queue group"),
+	slowConsumerEvents, err = otel.Meter("nats").Int64Counter(
+		"nats_slow_consumer_events_total",
+		metric.WithDescription("Slow-consumer episodes on a NATS subscription, by subject and queue group"),
 	)
 	if err != nil {
 		// Fall back to a no-op counter so recording stays safe even if the
 		// global meter provider is not initialised at package init time.
-		slowConsumerDropped, _ = noop.NewMeterProvider().Meter("nats").
-			Int64Counter("nats_slow_consumer_dropped_total")
+		slowConsumerEvents, _ = noop.NewMeterProvider().Meter("nats").
+			Int64Counter("nats_slow_consumer_events_total")
 	}
 }
 
+// subDropped returns the subscription's cumulative drop count and whether it
+// could be read at all. sub is nil for connection-level async errors, and
+// Dropped() errors on an already-closed subscription, which happens routinely
+// during shutdown.
+func subDropped(sub *nats.Subscription) (int, bool) {
+	if sub == nil {
+		return 0, false
+	}
+	dropped, err := sub.Dropped()
+	if err != nil {
+		return 0, false
+	}
+	return dropped, true
+}
+
 // slowConsumerFields builds the slog fields describing a slow consumer.
-// Every accessor is best-effort: sub is nil for connection-level async errors,
-// and Dropped/Pending/PendingLimits all error on an already-closed
-// subscription, which happens routinely during shutdown. A diagnostic path
-// must never panic or mask the event it is reporting.
-func slowConsumerFields(sub *nats.Subscription) []any {
+//
+// dropped/ok come from a single Dropped() read made by the caller rather than a
+// second read here, so the level decision and the logged value cannot diverge:
+// if the subscription closes between two reads, the level could say ERROR
+// ("messages dropped") while the field set silently omits the dropped count.
+//
+// The remaining accessors stay best-effort — Pending/PendingLimits also error on
+// a closed subscription, and a diagnostic path must never panic or mask the
+// event it is reporting.
+func slowConsumerFields(sub *nats.Subscription, dropped int, ok bool) []any {
 	if sub == nil {
 		return []any{"subject", "unknown"}
 	}
 	fields := []any{"subject", sub.Subject, "queue", sub.Queue}
-	if dropped, err := sub.Dropped(); err == nil {
+	if ok {
 		fields = append(fields, "dropped", dropped)
 	}
 	// nbytes, not bytes — a local named bytes shadows the stdlib package and
@@ -53,29 +83,18 @@ func slowConsumerFields(sub *nats.Subscription) []any {
 	return fields
 }
 
-// subDropped returns the subscription's drop count, or 0 when it cannot be read.
-func subDropped(sub *nats.Subscription) int {
-	if sub == nil {
-		return 0
-	}
-	dropped, err := sub.Dropped()
-	if err != nil {
-		return 0
-	}
-	return dropped
-}
-
-// logSlowConsumer reports a slow consumer and records the drop count.
+// logSlowConsumer reports a slow-consumer episode and counts it.
 func logSlowConsumer(log *slog.Logger, sub *nats.Subscription) {
-	dropped := subDropped(sub)
-	logSlowConsumerAt(log, dropped, slowConsumerFields(sub))
-	if dropped > 0 && sub != nil {
-		slowConsumerDropped.Add(context.Background(), int64(dropped),
-			metric.WithAttributes(
-				attribute.String("subject", sub.Subject),
-				attribute.String("queue", sub.Queue),
-			))
+	dropped, ok := subDropped(sub)
+	logSlowConsumerAt(log, dropped, slowConsumerFields(sub, dropped, ok))
+	if sub == nil {
+		return
 	}
+	slowConsumerEvents.Add(context.Background(), 1,
+		metric.WithAttributes(
+			attribute.String("subject", sub.Subject),
+			attribute.String("queue", sub.Queue),
+		))
 }
 
 // logSlowConsumerAt picks the level: dropped messages on a core subscription are

--- a/pkg/natsutil/slowconsumer_test.go
+++ b/pkg/natsutil/slowconsumer_test.go
@@ -1,0 +1,101 @@
+package natsutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/require"
+)
+
+// This file is in package natsutil (not natsutil_test) because it exercises
+// unexported helpers. The rest of the package's tests stay external.
+
+func TestSlowConsumerFields_RealSubscription(t *testing.T) {
+	nc := newLocalConn(t)
+	sub, err := nc.QueueSubscribe("slow.subject", "slow-queue", func(*nats.Msg) {})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	got := fieldMap(t, slowConsumerFields(sub))
+
+	require.Equal(t, "slow.subject", got["subject"])
+	require.Equal(t, "slow-queue", got["queue"])
+	require.Contains(t, got, "dropped")
+	require.Contains(t, got, "pending_msgs")
+	require.Contains(t, got, "pending_bytes")
+	require.Contains(t, got, "limit_msgs")
+	require.Contains(t, got, "limit_bytes")
+}
+
+func TestSlowConsumerFields_NilSubscription(t *testing.T) {
+	require.NotPanics(t, func() {
+		got := fieldMap(t, slowConsumerFields(nil))
+		require.Equal(t, "unknown", got["subject"])
+	})
+}
+
+func TestSlowConsumerFields_ClosedSubscription(t *testing.T) {
+	nc := newLocalConn(t)
+	sub, err := nc.Subscribe("closed.subject", func(*nats.Msg) {})
+	require.NoError(t, err)
+	require.NoError(t, sub.Unsubscribe())
+
+	require.NotPanics(t, func() {
+		got := fieldMap(t, slowConsumerFields(sub))
+		require.Equal(t, "closed.subject", got["subject"])
+	})
+}
+
+func TestLogSlowConsumer_LevelSelection(t *testing.T) {
+	tests := []struct {
+		name      string
+		dropped   int
+		wantLevel string
+	}{
+		{name: "no drops yet warns", dropped: 0, wantLevel: "WARN"},
+		{name: "drops are an error", dropped: 3, wantLevel: "ERROR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+			logSlowConsumerAt(log, tt.dropped, []any{"subject", "x"})
+
+			var rec map[string]any
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &rec))
+			require.Equal(t, tt.wantLevel, rec["level"])
+		})
+	}
+}
+
+func fieldMap(t *testing.T, fields []any) map[string]any {
+	t.Helper()
+	require.Zero(t, len(fields)%2, "slog fields must be key-value pairs")
+	out := make(map[string]any, len(fields)/2)
+	for i := 0; i < len(fields); i += 2 {
+		key, ok := fields[i].(string)
+		require.True(t, ok, "field key at %d is not a string", i)
+		out[key] = fields[i+1]
+	}
+	return out
+}
+
+func newLocalConn(t *testing.T) *nats.Conn {
+	t.Helper()
+	ns, err := natsserver.NewServer(&natsserver.Options{Port: -1})
+	require.NoError(t, err)
+	ns.Start()
+	require.True(t, ns.ReadyForConnections(5*time.Second))
+	t.Cleanup(ns.Shutdown)
+	nc, err := nats.Connect(ns.ClientURL())
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+	return nc
+}

--- a/pkg/natsutil/slowconsumer_test.go
+++ b/pkg/natsutil/slowconsumer_test.go
@@ -21,7 +21,10 @@ func TestSlowConsumerFields_RealSubscription(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sub.Unsubscribe() })
 
-	got := fieldMap(t, slowConsumerFields(sub))
+	dropped, ok := subDropped(sub)
+	require.True(t, ok, "a live subscription must report its drop count")
+
+	got := fieldMap(t, slowConsumerFields(sub, dropped, ok))
 
 	require.Equal(t, "slow.subject", got["subject"])
 	require.Equal(t, "slow-queue", got["queue"])
@@ -34,11 +37,16 @@ func TestSlowConsumerFields_RealSubscription(t *testing.T) {
 
 func TestSlowConsumerFields_NilSubscription(t *testing.T) {
 	require.NotPanics(t, func() {
-		got := fieldMap(t, slowConsumerFields(nil))
+		dropped, ok := subDropped(nil)
+		require.False(t, ok)
+		got := fieldMap(t, slowConsumerFields(nil, dropped, ok))
 		require.Equal(t, "unknown", got["subject"])
 	})
 }
 
+// A closed subscription must omit the counters it cannot read rather than
+// reporting a bogus zero — an ERROR line saying "messages dropped" with a
+// dropped:0 field would be worse than no field at all.
 func TestSlowConsumerFields_ClosedSubscription(t *testing.T) {
 	nc := newLocalConn(t)
 	sub, err := nc.Subscribe("closed.subject", func(*nats.Msg) {})
@@ -46,9 +54,49 @@ func TestSlowConsumerFields_ClosedSubscription(t *testing.T) {
 	require.NoError(t, sub.Unsubscribe())
 
 	require.NotPanics(t, func() {
-		got := fieldMap(t, slowConsumerFields(sub))
+		dropped, ok := subDropped(sub)
+		require.False(t, ok, "a closed subscription cannot report a drop count")
+
+		got := fieldMap(t, slowConsumerFields(sub, dropped, ok))
 		require.Equal(t, "closed.subject", got["subject"])
+		require.NotContains(t, got, "dropped")
+		require.NotContains(t, got, "pending_msgs")
+		require.NotContains(t, got, "limit_msgs")
 	})
+}
+
+// logSlowConsumer is the only function connect.go's ErrorHandler calls, so the
+// level rule and the field wiring must be verified on that path and not just on
+// the helpers beneath it.
+func TestLogSlowConsumer_LiveSubscriptionWarnsWithNoDrops(t *testing.T) {
+	nc := newLocalConn(t)
+	sub, err := nc.QueueSubscribe("live.subject", "live-queue", func(*nats.Msg) {})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	require.NotPanics(t, func() { logSlowConsumer(log, sub) })
+
+	var rec map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &rec))
+	require.Equal(t, "WARN", rec["level"], "a fresh subscription has dropped nothing yet")
+	require.Equal(t, "live.subject", rec["subject"])
+	require.Equal(t, "live-queue", rec["queue"])
+	require.Equal(t, float64(0), rec["dropped"])
+}
+
+func TestLogSlowConsumer_NilSubscriptionDoesNotPanic(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	require.NotPanics(t, func() { logSlowConsumer(log, nil) })
+
+	var rec map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &rec))
+	require.Equal(t, "WARN", rec["level"])
+	require.Equal(t, "unknown", rec["subject"])
 }
 
 func TestLogSlowConsumer_LevelSelection(t *testing.T) {

--- a/push-notification-service/main.go
+++ b/push-notification-service/main.go
@@ -115,7 +115,7 @@ func run() error {
 				return fmt.Errorf("worker drain: %w", dctx.Err())
 			}
 		},
-		func(_ context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(dctx context.Context) error { return healthStop(dctx) },
 		func(dctx context.Context) error { return obsShutdown(dctx) },
 	)

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -303,7 +303,7 @@ func main() {
 
 	shutdown.Wait(ctx, 25*time.Second,
 		func(ctx context.Context) error { return router.Shutdown(ctx) },
-		func(ctx context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error {
 			if closer, ok := keyStore.(interface{ Close() error }); ok {
 				return closer.Close()

--- a/room-worker/main.go
+++ b/room-worker/main.go
@@ -309,7 +309,7 @@ func main() {
 			}
 		},
 		func(ctx context.Context) error { return router.Shutdown(ctx) },
-		func(ctx context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, mongoClient); return nil },
 		func(ctx context.Context) error { return keyStore.Close() },
 		func(_ context.Context) error { valkeyutil.Disconnect(metaValkey); return nil },

--- a/search-service/main.go
+++ b/search-service/main.go
@@ -262,7 +262,7 @@ func main() {
 	shutdown.Wait(ctx, 25*time.Second,
 		// Wait for in-flight handlers BEFORE nc.Drain so they can't touch torn-down deps.
 		func(ctx context.Context) error { return router.Shutdown(ctx) },
-		func(ctx context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(_ context.Context) error { valkeyutil.Disconnect(valkey); return nil },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, mongoClient); return nil },
 		func(ctx context.Context) error { return healthServer.Shutdown(ctx) },

--- a/search-sync-worker/main.go
+++ b/search-sync-worker/main.go
@@ -348,7 +348,7 @@ func main() {
 			}
 			return nil
 		},
-		func(ctx context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, mongoClient); return nil },
 		func(ctx context.Context) error { return healthStop(ctx) },
 		// obsShutdown LAST so drain-window flush spans/logs are exported.

--- a/teams-hr-sync/main.go
+++ b/teams-hr-sync/main.go
@@ -136,7 +136,15 @@ func runStreamMode(ctx context.Context, cfg *config, graph msgraph.GroupReader, 
 	if err != nil {
 		return runStats{}, fmt.Errorf("connect nats: %w", err)
 	}
-	defer nc.Close()
+	defer func() {
+		// ctx is already cancelled on SIGTERM by the time this defer runs, so
+		// the drain deadline must not be derived from it.
+		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
+		defer cancel()
+		if err := natsutil.Drain(dctx, nc); err != nil {
+			slog.Error("nats drain", "error", err)
+		}
+	}()
 	js, err := jetstream.New(nc.NatsConn())
 	if err != nil {
 		return runStats{}, fmt.Errorf("init jetstream: %w", err)

--- a/teams-room-creation/main.go
+++ b/teams-room-creation/main.go
@@ -68,7 +68,11 @@ func run() error {
 		return fmt.Errorf("nats connect: %w", err)
 	}
 	defer func() {
-		if err := nc.Drain(); err != nil {
+		// ctx is already cancelled on SIGTERM by the time this defer runs, so
+		// the drain deadline must not be derived from it.
+		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
+		defer cancel()
+		if err := natsutil.Drain(dctx, nc); err != nil {
 			slog.Error("nats drain", "error", err)
 		}
 	}()

--- a/translation-service/main.go
+++ b/translation-service/main.go
@@ -118,7 +118,7 @@ func main() {
 
 	shutdown.Wait(ctx, 25*time.Second,
 		func(ctx context.Context) error { return router.Shutdown(ctx) },
-		func(ctx context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error { return obsShutdown(ctx) },
 	)
 }

--- a/user-presence-service/main.go
+++ b/user-presence-service/main.go
@@ -160,7 +160,7 @@ func main() {
 			}
 		},
 		func(ctx context.Context) error { return router.Shutdown(ctx) },
-		func(ctx context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(_ context.Context) error { return store.Close() },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, mongoClient); return nil },
 		func(ctx context.Context) error { return obsShutdown(ctx) },

--- a/user-presence-service/sync/main.go
+++ b/user-presence-service/sync/main.go
@@ -103,7 +103,11 @@ func run() error {
 		return fmt.Errorf("nats connect: %w", err)
 	}
 	defer func() {
-		if err := nc.Drain(); err != nil {
+		// ctx is already cancelled on SIGTERM by the time this defer runs, so
+		// the drain deadline must not be derived from it.
+		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
+		defer cancel()
+		if err := natsutil.Drain(dctx, nc); err != nil {
 			slog.Warn("nats drain", "error", err)
 		}
 	}()

--- a/user-presence-service/sync/main.go
+++ b/user-presence-service/sync/main.go
@@ -103,8 +103,11 @@ func run() error {
 		return fmt.Errorf("nats connect: %w", err)
 	}
 	defer func() {
-		// ctx is already cancelled on SIGTERM by the time this defer runs, so
-		// the drain deadline must not be derived from it.
+		// ctx carries the run deadline (context.WithTimeout at the top of run) and
+		// can already be Done when this defer executes, so the drain deadline must
+		// not derive from it. Unlike teams-room-creation this binary installs no
+		// signal handler — the expiry that matters here is RunTimeout elapsing
+		// during the run.
 		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
 		defer cancel()
 		if err := natsutil.Drain(dctx, nc); err != nil {

--- a/user-service/main.go
+++ b/user-service/main.go
@@ -143,7 +143,7 @@ func main() {
 
 	shutdown.Wait(ctx, 25*time.Second,
 		func(ctx context.Context) error { return router.Shutdown(ctx) },
-		func(ctx context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, mongoClient); return nil },
 		func(ctx context.Context) error { return obsShutdown(ctx) },
 	)


### PR DESCRIPTION
## The bug

`nats.Conn.Drain()` does not drain. From `nats.go@v1.50.0:6055-6075`, it flips the connection to `DRAINING_SUBS`, spawns `go nc.drainConnection()`, and returns `nil`. All the real work — draining each subscription, `FlushTimeout(5s)`, then `Close()` — happens on that goroutine.

Every service did this:

```go
func(ctx context.Context) error { return nc.Drain() },
```

The hook returned `nil` instantly, `shutdown.Wait` moved on, `main` returned, and `drainConnection` died wherever it got to. Whatever sat in the client write buffer at that moment was lost: JetStream acks (→ redelivery), request/reply responses (→ caller timeout), OUTBOX forwards.

The library's own doc comment names the fix — *"Use the ClosedCB option to know when the connection has moved from draining to closed."* Nothing in the repo did.

The trap was documented at exactly one site, `admin-service/main.go`, whose comment said Drain "returns immediately and finishes in the background". That reasoning was locally sound (an HTTP-only service with an idle connection) but was never generalised to the 22 sites where the connection is not idle.

## What changed

**`natsutil.Drain(ctx, conn)`** — starts the drain, then blocks on the connection's `CLOSED` status transition or `ctx`, whichever comes first. `ErrConnectionClosed` and `ErrConnectionReconnecting` are treated as benign (they surface on ordinary restarts today and log as shutdown errors). This mirrors the register-then-drain-then-wait pattern `pkg/natsrouter.Shutdown` already uses one level down for subscriptions.

**`DrainTimeout` set to 10s** (library default is 30s — larger than the entire shutdown budget, so it could never fire). Worst case is 10s + the internal `FlushTimeout(5s)` = 15s. Note `shutdown.Wait` creates **one** context for the whole shutdown and runs hooks sequentially over it, so the 25s is shared, not per-hook; 15s leaves ~10s for the remaining hooks, which are sub-second in practice.

**Slow consumer diagnostics.** The shared `nats.ErrorHandler` discarded its `*nats.Subscription`, so a slow consumer logged a bare `nats async error` — no subject, no queue, no drop count, nothing alertable. It now logs subject, queue, drop count and pending/limit counters, at ERROR once messages have actually dropped and WARN before that, and increments `nats_slow_consumer_events_total`.

That counter counts **episodes, not messages**, deliberately: `Subscription.Dropped()` is cumulative and never reset outside unsubscribe, and the callback fires only on the Active→SlowConsumer transition, so adding `Dropped()` per episode would re-add every earlier episode's drops (3 dropped then 5 more would report 3 + 8 = 11). The callback is also dispatched through an async queue, so a `Dropped()` read inside it isn't the count at episode time either. Exact numbers live in the log fields.

**30 call sites converted**, across five shapes:

| Shape | Count | Treatment |
|---|---|---|
| `shutdown.Wait` hook lambda | 19 | one-line swap; 5 needed the discarded `ctx` named |
| Inline in a combined hook | 2 | converted in place, existing error swallow kept |
| `defer` in a `run` function | 2 | `context.WithoutCancel` + 20s — the parent ctx is already cancelled when the defer runs |
| `nc.Close()` | 2 | `hr-sync-worker` split into its own hook; `teams-hr-sync` converted for consistency |
| `data-migration` shutdown paths | 5 | 4 hooks + `oplog-connector`'s own shutdown function |

**`media-service` shutdown chain fixed** (found by the final whole-branch review). It ran `go shutdown.Wait(...)` and then blocked on `srv.ListenAndServe()` directly, unlike every sibling Gin service. When the third hook closed the listener, `ListenAndServe` returned and the process exited — abandoning the rest of that hook and `obsShutdown` entirely. The structure predates this branch, but the branch worsens it: with one shared 25s context, a drain that now legitimately occupies up to 15s leaves the later hooks on a nearly-expired deadline, and `srv.Shutdown` with an expired context returns without waiting for in-flight requests. It now uses the same `srvErr`/`shutdownDone` pattern as `admin-service` and its six siblings; the hook list is unchanged.

**14 sites deliberately not converted.** The remaining `_ = nc.Drain()` calls in `data-migration` are startup error paths followed immediately by `os.Exit(1)` — nothing has been published, so there is nothing to flush, and blocking up to 15s before an error exit would be strictly worse. `tools/loadgen` (11 files) is a dev harness and is out of scope. `pkg/testutil/nats_binary.go` is test-harness teardown.

## Verification

- `make test` — full repo with `-race`, all packages pass
- `make lint` — 0 issues
- `make build` — every touched service
- `pkg/natsutil` coverage 87.8% (above the 80% floor, below the 90% target). `Drain` sits at 77.3%: the residual is a nil guard that cannot fire, a `default:` branch the library can never reach, and inherently racy windows. Not padded.

**SAST is partially unverified in this environment.** `gosec` passes with no medium+ findings, and semgrep's in-repo rules (`.semgrep/`, run with the gate's real flags) return 0 findings. `govulncheck` and semgrep's registry rulesets (`p/golang`, `p/security-audit`) could not run — the sandbox's egress policy returns 403 for `vuln.go.dev` and `semgrep.dev`. This branch touches no `go.mod`/`go.sum`, so `govulncheck`'s verdict should match `main`'s, but that is reasoning rather than a result. **CI must run the full gate.**

## Behaviour change to expect

Services now take up to ~15s to exit instead of exiting instantly. That is the point, but it will read as a pod-restart regression on first deploy. A service sitting at the full 10s drain timeout has a wedged subscription handler — a real finding, not a bug in this change.

## Known limitations (deliberately out of scope)

1. **The drain can be starved of budget.** `shutdown.Wait` shares one 25s context across sequential hooks, and in every JetStream worker the preceding `wg.Wait()` hook bounds itself on that *same* context. A wedged handler consumes the whole budget, and the drain then runs with an already-expired context. Fixing it means reserving a drain sub-budget inside `pkg/shutdown` — a different change.
2. **`hr-sync-worker` does not wait for in-flight handlers.** `cc.Stop()` is non-blocking and its cleanup calls `Unsubscribe()` rather than `Drain()`, removing the subscription from `nc.subs` synchronously — so `natsutil.Drain` has nothing left to wait on for that consumer. It reliably recovers an ack already queued in the write buffer (the bug fixed here), but not a handler still executing pre-ack. The loss window narrows from "every shutdown" to "a shutdown landing mid-message". Closing it needs a `sync.WaitGroup` around the `Consume` callback, and may be a codebase-wide question — CLAUDE.md's sequential-consumer pattern doesn't mandate one the way its high-throughput pattern does.
3. **`SetPendingLimits` tuning** for `broadcast-worker` fan-out. The remedy for slow-consumer pressure is raising the per-subscription buffer, but picking a number before the new counter shows real drop rates would be guessing. Diagnose first.
4. `media-service` drains NATS *before* shutting down its HTTP listener, unlike the workers. Pre-existing and left as-is — changing hook order is a behavioural change beyond the fix above.
5. A comment in `outbox-worker/main.go:200` still refers to `nc.Drain()` in prose; conceptually accurate, but the identifier no longer appears in that file.

Payload-size checks and `NoResponders` error mapping are **not** in this PR — they are #239.

## Notes for review

No wire, schema, or config change; nothing here is client-facing, so `docs/client-api.md` and its derived views are untouched. The spec and implementation plan are included under `docs/superpowers/`.

Each of the 7 implementation tasks was reviewed independently as it landed, followed by a whole-branch review that produced the `media-service` fix above. That review also verified, against the library source rather than the branch's claims, that `natsutil.Drain` registers its status listener *before* calling `Drain()`, that the three `WithoutCancel` batch jobs match each file's actual context construction, and that the new metric's `subject`/`queue` attributes are bounded (the codebase uses no `UseOldRequestStyle`, so mux'd request/reply shares one wildcard inbox per connection rather than a subscription per call).

Three defects originated in the plan rather than the implementation and were corrected in-branch: the metric overcounting described above, a comment asserting SIGTERM cancellation in a binary that installs no signal handler, and a build command that named a service while skipping the subpackage it edited.

Verified to merge cleanly against current `main`; the newly-landed `client-update-service` has no NATS connection, so the sweep remains complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Services now complete a more graceful, context-aware shutdown, allowing in-flight messaging work to finish before connections close.
  * Shutdown operations are bounded by timeouts to prevent services from hanging indefinitely.
  * Connection cleanup is more reliable during restarts, including improved handling of already-closed or reconnecting connections.
  * Slow messaging consumers now generate clearer diagnostic logs and monitoring metrics, helping identify dropped or delayed messages.
* **Documentation**
  * Added guidance covering connection draining, shutdown behavior, observability, testing, and rollout considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->