### PR TITLE
feat(mongoutil): let online services boot during a MongoDB outage

### DIFF
--- a/admin-service/main.go
+++ b/admin-service/main.go
@@ -55,12 +55,12 @@ func run() error {
 
 	db := mongoClient.Database(cfg.MongoDB)
 	st := newStoreMongo(db)
-	if err := st.EnsureIndexes(ctx); err != nil {
-		return fmt.Errorf("ensure indexes: %w", err)
-	}
 	sessStore := session.NewMongoStore(db)
-	if err := sessStore.EnsureIndexes(ctx); err != nil {
-		return fmt.Errorf("ensure session indexes: %w", err)
+	if err := mongoutil.EnsureIndexes(ctx,
+		mongoutil.Step("admin-service store", st.EnsureIndexes),
+		mongoutil.Step("admin-service sessions", sessStore.EnsureIndexes),
+	); err != nil {
+		return fmt.Errorf("ensure indexes: %w", err)
 	}
 
 	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)

--- a/admin-service/main.go
+++ b/admin-service/main.go
@@ -47,7 +47,8 @@ func run() error {
 			"site", cfg.SiteID, "all_site_ids", cfg.AllSiteIDs)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithObservability(sdk), mongoutil.WithLazyConnect())
 	if err != nil {
 		return fmt.Errorf("connect mongo: %w", err)
 	}

--- a/bot-message-handler/main.go
+++ b/bot-message-handler/main.go
@@ -65,7 +65,8 @@ func run() error {
 		return fmt.Errorf("bootstrap streams: %w", err)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithObservability(sdk), mongoutil.WithLazyConnect())
 	if err != nil {
 		return fmt.Errorf("connect mongo: %w", err)
 	}

--- a/bot-message-worker/main.go
+++ b/bot-message-worker/main.go
@@ -98,7 +98,8 @@ func run() error {
 		if cfg.MongoURI == "" {
 			return fmt.Errorf("ATREST_ENABLED=true requires MONGO_URI for the DEK collection")
 		}
-		mc, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+		mc, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+			mongoutil.WithObservability(sdk), mongoutil.WithLazyConnect())
 		if err != nil {
 			return fmt.Errorf("connect mongo: %w", err)
 		}

--- a/bot-room-service/main.go
+++ b/bot-room-service/main.go
@@ -68,7 +68,8 @@ func run() error {
 		return fmt.Errorf("init jetstream: %w", err)
 	}
 
-	mc, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mc, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithObservability(sdk), mongoutil.WithLazyConnect())
 	if err != nil {
 		return fmt.Errorf("connect mongo: %w", err)
 	}

--- a/botplatform-service/handler.go
+++ b/botplatform-service/handler.go
@@ -52,12 +52,13 @@ func newHandler(s BotplatformStore, cfg *config) *handler {
 	}
 }
 
+// HandleHealth answers the liveness probe, which asks "is this process alive",
+// not "can it reach everything it needs". It deliberately checks nothing:
+// docs/health-probes.md says a dependency being down must never get the pod
+// restarted. That matters more now the service starts without waiting for
+// MongoDB — a health check that failed when MongoDB was down would have
+// Kubernetes restarting the pod through the very outage it can now survive.
 func (h *handler) HandleHealth(c *gin.Context) {
-	if err := h.store.Ping(c.Request.Context()); err != nil {
-		slog.WarnContext(c.Request.Context(), "healthz ping failed", "error", err)
-		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "down"})
-		return
-	}
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 

--- a/botplatform-service/handler_test.go
+++ b/botplatform-service/handler_test.go
@@ -89,22 +89,14 @@ func post(t *testing.T, r http.Handler, path string, body any) *httptest.Respons
 	return w
 }
 
+// TestHandleHealth pins liveness as dependency-free: a MongoDB outage must not
+// restart the pod, so /healthz answers 200 without touching the store.
 func TestHandleHealth(t *testing.T) {
-	r, st, _ := newTestRouter(t)
-	st.EXPECT().Ping(gomock.Any()).Return(nil)
+	r, _, _ := newTestRouter(t)
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
-}
-
-func TestHandleHealth_MongoDown(t *testing.T) {
-	r, st, _ := newTestRouter(t)
-	st.EXPECT().Ping(gomock.Any()).Return(errors.New("mongo down"))
-	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 }
 
 func TestHandleLogin_Bot_HappyPath(t *testing.T) {

--- a/botplatform-service/main.go
+++ b/botplatform-service/main.go
@@ -49,7 +49,8 @@ func run() error {
 		return fmt.Errorf("init observability: %w", err)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithObservability(sdk), mongoutil.WithLazyConnect())
 	if err != nil {
 		return fmt.Errorf("connect mongo: %w", err)
 	}

--- a/botplatform-service/main.go
+++ b/botplatform-service/main.go
@@ -57,8 +57,10 @@ func run() error {
 
 	db := mongoClient.Database(cfg.MongoDB)
 	sessionStore := session.NewMongoStore(db)
-	if err := sessionStore.EnsureIndexes(ctx); err != nil {
-		return fmt.Errorf("ensure session indexes: %w", err)
+	if err := mongoutil.EnsureIndexes(ctx,
+		mongoutil.Step("botplatform-service sessions", sessionStore.EnsureIndexes),
+	); err != nil {
+		return fmt.Errorf("ensure indexes: %w", err)
 	}
 	st := newStoreMongo(db)
 	subStore := newMongoSubscriptionStore(db)

--- a/botplatform-service/mock_store_test.go
+++ b/botplatform-service/mock_store_test.go
@@ -100,17 +100,3 @@ func (mr *MockBotplatformStoreMockRecorder) InsertSession(ctx, s any) *gomock.Ca
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertSession", reflect.TypeOf((*MockBotplatformStore)(nil).InsertSession), ctx, s)
 }
-
-// Ping mocks base method.
-func (m *MockBotplatformStore) Ping(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Ping", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Ping indicates an expected call of Ping.
-func (mr *MockBotplatformStoreMockRecorder) Ping(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockBotplatformStore)(nil).Ping), ctx)
-}

--- a/botplatform-service/store.go
+++ b/botplatform-service/store.go
@@ -30,7 +30,4 @@ type BotplatformStore interface {
 	// DeleteSessionsBeyondCap drops every session row for account beyond the
 	// `max` newest, ordered by issuedAt DESC. Returns the number deleted.
 	DeleteSessionsBeyondCap(ctx context.Context, account string, max int) (int64, error)
-
-	// Ping is the readiness probe target.
-	Ping(ctx context.Context) error
 }

--- a/botplatform-service/store_mongo.go
+++ b/botplatform-service/store_mongo.go
@@ -58,10 +58,3 @@ func (s *storeMongo) DeleteSessionsBeyondCap(ctx context.Context, account string
 	}
 	return s.sessions.DeleteBeyondCap(ctx, account, max)
 }
-
-func (s *storeMongo) Ping(ctx context.Context) error {
-	if err := s.users.Database().Client().Ping(ctx, nil); err != nil {
-		return fmt.Errorf("ping mongo: %w", err)
-	}
-	return nil
-}

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -136,7 +136,7 @@ func main() {
 		slog.Info("room-meta L2 cache enabled", "ttl", cfg.RoomMetaL2TTL)
 	}
 	store := NewMongoStore(db.Collection("rooms"), db.Collection("subscriptions"), db.Collection("thread_rooms"), metaValkey, cfg.RoomMetaL2TTL)
-	if err := store.EnsureIndexes(ctx); err != nil {
+	if err := mongoutil.EnsureIndexes(ctx, mongoutil.Step("broadcast-worker store", store.EnsureIndexes)); err != nil {
 		slog.Error("ensure indexes failed", "error", err)
 		os.Exit(1)
 	}

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -116,7 +116,7 @@ func main() {
 		os.Exit(1)
 	}
 	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
-		mongoutil.WithObservability(sdk), mongoutil.WithReadPreference(readPref))
+		mongoutil.WithObservability(sdk), mongoutil.WithReadPreference(readPref), mongoutil.WithLazyConnect())
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)

