### PR TITLE
Fix shell variable syntax in setup.sh comment

### DIFF
--- a/docker-local/setup.sh
+++ b/docker-local/setup.sh
@@ -136,7 +136,7 @@ NATS_CREDS_FILE=/etc/nats/backend.creds
 DEV_MODE=true
 
 # Every setting in the service compose files is overridable from here — grep a
-# compose file for ${ to see a service's own knobs. The common ones:
+# compose file for \${ to see a service's own knobs. The common ones:
 #
 # Published host ports (change one to dodge a conflict; the URLs follow).
 #GATEWAY_HOST_PORT=7777        # baseUrl; portal/media URLs derive from it


### PR DESCRIPTION
## Summary
Escape the dollar sign in a shell comment to prevent unintended variable expansion and improve documentation clarity.

## Changes
- Escaped `${` in the comment on line 139 of `docker-local/setup.sh` by changing `${ ` to `\${` 
  - This prevents the shell from attempting to expand what follows as a variable reference
  - Improves readability of the documentation comment that instructs users to grep for service configuration knobs

## Details
The comment directs users to search compose files for `${` patterns to discover service configuration options. Without escaping, the shell could attempt variable expansion on this literal text, which is not the intended behavior in a comment context. The backslash escape ensures the `${` is treated as literal text in the documentation.

https://claude.ai/code/session_01SiLTENJXkUZ41T5ahiTkgS