### PR TITLE
search-sync-worker: pipeline ES flushes, pace failed-write retries, close ordering gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ bin/
 demo
 /seed-sample-data
 /loadgen
+# `go build ./...` run from inside a service dir writes the executable there
+/search-sync-worker/search-sync-worker
 *.exe
 *.exe~
 *.dll

--- a/pkg/jsretry/jsretry.go
+++ b/pkg/jsretry/jsretry.go
@@ -58,13 +58,17 @@ var DefaultBackoff = []time.Duration{
 }
 
 // BackpressureBackoff suits workers fronting a downstream that reports it is
-// shedding load (an ES 429, a saturated pool). It starts where DefaultBackoff
-// ends: a backend that just rejected the write needs time to drain, and a
-// one-second retry only feeds the overload that caused the rejection.
+// shedding load (an ES 429, a saturated pool). It skips DefaultBackoff's fast
+// rungs: a backend that just rejected the write needs time to drain, and a
+// one-second retry only feeds the overload that caused the rejection. It then
+// keeps DefaultBackoff's 10m tail, so shedding load never buys a message a
+// *smaller* retry budget than an ordinary failure would have got.
 var BackpressureBackoff = []time.Duration{
 	30 * time.Second,
 	1 * time.Minute,
 	2 * time.Minute,
+	5 * time.Minute,
+	10 * time.Minute,
 }
 
 // LowLatencyBackoff suits fan-out / delivery workers where the first retry must

--- a/pkg/jsretry/jsretry.go
+++ b/pkg/jsretry/jsretry.go
@@ -57,6 +57,16 @@ var DefaultBackoff = []time.Duration{
 	10 * time.Minute,
 }
 
+// BackpressureBackoff suits workers fronting a downstream that reports it is
+// shedding load (an ES 429, a saturated pool). It starts where DefaultBackoff
+// ends: a backend that just rejected the write needs time to drain, and a
+// one-second retry only feeds the overload that caused the rejection.
+var BackpressureBackoff = []time.Duration{
+	30 * time.Second,
+	1 * time.Minute,
+	2 * time.Minute,
+}
+
 // LowLatencyBackoff suits fan-out / delivery workers where the first retry must
 // be near-immediate so a sub-second hiccup isn't user-visible, while a genuine
 // outage is still spaced out.

--- a/pkg/jsretry/jsretry_test.go
+++ b/pkg/jsretry/jsretry_test.go
@@ -181,6 +181,29 @@ func TestDefaultBackoff_Shape(t *testing.T) {
 	}, DefaultBackoff)
 }
 
+// BackpressureBackoff exists to be strictly gentler than DefaultBackoff on a
+// backend that just said it is full: never retry sooner, never give up earlier.
+// The second half matters as much as the first — a schedule that skipped the
+// fast rungs but capped its tail below DefaultBackoff would swap one failure
+// mode (amplifying the overload) for another (dropping writes while the cluster
+// is still draining).
+func TestBackpressureBackoff_DominatesDefault(t *testing.T) {
+	assert.GreaterOrEqual(t, BackpressureBackoff[0], DefaultBackoff[2],
+		"the first backpressure retry must skip the fast rungs that feed the overload")
+
+	sum := func(s []time.Duration) time.Duration {
+		var total time.Duration
+		for _, d := range s {
+			total += d
+		}
+		return total
+	}
+	assert.GreaterOrEqual(t, sum(BackpressureBackoff), sum(DefaultBackoff),
+		"a saturated cluster gets at least the retry budget an ordinary failure gets")
+	assert.GreaterOrEqual(t, BackpressureBackoff[len(BackpressureBackoff)-1], DefaultBackoff[len(DefaultBackoff)-1],
+		"the reused tail entry paces the long outage; it must not be shorter than the default tail")
+}
+
 // Deliberately not extended: broadcast fan-out is user-visible and a
 // 15-minute-late broadcast is worthless.
 func TestLowLatencyBackoff_StaysShort(t *testing.T) {

--- a/pkg/searchengine/classify.go
+++ b/pkg/searchengine/classify.go
@@ -47,3 +47,44 @@ func IsBulkItemSuccess(action ActionType, result BulkResult) bool {
 	}
 	return false
 }
+
+// ErrRejectedExecution / ErrCircuitBreaking are the ES error types that mean
+// "the cluster is saturated", not "this write is invalid". They arrive as
+// per-item failures inside an otherwise-200 _bulk response.
+const (
+	ErrRejectedExecution = "es_rejected_execution_exception"
+	ErrCircuitBreaking   = "circuit_breaking_exception"
+)
+
+// IsBulkItemBackpressure reports whether a failed bulk item was rejected
+// because the search backend is overloaded rather than because the write
+// itself was bad. Callers use it to retry on a longer delay: retrying
+// promptly against a cluster that just shed load is what turns a transient
+// overload into a sustained one.
+//
+// Matched on status (429) or on the error type, since a circuit breaker can
+// surface under a 503 as well.
+func IsBulkItemBackpressure(result BulkResult) bool {
+	if result.Status == 429 {
+		return true
+	}
+	switch result.ErrorType {
+	case ErrRejectedExecution, ErrCircuitBreaking:
+		return true
+	}
+	return false
+}
+
+// IsBulkItemPermanent reports whether a failed bulk item can never succeed on
+// retry. A 400 means the backend rejected the document itself — a mapping
+// conflict, an unparseable field, an illegal argument — so redelivering
+// identical bytes can only fail identically. Callers drop it rather than
+// burning the consumer's redelivery budget on a doomed retry.
+//
+// Deliberately narrow: 429/503 are backpressure (IsBulkItemBackpressure), a 409
+// on an update is a live conflict a retry can win, and a 404
+// index_not_found_exception clears once the index or template exists. None of
+// those are permanent.
+func IsBulkItemPermanent(result BulkResult) bool {
+	return result.Status == 400
+}

--- a/pkg/searchengine/classify_test.go
+++ b/pkg/searchengine/classify_test.go
@@ -33,3 +33,45 @@ func TestIsBulkItemSuccess(t *testing.T) {
 		})
 	}
 }
+
+func TestIsBulkItemBackpressure(t *testing.T) {
+	tests := []struct {
+		name   string
+		result searchengine.BulkResult
+		want   bool
+	}{
+		{"429 is backpressure", searchengine.BulkResult{Status: 429}, true},
+		{"rejected execution is backpressure", searchengine.BulkResult{Status: 429, ErrorType: "es_rejected_execution_exception"}, true},
+		{"circuit breaker is backpressure", searchengine.BulkResult{Status: 429, ErrorType: "circuit_breaking_exception"}, true},
+		{"circuit breaker under a 503 is still backpressure", searchengine.BulkResult{Status: 503, ErrorType: "circuit_breaking_exception"}, true},
+		{"malformed doc is not backpressure", searchengine.BulkResult{Status: 400, ErrorType: "mapper_parsing_exception"}, false},
+		{"missing index is not backpressure", searchengine.BulkResult{Status: 404, ErrorType: "index_not_found_exception"}, false},
+		{"success is not backpressure", searchengine.BulkResult{Status: 201}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, searchengine.IsBulkItemBackpressure(tc.result))
+		})
+	}
+}
+
+func TestIsBulkItemPermanent(t *testing.T) {
+	tests := []struct {
+		name   string
+		result searchengine.BulkResult
+		want   bool
+	}{
+		{"malformed document is permanent", searchengine.BulkResult{Status: 400, ErrorType: "mapper_parsing_exception"}, true},
+		{"illegal argument is permanent", searchengine.BulkResult{Status: 400, ErrorType: "illegal_argument_exception"}, true},
+		{"backpressure is retryable", searchengine.BulkResult{Status: 429, ErrorType: "es_rejected_execution_exception"}, false},
+		{"update conflict is retryable", searchengine.BulkResult{Status: 409}, false},
+		{"missing index can clear later", searchengine.BulkResult{Status: 404, ErrorType: "index_not_found_exception"}, false},
+		{"server error is retryable", searchengine.BulkResult{Status: 500}, false},
+		{"success is not permanent", searchengine.BulkResult{Status: 201}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, searchengine.IsBulkItemPermanent(tc.result))
+		})
+	}
+}

--- a/search-sync-worker/collection.go
+++ b/search-sync-worker/collection.go
@@ -51,3 +51,19 @@ type Collection interface {
 type ByQueryCollection interface {
 	BuildByQuery(data []byte) (index string, body json.RawMessage, ok bool, err error)
 }
+
+// sequencedCollection is a Collection whose ordering guard needs the source
+// message's JetStream stream sequence — a strict total order assigned
+// server-side at publish. Handler routes through BuildActionSeq when a
+// collection implements this, and through BuildAction otherwise. Same
+// optional-capability shape as ByQueryCollection above.
+//
+// Only spotlight-org needs it. The INBOX and canonical collections carry an
+// event timestamp in their payload and guard on that (external versioning for
+// messages/spotlight, a painless timestamp compare for user-room); the HR
+// employees.upsert payload is a bare array with no timestamp of its own, so the
+// stream sequence is the only ordering token available to it.
+type sequencedCollection interface {
+	Collection
+	BuildActionSeq(data []byte, streamSeq uint64) ([]searchengine.BulkAction, error)
+}

--- a/search-sync-worker/config_test.go
+++ b/search-sync-worker/config_test.go
@@ -41,3 +41,22 @@ func TestConfig_HRJetStreamDomain(t *testing.T) {
 		assert.Equal(t, "hr-hub", cfg.HRJetStreamDomain)
 	})
 }
+
+func TestConfig_PipelineDepth(t *testing.T) {
+	t.Run("defaults to 2 so one bulk request overlaps the next batch's build", func(t *testing.T) {
+		setRequiredConfigEnv(t)
+
+		cfg, err := env.ParseAs[config]()
+		require.NoError(t, err)
+		assert.Equal(t, 2, cfg.PipelineDepth)
+	})
+
+	t.Run("reads PIPELINE_DEPTH when set", func(t *testing.T) {
+		setRequiredConfigEnv(t)
+		t.Setenv("PIPELINE_DEPTH", "4")
+
+		cfg, err := env.ParseAs[config]()
+		require.NoError(t, err)
+		assert.Equal(t, 4, cfg.PipelineDepth)
+	})
+}

--- a/search-sync-worker/consumer_config_test.go
+++ b/search-sync-worker/consumer_config_test.go
@@ -86,20 +86,59 @@ func TestBuildConsumerConfig(t *testing.T) {
 	})
 }
 
