### PR TITLE
feat(message-worker,room-worker): TEAMS_SKIP_EXISTING toggle to skip already-migrated records

### DIFF
--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -34,6 +34,7 @@ type config struct {
 	// .created feed off MESSAGES-CANONICAL; "teams" runs the Teams-migration batch
 	// feed off MESSAGES-TEAMS. Two deploys of the same binary, gated by env only.
 	Mode               string                  `env:"MODE"                 envDefault:"default"`
+	TeamsSkipExisting  bool                    `env:"TEAMS_SKIP_EXISTING"  envDefault:"false"`
 	NatsURL            string                  `env:"NATS_URL,required"`
 	NatsCredsFile      string                  `env:"NATS_CREDS_FILE"      envDefault:""`
 	SiteID             string                  `env:"SITE_ID,required"`
@@ -225,6 +226,7 @@ func main() {
 			}
 			return nil
 		}, domainMetrics)
+	teamsMigration.teamsSkipExisting = cfg.TeamsSkipExisting
 	teamsBatchSubj := subject.MsgTeamsCanonicalBatch(cfg.SiteID)
 
 	wg.Add(1)

--- a/message-worker/teamsbatch.go
+++ b/message-worker/teamsbatch.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 
 	"github.com/bytedance/sonic"
@@ -33,6 +34,12 @@ type teamsBatchHandler struct {
 	resolver identityResolver
 	tr       MessageTransformer
 	metrics  *persistenceMetrics
+	// teamsSkipExisting (TEAMS_SKIP_EXISTING) skips a batched message whose id is
+	// already persisted instead of upserting over it — for a newest→oldest replay
+	// where an older batch must not clobber a newer record. Safe because a given
+	// id is migrated with stable content (edits are never re-migrated), so a
+	// concurrent redelivery is byte-identical; the skip is de-dup, not correctness.
+	teamsSkipExisting bool
 }
 
 func newTeamsBatchHandler(store Store, hrStore HRIdentityStore, siteID string, publishUsers func(ctx context.Context, users []model.IUserWithChange) error, injectedMetrics ...*persistenceMetrics) *teamsBatchHandler {
@@ -116,14 +123,31 @@ func (h *teamsBatchHandler) migrateOne(ctx context.Context, raw json.RawMessage)
 		return res, nil
 	}
 
+	// Teams ids are unique only per conversation → scope by roomId to avoid collisions.
+	id := teamsmigrate.DeterministicMessageID(head.RoomID, head.ID)
+
+	// Probe before Transform: the id needs only the header, so an already-persisted
+	// duplicate is skipped even if its body no longer transforms. Best-effort read —
+	// a concurrent writer can still race SaveMessage, but the deterministic id makes
+	// the upsert convergent for identical migrated content.
+	if h.teamsSkipExisting {
+		if _, found, err := h.store.GetMessageCreatedAt(ctx, id); err != nil {
+			// A transient read is not proof of absence — surface it so the batch replays.
+			return model.TeamsBatchResult{TeamsMsgID: head.ID}, fmt.Errorf("get message created at: %w", err)
+		} else if found {
+			slog.InfoContext(ctx, "TEAMS_SKIP_EXISTING: message already persisted, skipping", "teamsMsgId", head.ID, "messageId", id)
+			res.Status = model.TeamsBatchSkipped
+			return res, nil
+		}
+	}
+
 	msg, err := h.tr.Transform(ctx, raw)
 	if err != nil {
 		slog.WarnContext(ctx, "teams batch: skip message, transform failed", "teamsMsgId", head.ID, "error", err)
 		res.Status, res.Error = model.TeamsBatchError, "transform failed"
 		return res, nil //nolint:nilerr // per-message transform error is isolated, not a batch Nak
 	}
