### PR TITLE
feat(search-sync): ES bulk/flush domain metrics for loadgen attribution

### DIFF
--- a/docs/specs/o11y/o11y-metrics-inventory.md
+++ b/docs/specs/o11y/o11y-metrics-inventory.md
@@ -121,7 +121,7 @@ missing beyond shared cache/key counters.
 | broadcast-worker | — | ✅ | ✅ | — | spans + `chat_nats_*` | — | shared `cache_*_total`, **`broadcast_worker_fanout_recipients`**, **`broadcast_worker_recipient_deliveries_total`** | E2E-key hits |
 | notification-worker | — | ✅ | ✅ | — | spans + `chat_nats_*` | — | shared `cache_*_total`, **`notification_worker_outcomes_total`** | — |
 | outbox-worker | — | — | — | — | spans | — | — | forwarded/dropped/retried events by destination and type |
-| search-sync-worker | — | — | — | — | spans (Fetch) | spans | — | bulk actions/flush, index vs delete, ES failures |
+| search-sync-worker | — | — | — | — | spans (Fetch) | spans | **`chat.search.sync.bulk.flush.duration`, `chat.search.sync.bulk.flush.actions`, `chat.search.sync.bulk.item.failures`, `chat.search.sync.messages`, `chat.search.sync.parent.resolve.duration`** (all labeled by `collection`) | (bulk outcomes covered 2026-08-19) |
 | search-service | — | ✅ | ✅ | — | spans | spans | **`search_service_requests_total`, `search_service_request_duration_seconds`, `search_service_es_duration_seconds`** | (well covered after request traffic) |
 | room-service | — | ✅ | ✅ | ✅ | spans + `chat_nats_*` | — | — | room create/join/leave outcomes |
 | room-worker | — | ✅ | ✅ | ✅ | spans + `chat_nats_*` | — | shared `cache_*_total`, `room_key_*_total` | member-add results, roomkey distributions, vault ops |
@@ -347,8 +347,8 @@ these exporters there (and to prod IaC) to cover Layer C.
    add to `docker-local/compose.o11y.yaml` + prod. *Infra, not app code.*
 2. **Hot-path domain counters (Layer B).** *Mostly done (2026-08-14).*
    Gatekeeper, message-worker, broadcast, and notification now own domain
-   counters (§2 table). Still open: **search-sync bulk outcomes**, and
-   broadcast's E2E-key hits.
+   counters (§2 table). Search-sync bulk outcomes closed 2026-08-19
+   (`chat.search.sync.*`, §2 table). Still open: broadcast's E2E-key hits.
 3. **ES client metrics (Layer A gap).** The NATS half of this item is closed —
    see §2.1 for the application-side families that replaced it. `searchengine`
    still emits spans but no metrics; decide whether app-side ES latency

--- a/docs/specs/o11y/o11y-metrics-inventory.md
+++ b/docs/specs/o11y/o11y-metrics-inventory.md
@@ -121,7 +121,7 @@ missing beyond shared cache/key counters.
 | broadcast-worker | — | ✅ | ✅ | — | spans + `chat_nats_*` | — | shared `cache_*_total`, **`broadcast_worker_fanout_recipients`**, **`broadcast_worker_recipient_deliveries_total`** | E2E-key hits |
 | notification-worker | — | ✅ | ✅ | — | spans + `chat_nats_*` | — | shared `cache_*_total`, **`notification_worker_outcomes_total`** | — |
 | outbox-worker | — | — | — | — | spans | — | — | forwarded/dropped/retried events by destination and type |
-| search-sync-worker | — | — | — | — | spans (Fetch) | spans | **`chat.search.sync.bulk.flush.duration`, `chat.search.sync.bulk.flush.actions`, `chat.search.sync.bulk.item.failures`, `chat.search.sync.messages`, `chat.search.sync.parent.resolve.duration`** (all labeled by `collection`) | (bulk outcomes covered 2026-08-19) |
+| search-sync-worker | — | — | — | — | spans (Fetch) | spans | **`search_sync_worker_bulk_flush_duration_seconds`, `search_sync_worker_bulk_flush_actions`, `search_sync_worker_bulk_item_failures_total`, `search_sync_worker_messages_total`, `search_sync_worker_parent_resolve_duration_seconds`** (all labeled by `collection`) | (bulk outcomes covered 2026-08-19) |
 | search-service | — | ✅ | ✅ | — | spans | spans | **`search_service_requests_total`, `search_service_request_duration_seconds`, `search_service_es_duration_seconds`** | (well covered after request traffic) |
 | room-service | — | ✅ | ✅ | ✅ | spans + `chat_nats_*` | — | — | room create/join/leave outcomes |
 | room-worker | — | ✅ | ✅ | ✅ | spans + `chat_nats_*` | — | shared `cache_*_total`, `room_key_*_total` | member-add results, roomkey distributions, vault ops |
@@ -348,7 +348,7 @@ these exporters there (and to prod IaC) to cover Layer C.
 2. **Hot-path domain counters (Layer B).** *Mostly done (2026-08-14).*
    Gatekeeper, message-worker, broadcast, and notification now own domain
    counters (§2 table). Search-sync bulk outcomes closed 2026-08-19
-   (`chat.search.sync.*`, §2 table). Still open: broadcast's E2E-key hits.
+   (`search_sync_worker_*`, §2 table). Still open: broadcast's E2E-key hits.
 3. **ES client metrics (Layer A gap).** The NATS half of this item is closed —
    see §2.1 for the application-side families that replaced it. `searchengine`
    still emits spans but no metrics; decide whether app-side ES latency

--- a/search-sync-worker/handler.go
+++ b/search-sync-worker/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
 	"go.opentelemetry.io/otel"