--- a/broadcast-worker/startup_resilience_integration_test.go
+++ b/broadcast-worker/startup_resilience_integration_test.go
@@ -1,0 +1,216 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
+	"github.com/hmchangw/chat/pkg/stream"
+	"github.com/hmchangw/chat/pkg/subject"
+	"github.com/hmchangw/chat/pkg/testutil"
+	"github.com/hmchangw/chat/pkg/userstore"
+)
+
+// TestStartup_ReachesServingStateWithMongoUnreachable walks the service's real
+// Mongo boot sequence with MongoDB down: connect, build the store, run the
+// index step. Before this change each of those steps killed the process; all
+// three must now complete so the worker can go on to consume from JetStream.
+func TestStartup_ReachesServingStateWithMongoUnreachable(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Gate 1: connect must not fail.
+	client, err := mongoutil.Connect(ctx, testutil.UnreachableMongoURI(t), "", "", mongoutil.WithLazyConnect())
+	require.NoError(t, err, "service must connect lazily while MongoDB is unreachable")
+	t.Cleanup(func() { mongoutil.Disconnect(context.Background(), client) })
+
+	db := client.Database("broadcast_worker_startup_test")
+	store := NewMongoStore(
+		db.Collection("rooms"),
+		db.Collection("subscriptions"),
+		db.Collection("thread_rooms"),
+		nil, // no Valkey L2 tier
+		time.Minute,
+	)
+	require.NotNil(t, store, "store must be constructible with MongoDB unreachable")
+
+	// Gate 2: an unreachable MongoDB is transient, so the index step must warn
+	// and report success, not hand the caller a reason to exit.
+	require.NoError(t,
+		mongoutil.EnsureIndexes(ctx, mongoutil.Step("broadcast-worker store", store.EnsureIndexes)),
+		"failed index creation must not stop startup")
+
+	// Serving state: the store answers requests with an error rather than
+	// hanging, so the consumer loop can Nak and retry instead of wedging.
+	opCtx, opCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer opCancel()
+	start := time.Now()
+	_, err = store.GetRoom(opCtx, "room-1")
+	elapsed := time.Since(start)
+
+	assert.Error(t, err, "reads must fail while MongoDB is unreachable")
+	assert.Less(t, elapsed, 8*time.Second, "reads must fail bounded, not hang")
+}
+
+// TestStartup_ConsumerRedeliversUntilMongoRecovers is the half that booting
+// during an outage is for. Reaching a serving state is worth nothing if the
+// consumer then mishandles the events it pulls, and the two ways to get that
+// wrong are both silent: Ack a message the store never processed (the event is
+// gone for good), or hot-loop Naks that burn MaxDeliver before MongoDB returns
+// (same outcome, slower). So this drives the worker's real consumer — the
+// production consumer config, broadcastProcessor, consumeLoop — against a
+// MongoDB that is down and then comes back, with no restart in between.
+func TestStartup_ConsumerRedeliversUntilMongoRecovers(t *testing.T) {
+	const siteID = "site-outage"
+	ctx := context.Background()
+
+	// Seed through a direct connection: the room has to exist for the post-
+	// recovery delivery to succeed, and the worker's own client cannot write it
+	// while the outage is on.
+	seed := testutil.MongoDB(t, "broadcast_worker_outage_test")
+	_, err := seed.Collection("rooms").InsertOne(ctx, model.Room{
+		ID: "r1", Name: "general", Type: model.RoomTypeChannel, UserCount: 2, SiteID: siteID,
+	})
+	require.NoError(t, err)
+	_, err = seed.Collection("subscriptions").InsertMany(ctx, []interface{}{
+		model.Subscription{ID: "s1", User: model.SubscriptionUser{ID: "u1", Account: "alice"}, RoomID: "r1"},
+		model.Subscription{ID: "s2", User: model.SubscriptionUser{ID: "u2", Account: "bob"}, RoomID: "r1"},
+	})
+	require.NoError(t, err)
+	seedUsers(t, seed)
+
+	// The worker reaches the same database through an endpoint that is down.
+	outage := testutil.NewMongoOutage(t, testutil.MongoURI(t))
+	client, err := mongoutil.Connect(ctx, outage.URI(), "", "", mongoutil.WithLazyConnect())
+	require.NoError(t, err, "worker must boot while MongoDB is unreachable")
+	t.Cleanup(func() { mongoutil.Disconnect(context.Background(), client) })
+
+	db := client.Database(seed.Name())
+	store := NewMongoStore(db.Collection("rooms"), db.Collection("subscriptions"), db.Collection("thread_rooms"), nil, 0)
+	pub := &recordingPublisher{}
+	handler := NewHandler(store, userstore.NewMongoStore(db.Collection("users")), pub, nil,
+		defaultParentFetcher, false, subject.RouteGlobal)
+
+	js, cons, iter, subj := startCanonicalConsumer(t, siteID)
+
+	// Count deliveries around the real processor rather than replacing it, so
+	// the Ack/Nak decision under test stays broadcastProcessor's.
+	var deliveries atomic.Int32
+	process := broadcastProcessor(handler)
+	counted := func(msgCtx context.Context, msg jetstream.Msg) {
+		deliveries.Add(1)
+		process(msgCtx, msg)
+	}
+
+	// The production composition: natsmetrics.Consume driving
+	// guardedProcessor(broadcastProcessor(…)), same as main.go wires.
+	metrics, _ := newTestBroadcastMetrics(t)
+	consumer := metrics.Consumer(natsmetrics.ConsumerConfig{
+		ServiceName: "broadcast-worker", Site: siteID,
+		Stream: stream.MessagesCanonical(siteID).Name, Consumer: "broadcast-worker",
+	})
+	consumer.LoopStarted(ctx)
+
+	var wg sync.WaitGroup
+	go natsmetrics.Consume(ctx, iter, consumer, 4, consumerMaxDeliver, &wg,
+		func(msg jetstream.Msg) natsmetrics.EventType { return natsmetrics.EventTypeFromSubject(msg.Subject()) },
+		guardedProcessor(counted))
+
+	evt := model.MessageEvent{
+		Event:  model.EventCreated,
+		SiteID: siteID,
+		Message: model.Message{
+			ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice", Content: "hello",
+			CreatedAt: time.Now().UTC().Truncate(time.Millisecond),
+		},
+	}
+	data, err := json.Marshal(evt)
+	require.NoError(t, err)
+	_, err = js.Publish(ctx, subj, data)
+	require.NoError(t, err)
+
+	// While MongoDB is down the event must come back. A second delivery proves
+	// the store failure was Nak'd rather than Acked away.
+	require.Eventually(t, func() bool { return deliveries.Load() >= 2 }, 30*time.Second, 100*time.Millisecond,
+		"the event was never redelivered — a failed Mongo read was Acked, losing the event")
+	assert.Empty(t, pub.getRecords(), "nothing may be broadcast from a read that failed")
+
+	// The retries are spaced, not a hot loop: a Nak() without delay would burn
+	// the consumer's MaxDeliver within milliseconds of the first failure.
+	assert.Less(t, deliveries.Load(), int32(consumerMaxDeliver),
+		"retries are spaced by jsretry backoff, so MaxDeliver must not be exhausted this early")
+
+	outage.Restore(t)
+
+	// Same process, same consumer: the next redelivery must now succeed.
+	require.Eventually(t, func() bool { return len(pub.getRecords()) > 0 }, 60*time.Second, 200*time.Millisecond,
+		"the event was never processed after MongoDB returned")
+
+	records := pub.getRecords()
+	require.Len(t, records, 1, "the recovered delivery must broadcast exactly once")
+	assert.Equal(t, subject.RoomEvent("r1", true), records[0].subject)
+
+	// And it is Acked: an unacked success would sit in ack-pending until AckWait
+	// expired and then broadcast the same event a second time.
+	require.Eventually(t, func() bool {
+		info, infoErr := cons.Info(ctx)
+		return infoErr == nil && info.NumAckPending == 0 && info.NumPending == 0
+	}, 10*time.Second, 200*time.Millisecond, "the processed event was never Acked")
+}
+
+// Consumer settings for the outage test. AckWait must exceed the time one
+// delivery spends failing against an unreachable MongoDB, or JetStream
+// redelivers underneath a handler that is still running and the delivery count
+// stops meaning what this test reads it to mean.
+const (
+	consumerAckWait    = 15 * time.Second
+	consumerMaxDeliver = 10
+)
+
+// startCanonicalConsumer builds the worker's real durable consumer over
+// MESSAGES-CANONICAL on the shared test NATS, returning it both directly (for
+// ack-state assertions) and as a Consume iterator, plus the subject to publish
+// canonical events on.
+func startCanonicalConsumer(t *testing.T, siteID string) (jetstream.JetStream, jetstream.Consumer, natsmetrics.Iterator, string) {
+	t.Helper()
+
+	nc, err := nats.Connect(testutil.NATS(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = nc.Drain() })
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	sc := stream.MessagesCanonical(siteID)
+	_, err = js.CreateOrUpdateStream(context.Background(), jetstream.StreamConfig{Name: sc.Name, Subjects: sc.Subjects})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = js.DeleteStream(context.Background(), sc.Name) })
+
+	cons, err := js.CreateOrUpdateConsumer(context.Background(), sc.Name, buildConsumerConfig(stream.ConsumerSettings{
+		AckWait:       consumerAckWait,
+		MaxDeliver:    consumerMaxDeliver,
+		MaxWaiting:    512,
+		MaxAckPending: 1000,
+	}, "broadcast-worker", sc.Subjects[0]))
+	require.NoError(t, err)
+
+	iter, err := cons.Messages()
+	require.NoError(t, err)
+	t.Cleanup(iter.Stop)
+
+	return js, cons, plainIterAdapter{inner: iter}, fmt.Sprintf("chat.msg.canonical.%s.created", siteID)
+}

--- a/history-service/cmd/main.go
+++ b/history-service/cmd/main.go
@@ -108,6 +108,7 @@ func main() {
 		mongoutil.WithReadPreference(readPref),
 		mongoutil.WithMaxPoolSize(cfg.Mongo.MaxPoolSize),
 		mongoutil.WithMinPoolSize(cfg.Mongo.MinPoolSize),
+		mongoutil.WithLazyConnect(),
 	)
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)

