### PR TITLE
feat(search-sync): MODE=default|teams split + fail-loud BuildAction

### DIFF
--- a/search-sync-worker/main.go
+++ b/search-sync-worker/main.go
@@ -31,6 +31,10 @@ type bootstrapConfig struct {
 }
 
 type config struct {
+	// Mode selects which collections this pod binds: "default" runs the live
+	// message/bot/spotlight/user-room consumers; "teams" runs only the
+	// migrated-Teams-history consumer (MESSAGES-TEAMS).
+	Mode                string `env:"MODE" envDefault:"default"`
 	NatsURL             string `env:"NATS_URL,required"`
 	NatsCredsFile       string `env:"NATS_CREDS_FILE" envDefault:""`
 	SiteID              string `env:"SITE_ID,required"`
@@ -82,6 +86,11 @@ func main() {
 	cfg, err := env.ParseAs[config]()
 	if err != nil {
 		slog.Error("parse config", "error", err)
+		os.Exit(1)
+	}
+
+	if cfg.Mode != "default" && cfg.Mode != "teams" {
+		slog.Error("invalid config", "MODE", cfg.Mode, "reason", `must be "default" or "teams"`)
 		os.Exit(1)
 	}
 
@@ -159,27 +168,32 @@ func main() {
 	}
 	db := mongoClient.Database(cfg.MongoDB)
 
-	msgColl := newMessageCollection(cfg.MsgIndexPrefix, cfg.SiteID, syncMessagesFrom, cfg.DevMode)
-	// search-service filters restricted-room access by threadParentMessageCreatedAt, so re-resolve it from the parent's indexed createdAt (the event omits it).
-	msgColl.parentResolver = newESParentResolver(engine, cfg.MsgIndexPrefix)
+	// Mode gates which consumers this pod binds. "teams" runs only the
+	// MESSAGES-TEAMS migrated-history consumer; "default" runs everything else.
+	var collections []Collection
+	if cfg.Mode == "teams" {
+		// Bound to MESSAGES-TEAMS: message-worker's teams mode persists migrated Teams
+		// history with no .created event on the canonical stream, so this indexes off
+		// its own stream/subject rather than a filter on the live message collection.
+		teamsMsgColl := newTeamsMessageCollection(cfg.MsgIndexPrefix, cfg.SiteID, cfg.DevMode)
+		teamsMsgColl.teamsUsers = newMongoTeamsUserResolver(db)
+		collections = []Collection{teamsMsgColl}
+	} else {
+		msgColl := newMessageCollection(cfg.MsgIndexPrefix, cfg.SiteID, syncMessagesFrom, cfg.DevMode)
+		// search-service filters restricted-room access by threadParentMessageCreatedAt, so re-resolve it from the parent's indexed createdAt (the event omits it).
+		msgColl.parentResolver = newESParentResolver(engine, cfg.MsgIndexPrefix)
 
-	// Second consumer over messageCollection, bound to BOT-MESSAGES-CANONICAL. isBot is derived per-doc from model.IsBot(UserAccount) so bots reuse the same index.
-	botMsgColl := newBotMessageCollection(cfg.MsgIndexPrefix, cfg.DevMode)
-	botMsgColl.parentResolver = newESParentResolver(engine, cfg.MsgIndexPrefix)
+		// Second consumer over messageCollection, bound to BOT-MESSAGES-CANONICAL. isBot is derived per-doc from model.IsBot(UserAccount) so bots reuse the same index.
+		botMsgColl := newBotMessageCollection(cfg.MsgIndexPrefix, cfg.DevMode)
+		botMsgColl.parentResolver = newESParentResolver(engine, cfg.MsgIndexPrefix)
 
-	// Third consumer, bound to MESSAGES-TEAMS: message-worker's teams mode persists
-	// migrated Teams history with no .created event on the canonical stream, so this
-	// indexes off its own stream/subject rather than a filter on msgColl.
-	teamsMsgColl := newTeamsMessageCollection(cfg.MsgIndexPrefix, cfg.SiteID, cfg.DevMode)
-	teamsMsgColl.teamsUsers = newMongoTeamsUserResolver(db)
-
-	collections := []Collection{
-		msgColl,
-		botMsgColl,
-		teamsMsgColl,
-		newSpotlightCollection(cfg.SpotlightIndex, cfg.DevMode),
-		newSpotlightOrgCollection(cfg.SpotlightOrgIndex, cfg.SiteID, cfg.HRCentralSiteID, cfg.DevMode),
-		newUserRoomCollection(cfg.UserRoomIndex, cfg.DevMode),
+		collections = []Collection{
+			msgColl,
+			botMsgColl,
+			newSpotlightCollection(cfg.SpotlightIndex, cfg.DevMode),
+			newSpotlightOrgCollection(cfg.SpotlightOrgIndex, cfg.SiteID, cfg.HRCentralSiteID, cfg.DevMode),
+			newUserRoomCollection(cfg.UserRoomIndex, cfg.DevMode),
+		}
 	}
 
 	for _, coll := range collections {

--- a/search-sync-worker/messages.go
+++ b/search-sync-worker/messages.go
@@ -82,9 +82,9 @@ func newBotMessageCollection(indexPrefix string, devMode bool) *messageCollectio
 
 // newTeamsMessageCollection binds to MESSAGES-TEAMS (message-worker's teams mode
 // persists the batch with no .created event on the canonical stream, so this is a
-// separate consumer, not a filter on the user collection). Reuses messageCollection's
-// BuildAction — it already detects + indexes the teams batch shape — and skips the
-// template/mapping pushes the user collection already performs for the same indexPrefix.
+// separate consumer, not a filter on the user collection). teamsOnly switches
+// BuildAction to decode only the batch shape, and skips the template/mapping pushes
+// the user collection already performs for the same indexPrefix.
 func newTeamsMessageCollection(indexPrefix, siteID string, devMode bool) *messageCollection {
 	return &messageCollection{
 		indexPrefix:  indexPrefix,
@@ -162,10 +162,18 @@ func (c *messageCollection) MappingUpdate() (string, json.RawMessage) {
 }
 
 func (c *messageCollection) BuildAction(data []byte) ([]searchengine.BulkAction, error) {
-	// A .teams.batch envelope carries a non-empty `messages` array; a normal
-	// MessageEvent has none. Detect by shape (BuildAction only sees the payload).
-	var batch model.TeamsBatchRequest
-	if err := json.Unmarshal(data, &batch); err == nil && len(batch.Messages) > 0 {
+	// Each collection consumes a single payload shape by mode: the teams-only
+	// collection binds MESSAGES-TEAMS (batch envelopes), every other binds a
+	// canonical stream (single MessageEvents). Decode exactly that shape and fail
+	// loud on a mismatch rather than silently trying the other.
+	if c.teamsOnly {
+		var batch model.TeamsBatchRequest
+		if err := json.Unmarshal(data, &batch); err != nil {
+			return nil, fmt.Errorf("teams batch: expected TeamsBatchRequest: %w", err)
+		}
+		if len(batch.Messages) == 0 {
+			return nil, fmt.Errorf("teams batch: expected TeamsBatchRequest with messages, got empty/other shape")
+		}
 		return c.buildTeamsActions(batch), nil
 	}
 

--- a/search-sync-worker/messages_test.go
+++ b/search-sync-worker/messages_test.go
@@ -644,7 +644,7 @@ func (f fakeTeamsUserResolver) ResolveIdentities(_ context.Context, ids []string
 }
 
 func TestMessageCollection_BuildAction_TeamsBatch(t *testing.T) {
-	c := newMessageCollection("messages-site-a-v1", "site-a", time.Time{}, false)
+	c := newTeamsMessageCollection("messages-site-a-v1", "site-a", false)
 	c.teamsUsers = fakeTeamsUserResolver{
 		"graph-1": {Account: "alice", UserID: "uid-alice"},
 		"graph-2": {Account: "bob", UserID: "uid-bob"},
@@ -684,7 +684,7 @@ func TestMessageCollection_BuildAction_TeamsBatch(t *testing.T) {
 }
 
 func TestMessageCollection_BuildAction_TeamsBatch_Skips(t *testing.T) {
-	c := newMessageCollection("messages-site-a-v1", "site-a", time.Time{}, false)
+	c := newTeamsMessageCollection("messages-site-a-v1", "site-a", false)
 	ts := time.Now().UTC()
 
 	data := teamsBatch(t,
@@ -700,7 +700,7 @@ func TestMessageCollection_BuildAction_TeamsBatch_Skips(t *testing.T) {
 }
 
 func TestMessageCollection_BuildAction_TeamsBatch_MalformedRecordDoesNotDropSiblings(t *testing.T) {
-	c := newMessageCollection("messages-site-a-v1", "site-a", time.Time{}, false)
+	c := newTeamsMessageCollection("messages-site-a-v1", "site-a", false)
 	ts := time.Now().UTC()
 
 	valid, err := json.Marshal(teamsmigrate.Message{
@@ -723,7 +723,7 @@ func TestMessageCollection_BuildAction_TeamsBatch_MalformedRecordDoesNotDropSibl
 }
 
 func TestMessageCollection_BuildAction_TeamsBatch_SetsOrigin(t *testing.T) {
-	c := newMessageCollection("messages-site-a-v1", "site-a", time.Time{}, false)
+	c := newTeamsMessageCollection("messages-site-a-v1", "site-a", false)
 	ts := time.Now().UTC()
 
 	valid, err := json.Marshal(teamsmigrate.Message{
@@ -757,4 +757,36 @@ func TestBuildMessageAction_NormalPath_OmitsOrigin(t *testing.T) {
 	require.NoError(t, json.Unmarshal(action.Doc, &doc))
 	_, hasOrigin := doc["origin"]
 	assert.False(t, hasOrigin, "non-Teams docs must not carry an origin field")
+}
+
+// --- Fail-loud mode split: each collection decodes only its own shape ---
+
+func TestMessageCollection_BuildAction_TeamsOnly_RejectsNonBatch(t *testing.T) {
+	c := newTeamsMessageCollection("messages-site-a-v1", "site-a", false)
+
+	// A bare array (not a {"messages":[...]} envelope) can't decode into the struct.
+	_, err := c.BuildAction([]byte(`[{"id":"x"}]`))
+	require.Error(t, err, "teams-only collection must reject a bare array, not fall through")
+
+	// A single MessageEvent object decodes but carries no `messages` — reject it
+	// instead of silently indexing nothing.
+	evt, _ := json.Marshal(model.MessageEvent{
+		Event:     model.EventCreated,
+		Timestamp: time.Now().UnixNano(),
+		Message:   model.Message{ID: "m-1", RoomID: "r-1", CreatedAt: time.Now().UTC()},
+	})
+	_, err = c.BuildAction(evt)
+	require.Error(t, err, "teams-only collection must reject a MessageEvent, not fall through")
+}
+
+func TestMessageCollection_BuildAction_Default_RejectsBatch(t *testing.T) {
+	c := newMessageCollection("messages-site-a-v1", "site-a", time.Time{}, false)
+
+	// A teams batch envelope reaching the default (non-teamsOnly) collection is a
+	// wiring error — decode only MessageEvent, so this fails loud.
+	data := teamsBatch(t, teamsmigrate.Message{
+		ID: "tm-1", RoomID: "room-1", MessageType: "message", CreatedDateTime: time.Now().UTC(),
+	})
+	_, err := c.BuildAction(data)
+	require.Error(t, err, "default collection must reject a batch envelope, not build teams actions")
 }

--- a/search-sync-worker/messages_test.go
+++ b/search-sync-worker/messages_test.go
@@ -761,32 +761,34 @@ func TestBuildMessageAction_NormalPath_OmitsOrigin(t *testing.T) {
 
 // --- Fail-loud mode split: each collection decodes only its own shape ---
 
-func TestMessageCollection_BuildAction_TeamsOnly_RejectsNonBatch(t *testing.T) {
-	c := newTeamsMessageCollection("messages-site-a-v1", "site-a", false)
+func TestMessageCollection_BuildAction_RejectsWrongShapePerMode(t *testing.T) {
+	teamsColl := newTeamsMessageCollection("messages-site-a-v1", "site-a", false)
+	defaultColl := newMessageCollection("messages-site-a-v1", "site-a", time.Time{}, false)
 
-	// A bare array (not a {"messages":[...]} envelope) can't decode into the struct.
-	_, err := c.BuildAction([]byte(`[{"id":"x"}]`))
-	require.Error(t, err, "teams-only collection must reject a bare array, not fall through")
-
-	// A single MessageEvent object decodes but carries no `messages` — reject it
-	// instead of silently indexing nothing.
-	evt, _ := json.Marshal(model.MessageEvent{
+	msgEvent, _ := json.Marshal(model.MessageEvent{
 		Event:     model.EventCreated,
 		Timestamp: time.Now().UnixNano(),
 		Message:   model.Message{ID: "m-1", RoomID: "r-1", CreatedAt: time.Now().UTC()},
 	})
-	_, err = c.BuildAction(evt)
-	require.Error(t, err, "teams-only collection must reject a MessageEvent, not fall through")
-}
-
-func TestMessageCollection_BuildAction_Default_RejectsBatch(t *testing.T) {
-	c := newMessageCollection("messages-site-a-v1", "site-a", time.Time{}, false)
-
-	// A teams batch envelope reaching the default (non-teamsOnly) collection is a
-	// wiring error — decode only MessageEvent, so this fails loud.
-	data := teamsBatch(t, teamsmigrate.Message{
+	batch := teamsBatch(t, teamsmigrate.Message{
 		ID: "tm-1", RoomID: "room-1", MessageType: "message", CreatedDateTime: time.Now().UTC(),
 	})
-	_, err := c.BuildAction(data)
-	require.Error(t, err, "default collection must reject a batch envelope, not build teams actions")
+
+	// Each collection decodes only its own shape and fails loud on a mismatch,
+	// never falls through to the other decode.
+	tests := []struct {
+		name string
+		c    Collection
+		data []byte
+	}{
+		{"teams-only rejects bare array", teamsColl, []byte(`[{"id":"x"}]`)},
+		{"teams-only rejects MessageEvent", teamsColl, msgEvent},
+		{"default rejects batch envelope", defaultColl, batch},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.c.BuildAction(tt.data)
+			require.Error(t, err)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Splits `search-sync-worker` into `MODE=default|teams` and makes `messageCollection.BuildAction` decode only the payload shape its mode consumes, failing loud on a mismatch instead of silently trying the other shape.

- `default` (unchanged behavior): the live message + bot + spotlight + spotlight-org + user-room consumers.
- `teams`: only the MESSAGES-TEAMS migrated-history consumer.

Mirrors the existing `message-worker` `MODE` convention. No durable rename — the teams consumer stays `message-sync-teams`.

Closes #304

## Changes

- `search-sync-worker/main.go`
  - New `MODE` env (`envDefault:"default"`), validated to `default|teams` at startup (`slog.Error` + `os.Exit(1)`), same pattern as `message-worker`.
  - The `collections` slice is now mode-gated: `teams` builds only the teams collection; `default` builds the previous set (message, bot, spotlight, spotlight-org, user-room), constructing only what the mode uses.
- `search-sync-worker/messages.go`
  - `BuildAction` branches on `teamsOnly`: the teams collection decodes **only** `model.TeamsBatchRequest` (unmarshal error, or an envelope with no `messages`, returns a wrapped clear error — no fallthrough); every other collection decodes **only** `model.MessageEvent`. Shape-detection removed.

## Verification

- `go test ./search-sync-worker/` — green (incl. new fail-loud cases: teams-mode rejects a bare array and a `MessageEvent`; default-mode rejects a batch envelope; existing teams-batch tests repointed to the teams collection).
- golangci-lint — 0 issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable worker modes for standard message synchronization and migrated Teams history synchronization.
  * Added startup validation for the selected operating mode.

* **Bug Fixes**
  * Improved Teams batch payload handling with clearer validation and error messages.
  * Prevented standard and Teams-specific payload formats from being processed by the wrong synchronization mode.

* **Tests**
  * Added coverage for rejecting invalid payload types in each operating mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->