+// The flush pipeline keeps `depth` batches in flight while the next one fills, so a
+// 1:1 collection needs ack-pending headroom for (depth+1) x the bulk size before the
+// size-based flush trigger can fire.
 func TestCheckBatchAckCoupling(t *testing.T) {
-	t.Run("ok when bulk size below ack pending", func(t *testing.T) {
-		assert.Empty(t, checkBatchAckCoupling(500, 1000))
-	})
+	tests := []struct {
+		name          string
+		bulkBatchSize int
+		maxAckPending int
+		depth         int
+		wantWarning   bool
+	}{
+		{
+			name:          "depth 1 fits at 2x",
+			bulkBatchSize: 500,
+			maxAckPending: 1000,
+			depth:         1,
+		},
+		{
+			name:          "depth 2 needs 3x and has it",
+			bulkBatchSize: 500,
+			maxAckPending: 1500,
+			depth:         2,
+		},
+		{
+			name:          "depth 2 at only 2x headroom warns",
+			bulkBatchSize: 500,
+			maxAckPending: 1000,
+			depth:         2,
+			wantWarning:   true,
+		},
+		{
+			name:          "smaller batches buy depth within the same budget",
+			bulkBatchSize: 250,
+			maxAckPending: 1000,
+			depth:         2,
+		},
+		{
+			name:          "single batch alone exceeds ack pending",
+			bulkBatchSize: 2000,
+			maxAckPending: 1000,
+			depth:         1,
+			wantWarning:   true,
+		},
+	}
 
-	t.Run("ok when bulk size equals ack pending", func(t *testing.T) {
-		// At equality a 1:1 collection can still just reach the threshold
-		// (the size trigger fires at ActionCount >= bulkBatchSize), so this
-		// is not flagged.
-		assert.Empty(t, checkBatchAckCoupling(1000, 1000))
-	})
-
-	t.Run("warns when bulk size exceeds ack pending", func(t *testing.T) {
-		msg := checkBatchAckCoupling(2000, 1000)
-		assert.NotEmpty(t, msg, "bulk size above ack pending must produce a warning")
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := checkBatchAckCoupling(tt.bulkBatchSize, tt.maxAckPending, tt.depth)
+			if tt.wantWarning {
+				assert.NotEmpty(t, msg)
+				return
+			}
+			assert.Empty(t, msg)
+		})
+	}
 }

--- a/search-sync-worker/consumer_pipeline_test.go
+++ b/search-sync-worker/consumer_pipeline_test.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/searchengine"
+)
+
+// streamingFetcher hands out an endless supply of messages, one per Fetch, and counts
+// the calls so a test can observe whether the consumer loop keeps pulling while a bulk
+// request is in flight. failAfter > 0 makes every Fetch past that many calls fail, for
+// the shape of a consumer that loses NATS with work still buffered.
+type streamingFetcher struct {
+	data      []byte
+	failAfter int
+	mu        sync.Mutex
+	n         int
+}
+
+func (f *streamingFetcher) Fetch(ctx context.Context, _ int, _ ...jetstream.FetchOpt) (msgBatch, error) {
+	f.mu.Lock()
+	f.n++
+	failed := f.failAfter > 0 && f.n > f.failAfter
+	f.mu.Unlock()
+	if failed {
+		return nil, errors.New("fetch failed")
+	}
+	return fakeO11yBatch{msgs: []o11ynats.FetchedMessage{{Ctx: ctx, Msg: &stubMsg{data: f.data}}}}, nil
+}
+
+func (f *streamingFetcher) fetches() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.n
+}
+
+// blockingStore holds every Bulk call open until the test closes release, and
+// records how many ran at once so a test can pin the pipeline's depth.
+type blockingStore struct {
+	entered chan struct{}
+	release chan struct{}
+
+	mu          sync.Mutex
+	inFlight    int
+	maxInFlight int
+}
+
+func newBlockingStore() *blockingStore {
+	return &blockingStore{entered: make(chan struct{}, 64), release: make(chan struct{})}
+}
+
+func (s *blockingStore) Bulk(_ context.Context, actions []searchengine.BulkAction) ([]searchengine.BulkResult, error) {
+	s.mu.Lock()
+	s.inFlight++
+	if s.inFlight > s.maxInFlight {
+		s.maxInFlight = s.inFlight
+	}
+	s.mu.Unlock()
+
+	s.entered <- struct{}{}
+	<-s.release
+
+	s.mu.Lock()
+	s.inFlight--
+	s.mu.Unlock()
+
+	return okResults(len(actions)), nil
+}
+
+// okResults is an all-success bulk response for n actions.
+func okResults(n int) []searchengine.BulkResult {
+	results := make([]searchengine.BulkResult, n)
+	for i := range results {
+		results[i] = searchengine.BulkResult{Status: 200}
+	}
+	return results
+}
+
+// UpdateByQuery satisfies Store; the pipeline tests only exercise the bulk path.
+func (s *blockingStore) UpdateByQuery(context.Context, string, json.RawMessage) error { return nil }
+
+func (s *blockingStore) maxConcurrent() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.maxInFlight
+}
+
+func pipelineMsgData(t *testing.T) []byte {
+	t.Helper()
+	data, err := json.Marshal(&model.MessageEvent{
+		Event: model.EventCreated,
+		Message: model.Message{
+			ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+			Content: "hello", CreatedAt: time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
+		},
+		SiteID: "site-a", Timestamp: 100,
+	})
+	require.NoError(t, err)
+	return data
+}
+
+// startPipelineConsumer runs a consumer with bulkBatchSize 1 so every message
+// triggers a flush, reaching the first bulk request after a single fetch.
+func startPipelineConsumer(t *testing.T, store Store, fetcher msgFetcher, depth int) (stopCh chan struct{}, doneCh chan struct{}) {
+	t.Helper()
+	handler := NewHandler(store, newMessageCollection("msgs-v1", "site-a", time.Time{}, false), 1)
+	stopCh = make(chan struct{})
+	doneCh = make(chan struct{})
+	go runConsumer(context.Background(), fetcher, handler, consumerTuning{
+		fetchBatchSize: 1, bulkFlushInterval: time.Hour, pipelineDepth: depth,
+	}, stopCh, doneCh)
+	return stopCh, doneCh
+}
+
+func requireClosed(t *testing.T, ch <-chan struct{}, msg string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatal(msg)
+	}
+}
+
+// Depth is what lets a collection overlap ES round-trips with the fetch and build behind
+// them, and it is bounded: unbounded concurrency would queue batches against ES without
+// limit and blow through the consumer's ack-pending budget.
+func TestRunConsumer_RunsUpToPipelineDepthConcurrently(t *testing.T) {
+	for _, depth := range []int{1, 2} {
+		t.Run(fmt.Sprintf("depth %d", depth), func(t *testing.T) {
+			store := newBlockingStore()
+			fetcher := &streamingFetcher{data: pipelineMsgData(t)}
+			stopCh, doneCh := startPipelineConsumer(t, store, fetcher, depth)
+
+			for i := 0; i < depth; i++ {
+				requireClosed(t, store.entered, "bulk request never started")
+			}
+			// Every slot is held, so a serial loop could not have fetched again.
+			require.Eventually(t, func() bool { return fetcher.fetches() > depth }, 5*time.Second, 5*time.Millisecond,
+				"consumer must keep fetching while the bulk requests are in flight")
+			require.Eventually(t, func() bool { return store.maxConcurrent() == depth }, 5*time.Second, 5*time.Millisecond,
+				"the pipeline must reach its configured depth")
+
+			// Bounded negative assertion: a depth+1'th request would have started by now.
+			select {
+			case <-store.entered:
+				t.Fatalf("a bulk request beyond depth %d started while all slots were held", depth)
+			case <-time.After(200 * time.Millisecond):
+			}
+			assert.Equal(t, depth, store.maxConcurrent())
+
+			close(store.release)
+			close(stopCh)
+			requireClosed(t, doneCh, "consumer did not shut down")
+		})
+	}
+}
+
+func TestRunConsumer_WaitsForInFlightBulksBeforeSignallingDone(t *testing.T) {
+	for _, depth := range []int{1, 2} {
+		t.Run(fmt.Sprintf("depth %d", depth), func(t *testing.T) {
+			store := newBlockingStore()
+			fetcher := &streamingFetcher{data: pipelineMsgData(t)}
+			stopCh, doneCh := startPipelineConsumer(t, store, fetcher, depth)
+
+			for i := 0; i < depth; i++ {
+				requireClosed(t, store.entered, "bulk request never started")
+			}
+			close(stopCh)
+
+			select {
+			case <-doneCh:
+				t.Fatal("consumer signalled done with bulk requests still in flight")
+			case <-time.After(200 * time.Millisecond):
+			}
+
+			close(store.release)
+			requireClosed(t, doneCh, "consumer did not shut down once every bulk request finished")
+		})
+	}
+}
+
+// recordingStore captures the batches handed to Bulk without blocking.
+type recordingStore struct {
+	mu    sync.Mutex
+	sizes []int
+}
+
+func (s *recordingStore) Bulk(_ context.Context, actions []searchengine.BulkAction) ([]searchengine.BulkResult, error) {
+	s.mu.Lock()
+	s.sizes = append(s.sizes, len(actions))
+	s.mu.Unlock()
+	return okResults(len(actions)), nil
+}
+
+// UpdateByQuery satisfies Store; the pipeline tests only exercise the bulk path.
+func (s *recordingStore) UpdateByQuery(context.Context, string, json.RawMessage) error { return nil }
+
+func (s *recordingStore) batches() []int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]int(nil), s.sizes...)
+}
+
+func TestRunConsumer_FlushesBufferedWorkOnShutdownAfterFetchErrors(t *testing.T) {
+	store := &recordingStore{}
+	fetcher := &streamingFetcher{data: pipelineMsgData(t), failAfter: 1}
+	// Bulk size 10 and a one-hour interval keep the buffered message below both
+	// flush triggers, so only the shutdown drain can get it to ES.
+	handler := NewHandler(store, newMessageCollection("msgs-v1", "site-a", time.Time{}, false), 10)
+	stopCh := make(chan struct{})
+	doneCh := make(chan struct{})
+	go runConsumer(context.Background(), fetcher, handler, consumerTuning{
+		fetchBatchSize: 10, bulkFlushInterval: time.Hour, pipelineDepth: 1,
+	}, stopCh, doneCh)
+
+	require.Eventually(t, func() bool { return fetcher.fetches() > 1 }, 5*time.Second, 5*time.Millisecond,
+		"consumer must keep looping after a fetch error")
+
+	close(stopCh)
+	requireClosed(t, doneCh, "consumer did not shut down")
+
+	assert.Equal(t, []int{1}, store.batches(), "the message buffered before the fetch errors must still reach ES")
+}
+
+// Depth is what lets a collection keep more than one bulk request in flight. It is
+// bounded: unbounded concurrency would let batches queue up against ES without limit
+// and blow past the consumer's ack-pending budget.

--- a/search-sync-worker/deploy/docker-compose.yml
+++ b/search-sync-worker/deploy/docker-compose.yml
@@ -32,6 +32,12 @@ services:
       # - HR_JETSTREAM_DOMAIN=hr-hub
       - USER_ROOM_INDEX=${USER_ROOM_INDEX:-user-room-mv-${SITE_ID:-site-local}}
       - BOOTSTRAP_STREAMS=${BOOTSTRAP_STREAMS:-true}
