### PR TITLE
fix(chat-frontend): bump uuid to 14.0.1 to remediate CVE-2026-41907

### DIFF
--- a/chat-frontend/package-lock.json
+++ b/chat-frontend/package-lock.json
@@ -18,7 +18,7 @@
         "oidc-client-ts": "^3.5.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "uuid": "^11.1.0"
+        "uuid": "^14.0.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -3197,16 +3197,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/chat-frontend/package.json
+++ b/chat-frontend/package.json
@@ -25,7 +25,7 @@
     "oidc-client-ts": "^3.5.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "uuid": "^11.1.0"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",


### PR DESCRIPTION
## What

Upgrade `chat-frontend`'s `uuid` dependency from `^11.1.0` (locked at 11.1.0) to `^14.0.0` (locked at 14.0.1).

## Why

**CVE-2026-41907** is an out-of-bounds write in the `uuid` package prior to `14.0.0`: the `v3` / `v5` / `v6` functions accepted external output buffers without validating buffer boundaries, allowing silent partial writes (memory-safety issue). The fix landed in `uuid@14.0.0`, which adds offset/length validation.

The pinned `11.1.0` falls inside the affected range, so SCA/dependency scanners flag the advisory. Upgrading clears it.

**Practical exposure in this app was nil** — `uuid` is only used via `v4` and `v7`, with no custom output buffer:

| File | Usage |
|------|-------|
| `src/api/_transport/asyncJob.ts` | `uuidv7()` |
| `src/context/ThreadEventsContext/ThreadEventsContext.jsx` | `uuidv4()` |
| `src/components/MainApp/ChatPage/RoomMessageInput/RoomMessageInput.jsx` | `uuidv4()` |

The vulnerable `v3`/`v5`/`v6` functions are never called. This upgrade is remediation-of-record that also clears the scanner finding.

## Compatibility

- `v4` / `v7` named exports are unchanged across the 12 / 13 / 14 majors — no call-site edits needed.
- The only relevant breaking change is the **Node 20+** requirement (14.0.0); the build image (`node:22-alpine`) and CI Node both satisfy it.
- The package has been ESM-only since v12; this project is already `"type": "module"` with named imports — unaffected.

## Scope

`chat-frontend/package.json` is the only manifest in the monorepo declaring `uuid`. `admin-frontend` does not depend on it, so no other frontend is affected.

## Verification

- `npm ci` — lockfile consistent (mirrors `deploy/Dockerfile`)
- `npm run typecheck` — clean
- `npm test` — **850 passed** (82 files)
- `npm run build` — production build clean
- `npm audit` — no advisories for `uuid`

## Out of scope

`npm audit` still reports 10 advisories in unrelated transitive dependencies; these predate this change and are intentionally left for a separate triage so this PR stays scoped to the single CVE.

## Files changed

- `chat-frontend/package.json`
- `chat-frontend/package-lock.json`

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpQeMPpszATCdJwm4VrJ4q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the UUID package to a newer version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->