### PR TITLE
Cross-site failover: SP2–SP4 design cycles + SP4-core failover state (portal-service)

### DIFF
--- a/docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md
+++ b/docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md
@@ -30,7 +30,7 @@ SP1  DR feed + backup materialization   (LINCHPIN — design not yet resolved)
         ▼               ▼                        ▼
 SP2  Backup serving   SP3  Routing brain       SP4  Failover trigger /
      stack + identity      (portal health-           health detection
-     (needs key custody)   aware override)           (feeds SP3)
+     (identity resolved)   aware override)           (feeds SP3)
         │               │                        │
         └───────┬───────┴────────────────────────┘
                 ▼
@@ -75,13 +75,18 @@ alongside from SP1 onward.
   - **SP1b (operational slice)** — rooms/subs/members/user-slice → backup Mongo via
     the mechanism chosen above. Blocked on §11.1.
 
-### SP2 — Backup serving stack + identity  *(needs SP1; needs key-custody design)*
-- **Deliverable:** the backup runs the impersonation — `auth-service` mints JWTs
-  for any site's accounts (incl. the `chat.local.room.>` grant), and the
-  send/receive + history-read paths serve from the materialized copy.
-- **Ready to plan?** **No.** Resolve §11.4 first (own brainstorm, security-
-  sensitive): concrete shared-signing / KMS scheme for cross-site JWT minting.
-  Serving-path work is plannable once SP1 exists and the key scheme is chosen.
+### SP2 — Backup serving stack + identity  *(identity resolved — World 1; serving needs SP1)*
+- **Deliverable:** the backup runs `auth-service` to mint displaced users' JWTs,
+  and the send/receive + history-read paths serve from the materialized copy.
+- **Identity — RESOLVED (World 1), spec `specs/2026-08-11-sp2-backup-identity-jwt-minting.md`.**
+  Production runs **one shared NATS account**, so the backup mints in that same
+  account (not impersonation, no per-site keys) and reuses `auth-service`
+  **unchanged**. The earlier "key-custody / KMS" brainstorm (old §11.4) is
+  **moot**. The only identity deliverables are config/ops: the shared-template
+  `chat.local.room.>` grant (SP0-coupled) and deploying `auth-service` at the
+  backup (SP6) — **no new minting code**.
+- **Serving path — still needs SP1.** Plannable once SP1 materialization exists;
+  that (not identity) is the remaining SP2 substance.
 
 ### SP3 — Routing brain: portal-service health-aware override  *(needs SP4 signal)*
 - **Deliverable:** `portal-service` becomes the single source of truth for "who
@@ -107,7 +112,8 @@ alongside from SP1 onward.
 ### SP6 — Ops / IaC / platform  *(cross-cutting runbook, not a TDD plan)*
 - Backup deployment (HA multi-AZ); backup as supercluster gateway peer; leaf-node
   `chat.local.>` deny on the backup's leaf; canonical restore-log `MaxAge` sizing
-  (spec §6.5); NKey/KMS provisioning (with SP2); **per-site replication-lag
+  (spec §6.5); backup `auth-service` deploy with the **shared** account creds
+  (World 1 — no per-site NKey/KMS provisioning); **per-site replication-lag
   monitoring + alerting** (spec §8 — the RPO-decay signal). Tracked as an ops
   checklist coordinated with the platform/NATS team, delivered alongside SP1–SP5.
 

--- a/docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md
+++ b/docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md
@@ -1,0 +1,126 @@
+# Cross-Site Failover — Program Decomposition & Roadmap
+
+> **Not a task-by-task implementation plan.** The design
+> (`docs/superpowers/specs/2026-07-28-cross-site-failover-design.md`) is a DR
+> *architecture* with unresolved core-mechanism decisions (§11 open questions) and
+> spans app code + platform/NATS + ops/IaC. Per the writing-plans Scope Check, it
+> is decomposed here into independently-plannable sub-projects. **Each sub-project
+> gets its own spec → plan → implement cycle**; several must resolve open design
+> questions (their own brainstorm) *before* a no-placeholder plan can be written.
+
+**Goal:** stand up single-site failover to a shared warm backup ("lifeboat"),
+scoped to send/receive in existing rooms + recent history, with clean failback.
+
+**Governing spec:** `docs/superpowers/specs/2026-07-28-cross-site-failover-design.md`
+
+---
+
+## Dependency graph
+
+```
+SP0  Local/global room subjects        (EXTERNAL — already designed+planned on
+      (prerequisite, not owned here)     branch claude/nats-subscription-reduction)
+        │
+        ▼
+SP1  DR feed + backup materialization   (LINCHPIN — design not yet resolved)
+      ├── SP1a  message slice  (canonical → backup Cassandra)   [most concrete]
+      └── SP1b  operational slice (rooms/subs/members → Mongo)  [mechanism open]
+        │
+        ├───────────────┬───────────────────────┐
+        ▼               ▼                        ▼
+SP2  Backup serving   SP3  Routing brain       SP4  Failover trigger /
+     stack + identity      (portal health-           health detection
+     (needs key custody)   aware override)           (feeds SP3)
+        │               │                        │
+        └───────┬───────┴────────────────────────┘
+                ▼
+SP5  Failback & reconciliation   (needs SP1+SP2 live; algorithm is spec §6)
+
+SP6  Ops / IaC / platform        (cross-cutting runbook, threads throughout —
+                                   NOT a TDD plan)
+```
+
+**Build order:** SP0 (external) → SP1 → {SP2, SP3, SP4} → SP5, with SP6 running
+alongside from SP1 onward.
+
+---
+
+## Sub-projects
+
+### SP0 — Local/global room subjects  *(external dependency — do not re-plan here)*
+- **Owner:** `claude/nats-subscription-reduction-z0wcya` (design + plan already
+  written there).
+- **Why it's here:** the backup's delivery correctness (spec §7) rests on the
+  `CrossSite` flag and the `chat.local.room.>` prefix. SP1b must carry `CrossSite`
+  on the DR feed; SP2 must add the `chat.local.room.>` subscribe grant to the
+  backup's JWTs.
+- **Action:** track it as a dependency; do not duplicate. Coordinate the two
+  integration points above when it lands.
+
+### SP1 — DR feed + backup materialization  *(LINCHPIN — needs a design cycle first)*
+- **Deliverable:** every site continuously ships its whole-site state to the
+  backup, which materializes per-`siteID` namespaces (spec §4.1).
+- **Ready to plan?** **No.** Resolve first (own brainstorm):
+  - §11.1 — operational-state feed mechanism: **Mongo change-streams vs a new
+    backup-directed event fan-out**. This choice gates SP1b entirely.
+  - How `CrossSite` (SP0) rides the feed.
+  - Canonical-stream sourcing topology into the backup (JetStream source/mirror
+    over gateway vs a dedicated consumer).
+  - Restore-log retention vs read-window (spec §6.5).
+- **Split:**
+  - **SP1a (message slice)** — source whole `MESSAGES_CANONICAL_{siteID}` → backup
+    Cassandra, bucketed schema, retention split. *Most concrete;* reuses
+    `message-worker` + JetStream sourcing patterns. Likely the first thing
+    plannable once the sourcing topology is picked.
+  - **SP1b (operational slice)** — rooms/subs/members/user-slice → backup Mongo via
+    the mechanism chosen above. Blocked on §11.1.
+
+### SP2 — Backup serving stack + identity  *(needs SP1; needs key-custody design)*
+- **Deliverable:** the backup runs the impersonation — `auth-service` mints JWTs
+  for any site's accounts (incl. the `chat.local.room.>` grant), and the
+  send/receive + history-read paths serve from the materialized copy.
+- **Ready to plan?** **No.** Resolve §11.4 first (own brainstorm, security-
+  sensitive): concrete shared-signing / KMS scheme for cross-site JWT minting.
+  Serving-path work is plannable once SP1 exists and the key scheme is chosen.
+
+### SP3 — Routing brain: portal-service health-aware override  *(needs SP4 signal)*
+- **Deliverable:** `portal-service` becomes the single source of truth for "who
+  serves account X right now"; returns the backup for a down site's accounts;
+  acts as the split-brain fence (spec §4.2).
+- **Ready to plan?** **Partially.** Codebase-local (`portal-service` exists), but
+  needs the health signal from SP4 and the failback-flip protocol (spec §6.3).
+  Plannable in parallel once SP4's signal shape is decided.
+
+### SP4 — Failover trigger / health detection  *(own design)*
+- **Deliverable:** auto-detect a down site (+ manual operator override) and drive
+  the SP3 override (spec §11.3).
+- **Ready to plan?** **No.** Resolve the detection mechanism and the override
+  control surface first (own brainstorm).
+
+### SP5 — Failback & reconciliation  *(needs SP1+SP2 live)*
+- **Deliverable:** replay the outage log home, verify convergence, cut over
+  clients (spec §6, fully specified algorithmically).
+- **Ready to plan?** **Blocked** on SP1/SP2 existing, but the *algorithm* is the
+  most complete part of the spec — this becomes concrete quickly once its
+  dependencies are real.
+
+### SP6 — Ops / IaC / platform  *(cross-cutting runbook, not a TDD plan)*
+- Backup deployment (HA multi-AZ); backup as supercluster gateway peer; leaf-node
+  `chat.local.>` deny on the backup's leaf; canonical restore-log `MaxAge` sizing
+  (spec §6.5); NKey/KMS provisioning (with SP2); **per-site replication-lag
+  monitoring + alerting** (spec §8 — the RPO-decay signal). Tracked as an ops
+  checklist coordinated with the platform/NATS team, delivered alongside SP1–SP5.
+
+---
+
+## Recommended next step
+
+**Brainstorm SP1 (the DR feed) — specifically resolve §11.1** (Mongo change-streams
+vs a backup-directed event fan-out for operational state) and the canonical
+sourcing topology. It is the linchpin: SP2 and SP5 cannot exist without it, and
+SP1a (the message slice) is likely writable as a concrete no-placeholder plan
+immediately once the sourcing topology is chosen.
+
+Everything downstream (SP2 identity, SP4 detection) also needs its own short
+design cycle before it can be planned without placeholders — this is expected for
+a DR architecture at this altitude, not a gap in the spec.

