### PR TITLE
chore: bump Go toolchain to 1.25.13 for the August 2026 security release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,11 +58,14 @@ permissions:
   contents: read
 
 env:
-  # Bumped to 1.25.12 for the July 2026 security release (govulncheck
-  # flagged a reachable crypto/tls (GO-2026-5856) stdlib advisory fixed
-  # in 1.25.12; 1.25.11 had covered the June GO-2026-5039/GO-2026-5037
-  # advisories).
-  GO_VERSION: "1.25.12"
+  # Bumped to 1.25.13 for the August 2026 security release (govulncheck
+  # flagged seven reachable stdlib advisories fixed in 1.25.13:
+  # GO-2026-6218 net/url, GO-2026-6091 html/template, GO-2026-6090
+  # crypto/tls, GO-2026-6089 net/http, GO-2026-6088 encoding/xml,
+  # GO-2026-5972 encoding/asn1, GO-2026-5026 x/net/idna via net/http).
+  # 1.25.12 had covered the July GO-2026-5856 crypto/tls advisory;
+  # 1.25.11 the June GO-2026-5039/GO-2026-5037 advisories.
+  GO_VERSION: "1.25.13"
   GOLANGCI_LINT_VERSION: "v2.11.4"
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,7 +324,7 @@ All commands are wrapped in the root Makefile. Always use `make` targets — nev
 - Always provide `envDefault` for non-critical config (port, database name, log level); never default secrets or connection strings — mark them `required`
 
 ### Docker
-- Multi-stage Dockerfiles: `golang:1.25.12-alpine` builder, `alpine:3.21` runtime
+- Multi-stage Dockerfiles: `golang:1.25.13-alpine` builder, `alpine:3.21` runtime
 - Location: `<service>/deploy/Dockerfile`
 - Build context: repo root so `pkg/` and `go.mod` are accessible
 - Docker Compose for local dev only — include only the dependencies the service needs

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ LOADGEN_LOCAL_VALUES := $(LOADGEN_CHART)/values-local.yaml
 # Go 1.25. Tracks the repo-wide Go (go.mod / ci.yml); Go fetches the
 # pinned toolchain on demand.
 GOBIN_DIR             := $(shell go env GOPATH)/bin
-TOOLS_GO_TOOLCHAIN    := go1.25.12
+TOOLS_GO_TOOLCHAIN    := go1.25.13
 GOLANGCI_LINT_VERSION := v2.11.4
 GOSEC_VERSION         := v2.26.1
 GOVULNCHECK_VERSION   := v1.3.0

--- a/admin-service/deploy/Dockerfile
+++ b/admin-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/admin-service/deploy/azure-pipelines.yml
+++ b/admin-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: admin-service
   REGISTRY: '$(containerRegistry)'
 

--- a/auth-service/deploy/Dockerfile
+++ b/auth-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/auth-service/deploy/azure-pipelines.yml
+++ b/auth-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: auth-service
   REGISTRY: '$(containerRegistry)'
 

--- a/bot-message-handler/deploy/Dockerfile
+++ b/bot-message-handler/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/bot-message-worker/deploy/Dockerfile
+++ b/bot-message-worker/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/bot-room-service/deploy/Dockerfile
+++ b/bot-room-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/botplatform-service/deploy/Dockerfile
+++ b/botplatform-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/botplatform-service/deploy/azure-pipelines.yml
+++ b/botplatform-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: botplatform-service
   REGISTRY: '$(containerRegistry)'
 

--- a/broadcast-worker/deploy/bot/Dockerfile
+++ b/broadcast-worker/deploy/bot/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 WORKDIR /app
 

--- a/broadcast-worker/deploy/bot/azure-pipelines.yml
+++ b/broadcast-worker/deploy/bot/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: broadcast-worker
   IMAGE_NAME: bot-broadcast-worker
   REGISTRY: '$(containerRegistry)'

--- a/broadcast-worker/deploy/user/Dockerfile
+++ b/broadcast-worker/deploy/user/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 WORKDIR /app
 

--- a/broadcast-worker/deploy/user/azure-pipelines.yml
+++ b/broadcast-worker/deploy/user/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: broadcast-worker
   REGISTRY: '$(containerRegistry)'
 

--- a/client-update-service/deploy/Dockerfile
+++ b/client-update-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/data-migration/es-index-migrator/deploy/Dockerfile
+++ b/data-migration/es-index-migrator/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 WORKDIR /app
 

--- a/data-migration/es-index-migrator/deploy/azure-pipelines.yml
+++ b/data-migration/es-index-migrator/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_PATH: data-migration/es-index-migrator
   IMAGE_NAME: es-index-migrator
   REGISTRY: '$(containerRegistry)'

--- a/data-migration/oplog-collections-transformer/deploy/Dockerfile
+++ b/data-migration/oplog-collections-transformer/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 WORKDIR /app
 