@@ -46,6 +47,7 @@ type Handler struct {
 	collection Collection
 	bulkSize   int // soft cap on buffered actions; callers drive flush via ActionCount()
 	tracer     trace.Tracer
+	metrics    *collectionMetrics // optional, set by main; nil-safe methods make an unwired handler a no-op
 	mu         sync.Mutex
 	pending    []pendingMsg
 	actions    []searchengine.BulkAction
@@ -85,6 +87,7 @@ func (h *Handler) AddWithContext(ctx context.Context, msg jetstream.Msg) {
 	if err != nil {
 		slog.ErrorContext(ctx, "decode payload", "error", err, "subject", msg.Subject(), "consumer", h.collection.ConsumerName())
 		natsutil.Ack(msg, "decode payload failed")
+		h.metrics.recordMessages(ctx, dispAckedPoison, 1)
 		return
 	}
 	actions, err := h.collection.BuildAction(data)
@@ -93,11 +96,13 @@ func (h *Handler) AddWithContext(ctx context.Context, msg jetstream.Msg) {
 		// good, so this line is the only trace; keep it identifying the message.
 		slog.ErrorContext(ctx, "build action", "error", err, "subject", msg.Subject(), "consumer", h.collection.ConsumerName())
 		natsutil.Ack(msg, "build action failed")
+		h.metrics.recordMessages(ctx, dispAckedPoison, 1)
 		return
 	}
 
 	if len(actions) == 0 {
 		natsutil.Ack(msg, "filtered, no actions")
+		h.metrics.recordMessages(ctx, dispAckedFiltered, 1)
 		return
 	}
 
@@ -128,9 +133,13 @@ func (h *Handler) Flush(ctx context.Context) {
 	bulkCtx, span := h.startFlushSpan(ctx, pending, len(actions))
 	defer span.End()
 
+	start := time.Now()
 	results, err := h.store.Bulk(bulkCtx, actions)
+	elapsed := time.Since(start).Seconds()
 	if err != nil {
 		slog.Error("bulk request failed", "error", err, "actions", len(actions))
+		h.metrics.recordFlush(bulkCtx, flushRequestError, elapsed, len(actions))
+		h.metrics.recordMessages(bulkCtx, dispNakkedRequestFailed, len(pending))
 		nakAll(pending, "bulk request failed")
 		return
 	}
@@ -148,31 +157,44 @@ func (h *Handler) Flush(ctx context.Context) {
 		//     is at worst a no-op.
 		// No duplicate processing, no lost events.
 		slog.Error("bulk result count mismatch", "expected", len(actions), "actual", len(results))
+		h.metrics.recordFlush(bulkCtx, flushResultMismatch, elapsed, len(actions))
+		h.metrics.recordMessages(bulkCtx, dispNakkedResultMismatch, len(pending))
 		nakAll(pending, "bulk result count mismatch")
 		return
 	}
 
+	h.metrics.recordFlush(bulkCtx, flushSuccess, elapsed, len(actions))
+
+	var acked, nakked int
 	for _, p := range pending {
 		allOK := true
 		for i := p.actionStart; i < p.actionStart+p.actionCount; i++ {
 			if searchengine.IsBulkItemSuccess(actions[i].Action, results[i]) {
 				continue
 			}
+			h.metrics.recordItemFailure(bulkCtx, string(actions[i].Action), results[i].Status)
+			if allOK {
+				// Log only the first failed item per message; the counter above still
+				// sees every failed action.
+				slog.Error("bulk item failed",
+					"status", results[i].Status,
+					"error", results[i].Error,
+					"docID", actions[i].DocID,
+					"index", actions[i].Index,
+				)
+			}
 			allOK = false
-			slog.Error("bulk item failed",
-				"status", results[i].Status,
-				"error", results[i].Error,
-				"docID", actions[i].DocID,
-				"index", actions[i].Index,
-			)
-			break
 		}
 		if allOK {
+			acked++
 			natsutil.Ack(p.jsMsg, "bulk actions succeeded")
 		} else {
+			nakked++
 			natsutil.Nak(p.jsMsg, "bulk action failed")
 		}
 	}
+	h.metrics.recordMessages(bulkCtx, dispAckedSuccess, acked)
+	h.metrics.recordMessages(bulkCtx, dispNakkedItemFailed, nakked)
 }
 
 func (h *Handler) startFlushSpan(ctx context.Context, pending []pendingMsg, actionCount int) (context.Context, trace.Span) {

--- a/search-sync-worker/handler.go
+++ b/search-sync-worker/handler.go
@@ -138,7 +138,7 @@ func (h *Handler) Flush(ctx context.Context) {
 	elapsed := time.Since(start).Seconds()
 	if err != nil {
 		slog.Error("bulk request failed", "error", err, "actions", len(actions))
-		h.metrics.recordFlush(bulkCtx, flushRequestError, elapsed, len(actions))
+		h.metrics.recordFlush(bulkCtx, flushRequestFailed, elapsed, len(actions))
 		h.metrics.recordMessages(bulkCtx, dispNakkedRequestFailed, len(pending))
 		nakAll(pending, "bulk request failed")
 		return

--- a/search-sync-worker/main.go
+++ b/search-sync-worker/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/caarlos0/env/v11"
 	"github.com/nats-io/nats.go/jetstream"
+	"go.opentelemetry.io/otel"
 
 	"github.com/hmchangw/chat/pkg/health"
 	"github.com/hmchangw/chat/pkg/jobguard"
@@ -168,6 +169,10 @@ func main() {
 	}
 	db := mongoClient.Database(cfg.MongoDB)
 
+	// obs.Init installed the SDK's MeterProvider as the OTel global, so this
+	// resolves to real instruments when metrics are enabled and no-ops otherwise.
+	esMetrics := newSyncMetrics(otel.Meter(metricsScope))
+
 	// Mode gates which consumers this pod binds. "teams" runs only the
 	// MESSAGES-TEAMS migrated-history consumer; "default" runs everything else.
 	var collections []Collection
@@ -181,11 +186,15 @@ func main() {
 	} else {
 		msgColl := newMessageCollection(cfg.MsgIndexPrefix, cfg.SiteID, syncMessagesFrom, cfg.DevMode)
 		// search-service filters restricted-room access by threadParentMessageCreatedAt, so re-resolve it from the parent's indexed createdAt (the event omits it).
-		msgColl.parentResolver = newESParentResolver(engine, cfg.MsgIndexPrefix)
+		msgResolver := newESParentResolver(engine, cfg.MsgIndexPrefix)
+		msgResolver.metrics = esMetrics
+		msgColl.parentResolver = msgResolver
 
 		// Second consumer over messageCollection, bound to BOT-MESSAGES-CANONICAL. isBot is derived per-doc from model.IsBot(UserAccount) so bots reuse the same index.
 		botMsgColl := newBotMessageCollection(cfg.MsgIndexPrefix, cfg.DevMode)
-		botMsgColl.parentResolver = newESParentResolver(engine, cfg.MsgIndexPrefix)
+		botMsgResolver := newESParentResolver(engine, cfg.MsgIndexPrefix)
+		botMsgResolver.metrics = esMetrics
+		botMsgColl.parentResolver = botMsgResolver
 
 		collections = []Collection{
 			msgColl,
@@ -314,6 +323,7 @@ func main() {
 		}
 
 		handler := NewHandler(&engineAdapter{engine: engine}, coll, cfg.BulkBatchSize)
+		handler.metrics = esMetrics.forCollection(coll.ConsumerName())
 		doneCh := make(chan struct{})
 		doneChs = append(doneChs, doneCh)
 

--- a/search-sync-worker/main.go
+++ b/search-sync-worker/main.go
@@ -187,13 +187,13 @@ func main() {
 		msgColl := newMessageCollection(cfg.MsgIndexPrefix, cfg.SiteID, syncMessagesFrom, cfg.DevMode)
 		// search-service filters restricted-room access by threadParentMessageCreatedAt, so re-resolve it from the parent's indexed createdAt (the event omits it).
 		msgResolver := newESParentResolver(engine, cfg.MsgIndexPrefix)
-		msgResolver.metrics = esMetrics
+		msgResolver.metrics = esMetrics.forCollection(msgColl.ConsumerName())
 		msgColl.parentResolver = msgResolver
 
 		// Second consumer over messageCollection, bound to BOT-MESSAGES-CANONICAL. isBot is derived per-doc from model.IsBot(UserAccount) so bots reuse the same index.
 		botMsgColl := newBotMessageCollection(cfg.MsgIndexPrefix, cfg.DevMode)
 		botMsgResolver := newESParentResolver(engine, cfg.MsgIndexPrefix)
-		botMsgResolver.metrics = esMetrics
+		botMsgResolver.metrics = esMetrics.forCollection(botMsgColl.ConsumerName())
 		botMsgColl.parentResolver = botMsgResolver
 
 		collections = []Collection{

--- a/search-sync-worker/metrics.go
+++ b/search-sync-worker/metrics.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/flywindy/o11y"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// metricsScope is the instrumentation scope for every instrument in this file.
+const metricsScope = "github.com/hmchangw/chat/search-sync-worker"
+
+// flushOutcome classifies one ES bulk flush round-trip. Per-item failures are
+// counted separately — a flush whose request succeeded is "success" even when
+// some items inside it failed.
+type flushOutcome string
+
+const (
+	flushSuccess        flushOutcome = "success"
+	flushRequestError   flushOutcome = "request_error"
+	flushResultMismatch flushOutcome = "result_mismatch"
+)
+
+var allFlushOutcomes = []flushOutcome{flushSuccess, flushRequestError, flushResultMismatch}
+
+// msgDisposition is a terminal (outcome, reason) pair for one source JetStream
+// message. Every label value is a closed enum so attribute sets are precomputed
+// once per collection and looked up by value on the hot path.
+type msgDisposition struct {
+	outcome string // acked | nakked
+	reason  string
+}
+
+var (
+	dispAckedSuccess         = msgDisposition{"acked", "success"}
+	dispAckedFiltered        = msgDisposition{"acked", "filtered"}
+	dispAckedPoison          = msgDisposition{"acked", "poison"}
+	dispNakkedRequestFailed  = msgDisposition{"nakked", "request_failed"}
+	dispNakkedItemFailed     = msgDisposition{"nakked", "item_failed"}
+	dispNakkedResultMismatch = msgDisposition{"nakked", "result_mismatch"}
+)
+
+var allDispositions = []msgDisposition{
+	dispAckedSuccess, dispAckedFiltered, dispAckedPoison,
+	dispNakkedRequestFailed, dispNakkedItemFailed, dispNakkedResultMismatch,
+}
+
+// syncMetrics owns the worker's ES-sync instruments. Instrument-creation
+// failures fall back to no-op instruments so telemetry can never block startup.
+type syncMetrics struct {
+	flushDuration metric.Float64Histogram
+	flushActions  metric.Int64Histogram
+	itemFailures  metric.Int64Counter
+	messages      metric.Int64Counter
+	parentResolve metric.Float64Histogram
+	resolvedOpt   metric.MeasurementOption
+	unresolvedOpt metric.MeasurementOption
+}
+
+func newSyncMetrics(meter metric.Meter) *syncMetrics {
+	noopMeter := noop.NewMeterProvider().Meter("search-sync-fallback")
+	// The o11y SDK only registers bucket views for its own instrument names, so
+	// latency histograms carry the shared boundaries as an instrument advisory.
+	latency := metric.WithExplicitBucketBoundaries(o11y.DefaultLatencyBuckets()...)
+
+	flushDuration, err := meter.Float64Histogram("chat.search.sync.bulk.flush.duration",
+		metric.WithDescription("ES bulk flush round-trip duration by outcome."), metric.WithUnit("s"), latency)
+	if err != nil {
+		flushDuration, _ = noopMeter.Float64Histogram("chat.search.sync.bulk.flush.duration")
+	}
+	flushActions, err := meter.Int64Histogram("chat.search.sync.bulk.flush.actions",
+		metric.WithDescription("ES bulk actions attempted per flush."),
+		metric.WithExplicitBucketBoundaries(1, 10, 50, 100, 250, 500, 1000, 2000))
+	if err != nil {
+		flushActions, _ = noopMeter.Int64Histogram("chat.search.sync.bulk.flush.actions")
+	}
+	itemFailures, err := meter.Int64Counter("chat.search.sync.bulk.item.failures",
+		metric.WithDescription("ES bulk items that failed, by action type and bounded status."))
+	if err != nil {
+		itemFailures, _ = noopMeter.Int64Counter("chat.search.sync.bulk.item.failures")
+	}
+	messages, err := meter.Int64Counter("chat.search.sync.messages",
+		metric.WithDescription("Source JetStream messages by terminal disposition."))
+	if err != nil {
+		messages, _ = noopMeter.Int64Counter("chat.search.sync.messages")
+	}
+	parentResolve, err := meter.Float64Histogram("chat.search.sync.parent.resolve.duration",
+		metric.WithDescription("Thread-parent createdAt ES self-lookup duration."), metric.WithUnit("s"), latency)
+	if err != nil {
+		parentResolve, _ = noopMeter.Float64Histogram("chat.search.sync.parent.resolve.duration")
+	}
+
+	return &syncMetrics{
+		flushDuration: flushDuration,
+		flushActions:  flushActions,
+		itemFailures:  itemFailures,
+		messages:      messages,
+		parentResolve: parentResolve,
+		resolvedOpt:   metric.WithAttributeSet(attribute.NewSet(attribute.String("outcome", "resolved"))),
+		unresolvedOpt: metric.WithAttributeSet(attribute.NewSet(attribute.String("outcome", "unresolved"))),
+	}
+}
+
+// recordParentResolve is nil-safe so an unwired resolver stays a no-op.
+func (m *syncMetrics) recordParentResolve(ctx context.Context, seconds float64, resolved bool) {
+	if m == nil {
+		return
+	}
+	opt := m.unresolvedOpt
+	if resolved {
+		opt = m.resolvedOpt
+	}
+	m.parentResolve.Record(ctx, seconds, opt)
+}
+
+// collectionMetrics binds syncMetrics to one collection's bounded label sets.
+type collectionMetrics struct {
+	m          *syncMetrics
+	collection string
+	actionsOpt metric.MeasurementOption
+	flushOpts  map[flushOutcome]metric.MeasurementOption
+	msgOpts    map[msgDisposition]metric.MeasurementOption
+}
+
+func (m *syncMetrics) forCollection(name string) *collectionMetrics {
+	flushOpts := make(map[flushOutcome]metric.MeasurementOption, len(allFlushOutcomes))
+	for _, o := range allFlushOutcomes {
+		flushOpts[o] = metric.WithAttributeSet(attribute.NewSet(
+			attribute.String("collection", name),
+			attribute.String("outcome", string(o)),
+		))
+	}
+	msgOpts := make(map[msgDisposition]metric.MeasurementOption, len(allDispositions))
+	for _, d := range allDispositions {
+		msgOpts[d] = metric.WithAttributeSet(attribute.NewSet(
+			attribute.String("collection", name),
+			attribute.String("outcome", d.outcome),
+			attribute.String("reason", d.reason),
+		))
+	}
+	return &collectionMetrics{
+		m:          m,
+		collection: name,
+		actionsOpt: metric.WithAttributeSet(attribute.NewSet(attribute.String("collection", name))),
+		flushOpts:  flushOpts,
+		msgOpts:    msgOpts,
+	}
+}
+
+// recordFlush records one bulk flush round-trip and the batch size it attempted.
+func (c *collectionMetrics) recordFlush(ctx context.Context, outcome flushOutcome, seconds float64, actions int) {
+	if c == nil {
+		return
+	}
+	c.m.flushDuration.Record(ctx, seconds, c.flushOpts[outcome])
+	c.m.flushActions.Record(ctx, int64(actions), c.actionsOpt)
+}
+
+// recordMessages counts n source messages sharing one terminal disposition.
+func (c *collectionMetrics) recordMessages(ctx context.Context, d msgDisposition, n int) {
+	if c == nil || n == 0 {
+		return
+	}
+	c.m.messages.Add(ctx, int64(n), c.msgOpts[d])
+}
+
+// recordItemFailure counts one failed bulk item. This is a cold path, so the
+// attribute set is built per call instead of precomputed per status.
+func (c *collectionMetrics) recordItemFailure(ctx context.Context, action string, status int) {
+	if c == nil {
+		return
+	}
+	c.m.itemFailures.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
+		attribute.String("collection", c.collection),
+		attribute.String("action", action),
+		attribute.String("status", bulkStatusLabel(status)),
+	)))
+}
+
+// bulkStatusLabel maps an ES bulk item status to a bounded label value: the
+// diagnostically interesting codes stay exact, everything else buckets by class.
+func bulkStatusLabel(status int) string {
+	switch status {
+	case 400, 404, 409, 413, 429, 500, 503:
+		return strconv.Itoa(status)
+	}
+	switch {
+	case status >= 400 && status < 500:
+		return "4xx"
+	case status >= 500 && status < 600:
+		return "5xx"
+	default:
+		return "other"
+	}
+}

--- a/search-sync-worker/metrics.go
+++ b/search-sync-worker/metrics.go
@@ -20,11 +20,11 @@ type flushOutcome string
 
 const (
 	flushSuccess        flushOutcome = "success"
-	flushRequestError   flushOutcome = "request_error"
+	flushRequestFailed  flushOutcome = "request_failed"
 	flushResultMismatch flushOutcome = "result_mismatch"
 )
 
-var allFlushOutcomes = []flushOutcome{flushSuccess, flushRequestError, flushResultMismatch}
+var allFlushOutcomes = []flushOutcome{flushSuccess, flushRequestFailed, flushResultMismatch}
 
 // msgDisposition is a terminal (outcome, reason) pair for one source JetStream
 // message. Every label value is a closed enum so attribute sets are precomputed
@@ -56,8 +56,6 @@ type syncMetrics struct {
 	itemFailures  metric.Int64Counter
 	messages      metric.Int64Counter
 	parentResolve metric.Float64Histogram
-	resolvedOpt   metric.MeasurementOption
-	unresolvedOpt metric.MeasurementOption
 }
 
 func newSyncMetrics(meter metric.Meter) *syncMetrics {
@@ -66,31 +64,31 @@ func newSyncMetrics(meter metric.Meter) *syncMetrics {
 	// latency histograms carry the shared boundaries as an instrument advisory.
 	latency := metric.WithExplicitBucketBoundaries(o11y.DefaultLatencyBuckets()...)
 
-	flushDuration, err := meter.Float64Histogram("chat.search.sync.bulk.flush.duration",
+	flushDuration, err := meter.Float64Histogram("search_sync_worker_bulk_flush_duration",
 		metric.WithDescription("ES bulk flush round-trip duration by outcome."), metric.WithUnit("s"), latency)
 	if err != nil {
-		flushDuration, _ = noopMeter.Float64Histogram("chat.search.sync.bulk.flush.duration")
+		flushDuration, _ = noopMeter.Float64Histogram("search_sync_worker_bulk_flush_duration")
 	}
-	flushActions, err := meter.Int64Histogram("chat.search.sync.bulk.flush.actions",
+	flushActions, err := meter.Int64Histogram("search_sync_worker_bulk_flush_actions",
 		metric.WithDescription("ES bulk actions attempted per flush."),
 		metric.WithExplicitBucketBoundaries(1, 10, 50, 100, 250, 500, 1000, 2000))
 	if err != nil {
-		flushActions, _ = noopMeter.Int64Histogram("chat.search.sync.bulk.flush.actions")
+		flushActions, _ = noopMeter.Int64Histogram("search_sync_worker_bulk_flush_actions")
 	}
-	itemFailures, err := meter.Int64Counter("chat.search.sync.bulk.item.failures",
+	itemFailures, err := meter.Int64Counter("search_sync_worker_bulk_item_failures",
 		metric.WithDescription("ES bulk items that failed, by action type and bounded status."))
 	if err != nil {
-		itemFailures, _ = noopMeter.Int64Counter("chat.search.sync.bulk.item.failures")
+		itemFailures, _ = noopMeter.Int64Counter("search_sync_worker_bulk_item_failures")
 	}
-	messages, err := meter.Int64Counter("chat.search.sync.messages",
-		metric.WithDescription("Source JetStream messages by terminal disposition."))
+	messages, err := meter.Int64Counter("search_sync_worker_messages",
+		metric.WithDescription("JetStream delivery attempts by disposition; a nakked delivery recurs on each redelivery."))
 	if err != nil {
-		messages, _ = noopMeter.Int64Counter("chat.search.sync.messages")
+		messages, _ = noopMeter.Int64Counter("search_sync_worker_messages")
 	}
-	parentResolve, err := meter.Float64Histogram("chat.search.sync.parent.resolve.duration",
+	parentResolve, err := meter.Float64Histogram("search_sync_worker_parent_resolve_duration",
 		metric.WithDescription("Thread-parent createdAt ES self-lookup duration."), metric.WithUnit("s"), latency)
 	if err != nil {
-		parentResolve, _ = noopMeter.Float64Histogram("chat.search.sync.parent.resolve.duration")
+		parentResolve, _ = noopMeter.Float64Histogram("search_sync_worker_parent_resolve_duration")
 	}
 
 	return &syncMetrics{
@@ -99,30 +97,18 @@ func newSyncMetrics(meter metric.Meter) *syncMetrics {
 		itemFailures:  itemFailures,
 		messages:      messages,
 		parentResolve: parentResolve,
-		resolvedOpt:   metric.WithAttributeSet(attribute.NewSet(attribute.String("outcome", "resolved"))),
-		unresolvedOpt: metric.WithAttributeSet(attribute.NewSet(attribute.String("outcome", "unresolved"))),
 	}
-}
-
-// recordParentResolve is nil-safe so an unwired resolver stays a no-op.
-func (m *syncMetrics) recordParentResolve(ctx context.Context, seconds float64, resolved bool) {
-	if m == nil {
-		return
-	}
-	opt := m.unresolvedOpt
-	if resolved {
-		opt = m.resolvedOpt
-	}
-	m.parentResolve.Record(ctx, seconds, opt)
 }
 
 // collectionMetrics binds syncMetrics to one collection's bounded label sets.
 type collectionMetrics struct {
-	m          *syncMetrics
-	collection string
-	actionsOpt metric.MeasurementOption
-	flushOpts  map[flushOutcome]metric.MeasurementOption
-	msgOpts    map[msgDisposition]metric.MeasurementOption
+	m             *syncMetrics
+	collection    string
+	actionsOpt    metric.MeasurementOption
+	resolvedOpt   metric.MeasurementOption
+	unresolvedOpt metric.MeasurementOption
+	flushOpts     map[flushOutcome]metric.MeasurementOption
+	msgOpts       map[msgDisposition]metric.MeasurementOption
 }
 
 func (m *syncMetrics) forCollection(name string) *collectionMetrics {
@@ -145,9 +131,25 @@ func (m *syncMetrics) forCollection(name string) *collectionMetrics {
 		m:          m,
 		collection: name,
 		actionsOpt: metric.WithAttributeSet(attribute.NewSet(attribute.String("collection", name))),
-		flushOpts:  flushOpts,
-		msgOpts:    msgOpts,
+		resolvedOpt: metric.WithAttributeSet(attribute.NewSet(
+			attribute.String("collection", name), attribute.String("outcome", "resolved"))),
+		unresolvedOpt: metric.WithAttributeSet(attribute.NewSet(
+			attribute.String("collection", name), attribute.String("outcome", "unresolved"))),
+		flushOpts: flushOpts,
+		msgOpts:   msgOpts,
 	}
+}
+
+// recordParentResolve is nil-safe so an unwired resolver stays a no-op.
+func (c *collectionMetrics) recordParentResolve(ctx context.Context, seconds float64, resolved bool) {
+	if c == nil {
+		return
+	}
+	opt := c.unresolvedOpt
+	if resolved {
+		opt = c.resolvedOpt
+	}
+	c.m.parentResolve.Record(ctx, seconds, opt)
 }
 
 // recordFlush records one bulk flush round-trip and the batch size it attempted.

--- a/search-sync-worker/metrics_test.go
+++ b/search-sync-worker/metrics_test.go
@@ -119,7 +119,7 @@ func TestSyncMetrics_FlushSuccess(t *testing.T) {
 
 	rm := collectMetrics(t, reader)
 
-	durations := histPoints[float64](t, rm, "chat.search.sync.bulk.flush.duration")
+	durations := histPoints[float64](t, rm, "search_sync_worker_bulk_flush_duration")
 	require.Len(t, durations, 1)
 	assert.Equal(t, uint64(1), durations[0].Count)
 	assert.Equal(t, map[string]string{
@@ -127,12 +127,12 @@ func TestSyncMetrics_FlushSuccess(t *testing.T) {
 		"outcome":    "success",
 	}, attrMap(durations[0].Attributes))
 
-	actions := histPoints[int64](t, rm, "chat.search.sync.bulk.flush.actions")
+	actions := histPoints[int64](t, rm, "search_sync_worker_bulk_flush_actions")
 	require.Len(t, actions, 1)
 	assert.Equal(t, int64(1), actions[0].Sum)
 	assert.Equal(t, map[string]string{"collection": "message-sync"}, attrMap(actions[0].Attributes))
 
-	messages := sumPoints(t, rm, "chat.search.sync.messages")
+	messages := sumPoints(t, rm, "search_sync_worker_messages")
 	assert.Equal(t, int64(1), sumValue(messages, map[string]string{
 		"collection": "message-sync", "outcome": "acked", "reason": "success",
 	}))
@@ -150,14 +150,14 @@ func TestSyncMetrics_FlushRequestError(t *testing.T) {
 
 	rm := collectMetrics(t, reader)
 
-	durations := histPoints[float64](t, rm, "chat.search.sync.bulk.flush.duration")
+	durations := histPoints[float64](t, rm, "search_sync_worker_bulk_flush_duration")
 	require.Len(t, durations, 1)
 	assert.Equal(t, map[string]string{
 		"collection": "message-sync",
-		"outcome":    "request_error",
+		"outcome":    "request_failed",
 	}, attrMap(durations[0].Attributes))
 
-	messages := sumPoints(t, rm, "chat.search.sync.messages")
+	messages := sumPoints(t, rm, "search_sync_worker_messages")
 	assert.Equal(t, int64(1), sumValue(messages, map[string]string{
 		"collection": "message-sync", "outcome": "nakked", "reason": "request_failed",
 	}))
@@ -175,17 +175,17 @@ func TestSyncMetrics_FlushItemFailure(t *testing.T) {
 
 	rm := collectMetrics(t, reader)
 
-	failures := sumPoints(t, rm, "chat.search.sync.bulk.item.failures")
+	failures := sumPoints(t, rm, "search_sync_worker_bulk_item_failures")
 	assert.Equal(t, int64(1), sumValue(failures, map[string]string{
 		"collection": "message-sync", "action": "index", "status": "429",
 	}))
 
-	messages := sumPoints(t, rm, "chat.search.sync.messages")
+	messages := sumPoints(t, rm, "search_sync_worker_messages")
 	assert.Equal(t, int64(1), sumValue(messages, map[string]string{
 		"collection": "message-sync", "outcome": "nakked", "reason": "item_failed",
 	}))
 
-	durations := histPoints[float64](t, rm, "chat.search.sync.bulk.flush.duration")
+	durations := histPoints[float64](t, rm, "search_sync_worker_bulk_flush_duration")
 	require.Len(t, durations, 1)
 	assert.Equal(t, "success", attrMap(durations[0].Attributes)["outcome"],
 		"per-item failures nak their own messages but the flush round-trip itself succeeded")
@@ -203,11 +203,11 @@ func TestSyncMetrics_FlushResultMismatch(t *testing.T) {
 
 	rm := collectMetrics(t, reader)
 
-	durations := histPoints[float64](t, rm, "chat.search.sync.bulk.flush.duration")
+	durations := histPoints[float64](t, rm, "search_sync_worker_bulk_flush_duration")
 	require.Len(t, durations, 1)
 	assert.Equal(t, "result_mismatch", attrMap(durations[0].Attributes)["outcome"])
 
-	messages := sumPoints(t, rm, "chat.search.sync.messages")
+	messages := sumPoints(t, rm, "search_sync_worker_messages")
 	assert.Equal(t, int64(1), sumValue(messages, map[string]string{
 		"collection": "message-sync", "outcome": "nakked", "reason": "result_mismatch",
 	}))
@@ -220,7 +220,7 @@ func TestSyncMetrics_AddPoisonAcked(t *testing.T) {
 	h.Add(&stubMsg{data: []byte("{invalid")})
 
 	rm := collectMetrics(t, reader)
-	messages := sumPoints(t, rm, "chat.search.sync.messages")
+	messages := sumPoints(t, rm, "search_sync_worker_messages")
 	assert.Equal(t, int64(1), sumValue(messages, map[string]string{
 		"collection": "message-sync", "outcome": "acked", "reason": "poison",
 	}))
@@ -237,7 +237,7 @@ func TestSyncMetrics_AddFilteredAcked(t *testing.T) {
 	h.Add(makeStubMsg(t, metricsTestEvent()))
 
 	rm := collectMetrics(t, reader)
-	messages := sumPoints(t, rm, "chat.search.sync.messages")
+	messages := sumPoints(t, rm, "search_sync_worker_messages")
 	assert.Equal(t, int64(1), sumValue(messages, map[string]string{
 		"collection": "message-sync", "outcome": "acked", "reason": "filtered",
 	}))
@@ -294,7 +294,7 @@ func TestESParentResolver_RecordsResolveDuration(t *testing.T) {
 			return time.Time{}, false
 		},
 		timeout: time.Second,
-		metrics: sm,
+		metrics: sm.forCollection("message-sync"),
 	}
 
 	_, ok := r.ResolveParentCreatedAt(context.Background(), "hit")
@@ -303,11 +303,14 @@ func TestESParentResolver_RecordsResolveDuration(t *testing.T) {
 	require.False(t, ok)
 
 	rm := collectMetrics(t, reader)
-	points := histPoints[float64](t, rm, "chat.search.sync.parent.resolve.duration")
+	points := histPoints[float64](t, rm, "search_sync_worker_parent_resolve_duration")
 	require.Len(t, points, 2)
 	byOutcome := map[string]uint64{}
 	for _, p := range points {
-		byOutcome[attrMap(p.Attributes)["outcome"]] = p.Count
+		attrs := attrMap(p.Attributes)
+		assert.Equal(t, "message-sync", attrs["collection"],
+			"the two message resolvers share the instruments, so the series must split by collection")
+		byOutcome[attrs["outcome"]] = p.Count
 	}
 	assert.Equal(t, uint64(1), byOutcome["resolved"])
 	assert.Equal(t, uint64(1), byOutcome["unresolved"])

--- a/search-sync-worker/metrics_test.go
+++ b/search-sync-worker/metrics_test.go
@@ -1,0 +1,314 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.uber.org/mock/gomock"
+
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/searchengine"
+)
+
+func newTestSyncMetrics(t *testing.T) (*syncMetrics, *sdkmetric.ManualReader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	return newSyncMetrics(mp.Meter("test")), reader
+}
+
+func collectMetrics(t *testing.T, reader sdkmetric.Reader) metricdata.ResourceMetrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	return rm
+}
+
+func sumPoints(t *testing.T, rm metricdata.ResourceMetrics, name string) []metricdata.DataPoint[int64] {
+	t.Helper()
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != name {
+				continue
+			}
+			data, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "metric %s has unexpected type %T", name, m.Data)
+			return data.DataPoints
+		}
+	}
+	return nil
+}
+
+func histPoints[T int64 | float64](t *testing.T, rm metricdata.ResourceMetrics, name string) []metricdata.HistogramDataPoint[T] {
+	t.Helper()
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != name {
+				continue
+			}
+			data, ok := m.Data.(metricdata.Histogram[T])
+			require.True(t, ok, "metric %s has unexpected type %T", name, m.Data)
+			return data.DataPoints
+		}
+	}
+	return nil
+}
+
+func attrMap(set attribute.Set) map[string]string {
+	out := map[string]string{}
+	for _, kv := range set.ToSlice() {
+		out[string(kv.Key)] = kv.Value.AsString()
+	}
+	return out
+}
+
+// sumValue returns the summed value of every datapoint matching want exactly.
+func sumValue(points []metricdata.DataPoint[int64], want map[string]string) int64 {
+	var total int64
+	for _, p := range points {
+		got := attrMap(p.Attributes)
+		match := len(got) == len(want)
+		for k, v := range want {
+			if got[k] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			total += p.Value
+		}
+	}
+	return total
+}
+
+func metricsTestHandler(t *testing.T, store Store) (*Handler, *sdkmetric.ManualReader) {
+	t.Helper()
+	sm, reader := newTestSyncMetrics(t)
+	h := NewHandler(store, newMessageCollection("msgs-v1", "site-a", time.Time{}, false), 500)
+	h.metrics = sm.forCollection("message-sync")
+	return h, reader
+}
+
+func metricsTestEvent() *model.MessageEvent {
+	return &model.MessageEvent{
+		Event: model.EventCreated,
+		Message: model.Message{
+			ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+			Content: "hello", CreatedAt: time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
+		},
+		SiteID: "site-a", Timestamp: 100,
+	}
+}
+
+func TestSyncMetrics_FlushSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	store.EXPECT().Bulk(gomock.Any(), gomock.Len(1)).
+		Return([]searchengine.BulkResult{{Status: 201}}, nil)
+
+	h, reader := metricsTestHandler(t, store)
+	h.Add(makeStubMsg(t, metricsTestEvent()))
+	h.Flush(context.Background())
+
+	rm := collectMetrics(t, reader)
+
+	durations := histPoints[float64](t, rm, "chat.search.sync.bulk.flush.duration")
+	require.Len(t, durations, 1)
+	assert.Equal(t, uint64(1), durations[0].Count)
+	assert.Equal(t, map[string]string{
+		"collection": "message-sync",
+		"outcome":    "success",
+	}, attrMap(durations[0].Attributes))
+
+	actions := histPoints[int64](t, rm, "chat.search.sync.bulk.flush.actions")
+	require.Len(t, actions, 1)
+	assert.Equal(t, int64(1), actions[0].Sum)
+	assert.Equal(t, map[string]string{"collection": "message-sync"}, attrMap(actions[0].Attributes))
+
+	messages := sumPoints(t, rm, "chat.search.sync.messages")
+	assert.Equal(t, int64(1), sumValue(messages, map[string]string{
+		"collection": "message-sync", "outcome": "acked", "reason": "success",
+	}))
+}
+
+func TestSyncMetrics_FlushRequestError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	store.EXPECT().Bulk(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("es down"))
+
+	h, reader := metricsTestHandler(t, store)
+	h.Add(makeStubMsg(t, metricsTestEvent()))
+	h.Flush(context.Background())
+
+	rm := collectMetrics(t, reader)
+
+	durations := histPoints[float64](t, rm, "chat.search.sync.bulk.flush.duration")
+	require.Len(t, durations, 1)
+	assert.Equal(t, map[string]string{
+		"collection": "message-sync",
+		"outcome":    "request_error",
+	}, attrMap(durations[0].Attributes))
+
+	messages := sumPoints(t, rm, "chat.search.sync.messages")
+	assert.Equal(t, int64(1), sumValue(messages, map[string]string{
+		"collection": "message-sync", "outcome": "nakked", "reason": "request_failed",
+	}))
+}
+
+func TestSyncMetrics_FlushItemFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	store.EXPECT().Bulk(gomock.Any(), gomock.Len(1)).
+		Return([]searchengine.BulkResult{{Status: 429, Error: "es_rejected_execution_exception"}}, nil)
+
+	h, reader := metricsTestHandler(t, store)
+	h.Add(makeStubMsg(t, metricsTestEvent()))
+	h.Flush(context.Background())
+
+	rm := collectMetrics(t, reader)
+
+	failures := sumPoints(t, rm, "chat.search.sync.bulk.item.failures")
+	assert.Equal(t, int64(1), sumValue(failures, map[string]string{
+		"collection": "message-sync", "action": "index", "status": "429",
+	}))
+
+	messages := sumPoints(t, rm, "chat.search.sync.messages")
+	assert.Equal(t, int64(1), sumValue(messages, map[string]string{
+		"collection": "message-sync", "outcome": "nakked", "reason": "item_failed",
+	}))
+
+	durations := histPoints[float64](t, rm, "chat.search.sync.bulk.flush.duration")
+	require.Len(t, durations, 1)
+	assert.Equal(t, "success", attrMap(durations[0].Attributes)["outcome"],
+		"per-item failures nak their own messages but the flush round-trip itself succeeded")
+}
+
+func TestSyncMetrics_FlushResultMismatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	store.EXPECT().Bulk(gomock.Any(), gomock.Len(1)).
+		Return([]searchengine.BulkResult{}, nil)
+
+	h, reader := metricsTestHandler(t, store)
+	h.Add(makeStubMsg(t, metricsTestEvent()))
+	h.Flush(context.Background())
+
+	rm := collectMetrics(t, reader)
+
+	durations := histPoints[float64](t, rm, "chat.search.sync.bulk.flush.duration")
+	require.Len(t, durations, 1)
+	assert.Equal(t, "result_mismatch", attrMap(durations[0].Attributes)["outcome"])
+
+	messages := sumPoints(t, rm, "chat.search.sync.messages")
+	assert.Equal(t, int64(1), sumValue(messages, map[string]string{
+		"collection": "message-sync", "outcome": "nakked", "reason": "result_mismatch",
+	}))
+}
+
+func TestSyncMetrics_AddPoisonAcked(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h, reader := metricsTestHandler(t, NewMockStore(ctrl))
+
+	h.Add(&stubMsg{data: []byte("{invalid")})
+
+	rm := collectMetrics(t, reader)
+	messages := sumPoints(t, rm, "chat.search.sync.messages")
+	assert.Equal(t, int64(1), sumValue(messages, map[string]string{
+		"collection": "message-sync", "outcome": "acked", "reason": "poison",
+	}))
+}
+
+func TestSyncMetrics_AddFilteredAcked(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	sm, reader := newTestSyncMetrics(t)
+	// syncFrom after the event's CreatedAt filters it out — zero actions, acked.
+	cutoff := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	h := NewHandler(NewMockStore(ctrl), newMessageCollection("msgs-v1", "site-a", cutoff, false), 500)
+	h.metrics = sm.forCollection("message-sync")
+
+	h.Add(makeStubMsg(t, metricsTestEvent()))
+
+	rm := collectMetrics(t, reader)
+	messages := sumPoints(t, rm, "chat.search.sync.messages")
+	assert.Equal(t, int64(1), sumValue(messages, map[string]string{
+		"collection": "message-sync", "outcome": "acked", "reason": "filtered",
+	}))
+	assert.Equal(t, 0, h.MessageCount())
+}
+
+func TestSyncMetrics_NoMetricsConfigured(t *testing.T) {
+	// A handler without metrics wiring must keep working — nothing to assert
+	// beyond "does not panic" on both the Add and Flush paths.
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	store.EXPECT().Bulk(gomock.Any(), gomock.Any()).
+		Return([]searchengine.BulkResult{{Status: 201}}, nil)
+
+	h := NewHandler(store, newMessageCollection("msgs-v1", "site-a", time.Time{}, false), 500)
+	h.Add(makeStubMsg(t, metricsTestEvent()))
+	h.Flush(context.Background())
+	assert.Equal(t, 0, h.MessageCount())
+}
+
+func TestBulkStatusLabel(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		want   string
+	}{
+		{"bad request kept exact", 400, "400"},
+		{"not found kept exact", 404, "404"},
+		{"conflict kept exact", 409, "409"},
+		{"payload too large kept exact", 413, "413"},
+		{"too many requests kept exact", 429, "429"},
+		{"internal kept exact", 500, "500"},
+		{"unavailable kept exact", 503, "503"},
+		{"other 4xx bucketed", 418, "4xx"},
+		{"other 5xx bucketed", 502, "5xx"},
+		{"non-error status bucketed as other", 302, "other"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, bulkStatusLabel(tt.status))
+		})
+	}
+}
+
+func TestESParentResolver_RecordsResolveDuration(t *testing.T) {
+	sm, reader := newTestSyncMetrics(t)
+
+	resolved := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	r := &esParentResolver{
+		esRead: func(ctx context.Context, messageID string) (time.Time, bool) {
+			if messageID == "hit" {
+				return resolved, true
+			}
+			return time.Time{}, false
+		},
+		timeout: time.Second,
+		metrics: sm,
+	}
+
+	_, ok := r.ResolveParentCreatedAt(context.Background(), "hit")
+	require.True(t, ok)
+	_, ok = r.ResolveParentCreatedAt(context.Background(), "miss")
+	require.False(t, ok)
+
+	rm := collectMetrics(t, reader)
+	points := histPoints[float64](t, rm, "chat.search.sync.parent.resolve.duration")
+	require.Len(t, points, 2)
+	byOutcome := map[string]uint64{}
+	for _, p := range points {
+		byOutcome[attrMap(p.Attributes)["outcome"]] = p.Count
+	}
+	assert.Equal(t, uint64(1), byOutcome["resolved"])
+	assert.Equal(t, uint64(1), byOutcome["unresolved"])
+}

--- a/search-sync-worker/thread_parent_resolver.go
+++ b/search-sync-worker/thread_parent_resolver.go
@@ -20,7 +20,7 @@ type esReadFn func(ctx context.Context, messageID string) (time.Time, bool)
 type esParentResolver struct {
 	esRead  esReadFn
 	timeout time.Duration
-	metrics *syncMetrics // optional, set by main; nil-safe recording
+	metrics *collectionMetrics // optional, set by main; nil-safe recording
 }
 
 // ResolveParentCreatedAt returns the parent's createdAt and ok=true when resolved.

--- a/search-sync-worker/thread_parent_resolver.go
+++ b/search-sync-worker/thread_parent_resolver.go
@@ -20,6 +20,7 @@ type esReadFn func(ctx context.Context, messageID string) (time.Time, bool)
 type esParentResolver struct {
 	esRead  esReadFn
 	timeout time.Duration
+	metrics *syncMetrics // optional, set by main; nil-safe recording
 }
 
 // ResolveParentCreatedAt returns the parent's createdAt and ok=true when resolved.
@@ -27,7 +28,10 @@ type esParentResolver struct {
 func (r *esParentResolver) ResolveParentCreatedAt(ctx context.Context, messageID string) (time.Time, bool) {
 	ctx, cancel := context.WithTimeout(ctx, r.timeout)
 	defer cancel()
-	return r.esRead(ctx, messageID)
+	start := time.Now()
+	createdAt, ok := r.esRead(ctx, messageID)
+	r.metrics.recordParentResolve(ctx, time.Since(start).Seconds(), ok)
+	return createdAt, ok
 }
 
 // esSearcher is the narrow search surface the ES self-lookup needs.


### PR DESCRIPTION
## Why

Under loadgen the `message-sync` durable shows elevated ack-pending and redelivered messages, and nothing on a dashboard can attribute it: the o11y Elasticsearch integration is trace-only (ADR 0020 §6), so ES bulk latency, per-item rejections (429), and the thread-parent ES self-lookup were invisible outside traces. This closes the search-sync bulk-outcome gap already tracked in `docs/specs/o11y/o11y-metrics-inventory.md`.

## What

Five service-local OTel instruments in `search-sync-worker/metrics.go`, following the repo's `nats_metrics.go` pattern (snake_case service-prefixed names, closed-enum labels, precomputed attribute sets, noop fallback on instrument-creation failure):

| Instrument (exported name) | Labels | Answers |
|---|---|---|
| `search_sync_worker_bulk_flush_duration_seconds` | `collection`, `outcome` | is ES bulk slow / approaching AckWait |
| `search_sync_worker_bulk_flush_actions` | `collection` | are batches filling up |
| `search_sync_worker_bulk_item_failures_total` | `collection`, `action`, `status` | is ES rejecting writes (429 visible directly) |
| `search_sync_worker_messages_total` | `collection`, `outcome`, `reason` | where redeliveries come from (request_failed / item_failed / result_mismatch) |
| `search_sync_worker_parent_resolve_duration_seconds` | `collection`, `outcome` | is the thread-parent ES self-lookup dragging the consumer loop |

Wiring: built once in `main.go` after `obs.Init`, bound per collection onto each `Handler` and the two parent resolvers. Unwired handlers/resolvers stay no-ops via nil-safe recorders, so existing tests and the teams mode are untouched.

One behavioral nuance: the per-message bulk-item failure loop now records every failed action instead of stopping at the first (logging still emits only the first per message). Ack/nak behavior is unchanged.

Also updates the metrics inventory row and marks the search-sync bulk-outcome follow-up closed.

## Validation

- TDD throughout: tests written first and watched fail, then implementation (`metrics_test.go`, 9 tests covering success / request error / item failure / result mismatch / poison / filtered / unwired no-op / status-label mapping / resolver outcomes)
- `make test` full suite green (race detector), `make lint` 0 issues
- `make sast`: gosec PASS; govulncheck/semgrep could not run in this container (proxy-blocked vuln DB / tool not installed) — CI gate covers them
- Branch reviewed (8-angle pass): no correctness findings; 4 observability-consistency findings all addressed in the second commit (snake_case naming per repo convention, `collection` label on parent-resolve, unified `request_failed` spelling, delivery-attempt wording)

No client-facing handler or API change — `docs/client-api.md` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YX7GYSNHxsfNt5cbg2BSt2

---
_Generated by [Claude Code](https://claude.ai/code/session_01YX7GYSNHxsfNt5cbg2BSt2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive observability metrics for search synchronization, including processing outcomes, bulk operations, item failures, and parent-resolution timing.
  * Metrics are reported per collection with bounded status and outcome labels.
  * Added tracking for message acknowledgements, filtered messages, and processing failures.

* **Documentation**
  * Updated the metrics inventory to document the new search synchronization metrics and completed bulk outcome coverage.

* **Tests**
  * Added coverage for successful and failed bulk operations, message dispositions, status labeling, and parent-resolution timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->