### PR TITLE
feat(chat-frontend): warm-start the sidebar from a subscription cache

### DIFF
--- a/chat-frontend/CLAUDE.md
+++ b/chat-frontend/CLAUDE.md
@@ -233,8 +233,20 @@ dispatch({ type: 'SOMETHING_LOADED', data: resp })
 ### Subscription state
 
 `state.subscriptions[roomId]` is the canonical per-user-per-room record (mirrors `pkg/model.Subscription` / `DMSubscription`). Populated by:
+- **Cache hydration** (first render — `lib/subscriptionCache` replayed through `BUCKETS_LOADED` + `CHATLIST_LOADED` in `useReducer`'s lazy initializer)
 - `BUCKETS_LOADED` (initial — three user-service RPCs in parallel via `fetchSidebarBuckets`)
 - `SUBSCRIPTION_UPSERTED` (live deltas from `subscription.update` events — merges partial payloads into the prior record)
+
+### Subscription cache (warm start)
+
+`lib/subscriptionCache` persists `subscriptions` + the three bucket id sets + `chatlist` to localStorage under one key, stamped with the owning `account`/`siteId`. localStorage (not IndexedDB) because the read must be **synchronous** — hydration runs inside `useReducer`'s lazy initializer so the sidebar's first paint already has rooms. An async store would push hydration into an effect and reintroduce the empty first frame.
+
+- Hydration replays cached data through the **same actions** the network path uses, so cached and fetched state are identical in shape by construction. `summaries` are derived (via `subToRoom`), never persisted.
+- `room.privateKey` is stripped before writing — room E2E keys stay memory-only in `RoomKeysContext`. Warm-painted encrypted rooms show the decryption placeholder until the fetch re-seeds keys.
+- Write-through is a 1s trailing debounce keyed by reference on the five persisted slices, guarded by `state.subscriptions === initialState.subscriptions` (an exact "we've been RESET" test) so logout and StrictMode remounts can't blank the cache.
+- The cache survives logout, keyed per account; a different account overwrites it.
+
+**Failed fetches are never destructive.** `fetchSidebarBuckets` reports a `failures: SidebarBucket[]` array (an RPC rejected, a later page failed, or the server never cleared `hasMore`). `useRoomSubscriptions` branches on it: all three failed → `ROOMS_FAILED` only, keeping what's on screen; one or two failed → `BUCKETS_LOADED` with `merge: true`, **omitting** the failed buckets' id arrays (the reducer reads presence as "this bucket is authoritative"); none failed → replace wholesale, which is the only path allowed to delete rooms.
 
 Consumers read via `useSubscription(roomId): DMSubscription | undefined`. Use it for:
 - Permission gating (`sub.roles.includes('owner')`)

--- a/chat-frontend/src/api/fetchSidebarBuckets/index.test.ts
+++ b/chat-frontend/src/api/fetchSidebarBuckets/index.test.ts
@@ -163,3 +163,65 @@ describe('fetchSidebarBuckets', () => {
     expect(warn).toHaveBeenCalled()
   })
 })
+
+describe('fetchSidebarBuckets: failure reporting', () => {
+  it('reports no failures when every bucket resolves', async () => {
+    const request = pagingRequest({
+      current: [{ subscriptions: [sub('r1')], hasMore: false }],
+      apps: [{ subscriptions: [], hasMore: false }],
+      rooms: [{ subscriptions: [sub('r1')], hasMore: false }],
+    })
+
+    const buckets = await fetchSidebarBuckets(fakeNats(request))
+
+    expect(buckets.failures).toEqual([])
+  })
+
+  it('names the bucket whose first page rejects', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const request = vi.fn(async (_subject: string, body: Record<string, unknown>) => {
+      if (body.type === 'apps') throw new Error('nats timeout')
+      return { subscriptions: [sub('r1')], hasMore: false }
+    })
+
+    const buckets = await fetchSidebarBuckets(fakeNats(request))
+
+    expect(buckets.failures).toEqual(['apps'])
+  })
+
+  it('names every bucket when the whole bootstrap fails', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const request = vi.fn(async () => {
+      throw new Error('disconnected')
+    })
+
+    const buckets = await fetchSidebarBuckets(fakeNats(request))
+
+    expect(buckets.failures.sort()).toEqual(['apps', 'favorites', 'rooms'])
+  })
+
+  it('marks a bucket degraded when a LATER page rejects', async () => {
+    // The pages already fetched are kept, but a truncated bucket must not be
+    // allowed to delete the rooms its missing pages would have listed.
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const request = vi.fn(async (_subject: string, body: Record<string, unknown>) => {
+      if (body.type !== 'rooms') return { subscriptions: [], hasMore: false }
+      if ((body.offset as number) === 0) return { subscriptions: [sub('r1')], hasMore: true }
+      throw new Error('page 2 died')
+    })
+
+    const buckets = await fetchSidebarBuckets(fakeNats(request))
+
+    expect(buckets.failures).toEqual(['rooms'])
+    expect(buckets.channelDmIds).toEqual(['r1'])
+  })
+
+  it('marks a bucket degraded when the server never clears hasMore', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const request = vi.fn(async () => ({ subscriptions: [sub('r1')], hasMore: true }))
+
+    const buckets = await fetchSidebarBuckets(fakeNats(request))
+
+    expect(buckets.failures.sort()).toEqual(['apps', 'favorites', 'rooms'])
+  }, 20000)
+})

--- a/chat-frontend/src/api/fetchSidebarBuckets/index.ts
+++ b/chat-frontend/src/api/fetchSidebarBuckets/index.ts
@@ -33,10 +33,19 @@ interface SidebarBucketReply {
   hasMore: boolean
 }
 