--- a/data-migration/oplog-collections-transformer/deploy/azure-pipelines.yml
+++ b/data-migration/oplog-collections-transformer/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_PATH: data-migration/oplog-collections-transformer
   IMAGE_NAME: oplog-collections-transformer
   REGISTRY: '$(containerRegistry)'

--- a/data-migration/oplog-connector/deploy/Dockerfile
+++ b/data-migration/oplog-connector/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 WORKDIR /app
 

--- a/data-migration/oplog-connector/deploy/azure-pipelines.yml
+++ b/data-migration/oplog-connector/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_PATH: data-migration/oplog-connector
   IMAGE_NAME: oplog-connector
   REGISTRY: '$(containerRegistry)'

--- a/data-migration/oplog-direct-transfer/deploy/Dockerfile
+++ b/data-migration/oplog-direct-transfer/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 WORKDIR /app
 

--- a/data-migration/oplog-direct-transfer/deploy/azure-pipelines.yml
+++ b/data-migration/oplog-direct-transfer/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_PATH: data-migration/oplog-direct-transfer
   IMAGE_NAME: oplog-direct-transfer
   REGISTRY: '$(containerRegistry)'

--- a/data-migration/oplog-transformer/deploy/Dockerfile
+++ b/data-migration/oplog-transformer/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 WORKDIR /app
 

--- a/data-migration/oplog-transformer/deploy/azure-pipelines.yml
+++ b/data-migration/oplog-transformer/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_PATH: data-migration/oplog-transformer
   IMAGE_NAME: oplog-transformer
   REGISTRY: '$(containerRegistry)'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hmchangw/chat
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/bytedance/sonic v1.15.0

--- a/history-service/deploy/Dockerfile
+++ b/history-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/history-service/deploy/azure-pipelines.yml
+++ b/history-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: history-service
   REGISTRY: '$(containerRegistry)'
 

--- a/hr-sync-worker/deploy/Dockerfile
+++ b/hr-sync-worker/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/hr-sync-worker/deploy/azure-pipelines.yml
+++ b/hr-sync-worker/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: hr-sync-worker
   REGISTRY: '$(containerRegistry)'
 

--- a/inbox-worker/deploy/Dockerfile
+++ b/inbox-worker/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 WORKDIR /app
 

--- a/inbox-worker/deploy/azure-pipelines.yml
+++ b/inbox-worker/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: inbox-worker
   REGISTRY: '$(containerRegistry)'
 

--- a/media-service/deploy/Dockerfile
+++ b/media-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/media-service/deploy/azure-pipelines.yml
+++ b/media-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: media-service
   REGISTRY: '$(containerRegistry)'
 

--- a/message-gatekeeper/deploy/Dockerfile
+++ b/message-gatekeeper/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/message-gatekeeper/deploy/azure-pipelines.yml
+++ b/message-gatekeeper/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: message-gatekeeper
   REGISTRY: '$(containerRegistry)'
 

--- a/message-worker/deploy/Dockerfile
+++ b/message-worker/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/message-worker/deploy/azure-pipelines.yml
+++ b/message-worker/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: message-worker
   REGISTRY: '$(containerRegistry)'
 

--- a/message-worker/deploy/teams/Dockerfile
+++ b/message-worker/deploy/teams/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/message-worker/deploy/teams/azure-pipelines.yml
+++ b/message-worker/deploy/teams/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: message-worker
   IMAGE_NAME: teams-message-worker
   REGISTRY: '$(containerRegistry)'

--- a/notification-worker/deploy/bot/Dockerfile
+++ b/notification-worker/deploy/bot/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 WORKDIR /app
 

--- a/notification-worker/deploy/bot/azure-pipelines.yml
+++ b/notification-worker/deploy/bot/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: notification-worker
   IMAGE_NAME: bot-notification-worker
   REGISTRY: '$(containerRegistry)'

--- a/notification-worker/deploy/user/Dockerfile
+++ b/notification-worker/deploy/user/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 WORKDIR /app
 

--- a/notification-worker/deploy/user/azure-pipelines.yml
+++ b/notification-worker/deploy/user/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: notification-worker
   REGISTRY: '$(containerRegistry)'
 

--- a/outbox-worker/deploy/Dockerfile
+++ b/outbox-worker/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/outbox-worker/deploy/azure-pipelines.yml
+++ b/outbox-worker/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: outbox-worker
   REGISTRY: '$(containerRegistry)'
 

--- a/portal-service/deploy/Dockerfile
+++ b/portal-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/portal-service/deploy/azure-pipelines.yml
+++ b/portal-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: portal-service
   REGISTRY: '$(containerRegistry)'
   # Repo-wide 80% minimum, gated like search-service's pipeline. main.go is

