### PR TITLE
fix(teams-hr-sync): publish employees.quit on the central HR subject

### DIFF
--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -1740,7 +1740,10 @@ func OrgSyncUsersUpsert(centralSiteID string) string {
 	return fmt.Sprintf("chat.hr.%s.users.upsert", centralSiteID)
 }
 
-// EmployeesQuit is the per-site subject for departed-employee batches.
+// EmployeesQuit is the departed-employee-batch subject on a site's HR feed.
+// Publishers use the CENTRAL site id (like employees/users upsert) — the batch's
+// own site rides the payload's SiteID; a per-site subject has no owning stream
+// unless that site is provisioned.
 func EmployeesQuit(siteID string) string {
 	return fmt.Sprintf("chat.hr.%s.employees.quit", siteID)
 }

--- a/teams-hr-sync/integration_test.go
+++ b/teams-hr-sync/integration_test.go
@@ -156,7 +156,8 @@ func TestRunSync_EndToEnd(t *testing.T) {
 	assert.Equal(t, "carol", employees[1].Account)
 	assert.Equal(t, model.IChangeTypeNewHire, employees[1].ChangeType)
 	var qb model.IHRSyncEmployeeQuitBatch
-	require.NoError(t, json.Unmarshal(msgs["chat.hr.site-a.employees.quit"], &qb))
+	// quit publishes on the CENTRAL subject; the batch's site rides the payload.
+	require.NoError(t, json.Unmarshal(msgs["chat.hr.central.employees.quit"], &qb))
 	assert.Equal(t, "site-a", qb.SiteID)
 	assert.Equal(t, []string{"alice"}, qb.Accounts, "only the teams-sourced departure quits; the legacy row never does")
 }

--- a/teams-hr-sync/publisher.go
+++ b/teams-hr-sync/publisher.go
@@ -60,7 +60,11 @@ func (p *publisher) publishSync(ctx context.Context, d diffResult) (emitResult, 
 	}
 	sort.Strings(siteIDs)
 	for _, siteID := range siteIDs {
-		if err := p.publishZstd(ctx, subject.EmployeesQuit(siteID),
+		// Publish on the CENTRAL HR subject (like upsert/users) — the departed
+		// employee's site rides the payload's SiteID. A per-site subject
+		// (chat.hr.{siteID}.employees.quit) has no owning stream unless that site
+		// was provisioned, so it fails with "no response from stream".
+		if err := p.publishZstd(ctx, subject.EmployeesQuit(p.central),
 			model.IHRSyncEmployeeQuitBatch{Timestamp: time.Now().UTC().UnixMilli(), SiteID: siteID, Accounts: d.Quits[siteID]}); err != nil {
 			return res, fmt.Errorf("publish employees.quit for site %s: %w", siteID, err)
 		}

--- a/teams-hr-sync/publisher_test.go
+++ b/teams-hr-sync/publisher_test.go
@@ -75,8 +75,9 @@ func TestPublishSync_AllThreeBatches(t *testing.T) {
 	assert.Equal(t, model.IChangeTypeNewHire, users[0].ChangeType)
 
 	// quit batches in sorted site order
-	assert.Equal(t, "chat.hr.site-a.employees.quit", got[2].subj)
-	assert.Equal(t, "chat.hr.site-b.employees.quit", got[3].subj)
+	// both quit batches publish on the CENTRAL subject; the site rides the payload
+	assert.Equal(t, "chat.hr.central.employees.quit", got[2].subj)
+	assert.Equal(t, "chat.hr.central.employees.quit", got[3].subj)
 	var qb model.IHRSyncEmployeeQuitBatch
 	got[2].decode(t, &qb)
 	assert.Equal(t, "site-a", qb.SiteID)
@@ -101,7 +102,7 @@ func TestPublishSync_QuitsOnlySkipsUpserts(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, res.QuitsWritten)
 	require.Len(t, got, 1)
-	assert.Equal(t, "chat.hr.site-a.employees.quit", got[0].subj)
+	assert.Equal(t, "chat.hr.central.employees.quit", got[0].subj)
 }
 
 func TestPublishSync_PublishErrorAborts(t *testing.T) {


### PR DESCRIPTION
## Summary

`teams-hr-sync` published the departed-employee quit batch to `chat.hr.{siteID}.employees.quit` — the *quitting employee's* own site. But only the **central** HR stream (`chat.hr.{CENTRAL_SITE_ID}.>`, `stream.OrgSyncStream`) is guaranteed to exist; a quit for a site whose HR stream isn't provisioned failed the publish with `nats: no response from stream`, aborting the whole sync run. (Employees/users upsert already publish to the central subject; only quit diverged.)

## Changes

- Publish the quit batch on `chat.hr.{CENTRAL_SITE_ID}.employees.quit` (via `p.central`), matching the upsert/users subjects. The batch's own site already travels in the payload's `SiteID`, and `hr-sync-worker` routes by the `.employees.quit` suffix and keys the deactivation on account, so where it's *processed* is unchanged — only the routing subject is corrected.
- Updated the `subject.EmployeesQuit` doc comment to state the central-subject convention.

No payload/schema change; no client-facing subject touched.

## Verification

- Unit: `publisher_test` updated — both per-site quit batches now assert `chat.hr.central.employees.quit`, with the `SiteID` preserved in each payload. `teams-hr-sync` + `pkg/subject` suites green; lint clean.
