### PR TITLE
fix(loadgen): restore created rooms after restart

### DIFF
--- a/tools/loadgen/failure_platform_test.go
+++ b/tools/loadgen/failure_platform_test.go
@@ -495,8 +495,8 @@ func TestFailureRecipientObserver_SubscriptionsAreAttributedAndFlushedBeforeHeal
 	topology := &soakTopology{
 		Rooms: []model.Room{{ID: "channel-1", Type: model.RoomTypeChannel}},
 		Subscriptions: []model.Subscription{
-			{RoomID: "channel-1", RoomType: model.RoomTypeChannel, IsSubscribed: true, User: model.SubscriptionUser{Account: "alice"}},
-			{RoomID: "channel-1", RoomType: model.RoomTypeChannel, IsSubscribed: true, User: model.SubscriptionUser{Account: "bob"}},
+			{RoomID: "channel-1", RoomType: model.RoomTypeChannel, User: model.SubscriptionUser{Account: "alice"}},
+			{RoomID: "channel-1", RoomType: model.RoomTypeChannel, User: model.SubscriptionUser{Account: "bob"}},
 		},
 	}
 	subscriptions, err := startFailureRecipientSubscriptions(source, topology, observer)
@@ -925,14 +925,13 @@ func TestFailureRecipientConnection_DrainWrapsTimeout(t *testing.T) {
 	assert.ErrorIs(t, err, nats.ErrDrainTimeout)
 }
 
