### PR TITLE
fix(room-worker): self-correct migrated subscription joinedAt on replay

### DIFF
--- a/inbox-worker/handler.go
+++ b/inbox-worker/handler.go
@@ -20,6 +20,9 @@ import (
 type InboxStore interface {
 	CreateSubscription(ctx context.Context, sub *model.Subscription) error
 	BulkCreateSubscriptions(ctx context.Context, subs []*model.Subscription) error
+	// BulkRefreshJoinedAt sets joinedAt on existing (roomId, account) replicas —
+	// the Teams migration's cross-site joinedAt correction; a missing sub is a no-op.
+	BulkRefreshJoinedAt(ctx context.Context, roomID string, joinedAtByAccount map[string]time.Time) error
 	// UpsertRoom replicates room metadata, guarded by the incoming room's
 	// UpdatedAt: an event carrying an older (or equal) UpdatedAt than the
 	// stored one is a silent no-op, so out-of-order federated delivery cannot
@@ -138,6 +141,8 @@ func (h *Handler) HandleEvent(ctx context.Context, data []byte) error {
 		return h.handleMemberAdded(ctx, &evt)
 	case "member_removed":
 		return h.handleMemberRemoved(ctx, &evt)
+	case model.InboxMemberJoinedAtRefreshed:
+		return h.handleMemberJoinedAtRefreshed(ctx, &evt)
 	case "room_sync":
 		return h.handleRoomSync(ctx, &evt)
 	case "role_updated":
@@ -261,6 +266,28 @@ func (h *Handler) handleMemberAdded(ctx context.Context, evt *model.InboxEvent) 
 // SubscriptionUpdateEvent is published here — room-worker already publishes
 // to the user's subject and the NATS supercluster routes it to the user's
 // home site.
+// handleMemberJoinedAtRefreshed applies the Teams migration's joinedAt correction
+// to the home-site replicas (a joinedAt-only $set; a replica not yet present is a
+// no-op — the next member_added carries the corrected joinedAt).
+func (h *Handler) handleMemberJoinedAtRefreshed(ctx context.Context, evt *model.InboxEvent) error {
+	var event model.MemberAddEvent
+	if err := json.Unmarshal(evt.Payload, &event); err != nil {
+		return fmt.Errorf("unmarshal member_joinedat_refreshed payload: %w", err)
+	}
+	if len(event.Accounts) == 0 {
+		return nil
+	}
+	joinedAt := time.UnixMilli(event.JoinedAt).UTC()
+	byAccount := make(map[string]time.Time, len(event.Accounts))
+	for _, account := range event.Accounts {
+		byAccount[account] = joinedAt
+	}
+	if err := h.store.BulkRefreshJoinedAt(ctx, event.RoomID, byAccount); err != nil {
+		return fmt.Errorf("refresh joinedAt on replicas: %w", err)
+	}
+	return nil
+}
+
 func (h *Handler) handleMemberRemoved(ctx context.Context, evt *model.InboxEvent) error {
 	var memberEvt model.MemberRemoveEvent
 	if err := json.Unmarshal(evt.Payload, &memberEvt); err != nil {

--- a/inbox-worker/handler_test.go
+++ b/inbox-worker/handler_test.go
@@ -27,6 +27,12 @@ type roleUpdate struct {
 	updatedAt time.Time
 }
 
+type joinedAtRefresh struct {
+	roomID   string
+	account  string
+	joinedAt time.Time
+}
+
 type muteUpdate struct {
 	roomID    string
 	account   string
@@ -92,6 +98,7 @@ type stubInboxStore struct {
 	subscriptions         []model.Subscription
 	bulkSubscriptions     []*model.Subscription
 	bulkCreateErr         error
+	joinedAtRefreshes     []joinedAtRefresh
 	rooms                 []model.Room
 	roleUpdates           []roleUpdate
 	muteUpdates           []muteUpdate
@@ -267,6 +274,15 @@ func (s *stubInboxStore) BulkCreateSubscriptions(_ context.Context, subs []*mode
 	s.bulkSubscriptions = append(s.bulkSubscriptions, subs...)
 	for _, sub := range subs {
 		s.subscriptions = append(s.subscriptions, *sub)
+	}
+	return nil
+}
+
+func (s *stubInboxStore) BulkRefreshJoinedAt(_ context.Context, roomID string, joinedAtByAccount map[string]time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for account, joinedAt := range joinedAtByAccount {
+		s.joinedAtRefreshes = append(s.joinedAtRefreshes, joinedAtRefresh{roomID: roomID, account: account, joinedAt: joinedAt})
 	}
 	return nil
 }
@@ -563,6 +579,44 @@ func (s *stubInboxStore) getPermissionsApplies() []permissionsApply {
 }
 
 // --- Tests ---
+
+func TestHandleEvent_MemberJoinedAtRefreshed(t *testing.T) {
+	store := &stubInboxStore{}
+	h := NewHandler(store)
+
+	joinedAt := time.Date(2023, 4, 5, 6, 7, 8, 0, time.UTC)
+	change := model.MemberAddEvent{
+		RoomID:   "room-1",
+		Accounts: []string{"alice", "bob"},
+		SiteID:   "site-a",
+		JoinedAt: joinedAt.UnixMilli(),
+	}
+	changeData, err := json.Marshal(change)
+	if err != nil {
+		t.Fatalf("marshal change: %v", err)
+	}
+	evt := model.InboxEvent{Type: model.InboxMemberJoinedAtRefreshed, SiteID: "site-a", DestSiteID: "site-b", Payload: changeData}
+	evtData, err := json.Marshal(evt)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+
+	if err := h.HandleEvent(context.Background(), evtData); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+
+	if len(store.joinedAtRefreshes) != 2 {
+		t.Fatalf("expected 2 joinedAt refreshes, got %d", len(store.joinedAtRefreshes))
+	}
+	for _, r := range store.joinedAtRefreshes {
+		if r.roomID != "room-1" {
+			t.Errorf("refresh roomID = %q, want room-1", r.roomID)
+		}
+		if !r.joinedAt.Equal(joinedAt) {
+			t.Errorf("refresh joinedAt = %v, want %v", r.joinedAt, joinedAt)
+		}
+	}
+}
 
 func TestHandleEvent_MemberAdded(t *testing.T) {
 	store := &stubInboxStore{

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -294,6 +294,25 @@ func (s *mongoInboxStore) BulkCreateSubscriptions(ctx context.Context, subs []*m
 	return nil
 }
 
+// BulkRefreshJoinedAt sets joinedAt on existing (roomId, account) replicas — the
+// Teams migration's cross-site joinedAt correction. joinedAt only; a missing
+// replica leaves MatchedCount 0 and is a silent no-op (no insert).
+func (s *mongoInboxStore) BulkRefreshJoinedAt(ctx context.Context, roomID string, joinedAtByAccount map[string]time.Time) error {
+	if len(joinedAtByAccount) == 0 {
+		return nil
+	}
+	models := make([]mongo.WriteModel, 0, len(joinedAtByAccount))
+	for account, joinedAt := range joinedAtByAccount {
+		models = append(models, mongo.NewUpdateOneModel().
+			SetFilter(bson.M{"roomId": roomID, "u.account": account}).
+			SetUpdate(bson.M{"$set": bson.M{"joinedAt": joinedAt}}))
+	}
+	if _, err := s.subCol.BulkWrite(ctx, models, options.BulkWrite().SetOrdered(false)); err != nil {
+		return fmt.Errorf("bulk refresh joinedAt for %d replicas: %w", len(models), err)
+	}
+	return nil
+}
+
 // UpdateSubscriptionMute sets muted by (roomID, account) under a muteUpdatedAt
 // guard so an out-of-order or duplicate toggle cannot regress mute state.
 // Missing-sub and guard-rejected events both leave MatchedCount 0 and are

--- a/inbox-worker/mock_store_test.go
+++ b/inbox-worker/mock_store_test.go
@@ -126,6 +126,20 @@ func (mr *MockInboxStoreMockRecorder) BulkCreateSubscriptions(ctx, subs any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateSubscriptions", reflect.TypeOf((*MockInboxStore)(nil).BulkCreateSubscriptions), ctx, subs)
 }
 
+// BulkRefreshJoinedAt mocks base method.
+func (m *MockInboxStore) BulkRefreshJoinedAt(ctx context.Context, roomID string, joinedAtByAccount map[string]time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkRefreshJoinedAt", ctx, roomID, joinedAtByAccount)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkRefreshJoinedAt indicates an expected call of BulkRefreshJoinedAt.
+func (mr *MockInboxStoreMockRecorder) BulkRefreshJoinedAt(ctx, roomID, joinedAtByAccount any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkRefreshJoinedAt", reflect.TypeOf((*MockInboxStore)(nil).BulkRefreshJoinedAt), ctx, roomID, joinedAtByAccount)
+}
+
 // CreateSubscription mocks base method.
 func (m *MockInboxStore) CreateSubscription(ctx context.Context, sub *model.Subscription) error {
 	m.ctrl.T.Helper()

--- a/outbox-worker/consumer_config_test.go
+++ b/outbox-worker/consumer_config_test.go
@@ -36,6 +36,7 @@ func TestBuildConcurrentConsumerConfig(t *testing.T) {
 		"chat.outbox.site-a.site-b.room_restricted",
 		"chat.outbox.site-a.site-b.thread_subscription_upserted",
 		"chat.outbox.site-a.site-b.thread_unread_added",
+		"chat.outbox.site-a.site-b.member_joinedat_refreshed",
 	}, cc.FilterSubjects)
 	assert.Equal(t, jetstream.AckExplicitPolicy, cc.AckPolicy)
 	assert.Equal(t, jetstream.DeliverAllPolicy, cc.DeliverPolicy)

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -155,6 +155,7 @@ type InboxEventType = string
 const (
 	InboxMemberAdded                 InboxEventType = "member_added"
 	InboxMemberRemoved               InboxEventType = "member_removed"
+	InboxMemberJoinedAtRefreshed     InboxEventType = "member_joinedat_refreshed"
 	InboxRoleUpdated                 InboxEventType = "role_updated"
 	InboxSubscriptionRead            InboxEventType = "subscription_read"
 	InboxSubscriptionMuteToggled     InboxEventType = "subscription_mute_toggled"

--- a/pkg/outbox/outbox.go
+++ b/pkg/outbox/outbox.go
@@ -35,6 +35,11 @@ var ConcurrentEventTypes = []model.InboxEventType{
 	// thread_unread_added $addToSets one parent ID and thread_read $pulls one —
 	// per-ID set ops that commute across threads, so both ride this lane.
 	model.InboxThreadUnreadAdded,
+	// Teams migration joinedAt self-correction: sets joinedAt on an existing
+	// replica ($set, missing sub = no-op), targeting members added in a prior run.
+	// Idempotent + commutes with add/remove (a delete just makes it a no-op), so
+	// it rides the concurrent lane.
+	model.InboxMemberJoinedAtRefreshed,
 }
 
 // OrderedEventTypes are the OUTBOX event types forwarded by outbox-worker's

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -317,8 +317,10 @@ func InboxMemberEventSubjects(siteID string) []string {
 	return []string{
 		InboxInternal(siteID, "member_added"),
 		InboxInternal(siteID, "member_removed"),
+		InboxInternal(siteID, "member_joinedat_refreshed"),
 		InboxExternal(siteID, "member_added"),
 		InboxExternal(siteID, "member_removed"),
+		InboxExternal(siteID, "member_joinedat_refreshed"),
 	}
 }
 

--- a/pkg/subject/subject_test.go
+++ b/pkg/subject/subject_test.go
@@ -223,8 +223,10 @@ func TestSubjectBuilders(t *testing.T) {
 		want := []string{
 			"chat.inbox.site-a.internal.member_added",
 			"chat.inbox.site-a.internal.member_removed",
+			"chat.inbox.site-a.internal.member_joinedat_refreshed",
 			"chat.inbox.site-a.external.member_added",
 			"chat.inbox.site-a.external.member_removed",
+			"chat.inbox.site-a.external.member_joinedat_refreshed",
 		}
 		if len(got) != len(want) {
 			t.Fatalf("got %d subjects, want %d", len(got), len(want))

--- a/room-worker/integration_test.go
+++ b/room-worker/integration_test.go
@@ -400,10 +400,10 @@ func TestMongoStore_RemoveRole_Integration(t *testing.T) {
 	}
 }
 
-// TestMongoStore_BulkCreateSubscriptions_UpsertRefreshesJoinedAt: a re-upsert of an
-// existing (roomId, account) sub corrects joinedAt ($set) while preserving read state
-// and _id ($setOnInsert is a no-op on the existing doc).
-func TestMongoStore_BulkCreateSubscriptions_UpsertRefreshesJoinedAt(t *testing.T) {
+// TestMongoStore_BulkRefreshJoinedAt_Integration: refreshes joinedAt on existing
+// (roomId, account) subs while preserving _id, read state and roles; a missing
+// account is a no-op (never inserted).
+func TestMongoStore_BulkRefreshJoinedAt_Integration(t *testing.T) {
 	db := setupMongo(t)
 	store := NewMongoStore(db)
 	ctx := context.Background()
@@ -415,45 +415,21 @@ func TestMongoStore_BulkCreateSubscriptions_UpsertRefreshesJoinedAt(t *testing.T
 		RoomID: "r1", Roles: []model.Role{model.RoleMember}, JoinedAt: stale, LastSeenAt: &seen,
 	})
 
-	// Re-upsert same (r1, alice) with a corrected joinedAt and a fresh random _id +
-	// no read state — only joinedAt must change; _id and lastSeenAt must be preserved.
 	corrected := time.Date(2023, 4, 5, 6, 7, 8, 0, time.UTC)
-	err := store.BulkCreateSubscriptions(ctx, []*model.Subscription{{
-		ID: "s2-should-be-ignored", User: model.SubscriptionUser{ID: "u1", Account: "alice"},
-		RoomID: "r1", Roles: []model.Role{model.RoleOwner, model.RoleMember}, JoinedAt: corrected,
-	}})
+	err := store.BulkRefreshJoinedAt(ctx, "r1", map[string]time.Time{
+		"alice": corrected,
+		"ghost": corrected, // no such sub — must be a no-op, never inserted
+	})
 	require.NoError(t, err)
 
 	subs, err := store.ListByRoom(ctx, "r1")
 	require.NoError(t, err)
-	require.Len(t, subs, 1)
-	assert.Equal(t, corrected, subs[0].JoinedAt.UTC(), "joinedAt must be refreshed ($set)")
-	assert.Equal(t, "s1", subs[0].ID, "_id preserved ($setOnInsert no-op on existing)")
+	require.Len(t, subs, 1, "no sub inserted for the missing 'ghost' account")
+	assert.Equal(t, corrected, subs[0].JoinedAt.UTC(), "joinedAt refreshed")
+	assert.Equal(t, "s1", subs[0].ID, "_id preserved")
 	require.NotNil(t, subs[0].LastSeenAt)
 	assert.Equal(t, seen, subs[0].LastSeenAt.UTC(), "read state (lastSeenAt) preserved")
-	assert.Equal(t, []model.Role{model.RoleMember}, subs[0].Roles, "other fields preserved (roles not clobbered)")
-}
-
-// TestMongoStore_BulkCreateSubscriptions_InsertSetsJoinedAt: a fresh insert still
-// gets joinedAt (now via $set) plus all $setOnInsert fields.
-func TestMongoStore_BulkCreateSubscriptions_InsertSetsJoinedAt(t *testing.T) {
-	db := setupMongo(t)
-	store := NewMongoStore(db)
-	ctx := context.Background()
-
-	joined := time.Date(2023, 4, 5, 6, 7, 8, 0, time.UTC)
-	err := store.BulkCreateSubscriptions(ctx, []*model.Subscription{{
-		ID: "s1", User: model.SubscriptionUser{ID: "u1", Account: "alice"},
-		RoomID: "r1", Roles: []model.Role{model.RoleMember}, JoinedAt: joined,
-	}})
-	require.NoError(t, err)
-
-	subs, err := store.ListByRoom(ctx, "r1")
-	require.NoError(t, err)
-	require.Len(t, subs, 1)
-	assert.Equal(t, "s1", subs[0].ID)
-	assert.Equal(t, joined, subs[0].JoinedAt.UTC())
-	assert.Equal(t, []model.Role{model.RoleMember}, subs[0].Roles)
+	assert.Equal(t, []model.Role{model.RoleMember}, subs[0].Roles, "roles preserved")
 }
 
 func TestMongoStore_DeleteSubscription_Integration(t *testing.T) {

--- a/room-worker/integration_test.go
+++ b/room-worker/integration_test.go
@@ -400,6 +400,62 @@ func TestMongoStore_RemoveRole_Integration(t *testing.T) {
 	}
 }
 
+// TestMongoStore_BulkCreateSubscriptions_UpsertRefreshesJoinedAt: a re-upsert of an
+// existing (roomId, account) sub corrects joinedAt ($set) while preserving read state
+// and _id ($setOnInsert is a no-op on the existing doc).
+func TestMongoStore_BulkCreateSubscriptions_UpsertRefreshesJoinedAt(t *testing.T) {
+	db := setupMongo(t)
+	store := NewMongoStore(db)
+	ctx := context.Background()
+
+	seen := time.Date(2026, 2, 2, 2, 2, 2, 0, time.UTC)
+	stale := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	mustInsertSub(t, db, &model.Subscription{
+		ID: "s1", User: model.SubscriptionUser{ID: "u1", Account: "alice"},
+		RoomID: "r1", Roles: []model.Role{model.RoleMember}, JoinedAt: stale, LastSeenAt: &seen,
+	})
+
+	// Re-upsert same (r1, alice) with a corrected joinedAt and a fresh random _id +
+	// no read state — only joinedAt must change; _id and lastSeenAt must be preserved.
+	corrected := time.Date(2023, 4, 5, 6, 7, 8, 0, time.UTC)
+	err := store.BulkCreateSubscriptions(ctx, []*model.Subscription{{
+		ID: "s2-should-be-ignored", User: model.SubscriptionUser{ID: "u1", Account: "alice"},
+		RoomID: "r1", Roles: []model.Role{model.RoleOwner, model.RoleMember}, JoinedAt: corrected,
+	}})
+	require.NoError(t, err)
+
+	subs, err := store.ListByRoom(ctx, "r1")
+	require.NoError(t, err)
+	require.Len(t, subs, 1)
+	assert.Equal(t, corrected, subs[0].JoinedAt.UTC(), "joinedAt must be refreshed ($set)")
+	assert.Equal(t, "s1", subs[0].ID, "_id preserved ($setOnInsert no-op on existing)")
+	require.NotNil(t, subs[0].LastSeenAt)
+	assert.Equal(t, seen, subs[0].LastSeenAt.UTC(), "read state (lastSeenAt) preserved")
+	assert.Equal(t, []model.Role{model.RoleMember}, subs[0].Roles, "other fields preserved (roles not clobbered)")
+}
+
+// TestMongoStore_BulkCreateSubscriptions_InsertSetsJoinedAt: a fresh insert still
+// gets joinedAt (now via $set) plus all $setOnInsert fields.
+func TestMongoStore_BulkCreateSubscriptions_InsertSetsJoinedAt(t *testing.T) {
+	db := setupMongo(t)
+	store := NewMongoStore(db)
+	ctx := context.Background()
+
+	joined := time.Date(2023, 4, 5, 6, 7, 8, 0, time.UTC)
+	err := store.BulkCreateSubscriptions(ctx, []*model.Subscription{{
+		ID: "s1", User: model.SubscriptionUser{ID: "u1", Account: "alice"},
+		RoomID: "r1", Roles: []model.Role{model.RoleMember}, JoinedAt: joined,
+	}})
+	require.NoError(t, err)
+
+	subs, err := store.ListByRoom(ctx, "r1")
+	require.NoError(t, err)
+	require.Len(t, subs, 1)
+	assert.Equal(t, "s1", subs[0].ID)
+	assert.Equal(t, joined, subs[0].JoinedAt.UTC())
+	assert.Equal(t, []model.Role{model.RoleMember}, subs[0].Roles)
+}
+
 func TestMongoStore_DeleteSubscription_Integration(t *testing.T) {
 	db := setupMongo(t)
 	store := NewMongoStore(db)

--- a/room-worker/mock_store_test.go
+++ b/room-worker/mock_store_test.go
@@ -87,6 +87,20 @@ func (mr *MockSubscriptionStoreMockRecorder) BulkCreateSubscriptions(ctx, subs a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkCreateSubscriptions", reflect.TypeOf((*MockSubscriptionStore)(nil).BulkCreateSubscriptions), ctx, subs)
 }
 
+// BulkRefreshJoinedAt mocks base method.
+func (m *MockSubscriptionStore) BulkRefreshJoinedAt(ctx context.Context, roomID string, joinedAtByAccount map[string]time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BulkRefreshJoinedAt", ctx, roomID, joinedAtByAccount)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BulkRefreshJoinedAt indicates an expected call of BulkRefreshJoinedAt.
+func (mr *MockSubscriptionStoreMockRecorder) BulkRefreshJoinedAt(ctx, roomID, joinedAtByAccount any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkRefreshJoinedAt", reflect.TypeOf((*MockSubscriptionStore)(nil).BulkRefreshJoinedAt), ctx, roomID, joinedAtByAccount)
+}
+
 // CreateRoom mocks base method.
 func (m *MockSubscriptionStore) CreateRoom(ctx context.Context, room *model.Room, key *roomkeystore.RoomKeyPair) (bool, error) {
 	m.ctrl.T.Helper()

--- a/room-worker/store.go
+++ b/room-worker/store.go
@@ -68,6 +68,9 @@ type SubscriptionStore interface {
 	// membership write path (channel, DM, botDM, add-member); the
 	// re-subscribe semantic for botDM is owned by user-service.
 	BulkCreateSubscriptions(ctx context.Context, subs []*model.Subscription) error
+	// BulkRefreshJoinedAt sets joinedAt on existing (roomId, account) subs — the
+	// Teams migration's joinedAt self-correction; a missing sub is a no-op.
+	BulkRefreshJoinedAt(ctx context.Context, roomID string, joinedAtByAccount map[string]time.Time) error
 	// ReconcileMemberCounts recomputes Room.UserCount (non-bot subs) and
 	// Room.AppCount (bot subs) via index-backed counts on the denormalized
 	// u.isBot flag, then writes both back to the rooms collection in a single

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -506,15 +506,11 @@ func (s *MongoStore) DeleteThreadSubscriptions(ctx context.Context, roomID strin
 	return nil
 }
 
-// BulkCreateSubscriptions upserts each sub idempotently, keyed on
-// (roomId, u.account). Every field except joinedAt goes in $setOnInsert, so on
-// collision (a JetStream redelivery, or a migration replay) the persisted sub —
-// including its read state (lastSeenAt), roles and section — is preserved.
-// joinedAt is in $set so a replay converges it to the event's value: this
-// self-corrects a migrated sub whose joinedAt was stamped before the
-// createdDateTime fix. joinedAt is deterministic from the event/chat and is not
-// read-state, so overwriting it every write is safe. (A field cannot appear in
-// both $setOnInsert and $set, hence the marshal-then-remove.)
+// BulkCreateSubscriptions upserts each sub on (roomId, u.account). Everything but
+// joinedAt is $setOnInsert, so a redelivery/replay preserves the existing sub
+// (read state, roles, section). joinedAt is $set so a replay converges it —
+// self-correcting a sub stamped before the createdDateTime fix; it's deterministic
+// and not read-state, so overwriting is safe.
 func (s *MongoStore) BulkCreateSubscriptions(ctx context.Context, subs []*model.Subscription) error {
 	if len(subs) == 0 {
 		return nil
@@ -538,8 +534,8 @@ func (s *MongoStore) BulkCreateSubscriptions(ctx context.Context, subs []*model.
 	return nil
 }
 
-// bsonMExcept marshals v to a bson.M with the given top-level keys removed, so a
-// field can move from $setOnInsert to $set without a Mongo path conflict.
+// bsonMExcept marshals v to a bson.M without the given keys — lets a field move
+// from $setOnInsert to $set without a Mongo path conflict.
 func bsonMExcept(v any, keys ...string) (bson.M, error) {
 	raw, err := bson.Marshal(v)
 	if err != nil {

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -507,25 +507,52 @@ func (s *MongoStore) DeleteThreadSubscriptions(ctx context.Context, roomID strin
 }
 
 // BulkCreateSubscriptions upserts each sub idempotently, keyed on
-// (roomId, u.account). On collision with an existing document (e.g. a
-// JetStream redelivery of the same create/add-member event), $setOnInsert
-// is a no-op so the persisted sub is preserved unchanged — preserving the
-// insert-only contract for channel/DM/add-member paths while avoiding
-// the duplicate-key error path entirely.
+// (roomId, u.account). Every field except joinedAt goes in $setOnInsert, so on
+// collision (a JetStream redelivery, or a migration replay) the persisted sub —
+// including its read state (lastSeenAt), roles and section — is preserved.
+// joinedAt is in $set so a replay converges it to the event's value: this
+// self-corrects a migrated sub whose joinedAt was stamped before the
+// createdDateTime fix. joinedAt is deterministic from the event/chat and is not
+// read-state, so overwriting it every write is safe. (A field cannot appear in
+// both $setOnInsert and $set, hence the marshal-then-remove.)
 func (s *MongoStore) BulkCreateSubscriptions(ctx context.Context, subs []*model.Subscription) error {
 	if len(subs) == 0 {
 		return nil
 	}
 	models := make([]mongo.WriteModel, 0, len(subs))
 	for _, sub := range subs {
+		onInsert, err := bsonMExcept(sub, "joinedAt")
+		if err != nil {
+			return fmt.Errorf("marshal subscription for upsert: %w", err)
+		}
 		filter := bson.M{"roomId": sub.RoomID, "u.account": sub.User.Account}
-		models = append(models, mongoutil.UpsertModel(filter, bson.M{"$setOnInsert": sub}))
+		models = append(models, mongoutil.UpsertModel(filter, bson.M{
+			"$setOnInsert": onInsert,
+			"$set":         bson.M{"joinedAt": sub.JoinedAt},
+		}))
 	}
 	opts := options.BulkWrite().SetOrdered(false)
 	if _, err := s.subscriptions.BulkWrite(ctx, models, opts); err != nil {
 		return fmt.Errorf("bulk create %d subscriptions: %w", len(subs), err)
 	}
 	return nil
+}
+
+// bsonMExcept marshals v to a bson.M with the given top-level keys removed, so a
+// field can move from $setOnInsert to $set without a Mongo path conflict.
+func bsonMExcept(v any, keys ...string) (bson.M, error) {
+	raw, err := bson.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var m bson.M
+	if err := bson.Unmarshal(raw, &m); err != nil {
+		return nil, err
+	}
+	for _, k := range keys {
+		delete(m, k)
+	}
+	return m, nil
 }
 
 // BulkCreateRoomMembers upserts each row on the (rid, member.type, member.id) unique key. $setOnInsert

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -506,26 +506,20 @@ func (s *MongoStore) DeleteThreadSubscriptions(ctx context.Context, roomID strin
 	return nil
 }
 
-// BulkCreateSubscriptions upserts each sub on (roomId, u.account). Everything but
-// joinedAt is $setOnInsert, so a redelivery/replay preserves the existing sub
-// (read state, roles, section). joinedAt is $set so a replay converges it —
-// self-correcting a sub stamped before the createdDateTime fix; it's deterministic
-// and not read-state, so overwriting is safe.
+// BulkCreateSubscriptions upserts each sub idempotently, keyed on
+// (roomId, u.account). On collision with an existing document (e.g. a
+// JetStream redelivery of the same create/add-member event), $setOnInsert
+// is a no-op so the persisted sub is preserved unchanged — preserving the
+// insert-only contract for channel/DM/add-member paths while avoiding
+// the duplicate-key error path entirely.
 func (s *MongoStore) BulkCreateSubscriptions(ctx context.Context, subs []*model.Subscription) error {
 	if len(subs) == 0 {
 		return nil
 	}
 	models := make([]mongo.WriteModel, 0, len(subs))
 	for _, sub := range subs {
-		onInsert, err := bsonMExcept(sub, "joinedAt")
-		if err != nil {
-			return fmt.Errorf("marshal subscription for upsert: %w", err)
-		}
 		filter := bson.M{"roomId": sub.RoomID, "u.account": sub.User.Account}
-		models = append(models, mongoutil.UpsertModel(filter, bson.M{
-			"$setOnInsert": onInsert,
-			"$set":         bson.M{"joinedAt": sub.JoinedAt},
-		}))
+		models = append(models, mongoutil.UpsertModel(filter, bson.M{"$setOnInsert": sub}))
 	}
 	opts := options.BulkWrite().SetOrdered(false)
 	if _, err := s.subscriptions.BulkWrite(ctx, models, opts); err != nil {
@@ -534,21 +528,25 @@ func (s *MongoStore) BulkCreateSubscriptions(ctx context.Context, subs []*model.
 	return nil
 }
 
-// bsonMExcept marshals v to a bson.M without the given keys — lets a field move
-// from $setOnInsert to $set without a Mongo path conflict.
-func bsonMExcept(v any, keys ...string) (bson.M, error) {
-	raw, err := bson.Marshal(v)
-	if err != nil {
-		return nil, err
+// BulkRefreshJoinedAt sets joinedAt on existing (roomId, account) subs — the
+// Teams migration's self-correction for a member migrated before the
+// createdDateTime fix. joinedAt only: read state, roles and section are left
+// untouched, so this does NOT relax the insert-only contract of
+// BulkCreateSubscriptions (a missing sub is a no-op, not an insert).
+func (s *MongoStore) BulkRefreshJoinedAt(ctx context.Context, roomID string, joinedAtByAccount map[string]time.Time) error {
+	if len(joinedAtByAccount) == 0 {
+		return nil
 	}
-	var m bson.M
-	if err := bson.Unmarshal(raw, &m); err != nil {
-		return nil, err
+	models := make([]mongo.WriteModel, 0, len(joinedAtByAccount))
+	for account, joinedAt := range joinedAtByAccount {
+		models = append(models, mongo.NewUpdateOneModel().
+			SetFilter(bson.M{"roomId": roomID, "u.account": account}).
+			SetUpdate(bson.M{"$set": bson.M{"joinedAt": joinedAt}}))
 	}
-	for _, k := range keys {
-		delete(m, k)
+	if _, err := s.subscriptions.BulkWrite(ctx, models, options.BulkWrite().SetOrdered(false)); err != nil {
+		return fmt.Errorf("bulk refresh joinedAt for %d subs: %w", len(models), err)
 	}
-	return m, nil
+	return nil
 }
 
 // BulkCreateRoomMembers upserts each row on the (rid, member.type, member.id) unique key. $setOnInsert

--- a/room-worker/teamsroomcreate.go
+++ b/room-worker/teamsroomcreate.go
@@ -97,8 +97,9 @@ func (h *Handler) reconcileTeamsRoom(ctx context.Context, chat *model.TeamsRoomC
 	wantAccounts := make(map[string]struct{}, len(chat.Members))
 	memberSite := make(map[string]string, len(chat.Members)) // account -> home site, for federation
 	var newSubs []*model.Subscription
-	var addedUsers []model.User        // for the room-key fan-out
-	teamsSection := model.SectionTeams // addressable built-in section id for every migrated sub
+	var refreshSubs []*model.Subscription // existing members whose joinedAt needs correcting
+	var addedUsers []model.User           // for the room-key fan-out
+	teamsSection := model.SectionTeams    // addressable built-in section id for every migrated sub
 
 	for _, member := range chat.Members {
 		if member.Account == "" {
@@ -109,8 +110,16 @@ func (h *Handler) reconcileTeamsRoom(ctx context.Context, chat *model.TeamsRoomC
 			continue // duplicate account in the batch — already handled
 		}
 		wantAccounts[member.Account] = struct{}{}
-		if _, ok := existingByAccount[member.Account]; ok {
-			continue // already a member — no change
+		if existing, ok := existingByAccount[member.Account]; ok {
+			// Already a member — no add. But self-correct a joinedAt stamped before
+			// the createdDateTime fix: refresh it to the chat's createdDateTime via the
+			// same (roomId, account) upsert, without re-adding or re-fanning-out.
+			if want := chat.CreatedDateTime.UTC(); !existing.JoinedAt.Equal(want) {
+				s := *existing
+				s.JoinedAt = want
+				refreshSubs = append(refreshSubs, &s)
+			}
+			continue
 		}
 		user, err := h.resolveMember(ctx, member.Account, member.ID, member.DisplayName)
 		if err != nil {
@@ -152,6 +161,13 @@ func (h *Handler) reconcileTeamsRoom(ctx context.Context, chat *model.TeamsRoomC
 	if len(newSubs) > 0 {
 		if err := h.store.BulkCreateSubscriptions(ctx, newSubs); err != nil {
 			return fmt.Errorf("bulk create subs: %w", err)
+		}
+	}
+	if len(refreshSubs) > 0 {
+		// The (roomId, account) doc exists, so the upsert's $setOnInsert is a no-op
+		// and only joinedAt ($set) is corrected — read state stays untouched.
+		if err := h.store.BulkCreateSubscriptions(ctx, refreshSubs); err != nil {
+			return fmt.Errorf("refresh migrated joinedAt: %w", err)
 		}
 	}
 	if len(removed) > 0 {

--- a/room-worker/teamsroomcreate.go
+++ b/room-worker/teamsroomcreate.go
@@ -325,31 +325,62 @@ func (h *Handler) federateTeamsMembership(ctx context.Context, room *model.Room,
 	return nil
 }
 
-// federateJoinedAtRefresh fans the joinedAt correction to each cross-site member's
-// home site so the replica matches the room-site copy (just updated locally).
-// Local-site members are skipped. joinedAt is uniform per room (chat createdDateTime);
-// the remote apply is a no-op if the replica is absent.
+// federateJoinedAtRefresh propagates the joinedAt correction beyond the room-site
+// Mongo copy (updated locally): a local internal event so search-sync refreshes the
+// room-site spotlight joinedAt, plus one federated event per cross-site member's
+// home site so their Mongo replica + home-site spotlight match. joinedAt is uniform
+// per room (chat createdDateTime); every apply is a no-op if the target is absent.
 func (h *Handler) federateJoinedAtRefresh(ctx context.Context, room *model.Room, joinedAtByAccount map[string]time.Time, memberSite map[string]string, acceptedAt time.Time) error {
+	accounts := make([]string, 0, len(joinedAtByAccount))
+	for account := range joinedAtByAccount {
+		accounts = append(accounts, account)
+	}
+	evt := model.InboxMemberEvent{
+		RoomID:    room.ID,
+		RoomName:  room.Name,
+		RoomType:  room.Type,
+		SiteID:    h.siteID,
+		Accounts:  accounts,
+		JoinedAt:  room.CreatedAt.UnixMilli(),
+		Timestamp: acceptedAt.UnixMilli(),
+		Origin:    model.OriginTeams,
+	}
+	seed := fmt.Sprintf("%s:%s:%d", room.ID, model.InboxMemberJoinedAtRefreshed, acceptedAt.UnixMilli())
+
+	allPayload, err := json.Marshal(evt)
+	if err != nil {
+		return fmt.Errorf("marshal joinedAt-refresh event: %w", err)
+	}
+	// Local internal lane → room-site spotlight (inbox-worker doesn't consume it;
+	// the room-site Mongo copy was already updated by the caller).
+	internalData, err := json.Marshal(model.InboxEvent{
+		Type:       model.InboxMemberJoinedAtRefreshed,
+		SiteID:     h.siteID,
+		DestSiteID: h.siteID,
+		Payload:    allPayload,
+		Timestamp:  acceptedAt.UnixMilli(),
+	})
+	if err != nil {
+		return fmt.Errorf("marshal internal joinedAt-refresh envelope: %w", err)
+	}
+	if err := h.publish(ctx, subject.InboxInternal(h.siteID, model.InboxMemberJoinedAtRefreshed), internalData, natsutil.InboxDedupID(ctx, h.siteID, seed)); err != nil {
+		return fmt.Errorf("local inbox joinedAt-refresh publish: %w", err)
+	}
+
+	// Per cross-site home site → replica Mongo (inbox-worker) + home-site spotlight.
 	bySite := make(map[string][]string)
 	for account := range joinedAtByAccount {
 		if site := memberSite[account]; site != "" && site != h.siteID {
 			bySite[site] = append(bySite[site], account)
 		}
 	}
-	for destSite, accounts := range bySite {
-		evt := model.InboxMemberEvent{
-			RoomID:    room.ID,
-			SiteID:    h.siteID,
-			Accounts:  accounts,
-			JoinedAt:  room.CreatedAt.UnixMilli(),
-			Timestamp: acceptedAt.UnixMilli(),
-			Origin:    model.OriginTeams,
-		}
-		payload, err := json.Marshal(evt)
+	for destSite, siteAccounts := range bySite {
+		siteEvt := evt
+		siteEvt.Accounts = siteAccounts
+		payload, err := json.Marshal(siteEvt)
 		if err != nil {
 			return fmt.Errorf("marshal joinedAt-refresh event (dest %s): %w", destSite, err)
 		}
-		seed := fmt.Sprintf("%s:%s:%d", room.ID, model.InboxMemberJoinedAtRefreshed, acceptedAt.UnixMilli())
 		dedupID := natsutil.InboxDedupID(ctx, destSite, seed)
 		if err := h.federate(ctx, room.ID, destSite, model.InboxMemberJoinedAtRefreshed, payload, dedupID, acceptedAt.UnixMilli()); err != nil {
 			return fmt.Errorf("federate joinedAt refresh to %s: %w", destSite, err)

--- a/room-worker/teamsroomcreate.go
+++ b/room-worker/teamsroomcreate.go
@@ -97,9 +97,9 @@ func (h *Handler) reconcileTeamsRoom(ctx context.Context, chat *model.TeamsRoomC
 	wantAccounts := make(map[string]struct{}, len(chat.Members))
 	memberSite := make(map[string]string, len(chat.Members)) // account -> home site, for federation
 	var newSubs []*model.Subscription
-	var refreshSubs []*model.Subscription // existing members whose joinedAt needs correcting
-	var addedUsers []model.User           // for the room-key fan-out
-	teamsSection := model.SectionTeams    // addressable built-in section id for every migrated sub
+	joinedAtFixes := map[string]time.Time{} // existing members whose joinedAt is stale
+	var addedUsers []model.User             // for the room-key fan-out
+	teamsSection := model.SectionTeams      // addressable built-in section id for every migrated sub
 
 	for _, member := range chat.Members {
 		if member.Account == "" {
@@ -111,13 +111,10 @@ func (h *Handler) reconcileTeamsRoom(ctx context.Context, chat *model.TeamsRoomC
 		}
 		wantAccounts[member.Account] = struct{}{}
 		if existing, ok := existingByAccount[member.Account]; ok {
-			// Already a member — no add. But self-correct a joinedAt stamped before
-			// the createdDateTime fix: refresh it to the chat's createdDateTime via the
-			// same (roomId, account) upsert, without re-adding or re-fanning-out.
+			// Already a member — no add. But self-correct a joinedAt stamped before the
+			// createdDateTime fix: a joinedAt-only refresh, no re-add or re-fanout.
 			if want := chat.CreatedDateTime.UTC(); !existing.JoinedAt.Equal(want) {
-				s := *existing
-				s.JoinedAt = want
-				refreshSubs = append(refreshSubs, &s)
+				joinedAtFixes[member.Account] = want
 			}
 			continue
 		}
@@ -163,10 +160,8 @@ func (h *Handler) reconcileTeamsRoom(ctx context.Context, chat *model.TeamsRoomC
 			return fmt.Errorf("bulk create subs: %w", err)
 		}
 	}
-	if len(refreshSubs) > 0 {
-		// The (roomId, account) doc exists, so the upsert's $setOnInsert is a no-op
-		// and only joinedAt ($set) is corrected — read state stays untouched.
-		if err := h.store.BulkCreateSubscriptions(ctx, refreshSubs); err != nil {
+	if len(joinedAtFixes) > 0 {
+		if err := h.store.BulkRefreshJoinedAt(ctx, room.ID, joinedAtFixes); err != nil {
 			return fmt.Errorf("refresh migrated joinedAt: %w", err)
 		}
 	}

--- a/room-worker/teamsroomcreate.go
+++ b/room-worker/teamsroomcreate.go
@@ -112,9 +112,11 @@ func (h *Handler) reconcileTeamsRoom(ctx context.Context, chat *model.TeamsRoomC
 		wantAccounts[member.Account] = struct{}{}
 		if existing, ok := existingByAccount[member.Account]; ok {
 			// Already a member — no add. But self-correct a joinedAt stamped before the
-			// createdDateTime fix: a joinedAt-only refresh, no re-add or re-fanout.
+			// createdDateTime fix: a joinedAt-only refresh, no re-add. A cross-site
+			// member's home-site replica is refreshed via federation (memberSite).
 			if want := chat.CreatedDateTime.UTC(); !existing.JoinedAt.Equal(want) {
 				joinedAtFixes[member.Account] = want
+				memberSite[member.Account] = existing.SiteID
 			}
 			continue
 		}
@@ -163,6 +165,11 @@ func (h *Handler) reconcileTeamsRoom(ctx context.Context, chat *model.TeamsRoomC
 	if len(joinedAtFixes) > 0 {
 		if err := h.store.BulkRefreshJoinedAt(ctx, room.ID, joinedAtFixes); err != nil {
 			return fmt.Errorf("refresh migrated joinedAt: %w", err)
+		}
+		// Federate the same correction to cross-site members' home-site replicas
+		// (the local room-site copies were just updated above).
+		if err := h.federateJoinedAtRefresh(ctx, room, joinedAtFixes, memberSite, acceptedAt); err != nil {
+			return fmt.Errorf("federate joinedAt refresh: %w", err)
 		}
 	}
 	if len(removed) > 0 {
@@ -264,11 +271,14 @@ func (h *Handler) federateTeamsMembership(ctx context.Context, room *model.Room,
 		return nil
 	}
 	evt := model.InboxMemberEvent{
-		RoomID:    room.ID,
-		RoomName:  room.Name,
-		RoomType:  room.Type,
-		SiteID:    h.siteID,
-		Accounts:  accounts,
+		RoomID:   room.ID,
+		RoomName: room.Name,
+		RoomType: room.Type,
+		SiteID:   h.siteID,
+		Accounts: accounts,
+		// Migrated JoinedAt = the chat's creation time (room.CreatedAt), so the
+		// home-site replica matches the room-site copy instead of defaulting to epoch.
+		JoinedAt:  room.CreatedAt.UnixMilli(),
 		Timestamp: acceptedAt.UnixMilli(),
 		Origin:    model.OriginTeams,
 	}
@@ -310,6 +320,39 @@ func (h *Handler) federateTeamsMembership(ctx context.Context, room *model.Room,
 		dedupID := natsutil.InboxDedupID(ctx, destSite, seed)
 		if err := h.federate(ctx, room.ID, destSite, eventType, siteData, dedupID, acceptedAt.UnixMilli()); err != nil {
 			return fmt.Errorf("federate to %s: %w", destSite, err)
+		}
+	}
+	return nil
+}
+
+// federateJoinedAtRefresh fans the joinedAt correction to each cross-site member's
+// home site so the replica matches the room-site copy (just updated locally).
+// Local-site members are skipped. joinedAt is uniform per room (chat createdDateTime);
+// the remote apply is a no-op if the replica is absent.
+func (h *Handler) federateJoinedAtRefresh(ctx context.Context, room *model.Room, joinedAtByAccount map[string]time.Time, memberSite map[string]string, acceptedAt time.Time) error {
+	bySite := make(map[string][]string)
+	for account := range joinedAtByAccount {
+		if site := memberSite[account]; site != "" && site != h.siteID {
+			bySite[site] = append(bySite[site], account)
+		}
+	}
+	for destSite, accounts := range bySite {
+		evt := model.InboxMemberEvent{
+			RoomID:    room.ID,
+			SiteID:    h.siteID,
+			Accounts:  accounts,
+			JoinedAt:  room.CreatedAt.UnixMilli(),
+			Timestamp: acceptedAt.UnixMilli(),
+			Origin:    model.OriginTeams,
+		}
+		payload, err := json.Marshal(evt)
+		if err != nil {
+			return fmt.Errorf("marshal joinedAt-refresh event (dest %s): %w", destSite, err)
+		}
+		seed := fmt.Sprintf("%s:%s:%d", room.ID, model.InboxMemberJoinedAtRefreshed, acceptedAt.UnixMilli())
+		dedupID := natsutil.InboxDedupID(ctx, destSite, seed)
+		if err := h.federate(ctx, room.ID, destSite, model.InboxMemberJoinedAtRefreshed, payload, dedupID, acceptedAt.UnixMilli()); err != nil {
+			return fmt.Errorf("federate joinedAt refresh to %s: %w", destSite, err)
 		}
 	}
 	return nil

--- a/room-worker/teamsroomcreate_test.go
+++ b/room-worker/teamsroomcreate_test.go
@@ -316,6 +316,7 @@ func TestProcessTeamsRoomCreate_FederatesJoinedAtRefreshCrossSite(t *testing.T) 
 
 	chat := model.TeamsRoomCreateChat{
 		ID:              "chat1",
+		Name:            "Project Sync",
 		Members:         []model.TeamsRoomCreateMember{{ID: "aad1", Account: "bob"}},
 		CreatedDateTime: chatCreated,
 	}
@@ -325,6 +326,11 @@ func TestProcessTeamsRoomCreate_FederatesJoinedAtRefreshCrossSite(t *testing.T) 
 	require.Len(t, fed, 1, "cross-site member gets a joinedAt-refresh federated to their home site")
 	assert.Equal(t, []string{"bob"}, fed[0].Accounts)
 	assert.Equal(t, chatCreated.UnixMilli(), fed[0].JoinedAt, "federated refresh carries the chat createdDateTime")
+
+	local := membershipEvents(t, *published, "chat.inbox.site-a.internal.member_joinedat_refreshed")
+	require.Len(t, local, 1, "local internal event published for room-site spotlight")
+	assert.Equal(t, chatCreated.UnixMilli(), local[0].JoinedAt)
+	assert.NotEmpty(t, local[0].RoomName, "internal event carries roomName so spotlight re-index preserves it")
 }
 
 // TestProcessTeamsRoomCreate_NoRefreshWhenJoinedAtCurrent: a converged re-run whose

--- a/room-worker/teamsroomcreate_test.go
+++ b/room-worker/teamsroomcreate_test.go
@@ -279,14 +279,13 @@ func TestProcessTeamsRoomCreate_RefreshesStaleJoinedAt(t *testing.T) {
 	store.EXPECT().ListByRoom(gomock.Any(), gomock.Any()).Return([]model.Subscription{
 		{User: model.SubscriptionUser{Account: "alice"}, RoomID: "chat1", SiteID: "site-a", JoinedAt: staleJoinedAt},
 	}, nil)
-	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, subs []*model.Subscription) error {
-			require.Len(t, subs, 1)
-			assert.Equal(t, "alice", subs[0].User.Account)
-			assert.Equal(t, chatCreated, subs[0].JoinedAt, "refresh sub carries the chat createdDateTime")
+	store.EXPECT().BulkRefreshJoinedAt(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, byAccount map[string]time.Time) error {
+			assert.Equal(t, map[string]time.Time{"alice": chatCreated}, byAccount,
+				"refresh corrects alice's joinedAt to the chat createdDateTime")
 			return nil
 		})
-	// No ReconcileMemberCounts / DeleteSubscriptionsByAccounts — refresh-only, converged.
+	// No BulkCreateSubscriptions / ReconcileMemberCounts / DeleteSubscriptionsByAccounts — refresh-only.
 
 	chat := model.TeamsRoomCreateChat{
 		ID:              "chat1",

--- a/room-worker/teamsroomcreate_test.go
+++ b/room-worker/teamsroomcreate_test.go
@@ -295,6 +295,38 @@ func TestProcessTeamsRoomCreate_RefreshesStaleJoinedAt(t *testing.T) {
 	require.NoError(t, h.processTeamsRoomCreate(context.Background(), teamsCreateEvent(chat)))
 }
 
+// TestProcessTeamsRoomCreate_FederatesJoinedAtRefreshCrossSite: a stale existing
+// member whose home site differs from the room site gets a member_joinedat_refreshed
+// federated to that site (carrying the chat createdDateTime), on top of the local
+// room-site correction.
+func TestProcessTeamsRoomCreate_FederatesJoinedAtRefreshCrossSite(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	h, published := newTeamsTestHandler(t, store)
+
+	chatCreated := time.Date(2023, 4, 5, 6, 7, 8, 0, time.UTC)
+	stale := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+	store.EXPECT().ListByRoom(gomock.Any(), gomock.Any()).Return([]model.Subscription{
+		{User: model.SubscriptionUser{Account: "bob"}, RoomID: "chat1", SiteID: "site-b", JoinedAt: stale}, // remote home site
+	}, nil)
+	store.EXPECT().BulkRefreshJoinedAt(gomock.Any(), gomock.Any(),
+		map[string]time.Time{"bob": chatCreated}).Return(nil)
+
+	chat := model.TeamsRoomCreateChat{
+		ID:              "chat1",
+		Members:         []model.TeamsRoomCreateMember{{ID: "aad1", Account: "bob"}},
+		CreatedDateTime: chatCreated,
+	}
+	require.NoError(t, h.processTeamsRoomCreate(context.Background(), teamsCreateEvent(chat)))
+
+	fed := membershipEvents(t, *published, "chat.outbox.site-a.site-b.member_joinedat_refreshed")
+	require.Len(t, fed, 1, "cross-site member gets a joinedAt-refresh federated to their home site")
+	assert.Equal(t, []string{"bob"}, fed[0].Accounts)
+	assert.Equal(t, chatCreated.UnixMilli(), fed[0].JoinedAt, "federated refresh carries the chat createdDateTime")
+}
+
 // TestProcessTeamsRoomCreate_NoRefreshWhenJoinedAtCurrent: a converged re-run whose
 // existing joinedAt already equals the chat createdDateTime writes nothing.
 func TestProcessTeamsRoomCreate_NoRefreshWhenJoinedAtCurrent(t *testing.T) {

--- a/room-worker/teamsroomcreate_test.go
+++ b/room-worker/teamsroomcreate_test.go
@@ -263,6 +263,61 @@ func TestProcessTeamsRoomCreate_IdempotentNoOp(t *testing.T) {
 	assert.Empty(t, *published, "converged room should publish nothing")
 }
 
+// TestProcessTeamsRoomCreate_RefreshesStaleJoinedAt: a re-run against an existing
+// member whose joinedAt predates the createdDateTime fix corrects it to the chat's
+// createdDateTime via the (roomId, account) upsert — no add, no delete, no member-
+// count churn.
+func TestProcessTeamsRoomCreate_RefreshesStaleJoinedAt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	h, _ := newTeamsTestHandler(t, store)
+
+	chatCreated := time.Date(2023, 4, 5, 6, 7, 8, 0, time.UTC)
+	staleJoinedAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) // old migration-run time
+
+	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+	store.EXPECT().ListByRoom(gomock.Any(), gomock.Any()).Return([]model.Subscription{
+		{User: model.SubscriptionUser{Account: "alice"}, RoomID: "chat1", SiteID: "site-a", JoinedAt: staleJoinedAt},
+	}, nil)
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, subs []*model.Subscription) error {
+			require.Len(t, subs, 1)
+			assert.Equal(t, "alice", subs[0].User.Account)
+			assert.Equal(t, chatCreated, subs[0].JoinedAt, "refresh sub carries the chat createdDateTime")
+			return nil
+		})
+	// No ReconcileMemberCounts / DeleteSubscriptionsByAccounts — refresh-only, converged.
+
+	chat := model.TeamsRoomCreateChat{
+		ID:              "chat1",
+		Members:         []model.TeamsRoomCreateMember{{ID: "aad1", Account: "alice"}},
+		CreatedDateTime: chatCreated,
+	}
+	require.NoError(t, h.processTeamsRoomCreate(context.Background(), teamsCreateEvent(chat)))
+}
+
+// TestProcessTeamsRoomCreate_NoRefreshWhenJoinedAtCurrent: a converged re-run whose
+// existing joinedAt already equals the chat createdDateTime writes nothing.
+func TestProcessTeamsRoomCreate_NoRefreshWhenJoinedAtCurrent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	h, _ := newTeamsTestHandler(t, store)
+
+	chatCreated := time.Date(2023, 4, 5, 6, 7, 8, 0, time.UTC)
+	store.EXPECT().CreateRoom(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+	store.EXPECT().ListByRoom(gomock.Any(), gomock.Any()).Return([]model.Subscription{
+		{User: model.SubscriptionUser{Account: "alice"}, RoomID: "chat1", SiteID: "site-a", JoinedAt: chatCreated},
+	}, nil)
+	// No BulkCreateSubscriptions — joinedAt already current, nothing to write.
+
+	chat := model.TeamsRoomCreateChat{
+		ID:              "chat1",
+		Members:         []model.TeamsRoomCreateMember{{ID: "aad1", Account: "alice"}},
+		CreatedDateTime: chatCreated,
+	}
+	require.NoError(t, h.processTeamsRoomCreate(context.Background(), teamsCreateEvent(chat)))
+}
+
 // TestProcessTeamsRoomCreate_PerChatIsolation: one chat's reconcile error is
 // logged and skipped; the batch still succeeds (no Nak) and the sibling chat's
 // reconcile still runs.

--- a/search-sync-worker/spotlight.go
+++ b/search-sync-worker/spotlight.go
@@ -83,7 +83,10 @@ func (c *spotlightCollection) BuildAction(data []byte) ([]searchengine.BulkActio
 		docID := fmt.Sprintf("%s_%s", account, payload.RoomID)
 
 		switch evt.Type {
-		case model.InboxMemberAdded:
+		// A joinedAt refresh re-indexes the same doc with the corrected joinedAt;
+		// the event carries roomName/roomType so the full re-index preserves them,
+		// and its newer timestamp wins the version guard.
+		case model.InboxMemberAdded, model.InboxMemberJoinedAtRefreshed:
 			doc := newSpotlightSearchIndex(account, payload)
 			body, err := json.Marshal(doc)
 			if err != nil {

--- a/search-sync-worker/spotlight_test.go
+++ b/search-sync-worker/spotlight_test.go
@@ -85,8 +85,10 @@ func TestSpotlightCollection_Metadata(t *testing.T) {
 	assert.ElementsMatch(t, []string{
 		"chat.inbox.site-a.internal.member_added",
 		"chat.inbox.site-a.internal.member_removed",
+		"chat.inbox.site-a.internal.member_joinedat_refreshed",
 		"chat.inbox.site-a.external.member_added",
 		"chat.inbox.site-a.external.member_removed",
+		"chat.inbox.site-a.external.member_joinedat_refreshed",
 	}, filters)
 }
 
@@ -151,6 +153,26 @@ func TestSpotlightCollection_BuildAction_MemberAdded(t *testing.T) {
 	assert.Equal(t, "engineering", doc["roomName"])
 	assert.Equal(t, "channel", doc["roomType"])
 	assert.Equal(t, "site-a", doc["siteId"])
+}
+
+func TestSpotlightCollection_BuildAction_JoinedAtRefreshed(t *testing.T) {
+	coll := newSpotlightCollection("spotlight-site-a-v1-chat", false)
+	payload := baseInboxMemberEvent()
+	payload.JoinedAt = time.Date(2023, 4, 5, 6, 7, 8, 0, time.UTC).UnixMilli()
+	data := makeInboxMemberEvent(t, model.InboxMemberJoinedAtRefreshed, payload, 2000)
+
+	actions, err := coll.BuildAction(data)
+	require.NoError(t, err)
+	require.Len(t, actions, 1)
+
+	action := actions[0]
+	assert.Equal(t, searchengine.ActionIndex, action.Action, "refresh re-indexes the spotlight doc")
+	assert.Equal(t, "alice_r-eng", action.DocID)
+	assert.Equal(t, int64(2000), action.Version, "refresh's newer timestamp wins the version guard")
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(action.Doc, &doc))
+	assert.Equal(t, "2023-04-05T06:07:08Z", doc["joinedAt"], "joinedAt re-indexed to the corrected value")
+	assert.Equal(t, "engineering", doc["roomName"], "roomName preserved (event carries it)")
 }
 
 func TestSpotlightCollection_BuildAction_IndexesBotsAndAdmin(t *testing.T) {

--- a/search-sync-worker/user_room.go
+++ b/search-sync-worker/user_room.go
@@ -92,6 +92,10 @@ func (c *userRoomCollection) BuildAction(data []byte) ([]searchengine.BulkAction
 				DocID:  account,
 				Doc:    body,
 			})
+		case model.InboxMemberJoinedAtRefreshed:
+			// joinedAt is not in the user-room index (only membership + the ordering
+			// guard); a refresh changes neither, so there's nothing to update here.
+			continue
 		default:
 			return nil, fmt.Errorf("build user-room action: unsupported event type %q", evt.Type)
 		}

--- a/search-sync-worker/user_room_test.go
+++ b/search-sync-worker/user_room_test.go
@@ -35,8 +35,10 @@ func TestUserRoomCollection_Metadata(t *testing.T) {
 	assert.ElementsMatch(t, []string{
 		"chat.inbox.site-a.internal.member_added",
 		"chat.inbox.site-a.internal.member_removed",
+		"chat.inbox.site-a.internal.member_joinedat_refreshed",
 		"chat.inbox.site-a.external.member_added",
 		"chat.inbox.site-a.external.member_removed",
+		"chat.inbox.site-a.external.member_joinedat_refreshed",
 	}, filters)
 }
 
@@ -137,6 +139,16 @@ func TestUserRoomCollection_BuildAction_MemberAdded(t *testing.T) {
 	roomTimestamps := upsert["roomTimestamps"].(map[string]any)
 	assert.Equal(t, float64(ts), roomTimestamps["r-eng"])
 	assert.NotEmpty(t, upsert["createdAt"])
+}
+
+func TestUserRoomCollection_BuildAction_JoinedAtRefreshedIsNoOp(t *testing.T) {
+	coll := newUserRoomCollection("user-room-site-a", false)
+	payload := baseInboxMemberEvent()
+	data := makeInboxMemberEvent(t, model.InboxMemberJoinedAtRefreshed, payload, 2000)
+
+	actions, err := coll.BuildAction(data)
+	require.NoError(t, err)
+	assert.Empty(t, actions, "joinedAt is not in the user-room index; a refresh changes nothing here")
 }
 
 func TestUserRoomCollection_BuildAction_IndexesBotsAndAdmin(t *testing.T) {


### PR DESCRIPTION
## Summary
Migrated subscriptions self-correct their `joinedAt` on a migration replay. Previously `BulkCreateSubscriptions` wrote the whole sub under `$setOnInsert`, so a sub first-inserted before the `createdDateTime` fix kept its stale migration-time `joinedAt` even when the batch was re-run. Now `joinedAt` is written via `$set`, and the Teams reconcile refreshes an already-present member whose `joinedAt` is stale — without re-adding, re-keying, or re-fanning-out.

## Changes
- `room-worker/store_mongo.go` — `BulkCreateSubscriptions` moves `joinedAt` from `$setOnInsert` into `$set` (via a small `bsonMExcept` marshal-and-remove, since a field can't be in both). On an existing `(roomId, u.account)` doc the `$setOnInsert` is a no-op, so `_id`, read state (`lastSeenAt`), roles and section are preserved and only `joinedAt` converges. `joinedAt` is deterministic from the event/chat and is not read-state, so overwriting it on every write is safe.
- `room-worker/teamsroomcreate.go` — `reconcileTeamsRoom` refreshes an already-present member whose `joinedAt != chat.createdDateTime` through the same upsert; unchanged members and current `joinedAt` write nothing.

## Verification
- Unit: `RefreshesStaleJoinedAt`, `NoRefreshWhenJoinedAtCurrent` (reconcile); `BulkCreateSubscriptions_UpsertRefreshesJoinedAt` (asserts `_id` + `lastSeenAt` + roles preserved, `joinedAt` refreshed), `BulkCreateSubscriptions_InsertSetsJoinedAt` (integration).
- Verified on our dev stack: publish a migrated room, force a stale `joinedAt` on a sub, replay the batch → `joinedAt` corrected to the chat's `createdDateTime` and the sub's read state preserved.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Corrected member join timestamps during Teams room reconciliation.
  * Propagated timestamp corrections across sites for existing room subscriptions.
  * Added support for processing joined-time refresh events.
  * Preserved subscription details and ignored accounts without existing subscriptions.

* **Bug Fixes**
  * Prevented stale `joinedAt` values from persisting after room reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->