### PR TITLE
Cross-site failover: SP3 — portal health-aware routing override

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -270,6 +270,8 @@ Site discovery — called once per login, **before** §2.2. Looks the account up
 
 **Discovery only — no token is validated here.** The endpoint serves non-secret directory data keyed by `account`. The client supplies the account directly: derived from the SSO token's `preferred_username` claim in production, or the dev login form in dev mode. The authoritative check is auth-service (§2.2), which validates the SSO token before minting a JWT — an account that resolves here still cannot obtain a NATS JWT or connect without a valid token at that step.
 
+> **Failover routing.** During a home-site outage, `baseUrl` and `natsUrl` may point at the shared backup site while `siteId` stays the account's home site (data on the backup is namespaced by the origin `siteId`). Clients need no special handling: the existing reconnect-on-connection-failure path re-queries this endpoint and receives the current coordinates, in both the failover and failback directions.
+
 #### Request
 
 | Field | Source | Type | Required | Notes |

--- a/docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md
+++ b/docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md
@@ -122,6 +122,11 @@ alongside from SP1 onward.
   dependencies are real.
 
 ### SP6 — Ops / IaC / platform  *(cross-cutting runbook, not a TDD plan)*
+- **Runbook drafted:** `plans/2026-08-12-sp6-ops-runbook.md` — consolidates every
+  ops requirement with a per-item readiness tag (READY now / GATED on SP1-SP2 /
+  external INFRA), and documents the operator-facing surface of the shipped SP4
+  control plane (failover/failback procedures, `FAILOVER_OPS_TOKEN`, the internal
+  listener) and the World-1 backup `auth-service` config.
 - Backup deployment (HA multi-AZ); backup as supercluster gateway peer; leaf-node
   `chat.local.>` deny on the backup's leaf; canonical restore-log `MaxAge` sizing
   (spec §6.5); backup `auth-service` deploy with the **shared** account creds

--- a/docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md
+++ b/docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md
@@ -92,9 +92,16 @@ alongside from SP1 onward.
 - **Deliverable:** `portal-service` becomes the single source of truth for "who
   serves account X right now"; returns the backup for a down site's accounts;
   acts as the split-brain fence (spec §4.2).
-- **Ready to plan?** **Partially.** Codebase-local (`portal-service` exists), but
-  needs the health signal from SP4 and the failback-flip protocol (spec §6.3).
-  Plannable in parallel once SP4's signal shape is decided.
+- **Ready to plan?** **Resolved & building** — spec `specs/2026-08-11-sp3-portal-routing-override.md`
+  (rewritten to World 1 / operator-driven SP4). SP3-core scopes the override to the
+  SSO `/api/userInfo` path only.
+- **Deferred, CRITICAL follow-up — bot failover.** The bot/admin `/api/v1/login`
+  path is intentionally left un-rerouted in SP3-core because bots are out of
+  lifeboat scope today and their login forwards to the (down) home botplatform.
+  Bots ARE business-critical; re-adding them is a follow-up whose weight is in SP1
+  (materialize bot/botplatform state) + SP2 (run botplatform at the backup, wire
+  the backup auth-service session branch). The SP3 routing hook is then a single
+  `servingURLs(...)` call in `HandleLogin`. Tracked so this is not lost.
 
 ### SP4 — Failover trigger / health detection  *(own design)*
 - **Deliverable:** auto-detect a down site (+ manual operator override) and drive

--- a/docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md
+++ b/docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md
@@ -47,15 +47,19 @@ alongside from SP1 onward.
 
 ## Sub-projects
 
-### SP0 — Local/global room subjects  *(external dependency — do not re-plan here)*
-- **Owner:** `claude/nats-subscription-reduction-z0wcya` (design + plan already
-  written there).
-- **Why it's here:** the backup's delivery correctness (spec §7) rests on the
-  `CrossSite` flag and the `chat.local.room.>` prefix. SP1b must carry `CrossSite`
-  on the DR feed; SP2 must add the `chat.local.room.>` subscribe grant to the
-  backup's JWTs.
-- **Action:** track it as a dependency; do not duplicate. Coordinate the two
-  integration points above when it lands.
+### SP0 — Local/global room subjects  *(LANDED on `main` — external, do not re-plan)*
+- **Owner:** `claude/nats-subscription-reduction-z0wcya` — **merged to `main`.**
+- **Status (2026-08-12): SHIPPED.** `main` has the `chat.local.room.{id}` subject
+  builders (`pkg/subject/subject.go`, with a `global` flag + `RouteDual`/`RouteLocal`
+  migration modes), the `CrossSite *bool` flag on `model.Room`/`SubscriptionRoom`,
+  and the `chat.local.room.>` subscribe grant in the shared scoped-signing template
+  (`docker-local/setup.sh`) + `signNATSJWT` docstring.
+- **Integration points — now resolved on `main`:** (1) the `chat.local.room.>`
+  grant SP2 needed **already exists** (SP2 has no grant work left); (2) SP1b must
+  carry `CrossSite` on the DR feed — free with whole-document oplog replication.
+- **Action:** the failover branch family is ~67 commits behind `main` (merge-base
+  `fc828a6`) and predates this. When it rebases onto current `main`, SP0 is simply
+  present — no coordination needed beyond the rebase itself.
 
 ### SP1 — DR feed + backup materialization  *(LINCHPIN — needs a design cycle first)*
 - **Deliverable:** every site continuously ships its whole-site state to the
@@ -82,9 +86,10 @@ alongside from SP1 onward.
   Production runs **one shared NATS account**, so the backup mints in that same
   account (not impersonation, no per-site keys) and reuses `auth-service`
   **unchanged**. The earlier "key-custody / KMS" brainstorm (old §11.4) is
-  **moot**. The only identity deliverables are config/ops: the shared-template
-  `chat.local.room.>` grant (SP0-coupled) and deploying `auth-service` at the
-  backup (SP6) — **no new minting code**.
+  **moot**. The shared-template `chat.local.room.>` grant is **already on `main`**
+  (SP0 shipped it — see SP0 above), so **identity is effectively complete**; the
+  only remaining identity task is deploying `auth-service` at the backup (SP6) —
+  **no new minting code, no grant work**.
 - **Serving path — still needs SP1.** Plannable once SP1 materialization exists;
   that (not identity) is the remaining SP2 substance.
 