-func TestSoakRuntimeSelector_RecipientSetsExcludeBots(t *testing.T) {
+func TestSoakRuntimeSelector_RecipientSetsUseExistingRowsAndExcludeBots(t *testing.T) {
 	topology := &soakTopology{
 		ActiveUsers: []model.User{{ID: "u-alice", Account: "alice"}},
 		Subscriptions: []model.Subscription{
-			{RoomID: "room-1", IsSubscribed: true, User: model.SubscriptionUser{Account: "alice"}},
-			{RoomID: "room-1", IsSubscribed: true, User: model.SubscriptionUser{Account: "borrowed-subscriber"}},
-			{RoomID: "room-1", IsSubscribed: true, User: model.SubscriptionUser{Account: "bot", IsBot: true}},
-			{RoomID: "room-1", IsSubscribed: false, User: model.SubscriptionUser{Account: "departed"}},
+			{RoomID: "room-1", User: model.SubscriptionUser{Account: "alice"}},
+			{RoomID: "room-1", User: model.SubscriptionUser{Account: "borrowed-subscriber"}},
+			{RoomID: "room-1", User: model.SubscriptionUser{Account: "bot", IsBot: true}},
 		}}
 
 	assert.Equal(t, map[string][]string{"room-1": {"alice", "borrowed-subscriber"}}, soakRecipientSets(topology))

--- a/tools/loadgen/failure_recipient.go
+++ b/tools/loadgen/failure_recipient.go
@@ -264,7 +264,7 @@ func startFailureRecipientSubscriptions(
 	for i := range topology.Subscriptions {
 		subscription := &topology.Subscriptions[i]
 		account := subscription.User.Account
-		if !subscription.IsSubscribed || subscription.User.IsBot || account == "" {
+		if !isSoakRoomMember(subscription) || subscription.User.IsBot || account == "" {
 			continue
 		}
 		add(subject.UserRoomEvent(account), account, recipientDeliveryRouteUser)

--- a/tools/loadgen/soak_edge_test.go
+++ b/tools/loadgen/soak_edge_test.go
@@ -232,12 +232,12 @@ func TestNewSoakRuntimeSelector_ValidatesInputs(t *testing.T) {
 			topology: &soakTopology{Rooms: []model.Room{{ID: "room-1"}}},
 		},
 		{
-			name: "room without subscribed member",
+			name: "room without usable member",
 			topology: &soakTopology{
 				Rooms: []model.Room{{ID: "room-1"}},
 				Subscriptions: []model.Subscription{{
 					RoomID: "room-1",
-					User:   model.SubscriptionUser{ID: "u-1", Account: "alice"},
+					User:   model.SubscriptionUser{ID: "u-1"},
 				}},
 			},
 			cfg: &cfg,
@@ -255,15 +255,16 @@ func TestNewSoakRuntimeSelector_ValidatesInputs(t *testing.T) {
 func TestNewSoakRuntimeSelector_SelectsOnlyValidMembers(t *testing.T) {
 	cfg := validSoakConfig(t)
 	selector, err := newSoakRuntimeSelector(&soakTopology{
-		Rooms: []model.Room{{ID: "room-1"}},
+		ActiveUsers: []model.User{{ID: "u-1", Account: "alice"}},
+		Rooms:       []model.Room{{ID: "room-1"}},
 		Subscriptions: []model.Subscription{
 			{
-				RoomID: "room-1", IsSubscribed: true,
-				User: model.SubscriptionUser{ID: "u-1", Account: "alice"},
+				RoomID: "room-1",
+				User:   model.SubscriptionUser{ID: "u-1", Account: "alice"},
 			},
 			{
-				RoomID: "room-1", IsSubscribed: false,
-				User: model.SubscriptionUser{ID: "u-2", Account: "bob"},
+				RoomID: "room-1",
+				User:   model.SubscriptionUser{ID: "u-2", Account: "bob"},
 			},
 			{
 				RoomID: "room-1", IsSubscribed: true,
@@ -348,16 +349,18 @@ func TestSoakTimerSleeper_ObservesCancellationAndTimer(t *testing.T) {
 func TestNewSoakMutator_AppliesDefaultsAndFiltersMembers(t *testing.T) {
 	mutator := newSoakMutator(
 		nil,
-		&soakTopology{Subscriptions: []model.Subscription{
-			{
-				RoomID: "room-1", IsSubscribed: true,
-				User: model.SubscriptionUser{Account: "alice"},
-			},
-			{
-				RoomID: "room-1", IsSubscribed: false,
-				User: model.SubscriptionUser{Account: "bob"},
-			},
-		}},
+		&soakTopology{
+			ActiveUsers: []model.User{{ID: "u-1", Account: "alice"}},
+			Subscriptions: []model.Subscription{
+				{
+					RoomID: "room-1",
+					User:   model.SubscriptionUser{ID: "u-1", Account: "alice"},
+				},
+				{
+					RoomID: "room-1",
+					User:   model.SubscriptionUser{ID: "u-2", Account: "bob"},
+				},
+			}},
 		nil,
 		nil,
 		nil,
@@ -487,8 +490,8 @@ func TestSoakReaderAndVerifier_ApplyDefaultsAndSkipEmptyCatalog(t *testing.T) {
 		soakReadConfig{},
 		&soakTopology{Subscriptions: []model.Subscription{
 			{
-				RoomID: "room-1", IsSubscribed: false,
-				User: model.SubscriptionUser{Account: "ignored"},
+				RoomID: "room-1",
+				User:   model.SubscriptionUser{},
 			},
 		}},
 		catalog,

--- a/tools/loadgen/soak_lane_request_contract_test.go
+++ b/tools/loadgen/soak_lane_request_contract_test.go
@@ -218,12 +218,9 @@ func TestSoakUserReader_SubscriptionDMTargetsAKnownDMPeer(t *testing.T) {
 	}
 }
 
-// A left room keeps its subscription row with isSubscribed=false. Pairing on it
-// names a counterpart who no longer shares the room, so the read is answered
-// with a legitimate empty result — the exact "measures nothing" outcome the
-// index exists to avoid. The room pool already filters on this; the pair index
-// has to agree with it.
-func TestSoakUserReader_RoomPairsIgnoreUnsubscribedMemberships(t *testing.T) {
+// Channel and DM membership is represented by row existence. Production does
+// not set isSubscribed for these rows; only botDM uses it as a soft toggle.
+func TestSoakUserReader_RoomPairsUseExistingDMMembershipRows(t *testing.T) {
 	transport := &soakRoomOpsTransport{reply: []byte(`{"subscription":{"id":"dm-1"}}`)}
 	reader, err := newSoakUserReader(
 		soakUserReadConfig{SiteID: "site-a", PageLimit: 5, RequestTimeout: time.Second},
@@ -234,10 +231,9 @@ func TestSoakUserReader_RoomPairsIgnoreUnsubscribedMemberships(t *testing.T) {
 			},
 			Rooms: []model.Room{{ID: "dm-1", Type: model.RoomTypeDM}},
 			Subscriptions: []model.Subscription{
-				{RoomID: "dm-1", RoomType: model.RoomTypeDM, IsSubscribed: true,
+				{RoomID: "dm-1", RoomType: model.RoomTypeDM,
 					User: model.SubscriptionUser{ID: "u1", Account: "user-a"}},
-				// user-b left: the row survives with isSubscribed=false.
-				{RoomID: "dm-1", RoomType: model.RoomTypeDM, IsSubscribed: false,
+				{RoomID: "dm-1", RoomType: model.RoomTypeDM,
 					User: model.SubscriptionUser{ID: "u2", Account: "user-b"}},
 			},
 		},
@@ -250,8 +246,7 @@ func TestSoakUserReader_RoomPairsIgnoreUnsubscribedMemberships(t *testing.T) {
 
 	require.NoError(t, reader.SubscriptionDM(context.Background()))
 
-	assert.Empty(t, transport.subjects,
-		"a room with one live member cannot name a counterpart; the lane must skip")
+	require.Len(t, transport.subjects, 1)
 }
 
 // The user lane addresses 2000 active accounts by design. DM rooms are seeded

--- a/tools/loadgen/soak_lane_request_contract_test.go
+++ b/tools/loadgen/soak_lane_request_contract_test.go
@@ -221,32 +221,58 @@ func TestSoakUserReader_SubscriptionDMTargetsAKnownDMPeer(t *testing.T) {
 // Channel and DM membership is represented by row existence. Production does
 // not set isSubscribed for these rows; only botDM uses it as a soft toggle.
 func TestSoakUserReader_RoomPairsUseExistingDMMembershipRows(t *testing.T) {
-	transport := &soakRoomOpsTransport{reply: []byte(`{"subscription":{"id":"dm-1"}}`)}
-	reader, err := newSoakUserReader(
-		soakUserReadConfig{SiteID: "site-a", PageLimit: 5, RequestTimeout: time.Second},
-		&soakTopology{
-			ActiveUsers: []model.User{
-				{ID: "u1", Account: "user-a"},
-				{ID: "u2", Account: "user-b"},
-			},
-			Rooms: []model.Room{{ID: "dm-1", Type: model.RoomTypeDM}},
-			Subscriptions: []model.Subscription{
-				{RoomID: "dm-1", RoomType: model.RoomTypeDM,
-					User: model.SubscriptionUser{ID: "u1", Account: "user-a"}},
-				{RoomID: "dm-1", RoomType: model.RoomTypeDM,
-					User: model.SubscriptionUser{ID: "u2", Account: "user-b"}},
-			},
+	allSubscriptions := []model.Subscription{
+		{RoomID: "dm-1", RoomType: model.RoomTypeDM,
+			User: model.SubscriptionUser{ID: "u1", Account: "user-a"}},
+		{RoomID: "dm-1", RoomType: model.RoomTypeDM,
+			User: model.SubscriptionUser{ID: "u2", Account: "user-b"}},
+	}
+	tests := []struct {
+		name          string
+		subscriptions []model.Subscription
+		wantRequests  int
+		wantSkipped   bool
+	}{
+		{
+			name:          "two membership rows dispatch",
+			subscriptions: allSubscriptions,
+			wantRequests:  1,
 		},
-		newSoakRPCClient(transport, soakRetryConfig{MaxAttempts: 1}, &soakRecordingSleeper{}, nil),
-		&soakRoomReadRecorder{},
-		rand.New(rand.NewSource(3)),
-		nil,
-	)
-	require.NoError(t, err)
+		{
+			name:          "one remaining membership row skips",
+			subscriptions: allSubscriptions[:1],
+			wantSkipped:   true,
+		},
+	}
 
-	require.NoError(t, reader.SubscriptionDM(context.Background()))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := &soakRoomOpsTransport{reply: []byte(`{"subscription":{"id":"dm-1"}}`)}
+			recorder := &soakRoomReadRecorder{}
+			reader, err := newSoakUserReader(
+				soakUserReadConfig{SiteID: "site-a", PageLimit: 5, RequestTimeout: time.Second},
+				&soakTopology{
+					ActiveUsers: []model.User{
+						{ID: "u1", Account: "user-a"},
+						{ID: "u2", Account: "user-b"},
+					},
+					Rooms:         []model.Room{{ID: "dm-1", Type: model.RoomTypeDM}},
+					Subscriptions: tt.subscriptions,
+				},
+				newSoakRPCClient(transport, soakRetryConfig{MaxAttempts: 1}, &soakRecordingSleeper{}, nil),
+				recorder,
+				rand.New(rand.NewSource(3)),
+				nil,
+			)
+			require.NoError(t, err)
 
-	require.Len(t, transport.subjects, 1)
+			require.NoError(t, reader.SubscriptionDM(context.Background()))
+
+			assert.Len(t, transport.subjects, tt.wantRequests)
+			require.Len(t, recorder.samples, 1)
+			assert.Equal(t, tt.wantSkipped, recorder.samples[0].Skipped)
+		})
+	}
 }
 
 // The user lane addresses 2000 active accounts by design. DM rooms are seeded

--- a/tools/loadgen/soak_main.go
+++ b/tools/loadgen/soak_main.go
@@ -315,7 +315,8 @@ func soakRecipientSets(topology *soakTopology) map[string][]string {
 	// production broadcast worker is still required to reach.
 	for i := range topology.Subscriptions {
 		subscription := &topology.Subscriptions[i]
-		if !subscription.IsSubscribed || subscription.User.IsBot || subscription.User.Account == "" {
+		if !isSoakRoomMember(subscription) ||
+			subscription.User.IsBot || subscription.User.Account == "" {
 			continue
 		}
 		recipients[subscription.RoomID] = append(recipients[subscription.RoomID], subscription.User.Account)

--- a/tools/loadgen/soak_read_test.go
+++ b/tools/loadgen/soak_read_test.go
@@ -265,12 +265,13 @@ func TestSoakReader_NormalEmptyResponseIsNotAnError(t *testing.T) {
 	assert.Empty(t, samples[0].ErrorClass)
 }
 
-func TestSoakReader_SelectsOnlySubscribedAccountForRoom(t *testing.T) {
+func TestSoakReader_SelectsOnlyActiveAccountForRoom(t *testing.T) {
 	topology := soakTopology{
+		ActiveUsers: []model.User{{ID: "u-alice", Account: "alice"}},
 		Subscriptions: []model.Subscription{
-			{RoomID: "room-1", IsSubscribed: false, User: model.SubscriptionUser{Account: "inactive"}},
-			{RoomID: "room-2", IsSubscribed: true, User: model.SubscriptionUser{Account: "other"}},
-			{RoomID: "room-1", IsSubscribed: true, User: model.SubscriptionUser{Account: "alice"}},
+			{RoomID: "room-1", User: model.SubscriptionUser{ID: "u-inactive", Account: "inactive"}},
+			{RoomID: "room-2", User: model.SubscriptionUser{ID: "u-other", Account: "other"}},
+			{RoomID: "room-1", User: model.SubscriptionUser{ID: "u-alice", Account: "alice"}},
 		},
 	}
 	transport := &soakReadTransport{replies: []soakRPCFakeReply{{

--- a/tools/loadgen/soak_roomstate.go
+++ b/tools/loadgen/soak_roomstate.go
@@ -241,7 +241,7 @@ func newSoakRoomStatePool(
 	for i := range topology.Subscriptions {
 		subscription := &topology.Subscriptions[i]
 		state, ok := channels[subscription.RoomID]
-		if !ok || !subscription.IsSubscribed || subscription.User.Account == "" {
+		if !ok || !isSoakRoomMember(subscription) || subscription.User.Account == "" {
 			continue
 		}
 		if subscribed[state.id] == nil {

--- a/tools/loadgen/soak_roomstate_test.go
+++ b/tools/loadgen/soak_roomstate_test.go
@@ -33,11 +33,11 @@ func soakRoomStateTestTopology(candidates int) *soakTopology {
 		Subscriptions: []model.Subscription{
 			{
 				RoomID: "room-1", User: model.SubscriptionUser{ID: users[0].ID, Account: users[0].Account},
-				Roles: []model.Role{model.RoleOwner}, IsSubscribed: true, RoomType: model.RoomTypeChannel,
+				Roles: []model.Role{model.RoleOwner}, RoomType: model.RoomTypeChannel,
 			},
 			{
 				RoomID: "room-1", User: model.SubscriptionUser{ID: users[1].ID, Account: users[1].Account},
-				Roles: []model.Role{model.RoleMember}, IsSubscribed: true, RoomType: model.RoomTypeChannel,
+				Roles: []model.Role{model.RoleMember}, RoomType: model.RoomTypeChannel,
 			},
 		},
 	}

--- a/tools/loadgen/soak_seed_integration_test.go
+++ b/tools/loadgen/soak_seed_integration_test.go
@@ -404,6 +404,74 @@ func TestLoadTopology_RestoresEnoughStateToBuildTheRoomPool(t *testing.T) {
 	assert.NotEmpty(t, pool.RoomIDs())
 }
 
+// Created rooms share the ownership ledger with the seeded topology. Their
+// subscriptions are written by room-service and carry neither loadgen's
+// soakRunId marker nor isSubscribed, so restart must recover them by owned room
+// scope and use row existence as channel membership.
+func TestLoadTopology_RestoresRoomsCreatedDuringTheRun(t *testing.T) {
+	ctx := context.Background()
+	db := testutil.MongoDB(t, "loadgen_soak_reload_created")
+
+	users := makeSoakUsers(12, "site-a")
+	userDocs := make([]any, len(users))
+	for i := range users {
+		userDocs[i] = users[i]
+	}
+	_, err := db.Collection("users").InsertMany(ctx, userDocs)
+	require.NoError(t, err)
+
+	store := &mongoSoakStore{db: db}
+	keyStore := roomkeystore.NewMongoStore(db.Collection("rooms"), time.Hour)
+	t.Cleanup(func() { require.NoError(t, keyStore.Close()) })
+	cfg := validSoakConfig(t)
+	cfg.MaxUsers = 12
+	cfg.ActiveUsers = 6
+	cfg.RoomCount = 5
+	cfg.ChannelRatio = 0.6
+	cfg.ChannelMembers = 3
+	cfg.ReactionsPerHotMessage = 3
+
+	seeded, err := seedSoak(ctx, store, keyStore, &soakSeedInput{
+		RunID: cfg.RunID, SiteID: "site-a", MongoDatabase: db.Name(),
+		CassandraKeyspace: "chat", Seed: 42, Config: &cfg,
+	}, newProductionSoakIDs())
+	require.NoError(t, err)
+
+	const createdRoomID = "created-room-1"
+	_, err = db.Collection("rooms").InsertOne(ctx, bson.D{
+		{Key: "_id", Value: createdRoomID},
+		{Key: "name", Value: soakCreatedRoomPrefix(cfg.RunID) + "one"},
+		{Key: "type", Value: model.RoomTypeChannel},
+		{Key: "siteId", Value: "site-a"},
+	})
+	require.NoError(t, err)
+	_, err = db.Collection("subscriptions").InsertOne(ctx, bson.D{
+		{Key: "_id", Value: "created-subscription-1"},
+		{Key: "u", Value: bson.D{
+			{Key: "_id", Value: seeded.ActiveUsers[0].ID},
+			{Key: "account", Value: seeded.ActiveUsers[0].Account},
+		}},
+		{Key: "roomId", Value: createdRoomID},
+		{Key: "siteId", Value: "site-a"},
+		{Key: "roles", Value: bson.A{model.RoleOwner}},
+		{Key: "roomType", Value: model.RoomTypeChannel},
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.AppendOwnedRooms(ctx, cfg.RunID, []string{createdRoomID}))
+
+	reloaded, err := store.LoadTopology(ctx, cfg.RunID, "site-a")
+	require.NoError(t, err)
+
+	assert.Len(t, reloaded.Rooms, len(seeded.Rooms)+1)
+	foundCreated := false
+	for i := range reloaded.Rooms {
+		foundCreated = foundCreated || reloaded.Rooms[i].ID == createdRoomID
+	}
+	assert.True(t, foundCreated)
+	_, err = newSoakRuntimeSelector(&reloaded, &cfg, 42)
+	require.NoError(t, err)
+}
+
 // The pool seeds its mute and read-cursor expectations from the reloaded
 // subscriptions. A projection that drops those fields makes a restarted process
 // expect the opposite mute state and report a correctness violation it caused.

--- a/tools/loadgen/soak_store.go
+++ b/tools/loadgen/soak_store.go
@@ -394,12 +394,21 @@ func (s *mongoSoakStore) loadOwnedTopologyPage(
 	if err := roomCursor.Close(ctx); err != nil {
 		return nil, nil, fmt.Errorf("close owned soak room cursor: %w", err)
 	}
+	ownedRoomIDs := make([]string, len(rooms))
+	for i := range rooms {
+		ownedRoomIDs[i] = rooms[i].ID
+	}
+	if len(ownedRoomIDs) == 0 {
+		return rooms, nil, nil
+	}
 
 	subscriptionCursor, err := s.db.Collection("subscriptions").Find(
 		ctx,
 		bson.D{
-			{Key: "roomId", Value: bson.D{{Key: "$in", Value: roomIDs}}},
-			{Key: "soakRunId", Value: runID},
+			// room-service writes create/member-lane subscriptions without
+			// loadgen's private soakRunId marker. The rooms query above has
+			// already narrowed this scope to rooms owned by the run.
+			{Key: "roomId", Value: bson.D{{Key: "$in", Value: ownedRoomIDs}}},
 			{Key: "siteId", Value: siteID},
 		},
 		options.Find().
@@ -678,11 +687,7 @@ func (s *mongoSoakStore) DeleteOwnedRoomBatch(
 	); err != nil {
 		return fmt.Errorf("delete wrapped DEKs for soak run %q: %w", runID, err)
 	}
-	ownedFilter := bson.D{
-		{Key: "soakRunId", Value: runID},
-		{Key: "roomId", Value: bson.D{{Key: "$in", Value: ownedRoomIDs}}},
-	}
-	if _, err := s.db.Collection("subscriptions").DeleteMany(ctx, ownedFilter); err != nil {
+	if _, err := s.db.Collection("subscriptions").DeleteMany(ctx, roomFilter); err != nil {
 		return fmt.Errorf("delete subscriptions for soak run %q: %w", runID, err)
 	}
 	roomOwnedFilter := bson.D{

--- a/tools/loadgen/soak_teardown_integration_test.go
+++ b/tools/loadgen/soak_teardown_integration_test.go
@@ -41,7 +41,9 @@ func TestTeardownSoak_DeletesOnlySelectedMongoRun(t *testing.T) {
 			bson.D{{Key: "_id", Value: "room-b"}, {Key: "soakRunId", Value: "run-b"}},
 		},
 		"subscriptions": {
-			bson.D{{Key: "_id", Value: "sub-a"}, {Key: "roomId", Value: "room-a"}, {Key: "soakRunId", Value: "run-a"}},
+			// room-service writes create-lane subscriptions without loadgen's
+			// private ownership marker. The owned room still defines their scope.
+			bson.D{{Key: "_id", Value: "sub-a"}, {Key: "roomId", Value: "room-a"}},
 			bson.D{{Key: "_id", Value: "sub-b"}, {Key: "roomId", Value: "room-b"}, {Key: "soakRunId", Value: "run-b"}},
 		},
 		"thread_rooms": {

--- a/tools/loadgen/soak_topology.go
+++ b/tools/loadgen/soak_topology.go
@@ -343,14 +343,13 @@ func buildSoakSubscriptions(
 				ID:      members[i].ID,
 				Account: members[i].Account,
 			},
-			RoomID:       room.ID,
-			SiteID:       room.SiteID,
-			Roles:        roles,
-			Name:         name,
-			RoomType:     room.Type,
-			IsSubscribed: true,
-			Open:         true,
-			JoinedAt:     joinedAt,
+			RoomID:   room.ID,
+			SiteID:   room.SiteID,
+			Roles:    roles,
+			Name:     name,
+			RoomType: room.Type,
+			Open:     true,
+			JoinedAt: joinedAt,
 		}
 	}
 	return subscriptions

--- a/tools/loadgen/soak_topology.go
+++ b/tools/loadgen/soak_topology.go
@@ -286,7 +286,7 @@ func isActiveSoakSubscription(
 	subscription *model.Subscription,
 	active map[string]struct{},
 ) bool {
-	if subscription == nil || !subscription.IsSubscribed {
+	if !isSoakRoomMember(subscription) {
 		return false
 	}
 	if len(active) == 0 {
@@ -294,6 +294,16 @@ func isActiveSoakSubscription(
 	}
 	_, ok := active[subscription.User.ID]
 	return ok
+}
+
+// isSoakRoomMember follows the production subscription model: channel and DM
+// membership is represented by row existence because leave deletes the row.
+// Only botDM keeps the row and uses IsSubscribed as a soft toggle.
+func isSoakRoomMember(subscription *model.Subscription) bool {
+	if subscription == nil {
+		return false
+	}
+	return subscription.RoomType != model.RoomTypeBotDM || subscription.IsSubscribed
 }
 
 func reserveSoakPair(a, b *model.User, used map[string]struct{}) bool {

--- a/tools/loadgen/soak_topology_test.go
+++ b/tools/loadgen/soak_topology_test.go
@@ -184,6 +184,32 @@ func TestBuildSoakTopology_IsDeterministicWithSeededIdentitySource(t *testing.T)
 	assert.Equal(t, a, b)
 }
 
+func TestIsActiveSoakSubscription_UsesExistingRoomRowsAsMembership(t *testing.T) {
+	active := map[string]struct{}{"u-1": {}}
+
+	assert.True(t, isActiveSoakSubscription(&model.Subscription{
+		RoomType: model.RoomTypeChannel,
+		User:     model.SubscriptionUser{ID: "u-1", Account: "alice"},
+	}, active))
+	assert.True(t, isActiveSoakSubscription(&model.Subscription{
+		RoomType: model.RoomTypeDM,
+		User:     model.SubscriptionUser{ID: "u-1", Account: "alice"},
+	}, active))
+	assert.False(t, isActiveSoakSubscription(&model.Subscription{
+		RoomType: model.RoomTypeChannel,
+		User:     model.SubscriptionUser{ID: "u-2", Account: "bob"},
+	}, active))
+	assert.False(t, isActiveSoakSubscription(&model.Subscription{
+		RoomType: model.RoomTypeBotDM,
+		User:     model.SubscriptionUser{ID: "u-1", Account: "alice"},
+	}, active))
+	assert.True(t, isActiveSoakSubscription(&model.Subscription{
+		RoomType:     model.RoomTypeBotDM,
+		IsSubscribed: true,
+		User:         model.SubscriptionUser{ID: "u-1", Account: "alice"},
+	}, active))
+}
+
 func TestBuildSoakTopology_RejectsImpossibleRoomShape(t *testing.T) {
 	cfg := validSoakConfig(t)
 	cfg.MaxUsers = 3

--- a/tools/loadgen/soak_topology_test.go
+++ b/tools/loadgen/soak_topology_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -184,30 +185,81 @@ func TestBuildSoakTopology_IsDeterministicWithSeededIdentitySource(t *testing.T)
 	assert.Equal(t, a, b)
 }
 
+func TestBuildSoakSubscriptions_LeavesBotDMOnlyFlagUnset(t *testing.T) {
+	members := makeSoakUsers(2, "site-a")
+
+	for _, roomType := range []model.RoomType{model.RoomTypeChannel, model.RoomTypeDM} {
+		t.Run(string(roomType), func(t *testing.T) {
+			subscriptions := buildSoakSubscriptions(
+				&model.Room{ID: "room-1", SiteID: "site-a", Type: roomType, Name: "room"},
+				members,
+				newSequenceSoakIDs(),
+				time.Unix(1, 0),
+			)
+
+			require.Len(t, subscriptions, 2)
+			for i := range subscriptions {
+				assert.False(t, subscriptions[i].IsSubscribed,
+					"channel and DM seed rows must match production membership documents")
+			}
+		})
+	}
+}
+
 func TestIsActiveSoakSubscription_UsesExistingRoomRowsAsMembership(t *testing.T) {
 	active := map[string]struct{}{"u-1": {}}
 
-	assert.True(t, isActiveSoakSubscription(&model.Subscription{
-		RoomType: model.RoomTypeChannel,
-		User:     model.SubscriptionUser{ID: "u-1", Account: "alice"},
-	}, active))
-	assert.True(t, isActiveSoakSubscription(&model.Subscription{
-		RoomType: model.RoomTypeDM,
-		User:     model.SubscriptionUser{ID: "u-1", Account: "alice"},
-	}, active))
-	assert.False(t, isActiveSoakSubscription(&model.Subscription{
-		RoomType: model.RoomTypeChannel,
-		User:     model.SubscriptionUser{ID: "u-2", Account: "bob"},
-	}, active))
-	assert.False(t, isActiveSoakSubscription(&model.Subscription{
-		RoomType: model.RoomTypeBotDM,
-		User:     model.SubscriptionUser{ID: "u-1", Account: "alice"},
-	}, active))
-	assert.True(t, isActiveSoakSubscription(&model.Subscription{
-		RoomType:     model.RoomTypeBotDM,
-		IsSubscribed: true,
-		User:         model.SubscriptionUser{ID: "u-1", Account: "alice"},
-	}, active))
+	tests := []struct {
+		name string
+		sub  *model.Subscription
+		want bool
+	}{
+		{
+			name: "active channel row",
+			sub: &model.Subscription{
+				RoomType: model.RoomTypeChannel,
+				User:     model.SubscriptionUser{ID: "u-1", Account: "alice"},
+			},
+			want: true,
+		},
+		{
+			name: "active DM row",
+			sub: &model.Subscription{
+				RoomType: model.RoomTypeDM,
+				User:     model.SubscriptionUser{ID: "u-1", Account: "alice"},
+			},
+			want: true,
+		},
+		{
+			name: "inactive user",
+			sub: &model.Subscription{
+				RoomType: model.RoomTypeChannel,
+				User:     model.SubscriptionUser{ID: "u-2", Account: "bob"},
+			},
+		},
+		{
+			name: "unsubscribed bot DM",
+			sub: &model.Subscription{
+				RoomType: model.RoomTypeBotDM,
+				User:     model.SubscriptionUser{ID: "u-1", Account: "alice"},
+			},
+		},
+		{
+			name: "subscribed bot DM",
+			sub: &model.Subscription{
+				RoomType:     model.RoomTypeBotDM,
+				IsSubscribed: true,
+				User:         model.SubscriptionUser{ID: "u-1", Account: "alice"},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isActiveSoakSubscription(tt.sub, active))
+		})
+	}
 }
 
 func TestBuildSoakTopology_RejectsImpossibleRoomShape(t *testing.T) {

--- a/tools/loadgen/soak_userread.go
+++ b/tools/loadgen/soak_userread.go
@@ -163,10 +163,7 @@ func soakUserRoomPairs(
 	members := make(map[string][]string)
 	for i := range topology.Subscriptions {
 		subscription := &topology.Subscriptions[i]
-		// isSubscribed=false is a room the account left; the row survives. The
-		// room pool filters the same way, and a pair built from a left room
-		// names a counterpart who no longer shares it.
-		if subscription.RoomType != roomType || !subscription.IsSubscribed ||
+		if subscription.RoomType != roomType || !isSoakRoomMember(subscription) ||
 			subscription.User.Account == "" {
 			continue
 		}


### PR DESCRIPTION
## Summary

- restore create-lane and member-lane subscriptions when a soak process reloads its topology
- align loadgen membership checks and seeded subscription documents with the production model
- delete all subscriptions scoped to verified run-owned rooms during teardown
- add regression coverage for seed -> create -> restart, DM member removal, and teardown cleanup

## Root cause

Two independent conditions made a run fail after its first create-lane room:

1. `AppendOwnedRooms` marks the room with `soakRunId`, but room-service writes the room's subscriptions without that loadgen-private marker. Reload queried rooms by ownership and subscriptions by ownership, so it loaded the room without any members. Teardown used the same asymmetric filter and left orphan subscriptions.
2. Loadgen treated `IsSubscribed` as channel/DM membership. Production channel and DM membership is represented by subscription-row existence because leaving deletes the row; only botDM retains the row and uses `IsSubscribed` as a soft toggle.

At the default `SOAK_ROOM_CREATE_RATE=0.05`, one created room was enough to make every later pod restart abort with `soak room %q has no subscribed member`.

## Changes

- load subscriptions only after resolving the ownership chunk to rooms that still match the run and site, then scope the subscription query by those verified room IDs
- delete subscriptions by verified owned room IDs so server-written rows are cleaned up
- centralize channel/DM versus botDM membership semantics in `isSoakRoomMember`
- apply the shared membership contract to sender selection, read/mutation targets, room state, recipient expectations, and recipient observation
- leave `IsSubscribed` unset on seeded channel/DM rows so seed data matches production-created membership documents
- cover the DM removal model explicitly: a DM with only one remaining subscription row produces no requester/peer pair
- use named table-driven cases for the shared membership predicate

## Behavioral impact

Reloaded create-lane channel rooms now enter `newSoakRoomStatePool`, so member and room mutation lanes may operate on them after a process restart. This is intentional and safe:

- `UserCount` is not consumed by loadgen, so its absence on a created room does not create a state mismatch
- renames append `-r{n}` and preserve the `soak-{run}-created-` prefix used by `CountCreatedRooms`
- mute targets remain seeded members while membership candidates come from non-members, preserving the disjoint-set invariant

The pool is built once at process startup and is not updated dynamically. A room created by the current process therefore joins the pool only after the next restart; first-process and post-restart mutation coverage are intentionally different for now.

## TDD evidence

### Red

- `TestLoadTopology_RestoresRoomsCreatedDuringTheRun` reproduced the restart failure with a room-service-shaped subscription
- teardown coverage reproduced the orphaned subscription
- unit fixtures without `isSubscribed` failed across selector, room state, DM pairing, recipient expectation, and observer setup
- `TestBuildSoakSubscriptions_LeavesBotDMOnlyFlagUnset` failed while seed still wrote `IsSubscribed: true` on channel/DM rows

### Green / Refactor

- topology reload and teardown now use verified owned-room scope
- all membership consumers share the production-aligned helper, including botDM soft-toggle behavior
- seed and production-created channel/DM rows now use the same membership representation
- DM single-row coverage pins the existing incomplete-pair guard

## Validation

- `make test SERVICE=tools/loadgen`
- `make coverage-loadgen-soak`
  - soak aggregate: 83.23%
  - soak core excluding `soak_main.go` and `soak_store.go`: 90.74%
- `make test-integration SERVICE=tools/loadgen`
- `make lint` — 0 issues
- `make coverage-loadgen-failure`
  - failure core: 81.13%
  - recipient observer: 97.30%
  - failure metrics: 100%
- gosec — pass
- Semgrep — pass
- `make sast-vuln GOVULNCHECK=/c/Users/SheepRocket/go/bin/govulncheck.exe` — 0 called vulnerabilities

One intermediate integration run observed the existing end-to-end drain timing failure `message-worker still has pending: expected 0, got 1`; the exact prior head subsequently passed the complete integration/race suite. The review follow-up commit passed the full loadgen unit race suite and the soak integration/coverage target.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved load-test room membership detection by recognizing existing room membership records, including those created by room services.
  - Preserved filtering for inactive users, bots, empty accounts, and invalid memberships.
  - Ensured active accounts are selected for room reads and direct-message requests.
  - Improved topology restoration and teardown for rooms created during a test run.
- **Tests**
  - Added coverage for membership filtering, account selection, topology restoration, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
