### PR TITLE
search-sync-worker: point-read the thread parent instead of searching every monthly index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ bin/
 demo
 /seed-sample-data
 /loadgen
+# `go build ./...` run from inside a service dir writes the executable there
+/search-sync-worker/search-sync-worker
 *.exe
 *.exe~
 *.dll

--- a/search-sync-worker/messages.go
+++ b/search-sync-worker/messages.go
@@ -19,7 +19,7 @@ import (
 
 // parentCreatedAtResolver resolves a thread parent's authoritative createdAt; ok=false leaves the field unset. Never errors. Satisfied by *esParentResolver.
 type parentCreatedAtResolver interface {
-	ResolveParentCreatedAt(ctx context.Context, messageID string) (time.Time, bool)
+	ResolveParentCreatedAt(ctx context.Context, messageID string, replyCreatedAt time.Time) (time.Time, bool)
 }
 
 // teamsIdentity is a migrated sender's nextgen identity for the search index: the
@@ -210,6 +210,9 @@ func (c *messageCollection) BuildAction(data []byte) ([]searchengine.BulkAction,
 
 // resolveThreadParentCreatedAt fills the parent createdAt for a thread reply; the gatekeeper's
 // value wins when present, else re-resolve from the ES index. No-op for nil resolver/non-thread/delete.
+//
+// The reply's own createdAt goes to the resolver as the upper bound on where the parent
+// can live: BuildAction has already rejected a zero value, so it is always usable.
 func (c *messageCollection) resolveThreadParentCreatedAt(evt *model.MessageEvent) {
 	if c.parentResolver == nil || evt.Message.ThreadParentMessageID == "" || evt.Event == model.EventDeleted {
 		return
@@ -217,7 +220,8 @@ func (c *messageCollection) resolveThreadParentCreatedAt(evt *model.MessageEvent
 	if evt.Message.ThreadParentMessageCreatedAt != nil {
 		return
 	}
-	if createdAt, ok := c.parentResolver.ResolveParentCreatedAt(context.Background(), evt.Message.ThreadParentMessageID); ok {
+	if createdAt, ok := c.parentResolver.ResolveParentCreatedAt(
+		context.Background(), evt.Message.ThreadParentMessageID, evt.Message.CreatedAt); ok {
 		evt.Message.ThreadParentMessageCreatedAt = &createdAt
 	}
 }

--- a/search-sync-worker/messages_reresolve_test.go
+++ b/search-sync-worker/messages_reresolve_test.go
@@ -15,15 +15,16 @@ import (
 
 // fakeParentResolver is a test double for parentCreatedAtResolver.
 type fakeParentResolver struct {
-	val    time.Time
-	ok     bool
-	calls  int
-	lastID string
+	val         time.Time
+	ok          bool
+	calls       int
+	lastID      string
+	lastReplyAt time.Time
 }
 
-func (f *fakeParentResolver) ResolveParentCreatedAt(_ context.Context, messageID string) (time.Time, bool) {
+func (f *fakeParentResolver) ResolveParentCreatedAt(_ context.Context, messageID string, replyCreatedAt time.Time) (time.Time, bool) {
 	f.calls++
-	f.lastID = messageID
+	f.lastID, f.lastReplyAt = messageID, replyCreatedAt
 	return f.val, f.ok
 }
 
@@ -131,4 +132,20 @@ func TestMessageCollection_BuildAction_ReresolvesThreadParent(t *testing.T) {
 		require.NotNil(t, got)
 		assert.True(t, got.Equal(eventVal))
 	})
+}
+
+// The resolver point-reads the reply's own month before falling back, so the reply's
+// createdAt has to reach it — otherwise every lookup probes the zero-time index.
+func TestMessageCollection_BuildAction_PassesReplyCreatedAtToResolver(t *testing.T) {
+	resolver := &fakeParentResolver{ok: false}
+	coll := newMessageCollection("msgs-v1", "site-a", time.Time{}, false)
+	coll.parentResolver = resolver
+
+	_, err := coll.BuildAction(threadReplyData(t, model.EventCreated, nil))
+	require.NoError(t, err)
+
+	require.Equal(t, 1, resolver.calls)
+	assert.Equal(t, "parent-1", resolver.lastID)
+	assert.True(t, resolver.lastReplyAt.Equal(time.Date(2026, 1, 20, 12, 0, 0, 0, time.UTC)),
+		"the reply's createdAt bounds where the parent can live; got %v", resolver.lastReplyAt)
 }

--- a/search-sync-worker/metrics_test.go
+++ b/search-sync-worker/metrics_test.go
@@ -286,20 +286,22 @@ func TestESParentResolver_RecordsResolveDuration(t *testing.T) {
 	sm, reader := newTestSyncMetrics(t)
 
 	resolved := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	replyAt := time.Date(2026, 2, 14, 0, 0, 0, 0, time.UTC)
+	// The duration covers the whole resolution, so the miss walks both month probes and
+	// the fallback search before it is recorded as unresolved.
 	r := &esParentResolver{
-		esRead: func(ctx context.Context, messageID string) (time.Time, bool) {
-			if messageID == "hit" {
-				return resolved, true
-			}
-			return time.Time{}, false
+		esGet: func(_ context.Context, _, messageID string) (time.Time, bool) {
+			return resolved, messageID == "hit"
 		},
-		timeout: time.Second,
-		metrics: sm.forCollection("message-sync"),
+		esSearch:    func(context.Context, string) (time.Time, bool) { return time.Time{}, false },
+		indexPrefix: "msgs-v1",
+		timeout:     time.Second,
+		metrics:     sm.forCollection("message-sync"),
 	}
 
-	_, ok := r.ResolveParentCreatedAt(context.Background(), "hit")
+	_, ok := r.ResolveParentCreatedAt(context.Background(), "hit", replyAt)
 	require.True(t, ok)
-	_, ok = r.ResolveParentCreatedAt(context.Background(), "miss")
+	_, ok = r.ResolveParentCreatedAt(context.Background(), "miss", replyAt)
 	require.False(t, ok)
 
 	rm := collectMetrics(t, reader)

--- a/search-sync-worker/parent_resolver_integration_test.go
+++ b/search-sync-worker/parent_resolver_integration_test.go
@@ -15,9 +15,13 @@ import (
 	"github.com/hmchangw/chat/pkg/searchindex"
 )
 
-// TestNewESRead_Integration exercises the ES self-lookup against a real index:
-// it reads a parent message's own (authoritative) createdAt by message ID.
-func TestNewESRead_Integration(t *testing.T) {
+// TestParentResolver_Integration exercises the parent lookup against a real index.
+//
+// Deliberately no refreshIndex before reading: the point of the point-read path is
+// that a get is realtime, so it must see a parent that has been indexed but not yet
+// refreshed. A search cannot, which is why the old cross-month lookup missed exactly
+// the recent-parent case that matters most.
+func TestParentResolver_Integration(t *testing.T) {
 	esURL := setupElasticsearch(t)
 	ctx := context.Background()
 
@@ -30,32 +34,47 @@ func TestNewESRead_Integration(t *testing.T) {
 	require.NoError(t, engine.UpsertTemplate(ctx, coll.TemplateName(), overrideIndexSettings(searchindex.MessageTemplateBody(prefix, true))))
 	index := prefix + "-2026-03"
 	preCreateIndex(t, esURL, index)
+	preCreateIndex(t, esURL, prefix+"-2026-02")
 	waitForClusterGreen(t, esURL, 120*time.Second)
 
-	// Index a parent message doc carrying its own (authoritative) createdAt.
-	parentCreatedAt := time.Date(2026, 3, 9, 7, 0, 0, 0, time.UTC)
-	doc, _ := json.Marshal(searchindex.MessageDoc{
-		MessageID: "parent-es-1",
-		RoomID:    "r1",
-		SiteID:    "site-a",
-		CreatedAt: parentCreatedAt,
+	indexParent := func(t *testing.T, id, idx string, createdAt time.Time) {
+		t.Helper()
+		doc, err := json.Marshal(searchindex.MessageDoc{
+			MessageID: id, RoomID: "r1", SiteID: "site-a", CreatedAt: createdAt,
+		})
+		require.NoError(t, err)
+		_, err = engine.Bulk(ctx, []searchengine.BulkAction{{
+			Action: searchengine.ActionIndex, Index: idx, DocID: id,
+			Version: createdAt.UnixMilli(), Doc: doc,
+		}})
+		require.NoError(t, err)
+	}
+
+	resolver := newESParentResolver(engine, prefix)
+	replyAt := time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC)
+
+	t.Run("resolves a same-month parent without waiting for a refresh", func(t *testing.T) {
+		parentAt := time.Date(2026, 3, 9, 7, 0, 0, 0, time.UTC)
+		indexParent(t, "parent-same-month", index, parentAt)
+
+		got, ok := resolver.ResolveParentCreatedAt(ctx, "parent-same-month", replyAt)
+
+		require.True(t, ok, "a get is realtime; an un-refreshed parent must still resolve")
+		assert.True(t, got.Equal(parentAt), "got %v want %v", got, parentAt)
 	})
-	_, err = engine.Bulk(ctx, []searchengine.BulkAction{{
-		Action:  searchengine.ActionIndex,
-		Index:   index,
-		DocID:   "parent-es-1",
-		Version: parentCreatedAt.UnixMilli(),
-		Doc:     doc,
-	}})
-	require.NoError(t, err)
-	refreshIndex(t, esURL, prefix+"-*")
 
-	read := newESRead(engine, prefix)
+	t.Run("resolves a parent in the previous month", func(t *testing.T) {
+		parentAt := time.Date(2026, 2, 25, 8, 0, 0, 0, time.UTC)
+		indexParent(t, "parent-prev-month", prefix+"-2026-02", parentAt)
 
-	got, ok := read(ctx, "parent-es-1")
-	require.True(t, ok)
-	assert.True(t, got.Equal(parentCreatedAt), "got %v want %v", got, parentCreatedAt)
+		got, ok := resolver.ResolveParentCreatedAt(ctx, "parent-prev-month", replyAt)
 
-	_, ok = read(ctx, "missing-parent")
-	assert.False(t, ok)
+		require.True(t, ok)
+		assert.True(t, got.Equal(parentAt), "got %v want %v", got, parentAt)
+	})
+
+	t.Run("ok=false for a parent nothing has indexed", func(t *testing.T) {
+		_, ok := resolver.ResolveParentCreatedAt(ctx, "missing-parent", replyAt)
+		assert.False(t, ok)
+	})
 }

--- a/search-sync-worker/thread_parent_resolver.go
+++ b/search-sync-worker/thread_parent_resolver.go
@@ -5,44 +5,120 @@ import (
 	"encoding/json"
 	"log/slog"
 	"time"
+
+	"github.com/hmchangw/chat/pkg/searchindex"
 )
 
-// parentResolveTimeout bounds a single thread-parent createdAt lookup so a slow
-// search backend can't stall the indexing path.
+// parentResolveTimeout bounds one thread-parent createdAt lookup — including any
+// fallback search — so a slow search backend can't stall the indexing path.
 const parentResolveTimeout = 2 * time.Second
 
-// esReadFn reads a message's (server-stamped, authoritative) createdAt from the
-// search index. ok=false means not found — the caller leaves the field unset.
-type esReadFn func(ctx context.Context, messageID string) (time.Time, bool)
+// esGetFn reads a message's createdAt from one concrete index by document id.
+// ok=false means the index or the document is absent.
+type esGetFn func(ctx context.Context, index, messageID string) (time.Time, bool)
 
-// esParentResolver resolves a thread parent's createdAt via an ES self-lookup. It
+// esSearchFn reads a message's createdAt by searching every monthly index.
+// ok=false means not found — the caller leaves the field unset.
+type esSearchFn func(ctx context.Context, messageID string) (time.Time, bool)
+
+// esParentResolver resolves a thread parent's createdAt from the search index. It
 // never errors: a miss or backend failure degrades the field rather than stalling.
 type esParentResolver struct {
-	esRead  esReadFn
-	timeout time.Duration
-	metrics *collectionMetrics // optional, set by main; nil-safe recording
+	esGet       esGetFn
+	esSearch    esSearchFn
+	indexPrefix string
+	timeout     time.Duration
+	metrics     *collectionMetrics // optional, set by main; nil-safe recording
+}
+
+// prevMonth returns any instant inside the calendar month before at.
+//
+// Not at.AddDate(0, -1, 0): that normalises overflow, so 31 March becomes
+// "31 February" and lands back on 3 March — repeating the month the caller just
+// probed. Going via time.Date on the month number normalises correctly, including
+// January rolling back into the previous December.
+func prevMonth(at time.Time) time.Time {
+	at = at.UTC()
+	return time.Date(at.Year(), at.Month()-1, 1, 0, 0, 0, 0, time.UTC)
 }
 
 // ResolveParentCreatedAt returns the parent's createdAt and ok=true when resolved.
 // ok=false means the parent isn't indexed yet — the caller leaves the field unset.
-func (r *esParentResolver) ResolveParentCreatedAt(ctx context.Context, messageID string) (time.Time, bool) {
+//
+// A parent always predates its reply and threads are overwhelmingly same-month, so
+// this point-reads the reply's month and then the one before it before falling back
+// to the cross-month search. Two reasons that ordering matters:
+//
+//   - A get is realtime — served from the translog, not bound by the index's
+//     refresh_interval — so it sees a parent indexed seconds ago. The search cannot,
+//     which made it miss exactly the recent-parent case that dominates live chat.
+//   - A get routes to a single shard by id; the search fans out across every monthly
+//     index times its shard count.
+//
+// The search stays as the fallback for parents older than one month, where the month
+// probes can't guess the index.
+func (r *esParentResolver) ResolveParentCreatedAt(ctx context.Context, messageID string, replyCreatedAt time.Time) (time.Time, bool) {
 	ctx, cancel := context.WithTimeout(ctx, r.timeout)
 	defer cancel()
+
+	// Times the whole resolution — both month probes and any fallback search — because
+	// that is the latency the indexing path actually pays for one parent.
 	start := time.Now()
-	createdAt, ok := r.esRead(ctx, messageID)
+	createdAt, ok := r.resolve(ctx, messageID, replyCreatedAt)
 	r.metrics.recordParentResolve(ctx, time.Since(start).Seconds(), ok)
 	return createdAt, ok
 }
 
-// esSearcher is the narrow search surface the ES self-lookup needs.
+// resolve point-reads the reply's month and then the one before it, falling back to the
+// cross-month search only for a parent older than either.
+func (r *esParentResolver) resolve(ctx context.Context, messageID string, replyCreatedAt time.Time) (time.Time, bool) {
+	for _, at := range [...]time.Time{replyCreatedAt, prevMonth(replyCreatedAt)} {
+		if createdAt, ok := r.esGet(ctx, searchindex.MessageIndexName(r.indexPrefix, at), messageID); ok {
+			return createdAt, true
+		}
+	}
+	return r.esSearch(ctx, messageID)
+}
+
+// esReader is the narrow surface the parent lookup needs.
 // searchengine.SearchEngine satisfies it.
-type esSearcher interface {
+type esReader interface {
+	GetDoc(ctx context.Context, index, docID string) (json.RawMessage, bool, error)
 	Search(ctx context.Context, indices []string, body json.RawMessage) (json.RawMessage, error)
 }
 
-// newESRead returns an esReadFn that looks the parent up by ID and returns its
-// createdAt. The lookup spans every monthly index for indexPrefix's version.
-func newESRead(searcher esSearcher, indexPrefix string) esReadFn {
+// newESGet returns an esGetFn that point-reads one index. A missing index is a
+// miss, not an error: GetDoc reports both as 404, which is what lets the caller
+// probe a month that may never have been created.
+func newESGet(reader esReader) esGetFn {
+	return func(ctx context.Context, index, messageID string) (time.Time, bool) {
+		raw, found, err := reader.GetDoc(ctx, index, messageID)
+		if err != nil {
+			slog.WarnContext(ctx, "ES parent createdAt get failed", "error", err, "index", index, "messageId", messageID)
+			return time.Time{}, false
+		}
+		if !found {
+			return time.Time{}, false
+		}
+		var resp struct {
+			Source struct {
+				CreatedAt time.Time `json:"createdAt"`
+			} `json:"_source"`
+		}
+		if err := json.Unmarshal(raw, &resp); err != nil {
+			slog.WarnContext(ctx, "decode ES parent get response failed", "error", err, "index", index, "messageId", messageID)
+			return time.Time{}, false
+		}
+		if resp.Source.CreatedAt.IsZero() {
+			return time.Time{}, false
+		}
+		return resp.Source.CreatedAt, true
+	}
+}
+
+// newESSearch returns an esSearchFn spanning every monthly index for indexPrefix's
+// version. Only reached for parents older than the two months probed by id.
+func newESSearch(reader esReader, indexPrefix string) esSearchFn {
 	pattern := indexPrefix + "-*"
 	return func(ctx context.Context, messageID string) (time.Time, bool) {
 		body, err := json.Marshal(map[string]any{
@@ -54,7 +130,7 @@ func newESRead(searcher esSearcher, indexPrefix string) esReadFn {
 			slog.WarnContext(ctx, "build ES parent lookup query failed", "error", err, "messageId", messageID)
 			return time.Time{}, false
 		}
-		raw, err := searcher.Search(ctx, []string{pattern}, body)
+		raw, err := reader.Search(ctx, []string{pattern}, body)
 		if err != nil {
 			slog.WarnContext(ctx, "ES parent createdAt lookup failed", "error", err, "messageId", messageID)
 			return time.Time{}, false
@@ -79,10 +155,12 @@ func newESRead(searcher esSearcher, indexPrefix string) esReadFn {
 	}
 }
 
-// newESParentResolver builds the ES-self-lookup resolver. searcher must be non-nil.
-func newESParentResolver(searcher esSearcher, indexPrefix string) *esParentResolver {
+// newESParentResolver builds the ES-self-lookup resolver. reader must be non-nil.
+func newESParentResolver(reader esReader, indexPrefix string) *esParentResolver {
 	return &esParentResolver{
-		esRead:  newESRead(searcher, indexPrefix),
-		timeout: parentResolveTimeout,
+		esGet:       newESGet(reader),
+		esSearch:    newESSearch(reader, indexPrefix),
+		indexPrefix: indexPrefix,
+		timeout:     parentResolveTimeout,
 	}
 }

--- a/search-sync-worker/thread_parent_resolver_test.go
+++ b/search-sync-worker/thread_parent_resolver_test.go
@@ -6,32 +6,107 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestESParentResolver_ResolveParentCreatedAt(t *testing.T) {
-	val := time.Date(2024, 6, 1, 9, 30, 0, 0, time.UTC)
+// prevMonth is the trap in this file: replyAt.AddDate(0, -1, 0) normalises
+// "31 February" back into March, so the boundary probe would silently repeat the
+// month it just tried.
+func TestPrevMonth(t *testing.T) {
+	tests := []struct {
+		name      string
+		at        time.Time
+		wantYear  int
+		wantMonth time.Month
+	}{
+		{"mid-month", time.Date(2026, 6, 14, 9, 0, 0, 0, time.UTC), 2026, time.May},
+		{"31st of a month the previous one is shorter than", time.Date(2026, 3, 31, 23, 59, 0, 0, time.UTC), 2026, time.February},
+		{"1st of the month", time.Date(2026, 3, 1, 0, 5, 0, 0, time.UTC), 2026, time.February},
+		{"january rolls back a year", time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC), 2025, time.December},
+		{"leap february", time.Date(2024, 3, 30, 12, 0, 0, 0, time.UTC), 2024, time.February},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := prevMonth(tt.at)
+			assert.Equal(t, tt.wantYear, got.Year())
+			assert.Equal(t, tt.wantMonth, got.Month())
+		})
+	}
+}
 
-	t.Run("returns the ES value when found", func(t *testing.T) {
-		var gotID string
-		r := &esParentResolver{
-			timeout: time.Second,
-			esRead: func(_ context.Context, id string) (time.Time, bool) {
-				gotID = id
-				return val, true
-			},
-		}
-		got, ok := r.ResolveParentCreatedAt(context.Background(), "parent-1")
-		assert.True(t, ok)
-		assert.True(t, got.Equal(val))
-		assert.Equal(t, "parent-1", gotID)
+// recordingReader captures which indices were probed, and answers from a fixture.
+type recordingReader struct {
+	found   map[string]time.Time // index -> createdAt present in that index
+	probed  []string
+	searchN int
+	searchT time.Time
+	searchK bool
+}
+
+func (r *recordingReader) get(_ context.Context, index, _ string) (time.Time, bool) {
+	r.probed = append(r.probed, index)
+	at, ok := r.found[index]
+	return at, ok
+}
+
+func (r *recordingReader) search(context.Context, string) (time.Time, bool) {
+	r.searchN++
+	return r.searchT, r.searchK
+}
+
+func newTestResolver(rr *recordingReader) *esParentResolver {
+	return &esParentResolver{
+		esGet:       rr.get,
+		esSearch:    rr.search,
+		indexPrefix: "msgs-v1",
+		timeout:     time.Second,
+	}
+}
+
+func TestESParentResolver_ResolveParentCreatedAt(t *testing.T) {
+	parentAt := time.Date(2026, 6, 1, 9, 30, 0, 0, time.UTC)
+	replyAt := time.Date(2026, 6, 14, 10, 0, 0, 0, time.UTC)
+
+	t.Run("a same-month parent costs one point read and no search", func(t *testing.T) {
+		rr := &recordingReader{found: map[string]time.Time{"msgs-v1-2026-06": parentAt}}
+
+		got, ok := newTestResolver(rr).ResolveParentCreatedAt(context.Background(), "parent-1", replyAt)
+
+		require.True(t, ok)
+		assert.True(t, got.Equal(parentAt))
+		assert.Equal(t, []string{"msgs-v1-2026-06"}, rr.probed)
+		assert.Zero(t, rr.searchN, "the cross-month search must stay off the common path")
 	})
 
-	t.Run("ok=false when the parent isn't found", func(t *testing.T) {
-		r := &esParentResolver{
-			timeout: time.Second,
-			esRead:  func(context.Context, string) (time.Time, bool) { return time.Time{}, false },
-		}
-		_, ok := r.ResolveParentCreatedAt(context.Background(), "missing")
+	t.Run("falls back to the previous month before searching", func(t *testing.T) {
+		rr := &recordingReader{found: map[string]time.Time{"msgs-v1-2026-05": parentAt}}
+
+		got, ok := newTestResolver(rr).ResolveParentCreatedAt(context.Background(), "parent-1", replyAt)
+
+		require.True(t, ok)
+		assert.True(t, got.Equal(parentAt))
+		assert.Equal(t, []string{"msgs-v1-2026-06", "msgs-v1-2026-05"}, rr.probed)
+		assert.Zero(t, rr.searchN)
+	})
+
+	t.Run("an older parent still resolves via the cross-month search", func(t *testing.T) {
+		old := time.Date(2025, 1, 2, 3, 4, 0, 0, time.UTC)
+		rr := &recordingReader{found: map[string]time.Time{}, searchT: old, searchK: true}
+
+		got, ok := newTestResolver(rr).ResolveParentCreatedAt(context.Background(), "parent-1", replyAt)
+
+		require.True(t, ok)
+		assert.True(t, got.Equal(old))
+		assert.Equal(t, []string{"msgs-v1-2026-06", "msgs-v1-2026-05"}, rr.probed)
+		assert.Equal(t, 1, rr.searchN)
+	})
+
+	t.Run("ok=false when nothing has the parent", func(t *testing.T) {
+		rr := &recordingReader{found: map[string]time.Time{}}
+
+		_, ok := newTestResolver(rr).ResolveParentCreatedAt(context.Background(), "missing", replyAt)
+
 		assert.False(t, ok)
+		assert.Equal(t, 1, rr.searchN, "the search is the last resort, tried once")
 	})
 }


### PR DESCRIPTION
The thread-parent `createdAt` fallback searched `messages-<site>-v1-*` — every monthly index — for one timestamp on one document, synchronously on the consumer goroutine. Fixing it turned out to be a correctness fix, not just a cost one.

Independent of #311: that PR touches `main.go`, `handler.go`, `spotlight_org.go` and three `pkg/` files; this one touches `messages.go` and `thread_parent_resolver.go`. Disjoint — they merge in either order.

## The correctness bug

The message template sets **`refresh_interval: 30s`** (`pkg/searchindex/template.go:74`), and an ES search only sees refreshed segments. So **a parent indexed less than thirty seconds ago is not searchable.** The lookup paid its full cost to return not-found for exactly the case that dominates live chat — a quick reply to a recent message — and the field then stays unset forever, because nothing backfills it.

That field is not decorative. `search-service/query_messages.go:209-226`, restricted-room clause B, matches a thread reply only when `tshow=true` **or** `threadParentMessageCreatedAt >= historySharedSince`. An ES `range` query cannot match a document missing the field, so:

> An unset value hides a thread reply the user is entitled to see — silently, and permanently until a reindex.

Fail-closed, so not a leak. But a false negative, and one that gets *more* likely during an incident: the resolver only runs when the gatekeeper left the field nil, and `message-gatekeeper/handler.go:507-514` nils it on **any** parent-fetch error. A Cassandra or history-service wobble therefore stops the field being filled for every thread reply, and search-sync-worker answers by issuing an ES search per reply.

## The fix

A **get is realtime** — served from the translog, not bound by `refresh_interval` — and routes to a single shard by id. The obstacle is that it needs a concrete index, and the monthly index name comes from the parent's `createdAt`, which is the thing being looked up.

The reply's own `createdAt` breaks the cycle: a parent always predates its reply, and threads are overwhelmingly same-month. So the resolver probes the reply's month, then the month before, and only then falls back to the existing cross-month search for genuinely old parents.

| Case | Before | After |
|---|---|---|
| Parent same month | ~4 shards × N monthly indices, **misses if <30s old** | 1 shard read, always finds it |
| Parent previous month | same fan-out | 2 shard reads |
| Parent older | same fan-out | 2 reads + the same search |
| Parent nowhere | same fan-out | 2 reads + search — marginally dearer |

The worst case costs slightly more. Good trade: realtime gets make "not indexed yet" much rarer, since today that also covers "indexed but not yet refreshed".

## One trap worth reviewing closely

`prevMonth` deliberately avoids `AddDate(0, -1, 0)`. That normalises **31 March** into "31 February" and lands back on **3 March** — repeating the month just probed and silently losing the boundary case. Going through `time.Date` on the month number normalises correctly, January → previous December included. There's a table test for it.

## Testing

Written test-first; the resolver tests assert the *probe sequence*, so an implementation that searches too eagerly or skips the previous month fails.

- `prevMonth`: mid-month, the 31st, the 1st, January→December, leap February
- Resolver: same-month hit costs one read and **no** search; previous-month hit; fallback to search for older; not-found
- A new test pins that the reply's `createdAt` actually reaches the resolver — without it every probe would target the zero-time index and nothing else would catch that

`prevMonth`, `ResolveParentCreatedAt` and `resolveThreadParentCreatedAt` are at 100%. Package coverage moves 55.7% → 54.7%: `newESGet` adds wire-adapter statements reachable only from the integration test, exactly like the `newESRead` it replaces, which was already 0% on `main`.

**The integration test drops its `refreshIndex` call.** That call was the test compensating for the production bug — without it the test fails on the old search path and passes on the new one, which is the property worth pinning. Docker was unavailable here, so it is compile-checked (`go vet -tags integration`) but **not executed**; CI is its first real run, and it is the only thing that verifies the realtime behaviour.

`make lint` 0 issues, `gosec` clean, full package green under `-race`.

## What this does not fix

If parent and reply land in the **same flush batch**, no lookup can find the parent — it hasn't been written yet. The real fix there is filling the field upstream: `message-gatekeeper` already does so best-effort, and `bot-message-handler` passes through whatever the client sent. This change makes the fallback fast and correct where a fallback can work; it doesn't remove the need for one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnEWtiYrtp72HsX78yjDLy

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnEWtiYrtp72HsX78yjDLy)_