--- a/docs/superpowers/plans/2026-08-12-sp3-portal-routing-override.md
+++ b/docs/superpowers/plans/2026-08-12-sp3-portal-routing-override.md
@@ -1,0 +1,617 @@
+# SP3-core: Portal Health-Aware Routing Override Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `portal-service` return the backup site's connection coordinates for a down site's SSO users, keyed on SP4's `servingTarget`, while keeping `siteId` = home.
+
+**Architecture:** A TTL-cached `failoverReader` wraps SP4's `FailoverStore`; a `servingURLs` helper swaps the home registry entry for the reserved backup entry when `servingTarget == backup`; `resolve()` (the `/api/userInfo` path) calls it. Only `baseUrl`/`natsUrl` change — `siteId` stays home. Bot/admin `/api/v1/login` is untouched (deferred).
+
+**Tech Stack:** Go 1.25, Gin, MongoDB (`mongo-driver/v2`), `caarlos0/env`, `go.uber.org/mock`, `stretchr/testify`.
+
+**Spec:** `docs/superpowers/specs/2026-08-11-sp3-portal-routing-override.md`
+
+## Global Constraints
+
+- Build via `make`: `make test SERVICE=portal-service`, `make test-integration SERVICE=portal-service`, `make lint`, `make build SERVICE=portal-service`.
+- Errors: infra `fmt.Errorf("...: %w", err)`; client-facing via `pkg/errcode` + `errhttp.Write`; `errors.Is` for comparison.
+- Logging: `log/slog` JSON, structured fields, request-context-aware. Never log secrets.
+- `json`+`bson` tags on model structs; DI = accept interfaces (define in consumer).
+- **`FailoverState` is passed by pointer** (gocritic hugeParam); its `ServingTarget()` is a pointer-receiver method on an addressable value.
+- TDD: Red → Green → Refactor → Commit. Tests in `package main`. Integration tests `//go:build integration`, reuse the `TestMain` in `portal-service/integration_test.go`.
+- Coverage ≥80% floor; ≥90% on `servingURLs` + `failoverReader`.
+- **This slice touches no `chat.user.*` RPC** — the `docs/client-api.md` edit is a courtesy narrative note, not a required RPC-doc change.
+
+## File Structure
+
+- **Create** `portal-service/failover_reader.go` — `failoverReader` (TTL cache over `FailoverStore`) + `newFailoverReader`.
+- **Create** `portal-service/failover_reader_test.go` — unit tests (injected clock, `MockFailoverStore`).
+- **Create** `portal-service/failover_reader_integration_test.go` — reader over real Mongo (`//go:build integration`).
+- **Modify** `portal-service/handler.go` — add `failoverTargeter` interface, `failover`/`backupSiteID` fields + options, `servingURLs`, wire `resolve()`.
+- **Modify** `portal-service/handler_test.go` — override tests (fake targeter).
+- **Create** `portal-service/failover_userinfo_integration_test.go` — `/api/userInfo` over real Mongo failover state (`//go:build integration`).
+- **Modify** `portal-service/main.go` — config (`FAILOVER_STATE_TTL`, `PORTAL_BACKUP_SITE_ID`), construct the store unconditionally, build the reader, pass options, reuse the store in the ops block.
+- **Modify** `docs/client-api.md` — §2 site-discovery narrative note.
+
+---
+
+### Task 1: The TTL-cached failover reader
+
+**Files:**
+- Create: `portal-service/failover_reader.go`
+- Test: `portal-service/failover_reader_test.go`, `portal-service/failover_reader_integration_test.go`
+
+**Interfaces:**
+- Consumes: `FailoverStore` (Get), `FailoverState.ServingTarget()`, `ServingHome`/`ServingBackup` (SP4). `MockFailoverStore` (generated).
+- Produces: `func newFailoverReader(store FailoverStore, ttl time.Duration) *failoverReader`; method `ServingTarget(ctx context.Context, siteID string) ServingTarget`; overridable `now func() time.Time` field for tests.
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Create `portal-service/failover_reader_test.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	gomock "go.uber.org/mock/gomock"
+)
+
+func TestFailoverReader_MissThenCacheHit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockFailoverStore(ctrl)
+	// Store is consulted exactly once; the second call is served from cache.
+	store.EXPECT().Get(gomock.Any(), "site-a").
+		Return(FailoverState{SiteID: "site-a", Status: StatusFailedOver, Version: 1}, nil).
+		Times(1)
+
+	r := newFailoverReader(store, time.Minute)
+	now := time.UnixMilli(1000)
+	r.now = func() time.Time { return now }
+
+	assert.Equal(t, ServingBackup, r.ServingTarget(context.Background(), "site-a"))
+	assert.Equal(t, ServingBackup, r.ServingTarget(context.Background(), "site-a"))
+}
+
+func TestFailoverReader_RefreshesAfterTTL(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockFailoverStore(ctrl)
+	gomock.InOrder(
+		store.EXPECT().Get(gomock.Any(), "site-a").
+			Return(FailoverState{SiteID: "site-a", Status: StatusFailedOver, Version: 1}, nil),
+		store.EXPECT().Get(gomock.Any(), "site-a").
+			Return(FailoverState{SiteID: "site-a", Status: StatusHealthy, Version: 2}, nil),
+	)
+
+	r := newFailoverReader(store, 5*time.Second)
+	now := time.UnixMilli(1000)
+	r.now = func() time.Time { return now }
+
+	assert.Equal(t, ServingBackup, r.ServingTarget(context.Background(), "site-a"))
+	now = now.Add(6 * time.Second) // past TTL
+	assert.Equal(t, ServingHome, r.ServingTarget(context.Background(), "site-a"))
+}
+
+func TestFailoverReader_StoreErrorFailsSafeHomeUncached(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockFailoverStore(ctrl)
+	// Error path is not cached: both calls hit the store.
+	store.EXPECT().Get(gomock.Any(), "site-a").Return(FailoverState{}, errors.New("mongo down")).Times(2)
+
+	r := newFailoverReader(store, time.Minute)
+	r.now = func() time.Time { return time.UnixMilli(1000) }
+
+	assert.Equal(t, ServingHome, r.ServingTarget(context.Background(), "site-a"))
+	assert.Equal(t, ServingHome, r.ServingTarget(context.Background(), "site-a"))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `make test SERVICE=portal-service`
+Expected: FAIL — `newFailoverReader` undefined.
+
+- [ ] **Step 3: Write the reader**
+
+Create `portal-service/failover_reader.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// failoverReader answers "where is this site served from right now?" from SP4's
+// FailoverStore, behind a short TTL cache so routing does not hit Mongo on every
+// login. Fail-safe: a store error resolves to home and is not cached.
+type failoverReader struct {
+	store FailoverStore
+	ttl   time.Duration
+	now   func() time.Time
+
+	mu    sync.Mutex
+	cache map[string]cachedTarget
+}
+
+type cachedTarget struct {
+	target  ServingTarget
+	expires time.Time
+}
+
+func newFailoverReader(store FailoverStore, ttl time.Duration) *failoverReader {
+	return &failoverReader{
+		store: store,
+		ttl:   ttl,
+		now:   time.Now,
+		cache: make(map[string]cachedTarget),
+	}
+}
+
+// ServingTarget returns home or backup for siteID. On a cache hit within the TTL
+// it returns the cached value; otherwise it reads the store, derives the target,
+// and caches it. A store error resolves to home (fail-safe) and is not cached.
+func (r *failoverReader) ServingTarget(ctx context.Context, siteID string) ServingTarget {
+	r.mu.Lock()
+	if c, ok := r.cache[siteID]; ok && r.now().Before(c.expires) {
+		r.mu.Unlock()
+		return c.target
+	}
+	r.mu.Unlock()
+
+	// Read outside the lock so a slow Mongo call does not serialize all readers.
+	st, err := r.store.Get(ctx, siteID)
+	if err != nil {
+		slog.WarnContext(ctx, "failover reader: store read failed, defaulting to home",
+			"siteId", siteID, "error", err)
+		return ServingHome
+	}
+	target := st.ServingTarget()
+
+	r.mu.Lock()
+	r.cache[siteID] = cachedTarget{target: target, expires: r.now().Add(r.ttl)}
+	r.mu.Unlock()
+	return target
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test SERVICE=portal-service`
+Expected: PASS.
+
+- [ ] **Step 5: Write the integration test (compiles now; runs in CI)**
+
+Create `portal-service/failover_reader_integration_test.go`:
+
+```go
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/testutil"
+)
+
+func TestFailoverReader_OverMongo(t *testing.T) {
+	db := testutil.MongoDB(t, "portal")
+	store := newMongoFailoverStore(db)
+	ctx := context.Background()
+
+	r := newFailoverReader(store, time.Minute)
+
+	// No document yet => healthy => home.
+	assert.Equal(t, ServingHome, r.ServingTarget(ctx, "site-a"))
+
+	// Fail the site over; a fresh reader (empty cache) sees backup.
+	require.NoError(t, store.Transition(ctx, &FailoverState{SiteID: "site-a", Status: StatusFailedOver, Version: 1, Since: 1, Timestamp: 1}))
+	r2 := newFailoverReader(store, time.Minute)
+	assert.Equal(t, ServingBackup, r2.ServingTarget(ctx, "site-a"))
+}
+```
+
+- [ ] **Step 6: Verify integration compiles**
+
+Run: `go vet -tags integration ./portal-service/...`
+Expected: no errors. (Execution needs Docker → CI.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add portal-service/failover_reader.go portal-service/failover_reader_test.go portal-service/failover_reader_integration_test.go
+git commit -m "portal-service: TTL-cached failover reader over SP4 store"
+```
+
+---
+
+### Task 2: The routing override (`servingURLs` + `resolve()`)
+
+**Files:**
+- Modify: `portal-service/handler.go`
+- Test: `portal-service/handler_test.go`, `portal-service/failover_userinfo_integration_test.go`
+
+**Interfaces:**
+- Consumes: `failoverReader` (Task 1) via a `failoverTargeter` interface; `siteURL`, `PortalHandler`, `PortalHandlerOption` (existing).
+- Produces:
+  - `type failoverTargeter interface { ServingTarget(ctx context.Context, siteID string) ServingTarget }`
+  - `PortalHandler` fields `failover failoverTargeter`, `backupSiteID string`.
+  - `func WithFailoverReader(f failoverTargeter) PortalHandlerOption`, `func WithBackupSiteID(id string) PortalHandlerOption`.
+  - `func (h *PortalHandler) servingURLs(ctx context.Context, siteID string) (siteURL, error)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `portal-service/handler_test.go`:
+
+```go
+// fakeTargeter is a failoverTargeter stub returning a fixed target.
+type fakeTargeter struct{ target ServingTarget }
+
+func (f fakeTargeter) ServingTarget(_ context.Context, _ string) ServingTarget { return f.target }
+
+// testSitesWithBackup extends testSites with a reserved backup entry.
+var testSitesWithBackup = map[string]siteURL{
+	"site-a":     {BaseURL: "https://site-a.example.com", NATSURL: "wss://nats-3.site-a.example.com"},
+	"site-b":     {BaseURL: "https://site-b.example.com", NATSURL: "wss://nats.site-b.example.com"},
+	"site-local": {BaseURL: "http://localhost:3000", NATSURL: "ws://localhost:9222"},
+	"_backup":    {BaseURL: "https://backup.example.com", NATSURL: "wss://nats.backup.example.com"},
+}
+
+func newFailoverHandler(cache *directoryCache, target ServingTarget) *PortalHandler {
+	return NewPortalHandler(cache, false, "site-local", "ws://localhost:9222", testSitesWithBackup, testSettings,
+		WithFailoverReader(fakeTargeter{target: target}), WithBackupSiteID("_backup"))
+}
+
+func TestHandleUserInfo_FailoverRoutesToBackup(t *testing.T) {
+	h := newFailoverHandler(cacheWith(alice), ServingBackup)
+	w := getUserInfo(t, setupRouter(t, h), "alice")
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp userInfoResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "https://backup.example.com", resp.BaseURL, "baseUrl swaps to backup")
+	assert.Equal(t, "wss://nats.backup.example.com", resp.NATSURL, "natsUrl swaps to backup")
+	assert.Equal(t, "site-a", resp.SiteID, "siteId MUST stay the home site")
+	assert.Equal(t, "E001", resp.EmployeeID, "identity fields unchanged")
+}
+
+func TestHandleUserInfo_HealthyRoutesHome(t *testing.T) {
+	h := newFailoverHandler(cacheWith(alice), ServingHome)
+	w := getUserInfo(t, setupRouter(t, h), "alice")
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp userInfoResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "https://site-a.example.com", resp.BaseURL)
+	assert.Equal(t, "site-a", resp.SiteID)
+}
+
+func TestHandleUserInfo_BackupMissingFromRegistryIsInternal(t *testing.T) {
+	// servingTarget=backup but no backup entry configured => loud 500.
+	h := NewPortalHandler(cacheWith(alice), false, "site-local", "ws://localhost:9222", testSites, testSettings,
+		WithFailoverReader(fakeTargeter{target: ServingBackup}), WithBackupSiteID("_backup"))
+	w := getUserInfo(t, setupRouter(t, h), "alice")
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestHandleUserInfo_NoFailoverConfiguredRoutesHome(t *testing.T) {
+	// newTestHandler sets no failover reader; the override must no-op to home.
+	h := newTestHandler(cacheWith(alice), false)
+	w := getUserInfo(t, setupRouter(t, h), "alice")
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp userInfoResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "https://site-a.example.com", resp.BaseURL)
+	assert.Equal(t, "site-a", resp.SiteID)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `make test SERVICE=portal-service`
+Expected: FAIL — `WithFailoverReader`, `WithBackupSiteID` undefined.
+
+- [ ] **Step 3: Add the interface, fields, options, and `servingURLs`**
+
+In `portal-service/handler.go`, add near the `PortalHandler` type:
+
+```go
+// failoverTargeter reads SP4's per-site serving target. *failoverReader
+// implements it; defined here (the consumer) so tests can inject a fake.
+type failoverTargeter interface {
+	ServingTarget(ctx context.Context, siteID string) ServingTarget
+}
+```
+
+Add two fields to the `PortalHandler` struct:
+
+```go
+	// failover resolves per-site failover routing (SP4). nil => always home.
+	failover failoverTargeter
+	// backupSiteID is the reserved PORTAL_SITE_URLS entry served during failover.
+	backupSiteID string
+```
+
+Add two options next to the existing `With*` options:
+
+```go
+// WithFailoverReader injects the SP4 failover target reader that drives the
+// health-aware routing override. Without it, routing is always home.
+func WithFailoverReader(f failoverTargeter) PortalHandlerOption {
+	return func(h *PortalHandler) { h.failover = f }
+}
+
+// WithBackupSiteID sets the reserved PORTAL_SITE_URLS id served for a
+// failed-over site (PORTAL_BACKUP_SITE_ID).
+func WithBackupSiteID(id string) PortalHandlerOption {
+	return func(h *PortalHandler) { h.backupSiteID = id }
+}
+```
+
+Add the helper:
+
+```go
+// servingURLs returns the coordinates to hand a client for an account homed on
+// siteID, applying SP4's failover override. siteID (the home site) is never
+// changed by this — only which registry entry's URLs are returned. A configured
+// backup that is missing from the registry is a loud internal error rather than
+// a silent mis-route to the down home site.
+func (h *PortalHandler) servingURLs(ctx context.Context, siteID string) (siteURL, error) {
+	if h.failover != nil && h.failover.ServingTarget(ctx, siteID) == ServingBackup {
+		b, ok := h.sites[h.backupSiteID]
+		if !ok {
+			return siteURL{}, fmt.Errorf("serving target is backup but backup site %q missing from registry", h.backupSiteID)
+		}
+		return b, nil
+	}
+	home, ok := h.sites[siteID]
+	if !ok {
+		return siteURL{}, fmt.Errorf("no URLs configured for siteId %q", siteID)
+	}
+	return home, nil
+}
+```
+
+- [ ] **Step 4: Wire `resolve()` to use it**
+
+In `resolve()`, replace this block:
+
+```go
+	site, siteOK := h.sites[e.SiteID]
+	if !siteOK && !devFallback {
+		// A directory entry homed on a site missing from the registry is an ops
+		// misconfiguration, not a client error — surface it as internal.
+		errhttp.Write(ctx, c, fmt.Errorf("no URLs configured for siteId %q", e.SiteID))
+		return
+	}
+	natsURL := site.NATSURL
+	if !siteOK {
+		// The dev-fallback site itself isn't in the registry — fall back to
+		// the legacy PORTAL_DEV_FALLBACK_NATS_URL so local logins keep working.
+		natsURL = h.devFallbackNatsURL
+	}
+```
+
+with:
+
+```go
+	var baseURL, natsURL string
+	if devFallback {
+		// Dev-fallback site never fails over; keep the legacy URL handling.
+		site, siteOK := h.sites[e.SiteID]
+		baseURL, natsURL = site.BaseURL, site.NATSURL
+		if !siteOK {
+			natsURL = h.devFallbackNatsURL // baseURL stays "" as before
+		}
+	} else {
+		su, err := h.servingURLs(ctx, e.SiteID)
+		if err != nil {
+			errhttp.Write(ctx, c, err) // raw wrapped => internal at the boundary
+			return
+		}
+		baseURL, natsURL = su.BaseURL, su.NATSURL
+	}
+```
+
+Then in the two `c.JSON(...)` response builders below, replace `BaseURL: site.BaseURL` with `BaseURL: baseURL` (the `NATSURL: natsURL` line is already correct). Both the `userInfoBotResponse` and `userInfoResponse` builders use `baseURL`.
+
+- [ ] **Step 5: Write the `/api/userInfo`-over-Mongo integration test**
+
+Create `portal-service/failover_userinfo_integration_test.go`:
+
+```go
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/testutil"
+)
+
+func TestUserInfo_FailoverOverMongo(t *testing.T) {
+	db := testutil.MongoDB(t, "portal")
+	store := newMongoFailoverStore(db)
+	ctx := context.Background()
+
+	// Short TTL so the flip-back is observable within the test.
+	reader := newFailoverReader(store, 20*time.Millisecond)
+	h := NewPortalHandler(cacheWith(alice), false, "site-local", "ws://localhost:9222",
+		testSitesWithBackup, testSettings,
+		WithFailoverReader(reader), WithBackupSiteID("_backup"))
+	r := setupRouter(t, h)
+
+	// Fail site-a over -> userInfo returns backup coords, home siteId.
+	require.NoError(t, store.Transition(ctx, &FailoverState{SiteID: "site-a", Status: StatusFailedOver, Version: 1, Since: 1, Timestamp: 1}))
+	var resp userInfoResponse
+	require.NoError(t, json.Unmarshal(getUserInfo(t, r, "alice").Body.Bytes(), &resp))
+	assert.Equal(t, http.StatusOK, getUserInfo(t, r, "alice").Code)
+	assert.Equal(t, "https://backup.example.com", resp.BaseURL)
+	assert.Equal(t, "site-a", resp.SiteID)
+}
+```
+
+- [ ] **Step 6: Run unit tests and verify the integration compiles**
+
+Run: `make test SERVICE=portal-service`
+Expected: PASS (new override tests + all existing handler tests still green).
+
+Run: `go vet -tags integration ./portal-service/...`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add portal-service/handler.go portal-service/handler_test.go portal-service/failover_userinfo_integration_test.go
+git commit -m "portal-service: health-aware routing override on /api/userInfo"
+```
+
+---
+
+### Task 3: Wire the reader into `main.go`
+
+**Files:**
+- Modify: `portal-service/main.go`
+
+**Interfaces:**
+- Consumes: `newFailoverReader` (Task 1), `WithFailoverReader`/`WithBackupSiteID` (Task 2), `newMongoFailoverStore` (SP4).
+
+- [ ] **Step 1: Add config fields**
+
+In the `config` struct, next to the SP4 failover fields, add:
+
+```go
+	// FailoverStateTTL bounds how long portal caches a site's serving target
+	// before re-reading it (routing freshness vs. Mongo load).
+	FailoverStateTTL time.Duration `env:"FAILOVER_STATE_TTL" envDefault:"5s"`
+	// BackupSiteID is the reserved PORTAL_SITE_URLS id served for a failed-over
+	// site. Empty in single-site/dev deployments (no failover occurs there).
+	BackupSiteID string `env:"PORTAL_BACKUP_SITE_ID" envDefault:""`
+```
+
+- [ ] **Step 2: Construct the store + reader before the handler, and pass the options**
+
+The failover store must exist unconditionally (routing needs it even when the control surface is off). Immediately before the `handler := NewPortalHandler(...)` call, add:
+
+```go
+	failoverStore := newMongoFailoverStore(mongoClient.Database(cfg.MongoDB))
+	failoverReader := newFailoverReader(failoverStore, cfg.FailoverStateTTL)
+```
+
+Then extend the `NewPortalHandler(...)` call's option list with:
+
+```go
+		WithFailoverReader(failoverReader), WithBackupSiteID(cfg.BackupSiteID),
+```
+
+- [ ] **Step 3: Reuse the store in the SP4 ops block**
+
+In the `if cfg.FailoverOpsToken != ""` block, delete the line that re-creates the store:
+
+```go
+		failoverStore := newMongoFailoverStore(mongoClient.Database(cfg.MongoDB))
+```
+
+so the block uses the `failoverStore` built in Step 2 (it is already in scope). The `NewFailoverHandler(failoverStore)` call is unchanged.
+
+- [ ] **Step 4: Verify build, lint, tests**
+
+Run: `make build SERVICE=portal-service`
+Expected: builds clean (no "declared and not used", no shadowing).
+
+Run: `make lint`
+Expected: 0 issues.
+
+Run: `make test SERVICE=portal-service`
+Expected: PASS.
+
+- [ ] **Step 5: Add local-dev backup coordinates (compose)**
+
+In `portal-service/deploy/docker-compose.yml`, extend `PORTAL_SITE_URLS` with a `_backup` entry and set `PORTAL_BACKUP_SITE_ID`. Replace the existing `PORTAL_SITE_URLS` line and add the id line in the `environment:` list:
+
+```yaml
+      - 'PORTAL_SITE_URLS={"site-local":{"baseUrl":"http://localhost:7777","natsUrl":"ws://localhost:9222"},"_backup":{"baseUrl":"http://localhost:7777","natsUrl":"ws://localhost:9222"}}'
+      - PORTAL_BACKUP_SITE_ID=_backup
+```
+
+(The dev backup points at the same local stack — there is no separate backup site locally; this just makes the config valid and exercisable.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add portal-service/main.go portal-service/deploy/docker-compose.yml
+git commit -m "portal-service: wire failover reader into routing + config"
+```
+
+---
+
+### Task 4: Client-API doc note
+
+**Files:**
+- Modify: `docs/client-api.md`
+
+- [ ] **Step 1: Add the site-discovery note**
+
+Find the §2 site-discovery / `GET /api/userInfo` subsection. Add a short note (matching the doc's prose style) after the response description:
+
+```markdown
+> **Failover routing.** During a home-site outage, `baseUrl` and `natsUrl` may
+> point at the shared backup site while `siteId` stays the account's home site
+> (data on the backup is namespaced by the origin `siteId`). Clients need no
+> special handling: the existing reconnect-on-connection-failure path re-queries
+> this endpoint and receives the current coordinates, in both the failover and
+> failback directions.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/client-api.md
+git commit -m "docs(client-api): note failover routing on /api/userInfo"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- §2 thin override at resolve seam → Task 2 (`servingURLs` + `resolve()`). ✓
+- §2.1 one helper → Task 2 `servingURLs`. ✓
+- §2.2 scope userInfo only, bots untouched → Task 2 modifies only `resolve()`; `HandleLogin` unchanged. ✓
+- §3 swaps URLs, `siteId` stays home → Task 2 keeps `SiteID: e.SiteID`, test `TestHandleUserInfo_FailoverRoutesToBackup` asserts it. ✓
+- §4 reserved backup entry / `PORTAL_BACKUP_SITE_ID` → Task 3 config + Task 2 `servingURLs` lookup. ✓
+- §5 client reconnect (no SP3 code) → nothing to implement; doc note Task 4. ✓
+- §6 failoverReader TTL + fail-safe home → Task 1. ✓
+- §6.1 main.go refactor (store unconditional) → Task 3. ✓
+- §7 split-brain / fail-safe home → Task 1 (error→home, uncached) + Task 2 (nil failover→home). ✓
+- §8 testing → Task 1 unit+integration, Task 2 unit+integration. ✓
+- §9 client-api note → Task 4. ✓
+
+**2. Placeholder scan:** No TBD/TODO; every step has code or an exact command. ✓
+
+**3. Type consistency:** `failoverReader`/`newFailoverReader`/`ServingTarget`, `failoverTargeter`, `servingURLs`, `WithFailoverReader`/`WithBackupSiteID`, `backupSiteID`, `FailoverStore`/`FailoverState`/`ServingHome`/`ServingBackup` — consistent across Tasks 1→3. `FailoverState` passed by pointer in `store.Transition(ctx, &FailoverState{...})` per SP4. ✓
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-08-12-sp3-portal-routing-override.md`.

--- a/docs/superpowers/plans/2026-08-12-sp6-ops-runbook.md
+++ b/docs/superpowers/plans/2026-08-12-sp6-ops-runbook.md
@@ -1,0 +1,231 @@
+# SP6 — Cross-Site Failover: Ops / IaC Runbook
+
+> **What this is.** SP6 of the cross-site failover ("lifeboat") program is a
+> **runbook coordinated with the platform/NATS/IaC team — not a TDD code plan**
+> (roadmap §SP6). This document consolidates every operational requirement, and
+> documents the operator-facing surface of the parts already shipped (SP3, SP4).
+>
+> - **Governing design:** `docs/superpowers/specs/2026-07-28-cross-site-failover-design.md` (§4, §6.5, §8, §9)
+> - **Roadmap:** `docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md` (SP6)
+> - **Related shipped work:** SP4 (failover state + control surface, `portal-service`), SP3 (routing override), SP2 (identity — World 1).
+
+## Readiness legend
+
+Each item is tagged with what an operator can action **today** vs. what is gated:
+
+- **[READY]** — actionable now against shipped code.
+- **[GATED:SP1]** / **[GATED:SP1+SP2]** — needs the backup materialization / serving stack to exist first.
+- **[INFRA]** — external platform/IaC work (Kubernetes, NATS supercluster, cloud), owned by the platform team; this repo carries no code for it.
+
+---
+
+## 1. The failover control surface  **[READY]**
+
+Shipped in SP4 (`portal-service`). This is how an operator drives a failover and
+failback. Portal is the **single routing authority and split-brain fence** — it
+is the only place the decision is made.
+
+### 1.1 Configuration
+
+| Env | Where | Meaning | Ops action |
+|---|---|---|---|
+| `FAILOVER_OPS_TOKEN` | portal-service | Break-glass bearer token gating the control surface. **Empty disables the control surface entirely.** | Provision as a secret (below). Required to operate failover. |
+| `FAILOVER_INTERNAL_ADDR` | portal-service | Listen address for the internal-only control listener (default `:8090`), kept **off** the public `:8085` discovery API. | Expose only to the ops network (below). |
+| `PORTAL_BACKUP_SITE_ID` | portal-service | Reserved id in `PORTAL_SITE_URLS` whose `{baseUrl,natsUrl}` are served for a failed-over site (e.g. `_backup`). Empty in single-site deployments. | Set once the backup site exists; add its entry to `PORTAL_SITE_URLS`. |
+| `FAILOVER_STATE_TTL` | portal-service | How long portal caches a site's serving target before re-reading (default `5s`). | Leave default unless routing-propagation latency needs tuning. |
+| `PORTAL_SITE_URLS` | portal-service | Site registry; **must contain the `PORTAL_BACKUP_SITE_ID` entry** or a failover returns `500` (loud, by design). | Add the backup entry when the backup is deployed. |
+
+### 1.2 Secret provisioning — `FAILOVER_OPS_TOKEN`
+
+- Generate a high-entropy random token; store in the platform secret manager
+  (the same mechanism that delivers other portal secrets).
+- Deliver to portal-service as an env var / mounted secret. **Never** commit it;
+  the local `deploy/docker-compose.yml` value (`dev-failover-token`) is dev-only.
+- Rotation: replace the secret and restart/roll portal. There is no session
+  state to migrate — the token gates each request independently.
+- The token authenticates *possession*, not a person; the `operator` field in
+  each request is self-asserted for the audit trail. A per-operator login is a
+  planned follow-up (SP4 spec §8, "option 3") and is **not** in scope here.
+
+### 1.3 Network policy — internal listener
+
+- The control routes live on `FAILOVER_INTERNAL_ADDR` (a **separate** HTTP
+  listener from the public discovery API on `:8085`). Restrict it to the ops
+  network / an internal LB — it must **not** be internet-reachable.
+- Portal's public `:8085` surface is unchanged and carries no privileged writes.
+
+### 1.4 Operator procedures
+
+Control endpoints (all require `Authorization: Bearer $FAILOVER_OPS_TOKEN`):
+
+```
+GET  /internal/v1/failover            # list every site's failover state
+GET  /internal/v1/failover/{siteId}   # one site's state
+POST /internal/v1/failover/{siteId}   # {"action": "...", "operator": "...", "reason": "..."}
+```
+
+State machine (operator-driven; every write is CAS-guarded, so concurrent portal
+replicas cannot diverge):
+
+```
+healthy ──failover──► failed_over ──failback──► failing_back ──complete──► healthy
+   ▲                       │
+   └──────── resume ───────┘   (false alarm; skip the drain)
+```
+
+`servingTarget` is `backup` while `failed_over`/`failing_back`, else `home`.
+
+**Declare a site down (fail over):**
+```bash
+curl -sS -H "Authorization: Bearer $FAILOVER_OPS_TOKEN" \
+  -X POST https://portal-internal/internal/v1/failover/site-a \
+  -d '{"action":"failover","operator":"jane","reason":"site-a NATS unreachable"}'
+```
+Effect: `site-a` accounts' `/api/userInfo` now return the backup's coordinates;
+displaced clients reconnect there on their next connection failure.
+
+**Begin failback (start draining home):** `{"action":"failback",...}` → moves to
+`failing_back`. **`servingTarget` stays `backup`** — users keep writing to a
+stable backup while the home site drains. *(The drain/replay itself is SP5.)*
+
+**Complete failback (flip home):** `{"action":"complete",...}` → `healthy`;
+`servingTarget` flips to `home`; the backup drains its impersonation and clients
+reconnect home. **Gate this on SP5's lag≈0 signal** once SP5 exists; today it is a
+manual operator action.
+
+**False alarm (undo a failover):** `{"action":"resume",...}` → straight back to
+`healthy`, skipping the drain.
+
+**Inspect:** `GET /internal/v1/failover` for the whole fleet's state, including
+`operator`/`reason`/`since` for the audit trail.
+
+### 1.5 Split-brain guarantee
+
+A site is `home` **xor** `backup` because the decision is a single, single-valued
+`FailoverState` document that only portal writes (CAS-guarded). Do **not**
+attempt to route around portal or edit the `failover_states` collection by hand —
+that is the one thing that can break the fence.
+
+---
+
+## 2. Backup identity & auth-service deploy  **[READY (config) / GATED:SP1+SP2 (serving)]**
+
+Identity is **resolved (World 1)** — one shared org NATS account, so the backup
+mints with the *same* signing identity every site uses. No per-site keys, no KMS
+scheme (see `specs/2026-08-11-sp2-backup-identity-jwt-minting.md`).
+
+Backup `auth-service` deployment requirements:
+
+- **[READY]** Configure with the **shared** `AUTH_SCOPED_SIGNING_KEY` +
+  `AUTH_ACCOUNT_PUB_KEY` — identical to every site. No new key material.
+- **[READY]** The `chat.local.room.>` subscribe grant is **already on `main`** in
+  the shared scoped-signing template (SP0). Nothing to add; the backup inherits it.
+- **[READY]** Point OIDC at the central Keycloak (reachable from the backup).
+- **[READY]** Leave `BOTPLATFORM_URL` **unset** on the backup — bot/admin login is
+  out of lifeboat scope, so the session-token branch need not work there.
+- **[READY]** Size the backup `auth-service` (and Keycloak reachability) for **one
+  largest site's reconnect peak** — a whole site re-mints at once on failover.
+  Client reconnect backoff/jitter + proactive-refresh jitter already spread it
+  (`docs/superpowers/specs/2026-06-05-seamless-nats-jwt-refresh-design.md`).
+- **[INFRA]** The backup's NATS `resolver` must preload the same shared account
+  JWT so it validates the minted user JWTs (it does, being a supercluster peer).
+
+The serving *handlers* (send/receive/history against the materialized copy) are
+**[GATED:SP1+SP2]** — they need the materialized data to exist.
+
+---
+
+## 3. Backup platform footprint  **[INFRA]**
+
+Owned by the platform/NATS/IaC team; no code in this repo.
+
+- **HA within itself (multi-AZ).** The backup is a failover SPOF — if it is down
+  when a site fails, there is no lifeboat. It **must** be HA. Documented limit,
+  not silently degraded (design §9).
+- **Supercluster gateway peer.** The backup must be a full gateway peer so that,
+  during a failover, **global-room** delivery reaches members still on healthy
+  sites (design §7).
+- **Leaf-node `chat.local.>` deny on the backup's leaf**, same as every site, so
+  local-room subjects stay site-local. Displaced clients connect intra-cluster on
+  the backup, so this does not affect their local-room delivery (design §7).
+- **Per-`siteID` namespacing** of the backup's Mongo/Cassandra (the exact scheme —
+  DB-per-site vs prefixed collections/keyspaces — is decided in SP1a/SP1b).
+
+---
+
+## 4. Streams & retention  **[GATED:SP1]**
+
+- **Restore-log `MaxAge`.** The backup's canonical stream is the durable restore
+  log for failback. Size its `MaxAge` **≥ the maximum tolerated outage**
+  (days/weeks — it is 1× per message, cheap). Do **not** rely on the 72h
+  Cassandra read window for restore; a longer outage would age its earliest
+  messages out (design §6.5).
+- **DR feed streams** (`DR_MESSAGES_{siteID}`, `DR_OPLOG_{siteID}`, per SP1a/SP1b)
+  and the backup's INBOX — owned/bootstrapped per the `BOOTSTRAP_STREAMS`
+  convention; ops/IaC owns creation in production.
+- **Bucket-window parity.** The backup and every origin site **must** share
+  `MESSAGE_BUCKET_HOURS` (default 72). A mismatch silently mis-partitions writes
+  and reads (CLAUDE.md §Cassandra; design §6.4). Enforce this in the backup's
+  deploy config.
+
+---
+
+## 5. Monitoring & alerting  **[GATED:SP1]**
+
+- **Per-site replication lag — the RPO-decay signal (highest-value alert).** If
+  the backup cannot keep up with the N-site aggregate ingest, its lag grows and
+  the DR guarantee *quietly* weakens — **the lag is the live RPO** (design §8).
+  Alert per origin site. NOTE: there is **no existing lag metric to reuse today**
+  (the design's "reuse the membership-federation lag signal" is aspirational —
+  verified: no such metric in the repo). This must be **built as part of SP1**
+  (emit a per-site replication-lag gauge from the backup materializers) and wired
+  to alerting here.
+- **Backup capacity — two separate numbers.** Size/alert the **ingest** tier for
+  the N-site aggregate (cheap 1× plane) and the **serving** tier for one largest
+  site's peak with ×F fan-out (design §8). They are different capacity budgets.
+- **Multi-site-outage ceiling.** The backup is sized for **one site down at a
+  time**; alert on concurrent multi-site failure as a documented degradation
+  ceiling (design §9), not a silent failure.
+
+---
+
+## 6. Failback operational must-dos  **[GATED:SP1+SP2, wired by SP5]**
+
+When SP5 replays the outage log home, the platform config must ensure:
+
+- **Suppress push notifications** for replayed messages — they are stale
+  (`notification-worker` skips events flagged as replay; design §6.6).
+- **Suppress / client-dedup re-broadcast** — restore is about durability in the
+  home site, not re-delivering to users who have moved on (design §6.6).
+
+These are behaviors SP5 implements; listed here so the ops handoff is complete.
+
+---
+
+## 7. Coordination checklist (platform/NATS team)
+
+Ordered by when each unblocks:
+
+1. **Now [READY]:** provision `FAILOVER_OPS_TOKEN`; restrict `FAILOVER_INTERNAL_ADDR`
+   to the ops network; confirm portal's public surface is unchanged.
+2. **Now [READY]:** confirm the World-1 shared-account model and that the backup
+   `auth-service` can deploy with the shared creds (no per-site keys).
+3. **With backup stand-up [INFRA]:** HA/multi-AZ deploy; gateway peering; leaf
+   deny; add the backup entry to `PORTAL_SITE_URLS` + set `PORTAL_BACKUP_SITE_ID`.
+4. **With SP1 [GATED]:** DR-feed stream creation; restore-log `MaxAge`; bucket-window
+   parity; **build + wire the per-site replication-lag alert.**
+5. **With SP5 [GATED]:** gate the `complete` transition on the lag≈0 signal;
+   confirm replay push/broadcast suppression.
+
+---
+
+## 8. Status snapshot
+
+| SP6 area | Readiness |
+|---|---|
+| Failover control surface ops (§1) | ✅ READY (shipped in SP4) |
+| Backup identity config (§2) | ✅ READY (World 1; grant on `main`) |
+| Backup serving handlers | ⛔ GATED on SP1+SP2 |
+| Platform footprint (§3) | 📋 INFRA (platform team) |
+| Streams/retention (§4), monitoring (§5) | ⛔ GATED on SP1 |
+| Failback must-dos (§6) | ⛔ GATED on SP1+SP2, wired by SP5 |

--- a/docs/superpowers/specs/2026-08-11-sp2-backup-identity-jwt-minting.md
+++ b/docs/superpowers/specs/2026-08-11-sp2-backup-identity-jwt-minting.md
@@ -62,22 +62,24 @@ time — so the mint path needs nothing from SP1.
 
 Neither is new minting logic; both are config/ops.
 
-### 4.1 The `chat.local.room.>` grant (shared template, SP0-coupled)
+### 4.1 The `chat.local.room.>` grant (shared template — ALREADY LANDED on `main`)
+> **Status update (2026-08-12): this deliverable is DONE on `main`.** SP0 has
+> merged to `main`, and the `chat.local.room.>` subscribe grant is already
+> present in the shared scoped-signing template (`docker-local/setup.sh:58`,
+> `--allow-sub "chat.local.room.>"`) and in the `signNATSJWT` "effective grants"
+> docstring (`auth-service/handler.go`, "Sub allow: … chat.room.>,
+> chat.local.room.> …"). Under the shared org account this was always **one edit
+> to one shared template**, and it has been made. **SP2 has no grant work left.**
+> (The failover branch family predates this on an older base — merge-base
+> `fc828a6`, ~67 commits behind `main` — which is why earlier revisions of this
+> spec framed the grant as forward-looking.)
+
 Post-SP0, same-site rooms move to `chat.local.room.{id}.>`. A user's JWT must then
 **subscribe `chat.local.room.>`** or they lose the majority of their rooms
-(design §7, req #1). Under the shared account this is **one edit to the shared
-scoped-signing template** (`docker-local/setup.sh` and its prod equivalent): add
-`--allow-sub "chat.local.room.>"` next to the existing `chat.room.>`. Because the
-template is shared, *every* user — home and displaced — gets it identically,
-which **eliminates** the design's "backup silently missing the grant" failure mode
-rather than mitigating it (there is no separate backup template to drift).
-
-Coupled to SP0 landing (the prefix must exist first). Granting a subscribe on a
-prefix nobody publishes to yet is a harmless no-op, so it *may* ship early, but
-there is nothing to exercise until SP0 is live. Ship it **with or immediately
-after SP0**, and in the same change update the `signNATSJWT` "effective grants"
-docstring and `docs/client-api.md §2.1` (both must stay in sync with the
-template).
+(design §7, req #1). Because the template is shared, *every* user — home and
+displaced — gets the grant identically, which **eliminates** the design's "backup
+silently missing the grant" failure mode rather than mitigating it (there is no
+separate backup template to drift). This is exactly what `main` already ships.
 
 ### 4.2 Backup `auth-service` deployment (ops / SP6 handoff)
 Deploy `auth-service` at the backup with the **shared** `AUTH_SCOPED_SIGNING_KEY`
@@ -162,9 +164,11 @@ assurance is config-level:
 
 ## 12. Open sub-decisions (call out in the plan)
 
-1. **Grant timing** — ship `chat.local.room.>` on the shared template *now* (a
-   harmless no-op until SP0) vs. bundled into the SP0 PR. *Leaning: with SP0*, so
-   it is exercised the moment the prefix exists.
+1. ~~**Grant timing** — ship `chat.local.room.>` on the shared template now vs.
+   with the SP0 PR.~~ **RESOLVED — already landed on `main`** (§4.1): SP0 shipped
+   the grant in the shared template and the `signNATSJWT` docstring. No SP2 grant
+   work remains; this only needs picking up when the failover branch rebases onto
+   current `main`.
 2. **Eligibility gate** — leave `auth-service` OIDC-only (status quo, this spec's
    choice) vs. introduce a system-wide mint-time gate later. Not a failover
    decision; noted only so the option is on record.

--- a/docs/superpowers/specs/2026-08-11-sp3-portal-routing-override.md
+++ b/docs/superpowers/specs/2026-08-11-sp3-portal-routing-override.md
@@ -1,40 +1,46 @@
 # SP3 (core) — Routing brain: portal-service health-aware override
 
 > **Scope discipline.** This slice makes `portal-service` return the **backup
-> site's** connection coordinates for a down site's accounts, keyed entirely on
+> site's** connection coordinates for a down site's SSO users, keyed entirely on
 > SP4's `servingTarget` signal. It is **codebase-local** — a thin override at
 > portal's existing resolve seam — and deliberately owns *only* the routing
 > decision. Detection/state (SP4), JWT minting (SP2), and failback replay (SP5)
 > are out of scope.
 >
+> **Revised 2026-08-12 after a collaborative brainstorm.** Decisions locked:
+> backup coordinates as a reserved entry in `PORTAL_SITE_URLS` (§4); the override
+> is scoped to the **SSO `/api/userInfo` path only** — the bot/admin
+> `/api/v1/login` path is left unchanged (§2.2); failback reconnect is drain-only,
+> **no SP3 code** (§5); the TTL-cached reader is built here (§6).
+>
 > - **Governing design:** `docs/superpowers/specs/2026-07-28-cross-site-failover-design.md` (§4.2, §6.3, §7)
 > - **Roadmap:** `docs/superpowers/plans/2026-07-28-cross-site-failover-roadmap.md` (SP3)
-> - **Consumes:** SP4's `FailoverState.servingTarget` (home | backup). **Blocked on** SP4's signal shape (now decided).
+> - **Consumes:** SP4's `FailoverState.ServingTarget()` (home | backup), already built in `portal-service`.
 
 ## 1. Goal
 
-When SP4 marks a site `failed_over`/`failing_back`, every login/discovery answer
-portal gives for that site's accounts must point at the **backup** — so displaced
-clients connect to the backup's NATS and mint from the backup's `auth-service`
+When SP4 marks a site `failed_over`/`failing_back`, `GET /api/userInfo` for that
+site's accounts must return the **backup's** `baseUrl`/`natsUrl` — so displaced
+SSO clients connect to the backup's NATS and mint from the backup's `auth-service`
 (SP2) — while a healthy site's accounts route home, unchanged. Portal is the
 design's **single routing authority and split-brain fence** (§4.2); this slice is
 where that authority becomes an actual reroute.
 
 The only observable outcome: for an account whose home site has
-`servingTarget=backup`, `GET /api/userInfo` (and `POST /api/v1/login`) return the
-backup's `baseUrl`/`natsUrl`; when the site is healthy, they return the home
+`servingTarget=backup`, `GET /api/userInfo` returns the backup's coordinates with
+`siteId` **still the home site**; when the site is healthy, it returns the home
 site's, exactly as today.
 
 ## 2. Decision — a thin override at the resolve seam, keyed on `servingTarget`
 
 Portal already resolves coordinates in one place: `handler.go:resolve()` looks up
 the account's home `siteID`, then returns `sites[siteID]`'s `BaseURL`/`NATSURL`
-(`PORTAL_SITE_URLS` registry). `HandleLogin` does the same for bot/admin logins.
-The override is a **single interception at that lookup**:
+(`PORTAL_SITE_URLS` registry). The override is a **single interception at that
+lookup**:
 
-> resolve the account's home `siteID` → read SP4's `FailoverState[siteID]` →
-> if `servingTarget == backup`, substitute the **backup** registry entry's URLs;
-> else use the home entry. Everything else about the response is unchanged.
+> resolve the account's home `siteID` → read SP4's `ServingTarget(siteID)` →
+> if `backup`, substitute the **backup** registry entry's URLs; else use the home
+> entry. Everything else about the response is unchanged.
 
 - **Reject — a separate "failover router" service or a new client protocol.** The
   frontend already re-queries portal on connection failure and connects to
@@ -46,34 +52,57 @@ The override is a **single interception at that lookup**:
   `{siteID}` (`chat.user.{account}.room.{roomID}.{siteID}.msg.send`; streams
   `MESSAGES_{siteID}`). The client must keep reporting its **home** `siteID` so
   its subjects land in the backup's copy *of that site*. Only the transport URLs
-  move; `siteID` does not (see §3).
+  move; `siteID` does not (§3).
 
-### 2.1 Centralize the override so both entry points honor it
+### 2.1 Centralize the override in one helper
 
-`resolve()` and `HandleLogin` both hand out site URLs, so the override lives in
-**one helper** both call — else a bot/admin of a down site would password-login
-straight to a dead site. Sketch:
+The lookup moves into a single helper so the swap logic lives in one place and is
+unit-testable in isolation:
 
 ```go
 // servingURLs returns the coordinates to hand the client for an account homed
 // on siteID, applying SP4's failover override. siteID (the home site) is
 // returned unchanged for data scoping; only the transport URLs may swap.
 func (h *PortalHandler) servingURLs(ctx context.Context, siteID string) (siteURL, error) {
-    target := h.failover.ServingTarget(ctx, siteID) // SP4 read, TTL-cached; home on miss/error
-    if target == servingBackup {
+    if h.failover.ServingTarget(ctx, siteID) == ServingBackup {
         b, ok := h.sites[h.backupSiteID]
-        if !ok { return siteURL{}, fmt.Errorf("backup site %q missing from registry", h.backupSiteID) }
+        if !ok {
+            // A failover with no configured backup is a real misconfig — surface
+            // it loudly rather than silently routing to the down home site.
+            return siteURL{}, fmt.Errorf("serving target is backup but backup site %q missing from registry", h.backupSiteID)
+        }
         return b, nil
     }
     home, ok := h.sites[siteID]
-    if !ok { return siteURL{}, fmt.Errorf("no URLs configured for siteId %q", siteID) }
+    if !ok {
+        return siteURL{}, fmt.Errorf("no URLs configured for siteId %q", siteID)
+    }
     return home, nil
 }
 ```
 
-Both handlers call `servingURLs(ctx, e.SiteID)` and keep returning `SiteID:
-e.SiteID` (home) in the body. Dev-mode fallback and the "site missing from
-registry" internal-error path are preserved.
+`resolve()` calls `servingURLs(ctx, e.SiteID)` and keeps returning `SiteID:
+e.SiteID` (home) in the body. Dev-mode fallback is preserved (the dev-fallback
+site resolves before the failover check and is never failed over).
+
+### 2.2 Scope — the SSO `/api/userInfo` path only; bots deferred
+
+The override applies to `/api/userInfo` (the SSO discovery path — the lifeboat
+population). `POST /api/v1/login` (bot/admin password login) is **left
+unchanged**, because:
+
+- Bot/admin functionality is **out of lifeboat scope** (design §2, §10).
+- That path *forwards the login to botplatform* at the home site, which is **down**
+  during the outage — so the login fails at the forward step regardless of which
+  URLs portal would return. Overriding its response URLs is moot until a backup
+  botplatform exists.
+
+**Bots are business-critical, and this is a deliberate deferral, not a drop.**
+Supporting bot failover is a follow-up whose weight lives in SP1 (materialize
+bot/botplatform state) and SP2 (run a botplatform + wire the backup
+`auth-service` session branch) — **not** here. When that lands, the SP3 side is a
+single `servingURLs(...)` call added to `HandleLogin`. Recorded so the priority
+is not lost.
 
 ## 3. What swaps, and what must not
 
@@ -91,13 +120,15 @@ against the backup copy.
 
 ## 4. Backup coordinates in the registry
 
-The backup is **one more entry** in `PORTAL_SITE_URLS`, under a reserved id
-(`PORTAL_BACKUP_SITE_ID`, e.g. `_backup`). No schema change — the existing
+The backup is **one more entry** in `PORTAL_SITE_URLS`, under a reserved id from
+`PORTAL_BACKUP_SITE_ID` (e.g. `_backup`). No schema change — the existing
 `siteURL{baseUrl,natsUrl}` shape already carries what the client needs, and
 startup validation (`parseSiteURLs`) already requires both URLs, so a
-misconfigured backup fails at boot, not at a user's failover. A single backup id
-suffices for the design's N→1 topology (§3); a multi-backup future is a registry
-extension, not a redesign.
+misconfigured backup fails at boot. A single backup id suffices for the design's
+N→1 topology; a multi-backup future is a registry extension, not a redesign.
+`PORTAL_BACKUP_SITE_ID` may be empty in single-site/dev deployments where no
+failover occurs (`servingTarget` is always `home`, so the backup lookup is never
+reached).
 
 ## 5. Client reconnect — reuse the existing self-heal, both directions
 
@@ -107,83 +138,83 @@ No new client protocol; the reroute rides the path the frontend already has
 - **Failover (home→backup):** the home site is down, so the displaced client's
   NATS connection has **already dropped**. Its existing reconnect logic re-queries
   portal, now gets the backup's URLs, mints via the backup's `auth-service` (SP2),
-  connects, and re-reads `subscription.list` (materialized by SP1) on the correct
-  prefixes. Automatic.
-- **Failback (backup→home):** after SP4 flips `failing_back → healthy` on SP5's
-  lag≈0 report, the backup **tears down its impersonation** and drains those
-  connections (design §6.3 step 6, §6.6). The drop is itself the nudge: the client
-  reconnects, re-queries portal, now gets home's URLs, and resumes on the home
-  site — the same self-heal, in reverse. SP3 does not invent a separate
-  "reconnect now" push; the drain-driven reconnect is sufficient and reuses tested
-  behavior.
+  connects, and re-reads `subscription.list` (materialized by SP1). Automatic.
+- **Failback (backup→home):** after SP4 flips `failing_back → healthy`, the backup
+  **tears down its impersonation** and drains those connections (design §6.3 step
+  6). The drop is itself the nudge: the client reconnects, re-queries portal, now
+  gets home's URLs, and resumes on the home site. **SP3 has no code here** — it
+  just answers home once the flip has happened; the drain is owned by SP2/SP5.
 
-SP3's responsibility ends at *handing out the right URL when asked*. The drain
-that forces the failback reconnect is the backup serving stack's (SP2/SP5); SP3
-just answers home once the flip has happened.
+## 6. The failover reader (built here)
 
-## 6. Split-brain fence — trust SP4's one record, never second-guess
+`failoverReader` wraps SP4's `FailoverStore` (same `package main`) behind a short
+TTL cache and exposes `ServingTarget(ctx, siteID) ServingTarget`:
 
-Portal is the fence because the serving target comes from **one** authoritative
-`FailoverState` document (SP4, §6 there), and SP3 is a pure reader of it:
+- On a cache hit within the TTL, return the cached target. On miss/expiry, call
+  `store.Get`, derive `state.ServingTarget()`, cache it with expiry `now + TTL`.
+- **Fail-safe = `home`.** A store error returns `ServingHome` and is **not**
+  cached (so a transient blip doesn't pin a stale answer) — an unreachable
+  failover store must never strand a healthy site's users on the backup.
+- TTL is `FAILOVER_STATE_TTL` (default `5s`): long enough to shield Mongo from
+  per-login reads, short enough that a flip reaches routing within seconds. It is
+  **separate** from portal's 24h directory cache and must not be merged into it.
+- The clock is injectable for deterministic TTL tests.
 
-- SP3 **never** derives failover from its own probing or from a login failure — it
-  reads `servingTarget` and nothing else. A site is `home` xor `backup` because
-  the field is single-valued; SP3 cannot manufacture a third answer.
-- **Fail-safe = home.** If the failover read misses or errors, `ServingTarget`
-  returns `home` (SP4 §6) — normal routing. An unreachable failover store must
-  never strand a healthy site's users on the backup.
-- **No caching of the decision past its TTL.** SP3 reads through SP4's short
-  `FAILOVER_STATE_TTL` cache (seconds), so a flip in either direction reaches new
-  logins within seconds without a per-login Mongo hit. This is separate from the
-  24h directory cache and must not be merged into it.
+### 6.1 main.go wiring refactor
 
-## 7. Testing (TDD, per CLAUDE.md §4)
+SP4 constructs the `mongoFailoverStore` **only** inside the
+`FAILOVER_OPS_TOKEN != ""` block (for the control surface). The reader needs the
+store **unconditionally** — routing must consult failover state even where the
+control surface is disabled. So the store construction moves out of that block:
+build `mongoFailoverStore` once, hand it to the always-on `failoverReader`, and
+let the optional control server reuse the same instance. `PortalHandler` gains a
+`failover *failoverReader` and a `backupSiteID string`.
 
-- **Unit (`handler_test.go`)** — table-driven over `servingURLs` + both handlers
-  with a mock failover reader: healthy → home URLs; `failed_over` → backup URLs
-  with `siteId` **still home**; `failing_back` → backup URLs; failover read
-  error/miss → home (fail-safe); backup id missing from registry → internal;
-  bot/admin login path honors the override identically; dev fallback unchanged.
-- **Unit** — assert the response body's `siteId` is the home site in every
-  failed-over case (the "must not swap `siteId`" invariant, locked by a test).
-- **Integration** (`//go:build integration`, `testutil.MongoDB`) — seed a
-  `FailoverState` of `failed_over` for a site, hit `/api/userInfo`, assert backup
-  coordinates + home `siteId`; flip to `healthy`, assert home coordinates after
-  the TTL; concurrent healthy/failed accounts resolve independently.
-- **Coverage** — ≥80% floor; ≥90% on `servingURLs` + the two handlers' override
-  branches.
+## 7. Split-brain fence — trust SP4's one record, never second-guess
 
-## 8. Documentation
+- SP3 **never** derives failover from its own probing or a login failure — it
+  reads `ServingTarget` and nothing else. A site is `home` xor `backup` because
+  the value is single-valued; SP3 cannot manufacture a third answer.
+- **Fail-safe = home** on any read miss/error (§6).
+- Reads go through the short TTL cache, never the 24h directory cache.
+
+## 8. Testing (TDD, per CLAUDE.md §4)
+
+- **Unit — `servingURLs`** (mock reader): healthy → home URLs; `backup` → backup
+  URLs; `servingTarget=backup` but backup id missing from registry → internal
+  error; home site missing from registry → internal error.
+- **Unit — `/api/userInfo`** (via `HandleUserInfo` with a mock reader): healthy →
+  home coords; `failed_over` → backup coords with **`siteId` still home** (the
+  "must not swap `siteId`" invariant, locked by a test); reader returns home on
+  error → home coords (fail-safe); dev fallback unchanged.
+- **Unit — `failoverReader`** (injected clock + mock store): cache hit within TTL
+  returns cached value without a second store call; refresh after expiry; store
+  error → `home` and not cached.
+- **Integration** (`//go:build integration`, `testutil.MongoDB`): seed a
+  `FailoverState` of `failed_over` via the store, hit `/api/userInfo`, assert
+  backup coords + home `siteId`; flip to `healthy`, assert home coords after the
+  TTL; a healthy account and a failed-over account resolve independently.
+- **Coverage** — ≥80% floor; ≥90% on `servingURLs` + the reader.
+
+## 9. Documentation
 
 `docs/client-api.md` §2 (site discovery): note that `baseUrl`/`natsUrl` may point
 at the backup during a home-site outage while `siteId` remains the home site, and
 that the client's existing reconnect-on-failure path is the failover/failback
-trigger. Field tables gain no new fields (the shapes are unchanged); only the
-narrative and the reason/behavior notes are added, per the doc's current style.
+trigger. Field tables gain no new fields; only the narrative note is added, per
+the doc's current style. (`/api/userInfo` is a discovery endpoint, not a
+`chat.user.*` RPC, so this is a courtesy note, not a required client-API RPC
+change.)
 
-## 9. Open sub-decisions (call out in the plan)
-
-1. **Backup id convention** — reserved entry in `PORTAL_SITE_URLS`
-   (`PORTAL_BACKUP_SITE_ID`) vs. a dedicated `PORTAL_BACKUP_SITE_URLS`. *Leaning:
-   reserved entry* (no new config surface, reuses `parseSiteURLs` validation).
-2. **Failover reader placement** — a `FailoverReader` interface defined in
-   portal (the consumer, per CLAUDE.md DI) with the Mongo + TTL-cache
-   implementation, shared in shape with SP4's writer but a distinct read
-   interface. Confirm SP4 and SP3 agree on the `FailoverState` document schema
-   (§3 in SP4) as the contract between them.
-3. **Proactive failback nudge** — rely solely on the backup drain (§5) vs. also
-   publishing a reconnect hint on the global `chat.user.{account}.>` tree (§7 of
-   the design says the per-user tree stays global, so a nudge is possible).
-   *Leaning: drain-only* for this core; add a nudge only if failback reconnect
-   latency proves too slow in practice.
-
-## 10. Out of scope (explicit — each its own slice)
+## 10. Out of scope (each its own slice)
 
 - **SP4** — producing/owning `FailoverState`; the detector and control surface.
-  SP3 only reads `servingTarget`.
+  SP3 only reads `ServingTarget`.
 - **SP2** — the backup's JWT minting and serving handlers the rerouted client
   then talks to.
 - **SP5** — failback replay/convergence and the backup-impersonation drain that
   triggers the failback reconnect.
+- **Bot failover** — the `/api/v1/login` override + botplatform-DR (§2.2). Critical,
+  deferred; the SP3 hook is one line once SP1/SP2 support it.
 - **SP6 — ops/IaC:** the backup deployment behind the registry URLs, and the
   backup as a supercluster gateway peer.

--- a/portal-service/deploy/docker-compose.yml
+++ b/portal-service/deploy/docker-compose.yml
@@ -28,7 +28,10 @@ services:
       # in handler.go — both required, nothing else read). baseUrl is the unified
       # backend origin (`{baseUrl}/api/v1/...` via the Traefik gateway on :7777);
       # natsUrl is the site's NATS WS URL.
-      - 'PORTAL_SITE_URLS={"site-local":{"baseUrl":"http://localhost:7777","natsUrl":"ws://localhost:9222"}}'
+      - 'PORTAL_SITE_URLS={"site-local":{"baseUrl":"http://localhost:7777","natsUrl":"ws://localhost:9222"},"_backup":{"baseUrl":"http://localhost:7777","natsUrl":"ws://localhost:9222"}}'
+      # Reserved backup entry served for a failed-over site (SP3). Points at the
+      # same local stack in dev — there is no separate backup site locally.
+      - PORTAL_BACKUP_SITE_ID=_backup
       # Single cluster-internal botplatform endpoint /api/v1/login forwards to.
       - BOTPLATFORM_URL=http://botplatform-service:8080
       # Served to the frontend via GET /api/settings. Both required (notEmpty) —

--- a/portal-service/failover_reader.go
+++ b/portal-service/failover_reader.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// failoverReader answers "where is this site served from right now?" from SP4's
+// FailoverStore, behind a short TTL cache so routing does not hit Mongo on every
+// login. Fail-safe: a store error resolves to home and is not cached.
+type failoverReader struct {
+	store FailoverStore
+	ttl   time.Duration
+	now   func() time.Time
+
+	mu    sync.Mutex
+	cache map[string]cachedTarget
+}
+
+type cachedTarget struct {
+	target  ServingTarget
+	expires time.Time
+}
+
+func newFailoverReader(store FailoverStore, ttl time.Duration) *failoverReader {
+	return &failoverReader{
+		store: store,
+		ttl:   ttl,
+		now:   time.Now,
+		cache: make(map[string]cachedTarget),
+	}
+}
+
+// ServingTarget returns home or backup for siteID. On a cache hit within the TTL
+// it returns the cached value; otherwise it reads the store, derives the target,
+// and caches it. A store error resolves to home (fail-safe) and is not cached.
+func (r *failoverReader) ServingTarget(ctx context.Context, siteID string) ServingTarget {
+	r.mu.Lock()
+	if c, ok := r.cache[siteID]; ok && r.now().Before(c.expires) {
+		r.mu.Unlock()
+		return c.target
+	}
+	r.mu.Unlock()
+
+	// Read outside the lock so a slow Mongo call does not serialize all readers.
+	st, err := r.store.Get(ctx, siteID)
+	if err != nil {
+		slog.WarnContext(ctx, "failover reader: store read failed, defaulting to home",
+			"siteId", siteID, "error", err)
+		return ServingHome
+	}
+	target := st.ServingTarget()
+
+	r.mu.Lock()
+	r.cache[siteID] = cachedTarget{target: target, expires: r.now().Add(r.ttl)}
+	r.mu.Unlock()
+	return target
+}

--- a/portal-service/failover_reader_integration_test.go
+++ b/portal-service/failover_reader_integration_test.go
@@ -1,0 +1,30 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/testutil"
+)
+
+func TestFailoverReader_OverMongo(t *testing.T) {
+	db := testutil.MongoDB(t, "portal")
+	store := newMongoFailoverStore(db)
+	ctx := context.Background()
+
+	r := newFailoverReader(store, time.Minute)
+
+	// No document yet => healthy => home.
+	assert.Equal(t, ServingHome, r.ServingTarget(ctx, "site-a"))
+
+	// Fail the site over; a fresh reader (empty cache) sees backup.
+	require.NoError(t, store.Transition(ctx, &FailoverState{SiteID: "site-a", Status: StatusFailedOver, Version: 1, Since: 1, Timestamp: 1}))
+	r2 := newFailoverReader(store, time.Minute)
+	assert.Equal(t, ServingBackup, r2.ServingTarget(ctx, "site-a"))
+}

--- a/portal-service/failover_reader_test.go
+++ b/portal-service/failover_reader_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	gomock "go.uber.org/mock/gomock"
+)
+
+func TestFailoverReader_MissThenCacheHit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockFailoverStore(ctrl)
+	// Store is consulted exactly once; the second call is served from cache.
+	store.EXPECT().Get(gomock.Any(), "site-a").
+		Return(FailoverState{SiteID: "site-a", Status: StatusFailedOver, Version: 1}, nil).
+		Times(1)
+
+	r := newFailoverReader(store, time.Minute)
+	now := time.UnixMilli(1000)
+	r.now = func() time.Time { return now }
+
+	assert.Equal(t, ServingBackup, r.ServingTarget(context.Background(), "site-a"))
+	assert.Equal(t, ServingBackup, r.ServingTarget(context.Background(), "site-a"))
+}
+
+func TestFailoverReader_RefreshesAfterTTL(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockFailoverStore(ctrl)
+	gomock.InOrder(
+		store.EXPECT().Get(gomock.Any(), "site-a").
+			Return(FailoverState{SiteID: "site-a", Status: StatusFailedOver, Version: 1}, nil),
+		store.EXPECT().Get(gomock.Any(), "site-a").
+			Return(FailoverState{SiteID: "site-a", Status: StatusHealthy, Version: 2}, nil),
+	)
+
+	r := newFailoverReader(store, 5*time.Second)
+	now := time.UnixMilli(1000)
+	r.now = func() time.Time { return now }
+
+	assert.Equal(t, ServingBackup, r.ServingTarget(context.Background(), "site-a"))
+	now = now.Add(6 * time.Second) // past TTL
+	assert.Equal(t, ServingHome, r.ServingTarget(context.Background(), "site-a"))
+}
+
+func TestFailoverReader_StoreErrorFailsSafeHomeUncached(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockFailoverStore(ctrl)
+	// Error path is not cached: both calls hit the store.
+	store.EXPECT().Get(gomock.Any(), "site-a").Return(FailoverState{}, errors.New("mongo down")).Times(2)
+
+	r := newFailoverReader(store, time.Minute)
+	r.now = func() time.Time { return time.UnixMilli(1000) }
+
+	assert.Equal(t, ServingHome, r.ServingTarget(context.Background(), "site-a"))
+	assert.Equal(t, ServingHome, r.ServingTarget(context.Background(), "site-a"))
+}

