### PR TITLE
feat: add application-side NATS failure metrics

### DIFF
--- a/broadcast-worker/consumeloop_test.go
+++ b/broadcast-worker/consumeloop_test.go
@@ -10,17 +10,21 @@ import (
 	natsserver "github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/stream"
 )
 
 // plainIterAdapter adapts the standard nats.go jetstream iterator (Next returns
-// (Msg, error)) to consumeLoop's messageIterator (which expects the
-// trace-carrying (ctx, Msg, error) shape of the o11y/nats facade). The
-// production wrapper is a thin tracing layer over the same iterator; the panic
-// recovery under test is identical regardless of which one feeds the loop, and
-// the standard client's Stop() is race-safe.
+// (Msg, error)) to natsmetrics.Iterator (which expects the trace-carrying
+// (ctx, Msg, error) shape of the o11y/nats facade). The production wrapper is a
+// thin tracing layer over the same iterator; the behaviour under test is
+// identical regardless of which one feeds the loop, and the standard client's
+// Stop() is race-safe.
 type plainIterAdapter struct{ inner jetstream.MessagesContext }
 
 func (a plainIterAdapter) Next(opts ...jetstream.NextOpt) (context.Context, jetstream.Msg, error) {
@@ -33,9 +37,9 @@ func (a plainIterAdapter) Next(opts ...jetstream.NextOpt) (context.Context, jets
 
 // startEmbeddedCanonicalConsumer spins up an in-process JetStream server (no
 // Docker) with the MESSAGES-CANONICAL stream and a broadcast-worker-style
-// durable consumer, returning the JetStream handle, a consumeLoop-compatible
-// iterator, and the subject to publish canonical messages on.
-func startEmbeddedCanonicalConsumer(t *testing.T, siteID string) (jetstream.JetStream, messageIterator, string) {
+// durable consumer, returning the JetStream handle, the iterator, the subject
+// to publish canonical messages on, and the durable's MaxDeliver.
+func startEmbeddedCanonicalConsumer(t *testing.T, siteID string) (jetstream.JetStream, natsmetrics.Iterator, string, int) {
 	t.Helper()
 	opts := &natsserver.Options{Port: -1, JetStream: true, StoreDir: t.TempDir()}
 	ns, err := natsserver.NewServer(opts)
@@ -58,12 +62,13 @@ func startEmbeddedCanonicalConsumer(t *testing.T, siteID string) (jetstream.JetS
 	// Short AckWait so a message that is NOT acked (left pending or Nak'd)
 	// visibly redelivers within the test window. jobguard Acks the poison
 	// message, so it must NOT redeliver.
-	cc := buildConsumerConfig(stream.ConsumerSettings{
+	settings := stream.ConsumerSettings{
 		AckWait:       time.Second,
 		MaxDeliver:    10,
 		MaxWaiting:    512,
 		MaxAckPending: 1000,
-	}, "broadcast-worker", sc.Subjects[0])
+	}
+	cc := buildConsumerConfig(settings, "broadcast-worker", sc.Subjects[0])
 	cons, err := js.CreateOrUpdateConsumer(context.Background(), sc.Name, cc)
 	require.NoError(t, err)
 
@@ -71,19 +76,18 @@ func startEmbeddedCanonicalConsumer(t *testing.T, siteID string) (jetstream.JetS
 	require.NoError(t, err)
 	t.Cleanup(iter.Stop)
 
-	return js, plainIterAdapter{inner: iter}, "chat.msg.canonical." + siteID + ".created"
+	return js, plainIterAdapter{inner: iter}, "chat.msg.canonical." + siteID + ".created", settings.MaxDeliver
 }
 
-// TestConsumeLoop_PoisonMessageDoesNotBlockStream is the regression test for the
-// missing panic recovery. A handler panic on the first ("poison") message must
-// not crash the worker or wedge the consumer: a good message published behind it
-// must still be processed, and the poison message must be Acked (poison drop)
-// rather than redelivered — a redelivery loop is what crash-loops a real worker.
-//
-// Run against the pre-fix loop (process invoked without jobguard.Run), the panic
-// terminates the test binary — that is the "before" failure this test guards.
-func TestConsumeLoop_PoisonMessageDoesNotBlockStream(t *testing.T) {
-	js, iter, subj := startEmbeddedCanonicalConsumer(t, "site-test")
+// TestConsume_PoisonMessageDoesNotBlockStream is the regression test for the
+// missing panic recovery, driven through the production composition
+// (natsmetrics.Consume + guardedProcessor). A handler panic on the first
+// ("poison") message must not crash the worker or wedge the consumer: a good
+// message published behind it must still be processed, and the poison message
+// must be Acked (poison drop) rather than redelivered — a redelivery loop is
+// what crash-loops a real worker.
+func TestConsume_PoisonMessageDoesNotBlockStream(t *testing.T) {
+	js, iter, subj, maxDeliver := startEmbeddedCanonicalConsumer(t, "site-test")
 
 	var poisonCalls atomic.Int32
 	good := make(chan struct{}, 1)
@@ -91,8 +95,8 @@ func TestConsumeLoop_PoisonMessageDoesNotBlockStream(t *testing.T) {
 	// process panics on the poison message (standing in for a handler panic such
 	// as an errcode option misuse or a nil deref) and signals on the good one.
 	// It never reaches Ack on the poison path — jobguard must recover and Ack it.
-	// No require/t.Fatal here: this runs on a consumeLoop goroutine, where
-	// FailNow is illegal.
+	// No require/t.Fatal here: this runs on a Consume goroutine, where FailNow
+	// is illegal.
 	process := func(_ context.Context, msg jetstream.Msg) {
 		if string(msg.Data()) == "poison" {
 			poisonCalls.Add(1)
@@ -105,8 +109,17 @@ func TestConsumeLoop_PoisonMessageDoesNotBlockStream(t *testing.T) {
 		}
 	}
 
+	m, _ := newTestBroadcastMetrics(t)
+	consumer := m.Consumer(natsmetrics.ConsumerConfig{
+		ServiceName: "broadcast-worker", Site: "site-test",
+		Stream: "MESSAGES-CANONICAL-site-test", Consumer: "broadcast-worker",
+	})
+	consumer.LoopStarted(context.Background())
+
 	var wg sync.WaitGroup
-	go consumeLoop(iter, process, 4, &wg)
+	go natsmetrics.Consume(context.Background(), iter, consumer, 4, maxDeliver, &wg,
+		func(msg jetstream.Msg) natsmetrics.EventType { return natsmetrics.EventTypeFromSubject(msg.Subject()) },
+		guardedProcessor(process))
 
 	// Poison FIRST, good behind it.
 	_, err := js.Publish(context.Background(), subj, []byte("poison"))
@@ -125,4 +138,150 @@ func TestConsumeLoop_PoisonMessageDoesNotBlockStream(t *testing.T) {
 	require.Never(t, func() bool { return poisonCalls.Load() > 1 }, 3*time.Second, 200*time.Millisecond,
 		"poison message was redelivered — it was not Acked as a poison drop, which crash-loops a real worker")
 	require.Equal(t, int32(1), poisonCalls.Load(), "poison handler must run exactly once")
+}
+
+func newTestBroadcastMetrics(t *testing.T) (*natsmetrics.Metrics, sdkmetric.Reader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	return natsmetrics.NewFromProvider(mp), reader
+}
+
+// TestConsume_MetricsAgainstRealJetStream is the metrics contract's integration
+// check: run real deliveries through a real durable and assert the exact
+// counter deltas, the loop gauge, and that no identifier leaked into a label.
+func TestConsume_MetricsAgainstRealJetStream(t *testing.T) {
+	js, iter, subj, maxDeliver := startEmbeddedCanonicalConsumer(t, "site-metrics")
+	m, reader := newTestBroadcastMetrics(t)
+	consumer := m.Consumer(natsmetrics.ConsumerConfig{
+		ServiceName: "broadcast-worker", Site: "site-metrics",
+		Stream: "MESSAGES-CANONICAL-site-metrics", Consumer: "broadcast-worker",
+	})
+	consumer.LoopStarted(context.Background())
+
+	redelivered := make(chan struct{}, 1)
+	acked := make(chan struct{}, 2)
+	var naks atomic.Int32
+
+	process := func(_ context.Context, msg *natsmetrics.Message) {
+		switch string(msg.Data()) {
+		case "ok":
+			_ = msg.Ack()
+			acked <- struct{}{}
+		case "transient":
+			// Nak once, then Ack on the redelivery so the run terminates.
+			if naks.Add(1) == 1 {
+				_ = msg.Nak()
+				return
+			}
+			_ = msg.Ack()
+			select {
+			case redelivered <- struct{}{}:
+			default:
+			}
+			acked <- struct{}{}
+		case "poison":
+			msg.MarkTerminal(context.Background(), natsmetrics.TerminalInvalidPayload)
+			_ = msg.Ack()
+			acked <- struct{}{}
+		}
+	}
+
+	var wg sync.WaitGroup
+	go natsmetrics.Consume(context.Background(), iter, consumer, 4, maxDeliver, &wg,
+		func(msg jetstream.Msg) natsmetrics.EventType { return natsmetrics.EventTypeFromSubject(msg.Subject()) },
+		process)
+
+	for _, body := range []string{"ok", "transient", "poison"} {
+		_, err := js.Publish(context.Background(), subj, []byte(body))
+		require.NoError(t, err)
+	}
+
+	// Three Acks total: ok, poison, and transient after its redelivery.
+	for range 3 {
+		select {
+		case <-acked:
+		case <-time.After(15 * time.Second):
+			t.Fatal("timed out waiting for deliveries to settle")
+		}
+	}
+	select {
+	case <-redelivered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("transient message never redelivered")
+	}
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	assert.Equal(t, int64(1), sumOf(t, rm, "chat.nats.consumer.loop.up", nil), "loop must be up")
+	assert.Equal(t, int64(3), sumOf(t, rm, "chat.nats.consumer.messages", map[string]string{"outcome": "ack", "event_type": "created"}))
+	assert.Equal(t, int64(1), sumOf(t, rm, "chat.nats.consumer.messages", map[string]string{"outcome": "nak", "event_type": "created"}))
+	assert.Equal(t, int64(1), sumOf(t, rm, "chat.nats.consumer.redeliveries", map[string]string{"event_type": "created"}))
+	assert.Equal(t, int64(1), sumOf(t, rm, "chat.nats.terminal.failures", map[string]string{"reason": "invalid_payload"}))
+
+	// The stream, subject and site carry a site id and a message body, but no
+	// message id, room id, account or subject may reach a label.
+	allowed := map[string]bool{
+		"service_name": true, "site": true, "stream": true,
+		"consumer": true, "event_type": true, "outcome": true, "reason": true,
+	}
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			for _, key := range attributeKeys(metric) {
+				assert.True(t, allowed[key], "unexpected label %q on %s", key, metric.Name)
+			}
+		}
+	}
+}
+
+func attributeKeys(m metricdata.Metrics) []string {
+	var keys []string
+	switch data := m.Data.(type) {
+	case metricdata.Sum[int64]:
+		for _, dp := range data.DataPoints {
+			for _, kv := range dp.Attributes.ToSlice() {
+				keys = append(keys, string(kv.Key))
+			}
+		}
+	case metricdata.Histogram[float64]:
+		for _, dp := range data.DataPoints {
+			for _, kv := range dp.Attributes.ToSlice() {
+				keys = append(keys, string(kv.Key))
+			}
+		}
+	}
+	return keys
+}
+
+// sumOf totals every data point of name whose attributes contain want.
+func sumOf(t *testing.T, rm metricdata.ResourceMetrics, name string, want map[string]string) int64 {
+	t.Helper()
+	var total int64
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			require.True(t, ok, name)
+			for _, dp := range sum.DataPoints {
+				got := map[string]string{}
+				for _, kv := range dp.Attributes.ToSlice() {
+					got[string(kv.Key)] = kv.Value.AsString()
+				}
+				matches := true
+				for k, v := range want {
+					if got[k] != v {
+						matches = false
+						break
+					}
+				}
+				if matches {
+					total += dp.Value
+				}
+			}
+		}
+	}
+	return total
 }

--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -73,18 +73,34 @@ type Handler struct {
 	metrics       *broadcastMetrics
 }
 
-func NewHandler(store Store, userStore userstore.UserStore, pub Publisher, keyStore RoomKeyProvider, parentFetcher ParentFetcher, encrypt bool, routeMode subject.RoomRouteMode) *Handler {
-	metrics := newBroadcastMetrics(otel.Meter("broadcast-worker"))
+type handlerOption func(*handlerOptions)
+
+type handlerOptions struct {
+	metrics *broadcastMetrics
+}
+
+func withBroadcastMetrics(metrics *broadcastMetrics) handlerOption {
+	return func(opts *handlerOptions) { opts.metrics = metrics }
+}
+
+func NewHandler(store Store, userStore userstore.UserStore, pub Publisher, keyStore RoomKeyProvider, parentFetcher ParentFetcher, encrypt bool, routeMode subject.RoomRouteMode, options ...handlerOption) *Handler {
+	var opts handlerOptions
+	for _, option := range options {
+		option(&opts)
+	}
+	if opts.metrics == nil {
+		opts.metrics = newBroadcastMetrics(otel.Meter("broadcast-worker"))
+	}
 	return &Handler{
 		store:         store,
 		userStore:     userStore,
-		pub:           &broadcastMetricPublisher{next: pub, metrics: metrics},
+		pub:           &broadcastMetricPublisher{next: pub, metrics: opts.metrics},
 		keyStore:      keyStore,
 		parentFetcher: parentFetcher,
 		encrypt:       encrypt,
 		encoder:       roomcrypto.NewEncoder(),
 		routeMode:     routeMode,
-		metrics:       metrics,
+		metrics:       opts.metrics,
 	}
 }
 

--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -98,7 +98,7 @@ func (h *Handler) HandleMessage(ctx context.Context, data []byte) error {
 		return errcode.Permanent(errcode.BadRequest("malformed message event"))
 	}
 	ctx = obs.ContextWithIdentity(ctx, evt.Message.UserAccount, evt.Message.RoomID, evt.SiteID)
-	ctx = withBroadcastMetricLabels(ctx, "unknown", string(evt.Event))
+	ctx = withBroadcastMetricLabels(ctx, roomUnknown, natsmetrics.EventType(evt.Event))
 
 	switch evt.Event {
 	case model.EventCreated:
@@ -700,6 +700,10 @@ func (h *Handler) publishMutation(ctx context.Context, room *model.Room, roomEvt
 
 	switch room.Type {
 	case model.RoomTypeChannel:
+		// Record the intended audience here too: publishChannelEvent does it for
+		// new messages, and a mutation with no fanout sample would leave the
+		// channel lane blank for edit/delete/pin/react during a campaign.
+		h.metrics.Fanout(ctx, roomChannel, labels.eventType, room.UserCount)
 		return h.publishRoomEvent(ctx, room.ID, room.CrossSite, room.CrossSiteAt, payload, fmt.Sprintf("%s event (message %s)", roomEvtType, messageID))
 
 	case model.RoomTypeDM, model.RoomTypeBotDM:
@@ -853,7 +857,7 @@ func (h *Handler) publishChannelEvent(ctx context.Context, meta *roommetacache.M
 	slog.Log(ctx, logctx.LevelFlow, "broadcast fan-out", "phase", "fanout",
 		"request_id", natsutil.RequestIDFromContext(ctx), "room_id", meta.ID,
 		"type", string(meta.Type), "delivery", "room-stream", "audience", meta.UserCount)
-	h.metrics.Fanout(ctx, "channel", broadcastLabels(ctx).eventType, meta.UserCount)
+	h.metrics.Fanout(ctx, roomChannel, broadcastLabels(ctx).eventType, meta.UserCount)
 	return h.publishRoomEvent(ctx, meta.ID, meta.CrossSite, meta.CrossSiteAt, payload, "channel event")
 }
 
@@ -861,7 +865,7 @@ func (h *Handler) publishChannelEvent(ctx context.Context, meta *roommetacache.M
 // sanctioned path enforced by .semgrep room-subject-publish-must-route (never inline a subject).
 func (h *Handler) publishRoomEvent(ctx context.Context, roomID string, crossSite *bool, crossSiteAt *time.Time, payload []byte, op string) error {
 	labels := broadcastLabels(ctx)
-	ctx = withBroadcastMetricLabels(ctx, "channel", labels.eventType)
+	ctx = withBroadcastMetricLabels(ctx, roomChannel, labels.eventType)
 	now := time.Now().UTC()
 	var pubErr error
 	for _, subj := range subject.RoomEventTargets(roomID, crossSite, crossSiteAt, h.routeMode, now) {
@@ -998,8 +1002,8 @@ func buildClientMessage(msg *model.Message, userMap map[string]model.User) *mode
 // accounts that already received the event on the first attempt.
 func (h *Handler) publishToThreadAccounts(ctx context.Context, accounts []string, payload []byte, parentMsgID string) error {
 	labels := broadcastLabels(ctx)
-	ctx = withBroadcastMetricLabels(ctx, "thread", labels.eventType)
-	h.metrics.Fanout(ctx, "thread", labels.eventType, len(accounts))
+	ctx = withBroadcastMetricLabels(ctx, roomThread, labels.eventType)
+	h.metrics.Fanout(ctx, roomThread, labels.eventType, len(accounts))
 	if len(accounts) == 0 {
 		return nil
 	}
@@ -1033,16 +1037,16 @@ func (h *Handler) publishToThreadAccounts(ctx context.Context, accounts []string
 	return nil
 }
 
-func roomKind(roomType model.RoomType) string {
+func roomKind(roomType model.RoomType) roomKindLabel {
 	switch roomType {
 	case model.RoomTypeChannel:
-		return "channel"
+		return roomChannel
 	case model.RoomTypeDM:
-		return "dm"
+		return roomDM
 	case model.RoomTypeBotDM:
-		return "bot_dm"
+		return roomBotDM
 	default:
-		return "unknown"
+		return roomUnknown
 	}
 }
 

--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -608,6 +608,7 @@ func (h *Handler) handleReacted(ctx context.Context, evt *model.MessageEvent) er
 	msg := evt.Message
 	// Log-and-drop on malformed payloads: NAK would loop forever on a publisher contract violation.
 	if evt.ReactionDelta == nil {
+		natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalInvalidPayload)
 		slog.ErrorContext(ctx, "reacted event missing ReactionDelta; dropping",
 			"messageID", msg.ID,
 			"roomID", msg.RoomID,
@@ -617,6 +618,7 @@ func (h *Handler) handleReacted(ctx context.Context, evt *model.MessageEvent) er
 		return nil
 	}
 	if msg.UpdatedAt == nil {
+		natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalInvalidPayload)
 		slog.ErrorContext(ctx, "reacted event missing UpdatedAt; dropping",
 			"messageID", msg.ID,
 			"roomID", msg.RoomID,

--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -13,12 +13,14 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"go.opentelemetry.io/otel"
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/logctx"
 	"github.com/hmchangw/chat/pkg/mention"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/model/cassandra"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
 	"github.com/hmchangw/chat/pkg/roomcrypto"
@@ -68,18 +70,21 @@ type Handler struct {
 	encrypt       bool
 	encoder       *roomcrypto.Encoder
 	routeMode     subject.RoomRouteMode
+	metrics       *broadcastMetrics
 }
 
 func NewHandler(store Store, userStore userstore.UserStore, pub Publisher, keyStore RoomKeyProvider, parentFetcher ParentFetcher, encrypt bool, routeMode subject.RoomRouteMode) *Handler {
+	metrics := newBroadcastMetrics(otel.Meter("broadcast-worker"))
 	return &Handler{
 		store:         store,
 		userStore:     userStore,
-		pub:           pub,
+		pub:           &broadcastMetricPublisher{next: pub, metrics: metrics},
 		keyStore:      keyStore,
 		parentFetcher: parentFetcher,
 		encrypt:       encrypt,
 		encoder:       roomcrypto.NewEncoder(),
 		routeMode:     routeMode,
+		metrics:       metrics,
 	}
 }
 
@@ -87,11 +92,13 @@ func NewHandler(store Store, userStore userstore.UserStore, pub Publisher, keySt
 func (h *Handler) HandleMessage(ctx context.Context, data []byte) error {
 	var evt model.MessageEvent
 	if err := sonic.Unmarshal(data, &evt); err != nil {
+		natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalInvalidPayload)
 		// Malformed payload — it will never parse on redelivery. Mark permanent
 		// so the caller Acks (drops) it instead of retrying until MaxDeliver.
 		return errcode.Permanent(errcode.BadRequest("malformed message event"))
 	}
 	ctx = obs.ContextWithIdentity(ctx, evt.Message.UserAccount, evt.Message.RoomID, evt.SiteID)
+	ctx = withBroadcastMetricLabels(ctx, "unknown", string(evt.Event))
 
 	switch evt.Event {
 	case model.EventCreated:
@@ -464,6 +471,8 @@ func (h *Handler) handleThreadTCountUpdated(ctx context.Context, evt *model.Mess
 
 func (h *Handler) publishThreadMetadata(ctx context.Context, room *model.Room, newTcount int, newTlm *time.Time,
 	parentMsgID, replyMsgID string, action model.ThreadAction, eventTimestamp int64) error {
+	labels := broadcastLabels(ctx)
+	ctx = withBroadcastMetricLabels(ctx, roomKind(room.Type), labels.eventType)
 	evt := model.ThreadMetadataUpdatedEvent{
 		Type:               model.RoomEventThreadMetadataUpdated,
 		RoomID:             room.ID,
@@ -665,6 +674,7 @@ func (h *Handler) handleReacted(ctx context.Context, evt *model.MessageEvent) er
 			"request_id", natsutil.RequestIDFromContext(ctx),
 		)
 	} else if pubErr := h.pub.Publish(ctx, subject.Notification(authorAccount), data); pubErr != nil {
+		natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalPublishExhausted)
 		slog.ErrorContext(ctx, "publish reaction author notification failed",
 			"error", pubErr,
 			"author", authorAccount,
@@ -681,6 +691,8 @@ func (h *Handler) handleReacted(ctx context.Context, evt *model.MessageEvent) er
 // type: channel events go to the room stream, DM/botDM events fan out per
 // non-bot member. evt must marshal to the wire payload for roomEvtType.
 func (h *Handler) publishMutation(ctx context.Context, room *model.Room, roomEvtType model.RoomEventType, messageID string, evt any) error {
+	labels := broadcastLabels(ctx)
+	ctx = withBroadcastMetricLabels(ctx, roomKind(room.Type), labels.eventType)
 	payload, err := sonic.Marshal(evt)
 	if err != nil {
 		return fmt.Errorf("marshal %s event: %w", roomEvtType, err)
@@ -691,11 +703,14 @@ func (h *Handler) publishMutation(ctx context.Context, room *model.Room, roomEvt
 		return h.publishRoomEvent(ctx, room.ID, room.CrossSite, room.CrossSiteAt, payload, fmt.Sprintf("%s event (message %s)", roomEvtType, messageID))
 
 	case model.RoomTypeDM, model.RoomTypeBotDM:
+		attempted, failed := 0, 0
 		for _, account := range room.Accounts {
 			if isBot(account) {
 				continue
 			}
+			attempted++
 			if err := h.pub.Publish(ctx, subject.UserRoomEvent(account), payload); err != nil {
+				failed++
 				slog.ErrorContext(ctx, "publish DM mutation event failed",
 					"error", err,
 					"type", roomEvtType,
@@ -705,6 +720,10 @@ func (h *Handler) publishMutation(ctx context.Context, room *model.Room, roomEvt
 					"request_id", natsutil.RequestIDFromContext(ctx),
 				)
 			}
+		}
+		h.metrics.Fanout(ctx, roomKind(room.Type), labels.eventType, attempted)
+		if failed > 0 {
+			natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalPublishExhausted)
 		}
 		return nil
 
@@ -834,12 +853,15 @@ func (h *Handler) publishChannelEvent(ctx context.Context, meta *roommetacache.M
 	slog.Log(ctx, logctx.LevelFlow, "broadcast fan-out", "phase", "fanout",
 		"request_id", natsutil.RequestIDFromContext(ctx), "room_id", meta.ID,
 		"type", string(meta.Type), "delivery", "room-stream", "audience", meta.UserCount)
+	h.metrics.Fanout(ctx, "channel", broadcastLabels(ctx).eventType, meta.UserCount)
 	return h.publishRoomEvent(ctx, meta.ID, meta.CrossSite, meta.CrossSiteAt, payload, "channel event")
 }
 
 // publishRoomEvent fans a channel room's .event out via subject.RoomEventTargets — the
 // sanctioned path enforced by .semgrep room-subject-publish-must-route (never inline a subject).
 func (h *Handler) publishRoomEvent(ctx context.Context, roomID string, crossSite *bool, crossSiteAt *time.Time, payload []byte, op string) error {
+	labels := broadcastLabels(ctx)
+	ctx = withBroadcastMetricLabels(ctx, "channel", labels.eventType)
 	now := time.Now().UTC()
 	var pubErr error
 	for _, subj := range subject.RoomEventTargets(roomID, crossSite, crossSiteAt, h.routeMode, now) {
@@ -869,6 +891,8 @@ func debugTraceDelivered(ctx context.Context, account, roomID string) {
 }
 
 func (h *Handler) publishDMEvents(ctx context.Context, meta *roommetacache.Meta, clientMsg *model.ClientMessage, timestamp int64, mentionedAccounts []string, roomEventType model.RoomEventType) error {
+	labels := broadcastLabels(ctx)
+	ctx = withBroadcastMetricLabels(ctx, roomKind(meta.Type), labels.eventType)
 	subs, err := h.store.ListSubscriptions(ctx, meta.ID)
 	if err != nil {
 		return fmt.Errorf("list subscriptions for DM room %s: %w", meta.ID, err)
@@ -916,6 +940,10 @@ func (h *Handler) publishDMEvents(ctx context.Context, meta *roommetacache.Meta,
 		debugTraceDelivered(ctx, account, meta.ID)
 	}
 	debugFlowFanout(ctx, meta.ID, string(meta.Type), "per-member", recipients, failed)
+	h.metrics.Fanout(ctx, roomKind(meta.Type), labels.eventType, recipients)
+	if failed > 0 {
+		natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalPublishExhausted)
+	}
 	return nil
 }
 
@@ -969,6 +997,9 @@ func buildClientMessage(msg *model.Message, userMap map[string]model.User) *mode
 // publish fails — partial failure is tolerated to avoid duplicate delivery to
 // accounts that already received the event on the first attempt.
 func (h *Handler) publishToThreadAccounts(ctx context.Context, accounts []string, payload []byte, parentMsgID string) error {
+	labels := broadcastLabels(ctx)
+	ctx = withBroadcastMetricLabels(ctx, "thread", labels.eventType)
+	h.metrics.Fanout(ctx, "thread", labels.eventType, len(accounts))
 	if len(accounts) == 0 {
 		return nil
 	}
@@ -996,7 +1027,23 @@ func (h *Handler) publishToThreadAccounts(ctx context.Context, accounts []string
 	if failCount.Load() == int64(len(accounts)) {
 		return fmt.Errorf("all %d thread account publishes failed for parent %s", len(accounts), parentMsgID)
 	}
+	if failCount.Load() > 0 {
+		natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalPublishExhausted)
+	}
 	return nil
+}
+
+func roomKind(roomType model.RoomType) string {
+	switch roomType {
+	case model.RoomTypeChannel:
+		return "channel"
+	case model.RoomTypeDM:
+		return "dm"
+	case model.RoomTypeBotDM:
+		return "bot_dm"
+	default:
+		return "unknown"
+	}
 }
 
 // threadFanOutAccounts builds the deduplicated fan-out recipient list for a

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -10,14 +10,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.uber.org/mock/gomock"
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/model/cassandra"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/roomcrypto"
 	"github.com/hmchangw/chat/pkg/roommetacache"
 	"github.com/hmchangw/chat/pkg/subject"
@@ -1643,9 +1647,13 @@ func TestHandleReacted_MissingDelta_LogsAndDrops(t *testing.T) {
 	data, _ := json.Marshal(&evt)
 
 	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
-	err := h.HandleMessage(context.Background(), data)
+	var err error
+	terminal := terminalCountFor(t, "invalid_payload", func(ctx context.Context) {
+		err = h.HandleMessage(ctx, data)
+	})
 	require.NoError(t, err, "malformed event must be acked, not NAK-ed")
 	assert.Empty(t, pub.records)
+	assert.Equal(t, int64(1), terminal, "a permanently dropped malformed event must leave terminal evidence")
 }
 
 // TestHandleReacted_MissingUpdatedAt_LogsAndDrops mirrors the missing-
@@ -1672,9 +1680,13 @@ func TestHandleReacted_MissingUpdatedAt_LogsAndDrops(t *testing.T) {
 	data, _ := json.Marshal(&evt)
 
 	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
-	err := h.HandleMessage(context.Background(), data)
+	var err error
+	terminal := terminalCountFor(t, "invalid_payload", func(ctx context.Context) {
+		err = h.HandleMessage(ctx, data)
+	})
 	require.NoError(t, err, "malformed event must be acked, not NAK-ed")
 	assert.Empty(t, pub.records)
+	assert.Equal(t, int64(1), terminal, "a permanently dropped malformed event must leave terminal evidence")
 }
 
 // findPublishRecord returns the first record whose subject matches, or nil.
@@ -3340,4 +3352,46 @@ func TestHandleCreated_AdvanceSenderLastSeen_FailureSwallowed(t *testing.T) {
 
 	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hello", msgTime)))
+}
+
+// stubJSMsg is the minimum jetstream.Msg surface Consumer.Track needs to build
+// a tracked delivery in a unit test. The drop paths under test Ack via the
+// tracked wrapper, so the disposition methods only need to succeed.
+type stubJSMsg struct {
+	subject string
+	data    []byte
+}
+
+func (s stubJSMsg) Metadata() (*jetstream.MsgMetadata, error) {
+	return &jetstream.MsgMetadata{NumDelivered: 1}, nil
+}
+func (s stubJSMsg) Data() []byte                     { return s.data }
+func (s stubJSMsg) Headers() nats.Header             { return nats.Header{} }
+func (s stubJSMsg) Subject() string                  { return s.subject }
+func (s stubJSMsg) Reply() string                    { return "" }
+func (s stubJSMsg) Ack() error                       { return nil }
+func (s stubJSMsg) DoubleAck(context.Context) error  { return nil }
+func (s stubJSMsg) Nak() error                       { return nil }
+func (s stubJSMsg) NakWithDelay(time.Duration) error { return nil }
+func (s stubJSMsg) InProgress() error                { return nil }
+func (s stubJSMsg) Term() error                      { return nil }
+func (s stubJSMsg) TermWithReason(string) error      { return nil }
+
+// terminalCountFor runs fn under a tracked delivery and returns how many
+// terminal failures it recorded for reason. A log-and-drop path returns nil, so
+// the counter is the only evidence the message was permanently discarded.
+func terminalCountFor(t *testing.T, reason string, fn func(context.Context)) int64 {
+	t.Helper()
+	m, reader := newTestBroadcastMetrics(t)
+	consumer := m.Consumer(natsmetrics.ConsumerConfig{
+		ServiceName: "broadcast-worker", Site: "s1",
+		Stream: "MESSAGES-CANONICAL-s1", Consumer: "broadcast-worker",
+	})
+	tracked := consumer.Track(context.Background(), stubJSMsg{subject: "chat.msg.canonical.s1.created"}, natsmetrics.EventCreated, 5)
+	fn(tracked.Context(context.Background()))
+	tracked.Finish(context.Background())
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	return sumOf(t, rm, "chat.nats.terminal.failures", map[string]string{"reason": reason})
 }

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -108,6 +108,7 @@ func main() {
 	}
 	sharedMetrics := natsmetrics.NewFromProvider(sdk.MeterProvider())
 	publishMetrics := sharedMetrics.Publisher("broadcast-worker", cfg.SiteID)
+	domainMetrics := newBroadcastMetrics(sdk.MeterProvider().Meter("broadcast-worker"))
 
 	readPref, err := mongoutil.ParseReadPreference(cfg.MongoReadPreference)
 	if err != nil {
@@ -166,7 +167,7 @@ func main() {
 		keyStore = roomkeystore.NewMongoStore(roomsPrimary, cfg.RoomKeyGracePeriod)
 	}
 
-	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)
+	nc, err := natsutil.ConnectWithMetrics(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace, sdk.MeterProvider())
 	if err != nil {
 		slog.Error("nats connect failed", "error", err)
 		os.Exit(1)
@@ -223,7 +224,7 @@ func main() {
 	}
 
 	parentFetcher := newHistoryParentFetcher(nc, publishMetrics)
-	handler := NewHandler(coalescer, us, publisher, keyProvider, parentFetcher, cfg.Encryption.Enabled, roomRouteMode)
+	handler := NewHandler(coalescer, us, publisher, keyProvider, parentFetcher, cfg.Encryption.Enabled, roomRouteMode, withBroadcastMetrics(domainMetrics))
 
 	// Core-NATS queue subscriber for server-broadcast events (e.g. thread tcount badge).
 	// Fire-and-forget: errors are logged inside HandleServerBroadcast; no retry path.

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hmchangw/chat/pkg/logctx"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
 	"github.com/hmchangw/chat/pkg/roomkeystore"
@@ -105,6 +106,8 @@ func main() {
 		slog.Error("init observability failed", "error", err)
 		os.Exit(1)
 	}
+	sharedMetrics := natsmetrics.New(sdk.MeterProvider().Meter("chat.nats"))
+	publishMetrics := sharedMetrics.Publisher("broadcast-worker", cfg.SiteID)
 
 	readPref, err := mongoutil.ParseReadPreference(cfg.MongoReadPreference)
 	if err != nil {
@@ -182,13 +185,19 @@ func main() {
 		os.Exit(1)
 	}
 
-	cons, err := js.CreateOrUpdateConsumer(ctx, wiring.CanonicalStream.Name, buildConsumerConfig(cfg.Consumer, cfg.Mode.ConsumerName("broadcast-worker"), wiring.CanonicalWildcard))
+	consumerCfg := buildConsumerConfig(cfg.Consumer, cfg.Mode.ConsumerName("broadcast-worker"), wiring.CanonicalWildcard)
+	consumerMetrics := sharedMetrics.Consumer(natsmetrics.ConsumerConfig{
+		ServiceName: "broadcast-worker", Site: cfg.SiteID,
+		Stream: wiring.CanonicalStream.Name, Consumer: consumerCfg.Durable,
+	})
+	consumerMetrics.LoopStopped(ctx)
+	cons, err := js.CreateOrUpdateConsumer(ctx, wiring.CanonicalStream.Name, consumerCfg)
 	if err != nil {
 		slog.Error("create consumer failed", "error", err)
 		os.Exit(1)
 	}
 
-	publisher := &natsPublisher{nc: nc}
+	publisher := &natsPublisher{nc: nc, metrics: publishMetrics}
 	// Coalesce per-message rooms.lastMsgAt writes into periodic BulkWrites — the handler still calls
 	// UpdateRoomLastMessage; the coalescing wrapper buffers it and drains via flushCtx/Run.
 	coalescer := newCoalescingStore(cachedStore, store)
@@ -235,9 +244,15 @@ func main() {
 		slog.Error("messages failed", "error", err)
 		os.Exit(1)
 	}
+	consumerMetrics.LoopStarted(ctx)
 
 	var wg sync.WaitGroup
-	go consumeLoop(iter, broadcastProcessor(handler), cfg.MaxWorkers, &wg)
+	processor := broadcastProcessor(handler)
+	go natsmetrics.Consume(iter, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
+		classifyBroadcastDelivery,
+		func(msgCtx context.Context, msg *natsmetrics.Message) {
+			jobguard.Run(msg, func() { processor(msgCtx, msg) })
+		})
 
 	healthStop, err := health.ServeWithPprof(cfg.HealthAddr, 5*time.Second, cfg.PProfEnabled,
 		natsutil.HealthCheck(nc),
@@ -254,6 +269,7 @@ func main() {
 			return broadcastSub.Unsubscribe()
 		},
 		func(ctx context.Context) error {
+			consumerMetrics.LoopStopped(ctx)
 			iter.Stop()
 			return nil
 		},
@@ -290,11 +306,14 @@ func main() {
 
 // natsPublisher adapts *o11ynats.Conn to the Publisher interface.
 type natsPublisher struct {
-	nc *o11ynats.Conn
+	nc      *o11ynats.Conn
+	metrics natsmetrics.Publisher
 }
 
 func (p *natsPublisher) Publish(ctx context.Context, subject string, data []byte) error {
-	if err := p.nc.PublishMsg(ctx, natsutil.NewMsg(ctx, subject, data)); err != nil {
+	err := p.nc.PublishMsg(ctx, natsutil.NewMsg(ctx, subject, data))
+	p.metrics.Attempt(ctx, natsmetrics.DestinationRecipientEvent, natsmetrics.OperationRecipientPublish, err)
+	if err != nil {
 		return fmt.Errorf("publish to %q: %w", subject, err)
 	}
 	return nil
@@ -350,6 +369,9 @@ func consumeLoop(iter messageIterator, process messageProcessor, maxWorkers int,
 				wg.Done()
 			}()
 			jobguard.Run(msg, func() { process(msgCtx, msg) })
+			if tracked, ok := msg.(interface{ FinishPending(context.Context) }); ok {
+				tracked.FinishPending(msgCtx)
+			}
 		}()
 	}
 }

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -106,7 +106,7 @@ func main() {
 		slog.Error("init observability failed", "error", err)
 		os.Exit(1)
 	}
-	sharedMetrics := natsmetrics.New(sdk.MeterProvider().Meter("chat.nats"))
+	sharedMetrics := natsmetrics.NewFromProvider(sdk.MeterProvider())
 	publishMetrics := sharedMetrics.Publisher("broadcast-worker", cfg.SiteID)
 
 	readPref, err := mongoutil.ParseReadPreference(cfg.MongoReadPreference)
@@ -222,7 +222,7 @@ func main() {
 		slog.Info("room-key cache enabled", "size", cfg.RoomKeyCacheSize, "ttl", cfg.RoomKeyCacheTTL)
 	}
 
-	parentFetcher := newHistoryParentFetcher(nc)
+	parentFetcher := newHistoryParentFetcher(nc, publishMetrics)
 	handler := NewHandler(coalescer, us, publisher, keyProvider, parentFetcher, cfg.Encryption.Enabled, roomRouteMode)
 
 	// Core-NATS queue subscriber for server-broadcast events (e.g. thread tcount badge).
@@ -247,12 +247,9 @@ func main() {
 	consumerMetrics.LoopStarted(ctx)
 
 	var wg sync.WaitGroup
-	processor := broadcastProcessor(handler)
-	go natsmetrics.Consume(iter, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
-		classifyBroadcastDelivery,
-		func(msgCtx context.Context, msg *natsmetrics.Message) {
-			jobguard.Run(msg, func() { processor(msgCtx, msg) })
-		})
+	go natsmetrics.Consume(ctx, iter, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
+		func(msg jetstream.Msg) natsmetrics.EventType { return natsmetrics.EventTypeFromSubject(msg.Subject()) },
+		guardedProcessor(broadcastProcessor(handler)))
 
 	healthStop, err := health.ServeWithPprof(cfg.HealthAddr, 5*time.Second, cfg.PProfEnabled,
 		natsutil.HealthCheck(nc),
@@ -322,12 +319,6 @@ func (p *natsPublisher) Publish(ctx context.Context, subject string, data []byte
 // messageProcessor handles one consumed message, performing its own Ack/Nak.
 type messageProcessor func(msgCtx context.Context, msg jetstream.Msg)
 
-// messageIterator is the slice of o11y/nats MessagesContext that consumeLoop drives —
-// an interface so the loop is testable against a real embedded JetStream consumer.
-type messageIterator interface {
-	Next(...jetstream.NextOpt) (context.Context, jetstream.Msg, error)
-}
-
 // broadcastProcessor builds the per-message processing closure: stamp the request ID, run
 // the handler, then settle via jsretry (short first retry; malformed events Ack-drop).
 func broadcastProcessor(handler *Handler) messageProcessor {
@@ -352,27 +343,13 @@ func broadcastProcessor(handler *Handler) messageProcessor {
 	}
 }
 
-// consumeLoop drains iter under a maxWorkers-bounded semaphore, tracking in-flight handlers on wg
-// so shutdown can wait; jobguard.Run recovers handler panics to avoid an un-acked crash-loop on JetStream redelivery.
-func consumeLoop(iter messageIterator, process messageProcessor, maxWorkers int, wg *sync.WaitGroup) {
-	sem := make(chan struct{}, maxWorkers)
-	for {
-		msgCtx, msg, err := iter.Next()
-		if err != nil {
-			return
-		}
-		sem <- struct{}{}
-		wg.Add(1)
-		go func() {
-			defer func() {
-				<-sem
-				wg.Done()
-			}()
-			jobguard.Run(msg, func() { process(msgCtx, msg) })
-			if tracked, ok := msg.(interface{ FinishPending(context.Context) }); ok {
-				tracked.FinishPending(msgCtx)
-			}
-		}()
+// guardedProcessor adapts a messageProcessor to natsmetrics.Consume, keeping
+// jobguard's panic recovery in the composition so a handler panic Acks instead
+// of crash-looping on JetStream redelivery. The integration test drives this
+// exact composition rather than a parallel copy of the loop.
+func guardedProcessor(process messageProcessor) natsmetrics.ProcessMessage {
+	return func(msgCtx context.Context, msg *natsmetrics.Message) {
+		jobguard.Run(msg, func() { process(msgCtx, msg) })
 	}
 }
 

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -247,7 +247,7 @@ func main() {
 	consumerMetrics.LoopStarted(ctx)
 
 	var wg sync.WaitGroup
-	go natsmetrics.Consume(ctx, iter, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
+	natsmetrics.Start(ctx, iter, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
 		func(msg jetstream.Msg) natsmetrics.EventType { return natsmetrics.EventTypeFromSubject(msg.Subject()) },
 		guardedProcessor(broadcastProcessor(handler)))
 

--- a/broadcast-worker/nats_metrics.go
+++ b/broadcast-worker/nats_metrics.go
@@ -5,6 +5,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 
 	"github.com/hmchangw/chat/pkg/natsmetrics"
 )
@@ -59,10 +60,19 @@ type broadcastMetrics struct {
 }
 
 func newBroadcastMetrics(meter metric.Meter) *broadcastMetrics {
-	fanout, _ := meter.Int64Histogram("broadcast_worker_fanout_recipients",
+	noopMeter := noop.NewMeterProvider().Meter("broadcast-worker")
+	fanout, err := meter.Int64Histogram("broadcast_worker_fanout_recipients",
 		metric.WithDescription("Intended fan-out recipients by bounded room and event kind."))
-	deliveries, _ := meter.Int64Counter("broadcast_worker_recipient_deliveries_total",
+	if err != nil {
+		// Telemetry must never block startup: fall back to a no-op instrument so
+		// the service runs blind on this metric rather than not at all.
+		fanout, _ = noopMeter.Int64Histogram("broadcast_worker_fanout_recipients")
+	}
+	deliveries, err := meter.Int64Counter("broadcast_worker_recipient_deliveries_total",
 		metric.WithDescription("Actual Core NATS recipient publish attempts by result."))
+	if err != nil {
+		deliveries, _ = noopMeter.Int64Counter("broadcast_worker_recipient_deliveries_total")
+	}
 	m := &broadcastMetrics{
 		fanout:       fanout,
 		deliveries:   deliveries,

--- a/broadcast-worker/nats_metrics.go
+++ b/broadcast-worker/nats_metrics.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+
+	"github.com/bytedance/sonic"
+	"github.com/nats-io/nats.go/jetstream"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
+)
+
+type broadcastMetrics struct {
+	fanout     metric.Int64Histogram
+	deliveries metric.Int64Counter
+}
+
+func classifyBroadcastDelivery(msg jetstream.Msg) natsmetrics.EventType {
+	var evt struct {
+		Event model.EventType `json:"event"`
+	}
+	if err := sonic.Unmarshal(msg.Data(), &evt); err != nil {
+		return natsmetrics.EventUnknown
+	}
+	return natsmetrics.NormalizeEventType(string(evt.Event))
+}
+
+func newBroadcastMetrics(meter metric.Meter) *broadcastMetrics {
+	fanout, _ := meter.Int64Histogram("broadcast_worker_fanout_recipients",
+		metric.WithDescription("Intended fan-out recipients by bounded room and event kind."))
+	deliveries, _ := meter.Int64Counter("broadcast_worker_recipient_deliveries_total",
+		metric.WithDescription("Actual Core NATS recipient publish attempts by result."))
+	return &broadcastMetrics{fanout: fanout, deliveries: deliveries}
+}
+
+func normalizeRoomKind(value string) string {
+	switch value {
+	case "channel", "dm", "bot_dm", "thread":
+		return value
+	default:
+		return "unknown"
+	}
+}
+
+func normalizeBroadcastEvent(value string) string {
+	switch value {
+	case "created", "updated", "deleted", "pinned", "unpinned", "reacted", "thread_reply_added":
+		return value
+	default:
+		return "unknown"
+	}
+}
+
+func (m *broadcastMetrics) Fanout(ctx context.Context, roomKind, eventType string, recipients int) {
+	if m == nil || m.fanout == nil {
+		return
+	}
+	m.fanout.Record(ctx, int64(recipients), metric.WithAttributes(
+		attribute.String("room_kind", normalizeRoomKind(roomKind)),
+		attribute.String("event_type", normalizeBroadcastEvent(eventType)),
+	))
+}
+
+func (m *broadcastMetrics) Delivery(ctx context.Context, roomKind, eventType string, err error) {
+	if m == nil || m.deliveries == nil {
+		return
+	}
+	result := "success"
+	if err != nil {
+		result = "failed"
+	}
+	m.deliveries.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("room_kind", normalizeRoomKind(roomKind)),
+		attribute.String("event_type", normalizeBroadcastEvent(eventType)),
+		attribute.String("result", result),
+	))
+}
+
+type broadcastMetricLabels struct{ roomKind, eventType string }
+type broadcastMetricKey struct{}
+
+func withBroadcastMetricLabels(ctx context.Context, roomKind, eventType string) context.Context {
+	return context.WithValue(ctx, broadcastMetricKey{}, broadcastMetricLabels{normalizeRoomKind(roomKind), normalizeBroadcastEvent(eventType)})
+}
+
+func broadcastLabels(ctx context.Context) broadcastMetricLabels {
+	labels, _ := ctx.Value(broadcastMetricKey{}).(broadcastMetricLabels)
+	labels.roomKind = normalizeRoomKind(labels.roomKind)
+	labels.eventType = normalizeBroadcastEvent(labels.eventType)
+	return labels
+}
+
+type broadcastMetricPublisher struct {
+	next    Publisher
+	metrics *broadcastMetrics
+}
+
+func (p *broadcastMetricPublisher) Publish(ctx context.Context, subject string, data []byte) error {
+	err := p.next.Publish(ctx, subject, data)
+	labels := broadcastLabels(ctx)
+	p.metrics.Delivery(ctx, labels.roomKind, labels.eventType, err)
+	return err
+}

--- a/broadcast-worker/nats_metrics.go
+++ b/broadcast-worker/nats_metrics.go
@@ -3,28 +3,59 @@ package main
 import (
 	"context"
 
-	"github.com/bytedance/sonic"
-	"github.com/nats-io/nats.go/jetstream"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
-	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/natsmetrics"
 )
 
-type broadcastMetrics struct {
-	fanout     metric.Int64Histogram
-	deliveries metric.Int64Counter
+// roomKindLabel and deliveryResult are closed enums so a typo is a compile
+// error rather than a silent `unknown` series at campaign time.
+type roomKindLabel string
+
+const (
+	roomChannel roomKindLabel = "channel"
+	roomDM      roomKindLabel = "dm"
+	roomBotDM   roomKindLabel = "bot_dm"
+	roomThread  roomKindLabel = "thread"
+	roomUnknown roomKindLabel = "unknown"
+)
+
+var allRoomKinds = []roomKindLabel{roomChannel, roomDM, roomBotDM, roomThread, roomUnknown}
+
+type deliveryResult string
+
+const (
+	deliverySuccess deliveryResult = "success"
+	deliveryFailed  deliveryResult = "failed"
+)
+
+var allDeliveryResults = []deliveryResult{deliverySuccess, deliveryFailed}
+
+type fanoutKey struct {
+	room  roomKindLabel
+	event natsmetrics.EventType
 }
 
-func classifyBroadcastDelivery(msg jetstream.Msg) natsmetrics.EventType {
-	var evt struct {
-		Event model.EventType `json:"event"`
-	}
-	if err := sonic.Unmarshal(msg.Data(), &evt); err != nil {
-		return natsmetrics.EventUnknown
-	}
-	return natsmetrics.NormalizeEventType(string(evt.Event))
+type deliveryKey struct {
+	room   roomKindLabel
+	event  natsmetrics.EventType
+	result deliveryResult
+}
+
+// broadcastMetrics explains user impact for a fan-out.
+//
+// The two families answer different questions and are NOT a ratio for channel
+// rooms: a channel event is delivered by a single publish to the room stream,
+// so fanout records the intended audience (meta.UserCount) while deliveries
+// records one attempt. Per-recipient delivery evidence for channels comes from
+// the loadgen recipient observer, not from these counters. For DM, bot-DM, and
+// thread fan-out the two are directly comparable — one publish per recipient.
+type broadcastMetrics struct {
+	fanout       metric.Int64Histogram
+	deliveries   metric.Int64Counter
+	fanoutOpts   map[fanoutKey]metric.MeasurementOption
+	deliveryOpts map[deliveryKey]metric.MeasurementOption
 }
 
 func newBroadcastMetrics(meter metric.Meter) *broadcastMetrics {
@@ -32,56 +63,80 @@ func newBroadcastMetrics(meter metric.Meter) *broadcastMetrics {
 		metric.WithDescription("Intended fan-out recipients by bounded room and event kind."))
 	deliveries, _ := meter.Int64Counter("broadcast_worker_recipient_deliveries_total",
 		metric.WithDescription("Actual Core NATS recipient publish attempts by result."))
-	return &broadcastMetrics{fanout: fanout, deliveries: deliveries}
+	m := &broadcastMetrics{
+		fanout:       fanout,
+		deliveries:   deliveries,
+		fanoutOpts:   make(map[fanoutKey]metric.MeasurementOption),
+		deliveryOpts: make(map[deliveryKey]metric.MeasurementOption),
+	}
+	for _, room := range allRoomKinds {
+		roomAttr := attribute.String("room_kind", string(room))
+		for _, event := range allBroadcastEvents {
+			eventAttr := attribute.String("event_type", string(event))
+			m.fanoutOpts[fanoutKey{room, event}] = metric.WithAttributes(roomAttr, eventAttr)
+			for _, result := range allDeliveryResults {
+				m.deliveryOpts[deliveryKey{room, event, result}] = metric.WithAttributes(
+					roomAttr, eventAttr, attribute.String("result", string(result)))
+			}
+		}
+	}
+	return m
 }
 
-func normalizeRoomKind(value string) string {
+// allBroadcastEvents is the subset of the shared event vocabulary this worker
+// can observe, plus unknown for anything it cannot classify.
+var allBroadcastEvents = []natsmetrics.EventType{
+	natsmetrics.EventCreated, natsmetrics.EventUpdated, natsmetrics.EventDeleted,
+	natsmetrics.EventPinned, natsmetrics.EventUnpinned, natsmetrics.EventReacted,
+	natsmetrics.EventThreadReplyAdded, natsmetrics.EventUnknown,
+}
+
+func normalizeRoomKind(value roomKindLabel) roomKindLabel {
 	switch value {
-	case "channel", "dm", "bot_dm", "thread":
+	case roomChannel, roomDM, roomBotDM, roomThread:
 		return value
 	default:
-		return "unknown"
+		return roomUnknown
 	}
 }
 
-func normalizeBroadcastEvent(value string) string {
+func normalizeBroadcastEvent(value natsmetrics.EventType) natsmetrics.EventType {
 	switch value {
-	case "created", "updated", "deleted", "pinned", "unpinned", "reacted", "thread_reply_added":
+	case natsmetrics.EventCreated, natsmetrics.EventUpdated, natsmetrics.EventDeleted,
+		natsmetrics.EventPinned, natsmetrics.EventUnpinned, natsmetrics.EventReacted,
+		natsmetrics.EventThreadReplyAdded:
 		return value
 	default:
-		return "unknown"
+		return natsmetrics.EventUnknown
 	}
 }
 
-func (m *broadcastMetrics) Fanout(ctx context.Context, roomKind, eventType string, recipients int) {
+func (m *broadcastMetrics) Fanout(ctx context.Context, room roomKindLabel, event natsmetrics.EventType, recipients int) {
 	if m == nil || m.fanout == nil {
 		return
 	}
-	m.fanout.Record(ctx, int64(recipients), metric.WithAttributes(
-		attribute.String("room_kind", normalizeRoomKind(roomKind)),
-		attribute.String("event_type", normalizeBroadcastEvent(eventType)),
-	))
+	m.fanout.Record(ctx, int64(recipients), m.fanoutOpts[fanoutKey{normalizeRoomKind(room), normalizeBroadcastEvent(event)}])
 }
 
-func (m *broadcastMetrics) Delivery(ctx context.Context, roomKind, eventType string, err error) {
+func (m *broadcastMetrics) Delivery(ctx context.Context, room roomKindLabel, event natsmetrics.EventType, err error) {
 	if m == nil || m.deliveries == nil {
 		return
 	}
-	result := "success"
+	result := deliverySuccess
 	if err != nil {
-		result = "failed"
+		result = deliveryFailed
 	}
-	m.deliveries.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("room_kind", normalizeRoomKind(roomKind)),
-		attribute.String("event_type", normalizeBroadcastEvent(eventType)),
-		attribute.String("result", result),
-	))
+	m.deliveries.Add(ctx, 1, m.deliveryOpts[deliveryKey{normalizeRoomKind(room), normalizeBroadcastEvent(event), result}])
 }
 
-type broadcastMetricLabels struct{ roomKind, eventType string }
+type broadcastMetricLabels struct {
+	roomKind  roomKindLabel
+	eventType natsmetrics.EventType
+}
+
 type broadcastMetricKey struct{}
 
-func withBroadcastMetricLabels(ctx context.Context, roomKind, eventType string) context.Context {
+func withBroadcastMetricLabels(ctx context.Context, roomKind roomKindLabel, eventType natsmetrics.EventType) context.Context {
 	return context.WithValue(ctx, broadcastMetricKey{}, broadcastMetricLabels{normalizeRoomKind(roomKind), normalizeBroadcastEvent(eventType)})
 }
 

--- a/broadcast-worker/nats_metrics_test.go
+++ b/broadcast-worker/nats_metrics_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestBroadcastMetrics_BoundedLabels(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	m := newBroadcastMetrics(mp.Meter("test"))
+	m.Fanout(context.Background(), "dm", "created", 3)
+	m.Delivery(context.Background(), "dynamic-room", "raw-event", errors.New("secret"))
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	var fanoutCount uint64
+	var deliveries int64
+	var deliveryLabels map[string]string
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			switch metric.Name {
+			case "broadcast_worker_fanout_recipients":
+				fanoutCount = metric.Data.(metricdata.Histogram[int64]).DataPoints[0].Count
+			case "broadcast_worker_recipient_deliveries_total":
+				point := metric.Data.(metricdata.Sum[int64]).DataPoints[0]
+				deliveries = point.Value
+				deliveryLabels = map[string]string{}
+				for _, attr := range point.Attributes.ToSlice() {
+					deliveryLabels[string(attr.Key)] = attr.Value.AsString()
+				}
+			}
+		}
+	}
+	assert.Equal(t, uint64(1), fanoutCount)
+	assert.Equal(t, int64(1), deliveries)
+	assert.Equal(t, map[string]string{"room_kind": "unknown", "event_type": "unknown", "result": "failed"}, deliveryLabels)
+}

--- a/broadcast-worker/nats_metrics_test.go
+++ b/broadcast-worker/nats_metrics_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/hmchangw/chat/pkg/natsmetrics"
+	"github.com/hmchangw/chat/pkg/subject"
 )
 
 func TestBroadcastMetrics_BoundedLabels(t *testing.T) {
@@ -41,4 +44,96 @@ func TestBroadcastMetrics_BoundedLabels(t *testing.T) {
 	assert.Equal(t, uint64(1), fanoutCount)
 	assert.Equal(t, int64(1), deliveries)
 	assert.Equal(t, map[string]string{"room_kind": "unknown", "event_type": "unknown", "result": "failed"}, deliveryLabels)
+}
+
+func TestHandler_PublishToThreadAccounts_RecordsFanoutScenarios(t *testing.T) {
+	tests := []struct {
+		name           string
+		accounts       []string
+		failedAccounts []string
+		wantError      bool
+		wantFanout     int64
+		wantSuccess    int64
+		wantFailed     int64
+		wantTerminal   int64
+	}{
+		{name: "zero recipients", wantFanout: 0},
+		{name: "full success", accounts: []string{"alice", "bob"}, wantFanout: 2, wantSuccess: 2},
+		{name: "partial success", accounts: []string{"alice", "bob"}, failedAccounts: []string{"bob"}, wantFanout: 2, wantSuccess: 1, wantFailed: 1, wantTerminal: 1},
+		{name: "total failure", accounts: []string{"alice", "bob"}, failedAccounts: []string{"alice", "bob"}, wantError: true, wantFanout: 2, wantFailed: 2},
+		{name: "duplicate recipients remain separate attempts", accounts: []string{"alice", "alice"}, wantFanout: 2, wantSuccess: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := sdkmetric.NewManualReader()
+			mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+			metrics := newBroadcastMetrics(mp.Meter("test"))
+			pub := &mockPublisher{failOn: map[string]error{}}
+			for _, account := range tt.failedAccounts {
+				pub.failOn[subject.UserRoomEvent(account)] = errors.New("publish failed")
+			}
+			h := NewHandler(nil, nil, pub, nil, nil, false, subject.RouteGlobal, withBroadcastMetrics(metrics))
+			ctx := context.Background()
+			consumer := natsmetrics.New(mp.Meter("shared")).Consumer(natsmetrics.ConsumerConfig{
+				ServiceName: "broadcast-worker", Site: "site-a", Stream: "MESSAGES_CANONICAL_site-a", Consumer: "broadcast-worker",
+			})
+			consumer.LoopStarted(ctx)
+			tracked := consumer.Track(ctx, stubJSMsg{subject: "chat.msg.canonical.site-a.created"}, natsmetrics.EventCreated, 5)
+			ctx = tracked.Context(ctx)
+			ctx = withBroadcastMetricLabels(ctx, roomThread, natsmetrics.EventCreated)
+
+			err := h.publishToThreadAccounts(ctx, tt.accounts, []byte(`{"type":"test"}`), "parent-id")
+			tracked.Finish(ctx)
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			var rm metricdata.ResourceMetrics
+			require.NoError(t, reader.Collect(context.Background(), &rm))
+			var fanoutCount uint64
+			var fanoutSum int64
+			deliveries := map[string]int64{}
+			var terminal int64
+			for _, scope := range rm.ScopeMetrics {
+				for _, metric := range scope.Metrics {
+					switch metric.Name {
+					case "broadcast_worker_fanout_recipients":
+						point := metric.Data.(metricdata.Histogram[int64]).DataPoints[0]
+						fanoutCount = point.Count
+						fanoutSum = point.Sum
+					case "broadcast_worker_recipient_deliveries_total":
+						for _, point := range metric.Data.(metricdata.Sum[int64]).DataPoints {
+							for _, attr := range point.Attributes.ToSlice() {
+								if string(attr.Key) == "result" {
+									deliveries[attr.Value.AsString()] = point.Value
+								}
+							}
+						}
+					case "chat.nats.terminal.failures":
+						for _, point := range metric.Data.(metricdata.Sum[int64]).DataPoints {
+							for _, attr := range point.Attributes.ToSlice() {
+								if string(attr.Key) == "reason" && attr.Value.AsString() == "publish_exhausted" {
+									terminal += point.Value
+								}
+							}
+						}
+					}
+				}
+			}
+			assert.Equal(t, uint64(1), fanoutCount)
+			assert.Equal(t, tt.wantFanout, fanoutSum)
+			assert.Equal(t, tt.wantSuccess, deliveries["success"])
+			assert.Equal(t, tt.wantFailed, deliveries["failed"])
+			assert.Equal(t, tt.wantTerminal, terminal)
+		})
+	}
+}
+
+func TestBroadcastMetrics_Record_NilReceiverIsSafe(t *testing.T) {
+	var metrics *broadcastMetrics
+	metrics.Fanout(context.Background(), roomChannel, natsmetrics.EventCreated, 1)
+	metrics.Delivery(context.Background(), roomChannel, natsmetrics.EventCreated, nil)
 }

--- a/broadcast-worker/parent_fetcher.go
+++ b/broadcast-worker/parent_fetcher.go
@@ -8,8 +8,10 @@ import (
 	"github.com/bytedance/sonic"
 
 	o11ynats "github.com/flywindy/o11y/nats"
+	"go.opentelemetry.io/otel"
 
 	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/subject"
 )
@@ -21,11 +23,12 @@ const parentFetchTimeout = 2 * time.Second
 // history-service's GetMessageByID handler, reading the author + createdAt the
 // channel thread fan-out needs.
 type historyParentFetcher struct {
-	nc *o11ynats.Conn
+	nc      *o11ynats.Conn
+	metrics *natsmetrics.Metrics
 }
 
 func newHistoryParentFetcher(nc *o11ynats.Conn) *historyParentFetcher {
-	return &historyParentFetcher{nc: nc}
+	return &historyParentFetcher{nc: nc, metrics: natsmetrics.New(otel.Meter("chat.nats"))}
 }
 
 // getMessageByIDRequest mirrors history-service's GetMessageByIDRequest wire shape.
@@ -52,7 +55,11 @@ func (f *historyParentFetcher) FetchParent(ctx context.Context, account, roomID,
 	if err != nil {
 		return nil, fmt.Errorf("marshal GetMessageByID request: %w", err)
 	}
+	started := time.Now()
 	msg, err := f.nc.Request(ctx, subject.MsgGet(account, roomID, siteID), reqBytes, parentFetchTimeout)
+	if f.metrics != nil {
+		f.metrics.Publisher("broadcast-worker", siteID).Request(ctx, natsmetrics.OperationHistoryGetMessage, time.Since(started), err)
+	}
 	if err != nil {
 		return nil, natsutil.RequestFailure(fmt.Sprintf("history request for parent %s", messageID), err)
 	}

--- a/broadcast-worker/parent_fetcher.go
+++ b/broadcast-worker/parent_fetcher.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bytedance/sonic"
 
 	o11ynats "github.com/flywindy/o11y/nats"
-	"go.opentelemetry.io/otel"
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/natsmetrics"
@@ -23,12 +22,15 @@ const parentFetchTimeout = 2 * time.Second
 // history-service's GetMessageByID handler, reading the author + createdAt the
 // channel thread fan-out needs.
 type historyParentFetcher struct {
-	nc      *o11ynats.Conn
-	metrics *natsmetrics.Metrics
+	nc *o11ynats.Conn
+	// metrics is injected: building a second natsmetrics.Metrics here would
+	// duplicate all nine shared instruments on a different construction path.
+	// The zero value is safe and records nothing.
+	metrics natsmetrics.Publisher
 }
 
-func newHistoryParentFetcher(nc *o11ynats.Conn) *historyParentFetcher {
-	return &historyParentFetcher{nc: nc, metrics: natsmetrics.New(otel.Meter("chat.nats"))}
+func newHistoryParentFetcher(nc *o11ynats.Conn, metrics natsmetrics.Publisher) *historyParentFetcher {
+	return &historyParentFetcher{nc: nc, metrics: metrics}
 }
 
 // getMessageByIDRequest mirrors history-service's GetMessageByIDRequest wire shape.
@@ -57,9 +59,7 @@ func (f *historyParentFetcher) FetchParent(ctx context.Context, account, roomID,
 	}
 	started := time.Now()
 	msg, err := f.nc.Request(ctx, subject.MsgGet(account, roomID, siteID), reqBytes, parentFetchTimeout)
-	if f.metrics != nil {
-		f.metrics.Publisher("broadcast-worker", siteID).Request(ctx, natsmetrics.OperationHistoryGetMessage, time.Since(started), err)
-	}
+	f.metrics.Request(ctx, natsmetrics.OperationHistoryGetMessage, time.Since(started), err)
 	if err != nil {
 		return nil, natsutil.RequestFailure(fmt.Sprintf("history request for parent %s", messageID), err)
 	}

--- a/broadcast-worker/parent_fetcher_test.go
+++ b/broadcast-worker/parent_fetcher_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hmchangw/chat/pkg/natsmetrics"
+
 	o11ynats "github.com/flywindy/o11y/nats"
 	natsserver "github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
@@ -59,7 +61,7 @@ func TestHistoryParentFetcher_FetchParent(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		fetcher := newHistoryParentFetcher(nc)
+		fetcher := newHistoryParentFetcher(nc, natsmetrics.Publisher{})
 		got, err := fetcher.FetchParent(context.Background(), account, roomID, siteID, messageID)
 		require.NoError(t, err)
 		require.NotNil(t, got)
@@ -76,7 +78,7 @@ func TestHistoryParentFetcher_FetchParent(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		fetcher := newHistoryParentFetcher(nc)
+		fetcher := newHistoryParentFetcher(nc, natsmetrics.Publisher{})
 		got, err := fetcher.FetchParent(context.Background(), account, roomID, siteID, messageID)
 		require.Error(t, err)
 		assert.Nil(t, got)
@@ -89,7 +91,7 @@ func TestHistoryParentFetcher_FetchParent(t *testing.T) {
 		nc := startTestNATS(t)
 		// Intentionally no subscriber: nc.Request must fail with "no responders".
 
-		fetcher := newHistoryParentFetcher(nc)
+		fetcher := newHistoryParentFetcher(nc, natsmetrics.Publisher{})
 		got, err := fetcher.FetchParent(context.Background(), account, roomID, siteID, messageID)
 		require.Error(t, err)
 		assert.Nil(t, got)
@@ -103,7 +105,7 @@ func TestHistoryParentFetcher_FetchParent(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		fetcher := newHistoryParentFetcher(nc)
+		fetcher := newHistoryParentFetcher(nc, natsmetrics.Publisher{})
 		got, err := fetcher.FetchParent(context.Background(), account, roomID, siteID, messageID)
 		require.Error(t, err)
 		assert.Nil(t, got)

--- a/docs/specs/o11y/o11y-metrics-inventory.md
+++ b/docs/specs/o11y/o11y-metrics-inventory.md
@@ -9,7 +9,7 @@ come from **dedicated exporters** (infra, not the app SDK). Companion to
 > against the Docker Compose o11y stack (`docker-local/compose.o11y.yaml` ->
 > Prometheus `:9090`). The instrument list was re-derived from source on
 > 2026-08-14 — every OTel and client_golang instrument in the repository is
-> accounted for in §2, §2.1, and §2.2 — but that pass was static, not a rescrape.
+> accounted for in §2 through §2.3 — but that pass was static, not a rescrape.
 
 > Storage note (2026-08-11): the authoritative, code-reverified MongoDB and
 > Cassandra metric set, direct-client coverage, exporter gaps, and shared
@@ -182,13 +182,30 @@ filled in here because they were not re-verified against a running stack.
 `teams-room-creation`, `teams-room-inspector`, `teams-room-verify`,
 `teams-user-sync`, `translation-service`.
 
-One exception owns a metric: **`bot-message-worker`** exposes
-`bot_msg_worker_permanent_error_total`, but it is registered through
-`prometheus/client_golang` (`promauto`), not the OTel meter. It is therefore
-**not** on the SDK `:2112` endpoint with everything else in this document, and
-it carries none of the resource attributes the other families are joined by.
-This is the only non-OTel application metric in the repository; converting it to
-the shared meter would put it on the same endpoint and label scheme.
+### 2.3 Metrics registered outside the OTel meter (2026-08-14)
+
+Seven application metrics are registered through `prometheus/client_golang`
+(`promauto`) rather than the OTel meter. They are therefore **not** on the SDK
+`:2112` endpoint that the rest of this document describes, and they carry none
+of the resource attributes (`service_name`, `site`) the OTel families are joined
+by — so they cannot be correlated with anything else here without knowing which
+endpoint exposes them.
+
+| Metric | Owner | Labels |
+|---|---|---|
+| `bot_msg_worker_permanent_error_total` | `bot-message-worker` | — |
+| `atrest_dek_cache_hits_total` | `pkg/atrest` | — |
+| `atrest_dek_cache_misses_total` | `pkg/atrest` | — |
+| `atrest_dek_creations_total` | `pkg/atrest` | — |
+| `atrest_kek_wrap_total` | `pkg/atrest` | result |
+| `atrest_kek_unwrap_total` | `pkg/atrest` | result |
+| `atrest_kek_renewal_failures_total` | `pkg/atrest` | — |
+
+`atrest_kek_renewal_failures_total` is documented in its own Help text as a hard
+alert (a sustained non-zero rate means the service cannot obtain a Vault token
+and encryption will fail once the current one expires). An alert on a series
+that is not on the standard endpoint is a trap worth closing: these belong on
+the shared meter, which is tracked as gap 6.
 
 **Observation:** shared cache/room-key counters are already present on some
 hot-path services, but they do not answer the core product questions (accepted
@@ -313,9 +330,10 @@ these exporters there (and to prod IaC) to cover Layer C.
    server health; lower urgency than NATS. *Infra.*
 5. **Histogram buckets.** SDK HTTP/DB histograms use `DefaultLatencyBuckets`
    (`WithHistogramBuckets` can override); confirm they match dashboard needs.
-6. **Move `bot-message-worker` onto the OTel meter.** It is the one application
-   metric registered through `prometheus/client_golang`, so it is off the
-   `:2112` endpoint and outside the shared label scheme (§2.2).
+6. **Move the seven `promauto` metrics onto the OTel meter** (`pkg/atrest` and
+   `bot-message-worker`, §2.3). They are off the `:2112` endpoint and outside
+   the shared label scheme, and one of them (`atrest_kek_renewal_failures_total`)
+   is meant to be a hard alert.
 
 Tracked as follow-ups in `docs/specs/o11y/o11y-followups.md`.
 

--- a/docs/specs/o11y/o11y-metrics-inventory.md
+++ b/docs/specs/o11y/o11y-metrics-inventory.md
@@ -7,7 +7,9 @@ come from **dedicated exporters** (infra, not the app SDK). Companion to
 
 > Status: inventory / design. Live values were verified locally on 2026-07-12
 > against the Docker Compose o11y stack (`docker-local/compose.o11y.yaml` ->
-> Prometheus `:9090`).
+> Prometheus `:9090`). The instrument list was re-derived from source on
+> 2026-08-14 — every OTel and client_golang instrument in the repository is
+> accounted for in §2, §2.1, and §2.2 — but that pass was static, not a rescrape.
 
 > Storage note (2026-08-11): the authoritative, code-reverified MongoDB and
 > Cassandra metric set, direct-client coverage, exporter gaps, and shared
@@ -91,9 +93,9 @@ Enabled wherever the matching `WithObservability` / middleware is wired.
 
 **Two notable auto-gaps (spans only, NO metrics):**
 - **NATS/JetStream client** (`otelnats`) — emits *spans*, but **no client
-  metrics** (no per-subject publish/consume counters or latency histograms from
-  the SDK). For a message platform this is a real gap; today the only NATS
-  numbers come from tracing.
+  metrics** from the SDK itself. This is still true of the instrumentation
+  layer; the gap is now covered at the application layer instead, by the shared
+  `chat.nats.*` families in §2.1. Do not expect SDK-auto NATS series.
 - **Elasticsearch client** (`searchengine`) — emits *spans* (ES `_search`/`_bulk`
   latency is visible in traces) but **no metrics** instrument.
 
@@ -114,10 +116,10 @@ missing beyond shared cache/key counters.
 | portal-service | ✅ | ✅ | — | — | — | — | — | account-lookup outcomes |
 | upload-service | ✅ | ✅ | — | — | — | — | — | upload count/bytes, MinIO put/get outcomes |
 | media-service | ✅ | ✅ | — | — | spans | — | — | avatar/emoji upload count/bytes, MinIO put/get outcomes |
-| message-gatekeeper | — | ✅ | ✅ | — | spans | — | shared `cache_*_total` | **validated / rejected counter** (by reason), canonical published |
-| message-worker | — | ✅ | — | ✅ | spans | — | shared `cache_*_total` | rows written, thread-sub upserts |
-| broadcast-worker | — | ✅ | ✅ | — | spans | — | shared `cache_*_total` | **fan-out size** histogram, deliveries, E2E-key hits |
-| notification-worker | — | ✅ | ✅ | — | spans | — | shared `cache_*_total` | notifications/pushes sent, suppressed |
+| message-gatekeeper | — | ✅ | ✅ | — | spans + `chat_nats_*` | — | shared `cache_*_total`, **`message_gatekeeper_messages_total`** | — |
+| message-worker | — | ✅ | — | ✅ | spans + `chat_nats_*` | — | shared `cache_*_total`, **`message_worker_persistence_total`** | thread-sub upserts |
+| broadcast-worker | — | ✅ | ✅ | — | spans + `chat_nats_*` | — | shared `cache_*_total`, **`broadcast_worker_fanout_recipients`**, **`broadcast_worker_recipient_deliveries_total`** | E2E-key hits |
+| notification-worker | — | ✅ | ✅ | — | spans + `chat_nats_*` | — | shared `cache_*_total`, **`notification_worker_outcomes_total`** | — |
 | outbox-worker | — | — | — | — | spans | — | — | forwarded/dropped/retried events by destination and type |
 | search-sync-worker | — | — | — | — | spans (Fetch) | spans | — | bulk actions/flush, index vs delete, ES failures |
 | search-service | — | ✅ | ✅ | — | spans | spans | **`search_service_requests_total`, `search_service_request_duration_seconds`, `search_service_es_duration_seconds`** | (well covered after request traffic) |
@@ -128,6 +130,65 @@ missing beyond shared cache/key counters.
 | user-presence-service | — | ✅ | ✅? | — | spans | — | — | presence queries, cache hit rate |
 | history-service | — | ✅ | — | ✅ | spans | — | shared `cache_*_total` | history reads, bucket-walk depth |
 | data-migration/oplog-* | — | ✅ | — | — | spans | — | **rich counters** (`oplog_*_events_processed_total`, `_naks_total`, `_terms_total`, `_skipped_total`, `_exhausted_total`, …) | (good exemplar — copy this pattern) |
+
+### 2.1 Shared application NATS metrics (2026-08-14)
+
+The SDK emits no NATS client metrics (§1), so these are owned by this repo and
+are emitted by every service that wires the shared helpers. Names are OTel
+instrument names; Prometheus renders them with `_` separators and adds
+`_total` / unit suffixes.
+
+Consumer and publisher families share a base of `service_name` + `site`; the
+"labels" column lists what each adds on top.
+
+| Instrument | Type | Owner | Labels beyond the base |
+|---|---|---|---|
+| `chat.nats.consumer.loop.up` | up-down counter | `pkg/natsmetrics` | stream, consumer |
+| `chat.nats.consumer.messages` | counter | `pkg/natsmetrics` | stream, consumer, event_type, outcome |
+| `chat.nats.consumer.redeliveries` | counter | `pkg/natsmetrics` | stream, consumer, event_type |
+| `chat.nats.consumer.processing.duration` | histogram (s) | `pkg/natsmetrics` | stream, consumer, event_type, outcome |
+| `chat.nats.terminal.failures` | counter | `pkg/natsmetrics` | stream, consumer, event_type, reason |
+| `chat.nats.publish.attempts` | counter | `pkg/natsmetrics` | destination_kind, operation, outcome |
+| `chat.nats.publish.retries` | counter | `pkg/natsmetrics` | destination_kind, operation |
+| `chat.nats.requests` | counter | `pkg/natsmetrics` | operation, outcome |
+| `chat.nats.request.duration` | histogram (s) | `pkg/natsmetrics` | operation, outcome |
+| `chat.nats.client.connected` | up-down counter | `pkg/natsutil` | none — one series per process |
+| `chat.nats.client.connection.events` | counter | `pkg/natsutil` | event |
+| `nats_slow_consumer_events_total` | counter | `pkg/natsutil` | subject, queue |
+
+The two `chat.nats.client.*` families are the exception: they carry no
+`service_name` or `site` at all, because they are emitted from the connection
+helper, which sits below the layer that knows the site. They are scoped by the
+OTel resource instead, so join them through `target_info` rather than expecting
+inline labels. `nats_slow_consumer_events_total` is scoped the same way.
+
+Reconnect-buffer overflow is **not** a connection event: nats.go returns
+`ErrReconnectBufExceeded` synchronously from `publish()` and never routes it
+through `ErrorHandler`, so it is counted as
+`chat_nats_publish_attempts_total{outcome="buffer_full"}`. The full semantics,
+label enums, and the alerts these drive are specified in the NATS failure
+metrics contract under `docs/load-testing/failure-testing/`.
+
+### 2.2 Services not previously inventoried (2026-08-14)
+
+The Layer B table above predates these services. Verified from source: none of
+them own application metric instruments, so they expose Layer A only (Go
+runtime, plus whichever clients they wire). Their dependency columns are not
+filled in here because they were not re-verified against a running stack.
+
+`bot-message-handler`, `bot-room-service`, `client-update-service`,
+`hr-sync-worker`, `push-notification-service`, `tcard-service`,
+`teams-chat-member-sync`, `teams-chat-sync`, `teams-hr-sync`,
+`teams-room-creation`, `teams-room-inspector`, `teams-room-verify`,
+`teams-user-sync`, `translation-service`.
+
+One exception owns a metric: **`bot-message-worker`** exposes
+`bot_msg_worker_permanent_error_total`, but it is registered through
+`prometheus/client_golang` (`promauto`), not the OTel meter. It is therefore
+**not** on the SDK `:2112` endpoint with everything else in this document, and
+it carries none of the resource attributes the other families are joined by.
+This is the only non-OTel application metric in the repository; converting it to
+the shared meter would put it on the same endpoint and label scheme.
 
 **Observation:** shared cache/room-key counters are already present on some
 hot-path services, but they do not answer the core product questions (accepted
@@ -196,7 +257,7 @@ PromQL evidence:
 | `sum by (service_name, cache, tier) (cache_misses_total)` | cache miss counters present for `message-worker`, `notification-worker`, `history-service`, `room-worker`, `broadcast-worker`, and `message-gatekeeper` |
 | `cache_errors_total` | empty in this run; expected when no cache errors occurred |
 | `search_service_*` | empty in this Prometheus window because no search request traffic was generated after Prometheus was recreated |
-| NATS/JetStream client metric queries | empty; expected, because NATS currently emits spans but no SDK client metrics |
+| NATS/JetStream client metric queries | empty; expected at the time, because NATS emitted spans but no SDK client metrics. Superseded by §2.1: the repository now emits application-side `chat.nats.*` families. |
 
 Sample cache counter values observed in this run:
 
@@ -240,17 +301,21 @@ these exporters there (and to prod IaC) to cover Layer C.
 1. **NATS/JetStream exporter (Layer C).** Highest value — consumer lag is
    invisible today. Deploy `prometheus-nats-exporter` (or scrape NATS `:8222`),
    add to `docker-local/compose.o11y.yaml` + prod. *Infra, not app code.*
-2. **Hot-path domain counters (Layer B).** Add `sdk.Meter()` instruments to
-   gatekeeper (validated/rejected by reason), broadcast (fan-out size),
-   notification (sent/suppressed), search-sync (bulk outcomes). Copy the
-   data-migration counter pattern. *App code — one small `metrics.go` per service.*
-3. **Confirm/So-what on NATS & ES client metrics (Layer A gap).** otelnats/
-   searchengine emit spans but no metrics; decide whether app-side NATS/ES
-   latency histograms are worth adding (or rely on traces + the exporters).
+2. **Hot-path domain counters (Layer B).** *Mostly done (2026-08-14).*
+   Gatekeeper, message-worker, broadcast, and notification now own domain
+   counters (§2 table). Still open: **search-sync bulk outcomes**, and
+   broadcast's E2E-key hits.
+3. **ES client metrics (Layer A gap).** The NATS half of this item is closed —
+   see §2.1 for the application-side families that replaced it. `searchengine`
+   still emits spans but no metrics; decide whether app-side ES latency
+   histograms are worth adding or whether traces plus the exporter suffice.
 4. **DB/Redis/Cassandra/ES server exporters (Layer C).** Standard exporters for
    server health; lower urgency than NATS. *Infra.*
 5. **Histogram buckets.** SDK HTTP/DB histograms use `DefaultLatencyBuckets`
    (`WithHistogramBuckets` can override); confirm they match dashboard needs.
+6. **Move `bot-message-worker` onto the OTel meter.** It is the one application
+   metric registered through `prometheus/client_golang`, so it is off the
+   `:2112` endpoint and outside the shared label scheme (§2.2).
 
 Tracked as follow-ups in `docs/specs/o11y/o11y-followups.md`.
 

--- a/docs/specs/o11y/o11y-metrics-inventory.md
+++ b/docs/specs/o11y/o11y-metrics-inventory.md
@@ -133,9 +133,11 @@ missing beyond shared cache/key counters.
 
 ### 2.1 Shared application NATS metrics (2026-08-14)
 
-The SDK emits no NATS client metrics (§1), so these are owned by this repo and
-are emitted by every service that wires the shared helpers. Names are OTel
-instrument names; Prometheus renders them with `_` separators and adds
+The SDK emits no NATS client metrics (§1), so these are owned by this repo.
+The shared consumer/publisher helpers are adopted by the four first-campaign
+services. Connection lifecycle metrics are opt-in through
+`natsutil.ConnectWithMetrics` and use the same four-service scope. Names are
+OTel instrument names; Prometheus renders them with `_` separators and adds
 `_total` / unit suffixes.
 
 Consumer and publisher families share a base of `service_name` + `site`; the
@@ -152,15 +154,16 @@ Consumer and publisher families share a base of `service_name` + `site`; the
 | `chat.nats.publish.retries` | counter | `pkg/natsmetrics` | destination_kind, operation |
 | `chat.nats.requests` | counter | `pkg/natsmetrics` | operation, outcome |
 | `chat.nats.request.duration` | histogram (s) | `pkg/natsmetrics` | operation, outcome |
-| `chat.nats.client.connected` | up-down counter | `pkg/natsutil` | none — one series per process |
+| `chat.nats.client.connected` | up-down counter | `pkg/natsutil` | none — one series per process; value is the live connection count |
 | `chat.nats.client.connection.events` | counter | `pkg/natsutil` | event |
 | `nats_slow_consumer_events_total` | counter | `pkg/natsutil` | subject, queue |
 
 The two `chat.nats.client.*` families are the exception: they carry no
-`service_name` or `site` at all, because they are emitted from the connection
-helper, which sits below the layer that knows the site. They are scoped by the
-OTel resource instead, so join them through `target_info` rather than expecting
-inline labels. `nats_slow_consumer_events_total` is scoped the same way.
+`service_name` or `site` at all, because they are emitted from the opt-in
+connection helper, which sits below the layer that knows the site. They are
+scoped by the OTel resource instead, so join them through `target_info` rather
+than expecting inline labels. `nats_slow_consumer_events_total` is scoped the
+same way.
 
 Reconnect-buffer overflow is **not** a connection event: nats.go returns
 `ErrReconnectBufExceeded` synchronously from `publish()` and never routes it

--- a/message-gatekeeper/fetcher_history.go
+++ b/message-gatekeeper/fetcher_history.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/bytedance/sonic"
 	o11ynats "github.com/flywindy/o11y/nats"
-	"go.opentelemetry.io/otel"
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model/cassandra"
@@ -25,11 +24,14 @@ const historyRequestTimeout = 2 * time.Second
 type historyParentFetcher struct {
 	nc          *o11ynats.Conn
 	chatBaseURL string
-	metrics     *natsmetrics.Metrics
+	// metrics is injected: building a second natsmetrics.Metrics here would
+	// duplicate all nine shared instruments on a different construction path.
+	// The zero value is safe and records nothing.
+	metrics natsmetrics.Publisher
 }
 
-func newHistoryParentFetcher(nc *o11ynats.Conn, chatBaseURL string) *historyParentFetcher {
-	return &historyParentFetcher{nc: nc, chatBaseURL: chatBaseURL, metrics: natsmetrics.New(otel.Meter("chat.nats"))}
+func newHistoryParentFetcher(nc *o11ynats.Conn, chatBaseURL string, metrics natsmetrics.Publisher) *historyParentFetcher {
+	return &historyParentFetcher{nc: nc, chatBaseURL: chatBaseURL, metrics: metrics}
 }
 
 // getMessageByIDRequest mirrors history-service's GetMessageByIDRequest wire
@@ -78,9 +80,7 @@ func (f *historyParentFetcher) FetchQuotedParent(
 	subj := subject.MsgGet(account, roomID, siteID)
 	started := time.Now()
 	msg, err := f.nc.Request(ctx, subj, reqBytes, historyRequestTimeout)
-	if f.metrics != nil {
-		f.metrics.Publisher("message-gatekeeper", siteID).Request(ctx, natsmetrics.OperationHistoryGetMessage, time.Since(started), err)
-	}
+	f.metrics.Request(ctx, natsmetrics.OperationHistoryGetMessage, time.Since(started), err)
 	if err != nil {
 		return nil, natsutil.RequestFailure("history request", err)
 	}

--- a/message-gatekeeper/fetcher_history.go
+++ b/message-gatekeeper/fetcher_history.go
@@ -7,9 +7,11 @@ import (
 
 	"github.com/bytedance/sonic"
 	o11ynats "github.com/flywindy/o11y/nats"
+	"go.opentelemetry.io/otel"
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model/cassandra"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/subject"
 )
@@ -23,10 +25,11 @@ const historyRequestTimeout = 2 * time.Second
 type historyParentFetcher struct {
 	nc          *o11ynats.Conn
 	chatBaseURL string
+	metrics     *natsmetrics.Metrics
 }
 
 func newHistoryParentFetcher(nc *o11ynats.Conn, chatBaseURL string) *historyParentFetcher {
-	return &historyParentFetcher{nc: nc, chatBaseURL: chatBaseURL}
+	return &historyParentFetcher{nc: nc, chatBaseURL: chatBaseURL, metrics: natsmetrics.New(otel.Meter("chat.nats"))}
 }
 
 // getMessageByIDRequest mirrors history-service's GetMessageByIDRequest wire
@@ -73,7 +76,11 @@ func (f *historyParentFetcher) FetchQuotedParent(
 	}
 
 	subj := subject.MsgGet(account, roomID, siteID)
+	started := time.Now()
 	msg, err := f.nc.Request(ctx, subj, reqBytes, historyRequestTimeout)
+	if f.metrics != nil {
+		f.metrics.Publisher("message-gatekeeper", siteID).Request(ctx, natsmetrics.OperationHistoryGetMessage, time.Since(started), err)
+	}
 	if err != nil {
 		return nil, natsutil.RequestFailure("history request", err)
 	}

--- a/message-gatekeeper/fetcher_history_test.go
+++ b/message-gatekeeper/fetcher_history_test.go
@@ -130,7 +130,9 @@ func TestHistoryParentFetcher_FetchQuotedParent(t *testing.T) {
 		assert.Nil(t, got)
 		assert.Equal(t, int64(1), requests("success"),
 			"a replied-to request is a transport success even when the payload is an error envelope")
-		assert.Contains(t, err.Error(), "message not found")
+		var ec *errcode.Error
+		require.ErrorAs(t, err, &ec, "the history error envelope must survive as a typed errcode")
+		assert.Equal(t, errcode.CodeNotFound, ec.Code)
 	})
 
 	t.Run("no responder — returns error", func(t *testing.T) {
@@ -158,7 +160,9 @@ func requestMetricFor(t *testing.T) (natsmetrics.Publisher, func(outcome string)
 		t.Helper()
 		var rm metricdata.ResourceMetrics
 		require.NoError(t, reader.Collect(context.Background(), &rm))
-		var total int64
+		// operationTotal guards the assertion itself: summing only the requested
+		// outcome would still pass if one request were recorded under two.
+		var total, operationTotal int64
 		for _, scope := range rm.ScopeMetrics {
 			for _, m := range scope.Metrics {
 				if m.Name != "chat.nats.requests" {
@@ -171,12 +175,17 @@ func requestMetricFor(t *testing.T) (natsmetrics.Publisher, func(outcome string)
 					for _, kv := range dp.Attributes.ToSlice() {
 						got[string(kv.Key)] = kv.Value.AsString()
 					}
-					if got["operation"] == string(natsmetrics.OperationHistoryGetMessage) && got["outcome"] == outcome {
+					if got["operation"] != string(natsmetrics.OperationHistoryGetMessage) {
+						continue
+					}
+					operationTotal += dp.Value
+					if got["outcome"] == outcome {
 						total += dp.Value
 					}
 				}
 			}
 		}
+		require.Equal(t, int64(1), operationTotal, "one history request must record exactly one outcome")
 		return total
 	}
 }

--- a/message-gatekeeper/fetcher_history_test.go
+++ b/message-gatekeeper/fetcher_history_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hmchangw/chat/pkg/natsmetrics"
+
 	natsserver "github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
@@ -67,7 +69,7 @@ func TestHistoryParentFetcher_FetchQuotedParent(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		fetcher := newHistoryParentFetcher(nc, baseURL)
+		fetcher := newHistoryParentFetcher(nc, baseURL, natsmetrics.Publisher{})
 		got, err := fetcher.FetchQuotedParent(context.Background(), account, roomID, siteID, messageID)
 		require.NoError(t, err)
 		require.NotNil(t, got)
@@ -100,7 +102,7 @@ func TestHistoryParentFetcher_FetchQuotedParent(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		fetcher := newHistoryParentFetcher(nc, baseURL)
+		fetcher := newHistoryParentFetcher(nc, baseURL, natsmetrics.Publisher{})
 		got, err := fetcher.FetchQuotedParent(context.Background(), account, roomID, siteID, messageID)
 		require.NoError(t, err)
 		require.NotNil(t, got)
@@ -117,7 +119,7 @@ func TestHistoryParentFetcher_FetchQuotedParent(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		fetcher := newHistoryParentFetcher(nc, baseURL)
+		fetcher := newHistoryParentFetcher(nc, baseURL, natsmetrics.Publisher{})
 		got, err := fetcher.FetchQuotedParent(context.Background(), account, roomID, siteID, messageID)
 		require.Error(t, err)
 		assert.Nil(t, got)
@@ -128,7 +130,7 @@ func TestHistoryParentFetcher_FetchQuotedParent(t *testing.T) {
 		nc := startTestNATS(t)
 		// Intentionally no subscriber: nc.Request must fail with "no responders".
 
-		fetcher := newHistoryParentFetcher(nc, baseURL)
+		fetcher := newHistoryParentFetcher(nc, baseURL, natsmetrics.Publisher{})
 		got, err := fetcher.FetchQuotedParent(context.Background(), account, roomID, siteID, messageID)
 		require.Error(t, err)
 		assert.Nil(t, got)

--- a/message-gatekeeper/fetcher_history_test.go
+++ b/message-gatekeeper/fetcher_history_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/trace/noop"
 
 	o11ynats "github.com/flywindy/o11y/nats"
@@ -69,10 +71,12 @@ func TestHistoryParentFetcher_FetchQuotedParent(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		fetcher := newHistoryParentFetcher(nc, baseURL, natsmetrics.Publisher{})
+		pub, requests := requestMetricFor(t)
+		fetcher := newHistoryParentFetcher(nc, baseURL, pub)
 		got, err := fetcher.FetchQuotedParent(context.Background(), account, roomID, siteID, messageID)
 		require.NoError(t, err)
 		require.NotNil(t, got)
+		assert.Equal(t, int64(1), requests("success"), "a served history request must be counted as success")
 		assert.Equal(t, messageID, got.MessageID)
 		assert.Equal(t, roomID, got.RoomID)
 		assert.Equal(t, "a reply inside thread T", got.Msg)
@@ -119,10 +123,13 @@ func TestHistoryParentFetcher_FetchQuotedParent(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		fetcher := newHistoryParentFetcher(nc, baseURL, natsmetrics.Publisher{})
+		pub, requests := requestMetricFor(t)
+		fetcher := newHistoryParentFetcher(nc, baseURL, pub)
 		got, err := fetcher.FetchQuotedParent(context.Background(), account, roomID, siteID, messageID)
 		require.Error(t, err)
 		assert.Nil(t, got)
+		assert.Equal(t, int64(1), requests("success"),
+			"a replied-to request is a transport success even when the payload is an error envelope")
 		assert.Contains(t, err.Error(), "message not found")
 	})
 
@@ -130,9 +137,46 @@ func TestHistoryParentFetcher_FetchQuotedParent(t *testing.T) {
 		nc := startTestNATS(t)
 		// Intentionally no subscriber: nc.Request must fail with "no responders".
 
-		fetcher := newHistoryParentFetcher(nc, baseURL, natsmetrics.Publisher{})
+		pub, requests := requestMetricFor(t)
+		fetcher := newHistoryParentFetcher(nc, baseURL, pub)
 		got, err := fetcher.FetchQuotedParent(context.Background(), account, roomID, siteID, messageID)
 		require.Error(t, err)
 		assert.Nil(t, got)
+		assert.Equal(t, int64(1), requests("no_responders"), "an unanswered history request must be counted as no_responders")
 	})
+}
+
+// requestMetricFor builds a Publisher backed by a manual reader so a test can
+// assert the history request outcome the fetcher records. Injecting a zero
+// natsmetrics.Publisher makes Request a no-op, which proves nothing.
+func requestMetricFor(t *testing.T) (natsmetrics.Publisher, func(outcome string) int64) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	pub := natsmetrics.NewFromProvider(mp).Publisher("message-gatekeeper", "s1")
+	return pub, func(outcome string) int64 {
+		t.Helper()
+		var rm metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(context.Background(), &rm))
+		var total int64
+		for _, scope := range rm.ScopeMetrics {
+			for _, m := range scope.Metrics {
+				if m.Name != "chat.nats.requests" {
+					continue
+				}
+				sum, ok := m.Data.(metricdata.Sum[int64])
+				require.True(t, ok, "chat.nats.requests must be a counter")
+				for _, dp := range sum.DataPoints {
+					got := map[string]string{}
+					for _, kv := range dp.Attributes.ToSlice() {
+						got[string(kv.Key)] = kv.Value.AsString()
+					}
+					if got["operation"] == string(natsmetrics.OperationHistoryGetMessage) && got["outcome"] == outcome {
+						total += dp.Value
+					}
+				}
+			}
+		}
+		return total
+	}
 }

--- a/message-gatekeeper/handler.go
+++ b/message-gatekeeper/handler.go
@@ -35,17 +35,9 @@ const maxContentBytes = 20 * 1024 // 20 KB
 // message-worker re-projects the real snapshot before the durable write.
 const quotedParentUnavailablePlaceholder = "Content temporarily unavailable"
 
+// errCanonicalPublish tags a canonical-publish failure so the settle path can
+// tell it apart from any other infra failure without matching on error text.
 var errCanonicalPublish = errors.New("canonical publish failed")
-
-type canonicalPublishError struct{ cause error }
-
-func (e *canonicalPublishError) Error() string {
-	return fmt.Sprintf("canonical publish failed: publish to MESSAGES-CANONICAL: %v", e.cause)
-}
-
-func (e *canonicalPublishError) Unwrap() error { return e.cause }
-
-func (e *canonicalPublishError) Is(target error) bool { return target == errCanonicalPublish }
 
 // replyFunc is the function signature for publishing a reply to a NATS subject.
 type replyFunc func(ctx context.Context, msg *nats.Msg) error
@@ -121,7 +113,7 @@ func (h *Handler) HandleJetStreamMsg(ctx context.Context, msg jetstream.Msg) {
 		// rather than let a forged value ride the reply and this span.
 		ctx = obs.ContextWithPublicIdentity(ctx, "", "", "")
 		natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalInvalidPayload)
-		h.metrics.Record(ctx, "rejected", "invalid_subject")
+		h.metrics.Record(ctx, resultRejected, reasonInvalidSubject)
 		slog.Warn("invalid subject", "subject", msg.Subject())
 		debugFlowRejected(ctx, req.RequestID, "invalid_subject")
 		// Best-effort error reply so the client doesn't hang; sendReply no-ops
@@ -139,7 +131,7 @@ func (h *Handler) HandleJetStreamMsg(ctx context.Context, msg jetstream.Msg) {
 
 	if parseErr != nil {
 		natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalInvalidPayload)
-		h.metrics.Record(ctx, "rejected", "invalid_payload")
+		h.metrics.Record(ctx, resultRejected, reasonInvalidPayload)
 		// Do not WithCause(parseErr) — JSON parse error strings embed the
 		// offending substring from an unauthenticated entry-point (see doc.go).
 		bad := errcode.BadRequest("unmarshal send message request")
@@ -166,28 +158,29 @@ func (h *Handler) HandleJetStreamMsg(ctx context.Context, msg jetstream.Msg) {
 		// validation branch must NOT also log here. Infra branch owns its log.
 		var ee *errcode.Error
 		if errors.As(err, &ee) {
-			if ee.Code == errcode.CodeBadRequest {
-				natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalInvalidPayload)
-			} else {
-				natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalPermanent)
-			}
-			h.metrics.Record(ctx, "rejected", gatekeeperReason(ee))
+			// A validation or policy rejection is an ordinary client error, not
+			// undeliverable work: the sender receives an error reply and the
+			// rejection is already counted by message_gatekeeper_messages_total.
+			// Recording it as a terminal failure would make the campaign's
+			// terminal-delivery signal non-zero at baseline and hide real loss.
+			h.metrics.Record(ctx, resultRejected, gatekeeperReason(ee))
 			debugFlowRejected(ctx, req.RequestID, string(ee.Code))
 			h.sendReply(ctx, account, &req, errnats.Marshal(ctx, err))
 			if err := msg.Ack(); err != nil {
 				slog.Error("failed to ack message", "error", err)
 			}
 		} else {
-			result := "retry"
-			if natsmetrics.IsFinalDeliveryFromContext(ctx) {
-				result = "failed"
+			final := natsmetrics.IsFinalDeliveryFromContext(ctx)
+			result := resultRetry
+			if final {
+				result = resultFailed
 			}
-			reason := "dependency"
+			reason := reasonDependency
 			if errors.Is(err, errCanonicalPublish) {
-				reason = "canonical_publish"
+				reason = reasonCanonicalPublish
 			}
 			h.metrics.Record(ctx, result, reason)
-			if errors.Is(err, errCanonicalPublish) && natsmetrics.IsFinalDeliveryFromContext(ctx) {
+			if errors.Is(err, errCanonicalPublish) && final {
 				natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalPublishExhausted)
 			}
 			// flow terminal for the infra path; the Error line below carries the cause.
@@ -201,25 +194,25 @@ func (h *Handler) HandleJetStreamMsg(ctx context.Context, msg jetstream.Msg) {
 	}
 
 	h.sendReply(ctx, account, &req, replyData)
-	h.metrics.Record(ctx, "accepted", "none")
+	h.metrics.Record(ctx, resultAccepted, reasonNone)
 
 	if err := msg.Ack(); err != nil {
 		slog.Error("failed to ack message", "err", err)
 	}
 }
 
-func gatekeeperReason(err *errcode.Error) string {
+func gatekeeperReason(err *errcode.Error) gatekeeperReasonCode {
 	switch err.Reason {
 	case errcode.MessageNotSubscribed:
-		return "not_subscribed"
+		return reasonNotSubscribed
 	case errcode.MessageLargeRoomPostRestricted:
-		return "room_restricted"
+		return reasonRoomRestricted
 	default:
 	}
 	if err.Code == errcode.CodeBadRequest {
-		return "invalid_payload"
+		return reasonInvalidPayload
 	}
-	return "unknown"
+	return reasonUnknown
 }
 
 // debugFlowReceived emits the flow-rung "received" breadcrumb at the gatekeeper
@@ -461,7 +454,7 @@ func (h *Handler) processMessage(ctx context.Context, account, roomID, siteID st
 	canonicalSubj := subject.MsgCanonicalCreated(siteID)
 	canonicalMsg := natsutil.NewMsg(ctx, canonicalSubj, evtData)
 	if _, err := h.publish(ctx, canonicalMsg, jetstream.WithMsgID(natsutil.CanonicalDedupID(&evt))); err != nil {
-		return nil, &canonicalPublishError{cause: err}
+		return nil, fmt.Errorf("publish to MESSAGES-CANONICAL: %w", errors.Join(errCanonicalPublish, err))
 	}
 	// flow: the message cleared the gate and was handed off to MESSAGES-CANONICAL.
 	slog.Log(ctx, logctx.LevelFlow, "gatekeeper published to canonical",

--- a/message-gatekeeper/handler.go
+++ b/message-gatekeeper/handler.go
@@ -70,10 +70,27 @@ type Handler struct {
 	metrics     *gatekeeperMetrics
 }
 
+type gatekeeperHandlerOption func(*gatekeeperHandlerOptions)
+
+type gatekeeperHandlerOptions struct {
+	metrics *gatekeeperMetrics
+}
+
+func withGatekeeperMetrics(metrics *gatekeeperMetrics) gatekeeperHandlerOption {
+	return func(opts *gatekeeperHandlerOptions) { opts.metrics = metrics }
+}
+
 // NewHandler constructs a new Handler with the given dependencies.
 // users may be nil; when nil, sender display-name resolution is skipped and
 // downstream consumers fall back to UserAccount.
-func NewHandler(store Store, users UserGetter, publish publishFunc, reply replyFunc, siteID string, parentFetcher ParentMessageFetcher, largeRoomThreshold, maxAttachments, maxAttachmentBytes int, chatBaseURL string) *Handler {
+func NewHandler(store Store, users UserGetter, publish publishFunc, reply replyFunc, siteID string, parentFetcher ParentMessageFetcher, largeRoomThreshold, maxAttachments, maxAttachmentBytes int, chatBaseURL string, options ...gatekeeperHandlerOption) *Handler {
+	var opts gatekeeperHandlerOptions
+	for _, option := range options {
+		option(&opts)
+	}
+	if opts.metrics == nil {
+		opts.metrics = newGatekeeperMetrics(otel.Meter("message-gatekeeper"))
+	}
 	return &Handler{
 		store:              store,
 		users:              users,
@@ -85,7 +102,7 @@ func NewHandler(store Store, users UserGetter, publish publishFunc, reply replyF
 		maxAttachments:     maxAttachments,
 		maxAttachmentBytes: maxAttachmentBytes,
 		chatBaseURL:        chatBaseURL,
-		metrics:            newGatekeeperMetrics(otel.Meter("message-gatekeeper")),
+		metrics:            opts.metrics,
 	}
 }
 

--- a/message-gatekeeper/handler.go
+++ b/message-gatekeeper/handler.go
@@ -120,7 +120,7 @@ func (h *Handler) HandleJetStreamMsg(ctx context.Context, msg jetstream.Msg) {
 		// when account or requestId is unusable. Ack — malformed is not retryable.
 		h.sendReply(ctx, accountFromSubject(msg.Subject()), &req, errnats.Marshal(ctx, errcode.BadRequest("invalid message subject")))
 		if err := msg.Ack(); err != nil {
-			slog.Error("failed to ack message", "error", err)
+			slog.ErrorContext(ctx, "failed to ack message", "error", err, "request_id", req.RequestID)
 		}
 		return
 	}
@@ -138,7 +138,7 @@ func (h *Handler) HandleJetStreamMsg(ctx context.Context, msg jetstream.Msg) {
 		debugFlowRejected(ctx, req.RequestID, "unmarshal")
 		h.sendReply(ctx, account, &req, errnats.Marshal(ctx, bad))
 		if err := msg.Ack(); err != nil {
-			slog.Error("failed to ack message", "error", err)
+			slog.ErrorContext(ctx, "failed to ack message", "error", err, "request_id", req.RequestID)
 		}
 		return
 	}
@@ -167,7 +167,7 @@ func (h *Handler) HandleJetStreamMsg(ctx context.Context, msg jetstream.Msg) {
 			debugFlowRejected(ctx, req.RequestID, string(ee.Code))
 			h.sendReply(ctx, account, &req, errnats.Marshal(ctx, err))
 			if err := msg.Ack(); err != nil {
-				slog.Error("failed to ack message", "error", err)
+				slog.ErrorContext(ctx, "failed to ack message", "error", err, "request_id", req.RequestID)
 			}
 		} else {
 			final := natsmetrics.IsFinalDeliveryFromContext(ctx)
@@ -187,7 +187,7 @@ func (h *Handler) HandleJetStreamMsg(ctx context.Context, msg jetstream.Msg) {
 			slog.Log(ctx, logctx.LevelFlow, "gatekeeper nak", "phase", "nak", "request_id", req.RequestID)
 			slog.ErrorContext(ctx, "process message failed (infra)", "error", err, "account", account, "room_id", roomID)
 			if err := msg.Nak(); err != nil {
-				slog.Error("failed to nack message", "error", err)
+				slog.ErrorContext(ctx, "failed to nack message", "error", err, "request_id", req.RequestID)
 			}
 		}
 		return
@@ -197,7 +197,7 @@ func (h *Handler) HandleJetStreamMsg(ctx context.Context, msg jetstream.Msg) {
 	h.metrics.Record(ctx, resultAccepted, reasonNone)
 
 	if err := msg.Ack(); err != nil {
-		slog.Error("failed to ack message", "err", err)
+		slog.ErrorContext(ctx, "failed to ack message", "error", err, "request_id", req.RequestID)
 	}
 }
 

--- a/message-gatekeeper/handler.go
+++ b/message-gatekeeper/handler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
+	"go.opentelemetry.io/otel"
 
 	"github.com/hmchangw/chat/pkg/displayfmt"
 	"github.com/hmchangw/chat/pkg/errcode"
@@ -21,6 +22,7 @@ import (
 	"github.com/hmchangw/chat/pkg/logctx"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/model/cassandra"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
 	"github.com/hmchangw/chat/pkg/subject"
@@ -32,6 +34,18 @@ const maxContentBytes = 20 * 1024 // 20 KB
 // when the authoritative fetch fails transiently. It never persists —
 // message-worker re-projects the real snapshot before the durable write.
 const quotedParentUnavailablePlaceholder = "Content temporarily unavailable"
+
+var errCanonicalPublish = errors.New("canonical publish failed")
+
+type canonicalPublishError struct{ cause error }
+
+func (e *canonicalPublishError) Error() string {
+	return fmt.Sprintf("canonical publish failed: publish to MESSAGES-CANONICAL: %v", e.cause)
+}
+
+func (e *canonicalPublishError) Unwrap() error { return e.cause }
+
+func (e *canonicalPublishError) Is(target error) bool { return target == errCanonicalPublish }
 
 // replyFunc is the function signature for publishing a reply to a NATS subject.
 type replyFunc func(ctx context.Context, msg *nats.Msg) error
@@ -61,6 +75,7 @@ type Handler struct {
 	// snapshot, from trusted inputs (the send room + the validated quoted message
 	// ID) so the link is correct even on the outage path.
 	chatBaseURL string
+	metrics     *gatekeeperMetrics
 }
 
 // NewHandler constructs a new Handler with the given dependencies.
@@ -78,6 +93,7 @@ func NewHandler(store Store, users UserGetter, publish publishFunc, reply replyF
 		maxAttachments:     maxAttachments,
 		maxAttachmentBytes: maxAttachmentBytes,
 		chatBaseURL:        chatBaseURL,
+		metrics:            newGatekeeperMetrics(otel.Meter("message-gatekeeper")),
 	}
 }
 
@@ -104,6 +120,8 @@ func (h *Handler) HandleJetStreamMsg(ctx context.Context, msg jetstream.Msg) {
 		// there is nothing to overwrite the sender's baggage with, so drop it
 		// rather than let a forged value ride the reply and this span.
 		ctx = obs.ContextWithPublicIdentity(ctx, "", "", "")
+		natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalInvalidPayload)
+		h.metrics.Record(ctx, "rejected", "invalid_subject")
 		slog.Warn("invalid subject", "subject", msg.Subject())
 		debugFlowRejected(ctx, req.RequestID, "invalid_subject")
 		// Best-effort error reply so the client doesn't hang; sendReply no-ops
@@ -120,6 +138,8 @@ func (h *Handler) HandleJetStreamMsg(ctx context.Context, msg jetstream.Msg) {
 	ctx = errcode.WithLogValues(ctx, "room_id", roomID)
 
 	if parseErr != nil {
+		natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalInvalidPayload)
+		h.metrics.Record(ctx, "rejected", "invalid_payload")
 		// Do not WithCause(parseErr) — JSON parse error strings embed the
 		// offending substring from an unauthenticated entry-point (see doc.go).
 		bad := errcode.BadRequest("unmarshal send message request")
@@ -146,12 +166,30 @@ func (h *Handler) HandleJetStreamMsg(ctx context.Context, msg jetstream.Msg) {
 		// validation branch must NOT also log here. Infra branch owns its log.
 		var ee *errcode.Error
 		if errors.As(err, &ee) {
+			if ee.Code == errcode.CodeBadRequest {
+				natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalInvalidPayload)
+			} else {
+				natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalPermanent)
+			}
+			h.metrics.Record(ctx, "rejected", gatekeeperReason(ee))
 			debugFlowRejected(ctx, req.RequestID, string(ee.Code))
 			h.sendReply(ctx, account, &req, errnats.Marshal(ctx, err))
 			if err := msg.Ack(); err != nil {
 				slog.Error("failed to ack message", "error", err)
 			}
 		} else {
+			result := "retry"
+			if natsmetrics.IsFinalDeliveryFromContext(ctx) {
+				result = "failed"
+			}
+			reason := "dependency"
+			if errors.Is(err, errCanonicalPublish) {
+				reason = "canonical_publish"
+			}
+			h.metrics.Record(ctx, result, reason)
+			if errors.Is(err, errCanonicalPublish) && natsmetrics.IsFinalDeliveryFromContext(ctx) {
+				natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalPublishExhausted)
+			}
 			// flow terminal for the infra path; the Error line below carries the cause.
 			slog.Log(ctx, logctx.LevelFlow, "gatekeeper nak", "phase", "nak", "request_id", req.RequestID)
 			slog.ErrorContext(ctx, "process message failed (infra)", "error", err, "account", account, "room_id", roomID)
@@ -163,10 +201,25 @@ func (h *Handler) HandleJetStreamMsg(ctx context.Context, msg jetstream.Msg) {
 	}
 
 	h.sendReply(ctx, account, &req, replyData)
+	h.metrics.Record(ctx, "accepted", "none")
 
 	if err := msg.Ack(); err != nil {
 		slog.Error("failed to ack message", "err", err)
 	}
+}
+
+func gatekeeperReason(err *errcode.Error) string {
+	switch err.Reason {
+	case errcode.MessageNotSubscribed:
+		return "not_subscribed"
+	case errcode.MessageLargeRoomPostRestricted:
+		return "room_restricted"
+	default:
+	}
+	if err.Code == errcode.CodeBadRequest {
+		return "invalid_payload"
+	}
+	return "unknown"
 }
 
 // debugFlowReceived emits the flow-rung "received" breadcrumb at the gatekeeper
@@ -408,7 +461,7 @@ func (h *Handler) processMessage(ctx context.Context, account, roomID, siteID st
 	canonicalSubj := subject.MsgCanonicalCreated(siteID)
 	canonicalMsg := natsutil.NewMsg(ctx, canonicalSubj, evtData)
 	if _, err := h.publish(ctx, canonicalMsg, jetstream.WithMsgID(natsutil.CanonicalDedupID(&evt))); err != nil {
-		return nil, fmt.Errorf("publish to MESSAGES-CANONICAL: %w", err)
+		return nil, &canonicalPublishError{cause: err}
 	}
 	// flow: the message cleared the gate and was handed off to MESSAGES-CANONICAL.
 	slog.Log(ctx, logctx.LevelFlow, "gatekeeper published to canonical",

--- a/message-gatekeeper/handler_test.go
+++ b/message-gatekeeper/handler_test.go
@@ -1837,25 +1837,31 @@ func TestHandler_sendReply(t *testing.T) {
 // ---- HandleJetStreamMsg coverage ----
 
 type fakeJSMsg struct {
-	subject string
-	data    []byte
-	headers nats.Header
-	acked   bool
-	naked   bool
+	subject      string
+	data         []byte
+	headers      nats.Header
+	numDelivered uint64
+	acked        bool
+	naked        bool
 }
 
-func (m *fakeJSMsg) Metadata() (*jetstream.MsgMetadata, error) { return nil, nil }
-func (m *fakeJSMsg) Data() []byte                              { return m.data }
-func (m *fakeJSMsg) Headers() nats.Header                      { return m.headers }
-func (m *fakeJSMsg) Subject() string                           { return m.subject }
-func (m *fakeJSMsg) Reply() string                             { return "" }
-func (m *fakeJSMsg) Ack() error                                { m.acked = true; return nil }
-func (m *fakeJSMsg) DoubleAck(context.Context) error           { m.acked = true; return nil }
-func (m *fakeJSMsg) Nak() error                                { m.naked = true; return nil }
-func (m *fakeJSMsg) NakWithDelay(time.Duration) error          { m.naked = true; return nil }
-func (m *fakeJSMsg) InProgress() error                         { return nil }
-func (m *fakeJSMsg) Term() error                               { return nil }
-func (m *fakeJSMsg) TermWithReason(string) error               { return nil }
+func (m *fakeJSMsg) Metadata() (*jetstream.MsgMetadata, error) {
+	if m.numDelivered == 0 {
+		return nil, nil
+	}
+	return &jetstream.MsgMetadata{NumDelivered: m.numDelivered}, nil
+}
+func (m *fakeJSMsg) Data() []byte                     { return m.data }
+func (m *fakeJSMsg) Headers() nats.Header             { return m.headers }
+func (m *fakeJSMsg) Subject() string                  { return m.subject }
+func (m *fakeJSMsg) Reply() string                    { return "" }
+func (m *fakeJSMsg) Ack() error                       { m.acked = true; return nil }
+func (m *fakeJSMsg) DoubleAck(context.Context) error  { m.acked = true; return nil }
+func (m *fakeJSMsg) Nak() error                       { m.naked = true; return nil }
+func (m *fakeJSMsg) NakWithDelay(time.Duration) error { m.naked = true; return nil }
+func (m *fakeJSMsg) InProgress() error                { return nil }
+func (m *fakeJSMsg) Term() error                      { return nil }
+func (m *fakeJSMsg) TermWithReason(string) error      { return nil }
 
 // Malformed body Acks (not retryable) and sends a bad_request reply if the
 // subject parsed cleanly.

--- a/message-gatekeeper/main.go
+++ b/message-gatekeeper/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -84,7 +83,7 @@ func main() {
 		slog.Error("init observability failed", "error", err)
 		os.Exit(1)
 	}
-	sharedMetrics := natsmetrics.New(sdk.MeterProvider().Meter("chat.nats"))
+	sharedMetrics := natsmetrics.NewFromProvider(sdk.MeterProvider())
 	publishMetrics := sharedMetrics.Publisher("message-gatekeeper", cfg.SiteID)
 
 	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)
@@ -156,7 +155,7 @@ func main() {
 		}
 		return nil
 	}
-	parentFetcher := newHistoryParentFetcher(nc, cfg.ChatBaseURL)
+	parentFetcher := newHistoryParentFetcher(nc, cfg.ChatBaseURL, publishMetrics)
 	handler := NewHandler(store, users, pub, reply, cfg.SiteID, parentFetcher, cfg.LargeRoomThreshold, cfg.MaxAttachments, cfg.MaxAttachmentBytes, cfg.ChatBaseURL)
 
 	if err := bootstrapStreams(ctx, js, cfg.SiteID, cfg.Bootstrap.Enabled); err != nil {
@@ -186,13 +185,8 @@ func main() {
 
 	var wg sync.WaitGroup
 
-	go natsmetrics.Consume(iter, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
-		func(msg jetstream.Msg) natsmetrics.EventType {
-			if strings.HasSuffix(msg.Subject(), ".msg.send") {
-				return natsmetrics.EventSend
-			}
-			return natsmetrics.EventUnknown
-		},
+	go natsmetrics.Consume(ctx, iter, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
+		func(msg jetstream.Msg) natsmetrics.EventType { return natsmetrics.EventTypeFromSubject(msg.Subject()) },
 		func(msgCtx context.Context, msg *natsmetrics.Message) {
 			handlerCtx, _ := natsutil.StampRequestID(msgCtx, msg.Headers(), msg.Subject())
 			handlerCtx = logctx.Admit(handlerCtx, msg.Headers())

--- a/message-gatekeeper/main.go
+++ b/message-gatekeeper/main.go
@@ -185,7 +185,7 @@ func main() {
 
 	var wg sync.WaitGroup
 
-	go natsmetrics.Consume(ctx, iter, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
+	natsmetrics.Start(ctx, iter, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
 		func(msg jetstream.Msg) natsmetrics.EventType { return natsmetrics.EventTypeFromSubject(msg.Subject()) },
 		func(msgCtx context.Context, msg *natsmetrics.Message) {
 			handlerCtx, _ := natsutil.StampRequestID(msgCtx, msg.Headers(), msg.Subject())

--- a/message-gatekeeper/main.go
+++ b/message-gatekeeper/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/hmchangw/chat/pkg/logctx"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
 	"github.com/hmchangw/chat/pkg/shutdown"
@@ -82,6 +84,8 @@ func main() {
 		slog.Error("init observability failed", "error", err)
 		os.Exit(1)
 	}
+	sharedMetrics := natsmetrics.New(sdk.MeterProvider().Meter("chat.nats"))
+	publishMetrics := sharedMetrics.Publisher("message-gatekeeper", cfg.SiteID)
 
 	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)
 	if err != nil {
@@ -138,13 +142,16 @@ func main() {
 	)
 	pub := func(ctx context.Context, msg *nats.Msg, opts ...jetstream.PublishOpt) (*jetstream.PubAck, error) {
 		ack, err := js.PublishMsg(ctx, msg, opts...)
+		publishMetrics.Attempt(ctx, natsmetrics.DestinationCanonical, natsmetrics.OperationCanonicalPublish, err)
 		if err != nil {
 			return nil, fmt.Errorf("publish to %q: %w", msg.Subject, err)
 		}
 		return ack, nil
 	}
 	reply := func(ctx context.Context, msg *nats.Msg) error {
-		if err := nc.PublishMsg(ctx, msg); err != nil {
+		err := nc.PublishMsg(ctx, msg)
+		publishMetrics.Attempt(ctx, natsmetrics.DestinationClientResponse, natsmetrics.OperationClientResponse, err)
+		if err != nil {
 			return fmt.Errorf("reply to %q: %w", msg.Subject, err)
 		}
 		return nil
@@ -158,7 +165,13 @@ func main() {
 	}
 
 	messagesCfg := stream.Messages(cfg.SiteID)
-	cons, err := js.CreateOrUpdateConsumer(ctx, messagesCfg.Name, buildConsumerConfig(cfg.Consumer))
+	consumerCfg := buildConsumerConfig(cfg.Consumer)
+	consumerMetrics := sharedMetrics.Consumer(natsmetrics.ConsumerConfig{
+		ServiceName: "message-gatekeeper", Site: cfg.SiteID,
+		Stream: messagesCfg.Name, Consumer: consumerCfg.Durable,
+	})
+	consumerMetrics.LoopStopped(ctx)
+	cons, err := js.CreateOrUpdateConsumer(ctx, messagesCfg.Name, consumerCfg)
 	if err != nil {
 		slog.Error("create consumer failed", "error", err)
 		os.Exit(1)
@@ -169,30 +182,23 @@ func main() {
 		slog.Error("messages failed", "error", err)
 		os.Exit(1)
 	}
+	consumerMetrics.LoopStarted(ctx)
 
-	sem := make(chan struct{}, cfg.MaxWorkers)
 	var wg sync.WaitGroup
 
-	go func() {
-		for {
-			msgCtx, msg, err := iter.Next()
-			if err != nil {
-				return
+	go natsmetrics.Consume(iter, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
+		func(msg jetstream.Msg) natsmetrics.EventType {
+			if strings.HasSuffix(msg.Subject(), ".msg.send") {
+				return natsmetrics.EventSend
 			}
-			sem <- struct{}{}
-			wg.Add(1)
-			go func() {
-				defer func() {
-					<-sem
-					wg.Done()
-				}()
-				handlerCtx, _ := natsutil.StampRequestID(msgCtx, msg.Headers(), msg.Subject())
-				handlerCtx = logctx.Admit(handlerCtx, msg.Headers())
-				logctx.CapturePayload(handlerCtx, "consumed", msg.Subject(), msg.Data())
-				handler.HandleJetStreamMsg(handlerCtx, msg)
-			}()
-		}
-	}()
+			return natsmetrics.EventUnknown
+		},
+		func(msgCtx context.Context, msg *natsmetrics.Message) {
+			handlerCtx, _ := natsutil.StampRequestID(msgCtx, msg.Headers(), msg.Subject())
+			handlerCtx = logctx.Admit(handlerCtx, msg.Headers())
+			logctx.CapturePayload(handlerCtx, "consumed", msg.Subject(), msg.Data())
+			handler.HandleJetStreamMsg(handlerCtx, msg)
+		})
 
 	healthStop, err := health.ServeWithPprof(cfg.HealthAddr, 5*time.Second, cfg.PProfEnabled,
 		natsutil.HealthCheck(nc),
@@ -206,6 +212,7 @@ func main() {
 
 	shutdown.Wait(ctx, 25*time.Second,
 		func(ctx context.Context) error {
+			consumerMetrics.LoopStopped(ctx)
 			iter.Stop()
 			return nil
 		},

--- a/message-gatekeeper/main.go
+++ b/message-gatekeeper/main.go
@@ -85,8 +85,9 @@ func main() {
 	}
 	sharedMetrics := natsmetrics.NewFromProvider(sdk.MeterProvider())
 	publishMetrics := sharedMetrics.Publisher("message-gatekeeper", cfg.SiteID)
+	domainMetrics := newGatekeeperMetrics(sdk.MeterProvider().Meter("message-gatekeeper"))
 
-	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)
+	nc, err := natsutil.ConnectWithMetrics(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace, sdk.MeterProvider())
 	if err != nil {
 		slog.Error("nats connect failed", "error", err)
 		os.Exit(1)
@@ -156,7 +157,7 @@ func main() {
 		return nil
 	}
 	parentFetcher := newHistoryParentFetcher(nc, cfg.ChatBaseURL, publishMetrics)
-	handler := NewHandler(store, users, pub, reply, cfg.SiteID, parentFetcher, cfg.LargeRoomThreshold, cfg.MaxAttachments, cfg.MaxAttachmentBytes, cfg.ChatBaseURL)
+	handler := NewHandler(store, users, pub, reply, cfg.SiteID, parentFetcher, cfg.LargeRoomThreshold, cfg.MaxAttachments, cfg.MaxAttachmentBytes, cfg.ChatBaseURL, withGatekeeperMetrics(domainMetrics))
 
 	if err := bootstrapStreams(ctx, js, cfg.SiteID, cfg.Bootstrap.Enabled); err != nil {
 		slog.Error("bootstrap streams failed", "error", err)

--- a/message-gatekeeper/nats_metrics.go
+++ b/message-gatekeeper/nats_metrics.go
@@ -7,30 +7,72 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
-type gatekeeperMetrics struct{ messages metric.Int64Counter }
+// gatekeeperResult and gatekeeperReasonCode are closed enums so a typo is a
+// compile error rather than a silent `unknown` series at campaign time.
+type gatekeeperResult string
+
+const (
+	resultAccepted gatekeeperResult = "accepted"
+	resultRejected gatekeeperResult = "rejected"
+	resultRetry    gatekeeperResult = "retry"
+	resultFailed   gatekeeperResult = "failed"
+)
+
+var allGatekeeperResults = []gatekeeperResult{resultAccepted, resultRejected, resultRetry, resultFailed}
+
+type gatekeeperReasonCode string
+
+const (
+	reasonNone             gatekeeperReasonCode = "none"
+	reasonInvalidSubject   gatekeeperReasonCode = "invalid_subject"
+	reasonInvalidPayload   gatekeeperReasonCode = "invalid_payload"
+	reasonNotSubscribed    gatekeeperReasonCode = "not_subscribed"
+	reasonRoomRestricted   gatekeeperReasonCode = "room_restricted"
+	reasonCanonicalPublish gatekeeperReasonCode = "canonical_publish"
+	reasonDependency       gatekeeperReasonCode = "dependency"
+	reasonUnknown          gatekeeperReasonCode = "unknown"
+)
+
+var allGatekeeperReasons = []gatekeeperReasonCode{
+	reasonNone, reasonInvalidSubject, reasonInvalidPayload, reasonNotSubscribed,
+	reasonRoomRestricted, reasonCanonicalPublish, reasonDependency, reasonUnknown,
+}
+
+type gatekeeperMetrics struct {
+	messages metric.Int64Counter
+	opts     map[gatekeeperKey]metric.MeasurementOption
+}
+
+type gatekeeperKey struct {
+	result gatekeeperResult
+	reason gatekeeperReasonCode
+}
 
 func newGatekeeperMetrics(meter metric.Meter) *gatekeeperMetrics {
 	counter, _ := meter.Int64Counter("message_gatekeeper_messages_total",
 		metric.WithDescription("Gatekeeper business outcomes by bounded result and reason."))
-	return &gatekeeperMetrics{messages: counter}
+	m := &gatekeeperMetrics{
+		messages: counter,
+		opts:     make(map[gatekeeperKey]metric.MeasurementOption, len(allGatekeeperResults)*len(allGatekeeperReasons)),
+	}
+	for _, result := range allGatekeeperResults {
+		for _, reason := range allGatekeeperReasons {
+			m.opts[gatekeeperKey{result, reason}] = metric.WithAttributes(
+				attribute.String("result", string(result)),
+				attribute.String("reason", string(reason)),
+			)
+		}
+	}
+	return m
 }
 
-func (m *gatekeeperMetrics) Record(ctx context.Context, result, reason string) {
+func (m *gatekeeperMetrics) Record(ctx context.Context, result gatekeeperResult, reason gatekeeperReasonCode) {
 	if m == nil || m.messages == nil {
 		return
 	}
-	switch result {
-	case "accepted", "rejected", "retry", "failed":
-	default:
-		result = "failed"
+	opt, ok := m.opts[gatekeeperKey{result, reason}]
+	if !ok {
+		opt = m.opts[gatekeeperKey{resultFailed, reasonUnknown}]
 	}
-	switch reason {
-	case "none", "invalid_subject", "invalid_payload", "not_subscribed", "room_restricted", "canonical_publish", "dependency", "unknown":
-	default:
-		reason = "unknown"
-	}
-	m.messages.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("result", result),
-		attribute.String("reason", reason),
-	))
+	m.messages.Add(ctx, 1, opt)
 }

--- a/message-gatekeeper/nats_metrics.go
+++ b/message-gatekeeper/nats_metrics.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type gatekeeperMetrics struct{ messages metric.Int64Counter }
+
+func newGatekeeperMetrics(meter metric.Meter) *gatekeeperMetrics {
+	counter, _ := meter.Int64Counter("message_gatekeeper_messages_total",
+		metric.WithDescription("Gatekeeper business outcomes by bounded result and reason."))
+	return &gatekeeperMetrics{messages: counter}
+}
+
+func (m *gatekeeperMetrics) Record(ctx context.Context, result, reason string) {
+	if m == nil || m.messages == nil {
+		return
+	}
+	switch result {
+	case "accepted", "rejected", "retry", "failed":
+	default:
+		result = "failed"
+	}
+	switch reason {
+	case "none", "invalid_subject", "invalid_payload", "not_subscribed", "room_restricted", "canonical_publish", "dependency", "unknown":
+	default:
+		reason = "unknown"
+	}
+	m.messages.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("result", result),
+		attribute.String("reason", reason),
+	))
+}

--- a/message-gatekeeper/nats_metrics.go
+++ b/message-gatekeeper/nats_metrics.go
@@ -5,6 +5,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 )
 
 // gatekeeperResult and gatekeeperReasonCode are closed enums so a typo is a
@@ -49,8 +50,14 @@ type gatekeeperKey struct {
 }
 
 func newGatekeeperMetrics(meter metric.Meter) *gatekeeperMetrics {
-	counter, _ := meter.Int64Counter("message_gatekeeper_messages_total",
+	noopMeter := noop.NewMeterProvider().Meter("message-gatekeeper")
+	counter, err := meter.Int64Counter("message_gatekeeper_messages_total",
 		metric.WithDescription("Gatekeeper business outcomes by bounded result and reason."))
+	if err != nil {
+		// Telemetry must never block startup: fall back to a no-op instrument so
+		// the service runs blind on this metric rather than not at all.
+		counter, _ = noopMeter.Int64Counter("message_gatekeeper_messages_total")
+	}
 	m := &gatekeeperMetrics{
 		messages: counter,
 		opts:     make(map[gatekeeperKey]metric.MeasurementOption, len(allGatekeeperResults)*len(allGatekeeperReasons)),

--- a/message-gatekeeper/nats_metrics_test.go
+++ b/message-gatekeeper/nats_metrics_test.go
@@ -2,14 +2,22 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.uber.org/mock/gomock"
+
+	"github.com/hmchangw/chat/pkg/idgen"
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 )
 
 func TestCanonicalPublishError_PreservesClassificationAndCause(t *testing.T) {
@@ -53,4 +61,76 @@ func TestGatekeeperMetrics_BoundedResults(t *testing.T) {
 	m.Record(context.Background(), gatekeeperResult("dynamic"), gatekeeperReasonCode("secret error text"))
 
 	assert.Equal(t, map[string]int64{"accepted/none": 1, "failed/unknown": 1}, gatekeeperCounts(t, reader))
+}
+
+func TestHandler_HandleJetStreamMsg_RecordsRejectedOutcome(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	metrics := newGatekeeperMetrics(mp.Meter("test"))
+	h := NewHandler(nil, nil, nil, func(context.Context, *nats.Msg) error { return nil }, "site-a", nil, 500, 1, 8192, "", withGatekeeperMetrics(metrics))
+	msg := &fakeJSMsg{subject: "chat.invalid", data: []byte(`{}`)}
+
+	h.HandleJetStreamMsg(context.Background(), msg)
+
+	assert.True(t, msg.acked)
+	assert.False(t, msg.naked)
+	assert.Equal(t, map[string]int64{"rejected/invalid_subject": 1}, gatekeeperCounts(t, reader))
+}
+
+func TestHandler_HandleJetStreamMsg_RecordsAcceptedAndRetryOutcomes(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		publishErr error
+		wantMetric map[string]int64
+		wantAck    bool
+		wantNak    bool
+		final      bool
+	}{
+		{name: "accepted", wantMetric: map[string]int64{"accepted/none": 1}, wantAck: true},
+		{name: "canonical publish retry", publishErr: errors.New("stream unavailable"), wantMetric: map[string]int64{"retry/canonical_publish": 1}, wantNak: true},
+		{name: "canonical publish exhausted", publishErr: errors.New("stream unavailable"), wantMetric: map[string]int64{"failed/canonical_publish": 1}, wantNak: true, final: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := sdkmetric.NewManualReader()
+			mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+			metrics := newGatekeeperMetrics(mp.Meter("test"))
+			ctrl := gomock.NewController(t)
+			store := NewMockStore(ctrl)
+			store.EXPECT().GetSubscription(gomock.Any(), "weather.bot", "room-1").Return(&model.Subscription{
+				User:  model.SubscriptionUser{ID: "u-bot", Account: "weather.bot"},
+				Roles: []model.Role{model.RoleMember},
+			}, nil)
+			h := NewHandler(store, nil, makePublishFunc(nil, tt.publishErr), func(context.Context, *nats.Msg) error { return nil }, "site-a", nil, 500, 1, 8192, "", withGatekeeperMetrics(metrics))
+			request := model.SendMessageRequest{
+				ID: idgen.GenerateMessageID(), Content: "hello",
+				RequestID: "01970a4f-8c2d-7c9a-abcd-e0123456789f",
+			}
+			data, err := json.Marshal(request)
+			require.NoError(t, err)
+			msg := &fakeJSMsg{subject: "chat.user.weather_bot.room.room-1.site-a.msg.send", data: data}
+			ctx := context.Background()
+			var delivery jetstream.Msg = msg
+			if tt.final {
+				msg.numDelivered = 1
+				consumer := natsmetrics.New(mp.Meter("shared")).Consumer(natsmetrics.ConsumerConfig{
+					ServiceName: "message-gatekeeper", Site: "site-a", Stream: "MESSAGES_site-a", Consumer: "message-gatekeeper",
+				})
+				consumer.LoopStarted(ctx)
+				tracked := consumer.Track(ctx, msg, natsmetrics.EventSend, 1)
+				delivery = tracked
+				ctx = tracked.Context(ctx)
+			}
+
+			h.HandleJetStreamMsg(ctx, delivery)
+
+			assert.Equal(t, tt.wantAck, msg.acked)
+			assert.Equal(t, tt.wantNak, msg.naked)
+			assert.Equal(t, tt.wantMetric, gatekeeperCounts(t, reader))
+		})
+	}
+}
+
+func TestGatekeeperMetrics_Record_NilReceiverIsSafe(t *testing.T) {
+	var metrics *gatekeeperMetrics
+	metrics.Record(context.Background(), resultAccepted, reasonNone)
 }

--- a/message-gatekeeper/nats_metrics_test.go
+++ b/message-gatekeeper/nats_metrics_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestCanonicalPublishError_PreservesClassificationAndCause(t *testing.T) {
+	cause := errors.New("stream unavailable")
+	err := &canonicalPublishError{cause: cause}
+
+	assert.ErrorIs(t, err, errCanonicalPublish)
+	assert.ErrorIs(t, err, cause)
+}
+
+func TestGatekeeperMetrics_BoundedResults(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	m := newGatekeeperMetrics(mp.Meter("test"))
+	m.Record(context.Background(), "accepted", "none")
+	m.Record(context.Background(), "dynamic", "secret error text")
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	got := map[string]int64{}
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != "message_gatekeeper_messages_total" {
+				continue
+			}
+			sum := metric.Data.(metricdata.Sum[int64])
+			for _, point := range sum.DataPoints {
+				values := map[string]string{}
+				for _, attr := range point.Attributes.ToSlice() {
+					values[string(attr.Key)] = attr.Value.AsString()
+				}
+				got[values["result"]+"/"+values["reason"]] = point.Value
+			}
+		}
+	}
+	assert.Equal(t, map[string]int64{"accepted/none": 1, "failed/unknown": 1}, got)
+}

--- a/message-gatekeeper/nats_metrics_test.go
+++ b/message-gatekeeper/nats_metrics_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,29 +14,23 @@ import (
 
 func TestCanonicalPublishError_PreservesClassificationAndCause(t *testing.T) {
 	cause := errors.New("stream unavailable")
-	err := &canonicalPublishError{cause: cause}
+	err := fmt.Errorf("publish to MESSAGES-CANONICAL: %w", errors.Join(errCanonicalPublish, cause))
 
 	assert.ErrorIs(t, err, errCanonicalPublish)
 	assert.ErrorIs(t, err, cause)
 }
 
-func TestGatekeeperMetrics_BoundedResults(t *testing.T) {
-	reader := sdkmetric.NewManualReader()
-	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-	m := newGatekeeperMetrics(mp.Meter("test"))
-	m.Record(context.Background(), "accepted", "none")
-	m.Record(context.Background(), "dynamic", "secret error text")
-
+func gatekeeperCounts(t *testing.T, reader sdkmetric.Reader) map[string]int64 {
+	t.Helper()
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(context.Background(), &rm))
 	got := map[string]int64{}
 	for _, scope := range rm.ScopeMetrics {
-		for _, metric := range scope.Metrics {
-			if metric.Name != "message_gatekeeper_messages_total" {
+		for _, m := range scope.Metrics {
+			if m.Name != "message_gatekeeper_messages_total" {
 				continue
 			}
-			sum := metric.Data.(metricdata.Sum[int64])
-			for _, point := range sum.DataPoints {
+			for _, point := range m.Data.(metricdata.Sum[int64]).DataPoints {
 				values := map[string]string{}
 				for _, attr := range point.Attributes.ToSlice() {
 					values[string(attr.Key)] = attr.Value.AsString()
@@ -44,5 +39,18 @@ func TestGatekeeperMetrics_BoundedResults(t *testing.T) {
 			}
 		}
 	}
-	assert.Equal(t, map[string]int64{"accepted/none": 1, "failed/unknown": 1}, got)
+	return got
+}
+
+func TestGatekeeperMetrics_BoundedResults(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	m := newGatekeeperMetrics(mp.Meter("test"))
+
+	m.Record(context.Background(), resultAccepted, reasonNone)
+	// A value outside the enum can only arrive via a conversion; it must still
+	// collapse instead of minting an unbounded series.
+	m.Record(context.Background(), gatekeeperResult("dynamic"), gatekeeperReasonCode("secret error text"))
+
+	assert.Equal(t, map[string]int64{"accepted/none": 1, "failed/unknown": 1}, gatekeeperCounts(t, reader))
 }

--- a/message-worker/handler.go
+++ b/message-worker/handler.go
@@ -158,10 +158,10 @@ func (h *Handler) processMessage(ctx context.Context, data []byte, isMigration b
 		}
 		newTcount, err := h.store.SaveThreadMessage(ctx, &evt.Message, sender, evt.SiteID, threadRoomID)
 		if err != nil {
-			h.metrics.Record(ctx, "thread_reply", "error")
+			h.metrics.Record(ctx, kindThreadReply, persistError)
 			return fmt.Errorf("save thread message: %w", err)
 		}
-		h.metrics.Record(ctx, "thread_reply", "success")
+		h.metrics.Record(ctx, kindThreadReply, persistSuccess)
 		debugFlowPersisted(ctx, evt.Message.ID, true)
 		// Suppress the live tcount badge for migrated replies: the source already delivered it, and the
 		// badge carries no migration header so broadcast-worker would re-notify. The count is persisted above.
@@ -172,27 +172,27 @@ func (h *Handler) processMessage(ctx context.Context, data []byte, isMigration b
 		}
 	} else {
 		if err := h.store.SaveMessage(ctx, &evt.Message, sender, evt.SiteID); err != nil {
-			h.metrics.Record(ctx, messageKind(&evt.Message), "error")
+			h.metrics.Record(ctx, messageKind(&evt.Message), persistError)
 			return fmt.Errorf("save message: %w", err)
 		}
-		h.metrics.Record(ctx, messageKind(&evt.Message), "success")
+		h.metrics.Record(ctx, messageKind(&evt.Message), persistSuccess)
 		debugFlowPersisted(ctx, evt.Message.ID, false)
 	}
 
 	return nil
 }
 
-func messageKind(msg *model.Message) string {
+func messageKind(msg *model.Message) messageKindLabel {
 	if msg.ThreadParentMessageID != "" {
-		return "thread_reply"
+		return kindThreadReply
 	}
 	if model.IsSystemMessageType(msg.Type) {
-		return "system"
+		return kindSystem
 	}
 	if msg.Type == "" || msg.Type == model.MessageTypeImportant {
-		return "user"
+		return kindUser
 	}
-	return "unknown"
+	return kindUnknown
 }
 
 // reprojectUnverifiedQuote corrects an untrusted quoted-parent snapshot before the

--- a/message-worker/handler.go
+++ b/message-worker/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bytedance/sonic"
 
 	"github.com/nats-io/nats.go/jetstream"
+	"go.opentelemetry.io/otel"
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/idgen"
@@ -18,6 +19,7 @@ import (
 	"github.com/hmchangw/chat/pkg/mention"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/model/cassandra"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
 	"github.com/hmchangw/chat/pkg/outbox"
@@ -35,6 +37,7 @@ type Handler struct {
 	threadStore ThreadStore
 	siteID      string
 	publish     PublishFunc
+	metrics     *persistenceMetrics
 }
 
 func NewHandler(store Store, userStore userstore.UserStore, threadStore ThreadStore, siteID string, publish PublishFunc) *Handler {
@@ -44,6 +47,7 @@ func NewHandler(store Store, userStore userstore.UserStore, threadStore ThreadSt
 		threadStore: threadStore,
 		siteID:      siteID,
 		publish:     publish,
+		metrics:     newPersistenceMetrics(otel.Meter("message-worker")),
 	}
 }
 
@@ -71,6 +75,7 @@ func (h *Handler) HandleJetStreamMsg(ctx context.Context, msg jetstream.Msg) {
 func (h *Handler) processMessage(ctx context.Context, data []byte, isMigration bool) error {
 	var evt model.MessageEvent
 	if err := sonic.Unmarshal(data, &evt); err != nil {
+		natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalInvalidPayload)
 		// Malformed payload — it will never parse on redelivery. Mark permanent
 		// so the handler Acks (drops) it instead of retrying until MaxDeliver.
 		return errcode.Permanent(errcode.BadRequest("malformed message event"))
@@ -153,8 +158,10 @@ func (h *Handler) processMessage(ctx context.Context, data []byte, isMigration b
 		}
 		newTcount, err := h.store.SaveThreadMessage(ctx, &evt.Message, sender, evt.SiteID, threadRoomID)
 		if err != nil {
+			h.metrics.Record(ctx, "thread_reply", "error")
 			return fmt.Errorf("save thread message: %w", err)
 		}
+		h.metrics.Record(ctx, "thread_reply", "success")
 		debugFlowPersisted(ctx, evt.Message.ID, true)
 		// Suppress the live tcount badge for migrated replies: the source already delivered it, and the
 		// badge carries no migration header so broadcast-worker would re-notify. The count is persisted above.
@@ -165,12 +172,27 @@ func (h *Handler) processMessage(ctx context.Context, data []byte, isMigration b
 		}
 	} else {
 		if err := h.store.SaveMessage(ctx, &evt.Message, sender, evt.SiteID); err != nil {
+			h.metrics.Record(ctx, messageKind(&evt.Message), "error")
 			return fmt.Errorf("save message: %w", err)
 		}
+		h.metrics.Record(ctx, messageKind(&evt.Message), "success")
 		debugFlowPersisted(ctx, evt.Message.ID, false)
 	}
 
 	return nil
+}
+
+func messageKind(msg *model.Message) string {
+	if msg.ThreadParentMessageID != "" {
+		return "thread_reply"
+	}
+	if model.IsSystemMessageType(msg.Type) {
+		return "system"
+	}
+	if msg.Type == "" || msg.Type == model.MessageTypeImportant {
+		return "user"
+	}
+	return "unknown"
 }
 
 // reprojectUnverifiedQuote corrects an untrusted quoted-parent snapshot before the

--- a/message-worker/handler.go
+++ b/message-worker/handler.go
@@ -40,14 +40,31 @@ type Handler struct {
 	metrics     *persistenceMetrics
 }
 
-func NewHandler(store Store, userStore userstore.UserStore, threadStore ThreadStore, siteID string, publish PublishFunc) *Handler {
+type messageWorkerHandlerOption func(*messageWorkerHandlerOptions)
+
+type messageWorkerHandlerOptions struct {
+	metrics *persistenceMetrics
+}
+
+func withPersistenceMetrics(metrics *persistenceMetrics) messageWorkerHandlerOption {
+	return func(opts *messageWorkerHandlerOptions) { opts.metrics = metrics }
+}
+
+func NewHandler(store Store, userStore userstore.UserStore, threadStore ThreadStore, siteID string, publish PublishFunc, options ...messageWorkerHandlerOption) *Handler {
+	var opts messageWorkerHandlerOptions
+	for _, option := range options {
+		option(&opts)
+	}
+	if opts.metrics == nil {
+		opts.metrics = newPersistenceMetrics(otel.Meter("message-worker"))
+	}
 	return &Handler{
 		store:       store,
 		userStore:   userStore,
 		threadStore: threadStore,
 		siteID:      siteID,
 		publish:     publish,
-		metrics:     newPersistenceMetrics(otel.Meter("message-worker")),
+		metrics:     opts.metrics,
 	}
 }
 

--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
 	"github.com/hmchangw/chat/pkg/msgbucket"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
 	"github.com/hmchangw/chat/pkg/shutdown"
@@ -90,6 +91,8 @@ func main() {
 		slog.Error("init observability failed", "error", err)
 		os.Exit(1)
 	}
+	sharedMetrics := natsmetrics.New(sdk.MeterProvider().Meter("chat.nats"))
+	publishMetrics := sharedMetrics.Publisher("message-worker", cfg.SiteID)
 
 	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)
 	if err != nil {
@@ -154,12 +157,16 @@ func main() {
 		// verbose-tracing intent ride onto downstream badge/inbox events.
 		msg := natsutil.NewMsg(ctx, subj, data)
 		if msgID == "" {
-			if err := nc.PublishMsg(ctx, msg); err != nil {
+			err := nc.PublishMsg(ctx, msg)
+			publishMetrics.Attempt(ctx, natsmetrics.DestinationRecipientEvent, natsmetrics.OperationThreadTCount, err)
+			if err != nil {
 				return fmt.Errorf("publish nats message to %s: %w", subj, err)
 			}
 			return nil
 		}
-		if _, err := js.PublishMsg(ctx, msg, jetstream.WithMsgID(msgID)); err != nil {
+		_, err := js.PublishMsg(ctx, msg, jetstream.WithMsgID(msgID))
+		publishMetrics.Attempt(ctx, natsmetrics.DestinationOutbox, natsmetrics.OperationRecipientPublish, err)
+		if err != nil {
 			return fmt.Errorf("publish jetstream message to %s with msgID %s: %w", subj, msgID, err)
 		}
 		return nil
@@ -175,7 +182,13 @@ func main() {
 		streamName = stream.MessagesTeams(cfg.SiteID).Name
 	}
 
-	cons, err := js.CreateOrUpdateConsumer(ctx, streamName, buildConsumerConfig(cfg.Consumer, cfg.Mode, cfg.SiteID))
+	consumerCfg := buildConsumerConfig(cfg.Consumer, cfg.Mode, cfg.SiteID)
+	consumerMetrics := sharedMetrics.Consumer(natsmetrics.ConsumerConfig{
+		ServiceName: "message-worker", Site: cfg.SiteID,
+		Stream: streamName, Consumer: consumerCfg.Durable,
+	})
+	consumerMetrics.LoopStopped(ctx)
+	cons, err := js.CreateOrUpdateConsumer(ctx, streamName, consumerCfg)
 	if err != nil {
 		slog.Error("create consumer failed", "error", err)
 		os.Exit(1)
@@ -186,6 +199,7 @@ func main() {
 		slog.Error("messages failed", "error", err)
 		os.Exit(1)
 	}
+	consumerMetrics.LoopStarted(ctx)
 
 	sem := make(chan struct{}, cfg.MaxWorkers)
 	var wg sync.WaitGroup
@@ -203,7 +217,9 @@ func main() {
 			if err != nil {
 				return fmt.Errorf("marshal user identity fanout: %w", err)
 			}
-			if _, err := js.PublishMsg(ctx, natsutil.NewMsg(ctx, subject.OrgSyncUsersUpsert(cfg.SiteID), data)); err != nil {
+			_, err = js.PublishMsg(ctx, natsutil.NewMsg(ctx, subject.OrgSyncUsersUpsert(cfg.SiteID), data))
+			publishMetrics.Attempt(ctx, natsmetrics.DestinationUserSync, natsmetrics.OperationTeamsUserUpsert, err)
+			if err != nil {
 				return fmt.Errorf("publish user identity fanout: %w", err)
 			}
 			return nil
@@ -214,12 +230,21 @@ func main() {
 		for {
 			msgCtx, msg, err := iter.Next()
 			if err != nil {
+				consumerMetrics.LoopFailed(context.Background(), err)
 				return
+			}
+			eventType := natsmetrics.EventCreated
+			if msg.Subject() == teamsBatchSubj {
+				eventType = natsmetrics.EventTeamsBatch
 			}
 			sem <- struct{}{}
 			wg.Add(1)
-			go func() {
+			go func(msgCtx context.Context, msg jetstream.Msg, eventType natsmetrics.EventType) {
+				tracked := consumerMetrics.Track(msgCtx, msg, eventType, consumerCfg.MaxDeliver)
+				msg = tracked
+				msgCtx = tracked.Context(msgCtx)
 				defer func() {
+					tracked.FinishPending(msgCtx)
 					<-sem
 					wg.Done()
 				}()
@@ -239,7 +264,7 @@ func main() {
 					logctx.CapturePayload(handlerCtx, "consumed", msg.Subject(), msg.Data())
 					handler.HandleJetStreamMsg(handlerCtx, msg)
 				})
-			}()
+			}(msgCtx, msg, eventType)
 		}
 	}()
 
@@ -255,6 +280,7 @@ func main() {
 
 	shutdown.Wait(ctx, 25*time.Second,
 		func(ctx context.Context) error {
+			consumerMetrics.LoopStopped(ctx)
 			iter.Stop()
 			return nil
 		},

--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -93,8 +93,9 @@ func main() {
 	}
 	sharedMetrics := natsmetrics.NewFromProvider(sdk.MeterProvider())
 	publishMetrics := sharedMetrics.Publisher("message-worker", cfg.SiteID)
+	domainMetrics := newPersistenceMetrics(sdk.MeterProvider().Meter("message-worker"))
 
-	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)
+	nc, err := natsutil.ConnectWithMetrics(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace, sdk.MeterProvider())
 	if err != nil {
 		slog.Error("nats connect failed", "error", err)
 		os.Exit(1)
@@ -170,7 +171,7 @@ func main() {
 			return fmt.Errorf("publish jetstream message to %s with msgID %s: %w", subj, msgID, err)
 		}
 		return nil
-	})
+	}, withPersistenceMetrics(domainMetrics))
 
 	if err := bootstrapStreams(ctx, js, cfg.SiteID, cfg.Mode, cfg.Bootstrap.Enabled); err != nil {
 		slog.Error("bootstrap streams failed", "error", err)
@@ -223,7 +224,7 @@ func main() {
 				return fmt.Errorf("publish user identity fanout: %w", err)
 			}
 			return nil
-		})
+		}, domainMetrics)
 	teamsBatchSubj := subject.MsgTeamsCanonicalBatch(cfg.SiteID)
 
 	wg.Add(1)

--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -91,7 +91,7 @@ func main() {
 		slog.Error("init observability failed", "error", err)
 		os.Exit(1)
 	}
-	sharedMetrics := natsmetrics.New(sdk.MeterProvider().Meter("chat.nats"))
+	sharedMetrics := natsmetrics.NewFromProvider(sdk.MeterProvider())
 	publishMetrics := sharedMetrics.Publisher("message-worker", cfg.SiteID)
 
 	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)
@@ -233,18 +233,14 @@ func main() {
 				consumerMetrics.LoopFailed(context.Background(), err)
 				return
 			}
-			eventType := natsmetrics.EventCreated
-			if msg.Subject() == teamsBatchSubj {
-				eventType = natsmetrics.EventTeamsBatch
-			}
 			sem <- struct{}{}
 			wg.Add(1)
-			go func(msgCtx context.Context, msg jetstream.Msg, eventType natsmetrics.EventType) {
-				tracked := consumerMetrics.Track(msgCtx, msg, eventType, consumerCfg.MaxDeliver)
+			go func(msgCtx context.Context, msg jetstream.Msg) {
+				tracked := consumerMetrics.Track(msgCtx, msg, natsmetrics.EventTypeFromSubject(msg.Subject()), consumerCfg.MaxDeliver)
 				msg = tracked
 				msgCtx = tracked.Context(msgCtx)
 				defer func() {
-					tracked.FinishPending(msgCtx)
+					tracked.Finish(msgCtx)
 					<-sem
 					wg.Done()
 				}()
@@ -264,7 +260,7 @@ func main() {
 					logctx.CapturePayload(handlerCtx, "consumed", msg.Subject(), msg.Data())
 					handler.HandleJetStreamMsg(handlerCtx, msg)
 				})
-			}(msgCtx, msg, eventType)
+			}(msgCtx, msg)
 		}
 	}()
 

--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -226,7 +226,12 @@ func main() {
 		})
 	teamsBatchSubj := subject.MsgTeamsCanonicalBatch(cfg.SiteID)
 
+	wg.Add(1)
 	go func() {
+		// The loop itself is counted so shutdown, which stops the iterator and
+		// then waits on wg, cannot pass through while a message Next already
+		// returned is still on its way to a worker.
+		defer wg.Done()
 		for {
 			msgCtx, msg, err := iter.Next()
 			if err != nil {

--- a/message-worker/nats_metrics.go
+++ b/message-worker/nats_metrics.go
@@ -5,6 +5,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 )
 
 // messageKindLabel and persistResult are closed enums so a typo is a compile
@@ -41,8 +42,14 @@ type persistenceMetrics struct {
 }
 
 func newPersistenceMetrics(meter metric.Meter) *persistenceMetrics {
-	counter, _ := meter.Int64Counter("message_worker_persistence_total",
+	noopMeter := noop.NewMeterProvider().Meter("message-worker")
+	counter, err := meter.Int64Counter("message_worker_persistence_total",
 		metric.WithDescription("Cassandra message persistence attempts by bounded message kind and result."))
+	if err != nil {
+		// Telemetry must never block startup: fall back to a no-op instrument so
+		// the service runs blind on this metric rather than not at all.
+		counter, _ = noopMeter.Int64Counter("message_worker_persistence_total")
+	}
 	m := &persistenceMetrics{
 		outcomes: counter,
 		opts:     make(map[persistKey]metric.MeasurementOption, len(allMessageKinds)*len(allPersistResults)),

--- a/message-worker/nats_metrics.go
+++ b/message-worker/nats_metrics.go
@@ -7,28 +7,64 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
-type persistenceMetrics struct{ outcomes metric.Int64Counter }
+// messageKindLabel and persistResult are closed enums so a typo is a compile
+// error rather than a silent `unknown` series at campaign time.
+type messageKindLabel string
+
+const (
+	kindUser           messageKindLabel = "user"
+	kindSystem         messageKindLabel = "system"
+	kindThreadReply    messageKindLabel = "thread_reply"
+	kindTeamsMigration messageKindLabel = "teams_migration"
+	kindUnknown        messageKindLabel = "unknown"
+)
+
+var allMessageKinds = []messageKindLabel{kindUser, kindSystem, kindThreadReply, kindTeamsMigration, kindUnknown}
+
+type persistResult string
+
+const (
+	persistSuccess persistResult = "success"
+	persistError   persistResult = "error"
+)
+
+var allPersistResults = []persistResult{persistSuccess, persistError}
+
+type persistKey struct {
+	kind   messageKindLabel
+	result persistResult
+}
+
+type persistenceMetrics struct {
+	outcomes metric.Int64Counter
+	opts     map[persistKey]metric.MeasurementOption
+}
 
 func newPersistenceMetrics(meter metric.Meter) *persistenceMetrics {
 	counter, _ := meter.Int64Counter("message_worker_persistence_total",
 		metric.WithDescription("Cassandra message persistence attempts by bounded message kind and result."))
-	return &persistenceMetrics{outcomes: counter}
+	m := &persistenceMetrics{
+		outcomes: counter,
+		opts:     make(map[persistKey]metric.MeasurementOption, len(allMessageKinds)*len(allPersistResults)),
+	}
+	for _, kind := range allMessageKinds {
+		for _, result := range allPersistResults {
+			m.opts[persistKey{kind, result}] = metric.WithAttributes(
+				attribute.String("message_kind", string(kind)),
+				attribute.String("result", string(result)),
+			)
+		}
+	}
+	return m
 }
 
-func (m *persistenceMetrics) Record(ctx context.Context, kind, result string) {
+func (m *persistenceMetrics) Record(ctx context.Context, kind messageKindLabel, result persistResult) {
 	if m == nil || m.outcomes == nil {
 		return
 	}
-	switch kind {
-	case "user", "system", "thread_reply", "teams_migration", "unknown":
-	default:
-		kind = "unknown"
+	opt, ok := m.opts[persistKey{kind, result}]
+	if !ok {
+		opt = m.opts[persistKey{kindUnknown, persistError}]
 	}
-	if result != "success" && result != "error" {
-		result = "error"
-	}
-	m.outcomes.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("message_kind", kind),
-		attribute.String("result", result),
-	))
+	m.outcomes.Add(ctx, 1, opt)
 }

--- a/message-worker/nats_metrics.go
+++ b/message-worker/nats_metrics.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type persistenceMetrics struct{ outcomes metric.Int64Counter }
+
+func newPersistenceMetrics(meter metric.Meter) *persistenceMetrics {
+	counter, _ := meter.Int64Counter("message_worker_persistence_total",
+		metric.WithDescription("Cassandra message persistence attempts by bounded message kind and result."))
+	return &persistenceMetrics{outcomes: counter}
+}
+
+func (m *persistenceMetrics) Record(ctx context.Context, kind, result string) {
+	if m == nil || m.outcomes == nil {
+		return
+	}
+	switch kind {
+	case "user", "system", "thread_reply", "teams_migration", "unknown":
+	default:
+		kind = "unknown"
+	}
+	if result != "success" && result != "error" {
+		result = "error"
+	}
+	m.outcomes.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("message_kind", kind),
+		attribute.String("result", result),
+	))
+}

--- a/message-worker/nats_metrics_test.go
+++ b/message-worker/nats_metrics_test.go
@@ -2,12 +2,18 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.uber.org/mock/gomock"
+
+	"github.com/hmchangw/chat/pkg/model"
 )
 
 func TestPersistenceMetrics_BoundedLabels(t *testing.T) {
@@ -35,4 +41,68 @@ func TestPersistenceMetrics_BoundedLabels(t *testing.T) {
 		}
 	}
 	assert.Equal(t, map[string]int64{"user/success": 1, "unknown/error": 1}, got)
+}
+
+func TestHandler_HandleJetStreamMsg_RecordsPersistenceOutcomes(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	message := model.Message{
+		ID: "msg-1", RoomID: "r1", UserID: "u-1", UserAccount: "alice",
+		Content: "hello", CreatedAt: now,
+	}
+	event := model.MessageEvent{Message: message, SiteID: "site-a", Timestamp: now.UnixMilli()}
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+	user := &model.User{ID: "u-1", Account: "alice", SiteID: "site-a", EngName: "Alice"}
+	sender := cassParticipant{ID: user.ID, EngName: user.EngName, Account: user.Account}
+
+	for _, tt := range []struct {
+		name       string
+		storeError error
+		wantResult string
+	}{
+		{name: "success", wantResult: "success"},
+		{name: "store error", storeError: errors.New("cassandra unavailable"), wantResult: "error"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := sdkmetric.NewManualReader()
+			mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+			metrics := newPersistenceMetrics(mp.Meter("test"))
+			ctrl := gomock.NewController(t)
+			store := NewMockStore(ctrl)
+			users := NewMockUserStore(ctrl)
+			threads := NewMockThreadStore(ctrl)
+			threads.EXPECT().AddReplyAccounts(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			stubHistoryAllMembers(threads)
+			users.EXPECT().FindUserByAccount(gomock.Any(), "alice").Return(user, nil)
+			store.EXPECT().SaveMessage(gomock.Any(), &message, &sender, "site-a").Return(tt.storeError)
+			h := NewHandler(store, users, threads, "site-a", func(context.Context, string, []byte, string) error { return nil }, withPersistenceMetrics(metrics))
+			msg := &fakeJSMsg{data: data}
+
+			h.HandleJetStreamMsg(context.Background(), msg)
+
+			var rm metricdata.ResourceMetrics
+			require.NoError(t, reader.Collect(context.Background(), &rm))
+			got := map[string]int64{}
+			for _, scope := range rm.ScopeMetrics {
+				for _, metric := range scope.Metrics {
+					if metric.Name != "message_worker_persistence_total" {
+						continue
+					}
+					for _, point := range metric.Data.(metricdata.Sum[int64]).DataPoints {
+						attrs := map[string]string{}
+						for _, attr := range point.Attributes.ToSlice() {
+							attrs[string(attr.Key)] = attr.Value.AsString()
+						}
+						got[attrs["message_kind"]+"/"+attrs["result"]] = point.Value
+					}
+				}
+			}
+			assert.Equal(t, map[string]int64{"user/" + tt.wantResult: 1}, got)
+		})
+	}
+}
+
+func TestPersistenceMetrics_Record_NilReceiverIsSafe(t *testing.T) {
+	var metrics *persistenceMetrics
+	metrics.Record(context.Background(), kindUser, persistSuccess)
 }

--- a/message-worker/nats_metrics_test.go
+++ b/message-worker/nats_metrics_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestPersistenceMetrics_BoundedLabels(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	m := newPersistenceMetrics(mp.Meter("test"))
+	m.Record(context.Background(), "user", "success")
+	m.Record(context.Background(), "dynamic-id", "raw error")
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	got := map[string]int64{}
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != "message_worker_persistence_total" {
+				continue
+			}
+			for _, point := range metric.Data.(metricdata.Sum[int64]).DataPoints {
+				values := map[string]string{}
+				for _, attr := range point.Attributes.ToSlice() {
+					values[string(attr.Key)] = attr.Value.AsString()
+				}
+				got[values["message_kind"]+"/"+values["result"]] = point.Value
+			}
+		}
+	}
+	assert.Equal(t, map[string]int64{"user/success": 1, "unknown/error": 1}, got)
+}

--- a/message-worker/store_cassandra.go
+++ b/message-worker/store_cassandra.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"time"
 
+	o11ycassandra "github.com/flywindy/o11y/cassandra"
 	"github.com/gocql/gocql"
 
 	"github.com/hmchangw/chat/pkg/atrest"
@@ -57,13 +58,25 @@ func toMentionSet(mentions []model.Participant) []*cassParticipant {
 
 // CassandraStore implements Store using a Cassandra session.
 type CassandraStore struct {
-	cassSession *gocql.Session
-	bucket      msgbucket.Sizer
-	cipher      atrest.Cipher // nil when ATREST_ENABLED=false
+	cassSession  *gocql.Session
+	bucket       msgbucket.Sizer
+	cipher       atrest.Cipher // nil when ATREST_ENABLED=false
+	newBatch     func(context.Context) *gocql.Batch
+	executeBatch func(context.Context, *gocql.Batch) error
 }
 
 func NewCassandraStore(session *gocql.Session, bucket msgbucket.Sizer, cipher atrest.Cipher) *CassandraStore {
-	return &CassandraStore{cassSession: session, bucket: bucket, cipher: cipher}
+	return &CassandraStore{
+		cassSession: session,
+		bucket:      bucket,
+		cipher:      cipher,
+		newBatch: func(ctx context.Context) *gocql.Batch {
+			return session.NewBatch(gocql.UnloggedBatch).WithContext(ctx)
+		},
+		executeBatch: func(ctx context.Context, batch *gocql.Batch) error {
+			return o11ycassandra.ExecuteBatch(ctx, session, batch)
+		},
+	}
 }
 
 // SaveMessage inserts msg into both messages_by_room and messages_by_id via a
@@ -83,7 +96,7 @@ func (s *CassandraStore) SaveMessage(ctx context.Context, msg *model.Message, se
 	b := s.bucket.Of(msg.CreatedAt)
 	mentions := toMentionSet(msg.Mentions)
 
-	batch := s.cassSession.NewBatch(gocql.UnloggedBatch).WithContext(ctx)
+	batch := s.newBatch(ctx)
 	batch.Query(
 		`INSERT INTO messages_by_room
 		   (room_id, bucket, created_at, message_id, sender, msg, site_id, updated_at,
@@ -104,7 +117,7 @@ func (s *CassandraStore) SaveMessage(ctx context.Context, msg *model.Message, se
 		mentions, msg.Type, msg.SysMsgData, msg.TShow, msg.QuotedParentMessage,
 		msg.Attachments, msg.Card, msg.CardAction,
 	)
-	if err := s.cassSession.ExecuteBatch(batch); err != nil {
+	if err := s.executeBatch(ctx, batch); err != nil {
 		return fmt.Errorf("save message %s: %w", msg.ID, err)
 	}
 	return nil
@@ -134,7 +147,7 @@ func (s *CassandraStore) saveMessageEncrypted(ctx context.Context, msg *model.Me
 	// attachments/card alongside the new enc_payload, and decryptIfNeeded would
 	// later overwrite them with empty fields from the bundle. sys_msg_data is
 	// NOT encrypted, so it is written as plaintext like any other metadata column.
-	batch := s.cassSession.NewBatch(gocql.UnloggedBatch).WithContext(ctx)
+	batch := s.newBatch(ctx)
 	batch.Query(
 		`INSERT INTO messages_by_room
 		   (room_id, bucket, created_at, message_id, sender, site_id, updated_at,
@@ -155,7 +168,7 @@ func (s *CassandraStore) saveMessageEncrypted(ctx context.Context, msg *model.Me
 		msg.ID, msg.CreatedAt, msg.RoomID, sender, siteID, msg.CreatedAt,
 		mentions, msg.Type, msg.TShow, cm.QuotedParentMessage, msg.SysMsgData, payload, encMeta,
 	)
-	if err := s.cassSession.ExecuteBatch(batch); err != nil {
+	if err := s.executeBatch(ctx, batch); err != nil {
 		return fmt.Errorf("save message %s: %w", msg.ID, err)
 	}
 	return nil
@@ -177,7 +190,7 @@ func (s *CassandraStore) SaveThreadMessage(ctx context.Context, msg *model.Messa
 	// One UnloggedBatch (same pattern as SaveMessage) groups the messages_by_id +
 	// thread_messages_by_thread writes (plus the conditional TShow mirror); each INSERT
 	// is idempotent so redelivery is safe. countAndSetParentTcount runs after commit.
-	batch := s.cassSession.NewBatch(gocql.UnloggedBatch).WithContext(ctx)
+	batch := s.newBatch(ctx)
 	batch.Query(
 		`INSERT INTO messages_by_id
 		 (message_id, created_at, room_id, sender, msg, site_id, updated_at, mentions,
@@ -219,7 +232,7 @@ func (s *CassandraStore) SaveThreadMessage(ctx context.Context, msg *model.Messa
 			msg.Attachments, msg.Card, msg.CardAction,
 		)
 	}
-	if err := s.cassSession.ExecuteBatch(batch); err != nil {
+	if err := s.executeBatch(ctx, batch); err != nil {
 		return nil, fmt.Errorf("save thread message %s: %w", msg.ID, err)
 	}
 
@@ -248,7 +261,7 @@ func (s *CassandraStore) saveThreadMessageEncrypted(ctx context.Context, msg *mo
 	// Single UnloggedBatch for both encrypted writes (plus the conditional TShow
 	// mirror) — same rationale as SaveThreadMessage. Encrypted body columns are bound
 	// NULL so a redelivered pre-encryption row can't end up in a hybrid state.
-	batch := s.cassSession.NewBatch(gocql.UnloggedBatch).WithContext(ctx)
+	batch := s.newBatch(ctx)
 	batch.Query(
 		`INSERT INTO messages_by_id
 		 (message_id, created_at, room_id, sender, site_id, updated_at, mentions,
@@ -290,7 +303,7 @@ func (s *CassandraStore) saveThreadMessageEncrypted(ctx context.Context, msg *mo
 			cm.QuotedParentMessage, msg.SysMsgData, payload, encMeta,
 		)
 	}
-	if err := s.cassSession.ExecuteBatch(batch); err != nil {
+	if err := s.executeBatch(ctx, batch); err != nil {
 		return nil, fmt.Errorf("save thread message %s: %w", msg.ID, err)
 	}
 

--- a/message-worker/store_cassandra_batch_test.go
+++ b/message-worker/store_cassandra_batch_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gocql/gocql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/msgbucket"
+)
+
+func TestCassandraStore_SaveMessage_InstrumentedBatchOutcome(t *testing.T) {
+	wantErr := errors.New("batch unavailable")
+	tests := []struct {
+		name     string
+		batchErr error
+		wantErr  string
+	}{
+		{name: "success"},
+		{name: "failure", batchErr: wantErr, wantErr: "save message message-1: batch unavailable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewCassandraStore(nil, msgbucket.New(time.Hour), nil)
+			store.newBatch = func(ctx context.Context) *gocql.Batch {
+				// No live session is allowed in a unit test; this constructor creates an offline batch.
+				//nolint:staticcheck // SA1019: session.NewBatch requires the prohibited live Cassandra dependency.
+				return gocql.NewBatch(gocql.UnloggedBatch).WithContext(ctx)
+			}
+			calls := 0
+			store.executeBatch = func(_ context.Context, batch *gocql.Batch) error {
+				calls++
+				assert.Len(t, batch.Entries, 2)
+				return tt.batchErr
+			}
+			msg := &model.Message{ID: "message-1", RoomID: "room-1", CreatedAt: time.UnixMilli(1_000)}
+
+			err := store.SaveMessage(context.Background(), msg, nil, "site-a")
+
+			assert.Equal(t, 1, calls)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tt.wantErr)
+				assert.ErrorIs(t, err, wantErr)
+			}
+		})
+	}
+}

--- a/message-worker/teamsbatch.go
+++ b/message-worker/teamsbatch.go
@@ -8,10 +8,12 @@ import (
 	"github.com/bytedance/sonic"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/nats-io/nats.go/jetstream"
+	"go.opentelemetry.io/otel"
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/jsretry"
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/teamsmigrate"
 )
@@ -30,6 +32,7 @@ type teamsBatchHandler struct {
 	siteID   string
 	resolver identityResolver
 	tr       MessageTransformer
+	metrics  *persistenceMetrics
 }
 
 func newTeamsBatchHandler(store Store, hrStore HRIdentityStore, siteID string, publishUsers func(ctx context.Context, users []model.IUserWithChange) error) *teamsBatchHandler {
@@ -40,6 +43,7 @@ func newTeamsBatchHandler(store Store, hrStore HRIdentityStore, siteID string, p
 		siteID:   siteID,
 		resolver: resolver,
 		tr:       NewDefaultTransformer(resolver),
+		metrics:  newPersistenceMetrics(otel.Meter("message-worker")),
 	}
 }
 
@@ -49,12 +53,14 @@ func newTeamsBatchHandler(store Store, hrStore HRIdentityStore, siteID string, p
 func (h *teamsBatchHandler) consume(ctx context.Context, msg jetstream.Msg) {
 	data, err := natsutil.DecodePayload(msg)
 	if err != nil {
+		natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalInvalidPayload)
 		// A corrupt frame never decodes on redelivery — drop it as poison.
 		jsretry.Settle(ctx, msg, jsretry.DefaultBackoff, errcode.Permanent(errcode.BadRequest("decode teams batch payload")))
 		return
 	}
 	var req model.TeamsBatchRequest
 	if err := sonic.Unmarshal(data, &req); err != nil {
+		natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalInvalidPayload)
 		// A malformed batch can never parse on redelivery — drop it as poison.
 		jsretry.Settle(ctx, msg, jsretry.DefaultBackoff, errcode.Permanent(errcode.BadRequest("malformed teams batch")))
 		return
@@ -123,11 +129,13 @@ func (h *teamsBatchHandler) migrateOne(ctx context.Context, raw json.RawMessage)
 	cass := &cassParticipant{ID: sender.UserID, EngName: sender.EngName, CompanyName: sender.ChineseName, Account: sender.Account}
 
 	if err := h.store.SaveMessage(ctx, &msg, cass, h.siteID); err != nil {
+		h.metrics.Record(ctx, "teams_migration", "error")
 		// A persist failure is infra: surface it so the batch Naks and replays.
 		slog.ErrorContext(ctx, "teams batch: save message failed", "teamsMsgId", head.ID, "error", err)
 		res.Status, res.Error = model.TeamsBatchError, "save message failed"
 		return res, err
 	}
+	h.metrics.Record(ctx, "teams_migration", "success")
 	res.Status = model.TeamsBatchPersisted
 	return res, nil
 }

--- a/message-worker/teamsbatch.go
+++ b/message-worker/teamsbatch.go
@@ -35,15 +35,21 @@ type teamsBatchHandler struct {
 	metrics  *persistenceMetrics
 }
 
-func newTeamsBatchHandler(store Store, hrStore HRIdentityStore, siteID string, publishUsers func(ctx context.Context, users []model.IUserWithChange) error) *teamsBatchHandler {
+func newTeamsBatchHandler(store Store, hrStore HRIdentityStore, siteID string, publishUsers func(ctx context.Context, users []model.IUserWithChange) error, injectedMetrics ...*persistenceMetrics) *teamsBatchHandler {
 	cache, _ := lru.New[string, resolvedSender](teamsSenderCacheSize) // errors only on size<=0
 	resolver := newSenderResolver(hrStore, siteID, cache, publishUsers)
+	var metrics *persistenceMetrics
+	if len(injectedMetrics) > 0 && injectedMetrics[0] != nil {
+		metrics = injectedMetrics[0]
+	} else {
+		metrics = newPersistenceMetrics(otel.Meter("message-worker"))
+	}
 	return &teamsBatchHandler{
 		store:    store,
 		siteID:   siteID,
 		resolver: resolver,
 		tr:       NewDefaultTransformer(resolver),
-		metrics:  newPersistenceMetrics(otel.Meter("message-worker")),
+		metrics:  metrics,
 	}
 }
 

--- a/message-worker/teamsbatch.go
+++ b/message-worker/teamsbatch.go
@@ -129,13 +129,13 @@ func (h *teamsBatchHandler) migrateOne(ctx context.Context, raw json.RawMessage)
 	cass := &cassParticipant{ID: sender.UserID, EngName: sender.EngName, CompanyName: sender.ChineseName, Account: sender.Account}
 
 	if err := h.store.SaveMessage(ctx, &msg, cass, h.siteID); err != nil {
-		h.metrics.Record(ctx, "teams_migration", "error")
+		h.metrics.Record(ctx, kindTeamsMigration, persistError)
 		// A persist failure is infra: surface it so the batch Naks and replays.
 		slog.ErrorContext(ctx, "teams batch: save message failed", "teamsMsgId", head.ID, "error", err)
 		res.Status, res.Error = model.TeamsBatchError, "save message failed"
 		return res, err
 	}
-	h.metrics.Record(ctx, "teams_migration", "success")
+	h.metrics.Record(ctx, kindTeamsMigration, persistSuccess)
 	res.Status = model.TeamsBatchPersisted
 	return res, nil
 }

--- a/notification-worker/emit.go
+++ b/notification-worker/emit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 )
 
 // publisher is the narrow sync-publish surface mobileEmitter needs; sync semantics let the
@@ -75,9 +76,11 @@ type jsPublisher struct {
 	js interface {
 		PublishMsg(ctx context.Context, msg *nats.Msg, opts ...jetstream.PublishOpt) (*jetstream.PubAck, error)
 	}
+	metrics natsmetrics.Publisher
 }
 
 func (p *jsPublisher) PublishMsg(ctx context.Context, msg *nats.Msg) error {
 	_, err := p.js.PublishMsg(ctx, msg)
+	p.metrics.Attempt(ctx, natsmetrics.DestinationPush, natsmetrics.OperationPushPublish, err)
 	return err
 }

--- a/notification-worker/handler.go
+++ b/notification-worker/handler.go
@@ -9,10 +9,12 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"go.opentelemetry.io/otel"
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/mention"
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
 	"github.com/hmchangw/chat/pkg/roommetacache"
@@ -50,7 +52,8 @@ type HandlerDeps struct {
 // Handler runs the per-message fan-out pipeline: exclusion filters, hook veto, EligibleForPush
 // routing, then the settings- and presence-gated shouldPush — one Emitter.Emit per surviving recipient.
 type Handler struct {
-	deps HandlerDeps
+	deps    HandlerDeps
+	metrics *notificationMetrics
 }
 
 // isNotifiable reports whether a message type produces push notifications.
@@ -71,12 +74,20 @@ func NewHandler(deps HandlerDeps) *Handler { //nolint:gocritic // hugeParam: one
 	if deps.Settings == nil {
 		deps.Settings = noopUserSettings{}
 	}
-	return &Handler{deps: deps}
+	return &Handler{deps: deps, metrics: newNotificationMetrics(otel.Meter("notification-worker"))}
 }
 
-func (h *Handler) HandleMessage(ctx context.Context, data []byte) error {
+func (h *Handler) HandleMessage(ctx context.Context, data []byte) (retErr error) {
+	outcome := "suppressed"
+	defer func() {
+		if retErr != nil && outcome == "suppressed" {
+			outcome = "failed"
+		}
+		h.metrics.Record(ctx, "push", outcome)
+	}()
 	var evt model.MessageEvent
 	if err := sonic.Unmarshal(data, &evt); err != nil {
+		natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalInvalidPayload)
 		// Malformed payload — it will never parse on redelivery. Mark permanent so the caller Acks (drops) it instead of retrying until MaxDeliver.
 		return errcode.Permanent(errcode.BadRequest("malformed message event"))
 	}
@@ -255,6 +266,7 @@ func (h *Handler) HandleMessage(ctx context.Context, data []byte) error {
 		evt.ID = fmt.Sprintf("%s-b%d", msg.ID, batchIdx)
 		evt.Accounts = batchAccounts
 		if err := h.deps.Emitter.Emit(ctx, evt); err != nil {
+			outcome = "publish_failed"
 			slog.Error("emit push batch failed", "error", err, "batch", batchIdx,
 				"recipients", len(batchAccounts), "messageId", msg.ID,
 				"request_id", natsutil.RequestIDFromContext(ctx))
@@ -264,6 +276,7 @@ func (h *Handler) HandleMessage(ctx context.Context, data []byte) error {
 	if len(emitErrs) > 0 {
 		return fmt.Errorf("emit push batches for message %s: %w", msg.ID, errors.Join(emitErrs...))
 	}
+	outcome = "sent"
 	return nil
 }
 

--- a/notification-worker/handler.go
+++ b/notification-worker/handler.go
@@ -46,7 +46,8 @@ type HandlerDeps struct {
 	Emitter            Emitter
 	RoomMeta           RoomMetaGetter // nil → title falls back to sender.Account
 	LargeRoomThreshold int
-	RecipientBatchSize int // per-event cap (≥ 1); 0 → defaultRecipientBatchSize
+	RecipientBatchSize int                  // per-event cap (≥ 1); 0 → defaultRecipientBatchSize
+	Metrics            *notificationMetrics // nil → built on the global meter
 }
 
 // Handler runs the per-message fan-out pipeline: exclusion filters, hook veto, EligibleForPush
@@ -74,16 +75,19 @@ func NewHandler(deps HandlerDeps) *Handler { //nolint:gocritic // hugeParam: one
 	if deps.Settings == nil {
 		deps.Settings = noopUserSettings{}
 	}
-	return &Handler{deps: deps, metrics: newNotificationMetrics(otel.Meter("notification-worker"))}
+	if deps.Metrics == nil {
+		deps.Metrics = newNotificationMetrics(otel.Meter("notification-worker"))
+	}
+	return &Handler{deps: deps, metrics: deps.Metrics}
 }
 
 func (h *Handler) HandleMessage(ctx context.Context, data []byte) (retErr error) {
-	outcome := "suppressed"
+	outcome := notifySuppressed
 	defer func() {
-		if retErr != nil && outcome == "suppressed" {
-			outcome = "failed"
+		if retErr != nil && outcome == notifySuppressed {
+			outcome = notifyFailed
 		}
-		h.metrics.Record(ctx, "push", outcome)
+		h.metrics.Record(ctx, notifyKindPush, outcome)
 	}()
 	var evt model.MessageEvent
 	if err := sonic.Unmarshal(data, &evt); err != nil {
@@ -266,7 +270,7 @@ func (h *Handler) HandleMessage(ctx context.Context, data []byte) (retErr error)
 		evt.ID = fmt.Sprintf("%s-b%d", msg.ID, batchIdx)
 		evt.Accounts = batchAccounts
 		if err := h.deps.Emitter.Emit(ctx, evt); err != nil {
-			outcome = "publish_failed"
+			outcome = notifyPublishFailed
 			slog.Error("emit push batch failed", "error", err, "batch", batchIdx,
 				"recipients", len(batchAccounts), "messageId", msg.ID,
 				"request_id", natsutil.RequestIDFromContext(ctx))
@@ -276,7 +280,7 @@ func (h *Handler) HandleMessage(ctx context.Context, data []byte) (retErr error)
 	if len(emitErrs) > 0 {
 		return fmt.Errorf("emit push batches for message %s: %w", msg.ID, errors.Join(emitErrs...))
 	}
-	outcome = "sent"
+	outcome = notifySent
 	return nil
 }
 

--- a/notification-worker/main.go
+++ b/notification-worker/main.go
@@ -141,7 +141,7 @@ func main() {
 		slog.Error("init observability failed", "error", err)
 		os.Exit(1)
 	}
-	sharedMetrics := natsmetrics.New(sdk.MeterProvider().Meter("chat.nats"))
+	sharedMetrics := natsmetrics.NewFromProvider(sdk.MeterProvider())
 	publishMetrics := sharedMetrics.Publisher("notification-worker", cfg.SiteID)
 	domainMetrics := newNotificationMetrics(sdk.MeterProvider().Meter("notification-worker"))
 
@@ -233,6 +233,7 @@ func main() {
 			cfg.SiteID,
 			cfg.PresenceBatchSize,
 			cfg.PresenceRPCTimeout,
+			publishMetrics,
 		)
 	}
 
@@ -244,7 +245,7 @@ func main() {
 	handler := NewHandler(HandlerDeps{
 		Members:            memberLookup,
 		Followers:          newMongoThreadFollowers(threadRoomCol),
-		Parent:             newHistoryParentFetcher(nc),
+		Parent:             newHistoryParentFetcher(nc, publishMetrics),
 		Presence:           presence,
 		Settings:           settings,
 		Hook:               noopVetoer{},
@@ -252,8 +253,8 @@ func main() {
 		RoomMeta:           roomMetaCache,
 		LargeRoomThreshold: cfg.LargeRoomThreshold,
 		RecipientBatchSize: cfg.PushRecipientBatchSize,
+		Metrics:            domainMetrics,
 	})
-	handler.metrics = domainMetrics
 
 	// Bounded worker drains the channel so slow Valkey doesn't block NATS dispatch; drops are safe because TTLs reconcile staleness.
 	invalCtx, invalCancel := context.WithCancel(ctx)
@@ -328,11 +329,11 @@ func main() {
 			sem <- struct{}{}
 			wg.Add(1)
 			go func(msgCtx context.Context, msg jetstream.Msg) {
-				tracked := consumerMetrics.Track(msgCtx, msg, natsmetrics.EventCreated, consumerCfg.MaxDeliver)
+				tracked := consumerMetrics.Track(msgCtx, msg, natsmetrics.EventTypeFromSubject(msg.Subject()), consumerCfg.MaxDeliver)
 				msg = tracked
 				msgCtx = tracked.Context(msgCtx)
 				defer func() {
-					tracked.FinishPending(msgCtx)
+					tracked.Finish(msgCtx)
 					<-sem
 					wg.Done()
 				}()
@@ -347,7 +348,7 @@ func main() {
 						if err := msg.Ack(); err != nil {
 							slog.Error("failed to ack migrated message", "error", err, "request_id", reqID)
 						}
-						domainMetrics.Record(handlerCtx, "push", "suppressed")
+						domainMetrics.Record(handlerCtx, notifyKindPush, notifySuppressed)
 						return
 					}
 					// Transient failures retry with backoff (never drop); malformed events Ack-drop as poison.

--- a/notification-worker/main.go
+++ b/notification-worker/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hmchangw/chat/pkg/jsretry"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
 	"github.com/hmchangw/chat/pkg/roommetacache"
@@ -140,6 +141,9 @@ func main() {
 		slog.Error("init observability failed", "error", err)
 		os.Exit(1)
 	}
+	sharedMetrics := natsmetrics.New(sdk.MeterProvider().Meter("chat.nats"))
+	publishMetrics := sharedMetrics.Publisher("notification-worker", cfg.SiteID)
+	domainMetrics := newNotificationMetrics(sdk.MeterProvider().Meter("notification-worker"))
 
 	readPref, err := mongoutil.ParseReadPreference(cfg.MongoReadPreference)
 	if err != nil {
@@ -206,16 +210,21 @@ func main() {
 		os.Exit(1)
 	}
 
-	cons, err := otelJS.CreateOrUpdateConsumer(ctx, wiring.CanonicalStream.Name, buildConsumerConfig(cfg.Consumer, cfg.Mode.ConsumerName("notification-worker"), wiring.CanonicalCreated))
+	consumerCfg := buildConsumerConfig(cfg.Consumer, cfg.Mode.ConsumerName("notification-worker"), wiring.CanonicalCreated)
+	consumerMetrics := sharedMetrics.Consumer(natsmetrics.ConsumerConfig{
+		ServiceName: "notification-worker", Site: cfg.SiteID,
+		Stream: wiring.CanonicalStream.Name, Consumer: consumerCfg.Durable,
+	})
+	consumerMetrics.LoopStopped(ctx)
+	cons, err := otelJS.CreateOrUpdateConsumer(ctx, wiring.CanonicalStream.Name, consumerCfg)
 	if err != nil {
 		slog.Error("create consumer failed", "error", err)
 		os.Exit(1)
 	}
-
 	// The broker advertises max_payload in its INFO on connect, so this is
 	// always in step with the server. An env var was a second source of truth
 	// that silently dropped batches whenever it drifted below the real limit.
-	emitter := newMobileEmitter(&jsPublisher{js: otelJS}, wiring.PushSendSubject, clampPayloadCap(nc.NatsConn().MaxPayload()))
+	emitter := newMobileEmitter(&jsPublisher{js: otelJS, metrics: publishMetrics}, wiring.PushSendSubject, clampPayloadCap(nc.NatsConn().MaxPayload()))
 
 	var presence PresenceSnapshotter = noopPresenceSnapshotter{}
 	if cfg.PresenceEnabled {
@@ -244,6 +253,7 @@ func main() {
 		LargeRoomThreshold: cfg.LargeRoomThreshold,
 		RecipientBatchSize: cfg.PushRecipientBatchSize,
 	})
+	handler.metrics = domainMetrics
 
 	// Bounded worker drains the channel so slow Valkey doesn't block NATS dispatch; drops are safe because TTLs reconcile staleness.
 	invalCtx, invalCancel := context.WithCancel(ctx)
@@ -303,6 +313,7 @@ func main() {
 		slog.Error("messages failed", "error", err)
 		os.Exit(1)
 	}
+	consumerMetrics.LoopStarted(ctx)
 
 	sem := make(chan struct{}, cfg.MaxWorkers)
 	var wg sync.WaitGroup
@@ -311,12 +322,17 @@ func main() {
 		for {
 			msgCtx, msg, err := iter.Next()
 			if err != nil {
+				consumerMetrics.LoopFailed(context.Background(), err)
 				return
 			}
 			sem <- struct{}{}
 			wg.Add(1)
-			go func() {
+			go func(msgCtx context.Context, msg jetstream.Msg) {
+				tracked := consumerMetrics.Track(msgCtx, msg, natsmetrics.EventCreated, consumerCfg.MaxDeliver)
+				msg = tracked
+				msgCtx = tracked.Context(msgCtx)
 				defer func() {
+					tracked.FinishPending(msgCtx)
 					<-sem
 					wg.Done()
 				}()
@@ -331,12 +347,13 @@ func main() {
 						if err := msg.Ack(); err != nil {
 							slog.Error("failed to ack migrated message", "error", err, "request_id", reqID)
 						}
+						domainMetrics.Record(handlerCtx, "push", "suppressed")
 						return
 					}
 					// Transient failures retry with backoff (never drop); malformed events Ack-drop as poison.
 					jsretry.Settle(handlerCtx, msg, jsretry.DefaultBackoff, handler.HandleMessage(handlerCtx, msg.Data()))
 				})
-			}()
+			}(msgCtx, msg)
 		}
 	}()
 
@@ -359,6 +376,7 @@ func main() {
 
 	shutdown.Wait(ctx, 25*time.Second,
 		func(_ context.Context) error {
+			consumerMetrics.LoopStopped(context.Background())
 			iter.Stop()
 			return nil
 		},

--- a/notification-worker/main.go
+++ b/notification-worker/main.go
@@ -319,7 +319,12 @@ func main() {
 	sem := make(chan struct{}, cfg.MaxWorkers)
 	var wg sync.WaitGroup
 
+	wg.Add(1)
 	go func() {
+		// The loop itself is counted so shutdown, which stops the iterator and
+		// then waits on wg, cannot pass through while a message Next already
+		// returned is still on its way to a worker.
+		defer wg.Done()
 		for {
 			msgCtx, msg, err := iter.Next()
 			if err != nil {

--- a/notification-worker/main.go
+++ b/notification-worker/main.go
@@ -189,7 +189,7 @@ func main() {
 	loader := &mongoMemberLoader{col: subCol}
 	memberLookup := newCachedMemberLookup(cache, loader.Load, cfg.RoomSubCacheTTL)
 
-	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)
+	nc, err := natsutil.ConnectWithMetrics(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace, sdk.MeterProvider())
 	if err != nil {
 		slog.Error("nats connect failed", "error", err)
 		os.Exit(1)

--- a/notification-worker/nats_metrics.go
+++ b/notification-worker/nats_metrics.go
@@ -5,6 +5,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 )
 
 // notifyKind and notifyResult are closed enums so a typo is a compile error
@@ -41,8 +42,14 @@ type notificationMetrics struct {
 }
 
 func newNotificationMetrics(meter metric.Meter) *notificationMetrics {
-	counter, _ := meter.Int64Counter("notification_worker_outcomes_total",
+	noopMeter := noop.NewMeterProvider().Meter("notification-worker")
+	counter, err := meter.Int64Counter("notification_worker_outcomes_total",
 		metric.WithDescription("Notification processing outcomes by bounded kind and result."))
+	if err != nil {
+		// Telemetry must never block startup: fall back to a no-op instrument so
+		// the service runs blind on this metric rather than not at all.
+		counter, _ = noopMeter.Int64Counter("notification_worker_outcomes_total")
+	}
 	m := &notificationMetrics{
 		outcomes: counter,
 		opts:     make(map[notifyKey]metric.MeasurementOption, len(allNotifyKinds)*len(allNotifyResults)),

--- a/notification-worker/nats_metrics.go
+++ b/notification-worker/nats_metrics.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type notificationMetrics struct{ outcomes metric.Int64Counter }
+
+func newNotificationMetrics(meter metric.Meter) *notificationMetrics {
+	counter, _ := meter.Int64Counter("notification_worker_outcomes_total",
+		metric.WithDescription("Notification processing outcomes by bounded kind and result."))
+	return &notificationMetrics{outcomes: counter}
+}
+
+func (m *notificationMetrics) Record(ctx context.Context, kind, result string) {
+	if m == nil || m.outcomes == nil {
+		return
+	}
+	if kind != "push" && kind != "notification" {
+		kind = "unknown"
+	}
+	switch result {
+	case "sent", "suppressed", "publish_failed", "failed":
+	default:
+		result = "failed"
+	}
+	m.outcomes.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("kind", kind), attribute.String("result", result)))
+}

--- a/notification-worker/nats_metrics.go
+++ b/notification-worker/nats_metrics.go
@@ -7,26 +7,64 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
-type notificationMetrics struct{ outcomes metric.Int64Counter }
+// notifyKind and notifyResult are closed enums so a typo is a compile error
+// rather than a silent `unknown` series at campaign time.
+type notifyKind string
+
+const (
+	notifyKindPush         notifyKind = "push"
+	notifyKindNotification notifyKind = "notification"
+	notifyKindUnknown      notifyKind = "unknown"
+)
+
+var allNotifyKinds = []notifyKind{notifyKindPush, notifyKindNotification, notifyKindUnknown}
+
+type notifyResult string
+
+const (
+	notifySent          notifyResult = "sent"
+	notifySuppressed    notifyResult = "suppressed"
+	notifyPublishFailed notifyResult = "publish_failed"
+	notifyFailed        notifyResult = "failed"
+)
+
+var allNotifyResults = []notifyResult{notifySent, notifySuppressed, notifyPublishFailed, notifyFailed}
+
+type notifyKey struct {
+	kind   notifyKind
+	result notifyResult
+}
+
+type notificationMetrics struct {
+	outcomes metric.Int64Counter
+	opts     map[notifyKey]metric.MeasurementOption
+}
 
 func newNotificationMetrics(meter metric.Meter) *notificationMetrics {
 	counter, _ := meter.Int64Counter("notification_worker_outcomes_total",
 		metric.WithDescription("Notification processing outcomes by bounded kind and result."))
-	return &notificationMetrics{outcomes: counter}
+	m := &notificationMetrics{
+		outcomes: counter,
+		opts:     make(map[notifyKey]metric.MeasurementOption, len(allNotifyKinds)*len(allNotifyResults)),
+	}
+	for _, kind := range allNotifyKinds {
+		for _, result := range allNotifyResults {
+			m.opts[notifyKey{kind, result}] = metric.WithAttributes(
+				attribute.String("kind", string(kind)),
+				attribute.String("result", string(result)),
+			)
+		}
+	}
+	return m
 }
 
-func (m *notificationMetrics) Record(ctx context.Context, kind, result string) {
+func (m *notificationMetrics) Record(ctx context.Context, kind notifyKind, result notifyResult) {
 	if m == nil || m.outcomes == nil {
 		return
 	}
-	if kind != "push" && kind != "notification" {
-		kind = "unknown"
+	opt, ok := m.opts[notifyKey{kind, result}]
+	if !ok {
+		opt = m.opts[notifyKey{notifyKindUnknown, notifyFailed}]
 	}
-	switch result {
-	case "sent", "suppressed", "publish_failed", "failed":
-	default:
-		result = "failed"
-	}
-	m.outcomes.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("kind", kind), attribute.String("result", result)))
+	m.outcomes.Add(ctx, 1, opt)
 }

--- a/notification-worker/nats_metrics_test.go
+++ b/notification-worker/nats_metrics_test.go
@@ -2,12 +2,17 @@ package main
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/roomsubcache"
 )
 
 func TestNotificationMetrics_BoundedLabels(t *testing.T) {
@@ -35,4 +40,75 @@ func TestNotificationMetrics_BoundedLabels(t *testing.T) {
 		}
 	}
 	assert.Equal(t, map[string]int64{"push/sent": 1, "unknown/failed": 1}, got)
+}
+
+func TestHandler_HandleMessage_RecordsNotificationOutcomes(t *testing.T) {
+	tests := []struct {
+		name        string
+		messageType string
+		emitter     Emitter
+		wantResult  string
+		wantError   bool
+	}{
+		{name: "sent", messageType: model.MessageTypeImportant, emitter: &recordingEmitter{}, wantResult: "sent"},
+		{name: "suppressed", messageType: model.MessageTypeRoomRenamed, emitter: &recordingEmitter{}, wantResult: "suppressed"},
+		{name: "publish failed", messageType: model.MessageTypeImportant, emitter: failingEmitter{err: errors.New("publish failed")}, wantResult: "publish_failed", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := sdkmetric.NewManualReader()
+			mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+			metrics := newNotificationMetrics(mp.Meter("test"))
+			h := NewHandler(HandlerDeps{
+				Members: &stubMembers{out: map[string][]roomsubcache.Member{
+					"r1": {{ID: "alice", Account: "alice"}, {ID: "bob", Account: "bob"}},
+				}},
+				Followers:          &stubFollowers{},
+				Parent:             stubParent{},
+				Presence:           noopPresenceSnapshotter{},
+				Settings:           noopUserSettings{},
+				Hook:               noopVetoer{},
+				Emitter:            tt.emitter,
+				LargeRoomThreshold: 500,
+				Metrics:            metrics,
+			})
+
+			err := h.HandleMessage(context.Background(), msgEvent(&model.Message{
+				ID: "m1", RoomID: "r1", UserID: "alice", UserAccount: "alice",
+				Type: tt.messageType, CreatedAt: time.Now(),
+			}))
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			var rm metricdata.ResourceMetrics
+			require.NoError(t, reader.Collect(context.Background(), &rm))
+			var got int64
+			for _, scope := range rm.ScopeMetrics {
+				for _, metric := range scope.Metrics {
+					if metric.Name != "notification_worker_outcomes_total" {
+						continue
+					}
+					for _, point := range metric.Data.(metricdata.Sum[int64]).DataPoints {
+						attrs := map[string]string{}
+						for _, attr := range point.Attributes.ToSlice() {
+							attrs[string(attr.Key)] = attr.Value.AsString()
+						}
+						if attrs["kind"] == "push" && attrs["result"] == tt.wantResult {
+							got += point.Value
+						}
+					}
+				}
+			}
+			assert.Equal(t, int64(1), got)
+		})
+	}
+}
+
+func TestNotificationMetrics_Record_NilReceiverIsSafe(t *testing.T) {
+	var metrics *notificationMetrics
+	metrics.Record(context.Background(), notifyKindPush, notifySent)
 }

--- a/notification-worker/nats_metrics_test.go
+++ b/notification-worker/nats_metrics_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestNotificationMetrics_BoundedLabels(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	m := newNotificationMetrics(mp.Meter("test"))
+	m.Record(context.Background(), "push", "sent")
+	m.Record(context.Background(), "dynamic", "secret")
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	got := map[string]int64{}
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != "notification_worker_outcomes_total" {
+				continue
+			}
+			for _, point := range metric.Data.(metricdata.Sum[int64]).DataPoints {
+				values := map[string]string{}
+				for _, attr := range point.Attributes.ToSlice() {
+					values[string(attr.Key)] = attr.Value.AsString()
+				}
+				got[values["kind"]+"/"+values["result"]] = point.Value
+			}
+		}
+	}
+	assert.Equal(t, map[string]int64{"push/sent": 1, "unknown/failed": 1}, got)
+}

--- a/notification-worker/parent_fetcher.go
+++ b/notification-worker/parent_fetcher.go
@@ -8,8 +8,10 @@ import (
 	"github.com/bytedance/sonic"
 
 	o11ynats "github.com/flywindy/o11y/nats"
+	"go.opentelemetry.io/otel"
 
 	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/subject"
 )
@@ -35,11 +37,12 @@ type ParentFetcher interface {
 // historyParentFetcher resolves the parent via a NATS request to history-service's
 // GetMessageByID handler, reading the author + createdAt the fan-out needs.
 type historyParentFetcher struct {
-	nc *o11ynats.Conn
+	nc      *o11ynats.Conn
+	metrics *natsmetrics.Metrics
 }
 
 func newHistoryParentFetcher(nc *o11ynats.Conn) *historyParentFetcher {
-	return &historyParentFetcher{nc: nc}
+	return &historyParentFetcher{nc: nc, metrics: natsmetrics.New(otel.Meter("chat.nats"))}
 }
 
 // getMessageByIDRequest mirrors history-service's GetMessageByIDRequest wire shape.
@@ -66,7 +69,11 @@ func (f *historyParentFetcher) FetchParent(ctx context.Context, account, roomID,
 	if err != nil {
 		return nil, fmt.Errorf("marshal GetMessageByID request: %w", err)
 	}
+	started := time.Now()
 	msg, err := f.nc.Request(ctx, subject.MsgGet(account, roomID, siteID), reqBytes, parentFetchTimeout)
+	if f.metrics != nil {
+		f.metrics.Publisher("notification-worker", siteID).Request(ctx, natsmetrics.OperationHistoryGetMessage, time.Since(started), err)
+	}
 	if err != nil {
 		return nil, natsutil.RequestFailure(fmt.Sprintf("history request for parent %s", messageID), err)
 	}

--- a/notification-worker/parent_fetcher.go
+++ b/notification-worker/parent_fetcher.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bytedance/sonic"
 
 	o11ynats "github.com/flywindy/o11y/nats"
-	"go.opentelemetry.io/otel"
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/natsmetrics"
@@ -37,12 +36,15 @@ type ParentFetcher interface {
 // historyParentFetcher resolves the parent via a NATS request to history-service's
 // GetMessageByID handler, reading the author + createdAt the fan-out needs.
 type historyParentFetcher struct {
-	nc      *o11ynats.Conn
-	metrics *natsmetrics.Metrics
+	nc *o11ynats.Conn
+	// metrics is injected: building a second natsmetrics.Metrics here would
+	// duplicate all nine shared instruments on a different construction path.
+	// The zero value is safe and records nothing.
+	metrics natsmetrics.Publisher
 }
 
-func newHistoryParentFetcher(nc *o11ynats.Conn) *historyParentFetcher {
-	return &historyParentFetcher{nc: nc, metrics: natsmetrics.New(otel.Meter("chat.nats"))}
+func newHistoryParentFetcher(nc *o11ynats.Conn, metrics natsmetrics.Publisher) *historyParentFetcher {
+	return &historyParentFetcher{nc: nc, metrics: metrics}
 }
 
 // getMessageByIDRequest mirrors history-service's GetMessageByIDRequest wire shape.
@@ -71,9 +73,7 @@ func (f *historyParentFetcher) FetchParent(ctx context.Context, account, roomID,
 	}
 	started := time.Now()
 	msg, err := f.nc.Request(ctx, subject.MsgGet(account, roomID, siteID), reqBytes, parentFetchTimeout)
-	if f.metrics != nil {
-		f.metrics.Publisher("notification-worker", siteID).Request(ctx, natsmetrics.OperationHistoryGetMessage, time.Since(started), err)
-	}
+	f.metrics.Request(ctx, natsmetrics.OperationHistoryGetMessage, time.Since(started), err)
 	if err != nil {
 		return nil, natsutil.RequestFailure(fmt.Sprintf("history request for parent %s", messageID), err)
 	}

--- a/notification-worker/parent_fetcher_test.go
+++ b/notification-worker/parent_fetcher_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hmchangw/chat/pkg/natsmetrics"
+
 	natsserver "github.com/nats-io/nats-server/v2/server"
 	nats "github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
@@ -60,7 +62,7 @@ func TestHistoryParentFetcher_FetchParent(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		fetcher := newHistoryParentFetcher(nc)
+		fetcher := newHistoryParentFetcher(nc, natsmetrics.Publisher{})
 		got, err := fetcher.FetchParent(context.Background(), account, roomID, siteID, messageID)
 		require.NoError(t, err)
 		require.NotNil(t, got)
@@ -77,7 +79,7 @@ func TestHistoryParentFetcher_FetchParent(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		fetcher := newHistoryParentFetcher(nc)
+		fetcher := newHistoryParentFetcher(nc, natsmetrics.Publisher{})
 		got, err := fetcher.FetchParent(context.Background(), account, roomID, siteID, messageID)
 		require.Error(t, err)
 		assert.Nil(t, got)
@@ -90,7 +92,7 @@ func TestHistoryParentFetcher_FetchParent(t *testing.T) {
 		nc := startTestNATS(t)
 		// Intentionally no subscriber: nc.Request must fail with "no responders".
 
-		fetcher := newHistoryParentFetcher(nc)
+		fetcher := newHistoryParentFetcher(nc, natsmetrics.Publisher{})
 		got, err := fetcher.FetchParent(context.Background(), account, roomID, siteID, messageID)
 		require.Error(t, err)
 		assert.Nil(t, got)
@@ -104,7 +106,7 @@ func TestHistoryParentFetcher_FetchParent(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		fetcher := newHistoryParentFetcher(nc)
+		fetcher := newHistoryParentFetcher(nc, natsmetrics.Publisher{})
 		got, err := fetcher.FetchParent(context.Background(), account, roomID, siteID, messageID)
 		require.Error(t, err)
 		assert.Nil(t, got)

--- a/notification-worker/presence.go
+++ b/notification-worker/presence.go
@@ -10,9 +10,11 @@ import (
 	"github.com/bytedance/sonic"
 
 	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/subject"
 )
 
@@ -39,6 +41,7 @@ type bulkPresenceSource struct {
 	siteID    string
 	batchSize int
 	timeout   time.Duration
+	metrics   *natsmetrics.Metrics
 }
 
 func newBulkPresenceSource(req presenceRequester, siteID string, batchSize int, timeout time.Duration) *bulkPresenceSource {
@@ -48,7 +51,7 @@ func newBulkPresenceSource(req presenceRequester, siteID string, batchSize int, 
 	if timeout <= 0 {
 		timeout = 2 * time.Second
 	}
-	return &bulkPresenceSource{req: req, siteID: siteID, batchSize: batchSize, timeout: timeout}
+	return &bulkPresenceSource{req: req, siteID: siteID, batchSize: batchSize, timeout: timeout, metrics: natsmetrics.New(otel.Meter("chat.nats"))}
 }
 
 func (b *bulkPresenceSource) Snapshot(ctx context.Context, accounts []string) (map[string]model.Presence, error) {
@@ -73,7 +76,11 @@ func (b *bulkPresenceSource) Snapshot(ctx context.Context, accounts []string) (m
 				slog.Warn("presence marshal failed", "error", err)
 				return
 			}
+			started := time.Now()
 			msg, err := b.req.Request(ctx, subj, data, b.timeout)
+			if b.metrics != nil {
+				b.metrics.Publisher("notification-worker", b.siteID).Request(ctx, natsmetrics.OperationPresenceLookup, time.Since(started), err)
+			}
 			if err != nil {
 				slog.Warn("presence rpc failed", "error", err, "chunk", len(ch))
 				return

--- a/notification-worker/presence.go
+++ b/notification-worker/presence.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bytedance/sonic"
 
 	"github.com/nats-io/nats.go"
-	"go.opentelemetry.io/otel"
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
@@ -41,17 +40,18 @@ type bulkPresenceSource struct {
 	siteID    string
 	batchSize int
 	timeout   time.Duration
-	metrics   *natsmetrics.Metrics
+	// metrics is injected; the zero value is safe and records nothing.
+	metrics natsmetrics.Publisher
 }
 
-func newBulkPresenceSource(req presenceRequester, siteID string, batchSize int, timeout time.Duration) *bulkPresenceSource {
+func newBulkPresenceSource(req presenceRequester, siteID string, batchSize int, timeout time.Duration, metrics natsmetrics.Publisher) *bulkPresenceSource {
 	if batchSize <= 0 {
 		batchSize = 512
 	}
 	if timeout <= 0 {
 		timeout = 2 * time.Second
 	}
-	return &bulkPresenceSource{req: req, siteID: siteID, batchSize: batchSize, timeout: timeout, metrics: natsmetrics.New(otel.Meter("chat.nats"))}
+	return &bulkPresenceSource{req: req, siteID: siteID, batchSize: batchSize, timeout: timeout, metrics: metrics}
 }
 
 func (b *bulkPresenceSource) Snapshot(ctx context.Context, accounts []string) (map[string]model.Presence, error) {
@@ -78,9 +78,7 @@ func (b *bulkPresenceSource) Snapshot(ctx context.Context, accounts []string) (m
 			}
 			started := time.Now()
 			msg, err := b.req.Request(ctx, subj, data, b.timeout)
-			if b.metrics != nil {
-				b.metrics.Publisher("notification-worker", b.siteID).Request(ctx, natsmetrics.OperationPresenceLookup, time.Since(started), err)
-			}
+			b.metrics.Request(ctx, natsmetrics.OperationPresenceLookup, time.Since(started), err)
 			if err != nil {
 				slog.Warn("presence rpc failed", "error", err, "chunk", len(ch))
 				return

--- a/notification-worker/presence_test.go
+++ b/notification-worker/presence_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hmchangw/chat/pkg/natsmetrics"
+
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -197,7 +199,7 @@ func TestBulkPresence_Chunks(t *testing.T) {
 		return out, nil
 	}}
 
-	src := newBulkPresenceSource(stub, "site-a", 500, time.Second)
+	src := newBulkPresenceSource(stub, "site-a", 500, time.Second, natsmetrics.Publisher{})
 	got, err := src.Snapshot(context.Background(), accounts)
 	require.NoError(t, err)
 	assert.Equal(t, 3, stub.calls, "expect ceil(1500/500) chunks")
@@ -208,7 +210,7 @@ func TestBulkPresence_FailOpenOnError(t *testing.T) {
 	stub := &stubRequester{reply: func(model.PresenceSnapshotRequest) (model.PresenceSnapshotReply, error) {
 		return model.PresenceSnapshotReply{}, errors.New("nats: timeout")
 	}}
-	src := newBulkPresenceSource(stub, "site-a", 100, 50*time.Millisecond)
+	src := newBulkPresenceSource(stub, "site-a", 100, 50*time.Millisecond, natsmetrics.Publisher{})
 	got, err := src.Snapshot(context.Background(), []string{"a", "b"})
 	require.NoError(t, err)
 	assert.Empty(t, got)
@@ -220,7 +222,7 @@ func TestBulkPresence_ErrorResponseLoggedAndFailOpen(t *testing.T) {
 			return errnats.MarshalQuiet(errcode.Internal("presence backend down")), nil
 		},
 	}
-	src := newBulkPresenceSource(stub, "site-a", 100, 50*time.Millisecond)
+	src := newBulkPresenceSource(stub, "site-a", 100, 50*time.Millisecond, natsmetrics.Publisher{})
 	got, err := src.Snapshot(context.Background(), []string{"alice", "bob"})
 	require.NoError(t, err) // fail-open: error envelope is swallowed
 	assert.Empty(t, got)

--- a/pkg/cassutil/cass.go
+++ b/pkg/cassutil/cass.go
@@ -39,7 +39,7 @@ func Connect(cfg Config, opts ...Option) (*gocql.Session, error) {
 	if cc.obs != nil {
 		// gocql attaches observers via the ClusterConfig, so o11y must build the
 		// session rather than wrap a live one. Batch spans additionally require
-		// o11ycassandra.ExecuteBatch at the call site (a Phase 3 concern).
+		// o11ycassandra.ExecuteBatch at each production call site.
 		session, err = o11ycassandra.NewSession(cluster, cc.obs.TracerProvider(), cc.obs.MeterProvider())
 	} else {
 		session, err = cluster.CreateSession()

--- a/pkg/jobguard/jobguard.go
+++ b/pkg/jobguard/jobguard.go
@@ -51,6 +51,9 @@ func Guard(label string, fn func()) (panicked bool) {
 // natsrouter.Recovery, which Acks-on-panic with an Internal reply.
 func Run(msg Message, process func()) {
 	if Guard(msg.Subject(), process) {
+		if marker, ok := msg.(interface{ MarkHandlerPanic() }); ok {
+			marker.MarkHandlerPanic()
+		}
 		if err := msg.Ack(); err != nil {
 			slog.Error("failed to ack after panic", "error", err, "subject", msg.Subject())
 			return

--- a/pkg/jobguard/jobguard_test.go
+++ b/pkg/jobguard/jobguard_test.go
@@ -16,10 +16,12 @@ type fakeMsg struct {
 	acked    bool
 	ackCalls int
 	ackErr   error
+	marked   bool
 }
 
-func (m *fakeMsg) Subject() string { return m.subject }
-func (m *fakeMsg) Ack() error      { m.acked = true; m.ackCalls++; return m.ackErr }
+func (m *fakeMsg) Subject() string   { return m.subject }
+func (m *fakeMsg) Ack() error        { m.acked = true; m.ackCalls++; return m.ackErr }
+func (m *fakeMsg) MarkHandlerPanic() { m.marked = true }
 
 func TestGuard_NoPanic_RunsFnAndReportsFalse(t *testing.T) {
 	ran := false
@@ -43,6 +45,7 @@ func TestRun_Panic_AcksAsPoisonDrop(t *testing.T) {
 	}, "a panicking process must be recovered, not crash the worker")
 	assert.True(t, msg.acked, "panic must Ack (poison-pill drop) — a deterministic panic would otherwise crash-loop via redelivery")
 	assert.Equal(t, 1, msg.ackCalls)
+	assert.True(t, msg.marked, "panic drops must expose terminal failure evidence")
 }
 
 func TestRun_NoPanic_DoesNotAck(t *testing.T) {

--- a/pkg/natsmetrics/buckets_test.go
+++ b/pkg/natsmetrics/buckets_test.go
@@ -1,0 +1,45 @@
+package natsmetrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flywindy/o11y"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// The OTel SDK default histogram boundaries top out at 10000 and start at 0/5,
+// which puts every sub-second NATS duration in the first bucket. Both latency
+// histograms must instead carry the SDK's shared latency boundaries so p95/p99
+// are comparable with the http.server.* families.
+func TestLatencyHistogramsUseSharedLatencyBuckets(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	c := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "s1", Stream: "STREAM_s1", Consumer: "durable"})
+	tracked := c.Track(context.Background(), &fakeMsg{}, EventCreated, 5)
+	require.NoError(t, tracked.Ack())
+	m.Publisher("svc", "s1").Request(context.Background(), OperationPresenceLookup, 0, nil)
+
+	rm := collect(t, reader)
+	want := o11y.DefaultLatencyBuckets()
+	for _, name := range []string{"chat.nats.consumer.processing.duration", "chat.nats.request.duration"} {
+		points := histogramPoints(t, rm, name)
+		require.Len(t, points, 1, name)
+		assert.Equal(t, want, points[0].Bounds, name)
+	}
+}
+
+func TestNewFromProviderUsesPackageScope(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	m := NewFromProvider(mp)
+	m.Publisher("svc", "s1").Attempt(context.Background(), DestinationCanonical, OperationCanonicalPublish, nil)
+
+	rm := collect(t, reader)
+	var scopes []string
+	for _, scope := range rm.ScopeMetrics {
+		scopes = append(scopes, scope.Scope.Name)
+	}
+	assert.Contains(t, scopes, ScopeName)
+}

--- a/pkg/natsmetrics/disposition_test.go
+++ b/pkg/natsmetrics/disposition_test.go
@@ -1,0 +1,146 @@
+package natsmetrics
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A delivery that ends without Ack/Nak/Term while the loop is still up relies
+// on AckWait redelivery, which is `left_pending`. The same delivery during
+// shutdown is `handler_cancelled` — the campaign has to tell those apart.
+func TestFinishDistinguishesCancellationFromAckWait(t *testing.T) {
+	tests := []struct {
+		name   string
+		loopUp bool
+		ctx    func() context.Context
+		want   Outcome
+	}{
+		{name: "loop up and live context", loopUp: true, ctx: context.Background, want: OutcomeLeftPending},
+		{name: "loop already stopped", loopUp: false, ctx: context.Background, want: OutcomeHandlerCancelled},
+		{
+			name:   "cancelled handler context",
+			loopUp: true,
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			want: OutcomeHandlerCancelled,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, reader := newTestMetrics(t)
+			c := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "s1", Stream: "STREAM_s1", Consumer: "durable"})
+			if tt.loopUp {
+				c.LoopStarted(context.Background())
+			}
+			tracked := c.Track(context.Background(), &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}}, EventCreated, 5)
+
+			tracked.Finish(tt.ctx())
+
+			rm := collect(t, reader)
+			points := metricPoints[int64](t, rm, "chat.nats.consumer.messages")
+			require.Len(t, points, 1)
+			assert.Equal(t, string(tt.want), attrs(points[0])["outcome"])
+		})
+	}
+}
+
+// An explicit Term is a deliberate application drop, not an unexpected fault.
+// Recording it as `internal` would trip the terminal-delivery alert as if the
+// service had malfunctioned.
+func TestTermRecordsPermanentNotInternal(t *testing.T) {
+	for _, name := range []string{"Term", "TermWithReason"} {
+		t.Run(name, func(t *testing.T) {
+			m, reader := newTestMetrics(t)
+			c := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "s1", Stream: "STREAM_s1", Consumer: "durable"})
+			tracked := c.Track(context.Background(), &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}}, EventCreated, 5)
+
+			if name == "Term" {
+				require.NoError(t, tracked.Term())
+			} else {
+				require.NoError(t, tracked.TermWithReason("caller supplied free text"))
+			}
+
+			rm := collect(t, reader)
+			points := metricPoints[int64](t, rm, "chat.nats.terminal.failures")
+			require.Len(t, points, 1)
+			assert.Equal(t, string(TerminalPermanent), attrs(points[0])["reason"])
+		})
+	}
+}
+
+// A handler that already classified the drop keeps its own reason: the first
+// MarkTerminal wins, so Term must not overwrite `invalid_payload`.
+func TestTermDoesNotOverwriteHandlerClassification(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	c := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "s1", Stream: "STREAM_s1", Consumer: "durable"})
+	tracked := c.Track(context.Background(), &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}}, EventCreated, 5)
+
+	tracked.MarkTerminal(context.Background(), TerminalInvalidPayload)
+	require.NoError(t, tracked.Term())
+
+	rm := collect(t, reader)
+	points := metricPoints[int64](t, rm, "chat.nats.terminal.failures")
+	require.Len(t, points, 1)
+	assert.Equal(t, string(TerminalInvalidPayload), attrs(points[0])["reason"])
+}
+
+// Classification must not run on the single dispatch goroutine: a slow
+// classifier would otherwise serialize the whole consumer.
+func TestConsumeClassifiesOffTheDispatchPath(t *testing.T) {
+	release := make(chan struct{})
+	var dispatched sync.WaitGroup
+	dispatched.Add(2)
+
+	iter := &scriptedIterator{msgs: []jetstream.Msg{
+		&fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}},
+		&fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}},
+	}}
+	m, _ := newTestMetrics(t)
+	c := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "s1", Stream: "STREAM_s1", Consumer: "durable"})
+	c.LoopStarted(context.Background())
+
+	var wg sync.WaitGroup
+	go Consume(context.Background(), iter, c, 4, 5, &wg,
+		func(jetstream.Msg) EventType {
+			dispatched.Done()
+			<-release // block every classifier until both messages are dispatched
+			return EventCreated
+		},
+		func(context.Context, *Message) {})
+
+	done := make(chan struct{})
+	go func() { dispatched.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second message was not dispatched while the first classifier was still running")
+	}
+	close(release)
+	wg.Wait()
+}
+
+// scriptedIterator yields msgs in order and then blocks so Consume keeps running.
+type scriptedIterator struct {
+	mu   sync.Mutex
+	msgs []jetstream.Msg
+}
+
+func (s *scriptedIterator) Next(...jetstream.NextOpt) (context.Context, jetstream.Msg, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.msgs) == 0 {
+		return nil, nil, jetstream.ErrConsumerDeleted
+	}
+	msg := s.msgs[0]
+	s.msgs = s.msgs[1:]
+	return context.Background(), msg, nil
+}

--- a/pkg/natsmetrics/loop.go
+++ b/pkg/natsmetrics/loop.go
@@ -1,0 +1,46 @@
+package natsmetrics
+
+import (
+	"context"
+	"sync"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// Iterator is the context-aware pull iterator surface used by the o11y NATS
+// wrapper. It is intentionally small so loop failure behavior is unit-testable.
+type Iterator interface {
+	Next(...jetstream.NextOpt) (context.Context, jetstream.Msg, error)
+}
+
+type ClassifyEvent func(jetstream.Msg) EventType
+type ProcessMessage func(context.Context, *Message)
+
+// Consume runs the existing bounded concurrent pull pattern. Callers mark the
+// loop started only after iterator creation succeeds; Consume marks it stopped
+// before returning from a terminal Next failure.
+func Consume(iter Iterator, consumer *Consumer, maxWorkers, maxDeliver int, wg *sync.WaitGroup, classify ClassifyEvent, process ProcessMessage) {
+	sem := make(chan struct{}, maxWorkers)
+	for {
+		msgCtx, msg, err := iter.Next()
+		if err != nil {
+			consumer.LoopFailed(context.Background(), err)
+			return
+		}
+		eventType := EventUnknown
+		if classify != nil {
+			eventType = NormalizeEventType(string(classify(msg)))
+		}
+		sem <- struct{}{}
+		wg.Add(1)
+		go func() {
+			tracked := consumer.Track(msgCtx, msg, eventType, maxDeliver)
+			defer func() {
+				tracked.FinishPending(msgCtx)
+				<-sem
+				wg.Done()
+			}()
+			process(tracked.Context(msgCtx), tracked)
+		}()
+	}
+}

--- a/pkg/natsmetrics/loop.go
+++ b/pkg/natsmetrics/loop.go
@@ -16,6 +16,19 @@ type Iterator interface {
 type ClassifyEvent func(jetstream.Msg) EventType
 type ProcessMessage func(context.Context, *Message)
 
+// Start registers the consumer loop with wg and then runs Consume in its own
+// goroutine. Registering before returning is the point: shutdown stops the
+// iterator and then waits on wg, so a loop counted only once it dispatches a
+// message lets that wait pass through while a message Next already returned is
+// still on its way to a worker.
+func Start(ctx context.Context, iter Iterator, consumer *Consumer, maxWorkers, maxDeliver int, wg *sync.WaitGroup, classify ClassifyEvent, process ProcessMessage) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		Consume(ctx, iter, consumer, maxWorkers, maxDeliver, wg, classify, process)
+	}()
+}
+
 // Consume runs the existing bounded concurrent pull pattern. Callers mark the
 // loop started only after iterator creation succeeds; Consume marks it stopped
 // before returning from a terminal Next failure.
@@ -24,6 +37,12 @@ type ProcessMessage func(context.Context, *Message)
 // classifier that parses the payload would otherwise serialize the whole
 // consumer behind one message at a time.
 func Consume(ctx context.Context, iter Iterator, consumer *Consumer, maxWorkers, maxDeliver int, wg *sync.WaitGroup, classify ClassifyEvent, process ProcessMessage) {
+	// A zero maxWorkers would make sem unbuffered and park the dispatch send
+	// forever — the loop stops consuming with no error and no terminal metric,
+	// while the loop-up gauge still reads 1. A negative one panics in make.
+	if maxWorkers < 1 {
+		maxWorkers = 1
+	}
 	sem := make(chan struct{}, maxWorkers)
 	for {
 		msgCtx, msg, err := iter.Next()

--- a/pkg/natsmetrics/loop.go
+++ b/pkg/natsmetrics/loop.go
@@ -19,28 +19,32 @@ type ProcessMessage func(context.Context, *Message)
 // Consume runs the existing bounded concurrent pull pattern. Callers mark the
 // loop started only after iterator creation succeeds; Consume marks it stopped
 // before returning from a terminal Next failure.
-func Consume(iter Iterator, consumer *Consumer, maxWorkers, maxDeliver int, wg *sync.WaitGroup, classify ClassifyEvent, process ProcessMessage) {
+//
+// classify runs inside the worker goroutine, not on the dispatch path: a
+// classifier that parses the payload would otherwise serialize the whole
+// consumer behind one message at a time.
+func Consume(ctx context.Context, iter Iterator, consumer *Consumer, maxWorkers, maxDeliver int, wg *sync.WaitGroup, classify ClassifyEvent, process ProcessMessage) {
 	sem := make(chan struct{}, maxWorkers)
 	for {
 		msgCtx, msg, err := iter.Next()
 		if err != nil {
-			consumer.LoopFailed(context.Background(), err)
+			consumer.LoopFailed(ctx, err)
 			return
-		}
-		eventType := EventUnknown
-		if classify != nil {
-			eventType = NormalizeEventType(string(classify(msg)))
 		}
 		sem <- struct{}{}
 		wg.Add(1)
-		go func() {
+		go func(msgCtx context.Context, msg jetstream.Msg) {
+			eventType := EventUnknown
+			if classify != nil {
+				eventType = NormalizeEventType(string(classify(msg)))
+			}
 			tracked := consumer.Track(msgCtx, msg, eventType, maxDeliver)
 			defer func() {
-				tracked.FinishPending(msgCtx)
+				tracked.Finish(msgCtx)
 				<-sem
 				wg.Done()
 			}()
 			process(tracked.Context(msgCtx), tracked)
-		}()
+		}(msgCtx, msg)
 	}
 }

--- a/pkg/natsmetrics/loop_test.go
+++ b/pkg/natsmetrics/loop_test.go
@@ -1,0 +1,70 @@
+package natsmetrics
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type failingIterator struct{ err error }
+
+func (i failingIterator) Next(...jetstream.NextOpt) (context.Context, jetstream.Msg, error) {
+	return nil, nil, i.err
+}
+
+type oneMessageIterator struct {
+	msg  jetstream.Msg
+	done bool
+}
+
+func (i *oneMessageIterator) Next(...jetstream.NextOpt) (context.Context, jetstream.Msg, error) {
+	if i.done {
+		return nil, nil, jetstream.ErrConsumerDeleted
+	}
+	i.done = true
+	return context.Background(), i.msg, nil
+}
+
+func TestConsume_TerminalNextFailureStopsLoop(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	c := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "s1", Stream: "stream", Consumer: "consumer"})
+	c.LoopStarted(context.Background())
+	var wg sync.WaitGroup
+
+	Consume(failingIterator{err: errors.New("iterator failed")}, c, 1, 5, &wg, nil, func(context.Context, *Message) {})
+
+	rm := collect(t, reader)
+	points := metricPoints[int64](t, rm, "chat.nats.consumer.loop.up")
+	require.Len(t, points, 1)
+	assert.Equal(t, int64(0), points[0].Value)
+}
+
+func TestConsume_TracksAndDisposesMessage(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	c := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "s1", Stream: "stream", Consumer: "consumer"})
+	c.LoopStarted(context.Background())
+	msg := &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 2}}
+	iter := &oneMessageIterator{msg: msg}
+	var wg sync.WaitGroup
+
+	Consume(iter, c, 1, 5, &wg, func(jetstream.Msg) EventType { return EventCreated }, func(ctx context.Context, tracked *Message) {
+		assert.False(t, IsFinalDeliveryFromContext(ctx))
+		require.NoError(t, tracked.Ack())
+	})
+	wg.Wait()
+
+	rm := collect(t, reader)
+	points := metricPoints[int64](t, rm, "chat.nats.consumer.messages")
+	require.Len(t, points, 1)
+	assert.Equal(t, int64(1), points[0].Value)
+	assert.Equal(t, string(OutcomeAck), attrs(points[0])["outcome"])
+	redeliveries := metricPoints[int64](t, rm, "chat.nats.consumer.redeliveries")
+	require.Len(t, redeliveries, 1)
+	assert.Equal(t, int64(1), redeliveries[0].Value)
+	assert.Equal(t, 1, msg.acks)
+}

--- a/pkg/natsmetrics/loop_test.go
+++ b/pkg/natsmetrics/loop_test.go
@@ -36,7 +36,7 @@ func TestConsume_TerminalNextFailureStopsLoop(t *testing.T) {
 	c.LoopStarted(context.Background())
 	var wg sync.WaitGroup
 
-	Consume(failingIterator{err: errors.New("iterator failed")}, c, 1, 5, &wg, nil, func(context.Context, *Message) {})
+	Consume(context.Background(), failingIterator{err: errors.New("iterator failed")}, c, 1, 5, &wg, nil, func(context.Context, *Message) {})
 
 	rm := collect(t, reader)
 	points := metricPoints[int64](t, rm, "chat.nats.consumer.loop.up")
@@ -52,7 +52,7 @@ func TestConsume_TracksAndDisposesMessage(t *testing.T) {
 	iter := &oneMessageIterator{msg: msg}
 	var wg sync.WaitGroup
 
-	Consume(iter, c, 1, 5, &wg, func(jetstream.Msg) EventType { return EventCreated }, func(ctx context.Context, tracked *Message) {
+	Consume(context.Background(), iter, c, 1, 5, &wg, func(jetstream.Msg) EventType { return EventCreated }, func(ctx context.Context, tracked *Message) {
 		assert.False(t, IsFinalDeliveryFromContext(ctx))
 		require.NoError(t, tracked.Ack())
 	})

--- a/pkg/natsmetrics/loop_test.go
+++ b/pkg/natsmetrics/loop_test.go
@@ -3,8 +3,10 @@ package natsmetrics
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
@@ -67,4 +69,94 @@ func TestConsume_TracksAndDisposesMessage(t *testing.T) {
 	require.Len(t, redeliveries, 1)
 	assert.Equal(t, int64(1), redeliveries[0].Value)
 	assert.Equal(t, 1, msg.acks)
+}
+
+// blockingIterator holds the loop inside Next until release is closed, then
+// ends it. It lets a test observe whether the loop goroutine is registered with
+// the WaitGroup while it is still running.
+type blockingIterator struct {
+	release chan struct{}
+	done    bool
+}
+
+func (i *blockingIterator) Next(...jetstream.NextOpt) (context.Context, jetstream.Msg, error) {
+	<-i.release
+	if i.done {
+		return nil, nil, jetstream.ErrConsumerDeleted
+	}
+	i.done = true
+	return context.Background(), &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}}, nil
+}
+
+// A zero MAX_WORKERS must not wedge the consumer. An unbuffered semaphore would
+// park the dispatch send forever, leaving the loop-up gauge at 1 with no error
+// and no terminal metric — a silent stall is worse than a slow consumer.
+func TestConsume_NonPositiveMaxWorkersStillConsumes(t *testing.T) {
+	for _, maxWorkers := range []int{0, -1} {
+		t.Run(fmt.Sprintf("maxWorkers=%d", maxWorkers), func(t *testing.T) {
+			m, _ := newTestMetrics(t)
+			c := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "s1", Stream: "stream", Consumer: "consumer"})
+			c.LoopStarted(context.Background())
+			iter := &oneMessageIterator{msg: &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}}}
+			var wg sync.WaitGroup
+			processed := make(chan struct{}, 1)
+
+			done := make(chan struct{})
+			go func() {
+				Consume(context.Background(), iter, c, maxWorkers, 5, &wg,
+					func(jetstream.Msg) EventType { return EventCreated },
+					func(_ context.Context, tracked *Message) {
+						processed <- struct{}{}
+						require.NoError(t, tracked.Ack())
+					})
+				close(done)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("Consume wedged with non-positive maxWorkers")
+			}
+			wg.Wait()
+			assert.Len(t, processed, 1)
+		})
+	}
+}
+
+// Start must register the loop with the WaitGroup before it returns. If the
+// loop is only counted once a message is dispatched, a shutdown that runs
+// iter.Stop() then wg.Wait() can pass straight through while a message returned
+// by Next has not been handed to a worker yet, and drain the connection under it.
+func TestStart_RegistersLoopBeforeReturning(t *testing.T) {
+	m, _ := newTestMetrics(t)
+	c := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "s1", Stream: "stream", Consumer: "consumer"})
+	c.LoopStarted(context.Background())
+	iter := &blockingIterator{release: make(chan struct{})}
+	var wg sync.WaitGroup
+
+	Start(context.Background(), iter, c, 4, 5, &wg,
+		func(jetstream.Msg) EventType { return EventCreated },
+		func(_ context.Context, tracked *Message) { require.NoError(t, tracked.Ack()) })
+
+	waited := make(chan struct{})
+	go func() { wg.Wait(); close(waited) }()
+
+	assert.Never(t, func() bool {
+		select {
+		case <-waited:
+			return true
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "wg.Wait() returned while the consumer loop was still running")
+
+	close(iter.release)
+	assert.Eventually(t, func() bool {
+		select {
+		case <-waited:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond, "wg.Wait() did not return after the loop exited")
 }

--- a/pkg/natsmetrics/metrics.go
+++ b/pkg/natsmetrics/metrics.go
@@ -1,0 +1,438 @@
+// Package natsmetrics provides bounded application-side NATS and JetStream
+// metrics. It observes existing publish and message-disposition behavior; it
+// never retries, acknowledges, or changes a business result on its own.
+package natsmetrics
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+type Outcome string
+
+const (
+	OutcomeAck              Outcome = "ack"
+	OutcomeNak              Outcome = "nak"
+	OutcomeTerm             Outcome = "term"
+	OutcomeLeftPending      Outcome = "left_pending"
+	OutcomeHandlerCancelled Outcome = "handler_cancelled"
+)
+
+type EventType string
+
+const (
+	EventCreated          EventType = "created"
+	EventUpdated          EventType = "updated"
+	EventDeleted          EventType = "deleted"
+	EventPinned           EventType = "pinned"
+	EventUnpinned         EventType = "unpinned"
+	EventReacted          EventType = "reacted"
+	EventThreadReplyAdded EventType = "thread_reply_added"
+	EventSend             EventType = "send"
+	EventTeamsBatch       EventType = "teams_batch"
+	EventUnknown          EventType = "unknown"
+)
+
+type PublishOutcome string
+
+const (
+	PublishSuccess         PublishOutcome = "success"
+	PublishTimeout         PublishOutcome = "timeout"
+	PublishNoResponders    PublishOutcome = "no_responders"
+	PublishDisconnected    PublishOutcome = "disconnected"
+	PublishBufferFull      PublishOutcome = "buffer_full"
+	PublishPermission      PublishOutcome = "permission"
+	PublishPayloadTooLarge PublishOutcome = "payload_too_large"
+	PublishOtherError      PublishOutcome = "other_error"
+)
+
+type TerminalReason string
+
+const (
+	TerminalMaxDeliver        TerminalReason = "max_deliver"
+	TerminalPermanent         TerminalReason = "permanent"
+	TerminalPublishExhausted  TerminalReason = "publish_exhausted"
+	TerminalConsumerDeleted   TerminalReason = "consumer_deleted"
+	TerminalStreamUnavailable TerminalReason = "stream_unavailable"
+	TerminalInvalidPayload    TerminalReason = "invalid_payload"
+	TerminalInternal          TerminalReason = "internal"
+)
+
+type DestinationKind string
+
+const (
+	DestinationCanonical      DestinationKind = "canonical"
+	DestinationRecipientEvent DestinationKind = "recipient_event"
+	DestinationNotification   DestinationKind = "notification"
+	DestinationPush           DestinationKind = "push"
+	DestinationOutbox         DestinationKind = "outbox"
+	DestinationInbox          DestinationKind = "inbox"
+	DestinationClientResponse DestinationKind = "client_response"
+	DestinationUserSync       DestinationKind = "user_sync"
+	DestinationUnknown        DestinationKind = "unknown"
+)
+
+type Operation string
+
+const (
+	OperationCanonicalPublish    Operation = "canonical_publish"
+	OperationClientResponse      Operation = "client_response"
+	OperationRecipientPublish    Operation = "recipient_publish"
+	OperationNotificationPublish Operation = "notification_publish"
+	OperationPushPublish         Operation = "push_publish"
+	OperationHistoryGetMessage   Operation = "history_get_message"
+	OperationPresenceLookup      Operation = "presence_lookup"
+	OperationThreadTCount        Operation = "thread_tcount"
+	OperationTeamsUserUpsert     Operation = "teams_user_upsert"
+	OperationUnknown             Operation = "unknown"
+)
+
+// Metrics owns the shared instruments. Instrument-creation failures fall back
+// to no-op instruments so telemetry can never block service startup or work.
+type Metrics struct {
+	loop               metric.Int64UpDownCounter
+	messages           metric.Int64Counter
+	redeliveries       metric.Int64Counter
+	processingDuration metric.Float64Histogram
+	publishAttempts    metric.Int64Counter
+	publishRetries     metric.Int64Counter
+	terminalFailures   metric.Int64Counter
+	requests           metric.Int64Counter
+	requestDuration    metric.Float64Histogram
+}
+
+func New(meter metric.Meter) *Metrics {
+	noopMeter := noop.NewMeterProvider().Meter("natsmetrics-fallback")
+	loop, err := meter.Int64UpDownCounter("chat.nats.consumer.loop.up", metric.WithDescription("Whether an application consumer loop can receive messages."))
+	if err != nil {
+		loop, _ = noopMeter.Int64UpDownCounter("chat.nats.consumer.loop.up")
+	}
+	messages, err := meter.Int64Counter("chat.nats.consumer.messages", metric.WithDescription("JetStream delivery attempts by terminal application disposition."))
+	if err != nil {
+		messages, _ = noopMeter.Int64Counter("chat.nats.consumer.messages")
+	}
+	redeliveries, err := meter.Int64Counter("chat.nats.consumer.redeliveries", metric.WithDescription("JetStream delivery attempts whose delivery count is greater than one."))
+	if err != nil {
+		redeliveries, _ = noopMeter.Int64Counter("chat.nats.consumer.redeliveries")
+	}
+	processing, err := meter.Float64Histogram("chat.nats.consumer.processing.duration", metric.WithDescription("Time from handler start through the disposition attempt."), metric.WithUnit("s"))
+	if err != nil {
+		processing, _ = noopMeter.Float64Histogram("chat.nats.consumer.processing.duration")
+	}
+	publishAttempts, err := meter.Int64Counter("chat.nats.publish.attempts", metric.WithDescription("Actual Core NATS or JetStream publish attempts."))
+	if err != nil {
+		publishAttempts, _ = noopMeter.Int64Counter("chat.nats.publish.attempts")
+	}
+	publishRetries, err := meter.Int64Counter("chat.nats.publish.retries", metric.WithDescription("Application-managed publish attempts after the first."))
+	if err != nil {
+		publishRetries, _ = noopMeter.Int64Counter("chat.nats.publish.retries")
+	}
+	terminal, err := meter.Int64Counter("chat.nats.terminal.failures", metric.WithDescription("Work that will receive no further application attempt."))
+	if err != nil {
+		terminal, _ = noopMeter.Int64Counter("chat.nats.terminal.failures")
+	}
+	requests, err := meter.Int64Counter("chat.nats.requests", metric.WithDescription("NATS request/reply results."))
+	if err != nil {
+		requests, _ = noopMeter.Int64Counter("chat.nats.requests")
+	}
+	requestDuration, err := meter.Float64Histogram("chat.nats.request.duration", metric.WithDescription("End-to-end NATS request/reply duration."), metric.WithUnit("s"))
+	if err != nil {
+		requestDuration, _ = noopMeter.Float64Histogram("chat.nats.request.duration")
+	}
+	return &Metrics{loop: loop, messages: messages, redeliveries: redeliveries, processingDuration: processing, publishAttempts: publishAttempts, publishRetries: publishRetries, terminalFailures: terminal, requests: requests, requestDuration: requestDuration}
+}
+
+type ConsumerConfig struct {
+	ServiceName string
+	Site        string
+	Stream      string
+	Consumer    string
+}
+
+type Consumer struct {
+	metrics *Metrics
+	attrs   []attribute.KeyValue
+	up      atomic.Bool
+}
+
+func (m *Metrics) Consumer(cfg ConsumerConfig) *Consumer {
+	return &Consumer{metrics: m, attrs: []attribute.KeyValue{
+		attribute.String("service_name", cfg.ServiceName),
+		attribute.String("site", cfg.Site),
+		attribute.String("stream", cfg.Stream),
+		attribute.String("consumer", cfg.Consumer),
+	}}
+}
+
+func (c *Consumer) LoopStarted(ctx context.Context) {
+	if c.up.CompareAndSwap(false, true) {
+		c.metrics.loop.Add(ctx, 1, metric.WithAttributes(c.attrs...))
+	}
+}
+
+func (c *Consumer) LoopStopped(ctx context.Context) {
+	if c.up.CompareAndSwap(true, false) {
+		c.metrics.loop.Add(ctx, -1, metric.WithAttributes(c.attrs...))
+		return
+	}
+	// Establish an explicit zero-valued series before iterator creation.
+	c.metrics.loop.Add(ctx, 0, metric.WithAttributes(c.attrs...))
+}
+
+// LoopFailed marks the loop down before recording the bounded terminal cause.
+func (c *Consumer) LoopFailed(ctx context.Context, err error) {
+	wasUp := c.up.Load()
+	c.LoopStopped(ctx)
+	if !wasUp {
+		return
+	}
+	reason := TerminalInternal
+	switch {
+	case errors.Is(err, jetstream.ErrConsumerDeleted):
+		reason = TerminalConsumerDeleted
+	case errors.Is(err, jetstream.ErrStreamNotFound), errors.Is(err, jetstream.ErrNoStreamResponse),
+		errors.Is(err, jetstream.ErrConnectionClosed), errors.Is(err, nats.ErrConnectionClosed),
+		errors.Is(err, nats.ErrDisconnected), errors.Is(err, nats.ErrNoResponders):
+		reason = TerminalStreamUnavailable
+	}
+	c.Terminal(ctx, EventUnknown, reason)
+}
+
+func (c *Consumer) Track(ctx context.Context, msg jetstream.Msg, eventType EventType, maxDeliver int) *Message {
+	eventType = NormalizeEventType(string(eventType))
+	tracked := &Message{Msg: msg, consumer: c, ctx: ctx, eventType: eventType, maxDeliver: maxDeliver, started: time.Now()}
+	if meta, err := msg.Metadata(); err == nil && meta != nil {
+		tracked.numDelivered = meta.NumDelivered
+		if meta.NumDelivered > 1 {
+			c.metrics.redeliveries.Add(ctx, 1, metric.WithAttributes(c.eventAttrs(eventType)...))
+		}
+	}
+	return tracked
+}
+
+func (c *Consumer) eventAttrs(eventType EventType) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, len(c.attrs)+1)
+	attrs = append(attrs, c.attrs...)
+	return append(attrs, attribute.String("event_type", string(NormalizeEventType(string(eventType)))))
+}
+
+func (c *Consumer) Terminal(ctx context.Context, eventType EventType, reason TerminalReason) {
+	attrs := c.eventAttrs(eventType)
+	attrs = append(attrs, attribute.String("reason", string(normalizeTerminalReason(reason))))
+	c.metrics.terminalFailures.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+// Message intercepts disposition calls while preserving the wrapped message's
+// exact method, return value, and call count.
+type Message struct {
+	jetstream.Msg
+	consumer     *Consumer
+	ctx          context.Context
+	eventType    EventType
+	maxDeliver   int
+	numDelivered uint64
+	started      time.Time
+	disposeOnce  sync.Once
+	terminalOnce sync.Once
+}
+
+type messageContextKey struct{}
+
+// Context returns ctx carrying this delivery recorder so deeper fan-out code
+// can report a swallowed terminal failure without accepting dynamic labels.
+func (m *Message) Context(ctx context.Context) context.Context {
+	return context.WithValue(ctx, messageContextKey{}, m)
+}
+
+// MarkTerminalFromContext records terminal evidence for the current delivery,
+// if ctx belongs to a tracked delivery. It is a no-op for ordinary contexts.
+func MarkTerminalFromContext(ctx context.Context, reason TerminalReason) {
+	if msg, ok := ctx.Value(messageContextKey{}).(*Message); ok {
+		msg.MarkTerminal(ctx, reason)
+	}
+}
+
+// IsFinalDeliveryFromContext reports whether ctx carries metadata proving the
+// current delivery is the configured final attempt.
+func IsFinalDeliveryFromContext(ctx context.Context) bool {
+	msg, ok := ctx.Value(messageContextKey{}).(*Message)
+	return ok && msg.IsFinalDelivery()
+}
+
+// IsFinalDelivery reports whether metadata proves this is the configured last
+// attempt. Missing metadata returns false rather than guessing.
+func (m *Message) IsFinalDelivery() bool {
+	return m.maxDeliver > 0 && m.numDelivered > 0 && m.numDelivered >= uint64(m.maxDeliver)
+}
+
+func (m *Message) Ack() error { err := m.Msg.Ack(); m.finish(OutcomeAck, err); return err }
+func (m *Message) DoubleAck(ctx context.Context) error {
+	err := m.Msg.DoubleAck(ctx)
+	m.finish(OutcomeAck, err)
+	return err
+}
+func (m *Message) Nak() error { err := m.Msg.Nak(); m.finish(OutcomeNak, err); return err }
+func (m *Message) NakWithDelay(delay time.Duration) error {
+	err := m.Msg.NakWithDelay(delay)
+	m.finish(OutcomeNak, err)
+	return err
+}
+func (m *Message) Term() error { err := m.Msg.Term(); m.finish(OutcomeTerm, err); return err }
+func (m *Message) TermWithReason(reason string) error {
+	err := m.Msg.TermWithReason(reason)
+	m.finish(OutcomeTerm, err)
+	return err
+}
+
+func (m *Message) MarkTerminal(ctx context.Context, reason TerminalReason) {
+	m.terminalOnce.Do(func() { m.consumer.Terminal(ctx, m.eventType, reason) })
+}
+
+// MarkHandlerPanic lets the shared panic guard classify its Ack-drop without
+// importing this package or changing the Ack behavior.
+func (m *Message) MarkHandlerPanic() { m.MarkTerminal(m.ctx, TerminalInternal) }
+
+func (m *Message) FinishPending(ctx context.Context) { m.finishWithOutcome(ctx, OutcomeLeftPending) }
+func (m *Message) FinishCancelled(ctx context.Context) {
+	m.finishWithOutcome(ctx, OutcomeHandlerCancelled)
+}
+
+func (m *Message) finish(want Outcome, err error) {
+	outcome := want
+	if err != nil {
+		outcome = OutcomeLeftPending
+	}
+	if want == OutcomeNak && m.maxDeliver > 0 && m.numDelivered >= uint64(m.maxDeliver) {
+		m.MarkTerminal(m.ctx, TerminalMaxDeliver)
+	}
+	if want == OutcomeTerm {
+		m.MarkTerminal(m.ctx, TerminalInternal)
+	}
+	m.finishWithOutcome(m.ctx, outcome)
+}
+
+func (m *Message) finishWithOutcome(ctx context.Context, outcome Outcome) {
+	m.disposeOnce.Do(func() {
+		attrs := m.consumer.eventAttrs(m.eventType)
+		attrs = append(attrs, attribute.String("outcome", string(outcome)))
+		opts := metric.WithAttributes(attrs...)
+		m.consumer.metrics.messages.Add(ctx, 1, opts)
+		m.consumer.metrics.processingDuration.Record(ctx, time.Since(m.started).Seconds(), opts)
+	})
+}
+
+type Publisher struct {
+	metrics   *Metrics
+	baseAttrs []attribute.KeyValue
+}
+
+func (m *Metrics) Publisher(serviceName, site string) Publisher {
+	return Publisher{metrics: m, baseAttrs: []attribute.KeyValue{attribute.String("service_name", serviceName), attribute.String("site", site)}}
+}
+
+func (p Publisher) publishAttrs(destination DestinationKind, operation Operation) []attribute.KeyValue {
+	attrs := append([]attribute.KeyValue{}, p.baseAttrs...)
+	return append(attrs,
+		attribute.String("destination_kind", string(normalizeDestination(destination))),
+		attribute.String("operation", string(normalizeOperation(operation))),
+	)
+}
+
+func (p Publisher) Attempt(ctx context.Context, destination DestinationKind, operation Operation, err error) {
+	if p.metrics == nil {
+		return
+	}
+	attrs := p.publishAttrs(destination, operation)
+	attrs = append(attrs, attribute.String("outcome", string(ClassifyPublishError(err))))
+	p.metrics.publishAttempts.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+func (p Publisher) Retry(ctx context.Context, destination DestinationKind, operation Operation) {
+	if p.metrics == nil {
+		return
+	}
+	p.metrics.publishRetries.Add(ctx, 1, metric.WithAttributes(p.publishAttrs(destination, operation)...))
+}
+
+func (p Publisher) Request(ctx context.Context, operation Operation, duration time.Duration, err error) {
+	if p.metrics == nil {
+		return
+	}
+	attrs := append([]attribute.KeyValue{}, p.baseAttrs...)
+	attrs = append(attrs,
+		attribute.String("operation", string(normalizeOperation(operation))),
+		attribute.String("outcome", string(ClassifyPublishError(err))),
+	)
+	opts := metric.WithAttributes(attrs...)
+	p.metrics.requests.Add(ctx, 1, opts)
+	p.metrics.requestDuration.Record(ctx, duration.Seconds(), opts)
+}
+
+func NormalizeEventType(value string) EventType {
+	switch EventType(value) {
+	case EventCreated, EventUpdated, EventDeleted, EventPinned, EventUnpinned, EventReacted, EventThreadReplyAdded, EventSend, EventTeamsBatch:
+		return EventType(value)
+	default:
+		return EventUnknown
+	}
+}
+
+func normalizeDestination(destination DestinationKind) DestinationKind {
+	switch destination {
+	case DestinationCanonical, DestinationRecipientEvent, DestinationNotification, DestinationPush, DestinationOutbox, DestinationInbox, DestinationClientResponse, DestinationUserSync:
+		return destination
+	default:
+		return DestinationUnknown
+	}
+}
+
+func normalizeOperation(operation Operation) Operation {
+	switch operation {
+	case OperationCanonicalPublish, OperationClientResponse, OperationRecipientPublish, OperationNotificationPublish, OperationPushPublish, OperationHistoryGetMessage, OperationPresenceLookup, OperationThreadTCount, OperationTeamsUserUpsert:
+		return operation
+	default:
+		return OperationUnknown
+	}
+}
+
+func normalizeTerminalReason(reason TerminalReason) TerminalReason {
+	switch reason {
+	case TerminalMaxDeliver, TerminalPermanent, TerminalPublishExhausted, TerminalConsumerDeleted, TerminalStreamUnavailable, TerminalInvalidPayload, TerminalInternal:
+		return reason
+	default:
+		return TerminalInternal
+	}
+}
+
+func ClassifyPublishError(err error) PublishOutcome {
+	var jsErr jetstream.JetStreamError
+	switch {
+	case err == nil:
+		return PublishSuccess
+	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, nats.ErrTimeout):
+		return PublishTimeout
+	case errors.Is(err, nats.ErrNoResponders), errors.Is(err, jetstream.ErrNoStreamResponse):
+		return PublishNoResponders
+	case errors.Is(err, nats.ErrDisconnected), errors.Is(err, nats.ErrConnectionClosed), errors.Is(err, jetstream.ErrConnectionClosed):
+		return PublishDisconnected
+	case errors.Is(err, nats.ErrReconnectBufExceeded):
+		return PublishBufferFull
+	case errors.Is(err, nats.ErrPermissionViolation), errors.Is(err, nats.ErrAuthorization):
+		return PublishPermission
+	case errors.As(err, &jsErr) && jsErr.APIError() != nil && jsErr.APIError().Code == 403:
+		return PublishPermission
+	case errors.Is(err, nats.ErrMaxPayload):
+		return PublishPayloadTooLarge
+	default:
+		return PublishOtherError
+	}
+}

--- a/pkg/natsmetrics/metrics.go
+++ b/pkg/natsmetrics/metrics.go
@@ -1,6 +1,11 @@
 // Package natsmetrics provides bounded application-side NATS and JetStream
 // metrics. It observes existing publish and message-disposition behavior; it
 // never retries, acknowledges, or changes a business result on its own.
+//
+// Every label value comes from a closed enum in this file, so the attribute
+// sets are precomputed once per Consumer/Publisher and looked up by value on
+// the hot path — fan-out records one publish per recipient and must not pay for
+// attribute-set construction each time.
 package natsmetrics
 
 import (
@@ -10,12 +15,18 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/flywindy/o11y"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
 )
+
+// ScopeName is the instrumentation scope for every instrument in this package.
+// Constructing through NewFromProvider keeps one scope per process so the
+// instruments dedupe instead of splitting into per-caller series.
+const ScopeName = "github.com/hmchangw/chat/pkg/natsmetrics"
 
 type Outcome string
 
@@ -26,6 +37,8 @@ const (
 	OutcomeLeftPending      Outcome = "left_pending"
 	OutcomeHandlerCancelled Outcome = "handler_cancelled"
 )
+
+var allOutcomes = []Outcome{OutcomeAck, OutcomeNak, OutcomeTerm, OutcomeLeftPending, OutcomeHandlerCancelled}
 
 type EventType string
 
@@ -42,6 +55,11 @@ const (
 	EventUnknown          EventType = "unknown"
 )
 
+var allEventTypes = []EventType{
+	EventCreated, EventUpdated, EventDeleted, EventPinned, EventUnpinned,
+	EventReacted, EventThreadReplyAdded, EventSend, EventTeamsBatch, EventUnknown,
+}
+
 type PublishOutcome string
 
 const (
@@ -55,6 +73,11 @@ const (
 	PublishOtherError      PublishOutcome = "other_error"
 )
 
+var allPublishOutcomes = []PublishOutcome{
+	PublishSuccess, PublishTimeout, PublishNoResponders, PublishDisconnected,
+	PublishBufferFull, PublishPermission, PublishPayloadTooLarge, PublishOtherError,
+}
+
 type TerminalReason string
 
 const (
@@ -66,6 +89,11 @@ const (
 	TerminalInvalidPayload    TerminalReason = "invalid_payload"
 	TerminalInternal          TerminalReason = "internal"
 )
+
+var allTerminalReasons = []TerminalReason{
+	TerminalMaxDeliver, TerminalPermanent, TerminalPublishExhausted, TerminalConsumerDeleted,
+	TerminalStreamUnavailable, TerminalInvalidPayload, TerminalInternal,
+}
 
 type DestinationKind string
 
@@ -80,6 +108,11 @@ const (
 	DestinationUserSync       DestinationKind = "user_sync"
 	DestinationUnknown        DestinationKind = "unknown"
 )
+
+var allDestinations = []DestinationKind{
+	DestinationCanonical, DestinationRecipientEvent, DestinationNotification, DestinationPush,
+	DestinationOutbox, DestinationInbox, DestinationClientResponse, DestinationUserSync, DestinationUnknown,
+}
 
 type Operation string
 
@@ -96,6 +129,12 @@ const (
 	OperationUnknown             Operation = "unknown"
 )
 
+var allOperations = []Operation{
+	OperationCanonicalPublish, OperationClientResponse, OperationRecipientPublish,
+	OperationNotificationPublish, OperationPushPublish, OperationHistoryGetMessage,
+	OperationPresenceLookup, OperationThreadTCount, OperationTeamsUserUpsert, OperationUnknown,
+}
+
 // Metrics owns the shared instruments. Instrument-creation failures fall back
 // to no-op instruments so telemetry can never block service startup or work.
 type Metrics struct {
@@ -110,8 +149,18 @@ type Metrics struct {
 	requestDuration    metric.Float64Histogram
 }
 
+// NewFromProvider builds the shared instruments on this package's own scope.
+// Prefer it over New so every caller in a process lands on one scope.
+func NewFromProvider(mp metric.MeterProvider) *Metrics { return New(mp.Meter(ScopeName)) }
+
 func New(meter metric.Meter) *Metrics {
 	noopMeter := noop.NewMeterProvider().Meter("natsmetrics-fallback")
+	// Latency instruments carry the SDK's shared boundaries as an instrument
+	// advisory. The o11y SDK only registers bucket views for its own instrument
+	// names, so without this these two histograms fall back to the OTel default
+	// boundaries (0..10000) and every sub-second duration lands in bucket one.
+	latency := metric.WithExplicitBucketBoundaries(o11y.DefaultLatencyBuckets()...)
+
 	loop, err := meter.Int64UpDownCounter("chat.nats.consumer.loop.up", metric.WithDescription("Whether an application consumer loop can receive messages."))
 	if err != nil {
 		loop, _ = noopMeter.Int64UpDownCounter("chat.nats.consumer.loop.up")
@@ -124,7 +173,7 @@ func New(meter metric.Meter) *Metrics {
 	if err != nil {
 		redeliveries, _ = noopMeter.Int64Counter("chat.nats.consumer.redeliveries")
 	}
-	processing, err := meter.Float64Histogram("chat.nats.consumer.processing.duration", metric.WithDescription("Time from handler start through the disposition attempt."), metric.WithUnit("s"))
+	processing, err := meter.Float64Histogram("chat.nats.consumer.processing.duration", metric.WithDescription("Time from handler start through the disposition attempt."), metric.WithUnit("s"), latency)
 	if err != nil {
 		processing, _ = noopMeter.Float64Histogram("chat.nats.consumer.processing.duration")
 	}
@@ -144,7 +193,7 @@ func New(meter metric.Meter) *Metrics {
 	if err != nil {
 		requests, _ = noopMeter.Int64Counter("chat.nats.requests")
 	}
-	requestDuration, err := meter.Float64Histogram("chat.nats.request.duration", metric.WithDescription("End-to-end NATS request/reply duration."), metric.WithUnit("s"))
+	requestDuration, err := meter.Float64Histogram("chat.nats.request.duration", metric.WithDescription("End-to-end NATS request/reply duration."), metric.WithUnit("s"), latency)
 	if err != nil {
 		requestDuration, _ = noopMeter.Float64Histogram("chat.nats.request.duration")
 	}
@@ -158,35 +207,92 @@ type ConsumerConfig struct {
 	Consumer    string
 }
 
+// consumerKey and publishKey index the precomputed attribute sets. Struct map
+// keys are compared by value, so a lookup costs no allocation.
+type consumerKey struct {
+	event   EventType
+	outcome Outcome
+}
+
+type terminalKey struct {
+	event  EventType
+	reason TerminalReason
+}
+
+type publishKey struct {
+	destination DestinationKind
+	operation   Operation
+	outcome     PublishOutcome
+}
+
+type retryKey struct {
+	destination DestinationKind
+	operation   Operation
+}
+
+type requestKey struct {
+	operation Operation
+	outcome   PublishOutcome
+}
+
 type Consumer struct {
 	metrics *Metrics
-	attrs   []attribute.KeyValue
+	loopOpt metric.MeasurementOption
+	message map[consumerKey]metric.MeasurementOption
+	redeliv map[EventType]metric.MeasurementOption
+	termOpt map[terminalKey]metric.MeasurementOption
 	up      atomic.Bool
 }
 
 func (m *Metrics) Consumer(cfg ConsumerConfig) *Consumer {
-	return &Consumer{metrics: m, attrs: []attribute.KeyValue{
+	base := []attribute.KeyValue{
 		attribute.String("service_name", cfg.ServiceName),
 		attribute.String("site", cfg.Site),
 		attribute.String("stream", cfg.Stream),
 		attribute.String("consumer", cfg.Consumer),
-	}}
+	}
+	withEvent := func(event EventType, extra ...attribute.KeyValue) []attribute.KeyValue {
+		attrs := make([]attribute.KeyValue, 0, len(base)+1+len(extra))
+		attrs = append(attrs, base...)
+		attrs = append(attrs, attribute.String("event_type", string(event)))
+		return append(attrs, extra...)
+	}
+	c := &Consumer{
+		metrics: m,
+		loopOpt: metric.WithAttributes(base...),
+		message: make(map[consumerKey]metric.MeasurementOption, len(allEventTypes)*len(allOutcomes)),
+		redeliv: make(map[EventType]metric.MeasurementOption, len(allEventTypes)),
+		termOpt: make(map[terminalKey]metric.MeasurementOption, len(allEventTypes)*len(allTerminalReasons)),
+	}
+	for _, event := range allEventTypes {
+		c.redeliv[event] = metric.WithAttributes(withEvent(event)...)
+		for _, outcome := range allOutcomes {
+			c.message[consumerKey{event, outcome}] = metric.WithAttributes(withEvent(event, attribute.String("outcome", string(outcome)))...)
+		}
+		for _, reason := range allTerminalReasons {
+			c.termOpt[terminalKey{event, reason}] = metric.WithAttributes(withEvent(event, attribute.String("reason", string(reason)))...)
+		}
+	}
+	return c
 }
 
 func (c *Consumer) LoopStarted(ctx context.Context) {
 	if c.up.CompareAndSwap(false, true) {
-		c.metrics.loop.Add(ctx, 1, metric.WithAttributes(c.attrs...))
+		c.metrics.loop.Add(ctx, 1, c.loopOpt)
 	}
 }
 
 func (c *Consumer) LoopStopped(ctx context.Context) {
 	if c.up.CompareAndSwap(true, false) {
-		c.metrics.loop.Add(ctx, -1, metric.WithAttributes(c.attrs...))
+		c.metrics.loop.Add(ctx, -1, c.loopOpt)
 		return
 	}
 	// Establish an explicit zero-valued series before iterator creation.
-	c.metrics.loop.Add(ctx, 0, metric.WithAttributes(c.attrs...))
+	c.metrics.loop.Add(ctx, 0, c.loopOpt)
 }
+
+// IsUp reports whether the loop is currently able to receive messages.
+func (c *Consumer) IsUp() bool { return c.up.Load() }
 
 // LoopFailed marks the loop down before recording the bounded terminal cause.
 func (c *Consumer) LoopFailed(ctx context.Context, err error) {
@@ -213,22 +319,15 @@ func (c *Consumer) Track(ctx context.Context, msg jetstream.Msg, eventType Event
 	if meta, err := msg.Metadata(); err == nil && meta != nil {
 		tracked.numDelivered = meta.NumDelivered
 		if meta.NumDelivered > 1 {
-			c.metrics.redeliveries.Add(ctx, 1, metric.WithAttributes(c.eventAttrs(eventType)...))
+			c.metrics.redeliveries.Add(ctx, 1, c.redeliv[eventType])
 		}
 	}
 	return tracked
 }
 
-func (c *Consumer) eventAttrs(eventType EventType) []attribute.KeyValue {
-	attrs := make([]attribute.KeyValue, 0, len(c.attrs)+1)
-	attrs = append(attrs, c.attrs...)
-	return append(attrs, attribute.String("event_type", string(NormalizeEventType(string(eventType)))))
-}
-
 func (c *Consumer) Terminal(ctx context.Context, eventType EventType, reason TerminalReason) {
-	attrs := c.eventAttrs(eventType)
-	attrs = append(attrs, attribute.String("reason", string(normalizeTerminalReason(reason))))
-	c.metrics.terminalFailures.Add(ctx, 1, metric.WithAttributes(attrs...))
+	key := terminalKey{NormalizeEventType(string(eventType)), normalizeTerminalReason(reason)}
+	c.metrics.terminalFailures.Add(ctx, 1, c.termOpt[key])
 }
 
 // Message intercepts disposition calls while preserving the wrapped message's
@@ -287,6 +386,9 @@ func (m *Message) NakWithDelay(delay time.Duration) error {
 	return err
 }
 func (m *Message) Term() error { err := m.Msg.Term(); m.finish(OutcomeTerm, err); return err }
+
+// TermWithReason forwards the caller's free-text reason to JetStream but never
+// to a label — the terminal metric uses the bounded `permanent` reason.
 func (m *Message) TermWithReason(reason string) error {
 	err := m.Msg.TermWithReason(reason)
 	m.finish(OutcomeTerm, err)
@@ -301,9 +403,16 @@ func (m *Message) MarkTerminal(ctx context.Context, reason TerminalReason) {
 // importing this package or changing the Ack behavior.
 func (m *Message) MarkHandlerPanic() { m.MarkTerminal(m.ctx, TerminalInternal) }
 
-func (m *Message) FinishPending(ctx context.Context) { m.finishWithOutcome(ctx, OutcomeLeftPending) }
-func (m *Message) FinishCancelled(ctx context.Context) {
-	m.finishWithOutcome(ctx, OutcomeHandlerCancelled)
+// Finish records the disposition for a delivery that returned without calling
+// Ack/Nak/Term. A live loop and live context mean the handler is relying on
+// AckWait redelivery (`left_pending`); a stopped loop or cancelled context mean
+// shutdown took the delivery away before it settled (`handler_cancelled`).
+func (m *Message) Finish(ctx context.Context) {
+	outcome := OutcomeLeftPending
+	if !m.consumer.IsUp() || ctx.Err() != nil {
+		outcome = OutcomeHandlerCancelled
+	}
+	m.finishWithOutcome(ctx, outcome)
 }
 
 func (m *Message) finish(want Outcome, err error) {
@@ -314,67 +423,95 @@ func (m *Message) finish(want Outcome, err error) {
 	if want == OutcomeNak && m.maxDeliver > 0 && m.numDelivered >= uint64(m.maxDeliver) {
 		m.MarkTerminal(m.ctx, TerminalMaxDeliver)
 	}
+	// An explicit Term is a deliberate drop. A handler that already classified
+	// the drop keeps its own reason — MarkTerminal is once-only.
 	if want == OutcomeTerm {
-		m.MarkTerminal(m.ctx, TerminalInternal)
+		m.MarkTerminal(m.ctx, TerminalPermanent)
 	}
 	m.finishWithOutcome(m.ctx, outcome)
 }
 
 func (m *Message) finishWithOutcome(ctx context.Context, outcome Outcome) {
 	m.disposeOnce.Do(func() {
-		attrs := m.consumer.eventAttrs(m.eventType)
-		attrs = append(attrs, attribute.String("outcome", string(outcome)))
-		opts := metric.WithAttributes(attrs...)
-		m.consumer.metrics.messages.Add(ctx, 1, opts)
-		m.consumer.metrics.processingDuration.Record(ctx, time.Since(m.started).Seconds(), opts)
+		opt := m.consumer.message[consumerKey{m.eventType, outcome}]
+		m.consumer.metrics.messages.Add(ctx, 1, opt)
+		m.consumer.metrics.processingDuration.Record(ctx, time.Since(m.started).Seconds(), opt)
 	})
 }
 
 type Publisher struct {
-	metrics   *Metrics
-	baseAttrs []attribute.KeyValue
+	metrics *Metrics
+	attempt map[publishKey]metric.MeasurementOption
+	retry   map[retryKey]metric.MeasurementOption
+	request map[requestKey]metric.MeasurementOption
 }
 
 func (m *Metrics) Publisher(serviceName, site string) Publisher {
-	return Publisher{metrics: m, baseAttrs: []attribute.KeyValue{attribute.String("service_name", serviceName), attribute.String("site", site)}}
+	base := []attribute.KeyValue{attribute.String("service_name", serviceName), attribute.String("site", site)}
+	build := func(extra ...attribute.KeyValue) metric.MeasurementOption {
+		attrs := make([]attribute.KeyValue, 0, len(base)+len(extra))
+		attrs = append(attrs, base...)
+		return metric.WithAttributes(append(attrs, extra...)...)
+	}
+	p := Publisher{
+		metrics: m,
+		attempt: make(map[publishKey]metric.MeasurementOption, len(allDestinations)*len(allOperations)*len(allPublishOutcomes)),
+		retry:   make(map[retryKey]metric.MeasurementOption, len(allDestinations)*len(allOperations)),
+		request: make(map[requestKey]metric.MeasurementOption, len(allOperations)*len(allPublishOutcomes)),
+	}
+	for _, destination := range allDestinations {
+		dst := attribute.String("destination_kind", string(destination))
+		for _, operation := range allOperations {
+			op := attribute.String("operation", string(operation))
+			p.retry[retryKey{destination, operation}] = build(dst, op)
+			for _, outcome := range allPublishOutcomes {
+				p.attempt[publishKey{destination, operation, outcome}] = build(dst, op, attribute.String("outcome", string(outcome)))
+			}
+		}
+	}
+	for _, operation := range allOperations {
+		op := attribute.String("operation", string(operation))
+		for _, outcome := range allPublishOutcomes {
+			p.request[requestKey{operation, outcome}] = build(op, attribute.String("outcome", string(outcome)))
+		}
+	}
+	return p
 }
 
-func (p Publisher) publishAttrs(destination DestinationKind, operation Operation) []attribute.KeyValue {
-	attrs := append([]attribute.KeyValue{}, p.baseAttrs...)
-	return append(attrs,
-		attribute.String("destination_kind", string(normalizeDestination(destination))),
-		attribute.String("operation", string(normalizeOperation(operation))),
-	)
-}
-
+// Attempt records one actual publish call.
+//
+// For Core NATS a nil error means the message entered the client's write or
+// reconnect buffer, NOT that the broker accepted it: nats.go buffers publishes
+// across a disconnect and only fails once the reconnect buffer overflows. Treat
+// `outcome="success"` on a Core NATS destination as "handed to the client", and
+// read it alongside the connection-state metrics in pkg/natsutil. JetStream
+// destinations wait for a PubAck, so their success is broker-confirmed.
 func (p Publisher) Attempt(ctx context.Context, destination DestinationKind, operation Operation, err error) {
 	if p.metrics == nil {
 		return
 	}
-	attrs := p.publishAttrs(destination, operation)
-	attrs = append(attrs, attribute.String("outcome", string(ClassifyPublishError(err))))
-	p.metrics.publishAttempts.Add(ctx, 1, metric.WithAttributes(attrs...))
+	key := publishKey{normalizeDestination(destination), normalizeOperation(operation), ClassifyPublishError(err)}
+	p.metrics.publishAttempts.Add(ctx, 1, p.attempt[key])
 }
 
+// Retry counts an application-managed publish attempt after the first. It is
+// only meaningful for a caller that loops around its own publish; JetStream's
+// internal PubAck retries and the consumer Nak path are not application retries
+// and must not be counted here.
 func (p Publisher) Retry(ctx context.Context, destination DestinationKind, operation Operation) {
 	if p.metrics == nil {
 		return
 	}
-	p.metrics.publishRetries.Add(ctx, 1, metric.WithAttributes(p.publishAttrs(destination, operation)...))
+	p.metrics.publishRetries.Add(ctx, 1, p.retry[retryKey{normalizeDestination(destination), normalizeOperation(operation)}])
 }
 
 func (p Publisher) Request(ctx context.Context, operation Operation, duration time.Duration, err error) {
 	if p.metrics == nil {
 		return
 	}
-	attrs := append([]attribute.KeyValue{}, p.baseAttrs...)
-	attrs = append(attrs,
-		attribute.String("operation", string(normalizeOperation(operation))),
-		attribute.String("outcome", string(ClassifyPublishError(err))),
-	)
-	opts := metric.WithAttributes(attrs...)
-	p.metrics.requests.Add(ctx, 1, opts)
-	p.metrics.requestDuration.Record(ctx, duration.Seconds(), opts)
+	opt := p.request[requestKey{normalizeOperation(operation), ClassifyPublishError(err)}]
+	p.metrics.requests.Add(ctx, 1, opt)
+	p.metrics.requestDuration.Record(ctx, duration.Seconds(), opt)
 }
 
 func NormalizeEventType(value string) EventType {

--- a/pkg/natsmetrics/metrics_test.go
+++ b/pkg/natsmetrics/metrics_test.go
@@ -1,0 +1,303 @@
+package natsmetrics
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+type fakeMsg struct {
+	meta    *jetstream.MsgMetadata
+	metaErr error
+	ackErr  error
+	nakErr  error
+	termErr error
+	acks    int
+	naks    int
+	terms   int
+}
+
+func (m *fakeMsg) Metadata() (*jetstream.MsgMetadata, error) { return m.meta, m.metaErr }
+func (m *fakeMsg) Data() []byte                              { return nil }
+func (m *fakeMsg) Headers() nats.Header                      { return nil }
+func (m *fakeMsg) Subject() string                           { return "chat.msg.canonical.s1.created" }
+func (m *fakeMsg) Reply() string                             { return "" }
+func (m *fakeMsg) Ack() error                                { m.acks++; return m.ackErr }
+func (m *fakeMsg) DoubleAck(context.Context) error           { m.acks++; return m.ackErr }
+func (m *fakeMsg) Nak() error                                { m.naks++; return m.nakErr }
+func (m *fakeMsg) NakWithDelay(time.Duration) error          { m.naks++; return m.nakErr }
+func (m *fakeMsg) InProgress() error                         { return nil }
+func (m *fakeMsg) Term() error                               { m.terms++; return m.termErr }
+func (m *fakeMsg) TermWithReason(string) error               { m.terms++; return m.termErr }
+
+func newTestMetrics(t *testing.T) (*Metrics, *sdkmetric.ManualReader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	return New(mp.Meter("test")), reader
+}
+
+func collect(t *testing.T, reader sdkmetric.Reader) metricdata.ResourceMetrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	return rm
+}
+
+func metricPoints[T int64 | float64](t *testing.T, rm metricdata.ResourceMetrics, name string) []metricdata.DataPoint[T] {
+	t.Helper()
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != name {
+				continue
+			}
+			switch data := m.Data.(type) {
+			case metricdata.Sum[T]:
+				return data.DataPoints
+			case metricdata.Gauge[T]:
+				return data.DataPoints
+			default:
+				t.Fatalf("metric %s has unexpected type %T", name, m.Data)
+			}
+		}
+	}
+	return nil
+}
+
+func histogramPoints(t *testing.T, rm metricdata.ResourceMetrics, name string) []metricdata.HistogramDataPoint[float64] {
+	t.Helper()
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name == name {
+				h, ok := m.Data.(metricdata.Histogram[float64])
+				require.True(t, ok)
+				return h.DataPoints
+			}
+		}
+	}
+	return nil
+}
+
+func attrs(dp metricdata.DataPoint[int64]) map[string]string {
+	out := map[string]string{}
+	for _, kv := range dp.Attributes.ToSlice() {
+		out[string(kv.Key)] = kv.Value.AsString()
+	}
+	return out
+}
+
+func TestConsumerLoopGaugeTransitions(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	c := m.Consumer(ConsumerConfig{ServiceName: "broadcast-worker", Site: "s1", Stream: "MESSAGES_CANONICAL_s1", Consumer: "broadcast-worker"})
+
+	c.LoopStopped(context.Background()) // iterator creation failure must expose zero
+	c.LoopStarted(context.Background())
+	c.LoopStarted(context.Background()) // idempotent
+	rm := collect(t, reader)
+	points := metricPoints[int64](t, rm, "chat.nats.consumer.loop.up")
+	require.Len(t, points, 1)
+	assert.Equal(t, int64(1), points[0].Value)
+
+	c.LoopStopped(context.Background())
+	c.LoopStopped(context.Background()) // idempotent
+	rm = collect(t, reader)
+	points = metricPoints[int64](t, rm, "chat.nats.consumer.loop.up")
+	require.Len(t, points, 1)
+	assert.Equal(t, int64(0), points[0].Value)
+}
+
+func TestConsumerLoopFailureUsesBoundedReason(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want TerminalReason
+	}{
+		{name: "consumer deleted", err: jetstream.ErrConsumerDeleted, want: TerminalConsumerDeleted},
+		{name: "stream unavailable", err: jetstream.ErrNoStreamResponse, want: TerminalStreamUnavailable},
+		{name: "unexpected iterator failure", err: errors.New("dynamic error text"), want: TerminalInternal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, reader := newTestMetrics(t)
+			c := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "s1", Stream: "STREAM_s1", Consumer: "durable"})
+			c.LoopStarted(context.Background())
+
+			c.LoopFailed(context.Background(), tt.err)
+
+			rm := collect(t, reader)
+			loop := metricPoints[int64](t, rm, "chat.nats.consumer.loop.up")
+			require.Len(t, loop, 1)
+			assert.Equal(t, int64(0), loop[0].Value)
+			terminal := metricPoints[int64](t, rm, "chat.nats.terminal.failures")
+			require.Len(t, terminal, 1)
+			assert.Equal(t, string(tt.want), attrs(terminal[0])["reason"])
+		})
+	}
+}
+
+func TestConsumerLoopFailureAfterShutdownDoesNotReportTerminalFailure(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	c := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "s1", Stream: "STREAM_s1", Consumer: "durable"})
+	c.LoopStopped(context.Background())
+
+	c.LoopFailed(context.Background(), jetstream.ErrConsumerDeleted)
+
+	rm := collect(t, reader)
+	assert.Empty(t, metricPoints[int64](t, rm, "chat.nats.terminal.failures"))
+}
+
+func TestTrackedMessageDispositionAndRedelivery(t *testing.T) {
+	tests := []struct {
+		name       string
+		msg        *fakeMsg
+		dispose    func(*Message) error
+		want       Outcome
+		redelivery int64
+	}{
+		{name: "ack", msg: &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}}, dispose: func(m *Message) error { return m.Ack() }, want: OutcomeAck},
+		{name: "double ack", msg: &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}}, dispose: func(m *Message) error { return m.DoubleAck(context.Background()) }, want: OutcomeAck},
+		{name: "nak redelivery", msg: &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 2}}, dispose: func(m *Message) error { return m.Nak() }, want: OutcomeNak, redelivery: 1},
+		{name: "term", msg: &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}}, dispose: func(m *Message) error { return m.Term() }, want: OutcomeTerm},
+		{name: "term with reason", msg: &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}}, dispose: func(m *Message) error { return m.TermWithReason("bounded by caller") }, want: OutcomeTerm},
+		{name: "ack failure stays pending", msg: &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}, ackErr: errors.New("ack failed")}, dispose: func(m *Message) error { return m.Ack() }, want: OutcomeLeftPending},
+		{name: "nak failure stays pending", msg: &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}, nakErr: errors.New("nak failed")}, dispose: func(m *Message) error { return m.Nak() }, want: OutcomeLeftPending},
+		{name: "term failure stays pending", msg: &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}, termErr: errors.New("term failed")}, dispose: func(m *Message) error { return m.Term() }, want: OutcomeLeftPending},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, reader := newTestMetrics(t)
+			c := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "s1", Stream: "STREAM_s1", Consumer: "durable"})
+			tracked := c.Track(context.Background(), tt.msg, EventCreated, 5)
+			_ = tt.dispose(tracked)
+			tracked.FinishPending(context.Background()) // must not double count
+
+			rm := collect(t, reader)
+			points := metricPoints[int64](t, rm, "chat.nats.consumer.messages")
+			require.Len(t, points, 1)
+			assert.Equal(t, int64(1), points[0].Value)
+			assert.Equal(t, string(tt.want), attrs(points[0])["outcome"])
+			redeliveries := metricPoints[int64](t, rm, "chat.nats.consumer.redeliveries")
+			if tt.redelivery == 0 {
+				assert.Empty(t, redeliveries)
+			} else {
+				require.Len(t, redeliveries, 1)
+				assert.Equal(t, tt.redelivery, redeliveries[0].Value)
+			}
+			durations := histogramPoints(t, rm, "chat.nats.consumer.processing.duration")
+			require.Len(t, durations, 1)
+			assert.Equal(t, uint64(1), durations[0].Count)
+		})
+	}
+}
+
+func TestTrackedMessageContextAndCancellation(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	c := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "s1", Stream: "STREAM_s1", Consumer: "durable"})
+	tracked := c.Track(context.Background(), &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 5}}, EventCreated, 5)
+	ctx := tracked.Context(context.Background())
+
+	assert.True(t, tracked.IsFinalDelivery())
+	assert.True(t, IsFinalDeliveryFromContext(ctx))
+	assert.False(t, IsFinalDeliveryFromContext(context.Background()))
+	MarkTerminalFromContext(context.Background(), TerminalPublishExhausted)
+	MarkTerminalFromContext(ctx, TerminalReason("dynamic reason"))
+	tracked.MarkHandlerPanic()
+	tracked.FinishCancelled(ctx)
+
+	rm := collect(t, reader)
+	terminal := metricPoints[int64](t, rm, "chat.nats.terminal.failures")
+	require.Len(t, terminal, 1)
+	assert.Equal(t, string(TerminalInternal), attrs(terminal[0])["reason"])
+	messages := metricPoints[int64](t, rm, "chat.nats.consumer.messages")
+	require.Len(t, messages, 1)
+	assert.Equal(t, string(OutcomeHandlerCancelled), attrs(messages[0])["outcome"])
+}
+
+func TestTerminalFailureAndMaxDeliver(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	c := m.Consumer(ConsumerConfig{ServiceName: "message-worker", Site: "s1", Stream: "MESSAGES_CANONICAL_s1", Consumer: "message-worker"})
+
+	permanent := c.Track(context.Background(), &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}}, EventUnknown, 5)
+	permanent.MarkTerminal(context.Background(), TerminalPermanent)
+	require.NoError(t, permanent.Ack())
+	exhausted := c.Track(context.Background(), &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 5}}, EventCreated, 5)
+	require.NoError(t, exhausted.NakWithDelay(time.Second))
+
+	rm := collect(t, reader)
+	points := metricPoints[int64](t, rm, "chat.nats.terminal.failures")
+	require.Len(t, points, 2)
+	reasons := map[string]int64{}
+	for _, point := range points {
+		reasons[attrs(point)["reason"]] = point.Value
+	}
+	assert.Equal(t, map[string]int64{"permanent": 1, "max_deliver": 1}, reasons)
+}
+
+func TestPublishAndRequestMetrics(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	p := m.Publisher("notification-worker", "s1")
+	p.Attempt(context.Background(), DestinationPush, OperationPushPublish, nil)
+	p.Attempt(context.Background(), DestinationPush, OperationPushPublish, nats.ErrNoResponders)
+	p.Retry(context.Background(), DestinationPush, OperationPushPublish)
+	p.Request(context.Background(), OperationPresenceLookup, 25*time.Millisecond, nats.ErrTimeout)
+
+	rm := collect(t, reader)
+	assert.Len(t, metricPoints[int64](t, rm, "chat.nats.publish.attempts"), 2)
+	assert.Len(t, metricPoints[int64](t, rm, "chat.nats.publish.retries"), 1)
+	requestPoints := metricPoints[int64](t, rm, "chat.nats.requests")
+	require.Len(t, requestPoints, 1)
+	assert.Equal(t, "timeout", attrs(requestPoints[0])["outcome"])
+	assert.Len(t, histogramPoints(t, rm, "chat.nats.request.duration"), 1)
+}
+
+func TestPublishAndRequestLabelsAreBounded(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	p := m.Publisher("notification-worker", "s1")
+	p.Attempt(context.Background(), DestinationKind("dynamic.destination"), Operation("dynamic.operation"), nil)
+	p.Request(context.Background(), Operation("another.dynamic.operation"), time.Millisecond, nil)
+
+	rm := collect(t, reader)
+	publishPoints := metricPoints[int64](t, rm, "chat.nats.publish.attempts")
+	require.Len(t, publishPoints, 1)
+	assert.Equal(t, string(DestinationUnknown), attrs(publishPoints[0])["destination_kind"])
+	assert.Equal(t, string(OperationUnknown), attrs(publishPoints[0])["operation"])
+	requestPoints := metricPoints[int64](t, rm, "chat.nats.requests")
+	require.Len(t, requestPoints, 1)
+	assert.Equal(t, string(OperationUnknown), attrs(requestPoints[0])["operation"])
+}
+
+func TestZeroValuePublisherDoesNotAffectBusinessFlow(t *testing.T) {
+	var publisher Publisher
+	publisher.Attempt(context.Background(), DestinationPush, OperationPushPublish, errors.New("publish failed"))
+	publisher.Retry(context.Background(), DestinationPush, OperationPushPublish)
+	publisher.Request(context.Background(), OperationPresenceLookup, time.Millisecond, errors.New("request failed"))
+}
+
+func TestClassifiersAreBounded(t *testing.T) {
+	assert.Equal(t, EventUnknown, NormalizeEventType("not-a-real-event"))
+	assert.Equal(t, EventCreated, NormalizeEventType("created"))
+	tests := []struct {
+		err  error
+		want PublishOutcome
+	}{
+		{nil, PublishSuccess},
+		{context.DeadlineExceeded, PublishTimeout},
+		{nats.ErrNoResponders, PublishNoResponders},
+		{nats.ErrDisconnected, PublishDisconnected},
+		{nats.ErrReconnectBufExceeded, PublishBufferFull},
+		{nats.ErrPermissionViolation, PublishPermission},
+		{nats.ErrMaxPayload, PublishPayloadTooLarge},
+		{errors.New("dynamic text"), PublishOtherError},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, ClassifyPublishError(tt.err))
+	}
+}

--- a/pkg/natsmetrics/metrics_test.go
+++ b/pkg/natsmetrics/metrics_test.go
@@ -177,7 +177,7 @@ func TestTrackedMessageDispositionAndRedelivery(t *testing.T) {
 			c := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "s1", Stream: "STREAM_s1", Consumer: "durable"})
 			tracked := c.Track(context.Background(), tt.msg, EventCreated, 5)
 			_ = tt.dispose(tracked)
-			tracked.FinishPending(context.Background()) // must not double count
+			tracked.Finish(context.Background()) // must not double count
 
 			rm := collect(t, reader)
 			points := metricPoints[int64](t, rm, "chat.nats.consumer.messages")
@@ -210,7 +210,7 @@ func TestTrackedMessageContextAndCancellation(t *testing.T) {
 	MarkTerminalFromContext(context.Background(), TerminalPublishExhausted)
 	MarkTerminalFromContext(ctx, TerminalReason("dynamic reason"))
 	tracked.MarkHandlerPanic()
-	tracked.FinishCancelled(ctx)
+	tracked.Finish(ctx)
 
 	rm := collect(t, reader)
 	terminal := metricPoints[int64](t, rm, "chat.nats.terminal.failures")

--- a/pkg/natsmetrics/subject.go
+++ b/pkg/natsmetrics/subject.go
@@ -1,0 +1,25 @@
+package natsmetrics
+
+import "strings"
+
+// EventTypeFromSubject derives the bounded event_type from a NATS subject's
+// last token.
+//
+// Every consumer of a stream must classify the same way: message-worker,
+// broadcast-worker, and notification-worker all read MESSAGES-CANONICAL, and a
+// campaign that cannot join their series on event_type cannot show a message
+// moving from accepted to persisted to delivered. The subject already carries
+// the verb (chat.msg.canonical.{site}.created, ….msg.send), so this needs no
+// payload parse — which also keeps classification off the dispatch path.
+func EventTypeFromSubject(subj string) EventType {
+	tail := subj
+	if idx := strings.LastIndexByte(subj, '.'); idx >= 0 {
+		tail = subj[idx+1:]
+	}
+	// The Teams migration lane spells its verb "batch"; every other subject
+	// tail already matches the shared event vocabulary.
+	if tail == "batch" {
+		return EventTeamsBatch
+	}
+	return NormalizeEventType(tail)
+}

--- a/pkg/natsmetrics/subject_test.go
+++ b/pkg/natsmetrics/subject_test.go
@@ -1,0 +1,37 @@
+package natsmetrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+// Every consumer of a stream must derive event_type the same way, otherwise the
+// campaign cannot join accepted -> persisted -> delivered on the label.
+func TestEventTypeFromSubject(t *testing.T) {
+	tests := []struct {
+		name string
+		subj string
+		want EventType
+	}{
+		{name: "canonical created", subj: subject.MsgCanonicalCreated("s1"), want: EventCreated},
+		{name: "canonical updated", subj: subject.MsgCanonicalUpdated("s1"), want: EventUpdated},
+		{name: "canonical deleted", subj: subject.MsgCanonicalDeleted("s1"), want: EventDeleted},
+		{name: "canonical pinned", subj: subject.MsgCanonicalPinned("s1"), want: EventPinned},
+		{name: "canonical unpinned", subj: subject.MsgCanonicalUnpinned("s1"), want: EventUnpinned},
+		{name: "canonical reacted", subj: subject.MsgCanonicalReacted("s1"), want: EventReacted},
+		{name: "teams batch", subj: subject.MsgTeamsCanonicalBatch("s1"), want: EventTeamsBatch},
+		{name: "user send", subj: subject.MsgSend("acct", "room", "s1"), want: EventSend},
+		{name: "unrecognized tail", subj: "chat.msg.canonical.s1.somethingelse", want: EventUnknown},
+		{name: "no dot", subj: "created", want: EventCreated},
+		{name: "empty", subj: "", want: EventUnknown},
+		{name: "trailing dot", subj: "chat.msg.canonical.s1.", want: EventUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, EventTypeFromSubject(tt.subj))
+		})
+	}
+}

--- a/pkg/natsutil/connect.go
+++ b/pkg/natsutil/connect.go
@@ -10,6 +10,7 @@ import (
 
 	o11ynats "github.com/flywindy/o11y/nats"
 	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -51,6 +52,21 @@ const (
 // can override it in either direction. With no higher-precedence source, false
 // selects the direct path without tracing or propagation overhead.
 func Connect(ctx context.Context, url, credsFile string, tp trace.TracerProvider, prop propagation.TextMapPropagator, tracingEnabled bool, opts ...nats.Option) (*o11ynats.Conn, error) {
+	return connect(ctx, url, credsFile, tp, prop, tracingEnabled, nil, opts...)
+}
+
+// ConnectWithMetrics opens a NATS connection and records its bounded lifecycle
+// metrics. It is intentionally opt-in so a focused failure campaign does not
+// expand instrumentation to every natsutil caller.
+func ConnectWithMetrics(ctx context.Context, url, credsFile string, tp trace.TracerProvider, prop propagation.TextMapPropagator, tracingEnabled bool, meterProvider metric.MeterProvider, opts ...nats.Option) (*o11ynats.Conn, error) {
+	var metrics *connMetrics
+	if meterProvider != nil {
+		metrics = newConnMetrics(meterProvider.Meter(connMetricsScope))
+	}
+	return connect(ctx, url, credsFile, tp, prop, tracingEnabled, metrics, opts...)
+}
+
+func connect(ctx context.Context, url, credsFile string, tp trace.TracerProvider, prop propagation.TextMapPropagator, tracingEnabled bool, metrics *connMetrics, opts ...nats.Option) (*o11ynats.Conn, error) {
 	if credsFile != "" {
 		if _, err := os.Stat(credsFile); err != nil {
 			return nil, fmt.Errorf("nats creds file %q: %w", credsFile, err)
@@ -59,25 +75,26 @@ func Connect(ctx context.Context, url, credsFile string, tp trace.TracerProvider
 
 	name := os.Getenv("HOSTNAME")
 	log := slog.With("component", "nats", "name", name)
+	connState := metrics.Connection()
 	baseOpts := []nats.Option{
 		nats.Name(name),
 		nats.MaxReconnects(-1),
 		nats.ReconnectWait(defaultReconnectWait),
 		nats.DrainTimeout(defaultDrainTimeout),
 		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
-			connEvents.Disconnected(ctx, err)
+			connState.Disconnected(ctx, err)
 			log.Warn("nats disconnected", "error", err)
 		}),
 		nats.ReconnectHandler(func(c *nats.Conn) {
-			connEvents.Reconnected(ctx)
+			connState.Reconnected(ctx)
 			log.Info("nats reconnected", "url", c.ConnectedUrl())
 		}),
 		nats.ClosedHandler(func(_ *nats.Conn) {
-			connEvents.Closed(ctx)
+			connState.Closed(ctx)
 			log.Warn("nats connection closed")
 		}),
 		nats.ErrorHandler(func(_ *nats.Conn, sub *nats.Subscription, err error) {
-			connEvents.AsyncError(ctx, err)
+			connState.AsyncError(ctx, err)
 			if errors.Is(err, nats.ErrSlowConsumer) {
 				logSlowConsumer(log, sub)
 				return
@@ -105,6 +122,6 @@ func Connect(ctx context.Context, url, credsFile string, tp trace.TracerProvider
 	}
 	// The library fires no callback for the first successful connect, so the
 	// gauge would stay at zero until the first disconnect without this.
-	connEvents.Connected(ctx)
+	connState.Connected(ctx)
 	return conn, nil
 }

--- a/pkg/natsutil/connect.go
+++ b/pkg/natsutil/connect.go
@@ -65,15 +65,19 @@ func Connect(ctx context.Context, url, credsFile string, tp trace.TracerProvider
 		nats.ReconnectWait(defaultReconnectWait),
 		nats.DrainTimeout(defaultDrainTimeout),
 		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
+			connEvents.Disconnected(ctx, err)
 			log.Warn("nats disconnected", "error", err)
 		}),
 		nats.ReconnectHandler(func(c *nats.Conn) {
+			connEvents.Reconnected(ctx)
 			log.Info("nats reconnected", "url", c.ConnectedUrl())
 		}),
 		nats.ClosedHandler(func(_ *nats.Conn) {
+			connEvents.Closed(ctx)
 			log.Warn("nats connection closed")
 		}),
 		nats.ErrorHandler(func(_ *nats.Conn, sub *nats.Subscription, err error) {
+			connEvents.AsyncError(ctx, err)
 			if errors.Is(err, nats.ErrSlowConsumer) {
 				logSlowConsumer(log, sub)
 				return
@@ -99,5 +103,8 @@ func Connect(ctx context.Context, url, credsFile string, tp trace.TracerProvider
 	if err != nil {
 		return nil, fmt.Errorf("connect nats: %w", err)
 	}
+	// The library fires no callback for the first successful connect, so the
+	// gauge would stay at zero until the first disconnect without this.
+	connEvents.Connected(ctx)
 	return conn, nil
 }

--- a/pkg/natsutil/connect_test.go
+++ b/pkg/natsutil/connect_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/hmchangw/chat/pkg/natsutil"
@@ -138,4 +140,49 @@ func TestConnect_SetsDrainTimeout(t *testing.T) {
 
 	require.Equal(t, 10*time.Second, conn.NatsConn().Opts.DrainTimeout,
 		"DrainTimeout must leave headroom in the shared 25s shutdown budget, not the 30s library default")
+}
+
+func TestConnectWithMetrics_TracksConnectionsIndependently(t *testing.T) {
+	serverURL := startTestServer(t)
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	first, err := natsutil.ConnectWithMetrics(context.Background(), serverURL, "",
+		noop.NewTracerProvider(), propagation.TraceContext{}, false, meterProvider)
+	require.NoError(t, err)
+	t.Cleanup(first.NatsConn().Close)
+	second, err := natsutil.ConnectWithMetrics(context.Background(), serverURL, "",
+		noop.NewTracerProvider(), propagation.TraceContext{}, false, meterProvider)
+	require.NoError(t, err)
+	t.Cleanup(second.NatsConn().Close)
+
+	require.Equal(t, int64(2), connectedMetricValue(t, reader))
+	first.NatsConn().Opts.DisconnectedErrCB(first.NatsConn(), errors.New("broker unavailable"))
+	require.Equal(t, int64(1), connectedMetricValue(t, reader))
+	second.NatsConn().Opts.ClosedCB(second.NatsConn())
+	require.Equal(t, int64(0), connectedMetricValue(t, reader))
+}
+
+func TestConnectWithMetrics_NilProviderDoesNotBlockConnection(t *testing.T) {
+	conn, err := natsutil.ConnectWithMetrics(context.Background(), startTestServer(t), "",
+		noop.NewTracerProvider(), propagation.TraceContext{}, false, nil)
+	require.NoError(t, err)
+	t.Cleanup(conn.NatsConn().Close)
+}
+
+func connectedMetricValue(t *testing.T, reader sdkmetric.Reader) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != "chat.nats.client.connected" {
+				continue
+			}
+			points := metric.Data.(metricdata.Sum[int64]).DataPoints
+			require.Len(t, points, 1)
+			return points[0].Value
+		}
+	}
+	t.Fatal("chat.nats.client.connected metric not found")
+	return 0
 }

--- a/pkg/natsutil/connmetrics.go
+++ b/pkg/natsutil/connmetrics.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"sync/atomic"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
 )
+
+const connMetricsScope = "github.com/hmchangw/chat/pkg/natsutil"
 
 // connMetrics reports the client's own view of its broker connection.
 //
@@ -27,7 +28,6 @@ import (
 type connMetrics struct {
 	connected metric.Int64UpDownCounter
 	events    metric.Int64Counter
-	up        atomic.Bool
 
 	// gaugeOpt carries no attributes: the gauge is one series per process.
 	gaugeOpt        metric.MeasurementOption
@@ -38,14 +38,18 @@ type connMetrics struct {
 	asyncErrorOpt   metric.MeasurementOption
 }
 
-var connEvents *connMetrics
-
-func init() { connEvents = newConnMetrics(otel.Meter("nats")) }
+// connMetricState owns one connection's lifecycle state. Multiple instrumented
+// connections share the same OTel instruments but transition independently, so
+// the up/down counter reports the number of live connections in the process.
+type connMetricState struct {
+	metrics *connMetrics
+	up      atomic.Bool
+}
 
 func newConnMetrics(meter metric.Meter) *connMetrics {
 	noopMeter := noop.NewMeterProvider().Meter("nats")
 	connected, err := meter.Int64UpDownCounter("chat.nats.client.connected",
-		metric.WithDescription("Whether this process currently has a live NATS broker connection."))
+		metric.WithDescription("Number of live NATS broker connections in this process."))
 	if err != nil {
 		connected, _ = noopMeter.Int64UpDownCounter("chat.nats.client.connected")
 	}
@@ -69,65 +73,72 @@ func newConnMetrics(meter metric.Meter) *connMetrics {
 	}
 }
 
-// Connected records the first successful connect. Later reconnects go through
-// Reconnected so the two are distinguishable in the events counter.
-func (c *connMetrics) Connected(ctx context.Context) {
+func (c *connMetrics) Connection() *connMetricState {
 	if c == nil {
-		return
+		return nil
 	}
-	c.markUp(ctx, c.connectedOpt)
+	return &connMetricState{metrics: c}
 }
 
-func (c *connMetrics) Reconnected(ctx context.Context) {
+// Connected records the first successful connect. Later reconnects go through
+// Reconnected so the two are distinguishable in the events counter.
+func (c *connMetricState) Connected(ctx context.Context) {
 	if c == nil {
 		return
 	}
-	c.markUp(ctx, c.reconnectedOpt)
+	c.markUp(ctx, c.metrics.connectedOpt)
+}
+
+func (c *connMetricState) Reconnected(ctx context.Context) {
+	if c == nil {
+		return
+	}
+	c.markUp(ctx, c.metrics.reconnectedOpt)
 }
 
 // Disconnected takes err only to keep the nats.DisconnectErrHandler signature
 // honest at the call site; the text is never a label.
-func (c *connMetrics) Disconnected(ctx context.Context, _ error) {
+func (c *connMetricState) Disconnected(ctx context.Context, _ error) {
 	if c == nil {
 		return
 	}
-	c.markDown(ctx, c.disconnectedOpt)
+	c.markDown(ctx, c.metrics.disconnectedOpt)
 }
 
-func (c *connMetrics) Closed(ctx context.Context) {
+func (c *connMetricState) Closed(ctx context.Context) {
 	if c == nil {
 		return
 	}
-	c.markDown(ctx, c.closedOpt)
+	c.markDown(ctx, c.metrics.closedOpt)
 }
 
 // AsyncError counts the connection-level async errors nats.go reports through
 // ErrorHandler. The error text is never a label: it is unbounded, and slow
 // consumers — the one async error worth separating — already have their own
 // dedicated counter.
-func (c *connMetrics) AsyncError(ctx context.Context, _ error) {
+func (c *connMetricState) AsyncError(ctx context.Context, _ error) {
 	if c == nil {
 		return
 	}
-	c.events.Add(ctx, 1, c.asyncErrorOpt)
+	c.metrics.events.Add(ctx, 1, c.metrics.asyncErrorOpt)
 }
 
-func (c *connMetrics) markUp(ctx context.Context, opt metric.MeasurementOption) {
+func (c *connMetricState) markUp(ctx context.Context, opt metric.MeasurementOption) {
 	if c == nil {
 		return
 	}
-	c.events.Add(ctx, 1, opt)
+	c.metrics.events.Add(ctx, 1, opt)
 	if c.up.CompareAndSwap(false, true) {
-		c.connected.Add(ctx, 1, c.gaugeOpt)
+		c.metrics.connected.Add(ctx, 1, c.metrics.gaugeOpt)
 	}
 }
 
-func (c *connMetrics) markDown(ctx context.Context, opt metric.MeasurementOption) {
+func (c *connMetricState) markDown(ctx context.Context, opt metric.MeasurementOption) {
 	if c == nil {
 		return
 	}
-	c.events.Add(ctx, 1, opt)
+	c.metrics.events.Add(ctx, 1, opt)
 	if c.up.CompareAndSwap(true, false) {
-		c.connected.Add(ctx, -1, c.gaugeOpt)
+		c.metrics.connected.Add(ctx, -1, c.metrics.gaugeOpt)
 	}
 }

--- a/pkg/natsutil/connmetrics.go
+++ b/pkg/natsutil/connmetrics.go
@@ -2,10 +2,8 @@ package natsutil
 
 import (
 	"context"
-	"errors"
 	"sync/atomic"
 
-	"github.com/nats-io/nats.go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -17,8 +15,11 @@ import (
 // Without it a broker outage and a wedged consumer loop look identical: the
 // JetStream consumer-loop gauge can stay at one while the client is detached,
 // and a Core NATS publish keeps returning nil because nats.go buffers across a
-// disconnect. The events counter is the only place a reconnect-buffer overflow
-// — the one condition that means client-side message loss — becomes queryable.
+// disconnect. Reconnect-buffer overflow — the one condition that means
+// client-side message loss — is not reported here: nats.go returns
+// ErrReconnectBufExceeded synchronously from Publish and never routes it
+// through ErrorHandler, so it is counted at the publish boundary instead, as
+// chat.nats.publish.attempts{outcome="buffer_full"}.
 //
 // service_name and site are not labels here: they come from the OTel resource
 // that pkg/obs installs, which is also how nats_slow_consumer_events_total is
@@ -34,7 +35,6 @@ type connMetrics struct {
 	disconnectedOpt metric.MeasurementOption
 	reconnectedOpt  metric.MeasurementOption
 	closedOpt       metric.MeasurementOption
-	bufferFullOpt   metric.MeasurementOption
 	asyncErrorOpt   metric.MeasurementOption
 }
 
@@ -65,7 +65,6 @@ func newConnMetrics(meter metric.Meter) *connMetrics {
 		disconnectedOpt: event("disconnected"),
 		reconnectedOpt:  event("reconnected"),
 		closedOpt:       event("closed"),
-		bufferFullOpt:   event("buffer_full"),
 		asyncErrorOpt:   event("async_error"),
 	}
 }
@@ -102,18 +101,15 @@ func (c *connMetrics) Closed(ctx context.Context) {
 	c.markDown(ctx, c.closedOpt)
 }
 
-// AsyncError classifies the connection-level async errors that matter to a
-// failure campaign. A reconnect-buffer overflow is client-side loss and gets
-// its own event; slow consumers keep their existing dedicated counter.
-func (c *connMetrics) AsyncError(ctx context.Context, err error) {
+// AsyncError counts the connection-level async errors nats.go reports through
+// ErrorHandler. The error text is never a label: it is unbounded, and slow
+// consumers — the one async error worth separating — already have their own
+// dedicated counter.
+func (c *connMetrics) AsyncError(ctx context.Context, _ error) {
 	if c == nil {
 		return
 	}
-	opt := c.asyncErrorOpt
-	if errors.Is(err, nats.ErrReconnectBufExceeded) {
-		opt = c.bufferFullOpt
-	}
-	c.events.Add(ctx, 1, opt)
+	c.events.Add(ctx, 1, c.asyncErrorOpt)
 }
 
 func (c *connMetrics) markUp(ctx context.Context, opt metric.MeasurementOption) {

--- a/pkg/natsutil/connmetrics.go
+++ b/pkg/natsutil/connmetrics.go
@@ -1,0 +1,137 @@
+package natsutil
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+
+	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// connMetrics reports the client's own view of its broker connection.
+//
+// Without it a broker outage and a wedged consumer loop look identical: the
+// JetStream consumer-loop gauge can stay at one while the client is detached,
+// and a Core NATS publish keeps returning nil because nats.go buffers across a
+// disconnect. The events counter is the only place a reconnect-buffer overflow
+// — the one condition that means client-side message loss — becomes queryable.
+//
+// service_name and site are not labels here: they come from the OTel resource
+// that pkg/obs installs, which is also how nats_slow_consumer_events_total is
+// scoped. Adding them per-series would duplicate the resource and drift from it.
+type connMetrics struct {
+	connected metric.Int64UpDownCounter
+	events    metric.Int64Counter
+	up        atomic.Bool
+
+	// gaugeOpt carries no attributes: the gauge is one series per process.
+	gaugeOpt        metric.MeasurementOption
+	connectedOpt    metric.MeasurementOption
+	disconnectedOpt metric.MeasurementOption
+	reconnectedOpt  metric.MeasurementOption
+	closedOpt       metric.MeasurementOption
+	bufferFullOpt   metric.MeasurementOption
+	asyncErrorOpt   metric.MeasurementOption
+}
+
+var connEvents *connMetrics
+
+func init() { connEvents = newConnMetrics(otel.Meter("nats")) }
+
+func newConnMetrics(meter metric.Meter) *connMetrics {
+	noopMeter := noop.NewMeterProvider().Meter("nats")
+	connected, err := meter.Int64UpDownCounter("chat.nats.client.connected",
+		metric.WithDescription("Whether this process currently has a live NATS broker connection."))
+	if err != nil {
+		connected, _ = noopMeter.Int64UpDownCounter("chat.nats.client.connected")
+	}
+	events, err := meter.Int64Counter("chat.nats.client.connection.events",
+		metric.WithDescription("NATS client connection lifecycle transitions by bounded event."))
+	if err != nil {
+		events, _ = noopMeter.Int64Counter("chat.nats.client.connection.events")
+	}
+	event := func(value string) metric.MeasurementOption {
+		return metric.WithAttributes(attribute.String("event", value))
+	}
+	return &connMetrics{
+		connected:       connected,
+		events:          events,
+		gaugeOpt:        metric.WithAttributes(),
+		connectedOpt:    event("connected"),
+		disconnectedOpt: event("disconnected"),
+		reconnectedOpt:  event("reconnected"),
+		closedOpt:       event("closed"),
+		bufferFullOpt:   event("buffer_full"),
+		asyncErrorOpt:   event("async_error"),
+	}
+}
+
+// Connected records the first successful connect. Later reconnects go through
+// Reconnected so the two are distinguishable in the events counter.
+func (c *connMetrics) Connected(ctx context.Context) {
+	if c == nil {
+		return
+	}
+	c.markUp(ctx, c.connectedOpt)
+}
+
+func (c *connMetrics) Reconnected(ctx context.Context) {
+	if c == nil {
+		return
+	}
+	c.markUp(ctx, c.reconnectedOpt)
+}
+
+// Disconnected takes err only to keep the nats.DisconnectErrHandler signature
+// honest at the call site; the text is never a label.
+func (c *connMetrics) Disconnected(ctx context.Context, _ error) {
+	if c == nil {
+		return
+	}
+	c.markDown(ctx, c.disconnectedOpt)
+}
+
+func (c *connMetrics) Closed(ctx context.Context) {
+	if c == nil {
+		return
+	}
+	c.markDown(ctx, c.closedOpt)
+}
+
+// AsyncError classifies the connection-level async errors that matter to a
+// failure campaign. A reconnect-buffer overflow is client-side loss and gets
+// its own event; slow consumers keep their existing dedicated counter.
+func (c *connMetrics) AsyncError(ctx context.Context, err error) {
+	if c == nil {
+		return
+	}
+	opt := c.asyncErrorOpt
+	if errors.Is(err, nats.ErrReconnectBufExceeded) {
+		opt = c.bufferFullOpt
+	}
+	c.events.Add(ctx, 1, opt)
+}
+
+func (c *connMetrics) markUp(ctx context.Context, opt metric.MeasurementOption) {
+	if c == nil {
+		return
+	}
+	c.events.Add(ctx, 1, opt)
+	if c.up.CompareAndSwap(false, true) {
+		c.connected.Add(ctx, 1, c.gaugeOpt)
+	}
+}
+
+func (c *connMetrics) markDown(ctx context.Context, opt metric.MeasurementOption) {
+	if c == nil {
+		return
+	}
+	c.events.Add(ctx, 1, opt)
+	if c.up.CompareAndSwap(true, false) {
+		c.connected.Add(ctx, -1, c.gaugeOpt)
+	}
+}

--- a/pkg/natsutil/connmetrics_test.go
+++ b/pkg/natsutil/connmetrics_test.go
@@ -98,8 +98,9 @@ func TestConnMetrics_EventLabelsAreBounded(t *testing.T) {
 	m.Disconnected(context.Background(), errors.New("some dynamic error text"))
 	m.Reconnected(context.Background())
 	m.Closed(context.Background())
-	// A reconnect-buffer overflow is the one async error that means client-side
-	// message loss, so it gets its own bounded event value.
+	// Every async error collapses to one bounded value. A reconnect-buffer
+	// overflow never arrives here — nats.go returns it synchronously from
+	// Publish — so it must not have an event value of its own to imply it does.
 	m.AsyncError(context.Background(), nats.ErrReconnectBufExceeded)
 	m.AsyncError(context.Background(), errors.New("unclassified async failure"))
 
@@ -108,8 +109,7 @@ func TestConnMetrics_EventLabelsAreBounded(t *testing.T) {
 		"disconnected": 1,
 		"reconnected":  1,
 		"closed":       1,
-		"buffer_full":  1,
-		"async_error":  1,
+		"async_error":  2,
 	}, eventCounts(t, reader))
 }
 

--- a/pkg/natsutil/connmetrics_test.go
+++ b/pkg/natsutil/connmetrics_test.go
@@ -52,23 +52,24 @@ func eventCounts(t *testing.T, reader sdkmetric.Reader) map[string]int64 {
 // the broker was fine" during a complete-outage campaign.
 func TestConnMetrics_GaugeTracksOutage(t *testing.T) {
 	m, reader := newTestConnMetrics(t)
+	conn := m.Connection()
 
-	m.Connected(context.Background())
+	conn.Connected(context.Background())
 	points := connPoints(t, reader, "chat.nats.client.connected")
 	require.Len(t, points, 1)
 	assert.Equal(t, int64(1), points[0].Value)
 
-	m.Disconnected(context.Background(), errors.New("broker unreachable"))
+	conn.Disconnected(context.Background(), errors.New("broker unreachable"))
 	points = connPoints(t, reader, "chat.nats.client.connected")
 	require.Len(t, points, 1)
 	assert.Equal(t, int64(0), points[0].Value)
 
-	m.Reconnected(context.Background())
+	conn.Reconnected(context.Background())
 	points = connPoints(t, reader, "chat.nats.client.connected")
 	require.Len(t, points, 1)
 	assert.Equal(t, int64(1), points[0].Value)
 
-	m.Closed(context.Background())
+	conn.Closed(context.Background())
 	points = connPoints(t, reader, "chat.nats.client.connected")
 	require.Len(t, points, 1)
 	assert.Equal(t, int64(0), points[0].Value)
@@ -79,11 +80,12 @@ func TestConnMetrics_GaugeTracksOutage(t *testing.T) {
 // stays a raw transition count, so it is not deduplicated.
 func TestConnMetrics_GaugeIsIdempotentButEventsAreRaw(t *testing.T) {
 	m, reader := newTestConnMetrics(t)
+	conn := m.Connection()
 
-	m.Connected(context.Background())
-	m.Connected(context.Background())
-	m.Disconnected(context.Background(), nil)
-	m.Disconnected(context.Background(), nil)
+	conn.Connected(context.Background())
+	conn.Connected(context.Background())
+	conn.Disconnected(context.Background(), nil)
+	conn.Disconnected(context.Background(), nil)
 
 	points := connPoints(t, reader, "chat.nats.client.connected")
 	require.Len(t, points, 1)
@@ -91,18 +93,41 @@ func TestConnMetrics_GaugeIsIdempotentButEventsAreRaw(t *testing.T) {
 	assert.Equal(t, map[string]int64{"connected": 2, "disconnected": 2}, eventCounts(t, reader))
 }
 
+func TestConnMetrics_ConnectionsTrackIndependently(t *testing.T) {
+	m, reader := newTestConnMetrics(t)
+	first := m.Connection()
+	second := m.Connection()
+
+	first.Connected(context.Background())
+	second.Connected(context.Background())
+	points := connPoints(t, reader, "chat.nats.client.connected")
+	require.Len(t, points, 1)
+	assert.Equal(t, int64(2), points[0].Value)
+
+	first.Disconnected(context.Background(), errors.New("first broker unavailable"))
+	points = connPoints(t, reader, "chat.nats.client.connected")
+	require.Len(t, points, 1)
+	assert.Equal(t, int64(1), points[0].Value)
+
+	second.Closed(context.Background())
+	points = connPoints(t, reader, "chat.nats.client.connected")
+	require.Len(t, points, 1)
+	assert.Equal(t, int64(0), points[0].Value)
+}
+
 func TestConnMetrics_EventLabelsAreBounded(t *testing.T) {
 	m, reader := newTestConnMetrics(t)
+	conn := m.Connection()
 
-	m.Connected(context.Background())
-	m.Disconnected(context.Background(), errors.New("some dynamic error text"))
-	m.Reconnected(context.Background())
-	m.Closed(context.Background())
+	conn.Connected(context.Background())
+	conn.Disconnected(context.Background(), errors.New("some dynamic error text"))
+	conn.Reconnected(context.Background())
+	conn.Closed(context.Background())
 	// Every async error collapses to one bounded value. A reconnect-buffer
 	// overflow never arrives here — nats.go returns it synchronously from
 	// Publish — so it must not have an event value of its own to imply it does.
-	m.AsyncError(context.Background(), nats.ErrReconnectBufExceeded)
-	m.AsyncError(context.Background(), errors.New("unclassified async failure"))
+	conn.AsyncError(context.Background(), nats.ErrReconnectBufExceeded)
+	conn.AsyncError(context.Background(), errors.New("unclassified async failure"))
 
 	assert.Equal(t, map[string]int64{
 		"connected":    1,
@@ -114,7 +139,7 @@ func TestConnMetrics_EventLabelsAreBounded(t *testing.T) {
 }
 
 func TestConnMetrics_NilReceiverIsSafe(t *testing.T) {
-	var m *connMetrics
+	var m *connMetricState
 	m.Connected(context.Background())
 	m.Disconnected(context.Background(), nil)
 	m.Reconnected(context.Background())

--- a/pkg/natsutil/connmetrics_test.go
+++ b/pkg/natsutil/connmetrics_test.go
@@ -1,0 +1,123 @@
+package natsutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func newTestConnMetrics(t *testing.T) (*connMetrics, sdkmetric.Reader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	return newConnMetrics(mp.Meter("test")), reader
+}
+
+func connPoints(t *testing.T, reader sdkmetric.Reader, name string) []metricdata.DataPoint[int64] {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name == name {
+				sum, ok := m.Data.(metricdata.Sum[int64])
+				require.True(t, ok, name)
+				return sum.DataPoints
+			}
+		}
+	}
+	return nil
+}
+
+func eventCounts(t *testing.T, reader sdkmetric.Reader) map[string]int64 {
+	t.Helper()
+	out := map[string]int64{}
+	for _, dp := range connPoints(t, reader, "chat.nats.client.connection.events") {
+		for _, kv := range dp.Attributes.ToSlice() {
+			if string(kv.Key) == "event" {
+				out[kv.Value.AsString()] = dp.Value
+			}
+		}
+	}
+	return out
+}
+
+// The gauge is what separates "the broker went away" from "the loop died while
+// the broker was fine" during a complete-outage campaign.
+func TestConnMetrics_GaugeTracksOutage(t *testing.T) {
+	m, reader := newTestConnMetrics(t)
+
+	m.Connected(context.Background())
+	points := connPoints(t, reader, "chat.nats.client.connected")
+	require.Len(t, points, 1)
+	assert.Equal(t, int64(1), points[0].Value)
+
+	m.Disconnected(context.Background(), errors.New("broker unreachable"))
+	points = connPoints(t, reader, "chat.nats.client.connected")
+	require.Len(t, points, 1)
+	assert.Equal(t, int64(0), points[0].Value)
+
+	m.Reconnected(context.Background())
+	points = connPoints(t, reader, "chat.nats.client.connected")
+	require.Len(t, points, 1)
+	assert.Equal(t, int64(1), points[0].Value)
+
+	m.Closed(context.Background())
+	points = connPoints(t, reader, "chat.nats.client.connected")
+	require.Len(t, points, 1)
+	assert.Equal(t, int64(0), points[0].Value)
+}
+
+// The gauge must stay a 0/1 state even if the client library repeats a
+// callback. The events counter mirrors loadgen_nats_connection_events_total and
+// stays a raw transition count, so it is not deduplicated.
+func TestConnMetrics_GaugeIsIdempotentButEventsAreRaw(t *testing.T) {
+	m, reader := newTestConnMetrics(t)
+
+	m.Connected(context.Background())
+	m.Connected(context.Background())
+	m.Disconnected(context.Background(), nil)
+	m.Disconnected(context.Background(), nil)
+
+	points := connPoints(t, reader, "chat.nats.client.connected")
+	require.Len(t, points, 1)
+	assert.Equal(t, int64(0), points[0].Value)
+	assert.Equal(t, map[string]int64{"connected": 2, "disconnected": 2}, eventCounts(t, reader))
+}
+
+func TestConnMetrics_EventLabelsAreBounded(t *testing.T) {
+	m, reader := newTestConnMetrics(t)
+
+	m.Connected(context.Background())
+	m.Disconnected(context.Background(), errors.New("some dynamic error text"))
+	m.Reconnected(context.Background())
+	m.Closed(context.Background())
+	// A reconnect-buffer overflow is the one async error that means client-side
+	// message loss, so it gets its own bounded event value.
+	m.AsyncError(context.Background(), nats.ErrReconnectBufExceeded)
+	m.AsyncError(context.Background(), errors.New("unclassified async failure"))
+
+	assert.Equal(t, map[string]int64{
+		"connected":    1,
+		"disconnected": 1,
+		"reconnected":  1,
+		"closed":       1,
+		"buffer_full":  1,
+		"async_error":  1,
+	}, eventCounts(t, reader))
+}
+
+func TestConnMetrics_NilReceiverIsSafe(t *testing.T) {
+	var m *connMetrics
+	m.Connected(context.Background())
+	m.Disconnected(context.Background(), nil)
+	m.Reconnected(context.Background())
+	m.Closed(context.Background())
+	m.AsyncError(context.Background(), nats.ErrSlowConsumer)
+}


### PR DESCRIPTION
## Summary

Implements Workstream B application-side NATS and JetStream failure telemetry for the first core-message campaign. The change provides one shared bounded-cardinality package, adopts it in `message-gatekeeper`, `message-worker`, `broadcast-worker`, and `notification-worker`, and adds opt-in NATS connection lifecycle evidence for those same four services.

The branch is synchronized with the current `main`. It does not change Ack/Nak/Term policy, introduce retries, add a telemetry provider, or instrument unrelated services.

## Service-by-service evidence

| Service | Consumer and disposition evidence | Publish/request evidence | Domain evidence |
|---|---|---|---|
| `message-gatekeeper` | `main.go` wires tracked MESSAGES deliveries; `handler.go` records Ack/Nak, invalid payload, retry, and final canonical-publish exhaustion | Canonical JetStream PubAck, client responses, and history request/reply | `message_gatekeeper_messages_total{result,reason}` |
| `message-worker` | `main.go` tracks canonical and Teams-batch deliveries; poison payloads are terminal; transient persistence failures Nak with existing backoff | Recipient/outbox publish attempts; all four Cassandra batches use the o11y batch seam | `message_worker_persistence_total{message_kind,result}` |
| `broadcast-worker` | `natsmetrics.Start` tracks the canonical loop and guarded handler disposition | Actual recipient Core NATS attempts and history requests | fan-out size, recipient success/failure, and `publish_exhausted` evidence for swallowed partial fan-out |
| `notification-worker` | Canonical delivery, redelivery, Ack/Nak, poison, and shutdown state | Notification/push publish attempts and presence/history requests | sent, suppressed, publish-failed, and failed outcomes |

## Shared metric contract

| Instrument | Labels | Bounded values |
|---|---|---|
| `chat.nats.consumer.loop.up` | `service_name,site,stream,consumer` | Deployment wiring only |
| `chat.nats.consumer.messages` | consumer labels + `event_type,outcome` | event: `created,updated,deleted,pinned,unpinned,reacted,thread_reply_added,send,teams_batch,unknown`; outcome: `ack,nak,term,left_pending,handler_cancelled` |
| `chat.nats.consumer.redeliveries` | consumer labels + `event_type` | Emitted only when JetStream `NumDelivered > 1` |
| `chat.nats.consumer.processing.duration` | consumer labels + `event_type,outcome` | Seconds with explicit o11y latency buckets |
| `chat.nats.publish.attempts` | `service_name,site,destination_kind,operation,outcome` | destination: `canonical,recipient_event,notification,push,outbox,inbox,client_response,user_sync,unknown`; outcome: `success,timeout,no_responders,disconnected,buffer_full,permission,payload_too_large,other_error` |
| `chat.nats.publish.retries` | `service_name,site,destination_kind,operation` | Declared; no producer because no target path has an application-managed publish loop |
| `chat.nats.terminal.failures` | consumer labels + `event_type,reason` | `max_deliver,permanent,publish_exhausted,consumer_deleted,stream_unavailable,invalid_payload,internal` |
| `chat.nats.requests` / `chat.nats.request.duration` | `service_name,site,operation,outcome` | Measured request/reply calls only; duration uses seconds and explicit latency buckets |
| `chat.nats.client.connected` | OTel resource only | Live connection count in the process |
| `chat.nats.client.connection.events` | `event` | `connected,disconnected,reconnected,closed,async_error` |

Connection metrics are opt-in through `natsutil.ConnectWithMetrics`; only the four campaign services call it. Each connection owns independent lifecycle state, while the shared up-down instrument aggregates the live connection count. A nil meter provider degrades to the ordinary connection path and never blocks startup.

## Domain metric contract

| Instrument | Labels and bounded values |
|---|---|
| `message_gatekeeper_messages_total` | result: `accepted,rejected,retry,failed`; reason: `none,invalid_subject,invalid_payload,not_subscribed,room_restricted,canonical_publish,dependency,unknown` |
| `message_worker_persistence_total` | message_kind: `user,system,thread_reply,teams_migration,unknown`; result: `success,error` |
| `broadcast_worker_fanout_recipients` | room_kind: `channel,dm,bot_dm,thread,unknown`; bounded `event_type` |
| `broadcast_worker_recipient_deliveries_total` | fan-out labels + result: `success,failed` |
| `notification_worker_outcomes_total` | kind: `push,notification,unknown`; result: `sent,suppressed,publish_failed,failed` |

No concrete subject, room ID, account, user ID, message ID, request ID, address, error text, or peer identity is used as a metric label.

## Ack, Nak, Term, and terminal semantics

- One `chat.nats.consumer.messages` disposition is emitted per JetStream delivery attempt.
- `Ack` and successful `DoubleAck` record `ack`; `Nak` and `NakWithDelay` record `nak`; `Term` records `term`; a failed disposition remains `left_pending`.
- A handler that returns without a disposition records `left_pending` while the loop and context are live, or `handler_cancelled` during shutdown.
- The loop gauge becomes 1 only after iterator creation and becomes 0 before terminal iterator/Next return and before graceful iterator stop.
- Redelivery is derived only from JetStream metadata where `NumDelivered > 1`.
- `max_deliver`, explicit permanent Term, poisoned payloads, loop failure, and swallowed partial fan-out use bounded terminal reasons. Marking is once-only per delivery.
- Gatekeeper validation/policy rejections are business outcomes, not terminal-loss evidence.
- Core NATS `outcome="success"` means accepted by the client/write or reconnect buffer, not recipient delivery. `ErrReconnectBufExceeded` is recorded at the publish boundary as `outcome="buffer_full"`.
- Metrics decorators preserve existing errors and business behavior. In particular, `broadcastMetricPublisher` returns the already-contextualized `natsPublisher.Publish` error unchanged instead of duplicating the subject wrapper.

## Tests added for the review follow-up

- Independent multi-connection state transitions and aggregate live count.
- Opt-in connection API and nil-provider no-op behavior.
- Gatekeeper accepted, rejected, retry, and exhausted canonical-publish outcomes.
- Message persistence success and Cassandra failure outcomes.
- Notification sent, suppressed, and publish-failed outcomes.
- Broadcast zero-recipient, full-success, partial-success, total-failure, and duplicate-recipient attempts, including partial-fan-out terminal evidence.
- Injected domain metrics for production handlers, with no redundant global-meter construction on the production path.

## Validation

- `make fmt` — completed
- `make test` — all unit tests pass with the race detector
- `make lint` — 0 issues
- `make sast-gosec` — pass
- `make sast-vuln` — no called vulnerabilities
- `make sast-semgrep` — 0 blocking findings
- `make test-integration SERVICE=broadcast-worker` — pass
- `make test-integration SERVICE=message-gatekeeper` — pass
- `make test-integration SERVICE=message-worker` — pass
- `make test-integration SERVICE=notification-worker` — pass
- `make test-integration SERVICE=pkg/natsutil` — pass
- `go.mod` / `go.sum` unchanged by this workstream

### Coverage evidence

| Scope | Statement coverage |
|---|---:|
| `pkg/natsmetrics` | 94.9% |
| `pkg/natsutil` | 88.0% |
| `broadcast-worker/handler.go` | 85.0% |
| `message-gatekeeper/handler.go` | 91.4% |
| `message-worker/handler.go` | 95.3% |
| `notification-worker/handler.go` | 95.0% |
| four service-local `nats_metrics.go` files | 93.3%–95.0% |

The existing flat `package main` services remain below 80% when process wiring and database adapters are included. Unit+integration package coverage is 70.0% (`broadcast-worker`), 65.2% (`message-gatekeeper`), 70.1% (`message-worker`), and 62.0% (`notification-worker`). This PR does not hide those legacy boundaries with coverage exclusions; the new shared instrumentation and the affected handler logic are covered at or above the scoped targets shown above.

## Remaining observability gaps

- Consumer terminate/recreate during a live campaign is not yet an embedded-JetStream integration scenario; the unit suite covers iterator creation/failure and loop-gauge transitions.
- Broker advisories/exporters, Prometheus recording rules, Grafana dashboards, fault annotations, and final rendered-name verification remain deployment/dashboard work.
- Workstream A owns the loadgen evidence ledger and recipient observers.
- `chat_jetstream_consumer_oldest_pending_age_seconds` remains unowned and is required by the pending-age settle gate.
