### PR TITLE
feat(admin-frontend): permissions console — ledger list, create dialog, account pickers

### DIFF
--- a/admin-frontend/src/api/_transport/httpEnvelope.test.ts
+++ b/admin-frontend/src/api/_transport/httpEnvelope.test.ts
@@ -69,6 +69,13 @@ describe('formatAsyncJobError', () => {
     expect(msg).not.toBe('token invalid')
   })
 
+  it('returns friendly copy for unknown_accounts', () => {
+    const err = new AsyncJobError('unknown accounts: zzz', { reason: 'unknown_accounts' })
+    const msg = formatAsyncJobError(err)
+    expect(msg).not.toBe('')
+    expect(msg).not.toBe('unknown accounts: zzz')
+  })
+
   it('falls back to err.message for an unknown reason', () => {
     const err = new AsyncJobError('something odd happened', { reason: 'not_in_catalog' })
     expect(formatAsyncJobError(err)).toBe('something odd happened')

--- a/admin-frontend/src/api/_transport/httpEnvelope.ts
+++ b/admin-frontend/src/api/_transport/httpEnvelope.ts
@@ -24,6 +24,7 @@ const REASON_COPY: Record<string, string> = {
   invalid_token: 'That link has expired or is invalid — request a new one.',
   account_exists: 'An account with that email already exists.',
   unknown_permission: "That permission isn't recognized.",
+  // "200" mirrors pkg/model.MaxSubjects; "1000" mirrors pkg/model.MaxReasonRunes.
   invalid_subject_count: 'Enter between 1 and 200 accounts.',
   invalid_reason: 'Enter a reason, up to 1000 characters.',
   missing_permission_fields: 'Applicant and approver are both required.',

--- a/admin-frontend/src/api/_transport/httpEnvelope.ts
+++ b/admin-frontend/src/api/_transport/httpEnvelope.ts
@@ -23,6 +23,16 @@ const REASON_COPY: Record<string, string> = {
   not_admin: 'You need admin access to do that.',
   invalid_token: 'That link has expired or is invalid — request a new one.',
   account_exists: 'An account with that email already exists.',
+  unknown_permission: "That permission isn't recognized.",
+  invalid_subject_count: 'Enter between 1 and 200 accounts.',
+  invalid_reason: 'Enter a reason, up to 1000 characters.',
+  missing_permission_fields: 'Applicant and approver are both required.',
+  invalid_permission_window:
+    "Check the dates — the start date must be on or before the expiry date, and the expiry date can't be in the past.",
+  unexpected_permission_window:
+    "Revoking a permission doesn't use the date fields — leave them blank.",
+  inactive_subject: "Some accounts are deactivated and can't be granted this permission.",
+  unknown_accounts: 'Some accounts do not exist on this site.',
 }
 
 /** User-facing message for an `AsyncJobError`; prefers reason-keyed copy (stable machine codes) over `err.message`. */

--- a/admin-frontend/src/api/admin/admin.test.ts
+++ b/admin-frontend/src/api/admin/admin.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { AsyncJobError } from '@/api'
 import {
+  createPermissions,
   createUser,
   getUser,
   listAudit,
+  listPermissions,
   listSessions,
   listUsers,
   revokeAllSessions,
@@ -294,5 +296,142 @@ describe('listAudit', () => {
 
     const [url] = fetchMock.mock.calls[0]
     expect(url).toBe('http://localhost:8082/v1/admin/audit')
+  })
+})
+
+const GRANT_VIEW = {
+  id: 'g-1',
+  permission: 'external.image.view',
+  subjectAccount: 'alice',
+  granted: true,
+  effectiveFrom: '2026-09-01',
+  expiresAt: '2026-12-31',
+  expiresAtUTC: '2026-12-31T16:00:00Z',
+  applicantAccount: 'carol',
+  approverAccount: 'dave',
+  reason: 'On-call staff must review production line photos from outside the fab.',
+  recordedBy: 'p_admin_wang',
+  recordedAt: '2026-08-11T03:00:00Z',
+}
+
+describe('createPermissions', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('POSTs /v1/admin/permissions with the request body and returns the created response', async () => {
+    const response = {
+      created: 2,
+      duplicatesIgnored: [],
+      grants: [
+        { id: 'g-1', subjectAccount: 'alice' },
+        { id: 'g-2', subjectAccount: 'bob' },
+      ],
+    }
+    const fetchMock = stubFetch(201, response)
+
+    const result = await createPermissions('tok', {
+      permission: 'external.image.view',
+      subjectAccounts: ['alice', 'bob'],
+      granted: true,
+      effectiveFrom: '2026-09-01',
+      expiresAt: '2026-12-31',
+      applicantAccount: 'carol',
+      approverAccount: 'dave',
+      reason: 'On-call staff must review production line photos from outside the fab.',
+    })
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8082/v1/admin/permissions')
+    expect(init.method).toBe('POST')
+    expect(init.headers.Authorization).toBe('Bearer tok')
+    expect(init.headers['Content-Type']).toBe('application/json')
+    expect(JSON.parse(init.body)).toEqual({
+      permission: 'external.image.view',
+      subjectAccounts: ['alice', 'bob'],
+      granted: true,
+      effectiveFrom: '2026-09-01',
+      expiresAt: '2026-12-31',
+      applicantAccount: 'carol',
+      approverAccount: 'dave',
+      reason: 'On-call staff must review production line photos from outside the fab.',
+    })
+    expect(result).toEqual(response)
+  })
+
+  it('throws AsyncJobError with reason preserved on a non-2xx response', async () => {
+    stubFetch(404, {
+      error: 'unknown accounts: zzz',
+      code: 'not_found',
+      reason: 'unknown_accounts',
+    })
+    const body = {
+      permission: 'external.image.view',
+      subjectAccounts: ['zzz'],
+      granted: true,
+      expiresAt: '2026-12-31',
+      applicantAccount: 'carol',
+      approverAccount: 'dave',
+      reason: 'test',
+    }
+
+    await expect(createPermissions('tok', body)).rejects.toBeInstanceOf(AsyncJobError)
+    await expect(createPermissions('tok', body)).rejects.toMatchObject({
+      reason: 'unknown_accounts',
+    })
+  })
+})
+
+describe('listPermissions', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('GETs /v1/admin/permissions with subjectAccount plus optional params when all are provided', async () => {
+    const fetchMock = stubFetch(200, { entries: [GRANT_VIEW], total: 1, currentlyGranted: true })
+
+    const result = await listPermissions('tok', {
+      subjectAccount: 'alice',
+      permission: 'external.image.view',
+      page: 2,
+      limit: 10,
+    })
+
+    const [url, init] = fetchMock.mock.calls[0]
+    const parsed = new URL(url)
+    expect(parsed.pathname).toBe('/v1/admin/permissions')
+    expect(parsed.searchParams.get('subjectAccount')).toBe('alice')
+    expect(parsed.searchParams.get('permission')).toBe('external.image.view')
+    expect(parsed.searchParams.get('page')).toBe('2')
+    expect(parsed.searchParams.get('limit')).toBe('10')
+    expect(init.method).toBe('GET')
+    expect(result).toEqual({ entries: [GRANT_VIEW], total: 1, currentlyGranted: true })
+  })
+
+  it('omits permission/page/limit from the query string when not provided', async () => {
+    const fetchMock = stubFetch(200, { entries: [], total: 0 })
+
+    await listPermissions('tok', { subjectAccount: 'alice' })
+
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8082/v1/admin/permissions?subjectAccount=alice')
+  })
+
+  it('omits subjectAccount from the query string when not provided (unfiltered list)', async () => {
+    const fetchMock = stubFetch(200, { entries: [], total: 0 })
+
+    await listPermissions('tok', {})
+
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8082/v1/admin/permissions')
+  })
+
+  it('GETs with permission only when subjectAccount is omitted', async () => {
+    const fetchMock = stubFetch(200, { entries: [], total: 0 })
+
+    await listPermissions('tok', { permission: 'external.image.view', page: 1, limit: 20 })
+
+    const [url] = fetchMock.mock.calls[0]
+    const parsed = new URL(url)
+    expect(parsed.searchParams.get('subjectAccount')).toBeNull()
+    expect(parsed.searchParams.get('permission')).toBe('external.image.view')
+    expect(parsed.searchParams.get('page')).toBe('1')
+    expect(parsed.searchParams.get('limit')).toBe('20')
   })
 })

--- a/admin-frontend/src/api/admin/index.ts
+++ b/admin-frontend/src/api/admin/index.ts
@@ -74,6 +74,54 @@ export interface AuditFilter {
   limit?: number
 }
 
+/** One row of the permission ledger (mirrors admin-service's `permissionGrantView`). */
+export interface PermissionGrantView {
+  id: string
+  permission: string
+  subjectAccount: string
+  granted: boolean
+  effectiveFrom?: string // "2026-09-01"
+  expiresAt?: string // "2026-12-31"
+  expiresAtUTC?: string // RFC3339
+  applicantAccount: string
+  approverAccount: string
+  reason: string
+  recordedBy: string
+  recordedAt: string
+}
+
+export interface CreatePermissionsRequest {
+  permission: string
+  subjectAccounts: string[]
+  granted: boolean
+  effectiveFrom?: string
+  expiresAt?: string
+  applicantAccount: string
+  approverAccount: string
+  reason: string
+}
+
+export interface CreatePermissionsResponse {
+  created: number
+  duplicatesIgnored: string[]
+  grants: { id: string; subjectAccount: string }[]
+}
+
+export interface ListPermissionsResponse {
+  currentlyGranted?: boolean
+  entries: PermissionGrantView[]
+  total: number
+}
+
+/** `subjectAccount` and `permission` are independently optional and combinable; the server
+ * includes `currentlyGranted` in the response only when both are given. */
+export interface ListPermissionsParams {
+  subjectAccount?: string
+  permission?: string
+  page?: number
+  limit?: number
+}
+
 /** Raw shape of admin-service's `userView` as it appears on the wire — the
  * `omitempty` fields may be absent; `normalizeUser` fills the defaults. */
 interface UserViewWire {
@@ -224,4 +272,26 @@ export async function listAudit(
     limit: filter.limit,
   })
   return adminFetch<{ entries: AuditEntry[]; total: number }>(authToken, 'GET', `/audit${qs}`)