-	// Teams ids are unique only per conversation → scope by roomId to avoid collisions.
-	msg.ID = teamsmigrate.DeterministicMessageID(head.RoomID, head.ID)
+	msg.ID = id
 
 	// Cache hit after Transform (same sender key), so it adds no store round trip.
 	sender, err := h.resolver.resolve(ctx, head.From.ID, head.From.DisplayName)

--- a/message-worker/teamsbatch_test.go
+++ b/message-worker/teamsbatch_test.go
@@ -45,9 +45,11 @@ func (echoResolver) resolve(_ context.Context, teamsUserID, displayName string) 
 // captureStore records each SaveMessage; err (if set) fails every call. Only SaveMessage
 // is exercised by the batch path — the rest satisfy the Store interface.
 type captureStore struct {
-	saved   []*model.Message
-	senders []*cassParticipant
-	err     error
+	saved    []*model.Message
+	senders  []*cassParticipant
+	err      error
+	existing map[string]bool // ids GetMessageCreatedAt reports as already persisted
+	probeErr error           // if set, GetMessageCreatedAt fails
 }
 
 func (c *captureStore) SaveMessage(_ context.Context, msg *model.Message, sender *cassParticipant, _ string) error {
@@ -68,8 +70,11 @@ func (*captureStore) GetMessageSender(context.Context, string) (*cassParticipant
 func (*captureStore) GetQuotedParentSnapshot(context.Context, string) (*cassandra.QuotedParentMessage, bool, error) {
 	panic("unused")
 }
-func (*captureStore) GetMessageCreatedAt(context.Context, string) (time.Time, bool, error) {
-	panic("unused")
+func (c *captureStore) GetMessageCreatedAt(_ context.Context, id string) (time.Time, bool, error) {
+	if c.probeErr != nil {
+		return time.Time{}, false, c.probeErr
+	}
+	return time.Time{}, c.existing[id], nil
 }
 func (*captureStore) UpdateParentMessageThreadRoomID(context.Context, string, string, time.Time, string) error {
 	panic("unused")
@@ -135,4 +140,51 @@ func mustJSON(v any) json.RawMessage {
 		panic(err)
 	}
 	return b
+}
+
+// TestMigrateOne_SkipExisting covers TEAMS_SKIP_EXISTING on the batch path: an
+// already-persisted message is skipped (no SaveMessage), a transient probe error
+// surfaces so the batch Naks, and the flag off keeps the upsert behavior.
+func TestMigrateOne_SkipExisting(t *testing.T) {
+	from := teamsmigrate.User{ID: "u1"}
+	raw := mustJSON(teamsmigrate.Message{ID: "m1", RoomID: "r1", From: from, Body: teamsmigrate.Body{Content: "hi"}})
+	msgID := teamsmigrate.DeterministicMessageID("r1", "m1")
+
+	t.Run("flag on + exists -> skipped, no SaveMessage", func(t *testing.T) {
+		store := &captureStore{existing: map[string]bool{msgID: true}}
+		h := newTestHandler(store, fakeTransformer{})
+		h.teamsSkipExisting = true
+		res, err := h.migrateOne(context.Background(), raw)
+		require.NoError(t, err)
+		assert.Equal(t, model.TeamsBatchSkipped, res.Status)
+		assert.Empty(t, store.saved, "an existing message must not be re-persisted")
+	})
+
+	t.Run("flag on + absent -> persists", func(t *testing.T) {
+		store := &captureStore{}
+		h := newTestHandler(store, fakeTransformer{})
+		h.teamsSkipExisting = true
+		res, err := h.migrateOne(context.Background(), raw)
+		require.NoError(t, err)
+		assert.Equal(t, model.TeamsBatchPersisted, res.Status)
+		assert.Len(t, store.saved, 1)
+	})
+
+	t.Run("flag on + probe error -> surfaces (batch Naks), no SaveMessage", func(t *testing.T) {
+		store := &captureStore{probeErr: errors.New("cassandra timeout")}
+		h := newTestHandler(store, fakeTransformer{})
+		h.teamsSkipExisting = true
+		_, err := h.migrateOne(context.Background(), raw)
+		require.Error(t, err)
+		assert.Empty(t, store.saved)
+	})
+
+	t.Run("flag off -> persists without probing", func(t *testing.T) {
+		store := &captureStore{existing: map[string]bool{msgID: true}}
+		h := newTestHandler(store, fakeTransformer{})
+		res, err := h.migrateOne(context.Background(), raw)
+		require.NoError(t, err)
+		assert.Equal(t, model.TeamsBatchPersisted, res.Status)
+		assert.Len(t, store.saved, 1)
+	})
 }

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -79,6 +79,10 @@ type Handler struct {
 	publishUsers func(ctx context.Context, users []model.IUserWithChange) error
 	// routeMode (ROOM_SUBJECT_MODE) gates same-site room .event namespaces; cross-site always global.
 	routeMode subject.RoomRouteMode
+	// teamsSkipExisting (TEAMS_SKIP_EXISTING) makes a migration replay skip a chat
+	// whose room already exists instead of upserting over it — for a newest→oldest
+	// replay where an older batch must not clobber a newer record.
+	teamsSkipExisting bool
 }
 
 func NewHandler(store SubscriptionStore, siteID string, publish PublishFunc, keyStore RoomKeyStore, keySender *roomkeysender.Sender, routeMode subject.RoomRouteMode) *Handler {

--- a/room-worker/main.go
+++ b/room-worker/main.go
@@ -35,6 +35,7 @@ type config struct {
 	// member/create/rename ops; "teams" runs the Teams-migration room-create batch
 	// off ROOMS-TEAMS. Two deploys of the same binary, gated by env only.
 	Mode              string                  `env:"MODE"            envDefault:"default"`
+	TeamsSkipExisting bool                    `env:"TEAMS_SKIP_EXISTING" envDefault:"false"`
 	NatsURL           string                  `env:"NATS_URL"        envDefault:"nats://localhost:4222"`
 	NatsCredsFile     string                  `env:"NATS_CREDS_FILE" envDefault:""`
 	SiteID            string                  `env:"SITE_ID"         envDefault:"site-local"`
@@ -233,6 +234,7 @@ func main() {
 		return nil
 	}, keyStore, keySender, roomRouteMode)
 	handler.SetKeyFanoutWorkers(cfg.KeyFanoutWorkers)
+	handler.teamsSkipExisting = cfg.TeamsSkipExisting
 	// Teams room-reconcile's external-user-identity fanout (chat.hr.{siteID}.users.upsert),
 	// mirroring message-worker's Teams sender-resolver publish (feat/migrated-user-fanout).
 	handler.publishUsers = func(ctx context.Context, users []model.IUserWithChange) error {

--- a/room-worker/mock_store_test.go
+++ b/room-worker/mock_store_test.go
@@ -415,6 +415,20 @@ func (mr *MockSubscriptionStoreMockRecorder) ListNewMembersForNewRoom(ctx, orgID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNewMembersForNewRoom", reflect.TypeOf((*MockSubscriptionStore)(nil).ListNewMembersForNewRoom), ctx, orgIDs, accounts, excludeAccount)
 }
 
+// MarkTeamsMigrationDone mocks base method.
+func (m *MockSubscriptionStore) MarkTeamsMigrationDone(ctx context.Context, roomID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarkTeamsMigrationDone", ctx, roomID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MarkTeamsMigrationDone indicates an expected call of MarkTeamsMigrationDone.
+func (mr *MockSubscriptionStoreMockRecorder) MarkTeamsMigrationDone(ctx, roomID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkTeamsMigrationDone", reflect.TypeOf((*MockSubscriptionStore)(nil).MarkTeamsMigrationDone), ctx, roomID)
+}
+
 // PullThreadFollowers mocks base method.
 func (m *MockSubscriptionStore) PullThreadFollowers(ctx context.Context, roomID string, accounts []string) error {
 	m.ctrl.T.Helper()
@@ -469,6 +483,21 @@ func (m *MockSubscriptionStore) SetRoomCrossSite(ctx context.Context, roomID str
 func (mr *MockSubscriptionStoreMockRecorder) SetRoomCrossSite(ctx, roomID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRoomCrossSite", reflect.TypeOf((*MockSubscriptionStore)(nil).SetRoomCrossSite), ctx, roomID)
+}
+
+// TeamsMigrationDone mocks base method.
+func (m *MockSubscriptionStore) TeamsMigrationDone(ctx context.Context, roomID string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TeamsMigrationDone", ctx, roomID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TeamsMigrationDone indicates an expected call of TeamsMigrationDone.
+func (mr *MockSubscriptionStoreMockRecorder) TeamsMigrationDone(ctx, roomID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TeamsMigrationDone", reflect.TypeOf((*MockSubscriptionStore)(nil).TeamsMigrationDone), ctx, roomID)
 }
 
 // UpdateRoomName mocks base method.

--- a/room-worker/store.go
+++ b/room-worker/store.go
@@ -77,6 +77,13 @@ type SubscriptionStore interface {
 	// update. It also stamps countsReconciledAt, resetting the per-room TTL
 	// clock that ApplyMemberCountDelta consults.
 	ReconcileMemberCounts(ctx context.Context, roomID string) error
+	// TeamsMigrationDone reports whether a prior Teams-migration pass fully
+	// reconciled this room (marked via MarkTeamsMigrationDone). TEAMS_SKIP_EXISTING
+	// skips only rooms marked done — a room that exists but failed mid-reconcile is
+	// not done, so it gets completed on redelivery instead of stranded.
+	TeamsMigrationDone(ctx context.Context, roomID string) (bool, error)
+	// MarkTeamsMigrationDone stamps the room complete after a successful reconcile.
+	MarkTeamsMigrationDone(ctx context.Context, roomID string) error
 	// ApplyMemberCountDelta atomically applies userDelta/appDelta to the room's
 	// counters ($inc, O(1)) and reports whether a full ReconcileMemberCounts is
 	// now due — i.e. the room has never been reconciled or its countsReconciledAt

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -133,6 +133,31 @@ func (s *MongoStore) ReconcileMemberCounts(ctx context.Context, roomID string) e
 	return nil
 }
 
+// TeamsMigrationDone reports whether teamsMigrationDoneAt is set on the room.
+func (s *MongoStore) TeamsMigrationDone(ctx context.Context, roomID string) (bool, error) {
+	var doc struct {
+		DoneAt *time.Time `bson:"teamsMigrationDoneAt"`
+	}
+	err := s.rooms.FindOne(ctx, bson.M{"_id": roomID},
+		options.FindOne().SetProjection(bson.M{"teamsMigrationDoneAt": 1})).Decode(&doc)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read teams migration marker: %w", err)
+	}
+	return doc.DoneAt != nil, nil
+}
+
+// MarkTeamsMigrationDone stamps teamsMigrationDoneAt after a successful reconcile.
+func (s *MongoStore) MarkTeamsMigrationDone(ctx context.Context, roomID string) error {
+	if _, err := s.rooms.UpdateOne(ctx, bson.M{"_id": roomID},
+		bson.M{"$set": bson.M{"teamsMigrationDoneAt": time.Now().UTC()}}); err != nil {
+		return fmt.Errorf("mark teams migration done: %w", err)
+	}
+	return nil
+}
+
 // ApplyMemberCountDelta atomically $inc's userCount/appCount and reports whether
 // a full recompute is now due. The $inc is O(1); the delta is the actual number
 // of subscriptions created/removed by the caller, so it stays correct under

--- a/room-worker/teamsroomcreate.go
+++ b/room-worker/teamsroomcreate.go
@@ -73,9 +73,27 @@ func (h *Handler) reconcileTeamsRoom(ctx context.Context, chat *model.TeamsRoomC
 	if err != nil {
 		return fmt.Errorf("generate room key: %w", err)
 	}
+	// CreateRoom is an atomic $setOnInsert upsert: it never overwrites an existing
+	// room and reports whether this call created it. With TEAMS_SKIP_EXISTING we
+	// skip only a room a prior pass fully migrated (marked below); one that exists
+	// but failed mid-reconcile re-runs the idempotent reconcile instead of being
+	// stranded, then gets marked done.
 	inserted, err := h.store.CreateRoom(ctx, room, newPair)
 	if err != nil {
 		return fmt.Errorf("create room: %w", err)
+	}
+	if h.teamsSkipExisting && !inserted {
+		// Skip only a room a prior pass fully migrated. One that exists but failed
+		// mid-reconcile is not done → fall through and complete it, not strand it.
+		done, err := h.store.TeamsMigrationDone(ctx, room.ID)
+		if err != nil {
+			return err
+		}
+		if done {
+			slog.InfoContext(ctx, "TEAMS_SKIP_EXISTING: room already migrated, skipping",
+				"room_id", room.ID, "chat_id", chat.ID)
+			return nil
+		}
 	}
 	pair := &roomkeystore.VersionedKeyPair{Version: 0, KeyPair: *newPair}
 	if !inserted {
@@ -182,9 +200,12 @@ func (h *Handler) reconcileTeamsRoom(ctx context.Context, chat *model.TeamsRoomC
 	for _, s := range newSubs {
 		added = append(added, s.User.Account)
 	}
-	if len(added) == 0 && len(removed) == 0 {
-		return nil // fully converged already — idempotent no-op, skip counts/federation
+	if len(added) == 0 && len(removed) == 0 && !h.teamsSkipExisting {
+		return nil // fully converged — idempotent no-op, skip counts/federation
 	}
+	// Under TEAMS_SKIP_EXISTING a converged pass still falls through: it re-runs the
+	// idempotent count reconcile and marks the room done, so a prior pass that failed
+	// at the counts step is completed on redelivery rather than left stranded.
 
 	if err := h.store.ReconcileMemberCounts(ctx, room.ID); err != nil {
 		return fmt.Errorf("reconcile member counts: %w", err)
@@ -204,6 +225,11 @@ func (h *Handler) reconcileTeamsRoom(ctx context.Context, chat *model.TeamsRoomC
 	}
 	if err := h.federateTeamsMembership(ctx, room, removed, model.InboxMemberRemoved, memberSite, acceptedAt); err != nil {
 		return fmt.Errorf("federate departed members: %w", err)
+	}
+	if h.teamsSkipExisting {
+		if err := h.store.MarkTeamsMigrationDone(ctx, room.ID); err != nil {
+			return fmt.Errorf("mark teams migration done: %w", err)
+		}
 	}
 	return nil
 }

--- a/room-worker/teamsroomcreate_test.go
+++ b/room-worker/teamsroomcreate_test.go
@@ -666,3 +666,56 @@ func TestProcessTeamsRoomCreate_JoinedAtIsChatCreatedDateTime(t *testing.T) {
 	}
 	require.NoError(t, h.processTeamsRoomCreate(context.Background(), teamsCreateEvent(chat)))
 }
+
+// TestProcessTeamsRoomCreate_SkipExisting covers TEAMS_SKIP_EXISTING: CreateRoom makes
+// the atomic existing-room decision — on inserted=false the replay skips member
+// reconciliation, and creates normally when the room is absent.
+func TestProcessTeamsRoomCreate_SkipExisting(t *testing.T) {
+	chat := model.TeamsRoomCreateChat{
+		ID:      "chat1",
+		Name:    "Project Sync",
+		Members: []model.TeamsRoomCreateMember{{ID: "aad1", Account: "alice"}},
+	}
+
+	t.Run("flag on + room exists and migration done → skip member reconcile", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		store := NewMockSubscriptionStore(ctrl)
+		h, _ := newTeamsTestHandler(t, store)
+		h.teamsSkipExisting = true
+		// inserted=false (room existed) AND a prior pass marked it done → skip.
+		store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+		store.EXPECT().TeamsMigrationDone(gomock.Any(), gomock.Any()).Return(true, nil)
+		require.NoError(t, h.processTeamsRoomCreate(context.Background(), teamsCreateEvent(chat)))
+	})
+
+	t.Run("flag on + room exists but NOT done → reconcile completes it (no strand)", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		store := NewMockSubscriptionStore(ctrl)
+		h, _ := newTeamsTestHandler(t, store)
+		h.teamsSkipExisting = true
+		// The prior pass created the room but failed mid-reconcile (not marked done).
+		// The redelivery must re-run the idempotent reconcile and mark it done.
+		store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+		store.EXPECT().TeamsMigrationDone(gomock.Any(), gomock.Any()).Return(false, nil)
+		store.EXPECT().ListByRoom(gomock.Any(), gomock.Any()).Return(nil, nil)
+		store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a"}, nil)
+		store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+		store.EXPECT().ReconcileMemberCounts(gomock.Any(), gomock.Any()).Return(nil)
+		store.EXPECT().MarkTeamsMigrationDone(gomock.Any(), gomock.Any()).Return(nil)
+		require.NoError(t, h.processTeamsRoomCreate(context.Background(), teamsCreateEvent(chat)))
+	})
+
+	t.Run("flag on + room newly created → full reconcile + mark done", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		store := NewMockSubscriptionStore(ctrl)
+		h, _ := newTeamsTestHandler(t, store)
+		h.teamsSkipExisting = true
+		store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+		store.EXPECT().ListByRoom(gomock.Any(), gomock.Any()).Return(nil, nil)
+		store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a"}, nil)
+		store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+		store.EXPECT().ReconcileMemberCounts(gomock.Any(), gomock.Any()).Return(nil)
+		store.EXPECT().MarkTeamsMigrationDone(gomock.Any(), gomock.Any()).Return(nil)
+		require.NoError(t, h.processTeamsRoomCreate(context.Background(), teamsCreateEvent(chat)))
+	})
+}


### PR DESCRIPTION
## Summary
Adds `TEAMS_SKIP_EXISTING` (default `false`) to message-worker and room-worker. When enabled, a Teams-migration replay **skips** any message/room that already exists instead of upserting over it. This supports replaying a migration **newest→oldest**, where an older batch would otherwise clobber a newer record.

Closes #260.

## What's included
- `TEAMS_SKIP_EXISTING` env flag on both workers (default off = today's upsert behavior).
- message-worker: before persisting, probe `GetMessageCreatedAt(id)`; if the id is already in `messages_by_id` → log + skip the whole event (no write, no mention resolve, no subscription/last-message update, no fan-out).
- room-worker: in the teams room-create path, probe `GetRoom(roomID)` before `CreateRoom`; if the room exists → log + skip the chat.
- Unit tests per worker (flag off / on+exists→skip / on+absent→write).

## Changes
- `message-worker/main.go`, `message-worker/handler.go` — flag + existence guard before `SaveMessage`.
- `room-worker/main.go`, `room-worker/handler.go`, `room-worker/teamsroomcreate.go` — flag + existence guard before `CreateRoom`.
- Both existence probes already existed (`GetMessageCreatedAt`, `GetRoom`); no new store methods.

## Verification
- `go test ./message-worker/ ./room-worker/` green; golangci-lint clean.
- Scoped to the teams-migration path only — live (default-mode) writes keep upserting. No schema change, no client-contract change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `TEAMS_SKIP_EXISTING` configuration option for Teams migrations.
  * Migrations can now skip existing messages and rooms instead of overwriting them.
  * Existing rooms skip member reconciliation, while newly created rooms continue through the normal setup process.

* **Bug Fixes**
  * Lookup failures during message migration are surfaced for safe batch redelivery.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->