### PR TITLE
fix(history-service): decrypt pinned messages so edited pins aren't empty

### DIFF
--- a/history-service/internal/cassrepo/pin.go
+++ b/history-service/internal/cassrepo/pin.go
@@ -33,7 +33,10 @@ const (
 	pinnedColumns = "room_id, pinned_at, message_id, sender, " +
 		"msg, mentions, attachments, card, card_action, quoted_parent_message, " +
 		"visible_to, deleted, type, sys_msg_data, site_id, edited_at, " +
-		"updated_at, pinned_by, created_at, tshow, thread_parent_id, thread_parent_created_at"
+		"updated_at, pinned_by, created_at, tshow, thread_parent_id, thread_parent_created_at, " +
+		// An at-rest edit rewrites the pinned row as ciphertext (msg nulled), so
+		// the read must carry these or an edited pin comes back empty.
+		"enc_payload, enc_meta"
 
 	pinnedByRoomQuery = "SELECT " + pinnedColumns + " FROM pinned_messages_by_room WHERE room_id = ?"
 )
@@ -120,11 +123,15 @@ func (r *Repository) GetPinnedMessages(ctx context.Context, roomID string, pageR
 			if !found {
 				break
 			}
+			if dErr := r.decryptIfNeeded(ctx, &m); dErr != nil {
+				scanErr = dErr
+				return
+			}
 			rows = append(rows, m)
 		}
 	})
 	if scanErr != nil {
-		return Page[models.Message]{}, fmt.Errorf("scan pinned message row for room %s: %w", roomID, scanErr)
+		return Page[models.Message]{}, fmt.Errorf("read pinned message row for room %s: %w", roomID, scanErr)
 	}
 	if err != nil {
 		return Page[models.Message]{}, fmt.Errorf("query pinned messages for room %s: %w", roomID, err)
@@ -133,6 +140,7 @@ func (r *Repository) GetPinnedMessages(ctx context.Context, roomID string, pageR
 }
 
 // GetAllPinnedMessages returns every pin for a room (internal: cap + orphan scan need it all).
+// Deliberately does not decrypt — its only caller reads MessageID/PinnedAt.
 func (r *Repository) GetAllPinnedMessages(ctx context.Context, roomID string) ([]models.Message, error) {
 	iter := r.session.Query(pinnedByRoomQuery, roomID).WithContext(ctx).Iter()
 	rows := make([]models.Message, 0)

--- a/history-service/internal/cassrepo/pin.go
+++ b/history-service/internal/cassrepo/pin.go
@@ -106,30 +106,15 @@ func (r *Repository) UnpinMessage(ctx context.Context, msg *models.Message) erro
 
 // GetPinnedMessages returns one page of pins for a room (redaction is service-side).
 func (r *Repository) GetPinnedMessages(ctx context.Context, roomID string, pageReq PageRequest) (Page[models.Message], error) {
-	builder := NewQueryBuilder(r.session.Query(pinnedByRoomQuery, roomID).WithContext(ctx)).
-		WithPageSize(pageReq.PageSize).
-		WithCursor(pageReq.Cursor)
-
-	rows := make([]models.Message, 0, pageReq.PageSize)
+	scan := r.scanMessagesUpTo(ctx)
+	var rows []models.Message
 	var scanErr error
-	nextCursor, err := builder.Fetch(func(iter *gocql.Iter) {
-		for {
-			var m models.Message
-			found, sErr := structScan(iter, &m)
-			if sErr != nil {
-				scanErr = sErr
-				return
-			}
-			if !found {
-				break
-			}
-			if dErr := r.decryptIfNeeded(ctx, &m); dErr != nil {
-				scanErr = dErr
-				return
-			}
-			rows = append(rows, m)
-		}
-	})
+	nextCursor, err := NewQueryBuilder(r.session.Query(pinnedByRoomQuery, roomID).WithContext(ctx)).
+		WithPageSize(pageReq.PageSize).
+		WithCursor(pageReq.Cursor).
+		Fetch(func(iter *gocql.Iter) {
+			rows, scanErr = scan(iter, pageReq.PageSize)
+		})
 	if scanErr != nil {
 		return Page[models.Message]{}, fmt.Errorf("read pinned message row for room %s: %w", roomID, scanErr)
 	}

--- a/history-service/internal/cassrepo/pin_integration_test.go
+++ b/history-service/internal/cassrepo/pin_integration_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hmchangw/chat/history-service/internal/models"
+	"github.com/hmchangw/chat/pkg/atrest"
+	cassmodel "github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/pkg/msgbucket"
 )
 
@@ -229,4 +231,57 @@ func TestRepository_GetPinnedMessages_Paginates(t *testing.T) {
 	}
 	assert.Len(t, seen, 5, "every pin returned exactly once across pages")
 	assert.ElementsMatch(t, []string{"a", "b", "c", "d", "e"}, seen)
+}
+
+// TestRepository_GetPinnedMessages_EditedEncryptedPin covers the at-rest path
+// end to end: an encrypted edit moves the body into enc_payload and nulls the
+// pinned mirror's plaintext columns, so the pinned read must select and decrypt
+// enc_payload or it hands the client an empty message.
+func TestRepository_GetPinnedMessages_EditedEncryptedPin(t *testing.T) {
+	ctx := context.Background()
+	session := setupCassandra(t)
+	mongoDB := setupMongo(t)
+
+	wrapper := newTestVaultWrapper(t, ctx)
+	cipher := atrest.NewCipher(wrapper, atrest.NewMongoDEKStore(mongoDB.Collection(atrest.CollectionName)),
+		atrest.Config{DEKCacheSize: 100, DEKCacheTTL: time.Hour})
+	sizer := msgbucket.New(24 * time.Hour)
+	repo := NewRepository(session, sizer, 365, cipher)
+
+	roomID := "r-pin-enc-1"
+	created := time.Date(2026, 5, 1, 9, 0, 0, 0, time.UTC)
+	sender := models.Participant{ID: "u1", Account: "alice"}
+	attachments := [][]byte{[]byte("att-1.bin")}
+
+	// Seed the message as an at-rest write leaves it: body in enc_payload, msg null.
+	payload, meta, err := cipher.Encrypt(ctx, roomID,
+		atrest.EncryptedFields{Msg: "original body", Attachments: attachments})
+	require.NoError(t, err)
+	encMeta := &cassmodel.EncMeta{Nonce: meta.Nonce}
+	require.NoError(t, session.Query(
+		`INSERT INTO messages_by_id (message_id, room_id, created_at, sender, enc_payload, enc_meta, deleted) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"m1", roomID, created, sender, payload, encMeta, false,
+	).WithContext(ctx).Exec())
+	require.NoError(t, session.Query(
+		`INSERT INTO messages_by_room (room_id, bucket, created_at, message_id, sender, enc_payload, enc_meta, deleted) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		roomID, sizer.Of(created), created, "m1", sender, payload, encMeta, false,
+	).WithContext(ctx).Exec())
+
+	// Pin then edit exactly as the service does: read (decrypts) before each write.
+	toPin, err := repo.GetMessageByID(ctx, "m1")
+	require.NoError(t, err)
+	pinnedAt := created.Add(time.Hour)
+	require.NoError(t, repo.PinMessage(ctx, toPin, pinnedAt, models.Participant{ID: "u2", Account: "mod"}))
+
+	toEdit, err := repo.GetMessageByID(ctx, "m1")
+	require.NoError(t, err)
+	require.NotNil(t, toEdit.PinnedAt, "the edit only touches the pinned mirror when PinnedAt is set")
+	require.NoError(t, repo.UpdateMessageContent(ctx, toEdit, "edited body", created.Add(2*time.Hour)))
+
+	page, err := repo.GetPinnedMessages(ctx, roomID, PageRequest{PageSize: 10})
+	require.NoError(t, err)
+	require.Len(t, page.Data, 1)
+	assert.Equal(t, "edited body", page.Data[0].Msg, "pinned list must return the edited body, not an empty string")
+	assert.Equal(t, attachments, page.Data[0].Attachments, "the encrypted edit nulls the plaintext attachments column too")
+	assert.Empty(t, page.Data[0].EncPayload, "ciphertext must not escape the repository")
 }

--- a/history-service/internal/cassrepo/pin_integration_test.go
+++ b/history-service/internal/cassrepo/pin_integration_test.go
@@ -253,7 +253,7 @@ func TestRepository_GetPinnedMessages_EditedEncryptedPin(t *testing.T) {
 	sender := models.Participant{ID: "u1", Account: "alice"}
 	attachments := [][]byte{[]byte("att-1.bin")}
 
-	// Seed the message as an at-rest write leaves it: body in enc_payload, msg null.
+	// Seed the canonical row as an at-rest write leaves it: body in enc_payload, msg null.
 	payload, meta, err := cipher.Encrypt(ctx, roomID,
 		atrest.EncryptedFields{Msg: "original body", Attachments: attachments})
 	require.NoError(t, err)
@@ -261,10 +261,6 @@ func TestRepository_GetPinnedMessages_EditedEncryptedPin(t *testing.T) {
 	require.NoError(t, session.Query(
 		`INSERT INTO messages_by_id (message_id, room_id, created_at, sender, enc_payload, enc_meta, deleted) VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		"m1", roomID, created, sender, payload, encMeta, false,
-	).WithContext(ctx).Exec())
-	require.NoError(t, session.Query(
-		`INSERT INTO messages_by_room (room_id, bucket, created_at, message_id, sender, enc_payload, enc_meta, deleted) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		roomID, sizer.Of(created), created, "m1", sender, payload, encMeta, false,
 	).WithContext(ctx).Exec())
 
 	// Pin then edit exactly as the service does: read (decrypts) before each write.


### PR DESCRIPTION
## Problem

`chat.user.{account}.request.room.{roomID}.{siteID}.msg.pinned.list` returned `msg: ""` for any pinned message that had been edited.

`pinned_messages_by_room` carries `enc_payload`/`enc_meta`, and the at-rest edit path (`write.go`'s `editPinnedMsgEncrypted`) moves the body into `enc_payload` while nulling `msg`, `attachments`, `card` and `card_action` on the pinned mirror. But the pinned-list read omitted both encrypted columns from its projection and never called `decryptIfNeeded` — so an edited pin came back with an empty body and no attachments. `ATREST_ENABLED` defaults to `true`, so this reproduces on any default deployment.

Sibling readers (`messages_by_room.go`, `messages_by_id.go`, `thread_messages.go`) already select and decrypt these columns; the pinned read was the only one that didn't.

## Fix

`history-service/internal/cassrepo/pin.go` only:

- add `enc_payload, enc_meta` to `pinnedColumns`
- `GetPinnedMessages` now scans through the shared `scanMessagesUpTo` helper, which structScans and decrypts each row (the same helper `GetThreadMessages` uses with this exact QueryBuilder/Fetch shape)
- a decrypt failure fails the whole request, matching the message-history readers; the error wrap is renamed `scan …` → `read …` since it now covers decrypt too
- `GetAllPinnedMessages` deliberately keeps reading undecrypted — its only caller (`enforcePinLimit`) reads just `MessageID`/`PinnedAt`

No change to any function signature, the `MessageReader` interface, generated mocks, the wire schema, or the Cassandra DDL — so no `make generate` and no `docs/client-api.md` schema edit.

## Behavior change reviewers should know about

Routing the pinned read through `scanMessagesUpTo` also makes it **honor `limit`**. The old loop drained the gocql iterator, and gocql auto-pages by default (`conn.go:1450` sets `iter.next` whenever more pages exist; `DisableAutoPage` is never called here) — so a request with `limit: 3` against a 10-pin room previously returned all 10 messages with `hasNext: false`. It now returns 3 plus a `nextCursor`.

That is the contract `docs/client-api.md` already documents (`limit` = max per page, `hasNext` = more pages exist) and matches `GetThreadMessages`, so this corrects a latent pagination bug rather than introducing one. Pins are capped at `MAX_PINNED_PER_ROOM` (default 10) and the default limit is far above that, so only a caller explicitly sending a small `limit` is affected. The loadgen soak lane already follows the cursor correctly.

One more consequence of decrypting here: if `ATREST_ENABLED` is turned off while encrypted pinned rows exist, `msg.pinned.list` now fails outright instead of returning blank bodies — same as message history already does in that situation.

## Tests

New integration test `TestRepository_GetPinnedMessages_EditedEncryptedPin` (real Cassandra + Vault-backed cipher): seed an encrypted message → `GetMessageByID` → `PinMessage` → `GetMessageByID` → `UpdateMessageContent` → `GetPinnedMessages`, asserting the edited body, the restored attachments, and that no ciphertext escapes the repository.

Written test-first and watched fail on the unfixed code:

```
--- FAIL: TestRepository_GetPinnedMessages_EditedEncryptedPin
    expected: "edited body"          actual: ""
    expected: [][]uint8{"att-1.bin"} actual: [][]uint8(nil)
```

Verification after the fix:

- `make lint` → `0 issues.`
- `make test SERVICE=history-service` → all packages ok
- `make test-integration SERVICE=history-service` → all packages ok (`cassrepo` 150s)

## Known gap, deliberately out of scope

`insertPinnedMsg` still writes the pin mirror in **plaintext** at pin time even when at-rest encryption is on — so a pinned message's body is stored unencrypted in `pinned_messages_by_room` until it is edited. That is the inconsistency that produced this bug (plaintext on pin, ciphertext on edit). Fixing it means changing the pin write path and is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)