+/** Which of the three `subscription.list` buckets a result came from. */
+export type SidebarBucket = 'favorites' | 'apps' | 'rooms'
+
 export interface SidebarBuckets {
   favoriteIds: string[]
   appIds: string[]
   channelDmIds: string[]
+  /** Buckets that did NOT drain cleanly — an RPC rejected, a later page
+   *  failed, or the server never cleared `hasMore`. Their contents are
+   *  whatever we managed to fetch, so the caller must treat them as
+   *  incomplete and refuse to delete rooms on their behalf. Empty means
+   *  the whole bootstrap is authoritative. */
+  failures: SidebarBucket[]
   /** Per-roomId map of the full subscription record (DM variant typing
    *  covers both kinds — see SidebarBucketReply above). The reducer
    *  stores this directly under `state.subscriptions` so components
@@ -82,12 +91,15 @@ export async function fetchSidebarBuckets({ user, request }: Nats): Promise<Side
     fetchAllPages(request, subject, { type: 'apps' }),
     fetchAllPages(request, subject, { type: 'rooms' }),
   ])
+  const failures: SidebarBucket[] = []
   const unwrap = (
-    result: PromiseSettledResult<DMSubscription[]>,
+    result: PromiseSettledResult<BucketPages>,
+    bucket: SidebarBucket,
     label: string,
   ): DMSubscription[] => {
     if (result.status === 'fulfilled') {
-      return result.value
+      if (result.value.degraded) failures.push(bucket)
+      return result.value.subs
     }
     const err = result.reason
     console.warn(
@@ -96,11 +108,12 @@ export async function fetchSidebarBuckets({ user, request }: Nats): Promise<Side
       'FAILED:',
       err?.message ?? err,
     )
+    failures.push(bucket)
     return []
   }
-  const favSubs = unwrap(results[0], `${subject} {type:current,favorite:true}`)
-  const appSubs = unwrap(results[1], `${subject} {type:apps}`)
-  const roomSubs = unwrap(results[2], `${subject} {type:rooms}`)
+  const favSubs = unwrap(results[0], 'favorites', `${subject} {type:current,favorite:true}`)
+  const appSubs = unwrap(results[1], 'apps', `${subject} {type:apps}`)
+  const roomSubs = unwrap(results[2], 'rooms', `${subject} {type:rooms}`)
 
   const subscriptions: Record<string, DMSubscription> = {}
   const rooms: Room[] = []
@@ -128,9 +141,17 @@ export async function fetchSidebarBuckets({ user, request }: Nats): Promise<Side
     favoriteIds: favSubs.map((s) => s.roomId),
     appIds: appSubs.map((s) => s.roomId),
     channelDmIds: roomSubs.map((s) => s.roomId),
+    failures,
     subscriptions,
     rooms,
   }
+}
+
+/** One bucket's drained pages plus whether the drain completed. `degraded`
+ *  means `subs` is a partial view of that bucket. */
+interface BucketPages {
+  subs: DMSubscription[]
+  degraded: boolean
 }
 
 /** Drain one subscription bucket to completion. Requests successive pages
@@ -150,7 +171,7 @@ async function fetchAllPages(
   request: Nats['request'],
   subject: string,
   filter: Record<string, unknown>,
-): Promise<DMSubscription[]> {
+): Promise<BucketPages> {
   const all: DMSubscription[] = []
   for (let page = 0; page < MAX_PAGES; page++) {
     let reply: SidebarBucketReply
@@ -167,17 +188,17 @@ async function fetchAllPages(
         'FAILED:',
         (err as Error)?.message ?? err,
       )
-      return all
+      return { subs: all, degraded: true }
     }
     if (reply?.subscriptions?.length) all.push(...reply.subscriptions)
-    if (!reply?.hasMore) return all
+    if (!reply?.hasMore) return { subs: all, degraded: false }
   }
   console.warn(
     '[sidebar-bootstrap]',
     `${subject} ${JSON.stringify(filter)}`,
     `stopped after MAX_PAGES=${MAX_PAGES}; server kept signalling hasMore — bucket may be truncated`,
   )
-  return all
+  return { subs: all, degraded: true }
 }
 
 /** Derive a `Room` from a subscription record — the ONE wire→Room mapper

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.cache.test.jsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.cache.test.jsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { NatsContext } from '../NatsContext/NatsContext'
+import { RoomEventsProvider, useRoomSummaries } from './RoomEventsContext'
+import { CACHE_KEY, loadSubscriptionCache, saveSubscriptionCache } from '@/lib/subscriptionCache'
+
+vi.mock('@/context/RoomKeysContext', () => ({
+  useRoomKeys: () => ({ decrypt: async () => null, hasKey: () => false, ensureKey: async () => false, seedKeys: () => {} }),
+}))
+
+const USER = { account: 'alice', siteId: 'site-A' }
+
+function sub(roomId, over = {}) {
+  return {
+    id: `sub-${roomId}`,
+    u: { id: 'u1', account: 'alice' },
+    roomId,
+    siteId: 'site-A',
+    roles: ['member'],
+    name: `name-${roomId}`,
+    roomType: 'channel',
+    joinedAt: '2026-01-01T00:00:00Z',
+    hasMention: false,
+    alert: false,
+    room: { userCount: 3, lastMsgAt: '2026-08-01T00:00:00Z', crossSite: false },
+    ...over,
+  }
+}
+
+/** Seed the cache the way a previous session would have left it. */
+function seedCache(subscriptions, over = {}) {
+  const ids = Object.keys(subscriptions)
+  saveSubscriptionCache(USER, {
+    subscriptions,
+    favoriteIds: [],
+    appIds: [],
+    channelDmIds: ids,
+    chatlist: undefined,
+    ...over,
+  })
+}
+
+function mockNats({ request, subscribe } = {}) {
+  return {
+    connected: true,
+    user: USER,
+    error: null,
+    connect: vi.fn(),
+    request: request ?? vi.fn().mockResolvedValue({ subscriptions: [], hasMore: false }),
+    publish: vi.fn(),
+    subscribe: subscribe ?? vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+    disconnect: vi.fn(),
+  }
+}
+
+function Probe() {
+  const { summaries, error } = useRoomSummaries()
+  return (
+    <div>
+      <div data-testid="ids">{summaries.map((r) => r.id).sort().join(',')}</div>
+      <div data-testid="error">{error ?? ''}</div>
+    </div>
+  )
+}
+
+function wrap(nats) {
+  return (
+    <NatsContext.Provider value={nats}>
+      <RoomEventsProvider>
+        <Probe />
+      </RoomEventsProvider>
+    </NatsContext.Provider>
+  )
+}
+
+/** A request stub whose subscription.list buckets each behave per `byBucket`
+ *  — either a subscription array or an Error to reject with. */
+function bucketRequest(byBucket) {
+  return vi.fn(async (subject, body) => {
+    if (!subject.endsWith('.subscription.list')) return { messages: [] }
+    const key = body.favorite ? 'favorites' : body.type === 'apps' ? 'apps' : 'rooms'
+    const outcome = byBucket[key] ?? []
+    if (outcome instanceof Error) throw outcome
+    return { subscriptions: outcome, hasMore: false }
+  })
+}
+
+describe('RoomEventsProvider: subscription cache', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.clearAllMocks()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('paints cached rooms on the very first render', () => {
+    seedCache({ r1: sub('r1'), r2: sub('r2') })
+    render(wrap(mockNats()))
+    // Synchronous assertion — no await. A hydration that only lands in an
+    // effect would leave this empty for a frame, which is the flash we're
+    // removing.
+    expect(screen.getByTestId('ids').textContent).toBe('r1,r2')
+  })
+
+  it('starts empty when the cache holds another account', () => {
+    saveSubscriptionCache({ account: 'bob', siteId: 'site-A' }, {
+      subscriptions: { r1: sub('r1') },
+      favoriteIds: [],
+      appIds: [],
+      channelDmIds: ['r1'],
+    })
+    render(wrap(mockNats()))
+    expect(screen.getByTestId('ids').textContent).toBe('')
+  })
+
+  it('opens live channel subscriptions for cached rooms', async () => {
+    seedCache({ r1: sub('r1') })
+    const subscribe = vi.fn().mockReturnValue({ unsubscribe: vi.fn() })
+    render(wrap(mockNats({ subscribe })))
+    await waitFor(() => {
+      const subjects = subscribe.mock.calls.map((c) => c[0])
+      expect(subjects).toContain('chat.local.room.r1.event')
+    })
+  })
+
+  it('keeps cached rooms when every bootstrap bucket fails', async () => {
+    seedCache({ r1: sub('r1'), r2: sub('r2') })
+    const err = new Error('disconnected')
+    const request = bucketRequest({ favorites: err, apps: err, rooms: err })
+    render(wrap(mockNats({ request })))
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(3))
+    await waitFor(() => expect(screen.getByTestId('error').textContent).not.toBe(''))
+    expect(screen.getByTestId('ids').textContent).toBe('r1,r2')
+  })
+
+  it('keeps the cached rooms of a bucket that failed while applying the ones that succeeded', async () => {
+    seedCache({ r1: sub('r1'), app1: sub('app1', { roomType: 'botDM' }) })
+    const request = bucketRequest({
+      favorites: [],
+      apps: new Error('apps bucket died'),
+      rooms: [sub('r1'), sub('r3')],
+    })
+    render(wrap(mockNats({ request })))
+    await waitFor(() => expect(screen.getByTestId('ids').textContent).toBe('app1,r1,r3'))
+  })
+
+  it('drops rooms the user left when every bucket succeeds', async () => {
+    seedCache({ r1: sub('r1'), gone: sub('gone') })
+    const request = bucketRequest({ favorites: [], apps: [], rooms: [sub('r1')] })
+    render(wrap(mockNats({ request })))
+    await waitFor(() => expect(screen.getByTestId('ids').textContent).toBe('r1'))
+  })
+
+  it('persists the fetched subscriptions for the next session', async () => {
+    const request = bucketRequest({ favorites: [], apps: [], rooms: [sub('r1')] })
+    render(wrap(mockNats({ request })))
+    await waitFor(
+      () => {
+        expect(Object.keys(loadSubscriptionCache(USER)?.subscriptions ?? {})).toEqual(['r1'])
+      },
+      { timeout: 3000 },
+    )
+  })
+
+  it('does not blank the cache when the provider tears down', async () => {
+    const request = bucketRequest({ favorites: [], apps: [], rooms: [sub('r1')] })
+    const { unmount } = render(wrap(mockNats({ request })))
+    await waitFor(() => expect(loadSubscriptionCache(USER)).not.toBeNull(), { timeout: 3000 })
+    unmount()
+    await new Promise((r) => setTimeout(r, 1100))
+    expect(Object.keys(loadSubscriptionCache(USER)?.subscriptions ?? {})).toEqual(['r1'])
+  })
+
+  it('writes nothing when storage is unavailable', async () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage disabled')
+    })
+    const request = bucketRequest({ favorites: [], apps: [], rooms: [sub('r1')] })
+    render(wrap(mockNats({ request })))
+    await waitFor(() => expect(screen.getByTestId('ids').textContent).toBe('r1'))
+    // Let the write debounce elapse so the failing write actually happens.
+    await waitFor(() => expect(setItem).toHaveBeenCalled(), { timeout: 3000 })
+    expect(window.localStorage.getItem(CACHE_KEY)).toBeNull()
+  })
+})

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.test.jsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.test.jsx
@@ -24,6 +24,11 @@ vi.mock('@/context/RoomKeysContext', () => ({
   useRoomKeys: () => currentRoomKeysMock,
 }))
 
