### PR TITLE
feat: user permission whitelist with cross-site sync and admin bulk operations

### DIFF
--- a/admin-frontend/src/api/_transport/httpEnvelope.test.ts
+++ b/admin-frontend/src/api/_transport/httpEnvelope.test.ts
@@ -69,6 +69,13 @@ describe('formatAsyncJobError', () => {
     expect(msg).not.toBe('token invalid')
   })
 
+  it('returns friendly copy for unknown_accounts', () => {
+    const err = new AsyncJobError('unknown accounts: zzz', { reason: 'unknown_accounts' })
+    const msg = formatAsyncJobError(err)
+    expect(msg).not.toBe('')
+    expect(msg).not.toBe('unknown accounts: zzz')
+  })
+
   it('falls back to err.message for an unknown reason', () => {
     const err = new AsyncJobError('something odd happened', { reason: 'not_in_catalog' })
     expect(formatAsyncJobError(err)).toBe('something odd happened')

--- a/admin-frontend/src/api/_transport/httpEnvelope.ts
+++ b/admin-frontend/src/api/_transport/httpEnvelope.ts
@@ -23,6 +23,17 @@ const REASON_COPY: Record<string, string> = {
   not_admin: 'You need admin access to do that.',
   invalid_token: 'That link has expired or is invalid — request a new one.',
   account_exists: 'An account with that email already exists.',
+  unknown_permission: "That permission isn't recognized.",
+  invalid_subject_count: 'Enter at least one account.',
+  // "1000" mirrors pkg/model.MaxReasonRunes.
+  invalid_reason: 'Enter a reason, up to 1000 characters.',
+  missing_permission_fields: 'Applicant and approver are both required.',
+  invalid_permission_window:
+    "Check the dates — the start date must be on or before the expiry date, and the expiry date can't be in the past.",
+  unexpected_permission_window:
+    "Revoking a permission doesn't use the date fields — leave them blank.",
+  inactive_subject: "Some accounts are deactivated and can't be granted this permission.",
+  unknown_accounts: 'Some accounts do not exist on this site.',
 }
 
 /** User-facing message for an `AsyncJobError`; prefers reason-keyed copy (stable machine codes) over `err.message`. */

--- a/admin-frontend/src/api/admin/admin.test.ts
+++ b/admin-frontend/src/api/admin/admin.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { AsyncJobError } from '@/api'
 import {
+  createPermissions,
   createUser,
   getUser,
   listAudit,
+  listPermissions,
   listSessions,
   listUsers,
+  resyncPermissions,
   revokeAllSessions,
   revokeSession,
   setPassword,
@@ -294,5 +297,204 @@ describe('listAudit', () => {
 
     const [url] = fetchMock.mock.calls[0]
     expect(url).toBe('http://localhost:8082/v1/admin/audit')
+  })
+})
+
+const GRANT_VIEW = {
+  id: 'g-1',
+  permission: 'external.image.view',
+  subjectAccount: 'alice',
+  granted: true,
+  effectiveFrom: '2026-09-01',
+  expiresAt: '2026-12-31',
+  applicantAccount: 'carol',
+  approverAccount: 'dave',
+  reason: 'On-call staff must review production line photos from outside the fab.',
+  recordedBy: 'p_admin_wang',
+  recordedAt: '2026-08-11T03:00:00Z',
+}
+
+describe('createPermissions', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('POSTs /v1/admin/permissions with the request body and returns the created response', async () => {
+    const response = {
+      created: 2,
+      duplicatesIgnored: [],
+    }
+    const fetchMock = stubFetch(201, response)
+
+    const result = await createPermissions('tok', {
+      permission: 'external.image.view',
+      subjectAccounts: ['alice', 'bob'],
+      granted: true,
+      effectiveFrom: '2026-09-01',
+      expiresAt: '2026-12-31',
+      applicantAccount: 'carol',
+      approverAccount: 'dave',
+      reason: 'On-call staff must review production line photos from outside the fab.',
+    })
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8082/v1/admin/permissions')
+    expect(init.method).toBe('POST')
+    expect(init.headers.Authorization).toBe('Bearer tok')
+    expect(init.headers['Content-Type']).toBe('application/json')
+    expect(JSON.parse(init.body)).toEqual({
+      permission: 'external.image.view',
+      subjectAccounts: ['alice', 'bob'],
+      granted: true,
+      effectiveFrom: '2026-09-01',
+      expiresAt: '2026-12-31',
+      applicantAccount: 'carol',
+      approverAccount: 'dave',
+      reason: 'On-call staff must review production line photos from outside the fab.',
+    })
+    expect(result).toEqual(response)
+  })
+
+  it('throws AsyncJobError with reason preserved on a non-2xx response', async () => {
+    stubFetch(404, {
+      error: 'unknown accounts: zzz',
+      code: 'not_found',
+      reason: 'unknown_accounts',
+    })
+    const body = {
+      permission: 'external.image.view',
+      subjectAccounts: ['zzz'],
+      granted: true,
+      expiresAt: '2026-12-31',
+      applicantAccount: 'carol',
+      approverAccount: 'dave',
+      reason: 'test',
+    }
+
+    await expect(createPermissions('tok', body)).rejects.toBeInstanceOf(AsyncJobError)
+    await expect(createPermissions('tok', body)).rejects.toMatchObject({
+      reason: 'unknown_accounts',
+    })
+  })
+
+  it('returns syncFailures when the response carries them', async () => {
+    stubFetch(201, {
+      created: 2,
+      duplicatesIgnored: [],
+      syncFailures: ['site-2'],
+    })
+
+    const result = await createPermissions('tok', {
+      permission: 'external.image.view',
+      subjectAccounts: ['alice', 'bob'],
+      granted: true,
+      expiresAt: '2026-12-31',
+      applicantAccount: 'carol',
+      approverAccount: 'dave',
+      reason: 'test',
+    })
+
+    expect(result.syncFailures).toEqual(['site-2'])
+  })
+})
+
+describe('resyncPermissions', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('POSTs /v1/admin/permissions/resync with the request body and returns the response', async () => {
+    const fetchMock = stubFetch(200, { syncFailures: ['site-2'] })
+
+    const result = await resyncPermissions('tok', {
+      permission: 'external.image.view',
+      accounts: ['alice', 'bob'],
+    })
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8082/v1/admin/permissions/resync')
+    expect(init.method).toBe('POST')
+    expect(init.headers.Authorization).toBe('Bearer tok')
+    expect(init.headers['Content-Type']).toBe('application/json')
+    expect(JSON.parse(init.body)).toEqual({
+      permission: 'external.image.view',
+      accounts: ['alice', 'bob'],
+    })
+    expect(result).toEqual({ syncFailures: ['site-2'] })
+  })
+
+  it('resolves with an empty object when the server reports no sync failures', async () => {
+    stubFetch(200, {})
+
+    const result = await resyncPermissions('tok', {
+      permission: 'external.image.view',
+      accounts: ['alice'],
+    })
+
+    expect(result.syncFailures).toBeUndefined()
+  })
+
+  it('throws AsyncJobError with reason preserved on a non-2xx response', async () => {
+    stubFetch(404, {
+      error: 'unknown accounts: zzz',
+      code: 'not_found',
+      reason: 'unknown_accounts',
+    })
+
+    await expect(
+      resyncPermissions('tok', { permission: 'external.image.view', accounts: ['zzz'] }),
+    ).rejects.toMatchObject({ reason: 'unknown_accounts' })
+  })
+})
+
+describe('listPermissions', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('GETs /v1/admin/permissions with subjectAccount plus optional params when all are provided', async () => {
+    const fetchMock = stubFetch(200, { entries: [GRANT_VIEW], total: 1, currentlyGranted: true })
+
+    const result = await listPermissions('tok', {
+      subjectAccount: 'alice',
+      permission: 'external.image.view',
+      page: 2,
+      limit: 10,
+    })
+
+    const [url, init] = fetchMock.mock.calls[0]
+    const parsed = new URL(url)
+    expect(parsed.pathname).toBe('/v1/admin/permissions')
+    expect(parsed.searchParams.get('subjectAccount')).toBe('alice')
+    expect(parsed.searchParams.get('permission')).toBe('external.image.view')
+    expect(parsed.searchParams.get('page')).toBe('2')
+    expect(parsed.searchParams.get('limit')).toBe('10')
+    expect(init.method).toBe('GET')
+    expect(result).toEqual({ entries: [GRANT_VIEW], total: 1, currentlyGranted: true })
+  })
+
+  it('omits permission/page/limit from the query string when not provided', async () => {
+    const fetchMock = stubFetch(200, { entries: [], total: 0 })
+
+    await listPermissions('tok', { subjectAccount: 'alice' })
+
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8082/v1/admin/permissions?subjectAccount=alice')
+  })
+
+  it('omits subjectAccount from the query string when not provided (unfiltered list)', async () => {
+    const fetchMock = stubFetch(200, { entries: [], total: 0 })
+
+    await listPermissions('tok', {})
+
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8082/v1/admin/permissions')
+  })
+
+  it('GETs with permission only when subjectAccount is omitted', async () => {
+    const fetchMock = stubFetch(200, { entries: [], total: 0 })
+
+    await listPermissions('tok', { permission: 'external.image.view', page: 1, limit: 20 })
+
+    const [url] = fetchMock.mock.calls[0]
+    const parsed = new URL(url)
+    expect(parsed.searchParams.get('subjectAccount')).toBeNull()
+    expect(parsed.searchParams.get('permission')).toBe('external.image.view')
+    expect(parsed.searchParams.get('page')).toBe('1')
+    expect(parsed.searchParams.get('limit')).toBe('20')
   })
 })

--- a/admin-frontend/src/api/admin/index.ts
+++ b/admin-frontend/src/api/admin/index.ts
@@ -74,6 +74,64 @@ export interface AuditFilter {
   limit?: number
 }
 
+/** One row of the permission ledger (mirrors admin-service's `permissionGrantView`). */
+export interface PermissionGrantView {
+  id: string
+  permission: string
+  subjectAccount: string
+  granted: boolean
+  effectiveFrom?: string // "2026-09-01"
+  expiresAt?: string // "2026-12-31"
+  applicantAccount: string
+  approverAccount: string
+  reason: string
+  recordedBy: string
+  recordedAt: string
+}
+
+export interface CreatePermissionsRequest {
+  permission: string
+  subjectAccounts: string[]
+  granted: boolean
+  effectiveFrom?: string
+  expiresAt?: string
+  applicantAccount: string
+  approverAccount: string
+  reason?: string
+}
+
+/** `syncFailures` lists the sites whose whitelist sync failed — the ledger write still
+ * succeeded (201), so those sites need a `resyncPermissions` follow-up. */
+export interface CreatePermissionsResponse {
+  created: number
+  duplicatesIgnored: string[]
+  syncFailures?: string[]
+}
+
+export interface ResyncPermissionsRequest {
+  permission: string
+  accounts: string[]
+}
+
+export interface ResyncPermissionsResponse {
+  syncFailures?: string[]
+}
+
+export interface ListPermissionsResponse {
+  currentlyGranted?: boolean
+  entries: PermissionGrantView[]
+  total: number
+}
+
+/** `subjectAccount` and `permission` are independently optional and combinable; the server
+ * includes `currentlyGranted` in the response only when both are given. */
+export interface ListPermissionsParams {
+  subjectAccount?: string
+  permission?: string
+  page?: number
+  limit?: number
+}
+
 /** Raw shape of admin-service's `userView` as it appears on the wire — the
  * `omitempty` fields may be absent; `normalizeUser` fills the defaults. */
 interface UserViewWire {
@@ -224,4 +282,35 @@ export async function listAudit(
     limit: filter.limit,
   })
   return adminFetch<{ entries: AuditEntry[]; total: number }>(authToken, 'GET', `/audit${qs}`)
+}
+
+/** @throws {AsyncJobError} on a non-2xx response (e.g. `unknown_accounts`, `inactive_subject`). */
+export async function createPermissions(
+  authToken: string,
+  body: CreatePermissionsRequest,
+): Promise<CreatePermissionsResponse> {
+  return adminFetch<CreatePermissionsResponse>(authToken, 'POST', '/permissions', body)
+}
+
+/** Replays the current ledger state for `accounts` to every site's whitelist.
+ * @throws {AsyncJobError} on a non-2xx response (e.g. `unknown_accounts`). */
+export async function resyncPermissions(
+  authToken: string,
+  body: ResyncPermissionsRequest,
+): Promise<ResyncPermissionsResponse> {
+  return adminFetch<ResyncPermissionsResponse>(authToken, 'POST', '/permissions/resync', body)
+}
+
+/** @throws {AsyncJobError} on a non-2xx response. */
+export async function listPermissions(
+  authToken: string,
+  params: ListPermissionsParams = {},
+): Promise<ListPermissionsResponse> {
+  const qs = buildQuery({
+    subjectAccount: params.subjectAccount,
+    permission: params.permission,
+    page: params.page,
+    limit: params.limit,
+  })
+  return adminFetch<ListPermissionsResponse>(authToken, 'GET', `/permissions${qs}`)
 }

--- a/admin-frontend/src/api/index.ts
+++ b/admin-frontend/src/api/index.ts
@@ -11,11 +11,14 @@ export { botLogin, changePassword } from './auth/botAuth'
 export type { Bundle } from './auth/botAuth'
 
 export {
+  createPermissions,
   createUser,
   getUser,
   listAudit,
+  listPermissions,
   listSessions,
   listUsers,
+  resyncPermissions,
   revokeAllSessions,
   revokeSession,
   setPassword,
@@ -26,8 +29,15 @@ export type {
   AdminUser,
   AuditEntry,
   AuditFilter,
+  CreatePermissionsRequest,
+  CreatePermissionsResponse,
   CreateUserInput,
+  ListPermissionsParams,
+  ListPermissionsResponse,
   ListUsersParams,
+  PermissionGrantView,
+  ResyncPermissionsRequest,
+  ResyncPermissionsResponse,
   SetPasswordInput,
   UpdateUserPatch,
 } from './admin'

--- a/admin-frontend/src/components/AppShell/AppShell.jsx
+++ b/admin-frontend/src/components/AppShell/AppShell.jsx
@@ -3,12 +3,14 @@ import { useAuth } from '@/context/AuthContext'
 import LazyFallback from '@/components/shared/LazyFallback'
 import './style.css'
 
-const UsersPage = lazy(() => import('@/components/UsersConsole'))
-const AuditView = lazy(() => import('@/components/AuditView'))
-
 const SECTIONS = [
-  { key: 'users', label: 'Users' },
-  { key: 'audit', label: 'Audit' },
+  { key: 'users', label: 'Users', Component: lazy(() => import('@/components/UsersConsole')) },
+  { key: 'audit', label: 'Audit', Component: lazy(() => import('@/components/AuditView')) },
+  {
+    key: 'permissions',
+    label: 'Permissions',
+    Component: lazy(() => import('@/components/PermissionsView')),
+  },
 ]
 
 // Top-level authed layout: nav to switch Users/Audit, header with signed-in account + logout.
@@ -20,16 +22,7 @@ export default function AppShell() {
     logout()
   }
 
-  const renderSection = () => {
-    if (section === 'users') return <UsersPage />
-    return <AuditView />
-  }
-
-  const content = (
-    <Suspense fallback={<LazyFallback variant="inline" />}>
-      {renderSection()}
-    </Suspense>
-  )
+  const { Component } = SECTIONS.find((s) => s.key === section) ?? SECTIONS[0]
 
   return (
     <div className="app-shell">
@@ -55,7 +48,11 @@ export default function AppShell() {
         </div>
       </nav>
 
-      <main className="app-shell-main">{content}</main>
+      <main className="app-shell-main">
+        <Suspense fallback={<LazyFallback variant="inline" />}>
+          <Component />
+        </Suspense>
+      </main>
     </div>
   )
 }

--- a/admin-frontend/src/components/AppShell/AppShell.test.jsx
+++ b/admin-frontend/src/components/AppShell/AppShell.test.jsx
@@ -4,12 +4,18 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 vi.mock('@/context/AuthContext', () => ({ useAuth: vi.fn() }))
 vi.mock('@/api', async (importOriginal) => {
   const actual = await importOriginal()
-  return { ...actual, listUsers: vi.fn(), listAudit: vi.fn() }
+  return {
+    ...actual,
+    listUsers: vi.fn(),
+    listAudit: vi.fn(),
+    createPermissions: vi.fn(),
+    listPermissions: vi.fn(),
+  }
 })
 
 import AppShell from './AppShell'
 import { useAuth } from '@/context/AuthContext'
-import { listUsers, listAudit } from '@/api'
+import { listUsers, listAudit, listPermissions } from '@/api'
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -19,6 +25,7 @@ beforeEach(() => {
   })
   listUsers.mockResolvedValue({ users: [], total: 0 })
   listAudit.mockResolvedValue({ entries: [], total: 0 })
+  listPermissions.mockResolvedValue({ entries: [], total: 0 })
 })
 
 describe('AppShell', () => {
@@ -59,5 +66,17 @@ describe('AppShell', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /^users$/i }))
     await waitFor(() => expect(listUsers).toHaveBeenCalledTimes(2))
+  })
+
+  it('switches from Users to Permissions via nav and mounts PermissionsView', async () => {
+    render(<AppShell />)
+    await waitFor(() => expect(listUsers).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByRole('button', { name: /^permissions$/i }))
+
+    await waitFor(() =>
+      expect(listPermissions).toHaveBeenCalledWith('tok', { page: 1, limit: 20 }),
+    )
+    expect(screen.getByRole('button', { name: /^create$/i })).toBeInTheDocument()
   })
 })

--- a/admin-frontend/src/components/AuditView/AuditView.jsx
+++ b/admin-frontend/src/components/AuditView/AuditView.jsx
@@ -1,14 +1,13 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { AsyncJobError, listAudit } from '@/api'
+import { listAudit } from '@/api'
 import { useAuth } from '@/context/AuthContext'
-import { useHandleAdminError } from '@/hooks/useHandleAdminError'
-import { useLatestRequest } from '@/hooks/useLatestRequest'
-import { useDebouncedSearch } from '@/hooks/useDebouncedSearch'
+import { usePagedAdminList } from '@/hooks/usePagedAdminList'
 import Pager from '@/components/shared/Pager'
 import './style.css'
 
 // Matches admin-service's parsePaging default limit (handler.go).
 const PAGE_SIZE = 20
+
+const DEFAULT_FILTERS = { action: '', targetAccount: '' }
 
 // Only include a filter param when the caller actually typed something —
 // mirrors listUsers' `q` omission so the wire call stays `{}` at rest.
@@ -20,82 +19,16 @@ function buildFilterParams(filters) {
 }
 
 // Settings → Audit console. Filter inputs update immediately; the query itself is debounced
-// (both fields serialized into one value). A generation counter drops stale in-flight responses.
+// (both fields serialized into one value) — see usePagedAdminList for the paging shell.
 export default function AuditView() {
   const { session } = useAuth()
-  const authToken = session?.authToken
-  const handleAdminError = useHandleAdminError()
-
-  const [entries, setEntries] = useState([])
-  const [total, setTotal] = useState(0)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(null)
-  const [notAuthorized, setNotAuthorized] = useState(false)
-  const [filters, setFilters] = useState({ action: '', targetAccount: '' })
-  const [page, setPage] = useState(1)
-
-  const { begin, isCurrent } = useLatestRequest()
-  // Tracks the filter key already reflected by the most recent fetch (whether
-  // triggered by the debounce or by goToPage), so a debounced onSearch firing
-  // after a manual goToPage — with the same filters it already picked up —
-  // doesn't clobber the page the user just navigated to.
-  const lastFetchedFilterKeyRef = useRef(JSON.stringify({ action: '', targetAccount: '' }))
-
-  const fetchAudit = useCallback(
-    async (params, pageArg) => {
-      const token = begin()
-      setLoading(true)
-      setError(null)
-      try {
-        const result = await listAudit(authToken, { ...params, page: pageArg, limit: PAGE_SIZE })
-        if (!isCurrent(token)) return // superseded by a newer request
-        setEntries(result.entries)
-        setTotal(result.total)
-        setNotAuthorized(false)
-      } catch (err) {
-        if (!isCurrent(token)) return
-        if (err instanceof AsyncJobError && err.reason === 'not_admin') {
-          setNotAuthorized(true)
-        } else {
-          const message = handleAdminError(err)
-          if (message !== null) setError(message)
-        }
-      } finally {
-        if (isCurrent(token)) setLoading(false)
-      }
-    },
-    [authToken, handleAdminError, begin, isCurrent],
-  )
-
-  useEffect(() => {
-    setPage(1)
-    fetchAudit({}, 1)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [authToken])
-
-  const { setQuery: setDebouncedFilters } = useDebouncedSearch({
-    onSearch: (serialized) => {
-      // If a manual goToPage already fetched with this exact filter set (e.g. the
-      // user paginated before this debounce fired), skip the redundant page-1 reset.
-      if (serialized === lastFetchedFilterKeyRef.current) return
-      lastFetchedFilterKeyRef.current = serialized
-      const parsed = serialized ? JSON.parse(serialized) : { action: '', targetAccount: '' }
-      setPage(1)
-      fetchAudit(buildFilterParams(parsed), 1)
-    },
-  })
-
-  const updateFilter = (key, value) => {
-    const next = { ...filters, [key]: value }
-    setFilters(next)
-    setDebouncedFilters(JSON.stringify(next))
-  }
-
-  const goToPage = (nextPage) => {
-    lastFetchedFilterKeyRef.current = JSON.stringify(filters)
-    setPage(nextPage)
-    fetchAudit(buildFilterParams(filters), nextPage)
-  }
+  const { entries, total, page, filters, loading, error, notAuthorized, updateFilter, goToPage } =
+    usePagedAdminList({
+      authToken: session?.authToken,
+      fetcher: (token, f, paging) => listAudit(token, { ...buildFilterParams(f), ...paging }),
+      defaultFilters: DEFAULT_FILTERS,
+      pageSize: PAGE_SIZE,
+    })
 
   if (notAuthorized) {
     return (
@@ -134,7 +67,7 @@ export default function AuditView() {
       ) : entries.length === 0 ? (
         <div className="audit-table-status">No audit entries found.</div>
       ) : (
-        <table className="audit-table">
+        <table className="data-table">
           <thead>
             <tr>
               <th>Actor</th>

--- a/admin-frontend/src/components/AuditView/AuditView.test.jsx
+++ b/admin-frontend/src/components/AuditView/AuditView.test.jsx
@@ -140,6 +140,21 @@ describe('AuditView', () => {
     expect(logout).not.toHaveBeenCalled()
   })
 
+  // Pins usePagedAdminList's deliberate setData(null)-on-error: a failed fetch clears the
+  // rows it was replacing, so the console never shows stale rows next to an error banner.
+  it('clears already-rendered rows when a later fetch fails, alongside the error banner', async () => {
+    listAudit.mockResolvedValue({ entries: [ENTRY_1, ENTRY_2], total: 50 })
+    render(<AuditView />)
+    expect(await screen.findByText('user.create')).toBeInTheDocument()
+
+    listAudit.mockRejectedValueOnce(new AsyncJobError('boom', { code: 'internal' }))
+    fireEvent.click(screen.getByRole('button', { name: /next/i }))
+
+    expect(await screen.findByText(/boom/i)).toBeInTheDocument()
+    expect(screen.queryByText('user.create')).not.toBeInTheDocument()
+    expect(screen.getByText(/no audit entries found/i)).toBeInTheDocument()
+  })
+
   it('logs the admin out instead of showing a banner on invalid_token', async () => {
     listAudit.mockRejectedValue(
       new AsyncJobError('expired', { code: 'unauthenticated', reason: 'invalid_token' }),

--- a/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/CreatePermissionsDialog.jsx
+++ b/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/CreatePermissionsDialog.jsx
@@ -1,0 +1,355 @@
+import { useMemo, useState } from 'react'
+import { AsyncJobError, createPermissions, resyncPermissions } from '@/api'
+import { useHandleAdminError } from '@/hooks/useHandleAdminError'
+import Modal from '@/components/shared/Modal'
+import AccountPicker from '@/components/shared/AccountPicker'
+import { PERMISSION_KEY } from '../permissionKey'
+import { parsePastedAccounts } from './parseAccounts'
+import './style.css'
+
+const MAX_REASON_RUNES = 1000 // mirrors pkg/model.MaxReasonRunes
+const DUPLICATES_INLINE_MAX = 20 // longer lists collapse behind a count
+
+// Grant/revoke form, opened as a dialog from PermissionsPage's "Create" button. On a successful
+// submit it reports up via `onCreated` immediately (PermissionsPage refreshes the list right
+// away) but — unlike UsersConsole's CreateUserForm/onCreated, which the parent uses to also
+// close the dialog — this dialog stays open and swaps to a result view so the admin can read the
+// created/duplicatesIgnored summary; `onClose` (via the result view's Close button, Cancel, Esc,
+// or the backdrop) is what actually dismisses it.
+export default function CreatePermissionsDialog({ authToken, onClose, onCreated }) {
+  const handleAdminError = useHandleAdminError()
+
+  const [mode, setMode] = useState('grant')
+  const [inputMode, setInputMode] = useState('pick')
+  const [subjectAccounts, setSubjectAccounts] = useState([])
+  const [pasteText, setPasteText] = useState('')
+  const [effectiveFrom, setEffectiveFrom] = useState('')
+  const [expiresAt, setExpiresAt] = useState('')
+  const [applicantAccount, setApplicantAccount] = useState('')
+  const [approverAccount, setApproverAccount] = useState('')
+  const [reason, setReason] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [formError, setFormError] = useState(null)
+  const [formErrorMetadata, setFormErrorMetadata] = useState(null)
+  const [result, setResult] = useState(null)
+  // The request as submitted — resync replays that, not the form fields as they stand now.
+  const [lastSubmitted, setLastSubmitted] = useState(null)
+  const [resyncing, setResyncing] = useState(false)
+
+  // The two subject inputs never merge: only the active mode's list is submitted.
+  const parsed = useMemo(() => parsePastedAccounts(pasteText), [pasteText])
+  const effectiveAccounts = inputMode === 'paste' ? parsed.accounts : subjectAccounts
+  const reasonRuneCount = [...reason].length
+  const clientInvalid =
+    effectiveAccounts.length === 0 ||
+    reasonRuneCount > MAX_REASON_RUNES ||
+    !applicantAccount ||
+    !approverAccount ||
+    (mode === 'grant' && !expiresAt)
+
+  // Builds the wire payload field-by-field so an omitted window field or a blank reason is
+  // truly absent from the object (and therefore from the JSON body) — never sent as "".
+  const buildPayload = () => {
+    const payload = {
+      permission: PERMISSION_KEY,
+      subjectAccounts: effectiveAccounts,
+      granted: mode === 'grant',
+    }
+    if (mode === 'grant') {
+      if (effectiveFrom) payload.effectiveFrom = effectiveFrom
+      payload.expiresAt = expiresAt
+    }
+    payload.applicantAccount = applicantAccount
+    payload.approverAccount = approverAccount
+    if (reason) payload.reason = reason
+    return payload
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (clientInvalid || submitting) return
+    setSubmitting(true)
+    setFormError(null)
+    setFormErrorMetadata(null)
+    try {
+      const response = await createPermissions(authToken, buildPayload())
+      setResult(response)
+      setLastSubmitted({ permission: PERMISSION_KEY, accounts: effectiveAccounts })
+      onCreated()
+    } catch (err) {
+      const message = handleAdminError(err)
+      if (message !== null) {
+        setFormError(message)
+        if (err instanceof AsyncJobError && err.metadata) setFormErrorMetadata(err.metadata)
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  // Re-delivers the recorded state to every site; writes nothing, so it is safe to press again.
+  const handleResync = async () => {
+    if (!lastSubmitted || resyncing) return
+    setResyncing(true)
+    setFormError(null)
+    try {
+      const r = await resyncPermissions(authToken, lastSubmitted)
+      // Empty (not absent) syncFailures is what renders "Sync complete." — the server omits the
+      // field when it has nothing to report, so only this path can produce [].
+      setResult({ ...result, syncFailures: r.syncFailures ?? [] })
+    } catch (err) {
+      const message = handleAdminError(err)
+      if (message !== null) setFormError(message)
+    } finally {
+      setResyncing(false)
+    }
+  }
+
+  // The accounts the server rejected, echoed back joined with ", " (null when it reported none).
+  const offenders =
+    typeof formErrorMetadata?.accounts === 'string' ? formErrorMetadata.accounts : null
+
+  // Drops those accounts from whichever input is active, so the admin can resubmit without
+  // hand-editing.
+  const stripOffenders = () => {
+    const drop = new Set(parsePastedAccounts(offenders).accounts)
+    if (inputMode === 'paste') {
+      setPasteText(parsed.accounts.filter((a) => !drop.has(a)).join('\n'))
+    } else {
+      setSubjectAccounts(subjectAccounts.filter((a) => !drop.has(a)))
+    }
+    setFormError(null)
+    setFormErrorMetadata(null)
+  }
+
+  return (
+    <Modal onClose={onClose} labelledBy="create-permissions-title">
+      <h2 id="create-permissions-title">Grant or revoke permission</h2>
+
+      {result ? (
+        <div>
+          <div className="permissions-result dialog-success">
+            <p>
+              {mode === 'grant'
+                ? `Created ${result.created} grant${result.created === 1 ? '' : 's'}.`
+                : `Recorded ${result.created} revocation${result.created === 1 ? '' : 's'}.`}
+            </p>
+            {result.duplicatesIgnored.length > DUPLICATES_INLINE_MAX ? (
+              <details className="permissions-duplicates">
+                <summary>{result.duplicatesIgnored.length} duplicates ignored</summary>
+                <p>{result.duplicatesIgnored.join(', ')}</p>
+              </details>
+            ) : (
+              result.duplicatesIgnored.length > 0 && (
+                <p className="permissions-duplicates">
+                  Duplicates ignored: {result.duplicatesIgnored.join(', ')}
+                </p>
+              )
+            )}
+          </div>
+
+          {result.syncFailures?.length > 0 ? (
+            <div className="permissions-sync-warning">
+              <p>
+                Recorded and effective at this site, but sync failed for:{' '}
+                {result.syncFailures.join(', ')}. Resend delivers the recorded state again —
+                safe to repeat.
+              </p>
+              <button type="button" className="btn" onClick={handleResync} disabled={resyncing}>
+                {resyncing ? 'Resending…' : 'Resend sync'}
+              </button>
+            </div>
+          ) : result.syncFailures?.length === 0 ? (
+            <p className="permissions-sync-ok">Sync complete.</p>
+          ) : null}
+
+          {formError && <p className="dialog-error">{formError}</p>}
+
+          <div className="dialog-actions">
+            <button type="button" className="dialog-cancel" onClick={onClose}>
+              Close
+            </button>
+          </div>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit}>
+          <p className="permissions-form-subtitle">Permission: {PERMISSION_KEY}</p>
+
+          <div className="permissions-mode-group" role="radiogroup" aria-label="Grant or revoke">
+            <label htmlFor="permissions-mode-grant" className="permissions-mode-option">
+              <input
+                type="radio"
+                id="permissions-mode-grant"
+                name="permissions-mode"
+                value="grant"
+                checked={mode === 'grant'}
+                onChange={() => setMode('grant')}
+                disabled={submitting}
+              />
+              Grant
+            </label>
+            <label htmlFor="permissions-mode-revoke" className="permissions-mode-option">
+              <input
+                type="radio"
+                id="permissions-mode-revoke"
+                name="permissions-mode"
+                value="revoke"
+                checked={mode === 'revoke'}
+                onChange={() => setMode('revoke')}
+                disabled={submitting}
+              />
+              Revoke
+            </label>
+          </div>
+
+          <div
+            className="permissions-mode-group"
+            role="radiogroup"
+            aria-label="Subject input mode"
+          >
+            <label htmlFor="permissions-input-mode-pick" className="permissions-mode-option">
+              <input
+                type="radio"
+                id="permissions-input-mode-pick"
+                name="permissions-input-mode"
+                value="pick"
+                checked={inputMode === 'pick'}
+                onChange={() => setInputMode('pick')}
+                disabled={submitting}
+              />
+              Pick ({subjectAccounts.length})
+            </label>
+            <label htmlFor="permissions-input-mode-paste" className="permissions-mode-option">
+              <input
+                type="radio"
+                id="permissions-input-mode-paste"
+                name="permissions-input-mode"
+                value="paste"
+                checked={inputMode === 'paste'}
+                onChange={() => setInputMode('paste')}
+                disabled={submitting}
+              />
+              Paste list ({parsed.accounts.length})
+            </label>
+          </div>
+
+          {inputMode === 'pick' ? (
+            <AccountPicker
+              id="permissions-subjects"
+              label="Subject accounts"
+              authToken={authToken}
+              multiple
+              value={subjectAccounts}
+              onChange={setSubjectAccounts}
+              disabled={submitting}
+            />
+          ) : (
+            <>
+              <label htmlFor="permissions-paste">Subject accounts (paste list)</label>
+              <textarea
+                id="permissions-paste"
+                className="permissions-paste-textarea"
+                value={pasteText}
+                onChange={(e) => setPasteText(e.target.value)}
+                disabled={submitting}
+                placeholder="Accounts separated by spaces, commas, or newlines"
+              />
+              <span className="permissions-subjects-count">
+                {parsed.accounts.length} account{parsed.accounts.length === 1 ? '' : 's'}
+                {parsed.duplicates > 0
+                  ? ` (${parsed.duplicates} duplicate${parsed.duplicates === 1 ? '' : 's'} removed)`
+                  : ''}
+              </span>
+            </>
+          )}
+
+          {mode === 'grant' && (
+            <div className="permissions-date-row">
+              <div className="permissions-date-field">
+                <label htmlFor="permissions-effective-from">Effective from (optional)</label>
+                <input
+                  type="date"
+                  id="permissions-effective-from"
+                  value={effectiveFrom}
+                  onChange={(e) => setEffectiveFrom(e.target.value)}
+                  disabled={submitting}
+                />
+              </div>
+              <div className="permissions-date-field">
+                <label htmlFor="permissions-expires-at">Expires at</label>
+                <input
+                  type="date"
+                  id="permissions-expires-at"
+                  value={expiresAt}
+                  onChange={(e) => setExpiresAt(e.target.value)}
+                  disabled={submitting}
+                />
+              </div>
+            </div>
+          )}
+
+          <AccountPicker
+            id="permissions-applicant"
+            label="Applicant account"
+            authToken={authToken}
+            value={applicantAccount}
+            onChange={setApplicantAccount}
+            disabled={submitting}
+          />
+
+          <AccountPicker
+            id="permissions-approver"
+            label="Approver account"
+            authToken={authToken}
+            value={approverAccount}
+            onChange={setApproverAccount}
+            disabled={submitting}
+          />
+
+          <label htmlFor="permissions-reason">Reason (optional)</label>
+          <textarea
+            id="permissions-reason"
+            className="permissions-reason-textarea"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            disabled={submitting}
+          />
+          <span className="permissions-reason-count">
+            {reasonRuneCount} / {MAX_REASON_RUNES}
+          </span>
+
+          {formError && (
+            <div className="dialog-error">
+              <p>{formError}</p>
+              {offenders && (
+                <>
+                  <p className="permissions-metadata-accounts">Accounts: {offenders}</p>
+                  <button
+                    type="button"
+                    className="btn permissions-strip-offenders"
+                    onClick={stripOffenders}
+                  >
+                    Remove these accounts
+                  </button>
+                </>
+              )}
+            </div>
+          )}
+
+          <div className="dialog-actions">
+            <button type="button" className="dialog-cancel" onClick={onClose} disabled={submitting}>
+              Cancel
+            </button>
+            <button type="submit" disabled={submitting || clientInvalid}>
+              {submitting
+                ? 'Submitting…'
+                : `${mode === 'grant' ? 'Grant permission to' : 'Revoke permission from'} ${
+                    effectiveAccounts.length
+                  } account${effectiveAccounts.length === 1 ? '' : 's'}`}
+            </button>
+          </div>
+        </form>
+      )}
+    </Modal>
+  )
+}

--- a/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/CreatePermissionsDialog.test.jsx
+++ b/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/CreatePermissionsDialog.test.jsx
@@ -1,0 +1,609 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+vi.mock('@/context/AuthContext', () => ({ useAuth: vi.fn() }))
+vi.mock('@/api', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, createPermissions: vi.fn(), resyncPermissions: vi.fn(), listUsers: vi.fn() }
+})
+
+import CreatePermissionsDialog from './CreatePermissionsDialog'
+import { useAuth } from '@/context/AuthContext'
+import { createPermissions, resyncPermissions, listUsers, AsyncJobError } from '@/api'
+
+const ALICE = { id: 'u-1', account: 'alice', siteId: 'site-1', engName: 'Alice', chineseName: '', roles: [], active: true, requirePasswordChange: false }
+const BOB = { id: 'u-2', account: 'bob', siteId: 'site-1', engName: 'Bob', chineseName: '', roles: [], active: true, requirePasswordChange: false }
+const CAROL = { id: 'u-3', account: 'carol', siteId: 'site-1', engName: 'Carol', chineseName: '', roles: [], active: true, requirePasswordChange: false }
+const DAVE = { id: 'u-4', account: 'dave', siteId: 'site-1', engName: 'Dave', chineseName: '', roles: [], active: true, requirePasswordChange: false }
+const GHOST = { id: 'u-5', account: 'ghost1', siteId: 'site-1', engName: 'Ghost', chineseName: '', roles: [], active: true, requirePasswordChange: false }
+
+let logout
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  logout = vi.fn()
+  useAuth.mockReturnValue({ logout })
+  listUsers.mockResolvedValue({ users: [], total: 0 })
+})
+
+// Drives one AccountPicker through a real search → select cycle. Requires fake timers
+// to already be active (the picker's search is debounced 300ms).
+async function pick(labelRegex, user) {
+  listUsers.mockResolvedValueOnce({ users: [user], total: 1 })
+  fireEvent.change(screen.getByLabelText(labelRegex), { target: { value: user.account } })
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(300)
+  })
+  fireEvent.click(await screen.findByRole('option', { name: new RegExp(`^${user.account}`, 'i') }))
+}
+
+// Everything the form needs except the subject accounts — lets the paste-mode tests supply
+// the subjects through the textarea instead of the picker.
+async function fillNonSubjectFields({ expiresAt = '2026-12-31' } = {}) {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  try {
+    await pick(/^applicant account$/i, CAROL)
+    await pick(/^approver account$/i, DAVE)
+  } finally {
+    vi.useRealTimers()
+  }
+  if (expiresAt) {
+    fireEvent.change(screen.getByLabelText(/expires at/i), { target: { value: expiresAt } })
+  }
+}
+
+async function fillRequiredPickers({ expiresAt = '2026-12-31' } = {}) {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  try {
+    await pick(/^subject accounts$/i, ALICE)
+  } finally {
+    vi.useRealTimers()
+  }
+  await fillNonSubjectFields({ expiresAt })
+}
+
+function pasteSubjects(text) {
+  fireEvent.click(screen.getByRole('radio', { name: /^paste list/i }))
+  fireEvent.change(screen.getByLabelText(/^subject accounts \(paste list\)$/i), {
+    target: { value: text },
+  })
+}
+
+describe('CreatePermissionsDialog — form', () => {
+  it('renders the form fields with grant mode selected by default', () => {
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    expect(screen.getByRole('radio', { name: /^grant$/i })).toBeChecked()
+    expect(screen.getByRole('radio', { name: /^revoke$/i })).not.toBeChecked()
+    expect(screen.getByLabelText(/^subject accounts$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/effective from/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/expires at/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^applicant account$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^approver account$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^reason/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /grant permission/i })).toBeInTheDocument()
+  })
+
+  it('hides the effectiveFrom/expiresAt date inputs in revoke mode', () => {
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    fireEvent.click(screen.getByRole('radio', { name: /^revoke$/i }))
+    expect(screen.queryByLabelText(/effective from/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/expires at/i)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /revoke permission/i })).toBeInTheDocument()
+  })
+
+  it('disables submit until subjects, applicant, approver, and expires-at are all set', async () => {
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /grant permission/i })).toBeDisabled()
+
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await pick(/^subject accounts$/i, ALICE)
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(screen.getByRole('button', { name: /grant permission/i })).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText(/expires at/i), { target: { value: '2026-12-31' } })
+    expect(screen.getByRole('button', { name: /grant permission/i })).toBeDisabled()
+
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await pick(/^applicant account$/i, CAROL)
+      await pick(/^approver account$/i, DAVE)
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(screen.getByRole('button', { name: /grant permission/i })).toBeEnabled()
+  })
+
+  it('never includes free-typed, unselected text in the submitted subjectAccounts', async () => {
+    createPermissions.mockResolvedValue({ created: 1, duplicatesIgnored: [] })
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await pick(/^subject accounts$/i, ALICE)
+      listUsers.mockResolvedValueOnce({ users: [], total: 0 })
+      fireEvent.change(screen.getByLabelText(/^subject accounts$/i), {
+        target: { value: 'not-a-real-match' },
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300)
+      })
+      await pick(/^applicant account$/i, CAROL)
+      await pick(/^approver account$/i, DAVE)
+    } finally {
+      vi.useRealTimers()
+    }
+    fireEvent.change(screen.getByLabelText(/expires at/i), { target: { value: '2026-12-31' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    await waitFor(() => expect(createPermissions).toHaveBeenCalledTimes(1))
+    const [, payload] = createPermissions.mock.calls[0]
+    expect(payload.subjectAccounts).toEqual(['alice'])
+  })
+
+  it('blocks submit and shows an error when reason exceeds 1000 runes', async () => {
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    const tooLong = 'a'.repeat(1001)
+    fireEvent.change(screen.getByLabelText(/^reason/i), { target: { value: tooLong } })
+
+    expect(screen.getByRole('button', { name: /grant permission/i })).toBeDisabled()
+    expect(screen.getByText(/1001 \/ 1000/)).toBeInTheDocument()
+  })
+
+  it('labels the submit button with the effective account count', async () => {
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    expect(
+      screen.getByRole('button', { name: /^grant permission to 0 accounts$/i }),
+    ).toBeInTheDocument()
+
+    await fillRequiredPickers()
+    expect(
+      screen.getByRole('button', { name: /^grant permission to 1 account$/i }),
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('radio', { name: /^revoke$/i }))
+    expect(
+      screen.getByRole('button', { name: /^revoke permission from 1 account$/i }),
+    ).toBeInTheDocument()
+  })
+})
+
+describe('CreatePermissionsDialog — subject input modes', () => {
+  it('starts in pick mode and swaps the picker for a textarea when paste mode is selected', () => {
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    expect(screen.getByRole('radio', { name: /^pick \(0\)$/i })).toBeChecked()
+    expect(screen.getByLabelText(/^subject accounts$/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/^subject accounts \(paste list\)$/i)).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('radio', { name: /^paste list \(0\)$/i }))
+
+    expect(screen.getByLabelText(/^subject accounts \(paste list\)$/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/^subject accounts$/i)).not.toBeInTheDocument()
+  })
+
+  it('shows the deduped count and the duplicates dropped from a pasted list', () => {
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    pasteSubjects('alice bob,alice\ncarol')
+
+    expect(screen.getByText(/3 accounts \(1 duplicate removed\)/)).toBeInTheDocument()
+  })
+
+  it('shows each mode its own count in the toggle labels', () => {
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    pasteSubjects('alice bob,alice\ncarol')
+
+    expect(screen.getByRole('radio', { name: /^pick \(0\)$/i })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /^paste list \(3\)$/i })).toBeChecked()
+  })
+
+  it('disables submit while the pasted list parses to zero accounts', async () => {
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillNonSubjectFields()
+    pasteSubjects('  \n , ; ')
+
+    expect(screen.getByRole('button', { name: /grant permission/i })).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText(/^subject accounts \(paste list\)$/i), {
+      target: { value: 'alice' },
+    })
+    expect(screen.getByRole('button', { name: /grant permission/i })).toBeEnabled()
+  })
+
+  it('submits the parsed paste list, never merged with the picked accounts', async () => {
+    createPermissions.mockResolvedValue({ created: 2, duplicatesIgnored: [] })
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers() // picks ALICE in pick mode
+    pasteSubjects('bob carol,bob')
+
+    fireEvent.click(screen.getByRole('button', { name: /^grant permission to 2 accounts$/i }))
+
+    await waitFor(() => expect(createPermissions).toHaveBeenCalledTimes(1))
+    const [, payload] = createPermissions.mock.calls[0]
+    expect(payload.subjectAccounts).toEqual(['bob', 'carol'])
+  })
+
+  it('accepts a 250-account paste — the old max-200 client cap is gone', async () => {
+    createPermissions.mockResolvedValue({ created: 250, duplicatesIgnored: [] })
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillNonSubjectFields()
+    const accounts = Array.from({ length: 250 }, (_, i) => `user${i}`)
+    pasteSubjects(accounts.join('\n'))
+
+    expect(screen.queryByText(/at most 200 accounts/i)).not.toBeInTheDocument()
+    const submit = screen.getByRole('button', { name: /^grant permission to 250 accounts$/i })
+    expect(submit).toBeEnabled()
+
+    fireEvent.click(submit)
+
+    await waitFor(() => expect(createPermissions).toHaveBeenCalledTimes(1))
+    const [, payload] = createPermissions.mock.calls[0]
+    expect(payload.subjectAccounts).toEqual(accounts)
+  })
+})
+
+describe('CreatePermissionsDialog — submit', () => {
+  it('submits a grant with the exact payload, omitting effectiveFrom and reason when left blank', async () => {
+    createPermissions.mockResolvedValue({ created: 2, duplicatesIgnored: [] })
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await pick(/^subject accounts$/i, ALICE)
+      await pick(/^subject accounts$/i, BOB)
+      await pick(/^applicant account$/i, CAROL)
+      await pick(/^approver account$/i, DAVE)
+    } finally {
+      vi.useRealTimers()
+    }
+    fireEvent.change(screen.getByLabelText(/expires at/i), { target: { value: '2026-12-31' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    await waitFor(() => expect(createPermissions).toHaveBeenCalledTimes(1))
+    const [token, payload] = createPermissions.mock.calls[0]
+    expect(token).toBe('tok')
+    expect(payload).toEqual({
+      permission: 'external.image.view',
+      subjectAccounts: ['alice', 'bob'],
+      granted: true,
+      expiresAt: '2026-12-31',
+      applicantAccount: 'carol',
+      approverAccount: 'dave',
+    })
+    expect(payload).not.toHaveProperty('effectiveFrom')
+    expect(payload).not.toHaveProperty('reason')
+  })
+
+  it('includes effectiveFrom and reason in the grant payload when filled in', async () => {
+    createPermissions.mockResolvedValue({ created: 1, duplicatesIgnored: [] })
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+    fireEvent.change(screen.getByLabelText(/effective from/i), { target: { value: '2026-09-01' } })
+    fireEvent.change(screen.getByLabelText(/^reason/i), {
+      target: { value: 'On-call staff must review photos.' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    await waitFor(() => expect(createPermissions).toHaveBeenCalledTimes(1))
+    const [, payload] = createPermissions.mock.calls[0]
+    expect(payload.effectiveFrom).toBe('2026-09-01')
+    expect(payload.reason).toBe('On-call staff must review photos.')
+  })
+
+  it('submits a revoke with the window fields omitted entirely', async () => {
+    createPermissions.mockResolvedValue({ created: 1, duplicatesIgnored: [] })
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    fireEvent.click(screen.getByRole('radio', { name: /^revoke$/i }))
+    await fillRequiredPickers({ expiresAt: null })
+
+    fireEvent.click(screen.getByRole('button', { name: /revoke permission/i }))
+
+    await waitFor(() => expect(createPermissions).toHaveBeenCalledTimes(1))
+    const [, payload] = createPermissions.mock.calls[0]
+    expect(payload).toEqual({
+      permission: 'external.image.view',
+      subjectAccounts: ['alice'],
+      granted: false,
+      applicantAccount: 'carol',
+      approverAccount: 'dave',
+    })
+    expect(payload).not.toHaveProperty('effectiveFrom')
+    expect(payload).not.toHaveProperty('expiresAt')
+  })
+
+  it('disables the submit button while the create request is in flight', async () => {
+    let resolveCreate
+    createPermissions.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCreate = resolve
+      }),
+    )
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+    expect(screen.getByRole('button', { name: /submitting/i })).toBeDisabled()
+
+    await act(async () => {
+      resolveCreate({ created: 1, duplicatesIgnored: [] })
+      await Promise.resolve()
+    })
+    expect(await screen.findByText(/created 1 grant/i)).toBeInTheDocument()
+  })
+})
+
+describe('CreatePermissionsDialog — result', () => {
+  it('shows the result content and calls onCreated immediately on success, without closing the dialog', async () => {
+    createPermissions.mockResolvedValue({
+      created: 2,
+      duplicatesIgnored: ['eve'],
+    })
+    const onCreated = vi.fn()
+    const onClose = vi.fn()
+    render(<CreatePermissionsDialog authToken="tok" onClose={onClose} onCreated={onCreated} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    expect(await screen.findByText(/created 2/i)).toBeInTheDocument()
+    expect(screen.getByText(/eve/)).toBeInTheDocument()
+    expect(onCreated).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('renders revoke-specific success copy in revoke mode', async () => {
+    createPermissions.mockResolvedValue({ created: 1, duplicatesIgnored: [] })
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    fireEvent.click(screen.getByRole('radio', { name: /^revoke$/i }))
+    await fillRequiredPickers({ expiresAt: null })
+
+    fireEvent.click(screen.getByRole('button', { name: /revoke permission/i }))
+
+    expect(await screen.findByText(/recorded 1 revocation/i)).toBeInTheDocument()
+    expect(screen.queryByText(/created/i)).not.toBeInTheDocument()
+  })
+
+  it('collapses a long duplicatesIgnored list behind a count', async () => {
+    const dupes = Array.from({ length: 30 }, (_, i) => `dupe${i}`)
+    createPermissions.mockResolvedValue({ created: 1, duplicatesIgnored: dupes })
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    expect(await screen.findByText(/^30 duplicates ignored$/i)).toBeVisible()
+    expect(screen.getByText(dupes.join(', '))).not.toBeVisible()
+  })
+
+  it('keeps a short duplicatesIgnored list inline', async () => {
+    createPermissions.mockResolvedValue({
+      created: 1,
+      duplicatesIgnored: ['eve', 'mallory'],
+    })
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    expect(await screen.findByText(/duplicates ignored: eve, mallory/i)).toBeVisible()
+  })
+
+  it('the Close button in the result view calls onClose', async () => {
+    createPermissions.mockResolvedValue({ created: 1, duplicatesIgnored: [] })
+    const onClose = vi.fn()
+    render(<CreatePermissionsDialog authToken="tok" onClose={onClose} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    expect(await screen.findByRole('button', { name: /^close$/i })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('CreatePermissionsDialog — errors', () => {
+  it('renders the mapped copy and offending accounts when createPermissions rejects with a reason', async () => {
+    createPermissions.mockRejectedValue(
+      new AsyncJobError('unknown accounts: zzz', {
+        code: 'not_found',
+        reason: 'unknown_accounts',
+        metadata: { accounts: 'zzz' },
+      }),
+    )
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    expect(await screen.findByText(/do not exist on this site/i)).toBeInTheDocument()
+    expect(screen.getByText(/zzz/)).toBeInTheDocument()
+  })
+
+  it('logs the admin out instead of showing a banner on invalid_token', async () => {
+    createPermissions.mockRejectedValue(
+      new AsyncJobError('expired', { code: 'unauthenticated', reason: 'invalid_token' }),
+    )
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    await waitFor(() => expect(logout).toHaveBeenCalledTimes(1))
+    expect(screen.queryByText(/expired/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('CreatePermissionsDialog — offender strip', () => {
+  const unknownAccounts = (accounts) =>
+    new AsyncJobError(`unknown accounts: ${accounts}`, {
+      code: 'not_found',
+      reason: 'unknown_accounts',
+      metadata: { accounts },
+    })
+
+  it('removes the offending accounts from the pasted list', async () => {
+    createPermissions.mockRejectedValue(unknownAccounts('ghost1, ghost2'))
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillNonSubjectFields()
+    pasteSubjects('alice ghost1 bob ghost2')
+
+    fireEvent.click(screen.getByRole('button', { name: /^grant permission to 4 accounts$/i }))
+
+    fireEvent.click(await screen.findByRole('button', { name: /^remove these accounts$/i }))
+
+    expect(screen.getByLabelText(/^subject accounts \(paste list\)$/i)).toHaveValue('alice\nbob')
+    expect(screen.getByRole('radio', { name: /^paste list \(2\)$/i })).toBeChecked()
+    expect(screen.queryByText(/do not exist on this site/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^remove these accounts$/i })).not.toBeInTheDocument()
+  })
+
+  it('removes the offending accounts from the picked selection', async () => {
+    createPermissions.mockRejectedValue(unknownAccounts('ghost1'))
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await pick(/^subject accounts$/i, ALICE)
+      await pick(/^subject accounts$/i, GHOST)
+    } finally {
+      vi.useRealTimers()
+    }
+    await fillNonSubjectFields()
+
+    fireEvent.click(screen.getByRole('button', { name: /^grant permission to 2 accounts$/i }))
+
+    fireEvent.click(await screen.findByRole('button', { name: /^remove these accounts$/i }))
+
+    expect(screen.queryByRole('button', { name: /^remove ghost1$/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^remove alice$/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /^grant permission to 1 account$/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('offers no strip button when the error carries no offending accounts', async () => {
+    createPermissions.mockRejectedValue(
+      new AsyncJobError('subject deactivated', { code: 'conflict', reason: 'inactive_subject' }),
+    )
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    expect(await screen.findByText(/deactivated/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^remove these accounts$/i })).not.toBeInTheDocument()
+  })
+})
+
+describe('CreatePermissionsDialog — sync failures', () => {
+  const withFailures = (syncFailures) => ({
+    created: 2,
+    duplicatesIgnored: [],
+    syncFailures,
+  })
+
+  it('warns which sites did not acknowledge the sync and offers a resend', async () => {
+    createPermissions.mockResolvedValue(withFailures(['site-b']))
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    expect(await screen.findByText(/sync failed for: site-b/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^resend sync$/i })).toBeEnabled()
+  })
+
+  it('shows no sync banner when the response carries no syncFailures', async () => {
+    createPermissions.mockResolvedValue({ created: 1, duplicatesIgnored: [] })
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+
+    expect(await screen.findByText(/created 1 grant/i)).toBeInTheDocument()
+    expect(screen.queryByText(/sync failed/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/sync complete/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^resend sync$/i })).not.toBeInTheDocument()
+  })
+
+  it('resends the just-submitted request, not the picker selection left behind', async () => {
+    createPermissions.mockResolvedValue(withFailures(['site-b']))
+    resyncPermissions.mockResolvedValue({})
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers() // picks ALICE in pick mode
+    pasteSubjects('bob carol')
+
+    fireEvent.click(screen.getByRole('button', { name: /^grant permission to 2 accounts$/i }))
+
+    fireEvent.click(await screen.findByRole('button', { name: /^resend sync$/i }))
+
+    await waitFor(() => expect(resyncPermissions).toHaveBeenCalledTimes(1))
+    expect(resyncPermissions.mock.calls[0]).toEqual([
+      'tok',
+      { permission: 'external.image.view', accounts: ['bob', 'carol'] },
+    ])
+  })
+
+  it('locks the resend button in flight and reports sync complete when it succeeds', async () => {
+    createPermissions.mockResolvedValue(withFailures(['site-b']))
+    let resolveResync
+    resyncPermissions.mockReturnValue(
+      new Promise((resolve) => {
+        resolveResync = resolve
+      }),
+    )
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /^resend sync$/i }))
+
+    expect(screen.getByRole('button', { name: /resending/i })).toBeDisabled()
+
+    await act(async () => {
+      resolveResync({})
+      await Promise.resolve()
+    })
+
+    expect(await screen.findByText(/^sync complete\.$/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^resend sync$/i })).not.toBeInTheDocument()
+  })
+
+  it('keeps the resend button when the resync still reports failures', async () => {
+    createPermissions.mockResolvedValue(withFailures(['site-b']))
+    resyncPermissions.mockResolvedValue({ syncFailures: ['site-c'] })
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /^resend sync$/i }))
+
+    await waitFor(() => expect(resyncPermissions).toHaveBeenCalledTimes(1))
+    expect(await screen.findByText(/sync failed for: site-c/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^resend sync$/i })).toBeEnabled()
+    expect(screen.queryByText(/sync complete/i)).not.toBeInTheDocument()
+  })
+
+  it('surfaces a failed resend without losing the banner', async () => {
+    createPermissions.mockResolvedValue(withFailures(['site-b']))
+    resyncPermissions.mockRejectedValue(
+      new AsyncJobError('boom', { code: 'internal', reason: 'internal' }),
+    )
+    render(<CreatePermissionsDialog authToken="tok" onClose={vi.fn()} onCreated={vi.fn()} />)
+    await fillRequiredPickers()
+
+    fireEvent.click(screen.getByRole('button', { name: /grant permission/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /^resend sync$/i }))
+
+    await waitFor(() => expect(resyncPermissions).toHaveBeenCalledTimes(1))
+    expect(await screen.findByText(/^boom$/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^resend sync$/i })).toBeEnabled()
+  })
+})

--- a/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/index.jsx
+++ b/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './CreatePermissionsDialog'

--- a/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/parseAccounts.js
+++ b/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/parseAccounts.js
@@ -1,0 +1,18 @@
+// Splits a pasted account list on whitespace/commas/semicolons, deduplicating while
+// preserving first-occurrence order. Accounts are kept verbatim (no case folding),
+// matching backend semantics.
+export function parsePastedAccounts(text) {
+  const seen = new Set()
+  const accounts = []
+  let duplicates = 0
+  for (const token of text.split(/[\s,;]+/)) {
+    if (!token) continue
+    if (seen.has(token)) {
+      duplicates += 1
+      continue
+    }
+    seen.add(token)
+    accounts.push(token)
+  }
+  return { accounts, duplicates }
+}

--- a/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/parseAccounts.test.js
+++ b/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/parseAccounts.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { parsePastedAccounts } from './parseAccounts'
+
+describe('parsePastedAccounts', () => {
+  it.each([
+    ['spaces', 'alice bob carol'],
+    ['newlines', 'alice\nbob\ncarol'],
+    ['commas', 'alice,bob,carol'],
+    ['semicolons', 'alice;bob;carol'],
+    ['tabs', 'alice\tbob\tcarol'],
+    ['mixed separators', 'alice, bob;\n\tcarol'],
+  ])('splits on %s', (_name, text) => {
+    expect(parsePastedAccounts(text)).toEqual({ accounts: ['alice', 'bob', 'carol'], duplicates: 0 })
+  })
+
+  it('trims surrounding whitespace and drops empty tokens', () => {
+    expect(parsePastedAccounts('  alice ,, \n\n bob ; \t')).toEqual({
+      accounts: ['alice', 'bob'],
+      duplicates: 0,
+    })
+  })
+
+  it('dedups preserving first occurrence and counts the dropped duplicates', () => {
+    expect(parsePastedAccounts('bob alice,bob\ncarol bob')).toEqual({
+      accounts: ['bob', 'alice', 'carol'],
+      duplicates: 2,
+    })
+  })
+
+  it('keeps accounts verbatim — no case folding (matches backend semantics)', () => {
+    expect(parsePastedAccounts('Alice alice ALICE')).toEqual({
+      accounts: ['Alice', 'alice', 'ALICE'],
+      duplicates: 0,
+    })
+  })
+
+  it('returns an empty result for an empty string', () => {
+    expect(parsePastedAccounts('')).toEqual({ accounts: [], duplicates: 0 })
+  })
+
+  it('returns an empty result for whitespace/separators only', () => {
+    expect(parsePastedAccounts(' \n,\t; ')).toEqual({ accounts: [], duplicates: 0 })
+  })
+})

--- a/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/style.css
+++ b/admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/style.css
@@ -1,0 +1,91 @@
+.permissions-form-subtitle {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  margin: calc(-1 * var(--space-sm)) 0 0;
+}
+
+.permissions-mode-group {
+  display: flex;
+  gap: var(--space-lg);
+}
+
+.permissions-mode-option {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  margin-top: 0;
+  font-weight: var(--font-medium);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.permissions-mode-option input {
+  accent-color: var(--accent);
+}
+
+.permissions-reason-textarea,
+.permissions-paste-textarea {
+  min-height: 72px;
+  resize: vertical;
+}
+
+.permissions-subjects-count,
+.permissions-reason-count {
+  display: block;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.permissions-date-row {
+  display: flex;
+  gap: var(--space-lg);
+}
+
+.permissions-date-field {
+  flex: 1;
+}
+
+.permissions-date-field label {
+  display: block;
+}
+
+.permissions-result {
+  margin-top: 0;
+}
+
+.permissions-duplicates {
+  margin-top: var(--space-xs);
+}
+
+.permissions-duplicates summary {
+  cursor: pointer;
+}
+
+.permissions-metadata-accounts {
+  margin-top: var(--space-xs);
+}
+
+.permissions-strip-offenders {
+  margin-top: var(--space-sm);
+}
+
+/* Partial failure: the write landed, only the fan-out to some sites did not. */
+.permissions-sync-warning {
+  margin-top: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--status-error-bg);
+  color: var(--status-error);
+  border: 1px solid var(--status-error);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+}
+
+.permissions-sync-warning button {
+  margin-top: var(--space-sm);
+}
+
+.permissions-sync-ok {
+  margin-top: var(--space-sm);
+  color: var(--status-success);
+  font-size: var(--text-sm);
+}

--- a/admin-frontend/src/components/PermissionsView/PermissionsPage/PermissionsPage.jsx
+++ b/admin-frontend/src/components/PermissionsView/PermissionsPage/PermissionsPage.jsx
@@ -1,0 +1,118 @@
+import { lazy, Suspense, useState } from 'react'
+import { listPermissions } from '@/api'
+import { useAuth } from '@/context/AuthContext'
+import { usePagedAdminList } from '@/hooks/usePagedAdminList'
+import LazyFallback from '@/components/shared/LazyFallback'
+import Pager from '@/components/shared/Pager'
+import PermissionsTable from '../PermissionsTable'
+import { PERMISSION_KEY } from '../permissionKey'
+import './style.css'
+
+const CreatePermissionsDialog = lazy(() => import('../CreatePermissionsDialog'))
+
+// Matches admin-service's parsePaging default limit (handler.go).
+const PAGE_SIZE = 20
+
+const DEFAULT_FILTERS = { subjectAccount: '', permission: '' }
+
+// Only include a filter param when the caller actually set it — mirrors AuditView's
+// buildFilterParams so the wire call stays `{}` (all rows, newest-first) at rest.
+function buildFilterParams(filters) {
+  const params = {}
+  if (filters.subjectAccount) params.subjectAccount = filters.subjectAccount
+  if (filters.permission) params.permission = filters.permission
+  return params
+}
+
+// Settings → Permissions console: list-first, mirroring UsersConsole/UsersPage. Unfiltered shows
+// page 1 of every row for the site (admin-service now supports both filters being optional).
+// "Create" opens the grant/revoke dialog; a successful submit refreshes this list immediately.
+export default function PermissionsPage() {
+  const { session } = useAuth()
+  const authToken = session?.authToken
+  const [showCreate, setShowCreate] = useState(false)
+
+  const {
+    data,
+    entries,
+    total,
+    page,
+    filters,
+    loading,
+    error,
+    notAuthorized,
+    updateFilter,
+    goToPage,
+    refresh,
+  } = usePagedAdminList({
+    authToken,
+    fetcher: (token, f, paging) => listPermissions(token, { ...buildFilterParams(f), ...paging }),
+    defaultFilters: DEFAULT_FILTERS,
+    pageSize: PAGE_SIZE,
+  })
+
+  if (notAuthorized) {
+    return (
+      <div className="permissions-page permissions-page-not-authorized">
+        <p>You are not authorized to manage permissions.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="permissions-page">
+      <div className="permissions-page-header">
+        <input
+          type="text"
+          className="permissions-filter-input"
+          aria-label="Filter by subject account"
+          placeholder="Subject account"
+          value={filters.subjectAccount}
+          onChange={(e) => updateFilter('subjectAccount', e.target.value)}
+        />
+        <select
+          className="permissions-filter-select"
+          aria-label="Filter by permission"
+          value={filters.permission}
+          onChange={(e) => updateFilter('permission', e.target.value)}
+        >
+          <option value="">All permissions</option>
+          <option value={PERMISSION_KEY}>{PERMISSION_KEY}</option>
+        </select>
+        <span className="permissions-page-total">{total} entries</span>
+        <button type="button" className="btn btn-primary" onClick={() => setShowCreate(true)}>
+          Create
+        </button>
+      </div>
+
+      {error && <div className="dialog-error">{error}</div>}
+
+      {data?.currentlyGranted === true && (
+        <span className="status-badge is-granted">Currently granted</span>
+      )}
+      {data?.currentlyGranted === false && (
+        <span className="status-badge is-not-granted">Not granted</span>
+      )}
+
+      <PermissionsTable entries={entries} loading={loading} />
+
+      <Pager
+        page={page}
+        limit={PAGE_SIZE}
+        total={total}
+        onPrev={() => goToPage(page - 1)}
+        onNext={() => goToPage(page + 1)}
+      />
+
+      {showCreate && (
+        <Suspense fallback={<LazyFallback variant="dialog" />}>
+          <CreatePermissionsDialog
+            authToken={authToken}
+            onClose={() => setShowCreate(false)}
+            onCreated={refresh}
+          />
+        </Suspense>
+      )}
+    </div>
+  )
+}

--- a/admin-frontend/src/components/PermissionsView/PermissionsPage/PermissionsPage.test.jsx
+++ b/admin-frontend/src/components/PermissionsView/PermissionsPage/PermissionsPage.test.jsx
@@ -1,0 +1,340 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+vi.mock('@/context/AuthContext', () => ({ useAuth: vi.fn() }))
+vi.mock('@/api', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, listPermissions: vi.fn() }
+})
+
+vi.mock('../CreatePermissionsDialog', () => ({
+  default: ({ onClose, onCreated }) => (
+    <div role="dialog" aria-label="create permissions">
+      <button type="button" onClick={onCreated}>
+        Fake create
+      </button>
+      <button type="button" onClick={onClose}>
+        Fake close
+      </button>
+    </div>
+  ),
+}))
+
+import PermissionsPage from './PermissionsPage'
+import { useAuth } from '@/context/AuthContext'
+import { listPermissions, AsyncJobError } from '@/api'
+
+const GRANT_ROW = {
+  id: 'g-1',
+  permission: 'external.image.view',
+  subjectAccount: 'alice',
+  granted: true,
+  effectiveFrom: '2026-09-01',
+  expiresAt: '2026-12-31',
+  applicantAccount: 'carol',
+  approverAccount: 'dave',
+  reason: 'Business trip.',
+  recordedBy: 'p_admin_wang',
+  recordedAt: '2026-08-11T03:00:00Z',
+}
+
+const REVOKE_ROW = {
+  id: 'g-2',
+  permission: 'external.image.view',
+  subjectAccount: 'alice',
+  granted: false,
+  applicantAccount: 'carol',
+  approverAccount: 'dave',
+  reason: 'Project ended.',
+  recordedBy: 'p_admin_wang',
+  recordedAt: '2026-08-12T03:00:00Z',
+}
+
+let logout
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  logout = vi.fn()
+  useAuth.mockReturnValue({
+    session: { authToken: 'tok', account: 'root', siteId: 'site-1' },
+    logout,
+  })
+  listPermissions.mockResolvedValue({ entries: [], total: 0 })
+})
+
+describe('PermissionsPage — list', () => {
+  it('calls listPermissions(token, {page:1, limit:20}) on mount with no filters and renders rows', async () => {
+    listPermissions.mockResolvedValue({ entries: [GRANT_ROW, REVOKE_ROW], total: 2 })
+    render(<PermissionsPage />)
+    await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 1, limit: 20 }))
+
+    const rows = await screen.findAllByRole('row')
+    expect(rows).toHaveLength(3)
+    expect(rows[1]).toHaveTextContent('alice')
+    expect(rows[1]).toHaveTextContent('Grant')
+    expect(rows[1]).toHaveTextContent('2026-09-01')
+    expect(rows[1]).toHaveTextContent('2026-12-31')
+    expect(rows[2]).toHaveTextContent('Revoke')
+    expect(rows[2]).toHaveTextContent('—')
+  })
+
+  it('shows a status message when the list is empty', async () => {
+    render(<PermissionsPage />)
+    expect(await screen.findByText(/no permission records found/i)).toBeInTheDocument()
+  })
+
+  it('re-queries with {subjectAccount} after the filter input debounces', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      render(<PermissionsPage />)
+      await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 1, limit: 20 }))
+
+      fireEvent.change(screen.getByLabelText(/filter by subject account/i), {
+        target: { value: 'alice' },
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400)
+      })
+
+      await waitFor(() =>
+        expect(listPermissions).toHaveBeenCalledWith('tok', {
+          subjectAccount: 'alice',
+          page: 1,
+          limit: 20,
+        }),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('re-queries with {permission} after the permission select debounces', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      render(<PermissionsPage />)
+      await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 1, limit: 20 }))
+
+      fireEvent.change(screen.getByLabelText(/filter by permission/i), {
+        target: { value: 'external.image.view' },
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400)
+      })
+
+      await waitFor(() =>
+        expect(listPermissions).toHaveBeenCalledWith('tok', {
+          permission: 'external.image.view',
+          page: 1,
+          limit: 20,
+        }),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('combines both filters into one fetch call once both have been set', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      render(<PermissionsPage />)
+      await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 1, limit: 20 }))
+
+      fireEvent.change(screen.getByLabelText(/filter by subject account/i), {
+        target: { value: 'alice' },
+      })
+      fireEvent.change(screen.getByLabelText(/filter by permission/i), {
+        target: { value: 'external.image.view' },
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400)
+      })
+
+      await waitFor(() =>
+        expect(listPermissions).toHaveBeenCalledWith('tok', {
+          subjectAccount: 'alice',
+          permission: 'external.image.view',
+          page: 1,
+          limit: 20,
+        }),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('shows the "Currently granted" badge only when currentlyGranted is true', async () => {
+    listPermissions.mockResolvedValue({ entries: [GRANT_ROW], total: 1, currentlyGranted: true })
+    render(<PermissionsPage />)
+    expect(await screen.findByText(/currently granted/i)).toBeInTheDocument()
+  })
+
+  it('shows the "Not granted" badge when currentlyGranted is false', async () => {
+    listPermissions.mockResolvedValue({ entries: [REVOKE_ROW], total: 1, currentlyGranted: false })
+    render(<PermissionsPage />)
+    expect(await screen.findByText(/^not granted$/i)).toBeInTheDocument()
+  })
+
+  it('shows no badge when currentlyGranted is absent from the response', async () => {
+    render(<PermissionsPage />)
+    await waitFor(() => expect(listPermissions).toHaveBeenCalled())
+    expect(screen.queryByText(/currently granted/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/^not granted$/i)).not.toBeInTheDocument()
+  })
+
+  it('renders a not-authorized state on a 403 not_admin error', async () => {
+    listPermissions.mockRejectedValue(
+      new AsyncJobError('forbidden', { code: 'forbidden', reason: 'not_admin' }),
+    )
+    render(<PermissionsPage />)
+    expect(await screen.findByText(/not authorized/i)).toBeInTheDocument()
+    expect(logout).not.toHaveBeenCalled()
+  })
+
+  it('shows a formatted error banner for other failures', async () => {
+    listPermissions.mockRejectedValue(new AsyncJobError('boom', { code: 'internal' }))
+    render(<PermissionsPage />)
+    expect(await screen.findByText(/boom/i)).toBeInTheDocument()
+    expect(logout).not.toHaveBeenCalled()
+  })
+
+  it('logs the admin out instead of showing a banner on invalid_token', async () => {
+    listPermissions.mockRejectedValue(
+      new AsyncJobError('expired', { code: 'unauthenticated', reason: 'invalid_token' }),
+    )
+    render(<PermissionsPage />)
+    await waitFor(() => expect(logout).toHaveBeenCalledTimes(1))
+    expect(screen.queryByText(/expired/i)).not.toBeInTheDocument()
+  })
+
+  describe('pagination', () => {
+    it('disables Prev on page 1 and requests page 2 on Next', async () => {
+      listPermissions.mockResolvedValue({ entries: [GRANT_ROW], total: 50 })
+      render(<PermissionsPage />)
+      await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 1, limit: 20 }))
+      expect(screen.getByRole('button', { name: /prev/i })).toBeDisabled()
+
+      fireEvent.click(screen.getByRole('button', { name: /next/i }))
+      await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 2, limit: 20 }))
+    })
+
+    it('resets to page 1 when a filter changes', async () => {
+      listPermissions.mockResolvedValue({ entries: [GRANT_ROW], total: 50 })
+      vi.useFakeTimers({ shouldAdvanceTime: true })
+      try {
+        render(<PermissionsPage />)
+        await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 1, limit: 20 }))
+
+        fireEvent.click(screen.getByRole('button', { name: /next/i }))
+        await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 2, limit: 20 }))
+
+        fireEvent.change(screen.getByLabelText(/filter by subject account/i), {
+          target: { value: 'alice' },
+        })
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(400)
+        })
+
+        await waitFor(() =>
+          expect(listPermissions).toHaveBeenCalledWith('tok', {
+            subjectAccount: 'alice',
+            page: 1,
+            limit: 20,
+          }),
+        )
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+
+  it('drops a stale out-of-order response so a slow earlier request cannot overwrite newer rows', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      render(<PermissionsPage />)
+      await waitFor(() => expect(listPermissions).toHaveBeenCalledWith('tok', { page: 1, limit: 20 }))
+
+      let resolveSlow
+      const slow = new Promise((resolve) => {
+        resolveSlow = resolve
+      })
+      listPermissions.mockReturnValueOnce(slow)
+      fireEvent.change(screen.getByLabelText(/filter by subject account/i), {
+        target: { value: 'first' },
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400)
+      })
+      await waitFor(() =>
+        expect(listPermissions).toHaveBeenCalledWith('tok', {
+          subjectAccount: 'first',
+          page: 1,
+          limit: 20,
+        }),
+      )
+
+      listPermissions.mockResolvedValueOnce({
+        entries: [{ ...GRANT_ROW, id: 'g-3', subjectAccount: 'second' }],
+        total: 1,
+      })
+      fireEvent.change(screen.getByLabelText(/filter by subject account/i), {
+        target: { value: 'second' },
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400)
+      })
+      await waitFor(() =>
+        expect(listPermissions).toHaveBeenCalledWith('tok', {
+          subjectAccount: 'second',
+          page: 1,
+          limit: 20,
+        }),
+      )
+
+      await waitFor(() => expect(screen.getByText('second')).toBeInTheDocument())
+
+      await act(async () => {
+        resolveSlow({ entries: [{ ...GRANT_ROW, id: 'g-1', subjectAccount: 'alice' }], total: 1 })
+        await Promise.resolve()
+      })
+
+      expect(screen.queryByText('alice')).not.toBeInTheDocument()
+      expect(screen.getByText('second')).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('PermissionsPage — create dialog', () => {
+  it('opens CreatePermissionsDialog when "Create" is clicked', async () => {
+    render(<PermissionsPage />)
+    await waitFor(() => expect(listPermissions).toHaveBeenCalled())
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('refetches the list when the dialog reports a successful create, keeping the dialog open', async () => {
+    render(<PermissionsPage />)
+    await waitFor(() => expect(listPermissions).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /fake create/i }))
+
+    await waitFor(() => expect(listPermissions).toHaveBeenCalledTimes(2))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('closes the dialog when it reports close', async () => {
+    render(<PermissionsPage />)
+    await waitFor(() => expect(listPermissions).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /fake close/i }))
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+})

--- a/admin-frontend/src/components/PermissionsView/PermissionsPage/index.jsx
+++ b/admin-frontend/src/components/PermissionsView/PermissionsPage/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './PermissionsPage'

--- a/admin-frontend/src/components/PermissionsView/PermissionsPage/style.css
+++ b/admin-frontend/src/components/PermissionsView/PermissionsPage/style.css
@@ -1,4 +1,4 @@
-.audit-view {
+.permissions-page {
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
@@ -7,21 +7,21 @@
   overflow-y: auto;
 }
 
-.audit-view-not-authorized {
+.permissions-page-not-authorized {
+  display: flex;
   align-items: center;
   justify-content: center;
   color: var(--text-muted);
 }
 
-.audit-view-header {
+.permissions-page-header {
   display: flex;
   align-items: center;
   gap: var(--space-md);
 }
 
-.audit-filter-input {
-  flex: 1;
-  max-width: 240px;
+.permissions-filter-input,
+.permissions-filter-select {
   padding: var(--space-sm) var(--space-md);
   background: var(--bg-input);
   border: 1px solid transparent;
@@ -30,20 +30,24 @@
   font: inherit;
 }
 
-.audit-filter-input:focus {
+.permissions-filter-input {
+  flex: 1;
+  max-width: 240px;
+}
+
+.permissions-filter-input:focus,
+.permissions-filter-select:focus {
   outline: none;
   background: var(--bg-surface);
   border-color: var(--accent);
 }
 
-.audit-view-total {
+.permissions-page-total {
   color: var(--text-muted);
   font-size: var(--text-sm);
-  white-space: nowrap;
 }
 
-.audit-table-status {
-  color: var(--text-muted);
-  font-size: var(--text-sm);
-  padding: var(--space-lg);
+/* Direct child of the page's flex column — don't let it stretch the full width. */
+.permissions-page .status-badge {
+  align-self: flex-start;
 }

--- a/admin-frontend/src/components/PermissionsView/PermissionsTable/PermissionsTable.jsx
+++ b/admin-frontend/src/components/PermissionsView/PermissionsTable/PermissionsTable.jsx
@@ -1,0 +1,50 @@
+import './style.css'
+
+// Presentational — no state, no api/ imports, mirrors UsersConsole/UserTable. Unlike the old
+// single-subject ledger table, the list can now span multiple subjects/permissions at once
+// (unfiltered or permission-only queries), so both columns are always shown.
+export default function PermissionsTable({ entries, loading }) {
+  if (loading) {
+    return <div className="permissions-table-status">Loading…</div>
+  }
+  if (entries.length === 0) {
+    return <div className="permissions-table-status">No permission records found.</div>
+  }
+
+  return (
+    <table className="data-table permissions-table">
+      <thead>
+        <tr>
+          <th>Subject</th>
+          <th>Permission</th>
+          <th>Change</th>
+          <th>Effective from</th>
+          <th>Expires at</th>
+          <th>Applicant</th>
+          <th>Approver</th>
+          <th>Reason</th>
+          <th>Recorded by</th>
+          <th>Recorded at</th>
+        </tr>
+      </thead>
+      <tbody>
+        {entries.map((entry) => (
+          <tr key={entry.id}>
+            <td>{entry.subjectAccount}</td>
+            <td>{entry.permission}</td>
+            <td>{entry.granted ? 'Grant' : 'Revoke'}</td>
+            {/* Civil dates ("YYYY-MM-DD") render verbatim — no Date parsing, matching the
+                fixed-UTC+8 write-time rule (design doc §8): the UI performs no timezone math. */}
+            <td>{entry.effectiveFrom ?? '—'}</td>
+            <td>{entry.expiresAt ?? '—'}</td>
+            <td>{entry.applicantAccount}</td>
+            <td>{entry.approverAccount}</td>
+            <td>{entry.reason}</td>
+            <td>{entry.recordedBy}</td>
+            <td>{new Date(entry.recordedAt).toLocaleString()}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/admin-frontend/src/components/PermissionsView/PermissionsTable/index.jsx
+++ b/admin-frontend/src/components/PermissionsView/PermissionsTable/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './PermissionsTable'

--- a/admin-frontend/src/components/PermissionsView/PermissionsTable/style.css
+++ b/admin-frontend/src/components/PermissionsView/PermissionsTable/style.css
@@ -1,0 +1,12 @@
+/* Chrome comes from the shared .data-table base; only the reason column needs more. */
+.permissions-table td {
+  /* A 1000-rune reason can be one unbroken token (no spaces) — let it wrap
+     instead of blowing out the table width. */
+  overflow-wrap: anywhere;
+}
+
+.permissions-table-status {
+  padding: var(--space-xl);
+  text-align: center;
+  color: var(--text-muted);
+}

--- a/admin-frontend/src/components/PermissionsView/index.jsx
+++ b/admin-frontend/src/components/PermissionsView/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './PermissionsPage'

--- a/admin-frontend/src/components/PermissionsView/permissionKey.js
+++ b/admin-frontend/src/components/PermissionsView/permissionKey.js
@@ -1,0 +1,3 @@
+// Sole known permission key today (design doc §1) — no picker needed until a second key ships.
+// Shared by PermissionsPage (filter select) and CreatePermissionsDialog (grant/revoke payload).
+export const PERMISSION_KEY = 'external.image.view'

--- a/admin-frontend/src/components/shared/AccountPicker/AccountPicker.jsx
+++ b/admin-frontend/src/components/shared/AccountPicker/AccountPicker.jsx
@@ -1,0 +1,163 @@
+import { useState } from 'react'
+import { listUsers } from '@/api'
+import { useHandleAdminError } from '@/hooks/useHandleAdminError'
+import { useDebouncedSearch } from '@/hooks/useDebouncedSearch'
+import { useLatestRequest } from '@/hooks/useLatestRequest'
+import './style.css'
+
+const SEARCH_LIMIT = 10
+
+// Search-to-select account field: typing queries the admin users API (debounced) and only an
+// account present in the results can be selected — free-typed text is never committed via
+// `onChange`, so it can never reach a submit payload. `multiple` renders removable chips backed
+// by an array `value`; single mode holds one account string and hides the input once set.
+export default function AccountPicker({ id, label, authToken, multiple = false, value, onChange, disabled }) {
+  const [options, setOptions] = useState([])
+  const [open, setOpen] = useState(false)
+  // Index into `options`, not a selected account: this is the ARIA-1.2 combobox active
+  // descendant, so focus stays on the input and only `aria-activedescendant` moves.
+  // Reset to 0 wherever `options` is replaced, so it can never dangle past the end.
+  const [highlight, setHighlight] = useState(0)
+  const handleAdminError = useHandleAdminError()
+  const { begin, isCurrent } = useLatestRequest()
+
+  const selected = multiple ? value : value ? [value] : []
+
+  const search = async (q) => {
+    // Stamp every invocation — including the empty-query short-circuit below — so a
+    // still-in-flight older request (e.g. "al" resolving after "ali", or after the field was
+    // cleared) can never win a race and overwrite fresher/cleared state (see
+    // useLatestRequest's own doc comment).
+    const token = begin()
+    if (!q) {
+      setOptions([])
+      setOpen(false)
+      return
+    }
+    try {
+      const result = await listUsers(authToken, { q, page: 1, limit: SEARCH_LIMIT })
+      if (!isCurrent(token)) return // superseded by a newer query
+      setOptions(result.users.filter((u) => !selected.includes(u.account)))
+      setHighlight(0)
+      setOpen(true)
+    } catch (err) {
+      if (!isCurrent(token)) return
+      setOptions([])
+      setOpen(false)
+      handleAdminError(err) // invalid_token logs out; other errors just leave the dropdown empty
+    }
+  }
+
+  const { query, setQuery } = useDebouncedSearch({ onSearch: search })
+
+  const select = (account) => {
+    if (multiple) {
+      if (!value.includes(account)) onChange([...value, account])
+      // Keep the dropdown open (minus the just-picked match) so several accounts from the
+      // same search can be added in a row without re-typing the query each time.
+      setOptions((prev) => prev.filter((u) => u.account !== account))
+      setHighlight(0)
+    } else {
+      onChange(account)
+      setQuery('')
+      setOptions([])
+      setOpen(false)
+    }
+  }
+
+  const optionId = (i) => `${id}-option-${i}`
+  const listOpen = open && options.length > 0
+
+  const onKeyDown = (e) => {
+    if (e.key === 'Escape') {
+      setOpen(false)
+      return
+    }
+    if (!['ArrowDown', 'ArrowUp', 'Enter'].includes(e.key)) return
+    if (!listOpen) {
+      // ArrowDown re-opens a list closed by Escape; without it the only way back is
+      // re-typing the query. Enter/ArrowUp on a closed list fall through to the form.
+      if (e.key === 'ArrowDown' && options.length > 0) {
+        e.preventDefault()
+        setOpen(true)
+      }
+      return
+    }
+    // preventDefault on all three: the arrows would otherwise jump the caret to the
+    // start/end of the input, and Enter would submit the form this picker sits in.
+    e.preventDefault()
+    if (e.key === 'Enter') select(options[highlight].account)
+    else setHighlight((i) => (i + (e.key === 'ArrowDown' ? 1 : options.length - 1)) % options.length)
+  }
+
+  const remove = (account) => {
+    onChange(multiple ? value.filter((a) => a !== account) : '')
+  }
+
+  const showInput = multiple || selected.length === 0
+
+  return (
+    <div className="account-picker">
+      <label htmlFor={id}>{label}</label>
+      {selected.length > 0 && (
+        <ul className="account-picker-chips">
+          {selected.map((account) => (
+            <li key={account} className="account-picker-chip">
+              <span>{account}</span>
+              <button
+                type="button"
+                aria-label={`Remove ${account}`}
+                onClick={() => remove(account)}
+                disabled={disabled}
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {showInput && (
+        <div className="account-picker-input-wrap">
+          <input
+            id={id}
+            type="text"
+            autoComplete="off"
+            role="combobox"
+            aria-expanded={listOpen}
+            aria-controls={`${id}-listbox`}
+            aria-activedescendant={listOpen ? optionId(highlight) : undefined}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onFocus={() => options.length > 0 && setOpen(true)}
+            onBlur={() => setOpen(false)}
+            onKeyDown={onKeyDown}
+            disabled={disabled}
+          />
+          {listOpen && (
+            <ul
+              id={`${id}-listbox`}
+              className="account-picker-options"
+              role="listbox"
+              // Keeps focus on the input across the click so `onBlur` above doesn't close the
+              // dropdown before the option's own onClick has a chance to run.
+              onMouseDown={(e) => e.preventDefault()}
+            >
+              {options.map((u, i) => (
+                <li
+                  key={u.account}
+                  id={optionId(i)}
+                  role="option"
+                  aria-selected={i === highlight}
+                  onClick={() => select(u.account)}
+                >
+                  {u.account}
+                  {u.engName ? ` (${u.engName})` : ''}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/admin-frontend/src/components/shared/AccountPicker/AccountPicker.test.jsx
+++ b/admin-frontend/src/components/shared/AccountPicker/AccountPicker.test.jsx
@@ -1,0 +1,396 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+vi.mock('@/context/AuthContext', () => ({ useAuth: vi.fn() }))
+vi.mock('@/api', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, listUsers: vi.fn() }
+})
+
+import AccountPicker from './AccountPicker'
+import { useAuth } from '@/context/AuthContext'
+import { listUsers, AsyncJobError } from '@/api'
+
+const ALICE = {
+  id: 'u-1',
+  account: 'alice',
+  siteId: 'site-1',
+  engName: 'Alice',
+  chineseName: '',
+  roles: [],
+  active: true,
+  requirePasswordChange: false,
+}
+const BOB = {
+  id: 'u-2',
+  account: 'bob',
+  siteId: 'site-1',
+  engName: 'Bob',
+  chineseName: '',
+  roles: [],
+  active: true,
+  requirePasswordChange: false,
+}
+
+let logout
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  logout = vi.fn()
+  useAuth.mockReturnValue({ logout })
+  listUsers.mockResolvedValue({ users: [], total: 0 })
+})
+
+async function typeAndWait(input, text) {
+  fireEvent.change(input, { target: { value: text } })
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(300)
+  })
+}
+
+describe('AccountPicker — single select', () => {
+  it('does not query listUsers on mount', () => {
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={vi.fn()} />)
+    expect(listUsers).not.toHaveBeenCalled()
+  })
+
+  it('queries listUsers debounced as the admin types and lists matches', async () => {
+    listUsers.mockResolvedValue({ users: [ALICE], total: 1 })
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={vi.fn()} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/applicant/i), 'ali')
+      expect(listUsers).toHaveBeenCalledWith('tok', { q: 'ali', page: 1, limit: 10 })
+      expect(await screen.findByRole('option', { name: /alice/i })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('selects a matched account on click, committing it via onChange', async () => {
+    listUsers.mockResolvedValue({ users: [ALICE], total: 1 })
+    const onChange = vi.fn()
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={onChange} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/applicant/i), 'ali')
+      fireEvent.click(await screen.findByRole('option', { name: /alice/i }))
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(onChange).toHaveBeenCalledWith('alice')
+  })
+
+  it('never commits free-typed text that was not selected from the results', async () => {
+    listUsers.mockResolvedValue({ users: [], total: 0 })
+    const onChange = vi.fn()
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={onChange} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/applicant/i), 'zzz-not-a-match')
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.queryByRole('option')).not.toBeInTheDocument()
+  })
+
+  it('renders the committed value as a removable chip and hides the search input', () => {
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="alice" onChange={vi.fn()} />)
+    expect(screen.getByText('alice')).toBeInTheDocument()
+    expect(screen.queryByLabelText(/applicant/i)).not.toBeInTheDocument()
+  })
+
+  it('clears the selection and re-shows the input when the chip is removed', () => {
+    const onChange = vi.fn()
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="alice" onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button', { name: /remove alice/i }))
+    expect(onChange).toHaveBeenCalledWith('')
+  })
+
+  it('closes the dropdown on Escape without committing a selection', async () => {
+    listUsers.mockResolvedValue({ users: [ALICE], total: 1 })
+    const onChange = vi.fn()
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={onChange} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      const input = screen.getByLabelText(/applicant/i)
+      await typeAndWait(input, 'ali')
+      expect(await screen.findByRole('option', { name: /alice/i })).toBeInTheDocument()
+      fireEvent.keyDown(input, { key: 'Escape' })
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(screen.queryByRole('option')).not.toBeInTheDocument()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})
+
+describe('AccountPicker — keyboard', () => {
+  it('moves the highlight with ArrowDown and commits it with Enter', async () => {
+    listUsers.mockResolvedValue({ users: [ALICE, BOB], total: 2 })
+    const onChange = vi.fn()
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={onChange} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      const input = screen.getByLabelText(/applicant/i)
+      await typeAndWait(input, 'a')
+      expect(await screen.findByRole('option', { name: /alice/i })).toBeInTheDocument()
+
+      // The highlight starts on the first match; one ArrowDown moves it to the second.
+      expect(input).toHaveAttribute('aria-activedescendant', 'p-option-0')
+      fireEvent.keyDown(input, { key: 'ArrowDown' })
+      expect(input).toHaveAttribute('aria-activedescendant', 'p-option-1')
+      expect(screen.getByRole('option', { name: /bob/i })).toHaveAttribute('aria-selected', 'true')
+      expect(screen.getByRole('option', { name: /alice/i })).toHaveAttribute('aria-selected', 'false')
+
+      // fireEvent returns false when the handler called preventDefault — Enter must not
+      // fall through and submit the form this picker sits in.
+      expect(fireEvent.keyDown(input, { key: 'Enter' })).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(onChange).toHaveBeenCalledWith('bob')
+  })
+
+  it('wraps the highlight from the first option to the last on ArrowUp', async () => {
+    listUsers.mockResolvedValue({ users: [ALICE, BOB], total: 2 })
+    const onChange = vi.fn()
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={onChange} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      const input = screen.getByLabelText(/applicant/i)
+      await typeAndWait(input, 'a')
+      expect(await screen.findByRole('option', { name: /alice/i })).toBeInTheDocument()
+      fireEvent.keyDown(input, { key: 'ArrowUp' })
+      expect(input).toHaveAttribute('aria-activedescendant', 'p-option-1')
+      fireEvent.keyDown(input, { key: 'Enter' })
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(onChange).toHaveBeenCalledWith('bob')
+  })
+
+  it('commits the first match on Enter with no arrow keys pressed', async () => {
+    listUsers.mockResolvedValue({ users: [ALICE, BOB], total: 2 })
+    const onChange = vi.fn()
+    render(<AccountPicker id="p" label="Subjects" authToken="tok" multiple value={[]} onChange={onChange} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      const input = screen.getByLabelText(/subjects/i)
+      await typeAndWait(input, 'a')
+      expect(await screen.findByRole('option', { name: /alice/i })).toBeInTheDocument()
+      fireEvent.keyDown(input, { key: 'Enter' })
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(onChange).toHaveBeenCalledWith(['alice'])
+  })
+
+  it('drops aria-activedescendant when Escape closes the list, and ArrowDown re-opens it', async () => {
+    listUsers.mockResolvedValue({ users: [ALICE, BOB], total: 2 })
+    const onChange = vi.fn()
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={onChange} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      const input = screen.getByLabelText(/applicant/i)
+      await typeAndWait(input, 'a')
+      expect(await screen.findByRole('option', { name: /alice/i })).toBeInTheDocument()
+
+      fireEvent.keyDown(input, { key: 'Escape' })
+      expect(input).not.toHaveAttribute('aria-activedescendant')
+      // Enter on a closed list must not commit anything.
+      fireEvent.keyDown(input, { key: 'Enter' })
+      expect(onChange).not.toHaveBeenCalled()
+
+      fireEvent.keyDown(input, { key: 'ArrowDown' })
+      expect(input).toHaveAttribute('aria-activedescendant', 'p-option-0')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('AccountPicker — multi select', () => {
+  it('appends a selected account as a chip via onChange', async () => {
+    listUsers.mockResolvedValue({ users: [ALICE, BOB], total: 2 })
+    const onChange = vi.fn()
+    render(
+      <AccountPicker id="p" label="Subjects" authToken="tok" multiple value={[]} onChange={onChange} />,
+    )
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/subjects/i), 'a')
+      fireEvent.click(await screen.findByRole('option', { name: /alice/i }))
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(onChange).toHaveBeenCalledWith(['alice'])
+  })
+
+  it('keeps the dropdown open after a selection so more matches can be picked', async () => {
+    listUsers.mockResolvedValue({ users: [ALICE, BOB], total: 2 })
+    render(<AccountPicker id="p" label="Subjects" authToken="tok" multiple value={[]} onChange={vi.fn()} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/subjects/i), 'a')
+      fireEvent.click(await screen.findByRole('option', { name: /alice/i }))
+      expect(await screen.findByRole('option', { name: /bob/i })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('shows one chip per selected account and removes only the clicked one', () => {
+    const onChange = vi.fn()
+    render(
+      <AccountPicker
+        id="p"
+        label="Subjects"
+        authToken="tok"
+        multiple
+        value={['alice', 'bob']}
+        onChange={onChange}
+      />,
+    )
+    expect(screen.getByText('alice')).toBeInTheDocument()
+    expect(screen.getByText('bob')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /remove alice/i }))
+    expect(onChange).toHaveBeenCalledWith(['bob'])
+  })
+
+  it('excludes already-selected accounts from the results dropdown', async () => {
+    listUsers.mockResolvedValue({ users: [ALICE, BOB], total: 2 })
+    render(
+      <AccountPicker id="p" label="Subjects" authToken="tok" multiple value={['alice']} onChange={vi.fn()} />,
+    )
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/subjects/i), 'a')
+      expect(await screen.findByRole('option', { name: /bob/i })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(screen.getAllByRole('option')).toHaveLength(1)
+    expect(screen.queryByRole('option', { name: /alice/i })).not.toBeInTheDocument()
+  })
+
+  it('keeps the search input visible even after selections exist', () => {
+    render(
+      <AccountPicker id="p" label="Subjects" authToken="tok" multiple value={['alice']} onChange={vi.fn()} />,
+    )
+    expect(screen.getByLabelText(/subjects/i)).toBeInTheDocument()
+  })
+
+  it('never commits free-typed text into the selected array', async () => {
+    listUsers.mockResolvedValue({ users: [], total: 0 })
+    const onChange = vi.fn()
+    render(<AccountPicker id="p" label="Subjects" authToken="tok" multiple value={[]} onChange={onChange} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/subjects/i), 'not-a-real-match')
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})
+
+describe('AccountPicker — errors', () => {
+  it('logs the admin out instead of showing results on invalid_token', async () => {
+    listUsers.mockRejectedValue(
+      new AsyncJobError('expired', { code: 'unauthenticated', reason: 'invalid_token' }),
+    )
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={vi.fn()} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/applicant/i), 'ali')
+    } finally {
+      vi.useRealTimers()
+    }
+    await waitFor(() => expect(logout).toHaveBeenCalledTimes(1))
+  })
+
+  it('shows no options and does not throw on a non-auth error', async () => {
+    listUsers.mockRejectedValue(new AsyncJobError('boom', { code: 'internal' }))
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={vi.fn()} />)
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await typeAndWait(screen.getByLabelText(/applicant/i), 'ali')
+    } finally {
+      vi.useRealTimers()
+    }
+    expect(screen.queryByRole('option')).not.toBeInTheDocument()
+    expect(logout).not.toHaveBeenCalled()
+  })
+})
+
+describe('AccountPicker — stale response guard', () => {
+  it('drops a stale out-of-order response so a slow earlier query cannot overwrite newer results', async () => {
+    render(<AccountPicker id="p" label="Applicant" authToken="tok" value="" onChange={vi.fn()} />)
+    const input = screen.getByLabelText(/applicant/i)
+
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      // First keystroke ("al") fires a query that will resolve LATE.
+      let resolveSlow
+      const slow = new Promise((resolve) => {
+        resolveSlow = resolve
+      })
+      listUsers.mockReturnValueOnce(slow)
+      await typeAndWait(input, 'al')
+      await waitFor(() =>
+        expect(listUsers).toHaveBeenCalledWith('tok', { q: 'al', page: 1, limit: 10 }),
+      )
+
+      // Second keystroke ("ali") fires a newer query that resolves immediately, before the
+      // first one settles — both requests are now in flight, out of order.
+      listUsers.mockResolvedValueOnce({
+        users: [
+          {
+            id: 'u-fresh',
+            account: 'fresh-account',
+            siteId: 'site-1',
+            engName: '',
+            chineseName: '',
+            roles: [],
+            active: true,
+            requirePasswordChange: false,
+          },
+        ],
+        total: 1,
+      })
+      await typeAndWait(input, 'ali')
+      await waitFor(() =>
+        expect(listUsers).toHaveBeenCalledWith('tok', { q: 'ali', page: 1, limit: 10 }),
+      )
+      expect(await screen.findByRole('option', { name: /fresh-account/i })).toBeInTheDocument()
+
+      // The stale "al" response now resolves — it must be dropped, not overwrite the
+      // already-current "ali" results.
+      await act(async () => {
+        resolveSlow({
+          users: [
+            {
+              id: 'u-stale',
+              account: 'stale-account',
+              siteId: 'site-1',
+              engName: '',
+              chineseName: '',
+              roles: [],
+              active: true,
+              requirePasswordChange: false,
+            },
+          ],
+          total: 1,
+        })
+        await Promise.resolve()
+      })
+
+      expect(screen.queryByRole('option', { name: /stale-account/i })).not.toBeInTheDocument()
+      expect(screen.getByRole('option', { name: /fresh-account/i })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/admin-frontend/src/components/shared/AccountPicker/index.jsx
+++ b/admin-frontend/src/components/shared/AccountPicker/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './AccountPicker'

--- a/admin-frontend/src/components/shared/AccountPicker/style.css
+++ b/admin-frontend/src/components/shared/AccountPicker/style.css
@@ -1,0 +1,79 @@
+.account-picker {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.account-picker-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.account-picker-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  padding: var(--space-2xs) var(--space-sm);
+  background: var(--bg-input);
+  border-radius: var(--radius-pill);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.account-picker-chip button {
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: var(--text-base);
+  line-height: 1;
+  padding: 0;
+}
+
+.account-picker-chip button:hover:not(:disabled) {
+  color: var(--text-primary);
+}
+
+.account-picker-chip button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.account-picker-input-wrap {
+  position: relative;
+}
+
+.account-picker-options {
+  position: absolute;
+  z-index: 10;
+  top: calc(100% + var(--space-2xs));
+  left: 0;
+  right: 0;
+  max-height: 200px;
+  overflow-y: auto;
+  margin: 0;
+  padding: var(--space-2xs) 0;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-dialog);
+  list-style: none;
+}
+
+.account-picker-options li {
+  padding: var(--space-xs) var(--space-md);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+
+/* Keyboard highlight shares the hover treatment — aria-selected is the active
+   descendant, so without it arrow-key navigation moves nothing the eye can see. */
+.account-picker-options li:hover,
+.account-picker-options li[aria-selected='true'] {
+  background: var(--bg-hover);
+}

--- a/admin-frontend/src/hooks/usePagedAdminList.js
+++ b/admin-frontend/src/hooks/usePagedAdminList.js
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { AsyncJobError } from '@/api'
+import { useDebouncedSearch } from './useDebouncedSearch'
+import { useHandleAdminError } from './useHandleAdminError'
+import { useLatestRequest } from './useLatestRequest'
+
+/** Shell shared by the paged, debounce-filtered admin consoles (Audit, Permissions): filter
+ * state, page state, stale-response guard, and the `not_admin` branch.
+ *
+ * `fetcher(authToken, filters, { page, limit })` keeps the page-specific query building local to
+ * the caller and returns the raw response; it is read through a ref, so an inline arrow is fine.
+ * The whole response is also exposed as `data` for fields beyond `entries`/`total`. */
+export function usePagedAdminList({ authToken, fetcher, defaultFilters, pageSize }) {
+  const handleAdminError = useHandleAdminError()
+  const { begin, isCurrent } = useLatestRequest()
+  const fetcherRef = useRef(fetcher)
+  fetcherRef.current = fetcher
+
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [notAuthorized, setNotAuthorized] = useState(false)
+  const [filters, setFilters] = useState(defaultFilters)
+  const [page, setPage] = useState(1)
+
+  // Tracks the filter key already reflected by the most recent fetch (whether triggered by the
+  // debounce or by goToPage), so a debounced onSearch firing after a manual goToPage — with the
+  // same filters it already picked up — doesn't clobber the page the user just navigated to.
+  const lastFetchedFilterKeyRef = useRef(JSON.stringify(defaultFilters))
+
+  const fetchPage = useCallback(
+    async (nextFilters, nextPage) => {
+      const token = begin()
+      setLoading(true)
+      setError(null)
+      try {
+        const result = await fetcherRef.current(authToken, nextFilters, {
+          page: nextPage,
+          limit: pageSize,
+        })
+        if (!isCurrent(token)) return // superseded by a newer request
+        setData(result)
+        setNotAuthorized(false)
+      } catch (err) {
+        if (!isCurrent(token)) return
+        // Deliberate: clearing stale rows makes both consoles show empty + the error banner,
+        // rather than rows that silently no longer match the filters/page that just failed.
+        setData(null)
+        if (err instanceof AsyncJobError && err.reason === 'not_admin') {
+          setNotAuthorized(true)
+        } else {
+          const message = handleAdminError(err)
+          if (message !== null) setError(message)
+        }
+      } finally {
+        if (isCurrent(token)) setLoading(false)
+      }
+    },
+    [authToken, pageSize, handleAdminError, begin, isCurrent],
+  )
+
+  useEffect(() => {
+    setPage(1)
+    fetchPage(defaultFilters, 1)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authToken])
+
+  const { setQuery: setDebouncedFilters } = useDebouncedSearch({
+    onSearch: (serialized) => {
+      if (serialized === lastFetchedFilterKeyRef.current) return
+      lastFetchedFilterKeyRef.current = serialized
+      setPage(1)
+      fetchPage(serialized ? JSON.parse(serialized) : defaultFilters, 1)
+    },
+  })
+
+  return {
+    data,
+    entries: data?.entries ?? [],
+    total: data?.total ?? 0,
+    page,
+    filters,
+    loading,
+    error,
+    notAuthorized,
+    updateFilter: (key, value) => {
+      const next = { ...filters, [key]: value }
+      setFilters(next)
+      setDebouncedFilters(JSON.stringify(next))
+    },
+    goToPage: (nextPage) => {
+      lastFetchedFilterKeyRef.current = JSON.stringify(filters)
+      setPage(nextPage)
+      fetchPage(filters, nextPage)
+    },
+    refresh: () => fetchPage(filters, page),
+  }
+}

--- a/admin-frontend/src/styles/index.css
+++ b/admin-frontend/src/styles/index.css
@@ -120,6 +120,44 @@ a:focus-visible,
   color: var(--text-primary);
 }
 
+/* Status pill — pair with a variant class for the on/off colours. */
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-2xs) var(--space-sm);
+  border-radius: var(--radius-pill);
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+}
+.status-badge.is-granted {
+  background: var(--status-success-bg);
+  color: var(--status-success);
+}
+.status-badge.is-not-granted {
+  background: var(--status-error-bg);
+  color: var(--status-error);
+}
+
+/* Admin list table — the console tables share this base and add only their own quirks. */
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.data-table th,
+.data-table td {
+  text-align: left;
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: var(--text-sm);
+}
+.data-table th {
+  color: var(--text-muted);
+  font-weight: var(--font-medium);
+}
+.data-table td {
+  color: var(--text-primary);
+}
+
 /* Custom scrollbar so dark mode doesn't show OS chrome. */
 .scrollbar-thin {
   scrollbar-width: thin;

--- a/admin-service/config.go
+++ b/admin-service/config.go
@@ -27,6 +27,9 @@ type Config struct {
 	// RoomRPCTimeout must stay below the HTTP server's WriteTimeout, or net/http
 	// closes the connection before the handler can answer.
 	RoomRPCTimeout time.Duration `env:"ROOM_RPC_TIMEOUT" envDefault:"5s"`
+	// AllSiteIDs lists every site in the federation (including this one); empty means
+	// no cross-site fanout — correct for single-site dev.
+	AllSiteIDs []string `env:"ALL_SITE_IDS" envSeparator:"," envDefault:""`
 }
 
 func loadConfig() (Config, error) {

--- a/admin-service/deploy/docker-compose.yml
+++ b/admin-service/deploy/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4318}
       - PORT=8082
       - SITE_ID=${SITE_ID:-site-local}
+      - ALL_SITE_IDS=${ALL_SITE_IDS:-${SITE_ID:-site-local}}
       - MONGO_URI=${MONGO_URI:-mongodb://mongodb:27017}
       - MONGO_DB=${MONGO_DB:-chat}
       - NATS_URL=${NATS_URL:-nats://nats:4222}

--- a/admin-service/handler.go
+++ b/admin-service/handler.go
@@ -19,20 +19,23 @@ import (
 	"github.com/hmchangw/chat/pkg/session"
 )
 
-// Handler wires the AdminStore, session.Store, Config, and room-service RPC
-// client into HTTP handler methods.
+// Handler wires the AdminStore, session.Store, Config, room-service RPC
+// client, and cross-site inbox publisher into HTTP handler methods.
 type Handler struct {
-	store    AdminStore
-	sessions session.Store
-	cfg      Config
-	roomRPC  roomRequester
+	store        AdminStore
+	sessions     session.Store
+	cfg          Config
+	roomRPC      roomRequester
+	publishInbox func(ctx context.Context, subj string, data []byte) error
 }
 
-// newHandler constructs a Handler with the given stores, config, and room RPC.
-// A nil rpc is tolerated so tests that never touch a room route need not build
-// one; the duty handler answers 503 rather than dereferencing it.
-func newHandler(store AdminStore, sessions session.Store, cfg Config, rpc roomRequester) *Handler { //nolint:gocritic // hugeParam: Config is a startup value copied once at construction
-	return &Handler{store: store, sessions: sessions, cfg: cfg, roomRPC: rpc}
+// newHandler constructs a Handler with the given stores, config, room RPC, and
+// inbox publisher. A nil rpc is tolerated so tests that never touch a room
+// route need not build one; the duty handler answers 503 rather than
+// dereferencing it. A nil publishInbox is tolerated the same way — fanout
+// no-ops in tests that don't exercise it.
+func newHandler(store AdminStore, sessions session.Store, cfg Config, rpc roomRequester, publishInbox func(ctx context.Context, subj string, data []byte) error) *Handler { //nolint:gocritic // hugeParam: Config is a startup value copied once at construction
+	return &Handler{store: store, sessions: sessions, cfg: cfg, roomRPC: rpc, publishInbox: publishInbox}
 }
 
 // nowMillis returns the current UTC time in unix milliseconds. Injected as a
@@ -88,12 +91,12 @@ func toView(u *model.User) userView {
 	}
 }
 
-// audit appends an audit entry for a mutating admin action; a write failure
-// is logged but not fatal. Details must carry non-secret context only —
-// never passwords, hashes, or tokens.
-func (h *Handler) audit(ctx context.Context, c *gin.Context, action, targetUserID, targetAccount string, details map[string]string) {
+// auditEntry builds one audit entry stamped with the request's principal and this
+// site. Details must carry non-secret context only — never passwords, hashes, or
+// tokens. ts is passed in so a batch can share one timestamp with its ledger rows.
+func (h *Handler) auditEntry(c *gin.Context, action, targetUserID, targetAccount string, details map[string]string, ts time.Time) *AuditEntry {
 	p := principalFrom(c)
-	e := &AuditEntry{
+	return &AuditEntry{
 		ID:            idgen.GenerateUUIDv7(),
 		ActorUserID:   p.UserID,
 		ActorAccount:  p.Account,
@@ -102,9 +105,14 @@ func (h *Handler) audit(ctx context.Context, c *gin.Context, action, targetUserI
 		TargetAccount: targetAccount,
 		Details:       details, // non-secret only — NEVER password/hash/token
 		SiteID:        h.cfg.SiteID,
-		Timestamp:     time.Now().UTC().UnixMilli(),
+		Timestamp:     ts.UnixMilli(),
 	}
-	if err := h.store.AppendAudit(ctx, e); err != nil {
+}
+
+// audit appends an audit entry for a mutating admin action; a write failure
+// is logged but not fatal.
+func (h *Handler) audit(ctx context.Context, c *gin.Context, action, targetUserID, targetAccount string, details map[string]string) {
+	if err := h.store.AppendAudit(ctx, h.auditEntry(c, action, targetUserID, targetAccount, details, time.Now().UTC())); err != nil {
 		slog.ErrorContext(ctx, "append audit entry failed", "action", action, "error", err)
 	}
 }

--- a/admin-service/handler_test.go
+++ b/admin-service/handler_test.go
@@ -342,7 +342,7 @@ func TestHandler_createUser(t *testing.T) {
 			m := NewMockAdminStore(ctrl)
 			tc.setupMock(m)
 
-			h := newHandler(m, emptySessionStore(), testCfg(), nil)
+			h := newHandler(m, emptySessionStore(), testCfg(), nil, nil)
 			r := setupRouter(h)
 
 			w := httptest.NewRecorder()
@@ -434,7 +434,7 @@ func TestHandler_listUsers(t *testing.T) {
 			m := NewMockAdminStore(ctrl)
 			tc.setupMock(m)
 
-			h := newHandler(m, emptySessionStore(), testCfg(), nil)
+			h := newHandler(m, emptySessionStore(), testCfg(), nil, nil)
 			r := setupRouter(h)
 
 			w := httptest.NewRecorder()
@@ -526,7 +526,7 @@ func TestHandler_getUser(t *testing.T) {
 			m := NewMockAdminStore(ctrl)
 			tc.setupMock(m)
 
-			h := newHandler(m, emptySessionStore(), testCfg(), nil)
+			h := newHandler(m, emptySessionStore(), testCfg(), nil, nil)
 			r := setupRouter(h)
 
 			w := httptest.NewRecorder()
@@ -713,7 +713,7 @@ func TestHandler_updateUser(t *testing.T) {
 				tc.setupSessions(sess)
 			}
 
-			h := newHandler(m, sess, testCfg(), nil)
+			h := newHandler(m, sess, testCfg(), nil, nil)
 			r := setupRouter(h)
 
 			w := httptest.NewRecorder()
@@ -741,7 +741,7 @@ func TestHandler_updateUser_DeactivateAndRevoke_TxError_Returns500(t *testing.T)
 	m.EXPECT().DeactivateAndRevoke(gomock.Any(), "site-A", "u2b").Return(fmt.Errorf("mongo dead"))
 	// no AppendAudit expectation — must not fire
 
-	h := newHandler(m, emptySessionStore(), testCfg(), nil)
+	h := newHandler(m, emptySessionStore(), testCfg(), nil, nil)
 	r := setupRouter(h)
 
 	w := httptest.NewRecorder()
@@ -866,7 +866,7 @@ func TestHandler_listSessions(t *testing.T) {
 				tc.setupSessions(sess)
 			}
 
-			h := newHandler(m, sess, testCfg(), nil)
+			h := newHandler(m, sess, testCfg(), nil, nil)
 			r := setupSessionRouter(h)
 
 			w := httptest.NewRecorder()
@@ -946,7 +946,7 @@ func TestHandler_revokeAllSessions(t *testing.T) {
 				tc.setupSessions(sess)
 			}
 
-			h := newHandler(m, sess, testCfg(), nil)
+			h := newHandler(m, sess, testCfg(), nil, nil)
 			r := setupSessionRouter(h)
 
 			w := httptest.NewRecorder()
@@ -1028,7 +1028,7 @@ func TestHandler_revokeSession(t *testing.T) {
 				tc.setupSessions(sess)
 			}
 
-			h := newHandler(m, sess, testCfg(), nil)
+			h := newHandler(m, sess, testCfg(), nil, nil)
 			r := setupSessionRouter(h)
 
 			w := httptest.NewRecorder()
@@ -1105,7 +1105,7 @@ func TestHandler_listAudit(t *testing.T) {
 			m := NewMockAdminStore(ctrl)
 			tc.setupMock(m)
 
-			h := newHandler(m, emptySessionStore(), testCfg(), nil)
+			h := newHandler(m, emptySessionStore(), testCfg(), nil, nil)
 			r := setupSessionRouter(h)
 
 			w := httptest.NewRecorder()
@@ -1129,7 +1129,7 @@ func TestHandler_healthz(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	m := NewMockAdminStore(ctrl)
 
-	h := newHandler(m, emptySessionStore(), testCfg(), nil)
+	h := newHandler(m, emptySessionStore(), testCfg(), nil, nil)
 	r := setupSessionRouter(h)
 
 	w := httptest.NewRecorder()
@@ -1147,7 +1147,7 @@ func TestHandler_readyz(t *testing.T) {
 		m := NewMockAdminStore(ctrl)
 		m.EXPECT().Ping(gomock.Any()).Return(nil)
 
-		h := newHandler(m, emptySessionStore(), testCfg(), nil)
+		h := newHandler(m, emptySessionStore(), testCfg(), nil, nil)
 		r := setupSessionRouter(h)
 
 		w := httptest.NewRecorder()
@@ -1164,7 +1164,7 @@ func TestHandler_readyz(t *testing.T) {
 		m := NewMockAdminStore(ctrl)
 		m.EXPECT().Ping(gomock.Any()).Return(fmt.Errorf("mongo unreachable"))
 
-		h := newHandler(m, emptySessionStore(), testCfg(), nil)
+		h := newHandler(m, emptySessionStore(), testCfg(), nil, nil)
 		r := setupSessionRouter(h)
 
 		w := httptest.NewRecorder()
@@ -1279,7 +1279,7 @@ func TestHandler_setPassword(t *testing.T) {
 				tc.setupSessions(sess)
 			}
 
-			h := newHandler(m, sess, testCfg(), nil)
+			h := newHandler(m, sess, testCfg(), nil, nil)
 			r := setupRouter(h)
 
 			w := httptest.NewRecorder()
@@ -1308,7 +1308,7 @@ func TestHandler_setPassword_TxError_Returns500(t *testing.T) {
 		Return(fmt.Errorf("mongo dead"))
 	// no AppendAudit expectation — must not fire
 
-	h := newHandler(m, emptySessionStore(), testCfg(), nil)
+	h := newHandler(m, emptySessionStore(), testCfg(), nil, nil)
 	r := setupRouter(h)
 
 	w := httptest.NewRecorder()

--- a/admin-service/integration_test.go
+++ b/admin-service/integration_test.go
@@ -591,6 +591,665 @@ func TestIntegration_EnsureIndexes_Idempotent(t *testing.T) {
 }
 
 // -------------------------------------------------------------------------
+// Permission grants: RecordPermissionChange (transactional ledger + state) +
+// GetUserPermissions (materialized state, site-unfiltered) + ListPermissionGrants
+// (company-wide ledger browse) + FindAccountStates (company-wide) + AppendAuditMany
+// -------------------------------------------------------------------------
+
+func TestIntegration_RecordPermissionChange_AllOrNothing(t *testing.T) {
+	db := testutil.MongoDBReplicaSet(t, "adminsvc")
+	st := newStoreMongo(db)
+	require.NoError(t, st.EnsureIndexes(context.Background()))
+	ctx := context.Background()
+
+	preexisting := &model.PermissionGrant{
+		ID: "dup-id", Permission: model.PermissionExternalImageView,
+		SubjectAccount: "zoe", Granted: false, ApplicantAccount: "carol", ApproverAccount: "dave",
+		Reason: "pre-existing row", RecordedBy: "p_admin", RecordedAt: time.Now().UTC(),
+	}
+	preexistingState := model.PermissionState{Granted: false, UpdatedAt: preexisting.RecordedAt}
+	require.NoError(t, st.RecordPermissionChange(ctx, []*model.PermissionGrant{preexisting}, preexistingState))
+
+	now := time.Now().UTC()
+	batch := []*model.PermissionGrant{
+		{ID: idgen.GenerateUUIDv7(), Permission: model.PermissionExternalImageView, SubjectAccount: "alice", Granted: true, EffectiveFrom: timePtr(now), ExpiresAt: timePtr(now.AddDate(0, 1, 0)), ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "batch row 1", RecordedBy: "p_admin", RecordedAt: now},
+		{ID: idgen.GenerateUUIDv7(), Permission: model.PermissionExternalImageView, SubjectAccount: "bob", Granted: true, EffectiveFrom: timePtr(now), ExpiresAt: timePtr(now.AddDate(0, 1, 0)), ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "batch row 2", RecordedBy: "p_admin", RecordedAt: now},
+		{ID: "dup-id", Permission: model.PermissionExternalImageView, SubjectAccount: "carl", Granted: true, EffectiveFrom: timePtr(now), ExpiresAt: timePtr(now.AddDate(0, 1, 0)), ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "batch row 3 — collides with preexisting _id", RecordedBy: "p_admin", RecordedAt: now},
+	}
+	batchState := model.PermissionState{Granted: true, EffectiveFrom: timePtr(now), ExpiresAt: timePtr(now.AddDate(0, 1, 0)), UpdatedAt: now}
+
+	err := st.RecordPermissionChange(ctx, batch, batchState)
+	require.Error(t, err, "a duplicate _id inside the batch must fail the whole transaction")
+
+	count, err := st.permGrants.CountDocuments(ctx, bson.M{"subjectAccount": bson.M{"$in": []string{"alice", "bob"}}})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count, "the transaction must roll back alice and bob too, not just the colliding row")
+
+	total, err := st.permGrants.CountDocuments(ctx, bson.M{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total, "only the pre-existing row should remain")
+
+	t.Run("empty batch is a no-op, not an error", func(t *testing.T) {
+		require.NoError(t, st.RecordPermissionChange(ctx, nil, model.PermissionState{}))
+	})
+}
+
+// TestRecordPermissionChange_TransactionAppliesLedgerAndState covers the
+// $exists:false guard arm: brand-new user docs with no permissions.externalImageView
+// field yet must still receive the state (the guard only blocks a STORED newer
+// watermark, not an absent one).
+func TestIntegration_RecordPermissionChange_TransactionAppliesLedgerAndState(t *testing.T) {
+	db := testutil.MongoDBReplicaSet(t, "adminsvc")
+	st := newStoreMongo(db)
+	require.NoError(t, st.EnsureIndexes(context.Background()))
+	ctx := context.Background()
+
+	require.NoError(t, st.CreateUser(ctx, &model.User{ID: idgen.GenerateUUIDv7(), Account: "harry", SiteID: "site-a"}))
+	require.NoError(t, st.CreateUser(ctx, &model.User{ID: idgen.GenerateUUIDv7(), Account: "ivy", SiteID: "site-a"}))
+
+	// Truncate to millisecond: Mongo stores time.Time as BSON datetime (int64 ms),
+	// so an untruncated in-memory value never round-trips equal to what's stored.
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	state := model.PermissionState{
+		Granted:       true,
+		EffectiveFrom: timePtr(now),
+		ExpiresAt:     timePtr(now.AddDate(0, 1, 0)),
+		UpdatedAt:     now,
+	}
+	grants := []*model.PermissionGrant{
+		{ID: idgen.GenerateUUIDv7(), Permission: model.PermissionExternalImageView, SubjectAccount: "harry", Granted: true, EffectiveFrom: state.EffectiveFrom, ExpiresAt: state.ExpiresAt, ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "batch", RecordedBy: "p_admin", RecordedAt: now},
+		{ID: idgen.GenerateUUIDv7(), Permission: model.PermissionExternalImageView, SubjectAccount: "ivy", Granted: true, EffectiveFrom: state.EffectiveFrom, ExpiresAt: state.ExpiresAt, ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "batch", RecordedBy: "p_admin", RecordedAt: now},
+	}
+
+	require.NoError(t, st.RecordPermissionChange(ctx, grants, state))
+
+	count, err := st.permGrants.CountDocuments(ctx, bson.M{"subjectAccount": bson.M{"$in": []string{"harry", "ivy"}}})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count, "both ledger rows must exist")
+
+	for _, account := range []string{"harry", "ivy"} {
+		var raw model.User
+		err := db.Collection("users").FindOne(ctx, bson.M{"account": account},
+			options.FindOne().SetProjection(bson.M{"permissions": 1}),
+		).Decode(&raw)
+		require.NoError(t, err)
+		require.NotNil(t, raw.Permissions, "account %s must carry a permissions snapshot", account)
+		got := raw.Permissions.ExternalImageView
+		require.NotNil(t, got, "account %s must carry externalImageView", account)
+		assert.Equal(t, state.Granted, got.Granted)
+		require.NotNil(t, got.EffectiveFrom)
+		require.NotNil(t, got.ExpiresAt)
+		assert.True(t, state.EffectiveFrom.Equal(*got.EffectiveFrom))
+		assert.True(t, state.ExpiresAt.Equal(*got.ExpiresAt))
+		assert.True(t, state.UpdatedAt.Equal(got.UpdatedAt))
+	}
+}
+
+// TestRecordPermissionChange_GuardKeepsNewerState covers the $lte guard arm from
+// both sides of the boundary: a strictly newer stored watermark blocks the write
+// (ledger row still lands), an equal watermark does not (spec's half-open $lte).
+func TestIntegration_RecordPermissionChange_GuardKeepsNewerState(t *testing.T) {
+	db := testutil.MongoDBReplicaSet(t, "adminsvc")
+	st := newStoreMongo(db)
+	require.NoError(t, st.EnsureIndexes(context.Background()))
+	ctx := context.Background()
+
+	// Truncate to millisecond: Mongo stores time.Time as BSON datetime (int64 ms),
+	// so an untruncated in-memory value never round-trips equal to what's stored.
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	state := model.PermissionState{
+		Granted:       true,
+		EffectiveFrom: timePtr(now),
+		ExpiresAt:     timePtr(now.AddDate(0, 1, 0)),
+		UpdatedAt:     now,
+	}
+
+	t.Run("stored state is newer — guard blocks the update, ledger still gets the row", func(t *testing.T) {
+		require.NoError(t, st.CreateUser(ctx, &model.User{ID: idgen.GenerateUUIDv7(), Account: "jack", SiteID: "site-a"}))
+
+		newerState := model.PermissionState{Granted: false, UpdatedAt: now.Add(time.Second)}
+		_, err := db.Collection("users").UpdateOne(ctx,
+			bson.M{"account": "jack"},
+			bson.M{"$set": bson.M{"permissions.externalImageView": newerState}},
+		)
+		require.NoError(t, err)
+
+		grant := &model.PermissionGrant{
+			ID: idgen.GenerateUUIDv7(), Permission: model.PermissionExternalImageView,
+			SubjectAccount: "jack", Granted: true, EffectiveFrom: state.EffectiveFrom, ExpiresAt: state.ExpiresAt,
+			ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "r", RecordedBy: "p_admin", RecordedAt: now,
+		}
+		require.NoError(t, st.RecordPermissionChange(ctx, []*model.PermissionGrant{grant}, state))
+
+		count, err := st.permGrants.CountDocuments(ctx, bson.M{"_id": grant.ID})
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), count, "ledger row must be inserted regardless of the guard")
+
+		var raw model.User
+		require.NoError(t, db.Collection("users").FindOne(ctx, bson.M{"account": "jack"},
+			options.FindOne().SetProjection(bson.M{"permissions": 1}),
+		).Decode(&raw))
+		require.NotNil(t, raw.Permissions)
+		require.NotNil(t, raw.Permissions.ExternalImageView)
+		assert.False(t, raw.Permissions.ExternalImageView.Granted, "user doc must keep the newer stored state, unchanged by the older write")
+		assert.True(t, newerState.UpdatedAt.Equal(raw.Permissions.ExternalImageView.UpdatedAt))
+	})
+
+	t.Run("stored state has an equal updatedAt — state is applied ($lte)", func(t *testing.T) {
+		require.NoError(t, st.CreateUser(ctx, &model.User{ID: idgen.GenerateUUIDv7(), Account: "kate", SiteID: "site-a"}))
+
+		equalState := model.PermissionState{Granted: false, UpdatedAt: state.UpdatedAt}
+		_, err := db.Collection("users").UpdateOne(ctx,
+			bson.M{"account": "kate"},
+			bson.M{"$set": bson.M{"permissions.externalImageView": equalState}},
+		)
+		require.NoError(t, err)
+
+		grant := &model.PermissionGrant{
+			ID: idgen.GenerateUUIDv7(), Permission: model.PermissionExternalImageView,
+			SubjectAccount: "kate", Granted: true, EffectiveFrom: state.EffectiveFrom, ExpiresAt: state.ExpiresAt,
+			ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "r", RecordedBy: "p_admin", RecordedAt: now,
+		}
+		require.NoError(t, st.RecordPermissionChange(ctx, []*model.PermissionGrant{grant}, state))
+
+		var raw model.User
+		require.NoError(t, db.Collection("users").FindOne(ctx, bson.M{"account": "kate"},
+			options.FindOne().SetProjection(bson.M{"permissions": 1}),
+		).Decode(&raw))
+		require.NotNil(t, raw.Permissions)
+		require.NotNil(t, raw.Permissions.ExternalImageView)
+		assert.True(t, raw.Permissions.ExternalImageView.Granted, "equal updatedAt must still apply — $lte, not strictly less-than")
+		assert.True(t, state.UpdatedAt.Equal(raw.Permissions.ExternalImageView.UpdatedAt))
+	})
+}
+
+// TestRecordPermissionChange_MissingUserIsNoop covers a subject account that
+// exists in the ledger's world but has no local user document (e.g. homed at
+// another site with no cached doc here yet) — the ledger append must still
+// succeed and the state-apply UpdateMany must not fabricate a user doc.
+func TestIntegration_RecordPermissionChange_MissingUserIsNoop(t *testing.T) {
+	db := testutil.MongoDBReplicaSet(t, "adminsvc")
+	st := newStoreMongo(db)
+	require.NoError(t, st.EnsureIndexes(context.Background()))
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	state := model.PermissionState{Granted: true, EffectiveFrom: timePtr(now), ExpiresAt: timePtr(now.AddDate(0, 1, 0)), UpdatedAt: now}
+	grant := &model.PermissionGrant{
+		ID: idgen.GenerateUUIDv7(), Permission: model.PermissionExternalImageView,
+		SubjectAccount: "ghost-account-no-doc", Granted: true, EffectiveFrom: state.EffectiveFrom, ExpiresAt: state.ExpiresAt,
+		ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "r", RecordedBy: "p_admin", RecordedAt: now,
+	}
+
+	require.NoError(t, st.RecordPermissionChange(ctx, []*model.PermissionGrant{grant}, state))
+
+	count, err := st.permGrants.CountDocuments(ctx, bson.M{"_id": grant.ID})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "ledger row must be inserted even though no user doc exists")
+
+	userCount, err := db.Collection("users").CountDocuments(ctx, bson.M{"account": "ghost-account-no-doc"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), userCount, "RecordPermissionChange must never create a user document")
+}
+
+func TestIntegration_GetUserPermissions(t *testing.T) {
+	db := testutil.MongoDBReplicaSet(t, "adminsvc")
+	st := newStoreMongo(db)
+	require.NoError(t, st.EnsureIndexes(context.Background()))
+	ctx := context.Background()
+
+	t.Run("account does not exist → (nil, nil)", func(t *testing.T) {
+		got, err := st.GetUserPermissions(ctx, "no-such-account")
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("account exists with no permissions snapshot → (nil, nil)", func(t *testing.T) {
+		require.NoError(t, st.CreateUser(ctx, &model.User{ID: idgen.GenerateUUIDv7(), Account: "liam", SiteID: "site-a"}))
+
+		got, err := st.GetUserPermissions(ctx, "liam")
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("account with a materialized permission state round-trips", func(t *testing.T) {
+		require.NoError(t, st.CreateUser(ctx, &model.User{ID: idgen.GenerateUUIDv7(), Account: "mia", SiteID: "site-a"}))
+
+		// Truncate to millisecond: Mongo stores time.Time as BSON datetime (int64 ms),
+		// so an untruncated in-memory value never round-trips equal to what's stored.
+		now := time.Now().UTC().Truncate(time.Millisecond)
+		state := model.PermissionState{
+			Granted:       true,
+			EffectiveFrom: timePtr(now),
+			ExpiresAt:     timePtr(now.AddDate(0, 1, 0)),
+			UpdatedAt:     now,
+		}
+		grant := &model.PermissionGrant{
+			ID: idgen.GenerateUUIDv7(), Permission: model.PermissionExternalImageView,
+			SubjectAccount: "mia", Granted: true, EffectiveFrom: state.EffectiveFrom, ExpiresAt: state.ExpiresAt,
+			ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "r", RecordedBy: "p_admin", RecordedAt: now,
+		}
+		require.NoError(t, st.RecordPermissionChange(ctx, []*model.PermissionGrant{grant}, state))
+
+		got, err := st.GetUserPermissions(ctx, "mia")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.NotNil(t, got.ExternalImageView)
+		assert.Equal(t, state.Granted, got.ExternalImageView.Granted)
+		require.NotNil(t, got.ExternalImageView.EffectiveFrom)
+		require.NotNil(t, got.ExternalImageView.ExpiresAt)
+		assert.True(t, state.EffectiveFrom.Equal(*got.ExternalImageView.EffectiveFrom))
+		assert.True(t, state.ExpiresAt.Equal(*got.ExternalImageView.ExpiresAt))
+		assert.True(t, state.UpdatedAt.Equal(got.ExternalImageView.UpdatedAt))
+	})
+
+	t.Run("site-unfiltered: account homed at a different site still returns its materialized state", func(t *testing.T) {
+		require.NoError(t, st.CreateUser(ctx, &model.User{ID: idgen.GenerateUUIDv7(), Account: "noah", SiteID: "site-b"}))
+
+		now := time.Now().UTC().Truncate(time.Millisecond)
+		state := model.PermissionState{
+			Granted:       true,
+			EffectiveFrom: timePtr(now),
+			ExpiresAt:     timePtr(now.AddDate(0, 1, 0)),
+			UpdatedAt:     now,
+		}
+		grant := &model.PermissionGrant{
+			ID: idgen.GenerateUUIDv7(), Permission: model.PermissionExternalImageView,
+			SubjectAccount: "noah", Granted: true, EffectiveFrom: state.EffectiveFrom, ExpiresAt: state.ExpiresAt,
+			ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "r", RecordedBy: "p_admin", RecordedAt: now,
+		}
+		require.NoError(t, st.RecordPermissionChange(ctx, []*model.PermissionGrant{grant}, state))
+
+		got, err := st.GetUserPermissions(ctx, "noah")
+		require.NoError(t, err)
+		require.NotNil(t, got, "a site-filtered query would find nothing for a site-b account")
+		require.NotNil(t, got.ExternalImageView)
+		assert.True(t, got.ExternalImageView.Granted)
+	})
+}
+
+// TestIntegration_GetUserPermissionsForAccounts covers the resync endpoint's batch read:
+// a mix of an account with a materialized state, an account whose doc exists but never had
+// the permission recorded, and an account with no doc at all.
+func TestIntegration_GetUserPermissionsForAccounts(t *testing.T) {
+	db := testutil.MongoDBReplicaSet(t, "adminsvc")
+	st := newStoreMongo(db)
+	require.NoError(t, st.EnsureIndexes(context.Background()))
+	ctx := context.Background()
+
+	// oscar: materialized state for the permission key, via RecordPermissionChange.
+	require.NoError(t, st.CreateUser(ctx, &model.User{ID: idgen.GenerateUUIDv7(), Account: "oscar", SiteID: "site-a"}))
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	state := model.PermissionState{
+		Granted:       true,
+		EffectiveFrom: timePtr(now),
+		ExpiresAt:     timePtr(now.AddDate(0, 1, 0)),
+		UpdatedAt:     now,
+	}
+	grant := &model.PermissionGrant{
+		ID: idgen.GenerateUUIDv7(), Permission: model.PermissionExternalImageView,
+		SubjectAccount: "oscar", Granted: true, EffectiveFrom: state.EffectiveFrom, ExpiresAt: state.ExpiresAt,
+		ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "r", RecordedBy: "p_admin", RecordedAt: now,
+	}
+	require.NoError(t, st.RecordPermissionChange(ctx, []*model.PermissionGrant{grant}, state))
+
+	// petra: user doc exists, but no permission was ever recorded for her.
+	require.NoError(t, st.CreateUser(ctx, &model.User{ID: idgen.GenerateUUIDv7(), Account: "petra", SiteID: "site-a"}))
+
+	// "ghost-user": no CreateUser call — no doc at all.
+
+	got, err := st.GetUserPermissionsForAccounts(ctx, []string{"oscar", "petra", "ghost-user"})
+	require.NoError(t, err)
+
+	assert.Len(t, got, 2, "only accounts with a user doc appear — oscar and petra, not ghost-user")
+	_, hasGhost := got["ghost-user"]
+	assert.False(t, hasGhost, "an account with no user doc must be absent from the map, not present with a nil value")
+
+	require.Contains(t, got, "oscar")
+	require.NotNil(t, got["oscar"])
+	require.NotNil(t, got["oscar"].ExternalImageView)
+	assert.Equal(t, state.Granted, got["oscar"].ExternalImageView.Granted)
+	require.NotNil(t, got["oscar"].ExternalImageView.EffectiveFrom)
+	require.NotNil(t, got["oscar"].ExternalImageView.ExpiresAt)
+	assert.True(t, state.EffectiveFrom.Equal(*got["oscar"].ExternalImageView.EffectiveFrom))
+	assert.True(t, state.ExpiresAt.Equal(*got["oscar"].ExternalImageView.ExpiresAt))
+	assert.True(t, state.UpdatedAt.Equal(got["oscar"].ExternalImageView.UpdatedAt))
+
+	require.Contains(t, got, "petra", "a user doc with nothing ever recorded must still appear in the map")
+	assert.Nil(t, got["petra"], "no permissions ever recorded for petra — nil UserPermissions, not a zero-value struct")
+}
+
+func TestIntegration_FindAccountStates(t *testing.T) {
+	db := testutil.MongoDBReplicaSet(t, "adminsvc")
+	st := newStoreMongo(db)
+	require.NoError(t, st.EnsureIndexes(context.Background()))
+	ctx := context.Background()
+
+	activeFlag := false
+	require.NoError(t, st.CreateUser(ctx, &model.User{ID: idgen.GenerateUUIDv7(), Account: "active-user", SiteID: "site-a"}))
+	require.NoError(t, st.CreateUser(ctx, &model.User{ID: idgen.GenerateUUIDv7(), Account: "inactive-user", SiteID: "site-a", Active: &activeFlag}))
+	require.NoError(t, st.CreateUser(ctx, &model.User{ID: idgen.GenerateUUIDv7(), Account: "other-site-user", SiteID: "site-b"}))
+
+	states, err := st.FindAccountStates(ctx, []string{"active-user", "inactive-user", "other-site-user", "ghost-user"})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]bool{"active-user": true, "inactive-user": false, "other-site-user": true}, states,
+		"ghost-user must be absent, not false; other-site-user (a different site) must still be found — lookup is company-wide")
+
+	_, exists := states["ghost-user"]
+	assert.False(t, exists, "an account that doesn't exist must not appear in the map at all")
+}
+
+func TestIntegration_ListPermissionGrants(t *testing.T) {
+	db := testutil.MongoDBReplicaSet(t, "adminsvc")
+	st := newStoreMongo(db)
+	require.NoError(t, st.EnsureIndexes(context.Background()))
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	otherPermission := model.PermissionKey("other.permission")
+	grants := []*model.PermissionGrant{
+		{ID: idgen.GenerateUUIDv7(), Permission: model.PermissionExternalImageView, SubjectAccount: "faye", Granted: true, EffectiveFrom: timePtr(now.Add(-3 * time.Hour)), ExpiresAt: timePtr(now.AddDate(0, 1, 0)), ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "r1", RecordedBy: "p_admin", RecordedAt: now.Add(-3 * time.Hour)},
+		{ID: idgen.GenerateUUIDv7(), Permission: model.PermissionExternalImageView, SubjectAccount: "faye", Granted: false, ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "r2", RecordedBy: "p_admin", RecordedAt: now.Add(-2 * time.Hour)},
+		{ID: idgen.GenerateUUIDv7(), Permission: otherPermission, SubjectAccount: "faye", Granted: true, EffectiveFrom: timePtr(now.Add(-1 * time.Hour)), ExpiresAt: timePtr(now.AddDate(0, 1, 0)), ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "r3 — different permission", RecordedBy: "p_admin", RecordedAt: now.Add(-1 * time.Hour)},
+		{ID: idgen.GenerateUUIDv7(), Permission: model.PermissionExternalImageView, SubjectAccount: "other-subject", Granted: true, EffectiveFrom: timePtr(now), ExpiresAt: timePtr(now.AddDate(0, 1, 0)), ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "r4 — different subject", RecordedBy: "p_admin", RecordedAt: now},
+	}
+	// Ledger-fixture seeding only — no user docs exist for these accounts, so the
+	// state-apply half of RecordPermissionChange is an inert no-op here.
+	state := model.PermissionState{Granted: true, EffectiveFrom: timePtr(now.Add(-3 * time.Hour)), ExpiresAt: timePtr(now.AddDate(0, 1, 0)), UpdatedAt: now}
+	require.NoError(t, st.RecordPermissionChange(ctx, grants, state))
+
+	t.Run("filters by subjectAccount+permission, newest first", func(t *testing.T) {
+		results, total, err := st.ListPermissionGrants(ctx, "faye", model.PermissionExternalImageView, 1, 10)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), total)
+		require.Len(t, results, 2)
+		assert.Equal(t, "r2", results[0].Reason, "revoke row (recorded later) must come first")
+		assert.Equal(t, "r1", results[1].Reason)
+	})
+
+	t.Run("permission empty means all permissions for the subject", func(t *testing.T) {
+		results, total, err := st.ListPermissionGrants(ctx, "faye", "", 1, 10)
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), total)
+		assert.Len(t, results, 3)
+	})
+
+	t.Run("pagination – page 1 limit 1", func(t *testing.T) {
+		results, total, err := st.ListPermissionGrants(ctx, "faye", "", 1, 1)
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), total)
+		assert.Len(t, results, 1)
+	})
+
+	t.Run("pagination – page 2 limit 1 returns a disjoint row from page 1", func(t *testing.T) {
+		page1, total1, err := st.ListPermissionGrants(ctx, "faye", "", 1, 1)
+		require.NoError(t, err)
+		require.Len(t, page1, 1)
+
+		page2, total2, err := st.ListPermissionGrants(ctx, "faye", "", 2, 1)
+		require.NoError(t, err)
+		require.Len(t, page2, 1)
+
+		assert.Equal(t, int64(3), total1)
+		assert.Equal(t, int64(3), total2)
+		assert.NotEqual(t, page1[0].ID, page2[0].ID, "page 2 must return a different row than page 1 — skip must actually advance")
+	})
+
+	t.Run("no match returns empty with total 0", func(t *testing.T) {
+		results, total, err := st.ListPermissionGrants(ctx, "no-such-subject", "", 1, 10)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), total)
+		assert.Empty(t, results)
+	})
+
+	t.Run("every field round-trips through the explicit projection", func(t *testing.T) {
+		results, _, err := st.ListPermissionGrants(ctx, "other-subject", model.PermissionExternalImageView, 1, 10)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		g := results[0]
+		assert.NotEmpty(t, g.ID)
+		assert.Equal(t, model.PermissionExternalImageView, g.Permission)
+		assert.Equal(t, "other-subject", g.SubjectAccount)
+		assert.True(t, g.Granted)
+		require.NotNil(t, g.EffectiveFrom)
+		require.NotNil(t, g.ExpiresAt)
+		assert.Equal(t, "carol", g.ApplicantAccount)
+		assert.Equal(t, "dave", g.ApproverAccount)
+		assert.Equal(t, "r4 — different subject", g.Reason)
+		assert.Equal(t, "p_admin", g.RecordedBy)
+		assert.False(t, g.RecordedAt.IsZero())
+	})
+
+	t.Run("no filters (subjectAccount and permission both empty) returns every row, newest first", func(t *testing.T) {
+		results, total, err := st.ListPermissionGrants(ctx, "", "", 1, 10)
+		require.NoError(t, err)
+		assert.Equal(t, int64(4), total)
+		require.Len(t, results, 4)
+		// newest first across ALL subjects: r4 (other-subject, now), r3 (faye, now-1h),
+		// r2 (faye, now-2h), r1 (faye, now-3h).
+		assert.Equal(t, "r4 — different subject", results[0].Reason)
+		assert.Equal(t, "r3 — different permission", results[1].Reason)
+		assert.Equal(t, "r2", results[2].Reason)
+		assert.Equal(t, "r1", results[3].Reason)
+	})
+
+	t.Run("permission only (no subjectAccount) filters across every subject, newest first", func(t *testing.T) {
+		results, total, err := st.ListPermissionGrants(ctx, "", model.PermissionExternalImageView, 1, 10)
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), total)
+		require.Len(t, results, 3)
+		for _, g := range results {
+			assert.Equal(t, model.PermissionExternalImageView, g.Permission)
+		}
+		// newest first across faye + other-subject, otherPermission's row excluded:
+		// r4 (other-subject, now), r2 (faye revoke, now-2h), r1 (faye grant, now-3h).
+		assert.Equal(t, "r4 — different subject", results[0].Reason)
+		assert.Equal(t, "r2", results[1].Reason)
+		assert.Equal(t, "r1", results[2].Reason)
+	})
+
+	t.Run("same recordedAt ties break on _id desc", func(t *testing.T) {
+		shared := time.Now().UTC()
+		tieGrants := []*model.PermissionGrant{
+			{ID: "tie-a", Permission: model.PermissionExternalImageView, SubjectAccount: "tie-subject", Granted: true, EffectiveFrom: timePtr(shared), ExpiresAt: timePtr(shared.AddDate(0, 1, 0)), ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "batch row a", RecordedBy: "p_admin", RecordedAt: shared},
+			{ID: "tie-b", Permission: model.PermissionExternalImageView, SubjectAccount: "tie-subject", Granted: false, ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "batch row b", RecordedBy: "p_admin", RecordedAt: shared},
+		}
+		require.NoError(t, st.RecordPermissionChange(ctx, tieGrants, model.PermissionState{Granted: false, UpdatedAt: shared}))
+
+		results, total, err := st.ListPermissionGrants(ctx, "tie-subject", "", 1, 10)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), total)
+		require.Len(t, results, 2)
+		assert.Equal(t, "tie-b", results[0].ID, "identical recordedAt must tie-break on the larger _id")
+		assert.Equal(t, "tie-a", results[1].ID)
+	})
+}
+
+func TestIntegration_AppendAuditMany(t *testing.T) {
+	db := testutil.MongoDBReplicaSet(t, "adminsvc")
+	st := newStoreMongo(db)
+	require.NoError(t, st.EnsureIndexes(context.Background()))
+	ctx := context.Background()
+
+	entries := []*AuditEntry{
+		{ID: idgen.GenerateUUIDv7(), ActorUserID: "admin1", ActorAccount: "p_admin", Action: "permission.grant", TargetAccount: "alice", Details: map[string]string{"permission": "external.image.view"}, SiteID: "site-a", Timestamp: time.Now().UTC().UnixMilli()},
+		{ID: idgen.GenerateUUIDv7(), ActorUserID: "admin1", ActorAccount: "p_admin", Action: "permission.grant", TargetAccount: "bob", Details: map[string]string{"permission": "external.image.view"}, SiteID: "site-a", Timestamp: time.Now().UTC().UnixMilli()},
+	}
+	require.NoError(t, st.AppendAuditMany(ctx, entries))
+
+	results, total, err := st.ListAudit(ctx, "site-a", AuditFilter{Action: "permission.grant"}, 1, 10)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), total)
+	assert.Len(t, results, 2)
+
+	t.Run("empty batch is a no-op, not an error", func(t *testing.T) {
+		require.NoError(t, st.AppendAuditMany(ctx, nil))
+	})
+}
+
+// planStage captures one node of a MongoDB explain winningPlan tree. Decoded
+// via bson.Raw so nesting depth doesn't have to be known up front.
+type planStage struct {
+	Stage      string   `bson:"stage"`
+	IndexName  string   `bson:"indexName"`
+	InputStage bson.Raw `bson:"inputStage"`
+}
+
+// collectStages walks a winningPlan tree and returns every stage found,
+// outermost first, keeping each stage's indexName (empty for non-IXSCAN
+// stages) so callers can assert not just THAT an index was used but WHICH
+// one — two different indexes can produce an identical stage-name shape
+// (IXSCAN, no SORT) while serving the query very differently.
+func collectStages(t *testing.T, raw bson.Raw) []planStage {
+	t.Helper()
+	if len(raw) == 0 {
+		return nil
+	}
+	var s planStage
+	require.NoError(t, bson.Unmarshal(raw, &s))
+	return append([]planStage{s}, collectStages(t, s.InputStage)...)
+}
+
+// indexNameForKeys resolves the auto-generated name MongoDB assigned to the
+// index with exactly the given key spec, by listing the real indexes on the
+// collection rather than hand-predicting mongod's naming convention (field
+// order is significant for a compound index's identity, so this is an
+// ordered comparison, not a set comparison).
+func indexNameForKeys(ctx context.Context, t *testing.T, iv mongo.IndexView, want bson.D) string {
+	t.Helper()
+	specs, err := iv.ListSpecifications(ctx)
+	require.NoError(t, err)
+	for _, spec := range specs {
+		var got bson.D
+		require.NoError(t, bson.Unmarshal(spec.KeysDocument, &got))
+		if indexKeysEqual(got, want) {
+			return spec.Name
+		}
+	}
+	require.Fail(t, "no index found matching the expected key spec — did EnsureIndexes change?")
+	return ""
+}
+
+// indexKeysEqual compares two index key specs field-by-field, in order.
+func indexKeysEqual(got, want bson.D) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i].Key != want[i].Key || indexDirection(got[i].Value) != indexDirection(want[i].Value) {
+			return false
+		}
+	}
+	return true
+}
+
+// indexDirection normalizes a decoded BSON numeric (int32/int64/float64) index
+// direction to int64 so driver-decoded values compare cleanly against Go int literals.
+func indexDirection(v any) int64 {
+	switch n := v.(type) {
+	case int32:
+		return int64(n)
+	case int64:
+		return n
+	case float64:
+		return int64(n)
+	case int:
+		return int64(n)
+	}
+	return 0
+}
+
+func TestIntegration_ListPermissionGrants_UsesIndexNoInMemorySort(t *testing.T) {
+	db := testutil.MongoDBReplicaSet(t, "adminsvc")
+	st := newStoreMongo(db)
+	require.NoError(t, st.EnsureIndexes(context.Background()))
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	require.NoError(t, st.RecordPermissionChange(ctx, []*model.PermissionGrant{
+		{ID: idgen.GenerateUUIDv7(), Permission: model.PermissionExternalImageView, SubjectAccount: "gina", Granted: true, EffectiveFrom: timePtr(now), ExpiresAt: timePtr(now.AddDate(0, 1, 0)), ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "r1", RecordedBy: "p_admin", RecordedAt: now},
+	}, model.PermissionState{Granted: true, EffectiveFrom: timePtr(now), ExpiresAt: timePtr(now.AddDate(0, 1, 0)), UpdatedAt: now}))
+
+	tests := []struct {
+		name      string
+		filter    bson.D
+		indexKeys bson.D // the compound index that must serve the query
+	}{
+		{
+			name: "subjectAccount+permission lookup",
+			filter: bson.D{
+				{Key: "permission", Value: string(model.PermissionExternalImageView)},
+				{Key: "subjectAccount", Value: "gina"},
+			},
+			indexKeys: bson.D{
+				{Key: "permission", Value: 1},
+				{Key: "subjectAccount", Value: 1},
+				{Key: "recordedAt", Value: -1},
+				{Key: "_id", Value: -1},
+			},
+		},
+		{
+			// The default landing view: GET with no subjectAccount/permission filters.
+			// Ties on recordedAt are guaranteed (createPermissions stamps one `now`
+			// across a multi-subject batch), so the browse index must also carry the
+			// _id tiebreaker or every page load pays a blocking in-memory SORT.
+			name:   "no-filter browse",
+			filter: bson.D{},
+			indexKeys: bson.D{
+				{Key: "recordedAt", Value: -1},
+				{Key: "_id", Value: -1},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Resolve the compound index's real auto-generated name at runtime
+			// (rather than hardcoding mongod's naming convention), so the assertion
+			// below can prove WHICH index served the query, not just that some index did.
+			wantIndexName := indexNameForKeys(ctx, t, st.permGrants.Indexes(), tc.indexKeys)
+			t.Logf("compound index resolved to name %q", wantIndexName)
+
+			cmd := bson.D{
+				{Key: "explain", Value: bson.D{
+					{Key: "find", Value: "permission_grants"},
+					{Key: "filter", Value: tc.filter},
+					{Key: "sort", Value: bson.D{{Key: "recordedAt", Value: -1}, {Key: "_id", Value: -1}}},
+				}},
+				{Key: "verbosity", Value: "queryPlanner"},
+			}
+
+			var result struct {
+				QueryPlanner struct {
+					WinningPlan bson.Raw `bson:"winningPlan"`
+				} `bson:"queryPlanner"`
+			}
+			require.NoError(t, db.RunCommand(ctx, cmd).Decode(&result))
+
+			stages := collectStages(t, result.QueryPlanner.WinningPlan)
+
+			var ixscanNames []string
+			sawSort := false
+			for _, s := range stages {
+				switch s.Stage {
+				case "IXSCAN":
+					ixscanNames = append(ixscanNames, s.IndexName)
+				case "SORT":
+					sawSort = true
+				}
+			}
+
+			require.NotEmpty(t, ixscanNames, "the hot query must use an index, not a collection scan")
+			assert.Equal(t, []string{wantIndexName}, ixscanNames,
+				"the query must be served by the expected compound index; a different index could still "+
+					"IXSCAN with no SORT stage — identical shape, wrong index — which is exactly what this "+
+					"assertion (as opposed to a stage-names-only check) catches")
+			assert.False(t, sawSort, "recordedAt desc,_id desc must come free from the index — no in-memory sort")
+		})
+	}
+}
+
+// -------------------------------------------------------------------------
 // TestLoginAndChangePasswordEndToEnd
 // -------------------------------------------------------------------------
 
@@ -602,7 +1261,7 @@ func TestLoginAndChangePasswordEndToEnd(t *testing.T) {
 	require.NoError(t, store.EnsureIndexes(context.Background()))
 
 	cfg := Config{SiteID: "site-a", BcryptCost: 4, SessionsMaxPerAccount: 100}
-	h := newHandler(store, sessions, cfg, nil)
+	h := newHandler(store, sessions, cfg, nil, nil)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.New()

--- a/admin-service/login_test.go
+++ b/admin-service/login_test.go
@@ -25,7 +25,7 @@ import (
 func loginRouter(t *testing.T, adminStore AdminStore, sessions session.Store, cfg Config) *gin.Engine { //nolint:gocritic // hugeParam: Config is a test-local value, cheap to copy per call
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	h := newHandler(adminStore, sessions, cfg, nil)
+	h := newHandler(adminStore, sessions, cfg, nil, nil)
 	r.POST("/v1/login", h.handleLogin)
 	return r
 }
@@ -373,7 +373,7 @@ func TestHandleLogin_TimingConsistent(t *testing.T) {
 func changePasswordRouter(t *testing.T, adminStore AdminStore, sessions session.Store, cfg Config) *gin.Engine { //nolint:gocritic // hugeParam: Config is a test-local value, cheap to copy per call
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	h := newHandler(adminStore, sessions, cfg, nil)
+	h := newHandler(adminStore, sessions, cfg, nil, nil)
 	r.POST("/v1/password/change", requireAdmin(sessions, cfg.SiteID), h.handleChangePassword)
 	return r
 }

--- a/admin-service/main.go
+++ b/admin-service/main.go
@@ -41,6 +41,12 @@ func run() error {
 		return fmt.Errorf("init observability: %w", err)
 	}
 
+	// Logged after obs.Init so it lands in the JSON handler like every other line.
+	if len(remoteSites(cfg.AllSiteIDs, cfg.SiteID)) == 0 {
+		slog.Warn("no remote peers in ALL_SITE_IDS — cross-site permission fanout is disabled; permission changes stay local to this site",
+			"site", cfg.SiteID, "all_site_ids", cfg.AllSiteIDs)
+	}
+
 	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
 	if err != nil {
 		return fmt.Errorf("connect mongo: %w", err)
@@ -61,7 +67,19 @@ func run() error {
 		return fmt.Errorf("connect nats: %w", err)
 	}
 
-	h := newHandler(st, sessStore, cfg, nc)
+	js, err := nc.JetStream()
+	if err != nil {
+		return fmt.Errorf("jetstream: %w", err)
+	}
+	// PublishMsg (not Publish) so X-Request-ID from ctx rides onto the outgoing
+	// message — same shape as user-service/publisher.
+	publishInbox := func(ctx context.Context, subj string, data []byte) error {
+		if _, err := js.PublishMsg(ctx, natsutil.NewMsg(ctx, subj, data)); err != nil {
+			return fmt.Errorf("publish inbox event: %w", err)
+		}
+		return nil
+	}
+	h := newHandler(st, sessStore, cfg, nc, publishInbox)
 
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()

--- a/admin-service/mock_store_test.go
+++ b/admin-service/mock_store_test.go
@@ -55,6 +55,20 @@ func (mr *MockAdminStoreMockRecorder) AppendAudit(ctx, e any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendAudit", reflect.TypeOf((*MockAdminStore)(nil).AppendAudit), ctx, e)
 }
 
+// AppendAuditMany mocks base method.
+func (m *MockAdminStore) AppendAuditMany(ctx context.Context, entries []*AuditEntry) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AppendAuditMany", ctx, entries)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AppendAuditMany indicates an expected call of AppendAuditMany.
+func (mr *MockAdminStoreMockRecorder) AppendAuditMany(ctx, entries any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendAuditMany", reflect.TypeOf((*MockAdminStore)(nil).AppendAuditMany), ctx, entries)
+}
+
 // CreateUser mocks base method.
 func (m *MockAdminStore) CreateUser(ctx context.Context, u *model.User) error {
 	m.ctrl.T.Helper()
@@ -97,6 +111,21 @@ func (mr *MockAdminStoreMockRecorder) EnsureIndexes(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureIndexes", reflect.TypeOf((*MockAdminStore)(nil).EnsureIndexes), ctx)
 }
 
+// FindAccountStates mocks base method.
+func (m *MockAdminStore) FindAccountStates(ctx context.Context, accounts []string) (map[string]bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindAccountStates", ctx, accounts)
+	ret0, _ := ret[0].(map[string]bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindAccountStates indicates an expected call of FindAccountStates.
+func (mr *MockAdminStoreMockRecorder) FindAccountStates(ctx, accounts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAccountStates", reflect.TypeOf((*MockAdminStore)(nil).FindAccountStates), ctx, accounts)
+}
+
 // GetUserByAccount mocks base method.
 func (m *MockAdminStore) GetUserByAccount(ctx context.Context, siteID, account string) (*model.User, error) {
 	m.ctrl.T.Helper()
@@ -127,6 +156,36 @@ func (mr *MockAdminStoreMockRecorder) GetUserForAuth(ctx, siteID, account any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserForAuth", reflect.TypeOf((*MockAdminStore)(nil).GetUserForAuth), ctx, siteID, account)
 }
 
+// GetUserPermissions mocks base method.
+func (m *MockAdminStore) GetUserPermissions(ctx context.Context, account string) (*model.UserPermissions, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserPermissions", ctx, account)
+	ret0, _ := ret[0].(*model.UserPermissions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserPermissions indicates an expected call of GetUserPermissions.
+func (mr *MockAdminStoreMockRecorder) GetUserPermissions(ctx, account any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserPermissions", reflect.TypeOf((*MockAdminStore)(nil).GetUserPermissions), ctx, account)
+}
+
+// GetUserPermissionsForAccounts mocks base method.
+func (m *MockAdminStore) GetUserPermissionsForAccounts(ctx context.Context, accounts []string) (map[string]*model.UserPermissions, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserPermissionsForAccounts", ctx, accounts)
+	ret0, _ := ret[0].(map[string]*model.UserPermissions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserPermissionsForAccounts indicates an expected call of GetUserPermissionsForAccounts.
+func (mr *MockAdminStoreMockRecorder) GetUserPermissionsForAccounts(ctx, accounts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserPermissionsForAccounts", reflect.TypeOf((*MockAdminStore)(nil).GetUserPermissionsForAccounts), ctx, accounts)
+}
+
 // ListAudit mocks base method.
 func (m *MockAdminStore) ListAudit(ctx context.Context, siteID string, f AuditFilter, page, limit int) ([]AuditEntry, int64, error) {
 	m.ctrl.T.Helper()
@@ -143,6 +202,22 @@ func (mr *MockAdminStoreMockRecorder) ListAudit(ctx, siteID, f, page, limit any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAudit", reflect.TypeOf((*MockAdminStore)(nil).ListAudit), ctx, siteID, f, page, limit)
 }
 
+// ListPermissionGrants mocks base method.
+func (m *MockAdminStore) ListPermissionGrants(ctx context.Context, subjectAccount string, permission model.PermissionKey, page, limit int) ([]model.PermissionGrant, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPermissionGrants", ctx, subjectAccount, permission, page, limit)
+	ret0, _ := ret[0].([]model.PermissionGrant)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListPermissionGrants indicates an expected call of ListPermissionGrants.
+func (mr *MockAdminStoreMockRecorder) ListPermissionGrants(ctx, subjectAccount, permission, page, limit any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPermissionGrants", reflect.TypeOf((*MockAdminStore)(nil).ListPermissionGrants), ctx, subjectAccount, permission, page, limit)
+}
+
 // Ping mocks base method.
 func (m *MockAdminStore) Ping(ctx context.Context) error {
 	m.ctrl.T.Helper()
@@ -155,6 +230,20 @@ func (m *MockAdminStore) Ping(ctx context.Context) error {
 func (mr *MockAdminStoreMockRecorder) Ping(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockAdminStore)(nil).Ping), ctx)
+}
+
+// RecordPermissionChange mocks base method.
+func (m *MockAdminStore) RecordPermissionChange(ctx context.Context, grants []*model.PermissionGrant, state model.PermissionState) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RecordPermissionChange", ctx, grants, state)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RecordPermissionChange indicates an expected call of RecordPermissionChange.
+func (mr *MockAdminStoreMockRecorder) RecordPermissionChange(ctx, grants, state any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordPermissionChange", reflect.TypeOf((*MockAdminStore)(nil).RecordPermissionChange), ctx, grants, state)
 }
 
 // SearchUsers mocks base method.

--- a/admin-service/permissions.go
+++ b/admin-service/permissions.go
@@ -1,0 +1,570 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/errcode/errhttp"
+	"github.com/hmchangw/chat/pkg/idgen"
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+// tzTaipei is the fixed date-interpretation rule (spec §8.1). Never time.Local.
+var tzTaipei = time.FixedZone("UTC+8", 8*60*60)
+
+const (
+	auditActionPermissionGrant  = "permission.grant"
+	auditActionPermissionRevoke = "permission.revoke"
+)
+
+// permissionRequest is the request body for POST /v1/admin/permissions.
+// EffectiveFrom/ExpiresAt are pointers so the handler can distinguish
+// "omitted" (nil) from "empty string" — required for the revoke-must-omit
+// rule (spec §4.4 step 9). Granted is a pointer for the same reason: an
+// omitted "granted" must be rejected, not silently default to false/revoke —
+// see the missing-fields check below (no binding tag, to keep the reason
+// grouped with applicantAccount/approverAccount as missing_permission_fields
+// rather than the generic JSON-bind bad_request).
+type permissionRequest struct {
+	Permission       string   `json:"permission"`
+	SubjectAccounts  []string `json:"subjectAccounts"`
+	Granted          *bool    `json:"granted"`
+	EffectiveFrom    *string  `json:"effectiveFrom"` // "2026-09-01"; nil on grant = now
+	ExpiresAt        *string  `json:"expiresAt"`     // "2026-12-31"; required on grant
+	ApplicantAccount string   `json:"applicantAccount"`
+	ApproverAccount  string   `json:"approverAccount"`
+	Reason           string   `json:"reason"`
+}
+
+type createPermissionsResponse struct {
+	Created           int      `json:"created"`
+	DuplicatesIgnored []string `json:"duplicatesIgnored"` // [] not null
+	// SyncFailures lists remote sites whose cross-site fanout publish did not land —
+	// omitted (not []) when every destination succeeded. The ledger write already
+	// committed regardless; this only flags which peers may be out of sync.
+	SyncFailures []string `json:"syncFailures,omitempty"`
+}
+
+// dedupPreserveOrder returns subjectAccounts with duplicates removed,
+// keeping each account's first-occurrence position, plus the accounts that
+// were dropped, in the order they were dropped. Never returns a nil
+// duplicates slice — the response field must marshal as [], not null.
+func dedupPreserveOrder(accounts []string) (deduped, duplicates []string) {
+	seen := make(map[string]bool, len(accounts))
+	deduped = make([]string, 0, len(accounts))
+	duplicates = []string{}
+	for _, a := range accounts {
+		if seen[a] {
+			duplicates = append(duplicates, a)
+			continue
+		}
+		seen[a] = true
+		deduped = append(deduped, a)
+	}
+	return deduped, duplicates
+}
+
+// parseWindow validates and converts the request window. Call ONLY when
+// granted=true. fromStr nil means effective immediately (now). until is the
+// day-after-untilStr at midnight tzTaipei — the half-open interval's
+// exclusive end (spec §3.4).
+func parseWindow(fromStr, untilStr *string, now time.Time) (from, until time.Time, err error) {
+	if untilStr == nil {
+		return time.Time{}, time.Time{}, errors.New("expiresAt is required for a grant")
+	}
+
+	untilDay, err := time.ParseInLocation("2006-01-02", *untilStr, tzTaipei)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("expiresAt must be YYYY-MM-DD: %w", err)
+	}
+	until = time.Date(untilDay.Year(), untilDay.Month(), untilDay.Day()+1, 0, 0, 0, 0, tzTaipei)
+
+	if fromStr == nil {
+		from = now
+	} else {
+		from, err = time.ParseInLocation("2006-01-02", *fromStr, tzTaipei)
+		if err != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("effectiveFrom must be YYYY-MM-DD: %w", err)
+		}
+	}
+
+	// until-not-in-the-past is checked before from-vs-until: fromStr==nil makes
+	// from default to now, which is always > a past until. Checking from-vs-until
+	// first would then report a misleading "effectiveFrom must not be after
+	// expiresAt" about a field the caller never sent.
+	if !until.After(now) {
+		return time.Time{}, time.Time{}, errors.New("expiresAt must not be in the past")
+	}
+	// until is already shifted +1 day from the caller's civil expiresAt, so
+	// from==until (from is one full day past expiresAt) must be rejected too —
+	// from.Before(until), not the weaker from.After(until)==false.
+	if !from.Before(until) {
+		return time.Time{}, time.Time{}, errors.New("effectiveFrom must not be after expiresAt")
+	}
+
+	return from, until, nil
+}
+
+// displayDate renders the civil date of t in tzTaipei ("2006-01-02") — the
+// admin GET's rendering of EffectiveFrom.
+func displayDate(t time.Time) string {
+	return t.In(tzTaipei).Format("2006-01-02")
+}
+
+// displayUntilDate renders the inclusive end date: the civil date of t in
+// tzTaipei minus one day. t is the stored half-open ExpiresAt instant
+// (already +1 day from what the admin typed); this reverses that shift so
+// the admin GET never shows the exclusive boundary (spec §3.4).
+func displayUntilDate(t time.Time) string {
+	return displayDate(t.AddDate(0, 0, -1))
+}
+
+// createPermissions handles POST /v1/admin/permissions — grants or revokes
+// a permission for one or more subject accounts, all-or-nothing, with one
+// audit entry per created row. Validation order matches spec §4.4 exactly.
+func (h *Handler) createPermissions(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	var req permissionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errhttp.Write(ctx, c, errcode.BadRequest("invalid request body",
+			errcode.WithReason(errcode.AuthMissingFields)))
+		return
+	}
+
+	if !model.KnownPermission(model.PermissionKey(req.Permission)) {
+		errhttp.Write(ctx, c, errcode.BadRequest("unknown permission",
+			errcode.WithReason(errcode.PermissionUnknownKey)))
+		return
+	}
+
+	if len(req.SubjectAccounts) == 0 {
+		errhttp.Write(ctx, c, errcode.BadRequest("subjectAccounts must not be empty",
+			errcode.WithReason(errcode.PermissionInvalidSubjects)))
+		return
+	}
+
+	subjects, duplicatesIgnored := dedupPreserveOrder(req.SubjectAccounts)
+
+	if utf8.RuneCountInString(req.Reason) > model.MaxReasonRunes {
+		errhttp.Write(ctx, c, errcode.BadRequest(fmt.Sprintf("reason must be at most %d runes", model.MaxReasonRunes),
+			errcode.WithReason(errcode.PermissionInvalidReason)))
+		return
+	}
+
+	if req.Granted == nil || req.ApplicantAccount == "" || req.ApproverAccount == "" {
+		errhttp.Write(ctx, c, errcode.BadRequest("granted, applicantAccount, and approverAccount are required",
+			errcode.WithReason(errcode.PermissionMissingFields)))
+		return
+	}
+	granted := *req.Granted
+
+	now := time.Now().UTC()
+
+	var from, until time.Time
+	if granted {
+		var err error
+		from, until, err = parseWindow(req.EffectiveFrom, req.ExpiresAt, now)
+		if err != nil {
+			errhttp.Write(ctx, c, errcode.BadRequest(err.Error(),
+				errcode.WithReason(errcode.PermissionInvalidWindow)))
+			return
+		}
+	} else if req.EffectiveFrom != nil || req.ExpiresAt != nil {
+		errhttp.Write(ctx, c, errcode.BadRequest("effectiveFrom and expiresAt must be absent on a revoke",
+			errcode.WithReason(errcode.PermissionUnexpectedWindow)))
+		return
+	}
+
+	// FindAccountStates must see every account this request references — subjects
+	// plus applicant/approver (spec §4.4 step 10: "all accounts exist at this site;
+	// subjects additionally pass IsActive()"). subjects is already deduped above, so
+	// only applicant/approver can repeat an entry; $in and the returned map tolerate it.
+	checkAccounts := append(slices.Clone(subjects), req.ApplicantAccount, req.ApproverAccount)
+
+	states, err := h.store.FindAccountStates(ctx, checkAccounts)
+	if err != nil {
+		errhttp.Write(ctx, c, fmt.Errorf("find account states: %w", err))
+		return
+	}
+
+	// Existence applies to subjects AND applicant/approver; IsActive() applies to
+	// subjects only — an inactive applicant/approver is explicitly allowed (spec
+	// §4.4 step 10; docs/client-api.md §9.13). The subjects lead checkAccounts, so
+	// i < len(subjects) is the is-a-subject test, and seen keeps an applicant or
+	// approver that repeats an earlier entry from being reported twice.
+	seen := make(map[string]bool, len(checkAccounts))
+	var unknown, inactive []string
+	for i, acct := range checkAccounts {
+		if seen[acct] {
+			continue
+		}
+		seen[acct] = true
+		switch active, exists := states[acct]; {
+		case !exists:
+			unknown = append(unknown, acct)
+		case i < len(subjects) && !active:
+			inactive = append(inactive, acct)
+		}
+	}
+	// Metadata "accounts" is CLIENT-VISIBLE by design (errcode doc.go) — the console
+	// renders it so the admin sees exactly which accounts were rejected; the message
+	// carries the same list for curl callers.
+	if len(unknown) > 0 {
+		errhttp.Write(ctx, c, errcode.NotFound("unknown accounts: "+strings.Join(unknown, ", "),
+			errcode.WithReason(errcode.PermissionUnknownAccounts),
+			errcode.WithMetadata("accounts", strings.Join(unknown, ", "))))
+		return
+	}
+	if len(inactive) > 0 {
+		errhttp.Write(ctx, c, errcode.BadRequest("inactive accounts cannot be granted a permission: "+strings.Join(inactive, ", "),
+			errcode.WithReason(errcode.PermissionInactiveSubject),
+			errcode.WithMetadata("accounts", strings.Join(inactive, ", "))))
+		return
+	}
+
+	key := model.PermissionKey(req.Permission)
+	principal := principalFrom(c)
+	grants := make([]*model.PermissionGrant, len(subjects))
+	for i, acct := range subjects {
+		g := &model.PermissionGrant{
+			ID:               idgen.GenerateUUIDv7(),
+			Permission:       key,
+			SubjectAccount:   acct,
+			Granted:          granted,
+			ApplicantAccount: req.ApplicantAccount,
+			ApproverAccount:  req.ApproverAccount,
+			Reason:           req.Reason,
+			RecordedBy:       principal.Account,
+			RecordedAt:       now,
+		}
+		if granted {
+			g.EffectiveFrom = &from
+			g.ExpiresAt = &until
+		}
+		grants[i] = g
+	}
+
+	state := model.PermissionState{Granted: *req.Granted, UpdatedAt: now}
+	if *req.Granted {
+		state.EffectiveFrom = &from
+		state.ExpiresAt = &until
+	}
+	if err := h.store.RecordPermissionChange(ctx, grants, state); err != nil {
+		errhttp.Write(ctx, c, fmt.Errorf("record permission change: %w", err))
+		return
+	}
+
+	// Audit BEFORE the fanout, not after: the fanout can burn its full budget on an
+	// unreachable peer, and this runs on the request ctx — a client disconnect during
+	// that window would cancel the audit write and lose every entry for a ledger write
+	// that already committed. Best-effort either way: a failure is logged, never fatal.
+	action := auditActionPermissionRevoke
+	if granted {
+		action = auditActionPermissionGrant
+	}
+	entries := make([]*AuditEntry, len(grants))
+	for i, g := range grants {
+		entries[i] = h.auditEntry(c, action, "", g.SubjectAccount,
+			map[string]string{"permission": string(g.Permission)}, now)
+	}
+	if err := h.store.AppendAuditMany(ctx, entries); err != nil {
+		slog.ErrorContext(ctx, "append permission audit entries failed", "action", action, "error", err)
+	}
+
+	fanoutCtx, cancelFanout := fanoutContext(ctx)
+	defer cancelFanout()
+	syncFailures := h.publishPermissionFanout(fanoutCtx, key, subjects, state)
+
+	c.JSON(http.StatusCreated, createPermissionsResponse{
+		Created:           len(grants),
+		DuplicatesIgnored: duplicatesIgnored,
+		SyncFailures:      syncFailures,
+	})
+}
+
+// fanoutChunkSize bounds one UserPermissionsUpdated event's Accounts so a worst-case
+// event stays ~320KB — 3× margin under NATS's default 1MB max_payload.
+const fanoutChunkSize = 5000
+
+// fanoutTimeout is the server-side budget for ONE request's whole cross-site fanout,
+// however many publishPermissionFanout calls that takes — resync makes one per state
+// group, and a per-call budget would multiply wall time by the group count until it
+// exceeded httpWriteTimeout and the admin lost the syncFailures reply.
+const fanoutTimeout = 5 * time.Second
+
+// fanoutContext derives the fanout budget from a request ctx. The request ctx has no
+// deadline and dies if the client disconnects — neither fits: the ledger write already
+// committed, so fanout runs to completion on its own budget. A destination that doesn't
+// land within it is reported in syncFailures like any other unacknowledged publish.
+func fanoutContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), fanoutTimeout)
+}
+
+// publishPermissionFanout publishes the batch to every remote site's INBOX, one event
+// per site per chunk of accounts. Failures are logged and aggregated per destination and
+// never abort the fanout — one dead peer must not block the others. Returns the
+// destinations whose publish was not acknowledged (nil when all landed). ctx must come
+// from fanoutContext — the caller owns the budget so repeated calls share one.
+func (h *Handler) publishPermissionFanout(ctx context.Context, permission model.PermissionKey, accounts []string, state model.PermissionState) []string {
+	dests := remoteSites(h.cfg.AllSiteIDs, h.cfg.SiteID)
+	if h.publishInbox == nil || len(accounts) == 0 || len(dests) == 0 {
+		return nil
+	}
+
+	now := time.Now().UTC().UnixMilli()
+	// Marshal each chunk's payload once; only the envelope differs per destination.
+	var chunks [][]byte
+	for start := 0; start < len(accounts); start += fanoutChunkSize {
+		end := min(start+fanoutChunkSize, len(accounts))
+		payload, err := json.Marshal(model.UserPermissionsUpdated{
+			Permission: permission,
+			Accounts:   accounts[start:end],
+			State:      state,
+			Timestamp:  now,
+		})
+		if err != nil {
+			// Cannot serialize the event at all: every destination is out of sync.
+			slog.ErrorContext(ctx, "marshal user permissions event", "error", err)
+			return dests
+		}
+		chunks = append(chunks, payload)
+	}
+
+	// One goroutine per destination. Destinations are independent and share ONE budget
+	// (fanoutContext), so publishing them serially lets a single unreachable peer burn
+	// the whole budget and hand every peer behind it an already-expired ctx — reporting
+	// healthy sites as sync failures. Results land in a position-indexed slice, so no
+	// lock is needed and the reported order stays the configured destination order.
+	failed := make([]bool, len(dests))
+	var g errgroup.Group
+	for i, dest := range dests {
+		g.Go(func() error {
+			for _, payload := range chunks {
+				data, err := json.Marshal(model.InboxEvent{
+					Type:       model.InboxUserPermissionsUpdated,
+					SiteID:     h.cfg.SiteID,
+					DestSiteID: dest,
+					Payload:    payload,
+					Timestamp:  now,
+				})
+				if err != nil {
+					slog.ErrorContext(ctx, "marshal permissions inbox envelope", "dest", dest, "error", err)
+					failed[i] = true
+					continue
+				}
+				if err := h.publishInbox(ctx, subject.InboxExternal(dest, model.InboxUserPermissionsUpdated), data); err != nil {
+					// Not self-healing like status/settings: surface it, don't swallow it.
+					slog.ErrorContext(ctx, "publish permissions inbox event", "dest", dest, "error", err)
+					failed[i] = true
+				}
+			}
+			return nil
+		})
+	}
+	_ = g.Wait() // every goroutine returns nil; per-destination outcomes are in failed
+
+	var failures []string
+	for i, dest := range dests {
+		if failed[i] {
+			failures = append(failures, dest)
+		}
+	}
+	return failures
+}
+
+// remoteSites filters allSiteIDs down to real remote destinations.
+func remoteSites(allSiteIDs []string, self string) []string {
+	var out []string
+	for _, dest := range allSiteIDs {
+		if dest != "" && dest != self {
+			out = append(out, dest)
+		}
+	}
+	return out
+}
+
+type resyncPermissionsRequest struct {
+	Permission string   `json:"permission"`
+	Accounts   []string `json:"accounts"`
+}
+
+type resyncPermissionsResponse struct {
+	SyncFailures []string `json:"syncFailures,omitempty"`
+}
+
+// resyncPermissions re-delivers the current materialized state for the given accounts —
+// re-delivery, not re-recording: it writes nothing (no ledger, no audit, no user docs)
+// and is idempotent (delivered states keep their stored watermarks, so remote guards
+// no-op anything already applied).
+func (h *Handler) resyncPermissions(c *gin.Context) {
+	ctx := c.Request.Context()
+	var req resyncPermissionsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errhttp.Write(ctx, c, errcode.BadRequest("invalid request body", errcode.WithReason(errcode.AuthMissingFields)))
+		return
+	}
+	key := model.PermissionKey(req.Permission)
+	if !model.KnownPermission(key) {
+		errhttp.Write(ctx, c, errcode.BadRequest("unknown permission", errcode.WithReason(errcode.PermissionUnknownKey)))
+		return
+	}
+	accounts, _ := dedupPreserveOrder(req.Accounts)
+	if len(accounts) == 0 {
+		errhttp.Write(ctx, c, errcode.BadRequest("accounts must be non-empty", errcode.WithReason(errcode.PermissionInvalidSubjects)))
+		return
+	}
+	perms, err := h.store.GetUserPermissionsForAccounts(ctx, accounts)
+	if err != nil {
+		errhttp.Write(ctx, c, fmt.Errorf("load user permissions: %w", err))
+		return
+	}
+	// Group by the state's canonical JSON: PermissionState holds pointers, so it can't
+	// be a map key itself. Field order is fixed by the struct and a nil bound (omitted)
+	// serializes distinctly from any set bound, so distinct states never collide; the
+	// worst case for a future field is one extra — and idempotent — fanout group.
+	groups := make(map[string][]string)
+	states := make(map[string]model.PermissionState)
+	for _, account := range accounts {
+		st := perms[account].State(key)
+		if st == nil {
+			continue // no doc or nothing recorded — nothing to sync
+		}
+		// Error discarded: PermissionState is bools, times, and pointers to them.
+		k, _ := json.Marshal(st)
+		groups[string(k)] = append(groups[string(k)], account)
+		states[string(k)] = *st
+	}
+	// ONE budget for the whole resync, not one per group: groups are keyed on
+	// UpdatedAt, so accounts granted across N admin submits yield N groups, and a
+	// per-group budget would stretch an unreachable peer's wall time to N × the
+	// budget — past httpWriteTimeout, which drops the connection before the admin
+	// can be told which peers to retry.
+	fanoutCtx, cancel := fanoutContext(ctx)
+	defer cancel()
+	seen := make(map[string]struct{})
+	var failures []string
+	for k, groupAccounts := range groups {
+		for _, dest := range h.publishPermissionFanout(fanoutCtx, key, groupAccounts, states[k]) {
+			if _, dup := seen[dest]; !dup {
+				seen[dest] = struct{}{}
+				failures = append(failures, dest)
+			}
+		}
+	}
+	c.JSON(http.StatusOK, resyncPermissionsResponse{SyncFailures: failures})
+}
+
+// permissionGrantView renders one ledger row for the admin GET: display
+// dates (civil, tzTaipei), not raw instants — spec §3.4. Revoke rows have no
+// window, so EffectiveFrom/ExpiresAt stay "" and are omitted.
+type permissionGrantView struct {
+	ID               string    `json:"id"`
+	Permission       string    `json:"permission"`
+	SubjectAccount   string    `json:"subjectAccount"`
+	Granted          bool      `json:"granted"`
+	EffectiveFrom    string    `json:"effectiveFrom,omitempty"` // "2026-09-01"; empty on revoke rows
+	ExpiresAt        string    `json:"expiresAt,omitempty"`     // "2026-12-31"; empty on revoke rows
+	ApplicantAccount string    `json:"applicantAccount"`
+	ApproverAccount  string    `json:"approverAccount"`
+	Reason           string    `json:"reason"`
+	RecordedBy       string    `json:"recordedBy"`
+	RecordedAt       time.Time `json:"recordedAt"`
+}
+
+type listPermissionsResponse struct {
+	// CurrentlyGranted is present ONLY when BOTH subjectAccount and permission
+	// query params were supplied — a latest-wins decision is meaningless
+	// without both (there is no single decision across multiple subjects or
+	// across multiple permissions).
+	CurrentlyGranted *bool                 `json:"currentlyGranted,omitempty"`
+	Entries          []permissionGrantView `json:"entries"`
+	Total            int64                 `json:"total"`
+}
+
+// toPermissionGrantView converts a stored grant row to its display form.
+func toPermissionGrantView(g *model.PermissionGrant) permissionGrantView {
+	v := permissionGrantView{
+		ID:               g.ID,
+		Permission:       string(g.Permission),
+		SubjectAccount:   g.SubjectAccount,
+		Granted:          g.Granted,
+		ApplicantAccount: g.ApplicantAccount,
+		ApproverAccount:  g.ApproverAccount,
+		Reason:           g.Reason,
+		RecordedBy:       g.RecordedBy,
+		RecordedAt:       g.RecordedAt,
+	}
+	if g.EffectiveFrom != nil {
+		v.EffectiveFrom = displayDate(*g.EffectiveFrom)
+	}
+	if g.ExpiresAt != nil {
+		v.ExpiresAt = displayUntilDate(*g.ExpiresAt)
+	}
+	return v
+}
+
+// listPermissions handles GET /v1/admin/permissions — returns the ledger
+// company-wide, newest-first, optionally filtered by subjectAccount and/or
+// permission (both independently optional), plus the current computed
+// decision when both filters narrow to a single subject+permission (spec
+// §4.6).
+func (h *Handler) listPermissions(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	subjectAccount := c.Query("subjectAccount")
+
+	permission := model.PermissionKey(c.Query("permission"))
+	if permission != "" && !model.KnownPermission(permission) {
+		errhttp.Write(ctx, c, errcode.BadRequest("unknown permission",
+			errcode.WithReason(errcode.PermissionUnknownKey)))
+		return
+	}
+
+	page, limit := parsePaging(c, 1, 20)
+
+	grants, total, err := h.store.ListPermissionGrants(ctx, subjectAccount, permission, page, limit)
+	if err != nil {
+		errhttp.Write(ctx, c, fmt.Errorf("list permission grants: %w", err))
+		return
+	}
+
+	entries := make([]permissionGrantView, len(grants))
+	for i := range grants {
+		entries[i] = toPermissionGrantView(&grants[i])
+	}
+
+	resp := listPermissionsResponse{
+		Entries: entries,
+		Total:   total,
+	}
+
+	// currentlyGranted reads the materialized per-account permission snapshot —
+	// meaningless without both filters (there's no single decision across
+	// multiple subjects or multiple permissions), so it's computed and included
+	// only when the caller supplied both (spec §4.6).
+	if permission != "" && subjectAccount != "" {
+		perms, err := h.store.GetUserPermissions(ctx, subjectAccount)
+		if err != nil {
+			errhttp.Write(ctx, c, fmt.Errorf("get user permissions: %w", err))
+			return
+		}
+		granted := perms.Evaluated(time.Now().UTC())[permission]
+		resp.CurrentlyGranted = &granted
+	}
+
+	c.JSON(http.StatusOK, resp)
+}

--- a/admin-service/permissions_test.go
+++ b/admin-service/permissions_test.go
@@ -1,0 +1,1575 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/session"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+// setupPermissionsRouter wires h into a Gin engine with the same fake
+// requireAdmin principal injection as setupRouter (handler_test.go), wired to
+// only the permission routes.
+func setupPermissionsRouter(h *Handler) *gin.Engine {
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(ctxPrincipal, session.Session{
+			ID:      "sess-1",
+			UserID:  "admin-user-id",
+			Account: "p_admin",
+			SiteID:  "site-A",
+			Roles:   []string{"admin"},
+		})
+		c.Next()
+	})
+	r.POST("/permissions", h.createPermissions)
+	r.GET("/permissions", h.listPermissions)
+	r.POST("/permissions/resync", h.resyncPermissions)
+	return r
+}
+
+// strPtr returns a pointer to s, for constructing permissionRequest's
+// optional *string date fields in test bodies.
+func strPtr(s string) *string { return &s }
+
+// futureDate returns the civil date (fixed UTC+8 rule) days from now as
+// YYYY-MM-DD, for handler test rows that must keep exercising their named
+// validation branch regardless of when the suite runs — a hardcoded date
+// would silently decay into the until-not-past branch once it lapses.
+func futureDate(days int) string {
+	return time.Now().In(tzTaipei).AddDate(0, 0, days).Format("2006-01-02")
+}
+
+// manyAccounts returns n distinct account names, "acct-0".."acct-(n-1)".
+func manyAccounts(n int) []string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = "acct-" + strconv.Itoa(i)
+	}
+	return out
+}
+
+// -------------------------------------------------------------------------
+// parseWindow / displayDate / displayUntilDate — pure-function unit tests
+// -------------------------------------------------------------------------
+
+func TestParseWindow(t *testing.T) {
+	fixedNow := time.Date(2026, 8, 11, 10, 0, 0, 0, time.UTC)
+	todayTaipei := fixedNow.In(tzTaipei)
+
+	tests := []struct {
+		name      string
+		fromStr   *string
+		untilStr  *string
+		wantErr   bool
+		wantFrom  time.Time
+		wantUntil time.Time
+	}{
+		{
+			name:      "explicit window, from before until",
+			fromStr:   strPtr("2026-09-01"),
+			untilStr:  strPtr("2026-12-31"),
+			wantFrom:  time.Date(2026, 9, 1, 0, 0, 0, 0, tzTaipei),
+			wantUntil: time.Date(2027, 1, 1, 0, 0, 0, 0, tzTaipei),
+		},
+		{
+			name:      "nil effectiveFrom defaults to now",
+			fromStr:   nil,
+			untilStr:  strPtr("2026-12-31"),
+			wantFrom:  fixedNow,
+			wantUntil: time.Date(2027, 1, 1, 0, 0, 0, 0, tzTaipei),
+		},
+		{
+			name:      "expiresAt == today (Taipei) is valid, until = tomorrow 00:00 Taipei",
+			fromStr:   nil,
+			untilStr:  strPtr(todayTaipei.Format("2006-01-02")),
+			wantFrom:  fixedNow,
+			wantUntil: time.Date(todayTaipei.Year(), todayTaipei.Month(), todayTaipei.Day()+1, 0, 0, 0, 0, tzTaipei),
+		},
+		{
+			name:     "nil expiresAt is rejected — required on a grant",
+			fromStr:  nil,
+			untilStr: nil,
+			wantErr:  true,
+		},
+		{
+			name:     "malformed expiresAt",
+			fromStr:  nil,
+			untilStr: strPtr("31-12-2026"),
+			wantErr:  true,
+		},
+		{
+			name:     "malformed effectiveFrom",
+			fromStr:  strPtr("not-a-date"),
+			untilStr: strPtr("2026-12-31"),
+			wantErr:  true,
+		},
+		{
+			name:     "from after until is rejected",
+			fromStr:  strPtr("2026-12-31"),
+			untilStr: strPtr("2026-09-01"),
+			wantErr:  true,
+		},
+		{
+			// Regression for the from==until off-by-one: until is always shifted
+			// +1 day from untilStr, so effectiveFrom one day past expiresAt lands
+			// exactly ON until. A strict from.After(until) check misses this
+			// (equal is not "after"); the fix must reject on !from.Before(until).
+			name:     "effectiveFrom exactly one day after expiresAt is rejected (from == until)",
+			fromStr:  strPtr("2026-09-02"),
+			untilStr: strPtr("2026-09-01"),
+			wantErr:  true,
+		},
+		{
+			name:      "effectiveFrom == expiresAt (same civil day) is accepted as a one-day window",
+			fromStr:   strPtr("2026-09-01"),
+			untilStr:  strPtr("2026-09-01"),
+			wantFrom:  time.Date(2026, 9, 1, 0, 0, 0, 0, tzTaipei),
+			wantUntil: time.Date(2026, 9, 2, 0, 0, 0, 0, tzTaipei),
+		},
+		{
+			name:     "expiresAt in the past is rejected",
+			fromStr:  nil,
+			untilStr: strPtr("2020-01-01"),
+			wantErr:  true,
+		},
+		{
+			// Distinct from "from after until is rejected": here explicit
+			// effectiveFrom precedes expiresAt (so the from-after-until check
+			// passes), isolating the until-not-in-the-past check as the one
+			// that must fire.
+			name:     "both dates in the past, from before until — still rejected as expired",
+			fromStr:  strPtr("2019-01-01"),
+			untilStr: strPtr("2019-06-01"),
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			from, until, err := parseWindow(tc.fromStr, tc.untilStr, fixedNow)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.True(t, tc.wantFrom.Equal(from), "from: got %v want %v", from, tc.wantFrom)
+			assert.True(t, tc.wantUntil.Equal(until), "until: got %v want %v", until, tc.wantUntil)
+		})
+	}
+}
+
+func TestDisplayDate(t *testing.T) {
+	got := displayDate(time.Date(2026, 9, 1, 0, 0, 0, 0, tzTaipei))
+	assert.Equal(t, "2026-09-01", got)
+}
+
+func TestDisplayUntilDate(t *testing.T) {
+	tests := []struct {
+		name  string
+		input time.Time
+		want  string
+	}{
+		{
+			name:  "round-trip: 2026-12-31 request date -> stored until-instant -> displayed back as 2026-12-31",
+			input: time.Date(2027, 1, 1, 0, 0, 0, 0, tzTaipei),
+			want:  "2026-12-31",
+		},
+		{
+			name:  "civil +1 day across a month boundary",
+			input: time.Date(2026, 10, 1, 0, 0, 0, 0, tzTaipei),
+			want:  "2026-09-30",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, displayUntilDate(tc.input))
+		})
+	}
+}
+
+// -------------------------------------------------------------------------
+// createPermissions — one subtest per spec §4.4 validation rule + success paths
+// -------------------------------------------------------------------------
+
+func TestHandler_createPermissions(t *testing.T) {
+	knownPermission := string(model.PermissionExternalImageView)
+
+	tests := []struct {
+		name       string
+		body       map[string]any
+		setupMock  func(m *MockAdminStore)
+		wantStatus int
+		wantReason string
+		checkBody  func(t *testing.T, body map[string]any)
+	}{
+		{
+			name: "unknown permission → 400 unknown_permission",
+			body: map[string]any{
+				"permission": "bogus.permission", "subjectAccounts": []string{"alice"}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock:  func(m *MockAdminStore) {},
+			wantStatus: http.StatusBadRequest,
+			wantReason: string(errcode.PermissionUnknownKey),
+		},
+		{
+			name: "empty subjectAccounts → 400 invalid_subject_count",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock:  func(m *MockAdminStore) {},
+			wantStatus: http.StatusBadRequest,
+			wantReason: string(errcode.PermissionInvalidSubjects),
+		},
+		{
+			name: "empty reason → 201, stored as empty string",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "carol", "approverAccount": "dave", "reason": "",
+			},
+			setupMock: func(m *MockAdminStore) {
+				m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).
+					Return(map[string]bool{"alice": true, "carol": true, "dave": true}, nil)
+				m.EXPECT().RecordPermissionChange(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, grants []*model.PermissionGrant, _ model.PermissionState) error {
+						require.Len(t, grants, 1)
+						assert.Equal(t, "", grants[0].Reason)
+						return nil
+					})
+				m.EXPECT().AppendAuditMany(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name: "reason absent from body → 201, stored as empty string",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "carol", "approverAccount": "dave",
+				// "reason" key intentionally omitted — must behave the same as "".
+			},
+			setupMock: func(m *MockAdminStore) {
+				m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).
+					Return(map[string]bool{"alice": true, "carol": true, "dave": true}, nil)
+				m.EXPECT().RecordPermissionChange(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, grants []*model.PermissionGrant, _ model.PermissionState) error {
+						require.Len(t, grants, 1)
+						assert.Equal(t, "", grants[0].Reason)
+						return nil
+					})
+				m.EXPECT().AppendAuditMany(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name: "reason over 1000 runes → 400 invalid_reason",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "carol", "approverAccount": "dave", "reason": strings.Repeat("測", 1001),
+			},
+			setupMock:  func(m *MockAdminStore) {},
+			wantStatus: http.StatusBadRequest,
+			wantReason: string(errcode.PermissionInvalidReason),
+		},
+		{
+			name: "missing applicantAccount → 400 missing_permission_fields",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock:  func(m *MockAdminStore) {},
+			wantStatus: http.StatusBadRequest,
+			wantReason: string(errcode.PermissionMissingFields),
+		},
+		{
+			name: "missing approverAccount → 400 missing_permission_fields",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "carol", "approverAccount": "", "reason": "reason text",
+			},
+			setupMock:  func(m *MockAdminStore) {},
+			wantStatus: http.StatusBadRequest,
+			wantReason: string(errcode.PermissionMissingFields),
+		},
+		{
+			// granted has no "binding:required" tag on purpose (see permissionRequest's
+			// doc comment) — an absent key must land here, in the explicit missing-fields
+			// check, not fall through and silently default to false/revoke.
+			name: "granted omitted → 400 missing_permission_fields",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"},
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock:  func(m *MockAdminStore) {},
+			wantStatus: http.StatusBadRequest,
+			wantReason: string(errcode.PermissionMissingFields),
+		},
+		{
+			name: "grant missing expiresAt → 400 invalid_permission_window",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": true,
+				"applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock:  func(m *MockAdminStore) {},
+			wantStatus: http.StatusBadRequest,
+			wantReason: string(errcode.PermissionInvalidWindow),
+		},
+		{
+			name: "malformed expiresAt → 400 invalid_permission_window",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": true,
+				"expiresAt": "31/12/2026", "applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock:  func(m *MockAdminStore) {},
+			wantStatus: http.StatusBadRequest,
+			wantReason: string(errcode.PermissionInvalidWindow),
+		},
+		{
+			name: "effectiveFrom after expiresAt → 400 invalid_permission_window",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": true,
+				"effectiveFrom": futureDate(2), "expiresAt": futureDate(1),
+				"applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock:  func(m *MockAdminStore) {},
+			wantStatus: http.StatusBadRequest,
+			wantReason: string(errcode.PermissionInvalidWindow),
+		},
+		{
+			name: "expiresAt in the past → 400 invalid_permission_window",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": true,
+				"expiresAt": "2020-01-01", "applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock:  func(m *MockAdminStore) {},
+			wantStatus: http.StatusBadRequest,
+			wantReason: string(errcode.PermissionInvalidWindow),
+			checkBody: func(t *testing.T, body map[string]any) {
+				// effectiveFrom was never sent — the message must name expiresAt, not
+				// misreport an effectiveFrom/expiresAt ordering problem the caller
+				// never created (from defaults to now, which is > any past expiresAt).
+				assert.Equal(t, "expiresAt must not be in the past", body["error"])
+			},
+		},
+		{
+			name: "revoke with effectiveFrom present → 400 unexpected_permission_window",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": false,
+				"effectiveFrom": "2026-09-01", "applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock:  func(m *MockAdminStore) {},
+			wantStatus: http.StatusBadRequest,
+			wantReason: string(errcode.PermissionUnexpectedWindow),
+		},
+		{
+			name: "revoke with expiresAt present → 400 unexpected_permission_window",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": false,
+				"expiresAt": "2026-12-31", "applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock:  func(m *MockAdminStore) {},
+			wantStatus: http.StatusBadRequest,
+			wantReason: string(errcode.PermissionUnexpectedWindow),
+		},
+		{
+			name: "duplicate subjects deduped and reported, only unique accounts hit the store",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice", "alice", "bob"}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock: func(m *MockAdminStore) {
+				m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, accounts []string) (map[string]bool, error) {
+						assert.Equal(t, []string{"alice", "bob", "carol", "dave"}, accounts,
+							"dedup must run before the lookup, which must also cover applicant+approver")
+						return map[string]bool{"alice": true, "bob": true, "carol": true, "dave": true}, nil
+					})
+				m.EXPECT().RecordPermissionChange(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().AppendAuditMany(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			wantStatus: http.StatusCreated,
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.Equal(t, float64(2), body["created"])
+				assert.Equal(t, []any{"alice"}, body["duplicatesIgnored"])
+			},
+		},
+		{
+			name: "unknown accounts → 404 unknown_accounts, message names them",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice", "ghost"}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock: func(m *MockAdminStore) {
+				m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).
+					Return(map[string]bool{"alice": true, "carol": true, "dave": true}, nil)
+			},
+			wantStatus: http.StatusNotFound,
+			wantReason: string(errcode.PermissionUnknownAccounts),
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.Contains(t, body["error"], "ghost")
+				md, _ := body["metadata"].(map[string]any)
+				assert.Equal(t, "ghost", md["accounts"]) // console renders metadata.accounts
+			},
+		},
+		{
+			name: "unknown applicant → 404 unknown_accounts",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "ghost-applicant", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock: func(m *MockAdminStore) {
+				// alice and dave exist; ghost-applicant does not — the existence check
+				// must reach applicantAccount, not just subjectAccounts (design §4.4 step 10).
+				m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).
+					Return(map[string]bool{"alice": true, "dave": true}, nil)
+			},
+			wantStatus: http.StatusNotFound,
+			wantReason: string(errcode.PermissionUnknownAccounts),
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.Contains(t, body["error"], "ghost-applicant")
+				md, _ := body["metadata"].(map[string]any)
+				assert.Equal(t, "ghost-applicant", md["accounts"])
+			},
+		},
+		{
+			name: "unknown approver → 404 unknown_accounts",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "carol", "approverAccount": "ghost-approver", "reason": "reason text",
+			},
+			setupMock: func(m *MockAdminStore) {
+				m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).
+					Return(map[string]bool{"alice": true, "carol": true}, nil)
+			},
+			wantStatus: http.StatusNotFound,
+			wantReason: string(errcode.PermissionUnknownAccounts),
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.Contains(t, body["error"], "ghost-approver")
+				md, _ := body["metadata"].(map[string]any)
+				assert.Equal(t, "ghost-approver", md["accounts"])
+			},
+		},
+		{
+			name: "inactive subject → 400 inactive_subject, message names it",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock: func(m *MockAdminStore) {
+				m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).
+					Return(map[string]bool{"alice": false, "carol": true, "dave": true}, nil)
+			},
+			wantStatus: http.StatusBadRequest,
+			wantReason: string(errcode.PermissionInactiveSubject),
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.Contains(t, body["error"], "alice")
+				md, _ := body["metadata"].(map[string]any)
+				assert.Equal(t, "alice", md["accounts"]) // console renders metadata.accounts
+			},
+		},
+		{
+			// Design §4.4 step 10: an inactive applicant/approver is explicitly
+			// allowed — only subjects are checked for IsActive(). This locks that
+			// the inactive-subject rejection above does NOT also apply to applicant/approver.
+			name: "inactive applicant (exists, active=false) with valid active subjects → 201 success",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "inactive-carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock: func(m *MockAdminStore) {
+				m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).
+					Return(map[string]bool{"alice": true, "inactive-carol": false, "dave": true}, nil)
+				m.EXPECT().RecordPermissionChange(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().AppendAuditMany(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			wantStatus: http.StatusCreated,
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.Equal(t, float64(1), body["created"])
+			},
+		},
+		{
+			name: "FindAccountStates store error → 500",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock: func(m *MockAdminStore) {
+				m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).
+					Return(nil, fmt.Errorf("boom"))
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "store insert error → 500, no audit call",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock: func(m *MockAdminStore) {
+				m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).
+					Return(map[string]bool{"alice": true, "carol": true, "dave": true}, nil)
+				m.EXPECT().RecordPermissionChange(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(fmt.Errorf("boom"))
+				m.EXPECT().AppendAuditMany(gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "success grant: 201, store receives the derived instants, audit entries match",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice", "bob"}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock: func(m *MockAdminStore) {
+				wantFrom := time.Date(2026, 9, 1, 0, 0, 0, 0, tzTaipei)
+				wantUntil := time.Date(2027, 1, 1, 0, 0, 0, 0, tzTaipei)
+
+				m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).
+					Return(map[string]bool{"alice": true, "bob": true, "carol": true, "dave": true}, nil)
+				m.EXPECT().RecordPermissionChange(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, grants []*model.PermissionGrant, state model.PermissionState) error {
+						require.Len(t, grants, 2)
+						for _, g := range grants {
+							assert.Equal(t, model.PermissionExternalImageView, g.Permission)
+							assert.True(t, g.Granted)
+							require.NotNil(t, g.EffectiveFrom)
+							require.NotNil(t, g.ExpiresAt)
+							assert.True(t, wantFrom.Equal(*g.EffectiveFrom), "effectiveFrom: got %v want %v", *g.EffectiveFrom, wantFrom)
+							assert.True(t, wantUntil.Equal(*g.ExpiresAt), "expiresAt: got %v want %v", *g.ExpiresAt, wantUntil)
+							assert.Equal(t, "carol", g.ApplicantAccount)
+							assert.Equal(t, "dave", g.ApproverAccount)
+							assert.Equal(t, "p_admin", g.RecordedBy)
+							assert.NotEmpty(t, g.ID)
+						}
+						assert.True(t, state.Granted)
+						require.NotNil(t, state.EffectiveFrom)
+						require.NotNil(t, state.ExpiresAt)
+						assert.True(t, wantFrom.Equal(*state.EffectiveFrom), "state.EffectiveFrom: got %v want %v", *state.EffectiveFrom, wantFrom)
+						assert.True(t, wantUntil.Equal(*state.ExpiresAt), "state.ExpiresAt: got %v want %v", *state.ExpiresAt, wantUntil)
+						assert.True(t, grants[0].RecordedAt.Equal(state.UpdatedAt), "state.UpdatedAt must equal the grants' shared RecordedAt")
+						return nil
+					})
+				m.EXPECT().AppendAuditMany(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, entries []*AuditEntry) error {
+						require.Len(t, entries, 2)
+						for _, e := range entries {
+							assert.Equal(t, auditActionPermissionGrant, e.Action)
+							assert.Equal(t, map[string]string{"permission": knownPermission}, e.Details)
+							assert.Equal(t, "p_admin", e.ActorAccount)
+						}
+						return nil
+					})
+			},
+			wantStatus: http.StatusCreated,
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.Equal(t, float64(2), body["created"])
+				assert.Equal(t, []any{}, body["duplicatesIgnored"])
+			},
+		},
+		{
+			name: "success revoke: stored rows carry nil window pointers",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": false,
+				"applicantAccount": "carol", "approverAccount": "dave", "reason": "project ended",
+			},
+			setupMock: func(m *MockAdminStore) {
+				m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).
+					Return(map[string]bool{"alice": true, "carol": true, "dave": true}, nil)
+				m.EXPECT().RecordPermissionChange(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, grants []*model.PermissionGrant, state model.PermissionState) error {
+						require.Len(t, grants, 1)
+						assert.False(t, grants[0].Granted)
+						assert.Nil(t, grants[0].EffectiveFrom)
+						assert.Nil(t, grants[0].ExpiresAt)
+						assert.False(t, state.Granted)
+						assert.Nil(t, state.EffectiveFrom)
+						assert.Nil(t, state.ExpiresAt)
+						assert.True(t, grants[0].RecordedAt.Equal(state.UpdatedAt), "state.UpdatedAt must equal the grants' shared RecordedAt")
+						return nil
+					})
+				m.EXPECT().AppendAuditMany(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, entries []*AuditEntry) error {
+						require.Len(t, entries, 1)
+						assert.Equal(t, auditActionPermissionRevoke, entries[0].Action)
+						return nil
+					})
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			// Best-effort audit contract: AppendAuditMany failing must never fail
+			// the request — the ledger write already committed. Locks the current
+			// slog.ErrorContext-and-continue behavior against regression.
+			name: "AppendAuditMany store error → still 201 (best-effort audit)",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock: func(m *MockAdminStore) {
+				m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).
+					Return(map[string]bool{"alice": true, "carol": true, "dave": true}, nil)
+				m.EXPECT().RecordPermissionChange(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().AppendAuditMany(gomock.Any(), gomock.Any()).Return(fmt.Errorf("boom"))
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			// No cap: the pre-bulk-round implementation rejected anything over a
+			// 200-subject ceiling. Locks that a batch far past that old limit
+			// still passes validation and reaches the store in one call.
+			name: "10,001 subjects (no cap) → 201, all pass validation",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": manyAccounts(10001), "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+			},
+			setupMock: func(m *MockAdminStore) {
+				accounts := manyAccounts(10001)
+				states := make(map[string]bool, len(accounts)+2)
+				for _, a := range accounts {
+					states[a] = true
+				}
+				states["carol"] = true
+				states["dave"] = true
+				m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).Return(states, nil)
+				m.EXPECT().RecordPermissionChange(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, grants []*model.PermissionGrant, _ model.PermissionState) error {
+						require.Len(t, grants, 10001)
+						return nil
+					})
+				m.EXPECT().AppendAuditMany(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			wantStatus: http.StatusCreated,
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.Equal(t, float64(10001), body["created"])
+			},
+		},
+		{
+			name: "exactly 1000-rune reason (the max) → 201",
+			body: map[string]any{
+				"permission": knownPermission, "subjectAccounts": []string{"alice"}, "granted": true,
+				"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+				"applicantAccount": "carol", "approverAccount": "dave", "reason": strings.Repeat("測", model.MaxReasonRunes),
+			},
+			setupMock: func(m *MockAdminStore) {
+				m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).
+					Return(map[string]bool{"alice": true, "carol": true, "dave": true}, nil)
+				m.EXPECT().RecordPermissionChange(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().AppendAuditMany(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			wantStatus: http.StatusCreated,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			m := NewMockAdminStore(ctrl)
+			tc.setupMock(m)
+
+			h := newHandler(m, emptySessionStore(), testCfg(), nil, nil)
+			r := setupPermissionsRouter(h)
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/permissions", bodyBytes(t, tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(w, req)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.wantReason != "" {
+				body := respBody(t, w)
+				assert.Equal(t, tc.wantReason, body["reason"])
+			}
+			if tc.checkBody != nil {
+				body := respBody(t, w)
+				tc.checkBody(t, body)
+			}
+		})
+	}
+}
+
+// -------------------------------------------------------------------------
+// createPermissions — cross-site fanout (publishPermissionFanout)
+// -------------------------------------------------------------------------
+
+// fanoutTestCfg is the 3-site fixture used by every fanout scenario below:
+// site-a (this site) publishing to remotes site-b and site-c.
+func fanoutTestCfg() Config {
+	return Config{SiteID: "site-a", AllSiteIDs: []string{"site-a", "site-b", "site-c"}}
+}
+
+// fanoutRequestBody returns a valid grant request for the given subject accounts.
+func fanoutRequestBody(accounts []string) map[string]any {
+	return map[string]any{
+		"permission": string(model.PermissionExternalImageView), "subjectAccounts": accounts, "granted": true,
+		"effectiveFrom": "2026-09-01", "expiresAt": "2026-12-31",
+		"applicantAccount": "carol", "approverAccount": "dave", "reason": "reason text",
+	}
+}
+
+// mockPermissionStoreOK wires FindAccountStates/RecordPermissionChange/AppendAuditMany
+// to succeed for the given subject accounts plus applicant/approver carol/dave.
+func mockPermissionStoreOK(m *MockAdminStore, accounts []string) {
+	states := make(map[string]bool, len(accounts)+2)
+	for _, a := range accounts {
+		states[a] = true
+	}
+	states["carol"] = true
+	states["dave"] = true
+	m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).Return(states, nil)
+	m.EXPECT().RecordPermissionChange(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	m.EXPECT().AppendAuditMany(gomock.Any(), gomock.Any()).Return(nil)
+}
+
+// publishLog captures fanout publishes. publishPermissionFanout runs one goroutine
+// per destination, so every recording closure must be race-safe; subjects[i] always
+// pairs with data[i] because both are appended under the same lock.
+type publishLog struct {
+	mu       sync.Mutex
+	subjects []string
+	data     [][]byte
+}
+
+func (l *publishLog) record(subj string, data []byte) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.subjects = append(l.subjects, subj)
+	l.data = append(l.data, data)
+}
+
+// publish returns a publishInbox func that records every call and succeeds.
+func (l *publishLog) publish(_ context.Context, subj string, data []byte) error {
+	l.record(subj, data)
+	return nil
+}
+
+// postPermissions POSTs body to h's /permissions route and returns the recorder.
+func postPermissions(h *Handler, body map[string]any, t *testing.T) *httptest.ResponseRecorder {
+	t.Helper()
+	r := setupPermissionsRouter(h)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/permissions", bodyBytes(t, body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestHandler_createPermissions_Fanout(t *testing.T) {
+	t.Run("happy path: 3 subjects fan out to the 2 remote sites, syncFailures omitted", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl)
+		accounts := []string{"alice", "bob", "eve"}
+		mockPermissionStoreOK(m, accounts)
+
+		var log publishLog
+
+		h := newHandler(m, emptySessionStore(), fanoutTestCfg(), nil, log.publish)
+		w := postPermissions(h, fanoutRequestBody(accounts), t)
+		require.Equal(t, http.StatusCreated, w.Code)
+
+		require.Len(t, log.subjects, 2, "one publish per remote site — site-b and site-c, self excluded")
+		// Destinations publish concurrently, so only the set is deterministic.
+		assert.ElementsMatch(t, []string{
+			subject.InboxExternal("site-b", model.InboxUserPermissionsUpdated),
+			subject.InboxExternal("site-c", model.InboxUserPermissionsUpdated),
+		}, log.subjects)
+
+		var gotDests []string
+		for i, data := range log.data {
+			var evt model.InboxEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			assert.Equal(t, model.InboxUserPermissionsUpdated, evt.Type)
+			assert.Equal(t, "site-a", evt.SiteID)
+			assert.Equal(t, subject.InboxExternal(evt.DestSiteID, model.InboxUserPermissionsUpdated), log.subjects[i],
+				"each event must be published on its own destination's subject")
+			gotDests = append(gotDests, evt.DestSiteID)
+
+			var payload model.UserPermissionsUpdated
+			require.NoError(t, json.Unmarshal(evt.Payload, &payload))
+			assert.Equal(t, model.PermissionExternalImageView, payload.Permission)
+			assert.ElementsMatch(t, accounts, payload.Accounts)
+			assert.True(t, payload.State.Granted)
+		}
+		assert.ElementsMatch(t, []string{"site-b", "site-c"}, gotDests)
+
+		body := respBody(t, w)
+		_, hasSyncFailures := body["syncFailures"]
+		assert.False(t, hasSyncFailures, "syncFailures must be omitted (omitempty) when every publish succeeds")
+	})
+
+	t.Run("audit entries are written before the fanout", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl)
+		accounts := []string{"alice"}
+		m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).
+			Return(map[string]bool{"alice": true, "carol": true, "dave": true}, nil)
+		m.EXPECT().RecordPermissionChange(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+		// Destinations publish concurrently, so guard the log; only calls[0] is asserted.
+		var mu sync.Mutex
+		var calls []string
+		record := func(what string) {
+			mu.Lock()
+			defer mu.Unlock()
+			calls = append(calls, what)
+		}
+		m.EXPECT().AppendAuditMany(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(context.Context, []*AuditEntry) error {
+				record("audit")
+				return nil
+			})
+		publish := func(context.Context, string, []byte) error {
+			record("publish")
+			return nil
+		}
+
+		h := newHandler(m, emptySessionStore(), fanoutTestCfg(), nil, publish)
+		require.Equal(t, http.StatusCreated, postPermissions(h, fanoutRequestBody(accounts), t).Code)
+
+		require.NotEmpty(t, calls)
+		assert.Equal(t, "audit", calls[0],
+			"audit must be written before the fanout — it runs on the cancellable request ctx, so a client disconnect during the fanout's multi-second budget would otherwise kill every audit entry for a ledger write that already committed")
+	})
+
+	t.Run("fanout ctx carries its own deadline and is severed from client cancellation", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl)
+		accounts := []string{"alice"}
+		mockPermissionStoreOK(m, accounts)
+
+		// Captured synchronously INSIDE the closure, at call time — the handler's own
+		// `defer cancelFanout()` fires the instant it returns, so a post-hoc check made
+		// after ServeHTTP returns would see Done() closed regardless of whether the
+		// cancellation came from the (already-canceled) client ctx or from that ordinary
+		// end-of-handler cleanup. Checking Err()/Deadline() at call time is the only timing
+		// that distinguishes "inherited the client's cancellation" from "the fanout is done".
+		// Guarded: destinations publish from their own goroutines, and every one of
+		// them sees the same fanout ctx, so the last write wins either way.
+		var mu sync.Mutex
+		var callErr error
+		var callDeadline time.Time
+		var callHasDeadline bool
+		publish := func(ctx context.Context, _ string, _ []byte) error {
+			mu.Lock()
+			defer mu.Unlock()
+			callErr = ctx.Err()
+			callDeadline, callHasDeadline = ctx.Deadline()
+			return nil
+		}
+
+		h := newHandler(m, emptySessionStore(), fanoutTestCfg(), nil, publish)
+		r := setupPermissionsRouter(h)
+
+		// Simulate a client hang-up: the request ctx is already canceled before the
+		// handler even runs — the fanout must not inherit that cancellation.
+		reqCtx, cancelReq := context.WithCancel(context.Background())
+		cancelReq()
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/permissions", bodyBytes(t, fanoutRequestBody(accounts))).WithContext(reqCtx)
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusCreated, w.Code, "a canceled client ctx must not fail the request — the ledger write already committed")
+
+		assert.NoError(t, callErr, "publish ctx must not already be canceled/expired at call time — it must be severed from the client's cancellation (context.WithoutCancel)")
+		require.True(t, callHasDeadline, "publish ctx must carry the fanout's own deadline, not run unbounded")
+		assert.WithinDuration(t, time.Now().Add(5*time.Second), callDeadline, 2*time.Second, "fanout deadline must be ~5s, not per-publish and not unbounded")
+	})
+
+	t.Run("chunking: 5001 accounts split into 5000+1 per destination", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl)
+		accounts := manyAccounts(5001)
+		mockPermissionStoreOK(m, accounts)
+
+		var log publishLog
+
+		h := newHandler(m, emptySessionStore(), fanoutTestCfg(), nil, log.publish)
+		w := postPermissions(h, fanoutRequestBody(accounts), t)
+		require.Equal(t, http.StatusCreated, w.Code)
+		require.Len(t, log.data, 4, "2 chunks x 2 remote destinations")
+
+		chunkSizesByDest := map[string][]int{}
+		accountsByDest := map[string][]string{}
+		var timestamps []int64
+		var states []model.PermissionState
+		for i, data := range log.data {
+			var evt model.InboxEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			var payload model.UserPermissionsUpdated
+			require.NoError(t, json.Unmarshal(evt.Payload, &payload))
+			assert.Equal(t, subject.InboxExternal(evt.DestSiteID, model.InboxUserPermissionsUpdated), log.subjects[i])
+
+			chunkSizesByDest[evt.DestSiteID] = append(chunkSizesByDest[evt.DestSiteID], len(payload.Accounts))
+			accountsByDest[evt.DestSiteID] = append(accountsByDest[evt.DestSiteID], payload.Accounts...)
+			timestamps = append(timestamps, payload.Timestamp)
+			states = append(states, payload.State)
+		}
+
+		for _, dest := range []string{"site-b", "site-c"} {
+			assert.ElementsMatch(t, []int{5000, 1}, chunkSizesByDest[dest], "dest %s chunk sizes", dest)
+			assert.ElementsMatch(t, accounts, accountsByDest[dest], "dest %s account union must be complete, no dupes", dest)
+		}
+		for _, ts := range timestamps {
+			assert.Equal(t, timestamps[0], ts, "every chunk shares the same publish Timestamp")
+		}
+		for _, s := range states {
+			assert.Equal(t, states[0], s, "every chunk shares the same derived State")
+		}
+	})
+
+	t.Run("failure aggregation: site-b errors, site-c still receives its chunk, status still 201", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl)
+		accounts := []string{"alice", "bob", "eve"}
+		mockPermissionStoreOK(m, accounts)
+
+		var log publishLog
+		publish := func(ctx context.Context, subj string, data []byte) error {
+			if strings.Contains(subj, ".site-b.") {
+				return fmt.Errorf("simulated publish failure")
+			}
+			return log.publish(ctx, subj, data)
+		}
+
+		h := newHandler(m, emptySessionStore(), fanoutTestCfg(), nil, publish)
+		w := postPermissions(h, fanoutRequestBody(accounts), t)
+		require.Equal(t, http.StatusCreated, w.Code, "fanout failures must never fail the request")
+
+		require.Len(t, log.subjects, 1, "site-c's publish must still land")
+		assert.Equal(t, subject.InboxExternal("site-c", model.InboxUserPermissionsUpdated), log.subjects[0])
+
+		body := respBody(t, w)
+		assert.Equal(t, []any{"site-b"}, body["syncFailures"])
+	})
+
+	t.Run("blank and self entries in AllSiteIDs are skipped, no publishes", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl)
+		accounts := []string{"alice"}
+		mockPermissionStoreOK(m, accounts)
+
+		published := 0
+		publish := func(_ context.Context, _ string, _ []byte) error {
+			published++
+			return nil
+		}
+
+		cfg := Config{SiteID: "site-a", AllSiteIDs: []string{"", "site-a"}}
+		h := newHandler(m, emptySessionStore(), cfg, nil, publish)
+		w := postPermissions(h, fanoutRequestBody(accounts), t)
+		require.Equal(t, http.StatusCreated, w.Code)
+		assert.Zero(t, published)
+
+		body := respBody(t, w)
+		_, hasSyncFailures := body["syncFailures"]
+		assert.False(t, hasSyncFailures)
+	})
+
+	t.Run("store failure → zero publishes", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl)
+		m.EXPECT().FindAccountStates(gomock.Any(), gomock.Any()).
+			Return(map[string]bool{"alice": true, "carol": true, "dave": true}, nil)
+		m.EXPECT().RecordPermissionChange(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(fmt.Errorf("boom"))
+
+		published := 0
+		publish := func(_ context.Context, _ string, _ []byte) error {
+			published++
+			return nil
+		}
+
+		h := newHandler(m, emptySessionStore(), fanoutTestCfg(), nil, publish)
+		w := postPermissions(h, fanoutRequestBody([]string{"alice"}), t)
+		require.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.Zero(t, published)
+	})
+}
+
+func TestRemoteSites(t *testing.T) {
+	tests := []struct {
+		name       string
+		allSiteIDs []string
+		self       string
+		want       []string
+	}{
+		{"filters out self and blank entries", []string{"", "site-a", "site-b", "site-c"}, "site-a", []string{"site-b", "site-c"}},
+		{"empty AllSiteIDs → nil", nil, "site-a", nil},
+		{"only self → nil", []string{"site-a"}, "site-a", nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, remoteSites(tc.allSiteIDs, tc.self))
+		})
+	}
+}
+
+// -------------------------------------------------------------------------
+// resyncPermissions — re-delivery, not re-recording: writes nothing, fans out
+// the current materialized state via publishPermissionFanout (Task 5).
+// -------------------------------------------------------------------------
+
+// postResync POSTs body to h's /permissions/resync route and returns the recorder.
+func postResync(h *Handler, body map[string]any, t *testing.T) *httptest.ResponseRecorder {
+	t.Helper()
+	r := setupPermissionsRouter(h)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/permissions/resync", bodyBytes(t, body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestHandler_resyncPermissions(t *testing.T) {
+	knownPermission := string(model.PermissionExternalImageView)
+
+	// storedState is a fixture with an UpdatedAt firmly in the past — every
+	// assertion on the fanned-out event's State.UpdatedAt must see exactly
+	// this value, never a freshly stamped now().
+	storedState := model.PermissionState{
+		Granted:       true,
+		EffectiveFrom: timePtr(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+		ExpiresAt:     timePtr(time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)),
+		UpdatedAt:     time.Date(2025, 6, 1, 8, 30, 0, 0, time.UTC),
+	}
+
+	t.Run("unknown permission → 400 unknown_permission", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl) // no expectations — store must not be touched
+		h := newHandler(m, emptySessionStore(), testCfg(), nil, nil)
+
+		w := postResync(h, map[string]any{"permission": "bogus.permission", "accounts": []string{"alice"}}, t)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		body := respBody(t, w)
+		assert.Equal(t, string(errcode.PermissionUnknownKey), body["reason"])
+	})
+
+	t.Run("empty accounts → 400 invalid_subject_count", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl) // no expectations — store must not be touched
+		h := newHandler(m, emptySessionStore(), testCfg(), nil, nil)
+
+		w := postResync(h, map[string]any{"permission": knownPermission, "accounts": []string{}}, t)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		body := respBody(t, w)
+		assert.Equal(t, string(errcode.PermissionInvalidSubjects), body["reason"])
+	})
+
+	t.Run("GetUserPermissionsForAccounts store error → 500", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl)
+		m.EXPECT().GetUserPermissionsForAccounts(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("boom"))
+		h := newHandler(m, emptySessionStore(), fanoutTestCfg(), nil, nil)
+
+		w := postResync(h, map[string]any{"permission": knownPermission, "accounts": []string{"alice"}}, t)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("never calls RecordPermissionChange or AppendAuditMany — resync only re-delivers, never re-records", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		// No RecordPermissionChange/AppendAuditMany expectations set — gomock fails
+		// the test the instant either is called.
+		m := NewMockAdminStore(ctrl)
+		perms := map[string]*model.UserPermissions{"alice": {ExternalImageView: &storedState}}
+		m.EXPECT().GetUserPermissionsForAccounts(gomock.Any(), gomock.Any()).Return(perms, nil)
+		h := newHandler(m, emptySessionStore(), fanoutTestCfg(), nil, nil)
+
+		w := postResync(h, map[string]any{"permission": knownPermission, "accounts": []string{"alice"}}, t)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("two accounts sharing one stored state → one fanout group, one event per dest, stored UpdatedAt preserved", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl)
+		perms := map[string]*model.UserPermissions{
+			"alice": {ExternalImageView: &storedState},
+			"bob":   {ExternalImageView: &storedState},
+		}
+		m.EXPECT().GetUserPermissionsForAccounts(gomock.Any(), gomock.Any()).Return(perms, nil)
+
+		var log publishLog
+
+		h := newHandler(m, emptySessionStore(), fanoutTestCfg(), nil, log.publish)
+		w := postResync(h, map[string]any{"permission": knownPermission, "accounts": []string{"alice", "bob"}}, t)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		require.Len(t, log.data, 2, "one group -> one event per remote dest (site-b, site-c)")
+		// Destinations publish concurrently, so only the set is deterministic.
+		assert.ElementsMatch(t, []string{
+			subject.InboxExternal("site-b", model.InboxUserPermissionsUpdated),
+			subject.InboxExternal("site-c", model.InboxUserPermissionsUpdated),
+		}, log.subjects)
+
+		for _, data := range log.data {
+			var evt model.InboxEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			var payload model.UserPermissionsUpdated
+			require.NoError(t, json.Unmarshal(evt.Payload, &payload))
+			assert.ElementsMatch(t, []string{"alice", "bob"}, payload.Accounts, "both accounts share the one group's event")
+			assert.Equal(t, storedState.Granted, payload.State.Granted)
+			require.NotNil(t, payload.State.UpdatedAt)
+			assert.True(t, storedState.UpdatedAt.Equal(payload.State.UpdatedAt),
+				"fanned-out State.UpdatedAt must be the STORED watermark, not a fresh timestamp: got %v want %v",
+				payload.State.UpdatedAt, storedState.UpdatedAt)
+		}
+
+		body := respBody(t, w)
+		_, hasSyncFailures := body["syncFailures"]
+		assert.False(t, hasSyncFailures, "syncFailures omitted when every publish succeeds")
+	})
+
+	t.Run("two accounts with different stored states → two groups, two events per dest, correct account/state pairing", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl)
+		stateB := model.PermissionState{
+			Granted:   false,
+			UpdatedAt: time.Date(2025, 7, 15, 9, 0, 0, 0, time.UTC),
+		}
+		perms := map[string]*model.UserPermissions{
+			"alice": {ExternalImageView: &storedState},
+			"bob":   {ExternalImageView: &stateB},
+		}
+		m.EXPECT().GetUserPermissionsForAccounts(gomock.Any(), gomock.Any()).Return(perms, nil)
+
+		var log publishLog
+
+		h := newHandler(m, emptySessionStore(), fanoutTestCfg(), nil, log.publish)
+		w := postResync(h, map[string]any{"permission": knownPermission, "accounts": []string{"alice", "bob"}}, t)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		require.Len(t, log.data, 4, "2 groups x 2 remote dests")
+
+		gotByAccount := map[string]model.PermissionState{}
+		for _, data := range log.data {
+			var evt model.InboxEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			var payload model.UserPermissionsUpdated
+			require.NoError(t, json.Unmarshal(evt.Payload, &payload))
+			require.Len(t, payload.Accounts, 1, "each group here has exactly one account")
+			gotByAccount[payload.Accounts[0]] = payload.State
+		}
+
+		require.Contains(t, gotByAccount, "alice")
+		require.Contains(t, gotByAccount, "bob")
+		assert.Equal(t, storedState.Granted, gotByAccount["alice"].Granted)
+		assert.True(t, storedState.UpdatedAt.Equal(gotByAccount["alice"].UpdatedAt))
+		assert.Equal(t, stateB.Granted, gotByAccount["bob"].Granted)
+		assert.True(t, stateB.UpdatedAt.Equal(gotByAccount["bob"].UpdatedAt))
+	})
+
+	t.Run("account absent from the store map and account present with Permissions == nil are both skipped", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl)
+		perms := map[string]*model.UserPermissions{
+			"alice":    {ExternalImageView: &storedState},
+			"nullperm": nil, // present, but Permissions itself is nil
+			// "ghost" intentionally absent from the map entirely
+		}
+		m.EXPECT().GetUserPermissionsForAccounts(gomock.Any(), gomock.Any()).Return(perms, nil)
+
+		var log publishLog
+
+		h := newHandler(m, emptySessionStore(), fanoutTestCfg(), nil, log.publish)
+		w := postResync(h, map[string]any{"permission": knownPermission, "accounts": []string{"alice", "ghost", "nullperm"}}, t)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		require.Len(t, log.data, 2, "only alice's group fans out, one event per remote dest")
+		for _, data := range log.data {
+			var evt model.InboxEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			var payload model.UserPermissionsUpdated
+			require.NoError(t, json.Unmarshal(evt.Payload, &payload))
+			assert.Equal(t, []string{"alice"}, payload.Accounts)
+		}
+	})
+
+	t.Run("a failing dest → syncFailures names it, 200", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl)
+		perms := map[string]*model.UserPermissions{"alice": {ExternalImageView: &storedState}}
+		m.EXPECT().GetUserPermissionsForAccounts(gomock.Any(), gomock.Any()).Return(perms, nil)
+
+		publish := func(_ context.Context, subj string, _ []byte) error {
+			if strings.Contains(subj, ".site-b.") {
+				return fmt.Errorf("simulated publish failure")
+			}
+			return nil
+		}
+
+		h := newHandler(m, emptySessionStore(), fanoutTestCfg(), nil, publish)
+		w := postResync(h, map[string]any{"permission": knownPermission, "accounts": []string{"alice"}}, t)
+		require.Equal(t, http.StatusOK, w.Code, "fanout failures must never fail the request")
+
+		body := respBody(t, w)
+		assert.Equal(t, []any{"site-b"}, body["syncFailures"])
+	})
+
+	t.Run("every group shares ONE fanout budget — the deadline does not restart per group", func(t *testing.T) {
+		// Regression pin: the budget used to be established inside publishPermissionFanout,
+		// which resync calls once PER state group. Groups are keyed on UpdatedAt, so N admin
+		// submits yield N groups and one unreachable peer cost N × the budget in wall time —
+		// past httpWriteTimeout (30s) at N ≥ 6, so net/http dropped the connection before the
+		// handler could report syncFailures. One shared budget = one shared deadline instant.
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl)
+		stateB := model.PermissionState{Granted: false, UpdatedAt: time.Date(2025, 7, 15, 9, 0, 0, 0, time.UTC)}
+		perms := map[string]*model.UserPermissions{
+			"alice": {ExternalImageView: &storedState},
+			"bob":   {ExternalImageView: &stateB},
+		}
+		m.EXPECT().GetUserPermissionsForAccounts(gomock.Any(), gomock.Any()).Return(perms, nil)
+
+		var mu sync.Mutex
+		var deadlines []time.Time
+		allHaveDeadline := true
+		publish := func(ctx context.Context, _ string, _ []byte) error {
+			d, ok := ctx.Deadline()
+			// Recorded, not asserted, here: destinations publish from their own
+			// goroutines, and require's FailNow is only legal on the test goroutine.
+			mu.Lock()
+			defer mu.Unlock()
+			allHaveDeadline = allHaveDeadline && ok
+			deadlines = append(deadlines, d)
+			return nil
+		}
+
+		h := newHandler(m, emptySessionStore(), fanoutTestCfg(), nil, publish)
+		w := postResync(h, map[string]any{"permission": knownPermission, "accounts": []string{"alice", "bob"}}, t)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		require.Len(t, deadlines, 4, "2 groups x 2 remote dests")
+		require.True(t, allHaveDeadline, "every publish ctx must carry the fanout budget's deadline")
+		assert.WithinDuration(t, time.Now().Add(fanoutTimeout), deadlines[0], 2*time.Second, "the shared budget must be the ~5s fanout budget")
+		for i, d := range deadlines {
+			assert.True(t, d.Equal(deadlines[0]),
+				"publish %d saw a different deadline (%v) than the first (%v) — each group got a fresh budget instead of sharing the request's one",
+				i, d, deadlines[0])
+		}
+	})
+
+	t.Run("nil bounds vs bounds set exactly at the Unix epoch are distinct states — must not collide into one group", func(t *testing.T) {
+		// Regression pin: the group key used to flatten each bound to UnixMilli, where a
+		// nil bound was bit-for-bit identical to a bound set at UnixMilli()==0. Two
+		// states sharing Granted+UpdatedAt but differing only in "no window" vs
+		// "window pinned to the epoch" must still fan out as two distinct payloads.
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl)
+		sharedUpdatedAt := time.Date(2025, 6, 1, 8, 30, 0, 0, time.UTC)
+		nilBoundsState := model.PermissionState{Granted: true, UpdatedAt: sharedUpdatedAt}
+		epochBoundsState := model.PermissionState{
+			Granted:       true,
+			EffectiveFrom: timePtr(time.UnixMilli(0)),
+			ExpiresAt:     timePtr(time.UnixMilli(0)),
+			UpdatedAt:     sharedUpdatedAt,
+		}
+		perms := map[string]*model.UserPermissions{
+			"penny": {ExternalImageView: &nilBoundsState},
+			"quinn": {ExternalImageView: &epochBoundsState},
+		}
+		m.EXPECT().GetUserPermissionsForAccounts(gomock.Any(), gomock.Any()).Return(perms, nil)
+
+		var log publishLog
+
+		h := newHandler(m, emptySessionStore(), fanoutTestCfg(), nil, log.publish)
+		w := postResync(h, map[string]any{"permission": knownPermission, "accounts": []string{"penny", "quinn"}}, t)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		require.Len(t, log.data, 4, "2 distinct groups x 2 remote dests — nil-bounds and epoch-bounds states must not merge into one group")
+
+		hasBoundsByAccount := map[string]bool{}
+		for _, data := range log.data {
+			var evt model.InboxEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			var payload model.UserPermissionsUpdated
+			require.NoError(t, json.Unmarshal(evt.Payload, &payload))
+			require.Len(t, payload.Accounts, 1, "each of the two groups here carries exactly one account")
+			hasBoundsByAccount[payload.Accounts[0]] = payload.State.EffectiveFrom != nil
+		}
+
+		require.Contains(t, hasBoundsByAccount, "penny")
+		require.Contains(t, hasBoundsByAccount, "quinn")
+		assert.False(t, hasBoundsByAccount["penny"], "penny's state must keep its nil EffectiveFrom")
+		assert.True(t, hasBoundsByAccount["quinn"], "quinn's state must keep its explicit (epoch) EffectiveFrom")
+	})
+}
+
+// -------------------------------------------------------------------------
+// listPermissions
+// -------------------------------------------------------------------------
+
+// timePtr returns a pointer to t, for constructing model.PermissionGrant
+// time-window fixtures. integration_test.go shares it — that file compiles
+// into the same package under -tags integration, while this untagged file is
+// part of every build.
+func timePtr(t time.Time) *time.Time { return &t }
+
+func TestHandler_listPermissions(t *testing.T) {
+	knownPermission := string(model.PermissionExternalImageView)
+
+	tests := []struct {
+		name       string
+		query      string
+		setupMock  func(m *MockAdminStore)
+		wantStatus int
+		wantReason string
+		checkBody  func(t *testing.T, body map[string]any)
+	}{
+		{
+			name:  "no filters → 200, all rows for the site passed through, no currentlyGranted",
+			query: "",
+			setupMock: func(m *MockAdminStore) {
+				rows := []model.PermissionGrant{
+					{ID: "g1", Permission: model.PermissionExternalImageView, SubjectAccount: "alice", Granted: true, ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "r1", RecordedBy: "p_admin", RecordedAt: time.Now().UTC()},
+					{ID: "g2", Permission: model.PermissionKey("other.permission"), SubjectAccount: "bob", Granted: false, ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "r2", RecordedBy: "p_admin", RecordedAt: time.Now().UTC()},
+				}
+				m.EXPECT().ListPermissionGrants(gomock.Any(), "", model.PermissionKey(""), 1, 20).
+					Return(rows, int64(2), nil)
+				m.EXPECT().GetUserPermissions(gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body map[string]any) {
+				entries, ok := body["entries"].([]any)
+				require.True(t, ok)
+				assert.Len(t, entries, 2)
+				assert.Equal(t, float64(2), body["total"])
+				_, present := body["currentlyGranted"]
+				assert.False(t, present, "no filters → no currentlyGranted key")
+			},
+		},
+		{
+			name:  "permission only (no subjectAccount) → 200, no currentlyGranted, mock receives subjectAccount \"\"",
+			query: "?permission=" + knownPermission,
+			setupMock: func(m *MockAdminStore) {
+				m.EXPECT().ListPermissionGrants(gomock.Any(), "", model.PermissionExternalImageView, 1, 20).
+					Return([]model.PermissionGrant{}, int64(0), nil)
+				m.EXPECT().GetUserPermissions(gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.Equal(t, []any{}, body["entries"])
+				_, present := body["currentlyGranted"]
+				assert.False(t, present, "subjectAccount omitted → no currentlyGranted key even though permission was given")
+			},
+		},
+		{
+			name:       "unknown permission → 400 unknown_permission",
+			query:      "?subjectAccount=alice&permission=bogus.permission",
+			setupMock:  func(m *MockAdminStore) {},
+			wantStatus: http.StatusBadRequest,
+			wantReason: string(errcode.PermissionUnknownKey),
+		},
+		{
+			name:  "store error → 500",
+			query: "?subjectAccount=alice",
+			setupMock: func(m *MockAdminStore) {
+				m.EXPECT().ListPermissionGrants(gomock.Any(), "alice", model.PermissionKey(""), 1, 20).
+					Return(nil, int64(0), fmt.Errorf("boom"))
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:  "GetUserPermissions store error → 500",
+			query: "?subjectAccount=alice&permission=" + knownPermission,
+			setupMock: func(m *MockAdminStore) {
+				m.EXPECT().ListPermissionGrants(gomock.Any(), "alice", model.PermissionExternalImageView, 1, 20).
+					Return([]model.PermissionGrant{}, int64(0), nil)
+				m.EXPECT().GetUserPermissions(gomock.Any(), "alice").
+					Return(nil, fmt.Errorf("boom"))
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:  "subjectAccount only, permission omitted → 200, no currentlyGranted key",
+			query: "?subjectAccount=alice",
+			setupMock: func(m *MockAdminStore) {
+				m.EXPECT().ListPermissionGrants(gomock.Any(), "alice", model.PermissionKey(""), 1, 20).
+					Return([]model.PermissionGrant{}, int64(0), nil)
+				m.EXPECT().GetUserPermissions(gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.Equal(t, []any{}, body["entries"])
+				assert.Equal(t, float64(0), body["total"])
+				_, present := body["currentlyGranted"]
+				assert.False(t, present, "permission omitted → no currentlyGranted key")
+			},
+		},
+		{
+			name:  "no permissions snapshot on the account — currentlyGranted present, false",
+			query: "?subjectAccount=alice&permission=" + knownPermission,
+			setupMock: func(m *MockAdminStore) {
+				m.EXPECT().ListPermissionGrants(gomock.Any(), "alice", model.PermissionExternalImageView, 1, 20).
+					Return([]model.PermissionGrant{}, int64(0), nil)
+				m.EXPECT().GetUserPermissions(gomock.Any(), "alice").
+					Return(nil, nil)
+			},
+			wantStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.Equal(t, []any{}, body["entries"])
+				val, ok := body["currentlyGranted"]
+				require.True(t, ok, "permission given → currentlyGranted key must be present")
+				assert.Equal(t, false, val)
+			},
+		},
+		{
+			name:  "currently granted true",
+			query: "?subjectAccount=alice&permission=" + knownPermission,
+			setupMock: func(m *MockAdminStore) {
+				now := time.Now().UTC()
+				latest := &model.PermissionGrant{
+					ID: "g1", Permission: model.PermissionExternalImageView,
+					SubjectAccount: "alice", Granted: true,
+					EffectiveFrom: timePtr(now.Add(-time.Hour)), ExpiresAt: timePtr(now.Add(time.Hour)),
+					ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "r", RecordedBy: "p_admin", RecordedAt: now.Add(-time.Hour),
+				}
+				m.EXPECT().ListPermissionGrants(gomock.Any(), "alice", model.PermissionExternalImageView, 1, 20).
+					Return([]model.PermissionGrant{*latest}, int64(1), nil)
+				m.EXPECT().GetUserPermissions(gomock.Any(), "alice").
+					Return(&model.UserPermissions{
+						ExternalImageView: &model.PermissionState{
+							Granted:       true,
+							EffectiveFrom: timePtr(now.Add(-time.Hour)),
+							ExpiresAt:     timePtr(now.Add(time.Hour)),
+							UpdatedAt:     now.Add(-time.Hour),
+						},
+					}, nil)
+			},
+			wantStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.Equal(t, true, body["currentlyGranted"])
+			},
+		},
+		{
+			name:  "currently granted state expired → currentlyGranted false",
+			query: "?subjectAccount=alice&permission=" + knownPermission,
+			setupMock: func(m *MockAdminStore) {
+				now := time.Now().UTC()
+				m.EXPECT().ListPermissionGrants(gomock.Any(), "alice", model.PermissionExternalImageView, 1, 20).
+					Return([]model.PermissionGrant{}, int64(0), nil)
+				m.EXPECT().GetUserPermissions(gomock.Any(), "alice").
+					Return(&model.UserPermissions{
+						ExternalImageView: &model.PermissionState{
+							Granted:       true,
+							EffectiveFrom: timePtr(now.Add(-2 * time.Hour)),
+							ExpiresAt:     timePtr(now.Add(-time.Hour)),
+							UpdatedAt:     now.Add(-2 * time.Hour),
+						},
+					}, nil)
+			},
+			wantStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body map[string]any) {
+				val, ok := body["currentlyGranted"]
+				require.True(t, ok)
+				assert.Equal(t, false, val)
+			},
+		},
+		{
+			name:  "ledger with a revoke row and a grant row: shapes differ",
+			query: "?subjectAccount=alice",
+			setupMock: func(m *MockAdminStore) {
+				grantRow := model.PermissionGrant{
+					ID: "g-grant", Permission: model.PermissionExternalImageView,
+					SubjectAccount: "alice", Granted: true,
+					EffectiveFrom:    timePtr(time.Date(2026, 9, 1, 0, 0, 0, 0, tzTaipei)),
+					ExpiresAt:        timePtr(time.Date(2027, 1, 1, 0, 0, 0, 0, tzTaipei)),
+					ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "r1",
+					RecordedBy: "p_admin", RecordedAt: time.Date(2026, 9, 1, 1, 0, 0, 0, time.UTC),
+				}
+				revokeRow := model.PermissionGrant{
+					ID: "g-revoke", Permission: model.PermissionExternalImageView,
+					SubjectAccount: "alice", Granted: false,
+					ApplicantAccount: "carol", ApproverAccount: "dave", Reason: "r2",
+					RecordedBy: "p_admin", RecordedAt: time.Date(2026, 10, 1, 0, 0, 0, 0, time.UTC),
+				}
+				m.EXPECT().ListPermissionGrants(gomock.Any(), "alice", model.PermissionKey(""), 1, 20).
+					Return([]model.PermissionGrant{revokeRow, grantRow}, int64(2), nil)
+				m.EXPECT().GetUserPermissions(gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body map[string]any) {
+				entries, ok := body["entries"].([]any)
+				require.True(t, ok)
+				require.Len(t, entries, 2)
+
+				revoke, ok := entries[0].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "g-revoke", revoke["id"])
+				_, hasFrom := revoke["effectiveFrom"]
+				_, hasUntil := revoke["expiresAt"]
+				assert.False(t, hasFrom, "revoke row must not carry an effectiveFrom key")
+				assert.False(t, hasUntil, "revoke row must not carry an expiresAt key")
+
+				grant, ok := entries[1].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "g-grant", grant["id"])
+				assert.Equal(t, "2026-09-01", grant["effectiveFrom"])
+				assert.Equal(t, "2026-12-31", grant["expiresAt"])
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			m := NewMockAdminStore(ctrl)
+			tc.setupMock(m)
+
+			h := newHandler(m, emptySessionStore(), testCfg(), nil, nil)
+			r := setupPermissionsRouter(h)
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/permissions"+tc.query, nil)
+			r.ServeHTTP(w, req)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+			body := respBody(t, w)
+			if tc.wantReason != "" {
+				assert.Equal(t, tc.wantReason, body["reason"])
+			}
+			if tc.checkBody != nil {
+				tc.checkBody(t, body)
+			}
+		})
+	}
+}

--- a/admin-service/room_onduty_integration_test.go
+++ b/admin-service/room_onduty_integration_test.go
@@ -93,7 +93,7 @@ func newOnDutyRig(t *testing.T, siteID string, reply func(model.RoomRestrictedRe
 	t.Cleanup(func() { _ = clientConn.NatsConn().Drain() })
 
 	cfg := Config{SiteID: siteID, BcryptCost: 4, SessionsMaxPerAccount: 100, RoomRPCTimeout: 5 * time.Second}
-	h := newHandler(store, sessions, cfg, clientConn)
+	h := newHandler(store, sessions, cfg, clientConn, nil)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
@@ -218,7 +218,7 @@ func TestIntegration_SetRoomOnDuty_RPCTimeout(t *testing.T) {
 
 	const rpcTimeout = 300 * time.Millisecond
 	cfg := Config{SiteID: "site-c", BcryptCost: 4, SessionsMaxPerAccount: 100, RoomRPCTimeout: rpcTimeout}
-	h := newHandler(store, sessions, cfg, clientConn)
+	h := newHandler(store, sessions, cfg, clientConn, nil)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.New()

--- a/admin-service/room_onduty_test.go
+++ b/admin-service/room_onduty_test.go
@@ -120,7 +120,7 @@ func TestSetRoomOnDuty_MapsOnDutyToBothFlags(t *testing.T) {
 			m := NewMockAdminStore(ctrl)
 
 			rpc := &fakeRoomRPC{reply: okReply(t)}
-			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc, nil)
 
 			w := doOnDuty(h, "r1", tc.body)
 
@@ -156,7 +156,7 @@ func TestSetRoomOnDuty_OwnerRequiredWhenTurningOn(t *testing.T) {
 			m := NewMockAdminStore(ctrl)
 
 			rpc := &fakeRoomRPC{reply: okReply(t)}
-			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc, nil)
 
 			w := doOnDuty(h, "r1", tc.body)
 
@@ -173,7 +173,7 @@ func TestSetRoomOnDuty_TrimsOwnerAccount(t *testing.T) {
 	m := NewMockAdminStore(ctrl)
 
 	rpc := &fakeRoomRPC{reply: okReply(t)}
-	h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+	h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc, nil)
 
 	w := doOnDuty(h, "r1", `{"onDuty":true,"ownerAccount":"  alice  "}`)
 
@@ -199,7 +199,7 @@ func TestSetRoomOnDuty_InvalidBody(t *testing.T) {
 			m := NewMockAdminStore(ctrl)
 
 			rpc := &fakeRoomRPC{reply: okReply(t)}
-			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc, nil)
 
 			w := doOnDuty(h, "r1", tc.body)
 
@@ -246,7 +246,7 @@ func TestSetRoomOnDuty_DownstreamErrorsPassThrough(t *testing.T) {
 			m := NewMockAdminStore(ctrl)
 
 			rpc := &fakeRoomRPC{reply: errReply(tc.remote)}
-			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc, nil)
 
 			w := doOnDuty(h, "r1", `{"onDuty":true,"ownerAccount":"alice"}`)
 
@@ -278,7 +278,7 @@ func TestSetRoomOnDuty_TransportErrorIsUnavailable(t *testing.T) {
 			m := NewMockAdminStore(ctrl)
 
 			rpc := &fakeRoomRPC{err: tc.err}
-			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc, nil)
 
 			w := doOnDuty(h, "r1", `{"onDuty":true,"ownerAccount":"alice"}`)
 
@@ -294,7 +294,7 @@ func TestSetRoomOnDuty_OtherTransportErrorIsInternal(t *testing.T) {
 	m := NewMockAdminStore(ctrl)
 
 	rpc := &fakeRoomRPC{err: fmt.Errorf("connection refused")}
-	h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+	h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc, nil)
 
 	w := doOnDuty(h, "r1", `{"onDuty":true,"ownerAccount":"alice"}`)
 
@@ -320,7 +320,7 @@ func TestSetRoomOnDuty_UnrecognizedReplyIsInternal(t *testing.T) {
 			m := NewMockAdminStore(ctrl) // strict mock: proves the handler does no store I/O
 
 			rpc := &fakeRoomRPC{reply: &nats.Msg{Data: tc.data}}
-			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+			h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc, nil)
 
 			w := doOnDuty(h, "r1", `{"onDuty":true,"ownerAccount":"alice"}`)
 
@@ -334,7 +334,7 @@ func TestSetRoomOnDuty_NilClientIsUnavailable(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	m := NewMockAdminStore(ctrl)
 
-	h := newHandler(m, emptySessionStore(), onDutyTestCfg(), nil)
+	h := newHandler(m, emptySessionStore(), onDutyTestCfg(), nil, nil)
 
 	w := doOnDuty(h, "r1", `{"onDuty":true,"ownerAccount":"alice"}`)
 
@@ -347,7 +347,7 @@ func TestSetRoomOnDuty_PropagatesRequestID(t *testing.T) {
 	m := NewMockAdminStore(ctrl)
 
 	rpc := &fakeRoomRPC{reply: okReply(t)}
-	h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+	h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc, nil)
 
 	const reqID = "01970a4f-8c2d-7c9a-abcd-e0123456789f"
 	r := gin.New()
@@ -376,7 +376,7 @@ func TestSetRoomOnDuty_UnknownRemoteCodeIsInternal(t *testing.T) {
 	m := NewMockAdminStore(ctrl)
 
 	rpc := &fakeRoomRPC{reply: &nats.Msg{Data: []byte(`{"code":"teapot","error":"i am a teapot"}`)}}
-	h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc)
+	h := newHandler(m, emptySessionStore(), onDutyTestCfg(), rpc, nil)
 
 	w := doOnDuty(h, "r1", `{"onDuty":true,"ownerAccount":"alice"}`)
 

--- a/admin-service/routes.go
+++ b/admin-service/routes.go
@@ -25,4 +25,7 @@ func registerRoutes(r *gin.Engine, h *Handler, sessions session.Store, siteID st
 	admin.DELETE("/sessions", h.revokeAllSessions)
 	admin.DELETE("/sessions/:sessionId", h.revokeSession)
 	admin.GET("/audit", h.listAudit)
+	admin.POST("/permissions", h.createPermissions)
+	admin.GET("/permissions", h.listPermissions)
+	admin.POST("/permissions/resync", h.resyncPermissions)
 }

--- a/admin-service/store.go
+++ b/admin-service/store.go
@@ -72,6 +72,37 @@ type AdminStore interface {
 	AppendAudit(ctx context.Context, e *AuditEntry) error
 	ListAudit(ctx context.Context, siteID string, f AuditFilter, page, limit int) ([]AuditEntry, int64, error)
 
+	// RecordPermissionChange appends the batch to the ledger and applies the derived
+	// state to the subjects' user documents under the per-key watermark guard — one
+	// transaction, all-or-nothing. Subject accounts are derived from the grants.
+	RecordPermissionChange(ctx context.Context, grants []*model.PermissionGrant, state model.PermissionState) error
+
+	// GetUserPermissions returns the account's materialized permission snapshot;
+	// (nil, nil) when the user or snapshot does not exist. Site-unfiltered: subjects
+	// may be homed at any site.
+	GetUserPermissions(ctx context.Context, account string) (*model.UserPermissions, error)
+
+	// GetUserPermissionsForAccounts returns the materialized snapshots for the given
+	// accounts in one read; accounts with no user doc are absent from the map.
+	// Site-unfiltered, like GetUserPermissions. Used by the resync endpoint, which only
+	// re-delivers this snapshot — never writes.
+	GetUserPermissionsForAccounts(ctx context.Context, accounts []string) (map[string]*model.UserPermissions, error)
+
+	// ListPermissionGrants returns the ledger newest-first (recordedAt desc, _id
+	// desc), company-wide (site-unfiltered — subjects may be homed at any site).
+	// subjectAccount == "" means all subjects; permission == "" means all
+	// permissions. The two filters are independent and any combination —
+	// including both empty — is valid.
+	ListPermissionGrants(ctx context.Context, subjectAccount string, permission model.PermissionKey, page, limit int) ([]model.PermissionGrant, int64, error)
+
+	// FindAccountStates reports account -> IsActive company-wide (the local users
+	// collection covers every site's users; subjects may be homed anywhere).
+	FindAccountStates(ctx context.Context, accounts []string) (map[string]bool, error)
+
+	// AppendAuditMany inserts all entries in one InsertMany. Best-effort contract same
+	// as AppendAudit (caller logs, never fails the request).
+	AppendAuditMany(ctx context.Context, entries []*AuditEntry) error
+
 	EnsureIndexes(ctx context.Context) error
 	Ping(ctx context.Context) error
 }

--- a/admin-service/store_mongo.go
+++ b/admin-service/store_mongo.go
@@ -17,12 +17,14 @@ import (
 type storeMongo struct {
 	users      *mongo.Collection
 	adminAudit *mongo.Collection
+	permGrants *mongo.Collection
 }
 
 func newStoreMongo(db *mongo.Database) *storeMongo {
 	return &storeMongo{
 		users:      db.Collection("users"),
 		adminAudit: db.Collection("admin_audit"),
+		permGrants: db.Collection("permission_grants"),
 	}
 }
 
@@ -51,6 +53,33 @@ func (s *storeMongo) EnsureIndexes(ctx context.Context) error {
 	})
 	if err != nil {
 		return fmt.Errorf("create admin_audit siteId_targetAccount_timestamp index: %w", err)
+	}
+
+	// Backs ListPermissionGrants's subjectAccount+permission lookup: equality
+	// prefix (permission, subjectAccount) + sort suffix (recordedAt, _id) so
+	// newest-first ordering comes free from the index (spec §3.6). Company-wide
+	// — the ledger browse no longer filters by siteId.
+	_, err = s.permGrants.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "permission", Value: 1},
+			{Key: "subjectAccount", Value: 1},
+			{Key: "recordedAt", Value: -1},
+			{Key: "_id", Value: -1},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("create permission_grants permission_subjectAccount_recordedAt_id index: %w", err)
+	}
+
+	// Backs the audit/BI browse (no subjectAccount equality, so index 1 above
+	// doesn't apply). The _id tiebreaker mirrors the list sort {recordedAt:-1,_id:-1}
+	// — without it every browse pays a blocking in-memory SORT, and recordedAt ties
+	// are guaranteed because a multi-subject batch stamps one shared timestamp.
+	_, err = s.permGrants.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{{Key: "recordedAt", Value: -1}, {Key: "_id", Value: -1}},
+	})
+	if err != nil {
+		return fmt.Errorf("create permission_grants recordedAt_id index: %w", err)
 	}
 
 	return nil
@@ -292,11 +321,7 @@ var auditProjection = bson.M{
 }
 
 func (s *storeMongo) AppendAudit(ctx context.Context, e *AuditEntry) error {
-	_, err := s.adminAudit.InsertOne(ctx, e)
-	if err != nil {
-		return fmt.Errorf("insert audit entry: %w", err)
-	}
-	return nil
+	return s.AppendAuditMany(ctx, []*AuditEntry{e})
 }
 
 // ListAudit returns audit entries newest-first, scoped to siteID, with optional
@@ -339,6 +364,194 @@ func (s *storeMongo) ListAudit(ctx context.Context, siteID string, f AuditFilter
 		entries = []AuditEntry{}
 	}
 	return entries, total, nil
+}
+
+// Full-row projection: every PermissionGrant field is needed by the ledger views;
+// keep in lockstep with the struct.
+var permissionGrantProjection = bson.M{
+	"_id":              1,
+	"permission":       1,
+	"subjectAccount":   1,
+	"granted":          1,
+	"effectiveFrom":    1,
+	"expiresAt":        1,
+	"applicantAccount": 1,
+	"approverAccount":  1,
+	"reason":           1,
+	"recordedBy":       1,
+	"recordedAt":       1,
+}
+
+// RecordPermissionChange appends the batch to the ledger and applies the derived state to
+// the subjects' user documents under the per-key watermark guard, in one transaction
+// (withTransaction + InsertMany + UpdateMany) — so a resend after a partial failure
+// cannot produce duplicate ledger rows, and a stale write can never clobber a newer
+// stored state (spec §4.4 note on step 11).
+func (s *storeMongo) RecordPermissionChange(ctx context.Context, grants []*model.PermissionGrant, state model.PermissionState) error {
+	if len(grants) == 0 {
+		return nil
+	}
+	field, ok := model.PermissionFieldName(grants[0].Permission)
+	if !ok {
+		return fmt.Errorf("record permission change: unknown permission %q", grants[0].Permission)
+	}
+	docs := make([]any, len(grants))
+	accounts := make([]string, len(grants))
+	for i, g := range grants {
+		docs[i] = g
+		accounts[i] = g.SubjectAccount
+	}
+	path := "permissions." + field
+	filter := bson.M{
+		"account": bson.M{"$in": accounts},
+		"$or": bson.A{
+			bson.M{path + ".updatedAt": bson.M{"$exists": false}},
+			bson.M{path + ".updatedAt": bson.M{"$lte": state.UpdatedAt}},
+		},
+	}
+	return s.withTransaction(ctx, func(ctx context.Context) error {
+		if _, err := s.permGrants.InsertMany(ctx, docs); err != nil {
+			return fmt.Errorf("insert permission grants: %w", err)
+		}
+		// MatchedCount may be < len(accounts): a newer stored state (guard) or a user
+		// doc missing locally is a no-op, not an error — same rule as the inbox apply.
+		if _, err := s.users.UpdateMany(ctx, filter, bson.M{"$set": bson.M{path: state}}); err != nil {
+			return fmt.Errorf("apply user permissions: %w", err)
+		}
+		return nil
+	})
+}
+
+// GetUserPermissions returns the account's materialized permission snapshot; (nil, nil)
+// when the user or snapshot does not exist. Site-unfiltered: subjects may be homed at
+// any site.
+func (s *storeMongo) GetUserPermissions(ctx context.Context, account string) (*model.UserPermissions, error) {
+	var doc struct {
+		Permissions *model.UserPermissions `bson:"permissions"`
+	}
+	err := s.users.FindOne(ctx, bson.M{"account": account},
+		options.FindOne().SetProjection(bson.M{"permissions": 1})).Decode(&doc)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find user permissions: %w", err)
+	}
+	return doc.Permissions, nil
+}
+
+// GetUserPermissionsForAccounts returns the materialized snapshots for the given
+// accounts in one read; accounts with no user doc are absent from the map.
+func (s *storeMongo) GetUserPermissionsForAccounts(ctx context.Context, accounts []string) (map[string]*model.UserPermissions, error) {
+	cur, err := s.users.Find(ctx, bson.M{"account": bson.M{"$in": accounts}},
+		options.Find().SetProjection(bson.M{"account": 1, "permissions": 1}))
+	if err != nil {
+		return nil, fmt.Errorf("find user permissions: %w", err)
+	}
+
+	var rows []struct {
+		Account     string                 `bson:"account"`
+		Permissions *model.UserPermissions `bson:"permissions"`
+	}
+	if err := cur.All(ctx, &rows); err != nil {
+		return nil, fmt.Errorf("decode user permissions: %w", err)
+	}
+
+	out := make(map[string]*model.UserPermissions, len(rows))
+	for _, row := range rows {
+		out[row.Account] = row.Permissions
+	}
+	return out, nil
+}
+
+// ListPermissionGrants returns the ledger newest-first (recordedAt desc, _id
+// desc), company-wide (site-unfiltered — subjects may be homed at any site).
+// subjectAccount == "" means all subjects; permission == "" means all
+// permissions — the two filters combine independently (spec §4.6). Omitting
+// either or both breaks the equality prefix on index 1, so this path falls
+// back to index 2 (recordedAt, _id) plus a residual filter, or — when both
+// are omitted — index 2 alone with no residual filter; accepted per spec.
+func (s *storeMongo) ListPermissionGrants(ctx context.Context, subjectAccount string, permission model.PermissionKey, page, limit int) ([]model.PermissionGrant, int64, error) {
+	filter := bson.M{}
+	if subjectAccount != "" {
+		filter["subjectAccount"] = subjectAccount
+	}
+	if permission != "" {
+		filter["permission"] = permission
+	}
+
+	skip := int64((page - 1) * limit)
+
+	total, err := s.permGrants.CountDocuments(ctx, filter)
+	if err != nil {
+		return nil, 0, fmt.Errorf("count permission grants: %w", err)
+	}
+
+	cur, err := s.permGrants.Find(ctx, filter,
+		options.Find().
+			SetProjection(permissionGrantProjection).
+			SetSort(bson.D{{Key: "recordedAt", Value: -1}, {Key: "_id", Value: -1}}).
+			SetSkip(skip).
+			SetLimit(int64(limit)),
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("find permission grants: %w", err)
+	}
+
+	var grants []model.PermissionGrant
+	if err := cur.All(ctx, &grants); err != nil {
+		return nil, 0, fmt.Errorf("decode permission grants: %w", err)
+	}
+	if grants == nil {
+		grants = []model.PermissionGrant{}
+	}
+	return grants, total, nil
+}
+
+// accountStateProjection contains only the fields FindAccountStates needs to
+// derive IsActive() — never the rest of the user document.
+var accountStateProjection = bson.M{"account": 1, "active": 1}
+
+// FindAccountStates returns account -> IsActive() for the accounts that exist
+// company-wide (the local users collection covers every site's users; subjects
+// may be homed anywhere) — accounts not present in the map do not exist. One
+// query for the whole batch (spec §4.4 step 10), rather than N lookups.
+func (s *storeMongo) FindAccountStates(ctx context.Context, accounts []string) (map[string]bool, error) {
+	cur, err := s.users.Find(ctx,
+		bson.M{"account": bson.M{"$in": accounts}},
+		options.Find().SetProjection(accountStateProjection),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("find account states: %w", err)
+	}
+
+	var rows []model.User
+	if err := cur.All(ctx, &rows); err != nil {
+		return nil, fmt.Errorf("decode account states: %w", err)
+	}
+
+	states := make(map[string]bool, len(rows))
+	for i := range rows {
+		states[rows[i].Account] = rows[i].IsActive()
+	}
+	return states, nil
+}
+
+// AppendAuditMany inserts all entries in one InsertMany — a 200-subject
+// batch would otherwise cost 200 round trips through AppendAudit. Same
+// best-effort contract: the caller logs a failure, never fails the request.
+func (s *storeMongo) AppendAuditMany(ctx context.Context, entries []*AuditEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	docs := make([]any, len(entries))
+	for i, e := range entries {
+		docs[i] = e
+	}
+	if _, err := s.adminAudit.InsertMany(ctx, docs); err != nil {
+		return fmt.Errorf("insert audit entries: %w", err)
+	}
+	return nil
 }
 
 func (s *storeMongo) Ping(ctx context.Context) error {

--- a/docker-local/compose.deps.yaml
+++ b/docker-local/compose.deps.yaml
@@ -32,6 +32,13 @@ services:
     # tracks the same image testcontainers uses.
     image: mongo:8.2.9
     container_name: chat-local-mongodb
+    # Single-node replica set — transactions (admin-service password-change,
+    # deactivate, and the new permission-grant batch insert) require one; a
+    # standalone mongod rejects them outright. The member host below is the
+    # in-network service name "mongodb", so container-side clients need no
+    # config change; host-side tools (make seed, tools/jaeger/README.md) add
+    # ?directConnection=true instead of trying to resolve that name.
+    command: ["--replSet", "rs0", "--bind_ip_all"]
     ports:
       - "27017:27017"
     volumes:
@@ -39,11 +46,18 @@ services:
       # chat.hr_employee went stale. `make seed` owns that collection now.
       - mongo-data:/data/db
     healthcheck:
-      test: ["CMD-SHELL", "echo 'db.runCommand({ping:1}).ok' | mongosh --quiet | grep -q 1"]
+      # The rs.status()/rs.initiate() pair only bootstraps the set; the trailing
+      # quit() is what decides health — without it every branch exits 0 and
+      # depends_on: service_healthy would release before a primary was elected.
+      test:
+        - CMD-SHELL
+        - >-
+          mongosh --quiet --eval
+          'try { rs.status().ok } catch (e) { rs.initiate({_id:"rs0",members:[{_id:0,host:"mongodb:27017"}]}) }
+          quit(db.hello().isWritablePrimary ? 0 : 1)'
       interval: 5s
-      timeout: 5s
-      retries: 10
-      start_period: 10s
+      timeout: 10s
+      retries: 15
     networks:
       - chat-local
 

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -4750,7 +4750,7 @@ Same shape as `status.getByName`:
 **Subject:** `chat.user.{account}.request.user.{siteID}.settings.get`
 **Reply subject:** auto-generated `_INBOX.>` (NATS request/reply)
 
-Returns the calling user's stored settings sub-document — **exactly as stored**. The server never injects defaults: a field the user never set is absent from the reply, and **absent means the client applies its own default** (cross-client default consistency is client-owned by design). A user who never set anything gets `{}`.
+Returns the calling user's stored settings sub-document — **exactly as stored** — plus the evaluated admin-managed `permissions`. The server never injects settings defaults: a field the user never set is absent from the reply, and **absent means the client applies its own default** (cross-client default consistency is client-owned by design). A user who never set anything gets `{ "permissions": … }` and nothing else.
 
 ##### Request body
 
@@ -4758,7 +4758,7 @@ None (empty payload).
 
 ##### Success response
 
-The stored settings object. All ten fields are optional and appear only when the user has explicitly set them:
+The stored settings object plus `permissions`. All ten settings fields are optional and appear only when the user has explicitly set them; `permissions` is always present:
 
 | Field | Type | Notes |
 |-------|------|-------|
@@ -4772,6 +4772,7 @@ The stored settings object. All ten fields are optional and appear only when the
 | `showNotificationsInCall` | boolean | Show notifications in call. Enforced server-side: when unset or `false`, push is suppressed while the user's presence is `"busy"` or `"in-call"`. A priority-contact pierce bypasses this — see `alwaysAllowPriorityNotifications`. This enforcement takes effect once presence reporting is enabled server-side; until then no status is treated as in-call, so pushes are delivered regardless of this setting. |
 | `initialChatScrollPosition` | string | Where a chat opens: `"lastRead"` \| `"newest"`. |
 | `priorityContacts` | string[] | Read-only here — raw contact accounts (not enriched), stored order. Written only by [`settings.priorityContacts.add`](#settingsprioritycontactsadd) / [`settings.priorityContacts.remove`](#settingsprioritycontactsremove), never by `settings.set`. |
+| `permissions` | map<permission key, boolean> | Evaluated admin-managed permissions; every known key is always present (`false` when never granted, expired, not yet effective, or revoked). Admin-written, read-only here — `settings.set` cannot touch it. No client event is emitted when an admin changes a permission: call `settings.get` again (e.g. on reconnect) to pick one up. |
 
 ```json
 {
@@ -4779,14 +4780,15 @@ The stored settings object. All ten fields are optional and appear only when the
   "themePreference": "dark",
   "translateMessageInto": "en-US",
   "messagePreviewEnabled": true,
-  "priorityContacts": ["alice", "helper.bot"]
+  "priorityContacts": ["alice", "helper.bot"],
+  "permissions": { "external.image.view": true }
 }
 ```
 
 Never-set user:
 
 ```json
-{}
+{ "permissions": { "external.image.view": false } }
 ```
 
 ##### Error response
@@ -4827,7 +4829,7 @@ Any non-empty subset of the nine settings fields (same types as [`settings.get`]
 
 ##### Success response
 
-The **full post-update settings** (same shape as [`settings.get`](#settingsget)) — sent fields updated, previously stored fields retained:
+The **full post-update settings** (the same ten settings fields as [`settings.get`](#settingsget), without `permissions`) — sent fields updated, previously stored fields retained:
 
 ```json
 {
@@ -4856,7 +4858,7 @@ The payload carries the **full post-update settings** (replace, don't merge):
 | Field | Type | Notes |
 |-------|------|-------|
 | `timestamp` | number | Publish time, Unix ms. |
-| `settings` | UserSettings | The full post-update settings — same ten optional fields as [`settings.get`](#settingsget). |
+| `settings` | UserSettings | The full post-update settings — the same ten optional settings fields as [`settings.get`](#settingsget), without `permissions`. |
 
 ```json
 {
@@ -6727,10 +6729,19 @@ Every error response — NATS reply subjects, JetStream async results, and HTTP 
 | `response_too_large` | internal | any RPC whose reply would exceed the transport `max_payload` (most often large history reads — retry with a smaller `limit`) |
 | `no_responders` | unavailable | any request/reply RPC whose upstream subject had no subscriber (`natsutil.RequestFailure`) — the upstream service is down, not yet started, or not routed to this site. Retry. |
 | `upstream_timeout` | unavailable | any request/reply RPC delivered to the upstream but not answered within the caller's timeout (`natsutil.RequestFailure`). Retry. |
+| `invalid_token` | unauthenticated | admin-service (every `Authorization: Bearer` route — §9.11 and all `/v1/admin/…`; token missing, unknown, or session not found), botplatform-service (session token failed validation, §7) |
 | `not_admin` | forbidden | admin-service (valid session, but caller does not hold the `admin` role or the session site does not match) |
 | `account_exists` | conflict | admin-service `POST /v1/admin/users` (account already exists in the users collection) |
 | `invalid_credentials` | unauthenticated | admin-service `POST /v1/login` (§9.10) (unknown account, wrong password, not admin, or deactivated — uniform response) |
 | `old_password_mismatch` | unauthenticated | admin-service `POST /v1/password/change` (§9.11) (`oldPassword` does not match) |
+| `unknown_permission` | bad_request | admin-service `POST /v1/admin/permissions` (§9.13), `GET /v1/admin/permissions` (§9.14), `POST /v1/admin/permissions/resync` (§9.15) (permission key not recognized) |
+| `invalid_subject_count` | bad_request | admin-service `POST /v1/admin/permissions` (§9.13) (`subjectAccounts` empty), `POST /v1/admin/permissions/resync` (§9.15) (`accounts` empty) |
+| `invalid_reason` | bad_request | admin-service `POST /v1/admin/permissions` (§9.13) (`reason` over 1000 runes) |
+| `missing_permission_fields` | bad_request | admin-service `POST /v1/admin/permissions` (§9.13) (`granted` omitted, or `applicantAccount`/`approverAccount` empty) |
+| `invalid_permission_window` | bad_request | admin-service `POST /v1/admin/permissions` (§9.13) (grant only: malformed date, `effectiveFrom` after `expiresAt`, or `expiresAt` not in the future) |
+| `unexpected_permission_window` | bad_request | admin-service `POST /v1/admin/permissions` (§9.13) (revoke only: `effectiveFrom`/`expiresAt` present with a non-null value; an explicit `null` counts as absent) |
+| `inactive_subject` | bad_request | admin-service `POST /v1/admin/permissions` (§9.13) (a subject account is deactivated) |
+| `unknown_accounts` | not_found | admin-service `POST /v1/admin/permissions` (§9.13) (a subject, applicant, or approver account does not exist; the lookup is company-wide, not filtered by site) |
 | `emoji_shortcode_reserved` | bad_request | media-service `PUT /api/v1/emoji/…` (shortcode collides with a built-in standard emoji) |
 | `emoji_delete_disabled` | forbidden | media-service `emoji.delete` (kill-switch `EMOJI_DELETE_ENABLED=false`, the default) |
 
@@ -7385,7 +7396,7 @@ Returns audit entries for the admin's site, newest-first, with optional filterin
 |---|---|---|
 | `targetAccount` | string | Optional. Filter by the affected user's account. |
 | `actor` | string | Optional. Filter by actor account. |
-| `action` | string | Optional. Filter by action string (e.g. `user.create`, `session.revoke_all`). |
+| `action` | string | Optional. Filter by action string (e.g. `user.create`, `session.revoke_all`, `permission.grant`, `permission.revoke`). |
 | `page` | integer | Page number, 1-based. Defaults to `1`. |
 | `limit` | integer | Page size. Defaults to `20`. |
 
@@ -7573,6 +7584,272 @@ For a room with members homed on other sites, room-service still fans the state 
 
 `None.`
 
+### 9.13 Create / revoke permission grants
+
+**Endpoint:** `POST /v1/admin/permissions`
+**Auth:** `Authorization: Bearer <authToken>`, admin role + same-site required.
+
+Records a new row in the append-only `permission_grants` ledger for one or more subject accounts — either a grant (`granted: true`) or a revocation (`granted: false`) of the same permission key in one call. Unlike its siblings this is not a `/users/:account/...`-shaped endpoint, because `subjectAccounts` is a batch. The same write also materializes the new state on each subject's user document — that snapshot, not the ledger, is what [`settings.get`](#settingsget) and `currentlyGranted` (§9.14) read; the ledger is audit history and is never rewritten. One `admin_audit` entry (`action`: `permission.grant` or `permission.revoke`, `targetAccount`: the subject, `details`: `{"permission": "<permission key>"}`) is written per subject alongside the ledger rows.
+
+After the write commits, the new state is fanned out to every other site so their copies converge. Large batches are split into chunks internally; that is transparent to callers — chunking never shows up in the request or the response, and only whole destinations appear in `syncFailures`.
+
+Dates are plain `YYYY-MM-DD` strings, interpreted under a fixed UTC+8 rule — never the caller's timezone, never the server's local timezone. There is no `timezone` field, and there never will be one for this endpoint.
+
+#### Request body
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `permission` | string | yes | Permission key. The only key defined today is `external.image.view`. |
+| `subjectAccounts` | string[] | yes | Accounts to grant or revoke for — non-empty, no fixed cap. Duplicates are silently deduplicated (first occurrence kept) and reported back in `duplicatesIgnored` — never rejected outright. |
+| `granted` | boolean | yes | `true` records a grant, `false` records a revocation. Required — a body that omits `granted`, or sends an explicit `granted: null`, is rejected with `400 missing_permission_fields`, not silently treated as `false`/revoke. |
+| `effectiveFrom` | string | no | Grant only — `YYYY-MM-DD`. Omitted means "effective immediately" (the write instant). Backdating is allowed. **Must be omitted when `granted` is `false`** — a revocation has no validity window. A JSON `null` is treated as absent (equivalent to omitting the field). |
+| `expiresAt` | string | when `granted` is `true` | Grant only — `YYYY-MM-DD`, the last valid day (inclusive). Stored internally as the exclusive-end instant, UTC+8 midnight the *following* day. A value equal to today is valid (the grant expires tonight); any earlier date is rejected. **Must be omitted when `granted` is `false`** — there are no permanent grants and no dated revocations. A JSON `null` is treated as absent (equivalent to omitting the field). |
+| `applicantAccount` | string | yes | Account of the person who requested the change (offline approval). Must exist; may be inactive. |
+| `approverAccount` | string | yes | Account of the person who approved the change (offline approval). Must exist; may be inactive. |
+| `reason` | string | no | Free text, ≤1000 runes (`utf8.RuneCountInString`) when present. Omitted or empty is accepted and stored as `""`. Retained permanently — this is an append-only ledger, not a mutable note. |
+
+Grant:
+
+```json
+{
+  "permission": "external.image.view",
+  "subjectAccounts": ["alice", "bob"],
+  "granted": true,
+  "effectiveFrom": "2026-09-01",
+  "expiresAt": "2026-12-31",
+  "applicantAccount": "carol",
+  "approverAccount": "dave",
+  "reason": "On-call staff must review production line photos from outside the fab."
+}
+```
+
+Revoke — `effectiveFrom`/`expiresAt` omitted (an explicit `null` is equivalent):
+
+```json
+{
+  "permission": "external.image.view",
+  "subjectAccounts": ["alice"],
+  "granted": false,
+  "applicantAccount": "carol",
+  "approverAccount": "dave",
+  "reason": "Project ended."
+}
+```
+
+#### Success response
+
+`HTTP 201`
+
+| Field | Type | Notes |
+|---|---|---|
+| `created` | integer | Number of ledger rows written — the deduplicated subject count. |
+| `duplicatesIgnored` | string[] | Subject accounts dropped as duplicates of an earlier entry in the same request. `[]`, never `null`, when there were none. |
+| `syncFailures` | string[] | Remote site IDs whose cross-site publish was not acknowledged. Omitted (not `[]`) when every destination landed. Still `201` when present — the ledger rows and this site's state were written; the listed sites may keep serving the previous decision until healed by [§9.15 resync](#915-resync-permission-fanout). |
+
+```json
+{
+  "created": 2,
+  "duplicatesIgnored": [],
+  "syncFailures": ["site-b"]
+}
+```
+
+#### Errors
+
+| Status | `code` | `reason` | Notes |
+|---|---|---|---|
+| 400 | `bad_request` | `missing_fields` | Body is not valid JSON. |
+| 400 | `bad_request` | `unknown_permission` | `permission` is not a recognized key. |
+| 400 | `bad_request` | `invalid_subject_count` | `subjectAccounts` is empty. |
+| 400 | `bad_request` | `invalid_reason` | `reason` exceeds 1000 runes. |
+| 400 | `bad_request` | `missing_permission_fields` | `granted` is omitted, or `applicantAccount`/`approverAccount` is empty. |
+| 400 | `bad_request` | `invalid_permission_window` | Grant only. `effectiveFrom`/`expiresAt` not `YYYY-MM-DD`, `effectiveFrom` after `expiresAt`, or `expiresAt`'s derived instant is not in the future (today is valid; yesterday or earlier is not). |
+| 400 | `bad_request` | `unexpected_permission_window` | Revoke only. `effectiveFrom` or `expiresAt` present with a non-null value; an explicit `null` counts as absent and is accepted. |
+| 404 | `not_found` | `unknown_accounts` | A subject, applicant, or approver account does not exist. Accounts are looked up company-wide — the lookup does not filter by `siteId`, so a subject may be homed at any site. Message names the offending accounts; `metadata.accounts` carries the same comma-joined list for programmatic display. |
+| 400 | `bad_request` | `inactive_subject` | A subject account exists but is deactivated. `applicantAccount`/`approverAccount` are exempt — a departed staff member may still be recorded as applicant or approver. Message names the offending accounts; `metadata.accounts` carries the same comma-joined list. |
+| 401 | `unauthenticated` | `invalid_token` | Token missing, unknown, or session not found. |
+| 403 | `forbidden` | `not_admin` | Valid session, but caller lacks the `admin` role or the session `siteId` does not match. |
+| 500 | `internal` | — | The batch insert is transactional — on failure, no ledger row was written and no audit entry exists. |
+
+```bash
+# Grant
+curl -X POST https://admin.example.com/v1/admin/permissions \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "permission": "external.image.view",
+    "subjectAccounts": ["alice", "bob"],
+    "granted": true,
+    "effectiveFrom": "2026-09-01",
+    "expiresAt": "2026-12-31",
+    "applicantAccount": "carol",
+    "approverAccount": "dave",
+    "reason": "On-call staff must review production line photos from outside the fab."
+  }'
+```
+
+```bash
+# Revoke
+curl -X POST https://admin.example.com/v1/admin/permissions \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "permission": "external.image.view",
+    "subjectAccounts": ["alice"],
+    "granted": false,
+    "applicantAccount": "carol",
+    "approverAccount": "dave",
+    "reason": "Project ended."
+  }'
+```
+
+### 9.14 List permission grants
+
+**Endpoint:** `GET /v1/admin/permissions`
+**Auth:** `Authorization: Bearer <authToken>`, admin role + same-site required.
+
+Returns the permission ledger, newest-first, plus the current computed decision when the filters narrow to a single subject and permission. Backs both the terminal workflow (confirm state before writing, confirm again after) and the console's lookup pane. Company-wide — the ledger browse does not filter by `siteId`, so rows for subjects homed at any site are returned.
+
+#### Query parameters
+
+| Parameter | Type | Notes |
+|---|---|---|
+| `subjectAccount` | string | Optional. Filter to one subject account. Omitted lists every subject. |
+| `permission` | string | Optional. Filter to one permission key. Omitted lists every permission. An unrecognized key returns `400 unknown_permission`. |
+| `page` | integer | Page number, 1-based. Defaults to `1`. |
+| `limit` | integer | Page size. Defaults to `20`, max `100`. |
+
+`subjectAccount` and `permission` combine independently, four ways: neither given returns every row; `subjectAccount` alone returns one subject's full ledger; `permission` alone returns one permission key across every subject; both given narrows to one subject's ledger for one permission. `currentlyGranted` (below) is included only in the both-given case.
+
+#### Success response
+
+`HTTP 200`
+
+| Field | Type | Notes |
+|---|---|---|
+| `currentlyGranted` | boolean | Present only when BOTH `subjectAccount` and `permission` were supplied — a single decision is meaningless without both. The current decision, evaluated at read time from the subject's materialized user-document state — the same evaluation path as [`settings.get`](#settingsget), so the two can never disagree. Not derived from the ledger rows below (those are audit history). Deliberately not named `granted`, which is a per-row field meaning "what this record did", not "current state". |
+| `entries` | [PermissionGrantView](#permissiongrantview)[] | The ledger, newest-first (`recordedAt` desc, `_id` desc tie-break). |
+| `total` | integer | Total matching rows across all pages. |
+
+```json
+{
+  "currentlyGranted": false,
+  "entries": [
+    {
+      "id": "0199f2c3a4b5c6d90199f2c3a4b5c6d9",
+      "permission": "external.image.view",
+      "subjectAccount": "alice",
+      "granted": false,
+      "applicantAccount": "carol",
+      "approverAccount": "dave",
+      "reason": "Project ended.",
+      "recordedBy": "p_admin_wang",
+      "recordedAt": "2026-10-15T02:03:04Z"
+    },
+    {
+      "id": "0199f2c3a4b5c6d70199f2c3a4b5c6d7",
+      "permission": "external.image.view",
+      "subjectAccount": "alice",
+      "granted": true,
+      "effectiveFrom": "2026-09-01",
+      "expiresAt": "2026-12-31",
+      "applicantAccount": "carol",
+      "approverAccount": "dave",
+      "reason": "On-call staff must review production line photos from outside the fab.",
+      "recordedBy": "p_admin_wang",
+      "recordedAt": "2026-09-01T01:00:00Z"
+    }
+  ],
+  "total": 2
+}
+```
+
+Note what this example demonstrates: the revoke row (newest, listed first) omits
+`effectiveFrom`/`expiresAt` entirely, and `currentlyGranted` reads
+`false` because the revoke is what the subject's materialized state now holds.
+
+#### Errors
+
+| Status | `code` | `reason` | Notes |
+|---|---|---|---|
+| 400 | `bad_request` | `unknown_permission` | `permission` is not a recognized key. |
+| 401 | `unauthenticated` | `invalid_token` | Token missing, unknown, or session not found. |
+| 403 | `forbidden` | `not_admin` | Valid session, but caller lacks the `admin` role or the session `siteId` does not match. |
+| 500 | `internal` | — | Server-side fault; cause is logged server-side only. |
+
+```bash
+# Lookup
+curl -G https://admin.example.com/v1/admin/permissions \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  --data-urlencode "subjectAccount=alice" \
+  --data-urlencode "permission=external.image.view"
+```
+
+### 9.15 Resync permission fanout
+
+**Endpoint:** `POST /v1/admin/permissions/resync`
+**Auth:** `Authorization: Bearer <authToken>`, admin role + same-site required.
+
+Re-delivers the **current** materialized state for the given accounts to every other site — the remediation for a `syncFailures` entry returned by §9.13. Re-delivery only: it reads each account's stored state and republishes it, and **writes nothing** — no ledger row, no `admin_audit` entry, no user-document update. Safe to call repeatedly: each delivered state carries its original write timestamp, and a destination ignores anything older than what it already holds — so a replay either rewrites the identical value or is discarded, and can never undo a newer decision.
+
+No existence or active check is performed — this endpoint syncs state, it does not validate people. An account with no stored state for the requested permission (unknown account, or never granted this permission) is silently skipped: nothing is published for it and it is not reported as an error.
+
+#### Request body
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `permission` | string | yes | Permission key to resync. The only key defined today is `external.image.view`. |
+| `accounts` | string[] | yes | Accounts to resync — non-empty, no fixed cap. Duplicates are silently deduplicated (first occurrence kept) and not reported. |
+
+```json
+{
+  "permission": "external.image.view",
+  "accounts": ["alice", "bob"]
+}
+```
+
+#### Success response
+
+`HTTP 200`
+
+| Field | Type | Notes |
+|---|---|---|
+| `syncFailures` | string[] | Remote site IDs whose republish was not acknowledged, deduplicated. Omitted (not `[]`) when every destination landed — the usual case; call again to retry. |
+
+Everything landed:
+
+```json
+{}
+```
+
+One destination still unreachable:
+
+```json
+{ "syncFailures": ["site-b"] }
+```
+
+#### Errors
+
+| Status | `code` | `reason` | Notes |
+|---|---|---|---|
+| 400 | `bad_request` | `missing_fields` | Body is not valid JSON. |
+| 400 | `bad_request` | `unknown_permission` | `permission` is not a recognized key. |
+| 400 | `bad_request` | `invalid_subject_count` | `accounts` is empty. |
+| 401 | `unauthenticated` | `invalid_token` | Token missing, unknown, or session not found. |
+| 403 | `forbidden` | `not_admin` | Valid session, but caller lacks the `admin` role or the session `siteId` does not match. |
+| 500 | `internal` | — | Failed to read the stored state; nothing was published. Cause is logged server-side only. |
+
+```bash
+# Resync the two accounts a failed grant left out of sync
+curl -X POST https://admin.example.com/v1/admin/permissions/resync \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "permission": "external.image.view",
+    "accounts": ["alice", "bob"]
+  }'
+```
+
 ### UserView
 
 Projected user record returned by all admin user endpoints. The `services` / bcrypt field is never included.
@@ -7616,12 +7893,28 @@ Projected user record returned by all admin user endpoints. The `services` / bcr
 | `id` | string | Audit entry ID. |
 | `actorUserId` | string | Internal user ID of the admin who performed the action. |
 | `actorAccount` | string | Account of the admin. |
-| `action` | string | Action string, e.g. `user.create`, `user.update`, `user.password.set`, `session.revoke_all`, `session.revoke`. |
+| `action` | string | Action string, e.g. `user.create`, `user.update`, `user.password.set`, `session.revoke_all`, `session.revoke`, `permission.grant`, `permission.revoke`. |
 | `targetUserId` | string | Internal ID of the affected user. Omitted when not applicable. |
 | `targetAccount` | string | Account of the affected user. Omitted when not applicable. |
 | `details` | map<string, string> | Non-secret context for the action (e.g. `{"account":"bob"}`). Omitted when empty. Never contains passwords, hashes, or tokens. |
 | `siteId` | string | Site the action was performed on. |
 | `timestamp` | integer | Epoch ms (UTC) when the action occurred. |
+
+### PermissionGrantView
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string | Ledger row ID (32-char UUIDv7 hex). |
+| `permission` | string | Permission key this row applies to. |
+| `subjectAccount` | string | The account this row grants or revokes the permission for. |
+| `granted` | boolean | What this row did — `true` for a grant, `false` for a revocation. Historical rows are never rewritten; this is not "does the subject currently hold the permission" (see `currentlyGranted`, §9.14). |
+| `effectiveFrom` | string | `YYYY-MM-DD`, decoded back from the stored instant at UTC+8. Omitted on revoke rows (no validity window). |
+| `expiresAt` | string | `YYYY-MM-DD`, the inclusive last valid day (decoded from the stored exclusive-end instant at UTC+8, minus one day). Omitted on revoke rows. |
+| `applicantAccount` | string | Who requested the change. |
+| `approverAccount` | string | Who approved the change. |
+| `reason` | string | Free-text justification, as submitted. |
+| `recordedBy` | string | The admin account that recorded this row (from the session token). |
+| `recordedAt` | string | RFC 3339. Server clock at write time (when the decision was recorded). Independent of the validity window — a grant can be back- or future-dated via `effectiveFrom`/`expiresAt`. |
 
 ---
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -269,6 +269,9 @@ matching `siteId`). Full schemas, examples, and error tables are in
 | `GET /v1/admin/audit` | synchronous HTTP | List the audit log (§9.9). |
 | `POST /v1/admin/rooms/:roomId/onduty` | synchronous HTTP | Toggle a channel's on-duty state: maps the boolean onto `restricted` + `externalAccess` via room-service's restrict RPC, with `ownerAccount` required when turning on. Emits a `room_restricted` room event; no system message, so nothing is displayed (§9.12). |
 | `POST /v1/password/change` | synchronous HTTP | Logged-in admin's self-service password change (§9.11). |
+| `POST /v1/admin/permissions` | synchronous HTTP | Grant or revoke a permission for one or more subject accounts; appends to the permission ledger, materializes the new state on each subject's user doc, and fans it out to every other site (unacknowledged destinations come back as `syncFailures`), with one slim audit entry per subject (§9.13). |
+| `GET /v1/admin/permissions` | synchronous HTTP | List the permission ledger newest-first — company-wide by default, with optional independent `subjectAccount` and `permission` query filters; `currentlyGranted` (read from the materialized state) is included only when both filters are set (§9.14). |
+| `POST /v1/admin/permissions/resync` | synchronous HTTP | Re-deliver the current materialized permission state for the given accounts to every other site; writes nothing, idempotent (§9.15). |
 
 **Emits:** None directly — HTTP-only. `POST /v1/admin/rooms/:roomId/onduty` makes room-service publish [`room_restricted`](events.md#room_restricted-roomrestrictedroomevent) on `chat.room.{roomID}.event`.
 
@@ -1598,8 +1601,9 @@ internally but is not delivered to clients.)
 
 **Subject:** `chat.user.{account}.request.user.{siteID}.settings.get`
 
-Returns the caller's stored settings **exactly as stored** — `{}` when never set.
-The server never injects defaults; **absent = the client applies its own default**.
+Returns the caller's stored settings **exactly as stored**, plus the evaluated
+admin-managed `permissions`. The server never injects settings defaults;
+**absent = the client applies its own default**.
 
 #### Request body
 
@@ -1607,7 +1611,8 @@ None (empty payload).
 
 #### Success response
 
-The stored settings object. All ten fields optional, present only when explicitly set:
+The stored settings object plus `permissions`. All ten settings fields optional,
+present only when explicitly set; `permissions` always present:
 
 | Field | Type |
 |---|---|
@@ -1621,8 +1626,9 @@ The stored settings object. All ten fields optional, present only when explicitl
 | `showNotificationsInCall` | boolean |
 | `initialChatScrollPosition` | string (`lastRead`\|`newest`) |
 | `priorityContacts` | string[] (raw accounts, read-only here — written only by `settings.priorityContacts.add`/`.remove`) |
+| `permissions` | map<permission key, boolean> (evaluated admin-managed permissions; every known key always present; read-only — `settings.set` cannot touch it) |
 
-`{ "fullWidth": true, "translateMessageInto": "en-US" }`
+`{ "fullWidth": true, "translateMessageInto": "en-US", "permissions": { "external.image.view": true } }`
 
 #### Errors
 
@@ -1641,8 +1647,9 @@ fields keep their stored value (or stay absent). At least one field required.
 
 #### Request body
 
-Any non-empty subset of the nine settings fields (same table as
-[settings.get](#settingsget)). `translateMessageInto` must be a language-tag
+Any non-empty subset of the nine writable settings fields (same table as
+[settings.get](#settingsget), minus the read-only `priorityContacts` and
+`permissions`). `translateMessageInto` must be a language-tag
 shape — hyphen-separated letter/digit subtags, leading subtag letters-only
 (e.g. `"en"`, `"en-US"`, `"zh-Hant-TW"`) — or `""` to explicitly turn
 translation off; no value whitelist.
@@ -1651,7 +1658,8 @@ translation off; no value whitelist.
 
 #### Success response
 
-The **full post-update settings** (same shape as [settings.get](#settingsget)).
+The **full post-update settings** (the same ten settings fields as
+[settings.get](#settingsget), without `permissions`).
 
 #### Errors
 

--- a/docs/superpowers/plans/2026-08-13-permission-sync-and-bulk.md
+++ b/docs/superpowers/plans/2026-08-13-permission-sync-and-bulk.md
@@ -1,0 +1,1256 @@
+# Permission Cross-Site Sync & Bulk Round Implementation Plan
+
+*As-shipped note: this plan describes deltas against a pre-rewrite branch state. The shipped history was rebuilt, so the removals it prescribes (`bodyLimit`, `permission.get`, `MaxSubjects`/`EvaluateGrant`/`SiteID`) never appear in the final commits, and some prescribed shapes (`stateGroupKey`, `GetUserSettingsAndPermissions`) were superseded by later cleanup. The code is the source of truth.*
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rework the already-implemented permission whitelist (branch state = the superseded 2026-08-11 revision) into the final design: permission state materialized on user documents and fanned out to every site in chunks, queried through `settings.get`, with an idempotent resync endpoint, no artificial request limits, and a bulk-capable admin console — then rewrite the branch history into a clean reviewable sequence.
+
+**Architecture:** admin-service writes the append-only ledger AND a per-user `PermissionState` snapshot in one Mongo transaction, then direct-publishes chunked `UserPermissionsUpdated` events to each remote site's INBOX (failures reported as `syncFailures`, healed by a read-only resync endpoint). inbox-worker applies events under a per-key `$lte` watermark guard. user-service composes the snapshot into the `settings.get` response at read time. The dedicated `permission.get` RPC and all request limits are removed.
+
+**Tech Stack:** Go 1.25, Gin, MongoDB driver v2, NATS JetStream (`nc.JetStream()`), mockgen, testify, testcontainers; React + Vitest for admin-frontend.
+
+**Specs (authoritative):** `docs/superpowers/specs/2026-08-10-user-permission-whitelist-design.md` (as amended through 2026-08-13) and `docs/superpowers/specs/2026-08-13-permission-bulk-frontend-design.md`.
+
+## Global Constraints
+
+- All commands via make targets: `make lint`, `make test [SERVICE=x]`, `make generate [SERVICE=x]`, `make test-integration [SERVICE=x]`, `make sast`. Never raw `go` commands.
+- TDD per task: write the failing test, see it fail, implement, see it pass, commit. Coverage floor 80%; target 90%+ on evaluation/guard/fanout logic.
+- Commits: conventional `type(scope): subject` (+ optional short body). **NEVER add `Co-Authored-By` or any AI-provenance trailer — this user rule overrides the repo-default trailer.** Never push; never touch main. The pre-commit hook runs lint/tests — fix failures, never bypass.
+- Watermark guard (both write sites, identical): filter `permissions.<field>.updatedAt` `$exists:false` OR `$lte <state.UpdatedAt>`; update `$set {permissions.<field>: <whole state>}`; **no upsert** (missing user doc = silent no-op); `MatchedCount < len(accounts)` is normal, never an error.
+- `<field>` always comes from `model.PermissionFieldName` — never hardcode `externalImageView` in filters outside pkg/model tests.
+- `fanoutChunkSize = 5000`. Event type const `user_permissions_updated`. Event `Timestamp` = `time.Now().UTC().UnixMilli()` at publish; `State.UpdatedAt` = the batch's `recordedAt`.
+- errcode Tier-1 only (`errcode.BadRequest(...)` etc. + `errhttp.Write` in Gin handlers; natsrouter returns automatically). Never log-and-return the same error. No new reasons — reuse `unknown_permission`, `invalid_subject_count` (now = empty list), `missing_permission_fields`, `invalid_permission_window`, `unexpected_permission_window`, `inactive_subject`, `unknown_accounts`.
+- `subjectAccounts`: non-empty, **no cap**; existence/active lookup is **site-unfiltered** (`{account: {$in: …}}`).
+- No new third-party dependencies. No `os.Getenv` — config via `caarlos0/env` struct tags.
+- Docs rule: `docs/client-api.md` and `docs/client-api/request-reply.md` change together (Task 13); `docs/client-api/events.md` untouched (INBOX events are site→site, not server→client).
+- pkg/model deletions (`EvaluateGrant`, `MaxSubjects`, `PermissionGrant.SiteID`) happen ONLY in Task 10, after every consumer is migrated.
+- Frontend copy is English, matching the existing console; client-side dedup preserves first-occurrence order.
+
+---
+
+### Task 1: pkg/model — permission state types (additive only)
+
+**Files:**
+- Modify: `pkg/model/permission.go` (append after `EvaluateGrant`)
+- Modify: `pkg/model/user.go` (User struct, next to `Settings`/`Chatlist` at ~L72-74)
+- Modify: `pkg/model/permission_test.go` (append)
+- Modify: `pkg/model/model_test.go` (round-trips)
+
+**Interfaces:**
+- Consumes: existing `PermissionKey`, `PermissionExternalImageView`, `KnownPermission`.
+- Produces (used by Tasks 3-9): `PermissionState` (+`Evaluate(now time.Time) bool`), `UserPermissions` (+`Evaluated(now time.Time) map[PermissionKey]bool`, +`State(k PermissionKey) *PermissionState`), `PermissionFieldName(k PermissionKey) (string, bool)`, `User.Permissions *UserPermissions`.
+- Deletes nothing (deletions are Task 10).
+
+- [ ] **Step 1: Write the failing tests** — append to `pkg/model/permission_test.go`:
+
+```go
+func TestPermissionState_Evaluate(t *testing.T) {
+	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+	before := now.Add(-time.Hour)
+	after := now.Add(time.Hour)
+	cases := []struct {
+		name  string
+		state *PermissionState
+		want  bool
+	}{
+		{"nil state", nil, false},
+		{"revoked", &PermissionState{Granted: false, UpdatedAt: now}, false},
+		{"granted but nil bounds fails closed", &PermissionState{Granted: true, UpdatedAt: now}, false},
+		{"granted but nil expiresAt fails closed", &PermissionState{Granted: true, EffectiveFrom: &before, UpdatedAt: now}, false},
+		{"granted but nil effectiveFrom fails closed", &PermissionState{Granted: true, ExpiresAt: &after, UpdatedAt: now}, false},
+		{"inside window", &PermissionState{Granted: true, EffectiveFrom: &before, ExpiresAt: &after, UpdatedAt: now}, true},
+		{"now == effectiveFrom is inside (closed start)", &PermissionState{Granted: true, EffectiveFrom: &now, ExpiresAt: &after, UpdatedAt: now}, true},
+		{"now == expiresAt is outside (open end)", &PermissionState{Granted: true, EffectiveFrom: &before, ExpiresAt: &now, UpdatedAt: now}, false},
+		{"not yet effective", &PermissionState{Granted: true, EffectiveFrom: &after, ExpiresAt: &after, UpdatedAt: now}, false},
+		{"expired", &PermissionState{Granted: true, EffectiveFrom: &before, ExpiresAt: &before, UpdatedAt: now}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.state.Evaluate(now))
+		})
+	}
+}
+
+func TestUserPermissions_Evaluated(t *testing.T) {
+	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+	before, after := now.Add(-time.Hour), now.Add(time.Hour)
+
+	t.Run("nil receiver yields every known key false", func(t *testing.T) {
+		var p *UserPermissions
+		assert.Equal(t, map[PermissionKey]bool{PermissionExternalImageView: false}, p.Evaluated(now))
+	})
+	t.Run("active grant evaluates true", func(t *testing.T) {
+		p := &UserPermissions{ExternalImageView: &PermissionState{Granted: true, EffectiveFrom: &before, ExpiresAt: &after, UpdatedAt: now}}
+		assert.True(t, p.Evaluated(now)[PermissionExternalImageView])
+	})
+	t.Run("expired grant evaluates false", func(t *testing.T) {
+		p := &UserPermissions{ExternalImageView: &PermissionState{Granted: true, EffectiveFrom: &before, ExpiresAt: &before, UpdatedAt: now}}
+		assert.False(t, p.Evaluated(now)[PermissionExternalImageView])
+	})
+}
+
+func TestUserPermissions_State(t *testing.T) {
+	st := &PermissionState{Granted: true}
+	p := &UserPermissions{ExternalImageView: st}
+	assert.Same(t, st, p.State(PermissionExternalImageView))
+	assert.Nil(t, p.State(PermissionKey("nope")))
+	var nilP *UserPermissions
+	assert.Nil(t, nilP.State(PermissionExternalImageView))
+}
+
+func TestPermissionFieldName(t *testing.T) {
+	f, ok := PermissionFieldName(PermissionExternalImageView)
+	assert.True(t, ok)
+	assert.Equal(t, "externalImageView", f)
+	_, ok = PermissionFieldName(PermissionKey("nope"))
+	assert.False(t, ok)
+}
+```
+
+Also extend `pkg/model/model_test.go`: add `PermissionState` and `UserPermissions` cases to the generic `roundTrip` table (follow the existing entries' shape; use a fully-populated `PermissionState` with both bounds and `UpdatedAt` set), and set `Permissions: &UserPermissions{...}` on the existing `User` round-trip fixture so the new field is covered.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `make test SERVICE=pkg/model`
+Expected: FAIL — `undefined: PermissionState`, `undefined: PermissionFieldName`.
+
+- [ ] **Step 3: Implement** — append to `pkg/model/permission.go`:
+
+```go
+// PermissionState is the latest admin decision for one permission key, materialized on
+// the user document and replicated to every site. UpdatedAt is the write's RecordedAt
+// and doubles as the per-key last-write-wins watermark.
+type PermissionState struct {
+	Granted       bool       `json:"granted"                 bson:"granted"`
+	EffectiveFrom *time.Time `json:"effectiveFrom,omitempty" bson:"effectiveFrom,omitempty"`
+	ExpiresAt     *time.Time `json:"expiresAt,omitempty"     bson:"expiresAt,omitempty"`
+	UpdatedAt     time.Time  `json:"updatedAt"               bson:"updatedAt"`
+}
+
+// Evaluate reports whether the permission is effective at now. A nil state, a revoked
+// state, or a grant missing either bound (malformed data) is false — deny, never panic.
+// now == EffectiveFrom is inside the window; now == ExpiresAt is outside (half-open).
+func (s *PermissionState) Evaluate(now time.Time) bool {
+	if s == nil || !s.Granted {
+		return false
+	}
+	if s.EffectiveFrom == nil || s.ExpiresAt == nil {
+		return false
+	}
+	return !now.Before(*s.EffectiveFrom) && now.Before(*s.ExpiresAt)
+}
+
+// UserPermissions is the admin-managed permission snapshot on the user document — one
+// named field per known PermissionKey. Deliberately a struct, not a map: the key
+// "external.image.view" contains dots, and MongoDB dot-path updates cannot address map
+// keys containing dots.
+type UserPermissions struct {
+	ExternalImageView *PermissionState `json:"externalImageView,omitempty" bson:"externalImageView,omitempty"`
+}
+
+// Evaluated returns the evaluated boolean for every known permission key. Nil-receiver
+// safe: no snapshot means every key is false. settings.get and the admin GET's
+// currentlyGranted both call this, so the entry points cannot disagree.
+func (p *UserPermissions) Evaluated(now time.Time) map[PermissionKey]bool {
+	out := map[PermissionKey]bool{PermissionExternalImageView: false}
+	if p == nil {
+		return out
+	}
+	out[PermissionExternalImageView] = p.ExternalImageView.Evaluate(now)
+	return out
+}
+
+// State returns the stored state for the given key, nil when absent or unknown.
+func (p *UserPermissions) State(k PermissionKey) *PermissionState {
+	if p == nil {
+		return nil
+	}
+	if k == PermissionExternalImageView {
+		return p.ExternalImageView
+	}
+	return nil
+}
+
+// PermissionFieldName maps a PermissionKey to its bson field name inside the
+// `permissions` sub-document ("external.image.view" → "externalImageView"); false for
+// unknown keys. The two guarded-update sites (admin-service store, inbox-worker store)
+// build their `permissions.<field>` dot-paths from this.
+func PermissionFieldName(k PermissionKey) (string, bool) {
+	if k == PermissionExternalImageView {
+		return "externalImageView", true
+	}
+	return "", false
+}
+```
+
+And in `pkg/model/user.go`, directly after the `Settings` field (~L72):
+
+```go
+	// Permissions is the admin-managed permission snapshot — a sibling of Settings so
+	// the settings whole-object replace can never touch it; nil = nothing ever recorded.
+	Permissions *UserPermissions `json:"permissions,omitempty" bson:"permissions,omitempty"`
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test SERVICE=pkg/model`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/model/permission.go pkg/model/user.go pkg/model/permission_test.go pkg/model/model_test.go
+git commit -m "feat(model): materialized permission state on the user document"
+```
+
+---
+
+### Task 2: pkg/model — UserPermissionsUpdated federation event
+
+**Files:**
+- Modify: `pkg/model/event.go` (const block ~L151-168; struct after `UserSettingsUpdated` ~L176)
+- Modify: `pkg/model/model_test.go`
+
+**Interfaces:**
+- Produces: `InboxUserPermissionsUpdated InboxEventType = "user_permissions_updated"`; `UserPermissionsUpdated{Permission PermissionKey; Accounts []string; State PermissionState; Timestamp int64}`.
+
+- [ ] **Step 1: Write the failing test** — add a `UserPermissionsUpdated` entry to `model_test.go`'s `roundTrip` table (populated `Accounts` of 2, full `State`, non-zero `Timestamp`).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `make test SERVICE=pkg/model` — Expected: FAIL `undefined: UserPermissionsUpdated`.
+
+- [ ] **Step 3: Implement** — in `pkg/model/event.go`, add to the `InboxEventType` const block:
+
+```go
+	InboxUserPermissionsUpdated InboxEventType = "user_permissions_updated"
+```
+
+and after `UserSettingsUpdated`:
+
+```go
+// UserPermissionsUpdated is the cross-site inbox event admin-service publishes after a
+// permission grant/revoke batch. One event carries one chunk of the batch: every account
+// in Accounts receives the same State. Receivers apply it under the per-key watermark
+// guard (State.UpdatedAt), so duplicated or reordered delivery is safe.
+type UserPermissionsUpdated struct {
+	Permission PermissionKey   `json:"permission" bson:"permission"`
+	Accounts   []string        `json:"accounts"   bson:"accounts"` // ≤ fanoutChunkSize per event
+	State      PermissionState `json:"state"      bson:"state"`
+	Timestamp  int64           `json:"timestamp"  bson:"timestamp"`
+}
+```
+
+- [ ] **Step 4: Run to verify pass** — `make test SERVICE=pkg/model` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/model/event.go pkg/model/model_test.go
+git commit -m "feat(model): user_permissions_updated inbox event"
+```
+
+---
+
+### Task 3: admin-service — write path: RecordPermissionChange + company-wide subjects
+
+**Files:**
+- Modify: `admin-service/store.go` (AdminStore interface)
+- Modify: `admin-service/store_mongo.go`
+- Modify: `admin-service/permissions.go` (`createPermissions`)
+- Modify: `admin-service/permissions_test.go`, `admin-service/integration_test.go`
+- Regenerate: `admin-service/mock_store_test.go` (`make generate SERVICE=admin-service`)
+
+**Interfaces:**
+- Consumes: Task 1 (`PermissionState`, `PermissionFieldName`), existing `withTransaction`, `parseWindow`, `dedupPreserveOrder`.
+- Produces (interface, replaces `InsertPermissionGrants`):
+  - `RecordPermissionChange(ctx context.Context, grants []*model.PermissionGrant, state model.PermissionState) error`
+  - `FindAccountStates(ctx context.Context, accounts []string) (map[string]bool, error)` — **siteID parameter removed**.
+- The validation cap check is removed (non-empty only). `model.MaxSubjects` itself still exists until Task 10 — after this task nothing references it in admin-service.
+
+- [ ] **Step 1: Write/adjust the failing tests** in `permissions_test.go`:
+  - Replace mock expectations of `InsertPermissionGrants(...)` with `RecordPermissionChange(gomock.Any(), gomock.Any(), gomock.Any())` capturing both args; assert on a **grant** request: `state.Granted == true`, `state.EffectiveFrom/ExpiresAt` equal the instants `parseWindow` produces for the request dates, `state.UpdatedAt` equals the grants' shared `RecordedAt`; on a **revoke**: `Granted == false`, both bounds nil.
+  - Replace `FindAccountStates(gomock.Any(), siteID, accounts)` expectations with the two-arg form.
+  - Delete the "subject count over cap" subtest; keep/adjust the empty-list subtest (still `invalid_subject_count`).
+  - Add a large-batch acceptance subtest: 10,001 unique accounts pass validation (mock `FindAccountStates` returns all-active; assert `RecordPermissionChange` receives 10,001 grants).
+- In `integration_test.go` (existing admin-service integration harness, `//go:build integration`):
+  - `TestRecordPermissionChange_TransactionAppliesLedgerAndState`: seed two user docs → call with 2 grants + granted state → both ledger rows exist AND both user docs carry `permissions.externalImageView` equal to the state.
+  - `TestRecordPermissionChange_GuardKeepsNewerState`: pre-set a user's `permissions.externalImageView.updatedAt` to `state.UpdatedAt + 1s` → call → ledger row inserted, user doc **unchanged**; with an equal timestamp → state **is** applied ($lte).
+  - `TestRecordPermissionChange_MissingUserIsNoop`: grant for an account with no user doc → ledger row inserted, no user doc created.
+
+- [ ] **Step 2: Run to verify failure** — `make generate SERVICE=admin-service` will fail until the interface changes; expected compile failures referencing `RecordPermissionChange`.
+
+- [ ] **Step 3: Implement.**
+  - `store.go`: replace the `InsertPermissionGrants` method (keep its doc comment style) and change `FindAccountStates`:
+
+```go
+	// RecordPermissionChange appends the batch to the ledger and applies the derived
+	// state to the subjects' user documents under the per-key watermark guard — one
+	// transaction, all-or-nothing. Subject accounts are derived from the grants.
+	RecordPermissionChange(ctx context.Context, grants []*model.PermissionGrant, state model.PermissionState) error
+	// FindAccountStates reports account -> IsActive company-wide (the local users
+	// collection covers every site's users; subjects may be homed anywhere).
+	FindAccountStates(ctx context.Context, accounts []string) (map[string]bool, error)
+```
+
+  - `store_mongo.go`: replace `InsertPermissionGrants` with:
+
+```go
+func (s *storeMongo) RecordPermissionChange(ctx context.Context, grants []*model.PermissionGrant, state model.PermissionState) error {
+	if len(grants) == 0 {
+		return nil
+	}
+	field, ok := model.PermissionFieldName(grants[0].Permission)
+	if !ok {
+		return fmt.Errorf("record permission change: unknown permission %q", grants[0].Permission)
+	}
+	docs := make([]any, len(grants))
+	accounts := make([]string, len(grants))
+	for i, g := range grants {
+		docs[i] = g
+		accounts[i] = g.SubjectAccount
+	}
+	path := "permissions." + field
+	filter := bson.M{
+		"account": bson.M{"$in": accounts},
+		"$or": bson.A{
+			bson.M{path + ".updatedAt": bson.M{"$exists": false}},
+			bson.M{path + ".updatedAt": bson.M{"$lte": state.UpdatedAt}},
+		},
+	}
+	return s.withTransaction(ctx, func(ctx context.Context) error {
+		if _, err := s.permGrants.InsertMany(ctx, docs); err != nil {
+			return fmt.Errorf("insert permission grants: %w", err)
+		}
+		// MatchedCount may be < len(accounts): a newer stored state (guard) or a user
+		// doc missing locally is a no-op, not an error — same rule as the inbox apply.
+		if _, err := s.users.UpdateMany(ctx, filter, bson.M{"$set": bson.M{path: state}}); err != nil {
+			return fmt.Errorf("apply user permissions: %w", err)
+		}
+		return nil
+	})
+}
+```
+
+  - `FindAccountStates`: drop the `siteID` parameter and remove `"siteId"` from its filter (now `bson.M{"account": bson.M{"$in": accounts}}`); projection unchanged.
+  - `permissions.go` `createPermissions`:
+    - Validation: replace the count check with non-empty only (`invalid_subject_count` when empty); delete the `> model.MaxSubjects` branch.
+    - Call `h.store.FindAccountStates(ctx, lookupAccounts)` (no site arg).
+    - After building `grants`, derive the state and swap the store call:
+
+```go
+	state := model.PermissionState{Granted: *req.Granted, UpdatedAt: now}
+	if *req.Granted {
+		state.EffectiveFrom = &from
+		state.ExpiresAt = &until
+	}
+	if err := h.store.RecordPermissionChange(ctx, grants, state); err != nil {
+		errhttp.Write(ctx, c, fmt.Errorf("record permission change: %w", err))
+		return
+	}
+```
+
+    (keep populating `grant.SiteID` for now — removed with the field in Task 10.)
+  - Run `make generate SERVICE=admin-service`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `make test SERVICE=admin-service`, then `make test-integration SERVICE=admin-service`.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add admin-service/
+git commit -m "feat(admin-service): materialize permission state in the write transaction"
+```
+
+---
+
+### Task 4: admin-service — read path: currentlyGranted from state; ledger browse without site
+
+**Files:**
+- Modify: `admin-service/store.go`, `admin-service/store_mongo.go` (also `EnsureIndexes`)
+- Modify: `admin-service/permissions.go` (`listPermissions`)
+- Modify: `admin-service/permissions_test.go`, `admin-service/integration_test.go`
+- Regenerate mocks.
+
+**Interfaces:**
+- Produces: `GetUserPermissions(ctx context.Context, account string) (*model.UserPermissions, error)` (nil, nil when no doc).
+- Changes: `ListPermissionGrants(ctx context.Context, subjectAccount string, permission model.PermissionKey, page, limit int) ([]model.PermissionGrant, int64, error)` — **siteID parameter removed**.
+- Deletes: `GetLatestPermissionGrant` (interface + impl + mocks + tests).
+- Ledger indexes become `{permission:1, subjectAccount:1, recordedAt:-1, _id:-1}` and `{recordedAt:-1, _id:-1}`.
+
+- [ ] **Step 1: Failing tests.** In `permissions_test.go`: replace `GetLatestPermissionGrant` expectations with `GetUserPermissions(gomock.Any(), "alice")` returning (a) a currently-valid granted state → `currentlyGranted: true`; (b) `nil, nil` → `false`; (c) an expired state → `false`. Assert `currentlyGranted` still appears only when both filters are set. Adjust `ListPermissionGrants` mock signatures.
+
+- [ ] **Step 2: Verify failure** — `make test SERVICE=admin-service` → compile errors.
+
+- [ ] **Step 3: Implement.**
+  - `store_mongo.go`:
+
+```go
+// GetUserPermissions returns the account's materialized permission snapshot; (nil, nil)
+// when the user or snapshot does not exist. Site-unfiltered: subjects may be homed at
+// any site.
+func (s *storeMongo) GetUserPermissions(ctx context.Context, account string) (*model.UserPermissions, error) {
+	var doc struct {
+		Permissions *model.UserPermissions `bson:"permissions"`
+	}
+	err := s.users.FindOne(ctx, bson.M{"account": account},
+		options.FindOne().SetProjection(bson.M{"permissions": 1})).Decode(&doc)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find user permissions: %w", err)
+	}
+	return doc.Permissions, nil
+}
+```
+
+    (match the surrounding file's option-builder style exactly — mirror how `FindAccountStates` builds its projection.)
+  - `ListPermissionGrants`: remove the `siteID` param and the `"siteId"` filter entry.
+  - `EnsureIndexes`: change the two permission index key docs to `{permission:1, subjectAccount:1, recordedAt:-1, _id:-1}` and `{recordedAt:-1, _id:-1}`.
+  - Delete `GetLatestPermissionGrant` from interface + impl.
+  - `permissions.go` `listPermissions`: replace the currentlyGranted block:
+
+```go
+	if permission != "" && subjectAccount != "" {
+		perms, err := h.store.GetUserPermissions(ctx, subjectAccount)
+		if err != nil {
+			errhttp.Write(ctx, c, fmt.Errorf("get user permissions: %w", err))
+			return
+		}
+		granted := perms.Evaluated(time.Now().UTC())[model.PermissionKey(permission)]
+		resp.CurrentlyGranted = &granted
+	}
+```
+
+  - `make generate SERVICE=admin-service`.
+
+- [ ] **Step 4: Verify pass** — `make test SERVICE=admin-service` and `make test-integration SERVICE=admin-service` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add admin-service/
+git commit -m "feat(admin-service): currentlyGranted reads the materialized state"
+```
+
+---
+
+### Task 5: admin-service — chunked fanout, syncFailures, body-limit removal
+
+**Files:**
+- Modify: `admin-service/config.go` (Config struct)
+- Modify: `admin-service/main.go` (JetStream + handler wiring; drop `bodyLimit` use at L73)
+- Modify: `admin-service/handler.go` (Handler struct ~L24-35 + `newHandler` signature)
+- Modify: `admin-service/permissions.go` (fanout helper + response field)
+- Modify: `admin-service/middleware.go`, `admin-service/middleware_test.go` (delete `maxRequestBodyBytes` + `bodyLimit` + their tests)
+- Modify: `admin-service/permissions_test.go`; touch other `newHandler` call sites in tests (grep `newHandler(`).
+
+**Interfaces:**
+- Consumes: `model.UserPermissionsUpdated`, `model.InboxEvent`, `subject.InboxExternal(dest, eventType)`.
+- Produces: `Handler.publishInbox func(ctx context.Context, subj string, data []byte) error` (nil in tests that don't fan out → fanout no-ops); `Config.AllSiteIDs []string`; `createPermissionsResponse.SyncFailures []string \`json:"syncFailures,omitempty"\``; unexported `fanoutChunkSize = 5000`; `(h *Handler) publishPermissionFanout(ctx, permission, accounts, state) []string` — reused by Task 6.
+
+- [ ] **Step 1: Failing tests** in `permissions_test.go` (inject a capture func as `publishInbox`; configure `cfg.AllSiteIDs = []string{"site-a", "site-b", "site-c"}` with `cfg.SiteID = "site-a"`):
+  - happy path, 3 subjects: exactly 2 publishes (site-b, site-c), subjects `chat.inbox.site-b.external.user_permissions_updated` etc.; unmarshal `InboxEvent` → `Type`, `SiteID: "site-a"`, `DestSiteID`, payload decodes to `UserPermissionsUpdated` with all 3 accounts + the derived state; `syncFailures` absent from the JSON response.
+  - chunking: 5,001 accounts → 2 events per dest (first 5,000 + last 1), union of accounts complete, same `State`/`Timestamp` on both.
+  - failure aggregation: capture func errors for dest `site-b` only → response `syncFailures == ["site-b"]`, site-c still receives all its chunks, status still 201.
+  - blank/self skipped: `AllSiteIDs` containing `""` and `"site-a"` produce no publishes.
+  - store failure → zero publishes.
+- Body-limit: delete `middleware_test.go`'s bodyLimit tests.
+
+- [ ] **Step 2: Verify failure** — `make test SERVICE=admin-service` → compile/assert failures.
+
+- [ ] **Step 3: Implement.**
+  - `config.go`:
+
+```go
+	// AllSiteIDs lists every site in the federation (including this one); empty means
+	// no cross-site fanout — correct for single-site dev.
+	AllSiteIDs []string `env:"ALL_SITE_IDS" envSeparator:"," envDefault:""`
+```
+
+  - `handler.go`: add field + parameter:
+
+```go
+	publishInbox func(ctx context.Context, subj string, data []byte) error
+```
+
+    `newHandler(store AdminStore, sessions session.Store, cfg Config, rpc roomRequester, publishInbox func(ctx context.Context, subj string, data []byte) error) *Handler` — assign it; update every call site (`main.go` + tests; tests that don't exercise fanout pass `nil`).
+  - `main.go`: after the NATS connect (L59-62):
+
+```go
+	js, err := nc.JetStream()
+	if err != nil {
+		return fmt.Errorf("jetstream: %w", err)
+	}
+	publishInbox := func(ctx context.Context, subj string, data []byte) error {
+		_, err := js.Publish(ctx, subj, data)
+		return err
+	}
+	h := newHandler(st, sessStore, cfg, nc, publishInbox)
+```
+
+    and delete the `r.Use(bodyLimit(maxRequestBodyBytes))` line.
+  - `middleware.go`: delete `maxRequestBodyBytes` and `bodyLimit`.
+  - `permissions.go`: add the helper + wire it after `RecordPermissionChange` succeeds and add `SyncFailures` to the response struct:
+
+```go
+// fanoutChunkSize bounds one UserPermissionsUpdated event's Accounts so a worst-case
+// event stays ~320KB — 3× margin under NATS's default 1MB max_payload.
+const fanoutChunkSize = 5000
+
+// publishPermissionFanout publishes the batch to every remote site's INBOX, one event
+// per site per chunk of accounts. Failures are logged and aggregated per destination and
+// the loop always continues — one dead peer must not block the others. Returns the
+// destinations whose publish was not acknowledged (nil when all landed).
+func (h *Handler) publishPermissionFanout(ctx context.Context, permission model.PermissionKey, accounts []string, state model.PermissionState) []string {
+	if h.publishInbox == nil || len(accounts) == 0 {
+		return nil
+	}
+	now := time.Now().UTC().UnixMilli()
+	// Marshal each chunk's payload once; only the envelope differs per destination.
+	var chunks [][]byte
+	for start := 0; start < len(accounts); start += fanoutChunkSize {
+		end := min(start+fanoutChunkSize, len(accounts))
+		payload, err := json.Marshal(model.UserPermissionsUpdated{
+			Permission: permission,
+			Accounts:   accounts[start:end],
+			State:      state,
+			Timestamp:  now,
+		})
+		if err != nil {
+			// Cannot serialize the event at all: every destination is out of sync.
+			slog.ErrorContext(ctx, "marshal user permissions event", "error", err)
+			return remoteSites(h.cfg.AllSiteIDs, h.cfg.SiteID)
+		}
+		chunks = append(chunks, payload)
+	}
+	var failures []string
+	for _, dest := range h.cfg.AllSiteIDs {
+		if dest == "" || dest == h.cfg.SiteID {
+			continue
+		}
+		failed := false
+		for _, payload := range chunks {
+			evt := model.InboxEvent{
+				Type:       model.InboxUserPermissionsUpdated,
+				SiteID:     h.cfg.SiteID,
+				DestSiteID: dest,
+				Payload:    payload,
+				Timestamp:  now,
+			}
+			data, err := json.Marshal(evt)
+			if err != nil {
+				slog.ErrorContext(ctx, "marshal permissions inbox envelope", "dest", dest, "error", err)
+				failed = true
+				continue
+			}
+			if err := h.publishInbox(ctx, subject.InboxExternal(dest, model.InboxUserPermissionsUpdated), data); err != nil {
+				// Not self-healing like status/settings: surface it, don't swallow it.
+				slog.ErrorContext(ctx, "publish permissions inbox event", "dest", dest, "error", err)
+				failed = true
+			}
+		}
+		if failed {
+			failures = append(failures, dest)
+		}
+	}
+	return failures
+}
+
+// remoteSites filters allSiteIDs down to real remote destinations.
+func remoteSites(allSiteIDs []string, self string) []string {
+	var out []string
+	for _, dest := range allSiteIDs {
+		if dest != "" && dest != self {
+			out = append(out, dest)
+		}
+	}
+	return out
+}
+```
+
+    In `createPermissions`, after the store call and before the audit write:
+
+```go
+	syncFailures := h.publishPermissionFanout(ctx, key, subjects, state)
+```
+
+    and include it in the 201 response (`SyncFailures: syncFailures`).
+
+- [ ] **Step 4: Verify pass** — `make test SERVICE=admin-service` → PASS; `make lint` → clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add admin-service/
+git commit -m "feat(admin-service): chunked cross-site permission fanout with syncFailures"
+```
+
+---
+
+### Task 6: admin-service — resync endpoint
+
+**Files:**
+- Modify: `admin-service/routes.go` (add `admin.POST("/permissions/resync", h.resyncPermissions)`)
+- Modify: `admin-service/permissions.go`
+- Modify: `admin-service/store.go`, `admin-service/store_mongo.go`
+- Modify: `admin-service/permissions_test.go`
+- Regenerate mocks.
+
+**Interfaces:**
+- Consumes: `publishPermissionFanout` (Task 5), `model.UserPermissions.State` (Task 1), `dedupPreserveOrder`.
+- Produces: `GetUserPermissionsForAccounts(ctx context.Context, accounts []string) (map[string]*model.UserPermissions, error)` (missing accounts simply absent from the map).
+
+- [ ] **Step 1: Failing tests** in `permissions_test.go`:
+  - unknown key → 400 `unknown_permission`; empty accounts → 400 `invalid_subject_count`.
+  - two accounts sharing one stored state → **one** fanout group: per remote dest exactly one event whose `Accounts` contains both; `State` equals the stored state (including its stored `UpdatedAt` — NOT a fresh timestamp).
+  - two accounts with different stored states → two groups → two events per dest with the matching account/state pairing.
+  - an account absent from the store map, and one present with `Permissions == nil` → both skipped, no event mentions them.
+  - store mock: assert **no** calls to `RecordPermissionChange` / `AppendAuditMany` (mock without expectations fails on any call).
+  - a failing dest → `{"syncFailures":["site-b"]}` with 200.
+
+- [ ] **Step 2: Verify failure** — `make test SERVICE=admin-service`.
+
+- [ ] **Step 3: Implement.**
+  - `store.go` + `store_mongo.go`:
+
+```go
+// GetUserPermissionsForAccounts returns the materialized snapshots for the given
+// accounts in one read; accounts with no user doc are absent from the map.
+func (s *storeMongo) GetUserPermissionsForAccounts(ctx context.Context, accounts []string) (map[string]*model.UserPermissions, error) {
+	cur, err := s.users.Find(ctx, bson.M{"account": bson.M{"$in": accounts}},
+		options.Find().SetProjection(bson.M{"account": 1, "permissions": 1}))
+	if err != nil {
+		return nil, fmt.Errorf("find user permissions: %w", err)
+	}
+	defer cur.Close(ctx)
+	out := make(map[string]*model.UserPermissions, len(accounts))
+	for cur.Next(ctx) {
+		var doc struct {
+			Account     string                 `bson:"account"`
+			Permissions *model.UserPermissions `bson:"permissions"`
+		}
+		if err := cur.Decode(&doc); err != nil {
+			return nil, fmt.Errorf("decode user permissions: %w", err)
+		}
+		out[doc.Account] = doc.Permissions
+	}
+	if err := cur.Err(); err != nil {
+		return nil, fmt.Errorf("iterate user permissions: %w", err)
+	}
+	return out, nil
+}
+```
+
+    (mirror the file's existing cursor-iteration style.)
+  - `permissions.go`:
+
+```go
+type resyncPermissionsRequest struct {
+	Permission string   `json:"permission"`
+	Accounts   []string `json:"accounts"`
+}
+
+type resyncPermissionsResponse struct {
+	SyncFailures []string `json:"syncFailures,omitempty"`
+}
+
+// stateGroupKey identifies one distinct stored PermissionState by value. Pointers make
+// PermissionState itself non-comparable, so the key flattens the bounds to UnixMilli
+// (0 = absent) — exact-instant equality is what "same state" means here.
+type stateGroupKey struct {
+	granted             bool
+	from, until, updated int64
+}
+
+func keyOfState(s model.PermissionState) stateGroupKey {
+	k := stateGroupKey{granted: s.Granted, updated: s.UpdatedAt.UnixMilli()}
+	if s.EffectiveFrom != nil {
+		k.from = s.EffectiveFrom.UnixMilli()
+	}
+	if s.ExpiresAt != nil {
+		k.until = s.ExpiresAt.UnixMilli()
+	}
+	return k
+}
+
+// resyncPermissions re-delivers the current materialized state for the given accounts —
+// re-delivery, not re-recording: it writes nothing (no ledger, no audit, no user docs)
+// and is idempotent (delivered states keep their stored watermarks, so remote guards
+// no-op anything already applied).
+func (h *Handler) resyncPermissions(c *gin.Context) {
+	ctx := c.Request.Context()
+	var req resyncPermissionsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errhttp.Write(ctx, c, errcode.BadRequest("invalid request body", errcode.WithReason(errcode.AuthMissingFields)))
+		return
+	}
+	key := model.PermissionKey(req.Permission)
+	if !model.KnownPermission(key) {
+		errhttp.Write(ctx, c, errcode.BadRequest("unknown permission", errcode.WithReason(errcode.PermissionUnknownKey)))
+		return
+	}
+	accounts, _ := dedupPreserveOrder(req.Accounts)
+	if len(accounts) == 0 {
+		errhttp.Write(ctx, c, errcode.BadRequest("accounts must be non-empty", errcode.WithReason(errcode.PermissionInvalidSubjects)))
+		return
+	}
+	perms, err := h.store.GetUserPermissionsForAccounts(ctx, accounts)
+	if err != nil {
+		errhttp.Write(ctx, c, fmt.Errorf("load user permissions: %w", err))
+		return
+	}
+	groups := make(map[stateGroupKey][]string)
+	states := make(map[stateGroupKey]model.PermissionState)
+	for _, account := range accounts {
+		st := perms[account].State(key)
+		if st == nil {
+			continue // no doc or nothing recorded — nothing to sync
+		}
+		k := keyOfState(*st)
+		groups[k] = append(groups[k], account)
+		states[k] = *st
+	}
+	seen := make(map[string]struct{})
+	var failures []string
+	for k, groupAccounts := range groups {
+		for _, dest := range h.publishPermissionFanout(ctx, key, groupAccounts, states[k]) {
+			if _, dup := seen[dest]; !dup {
+				seen[dest] = struct{}{}
+				failures = append(failures, dest)
+			}
+		}
+	}
+	c.JSON(http.StatusOK, resyncPermissionsResponse{SyncFailures: failures})
+}
+```
+
+    (Match the existing handlers' bind-error reason — reuse whatever `createPermissions` uses for a malformed body.)
+  - `routes.go`: register the route in the `requireAdmin` group next to the other two.
+  - `make generate SERVICE=admin-service`.
+
+- [ ] **Step 4: Verify pass** — `make test SERVICE=admin-service` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add admin-service/
+git commit -m "feat(admin-service): idempotent permission resync endpoint"
+```
+
+---
+
+### Task 7: inbox-worker — apply cross-site permission events
+
+**Files:**
+- Modify: `inbox-worker/handler.go` (event switch ~L113-152; `InboxStore` interface ~L79; new handler beside `handleUserSettingsUpdated` ~L415)
+- Modify: `inbox-worker/main.go` (guarded store method beside `UpdateUserSettings` ~L203)
+- Modify: `inbox-worker/handler_test.go`; inbox-worker integration test file
+- Regenerate: inbox-worker mocks (`make generate SERVICE=inbox-worker`)
+
+**Interfaces:**
+- Consumes: `model.UserPermissionsUpdated`, `model.PermissionFieldName`, `model.InboxUserPermissionsUpdated`.
+- Produces (InboxStore): `ApplyUserPermissions(ctx context.Context, permission model.PermissionKey, accounts []string, state model.PermissionState) error`.
+
+- [ ] **Step 1: Failing tests.**
+  - `handler_test.go` (mirror the `handleUserSettingsUpdated` test shapes): valid event → store called with decoded `permission/accounts/state`; malformed payload → error returned; **unknown permission key → returns nil (Ack) and the store is NOT called**.
+  - Integration (same package, `//go:build integration`, reuse the worker's existing Mongo harness): seed user docs, then assert on `ApplyUserPermissions`:
+    - fresh apply sets `permissions.externalImageView` == state on every listed account;
+    - a stored `updatedAt` **newer** than the event's → doc unchanged;
+    - an **equal** `updatedAt` → applied ($lte);
+    - an account with no user doc → no doc created, others still applied;
+    - per-key independence: pre-write a sibling field inside `permissions` (raw `bson.M{"permissions.somethingElse": ...}` seed) → apply → sibling untouched.
+
+- [ ] **Step 2: Verify failure** — `make test SERVICE=inbox-worker` → compile errors (`ApplyUserPermissions` undefined).
+
+- [ ] **Step 3: Implement.**
+  - `handler.go` switch case:
+
+```go
+	case model.InboxUserPermissionsUpdated:
+		return h.handleUserPermissionsUpdated(ctx, &evt)
+```
+
+  - handler (place next to `handleUserSettingsUpdated`):
+
+```go
+// handleUserPermissionsUpdated applies one chunk of an admin permission batch. A missing
+// user doc is a silent no-op (store-level guard), matching the other user events.
+func (h *Handler) handleUserPermissionsUpdated(ctx context.Context, evt *model.InboxEvent) error {
+	var e model.UserPermissionsUpdated
+	if err := json.Unmarshal(evt.Payload, &e); err != nil {
+		return fmt.Errorf("unmarshal user_permissions_updated payload: %w", err)
+	}
+	if _, ok := model.PermissionFieldName(e.Permission); !ok {
+		// A future permission key reaching a not-yet-upgraded site: retrying cannot
+		// succeed and must not poison the consumer — warn and Ack.
+		slog.WarnContext(ctx, "unknown permission key in user_permissions_updated", "permission", string(e.Permission))
+		return nil
+	}
+	if err := h.store.ApplyUserPermissions(ctx, e.Permission, e.Accounts, e.State); err != nil {
+		return fmt.Errorf("apply user permissions: %w", err)
+	}
+	return nil
+}
+```
+
+  - `InboxStore` interface entry (doc-comment style matching `UpdateUserSettings`'s):
+
+```go
+	// ApplyUserPermissions applies one permission state to the accounts under the
+	// per-key watermark guard. A missing user (no doc on this site) is a silent no-op.
+	ApplyUserPermissions(ctx context.Context, permission model.PermissionKey, accounts []string, state model.PermissionState) error
+```
+
+  - `main.go` store method (beside `UpdateUserSettings`):
+
+```go
+// ApplyUserPermissions applies state to every listed account under the per-key watermark
+// guard. $lte, not $lt: two writes can share a millisecond, and the apply is an
+// idempotent whole-state replace, so a same-ms tie resolves to last-delivered. No
+// upsert — a missing user doc is a silent no-op; MatchedCount < len(accounts) is normal.
+func (s *mongoInboxStore) ApplyUserPermissions(ctx context.Context, permission model.PermissionKey, accounts []string, state model.PermissionState) error {
+	if len(accounts) == 0 {
+		return nil
+	}
+	field, ok := model.PermissionFieldName(permission)
+	if !ok {
+		return fmt.Errorf("apply user permissions: unknown permission %q", permission)
+	}
+	path := "permissions." + field
+	filter := bson.M{
+		"account": bson.M{"$in": accounts},
+		"$or": bson.A{
+			bson.M{path + ".updatedAt": bson.M{"$exists": false}},
+			bson.M{path + ".updatedAt": bson.M{"$lte": state.UpdatedAt}},
+		},
+	}
+	if _, err := s.userCol.UpdateMany(ctx, filter, bson.M{"$set": bson.M{path: state}}); err != nil {
+		return fmt.Errorf("update user permissions: %w", err)
+	}
+	return nil
+}
+```
+
+  - `make generate SERVICE=inbox-worker`.
+
+- [ ] **Step 4: Verify pass** — `make test SERVICE=inbox-worker` and `make test-integration SERVICE=inbox-worker` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add inbox-worker/
+git commit -m "feat(inbox-worker): apply cross-site user permission events"
+```
+
+---
+
+### Task 8: user-service — settings.get returns evaluated permissions
+
+**Files:**
+- Modify: `user-service/models/settings.go`
+- Modify: `user-service/service/settings.go` (`GetSettings` ~L24-38)
+- Modify: `user-service/service/service.go` (`UserRepository` interface entry ~L35)
+- Modify: `user-service/mongorepo/users.go` (`GetUserSettings` ~L106-110)
+- Modify: settings-related tests in `user-service/service/` and `user-service/mongorepo/`
+- Regenerate: `make generate SERVICE=user-service`
+
+**Interfaces:**
+- Consumes: `model.UserPermissions.Evaluated` (Task 1).
+- Produces: `models.SettingsGetResponse{model.UserSettings; Permissions map[model.PermissionKey]bool}`; repo `GetUserSettingsAndPermissions(ctx context.Context, account string) (*model.UserSettings, *model.UserPermissions, error)` (replaces `GetUserSettings`; identical error/ErrNoDocuments semantics).
+- Unchanged: `SetSettings`, `UpdateUserSettings`, both settings fanouts, the `settings.update` client event.
+
+- [ ] **Step 1: Failing tests** (service layer, follow the existing GetSettings test shapes):
+  - repo returns `(nil, nil, nil)` → response has empty settings and `permissions == {"external.image.view": false}`;
+  - granted-in-window snapshot → `true`;
+  - expired / not-yet-effective / revoked snapshots → `false`;
+  - stored settings fields pass through unchanged beside the new key.
+  - mongorepo test: seed a user doc carrying both `settings` and `permissions` → one call returns both; a user with neither → `(nil, nil, nil)`-equivalent per existing semantics.
+
+- [ ] **Step 2: Verify failure** — `make test SERVICE=user-service` → compile errors.
+
+- [ ] **Step 3: Implement.**
+  - `models/settings.go`:
+
+```go
+// SettingsGetResponse is the settings.get reply: the user's settings plus the evaluated
+// admin-managed permissions. The permissions field is read-only on this surface — it is
+// not part of UserSettings, so settings.set structurally cannot touch it.
+type SettingsGetResponse struct {
+	model.UserSettings
+	Permissions map[model.PermissionKey]bool `json:"permissions"`
+}
+```
+
+  - `mongorepo/users.go` — rename/extend (preserve the current function's error wrapping and not-found behavior exactly; only the projection and return values change):
+
+```go
+// GetUserSettingsAndPermissions returns the settings sub-document and the admin-managed
+// permission snapshot in one read; either may be nil when never written.
+func (r *UserRepo) GetUserSettingsAndPermissions(ctx context.Context, account string) (*model.UserSettings, *model.UserPermissions, error) {
+	u, err := r.users.FindOne(ctx, activeUserFilter(account),
+		mongoutil.WithProjection(bson.M{"_id": 0, "settings": 1, "permissions": 1}))
+	// keep the existing GetUserSettings error handling verbatim (incl. its
+	// ErrNoDocuments treatment), returning (nil, nil, err-or-nil) accordingly
+	if err != nil {
+		return nil, nil, err // adjust to match the removed function's exact wrapping
+	}
+	return u.Settings, u.Permissions, nil
+}
+```
+
+  - `service/service.go` `UserRepository`: replace the `GetUserSettings` method entry with the new signature.
+  - `service/settings.go`:
+
+```go
+// GetSettings returns the stored settings verbatim plus the evaluated admin-managed
+// permissions — every known key, always present; a user with no snapshot gets false.
+func (s *UserService) GetSettings(c *natsrouter.Context) (*models.SettingsGetResponse, error) {
+	account := c.Param("account")
+	settings, perms, err := s.users.GetUserSettingsAndPermissions(c, account)
+	if err != nil {
+		return nil, fmt.Errorf("get settings: %w", err)
+	}
+	if settings == nil {
+		settings = &model.UserSettings{}
+	}
+	return &models.SettingsGetResponse{
+		UserSettings: *settings,
+		Permissions:  perms.Evaluated(time.Now().UTC()),
+	}, nil
+}
+```
+
+    (preserve whatever nil/error handling the current implementation applies around the repo call — read it first and keep its semantics; only the second return value and response type are new.)
+  - `make generate SERVICE=user-service`.
+
+- [ ] **Step 4: Verify pass** — `make test SERVICE=user-service` → PASS; `make test-integration SERVICE=user-service` if the mongorepo has integration coverage for settings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add user-service/
+git commit -m "feat(user-service): settings.get returns evaluated permissions"
+```
+
+---
+
+### Task 9: user-service + pkg/subject — remove the permission.get RPC stack
+
+**Files:**
+- Delete: `user-service/service/permission.go`, `user-service/service/permission_test.go`, `user-service/models/permission.go`, `user-service/models/permission_test.go`, `user-service/mongorepo/permissions.go`, `user-service/mongorepo/permissions_test.go`
+- Modify: `user-service/service/service.go` — remove the `PermissionRepository` interface, the `permissions` field, the `service.New` parameter, the `,PermissionRepository` in the `//go:generate mockgen` directive, and the `natsrouter.Register(r, subject.UserPermissionGetPattern(...), s.GetPermission)` line (~L196)
+- Modify: `user-service/main.go` — remove `permissionRepo := mongorepo.NewPermissionRepo(db)` (~L96) and the `service.New` argument
+- Modify: every test constructing `service.New(...)` (grep `service.New(` under `user-service/`) — drop the argument
+- Modify: `pkg/subject/subject.go` — delete `UserPermissionGet` + `UserPermissionGetPattern` (~L1364-1375) and remove `"permission"` from `ParseUserSubject`'s area whitelist/doc (~L1563-1580); `pkg/subject/subject_test.go` — delete their tests
+- Regenerate: `make generate SERVICE=user-service`
+
+**Interfaces:**
+- Consumes: nothing new. Produces: nothing — pure removal. After this task `grep -rn "UserPermissionGet\|PermissionRepository\|PermissionGetRequest" --include="*.go" .` must return zero hits.
+
+- [ ] **Step 1: Delete the six files, edit the wiring, regenerate mocks** (removal task — the "failing test" is the compiler: after deleting `service/permission.go` the build fails until every reference is gone).
+- [ ] **Step 2: Run the verification greps** above — zero hits — then `make lint` (whole-repo compile) and `make test SERVICE=user-service && make test SERVICE=pkg/subject`.
+Expected: PASS.
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A user-service/ pkg/subject/
+git commit -m "refactor(user-service): drop the permission.get RPC (superseded by settings.get)"
+```
+
+---
+
+### Task 10: pkg/model cleanup — delete EvaluateGrant, MaxSubjects, PermissionGrant.SiteID
+
+**Files:**
+- Modify: `pkg/model/permission.go` — delete `EvaluateGrant`, delete `MaxSubjects` (keep `MaxReasonRunes`), delete the `SiteID` field from `PermissionGrant`
+- Modify: `pkg/model/permission_test.go` — delete the `EvaluateGrant` tests
+- Modify: `pkg/model/model_test.go` — drop `SiteID` from the `PermissionGrant` round-trip fixture
+- Modify: `admin-service/permissions.go` — remove the `SiteID: h.cfg.SiteID` assignment when building grants
+- Modify: any admin-service test asserting `SiteID` on grants or referencing `MaxSubjects`
+
+**Interfaces:** pure deletion. Gate: `grep -rn "EvaluateGrant\|MaxSubjects" --include="*.go" .` → zero hits; `grep -rn "SiteID" pkg/model/permission.go admin-service/permissions.go` → zero hits.
+
+- [ ] **Step 1: Delete, run the greps, fix stragglers.**
+- [ ] **Step 2: Full verification** — `make lint && make test` (whole repo) and `make test-integration SERVICE=admin-service`.
+Expected: PASS.
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A pkg/model/ admin-service/
+git commit -m "refactor(model): drop EvaluateGrant, MaxSubjects, and the ledger SiteID column"
+```
+
+---
+
+### Task 11: admin-frontend — api client, paste-list mode, count-visible submit
+
+**Files:**
+- Modify: `admin-frontend/src/api/admin/index.ts`
+- Modify: `admin-frontend/src/api/admin/admin.test.ts`
+- Create: `admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/parseAccounts.js`
+- Create: `admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/parseAccounts.test.js`
+- Modify: `admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/CreatePermissionsDialog.jsx` + `style.css`
+- Modify: `admin-frontend/src/components/PermissionsView/CreatePermissionsDialog/CreatePermissionsDialog.test.jsx`
+- Modify: `admin-frontend/src/api/index.ts` if it re-exports the admin client symbols (mirror how `createPermissions` is exported).
+
+**Interfaces:**
+- Produces (api client):
+
+```ts
+export interface ResyncPermissionsRequest { permission: string; accounts: string[] }
+export interface ResyncPermissionsResponse { syncFailures?: string[] }
+export async function resyncPermissions(authToken: string, body: ResyncPermissionsRequest): Promise<ResyncPermissionsResponse>
+```
+
+  plus `CreatePermissionsResponse` gains `syncFailures?: string[]`.
+- Produces (parse helper, used by Task 12's strip action):
+
+```js
+export function parsePastedAccounts(text) // -> { accounts: string[], duplicates: number }
+```
+
+- [ ] **Step 1: Failing tests.**
+  - `parseAccounts.test.js`: splits on spaces/newlines/commas/semicolons/tabs; trims; drops empties; dedups preserving first occurrence and counts duplicates; empty string → `{accounts: [], duplicates: 0}`.
+  - `admin.test.ts`: `resyncPermissions` POSTs `/v1/admin/permissions/resync` with the body and Bearer header (follow the existing `createPermissions` test).
+  - Dialog tests: toggling to paste mode shows the textarea; typing `"alice bob,alice\ncarol"` shows "3 accounts (1 duplicate removed)"; submit payload uses the parsed list; toggle badges show `Pick (0) / Paste (3)`; empty paste disables submit; the submit button label carries the count ("Grant permission to 3 accounts"); the old max-200 error UI is gone (a 250-account paste is accepted client-side).
+
+- [ ] **Step 2: Verify failure** — run the frontend test suite the way the existing tests document (admin-frontend's package scripts; the repo's Vitest setup).
+
+- [ ] **Step 3: Implement.**
+  - `parseAccounts.js`:
+
+```js
+// Splits a pasted account list on whitespace/commas/semicolons, deduplicating while
+// preserving first-occurrence order. Accounts are kept verbatim (no case folding),
+// matching backend semantics.
+export function parsePastedAccounts(text) {
+  const seen = new Set()
+  const accounts = []
+  let duplicates = 0
+  for (const token of text.split(/[\s,;]+/)) {
+    if (!token) continue
+    if (seen.has(token)) {
+      duplicates += 1
+      continue
+    }
+    seen.add(token)
+    accounts.push(token)
+  }
+  return { accounts, duplicates }
+}
+```
+
+  - Dialog changes (`CreatePermissionsDialog.jsx`):
+    - Delete `MAX_SUBJECTS` (L9) and the over-limit span/error block (L147-156).
+    - Add state: `const [inputMode, setInputMode] = useState('pick')`, `const [pasteText, setPasteText] = useState('')`.
+    - Derive: `const parsed = parsePastedAccounts(pasteText)`; `const effectiveAccounts = inputMode === 'paste' ? parsed.accounts : subjectAccounts`; `clientInvalid` uses `effectiveAccounts.length === 0` (no cap term); `buildPayload` uses `effectiveAccounts`.
+    - Mode toggle (above the subject input; radio-style buttons like the grant/revoke group) labeled `Pick (N)` / `Paste list (M)` with each mode's own count; the active mode's input renders below — pick keeps the existing `AccountPicker`, paste renders:
+
+```jsx
+<label htmlFor="permissions-paste">Subject accounts (paste list)</label>
+<textarea
+  id="permissions-paste"
+  className="permissions-paste-textarea"
+  value={pasteText}
+  onChange={(e) => setPasteText(e.target.value)}
+  disabled={submitting}
+  placeholder="Accounts separated by spaces, commas, or newlines"
+/>
+<span className="permissions-subjects-count">
+  {parsed.accounts.length} account{parsed.accounts.length === 1 ? '' : 's'}
+  {parsed.duplicates > 0 ? ` (${parsed.duplicates} duplicate${parsed.duplicates === 1 ? '' : 's'} removed)` : ''}
+</span>
+```
+
+    - Submit button label gains the count: `` `Grant permission to ${effectiveAccounts.length} account${…}` `` / `` `Revoke permission from …` `` (keep the `Submitting…` in-flight label).
+    - `style.css`: minimal rules for the toggle row and textarea (follow the existing class naming).
+
+- [ ] **Step 4: Verify pass** — frontend test suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add admin-frontend/
+git commit -m "feat(admin-frontend): paste-list bulk input with count-visible submit"
+```
+
+---
+
+### Task 12: admin-frontend — syncFailures banner, resync button, offender strip, long-list collapse
+
+**Files:**
+- Modify: `CreatePermissionsDialog.jsx` + `style.css` + `CreatePermissionsDialog.test.jsx`
+
+**Interfaces:**
+- Consumes: `resyncPermissions` + `parsePastedAccounts` (Task 11); `formErrorMetadata.accounts` is a `", "`-joined string (see `errcode.WithMetadata("accounts", strings.Join(...))` in admin-service).
+
+- [ ] **Step 1: Failing tests.**
+  - Submit resolving with `syncFailures: ['site-b']` → result view shows a warning banner naming site-b and a "Resend sync" button; clicking it calls `resyncPermissions(token, {permission, accounts: <submitted accounts>})`; while pending the button is disabled; resolving with `{}` → banner switches to "Sync complete"; resolving again with failures keeps the button.
+  - No `syncFailures` in the response → no banner, no button.
+  - Error path: a 404 `unknown_accounts` with `metadata.accounts = "ghost1, ghost2"` → a "Remove these accounts" button appears; clicking it in paste mode rewrites the textarea without the two accounts; in pick mode it filters `subjectAccounts`.
+  - `duplicatesIgnored` of 30 entries renders a count with a collapsed expandable list (first render shows the count, not all 30 inline).
+
+- [ ] **Step 2: Verify failure** — frontend test suite.
+
+- [ ] **Step 3: Implement.**
+  - Keep the submitted request in state for resync: add `const [lastSubmitted, setLastSubmitted] = useState(null)`; in `handleSubmit`, on success `setLastSubmitted({ permission: PERMISSION_KEY, accounts: effectiveAccounts })` alongside `setResult(response)`.
+  - Result view banner (inside the `result ?` branch, after the success summary):
+
+```jsx
+{result.syncFailures?.length > 0 ? (
+  <div className="permissions-sync-warning">
+    <p>
+      Recorded and effective at this site, but sync failed for:{' '}
+      {result.syncFailures.join(', ')}. Resend delivers the recorded state again —
+      safe to repeat.
+    </p>
+    <button type="button" onClick={handleResync} disabled={resyncing}>
+      {resyncing ? 'Resending…' : 'Resend sync'}
+    </button>
+  </div>
+) : resyncDone ? (
+  <p className="permissions-sync-ok">Sync complete.</p>
+) : null}
+```
+
+    with:
+
+```jsx
+const [resyncing, setResyncing] = useState(false)
+const [resyncDone, setResyncDone] = useState(false)
+
+const handleResync = async () => {
+  if (!lastSubmitted || resyncing) return
+  setResyncing(true)
+  try {
+    const r = await resyncPermissions(authToken, lastSubmitted)
+    setResult({ ...result, syncFailures: r.syncFailures ?? [] })
+    setResyncDone(!(r.syncFailures?.length > 0))
+  } catch (err) {
+    const message = handleAdminError(err)
+    if (message !== null) setFormError(message)
+  } finally {
+    setResyncing(false)
+  }
+}
+```
+
+  - Offender strip (in the form-error block, when `formErrorMetadata?.accounts` is a string):
+
+```jsx
+const stripOffenders = () => {
+  const offenders = new Set(formErrorMetadata.accounts.split(/[\s,]+/).filter(Boolean))
+  if (inputMode === 'paste') {
+    setPasteText(parsePastedAccounts(pasteText).accounts.filter((a) => !offenders.has(a)).join('\n'))
+  } else {
+    setSubjectAccounts(subjectAccounts.filter((a) => !offenders.has(a)))
+  }
+  setFormError(null)
+  setFormErrorMetadata(null)
+}
+```
+
+    rendered as a button under the metadata list: `Remove these accounts`.
+  - `duplicatesIgnored` collapse: when `result.duplicatesIgnored.length > 20`, render `<details><summary>{n} duplicates ignored</summary>…joined list…</details>` instead of the inline paragraph; ≤20 keeps today's inline text.
+
+- [ ] **Step 4: Verify pass** — frontend suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add admin-frontend/
+git commit -m "feat(admin-frontend): syncFailures banner with resync and offender strip"
+```
+
+---
+
+### Task 13: docs — client-api.md + request-reply.md
+
+**Files:**
+- Modify: `docs/client-api.md`, `docs/client-api/request-reply.md` (both in this task; `docs/client-api/events.md` untouched)
+
+Apply, in both files where the section exists (client-api.md is canonical/fuller; request-reply.md is the terse mirror):
+
+- [ ] **Step 1: settings.get** — response field table gains `| permissions | map<permission key, boolean> | Evaluated admin-managed permissions; every known key always present; admin-written, read-only via settings — settings.set cannot touch it. |`; update the JSON example to include `"permissions": { "external.image.view": true }`; adjust the "All ten fields" sentence.
+- [ ] **Step 2: permission.get** — delete the whole subsection, its TOC entry, and its row in the user-service RPC subject table (both files).
+- [ ] **Step 3: §9.13 (create/revoke)** — `subjectAccounts` constraint → "non-empty (no fixed cap)"; `invalid_subject_count` error row → the empty-list case; delete the oversized-body 400 row; response field table + example gain `syncFailures` (`string[]`, omitempty — destinations whose INBOX publish was not acknowledged; remediation: §9.15 resync); add one sentence on chunked fanout being transparent to callers.
+- [ ] **Step 4: §9.14 (list)** — `currentlyGranted` prose: computed from the materialized user-document state (same evaluation path as `settings.get`).
+- [ ] **Step 5: new §9.15 Resync permission fanout** — `POST /v1/admin/permissions/resync`; request table (`permission` string required known key; `accounts` string[] required non-empty); semantics paragraph (re-delivery only — reads the current materialized state, writes no ledger/audit/user rows, idempotent, unknown/never-granted accounts skipped); success 200 `{ "syncFailures": ["site-b"] }` + empty-object example; error table (`unknown_permission` 400, `invalid_subject_count` 400, 401/403/500); curl example. Add its row to the admin HTTP table and TOC.
+- [ ] **Step 6: §6 reason catalog** — remove `permission.get` from the emitters of `unknown_permission`; add the resync endpoint to `unknown_permission` and `invalid_subject_count`.
+- [ ] **Step 7: Verify** — `grep -n "permission.get" docs/client-api.md docs/client-api/request-reply.md` → zero hits; render-skim the two new/edited tables for column alignment.
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/client-api.md docs/client-api/request-reply.md
+git commit -m "docs(client-api): permissions in settings.get, resync endpoint, no request caps"
+```
+
+---
+
+### Task 14: Finalize — gates, superseded-plan removal, history restructure
+
+**Files:** none new; deletes `docs/superpowers/plans/2026-08-11-user-permission-whitelist.md`; rewrites branch history.
+
+- [ ] **Step 1: Full gates.**
+
+```bash
+make generate && make fmt && make lint && make test
+make test-integration SERVICE=admin-service
+make test-integration SERVICE=inbox-worker
+make test-integration SERVICE=user-service
+make sast
+```
+
+All must pass (fix anything that fails before proceeding).
+
+- [ ] **Step 2: Drop superseded artifacts.** The 2026-08-11 plan documents the replaced implementation — per the reviewer-clarity requirement it must not reach the final history. Also clear any session review notes:
+
+```bash
+git rm docs/superpowers/plans/2026-08-11-user-permission-whitelist.md
+git rm -r --ignore-unmatch docs/reviews
+git commit -m "docs: drop the superseded implementation plan"
+```
+
+- [ ] **Step 3: History restructure.** Goal: the reviewer sees ONLY the final version's story — no superseded implementation, no fix-up churn. Method (no interactive rebase in this environment): safety branch → soft-reset to merge-base → re-commit in logical path groups.
+
+```bash
+git branch backup/permission-final
+git merge-base origin/main HEAD   # note it; call it $BASE below
+git reset --soft $BASE
+git restore --staged .
+git status --short | wc -l        # sanity: all branch changes now unstaged
+```
+
+Then create exactly this sequence (each: `git add <paths>` → `git commit`). Messages are subjects below plus a 1-3 sentence body you write from the final code's perspective (present tense, no history references, **no AI trailers**):
+
+| # | Paths | Subject |
+|---|---|---|
+| 1 | `history-service/internal/cassrepo/utils.go` | `chore(history-service): replace deprecated reflect.Ptr with reflect.Pointer` |
+| 2 | `docker-local/compose.deps.yaml tools/seed-sample-data/ tools/jaeger/README.md` | `fix(docker-local): run mongo as a single-node replica set` |
+| 3 | `docs/superpowers/` | `docs(spec): user permission whitelist — design and implementation plan` |
+| 4 | `pkg/errcode/` | `feat(errcode): permission error reasons` |
+| 5 | `pkg/model/` | `feat(model): permission ledger, materialized state, and federation event` |
+| 6 | `admin-service/` | `feat(admin-service): permission write path with cross-site fanout and resync` |
+| 7 | `inbox-worker/` | `feat(inbox-worker): apply cross-site user permission events` |
+| 8 | `user-service/ pkg/subject/` | `feat(user-service): surface permissions in settings.get` |
+| 9 | `admin-frontend/` | `feat(admin-frontend): permissions console with bulk paste and resync` |
+| 10 | `docs/client-api.md docs/client-api/` | `docs(client-api): permission endpoints and settings.get permissions` |
+
+After commit 10: `git status --short` MUST be empty. If anything remains, STOP — identify the file, decide its logical commit, amend or insert; do not invent an "misc" commit.
+
+- [ ] **Step 4: Verify the rewrite changed nothing.**
+
+```bash
+git diff backup/permission-final HEAD --stat   # MUST be empty
+git log --oneline $BASE..HEAD                  # exactly 10 commits, the table above
+make lint && make test                          # final green on the rewritten head
+```
+
+- [ ] **Step 5: Report.** Do **NOT** push (the remote branch has diverged; pushing requires `--force-with-lease` and happens only on the user's explicit request). Leave `backup/permission-final` in place until the user confirms the new history; note both facts in the completion report.
+

--- a/docs/superpowers/specs/2026-08-10-user-permission-whitelist-design.md
+++ b/docs/superpowers/specs/2026-08-10-user-permission-whitelist-design.md
@@ -1,0 +1,738 @@
+# User Permission Whitelist — Design
+
+**Status:** Approved, amended — ready for re-planning
+**Date:** 2026-08-10, amended 2026-08-11 (fixed UTC+8 interpretation, admin-frontend in scope,
+slim audit dual-write, Metabase column contract), amended 2026-08-12 (cross-site sync:
+permission state materialized on the user document and fanned out to every site; user query
+moves from the dedicated `permission.get` RPC into `settings.get`; the ledger is demoted to
+audit-only; admin-frontend changes deferred to the next round; single-admin-site
+deployment assumption — `SiteID` dropped from the ledger, subjects company-wide, reason
+wording clarified as optional), amended 2026-08-13 (bulk round: `MaxSubjects` and the
+request-body limit removed, fanout chunked at 5,000 accounts/event, console bulk-paste +
+resend — see `2026-08-13-permission-bulk-frontend-design.md`)
+
+## 1. Overview
+
+A whitelist permission recording whether a user may **view images from outside the
+corporate network**. Applications and approvals happen offline (mail / form / sign-off);
+an operation admin records the already-approved decision into the system.
+
+Every change is an independent record — `permission_grants` is an append-only ledger,
+which is also the audit report a BI tool reads. **The ledger is audit-only**: the current
+state is no longer computed from it. Instead, each admin write **materializes a per-user
+permission snapshot onto the `users` document and fans it out to every site**, so that all
+sites converge on the same state and a user's own site answers the query locally.
+
+### 1.1 Goals
+
+- Operation admins grant and revoke the permission for one or many users, via the HTTP
+  API (terminal/curl) and the existing admin-frontend console view.
+- A permission change takes effect at the admin's site immediately and **propagates to
+  every other site** (each site's `users` collection covers the whole company).
+- A user queries their own permission through the existing **`settings.get`** RPC — the
+  response gains a `permissions` field. No dedicated permission RPC exists.
+- A fanout publish failure is **surfaced to the caller** (`syncFailures` in the response),
+  never silently swallowed.
+- Every change is durably recorded with applicant, recording time, validity window,
+  optional reason, and approver; changes also appear in the existing `admin_audit` trail (slim
+  entries); the ledger stays directly readable by Metabase.
+
+### 1.2 Non-goals
+
+- **No enforcement.** media-service and the gateway are not changed. The answer is
+  advisory; the hook for future server-side enforcement is specified in §13 but not built.
+- **No in-system approval workflow.** There is no `pending` state — a write takes effect
+  immediately.
+- **No chat-frontend work.** The `settings.get` extension ships without client-side
+  integration; clients pick the field up whenever they next read settings.
+- **No client push event.** A permission change is visible on the next `settings.get`
+  call; no `chat.user.{account}.event.*` fanout is added. (Future option: piggyback on
+  the existing `settings.update` event.)
+- **No admin-frontend changes in this round.** *(Superseded 2026-08-13: the deferred
+  round is specified in `2026-08-13-permission-bulk-frontend-design.md` — paste-list
+  bulk input, count-visible submit, `syncFailures` banner + resend, offender strip.)*
+- **No Metabase integration.** Only the properties that the ledger is directly readable
+  and the required columns exist are preserved (§12).
+- **No durable relay (OUTBOX).** The user picked direct INBOX publish with error
+  reporting over the OUTBOX relay. §5 records the trade-off and the upgrade path.
+
+## 2. Architecture
+
+No new service. Identity models decide where each path lands:
+
+| Path | Service | Transport | Reason |
+|---|---|---|---|
+| Admin write | `admin-service` | HTTP (Gin) | Already has session-token auth, `requireAdmin`, an audit trail, and the admin-frontend console. |
+| Cross-site sync | `admin-service` → each remote site's INBOX | JetStream direct publish | Same lane as user-service's status/settings fanouts (`chat.inbox.{dest}.external.…`); applied by each site's `inbox-worker`. |
+| User query | `user-service` | NATS request/reply (`settings.get`) | The account in the subject **is** the authenticated identity; the permission field rides an RPC that already exists. |
+
+**Why admin cannot use NATS for the write API.** `pkg/principal/scope.go` documents that
+admins receive the same scoped signing-key template as an ordinary SSO user
+(`chat.user.<account>.>`), so an admin has no cross-account publish rights. The **fanout**
+publish is different: it is performed by admin-service's own service credentials
+(server-side), not by the admin's user identity — the same class of grant user-service
+already holds for its status/settings fanouts. Ops must permit admin-service to publish
+`chat.inbox.*.external.>` across the supercluster (§14).
+
+**Why users cannot use HTTP.** Unchanged from the original design: ordinary users hold
+only a NATS JWT/NKey; HTTP session tokens exist for admins and bots.
+
+**Deployment assumption — one admin site.** admin-service (and with it the ledger and
+every permission write) is deployed at exactly one site company-wide; subjects span the
+whole company, not just users homed at the admin site. Consequences threaded through
+this design: `PermissionGrant` carries no site column (§3.1), the ledger is the complete
+company-wide history (§12), and the subject lookups are site-unfiltered (§4.3, §4.5). If
+a second admin site ever appears, nothing corrupts — the watermark guard already
+converges multi-writer races (§5.2) — but the ledger splits across sites and a site
+discriminator would need to return.
+
+Both services connect to the same `chat` MongoDB database. The `users` collection at every
+site covers the whole company (provisioned by the per-site HR feed), which is what makes a
+materialized per-user snapshot the natural distribution unit.
+
+## 3. Data model
+
+### 3.1 Ledger collection (unchanged, audit-only)
+
+`permission_grants` in the `chat` database. **Append-only: insert only, never update or
+delete.**
+
+```go
+// pkg/model/permission.go (existing on the branch, unchanged)
+type PermissionKey string
+
+const PermissionExternalImageView PermissionKey = "external.image.view"
+
+const MaxReasonRunes = 1000 // MaxSubjects was removed by the 2026-08-13 bulk round
+
+type PermissionGrant struct {
+    ID               string        `json:"id"                      bson:"_id"`
+    Permission       PermissionKey `json:"permission"              bson:"permission"`
+    SubjectAccount   string        `json:"subjectAccount"          bson:"subjectAccount"`
+    Granted          bool          `json:"granted"                 bson:"granted"`
+    EffectiveFrom    *time.Time    `json:"effectiveFrom,omitempty" bson:"effectiveFrom,omitempty"`
+    ExpiresAt        *time.Time    `json:"expiresAt,omitempty"     bson:"expiresAt,omitempty"`
+    ApplicantAccount string        `json:"applicantAccount"        bson:"applicantAccount"`
+    ApproverAccount  string        `json:"approverAccount"         bson:"approverAccount"`
+    Reason           string        `json:"reason"                  bson:"reason"`
+    RecordedBy       string        `json:"recordedBy"              bson:"recordedBy"`
+    RecordedAt       time.Time     `json:"recordedAt"              bson:"recordedAt"`
+}
+```
+
+Field semantics, the pointer/`omitempty` rationale for the window fields, the
+"`Granted` must never carry `omitempty`" rule, and the half-open `[from, until)` interval
+semantics are unchanged from the 2026-08-11 revision. In brief: `Granted` records **what
+this record did**, never rewritten by later rows; `RecordedAt` is the server clock and
+doubles as the application time; window fields are absent on revoke rows; `RecordedBy` is
+the operation admin. With admin-service at a single site (§2), this one collection is
+the **complete company-wide change history**; it is no longer the source of the current
+state. The prior revision's `SiteID` column is **dropped** — a single writer site makes
+it a constant with zero discriminating power, and `RecordedBy` already identifies the
+actor.
+
+### 3.2 Materialized state (new)
+
+```go
+// pkg/model/permission.go (new)
+
+// PermissionState is the latest admin decision for one permission key, materialized on
+// the user document and replicated to every site. UpdatedAt is the write's RecordedAt
+// and doubles as the per-key last-write-wins watermark.
+type PermissionState struct {
+    Granted       bool       `json:"granted"                 bson:"granted"`
+    EffectiveFrom *time.Time `json:"effectiveFrom,omitempty" bson:"effectiveFrom,omitempty"`
+    ExpiresAt     *time.Time `json:"expiresAt,omitempty"     bson:"expiresAt,omitempty"`
+    UpdatedAt     time.Time  `json:"updatedAt"               bson:"updatedAt"`
+}
+
+// Evaluate reports whether the permission is effective at `now`. A nil state, a revoked
+// state, or a grant with a missing bound (malformed data) evaluates to false — deny,
+// never panic. Same boundary semantics as the former EvaluateGrant: now == EffectiveFrom
+// is inside the window, now == ExpiresAt is outside (half-open interval).
+func (s *PermissionState) Evaluate(now time.Time) bool
+
+// UserPermissions is the admin-managed snapshot on the user document — one named field
+// per known PermissionKey. Deliberately a struct, not a map: the key
+// "external.image.view" contains dots, and MongoDB dot-path updates cannot address map
+// keys containing dots, which would break the per-key guarded $set.
+type UserPermissions struct {
+    ExternalImageView *PermissionState `json:"externalImageView,omitempty" bson:"externalImageView,omitempty"`
+}
+
+// Evaluated returns the evaluated boolean for every known permission key. Nil-receiver
+// safe: a user with no snapshot gets every key = false. This is what settings.get and
+// the admin GET's currentlyGranted both call, so the entry points cannot disagree.
+func (p *UserPermissions) Evaluated(now time.Time) map[PermissionKey]bool
+
+// PermissionFieldName maps a PermissionKey to its bson field name inside the
+// `permissions` sub-document ("external.image.view" → "externalImageView"); reports
+// false for unknown keys. Used by the two guarded-update sites (admin-service store,
+// inbox-worker store) to build the `permissions.<field>` dot-paths.
+func PermissionFieldName(k PermissionKey) (string, bool)
+```
+
+`EvaluateGrant(*PermissionGrant, time.Time)` is **removed** — nothing evaluates ledger
+rows anymore. `PermissionState.Evaluate` inherits its tests and fail-closed semantics.
+
+```go
+// pkg/model/user.go — User gains a sibling field
+Permissions *UserPermissions `json:"permissions,omitempty" bson:"permissions,omitempty"`
+```
+
+### 3.3 Why a sibling field, not part of the `settings` sub-document
+
+The cross-site settings apply is a **whole-object replace** (`$set {settings: <snapshot>}`
+under a single `settingsUpdatedAt` watermark — inbox-worker, "receiver replaces, never
+merges"). Any state stored inside that sub-document is only as fresh as the site that
+last snapshotted it:
+
+- **Race with zero failures:** an admin grant at site A and an unrelated user settings
+  change at site B within the propagation window make B's snapshot (without the grant,
+  newer watermark) overwrite A's grant everywhere, while A's event (older watermark) is
+  rejected at B. The grant is lost company-wide with no error anywhere.
+- **Stale-copy resurrection:** a site that missed a permission event re-broadcasts its
+  stale copy inside the next settings snapshot and overwrites fresher state elsewhere.
+
+A snapshot's watermark can say "this bundle is newer", never "every field inside is
+newer". Different writers with independent "latest" therefore need **separate
+last-write-wins domains**: `permissions` is a sibling of `settings` with its own per-key
+watermark (`PermissionState.UpdatedAt`), exactly the way `chatlist` /
+`chatlistUpdatedAt` already sit beside `settings` / `settingsUpdatedAt`.
+
+The second, independent reason is the trust boundary: `settings.set`'s request struct
+embeds `model.UserSettings`. Keeping admin-managed state out of `UserSettings` means a
+user request **structurally** cannot name the field — no code-review convention required.
+
+The client-visible contract is unaffected: `settings.get` composes both fields into one
+response (§6). Storage is split; the response is merged.
+
+### 3.4 Validity window — half-open interval (unchanged)
+
+`EffectiveFrom` / `ExpiresAt` store instants for the half-open interval `[from, until)`.
+The `+1 day` civil-date conversion at write time, the UTC+8 interpretation rule, and the
+display-side reversal are unchanged (§9). The same instants are copied into
+`PermissionState`, so evaluation is identical at every site — expiry and delayed
+effectiveness flip **automatically at read time**; no site needs a scheduler or a
+re-fanout when a window boundary passes.
+
+### 3.5 Evaluation — write-time materialization, read-time decision
+
+"Does alice hold the permission now?" is answered by `user.Permissions` + `Evaluate(now)`
+— one document read, no ledger query. The state written by a POST is derived **entirely
+from the request** (the row being written is by definition the newest fact this site
+knows; cross-site races are resolved by the watermark guard, §5.2):
+
+```go
+// grant                                    // revoke
+PermissionState{                            PermissionState{
+    Granted:       true,                        Granted:   false,   // no window
+    EffectiveFrom: &from,  // parseWindow       UpdatedAt: recordedAt,
+    ExpiresAt:     &until, // parseWindow   }
+    UpdatedAt:     recordedAt,
+}
+```
+
+### 3.6 Ledger indexes (unchanged)
+
+```
+1. {permission:1, subjectAccount:1, recordedAt:-1, _id:-1}
+2. {recordedAt:-1, _id:-1}
+```
+
+Index 1 backs the filtered ledger browse (`GET` with `subjectAccount` and/or
+`permission`); index 2 backs the unfiltered newest-first browse. (Both lose the prior
+revision's `siteId` prefix along with the dropped column.) The ESR reasoning, the
+`_id` tie-break for same-millisecond batch rows, and the no-TTL rule are unchanged.
+admin-service alone creates these indexes. No index is added for the `users.permissions`
+field: every read of it is by `account` (already indexed as the user lookup key).
+
+### 3.7 Read freshness
+
+The dedicated primary-read permission repository from the previous revision is gone.
+Permission now rides `settings.get`'s existing read path in user-service and the admin
+GET's user lookup in admin-service; staleness is bounded by MongoDB replica lag on those
+paths (milliseconds), which replaces the previous design's same concern. Not worth a
+read-preference change to either existing path.
+
+## 4. Admin API — admin-service (HTTP)
+
+`POST /v1/admin/permissions` and `GET /v1/admin/permissions`, registered under the
+existing `requireAdmin` group. Request schemas, the grant/revoke examples, and the
+UTC+8 date handling are unchanged from the 2026-08-11 revision.
+
+### 4.1 Write path
+
+```
+POST /v1/admin/permissions
+ ① validation chain            — unchanged (§4.3)
+ ② derive PermissionState      — from the request (§3.5)
+ ③ withTransaction {
+      InsertMany  permission_grants          (ledger, unchanged)
+      UpdateMany  users                      (guarded per-key $set — same guard as §5.2)
+    }
+ ④ fanout                      — one batch event per remote site, after commit (§5)
+ ⑤ AppendAuditMany             — unchanged, best-effort
+ ⑥ 201 { created, duplicatesIgnored, grants, syncFailures? }
+```
+
+**Why ③ is one transaction:** the ledger row and the local state must not exist without
+each other. Ledger-only would mean "audited but not effective at the origin site while
+remote sites apply it"; state-only would mean "effective but unaudited" — the worst
+failure for a feature that exists to keep records. Both collections live in the same
+database; the existing `withTransaction` helper covers it. Failure has exactly one shape:
+the whole request 500s and nothing happened.
+
+**Why the origin write is also guarded:** two concurrent POSTs for the same subject can
+commit in the opposite order of their timestamps (the state is stamped before the
+transaction runs). Unguarded, the origin would keep the last-*committed* state while
+every remote converges on the newest *stamp* via the apply guard (§5.2) — divergence at
+the origin itself. The guarded `UpdateMany` (filter `updatedAt` missing-or-`$lte` this
+write's `UpdatedAt`) gives every site, origin included, the identical last-write-wins
+rule. The ledger row is still inserted either way: the admin *did* perform the action;
+the audit does not lie. In the no-race case the guard always passes.
+
+**Why fanout is after commit:** a publish cannot join a Mongo transaction, and publishing
+before commit would advertise state that never existed if the transaction aborts. After
+commit, the worst case is "origin has it, remotes get it late".
+
+**Store shape:** the branch's `InsertPermissionGrants(ctx, grants)` becomes
+`RecordPermissionChange(ctx context.Context, grants []*model.PermissionGrant,
+state model.PermissionState) error` — one transaction wrapping the ledger `InsertMany`
+and the guarded users `UpdateMany`; the subject accounts are derived from the grants.
+
+### 4.2 Response — 201
+
+```json
+{
+  "created": 2,
+  "duplicatesIgnored": [],
+  "grants": [
+    {"id": "0199f2c3a4b5...", "subjectAccount": "alice"},
+    {"id": "0199f2c3a4b6...", "subjectAccount": "bob"}
+  ],
+  "syncFailures": ["site-b"]
+}
+```
+
+`syncFailures` (new, `omitempty`) lists the destination sites whose INBOX publish was not
+acknowledged. The status stays **201**: the ledger and the origin-site state are already
+committed — a 5xx would claim the write failed when it did not. Remediation from the
+2026-08-13 round is the **resync endpoint** (bulk-round spec §5 — re-delivers the current
+state, writes nothing), surfaced in the console as a warning banner with a resend button;
+re-sending the request remains the fallback (§5.4).
+
+### 4.3 Validation (unchanged) and write steps
+
+The validation chain (JSON, known key, `subjectAccounts` **non-empty** — the fixed
+200-cap and the request-body limit were removed 2026-08-13, see the bulk-round spec —
+dedup-and-report, optional reason ≤ 1000 runes — omitted/empty accepted, stored as `""` —
+required fields, grant-window rules, revoke-window-absent, one-query account existence +
+subject `IsActive()`) is exactly the 2026-08-11 revision, including all its notes
+(backdated `effectiveFrom` allowed, past `expiresAt` rejected on the derived instant,
+inactive applicant/approver allowed, rejection messages name the offending accounts) —
+with **one scope change**: the existence/active lookup is **site-unfiltered**
+(`{account: {$in: …}}`), because subjects span the whole company (§2) and the local
+`users` collection covers everyone; `FindAccountStates` loses its `siteID` parameter.
+Steps 11+ become:
+
+| # | Step | Failure |
+|---|---|---|
+| 11 | `withTransaction` wrapping `InsertMany` (ledger) + guarded `UpdateMany` (users) | 500 |
+| 12 | Fanout to every remote site; failures → `syncFailures` (§5) | never fails the request |
+| 13 | `AppendAuditMany` — one entry per subject, best-effort | logged, not returned |
+
+### 4.4 Audit — slim dual-write (unchanged)
+
+One `admin_audit` entry per subject, `action` `permission.grant` / `permission.revoke`,
+`details` carrying only `{permission}`; written via `AppendAuditMany` (single
+`InsertMany`), best-effort. Positioning unchanged: the audit entry is a strict data
+subset of the ledger row; the dual-write buys the by-actor unified AuditView surface.
+
+### 4.5 Read (`GET /v1/admin/permissions`)
+
+Filters, paging, newest-first ordering, per-row date display (civil dates plus
+`expiresAtUTC`), and the both-filters-optional design are unchanged. One change:
+
+**`currentlyGranted` now reads the materialized state, not the ledger.** The
+materialized state is the authority every other reader uses — `settings.get` (§6) and
+the future enforcement hook (§13) both go through `Evaluated` — so the admin GET joins
+the same single decision path instead of keeping a second, ledger-derived one. (It also
+stays correct if admin writes ever happen at more than one site.) When both `permission`
+and `subjectAccount` are supplied, the handler fetches the subject's `users.permissions`
+(store method `GetUserPermissions(ctx, account)`, projection `{permissions: 1}`, filter
+`{account}` — subjects may be homed at any site) and returns
+`Evaluated(now)[permission]`. `GetLatestPermissionGrant` is removed.
+
+## 5. Cross-site propagation (new)
+
+### 5.1 Event
+
+```go
+// pkg/model/event.go
+const InboxUserPermissionsUpdated InboxEventType = "user_permissions_updated"
+
+// UserPermissionsUpdated is the cross-site inbox event admin-service publishes after a
+// permission grant/revoke batch. One event carries the whole batch: every account in
+// Accounts receives the same State. Receivers apply it under the per-key watermark
+// guard (State.UpdatedAt), so delivery may be duplicated or reordered safely.
+type UserPermissionsUpdated struct {
+    Permission PermissionKey   `json:"permission" bson:"permission"`
+    Accounts   []string        `json:"accounts"   bson:"accounts"`   // ≤ 5,000 per event (chunked, 2026-08-13)
+    State      PermissionState `json:"state"      bson:"state"`
+    Timestamp  int64           `json:"timestamp"  bson:"timestamp"`  // event publish time
+}
+```
+
+One POST → one event per remote site **per chunk of ≤5,000 accounts** (2026-08-13: the
+batch is chunked to stay under NATS's `max_payload`; each site has its own INBOX
+stream), published to
+`subject.InboxExternal(dest, model.InboxUserPermissionsUpdated)` =
+`chat.inbox.{dest}.external.user_permissions_updated`, wrapped in the standard
+`InboxEvent` envelope, skipping self and blank entries of `ALL_SITE_IDS`. The payload is
+marshaled once. No `Nats-Msg-Id` dedup — the guarded apply is idempotent, the same
+rationale user-service's publisher documents for status/settings.
+
+**Success means the destination stream acknowledged the publish** — the event is in that
+site's mailbox and JetStream's at-least-once delivery to inbox-worker takes over. It does
+*not* mean "applied"; nothing tracks end-to-end application, and nothing needs to.
+
+### 5.2 Apply — inbox-worker
+
+New switch case → handler → guarded store method:
+
+```go
+// InboxStore
+ApplyUserPermissions(ctx context.Context, permission model.PermissionKey,
+    accounts []string, state model.PermissionState) error
+```
+
+One `UpdateMany` (the batch shares one state and one guard condition):
+
+```js
+filter: {
+  account: {$in: accounts},
+  $or: [
+    {"permissions.externalImageView.updatedAt": {$exists: false}},
+    {"permissions.externalImageView.updatedAt": {$lte: state.updatedAt}},
+  ]
+}
+update: {$set: {"permissions.externalImageView": state}}
+```
+
+(The `externalImageView` path comes from `model.PermissionFieldName`.)
+
+- **`$lte`, not `$lt`** — same rationale as the settings guard: two writes can share a
+  millisecond, and dropping the second would leave a site permanently behind; the apply
+  is an idempotent whole-state replace, so a same-ms tie resolves to last-delivered.
+- **Per-key watermark** (inside the state, not a top-level `permissionsUpdatedAt`): a
+  future second permission key must not be blocked or regressed by events for this one.
+- **No upsert.** A missing user doc is a silent no-op, matching every existing user event
+  (status/settings/chatlist); user docs are provisioned everywhere by the HR feed.
+- **Unknown permission key** (a future key reaching a not-yet-upgraded site):
+  `slog.Warn` + return nil (Ack). Retrying cannot succeed and must not poison the
+  consumer; the state converges when the site is upgraded and the change is re-sent.
+- `MatchedCount < len(accounts)` is normal (missing users, newer local state) and is not
+  an error.
+
+admin-service's origin-side `UpdateMany` (§4.1 step ③) uses the identical filter/update
+shape so every site applies one rule.
+
+### 5.3 Failure handling — the decision
+
+Chosen: **direct publish + report** (over the OUTBOX durable relay; user decision
+2026-08-12). Per destination, a failed publish is `slog.Error`-logged and the destination
+is appended to `syncFailures`; the loop continues to the remaining sites (one dead peer
+must not block the others); the request still returns 201 (§4.2).
+
+Why this differs from `publishStatus`'s swallow-and-continue: status is self-healing —
+users change it constantly, and the next change re-broadcasts a full snapshot, so a lost
+event's damage is bounded by hours. A permission may not change again for a year, and a
+lost revoke is a standing security gap — so the error goes to the one party who can act,
+instead of a Warn log nobody watches.
+
+**Upgrade path, recorded:** the event payload and apply are transport-agnostic. If
+unattended durability is later required, switching to the OUTBOX relay is a
+producer-side-only change (publish `OutboxEvent` instead of direct INBOX; add the type to
+`pkg/outbox.ConcurrentEventTypes`; leave `OutboxEvent.RoomID` empty) — no API, model, or
+inbox-worker changes.
+
+### 5.4 Remediation — resync first, re-send as fallback
+
+**From the 2026-08-13 round, the primary remediation is the resync endpoint** (bulk-round
+spec §5): it re-fans-out the current materialized state and writes nothing — no duplicate
+rows, idempotent, safe to repeat. Re-POSTing the identical body remains the fallback when
+no dialog is open (e.g. after the crash window below). The re-POST's three effects are
+safe by construction:
+
+1. **Ledger**: new rows — duplicate audit entries, append-only noise, harmless (accepted
+   with the direct-publish decision).
+2. **Origin state**: the guarded `UpdateMany` re-applies the same logical state with a
+   newer watermark — idempotent.
+3. **Fanout**: re-published to *all* sites; sites that already applied it no-op via the
+   guard.
+
+The residual crash window — process dies between commit and fanout — surfaces to the
+admin as a failed HTTP request, whose natural response is the (safe) re-send. The truly
+silent gap is an admin who sees a timeout and assumes success (§17).
+
+## 6. User query — `settings.get` (user-service)
+
+The dedicated `permission.get` RPC and its whole stack are **removed** (it never merged
+and has no caller): `service/permission.go`, `models/permission.go`,
+`mongorepo/permissions.go`, the `PermissionRepository` interface + mock + `service.New`
+parameter + `main.go` wiring, the `subject.UserPermissionGet`/`…Pattern` builders, the
+`"permission"` area in `ParseUserSubject`, the registration line, and both client-api doc
+sections.
+
+Instead, `settings.get` (`chat.user.{account}.request.user.{siteID}.settings.get`)
+returns:
+
+```json
+{
+  "fullWidth": true,
+  "themePreference": "dark",
+  "...": "…(the existing ten fields, unchanged)…",
+  "permissions": { "external.image.view": true }
+}
+```
+
+```go
+// user-service/models/settings.go
+type SettingsGetResponse struct {
+    model.UserSettings                                       // embedded — fields promoted
+    Permissions map[model.PermissionKey]bool `json:"permissions"`
+}
+```
+
+- One Mongo read: `GetUserSettings` becomes `GetUserSettingsAndPermissions(ctx, account)
+  (*model.UserSettings, *model.UserPermissions, error)` — same query, projection extended
+  to `{settings: 1, permissions: 1}`. The `settings.set` path keeps its existing
+  repository method untouched.
+- `Permissions` is **always present** and contains **every known key**, evaluated at read
+  time via `UserPermissions.Evaluated(now)` — a user with no snapshot gets
+  `{"external.image.view": false}`. Read-time evaluation is what makes windows flip
+  automatically (§3.4).
+- Booleans only — no dates, no audit fields. Same exposure-surface reasoning as the
+  original design: the requirement is a yes/no.
+- **`settings.set`'s response and the `settings.update` client event are deliberately
+  unchanged** (pure `UserSettings`). The field is admin-managed and read-only through
+  this surface; a user cannot touch it because it is not part of `UserSettings` at all
+  (§3.3).
+
+## 7. Admin console — admin-frontend
+
+**Superseded 2026-08-13:** the deferred console round is specified in
+`2026-08-13-permission-bulk-frontend-design.md`. Original 2026-08-12 note follows.
+
+**Unchanged in this round** (user decision 2026-08-12). The already-built PermissionsView
+(list-first page, filters, `currentlyGranted` badge, create/revoke dialog with
+AccountPicker, result view) ships as-is:
+
+- The wire contracts it uses are backward-compatible: `syncFailures` is additive and
+  ignored; `currentlyGranted` keeps its name, type, and both-filters-only presence — only
+  its server-side source changes (§4.5).
+- Deferred to the next round: surfacing `syncFailures` (warning banner + guidance to
+  re-send) and any batch-oriented UX changes that come with the next requirements.
+
+## 8. Authentication
+
+| | Transport | Identity source | Caller supplies |
+|---|---|---|---|
+| Admin write | HTTP POST | `Authorization: Bearer <session token>` → `requireAdmin` | Session token |
+| Fanout publish | NATS JetStream | admin-service's own service credentials | — (server-side) |
+| User query | NATS `settings.get` | The `{account}` token in the subject, enforced by the NATS scoped signing key | **Nothing** |
+
+The key property survives the move into `settings.get`: **a user cannot query another
+user's permission because they cannot publish another user's subject.** As before, that
+guarantee is the ops-owned NATS signing-key template (`chat.user.<account>.>`), an
+external contract this design depends on.
+
+## 9. Dates and timezones (unchanged)
+
+The fixed UTC+8 interpretation rule (`tzTaipei = time.FixedZone("UTC+8", 8*60*60)`), the
+write-time-only conversion, the half-open-interval reasoning, and the "revocation
+involves no dates" analysis all stand unchanged. The API contract also still takes
+**calendar dates (`YYYY-MM-DD`), not RFC 3339 instants**, for the unchanged reasons: an
+instant contract would push the half-open `+1 day` conversion onto a human typing curl
+(silently losing a day), admit meaningless time-of-day precision, and hurt report
+readability; RFC 3339 remains output-only (`expiresAtUTC`). One amendment: user-service
+now *evaluates* window instants at read
+time (`PermissionState.Evaluate`), but evaluation is instant-against-instant comparison,
+which §9's own analysis shows is timezone-free — user-service still performs no civil
+date or timezone handling.
+
+## 10. Error codes (unchanged)
+
+The eight `Permission*` reasons in `pkg/errcode/codes_permission.go` stand as-is; all are
+emitted by the admin endpoints only (the RPC that used `unknown_permission` is gone, and
+`settings.get` takes no input to validate). No new reason: a fanout failure is not an
+error response (§4.2). Every reason remains registered in `allReasons`.
+
+## 11. Testing
+
+TDD red-green-refactor throughout. Coverage ≥80%, targeting 90%+ on evaluation, guard,
+and fanout logic.
+
+| File | Focus |
+|---|---|
+| `pkg/model/permission_test.go` | `PermissionState.Evaluate` table tests (boundaries: `now == effectiveFrom` → true, `now == expiresAt` → false; nil receiver; nil bounds on a granted state → deny; revoked). `Evaluated`: nil receiver → all known keys false; populated → per-key result. `PermissionFieldName` known/unknown. (Replaces the `EvaluateGrant` tests.) |
+| `pkg/model/model_test.go` | Round-trips for `PermissionState`, `UserPermissions`, `UserPermissionsUpdated`; `PermissionGrant` round-trip stays. |
+| `admin-service/permissions_test.go` | Validation tests unchanged. New: state derivation (grant window / revoke no-window); fanout — one captured publish per remote site with correct subject and payload, self/blank skipped; publish failure → destination in `syncFailures`, remaining sites still attempted, response 201; transaction failure → no publish, 500; `currentlyGranted` sourced from `GetUserPermissions` + `Evaluated`. |
+| `inbox-worker/handler_test.go` | New event: unmarshal + store call with decoded fields; malformed payload → error; unknown permission key → nil (Ack) + no store call. |
+| inbox-worker integration | Guarded `UpdateMany`: older watermark rejected, equal applied ($lte), newer applied, missing account no-op, per-key independence (a second key's event is not blocked by the first key's newer watermark). |
+| `user-service/service/settings_test.go` | `settings.get` merge: no snapshot → all-false map; granted-in-window → true; expired / not-yet-effective / revoked → false; settings fields unaffected. Removal of the permission RPC tests. |
+| admin-service integration | Transaction all-or-nothing across ledger + users; origin guard rejects an older write. |
+
+**Mocks:** admin-service regenerates via its `-source=store.go` directive; user-service's
+`//go:generate mockgen` list **drops** `PermissionRepository`; inbox-worker's store mock
+gains `ApplyUserPermissions`. Run `make generate` after interface changes.
+
+## 12. Metabase
+
+The ledger keeps the required columns (`subjectAccount`, `granted`, `effectiveFrom`,
+`expiresAt`, `applicantAccount`, `approverAccount`, `reason`) and stays directly
+readable; date display semantics are unchanged (exclusive-end instants, readers convert).
+
+**One admin site ⇒ one complete ledger.** Every permission write company-wide lands in
+the admin site's `permission_grants`, so BI reads a single collection with no cross-site
+merging. The current-holders view still reads the **`users` collection** — it shares the
+API's evaluation semantics instead of re-deriving latest-wins from history:
+
+```js
+[
+  {"$match": {"$expr": {"$and": [
+    {"$eq":  ["$permissions.externalImageView.granted", true]},
+    {"$lte": ["$permissions.externalImageView.effectiveFrom", "$$NOW"]},
+    {"$gt":  ["$permissions.externalImageView.expiresAt", "$$NOW"]}
+  ]}}},
+  {"$project": {"account": 1, "permissions.externalImageView": 1}}
+]
+```
+
+(`$$NOW` requires the `$expr`/aggregation form; the three conditions must be used as a
+whole — missing window fields on a never-granted user compare as `null` and are excluded
+by the `$gt`/`$eq` pair, same caveat as the prior revision's ledger aggregation.) The
+ledger remains the change-history / audit table it was designed to be.
+
+## 13. Future: server-side enforcement (not built)
+
+`chat.server.request.permission.{siteID}.check` remains the hook shape. It would read the
+subject's `users.permissions` and call `Evaluated` — the same pure decision path as
+`settings.get` and `currentlyGranted`, so the entry points cannot disagree. Because the
+state is materialized at every site, the future check is one local indexed read; no
+cross-site call.
+
+## 14. Supporting changes
+
+- **`docker-local/compose.deps.yaml`** — single-node replica set (unchanged from the prior
+  revision; the write transaction still requires it), with the
+  `?directConnection=true` host-side URI adjustments in the seed tool and jaeger README.
+- **`admin-service/main.go` / `middleware.go`** — the 1MB `http.MaxBytesReader` body
+  limit added earlier on this branch is **removed again** (user decision 2026-08-13;
+  risk recorded in the bulk-round spec §8.1).
+- **admin-service NATS wiring (new):**
+  - `main.go`: `js, err := nc.JetStream()` — the connection already exists (room on-duty
+    RPC); this adds the JetStream context.
+  - Config gains `AllSiteIDs []string` (`env:"ALL_SITE_IDS" envSeparator:","`,
+    `envDefault:""` — empty means no fanout, which is correct for single-site dev).
+  - The handler holds an injected `publishInbox func(ctx context.Context, subj string,
+    data []byte) error` field so unit tests capture publishes without NATS (the
+    repo-wide JetStream-testing convention).
+  - admin-service creates no streams: each site's INBOX belongs to inbox-worker; the
+    supercluster routing that makes a remote publish land is ops/IaC, as everywhere else.
+- **Deployment note (ops):** admin-service's NATS service account needs publish
+  permission on `chat.inbox.*.external.>` — the grant user-service already holds.
+
+## 15. Documentation
+
+| File | Change |
+|---|---|
+| `docs/client-api.md` settings section | `settings.get` response: add the `permissions` row (`map<permission key, boolean>`, admin-managed, read-only) + updated JSON example; note that `settings.set` cannot touch it. |
+| `docs/client-api.md` §3.4 `permission.get` | **Removed** (RPC deleted), including its TOC entry and subject-table row. |
+| `docs/client-api.md` §9.13 | Response gains `syncFailures` (field table + semantics: sites whose INBOX publish failed; remediation = re-send). |
+| `docs/client-api.md` §9.14 | `currentlyGranted` prose: sourced from the materialized state (same evaluation path as `settings.get`). |
+| `docs/client-api.md` §6 | Reason catalog: the eight permission reasons stay; drop the `permission.get` emitter references. |
+| `docs/client-api/request-reply.md` | Mirror all of the above (derived view, same PR). |
+| `docs/client-api/events.md` | **Unchanged** — `user_permissions_updated` is site→site (INBOX), not a server→client event; the `settings.update` client event is untouched. |
+
+## 16. Delta from the implemented branch
+
+The feature branch (`claude/user-whitelist-permission-api-5942da`, 28 commits, unmerged)
+already implements the 2026-08-11 revision. Disposition under this amendment:
+
+**Keep as-is**
+- `history-service` `reflect.Pointer` chore; docker-local replica set + host URI fixes;
+  admin-service body-limit middleware.
+- `pkg/errcode/codes_permission.go` (all eight reasons).
+- `pkg/model`: `PermissionKey`, `KnownPermission`, `MaxReasonRunes`, `PermissionGrant`
+  (`MaxSubjects` is removed by the 2026-08-13 round).
+- admin-service: the whole validation chain (minus the site-scope change below),
+  `InsertPermissionGrants`'s transaction+`InsertMany` core (absorbed into the new
+  transactional method), `AppendAuditMany`, `listPermissions` paging/date display.
+- admin-frontend: everything (PermissionsPage/Table/Dialog/AccountPicker, api client,
+  reason copy) — frozen this round.
+
+**Adjust**
+- `pkg/model/permission.go`: + `PermissionState` (+`Evaluate`), + `UserPermissions`
+  (+`Evaluated`), + `PermissionFieldName`; − `EvaluateGrant`; − `PermissionGrant.SiteID`.
+- `pkg/model/user.go`: + `Permissions` sibling field.
+- `pkg/model/event.go`: + `InboxUserPermissionsUpdated` + `UserPermissionsUpdated`.
+- admin-service `permissions.go`: write path gains state derivation, the users
+  `UpdateMany` inside the transaction, post-commit fanout, `syncFailures` in the
+  response; `currentlyGranted` re-sourced.
+- admin-service `store.go`/`store_mongo.go`: transactional method extended to apply
+  state; + `GetUserPermissions`; − `GetLatestPermissionGrant`; `FindAccountStates` and
+  `ListPermissionGrants` drop their site filter/parameter (company-wide subjects); both
+  ledger indexes drop the `siteId` prefix.
+- admin-service `main.go`/config: JetStream context, `ALL_SITE_IDS`, publish-func
+  injection.
+- user-service `service/settings.go` + `models/settings.go` + `mongorepo/users.go`:
+  `SettingsGetResponse` wrapper, extended projection, read-time evaluation.
+- inbox-worker `handler.go`/`main.go`: new case + handler + guarded `ApplyUserPermissions`.
+- Docs per §15.
+
+**Remove**
+- user-service `service/permission.go` (+test), `models/permission.go` (+test),
+  `mongorepo/permissions.go` (+test), `PermissionRepository` (interface, mock,
+  `service.New` param, `main.go` wiring, registration line).
+- `pkg/subject`: `UserPermissionGet`/`UserPermissionGetPattern`, the `"permission"`
+  `ParseUserSubject` area (+tests).
+- `docs/client-api.md` / `request-reply.md`: the `permission.get` sections.
+
+**Deferred (next round)**
+- admin-frontend `syncFailures` surfacing and any batch-UX changes.
+
+## 17. Residual risks
+
+1. **A lost response followed by a form re-submit duplicates ledger rows.** Confined to
+   the fallback path from the 2026-08-13 round on — the console's resend is the resync
+   endpoint, which writes nothing (§5.4). Duplicates from a re-submit remain harmless
+   append-only noise; state converges via the watermark guard.
+2. **Silent fanout gap.** Direct publish means a crash between commit and fanout, or an
+   admin who ignores a timeout / `syncFailures` and never re-sends, leaves remote sites
+   stale until the next change to the same subjects. Accepted with the direct-publish
+   decision; the OUTBOX upgrade path is recorded in §5.3.
+3. **Console blindness this round.** The current admin-frontend ignores `syncFailures`;
+   only curl callers and server logs see sync failures until the next-round UI lands.
+   *(Addressed by the 2026-08-13 round: `syncFailures` banner + resend button.)*
+4. **Clock skew across admin-service replicas.** `UpdatedAt` comes from the writing
+   replica's clock; ordering between near-simultaneous writes is only as correct as NTP
+   among the admin site's replicas. A same-millisecond tie under the `$lte` guard
+   resolves to last-delivered, which can differ per receiving site — same accepted class
+   as the settings lane.
+5. **Advisory, not enforced.** Unchanged; the enforcement hook is §13.
+6. **The fixed UTC+8 offset carries no DST rules.** Unchanged.
+7. **An approver without a chat account cannot be recorded.** Unchanged.
+8. **`reason` is permanently retained free text.** Unchanged.
+9. **The NATS subject scope and the supercluster routing are ops-owned external
+   contracts** — the user-identity guarantee (§8) and the fanout's deliverability (§14)
+   both live outside this repository.
+10. **A user doc missing at a remote site drops the apply** (silent no-op, no upsert). In
+    practice the HR feed provisions users everywhere before an admin would grant to them;
+    a re-send heals the exotic case.
+11. **No client push.** A client sees a permission change on its next `settings.get`;
+    an in-session revoke does not reach an already-loaded client until then.
+12. **Subject `IsActive()` can be stale for users homed at another site.** `active` does
+    not federate (a known, separate gap); the validation runs against the admin site's
+    local copy — the best signal available. Tracked as separate work.

--- a/docs/superpowers/specs/2026-08-13-permission-bulk-frontend-design.md
+++ b/docs/superpowers/specs/2026-08-13-permission-bulk-frontend-design.md
@@ -1,0 +1,217 @@
+# Permission Bulk Update & Resend (admin-frontend round) — Design
+
+**Status:** Approved, ready for planning
+**Date:** 2026-08-13 (resend mechanism revised same day: re-POST → minimal resync)
+**Builds on:** `2026-08-10-user-permission-whitelist-design.md` (as amended 2026-08-12).
+This is the admin-frontend round that spec deferred, plus the request-limit removals and
+fanout chunking that the bulk requirement forced onto the backend.
+
+*As-shipped note: this spec describes deltas against a pre-rewrite branch state. The shipped history was rebuilt, so the removals it prescribes (`bodyLimit`, `permission.get`, `MaxSubjects`/`EvaluateGrant`/`SiteID`) never appear in the final commits, and some prescribed shapes (`stateGroupKey`, `GetUserSettingsAndPermissions`) were superseded by later cleanup. The code is the source of truth.*
+
+## 1. Overview
+
+Two requirements drive this round:
+
+1. An admin must be able to update permissions for very large batches — the stated need
+   is 1,000 users at once. The design removes the artificial caps entirely rather than
+   raising them: no `MaxSubjects`, no request-body limit.
+2. When fanout to a site fails, the admin must be able to **re-send from the console**
+   to restore cross-site consistency — implemented as an idempotent **resync endpoint**
+   that re-delivers recorded state without re-recording anything.
+
+Everything lands in admin-service (producer side) and admin-frontend. inbox-worker,
+user-service, and the `pkg/model` event/state shapes are untouched; the wire-contract
+changes are the deleted `MaxSubjects` constant and one new admin endpoint (§5).
+
+## 2. Decisions
+
+| Decision | Choice | Rejected alternatives |
+|---|---|---|
+| Resend mechanism | **Minimal resync endpoint** — `POST /v1/admin/permissions/resync` re-fans-out the current materialized state from the local `users` docs; writes no ledger, audit, or user-doc rows | OUTBOX auto-retry (recommended, declined); re-POST of the identical body (chosen first on 2026-08-13, revised the same day once its duplicate-audit cost was weighed); persisted failure list + console list page (still declined) |
+| Bulk input | **Paste-list mode** toggle beside the existing AccountPicker | CSV upload; both |
+| Subject count cap | **Removed** (`MaxSubjects` deleted) | keep 200; raise to 1,000 or 10,000 |
+| Request body cap | **Removed** (1MB middleware deleted) — user decision 2026-08-13, **against the recorded recommendation**; risk §9.1 | keep 1MB |
+| NATS payload ceiling | **Chunked fanout**, 5,000 accounts per event | single event (would cap a batch at ~20k accounts) |
+| Mongo transaction | **Single transaction kept** — all-or-nothing preserved at any N | chunked transaction (loses atomicity) |
+
+Consequence the resend choice accepts (unchanged by the revision): the failure
+information lives only in the open dialog — closing it forfeits the console resend entry
+point (server logs remain the only trace). The resync itself writes nothing and is
+idempotent, so repeated retries cost nothing.
+
+## 3. Limit removals (backend)
+
+### 3.1 `MaxSubjects` — deleted
+
+- `pkg/model/permission.go`: the `MaxSubjects` constant is removed (`MaxReasonRunes`
+  stays).
+- Validation: "non-empty and ≤ `MaxSubjects`" becomes **non-empty only**;
+  `PermissionInvalidSubjects` (`invalid_subject_count`) is kept for the empty case.
+- The frontend cap-mirror constant is deleted with it.
+
+### 3.2 Request body limit — deleted
+
+- `admin-service/middleware.go`: `maxRequestBodyBytes` and `bodyLimit()` removed;
+  `main.go` drops the `r.Use(bodyLimit(...))` line; the middleware tests go with them.
+  This reverts the hardening this same branch introduced.
+- Recorded as an accepted risk (§9.1): JSON parsing precedes validation, so **no
+  app-level bound on request memory remains**. Surviving mitigations: the surface is
+  authenticated (`requireAdmin` rejects on headers before the body is read), server
+  read timeouts, and whatever ops-owned infrastructure limits exist (not verifiable
+  from this repository — no gateway or ingress config lives here).
+
+### 3.3 What still bounds a batch
+
+No fixed number anywhere. In practice: request memory (unbounded by decision), then the
+single Mongo transaction — 2N documents modified per batch; tens of thousands is the
+practical comfort zone, and an oversized batch fails **cleanly** (500, atomic, nothing
+partial, retryable). NATS is out of the equation thanks to chunking (§4). The only guard
+against an accidental whole-company paste is the visible count in the console (§6.2).
+
+## 4. Chunked fanout (admin-service)
+
+```go
+// ≈320KB per event at 64 bytes/account — 3× margin under NATS's default 1MB max_payload.
+const fanoutChunkSize = 5000
+```
+
+- The publish loop becomes: for each remote site × each chunk of ≤5,000 accounts → one
+  `UserPermissionsUpdated` event. Same event shape; `Accounts` carries the chunk;
+  `Permission`, `State`, and `Timestamp` are identical across all chunks of one batch.
+- A failed publish marks the destination in `syncFailures` (listed once) and the loop
+  **continues** through the remaining chunks and destinations — maximize delivery,
+  aggregate failures per destination. The response shape is unchanged.
+- Partial chunk delivery is safe by construction: remote applies are per-account guarded
+  and idempotent, so chunks may arrive in any order, duplicated, or not at all; a resync
+  re-publishes every chunk and already-applied accounts no-op.
+- **inbox-worker: zero changes.** It sees the same event type with shorter account
+  arrays, possibly several per batch.
+- The chunked-fanout function is **shared** by the write path (§ main spec 4.1 step ④)
+  and the resync endpoint (§5).
+- The OUTBOX upgrade path recorded in the main spec §5.3 is unaffected — the chunk loop
+  would simply publish `OutboxEvent`s instead of direct INBOX events.
+
+## 5. Resync endpoint (admin-service)
+
+`POST /v1/admin/permissions/resync`, registered under `requireAdmin` beside the existing
+permission routes.
+
+**Request:** `{"permission": "external.image.view", "accounts": ["alice", "bob", …]}`
+
+**Semantics: re-delivery, not re-recording.** The endpoint reads each account's current
+materialized state from the local `users` collection (one batch read, projection
+`{account, permissions.<field>}`), groups the accounts by identical state — one group per
+original batch in the common case; more if another write landed in between — and re-runs
+the chunked fanout (§4) once per group. It always delivers the **current** truth, never
+the original request's possibly-stale state. It writes nothing: no ledger rows, no audit
+entries, no user-doc updates.
+
+- **Validation:** known permission key (`unknown_permission`); `accounts` non-empty
+  (`invalid_subject_count`). **No existence or `IsActive` checks** — delivering
+  already-recorded state grants nothing new. Accounts with no local user doc or no state
+  for the key are silently skipped (they have nothing to sync).
+- **Response:** `{"syncFailures": […]}` — same field semantics as the write path
+  (destinations whose INBOX publish was not acknowledged); empty means every publish was
+  acknowledged. Status 200.
+- **Idempotent by construction:** the fanned-out states carry their stored `updatedAt`
+  watermarks, so remote guards no-op anything already applied. Safe to call repeatedly.
+- **No audit entry** — deliberate: the operation mutates nothing; server logs carry the
+  operational trace.
+- Store addition: a batch read, e.g. `GetUserPermissionsForAccounts(ctx, accounts)
+  (map[string]*model.UserPermissions, error)` (exact shape finalized in the plan);
+  the existing single-account `GetUserPermissions` stays for `currentlyGranted`.
+
+## 6. Console (admin-frontend)
+
+Exact user-facing copy follows the console's existing language and tone; strings below
+describe intent.
+
+### 6.1 Paste-list input mode
+
+`CreatePermissionsDialog` gains a two-mode subject input — **pick mode** (the existing
+AccountPicker, unchanged) and **paste mode** (a textarea):
+
+- Parse on `/[\s,;]+/` (whitespace, newlines, commas, semicolons), trim, drop empties.
+  Accounts are sent verbatim — no case normalization, matching backend semantics.
+- Live feedback: deduped count plus how many duplicates were dropped ("N accounts,
+  M duplicates removed"). Zero parsed accounts disables submit.
+- Modes never merge: **the active mode's list is what submits.** The toggle shows a
+  per-mode count badge (e.g. `Pick (5) / Paste (995)`) so "picked 5, pasted 995,
+  thought I sent 1000" cannot happen silently.
+
+### 6.2 Count-visible submit
+
+The submit control always carries the effective (deduped, active-mode) count — "Grant to
+25,431 users" / "Revoke from 12 users". With the caps gone, this visibility is the only
+guard against pasting the wrong file; it is a requirement, not a nicety.
+
+### 6.3 Result view — `syncFailures` banner + resync
+
+- When the 201 response carries `syncFailures`, the result view shows a warning banner —
+  "recorded and effective at this site, but sync to site-b failed" — with a **resend**
+  button.
+- The button calls **`POST /v1/admin/permissions/resync`** with `{permission, accounts}`
+  from the just-submitted request (both are still in the dialog's state). It locks while
+  in flight; on completion the banner reflects the resync response (empty
+  `syncFailures` → "sync complete"). Because resync writes nothing, the button may be
+  pressed repeatedly without cost.
+- The button renders only while the latest response's `syncFailures` is non-empty, and
+  it lives and dies with the dialog (accepted with the mechanism choice, §2).
+
+### 6.4 Offender-list scaling + one-click strip
+
+`unknown_accounts` / `inactive_subject` rejections can now name hundreds of accounts:
+
+- Scrollable offender list plus a copy-list control.
+- A **"remove these accounts"** action strips the offenders from the active input
+  (paste text or picker selection) so the admin can resubmit immediately. Backend
+  all-or-nothing semantics are unchanged — the convenience lives entirely client-side.
+
+### 6.5 Long result lists
+
+`duplicatesIgnored` (and `grants` at large N) render as counts with a collapsed,
+expandable list instead of dumping thousands of rows.
+
+## 7. Testing
+
+| Area | Cases |
+|---|---|
+| admin-service validation | empty list still rejected (`invalid_subject_count`); a large list (e.g. 10,001 accounts) accepted; body-limit middleware tests removed |
+| chunked fanout (unit, captured publish func) | N ≤ 5,000 → one event per dest; 5,001 → two; chunk boundaries exact and complete; a dest failing on any chunk → listed once in `syncFailures` while other chunks/dests are still attempted; per-chunk payload shape (same state/timestamp, chunked accounts) |
+| resync handler (unit) | groups accounts by identical state and fans out once per group; accounts with no doc/state are skipped; **no ledger/audit/user-doc writes** (store mock asserts no mutating calls); unknown key → `unknown_permission`; empty accounts → `invalid_subject_count`; `syncFailures` aggregation matches the write path |
+| admin-frontend (Vitest, existing dialog patterns) | paste parsing (separators, trim, dedup, count); zero-parse disables submit; mode badges + active-mode-wins payload; submit-label count; `syncFailures` banner + button posts `{permission, accounts}` to resync (not the original body) + in-flight lock + banner update from the resync response; strip action filters both input modes; long-list collapse |
+
+## 8. Documentation
+
+- `docs/client-api.md` §9.13: `subjectAccounts` constraint → "non-empty (no fixed
+  cap)"; `invalid_subject_count` description → the empty-list case; drop the
+  oversized-body 400 row.
+- `docs/client-api.md` new **§9.15 Resync permission fanout**: request/response field
+  tables, semantics (re-delivery only, writes nothing, idempotent), error table, curl
+  example.
+- `docs/client-api/request-reply.md`: mirror both in the same PR.
+- Main spec touch-ups in the same change (kept consistent rather than drifting):
+  `MaxSubjects` removed from §3.1, §4.3 step wording, §5.1 chunking note, §5.4
+  remediation now resync-first, §14 body-limit bullet flipped to a removal note,
+  §1.2/§7 deferral notes now point here, §16/§17 cross-references.
+
+## 9. Residual risks
+
+1. **Unbounded request body** (decision 2026-08-13, against the recorded
+   recommendation). No app-level memory bound on admin-service requests; any holder of
+   a valid admin session (leaked token, buggy internal script) can submit an
+   arbitrarily large body that is fully parsed before any validation runs. Remaining
+   mitigations: authentication precedes the body read; server read timeouts; ops-layer
+   limits if any. Rollback is re-adding the same 15 lines this round deletes.
+2. **Huge-N transaction behavior.** Never partial (single transaction); an absurd batch
+   fails clean (500) or runs slow. Practical comfort zone: tens of thousands of
+   subjects.
+3. **Resend caveats.** Closing the dialog forfeits the console resend entry point; the
+   fallback for a lost dialog (or the commit→fanout crash window) is re-submitting the
+   form, which — unlike resync — does insert a fresh batch of ledger/audit rows
+   (harmless, rare). Resync leaves no audit trace by design; server logs carry it.
+4. **Accidental mass grant.** With the caps gone, the visible count (§6.2) is the only
+   guard against pasting the wrong file into a security permission.
+5. **Partial chunk delivery window.** Until a resync succeeds, a failed destination may
+   hold some chunks of a batch and not others — per-account staleness that converges on
+   resync or on the next change to the affected accounts.

--- a/history-service/internal/cassrepo/utils.go
+++ b/history-service/internal/cassrepo/utils.go
@@ -124,7 +124,7 @@ func cqlFieldIndex(rt reflect.Type) map[string]int {
 // Separated from structScan so the column-matching logic is unit-testable without a live gocql iterator.
 func buildScanValues(dest any, colNames []string) (values []any, missingCol string, ok bool) {
 	rv := reflect.ValueOf(dest)
-	if rv.Kind() != reflect.Ptr || rv.Elem().Kind() != reflect.Struct {
+	if rv.Kind() != reflect.Pointer || rv.Elem().Kind() != reflect.Struct {
 		return nil, "", false
 	}
 	rv = rv.Elem()
@@ -146,7 +146,7 @@ func buildScanValues(dest any, colNames []string) (values []any, missingCol stri
 func structScan(iter *gocql.Iter, dest any) (bool, error) {
 	// Validate dest shape before touching the iterator (iter may be nil in tests).
 	rv := reflect.ValueOf(dest)
-	if rv.Kind() != reflect.Ptr || rv.Elem().Kind() != reflect.Struct {
+	if rv.Kind() != reflect.Pointer || rv.Elem().Kind() != reflect.Struct {
 		return false, nil
 	}
 

--- a/inbox-worker/handler.go
+++ b/inbox-worker/handler.go
@@ -80,6 +80,9 @@ type InboxStore interface {
 	// full post-update settings from the origin site, guarded by settingsUpdatedAt so an
 	// out-of-order or duplicate delivery can't regress. A missing user is a logged no-op.
 	UpdateUserSettings(ctx context.Context, account string, settings *model.UserSettings, updatedAt time.Time) error
+	// ApplyUserPermissions applies one permission state to the accounts under the
+	// per-key watermark guard. A missing user (no doc on this site) is a silent no-op.
+	ApplyUserPermissions(ctx context.Context, permission model.PermissionKey, accounts []string, state model.PermissionState) error
 	// UpdateUserChatlist replaces the local users doc's chatlist sub-document with the
 	// full post-update state from the origin site, guarded by chatlistUpdatedAt so an
 	// out-of-order or duplicate delivery can't regress. A missing user is a logged no-op.
@@ -141,6 +144,8 @@ func (h *Handler) HandleEvent(ctx context.Context, data []byte) error {
 		return h.handleUserStatusUpdated(ctx, &evt)
 	case model.InboxUserSettingsUpdated:
 		return h.handleUserSettingsUpdated(ctx, &evt)
+	case model.InboxUserPermissionsUpdated:
+		return h.handleUserPermissionsUpdated(ctx, &evt)
 	case model.InboxUserChatlistUpdated:
 		return h.handleUserChatlistUpdated(ctx, &evt)
 	case model.InboxSubscriptionSectionMoved:
@@ -425,6 +430,25 @@ func (h *Handler) handleUserSettingsUpdated(ctx context.Context, evt *model.Inbo
 	}
 	if err := h.store.UpdateUserSettings(ctx, e.Account, &e.Settings, time.UnixMilli(e.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("update user settings for %q: %w", e.Account, err)
+	}
+	return nil
+}
+
+// handleUserPermissionsUpdated applies one chunk of an admin permission batch. A missing
+// user doc is a silent no-op (store-level guard), matching the other user events.
+func (h *Handler) handleUserPermissionsUpdated(ctx context.Context, evt *model.InboxEvent) error {
+	var e model.UserPermissionsUpdated
+	if err := json.Unmarshal(evt.Payload, &e); err != nil {
+		return fmt.Errorf("unmarshal user_permissions_updated payload: %w", err)
+	}
+	if _, ok := model.PermissionFieldName(e.Permission); !ok {
+		// A future permission key reaching a not-yet-upgraded site: retrying cannot
+		// succeed and must not poison the consumer — warn and Ack.
+		slog.WarnContext(ctx, "unknown permission key in user_permissions_updated", "permission", string(e.Permission))
+		return nil
+	}
+	if err := h.store.ApplyUserPermissions(ctx, e.Permission, e.Accounts, e.State); err != nil {
+		return fmt.Errorf("apply user permissions: %w", err)
 	}
 	return nil
 }

--- a/inbox-worker/handler_test.go
+++ b/inbox-worker/handler_test.go
@@ -106,6 +106,13 @@ type stubInboxStore struct {
 	settingsUpdates       []userSettingsUpdate
 	chatlistUpdates       []userChatlistUpdate
 	sectionMoves          []sectionMove
+	permissionsApplies    []permissionsApply
+}
+
+type permissionsApply struct {
+	permission model.PermissionKey
+	accounts   []string
+	state      model.PermissionState
 }
 
 type userChatlistUpdate struct {
@@ -473,6 +480,21 @@ func (s *stubInboxStore) getSettingsUpdates() []userSettingsUpdate {
 	defer s.mu.Unlock()
 	cp := make([]userSettingsUpdate, len(s.settingsUpdates))
 	copy(cp, s.settingsUpdates)
+	return cp
+}
+
+func (s *stubInboxStore) ApplyUserPermissions(_ context.Context, permission model.PermissionKey, accounts []string, state model.PermissionState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.permissionsApplies = append(s.permissionsApplies, permissionsApply{permission: permission, accounts: accounts, state: state})
+	return nil
+}
+
+func (s *stubInboxStore) getPermissionsApplies() []permissionsApply {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]permissionsApply, len(s.permissionsApplies))
+	copy(cp, s.permissionsApplies)
 	return cp
 }
 
@@ -2121,6 +2143,76 @@ func TestHandler_UserSettingsUpdated_MalformedPayload(t *testing.T) {
 
 	require.Error(t, h.HandleEvent(context.Background(), evt))
 	assert.Empty(t, store.getSettingsUpdates())
+}
+
+func TestHandler_UserPermissionsUpdated(t *testing.T) {
+	store := &stubInboxStore{}
+	h := NewHandler(store)
+
+	effectiveFrom := time.UnixMilli(1000).UTC()
+	expiresAt := time.UnixMilli(9000).UTC()
+	state := model.PermissionState{
+		Granted:       true,
+		EffectiveFrom: &effectiveFrom,
+		ExpiresAt:     &expiresAt,
+		UpdatedAt:     time.UnixMilli(5000).UTC(),
+	}
+	payload, err := json.Marshal(model.UserPermissionsUpdated{
+		Permission: model.PermissionExternalImageView,
+		Accounts:   []string{"alice", "bob"},
+		State:      state,
+		Timestamp:  12345,
+	})
+	require.NoError(t, err)
+	evt, err := json.Marshal(model.InboxEvent{
+		Type: model.InboxUserPermissionsUpdated, Payload: payload, Timestamp: 12345,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, h.HandleEvent(context.Background(), evt))
+
+	applies := store.getPermissionsApplies()
+	require.Len(t, applies, 1)
+	assert.Equal(t, model.PermissionExternalImageView, applies[0].permission)
+	assert.Equal(t, []string{"alice", "bob"}, applies[0].accounts)
+	assert.Equal(t, state, applies[0].state)
+}
+
+func TestHandler_UserPermissionsUpdated_MalformedPayload(t *testing.T) {
+	store := &stubInboxStore{}
+	h := NewHandler(store)
+
+	evt, err := json.Marshal(model.InboxEvent{
+		Type:    model.InboxUserPermissionsUpdated,
+		Payload: []byte("not-json"),
+	})
+	require.NoError(t, err)
+
+	require.Error(t, h.HandleEvent(context.Background(), evt))
+	assert.Empty(t, store.getPermissionsApplies())
+}
+
+// TestHandler_UserPermissionsUpdated_UnknownPermissionKey covers a permission key this
+// site doesn't recognize yet (a newer site fanned out a key before this one upgraded).
+// Retrying can never succeed, so the handler must Ack (nil), not Nak-loop forever.
+func TestHandler_UserPermissionsUpdated_UnknownPermissionKey(t *testing.T) {
+	store := &stubInboxStore{}
+	h := NewHandler(store)
+
+	payload, err := json.Marshal(model.UserPermissionsUpdated{
+		Permission: model.PermissionKey("future.unknown.key"),
+		Accounts:   []string{"alice"},
+		State:      model.PermissionState{Granted: true, UpdatedAt: time.UnixMilli(5000).UTC()},
+		Timestamp:  12345,
+	})
+	require.NoError(t, err)
+	evt, err := json.Marshal(model.InboxEvent{
+		Type: model.InboxUserPermissionsUpdated, Payload: payload, Timestamp: 12345,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, h.HandleEvent(context.Background(), evt))
+	assert.Empty(t, store.getPermissionsApplies())
 }
 
 // A bot-DM member_added at the target MUST upsert a subscription only, never a rooms doc

--- a/inbox-worker/integration_test.go
+++ b/inbox-worker/integration_test.go
@@ -1656,3 +1656,117 @@ func TestInboxWorker_UpdateUserSettings_Integration(t *testing.T) {
 		assert.Equal(t, int64(0), count)
 	})
 }
+
+func TestInboxWorker_ApplyUserPermissions_Integration(t *testing.T) {
+	db := setupMongo(t)
+	ctx := context.Background()
+
+	store := &mongoInboxStore{
+		subCol:  db.Collection("subscriptions"),
+		roomCol: db.Collection("rooms"),
+		userCol: db.Collection("users"),
+	}
+
+	effectiveFrom := time.UnixMilli(500).UTC()
+	expiresAt := time.UnixMilli(9000).UTC()
+	state := model.PermissionState{
+		Granted:       true,
+		EffectiveFrom: &effectiveFrom,
+		ExpiresAt:     &expiresAt,
+		UpdatedAt:     time.UnixMilli(1000).UTC(),
+	}
+
+	// Each subtest owns its own account(s) so it passes standalone under -run.
+	seed := func(t *testing.T, account string) {
+		t.Helper()
+		_, err := db.Collection("users").InsertOne(ctx, model.User{ID: "u-" + account, Account: account, SiteID: "site-b"})
+		require.NoError(t, err)
+	}
+
+	t.Run("fresh apply sets externalImageView on every listed account", func(t *testing.T) {
+		seed(t, "perm-alice")
+		seed(t, "perm-bob")
+
+		require.NoError(t, store.ApplyUserPermissions(ctx, model.PermissionExternalImageView, []string{"perm-alice", "perm-bob"}, state))
+
+		for _, account := range []string{"perm-alice", "perm-bob"} {
+			var got model.User
+			require.NoError(t, store.userCol.FindOne(ctx, bson.M{"account": account}).Decode(&got))
+			require.NotNil(t, got.Permissions)
+			require.NotNil(t, got.Permissions.ExternalImageView)
+			assert.Equal(t, state.Granted, got.Permissions.ExternalImageView.Granted)
+			assert.True(t, state.UpdatedAt.Equal(got.Permissions.ExternalImageView.UpdatedAt))
+		}
+	})
+
+	t.Run("stored updatedAt newer than the event's — doc unchanged", func(t *testing.T) {
+		seed(t, "perm-newer")
+		newerState := model.PermissionState{Granted: false, UpdatedAt: time.UnixMilli(2000).UTC()}
+		_, err := db.Collection("users").UpdateOne(ctx,
+			bson.M{"account": "perm-newer"},
+			bson.M{"$set": bson.M{"permissions.externalImageView": newerState}},
+		)
+		require.NoError(t, err)
+
+		require.NoError(t, store.ApplyUserPermissions(ctx, model.PermissionExternalImageView, []string{"perm-newer"}, state))
+
+		var got model.User
+		require.NoError(t, store.userCol.FindOne(ctx, bson.M{"account": "perm-newer"}).Decode(&got))
+		require.NotNil(t, got.Permissions)
+		require.NotNil(t, got.Permissions.ExternalImageView)
+		assert.False(t, got.Permissions.ExternalImageView.Granted, "newer stored state must not be regressed")
+		assert.True(t, newerState.UpdatedAt.Equal(got.Permissions.ExternalImageView.UpdatedAt))
+	})
+
+	t.Run("equal updatedAt is applied ($lte)", func(t *testing.T) {
+		seed(t, "perm-equal")
+		equalState := model.PermissionState{Granted: false, UpdatedAt: state.UpdatedAt}
+		_, err := db.Collection("users").UpdateOne(ctx,
+			bson.M{"account": "perm-equal"},
+			bson.M{"$set": bson.M{"permissions.externalImageView": equalState}},
+		)
+		require.NoError(t, err)
+
+		require.NoError(t, store.ApplyUserPermissions(ctx, model.PermissionExternalImageView, []string{"perm-equal"}, state))
+
+		var got model.User
+		require.NoError(t, store.userCol.FindOne(ctx, bson.M{"account": "perm-equal"}).Decode(&got))
+		require.NotNil(t, got.Permissions)
+		require.NotNil(t, got.Permissions.ExternalImageView)
+		assert.True(t, got.Permissions.ExternalImageView.Granted, "equal updatedAt must still apply — $lte, not strictly less-than")
+	})
+
+	t.Run("account with no user doc is a no-op; others still applied", func(t *testing.T) {
+		seed(t, "perm-real")
+
+		require.NoError(t, store.ApplyUserPermissions(ctx, model.PermissionExternalImageView, []string{"perm-real", "perm-ghost"}, state))
+
+		var got model.User
+		require.NoError(t, store.userCol.FindOne(ctx, bson.M{"account": "perm-real"}).Decode(&got))
+		require.NotNil(t, got.Permissions)
+		require.NotNil(t, got.Permissions.ExternalImageView)
+		assert.True(t, got.Permissions.ExternalImageView.Granted)
+
+		count, err := store.userCol.CountDocuments(ctx, bson.M{"account": "perm-ghost"})
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), count, "ApplyUserPermissions must never create a user document")
+	})
+
+	t.Run("per-key independence: a sibling permissions field is untouched", func(t *testing.T) {
+		seed(t, "perm-sibling")
+		_, err := db.Collection("users").UpdateOne(ctx,
+			bson.M{"account": "perm-sibling"},
+			bson.M{"$set": bson.M{"permissions.somethingElse": "keep-me"}},
+		)
+		require.NoError(t, err)
+
+		require.NoError(t, store.ApplyUserPermissions(ctx, model.PermissionExternalImageView, []string{"perm-sibling"}, state))
+
+		var raw struct {
+			Permissions bson.M `bson:"permissions"`
+		}
+		require.NoError(t, db.Collection("users").FindOne(ctx, bson.M{"account": "perm-sibling"}).Decode(&raw))
+		assert.Equal(t, "keep-me", raw.Permissions["somethingElse"])
+		assert.NotNil(t, raw.Permissions["externalImageView"])
+	})
+}

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -217,6 +217,32 @@ func (s *mongoInboxStore) UpdateUserSettings(ctx context.Context, account string
 	return nil
 }
 
+// ApplyUserPermissions applies state to every listed account under the per-key watermark
+// guard. $lte, not $lt: two writes can share a millisecond, and the apply is an
+// idempotent whole-state replace, so a same-ms tie resolves to last-delivered. No
+// upsert — a missing user doc is a silent no-op; MatchedCount < len(accounts) is normal.
+func (s *mongoInboxStore) ApplyUserPermissions(ctx context.Context, permission model.PermissionKey, accounts []string, state model.PermissionState) error {
+	if len(accounts) == 0 {
+		return nil
+	}
+	field, ok := model.PermissionFieldName(permission)
+	if !ok {
+		return fmt.Errorf("apply user permissions: unknown permission %q", permission)
+	}
+	path := "permissions." + field
+	filter := bson.M{
+		"account": bson.M{"$in": accounts},
+		"$or": bson.A{
+			bson.M{path + ".updatedAt": bson.M{"$exists": false}},
+			bson.M{path + ".updatedAt": bson.M{"$lte": state.UpdatedAt}},
+		},
+	}
+	if _, err := s.userCol.UpdateMany(ctx, filter, bson.M{"$set": bson.M{path: state}}); err != nil {
+		return fmt.Errorf("update user permissions: %w", err)
+	}
+	return nil
+}
+
 // UpdateUserChatlist replaces the local users doc's chatlist sub-document with the origin
 // site's full post-update state — whole-object, so a removed section is removed here too.
 // A missing user (no doc on this site) is a silent no-op. updatedAt is unix-millis

--- a/inbox-worker/mock_store_test.go
+++ b/inbox-worker/mock_store_test.go
@@ -84,6 +84,20 @@ func (mr *MockInboxStoreMockRecorder) ApplyThreadReadAll(ctx, account, lastSeenA
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyThreadReadAll", reflect.TypeOf((*MockInboxStore)(nil).ApplyThreadReadAll), ctx, account, lastSeenAt)
 }
 
+// ApplyUserPermissions mocks base method.
+func (m *MockInboxStore) ApplyUserPermissions(ctx context.Context, permission model.PermissionKey, accounts []string, state model.PermissionState) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyUserPermissions", ctx, permission, accounts, state)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyUserPermissions indicates an expected call of ApplyUserPermissions.
+func (mr *MockInboxStoreMockRecorder) ApplyUserPermissions(ctx, permission, accounts, state any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyUserPermissions", reflect.TypeOf((*MockInboxStore)(nil).ApplyUserPermissions), ctx, permission, accounts, state)
+}
+
 // BulkCreateSubscriptions mocks base method.
 func (m *MockInboxStore) BulkCreateSubscriptions(ctx context.Context, subs []*model.Subscription) error {
 	m.ctrl.T.Helper()

--- a/pkg/errcode/codes_permission.go
+++ b/pkg/errcode/codes_permission.go
@@ -1,0 +1,13 @@
+package errcode
+
+// Permission-domain reason constants; wire values are unprefixed (house style: RoomUserNotFound = "user_not_found").
+const (
+	PermissionUnknownKey       Reason = "unknown_permission"
+	PermissionInvalidSubjects  Reason = "invalid_subject_count"
+	PermissionInvalidReason    Reason = "invalid_reason"
+	PermissionMissingFields    Reason = "missing_permission_fields"
+	PermissionInvalidWindow    Reason = "invalid_permission_window"
+	PermissionUnexpectedWindow Reason = "unexpected_permission_window"
+	PermissionInactiveSubject  Reason = "inactive_subject"
+	PermissionUnknownAccounts  Reason = "unknown_accounts"
+)

--- a/pkg/errcode/codes_test.go
+++ b/pkg/errcode/codes_test.go
@@ -21,6 +21,9 @@ var allReasons = []Reason{
 	RequestIDRequired,
 	EmojiShortcodeReserved,
 	EmojiDeleteDisabled,
+	PermissionUnknownKey, PermissionInvalidSubjects, PermissionInvalidReason,
+	PermissionMissingFields, PermissionInvalidWindow, PermissionUnexpectedWindow,
+	PermissionInactiveSubject, PermissionUnknownAccounts,
 }
 
 func TestReasons_SnakeCase(t *testing.T) {

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -167,6 +167,7 @@ const (
 	InboxRoomRestricted              InboxEventType = "room_restricted"
 	InboxUserStatusUpdated           InboxEventType = "user_status_updated"
 	InboxUserSettingsUpdated         InboxEventType = "user_settings_updated"
+	InboxUserPermissionsUpdated      InboxEventType = "user_permissions_updated"
 	InboxUserChatlistUpdated         InboxEventType = "user_chatlist_updated"
 	InboxSubscriptionSectionMoved    InboxEventType = "subscription_section_moved"
 )
@@ -177,6 +178,17 @@ type UserSettingsUpdated struct {
 	Account   string       `json:"account"   bson:"account"`
 	Settings  UserSettings `json:"settings"  bson:"settings"`
 	Timestamp int64        `json:"timestamp" bson:"timestamp"`
+}
+
+// UserPermissionsUpdated is the cross-site inbox event admin-service publishes after a
+// permission grant/revoke batch. One event carries one chunk of the batch: every account
+// in Accounts receives the same State. Receivers apply it under the per-key watermark
+// guard (State.UpdatedAt), so duplicated or reordered delivery is safe.
+type UserPermissionsUpdated struct {
+	Permission PermissionKey   `json:"permission" bson:"permission"`
+	Accounts   []string        `json:"accounts"   bson:"accounts"` // ≤ fanoutChunkSize per event
+	State      PermissionState `json:"state"      bson:"state"`
+	Timestamp  int64           `json:"timestamp"  bson:"timestamp"`
 }
 
 // SubscriptionReadEvent is InboxEvent.Payload for "subscription_read": sent room-home→user-home

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestUserJSON(t *testing.T) {
+	from := time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 9, 13, 0, 0, 0, 0, time.UTC)
 	u := model.User{
 		ID:          "u1",
 		Account:     "alice",
@@ -25,8 +27,78 @@ func TestUserJSON(t *testing.T) {
 		EngName:     "Alice Wang",
 		ChineseName: "愛麗絲",
 		EmployeeID:  "EMP001",
+		Permissions: &model.UserPermissions{
+			ExternalImageView: &model.PermissionState{
+				Granted:       true,
+				EffectiveFrom: &from,
+				ExpiresAt:     &until,
+				UpdatedAt:     time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC),
+			},
+		},
 	}
 	roundTrip(t, &u, &model.User{})
+}
+
+func TestPermissionGrantJSON(t *testing.T) {
+	from := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	g := model.PermissionGrant{
+		ID:               "0199f2c3a4b5701e8f2a4c6e9b1d3f00",
+		Permission:       model.PermissionExternalImageView,
+		SubjectAccount:   "alice",
+		Granted:          true,
+		EffectiveFrom:    &from,
+		ExpiresAt:        &until,
+		ApplicantAccount: "carol",
+		ApproverAccount:  "dave",
+		Reason:           "On-call staff must review production line photos from outside the fab.",
+		RecordedBy:       "p_admin_wang",
+		RecordedAt:       time.Date(2026, 8, 11, 3, 0, 0, 0, time.UTC),
+	}
+	roundTrip(t, &g, &model.PermissionGrant{})
+}
+
+func TestPermissionGrantRevokeJSON(t *testing.T) {
+	g := model.PermissionGrant{
+		ID:               "0199f2c3a4b6802f9a3b5d7fac2e4011",
+		Permission:       model.PermissionExternalImageView,
+		SubjectAccount:   "alice",
+		Granted:          false,
+		EffectiveFrom:    nil,
+		ExpiresAt:        nil,
+		ApplicantAccount: "carol",
+		ApproverAccount:  "dave",
+		Reason:           "Project ended.",
+		RecordedBy:       "p_admin_wang",
+		RecordedAt:       time.Date(2026, 8, 11, 3, 5, 0, 0, time.UTC),
+	}
+	roundTrip(t, &g, &model.PermissionGrant{})
+}
+
+func TestPermissionStateJSON(t *testing.T) {
+	from := time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 9, 13, 0, 0, 0, 0, time.UTC)
+	ps := model.PermissionState{
+		Granted:       true,
+		EffectiveFrom: &from,
+		ExpiresAt:     &until,
+		UpdatedAt:     time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC),
+	}
+	roundTrip(t, &ps, &model.PermissionState{})
+}
+
+func TestUserPermissionsJSON(t *testing.T) {
+	from := time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 9, 13, 0, 0, 0, 0, time.UTC)
+	up := model.UserPermissions{
+		ExternalImageView: &model.PermissionState{
+			Granted:       true,
+			EffectiveFrom: &from,
+			ExpiresAt:     &until,
+			UpdatedAt:     time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC),
+		},
+	}
+	roundTrip(t, &up, &model.UserPermissions{})
 }
 
 func TestUserJSON_WithSectAndDept(t *testing.T) {
@@ -4667,6 +4739,24 @@ func TestUserSettingsUpdated_UnsetSettingsOmittedFromJSON(t *testing.T) {
 	require.True(t, ok)
 	_, present := settings["fullWidth"]
 	assert.False(t, present, "an unset setting must be omitted, so absent keeps meaning client-default")
+}
+
+func TestUserPermissionsUpdatedJSON(t *testing.T) {
+	from := time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 9, 13, 0, 0, 0, 0, time.UTC)
+	src := model.UserPermissionsUpdated{
+		Permission: model.PermissionExternalImageView,
+		Accounts:   []string{"alice", "bob"},
+		State: model.PermissionState{
+			Granted:       true,
+			EffectiveFrom: &from,
+			ExpiresAt:     &until,
+			UpdatedAt:     time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC),
+		},
+		Timestamp: 1735689600000,
+	}
+	dst := model.UserPermissionsUpdated{}
+	roundTrip(t, &src, &dst)
 }
 
 func TestUserStatusUpdated_StatusIsShowOmittedWhenNil(t *testing.T) {

--- a/pkg/model/permission.go
+++ b/pkg/model/permission.go
@@ -1,0 +1,97 @@
+package model
+
+import "time"
+
+// PermissionKey identifies a whitelist permission.
+type PermissionKey string
+
+// PermissionExternalImageView gates viewing images from outside the corporate network.
+const PermissionExternalImageView PermissionKey = "external.image.view"
+
+const MaxReasonRunes = 1000
+
+// KnownPermission reports whether k is a recognized permission key. Derived from
+// PermissionFieldName so the closed set is declared in exactly one place.
+func KnownPermission(k PermissionKey) bool {
+	_, ok := PermissionFieldName(k)
+	return ok
+}
+
+// PermissionGrant is one row in the permission_grants append-only ledger:
+// insert-only, never updated or deleted. It is provenance only — the current
+// decision is the PermissionState materialized on the user document.
+type PermissionGrant struct {
+	ID               string        `json:"id"                      bson:"_id"`
+	Permission       PermissionKey `json:"permission"              bson:"permission"`
+	SubjectAccount   string        `json:"subjectAccount"          bson:"subjectAccount"`
+	Granted          bool          `json:"granted"                 bson:"granted"`
+	EffectiveFrom    *time.Time    `json:"effectiveFrom,omitempty" bson:"effectiveFrom,omitempty"`
+	ExpiresAt        *time.Time    `json:"expiresAt,omitempty"     bson:"expiresAt,omitempty"`
+	ApplicantAccount string        `json:"applicantAccount"        bson:"applicantAccount"`
+	ApproverAccount  string        `json:"approverAccount"         bson:"approverAccount"`
+	Reason           string        `json:"reason"                  bson:"reason"`
+	RecordedBy       string        `json:"recordedBy"              bson:"recordedBy"`
+	RecordedAt       time.Time     `json:"recordedAt"              bson:"recordedAt"`
+}
+
+// PermissionState is the latest admin decision for one permission key, materialized on
+// the user document and replicated to every site. UpdatedAt is the write's RecordedAt
+// and doubles as the per-key last-write-wins watermark.
+type PermissionState struct {
+	Granted       bool       `json:"granted"                 bson:"granted"`
+	EffectiveFrom *time.Time `json:"effectiveFrom,omitempty" bson:"effectiveFrom,omitempty"`
+	ExpiresAt     *time.Time `json:"expiresAt,omitempty"     bson:"expiresAt,omitempty"`
+	UpdatedAt     time.Time  `json:"updatedAt"               bson:"updatedAt"`
+}
+
+// Evaluate reports whether the permission is effective at now. A nil state, a revoked
+// state, or a grant missing either bound (malformed data) is false — deny, never panic.
+// now == EffectiveFrom is inside the window; now == ExpiresAt is outside (half-open).
+func (s *PermissionState) Evaluate(now time.Time) bool {
+	if s == nil || !s.Granted {
+		return false
+	}
+	if s.EffectiveFrom == nil || s.ExpiresAt == nil {
+		return false
+	}
+	return !now.Before(*s.EffectiveFrom) && now.Before(*s.ExpiresAt)
+}
+
+// UserPermissions is the admin-managed permission snapshot on the user document — one
+// named field per known PermissionKey. Deliberately a struct, not a map: the key
+// "external.image.view" contains dots, and MongoDB dot-path updates cannot address map
+// keys containing dots.
+type UserPermissions struct {
+	ExternalImageView *PermissionState `json:"externalImageView,omitempty" bson:"externalImageView,omitempty"`
+}
+
+// Evaluated returns the evaluated boolean for every known permission key. Nil-receiver
+// safe: no snapshot means every key is false. settings.get and the admin GET's
+// currentlyGranted both call this, so the entry points cannot disagree.
+func (p *UserPermissions) Evaluated(now time.Time) map[PermissionKey]bool {
+	return map[PermissionKey]bool{
+		PermissionExternalImageView: p.State(PermissionExternalImageView).Evaluate(now),
+	}
+}
+
+// State returns the stored state for the given key, nil when absent or unknown.
+func (p *UserPermissions) State(k PermissionKey) *PermissionState {
+	if p == nil {
+		return nil
+	}
+	if k == PermissionExternalImageView {
+		return p.ExternalImageView
+	}
+	return nil
+}
+
+// PermissionFieldName maps a PermissionKey to its bson field name inside the
+// `permissions` sub-document ("external.image.view" → "externalImageView"); false for
+// unknown keys. The two guarded-update sites (admin-service store, inbox-worker store)
+// build their `permissions.<field>` dot-paths from this.
+func PermissionFieldName(k PermissionKey) (string, bool) {
+	if k == PermissionExternalImageView {
+		return "externalImageView", true
+	}
+	return "", false
+}

--- a/pkg/model/permission_test.go
+++ b/pkg/model/permission_test.go
@@ -1,0 +1,90 @@
+package model_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hmchangw/chat/pkg/model"
+)
+
+func TestKnownPermission(t *testing.T) {
+	tests := []struct {
+		name string
+		key  model.PermissionKey
+		want bool
+	}{
+		{"known key is recognized", model.PermissionExternalImageView, true},
+		{"unknown key is not recognized", model.PermissionKey("external.video.view"), false},
+		{"empty key is not recognized", model.PermissionKey(""), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, model.KnownPermission(tt.key))
+		})
+	}
+}
+
+func TestPermissionState_Evaluate(t *testing.T) {
+	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+	before := now.Add(-time.Hour)
+	after := now.Add(time.Hour)
+	cases := []struct {
+		name  string
+		state *model.PermissionState
+		want  bool
+	}{
+		{"nil state", nil, false},
+		{"revoked", &model.PermissionState{Granted: false, UpdatedAt: now}, false},
+		{"granted but nil bounds fails closed", &model.PermissionState{Granted: true, UpdatedAt: now}, false},
+		{"granted but nil expiresAt fails closed", &model.PermissionState{Granted: true, EffectiveFrom: &before, UpdatedAt: now}, false},
+		{"granted but nil effectiveFrom fails closed", &model.PermissionState{Granted: true, ExpiresAt: &after, UpdatedAt: now}, false},
+		{"inside window", &model.PermissionState{Granted: true, EffectiveFrom: &before, ExpiresAt: &after, UpdatedAt: now}, true},
+		{"now == effectiveFrom is inside (closed start)", &model.PermissionState{Granted: true, EffectiveFrom: &now, ExpiresAt: &after, UpdatedAt: now}, true},
+		{"now == expiresAt is outside (open end)", &model.PermissionState{Granted: true, EffectiveFrom: &before, ExpiresAt: &now, UpdatedAt: now}, false},
+		{"not yet effective", &model.PermissionState{Granted: true, EffectiveFrom: &after, ExpiresAt: &after, UpdatedAt: now}, false},
+		{"expired", &model.PermissionState{Granted: true, EffectiveFrom: &before, ExpiresAt: &before, UpdatedAt: now}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.state.Evaluate(now))
+		})
+	}
+}
+
+func TestUserPermissions_Evaluated(t *testing.T) {
+	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+	before, after := now.Add(-time.Hour), now.Add(time.Hour)
+
+	t.Run("nil receiver yields every known key false", func(t *testing.T) {
+		var p *model.UserPermissions
+		assert.Equal(t, map[model.PermissionKey]bool{model.PermissionExternalImageView: false}, p.Evaluated(now))
+	})
+	t.Run("active grant evaluates true", func(t *testing.T) {
+		p := &model.UserPermissions{ExternalImageView: &model.PermissionState{Granted: true, EffectiveFrom: &before, ExpiresAt: &after, UpdatedAt: now}}
+		assert.True(t, p.Evaluated(now)[model.PermissionExternalImageView])
+	})
+	t.Run("expired grant evaluates false", func(t *testing.T) {
+		p := &model.UserPermissions{ExternalImageView: &model.PermissionState{Granted: true, EffectiveFrom: &before, ExpiresAt: &before, UpdatedAt: now}}
+		assert.False(t, p.Evaluated(now)[model.PermissionExternalImageView])
+	})
+}
+
+func TestUserPermissions_State(t *testing.T) {
+	st := &model.PermissionState{Granted: true}
+	p := &model.UserPermissions{ExternalImageView: st}
+	assert.Same(t, st, p.State(model.PermissionExternalImageView))
+	assert.Nil(t, p.State(model.PermissionKey("nope")))
+	var nilP *model.UserPermissions
+	assert.Nil(t, nilP.State(model.PermissionExternalImageView))
+}
+
+func TestPermissionFieldName(t *testing.T) {
+	f, ok := model.PermissionFieldName(model.PermissionExternalImageView)
+	assert.True(t, ok)
+	assert.Equal(t, "externalImageView", f)
+	_, ok = model.PermissionFieldName(model.PermissionKey("nope"))
+	assert.False(t, ok)
+}

--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -70,6 +70,9 @@ type User struct {
 	Services Services `json:"-" bson:"services,omitempty"`
 	// Settings is the per-user client-preferences sub-document; nil = never set.
 	Settings *UserSettings `json:"settings,omitempty" bson:"settings,omitempty"`
+	// Permissions is the admin-managed permission snapshot — a sibling of Settings so
+	// the settings whole-object replace can never touch it; nil = nothing ever recorded.
+	Permissions *UserPermissions `json:"permissions,omitempty" bson:"permissions,omitempty"`
 	// Chatlist is the per-user section-definition overlay; nil = never customized.
 	Chatlist *ChatlistState `json:"chatlist,omitempty" bson:"chatlist,omitempty"`
 }

--- a/tools/jaeger/README.md
+++ b/tools/jaeger/README.md
@@ -17,7 +17,7 @@ Jaeger UI: http://localhost:16686
 2. Run any service locally:
    ```bash
    # Example: broadcast-worker
-   NATS_URL=nats://localhost:4222 MONGO_URI=mongodb://localhost:27017 SITE_ID=site-local go run ./broadcast-worker/
+   NATS_URL=nats://localhost:4222 MONGO_URI=mongodb://localhost:27017/?directConnection=true SITE_ID=site-local go run ./broadcast-worker/
    ```
 3. Exercise the service (send messages, trigger events, etc.).
 4. Open http://localhost:16686, select the service name from the **Service** dropdown, and click **Find Traces**.

--- a/tools/seed-sample-data/main.go
+++ b/tools/seed-sample-data/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 type config struct {
-	MongoURI       string   `env:"MONGO_URI"       envDefault:"mongodb://localhost:27017"`
+	MongoURI       string   `env:"MONGO_URI"       envDefault:"mongodb://localhost:27017/?directConnection=true"`
 	MongoDB        string   `env:"MONGO_DB"        envDefault:"chat"`
 	MongoUsername  string   `env:"MONGO_USERNAME"  envDefault:""`
 	MongoPassword  string   `env:"MONGO_PASSWORD"  envDefault:""`

--- a/tools/seed-sample-data/main_test.go
+++ b/tools/seed-sample-data/main_test.go
@@ -10,7 +10,7 @@ import (
 func TestParseConfig_Defaults(t *testing.T) {
 	cfg, err := parseConfig(map[string]string{})
 	require.NoError(t, err)
-	assert.Equal(t, "mongodb://localhost:27017", cfg.MongoURI)
+	assert.Equal(t, "mongodb://localhost:27017/?directConnection=true", cfg.MongoURI)
 	assert.Equal(t, "chat", cfg.MongoDB)
 	assert.Equal(t, []string{"localhost:6379"}, cfg.ValkeyAddrs)
 	assert.Empty(t, cfg.ValkeyPassword)

--- a/user-service/models/settings.go
+++ b/user-service/models/settings.go
@@ -8,3 +8,11 @@ import "github.com/hmchangw/chat/pkg/model"
 type SettingsSetRequest struct {
 	model.UserSettings
 }
+
+// SettingsGetResponse is the settings.get reply: the user's settings plus the evaluated
+// admin-managed permissions. The permissions field is read-only on this surface — it is
+// not part of UserSettings, so settings.set structurally cannot touch it.
+type SettingsGetResponse struct {
+	model.UserSettings
+	Permissions map[model.PermissionKey]bool `json:"permissions"`
+}

--- a/user-service/mongorepo/settings_test.go
+++ b/user-service/mongorepo/settings_test.go
@@ -20,22 +20,32 @@ func ptrStr(s string) *string { return &s }
 func TestGetUserSettings_Integration(t *testing.T) {
 	r, db := newTestUserRepo(t)
 	ctx := context.Background()
+	now := time.Now().UTC()
 	seed(t, db, "users",
 		bson.M{"_id": "u-alice", "account": "alice", "active": true},
 		bson.M{"_id": "u-bob", "account": "bob", "active": true,
-			"settings": bson.M{"fullWidth": true, "translateMessageInto": "en-US"}},
+			"settings": bson.M{"fullWidth": true, "translateMessageInto": "en-US"},
+			"permissions": bson.M{"externalImageView": bson.M{
+				"granted":       true,
+				"effectiveFrom": now.Add(-time.Hour),
+				"expiresAt":     now.Add(time.Hour),
+				"updatedAt":     now.Add(-time.Hour),
+			}}},
 		bson.M{"_id": "u-ghost", "account": "ghost", "active": false,
 			"settings": bson.M{"fullWidth": true}},
 	)
 
-	t.Run("never-set settings come back nil", func(t *testing.T) {
+	// A matched user comes back non-nil with nil sub-documents when nothing was ever
+	// written — a nil user is reserved for "no active user" (the not-found signal).
+	t.Run("matched user with never-written sub-documents", func(t *testing.T) {
 		u, err := r.GetUserSettings(ctx, "alice")
 		require.NoError(t, err)
 		require.NotNil(t, u)
 		assert.Nil(t, u.Settings)
+		assert.Nil(t, u.Permissions)
 	})
 
-	t.Run("stored sub-document round-trips", func(t *testing.T) {
+	t.Run("both sub-documents round-trip in one read", func(t *testing.T) {
 		u, err := r.GetUserSettings(ctx, "bob")
 		require.NoError(t, err)
 		require.NotNil(t, u)
@@ -43,6 +53,12 @@ func TestGetUserSettings_Integration(t *testing.T) {
 		assert.Equal(t, ptrBool(true), u.Settings.FullWidth)
 		assert.Equal(t, ptrStr("en-US"), u.Settings.TranslateMessageInto)
 		assert.Nil(t, u.Settings.MuteAllNotifications)
+		require.NotNil(t, u.Permissions)
+		require.NotNil(t, u.Permissions.ExternalImageView)
+		assert.True(t, u.Permissions.ExternalImageView.Granted)
+		// Mongo truncates the stored bounds to ms — assert the evaluated decision,
+		// not the exact instants.
+		assert.True(t, u.Permissions.Evaluated(time.Now().UTC())[model.PermissionExternalImageView])
 	})
 
 	t.Run("inactive user dropped", func(t *testing.T) {

--- a/user-service/mongorepo/users.go
+++ b/user-service/mongorepo/users.go
@@ -101,11 +101,12 @@ func (r *UserRepo) GetHRInfoByAccounts(ctx context.Context, accounts []string) (
 	return out, nil
 }
 
-// GetUserSettings returns the user's stored settings sub-document (Settings is
-// nil when never set); (nil, nil) when no active user matched.
+// GetUserSettings returns the user's stored settings and admin-managed permission
+// snapshot in one read (Settings is nil when never written, Permissions is nil until
+// an admin writes one); (nil, nil) when no active user matched.
 func (r *UserRepo) GetUserSettings(ctx context.Context, account string) (*model.User, error) {
 	return r.users.FindOne(ctx, activeUserFilter(account),
-		mongoutil.WithProjection(bson.M{"_id": 0, "settings": 1}),
+		mongoutil.WithProjection(bson.M{"_id": 0, "settings": 1, "permissions": 1}),
 	)
 }
 

--- a/user-service/service/settings.go
+++ b/user-service/service/settings.go
@@ -19,9 +19,10 @@ import (
 // letter/digit subtags, leading subtag letters-only. No whitelist by design.
 var translateTagRe = regexp.MustCompile(`^[A-Za-z]+(-[A-Za-z0-9]+)*$`)
 
-// GetSettings returns exactly the stored settings sub-document; {} when never
-// set — the server never injects defaults (absent = client-defined default).
-func (s *UserService) GetSettings(c *natsrouter.Context) (*model.UserSettings, error) {
+// GetSettings returns exactly the stored settings sub-document — {} when never set, the
+// server never injects defaults (absent = client-defined default) — plus the evaluated
+// admin-managed permissions: every known key, always present; no snapshot means false.
+func (s *UserService) GetSettings(c *natsrouter.Context) (*models.SettingsGetResponse, error) {
 	account := c.Param("account")
 	c.WithLogValues("account", account)
 	u, err := s.users.GetUserSettings(c, account)
@@ -31,10 +32,14 @@ func (s *UserService) GetSettings(c *natsrouter.Context) (*model.UserSettings, e
 	if u == nil {
 		return nil, errcode.NotFound("user not found")
 	}
-	if u.Settings == nil {
-		return &model.UserSettings{}, nil
+	var settings model.UserSettings
+	if u.Settings != nil {
+		settings = *u.Settings
 	}
-	return u.Settings, nil
+	return &models.SettingsGetResponse{
+		UserSettings: settings,
+		Permissions:  u.Permissions.Evaluated(time.Now().UTC()),
+	}, nil
 }
 
 // SetSettings partially updates the caller's settings — only the fields sent

--- a/user-service/service/settings_test.go
+++ b/user-service/service/settings_test.go
@@ -31,7 +31,17 @@ func TestGetSettings_NeverSetReturnsEmptyObject(t *testing.T) {
 	require.NoError(t, err)
 	data, err := json.Marshal(resp)
 	require.NoError(t, err)
-	assert.JSONEq(t, `{}`, string(data), "never-set settings must serialize as {} — no injected defaults")
+	assert.JSONEq(t, `{"permissions":{"external.image.view":false}}`, string(data),
+		"never-set settings must serialize as {} — no injected defaults; permissions is always present")
+}
+
+// A nil user is the repo's "no active user" signal; a matched user with nothing
+// stored has nil sub-documents and must NOT read as not-found.
+func TestGetSettings_NotFound(t *testing.T) {
+	svc, _, users, _, _, _, _ := newSvc(t)
+	users.EXPECT().GetUserSettings(gomock.Any(), "ghost").Return(nil, nil)
+	_, err := svc.GetSettings(ctx("ghost", "site-a"))
+	requireCode(t, err, errcode.CodeNotFound)
 }
 
 func TestGetSettings_ReturnsStoredSubDocument(t *testing.T) {
@@ -40,14 +50,41 @@ func TestGetSettings_ReturnsStoredSubDocument(t *testing.T) {
 	users.EXPECT().GetUserSettings(gomock.Any(), "alice").Return(&model.User{Settings: stored}, nil)
 	resp, err := svc.GetSettings(ctx("alice", "site-a"))
 	require.NoError(t, err)
-	assert.Equal(t, stored, resp)
+	assert.Equal(t, *stored, resp.UserSettings)
+	data, err := json.Marshal(resp)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"fullWidth":true,"translateMessageInto":"en-US","permissions":{"external.image.view":false}}`,
+		string(data), "stored settings stay inlined at the top level, unchanged beside the new key")
 }
 
-func TestGetSettings_NotFound(t *testing.T) {
-	svc, _, users, _, _, _, _ := newSvc(t)
-	users.EXPECT().GetUserSettings(gomock.Any(), "ghost").Return(nil, nil)
-	_, err := svc.GetSettings(ctx("ghost", "site-a"))
-	requireCode(t, err, errcode.CodeNotFound)
+// Windows are evaluated at read time, so a snapshot flips without any cron.
+func TestGetSettings_EvaluatesPermissionsAtReadTime(t *testing.T) {
+	now := time.Now().UTC()
+	snapshot := func(granted bool, from, until time.Time) *model.UserPermissions {
+		return &model.UserPermissions{ExternalImageView: &model.PermissionState{
+			Granted: granted, EffectiveFrom: &from, ExpiresAt: &until, UpdatedAt: now,
+		}}
+	}
+	tests := []struct {
+		name  string
+		perms *model.UserPermissions
+		want  bool
+	}{
+		{"no snapshot", nil, false},
+		{"granted in window", snapshot(true, now.Add(-time.Hour), now.Add(time.Hour)), true},
+		{"expired", snapshot(true, now.Add(-2*time.Hour), now.Add(-time.Hour)), false},
+		{"not yet effective", snapshot(true, now.Add(time.Hour), now.Add(2*time.Hour)), false},
+		{"revoked", snapshot(false, now.Add(-time.Hour), now.Add(time.Hour)), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _, users, _, _, _, _ := newSvc(t)
+			users.EXPECT().GetUserSettings(gomock.Any(), "alice").Return(&model.User{Permissions: tt.perms}, nil)
+			resp, err := svc.GetSettings(ctx("alice", "site-a"))
+			require.NoError(t, err)
+			assert.Equal(t, map[model.PermissionKey]bool{model.PermissionExternalImageView: tt.want}, resp.Permissions)
+		})
+	}
 }
 
 func TestGetSettings_StoreError(t *testing.T) {


### PR DESCRIPTION
## Summary

End-to-end user permission whitelist (first key: `external.image.view`), administered from the admin console and enforced across sites:

- **Write path (`admin-service`)** — `POST /v1/admin/permissions` grants/revokes a permission for any number of subject accounts in one call (request caps removed; bulk paste in the console). The materialized `PermissionState` on user docs and the `permission_grants` audit ledger are written in a single Mongo transaction, then fanned out cross-site.
- **Cross-site sync** — chunked fanout (5000 accounts/chunk) published directly to each remote site's INBOX stream, destinations in parallel under one shared 5s budget; peers whose publish did not land are reported as `syncFailures` in the response (the local write has already committed).
- **Resync (`POST /v1/admin/permissions/resync`)** — idempotent re-delivery of the current materialized state (read-only: no writes, no audit entries); stored `updatedAt` is preserved so remote watermark guards no-op anything already applied.
- **Apply path (`inbox-worker`)** — applies `user_permissions_updated` events behind a per-field `updatedAt` watermark guard, so replays and out-of-order deliveries cannot regress state.
- **Read path (`user-service`)** — `settings.get` now returns evaluated permissions alongside settings; the interim `permission.get` RPC stack is removed.
- **Admin console (`admin-frontend`)** — permissions page with bulk paste (dedup + offender highlighting), typeahead account pickers with keyboard/ARIA support, audit view, and a resync flow driven by `syncFailures`.

Design spec and implementation plan are under `docs/superpowers/specs/` and `docs/superpowers/plans/` (annotated as-shipped); the client-facing contract is in `docs/client-api.md` §9.13–§9.15 and the `settings.get` section.

## Testing

- `make lint` clean; `make test` (race) green; admin-service / inbox-worker / user-service integration suites green (testcontainers).
- Frontend: 210/210 tests, typecheck, production build.
- SAST: gosec / govulncheck / semgrep (97 rules) — 0 findings.
- Live docker-local E2E: grant → Mongo txn → cross-site fanout → remote apply → watermark rejection of stale events → `settings.get` composition → full UI resync arc (`syncFailures` banner → Resend → "Sync complete.").

## Deliberately out of scope (follow-ups)

- Unify the inbox-worker `user_*` handlers' poison-message handling on `errcode.Permanent` (all four handlers together, separate PR).
- `eslint-plugin-jsx-a11y` + Modal focus-trap/aria-live sweep in admin-frontend.
- `permission_grants` retention/TTL policy (needs a product retention decision).
- Pre-existing debounce-vs-pagination race in admin list views (now fixable once, in the shared `usePagedAdminList` hook).
