### PR TITLE
cdc-verify: review-wave hardening follow-up to #240

### DIFF
--- a/search-service/integration_index_test.go
+++ b/search-service/integration_index_test.go
@@ -6,11 +6,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hmchangw/chat/pkg/testutil"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/hmchangw/chat/pkg/testutil"
 )
 
 // EnsureIndexes must not conflict with the canonical UNIQUE users.account_1 index

--- a/tools/cdc-verify/README.md
+++ b/tools/cdc-verify/README.md
@@ -13,7 +13,7 @@ stopped freely without perturbing the migration — no durable state, no acks
 that matter, no writes. Like `data-migration/`, it is **deletable** once the
 source is retired.
 
-```
+```text
                     ┌────────────────────────── tools/cdc-verify ──────────────────────────┐
 MIGRATION-OPLOG ────▶ watcher (ephemeral consumer, deliver-new) ─▶ verifier engine ─▶ results store (ring buffers)
    {siteID}     ────▶ stats poller (StreamInfo + consumer lag)  ──────────────┐             │
@@ -72,6 +72,8 @@ SITE_ID=site1 \
 NATS_URL=nats://localhost:4222 \
 SOURCE_MONGO_URI=mongodb://localhost:27017 \
 TARGET_MONGO_URI=mongodb://localhost:27018 \
