### PR TITLE
fix(upload-service): upload files under their original name

### DIFF
--- a/docs/superpowers/plans/2026-06-25-upload-service-timestamped-filename.md
+++ b/docs/superpowers/plans/2026-06-25-upload-service-timestamped-filename.md
@@ -1,5 +1,7 @@
 # Timestamped Drive Filenames Implementation Plan
 
+**Status:** Superseded (2026-08-20) — `uniqueName` was removed; uploads now send the original filename as-is. See commit f54b8e45 and the design doc's supersession note. Do not re-implement this plan.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Send a unique filename to Drive on every upload (so neither re-uploading the same file across requests nor duplicate names within one batch collide) while returning the original filename to the client.

--- a/docs/superpowers/specs/2026-06-25-upload-service-timestamped-filename-design.md
+++ b/docs/superpowers/specs/2026-06-25-upload-service-timestamped-filename-design.md
@@ -2,7 +2,10 @@
 
 **Date:** 2026-06-25
 **Service:** `upload-service`
-**Status:** Approved
+**Status:** Superseded (2026-08-20) — uploads now send the original filename
+as-is; `uniqueName` was removed because the mangled name leaked to users via
+download `Content-Disposition`, and product accepted the duplicate-name
+trade-off. See commit f54b8e45.
 
 ## Problem
 

--- a/upload-service/handler.go
+++ b/upload-service/handler.go
@@ -183,7 +183,7 @@ func (h *Handler) HandleUploadImages(c *gin.Context) {
 		return
 	}
 