--- a/push-notification-service/deploy/bot/Dockerfile
+++ b/push-notification-service/deploy/bot/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 WORKDIR /app
 

--- a/push-notification-service/deploy/bot/azure-pipelines.yml
+++ b/push-notification-service/deploy/bot/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: push-notification-service
   IMAGE_NAME: bot-push-notification-service
   REGISTRY: '$(containerRegistry)'

--- a/push-notification-service/deploy/user/Dockerfile
+++ b/push-notification-service/deploy/user/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 WORKDIR /app
 

--- a/push-notification-service/deploy/user/azure-pipelines.yml
+++ b/push-notification-service/deploy/user/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: push-notification-service
   REGISTRY: '$(containerRegistry)'
 

--- a/room-service/deploy/Dockerfile
+++ b/room-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/room-service/deploy/azure-pipelines.yml
+++ b/room-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: room-service
   REGISTRY: '$(containerRegistry)'
 

--- a/room-worker/deploy/Dockerfile
+++ b/room-worker/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/room-worker/deploy/azure-pipelines.yml
+++ b/room-worker/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: room-worker
   REGISTRY: '$(containerRegistry)'
 

--- a/room-worker/deploy/teams/Dockerfile
+++ b/room-worker/deploy/teams/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/room-worker/deploy/teams/azure-pipelines.yml
+++ b/room-worker/deploy/teams/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: room-worker
   IMAGE_NAME: teams-room-worker
   REGISTRY: '$(containerRegistry)'

--- a/search-service/deploy/Dockerfile
+++ b/search-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/search-sync-worker/deploy/Dockerfile
+++ b/search-sync-worker/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/search-sync-worker/deploy/azure-pipelines.yml
+++ b/search-sync-worker/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: search-sync-worker
   REGISTRY: '$(containerRegistry)'
 

--- a/tcard-service/deploy/Dockerfile
+++ b/tcard-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/tcard-service/deploy/azure-pipelines.yml
+++ b/tcard-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: tcard-service
   REGISTRY: '$(containerRegistry)'
   # Repo-wide 80% minimum, gated like portal-service's pipeline. main.go

--- a/teams-chat-member-sync/deploy/Dockerfile
+++ b/teams-chat-member-sync/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/teams-chat-member-sync/deploy/azure-pipelines.yml
+++ b/teams-chat-member-sync/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_DIR: teams-chat-member-sync
   IMAGE_NAME: teams-chat-member-sync
   REGISTRY: '$(containerRegistry)'

--- a/teams-chat-sync/deploy/Dockerfile
+++ b/teams-chat-sync/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/teams-chat-sync/deploy/azure-pipelines.yml
+++ b/teams-chat-sync/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_DIR: teams-chat-sync
   IMAGE_NAME: teams-chat-sync
   REGISTRY: '$(containerRegistry)'

--- a/teams-hr-sync/deploy/Dockerfile
+++ b/teams-hr-sync/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/teams-hr-sync/deploy/azure-pipelines.yml
+++ b/teams-hr-sync/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: teams-hr-sync
   REGISTRY: '$(containerRegistry)'
 

--- a/teams-room-creation/deploy/Dockerfile
+++ b/teams-room-creation/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/teams-room-creation/deploy/azure-pipelines.yml
+++ b/teams-room-creation/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_DIR: teams-room-creation
   IMAGE_NAME: teams-room-creation
   REGISTRY: '$(containerRegistry)'

--- a/teams-room-inspector/deploy/Dockerfile
+++ b/teams-room-inspector/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/teams-room-inspector/deploy/azure-pipelines.yml
+++ b/teams-room-inspector/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_DIR: teams-room-inspector
   IMAGE_NAME: teams-room-inspector
   REGISTRY: '$(containerRegistry)'

--- a/teams-room-verify/deploy/Dockerfile
+++ b/teams-room-verify/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/teams-room-verify/deploy/azure-pipelines.yml
+++ b/teams-room-verify/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_DIR: teams-room-verify
   IMAGE_NAME: teams-room-verify
   REGISTRY: '$(containerRegistry)'

--- a/teams-user-sync/deploy/Dockerfile
+++ b/teams-user-sync/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/teams-user-sync/deploy/azure-pipelines.yml
+++ b/teams-user-sync/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: teams-user-sync
   REGISTRY: '$(containerRegistry)'
 

--- a/tools/cdc-verify/deploy/Dockerfile
+++ b/tools/cdc-verify/deploy/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # ── Build stage ───────────────────────────────────────────────────────────────
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 WORKDIR /build
 

--- a/tools/graphmock/deploy/Dockerfile
+++ b/tools/graphmock/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/tools/loadgen/deploy/Dockerfile
+++ b/tools/loadgen/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 WORKDIR /app
 