--- a/portal-service/failover_userinfo_integration_test.go
+++ b/portal-service/failover_userinfo_integration_test.go
@@ -1,0 +1,39 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/testutil"
+)
+
+func TestUserInfo_FailoverOverMongo(t *testing.T) {
+	db := testutil.MongoDB(t, "portal")
+	store := newMongoFailoverStore(db)
+	ctx := context.Background()
+
+	// Short TTL so a later flip-back would be observable within the test.
+	reader := newFailoverReader(store, 20*time.Millisecond)
+	h := NewPortalHandler(cacheWith(alice), false, "site-local", "ws://localhost:9222",
+		testSitesWithBackup, testSettings,
+		WithFailoverReader(reader), WithBackupSiteID("_backup"))
+	r := setupRouter(t, h)
+
+	// Fail site-a over -> userInfo returns backup coords, home siteId.
+	require.NoError(t, store.Transition(ctx, &FailoverState{SiteID: "site-a", Status: StatusFailedOver, Version: 1, Since: 1, Timestamp: 1}))
+
+	w := getUserInfo(t, r, "alice")
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp userInfoResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "https://backup.example.com", resp.BaseURL)
+	assert.Equal(t, "site-a", resp.SiteID)
+}

--- a/portal-service/handler.go
+++ b/portal-service/handler.go
@@ -115,6 +115,17 @@ type PortalHandler struct {
 	// store is the optional live directory lookup used as the /api/v1/login
 	// role-gate fallback on a cache miss; nil-safe (miss stays a miss).
 	store DirectoryStore
+
+	// failover resolves per-site failover routing (SP4). nil => always home.
+	failover failoverTargeter
+	// backupSiteID is the reserved PORTAL_SITE_URLS entry served during failover.
+	backupSiteID string
+}
+
+// failoverTargeter reads SP4's per-site serving target. *failoverReader
+// implements it; defined here (the consumer) so tests can inject a fake.
+type failoverTargeter interface {
+	ServingTarget(ctx context.Context, siteID string) ServingTarget
 }
 
 // PortalHandlerOption configures optional PortalHandler dependencies.
