### PR TITLE
fix(admin-service): permission fanout review fixes — per-destination lanes, 1000-account chunks, FANOUT_TIMEOUT 30s

### DIFF
--- a/admin-service/config.go
+++ b/admin-service/config.go
@@ -12,6 +12,11 @@ import (
 // the handler always wins the race against net/http closing the connection.
 const httpWriteTimeout = 40 * time.Second
 
+// requestBudget is the absolute per-request deadline the permission handlers pin at
+// entry (withRequestBudget): httpWriteTimeout minus a margin to write the response
+// after the last in-handler wait, so syncFailures always reaches the caller.
+const requestBudget = httpWriteTimeout - 2*time.Second
+
 type Config struct {
 	Port                  string `env:"PORT" envDefault:"8082"`
 	SiteID                string `env:"SITE_ID,required"`

--- a/admin-service/config.go
+++ b/admin-service/config.go
@@ -10,7 +10,7 @@ import (
 // httpWriteTimeout bounds a response write measured from the request, so in-handler
 // waits count against it: RoomRPCTimeout and FanoutTimeout must stay under it so
 // the handler always wins the race against net/http closing the connection.
-const httpWriteTimeout = 30 * time.Second
+const httpWriteTimeout = 40 * time.Second
 
 type Config struct {
 	Port                  string `env:"PORT" envDefault:"8082"`
@@ -29,10 +29,13 @@ type Config struct {
 	// closes the connection before the handler can answer.
 	RoomRPCTimeout time.Duration `env:"ROOM_RPC_TIMEOUT" envDefault:"5s"`
 	// FanoutTimeout is the server-side budget for ONE request's whole cross-site
-	// permission fanout — every destination lane, every batch, every chunk. Like
-	// RoomRPCTimeout it must stay below the HTTP write timeout, or net/http drops the
-	// connection before the admin can read syncFailures.
-	FanoutTimeout time.Duration `env:"FANOUT_TIMEOUT" envDefault:"5s"`
+	// permission fanout — every destination lane, every batch, every chunk. Sized for a
+	// whole-site batch over cross-site gateways. Like RoomRPCTimeout it must stay below
+	// the HTTP write timeout, or net/http drops the connection before the admin can read
+	// syncFailures. The default exceeds main.go's 25s graceful-shutdown budget: a SIGTERM
+	// mid-fanout can kill the request before the admin sees syncFailures. Accepted — the
+	// ledger write already committed, and resync re-delivers anything cut short.
+	FanoutTimeout time.Duration `env:"FANOUT_TIMEOUT" envDefault:"30s"`
 	// AllSiteIDs lists every site in the federation (including this one); empty means
 	// no cross-site fanout — correct for single-site dev.
 	AllSiteIDs []string `env:"ALL_SITE_IDS" envSeparator:"," envDefault:""`

--- a/admin-service/config.go
+++ b/admin-service/config.go
@@ -7,7 +7,8 @@ import (
 	"github.com/caarlos0/env/v11"
 )
 
-// httpWriteTimeout bounds a response write; RoomRPCTimeout must stay under it so
+// httpWriteTimeout bounds a response write measured from the request, so in-handler
+// waits count against it: RoomRPCTimeout and FanoutTimeout must stay under it so
 // the handler always wins the race against net/http closing the connection.
 const httpWriteTimeout = 30 * time.Second
 
@@ -27,6 +28,11 @@ type Config struct {
 	// RoomRPCTimeout must stay below the HTTP server's WriteTimeout, or net/http
 	// closes the connection before the handler can answer.
 	RoomRPCTimeout time.Duration `env:"ROOM_RPC_TIMEOUT" envDefault:"5s"`
+	// FanoutTimeout is the server-side budget for ONE request's whole cross-site
+	// permission fanout — every destination lane, every batch, every chunk. Like
+	// RoomRPCTimeout it must stay below the HTTP write timeout, or net/http drops the
+	// connection before the admin can read syncFailures.
+	FanoutTimeout time.Duration `env:"FANOUT_TIMEOUT" envDefault:"5s"`
 	// AllSiteIDs lists every site in the federation (including this one); empty means
 	// no cross-site fanout — correct for single-site dev.
 	AllSiteIDs []string `env:"ALL_SITE_IDS" envSeparator:"," envDefault:""`
@@ -37,11 +43,24 @@ func loadConfig() (Config, error) {
 	if err := env.Parse(&c); err != nil {
 		return Config{}, err
 	}
-	if c.RoomRPCTimeout <= 0 {
-		return Config{}, fmt.Errorf("invalid ROOM_RPC_TIMEOUT %s: must be > 0", c.RoomRPCTimeout)
+	if err := checkHandlerTimeout("ROOM_RPC_TIMEOUT", c.RoomRPCTimeout); err != nil {
+		return Config{}, err
 	}
-	if c.RoomRPCTimeout >= httpWriteTimeout {
-		return Config{}, fmt.Errorf("invalid ROOM_RPC_TIMEOUT %s: must be below the %s HTTP write timeout", c.RoomRPCTimeout, httpWriteTimeout)
+	if err := checkHandlerTimeout("FANOUT_TIMEOUT", c.FanoutTimeout); err != nil {
+		return Config{}, err
 	}
 	return c, nil
+}
+
+// checkHandlerTimeout rejects a per-request budget the handler cannot honour: a
+// non-positive value yields an already-expired context, and one at or above
+// httpWriteTimeout lets net/http close the connection before the handler answers.
+func checkHandlerTimeout(name string, d time.Duration) error {
+	if d <= 0 {
+		return fmt.Errorf("invalid %s %s: must be > 0", name, d)
+	}
+	if d >= httpWriteTimeout {
+		return fmt.Errorf("invalid %s %s: must be below the %s HTTP write timeout", name, d, httpWriteTimeout)
+	}
+	return nil
 }

--- a/admin-service/config_test.go
+++ b/admin-service/config_test.go
@@ -18,6 +18,7 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	assert.Equal(t, "chat", cfg.MongoDB)
 	assert.Equal(t, 10, cfg.BcryptCost)
 	assert.Equal(t, 5*time.Second, cfg.RoomRPCTimeout)
+	assert.Equal(t, 5*time.Second, cfg.FanoutTimeout)
 }
 
 func TestLoadConfig_RequiresSiteAndMongo(t *testing.T) {
@@ -34,39 +35,44 @@ func TestLoadConfig_RequiresNatsURL(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestLoadConfig_RoomRPCTimeoutOverride(t *testing.T) {
+func TestLoadConfig_TimeoutOverrides(t *testing.T) {
 	t.Setenv("SITE_ID", "site-local")
 	t.Setenv("MONGO_URI", "mongodb://x")
 	t.Setenv("NATS_URL", "nats://x:4222")
 	t.Setenv("ROOM_RPC_TIMEOUT", "12s")
+	t.Setenv("FANOUT_TIMEOUT", "20s")
 	cfg, err := loadConfig()
 	require.NoError(t, err)
 	assert.Equal(t, 12*time.Second, cfg.RoomRPCTimeout)
+	assert.Equal(t, 20*time.Second, cfg.FanoutTimeout)
 }
 
-// A non-positive timeout yields an already-expired context, so every toggle
-// would fail; a timeout at or above the HTTP write timeout lets net/http close
-// the connection before the handler can answer. Both must fail at startup.
-func TestLoadConfig_RejectsUnusableRoomRPCTimeout(t *testing.T) {
-	tests := []struct {
+// A non-positive timeout yields an already-expired context, so every call would
+// fail; a timeout at or above the HTTP write timeout lets net/http close the
+// connection before the handler can answer. Both must fail at startup, for every
+// per-request budget the handler waits on.
+func TestLoadConfig_RejectsUnusableHandlerTimeouts(t *testing.T) {
+	values := []struct {
 		name  string
 		value string
 	}{
 		{name: "zero", value: "0s"},
 		{name: "negative", value: "-1s"},
-		{name: "equal to write timeout", value: "30s"},
-		{name: "above write timeout", value: "45s"},
+		{name: "equal to write timeout", value: httpWriteTimeout.String()},
+		{name: "above write timeout", value: (httpWriteTimeout + 5*time.Second).String()},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("SITE_ID", "site-local")
-			t.Setenv("MONGO_URI", "mongodb://x")
-			t.Setenv("NATS_URL", "nats://x:4222")
-			t.Setenv("ROOM_RPC_TIMEOUT", tc.value)
-			_, err := loadConfig()
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "ROOM_RPC_TIMEOUT")
-		})
+	for _, envName := range []string{"ROOM_RPC_TIMEOUT", "FANOUT_TIMEOUT"} {
+		for _, tc := range values {
+			t.Run(envName+"/"+tc.name, func(t *testing.T) {
+				t.Setenv("SITE_ID", "site-local")
+				t.Setenv("MONGO_URI", "mongodb://x")
+				t.Setenv("NATS_URL", "nats://x:4222")
+				t.Setenv(envName, tc.value)
+				_, err := loadConfig()
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), envName)
+			})
+		}
 	}
 }

--- a/admin-service/config_test.go
+++ b/admin-service/config_test.go
@@ -18,7 +18,7 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	assert.Equal(t, "chat", cfg.MongoDB)
 	assert.Equal(t, 10, cfg.BcryptCost)
 	assert.Equal(t, 5*time.Second, cfg.RoomRPCTimeout)
-	assert.Equal(t, 5*time.Second, cfg.FanoutTimeout)
+	assert.Equal(t, 30*time.Second, cfg.FanoutTimeout)
 }
 
 func TestLoadConfig_RequiresSiteAndMongo(t *testing.T) {

--- a/admin-service/deploy/docker-compose.yml
+++ b/admin-service/deploy/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - NATS_URL=${NATS_URL:-nats://nats:4222}
       - NATS_CREDS_FILE=${NATS_CREDS_FILE:-/etc/nats/backend.creds}
       - ROOM_RPC_TIMEOUT=${ROOM_RPC_TIMEOUT:-5s}
+      - FANOUT_TIMEOUT=${FANOUT_TIMEOUT:-5s}
       - BCRYPT_COST=${BCRYPT_COST:-10}
       - SESSIONS_MAX_PER_ACCOUNT=${SESSIONS_MAX_PER_ACCOUNT:-100}
     volumes:

--- a/admin-service/deploy/docker-compose.yml
+++ b/admin-service/deploy/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - NATS_URL=${NATS_URL:-nats://nats:4222}
       - NATS_CREDS_FILE=${NATS_CREDS_FILE:-/etc/nats/backend.creds}
       - ROOM_RPC_TIMEOUT=${ROOM_RPC_TIMEOUT:-5s}
-      - FANOUT_TIMEOUT=${FANOUT_TIMEOUT:-5s}
+      - FANOUT_TIMEOUT=${FANOUT_TIMEOUT:-30s}
       - BCRYPT_COST=${BCRYPT_COST:-10}
       - SESSIONS_MAX_PER_ACCOUNT=${SESSIONS_MAX_PER_ACCOUNT:-100}
     volumes:

--- a/admin-service/handler.go
+++ b/admin-service/handler.go
@@ -27,6 +27,9 @@ type Handler struct {
 	cfg          Config
 	roomRPC      roomRequester
 	publishInbox func(ctx context.Context, subj string, data []byte) error
+	// remoteDests is remoteSites(cfg.AllSiteIDs, cfg.SiteID), computed once — the
+	// config never changes after startup, so no request needs to re-derive it.
+	remoteDests []string
 }
 
 // newHandler constructs a Handler with the given stores, config, room RPC, and
@@ -35,7 +38,10 @@ type Handler struct {
 // dereferencing it. A nil publishInbox is tolerated the same way — fanout
 // no-ops in tests that don't exercise it.
 func newHandler(store AdminStore, sessions session.Store, cfg Config, rpc roomRequester, publishInbox func(ctx context.Context, subj string, data []byte) error) *Handler { //nolint:gocritic // hugeParam: Config is a startup value copied once at construction
-	return &Handler{store: store, sessions: sessions, cfg: cfg, roomRPC: rpc, publishInbox: publishInbox}
+	return &Handler{
+		store: store, sessions: sessions, cfg: cfg, roomRPC: rpc, publishInbox: publishInbox,
+		remoteDests: remoteSites(cfg.AllSiteIDs, cfg.SiteID),
+	}
 }
 
 // nowMillis returns the current UTC time in unix milliseconds. Injected as a

--- a/admin-service/permissions.go
+++ b/admin-service/permissions.go
@@ -136,7 +136,8 @@ func displayUntilDate(t time.Time) string {
 // a permission for one or more subject accounts, all-or-nothing, with one
 // audit entry per created row. Validation order matches spec §4.4 exactly.
 func (h *Handler) createPermissions(c *gin.Context) {
-	ctx := c.Request.Context()
+	ctx, cancel := withRequestBudget(c)
+	defer cancel()
 
 	var req permissionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -322,12 +323,19 @@ func (h *Handler) publishPermissionFanout(ctx context.Context, permission model.
 	if h.publishInbox == nil || len(dests) == 0 {
 		return nil
 	}
-	// The request ctx has no deadline and dies if the client disconnects — neither fits:
-	// the caller's local work is done (create's ledger write already committed; resync
-	// writes nothing), so re-delivery runs to completion on its own budget
-	// (cfg.FanoutTimeout), shared by every lane. A destination that doesn't land within
-	// it is reported like any other unacknowledged publish.
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), h.cfg.FanoutTimeout)
+	// The request ctx dies if the client disconnects, which doesn't fit: the caller's
+	// local work is done (create's ledger write already committed; resync writes
+	// nothing), so re-delivery runs to completion on its own budget, shared by every
+	// lane. That budget is cfg.FanoutTimeout capped by the request's absolute deadline
+	// (withRequestBudget): the local work already spent part of net/http's write window,
+	// and a fresh full FanoutTimeout on top could outlive it — the connection would
+	// close before the caller reads syncFailures. A destination that doesn't land in
+	// time is reported like any other unacknowledged publish.
+	deadline := time.Now().Add(h.cfg.FanoutTimeout)
+	if reqDeadline, ok := ctx.Deadline(); ok && reqDeadline.Before(deadline) {
+		deadline = reqDeadline
+	}
+	ctx, cancel := context.WithDeadline(context.WithoutCancel(ctx), deadline)
 	defer cancel()
 
 	now := time.Now().UTC().UnixMilli()
@@ -403,6 +411,13 @@ func (h *Handler) publishPermissionFanout(ctx context.Context, permission model.
 	return failures
 }
 
+// withRequestBudget pins one absolute deadline for the whole request, measured from
+// handler entry: net/http's WriteTimeout runs from the request, so the fanout can
+// only spend what the local work left over — see publishPermissionFanout.
+func withRequestBudget(c *gin.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(c.Request.Context(), requestBudget)
+}
+
 // remoteSites filters allSiteIDs down to real remote destinations: no self, no blanks,
 // no repeats — a peer listed twice in ALL_SITE_IDS would otherwise get a second lane,
 // a duplicate publish, and a duplicate syncFailures entry.
@@ -431,7 +446,8 @@ type resyncPermissionsResponse struct {
 // and is idempotent (delivered states keep their stored watermarks, so remote guards
 // no-op anything already applied).
 func (h *Handler) resyncPermissions(c *gin.Context) {
-	ctx := c.Request.Context()
+	ctx, cancel := withRequestBudget(c)
+	defer cancel()
 	var req resyncPermissionsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		errhttp.Write(ctx, c, errcode.BadRequest("invalid request body", errcode.WithReason(errcode.AuthMissingFields)))

--- a/admin-service/permissions.go
+++ b/admin-service/permissions.go
@@ -318,7 +318,7 @@ type fanoutBatch struct {
 // aggregated per destination and never abort the fanout. Returns the destinations whose
 // publish was not acknowledged (nil when all landed).
 func (h *Handler) publishPermissionFanout(ctx context.Context, permission model.PermissionKey, batches []fanoutBatch) []string {
-	dests := remoteSites(h.cfg.AllSiteIDs, h.cfg.SiteID)
+	dests := h.remoteDests
 	if h.publishInbox == nil || len(dests) == 0 {
 		return nil
 	}
@@ -344,7 +344,7 @@ func (h *Handler) publishPermissionFanout(ctx context.Context, permission model.
 			if err != nil {
 				// Cannot serialize the event at all: every destination is out of sync.
 				slog.ErrorContext(ctx, "marshal user permissions event", "error", err)
-				return dests
+				return slices.Clone(dests)
 			}
 			chunks = append(chunks, payload)
 		}
@@ -403,10 +403,13 @@ func (h *Handler) publishPermissionFanout(ctx context.Context, permission model.
 	return failures
 }
 
-// remoteSites filters allSiteIDs down to real remote destinations.
+// remoteSites filters allSiteIDs down to real remote destinations: no self, no blanks,
+// no repeats — a peer listed twice in ALL_SITE_IDS would otherwise get a second lane,
+// a duplicate publish, and a duplicate syncFailures entry.
 func remoteSites(allSiteIDs []string, self string) []string {
 	var out []string
-	for _, dest := range allSiteIDs {
+	deduped, _ := dedupPreserveOrder(allSiteIDs)
+	for _, dest := range deduped {
 		if dest != "" && dest != self {
 			out = append(out, dest)
 		}

--- a/admin-service/permissions.go
+++ b/admin-service/permissions.go
@@ -295,8 +295,14 @@ func (h *Handler) createPermissions(c *gin.Context) {
 }
 
 // fanoutChunkSize bounds one UserPermissionsUpdated event's Accounts so a worst-case
-// event stays ~320KB — 3× margin under NATS's default 1MB max_payload.
-const fanoutChunkSize = 5000
+// chunk's INBOX envelope stays under the 128KB max_payload our NATS brokers are
+// configured with (the NATS default is 1MB, but ours is tightened). The envelope
+// base64-encodes the inner event (InboxEvent.Payload is []byte), so the wire size is
+// ~4/3 of the event JSON: 1000 accounts of up to 64 chars with every state bound set
+// land around 90KB — pinned by TestFanoutChunk_FitsBrokerMaxPayload. An oversized chunk
+// fails client-side with ErrMaxPayload on the create AND on every resync of the same
+// batch shape, so this margin is what keeps the fanout self-healing via resync.
+const fanoutChunkSize = 1000
 
 // fanoutBatch is one (accounts, state) unit of a cross-site fanout. The create path
 // sends a single batch; resync sends one per distinct stored state.

--- a/admin-service/permissions.go
+++ b/admin-service/permissions.go
@@ -285,9 +285,7 @@ func (h *Handler) createPermissions(c *gin.Context) {
 		slog.ErrorContext(ctx, "append permission audit entries failed", "action", action, "error", err)
 	}
 
-	fanoutCtx, cancelFanout := fanoutContext(ctx)
-	defer cancelFanout()
-	syncFailures := h.publishPermissionFanout(fanoutCtx, key, subjects, state)
+	syncFailures := h.publishPermissionFanout(ctx, key, []fanoutBatch{{accounts: subjects, state: state}})
 
 	c.JSON(http.StatusCreated, createPermissionsResponse{
 		Created:           len(grants),
@@ -300,60 +298,73 @@ func (h *Handler) createPermissions(c *gin.Context) {
 // event stays ~320KB — 3× margin under NATS's default 1MB max_payload.
 const fanoutChunkSize = 5000
 
-// fanoutTimeout is the server-side budget for ONE request's whole cross-site fanout,
-// however many publishPermissionFanout calls that takes — resync makes one per state
-// group, and a per-call budget would multiply wall time by the group count until it
-// exceeded httpWriteTimeout and the admin lost the syncFailures reply.
-const fanoutTimeout = 5 * time.Second
-
-// fanoutContext derives the fanout budget from a request ctx. The request ctx has no
-// deadline and dies if the client disconnects — neither fits: the ledger write already
-// committed, so fanout runs to completion on its own budget. A destination that doesn't
-// land within it is reported in syncFailures like any other unacknowledged publish.
-func fanoutContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.WithoutCancel(ctx), fanoutTimeout)
+// fanoutBatch is one (accounts, state) unit of a cross-site fanout. The create path
+// sends a single batch; resync sends one per distinct stored state.
+type fanoutBatch struct {
+	accounts []string
+	state    model.PermissionState
 }
 
-// publishPermissionFanout publishes the batch to every remote site's INBOX, one event
-// per site per chunk of accounts. Failures are logged and aggregated per destination and
-// never abort the fanout — one dead peer must not block the others. Returns the
-// destinations whose publish was not acknowledged (nil when all landed). ctx must come
-// from fanoutContext — the caller owns the budget so repeated calls share one.
-func (h *Handler) publishPermissionFanout(ctx context.Context, permission model.PermissionKey, accounts []string, state model.PermissionState) []string {
+// publishPermissionFanout publishes every batch to every remote site's INBOX, one event
+// per site per chunk of accounts. Each destination gets its own goroutine that walks ALL
+// batches' chunks, so a stalled peer consumes only its own lane and can never hand a
+// later batch an expired ctx meant for a healthy peer. Failures are logged and
+// aggregated per destination and never abort the fanout. Returns the destinations whose
+// publish was not acknowledged (nil when all landed).
+func (h *Handler) publishPermissionFanout(ctx context.Context, permission model.PermissionKey, batches []fanoutBatch) []string {
 	dests := remoteSites(h.cfg.AllSiteIDs, h.cfg.SiteID)
-	if h.publishInbox == nil || len(accounts) == 0 || len(dests) == 0 {
+	if h.publishInbox == nil || len(dests) == 0 {
 		return nil
 	}
+	// The request ctx has no deadline and dies if the client disconnects — neither fits:
+	// the caller's local work is done (create's ledger write already committed; resync
+	// writes nothing), so re-delivery runs to completion on its own budget
+	// (cfg.FanoutTimeout), shared by every lane. A destination that doesn't land within
+	// it is reported like any other unacknowledged publish.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), h.cfg.FanoutTimeout)
+	defer cancel()
 
 	now := time.Now().UTC().UnixMilli()
 	// Marshal each chunk's payload once; only the envelope differs per destination.
 	var chunks [][]byte
-	for start := 0; start < len(accounts); start += fanoutChunkSize {
-		end := min(start+fanoutChunkSize, len(accounts))
-		payload, err := json.Marshal(model.UserPermissionsUpdated{
-			Permission: permission,
-			Accounts:   accounts[start:end],
-			State:      state,
-			Timestamp:  now,
-		})
-		if err != nil {
-			// Cannot serialize the event at all: every destination is out of sync.
-			slog.ErrorContext(ctx, "marshal user permissions event", "error", err)
-			return dests
+	for _, b := range batches {
+		for accounts := range slices.Chunk(b.accounts, fanoutChunkSize) {
+			payload, err := json.Marshal(model.UserPermissionsUpdated{
+				Permission: permission,
+				Accounts:   accounts,
+				State:      b.state,
+				Timestamp:  now,
+			})
+			if err != nil {
+				// Cannot serialize the event at all: every destination is out of sync.
+				slog.ErrorContext(ctx, "marshal user permissions event", "error", err)
+				return dests
+			}
+			chunks = append(chunks, payload)
 		}
-		chunks = append(chunks, payload)
+	}
+	if len(chunks) == 0 {
+		return nil
 	}
 
-	// One goroutine per destination. Destinations are independent and share ONE budget
-	// (fanoutContext), so publishing them serially lets a single unreachable peer burn
-	// the whole budget and hand every peer behind it an already-expired ctx — reporting
-	// healthy sites as sync failures. Results land in a position-indexed slice, so no
-	// lock is needed and the reported order stays the configured destination order.
+	// One goroutine per destination. Destinations are independent and share ONE budget,
+	// so publishing them serially lets a single unreachable peer burn the whole budget
+	// and hand every peer behind it an already-expired ctx — reporting healthy sites as
+	// sync failures. Results land in a position-indexed slice, so no lock is needed and
+	// the reported order stays the configured destination order.
 	failed := make([]bool, len(dests))
 	var g errgroup.Group
 	for i, dest := range dests {
 		g.Go(func() error {
-			for _, payload := range chunks {
+			subj := subject.InboxExternal(dest, model.InboxUserPermissionsUpdated)
+			for n, payload := range chunks {
+				if err := ctx.Err(); err != nil {
+					// The budget is gone: every remaining chunk would fail the same way, so
+					// report the lane once instead of once per chunk.
+					slog.ErrorContext(ctx, "fanout budget expired", "dest", dest, "chunks_skipped", len(chunks)-n, "error", err)
+					failed[i] = true
+					break
+				}
 				data, err := json.Marshal(model.InboxEvent{
 					Type:       model.InboxUserPermissionsUpdated,
 					SiteID:     h.cfg.SiteID,
@@ -366,7 +377,7 @@ func (h *Handler) publishPermissionFanout(ctx context.Context, permission model.
 					failed[i] = true
 					continue
 				}
-				if err := h.publishInbox(ctx, subject.InboxExternal(dest, model.InboxUserPermissionsUpdated), data); err != nil {
+				if err := h.publishInbox(ctx, subj, data); err != nil {
 					// Not self-healing like status/settings: surface it, don't swallow it.
 					slog.ErrorContext(ctx, "publish permissions inbox event", "dest", dest, "error", err)
 					failed[i] = true
@@ -448,23 +459,18 @@ func (h *Handler) resyncPermissions(c *gin.Context) {
 		groups[string(k)] = append(groups[string(k)], account)
 		states[string(k)] = *st
 	}
-	// ONE budget for the whole resync, not one per group: groups are keyed on
+	// ONE fanout call — hence ONE budget — for the whole resync: groups are keyed on
 	// UpdatedAt, so accounts granted across N admin submits yield N groups, and a
 	// per-group budget would stretch an unreachable peer's wall time to N × the
 	// budget — past httpWriteTimeout, which drops the connection before the admin
-	// can be told which peers to retry.
-	fanoutCtx, cancel := fanoutContext(ctx)
-	defer cancel()
-	seen := make(map[string]struct{})
-	var failures []string
+	// can be told which peers to retry. Handing every group to a single call keeps
+	// the budget shared while each destination walks all groups in its own lane, so
+	// a stalled peer cannot starve healthy peers of the later groups.
+	batches := make([]fanoutBatch, 0, len(groups))
 	for k, groupAccounts := range groups {
-		for _, dest := range h.publishPermissionFanout(fanoutCtx, key, groupAccounts, states[k]) {
-			if _, dup := seen[dest]; !dup {
-				seen[dest] = struct{}{}
-				failures = append(failures, dest)
-			}
-		}
+		batches = append(batches, fanoutBatch{accounts: groupAccounts, state: states[k]})
 	}
+	failures := h.publishPermissionFanout(ctx, key, batches)
 	c.JSON(http.StatusOK, resyncPermissionsResponse{SyncFailures: failures})
 }
 

--- a/admin-service/permissions_test.go
+++ b/admin-service/permissions_test.go
@@ -913,10 +913,10 @@ func TestHandler_createPermissions_Fanout(t *testing.T) {
 		assert.WithinDuration(t, time.Now().Add(h.cfg.FanoutTimeout), callDeadline, 2*time.Second, "fanout deadline must be the configured fanout budget, not per-publish and not unbounded")
 	})
 
-	t.Run("chunking: 5001 accounts split into 5000+1 per destination", func(t *testing.T) {
+	t.Run("chunking: one account over the chunk size splits into a full chunk plus one per destination", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		m := NewMockAdminStore(ctrl)
-		accounts := manyAccounts(5001)
+		accounts := manyAccounts(fanoutChunkSize + 1)
 		mockPermissionStoreOK(m, accounts)
 
 		var log publishLog
@@ -944,7 +944,7 @@ func TestHandler_createPermissions_Fanout(t *testing.T) {
 		}
 
 		for _, dest := range []string{"site-b", "site-c"} {
-			assert.ElementsMatch(t, []int{5000, 1}, chunkSizesByDest[dest], "dest %s chunk sizes", dest)
+			assert.ElementsMatch(t, []int{fanoutChunkSize, 1}, chunkSizesByDest[dest], "dest %s chunk sizes", dest)
 			assert.ElementsMatch(t, accounts, accountsByDest[dest], "dest %s account union must be complete, no dupes", dest)
 		}
 		for _, ts := range timestamps {
@@ -1056,6 +1056,37 @@ func postResync(h *Handler, body map[string]any, t *testing.T) *httptest.Respons
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
 	return w
+}
+
+// brokerMaxPayload is the max_payload our NATS brokers are configured with. The chunk
+// size is a compile-time guess at how many accounts fit under it, so this pins the
+// worst case the guess assumes — with the old 5000-account chunk this test fails.
+const brokerMaxPayload = 128 << 10
+
+func TestFanoutChunk_FitsBrokerMaxPayload(t *testing.T) {
+	// Worst case: a full chunk of long accounts with every state bound set. The INBOX
+	// envelope base64-encodes the inner event (InboxEvent.Payload is []byte), so the
+	// bytes on the wire are ~4/3 of the event JSON — measure the envelope, not the event.
+	accounts := make([]string, fanoutChunkSize)
+	for i := range accounts {
+		accounts[i] = fmt.Sprintf("%064d", i) // 64-char accounts, well past any real directory id
+	}
+	state := model.PermissionState{
+		Granted:       true,
+		EffectiveFrom: timePtr(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+		ExpiresAt:     timePtr(time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)),
+		UpdatedAt:     time.Date(2026, 6, 1, 8, 30, 0, 0, time.UTC),
+	}
+
+	var log publishLog
+	h := newHandler(nil, emptySessionStore(), fanoutTestCfg(), nil, log.publish)
+	failures := h.publishPermissionFanout(context.Background(), model.PermissionExternalImageView, []fanoutBatch{{accounts: accounts, state: state}})
+
+	require.Nil(t, failures)
+	require.Len(t, log.data, 2, "one full chunk -> one envelope per remote dest")
+	for _, data := range log.data {
+		assert.Less(t, len(data), brokerMaxPayload, "a worst-case chunk envelope must clear the broker max_payload")
+	}
 }
 
 func TestHandler_resyncPermissions(t *testing.T) {

--- a/admin-service/permissions_test.go
+++ b/admin-service/permissions_test.go
@@ -1297,7 +1297,7 @@ func TestHandler_resyncPermissions(t *testing.T) {
 		// Regression pin: the budget used to be established inside publishPermissionFanout,
 		// which resync called once PER state group. Groups are keyed on UpdatedAt, so N admin
 		// submits yield N groups and one unreachable peer cost N × the budget in wall time —
-		// past httpWriteTimeout (30s) at N ≥ 6, so net/http dropped the connection before the
+		// past httpWriteTimeout at small N, so net/http dropped the connection before the
 		// handler could report syncFailures. One shared budget = one shared deadline instant.
 		ctrl := gomock.NewController(t)
 		m := NewMockAdminStore(ctrl)

--- a/admin-service/permissions_test.go
+++ b/admin-service/permissions_test.go
@@ -1034,6 +1034,7 @@ func TestRemoteSites(t *testing.T) {
 		{"filters out self and blank entries", []string{"", "site-a", "site-b", "site-c"}, "site-a", []string{"site-b", "site-c"}},
 		{"empty AllSiteIDs → nil", nil, "site-a", nil},
 		{"only self → nil", []string{"site-a"}, "site-a", nil},
+		{"a repeated peer gets ONE lane, first-occurrence order kept", []string{"site-c", "site-b", "site-c", "site-a", "site-b"}, "site-a", []string{"site-c", "site-b"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/admin-service/permissions_test.go
+++ b/admin-service/permissions_test.go
@@ -913,6 +913,48 @@ func TestHandler_createPermissions_Fanout(t *testing.T) {
 		assert.WithinDuration(t, time.Now().Add(h.cfg.FanoutTimeout), callDeadline, 2*time.Second, "fanout deadline must be the configured fanout budget, not per-publish and not unbounded")
 	})
 
+	t.Run("fanout deadline is capped by the whole-request budget, not a fresh FANOUT_TIMEOUT", func(t *testing.T) {
+		// net/http's WriteTimeout runs from the request, not from the fanout: local work
+		// (Mongo tx, audit) that runs first eats into it. A fanout budget that always
+		// starts fresh could finish after net/http closed the connection, losing
+		// syncFailures. So the handler pins one absolute request deadline at entry and
+		// the fanout takes the earlier of it and now+FanoutTimeout.
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl)
+		accounts := []string{"alice"}
+		mockPermissionStoreOK(m, accounts)
+
+		var mu sync.Mutex
+		var callDeadline time.Time
+		publish := func(ctx context.Context, _ string, _ []byte) error {
+			mu.Lock()
+			defer mu.Unlock()
+			callDeadline, _ = ctx.Deadline()
+			return nil
+		}
+		cfg := fanoutTestCfg()
+		cfg.FanoutTimeout = time.Hour // far past the request budget: the request budget must win
+		h := newHandler(m, emptySessionStore(), cfg, nil, publish)
+		start := time.Now()
+		require.Equal(t, http.StatusCreated, postPermissions(h, fanoutRequestBody(accounts), t).Code)
+
+		mu.Lock()
+		defer mu.Unlock()
+		assert.WithinDuration(t, start.Add(requestBudget), callDeadline, 2*time.Second,
+			"fanout deadline must be bounded by the request budget measured from handler entry")
+		assert.Less(t, requestBudget, httpWriteTimeout, "the request budget must leave room to write the response before net/http's WriteTimeout")
+	})
+
+	t.Run("an already-spent request budget reports every destination without publishing", func(t *testing.T) {
+		var log publishLog
+		h := newHandler(nil, emptySessionStore(), fanoutTestCfg(), nil, log.publish)
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+		failures := h.publishPermissionFanout(ctx, model.PermissionExternalImageView, []fanoutBatch{{accounts: []string{"alice"}, state: model.PermissionState{Granted: true}}})
+		assert.Equal(t, []string{"site-b", "site-c"}, failures)
+		assert.Empty(t, log.subjects, "no publish may run on an expired budget")
+	})
+
 	t.Run("chunking: one account over the chunk size splits into a full chunk plus one per destination", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		m := NewMockAdminStore(ctrl)

--- a/admin-service/permissions_test.go
+++ b/admin-service/permissions_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -730,7 +731,7 @@ func TestHandler_createPermissions(t *testing.T) {
 // fanoutTestCfg is the 3-site fixture used by every fanout scenario below:
 // site-a (this site) publishing to remotes site-b and site-c.
 func fanoutTestCfg() Config {
-	return Config{SiteID: "site-a", AllSiteIDs: []string{"site-a", "site-b", "site-c"}}
+	return Config{SiteID: "site-a", AllSiteIDs: []string{"site-a", "site-b", "site-c"}, FanoutTimeout: 5 * time.Second}
 }
 
 // fanoutRequestBody returns a valid grant request for the given subject accounts.
@@ -909,7 +910,7 @@ func TestHandler_createPermissions_Fanout(t *testing.T) {
 
 		assert.NoError(t, callErr, "publish ctx must not already be canceled/expired at call time — it must be severed from the client's cancellation (context.WithoutCancel)")
 		require.True(t, callHasDeadline, "publish ctx must carry the fanout's own deadline, not run unbounded")
-		assert.WithinDuration(t, time.Now().Add(5*time.Second), callDeadline, 2*time.Second, "fanout deadline must be ~5s, not per-publish and not unbounded")
+		assert.WithinDuration(t, time.Now().Add(h.cfg.FanoutTimeout), callDeadline, 2*time.Second, "fanout deadline must be the configured fanout budget, not per-publish and not unbounded")
 	})
 
 	t.Run("chunking: 5001 accounts split into 5000+1 per destination", func(t *testing.T) {
@@ -1119,6 +1120,22 @@ func TestHandler_resyncPermissions(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
 
+	t.Run("no requested account has a stored state → 200, nothing published, syncFailures omitted", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl)
+		perms := map[string]*model.UserPermissions{"alice": {}} // doc exists, permission never recorded; carol has no doc
+		m.EXPECT().GetUserPermissionsForAccounts(gomock.Any(), gomock.Any()).Return(perms, nil)
+
+		var log publishLog
+		h := newHandler(m, emptySessionStore(), fanoutTestCfg(), nil, log.publish)
+		w := postResync(h, map[string]any{"permission": knownPermission, "accounts": []string{"alice", "carol"}}, t)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Empty(t, log.data, "nothing to re-deliver → no publish, even with remotes and a live publisher")
+		_, has := respBody(t, w)["syncFailures"]
+		assert.False(t, has, "syncFailures is omitted when no destination was attempted")
+	})
+
 	t.Run("two accounts sharing one stored state → one fanout group, one event per dest, stored UpdatedAt preserved", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		m := NewMockAdminStore(ctrl)
@@ -1247,7 +1264,7 @@ func TestHandler_resyncPermissions(t *testing.T) {
 
 	t.Run("every group shares ONE fanout budget — the deadline does not restart per group", func(t *testing.T) {
 		// Regression pin: the budget used to be established inside publishPermissionFanout,
-		// which resync calls once PER state group. Groups are keyed on UpdatedAt, so N admin
+		// which resync called once PER state group. Groups are keyed on UpdatedAt, so N admin
 		// submits yield N groups and one unreachable peer cost N × the budget in wall time —
 		// past httpWriteTimeout (30s) at N ≥ 6, so net/http dropped the connection before the
 		// handler could report syncFailures. One shared budget = one shared deadline instant.
@@ -1280,12 +1297,65 @@ func TestHandler_resyncPermissions(t *testing.T) {
 
 		require.Len(t, deadlines, 4, "2 groups x 2 remote dests")
 		require.True(t, allHaveDeadline, "every publish ctx must carry the fanout budget's deadline")
-		assert.WithinDuration(t, time.Now().Add(fanoutTimeout), deadlines[0], 2*time.Second, "the shared budget must be the ~5s fanout budget")
+		assert.WithinDuration(t, time.Now().Add(h.cfg.FanoutTimeout), deadlines[0], 2*time.Second, "the shared budget must be the configured fanout budget")
 		for i, d := range deadlines {
 			assert.True(t, d.Equal(deadlines[0]),
 				"publish %d saw a different deadline (%v) than the first (%v) — each group got a fresh budget instead of sharing the request's one",
 				i, d, deadlines[0])
 		}
+	})
+
+	t.Run("a stalled peer consumes only its own lane — healthy peers still receive every group", func(t *testing.T) {
+		// Regression pin for PR review: resync used to invoke the fanout once per state
+		// group, sequentially, under the shared budget. A peer that blocked until the
+		// deadline on the first group handed every later group an already-expired ctx,
+		// so healthy peers missed those groups and were reported as sync failures too.
+		ctrl := gomock.NewController(t)
+		m := NewMockAdminStore(ctrl)
+		stateB := model.PermissionState{Granted: false, UpdatedAt: time.Date(2025, 7, 15, 9, 0, 0, 0, time.UTC)}
+		perms := map[string]*model.UserPermissions{
+			"alice": {ExternalImageView: &storedState},
+			"bob":   {ExternalImageView: &stateB},
+		}
+		m.EXPECT().GetUserPermissionsForAccounts(gomock.Any(), gomock.Any()).Return(perms, nil)
+
+		var log publishLog
+		var siteBPublishes atomic.Int32
+		publish := func(ctx context.Context, subj string, data []byte) error {
+			if strings.Contains(subj, ".site-b.") {
+				siteBPublishes.Add(1)
+				<-ctx.Done() // site-b stalls until the fanout budget expires
+				return ctx.Err()
+			}
+			if err := ctx.Err(); err != nil { // a real publish fails on an expired budget
+				return err
+			}
+			return log.publish(ctx, subj, data)
+		}
+
+		cfg := fanoutTestCfg()
+		cfg.FanoutTimeout = 150 * time.Millisecond // keep the stalled lane short in tests
+		h := newHandler(m, emptySessionStore(), cfg, nil, publish)
+
+		w := postResync(h, map[string]any{"permission": knownPermission, "accounts": []string{"alice", "bob"}}, t)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		body := respBody(t, w)
+		assert.Equal(t, []any{"site-b"}, body["syncFailures"],
+			"only the stalled peer may be reported — site-c must not inherit an expired ctx from site-b's lane")
+		assert.Equal(t, int32(1), siteBPublishes.Load(),
+			"once the budget is gone the stalled lane must stop, not fail (and log) every remaining chunk")
+
+		var siteCAccounts []string
+		for _, data := range log.data {
+			var evt model.InboxEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			var payload model.UserPermissionsUpdated
+			require.NoError(t, json.Unmarshal(evt.Payload, &payload))
+			siteCAccounts = append(siteCAccounts, payload.Accounts...)
+		}
+		assert.ElementsMatch(t, []string{"alice", "bob"}, siteCAccounts,
+			"site-c must receive BOTH state groups despite site-b stalling")
 	})
 
 	t.Run("nil bounds vs bounds set exactly at the Unix epoch are distinct states — must not collide into one group", func(t *testing.T) {

--- a/docs/superpowers/specs/2026-08-10-user-permission-whitelist-design.md
+++ b/docs/superpowers/specs/2026-08-10-user-permission-whitelist-design.md
@@ -9,7 +9,12 @@ audit-only; admin-frontend changes deferred to the next round; single-admin-site
 deployment assumption — `SiteID` dropped from the ledger, subjects company-wide, reason
 wording clarified as optional), amended 2026-08-13 (bulk round: `MaxSubjects` and the
 request-body limit removed, fanout chunked at 5,000 accounts/event, console bulk-paste +
-resend — see `2026-08-13-permission-bulk-frontend-design.md`)
+resend — see `2026-08-13-permission-bulk-frontend-design.md`), amended 2026-08-17
+(post-merge review round: chunk retuned to 1,000 accounts/event for the 128KB broker
+`max_payload`; fanout budget is `FANOUT_TIMEOUT` (30s) validated at startup below the 40s
+HTTP write timeout; each destination walks every chunk in its own lane so a stalled peer
+cannot starve healthy ones; resync hands all state groups to one fanout call — see the
+2026-08-13 spec's amendment)
 
 ## 1. Overview
 
@@ -378,19 +383,21 @@ const InboxUserPermissionsUpdated InboxEventType = "user_permissions_updated"
 // guard (State.UpdatedAt), so delivery may be duplicated or reordered safely.
 type UserPermissionsUpdated struct {
     Permission PermissionKey   `json:"permission" bson:"permission"`
-    Accounts   []string        `json:"accounts"   bson:"accounts"`   // ≤ 5,000 per event (chunked, 2026-08-13)
+    Accounts   []string        `json:"accounts"   bson:"accounts"`   // ≤ 1,000 per event (chunked 2026-08-13; retuned 2026-08-17)
     State      PermissionState `json:"state"      bson:"state"`
     Timestamp  int64           `json:"timestamp"  bson:"timestamp"`  // event publish time
 }
 ```
 
-One POST → one event per remote site **per chunk of ≤5,000 accounts** (2026-08-13: the
-batch is chunked to stay under NATS's `max_payload`; each site has its own INBOX
-stream), published to
+One POST → one event per remote site **per chunk of ≤1,000 accounts** (2026-08-13: the
+batch is chunked to stay under the brokers' `max_payload`; 2026-08-17: retuned from 5,000
+because our brokers run 128KB, not NATS's 1MB default, and the `InboxEvent` envelope
+base64-encodes the payload; each site has its own INBOX stream), published to
 `subject.InboxExternal(dest, model.InboxUserPermissionsUpdated)` =
 `chat.inbox.{dest}.external.user_permissions_updated`, wrapped in the standard
-`InboxEvent` envelope, skipping self and blank entries of `ALL_SITE_IDS`. The payload is
-marshaled once. No `Nats-Msg-Id` dedup — the guarded apply is idempotent, the same
+`InboxEvent` envelope, skipping self, blank, and repeated entries of `ALL_SITE_IDS`. The
+payload is marshaled once; each destination publishes every chunk in its own goroutine
+lane under one shared `FANOUT_TIMEOUT` budget (2026-08-17). No `Nats-Msg-Id` dedup — the guarded apply is idempotent, the same
 rationale user-service's publisher documents for status/settings.
 
 **Success means the destination stream acknowledged the publish** — the event is in that

--- a/docs/superpowers/specs/2026-08-10-user-permission-whitelist-design.md
+++ b/docs/superpowers/specs/2026-08-10-user-permission-whitelist-design.md
@@ -397,7 +397,7 @@ base64-encodes the payload; each site has its own INBOX stream), published to
 `chat.inbox.{dest}.external.user_permissions_updated`, wrapped in the standard
 `InboxEvent` envelope, skipping self, blank, and repeated entries of `ALL_SITE_IDS`. The
 payload is marshaled once; each destination publishes every chunk in its own goroutine
-lane under one shared `FANOUT_TIMEOUT` budget (2026-08-17). No `Nats-Msg-Id` dedup — the guarded apply is idempotent, the same
+lane under one shared budget: `FANOUT_TIMEOUT` capped by the request's absolute deadline (handler entry + 38s, i.e. the 40s HTTP write timeout minus a response margin), so local work that already spent part of the write window can't let the fanout outlive the connection (2026-08-18). No `Nats-Msg-Id` dedup — the guarded apply is idempotent, the same
 rationale user-service's publisher documents for status/settings.
 
 **Success means the destination stream acknowledged the publish** — the event is in that

--- a/docs/superpowers/specs/2026-08-13-permission-bulk-frontend-design.md
+++ b/docs/superpowers/specs/2026-08-13-permission-bulk-frontend-design.md
@@ -1,7 +1,11 @@
 # Permission Bulk Update & Resend (admin-frontend round) — Design
 
 **Status:** Approved, ready for planning
-**Date:** 2026-08-13 (resend mechanism revised same day: re-POST → minimal resync)
+**Date:** 2026-08-13 (resend mechanism revised same day: re-POST → minimal resync);
+amended 2026-08-17 (post-merge review round: chunk 5,000 → 1,000 accounts/event for the
+128KB broker `max_payload`; per-destination fanout lanes; resync hands every state group
+to one fanout call; fanout budget `FANOUT_TIMEOUT` 30s, validated at startup below the 40s
+HTTP write timeout)
 **Builds on:** `2026-08-10-user-permission-whitelist-design.md` (as amended 2026-08-12).
 This is the admin-frontend round that spec deferred, plus the request-limit removals and
 fanout chunking that the bulk requirement forced onto the backend.
@@ -31,7 +35,7 @@ changes are the deleted `MaxSubjects` constant and one new admin endpoint (§5).
 | Bulk input | **Paste-list mode** toggle beside the existing AccountPicker | CSV upload; both |
 | Subject count cap | **Removed** (`MaxSubjects` deleted) | keep 200; raise to 1,000 or 10,000 |
 | Request body cap | **Removed** (1MB middleware deleted) — user decision 2026-08-13, **against the recorded recommendation**; risk §9.1 | keep 1MB |
-| NATS payload ceiling | **Chunked fanout**, 5,000 accounts per event | single event (would cap a batch at ~20k accounts) |
+| NATS payload ceiling | **Chunked fanout**, 1,000 accounts per event (5,000 until 2026-08-17 — the brokers run a 128KB `max_payload`, not NATS's 1MB default) | single event (would cap a batch at ~20k accounts) |
 | Mongo transaction | **Single transaction kept** — all-or-nothing preserved at any N | chunked transaction (loses atomicity) |
 
 Consequence the resend choice accepts (unchanged by the revision): the failure
@@ -71,16 +75,21 @@ against an accidental whole-company paste is the visible count in the console (�
 ## 4. Chunked fanout (admin-service)
 
 ```go
-// ≈320KB per event at 64 bytes/account — 3× margin under NATS's default 1MB max_payload.
-const fanoutChunkSize = 5000
+// ≈90KB per INBOX envelope at 64 bytes/account (the envelope base64-encodes the payload)
+// under the 128KB max_payload our brokers run — retuned from 5000 on 2026-08-17.
+const fanoutChunkSize = 1000
 ```
 
-- The publish loop becomes: for each remote site × each chunk of ≤5,000 accounts → one
+- The publish loop becomes: for each remote site × each chunk of ≤1,000 accounts → one
   `UserPermissionsUpdated` event. Same event shape; `Accounts` carries the chunk;
   `Permission`, `State`, and `Timestamp` are identical across all chunks of one batch.
-- A failed publish marks the destination in `syncFailures` (listed once) and the loop
-  **continues** through the remaining chunks and destinations — maximize delivery,
-  aggregate failures per destination. The response shape is unchanged.
+- 2026-08-17: each destination walks every chunk in its **own goroutine lane** under one
+  shared budget (`FANOUT_TIMEOUT`, default 30s, validated at startup to stay below the
+  40s HTTP write timeout so `syncFailures` is always deliverable). A stalled peer burns
+  only its own lane; once the budget is gone the lane stops and is reported once.
+- A failed publish marks the destination in `syncFailures` (listed once) and the lane
+  **continues** through its remaining chunks — maximize delivery, aggregate failures per
+  destination. The response shape is unchanged.
 - Partial chunk delivery is safe by construction: remote applies are per-account guarded
   and idempotent, so chunks may arrive in any order, duplicated, or not at all; a resync
   re-publishes every chunk and already-applied accounts no-op.
@@ -101,8 +110,10 @@ permission routes.
 **Semantics: re-delivery, not re-recording.** The endpoint reads each account's current
 materialized state from the local `users` collection (one batch read, projection
 `{account, permissions.<field>}`), groups the accounts by identical state — one group per
-original batch in the common case; more if another write landed in between — and re-runs
-the chunked fanout (§4) once per group. It always delivers the **current** truth, never
+original batch in the common case; more if another write landed in between — and hands
+every group to **one** chunked fanout call (§4; 2026-08-17: it used to call the fanout
+once per group, which let a peer stalled on the first group starve healthy peers of the
+later ones). It always delivers the **current** truth, never
 the original request's possibly-stale state. It writes nothing: no ledger rows, no audit
 entries, no user-doc updates.
 
@@ -177,8 +188,8 @@ expandable list instead of dumping thousands of rows.
 | Area | Cases |
 |---|---|
 | admin-service validation | empty list still rejected (`invalid_subject_count`); a large list (e.g. 10,001 accounts) accepted; body-limit middleware tests removed |
-| chunked fanout (unit, captured publish func) | N ≤ 5,000 → one event per dest; 5,001 → two; chunk boundaries exact and complete; a dest failing on any chunk → listed once in `syncFailures` while other chunks/dests are still attempted; per-chunk payload shape (same state/timestamp, chunked accounts) |
-| resync handler (unit) | groups accounts by identical state and fans out once per group; accounts with no doc/state are skipped; **no ledger/audit/user-doc writes** (store mock asserts no mutating calls); unknown key → `unknown_permission`; empty accounts → `invalid_subject_count`; `syncFailures` aggregation matches the write path |
+| chunked fanout (unit, captured publish func) | N ≤ 1,000 → one event per dest; 1,001 → two; a worst-case chunk envelope stays under 128KB; a stalled peer consumes only its own lane; chunk boundaries exact and complete; a dest failing on any chunk → listed once in `syncFailures` while other chunks/dests are still attempted; per-chunk payload shape (same state/timestamp, chunked accounts) |
+| resync handler (unit) | groups accounts by identical state and fans out all groups in one call (one shared deadline); accounts with no doc/state are skipped; **no ledger/audit/user-doc writes** (store mock asserts no mutating calls); unknown key → `unknown_permission`; empty accounts → `invalid_subject_count`; `syncFailures` aggregation matches the write path |
 | admin-frontend (Vitest, existing dialog patterns) | paste parsing (separators, trim, dedup, count); zero-parse disables submit; mode badges + active-mode-wins payload; submit-label count; `syncFailures` banner + button posts `{permission, accounts}` to resync (not the original body) + in-flight lock + banner update from the resync response; strip action filters both input modes; long-list collapse |
 
 ## 8. Documentation


### PR DESCRIPTION
## Summary

Post-merge fixes to the `admin-service` cross-site **permission fanout**, answering the review threads on #265. Scope is the four items accepted for this round; the rest are recorded as deferred below.

| Commit | Review thread | Change |
|---|---|---|
| `fix: fan out resync per destination…` | [julianshen — a blocked peer prevents later resync groups reaching healthy peers](https://github.com/hmchangw/newchat/pull/265#discussion_r3776656870) | Resync hands every `(accounts, state)` group to **one** fanout call; each destination walks all groups' chunks in its own goroutine lane under the shared budget, so a stalled peer burns only its own lane and can no longer hand a later group an expired ctx. Once the budget is gone a lane stops and is reported once. The budget moves from a package constant to **`FANOUT_TIMEOUT`** config, validated at startup below the HTTP write timeout the same way `ROOM_RPC_TIMEOUT` is (this is also what lets the stalled-peer regression test shrink it via `cfg`). |
| `fix: cap fanout chunks at 1000 accounts…` | [mliu33 — we only have 128kb max size, use 1000?](https://github.com/hmchangw/newchat/pull/265#discussion_r3779998931) | 5000 → 1000 accounts/event. The INBOX envelope base64-encodes the payload (`InboxEvent.Payload` is `[]byte`, ~4/3 inflation); `TestFanoutChunk_FitsBrokerMaxPayload` pushes a worst-case chunk (1000 × 64-char accounts, every state bound set) through the real publisher and asserts the envelope stays under 128KB (~90KB; the old 5000 fails it). |
| `fix: raise the fanout budget to 30s and the HTTP write timeout to 40s` | [mliu33 — too short for whole-site fanout, use 30s](https://github.com/hmchangw/newchat/pull/265#discussion_r3780070538) | `FANOUT_TIMEOUT` default 5s → 30s. `net/http`'s `WriteTimeout` counts in-handler time, so it moves 30s → 40s to keep the budget strictly below it — otherwise the connection drops before the admin can read `syncFailures`. `loadConfig` rejects any `FANOUT_TIMEOUT` at or above the write timeout. |
| `refactor: precompute remote fanout destinations at construction, deduped` | [mliu33 — build this up initially instead of looping every time](https://github.com/hmchangw/newchat/pull/265#discussion_r3780061667) | `remoteSites(cfg.AllSiteIDs, cfg.SiteID)` computed once in `newHandler`. Also collapses a peer listed twice in `ALL_SITE_IDS` (it used to get two lanes and could appear twice in `syncFailures`). |
| `docs(specs): amend…` | — | Design specs under `docs/superpowers/specs/` amended for this round (chunk size, lanes, `FANOUT_TIMEOUT`, single-call resync). |

Wire shape is unchanged (`inbox-worker` needs nothing); the only client-visible difference is that `POST /v1/admin/permissions` and `/resync` may now take up to 30s to answer while a remote peer is unreachable.

### New config

`FANOUT_TIMEOUT` (default `30s`, must be `> 0` and `< 40s`) — added to `admin-service/deploy/docker-compose.yml`. Fail-fast at startup like `ROOM_RPC_TIMEOUT`.

### Deploy note

With a stalled peer every permission POST/resync now runs for up to 30s. Any ingress / reverse proxy in front of admin-service needs an upstream read timeout ≥ 40s, or it will return 502/504 before the `syncFailures` reply arrives — the reply this round exists to deliver.

## Testing

- `make lint` clean; `make test SERVICE=admin-service` (race) green; every commit in the range is individually green.
- New/extended tests: stalled-peer lane isolation (deterministic, ctx-driven, no `time.Sleep`), single shared deadline across resync groups, worst-case chunk envelope under 128KB, empty-batch resync, `FANOUT_TIMEOUT` load/validation/override, `remoteSites` dedupe.
- Final whole-branch review: 0 critical; the one important finding (unpinned chunk-size assumption) is fixed in this branch.
- SAST: gosec and govulncheck clean locally; semgrep is not installed on this machine and runs in the CI `sast` job.

## Deferred from the #265 review (owner decision, not in this PR)

- [julianshen — wall-clock watermarks can discard revocations across replicas (monotonic revision)](https://github.com/hmchangw/newchat/pull/265#discussion_r3776656851) — needs a per-user revision design; tracked as follow-up.
- [julianshen — a crash after commit loses the cross-site update (durable OUTBOX for the fanout)](https://github.com/hmchangw/newchat/pull/265#discussion_r3776656858) — the in-process best-effort fanout + `syncFailures` + manual resync stays for now; the OUTBOX-lite migration is the recorded upgrade path.
- [julianshen — apply is a silent no-op when the remote site has no user doc](https://github.com/hmchangw/newchat/pull/265#discussion_r3776656879), [unknown-key runbook note](https://github.com/hmchangw/newchat/pull/265#discussion_r3776656887), [`ALL_SITE_IDS` should be required](https://github.com/hmchangw/newchat/pull/265#discussion_r3776656900), [AccountPicker error state](https://github.com/hmchangw/newchat/pull/265#discussion_r3776656914), [AccountPicker search](https://github.com/hmchangw/newchat/pull/265#discussion_r3776656921) — follow-ups.
- Deriving the chunk size from `nc.NatsConn().MaxPayload()` at runtime instead of the pinned constant.

## Self-Review Updates
- **Fanout deadline capped by the whole-request budget** (`b649e115`, answers the tGD blocking thread): `createPermissions`/`resyncPermissions` pin one absolute deadline at handler entry (`requestBudget = httpWriteTimeout − 2s`) and the fanout takes the earlier of that and `now + FANOUT_TIMEOUT` before severing client cancellation, so local work that already spent part of the write window can no longer let a stalled peer push the response past net/http's WriteTimeout. An already-spent budget reports every destination without publishing.
- Declined/deferred with replies on-thread: resync prebuffer OOM (bounded by real accounts with a stored state), site-ID token validation (repo-wide follow-up in `pkg/subject`), fanout 30s vs shutdown 25s (documented trade-off), account-ID length bound (owner decision).