--- a/history-service/cmd/main.go
+++ b/history-service/cmd/main.go
@@ -155,12 +155,11 @@ func main() {
 	userStore := userstore.NewMongoStore(db.Collection("users"))
 	appRepo := mongorepo.NewAppRepo(db)
 
-	if err := threadRoomRepo.EnsureIndexes(ctx); err != nil {
-		slog.Error("ensure thread_rooms indexes failed", "error", err)
-		os.Exit(1)
-	}
-	if err := threadSubRepo.EnsureIndexes(ctx); err != nil {
-		slog.Error("ensure thread_subscriptions indexes failed", "error", err)
+	if err := mongoutil.EnsureIndexes(ctx,
+		mongoutil.Step("history-service thread_rooms", threadRoomRepo.EnsureIndexes),
+		mongoutil.Step("history-service thread_subscriptions", threadSubRepo.EnsureIndexes),
+	); err != nil {
+		slog.Error("ensure indexes failed", "error", err)
 		os.Exit(1)
 	}
 

--- a/hr-sync-worker/main.go
+++ b/hr-sync-worker/main.go
@@ -42,7 +42,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoWriteURI, cfg.MongoWriteUsername, cfg.MongoWritePassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoWriteURI, cfg.MongoWriteUsername, cfg.MongoWritePassword,
+		mongoutil.WithObservability(sdk), mongoutil.WithLazyConnect())
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -639,7 +639,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithObservability(sdk), mongoutil.WithLazyConnect())
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -425,19 +425,22 @@ func (s *mongoInboxStore) UpdateSubscriptionRead(ctx context.Context, roomID, ac
 // userId is site-local, so keying on it would let federated upserts miss
 // existing documents and collide on this unique index.
 func (s *mongoInboxStore) ensureIndexes(ctx context.Context) error {
-	// Best-effort: drop the legacy (threadRoomId, userId) unique index so the
-	// (threadRoomId, userAccount) index can be created without a key conflict.
-	// Mirrors message-worker's threadStoreMongo.EnsureIndexes; the index may not
-	// exist (fresh deploy / test container), so ignore all errors.
-	_ = s.threadSubCol.Indexes().DropOne(ctx, "threadRoomId_1_userId_1") //nolint:errcheck
-
+	// Create the new index before dropping the old one. Failing to create it no
+	// longer stops the service starting, so if we dropped first and the create
+	// then failed, the collection would be left with no unique index at all
+	// while the service carried on serving.
 	if _, err := s.threadSubCol.Indexes().CreateOne(ctx, mongo.IndexModel{
 		Keys:    bson.D{{Key: "threadRoomId", Value: 1}, {Key: "userAccount", Value: 1}},
 		Options: options.Index().SetUnique(true),
 	}); err != nil {
 		return fmt.Errorf("ensure thread_subscriptions (threadRoomId,userAccount) index: %w", err)
 	}
-	return nil
+
+	// Remove the old (threadRoomId, userId) unique index, same as message-worker
+	// does. Finding it already gone is the normal case; any other failure is
+	// reported, because it means the old index is still there rejecting writes
+	// that come from another site.
+	return mongoutil.DropIndexIfExists(ctx, s.threadSubCol, "threadRoomId_1_userId_1")
 }
 
 // UpsertThreadSubscription inserts the subscription on first event for a
@@ -652,7 +655,7 @@ func main() {
 		userCol:      db.Collection("users"),
 		threadSubCol: db.Collection("thread_subscriptions"),
 	}
-	if err := store.ensureIndexes(ctx); err != nil {
+	if err := mongoutil.EnsureIndexes(ctx, mongoutil.Step("inbox-worker thread_subscriptions", store.ensureIndexes)); err != nil {
 		slog.Error("ensure indexes failed", "error", err)
 		os.Exit(1)
 	}

--- a/media-service/main.go
+++ b/media-service/main.go
@@ -54,7 +54,8 @@ func run() error {
 		return fmt.Errorf("init observability: %w", err)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithObservability(sdk), mongoutil.WithLazyConnect())
 	if err != nil {
 		return fmt.Errorf("connect mongo: %w", err)
 	}

--- a/media-service/main.go
+++ b/media-service/main.go
@@ -62,7 +62,9 @@ func run() error {
 	store := newMongoStore(mongoClient.Database(cfg.MongoDB))
 	defer mongoutil.Disconnect(ctx, mongoClient)
 
-	if err := store.EnsureEmojiIndexes(ctx); err != nil {
+	if err := mongoutil.EnsureIndexes(ctx,
+		mongoutil.Step("media-service emoji", store.EnsureEmojiIndexes),
+	); err != nil {
 		return fmt.Errorf("ensure emoji indexes: %w", err)
 	}
 

--- a/message-gatekeeper/main.go
+++ b/message-gatekeeper/main.go
@@ -98,7 +98,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithObservability(sdk), mongoutil.WithLazyConnect())
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)

--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -150,8 +150,8 @@ func main() {
 
 	store := NewCassandraStore(cassSession, bucketSizer, cipher)
 	threadStore := newThreadStoreMongo(db)
-	if err := threadStore.EnsureIndexes(ctx); err != nil {
-		slog.Error("ensure thread store indexes failed", "error", err)
+	if err := mongoutil.EnsureIndexes(ctx, mongoutil.Step("message-worker thread_rooms", threadStore.EnsureIndexes)); err != nil {
+		slog.Error("ensure indexes failed", "error", err)
 		os.Exit(1)
 	}
 	handler := NewHandler(store, us, threadStore, cfg.SiteID, func(ctx context.Context, subj string, data []byte, msgID string) error {

--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -118,7 +118,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithObservability(sdk), mongoutil.WithLazyConnect())
 	if err != nil {
 		slog.Error("mongodb connect failed", "error", err)
 		os.Exit(1)

--- a/message-worker/store_mongo.go
+++ b/message-worker/store_mongo.go
@@ -11,6 +11,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/mongoutil"
 )
 
 var (
@@ -44,11 +45,10 @@ func (s *threadStoreMongo) EnsureIndexes(ctx context.Context) error {
 		return fmt.Errorf("ensure thread_rooms parentMessageId index: %w", err)
 	}
 
-	// Best-effort: drop the legacy (threadRoomId, userId) unique index so the new
-	// (threadRoomId, userAccount) index can be created without a key conflict.
-	// The collection or index may not exist (fresh deploy / test container) — ignore all errors.
-	_ = s.threadSubscriptions.Indexes().DropOne(ctx, "threadRoomId_1_userId_1") //nolint:errcheck
-
+	// Create the new index before dropping the old one. Failing to create it no
+	// longer stops the service starting, so if we dropped first and the create
+	// then failed, the collection would be left with no unique index at all
+	// while the service carried on serving.
 	if _, err := s.threadSubscriptions.Indexes().CreateOne(ctx, mongo.IndexModel{
 		Keys:    bson.D{{Key: "threadRoomId", Value: 1}, {Key: "userAccount", Value: 1}},
 		Options: options.Index().SetUnique(true),
@@ -56,7 +56,12 @@ func (s *threadStoreMongo) EnsureIndexes(ctx context.Context) error {
 		return fmt.Errorf("ensure thread_subscriptions (threadRoomId,userAccount) index: %w", err)
 	}
 
-	return nil
+	// Remove the old (threadRoomId, userId) unique index. It keys on a user id
+	// that only means something on one site, so it wrongly rejects writes coming
+	// from another site. Finding it already gone is the normal case; any other
+	// failure is reported, because the old index would still be there rejecting
+	// those writes.
+	return mongoutil.DropIndexIfExists(ctx, s.threadSubscriptions, "threadRoomId_1_userId_1")
 }
 
 func (s *threadStoreMongo) CreateThreadRoom(ctx context.Context, room *model.ThreadRoom) error {

--- a/notification-worker/main.go
+++ b/notification-worker/main.go
@@ -151,7 +151,7 @@ func main() {
 		os.Exit(1)
 	}
 	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
-		mongoutil.WithObservability(sdk), mongoutil.WithReadPreference(readPref))
+		mongoutil.WithObservability(sdk), mongoutil.WithReadPreference(readPref), mongoutil.WithLazyConnect())
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)

--- a/pkg/mongoutil/dropindex_integration_test.go
+++ b/pkg/mongoutil/dropindex_integration_test.go
@@ -1,0 +1,68 @@
+//go:build integration
+
+package mongoutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/hmchangw/chat/pkg/testutil"
+)
+
+// TestDropIndexIfExists_RetiresAnExistingIndex covers the first boot after a
+// legacy index is replaced: the drop happens and is reported as success.
+func TestDropIndexIfExists_RetiresAnExistingIndex(t *testing.T) {
+	ctx := context.Background()
+	col := testutil.MongoDB(t, "mongoutil_dropindex_test").Collection("docs")
+
+	name, err := col.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys:    bson.D{{Key: "legacy", Value: 1}},
+		Options: options.Index().SetUnique(true),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, DropIndexIfExists(ctx, col, name))
+
+	specs, err := col.Indexes().ListSpecifications(ctx)
+	require.NoError(t, err)
+	for _, spec := range specs {
+		assert.NotEqual(t, name, spec.Name, "the legacy index must be gone")
+	}
+}
+
+// TestDropIndexIfExists_AbsentIsSuccess covers every boot after the first: the
+// index and even the collection are gone, which is the expected steady state.
+func TestDropIndexIfExists_AbsentIsSuccess(t *testing.T) {
+	ctx := context.Background()
+	db := testutil.MongoDB(t, "mongoutil_dropindex_test")
+
+	assert.NoError(t, DropIndexIfExists(ctx, db.Collection("never_created"), "legacy_1"),
+		"an absent collection means there is nothing to retire")
+
+	require.NoError(t, db.CreateCollection(ctx, "empty"))
+	assert.NoError(t, DropIndexIfExists(ctx, db.Collection("empty"), "legacy_1"),
+		"an absent index means there is nothing to retire")
+}
+
+// TestDropIndexIfExists_UnreachableMongoIsReported is the case the old
+// discard-everything call sites hid: the retirement did not happen, so the
+// caller must hear about it rather than record startup as clean.
+func TestDropIndexIfExists_UnreachableMongoIsReported(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client, err := Connect(ctx, testutil.UnreachableMongoURI(t), "", "", WithLazyConnect())
+	require.NoError(t, err)
+	t.Cleanup(func() { Disconnect(context.Background(), client) })
+
+	err = DropIndexIfExists(ctx, client.Database("mongoutil_dropindex_down").Collection("docs"), "legacy_1")
+	require.Error(t, err, "a drop that never reached MongoDB must not report success")
+	assert.Contains(t, err.Error(), "legacy_1", "the failing index must be identifiable")
+}

--- a/pkg/mongoutil/dropindex_test.go
+++ b/pkg/mongoutil/dropindex_test.go
@@ -1,0 +1,36 @@
+package mongoutil
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// TestIsIndexAbsentError pins the only two failures a legacy-index retirement
+// may swallow. Everything else — an unreachable MongoDB, a missing privilege —
+// has to reach the caller, or startup reports the replacement index is in place
+// while the legacy one is still enforcing its constraint.
+func TestIsIndexAbsentError(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		absent bool
+	}{
+		{"nothing to drop: collection was never created", mongo.CommandError{Code: 26, Name: "NamespaceNotFound"}, true},
+		{"nothing to drop: index already retired", mongo.CommandError{Code: 27, Name: "IndexNotFound"}, true},
+		{"a wrapped absent index is still absent", fmt.Errorf("drop: %w", mongo.CommandError{Code: 27, Name: "IndexNotFound"}), true},
+		{"unauthorized must not pass as absent", mongo.CommandError{Code: 13, Name: "Unauthorized"}, false},
+		{"interrupted must not pass as absent", mongo.CommandError{Code: 11601, Name: "Interrupted"}, false},
+		{"an unreachable MongoDB must not pass as absent", errors.New("server selection error: context deadline exceeded"), false},
+		{"no error", nil, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.absent, isIndexAbsentError(tc.err))
+		})
+	}
+}