+      # PIPELINE_DEPTH bulk requests can be in flight while one more batch fills, so the
+      # consumer needs ack-pending headroom for (PIPELINE_DEPTH+1) * BULK_BATCH_SIZE.
+      # At the defaults (depth 2, bulk 500) that is 1500; the shared default is 1000, which
+      # would leave the size-based flush unable to fire. Production must set this too.
+      - CONSUMER_MAX_ACK_PENDING=${CONSUMER_MAX_ACK_PENDING:-1500}
+      # - PIPELINE_DEPTH=2
       # Optional YYYY-MM-DD (UTC) cutoff for the messages collection.
       # When set, events whose Message.CreatedAt predates the date are
       # skipped — used during legacy-data migration. Leave unset/empty

--- a/search-sync-worker/handler.go
+++ b/search-sync-worker/handler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/jsretry"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/searchengine"
@@ -146,6 +148,30 @@ func (h *Handler) AddWithContext(ctx context.Context, msg jetstream.Msg) {
 	h.mu.Unlock()
 }
 
+// bulkItemError builds the settle error for one failed bulk item. A permanent failure
+// is wrapped with errcode.Permanent so jsretry Ack-drops it instead of retrying — the
+// backend rejected the document itself, so redelivering identical bytes can only fail
+// identically, and retrying would just hold an ack-pending slot for the full window.
+//
+// Only the status and error type go into the message; the document body never belongs
+// in an error that reaches the server log.
+func bulkItemError(result searchengine.BulkResult) error {
+	if searchengine.IsBulkItemPermanent(result) {
+		return errcode.Permanent(errcode.BadRequest(
+			fmt.Sprintf("search backend rejected the document: status %d %q", result.Status, result.ErrorType)))
+	}
+	return fmt.Errorf("bulk item failed: status %d %q", result.Status, result.ErrorType)
+}
+
+// itemBackoff picks the retry schedule a failed bulk item calls for. Backpressure gets
+// the slow curve; everything else rides the shared default.
+func itemBackoff(result searchengine.BulkResult) []time.Duration {
+	if searchengine.IsBulkItemBackpressure(result) {
+		return jsretry.BackpressureBackoff
+	}
+	return jsretry.DefaultBackoff
+}
+
 // Flush sends all buffered actions to ES and acks/naks per source message.
 func (h *Handler) Flush(ctx context.Context) {
 	h.mu.Lock()
@@ -194,35 +220,57 @@ func (h *Handler) Flush(ctx context.Context) {
 
 	h.metrics.recordFlush(bulkCtx, flushSuccess, elapsed, len(actions))
 
-	var acked, nakked int
+	var acked, poisoned, nakked int
 	for _, p := range pending {
-		allOK := true
+		var itemErr error
+		backoff := jsretry.DefaultBackoff
+		failed, permanent := false, false
 		for i := p.actionStart; i < p.actionStart+p.actionCount; i++ {
 			if searchengine.IsBulkItemSuccess(actions[i].Action, results[i]) {
 				continue
 			}
 			h.metrics.recordItemFailure(bulkCtx, string(actions[i].Action), results[i].Status)
-			if allOK {
-				// Log only the first failed item per message; the counter above still
-				// sees every failed action.
-				slog.Error("bulk item failed",
-					"status", results[i].Status,
-					"error", results[i].Error,
-					"docID", actions[i].DocID,
-					"index", actions[i].Index,
-				)
+			if failed {
+				continue // the counter above sees every failed action; the rest is decided once
 			}
-			allOK = false
+			failed = true
+			// The first failure decides the message's fate. disposition spells out what that
+			// was, because SettleQuiet leaves the Ack-drop of a permanent failure otherwise
+			// unlogged; it reads from the result, not the error, so the log cannot disagree
+			// with the settle decision.
+			permanent = searchengine.IsBulkItemPermanent(results[i])
+			disposition := "retry"
+			if permanent {
+				disposition = "drop"
+			}
+			slog.ErrorContext(p.ctx, "bulk item failed",
+				"status", results[i].Status,
+				"error", results[i].Error,
+				"errorType", results[i].ErrorType,
+				"backpressure", searchengine.IsBulkItemBackpressure(results[i]),
+				"disposition", disposition,
+				"docID", actions[i].DocID,
+				"index", actions[i].Index,
+			)
+			itemErr, backoff = bulkItemError(results[i]), itemBackoff(results[i])
 		}
-		if allOK {
+		// A permanent failure is Acked, not nakked, so it counts as a poison drop rather
+		// than inflating the nakked series with messages that were never retried.
+		switch {
+		case !failed:
 			acked++
-			natsutil.Ack(p.jsMsg, "bulk actions succeeded")
-		} else {
+		case permanent:
+			poisoned++
+		default:
 			nakked++
-			jsretry.Nak(bulkCtx, p.jsMsg, jsretry.DefaultBackoff, "bulk action failed")
 		}
+		// One SettleQuiet covers all three dispositions: a nil error acks, a permanent
+		// error Ack-drops, anything else naks on `backoff`. Quiet because the failure is
+		// already logged above with its ES detail.
+		jsretry.SettleQuiet(p.ctx, p.jsMsg, backoff, itemErr)
 	}
 	h.metrics.recordMessages(bulkCtx, dispAckedSuccess, acked)
+	h.metrics.recordMessages(bulkCtx, dispAckedPoison, poisoned)
 	h.metrics.recordMessages(bulkCtx, dispNakkedItemFailed, nakked)
 }
 

--- a/search-sync-worker/handler.go
+++ b/search-sync-worker/handler.go
@@ -193,18 +193,44 @@ func streamSequence(msg jetstream.Msg) uint64 {
 	return md.Sequence.Stream
 }
 
-// Flush sends all buffered actions to ES and acks/naks per source message.
-func (h *Handler) Flush(ctx context.Context) {
+// flushBatch is one detached unit of work: the buffered source messages and
+// the ES bulk actions they produced. Take hands it off so the consumer loop can
+// keep buffering the next batch while this one's bulk request is still in
+// flight.
+type flushBatch struct {
+	pending []pendingMsg
+	actions []searchengine.BulkAction
+}
+
+// Take detaches everything currently buffered and resets the buffer, returning
+// nil when there is nothing to flush. It never touches the search engine, so
+// the caller can hand the returned batch to a background flusher and keep
+// buffering immediately — ActionCount() reads 0 as soon as this returns.
+func (h *Handler) Take() *flushBatch {
 	h.mu.Lock()
+	defer h.mu.Unlock()
 	if len(h.pending) == 0 {
-		h.mu.Unlock()
-		return
+		return nil
 	}
-	pending := h.pending
-	actions := h.actions
+	batch := &flushBatch{pending: h.pending, actions: h.actions}
 	h.pending = make([]pendingMsg, 0, h.bulkSize)
 	h.actions = make([]searchengine.BulkAction, 0, h.bulkSize)
-	h.mu.Unlock()
+	return batch
+}
+
+// Flush detaches the buffer and sends it to ES. Callers that want the bulk
+// request to overlap with the next batch use Take + FlushBatch instead.
+func (h *Handler) Flush(ctx context.Context) {
+	h.FlushBatch(ctx, h.Take())
+}
+
+// FlushBatch sends one detached batch to ES and acks/naks per source message.
+// A nil batch is a no-op.
+func (h *Handler) FlushBatch(ctx context.Context, batch *flushBatch) {
+	if batch == nil {
+		return
+	}
+	pending, actions := batch.pending, batch.actions
 
 	bulkCtx, span := h.startFlushSpan(ctx, pending, len(actions))
 	defer span.End()

--- a/search-sync-worker/handler.go
+++ b/search-sync-worker/handler.go
@@ -121,7 +121,7 @@ func (h *Handler) AddWithContext(ctx context.Context, msg jetstream.Msg) {
 		}
 	}
 
-	actions, err := h.collection.BuildAction(data)
+	actions, err := h.buildActions(msg, data)
 	if err != nil {
 		// Every BuildAction error is parse/validation poison — Ack drops it for
 		// good, so this line is the only trace; keep it identifying the message.
@@ -170,6 +170,27 @@ func itemBackoff(result searchengine.BulkResult) []time.Duration {
 		return jsretry.BackpressureBackoff
 	}
 	return jsretry.DefaultBackoff
+}
+
+// buildActions converts one payload, handing collections that guard on stream order
+// the message's sequence (see sequencedCollection).
+func (h *Handler) buildActions(msg jetstream.Msg, data []byte) ([]searchengine.BulkAction, error) {
+	sc, ok := h.collection.(sequencedCollection)
+	if !ok {
+		return h.collection.BuildAction(data)
+	}
+	return sc.BuildActionSeq(data, streamSequence(msg))
+}
+
+// streamSequence returns the message's position in its stream, or 0 when the metadata
+// can't be read. Zero is the fail-closed value: it loses to any stored sequence, so a
+// message we can't order is skipped rather than allowed to overwrite a newer row.
+func streamSequence(msg jetstream.Msg) uint64 {
+	md, err := msg.Metadata()
+	if err != nil || md == nil {
+		return 0
+	}
+	return md.Sequence.Stream
 }
 
 // Flush sends all buffered actions to ES and acks/naks per source message.

--- a/search-sync-worker/handler_test.go
+++ b/search-sync-worker/handler_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -23,25 +24,44 @@ import (
 
 // stubMsg implements jetstream.Msg for testing.
 type stubMsg struct {
-	data     []byte
-	headers  nats.Header
-	acked    bool
-	nacked   bool
-	nakDelay time.Duration
+	data    []byte
+	headers nats.Header
+	acked   bool
+	// nacked is set by either nak path; nakedBare distinguishes the immediate
+	// Nak() (which asks for instant redelivery) from the paced NakWithDelay.
+	nacked       bool
+	nakedBare    bool
+	nakDelay     time.Duration
+	numDelivered uint64
 }
 
-func (m *stubMsg) Data() []byte                              { return m.data }
-func (m *stubMsg) Ack() error                                { m.acked = true; return nil }
-func (m *stubMsg) Nak() error                                { m.nacked = true; return nil }
-func (m *stubMsg) NakWithDelay(d time.Duration) error        { m.nacked = true; m.nakDelay = d; return nil }
-func (m *stubMsg) InProgress() error                         { return nil }
-func (m *stubMsg) Term() error                               { return nil }
-func (m *stubMsg) TermWithReason(string) error               { return nil }
-func (m *stubMsg) Metadata() (*jetstream.MsgMetadata, error) { return nil, nil }
-func (m *stubMsg) Subject() string                           { return "" }
-func (m *stubMsg) Reply() string                             { return "" }
-func (m *stubMsg) Headers() nats.Header                      { return m.headers }
-func (m *stubMsg) DoubleAck(context.Context) error           { return nil }
+func (m *stubMsg) Data() []byte                       { return m.data }
+func (m *stubMsg) Ack() error                         { m.acked = true; return nil }
+func (m *stubMsg) Nak() error                         { m.nacked, m.nakedBare = true, true; return nil }
+func (m *stubMsg) NakWithDelay(d time.Duration) error { m.nacked, m.nakDelay = true, d; return nil }
+func (m *stubMsg) InProgress() error                  { return nil }
+func (m *stubMsg) Term() error                        { return nil }
+func (m *stubMsg) TermWithReason(string) error        { return nil }
+func (m *stubMsg) Metadata() (*jetstream.MsgMetadata, error) {
+	if m.numDelivered == 0 {
+		return nil, nil // mirrors a message whose metadata can't be parsed
+	}
+	return &jetstream.MsgMetadata{NumDelivered: m.numDelivered}, nil
+}
+func (m *stubMsg) Subject() string                 { return "" }
+func (m *stubMsg) Reply() string                   { return "" }
+func (m *stubMsg) Headers() nats.Header            { return m.headers }
+func (m *stubMsg) DoubleAck(context.Context) error { return nil }
+
+// assertJitteredDelay asserts got is jsretry's equal-jitter of base: half the
+// base delay plus up to the other half. Exact-value assertions would be flaky —
+// jsretry deliberately randomizes so a fleet that parked during one outage does
+// not retry in lockstep.
+func assertJitteredDelay(t *testing.T, base, got time.Duration) {
+	t.Helper()
+	assert.GreaterOrEqual(t, got, base/2, "jittered delay must be at least half the base %s", base)
+	assert.LessOrEqual(t, got, base, "jittered delay must not exceed the base %s", base)
+}
 
 func makeStubMsg(t *testing.T, evt *model.MessageEvent) *stubMsg {
 	t.Helper()
@@ -113,6 +133,9 @@ func TestHandler_Add_RoomRenamed_UpdateByQuery(t *testing.T) {
 		msg := &stubMsg{data: renameData(t)}
 		h.Add(msg)
 		assert.True(t, msg.nacked)
+		assert.False(t, msg.nakedBare,
+			"an immediate nak re-hammers a backend that just failed the by-query")
+		assertJitteredDelay(t, 1*time.Second, msg.nakDelay)
 	})
 }
 
@@ -595,4 +618,100 @@ func (c *captureCollection) MappingUpdate() (string, json.RawMessage)  { return 
 func (c *captureCollection) BuildAction(data []byte) ([]searchengine.BulkAction, error) {
 	c.received = append(c.received[:0], data...)
 	return nil, nil
+}
+
+func TestHandler_Flush_RetryPacing(t *testing.T) {
+	evt := model.MessageEvent{
+		Event: model.EventCreated,
+		Message: model.Message{
+			ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+			Content: "hello", CreatedAt: time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
+		},
+		SiteID: "site-a", Timestamp: 100,
+	}
+
+	newMsg := func(t *testing.T, numDelivered uint64) *stubMsg {
+		t.Helper()
+		m := makeStubMsg(t, &evt)
+		m.numDelivered = numDelivered
+		return m
+	}
+
+	flushItem := func(t *testing.T, msg *stubMsg, result searchengine.BulkResult) {
+		t.Helper()
+		ctrl := gomock.NewController(t)
+		store := NewMockStore(ctrl)
+		store.EXPECT().Bulk(gomock.Any(), gomock.Len(1)).Return([]searchengine.BulkResult{result}, nil)
+		h := NewHandler(store, newMessageCollection("msgs-v1", "site-a", time.Time{}, false), 500)
+		h.Add(msg)
+		h.Flush(context.Background())
+	}
+
+	transient := searchengine.BulkResult{Status: 500, Error: "boom"}
+	backpressure := searchengine.BulkResult{Status: 429, ErrorType: searchengine.ErrRejectedExecution}
+
+	t.Run("transient failure walks jsretry.DefaultBackoff", func(t *testing.T) {
+		tests := []struct {
+			name         string
+			numDelivered uint64
+			want         time.Duration
+		}{
+			{"first delivery", 1, 1 * time.Second},
+			{"second delivery", 2, 5 * time.Second},
+			{"third delivery", 3, 30 * time.Second},
+			{"past the schedule clamps to the longest step", 9, 10 * time.Minute},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				msg := newMsg(t, tt.numDelivered)
+				flushItem(t, msg, transient)
+
+				assert.True(t, msg.nacked)
+				assert.False(t, msg.nakedBare, "an immediate nak re-hammers a backend that just failed")
+				assertJitteredDelay(t, tt.want, msg.nakDelay)
+			})
+		}
+	})
+
+	t.Run("backpressure skips the fast rungs of the default schedule", func(t *testing.T) {
+		msg := newMsg(t, 1)
+		flushItem(t, msg, backpressure)
+
+		assert.True(t, msg.nacked)
+		assert.False(t, msg.nakedBare)
+		assertJitteredDelay(t, 30*time.Second, msg.nakDelay)
+		assert.GreaterOrEqual(t, msg.nakDelay, 15*time.Second,
+			"a saturated cluster needs time to drain; retrying in 1s only feeds the overload")
+	})
+
+	t.Run("success still acks", func(t *testing.T) {
+		msg := newMsg(t, 1)
+		flushItem(t, msg, searchengine.BulkResult{Status: 201})
+
+		assert.True(t, msg.acked)
+		assert.False(t, msg.nacked)
+	})
+
+	t.Run("a document ES rejects as malformed is dropped, not retried", func(t *testing.T) {
+		msg := newMsg(t, 1)
+		flushItem(t, msg, searchengine.BulkResult{Status: 400, ErrorType: "mapper_parsing_exception"})
+
+		assert.True(t, msg.acked, "poison must be acked (dropped) so it stops consuming deliveries")
+		assert.False(t, msg.nacked)
+		assert.Zero(t, msg.nakDelay)
+	})
+
+	t.Run("whole-batch failure is paced too", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		store := NewMockStore(ctrl)
+		store.EXPECT().Bulk(gomock.Any(), gomock.Any()).Return(nil, errors.New("es unreachable"))
+		h := NewHandler(store, newMessageCollection("msgs-v1", "site-a", time.Time{}, false), 500)
+		msg := newMsg(t, 2)
+		h.Add(msg)
+		h.Flush(context.Background())
+
+		assert.True(t, msg.nacked)
+		assert.False(t, msg.nakedBare)
+		assertJitteredDelay(t, 5*time.Second, msg.nakDelay)
+	})
 }

--- a/search-sync-worker/handler_test.go
+++ b/search-sync-worker/handler_test.go
@@ -623,6 +623,52 @@ func (c *captureCollection) BuildAction(data []byte) ([]searchengine.BulkAction,
 	return nil, nil
 }
 
+func TestHandler_Take(t *testing.T) {
+	evt := model.MessageEvent{
+		Event: model.EventCreated,
+		Message: model.Message{
+			ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+			Content: "hello", CreatedAt: time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
+		},
+		SiteID: "site-a", Timestamp: 100,
+	}
+
+	t.Run("detaches buffered work and empties the buffer", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		store := NewMockStore(ctrl)
+		h := NewHandler(store, newMessageCollection("msgs-v1", "site-a", time.Time{}, false), 500)
+		h.Add(makeStubMsg(t, &evt))
+		h.Add(makeStubMsg(t, &evt))
+
+		batch := h.Take()
+
+		require.NotNil(t, batch)
+		assert.Len(t, batch.actions, 2, "detached batch carries the buffered actions")
+		assert.Len(t, batch.pending, 2, "detached batch carries the source messages for ack/nak")
+		assert.Equal(t, 0, h.ActionCount(), "buffer is empty immediately, before the bulk request runs")
+		assert.Equal(t, 0, h.MessageCount())
+	})
+
+	t.Run("returns nil when nothing is buffered", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		store := NewMockStore(ctrl)
+		h := NewHandler(store, newMessageCollection("msgs-v1", "site-a", time.Time{}, false), 500)
+
+		assert.Nil(t, h.Take())
+	})
+}
+
+func TestHandler_FlushBatch_NilBatchDoesNotCallStore(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	// No store.EXPECT(): any Bulk call fails the test.
+	h := NewHandler(store, newMessageCollection("msgs-v1", "site-a", time.Time{}, false), 500)
+
+	h.FlushBatch(context.Background(), nil)
+}
+
+// Retry pacing is delegated to pkg/jsretry, the repo-wide settle helper. These
+// tests pin the schedule search-sync-worker selects, not jsretry's internals.
 func TestHandler_Flush_RetryPacing(t *testing.T) {
 	evt := model.MessageEvent{
 		Event: model.EventCreated,

--- a/search-sync-worker/handler_test.go
+++ b/search-sync-worker/handler_test.go
@@ -33,6 +33,7 @@ type stubMsg struct {
 	nakedBare    bool
 	nakDelay     time.Duration
 	numDelivered uint64
+	streamSeq    uint64
 }
 
 func (m *stubMsg) Data() []byte                       { return m.data }
@@ -43,10 +44,12 @@ func (m *stubMsg) InProgress() error                  { return nil }
 func (m *stubMsg) Term() error                        { return nil }
 func (m *stubMsg) TermWithReason(string) error        { return nil }
 func (m *stubMsg) Metadata() (*jetstream.MsgMetadata, error) {
-	if m.numDelivered == 0 {
+	if m.numDelivered == 0 && m.streamSeq == 0 {
 		return nil, nil // mirrors a message whose metadata can't be parsed
 	}
-	return &jetstream.MsgMetadata{NumDelivered: m.numDelivered}, nil
+	md := &jetstream.MsgMetadata{NumDelivered: m.numDelivered}
+	md.Sequence.Stream = m.streamSeq
+	return md, nil
 }
 func (m *stubMsg) Subject() string                 { return "" }
 func (m *stubMsg) Reply() string                   { return "" }
@@ -713,5 +716,50 @@ func TestHandler_Flush_RetryPacing(t *testing.T) {
 		assert.True(t, msg.nacked)
 		assert.False(t, msg.nakedBare)
 		assertJitteredDelay(t, 5*time.Second, msg.nakDelay)
+	})
+}
+
+// sequencedStubCollection records the stream sequence Handler hands it.
+type sequencedStubCollection struct {
+	stubCollection
+	gotSeq uint64
+	called bool
+}
+
+func (c *sequencedStubCollection) BuildActionSeq(data []byte, streamSeq uint64) ([]searchengine.BulkAction, error) {
+	c.gotSeq, c.called = streamSeq, true
+	return c.BuildAction(data)
+}
+
+// The ordering guard is only as good as the sequence reaching it, and the routing runs
+// through a type assertion — so pin it.
+func TestHandler_Add_RoutesSequenceToSequencedCollection(t *testing.T) {
+	t.Run("hands over the message's stream sequence", func(t *testing.T) {
+		coll := &sequencedStubCollection{stubCollection: stubCollection{action: searchengine.ActionUpdate}}
+		h := NewHandler(NewMockStore(gomock.NewController(t)), coll, 500)
+
+		h.Add(&stubMsg{data: []byte(`{}`), streamSeq: 909})
+
+		assert.True(t, coll.called, "a sequenced collection must not fall through to BuildAction")
+		assert.Equal(t, uint64(909), coll.gotSeq)
+		assert.Equal(t, 1, h.ActionCount())
+	})
+
+	t.Run("unreadable metadata yields sequence 0", func(t *testing.T) {
+		coll := &sequencedStubCollection{stubCollection: stubCollection{action: searchengine.ActionUpdate}}
+		h := NewHandler(NewMockStore(gomock.NewController(t)), coll, 500)
+
+		h.Add(&stubMsg{data: []byte(`{}`)})
+
+		assert.True(t, coll.called)
+		assert.Zero(t, coll.gotSeq, "0 loses to any stored sequence, so the write is skipped not applied")
+	})
+
+	t.Run("plain collections still go through BuildAction", func(t *testing.T) {
+		h := NewHandler(NewMockStore(gomock.NewController(t)), newStubIndexCollection(), 500)
+
+		h.Add(&stubMsg{data: []byte(`{}`), streamSeq: 5})
+
+		assert.Equal(t, 1, h.ActionCount())
 	})
 }

--- a/search-sync-worker/integration_test.go
+++ b/search-sync-worker/integration_test.go
@@ -645,6 +645,7 @@ func TestSearchSyncSpotlightOrg_Integration(t *testing.T) {
 		engine.UpsertTemplate(ctx, coll.TemplateName(), overrideIndexSettings(coll.TemplateBody())),
 		"upsert spotlight-org template",
 	)
+	registerStoredScripts(t, ctx, engine, coll)
 	preCreateIndex(t, esURL, indexName)
 	waitForClusterGreen(t, esURL, 120*time.Second)
 
@@ -721,5 +722,47 @@ func TestSearchSyncSpotlightOrg_Integration(t *testing.T) {
 		assert.Equal(t, "Engineering Renamed", s1["sectName"], "renamed field updated")
 		assert.Equal(t, "D1", s1["deptId"], "deptId preserved")
 		assert.Equal(t, "Tech", s1["deptName"], "deptName preserved")
+	})
+
+	// The two writes above arrived in stream order, so the guard let both through and
+	// recorded the second sequence. These drive the guard itself: the HR payload has no
+	// timestamp, so ordering rests entirely on this script comparing stream sequences.
+	applyAt := func(t *testing.T, sectName string, seq uint64) searchengine.BulkResult {
+		t.Helper()
+		actions, buildErr := coll.BuildActionSeq(
+			hrBatchJSON(t, []SpotlightOrgIndex{{SectID: "S1", SectName: sectName}}), seq)
+		require.NoError(t, buildErr)
+		require.Len(t, actions, 1)
+		results, bulkErr := engine.Bulk(ctx, actions)
+		require.NoError(t, bulkErr)
+		require.Len(t, results, 1)
+		refreshIndex(t, esURL, indexName)
+		return results[0]
+	}
+
+	t.Run("the stored sequence advances with each applied write", func(t *testing.T) {
+		s1 := getDoc(t, esURL, indexName, "S1")
+		require.NotNil(t, s1)
+		assert.NotNil(t, s1["orgSeq"], "the guard needs a stored sequence to compare against")
+	})
+
+	t.Run("a stale sequence cannot overwrite a newer row", func(t *testing.T) {
+		result := applyAt(t, "Engineering STALE", 1)
+
+		assert.True(t, searchengine.IsBulkItemSuccess(searchengine.ActionUpdate, result),
+			"a skipped update is a successful no-op, not a failure to retry")
+		s1 := getDoc(t, esURL, indexName, "S1")
+		require.NotNil(t, s1)
+		assert.Equal(t, "Engineering Renamed", s1["sectName"],
+			"a redelivered or slow batch must not resurrect the older row")
+	})
+
+	t.Run("a newer sequence still applies", func(t *testing.T) {
+		applyAt(t, "Engineering Final", 999999)
+
+		s1 := getDoc(t, esURL, indexName, "S1")
+		require.NotNil(t, s1)
+		assert.Equal(t, "Engineering Final", s1["sectName"])
+		assert.Equal(t, "D1", s1["deptId"], "the guard must not cost doc-merge semantics")
 	})
 }