+}
+
+/** @throws {AsyncJobError} on a non-2xx response (e.g. `unknown_accounts`, `inactive_subject`). */
+export async function createPermissions(
+  authToken: string,
+  body: CreatePermissionsRequest,
+): Promise<CreatePermissionsResponse> {
+  return adminFetch<CreatePermissionsResponse>(authToken, 'POST', '/permissions', body)
+}
+
+/** @throws {AsyncJobError} on a non-2xx response. */
+export async function listPermissions(
+  authToken: string,
+  params: ListPermissionsParams = {},
+): Promise<ListPermissionsResponse> {
+  const qs = buildQuery({
+    subjectAccount: params.subjectAccount,
+    permission: params.permission,
+    page: params.page,
+    limit: params.limit,
+  })
+  return adminFetch<ListPermissionsResponse>(authToken, 'GET', `/permissions${qs}`)
 }

--- a/admin-frontend/src/api/index.ts
+++ b/admin-frontend/src/api/index.ts
@@ -11,9 +11,11 @@ export { botLogin, changePassword } from './auth/botAuth'
 export type { Bundle } from './auth/botAuth'
 
 export {
+  createPermissions,
   createUser,
   getUser,
   listAudit,
+  listPermissions,
   listSessions,
   listUsers,
   revokeAllSessions,
@@ -26,8 +28,13 @@ export type {
   AdminUser,
   AuditEntry,
   AuditFilter,
+  CreatePermissionsRequest,
+  CreatePermissionsResponse,
   CreateUserInput,
+  ListPermissionsParams,
+  ListPermissionsResponse,
   ListUsersParams,
+  PermissionGrantView,
   SetPasswordInput,
   UpdateUserPatch,
 } from './admin'

--- a/admin-frontend/src/components/AppShell/AppShell.jsx
+++ b/admin-frontend/src/components/AppShell/AppShell.jsx
@@ -5,10 +5,12 @@ import './style.css'
 
 const UsersPage = lazy(() => import('@/components/UsersConsole'))
 const AuditView = lazy(() => import('@/components/AuditView'))
+const PermissionsView = lazy(() => import('@/components/PermissionsView'))
 
 const SECTIONS = [
   { key: 'users', label: 'Users' },
   { key: 'audit', label: 'Audit' },
+  { key: 'permissions', label: 'Permissions' },
 ]
 
 // Top-level authed layout: nav to switch Users/Audit, header with signed-in account + logout.
@@ -22,7 +24,8 @@ export default function AppShell() {
 
   const renderSection = () => {
     if (section === 'users') return <UsersPage />
-    return <AuditView />
+    if (section === 'audit') return <AuditView />
+    return <PermissionsView />
   }
 
   const content = (

--- a/admin-frontend/src/components/AppShell/AppShell.test.jsx
+++ b/admin-frontend/src/components/AppShell/AppShell.test.jsx
@@ -4,12 +4,18 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 vi.mock('@/context/AuthContext', () => ({ useAuth: vi.fn() }))
 vi.mock('@/api', async (importOriginal) => {
   const actual = await importOriginal()
-  return { ...actual, listUsers: vi.fn(), listAudit: vi.fn() }
+  return {
+    ...actual,
+    listUsers: vi.fn(),
+    listAudit: vi.fn(),
+    createPermissions: vi.fn(),
+    listPermissions: vi.fn(),
+  }
 })
 
 import AppShell from './AppShell'
 import { useAuth } from '@/context/AuthContext'
-import { listUsers, listAudit } from '@/api'
+import { listUsers, listAudit, listPermissions } from '@/api'
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -19,6 +25,7 @@ beforeEach(() => {
   })
   listUsers.mockResolvedValue({ users: [], total: 0 })
   listAudit.mockResolvedValue({ entries: [], total: 0 })
+  listPermissions.mockResolvedValue({ entries: [], total: 0 })
 })
 
 describe('AppShell', () => {
@@ -59,5 +66,17 @@ describe('AppShell', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /^users$/i }))
     await waitFor(() => expect(listUsers).toHaveBeenCalledTimes(2))
+  })
+
+  it('switches from Users to Permissions via nav and mounts PermissionsView', async () => {
+    render(<AppShell />)
+    await waitFor(() => expect(listUsers).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByRole('button', { name: /^permissions$/i }))
+
+    await waitFor(() =>
+      expect(listPermissions).toHaveBeenCalledWith('tok', { page: 1, limit: 20 }),
+    )
+    expect(screen.getByRole('button', { name: /^create$/i })).toBeInTheDocument()
   })
 })

