### PR TITLE
fix(broadcast-worker): badge new mentions added by a message edit

### DIFF
--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -301,6 +301,11 @@ func (h *Handler) handleUpdated(ctx context.Context, evt *model.MessageEvent) er
 		return fmt.Errorf("fetch room %s: %w", msg.RoomID, err)
 	}
 
+	if err := h.badgeNewlyMentionedAccounts(ctx, room.ID, &msg); err != nil {
+		slog.WarnContext(ctx, "badge new mentions on edit failed",
+			"error", err, "room_id", room.ID, "request_id", natsutil.RequestIDFromContext(ctx))
+	}
+
 	edit := buildEditRoomEvent(room, evt)
 	if room.Type == model.RoomTypeChannel && h.encrypt {
 		if err := h.encryptEditedContent(ctx, room.ID, &edit); err != nil {
@@ -308,6 +313,34 @@ func (h *Handler) handleUpdated(ctx context.Context, evt *model.MessageEvent) er
 		}
 	}
 	return h.publishMutation(ctx, room, model.RoomEventMessageEdited, msg.ID, &edit)
+}
+
+// badgeNewlyMentionedAccounts badges accounts an edit newly @-mentions (per
+// their subscription's current HasMention). Additive only: never clears a
+// badge for a removed mention, never re-badges an already-mentioned account.
+func (h *Handler) badgeNewlyMentionedAccounts(ctx context.Context, roomID string, msg *model.Message) error {
+	parsed := mention.Parse(msg.Content)
+	if len(parsed.Accounts) == 0 {
+		return nil
+	}
+	subs, err := h.store.ListSubscriptions(ctx, roomID)
+	if err != nil {
+		return fmt.Errorf("list subscriptions %s: %w", roomID, err)
+	}
+	alreadyMentioned := make(map[string]bool, len(subs))
+	for i := range subs {
+		alreadyMentioned[subs[i].User.Account] = subs[i].HasMention
+	}
+	newAccounts := make([]string, 0, len(parsed.Accounts))
+	for _, account := range parsed.Accounts {
+		if !alreadyMentioned[account] {
+			newAccounts = append(newAccounts, account)
+		}
+	}
+	if len(newAccounts) == 0 {
+		return nil
+	}
+	return h.store.SetSubscriptionMentions(ctx, roomID, newAccounts, *msg.EditedAt)
 }
 
 func (h *Handler) handleThreadUpdated(ctx context.Context, evt *model.MessageEvent) error {

--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -302,8 +302,7 @@ func (h *Handler) handleUpdated(ctx context.Context, evt *model.MessageEvent) er
 	}
 
 	if err := h.badgeNewlyMentionedAccounts(ctx, room.ID, &msg); err != nil {
-		slog.WarnContext(ctx, "badge new mentions on edit failed",
-			"error", err, "room_id", room.ID, "request_id", natsutil.RequestIDFromContext(ctx))
+		return fmt.Errorf("badge new mentions on edit %s: %w", room.ID, err)
 	}
 
 	edit := buildEditRoomEvent(room, evt)
@@ -315,32 +314,16 @@ func (h *Handler) handleUpdated(ctx context.Context, evt *model.MessageEvent) er
 	return h.publishMutation(ctx, room, model.RoomEventMessageEdited, msg.ID, &edit)
 }
 