+// The provider now write-throughs its subscription state to localStorage and
+// hydrates from it on mount. Without this, one test's persisted sidebar would
+// warm-start the next one's provider.
+beforeEach(() => window.localStorage.clear())
+
 /** Turn an inline "room-shaped" fixture into a subscription record that
  *  the new bootstrap (3 subscription RPCs) returns. The real user-service
  *  now embeds room metadata under `room` (not top-level), so this helper

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
@@ -2,6 +2,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useReducer,
   useRef,
@@ -23,8 +24,10 @@ import {
   reorderChatlistSections,
   setChatlistSectionSortMode,
   moveChat,
+  subToRoom,
 } from '@/api'
 import { deriveSidebarSections } from '@/lib/chatlist'
+import { loadSubscriptionCache, saveSubscriptionCache } from '@/lib/subscriptionCache'
 import type {
   ChatlistState,
   ChatlistSortMode,
@@ -177,6 +180,42 @@ interface RoomEventsContextValue {
 
 const RoomEventsContext = createContext<RoomEventsContextValue | null>(null)
 
+/** Trailing-debounce window for the cache write. The persisted slices only
+ *  change on subscription/chatlist events, not on message traffic, so this
+ *  mostly just coalesces a burst of `subscription.update`s into one write. */
+const CACHE_WRITE_DEBOUNCE_MS = 1000
+
+/**
+ * Seed the reducer from the browser cache so the sidebar's first paint
+ * already has rooms.
+ *
+ * Replays the cached data through the SAME actions the network bootstrap
+ * uses, rather than assembling a state object by hand — cached state and
+ * fetched state are then identical in shape by construction, with no
+ * parallel hydration path to drift. Two consequences fall out of that:
+ * `unreadCount` zero-inits (it's a session-local counter no fetch would
+ * ever correct, so a persisted value would be stale forever) and
+ * `hasMention` comes from the subscription record, which is server-canonical.
+ */
+function hydrateFromCache(user: Nats['user']): RoomEventsState {
+  const cached = loadSubscriptionCache(user)
+  if (!cached) return initialState as RoomEventsState
+  const rooms = Object.values(cached.subscriptions).map((s) => subToRoom(s, user.siteId))
+  const seeded = roomEventsReducer(initialState, {
+    type: 'BUCKETS_LOADED',
+    favoriteIds: cached.favoriteIds,
+    appIds: cached.appIds,
+    channelDmIds: cached.channelDmIds,
+    subscriptions: cached.subscriptions,
+    rooms,
+  })
+  if (!cached.chatlist) return seeded as RoomEventsState
+  return roomEventsReducer(seeded, {
+    type: 'CHATLIST_LOADED',
+    chatlist: cached.chatlist,
+  }) as RoomEventsState
+}
+
 export function RoomEventsProvider({ children }: { children: ReactNode }) {
   // `useNats()` returns `never` to TS because NatsContext.jsx does
   // `createContext(null)` without annotations. Cast here so downstream
@@ -186,7 +225,7 @@ export function RoomEventsProvider({ children }: { children: ReactNode }) {
   const nats = useNats() as unknown as Nats
   const { user } = nats
   const { decrypt, ensureKey, seedKeys } = useRoomKeys()
-  const [state, dispatch] = useReducer(roomEventsReducer, initialState) as unknown as [
+  const [state, dispatch] = useReducer(roomEventsReducer, user, hydrateFromCache) as unknown as [
     RoomEventsState,
     Dispatch<{ type: string; [k: string]: unknown }>,
   ]
@@ -226,6 +265,23 @@ export function RoomEventsProvider({ children }: { children: ReactNode }) {
     ensureKey,
     seedKeys,
   )
+
+  // Write-through to the browser cache. Keyed by reference on the five
+  // persisted slices: message traffic churns roomState / summaries /
+  // msgRecvSeq but never these, so this stays quiet during a busy session.
+  //
+  // The identity check is the teardown guard. `RESET` returns the
+  // `initialState` OBJECT, so `=== initialState.subscriptions` is an exact
+  // "we've been reset" test — without it, logout (and StrictMode's
+  // double-mount) would persist the empty post-RESET state over a good cache.
+  const { subscriptions, favoriteIds, appIds, channelDmIds, chatlist } = state
+  useEffect(() => {
+    if (subscriptions === initialState.subscriptions) return undefined
+    const timer = setTimeout(() => {
+      saveSubscriptionCache(user, { subscriptions, favoriteIds, appIds, channelDmIds, chatlist })
+    }, CACHE_WRITE_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [user, subscriptions, favoriteIds, appIds, channelDmIds, chatlist])
 
   const loadHistory = useCallback(
     async (roomId: string) => {

--- a/chat-frontend/src/context/RoomEventsContext/reducer.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.js
@@ -354,6 +354,47 @@ export function roomEventsReducer(state, action) {
     }
     case 'BUCKETS_LOADED': {
       const subs = action.subscriptions ?? {}
+      // Seed only rooms with no preview yet. A live message can land before
+      // fetchSidebarBuckets resolves (the DM subscription goes live first), and
+      // that message is NEWER than this list snapshot — overwriting it would show
+      // an older message in the sidebar than the room itself displays.
+      // Shared by both paths: a degraded bootstrap still carries real previews
+      // for the buckets it did reach.
+      let previews = state.previews
+      for (const [roomId, sub] of Object.entries(subs)) {
+        if (previews[roomId]) continue
+        const preview = previewFromWire(sub?.room?.previewMessage)
+        if (!preview) continue
+        if (previews === state.previews) previews = { ...state.previews }
+        previews[roomId] = preview
+      }
+      if (action.merge) {
+        // Degraded-bootstrap path: one or two `subscription.list` buckets
+        // failed, so this payload is INCOMPLETE and must not be read as
+        // "everything else is gone". Upsert what arrived and leave the
+        // rest — only a complete fetch (replace, below) may delete.
+        const byId = new Map(state.summaries.map((s) => [s.id, s]))
+        for (const r of action.rooms ?? []) {
+          const prev = byId.get(r.id)
+          // Room metadata is server-fresh; unread bookkeeping is
+          // session-local and the payload has no opinion on it.
+          const base = prev
+            ? { ...toSummary(r), unreadCount: prev.unreadCount, hasMention: prev.hasMention, mentionAll: prev.mentionAll }
+            : toSummary(r)
+          byId.set(r.id, mergeSubscriptionIntoSummary(base, subs[r.id]))
+        }
+        return {
+          ...state,
+          summaries: sortByLastMsgDesc([...byId.values()]),
+          // A failed bucket is OMITTED by the caller rather than sent
+          // empty, so presence alone marks a bucket authoritative.
+          favoriteIds: action.favoriteIds ? new Set(action.favoriteIds) : state.favoriteIds,
+          appIds: action.appIds ? new Set(action.appIds) : state.appIds,
+          channelDmIds: action.channelDmIds ? new Set(action.channelDmIds) : state.channelDmIds,
+          subscriptions: { ...state.subscriptions, ...subs },
+          previews,
+        }
+      }
       let summaries
       if (action.rooms) {
         // Cold-start path: rooms are derived from the three subscription
@@ -372,18 +413,6 @@ export function roomEventsReducer(state, action) {
         summaries = state.summaries.map((s) =>
           subs[s.id] ? mergeSubscriptionIntoSummary(s, subs[s.id]) : s
         )
-      }
-      // Seed only rooms with no preview yet. A live message can land before
-      // fetchSidebarBuckets resolves (the DM subscription goes live first), and
-      // that message is NEWER than this list snapshot — overwriting it would show
-      // an older message in the sidebar than the room itself displays.
-      let previews = state.previews
-      for (const [roomId, sub] of Object.entries(subs)) {
-        if (previews[roomId]) continue
-        const preview = previewFromWire(sub?.room?.previewMessage)
-        if (!preview) continue
-        if (previews === state.previews) previews = { ...state.previews }
-        previews[roomId] = preview
       }
       return {
         ...state,

--- a/chat-frontend/src/context/RoomEventsContext/reducer.test.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.test.js
@@ -2364,3 +2364,122 @@ describe('roomEventsReducer: MESSAGE_RECEIVED historical-mode duplicate guard ap
     expect(next).toBe(seeded)
   })
 })
+
+describe('roomEventsReducer: BUCKETS_LOADED merge mode', () => {
+  // A degraded `subscription.list` bootstrap must never delete rooms: the
+  // caller can't tell "no rooms" from "the fetch failed", so a partial
+  // result upserts instead of replacing, and omits the buckets it couldn't
+  // reach rather than sending them as empty.
+  function sub(roomId, overrides = {}) {
+    return { roomId, siteId: 'site-A', name: `sub-${roomId}`, roomType: 'channel', hasMention: false, ...overrides }
+  }
+
+  const seeded = roomEventsReducer(initialState, {
+    type: 'BUCKETS_LOADED',
+    rooms: [room('a'), room('b')],
+    subscriptions: { a: sub('a'), b: sub('b') },
+    favoriteIds: ['a'],
+    appIds: ['b'],
+    channelDmIds: ['a', 'b'],
+  })
+
+  it('keeps subscriptions the merge payload omits', () => {
+    const next = roomEventsReducer(seeded, {
+      type: 'BUCKETS_LOADED',
+      merge: true,
+      rooms: [room('a')],
+      subscriptions: { a: sub('a', { name: 'renamed' }) },
+      channelDmIds: ['a'],
+    })
+    expect(Object.keys(next.subscriptions).sort()).toEqual(['a', 'b'])
+    expect(next.subscriptions.a.name).toBe('renamed')
+  })
+
+  it('keeps summaries the merge payload omits', () => {
+    const next = roomEventsReducer(seeded, {
+      type: 'BUCKETS_LOADED',
+      merge: true,
+      rooms: [room('a', { name: 'room-a-renamed' })],
+      subscriptions: { a: sub('a') },
+      channelDmIds: ['a'],
+    })
+    expect(next.summaries.map((r) => r.id).sort()).toEqual(['a', 'b'])
+    expect(next.summaries.find((r) => r.id === 'a').name).toBe('room-a-renamed')
+  })
+
+  it('keeps the bucket Sets the merge payload omits and replaces the ones it carries', () => {
+    const next = roomEventsReducer(seeded, {
+      type: 'BUCKETS_LOADED',
+      merge: true,
+      rooms: [room('a')],
+      subscriptions: { a: sub('a') },
+      channelDmIds: ['a'],
+    })
+    expect([...next.favoriteIds]).toEqual(['a'])
+    expect([...next.appIds]).toEqual(['b'])
+    expect([...next.channelDmIds]).toEqual(['a'])
+  })
+
+  it('adds rooms the merge payload introduces', () => {
+    const next = roomEventsReducer(seeded, {
+      type: 'BUCKETS_LOADED',
+      merge: true,
+      rooms: [room('c')],
+      subscriptions: { c: sub('c') },
+      channelDmIds: ['a', 'b', 'c'],
+    })
+    expect(next.summaries.map((r) => r.id).sort()).toEqual(['a', 'b', 'c'])
+    expect(next.subscriptions.c).toBeDefined()
+  })
+
+  it('preserves per-summary live state that the merge payload has no opinion on', () => {
+    const withUnread = {
+      ...seeded,
+      summaries: seeded.summaries.map((s) => (s.id === 'a' ? { ...s, unreadCount: 7 } : s)),
+    }
+    const next = roomEventsReducer(withUnread, {
+      type: 'BUCKETS_LOADED',
+      merge: true,
+      rooms: [room('a')],
+      subscriptions: { a: sub('a') },
+      channelDmIds: ['a'],
+    })
+    expect(next.summaries.find((r) => r.id === 'a').unreadCount).toBe(7)
+  })
+
+  it('seeds previews for the subscriptions a merge payload does carry', () => {
+    const next = roomEventsReducer(seeded, {
+      type: 'BUCKETS_LOADED',
+      merge: true,
+      rooms: [room('a')],
+      subscriptions: {
+        a: sub('a', {
+          room: {
+            previewMessage: {
+              messageId: 'm9',
+              content: 'hello there',
+              sender: { account: 'bob', engName: 'Bob' },
+              createdAt: '2026-08-14T10:00:00Z',
+            },
+          },
+        }),
+      },
+      channelDmIds: ['a'],
+    })
+    expect(next.previews.a).toMatchObject({ messageId: 'm9', text: 'hello there' })
+  })
+
+  it('replace mode still drops rooms the payload omits', () => {
+    const next = roomEventsReducer(seeded, {
+      type: 'BUCKETS_LOADED',
+      rooms: [room('a')],
+      subscriptions: { a: sub('a') },
+      favoriteIds: ['a'],
+      appIds: [],
+      channelDmIds: ['a'],
+    })
+    expect(next.summaries.map((r) => r.id)).toEqual(['a'])
+    expect(Object.keys(next.subscriptions)).toEqual(['a'])
+    expect(next.appIds.size).toBe(0)
+  })
+})

--- a/chat-frontend/src/context/RoomEventsContext/useRoomSubscriptions.js
+++ b/chat-frontend/src/context/RoomEventsContext/useRoomSubscriptions.js
@@ -19,6 +19,27 @@ import {
  *  the server's lastSeenAt for the active user stays current. */
 const MARK_READ_DEBOUNCE_MS = 500
 
+/** Which `SidebarBuckets` id-array each bucket owns. A bucket that failed
+ *  is OMITTED from the merge action rather than sent empty — the reducer
+ *  reads presence as "this bucket is authoritative". */
+const BUCKET_ID_FIELD = {
+  favorites: 'favoriteIds',
+  apps: 'appIds',
+  rooms: 'channelDmIds',
+}
+
+const BUCKET_COUNT = Object.keys(BUCKET_ID_FIELD).length
+
+/** Build the BUCKETS_LOADED action for a bootstrap result. A clean fetch
+ *  replaces wholesale (so rooms left while away disappear); a partial one
+ *  merges and drops the failed buckets' id arrays. */
+function bucketsLoadedAction({ failures: _failures, ...buckets }, failures) {
+  if (failures.length === 0) return { type: 'BUCKETS_LOADED', ...buckets }
+  const action = { type: 'BUCKETS_LOADED', merge: true, ...buckets }
+  for (const bucket of failures) delete action[BUCKET_ID_FIELD[bucket]]
+  return action
+}
+
 /**
  * Owns every backend subscription + the initial-room-list fetch that
  * keeps RoomEventsContext.state in sync with the server, AND owns the
@@ -519,17 +540,37 @@ export function useRoomSubscriptions(
       })
     })
 
+    // Rooms restored from the browser cache are on screen already, but
+    // nothing is listening to them yet — the channel-sub loop below only
+    // runs once the bootstrap resolves. Open them now so a warm-painted
+    // channel receives live messages immediately. openChannelSub is
+    // idempotent per (roomId, crossSite), so the bootstrap's loop no-ops
+    // for these and re-opens any whose crossSite it corrects.
+    for (const sub of Object.values(stateRef.current.subscriptions)) {
+      if (sub.roomType !== 'channel') continue
+      openChannelSub(sub.roomId, subToRoom(sub, user.siteId).crossSite)
+    }
+
     // Bootstrap the sidebar via the three user-service subscription
     // RPCs (favorites / apps / channel+dm). Each reply embeds the room
     // metadata inline, so `buckets.rooms` is the canonical full list —
-    // no separate `rooms.list` RPC is needed. Per-bucket failures
-    // degrade to empty (fetchSidebarBuckets uses Promise.allSettled);
-    // a total failure leaves the sidebar empty.
+    // no separate `rooms.list` RPC is needed.
     fetchSidebarBuckets(liveNats)
       .then((buckets) => {
         // Generation check, not just cancelledRef: a slow bootstrap from a
         // prior login must not seed keys or open subs into the new session.
         if (!isCurrent()) return
+
+        // A degraded bucket returns whatever it managed to fetch, which is
+        // indistinguishable from "the user has no rooms" — so an incomplete
+        // result must never be allowed to delete anything. Nothing at all
+        // came back: keep what's on screen (cache or a prior fetch) and
+        // report the failure instead of blanking the sidebar.
+        const failures = buckets.failures ?? []
+        if (failures.length === BUCKET_COUNT) {
+          safeDispatch({ type: 'ROOMS_FAILED', error: 'Could not load your chats.' })
+          return
+        }
         // Dev-only: seed sample sections + membership onto the loaded subs so
         // the grouped sidebar has populated custom sections to demo. No-op in
         // the live path (seedChatlistDemo returns null unless CHATLIST_MOCK).
@@ -542,7 +583,7 @@ export function useRoomSubscriptions(
             if (buckets.subscriptions[roomId]) buckets.subscriptions[roomId].favorite = true
           }
         }
-        safeDispatch({ type: 'BUCKETS_LOADED', ...buckets })
+        safeDispatch(bucketsLoadedAction(buckets, failures))
         // Load the section-definition overlay (chatlist.get). In mock mode
         // this returns the seeded sections; live, the backend's overlay.
         // Wrapped in Promise.resolve so it never blocks the channel-sub setup

--- a/chat-frontend/src/lib/subscriptionCache.js
+++ b/chat-frontend/src/lib/subscriptionCache.js
@@ -1,0 +1,162 @@
+/**
+ * Browser-local cache of the user's subscription list, so the sidebar's
+ * first paint after a reload already has rooms instead of waiting for the
+ * three `subscription.list` bootstrap RPCs to drain.
+ *
+ * localStorage (not IndexedDB) on purpose: the read has to be synchronous
+ * so `RoomEventsProvider` can hydrate inside `useReducer`'s lazy
+ * initializer, during the first render. An async store would force
+ * hydration into an effect, reintroducing the empty first frame this
+ * cache exists to remove.
+ *
+ * Only ever an accelerator: every entry point swallows storage failures
+ * and degrades to "no cache". Nothing here is a source of truth — the
+ * bootstrap fetch reconciles whatever we paint.
+ */
+
+/** @typedef {import('../api/types').DMSubscription} DMSubscription */
+/** @typedef {import('../api/types').ChatlistState} ChatlistState */
+
+/**
+ * @typedef {object} SubscriptionCachePayload
+ * @property {Record<string, DMSubscription>} subscriptions
+ * @property {string[]} favoriteIds
+ * @property {string[]} appIds
+ * @property {string[]} channelDmIds
+ * @property {ChatlistState} [chatlist]
+ */
+
+export const CACHE_KEY = 'chat.subscriptionCache.v1'
+
+/** Bumped whenever the stored shape changes. A record written by an older
+ *  (or newer) build is ignored rather than migrated — the bootstrap fetch
+ *  refills it within a second. */
+export const CACHE_VERSION = 1
+
+/** How many subscriptions a quota-failed write retries with, keeping the
+ *  most recently active rooms. A truncated cache is fine: it only shortens
+ *  the warm paint, and the fetch restores the full list. */
+export const QUOTA_RETRY_LIMIT = 300
+
+/** Drop the room's E2E private key before it reaches disk. Room keys stay
+ *  memory-only in RoomKeysContext, and this cache must not be the thing
+ *  that changes that. Everything else is copied as-is so the cache doesn't
+ *  silently lose fields as the wire type grows. */
+function withoutPrivateKey(sub) {
+  if (!sub?.room || !('privateKey' in sub.room)) return sub
+  const { privateKey, ...room } = sub.room
+  return { ...sub, room }
+}
+
+/** The bucket ids live in state as Sets, and `JSON.stringify(new Set(…))`
+ *  is `"{}"` — persisting one verbatim would hand the next hydration a
+ *  non-iterable. Normalize any iterable to a plain array. */
+function toIdArray(ids) {
+  if (!ids) return []
+  return Array.isArray(ids) ? ids : [...ids]
+}
+
+function lastActivity(sub) {
+  const ts = Date.parse(sub?.room?.lastMsgAt ?? '')
+  return Number.isNaN(ts) ? 0 : ts
+}
+
+/** Keep the `limit` most recently active rooms. */
+function trimToRecent(subscriptions, limit) {
+  const entries = Object.entries(subscriptions)
+  if (entries.length <= limit) return subscriptions
+  entries.sort((a, b) => lastActivity(b[1]) - lastActivity(a[1]))
+  return Object.fromEntries(entries.slice(0, limit))
+}
+
+function write(record) {
+  window.localStorage.setItem(CACHE_KEY, JSON.stringify(record))
+}
+
+/**
+ * Persist the sidebar-shaped slices for `user`. No-op without an
+ * identified user. A failed write (quota, disabled storage) is retried
+ * once with a trimmed subscription set, then the record is dropped
+ * entirely rather than left half-written.
+ *
+ * @param {{ account?: string, siteId?: string } | null | undefined} user
+ * @param {{
+ *   subscriptions?: Record<string, DMSubscription>,
+ *   favoriteIds?: Iterable<string>,
+ *   appIds?: Iterable<string>,
+ *   channelDmIds?: Iterable<string>,
+ *   chatlist?: ChatlistState,
+ * }} slices
+ */
+export function saveSubscriptionCache(user, { subscriptions, favoriteIds, appIds, channelDmIds, chatlist }) {
+  if (!user?.account || !user?.siteId) return
+  const record = {
+    v: CACHE_VERSION,
+    account: user.account,
+    siteId: user.siteId,
+    savedAt: Date.now(),
+    subscriptions: Object.fromEntries(
+      Object.entries(subscriptions ?? {}).map(([roomId, sub]) => [roomId, withoutPrivateKey(sub)]),
+    ),
+    favoriteIds: toIdArray(favoriteIds),
+    appIds: toIdArray(appIds),
+    channelDmIds: toIdArray(channelDmIds),
+    chatlist,
+  }
+  try {
+    write(record)
+    return
+  } catch {
+    // Fall through to the trimmed retry.
+  }
+  try {
+    write({ ...record, subscriptions: trimToRecent(record.subscriptions, QUOTA_RETRY_LIMIT) })
+  } catch {
+    clearSubscriptionCache()
+  }
+}
+
+/**
+ * Read the cached slices for `user`, or null when there is nothing
+ * usable: no record, a record from another schema version, a record
+ * belonging to a different account or site, or malformed content.
+ *
+ * A different account overwrites rather than accumulating one record per
+ * user, which bounds what the cache can occupy. The cost is that the
+ * previous account's next login is a cold start.
+ *
+ * @param {{ account?: string, siteId?: string } | null | undefined} user
+ * @returns {SubscriptionCachePayload | null}
+ */
+export function loadSubscriptionCache(user) {
+  if (!user?.account || !user?.siteId) return null
+  let record
+  try {
+    const raw = window.localStorage.getItem(CACHE_KEY)
+    if (!raw) return null
+    record = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (record?.v !== CACHE_VERSION) return null
+  if (record.account !== user.account || record.siteId !== user.siteId) return null
+  if (!record.subscriptions || typeof record.subscriptions !== 'object') return null
+  // localStorage is user-editable, so a bucket that isn't an array is
+  // dropped rather than passed on to `new Set(...)` at hydration.
+  const ids = (value) => (Array.isArray(value) ? value : [])
+  return {
+    subscriptions: record.subscriptions,
+    favoriteIds: ids(record.favoriteIds),
+    appIds: ids(record.appIds),
+    channelDmIds: ids(record.channelDmIds),
+    chatlist: record.chatlist,
+  }
+}
+
+export function clearSubscriptionCache() {
+  try {
+    window.localStorage.removeItem(CACHE_KEY)
+  } catch {
+    // Storage unavailable; nothing to clear.
+  }
+}

--- a/chat-frontend/src/lib/subscriptionCache.test.js
+++ b/chat-frontend/src/lib/subscriptionCache.test.js
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  CACHE_KEY,
+  QUOTA_RETRY_LIMIT,
+  clearSubscriptionCache,
+  loadSubscriptionCache,
+  saveSubscriptionCache,
+} from './subscriptionCache'
+
+const USER = { account: 'alice', siteId: 'site-a' }
+
+function sub(roomId, overrides = {}) {
+  return {
+    id: `s-${roomId}`,
+    u: { id: 'u1', account: 'alice' },
+    roomId,
+    siteId: 'site-a',
+    roles: ['member'],
+    name: `room ${roomId}`,
+    roomType: 'channel',
+    joinedAt: '2026-08-01T00:00:00Z',
+    hasMention: false,
+    alert: true,
+    ...overrides,
+  }
+}
+
+function payload(overrides = {}) {
+  return {
+    subscriptions: { r1: sub('r1') },
+    favoriteIds: ['r1'],
+    appIds: [],
+    channelDmIds: ['r1'],
+    chatlist: { sectionOrder: ['favorites'], sections: {}, sortMode: 'recent' },
+    ...overrides,
+  }
+}
+
+describe('subscriptionCache', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('round-trips the persisted slices', () => {
+    saveSubscriptionCache(USER, payload())
+    expect(loadSubscriptionCache(USER)).toEqual(payload())
+  })
+
+  it('stores the bucket ids as arrays when the caller passes Sets', () => {
+    // state.favoriteIds & friends are Sets, and JSON.stringify(new Set([...]))
+    // is "{}" — persisting one verbatim would hand hydration a non-iterable.
+    saveSubscriptionCache(USER, {
+      ...payload(),
+      favoriteIds: new Set(['r1']),
+      appIds: new Set(),
+      channelDmIds: new Set(['r1', 'r2']),
+    })
+    const loaded = loadSubscriptionCache(USER)
+    expect(loaded.favoriteIds).toEqual(['r1'])
+    expect(loaded.appIds).toEqual([])
+    expect(loaded.channelDmIds.sort()).toEqual(['r1', 'r2'])
+  })
+
+  it('strips room.privateKey while keeping the rest of room', () => {
+    saveSubscriptionCache(
+      USER,
+      payload({
+        subscriptions: {
+          r1: sub('r1', {
+            room: { userCount: 4, keyVersion: 2, crossSite: false, privateKey: 'SECRET' },
+          }),
+        },
+      }),
+    )
+    const room = loadSubscriptionCache(USER).subscriptions.r1.room
+    expect(room).toEqual({ userCount: 4, keyVersion: 2, crossSite: false })
+    expect(window.localStorage.getItem(CACHE_KEY)).not.toContain('SECRET')
+  })
+
+  it('returns null when nothing is stored', () => {
+    expect(loadSubscriptionCache(USER)).toBeNull()
+  })
+
+  it('returns null when the schema version differs', () => {
+    saveSubscriptionCache(USER, payload())
+    const stored = JSON.parse(window.localStorage.getItem(CACHE_KEY))
+    window.localStorage.setItem(CACHE_KEY, JSON.stringify({ ...stored, v: 999 }))
+    expect(loadSubscriptionCache(USER)).toBeNull()
+  })
+
+  it('returns null for a different account', () => {
+    saveSubscriptionCache(USER, payload())
+    expect(loadSubscriptionCache({ account: 'bob', siteId: 'site-a' })).toBeNull()
+  })
+
+  it('returns null for the same account on a different site', () => {
+    saveSubscriptionCache(USER, payload())
+    expect(loadSubscriptionCache({ account: 'alice', siteId: 'site-b' })).toBeNull()
+  })
+
+  it('returns null for malformed JSON', () => {
+    window.localStorage.setItem(CACHE_KEY, '{not json')
+    expect(loadSubscriptionCache(USER)).toBeNull()
+  })
+
+  it('returns null when the record has no subscriptions map', () => {
+    window.localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({ v: 1, account: 'alice', siteId: 'site-a', subscriptions: null }),
+    )
+    expect(loadSubscriptionCache(USER)).toBeNull()
+  })
+
+  it('falls back to empty buckets when a stored record holds non-array ids', () => {
+    // localStorage is user-editable; a bucket that isn't an array would
+    // otherwise reach `new Set(...)` and throw during the first render.
+    saveSubscriptionCache(USER, payload())
+    const stored = JSON.parse(window.localStorage.getItem(CACHE_KEY))
+    window.localStorage.setItem(CACHE_KEY, JSON.stringify({ ...stored, favoriteIds: { r1: true } }))
+    expect(loadSubscriptionCache(USER).favoriteIds).toEqual([])
+  })
+
+  it('clearSubscriptionCache removes the record', () => {
+    saveSubscriptionCache(USER, payload())
+    clearSubscriptionCache()
+    expect(window.localStorage.getItem(CACHE_KEY)).toBeNull()
+  })
+
+  it('retries a quota failure with only the most recently active rooms', () => {
+    const subscriptions = {}
+    for (let i = 0; i < QUOTA_RETRY_LIMIT + 5; i++) {
+      subscriptions[`r${i}`] = sub(`r${i}`, {
+        room: { lastMsgAt: new Date(1_700_000_000_000 + i * 1000).toISOString() },
+      })
+    }
+    const quotaErr = new Error('quota')
+    quotaErr.name = 'QuotaExceededError'
+    const setItem = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementationOnce(() => {
+        throw quotaErr
+      })
+    saveSubscriptionCache(USER, payload({ subscriptions }))
+    setItem.mockRestore()
+
+    const loaded = loadSubscriptionCache(USER)
+    expect(Object.keys(loaded.subscriptions)).toHaveLength(QUOTA_RETRY_LIMIT)
+    // The five oldest rooms are the ones dropped.
+    expect(loaded.subscriptions.r0).toBeUndefined()
+    expect(loaded.subscriptions[`r${QUOTA_RETRY_LIMIT + 4}`]).toBeDefined()
+  })
+
+  it('clears the record when even the trimmed retry exceeds quota', () => {
+    saveSubscriptionCache(USER, payload())
+    const quotaErr = new Error('quota')
+    quotaErr.name = 'QuotaExceededError'
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw quotaErr
+    })
+    expect(() => saveSubscriptionCache(USER, payload())).not.toThrow()
+    vi.restoreAllMocks()
+    expect(window.localStorage.getItem(CACHE_KEY)).toBeNull()
+  })
+
+  it('survives storage that throws on read', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage disabled')
+    })
+    expect(loadSubscriptionCache(USER)).toBeNull()
+  })
+
+  it('survives storage that throws on clear', () => {
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new Error('storage disabled')
+    })
+    expect(() => clearSubscriptionCache()).not.toThrow()
+  })
+
+  it('does not write without an identified user', () => {
+    saveSubscriptionCache(null, payload())
+    expect(window.localStorage.getItem(CACHE_KEY)).toBeNull()
+  })
+})

