### PR TITLE
feat(notification-worker): priority contacts pierce presence suppression

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -4757,9 +4757,9 @@ The stored settings object. All ten fields are optional and appear only when the
 | `translateMessageInto` | string | Target language tag for message translation, e.g. `"en-US"`; `""` means translation explicitly off. |
 | `messagePreviewEnabled` | boolean | Show message previews in the sidebar list. |
 | `muteAllNotifications` | boolean | Mute all notifications. Enforced server-side by `notification-worker`: push delivery is suppressed for this user unless pierced — see `alwaysAllowPriorityNotifications`. |
-| `alwaysAllowPriorityNotifications` | boolean | Always allow priority-contact notifications, even when muted. Enforced server-side: a message whose sender is in [`priorityContacts`](#settingsprioritycontactsadd) pierces `muteAllNotifications` in **any** room type — DM and channel alike — and for `.bot` senders as well as users. The pierce does not override `showNotificationsInCall`. |
+| `alwaysAllowPriorityNotifications` | boolean | Always allow priority-contact notifications. Enforced server-side: a message whose sender is in [`priorityContacts`](#settingsprioritycontactsadd) is pushed regardless of `muteAllNotifications`, of a `"busy"` (do-not-disturb) presence, and of an `"in-call"` presence — in **any** room type, DM and channel alike, and for `.bot` senders as well as users. This setting is the only opt-in for that pierce; listing a priority contact without enabling it changes nothing. Per-room mute is not pierced. |
 | `showPreviewsInNotifications` | boolean | Show previews in notifications. |
-| `showNotificationsInCall` | boolean | Show notifications in call. Enforced server-side: when unset or `false`, push is suppressed while the user's presence is `"busy"` or `"in-call"`. A priority-contact pierce of `muteAllNotifications` does not bypass this — set both to receive priority pushes while in a call. This enforcement takes effect once presence reporting is enabled server-side; until then no status is treated as in-call, so pushes are delivered regardless of this setting. |
+| `showNotificationsInCall` | boolean | Show notifications in call. Enforced server-side: when unset or `false`, push is suppressed while the user's presence is `"in-call"`. It does **not** govern `"busy"` (do-not-disturb), which suppresses push either way — see `alwaysAllowPriorityNotifications` for the only exemption. A priority-contact pierce does bypass this setting. This enforcement takes effect once presence reporting is enabled server-side; until then no status is treated as in-call, so pushes are delivered regardless of this setting. |
 | `initialChatScrollPosition` | string | Where a chat opens: `"lastRead"` \| `"newest"`. |
 | `priorityContacts` | string[] | Read-only here — raw contact accounts (not enriched), stored order. Written only by [`settings.priorityContacts.add`](#settingsprioritycontactsadd) / [`settings.priorityContacts.remove`](#settingsprioritycontactsremove), never by `settings.set`. |
 
@@ -6446,8 +6446,12 @@ The worker filters recipients per message:
 - In rooms with more than `LARGE_ROOM_THRESHOLD` members (default 500),
   pushes only to mentioned recipients (`@user`, `@all`, `@here`).
 - Bots never receive a mobile push.
-- Presence-busy / in-call recipients are not pushed; everyone else
-  (online, offline, away, missing) receives one.
+- Recipients whose presence is `busy` (do-not-disturb) are not pushed; `in-call`
+  recipients are not pushed unless they set `showNotificationsInCall`. Everyone
+  else (online, offline, away, missing) receives one.
+- A sender in the recipient's `priorityContacts` bypasses `muteAllNotifications`,
+  `busy` and `in-call`, but only when the recipient enabled
+  `alwaysAllowPriorityNotifications`. Per-room mute is never bypassed.
 
 ---
 

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -4757,9 +4757,9 @@ The stored settings object. All ten fields are optional and appear only when the
 | `translateMessageInto` | string | Target language tag for message translation, e.g. `"en-US"`; `""` means translation explicitly off. |
 | `messagePreviewEnabled` | boolean | Show message previews in the sidebar list. |
 | `muteAllNotifications` | boolean | Mute all notifications. Enforced server-side by `notification-worker`: push delivery is suppressed for this user unless pierced — see `alwaysAllowPriorityNotifications`. |
-| `alwaysAllowPriorityNotifications` | boolean | Always allow priority-contact notifications. Enforced server-side: a message whose sender is in [`priorityContacts`](#settingsprioritycontactsadd) is pushed regardless of `muteAllNotifications`, of a `"busy"` (do-not-disturb) presence, and of an `"in-call"` presence — in **any** room type, DM and channel alike, and for `.bot` senders as well as users. This setting is the only opt-in for that pierce; listing a priority contact without enabling it changes nothing. Per-room mute is not pierced. |
+| `alwaysAllowPriorityNotifications` | boolean | Always allow priority-contact notifications. Enforced server-side: a message whose sender is in [`priorityContacts`](#settingsprioritycontactsadd) is pushed regardless of `muteAllNotifications` and regardless of a suppressing presence (`"busy"` / `"in-call"`) — in **any** room type, DM and channel alike, and for `.bot` senders as well as users. This setting is the only opt-in for that pierce; listing a priority contact without enabling it changes nothing. Per-room mute is not pierced. |
 | `showPreviewsInNotifications` | boolean | Show previews in notifications. |
-| `showNotificationsInCall` | boolean | Show notifications in call. Enforced server-side: when unset or `false`, push is suppressed while the user's presence is `"in-call"`. It does **not** govern `"busy"` (do-not-disturb), which suppresses push either way — see `alwaysAllowPriorityNotifications` for the only exemption. A priority-contact pierce does bypass this setting. This enforcement takes effect once presence reporting is enabled server-side; until then no status is treated as in-call, so pushes are delivered regardless of this setting. |
+| `showNotificationsInCall` | boolean | Show notifications in call. Enforced server-side: when unset or `false`, push is suppressed while the user's presence is `"busy"` or `"in-call"`. A priority-contact pierce bypasses this — see `alwaysAllowPriorityNotifications`. This enforcement takes effect once presence reporting is enabled server-side; until then no status is treated as in-call, so pushes are delivered regardless of this setting. |
 | `initialChatScrollPosition` | string | Where a chat opens: `"lastRead"` \| `"newest"`. |
 | `priorityContacts` | string[] | Read-only here — raw contact accounts (not enriched), stored order. Written only by [`settings.priorityContacts.add`](#settingsprioritycontactsadd) / [`settings.priorityContacts.remove`](#settingsprioritycontactsremove), never by `settings.set`. |
 
@@ -6446,11 +6446,11 @@ The worker filters recipients per message:
 - In rooms with more than `LARGE_ROOM_THRESHOLD` members (default 500),
   pushes only to mentioned recipients (`@user`, `@all`, `@here`).
 - Bots never receive a mobile push.
-- Recipients whose presence is `busy` (do-not-disturb) are not pushed; `in-call`
-  recipients are not pushed unless they set `showNotificationsInCall`. Everyone
-  else (online, offline, away, missing) receives one.
-- A sender in the recipient's `priorityContacts` bypasses `muteAllNotifications`,
-  `busy` and `in-call`, but only when the recipient enabled
+- Presence-busy / in-call recipients are not pushed unless they set
+  `showNotificationsInCall`; everyone else (online, offline, away, missing)
+  receives one.
+- A sender in the recipient's `priorityContacts` bypasses `muteAllNotifications`
+  and presence suppression alike, but only when the recipient enabled
   `alwaysAllowPriorityNotifications`. Per-room mute is never bypassed.
 
 ---

--- a/docs/superpowers/plans/2026-08-10-priority-contact-presence-gating.md
+++ b/docs/superpowers/plans/2026-08-10-priority-contact-presence-gating.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make the priority-contact pierce cross the presence gate, and stop `showNotificationsInCall` from governing manual do-not-disturb.
+**Goal:** Make the priority-contact pierce cross the presence gate, and wire the issue's do-not-disturb / presenting rule into the gate as inert predicates for the presence side to fill in.
 
-**Architecture:** All behaviour lives in one pure function, `shouldPush` in `notification-worker/presence.go`. Its single predicate `isInCall` — which today buckets `busy` and `in-call` together — splits into `isDND` and `isInCall`, and the pierce moves to the top of the function as a total early return. Nothing else in the pipeline changes: the candidate loop, the settings/presence snapshots, survivor sorting, batching and dedup are untouched.
+**Architecture:** All behaviour lives in one pure function, `shouldPush` in `notification-worker/presence.go`. Two new predicates, `isDND` and `isPresenting`, are declared as package-level function vars returning `false` — deriving those statuses belongs to the presence side of the system, and this worker must not infer them from `busy`/`in-call`. `isInCall` is left byte-identical to what shipped. Nothing else in the pipeline changes: the candidate loop, the settings/presence snapshots, survivor sorting, batching and dedup are untouched.
 
 **Tech Stack:** Go 1.25, `stretchr/testify` for assertions, table-driven tests, `make` targets.
 
@@ -13,142 +13,180 @@
 ## Global Constraints
 
 - TDD is mandatory (CLAUDE.md §4): write the tests, run them, **confirm they fail**, then implement. Task 1 is ordered so every test exists before any implementation.
+- **Never infer DND or presenting from a status we already receive.** No mapping DND→`busy`, no mapping presenting→`in-call`. Those statuses are owned by the presence side; this worker declares the predicates and gates on them.
+- **Do not narrow `isInCall`.** It must keep matching both `busy` and `in-call` while `isDND` is inert, or every do-not-disturb user starts receiving pushes during the gap.
 - Use `make` targets, not raw `go` commands — except for coverage, where CLAUDE.md itself prescribes `go test -coverprofile` / `go tool cover -func`.
 - Unit tests for this service: `make test SERVICE=notification-worker` (expands to `go test -race ./notification-worker/...`). The target does **not** forward `-run`; to run a single test use `go test -race ./notification-worker/ -run '<Name>' -v` directly, and finish with the `make` target.
 - Test files stay in `package main` so they can reach unexported identifiers.
-- Presence statuses come from `pkg/model` constants — `model.StatusBusy` (`"busy"`), `model.StatusInCall` (`"in-call"`). Compare via `string(...)`; `model.Presence.AggregatedStatus` is a plain `string`.
-- Comments follow the repo's WHY-not-WHAT convention: max 2 lines, rationale only, never restating the code.
-- Minimum 80% coverage; `shouldPush`, `isDND` and `isInCall` must each reach 100%.
+- Tests that swap the stub vars MUST restore them via `t.Cleanup` — CLAUDE.md forbids shared mutable state between tests. Do not add `t.Parallel()` to those tests.
+- Comments follow the repo's WHY-not-WHAT convention: max 2 lines, rationale only.
+- Minimum 80% coverage; `shouldPush` and `isInCall` must reach 100%.
 - Lint and tests are enforced by a pre-commit hook. A failing hook means fix, not retry.
-- Do NOT add env vars, model fields, RPCs or events. `USER_SETTINGS_ENABLED=false` is already the kill switch for everything here.
+- Do NOT add env vars, model fields, RPCs or events. `USER_SETTINGS_ENABLED=false` is already the kill switch.
 - Do NOT modify `handler.go`'s candidate loop. A per-room-muted member must keep being dropped before the gate — no pierce resurrects them.
 
 ---
 
-### Task 1: Split the presence predicates and make the pierce total
+### Task 1: Wire rule 2 as inert predicates and make the pierce total
 
-Every test lands before the implementation, so the red phase is real. The two handler tests are here rather than in a later task for exactly that reason: written after the implementation they would pass on arrival and prove nothing.
+Every test lands before the implementation, so the red phase is real.
 
 **Files:**
-- Modify: `notification-worker/presence.go:119-143` (`isInCall`, `shouldPush`)
+- Modify: `notification-worker/presence.go` (add stub vars; rewrite `shouldPush`; leave `isInCall` alone)
 - Modify: `notification-worker/handler.go:200-207` (comment block above the two `Snapshot` calls)
-- Test: `notification-worker/presence_test.go:27-89` (`TestShouldPush`, `TestIsInCall`)
-- Test: `notification-worker/handler_test.go` (append two tests at end of file)
+- Test: `notification-worker/presence_test.go` (`TestShouldPush`, plus two helpers and a stub-contract test)
+- Test: `notification-worker/handler_test.go` (append two tests)
 
 **Interfaces:**
-- Consumes: `notifSettings` from `notification-worker/usersettings.go` — fields `muteAll`, `allowPriority`, `showInCall bool`, `priorityContacts map[string]struct{}`. `model.Presence{AggregatedStatus string}` from `pkg/model/presence.go`. Existing test fixtures in `handler_test.go`: `newTestHandlerWithSettings(members, presence, settings, hook, emit)`, `stubMembers{out map[string][]roomsubcache.Member}`, `stubPresence{out map[string]model.Presence}`, `stubSettings{out map[string]notifSettings, err error}`, `recordingEmitter` with `.accounts() []string`, `msgEvent(*model.Message) []byte`, `noopVetoer{}`.
-- Produces: `func isDND(p model.Presence) bool`, `func isInCall(p model.Presence) bool`, `func shouldPush(p model.Presence, ns notifSettings, isPrioritySender bool) bool` — **signature unchanged**, so `handler.go:213`'s call site keeps compiling untouched.
+- Consumes: `notifSettings` from `usersettings.go` — fields `muteAll`, `allowPriority`, `showInCall bool`, `priorityContacts map[string]struct{}`. `model.Presence{AggregatedStatus string}`. Existing fixtures in `handler_test.go`: `newTestHandlerWithSettings(members, presence, settings, hook, emit)`, `stubMembers{out map[string][]roomsubcache.Member}`, `stubPresence{out map[string]model.Presence}`, `stubSettings{out map[string]notifSettings, err error}`, `recordingEmitter` with `.accounts() []string`, `msgEvent(*model.Message) []byte`, `noopVetoer{}`.
+- Produces: `var isDND, isPresenting func(model.Presence) bool`; `shouldPush(p model.Presence, ns notifSettings, isPrioritySender bool) bool` — **signature unchanged**, so `handler.go:213`'s call site keeps compiling untouched. Test helpers `stubPresenceFlags(t, dnd, presenting bool)` and `stubPresenceFlagsByStatus(t, dndStatus, presentingStatus string)`.
 
-- [ ] **Step 1: Replace the `TestShouldPush` table**
+- [ ] **Step 1: Add the two test helpers**
 
-Replace the whole `tests := []struct{...}{...}` literal in `TestShouldPush` (`presence_test.go:28-62`) with the table below. Keep the surrounding `for`/`t.Run` loop exactly as it is.
+Insert above `TestShouldPush` in `presence_test.go`:
 
 ```go
-	tests := []struct {
-		name             string
-		status           string
-		ns               notifSettings
-		isPrioritySender bool
-		want             bool
-	}{
-		// Zero notifSettings must reproduce pre-Spec-3 behaviour on every status:
-		// no stored settings means no behaviour change from this deploy.
-		{"zero settings online", "online", notifSettings{}, false, true},
-		{"zero settings offline", "offline", notifSettings{}, false, true},
-		{"zero settings away", "away", notifSettings{}, false, true},
-		{"zero settings busy", "busy", notifSettings{}, false, false},
-		{"zero settings in-call", "in-call", notifSettings{}, false, false},
-		{"zero settings missing status", "", notifSettings{}, false, true},
-		{"zero settings unknown status", "unknown", notifSettings{}, false, true},
+// stubPresenceFlags swaps the isDND/isPresenting stubs for one test and restores
+// them afterwards, so a row that flips them cannot leak into a sibling test.
+func stubPresenceFlags(t *testing.T, dnd, presenting bool) {
+	t.Helper()
+	origDND, origPresenting := isDND, isPresenting
+	isDND = func(model.Presence) bool { return dnd }
+	isPresenting = func(model.Presence) bool { return presenting }
+	t.Cleanup(func() { isDND, isPresenting = origDND, origPresenting })
+}
+
+// stubPresenceFlagsByStatus points the isDND/isPresenting stubs at one status
+// each, restoring them afterwards. Lets a handler test prove the gate consults
+// both without asserting any real status mapping; "" disables that stub.
+func stubPresenceFlagsByStatus(t *testing.T, dndStatus, presentingStatus string) {
+	t.Helper()
+	origDND, origPresenting := isDND, isPresenting
+	isDND = func(p model.Presence) bool { return dndStatus != "" && p.AggregatedStatus == dndStatus }
+	isPresenting = func(p model.Presence) bool {
+		return presentingStatus != "" && p.AggregatedStatus == presentingStatus
+	}
+	t.Cleanup(func() { isDND, isPresenting = origDND, origPresenting })
+}
+```
+
+- [ ] **Step 2: Extend the `TestShouldPush` table with `dnd`/`presenting` columns**
+
+Add `dnd` and `presenting` bool fields to the struct after `status`, replace the rows with the table below, and add `stubPresenceFlags(t, tt.dnd, tt.presenting)` as the first line of the subtest body.
+
+```go
+		// Zero notifSettings with both stubs inert must reproduce the pre-change
+		// truth table exactly: no stored settings means no behaviour change.
+		{"zero settings online", "online", false, false, notifSettings{}, false, true},
+		{"zero settings offline", "offline", false, false, notifSettings{}, false, true},
+		{"zero settings away", "away", false, false, notifSettings{}, false, true},
+		{"zero settings busy", "busy", false, false, notifSettings{}, false, false},
+		{"zero settings in-call", "in-call", false, false, notifSettings{}, false, false},
+		{"zero settings missing status", "", false, false, notifSettings{}, false, true},
+		{"zero settings unknown status", "unknown", false, false, notifSettings{}, false, true},
 
 		// muteAll suppresses unless a priority sender pierces it.
-		{"muted, no pierce", "online", notifSettings{muteAll: true}, false, false},
-		{"muted, priority sender but pierce disabled", "online", notifSettings{muteAll: true}, true, false},
-		{"muted, pierce enabled but sender not priority", "online", notifSettings{muteAll: true, allowPriority: true}, false, false},
-		{"muted, pierce enabled and sender is priority", "online", notifSettings{muteAll: true, allowPriority: true}, true, true},
-		{"unmuted, pierce enabled, non-priority sender", "online", notifSettings{allowPriority: true}, false, true},
+		{"muted, no pierce", "online", false, false, notifSettings{muteAll: true}, false, false},
+		{"muted, priority sender but pierce disabled", "online", false, false, notifSettings{muteAll: true}, true, false},
+		{"muted, pierce enabled but sender not priority", "online", false, false, notifSettings{muteAll: true, allowPriority: true}, false, false},
+		{"muted, pierce enabled and sender is priority", "online", false, false, notifSettings{muteAll: true, allowPriority: true}, true, true},
+		{"unmuted, pierce enabled, non-priority sender", "online", false, false, notifSettings{allowPriority: true}, false, true},
 
-		// DND is no longer governed by showNotificationsInCall. This row is the one
-		// population whose pushes this change removes.
-		{"busy, opted in to in-call notifications, still suppressed", "busy", notifSettings{showInCall: true}, false, false},
-		{"busy, no opt-in", "busy", notifSettings{}, false, false},
+		// Rule 2: DND and presenting suppress on their own, and the in-call opt-in
+		// does not rescue them — showNotificationsInCall governs in-call only.
+		{"dnd", "online", true, false, notifSettings{}, false, false},
+		{"dnd, in-call opt-in does not rescue", "online", true, false, notifSettings{showInCall: true}, false, false},
+		{"presenting", "online", false, true, notifSettings{}, false, false},
+		{"presenting, in-call opt-in does not rescue", "online", false, true, notifSettings{showInCall: true}, false, false},
+		{"dnd and presenting together", "online", true, true, notifSettings{}, false, false},
 
-		// showNotificationsInCall still governs in-call, for every non-priority sender.
-		{"in-call, opted in", "in-call", notifSettings{showInCall: true}, false, true},
-		{"in-call, not opted in", "in-call", notifSettings{}, false, false},
+		// showNotificationsInCall governs the in-call bucket, for non-priority senders.
+		{"in-call, opted in", "in-call", false, false, notifSettings{showInCall: true}, false, true},
+		{"busy, opted in", "busy", false, false, notifSettings{showInCall: true}, false, true},
+		{"in-call, not opted in", "in-call", false, false, notifSettings{}, false, false},
 
-		// The pierce now crosses the presence gate too — the Spec 3 reversal.
-		{"busy, priority pierce", "busy", notifSettings{allowPriority: true}, true, true},
-		{"in-call, priority pierce without in-call opt-in", "in-call", notifSettings{allowPriority: true}, true, true},
-		{"muted+pierced, in-call without opt-in", "in-call", notifSettings{muteAll: true, allowPriority: true}, true, true},
-		{"muted+pierced, in-call with opt-in", "in-call", notifSettings{muteAll: true, allowPriority: true, showInCall: true}, true, true},
+		// The pierce crosses every suppressor, DND and presenting included.
+		{"dnd, priority pierce", "online", true, false, notifSettings{allowPriority: true}, true, true},
+		{"presenting, priority pierce", "online", false, true, notifSettings{allowPriority: true}, true, true},
+		{"in-call, priority pierce without in-call opt-in", "in-call", false, false, notifSettings{allowPriority: true}, true, true},
+		{"muted+dnd, priority pierce", "in-call", true, false, notifSettings{muteAll: true, allowPriority: true}, true, true},
 
 		// ...but only with its opt-in. A priority sender alone pierces nothing.
-		{"busy, priority sender but pierce disabled", "busy", notifSettings{}, true, false},
-		{"in-call, priority sender but pierce disabled", "in-call", notifSettings{}, true, false},
+		{"dnd, priority sender but pierce disabled", "online", true, false, notifSettings{}, true, false},
+		{"presenting, priority sender but pierce disabled", "online", false, true, notifSettings{}, true, false},
+		{"in-call, priority sender but pierce disabled", "in-call", false, false, notifSettings{}, true, false},
 
 		// Every suppressor clear.
-		{"muted+pierced, online", "online", notifSettings{muteAll: true, allowPriority: true, showInCall: true}, true, true},
+		{"muted+pierced, online", "online", false, false, notifSettings{muteAll: true, allowPriority: true, showInCall: true}, true, true},
 	}
 ```
 
-- [ ] **Step 2: Split `TestIsInCall` into two tests**
+- [ ] **Step 3: Add the stub-contract test**
 
-Replace `TestIsInCall` (`presence_test.go:71-89`) entirely with the pair below. Each asserts the *other* status is false — that mutual exclusion is what fails if anyone re-merges the bucket.
+`TestIsInCall` stays exactly as it is — it still asserts the `busy`+`in-call` bucket. Add alongside it:
 
 ```go
-func TestIsDND(t *testing.T) {
-	tests := []struct {
-		status string
-		want   bool
-	}{
-		{"busy", true},
-		{"in-call", false},
-		{"online", false},
-		{"offline", false},
-		{"away", false},
-		{"", false},
-		{"unknown", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.status, func(t *testing.T) {
-			assert.Equal(t, tt.want, isDND(model.Presence{AggregatedStatus: tt.status}))
-		})
-	}
-}
-
-func TestIsInCall(t *testing.T) {
-	tests := []struct {
-		status string
-		want   bool
-	}{
-		{"in-call", true},
-		{"busy", false},
-		{"online", false},
-		{"offline", false},
-		{"away", false},
-		{"", false},
-		{"unknown", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.status, func(t *testing.T) {
-			assert.Equal(t, tt.want, isInCall(model.Presence{AggregatedStatus: tt.status}))
+// TestDNDAndPresentingStubsAreInert pins the stub contract: until the presence
+// side ships the real predicates, neither may infer a status from what we
+// currently receive. A stub that starts returning true for "busy" or "in-call"
+// would silently change delivery, so every status we know about is asserted.
+func TestDNDAndPresentingStubsAreInert(t *testing.T) {
+	for _, status := range []string{"busy", "in-call", "online", "offline", "away", "", "unknown"} {
+		t.Run(status, func(t *testing.T) {
+			p := model.Presence{AggregatedStatus: status}
+			assert.False(t, isDND(p), "isDND must stay inert until the presence side owns it")
+			assert.False(t, isPresenting(p), "isPresenting must stay inert until the presence side owns it")
 		})
 	}
 }
 ```
 
-- [ ] **Step 3: Add the two handler tests**
+- [ ] **Step 4: Add the two handler tests**
 
-The table above proves the pure function. These prove the handler actually combines the settings map and the presence map per-recipient — `ns.isPriority(msg.UserAccount)` is keyed on the **sender's** account, an easy-to-invert wiring detail no pure-function test can catch.
-
-Append to the end of `notification-worker/handler_test.go`:
+The table proves the pure function. These prove the handler consults both stubs and that the pierce is keyed on the **sender's** account — an easy-to-invert wiring detail no pure-function test can catch. Append to `handler_test.go`:
 
 ```go
-// TestHandle_PriorityContactPiercesDND pins the Spec 3 reversal end-to-end: the
-// pierce crosses the presence gate, and it is keyed on the sender's account —
-// bob lists the sender, carol lists someone else, and both are equally in DND.
-func TestHandle_PriorityContactPiercesDND(t *testing.T) {
+// TestHandle_DNDAndPresentingSuppressPush proves the handler consults both stubs
+// once they go live. Every recipient here has showNotificationsInCall set, so
+// only a suppressor the opt-in does NOT govern can drop them — which is exactly
+// rule 2. Uses invented statuses so the test asserts the wiring, not a mapping
+// the presence side has yet to define.
+func TestHandle_DNDAndPresentingSuppressPush(t *testing.T) {
+	stubPresenceFlagsByStatus(t, "stub-dnd", "stub-presenting")
+
+	members := &stubMembers{out: map[string][]roomsubcache.Member{
+		"r1": {
+			{ID: "alice", Account: "alice"},
+			{ID: "bob", Account: "bob"},
+			{ID: "carol", Account: "carol"},
+			{ID: "dave", Account: "dave"},
+		},
+	}}
+	presence := &stubPresence{out: map[string]model.Presence{
+		"bob":   {AggregatedStatus: "stub-dnd"},
+		"carol": {AggregatedStatus: "stub-presenting"},
+		"dave":  {AggregatedStatus: "online"},
+	}}
+	settings := &stubSettings{out: map[string]notifSettings{
+		"bob":   {showInCall: true},
+		"carol": {showInCall: true},
+		"dave":  {showInCall: true},
+	}}
+	emit := &recordingEmitter{}
+	h := newTestHandlerWithSettings(members, presence, settings, noopVetoer{}, emit)
+
+	require.NoError(t, h.HandleMessage(context.Background(), msgEvent(&model.Message{
+		ID: "m1", RoomID: "r1", UserID: "alice", UserAccount: "alice", CreatedAt: time.Now(),
+	})))
+	assert.Equal(t, []string{"dave"}, emit.accounts(),
+		"DND and presenting suppress regardless of showNotificationsInCall")
+}
+
+// TestHandle_PriorityContactPiercesDNDStub is the pierce counterpart: the same
+// suppressed recipient survives when the sender is one of their priority contacts.
+func TestHandle_PriorityContactPiercesDNDStub(t *testing.T) {
+	stubPresenceFlagsByStatus(t, "stub-dnd", "")
+
 	members := &stubMembers{out: map[string][]roomsubcache.Member{
 		"r1": {
 			{ID: "alice", Account: "alice"},
@@ -157,8 +195,8 @@ func TestHandle_PriorityContactPiercesDND(t *testing.T) {
 		},
 	}}
 	presence := &stubPresence{out: map[string]model.Presence{
-		"bob":   {AggregatedStatus: "busy"},
-		"carol": {AggregatedStatus: "busy"},
+		"bob":   {AggregatedStatus: "stub-dnd"},
+		"carol": {AggregatedStatus: "stub-dnd"},
 	}}
 	settings := &stubSettings{out: map[string]notifSettings{
 		"bob":   {allowPriority: true, priorityContacts: map[string]struct{}{"alice": {}}},
@@ -173,62 +211,40 @@ func TestHandle_PriorityContactPiercesDND(t *testing.T) {
 	assert.Equal(t, []string{"bob"}, emit.accounts(),
 		"bob lists the sender as a priority contact and is pierced out of DND; carol does not")
 }
-
-// TestHandle_DNDIgnoresShowNotificationsInCall pins the other half of the split:
-// the in-call opt-in must not rescue a recipient who is in do-not-disturb.
-func TestHandle_DNDIgnoresShowNotificationsInCall(t *testing.T) {
-	members := &stubMembers{out: map[string][]roomsubcache.Member{
-		"r1": {
-			{ID: "alice", Account: "alice"},
-			{ID: "bob", Account: "bob"},
-			{ID: "carol", Account: "carol"},
-		},
-	}}
-	presence := &stubPresence{out: map[string]model.Presence{
-		"bob":   {AggregatedStatus: "busy"},
-		"carol": {AggregatedStatus: "in-call"},
-	}}
-	settings := &stubSettings{out: map[string]notifSettings{
-		"bob":   {showInCall: true},
-		"carol": {showInCall: true},
-	}}
-	emit := &recordingEmitter{}
-	h := newTestHandlerWithSettings(members, presence, settings, noopVetoer{}, emit)
-
-	require.NoError(t, h.HandleMessage(context.Background(), msgEvent(&model.Message{
-		ID: "m1", RoomID: "r1", UserID: "alice", UserAccount: "alice", CreatedAt: time.Now(),
-	})))
-	assert.Equal(t, []string{"carol"}, emit.accounts(),
-		"showNotificationsInCall covers in-call only; bob stays suppressed by DND")
-}
 ```
 
-- [ ] **Step 4: Run the tests to verify they fail**
+Also rename the existing `TestHandle_PriorityContactPiercesDND` (if present from an earlier draft) to `TestHandle_PriorityContactPiercesPresenceSuppression`, since with `isInCall` unchanged it exercises the `busy` bucket, not DND.
+
+- [ ] **Step 5: Run the tests to verify they fail**
 
 Run: `make test SERVICE=notification-worker`
 
-Expected: FAIL. The first failure is a compile error, `undefined: isDND`, because the identifier genuinely does not exist yet — that is a valid red phase, not a setup problem. Do not proceed until you have seen it.
+Expected: FAIL with a compile error, `undefined: isDND`. That is a valid red phase — the identifier genuinely does not exist yet. Do not proceed until you have seen it.
 
-- [ ] **Step 5: Rewrite the predicates and the gate**
+- [ ] **Step 6: Add the stubs and rewrite the gate**
 
-In `notification-worker/presence.go`, replace `isInCall` and `shouldPush` — everything from the `// isInCall reports whether presence alone suppresses push.` comment down to the closing brace of `shouldPush` (lines 119-143) — with:
+In `notification-worker/presence.go`, insert the stub vars immediately above `isInCall`, leave `isInCall` untouched, and rewrite `shouldPush`:
 
 ```go
-// isDND reports manual do-not-disturb. Split from isInCall because
-// showNotificationsInCall governs only the latter — DND means DND.
-func isDND(p model.Presence) bool {
-	return p.AggregatedStatus == string(model.StatusBusy)
-}
+// isDND and isPresenting are stubs: deriving these two statuses belongs to the
+// presence side of the system, which has not shipped them yet. They are vars so
+// tests can supply the eventual behaviour and prove the gate ordering now.
+//
+// Deliberately NOT inferred from any status we currently receive — mapping DND
+// onto "busy" or presenting onto "in-call" would invent a contract we do not own.
+// Until the real predicates land, both return false and rule 2 of the decision
+// table is inert.
+var (
+	isDND        = func(model.Presence) bool { return false }
+	isPresenting = func(model.Presence) bool { return false }
+)
+```
 
-// isInCall reports an active call. Teams "Presenting" arrives here too:
-// user-presence-service folds it into in-call rather than modelling it separately.
-func isInCall(p model.Presence) bool {
-	return p.AggregatedStatus == string(model.StatusInCall)
-}
-
-// shouldPush applies the priority-contact pierce, then three independent
-// suppressors. alwaysAllowPriorityNotifications is the single opt-in for
-// "priority contacts reach me anyway", so the pierce crosses all three.
+```go
+// shouldPush applies the priority-contact pierce, then the suppressors in the
+// issue's stated priority order. alwaysAllowPriorityNotifications is the single
+// opt-in for "priority contacts reach me anyway", so the pierce crosses all of
+// them. Unknown presence fails open.
 func shouldPush(p model.Presence, ns notifSettings, isPrioritySender bool) bool {
 	if ns.allowPriority && isPrioritySender {
 		return true
@@ -236,7 +252,7 @@ func shouldPush(p model.Presence, ns notifSettings, isPrioritySender bool) bool 
 	if ns.muteAll {
 		return false
 	}
-	if isDND(p) {
+	if isDND(p) || isPresenting(p) {
 		return false
 	}
 	if isInCall(p) && !ns.showInCall {
@@ -246,15 +262,17 @@ func shouldPush(p model.Presence, ns notifSettings, isPrioritySender bool) bool 
 }
 ```
 
-- [ ] **Step 6: Run the tests to verify they pass**
+Update `isInCall`'s doc comment to say the `busy`+`in-call` bucket holds *while `isDND` is inert*, so the next reader knows it is provisional.
+
+- [ ] **Step 7: Run the tests to verify they pass**
 
 Run: `make test SERVICE=notification-worker`
 
-Expected: PASS, everything — including the pre-existing `TestHandle_PresenceBusyDropsPush`, where bob is `busy` with zero settings and must still be dropped. That test must keep passing **unmodified**; if you find yourself editing it, the implementation is wrong.
+Expected: PASS, everything — including the pre-existing `TestHandle_PresenceBusyDropsPush` and `TestIsInCall`, both of which must keep passing **unmodified**. If you find yourself editing either, `isInCall` was narrowed when it should not have been.
 
-- [ ] **Step 7: Correct the stale comment in `handler.go`**
+- [ ] **Step 8: Correct the stale comment in `handler.go`**
 
-The comment block above the two `Snapshot` calls (`handler.go:200-207`) ends with a sentence that is no longer true — `showNotificationsInCall` is not the only thing modifying the presence decision. Replace only that trailing sentence, keeping the narrowing lines intact:
+The comment block above the two `Snapshot` calls ends with a sentence that is no longer true — `showNotificationsInCall` is not the only thing modifying the presence decision. Replace only that trailing sentence:
 
 ```go
 	// Both lookups run over the narrowed candidate set — only accounts that survived
@@ -265,32 +283,33 @@ The comment block above the two `Snapshot` calls (`handler.go:200-207`) ends wit
 	snapshot, _ := h.deps.Presence.Snapshot(ctx, accounts) // fail-open: error → empty map
 ```
 
-- [ ] **Step 8: Verify coverage of the changed functions**
+- [ ] **Step 9: Verify coverage**
 
 Run:
 
 ```bash
-go test -race -coverprofile=coverage.out ./notification-worker/ && go tool cover -func=coverage.out | grep -E "shouldPush|isDND|isInCall"
+go test -race -coverprofile=coverage.out ./notification-worker/ && go tool cover -func=coverage.out | grep -E "shouldPush|isInCall"
 ```
 
-Expected: `100.0%` on all three lines. Every branch has a table row, so anything less means a row is missing. Delete `coverage.out` afterwards — it must not be committed.
+Expected: `100.0%` on both. Delete `coverage.out` afterwards — it must not be committed.
 
-- [ ] **Step 9: Run the linter**
+- [ ] **Step 10: Lint**
 
 Run: `make lint`
 
 Expected: clean.
 
-- [ ] **Step 10: Commit**
+- [ ] **Step 11: Commit**
 
 ```bash
 git add notification-worker/presence.go notification-worker/presence_test.go notification-worker/handler.go notification-worker/handler_test.go
-git commit -m "feat(notification-worker): priority contacts pierce DND and in-call
+git commit -m "feat(notification-worker): priority contacts pierce presence suppression
 
-DND (presence \"busy\") is no longer governed by showNotificationsInCall,
-which now covers in-call only. alwaysAllowPriorityNotifications becomes the
-single opt-in for piercing mute, DND and in-call alike; per-room mute is
-still never pierced.
+alwaysAllowPriorityNotifications becomes the single opt-in for piercing
+mute and presence suppression alike. Adds inert isDND/isPresenting
+predicates so the issue's do-not-disturb rule is wired and tested; the
+presence side owns deriving those statuses, so nothing infers them from
+busy/in-call and isInCall is unchanged.
 
 Refs #221"
 ```
@@ -299,53 +318,55 @@ Refs #221"
 
 ### Task 2: Correct the documentation the change invalidates
 
-Three pieces of prose become factually wrong the moment Task 1 merges. CLAUDE.md requires `docs/client-api.md` to track client-facing behaviour in the same PR.
-
 **Files:**
-- Modify: `docs/client-api.md` — the `alwaysAllowPriorityNotifications` and `showNotificationsInCall` rows in the settings field table (~lines 4760-4763); the push-filter bullet in §4 (~lines 6449-6450)
+- Modify: `docs/client-api.md` — the `alwaysAllowPriorityNotifications` and `showNotificationsInCall` rows in the settings field table; the push-filter bullet in §4
 - Modify: `docs/superpowers/specs/2026-08-10-notification-settings-enforcement-design.md` (head of file)
 
 **Interfaces:** None — documentation only. No request/response schema, model struct or event changed, so `docs/client-api/request-reply.md` and `docs/client-api/events.md` are deliberately **not** touched.
 
+Document only what the code does **today**. Rule 2 stays out of the client API surface: writing "do-not-disturb suppresses push" while `isDND` returns false would document behaviour clients cannot observe.
+
 - [ ] **Step 1: Rewrite the `alwaysAllowPriorityNotifications` row**
 
-Find the row beginning `| \`alwaysAllowPriorityNotifications\` | boolean |`. Its final sentence currently reads "The pierce does not override `showNotificationsInCall`." Replace the entire row with:
+Its final sentence currently reads "The pierce does not override `showNotificationsInCall`." Replace the whole row with:
 
 ```markdown
-| `alwaysAllowPriorityNotifications` | boolean | Always allow priority-contact notifications. Enforced server-side: a message whose sender is in [`priorityContacts`](#settingsprioritycontactsadd) is pushed regardless of `muteAllNotifications`, of a `"busy"` (do-not-disturb) presence, and of an `"in-call"` presence — in **any** room type, DM and channel alike, and for `.bot` senders as well as users. This setting is the only opt-in for that pierce; listing a priority contact without enabling it changes nothing. Per-room mute is not pierced. |
+| `alwaysAllowPriorityNotifications` | boolean | Always allow priority-contact notifications. Enforced server-side: a message whose sender is in [`priorityContacts`](#settingsprioritycontactsadd) is pushed regardless of `muteAllNotifications` and regardless of a suppressing presence (`"busy"` / `"in-call"`) — in **any** room type, DM and channel alike, and for `.bot` senders as well as users. This setting is the only opt-in for that pierce; listing a priority contact without enabling it changes nothing. Per-room mute is not pierced. |
 ```
 
 - [ ] **Step 2: Rewrite the `showNotificationsInCall` row**
 
-Find the row beginning `| \`showNotificationsInCall\` | boolean |`. It currently claims the setting covers `"busy"` **or** `"in-call"`, and that the priority pierce does not bypass it — both now wrong. Replace the entire row with:
+Only the pierce sentence changes; the `busy` + `in-call` bucket stays accurate.
 
 ```markdown
-| `showNotificationsInCall` | boolean | Show notifications in call. Enforced server-side: when unset or `false`, push is suppressed while the user's presence is `"in-call"`. It does **not** govern `"busy"` (do-not-disturb), which suppresses push either way — see `alwaysAllowPriorityNotifications` for the only exemption. A priority-contact pierce does bypass this setting. This enforcement takes effect once presence reporting is enabled server-side; until then no status is treated as in-call, so pushes are delivered regardless of this setting. |
+| `showNotificationsInCall` | boolean | Show notifications in call. Enforced server-side: when unset or `false`, push is suppressed while the user's presence is `"busy"` or `"in-call"`. A priority-contact pierce bypasses this — see `alwaysAllowPriorityNotifications`. This enforcement takes effect once presence reporting is enabled server-side; until then no status is treated as in-call, so pushes are delivered regardless of this setting. |
 ```
 
-- [ ] **Step 3: Rewrite the §4 push-filter bullet**
+- [ ] **Step 3: Add the pierce to the §4 push-filter bullets**
 
-Find the bullet reading "Presence-busy / in-call recipients are not pushed; everyone else (online, offline, away, missing) receives one." Replace those two lines with:
+Keep the existing presence bullet's substance and add the pierce beneath it:
 
 ```markdown
-- Recipients whose presence is `busy` (do-not-disturb) are not pushed; `in-call`
-  recipients are not pushed unless they set `showNotificationsInCall`. Everyone
-  else (online, offline, away, missing) receives one.
-- A sender in the recipient's `priorityContacts` bypasses `muteAllNotifications`,
-  `busy` and `in-call`, but only when the recipient enabled
+- Presence-busy / in-call recipients are not pushed unless they set
+  `showNotificationsInCall`; everyone else (online, offline, away, missing)
+  receives one.
+- A sender in the recipient's `priorityContacts` bypasses `muteAllNotifications`
+  and presence suppression alike, but only when the recipient enabled
   `alwaysAllowPriorityNotifications`. Per-room mute is never bypassed.
 ```
 
 - [ ] **Step 4: Mark Spec 2 partly superseded**
 
-Insert immediately below the `# Notification Settings Enforcement (Spec 2 of 2)` heading in `docs/superpowers/specs/2026-08-10-notification-settings-enforcement-design.md`:
+Insert immediately below the `# Notification Settings Enforcement (Spec 2 of 2)` heading:
 
 ```markdown
 > **Partly superseded** by `2026-08-10-priority-contact-presence-gating-design.md`
-> (Spec 3, issue #221), which reverses two decisions below: the priority-contact
-> pierce now *does* cross the in-call gate, and `showNotificationsInCall` no longer
-> governs `busy`/do-not-disturb. Everything else here — placement, fail-open, the
-> no-cache reasoning, config — still describes the shipped code.
+> (Spec 3, issue #221), which reverses one decision below: the priority-contact
+> pierce now *does* cross the in-call gate. The `busy`+`in-call` bucket described
+> here is still what ships; Spec 3 adds inert `isDND`/`isPresenting` predicates
+> above it, to be filled in by the presence side of the system. Everything else
+> here — placement, fail-open, the no-cache reasoning, config — still describes
+> the shipped code.
 ```
 
 - [ ] **Step 5: Verify no derived view drifted**
@@ -356,13 +377,13 @@ Run:
 grep -n "showNotificationsInCall\|alwaysAllowPriorityNotifications" docs/client-api/request-reply.md docs/client-api/events.md
 ```
 
-Expected: no matches, or matches that merely name the field in a schema table without describing enforcement. If a derived view *describes* enforcement semantics, update it to match Steps 1-2 — CLAUDE.md forbids letting the views drift from the canonical doc.
+Expected: matches that merely name the field in a schema table without describing enforcement. If a view *describes* enforcement semantics, update it to match Steps 1-2.
 
 - [ ] **Step 6: Commit**
 
 ```bash
 git add docs/client-api.md docs/superpowers/specs/2026-08-10-notification-settings-enforcement-design.md
-git commit -m "docs(client-api): DND and priority-pierce enforcement semantics
+git commit -m "docs(client-api): priority-pierce bypasses presence suppression
 
 Refs #221"
 ```
@@ -377,7 +398,7 @@ Refs #221"
 
 Run: `make test`
 
-Expected: PASS. `shouldPush` is called only from `notification-worker`, so nothing outside it should move; a failure elsewhere means something unintended was touched.
+Expected: PASS. `shouldPush` is called only from `notification-worker`, so a failure elsewhere means something unintended was touched.
 
 - [ ] **Step 2: Lint**
 
@@ -389,13 +410,19 @@ Expected: clean.
 
 Run: `make sast`
 
-Expected: no medium-or-above findings. This change adds no I/O, parsing or crypto, so a new finding means something unrelated leaked into the branch.
+Expected: no medium-or-above findings. Note that in a sandboxed session `govulncheck` (needs `vuln.go.dev`) and semgrep's registry rulesets (need `semgrep.dev`) may be blocked by egress policy — report that rather than routing around it, and run the repo-local rules alone:
+
+```bash
+semgrep --error --severity=WARNING --severity=ERROR --metrics=off \
+  --exclude=tools --exclude=chat-frontend --exclude=testdata --exclude=docs \
+  --config=.semgrep/ ./notification-worker/
+```
 
 - [ ] **Step 4: Confirm the diff matches the spec's scope**
 
-Run: `git diff --stat main...HEAD`
+Run: `git diff --stat origin/main...HEAD`
 
-Expected files and no others: `notification-worker/presence.go`, `notification-worker/presence_test.go`, `notification-worker/handler.go`, `notification-worker/handler_test.go`, `docs/client-api.md`, the two spec files, and this plan. Specifically confirm **no** change to `notification-worker/main.go`, `notification-worker/usersettings.go`, either `notification-worker/deploy/*/docker-compose.yml`, or anything under `pkg/` — the spec adds no config and no wire surface. Also confirm no `coverage.out` was committed.
+Expected files and no others: `notification-worker/presence.go`, `notification-worker/presence_test.go`, `notification-worker/handler.go`, `notification-worker/handler_test.go`, `docs/client-api.md`, the two spec files, and this plan. Confirm **no** change to `notification-worker/main.go`, `usersettings.go`, either `deploy/*/docker-compose.yml`, or anything under `pkg/`. Confirm no `coverage.out` was committed.
 
 - [ ] **Step 5: Push**
 
@@ -404,3 +431,15 @@ git push -u origin claude/issue-221-design-plan-qxdqv5
 ```
 
 Retry up to 4 times with exponential backoff (2s, 4s, 8s, 16s) on network failure only.
+
+---
+
+## Follow-up (not this plan)
+
+When the presence side ships do-not-disturb and presenting, that change:
+
+1. Replaces the two stub vars with real `func isDND(p model.Presence) bool` / `func isPresenting(p model.Presence) bool`.
+2. Drops `"busy"` from `isInCall`, leaving it `in-call` only.
+3. Deletes `TestDNDAndPresentingStubsAreInert` and converts the test helpers if the vars become plain funcs.
+4. Adds the do-not-disturb sentence to the `showNotificationsInCall` row in `docs/client-api.md`.
+5. Sizes `{"settings.showNotificationsInCall": true, "active": {"$ne": false}}` in production first — those users stop receiving pushes while in do-not-disturb, the one delivery reduction in this whole series.

--- a/docs/superpowers/plans/2026-08-10-priority-contact-presence-gating.md
+++ b/docs/superpowers/plans/2026-08-10-priority-contact-presence-gating.md
@@ -1,0 +1,406 @@
+# Priority-Contact Presence Gating Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the priority-contact pierce cross the presence gate, and stop `showNotificationsInCall` from governing manual do-not-disturb.
+
+**Architecture:** All behaviour lives in one pure function, `shouldPush` in `notification-worker/presence.go`. Its single predicate `isInCall` — which today buckets `busy` and `in-call` together — splits into `isDND` and `isInCall`, and the pierce moves to the top of the function as a total early return. Nothing else in the pipeline changes: the candidate loop, the settings/presence snapshots, survivor sorting, batching and dedup are untouched.
+
+**Tech Stack:** Go 1.25, `stretchr/testify` for assertions, table-driven tests, `make` targets.
+
+**Spec:** `docs/superpowers/specs/2026-08-10-priority-contact-presence-gating-design.md`
+
+## Global Constraints
+
+- TDD is mandatory (CLAUDE.md §4): write the tests, run them, **confirm they fail**, then implement. Task 1 is ordered so every test exists before any implementation.
+- Use `make` targets, not raw `go` commands — except for coverage, where CLAUDE.md itself prescribes `go test -coverprofile` / `go tool cover -func`.
+- Unit tests for this service: `make test SERVICE=notification-worker` (expands to `go test -race ./notification-worker/...`). The target does **not** forward `-run`; to run a single test use `go test -race ./notification-worker/ -run '<Name>' -v` directly, and finish with the `make` target.
+- Test files stay in `package main` so they can reach unexported identifiers.
+- Presence statuses come from `pkg/model` constants — `model.StatusBusy` (`"busy"`), `model.StatusInCall` (`"in-call"`). Compare via `string(...)`; `model.Presence.AggregatedStatus` is a plain `string`.
+- Comments follow the repo's WHY-not-WHAT convention: max 2 lines, rationale only, never restating the code.
+- Minimum 80% coverage; `shouldPush`, `isDND` and `isInCall` must each reach 100%.
+- Lint and tests are enforced by a pre-commit hook. A failing hook means fix, not retry.
+- Do NOT add env vars, model fields, RPCs or events. `USER_SETTINGS_ENABLED=false` is already the kill switch for everything here.
+- Do NOT modify `handler.go`'s candidate loop. A per-room-muted member must keep being dropped before the gate — no pierce resurrects them.
+
+---
+
+### Task 1: Split the presence predicates and make the pierce total
+
+Every test lands before the implementation, so the red phase is real. The two handler tests are here rather than in a later task for exactly that reason: written after the implementation they would pass on arrival and prove nothing.
+
+**Files:**
+- Modify: `notification-worker/presence.go:119-143` (`isInCall`, `shouldPush`)
+- Modify: `notification-worker/handler.go:200-207` (comment block above the two `Snapshot` calls)
+- Test: `notification-worker/presence_test.go:27-89` (`TestShouldPush`, `TestIsInCall`)
+- Test: `notification-worker/handler_test.go` (append two tests at end of file)
+
+**Interfaces:**
+- Consumes: `notifSettings` from `notification-worker/usersettings.go` — fields `muteAll`, `allowPriority`, `showInCall bool`, `priorityContacts map[string]struct{}`. `model.Presence{AggregatedStatus string}` from `pkg/model/presence.go`. Existing test fixtures in `handler_test.go`: `newTestHandlerWithSettings(members, presence, settings, hook, emit)`, `stubMembers{out map[string][]roomsubcache.Member}`, `stubPresence{out map[string]model.Presence}`, `stubSettings{out map[string]notifSettings, err error}`, `recordingEmitter` with `.accounts() []string`, `msgEvent(*model.Message) []byte`, `noopVetoer{}`.
+- Produces: `func isDND(p model.Presence) bool`, `func isInCall(p model.Presence) bool`, `func shouldPush(p model.Presence, ns notifSettings, isPrioritySender bool) bool` — **signature unchanged**, so `handler.go:213`'s call site keeps compiling untouched.
+
+- [ ] **Step 1: Replace the `TestShouldPush` table**
+
+Replace the whole `tests := []struct{...}{...}` literal in `TestShouldPush` (`presence_test.go:28-62`) with the table below. Keep the surrounding `for`/`t.Run` loop exactly as it is.
+
+```go
+	tests := []struct {
+		name             string
+		status           string
+		ns               notifSettings
+		isPrioritySender bool
+		want             bool
+	}{
+		// Zero notifSettings must reproduce pre-Spec-3 behaviour on every status:
+		// no stored settings means no behaviour change from this deploy.
+		{"zero settings online", "online", notifSettings{}, false, true},
+		{"zero settings offline", "offline", notifSettings{}, false, true},
+		{"zero settings away", "away", notifSettings{}, false, true},
+		{"zero settings busy", "busy", notifSettings{}, false, false},
+		{"zero settings in-call", "in-call", notifSettings{}, false, false},
+		{"zero settings missing status", "", notifSettings{}, false, true},
+		{"zero settings unknown status", "unknown", notifSettings{}, false, true},
+
+		// muteAll suppresses unless a priority sender pierces it.
+		{"muted, no pierce", "online", notifSettings{muteAll: true}, false, false},
+		{"muted, priority sender but pierce disabled", "online", notifSettings{muteAll: true}, true, false},
+		{"muted, pierce enabled but sender not priority", "online", notifSettings{muteAll: true, allowPriority: true}, false, false},
+		{"muted, pierce enabled and sender is priority", "online", notifSettings{muteAll: true, allowPriority: true}, true, true},
+		{"unmuted, pierce enabled, non-priority sender", "online", notifSettings{allowPriority: true}, false, true},
+
+		// DND is no longer governed by showNotificationsInCall. This row is the one
+		// population whose pushes this change removes.
+		{"busy, opted in to in-call notifications, still suppressed", "busy", notifSettings{showInCall: true}, false, false},
+		{"busy, no opt-in", "busy", notifSettings{}, false, false},
+
+		// showNotificationsInCall still governs in-call, for every non-priority sender.
+		{"in-call, opted in", "in-call", notifSettings{showInCall: true}, false, true},
+		{"in-call, not opted in", "in-call", notifSettings{}, false, false},
+
+		// The pierce now crosses the presence gate too — the Spec 3 reversal.
+		{"busy, priority pierce", "busy", notifSettings{allowPriority: true}, true, true},
+		{"in-call, priority pierce without in-call opt-in", "in-call", notifSettings{allowPriority: true}, true, true},
+		{"muted+pierced, in-call without opt-in", "in-call", notifSettings{muteAll: true, allowPriority: true}, true, true},
+		{"muted+pierced, in-call with opt-in", "in-call", notifSettings{muteAll: true, allowPriority: true, showInCall: true}, true, true},
+
+		// ...but only with its opt-in. A priority sender alone pierces nothing.
+		{"busy, priority sender but pierce disabled", "busy", notifSettings{}, true, false},
+		{"in-call, priority sender but pierce disabled", "in-call", notifSettings{}, true, false},
+
+		// Every suppressor clear.
+		{"muted+pierced, online", "online", notifSettings{muteAll: true, allowPriority: true, showInCall: true}, true, true},
+	}
+```
+
+- [ ] **Step 2: Split `TestIsInCall` into two tests**
+
+Replace `TestIsInCall` (`presence_test.go:71-89`) entirely with the pair below. Each asserts the *other* status is false — that mutual exclusion is what fails if anyone re-merges the bucket.
+
+```go
+func TestIsDND(t *testing.T) {
+	tests := []struct {
+		status string
+		want   bool
+	}{
+		{"busy", true},
+		{"in-call", false},
+		{"online", false},
+		{"offline", false},
+		{"away", false},
+		{"", false},
+		{"unknown", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			assert.Equal(t, tt.want, isDND(model.Presence{AggregatedStatus: tt.status}))
+		})
+	}
+}
+
+func TestIsInCall(t *testing.T) {
+	tests := []struct {
+		status string
+		want   bool
+	}{
+		{"in-call", true},
+		{"busy", false},
+		{"online", false},
+		{"offline", false},
+		{"away", false},
+		{"", false},
+		{"unknown", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			assert.Equal(t, tt.want, isInCall(model.Presence{AggregatedStatus: tt.status}))
+		})
+	}
+}
+```
+
+- [ ] **Step 3: Add the two handler tests**
+
+The table above proves the pure function. These prove the handler actually combines the settings map and the presence map per-recipient — `ns.isPriority(msg.UserAccount)` is keyed on the **sender's** account, an easy-to-invert wiring detail no pure-function test can catch.
+
+Append to the end of `notification-worker/handler_test.go`:
+
+```go
+// TestHandle_PriorityContactPiercesDND pins the Spec 3 reversal end-to-end: the
+// pierce crosses the presence gate, and it is keyed on the sender's account —
+// bob lists the sender, carol lists someone else, and both are equally in DND.
+func TestHandle_PriorityContactPiercesDND(t *testing.T) {
+	members := &stubMembers{out: map[string][]roomsubcache.Member{
+		"r1": {
+			{ID: "alice", Account: "alice"},
+			{ID: "bob", Account: "bob"},
+			{ID: "carol", Account: "carol"},
+		},
+	}}
+	presence := &stubPresence{out: map[string]model.Presence{
+		"bob":   {AggregatedStatus: "busy"},
+		"carol": {AggregatedStatus: "busy"},
+	}}
+	settings := &stubSettings{out: map[string]notifSettings{
+		"bob":   {allowPriority: true, priorityContacts: map[string]struct{}{"alice": {}}},
+		"carol": {allowPriority: true, priorityContacts: map[string]struct{}{"dave": {}}},
+	}}
+	emit := &recordingEmitter{}
+	h := newTestHandlerWithSettings(members, presence, settings, noopVetoer{}, emit)
+
+	require.NoError(t, h.HandleMessage(context.Background(), msgEvent(&model.Message{
+		ID: "m1", RoomID: "r1", UserID: "alice", UserAccount: "alice", CreatedAt: time.Now(),
+	})))
+	assert.Equal(t, []string{"bob"}, emit.accounts(),
+		"bob lists the sender as a priority contact and is pierced out of DND; carol does not")
+}
+
+// TestHandle_DNDIgnoresShowNotificationsInCall pins the other half of the split:
+// the in-call opt-in must not rescue a recipient who is in do-not-disturb.
+func TestHandle_DNDIgnoresShowNotificationsInCall(t *testing.T) {
+	members := &stubMembers{out: map[string][]roomsubcache.Member{
+		"r1": {
+			{ID: "alice", Account: "alice"},
+			{ID: "bob", Account: "bob"},
+			{ID: "carol", Account: "carol"},
+		},
+	}}
+	presence := &stubPresence{out: map[string]model.Presence{
+		"bob":   {AggregatedStatus: "busy"},
+		"carol": {AggregatedStatus: "in-call"},
+	}}
+	settings := &stubSettings{out: map[string]notifSettings{
+		"bob":   {showInCall: true},
+		"carol": {showInCall: true},
+	}}
+	emit := &recordingEmitter{}
+	h := newTestHandlerWithSettings(members, presence, settings, noopVetoer{}, emit)
+
+	require.NoError(t, h.HandleMessage(context.Background(), msgEvent(&model.Message{
+		ID: "m1", RoomID: "r1", UserID: "alice", UserAccount: "alice", CreatedAt: time.Now(),
+	})))
+	assert.Equal(t, []string{"carol"}, emit.accounts(),
+		"showNotificationsInCall covers in-call only; bob stays suppressed by DND")
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they fail**
+
+Run: `make test SERVICE=notification-worker`
+
+Expected: FAIL. The first failure is a compile error, `undefined: isDND`, because the identifier genuinely does not exist yet — that is a valid red phase, not a setup problem. Do not proceed until you have seen it.
+
+- [ ] **Step 5: Rewrite the predicates and the gate**
+
+In `notification-worker/presence.go`, replace `isInCall` and `shouldPush` — everything from the `// isInCall reports whether presence alone suppresses push.` comment down to the closing brace of `shouldPush` (lines 119-143) — with:
+
+```go
+// isDND reports manual do-not-disturb. Split from isInCall because
+// showNotificationsInCall governs only the latter — DND means DND.
+func isDND(p model.Presence) bool {
+	return p.AggregatedStatus == string(model.StatusBusy)
+}
+
+// isInCall reports an active call. Teams "Presenting" arrives here too:
+// user-presence-service folds it into in-call rather than modelling it separately.
+func isInCall(p model.Presence) bool {
+	return p.AggregatedStatus == string(model.StatusInCall)
+}
+
+// shouldPush applies the priority-contact pierce, then three independent
+// suppressors. alwaysAllowPriorityNotifications is the single opt-in for
+// "priority contacts reach me anyway", so the pierce crosses all three.
+func shouldPush(p model.Presence, ns notifSettings, isPrioritySender bool) bool {
+	if ns.allowPriority && isPrioritySender {
+		return true
+	}
+	if ns.muteAll {
+		return false
+	}
+	if isDND(p) {
+		return false
+	}
+	if isInCall(p) && !ns.showInCall {
+		return false
+	}
+	return true
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `make test SERVICE=notification-worker`
+
+Expected: PASS, everything — including the pre-existing `TestHandle_PresenceBusyDropsPush`, where bob is `busy` with zero settings and must still be dropped. That test must keep passing **unmodified**; if you find yourself editing it, the implementation is wrong.
+
+- [ ] **Step 7: Correct the stale comment in `handler.go`**
+
+The comment block above the two `Snapshot` calls (`handler.go:200-207`) ends with a sentence that is no longer true — `showNotificationsInCall` is not the only thing modifying the presence decision. Replace only that trailing sentence, keeping the narrowing lines intact:
+
+```go
+	// Both lookups run over the narrowed candidate set — only accounts that survived
+	// the exclusion filters, never every member of a large room.
+	// TestHandle_SettingsFetchedOnlyForSurvivingCandidates pins that narrowing.
+	// shouldPush combines the two, keyed on the sender's account for the priority pierce.
+	settings, _ := h.deps.Settings.Snapshot(ctx, accounts) // fail-open: error → empty map
+	snapshot, _ := h.deps.Presence.Snapshot(ctx, accounts) // fail-open: error → empty map
+```
+
+- [ ] **Step 8: Verify coverage of the changed functions**
+
+Run:
+
+```bash
+go test -race -coverprofile=coverage.out ./notification-worker/ && go tool cover -func=coverage.out | grep -E "shouldPush|isDND|isInCall"
+```
+
+Expected: `100.0%` on all three lines. Every branch has a table row, so anything less means a row is missing. Delete `coverage.out` afterwards — it must not be committed.
+
+- [ ] **Step 9: Run the linter**
+
+Run: `make lint`
+
+Expected: clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add notification-worker/presence.go notification-worker/presence_test.go notification-worker/handler.go notification-worker/handler_test.go
+git commit -m "feat(notification-worker): priority contacts pierce DND and in-call
+
+DND (presence \"busy\") is no longer governed by showNotificationsInCall,
+which now covers in-call only. alwaysAllowPriorityNotifications becomes the
+single opt-in for piercing mute, DND and in-call alike; per-room mute is
+still never pierced.
+
+Refs #221"
+```
+
+---
+
+### Task 2: Correct the documentation the change invalidates
+
+Three pieces of prose become factually wrong the moment Task 1 merges. CLAUDE.md requires `docs/client-api.md` to track client-facing behaviour in the same PR.
+
+**Files:**
+- Modify: `docs/client-api.md` — the `alwaysAllowPriorityNotifications` and `showNotificationsInCall` rows in the settings field table (~lines 4760-4763); the push-filter bullet in §4 (~lines 6449-6450)
+- Modify: `docs/superpowers/specs/2026-08-10-notification-settings-enforcement-design.md` (head of file)
+
+**Interfaces:** None — documentation only. No request/response schema, model struct or event changed, so `docs/client-api/request-reply.md` and `docs/client-api/events.md` are deliberately **not** touched.
+
+- [ ] **Step 1: Rewrite the `alwaysAllowPriorityNotifications` row**
+
+Find the row beginning `| \`alwaysAllowPriorityNotifications\` | boolean |`. Its final sentence currently reads "The pierce does not override `showNotificationsInCall`." Replace the entire row with:
+
+```markdown
+| `alwaysAllowPriorityNotifications` | boolean | Always allow priority-contact notifications. Enforced server-side: a message whose sender is in [`priorityContacts`](#settingsprioritycontactsadd) is pushed regardless of `muteAllNotifications`, of a `"busy"` (do-not-disturb) presence, and of an `"in-call"` presence — in **any** room type, DM and channel alike, and for `.bot` senders as well as users. This setting is the only opt-in for that pierce; listing a priority contact without enabling it changes nothing. Per-room mute is not pierced. |
+```
+
+- [ ] **Step 2: Rewrite the `showNotificationsInCall` row**
+
+Find the row beginning `| \`showNotificationsInCall\` | boolean |`. It currently claims the setting covers `"busy"` **or** `"in-call"`, and that the priority pierce does not bypass it — both now wrong. Replace the entire row with:
+
+```markdown
+| `showNotificationsInCall` | boolean | Show notifications in call. Enforced server-side: when unset or `false`, push is suppressed while the user's presence is `"in-call"`. It does **not** govern `"busy"` (do-not-disturb), which suppresses push either way — see `alwaysAllowPriorityNotifications` for the only exemption. A priority-contact pierce does bypass this setting. This enforcement takes effect once presence reporting is enabled server-side; until then no status is treated as in-call, so pushes are delivered regardless of this setting. |
+```
+
+- [ ] **Step 3: Rewrite the §4 push-filter bullet**
+
+Find the bullet reading "Presence-busy / in-call recipients are not pushed; everyone else (online, offline, away, missing) receives one." Replace those two lines with:
+
+```markdown
+- Recipients whose presence is `busy` (do-not-disturb) are not pushed; `in-call`
+  recipients are not pushed unless they set `showNotificationsInCall`. Everyone
+  else (online, offline, away, missing) receives one.
+- A sender in the recipient's `priorityContacts` bypasses `muteAllNotifications`,
+  `busy` and `in-call`, but only when the recipient enabled
+  `alwaysAllowPriorityNotifications`. Per-room mute is never bypassed.
+```
+
+- [ ] **Step 4: Mark Spec 2 partly superseded**
+
+Insert immediately below the `# Notification Settings Enforcement (Spec 2 of 2)` heading in `docs/superpowers/specs/2026-08-10-notification-settings-enforcement-design.md`:
+
+```markdown
+> **Partly superseded** by `2026-08-10-priority-contact-presence-gating-design.md`
+> (Spec 3, issue #221), which reverses two decisions below: the priority-contact
+> pierce now *does* cross the in-call gate, and `showNotificationsInCall` no longer
+> governs `busy`/do-not-disturb. Everything else here — placement, fail-open, the
+> no-cache reasoning, config — still describes the shipped code.
+```
+
+- [ ] **Step 5: Verify no derived view drifted**
+
+Run:
+
+```bash
+grep -n "showNotificationsInCall\|alwaysAllowPriorityNotifications" docs/client-api/request-reply.md docs/client-api/events.md
+```
+
+Expected: no matches, or matches that merely name the field in a schema table without describing enforcement. If a derived view *describes* enforcement semantics, update it to match Steps 1-2 — CLAUDE.md forbids letting the views drift from the canonical doc.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/client-api.md docs/superpowers/specs/2026-08-10-notification-settings-enforcement-design.md
+git commit -m "docs(client-api): DND and priority-pierce enforcement semantics
+
+Refs #221"
+```
+
+---
+
+### Task 3: Whole-repo verification
+
+**Files:** none modified — this task only runs gates.
+
+- [ ] **Step 1: Full unit suite with race detector**
+
+Run: `make test`
+
+Expected: PASS. `shouldPush` is called only from `notification-worker`, so nothing outside it should move; a failure elsewhere means something unintended was touched.
+
+- [ ] **Step 2: Lint**
+
+Run: `make lint`
+
+Expected: clean.
+
+- [ ] **Step 3: SAST**
+
+Run: `make sast`
+
+Expected: no medium-or-above findings. This change adds no I/O, parsing or crypto, so a new finding means something unrelated leaked into the branch.
+
+- [ ] **Step 4: Confirm the diff matches the spec's scope**
+
+Run: `git diff --stat main...HEAD`
+
+Expected files and no others: `notification-worker/presence.go`, `notification-worker/presence_test.go`, `notification-worker/handler.go`, `notification-worker/handler_test.go`, `docs/client-api.md`, the two spec files, and this plan. Specifically confirm **no** change to `notification-worker/main.go`, `notification-worker/usersettings.go`, either `notification-worker/deploy/*/docker-compose.yml`, or anything under `pkg/` — the spec adds no config and no wire surface. Also confirm no `coverage.out` was committed.
+
+- [ ] **Step 5: Push**
+
+```bash
+git push -u origin claude/issue-221-design-plan-qxdqv5
+```
+
+Retry up to 4 times with exponential backoff (2s, 4s, 8s, 16s) on network failure only.

--- a/docs/superpowers/plans/2026-08-10-priority-contact-presence-gating.md
+++ b/docs/superpowers/plans/2026-08-10-priority-contact-presence-gating.md
@@ -443,3 +443,5 @@ When the presence side ships do-not-disturb and presenting, that change:
 3. Deletes `TestDNDAndPresentingStubsAreInert` and converts the test helpers if the vars become plain funcs.
 4. Adds the do-not-disturb sentence to the `showNotificationsInCall` row in `docs/client-api.md`.
 5. Sizes `{"settings.showNotificationsInCall": true, "active": {"$ne": false}}` in production first — those users stop receiving pushes while in do-not-disturb, the one delivery reduction in this whole series.
+
+**Sequence it consumer-first.** `shouldPush` fails open on unrecognized presence and `isInCall` matches literal status strings, so a producer emitting a new do-not-disturb representation while any `notification-worker` is still on the old binary makes that worker fail open and push to the users the change protects. Roll recognition out to every worker before any producer emits the new representation, and keep the old suppressing representation (or dual-encode) until the last old worker and every rollback target is gone.

--- a/docs/superpowers/specs/2026-08-10-notification-settings-enforcement-design.md
+++ b/docs/superpowers/specs/2026-08-10-notification-settings-enforcement-design.md
@@ -1,10 +1,12 @@
 # Notification Settings Enforcement (Spec 2 of 2)
 
 > **Partly superseded** by `2026-08-10-priority-contact-presence-gating-design.md`
-> (Spec 3, issue #221), which reverses two decisions below: the priority-contact
-> pierce now *does* cross the in-call gate, and `showNotificationsInCall` no longer
-> governs `busy`/do-not-disturb. Everything else here — placement, fail-open, the
-> no-cache reasoning, config — still describes the shipped code.
+> (Spec 3, issue #221), which reverses one decision below: the priority-contact
+> pierce now *does* cross the in-call gate. The `busy`+`in-call` bucket described
+> here is still what ships; Spec 3 adds inert `isDND`/`isPresenting` predicates
+> above it, to be filled in by the presence side of the system. Everything else
+> here — placement, fail-open, the no-cache reasoning, config — still describes
+> the shipped code.
 
 Spec 1 (`2026-08-08-priority-contacts-storage-api-design.md`) gave users a place to
 store notification preferences. Nothing reads them. This spec makes

--- a/docs/superpowers/specs/2026-08-10-notification-settings-enforcement-design.md
+++ b/docs/superpowers/specs/2026-08-10-notification-settings-enforcement-design.md
@@ -1,5 +1,11 @@
 # Notification Settings Enforcement (Spec 2 of 2)
 
+> **Partly superseded** by `2026-08-10-priority-contact-presence-gating-design.md`
+> (Spec 3, issue #221), which reverses two decisions below: the priority-contact
+> pierce now *does* cross the in-call gate, and `showNotificationsInCall` no longer
+> governs `busy`/do-not-disturb. Everything else here — placement, fail-open, the
+> no-cache reasoning, config — still describes the shipped code.
+
 Spec 1 (`2026-08-08-priority-contacts-storage-api-design.md`) gave users a place to
 store notification preferences. Nothing reads them. This spec makes
 `notification-worker` honour three of them when deciding whether to push.

--- a/docs/superpowers/specs/2026-08-10-priority-contact-presence-gating-design.md
+++ b/docs/superpowers/specs/2026-08-10-priority-contact-presence-gating-design.md
@@ -1,0 +1,253 @@
+# Priority-Contact Presence Gating (Spec 3 of 3)
+
+Issue #221. Spec 1 (`2026-08-08-priority-contacts-storage-api-design.md`) stored the
+settings. Spec 2 (`2026-08-10-notification-settings-enforcement-design.md`) made
+`notification-worker` enforce three of them. This spec finishes the decision table:
+presence-based suppression gains a priority-contact exemption, and manual
+do-not-disturb stops borrowing the in-call checkbox.
+
+The issue calls the component "push-notification-worker". That is
+`notification-worker`: its push path (`mobileEmitter` → `PUSH-NOTIFICATION` →
+`push-notification-service` → APNs/FCM) *is* the mobile lane, so "Desktop settings
+that sync to Mobile" means "the stored user settings gate this pipeline". No
+separate desktop/mobile settings store exists or is introduced.
+
+## Scope
+
+One function. `shouldPush` in `notification-worker/presence.go` is the only
+behavioural change. The candidate loop, the settings snapshotter, presence
+fetching, survivor sorting, batching and the `{messageID}-b{N}` dedup ID are all
+untouched — as in Spec 2, this changes only which accounts reach `survivors`.
+
+### Out of scope
+
+- **New config.** `USER_SETTINGS_ENABLED=false` already reverts the entire gate to
+  pre-enforcement behaviour, including everything here, so a second kill switch
+  would only add a state nobody tests.
+- **New wire surface.** No RPC, model field or event changes, so the derived views
+  (`docs/client-api/request-reply.md`, `docs/client-api/events.md`) are untouched
+  and the CLAUDE.md same-PR rule for them is not triggered.
+- **`showPreviewsInNotifications`.** Still shapes the push *body*, not whether one
+  is sent. Out of scope for the same reason Spec 2 gave.
+- **Per-room notification rules** beyond what the pipeline already applies. See
+  "Room rules are absolute" below.
+
+## Mapping the issue onto our status vocabulary
+
+The issue names three presence conditions — `Do not disturb`, `presenting`, and
+`In a call`. Our vocabulary has two relevant values, and they do not line up
+one-for-one:
+
+| Issue term | Our value | Where it comes from |
+|---|---|---|
+| `Do not disturb` | `busy` | Manual override (`settings`/`presence.status`), `model.StatusBusy` |
+| `presenting` | `in-call` | Teams activity `Presenting`, folded into in-call by `user-presence-service/sync/reconcile.go` |
+| `In a call` | `in-call` | Teams activities `InACall` / `InAConferenceCall` |
+
+**Decision: keep `Presenting` folded into `in-call`; split `busy` out on its own.**
+
+Making `presenting` a literal third status would mean a new `model.PresenceStatus`
+value, a change to `reconcile.go`'s `callActivities` mapping, a new value in the
+`docs/client-api.md` presence enum, and every client that switches on presence
+needing an update — all to distinguish two states the issue then treats
+identically except for which checkbox governs them. `Presenting` is a call
+activity; it is in-call in every sense our system models.
+
+The consequence is stated plainly rather than buried: **a Teams user who is
+Presenting is treated as in-call, so `showNotificationsInCall` can let those
+pushes through.** Under a literal reading of the issue, Presenting would suppress
+unconditionally. If that distinction turns out to matter to users, it is a
+presence-service change, not a notification-worker one.
+
+`busy`, by contrast, is already a distinct stored value and needs no new plumbing
+to separate.
+
+## The gate
+
+```go
+// isDND reports manual do-not-disturb. Separate from isInCall because
+// showNotificationsInCall governs only the latter.
+func isDND(p model.Presence) bool { return p.AggregatedStatus == string(model.StatusBusy) }
+
+// isInCall reports an active call. Teams "Presenting" arrives here too — see the
+// status-vocabulary mapping in the spec.
+func isInCall(p model.Presence) bool { return p.AggregatedStatus == string(model.StatusInCall) }
+
+// shouldPush applies the priority-contact pierce, then three independent
+// suppressors in the issue's stated priority order.
+func shouldPush(p model.Presence, ns notifSettings, isPrioritySender bool) bool {
+	if ns.allowPriority && isPrioritySender {
+		return true
+	}
+	if ns.muteAll {
+		return false
+	}
+	if isDND(p) {
+		return false
+	}
+	if isInCall(p) && !ns.showInCall {
+		return false
+	}
+	return true
+}
+```
+
+Four decisions are encoded here, each of which could reasonably have gone the
+other way. Two of them reverse Spec 2.
+
+### The pierce is total, and it is one switch
+
+`alwaysAllowPriorityNotifications` is the single control for "priority contacts
+can reach me anyway". It pierces mute, DND and in-call alike.
+
+The issue's table mentions the checkbox only on the mute-all row and leaves the
+status rows saying just "Priority contacts", which reads as an unconditional
+exemption. That reading is rejected: it would mean merely *adding* someone to
+priority contacts silently changes what happens during DND, for a user who never
+asked for that. Tying every pierce to one explicit opt-in gives one rule to
+document, one setting to find in the UI, and — importantly for rollout — no
+behaviour change at all for users who never enabled it.
+
+The early `return true` is deliberate over three `&& !pierce` clauses. It states
+"a priority contact reaches you regardless" as one readable fact instead of
+something the reader reconstructs from three conditions.
+
+**This reverses Spec 2**, which held that the pierce "deliberately does not cross
+the in-call gate", reasoning that letting it through "would make
+`showNotificationsInCall` unreachable for exactly the senders most likely to
+trigger it". That reasoning was sound but is now overruled by the issue's explicit
+"Priority contacts are still exempt". The setting is not unreachable — it governs
+every non-priority sender, which is the large majority of traffic.
+
+### `showNotificationsInCall` no longer governs DND
+
+Spec 2 bucketed `busy` and `in-call` together under one predicate, arguing that
+splitting them "would leave `busy` with no user-facing control at all and no
+setting to add one".
+
+The issue answers that objection directly: DND *should* have no user-facing
+control beyond the priority-contact exemption. Do-not-disturb means do not
+disturb — a checkbox named for calls should not quietly re-enable pushes during
+it. `busy` is also the one status the user sets by hand, so an explicit intent
+already exists and does not need a second one layered on top.
+
+**This reverses Spec 2**, which is left in place as the historical record with a
+superseded-by pointer at its head.
+
+### The pierce stays any-room
+
+The issue scopes the mute-all pierce to "Priority contacts' **1-on-1** messages".
+Spec 2 shipped it as any-room, and that stands: the setting says *always*, and a
+DM-only pierce would be a second undocumented rule the settings UI has no room to
+express. Narrowing it now would also silently reduce delivery for users already
+relying on the shipped behaviour. Kept unchanged.
+
+### Room rules are absolute
+
+The issue's step 4 — "none of the above → apply each chatroom's individual
+notification rules" — invites a short-circuit reading in which a step 1–3
+exception means "allow" and room rules are never consulted. Rejected.
+
+Per-room mute (`m.Muted`) and the large-room mention-only throttle run in the
+candidate loop, *before* the user-level gate, and no pierce resurrects a member
+they dropped. Step 4 is read as "user-level settings never *widen* delivery past a
+room rule". This matters precisely because the pierce is any-room: under the other
+reading, a priority contact posting in a channel you muted would push you, and
+per-room mute would stop being reliable.
+
+Practical consequence: **the candidate loop needs no change at all.** This spec
+stays confined to `shouldPush`.
+
+## Behaviour delta
+
+Exactly two populations move. Everyone else is bit-for-bit unchanged.
+
+| Population | Before | After |
+|---|---|---|
+| `showNotificationsInCall=true`, presence `busy` | pushed | **suppressed** |
+| `alwaysAllowPriorityNotifications=true` + sender in `priorityContacts`, presence `busy` or `in-call` | suppressed | **pushed** |
+
+Users with no stored settings are unaffected: the zero `notifSettings` has
+`showInCall=false` and `allowPriority=false`, so `busy` and `in-call` both
+suppressed before this change and both suppress after it. The same holds under
+`USER_SETTINGS_ENABLED=false`, whose `noopUserSettings` yields that zero value for
+every recipient — so the kill switch still restores pre-enforcement behaviour
+exactly.
+
+## Testing
+
+TDD per CLAUDE.md — tests first, confirmed red, then implementation. `shouldPush`
+is pure and I/O-free, so the unit table is the whole verification surface; no
+integration test is warranted because nothing here touches Mongo, NATS or Valkey.
+
+**`shouldPush` (table-driven, `presence_test.go`).** The matrix of `muteAll` ×
+`allowPriority` × `isPrioritySender` × `showInCall` × presence status over
+`{"", "online", "away", "offline", "busy", "in-call"}`. Named rows for:
+
+- the two moved populations above, one row each, named for the change;
+- the zero `notifSettings` reproducing pre-change behaviour on every status —
+  this is the row that pins "no stored settings, no change";
+- a priority sender *without* `allowPriority` still suppressed by DND and by
+  mute, pinning that the pierce needs its opt-in;
+- `showNotificationsInCall=true` + `in-call` + non-priority sender pushing,
+  pinning that the setting is still reachable.
+
+**`isDND` / `isInCall` (`presence_test.go`).** `TestIsInCall` splits into
+`TestIsDND` and `TestIsInCall`, each asserting the *other* status is false —
+that pair is what fails if anyone re-merges the bucket.
+
+**Pierce end-to-end (`handler_test.go`).** A `busy` recipient with
+`alwaysAllowPriorityNotifications` and the sender in `priorityContacts` is emitted
+to. Complements the pure-function table by proving the settings and presence maps
+are actually combined per-recipient in the survivor loop.
+
+Coverage floor 80%; `shouldPush` and its predicates are core logic and should
+reach 100% given how small they are.
+
+## Documentation
+
+Three `docs/client-api.md` rows become factually wrong on merge and are corrected
+in the same PR:
+
+- `alwaysAllowPriorityNotifications` — drop "The pierce does not override
+  `showNotificationsInCall`"; state that the pierce covers mute, DND and in-call,
+  in any room type.
+- `showNotificationsInCall` — it governs `"in-call"` only, no longer `"busy"`; the
+  priority pierce *does* bypass it.
+- `muteAllNotifications` — unchanged in substance; verify the cross-reference
+  still reads correctly beside the two rewritten rows.
+
+Plus the push-filter bullet in §4 ("Presence-busy / in-call recipients are not
+pushed; everyone else…"), which now needs the DND/in-call split and the priority
+exemption.
+
+`2026-08-10-notification-settings-enforcement-design.md` gains a one-line
+superseded-by pointer at its head so it is not read as current.
+
+## Rollout
+
+Population 1 is the one that matters: users who explicitly enabled
+`showNotificationsInCall` and use manual DND stop receiving pushes while
+do-not-disturb is set. That is the intended outcome and it is a silent,
+user-visible reduction in delivery, so it belongs in the release notes rather than
+arriving as a report of missing notifications.
+
+Release note: do-not-disturb now suppresses push regardless of the "show
+notifications in call" setting; priority contacts pierce do-not-disturb and
+in-call when "always allow priority contact notifications" is enabled;
+`USER_SETTINGS_ENABLED=false` reverts to prior behaviour without a rollback.
+
+Worth sizing population 1 against production `users` before deploying —
+`{"settings.showNotificationsInCall": true, "active": {"$ne": false}}` — so the
+change lands as a known number.
+
+## Files
+
+| File | Change |
+|------|--------|
+| `notification-worker/presence.go` | Split `isInCall` into `isDND` + `isInCall`; rewrite `shouldPush`. |
+| `notification-worker/presence_test.go` | Extend the `shouldPush` table; split `TestIsInCall`. |
+| `notification-worker/handler.go` | Correct the stale comment above the snapshot calls. |
+| `notification-worker/handler_test.go` | End-to-end priority pierce past a `busy` recipient. |
+| `docs/client-api.md` | Two settings rows; the §4 push-filter bullet. |
+| `docs/superpowers/specs/2026-08-10-notification-settings-enforcement-design.md` | Superseded-by pointer. |

--- a/docs/superpowers/specs/2026-08-10-priority-contact-presence-gating-design.md
+++ b/docs/superpowers/specs/2026-08-10-priority-contact-presence-gating-design.md
@@ -32,49 +32,55 @@ untouched — as in Spec 2, this changes only which accounts reach `survivors`.
 - **Per-room notification rules** beyond what the pipeline already applies. See
   "Room rules are absolute" below.
 
-## Mapping the issue onto our status vocabulary
+## Do-not-disturb and presenting are not ours to derive
 
 The issue names three presence conditions — `Do not disturb`, `presenting`, and
-`In a call`. Our vocabulary has two relevant values, and they do not line up
-one-for-one:
+`In a call`. Only the third exists in our vocabulary today. `busy` is a manual
+override and `Presenting` is currently folded into `in-call` by
+`user-presence-service/sync/reconcile.go`.
 
-| Issue term | Our value | Where it comes from |
-|---|---|---|
-| `Do not disturb` | `busy` | Manual override (`settings`/`presence.status`), `model.StatusBusy` |
-| `presenting` | `in-call` | Teams activity `Presenting`, folded into in-call by `user-presence-service/sync/reconcile.go` |
-| `In a call` | `in-call` | Teams activities `InACall` / `InAConferenceCall` |
+**Decision: do not infer either one. Stub both predicates.**
 
-**Decision: keep `Presenting` folded into `in-call`; split `busy` out on its own.**
+An earlier draft of this spec mapped `Do not disturb → busy` and
+`presenting → in-call`. That was wrong. Deriving DND from `busy` asserts a
+semantic equivalence this service has no authority to declare, and the same for
+presenting. Those statuses are owned by the presence side of the system, which
+will ship them; this worker's job is to gate on them, not to guess at them.
 
-Making `presenting` a literal third status would mean a new `model.PresenceStatus`
-value, a change to `reconcile.go`'s `callActivities` mapping, a new value in the
-`docs/client-api.md` presence enum, and every client that switches on presence
-needing an update — all to distinguish two states the issue then treats
-identically except for which checkbox governs them. `Presenting` is a call
-activity; it is in-call in every sense our system models.
+So `notification-worker` declares the two predicates it needs and leaves them
+inert:
 
-The consequence is stated plainly rather than buried: **a Teams user who is
-Presenting is treated as in-call, so `showNotificationsInCall` can let those
-pushes through.** Under a literal reading of the issue, Presenting would suppress
-unconditionally. If that distinction turns out to matter to users, it is a
-presence-service change, not a notification-worker one.
+```go
+var (
+	isDND        = func(model.Presence) bool { return false }
+	isPresenting = func(model.Presence) bool { return false }
+)
+```
 
-`busy`, by contrast, is already a distinct stored value and needs no new plumbing
-to separate.
+They are `var`s rather than plain funcs for one reason: a stub returning a
+constant makes its branch in `shouldPush` unreachable, so a plain func would ship
+the rule-2 wiring as untested dead code. As vars, tests supply the eventual
+behaviour and prove the gate ordering **now**, so when the real predicates land
+the only thing left to verify is the predicates themselves.
+
+**Consequence, stated rather than buried: rule 2 of the decision table is
+specified and wired but does not fire yet.** Until the presence side ships, a
+user in do-not-disturb is governed by whatever `isInCall` already covers.
+
+### `isInCall` is deliberately left alone
+
+`isInCall` keeps matching **both** `busy` and `in-call`, exactly as Spec 2 shipped
+it. Narrowing it to `in-call` now — the natural-looking tidy-up once `isDND`
+exists — would push notifications to every user in manual do-not-disturb for the
+entire gap before the presence side ships. Rule 2 arriving inert is acceptable;
+a regression in the meantime is not.
+
+When the real `isDND` lands, `busy` moves out of the `isInCall` bucket in that
+same change, and `showNotificationsInCall` narrows to in-call only.
 
 ## The gate
 
 ```go
-// isDND reports manual do-not-disturb. Separate from isInCall because
-// showNotificationsInCall governs only the latter.
-func isDND(p model.Presence) bool { return p.AggregatedStatus == string(model.StatusBusy) }
-
-// isInCall reports an active call. Teams "Presenting" arrives here too — see the
-// status-vocabulary mapping in the spec.
-func isInCall(p model.Presence) bool { return p.AggregatedStatus == string(model.StatusInCall) }
-
-// shouldPush applies the priority-contact pierce, then three independent
-// suppressors in the issue's stated priority order.
 func shouldPush(p model.Presence, ns notifSettings, isPrioritySender bool) bool {
 	if ns.allowPriority && isPrioritySender {
 		return true
@@ -82,7 +88,7 @@ func shouldPush(p model.Presence, ns notifSettings, isPrioritySender bool) bool 
 	if ns.muteAll {
 		return false
 	}
-	if isDND(p) {
+	if isDND(p) || isPresenting(p) {
 		return false
 	}
 	if isInCall(p) && !ns.showInCall {
@@ -92,8 +98,9 @@ func shouldPush(p model.Presence, ns notifSettings, isPrioritySender bool) bool 
 }
 ```
 
-Four decisions are encoded here, each of which could reasonably have gone the
-other way. Two of them reverse Spec 2.
+This is the issue's priority order literally: pierce, then mute, then rule 2,
+then the in-call bucket. Four decisions are encoded here, each of which could
+reasonably have gone the other way. One of them reverses Spec 2.
 
 ### The pierce is total, and it is one switch
 
@@ -119,20 +126,20 @@ trigger it". That reasoning was sound but is now overruled by the issue's explic
 "Priority contacts are still exempt". The setting is not unreachable — it governs
 every non-priority sender, which is the large majority of traffic.
 
-### `showNotificationsInCall` no longer governs DND
+### `showNotificationsInCall` will not govern DND — but not yet
 
-Spec 2 bucketed `busy` and `in-call` together under one predicate, arguing that
-splitting them "would leave `busy` with no user-facing control at all and no
-setting to add one".
+Rule 2 sits above the in-call check, so once `isDND` is real, a do-not-disturb
+user is suppressed whatever `showNotificationsInCall` says. That is the intent:
+do-not-disturb means do not disturb, and a checkbox named for calls should not
+quietly re-enable pushes during it.
 
-The issue answers that objection directly: DND *should* have no user-facing
-control beyond the priority-contact exemption. Do-not-disturb means do not
-disturb — a checkbox named for calls should not quietly re-enable pushes during
-it. `busy` is also the one status the user sets by hand, so an explicit intent
-already exists and does not need a second one layered on top.
+Today it changes nothing, because `isDND` is inert and `busy` is still inside the
+`isInCall` bucket. The ordering is what this spec locks in; the moment the
+predicate goes live the behaviour follows with no further change to `shouldPush`.
 
-**This reverses Spec 2**, which is left in place as the historical record with a
-superseded-by pointer at its head.
+Spec 2 argued the opposite — that splitting `busy` out "would leave `busy` with no
+user-facing control at all and no setting to add one". The issue answers that
+directly: DND *should* have no control beyond the priority-contact exemption.
 
 ### The pierce stays any-room
 
@@ -160,19 +167,26 @@ stays confined to `shouldPush`.
 
 ## Behaviour delta
 
-Exactly two populations move. Everyone else is bit-for-bit unchanged.
+**Exactly one population moves, and it moves toward more delivery, not less.**
 
 | Population | Before | After |
 |---|---|---|
-| `showNotificationsInCall=true`, presence `busy` | pushed | **suppressed** |
 | `alwaysAllowPriorityNotifications=true` + sender in `priorityContacts`, presence `busy` or `in-call` | suppressed | **pushed** |
 
+Nothing else changes. `isInCall` is byte-identical to what shipped, and the two
+new predicates are inert, so every recipient who is not a pierce case takes the
+same path as before. No user loses a notification on this deploy — which is what
+makes it safe to ship ahead of the presence side.
+
 Users with no stored settings are unaffected: the zero `notifSettings` has
-`showInCall=false` and `allowPriority=false`, so `busy` and `in-call` both
-suppressed before this change and both suppress after it. The same holds under
+`allowPriority=false`, so the pierce cannot fire for them. The same holds under
 `USER_SETTINGS_ENABLED=false`, whose `noopUserSettings` yields that zero value for
-every recipient — so the kill switch still restores pre-enforcement behaviour
-exactly.
+every recipient — the kill switch still restores pre-enforcement behaviour exactly.
+
+**When the presence side ships `isDND`/`isPresenting`,** a second population moves
+the other way: users in do-not-disturb who had `showNotificationsInCall` set stop
+being pushed. That is a reduction in delivery and belongs in *that* change's
+release notes, not this one's.
 
 ## Testing
 
@@ -181,73 +195,98 @@ is pure and I/O-free, so the unit table is the whole verification surface; no
 integration test is warranted because nothing here touches Mongo, NATS or Valkey.
 
 **`shouldPush` (table-driven, `presence_test.go`).** The matrix of `muteAll` ×
-`allowPriority` × `isPrioritySender` × `showInCall` × presence status over
-`{"", "online", "away", "offline", "busy", "in-call"}`. Named rows for:
+`allowPriority` × `isPrioritySender` × `showInCall` × `dnd` × `presenting` ×
+presence status over `{"", "online", "away", "offline", "busy", "in-call"}`. The
+`dnd`/`presenting` columns drive a `stubPresenceFlags` helper that swaps the two
+vars for the subtest and restores them in `t.Cleanup`, so no row leaks into a
+sibling. Named rows for:
 
-- the two moved populations above, one row each, named for the change;
-- the zero `notifSettings` reproducing pre-change behaviour on every status —
-  this is the row that pins "no stored settings, no change";
-- a priority sender *without* `allowPriority` still suppressed by DND and by
-  mute, pinning that the pierce needs its opt-in;
+- the moved population above;
+- the zero `notifSettings` with both stubs inert reproducing pre-change behaviour
+  on every status — the rows that pin "no stored settings, no change";
+- DND and presenting each suppressing while `showNotificationsInCall` is set,
+  pinning that the in-call opt-in does not rescue rule 2;
+- a priority sender *without* `allowPriority` still suppressed by DND, presenting
+  and mute, pinning that the pierce needs its opt-in;
 - `showNotificationsInCall=true` + `in-call` + non-priority sender pushing,
   pinning that the setting is still reachable.
 
-**`isDND` / `isInCall` (`presence_test.go`).** `TestIsInCall` splits into
-`TestIsDND` and `TestIsInCall`, each asserting the *other* status is false —
-that pair is what fails if anyone re-merges the bucket.
+**Stub contract (`presence_test.go`).** `TestDNDAndPresentingStubsAreInert`
+asserts both predicates return false for every status we currently receive —
+`busy` and `in-call` included. This is the test that fails if someone later
+"helpfully" wires DND to `busy`, which is exactly the inference this spec forbids.
+`TestIsInCall` is unchanged and still asserts the `busy`+`in-call` bucket.
 
-**Pierce end-to-end (`handler_test.go`).** A `busy` recipient with
-`alwaysAllowPriorityNotifications` and the sender in `priorityContacts` is emitted
-to. Complements the pure-function table by proving the settings and presence maps
-are actually combined per-recipient in the survivor loop.
+**Handler wiring (`handler_test.go`).** Two tests using invented statuses
+(`stub-dnd`, `stub-presenting`) via `stubPresenceFlagsByStatus`, so they assert
+the wiring without asserting a mapping the presence side has yet to define:
+one proving both predicates suppress despite `showNotificationsInCall`, one
+proving a priority sender pierces that suppression. These complement the
+pure-function table by proving the settings and presence maps are actually
+combined per-recipient in the survivor loop.
 
-Coverage floor 80%; `shouldPush` and its predicates are core logic and should
-reach 100% given how small they are.
+Coverage floor 80%; `shouldPush` and `isInCall` reach 100%.
 
 ## Documentation
 
-Three `docs/client-api.md` rows become factually wrong on merge and are corrected
-in the same PR:
+Two `docs/client-api.md` rows become factually wrong on merge and are corrected in
+the same PR:
 
 - `alwaysAllowPriorityNotifications` — drop "The pierce does not override
-  `showNotificationsInCall`"; state that the pierce covers mute, DND and in-call,
-  in any room type.
-- `showNotificationsInCall` — it governs `"in-call"` only, no longer `"busy"`; the
-  priority pierce *does* bypass it.
-- `muteAllNotifications` — unchanged in substance; verify the cross-reference
-  still reads correctly beside the two rewritten rows.
+  `showNotificationsInCall`"; state that the pierce covers mute and every presence
+  suppressor, in any room type.
+- `showNotificationsInCall` — still governs `"busy"` and `"in-call"`, but the
+  priority pierce now *does* bypass it.
 
-Plus the push-filter bullet in §4 ("Presence-busy / in-call recipients are not
-pushed; everyone else…"), which now needs the DND/in-call split and the priority
-exemption.
+Plus the push-filter bullet in §4, which gains the priority exemption.
 
-`2026-08-10-notification-settings-enforcement-design.md` gains a one-line
-superseded-by pointer at its head so it is not read as current.
+The docs describe only what the code does **today**. Rule 2 is deliberately
+undocumented on the client API surface: writing "do-not-disturb suppresses push"
+while `isDND` returns false would document a behaviour clients cannot observe.
+That sentence lands in the change that makes the predicate real.
+
+`2026-08-10-notification-settings-enforcement-design.md` gains a superseded-by
+pointer at its head so it is not read as current.
 
 ## Rollout
 
-Population 1 is the one that matters: users who explicitly enabled
-`showNotificationsInCall` and use manual DND stop receiving pushes while
-do-not-disturb is set. That is the intended outcome and it is a silent,
-user-visible reduction in delivery, so it belongs in the release notes rather than
-arriving as a report of missing notifications.
+Ordinary. No population loses notifications, so there is no silent
+reduction-in-delivery to pre-announce and no population to size beforehand.
 
-Release note: do-not-disturb now suppresses push regardless of the "show
-notifications in call" setting; priority contacts pierce do-not-disturb and
-in-call when "always allow priority contact notifications" is enabled;
+Release note: priority contacts now reach you while you are busy or in a call
+when "always allow priority contact notifications" is enabled;
 `USER_SETTINGS_ENABLED=false` reverts to prior behaviour without a rollback.
 
-Worth sizing population 1 against production `users` before deploying —
-`{"settings.showNotificationsInCall": true, "active": {"$ne": false}}` — so the
-change lands as a known number.
+**The follow-up is the one that needs care.** When the presence side ships DND and
+presenting, that change flips `isDND`/`isPresenting` to real implementations *and*
+narrows `isInCall` to `in-call` only. It should size
+`{"settings.showNotificationsInCall": true, "active": {"$ne": false}}` against
+production first, because those users stop receiving pushes while in
+do-not-disturb.
 
 ## Files
 
 | File | Change |
 |------|--------|
-| `notification-worker/presence.go` | Split `isInCall` into `isDND` + `isInCall`; rewrite `shouldPush`. |
-| `notification-worker/presence_test.go` | Extend the `shouldPush` table; split `TestIsInCall`. |
+| `notification-worker/presence.go` | Add inert `isDND`/`isPresenting` stub vars; rewrite `shouldPush`. `isInCall` unchanged. |
+| `notification-worker/presence_test.go` | Extend the `shouldPush` table with `dnd`/`presenting`; add the two stub helpers and the inert-contract test. `TestIsInCall` unchanged. |
 | `notification-worker/handler.go` | Correct the stale comment above the snapshot calls. |
-| `notification-worker/handler_test.go` | End-to-end priority pierce past a `busy` recipient. |
+| `notification-worker/handler_test.go` | Rule-2 suppression and priority pierce, end-to-end, via stubbed statuses. |
 | `docs/client-api.md` | Two settings rows; the §4 push-filter bullet. |
 | `docs/superpowers/specs/2026-08-10-notification-settings-enforcement-design.md` | Superseded-by pointer. |
+
+## What the presence side still owes this
+
+For whoever picks up the other half, the contract is exactly two functions in
+`notification-worker/presence.go`:
+
+```go
+func isDND(p model.Presence) bool        // true when the user is in do-not-disturb
+func isPresenting(p model.Presence) bool // true when the user is presenting
+```
+
+Converting the vars back to plain funcs is fine — `stubPresenceFlags` and
+`stubPresenceFlagsByStatus` in `presence_test.go` are the only things that need
+the var form, and both are test-only. That change must also drop `"busy"` from
+`isInCall`, delete `TestDNDAndPresentingStubsAreInert`, and add the DND sentence
+to the `showNotificationsInCall` row in `docs/client-api.md`.

--- a/docs/superpowers/specs/2026-08-10-priority-contact-presence-gating-design.md
+++ b/docs/superpowers/specs/2026-08-10-priority-contact-presence-gating-design.md
@@ -2,9 +2,10 @@
 
 Issue #221. Spec 1 (`2026-08-08-priority-contacts-storage-api-design.md`) stored the
 settings. Spec 2 (`2026-08-10-notification-settings-enforcement-design.md`) made
-`notification-worker` enforce three of them. This spec finishes the decision table:
-presence-based suppression gains a priority-contact exemption, and manual
-do-not-disturb stops borrowing the in-call checkbox.
+`notification-worker` enforce three of them. This spec changes one thing today —
+presence-based suppression gains a priority-contact exemption — and wires the rule
+that will stop manual do-not-disturb borrowing the in-call checkbox as inert
+predicates, for the presence side to implement.
 
 The issue calls the component "push-notification-worker". That is
 `notification-worker`: its push path (`mobileEmitter` → `PUSH-NOTIFICATION` →
@@ -263,6 +264,17 @@ narrows `isInCall` to `in-call` only. It should size
 `{"settings.showNotificationsInCall": true, "active": {"$ne": false}}` against
 production first, because those users stop receiving pushes while in
 do-not-disturb.
+
+**And it must be sequenced consumer-first.** `shouldPush` fails open on
+unrecognized presence, and `isInCall` matches the literal strings `busy` and
+`in-call`. So if the presence service begins emitting a new representation for
+do-not-disturb while any `notification-worker` is still on the old binary, that
+worker sees an unknown status, fails open, and pushes to precisely the users the
+change exists to protect — a rolling deploy would produce exactly the bug being
+fixed, intermittently. Deploy recognition to every `notification-worker` **before**
+any producer emits the new representation, and keep emitting the old suppressing
+representation (or dual-encode) until the last old worker and every rollback target
+is gone.
 
 ## Files
 

--- a/notification-worker/handler.go
+++ b/notification-worker/handler.go
@@ -201,8 +201,7 @@ func (h *Handler) HandleMessage(ctx context.Context, data []byte) error {
 	// Both lookups run over the narrowed candidate set — only accounts that survived
 	// the exclusion filters, never every member of a large room.
 	// TestHandle_SettingsFetchedOnlyForSurvivingCandidates pins that narrowing.
-	// shouldPush combines the two results, which is where showNotificationsInCall
-	// modifies the presence decision.
+	// shouldPush combines the two, keyed on the sender's account for the priority pierce.
 	settings, _ := h.deps.Settings.Snapshot(ctx, accounts) // fail-open: error → empty map
 	snapshot, _ := h.deps.Presence.Snapshot(ctx, accounts) // fail-open: error → empty map
 

--- a/notification-worker/handler_test.go
+++ b/notification-worker/handler_test.go
@@ -1232,4 +1232,61 @@ func TestHandle_PriorityContactSenderPiercesMute(t *testing.T) {
 		"bob listed helper.bot as priority; carol did not")
 }
 
+// TestHandle_PriorityContactPiercesDND pins the Spec 3 reversal end-to-end: the
+// pierce crosses the presence gate, and it is keyed on the sender's account —
+// bob lists the sender, carol lists someone else, and both are equally in DND.
+func TestHandle_PriorityContactPiercesDND(t *testing.T) {
+	members := &stubMembers{out: map[string][]roomsubcache.Member{
+		"r1": {
+			{ID: "alice", Account: "alice"},
+			{ID: "bob", Account: "bob"},
+			{ID: "carol", Account: "carol"},
+		},
+	}}
+	presence := &stubPresence{out: map[string]model.Presence{
+		"bob":   {AggregatedStatus: "busy"},
+		"carol": {AggregatedStatus: "busy"},
+	}}
+	settings := &stubSettings{out: map[string]notifSettings{
+		"bob":   {allowPriority: true, priorityContacts: map[string]struct{}{"alice": {}}},
+		"carol": {allowPriority: true, priorityContacts: map[string]struct{}{"dave": {}}},
+	}}
+	emit := &recordingEmitter{}
+	h := newTestHandlerWithSettings(members, presence, settings, noopVetoer{}, emit)
+
+	require.NoError(t, h.HandleMessage(context.Background(), msgEvent(&model.Message{
+		ID: "m1", RoomID: "r1", UserID: "alice", UserAccount: "alice", CreatedAt: time.Now(),
+	})))
+	assert.Equal(t, []string{"bob"}, emit.accounts(),
+		"bob lists the sender as a priority contact and is pierced out of DND; carol does not")
+}
+
+// TestHandle_DNDIgnoresShowNotificationsInCall pins the other half of the split:
+// the in-call opt-in must not rescue a recipient who is in do-not-disturb.
+func TestHandle_DNDIgnoresShowNotificationsInCall(t *testing.T) {
+	members := &stubMembers{out: map[string][]roomsubcache.Member{
+		"r1": {
+			{ID: "alice", Account: "alice"},
+			{ID: "bob", Account: "bob"},
+			{ID: "carol", Account: "carol"},
+		},
+	}}
+	presence := &stubPresence{out: map[string]model.Presence{
+		"bob":   {AggregatedStatus: "busy"},
+		"carol": {AggregatedStatus: "in-call"},
+	}}
+	settings := &stubSettings{out: map[string]notifSettings{
+		"bob":   {showInCall: true},
+		"carol": {showInCall: true},
+	}}
+	emit := &recordingEmitter{}
+	h := newTestHandlerWithSettings(members, presence, settings, noopVetoer{}, emit)
+
+	require.NoError(t, h.HandleMessage(context.Background(), msgEvent(&model.Message{
+		ID: "m1", RoomID: "r1", UserID: "alice", UserAccount: "alice", CreatedAt: time.Now(),
+	})))
+	assert.Equal(t, []string{"carol"}, emit.accounts(),
+		"showNotificationsInCall covers in-call only; bob stays suppressed by DND")
+}
+
 func int64Ptr(v int64) *int64 { return &v }

--- a/notification-worker/handler_test.go
+++ b/notification-worker/handler_test.go
@@ -1232,10 +1232,11 @@ func TestHandle_PriorityContactSenderPiercesMute(t *testing.T) {
 		"bob listed helper.bot as priority; carol did not")
 }
 
-// TestHandle_PriorityContactPiercesDND pins the Spec 3 reversal end-to-end: the
-// pierce crosses the presence gate, and it is keyed on the sender's account —
-// bob lists the sender, carol lists someone else, and both are equally in DND.
-func TestHandle_PriorityContactPiercesDND(t *testing.T) {
+// TestHandle_PriorityContactPiercesPresenceSuppression pins the reversal
+// end-to-end: the pierce crosses the presence gate, and it is keyed on the
+// sender's account — bob lists the sender, carol lists someone else, and both
+// have the same suppressing presence.
+func TestHandle_PriorityContactPiercesPresenceSuppression(t *testing.T) {
 	members := &stubMembers{out: map[string][]roomsubcache.Member{
 		"r1": {
 			{ID: "alice", Account: "alice"},
@@ -1261,9 +1262,47 @@ func TestHandle_PriorityContactPiercesDND(t *testing.T) {
 		"bob lists the sender as a priority contact and is pierced out of DND; carol does not")
 }
 
-// TestHandle_DNDIgnoresShowNotificationsInCall pins the other half of the split:
-// the in-call opt-in must not rescue a recipient who is in do-not-disturb.
-func TestHandle_DNDIgnoresShowNotificationsInCall(t *testing.T) {
+// TestHandle_DNDAndPresentingSuppressPush proves the handler consults both stubs
+// once they go live. Every recipient here has showNotificationsInCall set, so
+// only a suppressor the opt-in does NOT govern can drop them — which is exactly
+// rule 2. Uses invented statuses so the test asserts the wiring, not a mapping
+// the presence side has yet to define.
+func TestHandle_DNDAndPresentingSuppressPush(t *testing.T) {
+	stubPresenceFlagsByStatus(t, "stub-dnd", "stub-presenting")
+
+	members := &stubMembers{out: map[string][]roomsubcache.Member{
+		"r1": {
+			{ID: "alice", Account: "alice"},
+			{ID: "bob", Account: "bob"},
+			{ID: "carol", Account: "carol"},
+			{ID: "dave", Account: "dave"},
+		},
+	}}
+	presence := &stubPresence{out: map[string]model.Presence{
+		"bob":   {AggregatedStatus: "stub-dnd"},
+		"carol": {AggregatedStatus: "stub-presenting"},
+		"dave":  {AggregatedStatus: "online"},
+	}}
+	settings := &stubSettings{out: map[string]notifSettings{
+		"bob":   {showInCall: true},
+		"carol": {showInCall: true},
+		"dave":  {showInCall: true},
+	}}
+	emit := &recordingEmitter{}
+	h := newTestHandlerWithSettings(members, presence, settings, noopVetoer{}, emit)
+
+	require.NoError(t, h.HandleMessage(context.Background(), msgEvent(&model.Message{
+		ID: "m1", RoomID: "r1", UserID: "alice", UserAccount: "alice", CreatedAt: time.Now(),
+	})))
+	assert.Equal(t, []string{"dave"}, emit.accounts(),
+		"DND and presenting suppress regardless of showNotificationsInCall")
+}
+
+// TestHandle_PriorityContactPiercesDNDStub is the pierce counterpart: the same
+// suppressed recipient survives when the sender is one of their priority contacts.
+func TestHandle_PriorityContactPiercesDNDStub(t *testing.T) {
+	stubPresenceFlagsByStatus(t, "stub-dnd", "")
+
 	members := &stubMembers{out: map[string][]roomsubcache.Member{
 		"r1": {
 			{ID: "alice", Account: "alice"},
@@ -1272,12 +1311,12 @@ func TestHandle_DNDIgnoresShowNotificationsInCall(t *testing.T) {
 		},
 	}}
 	presence := &stubPresence{out: map[string]model.Presence{
-		"bob":   {AggregatedStatus: "busy"},
-		"carol": {AggregatedStatus: "in-call"},
+		"bob":   {AggregatedStatus: "stub-dnd"},
+		"carol": {AggregatedStatus: "stub-dnd"},
 	}}
 	settings := &stubSettings{out: map[string]notifSettings{
-		"bob":   {showInCall: true},
-		"carol": {showInCall: true},
+		"bob":   {allowPriority: true, priorityContacts: map[string]struct{}{"alice": {}}},
+		"carol": {allowPriority: true, priorityContacts: map[string]struct{}{"dave": {}}},
 	}}
 	emit := &recordingEmitter{}
 	h := newTestHandlerWithSettings(members, presence, settings, noopVetoer{}, emit)
@@ -1285,8 +1324,8 @@ func TestHandle_DNDIgnoresShowNotificationsInCall(t *testing.T) {
 	require.NoError(t, h.HandleMessage(context.Background(), msgEvent(&model.Message{
 		ID: "m1", RoomID: "r1", UserID: "alice", UserAccount: "alice", CreatedAt: time.Now(),
 	})))
-	assert.Equal(t, []string{"carol"}, emit.accounts(),
-		"showNotificationsInCall covers in-call only; bob stays suppressed by DND")
+	assert.Equal(t, []string{"bob"}, emit.accounts(),
+		"bob lists the sender as a priority contact and is pierced out of DND; carol does not")
 }
 
 func int64Ptr(v int64) *int64 { return &v }

--- a/notification-worker/handler_test.go
+++ b/notification-worker/handler_test.go
@@ -1259,7 +1259,7 @@ func TestHandle_PriorityContactPiercesPresenceSuppression(t *testing.T) {
 		ID: "m1", RoomID: "r1", UserID: "alice", UserAccount: "alice", CreatedAt: time.Now(),
 	})))
 	assert.Equal(t, []string{"bob"}, emit.accounts(),
-		"bob lists the sender as a priority contact and is pierced out of DND; carol does not")
+		"bob lists the sender as a priority contact and is pierced out of presence suppression; carol does not")
 }
 
 // TestHandle_DNDAndPresentingSuppressPush proves the handler consults both stubs

--- a/notification-worker/presence.go
+++ b/notification-worker/presence.go
@@ -116,24 +116,30 @@ func chunkStrings(in []string, size int) [][]string {
 	return out
 }
 
-// isInCall reports whether presence alone suppresses push. "busy" and "in-call"
-// are deliberately one bucket: showNotificationsInCall is the only user-facing
-// control over either, so splitting them would leave "busy" ungovernable.
-func isInCall(p model.Presence) bool {
-	switch p.AggregatedStatus {
-	case "busy", "in-call":
-		return true
-	default:
-		return false
-	}
+// isDND reports manual do-not-disturb. Split from isInCall because
+// showNotificationsInCall governs only the latter — DND means DND.
+func isDND(p model.Presence) bool {
+	return p.AggregatedStatus == string(model.StatusBusy)
 }
 
-// shouldPush applies the two independent suppressors. Mute is pierced by a
-// priority sender only when the recipient enabled alwaysAllowPriorityNotifications;
-// the pierce deliberately does not cross the in-call gate, which
-// showNotificationsInCall governs on its own. Unknown presence fails open.
+// isInCall reports an active call. Teams "Presenting" arrives here too:
+// user-presence-service folds it into in-call rather than modelling it separately.
+func isInCall(p model.Presence) bool {
+	return p.AggregatedStatus == string(model.StatusInCall)
+}
+
+// shouldPush applies the priority-contact pierce, then three independent
+// suppressors. alwaysAllowPriorityNotifications is the single opt-in for
+// "priority contacts reach me anyway", so the pierce crosses all three.
+// Unknown presence fails open.
 func shouldPush(p model.Presence, ns notifSettings, isPrioritySender bool) bool {
-	if ns.muteAll && (!ns.allowPriority || !isPrioritySender) {
+	if ns.allowPriority && isPrioritySender {
+		return true
+	}
+	if ns.muteAll {
+		return false
+	}
+	if isDND(p) {
 		return false
 	}
 	if isInCall(p) && !ns.showInCall {

--- a/notification-worker/presence.go
+++ b/notification-worker/presence.go
@@ -116,22 +116,35 @@ func chunkStrings(in []string, size int) [][]string {
 	return out
 }
 
-// isDND reports manual do-not-disturb. Split from isInCall because
-// showNotificationsInCall governs only the latter — DND means DND.
-func isDND(p model.Presence) bool {
-	return p.AggregatedStatus == string(model.StatusBusy)
-}
+// isDND and isPresenting are stubs: deriving these two statuses belongs to the
+// presence side of the system, which has not shipped them yet. They are vars so
+// tests can supply the eventual behaviour and prove the gate ordering now.
+//
+// Deliberately NOT inferred from any status we currently receive — mapping DND
+// onto "busy" or presenting onto "in-call" would invent a contract we do not own.
+// Until the real predicates land, both return false and rule 2 of the decision
+// table is inert.
+var (
+	isDND        = func(model.Presence) bool { return false }
+	isPresenting = func(model.Presence) bool { return false }
+)
 
-// isInCall reports an active call. Teams "Presenting" arrives here too:
-// user-presence-service folds it into in-call rather than modelling it separately.
+// isInCall reports whether presence alone suppresses push. "busy" and "in-call"
+// are one bucket while isDND is inert: showNotificationsInCall is the only
+// user-facing control over either, so splitting them now would push to DND users.
 func isInCall(p model.Presence) bool {
-	return p.AggregatedStatus == string(model.StatusInCall)
+	switch p.AggregatedStatus {
+	case "busy", "in-call":
+		return true
+	default:
+		return false
+	}
 }
 
-// shouldPush applies the priority-contact pierce, then three independent
-// suppressors. alwaysAllowPriorityNotifications is the single opt-in for
-// "priority contacts reach me anyway", so the pierce crosses all three.
-// Unknown presence fails open.
+// shouldPush applies the priority-contact pierce, then the suppressors in the
+// issue's stated priority order. alwaysAllowPriorityNotifications is the single
+// opt-in for "priority contacts reach me anyway", so the pierce crosses all of
+// them. Unknown presence fails open.
 func shouldPush(p model.Presence, ns notifSettings, isPrioritySender bool) bool {
 	if ns.allowPriority && isPrioritySender {
 		return true
@@ -139,7 +152,7 @@ func shouldPush(p model.Presence, ns notifSettings, isPrioritySender bool) bool 
 	if ns.muteAll {
 		return false
 	}
-	if isDND(p) {
+	if isDND(p) || isPresenting(p) {
 		return false
 	}
 	if isInCall(p) && !ns.showInCall {

--- a/notification-worker/presence_test.go
+++ b/notification-worker/presence_test.go
@@ -24,77 +24,102 @@ func TestNoopPresence_EmptySnapshot(t *testing.T) {
 	assert.Empty(t, snap)
 }
 
+// stubPresenceFlags swaps the isDND/isPresenting stubs for one test and restores
+// them afterwards, so a row that flips them cannot leak into a sibling test.
+func stubPresenceFlags(t *testing.T, dnd, presenting bool) {
+	t.Helper()
+	origDND, origPresenting := isDND, isPresenting
+	isDND = func(model.Presence) bool { return dnd }
+	isPresenting = func(model.Presence) bool { return presenting }
+	t.Cleanup(func() { isDND, isPresenting = origDND, origPresenting })
+}
+
+// stubPresenceFlagsByStatus points the isDND/isPresenting stubs at one status
+// each, restoring them afterwards. Lets a handler test prove the gate consults
+// both without asserting any real status mapping; "" disables that stub.
+func stubPresenceFlagsByStatus(t *testing.T, dndStatus, presentingStatus string) {
+	t.Helper()
+	origDND, origPresenting := isDND, isPresenting
+	isDND = func(p model.Presence) bool { return dndStatus != "" && p.AggregatedStatus == dndStatus }
+	isPresenting = func(p model.Presence) bool {
+		return presentingStatus != "" && p.AggregatedStatus == presentingStatus
+	}
+	t.Cleanup(func() { isDND, isPresenting = origDND, origPresenting })
+}
+
 func TestShouldPush(t *testing.T) {
 	tests := []struct {
 		name             string
 		status           string
+		dnd              bool
+		presenting       bool
 		ns               notifSettings
 		isPrioritySender bool
 		want             bool
 	}{
-		// Zero notifSettings must reproduce pre-Spec-3 behaviour on every status:
-		// no stored settings means no behaviour change from this deploy.
-		{"zero settings online", "online", notifSettings{}, false, true},
-		{"zero settings offline", "offline", notifSettings{}, false, true},
-		{"zero settings away", "away", notifSettings{}, false, true},
-		{"zero settings busy", "busy", notifSettings{}, false, false},
-		{"zero settings in-call", "in-call", notifSettings{}, false, false},
-		{"zero settings missing status", "", notifSettings{}, false, true},
-		{"zero settings unknown status", "unknown", notifSettings{}, false, true},
+		// Zero notifSettings with both stubs inert must reproduce the pre-change
+		// truth table exactly: no stored settings means no behaviour change.
+		{"zero settings online", "online", false, false, notifSettings{}, false, true},
+		{"zero settings offline", "offline", false, false, notifSettings{}, false, true},
+		{"zero settings away", "away", false, false, notifSettings{}, false, true},
+		{"zero settings busy", "busy", false, false, notifSettings{}, false, false},
+		{"zero settings in-call", "in-call", false, false, notifSettings{}, false, false},
+		{"zero settings missing status", "", false, false, notifSettings{}, false, true},
+		{"zero settings unknown status", "unknown", false, false, notifSettings{}, false, true},
 
 		// muteAll suppresses unless a priority sender pierces it.
-		{"muted, no pierce", "online", notifSettings{muteAll: true}, false, false},
-		{"muted, priority sender but pierce disabled", "online", notifSettings{muteAll: true}, true, false},
-		{"muted, pierce enabled but sender not priority", "online", notifSettings{muteAll: true, allowPriority: true}, false, false},
-		{"muted, pierce enabled and sender is priority", "online", notifSettings{muteAll: true, allowPriority: true}, true, true},
-		{"unmuted, pierce enabled, non-priority sender", "online", notifSettings{allowPriority: true}, false, true},
+		{"muted, no pierce", "online", false, false, notifSettings{muteAll: true}, false, false},
+		{"muted, priority sender but pierce disabled", "online", false, false, notifSettings{muteAll: true}, true, false},
+		{"muted, pierce enabled but sender not priority", "online", false, false, notifSettings{muteAll: true, allowPriority: true}, false, false},
+		{"muted, pierce enabled and sender is priority", "online", false, false, notifSettings{muteAll: true, allowPriority: true}, true, true},
+		{"unmuted, pierce enabled, non-priority sender", "online", false, false, notifSettings{allowPriority: true}, false, true},
 
-		// DND is no longer governed by showNotificationsInCall. This row is the one
-		// population whose pushes this change removes.
-		{"busy, opted in to in-call notifications, still suppressed", "busy", notifSettings{showInCall: true}, false, false},
-		{"busy, no opt-in", "busy", notifSettings{}, false, false},
+		// Rule 2: DND and presenting suppress on their own, and the in-call opt-in
+		// does not rescue them — showNotificationsInCall governs in-call only.
+		{"dnd", "online", true, false, notifSettings{}, false, false},
+		{"dnd, in-call opt-in does not rescue", "online", true, false, notifSettings{showInCall: true}, false, false},
+		{"presenting", "online", false, true, notifSettings{}, false, false},
+		{"presenting, in-call opt-in does not rescue", "online", false, true, notifSettings{showInCall: true}, false, false},
+		{"dnd and presenting together", "online", true, true, notifSettings{}, false, false},
 
-		// showNotificationsInCall still governs in-call, for every non-priority sender.
-		{"in-call, opted in", "in-call", notifSettings{showInCall: true}, false, true},
-		{"in-call, not opted in", "in-call", notifSettings{}, false, false},
+		// showNotificationsInCall governs the in-call bucket, for non-priority senders.
+		{"in-call, opted in", "in-call", false, false, notifSettings{showInCall: true}, false, true},
+		{"busy, opted in", "busy", false, false, notifSettings{showInCall: true}, false, true},
+		{"in-call, not opted in", "in-call", false, false, notifSettings{}, false, false},
 
-		// The pierce now crosses the presence gate too — the Spec 3 reversal.
-		{"busy, priority pierce", "busy", notifSettings{allowPriority: true}, true, true},
-		{"in-call, priority pierce without in-call opt-in", "in-call", notifSettings{allowPriority: true}, true, true},
-		{"muted+pierced, in-call without opt-in", "in-call", notifSettings{muteAll: true, allowPriority: true}, true, true},
-		{"muted+pierced, in-call with opt-in", "in-call", notifSettings{muteAll: true, allowPriority: true, showInCall: true}, true, true},
+		// The pierce crosses every suppressor, DND and presenting included.
+		{"dnd, priority pierce", "online", true, false, notifSettings{allowPriority: true}, true, true},
+		{"presenting, priority pierce", "online", false, true, notifSettings{allowPriority: true}, true, true},
+		{"in-call, priority pierce without in-call opt-in", "in-call", false, false, notifSettings{allowPriority: true}, true, true},
+		{"muted+dnd, priority pierce", "in-call", true, false, notifSettings{muteAll: true, allowPriority: true}, true, true},
 
 		// ...but only with its opt-in. A priority sender alone pierces nothing.
-		{"busy, priority sender but pierce disabled", "busy", notifSettings{}, true, false},
-		{"in-call, priority sender but pierce disabled", "in-call", notifSettings{}, true, false},
+		{"dnd, priority sender but pierce disabled", "online", true, false, notifSettings{}, true, false},
+		{"presenting, priority sender but pierce disabled", "online", false, true, notifSettings{}, true, false},
+		{"in-call, priority sender but pierce disabled", "in-call", false, false, notifSettings{}, true, false},
 
 		// Every suppressor clear.
-		{"muted+pierced, online", "online", notifSettings{muteAll: true, allowPriority: true, showInCall: true}, true, true},
+		{"muted+pierced, online", "online", false, false, notifSettings{muteAll: true, allowPriority: true, showInCall: true}, true, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			stubPresenceFlags(t, tt.dnd, tt.presenting)
 			got := shouldPush(model.Presence{AggregatedStatus: tt.status}, tt.ns, tt.isPrioritySender)
 			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestIsDND(t *testing.T) {
-	tests := []struct {
-		status string
-		want   bool
-	}{
-		{"busy", true},
-		{"in-call", false},
-		{"online", false},
-		{"offline", false},
-		{"away", false},
-		{"", false},
-		{"unknown", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.status, func(t *testing.T) {
-			assert.Equal(t, tt.want, isDND(model.Presence{AggregatedStatus: tt.status}))
+// TestDNDAndPresentingStubsAreInert pins the stub contract: until the presence
+// side ships the real predicates, neither may infer a status from what we
+// currently receive. A stub that starts returning true for "busy" or "in-call"
+// would silently change delivery, so every status we know about is asserted.
+func TestDNDAndPresentingStubsAreInert(t *testing.T) {
+	for _, status := range []string{"busy", "in-call", "online", "offline", "away", "", "unknown"} {
+		t.Run(status, func(t *testing.T) {
+			p := model.Presence{AggregatedStatus: status}
+			assert.False(t, isDND(p), "isDND must stay inert until the presence side owns it")
+			assert.False(t, isPresenting(p), "isPresenting must stay inert until the presence side owns it")
 		})
 	}
 }
@@ -104,8 +129,8 @@ func TestIsInCall(t *testing.T) {
 		status string
 		want   bool
 	}{
+		{"busy", true},
 		{"in-call", true},
-		{"busy", false},
 		{"online", false},
 		{"offline", false},
 		{"away", false},

--- a/notification-worker/presence_test.go
+++ b/notification-worker/presence_test.go
@@ -32,7 +32,8 @@ func TestShouldPush(t *testing.T) {
 		isPrioritySender bool
 		want             bool
 	}{
-		// Zero notifSettings must reproduce the pre-enforcement truth table exactly.
+		// Zero notifSettings must reproduce pre-Spec-3 behaviour on every status:
+		// no stored settings means no behaviour change from this deploy.
 		{"zero settings online", "online", notifSettings{}, false, true},
 		{"zero settings offline", "offline", notifSettings{}, false, true},
 		{"zero settings away", "away", notifSettings{}, false, true},
@@ -48,16 +49,26 @@ func TestShouldPush(t *testing.T) {
 		{"muted, pierce enabled and sender is priority", "online", notifSettings{muteAll: true, allowPriority: true}, true, true},
 		{"unmuted, pierce enabled, non-priority sender", "online", notifSettings{allowPriority: true}, false, true},
 
-		// showNotificationsInCall governs both suppressed statuses.
+		// DND is no longer governed by showNotificationsInCall. This row is the one
+		// population whose pushes this change removes.
+		{"busy, opted in to in-call notifications, still suppressed", "busy", notifSettings{showInCall: true}, false, false},
+		{"busy, no opt-in", "busy", notifSettings{}, false, false},
+
+		// showNotificationsInCall still governs in-call, for every non-priority sender.
 		{"in-call, opted in", "in-call", notifSettings{showInCall: true}, false, true},
-		{"busy, opted in", "busy", notifSettings{showInCall: true}, false, true},
 		{"in-call, not opted in", "in-call", notifSettings{}, false, false},
 
-		// The pierce does not cross the in-call gate.
-		{"muted+pierced but in-call without opt-in", "in-call", notifSettings{muteAll: true, allowPriority: true}, true, false},
-		{"muted+pierced and in-call with opt-in", "in-call", notifSettings{muteAll: true, allowPriority: true, showInCall: true}, true, true},
+		// The pierce now crosses the presence gate too — the Spec 3 reversal.
+		{"busy, priority pierce", "busy", notifSettings{allowPriority: true}, true, true},
+		{"in-call, priority pierce without in-call opt-in", "in-call", notifSettings{allowPriority: true}, true, true},
+		{"muted+pierced, in-call without opt-in", "in-call", notifSettings{muteAll: true, allowPriority: true}, true, true},
+		{"muted+pierced, in-call with opt-in", "in-call", notifSettings{muteAll: true, allowPriority: true, showInCall: true}, true, true},
 
-		// Both suppressors clear.
+		// ...but only with its opt-in. A priority sender alone pierces nothing.
+		{"busy, priority sender but pierce disabled", "busy", notifSettings{}, true, false},
+		{"in-call, priority sender but pierce disabled", "in-call", notifSettings{}, true, false},
+
+		// Every suppressor clear.
 		{"muted+pierced, online", "online", notifSettings{muteAll: true, allowPriority: true, showInCall: true}, true, true},
 	}
 	for _, tt := range tests {
@@ -68,13 +79,33 @@ func TestShouldPush(t *testing.T) {
 	}
 }
 
-func TestIsInCall(t *testing.T) {
+func TestIsDND(t *testing.T) {
 	tests := []struct {
 		status string
 		want   bool
 	}{
 		{"busy", true},
+		{"in-call", false},
+		{"online", false},
+		{"offline", false},
+		{"away", false},
+		{"", false},
+		{"unknown", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			assert.Equal(t, tt.want, isDND(model.Presence{AggregatedStatus: tt.status}))
+		})
+	}
+}
+
+func TestIsInCall(t *testing.T) {
+	tests := []struct {
+		status string
+		want   bool
+	}{
 		{"in-call", true},
+		{"busy", false},
 		{"online", false},
 		{"offline", false},
 		{"away", false},


### PR DESCRIPTION
## Summary

Implements priority-contact presence gating for push notifications. The `alwaysAllowPriorityNotifications` setting now pierces all suppressors — mute, do-not-disturb, and in-call — not just mute. Two new inert predicates (`isDND` and `isPresenting`) are wired into the decision gate to prepare for the presence side's eventual implementation, ensuring the rule is tested and ordered correctly before those predicates go live.

## Changes

**notification-worker/presence.go**
- Add stub vars `isDND` and `isPresenting` (both return `false` until the presence side ships real implementations)
- Rewrite `shouldPush` to apply the priority pierce first, then suppressors in priority order: mute, rule 2 (DND/presenting), in-call
- Update `isInCall` doc comment to note it covers `busy`+`in-call` while `isDND` is inert, preventing a regression when the real predicate lands
- `isInCall` itself is unchanged (byte-identical to shipped code)

**notification-worker/presence_test.go**
- Add `stubPresenceFlags` helper to swap stub vars for a test and restore via `t.Cleanup`
- Add `stubPresenceFlagsByStatus` helper to map stubs to invented statuses, letting handler tests assert wiring without asserting a mapping the presence side hasn't defined yet
- Extend `TestShouldPush` table with `dnd` and `presenting` columns; add rows covering:
  - Zero settings with both stubs inert reproducing pre-change behaviour
  - DND and presenting each suppressing despite `showNotificationsInCall`
  - Priority sender without `allowPriority` still suppressed
  - Pierce crossing all suppressors when enabled
- Add `TestDNDAndPresentingStubsAreInert` to pin the stub contract: both predicates must return `false` for every status we currently receive, preventing silent inference from `busy`/`in-call`

**notification-worker/handler.go**
- Correct stale comment above snapshot calls: replace trailing sentence to note `shouldPush` combines settings and presence, keyed on sender's account for the priority pierce

**notification-worker/handler_test.go**
- Add `TestHandle_DNDAndPresentingSuppressPush`: proves both stubs suppress despite `showNotificationsInCall`, using invented statuses to assert wiring
- Add `TestHandle_PriorityContactPiercesDNDStub`: proves priority sender pierces DND suppression when listed in `priorityContacts`
- Rename existing `TestHandle_PriorityContactPiercesDND` to `TestHandle_PriorityContactPiercesPresenceSuppression` (exercises `busy` bucket, not DND)

**docs/client-api.md**
- Update `alwaysAllowPriorityNotifications` row: clarify the pierce covers mute and every presence suppressor, in any room type
- Update `showNotificationsInCall` row: note the priority pierce now bypasses it
- Add priority-contact exemption to §4 push-filter bullets

**docs/superpowers/specs/2026-08-10-notification-settings-enforcement-design.md**
- Add superseded-by pointer at head, noting Spec 3 reverses the in-call gate decision

## Implementation Details

- **TDD:** All tests written and confirmed failing before implementation (red phase verified)
- **No inference:** `isDND` and `isPresenting` are deliberately not mapped from `busy`/`in-call`; those statuses are owned by the presence side
- **No regression:** `isInCall` unchanged; narrowing it now would push to DND users during the gap before the real predicate lands
- **Stub contract:** `TestDNDAndPresentingStubsAreInert` prevents future "helpful" wiring of DND→`busy`
- **Coverage:** `shouldPush` and `isInCall` reach 100%; overall floor 80%
- **No scope creep:** No env vars, model fields, RPCs, or events added; `USER_SETTINGS_ENABLED=false`

https://claude.ai/code/session_01A9198e5NbYxSfXWZPYaYBt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Priority-contact notifications can bypass global mute and busy/in-call suppression when enabled.
  * Per-room mute settings continue to suppress notifications.
  * DND and presenting statuses suppress notifications where applicable.
  * Busy or in-call recipients are excluded unless in-call notifications are enabled.

* **Documentation**
  * Updated guidance for priority-contact and presence-based notification behavior.

* **Tests**
  * Expanded coverage for mute, presence, in-call, and priority-contact scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->