### PR TITLE
feat(broadcast-worker): use DeliverNewPolicy for the fan-out durable

### DIFF
--- a/broadcast-worker/consumer_config_test.go
+++ b/broadcast-worker/consumer_config_test.go
@@ -26,7 +26,7 @@ func TestBuildConsumerConfig(t *testing.T) {
 		assert.Equal(t, 30*time.Second, cc.AckWait)
 		assert.Equal(t, 5, cc.MaxDeliver)
 		assert.Equal(t, 512, cc.MaxWaiting)
-		assert.Equal(t, jetstream.DeliverAllPolicy, cc.DeliverPolicy)
+		assert.Equal(t, jetstream.DeliverNewPolicy, cc.DeliverPolicy)
 	})
 
 	t.Run("overrides flow through", func(t *testing.T) {

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -356,9 +356,16 @@ func consumeLoop(iter messageIterator, process messageProcessor, maxWorkers int,
 
 // buildConsumerConfig returns the durable consumer config, centralized so it's unit-testable
 // without NATS; durable/filterSubject are env-driven so the binary can bind to user or bot streams.
+//
+// DeliverPolicy=New overrides the project default (All): broadcast-worker
+// only fans out to currently-connected subscribers, so replaying stream
+// history on a freshly-created durable would re-deliver stale messages to
+// live clients with no benefit. Honored only at consumer creation — an
+// existing durable keeps its cursor.
 func buildConsumerConfig(s stream.ConsumerSettings, durable, filterSubject string) jetstream.ConsumerConfig {
 	cc := stream.DurableConsumerDefaults(s)
 	cc.Durable = durable
 	cc.FilterSubject = filterSubject
+	cc.DeliverPolicy = jetstream.DeliverNewPolicy
 	return cc
 }


### PR DESCRIPTION
## Summary

Override the project-wide JetStream consumer default (`DeliverAllPolicy`) in broadcast-worker's `buildConsumerConfig`, setting `DeliverPolicy = DeliverNewPolicy` for its durable on the MESSAGES_CANONICAL stream.

broadcast-worker only fans out to currently-connected subscribers, so replaying stream history on a freshly-created durable (new deploy, new site, or a deleted-and-recreated durable) would re-deliver stale messages to live clients with no benefit. All other workers keep the `DeliverAllPolicy` default from `pkg/stream.DurableConsumerDefaults` — replay-from-start semantics are unchanged everywhere else.

## Changes

- `broadcast-worker/main.go` — `buildConsumerConfig` sets `cc.DeliverPolicy = jetstream.DeliverNewPolicy` after applying `stream.DurableConsumerDefaults`, with a comment documenting the rationale.
- `broadcast-worker/consumer_config_test.go` — `TestBuildConsumerConfig` asserts `DeliverNewPolicy` (written first, TDD red → green).

## Operational notes

- `DeliverPolicy` is honored only at consumer creation: existing `broadcast-worker` durables keep their cursor positions, and no migration or operator action is required.
- The override applies to both the user and bot bindings of the binary (durable/filter subject are env-driven through the same builder).

## Verification

- `go test -race ./broadcast-worker/ ./pkg/stream/` — pass
- `make lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRfHLaUEQiFSaGqQN5Gt3X

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRfHLaUEQiFSaGqQN5Gt3X)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New durable consumers now receive only newly published messages instead of replaying existing stream history.
  * Existing durable consumers continue processing from their current position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->