### PR TITLE
feat(search): SHOW_TEAMS_ROOM config to hide Teams rooms from list/search/counts

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -4070,6 +4070,8 @@ See [Error envelope](#6-error-envelope-reference).
 
 **System messages are never returned.** Server-generated room chrome (`type` of `room_created`, `members_added`, `member_removed`, `member_left`, `room_renamed`, `room_restricted`, `teams_meet_started` — see [`Message.type`](#message-schema)) is excluded from the search index, so it can never appear in `messages`. A client-set `type: "important"` message is normal user content and remains searchable.
 
+**Teams-migrated messages** are excluded when the server's `SHOW_TEAMS_ROOM` env is `false` (the default); included when `true`. Reversible read-time filter on the indexed `origin` field, no data change.
+
 ##### Request body
 
 ```json
@@ -4229,6 +4231,8 @@ See [Error envelope](#6-error-envelope-reference).
 **Reply subject:** auto-generated `_INBOX.>` (NATS request/reply)
 
 `{siteID}` is the requester's home site; the supercluster routes the request to that site's search-service. Full-text search across rooms the requester is subscribed to. Results are served directly from the spotlight ES index (one document per `(account, room)` pair), in ES relevance order.
+
+**Teams-migrated rooms** are excluded when the server's `SHOW_TEAMS_ROOM` env is `false` (the default); included when `true`. Reversible read-time filter on the indexed `origin` field, no data change.
 
 ##### Request body
 
@@ -5154,6 +5158,7 @@ Results are **paginated** by `offset`/`limit` (offset-based): the server returns
   - **List paths** (`subscription.list`, `subscription.getChannels`) and `subscription.count`: the subscription is **dropped**. Local rooms are filtered in the Mongo query; cross-site rooms are dropped after the per-site `GetRoomsInfo` lookup reveals the `Del-` name — this happens post-pagination, so a page can be shorter than `limit` (`hasMore` is computed from the database page, before the cross-site drop).
   - **Single-item lookups** (`subscription.getDM`, `subscription.getByRoomID`): the subscription is **kept with no `room` object** — the row is returned so the caller knows the subscription exists, but the deleted room is omitted.
 - **Local** rows carry the full room object (metadata + E2E key) from the `$lookup` baseline. **Cross-site** rows are fetched per remote site in parallel; if a site's RPC fails or a room isn't found, those rows are returned with **no `room` object** (the field is omitted) — the subscription still carries its own top-level `siteId`. `alert` and `hasMention` are unaffected (they come from the subscription, not the RPC).
+- **Teams-migrated rooms** (`room.origin == "teams"`, server-side only — not sent on the wire): excluded from `subscription.list`/`subscription.count` when the server's `SHOW_TEAMS_ROOM` env is `false` (the default); included when `true`. Reversible read-time filter, no data change.
 
 **Per-room-type record shape.** The kinds returned by `subscription.list` differ by row schema: `channel` and `dm` rows use the [Subscription](#subscription) schema (§3.0) — `dm` adds a top-level `hrInfo` — while `botDM` rows add a nested `app` object ([AppSubscription](#appsubscription), §3.0). All carry the nested [SubscriptionRoom](#subscriptionroom) (§3.0). Every field except the ones below is identical across the three types (`id`, `u`, `roomId`, `siteId`, `roles`, `joinedAt`, `muted`, `favorite`, `alert`, `hasMention`, `hasUnread`, `hasGroupMention`, the per-attribute `*UpdatedAt` timestamps, and the rest of `room`). `isSubscribed` is a **base [Subscription](#subscription) field** (boolean, optional — omitted unless stored `true`) shared by all three types, not a type-specific field. Type-specific fields:
 

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -4070,7 +4070,7 @@ See [Error envelope](#6-error-envelope-reference).
 
 **System messages are never returned.** Server-generated room chrome (`type` of `room_created`, `members_added`, `member_removed`, `member_left`, `room_renamed`, `room_restricted`, `teams_meet_started` — see [`Message.type`](#message-schema)) is excluded from the search index, so it can never appear in `messages`. A client-set `type: "important"` message is normal user content and remains searchable.
 
-**Teams-migrated messages** are excluded when the server's `SHOW_TEAMS_ROOM` env is `false` (the default); included when `true`. Reversible read-time filter on the indexed `origin` field, no data change.
+**Teams-migrated messages** are excluded when the server's `SHOW_TEAMS_ROOM` env is `false` (the default); included when `true`, **or** when the requesting account is listed in `SHOW_TEAMS_ROOM_ACCOUNTS` (a comma-separated per-account allowlist). Reversible read-time filter on the indexed `origin` field, no data change.
 
 ##### Request body
 
@@ -4232,7 +4232,7 @@ See [Error envelope](#6-error-envelope-reference).
 
 `{siteID}` is the requester's home site; the supercluster routes the request to that site's search-service. Full-text search across rooms the requester is subscribed to. Results are served directly from the spotlight ES index (one document per `(account, room)` pair), in ES relevance order.
 
-**Teams-migrated rooms** are excluded when the server's `SHOW_TEAMS_ROOM` env is `false` (the default); included when `true`. Reversible read-time filter on the indexed `origin` field, no data change.
+**Teams-migrated rooms** are excluded when the server's `SHOW_TEAMS_ROOM` env is `false` (the default); included when `true`, **or** when the requesting account is listed in `SHOW_TEAMS_ROOM_ACCOUNTS` (a comma-separated per-account allowlist). Reversible read-time filter on the indexed `origin` field, no data change.
 
 ##### Request body
 
@@ -5158,7 +5158,7 @@ Results are **paginated** by `offset`/`limit` (offset-based): the server returns
   - **List paths** (`subscription.list`, `subscription.getChannels`) and `subscription.count`: the subscription is **dropped**. Local rooms are filtered in the Mongo query; cross-site rooms are dropped after the per-site `GetRoomsInfo` lookup reveals the `Del-` name — this happens post-pagination, so a page can be shorter than `limit` (`hasMore` is computed from the database page, before the cross-site drop).
   - **Single-item lookups** (`subscription.getDM`, `subscription.getByRoomID`): the subscription is **kept with no `room` object** — the row is returned so the caller knows the subscription exists, but the deleted room is omitted.
 - **Local** rows carry the full room object (metadata + E2E key) from the `$lookup` baseline. **Cross-site** rows are fetched per remote site in parallel; if a site's RPC fails or a room isn't found, those rows are returned with **no `room` object** (the field is omitted) — the subscription still carries its own top-level `siteId`. `alert` and `hasMention` are unaffected (they come from the subscription, not the RPC).
-- **Teams-migrated rooms** (`room.origin == "teams"`, server-side only — not sent on the wire): excluded from `subscription.list`/`subscription.count` when the server's `SHOW_TEAMS_ROOM` env is `false` (the default); included when `true`. Reversible read-time filter, no data change.
+- **Teams-migrated rooms** (`room.origin == "teams"`, server-side only — not sent on the wire): excluded from `subscription.list`/`subscription.count` when the server's `SHOW_TEAMS_ROOM` env is `false` (the default); included when `true`, **or** when the requesting account is listed in `SHOW_TEAMS_ROOM_ACCOUNTS` (a comma-separated per-account allowlist). Reversible read-time filter, no data change.
 
 **Per-room-type record shape.** The kinds returned by `subscription.list` differ by row schema: `channel` and `dm` rows use the [Subscription](#subscription) schema (§3.0) — `dm` adds a top-level `hrInfo` — while `botDM` rows add a nested `app` object ([AppSubscription](#appsubscription), §3.0). All carry the nested [SubscriptionRoom](#subscriptionroom) (§3.0). Every field except the ones below is identical across the three types (`id`, `u`, `roomId`, `siteId`, `roles`, `joinedAt`, `muted`, `favorite`, `alert`, `hasMention`, `hasUnread`, `hasGroupMention`, the per-attribute `*UpdatedAt` timestamps, and the rest of `room`). `isSubscribed` is a **base [Subscription](#subscription) field** (boolean, optional — omitted unless stored `true`) shared by all three types, not a type-specific field. Type-specific fields:
 

--- a/inbox-worker/handler.go
+++ b/inbox-worker/handler.go
@@ -198,6 +198,10 @@ func (h *Handler) handleMemberAdded(ctx context.Context, evt *model.InboxEvent) 
 			HistorySharedSince: historySharedSince,
 			JoinedAt:           joinedAt,
 			Open:               true,
+			// Stamp provenance on the federated sub so the origin filter (which reads
+			// the sub's own origin, not the null cross-site $room.origin) can hide a
+			// Teams room from a remote member. Empty for native rooms.
+			Origin: event.Origin,
 		}
 		subs = append(subs, sub)
 	}

--- a/inbox-worker/handler_test.go
+++ b/inbox-worker/handler_test.go
@@ -550,6 +550,52 @@ func TestHandleEvent_MemberAdded(t *testing.T) {
 
 }
 
+// TestHandleEvent_MemberAdded_OriginStamped proves the Teams federation lane's
+// origin survives the decode: the producer marshals an InboxMemberEvent (which
+// carries Origin), the consumer decodes into MemberAddEvent, and the created sub
+// must be stamped so the remote-side origin filter can hide it. A native add
+// (no origin) leaves the sub origin empty.
+func TestHandleEvent_MemberAdded_OriginStamped(t *testing.T) {
+	run := func(t *testing.T, payload any, wantOrigin string) {
+		store := &stubInboxStore{users: []model.User{{ID: "uid-bob", Account: "bob", SiteID: "site-b"}}}
+		h := NewHandler(store)
+		payloadData, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("marshal payload: %v", err)
+		}
+		evtData, err := json.Marshal(model.InboxEvent{
+			Type: "member_added", SiteID: "site-a", DestSiteID: "site-b", Payload: payloadData,
+		})
+		if err != nil {
+			t.Fatalf("marshal event: %v", err)
+		}
+		if err := h.HandleEvent(context.Background(), evtData); err != nil {
+			t.Fatalf("HandleEvent: %v", err)
+		}
+		subs := store.getSubscriptions()
+		if len(subs) != 1 {
+			t.Fatalf("expected 1 subscription, got %d", len(subs))
+		}
+		if subs[0].Origin != wantOrigin {
+			t.Errorf("subscription Origin = %q, want %q", subs[0].Origin, wantOrigin)
+		}
+	}
+
+	t.Run("teams federation lane stamps origin", func(t *testing.T) {
+		// The Teams lane's real wire shape (room-worker federateTeamsMembership).
+		run(t, model.InboxMemberEvent{
+			RoomID: "room-teams", RoomType: model.RoomTypeChannel, SiteID: "site-a",
+			Accounts: []string{"bob"}, Origin: model.OriginTeams, Timestamp: 1,
+		}, model.OriginTeams)
+	})
+	t.Run("native add leaves origin empty", func(t *testing.T) {
+		run(t, model.MemberAddEvent{
+			Type: "member_added", RoomID: "room-native", SiteID: "site-a",
+			Accounts: []string{"bob"}, Timestamp: 1,
+		}, "")
+	})
+}
+
 func TestHandleEvent_MemberAdded_SetsTimestamps(t *testing.T) {
 	store := &stubInboxStore{
 		users: []model.User{

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -241,8 +241,12 @@ type MemberAddEvent struct {
 	HistorySharedSince *int64   `json:"historySharedSince,omitempty" bson:"historySharedSince,omitempty"`
 	// Members carries the member.list (enrich=true) display entries; org-expanded accounts ride Accounts only.
 	// Room-scoped event only — INBOX copies omit it (remote sites re-resolve display data).
-	Members   []RoomMemberEntry `json:"members,omitempty" bson:"members,omitempty"`
-	Timestamp int64             `json:"timestamp"         bson:"timestamp"`
+	Members []RoomMemberEntry `json:"members,omitempty" bson:"members,omitempty"`
+	// Origin marks provenance (OriginTeams for a Teams-migrated room); empty for
+	// native rooms. Shared json tag with InboxMemberEvent.Origin so the Teams lane's
+	// origin survives the inbox-worker decode into this struct and stamps the sub.
+	Origin    string `json:"origin,omitempty" bson:"origin,omitempty"`
+	Timestamp int64  `json:"timestamp"        bson:"timestamp"`
 }
 
 // Participant represents a user with display name info for client rendering. DisplayName is the

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -132,6 +132,10 @@ type InboxMemberEvent struct {
 	HistorySharedSince *int64   `json:"historySharedSince,omitempty"`
 	JoinedAt           int64    `json:"joinedAt,omitempty"`
 	Timestamp          int64    `json:"timestamp" bson:"timestamp"`
+	// Origin marks provenance (e.g. OriginTeams for Teams-migrated room
+	// membership); empty for natively-created rooms. Propagated into the
+	// spotlight search doc.
+	Origin string `json:"origin,omitempty"`
 }
 
 // NotificationEvent is the per-user reaction notification on chat.user.{account}.notification;

--- a/pkg/searchindex/messagedoc.go
+++ b/pkg/searchindex/messagedoc.go
@@ -32,6 +32,10 @@ type MessageDoc struct {
 	CardData              string                 `json:"cardData,omitempty"                      es:"text,custom_analyzer"`
 	Attachments           []cassandra.Attachment `json:"attachments,omitempty" es:"object_disabled"`
 	Card                  *cassandra.Card        `json:"card,omitempty"        es:"object_disabled"`
+	// Origin marks provenance (e.g. model.OriginTeams for Teams-migrated
+	// messages); empty for natively-created messages. Filtered by search-service
+	// when SHOW_TEAMS_ROOM is false.
+	Origin string `json:"origin,omitempty" es:"keyword"`
 }
 
 // MessageFields is the minimal, source-agnostic set of fields needed to

--- a/pkg/searchindex/spotlightdoc.go
+++ b/pkg/searchindex/spotlightdoc.go
@@ -12,6 +12,10 @@ type SpotlightDoc struct {
 	RoomType    string    `json:"roomType"    es:"keyword"`
 	SiteID      string    `json:"siteId"      es:"keyword"`
 	JoinedAt    time.Time `json:"joinedAt"    es:"date"`
+	// Origin marks provenance (e.g. model.OriginTeams for Teams-migrated
+	// rooms); empty for natively-created rooms. Filtered by search-service
+	// when SHOW_TEAMS_ROOM is false.
+	Origin string `json:"origin,omitempty" es:"keyword"`
 }
 
 // SpotlightFields is the minimal, source-agnostic input to NewSpotlightDoc.
@@ -22,6 +26,7 @@ type SpotlightFields struct {
 	RoomType    string
 	SiteID      string
 	JoinedAt    time.Time
+	Origin      string
 }
 
 // NewSpotlightDoc builds the ES document for the spotlight index from f.

--- a/room-worker/teamsroomcreate.go
+++ b/room-worker/teamsroomcreate.go
@@ -256,6 +256,7 @@ func (h *Handler) federateTeamsMembership(ctx context.Context, room *model.Room,
 		SiteID:    h.siteID,
 		Accounts:  accounts,
 		Timestamp: acceptedAt.UnixMilli(),
+		Origin:    model.OriginTeams,
 	}
 	payload, err := json.Marshal(evt)
 	if err != nil {

--- a/search-service/handler.go
+++ b/search-service/handler.go
@@ -32,6 +32,7 @@ type handlerConfig struct {
 	UserRoomIndex           string
 	SpotlightReadPattern    string
 	SpotlightOrgReadPattern string
+	ShowTeamsRoom           bool
 }
 
 type handler struct {
@@ -105,7 +106,7 @@ func (h *handler) searchMessages(c *natsrouter.Context, req model.SearchMessages
 	// When req.RoomIDs is set, buildMessageQuery -> scopedAccessClauses
 	// iterates req.RoomIDs and classifies each ID against this map directly,
 	// so no handler-level pre-classification is needed.
-	body, err := buildMessageQuery(req, account, restricted, h.cfg.RecentWindow, h.cfg.UserRoomIndex)
+	body, err := buildMessageQuery(req, account, restricted, h.cfg.RecentWindow, h.cfg.UserRoomIndex, h.cfg.ShowTeamsRoom)
 	if err != nil {
 		return nil, fmt.Errorf("building search query: %w", err)
 	}
@@ -148,7 +149,7 @@ func (h *handler) searchRooms(c *natsrouter.Context, req model.SearchRoomsReques
 	ctx, cancel := h.withRequestTimeout(c)
 	defer cancel()
 
-	body, err := buildRoomQuery(req, account)
+	body, err := buildRoomQuery(req, account, h.cfg.ShowTeamsRoom)
 	if err != nil {
 		// A typed errcode error (invalid roomType) passes through;
 		// anything else (marshal failure — unreachable) gets sanitized.

--- a/search-service/handler.go
+++ b/search-service/handler.go
@@ -33,6 +33,15 @@ type handlerConfig struct {
 	SpotlightReadPattern    string
 	SpotlightOrgReadPattern string
 	ShowTeamsRoom           bool
+	// ShowTeamsAccounts allowlists accounts that see Teams rooms/messages even when
+	// ShowTeamsRoom is false (SHOW_TEAMS_ROOM_ACCOUNTS).
+	ShowTeamsAccounts map[string]bool
+}
+
+// effectiveShowTeams reports whether account sees Teams rooms/messages — the global
+// flag OR the ops-managed allowlist.
+func (c *handlerConfig) effectiveShowTeams(account string) bool {
+	return c.ShowTeamsRoom || c.ShowTeamsAccounts[account]
 }
 
 type handler struct {
@@ -106,7 +115,7 @@ func (h *handler) searchMessages(c *natsrouter.Context, req model.SearchMessages
 	// When req.RoomIDs is set, buildMessageQuery -> scopedAccessClauses
 	// iterates req.RoomIDs and classifies each ID against this map directly,
 	// so no handler-level pre-classification is needed.
-	body, err := buildMessageQuery(req, account, restricted, h.cfg.RecentWindow, h.cfg.UserRoomIndex, h.cfg.ShowTeamsRoom)
+	body, err := buildMessageQuery(req, account, restricted, h.cfg.RecentWindow, h.cfg.UserRoomIndex, h.cfg.effectiveShowTeams(account))
 	if err != nil {
 		return nil, fmt.Errorf("building search query: %w", err)
 	}
@@ -149,7 +158,7 @@ func (h *handler) searchRooms(c *natsrouter.Context, req model.SearchRoomsReques
 	ctx, cancel := h.withRequestTimeout(c)
 	defer cancel()
 
-	body, err := buildRoomQuery(req, account, h.cfg.ShowTeamsRoom)
+	body, err := buildRoomQuery(req, account, h.cfg.effectiveShowTeams(account))
 	if err != nil {
 		// A typed errcode error (invalid roomType) passes through;
 		// anything else (marshal failure — unreachable) gets sanitized.

--- a/search-service/main.go
+++ b/search-service/main.go
@@ -100,6 +100,10 @@ type Config struct {
 	// door (ErrUnavailable) instead of piling unbounded work onto Elasticsearch/
 	// MongoDB. 0 disables the cap (unbounded spawn).
 	MaxConcurrency int `env:"MAX_CONCURRENCY" envDefault:"256"`
+	// ShowTeamsRoom controls whether Teams-migrated rooms/messages (origin
+	// "teams") appear in search results; false hides them (reversible read-time
+	// filter — see pkg/model.OriginTeams).
+	ShowTeamsRoom bool `env:"SHOW_TEAMS_ROOM" envDefault:"false"`
 }
 
 func main() {
@@ -208,6 +212,7 @@ func main() {
 		UserRoomIndex:           cfg.UserRoomIndex,
 		SpotlightReadPattern:    spotlightReadPattern,
 		SpotlightOrgReadPattern: spotlightOrgReadPattern,
+		ShowTeamsRoom:           cfg.ShowTeamsRoom,
 	})
 	handler.room = newRoomClient(nc)
 

--- a/search-service/main.go
+++ b/search-service/main.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/caarlos0/env/v11"
@@ -116,7 +117,7 @@ func teamsAccountSet(accounts []string) map[string]bool {
 	}
 	set := make(map[string]bool, len(accounts))
 	for _, a := range accounts {
-		if a != "" {
+		if a = strings.TrimSpace(a); a != "" {
 			set[a] = true
 		}
 	}

--- a/search-service/main.go
+++ b/search-service/main.go
@@ -104,6 +104,23 @@ type Config struct {
 	// "teams") appear in search results; false hides them (reversible read-time
 	// filter — see pkg/model.OriginTeams).
 	ShowTeamsRoom bool `env:"SHOW_TEAMS_ROOM" envDefault:"false"`
+	// ShowTeamsAccounts allowlists accounts that see Teams rooms/messages even when
+	// ShowTeamsRoom is false — an ops-managed set, comma-separated.
+	ShowTeamsAccounts []string `env:"SHOW_TEAMS_ROOM_ACCOUNTS" envSeparator:","`
+}
+
+// teamsAccountSet builds a lookup set from the SHOW_TEAMS_ROOM_ACCOUNTS list, dropping blanks.
+func teamsAccountSet(accounts []string) map[string]bool {
+	if len(accounts) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(accounts))
+	for _, a := range accounts {
+		if a != "" {
+			set[a] = true
+		}
+	}
+	return set
 }
 
 func main() {
@@ -213,6 +230,7 @@ func main() {
 		SpotlightReadPattern:    spotlightReadPattern,
 		SpotlightOrgReadPattern: spotlightOrgReadPattern,
 		ShowTeamsRoom:           cfg.ShowTeamsRoom,
+		ShowTeamsAccounts:       teamsAccountSet(cfg.ShowTeamsAccounts),
 	})
 	handler.room = newRoomClient(nc)
 

--- a/search-service/query_messages.go
+++ b/search-service/query_messages.go
@@ -28,8 +28,28 @@ var MessageIndexPattern = []string{"messages-*", "*:messages-*"}
 // (req.RoomIDs != nil), the inline terms clause is STILL gated by the
 // terms-lookup so a caller can't reach rooms they don't belong to by
 // passing arbitrary roomIds.
-func buildMessageQuery(req model.SearchMessagesRequest, account string, restricted map[string]int64, recentWindow time.Duration, userRoomIndex string) (json.RawMessage, error) {
+func buildMessageQuery(req model.SearchMessagesRequest, account string, restricted map[string]int64, recentWindow time.Duration, userRoomIndex string, showTeamsRoom bool) (json.RawMessage, error) {
 	clauses := roomAccessClauses(req.RoomIDs, account, restricted, userRoomIndex)
+
+	filter := []any{
+		map[string]any{
+			"range": map[string]any{
+				"createdAt": map[string]any{
+					"gte": fmt.Sprintf("now-%s", recentWindowToGte(recentWindow)),
+				},
+			},
+		},
+		map[string]any{
+			"bool": map[string]any{
+				"should":               clauses,
+				"minimum_should_match": 1,
+			},
+		},
+	}
+	mustNot := []any{}
+	if !showTeamsRoom {
+		mustNot = append(mustNot, map[string]any{"term": map[string]any{"origin": model.OriginTeams}})
+	}
 
 	body := map[string]any{
 		"from":             req.Offset,
@@ -52,21 +72,8 @@ func buildMessageQuery(req model.SearchMessagesRequest, account string, restrict
 						},
 					},
 				},
-				"filter": []any{
-					map[string]any{
-						"range": map[string]any{
-							"createdAt": map[string]any{
-								"gte": fmt.Sprintf("now-%s", recentWindowToGte(recentWindow)),
-							},
-						},
-					},
-					map[string]any{
-						"bool": map[string]any{
-							"should":               clauses,
-							"minimum_should_match": 1,
-						},
-					},
-				},
+				"filter":   filter,
+				"must_not": mustNot,
 			},
 		},
 		"sort": []any{

--- a/search-service/query_messages_test.go
+++ b/search-service/query_messages_test.go
@@ -35,7 +35,7 @@ func shouldClauses(t *testing.T, q map[string]any) []any {
 
 func TestBuildMessageQuery_GlobalUnrestricted(t *testing.T) {
 	req := model.SearchMessagesRequest{Query: "hello", Size: 25, Offset: 0}
-	raw, err := buildMessageQuery(req, "alice", nil, 365*24*time.Hour, "user-room")
+	raw, err := buildMessageQuery(req, "alice", nil, 365*24*time.Hour, "user-room", false)
 	require.NoError(t, err)
 
 	q := parseQuery(t, raw)
@@ -56,7 +56,7 @@ func TestBuildMessageQuery_GlobalUnrestricted(t *testing.T) {
 // text together.
 func TestBuildMessageQuery_SearchesAttachmentAndCardFields(t *testing.T) {
 	req := model.SearchMessagesRequest{Query: "report", Size: 25}
-	raw, err := buildMessageQuery(req, "alice", nil, 365*24*time.Hour, "user-room")
+	raw, err := buildMessageQuery(req, "alice", nil, 365*24*time.Hour, "user-room", false)
 	require.NoError(t, err)
 
 	q := parseQuery(t, raw)
@@ -82,7 +82,7 @@ func TestBuildMessageQuery_GlobalWithRestricted(t *testing.T) {
 		"room-b": 1_700_000_000_000,
 		"room-a": 1_600_000_000_000,
 	}
-	raw, err := buildMessageQuery(req, "alice", restricted, 24*time.Hour, "user-room")
+	raw, err := buildMessageQuery(req, "alice", restricted, 24*time.Hour, "user-room", false)
 	require.NoError(t, err)
 
 	q := parseQuery(t, raw)
@@ -141,7 +141,7 @@ func TestBuildMessageQuery_ScopedInlineTerms(t *testing.T) {
 		Query:   "hi",
 		RoomIDs: []string{"r1", "r2", "r3"},
 	}
-	raw, err := buildMessageQuery(req, "alice", nil, time.Hour, "user-room")
+	raw, err := buildMessageQuery(req, "alice", nil, time.Hour, "user-room", false)
 	require.NoError(t, err)
 
 	shoulds := shouldClauses(t, parseQuery(t, raw))
@@ -157,7 +157,7 @@ func TestBuildMessageQuery_ScopedMixed(t *testing.T) {
 		RoomIDs: []string{"r1", "restricted-r2", "r3"},
 	}
 	restricted := map[string]int64{"restricted-r2": 1_600_000_000_000}
-	raw, err := buildMessageQuery(req, "alice", restricted, time.Hour, "user-room")
+	raw, err := buildMessageQuery(req, "alice", restricted, time.Hour, "user-room", false)
 	require.NoError(t, err)
 
 	shoulds := shouldClauses(t, parseQuery(t, raw))
@@ -180,7 +180,7 @@ func TestBuildMessageQuery_ScopedMixed(t *testing.T) {
 
 func TestBuildMessageQuery_UserRoomIndexOverride(t *testing.T) {
 	req := model.SearchMessagesRequest{Query: "hi"}
-	raw, err := buildMessageQuery(req, "alice", nil, time.Hour, "custom-user-room")
+	raw, err := buildMessageQuery(req, "alice", nil, time.Hour, "custom-user-room", false)
 	require.NoError(t, err)
 
 	shoulds := shouldClauses(t, parseQuery(t, raw))
@@ -194,7 +194,7 @@ func TestBuildMessageQuery_ScopedAllRestricted(t *testing.T) {
 		RoomIDs: []string{"ra"},
 	}
 	restricted := map[string]int64{"ra": 1_700_000_000_000}
-	raw, err := buildMessageQuery(req, "alice", restricted, time.Hour, "user-room")
+	raw, err := buildMessageQuery(req, "alice", restricted, time.Hour, "user-room", false)
 	require.NoError(t, err)
 
 	shoulds := shouldClauses(t, parseQuery(t, raw))
@@ -205,7 +205,7 @@ func TestBuildMessageQuery_ScopedAllRestricted(t *testing.T) {
 
 func TestBuildMessageQuery_RecentWindow(t *testing.T) {
 	req := model.SearchMessagesRequest{Query: "hi"}
-	raw, err := buildMessageQuery(req, "alice", nil, 48*time.Hour, "user-room")
+	raw, err := buildMessageQuery(req, "alice", nil, 48*time.Hour, "user-room", false)
 	require.NoError(t, err)
 
 	filters := filterClauses(t, parseQuery(t, raw))
@@ -216,13 +216,35 @@ func TestBuildMessageQuery_RecentWindow(t *testing.T) {
 
 func TestBuildMessageQuery_RecentWindowDefault(t *testing.T) {
 	req := model.SearchMessagesRequest{Query: "hi"}
-	raw, err := buildMessageQuery(req, "alice", nil, 0, "user-room")
+	raw, err := buildMessageQuery(req, "alice", nil, 0, "user-room", false)
 	require.NoError(t, err)
 
 	filters := filterClauses(t, parseQuery(t, raw))
 	rng := filters[0].(map[string]any)["range"].(map[string]any)["createdAt"].(map[string]any)
 	// Zero / negative window defaults to 1 year (365 * 24h = 8760h).
 	assert.Equal(t, "now-8760h", rng["gte"])
+}
+
+func TestBuildMessageQuery_ShowTeamsRoomFalse_AddsMustNotOrigin(t *testing.T) {
+	req := model.SearchMessagesRequest{Query: "hi"}
+	raw, err := buildMessageQuery(req, "alice", nil, time.Hour, "user-room", false)
+	require.NoError(t, err)
+
+	q := parseQuery(t, raw)
+	mustNot := q["query"].(map[string]any)["bool"].(map[string]any)["must_not"].([]any)
+	require.Len(t, mustNot, 1)
+	term := mustNot[0].(map[string]any)["term"].(map[string]any)
+	assert.Equal(t, model.OriginTeams, term["origin"])
+}
+
+func TestBuildMessageQuery_ShowTeamsRoomTrue_OmitsMustNotOrigin(t *testing.T) {
+	req := model.SearchMessagesRequest{Query: "hi"}
+	raw, err := buildMessageQuery(req, "alice", nil, time.Hour, "user-room", true)
+	require.NoError(t, err)
+
+	q := parseQuery(t, raw)
+	mustNot := q["query"].(map[string]any)["bool"].(map[string]any)["must_not"].([]any)
+	assert.Len(t, mustNot, 0)
 }
 
 func TestRecentWindowToGte_Units(t *testing.T) {

--- a/search-service/query_rooms.go
+++ b/search-service/query_rooms.go
@@ -20,7 +20,7 @@ const (
 // search against the spotlight index. It returns a user-facing *errcode.Error
 // on invalid/unsupported roomType values and a plain error on marshalling
 // failures.
-func buildRoomQuery(req model.SearchRoomsRequest, account string) (json.RawMessage, error) {
+func buildRoomQuery(req model.SearchRoomsRequest, account string, showTeamsRoom bool) (json.RawMessage, error) {
 	roomTypeFilter, rerr := roomTypeFilterClause(req.RoomType)
 	if rerr != nil {
 		return nil, rerr
@@ -31,6 +31,10 @@ func buildRoomQuery(req model.SearchRoomsRequest, account string) (json.RawMessa
 	}
 	if roomTypeFilter != nil {
 		filters = append(filters, roomTypeFilter)
+	}
+	mustNot := []any{}
+	if !showTeamsRoom {
+		mustNot = append(mustNot, map[string]any{"term": map[string]any{"origin": model.OriginTeams}})
 	}
 
 	body := map[string]any{
@@ -49,7 +53,8 @@ func buildRoomQuery(req model.SearchRoomsRequest, account string) (json.RawMessa
 						},
 					},
 				},
-				"filter": filters,
+				"filter":   filters,
+				"must_not": mustNot,
 			},
 		},
 		"sort": []any{

--- a/search-service/query_rooms_test.go
+++ b/search-service/query_rooms_test.go
@@ -19,7 +19,7 @@ func subscriptionFilters(t *testing.T, q map[string]any) []any {
 
 func TestBuildSubscriptionQuery_RoomTypeAll(t *testing.T) {
 	req := model.SearchRoomsRequest{Query: "general", Size: 10, Offset: 0}
-	raw, err := buildRoomQuery(req, "alice")
+	raw, err := buildRoomQuery(req, "alice", false)
 	require.NoError(t, err)
 
 	q := parseQuery(t, raw)
@@ -35,7 +35,7 @@ func TestBuildSubscriptionQuery_RoomTypeAll(t *testing.T) {
 
 func TestBuildSubscriptionQuery_RoomTypeExplicitAll(t *testing.T) {
 	req := model.SearchRoomsRequest{Query: "general", RoomType: "all"}
-	raw, err := buildRoomQuery(req, "alice")
+	raw, err := buildRoomQuery(req, "alice", false)
 	require.NoError(t, err)
 
 	filters := subscriptionFilters(t, parseQuery(t, raw))
@@ -44,7 +44,7 @@ func TestBuildSubscriptionQuery_RoomTypeExplicitAll(t *testing.T) {
 
 func TestBuildSubscriptionQuery_RoomTypeChannel(t *testing.T) {
 	req := model.SearchRoomsRequest{Query: "general", RoomType: "channel"}
-	raw, err := buildRoomQuery(req, "alice")
+	raw, err := buildRoomQuery(req, "alice", false)
 	require.NoError(t, err)
 
 	filters := subscriptionFilters(t, parseQuery(t, raw))
@@ -55,7 +55,7 @@ func TestBuildSubscriptionQuery_RoomTypeChannel(t *testing.T) {
 
 func TestBuildSubscriptionQuery_RoomTypeDM(t *testing.T) {
 	req := model.SearchRoomsRequest{Query: "alice", RoomType: "dm"}
-	raw, err := buildRoomQuery(req, "alice")
+	raw, err := buildRoomQuery(req, "alice", false)
 	require.NoError(t, err)
 
 	filters := subscriptionFilters(t, parseQuery(t, raw))
@@ -66,7 +66,7 @@ func TestBuildSubscriptionQuery_RoomTypeDM(t *testing.T) {
 
 func TestBuildSubscriptionQuery_RoomTypeAppRejected(t *testing.T) {
 	req := model.SearchRoomsRequest{Query: "bot", RoomType: "app"}
-	_, err := buildRoomQuery(req, "alice")
+	_, err := buildRoomQuery(req, "alice", false)
 	require.Error(t, err)
 
 	var rerr *errcode.Error
@@ -77,7 +77,7 @@ func TestBuildSubscriptionQuery_RoomTypeAppRejected(t *testing.T) {
 
 func TestBuildSubscriptionQuery_UnknownRoomTypeRejected(t *testing.T) {
 	req := model.SearchRoomsRequest{Query: "x", RoomType: "orb"}
-	_, err := buildRoomQuery(req, "alice")
+	_, err := buildRoomQuery(req, "alice", false)
 	require.Error(t, err)
 
 	var rerr *errcode.Error
@@ -88,7 +88,7 @@ func TestBuildSubscriptionQuery_UnknownRoomTypeRejected(t *testing.T) {
 
 func TestBuildSubscriptionQuery_SortByScoreThenJoinedAtDesc(t *testing.T) {
 	req := model.SearchRoomsRequest{Query: "x"}
-	raw, err := buildRoomQuery(req, "alice")
+	raw, err := buildRoomQuery(req, "alice", false)
 	require.NoError(t, err)
 
 	sort := parseQuery(t, raw)["sort"].([]any)
@@ -98,9 +98,31 @@ func TestBuildSubscriptionQuery_SortByScoreThenJoinedAtDesc(t *testing.T) {
 	assert.Equal(t, "desc", joinedAt["order"])
 }
 
+func TestBuildRoomQuery_ShowTeamsRoomFalse_AddsMustNotOrigin(t *testing.T) {
+	req := model.SearchRoomsRequest{Query: "x"}
+	raw, err := buildRoomQuery(req, "alice", false)
+	require.NoError(t, err)
+
+	q := parseQuery(t, raw)
+	mustNot := q["query"].(map[string]any)["bool"].(map[string]any)["must_not"].([]any)
+	require.Len(t, mustNot, 1)
+	term := mustNot[0].(map[string]any)["term"].(map[string]any)
+	assert.Equal(t, model.OriginTeams, term["origin"])
+}
+
+func TestBuildRoomQuery_ShowTeamsRoomTrue_OmitsMustNotOrigin(t *testing.T) {
+	req := model.SearchRoomsRequest{Query: "x"}
+	raw, err := buildRoomQuery(req, "alice", true)
+	require.NoError(t, err)
+
+	q := parseQuery(t, raw)
+	mustNot := q["query"].(map[string]any)["bool"].(map[string]any)["must_not"].([]any)
+	assert.Len(t, mustNot, 0)
+}
+
 func TestBuildSubscriptionQuery_QueryFieldFlowsToESBody(t *testing.T) {
 	req := model.SearchRoomsRequest{Query: "engineering", Size: 5}
-	raw, err := buildRoomQuery(req, "alice")
+	raw, err := buildRoomQuery(req, "alice", false)
 	require.NoError(t, err)
 
 	q := parseQuery(t, raw)

--- a/search-service/showteams_test.go
+++ b/search-service/showteams_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+func TestEffectiveShowTeams(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     handlerConfig
+		account string
+		want    bool
+	}{
+		{"global on", handlerConfig{ShowTeamsRoom: true}, "alice", true},
+		{"global off, not allowlisted", handlerConfig{ShowTeamsRoom: false}, "alice", false},
+		{"global off, allowlisted", handlerConfig{ShowTeamsRoom: false, ShowTeamsAccounts: map[string]bool{"alice": true}}, "alice", true},
+		{"global off, other allowlisted", handlerConfig{ShowTeamsRoom: false, ShowTeamsAccounts: map[string]bool{"bob": true}}, "alice", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.effectiveShowTeams(tt.account); got != tt.want {
+				t.Errorf("effectiveShowTeams(%q) = %v, want %v", tt.account, got, tt.want)
+			}
+		})
+	}
+}

--- a/search-service/showteams_test.go
+++ b/search-service/showteams_test.go
@@ -22,3 +22,13 @@ func TestEffectiveShowTeams(t *testing.T) {
 		})
 	}
 }
+
+func TestTeamsAccountSet_TrimsWhitespace(t *testing.T) {
+	set := teamsAccountSet([]string{"alice", " bob", "  ", ""})
+	if !set["alice"] || !set["bob"] {
+		t.Fatalf("expected alice+bob (trimmed), got %v", set)
+	}
+	if set[" bob"] || len(set) != 2 {
+		t.Fatalf("blank/untrimmed entries must be dropped, got %v", set)
+	}
+}

--- a/search-sync-worker/main_test.go
+++ b/search-sync-worker/main_test.go
@@ -51,8 +51,8 @@ func TestPushMappings_PushesOnlyCollectionsWithMappings(t *testing.T) {
 	}
 
 	require.NoError(t, pushMappings(context.Background(), eng, collections))
-	assert.Equal(t, []string{"messages-x-*"}, eng.mappingPatterns,
-		"pattern is version-stripped so pre-bump indices are covered too")
+	assert.Equal(t, []string{"messages-x-*", "spotlight-x"}, eng.mappingPatterns,
+		"message pattern is version-stripped; spotlight is a single index updated directly (both backfill new fields onto existing indices); spotlight-org + user-room are no-ops")
 }
 
 // A non-nil but zero-length body is still "no update" — it must never

--- a/search-sync-worker/messages.go
+++ b/search-sync-worker/messages.go
@@ -266,6 +266,7 @@ func (c *messageCollection) buildTeamsActions(req model.TeamsBatchRequest) []sea
 			UserAccount: id.Account,
 			Content:     teamsmigrate.BodyToContent(tm.Body),
 			CreatedAt:   tm.CreatedDateTime,
+			Origin:      model.OriginTeams,
 		}
 		body, _ := json.Marshal(doc)
 		actions = append(actions, searchengine.BulkAction{

--- a/search-sync-worker/messages_test.go
+++ b/search-sync-worker/messages_test.go
@@ -721,3 +721,40 @@ func TestMessageCollection_BuildAction_TeamsBatch_MalformedRecordDoesNotDropSibl
 	require.Len(t, actions, 1, "the malformed record must be skipped, not abort the whole batch")
 	assert.Equal(t, teamsmigrate.DeterministicMessageID("room-1", "tm-1"), actions[0].DocID)
 }
+
+func TestMessageCollection_BuildAction_TeamsBatch_SetsOrigin(t *testing.T) {
+	c := newMessageCollection("messages-site-a-v1", "site-a", time.Time{}, false)
+	ts := time.Now().UTC()
+
+	valid, err := json.Marshal(teamsmigrate.Message{
+		ID: "tm-1", RoomID: "room-1", MessageType: "message", CreatedDateTime: ts,
+	})
+	require.NoError(t, err)
+	req := model.TeamsBatchRequest{Messages: []json.RawMessage{valid}}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	actions, buildErr := c.BuildAction(data)
+	require.NoError(t, buildErr)
+	require.Len(t, actions, 1)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(actions[0].Doc, &doc))
+	assert.Equal(t, model.OriginTeams, doc["origin"], "Teams-migrated docs must carry origin=teams")
+}
+
+func TestBuildMessageAction_NormalPath_OmitsOrigin(t *testing.T) {
+	ts := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	evt := &model.MessageEvent{
+		Event:     model.EventCreated,
+		Message:   model.Message{ID: "msg-1", RoomID: "r1", UserID: "u1", UserAccount: "alice", CreatedAt: ts},
+		SiteID:    "site-a",
+		Timestamp: 1737964678390,
+	}
+	action := buildMessageAction(evt, "msgs-v1")
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(action.Doc, &doc))
+	_, hasOrigin := doc["origin"]
+	assert.False(t, hasOrigin, "non-Teams docs must not carry an origin field")
+}

--- a/search-sync-worker/spotlight.go
+++ b/search-sync-worker/spotlight.go
@@ -107,6 +107,7 @@ func newSpotlightSearchIndex(account string, evt *model.InboxMemberEvent) search
 		RoomType:    string(evt.RoomType),
 		SiteID:      evt.SiteID,
 		JoinedAt:    convertJoinedAt(evt.JoinedAt),
+		Origin:      evt.Origin,
 	})
 }
 

--- a/search-sync-worker/spotlight.go
+++ b/search-sync-worker/spotlight.go
@@ -37,6 +37,17 @@ func (c *spotlightCollection) TemplateBody() json.RawMessage {
 	return searchindex.SpotlightTemplateBody(c.indexName, c.devMode)
 }
 
+// MappingUpdate backfills the SpotlightDoc properties (incl. the new `origin`
+// keyword) onto the already-created, non-rolled spotlight index — the template
+// alone only covers new indices. Without this, `origin` lands in `_source` but
+// stays unindexed on the existing index, so search-service's origin filter
+// silently no-ops. Overrides the embedded inboxMemberCollection no-op.
+func (c *spotlightCollection) MappingUpdate() (string, json.RawMessage) {
+	// Error discarded: input is a static map of literals, marshal cannot fail.
+	body, _ := json.Marshal(map[string]any{"properties": searchindex.EsPropertiesFromStruct[searchindex.SpotlightDoc]()})
+	return c.indexName, body
+}
+
 // BuildAction fans a member_added / member_removed event out into one ES
 // action per account in the payload. Bulk invites produce N spotlight docs
 // from a single event; single-user invites produce one.

--- a/search-sync-worker/spotlight_test.go
+++ b/search-sync-worker/spotlight_test.go
@@ -389,8 +389,17 @@ func TestSpotlightCollection_BuildAction_BulkRemove(t *testing.T) {
 }
 
 // Spotlight writes to one fixed index — no additive mapping push at startup.
-func TestSpotlightCollection_MappingUpdate_NoOp(t *testing.T) {
+func TestSpotlightCollection_MappingUpdate(t *testing.T) {
 	pattern, body := newSpotlightCollection("spotlight-site-a-v1-chat", false).MappingUpdate()
-	assert.Empty(t, pattern)
-	assert.Nil(t, body)
+	// Spotlight is a single, non-rolled index — update it directly (no version strip).
+	assert.Equal(t, "spotlight-site-a-v1-chat", pattern)
+	require.NotNil(t, body)
+
+	var parsed struct {
+		Properties map[string]any `json:"properties"`
+	}
+	require.NoError(t, json.Unmarshal(body, &parsed))
+	assert.Contains(t, parsed.Properties, "origin",
+		"origin must be in the mapping update so SHOW_TEAMS_ROOM's filter is indexed on the existing index")
+	assert.Contains(t, parsed.Properties, "roomName", "full property set keeps the update idempotent")
 }

--- a/search-sync-worker/spotlight_test.go
+++ b/search-sync-worker/spotlight_test.go
@@ -56,6 +56,18 @@ func TestNewSpotlightSearchIndex_ZeroJoinedAtStaysZeroTime(t *testing.T) {
 	assert.True(t, doc.JoinedAt.IsZero())
 }
 
+func TestNewSpotlightSearchIndex_OriginPropagated(t *testing.T) {
+	evt := &model.InboxMemberEvent{RoomID: "r-eng", Origin: model.OriginTeams}
+	doc := newSpotlightSearchIndex("alice", evt)
+	assert.Equal(t, model.OriginTeams, doc.Origin)
+}
+
+func TestNewSpotlightSearchIndex_NormalRoomOriginEmpty(t *testing.T) {
+	evt := &model.InboxMemberEvent{RoomID: "r-eng"}
+	doc := newSpotlightSearchIndex("alice", evt)
+	assert.Equal(t, "", doc.Origin)
+}
+
 func TestSpotlightCollection_Metadata(t *testing.T) {
 	coll := newSpotlightCollection("spotlight-site-a-v1-chat", false)
 

--- a/user-service/config/config.go
+++ b/user-service/config/config.go
@@ -57,6 +57,9 @@ type Config struct {
 	// appear in the subscription list/count; false hides them (reversible
 	// read-time filter — see pkg/model.OriginTeams).
 	ShowTeamsRoom bool `env:"SHOW_TEAMS_ROOM" envDefault:"false"`
+	// ShowTeamsAccounts allowlists accounts that see Teams rooms even when
+	// ShowTeamsRoom is false — an ops-managed set, comma-separated.
+	ShowTeamsAccounts []string `env:"SHOW_TEAMS_ROOM_ACCOUNTS" envSeparator:","`
 }
 
 // Load parses environment variables into Config; rejects MAX_SUBSCRIPTION_LIMIT < 1 because $limit:0 errors at query time.

--- a/user-service/config/config.go
+++ b/user-service/config/config.go
@@ -53,6 +53,10 @@ type Config struct {
 	AdminAcctPrefix string      `env:"ADMIN_ACCT_PREFIX"      envDefault:"p_admin"`
 	Mongo           MongoConfig `envPrefix:"MONGO_"`
 	NATS            NATSConfig  `envPrefix:"NATS_"`
+	// ShowTeamsRoom controls whether Teams-migrated rooms (origin "teams")
+	// appear in the subscription list/count; false hides them (reversible
+	// read-time filter — see pkg/model.OriginTeams).
+	ShowTeamsRoom bool `env:"SHOW_TEAMS_ROOM" envDefault:"false"`
 }
 
 // Load parses environment variables into Config; rejects MAX_SUBSCRIPTION_LIMIT < 1 because $limit:0 errors at query time.

--- a/user-service/main.go
+++ b/user-service/main.go
@@ -87,7 +87,7 @@ func main() {
 	readFromSecondary := mongorepo.WithReadPreference(readPref)
 
 	db := mongoClient.Database(cfg.Mongo.DB)
-	subRepo := mongorepo.NewSubscriptionRepo(db, cfg.SiteID, readFromSecondary)
+	subRepo := mongorepo.NewSubscriptionRepo(db, cfg.SiteID, readFromSecondary, mongorepo.WithShowTeamsRoom(cfg.ShowTeamsRoom))
 	userRepo := mongorepo.NewUserRepo(db, readFromSecondary)
 	appRepo := mongorepo.NewAppRepo(db, readFromSecondary)
 	threadSubRepo := mongorepo.NewThreadSubscriptionRepo(db)

--- a/user-service/main.go
+++ b/user-service/main.go
@@ -87,7 +87,7 @@ func main() {
 	readFromSecondary := mongorepo.WithReadPreference(readPref)
 
 	db := mongoClient.Database(cfg.Mongo.DB)
-	subRepo := mongorepo.NewSubscriptionRepo(db, cfg.SiteID, readFromSecondary, mongorepo.WithShowTeamsRoom(cfg.ShowTeamsRoom))
+	subRepo := mongorepo.NewSubscriptionRepo(db, cfg.SiteID, readFromSecondary, mongorepo.WithShowTeamsRoom(cfg.ShowTeamsRoom), mongorepo.WithShowTeamsAccounts(cfg.ShowTeamsAccounts))
 	userRepo := mongorepo.NewUserRepo(db, readFromSecondary)
 	appRepo := mongorepo.NewAppRepo(db, readFromSecondary)
 	threadSubRepo := mongorepo.NewThreadSubscriptionRepo(db)

--- a/user-service/mongorepo/readpref.go
+++ b/user-service/mongorepo/readpref.go
@@ -6,8 +6,9 @@ import "go.mongodb.org/mongo-driver/v2/mongo/readpref"
 type Option func(*settings)
 
 type settings struct {
-	readPref      *readpref.ReadPref
-	showTeamsRoom bool
+	readPref          *readpref.ReadPref
+	showTeamsRoom     bool
+	showTeamsAccounts map[string]bool
 }
 
 // WithReadPreference routes each repo's staleness-tolerant reads to rp; authz,
@@ -21,6 +22,22 @@ func WithReadPreference(rp *readpref.ReadPref) Option {
 // them. Only consumed by SubscriptionRepo.
 func WithShowTeamsRoom(show bool) Option {
 	return func(s *settings) { s.showTeamsRoom = show }
+}
+
+// WithShowTeamsAccounts allowlists accounts that see Teams-migrated rooms even when
+// SHOW_TEAMS_ROOM is false — an ops-managed set (SHOW_TEAMS_ROOM_ACCOUNTS). Empty is a no-op.
+func WithShowTeamsAccounts(accounts []string) Option {
+	return func(s *settings) {
+		if len(accounts) == 0 {
+			return
+		}
+		s.showTeamsAccounts = make(map[string]bool, len(accounts))
+		for _, a := range accounts {
+			if a != "" {
+				s.showTeamsAccounts[a] = true
+			}
+		}
+	}
 }
 
 func applyOptions(opts []Option) settings {

--- a/user-service/mongorepo/readpref.go
+++ b/user-service/mongorepo/readpref.go
@@ -6,13 +6,21 @@ import "go.mongodb.org/mongo-driver/v2/mongo/readpref"
 type Option func(*settings)
 
 type settings struct {
-	readPref *readpref.ReadPref
+	readPref      *readpref.ReadPref
+	showTeamsRoom bool
 }
 
 // WithReadPreference routes each repo's staleness-tolerant reads to rp; authz,
 // dedup, read-after-write reads, and writes keep the default. Nil is a no-op.
 func WithReadPreference(rp *readpref.ReadPref) Option {
 	return func(s *settings) { s.readPref = rp }
+}
+
+// WithShowTeamsRoom controls whether SubscriptionRepo's list/count queries
+// include Teams-migrated rooms (origin "teams"); false (the default) excludes
+// them. Only consumed by SubscriptionRepo.
+func WithShowTeamsRoom(show bool) Option {
+	return func(s *settings) { s.showTeamsRoom = show }
 }
 
 func applyOptions(opts []Option) settings {

--- a/user-service/mongorepo/readpref.go
+++ b/user-service/mongorepo/readpref.go
@@ -1,6 +1,10 @@
 package mongorepo
 
-import "go.mongodb.org/mongo-driver/v2/mongo/readpref"
+import (
+	"strings"
+
+	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
+)
 
 // Option customizes repo construction.
 type Option func(*settings)
@@ -33,7 +37,7 @@ func WithShowTeamsAccounts(accounts []string) Option {
 		}
 		s.showTeamsAccounts = make(map[string]bool, len(accounts))
 		for _, a := range accounts {
-			if a != "" {
+			if a = strings.TrimSpace(a); a != "" {
 				s.showTeamsAccounts[a] = true
 			}
 		}

--- a/user-service/mongorepo/subscriptions.go
+++ b/user-service/mongorepo/subscriptions.go
@@ -36,6 +36,9 @@ type SubscriptionRepo struct {
 	// showTeamsRoom mirrors SHOW_TEAMS_ROOM: false (default) excludes
 	// Teams-migrated rooms (origin "teams") from list/count results.
 	showTeamsRoom bool
+	// showTeamsAccounts (SHOW_TEAMS_ROOM_ACCOUNTS) allowlists accounts that see
+	// Teams rooms even when showTeamsRoom is false.
+	showTeamsAccounts map[string]bool
 }
 
 // NewSubscriptionRepo builds a SubscriptionRepo over db; the deleted-filter keeps cross-site rows, drops local rows with missing/soft-deleted rooms.
@@ -51,6 +54,7 @@ func NewSubscriptionRepo(db *mongo.Database, siteID string, opts ...Option) *Sub
 		enrichedSecondary:      enriched.WithReadPreference(s.readPref),
 		siteID:                 siteID,
 		showTeamsRoom:          s.showTeamsRoom,
+		showTeamsAccounts:      s.showTeamsAccounts,
 	}
 }
 
@@ -268,7 +272,7 @@ func (r *SubscriptionRepo) AggregateSubscriptions(ctx context.Context, account, 
 	// roomsEnrichStages(true) drops locally soft-deleted (^Del-) rooms; cross-site
 	// rooms have no local room doc and are kept (their deletion isn't visible here).
 	pipeline := bson.A{bson.M{"$match": match}}
-	pipeline = append(pipeline, r.originFilterStage()...)
+	pipeline = append(pipeline, r.originFilterStage(account)...)
 	pipeline = append(pipeline, roomsEnrichStages(true)...)
 	// Activity window keys on the room's lastMsgAt (surfaced by the enrich stage),
 	// not the subscription's _updatedAt. rooms-type only; cross-site / no-message
@@ -286,12 +290,12 @@ func (r *SubscriptionRepo) AggregateSubscriptions(ctx context.Context, account, 
 	return r.enriched.AggregatePagedHasMore(ctx, pipeline, page)
 }
 
-// originFilterStage excludes Teams-migrated rooms (origin "teams") when
-// showTeamsRoom is false; empty (no-op) otherwise. Filters on the subscription's
-// own origin field (reliable cross-site — a remote room has no local doc); enrichment
-// no longer overwrites it, so this is position-independent in the pipeline.
-func (r *SubscriptionRepo) originFilterStage() bson.A {
-	if r.showTeamsRoom {
+// originFilterStage excludes Teams-migrated rooms (origin "teams") for account
+// unless SHOW_TEAMS_ROOM is true or account is allowlisted; empty (no-op) otherwise.
+// Filters on the subscription's own origin field (reliable cross-site — a remote room
+// has no local doc); enrichment no longer overwrites it, so this is position-independent.
+func (r *SubscriptionRepo) originFilterStage(account string) bson.A {
+	if r.showTeamsRoom || r.showTeamsAccounts[account] {
 		return bson.A{}
 	}
 	return bson.A{bson.M{"$match": bson.M{"origin": bson.M{"$ne": model.OriginTeams}}}}
@@ -437,7 +441,7 @@ func activeSubscriptionFilter(account string) bson.M {
 // CountActiveSubscriptions counts the deleted-filtered active set via $count over the enriched pipeline (CountDocuments cannot see the join).
 func (r *SubscriptionRepo) CountActiveSubscriptions(ctx context.Context, account string) (int, error) {
 	pipeline := bson.A{bson.M{"$match": activeSubscriptionFilter(account)}}
-	pipeline = append(pipeline, r.originFilterStage()...)
+	pipeline = append(pipeline, r.originFilterStage(account)...)
 	pipeline = append(pipeline, roomsEnrichStages(true)...)
 	pipeline = append(pipeline, bson.M{"$count": "n"})
 	cur, err := r.subscriptionsSecondary.Raw().Aggregate(ctx, pipeline)
@@ -459,7 +463,7 @@ func (r *SubscriptionRepo) CountActiveSubscriptions(ctx context.Context, account
 // GetActiveSubscriptions returns the deleted-filtered active set used by the unread count, capped by limit.
 func (r *SubscriptionRepo) GetActiveSubscriptions(ctx context.Context, account string, limit int) ([]model.EnrichedSubscription, error) {
 	pipeline := bson.A{bson.M{"$match": activeSubscriptionFilter(account)}}
-	pipeline = append(pipeline, r.originFilterStage()...)
+	pipeline = append(pipeline, r.originFilterStage(account)...)
 	pipeline = append(pipeline, roomsEnrichStages(true)...)
 	// MongoDB rejects $limit:0 — callers short-circuit zero; stay defensive here.
 	if limit > 0 {

--- a/user-service/mongorepo/subscriptions.go
+++ b/user-service/mongorepo/subscriptions.go
@@ -268,8 +268,11 @@ func (r *SubscriptionRepo) AggregateSubscriptions(ctx context.Context, account, 
 	// roomsEnrichStages(true) drops locally soft-deleted (^Del-) rooms; cross-site
 	// rooms have no local room doc and are kept (their deletion isn't visible here).
 	pipeline := bson.A{bson.M{"$match": match}}
-	pipeline = append(pipeline, roomsEnrichStages(true)...)
+	// Origin filter runs BEFORE enrichment: it reads the sub's own origin, which is
+	// reliable cross-site. roomsEnrichStages overwrites origin with $room.origin (null
+	// for a remote room with no local doc), so filtering after enrich would leak it.
 	pipeline = append(pipeline, r.originFilterStage()...)
+	pipeline = append(pipeline, roomsEnrichStages(true)...)
 	// Activity window keys on the room's lastMsgAt (surfaced by the enrich stage),
 	// not the subscription's _updatedAt. rooms-type only; cross-site / no-message
 	// rooms (null lastMsgAt) fall outside the window.
@@ -287,8 +290,10 @@ func (r *SubscriptionRepo) AggregateSubscriptions(ctx context.Context, account, 
 }
 
 // originFilterStage excludes Teams-migrated rooms (origin "teams") when
-// showTeamsRoom is false; empty (no-op) otherwise. Must run after
-// roomsEnrichStages, which surfaces the joined room's origin field.
+// showTeamsRoom is false; empty (no-op) otherwise. Must run BEFORE
+// roomsEnrichStages: it filters on the subscription's own origin field (reliable
+// cross-site), which enrichment later overwrites with the null $room.origin of a
+// remote room that has no local doc.
 func (r *SubscriptionRepo) originFilterStage() bson.A {
 	if r.showTeamsRoom {
 		return bson.A{}
@@ -436,8 +441,10 @@ func activeSubscriptionFilter(account string) bson.M {
 // CountActiveSubscriptions counts the deleted-filtered active set via $count over the enriched pipeline (CountDocuments cannot see the join).
 func (r *SubscriptionRepo) CountActiveSubscriptions(ctx context.Context, account string) (int, error) {
 	pipeline := bson.A{bson.M{"$match": activeSubscriptionFilter(account)}}
-	pipeline = append(pipeline, roomsEnrichStages(true)...)
+	// Filter on the sub's own origin before enrichment overwrites it with the
+	// (null cross-site) $room.origin — see AggregateSubscriptions.
 	pipeline = append(pipeline, r.originFilterStage()...)
+	pipeline = append(pipeline, roomsEnrichStages(true)...)
 	pipeline = append(pipeline, bson.M{"$count": "n"})
 	cur, err := r.subscriptionsSecondary.Raw().Aggregate(ctx, pipeline)
 	if err != nil {

--- a/user-service/mongorepo/subscriptions.go
+++ b/user-service/mongorepo/subscriptions.go
@@ -33,6 +33,9 @@ type SubscriptionRepo struct {
 	subscriptionsSecondary *mongoutil.Collection[model.Subscription]
 	enrichedSecondary      *mongoutil.Collection[model.EnrichedSubscription]
 	siteID                 string // this instance's site — distinguishes local vs cross-site rows in the deleted-filter
+	// showTeamsRoom mirrors SHOW_TEAMS_ROOM: false (default) excludes
+	// Teams-migrated rooms (origin "teams") from list/count results.
+	showTeamsRoom bool
 }
 
 // NewSubscriptionRepo builds a SubscriptionRepo over db; the deleted-filter keeps cross-site rows, drops local rows with missing/soft-deleted rooms.
@@ -47,6 +50,7 @@ func NewSubscriptionRepo(db *mongo.Database, siteID string, opts ...Option) *Sub
 		subscriptionsSecondary: subscriptions.WithReadPreference(s.readPref),
 		enrichedSecondary:      enriched.WithReadPreference(s.readPref),
 		siteID:                 siteID,
+		showTeamsRoom:          s.showTeamsRoom,
 	}
 }
 
@@ -93,6 +97,7 @@ func roomsEnrichStages(dropDeleted bool) bson.A {
 					"encKey.priv":       1,
 					"encKey.ver":        1,
 					"crossSite":         1,
+					"origin":            1,
 				}},
 			},
 			"as": "room",
@@ -113,6 +118,7 @@ func roomsEnrichStages(dropDeleted bool) bson.A {
 			"appCount":          "$room.appCount",
 			"roomName":          "$room.name",
 			"crossSite":         "$room.crossSite",
+			"origin":            "$room.origin",
 			// Sort key: room activity (lastMsgAt), falling back to room.createdAt for
 			// rooms with no messages. Null for cross-site/missing rooms (they sort last).
 			"__sortKey": bson.M{"$ifNull": bson.A{"$room.lastMsgAt", "$room.createdAt"}},
@@ -263,6 +269,7 @@ func (r *SubscriptionRepo) AggregateSubscriptions(ctx context.Context, account, 
 	// rooms have no local room doc and are kept (their deletion isn't visible here).
 	pipeline := bson.A{bson.M{"$match": match}}
 	pipeline = append(pipeline, roomsEnrichStages(true)...)
+	pipeline = append(pipeline, r.originFilterStage()...)
 	// Activity window keys on the room's lastMsgAt (surfaced by the enrich stage),
 	// not the subscription's _updatedAt. rooms-type only; cross-site / no-message
 	// rooms (null lastMsgAt) fall outside the window.
@@ -277,6 +284,16 @@ func (r *SubscriptionRepo) AggregateSubscriptions(ctx context.Context, account, 
 	// denormalizing room activity onto the subscription — a write-side change tracked separately.
 	// Primary: the subscription list must reflect a just-changed subscription immediately.
 	return r.enriched.AggregatePagedHasMore(ctx, pipeline, page)
+}
+
+// originFilterStage excludes Teams-migrated rooms (origin "teams") when
+// showTeamsRoom is false; empty (no-op) otherwise. Must run after
+// roomsEnrichStages, which surfaces the joined room's origin field.
+func (r *SubscriptionRepo) originFilterStage() bson.A {
+	if r.showTeamsRoom {
+		return bson.A{}
+	}
+	return bson.A{bson.M{"$match": bson.M{"origin": bson.M{"$ne": model.OriginTeams}}}}
 }
 
 // sortStages orders rows by room activity (lastMsgAt) desc then name asc. In the
@@ -420,6 +437,7 @@ func activeSubscriptionFilter(account string) bson.M {
 func (r *SubscriptionRepo) CountActiveSubscriptions(ctx context.Context, account string) (int, error) {
 	pipeline := bson.A{bson.M{"$match": activeSubscriptionFilter(account)}}
 	pipeline = append(pipeline, roomsEnrichStages(true)...)
+	pipeline = append(pipeline, r.originFilterStage()...)
 	pipeline = append(pipeline, bson.M{"$count": "n"})
 	cur, err := r.subscriptionsSecondary.Raw().Aggregate(ctx, pipeline)
 	if err != nil {

--- a/user-service/mongorepo/subscriptions.go
+++ b/user-service/mongorepo/subscriptions.go
@@ -97,7 +97,6 @@ func roomsEnrichStages(dropDeleted bool) bson.A {
 					"encKey.priv":       1,
 					"encKey.ver":        1,
 					"crossSite":         1,
-					"origin":            1,
 				}},
 			},
 			"as": "room",
@@ -118,7 +117,8 @@ func roomsEnrichStages(dropDeleted bool) bson.A {
 			"appCount":          "$room.appCount",
 			"roomName":          "$room.name",
 			"crossSite":         "$room.crossSite",
-			"origin":            "$room.origin",
+			// origin is NOT set from room here — the subscription's own origin is kept
+			// (reliable cross-site; a remote room's $room.origin is null). See originFilterStage.
 			// Sort key: room activity (lastMsgAt), falling back to room.createdAt for
 			// rooms with no messages. Null for cross-site/missing rooms (they sort last).
 			"__sortKey": bson.M{"$ifNull": bson.A{"$room.lastMsgAt", "$room.createdAt"}},
@@ -268,9 +268,6 @@ func (r *SubscriptionRepo) AggregateSubscriptions(ctx context.Context, account, 
 	// roomsEnrichStages(true) drops locally soft-deleted (^Del-) rooms; cross-site
 	// rooms have no local room doc and are kept (their deletion isn't visible here).
 	pipeline := bson.A{bson.M{"$match": match}}
-	// Origin filter runs BEFORE enrichment: it reads the sub's own origin, which is
-	// reliable cross-site. roomsEnrichStages overwrites origin with $room.origin (null
-	// for a remote room with no local doc), so filtering after enrich would leak it.
 	pipeline = append(pipeline, r.originFilterStage()...)
 	pipeline = append(pipeline, roomsEnrichStages(true)...)
 	// Activity window keys on the room's lastMsgAt (surfaced by the enrich stage),
@@ -290,10 +287,9 @@ func (r *SubscriptionRepo) AggregateSubscriptions(ctx context.Context, account, 
 }
 
 // originFilterStage excludes Teams-migrated rooms (origin "teams") when
-// showTeamsRoom is false; empty (no-op) otherwise. Must run BEFORE
-// roomsEnrichStages: it filters on the subscription's own origin field (reliable
-// cross-site), which enrichment later overwrites with the null $room.origin of a
-// remote room that has no local doc.
+// showTeamsRoom is false; empty (no-op) otherwise. Filters on the subscription's
+// own origin field (reliable cross-site — a remote room has no local doc); enrichment
+// no longer overwrites it, so this is position-independent in the pipeline.
 func (r *SubscriptionRepo) originFilterStage() bson.A {
 	if r.showTeamsRoom {
 		return bson.A{}
@@ -441,8 +437,6 @@ func activeSubscriptionFilter(account string) bson.M {
 // CountActiveSubscriptions counts the deleted-filtered active set via $count over the enriched pipeline (CountDocuments cannot see the join).
 func (r *SubscriptionRepo) CountActiveSubscriptions(ctx context.Context, account string) (int, error) {
 	pipeline := bson.A{bson.M{"$match": activeSubscriptionFilter(account)}}
-	// Filter on the sub's own origin before enrichment overwrites it with the
-	// (null cross-site) $room.origin — see AggregateSubscriptions.
 	pipeline = append(pipeline, r.originFilterStage()...)
 	pipeline = append(pipeline, roomsEnrichStages(true)...)
 	pipeline = append(pipeline, bson.M{"$count": "n"})
@@ -465,6 +459,7 @@ func (r *SubscriptionRepo) CountActiveSubscriptions(ctx context.Context, account
 // GetActiveSubscriptions returns the deleted-filtered active set used by the unread count, capped by limit.
 func (r *SubscriptionRepo) GetActiveSubscriptions(ctx context.Context, account string, limit int) ([]model.EnrichedSubscription, error) {
 	pipeline := bson.A{bson.M{"$match": activeSubscriptionFilter(account)}}
+	pipeline = append(pipeline, r.originFilterStage()...)
 	pipeline = append(pipeline, roomsEnrichStages(true)...)
 	// MongoDB rejects $limit:0 — callers short-circuit zero; stay defensive here.
 	if limit > 0 {

--- a/user-service/mongorepo/subscriptions_origin_test.go
+++ b/user-service/mongorepo/subscriptions_origin_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
 
 	"github.com/hmchangw/chat/pkg/model"
@@ -12,7 +13,7 @@ import (
 func TestOriginFilterStage_ShowTeamsRoomFalse_ExcludesTeams(t *testing.T) {
 	r := &SubscriptionRepo{showTeamsRoom: false}
 	stages := r.originFilterStage()
-	assert.Len(t, stages, 1)
+	require.Len(t, stages, 1)
 	assert.Equal(t, bson.M{"$match": bson.M{"origin": bson.M{"$ne": model.OriginTeams}}}, stages[0])
 }
 

--- a/user-service/mongorepo/subscriptions_origin_test.go
+++ b/user-service/mongorepo/subscriptions_origin_test.go
@@ -12,13 +12,21 @@ import (
 
 func TestOriginFilterStage_ShowTeamsRoomFalse_ExcludesTeams(t *testing.T) {
 	r := &SubscriptionRepo{showTeamsRoom: false}
-	stages := r.originFilterStage()
+	stages := r.originFilterStage("alice")
 	require.Len(t, stages, 1)
 	assert.Equal(t, bson.M{"$match": bson.M{"origin": bson.M{"$ne": model.OriginTeams}}}, stages[0])
 }
 
 func TestOriginFilterStage_ShowTeamsRoomTrue_NoOp(t *testing.T) {
 	r := &SubscriptionRepo{showTeamsRoom: true}
-	stages := r.originFilterStage()
+	stages := r.originFilterStage("alice")
 	assert.Len(t, stages, 0)
+}
+
+func TestOriginFilterStage_AllowlistedAccount_NoOp(t *testing.T) {
+	r := &SubscriptionRepo{showTeamsRoom: false, showTeamsAccounts: map[string]bool{"alice": true}}
+	// Allowlisted account sees Teams rooms → no filter.
+	assert.Len(t, r.originFilterStage("alice"), 0)
+	// A non-allowlisted account is still filtered.
+	require.Len(t, r.originFilterStage("bob"), 1)
 }

--- a/user-service/mongorepo/subscriptions_origin_test.go
+++ b/user-service/mongorepo/subscriptions_origin_test.go
@@ -30,3 +30,11 @@ func TestOriginFilterStage_AllowlistedAccount_NoOp(t *testing.T) {
 	// A non-allowlisted account is still filtered.
 	require.Len(t, r.originFilterStage("bob"), 1)
 }
+
+func TestWithShowTeamsAccounts_TrimsWhitespace(t *testing.T) {
+	s := applyOptions([]Option{WithShowTeamsAccounts([]string{"alice", " bob", "  ", ""})})
+	r := &SubscriptionRepo{showTeamsAccounts: s.showTeamsAccounts}
+	assert.Len(t, r.originFilterStage("alice"), 0, "alice allowlisted")
+	assert.Len(t, r.originFilterStage("bob"), 0, "bob allowlisted despite leading space in env")
+	require.Len(t, r.originFilterStage("carol"), 1, "non-listed still filtered")
+}

--- a/user-service/mongorepo/subscriptions_origin_test.go
+++ b/user-service/mongorepo/subscriptions_origin_test.go
@@ -1,0 +1,23 @@
+package mongorepo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/hmchangw/chat/pkg/model"
+)
+
+func TestOriginFilterStage_ShowTeamsRoomFalse_ExcludesTeams(t *testing.T) {
+	r := &SubscriptionRepo{showTeamsRoom: false}
+	stages := r.originFilterStage()
+	assert.Len(t, stages, 1)
+	assert.Equal(t, bson.M{"$match": bson.M{"origin": bson.M{"$ne": model.OriginTeams}}}, stages[0])
+}
+
+func TestOriginFilterStage_ShowTeamsRoomTrue_NoOp(t *testing.T) {
+	r := &SubscriptionRepo{showTeamsRoom: true}
+	stages := r.originFilterStage()
+	assert.Len(t, stages, 0)
+}

--- a/user-service/mongorepo/subscriptions_test.go
+++ b/user-service/mongorepo/subscriptions_test.go
@@ -344,6 +344,38 @@ func TestAggregateSubscriptions_CrossSite_Integration(t *testing.T) {
 	assert.Nil(t, crossSite["sub-local-only"], "room without crossSite must decode as nil (unclassified)")
 }
 
+// TestAggregateSubscriptions_HidesCrossSiteTeamsRoom_Integration proves the origin
+// filter reads the SUB's own origin, not the enriched $room.origin. A Teams room owned
+// by site-a has no local room doc here, so $room.origin is null; only the sub carries
+// origin="teams". With showTeamsRoom=false (default) the Teams sub must be hidden while a
+// native cross-site sub (no origin, also no local room) stays visible.
+func TestAggregateSubscriptions_HidesCrossSiteTeamsRoom_Integration(t *testing.T) {
+	r, db := newTestSubscriptionRepo(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// No rooms seeded for either roomId → both are remote (no local doc), the cross-site case.
+	seed(t, db, "subscriptions",
+		bson.M{"_id": "sub-xsite-teams", "u": bson.M{"_id": "u-alice", "account": "alice"}, "roomId": "r-xsite-teams",
+			"name": "Migrated", "roomType": "channel", "siteId": "site-a", "origin": "teams", "createdAt": now},
+		bson.M{"_id": "sub-xsite-native", "u": bson.M{"_id": "u-alice", "account": "alice"}, "roomId": "r-xsite-native",
+			"name": "Native", "roomType": "channel", "siteId": "site-a", "createdAt": now},
+	)
+
+	page, err := r.AggregateSubscriptions(ctx, "alice", "rooms", false, nil, mongoutil.OffsetPageRequest{Offset: 0, Limit: 100})
+	require.NoError(t, err)
+	byID := map[string]bool{}
+	for _, sub := range page.Data {
+		byID[sub.ID] = true
+	}
+	assert.False(t, byID["sub-xsite-teams"], "cross-site Teams room must be hidden when showTeamsRoom=false")
+	assert.True(t, byID["sub-xsite-native"], "native cross-site room must stay visible")
+
+	n, err := r.CountActiveSubscriptions(ctx, "alice")
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "count must exclude the cross-site Teams room, include the native one")
+}
+
 // TestFindChannelsByMembers_CrossSite_Integration exercises the SEPARATE roomMatchStages
 // pipeline plus the terminal subscriptionProjection — an inclusion-only $project that
 // silently drops any field not explicitly whitelisted, so crossSite must be listed there

--- a/user-service/mongorepo/subscriptions_test.go
+++ b/user-service/mongorepo/subscriptions_test.go
@@ -374,6 +374,16 @@ func TestAggregateSubscriptions_HidesCrossSiteTeamsRoom_Integration(t *testing.T
 	n, err := r.CountActiveSubscriptions(ctx, "alice")
 	require.NoError(t, err)
 	assert.Equal(t, 1, n, "count must exclude the cross-site Teams room, include the native one")
+
+	// Unread path (GetActiveSubscriptions) must exclude it too.
+	subs, err := r.GetActiveSubscriptions(ctx, "alice", 100)
+	require.NoError(t, err)
+	unreadIDs := map[string]bool{}
+	for _, s := range subs {
+		unreadIDs[s.ID] = true
+	}
+	assert.False(t, unreadIDs["sub-xsite-teams"], "unread set must exclude the cross-site Teams room")
+	assert.True(t, unreadIDs["sub-xsite-native"], "unread set must include the native cross-site room")
 }
 
 // TestFindChannelsByMembers_CrossSite_Integration exercises the SEPARATE roomMatchStages


### PR DESCRIPTION
## Summary

Adds a global `SHOW_TEAMS_ROOM` config (default `false`) that hides Teams-migrated rooms from the room list, search, and counts, via a reversible read-time filter.

## What's included

- `pkg/searchindex`: `MessageDoc` and `SpotlightDoc` gain an indexed `origin` field (`es:"keyword"`).
- `search-sync-worker`: the Teams message-migration path (`buildTeamsActions`) and the Teams room-membership fan-out (via a new `InboxMemberEvent.Origin` field, set only by room-worker's Teams room-creation handler) tag their search docs with `origin=teams`. The normal (non-Teams) message/spotlight paths leave `origin` empty.
- `search-service`: new `SHOW_TEAMS_ROOM` env; when `false`, `search.messages` and Search Rooms add a `must_not: origin=teams` clause.
- `user-service`: new `SHOW_TEAMS_ROOM` env; when `false`, `subscription.list` and `subscription.count` exclude rooms with `origin=teams` via a post-enrichment Mongo `$match` stage.
- `docs/client-api.md`: notes the `SHOW_TEAMS_ROOM` visibility behavior on the room-list and search sections.

## Changes

| Component | Change |
|---|---|
| `pkg/model` | `InboxMemberEvent` gains `Origin` (propagates Teams provenance into the spotlight doc) |
| `search-service` | `Config.ShowTeamsRoom`, threaded into `buildMessageQuery` / `buildRoomQuery` |
| `user-service` | `Config.ShowTeamsRoom`, threaded into `mongorepo.SubscriptionRepo` via a new `WithShowTeamsRoom` option |

## Verification

Verified on our dev environment:
- `go test ./pkg/searchindex/... ./search-service/... ./user-service/... ./search-sync-worker/... ./room-worker/... ./pkg/model/...` — all green
- `golangci-lint` — 0 issues
- `go vet -tags integration` over the same packages — compiles clean

One-time note: enabling this on an existing deployment requires a search-index reindex/backfill so already-indexed Teams docs pick up the new `origin` field (out of scope for this PR — a deploy-time step).

Closes #254

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional visibility for Teams-migrated rooms, messages, and subscriptions.
  * Teams-migrated content is hidden by default from search results, subscription lists, and counts.
  * Visibility can be enabled globally or for specific accounts.
  * Preserved Teams-origin information for accurate filtering without modifying existing stored content.

* **Documentation**
  * Documented visibility settings, defaults, and affected results.

* **Tests**
  * Added coverage for filtering, account-based visibility, configuration, and origin tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Update — per-account allowlist (`SHOW_TEAMS_ROOM_ACCOUNTS`)

Adds a deployment-config allowlist on top of the global flag: an account listed in `SHOW_TEAMS_ROOM_ACCOUNTS` (comma-separated) sees Teams-migrated rooms even when `SHOW_TEAMS_ROOM=false`. Effective visibility = `SHOW_TEAMS_ROOM (global) || account ∈ allowlist`, checked per request against the same origin filter — no per-user storage, no settings RPC.

- **user-service**: `originFilterStage(account)` + `WithShowTeamsAccounts` option.
- **search-service**: `handlerConfig.effectiveShowTeams(account)` feeds the message/room query builders.
- Env on both services (defaults empty). No schema / client-contract change.
