### PR TITLE
fix(broadcast-worker): attach resolved mentions to the message_edited event

### DIFF
--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -383,7 +383,12 @@ func (h *Handler) handleUpdated(ctx context.Context, evt *model.MessageEvent) er
 		}
 	}
 
+	// Resolve mentionees once: the same participants render on the edit event
+	// and route the cross-site badge, so we avoid a second FindUsersByAccounts.
+	participants := h.resolveEditMentions(ctx, parsed)
+
 	edit := buildEditRoomEvent(room, evt)
+	edit.Mentions = participants
 	if room.Type == model.RoomTypeChannel && h.encrypt {
 		if err := h.encryptEditedContent(ctx, room.ID, &edit); err != nil {
 			return fmt.Errorf("encrypt edit content for room %s: %w", room.ID, err)
@@ -392,26 +397,10 @@ func (h *Handler) handleUpdated(ctx context.Context, evt *model.MessageEvent) er
 	if err := h.publishMutation(ctx, room, model.RoomEventMessageEdited, msg.ID, &edit); err != nil {
 		return err
 	}
-	h.federateEditMentions(ctx, room.ID, msg.ID, parsed, *msg.EditedAt)
+	// Routing runs after the client broadcast; an unresolved mentionee has no
+	// site, so federateMentions simply relays nothing rather than failing the edit.
+	h.federateMentions(ctx, room.ID, msg.ID, participants, *msg.EditedAt)
 	return nil
-}
-
-// federateEditMentions resolves an edit's mentionees to their home sites and
-// relays the badge. The lookup is routing-only, so it runs after the client
-// broadcast, is skipped when federation is off, and a failure costs the relay
-// rather than the local badge.
-func (h *Handler) federateEditMentions(ctx context.Context, roomID, msgID string, parsed mention.ParseResult, at time.Time) {
-	if h.publish == nil || len(parsed.Accounts) == 0 {
-		return
-	}
-	users, err := h.userStore.FindUsersByAccounts(ctx, parsed.Accounts)
-	if err != nil {
-		slog.WarnContext(ctx, "user lookup failed for edited mentions, skipping federation",
-			"error", err, "room_id", roomID,
-			"request_id", natsutil.RequestIDFromContext(ctx))
-		return
-	}
-	h.federateMentions(ctx, roomID, msgID, mention.ResolveFromParsed(parsed, usersByAccount(users)).Participants, at)
 }
 
 // federateMentions relays the badge to each mentionee's home site, one event per
@@ -494,6 +483,26 @@ func (h *Handler) federateMentions(ctx context.Context, roomID, msgID string, pa
 	}
 }
 