--- a/pkg/mongoutil/indexes.go
+++ b/pkg/mongoutil/indexes.go
@@ -1,0 +1,132 @@
+package mongoutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"golang.org/x/sync/errgroup"
+)
+
+// EnsureIndexesTimeout is how long one EnsureIndexes call gets in total. Its
+// steps run at the same time as each other, so this is the whole index budget
+// for a service's startup, not a cost per store: with MongoDB unreachable a
+// service waits this long once, however many stores it has.
+//
+// It is 30s rather than something shorter because asking MongoDB to create an
+// index does not return until the index is built, and building one over a
+// collection that already holds a lot of data genuinely takes a while.
+const EnsureIndexesTimeout = 30 * time.Second
+
+// IndexStep is one index-creation step to run at startup. The name is what
+// shows up in the log if it fails, so make it say which service and which
+// collection — for example "user-service subscriptions".
+type IndexStep struct {
+	Name   string
+	Ensure func(context.Context) error
+}
+
+// Step builds an IndexStep.
+func Step(name string, ensure func(context.Context) error) IndexStep {
+	return IndexStep{Name: name, Ensure: ensure}
+}
+
+// EnsureIndexes creates a service's indexes at startup. It sorts failures into
+// two kinds: ones a restart will clear, and ones only a person can.
+//
+// If MongoDB is unreachable, or is up but refusing writes, that is the first
+// kind. Creating an index is a write, so both look the same here. EnsureIndexes
+// logs a warning and reports success, so the service still starts. Nothing
+// retries in the background: the whole step runs again on the next start
+// anyway, and asking twice for an index that already exists costs nothing, so a
+// start that skipped it fixes itself later.
+//
+// That leaves a gap worth alerting on. Until some later start succeeds, a
+// missing ordinary index only makes queries slower, but a missing *unique*
+// index means nothing is stopping duplicate rows being written.
+//
+// The second kind — MongoDB rejecting the index because of data or an index
+// that is already there — is returned to the caller, which should exit. No
+// number of restarts will change MongoDB's mind, and the stores that produce
+// these errors attach instructions for whoever has to fix it (for example,
+// "drop the old non-unique account_1 index"). Starting up anyway would bury
+// those instructions in a warning nobody reads.
+func EnsureIndexes(ctx context.Context, steps ...IndexStep) error {
+	ctx, cancel := context.WithTimeout(ctx, EnsureIndexesTimeout)
+	defer cancel()
+
+	var g errgroup.Group
+	for _, step := range steps {
+		if step.Ensure == nil {
+			continue
+		}
+		g.Go(func() error {
+			err := step.Ensure(ctx)
+			if err == nil {
+				return nil
+			}
+			if isPermanentIndexError(err) {
+				return fmt.Errorf("ensure indexes %s: %w", step.Name, err)
+			}
+			slog.Warn("ensure indexes failed; continuing without them",
+				"indexes", step.Name,
+				"error", err.Error(),
+				"impact", "degraded query performance; unique constraints unenforced until a later start succeeds",
+			)
+			return nil
+		})
+	}
+	return g.Wait()
+}
+
+// MongoDB's two ways of saying there is nothing to drop: the collection was
+// never created, or the index is already gone.
+const (
+	codeNamespaceNotFound = 26
+	codeIndexNotFound     = 27
+)
+
+// DropIndexIfExists removes an old index we no longer want. "Not there" counts
+// as done, because that is the normal answer on a brand new deployment and on
+// every start after the first one that removed it.
+//
+// Anything else is reported. If the drop never reached MongoDB, or MongoDB
+// turned it down, the old index is still in place — and treating that as
+// success would let startup believe an old unique index is gone while it is
+// still rejecting writes the new index would have accepted.
+func DropIndexIfExists(ctx context.Context, col *mongo.Collection, name string) error {
+	if err := col.Indexes().DropOne(ctx, name); err != nil && !isIndexAbsentError(err) {
+		return fmt.Errorf("drop legacy index %q: %w", name, err)
+	}
+	return nil
+}
+
+// isIndexAbsentError tells "there was nothing to drop" apart from "the drop did
+// not happen".
+func isIndexAbsentError(err error) bool {
+	if se := mongo.ServerError(nil); errors.As(err, &se) {
+		return se.HasErrorCode(codeNamespaceNotFound) || se.HasErrorCode(codeIndexNotFound)
+	}
+	return false
+}
+
+// isPermanentIndexError reports whether MongoDB refused to create an index for
+// a reason someone has to go and fix, rather than just being unreachable:
+//
+//   - E11000: the collection already holds rows that a unique index would
+//     reject, so the duplicates have to be sorted out first.
+//   - 85 and 86: an index on those fields already exists with different
+//     settings. MongoDB will not change one in place, so the old one has to be
+//     dropped by hand.
+func isPermanentIndexError(err error) bool {
+	if mongo.IsDuplicateKeyError(err) {
+		return true
+	}
+	if se := mongo.ServerError(nil); errors.As(err, &se) {
+		return se.HasErrorCode(85) || se.HasErrorCode(86)
+	}
+	return false
+}

