### PR TITLE
fix(reactions): accept any emoji, drop the shortcode support check

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -3849,7 +3849,7 @@ Toggles a reaction on a message. Any subscribed room member may react — the se
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `messageId` | string | yes | The message to react to. |
-| `shortcode` | string | yes | The bare reaction shortcode without surrounding colons (e.g. `thumbsup`, `acme_party`). Must match `^[a-z0-9_+-]{1,32}$` after NFC normalisation. The server validates **format only** — it does not check the shortcode against the standard-emoji set or the site's registered custom emoji. Clients are expected to offer only shortcodes from their picker (built-in standard set + the local site's [`emoji.list`](#emojilist--list-a-sites-custom-emoji)). |
+| `shortcode` | string | yes | The reaction emoji — **any non-empty, visible textual or Unicode key** (e.g. a bare shortcode `thumbsup`, a colon-wrapped `:thumbsup:`, ASCII punctuation like `_`/`-`, a raw-unicode emoji `👍` / ZWJ sequence / flag, or a private-use glyph). The server applies **no support check**: it NFC-normalises the value and rejects only (a) a value over 64 bytes (a resource guard, ~20× any real emoji) or (b) a value with **no visible character** — empty, or made only of whitespace / control / zero-width / combining-mark code points. It does **not** check the character set, the standard-emoji set, or the site's registered custom emoji. The **FE decides renderability**. Note: reactions are stored as **opaque keys with no shortcode↔unicode aliasing**, so `thumbsup` and `👍` are two distinct reactions — the FE should send one consistent representation per emoji. Clients typically offer shortcodes from their picker (built-in standard set + the local site's [`emoji.list`](#emojilist--list-a-sites-custom-emoji)), but any emoji is accepted (e.g. a migrated one the picker doesn't list). |
 
 ```json
 {
@@ -3878,7 +3878,7 @@ Toggles a reaction on a message. Any subscribed room member may react — the se
 
 ##### Error response
 
-See [Error envelope](#6-error-envelope-reference). Common errors: `"messageId is required"`, `"shortcode is required"`, `"invalid reaction shortcode"` (malformed: fails `^[a-z0-9_+-]{1,32}$` after NFC), `"message not found"` (also returned when attempting to _add_ a reaction to a soft-deleted message), `"not subscribed to room"`, `"failed to add reaction"`, `"failed to remove reaction"`.
+See [Error envelope](#6-error-envelope-reference). Common errors: `"messageId is required"`, `"shortcode is required"`, `"reaction emoji too large"` (over 64 bytes post-NFC), `"reaction emoji is required"` (no visible character — whitespace / control / zero-width / combining-mark only; an *empty* shortcode returns `"shortcode is required"` instead, checked before canonicalization), `"message not found"` (also returned when attempting to _add_ a reaction to a soft-deleted message), `"not subscribed to room"`, `"failed to add reaction"`, `"failed to remove reaction"`.
 
 ##### Triggered events — success path
 
@@ -3892,7 +3892,7 @@ See [Error envelope](#6-error-envelope-reference). Common errors: `"messageId is
 | `timestamp` | number | Epoch ms (UTC). Event publish time. |
 | `eventTimestamp` | number | Milliseconds since Unix epoch (UTC). When message-worker published the canonical event. Omitted for legacy events. |
 | `messageId` | string | The reacted-to message's ID. |
-| `shortcode` | string | The bare reaction shortcode. |
+| `shortcode` | string | The canonical NFC-normalised reaction key — a textual shortcode (`thumbsup`) or a raw-unicode emoji (`👍`); opaque, not format-validated. |
 | `action` | string | `"added"` or `"removed"`. |
 | `actor` | [Participant](#participant) | The user whose toggle produced this event. |
 | `reactedAt` | string (RFC 3339) | Domain time of the toggle. |
@@ -3934,7 +3934,7 @@ See [Error envelope](#6-error-envelope-reference). Common errors: `"messageId is
 
 | Field | Type | Notes |
 |---|---|---|
-| `shortcode` | string | The emoji shortcode reacted with. |
+| `shortcode` | string | The canonical NFC-normalised reaction key reacted with — a textual shortcode or a raw-unicode emoji; opaque, not format-validated. |
 | `action` | string | Always `"added"` here (the notification only fires on add). |
 | `actor` | [Participant](#participant) | The user who reacted. `displayName` is populated (`CombineWithFallback(engName, chineseName, account)`); for a bot account (`.bot` suffix) it's the app's display name instead, falling back to the composed name if no app matches. |
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -1267,7 +1267,7 @@ state. Can always **remove** from a soft-deleted message; cannot **add** to one.
 | Field | Type | Notes |
 |---|---|---|
 | `messageId` | string | Required. |
-| `shortcode` | string | Required. Bare shortcode without colons (`thumbsup`, `acme_party`). Must match `^[a-z0-9_+-]{1,32}$` after NFC normalisation. Format-only validation — no registration check; clients offer only picker-sourced shortcodes (standard set + local [`emoji.list`](#emojilist)). |
+| `shortcode` | string | Required. The reaction emoji — a bare shortcode without colons (`thumbsup`, `acme_party`) or a raw-unicode emoji (`👍`, ZWJ sequence, flag). No support check: NFC-normalised, rejects only >64 bytes (resource guard) or a value with no visible character (empty / whitespace / control / zero-width / combining-mark only) — no character-set, registration, or standard-set check. Stored as an opaque key with no shortcode↔unicode aliasing (`thumbsup` ≠ `👍`); FE sends one consistent representation and decides renderability. |
 
 #### Success response
 
@@ -1280,8 +1280,7 @@ state. Can always **remove** from a soft-deleted message; cannot **add** to one.
 
 #### Errors
 
-`"messageId is required"`, `"shortcode is required"`, `"invalid reaction shortcode"`
-(malformed format), `"message not found"`, `"not subscribed to room"`.
+`"messageId is required"`, `"shortcode is required"`, `"reaction emoji too large"`, `"reaction emoji is required"`, `"message not found"`, `"not subscribed to room"`.
 
 **Emits:** [`message_reacted`](events.md#message_reacted-reactroomevent) (channel `chat.room.{roomID}.event`; DM `chat.user.{account}.event.room` per non-bot member), [`notification`](events.md#notification--reaction-notification) (to message author on add only) → [events.md](events.md)
 

--- a/history-service/internal/service/reactions.go
+++ b/history-service/internal/service/reactions.go
@@ -35,9 +35,13 @@ func (s *HistoryService) ReactMessage(c *natsrouter.Context, siteID string, req 
 		return nil, errcode.BadRequest("shortcode is required")
 	}
 
-	shortcode, err := emoji.Canonicalize(req.Shortcode)
+	// Reactions accept any emoji (no support check): CanonicalizeReaction only
+	// NFC-normalizes and caps size, so a raw-unicode or Teams-migrated emoji isn't
+	// rejected — the FE decides renderability. Its only error is an oversized blob,
+	// already a friendly client-facing BadRequest, so return it as-is.
+	shortcode, err := emoji.CanonicalizeReaction(req.Shortcode)
 	if err != nil {
-		return nil, errcode.BadRequest("invalid reaction shortcode")
+		return nil, err
 	}
 	// From here on, use the canonicalized shortcode (NFC-canonical) for any
 	// storage key or wire echo; req.Shortcode is raw input.

--- a/history-service/internal/service/reactions_test.go
+++ b/history-service/internal/service/reactions_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -64,8 +65,9 @@ func TestHistoryService_ReactMessage_NotSubscribed(t *testing.T) {
 	assertForbiddenErr(t, err, "not subscribed to room")
 }
 
-// Every pre-storage rejection path: empty fields, regex fail. Shortcode acceptance
-// is format-only (emoji.Canonicalize) — there is no registration lookup to fail.
+// Every pre-storage rejection path: empty fields, and the only remaining emoji
+// guard (oversize). Reactions accept any emoji — no support check
+// (emoji.CanonicalizeReaction) — so raw-unicode/uppercase/colon forms are NOT rejected.
 func TestHistoryService_ReactMessage_ValidationErrors(t *testing.T) {
 	cases := []struct {
 		name         string
@@ -87,16 +89,10 @@ func TestHistoryService_ReactMessage_ValidationErrors(t *testing.T) {
 			wantMsg:      "shortcode is required",
 		},
 		{
-			name:      "invalid shortcode format (colons)",
-			shortcode: ":thumbsup:", messageID: "m1",
+			name:      "oversize rejected",
+			shortcode: strings.Repeat("a", 65), messageID: "m1",
 			wantCategory: errcode.CodeBadRequest,
-			wantMsg:      "invalid reaction shortcode",
-		},
-		{
-			name:      "invalid shortcode format (uppercase)",
-			shortcode: "ThumbsUp", messageID: "m1",
-			wantCategory: errcode.CodeBadRequest,
-			wantMsg:      "invalid reaction shortcode",
+			wantMsg:      "reaction emoji too large",
 		},
 	}
 	for _, tc := range cases {
@@ -119,7 +115,7 @@ func TestHistoryService_ReactMessage_ValidationErrors(t *testing.T) {
 // TestHistoryService_ReactMessage_UnregisteredShortcode_Accepted covers the
 // behavior flip: a well-formed shortcode that is neither a standard emoji nor
 // registered in any site's custom_emojis collection is now accepted — format
-// validation (emoji.Canonicalize) is the only gate.
+// validation (emoji.CanonicalizeReaction) is the only gate.
 func TestHistoryService_ReactMessage_UnregisteredShortcode_Accepted(t *testing.T) {
 	f := newReactFixture(t)
 	createdAt := joinTime.Add(1 * time.Minute)

--- a/pkg/emoji/emoji.go
+++ b/pkg/emoji/emoji.go
@@ -1,9 +1,9 @@
-// Package emoji provides reaction shortcode canonicalization and the
-// built-in standard-emoji set. Shortcodes are bare (no colons),
-// `[a-z0-9_+-]{1,32}`, and NFC-normalised; the canonical form is what
-// callers bind into storage. There is no registration check here: reactions
-// accept any well-formed shortcode. media-service's upload path still uses
-// IsStandard to reserve standard names from custom-emoji registration.
+// Package emoji canonicalizes reaction emoji and holds the built-in
+// standard-emoji set. Reactions accept ANY emoji (raw unicode, ZWJ sequences,
+// ASCII shortcodes) via CanonicalizeReaction — there is no support check; the
+// FE decides renderability. Canonicalize (the `[a-z0-9_+-]{1,32}` form) is kept
+// for media-service's custom-emoji upload path, where shortcodes are named and
+// IsStandard reserves standard names.
 package emoji
 
 //go:generate go run -C gen .
@@ -12,8 +12,11 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"unicode"
 
 	"golang.org/x/text/unicode/norm"
+
+	"github.com/hmchangw/chat/pkg/errcode"
 )
 
 var shortcodeRe = regexp.MustCompile(`^[a-z0-9_+-]{1,32}$`)
@@ -41,6 +44,58 @@ func Canonicalize(shortcode string) (string, error) {
 		return "", fmt.Errorf("canonicalize shortcode %q: %w", shortcode, ErrInvalidShortcode)
 	}
 	return shortcode, nil
+}
+
+// ReactionMaxBytes caps a reaction emoji — ~20× any real emoji, so it only ever
+// rejects an abusive/buggy blob, never a legitimate reaction.
+const ReactionMaxBytes = 64
+
+// reactionMaxInputBytes bounds the pre-normalization input so an attacker-sized
+// blob can't force O(n) NFC work before the post-NFC cap applies. NFC grows
+// length only modestly, so this generous ceiling never rejects a valid emoji.
+const reactionMaxInputBytes = 256
+
+// CanonicalizeReaction normalizes a reaction emoji for use as a storage/wire key
+// with NO support check: any emoji is accepted and the FE decides renderability.
+// It keeps only structural invariants, none about "is this supported": a byte cap
+// (so a client can't blob-bomb the reactions map), NFC (so the same emoji in two
+// normalization forms is one storage key, not two reactions), and a content-rune
+// check (so an invisible key can't be stored). Returns a client-facing BadRequest
+// so callers can return the error as-is with a friendly message.
+//
+// It does NOT map shortcode↔unicode: `thumbsup` and `👍` are distinct keys, since
+// there is no support/alias table (that would contradict "accept any emoji"). The
+// FE is responsible for sending one consistent representation per emoji.
+func CanonicalizeReaction(emojiKey string) (string, error) {
+	if len(emojiKey) > reactionMaxInputBytes { // reject before paying for NFC
+		return "", errcode.BadRequest("reaction emoji too large")
+	}
+	if !norm.NFC.IsNormalString(emojiKey) {
+		emojiKey = norm.NFC.String(emojiKey)
+	}
+	if len(emojiKey) > ReactionMaxBytes { // check post-NFC — normalization can grow bytes.
+		return "", errcode.BadRequest("reaction emoji too large")
+	}
+	// Require a visible rune. "Invisible" = whitespace, control (Cc), format
+	// (Cf — U+200B ZWSP, U+200D ZWJ), or a combining mark (M — U+FE0F) — a key made
+	// only of these stores as an invisible reaction. Everything else is visible,
+	// including ASCII punctuation like `_`/`-` (valid shortcode chars), private-use
+	// glyphs (Co), and not-yet-assigned code points (Cn) — a future emoji absent
+	// from this Go build's Unicode tables must still be accepted ("FE decides
+	// renderability"), so we deny only Cc/Cf/M, NOT the whole C category.
+	if !hasVisibleRune(emojiKey) {
+		return "", errcode.BadRequest("reaction emoji is required")
+	}
+	return emojiKey, nil
+}
+
+func hasVisibleRune(s string) bool {
+	for _, r := range s {
+		if !unicode.IsSpace(r) && !unicode.In(r, unicode.Cc, unicode.Cf, unicode.M) {
+			return true
+		}
+	}
+	return false
 }
 
 // IsStandard reports whether an already-canonical shortcode is one of the

--- a/pkg/emoji/emoji_test.go
+++ b/pkg/emoji/emoji_test.go
@@ -104,3 +104,69 @@ func TestIsStandard(t *testing.T) {
 	assert.False(t, emoji.IsStandard("acme_party"))
 	assert.False(t, emoji.IsStandard(""))
 }
+
+func TestCanonicalizeReaction(t *testing.T) {
+	// Accepts any emoji (no support check); the only reject is an oversized blob.
+	accepted := []struct{ name, in, want string }{
+		{"ascii shortcode", "party_parrot", "party_parrot"},
+		{"uppercase allowed", "Party", "Party"},
+		{"raw unicode thumbsup", "👍", "👍"},
+		{"raw unicode with VS16", "❤️", "❤️"},
+		{"zwj family sequence", "👨‍👩‍👧‍👦", "👨‍👩‍👧‍👦"},
+		{"flag", "🇹🇼", "🇹🇼"},
+		{"colons allowed (opaque text)", ":thumbsup:", ":thumbsup:"},
+		{"underscore-only shortcode", "_", "_"},
+		{"dash-only shortcode", "-", "-"},
+		{"plus-one", "+1", "+1"},
+		{"private-use glyph accepted", "\ue000", "\ue000"},
+		{"64 bytes ok", strings.Repeat("a", 64), strings.Repeat("a", 64)},
+	}
+	for _, tc := range accepted {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := emoji.CanonicalizeReaction(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("over 64 bytes rejected", func(t *testing.T) {
+		got, err := emoji.CanonicalizeReaction(strings.Repeat("a", 65))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reaction emoji too large")
+		assert.Empty(t, got)
+	})
+
+	// A key with no visible rune (all whitespace/control) must be rejected — the
+	// old shortcode regex excluded these; without the guard they'd store as an
+	// invisible reaction.
+	invisible := []struct{ name, in string }{
+		{"space only", " "},
+		{"tab only", "\t"},
+		{"newline only", "\n"},
+		{"control char only", "\a"},
+		{"mixed whitespace", " \t\n"},
+		{"zero-width space only", "\u200b"},
+		{"zero-width joiner only", "\u200d"},
+		{"variation selector only", "\ufe0f"},
+		{"combining mark only", "\u0301"},
+	}
+	for _, tc := range invisible {
+		t.Run(tc.name+" rejected", func(t *testing.T) {
+			got, err := emoji.CanonicalizeReaction(tc.in)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "reaction emoji is required")
+			assert.Empty(t, got)
+		})
+	}
+}
+
+// TestCanonicalizeReaction_NFC_CollapsesForms: the same emoji in two normalization
+// forms canonicalizes to one key, so it can't create two separate reactions.
+func TestCanonicalizeReaction_NFC_CollapsesForms(t *testing.T) {
+	// U+00E9 (é precomposed) vs U+0065 U+0301 (e + combining acute).
+	a, err := emoji.CanonicalizeReaction("é")
+	require.NoError(t, err)
+	b, err := emoji.CanonicalizeReaction("é")
+	require.NoError(t, err)
+	assert.Equal(t, a, b, "NFC must collapse equivalent forms to one storage key")
+}

--- a/pkg/model/cassandra/reactions.go
+++ b/pkg/model/cassandra/reactions.go
@@ -11,8 +11,8 @@ import (
 // ReactionKey is the map-key UDT for Message.Reactions.
 type ReactionKey struct {
 	// Emoji must be NFC-normalised by writers; enforcement is in
-	// pkg/emoji.Canonicalize (the single chokepoint history-service uses
-	// before binding a value into this field; format-only, not this type).
+	// pkg/emoji.CanonicalizeReaction (the single chokepoint history-service uses
+	// before binding a value into this field; NFC + size only, no support check).
 	Emoji       string `json:"emoji"       cql:"emoji"`
 	UserAccount string `json:"userAccount" cql:"user_account"`
 }


### PR DESCRIPTION
## Summary

Reactions rejected any emoji that failed the shortcode regex `^[a-z0-9_+-]{1,32}$` — a raw-unicode emoji (`👍`), uppercase, or a ZWJ sequence — with `invalid reaction shortcode`, even though there is **no** support/registration check behind reactions (an unknown ASCII shortcode is already accepted and written). That blocked legitimate emoji (e.g. a migrated or picker-external one) for no correctness reason.

This drops the character-set "support check" on the reaction path: any emoji is accepted and the client decides renderability.

## Changes

- `pkg/emoji`: add `CanonicalizeReaction` — NFC-normalise + reject empty / over 64 bytes / control chars, with **no** character-set regex. The existing `Canonicalize` (`[a-z0-9_+-]{1,32}` + `IsStandard`) is unchanged and still used by the custom-emoji **upload** path (named ASCII shortcodes), so this is scoped to reactions.
- `history-service` `ReactMessage`: use `CanonicalizeReaction`; the error now fires only on genuinely malformed input (empty / oversized / control), never on an unsupported-but-valid emoji.
- NFC is retained deliberately: it collapses two normalization forms of the same emoji to one storage key, so a client can't create two separate reactions for one emoji.
- `docs/client-api.md` + the request/reply view: the `shortcode` field now documents "any emoji, FE decides renderability; NFC + size only".

## Verification

- Unit: `CanonicalizeReaction` accepts `👍`, flags, ZWJ family sequences, uppercase, ASCII shortcodes; rejects empty / >64 bytes / control chars; NFC collapses equivalent forms. `ReactMessage` validation tests updated (colon/uppercase are no longer rejections; control-char + oversize are). `pkg/emoji` + `history-service` suites green.
- Verified on our dev stack at the wire layer: reacting with a raw `👍` is accepted and the reply echoes `{"shortcode":"👍","action":"added"}`; an ASCII shortcode still works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reactions now support raw Unicode emoji, including multi-character sequences, as well as textual shortcodes.
  * Reaction values are NFC-normalized consistently and can be up to 64 bytes.
  * Textual shortcodes and Unicode emoji remain distinct reaction values.

* **Bug Fixes**
  * Improved validation rejects empty, invisible-only, or oversized values with clearer error messages.

* **Documentation**
  * Updated client API guidance to describe supported formats and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->