+CASSANDRA_HOSTS=localhost:9042 \
+CASSANDRA_KEYSPACE=chat \
 MAPPING_FILE=tools/cdc-verify/mapping.example.json \
 ./bin/cdc-verify
 ```
@@ -151,7 +153,7 @@ mismatch → match as the pipeline catches up, and it freezes there.
 One check per observed event (one table row), deduplicated per key while
 pending:
 
-```
+```text
 event observed ──▶ PENDING ── poll compare every VERIFY_POLL (default 2s) ──▶ MATCHED  (frozen — never re-checked)
                      │                                                   └──▶ FAILED   (VERIFY_TIMEOUT elapsed, default 60s;
                      │                                                        moved to failures table with field-level diff)
@@ -278,6 +280,7 @@ transformers, then tuned per environment.
 | `SOURCE_MONGO_URI` | yes | — | Source Mongo connection string |
 | `SOURCE_MONGO_USERNAME` / `SOURCE_MONGO_PASSWORD` | no | `""` | Source Mongo auth |
 | `SOURCE_DB` | no | `rocketchat` | Source database name |
+| `SOURCE_READ_PREFERENCE` | no | `primary` | Source Mongo read preference (`primary`, `primaryPreferred`, `secondary`, `secondaryPreferred`, `nearest`). Default `primary` — a stale secondary would report convergence lag that isn't there |
 | `TARGET_MONGO_URI` | yes | — | Destination Mongo connection string |
 | `TARGET_MONGO_USERNAME` / `TARGET_MONGO_PASSWORD` | no | `""` | Target Mongo auth |
 | `TARGET_DB` | no | `chat` | Destination database name |

--- a/tools/cdc-verify/bootstrap.go
+++ b/tools/cdc-verify/bootstrap.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/nats-io/nats.go/jetstream"
@@ -17,12 +18,21 @@ type bootstrapConfig struct {
 
 // bootstrapStreams creates MIGRATION-OPLOG-{siteID} from schema (Name+Subjects) for
 // dev stacks without oplog-connector; disabled it no-ops and js.Stream fails fast.
+// Create-only: an existing stream is owned by the real pipeline and never updated —
+// a bare Name+Subjects update would strip its retention/replica config.
 func bootstrapStreams(ctx context.Context, js jetstream.JetStream, siteID string, enabled bool) error {
 	if !enabled {
 		return nil
 	}
 	cfg := stream.MigrationOplog(siteID)
-	if _, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+	_, err := js.Stream(ctx, cfg.Name)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, jetstream.ErrStreamNotFound) {
+		return fmt.Errorf("check MIGRATION-OPLOG stream: %w", err)
+	}
+	if _, err := js.CreateStream(ctx, jetstream.StreamConfig{
 		Name:     cfg.Name,
 		Subjects: cfg.Subjects,
 	}); err != nil {

--- a/tools/cdc-verify/bootstrap_test.go
+++ b/tools/cdc-verify/bootstrap_test.go
@@ -17,20 +17,25 @@ func TestBootstrapStreams_Disabled(t *testing.T) {
 }
 
 // fakeJetStream embeds a nil jetstream.JetStream (unimplemented methods panic)
-// and overrides only CreateOrUpdateStream — all the enabled path uses.
+// and overrides only Stream + CreateStream — all the enabled path uses.
 type fakeJetStream struct {
 	jetstream.JetStream
-	created []jetstream.StreamConfig
-	err     error
+	streamErr error // Stream lookup result; nil = stream exists
+	created   []jetstream.StreamConfig
+	createErr error
 }
 
-func (f *fakeJetStream) CreateOrUpdateStream(_ context.Context, cfg jetstream.StreamConfig) (jetstream.Stream, error) { //nolint:gocritic // hugeParam: cfg is passed by value to satisfy jetstream.StreamManager
+func (f *fakeJetStream) Stream(_ context.Context, _ string) (jetstream.Stream, error) {
+	return nil, f.streamErr
+}
+
+func (f *fakeJetStream) CreateStream(_ context.Context, cfg jetstream.StreamConfig) (jetstream.Stream, error) { //nolint:gocritic // hugeParam: cfg is passed by value to satisfy jetstream.StreamManager
 	f.created = append(f.created, cfg)
-	return nil, f.err
+	return nil, f.createErr
 }
 
 func TestBootstrapStreams_EnabledCreatesSchemaOnly(t *testing.T) {
-	fjs := &fakeJetStream{}
+	fjs := &fakeJetStream{streamErr: jetstream.ErrStreamNotFound}
 	err := bootstrapStreams(context.Background(), fjs, "site1", true)
 	require.NoError(t, err)
 
@@ -42,8 +47,25 @@ func TestBootstrapStreams_EnabledCreatesSchemaOnly(t *testing.T) {
 	assert.Nil(t, got.Sources)
 }
 
+// An existing stream is left alone: create-only bootstrap must never rewrite
+// the config of a stream the real pipeline (oplog-connector/ops) owns.
+func TestBootstrapStreams_ExistingStreamUntouched(t *testing.T) {
+	fjs := &fakeJetStream{streamErr: nil}
+	err := bootstrapStreams(context.Background(), fjs, "site1", true)
+	require.NoError(t, err)
+	assert.Empty(t, fjs.created, "no create/update call for an existing stream")
+}
+
+func TestBootstrapStreams_LookupError(t *testing.T) {
+	fjs := &fakeJetStream{streamErr: errors.New("nats down")}
+	err := bootstrapStreams(context.Background(), fjs, "site1", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "check MIGRATION-OPLOG stream")
+	assert.Empty(t, fjs.created)
+}
+
 func TestBootstrapStreams_EnabledCreateError(t *testing.T) {
-	fjs := &fakeJetStream{err: errors.New("boom")}
+	fjs := &fakeJetStream{streamErr: jetstream.ErrStreamNotFound, createErr: errors.New("boom")}
 	err := bootstrapStreams(context.Background(), fjs, "site1", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "create MIGRATION-OPLOG stream")

--- a/tools/cdc-verify/compare.go
+++ b/tools/cdc-verify/compare.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // getPath walks a dot-path through nested map[string]any. No array indexing.
@@ -91,6 +92,65 @@ func isZeroValue(v any) bool {
 	}
 }
 
+// diffValueMaxString caps one diff value's string length: a diff is a pointer
+// at a mismatch, not a document dump, and rows are retained + broadcast as JSON.
+const diffValueMaxString = 2048
+
+// sanitizeDiffValue makes a value safe to retain and JSON-encode in a diff:
+// non-string map keys are stringified (json.Marshal rejects e.g. map[bool]T
+// from a driver), []byte becomes string, and huge strings are truncated.
+func sanitizeDiffValue(v any) any {
+	switch t := v.(type) {
+	case nil:
+		return nil
+	case string:
+		return truncDiffString(t)
+	case []byte:
+		return truncDiffString(string(t))
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for k, vv := range t {
+			out[truncDiffString(k)] = sanitizeDiffValue(vv)
+		}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, vv := range t {
+			out[i] = sanitizeDiffValue(vv)
+		}
+		return out
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Map:
+		out := make(map[string]any, rv.Len())
+		iter := rv.MapRange()
+		for iter.Next() {
+			out[truncDiffString(fmt.Sprint(iter.Key().Interface()))] = sanitizeDiffValue(iter.Value().Interface())
+		}
+		return out
+	case reflect.Slice, reflect.Array:
+		out := make([]any, rv.Len())
+		for i := range out {
+			out[i] = sanitizeDiffValue(rv.Index(i).Interface())
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func truncDiffString(s string) string {
+	if len(s) <= diffValueMaxString {
+		return s
+	}
+	cut := diffValueMaxString
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "…(truncated)"
+}
+
 // FieldDiff is one mismatched field in a failed sub-check.
 type FieldDiff struct {
 	SourcePath string `json:"sourcePath"`
@@ -116,7 +176,9 @@ func diffFields(src, dst map[string]any, pairs []fieldPair, reg transformRegistr
 		anyPresent := false
 		for _, sp := range p.SourcePaths {
 			v, ok := getPath(src, sp)
-			if ok {
+			// An explicit BSON null counts as absent: transformers drop null
+			// fields, so the dest legitimately holds nothing for them.
+			if ok && v != nil {
 				anyPresent = true
 			}
 			args = append(args, v)
@@ -130,7 +192,7 @@ func diffFields(src, dst map[string]any, pairs []fieldPair, reg transformRegistr
 			switch {
 			case !destZero:
 				diffs = append(diffs, FieldDiff{SourcePath: strings.Join(p.SourcePaths, ","),
-					DestField: p.DestField, Want: nil, Got: got, Cause: "absent in source, present in dest"})
+					DestField: p.DestField, Want: nil, Got: sanitizeDiffValue(got), Cause: "absent in source, present in dest"})
 			case p.Required:
 				diffs = append(diffs, FieldDiff{SourcePath: strings.Join(p.SourcePaths, ","),
 					DestField: p.DestField, Cause: "required field absent on both sides"})
@@ -146,7 +208,7 @@ func diffFields(src, dst map[string]any, pairs []fieldPair, reg transformRegistr
 		}
 		if !valuesEqual(want, got) {
 			diffs = append(diffs, FieldDiff{SourcePath: strings.Join(p.SourcePaths, ","),
-				DestField: p.DestField, Want: want, Got: got})
+				DestField: p.DestField, Want: sanitizeDiffValue(want), Got: sanitizeDiffValue(got)})
 		}
 	}
 	return diffs
@@ -165,7 +227,8 @@ func diffVerbatim(src, dst map[string]any, ignore []string) []FieldDiff {
 		}
 		got, ok := getPath(dst, k)
 		if !ok || !valuesEqual(want, got) {
-			diffs = append(diffs, FieldDiff{SourcePath: k, DestField: k, Want: want, Got: got})
+			diffs = append(diffs, FieldDiff{SourcePath: k, DestField: k,
+				Want: sanitizeDiffValue(want), Got: sanitizeDiffValue(got)})
 		}
 	}
 	for k, got := range dst {
@@ -173,7 +236,7 @@ func diffVerbatim(src, dst map[string]any, ignore []string) []FieldDiff {
 			continue
 		}
 		if _, ok := src[k]; !ok {
-			diffs = append(diffs, FieldDiff{DestField: k, Got: got, Cause: "present only in dest"})
+			diffs = append(diffs, FieldDiff{DestField: k, Got: sanitizeDiffValue(got), Cause: "present only in dest"})
 		}
 	}
 	return diffs

--- a/tools/cdc-verify/compare_test.go
+++ b/tools/cdc-verify/compare_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hmchangw/chat/pkg/msgbucket"
 )
@@ -220,4 +224,96 @@ func TestDiffVerbatim(t *testing.T) {
 	diffs = diffVerbatim(src, dst, []string{"_updatedAt", "n"})
 	assert.Len(t, diffs, 1)
 	assert.Equal(t, "extra", diffs[0].DestField)
+}
+
+// An explicit BSON null in the source counts as absent — transformers drop
+// null fields, so a zero/absent dest must match instead of diffing nil vs "".
+func TestDiffFields_ExplicitNullCountsAsAbsent(t *testing.T) {
+	reg := newTransformRegistry(msgbucket.New(72 * time.Hour))
+	src := map[string]any{"f": nil}
+
+	tests := []struct {
+		name      string
+		dst       map[string]any
+		required  bool
+		wantDiffs int
+		wantCause string
+	}{
+		{"null source vs absent dest", map[string]any{}, false, 0, ""},
+		{"null source vs empty-string dest", map[string]any{"field": ""}, false, 0, ""},
+		{"null source vs zero-int dest", map[string]any{"field": 0}, false, 0, ""},
+		{"null source vs present dest", map[string]any{"field": "x"}, false, 1, "absent in source, present in dest"},
+		{"required null source vs zero dest", map[string]any{"field": ""}, true, 1, "required"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pairs := []fieldPair{{SourcePaths: []string{"f"}, DestField: "field", Required: tt.required}}
+			diffs := diffFields(src, tt.dst, pairs, reg)
+			require.Len(t, diffs, tt.wantDiffs)
+			if tt.wantCause != "" {
+				assert.Contains(t, diffs[0].Cause, tt.wantCause)
+			}
+		})
+	}
+}
+
+func TestSanitizeDiffValue(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		want any
+	}{
+		{"nil passes through", nil, nil},
+		{"scalar passes through", int64(7), int64(7)},
+		{"short string passes through", "hi", "hi"},
+		{"bytes become string", []byte("raw"), "raw"},
+		{"non-string map keys stringified", map[bool]string{true: "x"}, map[string]any{"true": "x"}},
+		{"nested map sanitized", map[string]any{"m": map[int]int{1: 2}}, map[string]any{"m": map[string]any{"1": int(2)}}},
+		{"slice elements sanitized", []any{map[bool]bool{false: true}}, []any{map[string]any{"false": true}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeDiffValue(tt.in)
+			assert.Equal(t, tt.want, got)
+			_, err := json.Marshal(got)
+			assert.NoError(t, err, "sanitized value must be JSON-encodable")
+		})
+	}
+
+	t.Run("huge string truncated", func(t *testing.T) {
+		got, ok := sanitizeDiffValue(strings.Repeat("a", 10*diffValueMaxString)).(string)
+		require.True(t, ok)
+		assert.LessOrEqual(t, len(got), diffValueMaxString+len("…(truncated)"))
+		assert.True(t, strings.HasSuffix(got, "…(truncated)"))
+	})
+
+	t.Run("truncation never splits a rune", func(t *testing.T) {
+		s := strings.Repeat("é", diffValueMaxString) // 2-byte rune straddles the cap
+		got, ok := sanitizeDiffValue(s).(string)
+		require.True(t, ok)
+		assert.True(t, utf8.ValidString(got), "no split UTF-8 sequence at the cut point")
+	})
+}
+
+// Diff values must be safe to hold and broadcast: json.Marshal of a stored
+// diff can never fail, whatever driver types the lookup returned.
+func TestDiffFields_ValuesAreJSONSafe(t *testing.T) {
+	reg := newTransformRegistry(msgbucket.New(72 * time.Hour))
+	src := map[string]any{"f": "want"}
+	dst := map[string]any{"field": map[bool]string{true: "x"}}
+
+	diffs := diffFields(src, dst, []fieldPair{{SourcePaths: []string{"f"}, DestField: "field"}}, reg)
+	require.Len(t, diffs, 1)
+	_, err := json.Marshal(diffs)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"true": "x"}, diffs[0].Got)
+}
+
+func TestDiffVerbatim_ValuesAreJSONSafe(t *testing.T) {
+	src := map[string]any{"reactions": map[bool]string{true: "x"}}
+	dst := map[string]any{}
+	diffs := diffVerbatim(src, dst, nil)
+	require.Len(t, diffs, 1)
+	_, err := json.Marshal(diffs)
+	require.NoError(t, err)
 }

--- a/tools/cdc-verify/conninfo.go
+++ b/tools/cdc-verify/conninfo.go
@@ -70,7 +70,7 @@ func buildConnInfo(cfg *config, streamName string, cassandraInUse bool) ConnInfo
 
 	info.SourceMongo.URI = redactURI(cfg.SourceMongoURI)
 	info.SourceMongo.DB = cfg.SourceDB
-	info.SourceMongo.ReadPreference = "primaryPreferred"
+	info.SourceMongo.ReadPreference = cfg.SourceReadPreference
 
 	info.TargetMongo.URI = redactURI(cfg.TargetMongoURI)
 	info.TargetMongo.DB = cfg.TargetDB

--- a/tools/cdc-verify/conninfo_test.go
+++ b/tools/cdc-verify/conninfo_test.go
@@ -32,21 +32,22 @@ func TestRedactURI(t *testing.T) {
 
 func TestBuildConnInfo_NeverCarriesSecrets(t *testing.T) {
 	cfg := config{
-		SiteID:              "site1",
-		NATSURL:             "nats://tok3n@nats:4222",
-		CredsFile:           "/etc/creds/verify.creds",
-		SourceMongoURI:      "mongodb://root:sup3rs3cret@src:27017",
-		SourceMongoUsername: "srcuser",
-		SourceMongoPassword: "srcpass",
-		SourceDB:            "rocketchat",
-		TargetMongoURI:      "mongodb://tgt:27017",
-		TargetMongoPassword: "tgtpass",
-		TargetDB:            "chat",
-		CassandraHosts:      "cass1:9042,cass2:9042",
-		CassandraKeyspace:   "chat",
-		CassandraUsername:   "cassuser",
-		CassandraPassword:   "casspass",
-		MappingFile:         "/etc/cdc-verify/mapping.json",
+		SiteID:               "site1",
+		NATSURL:              "nats://tok3n@nats:4222",
+		CredsFile:            "/etc/creds/verify.creds",
+		SourceMongoURI:       "mongodb://root:sup3rs3cret@src:27017",
+		SourceMongoUsername:  "srcuser",
+		SourceMongoPassword:  "srcpass",
+		SourceDB:             "rocketchat",
+		TargetMongoURI:       "mongodb://tgt:27017",
+		TargetMongoPassword:  "tgtpass",
+		TargetDB:             "chat",
+		CassandraHosts:       "cass1:9042,cass2:9042",
+		CassandraKeyspace:    "chat",
+		CassandraUsername:    "cassuser",
+		CassandraPassword:    "casspass",
+		MappingFile:          "/etc/cdc-verify/mapping.json",
+		SourceReadPreference: "secondaryPreferred",
 	}
 	info := buildConnInfo(&cfg, "MIGRATION-OPLOG-site1", true)
 
@@ -55,7 +56,7 @@ func TestBuildConnInfo_NeverCarriesSecrets(t *testing.T) {
 	assert.Equal(t, "nats://***@nats:4222", info.NATS.URL)
 	assert.Equal(t, "mongodb://***@src:27017", info.SourceMongo.URI)
 	assert.Equal(t, "rocketchat", info.SourceMongo.DB)
-	assert.Equal(t, "primaryPreferred", info.SourceMongo.ReadPreference)
+	assert.Equal(t, "secondaryPreferred", info.SourceMongo.ReadPreference)
 	assert.Equal(t, "mongodb://tgt:27017", info.TargetMongo.URI)
 	assert.Equal(t, "chat", info.TargetMongo.DB)
 	assert.True(t, info.Cassandra.InUse)

--- a/tools/cdc-verify/handler.go
+++ b/tools/cdc-verify/handler.go
@@ -65,7 +65,10 @@ func (h *handler) inspect(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	case err != nil:
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		// Generic body only — a store error can carry URIs/hosts the browser
+		// must never see; the detail goes to the server log.
+		slog.Error("inspect failed", "collection", collection, "error", err)
+		http.Error(w, "inspect failed; see server log", http.StatusInternalServerError)
 		return
 	}
 	writeJSON(w, res)
@@ -117,7 +120,10 @@ func (h *handler) events(w http.ResponseWriter, r *http.Request) {
 		case <-keepalive.C:
 			fmt.Fprint(w, ": ping\n\n")
 			flusher.Flush()
-		case frame := <-ch:
+		case frame, ok := <-ch:
+			if !ok {
+				return // hub disconnected us as a slow client; the browser reconnects
+			}
 			fmt.Fprintf(w, "data: %s\n\n", frame)
 			flusher.Flush()
 		}

--- a/tools/cdc-verify/handler_test.go
+++ b/tools/cdc-verify/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -177,11 +178,13 @@ func TestHub_RegisterUnregisterAndDrop(t *testing.T) {
 	require.NoError(t, json.Unmarshal(frame, &ev))
 	assert.Equal(t, "stats", ev.Kind)
 
-	// fill the buffer; further broadcasts must not block
+	// Fill the buffer past capacity: the hub disconnects the unread client
+	// rather than blocking or silently dropping frames.
 	for i := 0; i < 100; i++ {
 		h.broadcastStats(StreamStats{Msgs: uint64(i)})
 	}
-	h.unregister(id)
+	assert.Equal(t, 0, h.clientCount())
+	h.unregister(id) // handler's deferred unregister is a harmless no-op
 	assert.Equal(t, 0, h.clientCount())
 }
 
@@ -190,6 +193,9 @@ type fakeInspector struct{}
 func (fakeInspector) Inspect(_ context.Context, collection, docID string) (InspectResult, error) {
 	if collection == "unmapped_coll" {
 		return InspectResult{}, fmt.Errorf("%w: %q", errUnmapped, collection)
+	}
+	if collection == "boom_coll" {
+		return InspectResult{}, fmt.Errorf("dial mongodb://internal-host-9:27017: refused")
 	}
 	return InspectResult{
 		Collection: collection,
@@ -233,6 +239,20 @@ func TestAPIInspect_UnmappedIs404(t *testing.T) {
 	require.NoError(t, err)
 	resp.Body.Close()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// A store failure returns a generic 500 body: the raw error can carry internal
+// URIs/hosts that must never reach the browser.
+func TestAPIInspect_InternalErrorBodyIsGeneric(t *testing.T) {
+	srv, _ := testServer(t)
+	resp, err := http.Get(srv.URL + "/api/inspect?collection=boom_coll&doc=x")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "internal-host-9")
+	assert.Contains(t, string(body), "inspect failed")
 }
 
 func TestAPIMapping(t *testing.T) {

--- a/tools/cdc-verify/hub.go
+++ b/tools/cdc-verify/hub.go
@@ -57,20 +57,24 @@ func (h *hub) broadcastStats(s StreamStats) { h.broadcast(sseEvent{Kind: "stats"
 //nolint:gocritic // see broadcastStats
 func (h *hub) broadcastResult(r CheckResult) { h.broadcast(sseEvent{Kind: "result", Data: r}) }
 
-// broadcast never blocks: a slow viewer loses intermediate frames, and the
-// next /api/state reload or SSE frame catches it up.
+// broadcast never blocks: a viewer that can't drain its buffer is disconnected
+// (channel closed, handler returns) — the browser's EventSource reconnects and
+// refetches full state on open, so nothing goes silently stale.
 func (h *hub) broadcast(ev sseEvent) {
 	b, err := json.Marshal(ev)
 	if err != nil {
 		slog.Error("marshal sse event", "error", err)
 		return
 	}
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-	for _, ch := range h.clients {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for id, ch := range h.clients {
 		select {
 		case ch <- b:
 		default:
+			slog.Warn("disconnecting slow sse client", "client", id)
+			close(ch)
+			delete(h.clients, id)
 		}
 	}
 }

--- a/tools/cdc-verify/hub_test.go
+++ b/tools/cdc-verify/hub_test.go
@@ -29,12 +29,14 @@ func TestHub_Broadcast_DeliversToClient(t *testing.T) {
 	assert.Contains(t, string(b), `"kind":"stats"`)
 }
 
-// A client whose channel is full must not block the broadcast: the frame is
-// dropped via the select default, exercising broadcast's non-blocking path.
-func TestHub_Broadcast_DropsWhenClientFull(t *testing.T) {
+// A client whose channel is full must not block the broadcast — and must not
+// silently lose frames either: the hub disconnects it (closed channel), so the
+// SSE handler returns and the browser reconnects with a full state refetch.
+func TestHub_Broadcast_DisconnectsSlowClient(t *testing.T) {
 	h := newHub()
+	slow := make(chan []byte) // unbuffered, no reader → always full
 	h.mu.Lock()
-	h.clients["slow"] = make(chan []byte) // unbuffered, no reader → always full
+	h.clients["slow"] = slow
 	h.mu.Unlock()
 
 	done := make(chan struct{})
@@ -43,7 +45,16 @@ func TestHub_Broadcast_DropsWhenClientFull(t *testing.T) {
 		close(done)
 	}()
 	<-done // returns only if broadcast didn't block on the full channel
-	assert.Equal(t, 1, h.clientCount())
+	assert.Equal(t, 0, h.clientCount(), "the slow client is removed")
+	_, open := <-slow
+	assert.False(t, open, "the slow client's channel is closed so its handler returns")
+
+	// A healthy client registered afterwards still receives frames.
+	_, ch := h.register()
+	h.broadcastResult(CheckResult{ID: "r2"})
+	b, open := <-ch
+	require.True(t, open)
+	assert.Contains(t, string(b), `"r2"`)
 }
 
 // A payload that cannot be JSON-marshaled hits the error branch and returns

--- a/tools/cdc-verify/integration_test.go
+++ b/tools/cdc-verify/integration_test.go
@@ -70,7 +70,7 @@ func startPipeline(t *testing.T, mapping *Mapping, srcDB, tgtDB *mongo.Database,
 	results = newResultsStore(200, 1000, nil)
 	v := newVerifier(mapping, newMongoStore(srcDB), newMongoStore(tgtDB), cass, reg, results, cfg)
 
-	w := newWatcher(js, streamCfg.Name, time.Time{}, v)
+	w := newWatcher(js, streamCfg.Name, subject.MigrationOplogWildcard(siteID), time.Time{}, v)
 	runCtx, runCancel := context.WithCancel(context.Background())
 	runErr := make(chan error, 1)
 	go func() { runErr <- w.Run(runCtx) }()

--- a/tools/cdc-verify/lookup_cassandra.go
+++ b/tools/cdc-verify/lookup_cassandra.go
@@ -41,7 +41,9 @@ func buildSelect(table string, key map[string]any, cols []string) (string, []any
 		conds = append(conds, k+" = ?")
 		args = append(args, key[k])
 	}
-	q := fmt.Sprintf("SELECT %s FROM %s WHERE %s", //nolint:gocritic
+	// LIMIT 2: one row proves presence, a second proves ambiguity — reading
+	// further rows of a wide partition buys nothing.
+	q := fmt.Sprintf("SELECT %s FROM %s WHERE %s LIMIT 2", //nolint:gocritic
 		colList, table, strings.Join(conds, " AND "))
 	return q, args, nil
 }

--- a/tools/cdc-verify/lookup_mongo_test.go
+++ b/tools/cdc-verify/lookup_mongo_test.go
@@ -29,12 +29,13 @@ func TestBsonToMap(t *testing.T) {
 func TestBuildSelect(t *testing.T) {
 	q, args, err := buildSelect("messages_by_id", map[string]any{"message_id": "m1"}, []string{"body", "created_at"})
 	require.NoError(t, err)
-	assert.Equal(t, "SELECT body, created_at FROM messages_by_id WHERE message_id = ?", q)
+	// LIMIT 2: one row proves presence, a second proves ambiguity — never more.
+	assert.Equal(t, "SELECT body, created_at FROM messages_by_id WHERE message_id = ? LIMIT 2", q)
 	assert.Equal(t, []any{"m1"}, args)
 
 	q, args, err = buildSelect("t", map[string]any{"b": int64(2), "a": "x"}, []string{"c"})
 	require.NoError(t, err)
-	assert.Equal(t, "SELECT c FROM t WHERE a = ? AND b = ?", q) // sorted key columns
+	assert.Equal(t, "SELECT c FROM t WHERE a = ? AND b = ? LIMIT 2", q) // sorted key columns
 	assert.Equal(t, []any{"x", int64(2)}, args)
 
 	_, _, err = buildSelect("bad;table", map[string]any{"a": 1}, []string{"c"})
@@ -48,6 +49,6 @@ func TestBuildSelect(t *testing.T) {
 func TestBuildSelect_AllColumns(t *testing.T) {
 	q, args, err := buildSelect("messages_by_id", map[string]any{"message_id": "m1"}, nil)
 	require.NoError(t, err)
-	assert.Equal(t, "SELECT * FROM messages_by_id WHERE message_id = ?", q)
+	assert.Equal(t, "SELECT * FROM messages_by_id WHERE message_id = ? LIMIT 2", q)
 	assert.Equal(t, []any{"m1"}, args)
 }

--- a/tools/cdc-verify/main.go
+++ b/tools/cdc-verify/main.go
@@ -241,7 +241,7 @@ func main() {
 
 	shutdown.Wait(context.Background(), 25*time.Second,
 		func(sctx context.Context) error { return srv.Shutdown(sctx) },
-		func(sctx context.Context) error { cancel(); v.Shutdown(sctx); return nil },
+		func(sctx context.Context) error { cancel(); return v.Shutdown(sctx) },
 		func(_ context.Context) error { return nc.Drain() },
 		func(sctx context.Context) error {
 			mongoutil.Disconnect(sctx, srcClient)

--- a/tools/cdc-verify/main.go
+++ b/tools/cdc-verify/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
-	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
 
 	"github.com/hmchangw/chat/pkg/cassutil"
 	"github.com/hmchangw/chat/pkg/mongoutil"
@@ -32,6 +31,9 @@ type config struct {
 	SourceMongoUsername string `env:"SOURCE_MONGO_USERNAME" envDefault:""`
 	SourceMongoPassword string `env:"SOURCE_MONGO_PASSWORD" envDefault:""`
 	SourceDB            string `env:"SOURCE_DB" envDefault:"rocketchat"`
+	// primary by default: a verifier polling a stale secondary would report
+	// convergence lag that isn't there. Relax deliberately per deployment.
+	SourceReadPreference string `env:"SOURCE_READ_PREFERENCE" envDefault:"primary"`
 
 	TargetMongoURI      string `env:"TARGET_MONGO_URI,required"`
 	TargetMongoUsername string `env:"TARGET_MONGO_USERNAME" envDefault:""`
@@ -77,6 +79,12 @@ func (c *config) validate() error {
 	}
 	if c.MessageBucketHours <= 0 {
 		return fmt.Errorf("MESSAGE_BUCKET_HOURS must be positive, got %d", c.MessageBucketHours)
+	}
+	if c.StatsInterval <= 0 {
+		return fmt.Errorf("STATS_INTERVAL must be positive, got %s", c.StatsInterval)
+	}
+	if _, err := mongoutil.ParseReadPreference(c.SourceReadPreference); err != nil {
+		return fmt.Errorf("SOURCE_READ_PREFERENCE: %w", err)
 	}
 	if c.StartAtTime != "" {
 		if _, err := time.Parse(time.RFC3339, c.StartAtTime); err != nil {
@@ -150,8 +158,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	srcReadPref, err := mongoutil.ParseReadPreference(cfg.SourceReadPreference) // validated already
+	if err != nil {
+		slog.Error("parse source read preference", "error", err)
+		os.Exit(1)
+	}
 	srcClient, err := mongoutil.Connect(ctx, cfg.SourceMongoURI, cfg.SourceMongoUsername, cfg.SourceMongoPassword,
-		mongoutil.WithReadPreference(readpref.PrimaryPreferred()))
+		mongoutil.WithReadPreference(srcReadPref))
 	if err != nil {
 		slog.Error("connect source mongo", "error", err)
 		os.Exit(1)

--- a/tools/cdc-verify/main.go
+++ b/tools/cdc-verify/main.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"syscall"
 	"time"
 
 	"github.com/caarlos0/env/v11"
@@ -194,15 +195,18 @@ func main() {
 	if cfg.StartAtTime != "" {
 		startAt, _ = time.Parse(time.RFC3339, cfg.StartAtTime) // validated already
 	}
-	w := newWatcher(js, streamName, startAt, v)
+	filter := subject.MigrationOplogWildcard(cfg.SiteID)
+	w := newWatcher(js, streamName, filter, startAt, v)
 	go func() {
 		if err := w.Run(ctx); err != nil {
-			slog.Error("watcher stopped", "error", err)
-			os.Exit(1) // a dead feed makes the dashboard lie; die loudly
+			// A dead feed makes the dashboard lie; die loudly — but through the
+			// signal path so shutdown.Wait still drains connections cleanly.
+			slog.Error("watcher stopped; shutting down", "error", err)
+			if p, perr := os.FindProcess(os.Getpid()); perr == nil {
+				_ = p.Signal(syscall.SIGTERM)
+			}
 		}
 	}()
-
-	filter := subject.MigrationOplogWildcard(cfg.SiteID)
 	poller := newStatsPoller(streamName,
 		func(ctx context.Context) (*jetstream.StreamInfo, error) {
 			return s.Info(ctx, jetstream.WithSubjectFilter(filter))

--- a/tools/cdc-verify/main_test.go
+++ b/tools/cdc-verify/main_test.go
@@ -36,6 +36,7 @@ func TestConfig_Defaults(t *testing.T) {
 	assert.Equal(t, 1000, cfg.FailedCap)
 	assert.Equal(t, 5*time.Second, cfg.StatsInterval)
 	assert.Equal(t, 72, cfg.MessageBucketHours)
+	assert.Equal(t, "primary", cfg.SourceReadPreference)
 	assert.False(t, cfg.Bootstrap.Enabled)
 	assert.NoError(t, cfg.validate())
 }
@@ -65,9 +66,17 @@ func TestConfig_Validate(t *testing.T) {
 		{"sample percent negative", func(c *config) { c.SamplePercent = -1 }, "SAMPLE_PERCENT"},
 		{"zero poll", func(c *config) { c.VerifyPoll = 0 }, "VERIFY_POLL"},
 		{"timeout below poll", func(c *config) { c.VerifyTimeout = time.Second }, "VERIFY_TIMEOUT"},
+		{"zero max checks", func(c *config) { c.MaxChecks = 0 }, "MAX_CHECKS"},
+		{"negative max checks", func(c *config) { c.MaxChecks = -1 }, "MAX_CHECKS"},
+		{"zero recent cap", func(c *config) { c.RecentCap = 0 }, "RECENT_CAP"},
+		{"zero failed cap", func(c *config) { c.FailedCap = 0 }, "RECENT_CAP and FAILED_CAP"},
+		{"zero stats interval", func(c *config) { c.StatsInterval = 0 }, "STATS_INTERVAL"},
+		{"negative stats interval", func(c *config) { c.StatsInterval = -time.Second }, "STATS_INTERVAL"},
 		{"zero bucket hours", func(c *config) { c.MessageBucketHours = 0 }, "MESSAGE_BUCKET_HOURS"},
 		{"bad start time", func(c *config) { c.StartAtTime = "not-a-time" }, "START_AT_TIME"},
 		{"ok start time", func(c *config) { c.StartAtTime = "2026-08-10T00:00:00Z" }, ""},
+		{"bad read preference", func(c *config) { c.SourceReadPreference = "quorum" }, "SOURCE_READ_PREFERENCE"},
+		{"ok read preference", func(c *config) { c.SourceReadPreference = "secondaryPreferred" }, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tools/cdc-verify/static/index.html
+++ b/tools/cdc-verify/static/index.html
@@ -386,6 +386,7 @@
 
   var TERMINAL = { matched: true, failed: true, skipped: true, superseded: true };
   var FEED_CAP = 100;
+  var FAILURES_CAP = 1000; // client-side retention; matches the server's FAILED_CAP default
   var PAIR_CAP = 50;
 
   // pairKey(source, alias) -> {pair, rows: Map<id, r>, order: [ids newest first]}
@@ -779,6 +780,8 @@
     return tr;
   }
 
+  // Full rebuild — initial state application only; SSE updates go through
+  // upsertFailureRow so one event never re-renders the whole table.
   function renderFailures() {
     var tbody = document.querySelector('#failures tbody');
     tbody.replaceChildren();
@@ -791,6 +794,16 @@
       if (!r) return;
       tbody.appendChild(buildFailureRow(r));
     });
+  }
+
+  function upsertFailureRow(r, isNew) {
+    var tbody = document.querySelector('#failures tbody');
+    var existing = tbody.querySelector('tr[data-id="' + r.id + '"]');
+    if (existing) { existing.replaceWith(buildFailureRow(r)); return; }
+    if (!isNew) return; // update to a row already evicted from the table
+    if (failuresOrder.length === 1) tbody.replaceChildren(); // drop the 'No failures.' placeholder
+    tbody.prepend(buildFailureRow(r));
+    while (tbody.children.length > FAILURES_CAP) tbody.removeChild(tbody.lastChild);
   }
 
   // ── state application ──
@@ -840,11 +853,14 @@
     if (r.state === 'failed') {
       var knownF = failuresMap.has(r.id);
       failuresMap.set(r.id, r);
-      if (!knownF) failuresOrder.unshift(r.id);
-      renderFailures();
+      if (!knownF) {
+        failuresOrder.unshift(r.id);
+        while (failuresOrder.length > FAILURES_CAP) failuresMap.delete(failuresOrder.pop());
+      }
+      upsertFailureRow(r, !knownF);
     } else if (failuresMap.has(r.id)) {
       failuresMap.set(r.id, r);
-      renderFailures();
+      upsertFailureRow(r, false);
     }
 
     tallyIfNew(r);
@@ -1113,16 +1129,26 @@
     openInspect(inspectParam.slice(0, sep), inspectParam.slice(sep + 1));
   }
 
-  fetch('/api/state')
-    .then(function (resp) { return resp.json(); })
-    .then(applyInitialState)
-    .catch(function (err) {
-      var errBanner = document.getElementById('error-banner');
-      errBanner.hidden = false;
-      errBanner.textContent = 'Failed to load state: ' + err;
-    });
+  function loadState() {
+    fetch('/api/state')
+      .then(function (resp) { return resp.json(); })
+      .then(applyInitialState)
+      .catch(function (err) {
+        var errBanner = document.getElementById('error-banner');
+        errBanner.hidden = false;
+        errBanner.textContent = 'Failed to load state: ' + err;
+      });
+  }
+  loadState();
 
   var es = new EventSource('/api/events');
+  var esFirstOpen = true;
+  // A reconnect (network blip, or the hub dropped us as a slow client) means
+  // frames were missed — refetch full state instead of trusting the tail.
+  es.onopen = function () {
+    if (esFirstOpen) { esFirstOpen = false; return; }
+    loadState();
+  };
   es.onmessage = function (msg) {
     var ev;
     try { ev = JSON.parse(msg.data); } catch (e) { return; }

--- a/tools/cdc-verify/verifier.go
+++ b/tools/cdc-verify/verifier.go
@@ -286,6 +286,19 @@ func (v *verifier) Submit(ev CDCEvent) {
 	}()
 }
 
+// SubmitUndecodable records a skipped row for an event whose payload failed to
+// decode; collection/op come from the subject, so the row is still routable.
+func (v *verifier) SubmitUndecodable(collection, op string) {
+	nowMs := v.now().UTC().UnixMilli()
+	row := CheckResult{
+		ID:          idgen.GenerateID(),
+		Collection:  collection,
+		Op:          op,
+		StartedAtMs: nowMs,
+	}
+	v.skip(&row, "decode-error", nowMs)
+}
+
 func (v *verifier) skip(row *CheckResult, reason string, nowMs int64) {
 	row.State = StateSkipped
 	row.SkipReason = reason

--- a/tools/cdc-verify/verifier.go
+++ b/tools/cdc-verify/verifier.go
@@ -247,10 +247,12 @@ func (v *verifier) Submit(ev CDCEvent) {
 	}
 	action := cs.src.Action(ev.Op)
 	if action == OpSkip {
+		v.supersedeKey(pendingKey(ev.Collection, ev.DocID))
 		v.skip(&row, "op-skip", nowMs)
 		return
 	}
 	if v.sampleFn() >= v.cfg.SamplePercent {
+		v.supersedeKey(pendingKey(ev.Collection, ev.DocID))
 		v.skip(&row, "sampled-out", nowMs)
 		return
 	}
@@ -261,7 +263,10 @@ func (v *verifier) Submit(ev CDCEvent) {
 		row.Targets[i] = TargetResult{Alias: alias}
 	}
 
-	ctx, cancel := context.WithCancel(v.baseCtx)
+	// The verify deadline counts from Submit — semaphore wait included — so a
+	// queued check expires instead of parking forever behind MAX_CHECKS.
+	deadline := v.now().Add(v.cfg.Timeout)
+	ctx, cancel := context.WithTimeout(v.baseCtx, v.cfg.Timeout)
 	h := &checkHandle{cancel: cancel}
 	key := pendingKey(ev.Collection, ev.DocID)
 	prev, started := v.beginCheck(key, h)
@@ -277,7 +282,7 @@ func (v *verifier) Submit(ev CDCEvent) {
 
 	go func() {
 		defer v.wg.Done()
-		v.runCheck(ctx, h, key, &row, cs, action)
+		v.runCheck(ctx, h, key, &row, cs, action, deadline)
 	}()
 }
 
@@ -286,6 +291,18 @@ func (v *verifier) skip(row *CheckResult, reason string, nowMs int64) {
 	row.SkipReason = reason
 	row.EndedAtMs = nowMs
 	v.results.Upsert(*row)
+}
+
+// supersedeKey cancels any pending check on key as superseded: a newer event
+// on the doc — even one this verifier skips — makes the old target stale.
+func (v *verifier) supersedeKey(key string) {
+	v.mu.Lock()
+	prev := v.pending[key]
+	v.mu.Unlock()
+	if prev != nil {
+		prev.superseded.Store(true)
+		prev.cancel()
+	}
 }
 
 func pendingKey(collection, docID string) string { return collection + "\x00" + docID }
@@ -324,24 +341,23 @@ type targetState struct {
 // runCheck owns one row from PENDING to a terminal state; its goroutine is the
 // row's sole writer and hands copies to the store.
 func (v *verifier) runCheck(ctx context.Context, h *checkHandle, key string, row *CheckResult,
-	cs *compiledSource, action OpAction,
+	cs *compiledSource, action OpAction, deadline time.Time,
 ) {
 	defer v.unregisterPending(key, h)
 	defer h.cancel() // release the context even on the terminal-state paths
-
-	select {
-	case v.sem <- struct{}{}:
-	case <-ctx.Done():
-		v.finishCancelled(h, row)
-		return
-	}
-	defer func() { <-v.sem }()
 
 	states := make([]targetState, len(cs.aliases))
 	for i, alias := range cs.aliases {
 		states[i] = targetState{alias: alias}
 	}
-	deadline := v.now().Add(v.cfg.Timeout)
+
+	select {
+	case v.sem <- struct{}{}:
+	case <-ctx.Done():
+		v.finishInterrupted(ctx, h, row, states)
+		return
+	}
+	defer func() { <-v.sem }()
 
 	for {
 		row.Attempts++
@@ -349,10 +365,10 @@ func (v *verifier) runCheck(ctx context.Context, h *checkHandle, key string, row
 
 		switch {
 		case allMatched(states):
-			v.finish(row, StateMatched, states)
+			v.finish(h, row, StateMatched, states)
 			return
 		case failNow, !v.now().Before(deadline):
-			v.finish(row, StateFailed, states)
+			v.finish(h, row, StateFailed, states)
 			return
 		}
 
@@ -361,7 +377,7 @@ func (v *verifier) runCheck(ctx context.Context, h *checkHandle, key string, row
 		v.results.Upsert(*row)
 
 		if !v.sleep(ctx, v.cfg.Poll) {
-			v.finishCancelled(h, row)
+			v.finishInterrupted(ctx, h, row, states)
 			return
 		}
 	}
@@ -600,26 +616,36 @@ func snapshotTargets(states []targetState, withDiffs bool) []TargetResult {
 	return out
 }
 
-func (v *verifier) finish(row *CheckResult, state CheckState, states []targetState) {
+// finish publishes the terminal state; a supersede that raced the terminal
+// transition wins, so the row never shows matched/failed for a stale target.
+func (v *verifier) finish(h *checkHandle, row *CheckResult, state CheckState, states []targetState) {
+	if h.superseded.Load() {
+		state = StateSuperseded
+	}
 	row.State = state
 	row.Targets = snapshotTargets(states, state == StateFailed)
 	row.EndedAtMs = v.now().UTC().UnixMilli()
 	v.results.Upsert(*row)
 }
 
-// finishCancelled: a superseded check records that outcome; a shutdown one
-// keeps its last observed state.
-func (v *verifier) finishCancelled(h *checkHandle, row *CheckResult) {
-	if !h.superseded.Load() {
-		return
+// finishInterrupted classifies a ctx-done wakeup: superseded by a newer event,
+// expired at the verify deadline (failed), or shutting down (keep last state).
+func (v *verifier) finishInterrupted(ctx context.Context, h *checkHandle, row *CheckResult, states []targetState) {
+	switch {
+	case h.superseded.Load():
+		v.finish(h, row, StateSuperseded, states)
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+		for i := range states {
+			if !states[i].matched && states[i].cause == "" {
+				states[i].cause = "timeout"
+			}
+		}
+		v.finish(h, row, StateFailed, states)
 	}
-	row.State = StateSuperseded
-	row.EndedAtMs = v.now().UTC().UnixMilli()
-	v.results.Upsert(*row)
 }
 
 // Shutdown cancels every in-flight check and waits for them, bounded by ctx.
-func (v *verifier) Shutdown(ctx context.Context) {
+func (v *verifier) Shutdown(ctx context.Context) error {
 	v.mu.Lock()
 	v.closed = true
 	v.mu.Unlock()
@@ -631,7 +657,9 @@ func (v *verifier) Shutdown(ctx context.Context) {
 	}()
 	select {
 	case <-done:
+		return nil
 	case <-ctx.Done():
+		return fmt.Errorf("verifier shutdown: checks still in flight: %w", ctx.Err())
 	}
 }
 
@@ -717,13 +745,9 @@ func (v *verifier) Inspect(ctx context.Context, collection, docID string) (Inspe
 			continue
 		}
 		it.Key = key
-		// nil columns/fields => whole doc / SELECT * — the inspect view wants everything
-		var doc map[string]any
-		if t.Kind == "cassandra" {
-			doc, err = v.cass.SelectOne(ctx, t.Table, key, nil)
-		} else {
-			doc, err = v.target.FindOne(ctx, t.Collection, key, nil)
-		}
+		// nil columns/fields => whole doc / SELECT * — the inspect view wants
+		// everything; lookupDest also guards the no-cassandra-store case.
+		doc, err := v.lookupDest(ctx, &t, key, nil)
 		switch {
 		case errors.Is(err, errNotFound):
 			it.Error = "not-found"

--- a/tools/cdc-verify/verifier_test.go
+++ b/tools/cdc-verify/verifier_test.go
@@ -523,16 +523,17 @@ func TestVerifier_ShutdownBoundedByContext(t *testing.T) {
 
 	expired, cancel := context.WithCancel(context.Background())
 	cancel()
-	done := make(chan struct{})
-	go func() { v.Shutdown(expired); close(done) }()
+	done := make(chan error, 1)
+	go func() { done <- v.Shutdown(expired) }()
 	select {
-	case <-done:
+	case err := <-done:
+		require.Error(t, err, "an expired context must surface as a shutdown error")
 	case <-time.After(2 * time.Second):
 		t.Fatal("Shutdown did not honour its context deadline")
 	}
 
 	close(release) // let the parked check finish, then drain it
-	v.Shutdown(context.Background())
+	assert.NoError(t, v.Shutdown(context.Background()))
 }
 
 func TestSleepCtx(t *testing.T) {
@@ -846,6 +847,88 @@ func TestCompile_DefensiveSkipAndSort(t *testing.T) {
 	assert.Equal(t, "b", cs.pairs["m"][1].DestField)
 	assert.NotContains(t, cs.pairs, "ghost")
 	assert.Empty(t, cs.pairs["v"]) // verbatim target carries no pairs
+}
+
+// Inspect must share lookupDest's nil-cassandra guard — a mapping with a
+// cassandra target but no wired store degrades to a lookup error, not a panic.
+func TestVerifier_Inspect_NilCassandraStore(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	src := NewMockSourceStore(ctrl)
+	tgt := NewMockTargetStore(ctrl)
+	results := newResultsStore(10, 10, nil)
+	v := newVerifier(verifierMapping(), src, tgt, nil,
+		newTransformRegistry(msgbucket.New(72*time.Hour)), results,
+		verifierConfig{Poll: time.Second, Timeout: time.Minute, MaxChecks: 4, SamplePercent: 100})
+
+	src.EXPECT().FindByID(gomock.Any(), "rocketchat_message", "m1").Return(srcDoc(), nil)
+	tgt.EXPECT().FindOne(gomock.Any(), "rooms", map[string]any{"_id": "r1"}, nil).
+		Return(map[string]any{"_id": "r1"}, nil)
+
+	got, err := v.Inspect(context.Background(), "rocketchat_message", "m1")
+	require.NoError(t, err)
+	require.Len(t, got.Targets, 2) // sorted: byId (cassandra), room (mongo)
+	assert.Contains(t, got.Targets[0].Error, "lookup-error:")
+	assert.Contains(t, got.Targets[0].Error, "no cassandra store")
+	assert.NotNil(t, got.Targets[1].Doc)
+}
+
+// A check queued behind MAX_CHECKS must still terminate at VERIFY_TIMEOUT —
+// the deadline counts from Submit, semaphore wait included.
+func TestVerifier_QueuedCheckFailsAtDeadline(t *testing.T) {
+	v, src, tgt, cass, results := testVerifier(t,
+		verifierConfig{Poll: 10 * time.Millisecond, Timeout: 80 * time.Millisecond, MaxChecks: 1, SamplePercent: 100})
+	src.EXPECT().FindByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(srcDoc(), nil).AnyTimes()
+	tgt.EXPECT().FindOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errNotFound).AnyTimes()
+	cass.EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errNotFound).AnyTimes()
+	// Park the semaphore holder between polls; only its context can free it.
+	v.sleep = func(ctx context.Context, _ time.Duration) bool {
+		<-ctx.Done()
+		return false
+	}
+
+	v.Submit(insertEvent("m1")) // takes the only semaphore slot, parks
+	v.Submit(insertEvent("m2")) // queued behind m1
+
+	waitState(t, results, "m2", StateFailed)
+	waitState(t, results, "m1", StateFailed)
+	v.Shutdown(context.Background())
+}
+
+// A skipped newer event on the same key still supersedes the pending check:
+// the doc changed again, so the old convergence target is stale.
+func TestVerifier_SkipEventSupersedesPending(t *testing.T) {
+	newParked := func(t *testing.T) (*verifier, *resultsStore) {
+		t.Helper()
+		v, src, tgt, cass, results := testVerifier(t,
+			verifierConfig{Poll: time.Second, Timeout: 60 * time.Second, MaxChecks: 4, SamplePercent: 100})
+		src.EXPECT().FindByID(gomock.Any(), gomock.Any(), "m1").Return(srcDoc(), nil).AnyTimes()
+		tgt.EXPECT().FindOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errNotFound).AnyTimes()
+		cass.EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errNotFound).AnyTimes()
+		v.sleep = func(ctx context.Context, _ time.Duration) bool {
+			<-ctx.Done()
+			return false
+		}
+		v.Submit(insertEvent("m1"))
+		waitState(t, results, "m1", StatePending)
+		return v, results
+	}
+
+	t.Run("op-skip supersedes", func(t *testing.T) {
+		v, results := newParked(t)
+		v.Submit(CDCEvent{Collection: "rocketchat_message", Op: "update", DocID: "m1"}) // update -> op-skip
+		waitState(t, results, "m1", StateSuperseded)
+		waitState(t, results, "m1", StateSkipped)
+		v.Shutdown(context.Background())
+	})
+
+	t.Run("sampled-out supersedes", func(t *testing.T) {
+		v, results := newParked(t)
+		v.sampleFn = func() int { return 100 } // >= SamplePercent -> sampled out
+		v.Submit(insertEvent("m1"))
+		waitState(t, results, "m1", StateSuperseded)
+		waitState(t, results, "m1", StateSkipped)
+		v.Shutdown(context.Background())
+	})
 }
 
 func TestNewVerifier_DefaultSampleFn(t *testing.T) {

--- a/tools/cdc-verify/verifier_test.go
+++ b/tools/cdc-verify/verifier_test.go
@@ -931,6 +931,18 @@ func TestVerifier_SkipEventSupersedesPending(t *testing.T) {
 	})
 }
 
+func TestVerifier_SubmitUndecodable(t *testing.T) {
+	v, _, _, _, results := testVerifier(t, verifierConfig{Poll: time.Second, Timeout: time.Second, MaxChecks: 4, SamplePercent: 100})
+	v.SubmitUndecodable("rocketchat_message", "insert")
+	recent := results.Recent()
+	require.Len(t, recent, 1)
+	assert.Equal(t, StateSkipped, recent[0].State)
+	assert.Equal(t, "decode-error", recent[0].SkipReason)
+	assert.Equal(t, "rocketchat_message", recent[0].Collection)
+	assert.Equal(t, "insert", recent[0].Op)
+	assert.Empty(t, recent[0].DocID)
+}
+
 func TestNewVerifier_DefaultSampleFn(t *testing.T) {
 	v := newVerifier(verifierMapping(), nil, nil, nil,
 		newTransformRegistry(msgbucket.New(72*time.Hour)), newResultsStore(1, 1, nil),

--- a/tools/cdc-verify/watcher.go
+++ b/tools/cdc-verify/watcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -12,33 +13,37 @@ import (
 
 type submitter interface {
 	Submit(ev CDCEvent)
+	SubmitUndecodable(collection, op string)
 }
 
 type watcher struct {
 	js      jetstream.JetStream
 	stream  string
+	filter  string // subject filter, chat.migration.oplog.{siteID}.>
 	startAt time.Time
 	sub     submitter
 	live    atomic.Bool
 }
 
-func newWatcher(js jetstream.JetStream, streamName string, startAt time.Time, sub submitter) *watcher {
-	return &watcher{js: js, stream: streamName, startAt: startAt, sub: sub}
+func newWatcher(js jetstream.JetStream, streamName, filter string, startAt time.Time, sub submitter) *watcher {
+	return &watcher{js: js, stream: streamName, filter: filter, startAt: startAt, sub: sub}
 }
 
 // orderedConfig maps the optional replay start onto the deliver policy: zero time = live tail.
-func orderedConfig(startAt time.Time) jetstream.OrderedConsumerConfig {
-	if startAt.IsZero() {
-		return jetstream.OrderedConsumerConfig{DeliverPolicy: jetstream.DeliverNewPolicy}
+func orderedConfig(startAt time.Time, filter string) jetstream.OrderedConsumerConfig {
+	cfg := jetstream.OrderedConsumerConfig{
+		DeliverPolicy:  jetstream.DeliverNewPolicy,
+		FilterSubjects: []string{filter},
 	}
-	return jetstream.OrderedConsumerConfig{
-		DeliverPolicy: jetstream.DeliverByStartTimePolicy,
-		OptStartTime:  &startAt,
+	if !startAt.IsZero() {
+		cfg.DeliverPolicy = jetstream.DeliverByStartTimePolicy
+		cfg.OptStartTime = &startAt
 	}
+	return cfg
 }
 
 func (w *watcher) Run(ctx context.Context) error {
-	cons, err := w.js.OrderedConsumer(ctx, w.stream, orderedConfig(w.startAt))
+	cons, err := w.js.OrderedConsumer(ctx, w.stream, orderedConfig(w.startAt, w.filter))
 	if err != nil {
 		return fmt.Errorf("create ordered consumer on %s: %w", w.stream, err)
 	}
@@ -53,17 +58,44 @@ func (w *watcher) Run(ctx context.Context) error {
 		w.live.Store(false)
 		cc.Stop()
 	}()
-	<-ctx.Done()
-	return nil
+	select {
+	case <-ctx.Done():
+		return nil
+	case <-cc.Closed():
+		// The consume loop died underneath us (connection lost past reconnect,
+		// consumer deleted) — a silent wait here would leave a lying dashboard.
+		return fmt.Errorf("consume loop on %s closed unexpectedly", w.stream)
+	}
 }
 
-func (w *watcher) handleMsg(data []byte, subject string) {
-	ev, err := decodeCDCEvent(data)
-	if err != nil {
+// parseOplogSubject splits chat.migration.oplog.{siteID}.{collection}.{op};
+// the subject is the authoritative routing key, not the payload.
+func parseOplogSubject(subj string) (collection, op string, ok bool) {
+	parts := strings.Split(subj, ".")
+	if len(parts) != 6 || parts[0] != "chat" || parts[1] != "migration" || parts[2] != "oplog" {
+		return "", "", false
+	}
+	return parts[4], parts[5], true
+}
+
+func (w *watcher) handleMsg(data []byte, subj string) {
+	collection, op, ok := parseOplogSubject(subj)
+	if !ok {
 		// Subject only — the payload may hold user content and must not be logged.
-		slog.Warn("skip undecodable oplog event", "subject", subject, "error", err)
+		slog.Warn("skip event on unrecognized subject", "subject", subj)
 		return
 	}
+	ev, err := decodeCDCEvent(data)
+	if err != nil {
+		slog.Warn("undecodable oplog event", "subject", subj, "error", err)
+		w.sub.SubmitUndecodable(collection, op)
+		return
+	}
+	if ev.Collection != collection || ev.Op != op {
+		slog.Warn("oplog payload disagrees with subject; subject wins",
+			"subject", subj, "payload_collection", ev.Collection, "payload_op", ev.Op)
+	}
+	ev.Collection, ev.Op = collection, op
 	w.sub.Submit(ev)
 }
 

--- a/tools/cdc-verify/watcher_test.go
+++ b/tools/cdc-verify/watcher_test.go
@@ -8,29 +8,83 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type captureSubmitter struct{ events []CDCEvent }
+type captureSubmitter struct {
+	events      []CDCEvent
+	undecodable []CDCEvent // collection/op only
+}
 
 func (c *captureSubmitter) Submit(ev CDCEvent) { c.events = append(c.events, ev) }
+func (c *captureSubmitter) SubmitUndecodable(collection, op string) {
+	c.undecodable = append(c.undecodable, CDCEvent{Collection: collection, Op: op})
+}
 
 func TestDeliverPolicy(t *testing.T) {
-	cfg := orderedConfig(time.Time{})
+	filter := "chat.migration.oplog.s1.>"
+	cfg := orderedConfig(time.Time{}, filter)
 	assert.Equal(t, jetstream.DeliverNewPolicy, cfg.DeliverPolicy)
 	assert.Nil(t, cfg.OptStartTime)
+	assert.Equal(t, []string{filter}, cfg.FilterSubjects)
 
 	at := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
-	cfg = orderedConfig(at)
+	cfg = orderedConfig(at, filter)
 	assert.Equal(t, jetstream.DeliverByStartTimePolicy, cfg.DeliverPolicy)
 	assert.Equal(t, at, *cfg.OptStartTime)
+	assert.Equal(t, []string{filter}, cfg.FilterSubjects)
+}
+
+func TestParseOplogSubject(t *testing.T) {
+	tests := []struct {
+		name           string
+		subject        string
+		wantCollection string
+		wantOp         string
+		wantOK         bool
+	}{
+		{"valid", "chat.migration.oplog.site1.rocketchat_message.insert", "rocketchat_message", "insert", true},
+		{"valid delete", "chat.migration.oplog.s1.users.delete", "users", "delete", true},
+		{"wrong prefix", "chat.msg.canonical.site1.created", "", "", false},
+		{"too few tokens", "chat.migration.oplog.site1.coll", "", "", false},
+		{"too many tokens", "chat.migration.oplog.site1.coll.insert.extra", "", "", false},
+		{"empty", "", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collection, op, ok := parseOplogSubject(tt.subject)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantCollection, collection)
+			assert.Equal(t, tt.wantOp, op)
+		})
+	}
 }
 
 func TestHandleMsg(t *testing.T) {
 	sub := &captureSubmitter{}
 	w := &watcher{sub: sub}
 
-	w.handleMsg([]byte(`{"op":"insert","coll":"rocketchat_message","documentKey":{"_id":"m1"}}`), "chat.migration.oplog.s1.rocketchat_message.insert")
+	w.handleMsg([]byte(`{"op":"insert","coll":"rocketchat_message","documentKey":{"_id":"m1"}}`),
+		"chat.migration.oplog.s1.rocketchat_message.insert")
 	assert.Len(t, sub.events, 1)
 	assert.Equal(t, "m1", sub.events[0].DocID)
 
-	w.handleMsg([]byte(`not json`), "chat.migration.oplog.s1.x.insert") // must not panic, not submit
-	assert.Len(t, sub.events, 1)
+	// The subject is authoritative for routing: a payload that disagrees is
+	// still verified, but under the subject's collection/op.
+	w.handleMsg([]byte(`{"op":"delete","coll":"other_coll","documentKey":{"_id":"m2"}}`),
+		"chat.migration.oplog.s1.rocketchat_message.update")
+	assert.Len(t, sub.events, 2)
+	assert.Equal(t, "rocketchat_message", sub.events[1].Collection)
+	assert.Equal(t, "update", sub.events[1].Op)
+	assert.Equal(t, "m2", sub.events[1].DocID)
+
+	// An undecodable payload on a well-formed subject surfaces as a skipped
+	// row instead of vanishing into the log.
+	w.handleMsg([]byte(`not json`), "chat.migration.oplog.s1.rocketchat_room.insert")
+	assert.Len(t, sub.events, 2)
+	assert.Len(t, sub.undecodable, 1)
+	assert.Equal(t, "rocketchat_room", sub.undecodable[0].Collection)
+	assert.Equal(t, "insert", sub.undecodable[0].Op)
+
+	// A malformed subject can't be classified at all — log-only skip.
+	w.handleMsg([]byte(`{}`), "some.other.subject")
+	assert.Len(t, sub.events, 2)
+	assert.Len(t, sub.undecodable, 1)
 }


### PR DESCRIPTION
## Summary

Follow-up to #240 (merged), addressing the real findings from its 58 review threads. Fix-to-thread mapping and the defend/deferred rationale are recorded on #240 ([summary comment](https://github.com/hmchangw/newchat/pull/240#issuecomment-5284693139) + per-thread replies).

## Key Changes

- **Verify deadline is enforced end-to-end** (`verifier.go`): `VERIFY_TIMEOUT` now becomes a context deadline at Submit time — it bounds the semaphore wait (a check queued behind `MAX_CHECKS` expires as `failed` instead of parking forever) and every source/dest/resolver store call. Skipped newer events (`op-skip`, `sampled-out`) supersede a pending check on the same key; a supersede that races the terminal transition wins; `Inspect` shares `lookupDest`'s nil-Cassandra guard (removes a panic path); `Shutdown` reports drain-timeout as an error.
- **Subject-authoritative, failure-visible watcher** (`watcher.go`, `main.go`): the ordered consumer filters on `chat.migration.oplog.{site}.>`; routing collection/op comes from the subject tokens (payload disagreement logged, subject wins); undecodable payloads surface as skipped `decode-error` rows; `Run` observes `ConsumeContext.Closed()`; a watcher failure SIGTERMs the process through `pkg/shutdown` instead of `os.Exit(1)`.
- **Comparison semantics + JSON-safe diffs** (`compare.go`): explicit BSON `null` in the source counts as absent (spec §5.3); all diff values pass a sanitizer — non-string map keys stringified, `[]byte`→string, 2 KB truncation — so result marshaling can never fail and failure retention is byte-bounded per value.
- **Safer store access** (`bootstrap.go`, `lookup_cassandra.go`): stream bootstrap is create-only (an existing stream's config is never rewritten); Cassandra point-selects carry `LIMIT 2` (one row proves presence, a second proves ambiguity).
- **Stricter config** (`main.go`, `conninfo.go`): `STATS_INTERVAL` validated (ticker panic); new `SOURCE_READ_PREFERENCE` env, default `primary` (a stale secondary would report convergence lag that isn't there), surfaced in the connections panel.
- **Resilient dashboard** (`hub.go`, `handler.go`, `static/index.html`): the SSE hub disconnects a slow client instead of silently dropping frames; the UI refetches `/api/state` on every SSE reconnect; the failures table renders incrementally with a client-side cap; `/api/inspect` errors return a generic 500 body (detail server-log only).
- **Docs**: README run example includes the Cassandra env, fences get languages, `SOURCE_READ_PREFERENCE` documented. Plus a one-line goimports fix in `search-service/integration_index_test.go` from repo-wide `make fmt`.

## Testing

- TDD throughout — each fix landed red→green; `make test SERVICE=tools/cdc-verify` race-clean; `golangci-lint` 0 issues (pre-commit hook).
- Integration and demoharness builds vet-clean; integration suite still needs a Docker-capable machine (same pre-merge caveat as #240).

## Notes

- No `chat.user.*` handler surface → no `docs/client-api.md` changes.
- Deferred follow-ups agreed in the #240 threads: `system_schema`-based Cassandra key/type validation, `omittedFields` metadata on whole-row inspect, lossless int64 comparison if a future mapping needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBUJtNXnwoeYSVWwUWrk74

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBUJtNXnwoeYSVWwUWrk74)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable MongoDB source read preferences via `SOURCE_READ_PREFERENCE`, defaulting to `primary`.
  - Added subject-filtered event processing for more accurate collection and operation routing.
  - Added clearer handling and reporting for undecodable events.

- **Bug Fixes**
  - Prevented sensitive error details from appearing in API responses.
  - Improved timeout, shutdown, and pending-check handling.
  - Limited Cassandra lookups to the rows needed for result validation.
  - Automatically disconnects slow event-stream clients.

- **User Interface**
  - Improved failure-list performance and capped stored failures at 1,000.
  - Reloads state after stream reconnections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->