@@ -130,6 +141,38 @@ func WithRestyClient(c *resty.Client) PortalHandlerOption {
 // can log in immediately.
 func WithDirectoryStore(s DirectoryStore) PortalHandlerOption {
 	return func(h *PortalHandler) { h.store = s }
+}
+
+// WithFailoverReader injects the SP4 failover target reader that drives the
+// health-aware routing override. Without it, routing is always home.
+func WithFailoverReader(f failoverTargeter) PortalHandlerOption {
+	return func(h *PortalHandler) { h.failover = f }
+}
+
+// WithBackupSiteID sets the reserved PORTAL_SITE_URLS id served for a
+// failed-over site (PORTAL_BACKUP_SITE_ID).
+func WithBackupSiteID(id string) PortalHandlerOption {
+	return func(h *PortalHandler) { h.backupSiteID = id }
+}
+
+// servingURLs returns the coordinates to hand a client for an account homed on
+// siteID, applying SP4's failover override. siteID (the home site) is never
+// changed by this — only which registry entry's URLs are returned. A configured
+// backup that is missing from the registry is a loud internal error rather than
+// a silent mis-route to the down home site.
+func (h *PortalHandler) servingURLs(ctx context.Context, siteID string) (siteURL, error) {
+	if h.failover != nil && h.failover.ServingTarget(ctx, siteID) == ServingBackup {
+		b, ok := h.sites[h.backupSiteID]
+		if !ok {
+			return siteURL{}, fmt.Errorf("serving target is backup but backup site %q missing from registry", h.backupSiteID)
+		}
+		return b, nil
+	}
+	home, ok := h.sites[siteID]
+	if !ok {
+		return siteURL{}, fmt.Errorf("no URLs configured for siteId %q", siteID)
+	}
+	return home, nil
 }
 
 // NewPortalHandler creates a PortalHandler. devMode synthesizes a dev-site
@@ -186,25 +229,34 @@ func (h *PortalHandler) resolve(ctx context.Context, c *gin.Context, account str
 		devFallback = true
 	}
 
-	site, siteOK := h.sites[e.SiteID]
-	if !siteOK && !devFallback {
-		// A directory entry homed on a site missing from the registry is an ops
-		// misconfiguration, not a client error — surface it as internal.
-		errhttp.Write(ctx, c, fmt.Errorf("no URLs configured for siteId %q", e.SiteID))
-		return
-	}
-	natsURL := site.NATSURL
-	if !siteOK {
-		// The dev-fallback site itself isn't in the registry — fall back to
-		// the legacy PORTAL_DEV_FALLBACK_NATS_URL so local logins keep working.
-		natsURL = h.devFallbackNatsURL
+	var baseURL, natsURL string
+	if devFallback {
+		// Dev-fallback site never fails over; keep the legacy URL handling.
+		site, siteOK := h.sites[e.SiteID]
+		baseURL, natsURL = site.BaseURL, site.NATSURL
+		if !siteOK {
+			// The dev-fallback site itself isn't in the registry — fall back to
+			// the legacy PORTAL_DEV_FALLBACK_NATS_URL so local logins keep working.
+			natsURL = h.devFallbackNatsURL // baseURL stays "" as before
+		}
+	} else {
+		// Provisioned account: apply SP4's failover override. siteId stays home;
+		// only the transport URLs may swap to the backup.
+		su, err := h.servingURLs(ctx, e.SiteID)
+		if err != nil {
+			// A missing home/backup registry entry is an ops misconfiguration,
+			// not a client error — surface it as internal.
+			errhttp.Write(ctx, c, err)
+			return
+		}
+		baseURL, natsURL = su.BaseURL, su.NATSURL
 	}
 
 	// Bot/admin accounts get the minimal URL bundle; everyone else the rich employee shape.
 	if model.HasLoginRole(e.Roles) {
 		c.JSON(http.StatusOK, userInfoBotResponse{
 			Account: e.Account,
-			BaseURL: site.BaseURL,
+			BaseURL: baseURL,
 			NATSURL: natsURL,
 			SiteID:  e.SiteID,
 		})
@@ -214,7 +266,7 @@ func (h *PortalHandler) resolve(ctx context.Context, c *gin.Context, account str
 	c.JSON(http.StatusOK, userInfoResponse{
 		Account:    e.Account,
 		EmployeeID: e.EmployeeID,
-		BaseURL:    site.BaseURL,
+		BaseURL:    baseURL,
 		NATSURL:    natsURL,
 		SiteID:     e.SiteID,
 	})

--- a/portal-service/handler_test.go
+++ b/portal-service/handler_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -714,4 +715,67 @@ func TestParseSiteURLs(t *testing.T) {
 			assert.Error(t, err)
 		})
 	}
+}
+
+// ----- SP3 failover routing override --------------------------------------
+
+// fakeTargeter is a failoverTargeter stub returning a fixed target.
+type fakeTargeter struct{ target ServingTarget }
+
+func (f fakeTargeter) ServingTarget(_ context.Context, _ string) ServingTarget { return f.target }
+
+// testSitesWithBackup extends testSites with a reserved backup entry.
+var testSitesWithBackup = map[string]siteURL{
+	"site-a":     {BaseURL: "https://site-a.example.com", NATSURL: "wss://nats-3.site-a.example.com"},
+	"site-b":     {BaseURL: "https://site-b.example.com", NATSURL: "wss://nats.site-b.example.com"},
+	"site-local": {BaseURL: "http://localhost:3000", NATSURL: "ws://localhost:9222"},
+	"_backup":    {BaseURL: "https://backup.example.com", NATSURL: "wss://nats.backup.example.com"},
+}
+
+func newFailoverHandler(cache *directoryCache, target ServingTarget) *PortalHandler {
+	return NewPortalHandler(cache, false, "site-local", "ws://localhost:9222", testSitesWithBackup, testSettings,
+		WithFailoverReader(fakeTargeter{target: target}), WithBackupSiteID("_backup"))
+}
+
+func TestHandleUserInfo_FailoverRoutesToBackup(t *testing.T) {
+	h := newFailoverHandler(cacheWith(alice), ServingBackup)
+	w := getUserInfo(t, setupRouter(t, h), "alice")
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp userInfoResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "https://backup.example.com", resp.BaseURL, "baseUrl swaps to backup")
+	assert.Equal(t, "wss://nats.backup.example.com", resp.NATSURL, "natsUrl swaps to backup")
+	assert.Equal(t, "site-a", resp.SiteID, "siteId MUST stay the home site")
+	assert.Equal(t, "E001", resp.EmployeeID, "identity fields unchanged")
+}
+
+func TestHandleUserInfo_HealthyRoutesHome(t *testing.T) {
+	h := newFailoverHandler(cacheWith(alice), ServingHome)
+	w := getUserInfo(t, setupRouter(t, h), "alice")
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp userInfoResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "https://site-a.example.com", resp.BaseURL)
+	assert.Equal(t, "site-a", resp.SiteID)
+}
+
+func TestHandleUserInfo_BackupMissingFromRegistryIsInternal(t *testing.T) {
+	// servingTarget=backup but no backup entry configured => loud 500.
+	h := NewPortalHandler(cacheWith(alice), false, "site-local", "ws://localhost:9222", testSites, testSettings,
+		WithFailoverReader(fakeTargeter{target: ServingBackup}), WithBackupSiteID("_backup"))
+	w := getUserInfo(t, setupRouter(t, h), "alice")
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestHandleUserInfo_NoFailoverConfiguredRoutesHome(t *testing.T) {
+	// newTestHandler sets no failover reader; the override must no-op to home.
+	h := newTestHandler(cacheWith(alice), false)
+	w := getUserInfo(t, setupRouter(t, h), "alice")
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp userInfoResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "https://site-a.example.com", resp.BaseURL)
+	assert.Equal(t, "site-a", resp.SiteID)
 }