--- a/pkg/mongoutil/indexes_test.go
+++ b/pkg/mongoutil/indexes_test.go
@@ -1,0 +1,233 @@
+package mongoutil
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// captureSlog swaps the default logger for one writing JSON into a buffer and
+// restores it on cleanup, so tests can assert on level and attributes.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+func decodeLogLines(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	dec := json.NewDecoder(bytes.NewReader(buf.Bytes()))
+	for dec.More() {
+		var m map[string]any
+		require.NoError(t, dec.Decode(&m))
+		out = append(out, m)
+	}
+	return out
+}
+
+// warnLine returns the last WARN line captured in buf, or nil if there is none.
+func warnLine(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	var warn map[string]any
+	for _, line := range decodeLogLines(t, buf) {
+		if line["level"] == "WARN" {
+			warn = line
+		}
+	}
+	return warn
+}
+
+func TestEnsureIndexes_SuccessIsQuiet(t *testing.T) {
+	buf := captureSlog(t)
+	called := false
+
+	err := EnsureIndexes(context.Background(), Step("test-store", func(context.Context) error {
+		called = true
+		return nil
+	}))
+
+	require.NoError(t, err)
+	assert.True(t, called, "the index step must actually run")
+	assert.Nil(t, warnLine(t, buf), "success must not warn")
+}
+
+// TestEnsureIndexes_TransientFailureWarnsAndContinues is the case the helper
+// exists for: MongoDB unreachable must not stop a service booting.
+func TestEnsureIndexes_TransientFailureWarnsAndContinues(t *testing.T) {
+	buf := captureSlog(t)
+
+	err := EnsureIndexes(context.Background(), Step("user-service subscriptions", func(context.Context) error {
+		return errors.New("connection refused")
+	}))
+
+	require.NoError(t, err, "a transient failure must not be reported to the caller")
+	warn := warnLine(t, buf)
+	require.NotNil(t, warn, "failure must log at WARN, got %v", decodeLogLines(t, buf))
+	assert.Equal(t, "user-service subscriptions", warn["indexes"],
+		"the failing step must be identifiable for alerting")
+	assert.Contains(t, warn["error"], "connection refused")
+}
+
+// TestEnsureIndexes_PermanentFailureIsReturned pins the fail-fast half: no
+// restart clears an index conflict or pre-existing duplicates, and the stores
+// raising them carry operator remediation text worth surfacing.
+func TestEnsureIndexes_PermanentFailureIsReturned(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"duplicate key blocks a unique index", mongo.WriteException{
+			WriteErrors: []mongo.WriteError{{Code: 11000, Message: "E11000 duplicate key error"}},
+		}},
+		{"index options conflict", mongo.CommandError{Code: 85, Name: "IndexOptionsConflict"}},
+		{"index key specs conflict", mongo.CommandError{Code: 86, Name: "IndexKeySpecsConflict"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := captureSlog(t)
+
+			err := EnsureIndexes(context.Background(), Step("user-service users", func(context.Context) error {
+				return tc.err
+			}))
+
+			require.Error(t, err, "a permanent failure must reach the caller so it can exit")
+			assert.Contains(t, err.Error(), "user-service users", "the failing step must be identifiable")
+			assert.Nil(t, warnLine(t, buf), "a permanent failure is returned, not downgraded to a warning")
+		})
+	}
+}
+
+// TestEnsureIndexes_RunsStepsConcurrently guards the property that keeps boot
+// time flat: a service with several stores must not pay the timeout once per
+// store while MongoDB is unreachable.
+func TestEnsureIndexes_RunsStepsConcurrently(t *testing.T) {
+	captureSlog(t)
+	const steps = 4
+
+	// A step reports itself in flight, then parks until every sibling has done
+	// the same. Parking selects on the context too, so a serial implementation
+	// unblocks on the shared budget instead of wedging the test.
+	started := make(chan struct{}, steps)
+	release := make(chan struct{})
+	all := make([]IndexStep, 0, steps)
+	for range steps {
+		all = append(all, Step("store", func(c context.Context) error {
+			started <- struct{}{}
+			select {
+			case <-release:
+			case <-c.Done():
+				return c.Err()
+			}
+			return nil
+		}))
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- EnsureIndexes(context.Background(), all...) }()
+
+	// Serial steps only ever report one in flight, so this waits out its bound
+	// and fails rather than blocking until the test binary's own timeout.
+	inFlight := 0
+	deadline := time.After(5 * time.Second)
+	for inFlight < steps {
+		select {
+		case <-started:
+			inFlight++
+		case <-deadline:
+			close(release)
+			<-done
+			t.Fatalf("only %d of %d steps ran concurrently", inFlight, steps)
+		}
+	}
+
+	close(release)
+	require.NoError(t, <-done)
+}
+
+func TestEnsureIndexes_NilStepIsSkipped(t *testing.T) {
+	buf := captureSlog(t)
+	assert.NotPanics(t, func() {
+		require.NoError(t, EnsureIndexes(context.Background(), Step("test-store", nil)))
+	})
+	assert.Nil(t, warnLine(t, buf), "a nil step is not a failure")
+}
+
+func TestEnsureIndexes_NoStepsIsNoOp(t *testing.T) {
+	captureSlog(t)
+	require.NoError(t, EnsureIndexes(context.Background()))
+}
+
+// TestEnsureIndexes_BoundsTheSteps pins the timeout the helper owns: during an
+// outage it must give up on its own, since most callers pass a startup context
+// with no deadline.
+func TestEnsureIndexes_BoundsTheSteps(t *testing.T) {
+	captureSlog(t)
+
+	var deadline time.Time
+	var ok bool
+	require.NoError(t, EnsureIndexes(context.Background(), Step("test-store", func(c context.Context) error {
+		deadline, ok = c.Deadline()
+		return nil
+	})))
+
+	require.True(t, ok, "the steps must run under a deadline even when the caller sets none")
+	assert.LessOrEqual(t, time.Until(deadline), EnsureIndexesTimeout)
+}
+
+// TestEnsureIndexes_KeepsShorterCallerDeadline checks the helper bounds without
+// loosening: a caller that wants a tighter budget keeps it.
+func TestEnsureIndexes_KeepsShorterCallerDeadline(t *testing.T) {
+	captureSlog(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	var remaining time.Duration
+	require.NoError(t, EnsureIndexes(ctx, Step("test-store", func(c context.Context) error {
+		d, _ := c.Deadline()
+		remaining = time.Until(d)
+		return nil
+	})))
+
+	assert.LessOrEqual(t, remaining, 50*time.Millisecond, "the helper must not extend a tighter caller deadline")
+}
+
+func TestEnsureIndexes_PassesContextThrough(t *testing.T) {
+	captureSlog(t)
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "v")
+
+	var got any
+	require.NoError(t, EnsureIndexes(ctx, Step("test-store", func(c context.Context) error {
+		got = c.Value(ctxKey{})
+		return nil
+	})))
+
+	assert.Equal(t, "v", got, "the caller's context must reach the index step")
+}
+
+// TestEnsureIndexes_CancelledContextIsTransient covers the outage shape where
+// the caller's startup context is already done: still a warning, not a
+// fail-fast, since a restart can clear it.
+func TestEnsureIndexes_CancelledContextIsTransient(t *testing.T) {
+	buf := captureSlog(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := EnsureIndexes(ctx, Step("test-store", func(c context.Context) error { return c.Err() }))
+
+	require.NoError(t, err)
+	assert.NotNil(t, warnLine(t, buf), "a cancelled-context failure must still warn")
+}

--- a/pkg/mongoutil/lazy.go
+++ b/pkg/mongoutil/lazy.go
@@ -1,0 +1,28 @@
+package mongoutil
+
+// WithLazyConnect skips the ping that Connect normally sends to check MongoDB
+// is reachable, so a service starts even while MongoDB is down.
+//
+// Why that matters: mongo.Connect never actually talks to MongoDB — it just
+// builds a client. The ping is the only thing that proves the database is
+// there, and every caller quits when it fails. So a service that happens to
+// restart during an outage (a deploy, a node drain, an out-of-memory kill)
+// dies at startup, and Kubernetes restarts it in a loop, waiting longer each
+// time — up to five minutes. Services then stay down for minutes after
+// MongoDB is already back.
+//
+// Skipping the ping does not mean the client never connects. The driver keeps
+// checking for MongoDB in the background by itself. While it is down, queries
+// return an error after about 30 seconds (sooner if the caller's context runs
+// out) rather than hanging. When MongoDB comes back, queries simply start
+// working again — no restart, and no reconnect code of our own.
+// TestConnect_LazyBootsDuringOutageThenRecovers is the proof.
+//
+// The ping stays on by default. Only use this for services that keep running
+// and can still do something useful with MongoDB down. Batch and CLI jobs
+// (data-migration/*, teams-*, tools/*, seed-sample-data) should keep it: they
+// have nothing useful to do without MongoDB, so starting anyway would turn a
+// clear "cannot reach MongoDB" at startup into a confusing failure later on.
+func WithLazyConnect() Option {
+	return func(c *connectConfig) { c.lazy = true }
+}

--- a/pkg/mongoutil/lazy_integration_test.go
+++ b/pkg/mongoutil/lazy_integration_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+
+package mongoutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/hmchangw/chat/pkg/testutil"
+)
+
+// TestConnect_LazyBootsDuringOutageThenRecovers is the scenario this option
+// exists for: a process starts while MongoDB is unreachable, serves (failing)
+// requests, and then works normally once MongoDB returns — all without a
+// restart. The default ping path cannot start at all here.
+func TestConnect_LazyBootsDuringOutageThenRecovers(t *testing.T) {
+	outage := testutil.NewMongoOutage(t, testutil.MongoURI(t))
+
+	// Boot during the outage: this is the step that currently kills every service.
+	bootCtx, bootCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer bootCancel()
+	client, err := Connect(bootCtx, outage.URI(), "", "", WithLazyConnect())
+	require.NoError(t, err, "lazy Connect must boot while MongoDB is unreachable")
+	t.Cleanup(func() { Disconnect(context.Background(), client) })
+
+	coll := client.Database("mongoutil_lazy_recovery_test").Collection("docs")
+	t.Cleanup(func() {
+		_ = client.Database("mongoutil_lazy_recovery_test").Drop(context.Background())
+	})
+
+	// While down, operations fail — bounded, not hanging.
+	downCtx, downCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer downCancel()
+	start := time.Now()
+	_, err = coll.InsertOne(downCtx, bson.M{"_id": "during-outage"})
+	require.Error(t, err, "operations must fail while MongoDB is unreachable")
+	assert.Less(t, time.Since(start), 5*time.Second, "must fail bounded, not hang")
+
+	// MongoDB comes back. The same client must recover with no restart.
+	outage.Restore(t)
+
+	upCtx, upCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer upCancel()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, err := coll.InsertOne(upCtx, bson.M{"_id": "after-recovery"})
+		assert.NoError(c, err)
+	}, 25*time.Second, 250*time.Millisecond, "lazy client must recover once MongoDB returns")
+
+	n, err := coll.CountDocuments(upCtx, bson.M{"_id": "after-recovery"})
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, n)
+}
+
+// TestConnect_LazyAgainstHealthyMongoWorksImmediately confirms skipping the
+// ping costs nothing in the normal case — the usual startup, just unproven.
+func TestConnect_LazyAgainstHealthyMongoWorksImmediately(t *testing.T) {
+	ctx := context.Background()
+	client, err := Connect(ctx, testutil.MongoURI(t), "", "", WithLazyConnect())
+	require.NoError(t, err)
+	t.Cleanup(func() { Disconnect(context.Background(), client) })
+
+	db := client.Database("mongoutil_lazy_healthy_test")
+	t.Cleanup(func() { _ = db.Drop(context.Background()) })
+
+	opCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	_, err = db.Collection("docs").InsertOne(opCtx, bson.M{"_id": "x"})
+	require.NoError(t, err)
+	n, err := db.Collection("docs").CountDocuments(opCtx, bson.M{})
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, n)
+}

