### PR TITLE
fix(cassandra): close four startup traps in session config and readiness

### DIFF
--- a/bot-message-worker/config_test.go
+++ b/bot-message-worker/config_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		hours      int
+		wantErrSub string
+	}{
+		{name: "default window", hours: 72},
+		{name: "one hour window", hours: 1},
+		// msgbucket.Sizer divides by the window, so a non-positive value panics
+		// on the first message unless startup rejects it.
+		{name: "zero window", hours: 0, wantErrSub: "MESSAGE_BUCKET_HOURS"},
+		{name: "negative window", hours: -1, wantErrSub: "MESSAGE_BUCKET_HOURS"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config{MessageBucketHours: tt.hours}
+
+			err := validateConfig(&cfg)
+
+			if tt.wantErrSub == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErrSub)
+		})
+	}
+}

--- a/bot-message-worker/main.go
+++ b/bot-message-worker/main.go
@@ -169,6 +169,7 @@ func run() error {
 
 	healthStop, err := health.ServeWithPprof(cfg.HealthAddr, 5*time.Second, cfg.PProfEnabled,
 		natsutil.HealthCheck(nc),
+		cassutil.HealthCheck(cassSess),
 	)
 	if err != nil {
 		return fmt.Errorf("health server: %w", err)

--- a/bot-message-worker/main.go
+++ b/bot-message-worker/main.go
@@ -58,11 +58,24 @@ func main() {
 	}
 }
 
+// validateConfig rejects values that would otherwise fail long after startup:
+// msgbucket.Sizer divides by the window, so a non-positive MESSAGE_BUCKET_HOURS
+// panics on the first message instead of failing the boot.
+func validateConfig(cfg *config) error {
+	if cfg.MessageBucketHours < 1 {
+		return fmt.Errorf("MESSAGE_BUCKET_HOURS must be >= 1, got %d", cfg.MessageBucketHours)
+	}
+	return nil
+}
+
 func run() error {
 	ctx := context.Background()
 	cfg, err := env.ParseAs[config]()
 	if err != nil {
 		return fmt.Errorf("parse config: %w", err)
+	}
+	if err := validateConfig(&cfg); err != nil {
+		return fmt.Errorf("invalid config: %w", err)
 	}
 
 	sdk, obsShutdown, err := obs.Init(ctx)

--- a/history-service/cmd/main.go
+++ b/history-service/cmd/main.go
@@ -229,6 +229,7 @@ func main() {
 
 	healthStop, err := health.ServeWithPprof(cfg.HealthAddr, 5*time.Second, cfg.PProfEnabled,
 		natsutil.HealthCheck(nc),
+		cassutil.HealthCheck(cassSession),
 	)
 	if err != nil {
 		slog.Error("health server failed to start", "error", err)

--- a/history-service/internal/config/config.go
+++ b/history-service/internal/config/config.go
@@ -13,7 +13,7 @@ import (
 
 // CassandraConfig holds Cassandra connection settings (env prefix: CASSANDRA_).
 type CassandraConfig struct {
-	Hosts    string `env:"HOSTS"    required:"true"`
+	Hosts    string `env:"HOSTS,required,notEmpty"`
 	Keyspace string `env:"KEYSPACE" envDefault:"chat"`
 	Username string `env:"USERNAME" envDefault:""`
 	Password string `env:"PASSWORD" envDefault:""`
@@ -23,7 +23,7 @@ type CassandraConfig struct {
 
 // MongoConfig holds MongoDB connection settings (env prefix: MONGO_).
 type MongoConfig struct {
-	URI      string `env:"URI"      required:"true"`
+	URI      string `env:"URI,required,notEmpty"`
 	DB       string `env:"DB"       envDefault:"chat"`
 	Username string `env:"USERNAME" envDefault:""`
 	Password string `env:"PASSWORD" envDefault:""`
@@ -44,7 +44,7 @@ type MongoConfig struct {
 
 // NATSConfig holds NATS connection settings (env prefix: NATS_).
 type NATSConfig struct {
-	URL       string `env:"URL" required:"true"`
+	URL       string `env:"URL,required,notEmpty"`
 	CredsFile string `env:"CREDS_FILE" envDefault:""`
 }
 

--- a/history-service/internal/config/config_test.go
+++ b/history-service/internal/config/config_test.go
@@ -183,6 +183,47 @@ func TestLoad_DefaultsReadPreferenceToSecondaryPreferred(t *testing.T) {
 	assert.Equal(t, "secondaryPreferred", cfg.Mongo.ReadPreference)
 }
 
+// connectionEnv is every env var the service cannot boot without.
+func connectionEnv() map[string]string {
+	return map[string]string{
+		"CASSANDRA_HOSTS": "localhost",
+		"MONGO_URI":       "mongodb://localhost:27017",
+		"NATS_URL":        "nats://localhost:4222",
+	}
+}
+
+// The `required` option must sit inside the env tag; a standalone
+// `required:"true"` struct tag is silently ignored by caarlos0/env, which lets
+// a pod boot with no Cassandra hosts and a NATS URL that falls back to the
+// driver's localhost default.
+func TestLoad_RejectsMissingConnectionEnv(t *testing.T) {
+	for missing := range connectionEnv() {
+		t.Run("unset "+missing, func(t *testing.T) {
+			for key, value := range connectionEnv() {
+				if key != missing {
+					t.Setenv(key, value)
+				}
+			}
+			unsetEnv(t, missing)
+
+			_, err := Load()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), missing)
+		})
+
+		t.Run("empty "+missing, func(t *testing.T) {
+			for key, value := range connectionEnv() {
+				t.Setenv(key, value)
+			}
+			t.Setenv(missing, "")
+
+			_, err := Load()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), missing)
+		})
+	}
+}
+
 // unsetEnv removes key for the duration of the test and restores its prior
 // presence/value on cleanup, so a default-value test can't be perturbed by an
 // externally set variable.

--- a/message-worker/README.md
+++ b/message-worker/README.md
@@ -26,11 +26,11 @@ chat.user.{account}.room.{roomID}.{siteID}.msg.send
 
 | Env Var              | Default                    | Description                     |
 |----------------------|----------------------------|---------------------------------|
-| `NATS_URL`           | `nats://localhost:4222`    | NATS server URL                 |
-| `SITE_ID`            | `site-local`               | Site identifier                 |
-| `MONGO_URI`          | `mongodb://localhost:27017` | MongoDB connection string       |
+| `NATS_URL`           | required                   | NATS server URL                 |
+| `SITE_ID`            | required                   | Site identifier                 |
+| `MONGO_URI`          | required                   | MongoDB connection string       |
 | `MONGO_DB`           | `chat`                     | MongoDB database name           |
-| `CASSANDRA_HOSTS`    | `localhost`                | Comma-separated Cassandra hosts |
+| `CASSANDRA_HOSTS`    | required                   | Comma-separated Cassandra hosts |
 | `CASSANDRA_KEYSPACE` | `chat`                     | Cassandra keyspace              |
 | `MAX_WORKERS`        | `100`                      | Max concurrent message handlers |
 

--- a/message-worker/config_test.go
+++ b/message-worker/config_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/caarlos0/env/v11"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// requiredEnv is the minimum env needed for a successful parse; each test
+// removes exactly one entry to assert startup refuses to guess it.
+func requiredEnv() map[string]string {
+	return map[string]string{
+		"NATS_URL":        "nats://localhost:4222",
+		"SITE_ID":         "site-local",
+		"MONGO_URI":       "mongodb://localhost:27017",
+		"CASSANDRA_HOSTS": "cassandra:9042",
+	}
+}
+
+func TestParseConfig_AcceptsRequiredEnv(t *testing.T) {
+	for key, value := range requiredEnv() {
+		t.Setenv(key, value)
+	}
+
+	cfg, err := env.ParseAs[config]()
+
+	require.NoError(t, err)
+	assert.Equal(t, "cassandra:9042", cfg.CassandraHosts)
+}
+
+// A defaulted connection string turns a missing env var into a connection to
+// the wrong cluster (CLAUDE.md: never default connection strings).
+func TestParseConfig_RejectsMissingCassandraHosts(t *testing.T) {
+	t.Run("unset", func(t *testing.T) {
+		for key, value := range requiredEnv() {
+			if key != "CASSANDRA_HOSTS" {
+				t.Setenv(key, value)
+			}
+		}
+		unsetEnv(t, "CASSANDRA_HOSTS")
+
+		_, err := env.ParseAs[config]()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "CASSANDRA_HOSTS")
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		for key, value := range requiredEnv() {
+			t.Setenv(key, value)
+		}
+		t.Setenv("CASSANDRA_HOSTS", "")
+
+		_, err := env.ParseAs[config]()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "CASSANDRA_HOSTS")
+	})
+}
+
+// unsetEnv removes key for the duration of the test and restores its prior
+// presence/value on cleanup, so an externally set variable can't mask the case
+// under test.
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	prev, had := os.LookupEnv(key)
+	require.NoError(t, os.Unsetenv(key))
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, prev)
+		}
+	})
+}

