### PR TITLE
fix(room-worker): migrated member JoinedAt = chat createdDateTime, not migration time

### DIFF
--- a/room-worker/teamsroomcreate.go
+++ b/room-worker/teamsroomcreate.go
@@ -125,7 +125,10 @@ func (h *Handler) reconcileTeamsRoom(ctx context.Context, chat *model.TeamsRoomC
 		if model.IsBot(member.Account) || model.IsPlatformAdminAccount(member.Account) {
 			roles = []model.Role{model.RoleMember}
 		}
-		sub := newSub(idgen.GenerateUUIDv7(), user, room, roles, room.Name, false, acceptedAt)
+		// JoinedAt = the chat's creation time, a meaningful historical value, not the
+		// migration run time (acceptedAt). Teams exposes no per-member add time; this is
+		// uniform per room. Not a history boundary — HistorySharedSince caps that (#302).
+		sub := newSub(idgen.GenerateUUIDv7(), user, room, roles, room.Name, false, chat.CreatedDateTime.UTC())
 		sub.Origin = model.OriginTeams
 		// Land every migrated chat in the built-in "Teams" section by default; the
 		// user re-organizes from there. No section import, no extra write.

--- a/room-worker/teamsroomcreate_test.go
+++ b/room-worker/teamsroomcreate_test.go
@@ -543,3 +543,34 @@ func TestProcessTeamsRoomCreate_StampsMigrationHeader(t *testing.T) {
 	require.NoError(t, h.processTeamsRoomCreate(context.Background(), teamsCreateEvent(chat)))
 	assert.True(t, gotHeader, "processTeamsRoomCreate must stamp X-Migration: live on publishes")
 }
+
+// TestProcessTeamsRoomCreate_JoinedAtIsChatCreatedDateTime: the migrated sub's
+// JoinedAt is the chat's createdDateTime (a historical time), not the migration
+// event timestamp (teamsCreateEvent stamps 1000ms). #302.
+func TestProcessTeamsRoomCreate_JoinedAtIsChatCreatedDateTime(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	h, _ := newTeamsTestHandler(t, store)
+
+	chatCreated := time.Date(2024, 3, 15, 9, 0, 0, 0, time.UTC)
+
+	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+	store.EXPECT().ListByRoom(gomock.Any(), gomock.Any()).Return(nil, nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{ID: "u1", Account: "alice", SiteID: "site-a"}, nil)
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, subs []*model.Subscription) error {
+			require.Len(t, subs, 1)
+			assert.Equal(t, chatCreated, subs[0].JoinedAt, "JoinedAt must be the chat createdDateTime, not the migration timestamp")
+			assert.NotEqual(t, time.UnixMilli(1000).UTC(), subs[0].JoinedAt, "JoinedAt must not be the migration event timestamp")
+			return nil
+		})
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), gomock.Any()).Return(nil)
+
+	chat := model.TeamsRoomCreateChat{
+		ID:              "chat1",
+		Name:            "Project Sync",
+		Members:         []model.TeamsRoomCreateMember{{ID: "aad1", Account: "alice"}},
+		CreatedDateTime: chatCreated,
+	}
+	require.NoError(t, h.processTeamsRoomCreate(context.Background(), teamsCreateEvent(chat)))
+}


### PR DESCRIPTION
## Summary
A Teams-migrated member's subscription `JoinedAt` was set to the migration **event timestamp** (≈ when migration ran), not a meaningful historical time. This uses the chat's **`createdDateTime`** instead.

## Changes
- `room-worker/teamsroomcreate.go`: pass `chat.CreatedDateTime.UTC()` (already in the room-create event, already used for `room.CreatedAt`) as the `joinedAt` arg to `newSub`. Scoped to that call — `room.UpdatedAt` and the membership federation events keep the event timestamp.
- Test: a migrated sub's `JoinedAt` equals the chat's `createdDateTime`, not the migration timestamp.

## Verification
- `JoinedAt` is membership metadata + a member-list sort key, **not** a history/read-access boundary — history is capped by `HistorySharedSince` (from `VisibleHistoryStartDateTime`), enforced separately. An earlier `JoinedAt` grants no extra history.
- Deterministic across NATS redelivery (sourced from the event).
- `go test ./room-worker/...` green; golangci-lint 0.

Closes #302