--- a/tools/loadgen/deploy/k8s/README.md
+++ b/tools/loadgen/deploy/k8s/README.md
@@ -298,7 +298,7 @@ docker run --rm --network chat-local \
   -v "$PWD:/src" -w /src \
   -e MONGO_URI=mongodb://mongodb:27017 \
   -e VALKEY_ADDRS=valkey:6379 \
-  golang:1.25.12 make seed
+  golang:1.25.13 make seed
 ```
 
 Create the cluster, build the exact loadgen image, and load it into kind:

--- a/tools/nats-debug/deploy/Dockerfile
+++ b/tools/nats-debug/deploy/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # ── Build stage ───────────────────────────────────────────────────────────────
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 
 WORKDIR /build
 

--- a/translation-service/deploy/Dockerfile
+++ b/translation-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/translation-service/deploy/azure-pipelines.yml
+++ b/translation-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: translation-service
   REGISTRY: '$(containerRegistry)'
 

--- a/upload-service/deploy/Dockerfile
+++ b/upload-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/user-presence-service/deploy/Dockerfile
+++ b/user-presence-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/user-presence-service/deploy/azure-pipelines.yml
+++ b/user-presence-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: user-presence-service
   REGISTRY: '$(containerRegistry)'
 

--- a/user-presence-service/sync/deploy/Dockerfile
+++ b/user-presence-service/sync/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/user-presence-service/sync/deploy/azure-pipelines.yml
+++ b/user-presence-service/sync/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_DIR: user-presence-service/sync
   IMAGE_NAME: user-presence-sync
   REGISTRY: '$(containerRegistry)'

--- a/user-service/deploy/Dockerfile
+++ b/user-service/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine AS builder
+FROM golang:1.25.13-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/user-service/deploy/azure-pipelines.yml
+++ b/user-service/deploy/azure-pipelines.yml
@@ -18,7 +18,7 @@ pr:
       - pkg/
 
 variables:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.25.13'
   SERVICE_NAME: user-service
   REGISTRY: '$(containerRegistry)'
 


### PR DESCRIPTION
`govulncheck` now flags seven reachable standard-library advisories against Go 1.25.12, all fixed in 1.25.13. Since `sast` is a blocking gate, **every branch fails CI until the toolchain moves** — this is not specific to any one change.

| Advisory | Package | Example reachable path |
|---|---|---|
| GO-2026-6218 | `net/url` | `pkg/msgraph` → `http.Client.Do` → `url.URL.Parse` |
| GO-2026-6091 | `html/template` | `search-service` → `http.Server.Serve` → `template.Template.Execute` |
| GO-2026-6090 | `crypto/tls` | `user-service` → `mongo.IndexView.CreateMany` → `tls.Dial` |
| GO-2026-6089 | `net/http` | `search-service` → `http.Server.Serve` |
| GO-2026-6088 | `encoding/xml` | `client-update-service` → `minio.Client.BucketExists` → `xml.Decoder.Decode` |
| GO-2026-5972 | `encoding/asn1` | `history-service` → `errgroup.Group.Go` → `asn1.Unmarshal` |
| GO-2026-5026 | `x/net/idna` via `net/http` | `pkg/atrest` |

`main` last ran CI at 13:11 UTC and passed; the advisories were published after that, so `main` is affected identically — the green tick on its last run predates the disclosure rather than clearing it.

## What changed

A single version bump, applied to every pin that is still live:

- `go.mod` (`go` directive) and the Makefile's `TOOLS_GO_TOOLCHAIN`
- `.github/workflows/ci.yml` (`GO_VERSION`)
- 51 `Dockerfile` builder images (`golang:1.25.13-alpine`)
- ~40 `deploy/**/azure-pipelines.yml` (`GO_VERSION`)
- `CLAUDE.md`'s stated Docker convention

The builder images and Azure pins move together with CI's, so the toolchain that builds production images is the one `govulncheck` actually checked — bumping CI alone would have turned the gate green while shipping binaries built on the vulnerable toolchain.

Historical design records under `docs/superpowers/` keep the version they were written against, matching how earlier bumps were handled (older plans still read `1.25.11`). The `ci.yml` comment is a running log of why each bump happened; this extends it rather than overwriting the previous entry.

## Verification

Run locally on `go1.25.13`: `go build ./...` clean, `make lint` 0 issues, `make test` 0 failures across all packages. `govulncheck` itself could not be run from this environment (`vuln.go.dev` is blocked by egress policy) — CI is the check that matters for it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YK3aAf3kKfkzmtSYtmjicQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01YK3aAf3kKfkzmtSYtmjicQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain across build, deployment, CI, and development environments from 1.25.12 to 1.25.13.
  * Updated builder images and local development references to use Go 1.25.13.
  * Incorporated the security advisories addressed by the updated Go release into release documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->