--- a/docs/superpowers/specs/2026-08-12-chat-frontend-subscription-cache-design.md
+++ b/docs/superpowers/specs/2026-08-12-chat-frontend-subscription-cache-design.md
@@ -1,0 +1,218 @@
+# chat-frontend: remember the user's subscriptions
+
+**Date:** 2026-08-12
+**Scope:** `chat-frontend` only. No backend service, NATS subject, or `pkg/model` type changes.
+
+## Problem
+
+Every login and every page reload starts the sidebar from nothing. `useRoomSubscriptions`
+fires `fetchSidebarBuckets` once per login cycle; until those three paginated
+`subscription.list` RPCs drain, `state.subscriptions`, `state.summaries`, and the three
+bucket ID sets are empty and the sidebar renders blank.
+
+The blank sidebar is also *sticky on failure*. `fetchSidebarBuckets` wraps the three bucket
+fetches in `Promise.allSettled` and degrades a failed bucket to `[]`, and `fetchAllPages`
+returns the pages it already has when a later page fails. The caller cannot distinguish
+"this user has no rooms" from "the fetch failed", so it dispatches `BUCKETS_LOADED`
+regardless — and that action replaces `state.subscriptions` wholesale and rebuilds
+`summaries` from `action.rooms`. A degraded fetch therefore overwrites a populated sidebar
+with an empty one.
+
+## Goals
+
+1. **Warm start.** The sidebar's first paint after reload shows the user's rooms, grouped
+   into their real chatlist sections, with no empty-then-populate flash.
+2. **Failures are never destructive.** Neither a degraded `subscription.list` bootstrap nor a
+   failed per-room `fetchMessageHistory` may remove rooms from the sidebar. Only a complete,
+   successful fetch is allowed to delete anything.
+
+## Non-goals
+
+Caching message bodies; an offline send queue; restoring `activeRoomId` across reloads;
+persisting room E2E keys; rendering the sidebar before the NATS connection is established
+(`App.jsx` gates `RoomEventsProvider` on `connected`, and that gate is unchanged).
+
+## Approach
+
+localStorage, read synchronously from the reducer's lazy initializer.
+
+IndexedDB was considered and rejected: its async API cannot run during the provider's first
+render, so hydration would have to arrive via an effect-dispatched action — reintroducing
+exactly the empty first frame this design removes. Its extra quota is not needed; at roughly
+300 bytes per trimmed subscription, 1,000 rooms is about 300KB, comfortably inside the ~5MB
+localStorage budget.
+
+## Component 1 — `src/lib/subscriptionCache.js`
+
+A synchronous storage helper. No React, no NATS, no async I/O, so it belongs in `lib/`.
+
+```js
+save(user, { subscriptions, favoriteIds, appIds, channelDmIds, chatlist })
+load(user) -> payload | null
+clear()
+```
+
+**Storage key.** One key, `chat.subscriptionCache.v1`, with `account` and `siteId` stamped
+inside the record. `load` returns `null` unless both the schema version and the identity match
+the passed `user`.
+
+A single key means a second account on the same machine overwrites the first rather than
+accumulating one blob per user, which bounds disk usage. Accepted trade-off: after account B
+logs in, account A's next login is a cold start. The cache is deliberately *not* cleared on
+logout — re-login by the same account stays warm.
+
+**Trim rule.** Deep-copy each subscription minus `room.privateKey`. One rule, not a field
+allowlist, so the cache does not silently drop fields as the wire type grows. Room E2E keys
+stay memory-only, matching `RoomKeysContext`'s current policy.
+
+**Failure handling.** Every read and write is `try/catch`-wrapped — disabled or private-mode
+storage must never break the app. On `QuotaExceededError`, retry once with the 300
+subscriptions having the most recent `room.lastMsgAt`; if that also fails, `clear()` and give
+up. The cache is only a paint accelerator, so degrading it is always safe.
+
+## Component 2 — hydration in `RoomEventsProvider`
+
+`state.summaries` is **not** persisted. Each subscription already carries its room metadata
+inline under `sub.room` — the reason the cold-start path needs no separate `rooms.list` RPC —
+so summaries are derived on hydration through the existing mappers:
+
+```js
+const [state, dispatch] = useReducer(roomEventsReducer, initialState, () => {
+  const cached = load(user)
+  if (!cached) return initialState
+  const rooms = Object.values(cached.subscriptions).map((s) => subToRoom(s, user.siteId))
+  const s = roomEventsReducer(initialState, { type: 'BUCKETS_LOADED', ...cached, rooms })
+  return roomEventsReducer(s, { type: 'CHATLIST_LOADED', chatlist: cached.chatlist })
+})
+```
+
+Hydration replays the cached data through the same actions the network path uses, so cached
+state and fetched state are identical in shape by construction — there is no parallel
+hydration code to drift. Two details follow for free: `toSummary` zero-inits `unreadCount`
+(a session-local counter that no fetch ever corrects, so a persisted value would be
+permanently stale), and `hasMention` is merged from the subscription record, which is
+server-canonical.
+
+Running inside the lazy initializer means this executes during the provider's first render,
+so the first paint already has rooms.
+
+**Consequence.** Cached subscriptions carry no `privateKey`, so an encrypted room warm-paints
+in the sidebar but its messages show the decryption placeholder until the fetch lands and
+re-seeds keys via `seedKeys`. Sidebar rows are unaffected.
+
+## Component 3 — write-through
+
+An effect in `RoomEventsProvider` keyed by reference on the five persisted slices
+(`subscriptions`, `favoriteIds`, `appIds`, `channelDmIds`, `chatlist`). Ordinary message
+traffic churns `roomState`, `summaries`, and `msgRecvSeq` but never these five, so the effect
+stays quiet; a 1s trailing debounce absorbs `SUBSCRIPTION_UPSERTED` bursts.
+
+**Teardown guard.** Skip the write when `state.subscriptions === initialState.subscriptions`.
+`RESET` returns the `initialState` object itself, so that identity check is an exact
+"we're torn down" test — it stops logout and StrictMode remounts from blanking the cache.
+
+## Component 4 — degradation-aware bootstrap
+
+### `fetchSidebarBuckets` reports what failed
+
+Add one field to `SidebarBuckets`:
+
+```ts
+failures: ('favorites' | 'apps' | 'rooms')[]
+```
+
+populated from the existing `allSettled` unwrap. A partial-page failure inside `fetchAllPages`
+(page 3 of 5 fails, pages 1–2 kept) also marks its bucket degraded — a truncated bucket must
+not be allowed to delete rooms.
+
+### `useRoomSubscriptions` branches on it
+
+| `failures.length` | Action |
+|---|---|
+| 0 | `BUCKETS_LOADED` as today — full replace, so rooms left while away disappear |
+| 1–2 | `BUCKETS_LOADED` with `merge: true`, **omitting the failed buckets' id arrays** |
+| 3 | No `BUCKETS_LOADED`; dispatch `ROOMS_FAILED` — cached sidebar stays, `useRoomSummaries().error` surfaces it |
+
+### `BUCKETS_LOADED` gains `action.merge`
+
+Replace mode (the default) is unchanged. Merge mode:
+
+- `subscriptions = { ...state.subscriptions, ...subs }` — upsert only, never remove.
+- Each bucket set: `action.favoriteIds ? new Set(action.favoriteIds) : state.favoriteIds`, and
+  likewise for `appIds` / `channelDmIds`. Because the hook *omits* failed buckets rather than
+  sending empty arrays, presence alone marks a bucket authoritative — no extra flag needed.
+- `summaries`: upsert `action.rooms` into `state.summaries`, keep unlisted rows, re-sort.
+
+### Per-room history failures
+
+`HISTORY_FAILED` already touches only that room's buffer in `roomState`, leaving `summaries`
+and `subscriptions` alone. This is a don't-regress requirement, covered by a test rather than
+a code change.
+
+## Component 5 — live subscriptions for warm-painted channels
+
+`openChannelSub` is driven by the fetch's `buckets.rooms` loop, so without this a warm-painted
+channel would render but receive no live messages until the fetch lands.
+
+The effect in `useRoomSubscriptions` opens channel subs for hydrated rooms in
+`stateRef.current.summaries` immediately after the four base subscriptions are set up.
+`openChannelSub` is already idempotent per `(roomId, crossSite)`, so the later fetch loop
+no-ops for rooms already open and re-opens any whose `crossSite` the fetch corrects.
+
+## Data flow
+
+Cold start (no cache):
+
+```
+mount → load() → null → initialState (sidebar empty)
+      → fetchSidebarBuckets → BUCKETS_LOADED (replace) → sidebar paints
+      → write-through persists
+```
+
+Warm start (cache present, fetch succeeds):
+
+```
+mount → load() → payload → BUCKETS_LOADED + CHATLIST_LOADED in lazy init
+      → FIRST PAINT has rooms + sections
+      → openChannelSub for cached channels
+      → fetchSidebarBuckets → BUCKETS_LOADED (replace) → reconciled
+      → write-through persists
+```
+
+Warm start, bootstrap fully fails:
+
+```
+mount → hydrated first paint
+      → fetchSidebarBuckets → failures = 3 → ROOMS_FAILED only
+      → sidebar keeps showing cached rooms; error surfaces via useRoomSummaries().error
+      → write-through does not fire (no persisted slice changed)
+```
+
+## Testing
+
+TDD, red first, per the root guidelines.
+
+**`lib/subscriptionCache.test.js`** — save/load round trip; `privateKey` stripped; version
+mismatch → `null`; account or siteId mismatch → `null`; malformed JSON → `null`; quota error →
+trim-and-retry then clear; storage throwing on access → no throw.
+
+**`reducer.test.js`** — merge mode adds new subs, keeps unlisted ones, keeps bucket sets for
+omitted buckets, replaces sets for present ones; replace mode still removes departed rooms;
+`HISTORY_FAILED` leaves `summaries` and `subscriptions` untouched.
+
+**`fetchSidebarBuckets/index.test.ts`** — `failures` populated per bucket, including the
+mid-pagination case.
+
+**`RoomEventsContext.test.jsx`** — a hydrated provider has rooms on first render (asserted
+without awaiting); an all-three-bucket failure leaves hydrated state intact and sets
+`roomsError`; a partial failure keeps the failed bucket's cached rooms; channel subs are
+opened for cached channels.
+
+## Documentation
+
+`chat-frontend/CLAUDE.md`'s "Subscription state" section gains cache hydration as the third
+population source alongside `BUCKETS_LOADED` and `SUBSCRIPTION_UPSERTED`, plus the
+merge-vs-replace rule.
+
+`docs/client-api.md` is untouched — no client-facing handler, subject, or `pkg/model` type
+changes.


