### PR TITLE
fix(msgraph): retry the group reads teams-hr-sync uses on 429/503

### DIFF
--- a/pkg/msgraph/chats.go
+++ b/pkg/msgraph/chats.go
@@ -131,21 +131,21 @@ func (g *graphClient) getThrottled(ctx context.Context, token, endpoint, operati
 		}
 		req, err := newExternalRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 		if err != nil {
-			return nil, fmt.Errorf("build chats request: %w", err)
+			return nil, fmt.Errorf("build %s request: %w", operation, err)
 		}
 		req.Header.Set("Authorization", "Bearer "+token)
 		resp, err := g.httpClient.Do(req)
 		if err != nil {
-			return nil, fmt.Errorf("get chats: %w", err)
+			return nil, fmt.Errorf("%s: %w", operation, err)
 		}
 		// Bound the read so a runaway or hostile response can't exhaust memory;
-		// real list-chats pages ($top=50, members expanded) are far smaller.
+		// real Graph pages are far smaller.
 		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<26)) // 64 MiB
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			return nil, fmt.Errorf("close chats response: %w", closeErr)
+			return nil, fmt.Errorf("close %s response: %w", operation, closeErr)
 		}
 		if readErr != nil {
-			return nil, fmt.Errorf("read chats response: %w", readErr)
+			return nil, fmt.Errorf("read %s response: %w", operation, readErr)
 		}
 		throttled := resp.StatusCode == http.StatusTooManyRequests ||
 			resp.StatusCode == http.StatusServiceUnavailable
@@ -179,9 +179,9 @@ func (g *graphClient) getThrottled(ctx context.Context, token, endpoint, operati
 			}
 			_ = json.Unmarshal(body, &graphErr)
 			if graphErr.Error.Code != "" {
-				return nil, fmt.Errorf("get chats: graph returned status %d (%s)", resp.StatusCode, graphErr.Error.Code)
+				return nil, fmt.Errorf("%s: graph returned status %d (%s)", operation, resp.StatusCode, graphErr.Error.Code)
 			}
-			return nil, fmt.Errorf("get chats: graph returned status %d", resp.StatusCode)
+			return nil, fmt.Errorf("%s: graph returned status %d", operation, resp.StatusCode)
 		}
 	}
 }

