### PR TITLE
feat(federation): order remote rooms in the chat list

### DIFF
--- a/bot-room-service/handler.go
+++ b/bot-room-service/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hmchangw/chat/pkg/roomkeysender"
 	"github.com/hmchangw/chat/pkg/roomkeystore"
 	"github.com/hmchangw/chat/pkg/subject"
+	"github.com/hmchangw/chat/pkg/timeutil"
 )
 
 // Rocket.Chat-legacy single-char rooms.t values.
@@ -126,8 +127,19 @@ func (h *handler) handleDMEnsure(c *natsrouter.Context, req BotDMEnsureRequest) 
 		},
 		CreatedByBot: ident.ID,
 	}
-	if err := h.store.InsertRoom(c, room); err != nil && !errors.Is(err, ErrDuplicate) {
-		return nil, fmt.Errorf("insert dm room: %w", err)
+	if err := h.store.InsertRoom(c, room); err != nil {
+		if !errors.Is(err, ErrDuplicate) {
+			return nil, fmt.Errorf("insert dm room: %w", err)
+		}
+		// The DM id is deterministic, so a duplicate means this room already
+		// exists and may carry history — take its position rather than federating
+		// nil and leaving the target unable to order it.
+		if existing, findErr := h.store.FindRoom(c, roomID); findErr == nil {
+			room.LastMsgAt = existing.LastMsgAt
+		} else {
+			slog.WarnContext(c, "read existing dm room failed; federating without an activity position",
+				"room_id", roomID, "error", findErr)
+		}
 	}
 	if _, err := h.store.UpsertSubscription(c, &Subscription{
 		ID: h.newUUIDv7(), RoomID: roomID, UserID: ident.ID, Account: ident.Account,
@@ -147,7 +159,7 @@ func (h *handler) handleDMEnsure(c *natsrouter.Context, req BotDMEnsureRequest) 
 	} else {
 		// DM member_added carries roomType=botDM + RequesterAccount=bot so the target names the subscription after the counterparty; subscription-only, no rooms doc.
 		if err := h.federateMemberAdded(c, roomID, target.ID, target.Account, target.SiteID, createdAt,
-			model.RoomTypeBotDM, "", ident.Account); err != nil {
+			model.RoomTypeBotDM, "", ident.Account, room.LastMsgAt); err != nil {
 			return nil, err
 		}
 	}
@@ -238,7 +250,7 @@ func (h *handler) handleCreate(c *natsrouter.Context, req BotCreateRoomRequest) 
 		// Channel-shape event; RoomName names the subscription at the target.
 		if u.SiteID != "" && u.SiteID != h.siteID {
 			if err := h.federateMemberAdded(c, roomID, u.ID, u.Account, u.SiteID, createdAt,
-				model.RoomTypeChannel, req.Name, ident.Account); err != nil {
+				model.RoomTypeChannel, req.Name, ident.Account, nil); err != nil {
 				return nil, err
 			}
 		}
@@ -309,7 +321,7 @@ func (h *handler) handleAdd(c *natsrouter.Context, req BotMembersBatchRequest) (
 		if u.SiteID != "" && u.SiteID != h.siteID {
 			roomType := roomTypeToModel(room.Type)
 			if err := h.federateMemberAdded(c, roomID, u.ID, u.Account, u.SiteID, created,
-				roomType, room.Name, ident.Account); err != nil {
+				roomType, room.Name, ident.Account, room.LastMsgAt); err != nil {
 				return nil, err
 			}
 		}
@@ -530,8 +542,9 @@ func (h *handler) loadRoomAndAssertOwner(ctx context.Context, roomID string, ide
 
 // federateMemberAdded relays member_added to a remote site's inbox-worker.
 // For DM/botDM the target names the subscription from RequesterAccount; for channels, from RoomName.
+// lastMsgAt is nil for a room with no messages yet (both creation paths).
 func (h *handler) federateMemberAdded(ctx context.Context, roomID, userID, account, destSiteID string, at time.Time,
-	roomType model.RoomType, roomName, requesterAccount string,
+	roomType model.RoomType, roomName, requesterAccount string, lastMsgAt *time.Time,
 ) error {
 	payload, err := json.Marshal(model.MemberAddEvent{
 		Type:             "member_added",
@@ -542,6 +555,7 @@ func (h *handler) federateMemberAdded(ctx context.Context, roomID, userID, accou
 		SiteID:           h.siteID,
 		Accounts:         []string{account},
 		JoinedAt:         at.UnixMilli(),
+		LastMsgAt:        timeutil.TimeToMillis(lastMsgAt),
 		Timestamp:        at.UnixMilli(),
 	})
 	if err != nil {

--- a/bot-room-service/handler_test.go
+++ b/bot-room-service/handler_test.go
@@ -32,6 +32,9 @@ type fakeStore struct {
 
 func (f *fakeStore) InsertRoom(ctx context.Context, r *Room) error { return f.InsertRoomFn(ctx, r) }
 func (f *fakeStore) FindRoom(ctx context.Context, id string) (*Room, error) {
+	if f.FindRoomFn == nil {
+		return nil, ErrNotFound
+	}
 	return f.FindRoomFn(ctx, id)
 }
 func (f *fakeStore) UpsertSubscription(ctx context.Context, s *Subscription) (bool, error) {
@@ -141,6 +144,59 @@ func TestHandleAdd_LocalMemberNoFederation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"bob-id"}, resp.Added.UserIDs)
 	assert.Empty(t, cap.calls, "local member does NOT federate")
+}
+
+func TestHandleDMEnsure_ExistingDMCarriesItsActivityPosition(t *testing.T) {
+	// The DM id is deterministic, so ensure can land on a room that already has
+	// history; federating nil there would leave the target unable to order it.
+	lastMsgAt := time.UnixMilli(1735689500000).UTC()
+	store := &fakeStore{
+		FindUserFn: func(_ context.Context, id string) (*model.User, error) {
+			return &model.User{ID: id, Account: "carol", SiteID: "site-b"}, nil
+		},
+		InsertRoomFn: func(_ context.Context, _ *Room) error { return ErrDuplicate },
+		FindRoomFn: func(_ context.Context, id string) (*Room, error) {
+			return &Room{ID: id, Type: roomTypeDM, SiteID: "site-a", LastMsgAt: &lastMsgAt}, nil
+		},
+		UpsertSubscriptionFn: func(_ context.Context, _ *Subscription) (bool, error) { return true, nil },
+	}
+	cap := &captureOutboxPayload{}
+	h := newHandler(store, "site-a", []string{"site-b"}, cap.publish, testKeyStore, testKeySender)
+
+	_, err := h.handleDMEnsure(withIdentity(t, "", ident()), BotDMEnsureRequest{TargetUserID: "carol-id"})
+	require.NoError(t, err)
+
+	require.Len(t, cap.payloads, 1)
+	var evt model.MemberAddEvent
+	require.NoError(t, json.Unmarshal(cap.payloads[0], &evt))
+	require.NotNil(t, evt.LastMsgAt, "an existing DM's position must ride the federated event")
+	assert.Equal(t, lastMsgAt.UnixMilli(), *evt.LastMsgAt)
+}
+
+func TestHandleAdd_RemoteMemberCarriesActivityPosition(t *testing.T) {
+	// A bot-owned channel can already have history, unlike the creation paths.
+	lastMsgAt := time.UnixMilli(1735689500000).UTC()
+	store := &fakeStore{
+		FindRoomFn: func(_ context.Context, _ string) (*Room, error) {
+			return &Room{ID: "r1", Type: "c", Name: "deployments", CreatedByBot: "bot-1", LastMsgAt: &lastMsgAt}, nil
+		},
+		UpsertSubscriptionFn: func(_ context.Context, _ *Subscription) (bool, error) { return true, nil },
+		FindUserFn: func(_ context.Context, id string) (*model.User, error) {
+			return &model.User{ID: id, Account: "carol", SiteID: "site-b"}, nil
+		},
+	}
+	cap := &captureOutboxPayload{}
+	h := newHandler(store, "site-a", []string{"site-b"}, cap.publish, testKeyStore, testKeySender)
+	c := withIdentity(t, "r1", ident())
+
+	_, err := h.handleAdd(c, BotMembersBatchRequest{UserIDs: []string{"carol-id"}})
+	require.NoError(t, err)
+
+	require.Len(t, cap.payloads, 1, "remote member triggers one member_added federation")
+	var evt model.MemberAddEvent
+	require.NoError(t, json.Unmarshal(cap.payloads[0], &evt))
+	require.NotNil(t, evt.LastMsgAt, "cross-site member_added carries the room's activity position")
+	assert.Equal(t, lastMsgAt.UnixMilli(), *evt.LastMsgAt)
 }
 
 func TestHandleAdd_DuplicateIsNoop(t *testing.T) {

--- a/bot-room-service/store.go
+++ b/bot-room-service/store.go
@@ -54,11 +54,13 @@ type RoomKeyStore interface {
 
 // Room is the projection of a rooms doc bot-room-service reads and writes.
 type Room struct {
-	ID           string
-	Type         string
-	Name         string
-	Topic        string
-	SiteID       string
+	ID     string
+	Type   string
+	Name   string
+	Topic  string
+	SiteID string
+	// LastMsgAt rides cross-site member_added; see model.MemberAddEvent.
+	LastMsgAt    *time.Time
 	CreatedAt    time.Time
 	Owner        *Participant
 	CreatedByBot string

--- a/bot-room-service/store_mongo.go
+++ b/bot-room-service/store_mongo.go
@@ -70,17 +70,18 @@ func (s *storeMongo) InsertRoom(ctx context.Context, room *Room) error {
 
 func (s *storeMongo) FindRoom(ctx context.Context, roomID string) (*Room, error) {
 	var doc struct {
-		ID           string    `bson:"_id"`
-		Type         string    `bson:"t"`
-		Name         string    `bson:"name"`
-		Topic        string    `bson:"topic"`
-		SiteID       string    `bson:"siteId"`
-		CreatedAt    time.Time `bson:"createdAt"`
-		CreatedByBot string    `bson:"createdByBot"`
+		ID           string     `bson:"_id"`
+		Type         string     `bson:"t"`
+		Name         string     `bson:"name"`
+		Topic        string     `bson:"topic"`
+		SiteID       string     `bson:"siteId"`
+		LastMsgAt    *time.Time `bson:"lastMsgAt"`
+		CreatedAt    time.Time  `bson:"createdAt"`
+		CreatedByBot string     `bson:"createdByBot"`
 	}
 	err := s.rooms.FindOne(ctx,
 		bson.M{"_id": roomID},
-		options.FindOne().SetProjection(bson.M{"_id": 1, "t": 1, "name": 1, "topic": 1, "siteId": 1, "createdAt": 1, "createdByBot": 1}),
+		options.FindOne().SetProjection(bson.M{"_id": 1, "t": 1, "name": 1, "topic": 1, "siteId": 1, "lastMsgAt": 1, "createdAt": 1, "createdByBot": 1}),
 	).Decode(&doc)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
@@ -90,7 +91,7 @@ func (s *storeMongo) FindRoom(ctx context.Context, roomID string) (*Room, error)
 	}
 	return &Room{
 		ID: doc.ID, Type: doc.Type, Name: doc.Name, Topic: doc.Topic,
-		SiteID: doc.SiteID, CreatedAt: doc.CreatedAt, CreatedByBot: doc.CreatedByBot,
+		SiteID: doc.SiteID, LastMsgAt: doc.LastMsgAt, CreatedAt: doc.CreatedAt, CreatedByBot: doc.CreatedByBot,
 	}, nil
 }
 

--- a/broadcast-worker/coalescer.go
+++ b/broadcast-worker/coalescer.go
@@ -27,6 +27,13 @@ type bulkRoomLastMsgWriter interface {
 	BulkUpdateRoomLastMessage(ctx context.Context, updates map[string]roomLastMsgUpdate) error
 }
 
+// roomActivityRefresh is one room's coalesced position, handed to the publisher
+// so destination sites can order a room they hold no rooms doc for.
+type roomActivityRefresh struct {
+	roomID string
+	at     time.Time
+}
+
 // coalescingStore wraps an inner Store and intercepts UpdateRoomLastMessage,
 // buffering the latest (msgID, createdAt, mentionAll) per roomID in memory.
 // Flush periodically drains the buffer through a single Mongo BulkWrite.
@@ -44,8 +51,32 @@ type coalescingStore struct {
 	Store
 	bulk bulkRoomLastMsgWriter
 
+	// crossSite reports whether a room has members off this site; nil disables
+	// the refresh entirely. Backed by the room-meta cache, so the flush pays a
+	// cache hit rather than a read — the handler just resolved the same room.
+	crossSite func(ctx context.Context, roomID string) bool
+	// publishActivity emits one refresh; nil disables. Errors are logged, never
+	// propagated — see Flush.
+	publishActivity func(ctx context.Context, r roomActivityRefresh) error
+	// refreshInterval throttles refreshes to at most one per room per interval,
+	// independently of the (much shorter) Mongo flush cadence. Non-positive
+	// publishes on every flush. See refreshRemoteActivity for why this is safe.
+	refreshInterval time.Duration
+	// lastRefreshed is the per-room watermark backing that throttle. Pruned each
+	// flush, so it stays bounded by rooms active within the interval rather than
+	// growing with every room ever seen.
+	lastRefreshed map[string]time.Time
+	now           func() time.Time
+
 	mu      sync.Mutex
 	pending map[string]roomLastMsgUpdate
+}
+
+func (c *coalescingStore) clock() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
 }
 
 func newCoalescingStore(inner Store, bulk bulkRoomLastMsgWriter) *coalescingStore {
@@ -85,7 +116,69 @@ func (c *coalescingStore) Flush(ctx context.Context) error {
 	batch := c.pending
 	c.pending = make(map[string]roomLastMsgUpdate, len(batch))
 	c.mu.Unlock()
+	c.refreshRemoteActivity(ctx, batch)
 	return c.bulk.BulkUpdateRoomLastMessage(ctx, batch)
+}
+
+// refreshRemoteActivity emits at most one activity refresh per cross-site room
+// per refreshInterval. Cost scales with distinct active cross-site rooms per
+// interval, not with message rate — coalescing collapses the window, and the
+// throttle decouples the announce rate from the (much shorter) Mongo flush.
+//
+// The interval can be generous because the consumer cannot see the difference:
+// the subscription list serves ordering from a cache whose own TTL is an order
+// of magnitude longer, so a position a few seconds behind is indistinguishable
+// from a fresh one. The cost of the throttle is that a room going quiet right
+// after a burst keeps the position from its last announce — stale by at most
+// one interval, and repaired by its next message.
+//
+// Failures are logged, not returned: the position is decorative, the next
+// message re-establishes it, and the room batch this rides with is the write
+// that actually matters.
+func (c *coalescingStore) refreshRemoteActivity(ctx context.Context, batch map[string]roomLastMsgUpdate) {
+	if c.publishActivity == nil || c.crossSite == nil {
+		return
+	}
+	now := c.clock()
+	for roomID, u := range batch {
+		if !c.crossSite(ctx, roomID) {
+			continue
+		}
+		if c.throttled(roomID, now) {
+			continue
+		}
+		if err := c.publishActivity(ctx, roomActivityRefresh{roomID: roomID, at: u.at}); err != nil {
+			slog.WarnContext(ctx, "publish room activity refresh failed", "room_id", roomID, "error", err)
+		}
+	}
+	c.pruneWatermarks(now)
+}
+
+// throttled reports whether roomID was announced within refreshInterval, and
+// records the announce when it was not.
+func (c *coalescingStore) throttled(roomID string, now time.Time) bool {
+	if c.refreshInterval <= 0 {
+		return false
+	}
+	if last, ok := c.lastRefreshed[roomID]; ok && now.Sub(last) < c.refreshInterval {
+		return true
+	}
+	if c.lastRefreshed == nil {
+		c.lastRefreshed = make(map[string]time.Time)
+	}
+	c.lastRefreshed[roomID] = now
+	return false
+}
+
+// pruneWatermarks drops rooms that have gone quiet for longer than the
+// interval; their next message re-announces immediately, so keeping them would
+// only leak memory.
+func (c *coalescingStore) pruneWatermarks(now time.Time) {
+	for roomID, last := range c.lastRefreshed {
+		if now.Sub(last) >= c.refreshInterval {
+			delete(c.lastRefreshed, roomID)
+		}
+	}
 }
 
 // Run drives the periodic flush loop until ctx is cancelled. On cancellation a

--- a/broadcast-worker/coalescer_test.go
+++ b/broadcast-worker/coalescer_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -85,6 +86,181 @@ func TestCoalescingStore_Flush_WritesPendingBatch(t *testing.T) {
 	assert.True(t, got["room-a"].lastMentionAllAt.IsZero())
 	assert.Equal(t, "msg-b", got["room-b"].msgID)
 	assert.Equal(t, t0.Add(time.Second), got["room-b"].lastMentionAllAt, "mentionAll=true must record lastMentionAllAt")
+}
+
+// fakeActivityPublisher records the cross-site activity refreshes a flush emits.
+type fakeActivityPublisher struct {
+	mu    sync.Mutex
+	sent  []roomActivityRefresh
+	fails bool
+}
+
+func (f *fakeActivityPublisher) publish(_ context.Context, r roomActivityRefresh) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.fails {
+		return errors.New("publish failed")
+	}
+	f.sent = append(f.sent, r)
+	return nil
+}
+
+func (f *fakeActivityPublisher) all() []roomActivityRefresh {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]roomActivityRefresh(nil), f.sent...)
+}
+
+func TestCoalescingStore_Flush_PublishesActivityForCrossSiteRoomsOnly(t *testing.T) {
+	bulk := &fakeBulkWriter{}
+	pub := &fakeActivityPublisher{}
+	c := newCoalescer(bulk)
+	// r-x is cross-site; r-local is not. Only the former needs a refresh — the
+	// destination is the only site without a rooms doc to order by.
+	c.crossSite = func(_ context.Context, roomID string) bool { return roomID == "r-x" }
+	c.publishActivity = pub.publish
+
+	t0 := time.Unix(1700000000, 0).UTC()
+	require.NoError(t, c.UpdateRoomLastMessage(context.Background(), "r-x", "m1", t0, false))
+	require.NoError(t, c.UpdateRoomLastMessage(context.Background(), "r-local", "m2", t0, false))
+	require.NoError(t, c.Flush(context.Background()))
+
+	sent := pub.all()
+	require.Len(t, sent, 1, "only the cross-site room is refreshed")
+	assert.Equal(t, "r-x", sent[0].roomID)
+	assert.Equal(t, t0, sent[0].at)
+}
+
+func TestCoalescingStore_Flush_CoalescesActivityToOnePublishPerRoom(t *testing.T) {
+	bulk := &fakeBulkWriter{}
+	pub := &fakeActivityPublisher{}
+	c := newCoalescer(bulk)
+	c.crossSite = func(_ context.Context, _ string) bool { return true }
+	c.publishActivity = pub.publish
+
+	t0 := time.Unix(1700000000, 0).UTC()
+	// Many messages in one window collapse to a single refresh carrying the latest
+	// position — this is what keeps the cost independent of message rate.
+	for i := range 50 {
+		require.NoError(t, c.UpdateRoomLastMessage(context.Background(), "r-busy", "m", t0.Add(time.Duration(i)*time.Millisecond), false))
+	}
+	require.NoError(t, c.Flush(context.Background()))
+
+	sent := pub.all()
+	require.Len(t, sent, 1)
+	assert.Equal(t, t0.Add(49*time.Millisecond), sent[0].at, "the latest position wins")
+}
+
+func TestCoalescingStore_Flush_ThrottlesRefreshPerRoom(t *testing.T) {
+	pub := &fakeActivityPublisher{}
+	c := newCoalescer(&fakeBulkWriter{})
+	c.crossSite = func(_ context.Context, _ string) bool { return true }
+	c.publishActivity = pub.publish
+	c.refreshInterval = 5 * time.Second
+	clock := time.Unix(1700000000, 0).UTC()
+	c.now = func() time.Time { return clock }
+
+	msgAt := clock
+	send := func() {
+		require.NoError(t, c.UpdateRoomLastMessage(context.Background(), "r-x", "m", msgAt, false))
+		require.NoError(t, c.Flush(context.Background()))
+	}
+
+	send() // first flush publishes
+	require.Len(t, pub.all(), 1)
+
+	// Nineteen more flush windows, landing at 4.75s — still inside the interval.
+	// The Mongo batch runs every time, but the room must not be re-announced.
+	for range 19 {
+		clock = clock.Add(250 * time.Millisecond)
+		msgAt = clock
+		send()
+	}
+	assert.Len(t, pub.all(), 1, "throttled within the refresh interval")
+
+	clock = clock.Add(5 * time.Second)
+	msgAt = clock
+	send()
+	sent := pub.all()
+	require.Len(t, sent, 2, "publishes again once the interval elapses")
+	assert.Equal(t, msgAt, sent[1].at, "and carries the latest position, not the one it skipped")
+}
+
+func TestCoalescingStore_Flush_ThrottlesRoomsIndependently(t *testing.T) {
+	pub := &fakeActivityPublisher{}
+	c := newCoalescer(&fakeBulkWriter{})
+	c.crossSite = func(_ context.Context, _ string) bool { return true }
+	c.publishActivity = pub.publish
+	c.refreshInterval = 5 * time.Second
+	clock := time.Unix(1700000000, 0).UTC()
+	c.now = func() time.Time { return clock }
+
+	require.NoError(t, c.UpdateRoomLastMessage(context.Background(), "r-a", "m", clock, false))
+	require.NoError(t, c.Flush(context.Background()))
+
+	// r-b is newly active — its own watermark is unset, so it publishes even
+	// though r-a is mid-interval.
+	clock = clock.Add(250 * time.Millisecond)
+	require.NoError(t, c.UpdateRoomLastMessage(context.Background(), "r-a", "m", clock, false))
+	require.NoError(t, c.UpdateRoomLastMessage(context.Background(), "r-b", "m", clock, false))
+	require.NoError(t, c.Flush(context.Background()))
+
+	var rooms []string
+	for _, r := range pub.all() {
+		rooms = append(rooms, r.roomID)
+	}
+	assert.Equal(t, []string{"r-a", "r-b"}, rooms)
+}
+
+func TestCoalescingStore_Flush_ZeroIntervalPublishesEveryFlush(t *testing.T) {
+	pub := &fakeActivityPublisher{}
+	c := newCoalescer(&fakeBulkWriter{})
+	c.crossSite = func(_ context.Context, _ string) bool { return true }
+	c.publishActivity = pub.publish
+	c.refreshInterval = 0 // throttling disabled
+
+	for range 3 {
+		require.NoError(t, c.UpdateRoomLastMessage(context.Background(), "r-x", "m", time.Now(), false))
+		require.NoError(t, c.Flush(context.Background()))
+	}
+	assert.Len(t, pub.all(), 3)
+}
+
+func TestCoalescingStore_Flush_ForgetsWatermarksForQuietRooms(t *testing.T) {
+	// The watermark map must stay bounded by rooms active within the interval,
+	// not grow with every room ever seen.
+	pub := &fakeActivityPublisher{}
+	c := newCoalescer(&fakeBulkWriter{})
+	c.crossSite = func(_ context.Context, _ string) bool { return true }
+	c.publishActivity = pub.publish
+	c.refreshInterval = time.Second
+	clock := time.Unix(1700000000, 0).UTC()
+	c.now = func() time.Time { return clock }
+
+	for i := range 100 {
+		require.NoError(t, c.UpdateRoomLastMessage(context.Background(), fmt.Sprintf("r-%d", i), "m", clock, false))
+	}
+	require.NoError(t, c.Flush(context.Background()))
+	assert.Len(t, c.lastRefreshed, 100)
+
+	// Those rooms go quiet; a later flush prunes their watermarks.
+	clock = clock.Add(10 * time.Second)
+	require.NoError(t, c.UpdateRoomLastMessage(context.Background(), "r-live", "m", clock, false))
+	require.NoError(t, c.Flush(context.Background()))
+	assert.Len(t, c.lastRefreshed, 1, "only the still-active room retains a watermark")
+}
+
+func TestCoalescingStore_Flush_PublishFailureDoesNotFailTheFlush(t *testing.T) {
+	// The refresh is decorative and self-healing on the next message; a publish
+	// failure must not lose the Mongo batch it rides with.
+	bulk := &fakeBulkWriter{}
+	c := newCoalescer(bulk)
+	c.crossSite = func(_ context.Context, _ string) bool { return true }
+	c.publishActivity = (&fakeActivityPublisher{fails: true}).publish
+
+	require.NoError(t, c.UpdateRoomLastMessage(context.Background(), "r-x", "m1", time.Now(), false))
+	require.NoError(t, c.Flush(context.Background()), "flush must still succeed")
+	assert.Equal(t, 1, bulk.callCount(), "and the room batch must still land")
 }
 
 func TestCoalescingStore_Update_LatestMessageWinsPerRoom(t *testing.T) {

--- a/broadcast-worker/deploy/bot/docker-compose.yml
+++ b/broadcast-worker/deploy/bot/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - NATS_URL=${NATS_URL:-nats://nats:4222}
       - NATS_CREDS_FILE=${NATS_CREDS_FILE:-/etc/nats/backend.creds}
       - SITE_ID=${SITE_ID:-site-local}
+      - ALL_SITE_IDS=${ALL_SITE_IDS:-${SITE_ID:-site-local}}
       # Same-site rooms (crossSite:false) are subscribed by the client on
       # chat.local.room.>; publishing global-only would never reach it.
       - ROOM_SUBJECT_MODE=${ROOM_SUBJECT_MODE:-dual}

--- a/broadcast-worker/deploy/user/docker-compose.yml
+++ b/broadcast-worker/deploy/user/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - NATS_URL=${NATS_URL:-nats://nats:4222}
       - NATS_CREDS_FILE=${NATS_CREDS_FILE:-/etc/nats/backend.creds}
       - SITE_ID=${SITE_ID:-site-local}
+      - ALL_SITE_IDS=${ALL_SITE_IDS:-${SITE_ID:-site-local}}
       # Same-site rooms (crossSite:false) are subscribed by the client on
       # chat.local.room.>; publishing global-only would never reach it.
       - ROOM_SUBJECT_MODE=${ROOM_SUBJECT_MODE:-dual}

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -41,31 +41,41 @@ type config struct {
 	NatsURL       string `env:"NATS_URL"                  envDefault:"nats://localhost:4222"`
 	NatsCredsFile string `env:"NATS_CREDS_FILE"           envDefault:""`
 	SiteID        string `env:"SITE_ID"                   envDefault:"default"`
-	MongoURI      string `env:"MONGO_URI"                 envDefault:"mongodb://localhost:27017"`
-	MongoDB       string `env:"MONGO_DB"                  envDefault:"chat"`
-	MongoUsername string `env:"MONGO_USERNAME"            envDefault:""`
-	MongoPassword string `env:"MONGO_PASSWORD"            envDefault:""`
+	// AllSiteIDs is every site in the supercluster, this one included. Peers are
+	// the destinations for the cross-site room-activity refresh; empty (the
+	// single-site default) disables it.
+	AllSiteIDs    []string `env:"ALL_SITE_IDS" envSeparator:","`
+	MongoURI      string   `env:"MONGO_URI"                 envDefault:"mongodb://localhost:27017"`
+	MongoDB       string   `env:"MONGO_DB"                  envDefault:"chat"`
+	MongoUsername string   `env:"MONGO_USERNAME"            envDefault:""`
+	MongoPassword string   `env:"MONGO_PASSWORD"            envDefault:""`
 	// MongoReadPreference: reads only; writes always hit the primary. secondaryPreferred
 	// offloads reads (a just-joined member is recovered via history).
-	MongoReadPreference  string          `env:"MONGO_READ_PREFERENCE"     envDefault:"secondaryPreferred"`
-	MaxWorkers           int             `env:"MAX_WORKERS"               envDefault:"100"`
-	LastMsgFlushInterval time.Duration   `env:"LAST_MSG_FLUSH_INTERVAL"   envDefault:"250ms"`
-	UserCacheSize        int             `env:"USER_CACHE_SIZE"           envDefault:"10000"`
-	UserCacheTTL         time.Duration   `env:"USER_CACHE_TTL"            envDefault:"5m"`
-	RoomMetaCacheSize    int             `env:"ROOM_META_CACHE_SIZE"      envDefault:"10000"`
-	RoomMetaCacheTTL     time.Duration   `env:"ROOM_META_CACHE_TTL"       envDefault:"2m"`
-	RoomKeyGracePeriod   time.Duration   `env:"ROOM_KEY_GRACE_PERIOD"     envDefault:"24h"`
-	RoomKeyCacheTTL      time.Duration   `env:"ROOM_KEY_CACHE_TTL"        envDefault:"10m"`
-	RoomKeyCacheSize     int             `env:"ROOM_KEY_CACHE_SIZE"       envDefault:"50000"`
-	RoomMetaL2TTL        time.Duration   `env:"ROOM_META_L2_TTL"          envDefault:"15m"`
-	ValkeyAddrs          []string        `env:"VALKEY_ADDRS"              envSeparator:","`
-	ValkeyPassword       string          `env:"VALKEY_PASSWORD"           envDefault:""`
-	ValkeyKeyGracePeriod time.Duration   `env:"VALKEY_KEY_GRACE_PERIOD" envDefault:"24h"`
-	HealthAddr           string          `env:"HEALTH_ADDR"              envDefault:":8081"`
-	PProfEnabled         bool            `env:"PPROF_ENABLED" envDefault:"false"`
-	MetricsAddr          string          `env:"METRICS_ADDR"             envDefault:":9090"`
-	Mode                 stream.Pipeline `env:"MODE,required"` // user | bot; drives all stream/subject wiring via pkg/stream.Resolve
-	RoomSubjectMode      string          `env:"ROOM_SUBJECT_MODE"        envDefault:"global"`
+	MongoReadPreference  string        `env:"MONGO_READ_PREFERENCE"     envDefault:"secondaryPreferred"`
+	MaxWorkers           int           `env:"MAX_WORKERS"               envDefault:"100"`
+	LastMsgFlushInterval time.Duration `env:"LAST_MSG_FLUSH_INTERVAL"   envDefault:"250ms"`
+	// RoomActivityRefreshInterval caps how often one room's position is announced
+	// cross-site, independently of the Mongo flush above. Generous by design: the
+	// subscription list serves ordering from a cache with a far longer TTL, so a
+	// position a few seconds behind is indistinguishable from a fresh one.
+	// Non-positive announces on every flush.
+	RoomActivityRefreshInterval time.Duration   `env:"ROOM_ACTIVITY_REFRESH_INTERVAL" envDefault:"5s"`
+	UserCacheSize               int             `env:"USER_CACHE_SIZE"           envDefault:"10000"`
+	UserCacheTTL                time.Duration   `env:"USER_CACHE_TTL"            envDefault:"5m"`
+	RoomMetaCacheSize           int             `env:"ROOM_META_CACHE_SIZE"      envDefault:"10000"`
+	RoomMetaCacheTTL            time.Duration   `env:"ROOM_META_CACHE_TTL"       envDefault:"2m"`
+	RoomKeyGracePeriod          time.Duration   `env:"ROOM_KEY_GRACE_PERIOD"     envDefault:"24h"`
+	RoomKeyCacheTTL             time.Duration   `env:"ROOM_KEY_CACHE_TTL"        envDefault:"10m"`
+	RoomKeyCacheSize            int             `env:"ROOM_KEY_CACHE_SIZE"       envDefault:"50000"`
+	RoomMetaL2TTL               time.Duration   `env:"ROOM_META_L2_TTL"          envDefault:"15m"`
+	ValkeyAddrs                 []string        `env:"VALKEY_ADDRS"              envSeparator:","`
+	ValkeyPassword              string          `env:"VALKEY_PASSWORD"           envDefault:""`
+	ValkeyKeyGracePeriod        time.Duration   `env:"VALKEY_KEY_GRACE_PERIOD" envDefault:"24h"`
+	HealthAddr                  string          `env:"HEALTH_ADDR"              envDefault:":8081"`
+	PProfEnabled                bool            `env:"PPROF_ENABLED" envDefault:"false"`
+	MetricsAddr                 string          `env:"METRICS_ADDR"             envDefault:":9090"`
+	Mode                        stream.Pipeline `env:"MODE,required"` // user | bot; drives all stream/subject wiring via pkg/stream.Resolve
+	RoomSubjectMode             string          `env:"ROOM_SUBJECT_MODE"        envDefault:"global"`
 	// RoomLocalityGrace: post-flip dual-publish window. Must match across all publisher services.
 	RoomLocalityGrace time.Duration           `env:"ROOM_LOCALITY_GRACE"      envDefault:"168h"`
 	Consumer          stream.ConsumerSettings `envPrefix:"CONSUMER_"`
@@ -201,6 +211,20 @@ func main() {
 	// Coalesce per-message rooms.lastMsgAt writes into periodic BulkWrites — the handler still calls
 	// UpdateRoomLastMessage; the coalescing wrapper buffers it and drains via flushCtx/Run.
 	coalescer := newCoalescingStore(cachedStore, store)
+	if peers := remotePeers(cfg.SiteID, cfg.AllSiteIDs); len(peers) > 0 {
+		coalescer.crossSite = crossSiteChecker(cachedStore)
+		coalescer.publishActivity = roomActivityPublisher(publisher, cfg.SiteID, peers)
+		coalescer.refreshInterval = cfg.RoomActivityRefreshInterval
+		coalescer.lastRefreshed = make(map[string]time.Time)
+		slog.Info("cross-site room-activity refresh enabled",
+			"peers", peers, "refresh_interval", cfg.RoomActivityRefreshInterval)
+	} else {
+		// Correct for a single-site deployment, but in a federated one it means
+		// remote chat lists cannot order this site's rooms — say so rather than
+		// leaving a missing ALL_SITE_IDS to look like everything is fine.
+		slog.Warn("cross-site room-activity refresh disabled: no remote peers configured",
+			"site", cfg.SiteID, "all_site_ids", cfg.AllSiteIDs)
+	}
 	flushCtx, flushCancel := context.WithCancel(context.Background())
 	go coalescer.Run(flushCtx, cfg.LastMsgFlushInterval, 5*time.Second)
 	slog.Info("last-msg coalescer enabled", "flush_interval", cfg.LastMsgFlushInterval)

--- a/broadcast-worker/roomactivity.go
+++ b/broadcast-worker/roomactivity.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/roommetacache"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+// metaReader is the slice of Store the cross-site check needs.
+type metaReader interface {
+	GetRoomMeta(ctx context.Context, roomID string) (roommetacache.Meta, error)
+}
+
+// remotePeers returns the sites to refresh: everything in allSiteIDs except this
+// one, blanks dropped and duplicates collapsed. Empty means single-site, which
+// disables the refresh.
+func remotePeers(siteID string, allSiteIDs []string) []string {
+	seen := make(map[string]struct{}, len(allSiteIDs))
+	var peers []string
+	for _, s := range allSiteIDs {
+		if s == "" || s == siteID {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		peers = append(peers, s)
+	}
+	return peers
+}
+
+// crossSiteChecker reports whether a room has members off this site, reading the
+// room-meta cache. An unclassified room (nil CrossSite) counts as cross-site:
+// the cost of guessing wrong is one wasted publish, and the destination ignores
+// rooms it holds no subscription for. A meta read failure skips the refresh —
+// the next message in the room retries it.
+func crossSiteChecker(s metaReader) func(ctx context.Context, roomID string) bool {
+	return func(ctx context.Context, roomID string) bool {
+		meta, err := s.GetRoomMeta(ctx, roomID)
+		if err != nil {
+			return false
+		}
+		return meta.CrossSite == nil || *meta.CrossSite
+	}
+}
+
+// roomActivityPublisher emits one refresh per peer site on the core-NATS
+// activity lane. One room per message keeps the payload bounded by
+// construction — a batched form would grow with the number of active rooms and
+// eventually exceed max_payload, silently losing a whole flush window.
+func roomActivityPublisher(p Publisher, siteID string, peers []string) func(context.Context, roomActivityRefresh) error {
+	return func(ctx context.Context, r roomActivityRefresh) error {
+		evt := model.RoomActivityEvent{
+			RoomID:    r.roomID,
+			SiteID:    siteID,
+			LastMsgAt: r.at.UTC().UnixMilli(),
+			Timestamp: time.Now().UTC().UnixMilli(),
+		}
+		data, err := json.Marshal(evt)
+		if err != nil {
+			return fmt.Errorf("marshal room activity event: %w", err)
+		}
+		// Every peer is attempted: one unreachable site must not deprive the
+		// others of the refresh, since a skipped peer keeps a stale position for
+		// the whole throttle interval.
+		var errs []error
+		for _, peer := range peers {
+			if err := p.Publish(ctx, subject.RoomActivity(peer), data); err != nil {
+				errs = append(errs, fmt.Errorf("publish room activity to %s: %w", peer, err))
+			}
+		}
+		return errors.Join(errs...)
+	}
+}

--- a/broadcast-worker/roomactivity_test.go
+++ b/broadcast-worker/roomactivity_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/roommetacache"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+func TestRemotePeers(t *testing.T) {
+	tests := []struct {
+		name string
+		self string
+		all  []string
+		want []string
+	}{
+		{name: "drops self", self: "a", all: []string{"a", "b", "c"}, want: []string{"b", "c"}},
+		{name: "single site has no peers", self: "a", all: []string{"a"}, want: nil},
+		{name: "unset disables", self: "a", all: nil, want: nil},
+		{name: "tolerates blanks and self repeated", self: "a", all: []string{"a", "", "b", "a"}, want: []string{"b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, remotePeers(tt.self, tt.all))
+		})
+	}
+}
+
+type capturePublisher struct {
+	subjects []string
+	payloads [][]byte
+	err      error
+}
+
+func (c *capturePublisher) Publish(_ context.Context, subj string, data []byte) error {
+	if c.err != nil {
+		return c.err
+	}
+	c.subjects = append(c.subjects, subj)
+	c.payloads = append(c.payloads, data)
+	return nil
+}
+
+func TestRoomActivityPublisher_OneSmallEventPerPeer(t *testing.T) {
+	pub := &capturePublisher{}
+	send := roomActivityPublisher(pub, "site-a", []string{"site-b", "site-c"})
+
+	at := time.UnixMilli(1740000000000).UTC()
+	require.NoError(t, send(context.Background(), roomActivityRefresh{roomID: "r1", at: at}))
+
+	// One message per destination, each carrying a single room — payload size is
+	// bounded by construction, so no batch can outgrow max_payload.
+	require.Len(t, pub.subjects, 2)
+	assert.Equal(t, subject.RoomActivity("site-b"), pub.subjects[0])
+	assert.Equal(t, subject.RoomActivity("site-c"), pub.subjects[1])
+
+	var evt model.RoomActivityEvent
+	require.NoError(t, json.Unmarshal(pub.payloads[0], &evt))
+	assert.Equal(t, "r1", evt.RoomID)
+	assert.Equal(t, "site-a", evt.SiteID, "the room's home site, so the destination can attribute it")
+	assert.Equal(t, at.UnixMilli(), evt.LastMsgAt)
+	assert.NotZero(t, evt.Timestamp)
+}
+
+func TestRoomActivityPublisher_PropagatesPublishError(t *testing.T) {
+	send := roomActivityPublisher(&capturePublisher{err: errors.New("no route")}, "site-a", []string{"site-b"})
+	require.Error(t, send(context.Background(), roomActivityRefresh{roomID: "r1", at: time.Now()}))
+}
+
+type fakeMetaStore struct {
+	meta roommetacache.Meta
+	err  error
+}
+
+func (f *fakeMetaStore) GetRoomMeta(_ context.Context, _ string) (roommetacache.Meta, error) {
+	return f.meta, f.err
+}
+
+func TestCrossSiteChecker(t *testing.T) {
+	yes, no := true, false
+	tests := []struct {
+		name string
+		meta roommetacache.Meta
+		err  error
+		want bool
+	}{
+		{name: "cross-site room refreshes", meta: roommetacache.Meta{CrossSite: &yes}, want: true},
+		{name: "same-site room does not", meta: roommetacache.Meta{CrossSite: &no}, want: false},
+		// Unclassified is fail-safe global elsewhere; here the cost of a wrong
+		// guess is one wasted publish, and the destination ignores rooms it has
+		// no subscription for — so treat it as cross-site.
+		{name: "unclassified refreshes", meta: roommetacache.Meta{CrossSite: nil}, want: true},
+		{name: "meta read failure does not refresh", err: errors.New("down"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			check := crossSiteChecker(&fakeMetaStore{meta: tt.meta, err: tt.err})
+			assert.Equal(t, tt.want, check(context.Background(), "r1"))
+		})
+	}
+}

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -1429,6 +1429,8 @@ For a **botDM**, the human member's event carries `appInfo` instead (the bot's o
 
 The event carries no separate account list — member identities are in `members`. When new members actually join (or a new org is added), a `members_added` system message also flows through the message pipeline and arrives as a `new_message` room event; a pure org→individual upgrade posts no such message.
 
+The cross-site INBOX copy of this event additionally carries `accounts` and `lastMsgAt` (the room's activity position, epoch ms). Both are server-internal federation fields, stripped from the client-facing copy documented above — clients never receive them.
+
 > [!NOTE]
 > **No-op:** when the request changes nothing — every requested account already subscribed, no org member upgraded to an individual membership, and every requested org already present — the requester still gets an `AsyncJobResult` with `status: "ok"` but **no** `subscription.update` / `member_added` events follow. In particular, **re-adding an already-present org is a no-op**. An **org→individual upgrade** (an existing org member added individually) is **not** a no-op: `member_added` fires with that individual in `members`, but no `members_added` system message is posted (no one newly joined).
 

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -916,6 +916,10 @@ The event carries no separate account list — member identities are in `members
 actually join (or a new org is added), a `members_added` system message also flows through the
 message pipeline as a `new_message` room event; a pure org→individual upgrade posts no such message.
 
+The cross-site INBOX copy additionally carries `accounts` and `lastMsgAt` (the room's activity
+position, epoch ms). Both are server-internal federation fields, stripped from the client-facing
+copy documented above — clients never receive them.
+
 > **No-op:** when the request changes nothing — every requested account already subscribed, no org
 > member upgraded to an individual membership, and every requested org already present — no
 > `member_added` event fires. In particular, re-adding an already-present org is a no-op. An

--- a/inbox-worker/handler.go
+++ b/inbox-worker/handler.go
@@ -28,6 +28,20 @@ type InboxStore interface {
 	// stored one is a silent no-op, so out-of-order federated delivery cannot
 	// regress room metadata.
 	UpsertRoom(ctx context.Context, room *model.Room) error
+	// UpsertRemoteRoomActivity records a remote room's ordering position under a
+	// $max guard, so a late or duplicate event is a no-op rather than a
+	// regression — what will let the activity-refresh publisher ride a lossy,
+	// unordered transport. Until it lands member_added is the only writer, so a
+	// dropped write is NOT self-healing.
+	UpsertRemoteRoomActivity(ctx context.Context, roomID, siteID string, lastMsgAt time.Time) error
+	// DeleteRemoteRoomActivity drops a remote room's ordering row once this site
+	// has no member left in it, so the collection does not accumulate rows for
+	// rooms nobody here can see.
+	DeleteRemoteRoomActivity(ctx context.Context, roomID string) error
+	// HasRoomSubscription reports whether this site holds any subscription for
+	// roomID. The activity refresh is broadcast to every peer, so this is what
+	// stops a site accumulating ordering rows for rooms none of its users are in.
+	HasRoomSubscription(ctx context.Context, roomID string) (bool, error)
 	// UpdateSubscriptionRoles applies roles guarded by rolesUpdatedAt (the source
 	// event's publish time): older/duplicate events are silent no-ops. A
 	// genuinely missing subscription still returns an error so the event is
@@ -122,11 +136,56 @@ type Handler struct {
 	// badge is the badge cache; nil (VALKEY_ADDRS unset) disables the
 	// invalidation hooks. Injected post-construction.
 	badge badgeCache
+	// roomSubs memoizes the "is this site a member of this room" check the
+	// activity refresh performs; nil disables it and every refresh reads through.
+	roomSubs *roomSubCache
+}
+
+// HandlerOption configures optional Handler behaviour.
+type HandlerOption func(*Handler)
+
+// WithRoomSubCache memoizes the room-membership check on the activity-refresh
+// lane. A non-positive size or ttl leaves it disabled.
+func WithRoomSubCache(size int, ttl time.Duration) HandlerOption {
+	return func(h *Handler) { h.roomSubs = newRoomSubCache(size, ttl) }
 }
 
 // NewHandler creates a Handler with the given store.
-func NewHandler(store InboxStore) *Handler {
-	return &Handler{store: store}
+func NewHandler(store InboxStore, opts ...HandlerOption) *Handler {
+	h := &Handler{store: store}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
+}
+
+// HandleRoomActivity applies a core-NATS activity refresh for a room owned by
+// another site. Dropped when this site holds no subscription for the room: the
+// refresh is broadcast to every peer, and a row here would otherwise be an
+// orphan nothing deletes.
+//
+// Errors are returned for logging only — there is no ack on this lane, and the
+// $max guard makes the next refresh idempotent, so a loss self-heals on the
+// room's next message.
+func (h *Handler) HandleRoomActivity(ctx context.Context, data []byte) error {
+	var evt model.RoomActivityEvent
+	if err := json.Unmarshal(data, &evt); err != nil {
+		return fmt.Errorf("unmarshal room activity event: %w", err)
+	}
+	if evt.RoomID == "" || evt.LastMsgAt <= 0 {
+		return fmt.Errorf("room activity event missing roomId or lastMsgAt")
+	}
+	subscribed, err := h.hasRoomSubscription(ctx, evt.RoomID)
+	if err != nil {
+		return fmt.Errorf("check room subscription: %w", err)
+	}
+	if !subscribed {
+		return nil
+	}
+	if err := h.store.UpsertRemoteRoomActivity(ctx, evt.RoomID, evt.SiteID, time.UnixMilli(evt.LastMsgAt).UTC()); err != nil {
+		return fmt.Errorf("apply room activity: %w", err)
+	}
+	return nil
 }
 
 // HandleEvent processes a single JetStream message payload.
@@ -254,6 +313,18 @@ func (h *Handler) handleMemberAdded(ctx context.Context, evt *model.InboxEvent) 
 		return fmt.Errorf("member_added references unknown users %v in room %s", missing, event.RoomID)
 	}
 
+	// After the missing-user return, so a room that gained no subscriber leaves
+	// no orphan row (nothing deletes them). Best-effort — the subscriptions above
+	// must not be re-run because an ordering row failed — but not self-healing
+	// yet, so alert on this log line.
+	h.roomSubs.set(event.RoomID, true)
+	if event.LastMsgAt != nil {
+		if err := h.store.UpsertRemoteRoomActivity(ctx, event.RoomID, event.SiteID, time.UnixMilli(*event.LastMsgAt).UTC()); err != nil {
+			slog.WarnContext(ctx, "seed remote room activity failed",
+				"room_id", event.RoomID, "site", event.SiteID, "error", err)
+		}
+	}
+
 	// No SubscriptionUpdateEvent is published here — room-worker already publishes
 	// to the user's subject and the NATS supercluster routes it to the user's
 	// home site.
@@ -298,6 +369,20 @@ func (h *Handler) handleMemberRemoved(ctx context.Context, evt *model.InboxEvent
 	}
 	if err := h.store.DeleteSubscriptionsByAccounts(ctx, memberEvt.RoomID, memberEvt.Accounts); err != nil {
 		return fmt.Errorf("delete subscriptions for room %s: %w", memberEvt.RoomID, err)
+	}
+	// Other members may remain, so re-resolve rather than caching a guess. When
+	// none do, the ordering row has no reader left here — drop it, or it becomes
+	// the orphan the seed path is careful not to create. Best-effort: a stale row
+	// only costs space, and re-adding a member re-seeds it.
+	h.roomSubs.invalidate(memberEvt.RoomID)
+	if stillMember, err := h.hasRoomSubscription(ctx, memberEvt.RoomID); err != nil {
+		slog.WarnContext(ctx, "check remaining members failed; leaving ordering row",
+			"room_id", memberEvt.RoomID, "error", err)
+	} else if !stillMember {
+		if err := h.store.DeleteRemoteRoomActivity(ctx, memberEvt.RoomID); err != nil {
+			slog.WarnContext(ctx, "delete remote room activity failed",
+				"room_id", memberEvt.RoomID, "error", err)
+		}
 	}
 	// Scrub the removed accounts' thread read-state on this site too (#308).
 	if err := h.store.DeleteThreadSubscriptions(ctx, memberEvt.RoomID, memberEvt.Accounts); err != nil {

--- a/inbox-worker/handler_test.go
+++ b/inbox-worker/handler_test.go
@@ -121,12 +121,62 @@ type stubInboxStore struct {
 	chatlistUpdates       []userChatlistUpdate
 	sectionMoves          []sectionMove
 	permissionsApplies    []permissionsApply
+	remoteRoomActivity    []remoteRoomActivity
+	remoteRoomActivityErr error
+	roomSubscribed        map[string]bool
+	deletedRemoteRooms    []string
+	hasRoomSubErr         error
 }
 
 type permissionsApply struct {
 	permission model.PermissionKey
 	accounts   []string
 	state      model.PermissionState
+}
+
+type remoteRoomActivity struct {
+	roomID    string
+	siteID    string
+	lastMsgAt time.Time
+}
+
+func (s *stubInboxStore) DeleteRemoteRoomActivity(_ context.Context, roomID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.roomSubscribed, roomID)
+	kept := s.remoteRoomActivity[:0]
+	for _, r := range s.remoteRoomActivity {
+		if r.roomID != roomID {
+			kept = append(kept, r)
+		}
+	}
+	s.remoteRoomActivity = kept
+	s.deletedRemoteRooms = append(s.deletedRemoteRooms, roomID)
+	return nil
+}
+
+func (s *stubInboxStore) HasRoomSubscription(_ context.Context, roomID string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.hasRoomSubErr != nil {
+		return false, s.hasRoomSubErr
+	}
+	for i := range s.bulkSubscriptions {
+		if s.bulkSubscriptions[i].RoomID == roomID {
+			return true, nil
+		}
+	}
+	return s.roomSubscribed[roomID], nil
+}
+
+func (s *stubInboxStore) UpsertRemoteRoomActivity(_ context.Context, roomID, siteID string, lastMsgAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.remoteRoomActivityErr != nil {
+		return s.remoteRoomActivityErr
+	}
+	s.remoteRoomActivity = append(s.remoteRoomActivity, remoteRoomActivity{roomID: roomID, siteID: siteID, lastMsgAt: lastMsgAt})
+	return nil
 }
 
 type userChatlistUpdate struct {
@@ -1938,6 +1988,107 @@ func TestHandleMemberAdded_BulkCreate_NonDuplicateError_ReturnsError(t *testing.
 	err := h.HandleEvent(context.Background(), evtData)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "bulk create subscriptions")
+}
+
+// memberAddedEventData builds the wire bytes for a cross-site member_added on
+// room r1, owned by site-A. lastMsgAt nil = a room that has never had a message.
+func memberAddedEventData(t *testing.T, lastMsgAt *int64) []byte {
+	t.Helper()
+	change := model.MemberAddEvent{
+		Type: "member_added", RoomID: "r1", RoomType: model.RoomTypeChannel,
+		Accounts: []string{"bob"}, SiteID: "site-A", JoinedAt: 1, Timestamp: 1,
+		LastMsgAt: lastMsgAt,
+	}
+	changeData, err := json.Marshal(change)
+	require.NoError(t, err)
+	evtData, err := json.Marshal(model.InboxEvent{Type: "member_added", SiteID: "site-A", DestSiteID: "site-B", Payload: changeData})
+	require.NoError(t, err)
+	return evtData
+}
+
+func TestHandleRoomActivity(t *testing.T) {
+	at := int64(1740000000000)
+	payload := func(roomID string, lastMsgAt int64) []byte {
+		b, err := json.Marshal(model.RoomActivityEvent{RoomID: roomID, SiteID: "site-A", LastMsgAt: lastMsgAt, Timestamp: at})
+		require.NoError(t, err)
+		return b
+	}
+
+	t.Run("applies when this site holds a subscription", func(t *testing.T) {
+		store := &stubInboxStore{roomSubscribed: map[string]bool{"r1": true}}
+		require.NoError(t, NewHandler(store).HandleRoomActivity(context.Background(), payload("r1", at)))
+
+		require.Len(t, store.remoteRoomActivity, 1)
+		assert.Equal(t, "r1", store.remoteRoomActivity[0].roomID)
+		assert.Equal(t, "site-A", store.remoteRoomActivity[0].siteID)
+		assert.Equal(t, time.UnixMilli(at).UTC(), store.remoteRoomActivity[0].lastMsgAt)
+	})
+
+	t.Run("drops rooms this site has no member in", func(t *testing.T) {
+		// The refresh is broadcast to every peer, so without this guard each site
+		// would accrue a row for every cross-site room in the deployment.
+		store := &stubInboxStore{}
+		require.NoError(t, NewHandler(store).HandleRoomActivity(context.Background(), payload("r-elsewhere", at)))
+		assert.Empty(t, store.remoteRoomActivity)
+	})
+
+	t.Run("rejects a malformed payload", func(t *testing.T) {
+		store := &stubInboxStore{roomSubscribed: map[string]bool{"r1": true}}
+		require.Error(t, NewHandler(store).HandleRoomActivity(context.Background(), []byte("{")))
+		assert.Empty(t, store.remoteRoomActivity)
+	})
+
+	t.Run("rejects an event with no position to apply", func(t *testing.T) {
+		store := &stubInboxStore{roomSubscribed: map[string]bool{"r1": true}}
+		require.Error(t, NewHandler(store).HandleRoomActivity(context.Background(), payload("r1", 0)))
+		assert.Empty(t, store.remoteRoomActivity)
+	})
+}
+
+func TestHandleMemberAdded_SeedsRemoteRoomActivity(t *testing.T) {
+	at := int64(1740000000000)
+	bob := []model.User{{ID: "u_bob", Account: "bob", SiteID: "site-B"}}
+
+	tests := []struct {
+		name     string
+		users    []model.User
+		lastMsg  *int64
+		seedErr  error
+		wantErr  bool
+		wantRows int
+		wantSubs int
+	}{
+		{name: "seeds the ordering row", users: bob, lastMsg: &at, wantRows: 1, wantSubs: 1},
+		{name: "no activity yet, nothing to seed", users: bob, lastMsg: nil, wantRows: 0, wantSubs: 1},
+		// Seeding before the missing-user return would leave a row for a room
+		// this site has no subscriber for, and nothing ever deletes it.
+		{name: "unknown user leaves no orphan row", users: nil, lastMsg: &at, wantErr: true, wantRows: 0, wantSubs: 0},
+		// The subscription is the correctness-critical write, so a failed
+		// ordering row must not Nak the event and re-run subscription creation.
+		{name: "seed failure does not fail the event", users: bob, lastMsg: &at, seedErr: fmt.Errorf("connection refused"), wantRows: 0, wantSubs: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &stubInboxStore{users: tt.users, remoteRoomActivityErr: tt.seedErr}
+			h := NewHandler(store)
+
+			err := h.HandleEvent(context.Background(), memberAddedEventData(t, tt.lastMsg))
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Len(t, store.remoteRoomActivity, tt.wantRows)
+			assert.Len(t, store.bulkSubscriptions, tt.wantSubs)
+			if tt.wantRows > 0 {
+				assert.Equal(t, "r1", store.remoteRoomActivity[0].roomID)
+				assert.Equal(t, "site-A", store.remoteRoomActivity[0].siteID, "the room's home site, not the destination")
+				assert.Equal(t, time.UnixMilli(at).UTC(), store.remoteRoomActivity[0].lastMsgAt)
+			}
+		})
+	}
 }
 
 func TestHandler_HandleEvent_ThreadRead_Happy(t *testing.T) {

--- a/inbox-worker/integration_test.go
+++ b/inbox-worker/integration_test.go
@@ -26,15 +26,45 @@ func setupMongo(t *testing.T) *mongo.Database {
 	return testutil.MongoDB(t, "inbox_worker_test")
 }
 
+// TestUpsertRemoteRoomActivity_MaxGuard_Integration pins the $max guard: the
+// write is idempotent and order-independent, so a duplicate or late event can
+// only ever advance lastMsgAt.
+func TestUpsertRemoteRoomActivity_MaxGuard_Integration(t *testing.T) {
+	db := setupMongo(t)
+	ctx := context.Background()
+	store := newGuardStore(db)
+
+	readBack := func(t *testing.T) model.RemoteRoom {
+		t.Helper()
+		var row model.RemoteRoom
+		require.NoError(t, db.Collection(remoteRoomsCollection).
+			FindOne(ctx, bson.M{"_id": "r-remote"}).Decode(&row))
+		row.LastMsgAt = row.LastMsgAt.UTC()
+		return row
+	}
+
+	base := time.UnixMilli(1740000000000).UTC()
+
+	// First touch upserts the row complete, including the immutable identity.
+	require.NoError(t, store.UpsertRemoteRoomActivity(ctx, "r-remote", "site-A", base))
+	assert.Equal(t, model.RemoteRoom{ID: "r-remote", SiteID: "site-A", LastMsgAt: base}, readBack(t))
+
+	// A newer event advances the position.
+	newer := base.Add(time.Minute)
+	require.NoError(t, store.UpsertRemoteRoomActivity(ctx, "r-remote", "site-A", newer))
+	assert.Equal(t, newer, readBack(t).LastMsgAt)
+
+	// A late or duplicate event carrying an older position is a silent no-op —
+	// this is what will make lossy, unordered delivery safe.
+	require.NoError(t, store.UpsertRemoteRoomActivity(ctx, "r-remote", "site-A", base))
+	assert.Equal(t, newer, readBack(t).LastMsgAt, "an older event must not regress the stored position")
+}
+
 func TestInboxWorker_MemberAdded_Integration(t *testing.T) {
 	db := setupMongo(t)
 	ctx := context.Background()
 
-	store := &mongoInboxStore{
-		subCol:  db.Collection("subscriptions"),
-		roomCol: db.Collection("rooms"),
-		userCol: db.Collection("users"),
-	}
+	store := newGuardStore(db)
 	handler := NewHandler(store)
 
 	// Seed user for lookup
@@ -78,11 +108,7 @@ func TestInboxWorker_RoomSync_Integration(t *testing.T) {
 	db := setupMongo(t)
 	ctx := context.Background()
 
-	store := &mongoInboxStore{
-		subCol:  db.Collection("subscriptions"),
-		roomCol: db.Collection("rooms"),
-		userCol: db.Collection("users"),
-	}
+	store := newGuardStore(db)
 	handler := NewHandler(store)
 
 	room := model.Room{ID: "r1", Name: "synced-room", Type: model.RoomTypeChannel, UserCount: 5}
@@ -109,11 +135,7 @@ func TestInboxWorker_RoleUpdated_Integration(t *testing.T) {
 	db := setupMongo(t)
 	ctx := context.Background()
 
-	store := &mongoInboxStore{
-		subCol:  db.Collection("subscriptions"),
-		roomCol: db.Collection("rooms"),
-		userCol: db.Collection("users"),
-	}
+	store := newGuardStore(db)
 	handler := NewHandler(store)
 
 	_, err := db.Collection("subscriptions").InsertOne(ctx, model.Subscription{
@@ -165,11 +187,7 @@ func TestInboxWorker_RoleUpdated_Integration(t *testing.T) {
 func TestInboxWorker_BulkCreateSubscriptions_IdempotentUpsert(t *testing.T) {
 	ctx := context.Background()
 	db := setupMongo(t)
-	store := &mongoInboxStore{
-		subCol:  db.Collection("subscriptions"),
-		roomCol: db.Collection("rooms"),
-		userCol: db.Collection("users"),
-	}
+	store := newGuardStore(db)
 
 	originalSeenAt := time.Now().UTC().Add(-time.Hour).Truncate(time.Millisecond)
 	original := &model.Subscription{
@@ -223,11 +241,7 @@ func TestInboxWorker_BulkCreateSubscriptions_IdempotentUpsert(t *testing.T) {
 
 func TestInboxWorker_MemberRemoved_Integration(t *testing.T) {
 	db := setupMongo(t)
-	store := &mongoInboxStore{
-		subCol:       db.Collection("subscriptions"),
-		roomCol:      db.Collection("rooms"),
-		threadSubCol: db.Collection("thread_subscriptions"),
-	}
+	store := newGuardStore(db)
 	h := NewHandler(store)
 
 	ctx := context.Background()
@@ -278,12 +292,7 @@ func TestInboxWorker_MemberRemoved_Integration(t *testing.T) {
 func TestInbox_UpdateSubscriptionRead_HappyPath(t *testing.T) {
 	ctx := context.Background()
 	db := setupMongo(t)
-	store := &mongoInboxStore{
-		subCol:       db.Collection("subscriptions"),
-		roomCol:      db.Collection("rooms"),
-		userCol:      db.Collection("users"),
-		threadSubCol: db.Collection("thread_subscriptions"),
-	}
+	store := newGuardStore(db)
 
 	joined := time.Now().UTC().Add(-time.Hour).Truncate(time.Millisecond)
 	_, err := store.subCol.InsertOne(ctx, model.Subscription{
@@ -307,12 +316,7 @@ func TestInbox_UpdateSubscriptionRead_HappyPath(t *testing.T) {
 func TestInbox_UpdateSubscriptionRead_OutOfOrderSkipped(t *testing.T) {
 	ctx := context.Background()
 	db := setupMongo(t)
-	store := &mongoInboxStore{
-		subCol:       db.Collection("subscriptions"),
-		roomCol:      db.Collection("rooms"),
-		userCol:      db.Collection("users"),
-		threadSubCol: db.Collection("thread_subscriptions"),
-	}
+	store := newGuardStore(db)
 
 	t2 := time.Now().UTC().Truncate(time.Millisecond)
 	_, err := store.subCol.InsertOne(ctx, model.Subscription{
@@ -336,12 +340,7 @@ func TestInbox_UpdateSubscriptionRead_OutOfOrderSkipped(t *testing.T) {
 func TestInbox_UpdateSubscriptionRead_EqualTimestampSkipped(t *testing.T) {
 	ctx := context.Background()
 	db := setupMongo(t)
-	store := &mongoInboxStore{
-		subCol:       db.Collection("subscriptions"),
-		roomCol:      db.Collection("rooms"),
-		userCol:      db.Collection("users"),
-		threadSubCol: db.Collection("thread_subscriptions"),
-	}
+	store := newGuardStore(db)
 
 	t1 := time.Now().UTC().Truncate(time.Millisecond)
 	_, err := store.subCol.InsertOne(ctx, model.Subscription{
@@ -428,12 +427,7 @@ func TestInboxWorker_ThreadSubscriptionUpserted_Insert_Integration(t *testing.T)
 	db := setupMongo(t)
 	ctx := context.Background()
 
-	store := &mongoInboxStore{
-		subCol:       db.Collection("subscriptions"),
-		roomCol:      db.Collection("rooms"),
-		userCol:      db.Collection("users"),
-		threadSubCol: db.Collection("thread_subscriptions"),
-	}
+	store := newGuardStore(db)
 	store.ensureIndexes(ctx)
 
 	handler := NewHandler(store)
@@ -477,12 +471,7 @@ func TestInboxWorker_ThreadSubscription_DedupByUserAccount_Integration(t *testin
 	db := setupMongo(t)
 	ctx := context.Background()
 
-	store := &mongoInboxStore{
-		subCol:       db.Collection("subscriptions"),
-		roomCol:      db.Collection("rooms"),
-		userCol:      db.Collection("users"),
-		threadSubCol: db.Collection("thread_subscriptions"),
-	}
+	store := newGuardStore(db)
 	store.ensureIndexes(ctx)
 
 	now := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
@@ -514,12 +503,7 @@ func TestInboxWorker_ThreadSubscriptionUpserted_MonotonicMention_Integration(t *
 	db := setupMongo(t)
 	ctx := context.Background()
 
-	store := &mongoInboxStore{
-		subCol:       db.Collection("subscriptions"),
-		roomCol:      db.Collection("rooms"),
-		userCol:      db.Collection("users"),
-		threadSubCol: db.Collection("thread_subscriptions"),
-	}
+	store := newGuardStore(db)
 	store.ensureIndexes(ctx)
 
 	handler := NewHandler(store)
@@ -595,11 +579,7 @@ func mustInsertUser(t *testing.T, db *mongo.Database, u *model.User) {
 // newIntegrationHandler creates a Handler wired to the given database for integration tests.
 func newIntegrationHandler(t *testing.T, db *mongo.Database) *Handler {
 	t.Helper()
-	store := &mongoInboxStore{
-		subCol:  db.Collection("subscriptions"),
-		roomCol: db.Collection("rooms"),
-		userCol: db.Collection("users"),
-	}
+	store := newGuardStore(db)
 	return NewHandler(store)
 }
 
@@ -749,10 +729,7 @@ func TestInboxWorker_FilterScoping_Integration(t *testing.T) {
 
 func TestInboxStore_ApplyThreadRead_HappyPath(t *testing.T) {
 	db := setupMongo(t)
-	store := &mongoInboxStore{
-		subCol:       db.Collection("subscriptions"),
-		threadSubCol: db.Collection("thread_subscriptions"),
-	}
+	store := newGuardStore(db)
 	ctx := context.Background()
 
 	now := time.Now().UTC().Truncate(time.Millisecond)
@@ -790,10 +767,7 @@ func TestInboxStore_ApplyThreadRead_HappyPath(t *testing.T) {
 // read state still applies).
 func TestInboxStore_ApplyThreadRead_LegacyEmptyParentID_SkipsPull(t *testing.T) {
 	db := setupMongo(t)
-	store := &mongoInboxStore{
-		subCol:       db.Collection("subscriptions"),
-		threadSubCol: db.Collection("thread_subscriptions"),
-	}
+	store := newGuardStore(db)
 	ctx := context.Background()
 
 	seedSub := model.Subscription{
@@ -829,10 +803,7 @@ func TestInboxStore_ApplyThreadRead_LegacyEmptyParentID_SkipsPull(t *testing.T) 
 // subsequent Subscription write matches nothing and is a silent no-op.
 func TestInboxStore_ApplyThreadRead_MissingSubscription_NoError(t *testing.T) {
 	db := setupMongo(t)
-	store := &mongoInboxStore{
-		subCol:       db.Collection("subscriptions"),
-		threadSubCol: db.Collection("thread_subscriptions"),
-	}
+	store := newGuardStore(db)
 	ctx := context.Background()
 
 	now := time.Now().UTC().Truncate(time.Millisecond)
@@ -853,10 +824,7 @@ func TestInboxStore_ApplyThreadRead_MissingSubscription_NoError(t *testing.T) {
 
 func TestInboxStore_ApplyThreadReadAll_HappyPath(t *testing.T) {
 	db := setupMongo(t)
-	store := &mongoInboxStore{
-		subCol:       db.Collection("subscriptions"),
-		threadSubCol: db.Collection("thread_subscriptions"),
-	}
+	store := newGuardStore(db)
 	ctx := context.Background()
 	now := time.Now().UTC().Truncate(time.Millisecond)
 
@@ -907,7 +875,7 @@ func TestInboxStore_ApplyThreadReadAll_HappyPath(t *testing.T) {
 
 func TestInboxStore_AddThreadUnread_Integration(t *testing.T) {
 	db := setupMongo(t)
-	store := &mongoInboxStore{subCol: db.Collection("subscriptions")}
+	store := newGuardStore(db)
 	ctx := context.Background()
 
 	_, err := db.Collection("subscriptions").InsertMany(ctx, []any{
@@ -932,7 +900,7 @@ func TestInboxStore_AddThreadUnread_Integration(t *testing.T) {
 
 func TestInboxStore_AddThreadUnread_EmptyAccountsNoop(t *testing.T) {
 	db := setupMongo(t)
-	store := &mongoInboxStore{subCol: db.Collection("subscriptions")}
+	store := newGuardStore(db)
 	ctx := context.Background()
 	require.NoError(t, store.AddThreadUnread(ctx, "r1", "p1", nil))
 }
@@ -940,10 +908,7 @@ func TestInboxStore_AddThreadUnread_EmptyAccountsNoop(t *testing.T) {
 // Stale event: thread-sub guard rejects, same gate skips the Subscription.
 func TestInboxStore_ApplyThreadRead_OutOfOrderThreadSub(t *testing.T) {
 	db := setupMongo(t)
-	store := &mongoInboxStore{
-		subCol:       db.Collection("subscriptions"),
-		threadSubCol: db.Collection("thread_subscriptions"),
-	}
+	store := newGuardStore(db)
 	ctx := context.Background()
 
 	t2 := time.Now().UTC().Truncate(time.Millisecond)
@@ -1002,7 +967,7 @@ func newSubFixtureWithRoles(id, userID, account, roomID string, roles []model.Ro
 func TestMongoInboxStore_UpdateSubscriptionNamesForRoom(t *testing.T) {
 	ctx := context.Background()
 	db := testutil.MongoDB(t, "inbox-worker-rename")
-	store := &mongoInboxStore{subCol: db.Collection("subscriptions")}
+	store := newGuardStore(db)
 
 	_, err := db.Collection("subscriptions").InsertMany(ctx, []any{
 		newSubFixture("s1", "u1", "alice", "r1", "old"),
@@ -1056,7 +1021,7 @@ func TestMongoInboxStore_ApplySubscriptionRestriction(t *testing.T) {
 
 	t.Run("restrict with owner rewrites roles and sets flags", func(t *testing.T) {
 		db := testutil.MongoDB(t, "inbox-worker-visibility-restrict")
-		store := &mongoInboxStore{subCol: db.Collection("subscriptions")}
+		store := newGuardStore(db)
 		seed(t, db)
 
 		require.NoError(t, store.ApplySubscriptionRestriction(context.Background(), "r1", true, false, "bob", time.Now().UTC()))
@@ -1074,7 +1039,7 @@ func TestMongoInboxStore_ApplySubscriptionRestriction(t *testing.T) {
 
 	t.Run("flags only when ownerAccount empty (roles untouched)", func(t *testing.T) {
 		db := testutil.MongoDB(t, "inbox-worker-visibility-flags")
-		store := &mongoInboxStore{subCol: db.Collection("subscriptions")}
+		store := newGuardStore(db)
 		seed(t, db)
 
 		require.NoError(t, store.ApplySubscriptionRestriction(context.Background(), "r1", true, true, "", time.Now().UTC()))
@@ -1092,7 +1057,7 @@ func TestMongoInboxStore_ApplySubscriptionRestriction(t *testing.T) {
 
 	t.Run("unrestrict clears flags and ignores ownerAccount", func(t *testing.T) {
 		db := testutil.MongoDB(t, "inbox-worker-visibility-unrestrict")
-		store := &mongoInboxStore{subCol: db.Collection("subscriptions")}
+		store := newGuardStore(db)
 		seed(t, db)
 
 		require.NoError(t, store.ApplySubscriptionRestriction(context.Background(), "r1", false, false, "bob", time.Now().UTC()))
@@ -1111,11 +1076,7 @@ func TestMongoInboxStore_ApplySubscriptionRestriction(t *testing.T) {
 func TestIntegration_HandleRoomRenamed(t *testing.T) {
 	ctx := context.Background()
 	db := testutil.MongoDB(t, "inbox-worker-rename-handler")
-	store := &mongoInboxStore{
-		subCol:  db.Collection("subscriptions"),
-		roomCol: db.Collection("rooms"),
-		userCol: db.Collection("users"),
-	}
+	store := newGuardStore(db)
 	h := NewHandler(store)
 
 	// Seed two subscription mirrors for room r1 with old name.
@@ -1159,11 +1120,7 @@ func TestIntegration_HandleRoomRenamed(t *testing.T) {
 func TestIntegration_HandleRoomVisibilityChanged(t *testing.T) {
 	ctx := context.Background()
 	db := testutil.MongoDB(t, "inbox-worker-visibility-handler")
-	store := &mongoInboxStore{
-		subCol:  db.Collection("subscriptions"),
-		roomCol: db.Collection("rooms"),
-		userCol: db.Collection("users"),
-	}
+	store := newGuardStore(db)
 	h := NewHandler(store)
 
 	// Seed: alice=owner, bob=member, carol=member.
@@ -1228,7 +1185,7 @@ func TestInboxStore_UpsertThreadSubscription_DedupesByUserAccount_Integration(t 
 	db := setupMongo(t)
 	ctx := context.Background()
 	threadSubs := db.Collection("thread_subscriptions")
-	store := &mongoInboxStore{threadSubCol: threadSubs}
+	store := newGuardStore(db)
 	store.ensureIndexes(ctx)
 
 	now := time.Now().UTC().Truncate(time.Millisecond)
@@ -1267,10 +1224,7 @@ func TestInboxStore_UpsertThreadSubscription_DedupesByUserAccount_Integration(t 
 // Missing thread-sub: the guarded update matches nothing and is a silent no-op.
 func TestInboxStore_ApplyThreadRead_MissingThreadSubscription_NoError(t *testing.T) {
 	db := setupMongo(t)
-	store := &mongoInboxStore{
-		subCol:       db.Collection("subscriptions"),
-		threadSubCol: db.Collection("thread_subscriptions"),
-	}
+	store := newGuardStore(db)
 	ctx := context.Background()
 
 	seedSub := model.Subscription{
@@ -1295,10 +1249,11 @@ func TestInboxStore_ApplyThreadRead_MissingThreadSubscription_NoError(t *testing
 
 func newGuardStore(db *mongo.Database) *mongoInboxStore {
 	return &mongoInboxStore{
-		subCol:       db.Collection("subscriptions"),
-		roomCol:      db.Collection("rooms"),
-		userCol:      db.Collection("users"),
-		threadSubCol: db.Collection("thread_subscriptions"),
+		subCol:        db.Collection("subscriptions"),
+		roomCol:       db.Collection("rooms"),
+		userCol:       db.Collection("users"),
+		threadSubCol:  db.Collection("thread_subscriptions"),
+		remoteRoomCol: db.Collection(remoteRoomsCollection),
 	}
 }
 
@@ -1553,11 +1508,7 @@ func TestInboxWorker_UpdateUserStatus_Integration(t *testing.T) {
 	db := setupMongo(t)
 	ctx := context.Background()
 
-	store := &mongoInboxStore{
-		subCol:  db.Collection("subscriptions"),
-		roomCol: db.Collection("rooms"),
-		userCol: db.Collection("users"),
-	}
+	store := newGuardStore(db)
 
 	_, err := db.Collection("users").InsertOne(ctx, model.User{
 		ID: "u1", Account: "alice", SiteID: "site-b", StatusText: "old", StatusIsShow: true,
@@ -1610,11 +1561,7 @@ func TestInboxWorker_UpdateUserSettings_Integration(t *testing.T) {
 	db := setupMongo(t)
 	ctx := context.Background()
 
-	store := &mongoInboxStore{
-		subCol:  db.Collection("subscriptions"),
-		roomCol: db.Collection("rooms"),
-		userCol: db.Collection("users"),
-	}
+	store := newGuardStore(db)
 
 	t1 := time.UnixMilli(1000).UTC()
 	t2 := time.UnixMilli(2000).UTC()
@@ -1692,11 +1639,7 @@ func TestInboxWorker_ApplyUserPermissions_Integration(t *testing.T) {
 	db := setupMongo(t)
 	ctx := context.Background()
 
-	store := &mongoInboxStore{
-		subCol:  db.Collection("subscriptions"),
-		roomCol: db.Collection("rooms"),
-		userCol: db.Collection("users"),
-	}
+	store := newGuardStore(db)
 
 	effectiveFrom := time.UnixMilli(500).UTC()
 	expiresAt := time.UnixMilli(9000).UTC()

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/caarlos0/env/v11"
 	o11yredis "github.com/flywindy/o11y/redis"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/redis/go-redis/v9"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -31,18 +32,23 @@ import (
 )
 
 type config struct {
-	NatsURL       string                  `env:"NATS_URL"        envDefault:"nats://localhost:4222"`
-	NatsCredsFile string                  `env:"NATS_CREDS_FILE" envDefault:""`
-	SiteID        string                  `env:"SITE_ID"         envDefault:"default"`
-	MongoURI      string                  `env:"MONGO_URI"       envDefault:"mongodb://localhost:27017"`
-	MongoDB       string                  `env:"MONGO_DB"        envDefault:"chat"`
-	MongoUsername string                  `env:"MONGO_USERNAME"  envDefault:""`
-	MongoPassword string                  `env:"MONGO_PASSWORD"  envDefault:""`
-	MaxWorkers    int                     `env:"MAX_WORKERS"     envDefault:"100"`
-	Consumer      stream.ConsumerSettings `envPrefix:"CONSUMER_"`
-	Bootstrap     bootstrapConfig         `envPrefix:"BOOTSTRAP_"`
-	HealthAddr    string                  `env:"HEALTH_ADDR" envDefault:":8081"`
-	PProfEnabled  bool                    `env:"PPROF_ENABLED" envDefault:"false"`
+	NatsURL       string `env:"NATS_URL"        envDefault:"nats://localhost:4222"`
+	NatsCredsFile string `env:"NATS_CREDS_FILE" envDefault:""`
+	SiteID        string `env:"SITE_ID"         envDefault:"default"`
+	MongoURI      string `env:"MONGO_URI"       envDefault:"mongodb://localhost:27017"`
+	MongoDB       string `env:"MONGO_DB"        envDefault:"chat"`
+	MongoUsername string `env:"MONGO_USERNAME"  envDefault:""`
+	MongoPassword string `env:"MONGO_PASSWORD"  envDefault:""`
+	MaxWorkers    int    `env:"MAX_WORKERS"     envDefault:"100"`
+	// RoomSubCache memoizes the room-membership check on the activity-refresh
+	// lane, which would otherwise cost a Mongo read per broadcast message.
+	// Either value non-positive disables it.
+	RoomSubCacheSize int                     `env:"ROOM_SUB_CACHE_SIZE" envDefault:"50000"`
+	RoomSubCacheTTL  time.Duration           `env:"ROOM_SUB_CACHE_TTL"  envDefault:"5m"`
+	Consumer         stream.ConsumerSettings `envPrefix:"CONSUMER_"`
+	Bootstrap        bootstrapConfig         `envPrefix:"BOOTSTRAP_"`
+	HealthAddr       string                  `env:"HEALTH_ADDR" envDefault:":8081"`
+	PProfEnabled     bool                    `env:"PPROF_ENABLED" envDefault:"false"`
 	// AdminAcctPrefix overrides the platform-admin account prefix (ADMIN_ACCT_PREFIX); keep it identical across services.
 	AdminAcctPrefix string `env:"ADMIN_ACCT_PREFIX" envDefault:"p_admin"`
 	// ValkeyAddrs seeds the Valkey cluster backing the badge cache
@@ -56,10 +62,67 @@ type config struct {
 
 // mongoInboxStore implements InboxStore using MongoDB.
 type mongoInboxStore struct {
-	subCol       *mongo.Collection
-	roomCol      *mongo.Collection
-	userCol      *mongo.Collection
-	threadSubCol *mongo.Collection
+	subCol        *mongo.Collection
+	roomCol       *mongo.Collection
+	userCol       *mongo.Collection
+	threadSubCol  *mongo.Collection
+	remoteRoomCol *mongo.Collection
+}
+
+// remoteRoomsCollection stores model.RemoteRoom. Deliberately NOT rooms: that
+// one is room-service's and its readers assume complete documents (members,
+// encKey, counts), which a federated peer cannot supply. Migration's room_sync
+// does replicate whole rooms here, so a migrated room can hold both and a
+// reader spanning the two must prefer rooms.
+const remoteRoomsCollection = "remote_rooms"
+
+// HasRoomSubscription reports whether any subscription for roomID exists here.
+// Served by the (roomId, u.account) unique index as a prefix scan; projected to
+// _id and capped at one doc since only existence matters.
+func (s *mongoInboxStore) HasRoomSubscription(ctx context.Context, roomID string) (bool, error) {
+	err := s.subCol.FindOne(ctx, bson.M{"roomId": roomID},
+		options.FindOne().SetProjection(bson.M{"_id": 1})).Err()
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, mongo.ErrNoDocuments):
+		return false, nil
+	default:
+		return false, fmt.Errorf("check room subscription %q: %w", roomID, err)
+	}
+}
+
+// DeleteRemoteRoomActivity drops a remote room's ordering row. Absent row is
+// not an error — the room may never have had one.
+func (s *mongoInboxStore) DeleteRemoteRoomActivity(ctx context.Context, roomID string) error {
+	if _, err := s.remoteRoomCol.DeleteOne(ctx, bson.M{"_id": roomID}); err != nil {
+		return fmt.Errorf("delete remote room activity %q: %w", roomID, err)
+	}
+	return nil
+}
+
+// UpsertRemoteRoomActivity advances a remote room's position under $max, so
+// out-of-order delivery can never regress it. $setOnInsert carries the
+// immutable identity so a first touch creates the row complete.
+func (s *mongoInboxStore) UpsertRemoteRoomActivity(ctx context.Context, roomID, siteID string, lastMsgAt time.Time) error {
+	filter := bson.M{"_id": roomID}
+	update := bson.M{
+		"$max":         bson.M{"lastMsgAt": lastMsgAt},
+		"$setOnInsert": bson.M{"siteId": siteID},
+	}
+	opts := options.UpdateOne().SetUpsert(true)
+	if _, err := s.remoteRoomCol.UpdateOne(ctx, filter, update, opts); err != nil {
+		if !mongo.IsDuplicateKeyError(err) {
+			return fmt.Errorf("upsert remote room activity %q: %w", roomID, err)
+		}
+		// Two concurrent first-touches. Unlike UpsertRoom, whose guard lives in
+		// the filter, this one filters on _id alone — so a duplicate says
+		// nothing about which value is newer. Retry; the row exists now.
+		if _, err := s.remoteRoomCol.UpdateOne(ctx, filter, update, opts); err != nil {
+			return fmt.Errorf("upsert remote room activity %q (retry after duplicate key): %w", roomID, err)
+		}
+	}
+	return nil
 }
 
 func (s *mongoInboxStore) CreateSubscription(ctx context.Context, sub *model.Subscription) error {
@@ -681,10 +744,11 @@ func main() {
 	}
 	db := mongoClient.Database(cfg.MongoDB)
 	store := &mongoInboxStore{
-		subCol:       db.Collection("subscriptions"),
-		roomCol:      db.Collection("rooms"),
-		userCol:      db.Collection("users"),
-		threadSubCol: db.Collection("thread_subscriptions"),
+		subCol:        db.Collection("subscriptions"),
+		roomCol:       db.Collection("rooms"),
+		userCol:       db.Collection("users"),
+		threadSubCol:  db.Collection("thread_subscriptions"),
+		remoteRoomCol: db.Collection(remoteRoomsCollection),
 	}
 	store.ensureIndexes(ctx)
 
@@ -742,8 +806,26 @@ func main() {
 		slog.Warn("badge cache DISABLED — VALKEY_ADDRS is empty (dev only)")
 	}
 
-	handler := NewHandler(store)
+	handler := NewHandler(store, WithRoomSubCache(cfg.RoomSubCacheSize, cfg.RoomSubCacheTTL))
 	handler.badge = badge
+	slog.Info("room-sub cache configured", "size", cfg.RoomSubCacheSize, "ttl", cfg.RoomSubCacheTTL)
+
+	// Core-NATS queue subscriber for the cross-site room-activity refresh. Not on
+	// INBOX by design: the signal is coalesced, idempotent and $max-guarded, so it
+	// needs no persistence or ordering, and keeping it off the stream stops a
+	// high-rate hint competing for retention with membership events that do need
+	// both. Fire-and-forget — a failure self-heals on the room's next message.
+	activitySub, err := nc.QueueSubscribe(ctx, subject.RoomActivity(cfg.SiteID), "inbox-worker",
+		func(msgCtx context.Context, msg *nats.Msg) {
+			actCtx, _ := natsutil.StampRequestID(msgCtx, msg.Header, msg.Subject)
+			if err := handler.HandleRoomActivity(actCtx, msg.Data); err != nil {
+				slog.WarnContext(actCtx, "apply room activity refresh failed", "error", err)
+			}
+		})
+	if err != nil {
+		slog.Error("subscribe room-activity failed", "error", err)
+		os.Exit(1)
+	}
 
 	// Two-lane pull pattern over the single INBOX external consumer:
 	//
@@ -842,6 +924,8 @@ func main() {
 				return fmt.Errorf("worker drain timed out: %w", ctx.Err())
 			}
 		},
+		// Unsubscribe before the drain so no refresh arrives after the store closes.
+		func(_ context.Context) error { return activitySub.Unsubscribe() },
 		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, mongoClient); return nil },
 		func(ctx context.Context) error {

--- a/inbox-worker/roomsubcache.go
+++ b/inbox-worker/roomsubcache.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2/expirable"
+
+	"github.com/hmchangw/chat/pkg/cachemetrics"
+)
+
+// roomSubCache answers "does this site hold a subscription for this room" from
+// memory. The activity refresh is broadcast to every peer, so without it each
+// arriving message costs a Mongo read just to discard most of them — and the
+// answer changes only on member_added/member_removed, which are rare against
+// message traffic, so the hit rate approaches 1 after warmup.
+//
+// Both polarities are cached. Negative entries are the point: rooms this site
+// has no member in are the common case and the ones being thrown away. A stale
+// negative is safe because member_added seeds the ordering row directly on the
+// join path, so a newly joined room is already correct in remote_rooms before
+// any refresh arrives — and the handlers below keep the entry in step anyway.
+type roomSubCache struct {
+	// mu serializes the read-through fill against the membership handlers. The
+	// refresh lane runs on its own subscription goroutine, so a fill that read
+	// "not a member" can otherwise land after a concurrent member_added wrote
+	// true — pinning the room's position at its join-time seed for the whole
+	// TTL, exactly the staleness the handler hooks exist to prevent.
+	mu      sync.Mutex
+	entries *lru.LRU[string, bool]
+	metrics cachemetrics.Recorder
+}
+
+func newRoomSubCache(size int, ttl time.Duration) *roomSubCache {
+	if size <= 0 || ttl <= 0 {
+		return nil // disabled: every refresh reads through
+	}
+	return &roomSubCache{
+		entries: lru.NewLRU[string, bool](size, nil, ttl),
+		metrics: cachemetrics.For("room_sub", "l1"),
+	}
+}
+
+func (c *roomSubCache) get(ctx context.Context, roomID string) (bool, bool) {
+	if c == nil {
+		return false, false
+	}
+	c.mu.Lock()
+	subscribed, ok := c.entries.Get(roomID)
+	c.mu.Unlock()
+	if ok {
+		c.metrics.Hit(ctx)
+	} else {
+		c.metrics.Miss(ctx)
+	}
+	return subscribed, ok
+}
+
+// set records an authoritative answer — from a membership handler, which knows
+// the outcome rather than inferring it from a read.
+func (c *roomSubCache) set(roomID string, subscribed bool) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries.Add(roomID, subscribed)
+}
+
+// fill records a read-through result without overwriting an entry a membership
+// handler wrote while the read was in flight. Those are authoritative; a
+// concurrent read only ever observed a snapshot that may already be stale.
+func (c *roomSubCache) fill(roomID string, subscribed bool) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, exists := c.entries.Get(roomID); exists {
+		return
+	}
+	c.entries.Add(roomID, subscribed)
+}
+
+// invalidate drops the entry so the next refresh re-resolves it. Used on
+// member_removed: losing one account does not prove the site has no members
+// left, and re-reading once is cheaper than reasoning about which guess is safe.
+func (c *roomSubCache) invalidate(roomID string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries.Remove(roomID)
+}
+
+// hasRoomSubscription answers from cache, falling back to the store and
+// recording the result. A store error is returned uncached.
+func (h *Handler) hasRoomSubscription(ctx context.Context, roomID string) (bool, error) {
+	if subscribed, ok := h.roomSubs.get(ctx, roomID); ok {
+		return subscribed, nil
+	}
+	subscribed, err := h.store.HasRoomSubscription(ctx, roomID)
+	if err != nil {
+		return false, err
+	}
+	h.roomSubs.fill(roomID, subscribed)
+	return subscribed, nil
+}

--- a/inbox-worker/roomsubcache_test.go
+++ b/inbox-worker/roomsubcache_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/model"
+)
+
+// countingStore counts HasRoomSubscription reads so the tests can assert the
+// cache actually removes them.
+type countingStore struct {
+	*stubInboxStore
+	reads int
+}
+
+func (c *countingStore) HasRoomSubscription(ctx context.Context, roomID string) (bool, error) {
+	c.reads++
+	return c.stubInboxStore.HasRoomSubscription(ctx, roomID)
+}
+
+func activityData(t *testing.T, roomID string) []byte {
+	t.Helper()
+	b, err := json.Marshal(model.RoomActivityEvent{
+		RoomID: roomID, SiteID: "site-A", LastMsgAt: 1740000000000, Timestamp: 1740000000000,
+	})
+	require.NoError(t, err)
+	return b
+}
+
+func TestRoomSubCache_SecondRefreshServesFromMemory(t *testing.T) {
+	store := &countingStore{stubInboxStore: &stubInboxStore{roomSubscribed: map[string]bool{"r1": true}}}
+	h := NewHandler(store, WithRoomSubCache(100, time.Minute))
+
+	for range 5 {
+		require.NoError(t, h.HandleRoomActivity(context.Background(), activityData(t, "r1")))
+	}
+	assert.Equal(t, 1, store.reads, "only the first refresh reads through")
+	assert.Len(t, store.remoteRoomActivity, 5, "every refresh still applies")
+}
+
+func TestRoomSubCache_NegativeEntriesAreCachedToo(t *testing.T) {
+	// Rooms this site has no member in are the common case and the whole point:
+	// they must not cost a read per refresh.
+	store := &countingStore{stubInboxStore: &stubInboxStore{}}
+	h := NewHandler(store, WithRoomSubCache(100, time.Minute))
+
+	for range 5 {
+		require.NoError(t, h.HandleRoomActivity(context.Background(), activityData(t, "r-elsewhere")))
+	}
+	assert.Equal(t, 1, store.reads)
+	assert.Empty(t, store.remoteRoomActivity)
+}
+
+func TestRoomSubCache_MemberAddedPromotesWithoutARead(t *testing.T) {
+	// A room cached negative must not stay invisible for the TTL once this site
+	// joins it — member_added updates the entry in the same process.
+	store := &countingStore{stubInboxStore: &stubInboxStore{users: []model.User{{ID: "u_bob", Account: "bob", SiteID: "site-B"}}}}
+	h := NewHandler(store, WithRoomSubCache(100, time.Minute))
+
+	require.NoError(t, h.HandleRoomActivity(context.Background(), activityData(t, "r1")))
+	require.Empty(t, store.remoteRoomActivity, "not a member yet")
+
+	at := int64(1740000000000)
+	require.NoError(t, h.HandleEvent(context.Background(), memberAddedEventData(t, &at)))
+
+	store.reads = 0
+	require.NoError(t, h.HandleRoomActivity(context.Background(), activityData(t, "r1")))
+	assert.Equal(t, 0, store.reads, "member_added already promoted the entry")
+	assert.NotEmpty(t, store.remoteRoomActivity, "and the refresh now applies")
+}
+
+func TestRoomSubCache_MemberRemovedForcesAReadThrough(t *testing.T) {
+	// Removal does not prove the site has no members left, so drop the entry and
+	// let the next refresh re-resolve it rather than caching a guess.
+	store := &countingStore{stubInboxStore: &stubInboxStore{roomSubscribed: map[string]bool{"r1": true}}}
+	h := NewHandler(store, WithRoomSubCache(100, time.Minute))
+
+	require.NoError(t, h.HandleRoomActivity(context.Background(), activityData(t, "r1")))
+	require.Equal(t, 1, store.reads)
+
+	evt, err := json.Marshal(model.InboxEvent{Type: "member_removed", Payload: mustJSON(t, model.MemberRemoveEvent{
+		Type: "member_removed", RoomID: "r1", Accounts: []string{"bob"},
+	})})
+	require.NoError(t, err)
+	require.NoError(t, h.HandleEvent(context.Background(), evt))
+
+	require.NoError(t, h.HandleRoomActivity(context.Background(), activityData(t, "r1")))
+	assert.Equal(t, 2, store.reads, "the invalidated room is re-resolved")
+}
+
+func TestRoomSubCache_DisabledAlwaysReadsThrough(t *testing.T) {
+	store := &countingStore{stubInboxStore: &stubInboxStore{roomSubscribed: map[string]bool{"r1": true}}}
+	h := NewHandler(store) // no cache option
+
+	for range 3 {
+		require.NoError(t, h.HandleRoomActivity(context.Background(), activityData(t, "r1")))
+	}
+	assert.Equal(t, 3, store.reads)
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -138,6 +138,18 @@ type InboxMemberEvent struct {
 	Origin string `json:"origin,omitempty"`
 }
 
+// RoomActivityEvent refreshes a remote room's chat-list ordering position on a
+// destination site, which holds no Room document for it. Published on the
+// core-NATS subject.RoomActivity lane, coalesced per room by the origin's
+// last-message flush, and applied under a $max guard — so it is safe to lose,
+// duplicate, or deliver out of order. LastMsgAt and Timestamp are epoch millis.
+type RoomActivityEvent struct {
+	RoomID    string `json:"roomId"    bson:"roomId"`
+	SiteID    string `json:"siteId"    bson:"siteId"`
+	LastMsgAt int64  `json:"lastMsgAt" bson:"lastMsgAt"`
+	Timestamp int64  `json:"timestamp" bson:"timestamp"`
+}
+
 // NotificationEvent is the per-user reaction notification on chat.user.{account}.notification;
 // distinct from PushNotificationEvent (batched mobile) — this is the legacy single-user envelope the FE listens on.
 type NotificationEvent struct {
@@ -270,6 +282,11 @@ type MemberAddEvent struct {
 	RequesterAccount   string   `json:"requesterAccount,omitempty" bson:"requesterAccount,omitempty"`
 	JoinedAt           int64    `json:"joinedAt"           bson:"joinedAt"`
 	HistorySharedSince *int64   `json:"historySharedSince,omitempty" bson:"historySharedSince,omitempty"`
+	// LastMsgAt is the room's activity position (epoch millis), nil when the room
+	// has never had a message. Cross-site INBOX copies only — like Accounts, it is
+	// stripped from the room-scoped (frontend) copy. The destination holds no rooms
+	// doc for a remote room, so this is the only key it can order the room by.
+	LastMsgAt *int64 `json:"lastMsgAt,omitempty" bson:"lastMsgAt,omitempty"`
 	// Members carries the member.list (enrich=true) display entries; org-expanded accounts ride Accounts only.
 	// Room-scoped event only — INBOX copies omit it (remote sites re-resolve display data).
 	Members []RoomMemberEntry `json:"members,omitempty" bson:"members,omitempty"`

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -2179,6 +2179,16 @@ func TestSubscriptionRoomJSON(t *testing.T) {
 	})
 }
 
+func TestRemoteRoom_RoundTrip(t *testing.T) {
+	rr := model.RemoteRoom{
+		ID:        "r1",
+		SiteID:    "site-a",
+		LastMsgAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	var got model.RemoteRoom
+	roundTrip(t, &rr, &got)
+}
+
 func TestRoom_CrossSiteRoundTrip(t *testing.T) {
 	r := model.Room{ID: "r1", SiteID: "site-a", CrossSite: boolPtr(true),
 		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),

--- a/pkg/model/room.go
+++ b/pkg/model/room.go
@@ -45,6 +45,15 @@ type Room struct {
 // OriginTeams marks a room/subscription imported from the Teams migration.
 const OriginTeams = "teams"
 
+// RemoteRoom is the chat-list ordering position of a room owned by another
+// site, for which this site holds no Room document. Written by inbox-worker
+// under a $max guard on LastMsgAt.
+type RemoteRoom struct {
+	ID        string    `json:"id" bson:"_id"`
+	SiteID    string    `json:"siteId" bson:"siteId"`
+	LastMsgAt time.Time `json:"lastMsgAt" bson:"lastMsgAt"`
+}
+
 // RoomsInfoBatchRequest is the NATS request body for the batch room info RPC.
 type RoomsInfoBatchRequest struct {
 	RoomIDs []string `json:"roomIds"`

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -309,6 +309,20 @@ func InboxExternalAll(siteID string) string {
 	return fmt.Sprintf("chat.inbox.%s.external.>", siteID)
 }
 
+// RoomActivity is the CORE-NATS subject carrying a remote room's activity
+// position to a destination site: `chat.roomactivity.{destSiteID}`.
+//
+// Deliberately outside `chat.inbox.>` so it is never captured by the INBOX
+// JetStream stream. The payload is a decorative ordering hint — coalesced,
+// idempotent, and applied under a $max guard — so it needs neither persistence
+// nor ordering, and putting it on INBOX would make a high-rate signal compete
+// for retention and ack budget with membership events that do need both.
+// Interest-routed across the supercluster: a site with no subscriber simply
+// does not receive it.
+func RoomActivity(destSiteID string) string {
+	return fmt.Sprintf("chat.roomactivity.%s", destSiteID)
+}
+
 // InboxMemberEventSubjects returns the subject filters a search-sync consumer
 // should use to receive the room-index-affecting events on both the internal
 // (same-site) and external (cross-site) lanes for the given site:

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hmchangw/chat/pkg/roomkeystore"
 	"github.com/hmchangw/chat/pkg/roommetacache"
 	"github.com/hmchangw/chat/pkg/subject"
+	"github.com/hmchangw/chat/pkg/timeutil"
 	"github.com/hmchangw/chat/pkg/valkeyutil"
 )
 
@@ -1162,8 +1163,11 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 	// subs are already committed, so failing here would let a redelivery
 	// (which recomputes needSub as empty) silently drop the events — degrade
 	// to the pre-add meta view instead and let subscription.list reconcile.
+	// Post-add view: the meta view unless the re-read succeeds. Also supplies the
+	// cross-site MemberAddEvent's activity position below — the meta view carries
+	// no lastMsgAt, so a failed re-read ships without one.
+	evtRoom := room
 	if len(subs) > 0 {
-		evtRoom := room
 		if freshRoom, err := h.store.GetRoom(ctx, req.RoomID); err == nil {
 			evtRoom = freshRoom
 		} else {
@@ -1302,6 +1306,7 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 			RequesterAccount:   req.RequesterAccount,
 			JoinedAt:           req.Timestamp,
 			HistorySharedSince: historySharedSince,
+			LastMsgAt:          timeutil.TimeToMillis(evtRoom.LastMsgAt),
 			Timestamp:          now.UnixMilli(),
 		}
 		siteEvtData, _ := json.Marshal(siteEvt)
@@ -1864,7 +1869,9 @@ func (h *Handler) finishCreateRoom(ctx context.Context, req *model.CreateRoomReq
 			RequesterAccount:   requester.Account,
 			JoinedAt:           req.Timestamp,
 			HistorySharedSince: nil,
-			Timestamp:          now.UnixMilli(),
+			// Nil in practice: the room was just created and has no activity yet.
+			LastMsgAt: timeutil.TimeToMillis(room.LastMsgAt),
+			Timestamp: now.UnixMilli(),
 		}
 		memberData, _ := json.Marshal(memberEvt)
 		memberSeed := fmt.Sprintf("%s:%s:%d", room.ID, requester.Account, req.Timestamp)
@@ -2469,7 +2476,10 @@ func (h *Handler) publishSyncDMInbox(ctx context.Context, room *model.Room, requ
 		SiteID:           room.SiteID,
 		RequesterAccount: requester.Account,
 		JoinedAt:         joinedAt.UnixMilli(),
-		Timestamp:        now,
+		// Nil for a freshly created DM; set on the duplicate-key reconcile
+		// branch, where room is the existing doc re-read from Mongo.
+		LastMsgAt: timeutil.TimeToMillis(room.LastMsgAt),
+		Timestamp: now,
 	}
 	pData, err := json.Marshal(memberEvt)
 	if err != nil {

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -1341,7 +1341,12 @@ func TestHandler_ProcessAddMembers_WithOrgs_RoomEventMembersEnrichment(t *testin
 	}
 	h := NewHandler(store, "site-a", publish, testKeyStore, testKeySender, subject.RouteGlobal)
 
+	// GetRoomMeta is served from roommetacache.Meta, which has no LastMsgAt
+	// field — the real store can never return one here. Mirroring that exactly
+	// is the point: the activity position must come from the full-room read, so
+	// a regression that reads it off the meta view fails this test.
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1", Name: "deal team", Type: model.RoomTypeChannel, SiteID: "site-a", CrossSite: ptrBool(false)}, nil)
+	roomLastMsgAt := time.UnixMilli(1735689500000).UTC()
 	// bob is the direct add; carol joins via org expansion only (not in req.Users).
 	store.EXPECT().ListAddMemberCandidates(gomock.Any(), []string{"eng"}, []string{"bob"}, "r1").
 		Return([]AddMemberCandidate{{Account: "bob", SiteID: "site-a"}, {Account: "carol", SiteID: "site-b"}}, nil)
@@ -1360,7 +1365,7 @@ func TestHandler_ProcessAddMembers_WithOrgs_RoomEventMembersEnrichment(t *testin
 		})
 	// Room already tracks individuals → no first-org backfill.
 	store.EXPECT().HasAnyRoomMembers(gomock.Any(), "r1").Return(true, nil)
-	expectGetRoom(store, "r1", "eng")
+	expectGetRoom(store, "r1", "eng", roomLastMsgAt)
 	store.EXPECT().BulkCreateRoomMembers(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, members []*model.RoomMember) error {
 			return nil
@@ -1431,6 +1436,13 @@ func TestHandler_ProcessAddMembers_WithOrgs_RoomEventMembersEnrichment(t *testin
 	var relayEvt model.MemberAddEvent
 	require.NoError(t, json.Unmarshal(relayEnv.Payload, &relayEvt))
 	assert.Equal(t, []string{"carol"}, relayEvt.Accounts, "the cross-site lane keeps the destination-site accounts")
+
+	// The destination site holds no rooms doc for r1, so the cross-site copy
+	// carries the room's activity position to seed its chat-list ordering.
+	require.NotNil(t, relayEvt.LastMsgAt, "cross-site member_added carries the room's activity position")
+	assert.Equal(t, roomLastMsgAt.UnixMilli(), *relayEvt.LastMsgAt)
+	assert.Nil(t, evt.LastMsgAt, "stripped from the room-scoped (frontend) copy, like accounts")
+	assert.Nil(t, internalEvt.LastMsgAt, "the same-site INBOX lane has a local rooms doc and needs no seed")
 }
 
 func TestHandler_ProcessAddMembers_OrgWithNoUsersFallsBackToOrgID(t *testing.T) {
@@ -3646,9 +3658,14 @@ func TestProcessCreateRoom_Channel_NoRoomKeyEvent(t *testing.T) {
 
 // expectGetRoom stubs the fan-out room re-read tolerantly (0+ calls) so tests
 // not asserting on the event room view stay independent of the read.
-func expectGetRoom(s *MockSubscriptionStore, roomID, name string) {
-	s.EXPECT().GetRoom(gomock.Any(), roomID).
-		Return(&model.Room{ID: roomID, Name: name, Type: model.RoomTypeChannel, SiteID: "site-a"}, nil).AnyTimes()
+// expectGetRoom stubs the full-room re-read. An optional lastMsgAt sets the
+// room's activity position, which the cross-site MemberAddEvent carries.
+func expectGetRoom(s *MockSubscriptionStore, roomID, name string, lastMsgAt ...time.Time) {
+	room := &model.Room{ID: roomID, Name: name, Type: model.RoomTypeChannel, SiteID: "site-a"}
+	if len(lastMsgAt) > 0 {
+		room.LastMsgAt = &lastMsgAt[0]
+	}
+	s.EXPECT().GetRoom(gomock.Any(), roomID).Return(room, nil).AnyTimes()
 }
 
 // assertNoRoomKeyPublished pins the no-separate-room.key invariant on the accounts' key subjects.


### PR DESCRIPTION
## Problem

A subscription to a room owned by another site has **no local `rooms` document**, permanently. `inbox-worker.handleMemberAdded` creates a subscription and nothing else, and `room_sync` — the only full-room replication path — is published solely by `data-migration/oplog-collections-transformer`, never by room-worker or room-service in normal operation.

Chat-list ordering keys on `room.lastMsgAt`. With no room doc there is no key, so every remote room sorts below every local one, ordered only by the subscription&#39;s denormalized `name`. With a paginated client that caps how far it reads, **an active remote room can never appear** — and the more active it is, the more wrong its position. Under an `updatedWithinDays` window it is worse: the cutoff tests `lastMsgAt == nil`, so remote rooms are dropped from the list entirely.

The room&#39;s real `lastMsgAt` *is* fetched — `enrichCrossSite` RPCs each remote site — but in the service layer, **after** the repo has already sorted and paged. The data needed to order correctly arrives strictly after the ordering decision.

Pre-existing behaviour, not a regression: the old in-Mongo `$ifNull` sort buried missing rooms the same way.

## Approach

Give each site the ordering position for the remote rooms its users belong to, from two sources — seeded when a member joins, refreshed as the room stays active.

**1. Wire contract** (`90daf6e`). `MemberAddEvent.LastMsgAt` seeds; `RoomActivityEvent` refreshes; `RemoteRoom` is the stored row. `subject.RoomActivity` is deliberately outside `chat.inbox.&gt;` so the refresh never touches the INBOX JetStream stream — it is coalesced, idempotent and `$max`-guarded, needing neither persistence nor ordering, and a high-rate signal there would compete for retention and ack budget with membership events that need both.

**2. Producers** (`1fae56f`). Four call sites publish cross-site `member_added`. room-worker&#39;s add-members path must not read the position off `room` — that comes from `GetRoomMeta`, built from `roommetacache.Meta`, which structurally has no `lastMsgAt`, so it would be nil unconditionally; the full room is already re-read for the subscription fan-out and that value is reused. `bot-room-service` is the fourth producer, reached when a user joins a bot-owned channel that already has history; its DM-ensure path matters too, since the DM id is deterministic and ensure can land on an existing room. The two creation paths pass nil, which is correct.

**3. Storage and lifecycle** (`ea957cf`). `remote_rooms` (`model.RemoteRoom`), written by inbox-worker from both the seed and the refresh. Deliberately not the `rooms` collection: that one is room-service&#39;s and its readers assume complete documents (members, `encKey`, counts) a federated peer cannot supply. Migration&#39;s `room_sync` replicates whole rooms onto the same external lane, so a migrated room can hold both and a reader spanning the two must prefer `rooms`.

The write is a `$max`-guarded upsert — idempotent and order-independent, which is what lets the refresh ride a lossy transport. A duplicate key means two concurrent first-touches, not a stale event (unlike `UpsertRoom`, whose guard lives in the filter), so it retries rather than swallowing the newer value. Lifecycle is closed at both ends: seeding runs after the missing-user return so a room that gained no subscriber leaves no row, and `member_removed` drops the row once no member remains.

**4. Refresh publisher** (`6cbe4aa`). Rides the coalescer that already buffers `rooms.lastMsgAt` on a 250ms flush.

## Cost

The refresh is broadcast to every peer, which needed bounding in three places:

| | naive | shipped |
|---|---|---|
| Publishes/sec (1k active cross-site rooms, 5 sites) | ~4,000 | ~200 |
| Destination Mongo reads/sec | ~1,000 | ~0 |

- **Coalescing** collapses a flush window to one entry per room, so cost is independent of message rate.
- **`ROOM_ACTIVITY_REFRESH_INTERVAL`** (default 5s) then caps how often a room is announced at all, decoupling it from the Mongo flush — a ~20× cut. The interval can be that generous because the consumer cannot see the difference: `subscription.list` serves ordering from a sort-key cache whose own TTL is an order of magnitude longer.
- **`ROOM_SUB_CACHE_SIZE`/`_TTL`** memoize the destination&#39;s membership check, taking the per-message Mongo read to zero in the steady state. Both handlers keep entries in step rather than relying on expiry, and read-through fills never overwrite what a membership handler wrote — losing that race would pin a freshly-joined room at its seed for the whole TTL.

**One room per message, never a batch.** Payload size is then bounded by construction; a batched form would grow with active-room count and eventually exceed `max_payload` — a cliff appearing only at peak load, losing a whole flush window at once.

`ALL_SITE_IDS` unset disables the lane. Correct for a single site, but a warning says so, since a federated deployment missing it would look healthy while remote chat lists silently could not order this site&#39;s rooms.

## Considered and rejected

**Targeting peers from a `Room.MemberSites` list.** Removal is the sharp edge: dropping one member doesn&#39;t prove no others from that site remain. Refcounts break under the at-least-once, idempotent federation lanes (`$inc` is not idempotent, and a redelivered `member_removed` silently under-counts); recomputing is O(room size) per removal; sticky-never-shrink decays toward broadcasting anyway. `Room.CrossSite` already faced this and chose sticky over-approximation. After the throttle and the cache, this would save ~30 KB/s per peer — not worth a membership-tracking mechanism with a correctness hazard in it.

## Scope — what this does *not* do

- **Nothing reads `remote_rooms` yet.** The read-path fallback belongs in `resolveSortKeys`, which exists only on #197&#39;s branch; on `main`, `AggregateSubscriptions` is still the `$lookup` pipeline. It lands once #197 merges — that is the commit that makes this user-visible.
- **No backfill** for existing subscriptions. Cheapest route is write-behind from the `GetRoomsInfo` results the service layer already fetches per page, which doubles as ongoing repair.
- **The four producers are not consolidated.** &#34;Cross-site copies carry the position&#34; lives in four hand-maintained call sites across two services, and nothing catches a fifth appearing. A `model.NewCrossSiteMemberAdd(...)` constructor would make it a property of the type — worth doing, too large here.
- **No end-to-end integration test** across the wire (publisher → core NATS → consumer → `remote_rooms`). Each half is covered against fakes, but nothing yet proves they agree on the payload. `pkg/testutil.NATS(t)` would support it.

## Testing

TDD throughout; every test failed for the intended reason before implementation.

- **inbox-worker:** table over seed fires / nothing to seed / unknown user leaves no orphan row / seed failure doesn&#39;t fail the event; refresh applies, drops non-member rooms, rejects malformed and position-less payloads; cache serves from memory, caches negatives, promotes on `member_added`, re-reads after `member_removed`.
- **broadcast-worker:** cross-site rooms only; coalesces to one publish per room; throttles per room and independently across rooms; prunes watermarks; publish failure doesn&#39;t fail the flush; one message per peer with a bounded payload.
- **room-worker / bot-room-service:** the mock mirrors the real store&#39;s shape (`GetRoomMeta` returns no `lastMsgAt`) so a regression reading it from there fails; bot-room-service unwraps the published `OutboxEvent` to assert what the destination actually receives.
- **Integration:** the `$max` guard against newer (advances), older (no-op), and first-touch completeness.

`make lint` 0 issues; full-repo `make test` (race) passes across 112 packages; `gosec` clean. `govulncheck` and the semgrep registry rulesets are proxy-blocked in the sandbox — CI&#39;s `sast` job covers them. Integration tests need a Docker daemon this container lacks; CI covers them, and it caught a nil `remoteRoomCol` in test-only store literals that local runs could not.

## Note for reviewers

`inbox-worker` has no `//go:generate` directive and its `MockInboxStore` is orphaned (tests use a hand-written `stubInboxStore`), so `make generate` is a no-op there and the generated mock is stale against the interface. Unused, so nothing breaks; the installed `mockgen` is built with go1.24 and cannot load this go1.25 module, so I left it rather than hand-editing.

The duplicate-key retry path has no test — forcing a genuine concurrent-insert race deterministically needs fault injection the suite has no facility for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfPa3pTMGaKVzV1xe1sqp7