--- a/portal-service/main.go
+++ b/portal-service/main.go
@@ -65,6 +65,12 @@ type config struct {
 	// FailoverInternalAddr is the listen address for the internal-only control
 	// surface — kept off the public browser-facing server.
 	FailoverInternalAddr string `env:"FAILOVER_INTERNAL_ADDR" envDefault:":8090"`
+	// FailoverStateTTL bounds how long portal caches a site's serving target
+	// before re-reading it (routing freshness vs. Mongo load).
+	FailoverStateTTL time.Duration `env:"FAILOVER_STATE_TTL" envDefault:"5s"`
+	// BackupSiteID is the reserved PORTAL_SITE_URLS id served for a failed-over
+	// site. Empty in single-site/dev deployments (no failover occurs there).
+	BackupSiteID string `env:"PORTAL_BACKUP_SITE_ID" envDefault:""`
 
 	// BotLoginEnabled gates portal's bot-role password login. Flip to false
 	// once the dedicated bot-devs client (which talks to botplatform directly)
@@ -126,10 +132,16 @@ func run() error {
 
 	slog.Info("directory config", "sites", len(sites), "refreshInterval", cfg.CacheRefreshInterval.String())
 
+	// The failover store backs both the always-on routing reader (SP3) and the
+	// optional operator control surface (SP4), so it is built unconditionally.
+	failoverStore := newMongoFailoverStore(mongoClient.Database(cfg.MongoDB))
+	failoverReader := newFailoverReader(failoverStore, cfg.FailoverStateTTL)
+
 	rc := restyutil.New(cfg.BotplatformURL, restyutil.WithTimeout(5*time.Second))
 	handler := NewPortalHandler(cache, cfg.DevMode,
 		cfg.DevFallbackSiteID, cfg.DevFallbackNatsURL, sites, settings,
-		WithRestyClient(rc), WithDirectoryStore(store))
+		WithRestyClient(rc), WithDirectoryStore(store),
+		WithFailoverReader(failoverReader), WithBackupSiteID(cfg.BackupSiteID))
 	if cfg.DevMode {
 		slog.Info("dev mode enabled — unknown accounts fall back to the dev site")
 	}
@@ -150,7 +162,6 @@ func run() error {
 	// listener so no privileged write shares the public discovery server.
 	var internalSrv *http.Server
 	if cfg.FailoverOpsToken != "" {
-		failoverStore := newMongoFailoverStore(mongoClient.Database(cfg.MongoDB))
 		failoverHandler := NewFailoverHandler(failoverStore)
 
 		ir := gin.New()


### PR DESCRIPTION
## What this is

SP3 of the cross-site failover ("lifeboat") program — the routing brain that makes SP4 *act*: when a site is failed over, `portal-service` hands its SSO users the **backup's** connection coordinates so they reconnect there.

**Stacked PR:** targets `claude/cross-site-failover-downstream` (the SP4 branch, PR #249), so this diff is only the SP3 increment. SP3 consumes the `FailoverStore` / `servingTarget` that SP4 built.

## Status

Design settled via a collaborative brainstorm; **spec committed, implementation to follow on this branch.** Opening as draft now so the work is visible and durable.

## Decisions (locked in the brainstorm)

- **Thin override at portal's `resolve()` seam**, keyed entirely on SP4's `servingTarget` (home|backup). No new service, no new client protocol — the frontend's existing reconnect-on-failure path is the trigger.
- **Only the URLs swap; `siteId` stays home.** The backup materializes per-origin-`siteId` namespaces and `msg.send` subjects carry `{siteId}`, so the displaced client must keep reporting its home site or its messages land in the wrong namespace. This is the load-bearing correctness point.
- **Scoped to the SSO `/api/userInfo` path only.** The bot/admin `/api/v1/login` path is left unchanged.
- **Backup coordinates = a reserved entry** in `PORTAL_SITE_URLS` (`PORTAL_BACKUP_SITE_ID`), reusing existing boot-time validation.
- **Failback reconnect = no SP3 code** — the backup's drain on flip-to-healthy is itself the nudge.
- **TTL-cached `failoverReader`** built here over SP4's store (fail-safe `home` on miss/error); `main.go` refactored to construct the store unconditionally (routing needs it even where the control surface is off).

## ⚠️ Deferred but business-critical: bot failover

Bots are **critical**, and excluding them here is a deliberate deferral because the current lifeboat scope is already large — not a decision that they don't matter. The bot/admin `/api/v1/login` path forwards login to the home-site botplatform (down during an outage), so rerouting its URLs is moot until a **backup botplatform** exists. The real weight is in SP1 (materialize bot/botplatform state) + SP2 (run botplatform at the backup, wire the backup auth-service session branch); the SP3 side is then a single `servingURLs(...)` call added to `HandleLogin`. Recorded in the spec and roadmap so it is not lost.

## Spec

`docs/superpowers/specs/2026-08-11-sp3-portal-routing-override.md` (rewritten for these decisions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bx1yBMCjo88ftnTB6ha5pA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bx1yBMCjo88ftnTB6ha5pA)_