### PR TITLE
fix(search-sync): re-index spotlight room name on rename

### DIFF
--- a/pkg/searchengine/adapter.go
+++ b/pkg/searchengine/adapter.go
@@ -262,24 +262,33 @@ func (a *httpAdapter) UpdateByQuery(ctx context.Context, index string, body json
 	}
 	defer resp.Body.Close()
 
-	respBody, readErr := io.ReadAll(resp.Body)
+	// Bound the response read: a large per-doc failures array or a rogue proxy
+	// body shouldn't let io.ReadAll allocate without limit.
+	const maxRespBytes = 1 << 20 // 1 MiB
+	respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, maxRespBytes))
 	if readErr != nil {
 		return fmt.Errorf("update by query: status %d, read body: %w", resp.StatusCode, readErr)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("update by query: status %d, body: %s", resp.StatusCode, respBody)
 	}
-	// A 200 can still carry per-doc failures or a server-side timeout; surface
-	// them so the caller Naks and retries (idempotent), matching the bulk path.
+	// A 200 can still carry per-doc failures, a server-side timeout, or (with
+	// conflicts=proceed) documents skipped on a concurrent version bump — surface
+	// all three so the caller Naks and retries. The retry is safe because the
+	// script guards on roomNameUpdatedAt (idempotent + order-independent).
 	var r struct {
-		TimedOut bool              `json:"timed_out"`
-		Failures []json.RawMessage `json:"failures"`
+		TimedOut         bool              `json:"timed_out"`
+		VersionConflicts int64             `json:"version_conflicts"`
+		Failures         []json.RawMessage `json:"failures"`
 	}
 	if err := json.Unmarshal(respBody, &r); err != nil {
 		return fmt.Errorf("update by query: decode response: %w", err)
 	}
 	if r.TimedOut {
 		return fmt.Errorf("update by query: timed out")
+	}
+	if r.VersionConflicts > 0 {
+		return fmt.Errorf("update by query: %d version conflict(s)", r.VersionConflicts)
 	}
 	if len(r.Failures) > 0 {
 		return fmt.Errorf("update by query: %d failure(s): %s", len(r.Failures), respBody)

--- a/pkg/searchengine/adapter.go
+++ b/pkg/searchengine/adapter.go
@@ -242,6 +242,51 @@ func (a *httpAdapter) UpdateMapping(ctx context.Context, indexPattern string, bo
 	return nil
 }
 
+// UpdateByQuery POSTs a painless `_update_by_query` to a single index with
+// conflicts=proceed (a concurrent version bump skips that doc, not the batch).
+func (a *httpAdapter) UpdateByQuery(ctx context.Context, index string, body json.RawMessage) error {
+	if index == "" {
+		return fmt.Errorf("update by query: index required")
+	}
+	path := fmt.Sprintf("/%s/_update_by_query?conflicts=proceed", url.PathEscape(index))
+	resp, err := a.do(ctx, "update_by_query", index, func(ctx context.Context) (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, path, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	})
+	if err != nil {
+		return fmt.Errorf("update by query: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return fmt.Errorf("update by query: status %d, read body: %w", resp.StatusCode, readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("update by query: status %d, body: %s", resp.StatusCode, respBody)
+	}
+	// A 200 can still carry per-doc failures or a server-side timeout; surface
+	// them so the caller Naks and retries (idempotent), matching the bulk path.
+	var r struct {
+		TimedOut bool              `json:"timed_out"`
+		Failures []json.RawMessage `json:"failures"`
+	}
+	if err := json.Unmarshal(respBody, &r); err != nil {
+		return fmt.Errorf("update by query: decode response: %w", err)
+	}
+	if r.TimedOut {
+		return fmt.Errorf("update by query: timed out")
+	}
+	if len(r.Failures) > 0 {
+		return fmt.Errorf("update by query: %d failure(s): %s", len(r.Failures), respBody)
+	}
+	return nil
+}
+
 func (a *httpAdapter) PutScript(ctx context.Context, id string, body json.RawMessage) error {
 	resp, err := a.do(ctx, "put_script", "", func(ctx context.Context) (*http.Request, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPut, fmt.Sprintf("/_scripts/%s", id), bytes.NewReader(body))

--- a/pkg/searchengine/adapter_test.go
+++ b/pkg/searchengine/adapter_test.go
@@ -387,3 +387,58 @@ func TestAdapter_GetIndexMapping(t *testing.T) {
 		assert.Nil(t, mapping)
 	})
 }
+
+func TestAdapter_UpdateByQuery(t *testing.T) {
+	okBody := `{"query":{"term":{"roomId":"r1"}},"script":{"source":"ctx._source.roomName = params.name"}}`
+
+	t.Run("success", func(t *testing.T) {
+		var captured string
+		ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+			assert.Equal(t, http.MethodPost, req.Method)
+			assert.Equal(t, "/spotlight-site1/_update_by_query", req.URL.Path)
+			assert.Equal(t, "proceed", req.URL.Query().Get("conflicts"))
+			body, _ := io.ReadAll(req.Body)
+			captured = string(body)
+			return jsonResponse(200, `{"updated":3,"timed_out":false,"failures":[]}`), nil
+		}}
+		err := newAdapter(ft).UpdateByQuery(context.Background(), "spotlight-site1", json.RawMessage(okBody))
+		require.NoError(t, err)
+		assert.JSONEq(t, okBody, captured)
+	})
+
+	t.Run("error status", func(t *testing.T) {
+		ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(404, `{"error":"index_not_found_exception"}`), nil
+		}}
+		err := newAdapter(ft).UpdateByQuery(context.Background(), "spotlight-site1", json.RawMessage(okBody))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "404")
+	})
+
+	t.Run("200 with timed_out errors", func(t *testing.T) {
+		ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(200, `{"timed_out":true,"failures":[]}`), nil
+		}}
+		err := newAdapter(ft).UpdateByQuery(context.Background(), "spotlight-site1", json.RawMessage(okBody))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "timed out")
+	})
+
+	t.Run("200 with failures errors", func(t *testing.T) {
+		ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(200, `{"timed_out":false,"failures":[{"cause":{"type":"version_conflict_engine_exception"}}]}`), nil
+		}}
+		err := newAdapter(ft).UpdateByQuery(context.Background(), "spotlight-site1", json.RawMessage(okBody))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failure")
+	})
+
+	t.Run("empty index rejected", func(t *testing.T) {
+		a := newAdapter(&fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+			t.Fatal("no request expected for empty index")
+			return nil, nil
+		}})
+		err := a.UpdateByQuery(context.Background(), "", json.RawMessage(okBody))
+		assert.Error(t, err)
+	})
+}