--- a/pkg/msgraph/chats.go
+++ b/pkg/msgraph/chats.go
@@ -100,7 +100,7 @@ func (g *graphClient) ListUserChats(ctx context.Context, userID string, from, to
 
 	var chats []Chat
 	for next != "" {
-		body, err := g.getThrottled(ctx, token, next, "list user chats")
+		body, err := g.getThrottled(ctx, token, next, "list user chats", 1<<26) // 64 MiB
 		if err != nil {
 			return nil, err
 		}
@@ -124,7 +124,7 @@ func (g *graphClient) ListUserChats(ctx context.Context, userID string, from, to
 // attempt so the rest of the pool still backs off after this user fails. Each
 // throttle response emits a WARN log (operation identifies the caller) carrying
 // the status, Retry-After, and computed backoff — never the token or endpoint.
-func (g *graphClient) getThrottled(ctx context.Context, token, endpoint, operation string) ([]byte, error) {
+func (g *graphClient) getThrottled(ctx context.Context, token, endpoint, operation string, maxBytes int64) ([]byte, error) {
 	for attempt := 1; ; attempt++ {
 		if err := g.waitThrottle(ctx); err != nil {
 			return nil, err
@@ -140,7 +140,7 @@ func (g *graphClient) getThrottled(ctx context.Context, token, endpoint, operati
 		}
 		// Bound the read so a runaway or hostile response can't exhaust memory;
 		// real Graph pages are far smaller.
-		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<26)) // 64 MiB
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBytes))
 		if closeErr := resp.Body.Close(); closeErr != nil {
 			return nil, fmt.Errorf("close %s response: %w", operation, closeErr)
 		}

--- a/pkg/msgraph/groups.go
+++ b/pkg/msgraph/groups.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"net/url"
 	"strconv"
 )
@@ -53,23 +51,11 @@ func (g *graphClient) GetGroup(ctx context.Context, groupID string) (*GroupProfi
 	q.Set("$select", "id,displayName,description")
 	endpoint := g.baseURL + "/groups/" + url.PathEscape(groupID) + "?" + q.Encode()
 
-	req, err := newExternalRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	// getThrottled retries 429/503 per Retry-After and shares the tenant-wide
+	// throttle gate, so an hr-sync run survives a Graph throttle/hiccup.
+	body, err := g.getThrottled(ctx, token, endpoint, "get group")
 	if err != nil {
-		return nil, fmt.Errorf("build get-group request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	resp, err := g.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("get group: %w", err)
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if err != nil {
-		return nil, fmt.Errorf("read get-group response: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		// Never wrap the response body — surface the status only.
-		return nil, fmt.Errorf("get group: graph returned status %d", resp.StatusCode)
+		return nil, err
 	}
 	var profile GroupProfile
 	if err := json.Unmarshal(body, &profile); err != nil {
@@ -139,23 +125,10 @@ func (g *graphClient) ListGroupMembers(ctx context.Context, groupID string, page
 }
 
 func (g *graphClient) fetchMembersPage(ctx context.Context, token, endpoint string) (*membersPage, error) {
-	req, err := newExternalRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	// Shares getThrottled's 429/503 retry + tenant throttle gate (see GetGroup).
+	body, err := g.getThrottled(ctx, token, endpoint, "list group members")
 	if err != nil {
-		return nil, fmt.Errorf("build list-members request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	resp, err := g.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("list group members: %w", err)
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<22))
-	if err != nil {
-		return nil, fmt.Errorf("read list-members response: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		// Never wrap the response body — surface the status only.
-		return nil, fmt.Errorf("list group members: graph returned status %d", resp.StatusCode)
+		return nil, err
 	}
 	var page membersPage
 	if err := json.Unmarshal(body, &page); err != nil {

--- a/pkg/msgraph/groups.go
+++ b/pkg/msgraph/groups.go
@@ -53,7 +53,7 @@ func (g *graphClient) GetGroup(ctx context.Context, groupID string) (*GroupProfi
 
 	// getThrottled retries 429/503 per Retry-After and shares the tenant-wide
 	// throttle gate, so an hr-sync run survives a Graph throttle/hiccup.
-	body, err := g.getThrottled(ctx, token, endpoint, "get group")
+	body, err := g.getThrottled(ctx, token, endpoint, "get group", 1<<20) // 1 MiB
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (g *graphClient) ListGroupMembers(ctx context.Context, groupID string, page
 
 func (g *graphClient) fetchMembersPage(ctx context.Context, token, endpoint string) (*membersPage, error) {
 	// Shares getThrottled's 429/503 retry + tenant throttle gate (see GetGroup).
-	body, err := g.getThrottled(ctx, token, endpoint, "list group members")
+	body, err := g.getThrottled(ctx, token, endpoint, "list group members", 1<<22) // 4 MiB
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/msgraph/groups_test.go
+++ b/pkg/msgraph/groups_test.go
@@ -149,3 +149,46 @@ func TestListGroupMembers_RejectsCrossOriginNextLink(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "deviates from configured graph origin")
 }
+
+func TestGetGroup_RetriesOn429(t *testing.T) {
+	tokenSrv := newTokenServer(t)
+	var calls int
+	graphSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls == 1 {
+			w.Header().Set("Retry-After", "0") // keep the test fast
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(GroupProfile{ID: "g1", DisplayName: "Engineering"})
+	}))
+	defer graphSrv.Close()
+
+	got, err := newTestGroupReader(tokenSrv.URL, graphSrv.URL).GetGroup(context.Background(), "g1")
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls, "a 429 must be retried, not surfaced")
+	assert.Equal(t, "g1", got.ID)
+}
+
+func TestListGroupMembers_RetriesOn429(t *testing.T) {
+	tokenSrv := newTokenServer(t)
+	var calls int
+	graphSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusServiceUnavailable) // 503 also retried
+			return
+		}
+		_, _ = w.Write([]byte(`{"value":[{"@odata.type":"#microsoft.graph.user","id":"u1","displayName":"Alice"}]}`))
+	}))
+	defer graphSrv.Close()
+
+	var got []GraphUser
+	_, err := newTestGroupReader(tokenSrv.URL, graphSrv.URL).
+		ListGroupMembers(context.Background(), "g1", 500, func(users []GraphUser) error { got = append(got, users...); return nil })
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls, "a 503 must be retried, not surfaced")
+	require.Len(t, got, 1)
+	assert.Equal(t, "u1", got[0].ID)
+}

--- a/pkg/msgraph/groups_test.go
+++ b/pkg/msgraph/groups_test.go
@@ -170,7 +170,7 @@ func TestGetGroup_RetriesOn429(t *testing.T) {
 	assert.Equal(t, "g1", got.ID)
 }
 
-func TestListGroupMembers_RetriesOn429(t *testing.T) {
+func TestListGroupMembers_RetriesOn503(t *testing.T) {
 	tokenSrv := newTokenServer(t)
 	var calls int
 	graphSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/msgraph/members.go
+++ b/pkg/msgraph/members.go
@@ -53,7 +53,7 @@ func (g *graphClient) ListChatMembers(ctx context.Context, chatID string) ([]Cha
 
 	var members []ChatMemberDetail
 	for next != "" {
-		body, err := g.getThrottled(ctx, token, next, "list chat members")
+		body, err := g.getThrottled(ctx, token, next, "list chat members", 1<<26) // 64 MiB
 		if err != nil {
 			return nil, fmt.Errorf("list chat members: %w", err)
 		}


### PR DESCRIPTION
## Summary

`teams-hr-sync` walks Microsoft Graph via `GetGroup` + `ListGroupMembers` (`pkg/msgraph/groups.go`). Each issued a single `httpClient.Do`, so a **429 throttle**, a **503**, or a transient network blip failed the whole HR-sync run — no `Retry-After` handling, no retry.

The chat-sync path already had a proper throttle-retry (`getThrottled`: retries 429/503 per `Retry-After`, capped attempts, shared tenant-wide throttle gate). The group reads just didn't use it.

## Changes

- `GetGroup` and `fetchMembersPage` (the `ListGroupMembers` page fetch) now route through `getThrottled`, gaining the 429/503 retry + the shared throttle gate.
- Generalized `getThrottled`'s error text from the hardcoded "chats" wording to the caller's `operation` label — which also corrects the previously-misleading "get chats" errors the chat-**members** path emitted.
- Removed the now-dead manual `Do`/read/status handling in the group path.

No happy-path behavior change; the only new behavior is retry on a throttled/unavailable response.

## Verification

- Unit: added `TestGetGroup_RetriesOn429` and `TestListGroupMembers_RetriesOn429` (503) — both assert the request is retried (2 calls) and succeeds, using an httptest server that throttles the first call. Existing `pkg/msgraph` suite green; lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Group and group-member retrieval now consistently use shared retry handling for temporary service errors and rate limits.
  - Requests receiving HTTP 429 or 503 responses are retried automatically before returning an error.
  - Response-size limits remain enforced for chat, group, and member retrieval.

- **Tests**
  - Added coverage verifying successful retries for rate-limited and temporarily unavailable group requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->