### PR TITLE
fix(docker-local): single-node mongo replica set + host directConnection URIs

### DIFF
--- a/docker-local/compose.deps.yaml
+++ b/docker-local/compose.deps.yaml
@@ -32,6 +32,13 @@ services:
     # tracks the same image testcontainers uses.
     image: mongo:8.2.9
     container_name: chat-local-mongodb
+    # Single-node replica set — transactions (admin-service password-change,
+    # deactivate, and the new permission-grant batch insert) require one; a
+    # standalone mongod rejects them outright. The member host below is the
+    # in-network service name "mongodb", so container-side clients need no
+    # config change; host-side tools (make seed, tools/jaeger/README.md) add
+    # ?directConnection=true instead of trying to resolve that name.
+    command: ["--replSet", "rs0", "--bind_ip_all"]
     ports:
       - "27017:27017"
     volumes:
@@ -39,11 +46,14 @@ services:
       # chat.hr_employee went stale. `make seed` owns that collection now.
       - mongo-data:/data/db
     healthcheck:
-      test: ["CMD-SHELL", "echo 'db.runCommand({ping:1}).ok' | mongosh --quiet | grep -q 1"]
+      test:
+        - CMD-SHELL
+        - >-
+          mongosh --quiet --eval
+          'try { rs.status().ok } catch (e) { rs.initiate({_id:"rs0",members:[{_id:0,host:"mongodb:27017"}]}) }'
       interval: 5s
-      timeout: 5s
-      retries: 10
-      start_period: 10s
+      timeout: 10s
+      retries: 15
     networks:
       - chat-local
 

--- a/docker-local/compose.deps.yaml
+++ b/docker-local/compose.deps.yaml
@@ -46,11 +46,13 @@ services:
       # chat.hr_employee went stale. `make seed` owns that collection now.
       - mongo-data:/data/db
     healthcheck:
+      # rs.initiate() returns before the election finishes, so the initiating
+      # probe deliberately fails; healthy only once the member is PRIMARY.
       test:
         - CMD-SHELL
         - >-
           mongosh --quiet --eval
-          'try { rs.status().ok } catch (e) { rs.initiate({_id:"rs0",members:[{_id:0,host:"mongodb:27017"}]}) }'
+          'try { if (rs.status().myState !== 1) quit(1) } catch (e) { rs.initiate({_id:"rs0",members:[{_id:0,host:"mongodb:27017"}]}); quit(1) }'
       interval: 5s
       timeout: 10s
       retries: 15

--- a/tools/jaeger/README.md
+++ b/tools/jaeger/README.md
@@ -17,7 +17,7 @@ Jaeger UI: http://localhost:16686
 2. Run any service locally:
    ```bash
    # Example: broadcast-worker
-   NATS_URL=nats://localhost:4222 MONGO_URI=mongodb://localhost:27017 SITE_ID=site-local go run ./broadcast-worker/
+   NATS_URL=nats://localhost:4222 MONGO_URI=mongodb://localhost:27017/?directConnection=true SITE_ID=site-local go run ./broadcast-worker/
    ```
 3. Exercise the service (send messages, trigger events, etc.).
 4. Open http://localhost:16686, select the service name from the **Service** dropdown, and click **Find Traces**.

--- a/tools/seed-sample-data/main.go
+++ b/tools/seed-sample-data/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 type config struct {
-	MongoURI       string   `env:"MONGO_URI"       envDefault:"mongodb://localhost:27017"`
+	MongoURI       string   `env:"MONGO_URI"       envDefault:"mongodb://localhost:27017/?directConnection=true"`
 	MongoDB        string   `env:"MONGO_DB"        envDefault:"chat"`
 	MongoUsername  string   `env:"MONGO_USERNAME"  envDefault:""`
 	MongoPassword  string   `env:"MONGO_PASSWORD"  envDefault:""`

--- a/tools/seed-sample-data/main_test.go
+++ b/tools/seed-sample-data/main_test.go
@@ -10,7 +10,7 @@ import (
 func TestParseConfig_Defaults(t *testing.T) {
 	cfg, err := parseConfig(map[string]string{})
 	require.NoError(t, err)
-	assert.Equal(t, "mongodb://localhost:27017", cfg.MongoURI)
+	assert.Equal(t, "mongodb://localhost:27017/?directConnection=true", cfg.MongoURI)
 	assert.Equal(t, "chat", cfg.MongoDB)
 	assert.Equal(t, []string{"localhost:6379"}, cfg.ValkeyAddrs)
 	assert.Empty(t, cfg.ValkeyPassword)


### PR DESCRIPTION
Converts docker-local MongoDB to a single-node replica set so local stacks support multi-document transactions (needed by upcoming admin-service work, and harmless for everything else).

- `mongod --replSet rs0` + self-initiating healthcheck (hardened from the `source-mongo` pattern in compose.migration-demo.yaml — healthy only once the member is PRIMARY); idempotent on existing volumes.
- The RS member advertises `mongodb:27017`, so HOST-side clients need `?directConnection=true`: applied to the two documented host touch points — the seed tool's `MONGO_URI` envDefault (+ its test) and the jaeger README example. In-network services are unaffected.

Verified: fresh `docker compose up` reaches PRIMARY; a real `WithTransaction` commit succeeds via the new host URI; `make seed`'s Mongo leg connects (its Valkey leg has a separate pre-existing host-resolution issue, untouched here).

## Self-Review Updates
- Review fix `746a343e`: the healthcheck now exits 0 only when `rs.status().myState === 1` (PRIMARY); the probe that runs `rs.initiate()` deliberately exits 1 so Docker keeps retrying until the member is writable. Previously the initiating probe reported healthy before election completed. Verified on a fresh `mongo:8.2.9` container: first probe initiates and exits 1, probe goes green ~2s later at PRIMARY.