--- a/pkg/searchengine/adapter_test.go
+++ b/pkg/searchengine/adapter_test.go
@@ -433,6 +433,15 @@ func TestAdapter_UpdateByQuery(t *testing.T) {
 		assert.Contains(t, err.Error(), "failure")
 	})
 
+	t.Run("200 with version_conflicts errors (Nak + retry)", func(t *testing.T) {
+		ft := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+			return jsonResponse(200, `{"updated":2,"version_conflicts":1,"timed_out":false,"failures":[]}`), nil
+		}}
+		err := newAdapter(ft).UpdateByQuery(context.Background(), "spotlight-site1", json.RawMessage(okBody))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "version conflict")
+	})
+
 	t.Run("empty index rejected", func(t *testing.T) {
 		a := newAdapter(&fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
 			t.Fatal("no request expected for empty index")

--- a/pkg/searchengine/searchengine.go
+++ b/pkg/searchengine/searchengine.go
@@ -69,6 +69,14 @@ type SearchEngine interface {
 	// matching pattern; templates apply only at creation, existing indices need this.
 	UpdateMapping(ctx context.Context, indexPattern string, body json.RawMessage) error
 
+	// UpdateByQuery runs a painless `_update_by_query` against index with the
+	// given request body (query + script). It mutates every matching document,
+	// so callers use it for field-keyed multi-doc updates the DocID-keyed Bulk
+	// API can't express — e.g. re-indexing roomName on every member's spotlight
+	// doc after a room rename. Runs with conflicts=proceed so a concurrent
+	// version bump skips that one doc instead of aborting the whole batch.
+	UpdateByQuery(ctx context.Context, index string, body json.RawMessage) error
+
 	GetIndexMapping(ctx context.Context, index string) (json.RawMessage, error)
 
 	// Search executes a `_search` against the comma-joined list of indices

--- a/pkg/searchindex/spotlightdoc.go
+++ b/pkg/searchindex/spotlightdoc.go
@@ -12,6 +12,10 @@ type SpotlightDoc struct {
 	RoomType    string    `json:"roomType"    es:"keyword"`
 	SiteID      string    `json:"siteId"      es:"keyword"`
 	JoinedAt    time.Time `json:"joinedAt"    es:"date"`
+	// RoomNameUpdatedAt is the event-millis under which RoomName is valid — the
+	// LWW clock a room_renamed update-by-query guards on so an out-of-order rename
+	// can't overwrite a newer name. Stamped = the member/rename event timestamp.
+	RoomNameUpdatedAt int64 `json:"roomNameUpdatedAt" es:"long"`
 	// Origin marks provenance (e.g. model.OriginTeams for Teams-migrated
 	// rooms); empty for natively-created rooms. Filtered by search-service
 	// when SHOW_TEAMS_ROOM is false.
@@ -20,13 +24,14 @@ type SpotlightDoc struct {
 
 // SpotlightFields is the minimal, source-agnostic input to NewSpotlightDoc.
 type SpotlightFields struct {
-	UserAccount string
-	RoomID      string
-	RoomName    string
-	RoomType    string
-	SiteID      string
-	JoinedAt    time.Time
-	Origin      string
+	UserAccount       string
+	RoomID            string
+	RoomName          string
+	RoomType          string
+	SiteID            string
+	JoinedAt          time.Time
+	RoomNameUpdatedAt int64
+	Origin            string
 }
 
 // NewSpotlightDoc builds the ES document for the spotlight index from f.

--- a/pkg/searchindex/spotlightdoc_test.go
+++ b/pkg/searchindex/spotlightdoc_test.go
@@ -13,12 +13,14 @@ func TestNewSpotlightDoc(t *testing.T) {
 	joinedAt := time.Date(2026, 7, 24, 9, 0, 0, 0, time.UTC)
 
 	doc := searchindex.NewSpotlightDoc(searchindex.SpotlightFields{
-		UserAccount: "alice",
-		RoomID:      "room1",
-		RoomName:    "general",
-		RoomType:    "channel",
-		SiteID:      "site-a",
-		JoinedAt:    joinedAt,
+		UserAccount:       "alice",
+		RoomID:            "room1",
+		RoomName:          "general",
+		RoomType:          "channel",
+		SiteID:            "site-a",
+		JoinedAt:          joinedAt,
+		RoomNameUpdatedAt: 1723800000000,
+		Origin:            "teams",
 	})
 
 	assert.Equal(t, "alice", doc.UserAccount)
@@ -27,6 +29,9 @@ func TestNewSpotlightDoc(t *testing.T) {
 	assert.Equal(t, "channel", doc.RoomType)
 	assert.Equal(t, "site-a", doc.SiteID)
 	assert.True(t, doc.JoinedAt.Equal(joinedAt))
+	// The struct conversion must carry the LWW clock + origin, not drop them.
+	assert.Equal(t, int64(1723800000000), doc.RoomNameUpdatedAt)
+	assert.Equal(t, "teams", doc.Origin)
 }
 
 func TestNewSpotlightDoc_ZeroJoinedAt(t *testing.T) {

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -309,18 +309,22 @@ func InboxExternalAll(siteID string) string {
 	return fmt.Sprintf("chat.inbox.%s.external.>", siteID)
 }
 
-// InboxMemberEventSubjects returns the subject filters a consumer should use to
-// receive member_added/member_removed events on both the internal (same-site)
-// and external (cross-site) lanes for the given site. Use with
+// InboxMemberEventSubjects returns the subject filters a search-sync consumer
+// should use to receive the room-index-affecting events on both the internal
+// (same-site) and external (cross-site) lanes for the given site:
+// member_added/member_removed (per-member docs) and room_renamed (re-index the
+// room name across every member's doc). Use with
 // jetstream.ConsumerConfig.FilterSubjects (NATS 2.10+).
 func InboxMemberEventSubjects(siteID string) []string {
 	return []string{
 		InboxInternal(siteID, "member_added"),
 		InboxInternal(siteID, "member_removed"),
 		InboxInternal(siteID, "member_joinedat_refreshed"),
+		InboxInternal(siteID, "room_renamed"),
 		InboxExternal(siteID, "member_added"),
 		InboxExternal(siteID, "member_removed"),
 		InboxExternal(siteID, "member_joinedat_refreshed"),
+		InboxExternal(siteID, "room_renamed"),
 	}
 }
 

--- a/pkg/subject/subject_test.go
+++ b/pkg/subject/subject_test.go
@@ -230,14 +230,7 @@ func TestSubjectBuilders(t *testing.T) {
 			"chat.inbox.site-a.external.member_joinedat_refreshed",
 			"chat.inbox.site-a.external.room_renamed",
 		}
-		if len(got) != len(want) {
-			t.Fatalf("got %d subjects, want %d", len(got), len(want))
-		}
-		for i := range want {
-			if got[i] != want[i] {
-				t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
-			}
-		}
+		require.Equal(t, want, got)
 	})
 }
 

--- a/pkg/subject/subject_test.go
+++ b/pkg/subject/subject_test.go
@@ -224,9 +224,11 @@ func TestSubjectBuilders(t *testing.T) {
 			"chat.inbox.site-a.internal.member_added",
 			"chat.inbox.site-a.internal.member_removed",
 			"chat.inbox.site-a.internal.member_joinedat_refreshed",
+			"chat.inbox.site-a.internal.room_renamed",
 			"chat.inbox.site-a.external.member_added",
 			"chat.inbox.site-a.external.member_removed",
 			"chat.inbox.site-a.external.member_joinedat_refreshed",
+			"chat.inbox.site-a.external.room_renamed",
 		}
 		if len(got) != len(want) {
 			t.Fatalf("got %d subjects, want %d", len(got), len(want))

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -2358,13 +2358,14 @@ func (h *Handler) processRoomRename(ctx context.Context, data []byte) (err error
 	if err != nil {
 		return fmt.Errorf("marshal internal rename event: %w", err)
 	}
-	// Return on failure so the ROOMS message redelivers rather than silently
-	// losing the spotlight re-index (for a single-site room there is no OUTBOX
-	// federate to cover it). Safe to retry: the publish carries a requestID-keyed
-	// dedup id, the sys message a deterministic id, and UpdateRoomName is an
-	// idempotent set — a redelivery re-runs them all without duplicating.
+	// Best-effort: log, don't Nak. Returning here would redeliver the whole
+	// handler, and UpdateRoomName / UpdateSubscriptionNamesForRoom (already
+	// committed above) are unconditional writes — a redelivered stale rename
+	// would revert newer canonical state. The spotlight re-index is a derived
+	// cache; a rare missed publish self-corrects on the next rename/membership
+	// event and is far cheaper than risking source-of-truth reversion.
 	if err := h.publish(ctx, subject.InboxInternal(h.siteID, model.InboxRoomRenamed), internalRenameData, natsutil.InboxDedupID(ctx, h.siteID, requestID)); err != nil {
-		return fmt.Errorf("publish local inbox room_renamed: %w", err)
+		slog.ErrorContext(ctx, "local inbox room_renamed publish failed (best-effort)", "error", err, "room_id", req.RoomID)
 	}
 	// Relay room_renamed through the OUTBOX ordered lane (not a direct INBOX
 	// publish) so it shares the per-destination FIFO consumer with member_added

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -2354,9 +2354,17 @@ func (h *Handler) processRoomRename(ctx context.Context, data []byte) (err error
 		Payload:    renamedPayload,
 		Timestamp:  now,
 	}
-	internalRenameData, _ := json.Marshal(internalRename)
+	internalRenameData, err := json.Marshal(internalRename)
+	if err != nil {
+		return fmt.Errorf("marshal internal rename event: %w", err)
+	}
+	// Return on failure so the ROOMS message redelivers rather than silently
+	// losing the spotlight re-index (for a single-site room there is no OUTBOX
+	// federate to cover it). Safe to retry: the publish carries a requestID-keyed
+	// dedup id, the sys message a deterministic id, and UpdateRoomName is an
+	// idempotent set — a redelivery re-runs them all without duplicating.
 	if err := h.publish(ctx, subject.InboxInternal(h.siteID, model.InboxRoomRenamed), internalRenameData, natsutil.InboxDedupID(ctx, h.siteID, requestID)); err != nil {
-		slog.ErrorContext(ctx, "local inbox room_renamed publish failed", "error", err, "room_id", req.RoomID)
+		return fmt.Errorf("publish local inbox room_renamed: %w", err)
 	}
 	// Relay room_renamed through the OUTBOX ordered lane (not a direct INBOX
 	// publish) so it shares the per-destination FIFO consumer with member_added

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -2342,6 +2342,22 @@ func (h *Handler) processRoomRename(ctx context.Context, data []byte) (err error
 	if err != nil {
 		return fmt.Errorf("marshal rename inbox payload: %w", err)
 	}
+	now := time.Now().UTC().UnixMilli()
+	// Same-site search feed: search-sync re-indexes the room name from this
+	// internal-lane event (mirrors the member_added/removed internal publish).
+	// Cross-site members are covered by the OUTBOX federate below; a single-site
+	// rename has no remote sites, so without this the spotlight index goes stale.
+	internalRename := model.InboxEvent{
+		Type:       model.InboxRoomRenamed,
+		SiteID:     h.siteID,
+		DestSiteID: h.siteID,
+		Payload:    renamedPayload,
+		Timestamp:  now,
+	}
+	internalRenameData, _ := json.Marshal(internalRename)
+	if err := h.publish(ctx, subject.InboxInternal(h.siteID, model.InboxRoomRenamed), internalRenameData, natsutil.InboxDedupID(ctx, h.siteID, requestID)); err != nil {
+		slog.ErrorContext(ctx, "local inbox room_renamed publish failed", "error", err, "room_id", req.RoomID)
+	}
 	// Relay room_renamed through the OUTBOX ordered lane (not a direct INBOX
 	// publish) so it shares the per-destination FIFO consumer with member_added
 	// and cannot overtake the add that creates a new member's subscription — a
@@ -2350,7 +2366,6 @@ func (h *Handler) processRoomRename(ctx context.Context, data []byte) (err error
 	// per-room ordering, so member.add and room.rename (separate ROOMS messages,
 	// concurrent workers) can still enqueue out of causal order. Full ordering
 	// awaits producer per-room lanes / reconciliation (design doc §5, §7).
-	now := time.Now().UTC().UnixMilli()
 	for _, remoteSiteID := range remoteSites {
 		if err := h.federate(ctx, req.RoomID, remoteSiteID, model.InboxRoomRenamed,
 			renamedPayload, natsutil.InboxDedupID(ctx, remoteSiteID, requestID), now); err != nil {

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -6727,6 +6727,50 @@ func TestProcessRoomRename_PublishesRoomRenamedEvent(t *testing.T) {
 	assert.Positive(t, renamed.Timestamp)
 }
 
+// The same-site search feed (internal INBOX lane) must carry room_renamed so
+// search-sync re-indexes the spotlight room name even when there are no remote
+// members — mirrors the member_added/removed internal publish.
+func TestProcessRoomRename_PublishesInternalSearchFeed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	store := NewMockSubscriptionStore(ctrl)
+
+	const roomID, newName = "r1", "renamed"
+	requestID := testRequestID
+	ts := int64(1700000000000)
+
+	store.EXPECT().UpdateRoomName(gomock.Any(), roomID, newName).Return(nil)
+	store.EXPECT().UpdateSubscriptionNamesForRoom(gomock.Any(), roomID, newName, gomock.Any()).Return(nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
+	store.EXPECT().ListByRoom(gomock.Any(), roomID).Return(nil, nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), roomID).Return(&model.Room{ID: roomID}, nil)
+
+	var feed [][]byte
+	publish := func(_ context.Context, subj string, data []byte, _ string) error {
+		if subj == subject.InboxInternal("site-a", model.InboxRoomRenamed) {
+			feed = append(feed, data)
+		}
+		return nil
+	}
+
+	h := &Handler{store: store, siteID: "site-a", publish: publish}
+	ctx := natsutil.WithRequestID(context.Background(), requestID)
+	body, _ := json.Marshal(model.RenameRoomRequest{RoomID: roomID, NewName: newName, Account: "alice", Timestamp: ts})
+
+	require.NoError(t, h.processRoomRename(ctx, body))
+
+	require.Len(t, feed, 1, "same-site search feed must carry exactly one room_renamed")
+	var evt model.InboxEvent
+	require.NoError(t, json.Unmarshal(feed[0], &evt))
+	assert.Equal(t, model.InboxRoomRenamed, evt.Type)
+	assert.Equal(t, "site-a", evt.SiteID)
+	var p model.RoomRenamedInboxPayload
+	require.NoError(t, json.Unmarshal(evt.Payload, &p))
+	assert.Equal(t, roomID, p.RoomID)
+	assert.Equal(t, newName, p.NewName)
+	assert.Equal(t, ts, p.Timestamp)
+}
+
 // Test 7: Happy path no remote sites.
 func TestProcessRoomRename_HappyPathNoRemoteSites(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/search-sync-worker/collection.go
+++ b/search-sync-worker/collection.go
@@ -41,3 +41,13 @@ type Collection interface {
 	// e.g. filtered).
 	BuildAction(data []byte) ([]searchengine.BulkAction, error)
 }
+
+// ByQueryCollection is an optional Collection capability for events that mutate
+// many documents keyed by a field rather than by DocID — a shape the DocID-keyed
+// Bulk API can't express. A collection implementing it gets first crack at a
+// message: ok=true means "I handled it as one _update_by_query against index";
+// ok=false falls through to the normal BuildAction bulk path. Spotlight uses it
+// for room_renamed (re-index roomName across every member's doc).
+type ByQueryCollection interface {
+	BuildByQuery(data []byte) (index string, body json.RawMessage, ok bool, err error)
+}

--- a/search-sync-worker/handler.go
+++ b/search-sync-worker/handler.go
@@ -102,15 +102,18 @@ func (h *Handler) AddWithContext(ctx context.Context, msg jetstream.Msg) {
 			// Parse/validation poison — Ack drops it (same as BuildAction).
 			slog.ErrorContext(ctx, "build by-query", "error", bqErr, "subject", msg.Subject(), "consumer", h.collection.ConsumerName())
 			natsutil.Ack(msg, "build by-query failed")
+			h.metrics.recordMessages(ctx, dispAckedPoison, 1)
 			return
 		}
 		if ok {
 			if err := h.store.UpdateByQuery(ctx, index, body); err != nil {
 				slog.ErrorContext(ctx, "update-by-query failed", "error", err, "index", index, "consumer", h.collection.ConsumerName())
 				natsutil.Nak(msg, "update-by-query failed")
+				h.metrics.recordMessages(ctx, dispNakkedRequestFailed, 1)
 				return
 			}
 			natsutil.Ack(msg, "update-by-query succeeded")
+			h.metrics.recordMessages(ctx, dispAckedSuccess, 1)
 			return
 		}
 	}

--- a/search-sync-worker/handler.go
+++ b/search-sync-worker/handler.go
@@ -90,6 +90,31 @@ func (h *Handler) AddWithContext(ctx context.Context, msg jetstream.Msg) {
 		h.metrics.recordMessages(ctx, dispAckedPoison, 1)
 		return
 	}
+
+	// By-query events (e.g. room rename) mutate many docs by field, not by
+	// DocID, so they can't ride the bulk buffer — apply each as a standalone
+	// _update_by_query and ack/nak it on its own. A collection that doesn't
+	// implement ByQueryCollection, or a message it doesn't claim (ok=false),
+	// falls through to the normal bulk path.
+	if bq, isBQ := h.collection.(ByQueryCollection); isBQ {
+		index, body, ok, bqErr := bq.BuildByQuery(data)
+		if bqErr != nil {
+			// Parse/validation poison — Ack drops it (same as BuildAction).
+			slog.ErrorContext(ctx, "build by-query", "error", bqErr, "subject", msg.Subject(), "consumer", h.collection.ConsumerName())
+			natsutil.Ack(msg, "build by-query failed")
+			return
+		}
+		if ok {
+			if err := h.store.UpdateByQuery(ctx, index, body); err != nil {
+				slog.ErrorContext(ctx, "update-by-query failed", "error", err, "index", index, "consumer", h.collection.ConsumerName())
+				natsutil.Nak(msg, "update-by-query failed")
+				return
+			}
+			natsutil.Ack(msg, "update-by-query succeeded")
+			return
+		}
+	}
+
 	actions, err := h.collection.BuildAction(data)
 	if err != nil {
 		// Every BuildAction error is parse/validation poison — Ack drops it for

--- a/search-sync-worker/handler_test.go
+++ b/search-sync-worker/handler_test.go
@@ -79,6 +79,42 @@ func TestHandler_Add_MalformedJSON(t *testing.T) {
 	assert.True(t, msg.acked)
 }
 
+func TestHandler_Add_RoomRenamed_UpdateByQuery(t *testing.T) {
+	renameData := func(t *testing.T) []byte {
+		t.Helper()
+		p, err := json.Marshal(model.RoomRenamedInboxPayload{RoomID: "r-eng", NewName: "platform", Timestamp: 9000})
+		require.NoError(t, err)
+		evt := model.InboxEvent{Type: model.InboxRoomRenamed, SiteID: "site-a", DestSiteID: "site-a", Payload: p, Timestamp: 9000}
+		data, err := json.Marshal(evt)
+		require.NoError(t, err)
+		return data
+	}
+
+	t.Run("applies update-by-query and acks, bypassing the bulk buffer", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		store := NewMockStore(ctrl)
+		h := NewHandler(store, newSpotlightCollection("spotlight-site-a-v1", false), 500)
+		store.EXPECT().UpdateByQuery(gomock.Any(), "spotlight-site-a-v1", gomock.Any()).Return(nil)
+
+		msg := &stubMsg{data: renameData(t)}
+		h.Add(msg)
+		assert.True(t, msg.acked)
+		assert.False(t, msg.nacked)
+		assert.Equal(t, 0, h.MessageCount(), "by-query path must not buffer a bulk action")
+	})
+
+	t.Run("naks on update-by-query error for redelivery", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		store := NewMockStore(ctrl)
+		h := NewHandler(store, newSpotlightCollection("spotlight-site-a-v1", false), 500)
+		store.EXPECT().UpdateByQuery(gomock.Any(), gomock.Any(), gomock.Any()).Return(assert.AnError)
+
+		msg := &stubMsg{data: renameData(t)}
+		h.Add(msg)
+		assert.True(t, msg.nacked)
+	})
+}
+
 func TestHandler_Flush(t *testing.T) {
 	ts := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	baseEvt := model.MessageEvent{

--- a/search-sync-worker/inbox_stream.go
+++ b/search-sync-worker/inbox_stream.go
@@ -49,6 +49,20 @@ func (b *inboxMemberCollection) MappingUpdate() (string, json.RawMessage) {
 	return "", nil
 }
 
+// peekInboxEventType returns just the InboxEvent type tag without decoding the
+// payload, so a collection can route/skip by type before the full member-event
+// parse. Returns "" on a malformed envelope — the caller's normal parse path
+// then surfaces the decode error.
+func peekInboxEventType(data []byte) model.InboxEventType {
+	var evt struct {
+		Type model.InboxEventType `json:"type"`
+	}
+	if err := json.Unmarshal(data, &evt); err != nil {
+		return ""
+	}
+	return evt.Type
+}
+
 // parseMemberEvent decodes an INBOX message into an InboxEvent + its
 // InboxMemberEvent payload and validates the common preconditions shared by
 // all inbox-member collections.

--- a/search-sync-worker/main.go
+++ b/search-sync-worker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -497,6 +498,10 @@ type engineAdapter struct {
 
 func (a *engineAdapter) Bulk(ctx context.Context, actions []searchengine.BulkAction) ([]searchengine.BulkResult, error) {
 	return a.engine.Bulk(ctx, actions)
+}
+
+func (a *engineAdapter) UpdateByQuery(ctx context.Context, index string, body json.RawMessage) error {
+	return a.engine.UpdateByQuery(ctx, index, body)
 }
 
 // consumerSource is the subset of Collection that buildConsumerConfig needs. Narrowing keeps the helper unit-testable with a small fake.

--- a/search-sync-worker/main_test.go
+++ b/search-sync-worker/main_test.go
@@ -25,6 +25,7 @@ func (f *fakeEngine) Bulk(context.Context, []searchengine.BulkAction) ([]searche
 }
 func (f *fakeEngine) UpsertTemplate(context.Context, string, json.RawMessage) error { return nil }
 func (f *fakeEngine) PutScript(context.Context, string, json.RawMessage) error      { return nil }
+func (f *fakeEngine) UpdateByQuery(context.Context, string, json.RawMessage) error  { return nil }
 func (f *fakeEngine) UpdateMapping(_ context.Context, pattern string, _ json.RawMessage) error {
 	f.mappingPatterns = append(f.mappingPatterns, pattern)
 	return f.mappingErr

--- a/search-sync-worker/mock_store_test.go
+++ b/search-sync-worker/mock_store_test.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	context "context"
+	json "encoding/json"
 	reflect "reflect"
 
 	searchengine "github.com/hmchangw/chat/pkg/searchengine"
@@ -54,4 +55,18 @@ func (m *MockStore) Bulk(ctx context.Context, actions []searchengine.BulkAction)
 func (mr *MockStoreMockRecorder) Bulk(ctx, actions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bulk", reflect.TypeOf((*MockStore)(nil).Bulk), ctx, actions)
+}
+
+// UpdateByQuery mocks base method.
+func (m *MockStore) UpdateByQuery(ctx context.Context, index string, body json.RawMessage) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateByQuery", ctx, index, body)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateByQuery indicates an expected call of UpdateByQuery.
+func (mr *MockStoreMockRecorder) UpdateByQuery(ctx, index, body any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateByQuery", reflect.TypeOf((*MockStore)(nil).UpdateByQuery), ctx, index, body)
 }

--- a/search-sync-worker/spotlight.go
+++ b/search-sync-worker/spotlight.go
@@ -135,7 +135,10 @@ func (c *spotlightCollection) BuildByQuery(data []byte) (string, json.RawMessage
 	if p.NewName == "" {
 		return "", nil, false, fmt.Errorf("build spotlight rename: missing newName")
 	}
-	body, err := buildSpotlightRenameByQuery(p.RoomID, p.NewName)
+	if p.Timestamp <= 0 {
+		return "", nil, false, fmt.Errorf("build spotlight rename: missing timestamp")
+	}
+	body, err := buildSpotlightRenameByQuery(p.RoomID, p.NewName, p.Timestamp)
 	if err != nil {
 		return "", nil, false, fmt.Errorf("build spotlight rename: %w", err)
 	}
@@ -143,20 +146,25 @@ func (c *spotlightCollection) BuildByQuery(data []byte) (string, json.RawMessage
 }
 
 // buildSpotlightRenameByQuery is the _update_by_query that sets roomName on every
-// doc of the renamed room. Ordering caveat (v1, no guard): with out-of-order
-// renames the older name can win and persist until the next rename (a later
-// member event stamps whatever name it was born with, so it doesn't reliably
-// correct forward). Spotlight is a derived cache — the room doc is source of
-// truth — so this is stale typeahead text, never data loss. Upgrade path: add
-// roomNameUpdatedAt to SpotlightDoc + its mapping and guard the script with
-// `if (params.ts > ctx._source.roomNameUpdatedAt)`.
-func buildSpotlightRenameByQuery(roomID, newName string) (json.RawMessage, error) {
+// doc of the renamed room, guarded by roomNameUpdatedAt so an out-of-order rename
+// can't overwrite a newer name: only a strictly-newer ts wins, and it stamps the
+// clock it just advanced. A stale delivery is a no-op (updated:0), converging on
+// last-write-wins regardless of arrival order.
+//
+// Residual (bounded, documented): a member added *concurrently* with a rename can
+// have its doc created (from the member event's name snapshot) only after the
+// rename's update-by-query already ran on the then-absent doc, so that one new
+// member can see the pre-rename name until the next event touches their doc.
+// Closing it fully needs query-time room-name resolution (a room doc + join),
+// out of scope for this typeahead cache — spotlight is derived, not source of truth.
+func buildSpotlightRenameByQuery(roomID, newName string, ts int64) (json.RawMessage, error) {
 	body, err := json.Marshal(map[string]any{
 		"query": map[string]any{"term": map[string]any{"roomId": roomID}},
 		"script": map[string]any{
-			"lang":   "painless",
-			"source": "ctx._source.roomName = params.name",
-			"params": map[string]any{"name": newName},
+			"lang": "painless",
+			"source": "long stored = ctx._source.roomNameUpdatedAt == null ? 0L : ((Number)ctx._source.roomNameUpdatedAt).longValue(); " +
+				"if (params.ts > stored) { ctx._source.roomName = params.name; ctx._source.roomNameUpdatedAt = params.ts; } else { ctx.op = 'noop'; }",
+			"params": map[string]any{"name": newName, "ts": ts},
 		},
 	})
 	if err != nil {
@@ -173,7 +181,10 @@ func newSpotlightSearchIndex(account string, evt *model.InboxMemberEvent) search
 		RoomType:    string(evt.RoomType),
 		SiteID:      evt.SiteID,
 		JoinedAt:    convertJoinedAt(evt.JoinedAt),
-		Origin:      evt.Origin,
+		// Stamp the name's LWW clock so a later rename (higher ts) wins and this
+		// doc's own name can't be reverted by an older rename delivered late.
+		RoomNameUpdatedAt: evt.Timestamp,
+		Origin:            evt.Origin,
 	})
 }
 

--- a/search-sync-worker/spotlight.go
+++ b/search-sync-worker/spotlight.go
@@ -162,8 +162,11 @@ func buildSpotlightRenameByQuery(roomID, newName string, ts int64) (json.RawMess
 		"query": map[string]any{"term": map[string]any{"roomId": roomID}},
 		"script": map[string]any{
 			"lang": "painless",
+			// >= (not >) so two renames sharing a millisecond both apply (last
+			// processed wins the tie) instead of dropping the second, and a
+			// redelivery of the same rename re-applies its own name idempotently.
 			"source": "long stored = ctx._source.roomNameUpdatedAt == null ? 0L : ((Number)ctx._source.roomNameUpdatedAt).longValue(); " +
-				"if (params.ts > stored) { ctx._source.roomName = params.name; ctx._source.roomNameUpdatedAt = params.ts; } else { ctx.op = 'noop'; }",
+				"if (params.ts >= stored) { ctx._source.roomName = params.name; ctx._source.roomNameUpdatedAt = params.ts; } else { ctx.op = 'noop'; }",
 			"params": map[string]any{"name": newName, "ts": ts},
 		},
 	})

--- a/search-sync-worker/spotlight.go
+++ b/search-sync-worker/spotlight.go
@@ -113,6 +113,58 @@ func (c *spotlightCollection) BuildAction(data []byte) ([]searchengine.BulkActio
 	return actions, nil
 }
 
+// BuildByQuery handles room_renamed: roomName lives on every member's spotlight
+// doc (`{account}_{roomId}`), and the rename payload carries no account list, so
+// a single _update_by_query keyed on roomId re-indexes them all. Returns ok=false
+// for member events, which fall through to BuildAction's bulk path.
+func (c *spotlightCollection) BuildByQuery(data []byte) (string, json.RawMessage, bool, error) {
+	var evt model.InboxEvent
+	if err := json.Unmarshal(data, &evt); err != nil {
+		return "", nil, false, fmt.Errorf("unmarshal inbox event: %w", err)
+	}
+	if evt.Type != model.InboxRoomRenamed {
+		return "", nil, false, nil
+	}
+	var p model.RoomRenamedInboxPayload
+	if err := json.Unmarshal(evt.Payload, &p); err != nil {
+		return "", nil, false, fmt.Errorf("unmarshal room_renamed payload: %w", err)
+	}
+	if p.RoomID == "" {
+		return "", nil, false, fmt.Errorf("build spotlight rename: missing roomId")
+	}
+	if p.NewName == "" {
+		return "", nil, false, fmt.Errorf("build spotlight rename: missing newName")
+	}
+	body, err := buildSpotlightRenameByQuery(p.RoomID, p.NewName)
+	if err != nil {
+		return "", nil, false, fmt.Errorf("build spotlight rename: %w", err)
+	}
+	return c.indexName, body, true, nil
+}
+
+// buildSpotlightRenameByQuery is the _update_by_query that sets roomName on every
+// doc of the renamed room. Ordering caveat (v1, no guard): with out-of-order
+// renames the older name can win and persist until the next rename (a later
+// member event stamps whatever name it was born with, so it doesn't reliably
+// correct forward). Spotlight is a derived cache — the room doc is source of
+// truth — so this is stale typeahead text, never data loss. Upgrade path: add
+// roomNameUpdatedAt to SpotlightDoc + its mapping and guard the script with
+// `if (params.ts > ctx._source.roomNameUpdatedAt)`.
+func buildSpotlightRenameByQuery(roomID, newName string) (json.RawMessage, error) {
+	body, err := json.Marshal(map[string]any{
+		"query": map[string]any{"term": map[string]any{"roomId": roomID}},
+		"script": map[string]any{
+			"lang":   "painless",
+			"source": "ctx._source.roomName = params.name",
+			"params": map[string]any{"name": newName},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal update-by-query: %w", err)
+	}
+	return body, nil
+}
+
 func newSpotlightSearchIndex(account string, evt *model.InboxMemberEvent) searchindex.SpotlightDoc {
 	return searchindex.NewSpotlightDoc(searchindex.SpotlightFields{
 		UserAccount: account,

--- a/search-sync-worker/spotlight_test.go
+++ b/search-sync-worker/spotlight_test.go
@@ -86,9 +86,11 @@ func TestSpotlightCollection_Metadata(t *testing.T) {
 		"chat.inbox.site-a.internal.member_added",
 		"chat.inbox.site-a.internal.member_removed",
 		"chat.inbox.site-a.internal.member_joinedat_refreshed",
+		"chat.inbox.site-a.internal.room_renamed",
 		"chat.inbox.site-a.external.member_added",
 		"chat.inbox.site-a.external.member_removed",
 		"chat.inbox.site-a.external.member_joinedat_refreshed",
+		"chat.inbox.site-a.external.room_renamed",
 	}, filters)
 }
 
@@ -408,6 +410,71 @@ func TestSpotlightCollection_BuildAction_BulkRemove(t *testing.T) {
 		assert.Equal(t, int64(67890), action.Version)
 		assert.Nil(t, action.Doc)
 	}
+}
+
+func makeInboxRenameEvent(t *testing.T, typ string, p model.RoomRenamedInboxPayload, ts int64) []byte {
+	t.Helper()
+	payloadData, err := json.Marshal(p)
+	require.NoError(t, err)
+	evt := model.InboxEvent{Type: typ, SiteID: "site-a", DestSiteID: "site-a", Payload: payloadData, Timestamp: ts}
+	data, err := json.Marshal(evt)
+	require.NoError(t, err)
+	return data
+}
+
+func TestSpotlightCollection_BuildByQuery_RoomRenamed(t *testing.T) {
+	coll := newSpotlightCollection("spotlight-site-a-v1-chat", false)
+	data := makeInboxRenameEvent(t, model.InboxRoomRenamed,
+		model.RoomRenamedInboxPayload{RoomID: "r-eng", NewName: "platform", Timestamp: 5000}, 5000)
+
+	index, body, ok, err := coll.BuildByQuery(data)
+	require.NoError(t, err)
+	require.True(t, ok, "room_renamed must be claimed by the by-query path")
+	assert.Equal(t, "spotlight-site-a-v1-chat", index)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(body, &req))
+	term := req["query"].(map[string]any)["term"].(map[string]any)
+	assert.Equal(t, "r-eng", term["roomId"], "update-by-query must be keyed on roomId")
+	script := req["script"].(map[string]any)
+	assert.Equal(t, "painless", script["lang"])
+	assert.Equal(t, "ctx._source.roomName = params.name", script["source"])
+	assert.Equal(t, "platform", script["params"].(map[string]any)["name"], "the new room name must ride the script params")
+}
+
+func TestSpotlightCollection_BuildByQuery_MemberEventFallsThrough(t *testing.T) {
+	coll := newSpotlightCollection("spotlight-site-a-v1-chat", false)
+	data := makeInboxMemberEvent(t, model.InboxMemberAdded, baseInboxMemberEvent(), 1000)
+
+	index, body, ok, err := coll.BuildByQuery(data)
+	require.NoError(t, err)
+	assert.False(t, ok, "member events fall through to the bulk BuildAction path")
+	assert.Empty(t, index)
+	assert.Nil(t, body)
+}
+
+func TestSpotlightCollection_BuildByQuery_Errors(t *testing.T) {
+	coll := newSpotlightCollection("spotlight-site-a-v1-chat", false)
+
+	t.Run("malformed inbox event", func(t *testing.T) {
+		_, _, ok, err := coll.BuildByQuery([]byte("{invalid"))
+		assert.Error(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("missing roomId", func(t *testing.T) {
+		data := makeInboxRenameEvent(t, model.InboxRoomRenamed, model.RoomRenamedInboxPayload{NewName: "x", Timestamp: 1}, 1)
+		_, _, ok, err := coll.BuildByQuery(data)
+		assert.Error(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("missing newName", func(t *testing.T) {
+		data := makeInboxRenameEvent(t, model.InboxRoomRenamed, model.RoomRenamedInboxPayload{RoomID: "r-eng", Timestamp: 1}, 1)
+		_, _, ok, err := coll.BuildByQuery(data)
+		assert.Error(t, err)
+		assert.False(t, ok)
+	})
 }
 
 // Spotlight writes to one fixed index — no additive mapping push at startup.

--- a/search-sync-worker/spotlight_test.go
+++ b/search-sync-worker/spotlight_test.go
@@ -438,8 +438,13 @@ func TestSpotlightCollection_BuildByQuery_RoomRenamed(t *testing.T) {
 	assert.Equal(t, "r-eng", term["roomId"], "update-by-query must be keyed on roomId")
 	script := req["script"].(map[string]any)
 	assert.Equal(t, "painless", script["lang"])
-	assert.Equal(t, "ctx._source.roomName = params.name", script["source"])
-	assert.Equal(t, "platform", script["params"].(map[string]any)["name"], "the new room name must ride the script params")
+	src := script["source"].(string)
+	assert.Contains(t, src, "roomNameUpdatedAt", "script must guard on the LWW clock")
+	assert.Contains(t, src, "params.ts > stored", "only a strictly-newer rename wins")
+	assert.Contains(t, src, "ctx.op = 'noop'", "a stale rename must no-op")
+	params := script["params"].(map[string]any)
+	assert.Equal(t, "platform", params["name"], "the new room name must ride the script params")
+	assert.EqualValues(t, 5000, params["ts"], "the rename timestamp must ride the script params for the guard")
 }
 
 func TestSpotlightCollection_BuildByQuery_MemberEventFallsThrough(t *testing.T) {
@@ -473,6 +478,13 @@ func TestSpotlightCollection_BuildByQuery_Errors(t *testing.T) {
 		data := makeInboxRenameEvent(t, model.InboxRoomRenamed, model.RoomRenamedInboxPayload{RoomID: "r-eng", Timestamp: 1}, 1)
 		_, _, ok, err := coll.BuildByQuery(data)
 		assert.Error(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("missing timestamp", func(t *testing.T) {
+		data := makeInboxRenameEvent(t, model.InboxRoomRenamed, model.RoomRenamedInboxPayload{RoomID: "r-eng", NewName: "x"}, 1)
+		_, _, ok, err := coll.BuildByQuery(data)
+		assert.Error(t, err, "a rename with no timestamp can't guard ordering — reject it")
 		assert.False(t, ok)
 	})
 }

--- a/search-sync-worker/spotlight_test.go
+++ b/search-sync-worker/spotlight_test.go
@@ -440,7 +440,7 @@ func TestSpotlightCollection_BuildByQuery_RoomRenamed(t *testing.T) {
 	assert.Equal(t, "painless", script["lang"])
 	src := script["source"].(string)
 	assert.Contains(t, src, "roomNameUpdatedAt", "script must guard on the LWW clock")
-	assert.Contains(t, src, "params.ts > stored", "only a strictly-newer rename wins")
+	assert.Contains(t, src, "params.ts >= stored", "a newer-or-equal rename wins (>= handles same-ms + redelivery)")
 	assert.Contains(t, src, "ctx.op = 'noop'", "a stale rename must no-op")
 	params := script["params"].(map[string]any)
 	assert.Equal(t, "platform", params["name"], "the new room name must ride the script params")

--- a/search-sync-worker/store.go
+++ b/search-sync-worker/store.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/hmchangw/chat/pkg/searchengine"
 )
@@ -11,4 +12,8 @@ import (
 // Store defines the search engine operations needed by the handler.
 type Store interface {
 	Bulk(ctx context.Context, actions []searchengine.BulkAction) ([]searchengine.BulkResult, error)
+	// UpdateByQuery applies a by-query mutation for events that touch many docs
+	// keyed by a field rather than by DocID (e.g. room rename → every member's
+	// spotlight doc). Standalone ES call, outside the bulk buffer.
+	UpdateByQuery(ctx context.Context, index string, body json.RawMessage) error
 }

--- a/search-sync-worker/user_room.go
+++ b/search-sync-worker/user_room.go
@@ -45,6 +45,14 @@ func (c *userRoomCollection) StoredScripts() map[string]json.RawMessage {
 // BuildAction fans a member_added/member_removed event into one ES update per account (bulk
 // invites yield N doc updates from one event); restricted rooms route into restrictedRooms{}, read alongside rooms[] by search-service.
 func (c *userRoomCollection) BuildAction(data []byte) ([]searchengine.BulkAction, error) {
+	// room_renamed rides the shared inbox filter but the user-room index stores
+	// no room name — spotlight owns the rename re-index (via BuildByQuery). Skip
+	// before parseMemberEvent (which would reject the rename payload as an empty
+	// member event): no actions = ack.
+	if peekInboxEventType(data) == model.InboxRoomRenamed {
+		return nil, nil
+	}
+
 	evt, payload, err := parseMemberEvent(data)
 	if err != nil {
 		return nil, err

--- a/search-sync-worker/user_room_test.go
+++ b/search-sync-worker/user_room_test.go
@@ -36,9 +36,11 @@ func TestUserRoomCollection_Metadata(t *testing.T) {
 		"chat.inbox.site-a.internal.member_added",
 		"chat.inbox.site-a.internal.member_removed",
 		"chat.inbox.site-a.internal.member_joinedat_refreshed",
+		"chat.inbox.site-a.internal.room_renamed",
 		"chat.inbox.site-a.external.member_added",
 		"chat.inbox.site-a.external.member_removed",
 		"chat.inbox.site-a.external.member_joinedat_refreshed",
+		"chat.inbox.site-a.external.room_renamed",
 	}, filters)
 }
 
@@ -403,6 +405,19 @@ func TestUserRoomCollection_BuildAction_BulkInvite(t *testing.T) {
 	assert.True(t, seenDocIDs["alice"])
 	assert.True(t, seenDocIDs["bob"])
 	assert.True(t, seenDocIDs["carol"])
+}
+
+// room_renamed rides the shared inbox filter but user-room stores no room name,
+// so BuildAction must skip it (nil actions, no error) — spotlight owns the
+// rename re-index. An error here would nak-loop a rename forever.
+func TestUserRoomCollection_BuildAction_RoomRenamedSkipped(t *testing.T) {
+	coll := newUserRoomCollection("user-room-site-a", false)
+	data := makeInboxRenameEvent(t, model.InboxRoomRenamed,
+		model.RoomRenamedInboxPayload{RoomID: "r-eng", NewName: "platform", Timestamp: 5000}, 5000)
+
+	actions, err := coll.BuildAction(data)
+	require.NoError(t, err)
+	assert.Empty(t, actions, "user-room ignores room_renamed")
 }
 
 func TestUserRoomCollection_BuildAction_Errors(t *testing.T) {


### PR DESCRIPTION
## Summary

Room renames left the spotlight (room-name typeahead) index stale, so `search.rooms` returned the old name after a rename — issue #315.

Two independent gaps caused it:

1. **Producer gap.** `room-worker`'s rename handler only *federated* `room_renamed` to remote sites (via OUTBOX). A same-site rename — the common case, and the only case in a single-site deployment — published **no** INBOX event at all, so the search feed never saw it. Member events, by contrast, dual-emit: an internal-lane publish for the local search feed *and* the cross-site federate.
2. **Consumer gap.** `search-sync-worker`'s spotlight collection sourced `roomName` only from member events; it never consumed `room_renamed`.

Fix closes both. `roomName` lives on every member's spotlight doc (`{account}_{roomId}`) and the rename payload carries no account list, so the re-index is a single `_update_by_query` keyed on `roomId`.

Closes #315

## Changes

- **`room-worker/handler.go`** — after a successful rename, also publish `room_renamed` on the same-site internal INBOX lane (`chat.inbox.{siteID}.internal.room_renamed`), mirroring the existing `member_added`/`member_removed` dual-emit. Cross-site members remain covered by the existing OUTBOX federate.
- **`pkg/searchengine`** — new `UpdateByQuery(ctx, index, body)` primitive on the engine interface + HTTP adapter (`POST /{index}/_update_by_query?conflicts=proceed`), for field-keyed multi-doc mutations the DocID-keyed bulk API can't express.
- **`search-sync-worker`** — spotlight implements an optional `ByQueryCollection` seam: `room_renamed` is applied as one `_update_by_query` that sets `roomName` on every doc matching `roomId` (painless `ctx._source.roomName = params.name`), dispatched by the handler outside the bulk buffer and acked/naked on its own. `user-room`'s `BuildAction` ignores `room_renamed` (no actions = ack). The shared inbox subject filter (`subject.InboxMemberEventSubjects`) is extended with `room_renamed` on both the internal and external lanes.

**Ordering caveat (v1, by design):** the update-by-query has no per-doc version guard, so two renames delivered out of order could momentarily leave the older name — same-score typeahead reordering only, never data loss — self-correcting on the next rename or membership event. Documented inline with the upgrade path (add `roomNameUpdatedAt` to the doc + mapping and guard the script). No new ES mapping field added.

### NATS subjects

- `chat.inbox.{siteID}.internal.room_renamed` — now published by `room-worker` (same-site search feed) and consumed by `search-sync-worker`.
- `chat.inbox.{siteID}.external.room_renamed` — already federated by the OUTBOX path; now also consumed by `search-sync-worker`.

## Verification

- `go build -o /dev/null ./search-sync-worker/ ./pkg/...` — clean
- `go test ./search-sync-worker/... ./pkg/subject/... ./pkg/searchengine/... ./pkg/natsmetrics/... ./room-worker/...` — pass (new: spotlight by-query happy/fallthrough/error, user-room skip, handler dispatch ack/nak, room-worker internal-feed publish; updated every exact subject-list assertion)
- `go vet -tags integration ./search-sync-worker/... ./pkg/searchengine/... ./room-worker/...` — clean (integration compiles)
- `golangci-lint` on all touched packages — `0 issues.`

**Acceptance e2e (must run before ready):** rename a room on the dev stack → confirm the spotlight `roomName` updates and `search.rooms` returns the new name, not the old one, for a member of that room (same-site and cross-site).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Room renames now update searchable room names across all relevant member records.
  * Room rename events trigger same-site search reindexing before remote federation.
  * Updates safely ignore stale rename events and support retrying failed operations.

* **Bug Fixes**
  * Prevented unnecessary updates to indexes that do not store room names.
  * Added validation and clearer handling for malformed or incomplete rename events.

* **Tests**
  * Added coverage for successful updates, failures, retries, conflicts, and event validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->