--- a/pkg/mongoutil/lazy_test.go
+++ b/pkg/mongoutil/lazy_test.go
@@ -1,0 +1,89 @@
+package mongoutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/testutil"
+)
+
+func TestWithLazyConnect_SetsFlag(t *testing.T) {
+	cfg := newConnectConfig(WithLazyConnect())
+	assert.True(t, cfg.lazy, "WithLazyConnect must set the lazy flag")
+}
+
+func TestNewConnectConfig_PingIsDefault(t *testing.T) {
+	cfg := newConnectConfig()
+	assert.False(t, cfg.lazy, "the startup ping must remain the default behaviour")
+}
+
+func TestWithLazyConnect_ComposesWithOtherOptions(t *testing.T) {
+	cfg := newConnectConfig(WithLazyConnect(), WithMaxPoolSize(7))
+	assert.True(t, cfg.lazy)
+	require.NotNil(t, cfg.maxPoolSize)
+	assert.EqualValues(t, 7, *cfg.maxPoolSize)
+}
+
+// TestConnect_DefaultPingsAndFailsWhenUnreachable pins the default contract:
+// with MongoDB unreachable, Connect must fail rather than hand back a client.
+// This is the behaviour batch/migration/CLI jobs rely on.
+func TestConnect_DefaultPingsAndFailsWhenUnreachable(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	client, err := Connect(ctx, testutil.UnreachableMongoURI(t), "", "")
+	require.Error(t, err, "default Connect must fail when MongoDB is unreachable")
+	assert.Nil(t, client)
+	assert.Contains(t, err.Error(), "mongo ping")
+}
+
+// TestConnect_LazyReturnsUsableClient is the whole point of the option: a
+// long-running service must be able to construct its store and reach a serving
+// state while MongoDB is down, instead of dying at boot.
+func TestConnect_LazyReturnsUsableClient(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	client, err := Connect(ctx, testutil.UnreachableMongoURI(t), "", "", WithLazyConnect())
+	require.NoError(t, err, "lazy Connect must not fail when MongoDB is unreachable")
+	require.NotNil(t, client)
+	t.Cleanup(func() { Disconnect(context.Background(), client) })
+
+	coll := client.Database("lazy_db").Collection("docs")
+	require.NotNil(t, coll)
+	assert.Equal(t, "docs", coll.Name())
+}
+
+// TestConnect_LazyFirstOperationStillFailsBounded is the sanity check the
+// design guidance asks for: booting lazily must not turn a hard startup
+// failure into a hang. The first operation still has to come back with an
+// error in bounded time.
+func TestConnect_LazyFirstOperationStillFailsBounded(t *testing.T) {
+	client, err := Connect(context.Background(), testutil.UnreachableMongoURI(t), "", "", WithLazyConnect())
+	require.NoError(t, err)
+	t.Cleanup(func() { Disconnect(context.Background(), client) })
+
+	opCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err = client.Database("lazy_db").Collection("docs").FindOne(opCtx, map[string]any{"_id": "x"}).Err()
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "first operation against unreachable MongoDB must return an error")
+	assert.Less(t, elapsed, 5*time.Second, "first operation must fail in bounded time, not hang")
+}
+
+func TestConnectRead_LazySucceedsWhenUnreachable(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	client, err := ConnectRead(ctx, testutil.UnreachableMongoURI(t), "", "", WithLazyConnect())
+	require.NoError(t, err, "lazy ConnectRead must not fail when MongoDB is unreachable")
+	require.NotNil(t, client)
+	t.Cleanup(func() { Disconnect(context.Background(), client) })
+}

--- a/pkg/mongoutil/mongo.go
+++ b/pkg/mongoutil/mongo.go
@@ -59,15 +59,29 @@ func connect(ctx context.Context, clientOpts *options.ClientOptions, uri string,
 		runCleanup(cleanup)
 		return nil, fmt.Errorf("mongo connect: %w", err)
 	}
-	if err := client.Ping(ctx, nil); err != nil {
-		_ = client.Disconnect(context.Background())
-		runCleanup(cleanup)
-		return nil, fmt.Errorf("mongo ping: %w", err)
+	// mongo.Connect above did not talk to MongoDB — it only built a client.
+	// This ping is the one thing that proves the database is reachable, which
+	// is why skipping it is what lets a service start during an outage. See
+	// WithLazyConnect for who should skip it and why.
+	if cfg.lazy {
+		// Without the ping, Connect can no longer fail because MongoDB is down.
+		// The only errors left are local ones, like a malformed URI, so callers
+		// that exit on a Connect error are still right to do so.
+		//
+		// WARN rather than Info: we have not checked that MongoDB is actually
+		// there, which is worth seeing in the log when a service looks unhealthy.
+		slog.Warn("MongoDB client created without startup ping (lazy connect)", "uri", sanitizeURI(uri))
+	} else {
+		if err := client.Ping(ctx, nil); err != nil {
+			_ = client.Disconnect(context.Background())
+			runCleanup(cleanup)
+			return nil, fmt.Errorf("mongo ping: %w", err)
+		}
+		slog.Info("connected to MongoDB", "uri", sanitizeURI(uri))
 	}
 	if cleanup != nil {
 		cleanups.Store(client, cleanup)
 	}
-	slog.Info("connected to MongoDB", "uri", sanitizeURI(uri))
 	return client, nil
 }
 

--- a/pkg/mongoutil/observability.go
+++ b/pkg/mongoutil/observability.go
@@ -25,6 +25,9 @@ type connectConfig struct {
 	// from the connection URI (or the driver default) survives.
 	maxPoolSize *uint64
 	minPoolSize *uint64
+	// lazy skips the startup ping so a service can boot while MongoDB is
+	// unreachable. False (ping) is the default — see WithLazyConnect.
+	lazy bool
 }
 
 // Option configures Connect. Options are additive; the zero config attaches no