+// resolveEditMentions resolves parsed @-mentions to participants (account +
+// display info) for the edit event, mirroring the create path so an edit-added
+// mention renders like a fresh one. The event's mentions[] is best-effort
+// enrichment, NOT the durable signal: the unread badge is set separately by
+// SetSubscriptionMentions and newContent still carries the raw @account, so on a
+// user-lookup error we drop the mentions[] enrichment entirely (return nil)
+// rather than emitting a partial set or failing/retrying the edit. nil when none.
+func (h *Handler) resolveEditMentions(ctx context.Context, parsed mention.ParseResult) []model.Participant {
+	if len(parsed.Accounts) == 0 {
+		return nil
+	}
+	users, err := h.userStore.FindUsersByAccounts(ctx, parsed.Accounts)
+	if err != nil {
+		slog.WarnContext(ctx, "user lookup failed resolving edit mentions, dropping edit mentions",
+			"error", err, "request_id", natsutil.RequestIDFromContext(ctx))
+		return nil
+	}
+	return mention.ResolveFromParsed(parsed, usersByAccount(users)).Participants
+}
+
 func (h *Handler) handleThreadUpdated(ctx context.Context, evt *model.MessageEvent) error {
 	msg := evt.Message
 	if msg.EditedAt == nil || msg.UpdatedAt == nil {
@@ -509,11 +518,12 @@ func (h *Handler) handleThreadUpdated(ctx context.Context, evt *model.MessageEve
 		return fmt.Errorf("get room %s: %w", msg.RoomID, err)
 	}
 
+	parsed := mention.Parse(msg.Content)
 	edit := buildEditRoomEvent(room, evt)
+	edit.Mentions = h.resolveEditMentions(ctx, parsed)
 
 	switch room.Type {
 	case model.RoomTypeChannel:
-		parsed := mention.Parse(msg.Content)
 		fanOut, err := h.channelThreadFanOut(ctx, room.ID, room.SiteID, parentMsgID, msg.UserAccount, parsed.Accounts, msg.ThreadParentMessageCreatedAt, evt.ThreadParentSenderAccount)
 		if err != nil {
 			return fmt.Errorf("channel thread fan-out for thread update of parent %s: %w", parentMsgID, err)

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -840,6 +840,41 @@ func TestHandleUpdated_ChannelRoomScopedPublish(t *testing.T) {
 	assert.True(t, roomEvt.UpdatedAt.Equal(edited))
 }
 
+func TestHandleUpdated_AttachesMentionsToEditEvent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	roomID := "r1"
+	store.EXPECT().GetRoom(gomock.Any(), roomID).Return(&model.Room{ID: roomID, Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
+	store.EXPECT().SetSubscriptionMentions(gomock.Any(), roomID, gomock.InAnyOrder([]string{"bob"}), gomock.Any()).Return(nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"bob"}).
+		Return([]model.User{{ID: "u-bob", Account: "bob", EngName: "Bob"}}, nil)
+
+	edited := time.Date(2026, 5, 14, 12, 5, 0, 0, time.UTC)
+	evt := model.MessageEvent{
+		Event: model.EventUpdated, SiteID: "site-a", Timestamp: edited.UnixMilli(),
+		Message: model.Message{
+			ID: "msg-1", RoomID: roomID, UserID: "u-alice", UserAccount: "alice",
+			Content: "morning team @bob", CreatedAt: edited.Add(-time.Hour),
+			EditedAt: &edited, UpdatedAt: &edited,
+		},
+	}
+	data, err := json.Marshal(&evt)
+	require.NoError(t, err)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	require.Len(t, pub.records, 1)
+	var roomEvt model.EditRoomEvent
+	require.NoError(t, json.Unmarshal(pub.records[0].data, &roomEvt))
+	require.Len(t, roomEvt.Mentions, 1, "edit event must carry the resolved mention")
+	assert.Equal(t, "bob", roomEvt.Mentions[0].Account)
+}
+
 func TestHandleUpdated_RelaysPreviewObject(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
@@ -994,6 +1029,8 @@ func TestHandleUpdated_BadgesNewlyAddedMentions(t *testing.T) {
 			store.EXPECT().GetRoom(gomock.Any(), "room-1").Return(testChannelRoom, nil)
 			if tc.wantSetMentions != nil {
 				store.EXPECT().SetSubscriptionMentions(gomock.Any(), "room-1", gomock.InAnyOrder(tc.wantSetMentions), edited).Return(nil)
+				// The edit event now also resolves participants for its mentions[] (mirrors create).
+				us.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return(nil, nil)
 			}
 
 			evt := model.MessageEvent{
@@ -2872,6 +2909,49 @@ func TestHandleThreadUpdated_ChannelRoom_FansOutToFollowers(t *testing.T) {
 	assert.True(t, subjects[subject.UserRoomEvent("carol")])
 }
 
+// The thread-edit event must carry resolved mentions[] just like the top-level
+// edit (TestHandleUpdated_AttachesMentionsToEditEvent) — without this a regression
+// dropping edit.Mentions from handleThreadUpdated would go unnoticed.
+func TestHandleThreadUpdated_AttachesMentionsToEditEvent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	parentAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	msgTime := parentAt.Add(2 * time.Hour)
+	editedAt := msgTime.Add(time.Minute)
+
+	room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"bob"}).
+		Return([]model.User{{ID: "u-bob", Account: "bob", SiteID: "site-a", EngName: "Bob"}}, nil)
+	store.EXPECT().GetHistorySharedSince(gomock.Any(), "r1", gomock.Any()).
+		Return(map[string]*time.Time{"bob": nil}, nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{}, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventUpdated, SiteID: "site-a", Timestamp: editedAt.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "r1", UserAccount: "alice",
+			Content: "@bob thread edit", CreatedAt: msgTime,
+			EditedAt: &editedAt, UpdatedAt: &editedAt,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, stubParentFetcher{info: &ParentMessageInfo{CreatedAt: parentAt}}, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	require.NotEmpty(t, pub.records)
+	var roomEvt model.EditRoomEvent
+	require.NoError(t, json.Unmarshal(pub.records[0].data, &roomEvt))
+	require.Len(t, roomEvt.Mentions, 1, "thread edit event must carry the resolved mention")
+	assert.Equal(t, "bob", roomEvt.Mentions[0].Account)
+}
+
 func TestHandleThreadUpdated_ChannelExcludesRestrictedAndNonMemberMentions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
@@ -2886,6 +2966,8 @@ func TestHandleThreadUpdated_ChannelExcludesRestrictedAndNonMemberMentions(t *te
 
 	room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}
 	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+	// The edit event resolves participants for its mentions[] (mirrors create).
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return(nil, nil)
 	// bob: member full access → included. carol: joined after parent → excluded.
 	// dave: absent → non-member → excluded.
 	store.EXPECT().GetHistorySharedSince(gomock.Any(), "r1", gomock.Any()).

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -3410,6 +3410,7 @@ The payload is flat (no zero-valued room fields):
 | `messageId` | string | The edited message's ID. |
 | `newContent` | string | Optional. New plaintext content. Present for DMs and unencrypted channels. Omitted for encrypted channels — see `encryptedNewContent`. |
 | `encryptedNewContent` | [EncryptedMessage](#encryptedmessage) | Optional. For encrypted channel rooms. Omitted otherwise. |
+| `mentions` | [Participant](#participant)[] | Optional. `@`-mentions resolved from the edited content, so an edit that adds a mention renders like a fresh message. Omitted when none. |
 | `editedBy` | string | The sender's account. |
 | `editedAt` | string | RFC 3339 timestamp. Domain time of the edit. |
 | `updatedAt` | string | RFC 3339 timestamp. |

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -611,6 +611,7 @@ Flat event — no zero-valued `RoomEvent` base fields. Triggered by
 | `messageId` | string | The edited message's ID. |
 | `newContent` | string | Optional. New plaintext content. Present for DMs and unencrypted channels. |
 | `encryptedNewContent` | [EncryptedMessage](../client-api.md#encryptedmessage) | Optional. For encrypted channel rooms. Decrypt with the room key to obtain the new content string. |
+| `mentions` | [Participant](../client-api.md#participant)[] | Optional. `@`-mentions resolved from the edited content, so an edit that adds a mention renders like a fresh message. Omitted when none. |
 | `editedBy` | string | The sender's account. |
 | `editedAt` | string | RFC 3339 timestamp. Domain time of the edit. |
 | `updatedAt` | string | RFC 3339 timestamp. |

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -409,9 +409,12 @@ type EditRoomEvent struct {
 	MessageID           string          `json:"messageId" bson:"messageId"`
 	NewContent          string          `json:"newContent,omitempty" bson:"newContent,omitempty"`
 	EncryptedNewContent json.RawMessage `json:"encryptedNewContent,omitempty" bson:"encryptedNewContent,omitempty"`
-	EditedBy            string          `json:"editedBy" bson:"editedBy"`
-	EditedAt            time.Time       `json:"editedAt" bson:"editedAt"`
-	UpdatedAt           time.Time       `json:"updatedAt" bson:"updatedAt"`
+	// Mentions are the @-mentions resolved from the edited content, so an edit that
+	// adds a mention renders it the same as a freshly-sent message. Omitted when none.
+	Mentions  []Participant `json:"mentions,omitempty" bson:"mentions,omitempty"`
+	EditedBy  string        `json:"editedBy" bson:"editedBy"`
+	EditedAt  time.Time     `json:"editedAt" bson:"editedAt"`
+	UpdatedAt time.Time     `json:"updatedAt" bson:"updatedAt"`
 	// ThreadParentMessageID is set when the edited message is a thread reply; its presence lets
 	// clients tell a thread-reply edit from a top-level one. Omitted for top-level messages.
 	ThreadParentMessageID string `json:"threadParentMessageId,omitempty" bson:"threadParentMessageId,omitempty"`


### PR DESCRIPTION
## Summary

When a message is edited to **add** an `@mention`, the mentioned user's subscription is badged (handled earlier), but the `message_edited` event carried **no** structured `mentions[]` — unlike a freshly-sent message, whose event carries the resolved participants. A client that renders a mention chip from that structured array therefore couldn't render it on an edited message; it would only have the raw `@name` text.

This attaches the resolved participants to the edit event, mirroring the create path.

## Changes

- `pkg/model`: `EditRoomEvent` gains `mentions []Participant` (`omitempty`).
- `broadcast-worker`: new `resolveMentionParticipants` (parse the edited content → resolve to participants, same as the create path) and set `edit.Mentions` in **both** edit paths — main-room (`handleUpdated`) and thread-reply (`handleThreadUpdated`). The existing badge behavior is unchanged.
- `docs/client-api.md` + the events view: document the new `mentions` field on `message_edited`.

## Verification

- Unit: a new test asserts the `message_edited` event carries the resolved mention; existing edit tests updated for the added participant resolution. `broadcast-worker` + `pkg/model` suites green.
- Verified on our dev stack at the wire layer: alice sends a plain message then edits it to add `@bob`; the `message_edited` event now carries `mentions: [{account:"bob", ...}]` (previously absent), for both main-room and thread-reply edits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edited messages now include resolved participants for mentions in the updated content.
  * Mentions in edited thread replies are recognized and routed correctly.
  * Mention data is reused for cross-site message federation.
  * Reaction keys now support visible text and Unicode values with normalization and validation.

* **Documentation**
  * Updated client API documentation for edited-message mentions, reaction keys, and subscription-list ordering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->