### PR DESCRIPTION
## Why

The sidebar has no memory. Every login and reload starts from an empty `state.subscriptions`, and nothing renders until three paginated `subscription.list` buckets drain.

The blank sidebar is also sticky on failure. `fetchSidebarBuckets` degrades a failed bucket to `[]`, and `fetchAllPages` returns the pages it already has when a later page fails — so the caller cannot tell *"this user has no rooms"* from *"the fetch failed"*. It dispatched `BUCKETS_LOADED` either way, and that action replaces `subscriptions` wholesale. A dropped connection overwrote a populated sidebar with an empty one.

## What changed

**Warm start.** `RoomEventsProvider` hydrates from `lib/subscriptionCache` inside `useReducer`'s lazy initializer, so the first paint already has rooms and sections. Hydration replays the cached data through the *same* `BUCKETS_LOADED` + `CHATLIST_LOADED` actions the network path uses, so cached and fetched state are identical in shape by construction — no parallel hydration path to drift. `summaries` are derived via `subToRoom` rather than persisted, which also stops `unreadCount` (a session-local counter no fetch ever corrects) from persisting a permanently stale value.

localStorage rather than IndexedDB is load-bearing: the read must be synchronous to run during the first render. An async store would push hydration into an effect and leave the empty frame exactly where it is.