--- a/pkg/testutil/mongooutage.go
+++ b/pkg/testutil/mongooutage.go
@@ -1,0 +1,169 @@
+//go:build integration
+
+package testutil
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// MongoOutage fakes a MongoDB that is down and later comes back, so a test can
+// check what a service does during an outage.
+//
+// It hands out an address where nothing is listening, so connections are
+// refused — the same thing a service sees when MongoDB is really down. Calling
+// Restore then starts listening on that address and passes traffic through to
+// the real MongoDB, which looks to the client like the database coming back.
+//
+// Why fake it instead of stopping MongoDB: every test in the package shares one
+// MongoDB container, so stopping it would break all of them. This gives one
+// test its own outage without touching anything the others use.
+//
+// Why an address with nothing listening, rather than something that accepts the
+// connection and hangs up: only a dead address gets connections refused.
+// Anything that accepts looks like a working server to the driver, which is a
+// different failure from an outage.
+type MongoOutage struct {
+	addr   string
+	target string
+
+	mu       sync.Mutex
+	listener net.Listener
+	wg       sync.WaitGroup
+	conns    []net.Conn
+	closed   bool
+}
+
+// NewMongoOutage reserves an address that refuses connections and, once
+// Restore runs, forwards it to the MongoDB behind targetURI.
+func NewMongoOutage(t *testing.T, targetURI string) *MongoOutage {
+	t.Helper()
+	u, err := url.Parse(targetURI)
+	require.NoError(t, err, "parse target URI %q", targetURI)
+	require.NotEmpty(t, u.Host, "parse host from %q", targetURI)
+
+	p := &MongoOutage{addr: ReserveAddr(t), target: u.Host}
+	t.Cleanup(p.Close)
+	return p
+}
+
+// URI is the address to point a MongoDB client at. Connections to it are
+// refused until Restore runs.
+//
+// Both settings in the URI matter, despite looking like boilerplate.
+// directConnection=true stops the driver asking MongoDB what address it should
+// really use — without it the driver gets the real container's address and goes
+// straight there, skipping the fake one, and the test proves nothing.
+// serverSelectionTimeoutMS shortens how long the driver waits before giving up,
+// so a test takes 2 seconds instead of the default 30, while still leaving a
+// slow machine enough time to notice the database is back after Restore.
+func (p *MongoOutage) URI() string {
+	return fmt.Sprintf("mongodb://%s/?directConnection=true&serverSelectionTimeoutMS=2000", p.addr)
+}
+
+// track records a socket so Close can shut it down later, or closes it straight
+// away and returns false if Close has already run. Without that check, a
+// connection arriving during shutdown would never be closed, and Close would
+// wait for it forever.
+func (p *MongoOutage) track(c net.Conn) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		_ = c.Close()
+		return false
+	}
+	p.conns = append(p.conns, c)
+	return true
+}
+
+// Restore starts passing traffic through to the real MongoDB — the outage ends.
+// The client is never told; it has to notice by itself, which is the whole
+// point of the test.
+//
+// The retry loop is needed rather than defensive: we deliberately gave the port
+// up so connections would be refused, so the operating system may not hand it
+// straight back.
+func (p *MongoOutage) Restore(t *testing.T) {
+	t.Helper()
+	var l net.Listener
+	var err error
+	for range 50 {
+		l, err = net.Listen("tcp", p.addr)
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.NoError(t, err, "bind outage proxy at %s", p.addr)
+
+	p.mu.Lock()
+	p.listener = l
+	p.mu.Unlock()
+
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return // listener closed
+			}
+			if !p.track(conn) {
+				return // teardown started
+			}
+			p.wg.Add(1)
+			go func() {
+				defer p.wg.Done()
+				p.forward(conn)
+			}()
+		}
+	}()
+}
+
+// forward passes one client connection through to MongoDB and back. Both
+// directions have to finish before either side is closed: closing early cuts
+// the other direction off mid-message, and the client would see a broken
+// connection instead of a working database — looking like the outage never
+// ended.
+func (p *MongoOutage) forward(client net.Conn) {
+	upstream, err := net.DialTimeout("tcp", p.target, 5*time.Second)
+	if err != nil {
+		_ = client.Close()
+		return
+	}
+	if !p.track(upstream) {
+		_ = client.Close()
+		return
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); _, _ = io.Copy(upstream, client) }()
+	go func() { defer wg.Done(); _, _ = io.Copy(client, upstream) }()
+	wg.Wait()
+	_ = client.Close()
+	_ = upstream.Close()
+}
+
+// Close tears the proxy down. Registered by NewMongoOutage; safe to call twice.
+func (p *MongoOutage) Close() {
+	p.mu.Lock()
+	p.closed = true
+	if p.listener != nil {
+		_ = p.listener.Close()
+		p.listener = nil
+	}
+	for _, c := range p.conns {
+		_ = c.Close()
+	}
+	p.conns = nil
+	p.mu.Unlock()
+	p.wg.Wait()
+}

--- a/pkg/testutil/mongouri.go
+++ b/pkg/testutil/mongouri.go
@@ -1,0 +1,40 @@
+package testutil
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+// ReserveAddr returns a local address with nothing listening on it: it opens a
+// port, notes the number, then closes it again.
+//
+// Nothing keeps that port free afterwards — the operating system may hand it to
+// another program. That is fine for a caller who only wants connections to be
+// refused. A caller who later wants to listen on it (see MongoOutage) has to
+// expect that and retry.
+func ReserveAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve local address: %v", err)
+	}
+	addr := l.Addr().String()
+	if err := l.Close(); err != nil {
+		t.Fatalf("release reserved address %s: %v", addr, err)
+	}
+	return addr
+}
+
+// UnreachableMongoURI returns a MongoDB address where nothing is listening —
+// what a service sees when MongoDB is down.
+//
+// Both settings in the URI matter. directConnection=true stops the driver
+// asking MongoDB for its real address and going there instead, which would
+// defeat the point. serverSelectionTimeoutMS shortens how long the driver waits
+// before giving up, so these tests take a fraction of a second each instead of
+// 30 seconds; queries still fail the same way, just sooner.
+func UnreachableMongoURI(t *testing.T) string {
+	t.Helper()
+	return fmt.Sprintf("mongodb://%s/?directConnection=true&serverSelectionTimeoutMS=200", ReserveAddr(t))
+}

--- a/portal-service/main.go
+++ b/portal-service/main.go
@@ -111,7 +111,7 @@ func run() error {
 	slog.Info("mongo read preference configured", "readPreference", readPref.Mode().String())
 
 	store := newMongoDirectoryStore(mongoClient.Database(cfg.MongoDB))
-	if err := store.EnsureIndexes(ctx); err != nil {
+	if err := mongoutil.EnsureIndexes(ctx, mongoutil.Step("portal-service directory", store.EnsureIndexes)); err != nil {
 		return fmt.Errorf("ensure directory indexes: %w", err)
 	}
 

--- a/portal-service/main.go
+++ b/portal-service/main.go
@@ -104,7 +104,7 @@ func run() error {
 		return fmt.Errorf("parse mongo read preference %q: %w", cfg.MongoReadPreference, err)
 	}
 	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
-		mongoutil.WithObservability(sdk), mongoutil.WithReadPreference(readPref))
+		mongoutil.WithObservability(sdk), mongoutil.WithReadPreference(readPref), mongoutil.WithLazyConnect())
 	if err != nil {
 		return fmt.Errorf("connect mongo: %w", err)
 	}

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -163,7 +163,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithObservability(sdk), mongoutil.WithLazyConnect())
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -191,14 +191,10 @@ func main() {
 	slog.Info("mongo secondary-read preference configured", "readPreference", readPref.Mode().String())
 
 	store := NewMongoStore(db, WithReadPreference(readPref))
-	// Bounded timeout so a hung createIndexes surfaces at startup.
-	ensureCtx, ensureCancel := context.WithTimeout(ctx, 30*time.Second)
-	if err := store.EnsureIndexes(ensureCtx); err != nil {
-		ensureCancel()
+	if err := mongoutil.EnsureIndexes(ctx, mongoutil.Step("room-service store", store.EnsureIndexes)); err != nil {
 		slog.Error("ensure store indexes failed", "error", err)
 		os.Exit(1)
 	}
-	ensureCancel()
 
 	// Read receipts resolve the target message through history-service (which
 	// owns message history) over NATS, so room-service has no direct Cassandra

--- a/room-worker/main.go
+++ b/room-worker/main.go
@@ -133,7 +133,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithObservability(sdk), mongoutil.WithLazyConnect())
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)

--- a/search-service/main.go
+++ b/search-service/main.go
@@ -195,7 +195,7 @@ func main() {
 		os.Exit(1)
 	}
 	mongoClient, err := mongoutil.Connect(ctx, cfg.Mongo.URI, cfg.Mongo.Username, cfg.Mongo.Password,
-		mongoutil.WithObservability(sdk), mongoutil.WithReadPreference(readPref))
+		mongoutil.WithObservability(sdk), mongoutil.WithReadPreference(readPref), mongoutil.WithLazyConnect())
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)

