### PR TITLE
feat(chat-frontend): show the last message as a sidebar preview

### DIFF
--- a/chat-frontend/src/api/index.ts
+++ b/chat-frontend/src/api/index.ts
@@ -81,6 +81,7 @@ export type {
   Message,
   HistoryMessage,
   Participant,
+  PreviewMessage,
   QuotedParentMessage,
   MemberEntry,
   Reader,

--- a/chat-frontend/src/api/types.ts
+++ b/chat-frontend/src/api/types.ts
@@ -48,6 +48,11 @@ export interface SubscriptionRoom {
    *  for initial key bootstrap (same payload as the room.key.get RPC). */
   privateKey?: string
   keyVersion?: number
+  /** The room's latest eligible message. Omitted when the room has no
+   *  message, that site's enrichment degraded, or the request set
+   *  `includeLastMessage: false`. Never present on live
+   *  `subscription.update` events — only on `subscription.list` rows. */
+  previewMessage?: PreviewMessage
 }
 
 /** Mirrors pkg/model.Subscription — the per-user record linking a user
@@ -172,6 +177,10 @@ export interface Participant {
   engName?: string
   chineseName?: string
   siteId?: string
+  /** Server-composed render-ready name (engName + chineseName + account
+   *  fallback; a bot sender's is its app name). Prefer it over the raw
+   *  fields. Mirrors model.Participant.DisplayName. */
+  displayName?: string
 }
 
 /** One reactor on a message reaction. Mirrors the wire `reactionUser`
@@ -214,6 +223,27 @@ export interface Attachment {
   /** Client-only: a local object URL for an optimistic just-sent image.
    *  Never arrives from the server; preferred as the <img> src when present. */
   localUrl?: string
+}
+
+/** Mirrors model.PreviewMessage — a room's most-recent eligible message,
+ *  resolved server-side at read time for room-list rendering. Eligible means
+ *  not soft-deleted and not a system message; the server walks back past an
+ *  ineligible tail, so the client never re-implements that rule.
+ *
+ *  Delivered on `subscription.list` rows (`SubscriptionRoom.previewMessage`)
+ *  and refreshed on `message_edited` / `message_deleted` events. */
+export interface PreviewMessage {
+  messageId: string
+  sender: Participant
+  /** The full message body; the client truncates for display. */
+  content: string
+  /** RFC3339. */
+  createdAt: string
+  attachments?: Attachment[]
+  mentions?: Participant[]
+  /** Always empty today — the server-side write path has not landed.
+   *  Declared for forward-compat; nothing reads it. */
+  visibleTo?: string
 }
 
 /** Cassandra's QuotedParentMessage shape — what gets embedded on a

--- a/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.jsx
+++ b/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.jsx
@@ -47,7 +47,7 @@ function RoomItem({ room, isSelected, onSelectRoom, onDragStartRoom, onDropOnRoo
             depend on whether this line has content, or the sidebar reflows
             as previews arrive during bootstrap. */}
         <div className="room-preview">
-          {room.preview && room.type !== 'dm' && (
+          {room.preview && room.type !== 'dm' && room.type !== 'botDM' && (
             <span className="room-preview-sender">{room.preview.senderName}: </span>
           )}
           {room.preview?.text}

--- a/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.jsx
+++ b/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.jsx
@@ -34,12 +34,25 @@ function RoomItem({ room, isSelected, onSelectRoom, onDragStartRoom, onDropOnRoo
       }}
     >
       <span className="room-drag-handle" aria-hidden="true">⋮⋮</span>
-      <span className="room-name">
-        {roomPrefix(room.type)}{roomDisplayName(room)}
-      </span>
-      {mentionBadge(room)}
-      <span className="room-meta">{room.userCount}</span>
-      {unread && <span className="room-badge-unread">{room.unreadCount}</span>}
+      <div className="room-item-body">
+        <div className="room-item-title">
+          <span className="room-name">
+            {roomPrefix(room.type)}{roomDisplayName(room)}
+          </span>
+          {mentionBadge(room)}
+          <span className="room-meta">{room.userCount}</span>
+          {unread && <span className="room-badge-unread">{room.unreadCount}</span>}
+        </div>
+        {/* Always rendered, even with no preview — the row's height must not
+            depend on whether this line has content, or the sidebar reflows
+            as previews arrive during bootstrap. */}
+        <div className="room-preview">
+          {room.preview && room.type !== 'dm' && (
+            <span className="room-preview-sender">{room.preview.senderName}: </span>
+          )}
+          {room.preview?.text}
+        </div>
+      </div>
     </div>
   )
 }