**Failures stop being destructive.** `fetchSidebarBuckets` now reports `failures: SidebarBucket[]`, covering all three causes — a rejected RPC, a rejected later page, and a server that never clears `hasMore`. `useRoomSubscriptions` branches on it:

| Failed buckets | Behavior |
|---|---|
| 0 | Replace wholesale — the only path that may delete rooms |
| 1–2 | `BUCKETS_LOADED` with `merge: true`, **omitting** the failed buckets' id arrays (the reducer reads presence as "this bucket is authoritative") |
| 3 | `ROOMS_FAILED` only — cached rooms stay on screen under the error banner |

**Cache contents.** Subscriptions, the three bucket id sets, and the chatlist overlay, under one key stamped with the owning `account`/`siteId` so another account's record is ignored rather than rendered. `room.privateKey` is stripped before writing, so room E2E keys stay memory-only as they are today. Write-through is a 1s trailing debounce keyed by reference on those slices, guarded by an identity check against `initialState` — `RESET` returns that object, making the check an exact "we've been torn down" test so logout and StrictMode remounts cannot blank a good cache. Quota failures retry once with the 300 most recently active rooms, then drop the record.

## Notes for reviewers

- **Encrypted rooms warm-paint without keys.** A cached encrypted room appears in the sidebar immediately, but its messages show the decryption placeholder until the bootstrap re-seeds keys. Deliberate — persisting key material was rejected.
- **Message previews are not cached.** The sidebar-preview feature landed after this design; warm-painted rows show a blank snippet line until the fetch lands. Persisting them would put message text on disk in a cache that deliberately survives logout, so it is left out pending a call on that trade-off.
- **The cache survives logout,** keyed per account, so re-login is warm. A second account on the same machine overwrites the record, which bounds disk use at the cost of a cold start for the first account.
- **One existing test file changed:** `RoomEventsContext.test.jsx` now clears `localStorage` between tests — without it one test's persisted sidebar warm-starts the next test's provider.
- The design doc is included at `docs/superpowers/specs/2026-08-12-chat-frontend-subscription-cache-design.md`.

## Testing

Written test-first throughout — every batch was run and watched fail before implementing. New coverage: `lib/subscriptionCache.test.js` (round trip, `privateKey` stripping, version/identity/malformed rejection, quota retry, hostile storage), `reducer.test.js` merge mode (upsert, omitted-bucket retention, preview seeding, replace-still-deletes), `fetchSidebarBuckets/index.test.ts` failure reporting, and `RoomEventsContext.cache.test.jsx` (first-render paint, per-bucket failure retention, channel subs for cached rooms, teardown guard).

`npm test` 986 passing across 87 files · `npm run typecheck` clean · `vite build` clean.