--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -36,7 +36,7 @@ type config struct {
 	NatsURL            string                  `env:"NATS_URL,required"`
 	NatsCredsFile      string                  `env:"NATS_CREDS_FILE"      envDefault:""`
 	SiteID             string                  `env:"SITE_ID,required"`
-	CassandraHosts     string                  `env:"CASSANDRA_HOSTS"      envDefault:"localhost"`
+	CassandraHosts     string                  `env:"CASSANDRA_HOSTS,required,notEmpty"`
 	CassandraKeyspace  string                  `env:"CASSANDRA_KEYSPACE"   envDefault:"chat"`
 	CassandraUsername  string                  `env:"CASSANDRA_USERNAME"   envDefault:""`
 	CassandraPassword  string                  `env:"CASSANDRA_PASSWORD"   envDefault:""`

--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -245,6 +245,7 @@ func main() {
 
 	healthStop, err := health.ServeWithPprof(cfg.HealthAddr, 5*time.Second, cfg.PProfEnabled,
 		natsutil.HealthCheck(nc),
+		cassutil.HealthCheck(cassSession),
 	)
 	if err != nil {
 		slog.Error("health server failed to start", "error", err)

--- a/pkg/cassutil/health.go
+++ b/pkg/cassutil/health.go
@@ -1,0 +1,38 @@
+package cassutil
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gocql/gocql"
+
+	"github.com/hmchangw/chat/pkg/health"
+)
+
+// healthQuery is served by the coordinator itself, so it exercises the
+// connection pool without touching application data or a user keyspace.
+const healthQuery = `SELECT key FROM system.local`
+
+// prober runs one readiness query. The seam keeps the check's error mapping
+// unit-testable without a live cluster.
+type prober func(ctx context.Context) error
+
+// HealthCheck returns a readiness check for the Cassandra session. Unlike the
+// NATS check this probes a shared datastore, so a cluster-wide outage marks
+// every pod not-ready at once — intended for a hard dependency: readiness (never
+// liveness) sheds traffic without restarting pods. On an instrumented session
+// each probe emits a query span, so keep the readiness interval coarse.
+func HealthCheck(session *gocql.Session) health.Check {
+	return healthCheckFor(func(ctx context.Context) error {
+		return session.Query(healthQuery).WithContext(ctx).Consistency(gocql.One).Exec()
+	})
+}
+
+func healthCheckFor(probe prober) health.Check {
+	return health.Check{Name: "cassandra", Probe: func(ctx context.Context) error {
+		if err := probe(ctx); err != nil {
+			return fmt.Errorf("cassandra probe: %w", err)
+		}
+		return nil
+	}}
+}

--- a/pkg/cassutil/health_test.go
+++ b/pkg/cassutil/health_test.go
@@ -1,0 +1,65 @@
+package cassutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthCheckFor(t *testing.T) {
+	probeErr := errors.New("gocql: no connections available")
+
+	tests := []struct {
+		name    string
+		probe   prober
+		wantErr error
+	}{
+		{
+			name:  "reachable cluster is ready",
+			probe: func(context.Context) error { return nil },
+		},
+		{
+			name:    "unreachable cluster is not ready",
+			probe:   func(context.Context) error { return probeErr },
+			wantErr: probeErr,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			check := healthCheckFor(tt.probe)
+			assert.Equal(t, "cassandra", check.Name)
+
+			err := check.Probe(context.Background())
+
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tt.wantErr, "the driver error must stay unwrappable")
+			assert.Contains(t, err.Error(), "cassandra")
+		})
+	}
+}
+
+// The readiness handler cancels its context on timeout; the probe must receive
+// that context so a hung cluster cannot stall the response.
+func TestHealthCheckFor_PassesContextToProbe(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var got context.Context
+	check := healthCheckFor(func(ctx context.Context) error {
+		got = ctx
+		return ctx.Err()
+	})
+
+	err := check.Probe(ctx)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, ctx, got)
+}