--- a/docs/superpowers/plans/2026-08-12-sp4-failover-state-portal.md
+++ b/docs/superpowers/plans/2026-08-12-sp4-failover-state-portal.md
@@ -1,0 +1,1201 @@
+# SP4-core: Operator-Driven Failover State (portal-service) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an operator-driven per-site failover state machine + ops-token-gated control surface to `portal-service`, producing the `servingTarget` (home|backup) signal SP3 will consume.
+
+**Architecture:** A Mongo-backed `FailoverState` document per site (portal is sole writer, CAS-guarded on a `version` field). A pure state machine validates operator transitions (`healthy → failed_over → failing_back → healthy`). The control surface is three HTTP routes on a **separate internal-only listener**, gated by a dedicated ops bearer token — kept off portal's public browser-facing server. Auth is a Gin middleware seam so a later per-operator login (option 3) swaps in without touching handlers.
+
+**Tech Stack:** Go 1.25, Gin, MongoDB (`mongo-driver/v2`), `caarlos0/env`, `pkg/errcode`, `go.uber.org/mock`, `stretchr/testify`, `testcontainers` via `pkg/testutil`.
+
+**Spec:** `docs/superpowers/specs/2026-08-11-sp4-failover-trigger-health-detection.md`
+
+## Global Constraints
+
+- Go 1.25; single root `go.mod`; `portal-service` is a flat `package main` at repo root.
+- Use `make` targets, never raw `go`: `make test SERVICE=portal-service`, `make test-integration SERVICE=portal-service`, `make generate SERVICE=portal-service`, `make lint`, `make build SERVICE=portal-service`.
+- Errors: wrap infra failures `fmt.Errorf("doing X: %w", err)`; client-facing errors via `pkg/errcode` constructors + `errhttp.Write`; compare with `errors.Is`. Never log the ops token, never log secrets.
+- Logging: `log/slog` JSON, structured key-value fields, via `slog.InfoContext`/`WarnContext` with the request context.
+- All model structs get `json` **and** `bson` tags, `camelCase` except `bson:"_id"`.
+- Every NATS/event-shaped struct carries `timestamp int64` set via `time.Now().UTC().UnixMilli()`. (Here the failover state carries `timestamp` + `since` the same way.)
+- TDD: Red → Green → Refactor → Commit. Tests in `package main` (`_test.go`) to reach unexported types. Integration tests tagged `//go:build integration`, reuse the existing `TestMain` in `portal-service/integration_test.go`.
+- Coverage ≥80% floor; ≥90% on the state machine + handler logic.
+- **No `docs/client-api.md` change:** the control surface is an internal ops HTTP API, not a `chat.user.*` RPC or an auth-service route, so the client-API doc rule does not apply. (Recorded so a reviewer does not flag its absence.)
+
+## File Structure
+
+- **Create** `portal-service/failover.go` — domain: `FailoverStatus`, `ServingTarget`, `FailoverState` (+ `ServingTarget()` method), `FailoverAction`, `nextStatus`, `applyAction`, sentinel errors. Pure, no I/O.
+- **Create** `portal-service/failover_mongo.go` — `mongoFailoverStore` implementing `FailoverStore` (Get / List / Transition with CAS).
+- **Create** `portal-service/failover_middleware.go` — `bearer` + `requireOps` Gin middleware (the swappable auth seam).
+- **Create** `portal-service/failover_handler.go` — `FailoverHandler` (List/Get/Post) + `registerFailoverRoutes`.
+- **Create** `portal-service/failover_test.go` — unit tests for the domain state machine.
+- **Create** `portal-service/failover_middleware_test.go` — unit tests for `requireOps`.
+- **Create** `portal-service/failover_handler_test.go` — unit tests for the handlers (mocked `FailoverStore`).
+- **Create** `portal-service/failover_integration_test.go` — Mongo CAS integration tests (`//go:build integration`).
+- **Modify** `portal-service/store.go` — add the `FailoverStore` interface (picked up by the existing mockgen directive).
+- **Modify** `portal-service/mock_store_test.go` — regenerated (never hand-edit).
+- **Modify** `pkg/errcode/codes_portal.go` — add three failover reasons.
+- **Modify** `portal-service/main.go` — config fields + start the internal control server (only when the token is set) + graceful shutdown.
+
+**Scope note — the TTL-cached `FailoverReader` moves to SP3.** The spec's read-path cache has exactly one consumer: SP3's `resolve()`. Building it here would leave an unused function that `staticcheck` (via `make lint`) flags. So SP4 builds the *derivation* (`FailoverState.ServingTarget()`, fully tested) and the store; SP3 builds the TTL cache over the store where it is actually consumed. The control surface reads the store **directly** (operators need fresh state, not a cached value).
+
+---
+
+### Task 1: Domain state machine (`failover.go`)
+
+**Files:**
+- Create: `portal-service/failover.go`
+- Test: `portal-service/failover_test.go`
+
+**Interfaces:**
+- Produces:
+  - `type FailoverStatus string` with consts `StatusHealthy="healthy"`, `StatusFailedOver="failed_over"`, `StatusFailingBack="failing_back"`.
+  - `type ServingTarget string` with consts `ServingHome="home"`, `ServingBackup="backup"`.
+  - `type FailoverState struct` (fields below) with method `ServingTarget() ServingTarget`.
+  - `type FailoverAction string` with consts `ActionFailover="failover"`, `ActionFailback="failback"`, `ActionComplete="complete"`, `ActionResume="resume"`.
+  - `func isKnownAction(a FailoverAction) bool`
+  - `func applyAction(cur FailoverState, action FailoverAction, operator, reason string, nowMs int64) (FailoverState, error)` — returns the next state or `errIllegalTransition`.
+  - `var errIllegalTransition error`, `var errFailoverVersionConflict error`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `portal-service/failover_test.go`:
+
+```go
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFailoverState_ServingTarget(t *testing.T) {
+	tests := []struct {
+		status FailoverStatus
+		want   ServingTarget
+	}{
+		{StatusHealthy, ServingHome},
+		{StatusFailedOver, ServingBackup},
+		{StatusFailingBack, ServingBackup},
+		{FailoverStatus("garbage"), ServingHome}, // unknown => fail-safe home
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.status), func(t *testing.T) {
+			s := FailoverState{Status: tc.status}
+			assert.Equal(t, tc.want, s.ServingTarget())
+		})
+	}
+}
+
+func TestApplyAction_LegalTransitions(t *testing.T) {
+	tests := []struct {
+		name   string
+		from   FailoverStatus
+		action FailoverAction
+		want   FailoverStatus
+	}{
+		{"failover", StatusHealthy, ActionFailover, StatusFailedOver},
+		{"failback", StatusFailedOver, ActionFailback, StatusFailingBack},
+		{"complete", StatusFailingBack, ActionComplete, StatusHealthy},
+		{"resume", StatusFailedOver, ActionResume, StatusHealthy},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cur := FailoverState{SiteID: "site-a", Status: tc.from, Version: 3}
+			next, err := applyAction(cur, tc.action, "jane", "because", 1700)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, next.Status)
+			assert.Equal(t, "site-a", next.SiteID)
+			assert.Equal(t, int64(4), next.Version, "version increments by 1")
+			assert.Equal(t, "jane", next.Operator)
+			assert.Equal(t, "because", next.Reason)
+			assert.Equal(t, int64(1700), next.Since)
+			assert.Equal(t, int64(1700), next.Timestamp)
+		})
+	}
+}
+
+func TestApplyAction_IllegalTransitions(t *testing.T) {
+	tests := []struct {
+		name   string
+		from   FailoverStatus
+		action FailoverAction
+	}{
+		{"double failover", StatusFailedOver, ActionFailover},
+		{"failback from healthy", StatusHealthy, ActionFailback},
+		{"complete from healthy", StatusHealthy, ActionComplete},
+		{"resume from failing_back", StatusFailingBack, ActionResume},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cur := FailoverState{SiteID: "site-a", Status: tc.from, Version: 1}
+			_, err := applyAction(cur, tc.action, "jane", "because", 1700)
+			assert.ErrorIs(t, err, errIllegalTransition)
+		})
+	}
+}
+
+func TestIsKnownAction(t *testing.T) {
+	for _, a := range []FailoverAction{ActionFailover, ActionFailback, ActionComplete, ActionResume} {
+		assert.True(t, isKnownAction(a))
+	}
+	assert.False(t, isKnownAction(FailoverAction("nope")))
+	assert.False(t, isKnownAction(FailoverAction("")))
+}
+
+func TestSentinelsDistinct(t *testing.T) {
+	assert.False(t, errors.Is(errIllegalTransition, errFailoverVersionConflict))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `make test SERVICE=portal-service`
+Expected: FAIL — undefined `FailoverStatus`, `applyAction`, etc.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `portal-service/failover.go`:
+
+```go
+package main
+
+import "errors"
+
+// FailoverStatus is a site's operator-driven failover lifecycle state.
+type FailoverStatus string
+
+const (
+	StatusHealthy     FailoverStatus = "healthy"
+	StatusFailedOver  FailoverStatus = "failed_over"
+	StatusFailingBack FailoverStatus = "failing_back"
+)
+
+// ServingTarget says where a site's users are served from right now. It is the
+// entire contract SP3's routing override consumes.
+type ServingTarget string
+
+const (
+	ServingHome   ServingTarget = "home"
+	ServingBackup ServingTarget = "backup"
+)
+
+// FailoverAction is an operator-requested transition.
+type FailoverAction string
+
+const (
+	ActionFailover FailoverAction = "failover" // healthy      -> failed_over
+	ActionFailback FailoverAction = "failback" // failed_over  -> failing_back
+	ActionComplete FailoverAction = "complete" // failing_back -> healthy
+	ActionResume   FailoverAction = "resume"   // failed_over  -> healthy (false alarm)
+)
+
+// errIllegalTransition is returned when an action is not valid from the current
+// status. errFailoverVersionConflict is returned by the store when an optimistic
+// CAS loses a race. Both are matched with errors.Is at the HTTP boundary.
+var (
+	errIllegalTransition       = errors.New("illegal failover transition")
+	errFailoverVersionConflict = errors.New("failover state version conflict")
+)
+
+// FailoverState is the sole authoritative record of a site's serving target.
+// One document per site, _id = siteID. version is the optimistic-concurrency
+// guard for the sole-writer CAS.
+type FailoverState struct {
+	SiteID    string         `json:"siteId"    bson:"_id"`
+	Status    FailoverStatus `json:"status"    bson:"status"`
+	Reason    string         `json:"reason"    bson:"reason"`
+	Operator  string         `json:"operator"  bson:"operator"`
+	Since     int64          `json:"since"     bson:"since"`
+	Version   int64          `json:"version"   bson:"version"`
+	Timestamp int64          `json:"timestamp" bson:"timestamp"`
+}
+
+// ServingTarget derives where this site is served from. Any status other than
+// failed_over/failing_back (including an unknown value) is home — the fail-safe.
+func (s FailoverState) ServingTarget() ServingTarget {
+	switch s.Status {
+	case StatusFailedOver, StatusFailingBack:
+		return ServingBackup
+	default:
+		return ServingHome
+	}
+}
+
+// isKnownAction reports whether a is one of the four defined actions.
+func isKnownAction(a FailoverAction) bool {
+	switch a {
+	case ActionFailover, ActionFailback, ActionComplete, ActionResume:
+		return true
+	default:
+		return false
+	}
+}
+
+// nextStatus returns the status resulting from applying action to cur, or
+// errIllegalTransition if the action is not valid from cur.
+func nextStatus(cur FailoverStatus, action FailoverAction) (FailoverStatus, error) {
+	switch {
+	case cur == StatusHealthy && action == ActionFailover:
+		return StatusFailedOver, nil
+	case cur == StatusFailedOver && action == ActionFailback:
+		return StatusFailingBack, nil
+	case cur == StatusFailedOver && action == ActionResume:
+		return StatusHealthy, nil
+	case cur == StatusFailingBack && action == ActionComplete:
+		return StatusHealthy, nil
+	default:
+		return "", errIllegalTransition
+	}
+}
+
+// applyAction computes the next FailoverState for an operator action. It bumps
+// version by 1 and stamps operator/reason/since/timestamp. It does not persist —
+// the caller CAS-writes the result via FailoverStore.Transition.
+func applyAction(cur FailoverState, action FailoverAction, operator, reason string, nowMs int64) (FailoverState, error) {
+	ns, err := nextStatus(cur.Status, action)
+	if err != nil {
+		return FailoverState{}, err
+	}
+	return FailoverState{
+		SiteID:    cur.SiteID,
+		Status:    ns,
+		Reason:    reason,
+		Operator:  operator,
+		Since:     nowMs,
+		Version:   cur.Version + 1,
+		Timestamp: nowMs,
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test SERVICE=portal-service`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add portal-service/failover.go portal-service/failover_test.go
+git commit -m "portal-service: failover state machine (domain)"
+```
+
+---
+
+### Task 2: FailoverStore interface + Mongo CAS store
+
+**Files:**
+- Modify: `portal-service/store.go` (add `FailoverStore` interface)
+- Create: `portal-service/failover_mongo.go`
+- Modify: `portal-service/mock_store_test.go` (regenerated)
+- Create: `portal-service/failover_integration_test.go`
+
+**Interfaces:**
+- Consumes: `FailoverState`, `errFailoverVersionConflict` (Task 1).
+- Produces:
+  - `type FailoverStore interface { Get(ctx, siteID) (FailoverState, error); List(ctx) ([]FailoverState, error); Transition(ctx, next FailoverState) error }`
+  - `func newMongoFailoverStore(db *mongo.Database) *mongoFailoverStore`
+  - `Get` returns a synthesized `{SiteID, Status: healthy, Version: 0}` when no document exists.
+  - `Transition` inserts when `next.Version == 1`, else CAS-updates on `version == next.Version-1`; returns `errFailoverVersionConflict` on a lost race.
+
+- [ ] **Step 1: Add the interface to `store.go`**
+
+Append to `portal-service/store.go` (below the existing `DirectoryStore`; the file's existing `//go:generate mockgen -source=store.go ...` directive will regenerate the mock to include it):
+
+```go
+// FailoverStore is the sole-writer, CAS-guarded persistence for per-site
+// FailoverState (portal is the split-brain fence). Get synthesizes a healthy,
+// version-0 state for a site with no document, so callers treat "no doc" as
+// healthy. Transition inserts the first state (version 1) or CAS-updates a
+// later one, returning errFailoverVersionConflict when the stored version does
+// not match next.Version-1.
+type FailoverStore interface {
+	Get(ctx context.Context, siteID string) (FailoverState, error)
+	List(ctx context.Context) ([]FailoverState, error)
+	Transition(ctx context.Context, next FailoverState) error
+}
+```
+
+- [ ] **Step 2: Regenerate the mock**
+
+Run: `make generate SERVICE=portal-service`
+Expected: `portal-service/mock_store_test.go` now contains `MockFailoverStore`. Do not hand-edit it.
+
+- [ ] **Step 3: Write the failing integration test**
+
+Create `portal-service/failover_integration_test.go`:
+
+```go
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/testutil"
+)
+
+func TestMongoFailoverStore_GetDefaultsHealthy(t *testing.T) {
+	db := testutil.MongoDB(t, "portal")
+	store := newMongoFailoverStore(db)
+	ctx := context.Background()
+
+	got, err := store.Get(ctx, "site-unknown")
+	require.NoError(t, err)
+	assert.Equal(t, StatusHealthy, got.Status)
+	assert.Equal(t, int64(0), got.Version)
+	assert.Equal(t, "site-unknown", got.SiteID)
+}
+
+func TestMongoFailoverStore_TransitionInsertThenUpdate(t *testing.T) {
+	db := testutil.MongoDB(t, "portal")
+	store := newMongoFailoverStore(db)
+	ctx := context.Background()
+
+	// First transition inserts version 1.
+	v1 := FailoverState{SiteID: "site-a", Status: StatusFailedOver, Operator: "jane", Reason: "down", Since: 100, Version: 1, Timestamp: 100}
+	require.NoError(t, store.Transition(ctx, v1))
+
+	got, err := store.Get(ctx, "site-a")
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailedOver, got.Status)
+	assert.Equal(t, int64(1), got.Version)
+
+	// Second transition CAS-updates to version 2.
+	v2 := FailoverState{SiteID: "site-a", Status: StatusFailingBack, Operator: "jane", Reason: "draining", Since: 200, Version: 2, Timestamp: 200}
+	require.NoError(t, store.Transition(ctx, v2))
+	got, err = store.Get(ctx, "site-a")
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailingBack, got.Status)
+	assert.Equal(t, int64(2), got.Version)
+}
+
+func TestMongoFailoverStore_TransitionStaleVersionConflicts(t *testing.T) {
+	db := testutil.MongoDB(t, "portal")
+	store := newMongoFailoverStore(db)
+	ctx := context.Background()
+
+	require.NoError(t, store.Transition(ctx, FailoverState{SiteID: "site-b", Status: StatusFailedOver, Version: 1, Since: 1, Timestamp: 1}))
+	// Now at version 1. A second "version 1" insert (stale) must conflict.
+	err := store.Transition(ctx, FailoverState{SiteID: "site-b", Status: StatusFailedOver, Version: 1, Since: 2, Timestamp: 2})
+	assert.ErrorIs(t, err, errFailoverVersionConflict)
+
+	// A version-3 update (skipping 2) finds no version-2 doc -> conflict.
+	err = store.Transition(ctx, FailoverState{SiteID: "site-b", Status: StatusHealthy, Version: 3, Since: 3, Timestamp: 3})
+	assert.ErrorIs(t, err, errFailoverVersionConflict)
+}
+
+func TestMongoFailoverStore_ConcurrentCASOneWinner(t *testing.T) {
+	db := testutil.MongoDB(t, "portal")
+	store := newMongoFailoverStore(db)
+	ctx := context.Background()
+
+	// Seed version 1.
+	require.NoError(t, store.Transition(ctx, FailoverState{SiteID: "site-c", Status: StatusFailedOver, Version: 1, Since: 1, Timestamp: 1}))
+
+	// Two goroutines both try to move version 1 -> 2. Exactly one wins.
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = store.Transition(ctx, FailoverState{SiteID: "site-c", Status: StatusHealthy, Version: 2, Since: 2, Timestamp: 2})
+		}(i)
+	}
+	wg.Wait()
+
+	conflicts := 0
+	oks := 0
+	for _, e := range errs {
+		switch {
+		case e == nil:
+			oks++
+		case assert.ErrorIs(t, e, errFailoverVersionConflict):
+			conflicts++
+		}
+	}
+	assert.Equal(t, 1, oks, "exactly one writer wins")
+	assert.Equal(t, 1, conflicts, "exactly one writer conflicts")
+}
+
+func TestMongoFailoverStore_List(t *testing.T) {
+	db := testutil.MongoDB(t, "portal")
+	store := newMongoFailoverStore(db)
+	ctx := context.Background()
+
+	require.NoError(t, store.Transition(ctx, FailoverState{SiteID: "site-x", Status: StatusFailedOver, Version: 1, Since: 1, Timestamp: 1}))
+	require.NoError(t, store.Transition(ctx, FailoverState{SiteID: "site-y", Status: StatusHealthy, Version: 1, Since: 1, Timestamp: 1}))
+
+	all, err := store.List(ctx)
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, s := range all {
+		ids[s.SiteID] = true
+	}
+	assert.True(t, ids["site-x"])
+	assert.True(t, ids["site-y"])
+}
+```
+
+- [ ] **Step 4: Run integration tests to verify they fail**
+
+Run: `make test-integration SERVICE=portal-service`
+Expected: FAIL — `newMongoFailoverStore` undefined.
+
+- [ ] **Step 5: Write the Mongo store**
+
+Create `portal-service/failover_mongo.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// mongoFailoverStore persists FailoverState in the failover_states collection,
+// keyed by _id = siteID, with optimistic-concurrency CAS on the version field.
+type mongoFailoverStore struct {
+	coll *mongo.Collection
+}
+
+func newMongoFailoverStore(db *mongo.Database) *mongoFailoverStore {
+	return &mongoFailoverStore{coll: db.Collection("failover_states")}
+}
+
+// Get returns the stored state for siteID, or a synthesized healthy version-0
+// state when no document exists (an unfailed site has no row).
+func (s *mongoFailoverStore) Get(ctx context.Context, siteID string) (FailoverState, error) {
+	var st FailoverState
+	err := s.coll.FindOne(ctx, bson.D{{Key: "_id", Value: siteID}}).Decode(&st)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return FailoverState{SiteID: siteID, Status: StatusHealthy, Version: 0}, nil
+	}
+	if err != nil {
+		return FailoverState{}, fmt.Errorf("get failover state %q: %w", siteID, err)
+	}
+	return st, nil
+}
+
+// List returns every stored failover state.
+func (s *mongoFailoverStore) List(ctx context.Context) ([]FailoverState, error) {
+	cur, err := s.coll.Find(ctx, bson.D{})
+	if err != nil {
+		return nil, fmt.Errorf("list failover states: %w", err)
+	}
+	var out []FailoverState
+	if err := cur.All(ctx, &out); err != nil {
+		return nil, fmt.Errorf("decode failover states: %w", err)
+	}
+	return out, nil
+}
+
+// Transition persists next. When next.Version == 1 it inserts the first state
+// (a concurrent insert -> duplicate key -> conflict). Otherwise it CAS-updates
+// the document whose stored version == next.Version-1; a non-match means a
+// racing writer moved first -> conflict.
+func (s *mongoFailoverStore) Transition(ctx context.Context, next FailoverState) error {
+	if next.Version < 1 {
+		return fmt.Errorf("transition: next version must be >= 1, got %d", next.Version)
+	}
+	if next.Version == 1 {
+		if _, err := s.coll.InsertOne(ctx, next); err != nil {
+			if mongo.IsDuplicateKeyError(err) {
+				return errFailoverVersionConflict
+			}
+			return fmt.Errorf("insert failover state: %w", err)
+		}
+		return nil
+	}
+	res, err := s.coll.UpdateOne(ctx,
+		bson.D{{Key: "_id", Value: next.SiteID}, {Key: "version", Value: next.Version - 1}},
+		bson.D{{Key: "$set", Value: bson.D{
+			{Key: "status", Value: next.Status},
+			{Key: "reason", Value: next.Reason},
+			{Key: "operator", Value: next.Operator},
+			{Key: "since", Value: next.Since},
+			{Key: "version", Value: next.Version},
+			{Key: "timestamp", Value: next.Timestamp},
+		}}},
+	)
+	if err != nil {
+		return fmt.Errorf("update failover state: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return errFailoverVersionConflict
+	}
+	return nil
+}
+```
+
+- [ ] **Step 6: Run integration tests to verify they pass**
+
+Run: `make test-integration SERVICE=portal-service`
+Expected: PASS. Also run `make test SERVICE=portal-service` to confirm the regenerated mock compiles.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add portal-service/store.go portal-service/failover_mongo.go portal-service/mock_store_test.go portal-service/failover_integration_test.go
+git commit -m "portal-service: Mongo CAS store for failover state"
+```
+
+---
+
+### Task 3: Ops-token auth middleware (`failover_middleware.go`)
+
+**Files:**
+- Create: `portal-service/failover_middleware.go`
+- Modify: `pkg/errcode/codes_portal.go` (add the unauthorized reason)
+- Create: `portal-service/failover_middleware_test.go`
+
+**Interfaces:**
+- Produces: `func bearer(c *gin.Context) string`; `func requireOps(token string) gin.HandlerFunc`.
+- Consumes: `errcode.PortalFailoverUnauthorized` (added this task).
+
+- [ ] **Step 1: Add the reason to `pkg/errcode/codes_portal.go`**
+
+Add inside the existing `const (...)` block in `pkg/errcode/codes_portal.go`:
+
+```go
+	// PortalFailoverUnauthorized: the failover control surface rejected a request whose ops bearer token was missing or wrong.
+	PortalFailoverUnauthorized Reason = "failover_unauthorized"
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `portal-service/failover_middleware_test.go`:
+
+```go
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func opsTestRouter(token string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	grp := r.Group("/internal", requireOps(token))
+	grp.GET("/ping", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+	return r
+}
+
+func TestRequireOps(t *testing.T) {
+	tests := []struct {
+		name       string
+		authHeader string
+		wantStatus int
+	}{
+		{"no header", "", http.StatusUnauthorized},
+		{"non-bearer scheme", "Basic abc", http.StatusUnauthorized},
+		{"wrong token", "Bearer wrong", http.StatusForbidden},
+		{"correct token", "Bearer s3cr3t", http.StatusOK},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := opsTestRouter("s3cr3t")
+			req := httptest.NewRequest(http.MethodGet, "/internal/ping", nil)
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `make test SERVICE=portal-service`
+Expected: FAIL — `requireOps` undefined.
+
+- [ ] **Step 4: Write the middleware**
+
+Create `portal-service/failover_middleware.go`:
+
+```go
+package main
+
+import (
+	"crypto/subtle"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/errcode/errhttp"
+)
+
+// bearer extracts the token from an "Authorization: Bearer <token>" header, or
+// "" when absent or a different scheme.
+func bearer(c *gin.Context) string {
+	if after, ok := strings.CutPrefix(c.GetHeader("Authorization"), "Bearer "); ok {
+		return strings.TrimSpace(after)
+	}
+	return ""
+}
+
+// requireOps gates the failover control surface on a shared ops bearer token.
+// It is the auth seam: a later per-operator login (option 3) replaces this
+// middleware without touching the handlers. Compares in constant time so a
+// wrong token cannot be timing-probed. The token is never logged.
+func requireOps(token string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		got := bearer(c)
+		if got == "" {
+			errhttp.Write(ctx, c, errcode.Unauthenticated("missing ops token",
+				errcode.WithReason(errcode.PortalFailoverUnauthorized)))
+			c.Abort()
+			return
+		}
+		if subtle.ConstantTimeCompare([]byte(got), []byte(token)) != 1 {
+			errhttp.Write(ctx, c, errcode.Forbidden("invalid ops token",
+				errcode.WithReason(errcode.PortalFailoverUnauthorized)))
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `make test SERVICE=portal-service`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add portal-service/failover_middleware.go portal-service/failover_middleware_test.go pkg/errcode/codes_portal.go
+git commit -m "portal-service: ops-token auth middleware for failover control surface"
+```
+
+---
+
+### Task 4: Control-surface handlers + routes (`failover_handler.go`)
+
+**Files:**
+- Create: `portal-service/failover_handler.go`
+- Modify: `pkg/errcode/codes_portal.go` (add two transition reasons)
+- Create: `portal-service/failover_handler_test.go`
+
+**Interfaces:**
+- Consumes: `FailoverStore` + `MockFailoverStore` (Task 2), `applyAction`/`isKnownAction`/`errFailoverVersionConflict` (Task 1), `requireOps` (Task 3).
+- Produces:
+  - `type FailoverHandler struct` with `func NewFailoverHandler(store FailoverStore) *FailoverHandler`.
+  - Methods `List`, `Get`, `Post` (gin handlers).
+  - `func registerFailoverRoutes(r *gin.Engine, h *FailoverHandler, opsToken string)` mounting `GET /internal/v1/failover`, `GET /internal/v1/failover/:siteId`, `POST /internal/v1/failover/:siteId` behind `requireOps`.
+  - Handler exposes an overridable `now func() time.Time` field (default `time.Now`) for deterministic tests.
+
+- [ ] **Step 1: Add the two transition reasons to `pkg/errcode/codes_portal.go`**
+
+Add inside the same `const (...)` block:
+
+```go
+	// PortalFailoverIllegalTransition: the requested failover action is not valid from the site's current status.
+	PortalFailoverIllegalTransition Reason = "failover_illegal_transition"
+	// PortalFailoverVersionConflict: the failover state changed concurrently (optimistic-concurrency CAS lost); retry.
+	PortalFailoverVersionConflict Reason = "failover_version_conflict"
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `portal-service/failover_handler_test.go`:
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+const testOpsToken = "s3cr3t"
+
+// newFailoverTestServer wires the handler + routes with a mocked store and a
+// fixed clock, behind the real requireOps middleware.
+func newFailoverTestServer(t *testing.T) (*gin.Engine, *MockFailoverStore) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	store := NewMockFailoverStore(ctrl)
+	h := NewFailoverHandler(store)
+	h.now = func() time.Time { return time.UnixMilli(1700).UTC() }
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	registerFailoverRoutes(r, h, testOpsToken)
+	return r, store
+}
+
+func do(t *testing.T, r *gin.Engine, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader *strings.Reader
+	if body == "" {
+		reader = strings.NewReader("")
+	} else {
+		reader = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(method, path, reader)
+	req.Header.Set("Authorization", "Bearer "+testOpsToken)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestFailoverHandler_List(t *testing.T) {
+	r, store := newFailoverTestServer(t)
+	store.EXPECT().List(gomock.Any()).Return([]FailoverState{
+		{SiteID: "site-a", Status: StatusFailedOver, Version: 1},
+	}, nil)
+
+	w := do(t, r, http.MethodGet, "/internal/v1/failover", "")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got []failoverStateResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "site-a", got[0].SiteID)
+	assert.Equal(t, ServingBackup, got[0].ServingTarget)
+}
+
+func TestFailoverHandler_Get(t *testing.T) {
+	r, store := newFailoverTestServer(t)
+	store.EXPECT().Get(gomock.Any(), "site-a").Return(
+		FailoverState{SiteID: "site-a", Status: StatusHealthy, Version: 0}, nil)
+
+	w := do(t, r, http.MethodGet, "/internal/v1/failover/site-a", "")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got failoverStateResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, StatusHealthy, got.Status)
+	assert.Equal(t, ServingHome, got.ServingTarget)
+}
+
+func TestFailoverHandler_PostFailoverHappyPath(t *testing.T) {
+	r, store := newFailoverTestServer(t)
+	store.EXPECT().Get(gomock.Any(), "site-a").Return(
+		FailoverState{SiteID: "site-a", Status: StatusHealthy, Version: 0}, nil)
+	store.EXPECT().Transition(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ any, next FailoverState) error {
+			assert.Equal(t, StatusFailedOver, next.Status)
+			assert.Equal(t, int64(1), next.Version)
+			assert.Equal(t, "jane", next.Operator)
+			assert.Equal(t, "nats down", next.Reason)
+			assert.Equal(t, int64(1700), next.Timestamp)
+			return nil
+		})
+
+	w := do(t, r, http.MethodPost, "/internal/v1/failover/site-a",
+		`{"action":"failover","operator":"jane","reason":"nats down"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got failoverStateResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, StatusFailedOver, got.Status)
+	assert.Equal(t, ServingBackup, got.ServingTarget)
+}
+
+func TestFailoverHandler_PostIllegalTransition(t *testing.T) {
+	r, store := newFailoverTestServer(t)
+	store.EXPECT().Get(gomock.Any(), "site-a").Return(
+		FailoverState{SiteID: "site-a", Status: StatusFailedOver, Version: 1}, nil)
+	// No Transition call expected.
+
+	w := do(t, r, http.MethodPost, "/internal/v1/failover/site-a",
+		`{"action":"failover","operator":"jane","reason":"again"}`)
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), "failover_illegal_transition")
+}
+
+func TestFailoverHandler_PostVersionConflict(t *testing.T) {
+	r, store := newFailoverTestServer(t)
+	store.EXPECT().Get(gomock.Any(), "site-a").Return(
+		FailoverState{SiteID: "site-a", Status: StatusHealthy, Version: 0}, nil)
+	store.EXPECT().Transition(gomock.Any(), gomock.Any()).Return(errFailoverVersionConflict)
+
+	w := do(t, r, http.MethodPost, "/internal/v1/failover/site-a",
+		`{"action":"failover","operator":"jane","reason":"race"}`)
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), "failover_version_conflict")
+}
+
+func TestFailoverHandler_PostValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"missing operator", `{"action":"failover","reason":"x"}`},
+		{"missing reason", `{"action":"failover","operator":"jane"}`},
+		{"unknown action", `{"action":"nope","operator":"jane","reason":"x"}`},
+		{"malformed json", `{`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, _ := newFailoverTestServer(t) // no store calls expected
+			w := do(t, r, http.MethodPost, "/internal/v1/failover/site-a", tc.body)
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
+}
+
+func TestFailoverHandler_PostGetStoreError(t *testing.T) {
+	r, store := newFailoverTestServer(t)
+	store.EXPECT().Get(gomock.Any(), "site-a").Return(FailoverState{}, errors.New("mongo down"))
+
+	w := do(t, r, http.MethodPost, "/internal/v1/failover/site-a",
+		`{"action":"failover","operator":"jane","reason":"x"}`)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestFailoverHandler_Unauthorized(t *testing.T) {
+	r, _ := newFailoverTestServer(t)
+	// No auth header -> requireOps rejects before any handler runs.
+	req := httptest.NewRequest(http.MethodGet, "/internal/v1/failover", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `make test SERVICE=portal-service`
+Expected: FAIL — `NewFailoverHandler`, `failoverStateResponse`, `registerFailoverRoutes` undefined.
+
+- [ ] **Step 4: Write the handlers**
+
+Create `portal-service/failover_handler.go`:
+
+```go
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/errcode/errhttp"
+)
+
+// FailoverHandler serves the operator control surface over the internal
+// listener. It reads/writes FailoverState directly (operators need fresh state,
+// not a cached view). now is overridable in tests.
+type FailoverHandler struct {
+	store FailoverStore
+	now   func() time.Time
+}
+
+func NewFailoverHandler(store FailoverStore) *FailoverHandler {
+	return &FailoverHandler{store: store, now: time.Now}
+}
+
+// failoverActionRequest is the POST body: the operator-requested transition,
+// who requested it, and why (both required for the audit trail).
+type failoverActionRequest struct {
+	Action   FailoverAction `json:"action"`
+	Operator string         `json:"operator"`
+	Reason   string         `json:"reason"`
+}
+
+// failoverStateResponse is the wire shape, with the derived servingTarget added.
+type failoverStateResponse struct {
+	SiteID        string         `json:"siteId"`
+	Status        FailoverStatus `json:"status"`
+	ServingTarget ServingTarget  `json:"servingTarget"`
+	Reason        string         `json:"reason"`
+	Operator      string         `json:"operator"`
+	Since         int64          `json:"since"`
+	Version       int64          `json:"version"`
+	Timestamp     int64          `json:"timestamp"`
+}
+
+func toResponse(s FailoverState) failoverStateResponse {
+	return failoverStateResponse{
+		SiteID:        s.SiteID,
+		Status:        s.Status,
+		ServingTarget: s.ServingTarget(),
+		Reason:        s.Reason,
+		Operator:      s.Operator,
+		Since:         s.Since,
+		Version:       s.Version,
+		Timestamp:     s.Timestamp,
+	}
+}
+
+// List returns every site's failover state.
+func (h *FailoverHandler) List(c *gin.Context) {
+	ctx := errcode.WithLogValues(c.Request.Context(), "request_id", c.GetString("request_id"))
+	states, err := h.store.List(ctx)
+	if err != nil {
+		errhttp.Write(ctx, c, fmt.Errorf("list failover states: %w", err))
+		return
+	}
+	out := make([]failoverStateResponse, 0, len(states))
+	for _, s := range states {
+		out = append(out, toResponse(s))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+// Get returns one site's failover state (a healthy default for an unknown site).
+func (h *FailoverHandler) Get(c *gin.Context) {
+	ctx := errcode.WithLogValues(c.Request.Context(), "request_id", c.GetString("request_id"))
+	siteID := c.Param("siteId")
+	st, err := h.store.Get(ctx, siteID)
+	if err != nil {
+		errhttp.Write(ctx, c, fmt.Errorf("get failover state: %w", err))
+		return
+	}
+	c.JSON(http.StatusOK, toResponse(st))
+}
+
+// Post applies an operator transition to a site's failover state.
+func (h *FailoverHandler) Post(c *gin.Context) {
+	ctx := errcode.WithLogValues(c.Request.Context(), "request_id", c.GetString("request_id"))
+	siteID := c.Param("siteId")
+
+	var req failoverActionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errhttp.Write(ctx, c, errcode.BadRequest("invalid request body",
+			errcode.WithReason(errcode.AuthMissingFields)))
+		return
+	}
+	if req.Operator == "" || req.Reason == "" {
+		errhttp.Write(ctx, c, errcode.BadRequest("operator and reason are required",
+			errcode.WithReason(errcode.AuthMissingFields)))
+		return
+	}
+	if !isKnownAction(req.Action) {
+		errhttp.Write(ctx, c, errcode.BadRequest(fmt.Sprintf("unknown action %q", req.Action)))
+		return
+	}
+
+	cur, err := h.store.Get(ctx, siteID)
+	if err != nil {
+		errhttp.Write(ctx, c, fmt.Errorf("get failover state: %w", err))
+		return
+	}
+
+	nowMs := h.now().UTC().UnixMilli()
+	next, err := applyAction(cur, req.Action, req.Operator, req.Reason, nowMs)
+	if err != nil {
+		errhttp.Write(ctx, c, errcode.Conflict(
+			fmt.Sprintf("action %q not allowed from status %q", req.Action, cur.Status),
+			errcode.WithReason(errcode.PortalFailoverIllegalTransition)))
+		return
+	}
+
+	if err := h.store.Transition(ctx, next); err != nil {
+		if errors.Is(err, errFailoverVersionConflict) {
+			errhttp.Write(ctx, c, errcode.Conflict("failover state changed concurrently, retry",
+				errcode.WithReason(errcode.PortalFailoverVersionConflict)))
+			return
+		}
+		errhttp.Write(ctx, c, fmt.Errorf("transition failover state: %w", err))
+		return
+	}
+
+	slog.InfoContext(ctx, "failover transition",
+		"siteId", siteID, "from", cur.Status, "to", next.Status,
+		"operator", req.Operator, "reason", req.Reason, "version", next.Version)
+	c.JSON(http.StatusOK, toResponse(next))
+}
+
+// registerFailoverRoutes mounts the control surface behind the ops-token gate.
+func registerFailoverRoutes(r *gin.Engine, h *FailoverHandler, opsToken string) {
+	grp := r.Group("/internal/v1/failover", requireOps(opsToken))
+	grp.GET("", h.List)
+	grp.GET("/:siteId", h.Get)
+	grp.POST("/:siteId", h.Post)
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `make test SERVICE=portal-service`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add portal-service/failover_handler.go portal-service/failover_handler_test.go pkg/errcode/codes_portal.go
+git commit -m "portal-service: failover control-surface handlers + routes"
+```
+
+---
+
+### Task 5: Wire the internal control server into `main.go`
+
+**Files:**
+- Modify: `portal-service/main.go`
+
+**Interfaces:**
+- Consumes: `newMongoFailoverStore` (Task 2), `NewFailoverHandler` + `registerFailoverRoutes` (Task 4).
+- Produces: no new exported symbols; wires config + a second `http.Server`.
+
+- [ ] **Step 1: Add config fields**
+
+In `portal-service/main.go`, add to the `config` struct (after the Mongo fields):
+
+```go
+	// FailoverOpsToken gates the operator failover control surface. Empty
+	// disables the internal control server entirely (no control surface).
+	FailoverOpsToken string `env:"FAILOVER_OPS_TOKEN" envDefault:""`
+	// FailoverInternalAddr is the listen address for the internal-only control
+	// surface — kept off the public browser-facing server.
+	FailoverInternalAddr string `env:"FAILOVER_INTERNAL_ADDR" envDefault:":8090"`
+```
+
+- [ ] **Step 2: Start the internal server (fail-fast bind) when the token is set**
+
+In `run()`, after `registerRoutes(r, handler)` and before building the public `srv`, add:
+
+```go
+	// Optional internal-only failover control surface. Bound on a separate
+	// listener so no privileged write shares the public discovery server.
+	var internalSrv *http.Server
+	if cfg.FailoverOpsToken != "" {
+		failoverStore := newMongoFailoverStore(mongoClient.Database(cfg.MongoDB))
+		failoverHandler := NewFailoverHandler(failoverStore)
+
+		ir := gin.New()
+		ir.Use(gin.Recovery())
+		ir.Use(ginutil.RequestID())
+		ir.Use(ginutil.AccessLog())
+		registerFailoverRoutes(ir, failoverHandler, cfg.FailoverOpsToken)
+
+		// net.Listen up front so a bad bind fails startup, not silently later.
+		ln, err := net.Listen("tcp", cfg.FailoverInternalAddr)
+		if err != nil {
+			return fmt.Errorf("bind failover control surface %q: %w", cfg.FailoverInternalAddr, err)
+		}
+		internalSrv = &http.Server{
+			Handler:      ir,
+			ReadTimeout:  10 * time.Second,
+			WriteTimeout: 10 * time.Second,
+		}
+		go func() {
+			slog.Info("failover control surface starting", "addr", cfg.FailoverInternalAddr)
+			if serveErr := internalSrv.Serve(ln); serveErr != nil && serveErr != http.ErrServerClosed {
+				slog.Error("failover control surface stopped", "error", serveErr)
+			}
+		}()
+	} else {
+		slog.Info("failover control surface disabled (FAILOVER_OPS_TOKEN unset)")
+	}
+```
+
+Add `"net"` to the import block.
+
+- [ ] **Step 3: Shut the internal server down gracefully**
+
+In the shutdown closure (the first function passed to `shutdown.Wait`), add `internalSrv.Shutdown` before the existing `srv.Shutdown` result is returned. Replace the closure body:
+
+```go
+			func(ctx context.Context) error {
+				slog.Info("shutting down portal service")
+				if internalSrv != nil {
+					if err := internalSrv.Shutdown(ctx); err != nil {
+						slog.Error("shutdown failover control surface", "error", err)
+					}
+				}
+				err := srv.Shutdown(ctx)
+				refreshCancel()
+				refreshWG.Wait()
+				mongoutil.Disconnect(ctx, mongoClient)
+				return err
+			},
+```
+
+- [ ] **Step 4: Verify build, lint, and full test suite**
+
+Run: `make build SERVICE=portal-service`
+Expected: builds clean.
+
+Run: `make lint`
+Expected: no findings (staticcheck sees every new function used; the ops token is never logged).
+
+Run: `make test SERVICE=portal-service && make test-integration SERVICE=portal-service`
+Expected: PASS.
+
+- [ ] **Step 5: Add local-dev env so the control surface runs in docker-compose**
+
+In `portal-service/deploy/docker-compose.yml`, add to the portal service's `environment:` block (a dev-only token — never a real secret):
+
+```yaml
+      FAILOVER_OPS_TOKEN: "dev-failover-token"
+      FAILOVER_INTERNAL_ADDR: ":8090"
+```
+
+Verify the YAML parses: `make build SERVICE=portal-service` (compose is not built here, but confirm the file is well-formed by eye — 6-space indent matching the sibling env keys).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add portal-service/main.go portal-service/deploy/docker-compose.yml
+git commit -m "portal-service: wire internal failover control server + config"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Spec §3 FailoverState fields → Task 1 (`FailoverState`) + Task 2 (persistence). ✓ (`servingTarget` derived, not stored — spec says derived.)
+- Spec §4 state machine (`healthy→failed_over→failing_back→healthy`, `resume`, `complete`) → Task 1 `nextStatus`/`applyAction` + tests. ✓
+- Spec §5 control surface (3 routes, internal listener, ops token, `operator`/`reason` audit, 409 on conflict, no token logged) → Tasks 3–5. ✓
+- Spec §6 read path / TTL reader → **deferred to SP3** (documented in File Structure scope note; the derivation `ServingTarget()` is built + tested here). ✓ (intentional decomposition, not a gap)
+- Spec §7 split-brain fence (sole writer, CAS, multi-replica) → Task 2 CAS + the concurrent-writer integration test. ✓
+- Spec §8 forward-compat (middleware seam, stable contract, `operator` field) → Task 3 `requireOps` seam + Task 4 body. ✓
+- Spec §9 config (`FAILOVER_OPS_TOKEN`, `FAILOVER_INTERNAL_ADDR`) → Task 5. (`FAILOVER_STATE_TTL` belongs to the deferred reader → SP3.) ✓
+- Spec §10 testing (state machine, control surface, integration CAS) → Tasks 1–4 tests. ✓
+
+**2. Placeholder scan:** No TBD/TODO; every step has runnable code or an exact command. ✓
+
+**3. Type consistency:** `FailoverState`, `FailoverStore` (Get/List/Transition), `FailoverStatus`/`ServingTarget`/`FailoverAction` consts, `applyAction`, `errFailoverVersionConflict`, `requireOps`, `NewFailoverHandler`, `registerFailoverRoutes`, `failoverStateResponse` — names and signatures match across Tasks 1→5. The mock `MockFailoverStore` is generated from the `store.go` interface (Task 2) and consumed in Task 4. ✓
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-08-12-sp4-failover-state-portal.md`.

--- a/docs/superpowers/specs/2026-07-28-cross-site-failover-design.md
+++ b/docs/superpowers/specs/2026-07-28-cross-site-failover-design.md
@@ -137,11 +137,21 @@ event-derived slice.
   connection failure; the reroute reuses that path.
 
 ### 4.3 Identity
-- The backup must mint NATS JWTs for **any** site's accounts, so it needs the
+> **Resolved (2026-08-12) — the trade-off below does not apply.** This section
+> assumed **per-site NATS accounts** (so the backup would concentrate every
+> site's signing keys — "World 2"). Production actually runs **one shared
+> org-level NATS account** for all clients ("World 1"): the chat `account` is a
+> *tag* on a scoped user JWT, and one signing key is trusted at every site. The
+> backup therefore mints in the *same* account every site uses — **not**
+> impersonation, no per-site keys — so it needs no special key custody and
+> reuses `auth-service` unchanged. See `specs/2026-08-11-sp2-backup-identity-jwt-minting.md`.
+> The only surviving identity task is the shared-template `chat.local.room.>`
+> grant (§7). The original per-site framing is retained below for history.
+- ~~The backup must mint NATS JWTs for **any** site's accounts, so it needs the
   account signing NKeys. This is the design's largest security trade-off (one
-  deployment can impersonate every site's users).
-- **Recommended:** a shared org-level signing scheme or KMS-fronted keys, rather
-  than copying raw per-site NKeys onto the backup.
+  deployment can impersonate every site's users).~~
+- ~~**Recommended:** a shared org-level signing scheme or KMS-fronted keys, rather
+  than copying raw per-site NKeys onto the backup.~~
 
 ## 5. Data flow
 
@@ -346,7 +356,7 @@ first time (a single 1× copy to the backup) — new inter-site traffic, but che
 | **Correlated multi-site outage** | Backup is sized for **one site down at a time**; concurrent multi-site failure degrades further (documented ceiling, alerting). |
 | **Split brain (A + backup both serving A)** | Prevented by portal-service as sole routing authority; failback flips only after reconciliation drains. |
 | **Last in-flight messages at outage instant** | Async RPO ⇒ seconds of potential loss accepted for lifeboat scope. |
-| **Identity key compromise on backup** | Mitigated by shared/KMS-fronted signing rather than raw NKey copies; backup hardened accordingly. |
+| **Identity key compromise on backup** | World 1: the backup holds no per-site keys — it uses the one shared account signing key already present on every site's `auth-service`, so it is no more key-exposed than any site. Reducing that shared key's exposure (fleet-wide remote signer) is a separate security project, not a failover concern (§4.3). |
 | **Replay duplicates on failback** | Idempotent: message-ID / `Nats-Msg-Id` dedup + append-only bucketed writes. |
 | **Silent RPO decay** (backup can't keep up with N-aggregate ingest) | Per-site replication-lag monitoring + alert (§8); the lag *is* the live RPO. |
 | **Outage longer than history window** | Restore uses the canonical **stream** log (`MaxAge` ≥ max outage), not the 72h Cassandra read window (§6.5); anti-entropy backstop re-derives the rest. |
@@ -371,8 +381,11 @@ first time (a single 1× copy to the backup) — new inter-site traffic, but che
    the (longer) canonical restore-log `MaxAge` (§6.5).
 3. **Health-detection mechanism** and the manual-override control surface
    (likely portal-service-owned).
-4. **Identity key custody** — concrete shared-signing / KMS scheme for the
-   backup minting cross-site JWTs, incl. the `chat.local.room.>` grant (§7).
+4. ~~**Identity key custody** — concrete shared-signing / KMS scheme for the
+   backup minting cross-site JWTs.~~ **Moot (World 1, 2026-08-12):** one shared
+   NATS account ⇒ no per-site keys, no custody problem; the backup reuses
+   `auth-service` unchanged. Only the `chat.local.room.>` grant (§7) remains —
+   see `specs/2026-08-11-sp2-backup-identity-jwt-minting.md`.
 5. **Backup capacity sizing** — separate ingest (N-aggregate) vs serving
    (largest single site) targets, and documented multi-site-outage degradation.
 6. **Failback cutover protocol** — precise drain/flip sequencing, tail-sweep

--- a/docs/superpowers/specs/2026-07-28-cross-site-failover-design.md
+++ b/docs/superpowers/specs/2026-07-28-cross-site-failover-design.md
@@ -55,20 +55,36 @@ site. It fits the existing architecture because data is already **`siteID`-scope
 end-to-end** (rooms/subs/members carry `SiteID`; streams are `<STREAM>_<siteID>`),
 so the backup simply runs per-origin-site namespaces.
 
-**Replication mechanism: Variant A — reuse the event federation.** The backup is
-modeled as "a peer subscribed to everything." It receives each site's
-membership / subscription / room-metadata events over the OUTBOX→INBOX lanes
-that already exist and materializes them with the existing `inbox-worker`
-apply logic, and it runs a `message-worker`-style consumer on each site's
-canonical message stream to persist recent history into its own Cassandra.
-This adds mostly configuration plus one "materialize-everything" consumer set —
-no new storage-replication subsystem.
+**Replication mechanism: Variant A — event-derived materialization, over a
+dedicated backup feed.** The backup is modeled as "a peer that holds a copy of
+everything." Two channels feed it, and the distinction is load-bearing:
 
-Rejected alternative — **Variant B (storage-layer replication):** Cassandra
-multi-DC (backup as an extra DC per ring) + Mongo change-stream/replica
-shipping. Higher fidelity but N multi-DC rings and a Mongo replication pipeline —
-more machinery and more than the lifeboat scope needs. Retained as the growth
-path if fidelity requirements ever exceed the event-derived slice.
+- **Messages** — a `message-worker`-style consumer sources each site's **whole**
+  `MESSAGES_CANONICAL_{siteID}` (1× per message, *before* the ×F fan-out) and
+  persists recent history into the backup's own Cassandra under the same bucketed
+  schema.
+- **Operational state** (rooms / subscriptions / members / user slice) — a
+  **dedicated, membership-independent DR feed** that ships *every* room's state
+  to the backup, applied with the same `inbox-worker`-style insert/delete/upsert
+  semantics.
+
+**Why not reuse the existing OUTBOX→INBOX federation for operational state:** that
+federation is **membership-driven** — it only fires when a room has a member on
+*another active site*. Same-site ("local") rooms produce no federation events at
+all, and (post the local/global subject work — see §7) they are the **majority**.
+Reusing federation would therefore leave the backup blind to most rooms. The DR
+feed is a distinct, backup-directed, unconditional whole-site channel — carried
+below the client-facing interest graph (JetStream / Mongo change-streams), so it
+neither depends on nor perturbs room locality. This pulls the *operational-state*
+slice partway toward Variant B mechanics while the *message* slice stays purely
+event-derived.
+
+Rejected alternative — **Variant B (full storage-layer replication):** Cassandra
+multi-DC (backup as an extra DC per ring) + full Mongo change-stream/replica
+shipping for *all* collections. Higher fidelity but N multi-DC rings and a broad
+Mongo replication pipeline — more machinery and more than the lifeboat scope
+needs. Retained as the growth path if fidelity requirements ever exceed the
+event-derived slice.
 
 **Two knobs, at recommended defaults:**
 - **Failover trigger:** automatic health-detection with a manual operator
@@ -80,29 +96,35 @@ path if fidelity requirements ever exceed the event-derived slice.
 ## 4. Architecture
 
 ```
-   Active Site A ──┐   (membership/sub/room events via OUTBOX→INBOX)
-   Active Site B ──┼──►  Backup "Lifeboat" Site
-   Active Site C ──┘   (canonical messages via cross-site consumer)
+   Active Site A ──┐   dedicated DR feed (unconditional, all rooms):
+   Active Site B ──┼──►    · whole MESSAGES_CANONICAL_{site}  (1×, no fan-out)
+   Active Site C ──┘       · rooms/subs/members/user-slice    (change-stream/feed)
+                          │
+                          ▼  Backup "Lifeboat" Site
                           │  materializes per-siteID namespaces:
                           │    Mongo: rooms, subs, members, users (slice)
-                          │    Cassandra: recent history (72h window)
+                          │    Cassandra: recent history (72h read window)
                           │
    portal-service ────────┘  routing brain / split-brain fence:
      account → (home site if healthy | backup if home down)
 ```
 
 ### 4.1 Backup site — materialization
-- Runs a per-origin-site set of consumers. For each active `siteID`, it
-  consumes that site's federated membership/subscription/room events (the lanes
-  `inbox-worker` already understands) and applies them with the **same
-  insert/delete/upsert semantics** `inbox-worker` uses today, into a
-  `siteID`-namespaced Mongo.
-- Runs a `message-worker`-style consumer against each site's
-  `MESSAGES_CANONICAL_{siteID}` (cross-site), persisting messages into its own
-  Cassandra under the same bucketed schema. History retention on the backup is
-  capped to the lifeboat window.
+- Runs a per-origin-site set of consumers. For each active `siteID`:
+  - **Messages:** a `message-worker`-style consumer sources the whole
+    `MESSAGES_CANONICAL_{siteID}` and persists into the backup's own Cassandra
+    under the same bucketed schema. The Cassandra **read window** is capped to the
+    lifeboat window (72h); the **restore log** (the canonical stream itself) is
+    retained far longer — see §6.
+  - **Operational state:** a dedicated DR feed ships *every* room's
+    room/subscription/member state (not just cross-site rooms), applied with the
+    same insert/delete/upsert semantics `inbox-worker` uses today, into a
+    `siteID`-namespaced Mongo.
 - Holds the **identity slice** (user roster + the room/subscription state) needed
   to authorize and serve `send`/`receive` — not full user-service parity.
+- Materializes the room **`CrossSite` locality flag** (see §7) so the backup's
+  broadcast path picks the correct subject prefix and `subscription.list` returns
+  the right locality to reconnecting clients.
 
 ### 4.2 Routing brain — `portal-service`
 - Becomes the **single source of truth** for "who serves account X *right now*."
@@ -124,9 +146,10 @@ path if fidelity requirements ever exceed the event-derived slice.
 ## 5. Data flow
 
 ### 5.1 Steady state (all sites up)
-Active sites federate their events to the backup exactly as they federate to
-peers today; the backup materializes them. The backup serves **no** live client
-traffic — it is warm, not hot.
+Active sites stream their DR feed (§4.1) to the backup, which materializes it.
+This is a **separate, unconditional, backup-directed channel** — not the
+membership-driven OUTBOX→INBOX peer federation, which skips same-site rooms. The
+backup serves **no** live client traffic — it is warm, not hot.
 
 ### 5.2 Failover (site A down)
 1. Health detection marks A down (auto, with manual override).
@@ -138,26 +161,184 @@ traffic — it is warm, not hot.
    Cassandra (and flow through the backup's canonical pipeline for delivery).
 
 ### 5.3 Failback (site A recovers)
-1. A comes back but is **not yet** re-designated as serving its accounts (portal
-   still points them at the backup).
-2. The backup **replays its outage-window messages** for A back into A over the
-   canonical/federation path. Because messages are **append-only with unique IDs
-   and Cassandra bucketing**, replay is **idempotent and conflict-free** (unique
-   `Nats-Msg-Id` / message-ID dedup absorbs duplicates).
-3. Once A has caught up, portal atomically flips A's accounts home; clients
-   reconnect to A.
+See §6 — the restore/failback protocol is detailed there.
 
-## 6. Reconciliation
+## 6. Failback & data restoration
 
-Lifeboat scope makes reconciliation simple: since room/DM creation and
-membership changes are **out of scope** during failover, the only new writes at
-the backup are **append-only messages**. There is no membership divergence to
-merge — only message backfill, which the existing dedup + bucketing make safe to
-replay. A periodic anti-entropy sweep (as in the membership-federation design
-§3.4) can serve as an unconditional backstop for any messages missed by the
-replay.
+When A returns, everything written at the backup during the outage must land in
+A (A is the permanent home of those rooms and messages). Because lifeboat scope
+confined new writes to **append-only messages** (plus best-effort read-state),
+restoration is a **replay, not a merge**.
 
-## 7. Failure modes
+### 6.1 What diverged
+Only two kinds of writes happened at the backup while it impersonated A:
+1. **New messages** into existing rooms — append-only, globally unique IDs
+   (`idgen.GenerateMessageID`), written to the backup's Cassandra *and* its
+   canonical stream for A.
+2. **Read-state** — `lastSeenAt` / read watermarks / receipts, monotonic
+   (max-wins).
+
+Explicitly **not** diverged: rooms, memberships, roles, profiles — those RPCs
+were blocked at the backup. No topology divergence ⇒ **no merge-conflict class**.
+
+### 6.2 The restore log
+Because the backup ran A's canonical pipeline during the outage, it already holds
+a **durable, ordered JetStream log of exactly the outage writes** (A's canonical
+namespace on the backup). Restore = **replay that log into A's front door**: the
+events re-enter A's normal `message-worker` (persist) → `search-sync-worker`
+(index), as if freshly federated.
+
+### 6.3 Failback choreography (ordering prevents split-brain and races)
+1. **A's infra recovers, but portal still points A's accounts at the backup.** A
+   is "up but not serving." Users keep writing to the backup — a stable source
+   while draining.
+2. **Replay the outage log backup → A** into A's `MESSAGES_CANONICAL_{A}`;
+   runs continuously, chasing A's lag toward zero.
+3. **Backfill read-state** as monotonic (`$max`-guarded) updates — order-
+   independent, best-effort. Skipping it only re-surfaces a few messages as
+   "unread"; never data loss.
+4. **Verify convergence** — a directional, outage-window-scoped anti-entropy diff
+   (latest message / counts per `(room, bucket)`) between the backup's A-copy and
+   A; reconcile anything replay missed. This is the §3.4-style backstop, narrowed
+   to one window and one direction.
+5. **Flip portal → home (A)** once lag ≈ 0. Clients reconnect to A, re-read
+   `subscription.list` (now current), and resume — reusing the reconnect-self-heal
+   path (§7). The replay stream stays alive briefly past the flip to sweep any
+   tail writes (safe — idempotent).
+6. **Tear down** the backup's A-impersonation; retain the outage log until
+   convergence is confirmed, then GC.
+
+### 6.4 Why replay is safe
+- **No duplicates:** Cassandra keys on `(room_id, bucket, message_id)` ⇒
+  idempotent upsert; JetStream `Nats-Msg-Id` (= DedupID) absorbs redelivery.
+- **Order-independent:** clustering key is the message's own `created_at` (stamped
+  at original send time), so any replay order still sorts correctly and history
+  reads by timestamp stay correct.
+- **Buckets line up:** `bucket = floor(created_at / window)` with the original
+  `created_at` ⇒ messages land in the same bucket they'd have occupied had A never
+  died (requires backup and A share `MESSAGE_BUCKET_HOURS` — already mandated).
+- **No double-delivery:** a remote member on a healthy site who saw a message live
+  during the outage is not re-notified; a re-fired broadcast is deduped client-side
+  by message ID.
+
+### 6.5 Retention — two tiers, and the long-outage case
+- **Fast path:** ordered stream replay.
+- **Backstop:** state-diff anti-entropy (§6.3 step 4) re-derives anything missed.
+- **Retention rule:** the restore log is the backup's **canonical stream**, not
+  its 72h Cassandra read window. Since canonical is 1× (no fan-out) and small,
+  size that stream's `MaxAge` **≥ the max tolerated outage** (days/weeks is cheap).
+  Do **not** depend on the 72h read window for restore — a longer outage would age
+  its earliest messages out before A returns.
+
+### 6.6 Operational must-dos on the backfill path
+- **Suppress push notifications** — replayed messages are stale; `notification-
+  worker` skips events flagged as replay.
+- **Suppress (or client-dedup) re-broadcast** — restore is about durability in A,
+  not re-delivering to users who have moved on.
+
+### 6.7 The forward gap (A's last pre-crash writes)
+Messages A persisted just before crashing that never replicated to the backup
+(the RPO tail) were **never lost** — they are durable in A's own Cassandra, merely
+invisible during the outage, and reappear when users are pointed home. Remote
+members who missed them recover via the client's normal history/gap fetch.
+
+## 7. Compatibility with local/global room subjects
+
+A separate design (`.../2026-07-28-local-global-room-subjects-design.md`) reduces
+NATS gateway interest-map memory by routing **same-site ("local") rooms** onto a
+`chat.local.room.{id}.>` prefix that the platform team **denies at the leaf node**
+(never advertised across the supercluster), while cross-site ("global") rooms keep
+the propagated `chat.room.{id}.>`. Locality is a sticky `CrossSite` flag on the
+`Room` doc: global iff ≥1 member's home site ≠ `room.SiteID`.
+
+The two designs are compatible, and split cleanly by locality:
+
+- **Global rooms** stay on the propagated prefix; during A's outage the backup
+  publishes globally and delivery reaches both the displaced member (intra-cluster
+  on the backup) and any member on a still-healthy site (via the backup→peer
+  gateway — requires the backup to be a full supercluster gateway peer). These are
+  exactly the rooms the membership-driven federation already covers.
+- **Local rooms** need only **intra-cluster** delivery on the backup: because
+  "local" ⇒ all members share one home site, they **all fail over to the same
+  backup together**, so the `chat.local.` leaf filter (which only blocks
+  *cross-gateway* interest) is irrelevant to their delivery.
+
+Classification is **home-site-based**, so a user being transiently relocated to
+the backup during failover does **not** perturb any room's `CrossSite` flag.
+
+**Integration requirements (must hold when both ship):**
+1. **Backup auth-service must grant `chat.local.room.>` subscribe** in the JWTs it
+   mints for displaced users. Missing it silently breaks subscription to local
+   rooms — i.e. the majority of the lifeboat's own promise. Highest-risk coupling.
+2. **Backup must materialize *and* honor `CrossSite`** — carried on the DR feed
+   (§4.1), read by the backup's broadcast path for prefix choice and returned on
+   `subscription.list`.
+3. **Leaf-node `chat.local.>` deny must also apply to the backup's leaf**, and
+   displaced clients must connect to the backup's own NATS (intra-cluster) — which
+   the portal reroute already does.
+
+**Synergy:** the reduction's reconnect-self-heal (reconnect → re-read
+`subscription.list` → subscribe on the correct prefix) *is* the failover/failback
+reconnect path; and the per-user tree (`chat.user.{account}.>`) stays global in
+its Phase 1, so reroute signaling and the locality-transition nudge still work
+through the backup.
+
+## 8. Performance & sizing
+
+**The structural fact that makes this affordable:** DR replication rides the
+**canonical plane (1× per message)**, not the **fan-out plane (×F, F≈100)**. The
+backup sources one copy per message and persists it; the ×F broadcast
+amplification happens only at *serving* time, and only for the one failed site
+during an actual failover.
+
+- **Replication cost ∝ M** (message count) — paid continuously by the backup.
+- **Serving cost ∝ M × F** — paid only for 1 site, only during failover.
+
+Reference load (`docs/nats-traffic-estimation.md`): ~4.5M msg/day per site
+(~52/s avg, ~250–500/s peak), canonical payload ~0.5–1.5 KB.
+
+**Steady state (N sites healthy):**
+
+| Resource | Load on the backup | Magnitude |
+|---|---|---|
+| Ingest compute | ~N `message-worker`-equivalents + N materializers, 24/7 | N × ~52/s avg; Cassandra shrugs |
+| WAN egress (each site→backup) | 1× canonical + tiny op events | ~50 KB/s avg, ~0.25–0.5 MB/s peak **per site** — trivial |
+| Cassandra storage | 72h window × aggregate volume | ~13 GB/site × N (bounded by window) |
+| Mongo storage | operational state for all servable rooms | not windowed by default — main storage lever |
+
+Ingest is sized to the **aggregate of N sites**, but on the cheap (1×) plane, so
+it is a modest continuous load — not a ×F blow-up.
+
+**Failover burst (the real peak):** backup = (continued N−1-site ingest) + (full
+live serving of 1 site, *now* with ×F fan-out) + (a reconnect thundering herd:
+TLS + JWT-mint storm + `subscription.list` bootstrap storm). Size the **serving**
+tier for one (largest) site's peak; size the **ingest** tier for the N-site
+aggregate — two different capacity numbers. Mitigate the herd with client
+reconnect backoff/jitter, rate-limited/pre-warmed auth, and pre-warmed Valkey.
+
+**Latency:** steady-state replication is async and off every user's critical path
+(zero user-facing impact; the lag *is* the RPO). At failover, displaced users'
+perceived latency = their RTT to the backup — a function of backup geography.
+
+**Relation to the reduction (different resources):** the reduction saves gateway
+**interest-map memory** (an ~O(clients × rooms) all-to-all RAM cost); DR
+replication costs backup **CPU/IO/disk ∝ Σ throughput** to **one** destination
+plus a cheap per-site WAN stream. DR does not re-inflate the interest graph. The
+one honest note: local-room canonical messages now leave their home site for the
+first time (a single 1× copy to the backup) — new inter-site traffic, but cheap.
+
+**Risks & levers:**
+- **Silent RPO decay** if the backup can't keep up with aggregate ingest — its lag
+  grows and the DR guarantee quietly weakens. **Monitor per-site replication lag**
+  (reuse the membership-federation lag signal) and alert.
+- **Warm-standby idle waste** — N-way ingest runs 24/7 while serving ~nothing. If
+  RTO can relax, a **colder** standby (buffer + replay-on-promote) cuts continuous
+  compute, trading RTO for cost.
+- **Biggest storage lever is Mongo, not Cassandra** (already windowed). Windowing
+  Mongo to recently-active rooms bounds it but risks a failover user not finding a
+  long-idle room — a scope decision.
+
+## 9. Failure modes
 
 | Vector | Handling |
 |---|---|
@@ -167,27 +348,35 @@ replay.
 | **Last in-flight messages at outage instant** | Async RPO ⇒ seconds of potential loss accepted for lifeboat scope. |
 | **Identity key compromise on backup** | Mitigated by shared/KMS-fronted signing rather than raw NKey copies; backup hardened accordingly. |
 | **Replay duplicates on failback** | Idempotent: message-ID / `Nats-Msg-Id` dedup + append-only bucketed writes. |
+| **Silent RPO decay** (backup can't keep up with N-aggregate ingest) | Per-site replication-lag monitoring + alert (§8); the lag *is* the live RPO. |
+| **Outage longer than history window** | Restore uses the canonical **stream** log (`MaxAge` ≥ max outage), not the 72h Cassandra read window (§6.5); anti-entropy backstop re-derives the rest. |
+| **Local room not materialized on backup** | DR feed is unconditional/whole-site (§4.1), not membership-driven federation, so same-site rooms are covered. |
 
-## 8. Non-goals
+## 10. Non-goals
 
 - No room/DM creation, membership, admin, search, presence, or media parity
-  during failover (lifeboat scope only).
+  during failover (lifeboat scope only). This constraint is **load-bearing**: it
+  is what keeps failback a replay rather than a bidirectional merge (§6).
 - No synchronous/zero-RPO cross-site replication.
 - No full-fidelity byte-for-byte DB replica of any site (that is Variant B, a
   future growth path).
 - No active-active (multi-primary) serving — the backup is warm-passive and
   serves only while a home site is down.
 
-## 9. Open questions / follow-ups
+## 11. Open questions / follow-ups
 
-1. **History window** exact size and per-room caps on the backup's Cassandra.
-2. **Health-detection mechanism** and the manual-override control surface
+1. **DR feed mechanism** for operational state — Mongo change-streams vs a new
+   backup-directed event fan-out; and how `CrossSite` rides it (§4.1, §7).
+2. **History read window** size and per-room caps on the backup's Cassandra, vs
+   the (longer) canonical restore-log `MaxAge` (§6.5).
+3. **Health-detection mechanism** and the manual-override control surface
    (likely portal-service-owned).
-3. **Identity key custody** — concrete shared-signing / KMS scheme for the
-   backup minting cross-site JWTs.
-4. **Backup capacity sizing** — headroom target (largest single site) and the
-   documented multi-site-outage degradation behavior.
-5. **Failback cutover protocol** — precise drain/flip sequencing and how clients
-   are signaled to reconnect home.
-6. **Reconciliation cadence** — replay-on-recovery plus the periodic
-   anti-entropy backstop interval.
+4. **Identity key custody** — concrete shared-signing / KMS scheme for the
+   backup minting cross-site JWTs, incl. the `chat.local.room.>` grant (§7).
+5. **Backup capacity sizing** — separate ingest (N-aggregate) vs serving
+   (largest single site) targets, and documented multi-site-outage degradation.
+6. **Failback cutover protocol** — precise drain/flip sequencing, tail-sweep
+   window, and how clients are signaled to reconnect home (§6.3).
+7. **Reconciliation cadence** — replay-on-recovery plus the periodic anti-entropy
+   backstop interval.
+8. **Per-site replication-lag monitoring** — the RPO-decay signal (§8).

--- a/docs/superpowers/specs/2026-07-28-cross-site-failover-design.md
+++ b/docs/superpowers/specs/2026-07-28-cross-site-failover-design.md
@@ -1,0 +1,193 @@
+# Cross-Site Failover — Shared Warm Backup Site ("Lifeboat")
+
+**Status:** Design / brainstorm output — not yet planned or implemented.
+**Date:** 2026-07-28
+
+## 1. Problem
+
+Each site is a fully independent silo: its own NATS, MongoDB, Cassandra,
+Elasticsearch, Valkey, and MinIO. A user has a **home site** (resolved via
+`portal-service`'s `account → siteID → {natsUrl, baseUrl}` directory), and their
+identity, rooms, subscriptions, and message history live **only** in that home
+site's databases. Cross-site federation today forwards *events* (membership,
+subscription-state, messages) via OUTBOX→INBOX — it does **not** replicate any
+site's full state anywhere.
+
+Consequently, when a site goes down, its users are simply offline: a standby
+site can accept a WebSocket connection but holds none of the displaced user's
+rooms, subscriptions, or history. There is no way to keep basic chatting working.
+
+**Goal:** when any single active site is down, its users can connect to a backup
+site and continue *basic chatting* — send/receive in rooms they already belong
+to, and read recent history — with acknowledged data surviving and healing back
+when the home site recovers.
+
+## 2. Scope
+
+**In scope (lifeboat functionality):**
+- Send and receive messages in rooms the user is **already** a member of.
+- Read **recent** message history (default window: 72h, matching
+  `MESSAGE_BUCKET_HOURS`).
+
+**Out of scope during failover (deferred, degraded):**
+- Creating rooms / DMs, membership changes, role changes.
+- Search, admin, media upload, presence parity.
+- Full-fidelity history beyond the recent window.
+
+Constraining failover to **append-only message traffic in existing rooms**
+is what makes both replication and recovery-time reconciliation tractable.
+
+## 3. Decision
+
+**Topology: N active sites → 1 dedicated warm backup site ("the lifeboat").**
+
+Every active site continuously ships its lifeboat data slice to the single
+backup site. The backup holds a recent, degraded copy of **every** site's
+essential state, namespaced by `siteID`. On a site-A outage, `portal-service`
+reroutes A's accounts to the backup's NATS URL, and the backup **impersonates
+site A** — serving A's rooms/subs/membership/recent-history and accepting new
+messages — until A recovers, at which point outage-window writes reconcile back
+and portal flips A's accounts home.
+
+**Why this topology:** N sites → 1 target is **N replication relationships, not
+a full mesh**, and **one** warm deployment to operate instead of a standby per
+site. It fits the existing architecture because data is already **`siteID`-scoped
+end-to-end** (rooms/subs/members carry `SiteID`; streams are `<STREAM>_<siteID>`),
+so the backup simply runs per-origin-site namespaces.
+
+**Replication mechanism: Variant A — reuse the event federation.** The backup is
+modeled as "a peer subscribed to everything." It receives each site's
+membership / subscription / room-metadata events over the OUTBOX→INBOX lanes
+that already exist and materializes them with the existing `inbox-worker`
+apply logic, and it runs a `message-worker`-style consumer on each site's
+canonical message stream to persist recent history into its own Cassandra.
+This adds mostly configuration plus one "materialize-everything" consumer set —
+no new storage-replication subsystem.
+
+Rejected alternative — **Variant B (storage-layer replication):** Cassandra
+multi-DC (backup as an extra DC per ring) + Mongo change-stream/replica
+shipping. Higher fidelity but N multi-DC rings and a Mongo replication pipeline —
+more machinery and more than the lifeboat scope needs. Retained as the growth
+path if fidelity requirements ever exceed the event-derived slice.
+
+**Two knobs, at recommended defaults:**
+- **Failover trigger:** automatic health-detection with a manual operator
+  override.
+- **RPO:** asynchronous replication — seconds of potential loss on the very last
+  in-flight messages. Synchronous/quorum cross-site replication is not worth its
+  cost for lifeboat scope.
+
+## 4. Architecture
+
+```
+   Active Site A ──┐   (membership/sub/room events via OUTBOX→INBOX)
+   Active Site B ──┼──►  Backup "Lifeboat" Site
+   Active Site C ──┘   (canonical messages via cross-site consumer)
+                          │  materializes per-siteID namespaces:
+                          │    Mongo: rooms, subs, members, users (slice)
+                          │    Cassandra: recent history (72h window)
+                          │
+   portal-service ────────┘  routing brain / split-brain fence:
+     account → (home site if healthy | backup if home down)
+```
+
+### 4.1 Backup site — materialization
+- Runs a per-origin-site set of consumers. For each active `siteID`, it
+  consumes that site's federated membership/subscription/room events (the lanes
+  `inbox-worker` already understands) and applies them with the **same
+  insert/delete/upsert semantics** `inbox-worker` uses today, into a
+  `siteID`-namespaced Mongo.
+- Runs a `message-worker`-style consumer against each site's
+  `MESSAGES_CANONICAL_{siteID}` (cross-site), persisting messages into its own
+  Cassandra under the same bucketed schema. History retention on the backup is
+  capped to the lifeboat window.
+- Holds the **identity slice** (user roster + the room/subscription state) needed
+  to authorize and serve `send`/`receive` — not full user-service parity.
+
+### 4.2 Routing brain — `portal-service`
+- Becomes the **single source of truth** for "who serves account X *right now*."
+  Normal: returns the home site. On A-down: returns the backup's NATS URL for
+  A's accounts.
+- This single authority is also the **split-brain fence**: A and the backup can
+  never both be designated to serve A's users. Failback flips the designation
+  atomically after reconciliation drains.
+- Frontend already connects to a NATS URL it is handed and re-queries portal on
+  connection failure; the reroute reuses that path.
+
+### 4.3 Identity
+- The backup must mint NATS JWTs for **any** site's accounts, so it needs the
+  account signing NKeys. This is the design's largest security trade-off (one
+  deployment can impersonate every site's users).
+- **Recommended:** a shared org-level signing scheme or KMS-fronted keys, rather
+  than copying raw per-site NKeys onto the backup.
+
+## 5. Data flow
+
+### 5.1 Steady state (all sites up)
+Active sites federate their events to the backup exactly as they federate to
+peers today; the backup materializes them. The backup serves **no** live client
+traffic — it is warm, not hot.
+
+### 5.2 Failover (site A down)
+1. Health detection marks A down (auto, with manual override).
+2. `portal-service` switches A's accounts to resolve to the backup's coordinates.
+3. Displaced clients reconnect to the backup; backup `auth-service` mints their
+   JWTs.
+4. Users send/receive in existing rooms and read recent history, served from the
+   backup's materialized copy of A. New messages persist to the backup's
+   Cassandra (and flow through the backup's canonical pipeline for delivery).
+
+### 5.3 Failback (site A recovers)
+1. A comes back but is **not yet** re-designated as serving its accounts (portal
+   still points them at the backup).
+2. The backup **replays its outage-window messages** for A back into A over the
+   canonical/federation path. Because messages are **append-only with unique IDs
+   and Cassandra bucketing**, replay is **idempotent and conflict-free** (unique
+   `Nats-Msg-Id` / message-ID dedup absorbs duplicates).
+3. Once A has caught up, portal atomically flips A's accounts home; clients
+   reconnect to A.
+
+## 6. Reconciliation
+
+Lifeboat scope makes reconciliation simple: since room/DM creation and
+membership changes are **out of scope** during failover, the only new writes at
+the backup are **append-only messages**. There is no membership divergence to
+merge — only message backfill, which the existing dedup + bucketing make safe to
+replay. A periodic anti-entropy sweep (as in the membership-federation design
+§3.4) can serve as an unconditional backstop for any messages missed by the
+replay.
+
+## 7. Failure modes
+
+| Vector | Handling |
+|---|---|
+| **Backup itself down when a site fails** | Backup is a failover SPOF; it MUST be HA within itself (multi-AZ). Documented limit, not silently degraded. |
+| **Correlated multi-site outage** | Backup is sized for **one site down at a time**; concurrent multi-site failure degrades further (documented ceiling, alerting). |
+| **Split brain (A + backup both serving A)** | Prevented by portal-service as sole routing authority; failback flips only after reconciliation drains. |
+| **Last in-flight messages at outage instant** | Async RPO ⇒ seconds of potential loss accepted for lifeboat scope. |
+| **Identity key compromise on backup** | Mitigated by shared/KMS-fronted signing rather than raw NKey copies; backup hardened accordingly. |
+| **Replay duplicates on failback** | Idempotent: message-ID / `Nats-Msg-Id` dedup + append-only bucketed writes. |
+
+## 8. Non-goals
+
+- No room/DM creation, membership, admin, search, presence, or media parity
+  during failover (lifeboat scope only).
+- No synchronous/zero-RPO cross-site replication.
+- No full-fidelity byte-for-byte DB replica of any site (that is Variant B, a
+  future growth path).
+- No active-active (multi-primary) serving — the backup is warm-passive and
+  serves only while a home site is down.
+
+## 9. Open questions / follow-ups
+
+1. **History window** exact size and per-room caps on the backup's Cassandra.
+2. **Health-detection mechanism** and the manual-override control surface
+   (likely portal-service-owned).
+3. **Identity key custody** — concrete shared-signing / KMS scheme for the
+   backup minting cross-site JWTs.
+4. **Backup capacity sizing** — headroom target (largest single site) and the
+   documented multi-site-outage degradation behavior.
+5. **Failback cutover protocol** — precise drain/flip sequencing and how clients
+   are signaled to reconnect home.
+6. **Reconciliation cadence** — replay-on-recovery plus the periodic
+   anti-entropy backstop interval.

--- a/docs/superpowers/specs/2026-07-29-sp1a-message-slice-dr-feed.md
+++ b/docs/superpowers/specs/2026-07-29-sp1a-message-slice-dr-feed.md
@@ -1,0 +1,138 @@
+# SP1a (core) — Message-slice DR feed, single site
+
+> **Scope discipline.** This is the *core* first slice of SP1a, deliberately
+> narrowed to **one origin site → the backup, message history only**. It is the
+> Cassandra counterpart to SP1b (operational slice). Everything else in the
+> failover program — the operational slice (SP1b), multi-site fan-out, backup
+> serving (SP2), routing (SP3), detection (SP4), failback replay (SP5) — is
+> explicitly **out of scope** and lands in its own PR.
+>
+> - **Governing design:** `docs/superpowers/specs/2026-07-28-cross-site-failover-design.md` (§4.1, §6.4, §6.5)
+> - **Roadmap:** `docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md` (SP1a)
+> - **Sibling:** `docs/superpowers/specs/2026-07-29-sp1b-operational-slice-dr-feed.md`
+
+## 1. Goal
+
+The backup site continuously receives **one origin site's message history** and
+materializes it into the backup's own `siteID`-namespaced Cassandra under the
+same bucketed schema, so the backup stays *warm* — a recent, queryable copy of
+that site's messages.
+
+Nothing in this slice *serves* that data. The only observable outcome: messages
+persisted at the origin site appear, shortly after, in the backup's Cassandra.
+
+## 2. Decision — replicate at the event layer, not the storage layer
+
+In this codebase Cassandra is written through exactly one door: the
+`MESSAGES_CANONICAL_{siteID}` stream, persisted by `message-worker`. That single
+ingress is what makes the event-layer approach clean.
+
+- **Rejected — Cassandra-native multi-DC replication.** Adding the backup as
+  another DC per keyspace fuses each site's independent Cassandra into
+  cross-region rings, fighting the "each site runs its own NATS / Mongo /
+  Cassandra independently" architecture and the per-`siteID` backup model.
+- **Rejected — application dual-write** (message-worker writes both Cassandras).
+  Synchronous cross-region write on the hot path, no durable buffer, couples
+  availability.
+- **Chosen — source the canonical stream** (design §4.1). The backup runs a
+  `message-worker`-shaped consumer that sources the whole
+  `MESSAGES_CANONICAL_{siteID}` over the gateway and persists into its **own**
+  Cassandra via the same `Store.SaveMessage` / `SaveThreadMessage`. No
+  cross-region cluster; reuses existing persistence code; the canonical stream
+  itself doubles as the durable restore log (§5).
+
+**The canonical event stream is the replication channel** — we don't replicate
+Cassandra, we replay the events that build it.
+
+## 3. Topology
+
+```
+[ origin site A ]                              [ backup site ]
+  MESSAGES_CANONICAL_{A}  ──►  DR_MESSAGES_{A}  ──►  message-worker-style  ──►  Cassandra
+   (single source of truth)     (JetStream,           consumer                  (siteID-
+                                 sourced x-site)       (SaveMessage)             scoped)
+```
+
+- **Sourced cross-gateway** — a backup-local `DR_MESSAGES_{A}` stream that
+  JetStream-**sources** the origin's whole `MESSAGES_CANONICAL_{A}` (durable
+  buffering + automatic resume; decoupled from momentary remote unavailability),
+  same rationale as SP1b's `DR_OPLOG` sourcing.
+- **Consumer at the backup** persists into the backup's own Cassandra, `siteID`-
+  scoped, under the identical bucketed schema.
+
+## 4. Why replay is safe (falls out of the existing schema)
+
+The message schema makes replay near-worry-free — three properties, all true
+today (design §6.4):
+
+- **Idempotent** — keyed on `(room_id, bucket, message_id)`, so a re-applied
+  write is a no-op upsert; JetStream `Nats-Msg-Id` absorbs redelivery.
+- **Order-independent** — the clustering key is the message's own `created_at`
+  (stamped at original send), so *any* replay order still sorts correctly on read.
+- **Buckets line up** — `bucket = floor(created_at / windowMs)` uses the original
+  `created_at`, so a replayed message lands in the exact partition it would have
+  occupied had A never died.
+
+This trio is why the message slice needs **no conflict reconciliation and no
+origin-echo handling** (unlike SP1b's failback hook): "just replay it" is correct.
+
+### 4.1 Hard invariant — shared bucket window
+
+Backup and every origin site **MUST** share `MESSAGE_BUCKET_HOURS` (default 72).
+A mismatch makes writes and reads target different `(room_id, bucket)` partitions
+and silently lose data — this is already mandated repo-wide (CLAUDE.md §
+Cassandra); this slice inherits and re-asserts it. Thread replies use
+`thread_messages_by_thread` (partitioned by `thread_room_id` alone, no bucket), so
+they carry no bucket-window dependency.
+
+## 5. Retention — two tiers (do not couple them)
+
+- **Read window (Cassandra):** the backup's Cassandra keeps only the lifeboat
+  window (~72h) needed to *serve* history during an outage.
+- **Restore log (the stream):** the `DR_MESSAGES_{siteID}` / canonical stream is
+  the durable restore log; size its `MaxAge` **≥ max tolerated outage**
+  (days/weeks — 1× with no fan-out, cheap).
+- **Rule:** restore (SP5) reads from the **stream**, never the 72h Cassandra
+  window — a longer outage would age the earliest messages out of Cassandra
+  before the origin returns. The two numbers are independent.
+
+## 6. The forward gap (noted, not solved here)
+
+Messages the origin persisted just before crashing that never reached the backup
+(the RPO tail) are **not lost** — they stay durable in the origin's own Cassandra
+and reappear when clients are pointed home; remote members recover them via the
+client's normal history/gap fetch (design §6.7). This slice does not attempt to
+close the gap; it only records that the gap is benign.
+
+## 7. Out of scope (explicit — each its own PR)
+
+- **SP1b** — operational slice → backup Mongo (sibling spec).
+- **Multi-site** — running this per-`siteID` for every origin site (this core is one site).
+- **SP2** — backup *serving* (history read path pointed at the backup Cassandra).
+- **SP3 / SP4** — routing override, health detection.
+- **SP5** — failback replay of the restore log into the origin's front door.
+- **SP6** — ops/IaC: gateway peering, stream `MaxAge` sizing, replication-lag alerting.
+
+## 8. Testing (TDD, per CLAUDE.md §4)
+
+- **Unit** — consumer/persist handler table tests (channel message + thread reply
+  → correct `SaveMessage` / `SaveThreadMessage` call; malformed payload; store
+  error → Nak vs poison), mocked store; assert idempotent re-delivery is a no-op.
+- **Integration** (`//go:build integration`, `testutil.NATS` +
+  `testutil.CassandraKeyspace`) — publish canonical events → source →
+  persist → read back from the backup Cassandra; assert bucket placement matches
+  the origin (same `MESSAGE_BUCKET_HOURS`), and that a replayed duplicate does not
+  double-write.
+- **Coverage** — ≥80% floor; ≥90% for the persist/handler business logic.
+
+## 9. Open sub-decisions (call out in the plan)
+
+1. **Deploy shape** — MODE-configured reuse of `message-worker` (a "replicate"
+   mode) vs a thin new DR consumer service. *Leaning: reuse* (matches the repo's
+   unified-worker convention and SP1b's reuse decision).
+2. **`DR_MESSAGES_{siteID}` ownership** — new per-site stream bootstrapped via the
+   standard `BOOTSTRAP_STREAMS` convention; which service owns creation, and
+   whether it is the same owner as SP1b's `DR_OPLOG_{siteID}`.
+3. **Backup Cassandra namespacing** — separate keyspace per `siteID` vs a
+   `siteID`-scoped table/partition scheme (align with SP1b's Mongo namespacing
+   choice for a consistent per-site story).

--- a/docs/superpowers/specs/2026-07-29-sp1b-operational-slice-dr-feed.md
+++ b/docs/superpowers/specs/2026-07-29-sp1b-operational-slice-dr-feed.md
@@ -1,0 +1,164 @@
+# SP1b (core) — Operational-slice DR feed, single site
+
+> **Scope discipline.** This is the *core* first slice of SP1b, deliberately
+> narrowed to **one origin site → the backup, operational state only**. It
+> resolves design open-question §11.1 ("DR feed mechanism for operational
+> state"). Everything else in the failover program — the message slice (SP1a),
+> multi-site fan-out, backup serving (SP2), routing (SP3), detection (SP4),
+> failback replay (SP5) — is explicitly **out of scope** and lands in its own
+> PR.
+>
+> - **Governing design:** `docs/superpowers/specs/2026-07-28-cross-site-failover-design.md` (§4.1, §11.1)
+> - **Roadmap:** `docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md` (SP1b)
+
+## 1. Goal
+
+The backup site continuously receives **one origin site's operational state**
+(rooms, subscriptions, members, and the user roster slice) and materializes it
+verbatim into a `siteID`-namespaced Mongo, so the backup stays *warm* — a
+recent, queryable copy of that site's lifeboat-servable state.
+
+Nothing in this slice *serves* that data. The only observable outcome: writes at
+the origin site's Mongo appear, shortly after, in the backup's Mongo under that
+site's namespace.
+
+## 2. Decision — reuse the oplog CDC pipeline
+
+Resolves §11.1 (**Mongo change-streams vs a new backup-directed event fan-out**)
+in favour of **Mongo change-streams**, by reusing the existing, tested oplog CDC
+components rather than building a new fan-out:
+
+- **`data-migration/oplog-connector`** — a change-stream tailer that emits a
+  `model.OplogEvent` envelope (dedup `EventID` = `Nats-Msg-Id`, op, collection,
+  opaque whole-document `FullDocument`, `SiteID`, `ClusterTime`) to a NATS
+  stream.
+- **`data-migration/oplog-direct-transfer`** — an applier whose `targetStore`
+  (`UpsertByID` / `DeleteByID`, keyed by native `_id`) writes each event verbatim
+  into a destination Mongo.
+
+### 2.1 Why change-streams, not the OUTBOX federation pattern
+
+The OUTBOX pattern is **membership-driven**: `room-service` / `room-worker`
+publish per-destination events only for state destined for a *peer site*
+(`member_added` / `member_removed` / `room_renamed` + subscription-state), and
+only for rooms that have cross-site membership. DR needs the **opposite
+property**: the *whole* site's operational state, membership-independent —
+including purely local rooms that never federate to anyone.
+
+Tailing the Mongo oplog captures **every** write to the watched collections
+regardless of membership or event type, with three properties the OUTBOX lane
+cannot give us:
+
+1. **Local rooms covered by construction** — the exact gap the OUTBOX lane leaves.
+2. **`CrossSite` rides free** — whole-document replication copies `Room.CrossSite`
+   verbatim, satisfying design §4.1 / §7 with zero extra work.
+3. **Zero producer changes** — room-service / room-worker / user-service are
+   untouched; no risk of a missed write path, now or in future.
+
+## 3. Topology
+
+Mirrors the existing connector → NATS → transfer split, applied cross-site:
+
+```
+[ origin site A ]                         [ backup site ]
+  Mongo (rooms, subscriptions,
+   room_members, users)
+        │ change stream (local)
+        ▼
+  oplog-connector  ──►  DR_OPLOG_{A}  ──►  oplog-direct-transfer  ──►  Mongo
+   (watches op collections)  (JetStream,      (applier)                (siteID-
+                              sourced x-site)                            scoped)
+```
+
+- **Tailer runs at the origin site**, co-located with that site's Mongo — the
+  change-stream connection stays local (robust; no cross-region change stream).
+- **Events cross the gateway as JetStream** — `DR_OPLOG_{A}` is sourced into the
+  backup (durable buffering + automatic resume; decoupled from momentary remote
+  unavailability), same rationale as SP1a's canonical sourcing.
+- **Applier runs at the backup**, writing into the `siteID`-scoped Mongo.
+
+## 4. What is replicated — the lifeboat operational slice
+
+Whitelisted collections (defense-in-depth: both the connector's watch set and the
+applier's `collections` guard):
+
+| Collection | Why it's in the lifeboat slice |
+|-----------|--------------------------------|
+| `rooms` | Room existence, `CrossSite` locality, metadata to serve/list rooms |
+| `subscriptions` | Who is subscribed to what — authorize + `subscription.list` |
+| `room_members` | Membership — authorize send/receive |
+| `thread_rooms` | Thread rooms parallel channel rooms |
+| `thread_subscriptions` | Thread subscription state |
+| `users` (roster slice) | Identity slice needed to authorize/serve (not full user-service parity) |
+
+Explicitly **excluded** from this core: messages (SP1a, Cassandra), and anything
+not needed to authorize + serve send/receive in existing rooms.
+
+## 5. Self-contained events — `updateLookup`
+
+The migration connector opens its change stream with **no** `updateLookup`
+("native oplog only") because its co-located transfer re-reads the source Mongo
+by `_id` for `update` ops (`oplog-direct-transfer/handler.go:resolveBySourceLookup`).
+
+For a **cross-site DR** feed that back-read would be a cross-region round-trip
+from the backup to the origin's Mongo on every update — a coupling we do not
+want. The DR connector therefore opens the change stream with
+`fullDocument: "updateLookup"` so `update` events carry the post-image inline and
+the feed is **self-contained**: the backup applier never reads back to the origin.
+
+## 6. Idempotency & ordering
+
+- **Idempotent** — `EventID` set as `Nats-Msg-Id` (JetStream dedup) + `_id`-keyed
+  upsert/delete absorb redelivery.
+- **Per-document order preserved** — change streams deliver a document's events in
+  oplog order; a single applier (or a per-`_id` FIFO, `MaxAckPending=1`, matching
+  the OUTBOX membership-lane precedent) preserves apply order so a later update
+  can't be overtaken by an earlier one.
+
+## 7. The failback origin hook (cheap insurance for SP5)
+
+SP5 (failback) must replay **only backup-authored writes** back to a recovered
+site — never echo the origin's own replicated data back at it. To make that a
+clean "tail this namespace/marker over this window" instead of a forensic diff,
+this core bakes in the separation now:
+
+- Backup-authored operational writes are **distinguishable from origin-replicated
+  writes** — via a dedicated backup namespace and/or an origin marker on the
+  document.
+- **Precedent already in-repo:** `oplog-connector/source_mongo.go` already carries
+  a `federation.origin` `$match` filter that drops foreign-origin insert/replace.
+  The same shape (an origin marker + a change-stream `$match`) is the mechanism
+  SP5 will filter on.
+
+This slice only guarantees the **separation exists and is queryable**; SP5 owns
+the replay, conflict policy, and cutover.
+
+## 8. Out of scope (explicit — each its own PR)
+
+- **SP1a** — message slice → backup Cassandra.
+- **Multi-site** — running this per-`siteID` for every origin site (this core is one site).
+- **SP2** — backup *serving* (JWT minting, send/receive/history read paths).
+- **SP3 / SP4** — routing override, health detection.
+- **SP5** — failback replay, origin filtering *use*, conflict reconciliation.
+- **SP6** — ops/IaC: gateway peering, stream `MaxAge` sizing, replication-lag alerting.
+
+## 9. Testing (TDD, per CLAUDE.md §4)
+
+- **Unit** — applier handler table tests (insert/replace/update/delete →
+  upsert/delete; collection-guard skip; poison vs transient), mocked `targetStore`.
+  Connector collection-selection + `updateLookup` config tests.
+- **Integration** (`//go:build integration`, `testutil.MongoDB` + `testutil.NATS`)
+  — change event at a source Mongo → published to `DR_OPLOG_{siteID}` → applied →
+  read back verbatim from the backup Mongo under the site namespace, including a
+  `CrossSite=true` room asserting the flag survives round-trip.
+- **Coverage** — ≥80% floor; ≥90% for the applier/handler business logic.
+
+## 10. Open sub-decisions (call out in the plan)
+
+1. **Deploy shape** — MODE-configured reuse of the existing
+   `oplog-connector` / `oplog-direct-transfer` binaries (matching the repo's
+   unified-worker convention) vs thin new DR services. *Leaning: reuse.*
+2. **`DR_OPLOG_{siteID}` ownership** — new per-site stream bootstrapped via the
+   standard `BOOTSTRAP_STREAMS` convention; which service owns creation.
+3. **Backup namespacing** — separate Mongo *database* per `siteID` vs a
+   `siteID`-prefixed collection scheme (feeds the §7 origin hook).

--- a/docs/superpowers/specs/2026-08-11-sp2-backup-identity-jwt-minting.md
+++ b/docs/superpowers/specs/2026-08-11-sp2-backup-identity-jwt-minting.md
@@ -1,0 +1,275 @@
+# SP2 (core) — Backup identity: cross-site NATS-JWT minting & key custody
+
+> **Scope discipline.** This is the *core* first slice of SP2, deliberately
+> narrowed to the **identity question that gates everything else**: how the
+> backup site mints valid NATS user JWTs for a down site's accounts — including
+> the `chat.local.room.>` grant — **without becoming a key-custody
+> catastrophe**. It resolves design open-question §11.4. The rest of SP2 — the
+> actual send/receive and history-read *serving* handlers pointed at the
+> materialized copy — is a **separate slice** (it needs SP1 live first) and is
+> out of scope here, exactly as SP1a/SP1b narrowed to their first slice.
+>
+> - **Governing design:** `docs/superpowers/specs/2026-07-28-cross-site-failover-design.md` (§4.3, §7, §11.4)
+> - **Roadmap:** `docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md` (SP2)
+> - **Depends on:** SP0 (local/global room subjects — the `chat.local.room.>` prefix) and SP1 (materialized identity slice to authorize against).
+
+## 1. Goal
+
+When `portal-service` reroutes a down site's accounts to the backup (§4.2), the
+backup's `auth-service` must mint each displaced user a NATS user JWT that:
+
+1. **Validates on the backup's own NATS** — same decentralized-JWT trust the
+   home site relies on (the NATS server checks the signature against a trusted
+   account signing key; there is **no** `auth_callout` on the connect path —
+   confirmed in `2026-06-05-seamless-nats-jwt-refresh-design.md`).
+2. **Carries the correct scoped grants** for lifeboat traffic, crucially
+   including **subscribe on `chat.local.room.>`** so the majority (post-SP0
+   local) rooms are reachable. Missing this silently breaks the lifeboat's core
+   promise (design §7, integration requirement #1 — "highest-risk coupling").
+
+…and to do this **without placing a long-lived account signing seed on the
+backup host**. The backup is the single deployment that holds every site's
+materialized data *and* can mint every site's users — a uniquely attractive
+target. Concentrating raw signing seeds there is the design's largest security
+trade-off (§4.3); this slice's whole job is to defuse it.
+
+Nothing in this slice *serves* chat traffic. The only observable outcome: given
+a valid upstream (OIDC / botplatform) credential for a rerouted account, the
+backup returns a NATS JWT that connects successfully to the backup's NATS and
+can subscribe both `chat.room.>` and `chat.local.room.>`.
+
+## 2. Identity model today (what we are extending)
+
+`auth-service` (`handler.go:signNATSJWT`) mints **scoped** user JWTs:
+
+- The chat `account` is **not** a NATS account — it is a **tag** (`account:<name>`)
+  on the user JWT. Pub/sub permissions are **not** in the code; they come from a
+  **scoped signing key template** attached to the NATS account (`docker-local/setup.sh`),
+  which resolves `{{tag(account)}}` to the caller's own `chat.user.{account}.>`
+  subtree.
+- Signing is a single call — `uc.Encode(h.signingKey)` — where `h.signingKey`
+  is an **Ed25519** `nkeys.KeyPair` (the account *scoped signing key* seed, env
+  `AUTH_SCOPED_SIGNING_KEY`). `IssuerAccount` is stamped so the resolver
+  attributes the signing key back to its account.
+- Both the architecture doc ("signed with the account NKey", singular) and local
+  dev provision **one** org-level `chatapp` account with **one** scoped signing
+  key. We take that as the production model (see §9 open sub-decision 1 if it is
+  not).
+
+**The load-bearing seam:** `jwt.UserClaims.Encode(pair nkeys.KeyPair)` needs
+only two things from `pair` — `Sign(msg) []byte` and `PublicKey() string`.
+Everything else about "who mints" is orthogonal to the claims. That is the hook
+this whole slice hangs on.
+
+## 3. Decision — one org-level signing identity, custody behind a remote signer; the backup holds no seed
+
+Resolve §11.4 in two moves:
+
+**(a) Consolidate on a single org-level signing identity** (already the model),
+rather than N per-site account seeds. Because `account` is a tag and permissions
+come from one shared scoped template, the backup mints a down site's users with
+the *same* signing identity every site already uses — there is no per-site key to
+copy in the first place. This turns "the backup needs N sites' NKeys" into "the
+backup needs signing access to the one org key," collapsing the custody surface
+from N seeds to one and making the `chat.local.room.>` grant a **single template
+edit** that serves every site uniformly (§4).
+
+**(b) Never materialize that one seed on the backup (or any auth-service host).**
+Front the Ed25519 signature with a **remote signer** that holds the seed and
+exposes only a narrow "sign these user-JWT bytes" operation, authenticated and
+audited per call. `auth-service` becomes a signing *client*: it builds the exact
+same claims and calls `Encode` with a `nkeys.KeyPair` implementation whose
+`Sign()` delegates to the signer and whose `PublicKey()` returns the known
+signing-key public key. Zero change to claim construction; the seed never enters
+the backup's address space.
+
+```go
+// remoteSignerKP implements nkeys.KeyPair by delegating Sign to the signer.
+// PublicKey returns the account signing key's public key (config, not secret).
+// Seed/PrivateKey return an error — the seed is unreachable by construction.
+// nkeys.KeyPair.Sign has no context param, so the adapter is constructed
+// per-mint carrying the request ctx (deadline/trace) it forwards to the signer.
+type remoteSignerKP struct {
+    ctx    context.Context
+    pub    string
+    signer Signer // Sign(ctx context.Context, msg []byte) ([]byte, error)
+}
+func (k *remoteSignerKP) PublicKey() (string, error)      { return k.pub, nil }
+func (k *remoteSignerKP) Sign(msg []byte) ([]byte, error) { return k.signer.Sign(k.ctx, msg) }
+func (k *remoteSignerKP) Seed() ([]byte, error)           { return nil, errSeedUnavailable }
+func (k *remoteSignerKP) PrivateKey() ([]byte, error)     { return nil, errSeedUnavailable }
+// Verify/Wipe: trivial. Drops straight into jwt.UserClaims.Encode(kp).
+```
+
+### 3.1 What "remote signer" concretely means (Ed25519 is the constraint)
+
+NKeys are **Ed25519**, and that rules out most managed KMS: AWS KMS has no
+Ed25519 signing primitive (only ECC_NIST / RSA), so "just use KMS" is not a drop-
+in. The two realizable forms:
+
+- **HashiCorp Vault Transit** — natively supports an `ed25519` key type with a
+  `sign`/`verify` API; the key never leaves Vault, access is policy-gated and
+  audit-logged, and rotation/revocation are first-class. **Recommended concrete
+  backing.**
+- **A dedicated in-house mint-service** — a minimal, hardened `package main`
+  service that is the *only* process holding the seed (in memory from a secret
+  store, on a tightly-scoped node), exposing one RPC: sign user-JWT bytes for a
+  validated request. Use this only if Vault Transit is unavailable; it
+  reintroduces a seed-holding host, so it must be the smallest, most locked-down
+  surface in the fleet.
+
+Either way the signer sits **behind the same trust boundary as the account
+scoped signing key it wields**, and the backup's `auth-service` authenticates to
+it with revocable, rate-limitable, per-deployment credentials.
+
+### 3.2 Approaches considered
+
+- **A — one org signing identity + remote signer (CHOSEN).** Smallest custody
+  surface (one key), the `chat.local.room.>` grant is one shared template edit,
+  and a backup compromise yields only *revocable, audited signing requests*, not
+  a stolen key. Cost: a signer round-trip on the JWT-mint path (mitigated §6) and
+  operating the signer as an HA dependency.
+- **B — per-site account signing keys, each behind the signer.** Retains NATS-
+  account isolation per site (revoke one site without touching others; the
+  backup's NATS must `resolver`-trust N account JWTs). Strongest blast-radius
+  containment, but N keys to provision/rotate and a per-site template to keep the
+  `chat.local.room.>` grant in sync across. This is the **fallback if production
+  actually runs per-site NATS accounts** (§9.1) — the signer seam is identical,
+  only keyed per site. Not chosen for the single-account model because it adds
+  fan-out with no isolation win when there is only one account.
+- **C — copy raw seed(s) onto the backup (REJECTED).** The naive baseline the
+  design rejects (§4.3). Simplest to build; worst posture — a backup compromise
+  exfiltrates a permanent, org-wide (or every-site) user-minting key that cannot
+  be revoked without re-keying the whole trust chain. Documented and rejected.
+
+## 4. The `chat.local.room.>` grant (SP0 coupling — the highest-risk edge)
+
+Post-SP0, same-site rooms move to a `chat.local.room.{id}.>` prefix denied at the
+leaf (never advertised cross-gateway). Displaced users connect **intra-cluster**
+on the backup, so the leaf deny is irrelevant to their delivery (design §7) — but
+their JWT must still carry **subscribe `chat.local.room.>`** or they cannot see
+local rooms at all.
+
+Under the §3 single-identity decision this is **one edit to the shared scoped
+template** (`setup.sh` / the production equivalent): add `--allow-sub
+"chat.local.room.>"` alongside the existing `chat.room.>`. Because the template
+is shared, every user — on their home site *and* displaced to the backup — gets
+the grant identically. This **eliminates** the design's "backup silently missing
+the grant" failure mode (§7 req #1) rather than merely mitigating it: there is no
+separate backup template to drift.
+
+The grant change is **coupled to SP0 landing** (the prefix must exist and be
+leaf-denied first). Until SP0 lands, local rooms are still on `chat.room.>` and
+the existing grant already covers them; the template edit ships **with or
+immediately after** SP0, and the `signNATSJWT` docstring's "effective grants"
+comment (kept in sync with `setup.sh` and `docs/client-api.md §2.1`) is updated
+in the same change.
+
+## 5. Serving-path trust (how the backup's NATS accepts these JWTs)
+
+For a minted JWT to connect, the backup's NATS must trust the signing key that
+signed it:
+
+- **Single-identity (§3a):** the backup's NATS `resolver` preloads the **same**
+  org account JWT (with the same scoped signing key) as every site. The backup is
+  a supercluster gateway peer (design §7, needed anyway for global-room delivery),
+  so the account and its signing key are already trusted there. No new trust
+  wiring — the backup validates a displaced user's JWT exactly as the home site
+  would.
+- **Per-site fallback (§3b):** the backup's NATS must additionally `resolver`-
+  trust each site's account JWT. An ops/IaC concern (SP6), not app code.
+
+This slice asserts the trust precondition and validates it in integration
+(§8); it does **not** own the NATS server config (SP6).
+
+## 6. Failover critical path — the mint storm vs. a remote signer
+
+Failover triggers a reconnect thundering herd (design §8): a TLS + JWT-mint storm
+as a whole site's users reconnect to the backup at once. Routing every mint
+through a remote signer adds that signer to the critical path, so:
+
+- **The signature is per-connect/refresh, not per-message.** JWTs are long-lived
+  (`NATS_JWT_EXPIRY`, default 2h) and the frontend already refreshes proactively
+  with **jitter** (`2026-06-05-seamless-nats-jwt-refresh-design.md`), so mint QPS
+  is bounded by (displaced users ÷ refresh interval) plus the one-time herd — not
+  message throughput.
+- **Mitigations (mostly already in the design):** client reconnect backoff/jitter
+  and rate-limited/pre-warmed auth (design §8); a persistent, pooled signer
+  connection warmed at backup startup; the signer co-located in the backup's
+  cluster (LAN round-trip, not WAN); and the signer itself **HA** — it is on the
+  failover-serving critical path, so it inherits the backup's own "must be HA
+  within itself" requirement (design §9). A signer outage during failover fails
+  *new* mints (degraded, alerting) but does not drop already-connected sessions.
+- **No pre-minting / no seed caching "for speed."** Caching the seed locally to
+  dodge the round-trip would re-create exactly the custody surface §3b removes.
+  The round-trip is the price of the guarantee; we pay it and size the signer for
+  the herd instead.
+
+## 7. Key rotation & revocation
+
+- **Rotation** is a signer concern, not a redeploy: Vault Transit rotates the
+  `ed25519` key in place; existing JWTs remain valid until `exp` (≤2h), new mints
+  use the new version. The backup never holds the key, so no host needs
+  re-provisioning.
+- **Revocation on suspected backup compromise:** revoke the backup deployment's
+  **signer credential** (Vault token/role) — instantly cuts the backup's ability
+  to mint, with **no** re-keying of the org signing identity and no impact on
+  healthy sites. This is the concrete payoff of §3b over §3c: the response to
+  compromise is a credential revoke, not a fleet-wide re-key.
+
+## 8. Testing (TDD, per CLAUDE.md §4)
+
+- **Unit** — `remoteSignerKP` table tests: `Sign` delegates to a mocked signer
+  and the resulting JWT verifies against the configured public key; `Seed`/
+  `PrivateKey` return the sentinel error (seed genuinely unreachable);
+  signer error → mint returns a wrapped infra error (collapses to `internal` at
+  the boundary, no seed/claims leaked into the cause). Assert the built claims are
+  **byte-identical** to the current in-process path (same tags, `IssuerAccount`,
+  scoped flag, jittered `exp`) so only the signer backing changed.
+- **Unit** — grant/template regression: a test that fails if the minted JWT's
+  effective grants (asserted via the account template fixture) omit
+  `chat.local.room.>`, locking the §4 coupling.
+- **Integration** (`//go:build integration`, `testutil.NATS`) — stand up NATS
+  trusting the test account signing key; run `auth-service` against a **local
+  Vault Transit `ed25519`** (or an in-process fake signer implementing the
+  `Signer` interface); mint a JWT and assert it **connects** and can **subscribe
+  `chat.local.room.>`** and `chat.room.>` but is denied outside its
+  `chat.user.{account}.>` — proving the end-to-end trust + grant path, not just
+  the signature.
+- **Coverage** — ≥80% floor; ≥90% on the signer-delegation + mint logic.
+
+## 9. Open sub-decisions (call out in the plan)
+
+1. **Production NATS-account topology — the pivot.** This slice assumes **one
+   org-level account** (matches local dev + the architecture doc). If production
+   actually runs **per-site accounts**, switch to approach §3b: the `Signer` seam
+   and every test above are unchanged; only the signing identity is keyed per
+   site and the backup's `resolver` trusts N account JWTs (SP6). **Confirm the
+   topology with the platform/NATS team before planning.**
+2. **Signer backing — Vault Transit vs. in-house mint-service.** *Leaning Vault
+   Transit* (native Ed25519, audited, rotation/revocation first-class, no new
+   seed-holding host). Fall back to a minimal in-house signer only if Vault is
+   unavailable.
+3. **Signer interface placement** — a new `pkg/natssign` (or similar; **not**
+   `utils`/`common` per CLAUDE.md naming) defining the `Signer` interface + the
+   `nkeys.KeyPair` adapter, consumed by `auth-service` and reusable by any future
+   minting node. Keep the interface in the consumer per CLAUDE.md DI rules.
+4. **Do site auth-services adopt the signer too, or only the backup?** Adopting
+   it fleet-wide removes the raw seed from *every* auth-service (strictly better
+   posture, one code path) at the cost of putting the signer on every site's
+   login path. *Leaning: fleet-wide*, phased — backup first (where the risk is
+   acute), sites second — but the phasing is a plan-level call.
+
+## 10. Out of scope (explicit — each its own slice)
+
+- **The serving handlers** — send/receive and history-read paths pointed at the
+  backup's materialized Cassandra/Mongo. That is the rest of SP2 and needs SP1
+  live; this slice is identity/minting only.
+- **SP3 / SP4** — routing override and health detection that *decide* to reroute.
+- **SP5** — failback replay.
+- **SP6 — ops/IaC:** the backup's NATS `resolver`/gateway trust config, Vault
+  Transit provisioning + policies, per-deployment signer credentials, and the
+  leaf-node `chat.local.>` deny on the backup's leaf.
+- **The SP0 template mechanics** themselves (prefix + leaf deny) — owned by the
+  local/global room-subjects work; this slice only adds the one grant line and
+  depends on that prefix existing.

--- a/docs/superpowers/specs/2026-08-11-sp2-backup-identity-jwt-minting.md
+++ b/docs/superpowers/specs/2026-08-11-sp2-backup-identity-jwt-minting.md
@@ -1,275 +1,170 @@
-# SP2 (core) — Backup identity: cross-site NATS-JWT minting & key custody
+# SP2 (core) — Backup JWT minting in the shared NATS account
 
-> **Scope discipline.** This is the *core* first slice of SP2, deliberately
-> narrowed to the **identity question that gates everything else**: how the
-> backup site mints valid NATS user JWTs for a down site's accounts — including
-> the `chat.local.room.>` grant — **without becoming a key-custody
-> catastrophe**. It resolves design open-question §11.4. The rest of SP2 — the
-> actual send/receive and history-read *serving* handlers pointed at the
-> materialized copy — is a **separate slice** (it needs SP1 live first) and is
-> out of scope here, exactly as SP1a/SP1b narrowed to their first slice.
+> **Revised 2026-08-12 — rewritten for World 1.** An earlier draft of this spec
+> designed a key-custody scheme (a remote Ed25519 signer / Vault, so the backup
+> would never hold per-site signing seeds). That design assumed **per-site NATS
+> accounts**. Production actually runs **one shared org-level NATS account** for
+> all clients (confirmed). In that world the backup mints in the *same* account
+> every site uses — it is **not** impersonating anyone and needs no per-site
+> keys — so the custody problem the old draft solved **does not exist**. This
+> revision replaces that draft entirely and shrinks SP2 to its real, small
+> footprint.
 >
-> - **Governing design:** `docs/superpowers/specs/2026-07-28-cross-site-failover-design.md` (§4.3, §7, §11.4)
+> - **Governing design:** `docs/superpowers/specs/2026-07-28-cross-site-failover-design.md` (§4.3, §7)
 > - **Roadmap:** `docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md` (SP2)
-> - **Depends on:** SP0 (local/global room subjects — the `chat.local.room.>` prefix) and SP1 (materialized identity slice to authorize against).
+> - **Depends on:** SP0 (the `chat.local.room.>` prefix) and SP1 (materialized data to *serve* — not needed to *mint*).
 
 ## 1. Goal
 
-When `portal-service` reroutes a down site's accounts to the backup (§4.2), the
-backup's `auth-service` must mint each displaced user a NATS user JWT that:
+When `portal-service` reroutes a down site's accounts to the backup (§4.2), a
+displaced user must be able to obtain a NATS credential from the backup and
+connect. This slice establishes that the backup can do so — and documents that,
+in World 1, it requires **essentially no new code**.
 
-1. **Validates on the backup's own NATS** — same decentralized-JWT trust the
-   home site relies on (the NATS server checks the signature against a trusted
-   account signing key; there is **no** `auth_callout` on the connect path —
-   confirmed in `2026-06-05-seamless-nats-jwt-refresh-design.md`).
-2. **Carries the correct scoped grants** for lifeboat traffic, crucially
-   including **subscribe on `chat.local.room.>`** so the majority (post-SP0
-   local) rooms are reachable. Missing this silently breaks the lifeboat's core
-   promise (design §7, integration requirement #1 — "highest-risk coupling").
+The only observable outcome: a displaced user presenting a valid OIDC token to
+the backup's `auth-service` receives a NATS JWT that connects to the backup's
+NATS and can subscribe both `chat.room.>` and (post-SP0) `chat.local.room.>`.
 
-…and to do this **without placing a long-lived account signing seed on the
-backup host**. The backup is the single deployment that holds every site's
-materialized data *and* can mint every site's users — a uniquely attractive
-target. Concentrating raw signing seeds there is the design's largest security
-trade-off (§4.3); this slice's whole job is to defuse it.
+## 2. Why this is nearly a no-op — World 1
 
-Nothing in this slice *serves* chat traffic. The only observable outcome: given
-a valid upstream (OIDC / botplatform) credential for a rerouted account, the
-backup returns a NATS JWT that connects successfully to the backup's NATS and
-can subscribe both `chat.room.>` and `chat.local.room.>`.
+NATS here uses the decentralized-JWT model, and the identity topology is the
+load-bearing fact:
 
-## 2. Identity model today (what we are extending)
+- There is **one shared org-level NATS account** for all clients, trusted by
+  every site's NATS (and the backup's). The chat `account` (`alice`) is **not** a
+  NATS account — it is a **tag** on a scoped user JWT. Permissions come from a
+  single server-side **scoped-signing-key template**; `{{tag(account)}}` resolves
+  to the caller's own `chat.user.{account}.>` subtree.
+- Signing is one call — `uc.Encode(signingKey)` in `auth-service/handler.go:
+  signNATSJWT` — with the shared account signing key (`AUTH_SCOPED_SIGNING_KEY`).
+  That same key is trusted at every site.
 
-`auth-service` (`handler.go:signNATSJWT`) mints **scoped** user JWTs:
+Because the account is shared, the backup minting `alice`'s token **is** minting
+in its own account — the one `alice` already belongs to. No impersonation, no
+per-site key, no signer indirection. The backup runs the **same `auth-service`,
+unchanged**, and the JWT it mints is indistinguishable from one `alice`'s home
+site would mint.
 
-- The chat `account` is **not** a NATS account — it is a **tag** (`account:<name>`)
-  on the user JWT. Pub/sub permissions are **not** in the code; they come from a
-  **scoped signing key template** attached to the NATS account (`docker-local/setup.sh`),
-  which resolves `{{tag(account)}}` to the caller's own `chat.user.{account}.>`
-  subtree.
-- Signing is a single call — `uc.Encode(h.signingKey)` — where `h.signingKey`
-  is an **Ed25519** `nkeys.KeyPair` (the account *scoped signing key* seed, env
-  `AUTH_SCOPED_SIGNING_KEY`). `IssuerAccount` is stamped so the resolver
-  attributes the signing key back to its account.
-- Both the architecture doc ("signed with the account NKey", singular) and local
-  dev provision **one** org-level `chatapp` account with **one** scoped signing
-  key. We take that as the production model (see §9 open sub-decision 1 if it is
-  not).
+## 3. The mint path (reused verbatim)
 
-**The load-bearing seam:** `jwt.UserClaims.Encode(pair nkeys.KeyPair)` needs
-only two things from `pair` — `Sign(msg) []byte` and `PublicKey() string`.
-Everything else about "who mints" is orthogonal to the claims. That is the hook
-this whole slice hangs on.
+`auth-service` today, on the OIDC branch (`handleSSO`): validate the SSO token
+against the central Keycloak (reachable from anywhere) → derive `account` from the
+token → `signNATSJWT` with the shared key → return the JWT. **There is no
+provisioning/eligibility gate** (the one the portal-service design once proposed
+was never shipped — `auth-service` has no `SITE_ID`, no Mongo). Minting is gated
+by OIDC alone.
 
-## 3. Decision — one org-level signing identity, custody behind a remote signer; the backup holds no seed
+The backup reuses this path with **zero changes**. "Does this user have rooms to
+serve?" is answered by SP1's materialized data at *serving* time, never at mint
+time — so the mint path needs nothing from SP1.
 
-Resolve §11.4 in two moves:
+## 4. The two actual deliverables
 
-**(a) Consolidate on a single org-level signing identity** (already the model),
-rather than N per-site account seeds. Because `account` is a tag and permissions
-come from one shared scoped template, the backup mints a down site's users with
-the *same* signing identity every site already uses — there is no per-site key to
-copy in the first place. This turns "the backup needs N sites' NKeys" into "the
-backup needs signing access to the one org key," collapsing the custody surface
-from N seeds to one and making the `chat.local.room.>` grant a **single template
-edit** that serves every site uniformly (§4).
+Neither is new minting logic; both are config/ops.
 
-**(b) Never materialize that one seed on the backup (or any auth-service host).**
-Front the Ed25519 signature with a **remote signer** that holds the seed and
-exposes only a narrow "sign these user-JWT bytes" operation, authenticated and
-audited per call. `auth-service` becomes a signing *client*: it builds the exact
-same claims and calls `Encode` with a `nkeys.KeyPair` implementation whose
-`Sign()` delegates to the signer and whose `PublicKey()` returns the known
-signing-key public key. Zero change to claim construction; the seed never enters
-the backup's address space.
+### 4.1 The `chat.local.room.>` grant (shared template, SP0-coupled)
+Post-SP0, same-site rooms move to `chat.local.room.{id}.>`. A user's JWT must then
+**subscribe `chat.local.room.>`** or they lose the majority of their rooms
+(design §7, req #1). Under the shared account this is **one edit to the shared
+scoped-signing template** (`docker-local/setup.sh` and its prod equivalent): add
+`--allow-sub "chat.local.room.>"` next to the existing `chat.room.>`. Because the
+template is shared, *every* user — home and displaced — gets it identically,
+which **eliminates** the design's "backup silently missing the grant" failure mode
+rather than mitigating it (there is no separate backup template to drift).
 
-```go
-// remoteSignerKP implements nkeys.KeyPair by delegating Sign to the signer.
-// PublicKey returns the account signing key's public key (config, not secret).
-// Seed/PrivateKey return an error — the seed is unreachable by construction.
-// nkeys.KeyPair.Sign has no context param, so the adapter is constructed
-// per-mint carrying the request ctx (deadline/trace) it forwards to the signer.
-type remoteSignerKP struct {
-    ctx    context.Context
-    pub    string
-    signer Signer // Sign(ctx context.Context, msg []byte) ([]byte, error)
-}
-func (k *remoteSignerKP) PublicKey() (string, error)      { return k.pub, nil }
-func (k *remoteSignerKP) Sign(msg []byte) ([]byte, error) { return k.signer.Sign(k.ctx, msg) }
-func (k *remoteSignerKP) Seed() ([]byte, error)           { return nil, errSeedUnavailable }
-func (k *remoteSignerKP) PrivateKey() ([]byte, error)     { return nil, errSeedUnavailable }
-// Verify/Wipe: trivial. Drops straight into jwt.UserClaims.Encode(kp).
-```
+Coupled to SP0 landing (the prefix must exist first). Granting a subscribe on a
+prefix nobody publishes to yet is a harmless no-op, so it *may* ship early, but
+there is nothing to exercise until SP0 is live. Ship it **with or immediately
+after SP0**, and in the same change update the `signNATSJWT` "effective grants"
+docstring and `docs/client-api.md §2.1` (both must stay in sync with the
+template).
 
-### 3.1 What "remote signer" concretely means (Ed25519 is the constraint)
+### 4.2 Backup `auth-service` deployment (ops / SP6 handoff)
+Deploy `auth-service` at the backup with the **shared** `AUTH_SCOPED_SIGNING_KEY`
++ `AUTH_ACCOUNT_PUB_KEY`, the central OIDC config, reachable at the backup
+`baseUrl` that portal (SP3) hands displaced clients. No app change. This is an
+ops/IaC deliverable, tracked under SP6; recorded here as SP2's operational
+precondition.
 
-NKeys are **Ed25519**, and that rules out most managed KMS: AWS KMS has no
-Ed25519 signing primitive (only ECC_NIST / RSA), so "just use KMS" is not a drop-
-in. The two realizable forms:
+## 5. What was dropped, and why
 
-- **HashiCorp Vault Transit** — natively supports an `ed25519` key type with a
-  `sign`/`verify` API; the key never leaves Vault, access is policy-gated and
-  audit-logged, and rotation/revocation are first-class. **Recommended concrete
-  backing.**
-- **A dedicated in-house mint-service** — a minimal, hardened `package main`
-  service that is the *only* process holding the seed (in memory from a secret
-  store, on a tightly-scoped node), exposing one RPC: sign user-JWT bytes for a
-  validated request. Use this only if Vault Transit is unavailable; it
-  reintroduces a seed-holding host, so it must be the smallest, most locked-down
-  surface in the fleet.
+Removed from SP2 entirely (all were World-2 concerns):
+- The remote-signer / Vault Transit Ed25519 signing scheme, the `Signer`
+  interface, and the `nkeys.KeyPair` delegating adapter (`pkg/natssign`).
+- Per-site signing keys and the "backup concentrates every site's keys"
+  blast-radius argument.
 
-Either way the signer sits **behind the same trust boundary as the account
-scoped signing key it wields**, and the backup's `auth-service` authenticates to
-it with revocable, rate-limitable, per-deployment credentials.
+In World 1 the single shared signing key **already lives on every site's
+`auth-service`**; the backup holds one more copy, not a new class of risk. If the
+org ever wants to reduce that exposure, the right project is fronting the **one
+shared key with a remote signer fleet-wide** — a security-hygiene effort
+**independent of failover**, which must not block or hide inside this program.
 
-### 3.2 Approaches considered
+## 6. Eligibility gate — considered, deferred
 
-- **A — one org signing identity + remote signer (CHOSEN).** Smallest custody
-  surface (one key), the `chat.local.room.>` grant is one shared template edit,
-  and a backup compromise yields only *revocable, audited signing requests*, not
-  a stolen key. Cost: a signer round-trip on the JWT-mint path (mitigated §6) and
-  operating the signer as an HA dependency.
-- **B — per-site account signing keys, each behind the signer.** Retains NATS-
-  account isolation per site (revoke one site without touching others; the
-  backup's NATS must `resolver`-trust N account JWTs). Strongest blast-radius
-  containment, but N keys to provision/rotate and a per-site template to keep the
-  `chat.local.room.>` grant in sync across. This is the **fallback if production
-  actually runs per-site NATS accounts** (§9.1) — the signer seam is identical,
-  only keyed per site. Not chosen for the single-account model because it adds
-  fan-out with no isolation win when there is only one account.
-- **C — copy raw seed(s) onto the backup (REJECTED).** The naive baseline the
-  design rejects (§4.3). Simplest to build; worst posture — a backup compromise
-  exfiltrates a permanent, org-wide (or every-site) user-minting key that cannot
-  be revoked without re-keying the whole trust chain. Documented and rejected.
+We considered making the backup mint only for accounts whose home site is
+currently failed-over (reading SP4's state), as defense-in-depth. **Deferred**,
+because: no site has any mint-time eligibility gate today; the minted token is
+**site-agnostic** in World 1 (identical regardless of who mints it or which site
+the account is "from"), so an over-broad mint grants no extra privilege; and
+portal (SP3) already routes only failed-over sites' users to the backup. Whether
+`auth-service` should gain an eligibility gate at all is a **system-wide policy
+question, not a failover one** — out of scope here.
 
-## 4. The `chat.local.room.>` grant (SP0 coupling — the highest-risk edge)
+## 7. Serving-path trust (trivial in World 1)
 
-Post-SP0, same-site rooms move to a `chat.local.room.{id}.>` prefix denied at the
-leaf (never advertised cross-gateway). Displaced users connect **intra-cluster**
-on the backup, so the leaf deny is irrelevant to their delivery (design §7) — but
-their JWT must still carry **subscribe `chat.local.room.>`** or they cannot see
-local rooms at all.
+The backup's NATS `resolver` preloads the **same** shared account JWT + scoped
+signing key as every site, so it validates a displaced user's JWT exactly as the
+home site would — no new trust wiring. The backup is a supercluster gateway peer
+(needed anyway for global-room delivery, design §7); that peering is ops/SP6.
 
-Under the §3 single-identity decision this is **one edit to the shared scoped
-template** (`setup.sh` / the production equivalent): add `--allow-sub
-"chat.local.room.>"` alongside the existing `chat.room.>`. Because the template
-is shared, every user — on their home site *and* displaced to the backup — gets
-the grant identically. This **eliminates** the design's "backup silently missing
-the grant" failure mode (§7 req #1) rather than merely mitigating it: there is no
-separate backup template to drift.
+## 8. Failover mint storm (operational note)
 
-The grant change is **coupled to SP0 landing** (the prefix must exist and be
-leaf-denied first). Until SP0 lands, local rooms are still on `chat.room.>` and
-the existing grant already covers them; the template edit ships **with or
-immediately after** SP0, and the `signNATSJWT` docstring's "effective grants"
-comment (kept in sync with `setup.sh` and `docs/client-api.md §2.1`) is updated
-in the same change.
+A whole site reconnecting at once is an OIDC-validate + sign burst on the backup's
+`auth-service` — now a **local** cost (no external signer on the path). Mitigated
+by the existing client reconnect backoff/jitter and proactive-refresh jitter
+(`2026-06-05-seamless-nats-jwt-refresh-design.md`); size the backup's
+`auth-service` (and Keycloak reachability) for one largest site's reconnect peak.
 
-## 5. Serving-path trust (how the backup's NATS accepts these JWTs)
+## 9. Bots/admins out of scope
 
-For a minted JWT to connect, the backup's NATS must trust the signing key that
-signed it:
+Admin/bot functionality is out of lifeboat scope (design §2, §10), so
+`auth-service`'s botplatform session-token branch need not work at the backup —
+leave `BOTPLATFORM_URL` unset there. Only the OIDC mint path serves displaced
+users.
 
-- **Single-identity (§3a):** the backup's NATS `resolver` preloads the **same**
-  org account JWT (with the same scoped signing key) as every site. The backup is
-  a supercluster gateway peer (design §7, needed anyway for global-room delivery),
-  so the account and its signing key are already trusted there. No new trust
-  wiring — the backup validates a displaced user's JWT exactly as the home site
-  would.
-- **Per-site fallback (§3b):** the backup's NATS must additionally `resolver`-
-  trust each site's account JWT. An ops/IaC concern (SP6), not app code.
+## 10. Testing (TDD, per CLAUDE.md §4)
 
-This slice asserts the trust precondition and validates it in integration
-(§8); it does **not** own the NATS server config (SP6).
+Honestly minimal — there is **no new Go logic in the mint path**, so most
+assurance is config-level:
 
-## 6. Failover critical path — the mint storm vs. a remote signer
+- **Grant regression (unit):** once the shared template carries
+  `chat.local.room.>`, a test that fails if a minted JWT's effective grants
+  (asserted against the account-template fixture) omit it — locking §4.1.
+- **Integration** (`//go:build integration`, `testutil.NATS`): stand up NATS
+  trusting the shared account signing key; run `auth-service`; mint via the OIDC
+  path (fake `TokenValidator`); assert the JWT **connects** and can **subscribe
+  `chat.room.>` and `chat.local.room.>`** but is denied outside its
+  `chat.user.{account}.>` — proving the end-to-end grant path at the backup.
+- No new `remoteSignerKP` / signer tests — that code no longer exists.
 
-Failover triggers a reconnect thundering herd (design §8): a TLS + JWT-mint storm
-as a whole site's users reconnect to the backup at once. Routing every mint
-through a remote signer adds that signer to the critical path, so:
+## 11. Out of scope (each its own slice)
 
-- **The signature is per-connect/refresh, not per-message.** JWTs are long-lived
-  (`NATS_JWT_EXPIRY`, default 2h) and the frontend already refreshes proactively
-  with **jitter** (`2026-06-05-seamless-nats-jwt-refresh-design.md`), so mint QPS
-  is bounded by (displaced users ÷ refresh interval) plus the one-time herd — not
-  message throughput.
-- **Mitigations (mostly already in the design):** client reconnect backoff/jitter
-  and rate-limited/pre-warmed auth (design §8); a persistent, pooled signer
-  connection warmed at backup startup; the signer co-located in the backup's
-  cluster (LAN round-trip, not WAN); and the signer itself **HA** — it is on the
-  failover-serving critical path, so it inherits the backup's own "must be HA
-  within itself" requirement (design §9). A signer outage during failover fails
-  *new* mints (degraded, alerting) but does not drop already-connected sessions.
-- **No pre-minting / no seed caching "for speed."** Caching the seed locally to
-  dodge the round-trip would re-create exactly the custody surface §3b removes.
-  The round-trip is the price of the guarantee; we pay it and size the signer for
-  the herd instead.
+- **The serving handlers** — send/receive + history-read against the backup's
+  materialized data (the rest of SP2, needs SP1).
+- **SP3 / SP4 / SP5** — routing override, health detection, failback.
+- **SP6 — ops/IaC:** the backup's NATS `resolver`/gateway trust config and the
+  `auth-service` deployment (§4.2).
+- **SP0 template mechanics** (the prefix + leaf deny) — this slice only adds the
+  one grant line and depends on that prefix existing.
+- **Fleet-wide signing-key hardening** — a separate, optional security project
+  (§5), not failover.
 
-## 7. Key rotation & revocation
+## 12. Open sub-decisions (call out in the plan)
 
-- **Rotation** is a signer concern, not a redeploy: Vault Transit rotates the
-  `ed25519` key in place; existing JWTs remain valid until `exp` (≤2h), new mints
-  use the new version. The backup never holds the key, so no host needs
-  re-provisioning.
-- **Revocation on suspected backup compromise:** revoke the backup deployment's
-  **signer credential** (Vault token/role) — instantly cuts the backup's ability
-  to mint, with **no** re-keying of the org signing identity and no impact on
-  healthy sites. This is the concrete payoff of §3b over §3c: the response to
-  compromise is a credential revoke, not a fleet-wide re-key.
-
-## 8. Testing (TDD, per CLAUDE.md §4)
-
-- **Unit** — `remoteSignerKP` table tests: `Sign` delegates to a mocked signer
-  and the resulting JWT verifies against the configured public key; `Seed`/
-  `PrivateKey` return the sentinel error (seed genuinely unreachable);
-  signer error → mint returns a wrapped infra error (collapses to `internal` at
-  the boundary, no seed/claims leaked into the cause). Assert the built claims are
-  **byte-identical** to the current in-process path (same tags, `IssuerAccount`,
-  scoped flag, jittered `exp`) so only the signer backing changed.
-- **Unit** — grant/template regression: a test that fails if the minted JWT's
-  effective grants (asserted via the account template fixture) omit
-  `chat.local.room.>`, locking the §4 coupling.
-- **Integration** (`//go:build integration`, `testutil.NATS`) — stand up NATS
-  trusting the test account signing key; run `auth-service` against a **local
-  Vault Transit `ed25519`** (or an in-process fake signer implementing the
-  `Signer` interface); mint a JWT and assert it **connects** and can **subscribe
-  `chat.local.room.>`** and `chat.room.>` but is denied outside its
-  `chat.user.{account}.>` — proving the end-to-end trust + grant path, not just
-  the signature.
-- **Coverage** — ≥80% floor; ≥90% on the signer-delegation + mint logic.
-
-## 9. Open sub-decisions (call out in the plan)
-
-1. **Production NATS-account topology — the pivot.** This slice assumes **one
-   org-level account** (matches local dev + the architecture doc). If production
-   actually runs **per-site accounts**, switch to approach §3b: the `Signer` seam
-   and every test above are unchanged; only the signing identity is keyed per
-   site and the backup's `resolver` trusts N account JWTs (SP6). **Confirm the
-   topology with the platform/NATS team before planning.**
-2. **Signer backing — Vault Transit vs. in-house mint-service.** *Leaning Vault
-   Transit* (native Ed25519, audited, rotation/revocation first-class, no new
-   seed-holding host). Fall back to a minimal in-house signer only if Vault is
-   unavailable.
-3. **Signer interface placement** — a new `pkg/natssign` (or similar; **not**
-   `utils`/`common` per CLAUDE.md naming) defining the `Signer` interface + the
-   `nkeys.KeyPair` adapter, consumed by `auth-service` and reusable by any future
-   minting node. Keep the interface in the consumer per CLAUDE.md DI rules.
-4. **Do site auth-services adopt the signer too, or only the backup?** Adopting
-   it fleet-wide removes the raw seed from *every* auth-service (strictly better
-   posture, one code path) at the cost of putting the signer on every site's
-   login path. *Leaning: fleet-wide*, phased — backup first (where the risk is
-   acute), sites second — but the phasing is a plan-level call.
-
-## 10. Out of scope (explicit — each its own slice)
-
-- **The serving handlers** — send/receive and history-read paths pointed at the
-  backup's materialized Cassandra/Mongo. That is the rest of SP2 and needs SP1
-  live; this slice is identity/minting only.
-- **SP3 / SP4** — routing override and health detection that *decide* to reroute.
-- **SP5** — failback replay.
-- **SP6 — ops/IaC:** the backup's NATS `resolver`/gateway trust config, Vault
-  Transit provisioning + policies, per-deployment signer credentials, and the
-  leaf-node `chat.local.>` deny on the backup's leaf.
-- **The SP0 template mechanics** themselves (prefix + leaf deny) — owned by the
-  local/global room-subjects work; this slice only adds the one grant line and
-  depends on that prefix existing.
+1. **Grant timing** — ship `chat.local.room.>` on the shared template *now* (a
+   harmless no-op until SP0) vs. bundled into the SP0 PR. *Leaning: with SP0*, so
+   it is exercised the moment the prefix exists.
+2. **Eligibility gate** — leave `auth-service` OIDC-only (status quo, this spec's
+   choice) vs. introduce a system-wide mint-time gate later. Not a failover
+   decision; noted only so the option is on record.

--- a/docs/superpowers/specs/2026-08-11-sp3-portal-routing-override.md
+++ b/docs/superpowers/specs/2026-08-11-sp3-portal-routing-override.md
@@ -1,0 +1,189 @@
+# SP3 (core) — Routing brain: portal-service health-aware override
+
+> **Scope discipline.** This slice makes `portal-service` return the **backup
+> site's** connection coordinates for a down site's accounts, keyed entirely on
+> SP4's `servingTarget` signal. It is **codebase-local** — a thin override at
+> portal's existing resolve seam — and deliberately owns *only* the routing
+> decision. Detection/state (SP4), JWT minting (SP2), and failback replay (SP5)
+> are out of scope.
+>
+> - **Governing design:** `docs/superpowers/specs/2026-07-28-cross-site-failover-design.md` (§4.2, §6.3, §7)
+> - **Roadmap:** `docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md` (SP3)
+> - **Consumes:** SP4's `FailoverState.servingTarget` (home | backup). **Blocked on** SP4's signal shape (now decided).
+
+## 1. Goal
+
+When SP4 marks a site `failed_over`/`failing_back`, every login/discovery answer
+portal gives for that site's accounts must point at the **backup** — so displaced
+clients connect to the backup's NATS and mint from the backup's `auth-service`
+(SP2) — while a healthy site's accounts route home, unchanged. Portal is the
+design's **single routing authority and split-brain fence** (§4.2); this slice is
+where that authority becomes an actual reroute.
+
+The only observable outcome: for an account whose home site has
+`servingTarget=backup`, `GET /api/userInfo` (and `POST /api/v1/login`) return the
+backup's `baseUrl`/`natsUrl`; when the site is healthy, they return the home
+site's, exactly as today.
+
+## 2. Decision — a thin override at the resolve seam, keyed on `servingTarget`
+
+Portal already resolves coordinates in one place: `handler.go:resolve()` looks up
+the account's home `siteID`, then returns `sites[siteID]`'s `BaseURL`/`NATSURL`
+(`PORTAL_SITE_URLS` registry). `HandleLogin` does the same for bot/admin logins.
+The override is a **single interception at that lookup**:
+
+> resolve the account's home `siteID` → read SP4's `FailoverState[siteID]` →
+> if `servingTarget == backup`, substitute the **backup** registry entry's URLs;
+> else use the home entry. Everything else about the response is unchanged.
+
+- **Reject — a separate "failover router" service or a new client protocol.** The
+  frontend already re-queries portal on connection failure and connects to
+  whatever URL it is handed (design §4.2, §7); a new service or protocol would
+  duplicate the directory and the reconnect path for no gain. The reroute *is*
+  the existing path with a different answer.
+- **Reject — rewriting the `siteID` to the backup's.** The backup materializes
+  **per-origin-`siteID` namespaces** and the message send subject carries
+  `{siteID}` (`chat.user.{account}.room.{roomID}.{siteID}.msg.send`; streams
+  `MESSAGES_{siteID}`). The client must keep reporting its **home** `siteID` so
+  its subjects land in the backup's copy *of that site*. Only the transport URLs
+  move; `siteID` does not (see §3).
+
+### 2.1 Centralize the override so both entry points honor it
+
+`resolve()` and `HandleLogin` both hand out site URLs, so the override lives in
+**one helper** both call — else a bot/admin of a down site would password-login
+straight to a dead site. Sketch:
+
+```go
+// servingURLs returns the coordinates to hand the client for an account homed
+// on siteID, applying SP4's failover override. siteID (the home site) is
+// returned unchanged for data scoping; only the transport URLs may swap.
+func (h *PortalHandler) servingURLs(ctx context.Context, siteID string) (siteURL, error) {
+    target := h.failover.ServingTarget(ctx, siteID) // SP4 read, TTL-cached; home on miss/error
+    if target == servingBackup {
+        b, ok := h.sites[h.backupSiteID]
+        if !ok { return siteURL{}, fmt.Errorf("backup site %q missing from registry", h.backupSiteID) }
+        return b, nil
+    }
+    home, ok := h.sites[siteID]
+    if !ok { return siteURL{}, fmt.Errorf("no URLs configured for siteId %q", siteID) }
+    return home, nil
+}
+```
+
+Both handlers call `servingURLs(ctx, e.SiteID)` and keep returning `SiteID:
+e.SiteID` (home) in the body. Dev-mode fallback and the "site missing from
+registry" internal-error path are preserved.
+
+## 3. What swaps, and what must not
+
+| Response field | Healthy | Failed over | Why |
+|---|---|---|---|
+| `baseUrl` | home | **backup** | JWT minting (SP2) + HTTP APIs served by the backup |
+| `natsUrl` | home | **backup** | client connects to the backup's NATS (intra-cluster) |
+| `siteId` | home | **home (unchanged)** | data is namespaced by origin `siteID` on the backup; `msg.send` subjects carry it |
+| `account`, `employeeId` | unchanged | unchanged | identity is site-independent |
+
+Keeping `siteId` = home is the load-bearing correctness point: it makes the
+displaced client publish/subscribe under the same site namespace the backup
+materialized (SP1) and mints grants for (SP2), so send/receive "just works"
+against the backup copy.
+
+## 4. Backup coordinates in the registry
+
+The backup is **one more entry** in `PORTAL_SITE_URLS`, under a reserved id
+(`PORTAL_BACKUP_SITE_ID`, e.g. `_backup`). No schema change — the existing
+`siteURL{baseUrl,natsUrl}` shape already carries what the client needs, and
+startup validation (`parseSiteURLs`) already requires both URLs, so a
+misconfigured backup fails at boot, not at a user's failover. A single backup id
+suffices for the design's N→1 topology (§3); a multi-backup future is a registry
+extension, not a redesign.
+
+## 5. Client reconnect — reuse the existing self-heal, both directions
+
+No new client protocol; the reroute rides the path the frontend already has
+(design §7 "reconnect-self-heal", §4.2):
+
+- **Failover (home→backup):** the home site is down, so the displaced client's
+  NATS connection has **already dropped**. Its existing reconnect logic re-queries
+  portal, now gets the backup's URLs, mints via the backup's `auth-service` (SP2),
+  connects, and re-reads `subscription.list` (materialized by SP1) on the correct
+  prefixes. Automatic.
+- **Failback (backup→home):** after SP4 flips `failing_back → healthy` on SP5's
+  lag≈0 report, the backup **tears down its impersonation** and drains those
+  connections (design §6.3 step 6, §6.6). The drop is itself the nudge: the client
+  reconnects, re-queries portal, now gets home's URLs, and resumes on the home
+  site — the same self-heal, in reverse. SP3 does not invent a separate
+  "reconnect now" push; the drain-driven reconnect is sufficient and reuses tested
+  behavior.
+
+SP3's responsibility ends at *handing out the right URL when asked*. The drain
+that forces the failback reconnect is the backup serving stack's (SP2/SP5); SP3
+just answers home once the flip has happened.
+
+## 6. Split-brain fence — trust SP4's one record, never second-guess
+
+Portal is the fence because the serving target comes from **one** authoritative
+`FailoverState` document (SP4, §6 there), and SP3 is a pure reader of it:
+
+- SP3 **never** derives failover from its own probing or from a login failure — it
+  reads `servingTarget` and nothing else. A site is `home` xor `backup` because
+  the field is single-valued; SP3 cannot manufacture a third answer.
+- **Fail-safe = home.** If the failover read misses or errors, `ServingTarget`
+  returns `home` (SP4 §6) — normal routing. An unreachable failover store must
+  never strand a healthy site's users on the backup.
+- **No caching of the decision past its TTL.** SP3 reads through SP4's short
+  `FAILOVER_STATE_TTL` cache (seconds), so a flip in either direction reaches new
+  logins within seconds without a per-login Mongo hit. This is separate from the
+  24h directory cache and must not be merged into it.
+
+## 7. Testing (TDD, per CLAUDE.md §4)
+
+- **Unit (`handler_test.go`)** — table-driven over `servingURLs` + both handlers
+  with a mock failover reader: healthy → home URLs; `failed_over` → backup URLs
+  with `siteId` **still home**; `failing_back` → backup URLs; failover read
+  error/miss → home (fail-safe); backup id missing from registry → internal;
+  bot/admin login path honors the override identically; dev fallback unchanged.
+- **Unit** — assert the response body's `siteId` is the home site in every
+  failed-over case (the "must not swap `siteId`" invariant, locked by a test).
+- **Integration** (`//go:build integration`, `testutil.MongoDB`) — seed a
+  `FailoverState` of `failed_over` for a site, hit `/api/userInfo`, assert backup
+  coordinates + home `siteId`; flip to `healthy`, assert home coordinates after
+  the TTL; concurrent healthy/failed accounts resolve independently.
+- **Coverage** — ≥80% floor; ≥90% on `servingURLs` + the two handlers' override
+  branches.
+
+## 8. Documentation
+
+`docs/client-api.md` §2 (site discovery): note that `baseUrl`/`natsUrl` may point
+at the backup during a home-site outage while `siteId` remains the home site, and
+that the client's existing reconnect-on-failure path is the failover/failback
+trigger. Field tables gain no new fields (the shapes are unchanged); only the
+narrative and the reason/behavior notes are added, per the doc's current style.
+
+## 9. Open sub-decisions (call out in the plan)
+
+1. **Backup id convention** — reserved entry in `PORTAL_SITE_URLS`
+   (`PORTAL_BACKUP_SITE_ID`) vs. a dedicated `PORTAL_BACKUP_SITE_URLS`. *Leaning:
+   reserved entry* (no new config surface, reuses `parseSiteURLs` validation).
+2. **Failover reader placement** — a `FailoverReader` interface defined in
+   portal (the consumer, per CLAUDE.md DI) with the Mongo + TTL-cache
+   implementation, shared in shape with SP4's writer but a distinct read
+   interface. Confirm SP4 and SP3 agree on the `FailoverState` document schema
+   (§3 in SP4) as the contract between them.
+3. **Proactive failback nudge** — rely solely on the backup drain (§5) vs. also
+   publishing a reconnect hint on the global `chat.user.{account}.>` tree (§7 of
+   the design says the per-user tree stays global, so a nudge is possible).
+   *Leaning: drain-only* for this core; add a nudge only if failback reconnect
+   latency proves too slow in practice.
+
+## 10. Out of scope (explicit — each its own slice)
+
+- **SP4** — producing/owning `FailoverState`; the detector and control surface.
+  SP3 only reads `servingTarget`.
+- **SP2** — the backup's JWT minting and serving handlers the rerouted client
+  then talks to.
+- **SP5** — failback replay/convergence and the backup-impersonation drain that
+  triggers the failback reconnect.
+- **SP6 — ops/IaC:** the backup deployment behind the registry URLs, and the
+  backup as a supercluster gateway peer.

--- a/docs/superpowers/specs/2026-08-11-sp4-failover-trigger-health-detection.md
+++ b/docs/superpowers/specs/2026-08-11-sp4-failover-trigger-health-detection.md
@@ -1,266 +1,184 @@
-# SP4 (core) — Failover trigger: health detection & operator control surface
+# SP4 (core) — Operator-driven failover state in portal-service
 
-> **Scope discipline.** This slice resolves design open-question §11.3: **how a
-> site is declared down** (auto-detection + manual override) and **the control
-> surface** an operator drives it from. Its load-bearing output is the
-> **failover-state signal** that SP3 (the routing brain) consumes — so this spec
-> is deliberately precise about that signal's shape and authority, and defers the
-> routing *use* of it to SP3. Everything downstream — the actual reroute in
-> `resolve()` (SP3), the failback replay (SP5) — is out of scope.
+> **Revised 2026-08-12 — rewritten after a collaborative brainstorm.** The first
+> draft designed auto-detection (a health probe, `suspected` state, config-gated
+> auto-failover, `hold_healthy`). We chose an **operator-confirmed** posture and
+> **deferred the probe**, so this slice is purely the operator-driven state
+> machine + control surface + the `servingTarget` signal. Auto-detection/alerting
+> is a later add-on that only ever writes an advisory status and fires an alert —
+> it never flips anything. The original probe design is superseded, not retained.
 >
-> - **Governing design:** `docs/superpowers/specs/2026-07-28-cross-site-failover-design.md` (§3 "Failover trigger" knob, §4.2, §6.3, §11.3)
+> - **Governing design:** `docs/superpowers/specs/2026-07-28-cross-site-failover-design.md` (§3 "Failover trigger" knob, §4.2, §6.3)
 > - **Roadmap:** `docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md` (SP4 — "feeds SP3")
-> - **Consumer:** SP3 (portal health-aware routing override); **hands off to:** SP5 (failback).
+> - **Consumer:** SP3 (portal routing override) reads the `servingTarget` signal. **Hands off to:** SP5 (failback lag-gate).
 
 ## 1. Goal
 
-Give `portal-service` — already the routing brain and the design's designated
-**split-brain fence** (§4.2) — an authoritative, per-site answer to *"is this
-site being served from home or from the backup right now, and who decided
-that?"*, and the operator controls to drive it. Concretely:
+Give `portal-service` — the one globally-scoped service, already the cross-site
+routing authority and split-brain fence (§4.2) — an authoritative, per-site
+answer to *"is this site served from home or from the backup right now, and who
+decided that?"*, plus the operator controls to drive it. An operator who knows
+(from existing infra monitoring) that site A is down can **fail it over** to the
+backup and later **fail it back**, and SP3 reads the resulting signal to route.
 
-1. A **persistent, portal-owned failover-state record** per site, whose derived
-   `ServingTarget` (home | backup) is the single fact SP3 reads to route.
-2. **Auto-detection** that watches each site's reachability and *proposes* a
-   failover, conservatively (multi-sample + dwell, flap-resistant).
-3. A **manual operator control surface** (portal-owned, admin-gated) that is
-   **always authoritative** over the automation: force a failover, hold a site
-   healthy (maintenance), or initiate failback.
+Explicitly **not** in this slice: automatic detection (deferred), the routing
+override itself (SP3), the failback data replay + lag gate (SP5), and any UI /
+per-operator login (a deliberate follow-up — see §8).
 
-This is the design's stated knob — "automatic health-detection with a manual
-operator override" (§3). This slice **does not** reroute traffic (SP3), does not
-replay outage writes (SP5), and does not mint JWTs (SP2). It produces and governs
-the *state*; SP3 acts on it.
+## 2. Decisions (from the brainstorm)
 
-## 2. Decision — a portal-owned failover-state machine; auto-detection proposes, the operator disposes
+- **Operator-confirmed, not automatic.** A human performs every flip. There is no
+  auto-failover, so no `AUTO_FAILOVER`, no dwell-to-promote, no `hold_healthy`
+  (those only existed to manage automation).
+- **Probe deferred.** No health probe in this slice. Operators learn of outages
+  from existing monitoring; the probe would only add a convenience alert and is
+  additive later (it will write an advisory status + alert, never flip state).
+- **Control surface on `portal-service`.** The failover decision is *global*; the
+  existing `admin-service` auth is *per-site* (`requireAdmin` checks
+  `sess.SiteID == siteID`), so it does not fit. Portal is the correct home.
+- **Auth = dedicated ops bearer token, internal-only.** A break-glass ops secret
+  gates the control routes on an internal listener, kept off portal's public
+  browser-facing API. `operator` id is carried in the request for audit
+  (self-asserted under this model — see §8 for the option-3 upgrade path).
 
-Three moves, in priority of what unblocks SP3:
+## 3. The `FailoverState` signal (the SP3 contract)
 
-**(a) The signal is a Mongo-backed per-site `FailoverState` record, portal is its
-sole writer.** Portal already owns a Mongo connection (the directory store's live
-`GetByAccount` fallback) and is the single routing authority, so co-locating the
-failover state there keeps the fence in one place. It must be **persistent**
-(survive portal restart) and **shared across portal replicas** — ruling out the
-in-memory directory-cache pattern. SP3 reads it on the routing path via a short
-TTL cache (seconds, §6), *not* the 24h directory refresh, so a failover takes
-effect promptly.
+One document per active site (`_id = siteID`) in portal's existing Mongo DB:
 
-**(b) Detection is conservative and, by default, advisory.** A probe loop marks a
-site `suspected` on sustained unreachability and **alerts**, but the
-reroute-causing transition to `failed_over` is **operator-confirmed by default**.
-Fully-automatic promotion is a **config-gated maturity step** (`AUTO_FAILOVER`,
-default off) with a dwell window — because a false-positive failover is
-expensive (needless failover + a full failback protocol) and, if the automation
-and an operator disagree, split-brain-adjacent. Portal sees the world from **one
-vantage point**, so it cannot by itself distinguish "site A is down" from "portal
-can't reach site A"; operator-confirm (or an external-monitor feed, §4) is the
-safe resolution of that ambiguity for v1.
-
-**(c) Manual override always wins.** An operator action (`force_failover`,
-`hold_healthy`, `failback`) sets an override that the auto-detector must respect —
-it can never auto-flip a site the operator has pinned, nor auto-fail-back one the
-operator forced over.
-
-### 2.1 Approaches considered (detection mechanism)
-
-- **A — portal active-probe + operator-confirm, external-monitor feed optional
-  (CHOSEN).** Portal probes each site's user-facing reachability; sustained
-  failure ⇒ `suspected` + alert; operator confirms (or `AUTO_FAILOVER` promotes
-  after dwell). Reuses portal's existing loop shape; keeps the fence and the
-  decision in one authority; conservative by construction. Optional: consume an
-  external monitor's verdict (below) as a corroborating signal.
-- **B — external monitoring drives it end-to-end** (Prometheus/Alertmanager or
-  k8s health flips the state; portal only reads). Decouples detection from
-  portal's single vantage point (multiple probers, battle-tested), but moves the
-  *trigger* authority outside the split-brain fence and couples DR to a specific
-  monitoring stack this repo doesn't standardize. Kept as the corroborating feed
-  in A, not the sole authority.
-- **C — sites heartbeat to portal** (absence ⇒ down). Symmetric to probing and
-  same partition ambiguity, but a site that is *up but can't reach portal* looks
-  down — a worse failure mode than A. Rejected.
-- **D — manual-only** (no automation, operator declares every outage). Simplest
-  and safest against false positives, but RTO becomes "time until a human
-  notices." Rejected as the *only* mechanism; retained as the effective default
-  behavior when `AUTO_FAILOVER` is off (auto-detect still alerts, human still
-  acts — but faster, because the alert fires).
-
-## 3. The `FailoverState` signal (the load-bearing SP3 contract)
-
-One document per active site (`_id = siteID`). This is the artifact SP3 is
-blocked on; it is defined here in full.
-
-| Field | Type | Meaning |
+| field | type | meaning |
 |------|------|---------|
 | `siteId` | string (`_id`) | the active site this state governs |
-| `status` | enum | `healthy` \| `suspected` \| `failed_over` \| `failing_back` |
-| `override` | enum | `none` \| `force_failover` \| `hold_healthy` \| `force_failback` — operator lock the detector must honor |
+| `status` | enum | `healthy` \| `failed_over` \| `failing_back` |
 | `servingTarget` | enum (derived) | `home` unless `status ∈ {failed_over, failing_back}` → `backup` |
-| `reason` | string | free-text (operator note or detector cause, e.g. `nats_unreachable`) |
-| `actor` | string | `auto` or the admin account that made the last transition |
-| `since` | int64 (ms) | when the current `status` began (for RTO/observability) |
-| `version` | int64 | optimistic-concurrency guard for the sole-writer CAS (§6) |
+| `reason` | string | operator note (why) |
+| `operator` | string | ops identity that made the last transition (audit) |
+| `since` | int64 (ms) | when the current `status` began |
+| `version` | int64 | optimistic-concurrency guard for the sole-writer CAS (§7) |
 | `timestamp` | int64 (ms) | event-level publish time, per CLAUDE.md "Event Timestamps" |
 
-**`servingTarget` is the entire SP3 contract.** SP3's `resolve()` computes: read
-the account's home `siteID`, look up its `FailoverState`; if `servingTarget ==
-backup`, return the **backup** site's coordinates from the registry instead of
-the home site's; else unchanged. Nothing else about SP4's internals leaks into
-SP3 — a clean, single-field seam.
+**`servingTarget` is the entire SP3 contract.** SP3's `resolve()` reads it: if
+`backup`, return the backup's coordinates instead of the home site's; else
+unchanged. Nothing else about SP4 leaks into SP3 — a single-field seam.
 
-State machine (portal is the only writer; every edge is CAS-guarded on `version`):
+## 4. State machine
+
+Operator-driven; every edge is CAS-guarded on `version` (§7):
 
 ```
-                 detector: sustained-unreachable + dwell
-   healthy ─────────────────────────────────────────────► suspected
-      ▲                                                        │
-      │ operator failback done / detector: recovered           │ operator confirm
-      │ (servingTarget flips home)                             │ OR AUTO_FAILOVER+dwell
-      │                                                        ▼
-  failing_back ◄───────────── operator: begin failback ─── failed_over
-   (still served from backup;                              (served from backup)
-    SP5 drains; flip on lag≈0)
+   healthy ──── failover ────► failed_over ──── failback ────► failing_back
+      ▲                            │                                │
+      │                            │ resume (false alarm)           │ complete
+      └──────────────┬─────────────┘                                │
+                     └──────────────── (terminal flip) ◄────────────┘
 ```
 
-- `hold_healthy` override pins `healthy` and blocks the `healthy→suspected→
-  failed_over` path (maintenance windows, known-flaky links).
-- `force_failover` jumps to `failed_over` regardless of probe state (operator
-  knows the site is down before the probe agrees).
-- `force_failback` / "begin failback" moves `failed_over → failing_back`; the
-  terminal `failing_back → healthy` flip is **gated on SP5 reporting lag≈0** and
-  is the atomic split-brain-safe cutover (§7).
+- `failover`: `healthy → failed_over` (operator declares site down; serve from backup).
+- `resume`: `failed_over → healthy` directly (false alarm; skip the drain).
+- `failback`: `failed_over → failing_back` (begin draining home).
+- `complete`: `failing_back → healthy` (drain done).
+- `servingTarget` stays `backup` through `failing_back` — users keep writing to a
+  stable backup while home drains.
 
-## 4. Detection mechanism — what portal probes, and how it avoids flapping
+**Forward-compat hook for SP5:** `failing_back` and its terminal `complete` flip
+exist so SP3's contract is stable and SP5 has its seam. **In this slice `complete`
+is a manual operator action** (there is no backup serving or replay to gate on
+yet). When SP5 lands, it owns gating `complete` on lag≈0; the state and the
+transition are unchanged — SP5 just becomes the actor that calls it.
 
-- **Probe target = user-serviceability, not liveness.** A site is "servable" iff
-  a displaced-nothing user could actually connect and mint: its **NATS is
-  reachable** (the client connect target) **and its `auth-service` is healthy**
-  (JWT minting). Portal probes the site's NATS monitoring `/healthz`
-  (JetStream-enabled check) and `auth-service` `/healthz` on an interval. These
-  two being up is the closest cheap proxy for "users can be served from home";
-  deeper datastore health is the site's own concern and, if broken, surfaces as
-  serving failures the operator escalates.
-- **Flap resistance:** require **M consecutive failed samples over a dwell
-  window** (config: `FAILOVER_PROBE_INTERVAL`, `FAILOVER_UNHEALTHY_SAMPLES`,
-  `FAILOVER_DWELL`) before `healthy → suspected`; require a symmetric healthy
-  streak before the detector proposes recovery. No single blip moves state.
-- **Advisory vs. auto:** on reaching the unhealthy threshold, always write
-  `suspected` + emit a high-severity alert (structured `slog` + the o11y metric
-  path). Promotion `suspected → failed_over` happens **only** on operator confirm,
-  **unless** `AUTO_FAILOVER=true`, in which case a further auto-dwell promotes it —
-  and even then `hold_healthy` blocks it.
-- **Corroboration (optional):** an external monitor may `POST` its own verdict
-  into the control surface (§5) as a second signal; portal records it in `reason`
-  but the state machine and CAS remain portal's.
+Illegal transitions (e.g. `healthy → failing_back`) are rejected.
 
-## 5. Manual-override control surface (portal-owned, admin-gated)
+## 5. Control surface
 
-New portal HTTP endpoints (admin-authenticated — reuse the platform-admin
-identity already in the codebase, `model.IsPlatformAdmin` / the admin console's
-auth; the exact middleware is a plan detail):
+New routes on an **internal-only HTTP listener** in portal (separate from the
+public discovery server, so no privileged write shares the browser-facing
+surface), gated by the ops-token middleware:
 
-- `GET /api/v1/failover` — list every site's `FailoverState` (admin console view
-  + operational dashboard source). Read-only.
-- `GET /api/v1/failover/{siteId}` — one site's state.
-- `POST /api/v1/failover/{siteId}` — operator action, body
-  `{ "action": "failover" | "failback" | "hold" | "release", "reason": "..." }`:
-  - `failover` → set `override=force_failover`, `status=failed_over`,
-    `actor=<admin>`.
-  - `hold` → `override=hold_healthy` (block auto-failover; maintenance).
-  - `release` → `override=none` (re-arm the detector).
-  - `failback` → `status=failing_back`, begin the SP5 drain; the terminal flip to
-    `healthy` is completed by SP5's lag≈0 report, not this call.
+- `GET  /internal/v1/failover` — list every site's `FailoverState`.
+- `GET  /internal/v1/failover/:siteId` — one site's state.
+- `POST /internal/v1/failover/:siteId` — body
+  `{ "action": "failover"|"failback"|"complete"|"resume", "operator": "...", "reason": "..." }`.
 
-Every write is CAS-guarded on `version` (§6) so a stale admin UI or a racing
-detector cannot clobber a newer transition; a losing writer gets a `409 conflict`
-(`errcode.Conflict`) and re-reads. All actions are audit-logged (`actor`,
-`reason`, from/to status) via structured `slog` — never the operator's
-credentials, per CLAUDE.md logging rules.
+Each write validates the transition against §4, CAS-updates on `version`, and
+records `operator`/`reason`/`since`/`timestamp`. A stale-`version` write (racing
+replica or stale client) returns `409 conflict` (`errcode.Conflict`) and the
+caller re-reads. All actions are audit-logged via structured `slog` (from/to
+status, `operator`, `reason`) — never the token, per CLAUDE.md logging rules.
 
-## 6. Split-brain fence — sole writer, CAS, multi-replica
+## 6. Read path (the signal SP3 consumes)
 
-The design leans the entire split-brain guarantee on portal being the sole
-routing authority (§4.2, §9). This slice makes that concrete:
+A `FailoverReader` exposing `ServingTarget(ctx, siteID) → home|backup`, backed by
+the store behind a **short TTL cache** (`FAILOVER_STATE_TTL`, default a few
+seconds): long enough to shield Mongo from per-login reads, short enough that a
+flip propagates to routing within seconds. This is **separate** from portal's 24h
+directory cache and must not be merged into it.
 
-- **Single source of truth:** the `FailoverState` document is the *only* place a
-  site's serving target is decided. A site is `home` xor `backup`, never both,
-  because `servingTarget` is derived from one `status` field on one document.
-- **Sole writer, CAS-guarded:** only portal writes it, and every transition is a
-  Mongo conditional update on `version` (optimistic concurrency). With multiple
-  portal replicas each running the detector, concurrent identical transitions are
-  idempotent and a divergent one loses the CAS and re-reads — no leader election
-  required for correctness (a single-flight/leader detector is an optional
-  efficiency, §9, not a correctness need).
-- **Read path freshness:** SP3 reads `FailoverState` behind a **short TTL cache**
-  (`FAILOVER_STATE_TTL`, default a few seconds) — long enough to shield Mongo
-  from per-login reads, short enough that a failover propagates to routing within
-  seconds. This is a *different* cache from the 24h directory cache and must not
-  be conflated with it.
-- **Fail-safe default:** if the state document is missing or unreadable, the
-  derived target is **`home`** (fail toward normal routing) — an unreachable
-  failover store must not itself trigger or freeze a failover.
+**Fail-safe = `home`.** A missing/unreadable state derives `home` (normal
+routing) — an unreachable failover store must never strand a healthy site's users
+on the backup. SP4 builds this reader; SP3 wires it into `resolve()`.
 
-## 7. Failback interaction (the SP5 boundary)
+## 7. Split-brain fence — sole writer, CAS, multi-replica
 
-SP4 owns the *state transitions* around failback; SP5 owns the *data work*:
+- **Single source of truth:** one `FailoverState` document per site; `servingTarget`
+  is single-valued, so a site is `home` xor `backup`, never both.
+- **Sole writer, CAS-guarded:** only portal writes it, each transition a Mongo
+  conditional update on `version`. Multiple portal replicas stay correct without
+  leader election — concurrent identical transitions are idempotent, a divergent
+  one loses the CAS and re-reads.
 
-- The operator (or, later, automation) moves `failed_over → failing_back` via the
-  control surface. `servingTarget` **stays `backup`** through `failing_back` —
-  users keep writing to a stable backup while SP5 drains the outage log home
-  (design §6.3 steps 1–4).
-- SP5 replays + verifies convergence and reports **lag≈0**; on that signal the
-  terminal `failing_back → healthy` flip runs (atomic, CAS-guarded), `servingTarget`
-  flips to `home`, and clients reconnect home via the existing reconnect-self-heal
-  path (§6.3 step 5). SP4 exposes the transition + the lag-gate hook; **SP5 owns
-  the replay, the lag measurement, and the convergence diff.**
-- The lag signal itself is the per-site replication-lag monitor (design §8, open
-  q §11.8, SP6). SP4 *reads* it to gate the flip; it does not build it.
+## 8. Forward-compatibility to the option-3 console (later)
 
-## 8. Testing (TDD, per CLAUDE.md §4)
+A per-operator login + failover console UI is a planned follow-up. This slice is
+shaped so that lands as an extension, not a rewrite:
 
-- **Unit — state machine:** table-driven transition tests (every legal edge;
-  illegal edges rejected; `hold_healthy` blocks auto-promotion; `force_failover`
-  jumps regardless of probe; `servingTarget` derivation for each status; CAS
-  version bump on each write; stale-version write → conflict).
-- **Unit — detector:** with an injected clock and a mock prober, assert M-of-N +
-  dwell before `suspected`; a single blip does not transition; `AUTO_FAILOVER`
-  off leaves promotion to the operator; on with dwell promotes; `hold_healthy`
-  still blocks. Probe function is an injected interface (no real NATS/HTTP).
-- **Unit — control surface:** each action → correct transition + audit fields;
-  non-admin → `403`; unknown action → `400`; CAS conflict → `409`; reason/actor
-  recorded, credentials never logged.
-- **Integration** (`//go:build integration`, `testutil.MongoDB`) — `FailoverStore`
-  round-trips; concurrent CAS writes (two goroutines) — exactly one wins, the
-  other re-reads; TTL-cached read reflects a write within the TTL; missing
-  document derives `home`.
-- **Coverage** — ≥80% floor; ≥90% on the state machine + detector logic.
+- **Auth is a Gin middleware seam** (`requireOps`), mirroring admin-service's
+  `requireAdmin`. Option 3 swaps in session-based platform-admin auth by replacing
+  the middleware — handlers and state machine untouched.
+- **Endpoint contract stays stable**, so a future console calls the same routes.
+- **`operator` stays in the model** — self-asserted now, session-derived once real
+  login exists; the audit schema does not change.
 
-## 9. Open sub-decisions (call out in the plan)
+## 9. Config (`caarlos0/env`)
 
-1. **`AUTO_FAILOVER` default & dwell.** *Leaning: default off* (advisory alert +
-   operator confirm) for the first production cut; enable per-deployment once the
-   probe's false-positive rate is understood. Dwell/sample tunables land in the
-   plan with defaults.
-2. **Detector run shape across replicas** — every-replica-with-CAS (correct,
-   simplest) vs. a single leader (fewer redundant probes). *Leaning:
-   every-replica-with-CAS*; revisit only if probe volume matters.
-3. **Backup-site coordinates in the registry** — how `servingTarget=backup`
-   resolves to URLs: a reserved backup entry in `PORTAL_SITE_URLS` vs. a dedicated
-   `PORTAL_BACKUP_SITE_URLS`. Decided in SP3 (the consumer); noted here because the
-   signal references it.
-4. **Admin auth middleware** — exact gating for the control surface (platform-
-   admin session vs. a dedicated ops credential). A plan detail; must be an
-   existing pattern, not a new auth scheme.
-5. **Alert transport** — `slog`+metric only vs. also a direct pager hook.
-   *Leaning: structured signal only*; paging is an ops/SP6 wiring concern off the
-   o11y metrics.
+| Env | Default | Notes |
+|-----|---------|-------|
+| `FAILOVER_OPS_TOKEN` | — | required to enable the control surface; the break-glass ops secret |
+| `FAILOVER_INTERNAL_ADDR` | `:8090` | internal listener for the control routes |
+| `FAILOVER_STATE_TTL` | `5s` | read-path cache TTL |
 
-## 10. Out of scope (explicit — each its own slice)
+Portal already holds a Mongo handle (the directory store), so the collection
+lives there; no new datastore.
 
-- **SP3** — the routing override itself (`resolve()` returning backup coordinates
-  when `servingTarget=backup`), the backup-URL registry entry, and the
-  reconnect-nudge to displaced clients. SP4 only produces the signal.
-- **SP5** — failback replay, convergence diff, and the lag measurement SP4's flip
-  gates on.
-- **SP2** — JWT minting on the backup.
-- **SP6 — ops/IaC:** the per-site replication-lag monitor SP4 reads, alert paging
-  wiring, and the backup's deployment.
+## 10. Testing (TDD, per CLAUDE.md §4)
+
+- **Unit — state machine:** table-driven over every legal edge; illegal edges
+  rejected; `servingTarget` derivation per status; CAS version bump per write;
+  stale-version → conflict.
+- **Unit — control surface:** missing/blank token → 401; wrong token → 403; each
+  action drives the correct transition + audit fields; unknown action → 400; CAS
+  conflict → 409; token never logged.
+- **Unit — reader:** TTL cache returns cached value within the window and refreshes
+  after; missing document → `home` (fail-safe).
+- **Integration** (`//go:build integration`, `testutil.MongoDB`): `FailoverStore`
+  round-trip; two concurrent CAS writers — exactly one wins, the other re-reads;
+  TTL-cached read reflects a write after the TTL.
+- **Coverage** — ≥80% floor; ≥90% on the state machine + control-surface logic.
+
+## 11. Out of scope (each its own slice)
+
+- **Auto-detection / health probe / alerting** — deferred; a later additive slice
+  that writes an advisory status + fires an alert, never flips state.
+- **SP3** — the routing override (`resolve()` returning backup coordinates), the
+  backup-URL registry entry, and reconnect nudging. SP4 only produces the signal.
+- **SP5** — failback replay, convergence, and gating `complete` on lag≈0.
+- **UI + per-operator login** — the option-3 console follow-up (§8).
+- **SP6 — ops/IaC:** the internal listener's network exposure, the ops-token
+  secret provisioning, and the backup deployment.
+
+## 12. Open sub-decisions (call out in the plan)
+
+1. **Internal listener mechanism** — a separate `http.Server` on
+   `FAILOVER_INTERNAL_ADDR` (clean separation, this spec's lean) vs. a route group
+   on the main server protected by network policy. Plan-level call.
+2. **`complete` in this slice** — expose it as a manual operator action now (so
+   failback is operable end-to-end pre-SP5), confirmed above; SP5 later becomes the
+   actor that gates and calls it. No schema change when that happens.

--- a/docs/superpowers/specs/2026-08-11-sp4-failover-trigger-health-detection.md
+++ b/docs/superpowers/specs/2026-08-11-sp4-failover-trigger-health-detection.md
@@ -1,0 +1,266 @@
+# SP4 (core) — Failover trigger: health detection & operator control surface
+
+> **Scope discipline.** This slice resolves design open-question §11.3: **how a
+> site is declared down** (auto-detection + manual override) and **the control
+> surface** an operator drives it from. Its load-bearing output is the
+> **failover-state signal** that SP3 (the routing brain) consumes — so this spec
+> is deliberately precise about that signal's shape and authority, and defers the
+> routing *use* of it to SP3. Everything downstream — the actual reroute in
+> `resolve()` (SP3), the failback replay (SP5) — is out of scope.
+>
+> - **Governing design:** `docs/superpowers/specs/2026-07-28-cross-site-failover-design.md` (§3 "Failover trigger" knob, §4.2, §6.3, §11.3)
+> - **Roadmap:** `docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md` (SP4 — "feeds SP3")
+> - **Consumer:** SP3 (portal health-aware routing override); **hands off to:** SP5 (failback).
+
+## 1. Goal
+
+Give `portal-service` — already the routing brain and the design's designated
+**split-brain fence** (§4.2) — an authoritative, per-site answer to *"is this
+site being served from home or from the backup right now, and who decided
+that?"*, and the operator controls to drive it. Concretely:
+
+1. A **persistent, portal-owned failover-state record** per site, whose derived
+   `ServingTarget` (home | backup) is the single fact SP3 reads to route.
+2. **Auto-detection** that watches each site's reachability and *proposes* a
+   failover, conservatively (multi-sample + dwell, flap-resistant).
+3. A **manual operator control surface** (portal-owned, admin-gated) that is
+   **always authoritative** over the automation: force a failover, hold a site
+   healthy (maintenance), or initiate failback.
+
+This is the design's stated knob — "automatic health-detection with a manual
+operator override" (§3). This slice **does not** reroute traffic (SP3), does not
+replay outage writes (SP5), and does not mint JWTs (SP2). It produces and governs
+the *state*; SP3 acts on it.
+
+## 2. Decision — a portal-owned failover-state machine; auto-detection proposes, the operator disposes
+
+Three moves, in priority of what unblocks SP3:
+
+**(a) The signal is a Mongo-backed per-site `FailoverState` record, portal is its
+sole writer.** Portal already owns a Mongo connection (the directory store's live
+`GetByAccount` fallback) and is the single routing authority, so co-locating the
+failover state there keeps the fence in one place. It must be **persistent**
+(survive portal restart) and **shared across portal replicas** — ruling out the
+in-memory directory-cache pattern. SP3 reads it on the routing path via a short
+TTL cache (seconds, §6), *not* the 24h directory refresh, so a failover takes
+effect promptly.
+
+**(b) Detection is conservative and, by default, advisory.** A probe loop marks a
+site `suspected` on sustained unreachability and **alerts**, but the
+reroute-causing transition to `failed_over` is **operator-confirmed by default**.
+Fully-automatic promotion is a **config-gated maturity step** (`AUTO_FAILOVER`,
+default off) with a dwell window — because a false-positive failover is
+expensive (needless failover + a full failback protocol) and, if the automation
+and an operator disagree, split-brain-adjacent. Portal sees the world from **one
+vantage point**, so it cannot by itself distinguish "site A is down" from "portal
+can't reach site A"; operator-confirm (or an external-monitor feed, §4) is the
+safe resolution of that ambiguity for v1.
+
+**(c) Manual override always wins.** An operator action (`force_failover`,
+`hold_healthy`, `failback`) sets an override that the auto-detector must respect —
+it can never auto-flip a site the operator has pinned, nor auto-fail-back one the
+operator forced over.
+
+### 2.1 Approaches considered (detection mechanism)
+
+- **A — portal active-probe + operator-confirm, external-monitor feed optional
+  (CHOSEN).** Portal probes each site's user-facing reachability; sustained
+  failure ⇒ `suspected` + alert; operator confirms (or `AUTO_FAILOVER` promotes
+  after dwell). Reuses portal's existing loop shape; keeps the fence and the
+  decision in one authority; conservative by construction. Optional: consume an
+  external monitor's verdict (below) as a corroborating signal.
+- **B — external monitoring drives it end-to-end** (Prometheus/Alertmanager or
+  k8s health flips the state; portal only reads). Decouples detection from
+  portal's single vantage point (multiple probers, battle-tested), but moves the
+  *trigger* authority outside the split-brain fence and couples DR to a specific
+  monitoring stack this repo doesn't standardize. Kept as the corroborating feed
+  in A, not the sole authority.
+- **C — sites heartbeat to portal** (absence ⇒ down). Symmetric to probing and
+  same partition ambiguity, but a site that is *up but can't reach portal* looks
+  down — a worse failure mode than A. Rejected.
+- **D — manual-only** (no automation, operator declares every outage). Simplest
+  and safest against false positives, but RTO becomes "time until a human
+  notices." Rejected as the *only* mechanism; retained as the effective default
+  behavior when `AUTO_FAILOVER` is off (auto-detect still alerts, human still
+  acts — but faster, because the alert fires).
+
+## 3. The `FailoverState` signal (the load-bearing SP3 contract)
+
+One document per active site (`_id = siteID`). This is the artifact SP3 is
+blocked on; it is defined here in full.
+
+| Field | Type | Meaning |
+|------|------|---------|
+| `siteId` | string (`_id`) | the active site this state governs |
+| `status` | enum | `healthy` \| `suspected` \| `failed_over` \| `failing_back` |
+| `override` | enum | `none` \| `force_failover` \| `hold_healthy` \| `force_failback` — operator lock the detector must honor |
+| `servingTarget` | enum (derived) | `home` unless `status ∈ {failed_over, failing_back}` → `backup` |
+| `reason` | string | free-text (operator note or detector cause, e.g. `nats_unreachable`) |
+| `actor` | string | `auto` or the admin account that made the last transition |
+| `since` | int64 (ms) | when the current `status` began (for RTO/observability) |
+| `version` | int64 | optimistic-concurrency guard for the sole-writer CAS (§6) |
+| `timestamp` | int64 (ms) | event-level publish time, per CLAUDE.md "Event Timestamps" |
+
+**`servingTarget` is the entire SP3 contract.** SP3's `resolve()` computes: read
+the account's home `siteID`, look up its `FailoverState`; if `servingTarget ==
+backup`, return the **backup** site's coordinates from the registry instead of
+the home site's; else unchanged. Nothing else about SP4's internals leaks into
+SP3 — a clean, single-field seam.
+
+State machine (portal is the only writer; every edge is CAS-guarded on `version`):
+
+```
+                 detector: sustained-unreachable + dwell
+   healthy ─────────────────────────────────────────────► suspected
+      ▲                                                        │
+      │ operator failback done / detector: recovered           │ operator confirm
+      │ (servingTarget flips home)                             │ OR AUTO_FAILOVER+dwell
+      │                                                        ▼
+  failing_back ◄───────────── operator: begin failback ─── failed_over
+   (still served from backup;                              (served from backup)
+    SP5 drains; flip on lag≈0)
+```
+
+- `hold_healthy` override pins `healthy` and blocks the `healthy→suspected→
+  failed_over` path (maintenance windows, known-flaky links).
+- `force_failover` jumps to `failed_over` regardless of probe state (operator
+  knows the site is down before the probe agrees).
+- `force_failback` / "begin failback" moves `failed_over → failing_back`; the
+  terminal `failing_back → healthy` flip is **gated on SP5 reporting lag≈0** and
+  is the atomic split-brain-safe cutover (§7).
+
+## 4. Detection mechanism — what portal probes, and how it avoids flapping
+
+- **Probe target = user-serviceability, not liveness.** A site is "servable" iff
+  a displaced-nothing user could actually connect and mint: its **NATS is
+  reachable** (the client connect target) **and its `auth-service` is healthy**
+  (JWT minting). Portal probes the site's NATS monitoring `/healthz`
+  (JetStream-enabled check) and `auth-service` `/healthz` on an interval. These
+  two being up is the closest cheap proxy for "users can be served from home";
+  deeper datastore health is the site's own concern and, if broken, surfaces as
+  serving failures the operator escalates.
+- **Flap resistance:** require **M consecutive failed samples over a dwell
+  window** (config: `FAILOVER_PROBE_INTERVAL`, `FAILOVER_UNHEALTHY_SAMPLES`,
+  `FAILOVER_DWELL`) before `healthy → suspected`; require a symmetric healthy
+  streak before the detector proposes recovery. No single blip moves state.
+- **Advisory vs. auto:** on reaching the unhealthy threshold, always write
+  `suspected` + emit a high-severity alert (structured `slog` + the o11y metric
+  path). Promotion `suspected → failed_over` happens **only** on operator confirm,
+  **unless** `AUTO_FAILOVER=true`, in which case a further auto-dwell promotes it —
+  and even then `hold_healthy` blocks it.
+- **Corroboration (optional):** an external monitor may `POST` its own verdict
+  into the control surface (§5) as a second signal; portal records it in `reason`
+  but the state machine and CAS remain portal's.
+
+## 5. Manual-override control surface (portal-owned, admin-gated)
+
+New portal HTTP endpoints (admin-authenticated — reuse the platform-admin
+identity already in the codebase, `model.IsPlatformAdmin` / the admin console's
+auth; the exact middleware is a plan detail):
+
+- `GET /api/v1/failover` — list every site's `FailoverState` (admin console view
+  + operational dashboard source). Read-only.
+- `GET /api/v1/failover/{siteId}` — one site's state.
+- `POST /api/v1/failover/{siteId}` — operator action, body
+  `{ "action": "failover" | "failback" | "hold" | "release", "reason": "..." }`:
+  - `failover` → set `override=force_failover`, `status=failed_over`,
+    `actor=<admin>`.
+  - `hold` → `override=hold_healthy` (block auto-failover; maintenance).
+  - `release` → `override=none` (re-arm the detector).
+  - `failback` → `status=failing_back`, begin the SP5 drain; the terminal flip to
+    `healthy` is completed by SP5's lag≈0 report, not this call.
+
+Every write is CAS-guarded on `version` (§6) so a stale admin UI or a racing
+detector cannot clobber a newer transition; a losing writer gets a `409 conflict`
+(`errcode.Conflict`) and re-reads. All actions are audit-logged (`actor`,
+`reason`, from/to status) via structured `slog` — never the operator's
+credentials, per CLAUDE.md logging rules.
+
+## 6. Split-brain fence — sole writer, CAS, multi-replica
+
+The design leans the entire split-brain guarantee on portal being the sole
+routing authority (§4.2, §9). This slice makes that concrete:
+
+- **Single source of truth:** the `FailoverState` document is the *only* place a
+  site's serving target is decided. A site is `home` xor `backup`, never both,
+  because `servingTarget` is derived from one `status` field on one document.
+- **Sole writer, CAS-guarded:** only portal writes it, and every transition is a
+  Mongo conditional update on `version` (optimistic concurrency). With multiple
+  portal replicas each running the detector, concurrent identical transitions are
+  idempotent and a divergent one loses the CAS and re-reads — no leader election
+  required for correctness (a single-flight/leader detector is an optional
+  efficiency, §9, not a correctness need).
+- **Read path freshness:** SP3 reads `FailoverState` behind a **short TTL cache**
+  (`FAILOVER_STATE_TTL`, default a few seconds) — long enough to shield Mongo
+  from per-login reads, short enough that a failover propagates to routing within
+  seconds. This is a *different* cache from the 24h directory cache and must not
+  be conflated with it.
+- **Fail-safe default:** if the state document is missing or unreadable, the
+  derived target is **`home`** (fail toward normal routing) — an unreachable
+  failover store must not itself trigger or freeze a failover.
+
+## 7. Failback interaction (the SP5 boundary)
+
+SP4 owns the *state transitions* around failback; SP5 owns the *data work*:
+
+- The operator (or, later, automation) moves `failed_over → failing_back` via the
+  control surface. `servingTarget` **stays `backup`** through `failing_back` —
+  users keep writing to a stable backup while SP5 drains the outage log home
+  (design §6.3 steps 1–4).
+- SP5 replays + verifies convergence and reports **lag≈0**; on that signal the
+  terminal `failing_back → healthy` flip runs (atomic, CAS-guarded), `servingTarget`
+  flips to `home`, and clients reconnect home via the existing reconnect-self-heal
+  path (§6.3 step 5). SP4 exposes the transition + the lag-gate hook; **SP5 owns
+  the replay, the lag measurement, and the convergence diff.**
+- The lag signal itself is the per-site replication-lag monitor (design §8, open
+  q §11.8, SP6). SP4 *reads* it to gate the flip; it does not build it.
+
+## 8. Testing (TDD, per CLAUDE.md §4)
+
+- **Unit — state machine:** table-driven transition tests (every legal edge;
+  illegal edges rejected; `hold_healthy` blocks auto-promotion; `force_failover`
+  jumps regardless of probe; `servingTarget` derivation for each status; CAS
+  version bump on each write; stale-version write → conflict).
+- **Unit — detector:** with an injected clock and a mock prober, assert M-of-N +
+  dwell before `suspected`; a single blip does not transition; `AUTO_FAILOVER`
+  off leaves promotion to the operator; on with dwell promotes; `hold_healthy`
+  still blocks. Probe function is an injected interface (no real NATS/HTTP).
+- **Unit — control surface:** each action → correct transition + audit fields;
+  non-admin → `403`; unknown action → `400`; CAS conflict → `409`; reason/actor
+  recorded, credentials never logged.
+- **Integration** (`//go:build integration`, `testutil.MongoDB`) — `FailoverStore`
+  round-trips; concurrent CAS writes (two goroutines) — exactly one wins, the
+  other re-reads; TTL-cached read reflects a write within the TTL; missing
+  document derives `home`.
+- **Coverage** — ≥80% floor; ≥90% on the state machine + detector logic.
+
+## 9. Open sub-decisions (call out in the plan)
+
+1. **`AUTO_FAILOVER` default & dwell.** *Leaning: default off* (advisory alert +
+   operator confirm) for the first production cut; enable per-deployment once the
+   probe's false-positive rate is understood. Dwell/sample tunables land in the
+   plan with defaults.
+2. **Detector run shape across replicas** — every-replica-with-CAS (correct,
+   simplest) vs. a single leader (fewer redundant probes). *Leaning:
+   every-replica-with-CAS*; revisit only if probe volume matters.
+3. **Backup-site coordinates in the registry** — how `servingTarget=backup`
+   resolves to URLs: a reserved backup entry in `PORTAL_SITE_URLS` vs. a dedicated
+   `PORTAL_BACKUP_SITE_URLS`. Decided in SP3 (the consumer); noted here because the
+   signal references it.
+4. **Admin auth middleware** — exact gating for the control surface (platform-
+   admin session vs. a dedicated ops credential). A plan detail; must be an
+   existing pattern, not a new auth scheme.
+5. **Alert transport** — `slog`+metric only vs. also a direct pager hook.
+   *Leaning: structured signal only*; paging is an ops/SP6 wiring concern off the
+   o11y metrics.
+
+## 10. Out of scope (explicit — each its own slice)
+
+- **SP3** — the routing override itself (`resolve()` returning backup coordinates
+  when `servingTarget=backup`), the backup-URL registry entry, and the
+  reconnect-nudge to displaced clients. SP4 only produces the signal.
+- **SP5** — failback replay, convergence diff, and the lag measurement SP4's flip
+  gates on.
+- **SP2** — JWT minting on the backup.
+- **SP6 — ops/IaC:** the per-site replication-lag monitor SP4 reads, alert paging
+  wiring, and the backup's deployment.

--- a/pkg/errcode/codes_portal.go
+++ b/pkg/errcode/codes_portal.go
@@ -6,4 +6,6 @@ const (
 	PortalAccountNotReady Reason = "account_not_ready"
 	// PortalBotLoginDisabled: portal /api/v1/login rejects a bot-role login because BOT_LOGIN_ENABLED=false.
 	PortalBotLoginDisabled Reason = "bot_login_disabled"
+	// PortalFailoverUnauthorized: the failover control surface rejected a request whose ops bearer token was missing or wrong.
+	PortalFailoverUnauthorized Reason = "failover_unauthorized"
 )

--- a/pkg/errcode/codes_portal.go
+++ b/pkg/errcode/codes_portal.go
@@ -8,4 +8,8 @@ const (
 	PortalBotLoginDisabled Reason = "bot_login_disabled"
 	// PortalFailoverUnauthorized: the failover control surface rejected a request whose ops bearer token was missing or wrong.
 	PortalFailoverUnauthorized Reason = "failover_unauthorized"
+	// PortalFailoverIllegalTransition: the requested failover action is not valid from the site's current status.
+	PortalFailoverIllegalTransition Reason = "failover_illegal_transition"
+	// PortalFailoverVersionConflict: the failover state changed concurrently (optimistic-concurrency CAS lost); retry.
+	PortalFailoverVersionConflict Reason = "failover_version_conflict"
 )

--- a/portal-service/deploy/docker-compose.yml
+++ b/portal-service/deploy/docker-compose.yml
@@ -37,6 +37,10 @@ services:
       - PORTAL_OTEL_BASE_URL=http://localhost:4318/v1
       - MONGO_URI=mongodb://mongodb:27017
       - MONGO_DB=chat
+      # Operator failover control surface (SP4). Dev-only token — never a real
+      # secret. Bound on an internal-only listener, off the public :8085 API.
+      - FAILOVER_OPS_TOKEN=dev-failover-token
+      - FAILOVER_INTERNAL_ADDR=:8090
     networks:
       - chat-local
 

--- a/portal-service/failover.go
+++ b/portal-service/failover.go
@@ -1,0 +1,109 @@
+package main
+
+import "errors"
+
+// FailoverStatus is a site's operator-driven failover lifecycle state.
+type FailoverStatus string
+
+const (
+	StatusHealthy     FailoverStatus = "healthy"
+	StatusFailedOver  FailoverStatus = "failed_over"
+	StatusFailingBack FailoverStatus = "failing_back"
+)
+
+// ServingTarget says where a site's users are served from right now. It is the
+// entire contract SP3's routing override consumes.
+type ServingTarget string
+
+const (
+	ServingHome   ServingTarget = "home"
+	ServingBackup ServingTarget = "backup"
+)
+
+// FailoverAction is an operator-requested transition.
+type FailoverAction string
+
+const (
+	ActionFailover FailoverAction = "failover" // healthy      -> failed_over
+	ActionFailback FailoverAction = "failback" // failed_over  -> failing_back
+	ActionComplete FailoverAction = "complete" // failing_back -> healthy
+	ActionResume   FailoverAction = "resume"   // failed_over  -> healthy (false alarm)
+)
+
+// errIllegalTransition is returned when an action is not valid from the current
+// status. errFailoverVersionConflict is returned by the store when an optimistic
+// CAS loses a race. Both are matched with errors.Is at the HTTP boundary.
+var (
+	errIllegalTransition       = errors.New("illegal failover transition")
+	errFailoverVersionConflict = errors.New("failover state version conflict")
+)
+
+// FailoverState is the sole authoritative record of a site's serving target.
+// One document per site, _id = siteID. version is the optimistic-concurrency
+// guard for the sole-writer CAS.
+type FailoverState struct {
+	SiteID    string         `json:"siteId"    bson:"_id"`
+	Status    FailoverStatus `json:"status"    bson:"status"`
+	Reason    string         `json:"reason"    bson:"reason"`
+	Operator  string         `json:"operator"  bson:"operator"`
+	Since     int64          `json:"since"     bson:"since"`
+	Version   int64          `json:"version"   bson:"version"`
+	Timestamp int64          `json:"timestamp" bson:"timestamp"`
+}
+
+// ServingTarget derives where this site is served from. Any status other than
+// failed_over/failing_back (including an unknown value) is home — the fail-safe.
+func (s FailoverState) ServingTarget() ServingTarget {
+	switch s.Status {
+	case StatusFailedOver, StatusFailingBack:
+		return ServingBackup
+	default:
+		return ServingHome
+	}
+}
+
+// isKnownAction reports whether a is one of the four defined actions.
+func isKnownAction(a FailoverAction) bool {
+	switch a {
+	case ActionFailover, ActionFailback, ActionComplete, ActionResume:
+		return true
+	default:
+		return false
+	}
+}
+
+// nextStatus returns the status resulting from applying action to cur, or
+// errIllegalTransition if the action is not valid from cur.
+func nextStatus(cur FailoverStatus, action FailoverAction) (FailoverStatus, error) {
+	switch {
+	case cur == StatusHealthy && action == ActionFailover:
+		return StatusFailedOver, nil
+	case cur == StatusFailedOver && action == ActionFailback:
+		return StatusFailingBack, nil
+	case cur == StatusFailedOver && action == ActionResume:
+		return StatusHealthy, nil
+	case cur == StatusFailingBack && action == ActionComplete:
+		return StatusHealthy, nil
+	default:
+		return "", errIllegalTransition
+	}
+}
+
+// applyAction computes the next FailoverState for an operator action. It bumps
+// version by 1 and stamps operator/reason/since/timestamp. It does not persist —
+// the caller CAS-writes the result via FailoverStore.Transition.
+func applyAction(cur FailoverState, action FailoverAction, operator, reason string, nowMs int64) (FailoverState, error) {
+	ns, err := nextStatus(cur.Status, action)
+	if err != nil {
+		return FailoverState{}, err
+	}
+	return FailoverState{
+		SiteID:    cur.SiteID,
+		Status:    ns,
+		Reason:    reason,
+		Operator:  operator,
+		Since:     nowMs,
+		Version:   cur.Version + 1,
+		Timestamp: nowMs,
+	}, nil
+}

--- a/portal-service/failover.go
+++ b/portal-service/failover.go
@@ -53,7 +53,7 @@ type FailoverState struct {
 
 // ServingTarget derives where this site is served from. Any status other than
 // failed_over/failing_back (including an unknown value) is home — the fail-safe.
-func (s FailoverState) ServingTarget() ServingTarget {
+func (s *FailoverState) ServingTarget() ServingTarget {
 	switch s.Status {
 	case StatusFailedOver, StatusFailingBack:
 		return ServingBackup
@@ -92,7 +92,7 @@ func nextStatus(cur FailoverStatus, action FailoverAction) (FailoverStatus, erro
 // applyAction computes the next FailoverState for an operator action. It bumps
 // version by 1 and stamps operator/reason/since/timestamp. It does not persist —
 // the caller CAS-writes the result via FailoverStore.Transition.
-func applyAction(cur FailoverState, action FailoverAction, operator, reason string, nowMs int64) (FailoverState, error) {
+func applyAction(cur *FailoverState, action FailoverAction, operator, reason string, nowMs int64) (FailoverState, error) {
 	ns, err := nextStatus(cur.Status, action)
 	if err != nil {
 		return FailoverState{}, err

--- a/portal-service/failover_handler.go
+++ b/portal-service/failover_handler.go
@@ -45,7 +45,7 @@ type failoverStateResponse struct {
 	Timestamp     int64          `json:"timestamp"`
 }
 
-func toResponse(s FailoverState) failoverStateResponse {
+func toResponse(s *FailoverState) failoverStateResponse {
 	return failoverStateResponse{
 		SiteID:        s.SiteID,
 		Status:        s.Status,
@@ -67,8 +67,8 @@ func (h *FailoverHandler) List(c *gin.Context) {
 		return
 	}
 	out := make([]failoverStateResponse, 0, len(states))
-	for _, s := range states {
-		out = append(out, toResponse(s))
+	for i := range states {
+		out = append(out, toResponse(&states[i]))
 	}
 	c.JSON(http.StatusOK, out)
 }
@@ -82,7 +82,7 @@ func (h *FailoverHandler) Get(c *gin.Context) {
 		errhttp.Write(ctx, c, fmt.Errorf("get failover state: %w", err))
 		return
 	}
-	c.JSON(http.StatusOK, toResponse(st))
+	c.JSON(http.StatusOK, toResponse(&st))
 }
 
 // Post applies an operator transition to a site's failover state.
@@ -113,7 +113,7 @@ func (h *FailoverHandler) Post(c *gin.Context) {
 	}
 
 	nowMs := h.now().UTC().UnixMilli()
-	next, err := applyAction(cur, req.Action, req.Operator, req.Reason, nowMs)
+	next, err := applyAction(&cur, req.Action, req.Operator, req.Reason, nowMs)
 	if err != nil {
 		errhttp.Write(ctx, c, errcode.Conflict(
 			fmt.Sprintf("action %q not allowed from status %q", req.Action, cur.Status),
@@ -121,7 +121,7 @@ func (h *FailoverHandler) Post(c *gin.Context) {
 		return
 	}
 
-	if err := h.store.Transition(ctx, next); err != nil {
+	if err := h.store.Transition(ctx, &next); err != nil {
 		if errors.Is(err, errFailoverVersionConflict) {
 			errhttp.Write(ctx, c, errcode.Conflict("failover state changed concurrently, retry",
 				errcode.WithReason(errcode.PortalFailoverVersionConflict)))
@@ -134,7 +134,7 @@ func (h *FailoverHandler) Post(c *gin.Context) {
 	slog.InfoContext(ctx, "failover transition",
 		"siteId", siteID, "from", cur.Status, "to", next.Status,
 		"operator", req.Operator, "reason", req.Reason, "version", next.Version)
-	c.JSON(http.StatusOK, toResponse(next))
+	c.JSON(http.StatusOK, toResponse(&next))
 }
 
 // registerFailoverRoutes mounts the control surface behind the ops-token gate.

--- a/portal-service/failover_handler.go
+++ b/portal-service/failover_handler.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/errcode/errhttp"
+)
+
+// FailoverHandler serves the operator control surface over the internal
+// listener. It reads/writes FailoverState directly (operators need fresh state,
+// not a cached view). now is overridable in tests.
+type FailoverHandler struct {
+	store FailoverStore
+	now   func() time.Time
+}
+
+func NewFailoverHandler(store FailoverStore) *FailoverHandler {
+	return &FailoverHandler{store: store, now: time.Now}
+}
+
+// failoverActionRequest is the POST body: the operator-requested transition,
+// who requested it, and why (both required for the audit trail).
+type failoverActionRequest struct {
+	Action   FailoverAction `json:"action"`
+	Operator string         `json:"operator"`
+	Reason   string         `json:"reason"`
+}
+
+// failoverStateResponse is the wire shape, with the derived servingTarget added.
+type failoverStateResponse struct {
+	SiteID        string         `json:"siteId"`
+	Status        FailoverStatus `json:"status"`
+	ServingTarget ServingTarget  `json:"servingTarget"`
+	Reason        string         `json:"reason"`
+	Operator      string         `json:"operator"`
+	Since         int64          `json:"since"`
+	Version       int64          `json:"version"`
+	Timestamp     int64          `json:"timestamp"`
+}
+
+func toResponse(s FailoverState) failoverStateResponse {
+	return failoverStateResponse{
+		SiteID:        s.SiteID,
+		Status:        s.Status,
+		ServingTarget: s.ServingTarget(),
+		Reason:        s.Reason,
+		Operator:      s.Operator,
+		Since:         s.Since,
+		Version:       s.Version,
+		Timestamp:     s.Timestamp,
+	}
+}
+
+// List returns every site's failover state.
+func (h *FailoverHandler) List(c *gin.Context) {
+	ctx := errcode.WithLogValues(c.Request.Context(), "request_id", c.GetString("request_id"))
+	states, err := h.store.List(ctx)
+	if err != nil {
+		errhttp.Write(ctx, c, fmt.Errorf("list failover states: %w", err))
+		return
+	}
+	out := make([]failoverStateResponse, 0, len(states))
+	for _, s := range states {
+		out = append(out, toResponse(s))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+// Get returns one site's failover state (a healthy default for an unknown site).
+func (h *FailoverHandler) Get(c *gin.Context) {
+	ctx := errcode.WithLogValues(c.Request.Context(), "request_id", c.GetString("request_id"))
+	siteID := c.Param("siteId")
+	st, err := h.store.Get(ctx, siteID)
+	if err != nil {
+		errhttp.Write(ctx, c, fmt.Errorf("get failover state: %w", err))
+		return
+	}
+	c.JSON(http.StatusOK, toResponse(st))
+}
+
+// Post applies an operator transition to a site's failover state.
+func (h *FailoverHandler) Post(c *gin.Context) {
+	ctx := errcode.WithLogValues(c.Request.Context(), "request_id", c.GetString("request_id"))
+	siteID := c.Param("siteId")
+
+	var req failoverActionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errhttp.Write(ctx, c, errcode.BadRequest("invalid request body",
+			errcode.WithReason(errcode.AuthMissingFields)))
+		return
+	}
+	if req.Operator == "" || req.Reason == "" {
+		errhttp.Write(ctx, c, errcode.BadRequest("operator and reason are required",
+			errcode.WithReason(errcode.AuthMissingFields)))
+		return
+	}
+	if !isKnownAction(req.Action) {
+		errhttp.Write(ctx, c, errcode.BadRequest(fmt.Sprintf("unknown action %q", req.Action)))
+		return
+	}
+
+	cur, err := h.store.Get(ctx, siteID)
+	if err != nil {
+		errhttp.Write(ctx, c, fmt.Errorf("get failover state: %w", err))
+		return
+	}
+
+	nowMs := h.now().UTC().UnixMilli()
+	next, err := applyAction(cur, req.Action, req.Operator, req.Reason, nowMs)
+	if err != nil {
+		errhttp.Write(ctx, c, errcode.Conflict(
+			fmt.Sprintf("action %q not allowed from status %q", req.Action, cur.Status),
+			errcode.WithReason(errcode.PortalFailoverIllegalTransition)))
+		return
+	}
+
+	if err := h.store.Transition(ctx, next); err != nil {
+		if errors.Is(err, errFailoverVersionConflict) {
+			errhttp.Write(ctx, c, errcode.Conflict("failover state changed concurrently, retry",
+				errcode.WithReason(errcode.PortalFailoverVersionConflict)))
+			return
+		}
+		errhttp.Write(ctx, c, fmt.Errorf("transition failover state: %w", err))
+		return
+	}
+
+	slog.InfoContext(ctx, "failover transition",
+		"siteId", siteID, "from", cur.Status, "to", next.Status,
+		"operator", req.Operator, "reason", req.Reason, "version", next.Version)
+	c.JSON(http.StatusOK, toResponse(next))
+}
+
+// registerFailoverRoutes mounts the control surface behind the ops-token gate.
+func registerFailoverRoutes(r *gin.Engine, h *FailoverHandler, opsToken string) {
+	grp := r.Group("/internal/v1/failover", requireOps(opsToken))
+	grp.GET("", h.List)
+	grp.GET("/:siteId", h.Get)
+	grp.POST("/:siteId", h.Post)
+}

--- a/portal-service/failover_handler_test.go
+++ b/portal-service/failover_handler_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+const testOpsToken = "s3cr3t"
+
+// newFailoverTestServer wires the handler + routes with a mocked store and a
+// fixed clock, behind the real requireOps middleware.
+func newFailoverTestServer(t *testing.T) (*gin.Engine, *MockFailoverStore) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	store := NewMockFailoverStore(ctrl)
+	h := NewFailoverHandler(store)
+	h.now = func() time.Time { return time.UnixMilli(1700).UTC() }
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	registerFailoverRoutes(r, h, testOpsToken)
+	return r, store
+}
+
+func do(t *testing.T, r *gin.Engine, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+testOpsToken)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestFailoverHandler_List(t *testing.T) {
+	r, store := newFailoverTestServer(t)
+	store.EXPECT().List(gomock.Any()).Return([]FailoverState{
+		{SiteID: "site-a", Status: StatusFailedOver, Version: 1},
+	}, nil)
+
+	w := do(t, r, http.MethodGet, "/internal/v1/failover", "")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got []failoverStateResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "site-a", got[0].SiteID)
+	assert.Equal(t, ServingBackup, got[0].ServingTarget)
+}
+
+func TestFailoverHandler_Get(t *testing.T) {
+	r, store := newFailoverTestServer(t)
+	store.EXPECT().Get(gomock.Any(), "site-a").Return(
+		FailoverState{SiteID: "site-a", Status: StatusHealthy, Version: 0}, nil)
+
+	w := do(t, r, http.MethodGet, "/internal/v1/failover/site-a", "")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got failoverStateResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, StatusHealthy, got.Status)
+	assert.Equal(t, ServingHome, got.ServingTarget)
+}
+
+func TestFailoverHandler_PostFailoverHappyPath(t *testing.T) {
+	r, store := newFailoverTestServer(t)
+	store.EXPECT().Get(gomock.Any(), "site-a").Return(
+		FailoverState{SiteID: "site-a", Status: StatusHealthy, Version: 0}, nil)
+	store.EXPECT().Transition(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ any, next FailoverState) error {
+			assert.Equal(t, StatusFailedOver, next.Status)
+			assert.Equal(t, int64(1), next.Version)
+			assert.Equal(t, "jane", next.Operator)
+			assert.Equal(t, "nats down", next.Reason)
+			assert.Equal(t, int64(1700), next.Timestamp)
+			return nil
+		})
+
+	w := do(t, r, http.MethodPost, "/internal/v1/failover/site-a",
+		`{"action":"failover","operator":"jane","reason":"nats down"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var got failoverStateResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, StatusFailedOver, got.Status)
+	assert.Equal(t, ServingBackup, got.ServingTarget)
+}
+
+func TestFailoverHandler_PostIllegalTransition(t *testing.T) {
+	r, store := newFailoverTestServer(t)
+	store.EXPECT().Get(gomock.Any(), "site-a").Return(
+		FailoverState{SiteID: "site-a", Status: StatusFailedOver, Version: 1}, nil)
+	// No Transition call expected.
+
+	w := do(t, r, http.MethodPost, "/internal/v1/failover/site-a",
+		`{"action":"failover","operator":"jane","reason":"again"}`)
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), "failover_illegal_transition")
+}
+
+func TestFailoverHandler_PostVersionConflict(t *testing.T) {
+	r, store := newFailoverTestServer(t)
+	store.EXPECT().Get(gomock.Any(), "site-a").Return(
+		FailoverState{SiteID: "site-a", Status: StatusHealthy, Version: 0}, nil)
+	store.EXPECT().Transition(gomock.Any(), gomock.Any()).Return(errFailoverVersionConflict)
+
+	w := do(t, r, http.MethodPost, "/internal/v1/failover/site-a",
+		`{"action":"failover","operator":"jane","reason":"race"}`)
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), "failover_version_conflict")
+}
+
+func TestFailoverHandler_PostValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"missing operator", `{"action":"failover","reason":"x"}`},
+		{"missing reason", `{"action":"failover","operator":"jane"}`},
+		{"unknown action", `{"action":"nope","operator":"jane","reason":"x"}`},
+		{"malformed json", `{`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, _ := newFailoverTestServer(t) // no store calls expected
+			w := do(t, r, http.MethodPost, "/internal/v1/failover/site-a", tc.body)
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
+}
+
+func TestFailoverHandler_PostGetStoreError(t *testing.T) {
+	r, store := newFailoverTestServer(t)
+	store.EXPECT().Get(gomock.Any(), "site-a").Return(FailoverState{}, errors.New("mongo down"))
+
+	w := do(t, r, http.MethodPost, "/internal/v1/failover/site-a",
+		`{"action":"failover","operator":"jane","reason":"x"}`)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestFailoverHandler_Unauthorized(t *testing.T) {
+	r, _ := newFailoverTestServer(t)
+	// No auth header -> requireOps rejects before any handler runs.
+	req := httptest.NewRequest(http.MethodGet, "/internal/v1/failover", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/portal-service/failover_handler_test.go
+++ b/portal-service/failover_handler_test.go
@@ -76,7 +76,7 @@ func TestFailoverHandler_PostFailoverHappyPath(t *testing.T) {
 	store.EXPECT().Get(gomock.Any(), "site-a").Return(
 		FailoverState{SiteID: "site-a", Status: StatusHealthy, Version: 0}, nil)
 	store.EXPECT().Transition(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ any, next FailoverState) error {
+		func(_ any, next *FailoverState) error {
 			assert.Equal(t, StatusFailedOver, next.Status)
 			assert.Equal(t, int64(1), next.Version)
 			assert.Equal(t, "jane", next.Operator)
@@ -138,9 +138,36 @@ func TestFailoverHandler_PostValidation(t *testing.T) {
 	}
 }
 
+func TestFailoverHandler_ListStoreError(t *testing.T) {
+	r, store := newFailoverTestServer(t)
+	store.EXPECT().List(gomock.Any()).Return(nil, errors.New("mongo down"))
+
+	w := do(t, r, http.MethodGet, "/internal/v1/failover", "")
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestFailoverHandler_GetStoreError(t *testing.T) {
+	r, store := newFailoverTestServer(t)
+	store.EXPECT().Get(gomock.Any(), "site-a").Return(FailoverState{}, errors.New("mongo down"))
+
+	w := do(t, r, http.MethodGet, "/internal/v1/failover/site-a", "")
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
 func TestFailoverHandler_PostGetStoreError(t *testing.T) {
 	r, store := newFailoverTestServer(t)
 	store.EXPECT().Get(gomock.Any(), "site-a").Return(FailoverState{}, errors.New("mongo down"))
+
+	w := do(t, r, http.MethodPost, "/internal/v1/failover/site-a",
+		`{"action":"failover","operator":"jane","reason":"x"}`)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestFailoverHandler_PostTransitionStoreError(t *testing.T) {
+	r, store := newFailoverTestServer(t)
+	store.EXPECT().Get(gomock.Any(), "site-a").Return(
+		FailoverState{SiteID: "site-a", Status: StatusHealthy, Version: 0}, nil)
+	store.EXPECT().Transition(gomock.Any(), gomock.Any()).Return(errors.New("mongo down"))
 
 	w := do(t, r, http.MethodPost, "/internal/v1/failover/site-a",
 		`{"action":"failover","operator":"jane","reason":"x"}`)

--- a/portal-service/failover_integration_test.go
+++ b/portal-service/failover_integration_test.go
@@ -32,7 +32,7 @@ func TestMongoFailoverStore_TransitionInsertThenUpdate(t *testing.T) {
 
 	// First transition inserts version 1.
 	v1 := FailoverState{SiteID: "site-a", Status: StatusFailedOver, Operator: "jane", Reason: "down", Since: 100, Version: 1, Timestamp: 100}
-	require.NoError(t, store.Transition(ctx, v1))
+	require.NoError(t, store.Transition(ctx, &v1))
 
 	got, err := store.Get(ctx, "site-a")
 	require.NoError(t, err)
@@ -41,7 +41,7 @@ func TestMongoFailoverStore_TransitionInsertThenUpdate(t *testing.T) {
 
 	// Second transition CAS-updates to version 2.
 	v2 := FailoverState{SiteID: "site-a", Status: StatusFailingBack, Operator: "jane", Reason: "draining", Since: 200, Version: 2, Timestamp: 200}
-	require.NoError(t, store.Transition(ctx, v2))
+	require.NoError(t, store.Transition(ctx, &v2))
 	got, err = store.Get(ctx, "site-a")
 	require.NoError(t, err)
 	assert.Equal(t, StatusFailingBack, got.Status)
@@ -53,13 +53,13 @@ func TestMongoFailoverStore_TransitionStaleVersionConflicts(t *testing.T) {
 	store := newMongoFailoverStore(db)
 	ctx := context.Background()
 
-	require.NoError(t, store.Transition(ctx, FailoverState{SiteID: "site-b", Status: StatusFailedOver, Version: 1, Since: 1, Timestamp: 1}))
+	require.NoError(t, store.Transition(ctx, &FailoverState{SiteID: "site-b", Status: StatusFailedOver, Version: 1, Since: 1, Timestamp: 1}))
 	// Now at version 1. A second "version 1" insert (stale) must conflict.
-	err := store.Transition(ctx, FailoverState{SiteID: "site-b", Status: StatusFailedOver, Version: 1, Since: 2, Timestamp: 2})
+	err := store.Transition(ctx, &FailoverState{SiteID: "site-b", Status: StatusFailedOver, Version: 1, Since: 2, Timestamp: 2})
 	assert.ErrorIs(t, err, errFailoverVersionConflict)
 
 	// A version-3 update (skipping 2) finds no version-2 doc -> conflict.
-	err = store.Transition(ctx, FailoverState{SiteID: "site-b", Status: StatusHealthy, Version: 3, Since: 3, Timestamp: 3})
+	err = store.Transition(ctx, &FailoverState{SiteID: "site-b", Status: StatusHealthy, Version: 3, Since: 3, Timestamp: 3})
 	assert.ErrorIs(t, err, errFailoverVersionConflict)
 }
 
@@ -69,7 +69,7 @@ func TestMongoFailoverStore_ConcurrentCASOneWinner(t *testing.T) {
 	ctx := context.Background()
 
 	// Seed version 1.
-	require.NoError(t, store.Transition(ctx, FailoverState{SiteID: "site-c", Status: StatusFailedOver, Version: 1, Since: 1, Timestamp: 1}))
+	require.NoError(t, store.Transition(ctx, &FailoverState{SiteID: "site-c", Status: StatusFailedOver, Version: 1, Since: 1, Timestamp: 1}))
 
 	// Two goroutines both try to move version 1 -> 2. Exactly one wins.
 	var wg sync.WaitGroup
@@ -78,7 +78,7 @@ func TestMongoFailoverStore_ConcurrentCASOneWinner(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			errs[idx] = store.Transition(ctx, FailoverState{SiteID: "site-c", Status: StatusHealthy, Version: 2, Since: 2, Timestamp: 2})
+			errs[idx] = store.Transition(ctx, &FailoverState{SiteID: "site-c", Status: StatusHealthy, Version: 2, Since: 2, Timestamp: 2})
 		}(i)
 	}
 	wg.Wait()
@@ -102,8 +102,8 @@ func TestMongoFailoverStore_List(t *testing.T) {
 	store := newMongoFailoverStore(db)
 	ctx := context.Background()
 
-	require.NoError(t, store.Transition(ctx, FailoverState{SiteID: "site-x", Status: StatusFailedOver, Version: 1, Since: 1, Timestamp: 1}))
-	require.NoError(t, store.Transition(ctx, FailoverState{SiteID: "site-y", Status: StatusHealthy, Version: 1, Since: 1, Timestamp: 1}))
+	require.NoError(t, store.Transition(ctx, &FailoverState{SiteID: "site-x", Status: StatusFailedOver, Version: 1, Since: 1, Timestamp: 1}))
+	require.NoError(t, store.Transition(ctx, &FailoverState{SiteID: "site-y", Status: StatusHealthy, Version: 1, Since: 1, Timestamp: 1}))
 
 	all, err := store.List(ctx)
 	require.NoError(t, err)

--- a/portal-service/failover_integration_test.go
+++ b/portal-service/failover_integration_test.go
@@ -1,0 +1,116 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/testutil"
+)
+
+func TestMongoFailoverStore_GetDefaultsHealthy(t *testing.T) {
+	db := testutil.MongoDB(t, "portal")
+	store := newMongoFailoverStore(db)
+	ctx := context.Background()
+
+	got, err := store.Get(ctx, "site-unknown")
+	require.NoError(t, err)
+	assert.Equal(t, StatusHealthy, got.Status)
+	assert.Equal(t, int64(0), got.Version)
+	assert.Equal(t, "site-unknown", got.SiteID)
+}
+
+func TestMongoFailoverStore_TransitionInsertThenUpdate(t *testing.T) {
+	db := testutil.MongoDB(t, "portal")
+	store := newMongoFailoverStore(db)
+	ctx := context.Background()
+
+	// First transition inserts version 1.
+	v1 := FailoverState{SiteID: "site-a", Status: StatusFailedOver, Operator: "jane", Reason: "down", Since: 100, Version: 1, Timestamp: 100}
+	require.NoError(t, store.Transition(ctx, v1))
+
+	got, err := store.Get(ctx, "site-a")
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailedOver, got.Status)
+	assert.Equal(t, int64(1), got.Version)
+
+	// Second transition CAS-updates to version 2.
+	v2 := FailoverState{SiteID: "site-a", Status: StatusFailingBack, Operator: "jane", Reason: "draining", Since: 200, Version: 2, Timestamp: 200}
+	require.NoError(t, store.Transition(ctx, v2))
+	got, err = store.Get(ctx, "site-a")
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailingBack, got.Status)
+	assert.Equal(t, int64(2), got.Version)
+}
+
+func TestMongoFailoverStore_TransitionStaleVersionConflicts(t *testing.T) {
+	db := testutil.MongoDB(t, "portal")
+	store := newMongoFailoverStore(db)
+	ctx := context.Background()
+
+	require.NoError(t, store.Transition(ctx, FailoverState{SiteID: "site-b", Status: StatusFailedOver, Version: 1, Since: 1, Timestamp: 1}))
+	// Now at version 1. A second "version 1" insert (stale) must conflict.
+	err := store.Transition(ctx, FailoverState{SiteID: "site-b", Status: StatusFailedOver, Version: 1, Since: 2, Timestamp: 2})
+	assert.ErrorIs(t, err, errFailoverVersionConflict)
+
+	// A version-3 update (skipping 2) finds no version-2 doc -> conflict.
+	err = store.Transition(ctx, FailoverState{SiteID: "site-b", Status: StatusHealthy, Version: 3, Since: 3, Timestamp: 3})
+	assert.ErrorIs(t, err, errFailoverVersionConflict)
+}
+
+func TestMongoFailoverStore_ConcurrentCASOneWinner(t *testing.T) {
+	db := testutil.MongoDB(t, "portal")
+	store := newMongoFailoverStore(db)
+	ctx := context.Background()
+
+	// Seed version 1.
+	require.NoError(t, store.Transition(ctx, FailoverState{SiteID: "site-c", Status: StatusFailedOver, Version: 1, Since: 1, Timestamp: 1}))
+
+	// Two goroutines both try to move version 1 -> 2. Exactly one wins.
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = store.Transition(ctx, FailoverState{SiteID: "site-c", Status: StatusHealthy, Version: 2, Since: 2, Timestamp: 2})
+		}(i)
+	}
+	wg.Wait()
+
+	conflicts := 0
+	oks := 0
+	for _, e := range errs {
+		switch {
+		case e == nil:
+			oks++
+		case assert.ErrorIs(t, e, errFailoverVersionConflict):
+			conflicts++
+		}
+	}
+	assert.Equal(t, 1, oks, "exactly one writer wins")
+	assert.Equal(t, 1, conflicts, "exactly one writer conflicts")
+}
+
+func TestMongoFailoverStore_List(t *testing.T) {
+	db := testutil.MongoDB(t, "portal")
+	store := newMongoFailoverStore(db)
+	ctx := context.Background()
+
+	require.NoError(t, store.Transition(ctx, FailoverState{SiteID: "site-x", Status: StatusFailedOver, Version: 1, Since: 1, Timestamp: 1}))
+	require.NoError(t, store.Transition(ctx, FailoverState{SiteID: "site-y", Status: StatusHealthy, Version: 1, Since: 1, Timestamp: 1}))
+
+	all, err := store.List(ctx)
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, s := range all {
+		ids[s.SiteID] = true
+	}
+	assert.True(t, ids["site-x"])
+	assert.True(t, ids["site-y"])
+}

--- a/portal-service/failover_middleware.go
+++ b/portal-service/failover_middleware.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"crypto/subtle"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/errcode/errhttp"
+)
+
+// bearer extracts the token from an "Authorization: Bearer <token>" header, or
+// "" when absent or a different scheme.
+func bearer(c *gin.Context) string {
+	if after, ok := strings.CutPrefix(c.GetHeader("Authorization"), "Bearer "); ok {
+		return strings.TrimSpace(after)
+	}
+	return ""
+}
+
+// requireOps gates the failover control surface on a shared ops bearer token.
+// It is the auth seam: a later per-operator login (option 3) replaces this
+// middleware without touching the handlers. Compares in constant time so a
+// wrong token cannot be timing-probed. The token is never logged.
+func requireOps(token string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		got := bearer(c)
+		if got == "" {
+			errhttp.Write(ctx, c, errcode.Unauthenticated("missing ops token",
+				errcode.WithReason(errcode.PortalFailoverUnauthorized)))
+			c.Abort()
+			return
+		}
+		if subtle.ConstantTimeCompare([]byte(got), []byte(token)) != 1 {
+			errhttp.Write(ctx, c, errcode.Forbidden("invalid ops token",
+				errcode.WithReason(errcode.PortalFailoverUnauthorized)))
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}

--- a/portal-service/failover_middleware_test.go
+++ b/portal-service/failover_middleware_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func opsTestRouter(token string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	grp := r.Group("/internal", requireOps(token))
+	grp.GET("/ping", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+	return r
+}
+
+func TestRequireOps(t *testing.T) {
+	tests := []struct {
+		name       string
+		authHeader string
+		wantStatus int
+	}{
+		{"no header", "", http.StatusUnauthorized},
+		{"non-bearer scheme", "Basic abc", http.StatusUnauthorized},
+		{"wrong token", "Bearer wrong", http.StatusForbidden},
+		{"correct token", "Bearer s3cr3t", http.StatusOK},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := opsTestRouter("s3cr3t")
+			req := httptest.NewRequest(http.MethodGet, "/internal/ping", nil)
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}

--- a/portal-service/failover_mongo.go
+++ b/portal-service/failover_mongo.go
@@ -50,7 +50,7 @@ func (s *mongoFailoverStore) List(ctx context.Context) ([]FailoverState, error) 
 // (a concurrent insert -> duplicate key -> conflict). Otherwise it CAS-updates
 // the document whose stored version == next.Version-1; a non-match means a
 // racing writer moved first -> conflict.
-func (s *mongoFailoverStore) Transition(ctx context.Context, next FailoverState) error {
+func (s *mongoFailoverStore) Transition(ctx context.Context, next *FailoverState) error {
 	if next.Version < 1 {
 		return fmt.Errorf("transition: next version must be >= 1, got %d", next.Version)
 	}

--- a/portal-service/failover_mongo.go
+++ b/portal-service/failover_mongo.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// mongoFailoverStore persists FailoverState in the failover_states collection,
+// keyed by _id = siteID, with optimistic-concurrency CAS on the version field.
+type mongoFailoverStore struct {
+	coll *mongo.Collection
+}
+
+func newMongoFailoverStore(db *mongo.Database) *mongoFailoverStore {
+	return &mongoFailoverStore{coll: db.Collection("failover_states")}
+}
+
+// Get returns the stored state for siteID, or a synthesized healthy version-0
+// state when no document exists (an unfailed site has no row).
+func (s *mongoFailoverStore) Get(ctx context.Context, siteID string) (FailoverState, error) {
+	var st FailoverState
+	err := s.coll.FindOne(ctx, bson.D{{Key: "_id", Value: siteID}}).Decode(&st)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return FailoverState{SiteID: siteID, Status: StatusHealthy, Version: 0}, nil
+	}
+	if err != nil {
+		return FailoverState{}, fmt.Errorf("get failover state %q: %w", siteID, err)
+	}
+	return st, nil
+}
+
+// List returns every stored failover state.
+func (s *mongoFailoverStore) List(ctx context.Context) ([]FailoverState, error) {
+	cur, err := s.coll.Find(ctx, bson.D{})
+	if err != nil {
+		return nil, fmt.Errorf("list failover states: %w", err)
+	}
+	var out []FailoverState
+	if err := cur.All(ctx, &out); err != nil {
+		return nil, fmt.Errorf("decode failover states: %w", err)
+	}
+	return out, nil
+}
+
+// Transition persists next. When next.Version == 1 it inserts the first state
+// (a concurrent insert -> duplicate key -> conflict). Otherwise it CAS-updates
+// the document whose stored version == next.Version-1; a non-match means a
+// racing writer moved first -> conflict.
+func (s *mongoFailoverStore) Transition(ctx context.Context, next FailoverState) error {
+	if next.Version < 1 {
+		return fmt.Errorf("transition: next version must be >= 1, got %d", next.Version)
+	}
+	if next.Version == 1 {
+		if _, err := s.coll.InsertOne(ctx, next); err != nil {
+			if mongo.IsDuplicateKeyError(err) {
+				return errFailoverVersionConflict
+			}
+			return fmt.Errorf("insert failover state: %w", err)
+		}
+		return nil
+	}
+	res, err := s.coll.UpdateOne(ctx,
+		bson.D{{Key: "_id", Value: next.SiteID}, {Key: "version", Value: next.Version - 1}},
+		bson.D{{Key: "$set", Value: bson.D{
+			{Key: "status", Value: next.Status},
+			{Key: "reason", Value: next.Reason},
+			{Key: "operator", Value: next.Operator},
+			{Key: "since", Value: next.Since},
+			{Key: "version", Value: next.Version},
+			{Key: "timestamp", Value: next.Timestamp},
+		}}},
+	)
+	if err != nil {
+		return fmt.Errorf("update failover state: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return errFailoverVersionConflict
+	}
+	return nil
+}

--- a/portal-service/failover_test.go
+++ b/portal-service/failover_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFailoverState_ServingTarget(t *testing.T) {
+	tests := []struct {
+		status FailoverStatus
+		want   ServingTarget
+	}{
+		{StatusHealthy, ServingHome},
+		{StatusFailedOver, ServingBackup},
+		{StatusFailingBack, ServingBackup},
+		{FailoverStatus("garbage"), ServingHome}, // unknown => fail-safe home
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.status), func(t *testing.T) {
+			s := FailoverState{Status: tc.status}
+			assert.Equal(t, tc.want, s.ServingTarget())
+		})
+	}
+}
+
+func TestApplyAction_LegalTransitions(t *testing.T) {
+	tests := []struct {
+		name   string
+		from   FailoverStatus
+		action FailoverAction
+		want   FailoverStatus
+	}{
+		{"failover", StatusHealthy, ActionFailover, StatusFailedOver},
+		{"failback", StatusFailedOver, ActionFailback, StatusFailingBack},
+		{"complete", StatusFailingBack, ActionComplete, StatusHealthy},
+		{"resume", StatusFailedOver, ActionResume, StatusHealthy},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cur := FailoverState{SiteID: "site-a", Status: tc.from, Version: 3}
+			next, err := applyAction(cur, tc.action, "jane", "because", 1700)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, next.Status)
+			assert.Equal(t, "site-a", next.SiteID)
+			assert.Equal(t, int64(4), next.Version, "version increments by 1")
+			assert.Equal(t, "jane", next.Operator)
+			assert.Equal(t, "because", next.Reason)
+			assert.Equal(t, int64(1700), next.Since)
+			assert.Equal(t, int64(1700), next.Timestamp)
+		})
+	}
+}
+
+func TestApplyAction_IllegalTransitions(t *testing.T) {
+	tests := []struct {
+		name   string
+		from   FailoverStatus
+		action FailoverAction
+	}{
+		{"double failover", StatusFailedOver, ActionFailover},
+		{"failback from healthy", StatusHealthy, ActionFailback},
+		{"complete from healthy", StatusHealthy, ActionComplete},
+		{"resume from failing_back", StatusFailingBack, ActionResume},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cur := FailoverState{SiteID: "site-a", Status: tc.from, Version: 1}
+			_, err := applyAction(cur, tc.action, "jane", "because", 1700)
+			assert.ErrorIs(t, err, errIllegalTransition)
+		})
+	}
+}
+
+func TestIsKnownAction(t *testing.T) {
+	for _, a := range []FailoverAction{ActionFailover, ActionFailback, ActionComplete, ActionResume} {
+		assert.True(t, isKnownAction(a))
+	}
+	assert.False(t, isKnownAction(FailoverAction("nope")))
+	assert.False(t, isKnownAction(FailoverAction("")))
+}
+
+func TestSentinelsDistinct(t *testing.T) {
+	assert.False(t, errors.Is(errIllegalTransition, errFailoverVersionConflict))
+}

--- a/portal-service/failover_test.go
+++ b/portal-service/failover_test.go
@@ -41,7 +41,7 @@ func TestApplyAction_LegalTransitions(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cur := FailoverState{SiteID: "site-a", Status: tc.from, Version: 3}
-			next, err := applyAction(cur, tc.action, "jane", "because", 1700)
+			next, err := applyAction(&cur, tc.action, "jane", "because", 1700)
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, next.Status)
 			assert.Equal(t, "site-a", next.SiteID)
@@ -68,7 +68,7 @@ func TestApplyAction_IllegalTransitions(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cur := FailoverState{SiteID: "site-a", Status: tc.from, Version: 1}
-			_, err := applyAction(cur, tc.action, "jane", "because", 1700)
+			_, err := applyAction(&cur, tc.action, "jane", "because", 1700)
 			assert.ErrorIs(t, err, errIllegalTransition)
 		})
 	}

--- a/portal-service/main.go
+++ b/portal-service/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"sync"
@@ -57,6 +58,13 @@ type config struct {
 	MongoDB       string `env:"MONGO_DB"       envDefault:"chat"`
 	MongoUsername string `env:"MONGO_USERNAME" envDefault:""`
 	MongoPassword string `env:"MONGO_PASSWORD" envDefault:""`
+
+	// FailoverOpsToken gates the operator failover control surface. Empty
+	// disables the internal control server entirely (no control surface).
+	FailoverOpsToken string `env:"FAILOVER_OPS_TOKEN" envDefault:""`
+	// FailoverInternalAddr is the listen address for the internal-only control
+	// surface — kept off the public browser-facing server.
+	FailoverInternalAddr string `env:"FAILOVER_INTERNAL_ADDR" envDefault:":8090"`
 
 	// BotLoginEnabled gates portal's bot-role password login. Flip to false
 	// once the dedicated bot-devs client (which talks to botplatform directly)
@@ -138,6 +146,39 @@ func run() error {
 	r.Use(ginutil.AccessLog())
 	registerRoutes(r, handler)
 
+	// Optional internal-only failover control surface. Bound on a separate
+	// listener so no privileged write shares the public discovery server.
+	var internalSrv *http.Server
+	if cfg.FailoverOpsToken != "" {
+		failoverStore := newMongoFailoverStore(mongoClient.Database(cfg.MongoDB))
+		failoverHandler := NewFailoverHandler(failoverStore)
+
+		ir := gin.New()
+		ir.Use(gin.Recovery())
+		ir.Use(ginutil.RequestID())
+		ir.Use(ginutil.AccessLog())
+		registerFailoverRoutes(ir, failoverHandler, cfg.FailoverOpsToken)
+
+		// net.Listen up front so a bad bind fails startup, not silently later.
+		ln, lerr := net.Listen("tcp", cfg.FailoverInternalAddr)
+		if lerr != nil {
+			return fmt.Errorf("bind failover control surface %q: %w", cfg.FailoverInternalAddr, lerr)
+		}
+		internalSrv = &http.Server{
+			Handler:      ir,
+			ReadTimeout:  10 * time.Second,
+			WriteTimeout: 10 * time.Second,
+		}
+		go func() {
+			slog.Info("failover control surface starting", "addr", cfg.FailoverInternalAddr)
+			if serveErr := internalSrv.Serve(ln); serveErr != nil && serveErr != http.ErrServerClosed {
+				slog.Error("failover control surface stopped", "error", serveErr)
+			}
+		}()
+	} else {
+		slog.Info("failover control surface disabled (FAILOVER_OPS_TOKEN unset)")
+	}
+
 	addr := fmt.Sprintf(":%s", cfg.Port)
 	srv := &http.Server{
 		Addr:         addr,
@@ -158,6 +199,11 @@ func run() error {
 		shutdown.Wait(ctx, 25*time.Second,
 			func(ctx context.Context) error {
 				slog.Info("shutting down portal service")
+				if internalSrv != nil {
+					if err := internalSrv.Shutdown(ctx); err != nil {
+						slog.Error("shutdown failover control surface", "error", err)
+					}
+				}
 				err := srv.Shutdown(ctx)
 				refreshCancel()
 				refreshWG.Wait()

--- a/portal-service/mock_store_test.go
+++ b/portal-service/mock_store_test.go
@@ -126,7 +126,7 @@ func (mr *MockFailoverStoreMockRecorder) List(ctx any) *gomock.Call {
 }
 
 // Transition mocks base method.
-func (m *MockFailoverStore) Transition(ctx context.Context, next FailoverState) error {
+func (m *MockFailoverStore) Transition(ctx context.Context, next *FailoverState) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Transition", ctx, next)
 	ret0, _ := ret[0].(error)

--- a/portal-service/mock_store_test.go
+++ b/portal-service/mock_store_test.go
@@ -40,6 +40,22 @@ func (m *MockDirectoryStore) EXPECT() *MockDirectoryStoreMockRecorder {
 	return m.recorder
 }
 
+// GetByAccount mocks base method.
+func (m *MockDirectoryStore) GetByAccount(ctx context.Context, account string) (employee, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByAccount", ctx, account)
+	ret0, _ := ret[0].(employee)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetByAccount indicates an expected call of GetByAccount.
+func (mr *MockDirectoryStoreMockRecorder) GetByAccount(ctx, account any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByAccount", reflect.TypeOf((*MockDirectoryStore)(nil).GetByAccount), ctx, account)
+}
+
 // ListEmployees mocks base method.
 func (m *MockDirectoryStore) ListEmployees(ctx context.Context) ([]employee, error) {
 	m.ctrl.T.Helper()
@@ -55,18 +71,70 @@ func (mr *MockDirectoryStoreMockRecorder) ListEmployees(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEmployees", reflect.TypeOf((*MockDirectoryStore)(nil).ListEmployees), ctx)
 }
 
-// GetByAccount mocks base method.
-func (m *MockDirectoryStore) GetByAccount(ctx context.Context, account string) (employee, bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetByAccount", ctx, account)
-	ret0, _ := ret[0].(employee)
-	ret1, _ := ret[1].(bool)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+// MockFailoverStore is a mock of FailoverStore interface.
+type MockFailoverStore struct {
+	ctrl     *gomock.Controller
+	recorder *MockFailoverStoreMockRecorder
+	isgomock struct{}
 }
 
-// GetByAccount indicates an expected call of GetByAccount.
-func (mr *MockDirectoryStoreMockRecorder) GetByAccount(ctx, account any) *gomock.Call {
+// MockFailoverStoreMockRecorder is the mock recorder for MockFailoverStore.
+type MockFailoverStoreMockRecorder struct {
+	mock *MockFailoverStore
+}
+
+// NewMockFailoverStore creates a new mock instance.
+func NewMockFailoverStore(ctrl *gomock.Controller) *MockFailoverStore {
+	mock := &MockFailoverStore{ctrl: ctrl}
+	mock.recorder = &MockFailoverStoreMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockFailoverStore) EXPECT() *MockFailoverStoreMockRecorder {
+	return m.recorder
+}
+
+// Get mocks base method.
+func (m *MockFailoverStore) Get(ctx context.Context, siteID string) (FailoverState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", ctx, siteID)
+	ret0, _ := ret[0].(FailoverState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockFailoverStoreMockRecorder) Get(ctx, siteID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByAccount", reflect.TypeOf((*MockDirectoryStore)(nil).GetByAccount), ctx, account)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockFailoverStore)(nil).Get), ctx, siteID)
+}
+
+// List mocks base method.
+func (m *MockFailoverStore) List(ctx context.Context) ([]FailoverState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List", ctx)
+	ret0, _ := ret[0].([]FailoverState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// List indicates an expected call of List.
+func (mr *MockFailoverStoreMockRecorder) List(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockFailoverStore)(nil).List), ctx)
+}
+
+// Transition mocks base method.
+func (m *MockFailoverStore) Transition(ctx context.Context, next FailoverState) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Transition", ctx, next)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Transition indicates an expected call of Transition.
+func (mr *MockFailoverStoreMockRecorder) Transition(ctx, next any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transition", reflect.TypeOf((*MockFailoverStore)(nil).Transition), ctx, next)
 }

--- a/portal-service/store.go
+++ b/portal-service/store.go
@@ -53,5 +53,5 @@ type DirectoryStore interface {
 type FailoverStore interface {
 	Get(ctx context.Context, siteID string) (FailoverState, error)
 	List(ctx context.Context) ([]FailoverState, error)
-	Transition(ctx context.Context, next FailoverState) error
+	Transition(ctx context.Context, next *FailoverState) error
 }

--- a/portal-service/store.go
+++ b/portal-service/store.go
@@ -43,3 +43,15 @@ type DirectoryStore interface {
 	// (_, false, nil) when the account does not exist.
 	GetByAccount(ctx context.Context, account string) (employee, bool, error)
 }
+
+// FailoverStore is the sole-writer, CAS-guarded persistence for per-site
+// FailoverState (portal is the split-brain fence). Get synthesizes a healthy,
+// version-0 state for a site with no document, so callers treat "no doc" as
+// healthy. Transition inserts the first state (version 1) or CAS-updates a
+// later one, returning errFailoverVersionConflict when the stored version does
+// not match next.Version-1.
+type FailoverStore interface {
+	Get(ctx context.Context, siteID string) (FailoverState, error)
+	List(ctx context.Context) ([]FailoverState, error)
+	Transition(ctx context.Context, next FailoverState) error
+}


### PR DESCRIPTION
## What this is

Downstream work on the cross-site failover ("lifeboat") program: the design cycles for SP2/SP3/SP4, plus the **first buildable slice implemented** — SP4-core in `portal-service`.

**Base branch:** this PR targets `claude/cross-site-failover-brainstorm-luol1d` (where the governing design + SP1 live) so the diff is *only* the downstream increment. SP1 is being implemented separately and is untouched here.

## Specs (design cycles)

- **SP2 rewritten to "World 1".** Production runs **one shared org-level NATS account** (confirmed), so the backup mints in that same account — not impersonation, no per-site keys. This **drops the entire key-custody / remote-signer / Vault design** (a World-2 concern) and shrinks SP2 to config/ops: the SP0-coupled `chat.local.room.>` grant + a backup `auth-service` deployment. No new minting code.
- **SP3 spec** — portal health-aware routing override (consumes SP4's `servingTarget` signal).
- **SP4 spec rewritten** — operator-confirmed posture; health probe deferred. SP4-core = the operator-driven `FailoverState` machine + control surface + `servingTarget` signal.
- **Reconciliation** — the governing design (§4.3, §11.4, failure-modes) and roadmap updated so the invalidated key-custody framing no longer misleads the next planner.

## Implemented — SP4-core (`portal-service`)

Operator-driven failover state; **no auto-detection** (deferred), no UI yet (a per-operator login/console is a planned follow-up — the auth is built as a middleware seam so that drops in without a rewrite).

- **State machine** — `healthy → failed_over → failing_back → healthy`, plus `resume` (false alarm). `servingTarget` (home|backup) is derived and is the entire SP3 contract.
- **Mongo CAS store** — one `failover_states` doc per site; portal is the sole writer, optimistic-concurrency guarded on `version` (the split-brain fence). Unknown sites synthesize a healthy default.
- **Control surface** — `GET`/`GET`/`POST /internal/v1/failover[/:siteId]` on an **internal-only listener** (kept off the public discovery server), gated by a dedicated ops bearer token (constant-time compare, never logged); `operator`/`reason` recorded for audit; `409` on illegal transition and version conflict.
- **Wiring** — internal server starts only when `FAILOVER_OPS_TOKEN` is set; fail-fast bind; graceful shutdown alongside the public server.

## Verification

- `make test SERVICE=portal-service` — **PASS** (race detector).
- `make build SERVICE=portal-service` — **builds clean.**
- `make lint` — **0 issues.**
- Coverage: domain, middleware, and all three handlers at **100%** unit coverage.
- **Integration tests** (Mongo CAS: default-healthy, insert→update, stale-version conflict, concurrent one-winner, list) are written and **compile under the `integration` tag**, but require Docker/testcontainers — they run in **CI**, not in the Docker-less dev sandbox where this was built.

## Scope notes

- The **TTL-cached reader** is intentionally deferred to SP3 (its only consumer) to avoid dead code the linter would reject; the `servingTarget` derivation it wraps is built and 100% tested here.
- No `docs/client-api.md` change — the control surface is an internal ops API, not a `chat.user.*` RPC.
- SP2's remaining deliverables (the grant, backup deploy) are config/ops and are blocked on SP0 landing.

## Draft because

This bundles design specs with the first implementation slice and stacks on the SP1 branch; opening as draft for review before it targets a longer-lived base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bx1yBMCjo88ftnTB6ha5pA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bx1yBMCjo88ftnTB6ha5pA)_