--- a/search-service/main.go
+++ b/search-service/main.go
@@ -213,13 +213,10 @@ func main() {
 	cache := newValkeyCache(valkey)
 	mongoStore := newMongoStore(mongoDB)
 
-	ensureCtx, ensureCancel := context.WithTimeout(ctx, 30*time.Second)
-	if err := mongoStore.ensureIndexes(ensureCtx); err != nil {
-		ensureCancel()
+	if err := mongoutil.EnsureIndexes(ctx, mongoutil.Step("search-service store", mongoStore.ensureIndexes)); err != nil {
 		slog.Error("ensure mongo indexes failed", "error", err)
 		os.Exit(1)
 	}
-	ensureCancel()
 	handler := newHandler(store, mongoStore, usersClient, cache, &handlerConfig{
 		SiteID:                  cfg.SiteID,
 		DocCounts:               cfg.Search.DocCounts,

--- a/search-sync-worker/main.go
+++ b/search-sync-worker/main.go
@@ -152,7 +152,8 @@ func main() {
 	}
 
 	// Mongo backs the migrated-Teams-history author lookup (teams_user → account → user _id).
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithObservability(sdk), mongoutil.WithLazyConnect())
 	if err != nil {
 		slog.Error("mongodb connect failed", "error", err)
 		os.Exit(1)

--- a/tcard-service/main.go
+++ b/tcard-service/main.go
@@ -69,7 +69,7 @@ func run() error {
 	}
 
 	store := newMongoCardStore(mongoClient.Database(cfg.MongoDB))
-	if err := store.EnsureIndexes(ctx); err != nil {
+	if err := mongoutil.EnsureIndexes(ctx, mongoutil.Step("tcard-service cards", store.EnsureIndexes)); err != nil {
 		return fmt.Errorf("ensure cards indexes: %w", err)
 	}
 

--- a/tcard-service/main.go
+++ b/tcard-service/main.go
@@ -62,7 +62,8 @@ func run() error {
 		return fmt.Errorf("init observability: %w", err)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithObservability(sdk), mongoutil.WithLazyConnect())
 	if err != nil {
 		return fmt.Errorf("connect mongo: %w", err)
 	}

--- a/upload-service/main.go
+++ b/upload-service/main.go
@@ -103,7 +103,8 @@ func run() error {
 		return fmt.Errorf("init observability: %w", err)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithObservability(sdk), mongoutil.WithLazyConnect())
 	if err != nil {
 		return fmt.Errorf("mongo connect: %w", err)
 	}

--- a/user-presence-service/main.go
+++ b/user-presence-service/main.go
@@ -101,7 +101,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.Mongo.URI, cfg.Mongo.Username, cfg.Mongo.Password, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.Mongo.URI, cfg.Mongo.Username, cfg.Mongo.Password,
+		mongoutil.WithObservability(sdk), mongoutil.WithLazyConnect())
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)

--- a/user-service/main.go
+++ b/user-service/main.go
@@ -70,7 +70,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.Mongo.URI, cfg.Mongo.Username, cfg.Mongo.Password, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.Mongo.URI, cfg.Mongo.Username, cfg.Mongo.Password,
+		mongoutil.WithObservability(sdk), mongoutil.WithLazyConnect())
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)

--- a/user-service/main.go
+++ b/user-service/main.go
@@ -93,23 +93,13 @@ func main() {
 	appRepo := mongorepo.NewAppRepo(db, readFromSecondary)
 	threadSubRepo := mongorepo.NewThreadSubscriptionRepo(db)
 	ssoTokenRepo := mongorepo.NewSSOTokenRepo(db)
-	if err := subRepo.EnsureIndexes(ctx); err != nil {
-		slog.Error("ensure indexes failed", "error", err)
-		os.Exit(1)
-	}
-	if err := userRepo.EnsureIndexes(ctx); err != nil {
-		slog.Error("ensure indexes failed", "error", err)
-		os.Exit(1)
-	}
-	if err := appRepo.EnsureIndexes(ctx); err != nil {
-		slog.Error("ensure indexes failed", "error", err)
-		os.Exit(1)
-	}
-	if err := threadSubRepo.EnsureIndexes(ctx); err != nil {
-		slog.Error("ensure indexes failed", "error", err)
-		os.Exit(1)
-	}
-	if err := ssoTokenRepo.EnsureIndexes(ctx); err != nil {
+	if err := mongoutil.EnsureIndexes(ctx,
+		mongoutil.Step("user-service subscriptions", subRepo.EnsureIndexes),
+		mongoutil.Step("user-service users", userRepo.EnsureIndexes),
+		mongoutil.Step("user-service apps", appRepo.EnsureIndexes),
+		mongoutil.Step("user-service thread_subscriptions", threadSubRepo.EnsureIndexes),
+		mongoutil.Step("user-service sso_tokens", ssoTokenRepo.EnsureIndexes),
+	); err != nil {
 		slog.Error("ensure indexes failed", "error", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary

Online services currently cannot **start** during a MongoDB outage. Two independent startup steps are fatal in every service:

1. `mongoutil.Connect` pings MongoDB and every caller treats failure as fatal (`mongo.Connect` is lazy in driver v2, so this ping *is* the reachability check).
2. `EnsureIndexes` at startup — `createIndexes` is a write, so it fails against a MongoDB that is down *or* degraded to read-only.

A pod that restarts mid-outage (deploy, node drain, OOM kill, HPA scale-up) therefore dies at boot and stays down for the rest of the outage plus the CrashLoopBackOff backoff after MongoDB returns. Across 22 services, a one-hour outage will almost certainly include at least one such restart — which means the request-path resilience work is worth nothing to a process that can't boot.

This PR lets a restarted pod boot, wire its stores, and reach a serving (degraded) state — **without** discarding the startup failures that no restart can fix.

## What changed

**`pkg/mongoutil`** — two additions, both leaving current behaviour as the default:

| Addition | Effect |
|---|---|
| `WithLazyConnect()` | Skips the startup ping so `Connect` returns a client without proving MongoDB is reachable. Lazy boots log at **WARN** since the connection is unproven. |
| `EnsureIndexes(ctx, steps...)` | Runs named index steps concurrently under one 30s budget, and splits failures by whether a restart can fix them (below). |

### Transient vs permanent index failures

This is the part worth reviewing. `EnsureIndexes` classifies:

- **Transient** — MongoDB unreachable or read-only. Logged at WARN with the step name and impact, reported as success, service boots. Self-heals on a later boot, since the step is idempotent and re-runs every start.
- **Permanent** — `E11000` (existing duplicates block a unique index), `85`/`86` (`IndexOptionsConflict` / `IndexKeySpecsConflict`). Returned to the caller, which exits as before.

Permanent failures have to stay fatal: `user-service/mongorepo/users.go` and `room-service/store_mongo.go` detect exactly these codes and return operator remediation text (*"drop the old non-unique `account_1` index … before starting this service"*). Nothing about a restart clears them, and the unique indexes involved are what room-worker's `$setOnInsert` retry-idempotency depends on — silently serving without them lets redelivered `member_added` events duplicate rows.

Steps run **concurrently** so a service with several stores stalls a boot once, not once per store — user-service has five, which would otherwise burn ~150s of an outage before its health server binds, long enough for a k8s startup probe to kill the pod and recreate the crash loop this PR removes.

**Call sites**

- `WithLazyConnect()` on **22 long-running online services** — the 21 online services plus `hr-sync-worker`, which has a health server, durable JetStream consumers and graceful shutdown, so it meets the documented eligibility bar.
- **18 index steps across 12 services** now go through `EnsureIndexes`. `media-service` is included: it had received `WithLazyConnect()` while keeping a fatal `EnsureEmojiIndexes`, so the change was a no-op there and it still crash-looped.
- `message-worker` and `inbox-worker` **create the new `thread_subscriptions` unique index before retiring the legacy one**. Dropping first was safe while a failed create was fatal; now that it isn't, that order could leave the collection with neither index while the service kept serving.
- `botplatform-service` no longer gates `/healthz` on a Mongo ping. A lazily-booted pod failed liveness and crash-looped through the outage anyway, and `docs/health-probes.md` already requires liveness to probe no dependency. The store's now-unused `Ping` is removed.

**Deliberately not opted in:** `data-migration/*`, `teams-*`, `tools/*`, `seed-sample-data`. Batch, migration and CLI jobs have no useful degraded mode — a silent lazy start would turn a clear startup failure into a confusing one deep into a run. They keep the ping and keep failing loudly.

## Behaviour notes

- **Lazy does not defer failure indefinitely.** The first operation still fails, bounded by the caller's context deadline or the driver's 30s server-selection timeout, whichever is shorter — reads return an error rather than hanging, so consumer loops can Nak and retry rather than wedge.
- **No background index retry, on purpose.** The step re-runs on every boot; a retry loop would add a goroutine and a termination path per service for a condition a restart fixes.
- **A recovered client needs no restart.** Once MongoDB returns, the same lazily-connected client works again (covered by an integration test that proxies an outage and then restores it).

## Risk

Unique indexes are the caveat that remains. If a service boots while MongoDB is unwritable, a *transient* failure means the index isn't created, and between MongoDB becoming writable again and the next restart, duplicates it would have rejected can be written. Permanent failures no longer fall into this gap — they stop the service as before.

The WARN line carries the step name and impact so it can be alerted on:

```
level=WARN msg="ensure indexes failed; continuing without them"
  indexes="user-service subscriptions" error="..."
  impact="degraded query performance; unique constraints unenforced until a later start succeeds"
```

## Testing

- `pkg/mongoutil/lazy_test.go` — option plumbing, ping-is-still-the-default, lazy succeeds against an unreachable port, client is usable, first operation fails in **bounded** time.
- `pkg/mongoutil/indexes_test.go` — success is quiet; transient failure warns and reports success; permanent failure (E11000, 85, 86) is returned and *not* downgraded; steps run concurrently; the helper owns a deadline and never loosens a tighter caller one.
- `pkg/mongoutil/lazy_integration_test.go` — an outage proxy boots a client against a dead endpoint, fails bounded while down, then **recovers with no restart** once MongoDB returns.
- `broadcast-worker/startup_resilience_integration_test.go` — walks the service's real Mongo boot sequence with MongoDB down (connect → build store → index step) and asserts all three complete.

Locally: `go build ./...` clean, `make lint` → 0 issues, `make test` → 108 packages ok. Integration suites not run (need Docker).

## Follow-ups not in this PR

- Index bootstrap still writes from app code on every start. The repo's established pattern for ops/IaC-owned provisioning is `BOOTSTRAP_STREAMS`-style env gating (create in dev, verify-and-fail-fast in production); indexes arguably belong there too.
- Readiness probes NATS only, so a lazily-booted pod reports ready while unable to serve Mongo-backed requests. That follows the documented policy in `docs/health-probes.md`, but the doc's supporting argument predates pods that have never reached Mongo at all.
- Workers that boot during an outage now consume during it. `inbox-worker`'s bare `msg.Nak()` against `MaxDeliver=5` burns all redeliveries in milliseconds, and `broadcast-worker`'s backoff gives ~36s of retry, so a longer outage drops those events where previously the pod wasn't running to receive them.
- Nothing enforces the service-vs-job choice; a `.semgrep` rule would stop service #23 silently picking the wrong one.

---

Supersedes #270 (same commits, same content).


---
_Generated by [Claude Code](https://claude.ai/code/session_01KDzjqaoGFtNaRdyTLBDSMf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Services can now start while MongoDB is temporarily unavailable and reconnect automatically when it recovers.
  * Added standardized index initialization with bounded execution and improved handling of temporary failures.
  * Added safer index migration support, including reliable removal of legacy indexes.

* **Bug Fixes**
  * Health checks now report service availability without requiring MongoDB to be reachable.
  * Workers can recover database operations and retry message processing without restarting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->