### PR TITLE
feat(room-service): accept users with only engName or chineseName

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -1204,7 +1204,7 @@ See [Error envelope](#6-error-envelope-reference). Returned synchronously on val
 - `"channel name is required"` / `"channel name must be at most 100 characters"`
 - `"bots cannot be added to a channel"` / `"bot not available"` (botDM target whose assistant is disabled)
 - `user "<account>": user not found` / `org "<orgId>": invalid org` (each wrapped with the offending account/org ID)
-- `"user is missing required name fields"`
+- `"user is missing required name fields"` — rejected only when BOTH `engName` and `chineseName` are empty (either one alone is sufficient)
 - `"exceeds maximum capacity (N): would create M members"`
 
 ```json

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -148,7 +148,7 @@ func (h *Handler) createRoom(c *natsrouter.Context, req model.CreateRoomRequest)
 		}
 		return nil, fmt.Errorf("get requester: %w", err)
 	}
-	if requester.EngName == "" || requester.ChineseName == "" {
+	if requester.EngName == "" && requester.ChineseName == "" {
 		return nil, errInvalidUserData
 	}
 
@@ -252,7 +252,7 @@ func (h *Handler) handleCreateRoomDMOrBotDM(ctx context.Context, req *model.Crea
 		}
 		return nil, fmt.Errorf("get counterpart: %w", err)
 	}
-	if roomType == model.RoomTypeDM && (other.EngName == "" || other.ChineseName == "") {
+	if roomType == model.RoomTypeDM && (other.EngName == "" && other.ChineseName == "") {
 		// botDMs counterpart is an app/bot whose users-collection record
 		// typically has empty name fields; the GetApp + Assistant.Enabled
 		// check below is the right validation for that case.

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -2688,15 +2688,80 @@ func TestHandleCreateRoom_RequesterNotFound(t *testing.T) {
 	assert.True(t, errcode.HasReason(err, errcode.RoomUserNotFound), "want RoomUserNotFound, got %v", err)
 }
 
-func TestHandleCreateRoom_RequesterMissingNameFields(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	store := NewMockRoomStore(ctrl)
-	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u-alice", Account: "alice"}, nil)
-	h := &Handler{store: store, siteID: "site-a", maxRoomSize: 1000}
+// TestHandleCreateRoom_RequesterNameFields covers #244: the creator check
+// rejects only when BOTH EngName and ChineseName are empty; either alone is
+// sufficient. Bot-requester exemption isn't exercised here (bots don't call
+// createRoom as requester); the DM counterpart's bot exemption is covered by
+// TestHandleCreateRoom_BotDM_AppCounterpartNoNameFields (roomType != DM skips
+// this check entirely for botDM).
+func TestHandleCreateRoom_RequesterNameFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		requester *model.User
+		wantErr   bool
+	}{
+		{"engName only", &model.User{ID: "u-alice", Account: "alice", EngName: "Alice"}, false},
+		{"chineseName only", &model.User{ID: "u-alice", Account: "alice", ChineseName: "愛麗絲"}, false},
+		{"both present", &model.User{ID: "u-alice", Account: "alice", EngName: "Alice", ChineseName: "愛麗絲"}, false},
+		{"neither", &model.User{ID: "u-alice", Account: "alice"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			store := NewMockRoomStore(ctrl)
+			store.EXPECT().GetUser(gomock.Any(), "alice").Return(tt.requester, nil)
+			if !tt.wantErr {
+				store.EXPECT().GetUser(gomock.Any(), "bob").Return(bobUser(), nil)
+				store.EXPECT().FindDMSubscription(gomock.Any(), "alice", "bob").
+					Return(&model.Subscription{RoomID: "existing-dm-room"}, nil)
+			}
+			h := &Handler{store: store, siteID: "site-a", maxRoomSize: 1000}
 
-	_, err := h.createRoom(ctxParams(map[string]string{"account": "alice"}), model.CreateRoomRequest{Users: []string{"bob"}})
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, errInvalidUserData))
+			_, err := h.createRoom(ctxParams(map[string]string{"account": "alice"}), model.CreateRoomRequest{Users: []string{"bob"}})
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, errInvalidUserData))
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestHandleCreateRoom_DMCounterpartNameFields covers #244 for the DM
+// counterpart check: rejects only when BOTH fields are empty on `other`.
+func TestHandleCreateRoom_DMCounterpartNameFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		other   *model.User
+		wantErr bool
+	}{
+		{"engName only", &model.User{ID: "u-bob", Account: "bob", EngName: "Bob"}, false},
+		{"chineseName only", &model.User{ID: "u-bob", Account: "bob", ChineseName: "陳博"}, false},
+		{"both present", bobUser(), false},
+		{"neither", &model.User{ID: "u-bob", Account: "bob"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			store := NewMockRoomStore(ctrl)
+			store.EXPECT().GetUser(gomock.Any(), "alice").Return(aliceUser(), nil)
+			store.EXPECT().GetUser(gomock.Any(), "bob").Return(tt.other, nil)
+			if !tt.wantErr {
+				store.EXPECT().FindDMSubscription(gomock.Any(), "alice", "bob").
+					Return(&model.Subscription{RoomID: "existing-dm-room"}, nil)
+			}
+			h := &Handler{store: store, siteID: "site-a", maxRoomSize: 1000}
+
+			_, err := h.createRoom(ctxParams(map[string]string{"account": "alice"}), model.CreateRoomRequest{Users: []string{"bob"}})
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, errInvalidUserData))
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestHandleCreateRoom_SelfDM_Creates(t *testing.T) {


### PR DESCRIPTION
## Summary

Relaxes room-create and DM-open name validation so a user with only
`engName` OR only `chineseName` set can create a room / open a DM.
Previously either field being empty was rejected; now rejection only
happens when both are empty.

Closes #244

## What's included

- `room-service/handler.go`: creator check (`createRoom`) and DM-counterpart
  check (`handleCreateRoomDMOrBotDM`) both changed from `||` to `&&` so
  rejection requires both name fields to be empty.
- `docs/client-api.md`: clarified the `errInvalidUserData` condition wording.

## Changes

- `room-service/handler.go:151` — `if requester.EngName == "" || requester.ChineseName == ""` → `&&`
- `room-service/handler.go:255` — `(other.EngName == "" || other.ChineseName == "")` → `&&`

Message-formatting path (`displayfmt.CombineWithFallback` / gatekeeper) is
untouched — it already falls back to chineseName when engName is absent.

## Verification

- `go test ./room-service/...` — green, including new table-driven cases for
  both checks (engName-only / chineseName-only / both / neither).
- `chat-lint.sh ./room-service/...` — 0 issues.