-	results, fileHeaders, origNames := preprocessFiles(files, h.maxImageSize)
+	results, fileHeaders := preprocessFiles(files, h.maxImageSize)
 	defer func() {
 		for _, mf := range fileHeaders {
 			_ = mf.File.Close()
@@ -203,9 +203,11 @@ func (h *Handler) HandleUploadImages(c *gin.Context) {
 
 	driveHost := h.drive.GetBaseURLFromRoomOrigin(siteID)
 	for i, resp := range responses {
+		// The name we sent is the source of truth (Drive echoes it on success and
+		// returns an empty name on a per-file failure).
 		name := resp.File.Filename
-		if i < len(origNames) {
-			name = origNames[i]
+		if i < len(fileHeaders) {
+			name = fileHeaders[i].Filename
 		}
 		item := uploadResultItem{Name: name, Status: resp.Status, Error: resp.Error}
 		if resp.Status == driveStatusSuccess {
@@ -472,9 +474,8 @@ func (h *Handler) requireMembership(ctx context.Context, c *gin.Context, roomID,
 // preprocessFiles runs the per-file size/extension/open checks. Rejected files
 // become failure result items; accepted files become MultipartFiles whose open
 // handles the caller is responsible for closing. Files keep their original name
-// (Drive addresses them by FileID); origNames lists them in send order so the
-// response can fall back to them when Drive returns an empty name on a per-file failure.
-func preprocessFiles(files []*multipart.FileHeader, maxSize int64) (results []uploadResultItem, fileHeaders []drive.MultipartFile, origNames []string) {
+// (Drive addresses them by FileID).
+func preprocessFiles(files []*multipart.FileHeader, maxSize int64) (results []uploadResultItem, fileHeaders []drive.MultipartFile) {
 	for _, fh := range files {
 		if fh.Size > maxSize {
 			results = append(results, uploadResultItem{Name: fh.Filename, Status: statusFailure, Error: "file size exceeds limit"})
@@ -490,9 +491,8 @@ func preprocessFiles(files []*multipart.FileHeader, maxSize int64) (results []up
 			continue
 		}
 		fileHeaders = append(fileHeaders, drive.MultipartFile{File: f, Filename: fh.Filename})
-		origNames = append(origNames, fh.Filename)
 	}
-	return results, fileHeaders, origNames
+	return results, fileHeaders
 }
 
 // readMultipartFile opens, reads, and closes a multipart file header's content.

--- a/upload-service/handler.go
+++ b/upload-service/handler.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -65,7 +64,6 @@ type Handler struct {
 	maxFileSize    int64
 	mimeFilter     *mediaTypeFilter
 	preview        previewFunc
-	nowMilli       func() int64
 	cacheMaxAge    int
 
 	setCookiePartitioned bool
@@ -82,7 +80,6 @@ func NewHandler(store Store, dc driveClient, s3 objectStore, maxImages, maxAttac
 		store: store, drive: dc, legacyDrive: legacyDrive, s3: s3, maxImages: maxImages, maxAttachments: maxAttachments,
 		maxImageSize: maxImageSize, maxFileSize: maxFileSize, mimeFilter: mimeFilter,
 		preview: preview, cacheMaxAge: cacheMaxAge, setCookiePartitioned: setCookiePartitioned,
-		nowMilli: func() int64 { return time.Now().UTC().UnixMilli() },
 	}
 }
 
@@ -186,7 +183,7 @@ func (h *Handler) HandleUploadImages(c *gin.Context) {
 		return
 	}
 
-	results, fileHeaders, origNames := preprocessFiles(files, h.maxImageSize, h.nowMilli())
+	results, fileHeaders, origNames := preprocessFiles(files, h.maxImageSize)
 	defer func() {
 		for _, mf := range fileHeaders {
 			_ = mf.File.Close()
@@ -317,7 +314,7 @@ func (h *Handler) HandleUploadFile(c *gin.Context) {
 	}
 
 	responses, err := h.drive.UploadGroupImages(user.Account, user.DisplayName(), user.Email, roomID, siteID,
-		[]drive.MultipartFile{{File: driveFile, Filename: uniqueName(fh.Filename, h.nowMilli(), 0)}})
+		[]drive.MultipartFile{{File: driveFile, Filename: fh.Filename}})
 	if err != nil {
 		errhttp.Write(ctx, c, fmt.Errorf("upload file to drive: %w", err))
 		return
@@ -474,12 +471,10 @@ func (h *Handler) requireMembership(ctx context.Context, c *gin.Context, roomID,
 
 // preprocessFiles runs the per-file size/extension/open checks. Rejected files
 // become failure result items; accepted files become MultipartFiles whose open
-// handles the caller is responsible for closing. Each accepted file is uploaded
-// under a unique name (timestamp + accepted-file index, so neither re-uploads
-// across requests nor duplicate names within a batch collide in Drive); origNames
-// lists the caller-facing originals in send order so the response can show them
-// (Drive echoes the unique name, and an empty name on a per-file failure).
-func preprocessFiles(files []*multipart.FileHeader, maxSize, milli int64) (results []uploadResultItem, fileHeaders []drive.MultipartFile, origNames []string) {
+// handles the caller is responsible for closing. Files keep their original name
+// (Drive addresses them by FileID); origNames lists them in send order so the
+// response can fall back to them when Drive returns an empty name on a per-file failure.
+func preprocessFiles(files []*multipart.FileHeader, maxSize int64) (results []uploadResultItem, fileHeaders []drive.MultipartFile, origNames []string) {
 	for _, fh := range files {
 		if fh.Size > maxSize {
 			results = append(results, uploadResultItem{Name: fh.Filename, Status: statusFailure, Error: "file size exceeds limit"})
@@ -494,7 +489,7 @@ func preprocessFiles(files []*multipart.FileHeader, maxSize, milli int64) (resul
 			results = append(results, uploadResultItem{Name: fh.Filename, Status: statusFailure, Error: "failed to open file"})
 			continue
 		}
-		fileHeaders = append(fileHeaders, drive.MultipartFile{File: f, Filename: uniqueName(fh.Filename, milli, len(origNames))})
+		fileHeaders = append(fileHeaders, drive.MultipartFile{File: f, Filename: fh.Filename})
 		origNames = append(origNames, fh.Filename)
 	}
 	return results, fileHeaders, origNames
@@ -508,18 +503,6 @@ func readMultipartFile(fh *multipart.FileHeader) ([]byte, error) {
 	}
 	defer f.Close()
 	return io.ReadAll(f)
-}
-
-// uniqueName inserts a millisecond timestamp and a per-batch index before the
-// file extension so uploads get distinct Drive object names:
-// "photo.png" -> "photo_1719312000000_0.png". The timestamp separates re-uploads
-// across requests; the index separates duplicate filenames within a single batch
-// (which are processed in the same millisecond). A name with no extension just
-// gets the suffix appended. Extension detection follows filepath.Ext semantics.
-func uniqueName(name string, milli int64, i int) string {
-	ext := filepath.Ext(name)
-	base := strings.TrimSuffix(name, ext)
-	return fmt.Sprintf("%s_%d_%d%s", base, milli, i, ext)
 }
 
 // contentDisposition builds an attachment Content-Disposition value. A non-empty

--- a/upload-service/handler_test.go
+++ b/upload-service/handler_test.go
@@ -382,7 +382,7 @@ func TestHandleHealth(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "ok")
 }
 
-func TestHandleUploadImages_SendsUniqueNames_ReturnsOriginals(t *testing.T) {
+func TestHandleUploadImages_SendsOriginalName(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
 	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
@@ -390,18 +390,17 @@ func TestHandleUploadImages_SendsUniqueNames_ReturnsOriginals(t *testing.T) {
 	fd := &fakeDrive{
 		baseURL: "https://drive.example.com",
 		uploadResp: []drive.UploadGroupImageResponse{
-			{Status: "success", File: drive.GroupImageObject{FileID: "img-1", GroupID: "r1", Filename: "a_1719312000000_0.png"}},
+			{Status: "success", File: drive.GroupImageObject{FileID: "img-1", GroupID: "r1", Filename: "a.png"}},
 		},
 	}
 	h := newHandler(store, fd)
-	h.nowMilli = func() int64 { return 1719312000000 }
 
 	body, ct := multipartBody(t, "images", map[string][]byte{"a.png": []byte("x")})
 	c, w := newUploadCtx(t, "r1", body, ct, okUser())
 	h.HandleUploadImages(c)
 
 	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, []string{"a_1719312000000_0.png"}, fd.uploadGot.filenames, "drive receives the unique name")
+	require.Equal(t, []string{"a.png"}, fd.uploadGot.filenames, "drive receives the original name")
 
 	var got struct {
 		Results []uploadResultItem `json:"results"`
@@ -413,9 +412,9 @@ func TestHandleUploadImages_SendsUniqueNames_ReturnsOriginals(t *testing.T) {
 	assert.Equal(t, "api/v1/file/rooms/r1/file/img-1?drive_host=https://drive.example.com", got.Results[0].RelativePath)
 }
 
-// Two files with the SAME name in one batch must get distinct indexed names so
-// they don't collide in Drive; both response items keep the original name.
-func TestHandleUploadImages_DuplicateNamesInBatch_GetDistinctNames(t *testing.T) {
+// Two files with the SAME name in one batch are both sent under their original
+// name (Drive addresses files by FileID); both response items keep it.
+func TestHandleUploadImages_DuplicateNamesInBatch_KeepOriginalNames(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
 	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
@@ -423,12 +422,11 @@ func TestHandleUploadImages_DuplicateNamesInBatch_GetDistinctNames(t *testing.T)
 	fd := &fakeDrive{
 		baseURL: "https://drive.example.com",
 		uploadResp: []drive.UploadGroupImageResponse{
-			{Status: "success", File: drive.GroupImageObject{FileID: "img-0", GroupID: "r1", Filename: "a_1719312000000_0.png"}},
-			{Status: "success", File: drive.GroupImageObject{FileID: "img-1", GroupID: "r1", Filename: "a_1719312000000_1.png"}},
+			{Status: "success", File: drive.GroupImageObject{FileID: "img-0", GroupID: "r1", Filename: "a.png"}},
+			{Status: "success", File: drive.GroupImageObject{FileID: "img-1", GroupID: "r1", Filename: "a.png"}},
 		},
 	}
 	h := newHandler(store, fd)
-	h.nowMilli = func() int64 { return 1719312000000 }
 
 	// Two parts under the same field with the same filename.
 	body := &bytes.Buffer{}
@@ -444,7 +442,7 @@ func TestHandleUploadImages_DuplicateNamesInBatch_GetDistinctNames(t *testing.T)
 	h.HandleUploadImages(c)
 
 	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, []string{"a_1719312000000_0.png", "a_1719312000000_1.png"}, fd.uploadGot.filenames, "duplicate names get distinct indexed names")
+	require.Equal(t, []string{"a.png", "a.png"}, fd.uploadGot.filenames, "duplicate names are sent as-is")
 
 	var got struct {
 		Results []uploadResultItem `json:"results"`
@@ -469,7 +467,6 @@ func TestHandleUploadImages_DriveErrorEmptyFilename_KeepsOriginalName(t *testing
 		},
 	}
 	h := newHandler(store, fd)
-	h.nowMilli = func() int64 { return 1719312000000 }
 
 	body, ct := multipartBody(t, "images", map[string][]byte{"a.png": []byte("x")})
 	c, w := newUploadCtx(t, "r1", body, ct, okUser())
@@ -487,7 +484,7 @@ func TestHandleUploadImages_DriveErrorEmptyFilename_KeepsOriginalName(t *testing
 	assert.Empty(t, got.Results[0].RelativePath)
 }
 
-func TestHandleUploadFile_SendsUniqueName_ReturnsOriginal(t *testing.T) {
+func TestHandleUploadFile_SendsOriginalName(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
 	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
@@ -495,11 +492,10 @@ func TestHandleUploadFile_SendsUniqueName_ReturnsOriginal(t *testing.T) {
 	fd := &fakeDrive{
 		baseURL: "http://drive",
 		uploadResp: []drive.UploadGroupImageResponse{
-			{Status: "success", File: drive.GroupImageObject{FileID: "f1", GroupID: "r1", Filename: "photo_1719312000000_0.png", FileSize: 3}},
+			{Status: "success", File: drive.GroupImageObject{FileID: "f1", GroupID: "r1", Filename: "photo.png", FileSize: 3}},
 		},
 	}
 	h := NewHandler(store, fd, &fakeS3{}, 0, testMaxAttachments, 0, 100<<20, newMediaTypeFilter("", "image/svg+xml"), imagePreview, testCacheMaxAge, true, &fakeDrive{})
-	h.nowMilli = func() int64 { return 1719312000000 }
 
 	body := &bytes.Buffer{}
 	mw := multipart.NewWriter(body)
@@ -520,7 +516,7 @@ func TestHandleUploadFile_SendsUniqueName_ReturnsOriginal(t *testing.T) {
 	h.HandleUploadFile(c)
 
 	require.Equal(t, http.StatusOK, rec.Code)
-	require.Equal(t, []string{"photo_1719312000000_0.png"}, fd.uploadGot.filenames, "drive receives the unique name")
+	require.Equal(t, []string{"photo.png"}, fd.uploadGot.filenames, "drive receives the original name")
 
 	var got struct {
 		Attachments []model.Attachment `json:"attachments"`
@@ -528,27 +524,6 @@ func TestHandleUploadFile_SendsUniqueName_ReturnsOriginal(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	require.Len(t, got.Attachments, 1)
 	assert.Equal(t, "photo.png", got.Attachments[0].Title, "response keeps the original name")
-}
-
-func Test_uniqueName(t *testing.T) {
-	const milli int64 = 1719312000000
-	tests := []struct {
-		name string
-		in   string
-		i    int
-		want string
-	}{
-		{"with extension", "photo.png", 0, "photo_1719312000000_0.png"},
-		{"uppercase extension", "IMG.JPG", 1, "IMG_1719312000000_1.JPG"},
-		{"no extension", "README", 2, "README_1719312000000_2"},
-		{"multi dot", "a.tar.gz", 0, "a.tar_1719312000000_0.gz"},
-		{"dotfile (filepath.Ext semantics)", ".gitignore", 0, "_1719312000000_0.gitignore"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, uniqueName(tt.in, milli, tt.i))
-		})
-	}
 }
 
 func TestRegisterRoutes_HealthAndAuthGuard(t *testing.T) {

--- a/upload-service/handler_test.go
+++ b/upload-service/handler_test.go
@@ -382,6 +382,53 @@ func TestHandleHealth(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "ok")
 }
 
+// A multi-file batch must keep the fileHeaders[i]/responses[i] pairing: each
+// result carries the name of the file at the same index, in send order.
+func TestHandleUploadImages_MultiFileBatch_ResultsMatchSendOrder(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
+	store.EXPECT().GetRoomSiteID(gomock.Any(), "r1").Return("site-x", nil)
+	fd := &fakeDrive{
+		baseURL: "https://drive.example.com",
+		uploadResp: []drive.UploadGroupImageResponse{
+			{Status: "success", File: drive.GroupImageObject{FileID: "img-0", GroupID: "r1", Filename: "a.png"}},
+			{Status: "failure", Error: "drive exploded", File: drive.GroupImageObject{}},
+			{Status: "success", File: drive.GroupImageObject{FileID: "img-2", GroupID: "r1", Filename: "c.png"}},
+		},
+	}
+	h := newHandler(store, fd)
+
+	// Build parts in a fixed order (multipartBody's map would randomize it).
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	for _, name := range []string{"a.png", "b.png", "c.png"} {
+		fw, err := mw.CreateFormFile("images", name)
+		require.NoError(t, err)
+		_, _ = fw.Write([]byte("x"))
+	}
+	require.NoError(t, mw.Close())
+
+	c, w := newUploadCtx(t, "r1", body, mw.FormDataContentType(), okUser())
+	h.HandleUploadImages(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, []string{"a.png", "b.png", "c.png"}, fd.uploadGot.filenames, "all files sent in order under original names")
+
+	var got struct {
+		Results []uploadResultItem `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.Len(t, got.Results, 3, "one result per submitted file")
+	assert.Equal(t, "a.png", got.Results[0].Name)
+	assert.Equal(t, "success", got.Results[0].Status)
+	assert.Equal(t, "b.png", got.Results[1].Name, "failed file keeps its own name, not a neighbor's")
+	assert.Equal(t, "failure", got.Results[1].Status)
+	assert.Equal(t, "c.png", got.Results[2].Name)
+	assert.Equal(t, "success", got.Results[2].Status)
+	assert.Equal(t, "api/v1/file/rooms/r1/file/img-2?drive_host=https://drive.example.com", got.Results[2].RelativePath)
+}
+
 func TestHandleUploadImages_SendsOriginalName(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)

--- a/upload-service/handler_test.go
+++ b/upload-service/handler_test.go
@@ -412,47 +412,6 @@ func TestHandleUploadImages_SendsOriginalName(t *testing.T) {
 	assert.Equal(t, "api/v1/file/rooms/r1/file/img-1?drive_host=https://drive.example.com", got.Results[0].RelativePath)
 }
 
-// Two files with the SAME name in one batch are both sent under their original
-// name (Drive addresses files by FileID); both response items keep it.
-func TestHandleUploadImages_DuplicateNamesInBatch_KeepOriginalNames(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "r1").Return("site-x", nil)
-	fd := &fakeDrive{
-		baseURL: "https://drive.example.com",
-		uploadResp: []drive.UploadGroupImageResponse{
-			{Status: "success", File: drive.GroupImageObject{FileID: "img-0", GroupID: "r1", Filename: "a.png"}},
-			{Status: "success", File: drive.GroupImageObject{FileID: "img-1", GroupID: "r1", Filename: "a.png"}},
-		},
-	}
-	h := newHandler(store, fd)
-
-	// Two parts under the same field with the same filename.
-	body := &bytes.Buffer{}
-	mw := multipart.NewWriter(body)
-	for i := 0; i < 2; i++ {
-		fw, err := mw.CreateFormFile("images", "a.png")
-		require.NoError(t, err)
-		_, _ = fw.Write([]byte("x"))
-	}
-	require.NoError(t, mw.Close())
-
-	c, w := newUploadCtx(t, "r1", body, mw.FormDataContentType(), okUser())
-	h.HandleUploadImages(c)
-
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, []string{"a.png", "a.png"}, fd.uploadGot.filenames, "duplicate names are sent as-is")
-
-	var got struct {
-		Results []uploadResultItem `json:"results"`
-	}
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
-	require.Len(t, got.Results, 2)
-	assert.Equal(t, "a.png", got.Results[0].Name)
-	assert.Equal(t, "a.png", got.Results[1].Name)
-}
-
 func TestHandleUploadImages_DriveErrorEmptyFilename_KeepsOriginalName(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)


### PR DESCRIPTION
## Problem

Uploaded files were stored in Drive under a mangled name — `uniqueName` rewrote every filename to `<base>_<millis>_<index><ext>`, and downloads surfaced that name via `Content-Disposition`. Users expect the original filename.

## Root cause

`uniqueName` was added by the 2026-06-25 spec as a guard against Drive rejecting duplicate filenames within a group, but the rewritten name leaks to users through Drive's echo on download.

## Change

- **Always send the original `fh.Filename` to Drive** (`HandleUploadFile` and `HandleUploadImages`/`preprocessFiles`); delete `uniqueName` and the injected `nowMilli` clock.
- **Accepted trade-off (product decision):** uploading a duplicate filename within a group may be rejected by Drive; the client sees a per-file failure in `results`.
- Remove the now-redundant `origNames` parallel slice; the response loop falls back to `fileHeaders[i].Filename` (Drive returns an empty name on per-file failure).
- Add a 3-file batch test locking the `fileHeaders[i]`/`responses[i]` pairing and send order.
- Mark both timestamped-filename design docs (spec + plan) as Superseded so the renaming logic doesn't get reintroduced from stale docs.

## Notes

- Response schema unchanged (`docs/client-api.md` needs no update; upload-service is an HTTP service, not a client-facing NATS handler).
- Known and deliberately untouched (existing behavior, out of scope): a Drive bulk response shorter than the number of files sent yields fewer result items under HTTP 200; upload-service package coverage is 75.4%, below the 80% floor (pre-existing debt, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Uploads now preserve the filenames submitted by users.
  - Uploaded image responses display the original filenames.
  - Multi-file upload results remain aligned with submission order.
  - Individual upload failures continue to be reported per file.

- **Documentation**
  - Updated related documentation to reflect the current filename behavior and mark previous plans as superseded.

- **Tests**
  - Added coverage for original filename preservation and ordered multi-file results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->