### PR TITLE
chore(history-service): replace deprecated reflect.Ptr alias

### DIFF
--- a/history-service/internal/cassrepo/utils.go
+++ b/history-service/internal/cassrepo/utils.go
@@ -124,7 +124,7 @@ func cqlFieldIndex(rt reflect.Type) map[string]int {
 // Separated from structScan so the column-matching logic is unit-testable without a live gocql iterator.
 func buildScanValues(dest any, colNames []string) (values []any, missingCol string, ok bool) {
 	rv := reflect.ValueOf(dest)
-	if rv.Kind() != reflect.Ptr || rv.Elem().Kind() != reflect.Struct {
+	if rv.Kind() != reflect.Pointer || rv.Elem().Kind() != reflect.Struct {
 		return nil, "", false
 	}
 	rv = rv.Elem()
@@ -146,7 +146,7 @@ func buildScanValues(dest any, colNames []string) (values []any, missingCol stri
 func structScan(iter *gocql.Iter, dest any) (bool, error) {
 	// Validate dest shape before touching the iterator (iter may be nil in tests).
 	rv := reflect.ValueOf(dest)
-	if rv.Kind() != reflect.Ptr || rv.Elem().Kind() != reflect.Struct {
+	if rv.Kind() != reflect.Pointer || rv.Elem().Kind() != reflect.Struct {
 		return false, nil
 	}
 


### PR DESCRIPTION
Two-line fix for the `reflect.Ptr` / `reflect.Pointer` deprecated-alias pair in `history-service/internal/cassrepo/utils.go`, flagged by `go vet` when golangci-lint is built with go1.26.

Pre-existing on `main`; surfaced while linting an unrelated feature branch. No behavior change (`reflect.Pointer` is the same constant).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated internal type handling to ensure pointer values are processed correctly during history data operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->