### PR TITLE
feat: harden single-site NATS failure readiness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint fmt tidy test test-integration coverage-loadgen-soak generate build validate-loadgen-k8s deps-up deps-down \
+.PHONY: lint fmt tidy test test-integration benchmark-natsmetrics coverage-loadgen-soak generate build validate-loadgen-k8s deps-up deps-down \
         require-deps up up-detached down dev ui-up ui-down \
         o11y-up o11y-down obs-up obs-down profile tools tools-mockgen sast sast-gosec sast-vuln sast-semgrep
 
@@ -79,6 +79,12 @@ ifdef SERVICE
 else
 	go test -race ./...
 endif
+
+# Measure the repository-owned JetStream delivery tracking overhead. The
+# benchmark uses pre-decoded metadata so nats.go reply-subject parsing remains
+# outside the result.
+benchmark-natsmetrics:
+	go test -run '^$$' -bench 'Benchmark(Consumer|Message)_' -benchmem ./pkg/natsmetrics
 
 # Run integration tests (requires Docker)
 test-integration:

--- a/broadcast-worker/config_test.go
+++ b/broadcast-worker/config_test.go
@@ -43,6 +43,15 @@ func TestConfig_Mode(t *testing.T) {
 	}
 }
 
+func TestConfig_ServiceName(t *testing.T) {
+	t.Setenv("MODE", "bot")
+	t.Setenv("OTEL_SERVICE_NAME", "bot-broadcast-worker")
+
+	cfg, err := env.ParseAs[config]()
+	require.NoError(t, err)
+	require.Equal(t, "bot-broadcast-worker", cfg.ServiceName)
+}
+
 func TestConfig_RoomSubjectMode(t *testing.T) {
 	t.Setenv("MODE", "user")
 

--- a/broadcast-worker/consumeloop_test.go
+++ b/broadcast-worker/consumeloop_test.go
@@ -35,6 +35,8 @@ func (a plainIterAdapter) Next(opts ...jetstream.NextOpt) (context.Context, jets
 	return context.Background(), msg, nil
 }
 
+func (a plainIterAdapter) Stop() { a.inner.Stop() }
+
 // startEmbeddedCanonicalConsumer spins up an in-process JetStream server (no
 // Docker) with the MESSAGES-CANONICAL stream and a broadcast-worker-style
 // durable consumer, returning the JetStream handle, the iterator, the subject

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -38,6 +38,7 @@ type encryptionConfig struct {
 }
 
 type config struct {
+	ServiceName   string `env:"OTEL_SERVICE_NAME"          envDefault:"unknown-service"`
 	NatsURL       string `env:"NATS_URL"                  envDefault:"nats://localhost:4222"`
 	NatsCredsFile string `env:"NATS_CREDS_FILE"           envDefault:""`
 	SiteID        string `env:"SITE_ID"                   envDefault:"default"`
@@ -107,7 +108,7 @@ func main() {
 		os.Exit(1)
 	}
 	sharedMetrics := natsmetrics.NewFromProvider(sdk.MeterProvider())
-	publishMetrics := sharedMetrics.Publisher("broadcast-worker", cfg.SiteID)
+	publishMetrics := sharedMetrics.Publisher(cfg.ServiceName, cfg.SiteID)
 	domainMetrics := newBroadcastMetrics(sdk.MeterProvider().Meter("broadcast-worker"))
 
 	readPref, err := mongoutil.ParseReadPreference(cfg.MongoReadPreference)
@@ -188,7 +189,7 @@ func main() {
 
 	consumerCfg := buildConsumerConfig(cfg.Consumer, cfg.Mode.ConsumerName("broadcast-worker"), wiring.CanonicalWildcard)
 	consumerMetrics := sharedMetrics.Consumer(natsmetrics.ConsumerConfig{
-		ServiceName: "broadcast-worker", Site: cfg.SiteID,
+		ServiceName: cfg.ServiceName, Site: cfg.SiteID,
 		Stream: wiring.CanonicalStream.Name, Consumer: consumerCfg.Durable,
 	})
 	consumerMetrics.LoopStopped(ctx)

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -237,7 +237,7 @@ func main() {
 
 	var wg sync.WaitGroup
 	supervisor := natsmetrics.NewSupervisor(natsmetrics.SupervisorConfig{})
-	iteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+	initialIteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
 		cons, err := js.CreateOrUpdateConsumer(factoryCtx, wiring.CanonicalStream.Name, consumerCfg)
 		if err != nil {
 			return nil, fmt.Errorf("create consumer: %w", err)
@@ -248,7 +248,19 @@ func main() {
 		}
 		return iter, nil
 	}
-	if err := supervisor.Start(ctx, iteratorFactory, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
+	recoveryIteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+		cons, err := js.Consumer(factoryCtx, wiring.CanonicalStream.Name, consumerCfg.Durable)
+		if err != nil {
+			return nil, fmt.Errorf("lookup consumer: %w", err)
+		}
+		iter, err := cons.Messages(factoryCtx, jetstream.PullMaxMessages(2*cfg.MaxWorkers))
+		if err != nil {
+			return nil, fmt.Errorf("create recovery iterator: %w", err)
+		}
+		return iter, nil
+	}
+	if err := supervisor.StartWithRecovery(ctx, initialIteratorFactory, recoveryIteratorFactory,
+		consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
 		func(msg jetstream.Msg) natsmetrics.EventType { return natsmetrics.EventTypeFromSubject(msg.Subject()) },
 		guardedProcessor(broadcastProcessor(handler))); err != nil {
 		slog.Error("start consumer supervisor failed", "error", err)

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -192,12 +192,6 @@ func main() {
 		ServiceName: cfg.ServiceName, Site: cfg.SiteID,
 		Stream: wiring.CanonicalStream.Name, Consumer: consumerCfg.Durable,
 	})
-	consumerMetrics.LoopStopped(ctx)
-	cons, err := js.CreateOrUpdateConsumer(ctx, wiring.CanonicalStream.Name, consumerCfg)
-	if err != nil {
-		slog.Error("create consumer failed", "error", err)
-		os.Exit(1)
-	}
 
 	publisher := &natsPublisher{nc: nc, metrics: publishMetrics}
 	// Coalesce per-message rooms.lastMsgAt writes into periodic BulkWrites — the handler still calls
@@ -241,17 +235,25 @@ func main() {
 		os.Exit(1)
 	}
 
-	iter, err := cons.Messages(ctx, jetstream.PullMaxMessages(2*cfg.MaxWorkers))
-	if err != nil {
-		slog.Error("messages failed", "error", err)
+	var wg sync.WaitGroup
+	supervisor := natsmetrics.NewSupervisor(natsmetrics.SupervisorConfig{})
+	iteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+		cons, err := js.CreateOrUpdateConsumer(factoryCtx, wiring.CanonicalStream.Name, consumerCfg)
+		if err != nil {
+			return nil, fmt.Errorf("create consumer: %w", err)
+		}
+		iter, err := cons.Messages(factoryCtx, jetstream.PullMaxMessages(2*cfg.MaxWorkers))
+		if err != nil {
+			return nil, fmt.Errorf("create iterator: %w", err)
+		}
+		return iter, nil
+	}
+	if err := supervisor.Start(ctx, iteratorFactory, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
+		func(msg jetstream.Msg) natsmetrics.EventType { return natsmetrics.EventTypeFromSubject(msg.Subject()) },
+		guardedProcessor(broadcastProcessor(handler))); err != nil {
+		slog.Error("start consumer supervisor failed", "error", err)
 		os.Exit(1)
 	}
-	consumerMetrics.LoopStarted(ctx)
-
-	var wg sync.WaitGroup
-	natsmetrics.Start(ctx, iter, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
-		func(msg jetstream.Msg) natsmetrics.EventType { return natsmetrics.EventTypeFromSubject(msg.Subject()) },
-		guardedProcessor(broadcastProcessor(handler)))
 
 	healthStop, err := health.ServeWithPprof(cfg.HealthAddr, 5*time.Second, cfg.PProfEnabled,
 		natsutil.HealthCheck(nc),
@@ -267,9 +269,8 @@ func main() {
 		func(_ context.Context) error {
 			return broadcastSub.Unsubscribe()
 		},
-		func(ctx context.Context) error {
-			consumerMetrics.LoopStopped(ctx)
-			iter.Stop()
+		func(context.Context) error {
+			supervisor.Stop()
 			return nil
 		},
 		func(ctx context.Context) error {

--- a/docs/specs/o11y/o11y-metrics-inventory.md
+++ b/docs/specs/o11y/o11y-metrics-inventory.md
@@ -192,9 +192,10 @@ The long-running pull consumers use a single-owner supervisor. Initial consumer
 and iterator creation is synchronous and fail-fast; only a loop that has
 successfully started enters recovery. A recoverable terminal iterator error
 first sets `chat.nats.consumer.loop.up` to zero and records a bounded terminal
-failure, then recreates the durable consumer and iterator with capped
-exponential backoff. Consecutive iterator generations that fail before receiving
-a message increase that backoff; a successful delivery resets it. Each failed or
+failure, then looks up the existing durable and recreates only its iterator with
+capped exponential backoff. Recovery never creates a missing durable.
+Consecutive iterator generations that fail before receiving a message increase
+that backoff; a successful delivery resets it. Each retryable failed or
 successful recreation increments `chat.nats.consumer.recovery.attempts`.
 
 `jetstream.ErrConsumerDeleted` is intentionally terminal and is not recreated.
@@ -202,6 +203,9 @@ Deleting a durable also deletes its server-side cursor, so automatic recreation
 would replay the retention window for `DeliverAllPolicy` consumers or skip
 pending work for `DeliverNewPolicy` consumers. The loop remains down and its
 `consumer_deleted` terminal metric requires operator intervention instead.
+The same terminal behavior applies when recovery lookup returns
+`jetstream.ErrConsumerNotFound`, including when a transport failure masked a
+concurrent durable deletion from the old iterator.
 
 One semaphore is shared across iterator generations, and concurrent starts on
 the same supervisor are rejected, so recovery cannot create duplicate active

--- a/docs/specs/o11y/o11y-metrics-inventory.md
+++ b/docs/specs/o11y/o11y-metrics-inventory.md
@@ -131,19 +131,21 @@ missing beyond shared cache/key counters.
 | history-service | — | ✅ | — | ✅ | spans | — | shared `cache_*_total` | history reads, bucket-walk depth |
 | data-migration/oplog-* | — | ✅ | — | — | spans | — | **rich counters** (`oplog_*_events_processed_total`, `_naks_total`, `_terms_total`, `_skipped_total`, `_exhausted_total`, …) | (good exemplar — copy this pattern) |
 
-### 2.1 Shared application NATS metrics (2026-08-14)
+### 2.1 Shared application NATS metrics (2026-08-15)
 
 The SDK emits no NATS client metrics (§1), so these are owned by this repo.
-The shared consumer/publisher helpers are adopted by the four first-campaign
-services. Connection lifecycle metrics are opt-in through
-`natsutil.ConnectWithMetrics` and use the same four-service scope. Names are
-OTel instrument names; Prometheus renders them with `_` separators and adds
-`_total` / unit suffixes.
+The shared consumer, supervisor, request, and publisher helpers are adopted by
+the first single-site failure-readiness services: `message-gatekeeper`,
+`message-worker`, `broadcast-worker`, `notification-worker`, `history-service`,
+`room-service`, and `room-worker`. Connection lifecycle metrics are opt-in
+through `natsutil.ConnectWithMetrics`. Names are OTel instrument names;
+Prometheus renders them with `_` separators and adds `_total` / unit suffixes.
 
 Consumer and publisher families share a base of `service_name` + `site`; the
-"labels" column lists what each adds on top. The three dual-deployment workers
-read `service_name` from `OTEL_SERVICE_NAME`, matching the OTel resource while
-keeping their instrumentation-scope names stable across deployments.
+"labels" column lists what each adds on top. Every adopter reads
+`service_name` from `OTEL_SERVICE_NAME`, matching the OTel resource. Normal,
+bot, and Teams deployments use distinct resource identities while the package
+instrumentation scopes remain stable.
 
 | Instrument | Type | Owner | Labels beyond the base |
 |---|---|---|---|
@@ -152,10 +154,13 @@ keeping their instrumentation-scope names stable across deployments.
 | `chat.nats.consumer.redeliveries` | counter | `pkg/natsmetrics` | stream, consumer, event_type |
 | `chat.nats.consumer.processing.duration` | histogram (s) | `pkg/natsmetrics` | stream, consumer, event_type, outcome |
 | `chat.nats.terminal.failures` | counter | `pkg/natsmetrics` | stream, consumer, event_type, reason |
+| `chat.nats.consumer.recovery.attempts` | counter | `pkg/natsmetrics` | stream, consumer, result |
 | `chat.nats.publish.attempts` | counter | `pkg/natsmetrics` | destination_kind, operation, outcome |
 | `chat.nats.publish.retries` | counter | `pkg/natsmetrics` | destination_kind, operation |
 | `chat.nats.requests` | counter | `pkg/natsmetrics` | operation, outcome |
 | `chat.nats.request.duration` | histogram (s) | `pkg/natsmetrics` | operation, outcome |
+| `chat.nats.request.handled` | counter | `pkg/natsmetrics` / `pkg/natsrouter` | operation, result |
+| `chat.nats.request.handler.duration` | histogram (s) | `pkg/natsmetrics` / `pkg/natsrouter` | operation, result |
 | `chat.nats.client.connected` | up-down counter | `pkg/natsutil` | none — one series per process; value is the live connection count |
 | `chat.nats.client.connection.events` | counter | `pkg/natsutil` | event |
 | `nats_slow_consumer_events_total` | counter | `pkg/natsutil` | subject, queue |
@@ -173,6 +178,40 @@ through `ErrorHandler`, so it is counted as
 `chat_nats_publish_attempts_total{outcome="buffer_full"}`. The full semantics,
 label enums, and the alerts these drive are specified in the NATS failure
 metrics contract under `docs/load-testing/failure-testing/`.
+
+All metric dimensions are closed enums. Request `result` is one of `success`,
+`bad_request`, `unauthenticated`, `forbidden`, `not_found`, `conflict`,
+`too_many_requests`, `unavailable`, or `internal`. Room/history request and
+publish operations are coarse bounded categories such as `room_read`,
+`room_mutation`, `member_read`, `member_mutation`, `history_read`,
+`history_mutation`, `room_publish`, `member_publish`, and `outbox_publish`.
+Unknown subject families normalize to `unknown`. Raw subjects, room IDs,
+account IDs, site IDs from subject tokens, and error strings are never labels.
+
+The long-running pull consumers use a single-owner supervisor. A terminal
+iterator error first sets `chat.nats.consumer.loop.up` to zero and records a
+bounded terminal failure, then recreates the durable consumer and iterator with
+capped exponential backoff. Each failed or successful recreation increments
+`chat.nats.consumer.recovery.attempts`. One semaphore is shared across iterator
+generations, and concurrent starts on the same supervisor are rejected, so
+recovery cannot create duplicate active iterators or exceed the configured
+worker limit while earlier handlers drain. Context cancellation stops backoff,
+stops the active iterator, and leaves the existing graceful in-flight wait and
+NATS drain ordering intact. Recovery state is telemetry, not a liveness failure:
+transient iterator loss does not deliberately restart an otherwise healthy
+process. These mechanics do not change handler-owned Ack, Nak, Term, or publish
+retry decisions.
+
+`notification-worker` applies the same supervision separately to its canonical
+message consumer and member-mute invalidation consumer. `room-worker` covers the
+normal and Teams room streams. `history-service` has no JetStream consumer loop;
+it adopts only connection, request/reply, and mutation-publish metrics.
+
+The Layer B rows above that show NATS spans only for `room-service`,
+`room-worker`, or `history-service` are superseded by this section: all three now
+emit the applicable `chat.nats.*` families. Their remaining gaps are domain
+outcomes such as room/member business results and history bucket-walk depth,
+not NATS failure evidence.
 
 ### 2.2 Services not previously inventoried (2026-08-14)
 

--- a/docs/specs/o11y/o11y-metrics-inventory.md
+++ b/docs/specs/o11y/o11y-metrics-inventory.md
@@ -188,19 +188,29 @@ publish operations are coarse bounded categories such as `room_read`,
 Unknown subject families normalize to `unknown`. Raw subjects, room IDs,
 account IDs, site IDs from subject tokens, and error strings are never labels.
 
-The long-running pull consumers use a single-owner supervisor. A terminal
-iterator error first sets `chat.nats.consumer.loop.up` to zero and records a
-bounded terminal failure, then recreates the durable consumer and iterator with
-capped exponential backoff. Each failed or successful recreation increments
-`chat.nats.consumer.recovery.attempts`. One semaphore is shared across iterator
-generations, and concurrent starts on the same supervisor are rejected, so
-recovery cannot create duplicate active iterators or exceed the configured
-worker limit while earlier handlers drain. Context cancellation stops backoff,
-stops the active iterator, and leaves the existing graceful in-flight wait and
-NATS drain ordering intact. Recovery state is telemetry, not a liveness failure:
-transient iterator loss does not deliberately restart an otherwise healthy
-process. These mechanics do not change handler-owned Ack, Nak, Term, or publish
-retry decisions.
+The long-running pull consumers use a single-owner supervisor. Initial consumer
+and iterator creation is synchronous and fail-fast; only a loop that has
+successfully started enters recovery. A recoverable terminal iterator error
+first sets `chat.nats.consumer.loop.up` to zero and records a bounded terminal
+failure, then recreates the durable consumer and iterator with capped
+exponential backoff. Consecutive iterator generations that fail before receiving
+a message increase that backoff; a successful delivery resets it. Each failed or
+successful recreation increments `chat.nats.consumer.recovery.attempts`.
+
+`jetstream.ErrConsumerDeleted` is intentionally terminal and is not recreated.
+Deleting a durable also deletes its server-side cursor, so automatic recreation
+would replay the retention window for `DeliverAllPolicy` consumers or skip
+pending work for `DeliverNewPolicy` consumers. The loop remains down and its
+`consumer_deleted` terminal metric requires operator intervention instead.
+
+One semaphore is shared across iterator generations, and concurrent starts on
+the same supervisor are rejected, so recovery cannot create duplicate active
+iterators or exceed the configured worker limit while earlier handlers drain.
+Context cancellation stops backoff, stops the active iterator, and leaves the
+existing graceful in-flight wait and NATS drain ordering intact. Recovery state
+is telemetry, not a liveness failure: transient iterator loss does not
+deliberately restart an otherwise healthy process. These mechanics do not change
+handler-owned Ack, Nak, Term, or publish retry decisions.
 
 `notification-worker` applies the same supervision separately to its canonical
 message consumer and member-mute invalidation consumer. `room-worker` covers the

--- a/docs/specs/o11y/o11y-metrics-inventory.md
+++ b/docs/specs/o11y/o11y-metrics-inventory.md
@@ -141,7 +141,9 @@ OTel instrument names; Prometheus renders them with `_` separators and adds
 `_total` / unit suffixes.
 
 Consumer and publisher families share a base of `service_name` + `site`; the
-"labels" column lists what each adds on top.
+"labels" column lists what each adds on top. The three dual-deployment workers
+read `service_name` from `OTEL_SERVICE_NAME`, matching the OTel resource while
+keeping their instrumentation-scope names stable across deployments.
 
 | Instrument | Type | Owner | Labels beyond the base |
 |---|---|---|---|

--- a/docs/specs/o11y/o11y-metrics-inventory.md
+++ b/docs/specs/o11y/o11y-metrics-inventory.md
@@ -179,14 +179,17 @@ through `ErrorHandler`, so it is counted as
 label enums, and the alerts these drive are specified in the NATS failure
 metrics contract under `docs/load-testing/failure-testing/`.
 
-All metric dimensions are closed enums. Request `result` is one of `success`,
-`bad_request`, `unauthenticated`, `forbidden`, `not_found`, `conflict`,
-`too_many_requests`, `unavailable`, or `internal`. Room/history request and
-publish operations are coarse bounded categories such as `room_read`,
-`room_mutation`, `member_read`, `member_mutation`, `history_read`,
-`history_mutation`, `room_publish`, `member_publish`, and `outbox_publish`.
-Unknown subject families normalize to `unknown`. Raw subjects, room IDs,
-account IDs, site IDs from subject tokens, and error strings are never labels.
+All subject- and error-derived metric dimensions are closed enums. Request
+`result` is one of `success`, `bad_request`, `unauthenticated`, `forbidden`,
+`not_found`, `conflict`, `too_many_requests`, `unavailable`, or `internal`.
+Room/history request and publish operations are coarse bounded categories such
+as `room_read`, `room_mutation`, `member_read`, `member_mutation`,
+`history_read`, `history_mutation`, `room_publish`, `member_publish`, and
+`outbox_publish`. `service_name` and `site` are operator-provided deployment
+identity dimensions, not closed enums; deployment configuration must constrain
+them to the deployed service and site inventory. Unknown subject families
+normalize to `unknown`. Raw subjects, room IDs, account IDs, site IDs parsed
+from subject tokens, and error strings are never labels.
 
 The long-running pull consumers use a single-owner supervisor. Initial consumer
 and iterator creation is synchronous and fail-fast; only a loop that has
@@ -194,6 +197,8 @@ successfully started enters recovery. A recoverable terminal iterator error
 first sets `chat.nats.consumer.loop.up` to zero and records a bounded terminal
 failure, then looks up the existing durable and recreates only its iterator with
 capped exponential backoff. Recovery never creates a missing durable.
+Every production recovery factory calls `js.Consumer(stream, durable)` before
+`consumer.Messages(...)`; none calls `CreateOrUpdateConsumer` after startup.
 Consecutive iterator generations that fail before receiving a message increase
 that backoff; a successful delivery resets it. Each retryable failed or
 successful recreation increments `chat.nats.consumer.recovery.attempts`.

--- a/history-service/cmd/main.go
+++ b/history-service/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
 	"github.com/hmchangw/chat/pkg/msgbucket"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsrouter"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
@@ -86,7 +87,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	nc, err := natsutil.Connect(ctx, cfg.NATS.URL, cfg.NATS.CredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)
+	sharedMetrics := natsmetrics.NewFromProvider(sdk.MeterProvider())
+	publishMetrics := sharedMetrics.Publisher(cfg.ServiceName, cfg.SiteID)
+	nc, err := natsutil.ConnectWithMetrics(ctx, cfg.NATS.URL, cfg.NATS.CredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace, sdk.MeterProvider())
 	if err != nil {
 		slog.Error("nats connect failed", "error", err)
 		os.Exit(1)
@@ -197,12 +200,12 @@ func main() {
 		slog.Info("preview cache enabled", "size", cfg.PreviewCacheSize, "ttl", cfg.PreviewCacheTTL)
 	}
 
-	pub := publisher.New(js)
+	pub := publisher.New(js, publisher.WithMetrics(publishMetrics))
 	svc := service.New(cassRepo, subSource, roomSource, pub, threadRoomRepo, threadSubRepo, userStore, appRepo, &cfg, opts...)
 
 	// Bound in-flight handlers so a burst is shed at the door instead of piling
 	// unbounded concurrent work onto the (now explicitly capped) Mongo pool.
-	routerOpts := []natsrouter.Option{natsrouter.WithSiteID(cfg.SiteID)}
+	routerOpts := []natsrouter.Option{natsrouter.WithSiteID(cfg.SiteID), natsrouter.WithMetrics(publishMetrics)}
 	if cfg.MaxConcurrency > 0 {
 		routerOpts = append(routerOpts, natsrouter.WithMaxConcurrency(cfg.MaxConcurrency))
 	}

--- a/history-service/internal/config/config.go
+++ b/history-service/internal/config/config.go
@@ -50,6 +50,7 @@ type NATSConfig struct {
 
 // Config is the top-level configuration for the history-service.
 type Config struct {
+	ServiceName             string          `env:"OTEL_SERVICE_NAME"          envDefault:"unknown-service"`
 	SiteID                  string          `env:"SITE_ID"                    envDefault:"site-local"`
 	HealthAddr              string          `env:"HEALTH_ADDR"                envDefault:":8081"`
 	PProfEnabled            bool            `env:"PPROF_ENABLED" envDefault:"false"`

--- a/history-service/internal/config/config_test.go
+++ b/history-service/internal/config/config_test.go
@@ -183,6 +183,17 @@ func TestLoad_DefaultsReadPreferenceToSecondaryPreferred(t *testing.T) {
 	assert.Equal(t, "secondaryPreferred", cfg.Mongo.ReadPreference)
 }
 
+func TestLoad_ServiceName(t *testing.T) {
+	t.Setenv("MONGO_URI", "mongodb://localhost:27017")
+	t.Setenv("CASSANDRA_HOSTS", "localhost")
+	t.Setenv("NATS_URL", "nats://localhost:4222")
+	t.Setenv("OTEL_SERVICE_NAME", "history-service-canary")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.Equal(t, "history-service-canary", cfg.ServiceName)
+}
+
 // unsetEnv removes key for the duration of the test and restores its prior
 // presence/value on cleanup, so a default-value test can't be perturbed by an
 // externally set variable.

--- a/history-service/internal/publisher/publisher.go
+++ b/history-service/internal/publisher/publisher.go
@@ -8,22 +8,46 @@ import (
 	o11ynats "github.com/flywindy/o11y/nats"
 	"github.com/nats-io/nats.go/jetstream"
 
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsutil"
 )
 
-// Publisher publishes byte payloads to NATS JetStream with dedup support.
-type Publisher struct {
-	js o11ynats.JetStream
+type attemptRecorder interface {
+	Attempt(context.Context, natsmetrics.DestinationKind, natsmetrics.Operation, error)
 }
 
-func New(js o11ynats.JetStream) *Publisher {
-	return &Publisher{js: js}
+// Publisher publishes byte payloads to NATS JetStream with dedup support.
+type Publisher struct {
+	js      o11ynats.JetStream
+	metrics attemptRecorder
+}
+
+type Option func(*Publisher)
+
+// WithMetrics enables bounded publish-attempt metrics without changing
+// JetStream acknowledgement or deduplication behavior.
+func WithMetrics(metrics natsmetrics.Publisher) Option {
+	return withAttemptRecorder(metrics)
+}
+
+func withAttemptRecorder(metrics attemptRecorder) Option {
+	return func(p *Publisher) { p.metrics = metrics }
+}
+
+func New(js o11ynats.JetStream, opts ...Option) *Publisher {
+	p := &Publisher{js: js}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
 }
 
 // Publish sends data to subj via JetStream with Nats-Msg-Id = msgID.
 func (p *Publisher) Publish(ctx context.Context, subj string, data []byte, msgID string) error {
 	msg := natsutil.NewMsg(ctx, subj, data)
-	if _, err := p.js.PublishMsg(ctx, msg, jetstream.WithMsgID(msgID)); err != nil {
+	_, err := p.js.PublishMsg(ctx, msg, jetstream.WithMsgID(msgID))
+	p.recordAttempt(ctx, subj, err)
+	if err != nil {
 		return fmt.Errorf("publishing to %q: %w", subj, err)
 	}
 	return nil
@@ -34,8 +58,18 @@ func (p *Publisher) Publish(ctx context.Context, subj string, data []byte, msgID
 func (p *Publisher) PublishMigration(ctx context.Context, subj string, data []byte, msgID string) error {
 	msg := natsutil.NewMsg(ctx, subj, data)
 	natsutil.SetMigrationLive(msg)
-	if _, err := p.js.PublishMsg(ctx, msg, jetstream.WithMsgID(msgID)); err != nil {
+	_, err := p.js.PublishMsg(ctx, msg, jetstream.WithMsgID(msgID))
+	p.recordAttempt(ctx, subj, err)
+	if err != nil {
 		return fmt.Errorf("publishing migration to %q: %w", subj, err)
 	}
 	return nil
+}
+
+func (p *Publisher) recordAttempt(ctx context.Context, subj string, err error) {
+	if p.metrics == nil {
+		return
+	}
+	destination, operation := natsmetrics.PublishLabelsFromSubject(subj)
+	p.metrics.Attempt(ctx, destination, operation, err)
 }

--- a/history-service/internal/publisher/publisher_test.go
+++ b/history-service/internal/publisher/publisher_test.go
@@ -1,0 +1,74 @@
+package publisher
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/natsmetrics"
+	"github.com/hmchangw/chat/pkg/natsutil"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+type recordingJetStream struct {
+	o11ynats.JetStream
+	msg *nats.Msg
+	err error
+}
+
+func (j *recordingJetStream) PublishMsg(_ context.Context, msg *nats.Msg, _ ...jetstream.PublishOpt) (*jetstream.PubAck, error) {
+	j.msg = msg
+	return &jetstream.PubAck{}, j.err
+}
+
+type recordedAttempt struct {
+	destination natsmetrics.DestinationKind
+	operation   natsmetrics.Operation
+	err         error
+}
+
+type recordingAttempts struct {
+	attempts []recordedAttempt
+}
+
+func (r *recordingAttempts) Attempt(_ context.Context, destination natsmetrics.DestinationKind, operation natsmetrics.Operation, err error) {
+	r.attempts = append(r.attempts, recordedAttempt{destination: destination, operation: operation, err: err})
+}
+
+func TestPublisher_PublishRecordsActualJetStreamAttempt(t *testing.T) {
+	publishErr := errors.New("publish unavailable")
+	js := &recordingJetStream{err: publishErr}
+	recorder := &recordingAttempts{}
+	p := New(js, withAttemptRecorder(recorder))
+
+	err := p.Publish(context.Background(), subject.MsgCanonicalUpdated("site-a"), []byte(`{"id":"m1"}`), "dedup-1")
+
+	require.ErrorIs(t, err, publishErr)
+	require.Len(t, recorder.attempts, 1)
+	assert.Equal(t, natsmetrics.DestinationCanonical, recorder.attempts[0].destination)
+	assert.Equal(t, natsmetrics.OperationCanonicalPublish, recorder.attempts[0].operation)
+	assert.ErrorIs(t, recorder.attempts[0].err, publishErr)
+}
+
+func TestPublisher_PublishMigrationPreservesHeaderAndRecordsSuccess(t *testing.T) {
+	js := &recordingJetStream{}
+	recorder := &recordingAttempts{}
+	p := New(js, withAttemptRecorder(recorder))
+	subj := subject.MsgCanonicalDeleted("site-a")
+
+	require.NoError(t, p.PublishMigration(context.Background(), subj, []byte(`{}`), "dedup-2"))
+
+	require.NotNil(t, js.msg)
+	assert.Equal(t, subj, js.msg.Subject)
+	assert.True(t, natsutil.IsMigrationLive(js.msg))
+	require.Len(t, recorder.attempts, 1)
+	assert.Equal(t, natsmetrics.DestinationCanonical, recorder.attempts[0].destination)
+	assert.Equal(t, natsmetrics.OperationCanonicalPublish, recorder.attempts[0].operation)
+	assert.NoError(t, recorder.attempts[0].err)
+}

--- a/message-gatekeeper/config_test.go
+++ b/message-gatekeeper/config_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/caarlos0/env/v11"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_ServiceName(t *testing.T) {
+	t.Setenv("NATS_URL", "nats://localhost:4222")
+	t.Setenv("SITE_ID", "site-a")
+	t.Setenv("MONGO_URI", "mongodb://localhost:27017")
+	t.Setenv("OTEL_SERVICE_NAME", "message-gatekeeper-canary")
+
+	cfg, err := env.ParseAs[config]()
+	require.NoError(t, err)
+	require.Equal(t, "message-gatekeeper-canary", cfg.ServiceName)
+}

--- a/message-gatekeeper/main.go
+++ b/message-gatekeeper/main.go
@@ -173,7 +173,7 @@ func main() {
 	})
 	var wg sync.WaitGroup
 	supervisor := natsmetrics.NewSupervisor(natsmetrics.SupervisorConfig{})
-	iteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+	initialIteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
 		cons, err := js.CreateOrUpdateConsumer(factoryCtx, messagesCfg.Name, consumerCfg)
 		if err != nil {
 			return nil, fmt.Errorf("create consumer: %w", err)
@@ -184,7 +184,19 @@ func main() {
 		}
 		return iter, nil
 	}
-	if err := supervisor.Start(ctx, iteratorFactory, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
+	recoveryIteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+		cons, err := js.Consumer(factoryCtx, messagesCfg.Name, consumerCfg.Durable)
+		if err != nil {
+			return nil, fmt.Errorf("lookup consumer: %w", err)
+		}
+		iter, err := cons.Messages(factoryCtx, jetstream.PullMaxMessages(2*cfg.MaxWorkers))
+		if err != nil {
+			return nil, fmt.Errorf("create recovery iterator: %w", err)
+		}
+		return iter, nil
+	}
+	if err := supervisor.StartWithRecovery(ctx, initialIteratorFactory, recoveryIteratorFactory,
+		consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
 		func(msg jetstream.Msg) natsmetrics.EventType { return natsmetrics.EventTypeFromSubject(msg.Subject()) },
 		func(msgCtx context.Context, msg *natsmetrics.Message) {
 			handlerCtx, _ := natsutil.StampRequestID(msgCtx, msg.Headers(), msg.Subject())

--- a/message-gatekeeper/main.go
+++ b/message-gatekeeper/main.go
@@ -26,6 +26,7 @@ import (
 )
 
 type config struct {
+	ServiceName        string                  `env:"OTEL_SERVICE_NAME" envDefault:"unknown-service"`
 	NatsURL            string                  `env:"NATS_URL,required"`
 	NatsCredsFile      string                  `env:"NATS_CREDS_FILE" envDefault:""`
 	SiteID             string                  `env:"SITE_ID,required"`
@@ -84,7 +85,7 @@ func main() {
 		os.Exit(1)
 	}
 	sharedMetrics := natsmetrics.NewFromProvider(sdk.MeterProvider())
-	publishMetrics := sharedMetrics.Publisher("message-gatekeeper", cfg.SiteID)
+	publishMetrics := sharedMetrics.Publisher(cfg.ServiceName, cfg.SiteID)
 	domainMetrics := newGatekeeperMetrics(sdk.MeterProvider().Meter("message-gatekeeper"))
 
 	nc, err := natsutil.ConnectWithMetrics(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace, sdk.MeterProvider())
@@ -167,33 +168,33 @@ func main() {
 	messagesCfg := stream.Messages(cfg.SiteID)
 	consumerCfg := buildConsumerConfig(cfg.Consumer)
 	consumerMetrics := sharedMetrics.Consumer(natsmetrics.ConsumerConfig{
-		ServiceName: "message-gatekeeper", Site: cfg.SiteID,
+		ServiceName: cfg.ServiceName, Site: cfg.SiteID,
 		Stream: messagesCfg.Name, Consumer: consumerCfg.Durable,
 	})
-	consumerMetrics.LoopStopped(ctx)
-	cons, err := js.CreateOrUpdateConsumer(ctx, messagesCfg.Name, consumerCfg)
-	if err != nil {
-		slog.Error("create consumer failed", "error", err)
-		os.Exit(1)
-	}
-
-	iter, err := cons.Messages(ctx, jetstream.PullMaxMessages(2*cfg.MaxWorkers))
-	if err != nil {
-		slog.Error("messages failed", "error", err)
-		os.Exit(1)
-	}
-	consumerMetrics.LoopStarted(ctx)
-
 	var wg sync.WaitGroup
-
-	natsmetrics.Start(ctx, iter, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
+	supervisor := natsmetrics.NewSupervisor(natsmetrics.SupervisorConfig{})
+	iteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+		cons, err := js.CreateOrUpdateConsumer(factoryCtx, messagesCfg.Name, consumerCfg)
+		if err != nil {
+			return nil, fmt.Errorf("create consumer: %w", err)
+		}
+		iter, err := cons.Messages(factoryCtx, jetstream.PullMaxMessages(2*cfg.MaxWorkers))
+		if err != nil {
+			return nil, fmt.Errorf("create iterator: %w", err)
+		}
+		return iter, nil
+	}
+	if err := supervisor.Start(ctx, iteratorFactory, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
 		func(msg jetstream.Msg) natsmetrics.EventType { return natsmetrics.EventTypeFromSubject(msg.Subject()) },
 		func(msgCtx context.Context, msg *natsmetrics.Message) {
 			handlerCtx, _ := natsutil.StampRequestID(msgCtx, msg.Headers(), msg.Subject())
 			handlerCtx = logctx.Admit(handlerCtx, msg.Headers())
 			logctx.CapturePayload(handlerCtx, "consumed", msg.Subject(), msg.Data())
 			handler.HandleJetStreamMsg(handlerCtx, msg)
-		})
+		}); err != nil {
+		slog.Error("start consumer supervisor failed", "error", err)
+		os.Exit(1)
+	}
 
 	healthStop, err := health.ServeWithPprof(cfg.HealthAddr, 5*time.Second, cfg.PProfEnabled,
 		natsutil.HealthCheck(nc),
@@ -206,9 +207,8 @@ func main() {
 	slog.Info("message-gatekeeper running", "site", cfg.SiteID)
 
 	shutdown.Wait(ctx, 25*time.Second,
-		func(ctx context.Context) error {
-			consumerMetrics.LoopStopped(ctx)
-			iter.Stop()
+		func(context.Context) error {
+			supervisor.Stop()
 			return nil
 		},
 		func(ctx context.Context) error {

--- a/message-gatekeeper/main.go
+++ b/message-gatekeeper/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/hmchangw/chat/pkg/health"
+	"github.com/hmchangw/chat/pkg/jobguard"
 	"github.com/hmchangw/chat/pkg/logctx"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
@@ -198,12 +199,12 @@ func main() {
 	if err := supervisor.StartWithRecovery(ctx, initialIteratorFactory, recoveryIteratorFactory,
 		consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
 		func(msg jetstream.Msg) natsmetrics.EventType { return natsmetrics.EventTypeFromSubject(msg.Subject()) },
-		func(msgCtx context.Context, msg *natsmetrics.Message) {
+		guardedGatekeeperProcessor(func(msgCtx context.Context, msg *natsmetrics.Message) {
 			handlerCtx, _ := natsutil.StampRequestID(msgCtx, msg.Headers(), msg.Subject())
 			handlerCtx = logctx.Admit(handlerCtx, msg.Headers())
 			logctx.CapturePayload(handlerCtx, "consumed", msg.Subject(), msg.Data())
 			handler.HandleJetStreamMsg(handlerCtx, msg)
-		}); err != nil {
+		})); err != nil {
 		slog.Error("start consumer supervisor failed", "error", err)
 		os.Exit(1)
 	}
@@ -239,6 +240,12 @@ func main() {
 		func(_ context.Context) error { valkeyutil.Disconnect(metaValkey); return nil },
 		func(ctx context.Context) error { return obsShutdown(ctx) },
 	)
+}
+
+func guardedGatekeeperProcessor(process natsmetrics.ProcessMessage) natsmetrics.ProcessMessage {
+	return func(msgCtx context.Context, msg *natsmetrics.Message) {
+		jobguard.Run(msg, func() { process(msgCtx, msg) })
+	}
 }
 
 // buildConsumerConfig returns the durable consumer config for

--- a/message-gatekeeper/nats_metrics_test.go
+++ b/message-gatekeeper/nats_metrics_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.uber.org/mock/gomock"
@@ -133,4 +134,25 @@ func TestHandler_HandleJetStreamMsg_RecordsAcceptedAndRetryOutcomes(t *testing.T
 func TestGatekeeperMetrics_Record_NilReceiverIsSafe(t *testing.T) {
 	var metrics *gatekeeperMetrics
 	metrics.Record(context.Background(), resultAccepted, reasonNone)
+}
+
+func TestGuardedGatekeeperProcessor_AcksPanickingMessage(t *testing.T) {
+	ctx := context.Background()
+	consumer := natsmetrics.NewFromProvider(noop.NewMeterProvider()).Consumer(natsmetrics.ConsumerConfig{
+		ServiceName: "message-gatekeeper",
+		Site:        "site-a",
+		Stream:      "MESSAGES_site-a",
+		Consumer:    "message-gatekeeper",
+	})
+	raw := &fakeJSMsg{subject: "chat.user.alice.room.room-a.site-a.msg.send"}
+	msg := consumer.Track(ctx, raw, natsmetrics.EventSend, 5)
+	called := false
+
+	guardedGatekeeperProcessor(func(context.Context, *natsmetrics.Message) {
+		called = true
+		panic("simulated handler panic")
+	})(ctx, msg)
+
+	assert.True(t, called)
+	assert.True(t, raw.acked, "a deterministic poison message must be Acked after panic recovery")
 }

--- a/message-worker/config_test.go
+++ b/message-worker/config_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/caarlos0/env/v11"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_ServiceName(t *testing.T) {
+	t.Setenv("NATS_URL", "nats://localhost:4222")
+	t.Setenv("SITE_ID", "site-a")
+	t.Setenv("MONGO_URI", "mongodb://localhost:27017")
+	t.Setenv("OTEL_SERVICE_NAME", "teams-message-worker")
+
+	cfg, err := env.ParseAs[config]()
+	require.NoError(t, err)
+	require.Equal(t, "teams-message-worker", cfg.ServiceName)
+}

--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -189,21 +189,6 @@ func main() {
 		ServiceName: cfg.ServiceName, Site: cfg.SiteID,
 		Stream: streamName, Consumer: consumerCfg.Durable,
 	})
-	consumerMetrics.LoopStopped(ctx)
-	cons, err := js.CreateOrUpdateConsumer(ctx, streamName, consumerCfg)
-	if err != nil {
-		slog.Error("create consumer failed", "error", err)
-		os.Exit(1)
-	}
-
-	iter, err := cons.Messages(ctx, jetstream.PullMaxMessages(2*cfg.MaxWorkers))
-	if err != nil {
-		slog.Error("messages failed", "error", err)
-		os.Exit(1)
-	}
-	consumerMetrics.LoopStarted(ctx)
-
-	sem := make(chan struct{}, cfg.MaxWorkers)
 	var wg sync.WaitGroup
 
 	// Built unconditionally in both modes: the consumer filter already scopes each
@@ -228,48 +213,41 @@ func main() {
 		}, domainMetrics)
 	teamsBatchSubj := subject.MsgTeamsCanonicalBatch(cfg.SiteID)
 
-	wg.Add(1)
-	go func() {
-		// The loop itself is counted so shutdown, which stops the iterator and
-		// then waits on wg, cannot pass through while a message Next already
-		// returned is still on its way to a worker.
-		defer wg.Done()
-		for {
-			msgCtx, msg, err := iter.Next()
-			if err != nil {
-				consumerMetrics.LoopFailed(context.Background(), err)
-				return
-			}
-			sem <- struct{}{}
-			wg.Add(1)
-			go func(msgCtx context.Context, msg jetstream.Msg) {
-				tracked := consumerMetrics.Track(msgCtx, msg, natsmetrics.EventTypeFromSubject(msg.Subject()), consumerCfg.MaxDeliver)
-				msg = tracked
-				msgCtx = tracked.Context(msgCtx)
-				defer func() {
-					tracked.Finish(msgCtx)
-					<-sem
-					wg.Done()
-				}()
-				// jobguard recovers handler panics — this goroutine runs outside
-				// natsrouter's Recovery middleware, so an unrecovered panic would
-				// crash the worker and crash-loop on JetStream redelivery.
-				jobguard.Run(msg, func() {
-					handlerCtx, _ := natsutil.StampRequestID(msgCtx, msg.Headers(), msg.Subject())
-					handlerCtx = logctx.Admit(handlerCtx, msg.Headers())
-					// Dispatch by subject: the one-time .teams.batch migration
-					// writes straight to Cassandra; the live .created feed runs the
-					// normal pipeline.
-					if msg.Subject() == teamsBatchSubj {
-						teamsMigration.consume(handlerCtx, msg)
-						return
-					}
-					logctx.CapturePayload(handlerCtx, "consumed", msg.Subject(), msg.Data())
-					handler.HandleJetStreamMsg(handlerCtx, msg)
-				})
-			}(msgCtx, msg)
+	supervisor := natsmetrics.NewSupervisor(natsmetrics.SupervisorConfig{})
+	iteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+		cons, err := js.CreateOrUpdateConsumer(factoryCtx, streamName, consumerCfg)
+		if err != nil {
+			return nil, fmt.Errorf("create consumer: %w", err)
 		}
-	}()
+		iter, err := cons.Messages(factoryCtx, jetstream.PullMaxMessages(2*cfg.MaxWorkers))
+		if err != nil {
+			return nil, fmt.Errorf("create iterator: %w", err)
+		}
+		return iter, nil
+	}
+	if err := supervisor.Start(ctx, iteratorFactory, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
+		func(msg jetstream.Msg) natsmetrics.EventType { return natsmetrics.EventTypeFromSubject(msg.Subject()) },
+		func(msgCtx context.Context, msg *natsmetrics.Message) {
+			// jobguard recovers handler panics — this goroutine runs outside
+			// natsrouter's Recovery middleware, so an unrecovered panic would
+			// crash the worker and crash-loop on JetStream redelivery.
+			jobguard.Run(msg, func() {
+				handlerCtx, _ := natsutil.StampRequestID(msgCtx, msg.Headers(), msg.Subject())
+				handlerCtx = logctx.Admit(handlerCtx, msg.Headers())
+				// Dispatch by subject: the one-time .teams.batch migration
+				// writes straight to Cassandra; the live .created feed runs the
+				// normal pipeline.
+				if msg.Subject() == teamsBatchSubj {
+					teamsMigration.consume(handlerCtx, msg)
+					return
+				}
+				logctx.CapturePayload(handlerCtx, "consumed", msg.Subject(), msg.Data())
+				handler.HandleJetStreamMsg(handlerCtx, msg)
+			})
+		}); err != nil {
+		slog.Error("start consumer supervisor failed", "error", err)
+		os.Exit(1)
+	}
 
 	healthStop, err := health.ServeWithPprof(cfg.HealthAddr, 5*time.Second, cfg.PProfEnabled,
 		natsutil.HealthCheck(nc),
@@ -282,9 +260,8 @@ func main() {
 	slog.Info("message-worker running", "site", cfg.SiteID)
 
 	shutdown.Wait(ctx, 25*time.Second,
-		func(ctx context.Context) error {
-			consumerMetrics.LoopStopped(ctx)
-			iter.Stop()
+		func(context.Context) error {
+			supervisor.Stop()
 			return nil
 		},
 		func(ctx context.Context) error {

--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -34,6 +34,7 @@ type config struct {
 	// .created feed off MESSAGES-CANONICAL; "teams" runs the Teams-migration batch
 	// feed off MESSAGES-TEAMS. Two deploys of the same binary, gated by env only.
 	Mode               string                  `env:"MODE"                 envDefault:"default"`
+	ServiceName        string                  `env:"OTEL_SERVICE_NAME"    envDefault:"unknown-service"`
 	NatsURL            string                  `env:"NATS_URL,required"`
 	NatsCredsFile      string                  `env:"NATS_CREDS_FILE"      envDefault:""`
 	SiteID             string                  `env:"SITE_ID,required"`
@@ -92,7 +93,7 @@ func main() {
 		os.Exit(1)
 	}
 	sharedMetrics := natsmetrics.NewFromProvider(sdk.MeterProvider())
-	publishMetrics := sharedMetrics.Publisher("message-worker", cfg.SiteID)
+	publishMetrics := sharedMetrics.Publisher(cfg.ServiceName, cfg.SiteID)
 	domainMetrics := newPersistenceMetrics(sdk.MeterProvider().Meter("message-worker"))
 
 	nc, err := natsutil.ConnectWithMetrics(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace, sdk.MeterProvider())
@@ -185,7 +186,7 @@ func main() {
 
 	consumerCfg := buildConsumerConfig(cfg.Consumer, cfg.Mode, cfg.SiteID)
 	consumerMetrics := sharedMetrics.Consumer(natsmetrics.ConsumerConfig{
-		ServiceName: "message-worker", Site: cfg.SiteID,
+		ServiceName: cfg.ServiceName, Site: cfg.SiteID,
 		Stream: streamName, Consumer: consumerCfg.Durable,
 	})
 	consumerMetrics.LoopStopped(ctx)

--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -214,7 +214,7 @@ func main() {
 	teamsBatchSubj := subject.MsgTeamsCanonicalBatch(cfg.SiteID)
 
 	supervisor := natsmetrics.NewSupervisor(natsmetrics.SupervisorConfig{})
-	iteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+	initialIteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
 		cons, err := js.CreateOrUpdateConsumer(factoryCtx, streamName, consumerCfg)
 		if err != nil {
 			return nil, fmt.Errorf("create consumer: %w", err)
@@ -225,7 +225,19 @@ func main() {
 		}
 		return iter, nil
 	}
-	if err := supervisor.Start(ctx, iteratorFactory, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
+	recoveryIteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+		cons, err := js.Consumer(factoryCtx, streamName, consumerCfg.Durable)
+		if err != nil {
+			return nil, fmt.Errorf("lookup consumer: %w", err)
+		}
+		iter, err := cons.Messages(factoryCtx, jetstream.PullMaxMessages(2*cfg.MaxWorkers))
+		if err != nil {
+			return nil, fmt.Errorf("create recovery iterator: %w", err)
+		}
+		return iter, nil
+	}
+	if err := supervisor.StartWithRecovery(ctx, initialIteratorFactory, recoveryIteratorFactory,
+		consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
 		func(msg jetstream.Msg) natsmetrics.EventType { return natsmetrics.EventTypeFromSubject(msg.Subject()) },
 		func(msgCtx context.Context, msg *natsmetrics.Message) {
 			// jobguard recovers handler panics — this goroutine runs outside

--- a/notification-worker/config_test.go
+++ b/notification-worker/config_test.go
@@ -44,6 +44,16 @@ func TestConfig_Mode(t *testing.T) {
 	}
 }
 
+func TestConfig_ServiceName(t *testing.T) {
+	t.Setenv("VALKEY_ADDRS", "valkey:6379")
+	t.Setenv("MODE", "bot")
+	t.Setenv("OTEL_SERVICE_NAME", "bot-notification-worker")
+
+	cfg, err := env.ParseAs[config]()
+	require.NoError(t, err)
+	require.Equal(t, "bot-notification-worker", cfg.ServiceName)
+}
+
 func TestConfig_UserSettingsDefaults(t *testing.T) {
 	t.Setenv("VALKEY_ADDRS", "valkey:6379")
 	t.Setenv("MODE", "user")

--- a/notification-worker/invalidation.go
+++ b/notification-worker/invalidation.go
@@ -8,11 +8,16 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 )
 
 func processInvalidationMessage(ctx context.Context, msg jetstream.Msg, queue chan<- string) {
 	var evt model.CanonicalMemberEvent
 	if err := sonic.Unmarshal(msg.Data(), &evt); err != nil {
+		// Acking a payload that will never decode drops it permanently, and Ack
+		// records a success disposition. Mark the terminal reason so the drop is
+		// visible as loss rather than as normal processing.
+		natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalInvalidPayload)
 		slog.WarnContext(ctx, "canonical member event decode failed", "error", err)
 		ackInvalidation(ctx, msg)
 		return

--- a/notification-worker/invalidation.go
+++ b/notification-worker/invalidation.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/bytedance/sonic"
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/hmchangw/chat/pkg/model"
+)
+
+func processInvalidationMessage(ctx context.Context, msg jetstream.Msg, queue chan<- string) {
+	var evt model.CanonicalMemberEvent
+	if err := sonic.Unmarshal(msg.Data(), &evt); err != nil {
+		slog.WarnContext(ctx, "canonical member event decode failed", "error", err)
+		ackInvalidation(ctx, msg)
+		return
+	}
+	if evt.RoomID != "" {
+		select {
+		case queue <- evt.RoomID:
+		default:
+			slog.WarnContext(ctx, "invalidation queue full, dropping (TTL will reconcile)", "roomId", evt.RoomID)
+		}
+	}
+	ackInvalidation(ctx, msg)
+}
+
+func ackInvalidation(ctx context.Context, msg jetstream.Msg) {
+	if err := msg.Ack(); err != nil {
+		slog.ErrorContext(ctx, "canonical member event ack failed", "error", err)
+	}
+}

--- a/notification-worker/invalidation_test.go
+++ b/notification-worker/invalidation_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/nats-io/nats.go/jetstream"
@@ -11,14 +12,15 @@ import (
 
 type invalidationTestMsg struct {
 	jetstream.Msg
-	data []byte
-	acks int
+	data   []byte
+	acks   int
+	ackErr error
 }
 
 func (m *invalidationTestMsg) Data() []byte { return m.data }
 func (m *invalidationTestMsg) Ack() error {
 	m.acks++
-	return nil
+	return m.ackErr
 }
 
 func TestProcessInvalidationMessage(t *testing.T) {
@@ -51,5 +53,20 @@ func TestProcessInvalidationMessage(t *testing.T) {
 
 		require.Equal(t, 1, msg.acks)
 		assert.Equal(t, "already-full", <-queue)
+	})
+
+	t.Run("acknowledgement failure is contained", func(t *testing.T) {
+		msg := &invalidationTestMsg{
+			data:   []byte(`{"type":"muted","roomId":"room-c","account":"alice","muted":true,"timestamp":3}`),
+			ackErr: errors.New("ack unavailable"),
+		}
+		queue := make(chan string, 1)
+
+		assert.NotPanics(t, func() {
+			processInvalidationMessage(context.Background(), msg, queue)
+		})
+
+		require.Equal(t, 1, msg.acks)
+		assert.Equal(t, "room-c", <-queue)
 	})
 }

--- a/notification-worker/invalidation_test.go
+++ b/notification-worker/invalidation_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type invalidationTestMsg struct {
+	jetstream.Msg
+	data []byte
+	acks int
+}
+
+func (m *invalidationTestMsg) Data() []byte { return m.data }
+func (m *invalidationTestMsg) Ack() error {
+	m.acks++
+	return nil
+}
+
+func TestProcessInvalidationMessage(t *testing.T) {
+	t.Run("enqueues room and acknowledges", func(t *testing.T) {
+		msg := &invalidationTestMsg{data: []byte(`{"type":"muted","roomId":"room-a","account":"alice","muted":true,"timestamp":1}`)}
+		queue := make(chan string, 1)
+
+		processInvalidationMessage(context.Background(), msg, queue)
+
+		require.Equal(t, 1, msg.acks)
+		assert.Equal(t, "room-a", <-queue)
+	})
+
+	t.Run("malformed payload acknowledges poison", func(t *testing.T) {
+		msg := &invalidationTestMsg{data: []byte("not-json")}
+		queue := make(chan string, 1)
+
+		processInvalidationMessage(context.Background(), msg, queue)
+
+		require.Equal(t, 1, msg.acks)
+		assert.Empty(t, queue)
+	})
+
+	t.Run("full queue acknowledges because ttl reconciles", func(t *testing.T) {
+		msg := &invalidationTestMsg{data: []byte(`{"type":"muted","roomId":"room-b","account":"alice","muted":false,"timestamp":2}`)}
+		queue := make(chan string, 1)
+		queue <- "already-full"
+
+		processInvalidationMessage(context.Background(), msg, queue)
+
+		require.Equal(t, 1, msg.acks)
+		assert.Equal(t, "already-full", <-queue)
+	})
+}

--- a/notification-worker/invalidation_test.go
+++ b/notification-worker/invalidation_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 )
 
 type invalidationTestMsg struct {
@@ -18,6 +22,12 @@ type invalidationTestMsg struct {
 }
 
 func (m *invalidationTestMsg) Data() []byte { return m.data }
+
+// Metadata is needed once a test tracks the message through natsmetrics; the
+// embedded nil jetstream.Msg would otherwise panic.
+func (m *invalidationTestMsg) Metadata() (*jetstream.MsgMetadata, error) {
+	return &jetstream.MsgMetadata{NumDelivered: 1}, nil
+}
 func (m *invalidationTestMsg) Ack() error {
 	m.acks++
 	return m.ackErr
@@ -69,4 +79,44 @@ func TestProcessInvalidationMessage(t *testing.T) {
 		require.Equal(t, 1, msg.acks)
 		assert.Equal(t, "room-c", <-queue)
 	})
+}
+
+// TestProcessInvalidationMessage_MalformedRecordsTerminal pins the evidence
+// rule: a payload that will never decode is Acked and permanently dropped, and
+// Message.Ack records OutcomeAck — a success. Without an explicit terminal mark
+// the drop is indistinguishable from normal processing in the metrics.
+func TestProcessInvalidationMessage_MalformedRecordsTerminal(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	consumer := natsmetrics.NewFromProvider(mp).Consumer(natsmetrics.ConsumerConfig{
+		ServiceName: "notification-worker", Site: "site-a",
+		Stream: "ROOMS-site-a", Consumer: "notification-worker-room-event-invalidate",
+	})
+	raw := &invalidationTestMsg{data: []byte("not-json")}
+	tracked := consumer.Track(context.Background(), raw, natsmetrics.EventUnknown, 5)
+
+	processInvalidationMessage(tracked.Context(context.Background()), tracked, make(chan string, 1))
+	tracked.Finish(context.Background())
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	var terminal int64
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != "chat.nats.terminal.failures" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			for _, dp := range sum.DataPoints {
+				for _, kv := range dp.Attributes.ToSlice() {
+					if string(kv.Key) == "reason" && kv.Value.AsString() == "invalid_payload" {
+						terminal += dp.Value
+					}
+				}
+			}
+		}
+	}
+	assert.Equal(t, int64(1), terminal, "a permanently dropped malformed event must leave terminal evidence")
 }

--- a/notification-worker/main.go
+++ b/notification-worker/main.go
@@ -35,6 +35,7 @@ import (
 )
 
 type config struct {
+	ServiceName   string `env:"OTEL_SERVICE_NAME"          envDefault:"unknown-service"`
 	NatsURL       string `env:"NATS_URL"                  envDefault:"nats://localhost:4222"`
 	NatsCredsFile string `env:"NATS_CREDS_FILE"           envDefault:""`
 	SiteID        string `env:"SITE_ID"                   envDefault:"default"`
@@ -142,7 +143,7 @@ func main() {
 		os.Exit(1)
 	}
 	sharedMetrics := natsmetrics.NewFromProvider(sdk.MeterProvider())
-	publishMetrics := sharedMetrics.Publisher("notification-worker", cfg.SiteID)
+	publishMetrics := sharedMetrics.Publisher(cfg.ServiceName, cfg.SiteID)
 	domainMetrics := newNotificationMetrics(sdk.MeterProvider().Meter("notification-worker"))
 
 	readPref, err := mongoutil.ParseReadPreference(cfg.MongoReadPreference)
@@ -212,7 +213,7 @@ func main() {
 
 	consumerCfg := buildConsumerConfig(cfg.Consumer, cfg.Mode.ConsumerName("notification-worker"), wiring.CanonicalCreated)
 	consumerMetrics := sharedMetrics.Consumer(natsmetrics.ConsumerConfig{
-		ServiceName: "notification-worker", Site: cfg.SiteID,
+		ServiceName: cfg.ServiceName, Site: cfg.SiteID,
 		Stream: wiring.CanonicalStream.Name, Consumer: consumerCfg.Durable,
 	})
 	consumerMetrics.LoopStopped(ctx)

--- a/notification-worker/main.go
+++ b/notification-worker/main.go
@@ -276,7 +276,7 @@ func main() {
 		Stream: roomsCfg.Name, Consumer: invalConsumerCfg.Durable,
 	})
 	invalSupervisor := natsmetrics.NewSupervisor(natsmetrics.SupervisorConfig{})
-	invalFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+	initialInvalFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
 		cons, err := otelJS.CreateOrUpdateConsumer(factoryCtx, roomsCfg.Name, invalConsumerCfg)
 		if err != nil {
 			return nil, fmt.Errorf("create invalidation consumer: %w", err)
@@ -287,7 +287,19 @@ func main() {
 		}
 		return iter, nil
 	}
-	if err := invalSupervisor.Start(ctx, invalFactory, invalConsumerMetrics, 1, invalConsumerCfg.MaxDeliver, &wg,
+	recoveryInvalFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+		cons, err := otelJS.Consumer(factoryCtx, roomsCfg.Name, invalConsumerCfg.Durable)
+		if err != nil {
+			return nil, fmt.Errorf("lookup invalidation consumer: %w", err)
+		}
+		iter, err := cons.Messages(factoryCtx, jetstream.PullMaxMessages(64))
+		if err != nil {
+			return nil, fmt.Errorf("create recovery invalidation iterator: %w", err)
+		}
+		return iter, nil
+	}
+	if err := invalSupervisor.StartWithRecovery(ctx, initialInvalFactory, recoveryInvalFactory,
+		invalConsumerMetrics, 1, invalConsumerCfg.MaxDeliver, &wg,
 		func(msg jetstream.Msg) natsmetrics.EventType {
 			return natsmetrics.RoomEventTypeFromSubject(msg.Subject())
 		},
@@ -299,7 +311,7 @@ func main() {
 	}
 
 	supervisor := natsmetrics.NewSupervisor(natsmetrics.SupervisorConfig{})
-	iteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+	initialIteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
 		cons, err := otelJS.CreateOrUpdateConsumer(factoryCtx, wiring.CanonicalStream.Name, consumerCfg)
 		if err != nil {
 			return nil, fmt.Errorf("create consumer: %w", err)
@@ -310,7 +322,19 @@ func main() {
 		}
 		return iter, nil
 	}
-	if err := supervisor.Start(ctx, iteratorFactory, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
+	recoveryIteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+		cons, err := otelJS.Consumer(factoryCtx, wiring.CanonicalStream.Name, consumerCfg.Durable)
+		if err != nil {
+			return nil, fmt.Errorf("lookup consumer: %w", err)
+		}
+		iter, err := cons.Messages(factoryCtx, jetstream.PullMaxMessages(2*cfg.MaxWorkers))
+		if err != nil {
+			return nil, fmt.Errorf("create recovery iterator: %w", err)
+		}
+		return iter, nil
+	}
+	if err := supervisor.StartWithRecovery(ctx, initialIteratorFactory, recoveryIteratorFactory,
+		consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
 		func(msg jetstream.Msg) natsmetrics.EventType { return natsmetrics.EventTypeFromSubject(msg.Subject()) },
 		func(msgCtx context.Context, msg *natsmetrics.Message) {
 			// jobguard recovers handler panics — this goroutine runs outside natsrouter's Recovery

--- a/notification-worker/main.go
+++ b/notification-worker/main.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bytedance/sonic"
-
 	"github.com/caarlos0/env/v11"
 	"github.com/nats-io/nats.go/jetstream"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -216,12 +214,6 @@ func main() {
 		ServiceName: cfg.ServiceName, Site: cfg.SiteID,
 		Stream: wiring.CanonicalStream.Name, Consumer: consumerCfg.Durable,
 	})
-	consumerMetrics.LoopStopped(ctx)
-	cons, err := otelJS.CreateOrUpdateConsumer(ctx, wiring.CanonicalStream.Name, consumerCfg)
-	if err != nil {
-		slog.Error("create consumer failed", "error", err)
-		os.Exit(1)
-	}
 	// The broker advertises max_payload in its INFO on connect, so this is
 	// always in step with the server. An env var was a second source of truth
 	// that silently dropped batches whenever it drifted below the real limit.
@@ -272,97 +264,76 @@ func main() {
 	// Mute is the only canonical member event still on this stream; add/remove invalidation rides on MESSAGES-CANONICAL sys-messages.
 	// DeliverNewPolicy: skip history on restart; roomsubcache TTL reconciles any boundary staleness.
 	roomsCfg := stream.Rooms(cfg.SiteID)
-	invalCons, err := otelJS.CreateOrUpdateConsumer(ctx, roomsCfg.Name, jetstream.ConsumerConfig{
+	invalConsumerCfg := jetstream.ConsumerConfig{
 		Durable:       cfg.Mode.ConsumerName("notification-worker-room-event-invalidate"),
 		FilterSubject: subject.RoomCanonicalMemberEvent(cfg.SiteID, model.CanonicalMemberEventMuted),
 		AckPolicy:     jetstream.AckExplicitPolicy,
 		DeliverPolicy: jetstream.DeliverNewPolicy,
-	})
-	if err != nil {
-		slog.Error("create canonical member event consumer failed", "error", err)
-		os.Exit(1)
 	}
-	invalIter, err := invalCons.Messages(ctx, jetstream.PullMaxMessages(64))
-	if err != nil {
-		slog.Error("canonical member event iterator failed", "error", err)
-		os.Exit(1)
-	}
-	go func() {
-		for {
-			_, msg, err := invalIter.Next()
-			if err != nil {
-				return
-			}
-			var evt model.CanonicalMemberEvent
-			if err := sonic.Unmarshal(msg.Data(), &evt); err != nil {
-				slog.Warn("canonical member event decode failed", "error", err)
-				_ = msg.Ack()
-				continue
-			}
-			if evt.RoomID != "" {
-				select {
-				case invalCh <- evt.RoomID:
-				default:
-					slog.Warn("invalidation queue full, dropping (TTL will reconcile)", "roomId", evt.RoomID)
-				}
-			}
-			_ = msg.Ack()
-		}
-	}()
-
-	iter, err := cons.Messages(ctx, jetstream.PullMaxMessages(2*cfg.MaxWorkers))
-	if err != nil {
-		slog.Error("messages failed", "error", err)
-		os.Exit(1)
-	}
-	consumerMetrics.LoopStarted(ctx)
-
-	sem := make(chan struct{}, cfg.MaxWorkers)
 	var wg sync.WaitGroup
-
-	wg.Add(1)
-	go func() {
-		// The loop itself is counted so shutdown, which stops the iterator and
-		// then waits on wg, cannot pass through while a message Next already
-		// returned is still on its way to a worker.
-		defer wg.Done()
-		for {
-			msgCtx, msg, err := iter.Next()
-			if err != nil {
-				consumerMetrics.LoopFailed(context.Background(), err)
-				return
-			}
-			sem <- struct{}{}
-			wg.Add(1)
-			go func(msgCtx context.Context, msg jetstream.Msg) {
-				tracked := consumerMetrics.Track(msgCtx, msg, natsmetrics.EventTypeFromSubject(msg.Subject()), consumerCfg.MaxDeliver)
-				msg = tracked
-				msgCtx = tracked.Context(msgCtx)
-				defer func() {
-					tracked.Finish(msgCtx)
-					<-sem
-					wg.Done()
-				}()
-				// jobguard recovers handler panics — this goroutine runs outside natsrouter's Recovery
-				// middleware, so an unrecovered panic would crash the worker and crash-loop on redelivery.
-				jobguard.Run(msg, func() {
-					handlerCtx, reqID := natsutil.StampRequestID(msgCtx, msg.Headers(), msg.Subject())
-					// Migrated events carry X-Migration: live — the source already delivered them, so
-					// this live-delivery worker must not re-notify. Ack and drop without invoking the handler.
-					if natsutil.IsMigrationLiveHeader(msg.Headers()) {
-						slog.Info("skipping migrated event (no re-notify)", "subject", msg.Subject(), "request_id", reqID)
-						if err := msg.Ack(); err != nil {
-							slog.Error("failed to ack migrated message", "error", err, "request_id", reqID)
-						}
-						domainMetrics.Record(handlerCtx, notifyKindPush, notifySuppressed)
-						return
-					}
-					// Transient failures retry with backoff (never drop); malformed events Ack-drop as poison.
-					jsretry.Settle(handlerCtx, msg, jsretry.DefaultBackoff, handler.HandleMessage(handlerCtx, msg.Data()))
-				})
-			}(msgCtx, msg)
+	invalConsumerMetrics := sharedMetrics.Consumer(natsmetrics.ConsumerConfig{
+		ServiceName: cfg.ServiceName, Site: cfg.SiteID,
+		Stream: roomsCfg.Name, Consumer: invalConsumerCfg.Durable,
+	})
+	invalSupervisor := natsmetrics.NewSupervisor(natsmetrics.SupervisorConfig{})
+	invalFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+		cons, err := otelJS.CreateOrUpdateConsumer(factoryCtx, roomsCfg.Name, invalConsumerCfg)
+		if err != nil {
+			return nil, fmt.Errorf("create invalidation consumer: %w", err)
 		}
-	}()
+		iter, err := cons.Messages(factoryCtx, jetstream.PullMaxMessages(64))
+		if err != nil {
+			return nil, fmt.Errorf("create invalidation iterator: %w", err)
+		}
+		return iter, nil
+	}
+	if err := invalSupervisor.Start(ctx, invalFactory, invalConsumerMetrics, 1, invalConsumerCfg.MaxDeliver, &wg,
+		func(msg jetstream.Msg) natsmetrics.EventType {
+			return natsmetrics.RoomEventTypeFromSubject(msg.Subject())
+		},
+		func(msgCtx context.Context, msg *natsmetrics.Message) {
+			processInvalidationMessage(msgCtx, msg, invalCh)
+		}); err != nil {
+		slog.Error("start invalidation consumer supervisor failed", "error", err)
+		os.Exit(1)
+	}
+
+	supervisor := natsmetrics.NewSupervisor(natsmetrics.SupervisorConfig{})
+	iteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+		cons, err := otelJS.CreateOrUpdateConsumer(factoryCtx, wiring.CanonicalStream.Name, consumerCfg)
+		if err != nil {
+			return nil, fmt.Errorf("create consumer: %w", err)
+		}
+		iter, err := cons.Messages(factoryCtx, jetstream.PullMaxMessages(2*cfg.MaxWorkers))
+		if err != nil {
+			return nil, fmt.Errorf("create iterator: %w", err)
+		}
+		return iter, nil
+	}
+	if err := supervisor.Start(ctx, iteratorFactory, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
+		func(msg jetstream.Msg) natsmetrics.EventType { return natsmetrics.EventTypeFromSubject(msg.Subject()) },
+		func(msgCtx context.Context, msg *natsmetrics.Message) {
+			// jobguard recovers handler panics — this goroutine runs outside natsrouter's Recovery
+			// middleware, so an unrecovered panic would crash the worker and crash-loop on redelivery.
+			jobguard.Run(msg, func() {
+				handlerCtx, reqID := natsutil.StampRequestID(msgCtx, msg.Headers(), msg.Subject())
+				// Migrated events carry X-Migration: live — the source already delivered them, so
+				// this live-delivery worker must not re-notify. Ack and drop without invoking the handler.
+				if natsutil.IsMigrationLiveHeader(msg.Headers()) {
+					slog.Info("skipping migrated event (no re-notify)", "subject", msg.Subject(), "request_id", reqID)
+					if err := msg.Ack(); err != nil {
+						slog.Error("failed to ack migrated message", "error", err, "request_id", reqID)
+					}
+					domainMetrics.Record(handlerCtx, notifyKindPush, notifySuppressed)
+					return
+				}
+				// Transient failures retry with backoff (never drop); malformed events Ack-drop as poison.
+				jsretry.Settle(handlerCtx, msg, jsretry.DefaultBackoff, handler.HandleMessage(handlerCtx, msg.Data()))
+			})
+		}); err != nil {
+		slog.Error("start consumer supervisor failed", "error", err)
+		os.Exit(1)
+	}
 
 	healthStop, err := health.ServeWithPprof(cfg.HealthAddr, 5*time.Second, cfg.PProfEnabled,
 		natsutil.HealthCheck(nc),
@@ -382,9 +353,9 @@ func main() {
 	)
 
 	shutdown.Wait(ctx, 25*time.Second,
-		func(_ context.Context) error {
-			consumerMetrics.LoopStopped(context.Background())
-			iter.Stop()
+		func(context.Context) error {
+			supervisor.Stop()
+			invalSupervisor.Stop()
 			return nil
 		},
 		func(ctx context.Context) error {
@@ -396,10 +367,6 @@ func main() {
 			case <-ctx.Done():
 				return fmt.Errorf("worker drain timed out: %w", ctx.Err())
 			}
-		},
-		func(_ context.Context) error {
-			invalIter.Stop()
-			return nil
 		},
 		func(stepCtx context.Context) error {
 			close(invalCh) // stop accepting work; worker drains the buffer

--- a/notification-worker/nats_metrics.go
+++ b/notification-worker/nats_metrics.go
@@ -13,12 +13,11 @@ import (
 type notifyKind string
 
 const (
-	notifyKindPush         notifyKind = "push"
-	notifyKindNotification notifyKind = "notification"
-	notifyKindUnknown      notifyKind = "unknown"
+	notifyKindPush    notifyKind = "push"
+	notifyKindUnknown notifyKind = "unknown"
 )
 
-var allNotifyKinds = []notifyKind{notifyKindPush, notifyKindNotification, notifyKindUnknown}
+var allNotifyKinds = []notifyKind{notifyKindPush, notifyKindUnknown}
 
 type notifyResult string
 

--- a/pkg/natsmetrics/disposition_test.go
+++ b/pkg/natsmetrics/disposition_test.go
@@ -144,3 +144,5 @@ func (s *scriptedIterator) Next(...jetstream.NextOpt) (context.Context, jetstrea
 	s.msgs = s.msgs[1:]
 	return context.Background(), msg, nil
 }
+
+func (*scriptedIterator) Stop() {}

--- a/pkg/natsmetrics/loop.go
+++ b/pkg/natsmetrics/loop.go
@@ -113,9 +113,10 @@ type SupervisorConfig struct {
 	wait       waitBackoff
 }
 
-// IteratorFactory recreates both the durable consumer handle and its pull
-// iterator. Callers keep stream, durable, and pull settings closed over in the
-// factory so recovery cannot drift from startup configuration.
+// IteratorFactory creates a durable consumer handle and its pull iterator.
+// Startup factories may create or update the durable; recovery factories must
+// only look up the existing durable so recovery cannot silently replace a lost
+// server-side delivery cursor.
 type IteratorFactory func(context.Context) (Iterator, error)
 
 // Supervisor owns exactly one iterator at a time and recreates it after a
@@ -160,6 +161,14 @@ func NewSupervisor(cfg SupervisorConfig) *Supervisor {
 // process cannot create duplicate pull iterators for the same durable through
 // this supervisor.
 func (s *Supervisor) Start(ctx context.Context, factory IteratorFactory, consumer *Consumer, maxWorkers, maxDeliver int, wg *sync.WaitGroup, classify ClassifyEvent, process ProcessMessage) error {
+	return s.StartWithRecovery(ctx, factory, factory, consumer, maxWorkers, maxDeliver, wg, classify, process)
+}
+
+// StartWithRecovery separates fail-fast startup creation from lookup-only
+// recovery. The recovery factory must never create a missing durable: after a
+// transport failure the iterator cannot reliably report that the durable was
+// concurrently deleted, and recreating it would replay or skip retained work.
+func (s *Supervisor) StartWithRecovery(ctx context.Context, initialFactory, recoveryFactory IteratorFactory, consumer *Consumer, maxWorkers, maxDeliver int, wg *sync.WaitGroup, classify ClassifyEvent, process ProcessMessage) error {
 	if !s.running.CompareAndSwap(false, true) {
 		return ErrSupervisorRunning
 	}
@@ -168,7 +177,7 @@ func (s *Supervisor) Start(ctx context.Context, factory IteratorFactory, consume
 	s.cancel = cancel
 	s.mu.Unlock()
 	consumer.LoopStopped(runCtx)
-	iter, err := factory(runCtx)
+	iter, err := initialFactory(runCtx)
 	if err != nil {
 		s.abortStart(cancel)
 		return fmt.Errorf("create initial consumer iterator: %w", err)
@@ -186,12 +195,12 @@ func (s *Supervisor) Start(ctx context.Context, factory IteratorFactory, consume
 	go func() {
 		defer wg.Done()
 		defer s.finish(runCtx, consumer)
-		s.run(runCtx, iter, factory, consumer, maxDeliver, wg, sem, classify, process)
+		s.run(runCtx, iter, recoveryFactory, consumer, maxDeliver, wg, sem, classify, process)
 	}()
 	return nil
 }
 
-func (s *Supervisor) run(ctx context.Context, iter Iterator, factory IteratorFactory, consumer *Consumer, maxDeliver int, wg *sync.WaitGroup, sem chan struct{}, classify ClassifyEvent, process ProcessMessage) {
+func (s *Supervisor) run(ctx context.Context, iter Iterator, recoveryFactory IteratorFactory, consumer *Consumer, maxDeliver int, wg *sync.WaitGroup, sem chan struct{}, classify ClassifyEvent, process ProcessMessage) {
 	backoff := s.minBackoff
 	recovered := false
 	for {
@@ -204,8 +213,8 @@ func (s *Supervisor) run(ctx context.Context, iter Iterator, factory IteratorFac
 		if ctx.Err() != nil {
 			return
 		}
-		if errors.Is(err, jetstream.ErrConsumerDeleted) {
-			slog.ErrorContext(ctx, "jetstream consumer deleted; automatic recreation disabled to preserve delivery position", "error", err)
+		if isMissingConsumer(err) {
+			slog.ErrorContext(ctx, "jetstream consumer missing or deleted; automatic recreation disabled to preserve delivery position", "error", err)
 			return
 		}
 		if received {
@@ -219,7 +228,7 @@ func (s *Supervisor) run(ctx context.Context, iter Iterator, factory IteratorFac
 			if err := s.wait(ctx, backoff); err != nil {
 				return
 			}
-			iter, err = factory(ctx)
+			iter, err = recoveryFactory(ctx)
 			if err == nil {
 				if !s.activate(ctx, iter) {
 					iter.Stop()
@@ -231,11 +240,20 @@ func (s *Supervisor) run(ctx context.Context, iter Iterator, factory IteratorFac
 			if ctx.Err() != nil {
 				return
 			}
+			if isMissingConsumer(err) {
+				consumer.Terminal(ctx, EventUnknown, TerminalConsumerDeleted)
+				slog.ErrorContext(ctx, "jetstream consumer missing during recovery; automatic creation disabled to preserve delivery position", "error", err)
+				return
+			}
 			consumer.RecoveryAttempt(ctx, RecoveryFailure)
 			backoff = nextBackoff(backoff, s.maxBackoff)
 			slog.WarnContext(ctx, "jetstream consumer recreation failed", "error", err, "retry_in", backoff)
 		}
 	}
+}
+
+func isMissingConsumer(err error) bool {
+	return errors.Is(err, jetstream.ErrConsumerDeleted) || errors.Is(err, jetstream.ErrConsumerNotFound)
 }
 
 func (s *Supervisor) abortStart(cancel context.CancelFunc) {

--- a/pkg/natsmetrics/loop.go
+++ b/pkg/natsmetrics/loop.go
@@ -204,9 +204,6 @@ func (s *Supervisor) run(ctx context.Context, iter Iterator, recoveryFactory Ite
 	backoff := s.minBackoff
 	recovered := false
 	for {
-		if recovered {
-			consumer.RecoveryAttempt(ctx, RecoverySuccess)
-		}
 		consumer.LoopStarted(ctx)
 		received, err := consume(ctx, iter, consumer, maxDeliver, wg, sem, classify, process)
 		s.stopActive()
@@ -230,6 +227,11 @@ func (s *Supervisor) run(ctx context.Context, iter Iterator, recoveryFactory Ite
 			}
 			iter, err = recoveryFactory(ctx)
 			if err == nil {
+				// Recorded here, symmetrically with the RecoveryFailure below, so
+				// the counter describes the recreation attempt itself. Deferring it
+				// until the next generation starts would drop the success whenever
+				// shutdown cancels the context between this point and activate.
+				consumer.RecoveryAttempt(ctx, RecoverySuccess)
 				if !s.activate(ctx, iter) {
 					iter.Stop()
 					return

--- a/pkg/natsmetrics/loop.go
+++ b/pkg/natsmetrics/loop.go
@@ -2,7 +2,11 @@ package natsmetrics
 
 import (
 	"context"
+	"errors"
+	"log/slog"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -11,6 +15,7 @@ import (
 // wrapper. It is intentionally small so loop failure behavior is unit-testable.
 type Iterator interface {
 	Next(...jetstream.NextOpt) (context.Context, jetstream.Msg, error)
+	Stop()
 }
 
 type ClassifyEvent func(jetstream.Msg) EventType
@@ -25,7 +30,7 @@ func Start(ctx context.Context, iter Iterator, consumer *Consumer, maxWorkers, m
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		Consume(ctx, iter, consumer, maxWorkers, maxDeliver, wg, classify, process)
+		_ = Consume(ctx, iter, consumer, maxWorkers, maxDeliver, wg, classify, process)
 	}()
 }
 
@@ -36,7 +41,7 @@ func Start(ctx context.Context, iter Iterator, consumer *Consumer, maxWorkers, m
 // classify runs inside the worker goroutine, not on the dispatch path: a
 // classifier that parses the payload would otherwise serialize the whole
 // consumer behind one message at a time.
-func Consume(ctx context.Context, iter Iterator, consumer *Consumer, maxWorkers, maxDeliver int, wg *sync.WaitGroup, classify ClassifyEvent, process ProcessMessage) {
+func Consume(ctx context.Context, iter Iterator, consumer *Consumer, maxWorkers, maxDeliver int, wg *sync.WaitGroup, classify ClassifyEvent, process ProcessMessage) error {
 	// A zero maxWorkers would make sem unbuffered and park the dispatch send
 	// forever — the loop stops consuming with no error and no terminal metric,
 	// while the loop-up gauge still reads 1. A negative one panics in make.
@@ -44,13 +49,32 @@ func Consume(ctx context.Context, iter Iterator, consumer *Consumer, maxWorkers,
 		maxWorkers = 1
 	}
 	sem := make(chan struct{}, maxWorkers)
+	return consume(ctx, iter, consumer, maxDeliver, wg, sem, classify, process)
+}
+
+func consume(ctx context.Context, iter Iterator, consumer *Consumer, maxDeliver int, wg *sync.WaitGroup, sem chan struct{}, classify ClassifyEvent, process ProcessMessage) error {
 	for {
 		msgCtx, msg, err := iter.Next()
 		if err != nil {
+			if ctx.Err() != nil {
+				consumer.LoopStopped(ctx)
+				return ctx.Err()
+			}
 			consumer.LoopFailed(ctx, err)
-			return
+			return err
 		}
-		sem <- struct{}{}
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			consumer.LoopStopped(ctx)
+			eventType := EventUnknown
+			if classify != nil {
+				eventType = NormalizeEventType(string(classify(msg)))
+			}
+			tracked := consumer.Track(msgCtx, msg, eventType, maxDeliver)
+			tracked.Finish(ctx)
+			return ctx.Err()
+		}
 		wg.Add(1)
 		go func(msgCtx context.Context, msg jetstream.Msg) {
 			eventType := EventUnknown
@@ -66,4 +90,187 @@ func Consume(ctx context.Context, iter Iterator, consumer *Consumer, maxWorkers,
 			process(tracked.Context(msgCtx), tracked)
 		}(msgCtx, msg)
 	}
+}
+
+const (
+	defaultSupervisorMinBackoff = 250 * time.Millisecond
+	defaultSupervisorMaxBackoff = 5 * time.Second
+)
+
+var ErrSupervisorRunning = errors.New("natsmetrics: supervisor already running")
+
+type waitBackoff func(context.Context, time.Duration) error
+
+// SupervisorConfig bounds recreation backoff. Non-positive values use the
+// package defaults; MaxBackoff below MinBackoff is raised to MinBackoff.
+type SupervisorConfig struct {
+	MinBackoff time.Duration
+	MaxBackoff time.Duration
+	wait       waitBackoff
+}
+
+// IteratorFactory recreates both the durable consumer handle and its pull
+// iterator. Callers keep stream, durable, and pull settings closed over in the
+// factory so recovery cannot drift from startup configuration.
+type IteratorFactory func(context.Context) (Iterator, error)
+
+// Supervisor owns exactly one iterator at a time and recreates it after a
+// terminal iterator or consumer-creation failure. One semaphore is shared
+// across generations so recovery cannot exceed the configured worker bound
+// while handlers from the previous generation are still in flight.
+type Supervisor struct {
+	minBackoff time.Duration
+	maxBackoff time.Duration
+	wait       waitBackoff
+	running    atomic.Bool
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	iter   Iterator
+}
+
+func NewSupervisor(cfg SupervisorConfig) *Supervisor {
+	minBackoff := cfg.MinBackoff
+	if minBackoff <= 0 {
+		minBackoff = defaultSupervisorMinBackoff
+	}
+	maxBackoff := cfg.MaxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = defaultSupervisorMaxBackoff
+	}
+	if maxBackoff < minBackoff {
+		maxBackoff = minBackoff
+	}
+	wait := cfg.wait
+	if wait == nil {
+		wait = waitForBackoff
+	}
+	return &Supervisor{minBackoff: minBackoff, maxBackoff: maxBackoff, wait: wait}
+}
+
+// Start registers the supervisor loop with wg before returning. A second
+// concurrent Start is rejected so one process cannot create duplicate pull
+// iterators for the same durable through this supervisor.
+func (s *Supervisor) Start(ctx context.Context, factory IteratorFactory, consumer *Consumer, maxWorkers, maxDeliver int, wg *sync.WaitGroup, classify ClassifyEvent, process ProcessMessage) error {
+	if !s.running.CompareAndSwap(false, true) {
+		return ErrSupervisorRunning
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	s.mu.Lock()
+	s.cancel = cancel
+	s.mu.Unlock()
+	if maxWorkers < 1 {
+		maxWorkers = 1
+	}
+	sem := make(chan struct{}, maxWorkers)
+	consumer.LoopStopped(runCtx)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer s.finish(runCtx, consumer)
+		s.run(runCtx, factory, consumer, maxDeliver, wg, sem, classify, process)
+	}()
+	return nil
+}
+
+func (s *Supervisor) run(ctx context.Context, factory IteratorFactory, consumer *Consumer, maxDeliver int, wg *sync.WaitGroup, sem chan struct{}, classify ClassifyEvent, process ProcessMessage) {
+	backoff := s.minBackoff
+	recovering := false
+	for {
+		if recovering {
+			if err := s.wait(ctx, backoff); err != nil {
+				return
+			}
+		}
+
+		iter, err := factory(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			consumer.RecoveryAttempt(ctx, RecoveryFailure)
+			slog.WarnContext(ctx, "jetstream consumer recreation failed", "error", err, "retry_in", backoff)
+			recovering = true
+			backoff = nextBackoff(backoff, s.maxBackoff)
+			continue
+		}
+		if !s.activate(ctx, iter) {
+			iter.Stop()
+			return
+		}
+		if recovering {
+			consumer.RecoveryAttempt(ctx, RecoverySuccess)
+		}
+		consumer.LoopStarted(ctx)
+		err = consume(ctx, iter, consumer, maxDeliver, wg, sem, classify, process)
+		s.stopActive()
+		if ctx.Err() != nil {
+			return
+		}
+		slog.WarnContext(ctx, "jetstream consumer loop failed; recreating", "error", err, "retry_in", s.minBackoff)
+		recovering = true
+		backoff = s.minBackoff
+	}
+}
+
+// Stop cancels retry backoff and stops the active iterator. It is idempotent;
+// callers then wait on the shared WaitGroup to preserve in-flight draining.
+func (s *Supervisor) Stop() {
+	s.mu.Lock()
+	if s.cancel != nil {
+		s.cancel()
+	}
+	iter := s.iter
+	s.iter = nil
+	s.mu.Unlock()
+	if iter != nil {
+		iter.Stop()
+	}
+}
+
+func (s *Supervisor) activate(ctx context.Context, iter Iterator) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if ctx.Err() != nil {
+		return false
+	}
+	s.iter = iter
+	return true
+}
+
+func (s *Supervisor) stopActive() {
+	s.mu.Lock()
+	iter := s.iter
+	s.iter = nil
+	s.mu.Unlock()
+	if iter != nil {
+		iter.Stop()
+	}
+}
+
+func (s *Supervisor) finish(ctx context.Context, consumer *Consumer) {
+	consumer.LoopStopped(ctx)
+	s.mu.Lock()
+	s.cancel = nil
+	s.iter = nil
+	s.mu.Unlock()
+	s.running.Store(false)
+}
+
+func waitForBackoff(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func nextBackoff(current, maximum time.Duration) time.Duration {
+	if current >= maximum || current > maximum/2 {
+		return maximum
+	}
+	return current * 2
 }

--- a/pkg/natsmetrics/loop.go
+++ b/pkg/natsmetrics/loop.go
@@ -3,6 +3,7 @@ package natsmetrics
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -49,20 +50,23 @@ func Consume(ctx context.Context, iter Iterator, consumer *Consumer, maxWorkers,
 		maxWorkers = 1
 	}
 	sem := make(chan struct{}, maxWorkers)
-	return consume(ctx, iter, consumer, maxDeliver, wg, sem, classify, process)
+	_, err := consume(ctx, iter, consumer, maxDeliver, wg, sem, classify, process)
+	return err
 }
 
-func consume(ctx context.Context, iter Iterator, consumer *Consumer, maxDeliver int, wg *sync.WaitGroup, sem chan struct{}, classify ClassifyEvent, process ProcessMessage) error {
+func consume(ctx context.Context, iter Iterator, consumer *Consumer, maxDeliver int, wg *sync.WaitGroup, sem chan struct{}, classify ClassifyEvent, process ProcessMessage) (bool, error) {
+	received := false
 	for {
 		msgCtx, msg, err := iter.Next()
 		if err != nil {
 			if ctx.Err() != nil {
 				consumer.LoopStopped(ctx)
-				return ctx.Err()
+				return received, ctx.Err()
 			}
 			consumer.LoopFailed(ctx, err)
-			return err
+			return received, err
 		}
+		received = true
 		select {
 		case sem <- struct{}{}:
 		case <-ctx.Done():
@@ -73,7 +77,7 @@ func consume(ctx context.Context, iter Iterator, consumer *Consumer, maxDeliver 
 			}
 			tracked := consumer.Track(msgCtx, msg, eventType, maxDeliver)
 			tracked.Finish(ctx)
-			return ctx.Err()
+			return received, ctx.Err()
 		}
 		wg.Add(1)
 		go func(msgCtx context.Context, msg jetstream.Msg) {
@@ -115,7 +119,9 @@ type SupervisorConfig struct {
 type IteratorFactory func(context.Context) (Iterator, error)
 
 // Supervisor owns exactly one iterator at a time and recreates it after a
-// terminal iterator or consumer-creation failure. One semaphore is shared
+// recoverable terminal iterator failure. A deleted durable is not recoverable:
+// recreating it would lose the server-side cursor and either replay or skip
+// retained work depending on its delivery policy. One semaphore is shared
 // across generations so recovery cannot exceed the configured worker bound
 // while handlers from the previous generation are still in flight.
 type Supervisor struct {
@@ -148,9 +154,11 @@ func NewSupervisor(cfg SupervisorConfig) *Supervisor {
 	return &Supervisor{minBackoff: minBackoff, maxBackoff: maxBackoff, wait: wait}
 }
 
-// Start registers the supervisor loop with wg before returning. A second
-// concurrent Start is rejected so one process cannot create duplicate pull
-// iterators for the same durable through this supervisor.
+// Start creates the first consumer iterator synchronously so startup remains
+// fail-fast. After that first successful creation it registers the supervisor
+// loop with wg before returning. A second concurrent Start is rejected so one
+// process cannot create duplicate pull iterators for the same durable through
+// this supervisor.
 func (s *Supervisor) Start(ctx context.Context, factory IteratorFactory, consumer *Consumer, maxWorkers, maxDeliver int, wg *sync.WaitGroup, classify ClassifyEvent, process ProcessMessage) error {
 	if !s.running.CompareAndSwap(false, true) {
 		return ErrSupervisorRunning
@@ -159,58 +167,84 @@ func (s *Supervisor) Start(ctx context.Context, factory IteratorFactory, consume
 	s.mu.Lock()
 	s.cancel = cancel
 	s.mu.Unlock()
+	consumer.LoopStopped(runCtx)
+	iter, err := factory(runCtx)
+	if err != nil {
+		s.abortStart(cancel)
+		return fmt.Errorf("create initial consumer iterator: %w", err)
+	}
+	if !s.activate(runCtx, iter) {
+		iter.Stop()
+		s.abortStart(cancel)
+		return runCtx.Err()
+	}
 	if maxWorkers < 1 {
 		maxWorkers = 1
 	}
 	sem := make(chan struct{}, maxWorkers)
-	consumer.LoopStopped(runCtx)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		defer s.finish(runCtx, consumer)
-		s.run(runCtx, factory, consumer, maxDeliver, wg, sem, classify, process)
+		s.run(runCtx, iter, factory, consumer, maxDeliver, wg, sem, classify, process)
 	}()
 	return nil
 }
 
-func (s *Supervisor) run(ctx context.Context, factory IteratorFactory, consumer *Consumer, maxDeliver int, wg *sync.WaitGroup, sem chan struct{}, classify ClassifyEvent, process ProcessMessage) {
+func (s *Supervisor) run(ctx context.Context, iter Iterator, factory IteratorFactory, consumer *Consumer, maxDeliver int, wg *sync.WaitGroup, sem chan struct{}, classify ClassifyEvent, process ProcessMessage) {
 	backoff := s.minBackoff
-	recovering := false
+	recovered := false
 	for {
-		if recovering {
-			if err := s.wait(ctx, backoff); err != nil {
-				return
-			}
-		}
-
-		iter, err := factory(ctx)
-		if err != nil {
-			if ctx.Err() != nil {
-				return
-			}
-			consumer.RecoveryAttempt(ctx, RecoveryFailure)
-			slog.WarnContext(ctx, "jetstream consumer recreation failed", "error", err, "retry_in", backoff)
-			recovering = true
-			backoff = nextBackoff(backoff, s.maxBackoff)
-			continue
-		}
-		if !s.activate(ctx, iter) {
-			iter.Stop()
-			return
-		}
-		if recovering {
+		if recovered {
 			consumer.RecoveryAttempt(ctx, RecoverySuccess)
 		}
 		consumer.LoopStarted(ctx)
-		err = consume(ctx, iter, consumer, maxDeliver, wg, sem, classify, process)
+		received, err := consume(ctx, iter, consumer, maxDeliver, wg, sem, classify, process)
 		s.stopActive()
 		if ctx.Err() != nil {
 			return
 		}
-		slog.WarnContext(ctx, "jetstream consumer loop failed; recreating", "error", err, "retry_in", s.minBackoff)
-		recovering = true
-		backoff = s.minBackoff
+		if errors.Is(err, jetstream.ErrConsumerDeleted) {
+			slog.ErrorContext(ctx, "jetstream consumer deleted; automatic recreation disabled to preserve delivery position", "error", err)
+			return
+		}
+		if received {
+			backoff = s.minBackoff
+		} else if recovered {
+			backoff = nextBackoff(backoff, s.maxBackoff)
+		}
+		slog.WarnContext(ctx, "jetstream consumer loop failed; recreating", "error", err, "retry_in", backoff)
+
+		for {
+			if err := s.wait(ctx, backoff); err != nil {
+				return
+			}
+			iter, err = factory(ctx)
+			if err == nil {
+				if !s.activate(ctx, iter) {
+					iter.Stop()
+					return
+				}
+				recovered = true
+				break
+			}
+			if ctx.Err() != nil {
+				return
+			}
+			consumer.RecoveryAttempt(ctx, RecoveryFailure)
+			backoff = nextBackoff(backoff, s.maxBackoff)
+			slog.WarnContext(ctx, "jetstream consumer recreation failed", "error", err, "retry_in", backoff)
+		}
 	}
+}
+
+func (s *Supervisor) abortStart(cancel context.CancelFunc) {
+	cancel()
+	s.mu.Lock()
+	s.cancel = nil
+	s.iter = nil
+	s.mu.Unlock()
+	s.running.Store(false)
 }
 
 // Stop cancels retry backoff and stops the active iterator. It is idempotent;

--- a/pkg/natsmetrics/loop_test.go
+++ b/pkg/natsmetrics/loop_test.go
@@ -18,6 +18,7 @@ type failingIterator struct{ err error }
 func (i failingIterator) Next(...jetstream.NextOpt) (context.Context, jetstream.Msg, error) {
 	return nil, nil, i.err
 }
+func (failingIterator) Stop() {}
 
 type oneMessageIterator struct {
 	msg  jetstream.Msg
@@ -31,6 +32,7 @@ func (i *oneMessageIterator) Next(...jetstream.NextOpt) (context.Context, jetstr
 	i.done = true
 	return context.Background(), i.msg, nil
 }
+func (*oneMessageIterator) Stop() {}
 
 func TestConsume_TerminalNextFailureStopsLoop(t *testing.T) {
 	m, reader := newTestMetrics(t)
@@ -87,6 +89,7 @@ func (i *blockingIterator) Next(...jetstream.NextOpt) (context.Context, jetstrea
 	i.done = true
 	return context.Background(), &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}}, nil
 }
+func (*blockingIterator) Stop() {}
 
 // A zero MAX_WORKERS must not wedge the consumer. An unbuffered semaphore would
 // park the dispatch send forever, leaving the loop-up gauge at 1 with no error

--- a/pkg/natsmetrics/metrics.go
+++ b/pkg/natsmetrics/metrics.go
@@ -380,7 +380,7 @@ func (c *Consumer) LoopFailed(ctx context.Context, err error) {
 	}
 	reason := TerminalInternal
 	switch {
-	case errors.Is(err, jetstream.ErrConsumerDeleted):
+	case errors.Is(err, jetstream.ErrConsumerDeleted), errors.Is(err, jetstream.ErrConsumerNotFound):
 		reason = TerminalConsumerDeleted
 	case errors.Is(err, jetstream.ErrStreamNotFound), errors.Is(err, jetstream.ErrNoStreamResponse),
 		errors.Is(err, jetstream.ErrConnectionClosed), errors.Is(err, nats.ErrConnectionClosed),

--- a/pkg/natsmetrics/metrics.go
+++ b/pkg/natsmetrics/metrics.go
@@ -52,12 +52,18 @@ const (
 	EventThreadReplyAdded EventType = "thread_reply_added"
 	EventSend             EventType = "send"
 	EventTeamsBatch       EventType = "teams_batch"
+	EventRoomCreate       EventType = "room_create"
+	EventMemberAdd        EventType = "member_add"
+	EventMemberRemove     EventType = "member_remove"
+	EventRoomRename       EventType = "room_rename"
+	EventMemberMuted      EventType = "member_muted"
 	EventUnknown          EventType = "unknown"
 )
 
 var allEventTypes = []EventType{
 	EventCreated, EventUpdated, EventDeleted, EventPinned, EventUnpinned,
 	EventReacted, EventThreadReplyAdded, EventSend, EventTeamsBatch, EventUnknown,
+	EventRoomCreate, EventMemberAdd, EventMemberRemove, EventRoomRename, EventMemberMuted,
 }
 
 type PublishOutcome string
@@ -95,6 +101,34 @@ var allTerminalReasons = []TerminalReason{
 	TerminalStreamUnavailable, TerminalInvalidPayload, TerminalInternal,
 }
 
+type RecoveryResult string
+
+const (
+	RecoverySuccess RecoveryResult = "success"
+	RecoveryFailure RecoveryResult = "failure"
+)
+
+var allRecoveryResults = []RecoveryResult{RecoverySuccess, RecoveryFailure}
+
+type RequestResult string
+
+const (
+	RequestSuccess         RequestResult = "success"
+	RequestBadRequest      RequestResult = "bad_request"
+	RequestUnauthenticated RequestResult = "unauthenticated"
+	RequestForbidden       RequestResult = "forbidden"
+	RequestNotFound        RequestResult = "not_found"
+	RequestConflict        RequestResult = "conflict"
+	RequestTooManyRequests RequestResult = "too_many_requests"
+	RequestUnavailable     RequestResult = "unavailable"
+	RequestInternal        RequestResult = "internal"
+)
+
+var allRequestResults = []RequestResult{
+	RequestSuccess, RequestBadRequest, RequestUnauthenticated, RequestForbidden,
+	RequestNotFound, RequestConflict, RequestTooManyRequests, RequestUnavailable, RequestInternal,
+}
+
 type DestinationKind string
 
 const (
@@ -104,6 +138,9 @@ const (
 	DestinationPush           DestinationKind = "push"
 	DestinationOutbox         DestinationKind = "outbox"
 	DestinationInbox          DestinationKind = "inbox"
+	DestinationRoomCanonical  DestinationKind = "room_canonical"
+	DestinationRoomEvent      DestinationKind = "room_event"
+	DestinationMemberEvent    DestinationKind = "member_event"
 	DestinationClientResponse DestinationKind = "client_response"
 	DestinationUserSync       DestinationKind = "user_sync"
 	DestinationUnknown        DestinationKind = "unknown"
@@ -111,7 +148,8 @@ const (
 
 var allDestinations = []DestinationKind{
 	DestinationCanonical, DestinationRecipientEvent, DestinationNotification, DestinationPush,
-	DestinationOutbox, DestinationInbox, DestinationClientResponse, DestinationUserSync, DestinationUnknown,
+	DestinationOutbox, DestinationInbox, DestinationRoomCanonical, DestinationRoomEvent,
+	DestinationMemberEvent, DestinationClientResponse, DestinationUserSync, DestinationUnknown,
 }
 
 type Operation string
@@ -126,13 +164,26 @@ const (
 	OperationPresenceLookup      Operation = "presence_lookup"
 	OperationThreadTCount        Operation = "thread_tcount"
 	OperationTeamsUserUpsert     Operation = "teams_user_upsert"
+	OperationHistoryRead         Operation = "history_read"
+	OperationHistoryMutation     Operation = "history_mutation"
+	OperationRoomRead            Operation = "room_read"
+	OperationRoomMutation        Operation = "room_mutation"
+	OperationMemberRead          Operation = "member_read"
+	OperationMemberMutation      Operation = "member_mutation"
+	OperationTeamsRoom           Operation = "teams_room"
+	OperationRoomPublish         Operation = "room_publish"
+	OperationMemberPublish       Operation = "member_publish"
+	OperationOutboxPublish       Operation = "outbox_publish"
 	OperationUnknown             Operation = "unknown"
 )
 
 var allOperations = []Operation{
 	OperationCanonicalPublish, OperationClientResponse, OperationRecipientPublish,
 	OperationNotificationPublish, OperationPushPublish, OperationHistoryGetMessage,
-	OperationPresenceLookup, OperationThreadTCount, OperationTeamsUserUpsert, OperationUnknown,
+	OperationPresenceLookup, OperationThreadTCount, OperationTeamsUserUpsert,
+	OperationHistoryRead, OperationHistoryMutation, OperationRoomRead, OperationRoomMutation,
+	OperationMemberRead, OperationMemberMutation, OperationTeamsRoom, OperationRoomPublish,
+	OperationMemberPublish, OperationOutboxPublish, OperationUnknown,
 }
 
 // Metrics owns the shared instruments. Instrument-creation failures fall back
@@ -145,8 +196,11 @@ type Metrics struct {
 	publishAttempts    metric.Int64Counter
 	publishRetries     metric.Int64Counter
 	terminalFailures   metric.Int64Counter
+	recoveryAttempts   metric.Int64Counter
 	requests           metric.Int64Counter
 	requestDuration    metric.Float64Histogram
+	handledRequests    metric.Int64Counter
+	handlerDuration    metric.Float64Histogram
 }
 
 // NewFromProvider builds the shared instruments on this package's own scope.
@@ -189,6 +243,10 @@ func New(meter metric.Meter) *Metrics {
 	if err != nil {
 		terminal, _ = noopMeter.Int64Counter("chat.nats.terminal.failures")
 	}
+	recoveryAttempts, err := meter.Int64Counter("chat.nats.consumer.recovery.attempts", metric.WithDescription("Application attempts to recreate a JetStream consumer iterator after loss."))
+	if err != nil {
+		recoveryAttempts, _ = noopMeter.Int64Counter("chat.nats.consumer.recovery.attempts")
+	}
 	requests, err := meter.Int64Counter("chat.nats.requests", metric.WithDescription("NATS request/reply results."))
 	if err != nil {
 		requests, _ = noopMeter.Int64Counter("chat.nats.requests")
@@ -197,7 +255,15 @@ func New(meter metric.Meter) *Metrics {
 	if err != nil {
 		requestDuration, _ = noopMeter.Float64Histogram("chat.nats.request.duration")
 	}
-	return &Metrics{loop: loop, messages: messages, redeliveries: redeliveries, processingDuration: processing, publishAttempts: publishAttempts, publishRetries: publishRetries, terminalFailures: terminal, requests: requests, requestDuration: requestDuration}
+	handledRequests, err := meter.Int64Counter("chat.nats.request.handled", metric.WithDescription("Inbound NATS request/reply handler results."))
+	if err != nil {
+		handledRequests, _ = noopMeter.Int64Counter("chat.nats.request.handled")
+	}
+	handlerDuration, err := meter.Float64Histogram("chat.nats.request.handler.duration", metric.WithDescription("Inbound NATS request/reply handler duration."), metric.WithUnit("s"), latency)
+	if err != nil {
+		handlerDuration, _ = noopMeter.Float64Histogram("chat.nats.request.handler.duration")
+	}
+	return &Metrics{loop: loop, messages: messages, redeliveries: redeliveries, processingDuration: processing, publishAttempts: publishAttempts, publishRetries: publishRetries, terminalFailures: terminal, recoveryAttempts: recoveryAttempts, requests: requests, requestDuration: requestDuration, handledRequests: handledRequests, handlerDuration: handlerDuration}
 }
 
 type ConsumerConfig struct {
@@ -235,12 +301,18 @@ type requestKey struct {
 	outcome   PublishOutcome
 }
 
+type handledRequestKey struct {
+	operation Operation
+	result    RequestResult
+}
+
 type Consumer struct {
 	metrics *Metrics
 	loopOpt metric.MeasurementOption
 	message map[consumerKey]metric.MeasurementOption
 	redeliv map[EventType]metric.MeasurementOption
 	termOpt map[terminalKey]metric.MeasurementOption
+	recover map[RecoveryResult]metric.MeasurementOption
 	up      atomic.Bool
 }
 
@@ -263,6 +335,11 @@ func (m *Metrics) Consumer(cfg ConsumerConfig) *Consumer {
 		message: make(map[consumerKey]metric.MeasurementOption, len(allEventTypes)*len(allOutcomes)),
 		redeliv: make(map[EventType]metric.MeasurementOption, len(allEventTypes)),
 		termOpt: make(map[terminalKey]metric.MeasurementOption, len(allEventTypes)*len(allTerminalReasons)),
+		recover: make(map[RecoveryResult]metric.MeasurementOption, len(allRecoveryResults)),
+	}
+	for _, result := range allRecoveryResults {
+		attrs := append(append([]attribute.KeyValue{}, base...), attribute.String("result", string(result)))
+		c.recover[result] = metric.WithAttributes(attrs...)
 	}
 	for _, event := range allEventTypes {
 		c.redeliv[event] = metric.WithAttributes(withEvent(event)...)
@@ -328,6 +405,13 @@ func (c *Consumer) Track(ctx context.Context, msg jetstream.Msg, eventType Event
 func (c *Consumer) Terminal(ctx context.Context, eventType EventType, reason TerminalReason) {
 	key := terminalKey{NormalizeEventType(string(eventType)), normalizeTerminalReason(reason)}
 	c.metrics.terminalFailures.Add(ctx, 1, c.termOpt[key])
+}
+
+func (c *Consumer) RecoveryAttempt(ctx context.Context, result RecoveryResult) {
+	if result != RecoverySuccess && result != RecoveryFailure {
+		result = RecoveryFailure
+	}
+	c.metrics.recoveryAttempts.Add(ctx, 1, c.recover[result])
 }
 
 // Message intercepts disposition calls while preserving the wrapped message's
@@ -444,6 +528,7 @@ type Publisher struct {
 	attempt map[publishKey]metric.MeasurementOption
 	retry   map[retryKey]metric.MeasurementOption
 	request map[requestKey]metric.MeasurementOption
+	handled map[handledRequestKey]metric.MeasurementOption
 }
 
 func (m *Metrics) Publisher(serviceName, site string) Publisher {
@@ -458,6 +543,7 @@ func (m *Metrics) Publisher(serviceName, site string) Publisher {
 		attempt: make(map[publishKey]metric.MeasurementOption, len(allDestinations)*len(allOperations)*len(allPublishOutcomes)),
 		retry:   make(map[retryKey]metric.MeasurementOption, len(allDestinations)*len(allOperations)),
 		request: make(map[requestKey]metric.MeasurementOption, len(allOperations)*len(allPublishOutcomes)),
+		handled: make(map[handledRequestKey]metric.MeasurementOption, len(allOperations)*len(allRequestResults)),
 	}
 	for _, destination := range allDestinations {
 		dst := attribute.String("destination_kind", string(destination))
@@ -473,6 +559,9 @@ func (m *Metrics) Publisher(serviceName, site string) Publisher {
 		op := attribute.String("operation", string(operation))
 		for _, outcome := range allPublishOutcomes {
 			p.request[requestKey{operation, outcome}] = build(op, attribute.String("outcome", string(outcome)))
+		}
+		for _, result := range allRequestResults {
+			p.handled[handledRequestKey{operation, result}] = build(op, attribute.String("result", string(result)))
 		}
 	}
 	return p
@@ -514,9 +603,22 @@ func (p Publisher) Request(ctx context.Context, operation Operation, duration ti
 	p.metrics.requestDuration.Record(ctx, duration.Seconds(), opt)
 }
 
+// HandledRequest records one inbound request/reply handler result. Both labels
+// are normalized against closed enums; subjects and error strings are never
+// attributes.
+func (p Publisher) HandledRequest(ctx context.Context, operation Operation, duration time.Duration, result RequestResult) {
+	if p.metrics == nil {
+		return
+	}
+	opt := p.handled[handledRequestKey{normalizeOperation(operation), normalizeRequestResult(result)}]
+	p.metrics.handledRequests.Add(ctx, 1, opt)
+	p.metrics.handlerDuration.Record(ctx, duration.Seconds(), opt)
+}
+
 func NormalizeEventType(value string) EventType {
 	switch EventType(value) {
-	case EventCreated, EventUpdated, EventDeleted, EventPinned, EventUnpinned, EventReacted, EventThreadReplyAdded, EventSend, EventTeamsBatch:
+	case EventCreated, EventUpdated, EventDeleted, EventPinned, EventUnpinned, EventReacted, EventThreadReplyAdded, EventSend, EventTeamsBatch,
+		EventRoomCreate, EventMemberAdd, EventMemberRemove, EventRoomRename, EventMemberMuted:
 		return EventType(value)
 	default:
 		return EventUnknown
@@ -525,7 +627,9 @@ func NormalizeEventType(value string) EventType {
 
 func normalizeDestination(destination DestinationKind) DestinationKind {
 	switch destination {
-	case DestinationCanonical, DestinationRecipientEvent, DestinationNotification, DestinationPush, DestinationOutbox, DestinationInbox, DestinationClientResponse, DestinationUserSync:
+	case DestinationCanonical, DestinationRecipientEvent, DestinationNotification, DestinationPush,
+		DestinationOutbox, DestinationInbox, DestinationRoomCanonical, DestinationRoomEvent,
+		DestinationMemberEvent, DestinationClientResponse, DestinationUserSync:
 		return destination
 	default:
 		return DestinationUnknown
@@ -534,10 +638,25 @@ func normalizeDestination(destination DestinationKind) DestinationKind {
 
 func normalizeOperation(operation Operation) Operation {
 	switch operation {
-	case OperationCanonicalPublish, OperationClientResponse, OperationRecipientPublish, OperationNotificationPublish, OperationPushPublish, OperationHistoryGetMessage, OperationPresenceLookup, OperationThreadTCount, OperationTeamsUserUpsert:
+	case OperationCanonicalPublish, OperationClientResponse, OperationRecipientPublish,
+		OperationNotificationPublish, OperationPushPublish, OperationHistoryGetMessage,
+		OperationPresenceLookup, OperationThreadTCount, OperationTeamsUserUpsert,
+		OperationHistoryRead, OperationHistoryMutation, OperationRoomRead, OperationRoomMutation,
+		OperationMemberRead, OperationMemberMutation, OperationTeamsRoom, OperationRoomPublish,
+		OperationMemberPublish, OperationOutboxPublish:
 		return operation
 	default:
 		return OperationUnknown
+	}
+}
+
+func normalizeRequestResult(result RequestResult) RequestResult {
+	switch result {
+	case RequestSuccess, RequestBadRequest, RequestUnauthenticated, RequestForbidden,
+		RequestNotFound, RequestConflict, RequestTooManyRequests, RequestUnavailable, RequestInternal:
+		return result
+	default:
+		return RequestInternal
 	}
 }
 

--- a/pkg/natsmetrics/metrics_benchmark_test.go
+++ b/pkg/natsmetrics/metrics_benchmark_test.go
@@ -1,0 +1,60 @@
+package natsmetrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	benchmarkTracked *Message
+	benchmarkContext context.Context
+)
+
+func benchmarkConsumer() *Consumer {
+	metrics := New(noop.NewMeterProvider().Meter("benchmark"))
+	return metrics.Consumer(ConsumerConfig{
+		ServiceName: "benchmark-worker",
+		Site:        "site-a",
+		Stream:      "MESSAGES_CANONICAL_site-a",
+		Consumer:    "benchmark-worker",
+	})
+}
+
+// BenchmarkConsumer_Track isolates the repository-owned wrapper cost. fakeMsg
+// returns pre-decoded metadata, so nats.go reply-subject parsing is not included.
+func BenchmarkConsumer_Track(b *testing.B) {
+	consumer := benchmarkConsumer()
+	ctx := context.Background()
+
+	for _, delivered := range []uint64{1, 2} {
+		name := "first_delivery"
+		if delivered > 1 {
+			name = "redelivery"
+		}
+		b.Run(name, func(b *testing.B) {
+			msg := &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: delivered}}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				benchmarkTracked = consumer.Track(ctx, msg, EventCreated, 5)
+			}
+		})
+	}
+}
+
+func BenchmarkMessage_Context(b *testing.B) {
+	consumer := benchmarkConsumer()
+	tracked := consumer.Track(context.Background(), &fakeMsg{
+		meta: &jetstream.MsgMetadata{NumDelivered: 1},
+	}, EventCreated, 5)
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		benchmarkContext = tracked.Context(ctx)
+	}
+}

--- a/pkg/natsmetrics/metrics_test.go
+++ b/pkg/natsmetrics/metrics_test.go
@@ -274,11 +274,30 @@ func TestPublishAndRequestLabelsAreBounded(t *testing.T) {
 	assert.Equal(t, string(OperationUnknown), attrs(requestPoints[0])["operation"])
 }
 
+func TestHandledRequestMetricsUseBoundedResults(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	p := m.Publisher("room-service", "site-a")
+	p.HandledRequest(context.Background(), OperationMemberRead, 12*time.Millisecond, RequestSuccess)
+	p.HandledRequest(context.Background(), Operation("dynamic.operation"), time.Millisecond, RequestResult("dynamic.error"))
+
+	rm := collect(t, reader)
+	points := metricPoints[int64](t, rm, "chat.nats.request.handled")
+	require.Len(t, points, 2)
+	got := map[string]map[string]string{}
+	for _, point := range points {
+		got[attrs(point)["operation"]] = attrs(point)
+	}
+	assert.Equal(t, string(RequestSuccess), got[string(OperationMemberRead)]["result"])
+	assert.Equal(t, string(RequestInternal), got[string(OperationUnknown)]["result"])
+	assert.Len(t, histogramPoints(t, rm, "chat.nats.request.handler.duration"), 2)
+}
+
 func TestZeroValuePublisherDoesNotAffectBusinessFlow(t *testing.T) {
 	var publisher Publisher
 	publisher.Attempt(context.Background(), DestinationPush, OperationPushPublish, errors.New("publish failed"))
 	publisher.Retry(context.Background(), DestinationPush, OperationPushPublish)
 	publisher.Request(context.Background(), OperationPresenceLookup, time.Millisecond, errors.New("request failed"))
+	publisher.HandledRequest(context.Background(), OperationMemberRead, time.Millisecond, RequestInternal)
 }
 
 func TestClassifiersAreBounded(t *testing.T) {

--- a/pkg/natsmetrics/metrics_test.go
+++ b/pkg/natsmetrics/metrics_test.go
@@ -121,6 +121,7 @@ func TestConsumerLoopFailureUsesBoundedReason(t *testing.T) {
 		want TerminalReason
 	}{
 		{name: "consumer deleted", err: jetstream.ErrConsumerDeleted, want: TerminalConsumerDeleted},
+		{name: "consumer missing", err: jetstream.ErrConsumerNotFound, want: TerminalConsumerDeleted},
 		{name: "stream unavailable", err: jetstream.ErrNoStreamResponse, want: TerminalStreamUnavailable},
 		{name: "unexpected iterator failure", err: errors.New("dynamic error text"), want: TerminalInternal},
 	}

--- a/pkg/natsmetrics/subject.go
+++ b/pkg/natsmetrics/subject.go
@@ -23,3 +23,117 @@ func EventTypeFromSubject(subj string) EventType {
 	}
 	return NormalizeEventType(tail)
 }
+
+// RoomEventTypeFromSubject maps ROOMS and ROOMS-TEAMS subjects onto a closed
+// room/member vocabulary. Site IDs and room IDs never become metric labels.
+func RoomEventTypeFromSubject(subj string) EventType {
+	if strings.HasPrefix(subj, "chat.teams.room.canonical.") {
+		if strings.HasSuffix(subj, ".create") {
+			return EventRoomCreate
+		}
+		return EventUnknown
+	}
+	if !strings.HasPrefix(subj, "chat.room.canonical.") {
+		return EventUnknown
+	}
+	switch {
+	case strings.HasSuffix(subj, ".event.member.muted"):
+		return EventMemberMuted
+	case strings.HasSuffix(subj, ".member.add"):
+		return EventMemberAdd
+	case strings.HasSuffix(subj, ".member.remove"):
+		return EventMemberRemove
+	case strings.HasSuffix(subj, ".room.rename"):
+		return EventRoomRename
+	case strings.HasSuffix(subj, ".create"):
+		return EventRoomCreate
+	default:
+		return EventUnknown
+	}
+}
+
+// RequestOperationFromSubject maps concrete request subjects to the bounded
+// operation vocabulary used by natsrouter. Dynamic account, room, and site
+// tokens are inspected only for shape and never become labels.
+func RequestOperationFromSubject(subj string) Operation {
+	switch {
+	case strings.HasPrefix(subj, "chat.server.request.history."):
+		return OperationHistoryRead
+	case strings.HasPrefix(subj, "chat.server.request.thread."):
+		return OperationHistoryRead
+	case strings.Contains(subj, ".msg."):
+		switch {
+		case hasAnySuffix(subj, ".msg.edit", ".msg.delete", ".msg.pin", ".msg.unpin", ".msg.react"):
+			return OperationHistoryMutation
+		case hasAnySuffix(subj, ".msg.history", ".msg.next", ".msg.surrounding", ".msg.get", ".msg.get.ids", ".msg.pinned.list", ".msg.thread"):
+			return OperationHistoryRead
+		}
+	case strings.Contains(subj, ".teams."):
+		return OperationTeamsRoom
+	case hasAnySuffix(subj, ".member.list", ".member.statuses", ".subscription.mentionable", ".members"):
+		return OperationMemberRead
+	case hasAnySuffix(subj, ".member.add", ".member.remove", ".member.role-update", ".mute.toggle"):
+		return OperationMemberMutation
+	case hasAnySuffix(subj, ".key.get", ".open", ".app.tabs", ".app.cmd-menu"):
+		return OperationRoomRead
+	case hasAnySuffix(subj, ".room.rename", ".create", ".chat.move", ".favorite.toggle", ".message.read", ".message.read-receipt", ".message.thread.read"):
+		return OperationRoomMutation
+	case strings.HasPrefix(subj, "chat.server.request.room.") && hasAnySuffix(subj, ".info.batch", ".thread.info.batch"):
+		return OperationRoomRead
+	case strings.HasPrefix(subj, "chat.server.request.room."):
+		return OperationRoomMutation
+	default:
+		return OperationUnknown
+	}
+	return OperationUnknown
+}
+
+// PublishLabelsFromSubject maps a publish destination to closed labels. It is
+// intentionally conservative: a new subject family remains unknown until it
+// receives an explicit bounded mapping.
+func PublishLabelsFromSubject(subj string) (DestinationKind, Operation) {
+	switch {
+	case strings.HasPrefix(subj, "chat.msg.canonical."):
+		return DestinationCanonical, OperationCanonicalPublish
+	case strings.HasPrefix(subj, "chat.room.canonical."), strings.HasPrefix(subj, "chat.teams.room.canonical."):
+		operation := OperationRoomPublish
+		if strings.Contains(subj, ".member.") || strings.Contains(subj, ".event.member.") {
+			operation = OperationMemberPublish
+		}
+		return DestinationRoomCanonical, operation
+	case strings.HasPrefix(subj, "chat.outbox."):
+		return DestinationOutbox, OperationOutboxPublish
+	case strings.HasPrefix(subj, "chat.inbox."):
+		if strings.Contains(subj, ".member_") {
+			return DestinationInbox, OperationMemberPublish
+		}
+		return DestinationInbox, OperationRoomPublish
+	case strings.HasPrefix(subj, "chat.room.") && strings.HasSuffix(subj, ".event"),
+		strings.HasPrefix(subj, "chat.local.room.") && strings.HasSuffix(subj, ".event"):
+		return DestinationRoomEvent, OperationRoomPublish
+	case strings.HasPrefix(subj, "chat.room.") && strings.HasSuffix(subj, ".event.member"),
+		strings.HasPrefix(subj, "chat.local.room.") && strings.HasSuffix(subj, ".event.member"):
+		return DestinationMemberEvent, OperationMemberPublish
+	case strings.HasPrefix(subj, "chat.user.") && (strings.HasSuffix(subj, ".event.room") || strings.HasSuffix(subj, ".event.room.update")):
+		return DestinationRecipientEvent, OperationRoomPublish
+	case strings.HasPrefix(subj, "chat.user.") && strings.HasSuffix(subj, ".event.subscription.update"):
+		return DestinationRecipientEvent, OperationMemberPublish
+	case strings.HasPrefix(subj, "chat.user.") && strings.HasSuffix(subj, ".event.room.key"):
+		return DestinationRecipientEvent, OperationRoomPublish
+	case strings.HasPrefix(subj, "chat.user.") && strings.Contains(subj, ".response."):
+		return DestinationClientResponse, OperationClientResponse
+	case strings.HasPrefix(subj, "chat.hr.") && strings.HasSuffix(subj, ".users.upsert"):
+		return DestinationUserSync, OperationTeamsUserUpsert
+	default:
+		return DestinationUnknown, OperationUnknown
+	}
+}
+
+func hasAnySuffix(value string, suffixes ...string) bool {
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(value, suffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/natsmetrics/subject.go
+++ b/pkg/natsmetrics/subject.go
@@ -56,19 +56,20 @@ func RoomEventTypeFromSubject(subj string) EventType {
 // operation vocabulary used by natsrouter. Dynamic account, room, and site
 // tokens are inspected only for shape and never become labels.
 func RequestOperationFromSubject(subj string) Operation {
+	tokens := strings.Split(subj, ".")
 	switch {
 	case strings.HasPrefix(subj, "chat.server.request.history."):
 		return OperationHistoryRead
 	case strings.HasPrefix(subj, "chat.server.request.thread."):
 		return OperationHistoryRead
-	case strings.Contains(subj, ".msg."):
+	case isRequestFamily(tokens, "msg") || isMigrationFamily(tokens, "msg"):
 		switch {
 		case hasAnySuffix(subj, ".msg.edit", ".msg.delete", ".msg.pin", ".msg.unpin", ".msg.react"):
 			return OperationHistoryMutation
-		case hasAnySuffix(subj, ".msg.history", ".msg.next", ".msg.surrounding", ".msg.get", ".msg.get.ids", ".msg.pinned.list", ".msg.thread"):
+		case hasAnySuffix(subj, ".msg.history", ".msg.next", ".msg.surrounding", ".msg.get", ".msg.get.ids", ".msg.pinned.list", ".msg.thread", ".msg.thread.parent"):
 			return OperationHistoryRead
 		}
-	case strings.Contains(subj, ".teams."):
+	case isRequestFamily(tokens, "teams"):
 		return OperationTeamsRoom
 	case hasAnySuffix(subj, ".member.list", ".member.statuses", ".subscription.mentionable", ".members"):
 		return OperationMemberRead
@@ -86,6 +87,21 @@ func RequestOperationFromSubject(subj string) Operation {
 		return OperationUnknown
 	}
 	return OperationUnknown
+}
+
+func isRequestFamily(tokens []string, family string) bool {
+	if len(tokens) < 5 || tokens[0] != "chat" || tokens[1] != "user" || tokens[3] != "request" {
+		return false
+	}
+	if tokens[4] == family {
+		return true
+	}
+	return len(tokens) >= 8 && tokens[4] == "room" && tokens[7] == family
+}
+
+func isMigrationFamily(tokens []string, family string) bool {
+	return len(tokens) >= 5 && tokens[0] == "chat" && tokens[1] == "migration" &&
+		tokens[2] == "internal" && tokens[4] == family
 }
 
 // PublishLabelsFromSubject maps a publish destination to closed labels. It is

--- a/pkg/natsmetrics/subject.go
+++ b/pkg/natsmetrics/subject.go
@@ -111,16 +111,23 @@ func PublishLabelsFromSubject(subj string) (DestinationKind, Operation) {
 	switch {
 	case strings.HasPrefix(subj, "chat.msg.canonical."):
 		return DestinationCanonical, OperationCanonicalPublish
-	case strings.HasPrefix(subj, "chat.room.canonical."), strings.HasPrefix(subj, "chat.teams.room.canonical."):
+	case strings.HasPrefix(subj, "chat.room.canonical."):
 		operation := OperationRoomPublish
-		if strings.Contains(subj, ".member.") || strings.Contains(subj, ".event.member.") {
+		if isMemberEventAt(strings.Split(subj, "."), 4) {
+			operation = OperationMemberPublish
+		}
+		return DestinationRoomCanonical, operation
+	case strings.HasPrefix(subj, "chat.teams.room.canonical."):
+		operation := OperationRoomPublish
+		if isMemberEventAt(strings.Split(subj, "."), 5) {
 			operation = OperationMemberPublish
 		}
 		return DestinationRoomCanonical, operation
 	case strings.HasPrefix(subj, "chat.outbox."):
 		return DestinationOutbox, OperationOutboxPublish
 	case strings.HasPrefix(subj, "chat.inbox."):
-		if strings.Contains(subj, ".member_") {
+		tokens := strings.Split(subj, ".")
+		if len(tokens) > 4 && strings.HasPrefix(tokens[4], "member_") {
 			return DestinationInbox, OperationMemberPublish
 		}
 		return DestinationInbox, OperationRoomPublish
@@ -143,6 +150,16 @@ func PublishLabelsFromSubject(subj string) (DestinationKind, Operation) {
 	default:
 		return DestinationUnknown, OperationUnknown
 	}
+}
+
+func isMemberEventAt(tokens []string, eventIndex int) bool {
+	if len(tokens) <= eventIndex {
+		return false
+	}
+	if tokens[eventIndex] == "member" {
+		return true
+	}
+	return tokens[eventIndex] == "event" && len(tokens) > eventIndex+1 && tokens[eventIndex+1] == "member"
 }
 
 func hasAnySuffix(value string, suffixes ...string) bool {

--- a/pkg/natsmetrics/subject_test.go
+++ b/pkg/natsmetrics/subject_test.go
@@ -98,9 +98,13 @@ func TestPublishLabelsFromSubject(t *testing.T) {
 		operation   Operation
 	}{
 		{name: "canonical message mutation", subj: subject.MsgCanonicalUpdated("site-a"), destination: DestinationCanonical, operation: OperationCanonicalPublish},
+		{name: "room create with member site", subj: subject.RoomCanonical("member", "create"), destination: DestinationRoomCanonical, operation: OperationRoomPublish},
+		{name: "room create with member prefix site", subj: subject.RoomCanonical("member_foo", "create"), destination: DestinationRoomCanonical, operation: OperationRoomPublish},
+		{name: "canonical member event", subj: subject.RoomCanonical("site-a", "member.add"), destination: DestinationRoomCanonical, operation: OperationMemberPublish},
 		{name: "outbox room event", subj: subject.Outbox("site-a", "site-b", "room_renamed"), destination: DestinationOutbox, operation: OperationOutboxPublish},
 		{name: "internal member feed", subj: subject.InboxInternal("site-a", "member_added"), destination: DestinationInbox, operation: OperationMemberPublish},
 		{name: "internal room feed", subj: subject.InboxInternal("site-a", "room_renamed"), destination: DestinationInbox, operation: OperationRoomPublish},
+		{name: "internal room feed with member prefix site", subj: subject.InboxInternal("member_foo", "room_renamed"), destination: DestinationInbox, operation: OperationRoomPublish},
 		{name: "room event", subj: subject.RoomEvent("room-a", true), destination: DestinationRoomEvent, operation: OperationRoomPublish},
 		{name: "member event", subj: subject.RoomMemberEvent("room-a", false), destination: DestinationMemberEvent, operation: OperationMemberPublish},
 		{name: "client room update", subj: subject.UserRoomUpdate("alice"), destination: DestinationRecipientEvent, operation: OperationRoomPublish},

--- a/pkg/natsmetrics/subject_test.go
+++ b/pkg/natsmetrics/subject_test.go
@@ -35,3 +35,83 @@ func TestEventTypeFromSubject(t *testing.T) {
 		})
 	}
 }
+
+func TestRoomEventTypeFromSubject(t *testing.T) {
+	tests := []struct {
+		name string
+		subj string
+		want EventType
+	}{
+		{name: "room create", subj: subject.RoomCanonical("site-a", "create"), want: EventRoomCreate},
+		{name: "teams room create", subj: subject.RoomTeamsCanonicalCreate("site-a"), want: EventRoomCreate},
+		{name: "member add", subj: subject.RoomCanonical("site-a", "member.add"), want: EventMemberAdd},
+		{name: "member remove", subj: subject.RoomCanonical("site-a", "member.remove"), want: EventMemberRemove},
+		{name: "room rename", subj: subject.RoomCanonical("site-a", "room.rename"), want: EventRoomRename},
+		{name: "member mute invalidation", subj: subject.RoomCanonicalMemberEvent("site-a", "muted"), want: EventMemberMuted},
+		{name: "unknown room operation", subj: subject.RoomCanonical("site-a", "unexpected"), want: EventUnknown},
+		{name: "message subject is not a room operation", subj: subject.MsgCanonicalCreated("site-a"), want: EventUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, RoomEventTypeFromSubject(tt.subj))
+		})
+	}
+}
+
+func TestRequestOperationFromSubject(t *testing.T) {
+	teamsMeeting, err := subject.TeamsMeeting("alice", "room-a", "site-a")
+	assert.NoError(t, err)
+	tests := []struct {
+		name string
+		subj string
+		want Operation
+	}{
+		{name: "history read", subj: subject.MsgHistory("alice", "room-a", "site-a"), want: OperationHistoryRead},
+		{name: "history mutation", subj: subject.MsgEdit("alice", "room-a", "site-a"), want: OperationHistoryMutation},
+		{name: "history migration mutation", subj: subject.MigrationInternalMsgEdit("site-a"), want: OperationHistoryMutation},
+		{name: "thread subscription read", subj: subject.ThreadSubscriptionList("site-a"), want: OperationHistoryRead},
+		{name: "room read", subj: subject.RoomKeyGet("alice", "room-a", "site-a"), want: OperationRoomRead},
+		{name: "room mutation", subj: subject.RoomRename("alice", "room-a", "site-a"), want: OperationRoomMutation},
+		{name: "member read", subj: subject.MemberList("alice", "room-a", "site-a"), want: OperationMemberRead},
+		{name: "organization member read", subj: subject.OrgMembers("alice", "org-a", "site-a"), want: OperationMemberRead},
+		{name: "member mutation", subj: subject.MemberAdd("alice", "room-a", "site-a"), want: OperationMemberMutation},
+		{name: "teams room", subj: teamsMeeting, want: OperationTeamsRoom},
+		{name: "server room read", subj: subject.RoomsInfoBatchSubscribe("site-a"), want: OperationRoomRead},
+		{name: "server room mutation", subj: subject.RoomKeyEnsure("site-a"), want: OperationRoomMutation},
+		{name: "dynamic unknown", subj: "chat.user.alice.request.room.room-a.site-a.unbounded.value", want: OperationUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, RequestOperationFromSubject(tt.subj))
+		})
+	}
+}
+
+func TestPublishLabelsFromSubject(t *testing.T) {
+	tests := []struct {
+		name        string
+		subj        string
+		destination DestinationKind
+		operation   Operation
+	}{
+		{name: "canonical message mutation", subj: subject.MsgCanonicalUpdated("site-a"), destination: DestinationCanonical, operation: OperationCanonicalPublish},
+		{name: "outbox room event", subj: subject.Outbox("site-a", "site-b", "room_renamed"), destination: DestinationOutbox, operation: OperationOutboxPublish},
+		{name: "internal member feed", subj: subject.InboxInternal("site-a", "member_added"), destination: DestinationInbox, operation: OperationMemberPublish},
+		{name: "internal room feed", subj: subject.InboxInternal("site-a", "room_renamed"), destination: DestinationInbox, operation: OperationRoomPublish},
+		{name: "room event", subj: subject.RoomEvent("room-a", true), destination: DestinationRoomEvent, operation: OperationRoomPublish},
+		{name: "member event", subj: subject.RoomMemberEvent("room-a", false), destination: DestinationMemberEvent, operation: OperationMemberPublish},
+		{name: "client room update", subj: subject.UserRoomUpdate("alice"), destination: DestinationRecipientEvent, operation: OperationRoomPublish},
+		{name: "client subscription update", subj: subject.SubscriptionUpdate("alice"), destination: DestinationRecipientEvent, operation: OperationMemberPublish},
+		{name: "client room key", subj: subject.RoomKeyUpdate("alice"), destination: DestinationRecipientEvent, operation: OperationRoomPublish},
+		{name: "async client response", subj: subject.UserResponse("alice", "request-a"), destination: DestinationClientResponse, operation: OperationClientResponse},
+		{name: "teams identity upsert", subj: subject.OrgSyncUsersUpsert("site-a"), destination: DestinationUserSync, operation: OperationTeamsUserUpsert},
+		{name: "unknown", subj: "chat.dynamic.account.room.site.error-text", destination: DestinationUnknown, operation: OperationUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			destination, operation := PublishLabelsFromSubject(tt.subj)
+			assert.Equal(t, tt.destination, destination)
+			assert.Equal(t, tt.operation, operation)
+		})
+	}
+}

--- a/pkg/natsmetrics/subject_test.go
+++ b/pkg/natsmetrics/subject_test.go
@@ -67,6 +67,7 @@ func TestRequestOperationFromSubject(t *testing.T) {
 		want Operation
 	}{
 		{name: "history read", subj: subject.MsgHistory("alice", "room-a", "site-a"), want: OperationHistoryRead},
+		{name: "thread parent read", subj: "chat.user.alice.request.room.room-a.site-a.msg.thread.parent", want: OperationHistoryRead},
 		{name: "history mutation", subj: subject.MsgEdit("alice", "room-a", "site-a"), want: OperationHistoryMutation},
 		{name: "history migration mutation", subj: subject.MigrationInternalMsgEdit("site-a"), want: OperationHistoryMutation},
 		{name: "thread subscription read", subj: subject.ThreadSubscriptionList("site-a"), want: OperationHistoryRead},
@@ -75,6 +76,8 @@ func TestRequestOperationFromSubject(t *testing.T) {
 		{name: "member read", subj: subject.MemberList("alice", "room-a", "site-a"), want: OperationMemberRead},
 		{name: "organization member read", subj: subject.OrgMembers("alice", "org-a", "site-a"), want: OperationMemberRead},
 		{name: "member mutation", subj: subject.MemberAdd("alice", "room-a", "site-a"), want: OperationMemberMutation},
+		{name: "teams account does not hijack member mutation", subj: subject.MemberAdd("teams", "room-a", "site-a"), want: OperationMemberMutation},
+		{name: "msg room does not hijack room read", subj: subject.RoomKeyGet("alice", "msg", "site-a"), want: OperationRoomRead},
 		{name: "teams room", subj: teamsMeeting, want: OperationTeamsRoom},
 		{name: "server room read", subj: subject.RoomsInfoBatchSubscribe("site-a"), want: OperationRoomRead},
 		{name: "server room mutation", subj: subject.RoomKeyEnsure("site-a"), want: OperationRoomMutation},

--- a/pkg/natsmetrics/supervisor_test.go
+++ b/pkg/natsmetrics/supervisor_test.go
@@ -1,0 +1,301 @@
+package natsmetrics
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type supervisorTestIterator struct {
+	next func() (context.Context, jetstream.Msg, error)
+	stop func()
+}
+
+func (i *supervisorTestIterator) Next(...jetstream.NextOpt) (context.Context, jetstream.Msg, error) {
+	return i.next()
+}
+
+func (i *supervisorTestIterator) Stop() {
+	if i.stop != nil {
+		i.stop()
+	}
+}
+
+func blockingSupervisorIterator(created chan<- struct{}, active, maxActive *atomic.Int64, duplicate *atomic.Bool) *supervisorTestIterator {
+	if active.Add(1) != 1 {
+		duplicate.Store(true)
+	}
+	for {
+		current := active.Load()
+		previous := maxActive.Load()
+		if current <= previous || maxActive.CompareAndSwap(previous, current) {
+			break
+		}
+	}
+	stopped := make(chan struct{})
+	var stopOnce sync.Once
+	close(created)
+	return &supervisorTestIterator{
+		next: func() (context.Context, jetstream.Msg, error) {
+			<-stopped
+			return nil, nil, jetstream.ErrConsumerDeleted
+		},
+		stop: func() {
+			stopOnce.Do(func() {
+				active.Add(-1)
+				close(stopped)
+			})
+		},
+	}
+}
+
+func failingSupervisorIterator(active, maxActive *atomic.Int64, duplicate *atomic.Bool, err error) *supervisorTestIterator {
+	if active.Add(1) != 1 {
+		duplicate.Store(true)
+	}
+	for {
+		current := active.Load()
+		previous := maxActive.Load()
+		if current <= previous || maxActive.CompareAndSwap(previous, current) {
+			break
+		}
+	}
+	var stopOnce sync.Once
+	return &supervisorTestIterator{
+		next: func() (context.Context, jetstream.Msg, error) { return nil, nil, err },
+		stop: func() {
+			stopOnce.Do(func() { active.Add(-1) })
+		},
+	}
+}
+
+func TestSupervisor_RecoversAfterTerminalIteratorFailure(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	consumer := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "site-a", Stream: "STREAM-site-a", Consumer: "durable"})
+	var (
+		factoryCalls atomic.Int64
+		active       atomic.Int64
+		maxActive    atomic.Int64
+		duplicate    atomic.Bool
+	)
+	recovered := make(chan struct{})
+	factory := func(context.Context) (Iterator, error) {
+		if factoryCalls.Add(1) == 1 {
+			return failingSupervisorIterator(&active, &maxActive, &duplicate, jetstream.ErrConsumerDeleted), nil
+		}
+		return blockingSupervisorIterator(recovered, &active, &maxActive, &duplicate), nil
+	}
+
+	supervisor := NewSupervisor(SupervisorConfig{
+		MinBackoff: 100 * time.Millisecond,
+		MaxBackoff: time.Second,
+		wait:       func(context.Context, time.Duration) error { return nil },
+	})
+	var wg sync.WaitGroup
+	require.NoError(t, supervisor.Start(context.Background(), factory, consumer, 2, 5, &wg, nil, func(context.Context, *Message) {}))
+
+	select {
+	case <-recovered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisor did not recreate the iterator")
+	}
+	supervisor.Stop()
+	wg.Wait()
+
+	assert.Equal(t, int64(2), factoryCalls.Load())
+	assert.Equal(t, int64(1), maxActive.Load())
+	assert.False(t, duplicate.Load(), "a replacement iterator started before the failed iterator stopped")
+	assert.Zero(t, active.Load())
+
+	rm := collect(t, reader)
+	terminal := metricPoints[int64](t, rm, "chat.nats.terminal.failures")
+	require.Len(t, terminal, 1)
+	assert.Equal(t, string(TerminalConsumerDeleted), attrs(terminal[0])["reason"])
+	recoveries := metricPoints[int64](t, rm, "chat.nats.consumer.recovery.attempts")
+	require.Len(t, recoveries, 1)
+	assert.Equal(t, string(RecoverySuccess), attrs(recoveries[0])["result"])
+	loop := metricPoints[int64](t, rm, "chat.nats.consumer.loop.up")
+	require.Len(t, loop, 1)
+	assert.Zero(t, loop[0].Value)
+}
+
+func TestSupervisor_RecreationFailuresUseCappedBackoff(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	consumer := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "site-a", Stream: "STREAM-site-a", Consumer: "durable"})
+	var (
+		factoryCalls atomic.Int64
+		active       atomic.Int64
+		maxActive    atomic.Int64
+		duplicate    atomic.Bool
+		waitMu       sync.Mutex
+		waits        []time.Duration
+	)
+	recovered := make(chan struct{})
+	factory := func(context.Context) (Iterator, error) {
+		call := factoryCalls.Add(1)
+		switch {
+		case call == 1:
+			return failingSupervisorIterator(&active, &maxActive, &duplicate, errors.New("terminal iterator failure")), nil
+		case call < 5:
+			return nil, errors.New("consumer recreation failed")
+		default:
+			return blockingSupervisorIterator(recovered, &active, &maxActive, &duplicate), nil
+		}
+	}
+	supervisor := NewSupervisor(SupervisorConfig{
+		MinBackoff: 100 * time.Millisecond,
+		MaxBackoff: 400 * time.Millisecond,
+		wait: func(_ context.Context, d time.Duration) error {
+			waitMu.Lock()
+			waits = append(waits, d)
+			waitMu.Unlock()
+			return nil
+		},
+	})
+	var wg sync.WaitGroup
+	require.NoError(t, supervisor.Start(context.Background(), factory, consumer, 1, 5, &wg, nil, func(context.Context, *Message) {}))
+
+	select {
+	case <-recovered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisor did not recover after recreation failures")
+	}
+	supervisor.Stop()
+	wg.Wait()
+
+	waitMu.Lock()
+	assert.Equal(t, []time.Duration{100 * time.Millisecond, 200 * time.Millisecond, 400 * time.Millisecond, 400 * time.Millisecond}, waits)
+	waitMu.Unlock()
+	assert.Equal(t, int64(1), maxActive.Load())
+	assert.False(t, duplicate.Load())
+
+	rm := collect(t, reader)
+	points := metricPoints[int64](t, rm, "chat.nats.consumer.recovery.attempts")
+	require.Len(t, points, 2)
+	results := map[string]int64{}
+	for _, point := range points {
+		results[attrs(point)["result"]] = point.Value
+	}
+	assert.Equal(t, int64(3), results[string(RecoveryFailure)])
+	assert.Equal(t, int64(1), results[string(RecoverySuccess)])
+}
+
+func TestSupervisor_CancellationStopsRetries(t *testing.T) {
+	m, _ := newTestMetrics(t)
+	consumer := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "site-a", Stream: "STREAM-site-a", Consumer: "durable"})
+	var factoryCalls atomic.Int64
+	backoffStarted := make(chan struct{})
+	supervisor := NewSupervisor(SupervisorConfig{
+		MinBackoff: time.Second,
+		MaxBackoff: time.Second,
+		wait: func(ctx context.Context, _ time.Duration) error {
+			close(backoffStarted)
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+	var wg sync.WaitGroup
+	require.NoError(t, supervisor.Start(context.Background(), func(context.Context) (Iterator, error) {
+		factoryCalls.Add(1)
+		return nil, errors.New("consumer unavailable")
+	}, consumer, 1, 5, &wg, nil, func(context.Context, *Message) {}))
+
+	select {
+	case <-backoffStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisor did not enter backoff")
+	}
+	supervisor.Stop()
+	wg.Wait()
+
+	assert.Equal(t, int64(1), factoryCalls.Load(), "cancellation must prevent another recreation attempt")
+}
+
+func TestSupervisor_RejectsConcurrentStart(t *testing.T) {
+	m, _ := newTestMetrics(t)
+	consumer := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "site-a", Stream: "STREAM-site-a", Consumer: "durable"})
+	created := make(chan struct{})
+	var active, maxActive atomic.Int64
+	var duplicate atomic.Bool
+	supervisor := NewSupervisor(SupervisorConfig{})
+	var wg sync.WaitGroup
+	factory := func(context.Context) (Iterator, error) {
+		return blockingSupervisorIterator(created, &active, &maxActive, &duplicate), nil
+	}
+	require.NoError(t, supervisor.Start(context.Background(), factory, consumer, 1, 5, &wg, nil, func(context.Context, *Message) {}))
+	<-created
+
+	err := supervisor.Start(context.Background(), factory, consumer, 1, 5, &wg, nil, func(context.Context, *Message) {})
+	require.ErrorIs(t, err, ErrSupervisorRunning)
+	supervisor.Stop()
+	wg.Wait()
+
+	assert.Equal(t, int64(1), maxActive.Load())
+	assert.False(t, duplicate.Load())
+}
+
+func TestSupervisor_StopWaitsForInFlightHandler(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	consumer := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "site-a", Stream: "STREAM-site-a", Consumer: "durable"})
+	msg := &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}}
+	stopped := make(chan struct{})
+	var stopOnce sync.Once
+	var delivered atomic.Bool
+	iter := &supervisorTestIterator{
+		next: func() (context.Context, jetstream.Msg, error) {
+			if delivered.CompareAndSwap(false, true) {
+				return context.Background(), msg, nil
+			}
+			<-stopped
+			return nil, nil, jetstream.ErrConsumerDeleted
+		},
+		stop: func() { stopOnce.Do(func() { close(stopped) }) },
+	}
+	handlerStarted := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	handlerErr := make(chan error, 1)
+	supervisor := NewSupervisor(SupervisorConfig{})
+	var wg sync.WaitGroup
+	require.NoError(t, supervisor.Start(context.Background(), func(context.Context) (Iterator, error) {
+		return iter, nil
+	}, consumer, 1, 5, &wg, func(jetstream.Msg) EventType { return EventCreated }, func(_ context.Context, tracked *Message) {
+		close(handlerStarted)
+		<-releaseHandler
+		handlerErr <- tracked.Ack()
+	}))
+
+	<-handlerStarted
+	supervisor.Stop()
+	waited := make(chan struct{})
+	go func() { wg.Wait(); close(waited) }()
+	assert.Never(t, func() bool {
+		select {
+		case <-waited:
+			return true
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond, "shutdown returned before the in-flight handler completed")
+
+	close(releaseHandler)
+	select {
+	case <-waited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("shutdown did not finish after the handler completed")
+	}
+	require.NoError(t, <-handlerErr)
+
+	rm := collect(t, reader)
+	terminal := metricPoints[int64](t, rm, "chat.nats.terminal.failures")
+	assert.Empty(t, terminal, "iterator stop caused by shutdown is not a terminal consumer failure")
+	messages := metricPoints[int64](t, rm, "chat.nats.consumer.messages")
+	require.Len(t, messages, 1)
+	assert.Equal(t, string(OutcomeAck), attrs(messages[0])["outcome"])
+}

--- a/pkg/natsmetrics/supervisor_test.go
+++ b/pkg/natsmetrics/supervisor_test.go
@@ -3,6 +3,7 @@ package natsmetrics
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -88,7 +89,7 @@ func TestSupervisor_RecoversAfterTerminalIteratorFailure(t *testing.T) {
 	recovered := make(chan struct{})
 	factory := func(context.Context) (Iterator, error) {
 		if factoryCalls.Add(1) == 1 {
-			return failingSupervisorIterator(&active, &maxActive, &duplicate, jetstream.ErrConsumerDeleted), nil
+			return failingSupervisorIterator(&active, &maxActive, &duplicate, errors.New("transient iterator failure")), nil
 		}
 		return blockingSupervisorIterator(recovered, &active, &maxActive, &duplicate), nil
 	}
@@ -117,13 +118,101 @@ func TestSupervisor_RecoversAfterTerminalIteratorFailure(t *testing.T) {
 	rm := collect(t, reader)
 	terminal := metricPoints[int64](t, rm, "chat.nats.terminal.failures")
 	require.Len(t, terminal, 1)
-	assert.Equal(t, string(TerminalConsumerDeleted), attrs(terminal[0])["reason"])
+	assert.Equal(t, string(TerminalInternal), attrs(terminal[0])["reason"])
 	recoveries := metricPoints[int64](t, rm, "chat.nats.consumer.recovery.attempts")
 	require.Len(t, recoveries, 1)
 	assert.Equal(t, string(RecoverySuccess), attrs(recoveries[0])["result"])
 	loop := metricPoints[int64](t, rm, "chat.nats.consumer.loop.up")
 	require.Len(t, loop, 1)
 	assert.Zero(t, loop[0].Value)
+}
+
+func TestSupervisor_DeletedConsumerStopsWithoutRecreation(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	consumer := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "site-a", Stream: "STREAM-site-a", Consumer: "durable"})
+	var (
+		factoryCalls atomic.Int64
+		active       atomic.Int64
+		maxActive    atomic.Int64
+		duplicate    atomic.Bool
+	)
+	recreated := make(chan struct{})
+	factory := func(context.Context) (Iterator, error) {
+		if factoryCalls.Add(1) == 1 {
+			return failingSupervisorIterator(&active, &maxActive, &duplicate, fmt.Errorf("next message: %w", jetstream.ErrConsumerDeleted)), nil
+		}
+		return blockingSupervisorIterator(recreated, &active, &maxActive, &duplicate), nil
+	}
+
+	supervisor := NewSupervisor(SupervisorConfig{
+		MinBackoff: time.Millisecond,
+		MaxBackoff: time.Millisecond,
+		wait:       func(context.Context, time.Duration) error { return nil },
+	})
+	var wg sync.WaitGroup
+	require.NoError(t, supervisor.Start(context.Background(), factory, consumer, 1, 5, &wg, nil, func(context.Context, *Message) {}))
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+
+	select {
+	case <-done:
+	case <-recreated:
+		supervisor.Stop()
+		<-done
+		t.Fatal("deleted durable was recreated")
+	case <-time.After(2 * time.Second):
+		supervisor.Stop()
+		<-done
+		t.Fatal("supervisor did not stop after consumer deletion")
+	}
+
+	assert.Equal(t, int64(1), factoryCalls.Load())
+	assert.Equal(t, int64(1), maxActive.Load())
+	assert.False(t, duplicate.Load())
+	assert.Zero(t, active.Load())
+
+	rm := collect(t, reader)
+	terminal := metricPoints[int64](t, rm, "chat.nats.terminal.failures")
+	require.Len(t, terminal, 1)
+	assert.Equal(t, string(TerminalConsumerDeleted), attrs(terminal[0])["reason"])
+	assert.Empty(t, metricPoints[int64](t, rm, "chat.nats.consumer.recovery.attempts"))
+}
+
+func TestSupervisor_StartReturnsInitialFactoryError(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	consumer := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "site-a", Stream: "STREAM-site-a", Consumer: "durable"})
+	sentinel := errors.New("stream unavailable at startup")
+	var factoryCalls atomic.Int64
+	called := make(chan struct{})
+	var calledOnce sync.Once
+	supervisor := NewSupervisor(SupervisorConfig{})
+	var wg sync.WaitGroup
+
+	err := supervisor.Start(context.Background(), func(context.Context) (Iterator, error) {
+		factoryCalls.Add(1)
+		calledOnce.Do(func() { close(called) })
+		return nil, sentinel
+	}, consumer, 1, 5, &wg, nil, func(context.Context, *Message) {})
+	if err == nil {
+		<-called
+		supervisor.Stop()
+		wg.Wait()
+	}
+
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, int64(1), factoryCalls.Load())
+	created := make(chan struct{})
+	var active, maxActive atomic.Int64
+	var duplicate atomic.Bool
+	require.NoError(t, supervisor.Start(context.Background(), func(context.Context) (Iterator, error) {
+		return blockingSupervisorIterator(created, &active, &maxActive, &duplicate), nil
+	}, consumer, 1, 5, &wg, nil, func(context.Context, *Message) {}), "a failed startup must release single-owner state for a later retry")
+	<-created
+	supervisor.Stop()
+	wg.Wait()
+	assert.False(t, duplicate.Load())
+	rm := collect(t, reader)
+	assert.Empty(t, metricPoints[int64](t, rm, "chat.nats.consumer.recovery.attempts"), "startup failure is not a recovery attempt")
 }
 
 func TestSupervisor_RecreationFailuresUseCappedBackoff(t *testing.T) {
@@ -187,6 +276,116 @@ func TestSupervisor_RecreationFailuresUseCappedBackoff(t *testing.T) {
 	assert.Equal(t, int64(1), results[string(RecoverySuccess)])
 }
 
+func TestSupervisor_ImmediateIteratorFailuresEscalateBackoff(t *testing.T) {
+	m, _ := newTestMetrics(t)
+	consumer := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "site-a", Stream: "STREAM-site-a", Consumer: "durable"})
+	var (
+		factoryCalls atomic.Int64
+		active       atomic.Int64
+		maxActive    atomic.Int64
+		duplicate    atomic.Bool
+		waitMu       sync.Mutex
+		waits        []time.Duration
+	)
+	recovered := make(chan struct{})
+	factory := func(context.Context) (Iterator, error) {
+		if factoryCalls.Add(1) < 4 {
+			return failingSupervisorIterator(&active, &maxActive, &duplicate, errors.New("iterator unavailable")), nil
+		}
+		return blockingSupervisorIterator(recovered, &active, &maxActive, &duplicate), nil
+	}
+	supervisor := NewSupervisor(SupervisorConfig{
+		MinBackoff: 100 * time.Millisecond,
+		MaxBackoff: 400 * time.Millisecond,
+		wait: func(_ context.Context, d time.Duration) error {
+			waitMu.Lock()
+			waits = append(waits, d)
+			waitMu.Unlock()
+			return nil
+		},
+	})
+	var wg sync.WaitGroup
+	require.NoError(t, supervisor.Start(context.Background(), factory, consumer, 1, 5, &wg, nil, func(context.Context, *Message) {}))
+
+	select {
+	case <-recovered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisor did not recover after immediate iterator failures")
+	}
+	supervisor.Stop()
+	wg.Wait()
+
+	waitMu.Lock()
+	assert.Equal(t, []time.Duration{100 * time.Millisecond, 200 * time.Millisecond, 400 * time.Millisecond}, waits)
+	waitMu.Unlock()
+	assert.Equal(t, int64(1), maxActive.Load())
+	assert.False(t, duplicate.Load())
+}
+
+func TestSupervisor_SuccessfulDeliveryResetsBackoff(t *testing.T) {
+	m, _ := newTestMetrics(t)
+	consumer := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "site-a", Stream: "STREAM-site-a", Consumer: "durable"})
+	var (
+		factoryCalls atomic.Int64
+		active       atomic.Int64
+		maxActive    atomic.Int64
+		duplicate    atomic.Bool
+		waitMu       sync.Mutex
+		waits        []time.Duration
+	)
+	recovered := make(chan struct{})
+	factory := func(context.Context) (Iterator, error) {
+		switch factoryCalls.Add(1) {
+		case 1:
+			return failingSupervisorIterator(&active, &maxActive, &duplicate, errors.New("initial iterator failure")), nil
+		case 2:
+			if active.Add(1) != 1 {
+				duplicate.Store(true)
+			}
+			var delivered atomic.Bool
+			var stopOnce sync.Once
+			return &supervisorTestIterator{
+				next: func() (context.Context, jetstream.Msg, error) {
+					if delivered.CompareAndSwap(false, true) {
+						return context.Background(), &fakeMsg{meta: &jetstream.MsgMetadata{NumDelivered: 1}}, nil
+					}
+					return nil, nil, errors.New("post-delivery iterator failure")
+				},
+				stop: func() { stopOnce.Do(func() { active.Add(-1) }) },
+			}, nil
+		default:
+			return blockingSupervisorIterator(recovered, &active, &maxActive, &duplicate), nil
+		}
+	}
+	supervisor := NewSupervisor(SupervisorConfig{
+		MinBackoff: 100 * time.Millisecond,
+		MaxBackoff: 400 * time.Millisecond,
+		wait: func(_ context.Context, d time.Duration) error {
+			waitMu.Lock()
+			waits = append(waits, d)
+			waitMu.Unlock()
+			return nil
+		},
+	})
+	var wg sync.WaitGroup
+	require.NoError(t, supervisor.Start(context.Background(), factory, consumer, 1, 5, &wg, nil, func(_ context.Context, msg *Message) {
+		assert.NoError(t, msg.Ack())
+	}))
+
+	select {
+	case <-recovered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisor did not recover after the post-delivery failure")
+	}
+	supervisor.Stop()
+	wg.Wait()
+
+	waitMu.Lock()
+	assert.Equal(t, []time.Duration{100 * time.Millisecond, 100 * time.Millisecond}, waits)
+	waitMu.Unlock()
+	assert.False(t, duplicate.Load())
+}
+
 func TestSupervisor_CancellationStopsRetries(t *testing.T) {
 	m, _ := newTestMetrics(t)
 	consumer := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "site-a", Stream: "STREAM-site-a", Consumer: "durable"})
@@ -203,7 +402,11 @@ func TestSupervisor_CancellationStopsRetries(t *testing.T) {
 	})
 	var wg sync.WaitGroup
 	require.NoError(t, supervisor.Start(context.Background(), func(context.Context) (Iterator, error) {
-		factoryCalls.Add(1)
+		if factoryCalls.Add(1) == 1 {
+			var active, maxActive atomic.Int64
+			var duplicate atomic.Bool
+			return failingSupervisorIterator(&active, &maxActive, &duplicate, errors.New("iterator unavailable")), nil
+		}
 		return nil, errors.New("consumer unavailable")
 	}, consumer, 1, 5, &wg, nil, func(context.Context, *Message) {}))
 

--- a/pkg/natsmetrics/supervisor_test.go
+++ b/pkg/natsmetrics/supervisor_test.go
@@ -178,6 +178,64 @@ func TestSupervisor_DeletedConsumerStopsWithoutRecreation(t *testing.T) {
 	assert.Empty(t, metricPoints[int64](t, rm, "chat.nats.consumer.recovery.attempts"))
 }
 
+func TestSupervisor_RecoveryMissingConsumerStopsWithoutCreation(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	consumer := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "site-a", Stream: "STREAM-site-a", Consumer: "durable"})
+	var (
+		initialCalls  atomic.Int64
+		recoveryCalls atomic.Int64
+		active        atomic.Int64
+		maxActive     atomic.Int64
+		duplicate     atomic.Bool
+	)
+	initialFactory := func(context.Context) (Iterator, error) {
+		initialCalls.Add(1)
+		return failingSupervisorIterator(&active, &maxActive, &duplicate, jetstream.ErrConnectionClosed), nil
+	}
+	recoveryFactory := func(context.Context) (Iterator, error) {
+		recoveryCalls.Add(1)
+		return nil, fmt.Errorf("lookup durable: %w", jetstream.ErrConsumerNotFound)
+	}
+
+	supervisor := NewSupervisor(SupervisorConfig{
+		MinBackoff: time.Millisecond,
+		MaxBackoff: time.Millisecond,
+		wait:       func(context.Context, time.Duration) error { return nil },
+	})
+	var wg sync.WaitGroup
+	require.NoError(t, supervisor.StartWithRecovery(context.Background(), initialFactory, recoveryFactory,
+		consumer, 1, 5, &wg, nil, func(context.Context, *Message) {}))
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		supervisor.Stop()
+		<-done
+		t.Fatal("supervisor retried after recovery found the durable missing")
+	}
+
+	assert.Equal(t, int64(1), initialCalls.Load(), "recovery must not call the create-or-update startup factory")
+	assert.Equal(t, int64(1), recoveryCalls.Load(), "a missing durable must stop recovery without retrying")
+	assert.Equal(t, int64(1), maxActive.Load())
+	assert.False(t, duplicate.Load())
+	assert.Zero(t, active.Load())
+
+	rm := collect(t, reader)
+	terminal := metricPoints[int64](t, rm, "chat.nats.terminal.failures")
+	require.Len(t, terminal, 2)
+	reasons := map[string]int64{}
+	for _, point := range terminal {
+		reasons[attrs(point)["reason"]] = point.Value
+	}
+	assert.Equal(t, map[string]int64{
+		string(TerminalStreamUnavailable): 1,
+		string(TerminalConsumerDeleted):   1,
+	}, reasons)
+	assert.Empty(t, metricPoints[int64](t, rm, "chat.nats.consumer.recovery.attempts"))
+}
+
 func TestSupervisor_StartReturnsInitialFactoryError(t *testing.T) {
 	m, reader := newTestMetrics(t)
 	consumer := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "site-a", Stream: "STREAM-site-a", Consumer: "durable"})

--- a/pkg/natsmetrics/supervisor_test.go
+++ b/pkg/natsmetrics/supervisor_test.go
@@ -560,3 +560,47 @@ func TestSupervisor_StopWaitsForInFlightHandler(t *testing.T) {
 	require.Len(t, messages, 1)
 	assert.Equal(t, string(OutcomeAck), attrs(messages[0])["outcome"])
 }
+
+// TestSupervisor_RecoverySuccessSurvivesShutdownRace pins the recreation
+// counter to the recreation attempt itself. Recording success only once the
+// next generation starts loses it whenever shutdown cancels the context between
+// the factory returning and activate running — a window a caller can hit simply
+// by stopping as soon as it observes the new iterator.
+func TestSupervisor_RecoverySuccessSurvivesShutdownRace(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	consumer := m.Consumer(ConsumerConfig{ServiceName: "svc", Site: "site-a", Stream: "STREAM-site-a", Consumer: "durable"})
+	var (
+		factoryCalls atomic.Int64
+		active       atomic.Int64
+		maxActive    atomic.Int64
+		duplicate    atomic.Bool
+		supervisor   *Supervisor
+	)
+	factory := func(context.Context) (Iterator, error) {
+		if factoryCalls.Add(1) == 1 {
+			return failingSupervisorIterator(&active, &maxActive, &duplicate, errors.New("terminal iterator failure")), nil
+		}
+		// Cancel before returning: the recreation has succeeded, but the
+		// supervisor will never activate this iterator.
+		supervisor.Stop()
+		return failingSupervisorIterator(&active, &maxActive, &duplicate, errors.New("unused")), nil
+	}
+	supervisor = NewSupervisor(SupervisorConfig{
+		MinBackoff: time.Millisecond,
+		MaxBackoff: time.Millisecond,
+		wait:       func(context.Context, time.Duration) error { return nil },
+	})
+
+	var wg sync.WaitGroup
+	require.NoError(t, supervisor.Start(context.Background(), factory, consumer, 1, 5, &wg, nil, func(context.Context, *Message) {}))
+	wg.Wait()
+
+	rm := collect(t, reader)
+	points := metricPoints[int64](t, rm, "chat.nats.consumer.recovery.attempts")
+	results := map[string]int64{}
+	for _, point := range points {
+		results[attrs(point)["result"]] = point.Value
+	}
+	assert.Equal(t, int64(1), results[string(RecoverySuccess)],
+		"a recreation that returned an iterator must be counted even if shutdown wins the activate race")
+}

--- a/pkg/natsrouter/context.go
+++ b/pkg/natsrouter/context.go
@@ -3,6 +3,7 @@ package natsrouter
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"sync"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/errcode/errnats"
 	"github.com/hmchangw/chat/pkg/logctx"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 )
 
 // HandlerFunc is the function type for handlers and middleware.
@@ -32,12 +34,13 @@ type responder interface {
 // single-writer contract: middleware must call SetContext before c.Next(),
 // never concurrently with handler-spawned goroutines that read c.Value.
 type Context struct {
-	ctx    context.Context
-	Msg    *nats.Msg
-	Params Params
-	reply  responder
-	keys   map[string]any
-	mu     sync.RWMutex
+	ctx           context.Context
+	Msg           *nats.Msg
+	Params        Params
+	reply         responder
+	keys          map[string]any
+	mu            sync.RWMutex
+	requestResult natsmetrics.RequestResult
 
 	chain *chainState
 }
@@ -60,11 +63,12 @@ func acquireContext(ctx context.Context, msg *nats.Msg, params Params, handlers 
 	cs.handlers = handlers
 	cs.index = -1
 	return &Context{
-		ctx:    ctx,
-		Msg:    msg,
-		Params: params,
-		reply:  reply,
-		chain:  cs,
+		ctx:           ctx,
+		Msg:           msg,
+		Params:        params,
+		reply:         reply,
+		chain:         cs,
+		requestResult: natsmetrics.RequestSuccess,
 	}
 }
 
@@ -85,9 +89,10 @@ func releaseContext(c *Context) {
 // NewContext creates a Context for testing handlers without a NATS connection.
 func NewContext(params map[string]string) *Context {
 	return &Context{
-		ctx:    context.Background(),
-		Params: NewParams(params),
-		chain:  &chainState{index: -1},
+		ctx:           context.Background(),
+		Params:        NewParams(params),
+		chain:         &chainState{index: -1},
+		requestResult: natsmetrics.RequestSuccess,
 	}
 }
 
@@ -230,6 +235,7 @@ func (c *Context) ReplyJSON(v any) {
 	data, err := json.Marshal(v)
 	if err != nil {
 		slog.ErrorContext(c, "marshal response failed", "error", err, "subject", c.subject())
+		c.requestResult = natsmetrics.RequestInternal
 		c.respond([]byte(`{"code":"internal","error":"internal error"}`))
 		return
 	}
@@ -238,11 +244,13 @@ func (c *Context) ReplyJSON(v any) {
 
 // ReplyError classifies err, logs it once, and sends the errcode envelope.
 func (c *Context) ReplyError(err error) {
+	c.requestResult = requestResultFromError(err)
 	c.respond(errnats.Marshal(c, err))
 }
 
 // ReplyErrorQuiet sends an errcode envelope without logging classification.
 func (c *Context) ReplyErrorQuiet(err error) {
+	c.requestResult = requestResultFromError(err)
 	c.respond(errnats.MarshalQuiet(err))
 }
 
@@ -258,7 +266,33 @@ func (c *Context) respond(data []byte) {
 		err = c.Msg.Respond(data)
 	}
 	if err != nil {
+		c.requestResult = natsmetrics.RequestInternal
 		slog.ErrorContext(c, "reply failed", "error", err, "subject", c.Msg.Subject)
+	}
+}
+
+func requestResultFromError(err error) natsmetrics.RequestResult {
+	var coded *errcode.Error
+	if !errors.As(err, &coded) {
+		return natsmetrics.RequestInternal
+	}
+	switch coded.Code {
+	case errcode.CodeBadRequest:
+		return natsmetrics.RequestBadRequest
+	case errcode.CodeUnauthenticated:
+		return natsmetrics.RequestUnauthenticated
+	case errcode.CodeForbidden:
+		return natsmetrics.RequestForbidden
+	case errcode.CodeNotFound:
+		return natsmetrics.RequestNotFound
+	case errcode.CodeConflict:
+		return natsmetrics.RequestConflict
+	case errcode.CodeTooManyRequests:
+		return natsmetrics.RequestTooManyRequests
+	case errcode.CodeUnavailable:
+		return natsmetrics.RequestUnavailable
+	default:
+		return natsmetrics.RequestInternal
 	}
 }
 

--- a/pkg/natsrouter/register.go
+++ b/pkg/natsrouter/register.go
@@ -94,13 +94,13 @@ func RegisterVoid[Req any](
 		var req Req
 		if err := json.Unmarshal(c.Msg.Data, &req); err != nil {
 			c.requestResult = natsmetrics.RequestBadRequest
-			slog.Error("invalid payload in void handler", "error", err, "subject", c.Msg.Subject)
+			slog.ErrorContext(c, "invalid payload in void handler", "error", err, "subject", c.Msg.Subject)
 			return
 		}
 
 		if err := fn(c, req); err != nil {
 			c.requestResult = requestResultFromError(err)
-			slog.Error("void handler error", "error", err, "subject", c.Msg.Subject)
+			slog.ErrorContext(c, "void handler error", "error", err, "subject", c.Msg.Subject)
 		}
 	})
 

--- a/pkg/natsrouter/register.go
+++ b/pkg/natsrouter/register.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 
 	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 )
 
 // Register subscribes a typed handler to a subject pattern.
@@ -92,11 +93,13 @@ func RegisterVoid[Req any](
 	handler := HandlerFunc(func(c *Context) {
 		var req Req
 		if err := json.Unmarshal(c.Msg.Data, &req); err != nil {
+			c.requestResult = natsmetrics.RequestBadRequest
 			slog.Error("invalid payload in void handler", "error", err, "subject", c.Msg.Subject)
 			return
 		}
 
 		if err := fn(c, req); err != nil {
+			c.requestResult = requestResultFromError(err)
 			slog.Error("void handler error", "error", err, "subject", c.Msg.Subject)
 		}
 	})

--- a/pkg/natsrouter/router.go
+++ b/pkg/natsrouter/router.go
@@ -8,6 +8,7 @@ import (
 	"runtime/debug"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/nats-io/nats.go"
 
@@ -15,6 +16,7 @@ import (
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/errcode/errnats"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 )
 
 // Router manages NATS subscriptions with pattern-based routing and middleware.
@@ -24,7 +26,9 @@ type Router struct {
 	middleware []HandlerFunc
 	// siteID labels client-facing requests whose subject pins the site to a
 	// static token, leaving no {siteID} param. Configured by WithSiteID.
-	siteID string
+	siteID  string
+	metrics natsmetrics.Publisher
+	reply   responder
 
 	// sem gates handler concurrency: every handler invocation acquires a
 	// slot before running and releases it on return. cap(sem) is the
@@ -82,6 +86,13 @@ func WithSiteID(siteID string) Option {
 	return func(r *Router) { r.siteID = siteID }
 }
 
+// WithMetrics enables bounded request/reply and response-publish metrics at
+// the router boundary. It is opt-in so existing routers retain their current
+// behavior until a service supplies its telemetry identity.
+func WithMetrics(metrics natsmetrics.Publisher) Option {
+	return func(r *Router) { r.metrics = metrics }
+}
+
 // New creates a Router with the given NATS connection and queue group.
 // By default, the router spawns handlers unboundedly (no admission
 // control). Use WithMaxConcurrency to opt into a concurrency cap.
@@ -93,7 +104,19 @@ func New(nc *o11ynats.Conn, queue string, opts ...Option) *Router {
 	for _, opt := range opts {
 		opt(r)
 	}
+	r.reply = routerResponder{nc: nc, metrics: r.metrics}
 	return r
+}
+
+type routerResponder struct {
+	nc      *o11ynats.Conn
+	metrics natsmetrics.Publisher
+}
+
+func (r routerResponder) Respond(ctx context.Context, msg *nats.Msg, data []byte) error {
+	err := r.nc.Respond(ctx, msg, data)
+	r.metrics.Attempt(ctx, natsmetrics.DestinationClientResponse, natsmetrics.OperationClientResponse, err)
+	return err
 }
 
 // Default returns a Router pre-configured with the recommended middleware
@@ -134,7 +157,7 @@ func (r *Router) replyBusy(ctx context.Context, msg *nats.Msg) {
 		return
 	}
 	// Admission rejection is operational, not a request failure; ReplyQuiet skips Classify.
-	if err := r.nc.Respond(ctx, msg, errnats.MarshalQuiet(errcode.Unavailable("service busy"))); err != nil {
+	if err := r.reply.Respond(ctx, msg, errnats.MarshalQuiet(errcode.Unavailable("service busy"))); err != nil {
 		slog.ErrorContext(ctx, "error reply failed", "error", err, "subject", msg.Subject)
 	}
 }
@@ -187,15 +210,19 @@ func (r *Router) addRoute(pattern string, handlers []HandlerFunc) {
 	all = append(all, handlers...)
 
 	natsHandler := func(msgCtx context.Context, m *nats.Msg) {
+		started := time.Now()
+		operation := natsmetrics.RequestOperationFromSubject(m.Subject)
 		// Stopping gate: reject before admit so Shutdown's contract holds
 		// even if a callback fires mid-drain or after Shutdown's ctx expired.
 		if r.stopping.Load() {
 			r.replyBusy(msgCtx, m)
+			r.metrics.HandledRequest(msgCtx, operation, time.Since(started), natsmetrics.RequestUnavailable)
 			return
 		}
 		admitted, release := r.admit()
 		if !admitted {
 			r.replyBusy(msgCtx, m)
+			r.metrics.HandledRequest(msgCtx, operation, time.Since(started), natsmetrics.RequestUnavailable)
 			return
 		}
 		r.wg.Add(1)
@@ -209,8 +236,14 @@ func (r *Router) addRoute(pattern string, handlers []HandlerFunc) {
 			// panic somehow escapes it. Either way, the process survives
 			// and the deferred semaphore/WG cleanup (registered earlier in
 			// this goroutine; runs after this defer in LIFO order) still fires.
+			c := acquireContext(msgCtx, m, rt.extractParams(m.Subject), all, r.reply)
+			defer releaseContext(c)
+			defer func() {
+				r.metrics.HandledRequest(msgCtx, operation, time.Since(started), c.requestResult)
+			}()
 			defer func() {
 				if rec := recover(); rec != nil {
+					c.requestResult = natsmetrics.RequestInternal
 					// Warn, not Error: a hit here means Recovery middleware
 					// is misconfigured or absent (Recovery would have caught
 					// it earlier and produced a structured ErrInternal
@@ -223,14 +256,12 @@ func (r *Router) addRoute(pattern string, handlers []HandlerFunc) {
 						"stack", string(debug.Stack()))
 					if m.Reply != "" {
 						// Already logged via the Warn above; ReplyQuiet avoids a second line.
-						if err := r.nc.Respond(msgCtx, m, errnats.MarshalQuiet(errcode.Internal("internal error"))); err != nil {
+						if err := r.reply.Respond(msgCtx, m, errnats.MarshalQuiet(errcode.Internal("internal error"))); err != nil {
 							slog.ErrorContext(msgCtx, "error reply failed", "error", err, "subject", m.Subject)
 						}
 					}
 				}
 			}()
-			c := acquireContext(msgCtx, m, rt.extractParams(m.Subject), all, r.nc)
-			defer releaseContext(c)
 			c.Next()
 		}()
 	}

--- a/pkg/natsrouter/router_test.go
+++ b/pkg/natsrouter/router_test.go
@@ -87,34 +87,46 @@ func TestRouter_WithMetricsRecordsBoundedRequestResultsAndReplies(t *testing.T) 
 		require.NoError(t, err)
 	}
 
-	var rm metricdata.ResourceMetrics
-	require.NoError(t, reader.Collect(context.Background(), &rm))
-	results := map[string]int64{}
-	var replyAttempts int64
-	for _, scope := range rm.ScopeMetrics {
-		for _, metric := range scope.Metrics {
-			sum, ok := metric.Data.(metricdata.Sum[int64])
-			if !ok {
-				continue
-			}
-			for _, point := range sum.DataPoints {
-				attrs := map[string]string{}
-				for _, kv := range point.Attributes.ToSlice() {
-					attrs[string(kv.Key)] = kv.Value.AsString()
+	wantResults := map[string]int64{"success": 1, "forbidden": 1, "bad_request": 1}
+	var (
+		results       map[string]int64
+		replyAttempts int64
+	)
+	require.Eventually(t, func() bool {
+		var rm metricdata.ResourceMetrics
+		if err := reader.Collect(context.Background(), &rm); err != nil {
+			return false
+		}
+		results = map[string]int64{}
+		replyAttempts = 0
+		for _, scope := range rm.ScopeMetrics {
+			for _, metric := range scope.Metrics {
+				sum, ok := metric.Data.(metricdata.Sum[int64])
+				if !ok {
+					continue
 				}
-				switch metric.Name {
-				case "chat.nats.request.handled":
-					assert.Equal(t, "member_read", attrs["operation"])
-					results[attrs["result"]] += point.Value
-				case "chat.nats.publish.attempts":
-					if attrs["destination_kind"] == "client_response" && attrs["operation"] == "client_response" {
-						replyAttempts += point.Value
+				for _, point := range sum.DataPoints {
+					attrs := map[string]string{}
+					for _, kv := range point.Attributes.ToSlice() {
+						attrs[string(kv.Key)] = kv.Value.AsString()
+					}
+					switch metric.Name {
+					case "chat.nats.request.handled":
+						if attrs["operation"] != "member_read" {
+							return false
+						}
+						results[attrs["result"]] += point.Value
+					case "chat.nats.publish.attempts":
+						if attrs["destination_kind"] == "client_response" && attrs["operation"] == "client_response" {
+							replyAttempts += point.Value
+						}
 					}
 				}
 			}
 		}
-	}
-	assert.Equal(t, map[string]int64{"success": 1, "forbidden": 1, "bad_request": 1}, results)
+		return assert.ObjectsAreEqual(wantResults, results) && replyAttempts == 3
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, wantResults, results)
 	assert.Equal(t, int64(3), replyAttempts)
 }
 

--- a/pkg/natsrouter/router_test.go
+++ b/pkg/natsrouter/router_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/trace/noop"
 
 	o11ynats "github.com/flywindy/o11y/nats"
@@ -20,6 +22,7 @@ import (
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/idgen"
 	"github.com/hmchangw/chat/pkg/logctx"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsutil"
 )
 
@@ -62,6 +65,57 @@ func TestRegister_Success(t *testing.T) {
 	var result testResp
 	require.NoError(t, json.Unmarshal(resp.Data, &result))
 	assert.Equal(t, "hello world from alice", result.Greeting)
+}
+
+func TestRouter_WithMetricsRecordsBoundedRequestResultsAndReplies(t *testing.T) {
+	nc := startTestNATS(t)
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	metrics := natsmetrics.NewFromProvider(mp).Publisher("room-service", "site-a")
+	r := New(nc, "room-service", WithMetrics(metrics))
+
+	Register(r, "chat.user.{account}.request.room.{roomID}.site-a.member.list",
+		func(_ *Context, req testReq) (*testResp, error) {
+			if req.Name == "deny" {
+				return nil, errcode.Forbidden("not allowed")
+			}
+			return &testResp{Greeting: "ok"}, nil
+		})
+
+	for _, body := range [][]byte{[]byte(`{"name":"ok"}`), []byte(`{"name":"deny"}`), []byte(`not json`)} {
+		_, err := nc.Request(context.Background(), "chat.user.alice.request.room.room-a.site-a.member.list", body, 2*time.Second)
+		require.NoError(t, err)
+	}
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	results := map[string]int64{}
+	var replyAttempts int64
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+			for _, point := range sum.DataPoints {
+				attrs := map[string]string{}
+				for _, kv := range point.Attributes.ToSlice() {
+					attrs[string(kv.Key)] = kv.Value.AsString()
+				}
+				switch metric.Name {
+				case "chat.nats.request.handled":
+					assert.Equal(t, "member_read", attrs["operation"])
+					results[attrs["result"]] += point.Value
+				case "chat.nats.publish.attempts":
+					if attrs["destination_kind"] == "client_response" && attrs["operation"] == "client_response" {
+						replyAttempts += point.Value
+					}
+				}
+			}
+		}
+	}
+	assert.Equal(t, map[string]int64{"success": 1, "forbidden": 1, "bad_request": 1}, results)
+	assert.Equal(t, int64(3), replyAttempts)
 }
 
 func TestRegister_ParamsExtraction(t *testing.T) {

--- a/pkg/roomkeysender/roomkeysender.go
+++ b/pkg/roomkeysender/roomkeysender.go
@@ -1,11 +1,13 @@
 package roomkeysender
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/subject"
 )
 
@@ -17,12 +19,24 @@ type Publisher interface {
 
 // Sender publishes room key events to user NATS subjects.
 type Sender struct {
-	pub Publisher
+	pub     Publisher
+	metrics natsmetrics.Publisher
+}
+
+type Option func(*Sender)
+
+// WithMetrics enables bounded Core NATS publish-attempt metrics.
+func WithMetrics(metrics natsmetrics.Publisher) Option {
+	return func(s *Sender) { s.metrics = metrics }
 }
 
 // NewSender creates a Sender backed by the given publisher.
-func NewSender(pub Publisher) *Sender {
-	return &Sender{pub: pub}
+func NewSender(pub Publisher, opts ...Option) *Sender {
+	s := &Sender{pub: pub}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // Marshal stamps the event Timestamp and serializes it once into a payload that
@@ -44,8 +58,17 @@ func (s *Sender) Marshal(evt model.RoomKeyEvent) ([]byte, error) {
 // SendData publishes an already-marshaled payload (from Marshal) to the room key
 // update subject for the given user account.
 func (s *Sender) SendData(account string, data []byte) error {
+	return s.SendDataContext(context.Background(), account, data)
+}
+
+// SendDataContext publishes an already-marshaled payload and correlates the
+// publish metric with the caller's context.
+func (s *Sender) SendDataContext(ctx context.Context, account string, data []byte) error {
 	subj := subject.RoomKeyUpdate(account)
-	if err := s.pub.Publish(subj, data); err != nil {
+	err := s.pub.Publish(subj, data)
+	destination, operation := natsmetrics.PublishLabelsFromSubject(subj)
+	s.metrics.Attempt(ctx, destination, operation, err)
+	if err != nil {
 		return fmt.Errorf("publish room key event: %w", err)
 	}
 	return nil

--- a/pkg/roomkeysender/roomkeysender_test.go
+++ b/pkg/roomkeysender/roomkeysender_test.go
@@ -161,32 +161,48 @@ func TestSender_SendData(t *testing.T) {
 }
 
 func TestSender_WithMetricsRecordsBoundedPublishResult(t *testing.T) {
-	reader := sdkmetric.NewManualReader()
-	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-	metrics := natsmetrics.NewFromProvider(mp).Publisher("room-worker", "site-a")
-	sender := roomkeysender.NewSender(&mockPublisher{}, roomkeysender.WithMetrics(metrics))
+	for _, tt := range []struct {
+		name        string
+		publishErr  error
+		wantOutcome string
+	}{
+		{name: "success", wantOutcome: "success"},
+		{name: "failure", publishErr: errors.New("connection lost"), wantOutcome: "other_error"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := sdkmetric.NewManualReader()
+			mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+			metrics := natsmetrics.NewFromProvider(mp).Publisher("room-worker", "site-a")
+			sender := roomkeysender.NewSender(&mockPublisher{err: tt.publishErr}, roomkeysender.WithMetrics(metrics))
 
-	require.NoError(t, sender.SendDataContext(context.Background(), "alice", []byte(`{}`)))
+			err := sender.SendDataContext(context.Background(), "alice", []byte(`{}`))
+			if tt.publishErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tt.publishErr)
+			}
 
-	var rm metricdata.ResourceMetrics
-	require.NoError(t, reader.Collect(context.Background(), &rm))
-	var found bool
-	for _, scope := range rm.ScopeMetrics {
-		for _, metric := range scope.Metrics {
-			if metric.Name != "chat.nats.publish.attempts" {
-				continue
-			}
-			for _, point := range metric.Data.(metricdata.Sum[int64]).DataPoints {
-				attrs := map[string]string{}
-				for _, kv := range point.Attributes.ToSlice() {
-					attrs[string(kv.Key)] = kv.Value.AsString()
+			var rm metricdata.ResourceMetrics
+			require.NoError(t, reader.Collect(context.Background(), &rm))
+			var found bool
+			for _, scope := range rm.ScopeMetrics {
+				for _, metric := range scope.Metrics {
+					if metric.Name != "chat.nats.publish.attempts" {
+						continue
+					}
+					for _, point := range metric.Data.(metricdata.Sum[int64]).DataPoints {
+						attrs := map[string]string{}
+						for _, kv := range point.Attributes.ToSlice() {
+							attrs[string(kv.Key)] = kv.Value.AsString()
+						}
+						if attrs["destination_kind"] == "recipient_event" && attrs["operation"] == "room_publish" && attrs["outcome"] == tt.wantOutcome {
+							found = true
+							assert.Equal(t, int64(1), point.Value)
+						}
+					}
 				}
-				if attrs["destination_kind"] == "recipient_event" && attrs["operation"] == "room_publish" && attrs["outcome"] == "success" {
-					found = true
-					assert.Equal(t, int64(1), point.Value)
-				}
 			}
-		}
+			assert.True(t, found)
+		})
 	}
-	assert.True(t, found)
 }

--- a/pkg/roomkeysender/roomkeysender_test.go
+++ b/pkg/roomkeysender/roomkeysender_test.go
@@ -1,14 +1,18 @@
 package roomkeysender_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/roomkeysender"
 )
 
@@ -154,4 +158,35 @@ func TestSender_SendData(t *testing.T) {
 		assert.Contains(t, err.Error(), "publish room key event")
 		assert.ErrorIs(t, err, sentinel)
 	})
+}
+
+func TestSender_WithMetricsRecordsBoundedPublishResult(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	metrics := natsmetrics.NewFromProvider(mp).Publisher("room-worker", "site-a")
+	sender := roomkeysender.NewSender(&mockPublisher{}, roomkeysender.WithMetrics(metrics))
+
+	require.NoError(t, sender.SendDataContext(context.Background(), "alice", []byte(`{}`)))
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	var found bool
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != "chat.nats.publish.attempts" {
+				continue
+			}
+			for _, point := range metric.Data.(metricdata.Sum[int64]).DataPoints {
+				attrs := map[string]string{}
+				for _, kv := range point.Attributes.ToSlice() {
+					attrs[string(kv.Key)] = kv.Value.AsString()
+				}
+				if attrs["destination_kind"] == "recipient_event" && attrs["operation"] == "room_publish" && attrs["outcome"] == "success" {
+					found = true
+					assert.Equal(t, int64(1), point.Value)
+				}
+			}
+		}
+	}
+	assert.True(t, found)
 }

--- a/room-service/config_test.go
+++ b/room-service/config_test.go
@@ -116,3 +116,13 @@ func TestConfig_RoomSubjectMode(t *testing.T) {
 		})
 	}
 }
+
+func TestConfig_ServiceName(t *testing.T) {
+	t.Setenv("NATS_URL", "nats://localhost:4222")
+	t.Setenv("MONGO_URI", "mongodb://localhost:27017")
+	t.Setenv("OTEL_SERVICE_NAME", "room-service-canary")
+
+	cfg, err := env.ParseAs[config]()
+	require.NoError(t, err)
+	require.Equal(t, "room-service-canary", cfg.ServiceName)
+}

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
 	"github.com/hmchangw/chat/pkg/msgraph"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsrouter"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
@@ -27,6 +28,7 @@ import (
 )
 
 type config struct {
+	ServiceName   string `env:"OTEL_SERVICE_NAME"          envDefault:"unknown-service"`
 	NatsURL       string `env:"NATS_URL,required"`
 	NatsCredsFile string `env:"NATS_CREDS_FILE"           envDefault:""`
 	SiteID        string `env:"SITE_ID"                   envDefault:"site-local"`
@@ -152,7 +154,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)
+	sharedMetrics := natsmetrics.NewFromProvider(sdk.MeterProvider())
+	publishMetrics := sharedMetrics.Publisher(cfg.ServiceName, cfg.SiteID)
+	nc, err := natsutil.ConnectWithMetrics(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace, sdk.MeterProvider())
 	if err != nil {
 		slog.Error("nats connect failed", "error", err)
 		os.Exit(1)
@@ -204,7 +208,7 @@ func main() {
 	// dependency. A history-service outage degrades only read receipts
 	// (errcode.Unavailable); core room/membership/subscription operations are
 	// all MongoDB-backed and unaffected.
-	msgReader := newHistoryMessageReader(nc, cfg.SiteID)
+	msgReader := newHistoryMessageReader(nc, cfg.SiteID, withHistoryMetrics(publishMetrics))
 
 	// Graph clients back the meetings RPC. Constructed only when the Azure app
 	// credentials are present; otherwise the meetings RPC reports not-configured
@@ -250,7 +254,7 @@ func main() {
 		dekProvisioner = atrest.NewCipher(w, atrest.NewMongoDEKStore(dekColl), cfg.Atrest)
 	}
 
-	memberListClient := NewNATSMemberListClient(nc.NatsConn(), cfg.MemberListTimeout)
+	memberListClient := NewNATSMemberListClient(nc.NatsConn(), cfg.MemberListTimeout, withMemberListMetrics(publishMetrics))
 	handler := NewHandler(store, keyStore, memberListClient, msgReader, cfg.SiteID, cfg.MaxRoomSize, cfg.MaxBatchSize, cfg.MemberListTimeout, cfg.RestrictedRoomMinMembers,
 		func(ctx context.Context, subj string, data []byte, msgID string) error {
 			msg := natsutil.NewMsg(ctx, subj, data)
@@ -258,13 +262,19 @@ func main() {
 			if msgID != "" {
 				opts = append(opts, jetstream.WithMsgID(msgID))
 			}
-			if _, err := js.PublishMsg(ctx, msg, opts...); err != nil {
+			_, err := js.PublishMsg(ctx, msg, opts...)
+			destination, operation := natsmetrics.PublishLabelsFromSubject(subj)
+			publishMetrics.Attempt(ctx, destination, operation, err)
+			if err != nil {
 				return fmt.Errorf("publish to %q: %w", subj, err)
 			}
 			return nil
 		},
 		func(ctx context.Context, subj string, data []byte) error {
-			if err := nc.PublishMsg(ctx, natsutil.NewMsg(ctx, subj, data)); err != nil {
+			err := nc.PublishMsg(ctx, natsutil.NewMsg(ctx, subj, data))
+			destination, operation := natsmetrics.PublishLabelsFromSubject(subj)
+			publishMetrics.Attempt(ctx, destination, operation, err)
+			if err != nil {
 				return fmt.Errorf("publish core to %q: %w", subj, err)
 			}
 			return nil
@@ -283,7 +293,7 @@ func main() {
 
 	// Bound in-flight handlers so a burst is shed at the door (ErrUnavailable)
 	// instead of piling unbounded work onto MongoDB. MAX_CONCURRENCY=0 disables.
-	routerOpts := []natsrouter.Option{natsrouter.WithSiteID(cfg.SiteID)}
+	routerOpts := []natsrouter.Option{natsrouter.WithSiteID(cfg.SiteID), natsrouter.WithMetrics(publishMetrics)}
 	if cfg.MaxConcurrency > 0 {
 		routerOpts = append(routerOpts, natsrouter.WithMaxConcurrency(cfg.MaxConcurrency))
 	}

--- a/room-service/memberlist_client.go
+++ b/room-service/memberlist_client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/subject"
 )
@@ -30,13 +31,32 @@ type MemberListClient interface {
 type natsMemberListClient struct {
 	nc      *nats.Conn
 	timeout time.Duration
+	metrics requestRecorder
+}
+
+type requestRecorder interface {
+	Request(context.Context, natsmetrics.Operation, time.Duration, error)
+}
+
+type memberListClientOption func(*natsMemberListClient)
+
+func withMemberListRequestRecorder(metrics requestRecorder) memberListClientOption {
+	return func(c *natsMemberListClient) { c.metrics = metrics }
+}
+
+func withMemberListMetrics(metrics natsmetrics.Publisher) memberListClientOption {
+	return withMemberListRequestRecorder(metrics)
 }
 
 // NewNATSMemberListClient creates a NATS-backed MemberListClient. Returns the
 // concrete type so future struct-only methods don't require widening the
 // MemberListClient interface ("accept interfaces, return structs").
-func NewNATSMemberListClient(nc *nats.Conn, timeout time.Duration) *natsMemberListClient {
-	return &natsMemberListClient{nc: nc, timeout: timeout}
+func NewNATSMemberListClient(nc *nats.Conn, timeout time.Duration, opts ...memberListClientOption) *natsMemberListClient {
+	c := &natsMemberListClient{nc: nc, timeout: timeout}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // ListMembers fetches members from a remote or same-site room via NATS request.
@@ -57,7 +77,11 @@ func (c *natsMemberListClient) ListMembers(ctx context.Context, requester string
 	// natsutil.NewMsg forwards the X-Request-ID from ctx for trace correlation;
 	// the remote member.list endpoint mints one (RequestID middleware) if absent.
 	out := natsutil.NewMsg(reqCtx, subject.MemberList(requester, ch.RoomID, ch.SiteID), body)
+	started := time.Now()
 	reply, err := c.nc.RequestMsgWithContext(reqCtx, out)
+	if c.metrics != nil {
+		c.metrics.Request(ctx, natsmetrics.OperationMemberRead, time.Since(started), err)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("member.list request to %s: %w", ch.SiteID, err)
 	}

--- a/room-service/memberlist_client.go
+++ b/room-service/memberlist_client.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -79,9 +80,19 @@ func (c *natsMemberListClient) ListMembers(ctx context.Context, requester string
 	out := natsutil.NewMsg(reqCtx, subject.MemberList(requester, ch.RoomID, ch.SiteID), body)
 	started := time.Now()
 	defer func() {
-		if c.metrics != nil {
-			c.metrics.Request(ctx, natsmetrics.OperationMemberRead, time.Since(started), resultErr)
+		if c.metrics == nil {
+			return
 		}
+		// A remote "not a room member" is a complete answer from a healthy peer:
+		// the request/reply exchange worked. chat.nats.requests carries a
+		// transport-shaped outcome enum, so counting a business rejection there
+		// lands it in other_error and leaves the family non-zero at baseline.
+		// GetMessageReadMeta already excludes its CodeNotFound the same way.
+		outcome := resultErr
+		if errors.Is(outcome, errNotRoomMember) {
+			outcome = nil
+		}
+		c.metrics.Request(ctx, natsmetrics.OperationMemberRead, time.Since(started), outcome)
 	}()
 	reply, err := c.nc.RequestMsgWithContext(reqCtx, out)
 	if err != nil {

--- a/room-service/memberlist_client.go
+++ b/room-service/memberlist_client.go
@@ -60,7 +60,7 @@ func NewNATSMemberListClient(nc *nats.Conn, timeout time.Duration, opts ...membe
 }
 
 // ListMembers fetches members from a remote or same-site room via NATS request.
-func (c *natsMemberListClient) ListMembers(ctx context.Context, requester string, ch model.ChannelRef, limit int) ([]model.RoomMember, error) {
+func (c *natsMemberListClient) ListMembers(ctx context.Context, requester string, ch model.ChannelRef, limit int) (members []model.RoomMember, resultErr error) {
 	req := model.ListRoomMembersRequest{}
 	if limit > 0 {
 		req.Limit = &limit
@@ -78,10 +78,12 @@ func (c *natsMemberListClient) ListMembers(ctx context.Context, requester string
 	// the remote member.list endpoint mints one (RequestID middleware) if absent.
 	out := natsutil.NewMsg(reqCtx, subject.MemberList(requester, ch.RoomID, ch.SiteID), body)
 	started := time.Now()
+	defer func() {
+		if c.metrics != nil {
+			c.metrics.Request(ctx, natsmetrics.OperationMemberRead, time.Since(started), resultErr)
+		}
+	}()
 	reply, err := c.nc.RequestMsgWithContext(reqCtx, out)
-	if c.metrics != nil {
-		c.metrics.Request(ctx, natsmetrics.OperationMemberRead, time.Since(started), err)
-	}
 	if err != nil {
 		return nil, fmt.Errorf("member.list request to %s: %w", ch.SiteID, err)
 	}

--- a/room-service/memberlist_client_test.go
+++ b/room-service/memberlist_client_test.go
@@ -287,3 +287,30 @@ func TestNATSMemberListClient_ContextCancellation(t *testing.T) {
 	assert.True(t, errors.Is(err, context.Canceled), "expected context.Canceled, got %v", err)
 	assert.Contains(t, err.Error(), "member.list request to site-us")
 }
+
+// TestNATSMemberListClient_NotRoomMemberIsNotARequestFailure pins the metric
+// semantics for a business rejection. "You are not a member" is a complete,
+// well-formed answer from a healthy remote — the request/reply exchange
+// succeeded. Counting it as a failed request puts chat_nats_requests into the
+// transport-shaped other_error bucket at baseline and makes the family
+// unusable as a failure signal, which is the same rule GetMessageReadMeta
+// already follows for CodeNotFound.
+func TestNATSMemberListClient_NotRoomMemberIsNotARequestFailure(t *testing.T) {
+	nc := startInProcessNATS(t)
+	ch := model.ChannelRef{RoomID: "room-eng", SiteID: "site-us"}
+	requester := "alice"
+
+	sub, err := nc.Subscribe(subject.MemberList(requester, ch.RoomID, ch.SiteID), func(m *nats.Msg) {
+		_ = m.Respond([]byte(`{"code":"forbidden","reason":"not_room_member","error":"only room members can perform this action"}`))
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	recorder := NewMockrequestRecorder(gomock.NewController(t))
+	recorder.EXPECT().Request(gomock.Any(), natsmetrics.OperationMemberRead, gomock.Any(), gomock.Nil())
+	client := NewNATSMemberListClient(nc, 2*time.Second, withMemberListRequestRecorder(recorder))
+
+	_, err = client.ListMembers(context.Background(), requester, ch, 0)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errNotRoomMember))
+}

--- a/room-service/memberlist_client_test.go
+++ b/room-service/memberlist_client_test.go
@@ -14,8 +14,23 @@ import (
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/subject"
 )
+
+type recordedRequest struct {
+	operation natsmetrics.Operation
+	duration  time.Duration
+	err       error
+}
+
+type recordingRequests struct {
+	requests []recordedRequest
+}
+
+func (r *recordingRequests) Request(_ context.Context, operation natsmetrics.Operation, duration time.Duration, err error) {
+	r.requests = append(r.requests, recordedRequest{operation: operation, duration: duration, err: err})
+}
 
 func startInProcessNATS(t *testing.T) *nats.Conn {
 	t.Helper()
@@ -55,6 +70,27 @@ func TestNATSMemberListClient_HappyPath(t *testing.T) {
 	got, err := client.ListMembers(context.Background(), requester, ch, 0)
 	require.NoError(t, err)
 	assert.Equal(t, members, got)
+}
+
+func TestNATSMemberListClient_RecordsBoundedRequestResult(t *testing.T) {
+	nc := startInProcessNATS(t)
+	recorder := &recordingRequests{}
+	client := NewNATSMemberListClient(nc, 2*time.Second, withMemberListRequestRecorder(recorder))
+	ch := model.ChannelRef{RoomID: "room-eng", SiteID: "site-us"}
+
+	sub, err := nc.Subscribe(subject.MemberList("alice", ch.RoomID, ch.SiteID), func(m *nats.Msg) {
+		data, _ := json.Marshal(model.ListRoomMembersResponse{})
+		_ = m.Respond(data)
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	_, err = client.ListMembers(context.Background(), "alice", ch, 0)
+	require.NoError(t, err)
+	require.Len(t, recorder.requests, 1)
+	assert.Equal(t, natsmetrics.OperationMemberRead, recorder.requests[0].operation)
+	assert.GreaterOrEqual(t, recorder.requests[0].duration, time.Duration(0))
+	assert.NoError(t, recorder.requests[0].err)
 }
 
 func TestNATSMemberListClient_RemoteError(t *testing.T) {

--- a/room-service/memberlist_client_test.go
+++ b/room-service/memberlist_client_test.go
@@ -11,26 +11,13 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/subject"
 )
-
-type recordedRequest struct {
-	operation natsmetrics.Operation
-	duration  time.Duration
-	err       error
-}
-
-type recordingRequests struct {
-	requests []recordedRequest
-}
-
-func (r *recordingRequests) Request(_ context.Context, operation natsmetrics.Operation, duration time.Duration, err error) {
-	r.requests = append(r.requests, recordedRequest{operation: operation, duration: duration, err: err})
-}
 
 func startInProcessNATS(t *testing.T) *nats.Conn {
 	t.Helper()
@@ -74,7 +61,11 @@ func TestNATSMemberListClient_HappyPath(t *testing.T) {
 
 func TestNATSMemberListClient_RecordsBoundedRequestResult(t *testing.T) {
 	nc := startInProcessNATS(t)
-	recorder := &recordingRequests{}
+	recorder := NewMockrequestRecorder(gomock.NewController(t))
+	recorder.EXPECT().Request(gomock.Any(), natsmetrics.OperationMemberRead, gomock.Any(), gomock.Nil()).
+		Do(func(_ context.Context, _ natsmetrics.Operation, duration time.Duration, _ error) {
+			assert.GreaterOrEqual(t, duration, time.Duration(0))
+		})
 	client := NewNATSMemberListClient(nc, 2*time.Second, withMemberListRequestRecorder(recorder))
 	ch := model.ChannelRef{RoomID: "room-eng", SiteID: "site-us"}
 
@@ -87,10 +78,37 @@ func TestNATSMemberListClient_RecordsBoundedRequestResult(t *testing.T) {
 
 	_, err = client.ListMembers(context.Background(), "alice", ch, 0)
 	require.NoError(t, err)
-	require.Len(t, recorder.requests, 1)
-	assert.Equal(t, natsmetrics.OperationMemberRead, recorder.requests[0].operation)
-	assert.GreaterOrEqual(t, recorder.requests[0].duration, time.Duration(0))
-	assert.NoError(t, recorder.requests[0].err)
+}
+
+func TestNATSMemberListClient_RecordsFinalRequestFailure(t *testing.T) {
+	tests := []struct {
+		name     string
+		response []byte
+	}{
+		{name: "remote errcode", response: []byte(`{"code":"not_found","error":"room not found"}`)},
+		{name: "invalid JSON", response: []byte(`{not json`)},
+		{name: "no responder"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nc := startInProcessNATS(t)
+			ch := model.ChannelRef{RoomID: "room-eng", SiteID: "site-us"}
+			if tt.response != nil {
+				sub, err := nc.Subscribe(subject.MemberList("alice", ch.RoomID, ch.SiteID), func(m *nats.Msg) {
+					_ = m.Respond(tt.response)
+				})
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = sub.Unsubscribe() })
+			}
+			recorder := NewMockrequestRecorder(gomock.NewController(t))
+			recorder.EXPECT().Request(gomock.Any(), natsmetrics.OperationMemberRead, gomock.Any(), gomock.Not(gomock.Nil()))
+			client := NewNATSMemberListClient(nc, 2*time.Second, withMemberListRequestRecorder(recorder))
+
+			_, err := client.ListMembers(context.Background(), "alice", ch, 0)
+
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestNATSMemberListClient_RemoteError(t *testing.T) {

--- a/room-service/mock_memberlist_client_test.go
+++ b/room-service/mock_memberlist_client_test.go
@@ -12,8 +12,10 @@ package main
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	model "github.com/hmchangw/chat/pkg/model"
+	natsmetrics "github.com/hmchangw/chat/pkg/natsmetrics"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -54,4 +56,40 @@ func (m *MockMemberListClient) ListMembers(ctx context.Context, requester string
 func (mr *MockMemberListClientMockRecorder) ListMembers(ctx, requester, ch, limit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMembers", reflect.TypeOf((*MockMemberListClient)(nil).ListMembers), ctx, requester, ch, limit)
+}
+
+// MockrequestRecorder is a mock of requestRecorder interface.
+type MockrequestRecorder struct {
+	ctrl     *gomock.Controller
+	recorder *MockrequestRecorderMockRecorder
+	isgomock struct{}
+}
+
+// MockrequestRecorderMockRecorder is the mock recorder for MockrequestRecorder.
+type MockrequestRecorderMockRecorder struct {
+	mock *MockrequestRecorder
+}
+
+// NewMockrequestRecorder creates a new mock instance.
+func NewMockrequestRecorder(ctrl *gomock.Controller) *MockrequestRecorder {
+	mock := &MockrequestRecorder{ctrl: ctrl}
+	mock.recorder = &MockrequestRecorderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockrequestRecorder) EXPECT() *MockrequestRecorderMockRecorder {
+	return m.recorder
+}
+
+// Request mocks base method.
+func (m *MockrequestRecorder) Request(arg0 context.Context, arg1 natsmetrics.Operation, arg2 time.Duration, arg3 error) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Request", arg0, arg1, arg2, arg3)
+}
+
+// Request indicates an expected call of Request.
+func (mr *MockrequestRecorderMockRecorder) Request(arg0, arg1, arg2, arg3 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Request", reflect.TypeOf((*MockrequestRecorder)(nil).Request), arg0, arg1, arg2, arg3)
 }

--- a/room-service/reader_history.go
+++ b/room-service/reader_history.go
@@ -58,17 +58,19 @@ type getMessageByIDRequest struct {
 // errcode.Unavailable so read receipts fail soft instead of erroring hard.
 func (r *historyMessageReader) GetMessageReadMeta(
 	ctx context.Context, account, roomID, messageID string,
-) (MessageReadMeta, bool, error) {
+) (meta MessageReadMeta, found bool, resultErr error) {
 	reqBytes, err := json.Marshal(getMessageByIDRequest{MessageID: messageID})
 	if err != nil {
 		return MessageReadMeta{}, false, fmt.Errorf("marshal get-message request: %w", err)
 	}
 
 	started := time.Now()
+	defer func() {
+		if r.metrics != nil {
+			r.metrics.Request(ctx, natsmetrics.OperationHistoryGetMessage, time.Since(started), resultErr)
+		}
+	}()
 	msg, err := r.nc.Request(ctx, subject.MsgGet(account, roomID, r.siteID), reqBytes, historyRequestTimeout)
-	if r.metrics != nil {
-		r.metrics.Request(ctx, natsmetrics.OperationHistoryGetMessage, time.Since(started), err)
-	}
 	if err != nil {
 		return MessageReadMeta{}, false, errcode.Unavailable("read receipts are temporarily unavailable",
 			errcode.WithReason(errcode.RoomReadReceiptsUnavailable),

--- a/room-service/reader_history.go
+++ b/room-service/reader_history.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model/cassandra"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/subject"
 )
 
@@ -21,12 +22,27 @@ const historyRequestTimeout = 2 * time.Second
 // read-receipt lookup through it lets room-service drop its direct Cassandra
 // dependency entirely.
 type historyMessageReader struct {
-	nc     *o11ynats.Conn
-	siteID string
+	nc      *o11ynats.Conn
+	siteID  string
+	metrics requestRecorder
 }
 
-func newHistoryMessageReader(nc *o11ynats.Conn, siteID string) *historyMessageReader {
-	return &historyMessageReader{nc: nc, siteID: siteID}
+type historyReaderOption func(*historyMessageReader)
+
+func withHistoryRequestRecorder(metrics requestRecorder) historyReaderOption {
+	return func(r *historyMessageReader) { r.metrics = metrics }
+}
+
+func withHistoryMetrics(metrics natsmetrics.Publisher) historyReaderOption {
+	return withHistoryRequestRecorder(metrics)
+}
+
+func newHistoryMessageReader(nc *o11ynats.Conn, siteID string, opts ...historyReaderOption) *historyMessageReader {
+	r := &historyMessageReader{nc: nc, siteID: siteID}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }
 
 // getMessageByIDRequest mirrors history-service's GetMessageByIDRequest wire
@@ -48,7 +64,11 @@ func (r *historyMessageReader) GetMessageReadMeta(
 		return MessageReadMeta{}, false, fmt.Errorf("marshal get-message request: %w", err)
 	}
 
+	started := time.Now()
 	msg, err := r.nc.Request(ctx, subject.MsgGet(account, roomID, r.siteID), reqBytes, historyRequestTimeout)
+	if r.metrics != nil {
+		r.metrics.Request(ctx, natsmetrics.OperationHistoryGetMessage, time.Since(started), err)
+	}
 	if err != nil {
 		return MessageReadMeta{}, false, errcode.Unavailable("read receipts are temporarily unavailable",
 			errcode.WithReason(errcode.RoomReadReceiptsUnavailable),

--- a/room-service/reader_history_test.go
+++ b/room-service/reader_history_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model/cassandra"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/subject"
 )
 
@@ -31,6 +32,25 @@ func startOtelNATS(t *testing.T) *o11ynats.Conn {
 	require.NoError(t, err)
 	t.Cleanup(nc.Close)
 	return nc
+}
+
+func TestHistoryMessageReader_RecordsBoundedRequestResult(t *testing.T) {
+	nc := startOtelNATS(t)
+	recorder := &recordingRequests{}
+	const siteID = "site-a"
+	_, err := nc.Subscribe(context.Background(), subject.MsgGet("alice", "room-a", siteID), func(_ context.Context, m *nats.Msg) {
+		data, _ := json.Marshal(cassandra.Message{RoomID: "room-a", CreatedAt: time.Now(), Sender: cassandra.Participant{Account: "alice"}})
+		_ = m.Respond(data)
+	})
+	require.NoError(t, err)
+
+	r := newHistoryMessageReader(nc, siteID, withHistoryRequestRecorder(recorder))
+	_, _, err = r.GetMessageReadMeta(context.Background(), "alice", "room-a", "message-a")
+	require.NoError(t, err)
+	require.Len(t, recorder.requests, 1)
+	assert.Equal(t, natsmetrics.OperationHistoryGetMessage, recorder.requests[0].operation)
+	assert.GreaterOrEqual(t, recorder.requests[0].duration, time.Duration(0))
+	assert.NoError(t, recorder.requests[0].err)
 }
 
 func TestHistoryMessageReader_GetMessageReadMeta(t *testing.T) {

--- a/room-service/reader_history_test.go
+++ b/room-service/reader_history_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace/noop"
+	"go.uber.org/mock/gomock"
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model/cassandra"
@@ -36,7 +37,11 @@ func startOtelNATS(t *testing.T) *o11ynats.Conn {
 
 func TestHistoryMessageReader_RecordsBoundedRequestResult(t *testing.T) {
 	nc := startOtelNATS(t)
-	recorder := &recordingRequests{}
+	recorder := NewMockrequestRecorder(gomock.NewController(t))
+	recorder.EXPECT().Request(gomock.Any(), natsmetrics.OperationHistoryGetMessage, gomock.Any(), gomock.Nil()).
+		Do(func(_ context.Context, _ natsmetrics.Operation, duration time.Duration, _ error) {
+			assert.GreaterOrEqual(t, duration, time.Duration(0))
+		})
 	const siteID = "site-a"
 	_, err := nc.Subscribe(context.Background(), subject.MsgGet("alice", "room-a", siteID), func(_ context.Context, m *nats.Msg) {
 		data, _ := json.Marshal(cassandra.Message{RoomID: "room-a", CreatedAt: time.Now(), Sender: cassandra.Participant{Account: "alice"}})
@@ -47,10 +52,35 @@ func TestHistoryMessageReader_RecordsBoundedRequestResult(t *testing.T) {
 	r := newHistoryMessageReader(nc, siteID, withHistoryRequestRecorder(recorder))
 	_, _, err = r.GetMessageReadMeta(context.Background(), "alice", "room-a", "message-a")
 	require.NoError(t, err)
-	require.Len(t, recorder.requests, 1)
-	assert.Equal(t, natsmetrics.OperationHistoryGetMessage, recorder.requests[0].operation)
-	assert.GreaterOrEqual(t, recorder.requests[0].duration, time.Duration(0))
-	assert.NoError(t, recorder.requests[0].err)
+}
+
+func TestHistoryMessageReader_RecordsFinalRequestFailure(t *testing.T) {
+	tests := []struct {
+		name     string
+		response []byte
+	}{
+		{name: "invalid JSON", response: []byte(`not json`)},
+		{name: "no responder"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nc := startOtelNATS(t)
+			const siteID = "site-a"
+			if tt.response != nil {
+				_, err := nc.Subscribe(context.Background(), subject.MsgGet("alice", "room-a", siteID), func(_ context.Context, m *nats.Msg) {
+					_ = m.Respond(tt.response)
+				})
+				require.NoError(t, err)
+			}
+			recorder := NewMockrequestRecorder(gomock.NewController(t))
+			recorder.EXPECT().Request(gomock.Any(), natsmetrics.OperationHistoryGetMessage, gomock.Any(), gomock.Not(gomock.Nil()))
+			r := newHistoryMessageReader(nc, siteID, withHistoryRequestRecorder(recorder))
+
+			_, _, err := r.GetMessageReadMeta(context.Background(), "alice", "room-a", "message-a")
+
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestHistoryMessageReader_GetMessageReadMeta(t *testing.T) {

--- a/room-worker/config_test.go
+++ b/room-worker/config_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/caarlos0/env/v11"
@@ -46,4 +47,22 @@ func TestConfig_RoomSubjectMode(t *testing.T) {
 			assert.Equal(t, tc.want, mode)
 		})
 	}
+}
+
+func TestConfig_ServiceName(t *testing.T) {
+	t.Setenv("OTEL_SERVICE_NAME", "teams-room-worker")
+
+	cfg, err := env.ParseAs[config]()
+	require.NoError(t, err)
+	require.Equal(t, "teams-room-worker", cfg.ServiceName)
+}
+
+func TestDeploymentServiceNamesAreDistinct(t *testing.T) {
+	normal, err := os.ReadFile("deploy/docker-compose.yml")
+	require.NoError(t, err)
+	teams, err := os.ReadFile("deploy/teams/docker-compose.yml")
+	require.NoError(t, err)
+
+	require.True(t, strings.Contains(string(normal), "OTEL_SERVICE_NAME=room-worker"))
+	require.True(t, strings.Contains(string(teams), "OTEL_SERVICE_NAME=teams-room-worker"))
 }

--- a/room-worker/config_test.go
+++ b/room-worker/config_test.go
@@ -63,6 +63,21 @@ func TestDeploymentServiceNamesAreDistinct(t *testing.T) {
 	teams, err := os.ReadFile("deploy/teams/docker-compose.yml")
 	require.NoError(t, err)
 
-	require.True(t, strings.Contains(string(normal), "OTEL_SERVICE_NAME=room-worker"))
-	require.True(t, strings.Contains(string(teams), "OTEL_SERVICE_NAME=teams-room-worker"))
+	require.True(t, hasComposeEnvironmentEntry(string(normal), "OTEL_SERVICE_NAME=room-worker"))
+	require.True(t, hasComposeEnvironmentEntry(string(teams), "OTEL_SERVICE_NAME=teams-room-worker"))
+}
+
+func TestHasComposeEnvironmentEntry_RejectsCommentsAndSuffixes(t *testing.T) {
+	content := "    # - OTEL_SERVICE_NAME=room-worker\n    - OTEL_SERVICE_NAME=room-worker-canary\n"
+
+	assert.False(t, hasComposeEnvironmentEntry(content, "OTEL_SERVICE_NAME=room-worker"))
+}
+
+func hasComposeEnvironmentEntry(content, entry string) bool {
+	for line := range strings.SplitSeq(content, "\n") {
+		if strings.TrimSpace(line) == "- "+entry {
+			return true
+		}
+	}
+	return false
 }

--- a/room-worker/deploy/teams/docker-compose.yml
+++ b/room-worker/deploy/teams/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     pull_policy: build
     environment:
       - MODE=teams
-      - OTEL_SERVICE_NAME=room-worker
+      - OTEL_SERVICE_NAME=teams-room-worker
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4318}
       - NATS_URL=nats://nats:4222
       - NATS_CREDS_FILE=/etc/nats/backend.creds

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -2549,7 +2549,7 @@ func (h *Handler) fanOutKey(ctx context.Context, roomID string, accounts []strin
 				<-sem
 				wg.Done()
 			}()
-			if err := h.keySender.SendData(acct, data); err != nil {
+			if err := h.keySender.SendDataContext(ctx, acct, data); err != nil {
 				slog.ErrorContext(ctx, "send room key", "error", err, "account", acct, "roomId", roomID)
 				roomkeymetrics.FanoutErrors.Add(ctx, 1, metric.WithAttributes(attribute.String("roomId", roomID)))
 				failed.Add(1)

--- a/room-worker/main.go
+++ b/room-worker/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hmchangw/chat/pkg/logctx"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsrouter"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
@@ -34,6 +35,7 @@ type config struct {
 	// member/create/rename ops; "teams" runs the Teams-migration room-create batch
 	// off ROOMS-TEAMS. Two deploys of the same binary, gated by env only.
 	Mode              string                  `env:"MODE"            envDefault:"default"`
+	ServiceName       string                  `env:"OTEL_SERVICE_NAME" envDefault:"unknown-service"`
 	NatsURL           string                  `env:"NATS_URL"        envDefault:"nats://localhost:4222"`
 	NatsCredsFile     string                  `env:"NATS_CREDS_FILE" envDefault:""`
 	SiteID            string                  `env:"SITE_ID"         envDefault:"site-local"`
@@ -121,8 +123,10 @@ func main() {
 		slog.Error("init observability failed", "error", err)
 		os.Exit(1)
 	}
+	sharedMetrics := natsmetrics.NewFromProvider(sdk.MeterProvider())
+	publishMetrics := sharedMetrics.Publisher(cfg.ServiceName, cfg.SiteID)
 
-	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)
+	nc, err := natsutil.ConnectWithMetrics(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace, sdk.MeterProvider())
 	if err != nil {
 		slog.Error("nats connect failed", "error", err)
 		os.Exit(1)
@@ -159,7 +163,7 @@ func main() {
 		slog.Info("room-meta L2 invalidation enabled")
 	}
 
-	keySender := roomkeysender.NewSender(nc.NatsConn())
+	keySender := roomkeysender.NewSender(nc.NatsConn(), roomkeysender.WithMetrics(publishMetrics))
 
 	// Eager at-rest DEK provisioning for synchronously-created DM rooms (the
 	// serverCreateDM path bypasses room-service's create-room flow). nil when
@@ -212,13 +216,19 @@ func main() {
 		msg := natsutil.NewMsg(ctx, subj, data)
 		if msgID == "" {
 			// Ephemeral client-delivery — core NATS, not persisted.
-			if err := nc.PublishMsg(ctx, msg); err != nil {
+			err := nc.PublishMsg(ctx, msg)
+			destination, operation := natsmetrics.PublishLabelsFromSubject(subj)
+			publishMetrics.Attempt(ctx, destination, operation, err)
+			if err != nil {
 				return fmt.Errorf("publish to %q: %w", subj, err)
 			}
 			return nil
 		}
 		// JetStream-backed (MESSAGES-CANONICAL, INBOX) — block on PubAck; server honors Nats-Msg-Id for dedup.
-		if _, err := js.PublishMsg(ctx, msg, jetstream.WithMsgID(msgID)); err != nil {
+		_, err := js.PublishMsg(ctx, msg, jetstream.WithMsgID(msgID))
+		destination, operation := natsmetrics.PublishLabelsFromSubject(subj)
+		publishMetrics.Attempt(ctx, destination, operation, err)
+		if err != nil {
 			return fmt.Errorf("publish to %q: %w", subj, err)
 		}
 		return nil
@@ -231,7 +241,11 @@ func main() {
 		if err != nil {
 			return fmt.Errorf("marshal user identity fanout: %w", err)
 		}
-		if _, err := js.PublishMsg(ctx, natsutil.NewMsg(ctx, subject.OrgSyncUsersUpsert(cfg.SiteID), data)); err != nil {
+		subj := subject.OrgSyncUsersUpsert(cfg.SiteID)
+		_, err = js.PublishMsg(ctx, natsutil.NewMsg(ctx, subj, data))
+		destination, operation := natsmetrics.PublishLabelsFromSubject(subj)
+		publishMetrics.Attempt(ctx, destination, operation, err)
+		if err != nil {
 			return fmt.Errorf("publish user identity fanout: %w", err)
 		}
 		return nil
@@ -240,45 +254,41 @@ func main() {
 	handler.valkey = metaValkey
 	handler.reconcileTTL = cfg.MemberCountReconcileTTL
 
-	router := natsrouter.New(nc, "room-worker", natsrouter.WithSiteID(cfg.SiteID))
+	router := natsrouter.New(nc, "room-worker", natsrouter.WithSiteID(cfg.SiteID), natsrouter.WithMetrics(publishMetrics))
 	router.Use(natsrouter.Recovery(), natsrouter.RequestID(), natsrouter.Logging())
 	natsrouter.Register(router, subject.RoomCreateDMSync(cfg.SiteID), handler.serverCreateDM)
 
-	sem := make(chan struct{}, cfg.MaxWorkers)
 	var wg sync.WaitGroup
-
-	cons, err := js.CreateOrUpdateConsumer(ctx, streamCfg.Name, buildConsumerConfig(cfg.Consumer, cfg.Mode))
-	if err != nil {
-		slog.Error("create consumer failed", "error", err)
-		os.Exit(1)
-	}
-
-	iter, err := cons.Messages(ctx, jetstream.PullMaxMessages(2*cfg.MaxWorkers))
-	if err != nil {
-		slog.Error("messages failed", "error", err)
-		os.Exit(1)
-	}
-
-	go func() {
-		for {
-			msgCtx, msg, err := iter.Next()
-			if err != nil {
-				return
-			}
-			sem <- struct{}{}
-			wg.Add(1)
-			go func() {
-				// runJobWithRecovery contains handler panics (it Acks — drops — the
-				// poison message) so this async goroutine, which runs outside
-				// natsrouter's recovery middleware, can't crash the worker.
-				defer func() {
-					<-sem
-					wg.Done()
-				}()
-				runJobWithRecovery(msgCtx, handler, msg)
-			}()
+	consumerCfg := buildConsumerConfig(cfg.Consumer, cfg.Mode)
+	consumerMetrics := sharedMetrics.Consumer(natsmetrics.ConsumerConfig{
+		ServiceName: cfg.ServiceName, Site: cfg.SiteID,
+		Stream: streamCfg.Name, Consumer: consumerCfg.Durable,
+	})
+	supervisor := natsmetrics.NewSupervisor(natsmetrics.SupervisorConfig{})
+	iteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+		cons, err := js.CreateOrUpdateConsumer(factoryCtx, streamCfg.Name, consumerCfg)
+		if err != nil {
+			return nil, fmt.Errorf("create consumer: %w", err)
 		}
-	}()
+		iter, err := cons.Messages(factoryCtx, jetstream.PullMaxMessages(2*cfg.MaxWorkers))
+		if err != nil {
+			return nil, fmt.Errorf("create iterator: %w", err)
+		}
+		return iter, nil
+	}
+	if err := supervisor.Start(ctx, iteratorFactory, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
+		func(msg jetstream.Msg) natsmetrics.EventType {
+			return natsmetrics.RoomEventTypeFromSubject(msg.Subject())
+		},
+		func(msgCtx context.Context, msg *natsmetrics.Message) {
+			// runJobWithRecovery contains handler panics (it Acks — drops — the
+			// poison message) so this async goroutine, which runs outside
+			// natsrouter's recovery middleware, can't crash the worker.
+			runJobWithRecovery(msgCtx, handler, msg)
+		}); err != nil {
+		slog.Error("start consumer supervisor failed", "error", err)
+		os.Exit(1)
+	}
 
 	healthStop, err := health.ServeWithPprof(cfg.HealthAddr, 5*time.Second, cfg.PProfEnabled,
 		natsutil.HealthCheck(nc),
@@ -294,8 +304,8 @@ func main() {
 	// THEN flush observability exporters. Reverse order drops traces/metrics
 	// emitted during NATS drain, mongo disconnect, and keyStore close.
 	hooks := []func(ctx context.Context) error{
-		func(ctx context.Context) error {
-			iter.Stop()
+		func(context.Context) error {
+			supervisor.Stop()
 			return nil
 		},
 		func(ctx context.Context) error {

--- a/room-worker/main.go
+++ b/room-worker/main.go
@@ -265,7 +265,7 @@ func main() {
 		Stream: streamCfg.Name, Consumer: consumerCfg.Durable,
 	})
 	supervisor := natsmetrics.NewSupervisor(natsmetrics.SupervisorConfig{})
-	iteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+	initialIteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
 		cons, err := js.CreateOrUpdateConsumer(factoryCtx, streamCfg.Name, consumerCfg)
 		if err != nil {
 			return nil, fmt.Errorf("create consumer: %w", err)
@@ -276,7 +276,19 @@ func main() {
 		}
 		return iter, nil
 	}
-	if err := supervisor.Start(ctx, iteratorFactory, consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
+	recoveryIteratorFactory := func(factoryCtx context.Context) (natsmetrics.Iterator, error) {
+		cons, err := js.Consumer(factoryCtx, streamCfg.Name, consumerCfg.Durable)
+		if err != nil {
+			return nil, fmt.Errorf("lookup consumer: %w", err)
+		}
+		iter, err := cons.Messages(factoryCtx, jetstream.PullMaxMessages(2*cfg.MaxWorkers))
+		if err != nil {
+			return nil, fmt.Errorf("create recovery iterator: %w", err)
+		}
+		return iter, nil
+	}
+	if err := supervisor.StartWithRecovery(ctx, initialIteratorFactory, recoveryIteratorFactory,
+		consumerMetrics, cfg.MaxWorkers, consumerCfg.MaxDeliver, &wg,
 		func(msg jetstream.Msg) natsmetrics.EventType {
 			return natsmetrics.RoomEventTypeFromSubject(msg.Subject())
 		},


### PR DESCRIPTION
## Summary

- expand the application-side NATS/JetStream failure evidence from the original four workers to the first single-site room/member campaign: `message-gatekeeper`, `message-worker`, `broadcast-worker`, `notification-worker`, `history-service`, `room-service`, and `room-worker`
- supervise every long-running pull iterator, including notification invalidation, with bounded lookup-only recovery backoff, single-iterator ownership, cancellation-aware shutdown, and recovery metrics
- add bounded inbound request/reply result and duration metrics at the opt-in `natsrouter` boundary, plus bounded outbound request and Core NATS/JetStream publish-attempt evidence for history and room paths
- derive metric `service_name` from `OTEL_SERVICE_NAME`, with distinct normal, bot, and Teams deployment identities and stable instrumentation scopes
- document the new metric families, closed label sets, and consumer-recovery semantics in the o11y inventory

This combines P0-2 and P0-4 for the first single-site failure-readiness round. It intentionally does not add load-generator room/member workloads, dashboards, federation traffic, push traffic, WSS simulation, broker/exporter metrics, or new business retry policies.

Consumer supervision observes and recovers transport failures without changing handler-owned Ack, Nak, Term, redelivery, or publish-retry behavior. A recoverable terminal iterator failure marks the loop down and records bounded terminal evidence; recovery then looks up the existing durable and recreates only its iterator with capped exponential backoff that grows across iterator generations which fail before receiving a message. A successful delivery resets the backoff. A missing or deleted durable is terminal and is never auto-created during recovery because its server-side cursor no longer exists; this prevents `DeliverAllPolicy` replay and `DeliverNewPolicy` data loss even when a concurrent connection outage masks the deletion from the old iterator. Recovery does not intentionally trigger a liveness restart. Shutdown cancels retries, stops the active iterator, and preserves the existing in-flight wait and NATS drain order.

## TDD evidence

Red was captured before each implementation slice:

- supervisor tests initially failed to compile because `NewSupervisor`, `SupervisorConfig`, and recovery-result metrics did not exist
- identity tests initially failed because the affected configs did not expose `OTEL_SERVICE_NAME`
- bounded room/history classification tests initially failed because the closed operations and subject classifiers did not exist
- notification invalidation tests initially failed before the handler was extracted into a testable function
- router tests initially failed because the opt-in metrics boundary did not exist
- history publisher and room outbound-client tests initially failed before their opt-in metrics options existed
- room-key publish tests initially failed before `WithMetrics` and `SendDataContext` existed

Green/refactor coverage includes terminal iterator failure, recreation failure and capped backoff, successful recovery, cancellation, duplicate-start rejection, in-flight shutdown waiting, invalidation dispositions, service identity, and bounded dynamic-subject labels.

Review follow-up Red tests reproduced deleted-durable recreation, asynchronous startup failure, floor-only iterator-flap backoff, the missing `msg.thread.parent` classification, and dynamic `msg`/`teams` token collisions before the fixes. A second Red test reproduced the residual transport-loss race: the initial iterator returned `ErrConnectionClosed`, recovery lookup returned wrapped `ErrConsumerNotFound`, and the test required the supervisor to stop without invoking the create-or-update factory or retrying the missing durable.

## Review follow-up (2026-08-16)

- wrapped the message-gatekeeper delivery callback with `jobguard.Run`, with a regression test proving a panicking poison message is Acked instead of crashing the process
- moved room-service member-list and history-reader request metrics to deferred final-result recording, covering transport, remote errcode, and decode failures without false-success series
- changed room/inbox publish classification to fixed event-token positions so dynamic site IDs cannot mint the wrong bounded operation
- made void-handler logs context-aware and made the asynchronous router metric test wait for deferred recording
- added invalidation Ack-error, room-key publish-error, exact Compose identity, and generated request-recorder mock coverage
- clarified that `service_name` and `site` are deployment identity dimensions and documented the per-recovery `js.Consumer` lookup that precedes iterator creation

Red evidence reproduced the missing gatekeeper guard as a compile failure, the dynamic-site classifier returning `member_publish` for room events, and the stale generated request-recorder mock before implementation and regeneration. Focused race-enabled tests passed after the fixes.
## Validation

- rebased onto `origin/main` at `c2de0ba2`
- `make fmt`
- `make lint`
- `make test`
- focused race-enabled `make test SERVICE=...` runs for all seven services plus `pkg/natsmetrics`, `pkg/natsrouter`, and `pkg/roomkeysender`
- integration-tagged tests for message-gatekeeper, message-worker, broadcast-worker, notification-worker, room-worker, history-service, room-service, and pkg/natsrouter
- `make sast` (`gosec`, `govulncheck`, and Semgrep all passed; no reachable vulnerabilities or findings)
- `make benchmark-natsmetrics`

Benchmark snapshot on Windows/amd64, AMD Ryzen 9 9950X:

```text
BenchmarkConsumer_Track/first_delivery-32    39.70 ns/op    128 B/op    1 allocs/op
BenchmarkConsumer_Track/redelivery-32        55.53 ns/op    144 B/op    2 allocs/op
BenchmarkMessage_Context-32                  22.81 ns/op     48 B/op    1 allocs/op
```

## Coverage status

The changed reusable packages satisfy the repository threshold:

- `pkg/natsmetrics`: 89.43%
- `pkg/natsrouter`: 91.59%
- `pkg/roomkeysender`: 91.30%
- `history-service/internal/publisher`: 83.3%
- `history-service/internal/config`: 93.1%

The integration-tagged full-service package baselines are still below the nominal 80% policy in several pre-existing `package main`/adapter surfaces (`history-service/cmd` 0.0%, `message-gatekeeper` 64.2%, `message-worker` 71.7%, `broadcast-worker` 70.0%, `notification-worker` 63.6%, `room-worker` 77.0%, and `room-service` 79.1%). `history-service/internal/mongorepo` is also 74.0%. The implementation and tests pass, but this policy gap remains explicit; the PR stays draft pending a decision to expand test scope or accept separate baseline remediation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive NATS and request metrics, including publish outcomes, request results, recovery activity, and processing durations.
  * Added configurable OpenTelemetry service names through `OTEL_SERVICE_NAME`.
  * Added automatic consumer recovery, coordinated shutdown, and context-aware publishing.
  * Added room invalidation processing with malformed-message handling.
* **Bug Fixes**
  * Improved handling of deleted consumers, interrupted deliveries, failed requests, and publish errors.
  * Added safer processing when handlers panic or invalid messages are received.
* **Documentation**
  * Expanded observability metrics coverage and deployment guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->