### PR TITLE
Cross-site failover: mirror a site's rooms & memberships to a warm backup

### DIFF
--- a/data-migration/oplog-connector/bootstrap.go
+++ b/data-migration/oplog-connector/bootstrap.go
@@ -22,20 +22,27 @@ type streamManager interface {
 	Stream(ctx context.Context, name string) (o11ynats.Stream, error)
 }
 
-// bootstrapStreams owns the MIGRATION-OPLOG-{siteID} stream — enabled it creates from schema (Name+Subjects), disabled it verifies existence and fails fast. Federation config stays ops/IaC-owned.
-func bootstrapStreams(ctx context.Context, js streamManager, siteID string, enabled bool) error {
+// bootstrapStreams owns the connector's target stream — MIGRATION-OPLOG-{siteID} in migration mode,
+// DR-OPLOG-{siteID} in DR mode. Enabled it creates from schema (Name+Subjects); disabled it verifies
+// existence and fails fast. Federation / cross-gateway routing stays ops/IaC-owned.
+func bootstrapStreams(ctx context.Context, js streamManager, siteID string, enabled, drMode bool) error {
 	cfg := stream.MigrationOplog(siteID)
+	label := "MIGRATION-OPLOG"
+	if drMode {
+		cfg = stream.DROplog(siteID)
+		label = "DR-OPLOG"
+	}
 	if enabled {
 		if _, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
 			Name:     cfg.Name,
 			Subjects: cfg.Subjects,
 		}); err != nil {
-			return fmt.Errorf("create MIGRATION-OPLOG stream: %w", err)
+			return fmt.Errorf("create %s stream: %w", label, err)
 		}
 		return nil
 	}
 	if _, err := js.Stream(ctx, cfg.Name); err != nil {
-		return fmt.Errorf("verify MIGRATION-OPLOG stream: %w", err)
+		return fmt.Errorf("verify %s stream: %w", label, err)
 	}
 	return nil
 }