-// badgeNewlyMentionedAccounts badges accounts an edit newly @-mentions (per
-// their subscription's current HasMention). Additive only: never clears a
-// badge for a removed mention, never re-badges an already-mentioned account.
+// badgeNewlyMentionedAccounts badges the accounts an edit @-mentions, mirroring
+// handleCreated. Additive only: SetSubscriptionMentions' filter skips
+// non-subscribers and accounts that have already read past the edit, so a
+// removed mention is never cleared and an already-read one is never re-flagged.
 func (h *Handler) badgeNewlyMentionedAccounts(ctx context.Context, roomID string, msg *model.Message) error {
 	parsed := mention.Parse(msg.Content)
 	if len(parsed.Accounts) == 0 {
 		return nil
 	}
-	subs, err := h.store.ListSubscriptions(ctx, roomID)
-	if err != nil {
-		return fmt.Errorf("list subscriptions %s: %w", roomID, err)
-	}
-	alreadyMentioned := make(map[string]bool, len(subs))
-	for i := range subs {
-		alreadyMentioned[subs[i].User.Account] = subs[i].HasMention
-	}
-	newAccounts := make([]string, 0, len(parsed.Accounts))
-	for _, account := range parsed.Accounts {
-		if !alreadyMentioned[account] {
-			newAccounts = append(newAccounts, account)
-		}
-	}
-	if len(newAccounts) == 0 {
-		return nil
-	}
-	return h.store.SetSubscriptionMentions(ctx, roomID, newAccounts, *msg.EditedAt)
+	return h.store.SetSubscriptionMentions(ctx, roomID, parsed.Accounts, *msg.EditedAt)
 }
 
 func (h *Handler) handleThreadUpdated(ctx context.Context, evt *model.MessageEvent) error {

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -950,41 +950,27 @@ func TestHandleUpdated_EncryptedChannel_EncryptsContent(t *testing.T) {
 func TestHandleUpdated_BadgesNewlyAddedMentions(t *testing.T) {
 	edited := time.Date(2026, 5, 14, 12, 5, 0, 0, time.UTC)
 
+	// The worker forwards every parsed mention to SetSubscriptionMentions; the
+	// additive / no-re-badge / skip-non-subscriber properties are enforced by the
+	// store filter (read-guard) and covered by TestSetSubscriptionMentions_ReadGuard_Integration.
 	tests := []struct {
 		name            string
 		content         string
-		subs            []model.Subscription
 		wantSetMentions []string // nil = SetSubscriptionMentions must not be called
 	}{
 		{
-			name:    "edit adds a new mention",
-			content: "hey @bob check this",
-			subs: []model.Subscription{
-				{User: model.SubscriptionUser{Account: "bob"}, RoomID: "room-1"},
-			},
+			name:            "edit adds a mention",
+			content:         "hey @bob check this",
 			wantSetMentions: []string{"bob"},
 		},
 		{
-			name:    "re-editing an already-mentioned account does not re-badge",
-			content: "hey @bob check this again",
-			subs: []model.Subscription{
-				{User: model.SubscriptionUser{Account: "bob"}, RoomID: "room-1", HasMention: true},
-			},
-			wantSetMentions: nil,
-		},
-		{
-			name:    "removing a mention badges nobody",
+			name:    "no mentions badges nobody",
 			content: "no mentions here anymore",
-			subs:    nil, // ListSubscriptions must not even be called
 		},
 		{
-			name:    "mixed: only the newly-added account is badged",
-			content: "hey @alice and @bob",
-			subs: []model.Subscription{
-				{User: model.SubscriptionUser{Account: "alice"}, RoomID: "room-1", HasMention: true},
-				{User: model.SubscriptionUser{Account: "bob"}, RoomID: "room-1"},
-			},
-			wantSetMentions: []string{"bob"},
+			name:            "every parsed mention is forwarded to the store",
+			content:         "hey @alice and @bob",
+			wantSetMentions: []string{"alice", "bob"},
 		},
 	}
 
@@ -997,9 +983,6 @@ func TestHandleUpdated_BadgesNewlyAddedMentions(t *testing.T) {
 			keyStore := NewMockRoomKeyProvider(ctrl)
 
 			store.EXPECT().GetRoom(gomock.Any(), "room-1").Return(testChannelRoom, nil)
-			if tc.subs != nil || tc.wantSetMentions != nil {
-				store.EXPECT().ListSubscriptions(gomock.Any(), "room-1").Return(tc.subs, nil)
-			}
 			if tc.wantSetMentions != nil {
 				store.EXPECT().SetSubscriptionMentions(gomock.Any(), "room-1", gomock.InAnyOrder(tc.wantSetMentions), edited).Return(nil)
 			}

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -947,6 +947,84 @@ func TestHandleUpdated_EncryptedChannel_EncryptsContent(t *testing.T) {
 	assert.Equal(t, "secret edit", plaintext)
 }
 
+func TestHandleUpdated_BadgesNewlyAddedMentions(t *testing.T) {
+	edited := time.Date(2026, 5, 14, 12, 5, 0, 0, time.UTC)
+
+	tests := []struct {
+		name            string
+		content         string
+		subs            []model.Subscription
+		wantSetMentions []string // nil = SetSubscriptionMentions must not be called
+	}{
+		{
+			name:    "edit adds a new mention",
+			content: "hey @bob check this",
+			subs: []model.Subscription{
+				{User: model.SubscriptionUser{Account: "bob"}, RoomID: "room-1"},
+			},
+			wantSetMentions: []string{"bob"},
+		},
+		{
+			name:    "re-editing an already-mentioned account does not re-badge",
+			content: "hey @bob check this again",
+			subs: []model.Subscription{
+				{User: model.SubscriptionUser{Account: "bob"}, RoomID: "room-1", HasMention: true},
+			},
+			wantSetMentions: nil,
+		},
+		{
+			name:    "removing a mention badges nobody",
+			content: "no mentions here anymore",
+			subs:    nil, // ListSubscriptions must not even be called
+		},
+		{
+			name:    "mixed: only the newly-added account is badged",
+			content: "hey @alice and @bob",
+			subs: []model.Subscription{
+				{User: model.SubscriptionUser{Account: "alice"}, RoomID: "room-1", HasMention: true},
+				{User: model.SubscriptionUser{Account: "bob"}, RoomID: "room-1"},
+			},
+			wantSetMentions: []string{"bob"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			store := NewMockStore(ctrl)
+			us := NewMockUserStore(ctrl)
+			pub := &mockPublisher{}
+			keyStore := NewMockRoomKeyProvider(ctrl)
+
+			store.EXPECT().GetRoom(gomock.Any(), "room-1").Return(testChannelRoom, nil)
+			if tc.subs != nil || tc.wantSetMentions != nil {
+				store.EXPECT().ListSubscriptions(gomock.Any(), "room-1").Return(tc.subs, nil)
+			}
+			if tc.wantSetMentions != nil {
+				store.EXPECT().SetSubscriptionMentions(gomock.Any(), "room-1", gomock.InAnyOrder(tc.wantSetMentions), edited).Return(nil)
+			}
+
+			evt := model.MessageEvent{
+				Event:     model.EventUpdated,
+				SiteID:    "site-a",
+				Timestamp: edited.UnixMilli(),
+				Message: model.Message{
+					ID: "msg-1", RoomID: "room-1", UserID: "u-alice", UserAccount: "alice",
+					Content:   tc.content,
+					CreatedAt: edited.Add(-time.Hour),
+					EditedAt:  &edited, UpdatedAt: &edited,
+				},
+			}
+			data, err := json.Marshal(&evt)
+			require.NoError(t, err)
+
+			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+			require.NoError(t, h.HandleMessage(context.Background(), data))
+			require.Len(t, pub.records, 1, "edit must still fan out regardless of mention badging")
+		})
+	}
+}
+
 func TestHandleUpdated_MissingEditedAt_ReturnsError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)


### PR DESCRIPTION
## Summary
Editing a message to add an `@mention` never set the mentioned user's mention badge — `handleUpdated` never parsed the edited content at all. Refs #229.

## What's included
- `broadcast-worker/handler.go`: `handleUpdated` now calls `badgeNewlyMentionedAccounts`, which parses the edited content's `@mention`s and badges only accounts not already mentioned (per their subscription's current `hasMention`). Additive only — never re-badges an already-mentioned account, never clears a badge for a removed mention.
- `broadcast-worker/handler_test.go`: `TestHandleUpdated_BadgesNewlyAddedMentions` — edit adds a new mention → badged; re-edit of an already-mentioned account → not re-badged; removing a mention → nobody badged; mixed new+already-mentioned → only the new account badged.

## Changes
- `broadcast-worker/handler.go` — new `badgeNewlyMentionedAccounts` helper, called from `handleUpdated`.

## Verification
- `go test ./broadcast-worker/...` — green.
- `golangci-lint` — clean.
- Reproduced the bug live on our dev stack before the fix (plain send → edit adds `@mention` → recipient's `hasMention` stayed `false`); see #229 for the repro detail.