--- a/search-sync-worker/main.go
+++ b/search-sync-worker/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/caarlos0/env/v11"
@@ -77,6 +78,13 @@ type config struct {
 	// the time-based counterpart to the size trigger, bounding write latency during idle periods.
 	BulkFlushInterval int `env:"BULK_FLUSH_INTERVAL" envDefault:"5"`
 
+	// PipelineDepth is how many ES bulk requests one collection keeps in flight while later
+	// batches fetch and build. 1 serializes fetch/build behind every round-trip; higher trades
+	// ack-pending headroom for throughput when ES latency dominates. Costs are per collection
+	// AND per pod, so the cluster sees depth x collections x replicas concurrent bulk requests.
+	// Needs (PipelineDepth+1) * BulkBatchSize <= CONSUMER_MAX_ACK_PENDING — see checkBatchAckCoupling.
+	PipelineDepth int `env:"PIPELINE_DEPTH" envDefault:"2"`
+
 	Consumer  stream.ConsumerSettings `envPrefix:"CONSUMER_"`
 	Bootstrap bootstrapConfig         `envPrefix:"BOOTSTRAP_"`
 
@@ -115,6 +123,12 @@ func main() {
 		slog.Error("invalid config", "name", "BULK_FLUSH_INTERVAL", "value", cfg.BulkFlushInterval, "reason", "must be > 0")
 		os.Exit(1)
 	}
+	// A non-positive depth would make the pipeline's slot channel unbuffered and park the
+	// consumer on its first flush forever.
+	if cfg.PipelineDepth <= 0 {
+		slog.Error("invalid config", "name", "PIPELINE_DEPTH", "value", cfg.PipelineDepth, "reason", "must be > 0")
+		os.Exit(1)
+	}
 	if _, _, ok := searchindex.StripVersion(cfg.MsgIndexPrefix); !ok {
 		slog.Error("invalid config", "name", "MSG_INDEX_PREFIX", "value", cfg.MsgIndexPrefix, "reason", "must end with -v<N>, e.g. messages-site-a-v1")
 		os.Exit(1)
@@ -134,10 +148,11 @@ func main() {
 	}
 
 	// Warn (don't fail) if the bulk batch size can't be reached under the consumer's ack-pending ceiling — see checkBatchAckCoupling.
-	if warning := checkBatchAckCoupling(cfg.BulkBatchSize, cfg.Consumer.MaxAckPending); warning != "" {
+	if warning := checkBatchAckCoupling(cfg.BulkBatchSize, cfg.Consumer.MaxAckPending, cfg.PipelineDepth); warning != "" {
 		slog.Warn("batch/ack-pending config coupling",
 			"bulkBatchSize", cfg.BulkBatchSize,
 			"maxAckPending", cfg.Consumer.MaxAckPending,
+			"pipelineDepth", cfg.PipelineDepth,
 			"detail", warning,
 		)
 	}
@@ -334,7 +349,11 @@ func main() {
 			"filters", consumerCfg.FilterSubjects,
 		)
 
-		go runConsumer(ctx, fetcher, handler, cfg.FetchBatchSize, cfg.BulkBatchSize, bulkFlushInterval, stopCh, doneCh)
+		go runConsumer(ctx, fetcher, handler, consumerTuning{
+			fetchBatchSize:    cfg.FetchBatchSize,
+			bulkFlushInterval: bulkFlushInterval,
+			pipelineDepth:     cfg.PipelineDepth,
+		}, stopCh, doneCh)
 	}
 
 	healthStop, err := health.ServeWithPprof(cfg.HealthAddr, 5*time.Second, cfg.PProfEnabled,
@@ -397,23 +416,90 @@ func pushMappings(ctx context.Context, engine searchengine.SearchEngine, collect
 	return nil
 }
 
-// runConsumer is the batch-flush consumer loop: fetchBatchSize bounds JetStream Fetch() pulls
-// (client-tuning only), bulkBatchSize caps buffered ES actions (flushed on stopCh, size, or bulkFlushInterval; the loop clamps fetch to remaining bulk capacity, but a fan-out message can still overshoot mid-loop and triggers its own flush).
+// flushPipeline overlaps up to `depth` ES bulk requests with the fetch and build of the
+// batches behind them. The slot channel is the cap: unbounded concurrency would queue
+// batches against ES without limit and blow through the consumer's ack-pending budget.
+//
+// Concurrent flushes can reach ES out of order, which is safe only because every
+// collection carries an ordering guard — external versioning on messages and spotlight,
+// a painless timestamp compare on user-room, a stream-sequence compare on spotlight-org.
+// A collection added without one MUST run at depth 1.
+//
+// Only the consumer goroutine calls run/wait, so the struct needs no lock of its own.
+type flushPipeline struct {
+	slots chan struct{} // buffered to depth; a token is held for each in-flight flush
+	wg    sync.WaitGroup
+}
+
+func newFlushPipeline(depth int) *flushPipeline {
+	return &flushPipeline{slots: make(chan struct{}, depth)}
+}
+
+// wait blocks until every in-flight flush has finished.
+func (p *flushPipeline) wait() {
+	p.wg.Wait()
+}
+
+// run detaches whatever the handler has buffered and flushes it in the background,
+// blocking for a slot once `depth` flushes are already in flight. Taking the batch first
+// frees the buffer immediately, so ActionCount() reads 0 on return.
+func (p *flushPipeline) run(ctx context.Context, h *Handler) {
+	batch := h.Take()
+	if batch == nil {
+		return
+	}
+	p.slots <- struct{}{}
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		defer func() { <-p.slots }()
+		// jobguard recovers panics from the batch handler so a poison message or malformed
+		// bulk response can't crash this collection's consumer; the batch's messages stay
+		// un-acked and JetStream redelivers after AckWait.
+		jobguard.Guard("search-sync flush", func() { h.FlushBatch(ctx, batch) })
+	}()
+}
+
+// consumerTuning groups runConsumer's throughput knobs so call sites name them instead
+// of passing a run of bare numbers.
+type consumerTuning struct {
+	fetchBatchSize    int
+	bulkFlushInterval time.Duration
+	pipelineDepth     int
+}
+
+// runConsumer is the batch-flush consumer loop: tune.fetchBatchSize bounds JetStream Fetch()
+// pulls (client-tuning only), while the handler's own bulk size caps buffered ES actions
+// (flushed on stopCh, size, or tune.bulkFlushInterval; the loop clamps fetch to remaining bulk
+// capacity, but a fan-out message can still overshoot mid-loop and triggers its own flush).
+//
+// Each flush is handed to a flushPipeline holding up to pipelineDepth requests in flight, so
+// ES round-trips overlap with the fetch and build behind them rather than serializing; the
+// loop only stalls once every slot is busy, which is the backpressure we want.
 func runConsumer(
 	ctx context.Context,
 	cons msgFetcher,
 	handler *Handler,
-	fetchBatchSize, bulkBatchSize int,
-	bulkFlushInterval time.Duration,
+	tune consumerTuning,
 	stopCh <-chan struct{},
 	doneCh chan<- struct{},
 ) {
 	defer close(doneCh)
 	lastFlush := time.Now()
 
-	// jobguard recovers panics from the batch handler so a poison message or malformed bulk response
-	// can't crash this collection's consumer goroutine; in-flight messages stay un-acked and JetStream redelivers after AckWait.
-	flush := func() { jobguard.Guard("search-sync flush", func() { handler.Flush(ctx) }) }
+	// bulkBatchSize is the handler's own cap — read it from there rather than passing the
+	// same number twice and letting the two drift.
+	bulkBatchSize := handler.bulkSize
+
+	pipe := newFlushPipeline(tune.pipelineDepth)
+	// flushNow hands the buffered batch to the pipeline and restarts the interval clock.
+	flushNow := func() {
+		pipe.run(ctx, handler)
+		lastFlush = time.Now()
+	}
+	// drain also waits on the in-flight bulk requests, so shutdown never abandons a write
+	// that is already on its way to ES.
+	drain := func() { flushNow(); pipe.wait() }
 	add := func(msgCtx context.Context, m jetstream.Msg) {
 		jobguard.Guard("search-sync add: "+m.Subject(), func() { handler.AddWithContext(msgCtx, m) })
 	}
@@ -421,35 +507,25 @@ func runConsumer(
 	for {
 		select {
 		case <-stopCh:
-			flush()
+			drain()
 			return
 		default:
 		}
 
 		// Bound the next Fetch by remaining bulk capacity so a steady stream of 1:1 messages can't
 		// overshoot bulkBatchSize; fan-out messages may still push us over, handled mid-loop below.
-		remaining := bulkBatchSize - handler.ActionCount()
-		if remaining <= 0 {
-			flush()
-			lastFlush = time.Now()
-			continue
-		}
-		fetchCount := fetchBatchSize
-		if fetchCount > remaining {
-			fetchCount = remaining
-		}
+		fetchCount := min(tune.fetchBatchSize, bulkBatchSize-handler.ActionCount())
 
 		batch, err := cons.Fetch(ctx, fetchCount, jetstream.FetchMaxWait(time.Second))
 		if err != nil {
 			select {
 			case <-stopCh:
-				flush()
+				drain()
 				return
 			default:
 			}
-			if handler.ActionCount() > 0 && time.Since(lastFlush) >= bulkFlushInterval {
-				flush()
-				lastFlush = time.Now()
+			if handler.ActionCount() > 0 && time.Since(lastFlush) >= tune.bulkFlushInterval {
+				flushNow()
 			}
 			continue
 		}
@@ -458,34 +534,35 @@ func runConsumer(
 		// goroutine blocked on an unbuffered send; an early break would leak it and stall shutdown.
 		for msg := range batch.Messages() {
 			add(msg.Ctx, msg.Msg)
-			// Mid-batch flush: if a fan-out message just pushed the buffer over the bulk cap, flush
-			// immediately — otherwise the next message's actions add to an already-oversized request.
+			// Size trigger, checked per message: a fan-out message can cross the cap on its own, and
+			// flushing here keeps the next message's actions out of an already-oversized request.
+			// Take() empties the buffer synchronously, so ActionCount stays under the cap after this.
 			if handler.ActionCount() >= bulkBatchSize {
-				flush()
-				lastFlush = time.Now()
+				flushNow()
 			}
 		}
 
-		if handler.ActionCount() >= bulkBatchSize {
-			flush()
-			lastFlush = time.Now()
-		} else if handler.ActionCount() > 0 && time.Since(lastFlush) >= bulkFlushInterval {
-			flush()
-			lastFlush = time.Now()
+		// Interval trigger: the size trigger above already fired for anything at the cap.
+		if handler.ActionCount() > 0 && time.Since(lastFlush) >= tune.bulkFlushInterval {
+			flushNow()
 		}
 	}
 }
 
-// checkBatchAckCoupling warns when bulkBatchSize exceeds maxAckPending: a 1:1 collection then
-// stalls at maxAckPending un-acked messages before the size-based flush can fire, undersizing every batch. Fan-out collections are unaffected. Empty string = no issue.
-func checkBatchAckCoupling(bulkBatchSize, maxAckPending int) string {
-	if bulkBatchSize > maxAckPending {
+// checkBatchAckCoupling warns when the pipelined batches can't fit under maxAckPending.
+// depth batches can be in flight while one more fills, so a 1:1 collection needs headroom
+// for (depth+1)*bulkBatchSize un-acked messages; below that it stalls before the size-based
+// flush can fire, undersizing every batch. Fan-out collections are unaffected. "" = no issue.
+func checkBatchAckCoupling(bulkBatchSize, maxAckPending, pipelineDepth int) string {
+	needed := (pipelineDepth + 1) * bulkBatchSize
+	if needed > maxAckPending {
 		return fmt.Sprintf(
-			"BULK_BATCH_SIZE (%d) exceeds CONSUMER_MAX_ACK_PENDING (%d): "+
-				"the size-based flush can never fire for 1:1 collections, so flushes "+
-				"will wait the full BULK_FLUSH_INTERVAL and batches stay undersized. "+
-				"Lower BULK_BATCH_SIZE to <= MAX_ACK_PENDING or raise MAX_ACK_PENDING.",
-			bulkBatchSize, maxAckPending,
+			"BULK_BATCH_SIZE (%[1]d) at PIPELINE_DEPTH %[2]d needs CONSUMER_MAX_ACK_PENDING >= "+
+				"%[3]d (%[2]d in flight plus one filling) but it is %[4]d: the size-based flush "+
+				"can never fire for 1:1 collections, so flushes will wait the full "+
+				"BULK_FLUSH_INTERVAL and batches stay undersized. Raise MAX_ACK_PENDING to "+
+				"%[3]d, or lower BULK_BATCH_SIZE to %[5]d, or drop PIPELINE_DEPTH.",
+			bulkBatchSize, pipelineDepth, needed, maxAckPending, maxAckPending/(pipelineDepth+1),
 		)
 	}
 	return ""

--- a/search-sync-worker/metrics_test.go
+++ b/search-sync-worker/metrics_test.go
@@ -191,6 +191,35 @@ func TestSyncMetrics_FlushItemFailure(t *testing.T) {
 		"per-item failures nak their own messages but the flush round-trip itself succeeded")
 }
 
+// A 400 is poison: jsretry Acks it rather than retrying, so it must land in the
+// acked/poison series. Counting it as nakked/item_failed like a transient failure
+// would inflate the retry series with messages that were never retried.
+func TestSyncMetrics_FlushPermanentItemFailureAcksAsPoison(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	store.EXPECT().Bulk(gomock.Any(), gomock.Len(1)).
+		Return([]searchengine.BulkResult{{Status: 400, ErrorType: "mapper_parsing_exception"}}, nil)
+
+	h, reader := metricsTestHandler(t, store)
+	h.Add(makeStubMsg(t, metricsTestEvent()))
+	h.Flush(context.Background())
+
+	rm := collectMetrics(t, reader)
+
+	failures := sumPoints(t, rm, "search_sync_worker_bulk_item_failures")
+	assert.Equal(t, int64(1), sumValue(failures, map[string]string{
+		"collection": "message-sync", "action": "index", "status": "400",
+	}), "a dropped item is still a failed item")
+
+	messages := sumPoints(t, rm, "search_sync_worker_messages")
+	assert.Equal(t, int64(1), sumValue(messages, map[string]string{
+		"collection": "message-sync", "outcome": "acked", "reason": "poison",
+	}))
+	assert.Zero(t, sumValue(messages, map[string]string{
+		"collection": "message-sync", "outcome": "nakked", "reason": "item_failed",
+	}), "poison is dropped, not retried")
+}
+
 func TestSyncMetrics_FlushResultMismatch(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)

--- a/search-sync-worker/spotlight_org.go
+++ b/search-sync-worker/spotlight_org.go
@@ -12,6 +12,37 @@ import (
 	"github.com/hmchangw/chat/pkg/subject"
 )
 
+// spotlightOrgUpsertScriptID is the stored-script id for the last-write-wins guard.
+// Bump the suffix if the source ever changes incompatibly, so a rolling deploy doesn't
+// leave old and new pods sharing one mutated definition.
+const spotlightOrgUpsertScriptID = "search-sync-spotlight-org-upsert-v1"
+
+// spotlightOrgUpsertScript applies one HR org row under a last-write-wins guard keyed on
+// params.seq — the source message's JetStream stream sequence, a strict total order
+// assigned server-side at publish time.
+//
+// The HR employees.upsert payload is a bare array carrying no timestamp of its own, so
+// the stream sequence is the only ordering token available. Without it the write is a
+// plain doc_as_upsert with no ordering semantics: a redelivered batch, or a batch from a
+// second pod sharing the durable consumer, can land after a newer one and leave the older
+// row stored.
+//
+// Merging params.doc key-by-key reproduces doc-merge semantics — the row is marshalled
+// with omitempty, so fields absent from a partial publish keep their stored values.
+//
+// Runs under scripted_upsert so a brand-new sectId also records its sequence;
+// ctx._source starts as the empty upsert doc and stored reads 0.
+//
+// Operational note: the guard compares sequences from ONE stream. If the HR stream is
+// ever recreated, sequences restart at 1 and will lose to the stored values, silently
+// dropping every subsequent update — clear orgSeq (or reindex) as part of any rebuild.
+const spotlightOrgUpsertScript = `long stored = ctx._source.orgSeq == null ? 0L : ((Number)ctx._source.orgSeq).longValue(); ` +
+	`long incoming = ((Number)params.seq).longValue(); ` +
+	`if (incoming > stored) { ` +
+	`for (entry in params.doc.entrySet()) { ctx._source[entry.getKey()] = entry.getValue(); } ` +
+	`ctx._source.orgSeq = incoming; ` +
+	`} else { ctx.op = 'none'; }`
+
 // spotlightOrgCollection maintains the spotlight-org ES index, one
 // document per sectId. Many employees collapse to one document via
 // dedup in BuildAction.
@@ -58,8 +89,12 @@ func (c *spotlightOrgCollection) TemplateBody() json.RawMessage {
 	return spotlightOrgTemplateBody(c.indexName, c.devMode)
 }
 
+// StoredScripts registers the last-write-wins guard; BuildAction references it by id
+// so the source isn't repeated in every fan-out action.
 func (c *spotlightOrgCollection) StoredScripts() map[string]json.RawMessage {
-	return nil
+	return map[string]json.RawMessage{
+		spotlightOrgUpsertScriptID: searchindex.StoredScriptBody(spotlightOrgUpsertScript),
+	}
 }
 
 // MappingUpdate returns no update — spotlight-org writes to one fixed index.
@@ -74,7 +109,18 @@ func (c *spotlightOrgCollection) MappingUpdate() (string, json.RawMessage) {
 // (last-wins) and emits one ES _update per unique sectId with doc_as_upsert:true.
 // Doc-merge + omitempty means partial-field publishes preserve stored values for
 // unset fields.
-func (c *spotlightOrgCollection) BuildAction(data []byte) ([]searchengine.BulkAction, error) {
+// BuildAction satisfies Collection but cannot be used: without a stream sequence the
+// guard rejects every write — including the insert of a brand-new sectId, since the
+// upsert seeds stored=0 and the guard needs incoming > stored — and ES reports each one
+// as a successful no-op. Failing loudly beats a fleet of silently discarded writes;
+// Handler always routes through BuildActionSeq.
+func (c *spotlightOrgCollection) BuildAction([]byte) ([]searchengine.BulkAction, error) {
+	return nil, fmt.Errorf("spotlight-org requires the source stream sequence: use BuildActionSeq")
+}
+
+// BuildActionSeq is BuildAction plus the source message's JetStream stream sequence,
+// which the last-write-wins guard compares against the stored one.
+func (c *spotlightOrgCollection) BuildActionSeq(data []byte, streamSeq uint64) ([]searchengine.BulkAction, error) {
 	var rows []SpotlightOrgIndex
 	if err := json.Unmarshal(data, &rows); err != nil {
 		return nil, fmt.Errorf("unmarshal hr employees: %w", err)
@@ -98,7 +144,7 @@ func (c *spotlightOrgCollection) BuildAction(data []byte) ([]searchengine.BulkAc
 
 	actions := make([]searchengine.BulkAction, 0, len(deduped))
 	for sectID, row := range deduped {
-		body, err := buildSpotlightOrgUpdateBody(row)
+		body, err := buildSpotlightOrgUpdateBody(row, streamSeq)
 		if err != nil {
 			return nil, err
 		}
@@ -112,16 +158,33 @@ func (c *spotlightOrgCollection) BuildAction(data []byte) ([]searchengine.BulkAc
 	return actions, nil
 }
 
-func buildSpotlightOrgUpdateBody(row *SpotlightOrgIndex) (json.RawMessage, error) {
-	body := map[string]any{
-		"doc":           row,
-		"doc_as_upsert": true,
-	}
-	data, err := json.Marshal(body)
+func buildSpotlightOrgUpdateBody(row *SpotlightOrgIndex, streamSeq uint64) (json.RawMessage, error) {
+	// scripted_upsert + an empty seed: the script owns both the insert and the merge, so a
+	// new sectId records its sequence instead of landing without one.
+	body := spotlightOrgUpdateBody{ScriptedUpsert: true}
+	body.Script.ID = spotlightOrgUpsertScriptID
+	body.Script.Params.Doc = row
+	body.Script.Params.Seq = streamSeq
+
+	data, err := json.Marshal(&body)
 	if err != nil {
 		return nil, fmt.Errorf("marshal spotlight-org update body: %w", err)
 	}
 	return data, nil
+}
+
+// spotlightOrgUpdateBody is the ES _update body for one org row. Typed rather than
+// nested map[string]any so marshalling stays allocation-cheap on the fan-out path.
+type spotlightOrgUpdateBody struct {
+	ScriptedUpsert bool     `json:"scripted_upsert"`
+	Upsert         struct{} `json:"upsert"`
+	Script         struct {
+		ID     string `json:"id"`
+		Params struct {
+			Doc *SpotlightOrgIndex `json:"doc"`
+			Seq uint64             `json:"seq"`
+		} `json:"params"`
+	} `json:"script"`
 }
 
 // SpotlightOrgIndex is the wire row, ES doc body, and ES mapping source
@@ -179,3 +242,7 @@ func spotlightOrgTemplateBody(indexName string, devMode bool) json.RawMessage {
 	data, _ := json.Marshal(tmpl)
 	return data
 }
+
+// spotlightOrgCollection needs the stream sequence for its ordering guard; the assertion
+// keeps that wiring compile-checked rather than silently lost to a renamed method.
+var _ sequencedCollection = (*spotlightOrgCollection)(nil)

--- a/search-sync-worker/spotlight_org_test.go
+++ b/search-sync-worker/spotlight_org_test.go
@@ -31,7 +31,8 @@ func TestSpotlightOrgCollection_Metadata(t *testing.T) {
 	filters := coll.FilterSubjects("site-a")
 	assert.Equal(t, []string{"chat.hr.site-central.employees.upsert"}, filters)
 
-	assert.Nil(t, coll.StoredScripts())
+	require.Contains(t, coll.StoredScripts(), spotlightOrgUpsertScriptID,
+		"the ordering guard runs as a stored script")
 }
 
 func TestSpotlightOrgTemplateBody(t *testing.T) {
@@ -112,7 +113,7 @@ func TestSpotlightOrg_BuildAction_HappyPath(t *testing.T) {
 		{SectID: "S2", SectName: "Sales", DeptID: "D2", DeptName: "Biz"},
 	})
 
-	actions, err := coll.BuildAction(data)
+	actions, err := coll.BuildActionSeq(data, 77)
 	require.NoError(t, err)
 	require.Len(t, actions, 2)
 
@@ -125,8 +126,10 @@ func TestSpotlightOrg_BuildAction_HappyPath(t *testing.T) {
 
 		var body map[string]any
 		require.NoError(t, json.Unmarshal(a.Doc, &body))
-		assert.Equal(t, true, body["doc_as_upsert"])
-		assert.Contains(t, body, "doc")
+		assert.Equal(t, true, body["scripted_upsert"])
+		params := body["script"].(map[string]any)["params"].(map[string]any)
+		assert.Equal(t, float64(77), params["seq"])
+		assert.Contains(t, params, "doc")
 	}
 	assert.True(t, docIDs["S1"])
 	assert.True(t, docIDs["S2"])
@@ -140,7 +143,7 @@ func TestSpotlightOrg_BuildAction_DedupBySectID(t *testing.T) {
 		{SectID: "S2", SectName: "Sales"},
 	})
 
-	actions, err := coll.BuildAction(data)
+	actions, err := coll.BuildActionSeq(data, 42)
 	require.NoError(t, err)
 	require.Len(t, actions, 2)
 
@@ -151,7 +154,7 @@ func TestSpotlightOrg_BuildAction_DedupBySectID(t *testing.T) {
 		}
 	}
 	require.NotNil(t, s1Body)
-	doc := s1Body["doc"].(map[string]any)
+	doc := s1Body["script"].(map[string]any)["params"].(map[string]any)["doc"].(map[string]any)
 	assert.Equal(t, "Engineering Renamed", doc["sectName"], "last-wins on dedup")
 }
 
@@ -163,7 +166,7 @@ func TestSpotlightOrg_BuildAction_EmptySectIDsSkipped(t *testing.T) {
 		{SectID: "", DeptID: "D9"},
 	})
 
-	actions, err := coll.BuildAction(data)
+	actions, err := coll.BuildActionSeq(data, 42)
 	require.NoError(t, err)
 	require.Len(t, actions, 1)
 	assert.Equal(t, "S1", actions[0].DocID)
@@ -176,7 +179,7 @@ func TestSpotlightOrg_BuildAction_AllEmptySectIDs(t *testing.T) {
 		{SectName: "no-section-2"},
 	})
 
-	actions, err := coll.BuildAction(data)
+	actions, err := coll.BuildActionSeq(data, 42)
 	require.NoError(t, err)
 	assert.Nil(t, actions)
 }
@@ -185,7 +188,7 @@ func TestSpotlightOrg_BuildAction_EmptyEmployees(t *testing.T) {
 	coll := newSpotlightOrgCollection("spotlightorg-site-a-v1", "site-a", "site-central", false)
 	data := hrBatchJSON(t, []SpotlightOrgIndex{})
 
-	actions, err := coll.BuildAction(data)
+	actions, err := coll.BuildActionSeq(data, 42)
 	require.NoError(t, err)
 	assert.Nil(t, actions)
 }
@@ -196,13 +199,13 @@ func TestSpotlightOrg_BuildAction_PartialFields(t *testing.T) {
 		{SectID: "S1", SectName: "Engineering"},
 	})
 
-	actions, err := coll.BuildAction(data)
+	actions, err := coll.BuildActionSeq(data, 42)
 	require.NoError(t, err)
 	require.Len(t, actions, 1)
 
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(actions[0].Doc, &body))
-	doc := body["doc"].(map[string]any)
+	doc := body["script"].(map[string]any)["params"].(map[string]any)["doc"].(map[string]any)
 
 	assert.Equal(t, "S1", doc["sectId"])
 	assert.Equal(t, "Engineering", doc["sectName"])
@@ -229,4 +232,63 @@ func TestSpotlightOrg_MappingUpdate_NoOp(t *testing.T) {
 	pattern, body := newSpotlightOrgCollection("spotlight-org-v1", "site-a", "hr", false).MappingUpdate()
 	assert.Empty(t, pattern)
 	assert.Nil(t, body)
+}
+
+// The HR employees.upsert payload is a bare array with no timestamp of its own, so
+// the guard keys on JetStream's stream sequence — a strict total order assigned
+// server-side at publish. Without it, a redelivered or slow batch would overwrite a
+// newer one, since doc_as_upsert has no ordering semantics at all.
+func TestSpotlightOrgCollection_BuildActionSeq_CarriesOrderingGuard(t *testing.T) {
+	coll := newSpotlightOrgCollection("spotlightorg-site-a-v1", "site-a", "site-central", false)
+	rows := []model.IEmployeeWithChange{{IEmployee: model.IEmployee{IOrg: model.IOrg{SectID: "S1", SectName: "Platform"}}}}
+	data, err := json.Marshal(rows)
+	require.NoError(t, err)
+
+	actions, err := coll.BuildActionSeq(data, 4242)
+	require.NoError(t, err)
+	require.Len(t, actions, 1)
+	assert.Equal(t, searchengine.ActionUpdate, actions[0].Action)
+	assert.Equal(t, "S1", actions[0].DocID)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(actions[0].Doc, &body))
+
+	assert.Equal(t, true, body["scripted_upsert"],
+		"the script must run on insert too, so a new doc records its sequence")
+	script := body["script"].(map[string]any)
+	assert.Equal(t, spotlightOrgUpsertScriptID, script["id"])
+
+	params := script["params"].(map[string]any)
+	assert.Equal(t, float64(4242), params["seq"], "the guard compares this against the stored sequence")
+	doc := params["doc"].(map[string]any)
+	assert.Equal(t, "S1", doc["sectId"])
+	assert.Equal(t, "Platform", doc["sectName"])
+	assert.NotContains(t, doc, "deptId", "omitempty keeps absent fields out, preserving stored values on merge")
+}
+
+func TestSpotlightOrgCollection_StoredScripts(t *testing.T) {
+	coll := newSpotlightOrgCollection("spotlightorg-site-a-v1", "site-a", "site-central", false)
+	scripts := coll.StoredScripts()
+	require.Contains(t, scripts, spotlightOrgUpsertScriptID)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(scripts[spotlightOrgUpsertScriptID], &parsed))
+	src := parsed["script"].(map[string]any)["source"].(string)
+	assert.Contains(t, src, "params.seq", "the guard must compare the incoming sequence")
+	assert.Contains(t, src, "ctx.op = 'none'", "a stale write must be skipped, not applied")
+}
+
+// Without a sequence every write would be discarded by the guard — including the insert
+// of a new sectId — and ES would report each as a successful no-op. Fail loudly instead.
+func TestSpotlightOrgCollection_BuildAction_WithoutSequenceIsAnError(t *testing.T) {
+	coll := newSpotlightOrgCollection("spotlightorg-site-a-v1", "site-a", "site-central", false)
+	rows := []model.IEmployeeWithChange{{IEmployee: model.IEmployee{IOrg: model.IOrg{SectID: "S1"}}}}
+	data, err := json.Marshal(rows)
+	require.NoError(t, err)
+
+	actions, err := coll.BuildAction(data)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "BuildActionSeq")
+	assert.Nil(t, actions)
 }


### PR DESCRIPTION
Started as an investigation into search-sync-worker running slowly with a growing backlog of pending messages. Four things came out of it: one throughput fix, one retry-amplification fix, and two correctness gaps found along the way.

> **Rebased onto `de777a1`.** `#344` landed on main in the meantime and independently moved this worker's flush path onto `pkg/jsretry`, so the retry commit below is now narrower than when it was written — see §2.

## ⚠️ Action required before this reaches production

Depth 2 at `BULK_BATCH_SIZE=500` needs `CONSUMER_MAX_ACK_PENDING=1500`, and the shared default is **1000**. `CONSUMER_MAX_ACK_PENDING` lives in `stream.ConsumerSettings`, so this service can&#39;t carry its own default via struct tags — the dev compose sets 1500, production has to set it too.

If it isn&#39;t set, the worker logs the coupling warning at startup and the size-based flush can never fire, so every batch falls back to the 5s timer undersized — **worse than before this PR**. Two ways to close it:

| Option | Effect |
|---|---|
| `CONSUMER_MAX_ACK_PENDING=1500` | keeps 500-doc batches, more messages in flight |
| `BULK_BATCH_SIZE=250` (no ack change) | 750 in flight (fewer than today&#39;s 1000), two concurrent 250-doc requests, halves the nak-all blast radius |

The `BULK_BATCH_SIZE` default is deliberately left at 500 rather than lowered here, so existing measurements stay comparable.

## 1. The consumer loop was fully serial

`runConsumer` did `Fetch → build → Bulk` with no overlap: nothing was fetched during the ES round-trip, nothing indexed during the fetch. It was the only JetStream worker in the repo with no overlap at all — the others run `cons.Messages()` with a `MAX_WORKERS` semaphore.

`Handler.Flush` is split into `Take` (detach the buffer, no I/O) + `FlushBatch`, so a batch can be handed to a background flusher while the loop keeps buffering. `PIPELINE_DEPTH` (default **2**) sets how many bulk requests stay in flight.

Batch time goes from `fetch + build + ES` to `max(fetch + build, ES)`, then depth multiplies the ES side.

**On the expected gain:** measured `fetch+build` is ~10–30ms against ES bulk latency of 50–500ms, so `b/a ≈ 4–10`. Depth 1 alone is worth roughly 10–25%, not 2× — the structural win is real but modest when ES dominates, which is why depth is configurable. Depth 2 rather than higher because it multiplies **per collection and per pod** (five collections at depth 2 is already ten concurrent bulk requests per replica), and because it&#39;s the most informative step: if doubling concurrency doesn&#39;t move throughput, deeper won&#39;t either.

Rollback is `PIPELINE_DEPTH=1`, which reproduces the pre-PR behaviour exactly.

## 2. Failed writes retried instantly, amplifying the failure

A failed flush nakked with a bare `Nak()`, which asks JetStream for **immediate** redelivery. The consumer&#39;s `BackOff` schedule does not pace that path — it governs AckWait-expiry redelivery only (confirmed in the nats.go docs and in the server&#39;s `processNak`, which puts a bare NAK straight on the redelivery queue and signals).

Worst at exactly the case it handled worst: an overloaded Elasticsearch reports `es_rejected_execution_exception` as a per-item **429 inside an otherwise-200** `_bulk` response. That&#39;s correctly a failure, so the batch was re-submitted at once — adding load to a cluster that had just shed it.

**What&#39;s left of this after the rebase:** `#344` fixed the bare-nak half on main — the whole flush path now paces through `pkg/jsretry`, which is where this PR was taking it. What remains here is the half `#344` didn&#39;t address: **classification**. `jsretry` picks a delay by *delivery count*, and a delivery count can&#39;t express &#34;the backend just told me it is full&#34;. New `searchengine.IsBulkItemBackpressure` recognises saturation (429, or the error type, since a circuit breaker can surface under a 503) and routes those items to `jsretry.BackpressureBackoff`, which skips the 1s/5s rungs that feed the overload.

The rebase also surfaced an inversion worth a commit of its own: `#344` gave `DefaultBackoff` a 10m tail, which left `BackpressureBackoff` with a **smaller** total budget than an ordinary failure (3m30s vs 12m36s) — reporting saturation would have bought a message *less* time to land. Its tail is extended to match, and a test now pins the dominance in both directions so the two schedules can&#39;t drift apart again.

Retry window before a message is dropped (`MaxDeliver=6`, so five retries; `jsretry` applies AWS equal jitter, so each delay lands in `[base/2, base]` and the window is a range):

| | Before | After |
|---|---|---|
| General failure | ~0s | 6m18s – 12m36s (`jsretry.DefaultBackoff`) |
| Backpressure | ~0s | 9m15s – 18m30s (`jsretry.BackpressureBackoff`) |

Still bounded: saturation lasting longer than that drops messages, and `CONSUMER_MAX_DELIVER` is the ops lever for it.

## 3. Poison documents burned the whole retry budget

A bulk item failing with **400** (`mapper_parsing_exception`, an unparseable field) can never succeed — the backend rejected the document itself. Every item failure was settled as transient, so a bad document burned all its deliveries and held an ack-pending slot for the full retry window before being dropped anyway. Same end state, twelve minutes and five wasted round-trips later.

400s now settle through `errcode.Permanent`, so `jsretry` Ack-drops them. Deliberately narrow: 429/503 are backpressure, a 409 on an update is a live conflict a retry can win, and a 404 `index_not_found_exception` clears once the index exists. All templates set `dynamic:false`, so an unmapped field is ignored rather than rejected — a 400 can&#39;t be a transient mapping race during a rolling deploy.

**Behaviour change:** malformed documents are now discarded immediately instead of after the full retry window. Because the settle path uses `SettleQuiet`, `jsretry`&#39;s own drop warning is suppressed, so the bulk-item log carries an explicit `disposition` field (`drop` | `retry`) — otherwise this would have been a silent drop.

## 4. spotlight-org had no ordering guard at all

Its writes were plain `doc_as_upsert` updates with no version and no timestamp compare, so whichever landed last won. Two ways that goes wrong: a batch nakked and redelivered after a later one applied, and two pods sharing the durable consumer processing adjacent batches concurrently. Either leaves the older org row stored until HR happens to republish that section.

Every other collection had a token to guard on and this one didn&#39;t — messages/spotlight use the event timestamp as an ES external version, user-room compares `params.ts` in painless. The HR `employees.upsert` payload is a bare array with no envelope, no timestamp, and no version field on the employee record (`employees.quit` has one; upsert doesn&#39;t).

So the guard keys on the message&#39;s **JetStream stream sequence** — a strict total order assigned server-side at publish, and the only ordering token the payload path offers. Reaching it needs the message rather than just its bytes, so `Collection` gains a narrow optional extension, `sequencedCollection`, that `Handler` routes through. Only spotlight-org implements it; a compile-time assertion keeps the wiring from being lost to a rename. Widening `BuildAction` for every collection would have churned ~65 call sites to hand three of them a parameter they have no use for.

The write becomes a `scripted_upsert` so the script owns both insert and merge and a new `orgSeq` field records its sequence. Merging `params.doc` key-by-key preserves the doc-merge semantics the `omitempty` row relies on — the existing integration assertion for partial publishes is unchanged and still passes. Unreadable metadata yields sequence 0, which `BuildAction` rejects as an error rather than letting a sequence-less write reach ES.

**Operational caveat**, documented on the script: the comparison is only meaningful within one stream. Recreating the HR stream restarts sequences at 1, which would lose to stored values and silently drop every later update — clear `orgSeq` or reindex as part of any such rebuild.

This is also what unblocks depth &gt; 1. Concurrent flushes can reach ES out of order, which is only safe now that all five collections carry a guard; the pipeline doc records that a collection added without one must run at depth 1.

## Commits

Four logical commits plus the rebase follow-up, each independently building and green so the branch stays bisectable:

1. `chore:` ignore the stray build binary
2. `fix:` settle failed writes through `pkg/jsretry` (now: backpressure/poison classification — §2, §3)
3. `fix:` guard spotlight-org against out-of-order writes (§4)
4. `perf:` pipeline the ES bulk flush, depth 2 by default (§1)
5. `fix(jsretry):` give `BackpressureBackoff` at least the default retry budget

## Testing

Every behaviour was written test-first and watched fail for the right reason — the pipelining tests failed with *&#34;consumer must fetch the next batch while the previous bulk request is in flight&#34;*, the backpressure-budget test with *&#34;3m30s is not greater than or equal to 12m36s&#34;*.

- `make test` (full monorepo, `-race`): passes
- Each of the five commits verified independently: `go build ./...` clean, package tests green
- `make lint`: 0 issues · `gosec`: clean
- Delay assertions are ranges, not exact values — `#344`&#39;s jitter deliberately randomizes within `[base/2, base]`, and pinning an exact duration would be flaky
- New functions at 100% coverage (`Take`, `bulkItemError`, `itemBackoff`, `buildActions`, `streamSequence`, `newFlushPipeline`, `run`, `wait`, `checkBatchAckCoupling`); `runConsumer` went from **0%** to 74%; worker package 55.7% → 63.1%
- The concurrency tests are bounded in both directions: they assert the pipeline *reaches* depth 2 and that no third request starts while both slots are held

**Not verified locally:** Docker was unavailable, so the extended spotlight-org integration test — which is the only thing that actually executes the new painless script — was compile-checked with `go vet -tags integration` but never run. A syntax error in that script would pass everything above and fail only in CI. Worth watching. `govulncheck` and `semgrep` also couldn&#39;t run (blocked egress / not installed); `gosec` passed.

## Not in scope

Found during the investigation, deliberately left out:

- **Synchronous per-message ES parent lookup** — a `Search` across every monthly index (~96 shard queries) per thread reply, on the consumer goroutine. Compounded by `refresh_interval: 30s`, which makes it systematically miss parents younger than 30s. Can exceed `AckWait` on reply-heavy replays, and can eat this PR&#39;s entire benefit by making the loop build-bound. **Now fixed separately in #313.**
- **No deadline on the ES bulk request** — the transport clones `http.DefaultTransport` (no `ResponseHeaderTimeout`) and the context is `context.Background()`, so a hung write can stall a collection indefinitely.
- Redundant per-account body marshalling in the fan-out collections; no `pkg/natsmetrics` instrumentation on this worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnEWtiYrtp72HsX78yjDLy