--- a/pkg/cassutil/integration_test.go
+++ b/pkg/cassutil/integration_test.go
@@ -108,6 +108,20 @@ func TestConnect_WithObservability_CassandraMetricsIncludeTable(t *testing.T) {
 		"Cassandra attempt metric must carry the addressed table")
 }
 
+func TestHealthCheck_ReadyWhileSessionIsLive(t *testing.T) {
+	keyspace, _, host := testutil.CassandraKeyspace(t, "cassutil_health")
+
+	session, err := Connect(Config{Hosts: host, Keyspace: keyspace})
+	require.NoError(t, err)
+
+	check := HealthCheck(session)
+	assert.Equal(t, "cassandra", check.Name)
+	require.NoError(t, check.Probe(context.Background()), "a live session must report ready")
+
+	Close(session)
+	assert.Error(t, check.Probe(context.Background()), "a closed session must report not ready")
+}
+
 func metricHasStringAttribute(metrics metricdata.ResourceMetrics, metricName, key, want string) bool {
 	for _, scope := range metrics.ScopeMetrics {
 		for _, m := range scope.Metrics {


### PR DESCRIPTION
Audit of every Cassandra touchpoint (`pkg/cassutil`, the four services and three tools that open sessions, their configs, and the compose/Makefile bring-up) turned up seven startup traps. This PR fixes four of them; the other three are listed at the bottom as follow-ups.

## Changes

### 1. `history-service` — `required:"true"` was an inert struct tag

`internal/config/config.go` marked `CASSANDRA_HOSTS`, `MONGO_URI`, and `NATS_URL` required with a standalone `required:"true"` tag. `caarlos0/env` only reads `required` as an option **inside** the `env` tag, so all three were optional. Verified before the fix: with all three unset, `Load()` returned `err=<nil>, hosts="", mongoURI="", natsURL=""`.

Empty Cassandra hosts at least died loudly (gocql `ErrNoHosts`), but an empty `NATS_URL` did not — nats.go falls back to `nats://127.0.0.1:4222`, so the pod would silently connect to a nonexistent local NATS.

Fixed to `env:"HOSTS,required,notEmpty"` (etc.). `notEmpty` matters: `required` alone accepts an explicitly-set empty string.

### 2. `bot-message-worker` — `MESSAGE_BUCKET_HOURS` was never validated

`msgbucket.Sizer.Of` divides by the window, and the package doc states callers must validate at startup. Every other caller does (`message-worker`, `history-service`, `es-index-migrator`, `cdc-verify`); this one did not, so `MESSAGE_BUCKET_HOURS=0` booted clean and panicked on the **first message**.

Added `validateConfig(*config)`, called immediately after parse.

### 3. No Cassandra readiness probe anywhere

`history-service`, `message-worker`, and `bot-message-worker` registered only `natsutil.HealthCheck(nc)`. A Cassandra outage after startup left them reporting `200 /readyz` while every read failed.

Added `pkg/cassutil.HealthCheck(session)` — a `health.Check` named `cassandra` running `SELECT key FROM system.local` at consistency ONE (coordinator-served, so it exercises the pool without touching application data or a user keyspace) — and wired it into all three services.

**Trade-off worth a reviewer's attention:** unlike the NATS check, this probes a *shared* datastore, so a cluster-wide Cassandra outage marks every pod not-ready at once. That is the intent for a hard dependency — readiness, never liveness, so traffic sheds without restart loops — but it does mean history-service's endpoints empty out during a full outage rather than serving errors. Documented at the function. Each probe also emits a query span on the instrumented sessions, so keep the readiness interval coarse.

### 4. `message-worker` defaulted its connection string

`CASSANDRA_HOSTS envDefault:"localhost"` meant a missing env in production dialled `localhost:9042` and crashlooped on a driver error rather than a config error (CLAUDE.md: never default connection strings). Now `required,notEmpty`. Both composes that run this binary already set it, so no deployment change was needed.

Also corrected `message-worker/README.md`, whose config table listed defaults for four vars that are all actually required — three of those rows (`NATS_URL`, `SITE_ID`, `MONGO_URI`) were already wrong before this change.

## Testing

TDD per CLAUDE.md — every test was confirmed failing before implementation (undefined `validateConfig`/`healthCheckFor`; "An error is expected but got nil" for both config changes).

- `history-service/internal/config`: `TestLoad_RejectsMissingConnectionEnv` — unset **and** empty, for each of the three vars
- `bot-message-worker`: table-driven `TestValidateConfig` — 72 / 1 / 0 / -1
- `pkg/cassutil`: unit tests for the error mapping and context propagation via a `prober` seam (mirroring `natsutil`'s `connStatus`), plus an integration test asserting live-session ready → closed-session not-ready

| Gate | Result |
|---|---|
| `make lint` | pass |
| `make test` (race, all packages) | pass, 0 failures |
| `go vet -tags integration` on touched packages | pass — integration tests compile |
| `make sast` | gosec **pass**; govulncheck and semgrep **could not run** |

Two verification gaps to be aware of:

- **`govulncheck` and `semgrep` did not run.** `vuln.go.dev:443` returns a gateway 403 under the sandbox's network policy, and semgrep isn't installed there. This diff adds no dependencies and doesn't touch `errcode`/`WithCause`, so both should be clean — but that is an expectation, not a result. CI gates on them.
- **The new Cassandra integration test was compiled, not executed** (needs Docker). Worth running `make test-integration SERVICE=pkg/cassutil` before merge.

## Not addressed (follow-ups from the same audit)

- **`MESSAGE_BUCKET_HOURS` compose divergence.** `message-worker`/`teams-message-worker`/`history-service` composes don't set it (image default 72); `bot-message-worker`/`es-index-migrator` hardcode 72; `loadgen` uses `${MESSAGE_BUCKET_HOURS:-72}` and the Makefile passes `--env-file docker-local/.env` to every service. Setting it in `.env` shifts only loadgen's bucket math — silent partition divergence, with no runtime cross-check since the window isn't persisted anywhere.
- **No schema verification at startup.** gocql validates hosts and keyspace, but nothing checks that the tables/UDTs from `docker-local/cassandra/init/*.cql` exist. A service pointed at a fresh-but-empty keyspace comes up healthy and fails per-message.
- **Local bring-up has no Cassandra gate.** `require-deps` inspects only the NATS container; no service compose has `depends_on` or `restart:`, and Cassandra's healthcheck has a 60s `start_period`, so `make up` too soon leaves permanently dead containers. Separately, `cassandra-init` sits in the `init` profile and only `make deps-up` runs it.

Lower-severity items also left alone: `MESSAGE_READ_MAX_BUCKETS` ↔ `MESSAGE_BUCKET_HOURS` coupling is unchecked (122 × 72h ≈ 366d matches the 365d floor by default only), writer/reader `ATREST_ENABLED` asymmetry isn't cross-checked at startup, and `bot-message-worker`'s `CASSANDRA_NUM_CONNS=4` is an unexplained outlier against cassutil's default of 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LZxpmRCGEEYXW3wR76wRmh

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZxpmRCGEEYXW3wR76wRmh)_