--- a/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx
+++ b/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx
@@ -144,14 +144,14 @@ describe('RoomList: message preview', () => {
   const preview = { messageId: 'm1', senderName: 'Alice Chen', text: 'hey are we still on' }
 
   it('renders the sender prefix and snippet in a channel row', () => {
-    useSidebarSections.mockReturnValue([section('chats', [summary('r1', { preview })])])
+    setup([section('chats', [summary('r1', { preview })])])
     render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
     expect(screen.getByText('Alice Chen:')).toBeInTheDocument()
     expect(screen.getByText('hey are we still on')).toBeInTheDocument()
   })
 
   it('omits the sender prefix in a DM row', () => {
-    useSidebarSections.mockReturnValue([
+    setup([
       section('chats', [summary('r1', { type: 'dm', preview })]),
     ])
     render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
@@ -160,7 +160,7 @@ describe('RoomList: message preview', () => {
   })
 
   it('renders the snippet line empty when the room has no preview', () => {
-    useSidebarSections.mockReturnValue([section('chats', [summary('r1')])])
+    setup([section('chats', [summary('r1')])])
     const { container } = render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
     const line = container.querySelector('.room-preview')
     expect(line).toBeInTheDocument()   // reserved, so the row height is stable
@@ -168,7 +168,7 @@ describe('RoomList: message preview', () => {
   })
 
   it('renders the attachment label a preview carries as its text', () => {
-    useSidebarSections.mockReturnValue([
+    setup([
       section('chats', [summary('r1', { preview: { ...preview, text: 'Photo' } })]),
     ])
     render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)

--- a/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx
+++ b/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx
@@ -159,12 +159,19 @@ describe('RoomList: message preview', () => {
     expect(screen.getByText('hey are we still on')).toBeInTheDocument()
   })
 
+  it('omits the sender prefix in a botDM row', () => {
+    setup([section('chats', [summary('r1', { type: 'botDM', preview })])])
+    render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
+    expect(screen.queryByText('Alice Chen:')).not.toBeInTheDocument()
+    expect(screen.getByText('hey are we still on')).toBeInTheDocument()
+  })
+
   it('renders the snippet line empty when the room has no preview', () => {
     setup([section('chats', [summary('r1')])])
     const { container } = render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
     const line = container.querySelector('.room-preview')
     expect(line).toBeInTheDocument()   // reserved, so the row height is stable
-    expect(line).toHaveTextContent('')
+    expect(line.textContent).toBe('')
   })
 
   it('renders the attachment label a preview carries as its text', () => {

--- a/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx
+++ b/chat-frontend/src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx
@@ -140,6 +140,42 @@ describe('RoomList: section controls', () => {
   })
 })
 
+describe('RoomList: message preview', () => {
+  const preview = { messageId: 'm1', senderName: 'Alice Chen', text: 'hey are we still on' }
+
+  it('renders the sender prefix and snippet in a channel row', () => {
+    useSidebarSections.mockReturnValue([section('chats', [summary('r1', { preview })])])
+    render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
+    expect(screen.getByText('Alice Chen:')).toBeInTheDocument()
+    expect(screen.getByText('hey are we still on')).toBeInTheDocument()
+  })
+
+  it('omits the sender prefix in a DM row', () => {
+    useSidebarSections.mockReturnValue([
+      section('chats', [summary('r1', { type: 'dm', preview })]),
+    ])
+    render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
+    expect(screen.queryByText('Alice Chen:')).not.toBeInTheDocument()
+    expect(screen.getByText('hey are we still on')).toBeInTheDocument()
+  })
+
+  it('renders the snippet line empty when the room has no preview', () => {
+    useSidebarSections.mockReturnValue([section('chats', [summary('r1')])])
+    const { container } = render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
+    const line = container.querySelector('.room-preview')
+    expect(line).toBeInTheDocument()   // reserved, so the row height is stable
+    expect(line).toHaveTextContent('')
+  })
+
+  it('renders the attachment label a preview carries as its text', () => {
+    useSidebarSections.mockReturnValue([
+      section('chats', [summary('r1', { preview: { ...preview, text: 'Photo' } })]),
+    ])
+    render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
+    expect(screen.getByText('Photo')).toBeInTheDocument()
+  })
+})
+
 describe('RoomList: drag to move', () => {
   it('dragging a chat and dropping on a custom section moves it there', () => {
     setup([

--- a/chat-frontend/src/components/MainApp/Sidebar/RoomList/style.css
+++ b/chat-frontend/src/components/MainApp/Sidebar/RoomList/style.css
@@ -53,6 +53,36 @@
   color: var(--text-primary);
 }
 
+.room-item-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.room-item-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+/* Always occupies a line, whether or not it has content — a room with no
+   preview must not render a shorter row. */
+.room-preview {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  line-height: 1.4;
+  min-height: 1.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.room-preview-sender {
+  color: var(--text-secondary);
+}
+
 .room-name {
   flex: 1;
   min-width: 0;

--- a/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.jsx
+++ b/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.jsx
@@ -7,6 +7,7 @@ import useHoverWithDelay from '@/hooks/useHoverWithDelay'
 import { useNats } from '@/context/NatsContext'
 import { useSubscription } from '@/context/RoomEventsContext'
 import { redactInaccessibleQuoteSnapshot } from '@/lib/redactQuote'
+import { messageSenderName } from '@/lib/participantName'
 import './style.css'
 
 function formatDateTime(dateStr) {
@@ -20,16 +21,6 @@ function formatDateTime(dateStr) {
   })
 }
 
-function senderName(msg) {
-  // userDisplayName is the server-composed render-ready name (engName +
-  // chineseName + account fallback); prefer it over the raw sender fields.
-  if (msg.userDisplayName) return msg.userDisplayName
-  if (msg.sender) {
-    return msg.sender.engName || msg.sender.account || msg.sender.userId || 'Unknown'
-  }
-  return msg.userAccount || msg.userId || 'Unknown'
-}
-
 function pinnedLabel(msg) {
   const by = msg.pinnedBy
   const byName = by?.engName || by?.account
@@ -37,7 +28,7 @@ function pinnedLabel(msg) {
 }
 
 function senderInitial(msg) {
-  const name = senderName(msg)
+  const name = messageSenderName(msg)
   return (name.charAt(0) || '?').toUpperCase()
 }
 
@@ -94,7 +85,7 @@ export default function MessageRow({
       )}
       <div className="message-row-body">
         <div className="message-header">
-          <span className="message-sender">{senderName(message)}</span>
+          <span className="message-sender">{messageSenderName(message)}</span>
           <span className="message-time">{formatDateTime(message.createdAt)}</span>
           {message.editedAt && <span className="message-edited"> (edited)</span>}
           {message.pinnedAt && (

--- a/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.test.jsx
+++ b/chat-frontend/src/components/shared/MessageList/MessageRow/MessageRow.test.jsx
@@ -107,6 +107,17 @@ describe('MessageRow', () => {
     fireEvent.click(screen.getByRole('button', { name: /quote/i }))
     expect(onReply).toHaveBeenCalledWith(msg)
   })
+
+  it('renders the nested sender displayName when userDisplayName is absent', () => {
+    const botMsg = {
+      id: 'm-bot',
+      content: 'deploy finished',
+      createdAt: '2026-05-13T10:42:00Z',
+      sender: { account: 'bot', displayName: 'Deploy Bot' },
+    }
+    render(<MessageRow message={botMsg} room={room} context="main" onThread={() => {}} onReply={() => {}} onJumpToMessage={() => {}} />)
+    expect(screen.getByText('Deploy Bot')).toBeInTheDocument()
+  })
 })
 
 describe('MessageRow — historySharedSince quote gate', () => {

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.test.jsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.test.jsx
@@ -86,6 +86,18 @@ function EventsProbe({ roomId }) {
   )
 }
 
+function PreviewProbe() {
+  const sections = useSidebarSections()
+  const rooms = sections.flatMap((s) => s.rooms)
+  return (
+    <div data-testid="previews">
+      {rooms
+        .map((r) => `${r.id}=${r.preview ? `${r.preview.senderName}|${r.preview.text}` : ''}`)
+        .join(';')}
+    </div>
+  )
+}
+
 describe('RoomEventsProvider', () => {
   beforeEach(() => vi.clearAllMocks())
 
@@ -208,6 +220,138 @@ describe('RoomEventsProvider', () => {
       expect(captured[i]).toBe(captured[0])
     }
     await waitFor(() => expect(nats.request).toHaveBeenCalled())
+  })
+
+  describe('sidebar previews', () => {
+    // A channel room whose subscription.list row carries a seeded preview.
+    const seededSub = () => ({
+      ...roomToSub({ id: 'g1', name: 'General', type: 'channel', siteId: 'site-A', userCount: 3 }),
+      room: {
+        userCount: 3,
+        lastMsgAt: '2026-08-14T10:00:00Z',
+        previewMessage: {
+          messageId: 'm1',
+          sender: { account: 'alice', displayName: 'Alice Chen' },
+          content: 'original body',
+          createdAt: '2026-08-14T10:00:00Z',
+        },
+      },
+    })
+
+    function setup() {
+      const request = vi.fn().mockImplementation((subject, payload) => {
+        if (subject.endsWith('.subscription.list') && payload?.type === 'rooms')
+          return Promise.resolve({ subscriptions: [seededSub()] })
+        return Promise.resolve({ subscriptions: [] })
+      })
+      const handlers = new Map()
+      const subscribe = vi.fn().mockImplementation((subject, cb) => {
+        handlers.set(subject, cb)
+        return { unsubscribe: vi.fn() }
+      })
+      return { nats: mockNats({ request, subscribe }), handlers, subscribe }
+    }
+
+    it('seeds the sidebar preview from subscription.list', async () => {
+      const { nats, subscribe } = setup()
+      render(wrap(<PreviewProbe />, nats))
+      await waitFor(() => expect(subscribe).toHaveBeenCalled())
+      await waitFor(() =>
+        expect(screen.getByTestId('previews').textContent).toBe('g1=Alice Chen|original body')
+      )
+    })
+
+    it('refreshes the preview from a message_edited event', async () => {
+      const { nats, handlers, subscribe } = setup()
+      render(wrap(<PreviewProbe />, nats))
+      await waitFor(() => expect(subscribe).toHaveBeenCalled())
+      await waitFor(() => expect(handlers.has('chat.room.g1.event')).toBe(true))
+
+      act(() => {
+        handlers.get('chat.room.g1.event')({
+          type: 'message_edited',
+          roomId: 'g1',
+          messageId: 'm1',
+          newContent: 'edited body',
+          editedAt: '2026-08-14T15:00:00Z',
+          previewMessage: {
+            messageId: 'm1',
+            sender: { account: 'alice', displayName: 'Alice Chen' },
+            content: 'edited body',
+            createdAt: '2026-08-14T15:00:00Z',
+          },
+        })
+      })
+      await waitFor(() =>
+        expect(screen.getByTestId('previews').textContent).toBe('g1=Alice Chen|edited body')
+      )
+    })
+
+    it('refreshes the preview for an encrypted edit carrying no plaintext body', async () => {
+      const { nats, handlers, subscribe } = setup()
+      render(wrap(<PreviewProbe />, nats))
+      await waitFor(() => expect(subscribe).toHaveBeenCalled())
+      await waitFor(() => expect(handlers.has('chat.room.g1.event')).toBe(true))
+
+      // No `newContent` — the mutation itself is dropped, but the sidebar
+      // snippet must still refresh from the plaintext previewMessage.
+      act(() => {
+        handlers.get('chat.room.g1.event')({
+          type: 'message_edited',
+          roomId: 'g1',
+          messageId: 'm1',
+          encryptedNewContent: { version: 1, nonce: 'n', ciphertext: 'c' },
+          editedAt: '2026-08-14T15:00:00Z',
+          previewMessage: {
+            messageId: 'm1',
+            sender: { account: 'alice', displayName: 'Alice Chen' },
+            content: 'server-side plaintext',
+            createdAt: '2026-08-14T15:00:00Z',
+          },
+        })
+      })
+      await waitFor(() =>
+        expect(screen.getByTestId('previews').textContent).toBe('g1=Alice Chen|server-side plaintext')
+      )
+    })
+
+    it('clears the preview when the displayed message is deleted and none follows', async () => {
+      const { nats, handlers, subscribe } = setup()
+      render(wrap(<PreviewProbe />, nats))
+      await waitFor(() => expect(subscribe).toHaveBeenCalled())
+      await waitFor(() => expect(handlers.has('chat.room.g1.event')).toBe(true))
+
+      act(() => {
+        handlers.get('chat.room.g1.event')({
+          type: 'message_deleted',
+          roomId: 'g1',
+          messageId: 'm1',
+          deletedBy: 'alice',
+          deletedAt: '2026-08-14T16:00:00Z',
+        })
+      })
+      await waitFor(() => expect(screen.getByTestId('previews').textContent).toBe('g1='))
+    })
+
+    it('keeps the preview when a different message is deleted', async () => {
+      const { nats, handlers, subscribe } = setup()
+      render(wrap(<PreviewProbe />, nats))
+      await waitFor(() => expect(subscribe).toHaveBeenCalled())
+      await waitFor(() => expect(handlers.has('chat.room.g1.event')).toBe(true))
+
+      act(() => {
+        handlers.get('chat.room.g1.event')({
+          type: 'message_deleted',
+          roomId: 'g1',
+          messageId: 'm-someone-else',
+          deletedBy: 'alice',
+          deletedAt: '2026-08-14T16:00:00Z',
+        })
+      })
+      // Give any dispatch a chance to land before asserting nothing changed.
+      await act(async () => { await Promise.resolve() })
+      expect(screen.getByTestId('previews').textContent).toBe('g1=Alice Chen|original body')
+    })
   })
 })
 

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
@@ -473,20 +473,22 @@ export interface SidebarSection {
  */
 export function useSidebarSections(): SidebarSection[] {
   const { state } = useRoomEventsInternal()
-  const { summaries, subscriptions, chatlist } = state
+  const { summaries, subscriptions, chatlist, previews } = state
   return useMemo(() => {
     const enrich = (room: RoomSummary): RoomSummary => {
       const sub = subscriptions[room.id]
-      if (!sub) return room
+      const preview = previews[room.id]
+      if (!sub && !preview) return room
       return {
         ...room,
-        subscriptionName: sub.name ?? room.subscriptionName,
-        hrInfo: sub.hrInfo ?? room.hrInfo,
+        subscriptionName: sub?.name ?? room.subscriptionName,
+        hrInfo: sub?.hrInfo ?? room.hrInfo,
+        preview,
       }
     }
     const sections = deriveSidebarSections(summaries, subscriptions, chatlist) as SidebarSection[]
     return sections.map((s) => ({ ...s, rooms: s.rooms.map(enrich) }))
-  }, [summaries, subscriptions, chatlist])
+  }, [summaries, subscriptions, chatlist, previews])
 }
 
 /** Raw overlay section order (the full list the backend stores — built-ins +

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
@@ -68,6 +68,25 @@ interface RoomPreview {
   senderName: string
   /** Single-line, flattened, capped at PREVIEW_MAX_LENGTH. */
   text: string
+  /** RFC3339, from the previewed message's createdAt. Powers
+   *  ROOM_PREVIEW_UPDATED's recency guard: broadcast-worker processes
+   *  canonical messages concurrently, so an edit/delete's server-resolved
+   *  preview can arrive after a genuinely newer message's live preview —
+   *  a strictly older incoming createdAt is rejected rather than regressing
+   *  the sidebar. Optional because older code paths / test fixtures may not
+   *  set it; a missing timestamp on either side of the comparison is
+   *  treated as "accept the write". */
+  createdAt?: string
+  /** True when this preview was built from a live message the client
+   *  couldn't decrypt — the reducer's "[encrypted message]" placeholder
+   *  branch. Guards ROOM_PREVIEW_UPDATED from overwriting the placeholder
+   *  with the server's plaintext previewMessage body for the SAME message
+   *  (history-service / broadcast-worker relay that body unencrypted). A
+   *  wire preview for a DIFFERENT, newer message still overwrites normally.
+   *  Known residual: after a reload there's no placeholder in state to
+   *  compare against, so bootstrap still shows the server's plaintext —
+   *  fully closing that gap needs a backend change, not a client one. */
+  encrypted?: boolean
 }
 
 /** Sidebar summary — derived from `model.Room` + the user's

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
@@ -58,6 +58,18 @@ interface RoomBufferState {
  *  returned page of exactly this size means older messages may follow. */
 const HISTORY_PAGE_SIZE = 50
 
+/** One room's stored sidebar preview. Flattened and name-resolved at write
+ *  time so the render layer never branches on whether it came from a wire
+ *  PreviewMessage or a live Message. */
+interface RoomPreview {
+  /** The previewed message's id — guards the delete-clears rule in the
+   *  reducer's ROOM_PREVIEW_UPDATED case. */
+  messageId: string
+  senderName: string
+  /** Single-line, flattened, capped at PREVIEW_MAX_LENGTH. */
+  text: string
+}
+
 /** Sidebar summary — derived from `model.Room` + the user's
  *  Subscription. Only the fields the sidebar / chat header read. */
 interface RoomSummary {
@@ -75,6 +87,10 @@ interface RoomSummary {
    *  for DM rooms whose subscription carried it. Plain channels stay
    *  undefined here. */
   hrInfo?: SubscriptionHRInfo
+  /** Joined in by useSidebarSections from state.previews. Undefined when the
+   *  room has no preview — the row still renders at full height with a blank
+   *  snippet line. */
+  preview?: RoomPreview
 }
 
 /** Top-level state shape returned by `roomEventsReducer`. */
@@ -96,6 +112,11 @@ interface RoomEventsState {
    *  so consumers reading the map for either channel or DM rooms see
    *  hrInfo as optional without narrowing. */
   subscriptions: Record<string, DMSubscription>
+  /** Keyed by roomId. Absent key = no preview to show. Deliberately NOT a
+   *  field on RoomSummary: summaries are rebuilt from `Room` records, which
+   *  mirror pkg/model.Room — and the backend hangs previewMessage off
+   *  SubscriptionRoom instead, so a summary field would break the mirror. */
+  previews: Record<string, RoomPreview>
   /** Chatlist section-definition overlay (names, order, sortMode). Seeded by
    *  CHATLIST_LOADED, replaced by CHATLIST_UPDATED (LWW). Membership rides the
    *  subscriptions; this is O(sections). */
@@ -530,4 +551,4 @@ export function useSubscription(roomId: string | null | undefined): DMSubscripti
   return roomId ? state.subscriptions[roomId] : undefined
 }
 
-export type { RoomEventsState, RoomSummary, RoomBufferState, RoomEventsContextValue }
+export type { RoomEventsState, RoomSummary, RoomPreview, RoomBufferState, RoomEventsContextValue }

--- a/chat-frontend/src/context/RoomEventsContext/reducer.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.js
@@ -1,7 +1,8 @@
 import { appendBounded, mergeById, MAX_CACHED } from '@/lib/messageBuffer'
 import { defaultChatlistState, sortByLastMsgDesc } from '@/lib/chatlist'
-import { previewSnippet, previewText } from '@/lib/previewText'
+import { previewSnippet } from '@/lib/previewText'
 import { participantDisplayName, messageSenderName } from '@/lib/participantName'
+import { isSystemMessageType } from '@/lib/messageType'
 
 export { MAX_CACHED }
 
@@ -134,6 +135,17 @@ function toSummary(room) {
 // empty sentinel.
 function previewFromMessage(msg, fallbackMentions) {
   if (!msg || !msg.id) return null
+  // Fix 1: a system message (room_renamed, members_added, …) is published to
+  // MESSAGES-CANONICAL with non-empty content and fans out as an ordinary
+  // new_message event, but it must never become the room's sidebar snippet —
+  // history-service's previewMessage resolution already excludes it, so
+  // treating it as eligible here makes a reload flip the snippet back.
+  // isSystemMessageType is a set-membership test, NOT `type !== ''`: the
+  // client-settable "important" type is deliberately absent from that set
+  // and previews like a normal message. sysMsgData is checked belt-and-
+  // braces because that's the field MessageList actually keys off to route
+  // a message to the SystemMessage renderer.
+  if (isSystemMessageType(msg.type) || msg.sysMsgData != null) return null
   return {
     messageId: msg.id,
     senderName: messageSenderName(msg),
@@ -141,13 +153,25 @@ function previewFromMessage(msg, fallbackMentions) {
     // Message.Mentions. Without the fallback a live preview shows the raw
     // @account while the same message shows @Display Name after a reload.
     text: previewSnippet(msg.content, msg.mentions ?? fallbackMentions, msg.attachments),
+    createdAt: msg.createdAt,
+    // Fix 3: marks a preview built from the "[encrypted message]" placeholder
+    // (see the MESSAGE_RECEIVED encrypted-message branch below) so
+    // ROOM_PREVIEW_UPDATED can avoid clobbering it with the server's
+    // unencrypted previewMessage body for the same message.
+    ...(msg.encrypted ? { encrypted: true } : {}),
   }
 }
 
-// Two stored previews are interchangeable when all three rendered fields match.
-// Used to keep the previews reference stable on a same-content write (e.g. the
-// server echo of a message this client already stored optimistically) — a fresh
-// object would invalidate useSidebarSections' memo for every room in the sidebar.
+// Two stored previews are interchangeable when all three RENDERED fields
+// match (messageId/senderName/text — what RoomList actually displays). Used
+// to keep the previews reference stable on a same-content write (e.g. the
+// server echo of a message this client already stored optimistically) — a
+// fresh object would invalidate useSidebarSections' memo for every room in
+// the sidebar. createdAt is deliberately NOT part of this comparison: it's
+// metadata for the ROOM_PREVIEW_UPDATED recency guard, not something the UI
+// renders, and two writes sharing the same messageId always share the same
+// createdAt (it's immutable per message) so including it could never change
+// the outcome — it would just be a redundant field-by-field check.
 function samePreview(a, b) {
   return !!a && !!b && a.messageId === b.messageId && a.senderName === b.senderName && a.text === b.text
 }
@@ -160,7 +184,21 @@ function previewFromWire(previewMessage) {
     messageId: previewMessage.messageId,
     senderName: participantDisplayName(previewMessage.sender),
     text: previewSnippet(previewMessage.content, previewMessage.mentions, previewMessage.attachments),
+    createdAt: previewMessage.createdAt,
   }
+}
+
+// Fix 7: true only when `nextCreatedAt` is a STRICTLY older, parseable
+// timestamp than `curCreatedAt`. Tolerant by design — a missing or
+// unparseable timestamp on either side is treated as "accept the write"
+// rather than dropping a legitimate update just because older stored data
+// (or a malformed wire payload) lacks a comparable createdAt.
+function isOlderPreview(nextCreatedAt, curCreatedAt) {
+  if (!nextCreatedAt || !curCreatedAt) return false
+  const nextT = Date.parse(nextCreatedAt)
+  const curT = Date.parse(curCreatedAt)
+  if (Number.isNaN(nextT) || Number.isNaN(curT)) return false
+  return nextT < curT
 }
 
 /**
@@ -506,7 +544,13 @@ export function roomEventsReducer(state, action) {
           prev.messages.some((m) => m.id === msg.id) ||
           prev.pendingLiveMessages.some((m) => m.id === msg.id)
         ) {
-          return state
+          // Fix 2: previews is computed once above and applied at every
+          // return point in this action — this duplicate-message guard used
+          // to skip that, discarding an optimistic preview's upgrade from
+          // the server echo whenever the room sat in historical buffer mode.
+          // Only allocate when the write actually changed something, so a
+          // true no-op still returns the identical state reference.
+          return previews === state.previews ? state : { ...state, previews }
         }
         const pendingLiveMessages = [...prev.pendingLiveMessages, msg]
         const nextRoomState = {
@@ -833,10 +877,21 @@ export function roomEventsReducer(state, action) {
       // action carries no mentions, so mention tokens flatten literally
       // here; the server's message_edited event follows with the
       // authoritative preview a moment later.
+      // Fix 4: use previewSnippet (not previewText) so an edit that blanks
+      // the body falls back to the attachment label instead of leaving a
+      // dangling "Sender: " row — attachments aren't on the action (edits
+      // never touch them), so read them off the buffered message being
+      // edited (updatedMsg, which carries them forward from prev.messages[idx]).
       const cur = state.previews[action.roomId]
       const previews =
         cur && cur.messageId === action.messageId
-          ? { ...state.previews, [action.roomId]: { ...cur, text: previewText(action.content) } }
+          ? {
+              ...state.previews,
+              [action.roomId]: {
+                ...cur,
+                text: previewSnippet(action.content, updatedMsg.mentions, updatedMsg.attachments),
+              },
+            }
           : state.previews
       return {
         ...state,
@@ -911,7 +966,28 @@ export function roomEventsReducer(state, action) {
       const { roomId, previewMessage, deletedMessageId } = action
       if (!roomId) return state
       const next = previewFromWire(previewMessage)
-      if (next) return { ...state, previews: { ...state.previews, [roomId]: next } }
+      if (next) {
+        const cur = state.previews[roomId]
+        // Fix 3: the live path already knows this message can't be decrypted
+        // and stored the "[encrypted message]" placeholder. history-service /
+        // broadcast-worker relay previewMessage.content unencrypted, so a
+        // wire preview for the SAME message would flip the row back to
+        // plaintext the timeline is deliberately refusing to render. A wire
+        // preview for a DIFFERENT (newer) message still overwrites normally.
+        // Known residual: after a reload there's no placeholder in state to
+        // compare against (BUCKETS_LOADED seeds straight from the wire), so
+        // bootstrap still shows the server's plaintext — fully closing that
+        // needs a backend change (withholding plaintext for encrypted rooms
+        // server-side), not something this guard can fix client-side.
+        if (cur?.encrypted && cur.messageId === next.messageId) return state
+        // Fix 7: broadcast-worker processes canonical messages concurrently,
+        // so an edit/delete's server-resolved preview can be computed before
+        // a genuinely newer message and still arrive after it — reject only
+        // a STRICTLY older write; missing/unparseable timestamps are
+        // accepted rather than dropped (see isOlderPreview).
+        if (isOlderPreview(next.createdAt, cur?.createdAt)) return state
+        return { ...state, previews: { ...state.previews, [roomId]: next } }
+      }
       // No preview on the event. For a delete that means nothing eligible is
       // left — but only when the deleted message is the one on display. Any
       // other id is contradictory input (the server would have echoed the

--- a/chat-frontend/src/context/RoomEventsContext/reducer.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.js
@@ -882,6 +882,24 @@ export function roomEventsReducer(state, action) {
         },
       }
     }
+    case 'ROOM_PREVIEW_UPDATED': {
+      // The room's refreshed preview after an edit or delete, computed
+      // server-side. Its own action rather than a field on MESSAGE_EDITED /
+      // MESSAGE_DELETED because both of those bail when the room has no
+      // message buffer — which is the normal case for a sidebar row.
+      const { roomId, previewMessage, deletedMessageId } = action
+      if (!roomId) return state
+      const next = previewFromWire(previewMessage)
+      if (next) return { ...state, previews: { ...state.previews, [roomId]: next } }
+      // No preview on the event. For a delete that means nothing eligible is
+      // left — but only when the deleted message is the one on display. Any
+      // other id is contradictory input (the server would have echoed the
+      // unchanged preview), so leave what's there.
+      const cur = state.previews[roomId]
+      if (!deletedMessageId || !cur || cur.messageId !== deletedMessageId) return state
+      const { [roomId]: _cleared, ...rest } = state.previews
+      return { ...state, previews: rest }
+    }
     case 'MESSAGE_REACTED': {
       // Live `message_reacted` toggle. Mirrors MESSAGE_EDITED's dual-buffer
       // patch so a reaction arriving while in historical mode isn't lost when

--- a/chat-frontend/src/context/RoomEventsContext/reducer.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.js
@@ -132,12 +132,15 @@ function toSummary(room) {
 // Build a stored preview from a live message. Returns null when there is
 // nothing to store, so callers leave the map untouched rather than writing an
 // empty sentinel.
-function previewFromMessage(msg) {
+function previewFromMessage(msg, fallbackMentions) {
   if (!msg || !msg.id) return null
   return {
     messageId: msg.id,
     senderName: messageSenderName(msg),
-    text: previewSnippet(msg.content, msg.mentions, msg.attachments),
+    // Mentions ride the event, not the message — the gatekeeper never populates
+    // Message.Mentions. Without the fallback a live preview shows the raw
+    // @account while the same message shows @Display Name after a reload.
+    text: previewSnippet(msg.content, msg.mentions ?? fallbackMentions, msg.attachments),
   }
 }
 
@@ -332,13 +335,17 @@ export function roomEventsReducer(state, action) {
           subs[s.id] ? mergeSubscriptionIntoSummary(s, subs[s.id]) : s
         )
       }
-      // Seed from the room metadata user-service embeds on each list row.
-      // Starts from the existing map so the partial-update path (no rooms
-      // supplied) doesn't wipe previews already in hand.
-      const previews = { ...state.previews }
+      // Seed only rooms with no preview yet. A live message can land before
+      // fetchSidebarBuckets resolves (the DM subscription goes live first), and
+      // that message is NEWER than this list snapshot — overwriting it would show
+      // an older message in the sidebar than the room itself displays.
+      let previews = state.previews
       for (const [roomId, sub] of Object.entries(subs)) {
+        if (previews[roomId]) continue
         const preview = previewFromWire(sub?.room?.previewMessage)
-        if (preview) previews[roomId] = preview
+        if (!preview) continue
+        if (previews === state.previews) previews = { ...state.previews }
+        previews[roomId] = preview
       }
       return {
         ...state,
@@ -480,7 +487,14 @@ export function roomEventsReducer(state, action) {
       // Thread replies returned above, so anything reaching here belongs in
       // the room timeline and is a preview candidate. Computed once and
       // applied at every return point below.
-      const nextPreview = previewFromMessage(msg)
+      //
+      // Note: excluding EVERY thread reply this way is broader than the
+      // server's rule — the server excludes only hidden (tshow: false)
+      // replies, and a tshow: true reply can legitimately be a room's
+      // preview. That's fine only because this frontend has no tshow
+      // support at all, so no thread reply ever reaches the room timeline
+      // here. Anyone adding tshow must revisit this.
+      const nextPreview = previewFromMessage(msg, evt.mentions)
       const previews =
         !nextPreview || samePreview(state.previews[roomId], nextPreview)
           ? state.previews
@@ -788,8 +802,15 @@ export function roomEventsReducer(state, action) {
       if (prev.messages.some((m) => m.id === msg.id)) return state
       const messages = appendBounded(prev.messages, msg)
       // A thread reply doesn't appear in the room timeline, so it isn't the
-      // room's preview either — matching the server, which omits
-      // previewMessage for hidden thread replies.
+      // room's preview either. This excludes EVERY thread reply, which is
+      // broader than the server's rule — the server excludes only hidden
+      // (tshow: false) replies; a tshow: true reply can legitimately be a
+      // room's preview. Correct only because this frontend has no tshow
+      // support: no thread reply ever appears in the room timeline here.
+      // Anyone adding tshow must revisit this.
+      // A local optimistic send has no event, so there's no fallback mentions
+      // source — msg.mentions is always undefined for these and the raw
+      // @account renders until the server echo (MESSAGE_RECEIVED) arrives.
       const nextPreview = msg.threadParentMessageId ? null : previewFromMessage(msg)
       const previews =
         !nextPreview || samePreview(state.previews[roomId], nextPreview)

--- a/chat-frontend/src/context/RoomEventsContext/reducer.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.js
@@ -141,6 +141,14 @@ function previewFromMessage(msg) {
   }
 }
 
+// Two stored previews are interchangeable when all three rendered fields match.
+// Used to keep the previews reference stable on a same-content write (e.g. the
+// server echo of a message this client already stored optimistically) — a fresh
+// object would invalidate useSidebarSections' memo for every room in the sidebar.
+function samePreview(a, b) {
+  return !!a && !!b && a.messageId === b.messageId && a.senderName === b.senderName && a.text === b.text
+}
+
 // Build a stored preview from a wire PreviewMessage (subscription.list rows
 // and the refreshed preview on edit/delete events).
 function previewFromWire(previewMessage) {
@@ -473,9 +481,10 @@ export function roomEventsReducer(state, action) {
       // the room timeline and is a preview candidate. Computed once and
       // applied at every return point below.
       const nextPreview = previewFromMessage(msg)
-      const previews = nextPreview
-        ? { ...state.previews, [roomId]: nextPreview }
-        : state.previews
+      const previews =
+        !nextPreview || samePreview(state.previews[roomId], nextPreview)
+          ? state.previews
+          : { ...state.previews, [roomId]: nextPreview }
       const prev = state.roomState[roomId] ?? emptyRoomState()
       const isActive = state.activeRoomId === roomId
       if (prev.bufferMode === BUFFER_MODE.HISTORICAL) {
@@ -782,9 +791,10 @@ export function roomEventsReducer(state, action) {
       // room's preview either — matching the server, which omits
       // previewMessage for hidden thread replies.
       const nextPreview = msg.threadParentMessageId ? null : previewFromMessage(msg)
-      const previews = nextPreview
-        ? { ...state.previews, [roomId]: nextPreview }
-        : state.previews
+      const previews =
+        !nextPreview || samePreview(state.previews[roomId], nextPreview)
+          ? state.previews
+          : { ...state.previews, [roomId]: nextPreview }
       return {
         ...state,
         roomState: { ...state.roomState, [roomId]: { ...prev, messages } },

--- a/chat-frontend/src/context/RoomEventsContext/reducer.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.js
@@ -1,5 +1,7 @@
 import { appendBounded, mergeById, MAX_CACHED } from '@/lib/messageBuffer'
 import { defaultChatlistState, sortByLastMsgDesc } from '@/lib/chatlist'
+import { previewSnippet, previewText } from '@/lib/previewText'
+import { participantDisplayName, messageSenderName } from '@/lib/participantName'
 
 export { MAX_CACHED }
 
@@ -85,6 +87,16 @@ export const initialState = {
    */
   subscriptions: {},
   /**
+   * Per-roomId sidebar preview: the room's most recent eligible message,
+   * flattened to a single line at write time. An absent key means there is
+   * nothing to show — the row still renders at full height with a blank
+   * snippet line (the row's height is a CSS property, not a consequence of
+   * this map).
+   *
+   * Shape: { [roomId]: { messageId, senderName, text } }
+   */
+  previews: {},
+  /**
    * The per-user chatlist section-definition overlay (ChatlistState) — the
    * section names, display order, and sortMode. Membership is NOT here; it
    * rides each subscription's sectionId/sectionOrder. Seeded by
@@ -114,6 +126,29 @@ function toSummary(room) {
     unreadCount: 0,
     hasMention: false,
     mentionAll: false,
+  }
+}
+
+// Build a stored preview from a live message. Returns null when there is
+// nothing to store, so callers leave the map untouched rather than writing an
+// empty sentinel.
+function previewFromMessage(msg) {
+  if (!msg || !msg.id) return null
+  return {
+    messageId: msg.id,
+    senderName: messageSenderName(msg),
+    text: previewSnippet(msg.content, msg.mentions, msg.attachments),
+  }
+}
+
+// Build a stored preview from a wire PreviewMessage (subscription.list rows
+// and the refreshed preview on edit/delete events).
+function previewFromWire(previewMessage) {
+  if (!previewMessage || !previewMessage.messageId) return null
+  return {
+    messageId: previewMessage.messageId,
+    senderName: participantDisplayName(previewMessage.sender),
+    text: previewSnippet(previewMessage.content, previewMessage.mentions, previewMessage.attachments),
   }
 }
 
@@ -252,6 +287,11 @@ export function roomEventsReducer(state, action) {
         const { [action.roomId]: _drop, ...restSubs } = subscriptions
         subscriptions = restSubs
       }
+      let previews = state.previews
+      if (previews[action.roomId]) {
+        const { [action.roomId]: _dropPreview, ...restPreviews } = previews
+        previews = restPreviews
+      }
       return {
         ...state,
         summaries,
@@ -260,6 +300,7 @@ export function roomEventsReducer(state, action) {
         appIds,
         channelDmIds,
         subscriptions,
+        previews,
       }
     }
     case 'BUCKETS_LOADED': {
@@ -283,6 +324,14 @@ export function roomEventsReducer(state, action) {
           subs[s.id] ? mergeSubscriptionIntoSummary(s, subs[s.id]) : s
         )
       }
+      // Seed from the room metadata user-service embeds on each list row.
+      // Starts from the existing map so the partial-update path (no rooms
+      // supplied) doesn't wipe previews already in hand.
+      const previews = { ...state.previews }
+      for (const [roomId, sub] of Object.entries(subs)) {
+        const preview = previewFromWire(sub?.room?.previewMessage)
+        if (preview) previews[roomId] = preview
+      }
       return {
         ...state,
         summaries,
@@ -290,6 +339,7 @@ export function roomEventsReducer(state, action) {
         appIds: new Set(action.appIds),
         channelDmIds: new Set(action.channelDmIds),
         subscriptions: subs,
+        previews,
       }
     }
     case 'SUBSCRIPTION_UPSERTED': {
@@ -419,6 +469,13 @@ export function roomEventsReducer(state, action) {
         }
       }
       const roomId = evt.roomId
+      // Thread replies returned above, so anything reaching here belongs in
+      // the room timeline and is a preview candidate. Computed once and
+      // applied at every return point below.
+      const nextPreview = previewFromMessage(msg)
+      const previews = nextPreview
+        ? { ...state.previews, [roomId]: nextPreview }
+        : state.previews
       const prev = state.roomState[roomId] ?? emptyRoomState()
       const isActive = state.activeRoomId === roomId
       if (prev.bufferMode === BUFFER_MODE.HISTORICAL) {
@@ -462,6 +519,7 @@ export function roomEventsReducer(state, action) {
           summaries,
           roomState: { ...state.roomState, [roomId]: nextRoomState },
           msgRecvSeq: state.msgRecvSeq + 1,
+          previews,
         }
       }
       // Replace optimistic createdAt (client clock) with server's — keeping
@@ -480,6 +538,7 @@ export function roomEventsReducer(state, action) {
         return {
           ...state,
           roomState: { ...state.roomState, [roomId]: { ...prev, messages: mergedMessages } },
+          previews,
         }
       }
       const messages = appendBounded(prev.messages, msg)
@@ -513,6 +572,7 @@ export function roomEventsReducer(state, action) {
         summaries,
         roomState: { ...state.roomState, [roomId]: nextRoomState },
         msgRecvSeq: state.msgRecvSeq + 1,
+        previews,
       }
     }
     case 'HISTORY_LOADED': {
@@ -718,9 +778,17 @@ export function roomEventsReducer(state, action) {
       const prev = state.roomState[roomId] ?? emptyRoomState()
       if (prev.messages.some((m) => m.id === msg.id)) return state
       const messages = appendBounded(prev.messages, msg)
+      // A thread reply doesn't appear in the room timeline, so it isn't the
+      // room's preview either — matching the server, which omits
+      // previewMessage for hidden thread replies.
+      const nextPreview = msg.threadParentMessageId ? null : previewFromMessage(msg)
+      const previews = nextPreview
+        ? { ...state.previews, [roomId]: nextPreview }
+        : state.previews
       return {
         ...state,
         roomState: { ...state.roomState, [roomId]: { ...prev, messages } },
+        previews,
       }
     }
     case 'MESSAGE_EDITED_LOCAL': {
@@ -730,9 +798,19 @@ export function roomEventsReducer(state, action) {
       if (idx < 0) return state
       const updatedMsg = { ...prev.messages[idx], content: action.content, editedAt: action.editedAt }
       const messages = [...prev.messages.slice(0, idx), updatedMsg, ...prev.messages.slice(idx + 1)]
+      // Only the message currently on display affects the preview. The
+      // action carries no mentions, so mention tokens flatten literally
+      // here; the server's message_edited event follows with the
+      // authoritative preview a moment later.
+      const cur = state.previews[action.roomId]
+      const previews =
+        cur && cur.messageId === action.messageId
+          ? { ...state.previews, [action.roomId]: { ...cur, text: previewText(action.content) } }
+          : state.previews
       return {
         ...state,
         roomState: { ...state.roomState, [action.roomId]: { ...prev, messages } },
+        previews,
       }
     }
     case 'MESSAGE_DELETED_LOCAL': {
@@ -742,6 +820,9 @@ export function roomEventsReducer(state, action) {
       if (idx < 0) return state
       const updatedMsg = { ...prev.messages[idx], deleted: true }
       const messages = [...prev.messages.slice(0, idx), updatedMsg, ...prev.messages.slice(idx + 1)]
+      // Preview deliberately untouched: the client can't reproduce the
+      // server's walk-back to an earlier eligible message. The authoritative
+      // message_deleted event corrects it.
       return {
         ...state,
         roomState: { ...state.roomState, [action.roomId]: { ...prev, messages } },

--- a/chat-frontend/src/context/RoomEventsContext/reducer.test.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.test.js
@@ -1966,5 +1966,28 @@ describe('roomEventsReducer previews', () => {
       const state = seeded()
       expect(roomEventsReducer(state, { type: 'ROOM_PREVIEW_UPDATED' })).toBe(state)
     })
+
+    it('leaves state untouched when a delete arrives for a room with no stored preview', () => {
+      // The `!cur` guard must short-circuit before cur.messageId is read. Nothing
+      // else in the suite covers deletedMessageId present + no stored entry, and
+      // this branch is the clear rule's core guarantee.
+      const state = { ...initialState, previews: {} }
+      const next = roomEventsReducer(state, {
+        type: 'ROOM_PREVIEW_UPDATED', roomId: 'r-none', deletedMessageId: 'm1',
+      })
+      expect(next).toBe(state)
+    })
+
+    it('leaves other rooms untouched when a delete arrives for a room with no stored preview', () => {
+      const state = {
+        ...initialState,
+        previews: { 'r-other': { messageId: 'm1', senderName: 'Alice Chen', text: 'kept' } },
+      }
+      const next = roomEventsReducer(state, {
+        type: 'ROOM_PREVIEW_UPDATED', roomId: 'r-none', deletedMessageId: 'm1',
+      })
+      expect(next).toBe(state)
+      expect(next.previews['r-other'].text).toBe('kept')
+    })
   })
 })

--- a/chat-frontend/src/context/RoomEventsContext/reducer.test.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.test.js
@@ -1908,4 +1908,63 @@ describe('roomEventsReducer previews', () => {
     const seeded = { ...initialState, previews: { r1: { messageId: 'm8', senderName: 'A', text: 'x' } } }
     expect(roomEventsReducer(seeded, { type: 'RESET' }).previews).toEqual({})
   })
+
+  describe('ROOM_PREVIEW_UPDATED', () => {
+    const seeded = () => ({
+      ...initialState,
+      previews: { r1: { messageId: 'm1', senderName: 'Alice Chen', text: 'old body' } },
+    })
+
+    it('overwrites from the event previewMessage', () => {
+      const next = roomEventsReducer(seeded(), {
+        type: 'ROOM_PREVIEW_UPDATED',
+        roomId: 'r1',
+        previewMessage: {
+          messageId: 'm2',
+          sender: { account: 'bob', displayName: 'Bob Lin' },
+          content: 'edited body',
+          createdAt: '2026-08-14T15:00:00Z',
+        },
+      })
+      expect(next.previews.r1).toEqual({ messageId: 'm2', senderName: 'Bob Lin', text: 'edited body' })
+    })
+
+    it('updates a room that has no message buffer', () => {
+      const next = roomEventsReducer(initialState, {
+        type: 'ROOM_PREVIEW_UPDATED',
+        roomId: 'r-unopened',
+        previewMessage: {
+          messageId: 'm3',
+          sender: { account: 'bob', displayName: 'Bob Lin' },
+          content: 'from a room I never opened',
+          createdAt: '2026-08-14T15:00:00Z',
+        },
+      })
+      expect(next.previews['r-unopened'].text).toBe('from a room I never opened')
+    })
+
+    it('clears when the deleted message is the one on display and no preview follows', () => {
+      const next = roomEventsReducer(seeded(), {
+        type: 'ROOM_PREVIEW_UPDATED', roomId: 'r1', deletedMessageId: 'm1',
+      })
+      expect(next.previews.r1).toBeUndefined()
+    })
+
+    it('does NOT clear when the deleted message is a different one', () => {
+      const next = roomEventsReducer(seeded(), {
+        type: 'ROOM_PREVIEW_UPDATED', roomId: 'r1', deletedMessageId: 'm-other',
+      })
+      expect(next.previews.r1.text).toBe('old body')
+    })
+
+    it('leaves the preview alone when neither a previewMessage nor a deletedMessageId is given', () => {
+      const next = roomEventsReducer(seeded(), { type: 'ROOM_PREVIEW_UPDATED', roomId: 'r1' })
+      expect(next.previews.r1.text).toBe('old body')
+    })
+
+    it('ignores an action with no roomId', () => {
+      const state = seeded()
+      expect(roomEventsReducer(state, { type: 'ROOM_PREVIEW_UPDATED' })).toBe(state)
+    })
+  })
 })

--- a/chat-frontend/src/context/RoomEventsContext/reducer.test.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.test.js
@@ -1776,6 +1776,46 @@ describe('roomEventsReducer previews', () => {
     expect(next.previews.r1).toBeUndefined()
   })
 
+  it('BUCKETS_LOADED does not clobber a fresher live preview already in state', () => {
+    // Regression: the DM subscription goes live BEFORE fetchSidebarBuckets
+    // resolves, so a live message can land and be written to previews via
+    // MESSAGE_RECEIVED before this dispatch fires. That live entry is NEWER
+    // than the list snapshot's previewMessage and must survive.
+    const seeded = {
+      ...initialState,
+      previews: { r1: { messageId: 'm-live', senderName: 'Live Sender', text: 'just arrived' } },
+    }
+    const next = roomEventsReducer(seeded, {
+      type: 'BUCKETS_LOADED',
+      favoriteIds: [], appIds: [], channelDmIds: ['r1'],
+      rooms: [{ id: 'r1', name: 'General', type: 'channel', siteId: 'site-A', userCount: 2 }],
+      subscriptions: { r1: { roomId: 'r1', name: 'General', room: { previewMessage: wirePreview({ messageId: 'm-stale' }) } } },
+    })
+    expect(next.previews.r1).toEqual({ messageId: 'm-live', senderName: 'Live Sender', text: 'just arrived' })
+  })
+
+  it('BUCKETS_LOADED still seeds a room with no prior preview alongside one that is guarded', () => {
+    const seeded = {
+      ...initialState,
+      previews: { r1: { messageId: 'm-live', senderName: 'Live Sender', text: 'just arrived' } },
+    }
+    const next = roomEventsReducer(seeded, {
+      type: 'BUCKETS_LOADED',
+      favoriteIds: [], appIds: [], channelDmIds: ['r1', 'r2'],
+      rooms: [
+        { id: 'r1', name: 'General', type: 'channel', siteId: 'site-A', userCount: 2 },
+        { id: 'r2', name: 'Other', type: 'channel', siteId: 'site-A', userCount: 2 },
+      ],
+      subscriptions: {
+        r1: { roomId: 'r1', name: 'General', room: { previewMessage: wirePreview({ messageId: 'm-stale' }) } },
+        r2: { roomId: 'r2', name: 'Other', room: { previewMessage: wirePreview({ messageId: 'm-new-r2' }) } },
+      },
+    })
+    // r1's live entry survives; r2 (no prior entry) is seeded normally.
+    expect(next.previews.r1.messageId).toBe('m-live')
+    expect(next.previews.r2.messageId).toBe('m-new-r2')
+  })
+
   it('MESSAGE_RECEIVED overwrites the preview for a room with no message buffer', () => {
     const next = roomEventsReducer(initialState, {
       type: 'MESSAGE_RECEIVED',
@@ -1802,11 +1842,14 @@ describe('roomEventsReducer previews', () => {
   })
 
   it('MESSAGE_RECEIVED keeps the previews reference stable on a content-identical write', () => {
-    // Mirrors the server echoing back a message this client already stored
-    // optimistically (the existingIdx >= 0 branch): the incoming message
-    // renders to the exact same stored preview already in state, so the
-    // previews map must not be reallocated — a fresh object here would
-    // invalidate useSidebarSections' memo for every room in the sidebar.
+    // No roomState.r1 is seeded here, so this exercises the NEW-message
+    // branch (existingIdx < 0), not the existingIdx >= 0 server-echo branch.
+    // previews is computed once and shared across every return point though,
+    // so the reference-stability guarantee is exercised either way: the
+    // incoming message renders to the exact same stored preview already in
+    // state, so the previews map must not be reallocated — a fresh object
+    // here would invalidate useSidebarSections' memo for every room in the
+    // sidebar.
     const seeded = {
       ...initialState,
       previews: { r1: { messageId: 'm2', senderName: 'Bob Lin', text: 'newest' } },
@@ -1819,6 +1862,27 @@ describe('roomEventsReducer previews', () => {
       },
     })
     expect(next.previews).toBe(seeded.previews)
+  })
+
+  it('MESSAGE_RECEIVED resolves mentions from the event when the message carries none', () => {
+    // Message.Mentions is never populated by the gatekeeper — mentions ride
+    // the event, not the message. Without the fallback, a live preview would
+    // show the raw @account instead of the resolved display name.
+    const next = roomEventsReducer(initialState, {
+      type: 'MESSAGE_RECEIVED',
+      event: {
+        roomId: 'r1',
+        mentions: [{ account: 'alice', engName: 'Alice Chen' }],
+        message: {
+          id: 'm10',
+          content: 'hey @alice check this out',
+          userDisplayName: 'Bob Lin',
+          createdAt: '2026-08-14T11:00:00Z',
+          // no mentions on the message itself
+        },
+      },
+    })
+    expect(next.previews.r1.text).toBe('hey @Alice Chen check this out')
   })
 
   it('MESSAGE_RECEIVED ignores a thread reply', () => {

--- a/chat-frontend/src/context/RoomEventsContext/reducer.test.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.test.js
@@ -1801,8 +1801,37 @@ describe('roomEventsReducer previews', () => {
     expect(next.previews.r1.text).toBe('Photo')
   })
 
+  it('MESSAGE_RECEIVED keeps the previews reference stable on a content-identical write', () => {
+    // Mirrors the server echoing back a message this client already stored
+    // optimistically (the existingIdx >= 0 branch): the incoming message
+    // renders to the exact same stored preview already in state, so the
+    // previews map must not be reallocated — a fresh object here would
+    // invalidate useSidebarSections' memo for every room in the sidebar.
+    const seeded = {
+      ...initialState,
+      previews: { r1: { messageId: 'm2', senderName: 'Bob Lin', text: 'newest' } },
+    }
+    const next = roomEventsReducer(seeded, {
+      type: 'MESSAGE_RECEIVED',
+      event: {
+        roomId: 'r1',
+        message: { id: 'm2', content: 'newest', userDisplayName: 'Bob Lin', createdAt: '2026-08-14T11:00:00Z' },
+      },
+    })
+    expect(next.previews).toBe(seeded.previews)
+  })
+
   it('MESSAGE_RECEIVED ignores a thread reply', () => {
-    const seeded = { ...initialState, previews: { r1: { messageId: 'm1', senderName: 'A', text: 'first' } } }
+    // Seed roomState.r1 with the parent message present so the dispatch
+    // actually reaches the thread-reply path (state.roomState[roomId] must
+    // exist and contain the parent, or the reducer returns early at the
+    // `!tPrev` / `parentIdx < 0` guards before ever reaching the preview
+    // computation this test means to exercise).
+    const seeded = {
+      ...initialState,
+      previews: { r1: { messageId: 'm1', senderName: 'A', text: 'first' } },
+      roomState: { r1: { ...emptyBuffer(), messages: [{ id: 'm1', content: 'first' }] } },
+    }
     const next = roomEventsReducer(seeded, {
       type: 'MESSAGE_RECEIVED',
       event: {
@@ -1811,6 +1840,10 @@ describe('roomEventsReducer previews', () => {
       },
     })
     expect(next.previews.r1.messageId).toBe('m1')
+    // Proves the thread-reply path actually ran (not short-circuited by a
+    // missing parent): the reducer bumps the parent's tcount by 1 on a
+    // successfully-matched, non-duplicate thread reply.
+    expect(next.roomState.r1.messages.find((m) => m.id === 'm1').tcount).toBe(1)
   })
 
   it('MESSAGE_SENT_LOCAL previews the local send optimistically', () => {
@@ -1857,7 +1890,10 @@ describe('roomEventsReducer previews', () => {
     // always omitted there. Regression guard against wiring it up.
     const next = roomEventsReducer(initialState, {
       type: 'SUBSCRIPTION_UPSERTED',
-      subscription: { roomId: 'r1', roomType: 'channel', siteId: 'site-A', name: 'General', room: {} },
+      subscription: {
+        roomId: 'r1', roomType: 'channel', siteId: 'site-A', name: 'General',
+        room: { previewMessage: wirePreview() },
+      },
     })
     expect(next.previews).toEqual({})
   })

--- a/chat-frontend/src/context/RoomEventsContext/reducer.test.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.test.js
@@ -1763,7 +1763,10 @@ describe('roomEventsReducer previews', () => {
       rooms: [{ id: 'r1', name: 'General', type: 'channel', siteId: 'site-A', userCount: 2 }],
       subscriptions: { r1: { roomId: 'r1', name: 'General', room: { previewMessage: wirePreview() } } },
     })
-    expect(next.previews.r1).toEqual({ messageId: 'm1', senderName: 'Alice Chen', text: 'hello there' })
+    expect(next.previews.r1).toEqual({
+      messageId: 'm1', senderName: 'Alice Chen', text: 'hello there',
+      createdAt: '2026-08-14T10:00:00Z',
+    })
   })
 
   it('BUCKETS_LOADED leaves a room without a previewMessage absent from the map', () => {
@@ -1824,7 +1827,10 @@ describe('roomEventsReducer previews', () => {
         message: { id: 'm2', content: 'newest', userDisplayName: 'Bob Lin', createdAt: '2026-08-14T11:00:00Z' },
       },
     })
-    expect(next.previews.r1).toEqual({ messageId: 'm2', senderName: 'Bob Lin', text: 'newest' })
+    expect(next.previews.r1).toEqual({
+      messageId: 'm2', senderName: 'Bob Lin', text: 'newest',
+      createdAt: '2026-08-14T11:00:00Z',
+    })
   })
 
   it('MESSAGE_RECEIVED uses the attachment fallback when the body is empty', () => {
@@ -1916,7 +1922,10 @@ describe('roomEventsReducer previews', () => {
       roomId: 'r1',
       message: { id: 'm4', content: 'typed by me', userDisplayName: 'Me', createdAt: '2026-08-14T13:00:00Z', _local: true },
     })
-    expect(next.previews.r1).toEqual({ messageId: 'm4', senderName: 'Me', text: 'typed by me' })
+    expect(next.previews.r1).toEqual({
+      messageId: 'm4', senderName: 'Me', text: 'typed by me',
+      createdAt: '2026-08-14T13:00:00Z',
+    })
   })
 
   it('MESSAGE_EDITED_LOCAL rewrites the preview only when the edited message is the one on display', () => {
@@ -1936,6 +1945,29 @@ describe('roomEventsReducer previews', () => {
       content: 'irrelevant', editedAt: '2026-08-14T14:00:00Z',
     })
     expect(miss.previews.r1.text).toBe('before')
+  })
+
+  it('MESSAGE_EDITED_LOCAL falls back to the attachment label when the edited content is empty', () => {
+    // Fix 4 regression: editing a photo's caption to empty must not blank
+    // the snippet to a dangling "Alice Chen: " — previewSnippet (not
+    // previewText) must run so the attachment fallback kicks in. The action
+    // itself carries no attachments; they come from the buffered message
+    // being edited.
+    const seeded = {
+      ...initialState,
+      previews: { r1: { messageId: 'm5', senderName: 'Alice Chen', text: 'a caption' } },
+      roomState: {
+        r1: {
+          ...emptyBuffer(),
+          messages: [{ id: 'm5', content: 'a caption', attachments: [{ imageUrl: '/a.png' }] }],
+        },
+      },
+    }
+    const out = roomEventsReducer(seeded, {
+      type: 'MESSAGE_EDITED_LOCAL', roomId: 'r1', messageId: 'm5',
+      content: '', editedAt: '2026-08-14T14:00:00Z',
+    })
+    expect(out.previews.r1.text).toBe('Photo')
   })
 
   it('MESSAGE_DELETED_LOCAL leaves the preview alone', () => {
@@ -1990,7 +2022,10 @@ describe('roomEventsReducer previews', () => {
           createdAt: '2026-08-14T15:00:00Z',
         },
       })
-      expect(next.previews.r1).toEqual({ messageId: 'm2', senderName: 'Bob Lin', text: 'edited body' })
+      expect(next.previews.r1).toEqual({
+        messageId: 'm2', senderName: 'Bob Lin', text: 'edited body',
+        createdAt: '2026-08-14T15:00:00Z',
+      })
     })
 
     it('updates a room that has no message buffer', () => {
@@ -2053,5 +2088,279 @@ describe('roomEventsReducer previews', () => {
       expect(next).toBe(state)
       expect(next.previews['r-other'].text).toBe('kept')
     })
+
+    describe('encrypted-placeholder guard (Fix 3)', () => {
+      it('does not overwrite a stored encrypted placeholder with the wire plaintext for the SAME message', () => {
+        const state = {
+          ...initialState,
+          previews: {
+            r1: {
+              messageId: 'm-enc', senderName: 'Alice Chen', text: '[encrypted message]',
+              createdAt: '2026-08-14T15:00:00Z', encrypted: true,
+            },
+          },
+        }
+        const next = roomEventsReducer(state, {
+          type: 'ROOM_PREVIEW_UPDATED',
+          roomId: 'r1',
+          previewMessage: {
+            messageId: 'm-enc',
+            sender: { account: 'bob', displayName: 'Bob Lin' },
+            content: 'the actual plaintext body',
+            createdAt: '2026-08-14T15:00:00Z',
+          },
+        })
+        expect(next).toBe(state)
+      })
+
+      it('DOES overwrite an encrypted placeholder when the wire preview is for a DIFFERENT (newer) message', () => {
+        const state = {
+          ...initialState,
+          previews: {
+            r1: {
+              messageId: 'm-enc', senderName: 'Alice Chen', text: '[encrypted message]',
+              createdAt: '2026-08-14T15:00:00Z', encrypted: true,
+            },
+          },
+        }
+        const next = roomEventsReducer(state, {
+          type: 'ROOM_PREVIEW_UPDATED',
+          roomId: 'r1',
+          previewMessage: {
+            messageId: 'm-newer',
+            sender: { account: 'bob', displayName: 'Bob Lin' },
+            content: 'a newer plaintext message',
+            createdAt: '2026-08-14T16:00:00Z',
+          },
+        })
+        expect(next.previews.r1).toEqual({
+          messageId: 'm-newer', senderName: 'Bob Lin', text: 'a newer plaintext message',
+          createdAt: '2026-08-14T16:00:00Z',
+        })
+      })
+    })
+
+    describe('recency guard (Fix 7)', () => {
+      const seededWithCreatedAt = () => ({
+        ...initialState,
+        previews: {
+          r1: {
+            messageId: 'm1', senderName: 'Alice Chen', text: 'old body',
+            createdAt: '2026-08-14T15:00:00Z',
+          },
+        },
+      })
+
+      it('rejects a wire preview strictly older than the stored one', () => {
+        const state = seededWithCreatedAt()
+        const next = roomEventsReducer(state, {
+          type: 'ROOM_PREVIEW_UPDATED',
+          roomId: 'r1',
+          previewMessage: {
+            messageId: 'm-late-arriving',
+            sender: { account: 'bob', displayName: 'Bob Lin' },
+            content: 'resolved before the newer message but delivered after',
+            createdAt: '2026-08-14T14:00:00Z',
+          },
+        })
+        expect(next).toBe(state)
+      })
+
+      it('accepts a wire preview newer than the stored one', () => {
+        const next = roomEventsReducer(seededWithCreatedAt(), {
+          type: 'ROOM_PREVIEW_UPDATED',
+          roomId: 'r1',
+          previewMessage: {
+            messageId: 'm-new',
+            sender: { account: 'bob', displayName: 'Bob Lin' },
+            content: 'genuinely newer',
+            createdAt: '2026-08-14T16:00:00Z',
+          },
+        })
+        expect(next.previews.r1).toEqual({
+          messageId: 'm-new', senderName: 'Bob Lin', text: 'genuinely newer',
+          createdAt: '2026-08-14T16:00:00Z',
+        })
+      })
+
+      it('accepts the write when either timestamp is missing or unparseable, rather than dropping it', () => {
+        // Missing stored createdAt (e.g. a preview seeded before this field existed).
+        const noStoredTimestamp = {
+          ...initialState,
+          previews: { r1: { messageId: 'm1', senderName: 'Alice Chen', text: 'old body' } },
+        }
+        const next1 = roomEventsReducer(noStoredTimestamp, {
+          type: 'ROOM_PREVIEW_UPDATED',
+          roomId: 'r1',
+          previewMessage: {
+            messageId: 'm2', sender: { account: 'bob', displayName: 'Bob Lin' },
+            content: 'accepted', createdAt: '2026-08-14T10:00:00Z',
+          },
+        })
+        expect(next1.previews.r1.messageId).toBe('m2')
+
+        // Unparseable incoming createdAt.
+        const next2 = roomEventsReducer(seededWithCreatedAt(), {
+          type: 'ROOM_PREVIEW_UPDATED',
+          roomId: 'r1',
+          previewMessage: {
+            messageId: 'm3', sender: { account: 'bob', displayName: 'Bob Lin' },
+            content: 'also accepted', createdAt: 'not-a-real-timestamp',
+          },
+        })
+        expect(next2.previews.r1.messageId).toBe('m3')
+      })
+
+      it('does not interfere with the clear-on-delete rule', () => {
+        const next = roomEventsReducer(seededWithCreatedAt(), {
+          type: 'ROOM_PREVIEW_UPDATED', roomId: 'r1', deletedMessageId: 'm1',
+        })
+        expect(next.previews.r1).toBeUndefined()
+      })
+    })
+  })
+})
+
+describe('roomEventsReducer: system messages are never live previews (Fix 1)', () => {
+  const SYSTEM_TYPES = [
+    'room_created',
+    'members_added',
+    'member_removed',
+    'member_left',
+    'room_renamed',
+    'room_restricted',
+    'teams_meet_started',
+  ]
+
+  it.each(SYSTEM_TYPES)('MESSAGE_RECEIVED with type=%s does not seed or overwrite the room preview', (type) => {
+    const seeded = {
+      ...initialState,
+      previews: { r1: { messageId: 'm-old', senderName: 'Alice Chen', text: 'existing preview' } },
+    }
+    const next = roomEventsReducer(seeded, {
+      type: 'MESSAGE_RECEIVED',
+      event: {
+        roomId: 'r1',
+        message: {
+          id: 'm-sys', type, content: 'Bob renamed the channel to #general',
+          createdAt: '2026-08-14T12:00:00Z', sender: { account: 'bob', engName: 'Bob' },
+        },
+      },
+    })
+    // Message still lands in the room timeline (system messages ARE
+    // rendered, just not previewed) — only the preview must be untouched.
+    expect(next.roomState.r1.messages.some((m) => m.id === 'm-sys')).toBe(true)
+    expect(next.previews.r1).toBe(seeded.previews.r1)
+  })
+
+  it('does NOT exclude type="important" — it previews like a normal message', () => {
+    const next = roomEventsReducer(initialState, {
+      type: 'MESSAGE_RECEIVED',
+      event: {
+        roomId: 'r1',
+        message: {
+          id: 'm-imp', type: 'important', content: 'read this',
+          createdAt: '2026-08-14T12:00:00Z', sender: { account: 'bob', engName: 'Bob' },
+        },
+      },
+    })
+    expect(next.previews.r1).toMatchObject({ messageId: 'm-imp', text: 'read this' })
+  })
+
+  it('excludes a message carrying sysMsgData even without a recognized type (belt and braces)', () => {
+    const seeded = {
+      ...initialState,
+      previews: { r1: { messageId: 'm-old', senderName: 'Alice Chen', text: 'existing preview' } },
+    }
+    const next = roomEventsReducer(seeded, {
+      type: 'MESSAGE_RECEIVED',
+      event: {
+        roomId: 'r1',
+        message: {
+          id: 'm-sys2', sysMsgData: '{"meetingId":"abc"}', content: 'Meeting started',
+          createdAt: '2026-08-14T12:00:00Z',
+        },
+      },
+    })
+    expect(next.previews.r1).toBe(seeded.previews.r1)
+  })
+})
+
+describe('roomEventsReducer: MESSAGE_RECEIVED historical-mode duplicate guard applies previews (Fix 2)', () => {
+  function historicalRoom(pending = []) {
+    return {
+      messages: [{ id: 'm1', content: 'old', createdAt: '2026-08-14T09:00:00Z' }],
+      hasLoadedHistory: true, historyError: null, unreadCount: 0,
+      hasMention: false, mentionAll: false, lastMsgAt: null, lastMsgId: null,
+      bufferMode: BUFFER_MODE.HISTORICAL, pendingLiveMessages: pending, focusMessageId: 'm1',
+      hasMoreOlder: true, loadingOlder: false,
+    }
+  }
+
+  it('a MESSAGE_RECEIVED duplicate (already in messages) still applies the computed preview', () => {
+    // Regression: the duplicate-message guard used to `return state`
+    // unconditionally, discarding the previews map computed just above it —
+    // an optimistic preview was never upgraded by the server echo while the
+    // room sat in historical buffer mode.
+    const seeded = {
+      ...initialState,
+      previews: { r1: { messageId: 'm1', senderName: 'Me', text: 'optimistic body' } },
+      roomState: { r1: historicalRoom() },
+    }
+    const next = roomEventsReducer(seeded, {
+      type: 'MESSAGE_RECEIVED',
+      event: {
+        roomId: 'r1',
+        message: {
+          id: 'm1', content: 'server-confirmed body', createdAt: '2026-08-14T09:00:00Z',
+          sender: { account: 'me', engName: 'Me' },
+        },
+      },
+    })
+    expect(next.previews.r1.text).toBe('server-confirmed body')
+    // The duplicate guard's own job (not touching messages/pending) still holds.
+    expect(next.roomState.r1.messages).toBe(seeded.roomState.r1.messages)
+  })
+
+  it('a duplicate already in pendingLiveMessages still applies the computed preview', () => {
+    const seeded = {
+      ...initialState,
+      previews: { r1: { messageId: 'm2', senderName: 'Me', text: 'optimistic body' } },
+      roomState: {
+        r1: historicalRoom([{ id: 'm2', content: 'pending', createdAt: '2026-08-14T09:30:00Z' }]),
+      },
+    }
+    const next = roomEventsReducer(seeded, {
+      type: 'MESSAGE_RECEIVED',
+      event: {
+        roomId: 'r1',
+        message: {
+          id: 'm2', content: 'server-confirmed body', createdAt: '2026-08-14T09:30:00Z',
+          sender: { account: 'me', engName: 'Me' },
+        },
+      },
+    })
+    expect(next.previews.r1.text).toBe('server-confirmed body')
+  })
+
+  it('a true no-op duplicate (identical resulting preview) returns the identical state reference', () => {
+    const seeded = {
+      ...initialState,
+      previews: { r1: { messageId: 'm1', senderName: 'Bob', text: 'old', createdAt: '2026-08-14T09:00:00Z' } },
+      roomState: {
+        r1: historicalRoom(),
+      },
+    }
+    const next = roomEventsReducer(seeded, {
+      type: 'MESSAGE_RECEIVED',
+      event: {
+        roomId: 'r1',
+        message: {
+          id: 'm1', content: 'old', createdAt: '2026-08-14T09:00:00Z',
+          sender: { account: 'bob', engName: 'Bob' },
+        },
+      },
+    })
+    expect(next).toBe(seeded)
   })
 })

--- a/chat-frontend/src/context/RoomEventsContext/reducer.test.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.test.js
@@ -1733,3 +1733,143 @@ describe('roomEventsReducer: older-message pagination', () => {
     expect(next.roomState.a.bufferMode).toBe(BUFFER_MODE.HISTORICAL)
   })
 })
+
+describe('roomEventsReducer previews', () => {
+  function emptyBuffer() {
+    return {
+      messages: [], hasLoadedHistory: false, historyError: null, unreadCount: 0,
+      hasMention: false, mentionAll: false, lastMsgAt: null, lastMsgId: null,
+      bufferMode: 'live', pendingLiveMessages: [], focusMessageId: null,
+      hasMoreOlder: true, loadingOlder: false,
+    }
+  }
+
+  const wirePreview = (over = {}) => ({
+    messageId: 'm1',
+    sender: { account: 'alice', displayName: 'Alice Chen' },
+    content: 'hello **there**',
+    createdAt: '2026-08-14T10:00:00Z',
+    ...over,
+  })
+
+  it('starts empty', () => {
+    expect(initialState.previews).toEqual({})
+  })
+
+  it('BUCKETS_LOADED seeds a preview from sub.room.previewMessage', () => {
+    const next = roomEventsReducer(initialState, {
+      type: 'BUCKETS_LOADED',
+      favoriteIds: [], appIds: [], channelDmIds: ['r1'],
+      rooms: [{ id: 'r1', name: 'General', type: 'channel', siteId: 'site-A', userCount: 2 }],
+      subscriptions: { r1: { roomId: 'r1', name: 'General', room: { previewMessage: wirePreview() } } },
+    })
+    expect(next.previews.r1).toEqual({ messageId: 'm1', senderName: 'Alice Chen', text: 'hello there' })
+  })
+
+  it('BUCKETS_LOADED leaves a room without a previewMessage absent from the map', () => {
+    const next = roomEventsReducer(initialState, {
+      type: 'BUCKETS_LOADED',
+      favoriteIds: [], appIds: [], channelDmIds: ['r1'],
+      rooms: [{ id: 'r1', name: 'General', type: 'channel', siteId: 'site-A', userCount: 2 }],
+      subscriptions: { r1: { roomId: 'r1', name: 'General', room: {} } },
+    })
+    expect(next.previews.r1).toBeUndefined()
+  })
+
+  it('MESSAGE_RECEIVED overwrites the preview for a room with no message buffer', () => {
+    const next = roomEventsReducer(initialState, {
+      type: 'MESSAGE_RECEIVED',
+      event: {
+        roomId: 'r1',
+        message: { id: 'm2', content: 'newest', userDisplayName: 'Bob Lin', createdAt: '2026-08-14T11:00:00Z' },
+      },
+    })
+    expect(next.previews.r1).toEqual({ messageId: 'm2', senderName: 'Bob Lin', text: 'newest' })
+  })
+
+  it('MESSAGE_RECEIVED uses the attachment fallback when the body is empty', () => {
+    const next = roomEventsReducer(initialState, {
+      type: 'MESSAGE_RECEIVED',
+      event: {
+        roomId: 'r1',
+        message: {
+          id: 'm3', content: '', userDisplayName: 'Bob Lin',
+          createdAt: '2026-08-14T11:00:00Z', attachments: [{ imageUrl: '/a.png' }],
+        },
+      },
+    })
+    expect(next.previews.r1.text).toBe('Photo')
+  })
+
+  it('MESSAGE_RECEIVED ignores a thread reply', () => {
+    const seeded = { ...initialState, previews: { r1: { messageId: 'm1', senderName: 'A', text: 'first' } } }
+    const next = roomEventsReducer(seeded, {
+      type: 'MESSAGE_RECEIVED',
+      event: {
+        roomId: 'r1',
+        message: { id: 'm9', content: 'reply', threadParentMessageId: 'm1', createdAt: '2026-08-14T12:00:00Z' },
+      },
+    })
+    expect(next.previews.r1.messageId).toBe('m1')
+  })
+
+  it('MESSAGE_SENT_LOCAL previews the local send optimistically', () => {
+    const next = roomEventsReducer(initialState, {
+      type: 'MESSAGE_SENT_LOCAL',
+      roomId: 'r1',
+      message: { id: 'm4', content: 'typed by me', userDisplayName: 'Me', createdAt: '2026-08-14T13:00:00Z', _local: true },
+    })
+    expect(next.previews.r1).toEqual({ messageId: 'm4', senderName: 'Me', text: 'typed by me' })
+  })
+
+  it('MESSAGE_EDITED_LOCAL rewrites the preview only when the edited message is the one on display', () => {
+    const seeded = {
+      ...initialState,
+      previews: { r1: { messageId: 'm5', senderName: 'Me', text: 'before' } },
+      roomState: { r1: { ...emptyBuffer(), messages: [{ id: 'm5', content: 'before' }] } },
+    }
+    const hit = roomEventsReducer(seeded, {
+      type: 'MESSAGE_EDITED_LOCAL', roomId: 'r1', messageId: 'm5',
+      content: 'after', editedAt: '2026-08-14T14:00:00Z',
+    })
+    expect(hit.previews.r1.text).toBe('after')
+
+    const miss = roomEventsReducer(seeded, {
+      type: 'MESSAGE_EDITED_LOCAL', roomId: 'r1', messageId: 'm5-other',
+      content: 'irrelevant', editedAt: '2026-08-14T14:00:00Z',
+    })
+    expect(miss.previews.r1.text).toBe('before')
+  })
+
+  it('MESSAGE_DELETED_LOCAL leaves the preview alone', () => {
+    const seeded = {
+      ...initialState,
+      previews: { r1: { messageId: 'm6', senderName: 'Me', text: 'doomed' } },
+      roomState: { r1: { ...emptyBuffer(), messages: [{ id: 'm6', content: 'doomed' }] } },
+    }
+    const next = roomEventsReducer(seeded, { type: 'MESSAGE_DELETED_LOCAL', roomId: 'r1', messageId: 'm6' })
+    expect(next.previews.r1.text).toBe('doomed')
+  })
+
+  it('SUBSCRIPTION_UPSERTED never seeds a preview', () => {
+    // Its `added` payload embeds a `room` object, which makes it look like a
+    // seeding source — but docs/client-api.md specifies previewMessage is
+    // always omitted there. Regression guard against wiring it up.
+    const next = roomEventsReducer(initialState, {
+      type: 'SUBSCRIPTION_UPSERTED',
+      subscription: { roomId: 'r1', roomType: 'channel', siteId: 'site-A', name: 'General', room: {} },
+    })
+    expect(next.previews).toEqual({})
+  })
+
+  it('ROOM_REMOVED drops the room preview', () => {
+    const seeded = { ...initialState, previews: { r1: { messageId: 'm7', senderName: 'A', text: 'x' } } }
+    const next = roomEventsReducer(seeded, { type: 'ROOM_REMOVED', roomId: 'r1' })
+    expect(next.previews.r1).toBeUndefined()
+  })
+
+  it('RESET clears every preview', () => {
+    const seeded = { ...initialState, previews: { r1: { messageId: 'm8', senderName: 'A', text: 'x' } } }
+    expect(roomEventsReducer(seeded, { type: 'RESET' }).previews).toEqual({})
+  })
+})

--- a/chat-frontend/src/context/RoomEventsContext/useRoomSubscriptions.js
+++ b/chat-frontend/src/context/RoomEventsContext/useRoomSubscriptions.js
@@ -201,8 +201,13 @@ export function useRoomSubscriptions(
         // Preview first, and unconditionally: the sidebar snippet must update
         // even when the edit itself can't be applied — an encrypted body
         // returns below, and MESSAGE_EDITED bails for a room with no buffer.
-        // The server omits previewMessage for hidden thread-reply edits, so
-        // no client-side thread guard is needed here.
+        // No client-side thread guard needed here — we just apply whatever
+        // previewMessage the server sends. Separately, this frontend's own
+        // preview computation (reducer.js) excludes EVERY thread reply from
+        // being a preview candidate, which is broader than the server's rule
+        // (hidden/tshow: false only) — correct only because this frontend has
+        // no tshow support, so no shown reply ever reaches the room timeline
+        // here. Anyone adding tshow must revisit that exclusion.
         if (evt.previewMessage) {
           safeDispatch({
             type: 'ROOM_PREVIEW_UPDATED',

--- a/chat-frontend/src/context/RoomEventsContext/useRoomSubscriptions.js
+++ b/chat-frontend/src/context/RoomEventsContext/useRoomSubscriptions.js
@@ -198,6 +198,18 @@ export function useRoomSubscriptions(
     const handleMutationEvent = (evt) => {
       if (evt?.type === 'message_edited' && evt.messageId) {
         const { messageId, newContent, editedAt } = evt
+        // Preview first, and unconditionally: the sidebar snippet must update
+        // even when the edit itself can't be applied — an encrypted body
+        // returns below, and MESSAGE_EDITED bails for a room with no buffer.
+        // The server omits previewMessage for hidden thread-reply edits, so
+        // no client-side thread guard is needed here.
+        if (evt.previewMessage) {
+          safeDispatch({
+            type: 'ROOM_PREVIEW_UPDATED',
+            roomId: evt.roomId,
+            previewMessage: evt.previewMessage,
+          })
+        }
         // Drop edits without a plaintext body. Encrypted channel rooms emit
         // `encryptedNewContent` instead; blanking the existing content to ''
         // would silently wipe the message until decryption is implemented.
@@ -216,6 +228,15 @@ export function useRoomSubscriptions(
       }
       if (evt?.type === 'message_deleted' && evt.messageId) {
         const { messageId } = evt
+        // deletedMessageId lets the reducer clear the preview only when the
+        // deleted message is the one on display; an absent previewMessage
+        // means nothing eligible is left in the room.
+        safeDispatch({
+          type: 'ROOM_PREVIEW_UPDATED',
+          roomId: evt.roomId,
+          previewMessage: evt.previewMessage,
+          deletedMessageId: messageId,
+        })
         safeDispatch({ type: 'MESSAGE_DELETED', roomId: evt.roomId, messageId })
         fanThreadMutation({ kind: 'deleted', messageId })
         return true

--- a/chat-frontend/src/lib/messageType.js
+++ b/chat-frontend/src/lib/messageType.js
@@ -1,0 +1,27 @@
+// Mirrors the server's system-message type set (pkg/model/event.go:624-659).
+// A normal user message has Type === '' — these seven are server-emitted
+// events that happen to ride the same MESSAGES-CANONICAL -> new_message
+// fan-out as ordinary content, so eligibility for previews/notifications
+// must be decided by set membership, never by `type !== ''`.
+//
+// Critical: MessageTypeImportant ("important") is deliberately NOT in this
+// set (event.go:661-667) — it's the sole client-settable type, and it
+// previews + notifies like a normal message.
+
+export const SYSTEM_MESSAGE_TYPES = new Set([
+  'room_created',
+  'members_added',
+  'member_removed',
+  'member_left',
+  'room_renamed',
+  'room_restricted',
+  'teams_meet_started',
+])
+
+/**
+ * @param {string | null | undefined} type
+ * @returns {boolean}
+ */
+export function isSystemMessageType(type) {
+  return !!type && SYSTEM_MESSAGE_TYPES.has(type)
+}

--- a/chat-frontend/src/lib/messageType.test.js
+++ b/chat-frontend/src/lib/messageType.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { isSystemMessageType, SYSTEM_MESSAGE_TYPES } from './messageType'
+
+describe('isSystemMessageType', () => {
+  it.each([
+    'room_created',
+    'members_added',
+    'member_removed',
+    'member_left',
+    'room_renamed',
+    'room_restricted',
+    'teams_meet_started',
+  ])('treats %s as a system message type', (type) => {
+    expect(isSystemMessageType(type)).toBe(true)
+  })
+
+  it('does NOT treat "important" as a system message type', () => {
+    // MessageTypeImportant is client-settable and previews/notifies like a
+    // normal message — see pkg/model/event.go:661-667.
+    expect(isSystemMessageType('important')).toBe(false)
+  })
+
+  it('does not treat an empty string as a system message type', () => {
+    expect(isSystemMessageType('')).toBe(false)
+  })
+
+  it('does not treat undefined as a system message type', () => {
+    expect(isSystemMessageType(undefined)).toBe(false)
+  })
+
+  it('does not treat an unrecognized type as a system message type', () => {
+    expect(isSystemMessageType('some_future_type')).toBe(false)
+  })
+
+  it('SYSTEM_MESSAGE_TYPES contains exactly the seven known types', () => {
+    expect([...SYSTEM_MESSAGE_TYPES].sort()).toEqual(
+      [
+        'room_created',
+        'members_added',
+        'member_removed',
+        'member_left',
+        'room_renamed',
+        'room_restricted',
+        'teams_meet_started',
+      ].sort()
+    )
+  })
+})

--- a/chat-frontend/src/lib/participantName.js
+++ b/chat-frontend/src/lib/participantName.js
@@ -1,0 +1,30 @@
+// Display-name resolution for message senders. One rule, two shapes: a wire
+// Participant (nested on a PreviewMessage) and a Message (which carries the
+// server-composed name at the top level). No React, no I/O.
+
+/**
+ * Resolve a wire Participant to a render-ready name. `displayName` is composed
+ * server-side (engName + chineseName + account fallback; a bot's is its app
+ * name), so it wins when present.
+ *
+ * @param {{ displayName?: string, engName?: string, account?: string, userId?: string } | null | undefined} participant
+ * @returns {string}
+ */
+export function participantDisplayName(participant) {
+  if (!participant) return 'Unknown'
+  return participant.displayName || participant.engName || participant.account || participant.userId || 'Unknown'
+}
+
+/**
+ * Resolve a Message's sender name. The top-level `userDisplayName` is the
+ * server's render-ready composition and is preferred over the nested sender.
+ *
+ * @param {{ userDisplayName?: string, sender?: object, userAccount?: string, userId?: string } | null | undefined} msg
+ * @returns {string}
+ */
+export function messageSenderName(msg) {
+  if (!msg) return 'Unknown'
+  if (msg.userDisplayName) return msg.userDisplayName
+  if (msg.sender) return participantDisplayName(msg.sender)
+  return msg.userAccount || msg.userId || 'Unknown'
+}

--- a/chat-frontend/src/lib/participantName.test.js
+++ b/chat-frontend/src/lib/participantName.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { participantDisplayName, messageSenderName } from './participantName'
+
+describe('participantDisplayName', () => {
+  it('prefers the server-composed displayName', () => {
+    expect(participantDisplayName({ displayName: 'Alice Chen', engName: 'Alice', account: 'alice' }))
+      .toBe('Alice Chen')
+  })
+
+  it('falls back to engName, then account, then userId', () => {
+    expect(participantDisplayName({ engName: 'Alice', account: 'alice' })).toBe('Alice')
+    expect(participantDisplayName({ account: 'alice', userId: 'u1' })).toBe('alice')
+    expect(participantDisplayName({ userId: 'u1' })).toBe('u1')
+  })
+
+  it('returns Unknown for null, undefined, and an empty participant', () => {
+    expect(participantDisplayName(null)).toBe('Unknown')
+    expect(participantDisplayName(undefined)).toBe('Unknown')
+    expect(participantDisplayName({})).toBe('Unknown')
+  })
+})
+
+describe('messageSenderName', () => {
+  it('prefers the top-level userDisplayName', () => {
+    expect(messageSenderName({ userDisplayName: 'Alice Chen', sender: { engName: 'Alice' } }))
+      .toBe('Alice Chen')
+  })
+
+  it('falls back to the nested sender participant', () => {
+    expect(messageSenderName({ sender: { displayName: 'Deploy Bot' } })).toBe('Deploy Bot')
+    expect(messageSenderName({ sender: { engName: 'Alice' } })).toBe('Alice')
+  })
+
+  it('falls back to userAccount then userId when there is no sender', () => {
+    expect(messageSenderName({ userAccount: 'alice' })).toBe('alice')
+    expect(messageSenderName({ userId: 'u1' })).toBe('u1')
+  })
+
+  it('returns Unknown for an empty or missing message', () => {
+    expect(messageSenderName({})).toBe('Unknown')
+    expect(messageSenderName(null)).toBe('Unknown')
+  })
+})

--- a/chat-frontend/src/lib/previewText.js
+++ b/chat-frontend/src/lib/previewText.js
@@ -1,0 +1,77 @@
+// Flatten a message body into a single-line plain-text snippet for the sidebar
+// room list. Reuses the message-content tokenizer so the snippet and the
+// rendered message agree on what the body says. No React, no I/O.
+
+import { parseMessageContent } from './messageContent'
+import { attachmentKind } from './attachment'
+
+// Hard cap on the returned string. CSS ellipsis truncates visually but leaves
+// the whole string in the DOM, so without this a multi-thousand-character
+// message sits in the sidebar for as long as it's the room's latest.
+export const PREVIEW_MAX_LENGTH = 140
+
+const KIND_LABEL = { image: 'Photo', audio: 'Audio', video: 'Video' }
+
+/**
+ * Flatten a message body to a single line of plain text.
+ *
+ * @param {string | null | undefined} content
+ * @param {{ account?: string, engName?: string }[]} [mentions]
+ * @returns {string} '' when there is nothing to show
+ */
+export function previewText(content, mentions = []) {
+  if (!content) return ''
+  const flat = flattenNodes(parseMessageContent(content, mentions))
+  const collapsed = flat.replace(/\s+/g, ' ').trim()
+  return collapsed.length > PREVIEW_MAX_LENGTH ? collapsed.slice(0, PREVIEW_MAX_LENGTH) : collapsed
+}
+
+/**
+ * Label for a message whose body is empty but which carries attachments.
+ *
+ * @param {import('../api/types').Attachment[] | null | undefined} attachments
+ * @returns {string} '' when there are none
+ */
+export function attachmentFallbackText(attachments) {
+  const first = attachments?.[0]
+  if (!first) return ''
+  return KIND_LABEL[attachmentKind(first)] ?? (first.title || 'File')
+}
+
+/**
+ * The sidebar snippet for a message: its flattened body, or an attachment
+ * label when the body is empty. Single entry point for both preview writers.
+ *
+ * @param {string | null | undefined} content
+ * @param {{ account?: string, engName?: string }[]} [mentions]
+ * @param {import('../api/types').Attachment[] | null | undefined} [attachments]
+ * @returns {string}
+ */
+export function previewSnippet(content, mentions, attachments) {
+  return previewText(content, mentions) || attachmentFallbackText(attachments)
+}
+
+function flattenNodes(nodes) {
+  let out = ''
+  for (const node of nodes) out += flattenNode(node)
+  return out
+}
+
+function flattenNode(node) {
+  switch (node.type) {
+    case 'mention':
+      return `@${node.display}`
+    // link/code/codeblock all carry their visible text on `.text`; a link's
+    // href is deliberately never emitted separately.
+    case 'link':
+    case 'code':
+    case 'codeblock':
+      return node.text
+    case 'strong':
+    case 'em':
+    case 'del':
+      return flattenNodes(node.children)
+    default:
+      return node.text ?? ''
+  }
+}

--- a/chat-frontend/src/lib/previewText.js
+++ b/chat-frontend/src/lib/previewText.js
@@ -10,6 +10,17 @@ import { attachmentKind } from './attachment'
 // message sits in the sidebar for as long as it's the room's latest.
 export const PREVIEW_MAX_LENGTH = 140
 
+// Headroom applied BEFORE tokenizing: previewText runs on the reducer hot
+// path for every message in every room (not just the ones being rendered),
+// so parseMessageContent — recursive, O(body length) — must never see a
+// full multi-KB body just to produce a 140-char snippet. The margin has to
+// be generous rather than exactly PREVIEW_MAX_LENGTH because markup near the
+// boundary can both shrink (**bold** -> bold) and grow (@alice -> @Alice
+// Chen) once parsed, so the raw prefix needs slack on both sides to still
+// resolve correctly.
+const PARSE_SLICE_MARGIN = 500
+const PARSE_SLICE_LENGTH = PREVIEW_MAX_LENGTH + PARSE_SLICE_MARGIN
+
 const KIND_LABEL = { image: 'Photo', audio: 'Audio', video: 'Video' }
 
 /**
@@ -21,9 +32,22 @@ const KIND_LABEL = { image: 'Photo', audio: 'Audio', video: 'Video' }
  */
 export function previewText(content, mentions = []) {
   if (!content) return ''
-  const flat = flattenNodes(parseMessageContent(content, mentions))
+  const bounded = safeSlice(content, PARSE_SLICE_LENGTH)
+  const flat = flattenNodes(parseMessageContent(bounded, mentions))
   const collapsed = flat.replace(/\s+/g, ' ').trim()
-  return collapsed.length > PREVIEW_MAX_LENGTH ? collapsed.slice(0, PREVIEW_MAX_LENGTH) : collapsed
+  return safeSlice(collapsed, PREVIEW_MAX_LENGTH)
+}
+
+// Slice to at most maxLength UTF-16 code units without splitting a surrogate
+// pair. A plain slice(0, N) can land between a high surrogate (0xD800-
+// 0xDBFF) and its low surrogate, leaving a lone surrogate that renders as
+// U+FFFD — drop the whole pair instead of half of it.
+function safeSlice(str, maxLength) {
+  if (str.length <= maxLength) return str
+  let end = maxLength
+  const code = str.charCodeAt(end - 1)
+  if (code >= 0xd800 && code <= 0xdbff) end -= 1
+  return str.slice(0, end)
 }
 
 /**

--- a/chat-frontend/src/lib/previewText.js
+++ b/chat-frontend/src/lib/previewText.js
@@ -10,17 +10,6 @@ import { attachmentKind } from './attachment'
 // message sits in the sidebar for as long as it's the room's latest.
 export const PREVIEW_MAX_LENGTH = 140
 
-// Headroom applied BEFORE tokenizing: previewText runs on the reducer hot
-// path for every message in every room (not just the ones being rendered),
-// so parseMessageContent — recursive, O(body length) — must never see a
-// full multi-KB body just to produce a 140-char snippet. The margin has to
-// be generous rather than exactly PREVIEW_MAX_LENGTH because markup near the
-// boundary can both shrink (**bold** -> bold) and grow (@alice -> @Alice
-// Chen) once parsed, so the raw prefix needs slack on both sides to still
-// resolve correctly.
-const PARSE_SLICE_MARGIN = 500
-const PARSE_SLICE_LENGTH = PREVIEW_MAX_LENGTH + PARSE_SLICE_MARGIN
-
 const KIND_LABEL = { image: 'Photo', audio: 'Audio', video: 'Video' }
 
 /**
@@ -32,8 +21,7 @@ const KIND_LABEL = { image: 'Photo', audio: 'Audio', video: 'Video' }
  */
 export function previewText(content, mentions = []) {
   if (!content) return ''
-  const bounded = safeSlice(content, PARSE_SLICE_LENGTH)
-  const flat = flattenNodes(parseMessageContent(bounded, mentions))
+  const flat = flattenNodes(parseMessageContent(content, mentions))
   const collapsed = flat.replace(/\s+/g, ' ').trim()
   return safeSlice(collapsed, PREVIEW_MAX_LENGTH)
 }

--- a/chat-frontend/src/lib/previewText.test.js
+++ b/chat-frontend/src/lib/previewText.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { previewText, attachmentFallbackText, previewSnippet, PREVIEW_MAX_LENGTH } from './previewText'
+
+describe('previewText', () => {
+  it('returns plain text unchanged', () => {
+    expect(previewText('hello there')).toBe('hello there')
+  })
+
+  it('returns empty string for empty, null, and undefined input', () => {
+    expect(previewText('')).toBe('')
+    expect(previewText(null)).toBe('')
+    expect(previewText(undefined)).toBe('')
+  })
+
+  it('drops markdown emphasis markers but keeps the text', () => {
+    expect(previewText('**bold** and *italic* and ~~struck~~')).toBe('bold and italic and struck')
+  })
+
+  it('flattens nested emphasis', () => {
+    expect(previewText('**bold with _inner italic_ inside**')).toBe('bold with inner italic inside')
+  })
+
+  it('leaves the outer markers literal when emphasis nests with the same marker', () => {
+    // The tokenizer's strong pattern forbids `*` inside its captured group, so
+    // `**a *b* c**` never matches as strong — the outer asterisks stay literal.
+    expect(previewText('**bold with *inner italic* inside**')).toBe('**bold with inner italic inside**')
+  })
+
+  it('drops inline code backticks', () => {
+    expect(previewText('run `npm test` now')).toBe('run npm test now')
+  })
+
+  it('keeps fenced code block contents and collapses their newlines', () => {
+    expect(previewText('see:\n```\nline one\nline two\n```')).toBe('see: line one line two')
+  })
+
+  it('leaves an unterminated fence as literal text', () => {
+    expect(previewText('oops ```never closed')).toBe('oops ```never closed')
+  })
+
+  it('renders a resolved mention as @ plus the display name', () => {
+    const mentions = [{ account: 'alice', engName: 'Alice Chen' }]
+    expect(previewText('hey @alice ping', mentions)).toBe('hey @Alice Chen ping')
+  })
+
+  it('renders @all as @all', () => {
+    expect(previewText('@all standup now')).toBe('@all standup now')
+  })
+
+  it('leaves an unresolved mention as literal text', () => {
+    expect(previewText('hey @nobody there', [])).toBe('hey @nobody there')
+  })
+
+  it('renders a link as its visible label, never a separate href', () => {
+    expect(previewText('see https://example.com/x now')).toBe('see https://example.com/x now')
+  })
+
+  it('collapses newlines and runs of whitespace to single spaces, then trims', () => {
+    expect(previewText('  line one\n\n  line   two \t three  ')).toBe('line one line two three')
+  })
+
+  it('caps the result at PREVIEW_MAX_LENGTH characters', () => {
+    const long = 'x'.repeat(500)
+    const out = previewText(long)
+    expect(out).toHaveLength(PREVIEW_MAX_LENGTH)
+    expect(PREVIEW_MAX_LENGTH).toBe(140)
+  })
+})
+
+describe('attachmentFallbackText', () => {
+  it('returns empty string for no attachments', () => {
+    expect(attachmentFallbackText(undefined)).toBe('')
+    expect(attachmentFallbackText([])).toBe('')
+  })
+
+  it('labels an image Photo', () => {
+    expect(attachmentFallbackText([{ imageUrl: '/a.png' }])).toBe('Photo')
+  })
+
+  it('labels audio and video', () => {
+    expect(attachmentFallbackText([{ audioUrl: '/a.mp3' }])).toBe('Audio')
+    expect(attachmentFallbackText([{ videoUrl: '/a.mp4' }])).toBe('Video')
+  })
+
+  it('uses a generic file attachment title', () => {
+    expect(attachmentFallbackText([{ title: 'report.pdf', fileType: 'application/pdf' }])).toBe('report.pdf')
+  })
+
+  it('falls back to File for an untitled file attachment', () => {
+    expect(attachmentFallbackText([{ title: '', fileType: 'application/pdf' }])).toBe('File')
+  })
+
+  it('classifies by the first attachment only', () => {
+    expect(attachmentFallbackText([{ imageUrl: '/a.png' }, { title: 'b.pdf' }])).toBe('Photo')
+  })
+})
+
+describe('previewSnippet', () => {
+  it('prefers text over the attachment fallback', () => {
+    expect(previewSnippet('look at this', [], [{ imageUrl: '/a.png' }])).toBe('look at this')
+  })
+
+  it('falls back to the attachment label when the text is empty', () => {
+    expect(previewSnippet('', [], [{ imageUrl: '/a.png' }])).toBe('Photo')
+  })
+
+  it('returns empty string when there is neither text nor attachments', () => {
+    expect(previewSnippet('', [], [])).toBe('')
+  })
+})

--- a/chat-frontend/src/lib/previewText.test.js
+++ b/chat-frontend/src/lib/previewText.test.js
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { previewText, attachmentFallbackText, previewSnippet, PREVIEW_MAX_LENGTH } from './previewText'
+import * as messageContent from './messageContent'
 
 describe('previewText', () => {
   it('returns plain text unchanged', () => {
@@ -64,6 +65,36 @@ describe('previewText', () => {
     const out = previewText(long)
     expect(out).toHaveLength(PREVIEW_MAX_LENGTH)
     expect(PREVIEW_MAX_LENGTH).toBe(140)
+  })
+
+  it('does not split a surrogate pair straddling the PREVIEW_MAX_LENGTH boundary', () => {
+    // 139 plain chars + a 2-code-unit emoji puts the emoji's code units at
+    // indices 139/140 — a naive slice(0, 140) keeps only the high surrogate,
+    // leaving a lone surrogate that renders as U+FFFD.
+    const content = 'a'.repeat(139) + '😀' + 'b'.repeat(20)
+    const out = previewText(content)
+    expect(out).toHaveLength(139)
+    expect(out).toBe('a'.repeat(139))
+    // No lone surrogate anywhere in the output.
+    expect(/[\uD800-\uDFFF]/.test(out)).toBe(false)
+  })
+
+  it('slices the raw content to a bounded prefix before tokenizing (perf)', () => {
+    // parseMessageContent runs on the reducer hot path for every message in
+    // every room, so a multi-KB body must never be fully tokenized just to
+    // produce a 140-char snippet.
+    const spy = vi.spyOn(messageContent, 'parseMessageContent')
+    try {
+      const long = 'x'.repeat(20000)
+      const out = previewText(long)
+      expect(out).toHaveLength(PREVIEW_MAX_LENGTH)
+      expect(spy).toHaveBeenCalledTimes(1)
+      const [passedContent] = spy.mock.calls[0]
+      expect(passedContent.length).toBeLessThan(2000)
+      expect(passedContent.length).toBeGreaterThan(PREVIEW_MAX_LENGTH)
+    } finally {
+      spy.mockRestore()
+    }
   })
 })
 

--- a/chat-frontend/src/lib/previewText.test.js
+++ b/chat-frontend/src/lib/previewText.test.js
@@ -1,6 +1,5 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { previewText, attachmentFallbackText, previewSnippet, PREVIEW_MAX_LENGTH } from './previewText'
-import * as messageContent from './messageContent'
 
 describe('previewText', () => {
   it('returns plain text unchanged', () => {
@@ -79,22 +78,10 @@ describe('previewText', () => {
     expect(/[\uD800-\uDFFF]/.test(out)).toBe(false)
   })
 
-  it('slices the raw content to a bounded prefix before tokenizing (perf)', () => {
-    // parseMessageContent runs on the reducer hot path for every message in
-    // every room, so a multi-KB body must never be fully tokenized just to
-    // produce a 140-char snippet.
-    const spy = vi.spyOn(messageContent, 'parseMessageContent')
-    try {
-      const long = 'x'.repeat(20000)
-      const out = previewText(long)
-      expect(out).toHaveLength(PREVIEW_MAX_LENGTH)
-      expect(spy).toHaveBeenCalledTimes(1)
-      const [passedContent] = spy.mock.calls[0]
-      expect(passedContent.length).toBeLessThan(2000)
-      expect(passedContent.length).toBeGreaterThan(PREVIEW_MAX_LENGTH)
-    } finally {
-      spy.mockRestore()
-    }
+  it('applies the full cap to a markdown-heavy body that shrinks when flattened', () => {
+    // `**x**` flattens 5:1, so a bounded pre-parse would yield fewer than the
+    // cap here even though the full body has more than enough content.
+    expect(previewText('**x**'.repeat(150))).toHaveLength(PREVIEW_MAX_LENGTH)
   })
 })
 

--- a/docs/superpowers/plans/2026-08-14-chat-frontend-message-preview.md
+++ b/docs/superpowers/plans/2026-08-14-chat-frontend-message-preview.md
@@ -1,0 +1,1493 @@
+# chat-frontend Sidebar Message Preview Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render each sidebar room's most recent message as a live-updating snippet under the room name.
+
+**Architecture:** A dedicated `state.previews` map in `roomEventsReducer`, seeded from `subscription.list`'s existing `sub.room.previewMessage` and updated by live message, edit, and delete events. Message bodies are flattened to single-line plain text at write time by a pure `lib/` function built on the existing content tokenizer. `useSidebarSections` joins the map into each room; `RoomItem` renders a second line whose height is constant whether or not a preview exists.
+
+**Tech Stack:** React 18, Vite, vitest + @testing-library/react, plain CSS with design tokens. `api/` is TypeScript (strict); components, contexts (except `.tsx` ones), lib, and tests are JS.
+
+**Spec:** `docs/superpowers/specs/2026-08-14-chat-frontend-message-preview-design.md`
+
+## Global Constraints
+
+- All commands run from `chat-frontend/`. Never run raw `go` commands; this feature touches no Go.
+- `npm run typecheck` and `npm test` must pass on **every** commit. `vite build` clean at the end.
+- No hardcoded hex or px values in component CSS — every value reads a token from `src/styles/tokens.css`.
+- `lib/` is pure-utility: no React, no NATS, no async I/O.
+- Components never deep-import `@/api/_transport/...`; wire types come from `@/api`.
+- Test files live next to source (`Foo.jsx` → `Foo.test.jsx`), same folder, `package`-local.
+- TDD is mandatory: write the failing test, **run it and confirm it fails**, then implement. Never skip the Red phase.
+- Never mention model identifiers, session ids, or AI provenance in commit messages or code comments.
+- No change to `docs/client-api.md` — nothing on the wire moves.
+- Branch: `claude/message-preview-chat-frontend-08drl2`. Commit after each task.
+
+## File Structure
+
+**Created:**
+
+| File | Responsibility |
+|---|---|
+| `src/lib/previewText.js` | Flatten a message body + attachments to a single-line snippet |
+| `src/lib/previewText.test.js` | Its tests |
+| `src/lib/participantName.js` | Resolve a Participant / Message to a display name |
+| `src/lib/participantName.test.js` | Its tests |
+
+**Modified:**
+
+| File | Change |
+|---|---|
+| `src/api/types.ts` | `Participant.displayName`, new `PreviewMessage`, `SubscriptionRoom.previewMessage` |
+| `src/api/index.ts` | Re-export `PreviewMessage` |
+| `src/context/RoomEventsContext/reducer.js` | `previews` state + six writers |
+| `src/context/RoomEventsContext/reducer.test.js` | Writer tests |
+| `src/context/RoomEventsContext/RoomEventsContext.tsx` | `RoomPreview` type, state field, `useSidebarSections` join |
+| `src/context/RoomEventsContext/RoomEventsContext.test.jsx` | Join test |
+| `src/context/RoomEventsContext/useRoomSubscriptions.js` | Dispatch `ROOM_PREVIEW_UPDATED` |
+| `src/components/shared/MessageList/MessageRow/MessageRow.jsx` | Delegate `senderName` to `lib/` |
+| `src/components/MainApp/Sidebar/RoomList/RoomList.jsx` | Two-line `RoomItem` |
+| `src/components/MainApp/Sidebar/RoomList/style.css` | Two-line row layout |
+| `src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx` | Render tests |
+
+---
+
+### Task 1: The flattener (`lib/previewText.js`)
+
+Pure text transformation with no dependencies on React or state. Built first because every later task consumes it.
+
+**Files:**
+- Create: `src/lib/previewText.js`
+- Test: `src/lib/previewText.test.js`
+
+**Interfaces:**
+- Consumes: `parseMessageContent(content, mentions)` from `src/lib/messageContent.js`, which returns nodes shaped `{type:'text',text}`, `{type:'mention',account,all,display}`, `{type:'link',href,text}`, `{type:'code',text}`, `{type:'codeblock',text}`, `{type:'strong'|'em'|'del',children}`. Also `attachmentKind(att)` from `src/lib/attachment.js`, returning `'image'|'audio'|'video'|'file'`.
+- Produces:
+  - `PREVIEW_MAX_LENGTH: number` (140)
+  - `previewText(content, mentions?) → string`
+  - `attachmentFallbackText(attachments) → string`
+  - `previewSnippet(content, mentions, attachments) → string` ← the entry point Tasks 4 and 5 call
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/previewText.test.js`:
+
+```js
+import { describe, it, expect } from 'vitest'
+import { previewText, attachmentFallbackText, previewSnippet, PREVIEW_MAX_LENGTH } from './previewText'
+
+describe('previewText', () => {
+  it('returns plain text unchanged', () => {
+    expect(previewText('hello there')).toBe('hello there')
+  })
+
+  it('returns empty string for empty, null, and undefined input', () => {
+    expect(previewText('')).toBe('')
+    expect(previewText(null)).toBe('')
+    expect(previewText(undefined)).toBe('')
+  })
+
+  it('drops markdown emphasis markers but keeps the text', () => {
+    expect(previewText('**bold** and *italic* and ~~struck~~')).toBe('bold and italic and struck')
+  })
+
+  it('flattens nested emphasis', () => {
+    expect(previewText('**bold with *inner italic* inside**')).toBe('bold with inner italic inside')
+  })
+
+  it('drops inline code backticks', () => {
+    expect(previewText('run `npm test` now')).toBe('run npm test now')
+  })
+
+  it('keeps fenced code block contents and collapses their newlines', () => {
+    expect(previewText('see:\n```\nline one\nline two\n```')).toBe('see: line one line two')
+  })
+
+  it('leaves an unterminated fence as literal text', () => {
+    expect(previewText('oops ```never closed')).toBe('oops ```never closed')
+  })
+
+  it('renders a resolved mention as @ plus the display name', () => {
+    const mentions = [{ account: 'alice', engName: 'Alice Chen' }]
+    expect(previewText('hey @alice ping', mentions)).toBe('hey @Alice Chen ping')
+  })
+
+  it('renders @all as @all', () => {
+    expect(previewText('@all standup now')).toBe('@all standup now')
+  })
+
+  it('leaves an unresolved mention as literal text', () => {
+    expect(previewText('hey @nobody there', [])).toBe('hey @nobody there')
+  })
+
+  it('renders a link as its visible label, never a separate href', () => {
+    expect(previewText('see https://example.com/x now')).toBe('see https://example.com/x now')
+  })
+
+  it('collapses newlines and runs of whitespace to single spaces, then trims', () => {
+    expect(previewText('  line one\n\n  line   two \t three  ')).toBe('line one line two three')
+  })
+
+  it('caps the result at PREVIEW_MAX_LENGTH characters', () => {
+    const long = 'x'.repeat(500)
+    const out = previewText(long)
+    expect(out).toHaveLength(PREVIEW_MAX_LENGTH)
+    expect(PREVIEW_MAX_LENGTH).toBe(140)
+  })
+})
+
+describe('attachmentFallbackText', () => {
+  it('returns empty string for no attachments', () => {
+    expect(attachmentFallbackText(undefined)).toBe('')
+    expect(attachmentFallbackText([])).toBe('')
+  })
+
+  it('labels an image Photo', () => {
+    expect(attachmentFallbackText([{ imageUrl: '/a.png' }])).toBe('Photo')
+  })
+
+  it('labels audio and video', () => {
+    expect(attachmentFallbackText([{ audioUrl: '/a.mp3' }])).toBe('Audio')
+    expect(attachmentFallbackText([{ videoUrl: '/a.mp4' }])).toBe('Video')
+  })
+
+  it('uses a generic file attachment title', () => {
+    expect(attachmentFallbackText([{ title: 'report.pdf', fileType: 'application/pdf' }])).toBe('report.pdf')
+  })
+
+  it('falls back to File for an untitled file attachment', () => {
+    expect(attachmentFallbackText([{ title: '', fileType: 'application/pdf' }])).toBe('File')
+  })
+
+  it('classifies by the first attachment only', () => {
+    expect(attachmentFallbackText([{ imageUrl: '/a.png' }, { title: 'b.pdf' }])).toBe('Photo')
+  })
+})
+
+describe('previewSnippet', () => {
+  it('prefers text over the attachment fallback', () => {
+    expect(previewSnippet('look at this', [], [{ imageUrl: '/a.png' }])).toBe('look at this')
+  })
+
+  it('falls back to the attachment label when the text is empty', () => {
+    expect(previewSnippet('', [], [{ imageUrl: '/a.png' }])).toBe('Photo')
+  })
+
+  it('returns empty string when there is neither text nor attachments', () => {
+    expect(previewSnippet('', [], [])).toBe('')
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- src/lib/previewText.test.js`
+Expected: FAIL — `Failed to resolve import "./previewText"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/previewText.js`:
+
+```js
+// Flatten a message body into a single-line plain-text snippet for the sidebar
+// room list. Reuses the message-content tokenizer so the snippet and the
+// rendered message agree on what the body says. No React, no I/O.
+
+import { parseMessageContent } from './messageContent'
+import { attachmentKind } from './attachment'
+
+// Hard cap on the returned string. CSS ellipsis truncates visually but leaves
+// the whole string in the DOM, so without this a multi-thousand-character
+// message sits in the sidebar for as long as it's the room's latest.
+export const PREVIEW_MAX_LENGTH = 140
+
+const KIND_LABEL = { image: 'Photo', audio: 'Audio', video: 'Video' }
+
+/**
+ * Flatten a message body to a single line of plain text.
+ *
+ * @param {string | null | undefined} content
+ * @param {{ account?: string, engName?: string }[]} [mentions]
+ * @returns {string} '' when there is nothing to show
+ */
+export function previewText(content, mentions = []) {
+  if (!content) return ''
+  const flat = flattenNodes(parseMessageContent(content, mentions))
+  const collapsed = flat.replace(/\s+/g, ' ').trim()
+  return collapsed.length > PREVIEW_MAX_LENGTH ? collapsed.slice(0, PREVIEW_MAX_LENGTH) : collapsed
+}
+
+/**
+ * Label for a message whose body is empty but which carries attachments.
+ *
+ * @param {import('../api/types').Attachment[] | null | undefined} attachments
+ * @returns {string} '' when there are none
+ */
+export function attachmentFallbackText(attachments) {
+  const first = attachments?.[0]
+  if (!first) return ''
+  return KIND_LABEL[attachmentKind(first)] ?? (first.title || 'File')
+}
+
+/**
+ * The sidebar snippet for a message: its flattened body, or an attachment
+ * label when the body is empty. Single entry point for both preview writers.
+ *
+ * @param {string | null | undefined} content
+ * @param {{ account?: string, engName?: string }[]} [mentions]
+ * @param {import('../api/types').Attachment[] | null | undefined} [attachments]
+ * @returns {string}
+ */
+export function previewSnippet(content, mentions, attachments) {
+  return previewText(content, mentions) || attachmentFallbackText(attachments)
+}
+
+function flattenNodes(nodes) {
+  let out = ''
+  for (const node of nodes) out += flattenNode(node)
+  return out
+}
+
+function flattenNode(node) {
+  switch (node.type) {
+    case 'mention':
+      return `@${node.display}`
+    // link/code/codeblock all carry their visible text on `.text`; a link's
+    // href is deliberately never emitted separately.
+    case 'link':
+    case 'code':
+    case 'codeblock':
+      return node.text
+    case 'strong':
+    case 'em':
+    case 'del':
+      return flattenNodes(node.children)
+    default:
+      return node.text ?? ''
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm test -- src/lib/previewText.test.js`
+Expected: PASS, 21 tests.
+
+If the unterminated-fence case fails, do **not** change the expectation — check that `parseMessageContent` emitted the backticks as plain text. The tokenizer's `FENCE_RE` requires a closing fence, so an unterminated one stays literal.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/previewText.js src/lib/previewText.test.js
+git commit -m "feat(chat-frontend): add previewText flattener for sidebar snippets"
+```
+
+---
+
+### Task 2: Display-name resolution (`lib/participantName.js`)
+
+The only display-name rule in the codebase is private to `MessageRow`. The preview writers need the same rule for two different shapes, so it moves to `lib/` with both consumers on one implementation.
+
+**Files:**
+- Create: `src/lib/participantName.js`
+- Test: `src/lib/participantName.test.js`
+- Modify: `src/components/shared/MessageList/MessageRow/MessageRow.jsx:23-31`
+- Test: `src/components/shared/MessageList/MessageRow/MessageRow.test.jsx`
+
+**Interfaces:**
+- Produces:
+  - `participantDisplayName(participant) → string` — for a wire `Participant` (used on `PreviewMessage.sender`)
+  - `messageSenderName(msg) → string` — for a `Message` (used on live messages and by `MessageRow`)
+
+**Behavior change to be aware of:** the current `MessageRow.senderName` reads `msg.sender.engName` and never consults `msg.sender.displayName`, even though the Go `Participant` has carried `DisplayName` all along. The extracted helper prefers `displayName`. `msg.userDisplayName` still wins ahead of both, so this only changes rendering when the top-level field is absent and the nested one is present — for bot senders, `displayName` is the app name and is the better answer.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/participantName.test.js`:
+
+```js
+import { describe, it, expect } from 'vitest'
+import { participantDisplayName, messageSenderName } from './participantName'
+
+describe('participantDisplayName', () => {
+  it('prefers the server-composed displayName', () => {
+    expect(participantDisplayName({ displayName: 'Alice Chen', engName: 'Alice', account: 'alice' }))
+      .toBe('Alice Chen')
+  })
+
+  it('falls back to engName, then account, then userId', () => {
+    expect(participantDisplayName({ engName: 'Alice', account: 'alice' })).toBe('Alice')
+    expect(participantDisplayName({ account: 'alice', userId: 'u1' })).toBe('alice')
+    expect(participantDisplayName({ userId: 'u1' })).toBe('u1')
+  })
+
+  it('returns Unknown for null, undefined, and an empty participant', () => {
+    expect(participantDisplayName(null)).toBe('Unknown')
+    expect(participantDisplayName(undefined)).toBe('Unknown')
+    expect(participantDisplayName({})).toBe('Unknown')
+  })
+})
+
+describe('messageSenderName', () => {
+  it('prefers the top-level userDisplayName', () => {
+    expect(messageSenderName({ userDisplayName: 'Alice Chen', sender: { engName: 'Alice' } }))
+      .toBe('Alice Chen')
+  })
+
+  it('falls back to the nested sender participant', () => {
+    expect(messageSenderName({ sender: { displayName: 'Deploy Bot' } })).toBe('Deploy Bot')
+    expect(messageSenderName({ sender: { engName: 'Alice' } })).toBe('Alice')
+  })
+
+  it('falls back to userAccount then userId when there is no sender', () => {
+    expect(messageSenderName({ userAccount: 'alice' })).toBe('alice')
+    expect(messageSenderName({ userId: 'u1' })).toBe('u1')
+  })
+
+  it('returns Unknown for an empty or missing message', () => {
+    expect(messageSenderName({})).toBe('Unknown')
+    expect(messageSenderName(null)).toBe('Unknown')
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- src/lib/participantName.test.js`
+Expected: FAIL — `Failed to resolve import "./participantName"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/participantName.js`:
+
+```js
+// Display-name resolution for message senders. One rule, two shapes: a wire
+// Participant (nested on a PreviewMessage) and a Message (which carries the
+// server-composed name at the top level). No React, no I/O.
+
+/**
+ * Resolve a wire Participant to a render-ready name. `displayName` is composed
+ * server-side (engName + chineseName + account fallback; a bot's is its app
+ * name), so it wins when present.
+ *
+ * @param {{ displayName?: string, engName?: string, account?: string, userId?: string } | null | undefined} participant
+ * @returns {string}
+ */
+export function participantDisplayName(participant) {
+  if (!participant) return 'Unknown'
+  return participant.displayName || participant.engName || participant.account || participant.userId || 'Unknown'
+}
+
+/**
+ * Resolve a Message's sender name. The top-level `userDisplayName` is the
+ * server's render-ready composition and is preferred over the nested sender.
+ *
+ * @param {{ userDisplayName?: string, sender?: object, userAccount?: string, userId?: string } | null | undefined} msg
+ * @returns {string}
+ */
+export function messageSenderName(msg) {
+  if (!msg) return 'Unknown'
+  if (msg.userDisplayName) return msg.userDisplayName
+  if (msg.sender) return participantDisplayName(msg.sender)
+  return msg.userAccount || msg.userId || 'Unknown'
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm test -- src/lib/participantName.test.js`
+Expected: PASS, 9 tests.
+
+- [ ] **Step 5: Point MessageRow at the shared helper**
+
+In `src/components/shared/MessageList/MessageRow/MessageRow.jsx`, add to the imports:
+
+```jsx
+import { messageSenderName } from '@/lib/participantName'
+```
+
+Then delete the local `senderName` function (lines 23-31, the block starting `function senderName(msg) {` and ending with its closing brace) and replace every call to `senderName(` in that file with `messageSenderName(`. There are two call sites: inside `senderInitial` and in the component body.
+
+- [ ] **Step 6: Run the MessageRow tests to verify nothing regressed**
+
+Run: `npm test -- src/components/shared/MessageList/MessageRow/MessageRow.test.jsx`
+Expected: PASS, all existing tests green.
+
+- [ ] **Step 7: Add the behavior-change test**
+
+Append to `src/components/shared/MessageList/MessageRow/MessageRow.test.jsx`, inside the `describe('MessageRow', …)` block. The file has no render helper — every test inlines `render(<MessageRow … />)` against the module-level `msg` and `room` fixtures, so this one does too:
+
+```js
+  it('renders the nested sender displayName when userDisplayName is absent', () => {
+    const botMsg = {
+      id: 'm-bot',
+      content: 'deploy finished',
+      createdAt: '2026-05-13T10:42:00Z',
+      sender: { account: 'bot', displayName: 'Deploy Bot' },
+    }
+    render(<MessageRow message={botMsg} room={room} context="main" onThread={() => {}} onReply={() => {}} onJumpToMessage={() => {}} />)
+    expect(screen.getByText('Deploy Bot')).toBeInTheDocument()
+  })
+```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `npm test -- src/components/shared/MessageList/MessageRow/MessageRow.test.jsx`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/lib/participantName.js src/lib/participantName.test.js \
+        src/components/shared/MessageList/MessageRow/MessageRow.jsx \
+        src/components/shared/MessageList/MessageRow/MessageRow.test.jsx
+git commit -m "refactor(chat-frontend): extract sender display-name resolution to lib
+
+MessageRow held the only display-name rule in the codebase, private to the
+component. The sidebar preview needs the same rule for a wire Participant, so
+it moves to lib/ with both consumers on one implementation.
+
+The Participant branch now prefers the server-composed displayName, which the
+old inline version ignored despite Go having carried it all along."
+```
+
+---
+
+### Task 3: Wire type mirrors
+
+Pure type declarations. Its test is `npm run typecheck` — there is no runtime behavior to assert. Later tasks do not compile without it.
+
+**Files:**
+- Modify: `src/api/types.ts`
+- Modify: `src/api/index.ts:62-95`
+- Modify: `src/context/RoomEventsContext/RoomEventsContext.tsx`
+
+**Interfaces:**
+- Produces: `PreviewMessage` (exported from `@/api`), `Participant.displayName`, `SubscriptionRoom.previewMessage`, `RoomPreview`, `RoomEventsState.previews`, `RoomSummary.preview`
+
+- [ ] **Step 1: Add `displayName` to `Participant`**
+
+In `src/api/types.ts`, in the `Participant` interface (around line 169), add after `siteId`:
+
+```ts
+  /** Server-composed render-ready name (engName + chineseName + account
+   *  fallback; a bot sender's is its app name). Prefer it over the raw
+   *  fields. Mirrors model.Participant.DisplayName. */
+  displayName?: string
+```
+
+- [ ] **Step 2: Add the `PreviewMessage` interface**
+
+In `src/api/types.ts`, immediately after the `Attachment` interface (which ends around line 217), add:
+
+```ts
+/** Mirrors model.PreviewMessage — a room's most-recent eligible message,
+ *  resolved server-side at read time for room-list rendering. Eligible means
+ *  not soft-deleted and not a system message; the server walks back past an
+ *  ineligible tail, so the client never re-implements that rule.
+ *
+ *  Delivered on `subscription.list` rows (`SubscriptionRoom.previewMessage`)
+ *  and refreshed on `message_edited` / `message_deleted` events. */
+export interface PreviewMessage {
+  messageId: string
+  sender: Participant
+  /** The full message body; the client truncates for display. */
+  content: string
+  /** RFC3339. */
+  createdAt: string
+  attachments?: Attachment[]
+  mentions?: Participant[]
+  /** Always empty today — the server-side write path has not landed.
+   *  Declared for forward-compat; nothing reads it. */
+  visibleTo?: string
+}
+```
+
+- [ ] **Step 3: Add `previewMessage` to `SubscriptionRoom`**
+
+In `src/api/types.ts`, in the `SubscriptionRoom` interface (around line 30), add after `keyVersion`:
+
+```ts
+  /** The room's latest eligible message. Omitted when the room has no
+   *  message, that site's enrichment degraded, or the request set
+   *  `includeLastMessage: false`. Never present on live
+   *  `subscription.update` events — only on `subscription.list` rows. */
+  previewMessage?: PreviewMessage
+```
+
+- [ ] **Step 4: Re-export from the barrel**
+
+In `src/api/index.ts`, inside the `export type { … } from './types'` block, add `PreviewMessage` on the line after `Participant`:
+
+```ts
+  Participant,
+  PreviewMessage,
+```
+
+- [ ] **Step 5: Add the context types**
+
+In `src/context/RoomEventsContext/RoomEventsContext.tsx`, add above the `RoomSummary` interface:
+
+```ts
+/** One room's stored sidebar preview. Flattened and name-resolved at write
+ *  time so the render layer never branches on whether it came from a wire
+ *  PreviewMessage or a live Message. */
+interface RoomPreview {
+  /** The previewed message's id — guards the delete-clears rule in the
+   *  reducer's ROOM_PREVIEW_UPDATED case. */
+  messageId: string
+  senderName: string
+  /** Single-line, flattened, capped at PREVIEW_MAX_LENGTH. */
+  text: string
+}
+```
+
+Add to the `RoomSummary` interface, after `hrInfo`:
+
+```ts
+  /** Joined in by useSidebarSections from state.previews. Undefined when the
+   *  room has no preview — the row still renders at full height with a blank
+   *  snippet line. */
+  preview?: RoomPreview
+```
+
+Add to the `RoomEventsState` interface, after `subscriptions`:
+
+```ts
+  /** Keyed by roomId. Absent key = no preview to show. Deliberately NOT a
+   *  field on RoomSummary: summaries are rebuilt from `Room` records, which
+   *  mirror pkg/model.Room — and the backend hangs previewMessage off
+   *  SubscriptionRoom instead, so a summary field would break the mirror. */
+  previews: Record<string, RoomPreview>
+```
+
+Finally, add `RoomPreview` to the type re-export at the bottom of the file:
+
+```ts
+export type { RoomEventsState, RoomSummary, RoomPreview, RoomBufferState, RoomEventsContextValue }
+```
+
+- [ ] **Step 6: Run typecheck to verify it passes**
+
+Run: `npm run typecheck`
+Expected: PASS, no errors. If it reports that `previews` is missing on an object literal typed `RoomEventsState`, that is Task 4's job — leave it and note it; the reducer's `initialState` is JS and unchecked, so this should not happen.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `npm test`
+Expected: PASS — no runtime behavior changed.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/api/types.ts src/api/index.ts src/context/RoomEventsContext/RoomEventsContext.tsx
+git commit -m "types(chat-frontend): mirror PreviewMessage and Participant.displayName"
+```
+
+---
+
+### Task 4: Reducer — `previews` state and the message-derived writers
+
+Adds the state key and every writer whose source is a message the client already holds. The event-sourced writer is Task 5.
+
+**Files:**
+- Modify: `src/context/RoomEventsContext/reducer.js`
+- Test: `src/context/RoomEventsContext/reducer.test.js`
+
+**Interfaces:**
+- Consumes: `previewSnippet`, `previewText` (Task 1); `participantDisplayName`, `messageSenderName` (Task 2)
+- Produces: `state.previews: Record<roomId, {messageId, senderName, text}>`; module-private `previewFromMessage(msg)` and `previewFromWire(previewMessage)`, both returning the stored shape or `null`. Task 5 uses `previewFromWire`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/context/RoomEventsContext/reducer.test.js`. Match the file's existing import style — it already imports `roomEventsReducer` and `initialState`; add nothing new to the imports.
+
+```js
+describe('roomEventsReducer previews', () => {
+  const wirePreview = (over = {}) => ({
+    messageId: 'm1',
+    sender: { account: 'alice', displayName: 'Alice Chen' },
+    content: 'hello **there**',
+    createdAt: '2026-08-14T10:00:00Z',
+    ...over,
+  })
+
+  it('starts empty', () => {
+    expect(initialState.previews).toEqual({})
+  })
+
+  it('BUCKETS_LOADED seeds a preview from sub.room.previewMessage', () => {
+    const next = roomEventsReducer(initialState, {
+      type: 'BUCKETS_LOADED',
+      favoriteIds: [], appIds: [], channelDmIds: ['r1'],
+      rooms: [{ id: 'r1', name: 'General', type: 'channel', siteId: 'site-A', userCount: 2 }],
+      subscriptions: { r1: { roomId: 'r1', name: 'General', room: { previewMessage: wirePreview() } } },
+    })
+    expect(next.previews.r1).toEqual({ messageId: 'm1', senderName: 'Alice Chen', text: 'hello there' })
+  })
+
+  it('BUCKETS_LOADED leaves a room without a previewMessage absent from the map', () => {
+    const next = roomEventsReducer(initialState, {
+      type: 'BUCKETS_LOADED',
+      favoriteIds: [], appIds: [], channelDmIds: ['r1'],
+      rooms: [{ id: 'r1', name: 'General', type: 'channel', siteId: 'site-A', userCount: 2 }],
+      subscriptions: { r1: { roomId: 'r1', name: 'General', room: {} } },
+    })
+    expect(next.previews.r1).toBeUndefined()
+  })
+
+  it('MESSAGE_RECEIVED overwrites the preview for a room with no message buffer', () => {
+    const next = roomEventsReducer(initialState, {
+      type: 'MESSAGE_RECEIVED',
+      event: {
+        roomId: 'r1',
+        message: { id: 'm2', content: 'newest', userDisplayName: 'Bob Lin', createdAt: '2026-08-14T11:00:00Z' },
+      },
+    })
+    expect(next.previews.r1).toEqual({ messageId: 'm2', senderName: 'Bob Lin', text: 'newest' })
+  })
+
+  it('MESSAGE_RECEIVED uses the attachment fallback when the body is empty', () => {
+    const next = roomEventsReducer(initialState, {
+      type: 'MESSAGE_RECEIVED',
+      event: {
+        roomId: 'r1',
+        message: {
+          id: 'm3', content: '', userDisplayName: 'Bob Lin',
+          createdAt: '2026-08-14T11:00:00Z', attachments: [{ imageUrl: '/a.png' }],
+        },
+      },
+    })
+    expect(next.previews.r1.text).toBe('Photo')
+  })
+
+  it('MESSAGE_RECEIVED ignores a thread reply', () => {
+    const seeded = { ...initialState, previews: { r1: { messageId: 'm1', senderName: 'A', text: 'first' } } }
+    const next = roomEventsReducer(seeded, {
+      type: 'MESSAGE_RECEIVED',
+      event: {
+        roomId: 'r1',
+        message: { id: 'm9', content: 'reply', threadParentMessageId: 'm1', createdAt: '2026-08-14T12:00:00Z' },
+      },
+    })
+    expect(next.previews.r1.messageId).toBe('m1')
+  })
+
+  it('MESSAGE_SENT_LOCAL previews the local send optimistically', () => {
+    const next = roomEventsReducer(initialState, {
+      type: 'MESSAGE_SENT_LOCAL',
+      roomId: 'r1',
+      message: { id: 'm4', content: 'typed by me', userDisplayName: 'Me', createdAt: '2026-08-14T13:00:00Z', _local: true },
+    })
+    expect(next.previews.r1).toEqual({ messageId: 'm4', senderName: 'Me', text: 'typed by me' })
+  })
+
+  it('MESSAGE_EDITED_LOCAL rewrites the preview only when the edited message is the one on display', () => {
+    const seeded = {
+      ...initialState,
+      previews: { r1: { messageId: 'm5', senderName: 'Me', text: 'before' } },
+      roomState: { r1: { ...emptyBuffer(), messages: [{ id: 'm5', content: 'before' }] } },
+    }
+    const hit = roomEventsReducer(seeded, {
+      type: 'MESSAGE_EDITED_LOCAL', roomId: 'r1', messageId: 'm5',
+      content: 'after', editedAt: '2026-08-14T14:00:00Z',
+    })
+    expect(hit.previews.r1.text).toBe('after')
+
+    const miss = roomEventsReducer(seeded, {
+      type: 'MESSAGE_EDITED_LOCAL', roomId: 'r1', messageId: 'm5-other',
+      content: 'irrelevant', editedAt: '2026-08-14T14:00:00Z',
+    })
+    expect(miss.previews.r1.text).toBe('before')
+  })
+
+  it('MESSAGE_DELETED_LOCAL leaves the preview alone', () => {
+    const seeded = {
+      ...initialState,
+      previews: { r1: { messageId: 'm6', senderName: 'Me', text: 'doomed' } },
+      roomState: { r1: { ...emptyBuffer(), messages: [{ id: 'm6', content: 'doomed' }] } },
+    }
+    const next = roomEventsReducer(seeded, { type: 'MESSAGE_DELETED_LOCAL', roomId: 'r1', messageId: 'm6' })
+    expect(next.previews.r1.text).toBe('doomed')
+  })
+
+  it('SUBSCRIPTION_UPSERTED never seeds a preview', () => {
+    // Its `added` payload embeds a `room` object, which makes it look like a
+    // seeding source — but docs/client-api.md specifies previewMessage is
+    // always omitted there. Regression guard against wiring it up.
+    const next = roomEventsReducer(initialState, {
+      type: 'SUBSCRIPTION_UPSERTED',
+      subscription: { roomId: 'r1', roomType: 'channel', siteId: 'site-A', name: 'General', room: {} },
+    })
+    expect(next.previews).toEqual({})
+  })
+
+  it('ROOM_REMOVED drops the room preview', () => {
+    const seeded = { ...initialState, previews: { r1: { messageId: 'm7', senderName: 'A', text: 'x' } } }
+    const next = roomEventsReducer(seeded, { type: 'ROOM_REMOVED', roomId: 'r1' })
+    expect(next.previews.r1).toBeUndefined()
+  })
+
+  it('RESET clears every preview', () => {
+    const seeded = { ...initialState, previews: { r1: { messageId: 'm8', senderName: 'A', text: 'x' } } }
+    expect(roomEventsReducer(seeded, { type: 'RESET' }).previews).toEqual({})
+  })
+})
+```
+
+Add this helper near the top of the same `describe` block (the file may already have an equivalent — reuse it if so, and delete this one):
+
+```js
+function emptyBuffer() {
+  return {
+    messages: [], hasLoadedHistory: false, historyError: null, unreadCount: 0,
+    hasMention: false, mentionAll: false, lastMsgAt: null, lastMsgId: null,
+    bufferMode: 'live', pendingLiveMessages: [], focusMessageId: null,
+    hasMoreOlder: true, loadingOlder: false,
+  }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm test -- src/context/RoomEventsContext/reducer.test.js -t previews`
+Expected: FAIL — `expected undefined to equal {}` on the first case, and `Cannot read properties of undefined` on the rest.
+
+- [ ] **Step 3: Add the state key and the two builders**
+
+In `src/context/RoomEventsContext/reducer.js`, add to the imports at the top:
+
+```js
+import { previewSnippet, previewText } from '@/lib/previewText'
+import { participantDisplayName, messageSenderName } from '@/lib/participantName'
+```
+
+Add to `initialState`, after the `subscriptions: {}` entry:
+
+```js
+  /**
+   * Per-roomId sidebar preview: the room's most recent eligible message,
+   * flattened to a single line at write time. An absent key means there is
+   * nothing to show — the row still renders at full height with a blank
+   * snippet line (the row's height is a CSS property, not a consequence of
+   * this map).
+   *
+   * Shape: { [roomId]: { messageId, senderName, text } }
+   */
+  previews: {},
+```
+
+Add these two builders next to `toSummary` (above `mergeSubscriptionIntoSummary`):
+
+```js
+// Build a stored preview from a live message. Returns null when there is
+// nothing to store, so callers leave the map untouched rather than writing an
+// empty sentinel.
+function previewFromMessage(msg) {
+  if (!msg || !msg.id) return null
+  return {
+    messageId: msg.id,
+    senderName: messageSenderName(msg),
+    text: previewSnippet(msg.content, msg.mentions, msg.attachments),
+  }
+}
+
+// Build a stored preview from a wire PreviewMessage (subscription.list rows
+// and the refreshed preview on edit/delete events).
+function previewFromWire(previewMessage) {
+  if (!previewMessage || !previewMessage.messageId) return null
+  return {
+    messageId: previewMessage.messageId,
+    senderName: participantDisplayName(previewMessage.sender),
+    text: previewSnippet(previewMessage.content, previewMessage.mentions, previewMessage.attachments),
+  }
+}
+```
+
+- [ ] **Step 4: Wire `BUCKETS_LOADED`**
+
+In the `BUCKETS_LOADED` case, after the `summaries` if/else and before the `return`, insert:
+
+```js
+      // Seed from the room metadata user-service embeds on each list row.
+      // Starts from the existing map so the partial-update path (no rooms
+      // supplied) doesn't wipe previews already in hand.
+      const previews = { ...state.previews }
+      for (const [roomId, sub] of Object.entries(subs)) {
+        const preview = previewFromWire(sub?.room?.previewMessage)
+        if (preview) previews[roomId] = preview
+      }
+```
+
+and add `previews,` to that case's returned object.
+
+- [ ] **Step 5: Wire `MESSAGE_RECEIVED`**
+
+In the `MESSAGE_RECEIVED` case, immediately after the thread-reply block closes — that is, right after `const roomId = evt.roomId` — insert:
+
+```js
+      // Thread replies returned above, so anything reaching here belongs in
+      // the room timeline and is a preview candidate. Computed once and
+      // applied at every return point below.
+      const nextPreview = previewFromMessage(msg)
+      const previews = nextPreview
+        ? { ...state.previews, [roomId]: nextPreview }
+        : state.previews
+```
+
+Then add `previews,` to **all three** returned objects in this case: the historical-buffer-mode return, the `existingIdx >= 0` optimistic-echo return, and the final live-append return. Missing any one of them means previews silently stop updating in that mode.
+
+- [ ] **Step 6: Wire the local-optimistic and lifecycle cases**
+
+In `MESSAGE_SENT_LOCAL`, after `const messages = appendBounded(prev.messages, msg)`, insert:
+
+```js
+      // A thread reply doesn't appear in the room timeline, so it isn't the
+      // room's preview either — matching the server, which omits
+      // previewMessage for hidden thread replies.
+      const nextPreview = msg.threadParentMessageId ? null : previewFromMessage(msg)
+      const previews = nextPreview
+        ? { ...state.previews, [roomId]: nextPreview }
+        : state.previews
+```
+
+and add `previews,` to its returned object.
+
+In `MESSAGE_EDITED_LOCAL`, after `const messages = [...]`, insert:
+
+```js
+      // Only the message currently on display affects the preview. The
+      // action carries no mentions, so mention tokens flatten literally
+      // here; the server's message_edited event follows with the
+      // authoritative preview a moment later.
+      const cur = state.previews[action.roomId]
+      const previews =
+        cur && cur.messageId === action.messageId
+          ? { ...state.previews, [action.roomId]: { ...cur, text: previewText(action.content) } }
+          : state.previews
+```
+
+and add `previews,` to its returned object.
+
+In `MESSAGE_DELETED_LOCAL`, add **nothing**. Leave a comment above its `return`:
+
+```js
+      // Preview deliberately untouched: the client can't reproduce the
+      // server's walk-back to an earlier eligible message. The authoritative
+      // message_deleted event corrects it.
+```
+
+In `ROOM_REMOVED`, after the `subscriptions` block, insert:
+
+```js
+      let previews = state.previews
+      if (previews[action.roomId]) {
+        const { [action.roomId]: _dropPreview, ...restPreviews } = previews
+        previews = restPreviews
+      }
+```
+
+and add `previews,` to its returned object.
+
+`RESET` returns `initialState`, which now carries `previews: {}` — no edit needed, but its test stays as a regression guard.
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `npm test -- src/context/RoomEventsContext/reducer.test.js`
+Expected: PASS — the new `previews` block plus every pre-existing reducer test.
+
+- [ ] **Step 8: Run the full suite and typecheck**
+
+Run: `npm test && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/context/RoomEventsContext/reducer.js src/context/RoomEventsContext/reducer.test.js
+git commit -m "feat(chat-frontend): track per-room message previews in the reducer"
+```
+
+---
+
+### Task 5: Reducer — `ROOM_PREVIEW_UPDATED`
+
+The event-sourced writer. Separate from Task 4 because it is the one case a reviewer might reject on its own: its clear rule is the subtlest logic in the feature.
+
+**Files:**
+- Modify: `src/context/RoomEventsContext/reducer.js`
+- Test: `src/context/RoomEventsContext/reducer.test.js`
+
+**Interfaces:**
+- Consumes: `previewFromWire` (Task 4)
+- Produces: the `ROOM_PREVIEW_UPDATED` action contract that Task 6 dispatches:
+  `{ type: 'ROOM_PREVIEW_UPDATED', roomId: string, previewMessage?: PreviewMessage, deletedMessageId?: string }`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `describe('roomEventsReducer previews', …)` block in `src/context/RoomEventsContext/reducer.test.js`:
+
+```js
+  describe('ROOM_PREVIEW_UPDATED', () => {
+    const seeded = () => ({
+      ...initialState,
+      previews: { r1: { messageId: 'm1', senderName: 'Alice Chen', text: 'old body' } },
+    })
+
+    it('overwrites from the event previewMessage', () => {
+      const next = roomEventsReducer(seeded(), {
+        type: 'ROOM_PREVIEW_UPDATED',
+        roomId: 'r1',
+        previewMessage: {
+          messageId: 'm2',
+          sender: { account: 'bob', displayName: 'Bob Lin' },
+          content: 'edited body',
+          createdAt: '2026-08-14T15:00:00Z',
+        },
+      })
+      expect(next.previews.r1).toEqual({ messageId: 'm2', senderName: 'Bob Lin', text: 'edited body' })
+    })
+
+    it('updates a room that has no message buffer', () => {
+      const next = roomEventsReducer(initialState, {
+        type: 'ROOM_PREVIEW_UPDATED',
+        roomId: 'r-unopened',
+        previewMessage: {
+          messageId: 'm3',
+          sender: { account: 'bob', displayName: 'Bob Lin' },
+          content: 'from a room I never opened',
+          createdAt: '2026-08-14T15:00:00Z',
+        },
+      })
+      expect(next.previews['r-unopened'].text).toBe('from a room I never opened')
+    })
+
+    it('clears when the deleted message is the one on display and no preview follows', () => {
+      const next = roomEventsReducer(seeded(), {
+        type: 'ROOM_PREVIEW_UPDATED', roomId: 'r1', deletedMessageId: 'm1',
+      })
+      expect(next.previews.r1).toBeUndefined()
+    })
+
+    it('does NOT clear when the deleted message is a different one', () => {
+      const next = roomEventsReducer(seeded(), {
+        type: 'ROOM_PREVIEW_UPDATED', roomId: 'r1', deletedMessageId: 'm-other',
+      })
+      expect(next.previews.r1.text).toBe('old body')
+    })
+
+    it('leaves the preview alone when neither a previewMessage nor a deletedMessageId is given', () => {
+      const next = roomEventsReducer(seeded(), { type: 'ROOM_PREVIEW_UPDATED', roomId: 'r1' })
+      expect(next.previews.r1.text).toBe('old body')
+    })
+
+    it('ignores an action with no roomId', () => {
+      const state = seeded()
+      expect(roomEventsReducer(state, { type: 'ROOM_PREVIEW_UPDATED' })).toBe(state)
+    })
+  })
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm test -- src/context/RoomEventsContext/reducer.test.js -t ROOM_PREVIEW_UPDATED`
+Expected: FAIL — the reducer falls through to its default case, so the preview never changes and the overwrite cases fail first.
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/context/RoomEventsContext/reducer.js`, add a new case next to `MESSAGE_DELETED`:
+
+```js
+    case 'ROOM_PREVIEW_UPDATED': {
+      // The room's refreshed preview after an edit or delete, computed
+      // server-side. Its own action rather than a field on MESSAGE_EDITED /
+      // MESSAGE_DELETED because both of those bail when the room has no
+      // message buffer — which is the normal case for a sidebar row.
+      const { roomId, previewMessage, deletedMessageId } = action
+      if (!roomId) return state
+      const next = previewFromWire(previewMessage)
+      if (next) return { ...state, previews: { ...state.previews, [roomId]: next } }
+      // No preview on the event. For a delete that means nothing eligible is
+      // left — but only when the deleted message is the one on display. Any
+      // other id is contradictory input (the server would have echoed the
+      // unchanged preview), so leave what's there.
+      const cur = state.previews[roomId]
+      if (!deletedMessageId || !cur || cur.messageId !== deletedMessageId) return state
+      const { [roomId]: _cleared, ...rest } = state.previews
+      return { ...state, previews: rest }
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm test -- src/context/RoomEventsContext/reducer.test.js`
+Expected: PASS, including all pre-existing cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/context/RoomEventsContext/reducer.js src/context/RoomEventsContext/reducer.test.js
+git commit -m "feat(chat-frontend): apply server-refreshed previews on edit and delete"
+```
+
+---
+
+### Task 6: Dispatch `ROOM_PREVIEW_UPDATED` and join previews into the sidebar
+
+The context wiring: dispatch the action from live events, and expose the result through `useSidebarSections`. These ship together because the join is what makes the dispatch observable — there is no other reader of `state.previews`.
+
+Placement matters: the dispatch must happen **before** the existing early return that drops edits with no plaintext body, or encrypted-room edits never update the sidebar.
+
+**Files:**
+- Modify: `src/context/RoomEventsContext/useRoomSubscriptions.js:196-221`
+- Modify: `src/context/RoomEventsContext/RoomEventsContext.tsx` (`useSidebarSections`)
+- Test: `src/context/RoomEventsContext/RoomEventsContext.test.jsx`
+
+**Interfaces:**
+- Consumes: the `ROOM_PREVIEW_UPDATED` action contract from Task 5; `state.previews` from Task 4; `RoomSummary.preview` from Task 3
+- Produces: `RoomSummary.preview` populated on every room `useSidebarSections` returns — Task 7 renders it
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/context/RoomEventsContext/RoomEventsContext.test.jsx`, at the end of the `describe('RoomEventsProvider', …)` block. This uses the file's existing `mockNats` / `wrap` / `roomToSub` helpers and its established pattern of capturing subscription callbacks in a `handlers` Map.
+
+First add the probe, next to the file's other probes (`SummariesProbe`, `EventsProbe`):
+
+```jsx
+function PreviewProbe() {
+  const sections = useSidebarSections()
+  const rooms = sections.flatMap((s) => s.rooms)
+  return (
+    <div data-testid="previews">
+      {rooms
+        .map((r) => `${r.id}=${r.preview ? `${r.preview.senderName}|${r.preview.text}` : ''}`)
+        .join(';')}
+    </div>
+  )
+}
+```
+
+Then the tests:
+
+```jsx
+  describe('sidebar previews', () => {
+    // A channel room whose subscription.list row carries a seeded preview.
+    const seededSub = () => ({
+      ...roomToSub({ id: 'g1', name: 'General', type: 'channel', siteId: 'site-A', userCount: 3 }),
+      room: {
+        userCount: 3,
+        lastMsgAt: '2026-08-14T10:00:00Z',
+        previewMessage: {
+          messageId: 'm1',
+          sender: { account: 'alice', displayName: 'Alice Chen' },
+          content: 'original body',
+          createdAt: '2026-08-14T10:00:00Z',
+        },
+      },
+    })
+
+    function setup() {
+      const request = vi.fn().mockImplementation((subject, payload) => {
+        if (subject.endsWith('.subscription.list') && payload?.type === 'rooms')
+          return Promise.resolve({ subscriptions: [seededSub()] })
+        return Promise.resolve({ subscriptions: [] })
+      })
+      const handlers = new Map()
+      const subscribe = vi.fn().mockImplementation((subject, cb) => {
+        handlers.set(subject, cb)
+        return { unsubscribe: vi.fn() }
+      })
+      return { nats: mockNats({ request, subscribe }), handlers, subscribe }
+    }
+
+    it('seeds the sidebar preview from subscription.list', async () => {
+      const { nats, subscribe } = setup()
+      render(wrap(<PreviewProbe />, nats))
+      await waitFor(() => expect(subscribe).toHaveBeenCalled())
+      await waitFor(() =>
+        expect(screen.getByTestId('previews').textContent).toBe('g1=Alice Chen|original body')
+      )
+    })
+
+    it('refreshes the preview from a message_edited event', async () => {
+      const { nats, handlers, subscribe } = setup()
+      render(wrap(<PreviewProbe />, nats))
+      await waitFor(() => expect(subscribe).toHaveBeenCalled())
+      await waitFor(() => expect(handlers.has('chat.room.g1.event')).toBe(true))
+
+      act(() => {
+        handlers.get('chat.room.g1.event')({
+          type: 'message_edited',
+          roomId: 'g1',
+          messageId: 'm1',
+          newContent: 'edited body',
+          editedAt: '2026-08-14T15:00:00Z',
+          previewMessage: {
+            messageId: 'm1',
+            sender: { account: 'alice', displayName: 'Alice Chen' },
+            content: 'edited body',
+            createdAt: '2026-08-14T15:00:00Z',
+          },
+        })
+      })
+      await waitFor(() =>
+        expect(screen.getByTestId('previews').textContent).toBe('g1=Alice Chen|edited body')
+      )
+    })
+
+    it('refreshes the preview for an encrypted edit carrying no plaintext body', async () => {
+      const { nats, handlers, subscribe } = setup()
+      render(wrap(<PreviewProbe />, nats))
+      await waitFor(() => expect(subscribe).toHaveBeenCalled())
+      await waitFor(() => expect(handlers.has('chat.room.g1.event')).toBe(true))
+
+      // No `newContent` — the mutation itself is dropped, but the sidebar
+      // snippet must still refresh from the plaintext previewMessage.
+      act(() => {
+        handlers.get('chat.room.g1.event')({
+          type: 'message_edited',
+          roomId: 'g1',
+          messageId: 'm1',
+          encryptedNewContent: { version: 1, nonce: 'n', ciphertext: 'c' },
+          editedAt: '2026-08-14T15:00:00Z',
+          previewMessage: {
+            messageId: 'm1',
+            sender: { account: 'alice', displayName: 'Alice Chen' },
+            content: 'server-side plaintext',
+            createdAt: '2026-08-14T15:00:00Z',
+          },
+        })
+      })
+      await waitFor(() =>
+        expect(screen.getByTestId('previews').textContent).toBe('g1=Alice Chen|server-side plaintext')
+      )
+    })
+
+    it('clears the preview when the displayed message is deleted and none follows', async () => {
+      const { nats, handlers, subscribe } = setup()
+      render(wrap(<PreviewProbe />, nats))
+      await waitFor(() => expect(subscribe).toHaveBeenCalled())
+      await waitFor(() => expect(handlers.has('chat.room.g1.event')).toBe(true))
+
+      act(() => {
+        handlers.get('chat.room.g1.event')({
+          type: 'message_deleted',
+          roomId: 'g1',
+          messageId: 'm1',
+          deletedBy: 'alice',
+          deletedAt: '2026-08-14T16:00:00Z',
+        })
+      })
+      await waitFor(() => expect(screen.getByTestId('previews').textContent).toBe('g1='))
+    })
+
+    it('keeps the preview when a different message is deleted', async () => {
+      const { nats, handlers, subscribe } = setup()
+      render(wrap(<PreviewProbe />, nats))
+      await waitFor(() => expect(subscribe).toHaveBeenCalled())
+      await waitFor(() => expect(handlers.has('chat.room.g1.event')).toBe(true))
+
+      act(() => {
+        handlers.get('chat.room.g1.event')({
+          type: 'message_deleted',
+          roomId: 'g1',
+          messageId: 'm-someone-else',
+          deletedBy: 'alice',
+          deletedAt: '2026-08-14T16:00:00Z',
+        })
+      })
+      // Give any dispatch a chance to land before asserting nothing changed.
+      await act(async () => { await Promise.resolve() })
+      expect(screen.getByTestId('previews').textContent).toBe('g1=Alice Chen|original body')
+    })
+  })
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm test -- src/context/RoomEventsContext/RoomEventsContext.test.jsx -t "sidebar previews"`
+Expected: FAIL — every case renders `g1=` because `useSidebarSections` doesn't join `preview` yet, and nothing dispatches `ROOM_PREVIEW_UPDATED`.
+
+- [ ] **Step 3: Add the join**
+
+In `src/context/RoomEventsContext/RoomEventsContext.tsx`, in `useSidebarSections`, widen the destructure and the enrich:
+
+```ts
+  const { summaries, subscriptions, chatlist, previews } = state
+  return useMemo(() => {
+    const enrich = (room: RoomSummary): RoomSummary => {
+      const sub = subscriptions[room.id]
+      const preview = previews[room.id]
+      if (!sub && !preview) return room
+      return {
+        ...room,
+        subscriptionName: sub?.name ?? room.subscriptionName,
+        hrInfo: sub?.hrInfo ?? room.hrInfo,
+        preview,
+      }
+    }
+    const sections = deriveSidebarSections(summaries, subscriptions, chatlist) as SidebarSection[]
+    return sections.map((s) => ({ ...s, rooms: s.rooms.map(enrich) }))
+  }, [summaries, subscriptions, chatlist, previews])
+```
+
+The `if (!sub && !preview) return room` early return preserves the previous identity-stable behavior for rooms with neither. `previews` joins the dependency list — omitting it would freeze the sidebar on the first render's previews.
+
+- [ ] **Step 4: Run the seed test to verify it passes**
+
+Run: `npm test -- src/context/RoomEventsContext/RoomEventsContext.test.jsx -t "seeds the sidebar preview"`
+Expected: PASS. The other four still fail — no dispatch yet.
+
+- [ ] **Step 5: Write the dispatch implementation**
+
+In `src/context/RoomEventsContext/useRoomSubscriptions.js`, in `handleMutationEvent`, change the `message_edited` branch so the preview dispatch precedes the plaintext guard:
+
+```js
+      if (evt?.type === 'message_edited' && evt.messageId) {
+        const { messageId, newContent, editedAt } = evt
+        // Preview first, and unconditionally: the sidebar snippet must update
+        // even when the edit itself can't be applied — an encrypted body
+        // returns below, and MESSAGE_EDITED bails for a room with no buffer.
+        // The server omits previewMessage for hidden thread-reply edits, so
+        // no client-side thread guard is needed here.
+        if (evt.previewMessage) {
+          safeDispatch({
+            type: 'ROOM_PREVIEW_UPDATED',
+            roomId: evt.roomId,
+            previewMessage: evt.previewMessage,
+          })
+        }
+        // Drop edits without a plaintext body. Encrypted channel rooms emit
+        // `encryptedNewContent` instead; blanking the existing content to ''
+        // would silently wipe the message until decryption is implemented.
+        if (typeof newContent !== 'string') return true
+```
+
+Leave the rest of that branch unchanged.
+
+Then change the `message_deleted` branch to dispatch the preview action first:
+
+```js
+      if (evt?.type === 'message_deleted' && evt.messageId) {
+        const { messageId } = evt
+        // deletedMessageId lets the reducer clear the preview only when the
+        // deleted message is the one on display; an absent previewMessage
+        // means nothing eligible is left in the room.
+        safeDispatch({
+          type: 'ROOM_PREVIEW_UPDATED',
+          roomId: evt.roomId,
+          previewMessage: evt.previewMessage,
+          deletedMessageId: messageId,
+        })
+        safeDispatch({ type: 'MESSAGE_DELETED', roomId: evt.roomId, messageId })
+        fanThreadMutation({ kind: 'deleted', messageId })
+        return true
+      }
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `npm test -- src/context/RoomEventsContext/RoomEventsContext.test.jsx`
+Expected: PASS — all five preview cases plus every pre-existing test in the file.
+
+- [ ] **Step 7: Run the full suite and typecheck**
+
+Run: `npm test && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/context/RoomEventsContext/useRoomSubscriptions.js \
+        src/context/RoomEventsContext/RoomEventsContext.tsx \
+        src/context/RoomEventsContext/RoomEventsContext.test.jsx
+git commit -m "feat(chat-frontend): dispatch preview updates and join them into the sidebar
+
+The dispatch precedes the plaintext-body guard so an encrypted-room edit still
+refreshes the sidebar snippet — broadcast-worker relays previewMessage in
+plaintext even when it encrypts the message body."
+```
+
+---
+
+### Task 7: Render the second line
+
+The visible deliverable, and a pure component change — `RoomList.test.jsx` already mocks `useSidebarSections`, so this task asserts on the DOM with no context in play.
+
+**Files:**
+- Modify: `src/components/MainApp/Sidebar/RoomList/RoomList.jsx:19-43`
+- Modify: `src/components/MainApp/Sidebar/RoomList/style.css:33-69`
+- Test: `src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx`
+
+**Interfaces:**
+- Consumes: `RoomSummary.preview` — `{ messageId, senderName, text }`, joined by `useSidebarSections` in Task 6
+- Produces: the rendered sidebar row; nothing downstream depends on it
+
+- [ ] **Step 1: Write the failing render tests**
+
+Append to `src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx`, inside the outermost `describe`. The file already has `summary(id, overrides)` and `section(key, rooms, over)` helpers — use them.
+
+```js
+  const preview = { messageId: 'm1', senderName: 'Alice Chen', text: 'hey are we still on' }
+
+  it('renders the sender prefix and snippet in a channel row', () => {
+    useSidebarSections.mockReturnValue([section('chats', [summary('r1', { preview })])])
+    render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
+    expect(screen.getByText('Alice Chen:')).toBeInTheDocument()
+    expect(screen.getByText('hey are we still on')).toBeInTheDocument()
+  })
+
+  it('omits the sender prefix in a DM row', () => {
+    useSidebarSections.mockReturnValue([
+      section('chats', [summary('r1', { type: 'dm', preview })]),
+    ])
+    render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
+    expect(screen.queryByText('Alice Chen:')).not.toBeInTheDocument()
+    expect(screen.getByText('hey are we still on')).toBeInTheDocument()
+  })
+
+  it('renders the snippet line empty when the room has no preview', () => {
+    useSidebarSections.mockReturnValue([section('chats', [summary('r1')])])
+    const { container } = render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
+    const line = container.querySelector('.room-preview')
+    expect(line).toBeInTheDocument()   // reserved, so the row height is stable
+    expect(line).toHaveTextContent('')
+  })
+
+  it('renders the attachment label a preview carries as its text', () => {
+    useSidebarSections.mockReturnValue([
+      section('chats', [summary('r1', { preview: { ...preview, text: 'Photo' } })]),
+    ])
+    render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
+    expect(screen.getByText('Photo')).toBeInTheDocument()
+  })
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm test -- src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx -t preview`
+Expected: FAIL — `Unable to find an element with the text: Alice Chen:`, and `.room-preview` is null.
+
+- [ ] **Step 3: Restructure `RoomItem`**
+
+In `src/components/MainApp/Sidebar/RoomList/RoomList.jsx`, replace the `RoomItem` return block. The name, badges, and counts move into a title row; the whole text column becomes one flex child so the drag handle keeps its place:
+
+```jsx
+    <div
+      className={classes.join(' ')}
+      onClick={() => onSelectRoom(room)}
+      draggable
+      onDragStart={(e) => onDragStartRoom(e, room)}
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={(e) => {
+        e.stopPropagation()
+        onDropOnRoom(room)
+      }}
+    >
+      <span className="room-drag-handle" aria-hidden="true">⋮⋮</span>
+      <div className="room-item-body">
+        <div className="room-item-title">
+          <span className="room-name">
+            {roomPrefix(room.type)}{roomDisplayName(room)}
+          </span>
+          {mentionBadge(room)}
+          <span className="room-meta">{room.userCount}</span>
+          {unread && <span className="room-badge-unread">{room.unreadCount}</span>}
+        </div>
+        {/* Always rendered, even with no preview — the row's height must not
+            depend on whether this line has content, or the sidebar reflows
+            as previews arrive during bootstrap. */}
+        <div className="room-preview">
+          {room.preview && room.type !== 'dm' && (
+            <span className="room-preview-sender">{room.preview.senderName}: </span>
+          )}
+          {room.preview?.text}
+        </div>
+      </div>
+    </div>
+```
+
+- [ ] **Step 4: Add the styles**
+
+In `src/components/MainApp/Sidebar/RoomList/style.css`, add after the `.room-name` rule:
+
+```css
+.room-item-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.room-item-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+/* Always occupies a line, whether or not it has content — a room with no
+   preview must not render a shorter row. */
+.room-preview {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  line-height: 1.4;
+  min-height: 1.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.room-preview-sender {
+  color: var(--text-secondary);
+}
+```
+
+`.room-name` already carries `flex: 1; min-width: 0` and its own ellipsis rules — leave it untouched; it now flexes inside `.room-item-title` instead of `.room-item`.
+
+- [ ] **Step 5: Run the render tests to verify they pass**
+
+Run: `npm test -- src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx`
+Expected: PASS, including the pre-existing drag-and-drop and section tests. If a pre-existing test queried a badge as a direct child of `.room-item`, update its selector to the new nesting — that is a legitimate consequence of the restructure, not a behavior change.
+
+- [ ] **Step 6: Run every gate**
+
+Run: `npm test && npm run typecheck && npm run build`
+Expected: all PASS, build clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/MainApp/Sidebar/RoomList/RoomList.jsx \
+        src/components/MainApp/Sidebar/RoomList/style.css \
+        src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx
+git commit -m "feat(chat-frontend): render the last-message preview in the sidebar
+
+Room rows are now two lines: name and badges above, sender plus a flattened
+one-line snippet below. The snippet line is always rendered, so a room with no
+preview keeps full row height rather than reflowing the list as previews land."
+```
+
+---
+
+## Verification
+
+After Task 7, confirm the whole feature end to end:
+
+- [ ] `npm test` — full suite green
+- [ ] `npm run typecheck` — no errors
+- [ ] `npm run build` — clean production build
+- [ ] `git log --oneline` shows seven feature commits on `claude/message-preview-chat-frontend-08drl2`
+- [ ] `git diff main --stat` touches only the files in the File Structure table
+- [ ] Confirm no `docs/client-api.md` change is present in the diff — nothing on the wire moved
+
+## Out of scope
+
+Do not add, even if it seems natural while working:
+
+- Timestamps on the preview line
+- Bolding the snippet for unread rooms
+- Previews in the search results pane or thread list
+- URL unfurling or link preview cards
+- Mention or attachment *indicators* — the text fallback in Task 1 is the whole of it
+- Sending `includeLastMessage: false` on `subscription.list` — the default (include) is what this feature needs

--- a/docs/superpowers/plans/2026-08-14-chat-frontend-message-preview.md
+++ b/docs/superpowers/plans/2026-08-14-chat-frontend-message-preview.md
@@ -1395,7 +1395,9 @@ Append to `src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx`, inside th
     const { container } = render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
     const line = container.querySelector('.room-preview')
     expect(line).toBeInTheDocument()   // reserved, so the row height is stable
-    expect(line).toHaveTextContent('')
+    // toBe, not toHaveTextContent: the latter is a substring check that every
+    // string satisfies, so it would assert nothing.
+    expect(line.textContent).toBe('')
   })
 
   it('renders the attachment label a preview carries as its text', () => {
@@ -1440,7 +1442,7 @@ In `src/components/MainApp/Sidebar/RoomList/RoomList.jsx`, replace the `RoomItem
             depend on whether this line has content, or the sidebar reflows
             as previews arrive during bootstrap. */}
         <div className="room-preview">
-          {room.preview && room.type !== 'dm' && (
+          {room.preview && room.type !== 'dm' && room.type !== 'botDM' && (
             <span className="room-preview-sender">{room.preview.senderName}: </span>
           )}
           {room.preview?.text}

--- a/docs/superpowers/plans/2026-08-14-chat-frontend-message-preview.md
+++ b/docs/superpowers/plans/2026-08-14-chat-frontend-message-preview.md
@@ -92,7 +92,13 @@ describe('previewText', () => {
   })
 
   it('flattens nested emphasis', () => {
-    expect(previewText('**bold with *inner italic* inside**')).toBe('bold with inner italic inside')
+    expect(previewText('**bold with _inner italic_ inside**')).toBe('bold with inner italic inside')
+  })
+
+  it('leaves the outer markers literal when emphasis nests with the same marker', () => {
+    // The tokenizer's strong pattern forbids `*` inside its captured group, so
+    // `**a *b* c**` never matches as strong — the outer asterisks stay literal.
+    expect(previewText('**bold with *inner italic* inside**')).toBe('**bold with inner italic inside**')
   })
 
   it('drops inline code backticks', () => {
@@ -271,7 +277,7 @@ function flattenNode(node) {
 - [ ] **Step 4: Run the tests to verify they pass**
 
 Run: `npm test -- src/lib/previewText.test.js`
-Expected: PASS, 21 tests.
+Expected: PASS, 22 tests.
 
 If the unterminated-fence case fails, do **not** change the expectation — check that `parseMessageContent` emitted the backticks as plain text. The tokenizer's `FENCE_RE` requires a closing fence, so an unterminated one stays literal.
 

--- a/docs/superpowers/plans/2026-08-14-chat-frontend-message-preview.md
+++ b/docs/superpowers/plans/2026-08-14-chat-frontend-message-preview.md
@@ -1369,29 +1369,29 @@ The visible deliverable, and a pure component change — `RoomList.test.jsx` alr
 
 - [ ] **Step 1: Write the failing render tests**
 
-Append to `src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx`, inside the outermost `describe`. The file already has `summary(id, overrides)` and `section(key, rooms, over)` helpers — use them.
+Append to `src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx`, inside the outermost `describe`. The file already has `summary(id, overrides)`, `section(key, rooms, over)`, and `setup(sections)` helpers — use them.
+
+**Use `setup(...)`, never `useSidebarSections.mockReturnValue(...)` directly.** `setup` primes all four mocked hooks; priming only `useSidebarSections` leaves the other three returning `undefined`, and `RoomList` crashes destructuring `useChatlistActions()`. Such a test still passes in a full-file run — `vi.clearAllMocks()` clears call history but not implementations, so a previous test's `setup()` leaks through — and fails the moment it runs alone. That is exactly the order-dependence `CLAUDE.md` forbids.
 
 ```js
   const preview = { messageId: 'm1', senderName: 'Alice Chen', text: 'hey are we still on' }
 
   it('renders the sender prefix and snippet in a channel row', () => {
-    useSidebarSections.mockReturnValue([section('chats', [summary('r1', { preview })])])
+    setup([section('chats', [summary('r1', { preview })])])
     render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
     expect(screen.getByText('Alice Chen:')).toBeInTheDocument()
     expect(screen.getByText('hey are we still on')).toBeInTheDocument()
   })
 
   it('omits the sender prefix in a DM row', () => {
-    useSidebarSections.mockReturnValue([
-      section('chats', [summary('r1', { type: 'dm', preview })]),
-    ])
+    setup([section('chats', [summary('r1', { type: 'dm', preview })])])
     render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
     expect(screen.queryByText('Alice Chen:')).not.toBeInTheDocument()
     expect(screen.getByText('hey are we still on')).toBeInTheDocument()
   })
 
   it('renders the snippet line empty when the room has no preview', () => {
-    useSidebarSections.mockReturnValue([section('chats', [summary('r1')])])
+    setup([section('chats', [summary('r1')])])
     const { container } = render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
     const line = container.querySelector('.room-preview')
     expect(line).toBeInTheDocument()   // reserved, so the row height is stable
@@ -1399,9 +1399,7 @@ Append to `src/components/MainApp/Sidebar/RoomList/RoomList.test.jsx`, inside th
   })
 
   it('renders the attachment label a preview carries as its text', () => {
-    useSidebarSections.mockReturnValue([
-      section('chats', [summary('r1', { preview: { ...preview, text: 'Photo' } })]),
-    ])
+    setup([section('chats', [summary('r1', { preview: { ...preview, text: 'Photo' } })])])
     render(<RoomList selectedRoomId={null} onSelectRoom={vi.fn()} />)
     expect(screen.getByText('Photo')).toBeInTheDocument()
   })

--- a/docs/superpowers/plans/2026-08-14-chat-frontend-message-preview.md
+++ b/docs/superpowers/plans/2026-08-14-chat-frontend-message-preview.md
@@ -670,7 +670,18 @@ describe('roomEventsReducer previews', () => {
   })
 
   it('MESSAGE_RECEIVED ignores a thread reply', () => {
-    const seeded = { ...initialState, previews: { r1: { messageId: 'm1', senderName: 'A', text: 'first' } } }
+    // roomState MUST be seeded with the parent. Without it the dispatch exits at
+    // the thread block's `if (!tPrev) return state` guard and never reaches the
+    // path under test — the assertion would then hold even if the preview write
+    // were hoisted above the thread guard, i.e. it would not catch the regression
+    // it exists to catch. Assert on the parent too, proving the thread path ran.
+    const seeded = {
+      ...initialState,
+      previews: { r1: { messageId: 'm1', senderName: 'A', text: 'first' } },
+      roomState: {
+        r1: { ...emptyBuffer(), messages: [{ id: 'm1', content: 'first', createdAt: '2026-08-14T11:00:00Z' }] },
+      },
+    }
     const next = roomEventsReducer(seeded, {
       type: 'MESSAGE_RECEIVED',
       event: {
@@ -679,6 +690,16 @@ describe('roomEventsReducer previews', () => {
       },
     })
     expect(next.previews.r1.messageId).toBe('m1')
+  })
+
+  it('MESSAGE_RECEIVED keeps the previews reference on a same-content echo', () => {
+    // The server echo of a message this client already stored optimistically must
+    // not allocate a new previews object — a fresh reference invalidates
+    // useSidebarSections' memo for every room in the sidebar.
+    const msg = { id: 'm2', content: 'newest', userDisplayName: 'Bob Lin', createdAt: '2026-08-14T11:00:00Z' }
+    const first = roomEventsReducer(initialState, { type: 'MESSAGE_RECEIVED', event: { roomId: 'r1', message: msg } })
+    const second = roomEventsReducer(first, { type: 'MESSAGE_RECEIVED', event: { roomId: 'r1', message: msg } })
+    expect(second.previews).toBe(first.previews)
   })
 
   it('MESSAGE_SENT_LOCAL previews the local send optimistically', () => {
@@ -725,7 +746,12 @@ describe('roomEventsReducer previews', () => {
     // always omitted there. Regression guard against wiring it up.
     const next = roomEventsReducer(initialState, {
       type: 'SUBSCRIPTION_UPSERTED',
-      subscription: { roomId: 'r1', roomType: 'channel', siteId: 'site-A', name: 'General', room: {} },
+      subscription: {
+        roomId: 'r1', roomType: 'channel', siteId: 'site-A', name: 'General',
+        // A previewMessage is deliberately present: the real wire never carries one
+        // here, so an empty `room` would make this guard vacuously true.
+        room: { previewMessage: wirePreview() },
+      },
     })
     expect(next.previews).toEqual({})
   })
@@ -800,6 +826,14 @@ function previewFromMessage(msg) {
   }
 }
 
+// Two stored previews are interchangeable when all three rendered fields match.
+// Used to keep the previews reference stable on a same-content write (e.g. the
+// server echo of a message this client already stored optimistically) — a fresh
+// object would invalidate useSidebarSections' memo for every room in the sidebar.
+function samePreview(a, b) {
+  return !!a && !!b && a.messageId === b.messageId && a.senderName === b.senderName && a.text === b.text
+}
+
 // Build a stored preview from a wire PreviewMessage (subscription.list rows
 // and the refreshed preview on edit/delete events).
 function previewFromWire(previewMessage) {
@@ -838,9 +872,10 @@ In the `MESSAGE_RECEIVED` case, immediately after the thread-reply block closes 
       // the room timeline and is a preview candidate. Computed once and
       // applied at every return point below.
       const nextPreview = previewFromMessage(msg)
-      const previews = nextPreview
-        ? { ...state.previews, [roomId]: nextPreview }
-        : state.previews
+      const previews =
+        !nextPreview || samePreview(state.previews[roomId], nextPreview)
+          ? state.previews
+          : { ...state.previews, [roomId]: nextPreview }
 ```
 
 Then add `previews,` to **all three** returned objects in this case: the historical-buffer-mode return, the `existingIdx >= 0` optimistic-echo return, and the final live-append return. Missing any one of them means previews silently stop updating in that mode.
@@ -854,9 +889,10 @@ In `MESSAGE_SENT_LOCAL`, after `const messages = appendBounded(prev.messages, ms
       // room's preview either — matching the server, which omits
       // previewMessage for hidden thread replies.
       const nextPreview = msg.threadParentMessageId ? null : previewFromMessage(msg)
-      const previews = nextPreview
-        ? { ...state.previews, [roomId]: nextPreview }
-        : state.previews
+      const previews =
+        !nextPreview || samePreview(state.previews[roomId], nextPreview)
+          ? state.previews
+          : { ...state.previews, [roomId]: nextPreview }
 ```
 
 and add `previews,` to its returned object.

--- a/docs/superpowers/plans/2026-08-14-chat-frontend-message-preview.md
+++ b/docs/superpowers/plans/2026-08-14-chat-frontend-message-preview.md
@@ -292,7 +292,9 @@ git commit -m "feat(chat-frontend): add previewText flattener for sidebar snippe
 
 ### Task 2: Display-name resolution (`lib/participantName.js`)
 
-The only display-name rule in the codebase is private to `MessageRow`. The preview writers need the same rule for two different shapes, so it moves to `lib/` with both consumers on one implementation.
+`MessageRow` keeps its display-name rule private. The preview writers need the same rule for two different shapes, so it moves to `lib/` with both consumers on one implementation.
+
+Other name-resolution sites exist (`QuotedBlock.senderLabel`, and the optimistic quote targets in `ChatPage` and `ThreadRightBar`) and are deliberately left alone — they resolve quote snapshots, not `Participant` objects.
 
 **Files:**
 - Create: `src/lib/participantName.js`

--- a/docs/superpowers/specs/2026-08-14-chat-frontend-message-preview-design.md
+++ b/docs/superpowers/specs/2026-08-14-chat-frontend-message-preview-design.md
@@ -56,7 +56,7 @@ that nor changes it.
 |---|---|
 | Surface | Sidebar `RoomList` last-message snippet |
 | Row shape | Two lines: name + badges, then `Alice: <snippet>` |
-| Sender prefix | Omitted in DM rooms |
+| Sender prefix | Omitted in DM rooms — both `dm` and `botDM`, whose row title already is the counterpart's name. `discussion` is multi-party and keeps the prefix. |
 | Timestamp | None |
 | Mention / unread indicators on the preview line | None |
 | Attachment-only messages | `'Photo'` / `'Audio'` / `'Video'` / title-or-`'File'` |

--- a/docs/superpowers/specs/2026-08-14-chat-frontend-message-preview-design.md
+++ b/docs/superpowers/specs/2026-08-14-chat-frontend-message-preview-design.md
@@ -1,0 +1,297 @@
+# chat-frontend: sidebar message preview
+
+**Date:** 2026-08-14
+**Status:** approved design, ready for planning
+**Scope:** `chat-frontend` only. No backend change, no wire change.
+
+## Goal
+
+Render each sidebar room's most recent message as a snippet under the room name,
+kept live as messages arrive, are edited, and are deleted.
+
+## Background
+
+The backend already produces this data; the frontend has never read it.
+
+`pkg/model.PreviewMessage` (`messageId`, `sender`, `content`, `createdAt`,
+`attachments`, `mentions`, `visibleTo`) reaches the client on three carriers:
+
+| Carrier | Field | When |
+|---|---|---|
+| `subscription.list` reply | `sub.room.previewMessage` | Cold start |
+| `message_edited` event | `evt.previewMessage` | Server-recomputed after an edit |
+| `message_deleted` event | `evt.previewMessage` | Server-recomputed after a delete |
+
+`new_message` carries no preview field — it carries the full `message`, so the
+client derives the snippet itself.
+
+Eligibility is resolved server-side: soft-deleted and system messages are
+skipped, walking back to an earlier surviving message; quoted replies count as
+normal content. The client never re-implements this walk.
+
+`fetchSidebarBuckets` already stores each `subscription.list` row whole,
+including its nested `room`. The bootstrap data is therefore in hand today —
+`SubscriptionRoom` in `api/types.ts` simply doesn't declare the field.
+
+### Encryption is not a factor
+
+Two layers exist and neither blocks this feature:
+
+- **At-rest** (`EncPayload` / `EncMeta`, `pkg/atrest`) is server-side.
+  history-service decrypts before replying, so `previewMessage.content` is
+  plaintext.
+- **Room E2E** (`encryptedMessage`, room key) applies to broadcast events only.
+  `useRoomSubscriptions.decryptAndDispatch` resolves content — or substitutes
+  the existing `'[encrypted message]'` placeholder — before the reducer sees it,
+  so a locally derived preview inherits whatever the message list shows.
+
+Note for the record: broadcast-worker copies `evt.PreviewMessage` through
+without encrypting it (`broadcast-worker/handler.go:737,757`), so edit and delete
+previews are plaintext even in an E2E deployment. This spec neither depends on
+that nor changes it.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Surface | Sidebar `RoomList` last-message snippet |
+| Row shape | Two lines: name + badges, then `Alice: <snippet>` |
+| Sender prefix | Omitted in DM rooms |
+| Timestamp | None |
+| Mention / unread indicators on the preview line | None |
+| Attachment-only messages | `'Photo'` / `'Audio'` / `'Video'` / title-or-`'File'` |
+| No preview available | Row keeps constant height; snippet line renders empty |
+| Markup handling | Flatten to plain text |
+| State location | Dedicated `state.previews` map |
+
+## Architecture
+
+### State
+
+`roomEventsReducer` gains one key:
+
+```js
+previews: Record<roomId, RoomPreview>
+
+RoomPreview = {
+  messageId: string,   // guards the delete rule below
+  senderName: string,  // resolved at write time
+  text: string,        // flattened, capped
+}
+```
+
+Three properties of this shape are deliberate:
+
+- **Flattened at write time, not render time.** `useSidebarSections` recomputes
+  its whole memo whenever `previews` changes. Flattening on read would re-flatten
+  every room in the sidebar on every single message event; flattening on write is
+  one call per event.
+- **`senderName` is a resolved string, not a `Participant`.** The two sources
+  carry the name differently — `PreviewMessage.sender.displayName` versus a live
+  `Message`'s top-level `userDisplayName`. Normalizing at write time means the
+  render layer never branches on provenance.
+- **`createdAt` and `attachments` are not stored.** Nothing renders them. Storing
+  only what renders keeps the reducer tests honest about what the feature
+  consumes.
+
+### Why a keyed map rather than a field on `RoomSummary`
+
+`summaries` is rebuilt wholesale from `Room` records on `BUCKETS_LOADED` and
+`ROOMS_LOADED`, and the `Room` type mirrors `pkg/model.Room` — which has no
+preview field, because the backend hangs it off `SubscriptionRoom`. Adding one
+would break the type-mirror rule. A keyed map also matches the existing shape of
+`subscriptions` and `roomState`, and updates in O(1) independent of summary
+rebuilds.
+
+Rejected alternative: deriving the preview at render time from
+`state.roomState[roomId].messages`. `roomState` exists only for rooms whose
+history has been loaded, which at bootstrap is none of them.
+
+### Writers
+
+| Action | Source | Behavior |
+|---|---|---|
+| `BUCKETS_LOADED` | `sub.room.previewMessage` | Seed every room that has one; rooms without stay absent |
+| `MESSAGE_RECEIVED` | the incoming message | Overwrite. Applied at **both** return points — live and historical buffer modes |
+| `MESSAGE_SENT_LOCAL` | the optimistic message | Overwrite; the server echo later rewrites it identically |
+| `MESSAGE_EDITED_LOCAL` | the edited message | Overwrite **only** when the edited id equals the stored `messageId` |
+| `MESSAGE_DELETED_LOCAL` | — | No-op. See below. |
+| `ROOM_PREVIEW_UPDATED` | edit / delete events | Overwrite when `previewMessage` present; clear when absent **and** `deletedMessageId` equals the stored `messageId` |
+| `SUBSCRIPTION_UPSERTED` | — | No-op. See below. |
+| `ROOM_REMOVED` | — | Delete the entry so leaving a room strands nothing |
+| `RESET` | — | Clear the whole map |
+
+Every writer that derives a preview from a message applies the hidden-thread-reply
+guard below — `MESSAGE_RECEIVED` and `MESSAGE_SENT_LOCAL` alike.
+
+`MESSAGE_DELETED_LOCAL` is intentionally inert: the client cannot reproduce the
+server's walk-back to an earlier eligible message, so it waits for the
+authoritative event rather than guessing.
+
+`SUBSCRIPTION_UPSERTED` is a no-op even though its `added` payload embeds a
+`room` object: `docs/client-api.md` specifies `previewMessage` is *always*
+omitted there. A newly added room therefore shows a blank snippet line until its
+first message arrives — correct, since a just-created room has none.
+
+`RESET` clearing the map is not optional. It fires on logout, and a stale preview
+surviving into the next account's session would leak one room's message content
+to a different user on the same device.
+
+The `ROOM_PREVIEW_UPDATED` clear rule is guarded on `messageId` because an absent
+`previewMessage` alongside a `deletedMessageId` that *isn't* the current preview
+is contradictory input — the server would have echoed the unchanged preview.
+Leaving the existing value alone is the safe read.
+
+### Why edit and delete need their own action
+
+Both `MESSAGE_EDITED` and `MESSAGE_DELETED` open with:
+
+```js
+const prev = state.roomState[action.roomId]
+if (!prev) return state
+```
+
+They bail when the room's message buffer doesn't exist — which for a sidebar
+preview is the *normal* case: the user isn't in the room, its history was never
+loaded, and the preview must still update.
+
+One layer up, `useRoomSubscriptions.handleMutationEvent` drops an edit with no
+plaintext `newContent` (`if (typeof newContent !== 'string') return true`)
+before dispatching at all, so in an E2E deployment the edit never reaches the
+reducer even though its `previewMessage` rode along in plaintext.
+
+Threading a preview field through two paths that each bail early for unrelated
+reasons is fragile. `ROOM_PREVIEW_UPDATED` is dispatched from
+`handleMutationEvent` for every edit and delete carrying preview data,
+independent of whether the mutation itself dispatches.
+
+```
+ROOM_PREVIEW_UPDATED = {
+  roomId: string,
+  previewMessage?: PreviewMessage,
+  deletedMessageId?: string,
+}
+```
+
+### Read seam
+
+`useSidebarSections`'s existing `enrich` — which already joins each summary with
+its subscription's display name and `hrInfo` — gains one join against
+`previews[room.id]`, and `previews` joins its memo dependency list. `RoomList`
+stays a pure consumer of what `useSidebarSections` hands it.
+
+## Components
+
+### `lib/previewText.js`
+
+`previewText(content, mentions) → string`. Pure: no React, no I/O. Calls the
+existing `parseMessageContent(content, mentions)` and walks the node tree.
+
+| Node | Flattens to |
+|---|---|
+| `text` | verbatim |
+| `mention` | `@` + `node.display`; `@all` for mention-all |
+| `link` | `node.text` — the visible label, never the href |
+| `code`, `codeblock` | raw inner text; fences and backticks dropped |
+| `strong`, `em`, `del` | recurse into children; markers dropped |
+
+Then: collapse every whitespace run — newlines included — to a single space,
+trim, and hard-cap at 140 characters.
+
+The cap is not cosmetic. CSS ellipsis truncates visually but leaves the whole
+string in the DOM; without it a 4,000-character message sits in the sidebar for
+as long as it's the room's latest.
+
+### `lib/` sender-name helper
+
+`MessageRow`'s private `senderName(msg)` has the only display-name resolution
+rule in the codebase. Its `Participant` branch moves to `lib/` so the preview
+path and the message row resolve names by one rule rather than two. `MessageRow`
+delegates to it; its top-level `userDisplayName` preference is unchanged.
+
+### Attachment fallback
+
+When `previewText` yields an empty string and the message has attachments,
+classify the first via the existing `lib/attachment.attachmentKind` and store:
+
+| Kind | Text |
+|---|---|
+| `image` | `Photo` |
+| `audio` | `Audio` |
+| `video` | `Video` |
+| `file` | the attachment's `title`, or `File` when untitled |
+
+No new classification logic — `attachmentKind` already prefers the
+media-specific URL, then the `fileType` MIME family, then generic file.
+
+### `RoomItem` rendering
+
+A second line: `<span className="room-preview">` holding a muted sender `<span>`
+(`Alice: `, omitted when `room.type === 'dm'`) followed by the text. Both lines
+get `overflow: hidden; text-overflow: ellipsis; white-space: nowrap`.
+
+Row height is fixed in CSS on `.room-item`, so the row is two lines tall whether
+or not the join found a preview. A room with no preview renders an empty snippet
+line — reserved space, blank content — and no row ever reflows as previews
+arrive. Colors and spacing come from `styles/tokens.css`; no hardcoded values.
+
+**State absence and render collapse are separate concerns and must stay
+separate.** A room with no preview is absent from the `previews` map — no
+sentinel entry, no empty-string record. The constant row height is a CSS
+property of the row, not a consequence of the child having text.
+
+### Type mirror fixes
+
+Both are prerequisites — the feature doesn't type-check without them:
+
+- `Participant` gains `displayName?: string`. Go's `model.Participant` has had
+  `DisplayName` since it was written; the TS mirror omits it.
+- `SubscriptionRoom` gains `previewMessage?: PreviewMessage`, and
+  `PreviewMessage` is declared in `api/types.ts` mirroring the Go struct
+  field-for-field.
+
+## Edge cases
+
+| Case | Behavior |
+|---|---|
+| Hidden thread reply (`threadParentMessageId` set, `tshow` not true) | Never touches the preview — matches the server, which omits `previewMessage` for exactly these |
+| Encrypted room, live message | No special handling; `decryptAndDispatch` resolves content upstream |
+| Encrypted room, undecryptable | Previews as `[encrypted message]`, matching the message list |
+| Failed optimistic send (`_status: 'failed'`) | Still previews, matching the message list |
+| `visibleTo` | Ignored; its server-side write path hasn't landed and the field is always empty |
+| Room with only system or deleted messages | Server omits the preview; blank snippet line |
+| Site enrichment degraded | Indistinguishable from "no messages" on the wire; blank snippet line |
+| Message with attachments *and* text | Text wins; the attachment fallback applies only to empty text |
+
+## Testing
+
+TDD per the repo rule — Red confirmed before Green on each.
+
+**`lib/previewText.test.js`** — pure, no React. Each node type; nested emphasis;
+unterminated fence; mention with no matching participant; `@all`; newline
+collapsing; the 140-character cap; empty and null input.
+
+**`reducer.test.js`** — one case per writer in the table, plus the four easiest to
+get wrong: an edit arriving for a room with no `roomState`; a delete whose
+`deletedMessageId` doesn't match the stored preview; a hidden thread reply
+leaving the preview untouched; and `RESET` clearing the map. Pure JS, no React.
+
+**`RoomList.test.jsx`** — sender prefix present in a channel, absent in a DM;
+blank line when the join finds nothing; row height constant across both; the
+attachment fallback rendering.
+
+**`RoomEventsContext.test.jsx`** — the `useSidebarSections` join, including a
+room present in `summaries` but absent from `previews`.
+
+Gates: `npm run typecheck` and `npm test` pass; `vite build` clean.
+
+## Non-goals
+
+Recorded so they don't creep in during implementation:
+
+- Timestamps on the preview line
+- Unread-state bolding of the snippet
+- Previews in the search results pane or thread list
+- URL unfurling or link preview cards
+- Mention or attachment *indicators* (distinct from the text fallback above)
+- Any `docs/client-api.md` change — nothing on the wire moves

--- a/docs/superpowers/specs/2026-08-14-chat-frontend-message-preview-design.md
+++ b/docs/superpowers/specs/2026-08-14-chat-frontend-message-preview-design.md
@@ -204,10 +204,23 @@ as long as it's the room's latest.
 
 ### `lib/` sender-name helper
 
-`MessageRow`'s private `senderName(msg)` has the only display-name resolution
-rule in the codebase. Its `Participant` branch moves to `lib/` so the preview
-path and the message row resolve names by one rule rather than two. `MessageRow`
+`MessageRow`'s private `senderName(msg)` moves to `lib/` so the preview path and
+the message row resolve names by one rule rather than two. `MessageRow`
 delegates to it; its top-level `userDisplayName` preference is unchanged.
+
+It is not the codebase's only such rule — `QuotedBlock.senderLabel`, and the
+optimistic quote targets built in `ChatPage` and `ThreadRightBar`, each resolve
+names their own way and none consult `displayName`. Those are out of scope here
+and are left alone: they operate on quote snapshots, not on a `Participant`.
+
+The extracted helper prefers `participant.displayName`, which the inline version
+never consulted. That branch is **unreachable from `MessageRow`** — nothing
+populates a message's nested `sender.displayName`: `broadcast-worker`'s
+`buildClientMessage` sets only account/engName/chineseName, and across
+history-service the field is assigned in exactly one place,
+`rooms.go:216`'s `toPreviewMessage`. The branch exists for
+`PreviewMessage.sender`, the one shape that carries it, where it delivers a
+bot's app name.
 
 ### Attachment fallback
 

--- a/docs/superpowers/specs/2026-08-14-chat-frontend-message-preview-design.md
+++ b/docs/superpowers/specs/2026-08-14-chat-frontend-message-preview-design.md
@@ -111,7 +111,7 @@ history has been loaded, which at bootstrap is none of them.
 
 | Action | Source | Behavior |
 |---|---|---|
-| `BUCKETS_LOADED` | `sub.room.previewMessage` | Seed every room that has one; rooms without stay absent |
+| `BUCKETS_LOADED` | `sub.room.previewMessage` | Seed only rooms with **no** preview yet. A live message can land before `fetchSidebarBuckets` resolves (the DM subscription goes live first) and is newer than this snapshot — overwriting it would show an older message in the sidebar than the room does. |
 | `MESSAGE_RECEIVED` | the incoming message | Overwrite. Applied at **both** return points — live and historical buffer modes |
 | `MESSAGE_SENT_LOCAL` | the optimistic message | Overwrite; the server echo later rewrites it identically |
 | `MESSAGE_EDITED_LOCAL` | the edited message | Overwrite **only** when the edited id equals the stored `messageId` |
@@ -121,8 +121,8 @@ history has been loaded, which at bootstrap is none of them.
 | `ROOM_REMOVED` | — | Delete the entry so leaving a room strands nothing |
 | `RESET` | — | Clear the whole map |
 
-Every writer that derives a preview from a message applies the hidden-thread-reply
-guard below — `MESSAGE_RECEIVED` and `MESSAGE_SENT_LOCAL` alike.
+Every writer that derives a preview from a message applies the thread-reply guard
+below — `MESSAGE_RECEIVED` and `MESSAGE_SENT_LOCAL` alike.
 
 `MESSAGE_DELETED_LOCAL` is intentionally inert: the client cannot reproduce the
 server's walk-back to an earlier eligible message, so it waits for the
@@ -243,10 +243,11 @@ A second line: `<span className="room-preview">` holding a muted sender `<span>`
 (`Alice: `, omitted when `room.type === 'dm'`) followed by the text. Both lines
 get `overflow: hidden; text-overflow: ellipsis; white-space: nowrap`.
 
-Row height is fixed in CSS on `.room-item`, so the row is two lines tall whether
-or not the join found a preview. A room with no preview renders an empty snippet
-line — reserved space, blank content — and no row ever reflows as previews
-arrive. Colors and spacing come from `styles/tokens.css`; no hardcoded values.
+Height is reserved on `.room-preview` itself — `min-height: 1.4em` against a
+matching unitless `line-height: 1.4`, so an empty snippet line occupies exactly
+the same box as a populated one. The row is therefore two lines tall whether or
+not the join found a preview, and no row reflows as previews arrive. Colors and
+spacing come from `styles/tokens.css`; no hardcoded values.
 
 **State absence and render collapse are separate concerns and must stay
 separate.** A room with no preview is absent from the `previews` map — no
@@ -267,7 +268,7 @@ Both are prerequisites — the feature doesn't type-check without them:
 
 | Case | Behavior |
 |---|---|
-| Hidden thread reply (`threadParentMessageId` set, `tshow` not true) | Never touches the preview — matches the server, which omits `previewMessage` for exactly these |
+| Thread reply (any `threadParentMessageId`) | Never touches the preview. This is BROADER than the server's rule: the server excludes only *hidden* replies, and a `tshow: true` reply does get a `messages_by_room` row and can legitimately be a room's preview. Correct here only because this frontend has no `tshow` support — no thread reply reaches the room timeline. Revisit when `tshow` lands. |
 | Encrypted room, live message | No special handling; `decryptAndDispatch` resolves content upstream |
 | Encrypted room, undecryptable | Previews as `[encrypted message]`, matching the message list |
 | Failed optimistic send (`_status: 'failed'`) | Still previews, matching the message list |


### PR DESCRIPTION
## What

Each sidebar room now renders its most recent message as a second line — `Alice: hey are we still on` — kept live as messages arrive, are edited, and are deleted.

**No backend change and no wire change.** `PreviewMessage` has been arriving on `subscription.list` rows (`sub.room.previewMessage`) and on `message_edited` / `message_deleted` events all along; the frontend never declared the field, so the data was being thrown away.

## How

- **`state.previews`** — a new `Record<roomId, { messageId, senderName, text, createdAt, encrypted? }>` in `roomEventsReducer`. A keyed map rather than a field on `RoomSummary`, because summaries are rebuilt wholesale from `Room` records that mirror `pkg/model.Room`, and the backend hangs the preview off `SubscriptionRoom` instead.
- **`lib/previewText.js`** — flattens a body to one plain-text line over the existing `parseMessageContent` tokenizer: mentions resolve to `@Display Name`, links to their visible text, markup and fences dropped, whitespace collapsed, capped at 140 chars on a surrogate-safe boundary.
- **`ROOM_PREVIEW_UPDATED`** — its own action rather than a field threaded onto `MESSAGE_EDITED` / `MESSAGE_DELETED`. Both of those bail when a room has no message buffer, which is precisely the normal case for a sidebar row of a room the user hasn't opened.
- **`useSidebarSections`** joins the map into each room; **`RoomItem`** renders the second line.

## Behavior worth knowing

| Case | Behavior |
|---|---|
| No preview available | Row keeps full height with a blank snippet line. The sidebar bootstraps over three paginated RPCs, so a row that grew a second line as its preview landed would reflow the list in stages. |
| DM / botDM | Sender prefix omitted — the row title is already the counterpart's name. |
| Attachment-only message | `Photo` / `Audio` / `Video` / the file's title. |
| System messages | Excluded, mirroring the server's eligibility rule. Note `important` is *not* a system type and previews normally. |
| Thread replies | Excluded. This is broader than the server's rule, which excludes only hidden replies — correct only while this frontend has no `tshow` support, and flagged in the code for whoever adds it. |
| Logout | `RESET` clears the map, so one account's preview can't survive into the next session on a shared device. |
| Concurrent edit/delete | Rejected when strictly older than the stored preview; `broadcast-worker` processes canonical messages concurrently, so a stale resolve can arrive after a newer message. |
| Bootstrap race | `BUCKETS_LOADED` seeds only rooms with no preview yet — the DM subscription goes live before `fetchSidebarBuckets` resolves, so a message arriving in that window is newer than the list snapshot. |

## Testing

949 tests across 85 files, `tsc --noEmit` clean, production build clean.

The design spec and implementation plan are included under `docs/superpowers/`.

## Follow-ups (none blocking)

- **Backend.** `history-service`'s `previewAfterMutation` returns `nil` both for "no eligible message remains" and for a read error. The client cannot distinguish them, so a transient Cassandra failure during a delete blanks a valid snippet until the next `subscription.list`, and an encrypted room still shows server plaintext on cold load. Both need an explicit cleared-signal on the event; no honest client-side mitigation exists, since never-clearing would strand a deleted message's text in the sidebar permanently.
- Undecryptable E2E messages preview as `Unknown: [encrypted message]` — untested.
- A fourth inline copy of the `dm || botDM` predicate now exists; candidate for a shared helper in `lib/roomFormat`.
- `previewText` parses the full body to keep 140 chars. A bounded pre-parse was tried and reverted: markup shrinks up to 7:1 when flattened, so any slice can truncate below the cap. If this ever shows in a profile, the safe optimization is skipping the parse entirely for bodies with no markup characters.