### PR TITLE
Route cross-site room history to room's home site, not user's

### DIFF
--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.test.jsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.test.jsx
@@ -129,6 +129,45 @@ describe('RoomEventsProvider', () => {
     )
   })
 
+  it('loadHistory routes to the room home site for a cross-site room, not the user home site', async () => {
+    // User is logged in on site-B; the room lives on site-A. History must be
+    // fetched from the room's home site (site-A), or history-service on site-B
+    // replies "room not found".
+    const rooms = [{ id: 'a', name: 'x', type: 'channel', siteId: 'site-A', userCount: 2, lastMsgAt: null }]
+    const request = vi.fn().mockImplementation((subject, payload) => {
+      if (subject.includes('.msg.history')) return Promise.resolve({ messages: [] })
+      if (subject.endsWith('.subscription.list') && payload?.type === 'rooms')
+        return Promise.resolve({ subscriptions: rooms.map(roomToSub) })
+      if (subject.endsWith('.subscription.list')) return Promise.resolve({ subscriptions: [] })
+      throw new Error('unexpected subject: ' + subject)
+    })
+    const nats = mockNats({ request, user: { account: 'alice', siteId: 'site-B' } })
+
+    function Trigger() {
+      const { loadHistory } = useRoomEvents('a')
+      const { summaries } = useRoomSummaries()
+      return (
+        <div>
+          <button onClick={() => loadHistory()}>load</button>
+          <div data-testid="count">{summaries.length}</div>
+        </div>
+      )
+    }
+
+    render(wrap(<Trigger />, nats))
+    // Wait for the bootstrap summary to land so loadHistory sees the room's siteId.
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('1'))
+    await act(async () => {
+      screen.getByText('load').click()
+    })
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith('chat.user.alice.request.room.a.site-A.msg.history', { limit: 50 }),
+    )
+    // Never routed to the user's own home site.
+    const historyCalls = request.mock.calls.filter(([subject]) => subject.includes('.msg.history'))
+    expect(historyCalls.every(([subject]) => !subject.includes('.site-B.'))).toBe(true)
+  })
+
   it('loadHistory surfaces historyError on failure', async () => {
     const request = vi.fn().mockImplementation((subject) => {
       if (subject.includes('.msg.history')) return Promise.reject(new Error('boom'))

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
@@ -194,10 +194,17 @@ export function RoomEventsProvider({ children }: { children: ReactNode }) {
       if (prev?.hasLoadedHistory) return
       if (inflightHistory.current.has(roomId)) return inflightHistory.current.get(roomId)
 
+      // Route to the room's home site: a cross-site room's history lives on
+      // another site, so use the summary's siteId (mirrors loadOlderHistory /
+      // markRoomRead / loadSurrounding); fall back to the user's home site when
+      // no summary is loaded yet.
+      const summary = stateRef.current.summaries.find((r) => r.id === roomId)
+      const siteId = summary?.siteId ?? user.siteId
+
       const gen = currentGeneration()
       const promise = (async () => {
         try {
-          const resp = await fetchMessageHistory(nats, { roomId, siteId: user.siteId, limit: HISTORY_PAGE_SIZE })
+          const resp = await fetchMessageHistory(nats, { roomId, siteId, limit: HISTORY_PAGE_SIZE })
           // history-service ships newest-first; the UI reads chronological.
           // Normalisation to the broadcast `Message` shape now happens inside
           // the api op.


### PR DESCRIPTION
## Summary
Fix history loading for cross-site rooms by routing to the room's home site instead of the user's home site. When a user logged in on site-B accesses a room that lives on site-A, the history must be fetched from site-A's history service, or the request will fail with "room not found".

## Changes
- **RoomEventsContext.tsx**: Updated `loadHistory` to determine the target `siteId` from the room summary (if available) rather than always using the user's home site. This mirrors the behavior of `loadOlderHistory`, `markRoomRead`, and `loadSurrounding`.
- **RoomEventsContext.test.jsx**: Added test case verifying that `loadHistory` routes to the room's home site (`site-A`) for a cross-site room, even when the user is logged in on a different site (`site-B`).

## Implementation Details
- The fix uses the room summary's `siteId` when available, falling back to the user's `siteId` during bootstrap before the summary is loaded.
- This ensures consistent routing behavior across all history-related operations in the context.

https://claude.ai/code/session_01JP4LkD3SVG424CutmtAtXB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message history loading for rooms from other sites.
  * History requests now use the room’s site when available, with a fallback to the user’s home site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->