--- a/admin-frontend/src/components/PermissionsView/AccountPicker/AccountPicker.jsx
+++ b/admin-frontend/src/components/PermissionsView/AccountPicker/AccountPicker.jsx
@@ -1,0 +1,123 @@
+import { useState } from 'react'
+import { listUsers } from '@/api'
+import { useHandleAdminError } from '@/hooks/useHandleAdminError'
+import { useDebouncedSearch } from '@/hooks/useDebouncedSearch'
+import { useLatestRequest } from '@/hooks/useLatestRequest'
+import './style.css'
+
+const SEARCH_LIMIT = 10
+
+// Search-to-select account field: typing queries the admin users API (debounced) and only an
+// account present in the results can be selected — free-typed text is never committed via
+// `onChange`, so it can never reach a submit payload. `multiple` renders removable chips backed
+// by an array `value`; single mode holds one account string and hides the input once set.
+export default function AccountPicker({ id, label, authToken, multiple = false, value, onChange, disabled }) {
+  const [options, setOptions] = useState([])
+  const [open, setOpen] = useState(false)
+  const handleAdminError = useHandleAdminError()
+  const { begin, isCurrent } = useLatestRequest()
+
+  const selected = multiple ? value : value ? [value] : []
+
+  const search = async (q) => {
+    // Stamp every invocation — including the empty-query short-circuit below — so a
+    // still-in-flight older request (e.g. "al" resolving after "ali", or after the field was
+    // cleared) can never win a race and overwrite fresher/cleared state (see
+    // useLatestRequest's own doc comment).
+    const token = begin()
+    if (!q) {
+      setOptions([])
+      setOpen(false)
+      return
+    }
+    try {
+      const result = await listUsers(authToken, { q, page: 1, limit: SEARCH_LIMIT })
+      if (!isCurrent(token)) return // superseded by a newer query
+      setOptions(result.users.filter((u) => !selected.includes(u.account)))
+      setOpen(true)
+    } catch (err) {
+      if (!isCurrent(token)) return
+      setOptions([])
+      setOpen(false)
+      handleAdminError(err) // invalid_token logs out; other errors just leave the dropdown empty
+    }
+  }
+
+  const { query, setQuery } = useDebouncedSearch({ onSearch: search })
+
+  const select = (account) => {
+    if (multiple) {
+      if (!value.includes(account)) onChange([...value, account])
+      // Keep the dropdown open (minus the just-picked match) so several accounts from the
+      // same search can be added in a row without re-typing the query each time.
+      setOptions((prev) => prev.filter((u) => u.account !== account))
+    } else {
+      onChange(account)
+      setQuery('')
+      setOptions([])
+      setOpen(false)
+    }
+  }
+
+  const remove = (account) => {
+    onChange(multiple ? value.filter((a) => a !== account) : '')
+  }
+
+  const showInput = multiple || selected.length === 0
+
+  return (
+    <div className="account-picker">
+      <label htmlFor={id}>{label}</label>
+      {selected.length > 0 && (
+        <ul className="account-picker-chips">
+          {selected.map((account) => (
+            <li key={account} className="account-picker-chip">
+              <span>{account}</span>
+              <button
+                type="button"
+                aria-label={`Remove ${account}`}
+                onClick={() => remove(account)}
+                disabled={disabled}
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {showInput && (
+        <div className="account-picker-input-wrap">
+          <input
+            id={id}
+            type="text"
+            autoComplete="off"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onFocus={() => options.length > 0 && setOpen(true)}
+            onBlur={() => setOpen(false)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') setOpen(false)
+            }}
+            disabled={disabled}
+          />
+          {open && options.length > 0 && (
+            <ul
+              className="account-picker-options"
+              role="listbox"
+              // Keeps focus on the input across the click so `onBlur` above doesn't close the
+              // dropdown before the option's own onClick has a chance to run.
+              onMouseDown={(e) => e.preventDefault()}
+            >
+              {options.map((u) => (
+                <li key={u.account} role="option" aria-selected="false" onClick={() => select(u.account)}>
+                  {u.account}
+                  {u.engName ? ` (${u.engName})` : ''}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/admin-frontend/src/components/PermissionsView/AccountPicker/AccountPicker.test.jsx
+++ b/admin-frontend/src/components/PermissionsView/AccountPicker/AccountPicker.test.jsx
@@ -1,0 +1,310 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+vi.mock('@/context/AuthContext', () => ({ useAuth: vi.fn() }))
+vi.mock('@/api', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, listUsers: vi.fn() }
+})
+
+import AccountPicker from './AccountPicker'
+import { useAuth } from '@/context/AuthContext'
+import { listUsers, AsyncJobError } from '@/api'
+
+const ALICE = {
+  id: 'u-1',
+  account: 'alice',
+  siteId: 'site-1',
+  engName: 'Alice',
+  chineseName: '',
+  roles: [],
+  active: true,
+  requirePasswordChange: false,
+}
+const BOB = {
+  id: 'u-2',
+  account: 'bob',
+  siteId: 'site-1',
+  engName: 'Bob',
+  chineseName: '',
+  roles: [],
+  active: true,
+  requirePasswordChange: false,
+}
+
+let logout
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  logout = vi.fn()
+  useAuth.mockReturnValue({ logout })
+  listUsers.mockResolvedValue({ users: [], total: 0 })
+})
+
+async function typeAndWait(input, text) {
+  fireEvent.change(input, { target: { value: text } })
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(300)
+  })
+}
+
+describe('AccountPicker — single select', () => {
+  it('does not query listUsers on mount', () => {
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={vi.fn()} />)
+    expect(listUsers).not.toHaveBeenCalled()
+  })
+
+  it('queries listUsers debounced as the admin types and lists matches', async () => {
+    listUsers.mockResolvedValue({ users: [ALICE], total: 1 })
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={vi.fn()} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/applicant/i), 'ali')
+      expect(listUsers).toHaveBeenCalledWith('tok', { q: 'ali', page: 1, limit: 10 })
+      expect(await screen.findByRole('option', { name: /alice/i })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('selects a matched account on click, committing it via onChange', async () => {
+    listUsers.mockResolvedValue({ users: [ALICE], total: 1 })
+    const onChange = vi.fn()
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={onChange} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/applicant/i), 'ali')
+      fireEvent.click(await screen.findByRole('option', { name: /alice/i }))
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(onChange).toHaveBeenCalledWith('alice')
+  })
+
+  it('never commits free-typed text that was not selected from the results', async () => {
+    listUsers.mockResolvedValue({ users: [], total: 0 })
+    const onChange = vi.fn()
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={onChange} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/applicant/i), 'zzz-not-a-match')
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.queryByRole('option')).not.toBeInTheDocument()
+  })
+
+  it('renders the committed value as a removable chip and hides the search input', () => {
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="alice" onChange={vi.fn()} />)
+    expect(screen.getByText('alice')).toBeInTheDocument()
+    expect(screen.queryByLabelText(/applicant/i)).not.toBeInTheDocument()
+  })
+
+  it('clears the selection and re-shows the input when the chip is removed', () => {
+    const onChange = vi.fn()
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="alice" onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button', { name: /remove alice/i }))
+    expect(onChange).toHaveBeenCalledWith('')
+  })
+
+  it('closes the dropdown on Escape without committing a selection', async () => {
+    listUsers.mockResolvedValue({ users: [ALICE], total: 1 })
+    const onChange = vi.fn()
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={onChange} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      const input = screen.getByLabelText(/applicant/i)
+      await typeAndWait(input, 'ali')
+      expect(await screen.findByRole('option', { name: /alice/i })).toBeInTheDocument()
+      fireEvent.keyDown(input, { key: 'Escape' })
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(screen.queryByRole('option')).not.toBeInTheDocument()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})
+
+describe('AccountPicker — multi select', () => {
+  it('appends a selected account as a chip via onChange', async () => {
+    listUsers.mockResolvedValue({ users: [ALICE, BOB], total: 2 })
+    const onChange = vi.fn()
+    render(
+      <AccountPicker id="p" label="Subjects" authToken="tok" multiple value={[]} onChange={onChange} />,
+    )
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/subjects/i), 'a')
+      fireEvent.click(await screen.findByRole('option', { name: /alice/i }))
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(onChange).toHaveBeenCalledWith(['alice'])
+  })
+
+  it('keeps the dropdown open after a selection so more matches can be picked', async () => {
+    listUsers.mockResolvedValue({ users: [ALICE, BOB], total: 2 })
+    render(<AccountPicker id="p" label="Subjects" authToken="tok" multiple value={[]} onChange={vi.fn()} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/subjects/i), 'a')
+      fireEvent.click(await screen.findByRole('option', { name: /alice/i }))
+      expect(await screen.findByRole('option', { name: /bob/i })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('shows one chip per selected account and removes only the clicked one', () => {
+    const onChange = vi.fn()
+    render(
+      <AccountPicker
+        id="p"
+        label="Subjects"
+        authToken="tok"
+        multiple
+        value={['alice', 'bob']}
+        onChange={onChange}
+      />,
+    )
+    expect(screen.getByText('alice')).toBeInTheDocument()
+    expect(screen.getByText('bob')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /remove alice/i }))
+    expect(onChange).toHaveBeenCalledWith(['bob'])
+  })
+
+  it('excludes already-selected accounts from the results dropdown', async () => {
+    listUsers.mockResolvedValue({ users: [ALICE, BOB], total: 2 })
+    render(
+      <AccountPicker id="p" label="Subjects" authToken="tok" multiple value={['alice']} onChange={vi.fn()} />,
+    )
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/subjects/i), 'a')
+      expect(await screen.findByRole('option', { name: /bob/i })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(screen.queryByRole('option', { name: /^alice$/i })).not.toBeInTheDocument()
+  })
+
+  it('keeps the search input visible even after selections exist', () => {
+    render(
+      <AccountPicker id="p" label="Subjects" authToken="tok" multiple value={['alice']} onChange={vi.fn()} />,
+    )
+    expect(screen.getByLabelText(/subjects/i)).toBeInTheDocument()
+  })
+
+  it('never commits free-typed text into the selected array', async () => {
+    listUsers.mockResolvedValue({ users: [], total: 0 })
+    const onChange = vi.fn()
+    render(<AccountPicker id="p" label="Subjects" authToken="tok" multiple value={[]} onChange={onChange} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/subjects/i), 'not-a-real-match')
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})
+
+describe('AccountPicker — errors', () => {
+  it('logs the admin out instead of showing results on invalid_token', async () => {
+    listUsers.mockRejectedValue(
+      new AsyncJobError('expired', { code: 'unauthenticated', reason: 'invalid_token' }),
+    )
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={vi.fn()} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/applicant/i), 'ali')
+    } finally {
+      vi.useRealTimers()
+    }
+    await waitFor(() => expect(logout).toHaveBeenCalledTimes(1))
+  })
+
+  it('shows no options and does not throw on a non-auth error', async () => {
+    listUsers.mockRejectedValue(new AsyncJobError('boom', { code: 'internal' }))
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={vi.fn()} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/applicant/i), 'ali')
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(screen.queryByRole('option')).not.toBeInTheDocument()
+    expect(logout).not.toHaveBeenCalled()
+  })
+})
+
+describe('AccountPicker — stale response guard', () => {
+  it('drops a stale out-of-order response so a slow earlier query cannot overwrite newer results', async () => {
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={vi.fn()} />)
+    const input = screen.getByLabelText(/applicant/i)
+
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      // First keystroke ("al") fires a query that will resolve LATE.
+      let resolveSlow
+      const slow = new Promise((resolve) => {
+        resolveSlow = resolve
+      })
+      listUsers.mockReturnValueOnce(slow)
+      await typeAndWait(input, 'al')
+      await waitFor(() =>
+        expect(listUsers).toHaveBeenCalledWith('tok', { q: 'al', page: 1, limit: 10 }),
+      )
+
+      // Second keystroke ("ali") fires a newer query that resolves immediately, before the
+      // first one settles — both requests are now in flight, out of order.
+      listUsers.mockResolvedValueOnce({
+        users: [
+          {
+            id: 'u-fresh',
+            account: 'fresh-account',
+            siteId: 'site-1',
+            engName: '',
+            chineseName: '',
+            roles: [],
+            active: true,
+            requirePasswordChange: false,
+          },
+        ],
+        total: 1,
+      })
+      await typeAndWait(input, 'ali')
+      await waitFor(() =>
+        expect(listUsers).toHaveBeenCalledWith('tok', { q: 'ali', page: 1, limit: 10 }),
+      )
+      expect(await screen.findByRole('option', { name: /fresh-account/i })).toBeInTheDocument()
+
+      // The stale "al" response now resolves — it must be dropped, not overwrite the
+      // already-current "ali" results.
+      await act(async () => {
+        resolveSlow({
+          users: [
+            {
+              id: 'u-stale',
+              account: 'stale-account',
+              siteId: 'site-1',
+              engName: '',
+              chineseName: '',
+              roles: [],
+              active: true,
+              requirePasswordChange: false,
+            },
+          ],
+          total: 1,
+        })
+        await Promise.resolve()
+      })
+
+      expect(screen.queryByRole('option', { name: /stale-account/i })).not.toBeInTheDocument()
+      expect(screen.getByRole('option', { name: /fresh-account/i })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/admin-frontend/src/components/PermissionsView/AccountPicker/index.jsx
+++ b/admin-frontend/src/components/PermissionsView/AccountPicker/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './AccountPicker'

--- a/admin-frontend/src/components/PermissionsView/AccountPicker/style.css
+++ b/admin-frontend/src/components/PermissionsView/AccountPicker/style.css
@@ -1,0 +1,76 @@
+.account-picker {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.account-picker-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.account-picker-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  padding: var(--space-2xs) var(--space-sm);
+  background: var(--bg-input);
+  border-radius: var(--radius-pill);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.account-picker-chip button {
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: var(--text-base);
+  line-height: 1;
+  padding: 0;
+}
+
+.account-picker-chip button:hover:not(:disabled) {
+  color: var(--text-primary);
+}
+
+.account-picker-chip button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.account-picker-input-wrap {
+  position: relative;
+}
+
+.account-picker-options {
+  position: absolute;
+  z-index: 10;
+  top: calc(100% + var(--space-2xs));
+  left: 0;
+  right: 0;
+  max-height: 200px;
+  overflow-y: auto;
+  margin: 0;
+  padding: var(--space-2xs) 0;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-dialog);
+  list-style: none;
+}
+
+.account-picker-options li {
+  padding: var(--space-xs) var(--space-md);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+
+.account-picker-options li:hover {
+  background: var(--bg-hover);
+}

--- a/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/CreatePermissionsDialog.jsx
+++ b/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/CreatePermissionsDialog.jsx
@@ -1,0 +1,244 @@
+import { useState } from 'react'
+import { AsyncJobError, createPermissions } from '@/api'
+import { useHandleAdminError } from '@/hooks/useHandleAdminError'
+import Modal from '@/components/shared/Modal'
+import AccountPicker from '../AccountPicker'
+import { PERMISSION_KEY } from '../permissionKey'
+import './style.css'
+
+const MAX_SUBJECTS = 200
+const MAX_REASON_RUNES = 1000
+
+// Grant/revoke form, opened as a dialog from PermissionsPage's "Create" button. On a successful
+// submit it reports up via `onCreated` immediately (PermissionsPage refreshes the list right
+// away) but — unlike UsersConsole's CreateUserForm/onCreated, which the parent uses to also
+// close the dialog — this dialog stays open and swaps to a result view so the admin can read the
+// created/duplicatesIgnored summary; `onClose` (via the result view's Close button, Cancel, Esc,
+// or the backdrop) is what actually dismisses it.
+export default function CreatePermissionsDialog({ authToken, onClose, onCreated }) {
+  const handleAdminError = useHandleAdminError()
+
+  const [mode, setMode] = useState('grant')
+  const [subjectAccounts, setSubjectAccounts] = useState([])
+  const [effectiveFrom, setEffectiveFrom] = useState('')
+  const [expiresAt, setExpiresAt] = useState('')
+  const [applicantAccount, setApplicantAccount] = useState('')
+  const [approverAccount, setApproverAccount] = useState('')
+  const [reason, setReason] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [formError, setFormError] = useState(null)
+  const [formErrorMetadata, setFormErrorMetadata] = useState(null)
+  const [result, setResult] = useState(null)
+
+  const subjectCount = subjectAccounts.length
+  const tooManySubjects = subjectCount > MAX_SUBJECTS
+  const reasonRuneCount = [...reason].length
+  const clientInvalid =
+    subjectCount === 0 ||
+    tooManySubjects ||
+    reasonRuneCount > MAX_REASON_RUNES ||
+    !applicantAccount ||
+    !approverAccount ||
+    (mode === 'grant' && !expiresAt)
+
+  // Builds the wire payload field-by-field so an omitted window field or a blank reason is
+  // truly absent from the object (and therefore from the JSON body) — never sent as "".
+  const buildPayload = () => {
+    const payload = {
+      permission: PERMISSION_KEY,
+      subjectAccounts,
+      granted: mode === 'grant',
+    }
+    if (mode === 'grant') {
+      if (effectiveFrom) payload.effectiveFrom = effectiveFrom
+      payload.expiresAt = expiresAt
+    }
+    payload.applicantAccount = applicantAccount
+    payload.approverAccount = approverAccount
+    if (reason) payload.reason = reason
+    return payload
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (clientInvalid || submitting) return
+    setSubmitting(true)
+    setFormError(null)
+    setFormErrorMetadata(null)
+    try {
+      const response = await createPermissions(authToken, buildPayload())
+      setResult({ ...response, requestMode: mode })
+      onCreated()
+    } catch (err) {
+      const message = handleAdminError(err)
+      if (message !== null) {
+        setFormError(message)
+        if (err instanceof AsyncJobError && err.metadata) setFormErrorMetadata(err.metadata)
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Modal onClose={onClose} labelledBy="create-permissions-title">
+      <h2 id="create-permissions-title">Grant or revoke permission</h2>
+
+      {result ? (
+        <div>
+          <div className="permissions-result dialog-success">
+            <p>
+              {result.requestMode === 'grant'
+                ? `Created ${result.created} grant${result.created === 1 ? '' : 's'}.`
+                : `Recorded ${result.created} revocation${result.created === 1 ? '' : 's'}.`}
+            </p>
+            {result.duplicatesIgnored.length > 0 && (
+              <p className="permissions-duplicates">
+                Duplicates ignored: {result.duplicatesIgnored.join(', ')}
+              </p>
+            )}
+          </div>
+          <div className="dialog-actions">
+            <button type="button" className="dialog-cancel" onClick={onClose}>
+              Close
+            </button>
+          </div>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit}>
+          <p className="permissions-form-subtitle">Permission: {PERMISSION_KEY}</p>
+
+          <div className="permissions-mode-group" role="radiogroup" aria-label="Grant or revoke">
+            <label htmlFor="permissions-mode-grant" className="permissions-mode-option">
+              <input
+                type="radio"
+                id="permissions-mode-grant"
+                name="permissions-mode"
+                value="grant"
+                checked={mode === 'grant'}
+                onChange={() => setMode('grant')}
+                disabled={submitting}
+              />
+              Grant
+            </label>
+            <label htmlFor="permissions-mode-revoke" className="permissions-mode-option">
+              <input
+                type="radio"
+                id="permissions-mode-revoke"
+                name="permissions-mode"
+                value="revoke"
+                checked={mode === 'revoke'}
+                onChange={() => setMode('revoke')}
+                disabled={submitting}
+              />
+              Revoke
+            </label>
+          </div>
+
+          <AccountPicker
+            id="permissions-subjects"
+            label="Subject accounts"
+            authToken={authToken}
+            multiple
+            value={subjectAccounts}
+            onChange={setSubjectAccounts}
+            disabled={submitting}
+          />
+          <span
+            className={`permissions-subjects-count ${tooManySubjects ? 'is-over-limit' : ''}`}
+          >
+            {subjectCount} account{subjectCount === 1 ? '' : 's'} (max {MAX_SUBJECTS})
+          </span>
+          {tooManySubjects && (
+            <div className="permissions-field-error">
+              Enter at most {MAX_SUBJECTS} accounts — you have {subjectCount}.
+            </div>
+          )}
+
+          {mode === 'grant' && (
+            <div className="permissions-date-row">
+              <div className="permissions-date-field">
+                <label htmlFor="permissions-effective-from">Effective from (optional)</label>
+                <input
+                  type="date"
+                  id="permissions-effective-from"
+                  value={effectiveFrom}
+                  onChange={(e) => setEffectiveFrom(e.target.value)}
+                  disabled={submitting}
+                />
+              </div>
+              <div className="permissions-date-field">
+                <label htmlFor="permissions-expires-at">Expires at</label>
+                <input
+                  type="date"
+                  id="permissions-expires-at"
+                  value={expiresAt}
+                  onChange={(e) => setExpiresAt(e.target.value)}
+                  disabled={submitting}
+                />
+              </div>
+            </div>
+          )}
+
+          <AccountPicker
+            id="permissions-applicant"
+            label="Applicant account"
+            authToken={authToken}
+            value={applicantAccount}
+            onChange={setApplicantAccount}
+            disabled={submitting}
+          />
+
+          <AccountPicker
+            id="permissions-approver"
+            label="Approver account"
+            authToken={authToken}
+            value={approverAccount}
+            onChange={setApproverAccount}
+            disabled={submitting}
+          />
+
+          <label htmlFor="permissions-reason">Reason (optional)</label>
+          <textarea
+            id="permissions-reason"
+            className="permissions-reason-textarea"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            disabled={submitting}
+          />
+          <span className="permissions-reason-count">
+            {reasonRuneCount} / {MAX_REASON_RUNES}
+          </span>
+
+          {formError && (
+            <div className="dialog-error">
+              <p>{formError}</p>
+              {formErrorMetadata && Object.keys(formErrorMetadata).length > 0 && (
+                <ul className="permissions-metadata-list">
+                  {Object.entries(formErrorMetadata).map(([key, value]) => (
+                    <li key={key}>
+                      {key}: {value}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+
+          <div className="dialog-actions">
+            <button type="button" className="dialog-cancel" onClick={onClose} disabled={submitting}>
+              Cancel
+            </button>
+            <button type="submit" disabled={submitting || clientInvalid}>
+              {submitting
+                ? 'Submitting…'
+                : mode === 'grant'
+                  ? 'Grant permission'
+                  : 'Revoke permission'}
+            </button>
+          </div>
+        </form>
+      )}
+    </Modal>
+  )
+}

--- a/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/CreatePermissionsDialog.jsx
+++ b/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/CreatePermissionsDialog.jsx
@@ -6,8 +6,8 @@ import AccountPicker from '../AccountPicker'
 import { PERMISSION_KEY } from '../permissionKey'
 import './style.css'
 
-const MAX_SUBJECTS = 200
-const MAX_REASON_RUNES = 1000
+const MAX_SUBJECTS = 200 // mirrors pkg/model.MaxSubjects
+const MAX_REASON_RUNES = 1000 // mirrors pkg/model.MaxReasonRunes
 
 // Grant/revoke form, opened as a dialog from PermissionsPage's "Create" button. On a successful
 // submit it reports up via `onCreated` immediately (PermissionsPage refreshes the list right
@@ -67,7 +67,7 @@ export default function CreatePermissionsDialog({ authToken, onClose, onCreated 
     setFormErrorMetadata(null)
     try {
       const response = await createPermissions(authToken, buildPayload())
-      setResult({ ...response, requestMode: mode })
+      setResult(response)
       onCreated()
     } catch (err) {
       const message = handleAdminError(err)
@@ -88,7 +88,7 @@ export default function CreatePermissionsDialog({ authToken, onClose, onCreated 
         <div>
           <div className="permissions-result dialog-success">
             <p>
-              {result.requestMode === 'grant'
+              {mode === 'grant'
                 ? `Created ${result.created} grant${result.created === 1 ? '' : 's'}.`
                 : `Recorded ${result.created} revocation${result.created === 1 ? '' : 's'}.`}
             </p>

--- a/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/CreatePermissionsDialog.test.jsx
+++ b/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/CreatePermissionsDialog.test.jsx
@@ -1,0 +1,349 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+vi.mock('@/context/AuthContext', () => ({ useAuth: vi.fn() }))
+vi.mock('@/api', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, createPermissions: vi.fn(), listUsers: vi.fn() }
+})
+
+import CreatePermissionsDialog from './CreatePermissionsDialog'
+import { useAuth } from '@/context/AuthContext'
+import { createPermissions, listUsers, AsyncJobError } from '@/api'
+
+const ALICE = { id: 'u-1', account: 'alice', siteId: 'site-1', engName: 'Alice', chineseName: '', roles: [], active: true, requirePasswordChange: false }
+const BOB = { id: 'u-2', account: 'bob', siteId: 'site-1', engName: 'Bob', chineseName: '', roles: [], active: true, requirePasswordChange: false }
+const CAROL = { id: 'u-3', account: 'carol', siteId: 'site-1', engName: 'Carol', chineseName: '', roles: [], active: true, requirePasswordChange: false }
+const DAVE = { id: 'u-4', account: 'dave', siteId: 'site-1', engName: 'Dave', chineseName: '', roles: [], active: true, requirePasswordChange: false }
+
+let logout
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  logout = vi.fn()
+  useAuth.mockReturnValue({ logout })
+  listUsers.mockResolvedValue({ users: [], total: 0 })
+})
+
+// Drives one AccountPicker through a real search → select cycle. Requires fake timers
+// to already be active (the picker's search is debounced 300ms).
+async function pick(labelRegex, user) {
+  listUsers.mockResolvedValueOnce({ users: [user], total: 1 })
+  fireEvent.change(screen.getByLabelText(labelRegex), { target: { value: user.account } })
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(300)
+  })
+  fireEvent.click(await screen.findByRole('option', { name: new RegExp(`^${user.account}`, 'i') }))
+}
+
+async function fillRequiredPickers({ expiresAt = '2026-12-31' } = {}) {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  try {
+    await pick(/^subject accounts$/i, ALICE)
+    await pick(/^applicant account$/i, CAROL)
+    await pick(/^approver account$/i, DAVE)
+  } finally {
+    vi.useRealTimers()
+  }
+  if (expiresAt) {
+    fireEvent.change(screen.getByLabelText(/expires at/i), { target: { value: expiresAt } })
+  }
+}
+
+describe('CreatePermissionsDialog — form', () => {
+  it('renders the form fields with grant mode selected by default', () => {
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    expect(screen.getByRole('radio', { name: /^grant$/i })).toBeChecked()
+    expect(screen.getByRole('radio', { name: /^revoke$/i })).not.toBeChecked()
+    expect(screen.getByLabelText(/^subject accounts$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/effective from/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/expires at/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^applicant account$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^approver account$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^reason/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /grant permission/i })).toBeInTheDocument()
+  })
+
+  it('hides the effectiveFrom/expiresAt date inputs in revoke mode', () => {
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    fireEvent.click(screen.getByRole('radio', { name: /^revoke$/i }))
+    expect(screen.queryByLabelText(/effective from/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/expires at/i)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /revoke permission/i })).toBeInTheDocument()
+  })
+
+  it('disables submit until subjects, applicant, approver, and expires-at are all set', async () => {
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /grant permission/i })).toBeDisabled()
+
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await pick(/^subject accounts$/i, ALICE)
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(screen.getByRole('button', { name: /grant permission/i })).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText(/expires at/i), { target: { value: '2026-12-31' } })
+    expect(screen.getByRole('button', { name: /grant permission/i })).toBeDisabled()
+
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await pick(/^applicant account$/i, CAROL)
+      await pick(/^approver account$/i, DAVE)
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(screen.getByRole('button', { name: /grant permission/i })).toBeEnabled()
+  })
+
+  it('shows a client-side error and disables submit when more than 200 subjects are selected', async () => {
+    const manyUsers = Array.from({ length: 201 }, (_, i) => ({
+      id: `u-${i}`,
+      account: `user${i}`,
+      siteId: 'site-1',
+      engName: '',
+      chineseName: '',
+      roles: [],
+      active: true,
+      requirePasswordChange: false,
+    }))
+    listUsers.mockResolvedValue({ users: manyUsers, total: 201 })
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      fireEvent.change(screen.getByLabelText(/^subject accounts$/i), { target: { value: 'user' } })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300)
+      })
+      const options = await screen.findAllByRole('option')
+      expect(options).toHaveLength(201)
+      // One fireEvent.click per option, NOT batched inside a single outer act(): each
+      // fireEvent.click already act()-wraps and flushes its own render, so `value` stays
+      // fresh for the next click. Batching all 201 into one act() would have every click
+      // read the same stale `value` closure and only the last selection would stick.
+      for (const option of options) {
+        fireEvent.click(option)
+      }
+    } finally {
+      vi.useRealTimers()
+    }
+
+    expect(screen.getByText(/enter at most 200 accounts/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /grant permission/i })).toBeDisabled()
+  })
+
+  it('never includes free-typed, unselected text in the submitted subjectAccounts', async () => {
+    createPermissions.mockResolvedValue({ created: 1, duplicatesIgnored: [], grants: [] })
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await pick(/^subject accounts$/i, ALICE)
+      listUsers.mockResolvedValueOnce({ users: [], total: 0 })
+      fireEvent.change(screen.getByLabelText(/^subject accounts$/i), {
+        target: { value: 'not-a-real-match' },
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300)
+      })
+      await pick(/^applicant account$/i, CAROL)
+      await pick(/^approver account$/i, DAVE)
+    } finally {
+      vi.useRealTimers()
+    }
+    fireEvent.change(screen.getByLabelText(/expires at/i), { target: { value: '2026-12-31' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    await waitFor(() => expect(createPermissions).toHaveBeenCalledTimes(1))
+    const [, payload] = createPermissions.mock.calls[0]
+    expect(payload.subjectAccounts).toEqual(['alice'])
+  })
+
+  it('blocks submit and shows an error when reason exceeds 1000 runes', async () => {
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    const tooLong = 'a'.repeat(1001)
+    fireEvent.change(screen.getByLabelText(/^reason/i), { target: { value: tooLong } })
+
+    expect(screen.getByRole('button', { name: /grant permission/i })).toBeDisabled()
+    expect(screen.getByText(/1001 \/ 1000/)).toBeInTheDocument()
+  })
+})
+
+describe('CreatePermissionsDialog — submit', () => {
+  it('submits a grant with the exact payload, omitting effectiveFrom and reason when left blank', async () => {
+    createPermissions.mockResolvedValue({ created: 2, duplicatesIgnored: [], grants: [] })
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await pick(/^subject accounts$/i, ALICE)
+      await pick(/^subject accounts$/i, BOB)
+      await pick(/^applicant account$/i, CAROL)
+      await pick(/^approver account$/i, DAVE)
+    } finally {
+      vi.useRealTimers()
+    }
+    fireEvent.change(screen.getByLabelText(/expires at/i), { target: { value: '2026-12-31' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    await waitFor(() => expect(createPermissions).toHaveBeenCalledTimes(1))
+    const [token, payload] = createPermissions.mock.calls[0]
+    expect(token).toBe('tok')
+    expect(payload).toEqual({
+      permission: 'external.image.view',
+      subjectAccounts: ['alice', 'bob'],
+      granted: true,
+      expiresAt: '2026-12-31',
+      applicantAccount: 'carol',
+      approverAccount: 'dave',
+    })
+    expect(payload).not.toHaveProperty('effectiveFrom')
+    expect(payload).not.toHaveProperty('reason')
+  })
+
+  it('includes effectiveFrom and reason in the grant payload when filled in', async () => {
+    createPermissions.mockResolvedValue({ created: 1, duplicatesIgnored: [], grants: [] })
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+    fireEvent.change(screen.getByLabelText(/effective from/i), { target: { value: '2026-09-01' } })
+    fireEvent.change(screen.getByLabelText(/^reason/i), {
+      target: { value: 'On-call staff must review photos.' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    await waitFor(() => expect(createPermissions).toHaveBeenCalledTimes(1))
+    const [, payload] = createPermissions.mock.calls[0]
+    expect(payload.effectiveFrom).toBe('2026-09-01')
+    expect(payload.reason).toBe('On-call staff must review photos.')
+  })
+
+  it('submits a revoke with the window fields omitted entirely', async () => {
+    createPermissions.mockResolvedValue({ created: 1, duplicatesIgnored: [], grants: [] })
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    fireEvent.click(screen.getByRole('radio', { name: /^revoke$/i }))
+    await fillRequiredPickers({ expiresAt: null })
+
+    fireEvent.click(screen.getByRole('button', { name: /revoke permission/i }))
+
+    await waitFor(() => expect(createPermissions).toHaveBeenCalledTimes(1))
+    const [, payload] = createPermissions.mock.calls[0]
+    expect(payload).toEqual({
+      permission: 'external.image.view',
+      subjectAccounts: ['alice'],
+      granted: false,
+      applicantAccount: 'carol',
+      approverAccount: 'dave',
+    })
+    expect(payload).not.toHaveProperty('effectiveFrom')
+    expect(payload).not.toHaveProperty('expiresAt')
+  })
+
+  it('disables the submit button while the create request is in flight', async () => {
+    let resolveCreate
+    createPermissions.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCreate = resolve
+      }),
+    )
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+    expect(screen.getByRole('button', { name: /submitting/i })).toBeDisabled()
+
+    await act(async () => {
+      resolveCreate({ created: 1, duplicatesIgnored: [], grants: [] })
+      await Promise.resolve()
+    })
+    expect(await screen.findByText(/created 1 grant/i)).toBeInTheDocument()
+  })
+})
+
+describe('CreatePermissionsDialog — result', () => {
+  it('shows the result content and calls onCreated immediately on success, without closing the dialog', async () => {
+    createPermissions.mockResolvedValue({
+      created: 2,
+      duplicatesIgnored: ['eve'],
+      grants: [
+        { id: 'g-1', subjectAccount: 'alice' },
+        { id: 'g-2', subjectAccount: 'bob' },
+      ],
+    })
+    const onCreated = vi.fn()
+    const onClose = vi.fn()
+    render(<CreatePermissionsDialog authToken="tok" onClose={onClose} onCreated={onCreated} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    expect(await screen.findByText(/created 2/i)).toBeInTheDocument()
+    expect(screen.getByText(/eve/)).toBeInTheDocument()
+    expect(onCreated).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('renders revoke-specific success copy in revoke mode', async () => {
+    createPermissions.mockResolvedValue({ created: 1, duplicatesIgnored: [], grants: [] })
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    fireEvent.click(screen.getByRole('radio', { name: /^revoke$/i }))
+    await fillRequiredPickers({ expiresAt: null })
+
+    fireEvent.click(screen.getByRole('button', { name: /revoke permission/i }))
+
+    expect(await screen.findByText(/recorded 1 revocation/i)).toBeInTheDocument()
+    expect(screen.queryByText(/created/i)).not.toBeInTheDocument()
+  })
+
+  it('the Close button in the result view calls onClose', async () => {
+    createPermissions.mockResolvedValue({ created: 1, duplicatesIgnored: [], grants: [] })
+    const onClose = vi.fn()
+    render(<CreatePermissionsDialog authToken="tok" onClose={onClose} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    expect(await screen.findByRole('button', { name: /^close$/i })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('CreatePermissionsDialog — errors', () => {
+  it('renders the mapped copy and offending accounts when createPermissions rejects with a reason', async () => {
+    createPermissions.mockRejectedValue(
+      new AsyncJobError('unknown accounts: zzz', {
+        code: 'not_found',
+        reason: 'unknown_accounts',
+        metadata: { accounts: 'zzz' },
+      }),
+    )
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    expect(await screen.findByText(/do not exist on this site/i)).toBeInTheDocument()
+    expect(screen.getByText(/zzz/)).toBeInTheDocument()
+  })
+
+  it('logs the admin out instead of showing a banner on invalid_token', async () => {
+    createPermissions.mockRejectedValue(
+      new AsyncJobError('expired', { code: 'unauthenticated', reason: 'invalid_token' }),
+    )
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    await waitFor(() => expect(logout).toHaveBeenCalledTimes(1))
+    expect(screen.queryByText(/expired/i)).not.toBeInTheDocument()
+  })
+})

--- a/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/index.jsx
+++ b/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './CreatePermissionsDialog'

--- a/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/style.css
+++ b/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/style.css
@@ -1,0 +1,73 @@
+.permissions-form-subtitle {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  margin: calc(-1 * var(--space-sm)) 0 0;
+}
+
+.permissions-mode-group {
+  display: flex;
+  gap: var(--space-lg);
+}
+
+.permissions-mode-option {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  margin-top: 0;
+  font-weight: var(--font-medium);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.permissions-mode-option input {
+  accent-color: var(--accent);
+}
+
+.permissions-reason-textarea {
+  min-height: 72px;
+  resize: vertical;
+}
+
+.permissions-subjects-count,
+.permissions-reason-count {
+  display: block;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.permissions-subjects-count.is-over-limit {
+  color: var(--status-error);
+  font-weight: var(--font-medium);
+}
+
+.permissions-field-error {
+  color: var(--status-error);
+  font-size: var(--text-sm);
+}
+
+.permissions-date-row {
+  display: flex;
+  gap: var(--space-lg);
+}
+
+.permissions-date-field {
+  flex: 1;
+}
+
+.permissions-date-field label {
+  display: block;
+}
+
+.permissions-result {
+  margin-top: 0;
+}
+
+.permissions-duplicates {
+  margin-top: var(--space-xs);
+}
+
+.permissions-metadata-list {
+  margin-top: var(--space-xs);
+  padding-left: var(--space-lg);
+  font-size: var(--text-sm);
+}

--- a/admin-frontend/src/components/PermissionsView/PermissionsPage/PermissionsPage.jsx
+++ b/admin-frontend/src/components/PermissionsView/PermissionsPage/PermissionsPage.jsx
@@ -1,0 +1,177 @@
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react'
+import { AsyncJobError, listPermissions } from '@/api'
+import { useAuth } from '@/context/AuthContext'
+import { useHandleAdminError } from '@/hooks/useHandleAdminError'
+import { useLatestRequest } from '@/hooks/useLatestRequest'
+import { useDebouncedSearch } from '@/hooks/useDebouncedSearch'
+import LazyFallback from '@/components/shared/LazyFallback'
+import Pager from '@/components/shared/Pager'
+import PermissionsTable from '../PermissionsTable'
+import { PERMISSION_KEY } from '../permissionKey'
+import './style.css'
+
+const CreatePermissionsDialog = lazy(() => import('../CreatePermissionsDialog'))
+
+// Matches admin-service's parsePaging default limit (handler.go).
+const PAGE_SIZE = 20
+
+const DEFAULT_FILTERS = { subjectAccount: '', permission: '' }
+
+// Only include a filter param when the caller actually set it — mirrors AuditView's
+// buildFilterParams so the wire call stays `{}` (all rows, newest-first) at rest.
+function buildFilterParams(filters) {
+  const params = {}
+  if (filters.subjectAccount) params.subjectAccount = filters.subjectAccount
+  if (filters.permission) params.permission = filters.permission
+  return params
+}
+
+// Settings → Permissions console: list-first, mirroring UsersConsole/UsersPage. Unfiltered shows
+// page 1 of every row for the site (admin-service now supports both filters being optional).
+// "Create" opens the grant/revoke dialog; a successful submit refreshes this list immediately.
+export default function PermissionsPage() {
+  const { session } = useAuth()
+  const authToken = session?.authToken
+  const handleAdminError = useHandleAdminError()
+
+  const [entries, setEntries] = useState([])
+  const [total, setTotal] = useState(0)
+  const [currentlyGranted, setCurrentlyGranted] = useState(undefined)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [notAuthorized, setNotAuthorized] = useState(false)
+  const [filters, setFilters] = useState(DEFAULT_FILTERS)
+  const [page, setPage] = useState(1)
+  const [showCreate, setShowCreate] = useState(false)
+
+  const { begin, isCurrent } = useLatestRequest()
+  // Tracks the filter key already reflected by the most recent fetch (whether triggered by the
+  // debounce or by goToPage), so a debounced onSearch firing after a manual goToPage — with the
+  // same filters it already picked up — doesn't clobber the page the user just navigated to.
+  const lastFetchedFilterKeyRef = useRef(JSON.stringify(DEFAULT_FILTERS))
+
+  const fetchPermissions = useCallback(
+    async (params, pageArg) => {
+      const token = begin()
+      setLoading(true)
+      setError(null)
+      try {
+        const result = await listPermissions(authToken, { ...params, page: pageArg, limit: PAGE_SIZE })
+        if (!isCurrent(token)) return // superseded by a newer request
+        setEntries(result.entries)
+        setTotal(result.total)
+        setCurrentlyGranted(result.currentlyGranted)
+        setNotAuthorized(false)
+      } catch (err) {
+        if (!isCurrent(token)) return
+        setEntries([])
+        setTotal(0)
+        setCurrentlyGranted(undefined)
+        if (err instanceof AsyncJobError && err.reason === 'not_admin') {
+          setNotAuthorized(true)
+        } else {
+          const message = handleAdminError(err)
+          if (message !== null) setError(message)
+        }
+      } finally {
+        if (isCurrent(token)) setLoading(false)
+      }
+    },
+    [authToken, handleAdminError, begin, isCurrent],
+  )
+
+  useEffect(() => {
+    setPage(1)
+    fetchPermissions({}, 1)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authToken])
+
+  const { setQuery: setDebouncedFilters } = useDebouncedSearch({
+    onSearch: (serialized) => {
+      if (serialized === lastFetchedFilterKeyRef.current) return
+      lastFetchedFilterKeyRef.current = serialized
+      const parsed = serialized ? JSON.parse(serialized) : DEFAULT_FILTERS
+      setPage(1)
+      fetchPermissions(buildFilterParams(parsed), 1)
+    },
+  })
+
+  const updateFilter = (key, value) => {
+    const next = { ...filters, [key]: value }
+    setFilters(next)
+    setDebouncedFilters(JSON.stringify(next))
+  }
+
+  const refresh = () => fetchPermissions(buildFilterParams(filters), page)
+
+  const goToPage = (nextPage) => {
+    lastFetchedFilterKeyRef.current = JSON.stringify(filters)
+    setPage(nextPage)
+    fetchPermissions(buildFilterParams(filters), nextPage)
+  }
+
+  if (notAuthorized) {
+    return (
+      <div className="permissions-page permissions-page-not-authorized">
+        <p>You are not authorized to manage permissions.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="permissions-page">
+      <div className="permissions-page-header">
+        <input
+          type="text"
+          className="permissions-filter-input"
+          aria-label="Filter by subject account"
+          placeholder="Subject account"
+          value={filters.subjectAccount}
+          onChange={(e) => updateFilter('subjectAccount', e.target.value)}
+        />
+        <select
+          className="permissions-filter-select"
+          aria-label="Filter by permission"
+          value={filters.permission}
+          onChange={(e) => updateFilter('permission', e.target.value)}
+        >
+          <option value="">All permissions</option>
+          <option value={PERMISSION_KEY}>{PERMISSION_KEY}</option>
+        </select>
+        <span className="permissions-page-total">{total} entries</span>
+        <button type="button" className="btn btn-primary" onClick={() => setShowCreate(true)}>
+          Create
+        </button>
+      </div>
+
+      {error && <div className="dialog-error">{error}</div>}
+
+      {currentlyGranted === true && (
+        <span className="permissions-badge is-granted">Currently granted</span>
+      )}
+      {currentlyGranted === false && (
+        <span className="permissions-badge is-not-granted">Not granted</span>
+      )}
+
+      <PermissionsTable entries={entries} loading={loading} />
+
+      <Pager
+        page={page}
+        limit={PAGE_SIZE}
+        total={total}
+        onPrev={() => goToPage(page - 1)}
+        onNext={() => goToPage(page + 1)}
+      />
+
+      {showCreate && (
+        <Suspense fallback={<LazyFallback variant="dialog" />}>
+          <CreatePermissionsDialog
+            authToken={authToken}
+            onClose={() => setShowCreate(false)}
+            onCreated={refresh}
+          />
+        </Suspense>
+      )}
+    </div>
+  )
+}

--- a/admin-frontend/src/components/PermissionsView/PermissionsPage/PermissionsPage.test.jsx
+++ b/admin-frontend/src/components/PermissionsView/PermissionsPage/PermissionsPage.test.jsx
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+vi.mock('@/context/AuthContext', () => ({ useAuth: vi.fn() }))
+vi.mock('@/api', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, listPermissions: vi.fn() }
+})
+
+vi.mock('../CreatePermissionsDialog', () => ({
+  default: ({ onClose, onCreated }) => (
+    <div role="dialog" aria-label="create permissions">
+      <button type="button" onClick={onCreated}>
+        Fake create
+      </button>
+      <button type="button" onClick={onClose}>
+        Fake close
+      </button>
+    </div>
+  ),
+}))
+
+import PermissionsPage from './PermissionsPage'
+import { useAuth } from '@/context/AuthContext'
+import { listPermissions, AsyncJobError } from '@/api'
+
+const GRANT_ROW = {
+  id: 'g-1',
+  permission: 'external.image.view',
+  subjectAccount: 'alice',
+  granted: true,
+  effectiveFrom: '2026-09-01',
+  expiresAt: '2026-12-31',
+  expiresAtUTC: '2026-12-31T16:00:00Z',
+  applicantAccount: 'carol',
+  approverAccount: 'dave',
+  reason: 'Business trip.',
+  recordedBy: 'p_admin_wang',
+  recordedAt: '2026-08-11T03:00:00Z',
+}
+
+const REVOKE_ROW = {
+  id: 'g-2',
+  permission: 'external.image.view',
+  subjectAccount: 'alice',
+  granted: false,
+  applicantAccount: 'carol',
+  approverAccount: 'dave',
+  reason: 'Project ended.',
+  recordedBy: 'p_admin_wang',
+  recordedAt: '2026-08-12T03:00:00Z',
+}
+
+let logout
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  logout = vi.fn()
+  useAuth.mockReturnValue({
+    session: { authToken: 'tok', account: 'root', siteId: 'site-1' },
+    logout,
+  })
+  listPermissions.mockResolvedValue({ entries: [], total: 0 })
+})
+
+describe('PermissionsPage — list', () => {
+  it('calls listPermissions(token, {page:1, limit:20}) on mount with no filters and renders rows', async () => {
+    listPermissions.mockResolvedValue({ entries: [GRANT_ROW, REVOKE_ROW], total: 2 })
+    render(<PermissionsPage />)
+    await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 1, limit: 20 }))
+
+    const rows = await screen.findAllByRole('row')
+    expect(rows).toHaveLength(3)
+    expect(rows[1]).toHaveTextContent('alice')
+    expect(rows[1]).toHaveTextContent('Grant')
+    expect(rows[1]).toHaveTextContent('2026-09-01')
+    expect(rows[1]).toHaveTextContent('2026-12-31')
+    expect(rows[2]).toHaveTextContent('Revoke')
+    expect(rows[2]).toHaveTextContent('—')
+  })
+
+  it('shows a status message when the list is empty', async () => {
+    render(<PermissionsPage />)
+    expect(await screen.findByText(/no permission records found/i)).toBeInTheDocument()
+  })
+
+  it('re-queries with {subjectAccount} after the filter input debounces', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      render(<PermissionsPage />)
+      await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 1, limit: 20 }))
+
+      fireEvent.change(screen.getByLabelText(/filter by subject account/i), {
+        target: { value: 'alice' },
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400)
+      })
+
+      await waitFor(() =>
+        expect(listPermissions).toHaveBeenCalledWith('tok', {
+          subjectAccount: 'alice',
+          page: 1,
+          limit: 20,
+        }),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('re-queries with {permission} after the permission select debounces', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      render(<PermissionsPage />)
+      await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 1, limit: 20 }))
+
+      fireEvent.change(screen.getByLabelText(/filter by permission/i), {
+        target: { value: 'external.image.view' },
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400)
+      })
+
+      await waitFor(() =>
+        expect(listPermissions).toHaveBeenCalledWith('tok', {
+          permission: 'external.image.view',
+          page: 1,
+          limit: 20,
+        }),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('combines both filters into one fetch call once both have been set', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      render(<PermissionsPage />)
+      await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 1, limit: 20 }))
+
+      fireEvent.change(screen.getByLabelText(/filter by subject account/i), {
+        target: { value: 'alice' },
+      })
+      fireEvent.change(screen.getByLabelText(/filter by permission/i), {
+        target: { value: 'external.image.view' },
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400)
+      })
+
+      await waitFor(() =>
+        expect(listPermissions).toHaveBeenCalledWith('tok', {
+          subjectAccount: 'alice',
+          permission: 'external.image.view',
+          page: 1,
+          limit: 20,
+        }),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('shows the "Currently granted" badge only when currentlyGranted is true', async () => {
+    listPermissions.mockResolvedValue({ entries: [GRANT_ROW], total: 1, currentlyGranted: true })
+    render(<PermissionsPage />)
+    expect(await screen.findByText(/currently granted/i)).toBeInTheDocument()
+  })
+
+  it('shows the "Not granted" badge when currentlyGranted is false', async () => {
+    listPermissions.mockResolvedValue({ entries: [REVOKE_ROW], total: 1, currentlyGranted: false })
+    render(<PermissionsPage />)
+    expect(await screen.findByText(/^not granted$/i)).toBeInTheDocument()
+  })
+
+  it('shows no badge when currentlyGranted is absent from the response', async () => {
+    render(<PermissionsPage />)
+    await waitFor(() => expect(listPermissions).toHaveBeenCalled())
+    expect(screen.queryByText(/currently granted/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/^not granted$/i)).not.toBeInTheDocument()
+  })
+
+  it('renders a not-authorized state on a 403 not_admin error', async () => {
+    listPermissions.mockRejectedValue(
+      new AsyncJobError('forbidden', { code: 'forbidden', reason: 'not_admin' }),
+    )
+    render(<PermissionsPage />)
+    expect(await screen.findByText(/not authorized/i)).toBeInTheDocument()
+    expect(logout).not.toHaveBeenCalled()
+  })
+
+  it('shows a formatted error banner for other failures', async () => {
+    listPermissions.mockRejectedValue(new AsyncJobError('boom', { code: 'internal' }))
+    render(<PermissionsPage />)
+    expect(await screen.findByText(/boom/i)).toBeInTheDocument()
+    expect(logout).not.toHaveBeenCalled()
+  })
+
+  it('logs the admin out instead of showing a banner on invalid_token', async () => {
+    listPermissions.mockRejectedValue(
+      new AsyncJobError('expired', { code: 'unauthenticated', reason: 'invalid_token' }),
+    )
+    render(<PermissionsPage />)
+    await waitFor(() => expect(logout).toHaveBeenCalledTimes(1))
+    expect(screen.queryByText(/expired/i)).not.toBeInTheDocument()
+  })
+
+  describe('pagination', () => {
+    it('disables Prev on page 1 and requests page 2 on Next', async () => {
+      listPermissions.mockResolvedValue({ entries: [GRANT_ROW], total: 50 })
+      render(<PermissionsPage />)
+      await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 1, limit: 20 }))
+      expect(screen.getByRole('button', { name: /prev/i })).toBeDisabled()
+
+      fireEvent.click(screen.getByRole('button', { name: /next/i }))
+      await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 2, limit: 20 }))
+    })
+
+    it('resets to page 1 when a filter changes', async () => {
+      listPermissions.mockResolvedValue({ entries: [GRANT_ROW], total: 50 })
+      vi.useFakeTimers({ shouldAdvanceTime: true })
+      try {
+        render(<PermissionsPage />)
+        await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 1, limit: 20 }))
+
+        fireEvent.click(screen.getByRole('button', { name: /next/i }))
+        await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 2, limit: 20 }))
+
+        fireEvent.change(screen.getByLabelText(/filter by subject account/i), {
+          target: { value: 'alice' },
+        })
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(400)
+        })
+
+        await waitFor(() =>
+          expect(listPermissions).toHaveBeenCalledWith('tok', {
+            subjectAccount: 'alice',
+            page: 1,
+            limit: 20,
+          }),
+        )
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+
+  it('drops a stale out-of-order response so a slow earlier request cannot overwrite newer rows', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      render(<PermissionsPage />)
+      await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 1, limit: 20 }))
+
+      let resolveSlow
+      const slow = new Promise((resolve) => {
+        resolveSlow = resolve
+      })
+      listPermissions.mockReturnValueOnce(slow)
+      fireEvent.change(screen.getByLabelText(/filter by subject account/i), {
+        target: { value: 'first' },
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400)
+      })
+      await waitFor(() =>
+        expect(listPermissions).toHaveBeenCalledWith('tok', {
+          subjectAccount: 'first',
+          page: 1,
+          limit: 20,
+        }),
+      )
+
+      listPermissions.mockResolvedValueOnce({
+        entries: [{ ...GRANT_ROW, id: 'g-3', subjectAccount: 'second' }],
+        total: 1,
+      })
+      fireEvent.change(screen.getByLabelText(/filter by subject account/i), {
+        target: { value: 'second' },
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400)
+      })
+      await waitFor(() =>
+        expect(listPermissions).toHaveBeenCalledWith('tok', {
+          subjectAccount: 'second',
+          page: 1,
+          limit: 20,
+        }),
+      )
+
+      await waitFor(() => expect(screen.getByText('second')).toBeInTheDocument())
+
+      await act(async () => {
+        resolveSlow({ entries: [{ ...GRANT_ROW, id: 'g-1', subjectAccount: 'alice' }], total: 1 })
+        await Promise.resolve()
+      })
+
+      expect(screen.queryByText('alice')).not.toBeInTheDocument()
+      expect(screen.getByText('second')).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('PermissionsPage — create dialog', () => {
+  it('opens CreatePermissionsDialog when "Create" is clicked', async () => {
+    render(<PermissionsPage />)
+    await waitFor(() => expect(listPermissions).toHaveBeenCalled())
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('refetches the list when the dialog reports a successful create, keeping the dialog open', async () => {
+    render(<PermissionsPage />)
+    await waitFor(() => expect(listPermissions).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /fake create/i }))
+
+    await waitFor(() => expect(listPermissions).toHaveBeenCalledTimes(2))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('closes the dialog when it reports close', async () => {
+    render(<PermissionsPage />)
+    await waitFor(() => expect(listPermissions).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /fake close/i }))
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+})

--- a/admin-frontend/src/components/PermissionsView/PermissionsPage/index.jsx
+++ b/admin-frontend/src/components/PermissionsView/PermissionsPage/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './PermissionsPage'

--- a/admin-frontend/src/components/PermissionsView/PermissionsPage/style.css
+++ b/admin-frontend/src/components/PermissionsView/PermissionsPage/style.css
@@ -1,0 +1,68 @@
+.permissions-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  padding: var(--space-xl);
+  height: 100%;
+  overflow-y: auto;
+}
+
+.permissions-page-not-authorized {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+}
+
+.permissions-page-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.permissions-filter-input,
+.permissions-filter-select {
+  padding: var(--space-sm) var(--space-md);
+  background: var(--bg-input);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font: inherit;
+}
+
+.permissions-filter-input {
+  flex: 1;
+  max-width: 240px;
+}
+
+.permissions-filter-input:focus,
+.permissions-filter-select:focus {
+  outline: none;
+  background: var(--bg-surface);
+  border-color: var(--accent);
+}
+
+.permissions-page-total {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.permissions-badge {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  padding: var(--space-2xs) var(--space-sm);
+  border-radius: var(--radius-pill);
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+}
+
+.permissions-badge.is-granted {
+  background: var(--status-success-bg);
+  color: var(--status-success);
+}
+
+.permissions-badge.is-not-granted {
+  background: var(--status-error-bg);
+  color: var(--status-error);
+}

--- a/admin-frontend/src/components/PermissionsView/PermissionsTable/PermissionsTable.jsx
+++ b/admin-frontend/src/components/PermissionsView/PermissionsTable/PermissionsTable.jsx
@@ -1,0 +1,50 @@
+import './style.css'
+
+// Presentational — no state, no api/ imports, mirrors UsersConsole/UserTable. Unlike the old
+// single-subject ledger table, the list can now span multiple subjects/permissions at once
+// (unfiltered or permission-only queries), so both columns are always shown.
+export default function PermissionsTable({ entries, loading }) {
+  if (loading) {
+    return <div className="permissions-table-status">Loading…</div>
+  }
+  if (entries.length === 0) {
+    return <div className="permissions-table-status">No permission records found.</div>
+  }
+
+  return (
+    <table className="permissions-table">
+      <thead>
+        <tr>
+          <th>Subject</th>
+          <th>Permission</th>
+          <th>Change</th>
+          <th>Effective from</th>
+          <th>Expires at</th>
+          <th>Applicant</th>
+          <th>Approver</th>
+          <th>Reason</th>
+          <th>Recorded by</th>
+          <th>Recorded at</th>
+        </tr>
+      </thead>
+      <tbody>
+        {entries.map((entry) => (
+          <tr key={entry.id}>
+            <td>{entry.subjectAccount}</td>
+            <td>{entry.permission}</td>
+            <td>{entry.granted ? 'Grant' : 'Revoke'}</td>
+            {/* Civil dates ("YYYY-MM-DD") render verbatim — no Date parsing, matching the
+                fixed-UTC+8 write-time rule (design doc §8): the UI performs no timezone math. */}
+            <td>{entry.effectiveFrom ?? '—'}</td>
+            <td>{entry.expiresAt ?? '—'}</td>
+            <td>{entry.applicantAccount}</td>
+            <td>{entry.approverAccount}</td>
+            <td>{entry.reason}</td>
+            <td>{entry.recordedBy}</td>
+            <td>{new Date(entry.recordedAt).toLocaleString()}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/admin-frontend/src/components/PermissionsView/PermissionsTable/index.jsx
+++ b/admin-frontend/src/components/PermissionsView/PermissionsTable/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './PermissionsTable'

--- a/admin-frontend/src/components/PermissionsView/PermissionsTable/style.css
+++ b/admin-frontend/src/components/PermissionsView/PermissionsTable/style.css
@@ -1,0 +1,32 @@
+.permissions-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-base);
+}
+
+.permissions-table th,
+.permissions-table td {
+  text-align: left;
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.permissions-table th {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+}
+
+.permissions-table td {
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  /* A 1000-rune reason can be one unbroken token (no spaces) — let it wrap
+     instead of blowing out the table width. */
+  overflow-wrap: anywhere;
+}
+
+.permissions-table-status {
+  padding: var(--space-xl);
+  text-align: center;
+  color: var(--text-muted);
+}

--- a/admin-frontend/src/components/PermissionsView/index.jsx
+++ b/admin-frontend/src/components/PermissionsView/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './PermissionsPage'

--- a/admin-frontend/src/components/PermissionsView/permissionKey.js
+++ b/admin-frontend/src/components/PermissionsView/permissionKey.js
@@ -1,0 +1,3 @@
+// Sole known permission key today (design doc §1) — no picker needed until a second key ships.
+// Shared by PermissionsPage (filter select) and CreatePermissionsDialog (grant/revoke payload).
+export const PERMISSION_KEY = 'external.image.view'


### PR DESCRIPTION
Admin-console UI for the permission whitelist, on top of the backend PR. Mirrors the Users console's structure and idioms throughout.

- **PermissionsPage** — list-first: filter bar (subject account text + permission select, shared debounce à la AuditView) + Create button + paginated ledger table. Unfiltered shows all rows newest-first; the Currently granted / Not granted badge renders only when both filters are set (matching the API's `currentlyGranted` semantics). `not_admin` handled like sibling views.
- **CreatePermissionsDialog** — grant/revoke form in the shared Modal. Grant requires an expiry date (effective-from optional, backdating allowed); revoke sends no window fields; reason optional (≤1000 runes when present); success view shows created count + duplicates and refreshes the list behind the dialog immediately.
- **AccountPicker** — search-to-select for subjects (multi, chips) and applicant/approver (single), backed by the existing `GET /v1/admin/users?q=` API; only accounts found and clicked can be submitted (free-typed text never reaches the payload); debounced + stale-response-guarded (`useLatestRequest`, incl. an out-of-order race test).
- API client: permissions list params gain optional filters; types mirror the wire contract's omit-semantics (`?:`, never null).

Tests: 30+ view tests incl. fetch-args per filter combination, dialog lifecycle + list refresh, picker race (first-issued-resolves-last), unselectable free text, revoke payload shape; full frontend suite + tsc + build green.

Known follow-up candidates (non-blocking, noted from review): AccountPicker dropdown is mouse-only (no arrow-key/Enter selection yet); a narrow interleaving can reopen the dropdown right after a selection while a newer search is still in flight.


https://github.com/user-attachments/assets/1c8fea57-f528-43c4-8719-09a4327e363d