### PR TITLE
Valkey timeout and startup hardening

### DIFF
--- a/botplatform-service/main.go
+++ b/botplatform-service/main.go
@@ -75,9 +75,12 @@ func run() error {
 	h.dmEnsurer = newNATSDMEnsurer(nc.NatsConn(), cfg.SiteID, 15*time.Second)
 
 	// Empty VALKEY_ADDRS silently disables rate-limit + idempotency (dev only; prod must supply).
+	// Lazy connect: bots are critical, so an unreachable Valkey must not block startup —
+	// otherwise a pod restart during an outage crashloops and both middlewares' fail-open
+	// posture never gets a chance to run.
 	var valkey valkeyutil.Client
 	if len(cfg.ValkeyAddrs) > 0 {
-		valkey, err = valkeyutil.ConnectCluster(ctx, cfg.ValkeyAddrs, cfg.ValkeyPassword,
+		valkey, err = valkeyutil.ConnectClusterLazy(ctx, cfg.ValkeyAddrs, cfg.ValkeyPassword,
 			valkeyutil.WithObservability(sdk),
 			valkeyutil.WithRequireParentSpan(true),
 		)

--- a/botplatform-service/metrics.go
+++ b/botplatform-service/metrics.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/hmchangw/chat/pkg/valkeyutil"
+)
+
+// controlBypassed counts requests admitted without a Valkey-backed control because Valkey
+// was unavailable. A non-zero rate means rate limiting or duplicate suppression is off for
+// that window — alert on it, since the bots keep serving and nothing else surfaces the gap.
+var controlBypassed metric.Int64Counter
+
+func init() {
+	m := otel.Meter("botplatform")
+
+	var err error
+	controlBypassed, err = m.Int64Counter(
+		"bot_control_bypassed_total",
+		metric.WithDescription("Bot requests that bypassed a Valkey-backed control due to Valkey unavailability"),
+	)
+	if err != nil {
+		// Fall back to a no-op counter so the service still runs if the global meter
+		// provider is not yet initialised at package init time.
+		controlBypassed, _ = noop.NewMeterProvider().Meter("botplatform").
+			Int64Counter("bot_control_bypassed_total")
+	}
+}
+
+// There are only three controls, so their attribute sets are built once at init
+// rather than allocated and sorted on every bypassed request.
+var (
+	controlRateLimitCaller = metric.WithAttributes(attribute.String("control", "rate_limit_caller"))
+	controlRateLimitGlobal = metric.WithAttributes(attribute.String("control", "rate_limit_global"))
+	controlIdempotency     = metric.WithAttributes(attribute.String("control", "idempotency"))
+)
+
+// bypassControl records one fail-open admission: the log carries the cause for
+// diagnosis, the counter is what to alert on since it survives log sampling.
+// Shared by every control so their bypass telemetry cannot drift apart.
+//
+// The log goes through valkeyutil.LogDegraded, which drops to Debug once the
+// circuit is open — otherwise a Valkey outage emits one Warn per bot request,
+// unthrottled, for its whole duration. The counter is unconditional, so the
+// signal you alert on never depends on log level.
+func bypassControl(ctx context.Context, control string, attrs metric.MeasurementOption, err error, logArgs ...any) {
+	valkeyutil.LogDegraded(ctx, "bot "+control+" unavailable; admitting request", err, logArgs...)
+	controlBypassed.Add(ctx, 1, attrs)
+}

--- a/botplatform-service/metrics_test.go
+++ b/botplatform-service/metrics_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// swapBypassCounter points controlBypassed at an in-memory reader and restores the
+// original on cleanup so the tests stay independent.
+func swapBypassCounter(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	c, err := mp.Meter("botplatform").Int64Counter("bot_control_bypassed_total")
+	require.NoError(t, err)
+	old := controlBypassed
+	controlBypassed = c
+	t.Cleanup(func() { controlBypassed = old })
+	return reader
+}
+
+// bypassCount returns the counter value for one control label, and whether it was recorded.
+func bypassCount(t *testing.T, reader *sdkmetric.ManualReader, control string) (int64, bool) {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "bot_control_bypassed_total" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "bot_control_bypassed_total must be an int64 sum")
+			for _, dp := range sum.DataPoints {
+				if v, found := dp.Attributes.Value(attribute.Key("control")); found && v.AsString() == control {
+					return dp.Value, true
+				}
+			}
+		}
+	}
+	return 0, false
+}
+
+func TestControlBypassedMetric(t *testing.T) {
+	t.Run("rate-limit caller fail-open records a bypass", func(t *testing.T) {
+		reader := swapBypassCounter(t)
+		client := newFakeIncr()
+		client.err = errors.New("boom")
+		r, _ := mountRLTest(t, client, 10, 100)
+
+		r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/bot", nil))
+
+		n, ok := bypassCount(t, reader, "rate_limit_caller")
+		require.True(t, ok, "expected a bypass recorded for control=rate_limit_caller")
+		assert.Equal(t, int64(1), n)
+	})
+
+	t.Run("rate-limit global fail-open records a bypass", func(t *testing.T) {
+		reader := swapBypassCounter(t)
+		client := newFakeIncr()
+		client.err = errors.New("boom")
+		client.errKey = "botrl:global"
+		r, _ := mountRLTest(t, client, 10, 100)
+
+		r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/bot", nil))
+
+		n, ok := bypassCount(t, reader, "rate_limit_global")
+		require.True(t, ok, "expected a bypass recorded for control=rate_limit_global")
+		assert.Equal(t, int64(1), n)
+	})
+
+	t.Run("idempotency fail-open records a bypass", func(t *testing.T) {
+		reader := swapBypassCounter(t)
+		client := newFakeSentinel()
+		client.setNXErr = errors.New("boom")
+		r, _, _ := mountIdemTest(t, client, &stubTime{ns: time.Second.Nanoseconds()}, "site-a")
+
+		r.ServeHTTP(httptest.NewRecorder(), idemPost("/api/v1/rooms/r1/messages", []byte(`{"content":"hi"}`)))
+
+		n, ok := bypassCount(t, reader, "idempotency")
+		require.True(t, ok, "expected a bypass recorded for control=idempotency")
+		assert.Equal(t, int64(1), n)
+	})
+
+	t.Run("healthy Valkey records no bypass", func(t *testing.T) {
+		reader := swapBypassCounter(t)
+		r, _ := mountRLTest(t, newFakeIncr(), 10, 100)
+
+		r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/bot", nil))
+
+		_, ok := bypassCount(t, reader, "rate_limit_caller")
+		assert.False(t, ok, "no bypass may be recorded while the limiter is healthy")
+	})
+}

