### PR TITLE
fix(room-worker): inherit room restricted/externalAccess on subscription create

### DIFF
--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -1484,6 +1484,9 @@ func newSub(id string, user *model.User, room *model.Room, roles []model.Role,
 		IsSubscribed: isSubscribed,
 		JoinedAt:     joinedAt,
 		Open:         true,
+		// Denorm from room so subscription.list doesn't drop new members of a restricted room (#298).
+		Restricted:     room.Restricted,
+		ExternalAccess: room.ExternalAccess,
 	}
 }
 

--- a/room-worker/subscription_restricted_test.go
+++ b/room-worker/subscription_restricted_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hmchangw/chat/pkg/model"
+)
+
+// TestNewSub_InheritsRoomRestriction asserts a newly-created subscription carries
+// the room's {restricted, externalAccess} denorm, so a member added to an
+// already-restricted room is not omitted from subscription.list (#298).
+func TestNewSub_InheritsRoomRestriction(t *testing.T) {
+	ts := time.Now().UTC()
+	user := &model.User{ID: "u1", Account: "alice"}
+
+	restricted := &model.Room{ID: "r1", SiteID: "site-a", Type: model.RoomTypeChannel, Restricted: true, ExternalAccess: true}
+	sub := newSub("s1", user, restricted, nil, "n", false, ts)
+	assert.True(t, sub.Restricted, "sub must inherit room.Restricted")
+	assert.True(t, sub.ExternalAccess, "sub must inherit room.ExternalAccess")
+
+	open := &model.Room{ID: "r2", SiteID: "site-a", Type: model.RoomTypeChannel}
+	openSub := newSub("s2", user, open, nil, "n", false, ts)
+	assert.False(t, openSub.Restricted, "unrestricted room yields Restricted=false")
+	assert.False(t, openSub.ExternalAccess, "unrestricted room yields ExternalAccess=false")
+}

--- a/room-worker/subscription_restricted_test.go
+++ b/room-worker/subscription_restricted_test.go
@@ -11,18 +11,26 @@ import (
 
 // TestNewSub_InheritsRoomRestriction asserts a newly-created subscription carries
 // the room's {restricted, externalAccess} denorm, so a member added to an
-// already-restricted room is not omitted from subscription.list (#298).
+// already-restricted room is not omitted from subscription.list (#298). The
+// asymmetric cases guard against a field-swap or copy-one-into-both regression.
 func TestNewSub_InheritsRoomRestriction(t *testing.T) {
 	ts := time.Now().UTC()
 	user := &model.User{ID: "u1", Account: "alice"}
 
-	restricted := &model.Room{ID: "r1", SiteID: "site-a", Type: model.RoomTypeChannel, Restricted: true, ExternalAccess: true}
-	sub := newSub("s1", user, restricted, nil, "n", false, ts)
-	assert.True(t, sub.Restricted, "sub must inherit room.Restricted")
-	assert.True(t, sub.ExternalAccess, "sub must inherit room.ExternalAccess")
-
-	open := &model.Room{ID: "r2", SiteID: "site-a", Type: model.RoomTypeChannel}
-	openSub := newSub("s2", user, open, nil, "n", false, ts)
-	assert.False(t, openSub.Restricted, "unrestricted room yields Restricted=false")
-	assert.False(t, openSub.ExternalAccess, "unrestricted room yields ExternalAccess=false")
+	for _, tc := range []struct {
+		name                       string
+		restricted, externalAccess bool
+	}{
+		{"both false", false, false},
+		{"both true", true, true},
+		{"restricted only", true, false},
+		{"externalAccess only", false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			room := &model.Room{ID: "r1", SiteID: "site-a", Type: model.RoomTypeChannel, Restricted: tc.restricted, ExternalAccess: tc.externalAccess}
+			sub := newSub("s1", user, room, nil, "n", false, ts)
+			assert.Equal(t, tc.restricted, sub.Restricted, "sub.Restricted must equal room.Restricted")
+			assert.Equal(t, tc.externalAccess, sub.ExternalAccess, "sub.ExternalAccess must equal room.ExternalAccess")
+		})
+	}
 }


### PR DESCRIPTION
## Summary

A member added to an **already-restricted** channel room got a subscription without `restricted`/`externalAccess`, so `subscription.list` omitted them for that user even though the room is `restricted:true` (pre-existing members' subs correctly carried it).

Root cause: `newSub` (`room-worker/handler.go`) builds the subscription from the `room` object but never copies `room.Restricted` / `room.ExternalAccess`. The sub-side denorm is otherwise only written by `ApplySubscriptionRestriction`, a one-time `UpdateMany({roomId})` run at the `room.restricted` **toggle** over subs that exist then — a member added *after* the toggle is created by `newSub` and never inherits the flags.

## Changes

- `newSub` now sets `Restricted: room.Restricted` and `ExternalAccess: room.ExternalAccess`. It already receives the `room`, and every sub-create path (add-member, DM, bot-DM, Teams-migration) routes through it, so one change fixes all uniformly. Harmless when the room isn't restricted (copies `false`, which `omitempty` drops).
- No schema, contract, or `docs/client-api.md` change — the `Subscription` fields already exist and `subscription.list` already projects them.

## Verification

- Unit (red→green): `TestNewSub_InheritsRoomRestriction` — a restricted room (`Restricted:true`, `ExternalAccess:true`) yields a sub with both true; a non-restricted room yields both false.
- `go test ./room-worker/...` — green.
- `golangci-lint run ./room-worker/...` — 0 issues.

Closes #298


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Room access settings are now preserved when creating subscriptions, ensuring subscription lists accurately reflect restricted and externally accessible rooms.

* **Tests**
  * Added coverage for restricted and unrestricted room scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->