--- a/data-migration/oplog-connector/bootstrap_test.go
+++ b/data-migration/oplog-connector/bootstrap_test.go
@@ -30,7 +30,7 @@ func (f *fakeStreamManager) Stream(_ context.Context, name string) (o11ynats.Str
 
 func TestBootstrapStreams_DisabledVerifiesOnly(t *testing.T) {
 	fsm := &fakeStreamManager{}
-	err := bootstrapStreams(context.Background(), fsm, "site1", false)
+	err := bootstrapStreams(context.Background(), fsm, "site1", false, false)
 	require.NoError(t, err)
 	assert.Empty(t, fsm.created, "must not create streams when disabled")
 	assert.Equal(t, []string{"MIGRATION-OPLOG-site1"}, fsm.streamHit)
@@ -38,14 +38,14 @@ func TestBootstrapStreams_DisabledVerifiesOnly(t *testing.T) {
 
 func TestBootstrapStreams_DisabledMissingStreamFails(t *testing.T) {
 	fsm := &fakeStreamManager{streamErr: errors.New("stream not found")}
-	err := bootstrapStreams(context.Background(), fsm, "site1", false)
+	err := bootstrapStreams(context.Background(), fsm, "site1", false, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "verify MIGRATION-OPLOG stream")
 }
 
 func TestBootstrapStreams_EnabledCreatesSchemaOnly(t *testing.T) {
 	fsm := &fakeStreamManager{}
-	err := bootstrapStreams(context.Background(), fsm, "site1", true)
+	err := bootstrapStreams(context.Background(), fsm, "site1", true, false)
 	require.NoError(t, err)
 
 	require.Len(t, fsm.created, 1)
@@ -55,4 +55,29 @@ func TestBootstrapStreams_EnabledCreatesSchemaOnly(t *testing.T) {
 	// Federation config is ops/IaC-owned — never set here.
 	assert.Nil(t, got.Sources)
 	assert.Empty(t, fsm.streamHit, "enabled path does not verify")
+}
+
+func TestBootstrapStreams_DR_EnabledCreatesDROplog(t *testing.T) {
+	fsm := &fakeStreamManager{}
+	err := bootstrapStreams(context.Background(), fsm, "site1", true, true)
+	require.NoError(t, err)
+	require.Len(t, fsm.created, 1)
+	got := fsm.created[0]
+	assert.Equal(t, "DR-OPLOG-site1", got.Name)
+	assert.Equal(t, []string{"chat.dr.oplog.site1.>"}, got.Subjects)
+}
+
+func TestBootstrapStreams_DR_DisabledVerifiesDROplog(t *testing.T) {
+	fsm := &fakeStreamManager{}
+	err := bootstrapStreams(context.Background(), fsm, "site1", false, true)
+	require.NoError(t, err)
+	assert.Empty(t, fsm.created)
+	assert.Equal(t, []string{"DR-OPLOG-site1"}, fsm.streamHit)
+}
+
+func TestBootstrapStreams_DR_DisabledMissingStreamFails(t *testing.T) {
+	fsm := &fakeStreamManager{streamErr: errors.New("stream not found")}
+	err := bootstrapStreams(context.Background(), fsm, "site1", false, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "verify DR-OPLOG stream")
 }

--- a/data-migration/oplog-connector/config.go
+++ b/data-migration/oplog-connector/config.go
@@ -40,12 +40,29 @@ type config struct {
 	StartAtTime      string `env:"START_AT_TIME"      envDefault:""`    // RFC3339 or unix-ms
 	StartResumeToken string `env:"START_RESUME_TOKEN" envDefault:""`    // _data hex, one-off seed override
 
+	// Mode selects the CDC target lane. "migration" (default) tails the legacy source Mongo and
+	// publishes to MIGRATION_OPLOG on the chat.migration.oplog.> subjects — the original behavior,
+	// with native oplog only (no post-image on updates). "dr" ships a site's operational state to
+	// the shared backup: it publishes to DR-OPLOG on chat.dr.oplog.> and opens the change stream
+	// with updateLookup so update events carry the full post-image inline (the dr-oplog-worker
+	// applier is self-contained and never reads back to the origin Mongo).
+	Mode string `env:"MODE" envDefault:"migration"`
+
 	Bootstrap bootstrapConfig `envPrefix:"BOOTSTRAP_"`
 
 	// HealthAddr binds the /healthz listener (k8s probe target). Application and
 	// runtime metrics are exported by the o11y SDK on its own Prometheus endpoint.
 	HealthAddr string `env:"HEALTH_ADDR" envDefault:":9090"`
 }
+
+// modeMigration and modeDR are the valid values of config.Mode.
+const (
+	modeMigration = "migration"
+	modeDR        = "dr"
+)
+
+// isDR reports whether this deployment runs the disaster-recovery lane.
+func (c *config) isDR() bool { return c.Mode == modeDR }
 
 // parseConfig parses and validates the environment configuration.
 func parseConfig() (config, error) {
@@ -64,6 +81,12 @@ func parseConfig() (config, error) {
 		trimmed = append(trimmed, coll)
 	}
 	cfg.WatchCollections = trimmed
+	cfg.Mode = strings.TrimSpace(cfg.Mode)
+	switch cfg.Mode {
+	case modeMigration, modeDR:
+	default:
+		return config{}, fmt.Errorf("invalid MODE %q (want %s|%s)", cfg.Mode, modeMigration, modeDR)
+	}
 	switch cfg.StartMode {
 	case "now", "time":
 	default:

--- a/data-migration/oplog-connector/config_test.go
+++ b/data-migration/oplog-connector/config_test.go
@@ -32,6 +32,27 @@ func TestParseConfig_DefaultsAndSlices(t *testing.T) {
 	assert.Equal(t, ":9090", cfg.HealthAddr)
 	assert.Equal(t, "now", cfg.StartMode)
 	assert.False(t, cfg.Bootstrap.Enabled)
+	assert.Equal(t, "migration", cfg.Mode)
+	assert.False(t, cfg.isDR())
+}
+
+func TestParseConfig_DRMode(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("MODE", "dr")
+	t.Setenv("WATCH_COLLECTIONS", "rooms,subscriptions,room_members")
+	t.Setenv("SOURCE_DB", "chat")
+	cfg, err := parseConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "dr", cfg.Mode)
+	assert.True(t, cfg.isDR())
+}
+
+func TestParseConfig_RejectsInvalidMode(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("MODE", "banana")
+	_, err := parseConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MODE")
 }
 
 func TestParseConfig_RejectsDuplicateCollections(t *testing.T) {

--- a/data-migration/oplog-connector/envelope.go
+++ b/data-migration/oplog-connector/envelope.go
@@ -7,7 +7,6 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 
 	"github.com/hmchangw/chat/pkg/model"
-	"github.com/hmchangw/chat/pkg/subject"
 )
 
 // changeEvent is the connector-internal decoded form of one change-stream event; documents stay raw BSON until buildEnvelope makes them opaque JSON.
@@ -23,12 +22,17 @@ type changeEvent struct {
 	ClusterTimeMs     int64    // source op time, unix ms
 }
 
+// subjectFunc builds the publish subject for one event from its site, collection, and op. The
+// lane's builder is injected (subject.MigrationOplog or subject.DROplog) so buildEnvelope stays
+// lane-agnostic.
+type subjectFunc func(siteID, collection, op string) string
+
 // buildEnvelope maps a change event to its subject, dedup id, and opaque OplogEvent. nowMs is injected (no time.Now) so the function stays pure and testable.
 //
 // A field that won't encode never drops the event: the field is left nil and the
 // event is flagged Degraded (first failure wins) so the stream stays lossless.
-func buildEnvelope(ev *changeEvent, siteID string, nowMs int64) (subj, msgID string, evt model.OplogEvent) {
-	subj = subject.MigrationOplog(siteID, ev.Collection, ev.Op)
+func buildEnvelope(ev *changeEvent, siteID string, nowMs int64, subjectFor subjectFunc) (subj, msgID string, evt model.OplogEvent) {
+	subj = subjectFor(siteID, ev.Collection, ev.Op)
 	msgID = ev.EventID
 
 	evt = model.OplogEvent{

--- a/data-migration/oplog-connector/envelope_test.go
+++ b/data-migration/oplog-connector/envelope_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/hmchangw/chat/pkg/subject"
 )
 
 func mustRaw(t *testing.T, m bson.M) bson.Raw {
@@ -50,7 +52,7 @@ func TestBuildEnvelope_OpsAndSubjects(t *testing.T) {
 				ev.UpdateDescription = mustRaw(t, bson.M{"updatedFields": bson.M{"msg": "edited"}})
 			}
 
-			subj, msgID, evt := buildEnvelope(&ev, site, nowMs)
+			subj, msgID, evt := buildEnvelope(&ev, site, nowMs, subject.MigrationOplog)
 
 			assert.Equal(t, tc.wantSubject, subj)
 			assert.Equal(t, ev.EventID, msgID, "msgID must equal eventID")
@@ -85,6 +87,24 @@ func TestBuildEnvelope_OpsAndSubjects(t *testing.T) {
 	}
 }
 
+// The DR lane injects subject.DROplog, so envelopes publish onto the chat.dr.oplog.> subjects the
+// dr-oplog-worker consumes — same envelope shape, different lane.
+func TestBuildEnvelope_DRSubjectLane(t *testing.T) {
+	ev := changeEvent{
+		EventID:      "EVT-dr",
+		Op:           "update",
+		DB:           "chat",
+		Collection:   "rooms",
+		DocumentKey:  mustRaw(t, bson.M{"_id": "r1"}),
+		FullDocument: mustRaw(t, bson.M{"_id": "r1", "name": "general"}),
+	}
+	subj, _, evt := buildEnvelope(&ev, "site1", 1, subject.DROplog)
+	assert.Equal(t, "chat.dr.oplog.site1.rooms.update", subj)
+	// updateLookup populates the post-image on updates in the DR lane.
+	require.NotNil(t, evt.FullDocument)
+	assert.True(t, json.Valid(evt.FullDocument))
+}
+
 func TestBuildEnvelope_DegradesOnFieldEncodeFailure(t *testing.T) {
 	// Lock the fixture: this raw declares length 5 but its terminator byte is
 	// 0x01 (not 0x00), so MarshalExtJSON rejects it.
@@ -101,7 +121,7 @@ func TestBuildEnvelope_DegradesOnFieldEncodeFailure(t *testing.T) {
 		FullDocument: bad, // forces the encode failure
 	}
 
-	_, msgID, evt := buildEnvelope(&ev, "site1", 1)
+	_, msgID, evt := buildEnvelope(&ev, "site1", 1, subject.MigrationOplog)
 
 	assert.True(t, evt.Degraded, "a field that fails to encode degrades the event")
 	assert.NotEmpty(t, evt.DegradedReason, "degraded events carry a reason")
@@ -126,7 +146,7 @@ func TestBuildEnvelope_OpaqueDocumentContents(t *testing.T) {
 		DocumentKey:  mustRaw(t, bson.M{"_id": "u1"}),
 		FullDocument: mustRaw(t, bson.M{"_id": "u1", "name": "alice", "active": true}),
 	}
-	_, _, evt := buildEnvelope(&ev, "site1", 1)
+	_, _, evt := buildEnvelope(&ev, "site1", 1, subject.MigrationOplog)
 
 	// The connector does not interpret the doc; it round-trips as JSON.
 	var decoded map[string]any

--- a/data-migration/oplog-connector/handler.go
+++ b/data-migration/oplog-connector/handler.go
@@ -12,6 +12,8 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"go.mongodb.org/mongo-driver/v2/mongo"
+
+	"github.com/hmchangw/chat/pkg/subject"
 )
 
 const (
@@ -80,6 +82,7 @@ type watcher struct {
 	maxBackoff       time.Duration
 	now              func() int64 // unix ms; injectable for tests
 	metrics          *metrics     // nil-safe; set by start(), nil in unit tests
+	subjectFor       subjectFunc  // publish-subject builder; defaults to the migration lane
 	log              *slog.Logger
 }
 
@@ -98,6 +101,7 @@ func newWatcher(siteID, collection string, src changeSource, pub publisher, stor
 		initialBackoff:   defaultInitialBackoff,
 		maxBackoff:       defaultMaxBackoff,
 		now:              func() int64 { return time.Now().UTC().UnixMilli() },
+		subjectFor:       subject.MigrationOplog, // migration lane by default; start() overrides for DR
 		log:              slog.With("collection", collection),
 	}
 }
@@ -180,7 +184,7 @@ func (w *watcher) run(ctx context.Context) error {
 
 // publishWithRetry publishes one event synchronously, retrying with capped backoff until pub-ack or ctx cancel. EventID (the dedup id) is guaranteed non-empty upstream; a field that fails to encode is published degraded (not dropped) so the stream stays lossless.
 func (w *watcher) publishWithRetry(ctx context.Context, ev *changeEvent) error {
-	subj, msgID, evt := buildEnvelope(ev, w.siteID, w.now())
+	subj, msgID, evt := buildEnvelope(ev, w.siteID, w.now(), w.subjectFor)
 	data, err := json.Marshal(evt)
 	if err != nil {
 		// This event is DROPPED (never reaches the stream), so name the op — eventId alone

--- a/data-migration/oplog-connector/integration_test.go
+++ b/data-migration/oplog-connector/integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hmchangw/chat/pkg/mongoutil"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
+	"github.com/hmchangw/chat/pkg/subject"
 	"github.com/hmchangw/chat/pkg/testutil"
 )
 
@@ -144,7 +145,7 @@ func TestOplogConnector_ChangeStreamEndToEnd(t *testing.T) {
 
 	// Open the change stream BEFORE mutating so "from now" captures everything.
 	// No federation filter here — this test exercises the dumb-pump pass-through of all ops.
-	src, err := openMongoChangeSource(ctx, source, startPoint{Kind: startFromNow}, false)
+	src, err := openMongoChangeSource(ctx, source, startPoint{Kind: startFromNow}, false, false)
 	require.NoError(t, err)
 
 	pub := &fakePublisher{}
@@ -213,6 +214,58 @@ func TestOplogConnector_ChangeStreamEndToEnd(t *testing.T) {
 	assert.NotEmpty(t, saved.ids())
 }
 
+// TestOplogConnector_DRMode_UpdateLookupPostImage proves the DR lane is self-contained: with
+// updateLookup on and subject.DROplog injected, an update publishes to chat.dr.oplog.> and carries
+// the full post-image inline — exactly what the dr-oplog-worker applier needs (it never reads back
+// to the origin Mongo). Contrast the migration path, where an update carries only the delta.
+func TestOplogConnector_DRMode_UpdateLookupPostImage(t *testing.T) {
+	const coll = "rooms"
+	client, _ := startReplicaSet(t)
+	source := createSourceCollection(t, client.Database("chat"), coll)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// DR lane: updateLookup ON, no federation filter.
+	src, err := openMongoChangeSource(ctx, source, startPoint{Kind: startFromNow}, false, true)
+	require.NoError(t, err)
+
+	pub := &fakePublisher{}
+	store, _ := captureStore(t)
+	w := newWatcher("site1", coll, src, pub, store, 1, time.Hour)
+	w.subjectFor = subject.DROplog // DR lane
+	w.initialBackoff = time.Millisecond
+
+	runCtx, runCancel := context.WithCancel(ctx)
+	runErr := make(chan error, 1)
+	go func() { runErr <- w.run(runCtx) }()
+
+	_, err = source.InsertOne(ctx, bson.M{"_id": "r1", "name": "general", "crossSite": true})
+	require.NoError(t, err)
+	_, err = source.UpdateOne(ctx, bson.M{"_id": "r1"}, bson.M{"$set": bson.M{"name": "renamed"}})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool { return len(pub.snapshot()) >= 2 }, 30*time.Second, 50*time.Millisecond,
+		"expected insert+update envelopes")
+
+	runCancel()
+	require.NoError(t, <-runErr, "watcher exits cleanly on ctx cancel")
+
+	msgs := pub.snapshot()
+	require.GreaterOrEqual(t, len(msgs), 2)
+	assert.Equal(t, "chat.dr.oplog.site1.rooms.insert", msgs[0].Subject)
+	assert.Equal(t, "chat.dr.oplog.site1.rooms.update", msgs[1].Subject)
+
+	var updateEvt struct {
+		Op           string          `json:"op"`
+		FullDocument json.RawMessage `json:"fullDocument"`
+	}
+	require.NoError(t, json.Unmarshal(msgs[1].Data, &updateEvt))
+	assert.Equal(t, "update", updateEvt.Op)
+	require.NotEmpty(t, updateEvt.FullDocument, "DR update carries the looked-up post-image (self-contained)")
+	assert.Contains(t, string(updateEvt.FullDocument), "renamed", "post-image reflects the update")
+}
+
 func TestOplogConnector_FederationFilterDropsForeignInserts(t *testing.T) {
 	const coll = "rocketchat_message"
 	client, _ := startReplicaSet(t)
@@ -222,7 +275,7 @@ func TestOplogConnector_FederationFilterDropsForeignInserts(t *testing.T) {
 	defer cancel()
 
 	// Federation filter ON (this collection is the message collection in the test).
-	src, err := openMongoChangeSource(ctx, source, startPoint{Kind: startFromNow}, true)
+	src, err := openMongoChangeSource(ctx, source, startPoint{Kind: startFromNow}, true, false)
 	require.NoError(t, err)
 
 	pub := &fakePublisher{}

--- a/data-migration/oplog-connector/main.go
+++ b/data-migration/oplog-connector/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
 	"github.com/hmchangw/chat/pkg/shutdown"
+	"github.com/hmchangw/chat/pkg/subject"
 )
 
 func main() {
@@ -40,8 +41,13 @@ func main() {
 		os.Exit(1)
 	}
 	// role distinguishes the two split deployments in logs and metrics (PR #482 review).
+	// The DR lane is a third role — it publishes to a different stream and never runs the
+	// federation-origin filter (its watched collections are new-stack operational ones).
 	role := "collections"
-	if cfg.watchesMessages() {
+	switch {
+	case cfg.isDR():
+		role = "dr"
+	case cfg.watchesMessages():
 		role = "messages"
 	}
 	m, err := newMetrics(role)
@@ -64,9 +70,13 @@ func main() {
 		os.Exit(1)
 	}
 	slog.Info("oplog-connector started", "site", cfg.SiteID, "role", role, "collections", cfg.WatchCollections)
-	if cfg.watchesMessages() {
+	switch {
+	case cfg.isDR():
+		slog.Info("DR lane active — publishing to DR-OPLOG with updateLookup (self-contained events)",
+			"role", role, "collections", cfg.WatchCollections)
+	case cfg.watchesMessages():
 		slog.Info("federation-origin filter active", "role", role, "message_collection", cfg.MessageCollection)
-	} else {
+	default:
 		// Warn, not Info: legitimate for a collections-role pod, but conspicuous when a MESSAGE_COLLECTION
 		// typo leaves a message pod forwarding foreign-origin messages unfiltered (double-deliver).
 		slog.Warn("no message collection watched — federation-origin filter inactive",
@@ -136,7 +146,7 @@ func start(ctx context.Context, cfg *config, m *metrics, obsProv mongoutil.Obser
 		mongoutil.Disconnect(ctx, client)
 		return nil, fmt.Errorf("jetstream init: %w", err)
 	}
-	if err := bootstrapStreams(ctx, js, cfg.SiteID, cfg.Bootstrap.Enabled); err != nil {
+	if err := bootstrapStreams(ctx, js, cfg.SiteID, cfg.Bootstrap.Enabled, cfg.isDR()); err != nil {
 		_ = nc.Drain()
 		mongoutil.Disconnect(ctx, client)
 		return nil, fmt.Errorf("bootstrap streams: %w", err)
@@ -175,7 +185,7 @@ func start(ctx context.Context, cfg *config, m *metrics, obsProv mongoutil.Obser
 		}
 		mongoColl := sourceDB.Collection(coll,
 			options.Collection().SetReadPreference(rp).SetReadConcern(readconcern.Majority()))
-		src, err := openMongoChangeSource(watchCtx, mongoColl, sp, coll == cfg.MessageCollection)
+		src, err := openMongoChangeSource(watchCtx, mongoColl, sp, coll == cfg.MessageCollection, cfg.isDR())
 		if err != nil {
 			c.Close()
 			return nil, fmt.Errorf("open change stream %q: %w", coll, err)
@@ -183,6 +193,9 @@ func start(ctx context.Context, cfg *config, m *metrics, obsProv mongoutil.Obser
 
 		w := newWatcher(cfg.SiteID, coll, src, js, store, cfg.CheckpointEvery, checkpointMaxAge)
 		w.metrics = m
+		if cfg.isDR() {
+			w.subjectFor = subject.DROplog // DR lane publishes to chat.dr.oplog.>
+		}
 		c.wg.Add(1)
 		go func(w *watcher) {
 			defer c.wg.Done()

--- a/data-migration/oplog-connector/source_mongo.go
+++ b/data-migration/oplog-connector/source_mongo.go
@@ -29,10 +29,15 @@ type mongoChangeSource struct {
 	cs *mongo.ChangeStream
 }
 
-// openMongoChangeSource opens a change stream at sp with no lookups/pre-images — native oplog only.
-// federationFilter adds a $match dropping foreign-origin insert/replace (caller scopes it to the message collection).
-func openMongoChangeSource(ctx context.Context, coll *mongo.Collection, sp startPoint, federationFilter bool) (*mongoChangeSource, error) {
+// openMongoChangeSource opens a change stream at sp. federationFilter adds a $match dropping
+// foreign-origin insert/replace (caller scopes it to the message collection). updateLookup, when
+// true, sets fullDocument=updateLookup so update events carry the current post-image inline (the
+// DR lane needs self-contained events); when false the stream is native oplog only (migration).
+func openMongoChangeSource(ctx context.Context, coll *mongo.Collection, sp startPoint, federationFilter, updateLookup bool) (*mongoChangeSource, error) {
 	opts := options.ChangeStream()
+	if updateLookup {
+		opts.SetFullDocument(options.UpdateLookup)
+	}
 	switch sp.Kind {
 	case startAfterToken:
 		opts.SetStartAfter(sp.Token)

--- a/docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md
+++ b/docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md
@@ -1,0 +1,126 @@
+# Cross-Site Failover — Program Decomposition & Roadmap
+
+> **Not a task-by-task implementation plan.** The design
+> (`docs/superpowers/specs/2026-07-28-cross-site-failover-design.md`) is a DR
+> *architecture* with unresolved core-mechanism decisions (§11 open questions) and
+> spans app code + platform/NATS + ops/IaC. Per the writing-plans Scope Check, it
+> is decomposed here into independently-plannable sub-projects. **Each sub-project
+> gets its own spec → plan → implement cycle**; several must resolve open design
+> questions (their own brainstorm) *before* a no-placeholder plan can be written.
+
+**Goal:** stand up single-site failover to a shared warm backup ("lifeboat"),
+scoped to send/receive in existing rooms + recent history, with clean failback.
+
+**Governing spec:** `docs/superpowers/specs/2026-07-28-cross-site-failover-design.md`
+
+---
+
+## Dependency graph
+
+```
+SP0  Local/global room subjects        (EXTERNAL — already designed+planned on
+      (prerequisite, not owned here)     branch claude/nats-subscription-reduction)
+        │
+        ▼
+SP1  DR feed + backup materialization   (LINCHPIN — design not yet resolved)
+      ├── SP1a  message slice  (canonical → backup Cassandra)   [most concrete]
+      └── SP1b  operational slice (rooms/subs/members → Mongo)  [mechanism open]
+        │
+        ├───────────────┬───────────────────────┐
+        ▼               ▼                        ▼
+SP2  Backup serving   SP3  Routing brain       SP4  Failover trigger /
+     stack + identity      (portal health-           health detection
+     (needs key custody)   aware override)           (feeds SP3)
+        │               │                        │
+        └───────┬───────┴────────────────────────┘
+                ▼
+SP5  Failback & reconciliation   (needs SP1+SP2 live; algorithm is spec §6)
+
+SP6  Ops / IaC / platform        (cross-cutting runbook, threads throughout —
+                                   NOT a TDD plan)
+```
+
+**Build order:** SP0 (external) → SP1 → {SP2, SP3, SP4} → SP5, with SP6 running
+alongside from SP1 onward.
+
+---
+
+## Sub-projects
+
+### SP0 — Local/global room subjects  *(external dependency — do not re-plan here)*
+- **Owner:** `claude/nats-subscription-reduction-z0wcya` (design + plan already
+  written there).
+- **Why it's here:** the backup's delivery correctness (spec §7) rests on the
+  `CrossSite` flag and the `chat.local.room.>` prefix. SP1b must carry `CrossSite`
+  on the DR feed; SP2 must add the `chat.local.room.>` subscribe grant to the
+  backup's JWTs.
+- **Action:** track it as a dependency; do not duplicate. Coordinate the two
+  integration points above when it lands.
+
+### SP1 — DR feed + backup materialization  *(LINCHPIN — needs a design cycle first)*
+- **Deliverable:** every site continuously ships its whole-site state to the
+  backup, which materializes per-`siteID` namespaces (spec §4.1).
+- **Ready to plan?** **No.** Resolve first (own brainstorm):
+  - §11.1 — operational-state feed mechanism: **Mongo change-streams vs a new
+    backup-directed event fan-out**. This choice gates SP1b entirely.
+  - How `CrossSite` (SP0) rides the feed.
+  - Canonical-stream sourcing topology into the backup (JetStream source/mirror
+    over gateway vs a dedicated consumer).
+  - Restore-log retention vs read-window (spec §6.5).
+- **Split:**
+  - **SP1a (message slice)** — source whole `MESSAGES_CANONICAL_{siteID}` → backup
+    Cassandra, bucketed schema, retention split. *Most concrete;* reuses
+    `message-worker` + JetStream sourcing patterns. Likely the first thing
+    plannable once the sourcing topology is picked.
+  - **SP1b (operational slice)** — rooms/subs/members/user-slice → backup Mongo via
+    the mechanism chosen above. Blocked on §11.1.
+
+### SP2 — Backup serving stack + identity  *(needs SP1; needs key-custody design)*
+- **Deliverable:** the backup runs the impersonation — `auth-service` mints JWTs
+  for any site's accounts (incl. the `chat.local.room.>` grant), and the
+  send/receive + history-read paths serve from the materialized copy.
+- **Ready to plan?** **No.** Resolve §11.4 first (own brainstorm, security-
+  sensitive): concrete shared-signing / KMS scheme for cross-site JWT minting.
+  Serving-path work is plannable once SP1 exists and the key scheme is chosen.
+
+### SP3 — Routing brain: portal-service health-aware override  *(needs SP4 signal)*
+- **Deliverable:** `portal-service` becomes the single source of truth for "who
+  serves account X right now"; returns the backup for a down site's accounts;
+  acts as the split-brain fence (spec §4.2).
+- **Ready to plan?** **Partially.** Codebase-local (`portal-service` exists), but
+  needs the health signal from SP4 and the failback-flip protocol (spec §6.3).
+  Plannable in parallel once SP4's signal shape is decided.
+
+### SP4 — Failover trigger / health detection  *(own design)*
+- **Deliverable:** auto-detect a down site (+ manual operator override) and drive
+  the SP3 override (spec §11.3).
+- **Ready to plan?** **No.** Resolve the detection mechanism and the override
+  control surface first (own brainstorm).
+
+### SP5 — Failback & reconciliation  *(needs SP1+SP2 live)*
+- **Deliverable:** replay the outage log home, verify convergence, cut over
+  clients (spec §6, fully specified algorithmically).
+- **Ready to plan?** **Blocked** on SP1/SP2 existing, but the *algorithm* is the
+  most complete part of the spec — this becomes concrete quickly once its
+  dependencies are real.
+
+### SP6 — Ops / IaC / platform  *(cross-cutting runbook, not a TDD plan)*
+- Backup deployment (HA multi-AZ); backup as supercluster gateway peer; leaf-node
+  `chat.local.>` deny on the backup's leaf; canonical restore-log `MaxAge` sizing
+  (spec §6.5); NKey/KMS provisioning (with SP2); **per-site replication-lag
+  monitoring + alerting** (spec §8 — the RPO-decay signal). Tracked as an ops
+  checklist coordinated with the platform/NATS team, delivered alongside SP1–SP5.
+
+---
+
+## Recommended next step
+
+**Brainstorm SP1 (the DR feed) — specifically resolve §11.1** (Mongo change-streams
+vs a backup-directed event fan-out for operational state) and the canonical
+sourcing topology. It is the linchpin: SP2 and SP5 cannot exist without it, and
+SP1a (the message slice) is likely writable as a concrete no-placeholder plan
+immediately once the sourcing topology is chosen.
+
+Everything downstream (SP2 identity, SP4 detection) also needs its own short
+design cycle before it can be planned without placeholders — this is expected for
+a DR architecture at this altitude, not a gap in the spec.

--- a/docs/superpowers/specs/2026-07-28-cross-site-failover-design.md
+++ b/docs/superpowers/specs/2026-07-28-cross-site-failover-design.md
@@ -55,20 +55,36 @@ site. It fits the existing architecture because data is already **`siteID`-scope
 end-to-end** (rooms/subs/members carry `SiteID`; streams are `<STREAM>_<siteID>`),
 so the backup simply runs per-origin-site namespaces.
 
-**Replication mechanism: Variant A — reuse the event federation.** The backup is
-modeled as "a peer subscribed to everything." It receives each site's
-membership / subscription / room-metadata events over the OUTBOX→INBOX lanes
-that already exist and materializes them with the existing `inbox-worker`
-apply logic, and it runs a `message-worker`-style consumer on each site's
-canonical message stream to persist recent history into its own Cassandra.
-This adds mostly configuration plus one "materialize-everything" consumer set —
-no new storage-replication subsystem.
+**Replication mechanism: Variant A — event-derived materialization, over a
+dedicated backup feed.** The backup is modeled as "a peer that holds a copy of
+everything." Two channels feed it, and the distinction is load-bearing:
 
-Rejected alternative — **Variant B (storage-layer replication):** Cassandra
-multi-DC (backup as an extra DC per ring) + Mongo change-stream/replica
-shipping. Higher fidelity but N multi-DC rings and a Mongo replication pipeline —
-more machinery and more than the lifeboat scope needs. Retained as the growth
-path if fidelity requirements ever exceed the event-derived slice.
+- **Messages** — a `message-worker`-style consumer sources each site's **whole**
+  `MESSAGES_CANONICAL_{siteID}` (1× per message, *before* the ×F fan-out) and
+  persists recent history into the backup's own Cassandra under the same bucketed
+  schema.
+- **Operational state** (rooms / subscriptions / members / user slice) — a
+  **dedicated, membership-independent DR feed** that ships *every* room's state
+  to the backup, applied with the same `inbox-worker`-style insert/delete/upsert
+  semantics.
+
+**Why not reuse the existing OUTBOX→INBOX federation for operational state:** that
+federation is **membership-driven** — it only fires when a room has a member on
+*another active site*. Same-site ("local") rooms produce no federation events at
+all, and (post the local/global subject work — see §7) they are the **majority**.
+Reusing federation would therefore leave the backup blind to most rooms. The DR
+feed is a distinct, backup-directed, unconditional whole-site channel — carried
+below the client-facing interest graph (JetStream / Mongo change-streams), so it
+neither depends on nor perturbs room locality. This pulls the *operational-state*
+slice partway toward Variant B mechanics while the *message* slice stays purely
+event-derived.
+
+Rejected alternative — **Variant B (full storage-layer replication):** Cassandra
+multi-DC (backup as an extra DC per ring) + full Mongo change-stream/replica
+shipping for *all* collections. Higher fidelity but N multi-DC rings and a broad
+Mongo replication pipeline — more machinery and more than the lifeboat scope
+needs. Retained as the growth path if fidelity requirements ever exceed the
+event-derived slice.
 
 **Two knobs, at recommended defaults:**
 - **Failover trigger:** automatic health-detection with a manual operator
@@ -80,29 +96,35 @@ path if fidelity requirements ever exceed the event-derived slice.
 ## 4. Architecture
 
 ```
-   Active Site A ──┐   (membership/sub/room events via OUTBOX→INBOX)
-   Active Site B ──┼──►  Backup "Lifeboat" Site
-   Active Site C ──┘   (canonical messages via cross-site consumer)
+   Active Site A ──┐   dedicated DR feed (unconditional, all rooms):
+   Active Site B ──┼──►    · whole MESSAGES_CANONICAL_{site}  (1×, no fan-out)
+   Active Site C ──┘       · rooms/subs/members/user-slice    (change-stream/feed)
+                          │
+                          ▼  Backup "Lifeboat" Site
                           │  materializes per-siteID namespaces:
                           │    Mongo: rooms, subs, members, users (slice)
-                          │    Cassandra: recent history (72h window)
+                          │    Cassandra: recent history (72h read window)
                           │
    portal-service ────────┘  routing brain / split-brain fence:
      account → (home site if healthy | backup if home down)
 ```
 
 ### 4.1 Backup site — materialization
-- Runs a per-origin-site set of consumers. For each active `siteID`, it
-  consumes that site's federated membership/subscription/room events (the lanes
-  `inbox-worker` already understands) and applies them with the **same
-  insert/delete/upsert semantics** `inbox-worker` uses today, into a
-  `siteID`-namespaced Mongo.
-- Runs a `message-worker`-style consumer against each site's
-  `MESSAGES_CANONICAL_{siteID}` (cross-site), persisting messages into its own
-  Cassandra under the same bucketed schema. History retention on the backup is
-  capped to the lifeboat window.
+- Runs a per-origin-site set of consumers. For each active `siteID`:
+  - **Messages:** a `message-worker`-style consumer sources the whole
+    `MESSAGES_CANONICAL_{siteID}` and persists into the backup's own Cassandra
+    under the same bucketed schema. The Cassandra **read window** is capped to the
+    lifeboat window (72h); the **restore log** (the canonical stream itself) is
+    retained far longer — see §6.
+  - **Operational state:** a dedicated DR feed ships *every* room's
+    room/subscription/member state (not just cross-site rooms), applied with the
+    same insert/delete/upsert semantics `inbox-worker` uses today, into a
+    `siteID`-namespaced Mongo.
 - Holds the **identity slice** (user roster + the room/subscription state) needed
   to authorize and serve `send`/`receive` — not full user-service parity.
+- Materializes the room **`CrossSite` locality flag** (see §7) so the backup's
+  broadcast path picks the correct subject prefix and `subscription.list` returns
+  the right locality to reconnecting clients.
 
 ### 4.2 Routing brain — `portal-service`
 - Becomes the **single source of truth** for "who serves account X *right now*."
@@ -124,9 +146,10 @@ path if fidelity requirements ever exceed the event-derived slice.
 ## 5. Data flow
 
 ### 5.1 Steady state (all sites up)
-Active sites federate their events to the backup exactly as they federate to
-peers today; the backup materializes them. The backup serves **no** live client
-traffic — it is warm, not hot.
+Active sites stream their DR feed (§4.1) to the backup, which materializes it.
+This is a **separate, unconditional, backup-directed channel** — not the
+membership-driven OUTBOX→INBOX peer federation, which skips same-site rooms. The
+backup serves **no** live client traffic — it is warm, not hot.
 
 ### 5.2 Failover (site A down)
 1. Health detection marks A down (auto, with manual override).
@@ -138,26 +161,184 @@ traffic — it is warm, not hot.
    Cassandra (and flow through the backup's canonical pipeline for delivery).
 
 ### 5.3 Failback (site A recovers)
-1. A comes back but is **not yet** re-designated as serving its accounts (portal
-   still points them at the backup).
-2. The backup **replays its outage-window messages** for A back into A over the
-   canonical/federation path. Because messages are **append-only with unique IDs
-   and Cassandra bucketing**, replay is **idempotent and conflict-free** (unique
-   `Nats-Msg-Id` / message-ID dedup absorbs duplicates).
-3. Once A has caught up, portal atomically flips A's accounts home; clients
-   reconnect to A.
+See §6 — the restore/failback protocol is detailed there.
 
-## 6. Reconciliation
+## 6. Failback & data restoration
 
-Lifeboat scope makes reconciliation simple: since room/DM creation and
-membership changes are **out of scope** during failover, the only new writes at
-the backup are **append-only messages**. There is no membership divergence to
-merge — only message backfill, which the existing dedup + bucketing make safe to
-replay. A periodic anti-entropy sweep (as in the membership-federation design
-§3.4) can serve as an unconditional backstop for any messages missed by the
-replay.
+When A returns, everything written at the backup during the outage must land in
+A (A is the permanent home of those rooms and messages). Because lifeboat scope
+confined new writes to **append-only messages** (plus best-effort read-state),
+restoration is a **replay, not a merge**.
 
-## 7. Failure modes
+### 6.1 What diverged
+Only two kinds of writes happened at the backup while it impersonated A:
+1. **New messages** into existing rooms — append-only, globally unique IDs
+   (`idgen.GenerateMessageID`), written to the backup's Cassandra *and* its
+   canonical stream for A.
+2. **Read-state** — `lastSeenAt` / read watermarks / receipts, monotonic
+   (max-wins).
+
+Explicitly **not** diverged: rooms, memberships, roles, profiles — those RPCs
+were blocked at the backup. No topology divergence ⇒ **no merge-conflict class**.
+
+### 6.2 The restore log
+Because the backup ran A's canonical pipeline during the outage, it already holds
+a **durable, ordered JetStream log of exactly the outage writes** (A's canonical
+namespace on the backup). Restore = **replay that log into A's front door**: the
+events re-enter A's normal `message-worker` (persist) → `search-sync-worker`
+(index), as if freshly federated.
+
+### 6.3 Failback choreography (ordering prevents split-brain and races)
+1. **A's infra recovers, but portal still points A's accounts at the backup.** A
+   is "up but not serving." Users keep writing to the backup — a stable source
+   while draining.
+2. **Replay the outage log backup → A** into A's `MESSAGES_CANONICAL_{A}`;
+   runs continuously, chasing A's lag toward zero.
+3. **Backfill read-state** as monotonic (`$max`-guarded) updates — order-
+   independent, best-effort. Skipping it only re-surfaces a few messages as
+   "unread"; never data loss.
+4. **Verify convergence** — a directional, outage-window-scoped anti-entropy diff
+   (latest message / counts per `(room, bucket)`) between the backup's A-copy and
+   A; reconcile anything replay missed. This is the §3.4-style backstop, narrowed
+   to one window and one direction.
+5. **Flip portal → home (A)** once lag ≈ 0. Clients reconnect to A, re-read
+   `subscription.list` (now current), and resume — reusing the reconnect-self-heal
+   path (§7). The replay stream stays alive briefly past the flip to sweep any
+   tail writes (safe — idempotent).
+6. **Tear down** the backup's A-impersonation; retain the outage log until
+   convergence is confirmed, then GC.
+
+### 6.4 Why replay is safe
+- **No duplicates:** Cassandra keys on `(room_id, bucket, message_id)` ⇒
+  idempotent upsert; JetStream `Nats-Msg-Id` (= DedupID) absorbs redelivery.
+- **Order-independent:** clustering key is the message's own `created_at` (stamped
+  at original send time), so any replay order still sorts correctly and history
+  reads by timestamp stay correct.
+- **Buckets line up:** `bucket = floor(created_at / window)` with the original
+  `created_at` ⇒ messages land in the same bucket they'd have occupied had A never
+  died (requires backup and A share `MESSAGE_BUCKET_HOURS` — already mandated).
+- **No double-delivery:** a remote member on a healthy site who saw a message live
+  during the outage is not re-notified; a re-fired broadcast is deduped client-side
+  by message ID.
+
+### 6.5 Retention — two tiers, and the long-outage case
+- **Fast path:** ordered stream replay.
+- **Backstop:** state-diff anti-entropy (§6.3 step 4) re-derives anything missed.
+- **Retention rule:** the restore log is the backup's **canonical stream**, not
+  its 72h Cassandra read window. Since canonical is 1× (no fan-out) and small,
+  size that stream's `MaxAge` **≥ the max tolerated outage** (days/weeks is cheap).
+  Do **not** depend on the 72h read window for restore — a longer outage would age
+  its earliest messages out before A returns.
+
+### 6.6 Operational must-dos on the backfill path
+- **Suppress push notifications** — replayed messages are stale; `notification-
+  worker` skips events flagged as replay.
+- **Suppress (or client-dedup) re-broadcast** — restore is about durability in A,
+  not re-delivering to users who have moved on.
+
+### 6.7 The forward gap (A's last pre-crash writes)
+Messages A persisted just before crashing that never replicated to the backup
+(the RPO tail) were **never lost** — they are durable in A's own Cassandra, merely
+invisible during the outage, and reappear when users are pointed home. Remote
+members who missed them recover via the client's normal history/gap fetch.
+
+## 7. Compatibility with local/global room subjects
+
+A separate design (`.../2026-07-28-local-global-room-subjects-design.md`) reduces
+NATS gateway interest-map memory by routing **same-site ("local") rooms** onto a
+`chat.local.room.{id}.>` prefix that the platform team **denies at the leaf node**
+(never advertised across the supercluster), while cross-site ("global") rooms keep
+the propagated `chat.room.{id}.>`. Locality is a sticky `CrossSite` flag on the
+`Room` doc: global iff ≥1 member's home site ≠ `room.SiteID`.
+
+The two designs are compatible, and split cleanly by locality:
+
+- **Global rooms** stay on the propagated prefix; during A's outage the backup
+  publishes globally and delivery reaches both the displaced member (intra-cluster
+  on the backup) and any member on a still-healthy site (via the backup→peer
+  gateway — requires the backup to be a full supercluster gateway peer). These are
+  exactly the rooms the membership-driven federation already covers.
+- **Local rooms** need only **intra-cluster** delivery on the backup: because
+  "local" ⇒ all members share one home site, they **all fail over to the same
+  backup together**, so the `chat.local.` leaf filter (which only blocks
+  *cross-gateway* interest) is irrelevant to their delivery.
+
+Classification is **home-site-based**, so a user being transiently relocated to
+the backup during failover does **not** perturb any room's `CrossSite` flag.
+
+**Integration requirements (must hold when both ship):**
+1. **Backup auth-service must grant `chat.local.room.>` subscribe** in the JWTs it
+   mints for displaced users. Missing it silently breaks subscription to local
+   rooms — i.e. the majority of the lifeboat's own promise. Highest-risk coupling.
+2. **Backup must materialize *and* honor `CrossSite`** — carried on the DR feed
+   (§4.1), read by the backup's broadcast path for prefix choice and returned on
+   `subscription.list`.
+3. **Leaf-node `chat.local.>` deny must also apply to the backup's leaf**, and
+   displaced clients must connect to the backup's own NATS (intra-cluster) — which
+   the portal reroute already does.
+
+**Synergy:** the reduction's reconnect-self-heal (reconnect → re-read
+`subscription.list` → subscribe on the correct prefix) *is* the failover/failback
+reconnect path; and the per-user tree (`chat.user.{account}.>`) stays global in
+its Phase 1, so reroute signaling and the locality-transition nudge still work
+through the backup.
+
+## 8. Performance & sizing
+
+**The structural fact that makes this affordable:** DR replication rides the
+**canonical plane (1× per message)**, not the **fan-out plane (×F, F≈100)**. The
+backup sources one copy per message and persists it; the ×F broadcast
+amplification happens only at *serving* time, and only for the one failed site
+during an actual failover.
+
+- **Replication cost ∝ M** (message count) — paid continuously by the backup.
+- **Serving cost ∝ M × F** — paid only for 1 site, only during failover.
+
+Reference load (`docs/nats-traffic-estimation.md`): ~4.5M msg/day per site
+(~52/s avg, ~250–500/s peak), canonical payload ~0.5–1.5 KB.
+
+**Steady state (N sites healthy):**
+
+| Resource | Load on the backup | Magnitude |
+|---|---|---|
+| Ingest compute | ~N `message-worker`-equivalents + N materializers, 24/7 | N × ~52/s avg; Cassandra shrugs |
+| WAN egress (each site→backup) | 1× canonical + tiny op events | ~50 KB/s avg, ~0.25–0.5 MB/s peak **per site** — trivial |
+| Cassandra storage | 72h window × aggregate volume | ~13 GB/site × N (bounded by window) |
+| Mongo storage | operational state for all servable rooms | not windowed by default — main storage lever |
+
+Ingest is sized to the **aggregate of N sites**, but on the cheap (1×) plane, so
+it is a modest continuous load — not a ×F blow-up.
+
+**Failover burst (the real peak):** backup = (continued N−1-site ingest) + (full
+live serving of 1 site, *now* with ×F fan-out) + (a reconnect thundering herd:
+TLS + JWT-mint storm + `subscription.list` bootstrap storm). Size the **serving**
+tier for one (largest) site's peak; size the **ingest** tier for the N-site
+aggregate — two different capacity numbers. Mitigate the herd with client
+reconnect backoff/jitter, rate-limited/pre-warmed auth, and pre-warmed Valkey.
+
+**Latency:** steady-state replication is async and off every user's critical path
+(zero user-facing impact; the lag *is* the RPO). At failover, displaced users'
+perceived latency = their RTT to the backup — a function of backup geography.
+
+**Relation to the reduction (different resources):** the reduction saves gateway
+**interest-map memory** (an ~O(clients × rooms) all-to-all RAM cost); DR
+replication costs backup **CPU/IO/disk ∝ Σ throughput** to **one** destination
+plus a cheap per-site WAN stream. DR does not re-inflate the interest graph. The
+one honest note: local-room canonical messages now leave their home site for the
+first time (a single 1× copy to the backup) — new inter-site traffic, but cheap.
+
+**Risks & levers:**
+- **Silent RPO decay** if the backup can't keep up with aggregate ingest — its lag
+  grows and the DR guarantee quietly weakens. **Monitor per-site replication lag**
+  (reuse the membership-federation lag signal) and alert.
+- **Warm-standby idle waste** — N-way ingest runs 24/7 while serving ~nothing. If
+  RTO can relax, a **colder** standby (buffer + replay-on-promote) cuts continuous
+  compute, trading RTO for cost.
+- **Biggest storage lever is Mongo, not Cassandra** (already windowed). Windowing
+  Mongo to recently-active rooms bounds it but risks a failover user not finding a
+  long-idle room — a scope decision.
+
+## 9. Failure modes
 
 | Vector | Handling |
 |---|---|
@@ -167,27 +348,35 @@ replay.
 | **Last in-flight messages at outage instant** | Async RPO ⇒ seconds of potential loss accepted for lifeboat scope. |
 | **Identity key compromise on backup** | Mitigated by shared/KMS-fronted signing rather than raw NKey copies; backup hardened accordingly. |
 | **Replay duplicates on failback** | Idempotent: message-ID / `Nats-Msg-Id` dedup + append-only bucketed writes. |
+| **Silent RPO decay** (backup can't keep up with N-aggregate ingest) | Per-site replication-lag monitoring + alert (§8); the lag *is* the live RPO. |
+| **Outage longer than history window** | Restore uses the canonical **stream** log (`MaxAge` ≥ max outage), not the 72h Cassandra read window (§6.5); anti-entropy backstop re-derives the rest. |
+| **Local room not materialized on backup** | DR feed is unconditional/whole-site (§4.1), not membership-driven federation, so same-site rooms are covered. |
 
-## 8. Non-goals
+## 10. Non-goals
 
 - No room/DM creation, membership, admin, search, presence, or media parity
-  during failover (lifeboat scope only).
+  during failover (lifeboat scope only). This constraint is **load-bearing**: it
+  is what keeps failback a replay rather than a bidirectional merge (§6).
 - No synchronous/zero-RPO cross-site replication.
 - No full-fidelity byte-for-byte DB replica of any site (that is Variant B, a
   future growth path).
 - No active-active (multi-primary) serving — the backup is warm-passive and
   serves only while a home site is down.
 
-## 9. Open questions / follow-ups
+## 11. Open questions / follow-ups
 
-1. **History window** exact size and per-room caps on the backup's Cassandra.
-2. **Health-detection mechanism** and the manual-override control surface
+1. **DR feed mechanism** for operational state — Mongo change-streams vs a new
+   backup-directed event fan-out; and how `CrossSite` rides it (§4.1, §7).
+2. **History read window** size and per-room caps on the backup's Cassandra, vs
+   the (longer) canonical restore-log `MaxAge` (§6.5).
+3. **Health-detection mechanism** and the manual-override control surface
    (likely portal-service-owned).
-3. **Identity key custody** — concrete shared-signing / KMS scheme for the
-   backup minting cross-site JWTs.
-4. **Backup capacity sizing** — headroom target (largest single site) and the
-   documented multi-site-outage degradation behavior.
-5. **Failback cutover protocol** — precise drain/flip sequencing and how clients
-   are signaled to reconnect home.
-6. **Reconciliation cadence** — replay-on-recovery plus the periodic
-   anti-entropy backstop interval.
+4. **Identity key custody** — concrete shared-signing / KMS scheme for the
+   backup minting cross-site JWTs, incl. the `chat.local.room.>` grant (§7).
+5. **Backup capacity sizing** — separate ingest (N-aggregate) vs serving
+   (largest single site) targets, and documented multi-site-outage degradation.
+6. **Failback cutover protocol** — precise drain/flip sequencing, tail-sweep
+   window, and how clients are signaled to reconnect home (§6.3).
+7. **Reconciliation cadence** — replay-on-recovery plus the periodic anti-entropy
+   backstop interval.
+8. **Per-site replication-lag monitoring** — the RPO-decay signal (§8).

--- a/docs/superpowers/specs/2026-07-28-cross-site-failover-design.md
+++ b/docs/superpowers/specs/2026-07-28-cross-site-failover-design.md
@@ -1,0 +1,193 @@
+# Cross-Site Failover — Shared Warm Backup Site ("Lifeboat")
+
+**Status:** Design / brainstorm output — not yet planned or implemented.
+**Date:** 2026-07-28
+
+## 1. Problem
+
+Each site is a fully independent silo: its own NATS, MongoDB, Cassandra,
+Elasticsearch, Valkey, and MinIO. A user has a **home site** (resolved via
+`portal-service`'s `account → siteID → {natsUrl, baseUrl}` directory), and their
+identity, rooms, subscriptions, and message history live **only** in that home
+site's databases. Cross-site federation today forwards *events* (membership,
+subscription-state, messages) via OUTBOX→INBOX — it does **not** replicate any
+site's full state anywhere.
+
+Consequently, when a site goes down, its users are simply offline: a standby
+site can accept a WebSocket connection but holds none of the displaced user's
+rooms, subscriptions, or history. There is no way to keep basic chatting working.
+
+**Goal:** when any single active site is down, its users can connect to a backup
+site and continue *basic chatting* — send/receive in rooms they already belong
+to, and read recent history — with acknowledged data surviving and healing back
+when the home site recovers.
+
+## 2. Scope
+
+**In scope (lifeboat functionality):**
+- Send and receive messages in rooms the user is **already** a member of.
+- Read **recent** message history (default window: 72h, matching
+  `MESSAGE_BUCKET_HOURS`).
+
+**Out of scope during failover (deferred, degraded):**
+- Creating rooms / DMs, membership changes, role changes.
+- Search, admin, media upload, presence parity.
+- Full-fidelity history beyond the recent window.
+
+Constraining failover to **append-only message traffic in existing rooms**
+is what makes both replication and recovery-time reconciliation tractable.
+
+## 3. Decision
+
+**Topology: N active sites → 1 dedicated warm backup site ("the lifeboat").**
+
+Every active site continuously ships its lifeboat data slice to the single
+backup site. The backup holds a recent, degraded copy of **every** site's
+essential state, namespaced by `siteID`. On a site-A outage, `portal-service`
+reroutes A's accounts to the backup's NATS URL, and the backup **impersonates
+site A** — serving A's rooms/subs/membership/recent-history and accepting new
+messages — until A recovers, at which point outage-window writes reconcile back
+and portal flips A's accounts home.
+
+**Why this topology:** N sites → 1 target is **N replication relationships, not
+a full mesh**, and **one** warm deployment to operate instead of a standby per
+site. It fits the existing architecture because data is already **`siteID`-scoped
+end-to-end** (rooms/subs/members carry `SiteID`; streams are `<STREAM>_<siteID>`),
+so the backup simply runs per-origin-site namespaces.
+
+**Replication mechanism: Variant A — reuse the event federation.** The backup is
+modeled as "a peer subscribed to everything." It receives each site's
+membership / subscription / room-metadata events over the OUTBOX→INBOX lanes
+that already exist and materializes them with the existing `inbox-worker`
+apply logic, and it runs a `message-worker`-style consumer on each site's
+canonical message stream to persist recent history into its own Cassandra.
+This adds mostly configuration plus one "materialize-everything" consumer set —
+no new storage-replication subsystem.
+
+Rejected alternative — **Variant B (storage-layer replication):** Cassandra
+multi-DC (backup as an extra DC per ring) + Mongo change-stream/replica
+shipping. Higher fidelity but N multi-DC rings and a Mongo replication pipeline —
+more machinery and more than the lifeboat scope needs. Retained as the growth
+path if fidelity requirements ever exceed the event-derived slice.
+
+**Two knobs, at recommended defaults:**
+- **Failover trigger:** automatic health-detection with a manual operator
+  override.
+- **RPO:** asynchronous replication — seconds of potential loss on the very last
+  in-flight messages. Synchronous/quorum cross-site replication is not worth its
+  cost for lifeboat scope.
+
+## 4. Architecture
+
+```
+   Active Site A ──┐   (membership/sub/room events via OUTBOX→INBOX)
+   Active Site B ──┼──►  Backup "Lifeboat" Site
+   Active Site C ──┘   (canonical messages via cross-site consumer)
+                          │  materializes per-siteID namespaces:
+                          │    Mongo: rooms, subs, members, users (slice)
+                          │    Cassandra: recent history (72h window)
+                          │
+   portal-service ────────┘  routing brain / split-brain fence:
+     account → (home site if healthy | backup if home down)
+```
+
+### 4.1 Backup site — materialization
+- Runs a per-origin-site set of consumers. For each active `siteID`, it
+  consumes that site's federated membership/subscription/room events (the lanes
+  `inbox-worker` already understands) and applies them with the **same
+  insert/delete/upsert semantics** `inbox-worker` uses today, into a
+  `siteID`-namespaced Mongo.
+- Runs a `message-worker`-style consumer against each site's
+  `MESSAGES_CANONICAL_{siteID}` (cross-site), persisting messages into its own
+  Cassandra under the same bucketed schema. History retention on the backup is
+  capped to the lifeboat window.
+- Holds the **identity slice** (user roster + the room/subscription state) needed
+  to authorize and serve `send`/`receive` — not full user-service parity.
+
+### 4.2 Routing brain — `portal-service`
+- Becomes the **single source of truth** for "who serves account X *right now*."
+  Normal: returns the home site. On A-down: returns the backup's NATS URL for
+  A's accounts.
+- This single authority is also the **split-brain fence**: A and the backup can
+  never both be designated to serve A's users. Failback flips the designation
+  atomically after reconciliation drains.
+- Frontend already connects to a NATS URL it is handed and re-queries portal on
+  connection failure; the reroute reuses that path.
+
+### 4.3 Identity
+- The backup must mint NATS JWTs for **any** site's accounts, so it needs the
+  account signing NKeys. This is the design's largest security trade-off (one
+  deployment can impersonate every site's users).
+- **Recommended:** a shared org-level signing scheme or KMS-fronted keys, rather
+  than copying raw per-site NKeys onto the backup.
+
+## 5. Data flow
+
+### 5.1 Steady state (all sites up)
+Active sites federate their events to the backup exactly as they federate to
+peers today; the backup materializes them. The backup serves **no** live client
+traffic — it is warm, not hot.
+
+### 5.2 Failover (site A down)
+1. Health detection marks A down (auto, with manual override).
+2. `portal-service` switches A's accounts to resolve to the backup's coordinates.
+3. Displaced clients reconnect to the backup; backup `auth-service` mints their
+   JWTs.
+4. Users send/receive in existing rooms and read recent history, served from the
+   backup's materialized copy of A. New messages persist to the backup's
+   Cassandra (and flow through the backup's canonical pipeline for delivery).
+
+### 5.3 Failback (site A recovers)
+1. A comes back but is **not yet** re-designated as serving its accounts (portal
+   still points them at the backup).
+2. The backup **replays its outage-window messages** for A back into A over the
+   canonical/federation path. Because messages are **append-only with unique IDs
+   and Cassandra bucketing**, replay is **idempotent and conflict-free** (unique
+   `Nats-Msg-Id` / message-ID dedup absorbs duplicates).
+3. Once A has caught up, portal atomically flips A's accounts home; clients
+   reconnect to A.
+
+## 6. Reconciliation
+
+Lifeboat scope makes reconciliation simple: since room/DM creation and
+membership changes are **out of scope** during failover, the only new writes at
+the backup are **append-only messages**. There is no membership divergence to
+merge — only message backfill, which the existing dedup + bucketing make safe to
+replay. A periodic anti-entropy sweep (as in the membership-federation design
+§3.4) can serve as an unconditional backstop for any messages missed by the
+replay.
+
+## 7. Failure modes
+
+| Vector | Handling |
+|---|---|
+| **Backup itself down when a site fails** | Backup is a failover SPOF; it MUST be HA within itself (multi-AZ). Documented limit, not silently degraded. |
+| **Correlated multi-site outage** | Backup is sized for **one site down at a time**; concurrent multi-site failure degrades further (documented ceiling, alerting). |
+| **Split brain (A + backup both serving A)** | Prevented by portal-service as sole routing authority; failback flips only after reconciliation drains. |
+| **Last in-flight messages at outage instant** | Async RPO ⇒ seconds of potential loss accepted for lifeboat scope. |
+| **Identity key compromise on backup** | Mitigated by shared/KMS-fronted signing rather than raw NKey copies; backup hardened accordingly. |
+| **Replay duplicates on failback** | Idempotent: message-ID / `Nats-Msg-Id` dedup + append-only bucketed writes. |
+
+## 8. Non-goals
+
+- No room/DM creation, membership, admin, search, presence, or media parity
+  during failover (lifeboat scope only).
+- No synchronous/zero-RPO cross-site replication.
+- No full-fidelity byte-for-byte DB replica of any site (that is Variant B, a
+  future growth path).
+- No active-active (multi-primary) serving — the backup is warm-passive and
+  serves only while a home site is down.
+
+## 9. Open questions / follow-ups
+
+1. **History window** exact size and per-room caps on the backup's Cassandra.
+2. **Health-detection mechanism** and the manual-override control surface
+   (likely portal-service-owned).
+3. **Identity key custody** — concrete shared-signing / KMS scheme for the
+   backup minting cross-site JWTs.
+4. **Backup capacity sizing** — headroom target (largest single site) and the
+   documented multi-site-outage degradation behavior.
+5. **Failback cutover protocol** — precise drain/flip sequencing and how clients
+   are signaled to reconnect home.
+6. **Reconciliation cadence** — replay-on-recovery plus the periodic
+   anti-entropy backstop interval.

--- a/docs/superpowers/specs/2026-07-29-sp1a-message-slice-dr-feed.md
+++ b/docs/superpowers/specs/2026-07-29-sp1a-message-slice-dr-feed.md
@@ -1,0 +1,138 @@
+# SP1a (core) — Message-slice DR feed, single site
+
+> **Scope discipline.** This is the *core* first slice of SP1a, deliberately
+> narrowed to **one origin site → the backup, message history only**. It is the
+> Cassandra counterpart to SP1b (operational slice). Everything else in the
+> failover program — the operational slice (SP1b), multi-site fan-out, backup
+> serving (SP2), routing (SP3), detection (SP4), failback replay (SP5) — is
+> explicitly **out of scope** and lands in its own PR.
+>
+> - **Governing design:** `docs/superpowers/specs/2026-07-28-cross-site-failover-design.md` (§4.1, §6.4, §6.5)
+> - **Roadmap:** `docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md` (SP1a)
+> - **Sibling:** `docs/superpowers/specs/2026-07-29-sp1b-operational-slice-dr-feed.md`
+
+## 1. Goal
+
+The backup site continuously receives **one origin site's message history** and
+materializes it into the backup's own `siteID`-namespaced Cassandra under the
+same bucketed schema, so the backup stays *warm* — a recent, queryable copy of
+that site's messages.
+
+Nothing in this slice *serves* that data. The only observable outcome: messages
+persisted at the origin site appear, shortly after, in the backup's Cassandra.
+
+## 2. Decision — replicate at the event layer, not the storage layer
+
+In this codebase Cassandra is written through exactly one door: the
+`MESSAGES_CANONICAL_{siteID}` stream, persisted by `message-worker`. That single
+ingress is what makes the event-layer approach clean.
+
+- **Rejected — Cassandra-native multi-DC replication.** Adding the backup as
+  another DC per keyspace fuses each site's independent Cassandra into
+  cross-region rings, fighting the "each site runs its own NATS / Mongo /
+  Cassandra independently" architecture and the per-`siteID` backup model.
+- **Rejected — application dual-write** (message-worker writes both Cassandras).
+  Synchronous cross-region write on the hot path, no durable buffer, couples
+  availability.
+- **Chosen — source the canonical stream** (design §4.1). The backup runs a
+  `message-worker`-shaped consumer that sources the whole
+  `MESSAGES_CANONICAL_{siteID}` over the gateway and persists into its **own**
+  Cassandra via the same `Store.SaveMessage` / `SaveThreadMessage`. No
+  cross-region cluster; reuses existing persistence code; the canonical stream
+  itself doubles as the durable restore log (§5).
+
+**The canonical event stream is the replication channel** — we don't replicate
+Cassandra, we replay the events that build it.
+
+## 3. Topology
+
+```
+[ origin site A ]                              [ backup site ]
+  MESSAGES_CANONICAL_{A}  ──►  DR_MESSAGES_{A}  ──►  message-worker-style  ──►  Cassandra
+   (single source of truth)     (JetStream,           consumer                  (siteID-
+                                 sourced x-site)       (SaveMessage)             scoped)
+```
+
+- **Sourced cross-gateway** — a backup-local `DR_MESSAGES_{A}` stream that
+  JetStream-**sources** the origin's whole `MESSAGES_CANONICAL_{A}` (durable
+  buffering + automatic resume; decoupled from momentary remote unavailability),
+  same rationale as SP1b's `DR_OPLOG` sourcing.
+- **Consumer at the backup** persists into the backup's own Cassandra, `siteID`-
+  scoped, under the identical bucketed schema.
+
+## 4. Why replay is safe (falls out of the existing schema)
+
+The message schema makes replay near-worry-free — three properties, all true
+today (design §6.4):
+
+- **Idempotent** — keyed on `(room_id, bucket, message_id)`, so a re-applied
+  write is a no-op upsert; JetStream `Nats-Msg-Id` absorbs redelivery.
+- **Order-independent** — the clustering key is the message's own `created_at`
+  (stamped at original send), so *any* replay order still sorts correctly on read.
+- **Buckets line up** — `bucket = floor(created_at / windowMs)` uses the original
+  `created_at`, so a replayed message lands in the exact partition it would have
+  occupied had A never died.
+
+This trio is why the message slice needs **no conflict reconciliation and no
+origin-echo handling** (unlike SP1b's failback hook): "just replay it" is correct.
+
+### 4.1 Hard invariant — shared bucket window
+
+Backup and every origin site **MUST** share `MESSAGE_BUCKET_HOURS` (default 72).
+A mismatch makes writes and reads target different `(room_id, bucket)` partitions
+and silently lose data — this is already mandated repo-wide (CLAUDE.md §
+Cassandra); this slice inherits and re-asserts it. Thread replies use
+`thread_messages_by_thread` (partitioned by `thread_room_id` alone, no bucket), so
+they carry no bucket-window dependency.
+
+## 5. Retention — two tiers (do not couple them)
+
+- **Read window (Cassandra):** the backup's Cassandra keeps only the lifeboat
+  window (~72h) needed to *serve* history during an outage.
+- **Restore log (the stream):** the `DR_MESSAGES_{siteID}` / canonical stream is
+  the durable restore log; size its `MaxAge` **≥ max tolerated outage**
+  (days/weeks — 1× with no fan-out, cheap).
+- **Rule:** restore (SP5) reads from the **stream**, never the 72h Cassandra
+  window — a longer outage would age the earliest messages out of Cassandra
+  before the origin returns. The two numbers are independent.
+
+## 6. The forward gap (noted, not solved here)
+
+Messages the origin persisted just before crashing that never reached the backup
+(the RPO tail) are **not lost** — they stay durable in the origin's own Cassandra
+and reappear when clients are pointed home; remote members recover them via the
+client's normal history/gap fetch (design §6.7). This slice does not attempt to
+close the gap; it only records that the gap is benign.
+
+## 7. Out of scope (explicit — each its own PR)
+
+- **SP1b** — operational slice → backup Mongo (sibling spec).
+- **Multi-site** — running this per-`siteID` for every origin site (this core is one site).
+- **SP2** — backup *serving* (history read path pointed at the backup Cassandra).
+- **SP3 / SP4** — routing override, health detection.
+- **SP5** — failback replay of the restore log into the origin's front door.
+- **SP6** — ops/IaC: gateway peering, stream `MaxAge` sizing, replication-lag alerting.
+
+## 8. Testing (TDD, per CLAUDE.md §4)
+
+- **Unit** — consumer/persist handler table tests (channel message + thread reply
+  → correct `SaveMessage` / `SaveThreadMessage` call; malformed payload; store
+  error → Nak vs poison), mocked store; assert idempotent re-delivery is a no-op.
+- **Integration** (`//go:build integration`, `testutil.NATS` +
+  `testutil.CassandraKeyspace`) — publish canonical events → source →
+  persist → read back from the backup Cassandra; assert bucket placement matches
+  the origin (same `MESSAGE_BUCKET_HOURS`), and that a replayed duplicate does not
+  double-write.
+- **Coverage** — ≥80% floor; ≥90% for the persist/handler business logic.
+
+## 9. Open sub-decisions (call out in the plan)
+
+1. **Deploy shape** — MODE-configured reuse of `message-worker` (a "replicate"
+   mode) vs a thin new DR consumer service. *Leaning: reuse* (matches the repo's
+   unified-worker convention and SP1b's reuse decision).
+2. **`DR_MESSAGES_{siteID}` ownership** — new per-site stream bootstrapped via the
+   standard `BOOTSTRAP_STREAMS` convention; which service owns creation, and
+   whether it is the same owner as SP1b's `DR_OPLOG_{siteID}`.
+3. **Backup Cassandra namespacing** — separate keyspace per `siteID` vs a
+   `siteID`-scoped table/partition scheme (align with SP1b's Mongo namespacing
+   choice for a consistent per-site story).

--- a/docs/superpowers/specs/2026-07-29-sp1b-operational-slice-dr-feed.md
+++ b/docs/superpowers/specs/2026-07-29-sp1b-operational-slice-dr-feed.md
@@ -153,12 +153,41 @@ the replay, conflict policy, and cutover.
   `CrossSite=true` room asserting the flag survives round-trip.
 - **Coverage** — ≥80% floor; ≥90% for the applier/handler business logic.
 
-## 10. Open sub-decisions (call out in the plan)
+## 10. Sub-decisions — resolved during implementation
 
-1. **Deploy shape** — MODE-configured reuse of the existing
-   `oplog-connector` / `oplog-direct-transfer` binaries (matching the repo's
-   unified-worker convention) vs thin new DR services. *Leaning: reuse.*
-2. **`DR_OPLOG_{siteID}` ownership** — new per-site stream bootstrapped via the
-   standard `BOOTSTRAP_STREAMS` convention; which service owns creation.
-3. **Backup namespacing** — separate Mongo *database* per `siteID` vs a
-   `siteID`-prefixed collection scheme (feeds the §7 origin hook).
+1. **Deploy shape** — a thin new **`dr-oplog-worker`** service (repo-root, flat
+   layout) that *reuses the patterns/packages* of `oplog-direct-transfer`
+   (envelope, disposition helpers in `pkg/migration`, verbatim `targetStore`)
+   rather than config-reusing the migration binary. Rationale: the migration
+   connector is coupled to legacy semantics (`rocketchat*` defaults, a `migration`
+   checkpoint DB, a `federation.origin` filter) and — decisively — opens its
+   change stream with *no* `updateLookup`, so config-reuse could not give a
+   self-contained feed (§5). The applier is meaningfully *simpler* than the
+   migration transfer: no source-Mongo connection, no lookups map.
+2. **`DR_OPLOG_{siteID}` ownership** — new per-site stream in `pkg/stream.DROplog`
+   / `pkg/subject.DROplog`, bootstrapped by `dr-oplog-worker` via the standard
+   `BOOTSTRAP_STREAMS` convention (no-op in prod; ops/IaC owns the real stream +
+   gateway routing).
+3. **Backup namespacing** — **separate Mongo database per origin site**
+   (`TARGET_DB_PREFIX` + `siteID`, default `chat_dr_{siteID}`). A whole DB per
+   site gives the cleanest isolation and the cleanest §7 failback boundary.
+
+## 11. Implementation status
+
+**Built and unit-tested** (this PR — the backup-side heart):
+- `pkg/subject.DROplog` / `DROplogWildcard`, `pkg/stream.DROplog` (+ tests).
+- `dr-oplog-worker` service: config, self-contained applier handler
+  (insert/replace/update via inline `fullDocument`; delete; explicit-`null`
+  post-image and missing post-image both poison; native `_id` types), verbatim
+  `mongoTargetStore`, `DR_OPLOG` bootstrap, metrics, consume/disposition wiring,
+  `deploy/` (Dockerfile, docker-compose, azure-pipelines). Business-logic units at
+  ~100%; `main`/`store_mongo`/`createConsumerWithRetry` are integration-covered
+  (build-tagged `integration_test.go`, incl. a `CrossSite` round-trip) — they need
+  Docker/testcontainers and run in CI, clearing the 80% floor there.
+
+**Next increment (same SP1b PR):** producer-side `updateLookup` — a DR-configured
+connector (or an opt-in `updateLookup` option on the existing change source,
+defaulted off to preserve migration behavior) so `update` events carry the inline
+post-image the applier's self-contained contract (§5) requires end-to-end.
+
+**Deferred to their own PRs:** SP1a (messages), multi-site fan-out, SP2/3/4/5/6.

--- a/docs/superpowers/specs/2026-07-29-sp1b-operational-slice-dr-feed.md
+++ b/docs/superpowers/specs/2026-07-29-sp1b-operational-slice-dr-feed.md
@@ -185,9 +185,20 @@ the replay, conflict policy, and cutover.
   (build-tagged `integration_test.go`, incl. a `CrossSite` round-trip) — they need
   Docker/testcontainers and run in CI, clearing the 80% floor there.
 
-**Next increment (same SP1b PR):** producer-side `updateLookup` — a DR-configured
-connector (or an opt-in `updateLookup` option on the existing change source,
-defaulted off to preserve migration behavior) so `update` events carry the inline
-post-image the applier's self-contained contract (§5) requires end-to-end.
+**Producer side (now built)** — the DR feed is live end-to-end. Rather than fork
+the connector's tested CDC engine (checkpointing, watchers, backoff), the
+existing `oplog-connector` gained a config-gated **`MODE=dr`** lane (default
+`migration`, byte-identical to before):
+- opens the change stream with `fullDocument: updateLookup`, so `update` events
+  carry the inline post-image the applier's self-contained contract (§5) needs;
+- injects `subject.DROplog` so envelopes publish onto `chat.dr.oplog.>`;
+- bootstraps / verifies `DR_OPLOG_{siteID}` instead of `MIGRATION_OPLOG`.
+- A DR-mode integration test asserts an `update` publishes to the DR lane
+  carrying the looked-up post-image.
+- DR deployment config: `MODE=dr`, `SOURCE_DB=chat`,
+  `WATCH_COLLECTIONS=rooms,subscriptions,room_members,thread_rooms,thread_subscriptions,users`.
+  This differs from the applier's new-service decision for a principled reason:
+  here extending is *simpler* and preserves migration behavior; there a new
+  service was simpler and the migration applier's source-lookup was wrong for DR.
 
 **Deferred to their own PRs:** SP1a (messages), multi-site fan-out, SP2/3/4/5/6.

--- a/docs/superpowers/specs/2026-07-29-sp1b-operational-slice-dr-feed.md
+++ b/docs/superpowers/specs/2026-07-29-sp1b-operational-slice-dr-feed.md
@@ -1,0 +1,164 @@
+# SP1b (core) — Operational-slice DR feed, single site
+
+> **Scope discipline.** This is the *core* first slice of SP1b, deliberately
+> narrowed to **one origin site → the backup, operational state only**. It
+> resolves design open-question §11.1 ("DR feed mechanism for operational
+> state"). Everything else in the failover program — the message slice (SP1a),
+> multi-site fan-out, backup serving (SP2), routing (SP3), detection (SP4),
+> failback replay (SP5) — is explicitly **out of scope** and lands in its own
+> PR.
+>
+> - **Governing design:** `docs/superpowers/specs/2026-07-28-cross-site-failover-design.md` (§4.1, §11.1)
+> - **Roadmap:** `docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md` (SP1b)
+
+## 1. Goal
+
+The backup site continuously receives **one origin site's operational state**
+(rooms, subscriptions, members, and the user roster slice) and materializes it
+verbatim into a `siteID`-namespaced Mongo, so the backup stays *warm* — a
+recent, queryable copy of that site's lifeboat-servable state.
+
+Nothing in this slice *serves* that data. The only observable outcome: writes at
+the origin site's Mongo appear, shortly after, in the backup's Mongo under that
+site's namespace.
+
+## 2. Decision — reuse the oplog CDC pipeline
+
+Resolves §11.1 (**Mongo change-streams vs a new backup-directed event fan-out**)
+in favour of **Mongo change-streams**, by reusing the existing, tested oplog CDC
+components rather than building a new fan-out:
+
+- **`data-migration/oplog-connector`** — a change-stream tailer that emits a
+  `model.OplogEvent` envelope (dedup `EventID` = `Nats-Msg-Id`, op, collection,
+  opaque whole-document `FullDocument`, `SiteID`, `ClusterTime`) to a NATS
+  stream.
+- **`data-migration/oplog-direct-transfer`** — an applier whose `targetStore`
+  (`UpsertByID` / `DeleteByID`, keyed by native `_id`) writes each event verbatim
+  into a destination Mongo.
+
+### 2.1 Why change-streams, not the OUTBOX federation pattern
+
+The OUTBOX pattern is **membership-driven**: `room-service` / `room-worker`
+publish per-destination events only for state destined for a *peer site*
+(`member_added` / `member_removed` / `room_renamed` + subscription-state), and
+only for rooms that have cross-site membership. DR needs the **opposite
+property**: the *whole* site's operational state, membership-independent —
+including purely local rooms that never federate to anyone.
+
+Tailing the Mongo oplog captures **every** write to the watched collections
+regardless of membership or event type, with three properties the OUTBOX lane
+cannot give us:
+
+1. **Local rooms covered by construction** — the exact gap the OUTBOX lane leaves.
+2. **`CrossSite` rides free** — whole-document replication copies `Room.CrossSite`
+   verbatim, satisfying design §4.1 / §7 with zero extra work.
+3. **Zero producer changes** — room-service / room-worker / user-service are
+   untouched; no risk of a missed write path, now or in future.
+
+## 3. Topology
+
+Mirrors the existing connector → NATS → transfer split, applied cross-site:
+
+```
+[ origin site A ]                         [ backup site ]
+  Mongo (rooms, subscriptions,
+   room_members, users)
+        │ change stream (local)
+        ▼
+  oplog-connector  ──►  DR_OPLOG_{A}  ──►  oplog-direct-transfer  ──►  Mongo
+   (watches op collections)  (JetStream,      (applier)                (siteID-
+                              sourced x-site)                            scoped)
+```
+
+- **Tailer runs at the origin site**, co-located with that site's Mongo — the
+  change-stream connection stays local (robust; no cross-region change stream).
+- **Events cross the gateway as JetStream** — `DR_OPLOG_{A}` is sourced into the
+  backup (durable buffering + automatic resume; decoupled from momentary remote
+  unavailability), same rationale as SP1a's canonical sourcing.
+- **Applier runs at the backup**, writing into the `siteID`-scoped Mongo.
+
+## 4. What is replicated — the lifeboat operational slice
+
+Whitelisted collections (defense-in-depth: both the connector's watch set and the
+applier's `collections` guard):
+
+| Collection | Why it's in the lifeboat slice |
+|-----------|--------------------------------|
+| `rooms` | Room existence, `CrossSite` locality, metadata to serve/list rooms |
+| `subscriptions` | Who is subscribed to what — authorize + `subscription.list` |
+| `room_members` | Membership — authorize send/receive |
+| `thread_rooms` | Thread rooms parallel channel rooms |
+| `thread_subscriptions` | Thread subscription state |
+| `users` (roster slice) | Identity slice needed to authorize/serve (not full user-service parity) |
+
+Explicitly **excluded** from this core: messages (SP1a, Cassandra), and anything
+not needed to authorize + serve send/receive in existing rooms.
+
+## 5. Self-contained events — `updateLookup`
+
+The migration connector opens its change stream with **no** `updateLookup`
+("native oplog only") because its co-located transfer re-reads the source Mongo
+by `_id` for `update` ops (`oplog-direct-transfer/handler.go:resolveBySourceLookup`).
+
+For a **cross-site DR** feed that back-read would be a cross-region round-trip
+from the backup to the origin's Mongo on every update — a coupling we do not
+want. The DR connector therefore opens the change stream with
+`fullDocument: "updateLookup"` so `update` events carry the post-image inline and
+the feed is **self-contained**: the backup applier never reads back to the origin.
+
+## 6. Idempotency & ordering
+
+- **Idempotent** — `EventID` set as `Nats-Msg-Id` (JetStream dedup) + `_id`-keyed
+  upsert/delete absorb redelivery.
+- **Per-document order preserved** — change streams deliver a document's events in
+  oplog order; a single applier (or a per-`_id` FIFO, `MaxAckPending=1`, matching
+  the OUTBOX membership-lane precedent) preserves apply order so a later update
+  can't be overtaken by an earlier one.
+
+## 7. The failback origin hook (cheap insurance for SP5)
+
+SP5 (failback) must replay **only backup-authored writes** back to a recovered
+site — never echo the origin's own replicated data back at it. To make that a
+clean "tail this namespace/marker over this window" instead of a forensic diff,
+this core bakes in the separation now:
+
+- Backup-authored operational writes are **distinguishable from origin-replicated
+  writes** — via a dedicated backup namespace and/or an origin marker on the
+  document.
+- **Precedent already in-repo:** `oplog-connector/source_mongo.go` already carries
+  a `federation.origin` `$match` filter that drops foreign-origin insert/replace.
+  The same shape (an origin marker + a change-stream `$match`) is the mechanism
+  SP5 will filter on.
+
+This slice only guarantees the **separation exists and is queryable**; SP5 owns
+the replay, conflict policy, and cutover.
+
+## 8. Out of scope (explicit — each its own PR)
+
+- **SP1a** — message slice → backup Cassandra.
+- **Multi-site** — running this per-`siteID` for every origin site (this core is one site).
+- **SP2** — backup *serving* (JWT minting, send/receive/history read paths).
+- **SP3 / SP4** — routing override, health detection.
+- **SP5** — failback replay, origin filtering *use*, conflict reconciliation.
+- **SP6** — ops/IaC: gateway peering, stream `MaxAge` sizing, replication-lag alerting.
+
+## 9. Testing (TDD, per CLAUDE.md §4)
+
+- **Unit** — applier handler table tests (insert/replace/update/delete →
+  upsert/delete; collection-guard skip; poison vs transient), mocked `targetStore`.
+  Connector collection-selection + `updateLookup` config tests.
+- **Integration** (`//go:build integration`, `testutil.MongoDB` + `testutil.NATS`)
+  — change event at a source Mongo → published to `DR_OPLOG_{siteID}` → applied →
+  read back verbatim from the backup Mongo under the site namespace, including a
+  `CrossSite=true` room asserting the flag survives round-trip.
+- **Coverage** — ≥80% floor; ≥90% for the applier/handler business logic.
+
+## 10. Open sub-decisions (call out in the plan)
+
+1. **Deploy shape** — MODE-configured reuse of the existing
+   `oplog-connector` / `oplog-direct-transfer` binaries (matching the repo's
+   unified-worker convention) vs thin new DR services. *Leaning: reuse.*
+2. **`DR_OPLOG_{siteID}` ownership** — new per-site stream bootstrapped via the
+   standard `BOOTSTRAP_STREAMS` convention; which service owns creation.
+3. **Backup namespacing** — separate Mongo *database* per `siteID` vs a
+   `siteID`-prefixed collection scheme (feeds the §7 origin hook).

--- a/dr-oplog-worker/bootstrap.go
+++ b/dr-oplog-worker/bootstrap.go
@@ -18,7 +18,7 @@ type streamManager interface {
 }
 
 // bootstrapStreams is a no-op in production (streams are ops/IaC-owned). When Enabled
-// (dev/integration) it creates only the DR_OPLOG_{siteID} schema (Name + Subjects); the
+// (dev/integration) it creates only the DR-OPLOG-{siteID} schema (Name + Subjects); the
 // cross-gateway routing that lands a remote origin site's publish here is an ops/IaC concern.
 func bootstrapStreams(ctx context.Context, js streamManager, siteID string, enabled bool) error {
 	if !enabled {
@@ -29,7 +29,7 @@ func bootstrapStreams(ctx context.Context, js streamManager, siteID string, enab
 		Name:     cfg.Name,
 		Subjects: cfg.Subjects,
 	}); err != nil {
-		return fmt.Errorf("create DR_OPLOG stream: %w", err)
+		return fmt.Errorf("create DR-OPLOG stream: %w", err)
 	}
 	return nil
 }

--- a/dr-oplog-worker/bootstrap.go
+++ b/dr-oplog-worker/bootstrap.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nats-io/nats.go/jetstream"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+
+	"github.com/hmchangw/chat/pkg/stream"
+)
+
+// streamManager is the minimal JetStream surface bootstrapStreams needs, service-local so tests
+// can fake it without mockgen.
+type streamManager interface {
+	CreateOrUpdateStream(ctx context.Context, cfg jetstream.StreamConfig) (o11ynats.Stream, error)
+}
+
+// bootstrapStreams is a no-op in production (streams are ops/IaC-owned). When Enabled
+// (dev/integration) it creates only the DR_OPLOG_{siteID} schema (Name + Subjects); the
+// cross-gateway routing that lands a remote origin site's publish here is an ops/IaC concern.
+func bootstrapStreams(ctx context.Context, js streamManager, siteID string, enabled bool) error {
+	if !enabled {
+		return nil
+	}
+	cfg := stream.DROplog(siteID)
+	if _, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:     cfg.Name,
+		Subjects: cfg.Subjects,
+	}); err != nil {
+		return fmt.Errorf("create DR_OPLOG stream: %w", err)
+	}
+	return nil
+}

--- a/dr-oplog-worker/bootstrap_test.go
+++ b/dr-oplog-worker/bootstrap_test.go
@@ -42,5 +42,5 @@ func TestBootstrapStreams_Error_Wrapped(t *testing.T) {
 	fsm := &fakeStreamManager{err: errors.New("nats down")}
 	err := bootstrapStreams(context.Background(), fsm, "site1", true)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "DR_OPLOG")
+	assert.Contains(t, err.Error(), "DR-OPLOG")
 }

--- a/dr-oplog-worker/bootstrap_test.go
+++ b/dr-oplog-worker/bootstrap_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+)
+
+// fakeStreamManager records CreateOrUpdateStream calls.
+type fakeStreamManager struct {
+	configs []jetstream.StreamConfig
+	err     error
+}
+
+//nolint:gocritic // hugeParam: signature must satisfy the streamManager interface (jetstream.StreamConfig is passed by value there).
+func (f *fakeStreamManager) CreateOrUpdateStream(_ context.Context, cfg jetstream.StreamConfig) (o11ynats.Stream, error) {
+	f.configs = append(f.configs, cfg)
+	return nil, f.err
+}
+
+func TestBootstrapStreams_Disabled_NoOp(t *testing.T) {
+	fsm := &fakeStreamManager{}
+	require.NoError(t, bootstrapStreams(context.Background(), fsm, "site1", false))
+	assert.Empty(t, fsm.configs)
+}
+
+func TestBootstrapStreams_Enabled_CreatesDROplog(t *testing.T) {
+	fsm := &fakeStreamManager{}
+	require.NoError(t, bootstrapStreams(context.Background(), fsm, "site1", true))
+	require.Len(t, fsm.configs, 1)
+	assert.Equal(t, "DR-OPLOG-site1", fsm.configs[0].Name)
+	assert.Equal(t, []string{"chat.dr.oplog.site1.>"}, fsm.configs[0].Subjects)
+}
+
+func TestBootstrapStreams_Error_Wrapped(t *testing.T) {
+	fsm := &fakeStreamManager{err: errors.New("nats down")}
+	err := bootstrapStreams(context.Background(), fsm, "site1", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DR_OPLOG")
+}

--- a/dr-oplog-worker/config.go
+++ b/dr-oplog-worker/config.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/caarlos0/env/v11"
+)
+
+// config holds every tunable, parsed from the environment via caarlos0/env.
+// Required fields have no default and fail-fast at startup when absent.
+//
+// Unlike oplog-direct-transfer, the DR applier is self-contained: the producer-side
+// connector opens its change stream with updateLookup, so every insert/replace/update
+// event carries the full post-image inline. The applier therefore needs NO source Mongo
+// connection and never reads back across the gateway to the origin site.
+type config struct {
+	// SiteID is the origin site this applier instance replicates. One instance per origin site.
+	SiteID string `env:"SITE_ID,required"`
+
+	NatsURL       string `env:"NATS_URL,required"`
+	NatsCredsFile string `env:"NATS_CREDS_FILE" envDefault:""`
+
+	// Target backup Mongo: verbatim upsert/delete by _id into the per-site namespace.
+	TargetMongoURI string `env:"TARGET_MONGO_URI,required"`
+	TargetUsername string `env:"TARGET_MONGO_USERNAME" envDefault:""`
+	TargetPassword string `env:"TARGET_MONGO_PASSWORD" envDefault:""`
+
+	// TargetDBPrefix namespaces each origin site into its own backup database (prefix + siteID).
+	// A whole database per origin site keeps sites isolated and gives failback (SP5) a clean
+	// boundary for separating backup-authored writes from origin-replicated ones.
+	TargetDBPrefix string `env:"TARGET_DB_PREFIX" envDefault:"chat_dr_"`
+
+	// DRCollections is the lifeboat operational slice replicated verbatim to the same-named
+	// destination collection. Config-driven so adding one is an env change.
+	DRCollections []string `env:"DR_COLLECTIONS" envSeparator:"," envDefault:"rooms,subscriptions,room_members,thread_rooms,thread_subscriptions,users"`
+
+	ConsumerDurable string `env:"CONSUMER_DURABLE" envDefault:"dr-oplog-worker"`
+	MaxDeliver      int    `env:"MAX_DELIVER" envDefault:"1000"`
+
+	Bootstrap bootstrapConfig `envPrefix:"BOOTSTRAP_"`
+
+	HealthAddr string `env:"HEALTH_ADDR" envDefault:":9090"`
+}
+
+type bootstrapConfig struct {
+	Enabled bool `env:"STREAMS" envDefault:"false"`
+}
+
+// TargetDB is the backup database name for this instance's origin site.
+func (c *config) TargetDB() string {
+	return c.TargetDBPrefix + c.SiteID
+}
+
+// parseConfig parses and validates the environment configuration.
+func parseConfig() (config, error) {
+	cfg, err := env.ParseAs[config]()
+	if err != nil {
+		return config{}, fmt.Errorf("parse config: %w", err)
+	}
+	// `required` only rejects an unset var, not whitespace. Trim + re-validate required scalars.
+	cfg.SiteID = strings.TrimSpace(cfg.SiteID)
+	cfg.NatsURL = strings.TrimSpace(cfg.NatsURL)
+	cfg.TargetMongoURI = strings.TrimSpace(cfg.TargetMongoURI)
+	for name, v := range map[string]string{
+		"SITE_ID":          cfg.SiteID,
+		"NATS_URL":         cfg.NatsURL,
+		"TARGET_MONGO_URI": cfg.TargetMongoURI,
+	} {
+		if v == "" {
+			return config{}, fmt.Errorf("%s must be non-empty", name)
+		}
+	}
+	// Trim, non-empty, dedup the collection list — each maps to one consumer subject.
+	seen := make(map[string]struct{}, len(cfg.DRCollections))
+	trimmed := make([]string, 0, len(cfg.DRCollections))
+	for _, c := range cfg.DRCollections {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			return config{}, fmt.Errorf("DR_COLLECTIONS has an empty entry (check for stray commas)")
+		}
+		if _, dup := seen[c]; dup {
+			return config{}, fmt.Errorf("DR_COLLECTIONS has duplicate entry %q", c)
+		}
+		seen[c] = struct{}{}
+		trimmed = append(trimmed, c)
+	}
+	if len(trimmed) == 0 {
+		return config{}, fmt.Errorf("DR_COLLECTIONS must list at least one collection")
+	}
+	cfg.DRCollections = trimmed
+	return cfg, nil
+}

--- a/dr-oplog-worker/config_test.go
+++ b/dr-oplog-worker/config_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setRequiredEnv(t *testing.T) {
+	t.Setenv("SITE_ID", "site1")
+	t.Setenv("NATS_URL", "nats://localhost:4222")
+	t.Setenv("TARGET_MONGO_URI", "mongodb://localhost:27017")
+}
+
+func TestParseConfig_Defaults(t *testing.T) {
+	setRequiredEnv(t)
+	cfg, err := parseConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "site1", cfg.SiteID)
+	assert.Equal(t, "chat_dr_", cfg.TargetDBPrefix)
+	assert.Equal(t, "chat_dr_site1", cfg.TargetDB())
+	assert.Equal(t, "dr-oplog-worker", cfg.ConsumerDurable)
+	assert.Equal(t, 1000, cfg.MaxDeliver)
+	assert.Contains(t, cfg.DRCollections, "rooms")
+	assert.Contains(t, cfg.DRCollections, "subscriptions")
+	assert.Contains(t, cfg.DRCollections, "users")
+	assert.Len(t, cfg.DRCollections, 6)
+}
+
+// The DR applier is self-contained (updateLookup on the producer): it MUST NOT require a
+// source Mongo connection. Parsing succeeds with no SOURCE_MONGO_URI set.
+func TestParseConfig_NoSourceMongoRequired(t *testing.T) {
+	setRequiredEnv(t)
+	_, err := parseConfig()
+	require.NoError(t, err)
+}
+
+func TestParseConfig_TrimsAndValidatesRequired(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("SITE_ID", "   ")
+	_, err := parseConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SITE_ID")
+}
+
+func TestParseConfig_RejectsEmptyCollectionEntry(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("DR_COLLECTIONS", "rooms,,users")
+	_, err := parseConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DR_COLLECTIONS")
+}
+
+func TestParseConfig_RejectsDuplicateCollection(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("DR_COLLECTIONS", "rooms,rooms")
+	_, err := parseConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate")
+}
+
+func TestParseConfig_TargetDBHonoursPrefix(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("TARGET_DB_PREFIX", "lifeboat_")
+	t.Setenv("SITE_ID", "tokyo")
+	cfg, err := parseConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "lifeboat_tokyo", cfg.TargetDB())
+}

--- a/dr-oplog-worker/deploy/Dockerfile
+++ b/dr-oplog-worker/deploy/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.25.12-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY pkg/ pkg/
+COPY dr-oplog-worker/ dr-oplog-worker/
+
+RUN CGO_ENABLED=0 go build -o /dr-oplog-worker ./dr-oplog-worker/
+
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates && adduser -D -u 10001 app
+
+COPY --from=builder /dr-oplog-worker /dr-oplog-worker
+
+USER app
+ENTRYPOINT ["/dr-oplog-worker"]

--- a/dr-oplog-worker/deploy/azure-pipelines.yml
+++ b/dr-oplog-worker/deploy/azure-pipelines.yml
@@ -1,0 +1,80 @@
+trigger:
+  branches:
+    include:
+      - main
+      - develop
+  paths:
+    include:
+      - dr-oplog-worker/
+      - pkg/
+
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - dr-oplog-worker/
+      - pkg/
+
+variables:
+  GO_VERSION: '1.25.12'
+  SERVICE_PATH: dr-oplog-worker
+  IMAGE_NAME: dr-oplog-worker
+  REGISTRY: '$(containerRegistry)'
+
+stages:
+  - stage: Validate
+    displayName: 'Lint & Test'
+    jobs:
+      - job: LintAndTest
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+          - task: GoTool@0
+            inputs:
+              version: '$(GO_VERSION)'
+            displayName: 'Install Go $(GO_VERSION)'
+
+          - script: go vet ./$(SERVICE_PATH)/... ./pkg/...
+            displayName: 'Go Vet'
+
+          - script: go test ./pkg/... -v -race -coverprofile=coverage-pkg.out
+            displayName: 'Test shared packages'
+
+          # Run unit + integration (-tags=integration) so the handler wiring — which
+          # is only reachable with real Mongo/NATS (testcontainers) — counts toward
+          # the coverage floor. Requires Docker on the agent.
+          - script: go test ./$(SERVICE_PATH)/... -tags=integration -v -race -coverprofile=coverage-$(IMAGE_NAME).out
+            displayName: 'Test $(IMAGE_NAME) (unit + integration)'
+
+          - script: |
+              set -euo pipefail
+              pct=$(go tool cover -func=coverage-$(IMAGE_NAME).out | awk '/^total:/ {print substr($3, 1, length($3)-1)}')
+              echo "$(IMAGE_NAME) total coverage: ${pct}%"
+              awk -v p="$pct" 'BEGIN { exit (p+0 < 80) }' || { echo "##vso[task.logissue type=error]coverage ${pct}% is below the 80% floor (CLAUDE.md §4)"; exit 1; }
+            displayName: 'Enforce 80% coverage floor'
+
+          - script: go build -o /dev/null ./$(SERVICE_PATH)/
+            displayName: 'Build $(IMAGE_NAME)'
+
+  - stage: Build
+    displayName: 'Build & Push Image'
+    dependsOn: Validate
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+    jobs:
+      - job: BuildImage
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+          - task: Docker@2
+            inputs:
+              containerRegistry: '$(containerRegistry)'
+              repository: 'chat/$(IMAGE_NAME)'
+              command: 'buildAndPush'
+              Dockerfile: '$(SERVICE_PATH)/deploy/Dockerfile'
+              buildContext: '.'
+              tags: |
+                $(Build.BuildId)
+                latest
+            displayName: 'Build & push $(IMAGE_NAME)'

--- a/dr-oplog-worker/deploy/docker-compose.yml
+++ b/dr-oplog-worker/deploy/docker-compose.yml
@@ -1,0 +1,42 @@
+name: dr-oplog-worker
+
+# Local dev only. Stands up a JetStream-enabled NATS, a backup (target) Mongo, and the DR applier.
+# The DR applier is self-contained: the producer-side connector uses updateLookup, so events carry
+# the full post-image and this service needs NO source Mongo. In prod the DR_OPLOG stream and the
+# cross-gateway routing that lands a remote origin site's publish here are ops/IaC-owned; this
+# compose sets BOOTSTRAP_STREAMS=true only to stand up a fresh NATS locally.
+
+services:
+  target-mongo:
+    image: mongo:7
+    networks:
+      - dr-oplog-local
+
+  nats:
+    image: nats:2.10-alpine
+    command: ["--jetstream", "--http_port", "8222"]
+    networks:
+      - dr-oplog-local
+
+  dr-oplog-worker:
+    build:
+      context: ../..
+      dockerfile: dr-oplog-worker/deploy/Dockerfile
+    depends_on:
+      target-mongo:
+        condition: service_started
+      nats:
+        condition: service_started
+    environment:
+      - SITE_ID=site-local
+      - NATS_URL=nats://nats:4222
+      - TARGET_MONGO_URI=mongodb://target-mongo:27017/
+      - TARGET_DB_PREFIX=chat_dr_
+      - DR_COLLECTIONS=rooms,subscriptions,room_members,thread_rooms,thread_subscriptions,users
+      - BOOTSTRAP_STREAMS=true
+    networks:
+      - dr-oplog-local
+
+networks:
+  dr-oplog-local:
+    driver: bridge

--- a/dr-oplog-worker/deploy/docker-compose.yml
+++ b/dr-oplog-worker/deploy/docker-compose.yml
@@ -2,7 +2,7 @@ name: dr-oplog-worker
 
 # Local dev only. Stands up a JetStream-enabled NATS, a backup (target) Mongo, and the DR applier.
 # The DR applier is self-contained: the producer-side connector uses updateLookup, so events carry
-# the full post-image and this service needs NO source Mongo. In prod the DR_OPLOG stream and the
+# the full post-image and this service needs NO source Mongo. In prod the DR-OPLOG stream and the
 # cross-gateway routing that lands a remote origin site's publish here are ops/IaC-owned; this
 # compose sets BOOTSTRAP_STREAMS=true only to stand up a fresh NATS locally.
 

--- a/dr-oplog-worker/event.go
+++ b/dr-oplog-worker/event.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/hmchangw/chat/pkg/migration"
+)
+
+// oplogEvent is the subset of the connector's OplogEvent wire shape this applier needs.
+// fullDocument/documentKey are relaxed extended JSON (the connector's encoding). The DR feed
+// opens its change stream with updateLookup, so fullDocument is present for insert/replace/update
+// (absent only for delete) — this applier never re-reads the origin Mongo.
+type oplogEvent struct {
+	EventID      string          `json:"eventId"`
+	Op           string          `json:"op"`
+	Collection   string          `json:"coll"`
+	DocumentKey  json.RawMessage `json:"documentKey"`
+	FullDocument json.RawMessage `json:"fullDocument"`
+}
+
+// documentID extracts the _id value from a documentKey as its native BSON type (string, ObjectID,
+// int, …) — NOT forced to string, since the operational collections key by different id types.
+// Returns migration.ErrPoison when the payload is malformed or has no _id.
+func documentID(raw json.RawMessage) (any, error) {
+	var d bson.D
+	if err := bson.UnmarshalExtJSON(raw, false, &d); err != nil {
+		return nil, fmt.Errorf("%w: bad documentKey: %v", migration.ErrPoison, err) //nolint:errorlint // single-%w sentinel wrap; decode err is informational
+	}
+	for _, e := range d {
+		if e.Key == "_id" {
+			return e.Value, nil
+		}
+	}
+	return nil, fmt.Errorf("%w: documentKey has no _id", migration.ErrPoison)
+}
+
+// decodeExtJSONDoc decodes a relaxed-extJSON document into an opaque, type-preserving bson.D.
+func decodeExtJSONDoc(raw json.RawMessage) (bson.D, error) {
+	var d bson.D
+	if err := bson.UnmarshalExtJSON(raw, false, &d); err != nil {
+		return nil, fmt.Errorf("%w: decode full document: %v", migration.ErrPoison, err) //nolint:errorlint // single-%w sentinel wrap; decode err is informational
+	}
+	return d, nil
+}

--- a/dr-oplog-worker/handler.go
+++ b/dr-oplog-worker/handler.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/hmchangw/chat/pkg/migration"
+)
+
+// handler applies one decoded DR oplog event to the backup Mongo. It is self-contained: every
+// insert/replace/update carries the full post-image (the connector uses updateLookup), so there
+// is no source-Mongo re-read and no cross-gateway dependency on the origin site.
+type handler struct {
+	collections map[string]struct{} // watched DR collections (defense-in-depth vs the subject filter)
+	target      targetStore
+	metrics     *metrics // nil-safe
+}
+
+// handle maps one event to a verbatim target write. nil = ack+count; ErrSkipped =
+// ack-without-count; ErrPoison => Term; any other error => Nak (transient).
+//
+//nolint:gocritic // ev passed by value: one per message off the consume loop, off the hot path.
+func (h *handler) handle(ctx context.Context, ev oplogEvent) error {
+	if _, ok := h.collections[ev.Collection]; !ok {
+		// The consumer's subject filter should prevent this; skip defensively without a write.
+		h.metrics.onSkipped(ctx, "other_collection")
+		return migration.ErrSkipped
+	}
+
+	id, err := documentID(ev.DocumentKey)
+	if err != nil {
+		return err // poison
+	}
+
+	switch ev.Op {
+	case "delete":
+		if derr := h.target.DeleteByID(ctx, ev.Collection, id); derr != nil {
+			return fmt.Errorf("delete %s: %w", ev.Collection, derr)
+		}
+		h.metrics.onWrite(ctx, ev.Collection, "delete")
+		return nil
+	case "insert", "replace", "update":
+		return h.upsert(ctx, ev, id)
+	default:
+		// Collection-level or unrecognized op (drop/rename/invalidate) — nothing to write.
+		h.metrics.onSkipped(ctx, "unknown_op")
+		return migration.ErrSkipped
+	}
+}
+
+// upsert decodes the inline full document and writes it verbatim by _id. A missing fullDocument on
+// a non-delete op can never succeed here (no source to recover from), so it poisons.
+//
+//nolint:gocritic // ev passed by value to mirror handle's signature; off the hot path.
+func (h *handler) upsert(ctx context.Context, ev oplogEvent, id any) error {
+	// Absent (omitted) or an explicit JSON null both mean "no post-image" — either can never
+	// succeed on a self-contained applier, so poison rather than upsert an empty/garbage doc.
+	if len(ev.FullDocument) == 0 || bytes.Equal(bytes.TrimSpace(ev.FullDocument), []byte("null")) {
+		return fmt.Errorf("%w: %s without fullDocument (DR feed requires updateLookup)", migration.ErrPoison, ev.Op)
+	}
+	doc, err := decodeExtJSONDoc(ev.FullDocument)
+	if err != nil {
+		return err // poison
+	}
+	if derr := h.target.UpsertByID(ctx, ev.Collection, id, doc); derr != nil {
+		return fmt.Errorf("upsert %s: %w", ev.Collection, derr)
+	}
+	h.metrics.onWrite(ctx, ev.Collection, "upsert")
+	return nil
+}

--- a/dr-oplog-worker/handler_test.go
+++ b/dr-oplog-worker/handler_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/hmchangw/chat/pkg/migration"
+)
+
+// fakeTarget records upserts/deletes.
+type fakeTarget struct {
+	upserts   []writeCall
+	deletes   []writeCall
+	upsertErr error
+	deleteErr error
+}
+
+type writeCall struct {
+	collection string
+	id         any
+	doc        bson.D
+}
+
+func (f *fakeTarget) UpsertByID(_ context.Context, collection string, id any, doc bson.D) error {
+	if f.upsertErr != nil {
+		return f.upsertErr
+	}
+	f.upserts = append(f.upserts, writeCall{collection, id, doc})
+	return nil
+}
+
+func (f *fakeTarget) DeleteByID(_ context.Context, collection string, id any) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	f.deletes = append(f.deletes, writeCall{collection: collection, id: id})
+	return nil
+}
+
+const testColl = "rooms"
+
+func newTestHandler(target targetStore) *handler {
+	return &handler{
+		collections: map[string]struct{}{testColl: {}},
+		target:      target,
+	}
+}
+
+func TestHandle_Insert_Upserts(t *testing.T) {
+	tgt := &fakeTarget{}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{
+		Op: "insert", Collection: testColl,
+		DocumentKey:  json.RawMessage(`{"_id":"r1"}`),
+		FullDocument: json.RawMessage(`{"_id":"r1","name":"general","crossSite":true}`),
+	}
+	require.NoError(t, h.handle(context.Background(), ev))
+	require.Len(t, tgt.upserts, 1)
+	assert.Equal(t, testColl, tgt.upserts[0].collection)
+	assert.Equal(t, "r1", tgt.upserts[0].id)
+	assert.Empty(t, tgt.deletes)
+}
+
+func TestHandle_Replace_Upserts(t *testing.T) {
+	tgt := &fakeTarget{}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{
+		Op: "replace", Collection: testColl,
+		DocumentKey:  json.RawMessage(`{"_id":"r1"}`),
+		FullDocument: json.RawMessage(`{"_id":"r1","name":"renamed"}`),
+	}
+	require.NoError(t, h.handle(context.Background(), ev))
+	require.Len(t, tgt.upserts, 1)
+}
+
+// The DR feed uses updateLookup, so update events carry the full post-image inline — the applier
+// upserts directly from fullDocument and never reads back to the origin site's Mongo.
+func TestHandle_Update_UpsertsFromFullDocument_NoLookup(t *testing.T) {
+	tgt := &fakeTarget{}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{
+		Op: "update", Collection: testColl,
+		DocumentKey:  json.RawMessage(`{"_id":"r1"}`),
+		FullDocument: json.RawMessage(`{"_id":"r1","name":"updated","crossSite":false}`),
+	}
+	require.NoError(t, h.handle(context.Background(), ev))
+	require.Len(t, tgt.upserts, 1)
+	assert.Equal(t, "r1", tgt.upserts[0].id)
+}
+
+func TestHandle_Delete_DeletesByID(t *testing.T) {
+	tgt := &fakeTarget{}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{
+		Op: "delete", Collection: testColl,
+		DocumentKey: json.RawMessage(`{"_id":"r1"}`),
+	}
+	require.NoError(t, h.handle(context.Background(), ev))
+	require.Len(t, tgt.deletes, 1)
+	assert.Equal(t, "r1", tgt.deletes[0].id)
+	assert.Empty(t, tgt.upserts)
+}
+
+// A native (non-string) _id — e.g. an ObjectID — round-trips as its native BSON type. The DR
+// applier upserts/deletes by native id (no string source-lookup), so this is NOT poison.
+func TestHandle_NativeObjectID_Upserts(t *testing.T) {
+	tgt := &fakeTarget{}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{
+		Op: "insert", Collection: testColl,
+		DocumentKey:  json.RawMessage(`{"_id":{"$oid":"5f9b1c2d3e4a5b6c7d8e9f01"}}`),
+		FullDocument: json.RawMessage(`{"_id":{"$oid":"5f9b1c2d3e4a5b6c7d8e9f01"},"name":"x"}`),
+	}
+	require.NoError(t, h.handle(context.Background(), ev))
+	require.Len(t, tgt.upserts, 1)
+	assert.IsType(t, bson.ObjectID{}, tgt.upserts[0].id)
+}
+
+func TestHandle_OtherCollection_Skips(t *testing.T) {
+	tgt := &fakeTarget{}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{Op: "insert", Collection: "not_watched", DocumentKey: json.RawMessage(`{"_id":"r1"}`)}
+	err := h.handle(context.Background(), ev)
+	assert.ErrorIs(t, err, migration.ErrSkipped)
+}
+
+func TestHandle_UnknownOp_Skips(t *testing.T) {
+	tgt := &fakeTarget{}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{Op: "drop", Collection: testColl, DocumentKey: json.RawMessage(`{"_id":"r1"}`)}
+	err := h.handle(context.Background(), ev)
+	assert.ErrorIs(t, err, migration.ErrSkipped)
+	assert.Empty(t, tgt.upserts)
+	assert.Empty(t, tgt.deletes)
+}
+
+func TestHandle_BadDocumentKey_Poison(t *testing.T) {
+	tgt := &fakeTarget{}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{Op: "delete", Collection: testColl, DocumentKey: json.RawMessage(`{}`)}
+	err := h.handle(context.Background(), ev)
+	assert.ErrorIs(t, err, migration.ErrPoison)
+}
+
+// Self-contained contract: an insert/replace/update with no fullDocument can never succeed on a
+// DR applier (there is no source to recover from), so it poisons rather than Naks forever.
+func TestHandle_Insert_NoFullDocument_Poison(t *testing.T) {
+	tgt := &fakeTarget{}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{Op: "insert", Collection: testColl, DocumentKey: json.RawMessage(`{"_id":"r1"}`)}
+	err := h.handle(context.Background(), ev)
+	assert.ErrorIs(t, err, migration.ErrPoison)
+	assert.Empty(t, tgt.upserts)
+}
+
+func TestHandle_Update_NoFullDocument_Poison(t *testing.T) {
+	tgt := &fakeTarget{}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{Op: "update", Collection: testColl, DocumentKey: json.RawMessage(`{"_id":"r1"}`)}
+	err := h.handle(context.Background(), ev)
+	assert.ErrorIs(t, err, migration.ErrPoison)
+	assert.Empty(t, tgt.upserts)
+}
+
+// An explicit JSON null post-image (a producer that emits "fullDocument":null rather than omitting
+// it) is treated the same as absent — poison, never an empty-doc upsert.
+func TestHandle_ExplicitNullFullDocument_Poison(t *testing.T) {
+	tgt := &fakeTarget{}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{
+		Op: "update", Collection: testColl,
+		DocumentKey:  json.RawMessage(`{"_id":"r1"}`),
+		FullDocument: json.RawMessage(`null`),
+	}
+	err := h.handle(context.Background(), ev)
+	assert.ErrorIs(t, err, migration.ErrPoison)
+	assert.Empty(t, tgt.upserts)
+}
+
+func TestHandle_BadFullDocument_Poison(t *testing.T) {
+	tgt := &fakeTarget{}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{
+		Op: "insert", Collection: testColl,
+		DocumentKey:  json.RawMessage(`{"_id":"r1"}`),
+		FullDocument: json.RawMessage(`{not json`),
+	}
+	err := h.handle(context.Background(), ev)
+	assert.ErrorIs(t, err, migration.ErrPoison)
+}
+
+func TestHandle_UpsertTargetError_Nak(t *testing.T) {
+	tgt := &fakeTarget{upsertErr: errors.New("mongo down")}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{
+		Op: "insert", Collection: testColl,
+		DocumentKey:  json.RawMessage(`{"_id":"r1"}`),
+		FullDocument: json.RawMessage(`{"_id":"r1","name":"x"}`),
+	}
+	err := h.handle(context.Background(), ev)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, migration.ErrPoison)
+	assert.NotErrorIs(t, err, migration.ErrSkipped)
+}
+
+func TestHandle_DeleteTargetError_Nak(t *testing.T) {
+	tgt := &fakeTarget{deleteErr: errors.New("mongo down")}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{Op: "delete", Collection: testColl, DocumentKey: json.RawMessage(`{"_id":"r1"}`)}
+	err := h.handle(context.Background(), ev)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, migration.ErrPoison)
+	assert.NotErrorIs(t, err, migration.ErrSkipped)
+}

--- a/dr-oplog-worker/integration_test.go
+++ b/dr-oplog-worker/integration_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/hmchangw/chat/pkg/testutil"
+)
+
+func TestMongoTargetStore_UpsertAndDelete(t *testing.T) {
+	db := testutil.MongoDB(t, "droplog")
+	store := NewMongoTargetStore(db)
+	ctx := context.Background()
+	const coll = "rooms"
+
+	require.NoError(t, store.UpsertByID(ctx, coll, "r1", bson.D{{Key: "_id", Value: "r1"}, {Key: "name", Value: "general"}}))
+	var got bson.M
+	require.NoError(t, db.Collection(coll).FindOne(ctx, bson.M{"_id": "r1"}).Decode(&got))
+	assert.Equal(t, "general", got["name"])
+
+	// Idempotent re-upsert (redelivery) with new content — one doc, replaced.
+	require.NoError(t, store.UpsertByID(ctx, coll, "r1", bson.D{{Key: "_id", Value: "r1"}, {Key: "name", Value: "renamed"}}))
+	n, err := db.Collection(coll).CountDocuments(ctx, bson.M{"_id": "r1"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+	require.NoError(t, db.Collection(coll).FindOne(ctx, bson.M{"_id": "r1"}).Decode(&got))
+	assert.Equal(t, "renamed", got["name"])
+
+	require.NoError(t, store.DeleteByID(ctx, coll, "r1"))
+	n, err = db.Collection(coll).CountDocuments(ctx, bson.M{"_id": "r1"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+
+	// Delete of a missing row is a no-op, not an error.
+	require.NoError(t, store.DeleteByID(ctx, coll, "ghost"))
+}
+
+func TestHandle_EndToEnd_ThroughStore(t *testing.T) {
+	db := testutil.MongoDB(t, "droplog-e2e")
+	h := &handler{
+		collections: map[string]struct{}{"rooms": {}},
+		target:      NewMongoTargetStore(db),
+	}
+	ctx := context.Background()
+	ev := oplogEvent{Op: "insert", Collection: "rooms",
+		DocumentKey:  []byte(`{"_id":"r9"}`),
+		FullDocument: []byte(`{"_id":"r9","name":"neo"}`)}
+	require.NoError(t, h.handle(ctx, ev))
+	var got bson.M
+	require.NoError(t, db.Collection("rooms").FindOne(ctx, bson.M{"_id": "r9"}).Decode(&got))
+	assert.Equal(t, "neo", got["name"])
+}
+
+// The DR feed uses updateLookup: update events carry the full post-image and upsert directly,
+// with no source-Mongo re-read. Verify verbatim replacement lands in the backup.
+func TestHandle_Update_EndToEnd_SelfContained(t *testing.T) {
+	db := testutil.MongoDB(t, "droplog-update")
+	h := &handler{
+		collections: map[string]struct{}{"subscriptions": {}},
+		target:      NewMongoTargetStore(db),
+	}
+	ctx := context.Background()
+	require.NoError(t, h.handle(ctx, oplogEvent{Op: "insert", Collection: "subscriptions",
+		DocumentKey: []byte(`{"_id":"s1"}`), FullDocument: []byte(`{"_id":"s1","unread":3}`)}))
+	require.NoError(t, h.handle(ctx, oplogEvent{Op: "update", Collection: "subscriptions",
+		DocumentKey: []byte(`{"_id":"s1"}`), FullDocument: []byte(`{"_id":"s1","unread":0}`)}))
+	var got bson.M
+	require.NoError(t, db.Collection("subscriptions").FindOne(ctx, bson.M{"_id": "s1"}).Decode(&got))
+	assert.EqualValues(t, 0, got["unread"])
+}
+
+// The room's CrossSite locality flag must survive the DR feed verbatim (spec §7 / design §4.1) —
+// the backup's broadcast path depends on it.
+func TestHandle_CrossSiteFlag_RoundTrips(t *testing.T) {
+	db := testutil.MongoDB(t, "droplog-crosssite")
+	h := &handler{
+		collections: map[string]struct{}{"rooms": {}},
+		target:      NewMongoTargetStore(db),
+	}
+	ctx := context.Background()
+	require.NoError(t, h.handle(ctx, oplogEvent{Op: "insert", Collection: "rooms",
+		DocumentKey: []byte(`{"_id":"r1"}`), FullDocument: []byte(`{"_id":"r1","name":"fed","crossSite":true}`)}))
+	var got bson.M
+	require.NoError(t, db.Collection("rooms").FindOne(ctx, bson.M{"_id": "r1"}).Decode(&got))
+	assert.Equal(t, true, got["crossSite"])
+}
+
+func TestHandle_Delete_EndToEnd(t *testing.T) {
+	db := testutil.MongoDB(t, "droplog-delete")
+	h := &handler{
+		collections: map[string]struct{}{"room_members": {}},
+		target:      NewMongoTargetStore(db),
+	}
+	ctx := context.Background()
+	require.NoError(t, h.handle(ctx, oplogEvent{Op: "insert", Collection: "room_members",
+		DocumentKey: []byte(`{"_id":"m1"}`), FullDocument: []byte(`{"_id":"m1","role":"member"}`)}))
+	n, err := db.Collection("room_members").CountDocuments(ctx, bson.M{"_id": "m1"})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+
+	require.NoError(t, h.handle(ctx, oplogEvent{Op: "delete", Collection: "room_members", DocumentKey: []byte(`{"_id":"m1"}`)}))
+	n, err = db.Collection("room_members").CountDocuments(ctx, bson.M{"_id": "m1"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+}

--- a/dr-oplog-worker/main.go
+++ b/dr-oplog-worker/main.go
@@ -171,7 +171,7 @@ func processOne(ctx context.Context, h *handler, m jetstream.Msg, mtr *metrics, 
 	}
 }
 
-// streamWaitTimeout bounds how long startup waits for the DR_OPLOG stream to exist.
+// streamWaitTimeout bounds how long startup waits for the DR-OPLOG stream to exist.
 const streamWaitTimeout = 60 * time.Second
 
 //nolint:gocritic // hugeParam: cfg passed by value to match jetstream.CreateOrUpdateConsumer's signature.
@@ -185,7 +185,7 @@ func createConsumerWithRetry(ctx context.Context, js o11ynats.JetStream, streamN
 		if !errors.Is(err, jetstream.ErrStreamNotFound) || time.Now().After(deadline) {
 			return nil, err
 		}
-		slog.Warn("waiting for DR_OPLOG stream to exist", "stream", streamName)
+		slog.Warn("waiting for DR-OPLOG stream to exist", "stream", streamName)
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()

--- a/dr-oplog-worker/main.go
+++ b/dr-oplog-worker/main.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+
+	"github.com/hmchangw/chat/pkg/health"
+	"github.com/hmchangw/chat/pkg/migration"
+	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/pkg/natsutil"
+	"github.com/hmchangw/chat/pkg/obs"
+	"github.com/hmchangw/chat/pkg/shutdown"
+	"github.com/hmchangw/chat/pkg/stream"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+func main() {
+	cfg, err := parseConfig()
+	if err != nil {
+		slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
+		slog.Error("parse config", "error", err)
+		os.Exit(1)
+	}
+	ctx := context.Background()
+
+	sdk, obsShutdown, err := obs.Init(ctx)
+	if err != nil {
+		slog.Error("init observability failed", "error", err)
+		os.Exit(1)
+	}
+	m, err := newMetrics()
+	if err != nil {
+		slog.Error("init metrics failed", "error", err)
+		os.Exit(1)
+	}
+
+	// Bind synchronously so a port conflict fails startup loudly. Metrics are
+	// owned by the o11y SDK's Prometheus endpoint; this is health-only.
+	healthStop, err := health.Serve(cfg.HealthAddr, 5*time.Second)
+	if err != nil {
+		slog.Error("health server failed to start", "addr", cfg.HealthAddr, "error", err)
+		os.Exit(1)
+	}
+
+	// The DR applier is self-contained (updateLookup on the producer) — it connects to the backup
+	// (target) Mongo only, never back to the origin site's Mongo.
+	targetClient, err := mongoutil.Connect(ctx, cfg.TargetMongoURI, cfg.TargetUsername, cfg.TargetPassword, mongoutil.WithObservability(sdk))
+	if err != nil {
+		slog.Error("target mongo connect failed", "error", err)
+		os.Exit(1)
+	}
+
+	collections := make(map[string]struct{}, len(cfg.DRCollections))
+	filterSubjects := make([]string, 0, len(cfg.DRCollections))
+	for _, coll := range cfg.DRCollections {
+		collections[coll] = struct{}{}
+		filterSubjects = append(filterSubjects, subject.DROplog(cfg.SiteID, coll, "*"))
+	}
+
+	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)
+	if err != nil {
+		slog.Error("nats connect failed", "error", err)
+		mongoutil.Disconnect(ctx, targetClient)
+		os.Exit(1)
+	}
+	js, err := nc.JetStream()
+	if err != nil {
+		slog.Error("jetstream init failed", "error", err)
+		_ = nc.Drain()
+		mongoutil.Disconnect(ctx, targetClient)
+		os.Exit(1)
+	}
+
+	if err := bootstrapStreams(ctx, js, cfg.SiteID, cfg.Bootstrap.Enabled); err != nil {
+		slog.Error("bootstrap streams failed", "error", err)
+		_ = nc.Drain()
+		mongoutil.Disconnect(ctx, targetClient)
+		os.Exit(1)
+	}
+
+	h := &handler{
+		collections: collections,
+		target:      NewMongoTargetStore(targetClient.Database(cfg.TargetDB())),
+		metrics:     m,
+	}
+
+	streamName := stream.DROplog(cfg.SiteID).Name
+	cons, err := createConsumerWithRetry(ctx, js, streamName, jetstream.ConsumerConfig{
+		Durable:        cfg.ConsumerDurable,
+		AckPolicy:      jetstream.AckExplicitPolicy,
+		DeliverPolicy:  jetstream.DeliverAllPolicy,
+		MaxDeliver:     cfg.MaxDeliver,
+		FilterSubjects: filterSubjects,
+	})
+	if err != nil {
+		slog.Error("create consumer failed", "stream", streamName, "error", err)
+		_ = nc.Drain()
+		mongoutil.Disconnect(ctx, targetClient)
+		os.Exit(1)
+	}
+
+	cc, err := cons.Consume(ctx, func(msgCtx context.Context, msg jetstream.Msg) {
+		processOne(msgCtx, h, msg, m, cfg.MaxDeliver)
+	})
+	if err != nil {
+		slog.Error("consume failed", "stream", streamName, "error", err)
+		_ = nc.Drain()
+		mongoutil.Disconnect(ctx, targetClient)
+		os.Exit(1)
+	}
+
+	slog.Info("dr-oplog-worker started", "site", cfg.SiteID, "stream", streamName,
+		"targetDB", cfg.TargetDB(), "collections", cfg.DRCollections)
+
+	shutdown.Wait(ctx, 25*time.Second,
+		func(context.Context) error { cc.Stop(); return nil },
+		func(ctx context.Context) error { return healthStop(ctx) },
+		func(context.Context) error { return nc.Drain() },
+		func(ctx context.Context) error { mongoutil.Disconnect(ctx, targetClient); return nil },
+		func(ctx context.Context) error { return obsShutdown(ctx) },
+	)
+}
+
+// processOne decodes one event and maps its handler outcome to a JetStream disposition.
+func processOne(ctx context.Context, h *handler, m jetstream.Msg, mtr *metrics, maxDeliver int) {
+	ctx, reqID := natsutil.StampRequestID(ctx, m.Headers(), m.Subject())
+	dispose := func(action string, fn func() error) {
+		if derr := fn(); derr != nil {
+			slog.Error("jetstream disposition failed", "action", action, "error", derr, "request_id", reqID)
+		}
+	}
+	var ev oplogEvent
+	if err := json.Unmarshal(m.Data(), &ev); err != nil {
+		slog.Error("decode oplog event — term", "error", err, "request_id", reqID)
+		mtr.onTerm(ctx, "unknown", "unknown")
+		dispose("term", m.Term)
+		return
+	}
+	var numDelivered uint64
+	if meta, err := m.Metadata(); err == nil {
+		numDelivered = meta.NumDelivered
+	}
+	isFinal := migration.IsFinalDelivery(numDelivered, maxDeliver)
+	err := h.handle(ctx, ev)
+	switch migration.Classify(err, isFinal) {
+	case migration.ActionAck:
+		mtr.onProcessed(ctx, ev.Op, ev.Collection)
+		dispose("ack", m.Ack)
+	case migration.ActionTerm:
+		slog.Error("poison event — term (skipping)", "eventId", ev.EventID, "error", err, "request_id", reqID)
+		mtr.onTerm(ctx, ev.Op, ev.Collection)
+		dispose("term", m.Term)
+	case migration.ActionAckSkip:
+		dispose("ack", m.Ack)
+	case migration.ActionTermExhausted:
+		slog.Error("delivery limit reached — terming (dropping)", "eventId", ev.EventID, "op", ev.Op, "cap", maxDeliver, "error", err, "request_id", reqID)
+		mtr.onExhausted(ctx, ev.Op, ev.Collection)
+		dispose("term", m.Term)
+	default:
+		slog.Error("transient failure — nak", "eventId", ev.EventID, "error", err, "request_id", reqID)
+		mtr.onNak(ctx, ev.Op, ev.Collection)
+		dispose("nak", func() error { return m.NakWithDelay(2 * time.Second) })
+	}
+}
+
+// streamWaitTimeout bounds how long startup waits for the DR_OPLOG stream to exist.
+const streamWaitTimeout = 60 * time.Second
+
+//nolint:gocritic // hugeParam: cfg passed by value to match jetstream.CreateOrUpdateConsumer's signature.
+func createConsumerWithRetry(ctx context.Context, js o11ynats.JetStream, streamName string, cfg jetstream.ConsumerConfig) (o11ynats.Consumer, error) {
+	deadline := time.Now().Add(streamWaitTimeout)
+	for {
+		cons, err := js.CreateOrUpdateConsumer(ctx, streamName, cfg)
+		if err == nil {
+			return cons, nil
+		}
+		if !errors.Is(err, jetstream.ErrStreamNotFound) || time.Now().After(deadline) {
+			return nil, err
+		}
+		slog.Warn("waiting for DR_OPLOG stream to exist", "stream", streamName)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}

--- a/dr-oplog-worker/main_test.go
+++ b/dr-oplog-worker/main_test.go
@@ -1,0 +1,11 @@
+//go:build integration
+
+package main
+
+import (
+	"testing"
+
+	"github.com/hmchangw/chat/pkg/testutil"
+)
+
+func TestMain(m *testing.M) { testutil.RunTests(m) }

--- a/dr-oplog-worker/metrics.go
+++ b/dr-oplog-worker/metrics.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// metrics holds the service's instruments. Nil-safe (tests run without a meter).
+type metrics struct {
+	processed metric.Int64Counter
+	naks      metric.Int64Counter
+	terms     metric.Int64Counter
+	skipped   metric.Int64Counter
+	exhausted metric.Int64Counter
+	writes    metric.Int64Counter
+}
+
+func newMetrics() (*metrics, error) {
+	m := otel.Meter("dr-oplog-worker")
+	processed, err := m.Int64Counter("dr_oplog_worker_events_processed_total",
+		metric.WithDescription("DR oplog events handled and acked, by op+collection"))
+	if err != nil {
+		return nil, fmt.Errorf("processed counter: %w", err)
+	}
+	naks, err := m.Int64Counter("dr_oplog_worker_naks_total",
+		metric.WithDescription("transient failures naked for redelivery, by op+collection"))
+	if err != nil {
+		return nil, fmt.Errorf("naks counter: %w", err)
+	}
+	terms, err := m.Int64Counter("dr_oplog_worker_terms_total",
+		metric.WithDescription("poison/undecodable events termed, by op+collection"))
+	if err != nil {
+		return nil, fmt.Errorf("terms counter: %w", err)
+	}
+	skipped, err := m.Int64Counter("dr_oplog_worker_events_skipped_total",
+		metric.WithDescription("events deliberately skipped, by reason"))
+	if err != nil {
+		return nil, fmt.Errorf("skipped counter: %w", err)
+	}
+	exhausted, err := m.Int64Counter("dr_oplog_worker_exhausted_total",
+		metric.WithDescription("events termed after reaching MaxDeliver, by op+collection"))
+	if err != nil {
+		return nil, fmt.Errorf("exhausted counter: %w", err)
+	}
+	writes, err := m.Int64Counter("dr_oplog_worker_writes_total",
+		metric.WithDescription("backup writes, by collection+action (upsert/delete)"))
+	if err != nil {
+		return nil, fmt.Errorf("writes counter: %w", err)
+	}
+	return &metrics{processed: processed, naks: naks, terms: terms, skipped: skipped, exhausted: exhausted, writes: writes}, nil
+}
+
+func opCollAttr(op, collection string) metric.MeasurementOption {
+	return metric.WithAttributes(attribute.String("op", op), attribute.String("collection", collection))
+}
+
+func (m *metrics) onProcessed(ctx context.Context, op, collection string) {
+	if m == nil {
+		return
+	}
+	m.processed.Add(ctx, 1, opCollAttr(op, collection))
+}
+
+func (m *metrics) onNak(ctx context.Context, op, collection string) {
+	if m == nil {
+		return
+	}
+	m.naks.Add(ctx, 1, opCollAttr(op, collection))
+}
+
+func (m *metrics) onTerm(ctx context.Context, op, collection string) {
+	if m == nil {
+		return
+	}
+	m.terms.Add(ctx, 1, opCollAttr(op, collection))
+}
+
+func (m *metrics) onSkipped(ctx context.Context, reason string) {
+	if m == nil {
+		return
+	}
+	m.skipped.Add(ctx, 1, metric.WithAttributes(attribute.String("reason", reason)))
+}
+
+func (m *metrics) onExhausted(ctx context.Context, op, collection string) {
+	if m == nil {
+		return
+	}
+	m.exhausted.Add(ctx, 1, opCollAttr(op, collection))
+}
+
+func (m *metrics) onWrite(ctx context.Context, collection, action string) {
+	if m == nil {
+		return
+	}
+	m.writes.Add(ctx, 1, metric.WithAttributes(attribute.String("collection", collection), attribute.String("action", action)))
+}

--- a/dr-oplog-worker/metrics_test.go
+++ b/dr-oplog-worker/metrics_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestNewMetrics(t *testing.T) {
+	m, err := newMetrics()
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	m.onProcessed(context.Background(), "insert", "rooms")
+	m.onNak(context.Background(), "update", "rooms")
+	m.onTerm(context.Background(), "insert", "users")
+	m.onSkipped(context.Background(), "other_collection")
+	m.onExhausted(context.Background(), "update", "rooms")
+	m.onWrite(context.Background(), "rooms", "upsert")
+}
+
+func TestMetrics_NilSafe(t *testing.T) {
+	var m *metrics
+	require.NotPanics(t, func() {
+		m.onProcessed(context.Background(), "insert", "rooms")
+		m.onNak(context.Background(), "update", "rooms")
+		m.onTerm(context.Background(), "insert", "users")
+		m.onSkipped(context.Background(), "other_collection")
+		m.onExhausted(context.Background(), "update", "rooms")
+		m.onWrite(context.Background(), "rooms", "delete")
+	})
+}
+
+func TestMetrics_WriteCounterCarriesCollectionAndAction(t *testing.T) {
+	prev := otel.GetMeterProvider()
+	t.Cleanup(func() { otel.SetMeterProvider(prev) })
+	reader := sdkmetric.NewManualReader()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+
+	m, err := newMetrics()
+	require.NoError(t, err)
+	ctx := context.Background()
+	m.onWrite(ctx, "subscriptions", "delete")
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+
+	found := false
+	for _, sm := range rm.ScopeMetrics {
+		for _, md := range sm.Metrics {
+			if md.Name != "dr_oplog_worker_writes_total" {
+				continue
+			}
+			sum, ok := md.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			require.Len(t, sum.DataPoints, 1)
+			attrs := sum.DataPoints[0].Attributes
+			coll, _ := attrs.Value(attribute.Key("collection"))
+			action, _ := attrs.Value(attribute.Key("action"))
+			assert.Equal(t, "subscriptions", coll.AsString())
+			assert.Equal(t, "delete", action.AsString())
+			found = true
+		}
+	}
+	assert.True(t, found, "writes counter recorded")
+}

--- a/dr-oplog-worker/processone_test.go
+++ b/dr-oplog-worker/processone_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeJSMsg is a minimal jetstream.Msg for disposition testing — embeds the interface (unused
+// methods panic) and overrides only Data/Headers/Subject/Metadata and the three ack flavors.
+type fakeJSMsg struct {
+	jetstream.Msg
+	data         []byte
+	numDelivered uint64
+	acked        bool
+	termed       bool
+	nakDelays    []time.Duration
+}
+
+func (m *fakeJSMsg) Data() []byte         { return m.data }
+func (m *fakeJSMsg) Headers() nats.Header { return nil }
+func (m *fakeJSMsg) Subject() string      { return "chat.dr.oplog.site1.rooms.insert" }
+func (m *fakeJSMsg) Metadata() (*jetstream.MsgMetadata, error) {
+	return &jetstream.MsgMetadata{NumDelivered: m.numDelivered}, nil
+}
+func (m *fakeJSMsg) Ack() error  { m.acked = true; return nil }
+func (m *fakeJSMsg) Term() error { m.termed = true; return nil }
+func (m *fakeJSMsg) NakWithDelay(d time.Duration) error {
+	m.nakDelays = append(m.nakDelays, d)
+	return nil
+}
+
+func TestProcessOne_Insert_Acks(t *testing.T) {
+	tgt := &fakeTarget{}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{Op: "insert", Collection: testColl,
+		DocumentKey: json.RawMessage(`{"_id":"r1"}`), FullDocument: json.RawMessage(`{"_id":"r1"}`)}
+	data, _ := json.Marshal(ev)
+	m := &fakeJSMsg{data: data}
+	processOne(context.Background(), h, m, nil, 1000)
+	require.Len(t, tgt.upserts, 1)
+	assert.True(t, m.acked)
+	assert.False(t, m.termed)
+}
+
+func TestProcessOne_BadJSON_Terms(t *testing.T) {
+	tgt := &fakeTarget{}
+	h := newTestHandler(tgt)
+	m := &fakeJSMsg{data: []byte(`{bad`)}
+	processOne(context.Background(), h, m, nil, 1000)
+	assert.True(t, m.termed)
+	assert.False(t, m.acked)
+}
+
+func TestProcessOne_Poison_Terms(t *testing.T) {
+	tgt := &fakeTarget{}
+	h := newTestHandler(tgt)
+	// insert without fullDocument → poison on a self-contained applier.
+	ev := oplogEvent{Op: "insert", Collection: testColl, DocumentKey: json.RawMessage(`{"_id":"r1"}`)}
+	data, _ := json.Marshal(ev)
+	m := &fakeJSMsg{data: data}
+	processOne(context.Background(), h, m, nil, 1000)
+	assert.True(t, m.termed)
+	assert.False(t, m.acked)
+}
+
+func TestProcessOne_Skip_Acks(t *testing.T) {
+	tgt := &fakeTarget{}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{Op: "insert", Collection: "not_watched", DocumentKey: json.RawMessage(`{"_id":"r1"}`)}
+	data, _ := json.Marshal(ev)
+	m := &fakeJSMsg{data: data}
+	processOne(context.Background(), h, m, nil, 1000)
+	assert.True(t, m.acked)
+	assert.False(t, m.termed)
+}
+
+func TestProcessOne_TargetError_Naks(t *testing.T) {
+	tgt := &fakeTarget{deleteErr: errors.New("mongo down")}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{Op: "delete", Collection: testColl, DocumentKey: json.RawMessage(`{"_id":"r1"}`)}
+	data, _ := json.Marshal(ev)
+	m := &fakeJSMsg{data: data}
+	processOne(context.Background(), h, m, nil, 1000)
+	require.Len(t, m.nakDelays, 1)
+	assert.Equal(t, 2*time.Second, m.nakDelays[0])
+}
+
+func TestProcessOne_TargetError_Exhausted_Terms(t *testing.T) {
+	tgt := &fakeTarget{deleteErr: errors.New("mongo down")}
+	h := newTestHandler(tgt)
+	ev := oplogEvent{Op: "delete", Collection: testColl, DocumentKey: json.RawMessage(`{"_id":"r1"}`)}
+	data, _ := json.Marshal(ev)
+	// numDelivered == maxDeliver → final delivery, transient failure escalates to Term.
+	m := &fakeJSMsg{data: data, numDelivered: 1000}
+	processOne(context.Background(), h, m, nil, 1000)
+	assert.True(t, m.termed)
+	assert.Empty(t, m.nakDelays)
+}

--- a/dr-oplog-worker/store.go
+++ b/dr-oplog-worker/store.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// targetStore is the verbatim per-collection write surface on the backup Mongo, keyed by native
+// _id. Defined in the consumer (per CLAUDE.md) and hand-faked in tests, so no mockgen is needed.
+type targetStore interface {
+	UpsertByID(ctx context.Context, collection string, id any, doc bson.D) error
+	DeleteByID(ctx context.Context, collection string, id any) error
+}

--- a/dr-oplog-worker/store_mongo.go
+++ b/dr-oplog-worker/store_mongo.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+// mongoTargetStore writes verbatim docs into the backup database's collections, keyed by _id.
+// The database is the per-origin-site namespace (chat_dr_{siteID}); collections are resolved by name.
+type mongoTargetStore struct {
+	db *mongo.Database
+}
+
+var _ targetStore = (*mongoTargetStore)(nil)
+
+// NewMongoTargetStore binds the per-site backup database; collections are resolved per-call by name.
+func NewMongoTargetStore(db *mongo.Database) *mongoTargetStore {
+	return &mongoTargetStore{db: db}
+}
+
+// UpsertByID replaces (or inserts) the doc keyed by _id. Idempotent under redelivery.
+func (s *mongoTargetStore) UpsertByID(ctx context.Context, collection string, id any, doc bson.D) error {
+	_, err := s.db.Collection(collection).ReplaceOne(ctx,
+		bson.D{{Key: "_id", Value: id}}, doc, options.Replace().SetUpsert(true))
+	if err != nil {
+		return fmt.Errorf("upsert into %s: %w", collection, err)
+	}
+	return nil
+}
+
+// DeleteByID removes the doc keyed by _id. A missing row deletes nothing and is not an error.
+func (s *mongoTargetStore) DeleteByID(ctx context.Context, collection string, id any) error {
+	if _, err := s.db.Collection(collection).DeleteOne(ctx, bson.D{{Key: "_id", Value: id}}); err != nil {
+		return fmt.Errorf("delete from %s: %w", collection, err)
+	}
+	return nil
+}

--- a/pkg/stream/dr_oplog_test.go
+++ b/pkg/stream/dr_oplog_test.go
@@ -1,0 +1,15 @@
+package stream_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hmchangw/chat/pkg/stream"
+)
+
+func TestDROplog(t *testing.T) {
+	cfg := stream.DROplog("site1")
+	assert.Equal(t, "DR-OPLOG-site1", cfg.Name)
+	assert.Equal(t, []string{"chat.dr.oplog.site1.>"}, cfg.Subjects)
+}

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -81,6 +81,16 @@ func Outbox(siteID string) Config {
 	}
 }
 
+// DROplog returns DR-OPLOG-{siteID}: disaster-recovery CDC events shipped from an origin site's
+// operational Mongo to the shared backup. The backup sources this per origin site; ops/IaC owns
+// the cross-gateway routing that lands a remote publish here (not any service's bootstrap).
+func DROplog(siteID string) Config {
+	return Config{
+		Name:     fmt.Sprintf("DR-OPLOG-%s", siteID),
+		Subjects: []string{subject.DROplogWildcard(siteID)},
+	}
+}
+
 // MigrationOplog returns MIGRATION-OPLOG-{siteID}: raw CDC events from legacy source Mongo.
 func MigrationOplog(siteID string) Config {
 	return Config{

--- a/pkg/subject/dr.go
+++ b/pkg/subject/dr.go
@@ -1,0 +1,17 @@
+package subject
+
+import "fmt"
+
+// DROplog builds the subject for one disaster-recovery CDC event shipped from an origin site
+// to the shared backup: chat.dr.oplog.{siteID}.{collection}.{op}. siteID is the origin site
+// whose operational Mongo was tailed; collection is the new-stack collection name (e.g. rooms);
+// op is insert|update|replace|delete.
+func DROplog(siteID, collection, op string) string {
+	return fmt.Sprintf("chat.dr.oplog.%s.%s.%s", siteID, collection, op)
+}
+
+// DROplogWildcard matches every DR oplog event for an origin site — the DR_OPLOG_{siteID}
+// stream's subjects, and the pattern the backup sources over the supercluster gateway.
+func DROplogWildcard(siteID string) string {
+	return fmt.Sprintf("chat.dr.oplog.%s.>", siteID)
+}

--- a/pkg/subject/dr.go
+++ b/pkg/subject/dr.go
@@ -10,7 +10,7 @@ func DROplog(siteID, collection, op string) string {
 	return fmt.Sprintf("chat.dr.oplog.%s.%s.%s", siteID, collection, op)
 }
 
-// DROplogWildcard matches every DR oplog event for an origin site — the DR_OPLOG_{siteID}
+// DROplogWildcard matches every DR oplog event for an origin site — the DR-OPLOG-{siteID}
 // stream's subjects, and the pattern the backup sources over the supercluster gateway.
 func DROplogWildcard(siteID string) string {
 	return fmt.Sprintf("chat.dr.oplog.%s.>", siteID)

--- a/pkg/subject/dr_test.go
+++ b/pkg/subject/dr_test.go
@@ -1,0 +1,22 @@
+package subject_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+func TestDROplog(t *testing.T) {
+	assert.Equal(t, "chat.dr.oplog.site1.rooms.insert",
+		subject.DROplog("site1", "rooms", "insert"))
+	assert.Equal(t, "chat.dr.oplog.site1.subscriptions.delete",
+		subject.DROplog("site1", "subscriptions", "delete"))
+	assert.Equal(t, "chat.dr.oplog.site2.room_members.update",
+		subject.DROplog("site2", "room_members", "update"))
+}
+
+func TestDROplogWildcard(t *testing.T) {
+	assert.Equal(t, "chat.dr.oplog.site1.>", subject.DROplogWildcard("site1"))
+}


### PR DESCRIPTION
**Status: 🚧 Draft — not ready to merge.** CI hasn't validated yet; scope is deliberately partial (see below).

## Summary
Establishes the cross-site failover ("lifeboat") program and implements its first functional slice — **SP1b**, the operational-state DR feed that keeps a shared warm backup continuously up to date with one origin site's rooms / subscriptions / members / roster.

## What's in this PR

**Design & planning** (`docs/superpowers/`)
- Governing design — shared warm backup ("lifeboat") architecture, data flow, failback, sizing.
- Program decomposition & roadmap (SP0–SP6).
- SP1a (message slice) and SP1b (operational slice) core specs.

**SP1b implementation** — single origin site → backup, operational state only:
- **`dr-oplog-worker`** (new service) — a self-contained applier that consumes `OplogEvent`s from `DR-OPLOG-{siteID}` and writes the lifeboat slice (`rooms`, `subscriptions`, `room_members`, `thread_rooms`, `thread_subscriptions`, `users`) verbatim into a per-site backup Mongo (`chat_dr_{siteID}`), keyed by native `_id`.
- **`oplog-connector` `MODE=dr` lane** — config-gated (default `migration` is byte-identical to before): opens the change stream with `updateLookup` so `update` events carry the full post-image inline, injects `subject.DROplog` to publish on `chat.dr.oplog.>`, and bootstraps/verifies `DR-OPLOG-{siteID}`.
- **`pkg/stream.DROplog` / `pkg/subject.DROplog`** — stream + subject builders.

## Key decisions
- **Mongo change-streams (oplog CDC), not the OUTBOX federation pattern** — DR needs the *whole* site's operational state, membership-independent (purely-local rooms included); `CrossSite` rides free as a whole-document copy; zero producer changes.
- **Self-contained feed via `updateLookup`** — the applier never reads back cross-region to the origin Mongo.
- **Per-origin-site database** (`chat_dr_{siteID}`) — clean isolation and a clean failback (SP5) boundary for separating backup-authored writes from origin-replicated ones.
- **Reuse over fork** — the applier reuses `oplog-direct-transfer`'s patterns (simpler: no source lookup); the producer *extends* the tested `oplog-connector` engine (config-gated) rather than duplicating checkpointing/watchers/backoff.

## Out of scope — each its own follow-up PR
SP1a (message slice → Cassandra), multi-site fan-out, SP2 (backup serving + identity), SP3 (routing), SP4 (health detection), SP5 (failback), SP6 (ops/IaC).

## Testing
- **Unit** (`-race`): business logic ~100% (applier handler, config, disposition, bootstrap, envelope/subject builders).
- **Integration** (`//go:build integration`, testcontainers): store + end-to-end incl. a `CrossSite` round-trip and a DR-mode `updateLookup` post-image assertion.
- `make lint` (full `./...`) → 0 issues; `gosec` clean; entire module builds (unit + integration-tagged).
- ⚠️ Integration tests and the 80% coverage floor run in **CI** — not executed locally (no Docker in the authoring environment).

## Notes
- Rebased onto latest `main`; adopted the repo-wide hyphenated stream-name convention (`DR-OPLOG-`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)