--- a/botplatform-service/middleware.go
+++ b/botplatform-service/middleware.go
@@ -104,6 +104,10 @@ type incrExClient interface {
 
 // botRateLimit enforces per-caller then global fixed-window counters (60s each); 0 disables.
 // Per-caller first so a rejected caller doesn't consume the global budget.
+//
+// Fails OPEN: an unreachable Valkey admits the request instead of rejecting it. Bots are
+// critical, so a lost ceiling beats a dead bot — during an outage nothing throttles a
+// looping caller, which is the accepted cost of staying up.
 func botRateLimit(client incrExClient, perCaller, perGlobal int) gin.HandlerFunc {
 	const window = time.Minute
 
@@ -125,8 +129,8 @@ func botRateLimit(client incrExClient, perCaller, perGlobal int) gin.HandlerFunc
 		if perCaller > 0 {
 			n, err := client.IncrEx(ctx, "botrl:caller:"+pr.UserID, window)
 			if err != nil {
-				errhttp.Write(ctx, c, errcode.Internal("bot rate limit caller", errcode.WithCause(err)))
-				c.Abort()
+				bypassControl(ctx, "rate limit", controlRateLimitCaller, err, "counter", "caller")
+				c.Next()
 				return
 			}
 			if n > int64(perCaller) {
@@ -140,8 +144,8 @@ func botRateLimit(client incrExClient, perCaller, perGlobal int) gin.HandlerFunc
 		if perGlobal > 0 {
 			n, err := client.IncrEx(ctx, "botrl:global", window)
 			if err != nil {
-				errhttp.Write(ctx, c, errcode.Internal("bot rate limit global", errcode.WithCause(err)))
-				c.Abort()
+				bypassControl(ctx, "rate limit", controlRateLimitGlobal, err, "counter", "global")
+				c.Next()
 				return
 			}
 			if n > int64(perGlobal) {

--- a/botplatform-service/middleware_idempotency.go
+++ b/botplatform-service/middleware_idempotency.go
@@ -37,6 +37,10 @@ type resourceIDFunc func(c *gin.Context) string
 
 // botIdempotency is a Valkey-backed sentinel: SET NX per opID, then Del on non-5xx (5xx keeps
 // the sentinel so a retry can't race the still-running original). Response body is not cached.
+//
+// Fails OPEN: an unreachable Valkey admits the request. The sentinel only ever guarded
+// overlapping retries — it releases on non-5xx, and the 60s bucket re-keys later retries —
+// so failing open widens an already-open window rather than dropping durable dedup.
 func botIdempotency(
 	client sentinelClient,
 	siteID, endpoint string,
@@ -70,12 +74,13 @@ func botIdempotency(
 		key := "idem:" + opID
 
 		acquired, err := client.SetNX(ctx, key, "processing", sentinelTTL)
-		if err != nil {
-			errhttp.Write(ctx, c, errcode.Internal("bot idempotency: acquire", errcode.WithCause(err)))
-			c.Abort()
+		switch {
+		case err != nil:
+			// Admit without a sentinel; skip the release below since nothing was acquired.
+			bypassControl(ctx, "idempotency", controlIdempotency, err, "endpoint", endpoint)
+			c.Next()
 			return
-		}
-		if !acquired {
+		case !acquired:
 			c.Header("Retry-After", "1")
 			errhttp.Write(ctx, c, errBotInFlight)
 			c.Abort()

--- a/botplatform-service/middleware_idempotency_test.go
+++ b/botplatform-service/middleware_idempotency_test.go
@@ -57,11 +57,12 @@ type stubTime struct{ ns int64 }
 func (s *stubTime) Now() time.Time { return time.Unix(0, s.ns) }
 
 // mountIdemTest builds a router with a fake bot principal and idempotency middleware.
-func mountIdemTest(t *testing.T, client sentinelClient, tp timeProvider, siteID string) (*gin.Engine, *int32) {
+func mountIdemTest(t *testing.T, client sentinelClient, tp timeProvider, siteID string) (*gin.Engine, *int32, *[]byte) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	var handlerCalls int32
+	var seenBody []byte
 	r.Use(func(c *gin.Context) {
 		c.Set(ctxBotPrincipal, &session.Session{
 			UserID:  "bot-user-id",
@@ -75,6 +76,9 @@ func mountIdemTest(t *testing.T, client sentinelClient, tp timeProvider, siteID 
 		func(c *gin.Context) string { return c.Param("roomID") }, tp)
 	r.POST("/api/v1/rooms/:roomID/messages", mw, func(c *gin.Context) {
 		atomic.AddInt32(&handlerCalls, 1)
+		b, err := c.GetRawData()
+		require.NoError(t, err)
+		seenBody = b
 		if s := c.Query("status"); s != "" {
 			switch s {
 			case "500":
@@ -88,7 +92,7 @@ func mountIdemTest(t *testing.T, client sentinelClient, tp timeProvider, siteID 
 		}
 		c.Status(http.StatusOK)
 	})
-	return r, &handlerCalls
+	return r, &handlerCalls, &seenBody
 }
 
 func idemPost(url string, body []byte) *http.Request {
@@ -103,7 +107,7 @@ func TestBotIdempotency(t *testing.T) {
 	t.Run("first call acquires sentinel and handler runs", func(t *testing.T) {
 		client := newFakeSentinel()
 		tp := &stubTime{ns: time.Second.Nanoseconds()}
-		r, calls := mountIdemTest(t, client, tp, siteID)
+		r, calls, _ := mountIdemTest(t, client, tp, siteID)
 
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, idemPost("/api/v1/rooms/r1/messages", []byte(`{"content":"hi"}`)))
@@ -116,7 +120,7 @@ func TestBotIdempotency(t *testing.T) {
 	t.Run("in-flight duplicate rejected with 409 and Retry-After", func(t *testing.T) {
 		client := newFakeSentinel()
 		tp := &stubTime{ns: time.Second.Nanoseconds()}
-		r, calls := mountIdemTest(t, client, tp, siteID)
+		r, calls, _ := mountIdemTest(t, client, tp, siteID)
 
 		w1 := httptest.NewRecorder()
 		r.ServeHTTP(w1, idemPost("/api/v1/rooms/r1/messages", []byte(`{"content":"hi"}`)))
@@ -139,7 +143,7 @@ func TestBotIdempotency(t *testing.T) {
 	t.Run("same body different time bucket produces different opID", func(t *testing.T) {
 		client := newFakeSentinel()
 		tp := &stubTime{ns: time.Second.Nanoseconds()}
-		r, calls := mountIdemTest(t, client, tp, siteID)
+		r, calls, _ := mountIdemTest(t, client, tp, siteID)
 
 		w1 := httptest.NewRecorder()
 		r.ServeHTTP(w1, idemPost("/api/v1/rooms/r1/messages", []byte(`{"content":"hi"}`)))
@@ -158,7 +162,7 @@ func TestBotIdempotency(t *testing.T) {
 	t.Run("different body produces different opID", func(t *testing.T) {
 		client := newFakeSentinel()
 		tp := &stubTime{ns: time.Second.Nanoseconds()}
-		r, calls := mountIdemTest(t, client, tp, siteID)
+		r, calls, _ := mountIdemTest(t, client, tp, siteID)
 
 		r.ServeHTTP(httptest.NewRecorder(), idemPost("/api/v1/rooms/r1/messages", []byte(`{"content":"a"}`)))
 		r.ServeHTTP(httptest.NewRecorder(), idemPost("/api/v1/rooms/r1/messages", []byte(`{"content":"b"}`)))
@@ -171,7 +175,7 @@ func TestBotIdempotency(t *testing.T) {
 	t.Run("success 200 releases sentinel", func(t *testing.T) {
 		client := newFakeSentinel()
 		tp := &stubTime{ns: time.Second.Nanoseconds()}
-		r, _ := mountIdemTest(t, client, tp, siteID)
+		r, _, _ := mountIdemTest(t, client, tp, siteID)
 
 		r.ServeHTTP(httptest.NewRecorder(), idemPost("/api/v1/rooms/r1/messages", []byte(`{"content":"ok"}`)))
 		assert.Equal(t, int32(1), atomic.LoadInt32(&client.delCalls))
@@ -180,7 +184,7 @@ func TestBotIdempotency(t *testing.T) {
 	t.Run("client-error 4xx releases sentinel", func(t *testing.T) {
 		client := newFakeSentinel()
 		tp := &stubTime{ns: time.Second.Nanoseconds()}
-		r, _ := mountIdemTest(t, client, tp, siteID)
+		r, _, _ := mountIdemTest(t, client, tp, siteID)
 
 		r.ServeHTTP(httptest.NewRecorder(), idemPost("/api/v1/rooms/r1/messages?status=400", []byte(`{"content":"bad"}`)))
 		assert.Equal(t, int32(1), atomic.LoadInt32(&client.delCalls))
@@ -189,46 +193,51 @@ func TestBotIdempotency(t *testing.T) {
 	t.Run("server-error 5xx keeps sentinel", func(t *testing.T) {
 		client := newFakeSentinel()
 		tp := &stubTime{ns: time.Second.Nanoseconds()}
-		r, _ := mountIdemTest(t, client, tp, siteID)
+		r, _, _ := mountIdemTest(t, client, tp, siteID)
 
 		r.ServeHTTP(httptest.NewRecorder(), idemPost("/api/v1/rooms/r1/messages?status=500", []byte(`{"content":"boom"}`)))
 		assert.Equal(t, int32(0), atomic.LoadInt32(&client.delCalls),
 			"5xx must NOT release the sentinel — let it expire so the original handler is not raced")
 	})
 
-	t.Run("valkey error on SetNX surfaces as 500", func(t *testing.T) {
+	// Bots are critical: an unreachable sentinel must admit rather than reject. The guard
+	// only ever covered overlapping retries (it releases on non-5xx), so failing open
+	// widens a window that is already open, it does not remove durable dedup.
+	t.Run("SetNX error fails open and admits the request", func(t *testing.T) {
 		client := newFakeSentinel()
 		client.setNXErr = errors.New("boom")
 		tp := &stubTime{ns: time.Second.Nanoseconds()}
-		r, calls := mountIdemTest(t, client, tp, siteID)
+		r, calls, _ := mountIdemTest(t, client, tp, siteID)
 
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, idemPost("/api/v1/rooms/r1/messages", []byte(`{"content":"hi"}`)))
-		assert.Equal(t, http.StatusInternalServerError, w.Code)
-		assert.Equal(t, int32(0), *calls, "handler must not run when sentinel acquire fails")
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, int32(1), *calls, "handler must run when the sentinel is unavailable")
+		assert.Equal(t, int32(0), atomic.LoadInt32(&client.delCalls),
+			"must not release a sentinel it never acquired")
 	})
 
-	t.Run("body available to downstream handler after middleware", func(t *testing.T) {
-		client := newFakeSentinel()
-		tp := &stubTime{ns: time.Second.Nanoseconds()}
-		gin.SetMode(gin.TestMode)
-		r := gin.New()
-		r.Use(func(c *gin.Context) {
-			c.Set(ctxBotPrincipal, &session.Session{UserID: "u1", SiteID: siteID, Roles: []string{"bot"}})
-			c.Next()
-		})
-		mw := botIdempotency(client, siteID, "sendRoom", 30*time.Second,
-			func(c *gin.Context) string { return c.Param("roomID") }, tp)
-		var seen []byte
-		r.POST("/x/:roomID", mw, func(c *gin.Context) {
-			b, err := c.GetRawData()
-			require.NoError(t, err)
-			seen = b
-			c.Status(http.StatusOK)
-		})
+	// The middleware consumes the request body to hash it into the opID, so it
+	// must restore it for the handler — on the healthy path and the fail-open
+	// path alike, since fail-open returns early and skips the release branch.
+	t.Run("body reaches the handler", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			setNXErr error
+			payload  []byte
+		}{
+			{"sentinel acquired", nil, []byte(`{"content":"body-must-round-trip"}`)},
+			{"sentinel unavailable, admitted fail-open", errors.New("boom"), []byte(`{"content":"degraded"}`)},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				client := newFakeSentinel()
+				client.setNXErr = tc.setNXErr
+				r, _, seen := mountIdemTest(t, client, &stubTime{ns: time.Second.Nanoseconds()}, siteID)
 
-		payload := []byte(`{"content":"body-must-round-trip"}`)
-		r.ServeHTTP(httptest.NewRecorder(), idemPost("/x/r1", payload))
-		assert.Equal(t, payload, seen, "middleware must not consume the body")
+				r.ServeHTTP(httptest.NewRecorder(), idemPost("/api/v1/rooms/r1/messages", tc.payload))
+				assert.Equal(t, tc.payload, *seen, "middleware must restore the body it consumed")
+			})
+		}
 	})
 }

--- a/botplatform-service/middleware_ratelimit_test.go
+++ b/botplatform-service/middleware_ratelimit_test.go
@@ -17,10 +17,11 @@ import (
 	"github.com/hmchangw/chat/pkg/session"
 )
 
-// fakeIncr is a minimal in-memory IncrEx stub.
+// fakeIncr is a minimal in-memory IncrEx stub. errKey scopes err to one counter.
 type fakeIncr struct {
 	counts map[string]int64
 	err    error
+	errKey string
 	calls  int32
 }
 
@@ -28,7 +29,7 @@ func newFakeIncr() *fakeIncr { return &fakeIncr{counts: map[string]int64{}} }
 
 func (f *fakeIncr) IncrEx(_ context.Context, key string, _ time.Duration) (int64, error) {
 	atomic.AddInt32(&f.calls, 1)
-	if f.err != nil {
+	if f.err != nil && (f.errKey == "" || f.errKey == key) {
 		return 0, f.err
 	}
 	f.counts[key]++
@@ -111,15 +112,47 @@ func TestBotRateLimit(t *testing.T) {
 		assert.Equal(t, "rate_limited_global", body["reason"])
 	})
 
-	t.Run("valkey error is 500 (internal)", func(t *testing.T) {
+	// Bots are critical: a Valkey outage must never take them down. Losing the ceiling
+	// is the accepted cost — an unthrottled bot beats a bot that cannot send at all.
+	t.Run("caller-counter error fails open and admits the request", func(t *testing.T) {
 		client := newFakeIncr()
 		client.err = errors.New("boom")
 		r, seen := mountRLTest(t, client, 10, 100)
 
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req())
-		assert.Equal(t, http.StatusInternalServerError, w.Code)
-		assert.Equal(t, int32(0), *seen)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, int32(1), *seen, "handler must run when the limiter is unavailable")
+	})
+
+	t.Run("global-counter error fails open and admits the request", func(t *testing.T) {
+		client := newFakeIncr()
+		client.err = errors.New("boom")
+		client.errKey = "botrl:global"
+		r, seen := mountRLTest(t, client, 10, 100)
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req())
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, int32(1), *seen)
+		assert.Equal(t, int64(1), client.counts["botrl:caller:bot-user-id"],
+			"caller counter succeeded before the global counter failed")
+	})
+
+	t.Run("outage does not mask a caller already over its limit", func(t *testing.T) {
+		client := newFakeIncr()
+		r, seen := mountRLTest(t, client, 1, 100)
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req())
+		require.Equal(t, http.StatusOK, w.Code)
+
+		// Valkey fails only from here on; the caller is already at its ceiling.
+		client.err = errors.New("boom")
+		w2 := httptest.NewRecorder()
+		r.ServeHTTP(w2, req())
+		assert.Equal(t, http.StatusOK, w2.Code, "fail-open admits — the counter is unreadable")
+		assert.Equal(t, int32(2), *seen)
 	})
 
 	t.Run("zero limits disable the middleware (feature-off)", func(t *testing.T) {

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -121,9 +121,10 @@ func main() {
 	db := mongoClient.Database(cfg.MongoDB)
 	var metaValkey valkeyutil.Client
 	if len(cfg.ValkeyAddrs) > 0 {
-		metaValkey, err = valkeyutil.ConnectCluster(ctx, cfg.ValkeyAddrs, cfg.ValkeyPassword,
+		metaValkey, err = valkeyutil.ConnectClusterLazy(ctx, cfg.ValkeyAddrs, cfg.ValkeyPassword,
 			valkeyutil.WithObservability(sdk),
 			valkeyutil.WithRequireParentSpan(true),
+			valkeyutil.WithBreakerName("broadcast-worker"),
 		)
 		if err != nil {
 			slog.Error("valkey connect (room-meta L2) failed", "error", err)

--- a/docs/health-probes.md
+++ b/docs/health-probes.md
@@ -50,6 +50,46 @@ addition, since that is the failure neither current probe catches.)
 `HEALTH_ADDR` is a standard `caarlos0/env` var; override per deployment if
 `:8081` clashes with another container port.
 
+## Valkey is never a startup gate
+
+Long-running services build their Valkey client through
+`valkeyutil.ConnectClusterLazy` (or `valkeyutil.NewClusterClient`, for the
+raw-client consumers in `user-presence-service`). Both log an unreachable
+cluster and return a usable client rather than failing.
+
+This mirrors the readiness reasoning above: a shared datastore is the same for
+every replica, so making it fatal at startup means a Valkey outage overlapping a
+rollout, scale-up, or node drain crashloops every pod at once — including the
+message path. go-redis dials lazily and self-heals per call, so a pod that
+starts during an outage recovers on its own when Valkey returns.
+
+`valkeyutil.ConnectCluster` keeps the fail-fast contract and is used only by the
+one-shot CLI `tools/seed-sample-data`, where aborting the run is correct.
+
+### What degrades, and how
+
+| Consumer | Behavior while Valkey is down |
+|---|---|
+| Room metadata, room subscriptions, search restricted-rooms | Fall back to MongoDB / Elasticsearch. Correct results, higher latency and load. |
+| `botplatform-service` rate limit + idempotency | **Fail open** — bot requests are admitted unthrottled and without duplicate suppression. Bots are critical, so a lost ceiling beats a dead bot. |
+| `user-presence-service` | No fallback exists — Valkey is the store of record, so presence RPCs return `errcode` errors until it returns. `user-service` degrades `/me` to `presence: "offline"` rather than failing. |
+
+Room-metadata invalidation (`BustMeta`) is best-effort, so a rename or
+member-count change during an outage can serve stale metadata until
+`ROOM_META_L2_TTL` expires (default 15m). The write itself still lands in Mongo.
+
+### What to watch
+
+- `valkey_breaker_state` (0 closed, 1 half-open, 2 open) and
+  `valkey_breaker_transitions_total`, both labelled by service. The breaker
+  short-circuits calls while the cluster is down so the degraded path does not
+  pay a timeout per request. It decorates the `Client` facade, so
+  `user-presence-service`'s raw client is not behind one and pays its
+  `StoreProfile` budget per call instead.
+- `bot_control_bypassed_total{control}` — non-zero means bot rate limiting or
+  duplicate suppression is currently off. This is the only durable signal that
+  those controls were skipped; alert on it.
+
 ## Optional pprof profiling surface
 
 The nine message-pipeline NATS services (`broadcast-worker`, `history-service`,

--- a/docs/superpowers/plans/2026-08-11-valkey-hardening.md
+++ b/docs/superpowers/plans/2026-08-11-valkey-hardening.md
@@ -1,0 +1,1837 @@
+# Valkey Timeout and Startup Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bound Valkey failure latency with timeout profiles and a circuit breaker, and remove the fatal startup PING that crashloops seven services during a Valkey outage.
+
+**Architecture:** All changes concentrate in `pkg/valkeyutil`, which every consumer already depends on. Two named timeout `Profile` values replace go-redis defaults; a `sony/gobreaker` circuit breaker wraps the `Client` interface so a downed Valkey short-circuits instead of burning the timeout budget per call; and a new `ConnectClusterLazy` demotes the startup PING from fatal to a log. Consumers need almost no changes because they already branch on `ErrCacheMiss` and fall back on everything else — the breaker's `ErrUnavailable` lands in the existing fallback path. `botplatform-service` is the exception: it fails open on both Valkey-backed controls so bots keep serving through an outage (see Task 9).
+
+**Tech Stack:** Go 1.25, `github.com/redis/go-redis/v9` v9.18.0, `github.com/sony/gobreaker/v2` v2.4.0 (new), OpenTelemetry `go.opentelemetry.io/otel` v1.44.0, `go.uber.org/mock`, `stretchr/testify`.
+
+**Spec:** `docs/superpowers/specs/2026-08-11-valkey-hardening-design.md`
+
+## Global Constraints
+
+- Branch: `claude/valkey-outage-impact-m5dxjd`. Never push elsewhere.
+- TDD is mandatory (CLAUDE.md §4): write the failing test, run it, confirm it fails, then implement. Never write implementation before its test.
+- Use `make` targets only — never raw `go` commands. `make test SERVICE=<name>`, `make lint`, `make fmt`, `make sast`. `SERVICE` is a path relative to the repo root, so shared packages use `SERVICE=pkg/valkeyutil` (never `../pkg/...`).
+- Two exceptions, both sanctioned and both having no `make` equivalent: `go get` to add the approved dependency (Task 3), and `go test -coverprofile` / `go tool cover` for the coverage check (CLAUDE.md §4 prescribes exactly these). Everything else goes through `make`.
+- All tests run with `-race` (the Makefile handles this).
+- Minimum 80% coverage per package; `pkg/valkeyutil` is shared infrastructure and targets 90%.
+- Logging is `log/slog` with structured key-value fields. Never interpolate. Never log keys, tokens, or message bodies.
+- Error wrapping: `fmt.Errorf("short description: %w", err)` describing what the current function was doing. Never bare `err`, never `"error: %w"`.
+- New third-party dependency `github.com/sony/gobreaker/v2` is pre-approved by the spec. Add no others.
+- Timeout profile values are **code constants**, not environment variables. This is a deliberate, spec-documented departure from CLAUDE.md §6.
+- Integration tests need the `//go:build integration` tag and a `TestMain` calling `testutil.RunTests(m)`.
+- Commit after each task's tests pass. The pre-commit hook runs lint and tests.
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `pkg/valkeyutil/profile.go` (create) | `Profile` type, `CacheProfile`, `StoreProfile`, `ClusterOptionsFor`. |
+| `pkg/valkeyutil/profile_test.go` (create) | Profile → `ClusterOptions` mapping tests. |
+| `pkg/valkeyutil/breaker.go` (create) | `breakerClient`, `ErrUnavailable`, `IsUnavailable`, `isSuccessful`. |
+| `pkg/valkeyutil/breaker_test.go` (create) | State machine, `isSuccessful` classification, concurrency. |
+| `pkg/valkeyutil/metrics.go` (create) | Breaker transition counter + state gauge. |
+| `pkg/valkeyutil/valkey.go` (modify) | `ConnectClusterLazy`; `ConnectCluster` uses profiles + breaker. |
+| `pkg/valkeyutil/observability.go` (modify) | `WithProfile`, `WithBreakerName`, `WithoutCircuitBreaker` options. |
+| `user-presence-service/presencestore/store.go` (modify) | `NewValkeyStoreLazy` using `StoreProfile`. |
+| 6 × `main.go` (modify) | Switch to lazy connect, drop `os.Exit`. |
+| `pkg/roommetacache/valkey.go`, `notification-worker/members.go`, `search-service/handler.go` (modify) | Gate warn logs on `!IsUnavailable`. |
+| `botplatform-service/middleware.go`, `middleware_idempotency.go`, `main.go` (modify) | Unconditional fail-open + lazy connect (supersedes the posture split; see Task 9). |
+| `botplatform-service/metrics.go` (create) | `bot_control_bypassed_total` counter. |
+
+---
+
+### Task 1: Timeout profiles
+
+**Files:**
+- Create: `pkg/valkeyutil/profile.go`
+- Create: `pkg/valkeyutil/profile_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `type Profile struct{ DialTimeout, ReadTimeout, WriteTimeout, PoolTimeout time.Duration; MaxRetries int }`; vars `CacheProfile`, `StoreProfile`; `func ClusterOptionsFor(addrs []string, password string, p Profile) *redis.ClusterOptions`.
+
+Background: `pkg/valkeyutil/valkey.go:40` currently builds `redis.ClusterOptions` with only `Addrs` and `Password`, so go-redis defaults apply — 5s dial, 3s read, 3 retries, and `ContextTimeoutEnabled: false`. That last one means a caller's context deadline does **not** bound the socket read.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `pkg/valkeyutil/profile_test.go`:
+
+```go
+package valkeyutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClusterOptionsFor(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile Profile
+		wantRead time.Duration
+		wantRetries int
+	}{
+		{"cache profile", CacheProfile, 150 * time.Millisecond, 1},
+		{"store profile", StoreProfile, 500 * time.Millisecond, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := ClusterOptionsFor([]string{"host:6379"}, "pw", tt.profile)
+
+			assert.Equal(t, []string{"host:6379"}, opts.Addrs)
+			assert.Equal(t, "pw", opts.Password)
+			assert.Equal(t, tt.wantRead, opts.ReadTimeout)
+			assert.Equal(t, tt.wantRead, opts.WriteTimeout)
+			assert.Equal(t, tt.wantRetries, opts.MaxRetries)
+			assert.Equal(t, time.Second, opts.DialTimeout)
+			// The critical one: without this, a caller's context deadline does
+			// not bound the socket read and the profile buys nothing.
+			assert.True(t, opts.ContextTimeoutEnabled, "ContextTimeoutEnabled must be set")
+		})
+	}
+}
+
+func TestProfiles_CacheIsTighterThanStore(t *testing.T) {
+	// Presence uses Valkey as its store of record, so it gets more headroom
+	// than the cache consumers, which all have a Mongo/ES fallback.
+	assert.Less(t, CacheProfile.ReadTimeout, StoreProfile.ReadTimeout)
+	assert.Less(t, CacheProfile.MaxRetries, StoreProfile.MaxRetries)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test SERVICE=pkg/valkeyutil`
+(If the Makefile's `SERVICE` var does not resolve `pkg/` paths, run `make test` and confirm the `pkg/valkeyutil` package fails to build.)
+Expected: FAIL — `undefined: Profile`, `undefined: CacheProfile`, `undefined: ClusterOptionsFor`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `pkg/valkeyutil/profile.go`:
+
+```go
+package valkeyutil
+
+import (
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Profile is a bounded timeout budget for a Valkey client. go-redis defaults
+// (5s dial, 3s read, 3 retries) are far too loose for a cache on the message
+// hot path: against a blackholing Valkey they turn a fail-open read into a
+// multi-second stall on every call.
+//
+// These are code constants rather than environment variables by design (see
+// the spec). They are internal tuning, and a wrong value silently reintroduces
+// the stall this package exists to prevent.
+type Profile struct {
+	DialTimeout  time.Duration
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+	PoolTimeout  time.Duration
+	MaxRetries   int
+}
+
+var (
+	// CacheProfile serves consumers that have a backing store to fall back to
+	// (room meta, room subscriptions, search restricted-rooms). Failing fast
+	// matters more than succeeding slowly — the fallback is always available.
+	CacheProfile = Profile{
+		DialTimeout:  time.Second,
+		ReadTimeout:  150 * time.Millisecond,
+		WriteTimeout: 150 * time.Millisecond,
+		PoolTimeout:  250 * time.Millisecond,
+		MaxRetries:   1,
+	}
+
+	// StoreProfile serves user-presence-service, where Valkey is the store of
+	// record and no fallback exists. A cache-tight ceiling on a Lua EVAL under
+	// load would manufacture failures nothing can absorb.
+	StoreProfile = Profile{
+		DialTimeout:  time.Second,
+		ReadTimeout:  500 * time.Millisecond,
+		WriteTimeout: 500 * time.Millisecond,
+		PoolTimeout:  time.Second,
+		MaxRetries:   2,
+	}
+)
+
+// ClusterOptionsFor builds the go-redis cluster options for a profile.
+// Exported so user-presence-service/presencestore, which constructs its own
+// client for Lua scripting, applies the same budget without duplicating it.
+func ClusterOptionsFor(addrs []string, password string, p Profile) *redis.ClusterOptions {
+	return &redis.ClusterOptions{
+		Addrs:        addrs,
+		Password:     password,
+		DialTimeout:  p.DialTimeout,
+		ReadTimeout:  p.ReadTimeout,
+		WriteTimeout: p.WriteTimeout,
+		PoolTimeout:  p.PoolTimeout,
+		MaxRetries:   p.MaxRetries,
+		// Without this, go-redis ignores the caller's context deadline for
+		// socket reads and only ReadTimeout applies.
+		ContextTimeoutEnabled: true,
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test SERVICE=pkg/valkeyutil` (or `make test`)
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/valkeyutil/profile.go pkg/valkeyutil/profile_test.go
+git commit -m "feat(valkeyutil): add CacheProfile and StoreProfile timeout budgets"
+```
+
+---
+
+### Task 2: Apply profiles in ConnectCluster, prove latency is bounded
+
+**Files:**
+- Modify: `pkg/valkeyutil/valkey.go:39-61` (`ConnectCluster`)
+- Modify: `pkg/valkeyutil/observability.go:19-22` (`connectConfig`), `:58-66` (`newConnectConfig`)
+- Modify: `pkg/valkeyutil/valkey_test.go` (append)
+
+**Interfaces:**
+- Consumes: `ClusterOptionsFor`, `CacheProfile`, `StoreProfile` from Task 1.
+- Produces: `func WithProfile(p Profile) Option`. `ConnectCluster` keeps its existing signature `(ctx, addrs, password, opts ...Option) (Client, error)` and now defaults to `CacheProfile`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/valkeyutil/valkey_test.go`:
+
+```go
+// blackholeListener accepts TCP connections and never responds. This is the
+// failure mode that matters: a Valkey that refuses connections fails fast on
+// its own, but one that silently drops packets stalls every call until a
+// timeout fires. Connection-refused testing never catches it.
+func blackholeListener(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed
+			}
+			// Hold the connection open and never write. Closed by t.Cleanup.
+			t.Cleanup(func() { _ = conn.Close() })
+		}
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		<-done
+	})
+	return ln.Addr().String()
+}
+
+func TestConnectCluster_BoundedLatencyAgainstBlackhole(t *testing.T) {
+	addr := blackholeListener(t)
+
+	start := time.Now()
+	_, err := ConnectCluster(context.Background(), []string{addr}, "")
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "connect against a blackhole must fail, not hang")
+	// The 5s ping ceiling in ConnectCluster is the outer bound; the profile
+	// should bring us well inside it. go-redis defaults (5s dial + 3s read x3
+	// retries) would blow through this.
+	assert.Less(t, elapsed, 6*time.Second, "connect must be bounded by dial/read timeouts")
+}
+
+func TestWithProfile_OverridesDefault(t *testing.T) {
+	cfg := newConnectConfig(WithProfile(StoreProfile))
+	assert.Equal(t, StoreProfile, cfg.profile)
+}
+
+func TestNewConnectConfig_DefaultsToCacheProfile(t *testing.T) {
+	cfg := newConnectConfig()
+	assert.Equal(t, CacheProfile, cfg.profile)
+}
+```
+
+Add `net`, `time`, `context` to the test file's imports if not already present, plus `require` from `github.com/stretchr/testify/require`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test SERVICE=pkg/valkeyutil`
+Expected: FAIL — `undefined: WithProfile`, and `cfg.profile` is not a field of `connectConfig`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `pkg/valkeyutil/observability.go`, add the field to `connectConfig`:
+
+```go
+type connectConfig struct {
+	obs       Observability
+	redisOpts []o11yredis.Option
+	profile   Profile
+}
+```
+
+Add the option (place it near the other `With*` functions):
+
+```go
+// WithProfile selects the timeout budget for the client. Defaults to
+// CacheProfile; user-presence-service passes StoreProfile because Valkey is
+// its store of record rather than a cache.
+func WithProfile(p Profile) Option {
+	return func(c *connectConfig) { c.profile = p }
+}
+```
+
+Change `newConnectConfig` to seed the default:
+
+```go
+func newConnectConfig(opts ...Option) connectConfig {
+	cfg := connectConfig{profile: CacheProfile}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	return cfg
+}
+```
+
+In `pkg/valkeyutil/valkey.go`, rewrite the head of `ConnectCluster` so the config is read **before** the client is built:
+
+```go
+func ConnectCluster(ctx context.Context, addrs []string, password string, opts ...Option) (Client, error) {
+	cc := newConnectConfig(opts...)
+	c := redis.NewClusterClient(ClusterOptionsFor(addrs, password, cc.profile))
+	if err := instrumentCluster(c, cc); err != nil {
+		if closeErr := c.Close(); closeErr != nil {
+			slog.Warn("valkey cluster close after failed instrument", "error", closeErr)
+		}
+		return nil, err
+	}
+	// ... rest of the function (ping gate) unchanged for now
+```
+
+Note the ordering change: the existing code calls `newConnectConfig(opts...)` inline inside `instrumentCluster(c, newConnectConfig(opts...))`. Hoist it to a local so the same config drives both the options and the instrumentation.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test SERVICE=pkg/valkeyutil`
+Expected: PASS. The blackhole test should complete in roughly 1–2 seconds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/valkeyutil/valkey.go pkg/valkeyutil/observability.go pkg/valkeyutil/valkey_test.go
+git commit -m "feat(valkeyutil): apply timeout profiles to cluster clients"
+```
+
+---
+
+### Task 3: Circuit breaker
+
+**Files:**
+- Create: `pkg/valkeyutil/breaker.go`
+- Create: `pkg/valkeyutil/breaker_test.go`
+- Modify: `go.mod`, `go.sum`
+
+**Interfaces:**
+- Consumes: `Client`, `ErrCacheMiss` from `pkg/valkeyutil/valkey.go:18-32`.
+- Produces: `var ErrUnavailable error`; `func IsUnavailable(err error) bool`; `func NewBreakerClient(inner Client, name string) Client`; `func isSuccessful(err error) bool` (unexported, tested directly since it is the highest-risk logic in the package).
+
+Background: bounded timeouts still cost ~300ms per call during an outage. At message volume that is its own throughput problem, so the client short-circuits once Valkey is demonstrably down.
+
+- [ ] **Step 1: Add the dependency**
+
+```bash
+go get github.com/sony/gobreaker/v2@v2.4.0
+```
+
+Then verify it resolved to exactly `v2.4.0`:
+
+```bash
+grep gobreaker go.mod
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `pkg/valkeyutil/breaker_test.go`:
+
+```go
+package valkeyutil
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubClient is a Client whose Get result is controlled per call.
+type stubClient struct {
+	mu   sync.Mutex
+	err  error
+	val  string
+	gets int
+}
+
+func (s *stubClient) Get(ctx context.Context, key string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.gets++
+	return s.val, s.err
+}
+func (s *stubClient) Set(ctx context.Context, key, value string, ttl time.Duration) error { return s.err }
+func (s *stubClient) SetNX(ctx context.Context, key, value string, ttl time.Duration) (bool, error) {
+	return true, s.err
+}
+func (s *stubClient) IncrEx(ctx context.Context, key string, ttl time.Duration) (int64, error) {
+	return 1, s.err
+}
+func (s *stubClient) Del(ctx context.Context, keys ...string) error { return s.err }
+func (s *stubClient) Close() error                                  { return nil }
+
+func (s *stubClient) setErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.err = err
+}
+func (s *stubClient) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.gets
+}
+
+// This is the test that matters most. gobreaker counts every returned error as
+// a failure, so a cache miss — which is the cache working correctly — would
+// trip the breaker and disable Valkey for a perfectly healthy workload.
+func TestIsSuccessful(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil is success", nil, true},
+		{"cache miss is success, not a failure", ErrCacheMiss, true},
+		{"wrapped cache miss is success", fmt.Errorf("valkey get json: %w", ErrCacheMiss), true},
+		{"context canceled is success", context.Canceled, true},
+		{"transport error is failure", errors.New("dial tcp: i/o timeout"), false},
+		{"plain error is failure", errors.New("x"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSuccessful(tt.err))
+		})
+	}
+}
+
+func TestIsSuccessful_StringSimilarErrorIsStillAFailure(t *testing.T) {
+	// Only errors.Is-matching misses count as success. An error that merely
+	// reads like a miss must still trip the breaker.
+	lookalike := errors.New("valkey get json: " + ErrCacheMiss.Error())
+	assert.False(t, isSuccessful(lookalike))
+}
+
+func TestBreaker_CacheMissesNeverTrip(t *testing.T) {
+	stub := &stubClient{err: ErrCacheMiss}
+	c := NewBreakerClient(stub, "test-miss")
+
+	for i := 0; i < 50; i++ {
+		_, err := c.Get(context.Background(), "k")
+		require.ErrorIs(t, err, ErrCacheMiss)
+	}
+	assert.Equal(t, 50, stub.callCount(), "every call must reach the inner client")
+}
+
+func TestBreaker_TripsAfterConsecutiveFailures(t *testing.T) {
+	boom := errors.New("i/o timeout")
+	stub := &stubClient{err: boom}
+	c := NewBreakerClient(stub, "test-trip")
+
+	for i := 0; i < breakerFailureThreshold; i++ {
+		_, err := c.Get(context.Background(), "k")
+		require.ErrorIs(t, err, boom)
+	}
+	inner := stub.callCount()
+
+	// Breaker is now open: calls short-circuit without touching the inner client.
+	_, err := c.Get(context.Background(), "k")
+	assert.True(t, IsUnavailable(err), "expected ErrUnavailable, got %v", err)
+	assert.Equal(t, inner, stub.callCount(), "open breaker must not call inner")
+}
+
+func TestBreaker_RecoversAfterCooldown(t *testing.T) {
+	boom := errors.New("i/o timeout")
+	stub := &stubClient{err: boom}
+	c := NewBreakerClient(stub, "test-recover")
+
+	for i := 0; i < breakerFailureThreshold; i++ {
+		_, _ = c.Get(context.Background(), "k")
+	}
+	require.True(t, IsUnavailable(mustErr(c.Get(context.Background(), "k"))))
+
+	// Valkey comes back; wait out the cooldown so the breaker half-opens.
+	stub.setErr(nil)
+	stub.val = "v"
+	time.Sleep(breakerCooldown + 100*time.Millisecond)
+
+	got, err := c.Get(context.Background(), "k")
+	require.NoError(t, err)
+	assert.Equal(t, "v", got)
+}
+
+func TestBreaker_ConcurrentCallersAreSafe(t *testing.T) {
+	stub := &stubClient{err: errors.New("i/o timeout")}
+	c := NewBreakerClient(stub, "test-concurrent")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = c.Get(context.Background(), "k")
+		}()
+	}
+	wg.Wait() // -race asserts no data race in the breaker itself
+}
+
+func TestBreaker_PassesThroughAllMethods(t *testing.T) {
+	stub := &stubClient{val: "v"}
+	c := NewBreakerClient(stub, "test-methods")
+	ctx := context.Background()
+
+	got, err := c.Get(ctx, "k")
+	require.NoError(t, err)
+	assert.Equal(t, "v", got)
+
+	require.NoError(t, c.Set(ctx, "k", "v", time.Minute))
+
+	ok, err := c.SetNX(ctx, "k", "v", time.Minute)
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	n, err := c.IncrEx(ctx, "k", time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+
+	require.NoError(t, c.Del(ctx, "k"))
+	require.NoError(t, c.Close())
+}
+
+func mustErr(_ string, err error) error { return err }
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `make test SERVICE=pkg/valkeyutil`
+Expected: FAIL — `undefined: isSuccessful`, `NewBreakerClient`, `IsUnavailable`, `breakerFailureThreshold`, `breakerCooldown`.
+
+- [ ] **Step 4: Write minimal implementation**
+
+Create `pkg/valkeyutil/breaker.go`:
+
+```go
+package valkeyutil
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/sony/gobreaker/v2"
+)
+
+const (
+	// breakerFailureThreshold rides out a single blip but trips on a real
+	// outage.
+	breakerFailureThreshold = 5
+	// breakerCooldown is how long the breaker stays open before allowing one
+	// half-open probe through.
+	breakerCooldown = 5 * time.Second
+)
+
+// ErrUnavailable is returned when the circuit breaker is open — Valkey is
+// known-down and the call short-circuited without a network round-trip.
+//
+// Every fail-open consumer already branches errors.Is(err, ErrCacheMiss) for
+// the miss case and falls back on everything else, so ErrUnavailable lands in
+// the fallback path with no consumer change required.
+var ErrUnavailable = errors.New("valkey: circuit open")
+
+// IsUnavailable reports whether err came from an open circuit breaker rather
+// than a live failure. Call sites use it to suppress per-call warn logs during
+// an outage — the breaker already logs each state transition once.
+func IsUnavailable(err error) bool {
+	return errors.Is(err, ErrUnavailable)
+}
+
+// isSuccessful classifies an inner-client error for breaker accounting.
+//
+// This is the most consequential function in the package. gobreaker treats
+// every returned error as a failure, so without this a cold or sparse keyspace
+// would trip the breaker on ordinary cache misses and disable Valkey for a
+// workload that is behaving perfectly — a self-inflicted outage. Only genuine
+// transport failures may count toward the trip threshold.
+func isSuccessful(err error) bool {
+	if err == nil {
+		return true
+	}
+	return errors.Is(err, ErrCacheMiss) || errors.Is(err, context.Canceled)
+}
+
+// breakerClient wraps a Client with one shared circuit breaker. Reachability
+// is a property of the connection, not of the command, so all methods share a
+// single breaker rather than one per operation.
+type breakerClient struct {
+	inner Client
+	cb    *gobreaker.CircuitBreaker[any]
+}
+
+// NewBreakerClient wraps inner with a circuit breaker named name (used in log
+// and metric labels).
+func NewBreakerClient(inner Client, name string) Client {
+	cb := gobreaker.NewCircuitBreaker[any](gobreaker.Settings{
+		Name:        name,
+		MaxRequests: 1, // one half-open probe, so recovery never stampedes
+		Interval:    0, // never auto-reset counts while closed
+		Timeout:     breakerCooldown,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= breakerFailureThreshold
+		},
+		IsSuccessful: isSuccessful,
+		OnStateChange: func(name string, from, to gobreaker.State) {
+			slog.Warn("valkey circuit breaker state change",
+				"breaker", name, "from", from.String(), "to", to.String())
+			recordBreakerTransition(name, from.String(), to.String(), to)
+		},
+	})
+	return &breakerClient{inner: inner, cb: cb}
+}
+
+// exec runs fn through the breaker, translating gobreaker's own rejection
+// errors into ErrUnavailable so consumers have one sentinel to match on.
+func (b *breakerClient) exec(fn func() (any, error)) (any, error) {
+	v, err := b.cb.Execute(fn)
+	if errors.Is(err, gobreaker.ErrOpenState) || errors.Is(err, gobreaker.ErrTooManyRequests) {
+		return nil, ErrUnavailable
+	}
+	return v, err
+}
+
+func (b *breakerClient) Get(ctx context.Context, key string) (string, error) {
+	v, err := b.exec(func() (any, error) { return b.inner.Get(ctx, key) })
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil
+}
+
+func (b *breakerClient) Set(ctx context.Context, key, value string, ttl time.Duration) error {
+	_, err := b.exec(func() (any, error) { return nil, b.inner.Set(ctx, key, value, ttl) })
+	return err
+}
+
+func (b *breakerClient) SetNX(ctx context.Context, key, value string, ttl time.Duration) (bool, error) {
+	v, err := b.exec(func() (any, error) { return b.inner.SetNX(ctx, key, value, ttl) })
+	if err != nil {
+		return false, err
+	}
+	return v.(bool), nil
+}
+
+func (b *breakerClient) IncrEx(ctx context.Context, key string, ttl time.Duration) (int64, error) {
+	v, err := b.exec(func() (any, error) { return b.inner.IncrEx(ctx, key, ttl) })
+	if err != nil {
+		return 0, err
+	}
+	return v.(int64), nil
+}
+
+func (b *breakerClient) Del(ctx context.Context, keys ...string) error {
+	_, err := b.exec(func() (any, error) { return nil, b.inner.Del(ctx, keys...) })
+	return err
+}
+
+// Close bypasses the breaker — shutdown must not be blocked by an open circuit.
+func (b *breakerClient) Close() error { return b.inner.Close() }
+```
+
+Note: `recordBreakerTransition` is defined in Task 4. To keep this task compiling on its own, add a temporary no-op at the bottom of `breaker.go` and delete it in Task 4:
+
+```go
+// Replaced by the real implementation in metrics.go (Task 4).
+func recordBreakerTransition(name, from, to string, state gobreaker.State) {}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `make test SERVICE=pkg/valkeyutil`
+Expected: PASS. `TestBreaker_RecoversAfterCooldown` takes ~5s because it waits out the real cooldown.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add go.mod go.sum pkg/valkeyutil/breaker.go pkg/valkeyutil/breaker_test.go
+git commit -m "feat(valkeyutil): add circuit breaker with cache-miss-aware failure accounting"
+```
+
+---
+
+### Task 4: Breaker observability
+
+**Files:**
+- Create: `pkg/valkeyutil/metrics.go`
+- Modify: `pkg/valkeyutil/breaker.go` (delete the temporary no-op from Task 3)
+- Create: `pkg/valkeyutil/metrics_test.go`
+
+**Interfaces:**
+- Consumes: `gobreaker.State` from Task 3's `OnStateChange`.
+- Produces: `func recordBreakerTransition(name, from, to string, state gobreaker.State)`.
+
+Follow the instrument-init pattern already used by `pkg/roomkeymetrics/roomkeymetrics.go:21-49` — package `init()`, `otel.Meter(...)`, and a `noop` fallback so the program still runs when no MeterProvider is installed.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `pkg/valkeyutil/metrics_test.go`:
+
+```go
+package valkeyutil
+
+import (
+	"testing"
+
+	"github.com/sony/gobreaker/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStateValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		state gobreaker.State
+		want  int64
+	}{
+		{"closed", gobreaker.StateClosed, 0},
+		{"half-open", gobreaker.StateHalfOpen, 1},
+		{"open", gobreaker.StateOpen, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, stateValue(tt.state))
+		})
+	}
+}
+
+func TestRecordBreakerTransition_NoPanicWithoutMeterProvider(t *testing.T) {
+	// Instruments fall back to no-ops when no MeterProvider is installed;
+	// recording must stay safe on the hot path regardless.
+	assert.NotPanics(t, func() {
+		recordBreakerTransition("test", "closed", "open", gobreaker.StateOpen)
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test SERVICE=pkg/valkeyutil`
+Expected: FAIL — `undefined: stateValue`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Delete the temporary no-op `recordBreakerTransition` from the bottom of `pkg/valkeyutil/breaker.go`.
+
+Create `pkg/valkeyutil/metrics.go`:
+
+```go
+package valkeyutil
+
+import (
+	"context"
+
+	"github.com/sony/gobreaker/v2"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	// breakerTransitions counts circuit breaker state changes, tagged by
+	// breaker name and the from/to states.
+	breakerTransitions metric.Int64Counter
+	// breakerState reports the current state: 0 closed, 1 half-open, 2 open.
+	breakerState metric.Int64Gauge
+)
+
+func init() {
+	m := otel.Meter("valkey")
+
+	var err error
+	breakerTransitions, err = m.Int64Counter(
+		"valkey_breaker_transitions_total",
+		metric.WithDescription("Valkey circuit breaker state transitions, by breaker and from/to state"),
+	)
+	if err != nil {
+		breakerTransitions, _ = noop.NewMeterProvider().Meter("valkey").
+			Int64Counter("valkey_breaker_transitions_total")
+	}
+
+	breakerState, err = m.Int64Gauge(
+		"valkey_breaker_state",
+		metric.WithDescription("Current Valkey circuit breaker state: 0 closed, 1 half-open, 2 open"),
+	)
+	if err != nil {
+		breakerState, _ = noop.NewMeterProvider().Meter("valkey").
+			Int64Gauge("valkey_breaker_state")
+	}
+}
+
+// stateValue encodes a breaker state for the gauge.
+func stateValue(s gobreaker.State) int64 {
+	switch s {
+	case gobreaker.StateHalfOpen:
+		return 1
+	case gobreaker.StateOpen:
+		return 2
+	default:
+		return 0
+	}
+}
+
+// recordBreakerTransition emits the transition counter and current-state gauge.
+func recordBreakerTransition(name, from, to string, state gobreaker.State) {
+	ctx := context.Background()
+	breakerTransitions.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("breaker", name),
+		attribute.String("from", from),
+		attribute.String("to", to),
+	))
+	breakerState.Record(ctx, stateValue(state), metric.WithAttributes(
+		attribute.String("breaker", name),
+	))
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test SERVICE=pkg/valkeyutil`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/valkeyutil/metrics.go pkg/valkeyutil/metrics_test.go pkg/valkeyutil/breaker.go
+git commit -m "feat(valkeyutil): emit circuit breaker transition and state metrics"
+```
+
+---
+
+### Task 5: ConnectClusterLazy
+
+**Files:**
+- Modify: `pkg/valkeyutil/valkey.go` (add `ConnectClusterLazy`, wire the breaker into both constructors)
+- Modify: `pkg/valkeyutil/observability.go` (add `WithBreakerName`, `WithoutCircuitBreaker`)
+- Modify: `pkg/valkeyutil/valkey_test.go` (append)
+
+**Interfaces:**
+- Consumes: `NewBreakerClient` (Task 3), `ClusterOptionsFor` + profiles (Tasks 1–2).
+- Produces: `func ConnectClusterLazy(ctx context.Context, addrs []string, password string, opts ...Option) (Client, error)`; `func WithBreakerName(name string) Option`; `func WithoutCircuitBreaker() Option`.
+
+Background: the crashloop comes entirely from the startup PING at `pkg/valkeyutil/valkey.go:52` being fatal. go-redis already dials lazily and self-heals per call, so no background retry goroutine is needed — and therefore no goroutine termination path to get wrong (CLAUDE.md §3).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/valkeyutil/valkey_test.go`:
+
+```go
+func TestConnectClusterLazy_ReturnsUsableClientWhenUnreachable(t *testing.T) {
+	addr := blackholeListener(t)
+
+	client, err := ConnectClusterLazy(context.Background(), []string{addr}, "")
+	require.NoError(t, err, "lazy connect must not fail on an unreachable Valkey")
+	require.NotNil(t, client)
+	t.Cleanup(func() { _ = client.Close() })
+
+	// The client is usable; the call itself errors rather than panicking.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, getErr := client.Get(ctx, "some-key")
+	assert.Error(t, getErr)
+}
+
+func TestConnectClusterLazy_BoundedFirstCall(t *testing.T) {
+	addr := blackholeListener(t)
+	client, err := ConnectClusterLazy(context.Background(), []string{addr}, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	start := time.Now()
+	_, _ = client.Get(context.Background(), "k")
+	assert.Less(t, time.Since(start), 5*time.Second, "CacheProfile must bound the first call")
+}
+
+func TestWithoutCircuitBreaker(t *testing.T) {
+	cfg := newConnectConfig(WithoutCircuitBreaker())
+	assert.False(t, cfg.breaker)
+}
+
+func TestNewConnectConfig_BreakerOnByDefault(t *testing.T) {
+	cfg := newConnectConfig()
+	assert.True(t, cfg.breaker)
+	assert.Equal(t, "valkey", cfg.breakerName)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test SERVICE=pkg/valkeyutil`
+Expected: FAIL — `undefined: ConnectClusterLazy`, `WithoutCircuitBreaker`; `cfg.breaker` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `pkg/valkeyutil/observability.go`, extend `connectConfig` and its defaults:
+
+```go
+type connectConfig struct {
+	obs         Observability
+	redisOpts   []o11yredis.Option
+	profile     Profile
+	breaker     bool
+	breakerName string
+}
+```
+
+```go
+func newConnectConfig(opts ...Option) connectConfig {
+	cfg := connectConfig{profile: CacheProfile, breaker: true, breakerName: "valkey"}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	return cfg
+}
+```
+
+Add the two options:
+
+```go
+// WithBreakerName labels the circuit breaker in logs and metrics. Defaults to
+// "valkey"; pass the service name when several clients coexist in one process.
+func WithBreakerName(name string) Option {
+	return func(c *connectConfig) { c.breakerName = name }
+}
+
+// WithoutCircuitBreaker disables the breaker. Intended for tests and one-shot
+// CLI tools, where short-circuiting adds nothing.
+func WithoutCircuitBreaker() Option {
+	return func(c *connectConfig) { c.breaker = false }
+}
+```
+
+In `pkg/valkeyutil/valkey.go`, factor the shared construction and add the lazy variant:
+
+```go
+// buildCluster constructs and instruments the raw cluster client.
+func buildCluster(addrs []string, password string, cc connectConfig) (*redis.ClusterClient, error) {
+	c := redis.NewClusterClient(ClusterOptionsFor(addrs, password, cc.profile))
+	if err := instrumentCluster(c, cc); err != nil {
+		if closeErr := c.Close(); closeErr != nil {
+			slog.Warn("valkey cluster close after failed instrument", "error", closeErr)
+		}
+		return nil, err
+	}
+	return c, nil
+}
+
+// wrap applies the circuit breaker unless disabled.
+func wrap(c *redis.ClusterClient, cc connectConfig) Client {
+	base := Client(&clusterClient{c: c})
+	if !cc.breaker {
+		return base
+	}
+	return NewBreakerClient(base, cc.breakerName)
+}
+
+// ConnectClusterLazy builds an instrumented cluster client without gating on
+// reachability. The PING becomes a non-fatal probe: unreachable Valkey is
+// logged and a usable Client is still returned.
+//
+// This is what services must use. go-redis dials lazily and self-heals per
+// call, so a Valkey outage no longer prevents a pod from starting — which
+// otherwise turns any rollout or scale-up during an outage into a
+// CrashLoopBackOff on the message path.
+//
+// The returned error covers construction and instrumentation failures only.
+func ConnectClusterLazy(ctx context.Context, addrs []string, password string, opts ...Option) (Client, error) {
+	cc := newConnectConfig(opts...)
+	c, err := buildCluster(addrs, password, cc)
+	if err != nil {
+		return nil, err
+	}
+	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := c.Ping(pingCtx).Err(); err != nil {
+		slog.Warn("valkey cluster unreachable at startup; continuing with lazy connect",
+			"addrs", addrs, "error", err)
+	} else {
+		slog.Info("connected to Valkey cluster", "addrs", addrs)
+	}
+	return wrap(c, cc), nil
+}
+```
+
+Rewrite `ConnectCluster` to reuse the same helpers, keeping its fail-fast contract for the one-shot CLI:
+
+```go
+// ConnectCluster dials a Valkey cluster, verifies connectivity with PING, and
+// returns a Client. It fails when Valkey is unreachable.
+//
+// Long-running services must use ConnectClusterLazy instead — a fatal startup
+// probe crashloops the pod during a Valkey outage. This variant remains for
+// one-shot CLI tools (tools/seed-sample-data), where failing fast is correct.
+func ConnectCluster(ctx context.Context, addrs []string, password string, opts ...Option) (Client, error) {
+	cc := newConnectConfig(opts...)
+	c, err := buildCluster(addrs, password, cc)
+	if err != nil {
+		return nil, err
+	}
+	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := c.Ping(pingCtx).Err(); err != nil {
+		if closeErr := c.Close(); closeErr != nil {
+			slog.Warn("valkey cluster close after failed connect", "error", closeErr)
+		}
+		return nil, fmt.Errorf("valkey cluster connect: %w", err)
+	}
+	slog.Info("connected to Valkey cluster", "addrs", addrs)
+	return wrap(c, cc), nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test SERVICE=pkg/valkeyutil`
+Expected: PASS
+
+- [ ] **Step 5: Run the integration suite to confirm no regression**
+
+Run: `make test-integration SERVICE=pkg/valkeyutil`
+Expected: PASS (requires Docker; uses `testutil.SharedValkeyCluster`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/valkeyutil/valkey.go pkg/valkeyutil/observability.go pkg/valkeyutil/valkey_test.go
+git commit -m "feat(valkeyutil): add ConnectClusterLazy and wire the breaker into constructors"
+```
+
+---
+
+### Task 6: Presence store lazy connect
+
+**Files:**
+- Modify: `user-presence-service/presencestore/store.go:184-203`
+- Modify: `user-presence-service/main.go:95-102`
+- Modify: `user-presence-service/presencestore/store_test.go` (create if absent)
+
+**Interfaces:**
+- Consumes: `valkeyutil.ClusterOptionsFor`, `valkeyutil.StoreProfile` (Task 1).
+- Produces: `func NewValkeyStoreLazy(cfg ClusterConfig, staleThreshold, connsTTL time.Duration) *Store`.
+
+`presencestore` builds its own `*redis.ClusterClient` because it needs Lua scripting, so it cannot use `valkeyutil.Client`. It uses `ClusterOptionsFor` so the timeout budget is not duplicated. Per the spec, presence starts and serves `errcode` errors rather than exiting.
+
+- [ ] **Step 1: Write the failing test**
+
+Create or append to `user-presence-service/presencestore/store_test.go`:
+
+```go
+package presencestore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewValkeyStoreLazy_ReturnsStoreWhenUnreachable(t *testing.T) {
+	// 203.0.113.0/24 is TEST-NET-3 — reserved, never routable.
+	store := NewValkeyStoreLazy(
+		ClusterConfig{Addrs: []string{"203.0.113.1:6379"}},
+		30*time.Second, time.Minute,
+	)
+	require.NotNil(t, store, "lazy construction must always yield a store")
+	t.Cleanup(func() { _ = store.Close() })
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test SERVICE=user-presence-service`
+Expected: FAIL — `undefined: NewValkeyStoreLazy`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `user-presence-service/presencestore/store.go`, add below `NewValkeyStore`:
+
+```go
+// NewValkeyStoreLazy builds the store without gating on reachability. Valkey
+// is presence's store of record, so an outage means requests return errors —
+// but the pod must still start, otherwise any rollout during an outage
+// crashloops the service. go-redis reconnects on its own.
+func NewValkeyStoreLazy(cfg ClusterConfig, staleThreshold, connsTTL time.Duration) *Store {
+	c := redis.NewClusterClient(valkeyutil.ClusterOptionsFor(cfg.Addrs, cfg.Password, valkeyutil.StoreProfile))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := c.Ping(ctx).Err(); err != nil {
+		slog.Warn("valkey cluster unreachable at startup; continuing with lazy connect",
+			"addrs", cfg.Addrs, "error", err)
+	}
+	return NewValkeyStoreFromClient(c, staleThreshold, connsTTL)
+}
+```
+
+Add the `valkeyutil` import: `"github.com/hmchangw/chat/pkg/valkeyutil"`.
+
+Also update `NewValkeyStore` to use the same options so the eager path shares the budget:
+
+```go
+	c := redis.NewClusterClient(valkeyutil.ClusterOptionsFor(cfg.Addrs, cfg.Password, valkeyutil.StoreProfile))
+```
+
+In `user-presence-service/main.go`, replace lines 95–102:
+
+```go
+	store := presencestore.NewValkeyStoreLazy(
+		presencestore.ClusterConfig{Addrs: cfg.Valkey.Addrs, Password: cfg.Valkey.Password},
+		cfg.Presence.StaleThreshold, cfg.Presence.ConnsTTL,
+	)
+```
+
+Remove the now-unused `err` handling block. Verify `err` is still used later in `main` (it is — `mongoutil.Connect` on the next line reassigns it); if the compiler reports `err` declared and not used, change the Mongo line from `mongoClient, err :=` to keep `:=` since `mongoClient` is new.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test SERVICE=user-presence-service`
+Expected: PASS
+
+- [ ] **Step 5: Verify it builds**
+
+Run: `make build SERVICE=user-presence-service`
+Expected: success
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add user-presence-service/
+git commit -m "feat(user-presence-service): lazy Valkey connect with StoreProfile timeouts"
+```
+
+---
+
+### Task 7: Switch the five cache services to lazy connect
+
+**Files:**
+- Modify: `message-gatekeeper/main.go:104-115`
+- Modify: `broadcast-worker/main.go:122-133`
+- Modify: `room-worker/main.go:149-160`
+- Modify: `notification-worker/main.go:166-173`
+- Modify: `search-service/main.go:152-159`
+
+**Interfaces:**
+- Consumes: `valkeyutil.ConnectClusterLazy` (Task 5).
+- Produces: nothing new.
+
+Each site currently calls `ConnectCluster` and treats failure as fatal. All five use the default `CacheProfile`, so only the constructor name and the error branch change. Add `valkeyutil.WithBreakerName("<service-name>")` so metrics distinguish services.
+
+- [ ] **Step 1: Modify message-gatekeeper**
+
+`message-gatekeeper/main.go`, replacing lines 104–115:
+
+```go
+	var metaValkey valkeyutil.Client
+	if len(cfg.ValkeyAddrs) > 0 {
+		// Lazy: an unreachable Valkey must not stop the gatekeeper from
+		// starting — room-meta reads fall back to Mongo.
+		metaValkey, err = valkeyutil.ConnectClusterLazy(ctx, cfg.ValkeyAddrs, cfg.ValkeyPassword,
+			valkeyutil.WithObservability(sdk),
+			valkeyutil.WithRequireParentSpan(true),
+			valkeyutil.WithBreakerName("message-gatekeeper"),
+		)
+		if err != nil {
+			slog.Error("valkey client build (room-meta L2) failed", "error", err)
+			os.Exit(1)
+		}
+		slog.Info("room-meta L2 cache enabled", "ttl", cfg.RoomMetaL2TTL)
+	}
+```
+
+The retained `os.Exit(1)` is correct here: `ConnectClusterLazy` only errors on construction/instrumentation failure, which is a programming or configuration fault, not an outage.
+
+- [ ] **Step 2: Modify broadcast-worker**
+
+`broadcast-worker/main.go`, lines 122–133 — identical shape, with `valkeyutil.WithBreakerName("broadcast-worker")` and the log message `"valkey client build (room-meta L2) failed"`.
+
+- [ ] **Step 3: Modify room-worker**
+
+`room-worker/main.go`, lines 149–160 — identical shape, with `valkeyutil.WithBreakerName("room-worker")` and the log message `"valkey client build (room-meta L2 invalidation) failed"`. Keep the trailing `slog.Info("room-meta L2 invalidation enabled")`.
+
+- [ ] **Step 4: Modify notification-worker**
+
+`notification-worker/main.go`, lines 166–173. This site is unconditional (no `len(cfg.ValkeyAddrs) > 0` guard):
+
+```go
+	valkeyClient, err := valkeyutil.ConnectClusterLazy(ctx, cfg.ValkeyAddrs, cfg.ValkeyPassword,
+		valkeyutil.WithObservability(sdk),
+		valkeyutil.WithRequireParentSpan(true),
+		valkeyutil.WithBreakerName("notification-worker"),
+	)
+	if err != nil {
+		slog.Error("valkey client build failed", "error", err)
+		os.Exit(1)
+	}
+```
+
+- [ ] **Step 5: Modify search-service**
+
+`search-service/main.go`, lines 152–159:
+
+```go
+	valkey, err := valkeyutil.ConnectClusterLazy(ctx, cfg.Valkey.Addrs, cfg.Valkey.Password,
+		valkeyutil.WithObservability(sdk),
+		valkeyutil.WithRequireParentSpan(true),
+		valkeyutil.WithBreakerName("search-service"),
+	)
+	if err != nil {
+		slog.Error("valkey client build failed", "error", err)
+		os.Exit(1)
+	}
+```
+
+- [ ] **Step 6: Verify every service builds and tests pass**
+
+```bash
+make build SERVICE=message-gatekeeper
+make build SERVICE=broadcast-worker
+make build SERVICE=room-worker
+make build SERVICE=notification-worker
+make build SERVICE=search-service
+make test
+```
+
+Expected: all succeed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add message-gatekeeper/main.go broadcast-worker/main.go room-worker/main.go notification-worker/main.go search-service/main.go
+git commit -m "feat: lazy Valkey connect across the five cache consumers"
+```
+
+---
+
+### Task 8: Suppress the per-call warn flood
+
+**Files:**
+- Modify: `pkg/roommetacache/valkey.go:45-48`
+- Modify: `notification-worker/members.go:45-47`
+- Modify: `search-service/handler.go:226-228`
+- Modify: `pkg/roommetacache/valkey_test.go` (append)
+
+**Interfaces:**
+- Consumes: `valkeyutil.IsUnavailable` (Task 3).
+- Produces: nothing new.
+
+An open breaker returns `ErrUnavailable` on every call. All three sites currently log a WARN per call, which during an outage is a log flood at message volume. The breaker already logs each state transition once, so these become redundant.
+
+The `cachemetrics` `Error` recording stays unconditional — the metric is the signal; the log is the noise.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/roommetacache/valkey_test.go`. Use the package's existing fake Valkey client and spy recorder — check the top of that file for their names and reuse them rather than defining new ones.
+
+```go
+// countingHandler counts emitted log records so the test can assert on log
+// volume, which is the actual behavior being changed here.
+type countingHandler struct {
+	slog.Handler
+	warns int
+}
+
+func (h *countingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *countingHandler) Handle(_ context.Context, r slog.Record) error {
+	if r.Level == slog.LevelWarn {
+		h.warns++
+	}
+	return nil
+}
+func (h *countingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *countingHandler) WithGroup(string) slog.Handler      { return h }
+
+// withCountingLogger swaps the default slog logger for the duration of a test.
+func withCountingLogger(t *testing.T) *countingHandler {
+	t.Helper()
+	h := &countingHandler{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return h
+}
+
+func TestReadL2_UnavailableRecordsErrorButDoesNotLog(t *testing.T) {
+	// An open circuit breaker fires on every call. The error metric is the
+	// signal and must still fire; the per-call warn is the noise and must not,
+	// or an outage floods the logs at message rate.
+	logs := withCountingLogger(t)
+	rec := &spyRecorder{}
+	client := &fakeClient{getErr: valkeyutil.ErrUnavailable}
+
+	meta, found := readL2(context.Background(), client, "room-1", rec)
+
+	assert.False(t, found, "unavailable must fall through to Mongo")
+	assert.Equal(t, Meta{}, meta)
+	assert.Equal(t, 1, rec.errors, "error metric must still fire")
+	assert.Equal(t, 0, logs.warns, "open breaker must not log per call")
+}
+
+func TestReadL2_LiveFailureStillLogs(t *testing.T) {
+	// A genuine transport failure is rare and diagnostic — keep logging it.
+	logs := withCountingLogger(t)
+	rec := &spyRecorder{}
+	client := &fakeClient{getErr: errors.New("i/o timeout")}
+
+	_, found := readL2(context.Background(), client, "room-1", rec)
+
+	assert.False(t, found)
+	assert.Equal(t, 1, rec.errors)
+	assert.Equal(t, 1, logs.warns, "live failures must still log")
+}
+```
+
+Adjust `spyRecorder` and `fakeClient` to match the existing test helpers in the file. If the file has no fake client, add one satisfying `valkeyutil.Client` with a settable `getErr`. Note these two tests mutate the process-wide default logger, so they must not run with `t.Parallel()`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test SERVICE=pkg/roommetacache`
+Expected: FAIL on `TestReadL2_UnavailableRecordsErrorButDoesNotLog` with `expected 0, got 1` for the warn count — current code logs unconditionally. `TestReadL2_LiveFailureStillLogs` should already pass, which confirms the new test is discriminating rather than trivially true.
+
+- [ ] **Step 3: Write the implementation**
+
+`pkg/roommetacache/valkey.go`, replacing lines 45–48:
+
+```go
+	rec.Error(ctx)
+	// An open circuit breaker fires on every call; the breaker already logs
+	// each state transition once, so logging here would flood at message rate.
+	if !valkeyutil.IsUnavailable(err) {
+		slog.WarnContext(ctx, "room meta L2 read failed, falling back to mongo",
+			"room_id", roomID, "error", err)
+	}
+	return Meta{}, false
+```
+
+Apply the same gate to the populate warning at `pkg/roommetacache/valkey.go:73-76` and to `BustMeta` at `:88-91`.
+
+`notification-worker/members.go`, replacing lines 45–47:
+
+```go
+	} else if !errors.Is(err, valkeyutil.ErrCacheMiss) && !valkeyutil.IsUnavailable(err) {
+		slog.Warn("roomsubcache get failed, falling back to mongo", "error", err, "roomId", roomID)
+	}
+```
+
+Note the `Set` warning at `members.go:61-63` and the `Invalidate` warning at `:79-81` need the same gate.
+
+`search-service/handler.go`, replacing lines 226–228:
+
+```go
+	if cerr != nil && !valkeyutil.IsUnavailable(cerr) {
+		slog.Warn("valkey read failed; falling through to ES", "account", account, "error", cerr)
+	}
+```
+
+Leave the rest of `loadRestricted` untouched — the `cache_err=%v` fold at line 240 and the `cerr == nil` guard on the SET at line 254 are both still correct.
+
+Add the `valkeyutil` import to `notification-worker/members.go` (already present) and `search-service/handler.go` (add if absent).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+make test SERVICE=pkg/roommetacache
+make test SERVICE=notification-worker
+make test SERVICE=search-service
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/roommetacache/ notification-worker/members.go search-service/handler.go
+git commit -m "feat: suppress per-call Valkey warns while the circuit breaker is open"
+```
+
+---
+
+### Task 9: botplatform-service posture split
+
+> **SUPERSEDED — implemented as unconditional fail-open.** The posture split below kept the
+> three room-management endpoints fail-closed. That was overturned by an explicit requirement
+> that bots keep serving through a Valkey outage, plus two findings:
+>
+> 1. Only `POST /rooms` carries real duplicate cost. `members/add` and `members/remove` are
+>    naturally idempotent (`room-service` resolves net-new members; removing an absent member
+>    is a no-op), and DM rooms dedupe via the deterministic `idgen.BuildDMRoomID`.
+> 2. The sentinel never provided durable dedup anyway — it releases on non-5xx and re-keys
+>    every 60s bucket, so it only ever guarded *overlapping* retries. Failing open widens a
+>    window already open in healthy operation.
+>
+> Shipped instead: `ConnectClusterLazy` + fail-open on both middlewares, no `failOpen`
+> parameter and no `routes.go` change. The `bot_control_bypassed_total` counter below was
+> kept as specified. See `progress.md` for the full analysis.
+
+**Files:**
+- Create: `botplatform-service/metrics.go`
+- Modify: `botplatform-service/middleware.go:107-156` (`botRateLimit`)
+- Modify: `botplatform-service/middleware_idempotency.go:38-95` (`botIdempotency`)
+- Modify: `botplatform-service/routes.go:22-32`
+- Modify: `botplatform-service/middleware_ratelimit_test.go`, `botplatform-service/middleware_idempotency_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (the middlewares take `incrExClient` / `sentinelClient`, not `valkeyutil.Client`).
+- Produces: `func botRateLimit(client incrExClient, perCaller, perGlobal int, failOpen bool) gin.HandlerFunc`; `func botIdempotency(client sentinelClient, siteID, endpoint string, sentinelTTL time.Duration, resourceIDFrom resourceIDFunc, tp timeProvider, failOpen bool) gin.HandlerFunc`; `func recordControlBypassed(ctx context.Context, control string)`.
+
+Per the spec: rate limiting is a **protective** control and is suspended on Valkey error; idempotency is a **correctness** control and splits — message send fails open, room management stays fail-closed.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `botplatform-service/middleware_ratelimit_test.go`:
+
+```go
+func TestBotRateLimit_FailOpenOnValkeyError(t *testing.T) {
+	// Rate limiting protects the platform, not the data. During a Valkey
+	// outage availability wins: the request proceeds.
+	client := &stubIncrEx{err: errors.New("i/o timeout")}
+	called := false
+
+	r := gin.New()
+	r.POST("/x", withBotPrincipal("bot-1"), botRateLimit(client, 10, 100, true), func(c *gin.Context) {
+		called = true
+		c.Status(http.StatusOK)
+	})
+
+	w := performPost(t, r, "/x", `{}`)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, called, "handler must run when the limiter fails open")
+}
+
+func TestBotRateLimit_FailClosedStillAvailable(t *testing.T) {
+	client := &stubIncrEx{err: errors.New("i/o timeout")}
+	r := gin.New()
+	r.POST("/x", withBotPrincipal("bot-1"), botRateLimit(client, 10, 100, false), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := performPost(t, r, "/x", `{}`)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestBotRateLimit_LimitStillEnforcedWhenValkeyHealthy(t *testing.T) {
+	// Fail-open must not weaken the limit when Valkey is up.
+	client := &stubIncrEx{n: 11}
+	r := gin.New()
+	r.POST("/x", withBotPrincipal("bot-1"), botRateLimit(client, 10, 100, true), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := performPost(t, r, "/x", `{}`)
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+}
+```
+
+Append to `botplatform-service/middleware_idempotency_test.go`:
+
+```go
+func TestBotIdempotency_MessageSendFailsOpen(t *testing.T) {
+	client := &stubSentinel{setNXErr: errors.New("i/o timeout")}
+	called := false
+
+	r := gin.New()
+	r.POST("/x", withBotPrincipal("bot-1"),
+		botIdempotency(client, "site-a", "sendRoom", time.Minute, func(*gin.Context) string { return "r1" }, nil, true),
+		func(c *gin.Context) { called = true; c.Status(http.StatusOK) })
+
+	w := performPost(t, r, "/x", `{"text":"hi"}`)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, called, "message send must proceed without the sentinel")
+}
+
+func TestBotIdempotency_RoomMgmtFailsClosed(t *testing.T) {
+	// A duplicate room creation or member add is expensive and awkward to
+	// undo, so these stay fail-closed even during an outage.
+	client := &stubSentinel{setNXErr: errors.New("i/o timeout")}
+	called := false
+
+	r := gin.New()
+	r.POST("/x", withBotPrincipal("bot-1"),
+		botIdempotency(client, "site-a", "createRoom", time.Minute, func(*gin.Context) string { return "" }, nil, false),
+		func(c *gin.Context) { called = true; c.Status(http.StatusOK) })
+
+	w := performPost(t, r, "/x", `{"name":"r"}`)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.False(t, called, "room management must not proceed without the sentinel")
+}
+
+func TestBotIdempotency_FailOpenStillRejectsInFlightDuplicate(t *testing.T) {
+	// Fail-open applies only to Valkey errors, never to a healthy refusal.
+	client := &stubSentinel{acquired: false}
+	r := gin.New()
+	r.POST("/x", withBotPrincipal("bot-1"),
+		botIdempotency(client, "site-a", "sendRoom", time.Minute, func(*gin.Context) string { return "r1" }, nil, true),
+		func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := performPost(t, r, "/x", `{"text":"hi"}`)
+	assert.Equal(t, http.StatusConflict, w.Code) // whatever errBotInFlight maps to
+}
+```
+
+Reuse the existing stubs and helpers in those test files (`stubIncrEx`, `stubSentinel`, `withBotPrincipal`, `performPost` or their real names — check the file headers). If a helper does not exist, add it in the test file. Confirm the expected status for `errBotInFlight` by reading its definition in `botplatform-service/helper.go` and correct the last assertion to match.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `make test SERVICE=botplatform-service`
+Expected: FAIL — too many arguments to `botRateLimit` and `botIdempotency`.
+
+- [ ] **Step 3: Add the bypass metric**
+
+Create `botplatform-service/metrics.go`:
+
+```go
+package main
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// controlBypassed counts requests that skipped a Valkey-backed control because
+// Valkey was unavailable. A non-zero rate means abuse protection or duplicate
+// suppression is off and should be alerted on.
+var controlBypassed metric.Int64Counter
+
+func init() {
+	m := otel.Meter("botplatform")
+	var err error
+	controlBypassed, err = m.Int64Counter(
+		"bot_control_bypassed_total",
+		metric.WithDescription("Bot requests that bypassed a Valkey-backed control due to Valkey unavailability"),
+	)
+	if err != nil {
+		controlBypassed, _ = noop.NewMeterProvider().Meter("botplatform").
+			Int64Counter("bot_control_bypassed_total")
+	}
+}
+
+// recordControlBypassed emits the bypass counter for the named control.
+func recordControlBypassed(ctx context.Context, control string) {
+	controlBypassed.Add(ctx, 1, metric.WithAttributes(attribute.String("control", control)))
+}
+```
+
+- [ ] **Step 4: Implement the rate-limit fail-open path**
+
+In `botplatform-service/middleware.go`, change the signature and both error branches:
+
+```go
+// botRateLimit enforces per-caller then global fixed-window counters (60s each); 0 disables.
+// Per-caller first so a rejected caller doesn't consume the global budget.
+//
+// failOpen governs behavior when Valkey itself errors. Rate limiting is a
+// protective control — it guards the platform, not the data — so during a
+// Valkey outage availability wins and the request proceeds. A suspended
+// control is never silent: it logs and increments bot_control_bypassed_total.
+func botRateLimit(client incrExClient, perCaller, perGlobal int, failOpen bool) gin.HandlerFunc {
+	const window = time.Minute
+
+	return func(c *gin.Context) {
+		if perCaller <= 0 && perGlobal <= 0 {
+			c.Next()
+			return
+		}
+
+		ctx := c.Request.Context()
+
+		pr := botPrincipalFrom(c)
+		if pr == nil {
+			errhttp.Write(ctx, c, errcode.Internal("bot rate limit: missing principal"))
+			c.Abort()
+			return
+		}
+
+		// bypass handles a Valkey failure per the configured posture. It
+		// reports true when the request should proceed uncounted.
+		bypass := func(scope string, err error) bool {
+			if !failOpen {
+				errhttp.Write(ctx, c, errcode.Internal("bot rate limit "+scope, errcode.WithCause(err)))
+				c.Abort()
+				return false
+			}
+			slog.WarnContext(ctx, "bot rate limit suspended: valkey unavailable",
+				"scope", scope, "error", err)
+			recordControlBypassed(ctx, "ratelimit")
+			return true
+		}
+
+		if perCaller > 0 {
+			n, err := client.IncrEx(ctx, "botrl:caller:"+pr.UserID, window)
+			if err != nil {
+				if !bypass("caller", err) {
+					return
+				}
+			} else if n > int64(perCaller) {
+				c.Header("Retry-After", "60")
+				errhttp.Write(ctx, c, errBotRateLimitedCaller)
+				c.Abort()
+				return
+			}
+		}
+
+		if perGlobal > 0 {
+			n, err := client.IncrEx(ctx, "botrl:global", window)
+			if err != nil {
+				if !bypass("global", err) {
+					return
+				}
+			} else if n > int64(perGlobal) {
+				c.Header("Retry-After", "60")
+				errhttp.Write(ctx, c, errBotRateLimitedGlobal)
+				c.Abort()
+				return
+			}
+		}
+
+		c.Next()
+	}
+}
+```
+
+Add `"log/slog"` to the imports if absent.
+
+- [ ] **Step 5: Implement the idempotency posture split**
+
+In `botplatform-service/middleware_idempotency.go`, add the parameter and change only the `SetNX` error branch:
+
+```go
+// botIdempotency is a Valkey-backed sentinel: SET NX per opID, then Del on non-5xx (5xx keeps
+// the sentinel so a retry can't race the still-running original). Response body is not cached.
+//
+// failOpen governs behavior when Valkey itself errors, and differs by endpoint
+// class. Message send passes true: a duplicate message is visible but
+// recoverable, and the bot write API stays up. Room management passes false: a
+// duplicate room creation or member add is expensive and awkward to undo, so
+// those endpoints keep returning errcode.Internal.
+//
+// failOpen never applies to a healthy refusal — an unacquired sentinel is
+// still a rejected in-flight duplicate.
+func botIdempotency(
+	client sentinelClient,
+	siteID, endpoint string,
+	sentinelTTL time.Duration,
+	resourceIDFrom resourceIDFunc,
+	tp timeProvider,
+	failOpen bool,
+) gin.HandlerFunc {
+```
+
+Replace the `SetNX` error branch:
+
+```go
+		acquired, err := client.SetNX(ctx, key, "processing", sentinelTTL)
+		if err != nil {
+			if !failOpen {
+				errhttp.Write(ctx, c, errcode.Internal("bot idempotency: acquire", errcode.WithCause(err)))
+				c.Abort()
+				return
+			}
+			slog.WarnContext(ctx, "bot idempotency suspended: valkey unavailable",
+				"endpoint", endpoint, "error", err)
+			recordControlBypassed(ctx, "idempotency")
+			c.Next()
+			return
+		}
+```
+
+The `c.Next(); return` is deliberate: with no sentinel acquired there is nothing to release, so the trailing `Del` block must be skipped.
+
+- [ ] **Step 6: Wire the postures in routes.go**
+
+In `botplatform-service/routes.go`, replace lines 24–32:
+
+```go
+	if valkey != nil {
+		// Rate limiting is protective — suspend it rather than reject traffic
+		// when Valkey is down.
+		rateLimit = botRateLimit(valkey, cfg.BotRateLimitPerCallerPerMin, cfg.BotRateLimitGlobalPerMin, true)
+		// Message send fails open: a duplicate message is recoverable.
+		msgIdem = func(endpoint string, resourceFrom resourceIDFunc) gin.HandlerFunc {
+			return botIdempotency(valkey, cfg.SiteID, endpoint, cfg.BotIdempotencyMsgTTL, resourceFrom, nil, true)
+		}
+		// Room management stays fail-closed: a duplicate create or member add
+		// is expensive and awkward to undo.
+		roomMgmtIdem = func(endpoint string, resourceFrom resourceIDFunc) gin.HandlerFunc {
+			return botIdempotency(valkey, cfg.SiteID, endpoint, cfg.BotIdempotencyRoomMgmtTTL, resourceFrom, nil, false)
+		}
+	}
+```
+
+- [ ] **Step 7: Switch botplatform to lazy connect**
+
+In `botplatform-service/main.go`, replace lines 79–86:
+
+```go
+	var valkey valkeyutil.Client
+	if len(cfg.ValkeyAddrs) > 0 {
+		valkey, err = valkeyutil.ConnectClusterLazy(ctx, cfg.ValkeyAddrs, cfg.ValkeyPassword,
+			valkeyutil.WithObservability(sdk),
+			valkeyutil.WithRequireParentSpan(true),
+			valkeyutil.WithBreakerName("botplatform-service"),
+		)
+		if err != nil {
+			return fmt.Errorf("build valkey client: %w", err)
+		}
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `make test SERVICE=botplatform-service`
+Expected: PASS
+
+- [ ] **Step 9: Verify the build**
+
+Run: `make build SERVICE=botplatform-service`
+Expected: success
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add botplatform-service/
+git commit -m "feat(botplatform-service): suspend rate limiting and split idempotency posture on Valkey outage"
+```
+
+---
+
+### Task 10: Full verification and documentation
+
+**Files:**
+- Modify: `docs/health-probes.md` (append a short section)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing.
+
+No `docs/client-api.md` update is required: nothing in this plan changes a client-facing request/response schema or a `pkg/model` wire struct. The `botplatform-service` HTTP endpoints keep their shapes — only which status they return when Valkey is down, which is already covered by the generic error envelope.
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `make test`
+Expected: PASS across all packages.
+
+- [ ] **Step 2: Check coverage on the new package**
+
+```bash
+go test -coverprofile=/tmp/valkeyutil.out ./pkg/valkeyutil/ && go tool cover -func=/tmp/valkeyutil.out | tail -1
+```
+
+Expected: 90% or above. If below, add table cases to `breaker_test.go` for the untested method wrappers before proceeding.
+
+- [ ] **Step 3: Run lint and formatting**
+
+```bash
+make fmt
+make lint
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Run SAST**
+
+Run: `make sast`
+Expected: no medium-or-above findings. This is a blocking CI gate.
+
+- [ ] **Step 5: Run integration tests for the touched packages**
+
+```bash
+make test-integration SERVICE=pkg/valkeyutil
+make test-integration SERVICE=pkg/roommetacache
+make test-integration SERVICE=botplatform-service
+make test-integration SERVICE=user-presence-service
+```
+
+Expected: PASS (requires Docker).
+
+- [ ] **Step 6: Document the behavior change**
+
+Append to `docs/health-probes.md`, after the "Liveness" section:
+
+```markdown
+## Valkey is never a startup gate
+
+Services build their Valkey client through `valkeyutil.ConnectClusterLazy`,
+which logs an unreachable cluster and returns a usable client rather than
+failing. This is deliberate and mirrors the readiness reasoning above: a shared
+datastore is the same for every replica, so making it fatal at startup means a
+Valkey outage that overlaps a rollout, scale-up, or node drain crashloops every
+pod at once — including the message path.
+
+Cache consumers degrade to Mongo or Elasticsearch; `user-presence-service`
+returns `errcode` errors until Valkey returns. A circuit breaker
+(`valkey_breaker_state`) short-circuits calls while the cluster is down so the
+degraded path does not pay a timeout per request.
+
+`valkeyutil.ConnectCluster` retains the fail-fast behavior and is used only by
+one-shot CLI tools.
+```
+
+- [ ] **Step 7: Commit and push**
+
+```bash
+git add docs/health-probes.md
+git commit -m "docs(health-probes): record that Valkey is never a startup gate"
+git push -u origin claude/valkey-outage-impact-m5dxjd
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage.** Timeout profiles → Task 1–2. Circuit breaker including the `IsSuccessful` hazard → Task 3. Observability (`valkey_breaker_transitions`, `valkey_breaker_state`, `bot_control_bypassed`) → Tasks 4 and 9. Lazy connect across all seven services → Tasks 5–7 and 9 step 7. Log-flood gating at the three named call sites → Task 8. botplatform posture split → Task 9. Blackhole latency test → Task 2. Testing requirements → distributed, with the full gate in Task 10.
+
+**Known ordering constraint.** Task 3 introduces a temporary no-op `recordBreakerTransition` so it compiles standalone; Task 4 step 3 deletes it. Do not run Task 4 before Task 3.
+
+**Type consistency.** `Profile`, `CacheProfile`, `StoreProfile`, and `ClusterOptionsFor` are defined in Task 1 and consumed under those exact names in Tasks 2, 5, and 6. `ErrUnavailable` / `IsUnavailable` / `NewBreakerClient` are defined in Task 3 and consumed in Tasks 5 and 8. `recordBreakerTransition(name, from, to string, state gobreaker.State)` has the same five-part signature in its Task 3 stub and its Task 4 implementation. `botRateLimit` and `botIdempotency` gain their `failOpen bool` as the final parameter in Task 9 and are called with it in the same task.
+
+**Deliberate departures from the codebase norm, both spec-sanctioned.** Timeout profiles are code constants rather than `caarlos0/env` config (CLAUDE.md §6), and the circuit breaker is on by default in both constructors, so existing `ConnectCluster` callers get it without opting in. Reviewers will stop on both; the reasoning is in the spec.

--- a/docs/superpowers/specs/2026-08-11-valkey-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-11-valkey-hardening-design.md
@@ -1,0 +1,244 @@
+# Valkey Timeout and Startup Hardening
+
+An audit of the Valkey surface asked whether a Valkey outage brings the system
+down. It does not — the cache consumers are all written fail-open and degrade to
+Mongo or Elasticsearch. But two mechanical traps sit underneath that correctness
+and can convert a cache incident into a chat outage. This spec closes both.
+
+Neither trap is a logic bug in the consumers. Both live in how the client is
+constructed.
+
+## The two traps
+
+**The timeout trap.** `valkeyutil.ConnectCluster` builds its `redis.ClusterOptions`
+with only `Addrs` and `Password` (`pkg/valkeyutil/valkey.go:40`), and
+`presencestore.NewValkeyStore` does the same (`user-presence-service/presencestore/store.go:193`).
+Every timeout is therefore a go-redis default: 5s dial, 3s read, 3 retries. Against
+a Valkey that *refuses* connections this is harmless — the dial fails instantly. Against
+one that **blackholes** packets, which is the more common degraded mode, every
+hot-path GET burns seconds before the Mongo fallback runs. Per message. On the
+JetStream consumers that means throughput collapse, ack-pending saturation, and a
+growing stream backlog.
+
+The code is fail-open. The network behavior is fail-slow. Fail-open only works if
+it fails fast.
+
+**The startup trap.** `ConnectCluster` gates on a `PING` and returns an error on
+failure (`pkg/valkeyutil/valkey.go:52`); every caller treats that as fatal. Seven
+services exit: `notification-worker/main.go:170` and `search-service/main.go:156`
+unconditionally, and `message-gatekeeper/main.go:110`, `broadcast-worker/main.go:128`,
+`room-worker/main.go:155`, `botplatform-service/main.go:84`,
+`user-presence-service/main.go:100` whenever `VALKEY_ADDRS` is set — which
+production sets.
+
+Running pods survive an outage, because liveness is process-up-only and readiness
+probes NATS alone (`docs/health-probes.md`). But any rollout, HPA scale-up, node
+drain, or OOM-kill during the outage puts the core message path —
+`message-gatekeeper` and `broadcast-worker` — into `CrashLoopBackOff`. A cache
+outage that happens to overlap a deploy becomes a chat outage.
+
+## Scope
+
+- Bounded, profile-driven timeouts on every Valkey client.
+- A circuit breaker so the degraded path costs approximately nothing.
+- Removal of the fatal startup `PING` gate across all seven services.
+- Two posture changes in `botplatform-service`, described below.
+
+### Out of scope
+
+- The fail-open behavior of the cache consumers (`roommetacache`, `roomsubcache`,
+  `search-service`). It is already correct; this spec only makes it fast.
+- Valkey topology, replication, and failover — an ops concern.
+- `user-presence-service`'s lack of a fallback store. Valkey is legitimately its
+  store of record; serving errors is the right failure mode, not a design defect.
+
+## Timeout profiles
+
+Two named profiles in `pkg/valkeyutil`, selected per call site.
+
+| Knob | `CacheProfile` | `StoreProfile` | go-redis default |
+|------|---------------|----------------|------------------|
+| `DialTimeout` | 1s | 1s | 5s |
+| `ReadTimeout` / `WriteTimeout` | 150ms | 500ms | 3s |
+| `MaxRetries` | 1 | 2 | 3 |
+| `PoolTimeout` | 250ms | 1s | ~`ReadTimeout`+1s |
+| `ContextTimeoutEnabled` | true | true | **false** |
+
+`CacheProfile` serves the five cache consumers. `StoreProfile` serves
+`user-presence-service`, where Valkey is the store of record rather than a cache —
+a 150ms ceiling on a Lua `EVAL` under load would manufacture failures that no
+fallback can absorb.
+
+`ContextTimeoutEnabled` is the least obvious and most important entry. With it
+false, which is today's state, a caller's `context.WithTimeout` does **not** bound
+the socket read. The 10s `fetchTimeout` guards in `pkg/roommetacache/roommetacache.go:34`
+and `notification-worker/members.go:18` are consequently the only ceiling on a
+hung Valkey call, and they are two orders of magnitude above the intended budget.
+
+These are code constants, not environment variables. CLAUDE.md §6 requires
+deployment configuration to come from the environment, but these are internal
+tuning constants: exposing them would add seven services' worth of surface that
+nobody will set correctly under incident pressure, and a wrong value reintroduces
+exactly the trap being closed.
+
+## Circuit breaker
+
+Bounded timeouts still cost roughly 300ms on every hot-path call during an
+outage. At message volume that is its own throughput problem, so the client
+short-circuits once Valkey is demonstrably down.
+
+`github.com/sony/gobreaker/v2`, pinned at `v2.4.0`. This is a new third-party
+dependency, approved during design in preference to a hand-rolled breaker.
+
+One `*gobreaker.CircuitBreaker[any]` per `Client` instance, shared across all five
+interface methods — reachability is a property of the connection, not of the
+command. Values box through `any`, which is free relative to a network round-trip.
+
+| Setting | Value | Reason |
+|---------|-------|--------|
+| `ReadyToTrip` | `ConsecutiveFailures >= 5` | Rides out a single blip; trips on a real outage. |
+| `Timeout` | 5s | Open → half-open cooldown. |
+| `MaxRequests` | 1 | One half-open probe, so recovery never stampedes. |
+| `Interval` | 0 | No auto-reset while closed; consecutive-failure semantics. |
+| `OnStateChange` | transition log + metric | See Observability. |
+
+### IsSuccessful is load-bearing
+
+gobreaker counts every returned error as a failure. `valkeyutil.ErrCacheMiss` is
+not a failure — it is the cache working correctly — and a cold or sparse keyspace
+would otherwise trip the breaker and disable Valkey for a workload that is
+behaving perfectly. `Settings.IsSuccessful` must therefore classify both
+`ErrCacheMiss` and `context.Canceled` as successes. Only transport errors count
+toward the trip threshold.
+
+This is the single detail most likely to be got wrong, and it fails in the
+direction of a self-inflicted outage. It gets a dedicated test.
+
+### Callers need almost no changes
+
+When open, the breaker surfaces `gobreaker.ErrOpenState` / `ErrTooManyRequests`,
+which `valkeyutil` maps to an exported `ErrUnavailable` alongside a new
+`valkeyutil.IsUnavailable(err)` helper.
+
+Every fail-open consumer already branches `errors.Is(err, ErrCacheMiss)` → treat
+as miss, everything else → log and fall back. `ErrUnavailable` lands in the
+fallback branch with no code change at all.
+
+The one genuine edit is log volume: a per-message WARN during an outage is a log
+flood. The breaker logs the closed→open and open→closed transitions once, and the
+three existing call-site warnings are gated on `!IsUnavailable(err)`:
+
+- `pkg/roommetacache/valkey.go:46`
+- `notification-worker/members.go:46`
+- `search-service/handler.go:227`
+
+## Startup: lazy connect
+
+The fix is smaller than the trap suggests. go-redis already dials lazily and
+self-heals per call, so nothing needs to retry in the background. The crashloop
+comes entirely from the startup `PING` being treated as fatal.
+
+`valkeyutil.ConnectClusterLazy` performs identical construction and
+instrumentation, demotes the `PING` to a non-fatal reachability log, and always
+returns a usable `Client`. `presencestore.NewValkeyStore` gets the same treatment.
+All seven call sites switch to it and drop their `os.Exit(1)` / error return.
+
+No background goroutine is introduced, so there is no termination path to get
+wrong (CLAUDE.md §3, concurrency).
+
+`ConnectCluster` is retained for `tools/seed-sample-data`, a one-shot CLI where
+failing fast on an unreachable Valkey is the correct behavior.
+
+## Per-service posture after the change
+
+| Service | Boot with Valkey down | Runtime behavior |
+|---------|----------------------|------------------|
+| `message-gatekeeper` | starts | breaker opens; room-meta reads go to Mongo |
+| `broadcast-worker` | starts | breaker opens; room-meta reads go to Mongo |
+| `room-worker` | starts | `BustMeta` no-ops; L2 TTL reconciles |
+| `notification-worker` | starts | member fan-out falls back to Mongo |
+| `search-service` | starts | restricted-rooms falls through to Elasticsearch |
+| `user-presence-service` | starts | `errcode` errors per request; self-heals |
+| `botplatform-service` | starts | see below |
+
+### botplatform-service
+
+Two Valkey-backed controls sit on the same requests, and they degrade
+differently because they protect different things.
+
+**Rate limiting is suspended.** It is a protective control — it guards the
+platform, not the data — so availability wins during an outage. `botRateLimit`
+(`botplatform-service/middleware.go:128`) gains a fail-open path: on a Valkey
+error it logs WARN, emits a metric, and calls `c.Next()` instead of aborting with
+`errcode.Internal`.
+
+**Idempotency splits by endpoint.** It is a correctness control: the sentinel is
+what stops a retrying bot from double-executing within the 60s bucket. A
+duplicate message is visible but recoverable; a duplicate room creation or member
+add is expensive and awkward to undo. So:
+
+| Endpoints | Posture on Valkey error |
+|-----------|------------------------|
+| `POST /api/v1/rooms/:roomID/messages`, `POST /api/v1/dms/:userID/messages` | fail **open** — proceed without the sentinel |
+| `POST /api/v1/rooms`, `.../members/add`, `.../members/remove` | fail **closed** — `errcode.Internal`, as today |
+
+`routes.go` already builds the two classes through separate closures
+(`botplatform-service/routes.go:27` for messages, `:30` for room management), so
+this is a `failOpen bool` parameter on `botIdempotency` rather than a
+restructure. `botRateLimit` at `:25` takes the same parameter, set `true`.
+
+A suspended control must never be silent — both fail-open paths log and emit the
+metric below.
+
+## Observability
+
+| Signal | Type | Purpose |
+|--------|------|---------|
+| `valkey_breaker_transitions{from,to}` | counter | Emitted from `OnStateChange`. |
+| `valkey_breaker_state` | gauge | Current state, for dashboards. |
+| `bot_control_bypassed{control="ratelimit"\|"idempotency"}` | counter | A bypassed control is an alertable condition — abuse protection is off. |
+
+Existing `cachemetrics` hit/miss/error recording is unchanged.
+
+## Testing
+
+TDD throughout, per CLAUDE.md §4. Red before green on every item.
+
+**Breaker.** Table-driven unit tests over closed → open → half-open → closed,
+threshold boundaries, and concurrent callers under `-race`. `IsSuccessful` gets
+its own table asserting that `ErrCacheMiss` and `context.Canceled` never trip the
+breaker while transport errors do.
+
+**Bounded latency.** A `net.Listen` that accepts connections and never responds —
+a deterministic blackhole. This is the failure mode that connection-refused
+testing misses entirely, and it is the one the timeout profiles exist to bound.
+Assert a `Get` returns within the profile budget.
+
+**Lazy connect.** Assert a usable `Client` comes back from an unreachable address
+and that the first call returns an error rather than panicking.
+
+**botplatform.** Extend the existing tables in `middleware_ratelimit_test.go` and
+`middleware_idempotency_test.go` with a Valkey-error case per posture, including
+the fail-closed room-management case.
+
+**Integration.** `testutil.SharedValkeyCluster` for the healthy-path regression,
+with `testutil.FlushValkey` registered in `t.Cleanup` per CLAUDE.md §4.
+
+Coverage floor is 80%; `pkg/valkeyutil` is shared infrastructure and targets 90%.
+
+## Risks
+
+**The profiles are tighter than production has ever run.** A p99 Valkey latency
+above 150ms would start failing cache reads that today succeed slowly. The
+consumers all fall back correctly, so the failure mode is extra Mongo load rather
+than errors — but the `cachemetrics` error series should be watched after rollout,
+and `CacheProfile` loosened if it proves tight.
+
+**Suspended rate limiting removes abuse protection during an outage**, at exactly
+the moment the platform is already degraded. This is the accepted cost of the
+availability posture chosen during design; the `bot_control_bypassed` alert is the
+compensating control.
+
+**Fail-open message idempotency admits duplicate bot messages** during an outage.
+Bounded by the 60s bucket and limited to bots that retry, and duplicates remain
+impossible on the expensive room-management paths.

--- a/docs/superpowers/specs/2026-08-11-valkey-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-11-valkey-hardening-design.md
@@ -102,17 +102,37 @@ command. Values box through `any`, which is free relative to a network round-tri
 | `Interval` | 0 | No auto-reset while closed; consecutive-failure semantics. |
 | `OnStateChange` | transition log + metric | See Observability. |
 
-### IsSuccessful is load-bearing
+### Error classification is load-bearing
 
-gobreaker counts every returned error as a failure. `valkeyutil.ErrCacheMiss` is
-not a failure — it is the cache working correctly — and a cold or sparse keyspace
-would otherwise trip the breaker and disable Valkey for a workload that is
-behaving perfectly. `Settings.IsSuccessful` must therefore classify both
-`ErrCacheMiss` and `context.Canceled` as successes. Only transport errors count
-toward the trip threshold.
+gobreaker's default counts every returned error as a failure.
+`valkeyutil.ErrCacheMiss` is not a failure — it is the cache working correctly —
+and a cold or sparse keyspace would otherwise trip the breaker and disable
+Valkey for a workload that is behaving perfectly. `Settings.IsSuccessful` must
+classify `ErrCacheMiss` as a success. Only transport errors count toward the
+trip threshold.
 
-This is the single detail most likely to be got wrong, and it fails in the
-direction of a self-inflicted outage. It gets a dedicated test.
+Some errors are evidence of nothing either way, and for those *both* scores are
+wrong. Counting them failures opens the breaker on a healthy cache and stampedes
+the fallback store; counting them successes clears `ConsecutiveFailures` and can
+hold the breaker closed straight through a real outage. gobreaker v2 provides a
+third outcome for exactly this — `Settings.IsExcluded` drops a call from the
+accounting entirely — and it is consulted before `IsSuccessful`. Two errors are
+excluded:
+
+| Error | Why it is excluded |
+|---|---|
+| `context.Canceled` | The caller went away. An outage generates these in bulk — one slow sibling makes an errgroup cancel all the others at once. |
+| `redis.ErrPoolTimeout` | Local saturation: our own concurrency outran the pool, so Valkey was never asked. |
+
+`context.DeadlineExceeded` is deliberately **not** excluded. With
+`ContextTimeoutEnabled` bounding socket reads, a deadline is precisely how a
+blackholing Valkey surfaces — the degraded mode this design targets — so it must
+keep counting as a failure.
+
+This is the single detail most likely to be got wrong, and each way of getting
+it wrong disables the protection in a different direction. Both predicates get
+dedicated tests, including a test that an excluded error does not reset the
+consecutive-failure count.
 
 ### Callers need almost no changes
 

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/redis/go-redis/v9 v9.18.0
+	github.com/sony/gobreaker/v2 v2.4.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/minio v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -299,6 +299,8 @@ github.com/shirou/gopsutil/v4 v4.26.3 h1:2ESdQt90yU3oXF/CdOlRCJxrP+Am1aBYubTMTfx
 github.com/shirou/gopsutil/v4 v4.26.3/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
+github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
+github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/message-gatekeeper/main.go
+++ b/message-gatekeeper/main.go
@@ -103,9 +103,10 @@ func main() {
 
 	var metaValkey valkeyutil.Client
 	if len(cfg.ValkeyAddrs) > 0 {
-		metaValkey, err = valkeyutil.ConnectCluster(ctx, cfg.ValkeyAddrs, cfg.ValkeyPassword,
+		metaValkey, err = valkeyutil.ConnectClusterLazy(ctx, cfg.ValkeyAddrs, cfg.ValkeyPassword,
 			valkeyutil.WithObservability(sdk),
 			valkeyutil.WithRequireParentSpan(true),
+			valkeyutil.WithBreakerName("message-gatekeeper"),
 		)
 		if err != nil {
 			slog.Error("valkey connect (room-meta L2) failed", "error", err)

--- a/notification-worker/main.go
+++ b/notification-worker/main.go
@@ -162,9 +162,10 @@ func main() {
 	// preference. The other collections here tolerate replica lag and keep it.
 	usersCol := mongoutil.CollectionWithReadPreference(db.Collection("users"), readpref.Primary())
 
-	valkeyClient, err := valkeyutil.ConnectCluster(ctx, cfg.ValkeyAddrs, cfg.ValkeyPassword,
+	valkeyClient, err := valkeyutil.ConnectClusterLazy(ctx, cfg.ValkeyAddrs, cfg.ValkeyPassword,
 		valkeyutil.WithObservability(sdk),
 		valkeyutil.WithRequireParentSpan(true),
+		valkeyutil.WithBreakerName("notification-worker"),
 	)
 	if err != nil {
 		slog.Error("valkey connect failed", "error", err)

--- a/notification-worker/members.go
+++ b/notification-worker/members.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"golang.org/x/sync/singleflight"
@@ -43,7 +42,7 @@ func (c *cachedMemberLookup) GetMembers(ctx context.Context, roomID string) ([]r
 	if got, err := c.cache.Get(ctx, roomID); err == nil {
 		return got, nil
 	} else if !errors.Is(err, valkeyutil.ErrCacheMiss) {
-		slog.Warn("roomsubcache get failed, falling back to mongo", "error", err, "roomId", roomID)
+		valkeyutil.LogDegraded(ctx, "roomsubcache get failed, falling back to mongo", err, "roomId", roomID)
 	}
 
 	// Miss path: singleflight collapses concurrent Mongo loads on the same room.
@@ -51,15 +50,22 @@ func (c *cachedMemberLookup) GetMembers(ctx context.Context, roomID string) ([]r
 		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), memberFetchTimeout)
 		defer cancel()
 		// Re-check inside the flight in case a sibling caller already populated.
-		if got, err := c.cache.Get(fetchCtx, roomID); err == nil {
+		got, getErr := c.cache.Get(fetchCtx, roomID)
+		if getErr == nil {
 			return got, nil
 		}
 		loaded, lerr := c.load(fetchCtx, roomID)
 		if lerr != nil {
 			return nil, fmt.Errorf("load members for room %s: %w", roomID, lerr)
 		}
+		// Don't marshal a member list Valkey is known to be refusing. With the
+		// breaker open the Set is rejected in microseconds, so the JSON encode of a
+		// large room would be pure waste — once per message, for the whole outage.
+		if valkeyutil.IsUnavailable(getErr) {
+			return loaded, nil
+		}
 		if setErr := c.cache.Set(fetchCtx, roomID, loaded, c.ttl); setErr != nil {
-			slog.Warn("roomsubcache set failed", "error", setErr, "roomId", roomID)
+			valkeyutil.LogDegraded(fetchCtx, "roomsubcache set failed", setErr, "roomId", roomID)
 		}
 		return loaded, nil
 	})
@@ -77,6 +83,6 @@ func (c *cachedMemberLookup) GetMembers(ctx context.Context, roomID string) ([]r
 // Invalidate drops the room from Valkey on membership change.
 func (c *cachedMemberLookup) Invalidate(ctx context.Context, roomID string) {
 	if err := c.cache.Invalidate(ctx, roomID); err != nil {
-		slog.Warn("roomsubcache invalidate failed", "error", err, "roomId", roomID)
+		valkeyutil.LogDegraded(ctx, "roomsubcache invalidate failed", err, "roomId", roomID)
 	}
 }

--- a/notification-worker/members_test.go
+++ b/notification-worker/members_test.go
@@ -148,15 +148,47 @@ func TestCachedMemberLookup_InvalidateClearsValkey(t *testing.T) {
 	assert.Equal(t, loader.out, got, "after Invalidate the next read must reload")
 }
 
-type erroringCache struct{ err error }
+type erroringCache struct {
+	err  error
+	sets atomic.Int32
+}
 
 func (e *erroringCache) Get(context.Context, string) ([]roomsubcache.Member, error) {
 	return nil, e.err
 }
 func (e *erroringCache) Set(context.Context, string, []roomsubcache.Member, time.Duration) error {
+	e.sets.Add(1)
 	return nil
 }
 func (e *erroringCache) Invalidate(context.Context, string) error { return nil }
+
+// With the circuit open, Set is rejected in microseconds — so populating the
+// cache would serialize the whole member list to JSON only to throw it away,
+// once per message for the duration of the outage. A live failure still tries,
+// since that one may well succeed.
+func TestCachedMemberLookup_SkipsPopulateWhileCircuitOpen(t *testing.T) {
+	tests := []struct {
+		name     string
+		getErr   error
+		wantSets int32
+	}{
+		{"circuit open skips the populate", valkeyutil.ErrUnavailable, 0},
+		{"live failure still attempts the populate", errors.New("i/o timeout"), 1},
+		{"plain miss populates as usual", valkeyutil.ErrCacheMiss, 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := &erroringCache{err: tc.getErr}
+			loader := &fakeLoader{out: []roomsubcache.Member{{ID: "u1", Account: "alice"}}}
+			lookup := newCachedMemberLookup(cache, loader.Load, time.Minute)
+
+			got, err := lookup.GetMembers(context.Background(), "r1")
+			require.NoError(t, err, "the Mongo fallback must still serve the request")
+			assert.Equal(t, loader.out, got)
+			assert.Equal(t, tc.wantSets, cache.sets.Load())
+		})
+	}
+}
 
 func TestCachedMemberLookup_LeaderCancelDoesNotPoisonWaiters(t *testing.T) {
 	cache := newFakeCache()

--- a/pkg/roommetacache/valkey.go
+++ b/pkg/roommetacache/valkey.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -43,8 +42,7 @@ func readL2(ctx context.Context, client valkeyutil.Client, roomID string, rec Re
 		return Meta{}, false
 	}
 	rec.Error(ctx)
-	slog.WarnContext(ctx, "room meta L2 read failed, falling back to mongo",
-		"room_id", roomID, "error", err)
+	valkeyutil.LogDegraded(ctx, "room meta L2 read failed, falling back to mongo", err, "room_id", roomID)
 	return Meta{}, false
 }
 
@@ -71,8 +69,7 @@ func ReadThrough(ctx context.Context, client valkeyutil.Client, rooms *mongo.Col
 		return Meta{}, fmt.Errorf("l2 read-through: %w", err)
 	}
 	if err := valkeyutil.SetJSONWithTTL(ctx, client, MetaKey(roomID), meta, ttl); err != nil {
-		slog.WarnContext(ctx, "room meta L2 populate failed (TTL will reconcile)",
-			"room_id", roomID, "error", err)
+		valkeyutil.LogDegraded(ctx, "room meta L2 populate failed (TTL will reconcile)", err, "room_id", roomID)
 	}
 	return meta, nil
 }
@@ -86,7 +83,6 @@ func BustMeta(ctx context.Context, client valkeyutil.Client, roomID string) {
 		return
 	}
 	if err := client.Del(ctx, MetaKey(roomID)); err != nil {
-		slog.WarnContext(ctx, "room meta L2 invalidate failed (TTL will reconcile)",
-			"room_id", roomID, "error", err)
+		valkeyutil.LogDegraded(ctx, "room meta L2 invalidate failed (TTL will reconcile)", err, "room_id", roomID)
 	}
 }

--- a/pkg/valkeyutil/breaker.go
+++ b/pkg/valkeyutil/breaker.go
@@ -1,0 +1,158 @@
+package valkeyutil
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/sony/gobreaker/v2"
+)
+
+const (
+	// breakerFailureThreshold rides out a single blip but trips on a real
+	// outage.
+	breakerFailureThreshold = 5
+	// breakerCooldown is how long the breaker stays open before allowing one
+	// half-open probe through.
+	breakerCooldown = 5 * time.Second
+)
+
+// ErrUnavailable is returned when the circuit breaker is open — Valkey is
+// known-down and the call short-circuited without a network round-trip.
+//
+// Every fail-open consumer already branches errors.Is(err, ErrCacheMiss) for
+// the miss case and falls back on everything else, so ErrUnavailable lands in
+// the fallback path with no consumer change required.
+var ErrUnavailable = errors.New("valkey: circuit open")
+
+// IsUnavailable reports whether err came from an open circuit breaker rather
+// than a live failure. Call sites use it to suppress per-call warn logs during
+// an outage — the breaker already logs each state transition once.
+func IsUnavailable(err error) bool {
+	return errors.Is(err, ErrUnavailable)
+}
+
+// LogDegraded reports a Valkey call that fell back to its backing store,
+// attaching err and the caller's own context args.
+//
+// It is the single place that decides how loud to be while Valkey is down. A
+// live failure is news and logs at Warn. An open circuit is not: the breaker
+// already logged the transition once, so a per-call Warn would emit one line
+// per request for the whole outage — and because the breaker fails in
+// microseconds rather than seconds, nothing throttles that flood any more. Those
+// drop to Debug, still available on demand without drowning the log.
+//
+// Callers keep their own message and fields, so the diagnostic context survives;
+// only the level moves.
+func LogDegraded(ctx context.Context, msg string, err error, args ...any) {
+	level := slog.LevelWarn
+	if IsUnavailable(err) {
+		level = slog.LevelDebug
+	}
+	slog.Log(ctx, level, msg, append(args, "error", err)...)
+}
+
+// isSuccessful classifies an inner-client error for breaker accounting.
+//
+// This is the most consequential function in the package. gobreaker treats
+// every returned error as a failure, so without this a cold or sparse keyspace
+// would trip the breaker on ordinary cache misses and disable Valkey for a
+// workload that is behaving perfectly — a self-inflicted outage. Only genuine
+// transport failures may count toward the trip threshold.
+//
+// gobreaker offers no neutral outcome, so each ambiguous error is scored by
+// which wrong answer costs less:
+//   - Cache miss: a completed round trip. Unambiguously healthy.
+//   - Pool timeout: our own concurrency outran the pool; Valkey was never asked.
+//     Scored a success, because counting it a failure lets a local burst black out
+//     a healthy cache and stampede the fallback store.
+//   - Cancellation: scored a FAILURE. It is no evidence Valkey is healthy, and
+//     since gobreaker clears ConsecutiveFailures on every success, scoring it a
+//     success would let cancellations — which an outage generates in bulk, e.g.
+//     an errgroup cancelling siblings — hold the breaker closed through a real
+//     outage. That is the failure this package exists to prevent.
+func isSuccessful(err error) bool {
+	if err == nil {
+		return true
+	}
+	return errors.Is(err, ErrCacheMiss) || errors.Is(err, redis.ErrPoolTimeout)
+}
+
+// breakerClient wraps a Client with one shared circuit breaker. Reachability
+// is a property of the connection, not of the command, so all methods share a
+// single breaker rather than one per operation.
+type breakerClient struct {
+	inner Client
+	cb    *gobreaker.CircuitBreaker[any]
+}
+
+// NewBreakerClient wraps inner with a circuit breaker named name (used in log
+// and metric labels).
+func NewBreakerClient(inner Client, name string) Client {
+	cb := gobreaker.NewCircuitBreaker[any](gobreaker.Settings{
+		Name:        name,
+		MaxRequests: 1, // one half-open probe, so recovery never stampedes
+		Interval:    0, // never auto-reset counts while closed
+		Timeout:     breakerCooldown,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= breakerFailureThreshold
+		},
+		IsSuccessful: isSuccessful,
+		OnStateChange: func(name string, from, to gobreaker.State) {
+			slog.Warn("valkey circuit breaker state change",
+				"breaker", name, "from", from.String(), "to", to.String())
+			recordBreakerTransition(name, from, to)
+		},
+	})
+	recordBreakerState(name, gobreaker.StateClosed)
+	return &breakerClient{inner: inner, cb: cb}
+}
+
+// exec runs fn through the breaker, translating gobreaker's own rejection
+// errors into ErrUnavailable so consumers have one sentinel to match on.
+func (b *breakerClient) exec(fn func() (any, error)) (any, error) {
+	v, err := b.cb.Execute(fn)
+	if errors.Is(err, gobreaker.ErrOpenState) || errors.Is(err, gobreaker.ErrTooManyRequests) {
+		return nil, ErrUnavailable
+	}
+	return v, err
+}
+
+func (b *breakerClient) Get(ctx context.Context, key string) (string, error) {
+	v, err := b.exec(func() (any, error) { return b.inner.Get(ctx, key) })
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil
+}
+
+func (b *breakerClient) Set(ctx context.Context, key, value string, ttl time.Duration) error {
+	_, err := b.exec(func() (any, error) { return nil, b.inner.Set(ctx, key, value, ttl) })
+	return err
+}
+
+func (b *breakerClient) SetNX(ctx context.Context, key, value string, ttl time.Duration) (bool, error) {
+	v, err := b.exec(func() (any, error) { return b.inner.SetNX(ctx, key, value, ttl) })
+	if err != nil {
+		return false, err
+	}
+	return v.(bool), nil
+}
+
+func (b *breakerClient) IncrEx(ctx context.Context, key string, ttl time.Duration) (int64, error) {
+	v, err := b.exec(func() (any, error) { return b.inner.IncrEx(ctx, key, ttl) })
+	if err != nil {
+		return 0, err
+	}
+	return v.(int64), nil
+}
+
+func (b *breakerClient) Del(ctx context.Context, keys ...string) error {
+	_, err := b.exec(func() (any, error) { return nil, b.inner.Del(ctx, keys...) })
+	return err
+}
+
+// Close bypasses the breaker — shutdown must not be blocked by an open circuit.
+func (b *breakerClient) Close() error { return b.inner.Close() }

--- a/pkg/valkeyutil/breaker.go
+++ b/pkg/valkeyutil/breaker.go
@@ -56,28 +56,43 @@ func LogDegraded(ctx context.Context, msg string, err error, args ...any) {
 
 // isSuccessful classifies an inner-client error for breaker accounting.
 //
-// This is the most consequential function in the package. gobreaker treats
-// every returned error as a failure, so without this a cold or sparse keyspace
-// would trip the breaker on ordinary cache misses and disable Valkey for a
-// workload that is behaving perfectly — a self-inflicted outage. Only genuine
-// transport failures may count toward the trip threshold.
+// gobreaker's default treats every returned error as a failure, so without this
+// a cold or sparse keyspace would trip the breaker on ordinary cache misses and
+// disable Valkey for a workload that is behaving perfectly — a self-inflicted
+// outage. A miss is a completed round trip and so unambiguously healthy; only
+// genuine transport failures may count toward the trip threshold.
 //
-// gobreaker offers no neutral outcome, so each ambiguous error is scored by
-// which wrong answer costs less:
-//   - Cache miss: a completed round trip. Unambiguously healthy.
-//   - Pool timeout: our own concurrency outran the pool; Valkey was never asked.
-//     Scored a success, because counting it a failure lets a local burst black out
-//     a healthy cache and stampede the fallback store.
-//   - Cancellation: scored a FAILURE. It is no evidence Valkey is healthy, and
-//     since gobreaker clears ConsecutiveFailures on every success, scoring it a
-//     success would let cancellations — which an outage generates in bulk, e.g.
-//     an errgroup cancelling siblings — hold the breaker closed through a real
-//     outage. That is the failure this package exists to prevent.
+// Errors that are evidence of nothing either way never reach here: isExcluded
+// removes them from the accounting first.
 func isSuccessful(err error) bool {
 	if err == nil {
 		return true
 	}
-	return errors.Is(err, ErrCacheMiss) || errors.Is(err, redis.ErrPoolTimeout)
+	return errors.Is(err, ErrCacheMiss)
+}
+
+// isExcluded reports whether an error should be dropped from breaker accounting
+// entirely — counted neither a success nor a failure. gobreaker consults it
+// before isSuccessful.
+//
+// Both scores are wrong for an error that carries no signal about Valkey's
+// reachability, and each is wrong in its own direction: a failure lets these
+// open the breaker on a healthy cache and stampede the fallback store, while a
+// success clears ConsecutiveFailures and can hold the breaker closed straight
+// through a real outage. Exclusion is the only answer that does neither.
+//
+//   - Cancellation: the caller went away. Says nothing about Valkey, and an
+//     outage generates these in bulk — one slow sibling makes an errgroup cancel
+//     all the others at once.
+//   - Pool timeout: our own concurrency outran the pool, so Valkey was never
+//     asked.
+//
+// context.DeadlineExceeded is deliberately NOT excluded. Once
+// ContextTimeoutEnabled bounds socket reads, a deadline is exactly how a
+// blackholing Valkey surfaces — the degraded mode this package exists to catch —
+// so it must keep counting as a failure.
+func isExcluded(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, redis.ErrPoolTimeout)
 }
 
 // breakerClient wraps a Client with one shared circuit breaker. Reachability
@@ -100,6 +115,7 @@ func NewBreakerClient(inner Client, name string) Client {
 			return counts.ConsecutiveFailures >= breakerFailureThreshold
 		},
 		IsSuccessful: isSuccessful,
+		IsExcluded:   isExcluded,
 		OnStateChange: func(name string, from, to gobreaker.State) {
 			slog.Warn("valkey circuit breaker state change",
 				"breaker", name, "from", from.String(), "to", to.String())

--- a/pkg/valkeyutil/breaker_test.go
+++ b/pkg/valkeyutil/breaker_test.go
@@ -1,0 +1,213 @@
+package valkeyutil
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubClient is a Client whose Get result is controlled per call.
+type stubClient struct {
+	mu   sync.Mutex
+	err  error
+	val  string
+	gets int
+}
+
+func (s *stubClient) Get(ctx context.Context, key string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.gets++
+	return s.val, s.err
+}
+func (s *stubClient) Set(ctx context.Context, key, value string, ttl time.Duration) error {
+	return s.err
+}
+func (s *stubClient) SetNX(ctx context.Context, key, value string, ttl time.Duration) (bool, error) {
+	return true, s.err
+}
+func (s *stubClient) IncrEx(ctx context.Context, key string, ttl time.Duration) (int64, error) {
+	return 1, s.err
+}
+func (s *stubClient) Del(ctx context.Context, keys ...string) error { return s.err }
+func (s *stubClient) Close() error                                  { return nil }
+
+func (s *stubClient) setErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.err = err
+}
+func (s *stubClient) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.gets
+}
+
+// This is the test that matters most. gobreaker counts every returned error as
+// a failure, so a cache miss — which is the cache working correctly — would
+// trip the breaker and disable Valkey for a perfectly healthy workload.
+func TestIsSuccessful(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil is success", nil, true},
+		{"cache miss is success, not a failure", ErrCacheMiss, true},
+		{"wrapped cache miss is success", fmt.Errorf("valkey get json: %w", ErrCacheMiss), true},
+		// A cancelled call proves nothing about Valkey, and gobreaker resets
+		// ConsecutiveFailures on every success — so scoring it a success would let a
+		// steady trickle of cancellations (errgroup cancelling siblings during an
+		// outage) keep the breaker from ever tripping. Failure is the safer wrong answer.
+		{"context canceled is failure", context.Canceled, false},
+		{"wrapped context canceled is failure", fmt.Errorf("valkey get: %w", context.Canceled), false},
+		{"deadline exceeded is failure", context.DeadlineExceeded, false},
+		// Pool exhaustion is local saturation, not an unreachable Valkey. Scoring it a
+		// failure would let a burst of our own concurrency black out a healthy cache
+		// and stampede the fallback store — here success is the safer wrong answer.
+		{"pool timeout is success", redis.ErrPoolTimeout, true},
+		{"wrapped pool timeout is success", fmt.Errorf("valkey get: %w", redis.ErrPoolTimeout), true},
+		{"transport error is failure", errors.New("dial tcp: i/o timeout"), false},
+		{"plain error is failure", errors.New("x"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSuccessful(tt.err))
+		})
+	}
+}
+
+func TestIsSuccessful_StringSimilarErrorIsStillAFailure(t *testing.T) {
+	// Only errors.Is-matching misses count as success. An error that merely
+	// reads like a miss must still trip the breaker.
+	lookalike := errors.New("valkey get json: " + ErrCacheMiss.Error())
+	assert.False(t, isSuccessful(lookalike))
+}
+
+func TestBreaker_CacheMissesNeverTrip(t *testing.T) {
+	stub := &stubClient{err: ErrCacheMiss}
+	c := NewBreakerClient(stub, "test-miss")
+
+	for i := 0; i < 50; i++ {
+		_, err := c.Get(context.Background(), "k")
+		require.ErrorIs(t, err, ErrCacheMiss)
+	}
+	assert.Equal(t, 50, stub.callCount(), "every call must reach the inner client")
+}
+
+func TestBreaker_TripsAfterConsecutiveFailures(t *testing.T) {
+	boom := errors.New("i/o timeout")
+	stub := &stubClient{err: boom}
+	c := NewBreakerClient(stub, "test-trip")
+
+	for i := 0; i < breakerFailureThreshold; i++ {
+		_, err := c.Get(context.Background(), "k")
+		require.ErrorIs(t, err, boom)
+	}
+	inner := stub.callCount()
+
+	// Breaker is now open: calls short-circuit without touching the inner client.
+	_, err := c.Get(context.Background(), "k")
+	assert.True(t, IsUnavailable(err), "expected ErrUnavailable, got %v", err)
+	assert.Equal(t, inner, stub.callCount(), "open breaker must not call inner")
+}
+
+func TestBreaker_RecoversAfterCooldown(t *testing.T) {
+	boom := errors.New("i/o timeout")
+	stub := &stubClient{err: boom}
+	c := NewBreakerClient(stub, "test-recover")
+
+	for i := 0; i < breakerFailureThreshold; i++ {
+		_, _ = c.Get(context.Background(), "k")
+	}
+	require.True(t, IsUnavailable(mustErr(c.Get(context.Background(), "k"))))
+
+	// Valkey comes back; wait out the cooldown so the breaker half-opens.
+	stub.setErr(nil)
+	stub.val = "v"
+	time.Sleep(breakerCooldown + 100*time.Millisecond)
+
+	got, err := c.Get(context.Background(), "k")
+	require.NoError(t, err)
+	assert.Equal(t, "v", got)
+}
+
+func TestBreaker_ConcurrentCallersAreSafe(t *testing.T) {
+	stub := &stubClient{err: errors.New("i/o timeout")}
+	c := NewBreakerClient(stub, "test-concurrent")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = c.Get(context.Background(), "k")
+		}()
+	}
+	wg.Wait() // -race asserts no data race in the breaker itself
+}
+
+func TestBreaker_PassesThroughAllMethods(t *testing.T) {
+	stub := &stubClient{val: "v"}
+	c := NewBreakerClient(stub, "test-methods")
+	ctx := context.Background()
+
+	got, err := c.Get(ctx, "k")
+	require.NoError(t, err)
+	assert.Equal(t, "v", got)
+
+	require.NoError(t, c.Set(ctx, "k", "v", time.Minute))
+
+	ok, err := c.SetNX(ctx, "k", "v", time.Minute)
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	n, err := c.IncrEx(ctx, "k", time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+
+	require.NoError(t, c.Del(ctx, "k"))
+	require.NoError(t, c.Close())
+}
+
+func mustErr(_ string, err error) error { return err }
+
+func TestLogDegraded_LevelDependsOnCircuitState(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"live failure is news, logs at warn", errors.New("dial tcp: connection refused"), "WARN"},
+		{"open circuit is already known, drops to debug", ErrUnavailable, "DEBUG"},
+		{"wrapped open circuit drops to debug", fmt.Errorf("l2 get: %w", ErrUnavailable), "DEBUG"},
+		{"cache miss is still a live outcome, warns", ErrCacheMiss, "WARN"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			old := slog.Default()
+			slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+			t.Cleanup(func() { slog.SetDefault(old) })
+
+			LogDegraded(context.Background(), "room meta L2 read failed", tt.err, "room_id", "r1")
+
+			var rec map[string]any
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &rec))
+			assert.Equal(t, tt.want, rec["level"])
+			assert.Equal(t, "room meta L2 read failed", rec["msg"], "message must survive the level change")
+			assert.Equal(t, "r1", rec["room_id"], "caller context must survive the level change")
+			assert.NotEmpty(t, rec["error"], "the cause must always be attached")
+		})
+	}
+}

--- a/pkg/valkeyutil/breaker_test.go
+++ b/pkg/valkeyutil/breaker_test.go
@@ -56,6 +56,10 @@ func (s *stubClient) callCount() int {
 // This is the test that matters most. gobreaker counts every returned error as
 // a failure, so a cache miss — which is the cache working correctly — would
 // trip the breaker and disable Valkey for a perfectly healthy workload.
+//
+// isSuccessful only decides the success/failure axis. Errors that are evidence
+// of nothing either way are removed from the accounting entirely by isExcluded,
+// which gobreaker consults first; see TestIsExcluded.
 func TestIsSuccessful(t *testing.T) {
 	tests := []struct {
 		name string
@@ -65,24 +69,58 @@ func TestIsSuccessful(t *testing.T) {
 		{"nil is success", nil, true},
 		{"cache miss is success, not a failure", ErrCacheMiss, true},
 		{"wrapped cache miss is success", fmt.Errorf("valkey get json: %w", ErrCacheMiss), true},
-		// A cancelled call proves nothing about Valkey, and gobreaker resets
-		// ConsecutiveFailures on every success — so scoring it a success would let a
-		// steady trickle of cancellations (errgroup cancelling siblings during an
-		// outage) keep the breaker from ever tripping. Failure is the safer wrong answer.
-		{"context canceled is failure", context.Canceled, false},
-		{"wrapped context canceled is failure", fmt.Errorf("valkey get: %w", context.Canceled), false},
+		// Neither of these is a success. Scoring them so would clear
+		// ConsecutiveFailures and hold the breaker closed through a real outage.
+		// They are excluded rather than scored — isSuccessful is never reached for
+		// them — but the verdict is asserted here so a future change to the
+		// exclusion set cannot silently promote them to successes.
+		{"context canceled is not a success", context.Canceled, false},
+		{"pool timeout is not a success", redis.ErrPoolTimeout, false},
+		// Deliberately NOT excluded: with ContextTimeoutEnabled a blackholing
+		// Valkey surfaces as a deadline, which is the outage this package exists
+		// to catch.
 		{"deadline exceeded is failure", context.DeadlineExceeded, false},
-		// Pool exhaustion is local saturation, not an unreachable Valkey. Scoring it a
-		// failure would let a burst of our own concurrency black out a healthy cache
-		// and stampede the fallback store — here success is the safer wrong answer.
-		{"pool timeout is success", redis.ErrPoolTimeout, true},
-		{"wrapped pool timeout is success", fmt.Errorf("valkey get: %w", redis.ErrPoolTimeout), true},
+		{"wrapped deadline exceeded is failure", fmt.Errorf("valkey get: %w", context.DeadlineExceeded), false},
 		{"transport error is failure", errors.New("dial tcp: i/o timeout"), false},
 		{"plain error is failure", errors.New("x"), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, isSuccessful(tt.err))
+		})
+	}
+}
+
+// gobreaker v2 has a third outcome: IsExcluded removes a call from the
+// accounting entirely, counting it neither a success nor a failure. Errors that
+// carry no evidence about Valkey's reachability belong there — scoring them
+// either way is a wrong answer with a real cost.
+func TestIsExcluded(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil is accounted", nil, false},
+		// The caller went away. This says nothing about Valkey, so counting it a
+		// failure lets a burst of cancellations open the breaker on a healthy
+		// cache — and counting it a success lets one hold the breaker closed
+		// through a real outage.
+		{"context canceled is excluded", context.Canceled, true},
+		{"wrapped context canceled is excluded", fmt.Errorf("valkey get: %w", context.Canceled), true},
+		// Local saturation: our own concurrency outran the pool, so Valkey was
+		// never asked.
+		{"pool timeout is excluded", redis.ErrPoolTimeout, true},
+		{"wrapped pool timeout is excluded", fmt.Errorf("valkey get: %w", redis.ErrPoolTimeout), true},
+		// A deadline IS evidence — a blackholing Valkey looks exactly like this.
+		{"deadline exceeded is accounted", context.DeadlineExceeded, false},
+		{"wrapped deadline exceeded is accounted", fmt.Errorf("valkey get: %w", context.DeadlineExceeded), false},
+		{"cache miss is accounted", ErrCacheMiss, false},
+		{"transport error is accounted", errors.New("dial tcp: i/o timeout"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isExcluded(tt.err))
 		})
 	}
 }
@@ -120,6 +158,84 @@ func TestBreaker_TripsAfterConsecutiveFailures(t *testing.T) {
 	_, err := c.Get(context.Background(), "k")
 	assert.True(t, IsUnavailable(err), "expected ErrUnavailable, got %v", err)
 	assert.Equal(t, inner, stub.callCount(), "open breaker must not call inner")
+}
+
+// A cancelled caller is no evidence Valkey is down. Counting cancellations as
+// failures opens the breaker on a perfectly healthy cache and stampedes the
+// fallback store — and they arrive in bursts, since one slow sibling makes an
+// errgroup cancel all the others at once.
+func TestBreaker_CancellationsAloneNeverTrip(t *testing.T) {
+	stub := &stubClient{err: context.Canceled}
+	c := NewBreakerClient(stub, "test-cancel-neutral")
+
+	calls := breakerFailureThreshold * 3
+	for i := 0; i < calls; i++ {
+		_, err := c.Get(context.Background(), "k")
+		require.ErrorIs(t, err, context.Canceled, "call %d short-circuited: the breaker opened on cancellations", i)
+	}
+	assert.Equal(t, calls, stub.callCount(), "every call must reach the inner client")
+}
+
+// The other half of neutrality: excluded errors must not clear the failure
+// count either, or a trickle of them holds the breaker closed through a real
+// outage — the failure mode this package exists to prevent.
+func TestBreaker_ExcludedErrorsDoNotResetFailureCount(t *testing.T) {
+	boom := errors.New("i/o timeout")
+	tests := []struct {
+		name     string
+		excluded error
+	}{
+		{"cancellation between failures", context.Canceled},
+		{"pool timeout between failures", redis.ErrPoolTimeout},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stub := &stubClient{}
+			c := NewBreakerClient(stub, "test-no-reset-"+tt.name)
+			ctx := context.Background()
+
+			// One short of the threshold.
+			stub.setErr(boom)
+			for i := 0; i < breakerFailureThreshold-1; i++ {
+				_, err := c.Get(ctx, "k")
+				require.ErrorIs(t, err, boom)
+			}
+
+			stub.setErr(tt.excluded)
+			_, err := c.Get(ctx, "k")
+			require.ErrorIs(t, err, tt.excluded)
+
+			// This is the threshold'th consecutive real failure.
+			stub.setErr(boom)
+			_, err = c.Get(ctx, "k")
+			require.ErrorIs(t, err, boom)
+
+			before := stub.callCount()
+			_, err = c.Get(ctx, "k")
+			assert.True(t, IsUnavailable(err),
+				"breaker must be open: an excluded error must not reset ConsecutiveFailures")
+			assert.Equal(t, before, stub.callCount(), "open breaker must not call inner")
+		})
+	}
+}
+
+// Guards the exclusion set from growing too far. A deadline is how a
+// blackholing Valkey — the degraded mode this package targets — actually
+// surfaces once ContextTimeoutEnabled bounds socket reads, so it must stay in
+// the accounting as a failure.
+func TestBreaker_DeadlineExceededStillTrips(t *testing.T) {
+	stub := &stubClient{err: context.DeadlineExceeded}
+	c := NewBreakerClient(stub, "test-deadline-trips")
+
+	for i := 0; i < breakerFailureThreshold; i++ {
+		_, err := c.Get(context.Background(), "k")
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	}
+
+	before := stub.callCount()
+	_, err := c.Get(context.Background(), "k")
+	assert.True(t, IsUnavailable(err), "a blackholing Valkey must still open the breaker")
+	assert.Equal(t, before, stub.callCount())
 }
 
 func TestBreaker_RecoversAfterCooldown(t *testing.T) {

--- a/pkg/valkeyutil/integration_test.go
+++ b/pkg/valkeyutil/integration_test.go
@@ -92,3 +92,51 @@ func TestClusterRedisClient_Integration_IncrEx(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), n)
 }
+
+// TestClusterRedisClient_Integration_IncrEx_RepairsMissingTTL: a counter left
+// without an expiry — the exact state a succeeded INCR + failed EXPIRE leaves —
+// must get its TTL repaired by the next increment. Without the repair the fixed
+// window never resets, the counter climbs forever, and the caller is throttled
+// permanently once it passes the ceiling, long after Valkey recovers.
+func TestClusterRedisClient_Integration_IncrEx_RepairsMissingTTL(t *testing.T) {
+	raw := testutil.SharedValkeyCluster(t)
+	t.Cleanup(func() { testutil.FlushValkey(t) })
+	client := &clusterClient{c: raw}
+	ctx := context.Background()
+
+	require.NoError(t, raw.Incr(ctx, "rl:poisoned").Err())
+	ttl, err := raw.TTL(ctx, "rl:poisoned").Result()
+	require.NoError(t, err)
+	require.Equal(t, -1*time.Nanosecond, ttl, "precondition: key exists with no expiry")
+
+	n, err := client.IncrEx(ctx, "rl:poisoned", 30*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), n)
+
+	ttl, err = raw.TTL(ctx, "rl:poisoned").Result()
+	require.NoError(t, err)
+	assert.Greater(t, ttl, time.Duration(0), "missing TTL must be repaired by the next increment")
+}
+
+// TestClusterRedisClient_Integration_IncrEx_DoesNotExtendWindow: repairing a
+// missing TTL must not become a sliding window — an increment against a key that
+// already has an expiry leaves that expiry alone, or a caller could hold its
+// window open forever by keeping up a steady request rate.
+func TestClusterRedisClient_Integration_IncrEx_DoesNotExtendWindow(t *testing.T) {
+	raw := testutil.SharedValkeyCluster(t)
+	t.Cleanup(func() { testutil.FlushValkey(t) })
+	client := &clusterClient{c: raw}
+	ctx := context.Background()
+
+	_, err := client.IncrEx(ctx, "rl:window", 30*time.Second)
+	require.NoError(t, err)
+	// Shorten the live window, then increment again with the original long TTL.
+	require.NoError(t, raw.Expire(ctx, "rl:window", 5*time.Second).Err())
+
+	_, err = client.IncrEx(ctx, "rl:window", 30*time.Second)
+	require.NoError(t, err)
+
+	ttl, err := raw.TTL(ctx, "rl:window").Result()
+	require.NoError(t, err)
+	assert.LessOrEqual(t, ttl, 5*time.Second, "an existing window must not be extended")
+}

--- a/pkg/valkeyutil/metrics.go
+++ b/pkg/valkeyutil/metrics.go
@@ -1,0 +1,77 @@
+package valkeyutil
+
+import (
+	"context"
+
+	"github.com/sony/gobreaker/v2"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	// breakerTransitions counts circuit breaker state changes, tagged by
+	// breaker name and the from/to states.
+	breakerTransitions metric.Int64Counter
+	// breakerState reports the current state: 0 closed, 1 half-open, 2 open.
+	breakerState metric.Int64Gauge
+)
+
+func init() {
+	m := otel.Meter("valkey")
+
+	var err error
+	breakerTransitions, err = m.Int64Counter(
+		"valkey_breaker_transitions_total",
+		metric.WithDescription("Valkey circuit breaker state transitions, by breaker and from/to state"),
+	)
+	if err != nil {
+		// Fall back to a no-op counter so the program continues to run even if
+		// the global meter provider is not yet initialised at package init time.
+		breakerTransitions, _ = noop.NewMeterProvider().Meter("valkey").
+			Int64Counter("valkey_breaker_transitions_total")
+	}
+
+	breakerState, err = m.Int64Gauge(
+		"valkey_breaker_state",
+		metric.WithDescription("Current Valkey circuit breaker state: 0 closed, 1 half-open, 2 open"),
+	)
+	if err != nil {
+		breakerState, _ = noop.NewMeterProvider().Meter("valkey").
+			Int64Gauge("valkey_breaker_state")
+	}
+}
+
+// stateValue encodes a breaker state for the gauge.
+func stateValue(s gobreaker.State) int64 {
+	switch s {
+	case gobreaker.StateHalfOpen:
+		return 1
+	case gobreaker.StateOpen:
+		return 2
+	default:
+		return 0
+	}
+}
+
+// recordBreakerState emits the current-state gauge. Called at construction as
+// well as on transition, so a process whose breaker never trips still exports a
+// steady 0 rather than no series at all.
+func recordBreakerState(name string, state gobreaker.State) {
+	breakerState.Record(context.Background(), stateValue(state), metric.WithAttributes(
+		attribute.String("breaker", name),
+	))
+}
+
+// recordBreakerTransition emits the transition counter and current-state gauge.
+// Takes states rather than their strings: passing both invited a caller to hand
+// over a label and a state that disagree, which no compiler would catch.
+func recordBreakerTransition(name string, from, to gobreaker.State) {
+	breakerTransitions.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("breaker", name),
+		attribute.String("from", from.String()),
+		attribute.String("to", to.String()),
+	))
+	recordBreakerState(name, to)
+}

--- a/pkg/valkeyutil/metrics_test.go
+++ b/pkg/valkeyutil/metrics_test.go
@@ -1,0 +1,95 @@
+package valkeyutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sony/gobreaker/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// swapBreakerStateGauge points the breaker STATE GAUGE at an in-memory reader and
+// restores the original on cleanup. Deliberately narrow: breakerTransitions is
+// left on the global meter, so do not expect counter assertions to work here.
+func swapBreakerStateGauge(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	m := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)).Meter("valkey")
+
+	gauge, err := m.Int64Gauge("valkey_breaker_state")
+	require.NoError(t, err)
+	oldState := breakerState
+	breakerState = gauge
+	t.Cleanup(func() { breakerState = oldState })
+
+	return reader
+}
+
+// gaugeValue returns the gauge value for one breaker label, and whether it exists.
+func gaugeValue(t *testing.T, reader *sdkmetric.ManualReader, name, breaker string) (int64, bool) {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, mt := range sm.Metrics {
+			if mt.Name != name {
+				continue
+			}
+			g, ok := mt.Data.(metricdata.Gauge[int64])
+			require.True(t, ok, "%s must be an int64 gauge", name)
+			for _, dp := range g.DataPoints {
+				if v, found := dp.Attributes.Value(attribute.Key("breaker")); found && v.AsString() == breaker {
+					return dp.Value, true
+				}
+			}
+		}
+	}
+	return 0, false
+}
+
+func TestStateValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		state gobreaker.State
+		want  int64
+	}{
+		{"closed", gobreaker.StateClosed, 0},
+		{"half-open", gobreaker.StateHalfOpen, 1},
+		{"open", gobreaker.StateOpen, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, stateValue(tt.state))
+		})
+	}
+}
+
+func TestRecordBreakerTransition_NoPanicWithoutMeterProvider(t *testing.T) {
+	// Instruments fall back to no-ops when no MeterProvider is installed;
+	// recording must stay safe on the hot path regardless.
+	assert.NotPanics(t, func() {
+		recordBreakerTransition("test", gobreaker.StateClosed, gobreaker.StateOpen)
+	})
+}
+
+func TestRecordBreakerState_NoPanicWithoutMeterProvider(t *testing.T) {
+	assert.NotPanics(t, func() {
+		recordBreakerState("test", gobreaker.StateClosed)
+	})
+}
+
+// NewBreakerClient must seed the gauge, or a process whose breaker never trips
+// exports no valkey_breaker_state series at all — indistinguishable from a dead
+// process on a dashboard, when it is in fact the healthy steady state.
+func TestNewBreakerClient_SeedsStateGauge(t *testing.T) {
+	reader := swapBreakerStateGauge(t)
+	NewBreakerClient(&stubClient{}, "seed-test")
+
+	v, ok := gaugeValue(t, reader, "valkey_breaker_state", "seed-test")
+	assert.True(t, ok, "a freshly constructed breaker must export its closed state")
+	assert.Equal(t, int64(0), v)
+}

--- a/pkg/valkeyutil/observability.go
+++ b/pkg/valkeyutil/observability.go
@@ -17,8 +17,11 @@ type Observability interface {
 }
 
 type connectConfig struct {
-	obs       Observability
-	redisOpts []o11yredis.Option
+	obs         Observability
+	redisOpts   []o11yredis.Option
+	profile     Profile
+	breaker     bool
+	breakerName string
 }
 
 // Option configures ConnectCluster. The zero config attaches no instrumentation
@@ -55,12 +58,31 @@ func WithIgnoredCommands(names ...string) Option {
 	return WithRedisOptions(o11yredis.WithIgnoredCommands(names...))
 }
 
+// WithProfile selects the timeout budget for the client. Defaults to
+// CacheProfile; user-presence-service passes StoreProfile because Valkey is
+// its store of record rather than a cache.
+func WithProfile(p Profile) Option {
+	return func(c *connectConfig) { c.profile = p }
+}
+
 func newConnectConfig(opts ...Option) connectConfig {
-	var cfg connectConfig
+	cfg := connectConfig{profile: CacheProfile, breaker: true, breakerName: "valkey"}
 	for _, opt := range opts {
 		if opt != nil {
 			opt(&cfg)
 		}
 	}
 	return cfg
+}
+
+// WithBreakerName labels the circuit breaker in logs and metrics. Defaults to
+// "valkey"; pass the service name when several clients coexist in one process.
+func WithBreakerName(name string) Option {
+	return func(c *connectConfig) { c.breakerName = name }
+}
+
+// WithoutCircuitBreaker disables the breaker. Intended for tests and one-shot
+// CLI tools, where short-circuiting adds nothing.
+func WithoutCircuitBreaker() Option {
+	return func(c *connectConfig) { c.breaker = false }
 }

--- a/pkg/valkeyutil/observability_integration_test.go
+++ b/pkg/valkeyutil/observability_integration_test.go
@@ -41,7 +41,8 @@ func TestInstrumentCluster_RecordsCommandSpan(t *testing.T) {
 	// Exercise the exact instrumentation path ConnectCluster uses. The
 	// container client is built with a ClusterSlots override (ConnectCluster's
 	// auto-discovery can't reach it), so wrap it directly here.
-	require.NoError(t, instrumentCluster(c, newConnectConfig(WithObservability(recorderObs{tp: tp}))))
+	cfg := newConnectConfig(WithObservability(recorderObs{tp: tp}))
+	require.NoError(t, instrumentCluster(c, &cfg))
 	client := &clusterClient{c: c}
 
 	ctx := context.Background()
@@ -71,10 +72,11 @@ func TestInstrumentCluster_RequireParentSpan(t *testing.T) {
 	tp := trace.NewTracerProvider(trace.WithSyncer(exporter))
 	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
 
-	require.NoError(t, instrumentCluster(c, newConnectConfig(
+	cfg := newConnectConfig(
 		WithObservability(recorderObs{tp: tp}),
 		WithRequireParentSpan(true),
-	)))
+	)
+	require.NoError(t, instrumentCluster(c, &cfg))
 	client := &clusterClient{c: c}
 
 	require.NoError(t, client.Set(context.Background(), "obs-no-parent", "v", time.Hour))

--- a/pkg/valkeyutil/observability_test.go
+++ b/pkg/valkeyutil/observability_test.go
@@ -44,5 +44,32 @@ func TestNewConnectConfig_NilOptionIgnored(t *testing.T) {
 func TestInstrumentCluster_NoObservability_NoError(t *testing.T) {
 	// With no observability configured, instrumentCluster is a no-op and must
 	// not touch the (here nil) client.
-	assert.NoError(t, instrumentCluster(nil, newConnectConfig()))
+	cfg := newConnectConfig()
+	assert.NoError(t, instrumentCluster(nil, &cfg))
+}
+
+func TestWithProfile_OverridesDefault(t *testing.T) {
+	cfg := newConnectConfig(WithProfile(StoreProfile))
+	assert.Equal(t, StoreProfile, cfg.profile)
+}
+
+func TestNewConnectConfig_DefaultsToCacheProfile(t *testing.T) {
+	cfg := newConnectConfig()
+	assert.Equal(t, CacheProfile, cfg.profile)
+}
+
+func TestWithoutCircuitBreaker(t *testing.T) {
+	cfg := newConnectConfig(WithoutCircuitBreaker())
+	assert.False(t, cfg.breaker)
+}
+
+func TestNewConnectConfig_BreakerOnByDefault(t *testing.T) {
+	cfg := newConnectConfig()
+	assert.True(t, cfg.breaker)
+	assert.Equal(t, "valkey", cfg.breakerName)
+}
+
+func TestWithBreakerName(t *testing.T) {
+	cfg := newConnectConfig(WithBreakerName("presence"))
+	assert.Equal(t, "presence", cfg.breakerName)
 }

--- a/pkg/valkeyutil/profile.go
+++ b/pkg/valkeyutil/profile.go
@@ -1,0 +1,70 @@
+package valkeyutil
+
+import (
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Profile is a bounded timeout budget for a Valkey client. go-redis cluster
+// defaults (5s dial, 3s read/write, and MaxRetries -1 — no retries at all, see
+// ClusterOptions.init) are far too loose for a cache on the message hot path:
+// against a blackholing Valkey they turn a fail-open read into a multi-second
+// stall on every call.
+//
+// Note these profiles ADD retries where the cluster default has none, so a
+// profile's worst-case per-command latency is (MaxRetries+1) x ReadTimeout plus
+// backoff, not ReadTimeout alone.
+//
+// These are code constants rather than environment variables by design (see
+// the spec). They are internal tuning, and a wrong value silently reintroduces
+// the stall this package exists to prevent.
+type Profile struct {
+	DialTimeout  time.Duration
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+	PoolTimeout  time.Duration
+	MaxRetries   int
+}
+
+var (
+	// CacheProfile serves consumers that have a backing store to fall back to
+	// (room meta, room subscriptions, search restricted-rooms). Failing fast
+	// matters more than succeeding slowly — the fallback is always available.
+	CacheProfile = Profile{
+		DialTimeout:  time.Second,
+		ReadTimeout:  150 * time.Millisecond,
+		WriteTimeout: 150 * time.Millisecond,
+		PoolTimeout:  250 * time.Millisecond,
+		MaxRetries:   1,
+	}
+
+	// StoreProfile serves user-presence-service, where Valkey is the store of
+	// record and no fallback exists. A cache-tight ceiling on a Lua EVAL under
+	// load would manufacture failures nothing can absorb.
+	StoreProfile = Profile{
+		DialTimeout:  time.Second,
+		ReadTimeout:  500 * time.Millisecond,
+		WriteTimeout: 500 * time.Millisecond,
+		PoolTimeout:  time.Second,
+		MaxRetries:   2,
+	}
+)
+
+// ClusterOptionsFor builds the go-redis cluster options for a profile.
+// Exported so user-presence-service/presencestore, which constructs its own
+// client for Lua scripting, applies the same budget without duplicating it.
+func ClusterOptionsFor(addrs []string, password string, p Profile) *redis.ClusterOptions {
+	return &redis.ClusterOptions{
+		Addrs:        addrs,
+		Password:     password,
+		DialTimeout:  p.DialTimeout,
+		ReadTimeout:  p.ReadTimeout,
+		WriteTimeout: p.WriteTimeout,
+		PoolTimeout:  p.PoolTimeout,
+		MaxRetries:   p.MaxRetries,
+		// Without this, go-redis ignores the caller's context deadline for
+		// socket reads and only ReadTimeout applies.
+		ContextTimeoutEnabled: true,
+	}
+}

--- a/pkg/valkeyutil/profile_test.go
+++ b/pkg/valkeyutil/profile_test.go
@@ -1,0 +1,42 @@
+package valkeyutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClusterOptionsFor(t *testing.T) {
+	tests := []struct {
+		name        string
+		profile     Profile
+		wantRead    time.Duration
+		wantRetries int
+	}{
+		{"cache profile", CacheProfile, 150 * time.Millisecond, 1},
+		{"store profile", StoreProfile, 500 * time.Millisecond, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := ClusterOptionsFor([]string{"host:6379"}, "pw", tt.profile)
+
+			assert.Equal(t, []string{"host:6379"}, opts.Addrs)
+			assert.Equal(t, "pw", opts.Password)
+			assert.Equal(t, tt.wantRead, opts.ReadTimeout)
+			assert.Equal(t, tt.wantRead, opts.WriteTimeout)
+			assert.Equal(t, tt.wantRetries, opts.MaxRetries)
+			assert.Equal(t, time.Second, opts.DialTimeout)
+			// The critical one: without this, a caller's context deadline does
+			// not bound the socket read and the profile buys nothing.
+			assert.True(t, opts.ContextTimeoutEnabled, "ContextTimeoutEnabled must be set")
+		})
+	}
+}
+
+func TestProfiles_CacheIsTighterThanStore(t *testing.T) {
+	// Presence uses Valkey as its store of record, so it gets more headroom
+	// than the cache consumers, which all have a Mongo/ES fallback.
+	assert.Less(t, CacheProfile.ReadTimeout, StoreProfile.ReadTimeout)
+	assert.Less(t, CacheProfile.MaxRetries, StoreProfile.MaxRetries)
+}

--- a/pkg/valkeyutil/valkey.go
+++ b/pkg/valkeyutil/valkey.go
@@ -21,8 +21,9 @@ type Client interface {
 	// SetNX atomically sets key to value with ttl iff key is absent: (true,nil) acquired,
 	// (false,nil) refused, (false,err) transport failure. ttl must be > 0 — a zero ttl stores without expiry.
 	SetNX(ctx context.Context, key, value string, ttl time.Duration) (bool, error)
-	// IncrEx atomically increments key by 1, returning the post-increment count. ttl applies only
-	// on the 0->1 transition (standard fixed-window rate-limit recipe), via INCR + conditional EXPIRE.
+	// IncrEx increments key by 1, returning the post-increment count. ttl opens a fixed window
+	// via INCR + EXPIRE NX: the first increment sets the expiry, later ones leave a live window
+	// alone but repair a missing one, so a counter can never outlive its window.
 	IncrEx(ctx context.Context, key string, ttl time.Duration) (int64, error)
 	Del(ctx context.Context, keys ...string) error
 	Close() error
@@ -35,34 +36,112 @@ type clusterClient struct {
 	c *redis.ClusterClient
 }
 
-// ConnectCluster dials a Valkey cluster via the provided seed addresses, verifies connectivity with PING, and returns a Client.
-func ConnectCluster(ctx context.Context, addrs []string, password string, opts ...Option) (Client, error) {
-	c := redis.NewClusterClient(&redis.ClusterOptions{
-		Addrs:    addrs,
-		Password: password,
-	})
-	if err := instrumentCluster(c, newConnectConfig(opts...)); err != nil {
+// buildCluster constructs and instruments the raw cluster client. Callers own
+// closing c on any error path that follows.
+func buildCluster(addrs []string, password string, cc *connectConfig) (*redis.ClusterClient, error) {
+	c := redis.NewClusterClient(ClusterOptionsFor(addrs, password, cc.profile))
+	if err := instrumentCluster(c, cc); err != nil {
 		if closeErr := c.Close(); closeErr != nil {
 			slog.Warn("valkey cluster close after failed instrument", "error", closeErr)
 		}
 		return nil, err
 	}
-	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	return c, nil
+}
+
+// wrap applies the circuit breaker unless disabled via WithoutCircuitBreaker.
+func wrap(c *redis.ClusterClient, cc *connectConfig) Client {
+	base := Client(&clusterClient{c: c})
+	if !cc.breaker {
+		return base
+	}
+	return NewBreakerClient(base, cc.breakerName)
+}
+
+// pingTimeout bounds the startup reachability probe. Note the effective socket
+// deadline is min(pingTimeout, Profile.ReadTimeout) — go-redis takes the earlier
+// of the two — so in practice the profile governs and this is only a ceiling.
+const pingTimeout = 5 * time.Second
+
+// connect builds, instruments and probes a cluster client, returning it with the
+// resolved config. failFast decides the sole difference between the exported
+// constructors: whether an unreachable cluster is fatal or merely logged.
+func connect(ctx context.Context, addrs []string, password string, failFast bool, opts ...Option) (*redis.ClusterClient, *connectConfig, error) {
+	cc := newConnectConfig(opts...)
+	c, err := buildCluster(addrs, password, &cc)
+	if err != nil {
+		return nil, nil, err
+	}
+	pingCtx, cancel := context.WithTimeout(ctx, pingTimeout)
 	defer cancel()
-	if err := c.Ping(pingCtx).Err(); err != nil {
-		// Close the half-constructed client on the ping-failure path so unreachable addrs don't leak internal go-redis pool state.
+	switch pingErr := c.Ping(pingCtx).Err(); {
+	case pingErr == nil:
+		slog.Info("connected to Valkey cluster", "addrs", addrs)
+	case failFast:
+		// Close the half-constructed client so unreachable addrs don't leak internal go-redis pool state.
 		if closeErr := c.Close(); closeErr != nil {
 			slog.Warn("valkey cluster close after failed connect", "error", closeErr)
 		}
-		return nil, fmt.Errorf("valkey cluster connect: %w", err)
+		return nil, nil, fmt.Errorf("valkey cluster connect: %w", pingErr)
+	default:
+		slog.Warn("valkey cluster unreachable at startup; continuing with lazy connect",
+			"addrs", addrs, "error", pingErr)
 	}
-	slog.Info("connected to Valkey cluster", "addrs", addrs)
-	return &clusterClient{c: c}, nil
+	return c, &cc, nil
+}
+
+// ConnectCluster dials a Valkey cluster via the provided seed addresses, verifies connectivity with PING, and returns a Client.
+// It fails fast when Valkey is unreachable.
+//
+// Long-running services must use ConnectClusterLazy instead — a fatal startup
+// probe crashloops the pod during a Valkey outage. ConnectCluster remains for
+// one-shot CLI tools (tools/seed-sample-data), where failing fast is correct.
+func ConnectCluster(ctx context.Context, addrs []string, password string, opts ...Option) (Client, error) {
+	c, cc, err := connect(ctx, addrs, password, true, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return wrap(c, cc), nil
+}
+
+// ConnectClusterLazy builds an instrumented cluster client without gating on
+// reachability. The startup PING becomes a non-fatal probe: an unreachable
+// Valkey is logged and a usable Client is still returned.
+//
+// This is what long-running services must use. go-redis dials lazily and
+// self-heals per call, so a Valkey outage no longer prevents a pod from
+// starting — which otherwise turns any rollout, autoscale, or node drain
+// during the outage into a CrashLoopBackOff on the message path.
+//
+// The returned error covers construction and instrumentation failures only;
+// it is never returned because Valkey happens to be unreachable.
+func ConnectClusterLazy(ctx context.Context, addrs []string, password string, opts ...Option) (Client, error) {
+	c, cc, err := connect(ctx, addrs, password, false, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return wrap(c, cc), nil
+}
+
+// NewClusterClient returns the raw instrumented cluster client, for consumers
+// whose commands fall outside the Client facade — Lua scripting, sorted sets,
+// pipelines. It applies the same options (profile, observability) and the same
+// non-fatal startup probe as ConnectClusterLazy, so those consumers no longer
+// have to re-implement construction and silently lose the o11y hooks.
+//
+// The circuit breaker is not available here: it decorates the Client facade, so
+// a raw-client consumer sees timeouts rather than short-circuits.
+//
+// The returned error covers construction and instrumentation only; it is never
+// returned because Valkey happens to be unreachable.
+func NewClusterClient(ctx context.Context, addrs []string, password string, opts ...Option) (*redis.ClusterClient, error) {
+	c, _, err := connect(ctx, addrs, password, false, opts...)
+	return c, err
 }
 
 // instrumentCluster attaches o11y/redis tracing+metrics hooks when observability is configured.
 // o11yredis.Wrap mutates the client in place and is idempotent, registering its own teardown — Disconnect needs no extra handling.
-func instrumentCluster(c *redis.ClusterClient, cc connectConfig) error {
+func instrumentCluster(c *redis.ClusterClient, cc *connectConfig) error {
 	if cc.obs == nil {
 		return nil
 	}
@@ -119,17 +198,27 @@ func (r *clusterClient) SetNX(ctx context.Context, key, value string, ttl time.D
 }
 
 func (r *clusterClient) IncrEx(ctx context.Context, key string, ttl time.Duration) (int64, error) {
-	n, err := r.c.Incr(ctx, key).Result()
-	if err != nil {
+	if ttl <= 0 {
+		n, err := r.c.Incr(ctx, key).Result()
+		if err != nil {
+			return 0, fmt.Errorf("valkey incr: %w", err)
+		}
+		return n, nil
+	}
+	// EXPIRE NX on every increment, not a bare EXPIRE on the 0->1 transition: if a
+	// prior call's INCR landed and its EXPIRE did not, the counter is left with no
+	// expiry, never resets, and permanently throttles the caller once it passes the
+	// ceiling. NX repairs that on the next increment while leaving a live window
+	// alone, so this stays a fixed window rather than becoming a sliding one.
+	// Pipelined to keep the pair at one round trip; both commands share a key, so
+	// cluster routing keeps them on one node.
+	pipe := r.c.Pipeline()
+	incr := pipe.Incr(ctx, key)
+	pipe.ExpireNX(ctx, key, ttl)
+	if _, err := pipe.Exec(ctx); err != nil {
 		return 0, fmt.Errorf("valkey incr: %w", err)
 	}
-	if n == 1 && ttl > 0 {
-		// Only the 0->1 caller sets TTL; failure would let the key persist past the window, so surface it.
-		if err := r.c.Expire(ctx, key, ttl).Err(); err != nil {
-			return n, fmt.Errorf("valkey incr expire: %w", err)
-		}
-	}
-	return n, nil
+	return incr.Val(), nil
 }
 
 func (r *clusterClient) Del(ctx context.Context, keys ...string) error {

--- a/pkg/valkeyutil/valkey_test.go
+++ b/pkg/valkeyutil/valkey_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"testing"
 	"time"
 
@@ -231,4 +232,107 @@ func TestConnectCluster_ErrorPath(t *testing.T) {
 	_, err := valkeyutil.ConnectCluster(context.Background(), []string{"127.0.0.1:1"}, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "valkey cluster connect")
+}
+
+// blackholeListener accepts TCP connections and never responds. This is the
+// failure mode that matters: a Valkey that refuses connections fails fast on
+// its own, but one that silently drops packets stalls every call until a
+// timeout fires. Connection-refused testing never catches it.
+func blackholeListener(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed
+			}
+			// Hold the connection open and never write. Closed by t.Cleanup.
+			t.Cleanup(func() { _ = conn.Close() })
+		}
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		<-done
+	})
+	return ln.Addr().String()
+}
+
+func TestConnectCluster_BoundedLatencyAgainstBlackhole(t *testing.T) {
+	addr := blackholeListener(t)
+
+	start := time.Now()
+	_, err := valkeyutil.ConnectCluster(context.Background(), []string{addr}, "")
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "connect against a blackhole must fail, not hang")
+	// 2s is chosen to discriminate, not just to be generous: it is below the old
+	// go-redis default ReadTimeout (3s) and below ConnectCluster's own 5s ping
+	// ceiling, so this assertion would FAIL against the unfixed defaults instead
+	// of being masked by that ceiling. Measured actual is ~0.17s, so 2s still
+	// leaves ~10x margin against CI jitter.
+	assert.Less(t, elapsed, 2*time.Second, "connect must be bounded by dial/read timeouts")
+}
+
+func TestConnectClusterLazy_ReturnsUsableClientWhenUnreachable(t *testing.T) {
+	addr := blackholeListener(t)
+
+	client, err := valkeyutil.ConnectClusterLazy(context.Background(), []string{addr}, "")
+	require.NoError(t, err, "lazy connect must not fail on an unreachable Valkey")
+	require.NotNil(t, client)
+	t.Cleanup(func() { _ = client.Close() })
+
+	// The client is usable; the call itself errors rather than panicking.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, getErr := client.Get(ctx, "some-key")
+	assert.Error(t, getErr)
+}
+
+func TestConnectClusterLazy_BoundedFirstCall(t *testing.T) {
+	addr := blackholeListener(t)
+	client, err := valkeyutil.ConnectClusterLazy(context.Background(), []string{addr}, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	start := time.Now()
+	_, _ = client.Get(context.Background(), "k")
+	elapsed := time.Since(start)
+	t.Logf("first Get against blackhole took %s", elapsed)
+	// The brief's own suggested 5s ceiling matches ConnectClusterLazy's PING
+	// bound and would pass even against an unbounded stall, so it proves
+	// nothing. CacheProfile bounds a single Get to ReadTimeout(150ms) +
+	// MaxRetries(1)*ReadTimeout ~= 300ms plus one-time cluster-slots discovery
+	// against the same blackhole; 2s (same threshold as the ConnectCluster
+	// blackhole test above, and still below go-redis's old 3s default
+	// ReadTimeout) discriminates a genuinely bounded first call from an
+	// unbounded one while leaving ample margin over the measured ~0.2-0.3s.
+	assert.Less(t, elapsed, 2*time.Second, "CacheProfile must bound the first call")
+}
+
+// NewClusterClient exists so raw-client consumers (Lua scripting, sorted sets)
+// stop re-implementing construction and silently losing instrumentation. Like
+// ConnectClusterLazy, an unreachable cluster is a logged probe, not an error.
+func TestNewClusterClient_UnreachableIsNotAnError(t *testing.T) {
+	c, err := valkeyutil.NewClusterClient(context.Background(),
+		[]string{"127.0.0.1:1"}, "", valkeyutil.WithProfile(valkeyutil.StoreProfile))
+	require.NoError(t, err, "unreachability must never fail construction")
+	require.NotNil(t, c)
+	t.Cleanup(func() { _ = c.Close() })
+
+	opts := c.Options()
+	assert.Equal(t, valkeyutil.StoreProfile.ReadTimeout, opts.ReadTimeout)
+	assert.Equal(t, valkeyutil.StoreProfile.WriteTimeout, opts.WriteTimeout)
+	assert.Equal(t, valkeyutil.StoreProfile.MaxRetries, opts.MaxRetries)
+	assert.True(t, opts.ContextTimeoutEnabled, "caller deadlines must bound socket reads")
+}
+
+func TestNewClusterClient_DefaultsToCacheProfile(t *testing.T) {
+	c, err := valkeyutil.NewClusterClient(context.Background(), []string{"127.0.0.1:1"}, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+	assert.Equal(t, valkeyutil.CacheProfile.ReadTimeout, c.Options().ReadTimeout)
 }

--- a/room-worker/main.go
+++ b/room-worker/main.go
@@ -148,9 +148,10 @@ func main() {
 
 	var metaValkey valkeyutil.Client
 	if len(cfg.ValkeyAddrs) > 0 {
-		metaValkey, err = valkeyutil.ConnectCluster(ctx, cfg.ValkeyAddrs, cfg.ValkeyPassword,
+		metaValkey, err = valkeyutil.ConnectClusterLazy(ctx, cfg.ValkeyAddrs, cfg.ValkeyPassword,
 			valkeyutil.WithObservability(sdk),
 			valkeyutil.WithRequireParentSpan(true),
+			valkeyutil.WithBreakerName("room-worker"),
 		)
 		if err != nil {
 			slog.Error("valkey connect (room-meta L2 invalidation) failed", "error", err)

--- a/search-service/handler.go
+++ b/search-service/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hmchangw/chat/pkg/natsrouter"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/subject"
+	"github.com/hmchangw/chat/pkg/valkeyutil"
 )
 
 // defaultUsersLimit is the page size forwarded to the HR endpoint when the
@@ -257,7 +258,7 @@ func (h *handler) searchOrgs(c *natsrouter.Context, req model.SearchOrgsRequest)
 func (h *handler) loadRestricted(ctx context.Context, account string) (map[string]int64, error) {
 	cached, hit, cerr := h.cache.GetRestricted(ctx, account)
 	if cerr != nil {
-		slog.Warn("valkey read failed; falling through to ES", "account", account, "error", cerr)
+		valkeyutil.LogDegraded(ctx, "valkey read failed; falling through to ES", cerr, "account", account)
 	}
 	if hit {
 		return cached, nil
@@ -287,7 +288,7 @@ func (h *handler) loadRestricted(ctx context.Context, account string) (map[strin
 	// without new signal.
 	if cerr == nil {
 		if err := h.cache.SetRestricted(ctx, account, restricted, h.cfg.RestrictedRoomsCacheTTL); err != nil {
-			slog.Warn("valkey set failed; continuing without cache", "account", account, "error", err)
+			valkeyutil.LogDegraded(ctx, "valkey set failed; continuing without cache", err, "account", account)
 		}
 	}
 	return restricted, nil

--- a/search-service/main.go
+++ b/search-service/main.go
@@ -174,9 +174,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	valkey, err := valkeyutil.ConnectCluster(ctx, cfg.Valkey.Addrs, cfg.Valkey.Password,
+	valkey, err := valkeyutil.ConnectClusterLazy(ctx, cfg.Valkey.Addrs, cfg.Valkey.Password,
 		valkeyutil.WithObservability(sdk),
 		valkeyutil.WithRequireParentSpan(true),
+		valkeyutil.WithBreakerName("search-service"),
 	)
 	if err != nil {
 		slog.Error("valkey connect failed", "error", err)

--- a/tools/seed-sample-data/main.go
+++ b/tools/seed-sample-data/main.go
@@ -115,7 +115,12 @@ func run(reset bool) error {
 	// writeSideStores provisions their keys.
 	keyStore := roomkeystore.NewMongoStore(db.Collection("rooms"), 5*time.Minute)
 
-	valkeyClient, err := valkeyutil.ConnectCluster(ctx, cfg.ValkeyAddrs, cfg.ValkeyPassword)
+	// One-shot CLI: fail fast on an unreachable Valkey (ConnectCluster, not the
+	// Lazy variant that long-running services need), and no circuit breaker — a
+	// bulk seed has no fallback path, so short-circuiting mid-run would abort the
+	// seed with a confusing error instead of surfacing the real Valkey failure.
+	valkeyClient, err := valkeyutil.ConnectCluster(ctx, cfg.ValkeyAddrs, cfg.ValkeyPassword,
+		valkeyutil.WithoutCircuitBreaker())
 	if err != nil {
 		return fmt.Errorf("valkey client connect: %w", err)
 	}

--- a/user-presence-service/main.go
+++ b/user-presence-service/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hmchangw/chat/pkg/shutdown"
 	"github.com/hmchangw/chat/pkg/subject"
 	"github.com/hmchangw/chat/pkg/userstore"
+	"github.com/hmchangw/chat/pkg/valkeyutil"
 	"github.com/hmchangw/chat/user-presence-service/presencestore"
 )
 
@@ -92,12 +93,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	store, err := presencestore.NewValkeyStore(
+	store, err := presencestore.NewValkeyStore(ctx,
 		presencestore.ClusterConfig{Addrs: cfg.Valkey.Addrs, Password: cfg.Valkey.Password},
 		cfg.Presence.StaleThreshold, cfg.Presence.ConnsTTL,
+		valkeyutil.WithObservability(sdk),
 	)
 	if err != nil {
-		slog.Error("valkey connect failed", "error", err)
+		slog.Error("build valkey client failed", "error", err)
 		os.Exit(1)
 	}
 

--- a/user-presence-service/presencestore/store.go
+++ b/user-presence-service/presencestore/store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/subject"
+	"github.com/hmchangw/chat/pkg/valkeyutil"
 )
 
 const keyPrefix = "presence:"
@@ -188,16 +189,21 @@ type ClusterConfig struct {
 	Password string
 }
 
-// NewValkeyStore dials the cluster, pings it, and returns a Store.
-func NewValkeyStore(cfg ClusterConfig, staleThreshold, connsTTL time.Duration) (*Store, error) {
-	c := redis.NewClusterClient(&redis.ClusterOptions{Addrs: cfg.Addrs, Password: cfg.Password})
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if err := c.Ping(ctx).Err(); err != nil {
-		if closeErr := c.Close(); closeErr != nil {
-			slog.Warn("valkey cluster close after failed connect", "error", closeErr)
-		}
-		return nil, fmt.Errorf("valkey cluster connect: %w", err)
+// NewValkeyStore dials the cluster and returns a Store. Construction, the
+// StoreProfile budget and the non-fatal startup probe all come from
+// valkeyutil.NewClusterClient, so this path picks up the same o11y hooks as
+// every other Valkey client in the fleet.
+//
+// Presence is the store of record with no fallback, hence StoreProfile's wider
+// budget rather than the cache-tight CacheProfile: a ceiling that manufactures
+// Lua EVAL timeouts here has nothing to degrade to. Unreachability is not an
+// error — failing startup would turn any rollout or node drain during an outage
+// into a CrashLoopBackOff on the one service that cannot degrade.
+func NewValkeyStore(ctx context.Context, cfg ClusterConfig, staleThreshold, connsTTL time.Duration, opts ...valkeyutil.Option) (*Store, error) {
+	c, err := valkeyutil.NewClusterClient(ctx, cfg.Addrs, cfg.Password,
+		append([]valkeyutil.Option{valkeyutil.WithProfile(valkeyutil.StoreProfile)}, opts...)...)
+	if err != nil {
+		return nil, fmt.Errorf("build presence valkey client: %w", err)
 	}
 	return NewValkeyStoreFromClient(c, staleThreshold, connsTTL), nil
 }

--- a/user-presence-service/presencestore/store_test.go
+++ b/user-presence-service/presencestore/store_test.go
@@ -1,0 +1,50 @@
+package presencestore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/valkeyutil"
+)
+
+// Presence is Valkey-only — there is no database behind it — so an unreachable
+// cluster at startup must not stop the pod coming up. A fatal probe turns any
+// rollout or node drain during a Valkey outage into a CrashLoopBackOff that
+// outlives the outage itself; a lazily-connected client self-heals on the next
+// call once Valkey returns.
+func TestNewValkeyStore_UnreachableClusterStillReturnsStore(t *testing.T) {
+	store, err := NewValkeyStore(
+		context.Background(),
+		ClusterConfig{Addrs: []string{"127.0.0.1:1"}},
+		time.Minute, time.Minute,
+	)
+	require.NoError(t, err, "an unreachable cluster must not fail construction")
+	require.NotNil(t, store)
+	t.Cleanup(func() { _ = store.Close() })
+}
+
+// The store of record must carry StoreProfile's budget, not go-redis defaults.
+// Its Lua EVALs have no fallback to absorb a manufactured timeout, so the
+// cache-tight CacheProfile would be actively harmful here. Asserted on the
+// constructed client rather than on an options helper, so the wiring itself is
+// covered rather than a restatement of ClusterOptionsFor's own test.
+func TestNewValkeyStore_UsesStoreProfile(t *testing.T) {
+	store, err := NewValkeyStore(
+		context.Background(),
+		ClusterConfig{Addrs: []string{"127.0.0.1:1"}},
+		time.Minute, time.Minute,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	opts := store.c.Options()
+	assert.Equal(t, valkeyutil.StoreProfile.ReadTimeout, opts.ReadTimeout)
+	assert.Equal(t, valkeyutil.StoreProfile.WriteTimeout, opts.WriteTimeout)
+	assert.Equal(t, valkeyutil.StoreProfile.PoolTimeout, opts.PoolTimeout)
+	assert.Equal(t, valkeyutil.StoreProfile.MaxRetries, opts.MaxRetries)
+	assert.True(t, opts.ContextTimeoutEnabled, "caller deadlines must bound socket reads")
+}

--- a/user-presence-service/sync/main.go
+++ b/user-presence-service/sync/main.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	"github.com/caarlos0/env/v11"
-	"github.com/redis/go-redis/v9"
 
 	"github.com/hmchangw/chat/pkg/msgraph"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
+	"github.com/hmchangw/chat/pkg/valkeyutil"
 	"github.com/hmchangw/chat/user-presence-service/presencestore"
 )
 
@@ -88,9 +88,14 @@ func run() error {
 		}
 	}()
 
-	clusterClient := redis.NewClusterClient(&redis.ClusterOptions{
-		Addrs: cfg.ValkeyAddrs, Password: cfg.ValkeyPassword,
-	})
+	// Raw client (the in-call index and ID map issue sorted-set commands outside
+	// the Client facade), built through valkeyutil so this path gets the same
+	// StoreProfile budget and o11y hooks as the presence store it writes through.
+	clusterClient, err := valkeyutil.NewClusterClient(ctx, cfg.ValkeyAddrs, cfg.ValkeyPassword,
+		valkeyutil.WithProfile(valkeyutil.StoreProfile), valkeyutil.WithObservability(sdk))
+	if err != nil {
+		return fmt.Errorf("build valkey client: %w", err)
+	}
 	defer func() {
 		if err := clusterClient.Close(); err != nil {
 			slog.Warn("valkey close", "error", err)


### PR DESCRIPTION
Closes the two mechanical traps that let a Valkey outage escalate into a chat outage. Neither is a logic bug in the cache consumers — both live in how the client is constructed.

**The timeout trap.** The client was built with only `Addrs` and `Password`, so go-redis defaults applied and `ContextTimeoutEnabled` was `false` — a caller's context deadline did not bound socket reads at all. Against a Valkey that *blackholes* packets (the common degraded mode, rather than one that refuses connections), every hot-path read stalled for seconds before falling back. The code was fail-open; the network behaviour was fail-slow.

**The startup trap.** Seven services treated a failed startup `PING` as fatal. Running pods survived an outage, but any rollout, autoscale, node drain, or OOM-kill during one would put `message-gatekeeper` and `broadcast-worker` into `CrashLoopBackOff` — and the crashloop outlived the outage.

## Review order

`pkg/valkeyutil` is 12 of 38 files and everything else depends on its contract, so read it first. Each commit is one self-contained change and builds independently (verified), so commit-by-commit works.

| Commit | Scope |
|---|---|
| `d2d849a` | Design spec + implementation plan (working notes — see *Open questions*) |
| `dae29ef` | `pkg/valkeyutil`: profiles, breaker, non-fatal connect, `IncrEx` fix, `LogDegraded` |
| `b4fae2d` | `botplatform-service`: fail-open posture |
| `4ff5a3b` | `user-presence-service`: lazy connect + `StoreProfile` |
| `6904300` | Five cache services lazy; seeder keeps failing fast |
| `f049618` | Warn-flood suppression at the cache consumers |
| `eadb2e7` | `docs/health-probes.md` |
| `dc8f5a2` | Breaker error classification corrected — see below |

## Behaviour changes

These are the things that change in production, and the reason to read the PR rather than the diff:

1. **The circuit breaker is on by default** for existing `ConnectCluster` callers, without them opting in. Deliberate; `WithoutCircuitBreaker()` opts out.
2. **`botplatform-service` fails open.** During an outage bot requests are admitted **unthrottled and without duplicate suppression**. Bots are critical, so a lost ceiling beats a dead bot — this is a conscious trade, not an oversight. `bot_control_bypassed_total{control}` is the only durable signal that protection was off; alert on it.
3. **Six services no longer fail startup** on an unreachable Valkey. `tools/seed-sample-data` still does, which is correct for a one-shot CLI.
4. **`user-presence-service` gains o11y hooks.** It previously built a raw client outside `valkeyutil` and was the only Valkey client in the fleet emitting no command spans or pool metrics.
5. **`IncrEx` changes wire behaviour** from `INCR` + conditional `EXPIRE` to a pipelined `INCR` + `EXPIRE NX`. This fixes a latent bug: a landed `INCR` whose `EXPIRE` failed left a counter with no expiry, so the window never reset and the caller was throttled *permanently* once past the ceiling, long after Valkey recovered.
6. **Per-call warn logs drop to Debug while the circuit is open.** A live failure still logs at Warn.

## Design decisions worth a reviewer's attention

**`ContextTimeoutEnabled: true`** is the load-bearing field. Without it the whole profile mechanism is decorative.

**Breaker error classification uses all three of gobreaker's outcomes** (corrected in `dc8f5a2`; the earlier commits got this wrong and the reasoning is worth stating).

The original implementation forced every error into success-or-failure, on the stated premise that "gobreaker offers no neutral outcome, so each ambiguous error is scored by which wrong answer costs less." That premise is **false** for the `gobreaker/v2 v2.4.0` this PR pins: `Settings.IsExcluded` drops a call from the accounting entirely, is consulted before `IsSuccessful`, and its own documentation offers *ignoring context cancellations* as the example use case.

Both forced scores were live defects, failing in opposite directions:

- **Cancellation was scored a failure.** A cancelled caller is no evidence Valkey is unhealthy, but `ReadyToTrip` fires at five consecutive failures — so a burst opened the breaker on a healthy cache and stampeded Mongo, the self-inflicted outage the classifier exists to prevent. Cancellations arrive in exactly that shape, since one slow sibling makes an errgroup cancel all the others at once.
- **Pool timeout was scored a success**, which clears `ConsecutiveFailures`. A genuine outage interleaved with pool timeouts kept the count near zero and the breaker never tripped — the same "held closed through a real outage" failure the cancellation reasoning was trying to avoid, reached from the other side.

Both are now **excluded**: they move neither counter, so they can neither trip the breaker nor hold it closed. `context.DeadlineExceeded` is deliberately **left in the accounting as a failure** — with `ContextTimeoutEnabled` bounding socket reads, a deadline is precisely how a blackholing Valkey surfaces, which is the degraded mode this PR targets. Excluding it too would blind the breaker to the outage it was built for.

**Timeout values are code constants, not environment variables** — a departure from the repo's usual env-config rule. Exposing them adds seven services' worth of surface nobody will set correctly under incident pressure, and a wrong value silently reintroduces the trap. Flagged because a reviewer should weigh in.

**Profiles add retries.** The go-redis *cluster* default is `MaxRetries: -1` (no retries), so worst-case per-command latency is `(MaxRetries+1) × ReadTimeout` plus backoff, not `ReadTimeout` alone.

## Known limitations

- **One breaker spans the whole cluster.** A single-shard failover trips it and short-circuits keys on healthy shards too. Per-shard breakers need slot mapping; not attempted here.
- **The breaker decorates the `Client` facade**, so `user-presence-service`'s raw client (Lua, sorted sets) is not behind one and pays its `StoreProfile` budget per call instead.
- **Room-metadata invalidation stays best-effort**, so a rename during an outage can serve stale metadata until `ROOM_META_L2_TTL` (default 15m). The write itself still lands in Mongo.

## Verification

- CI was green on `eadb2e7`: `test`, `lint`, `sast`, and all 50 `test-integration` jobs. `dc8f5a2` is re-running.
- Locally on `dc8f5a2`: `make lint` 0 issues, `make test` green (109 packages), `go build ./...` and `go vet -tags=integration` clean, `gosec` clean. `govulncheck` and `semgrep` could not run in the dev sandbox (their rule/vuln feeds are network-fetched and blocked there) — CI covers all three.
- `pkg/valkeyutil` unit coverage is **71.4%**. The remainder is the `clusterClient` store methods, which need a live server and are covered by the integration suite per CLAUDE.md §4 — not a gap, but stated plainly rather than rounded up. `breaker.go` itself is at 100% for both classifier predicates.
- Every commit builds and vets independently; the branch is bisectable.

## Open questions for the reviewer

1. **`github.com/sony/gobreaker/v2` is a new dependency.** CLAUDE.md requires sign-off before adding one. Please confirm.
2. **Should the spec and plan ship?** `docs/superpowers/**` is the bulk of the diff and they are working notes rather than reference docs. Say the word and I will drop them, cutting the review surface substantially. Note the plan still contains the superseded `isSuccessful` body verbatim as a historical transcript; if these files ship rather than being dropped, that block wants a correction too.
3. **Timeout constants vs env vars** (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtKXocLa5CCVCJdasafSK2