### PR TITLE
fix(loadgen): bound the recipient expectation map by the operations the ledger retires

### DIFF
--- a/docs/specs/o11y/storage-dependency-metrics.md
+++ b/docs/specs/o11y/storage-dependency-metrics.md
@@ -91,7 +91,7 @@ These metrics do not replace database telemetry; they connect dependency behavio
 | `loadgen_failure_operations_total{scenario,lane,result}` | loadgen soak | Terminal `good`/`bad`/`unverified`/`not_sent`/`missing_after_deadline` results for durable operation lanes | Existing for Cassandra user-message sends |
 | `loadgen_failure_observations_total{scenario,lane,observer,result}` | loadgen soak | Separates admission failures from Cassandra history loss or mismatch | Existing for admission and Cassandra history |
 | `loadgen_failure_inflight{scenario,lane}` | loadgen soak | Unresolved-operation backlog and deadline pressure | Existing for Cassandra user-message sends |
-| `loadgen_failure_recipient_expectations` | loadgen soak | Recipient expectations retained in memory. A healthy run tracks `loadgen_failure_inflight`; climbing past it means the map is outliving the operations again | Existing |
+| `loadgen_failure_recipient_expectations` | loadgen soak | Recipient expectations retained in memory, collected at scrape time so a stalled expiry sweep cannot freeze it. A healthy run tracks `loadgen_failure_inflight`; climbing past it means the map is outliving the operations again | Existing |
 | `loadgen_failure_recovered_operations_total` | loadgen soak | Operations restored from the PVC-backed WAL after loadgen restart | Existing |
 | `loadgen_failure_invalidations_total{reason}` | loadgen soak | Ledger capacity or WAL failures that invalidate evidence | Existing |
 | `loadgen_failure_journal_bytes` | loadgen soak | Persistent evidence footprint and compaction health | Existing |

--- a/docs/specs/o11y/storage-dependency-metrics.md
+++ b/docs/specs/o11y/storage-dependency-metrics.md
@@ -91,6 +91,7 @@ These metrics do not replace database telemetry; they connect dependency behavio
 | `loadgen_failure_operations_total{scenario,lane,result}` | loadgen soak | Terminal `good`/`bad`/`unverified`/`not_sent`/`missing_after_deadline` results for durable operation lanes | Existing for Cassandra user-message sends |
 | `loadgen_failure_observations_total{scenario,lane,observer,result}` | loadgen soak | Separates admission failures from Cassandra history loss or mismatch | Existing for admission and Cassandra history |
 | `loadgen_failure_inflight{scenario,lane}` | loadgen soak | Unresolved-operation backlog and deadline pressure | Existing for Cassandra user-message sends |
+| `loadgen_failure_recipient_expectations` | loadgen soak | Recipient expectations retained in memory. A healthy run tracks `loadgen_failure_inflight`; climbing past it means the map is outliving the operations again | Existing |
 | `loadgen_failure_recovered_operations_total` | loadgen soak | Operations restored from the PVC-backed WAL after loadgen restart | Existing |
 | `loadgen_failure_invalidations_total{reason}` | loadgen soak | Ledger capacity or WAL failures that invalidate evidence | Existing |
 | `loadgen_failure_journal_bytes` | loadgen soak | Persistent evidence footprint and compaction health | Existing |

--- a/tools/loadgen/failure_ledger.go
+++ b/tools/loadgen/failure_ledger.go
@@ -692,6 +692,18 @@ func (l *failureLedger) AbandonWithReason(
 	return nil
 }
 
+// Retired reports that the ledger no longer holds the operation. An error from
+// a finalizing call does not answer that question: finalizeLocked commits the
+// removal and compacts afterwards, so a compaction failure returns an error on
+// an operation that is already gone — and one nothing reports can never be
+// reported again.
+func (l *failureLedger) Retired(operationID string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	_, active := l.active[operationID]
+	return !active
+}
+
 func (l *failureLedger) Observe(
 	operationID string,
 	observer failureObserver,

--- a/tools/loadgen/failure_ledger.go
+++ b/tools/loadgen/failure_ledger.go
@@ -887,12 +887,19 @@ func (l *failureLedger) Expire(now time.Time) ([]string, error) {
 		}
 		result := failureOperationResult(operation)
 		operationID := operation.ID
-		if err := l.finalizeLocked(
+		err := l.finalizeLocked(
 			operation, result, failureOperationFinalReason(operation, result), now,
-		); err != nil {
+		)
+		// Report by what left the ledger, not by whether the call succeeded.
+		// finalizeLocked drops the operation from l.active and compacts
+		// afterwards, so it can fail on one it has already retired — and an ID
+		// this loop does not report can never be reported by a later sweep.
+		if _, stillActive := l.active[operationID]; !stillActive {
+			finalized = append(finalized, operationID)
+		}
+		if err != nil {
 			return finalized, err
 		}
-		finalized = append(finalized, operationID)
 	}
 	return finalized, nil
 }

--- a/tools/loadgen/failure_ledger.go
+++ b/tools/loadgen/failure_ledger.go
@@ -832,18 +832,23 @@ func defaultFailureReason(
 	}
 }
 
-func (l *failureLedger) Expire(now time.Time) (int, error) {
+// Expire finalizes every operation past its deadline and returns the IDs it
+// actually finalized. The IDs matter to callers holding per-operation state:
+// a successful call is not a complete one — it stops at expireBatch and skips
+// claimed operations mid-verification — so "the sweep succeeded" is not a
+// licence to discard anything else that looks overdue.
+func (l *failureLedger) Expire(now time.Time) ([]string, error) {
 	if now.IsZero() {
 		now = l.now()
 	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if err := l.ensureOpen(); err != nil {
-		return 0, err
+		return nil, err
 	}
-	finalized := 0
+	var finalized []string
 	for _, operation := range l.active {
-		if l.expireBatch > 0 && finalized >= l.expireBatch {
+		if l.expireBatch > 0 && len(finalized) >= l.expireBatch {
 			break
 		}
 		if now.Before(operation.Deadline) {
@@ -881,12 +886,13 @@ func (l *failureLedger) Expire(now time.Time) (int, error) {
 			}
 		}
 		result := failureOperationResult(operation)
+		operationID := operation.ID
 		if err := l.finalizeLocked(
 			operation, result, failureOperationFinalReason(operation, result), now,
 		); err != nil {
 			return finalized, err
 		}
-		finalized++
+		finalized = append(finalized, operationID)
 	}
 	return finalized, nil
 }

--- a/tools/loadgen/failure_ledger_expiry_test.go
+++ b/tools/loadgen/failure_ledger_expiry_test.go
@@ -31,7 +31,8 @@ func TestFailureLedger_ExpireRetiresAtMostOneBatchPerSweep(t *testing.T) {
 	require.NoError(t, err)
 	startExpiredOperations(t, ledger, 100, now)
 
-	finalized, err := ledger.Expire(now.Add(time.Minute))
+	finalizedIDs, err := ledger.Expire(now.Add(time.Minute))
+	finalized := len(finalizedIDs)
 
 	require.NoError(t, err)
 	assert.Equal(t, 25, finalized)
@@ -48,7 +49,8 @@ func TestFailureLedger_ExpireDrainsTheBacklogOverSuccessiveSweeps(t *testing.T) 
 
 	total := 0
 	for range 4 {
-		finalized, err := ledger.Expire(now.Add(time.Minute))
+		finalizedIDs, err := ledger.Expire(now.Add(time.Minute))
+		finalized := len(finalizedIDs)
 		require.NoError(t, err)
 		total += finalized
 	}
@@ -65,7 +67,8 @@ func TestFailureLedger_ExpireIsUnboundedWhenNoBatchIsConfigured(t *testing.T) {
 	require.NoError(t, err)
 	startExpiredOperations(t, ledger, 60, now)
 
-	finalized, err := ledger.Expire(now.Add(time.Minute))
+	finalizedIDs, err := ledger.Expire(now.Add(time.Minute))
+	finalized := len(finalizedIDs)
 
 	require.NoError(t, err)
 	assert.Equal(t, 60, finalized)

--- a/tools/loadgen/failure_ledger_review_test.go
+++ b/tools/loadgen/failure_ledger_review_test.go
@@ -33,7 +33,8 @@ func TestFailureLedger_AbandonFinalizesWithoutDataLoss(t *testing.T) {
 	assert.Equal(t, uint64(1), snapshot.Results[failureResultNotSent])
 	assert.Zero(t, snapshot.Results[failureResultMissingAfterDeadline])
 
-	expired, err := ledger.Expire(now.Add(time.Hour))
+	expiredIDs, err := ledger.Expire(now.Add(time.Hour))
+	expired := len(expiredIDs)
 	require.NoError(t, err)
 	assert.Zero(t, expired)
 }
@@ -174,7 +175,8 @@ func TestFailureLedger_FinalizationPreservesDeterministicReason(t *testing.T) {
 
 			tt.observe(t, ledger)
 			if tt.expire {
-				finalized, err := ledger.Expire(now.Add(time.Minute))
+				finalizedIDs, err := ledger.Expire(now.Add(time.Minute))
+				finalized := len(finalizedIDs)
 				require.NoError(t, err)
 				require.Equal(t, 1, finalized)
 			}
@@ -316,7 +318,8 @@ func TestFailureLedger_ExpireSkipsClaimedOperation(t *testing.T) {
 	_, ok := ledger.ClaimDue(now)
 	require.True(t, ok)
 
-	finalized, err := ledger.Expire(now.Add(time.Hour))
+	finalizedIDs, err := ledger.Expire(now.Add(time.Hour))
+	finalized := len(finalizedIDs)
 	require.NoError(t, err)
 	assert.Zero(t, finalized, "an in-flight verification must not be finalized underneath the reconciler")
 	assert.Equal(t, 1, ledger.Snapshot().Active)
@@ -340,7 +343,8 @@ func TestFailureLedger_ExpireFinalizesReleasedClaim(t *testing.T) {
 	require.True(t, ok)
 	require.NoError(t, ledger.ReleaseClaim("released", now))
 
-	finalized, err := ledger.Expire(now.Add(time.Hour))
+	finalizedIDs, err := ledger.Expire(now.Add(time.Hour))
+	finalized := len(finalizedIDs)
 	require.NoError(t, err)
 	assert.Equal(t, 1, finalized)
 }
@@ -361,7 +365,8 @@ func TestFailureLedger_HistoryObservationReleasesClaimForAdmissionExpiry(t *test
 	require.NoError(t, err)
 	assert.False(t, finalized)
 
-	expired, err := ledger.Expire(now.Add(time.Hour))
+	expiredIDs, err := ledger.Expire(now.Add(time.Hour))
+	expired := len(expiredIDs)
 	require.NoError(t, err)
 	assert.Equal(t, 1, expired)
 	snapshot := ledger.Snapshot()

--- a/tools/loadgen/failure_ledger_test.go
+++ b/tools/loadgen/failure_ledger_test.go
@@ -69,7 +69,8 @@ func TestFailureLedger_RejectedAdmissionDoesNotBecomeMissingSideEffect(t *testin
 	)
 	require.NoError(t, err)
 
-	finalized, err := ledger.Expire(now.Add(time.Minute))
+	finalizedIDs, err := ledger.Expire(now.Add(time.Minute))
+	finalized := len(finalizedIDs)
 	require.NoError(t, err)
 	require.Equal(t, 1, finalized)
 	assert.Equal(

--- a/tools/loadgen/failure_observation_runtime.go
+++ b/tools/loadgen/failure_observation_runtime.go
@@ -54,6 +54,7 @@ func newSoakFailureObservationRuntime(
 	ledger *failureLedger,
 	metrics *Metrics,
 	queue int,
+	evidenceCapacity int,
 	evidenceDirectory string,
 	now func() time.Time,
 ) *soakFailureObservationRuntime {
@@ -61,7 +62,8 @@ func newSoakFailureObservationRuntime(
 	if !enabled {
 		return runtime
 	}
-	options := make([]failureRecipientObserverOption, 0, 1)
+	options := make([]failureRecipientObserverOption, 0, 2)
+	options = append(options, withFailureRecipientEvidenceCapacity(evidenceCapacity))
 	if evidenceDirectory != "" {
 		options = append(options, withFailureRecipientEvidenceDir(evidenceDirectory))
 	}

--- a/tools/loadgen/failure_observation_runtime.go
+++ b/tools/loadgen/failure_observation_runtime.go
@@ -93,6 +93,16 @@ func (r *soakFailureObservationRuntime) StartRecipient(
 	return nil
 }
 
+// Evidence exposes the recipient expectation map so the failure sweep can bound
+// it by the same deadline the ledger uses. nil when the observer is off, which
+// ExpireBefore handles.
+func (r *soakFailureObservationRuntime) Evidence() *recipientEvidence {
+	if r == nil || r.recipient == nil {
+		return nil
+	}
+	return r.recipient.evidence
+}
+
 func (r *soakFailureObservationRuntime) Recipient() *failureRecipientObserver {
 	if r == nil {
 		return nil

--- a/tools/loadgen/failure_observation_runtime_test.go
+++ b/tools/loadgen/failure_observation_runtime_test.go
@@ -98,7 +98,7 @@ func TestSoakFailureTracker_RecipientEffectIsOptIn(t *testing.T) {
 }
 
 func TestFailureObservationRuntime_DisabledCreatesNoRecipientRuntime(t *testing.T) {
-	runtime := newSoakFailureObservationRuntime(false, nil, NewMetrics(), 1, t.TempDir(), time.Now)
+	runtime := newSoakFailureObservationRuntime(false, nil, NewMetrics(), 1, 0, t.TempDir(), time.Now)
 	assert.Nil(t, runtime.Recipient())
 	require.NoError(t, runtime.StartRecipient(nil, nil, nil))
 	require.NoError(t, runtime.Close())

--- a/tools/loadgen/failure_recipient.go
+++ b/tools/loadgen/failure_recipient.go
@@ -822,14 +822,26 @@ func withFailureRecipientEvidenceDir(directory string) failureRecipientObserverO
 	return func(observer *failureRecipientObserver) { observer.evidenceDir = directory }
 }
 
+// recipientEvidenceCapacityFactor is the headroom the expectation map keeps over
+// the ledger's own capacity.
+//
+// The sweep frees ledger slots inside Expire and frees the matching evidence
+// afterwards, in ForgetAll, so between the two the ledger has room the evidence
+// does not. Sized exactly like the ledger, a send arriving in that window is
+// refused registration even though the ledger would have admitted its
+// operation. One extra generation closes the window by construction: an
+// unbounded sweep can retire at most the whole ledger before cleanup runs, so
+// the lag can never exceed one capacity.
+const recipientEvidenceCapacityFactor = 2
+
 // withFailureRecipientEvidenceCapacity bounds the expectation map. Callers pass
 // the ledger's own capacity: an expectation exists per ledger operation, so the
 // ledger's admission limit binds first in a healthy run and this only engages
-// when expiry has stopped working.
+// once expiry has stopped working.
 func withFailureRecipientEvidenceCapacity(capacity int) failureRecipientObserverOption {
 	return func(o *failureRecipientObserver) {
 		if capacity > 0 {
-			o.evidence.capacity = capacity
+			o.evidence.capacity = capacity * recipientEvidenceCapacityFactor
 		}
 	}
 }

--- a/tools/loadgen/failure_recipient.go
+++ b/tools/loadgen/failure_recipient.go
@@ -613,13 +613,20 @@ func (r *recipientEvidence) Forget(operationID string) {
 }
 
 // ExpireBefore releases every expectation registered at or before cutoff and
-// returns how many went. The caller passes now minus the operation deadline, so
-// an expectation cannot outlive the operation it describes. It exists because the ledger's own expiry finalizes an
-// operation and forgets it without telling the evidence: Finalize is the only
-// other way out of this map and it runs inside the reconciler, so anything the
-// reconciler does not reach was retained for the life of the process. The
-// per-recipient route maps incrementRecipientRoute allocates make that the
-// largest object graph in the run.
+// returns how many went. Callers pass now minus the operation deadline, so an
+// expectation cannot outlive the operation it describes.
+//
+// It exists because the ledger's own expiry finalizes an operation and forgets
+// it without telling the evidence, while Finalize — the only other way out of
+// this map — runs inside the reconciler. Anything the reconciler never reaches
+// was therefore retained for the life of the process, and each entry holds one
+// route map per recipient, which made this the largest object graph in the run.
+//
+// A recovered expectation is registered when the restart replays it rather than
+// when its operation started, so it can outlive that operation by up to one
+// deadline. That over-retention is bounded and costs one deadline of entries
+// once per restart; treating a replayed entry as already aged would expire
+// evidence the run can still resolve.
 //
 // It is deliberately not driven from the ledger's finalize path. That would put
 // the evidence lock underneath the ledger lock, while the observer already

--- a/tools/loadgen/failure_recipient.go
+++ b/tools/loadgen/failure_recipient.go
@@ -351,19 +351,9 @@ type recipientExpectationConfig struct {
 	Route       recipientExpectedRoute
 	Source      recipientSetSource
 	Complete    bool
-	// Deadline is the operation's own deadline when the caller knows it. The
-	// ledger honours each operation's persisted deadline, so an entry expired
-	// on the sweep's current retention alone can be released while its
-	// operation is still live — a recovered operation accepted under a longer
-	// deadline is the reachable case. Optional: without it the sweep falls back
-	// to registration time, which matches for operations started in this
-	// process under this configuration.
-	Deadline time.Time
 }
 
 type recipientExpectation struct {
-	registeredAt      time.Time
-	deadline          time.Time
 	expected          map[string]struct{}
 	observed          map[string]map[recipientDeliveryRoute]int
 	mismatches        map[string]struct{}
@@ -386,15 +376,6 @@ type recipientEvidence struct {
 	// failing to expire would otherwise reinstate the growth this file exists
 	// to stop. Zero means unbounded.
 	capacity int
-	// now is injectable so expiry can be asserted without sleeping.
-	now func() time.Time
-}
-
-func (r *recipientEvidence) clock() time.Time {
-	if r.now == nil {
-		return time.Now().UTC()
-	}
-	return r.now().UTC()
 }
 
 type recipientEvidenceDisposition string
@@ -411,7 +392,6 @@ func newRecipientEvidence(allowDuplicates bool) *recipientEvidence {
 	return &recipientEvidence{
 		allowDuplicates: allowDuplicates,
 		operations:      make(map[string]*recipientExpectation),
-		now:             func() time.Time { return time.Now().UTC() },
 	}
 }
 
@@ -474,9 +454,7 @@ func (r *recipientEvidence) ExpectDelivery(config *recipientExpectationConfig) e
 			r.capacity)
 	}
 	r.operations[config.OperationID] = &recipientExpectation{
-		registeredAt: r.clock(),
-		deadline:     config.Deadline,
-		expected:     expected, observed: make(map[string]map[recipientDeliveryRoute]int), mismatches: make(map[string]struct{}),
+		expected: expected, observed: make(map[string]map[recipientDeliveryRoute]int), mismatches: make(map[string]struct{}),
 		roomID: config.RoomID, eventType: config.EventType,
 		route: config.Route, source: config.Source, complete: config.Complete,
 		durableMissing: make(map[string]struct{}), durableUnexpected: make(map[string]struct{}),
@@ -631,46 +609,30 @@ func (r *recipientEvidence) Forget(operationID string) {
 	delete(r.operations, operationID)
 }
 
-// ExpireBefore releases every expectation registered at or before cutoff and
-// returns how many went. Callers pass now minus the operation deadline, so an
-// expectation cannot outlive the operation it describes.
+// ForgetAll releases the expectations for the operations the ledger reports it
+// finalized, and returns how many went. Taking the IDs from the ledger is what
+// keeps the two aligned: a time-based bound cannot be, because Expire stops at
+// its batch limit and skips claimed operations mid-verification, so "past its
+// deadline" and "the ledger is done with it" are different sets.
 //
-// It exists because the ledger's own expiry finalizes an operation and forgets
-// it without telling the evidence, while Finalize — the only other way out of
-// this map — runs inside the reconciler. Anything the reconciler never reaches
-// was therefore retained for the life of the process, and each entry holds one
-// route map per recipient, which made this the largest object graph in the run.
-//
-// A recovered expectation is registered when the restart replays it rather than
-// when its operation started, so it can outlive that operation by up to one
-// deadline. That over-retention is bounded and costs one deadline of entries
-// once per restart; treating a replayed entry as already aged would expire
-// evidence the run can still resolve.
-//
-// It is deliberately not driven from the ledger's finalize path. That would put
-// the evidence lock underneath the ledger lock, while the observer already
-// takes them the other way round; a sweep that holds neither cannot deadlock
-// however those paths change.
-func (r *recipientEvidence) ExpireBefore(cutoff time.Time) int {
-	if r == nil {
+// The caller passes IDs the ledger has already returned, so this takes only the
+// evidence lock — the ledger's is released by then, and no ordering between the
+// two is created.
+func (r *recipientEvidence) ForgetAll(operationIDs []string) int {
+	if r == nil || len(operationIDs) == 0 {
 		return 0
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	expired := 0
-	for operationID, expectation := range r.operations {
-		if !expectation.deadline.IsZero() {
-			// It knows when its operation ends, so nothing else may release it.
-			if !expectation.deadline.Before(r.clock()) {
-				continue
-			}
-		} else if expectation.registeredAt.IsZero() || expectation.registeredAt.After(cutoff) {
+	forgotten := 0
+	for _, operationID := range operationIDs {
+		if _, tracked := r.operations[operationID]; !tracked {
 			continue
 		}
 		delete(r.operations, operationID)
-		expired++
+		forgotten++
 	}
-	return expired
+	return forgotten
 }
 
 // Len reports how many expectations are retained. The run needs this as a gauge:
@@ -973,17 +935,12 @@ func (o *failureRecipientObserver) Recover(operations []failureOperation) error 
 			err = o.ExpectDelivery(&recipientExpectationConfig{
 				OperationID: operation.ID, Recipients: recipients,
 				Route: recipientExpectedRouteAny, Source: recipientSetSourceLegacy, Complete: false,
-				Deadline: operation.Deadline,
 			})
 		} else {
 			err = o.ExpectDelivery(&recipientExpectationConfig{
 				OperationID: operation.ID, Recipients: recipients,
 				RoomID: operation.Targets["roomId"], EventType: eventType,
 				Route: route, Source: source, Complete: complete,
-				// The persisted deadline, not this process's retention: the
-				// ledger keeps the operation until this instant regardless of
-				// how SOAK_RECONCILE_DEADLINE was changed between runs.
-				Deadline: operation.Deadline,
 			})
 		}
 		if err != nil {

--- a/tools/loadgen/failure_recipient.go
+++ b/tools/loadgen/failure_recipient.go
@@ -351,10 +351,19 @@ type recipientExpectationConfig struct {
 	Route       recipientExpectedRoute
 	Source      recipientSetSource
 	Complete    bool
+	// Deadline is the operation's own deadline when the caller knows it. The
+	// ledger honours each operation's persisted deadline, so an entry expired
+	// on the sweep's current retention alone can be released while its
+	// operation is still live — a recovered operation accepted under a longer
+	// deadline is the reachable case. Optional: without it the sweep falls back
+	// to registration time, which matches for operations started in this
+	// process under this configuration.
+	Deadline time.Time
 }
 
 type recipientExpectation struct {
 	registeredAt      time.Time
+	deadline          time.Time
 	expected          map[string]struct{}
 	observed          map[string]map[recipientDeliveryRoute]int
 	mismatches        map[string]struct{}
@@ -373,6 +382,10 @@ type recipientEvidence struct {
 	mu              sync.Mutex
 	allowDuplicates bool
 	operations      map[string]*recipientExpectation
+	// capacity bounds the map when expiry cannot run — a ledger that keeps
+	// failing to expire would otherwise reinstate the growth this file exists
+	// to stop. Zero means unbounded.
+	capacity int
 	// now is injectable so expiry can be asserted without sleeping.
 	now func() time.Time
 }
@@ -455,8 +468,14 @@ func (r *recipientEvidence) ExpectDelivery(config *recipientExpectationConfig) e
 	if _, exists := r.operations[config.OperationID]; exists {
 		return fmt.Errorf("recipient expectation %q already exists", config.OperationID)
 	}
+	if r.capacity > 0 && len(r.operations) >= r.capacity {
+		return fmt.Errorf(
+			"recipient expectation capacity %d exceeded; evidence is not being expired",
+			r.capacity)
+	}
 	r.operations[config.OperationID] = &recipientExpectation{
 		registeredAt: r.clock(),
+		deadline:     config.Deadline,
 		expected:     expected, observed: make(map[string]map[recipientDeliveryRoute]int), mismatches: make(map[string]struct{}),
 		roomID: config.RoomID, eventType: config.EventType,
 		route: config.Route, source: config.Source, complete: config.Complete,
@@ -640,7 +659,12 @@ func (r *recipientEvidence) ExpireBefore(cutoff time.Time) int {
 	defer r.mu.Unlock()
 	expired := 0
 	for operationID, expectation := range r.operations {
-		if expectation.registeredAt.IsZero() || expectation.registeredAt.After(cutoff) {
+		if !expectation.deadline.IsZero() {
+			// It knows when its operation ends, so nothing else may release it.
+			if !expectation.deadline.Before(r.clock()) {
+				continue
+			}
+		} else if expectation.registeredAt.IsZero() || expectation.registeredAt.After(cutoff) {
 			continue
 		}
 		delete(r.operations, operationID)
@@ -836,6 +860,18 @@ func withFailureRecipientEvidenceDir(directory string) failureRecipientObserverO
 	return func(observer *failureRecipientObserver) { observer.evidenceDir = directory }
 }
 
+// withFailureRecipientEvidenceCapacity bounds the expectation map. Callers pass
+// the ledger's own capacity: an expectation exists per ledger operation, so the
+// ledger's admission limit binds first in a healthy run and this only engages
+// when expiry has stopped working.
+func withFailureRecipientEvidenceCapacity(capacity int) failureRecipientObserverOption {
+	return func(o *failureRecipientObserver) {
+		if capacity > 0 {
+			o.evidence.capacity = capacity
+		}
+	}
+}
+
 func withFailureRecipientDuplicatePolicy(allow bool) failureRecipientObserverOption {
 	return func(observer *failureRecipientObserver) {
 		observer.evidence.allowDuplicates = allow
@@ -937,12 +973,17 @@ func (o *failureRecipientObserver) Recover(operations []failureOperation) error 
 			err = o.ExpectDelivery(&recipientExpectationConfig{
 				OperationID: operation.ID, Recipients: recipients,
 				Route: recipientExpectedRouteAny, Source: recipientSetSourceLegacy, Complete: false,
+				Deadline: operation.Deadline,
 			})
 		} else {
 			err = o.ExpectDelivery(&recipientExpectationConfig{
 				OperationID: operation.ID, Recipients: recipients,
 				RoomID: operation.Targets["roomId"], EventType: eventType,
 				Route: route, Source: source, Complete: complete,
+				// The persisted deadline, not this process's retention: the
+				// ledger keeps the operation until this instant regardless of
+				// how SOAK_RECONCILE_DEADLINE was changed between runs.
+				Deadline: operation.Deadline,
 			})
 		}
 		if err != nil {

--- a/tools/loadgen/failure_recipient.go
+++ b/tools/loadgen/failure_recipient.go
@@ -354,6 +354,7 @@ type recipientExpectationConfig struct {
 }
 
 type recipientExpectation struct {
+	registeredAt      time.Time
 	expected          map[string]struct{}
 	observed          map[string]map[recipientDeliveryRoute]int
 	mismatches        map[string]struct{}
@@ -372,6 +373,15 @@ type recipientEvidence struct {
 	mu              sync.Mutex
 	allowDuplicates bool
 	operations      map[string]*recipientExpectation
+	// now is injectable so expiry can be asserted without sleeping.
+	now func() time.Time
+}
+
+func (r *recipientEvidence) clock() time.Time {
+	if r.now == nil {
+		return time.Now().UTC()
+	}
+	return r.now().UTC()
 }
 
 type recipientEvidenceDisposition string
@@ -385,7 +395,11 @@ const (
 )
 
 func newRecipientEvidence(allowDuplicates bool) *recipientEvidence {
-	return &recipientEvidence{allowDuplicates: allowDuplicates, operations: make(map[string]*recipientExpectation)}
+	return &recipientEvidence{
+		allowDuplicates: allowDuplicates,
+		operations:      make(map[string]*recipientExpectation),
+		now:             func() time.Time { return time.Now().UTC() },
+	}
 }
 
 func (r *recipientEvidence) Expect(operationID string, recipients []string) error {
@@ -442,7 +456,8 @@ func (r *recipientEvidence) ExpectDelivery(config *recipientExpectationConfig) e
 		return fmt.Errorf("recipient expectation %q already exists", config.OperationID)
 	}
 	r.operations[config.OperationID] = &recipientExpectation{
-		expected: expected, observed: make(map[string]map[recipientDeliveryRoute]int), mismatches: make(map[string]struct{}),
+		registeredAt: r.clock(),
+		expected:     expected, observed: make(map[string]map[recipientDeliveryRoute]int), mismatches: make(map[string]struct{}),
 		roomID: config.RoomID, eventType: config.EventType,
 		route: config.Route, source: config.Source, complete: config.Complete,
 		durableMissing: make(map[string]struct{}), durableUnexpected: make(map[string]struct{}),
@@ -595,6 +610,48 @@ func (r *recipientEvidence) Forget(operationID string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	delete(r.operations, operationID)
+}
+
+// ExpireBefore releases every expectation registered at or before cutoff and
+// returns how many went. The caller passes now minus the operation deadline, so
+// an expectation cannot outlive the operation it describes. It exists because the ledger's own expiry finalizes an
+// operation and forgets it without telling the evidence: Finalize is the only
+// other way out of this map and it runs inside the reconciler, so anything the
+// reconciler does not reach was retained for the life of the process. The
+// per-recipient route maps incrementRecipientRoute allocates make that the
+// largest object graph in the run.
+//
+// It is deliberately not driven from the ledger's finalize path. That would put
+// the evidence lock underneath the ledger lock, while the observer already
+// takes them the other way round; a sweep that holds neither cannot deadlock
+// however those paths change.
+func (r *recipientEvidence) ExpireBefore(cutoff time.Time) int {
+	if r == nil {
+		return 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	expired := 0
+	for operationID, expectation := range r.operations {
+		if expectation.registeredAt.IsZero() || expectation.registeredAt.After(cutoff) {
+			continue
+		}
+		delete(r.operations, operationID)
+		expired++
+	}
+	return expired
+}
+
+// Len reports how many expectations are retained. The run needs this as a gauge:
+// a count that tracks the ledger's own in-flight number is healthy, one that
+// climbs past it is this map leaking again.
+func (r *recipientEvidence) Len() int {
+	if r == nil {
+		return 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.operations)
 }
 
 func (r *recipientEvidence) Complete(operationID string) bool {

--- a/tools/loadgen/failure_recipient_expiry_test.go
+++ b/tools/loadgen/failure_recipient_expiry_test.go
@@ -10,45 +10,49 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newExpiryTestEvidence pins the clock so retention can be asserted without
-// sleeping.
-func newExpiryTestEvidence(at *time.Time) *recipientEvidence {
-	evidence := newRecipientEvidence(false)
-	evidence.now = func() time.Time { return *at }
-	return evidence
+// startExpiryOperation puts one operation in the ledger and its expectation in
+// the evidence, which is the pairing the sweep has to keep in step.
+func startExpiryOperation(
+	t *testing.T,
+	ledger *failureLedger,
+	evidence *recipientEvidence,
+	id string,
+	at time.Time,
+) {
+	t.Helper()
+	require.NoError(t, ledger.Start(&failureOperation{
+		ID: id, Scenario: soakFailureScenario, Lane: soakFailureLaneMessageSend,
+		StartedAt: at, VerifyAfter: at, Deadline: at.Add(time.Minute),
+		Expected: []failureObserver{failureObserverRecipient},
+	}))
+	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
+		OperationID: id, Recipients: []string{"a"}, Complete: true,
+	}))
 }
 
 // The evidence map is emptied only by Finalize, which runs inside the
 // reconciler. An operation that reaches its deadline without being reconciled
-// is finalized by failureLedger.Expire — which drops it from the ledger and
-// never tells the evidence, so its expectation stays for the life of the
-// process. At 55 sends/s with 100 recipients each that is ~20M per-recipient
-// route maps an hour, and it is what an 8GB pod dies of.
-func TestRecipientEvidence_ExpiresExpectationsOlderThanTheCutoff(t *testing.T) {
-	clock := time.Unix(1000, 0).UTC()
-	evidence := newExpiryTestEvidence(&clock)
+// is finalized by failureLedger.Expire — which drops it from the ledger and,
+// before this, never told the evidence. At 55 sends/s with 100 recipients each
+// that is ~20M per-recipient route maps an hour, and it is what an 8GB pod
+// dies of.
+func TestRecipientEvidence_ForgetAllReleasesTheGivenOperations(t *testing.T) {
+	evidence := newRecipientEvidence(false)
+	for _, id := range []string{"op-1", "op-2", "op-3"} {
+		require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
+			OperationID: id, Recipients: []string{"a"}, Complete: true,
+		}))
+	}
 
-	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
-		OperationID: "op-old", Recipients: []string{"a", "b"}, Complete: true,
-	}))
-	clock = clock.Add(10 * time.Minute)
-	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
-		OperationID: "op-recent", Recipients: []string{"c"}, Complete: true,
-	}))
-
-	expired := evidence.ExpireBefore(clock.Add(-5 * time.Minute))
-
-	assert.Equal(t, 1, expired)
-	assert.Equal(t, 1, evidence.Len(),
-		"the entry older than the cutoff must go, the recent one must stay")
+	assert.Equal(t, 2, evidence.ForgetAll([]string{"op-1", "op-3"}))
+	assert.Equal(t, 1, evidence.Len())
 }
 
-// Expiry has to release the observations too, not just the outer entry: the
+// Releasing the outer entry has to release the observations with it: the
 // per-recipient route maps incrementRecipientRoute allocates are where the
 // bytes actually are.
-func TestRecipientEvidence_ExpiryReleasesObservedRoutes(t *testing.T) {
-	clock := time.Unix(1000, 0).UTC()
-	evidence := newExpiryTestEvidence(&clock)
+func TestRecipientEvidence_ForgetAllReleasesObservedRoutes(t *testing.T) {
+	evidence := newRecipientEvidence(false)
 	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
 		OperationID: "op", Recipients: []string{"a", "b", "c"}, Complete: true,
 	}))
@@ -56,7 +60,7 @@ func TestRecipientEvidence_ExpiryReleasesObservedRoutes(t *testing.T) {
 		require.True(t, evidence.Observe("op", recipient))
 	}
 
-	require.Equal(t, 1, evidence.ExpireBefore(clock.Add(time.Minute)))
+	require.Equal(t, 1, evidence.ForgetAll([]string{"op"}))
 
 	assert.Zero(t, evidence.Len())
 	assert.Equal(t, recipientEvidenceUntracked,
@@ -64,197 +68,135 @@ func TestRecipientEvidence_ExpiryReleasesObservedRoutes(t *testing.T) {
 		"a released expectation must not be resurrected by a late delivery")
 }
 
-// Nothing may be released before its operation could still be reconciled, or
-// the sweep would turn a verifiable delivery into an unverified one.
-func TestRecipientEvidence_KeepsExpectationsInsideTheRetentionWindow(t *testing.T) {
-	clock := time.Unix(1000, 0).UTC()
-	evidence := newExpiryTestEvidence(&clock)
+func TestRecipientEvidence_ForgetAllIgnoresWhatItDoesNotHold(t *testing.T) {
+	var absent *recipientEvidence
+	assert.Zero(t, absent.ForgetAll([]string{"op"}))
+	assert.Zero(t, absent.Len())
+
+	evidence := newRecipientEvidence(false)
+	assert.Zero(t, evidence.ForgetAll([]string{"never-registered"}))
+	assert.Zero(t, evidence.ForgetAll(nil))
+}
+
+// Expire is the only thing that knows which operations it actually retired, so
+// it has to say. A count leaves every caller holding per-operation state to
+// guess, and guessing is what the two findings on this PR were about.
+func TestFailureLedger_ExpireReportsTheOperationsItFinalized(t *testing.T) {
+	at := time.Unix(1000, 0).UTC()
+	ledger, err := newFailureLedger(&failureLedgerConfig{
+		Capacity: 16, Now: func() time.Time { return at },
+	})
+	require.NoError(t, err)
+	evidence := newRecipientEvidence(false)
+	startExpiryOperation(t, ledger, evidence, "op-1", at)
+	startExpiryOperation(t, ledger, evidence, "op-2", at)
+
+	expired, err := ledger.Expire(at.Add(2 * time.Minute))
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"op-1", "op-2"}, expired)
+}
+
+func TestRunSoakFailureExpiry_ForgetsExactlyWhatTheLedgerFinalized(t *testing.T) {
+	at := time.Unix(1000, 0).UTC()
+	ledger, err := newFailureLedger(&failureLedgerConfig{
+		Capacity: 16, Now: func() time.Time { return at },
+	})
+	require.NoError(t, err)
+	evidence := newRecipientEvidence(false)
+	startExpiryOperation(t, ledger, evidence, "op", at)
+
+	ticks := make(chan time.Time, 1)
+	ticks <- at.Add(2 * time.Minute)
+	close(ticks)
+	runSoakFailureExpiry(context.Background(), ledger, evidence, ticks, nil)
+
+	assert.Zero(t, evidence.Len(),
+		"the sweep that finalizes an operation must release its evidence")
+}
+
+// Expire stops at LEDGER_EXPIRE_BATCH and returns no error, so a successful
+// call is not a complete one. Releasing every overdue expectation on that tick
+// strands the operations the batch did not reach: still active, still
+// reconcilable, and with no recipient evidence left to reconcile against.
+func TestRunSoakFailureExpiry_KeepsEvidenceTheLedgerBatchDeferred(t *testing.T) {
+	at := time.Unix(1000, 0).UTC()
+	ledger, err := newFailureLedger(&failureLedgerConfig{
+		Capacity: 16, ExpireBatch: 1, Now: func() time.Time { return at },
+	})
+	require.NoError(t, err)
+	evidence := newRecipientEvidence(false)
+	startExpiryOperation(t, ledger, evidence, "op-1", at)
+	startExpiryOperation(t, ledger, evidence, "op-2", at)
+
+	ticks := make(chan time.Time, 1)
+	ticks <- at.Add(2 * time.Minute)
+	close(ticks)
+	runSoakFailureExpiry(context.Background(), ledger, evidence, ticks, nil)
+
+	assert.Equal(t, 1, evidence.Len(),
+		"the operation the batch limit deferred must keep its evidence")
+}
+
+// A claimed operation is mid-verification, so Expire skips it and the sweep
+// completes without error. This is the ordinary path, not a configuration edge:
+// the reconciler is about to call Finalize and needs the evidence still there.
+func TestRunSoakFailureExpiry_KeepsEvidenceForAClaimedOperation(t *testing.T) {
+	at := time.Unix(1000, 0).UTC()
+	ledger, err := newFailureLedger(&failureLedgerConfig{
+		Capacity: 16, Now: func() time.Time { return at },
+	})
+	require.NoError(t, err)
+	evidence := newRecipientEvidence(false)
+	startExpiryOperation(t, ledger, evidence, "op", at)
+	_, claimed := ledger.ClaimDue(at.Add(2 * time.Minute))
+	require.True(t, claimed, "the operation must be claimed for this to test anything")
+
+	ticks := make(chan time.Time, 1)
+	ticks <- at.Add(3 * time.Minute)
+	close(ticks)
+	runSoakFailureExpiry(context.Background(), ledger, evidence, ticks, nil)
+
+	assert.Equal(t, 1, evidence.Len(),
+		"evidence for an operation the reconciler is verifying must survive the sweep")
+}
+
+// A failed expiry finalizes nothing, so there is nothing to forget — and the
+// operations stay live and reconcilable.
+func TestRunSoakFailureExpiry_KeepsEvidenceWhenLedgerExpiryFails(t *testing.T) {
+	at := time.Unix(1000, 0).UTC()
+	ledger, err := newFailureLedger(&failureLedgerConfig{
+		Capacity: 16, Now: func() time.Time { return at },
+	})
+	require.NoError(t, err)
+	evidence := newRecipientEvidence(false)
 	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
 		OperationID: "op", Recipients: []string{"a"}, Complete: true,
 	}))
+	require.NoError(t, ledger.Close())
 
-	assert.Zero(t, evidence.ExpireBefore(clock.Add(-time.Nanosecond)))
+	var swept []error
+	ticks := make(chan time.Time, 1)
+	ticks <- at.Add(time.Hour)
+	close(ticks)
+	runSoakFailureExpiry(context.Background(), ledger, evidence, ticks,
+		func(err error) { swept = append(swept, err) })
+
+	require.NotEmpty(t, swept, "a failed ledger expiry must be reported")
 	assert.Equal(t, 1, evidence.Len())
 }
 
-// A nil evidence is the observer-disabled case, which the sweep runs into on
-// every tick of a default configuration.
-func TestRecipientEvidence_ExpiryToleratesADisabledObserver(t *testing.T) {
-	var evidence *recipientEvidence
-
-	assert.Zero(t, evidence.ExpireBefore(time.Unix(1000, 0).UTC()))
-	assert.Zero(t, evidence.Len())
-}
-
-// Expiry runs on the same sweep as the ledger's, so the evidence cannot outlive
-// the operations it describes even when nothing reconciles.
-func TestRunSoakFailureExpiry_ExpiresRecipientEvidenceOnEveryTick(t *testing.T) {
-	clock := time.Unix(1000, 0).UTC()
-	ledger, err := newFailureLedger(&failureLedgerConfig{
-		Capacity: 16, Now: func() time.Time { return clock },
-	})
-	require.NoError(t, err)
-
-	evidence := newExpiryTestEvidence(&clock)
-	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
-		OperationID: "op", Recipients: []string{"a"}, Complete: true,
-	}))
-	require.Equal(t, 1, evidence.Len())
-
-	ticks := make(chan time.Time, 1)
-	ticks <- clock.Add(11 * time.Minute)
-	close(ticks)
-	runSoakFailureExpiry(context.Background(), ledger, evidence, 10*time.Minute, ticks, nil)
-
-	assert.Zero(t, evidence.Len(),
-		"the sweep that expires ledger operations must expire their evidence too")
-}
-
-// The retention window is the operation deadline, so an expectation whose
-// operation is still live must survive the sweep.
-func TestRunSoakFailureExpiry_KeepsEvidenceForStillLiveOperations(t *testing.T) {
-	clock := time.Unix(1000, 0).UTC()
-	ledger, err := newFailureLedger(&failureLedgerConfig{
-		Capacity: 16, Now: func() time.Time { return clock },
-	})
-	require.NoError(t, err)
-
-	evidence := newExpiryTestEvidence(&clock)
-	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
-		OperationID: "op", Recipients: []string{"a"}, Complete: true,
-	}))
-
-	ticks := make(chan time.Time, 1)
-	ticks <- clock.Add(time.Minute)
-	close(ticks)
-	runSoakFailureExpiry(context.Background(), ledger, evidence, 10*time.Minute, ticks, nil)
-
-	assert.Equal(t, 1, evidence.Len(),
-		"an operation one minute into a ten minute deadline is still verifiable")
-}
-
-// Without a gauge the only way to see this map growing again is a heap
-// profile, which is how it went unnoticed for the whole investigation. A
-// healthy run tracks the ledger's own in-flight count; a run climbing past it
-// is this leaking again.
-func TestRunSoakFailureExpiry_PublishesTheRetainedExpectationCount(t *testing.T) {
-	clock := time.Unix(1000, 0).UTC()
-	ledger, err := newFailureLedger(&failureLedgerConfig{
-		Capacity: 16, Now: func() time.Time { return clock },
-	})
-	require.NoError(t, err)
-
-	metrics := NewMetrics()
-	evidence := newExpiryTestEvidence(&clock)
-	for _, id := range []string{"op-1", "op-2", "op-3"} {
+// Forgetting only what the ledger retired means a ledger that stops retiring
+// stops bounding the map, so it needs a ceiling of its own — the ledger has
+// LEDGER_CAPACITY and this had nothing.
+func TestRecipientEvidence_RefusesToGrowPastItsCapacity(t *testing.T) {
+	evidence := newRecipientEvidence(false)
+	evidence.capacity = 2
+	for _, id := range []string{"op-1", "op-2"} {
 		require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
 			OperationID: id, Recipients: []string{"a"}, Complete: true,
 		}))
 	}
-
-	ticks := make(chan time.Time, 1)
-	ticks <- clock.Add(time.Minute)
-	close(ticks)
-	runSoakFailureExpiry(context.Background(), ledger, evidence, 10*time.Minute, ticks, nil,
-		withSoakFailureExpiryMetrics(metrics))
-
-	assert.Equal(t, float64(3), testutil.ToFloat64(metrics.FailureRecipientExpectations))
-}
-
-// A zero retention makes the cutoff equal to now, which would release every
-// expectation registered so far — including operations still inside their
-// deadline, turning verifiable deliveries into unverified ones. Config
-// validation forbids a zero SOAK_RECONCILE_DEADLINE, so this is a guard against
-// a caller mistake rather than a reachable configuration, and the sweep must
-// decline to expire rather than guess a window.
-func TestRunSoakFailureExpiry_DoesNotExpireWithoutARetentionWindow(t *testing.T) {
-	clock := time.Unix(1000, 0).UTC()
-	ledger, err := newFailureLedger(&failureLedgerConfig{
-		Capacity: 16, Now: func() time.Time { return clock },
-	})
-	require.NoError(t, err)
-
-	evidence := newExpiryTestEvidence(&clock)
-	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
-		OperationID: "op", Recipients: []string{"a"}, Complete: true,
-	}))
-
-	ticks := make(chan time.Time, 1)
-	ticks <- clock.Add(time.Hour)
-	close(ticks)
-	runSoakFailureExpiry(context.Background(), ledger, evidence, 0, ticks, nil)
-
-	assert.Equal(t, 1, evidence.Len(),
-		"no retention window means no basis to expire, not expire everything")
-}
-
-// Registration time plus the *current* retention is not the same bound the
-// ledger uses. The ledger honours each operation's persisted deadline, so an
-// operation accepted under a 60m deadline and recovered into a process
-// configured for 10m stays live in the ledger while a retention-only sweep
-// releases its evidence after 10m — and a delivery arriving in between is
-// treated as untracked. An expectation that knows its own deadline must be held
-// to that one.
-func TestRecipientEvidence_HoldsAnExpectationToItsOwnDeadline(t *testing.T) {
-	clock := time.Unix(1000, 0).UTC()
-	evidence := newExpiryTestEvidence(&clock)
-	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
-		OperationID: "recovered", Recipients: []string{"a"}, Complete: true,
-		Deadline: clock.Add(time.Hour),
-	}))
-
-	// A ten-minute retention would release a ten-minute-old registration.
-	assert.Zero(t, evidence.ExpireBefore(clock.Add(-10*time.Minute)))
-	assert.Equal(t, 1, evidence.Len(),
-		"its own deadline outranks the sweep's retention window")
-
-	clock = clock.Add(time.Hour + time.Second)
-	assert.Equal(t, 1, evidence.ExpireBefore(clock.Add(-10*time.Minute)))
-}
-
-// The ledger's expiry is what finalizes the operation the evidence belongs to.
-// If that write fails the operation is still live and still reconcilable, so
-// releasing its evidence on the same tick destroys the only record of what was
-// delivered.
-func TestRunSoakFailureExpiry_KeepsEvidenceWhenLedgerExpiryFails(t *testing.T) {
-	clock := time.Unix(1000, 0).UTC()
-	ledger, err := newFailureLedger(&failureLedgerConfig{
-		Capacity: 16, Now: func() time.Time { return clock },
-	})
-	require.NoError(t, err)
-	require.NoError(t, ledger.Close())
-
-	evidence := newExpiryTestEvidence(&clock)
-	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
-		OperationID: "op", Recipients: []string{"a"}, Complete: true,
-	}))
-
-	var swept []error
-	ticks := make(chan time.Time, 1)
-	ticks <- clock.Add(time.Hour)
-	close(ticks)
-	runSoakFailureExpiry(context.Background(), ledger, evidence, 10*time.Minute, ticks,
-		func(err error) { swept = append(swept, err) })
-
-	require.NotEmpty(t, swept, "a failed ledger expiry must be reported")
-	assert.Equal(t, 1, evidence.Len(),
-		"evidence for an operation the ledger could not finalize must survive the tick")
-}
-
-// Gating expiry on the ledger reinstates the leak if the ledger keeps failing,
-// so the map needs a ceiling of its own — the ledger has LEDGER_CAPACITY and
-// this had nothing.
-func TestRecipientEvidence_RefusesToGrowPastItsCapacity(t *testing.T) {
-	clock := time.Unix(1000, 0).UTC()
-	evidence := newExpiryTestEvidence(&clock)
-	evidence.capacity = 2
-
-	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
-		OperationID: "op-1", Recipients: []string{"a"}, Complete: true,
-	}))
-	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
-		OperationID: "op-2", Recipients: []string{"a"}, Complete: true,
-	}))
 
 	err := evidence.ExpectDelivery(&recipientExpectationConfig{
 		OperationID: "op-3", Recipients: []string{"a"}, Complete: true,
@@ -263,4 +205,31 @@ func TestRecipientEvidence_RefusesToGrowPastItsCapacity(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "capacity")
 	assert.Equal(t, 2, evidence.Len())
+}
+
+// Without a gauge the only way to see this map growing again is a heap profile,
+// which is how it went unnoticed for the whole investigation. A healthy run
+// tracks the ledger's own in-flight count; a run climbing past it is this
+// leaking again.
+func TestRunSoakFailureExpiry_PublishesTheRetainedExpectationCount(t *testing.T) {
+	at := time.Unix(1000, 0).UTC()
+	ledger, err := newFailureLedger(&failureLedgerConfig{
+		Capacity: 16, Now: func() time.Time { return at },
+	})
+	require.NoError(t, err)
+	metrics := NewMetrics()
+	evidence := newRecipientEvidence(false)
+	for _, id := range []string{"op-1", "op-2", "op-3"} {
+		require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
+			OperationID: id, Recipients: []string{"a"}, Complete: true,
+		}))
+	}
+
+	ticks := make(chan time.Time, 1)
+	ticks <- at.Add(time.Minute)
+	close(ticks)
+	runSoakFailureExpiry(context.Background(), ledger, evidence, ticks, nil,
+		withSoakFailureExpiryMetrics(metrics))
+
+	assert.Equal(t, float64(3), testutil.ToFloat64(metrics.FailureRecipientExpectations))
 }

--- a/tools/loadgen/failure_recipient_expiry_test.go
+++ b/tools/loadgen/failure_recipient_expiry_test.go
@@ -233,3 +233,17 @@ func TestRunSoakFailureExpiry_PublishesTheRetainedExpectationCount(t *testing.T)
 
 	assert.Equal(t, float64(3), testutil.ToFloat64(metrics.FailureRecipientExpectations))
 }
+
+// The sweep frees ledger slots before ForgetAll frees the matching evidence, so
+// for a moment the ledger has room the evidence does not. Sized equal, that
+// window refuses to register a send the ledger would have admitted. Headroom of
+// one full ledger generation closes it by construction: even a sweep that
+// finalizes every operation before cleanup runs cannot fill the gap.
+func TestFailureRecipientObserver_EvidenceCarriesHeadroomOverTheLedger(t *testing.T) {
+	observer := newFailureRecipientObserver(nil, nil, 1, nil,
+		withFailureRecipientEvidenceCapacity(10))
+
+	require.Greater(t, observer.evidence.capacity, 10,
+		"an evidence map sized exactly like the ledger rejects during the cleanup lag")
+	assert.Equal(t, 20, observer.evidence.capacity)
+}

--- a/tools/loadgen/failure_recipient_expiry_test.go
+++ b/tools/loadgen/failure_recipient_expiry_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newExpiryTestEvidence pins the clock so retention can be asserted without
+// sleeping.
+func newExpiryTestEvidence(at *time.Time) *recipientEvidence {
+	evidence := newRecipientEvidence(false)
+	evidence.now = func() time.Time { return *at }
+	return evidence
+}
+
+// The evidence map is emptied only by Finalize, which runs inside the
+// reconciler. An operation that reaches its deadline without being reconciled
+// is finalized by failureLedger.Expire — which drops it from the ledger and
+// never tells the evidence, so its expectation stays for the life of the
+// process. At 55 sends/s with 100 recipients each that is ~20M per-recipient
+// route maps an hour, and it is what an 8GB pod dies of.
+func TestRecipientEvidence_ExpiresExpectationsOlderThanTheCutoff(t *testing.T) {
+	clock := time.Unix(1000, 0).UTC()
+	evidence := newExpiryTestEvidence(&clock)
+
+	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
+		OperationID: "op-old", Recipients: []string{"a", "b"}, Complete: true,
+	}))
+	clock = clock.Add(10 * time.Minute)
+	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
+		OperationID: "op-recent", Recipients: []string{"c"}, Complete: true,
+	}))
+
+	expired := evidence.ExpireBefore(clock.Add(-5 * time.Minute))
+
+	assert.Equal(t, 1, expired)
+	assert.Equal(t, 1, evidence.Len(),
+		"the entry older than the cutoff must go, the recent one must stay")
+}
+
+// Expiry has to release the observations too, not just the outer entry: the
+// per-recipient route maps incrementRecipientRoute allocates are where the
+// bytes actually are.
+func TestRecipientEvidence_ExpiryReleasesObservedRoutes(t *testing.T) {
+	clock := time.Unix(1000, 0).UTC()
+	evidence := newExpiryTestEvidence(&clock)
+	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
+		OperationID: "op", Recipients: []string{"a", "b", "c"}, Complete: true,
+	}))
+	for _, recipient := range []string{"a", "b", "c"} {
+		require.True(t, evidence.Observe("op", recipient))
+	}
+
+	require.Equal(t, 1, evidence.ExpireBefore(clock.Add(time.Minute)))
+
+	assert.Zero(t, evidence.Len())
+	assert.Equal(t, recipientEvidenceUntracked,
+		evidence.ObserveDelivery("op", "a", "", "", recipientDeliveryRouteRoomGlobal),
+		"a released expectation must not be resurrected by a late delivery")
+}
+
+// Nothing may be released before its operation could still be reconciled, or
+// the sweep would turn a verifiable delivery into an unverified one.
+func TestRecipientEvidence_KeepsExpectationsInsideTheRetentionWindow(t *testing.T) {
+	clock := time.Unix(1000, 0).UTC()
+	evidence := newExpiryTestEvidence(&clock)
+	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
+		OperationID: "op", Recipients: []string{"a"}, Complete: true,
+	}))
+
+	assert.Zero(t, evidence.ExpireBefore(clock.Add(-time.Nanosecond)))
+	assert.Equal(t, 1, evidence.Len())
+}
+
+// A nil evidence is the observer-disabled case, which the sweep runs into on
+// every tick of a default configuration.
+func TestRecipientEvidence_ExpiryToleratesADisabledObserver(t *testing.T) {
+	var evidence *recipientEvidence
+
+	assert.Zero(t, evidence.ExpireBefore(time.Unix(1000, 0).UTC()))
+	assert.Zero(t, evidence.Len())
+}
+
+// Expiry runs on the same sweep as the ledger's, so the evidence cannot outlive
+// the operations it describes even when nothing reconciles.
+func TestRunSoakFailureExpiry_ExpiresRecipientEvidenceOnEveryTick(t *testing.T) {
+	clock := time.Unix(1000, 0).UTC()
+	ledger, err := newFailureLedger(&failureLedgerConfig{
+		Capacity: 16, Now: func() time.Time { return clock },
+	})
+	require.NoError(t, err)
+
+	evidence := newExpiryTestEvidence(&clock)
+	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
+		OperationID: "op", Recipients: []string{"a"}, Complete: true,
+	}))
+	require.Equal(t, 1, evidence.Len())
+
+	ticks := make(chan time.Time, 1)
+	ticks <- clock.Add(11 * time.Minute)
+	close(ticks)
+	runSoakFailureExpiry(context.Background(), ledger, evidence, 10*time.Minute, ticks, nil)
+
+	assert.Zero(t, evidence.Len(),
+		"the sweep that expires ledger operations must expire their evidence too")
+}
+
+// The retention window is the operation deadline, so an expectation whose
+// operation is still live must survive the sweep.
+func TestRunSoakFailureExpiry_KeepsEvidenceForStillLiveOperations(t *testing.T) {
+	clock := time.Unix(1000, 0).UTC()
+	ledger, err := newFailureLedger(&failureLedgerConfig{
+		Capacity: 16, Now: func() time.Time { return clock },
+	})
+	require.NoError(t, err)
+
+	evidence := newExpiryTestEvidence(&clock)
+	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
+		OperationID: "op", Recipients: []string{"a"}, Complete: true,
+	}))
+
+	ticks := make(chan time.Time, 1)
+	ticks <- clock.Add(time.Minute)
+	close(ticks)
+	runSoakFailureExpiry(context.Background(), ledger, evidence, 10*time.Minute, ticks, nil)
+
+	assert.Equal(t, 1, evidence.Len(),
+		"an operation one minute into a ten minute deadline is still verifiable")
+}
+
+// Without a gauge the only way to see this map growing again is a heap
+// profile, which is how it went unnoticed for the whole investigation. A
+// healthy run tracks the ledger's own in-flight count; a run climbing past it
+// is this leaking again.
+func TestRunSoakFailureExpiry_PublishesTheRetainedExpectationCount(t *testing.T) {
+	clock := time.Unix(1000, 0).UTC()
+	ledger, err := newFailureLedger(&failureLedgerConfig{
+		Capacity: 16, Now: func() time.Time { return clock },
+	})
+	require.NoError(t, err)
+
+	metrics := NewMetrics()
+	evidence := newExpiryTestEvidence(&clock)
+	for _, id := range []string{"op-1", "op-2", "op-3"} {
+		require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
+			OperationID: id, Recipients: []string{"a"}, Complete: true,
+		}))
+	}
+
+	ticks := make(chan time.Time, 1)
+	ticks <- clock.Add(time.Minute)
+	close(ticks)
+	runSoakFailureExpiry(context.Background(), ledger, evidence, 10*time.Minute, ticks, nil,
+		withSoakFailureExpiryMetrics(metrics))
+
+	assert.Equal(t, float64(3), testutil.ToFloat64(metrics.FailureRecipientExpectations))
+}

--- a/tools/loadgen/failure_recipient_expiry_test.go
+++ b/tools/loadgen/failure_recipient_expiry_test.go
@@ -294,3 +294,33 @@ func TestSoakFailureTracker_AbandonUnsentReleasesTheRecipientExpectation(t *test
 	assert.Zero(t, observer.evidence.Len(),
 		"an abandoned operation leaves the ledger, so its expectation must go with it")
 }
+
+// The error branch of AbandonUnsent kept the expectation on the reasoning that
+// a failed call leaves the operation reconcilable. That holds for a failure
+// before the commit and not for one after it: finalizeLocked deletes from
+// l.active and compacts afterwards, so a compaction error arrives on an
+// operation the ledger has already retired — and no sweep will ever name it.
+func TestSoakFailureTracker_AbandonUnsentReleasesTheExpectationItRetired(t *testing.T) {
+	now := time.Date(2026, 8, 12, 1, 2, 3, 0, time.UTC)
+	ledger, err := newFailureLedger(&failureLedgerConfig{
+		Capacity: 4, CompactEvery: 1, Journal: &compactFailingJournal{},
+	})
+	require.NoError(t, err)
+	observer := newFailureRecipientObserver(ledger, nil, 4, func() time.Time { return now })
+	tracker := newSoakFailureTracker(
+		ledger, 0, time.Minute, func() time.Time { return now },
+		withSoakFailureRecipientObserver(observer),
+	)
+	pending := testSoakFailurePending(now)
+	pending.Target.Recipients = []string{"alice"}
+	require.NoError(t, tracker.Start(pending))
+	require.Equal(t, 1, observer.evidence.Len())
+
+	err = tracker.AbandonUnsent(pending)
+
+	require.Error(t, err, "the compaction failure must still be propagated")
+	assert.NotContains(t, ledger.active, pending.MessageID,
+		"the operation was retired before the compaction failed")
+	assert.Zero(t, observer.evidence.Len(),
+		"an expectation the ledger has retired must be released, error or not")
+}

--- a/tools/loadgen/failure_recipient_expiry_test.go
+++ b/tools/loadgen/failure_recipient_expiry_test.go
@@ -247,3 +247,50 @@ func TestFailureRecipientObserver_EvidenceCarriesHeadroomOverTheLedger(t *testin
 		"an evidence map sized exactly like the ledger rejects during the cleanup lag")
 	assert.Equal(t, 20, observer.evidence.capacity)
 }
+
+// finalizeLocked removes the operation from l.active and compacts afterwards,
+// so a compaction failure returns an error on an operation that has already
+// been retired. Returning before recording that ID strands its evidence for the
+// life of the run: nothing is left in l.active for any later sweep to report.
+func TestFailureLedger_ExpireReportsAnOperationRetiredBeforeTheFailure(t *testing.T) {
+	at := time.Unix(1000, 0).UTC()
+	ledger, err := newFailureLedger(&failureLedgerConfig{
+		Capacity: 16, CompactEvery: 1,
+		Journal: &compactFailingJournal{},
+		Now:     func() time.Time { return at },
+	})
+	require.NoError(t, err)
+	evidence := newRecipientEvidence(false)
+	startExpiryOperation(t, ledger, evidence, "op", at)
+
+	expired, err := ledger.Expire(at.Add(2 * time.Minute))
+
+	require.Error(t, err, "a failed compaction must still surface")
+	assert.NotContains(t, ledger.active, "op",
+		"the operation was retired before the compaction failed")
+	assert.Equal(t, []string{"op"}, expired,
+		"an operation that left the ledger must be reported or its evidence is stranded")
+}
+
+// AbandonUnsent finalizes the operation, which removes it from l.active — so no
+// later Expire can report it either. The expectation registered before the
+// publish attempt would then outlive the run that created it.
+func TestSoakFailureTracker_AbandonUnsentReleasesTheRecipientExpectation(t *testing.T) {
+	now := time.Date(2026, 8, 12, 1, 2, 3, 0, time.UTC)
+	ledger, err := newFailureLedger(&failureLedgerConfig{Capacity: 4})
+	require.NoError(t, err)
+	observer := newFailureRecipientObserver(ledger, nil, 4, func() time.Time { return now })
+	tracker := newSoakFailureTracker(
+		ledger, 0, time.Minute, func() time.Time { return now },
+		withSoakFailureRecipientObserver(observer),
+	)
+	pending := testSoakFailurePending(now)
+	pending.Target.Recipients = []string{"alice"}
+	require.NoError(t, tracker.Start(pending))
+	require.Equal(t, 1, observer.evidence.Len())
+
+	require.NoError(t, tracker.AbandonUnsent(pending))
+
+	assert.Zero(t, observer.evidence.Len(),
+		"an abandoned operation leaves the ledger, so its expectation must go with it")
+}

--- a/tools/loadgen/failure_recipient_expiry_test.go
+++ b/tools/loadgen/failure_recipient_expiry_test.go
@@ -187,3 +187,80 @@ func TestRunSoakFailureExpiry_DoesNotExpireWithoutARetentionWindow(t *testing.T)
 	assert.Equal(t, 1, evidence.Len(),
 		"no retention window means no basis to expire, not expire everything")
 }
+
+// Registration time plus the *current* retention is not the same bound the
+// ledger uses. The ledger honours each operation's persisted deadline, so an
+// operation accepted under a 60m deadline and recovered into a process
+// configured for 10m stays live in the ledger while a retention-only sweep
+// releases its evidence after 10m — and a delivery arriving in between is
+// treated as untracked. An expectation that knows its own deadline must be held
+// to that one.
+func TestRecipientEvidence_HoldsAnExpectationToItsOwnDeadline(t *testing.T) {
+	clock := time.Unix(1000, 0).UTC()
+	evidence := newExpiryTestEvidence(&clock)
+	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
+		OperationID: "recovered", Recipients: []string{"a"}, Complete: true,
+		Deadline: clock.Add(time.Hour),
+	}))
+
+	// A ten-minute retention would release a ten-minute-old registration.
+	assert.Zero(t, evidence.ExpireBefore(clock.Add(-10*time.Minute)))
+	assert.Equal(t, 1, evidence.Len(),
+		"its own deadline outranks the sweep's retention window")
+
+	clock = clock.Add(time.Hour + time.Second)
+	assert.Equal(t, 1, evidence.ExpireBefore(clock.Add(-10*time.Minute)))
+}
+
+// The ledger's expiry is what finalizes the operation the evidence belongs to.
+// If that write fails the operation is still live and still reconcilable, so
+// releasing its evidence on the same tick destroys the only record of what was
+// delivered.
+func TestRunSoakFailureExpiry_KeepsEvidenceWhenLedgerExpiryFails(t *testing.T) {
+	clock := time.Unix(1000, 0).UTC()
+	ledger, err := newFailureLedger(&failureLedgerConfig{
+		Capacity: 16, Now: func() time.Time { return clock },
+	})
+	require.NoError(t, err)
+	require.NoError(t, ledger.Close())
+
+	evidence := newExpiryTestEvidence(&clock)
+	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
+		OperationID: "op", Recipients: []string{"a"}, Complete: true,
+	}))
+
+	var swept []error
+	ticks := make(chan time.Time, 1)
+	ticks <- clock.Add(time.Hour)
+	close(ticks)
+	runSoakFailureExpiry(context.Background(), ledger, evidence, 10*time.Minute, ticks,
+		func(err error) { swept = append(swept, err) })
+
+	require.NotEmpty(t, swept, "a failed ledger expiry must be reported")
+	assert.Equal(t, 1, evidence.Len(),
+		"evidence for an operation the ledger could not finalize must survive the tick")
+}
+
+// Gating expiry on the ledger reinstates the leak if the ledger keeps failing,
+// so the map needs a ceiling of its own — the ledger has LEDGER_CAPACITY and
+// this had nothing.
+func TestRecipientEvidence_RefusesToGrowPastItsCapacity(t *testing.T) {
+	clock := time.Unix(1000, 0).UTC()
+	evidence := newExpiryTestEvidence(&clock)
+	evidence.capacity = 2
+
+	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
+		OperationID: "op-1", Recipients: []string{"a"}, Complete: true,
+	}))
+	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
+		OperationID: "op-2", Recipients: []string{"a"}, Complete: true,
+	}))
+
+	err := evidence.ExpectDelivery(&recipientExpectationConfig{
+		OperationID: "op-3", Recipients: []string{"a"}, Complete: true,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "capacity")
+	assert.Equal(t, 2, evidence.Len())
+}

--- a/tools/loadgen/failure_recipient_expiry_test.go
+++ b/tools/loadgen/failure_recipient_expiry_test.go
@@ -211,27 +211,30 @@ func TestRecipientEvidence_RefusesToGrowPastItsCapacity(t *testing.T) {
 // which is how it went unnoticed for the whole investigation. A healthy run
 // tracks the ledger's own in-flight count; a run climbing past it is this
 // leaking again.
-func TestRunSoakFailureExpiry_PublishesTheRetainedExpectationCount(t *testing.T) {
-	at := time.Unix(1000, 0).UTC()
-	ledger, err := newFailureLedger(&failureLedgerConfig{
-		Capacity: 16, Now: func() time.Time { return at },
-	})
-	require.NoError(t, err)
+//
+// The gauge is read at scrape time rather than written by the expiry sweep. The
+// sweep publishing it makes the value depend on the sweep still running, and a
+// ledger stalled on its journal is exactly the condition the gauge exists to
+// expose — it would freeze at the last healthy number and read as normal.
+func TestMetrics_RecipientExpectationsReportsWithoutTheSweep(t *testing.T) {
 	metrics := NewMetrics()
 	evidence := newRecipientEvidence(false)
+
+	assert.Zero(t, testutil.ToFloat64(metrics.FailureRecipientExpectations),
+		"a run without a recipient observer must report zero, not fail to collect")
+
+	metrics.SetRecipientExpectationSource(evidence.Len)
 	for _, id := range []string{"op-1", "op-2", "op-3"} {
 		require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
 			OperationID: id, Recipients: []string{"a"}, Complete: true,
 		}))
 	}
 
-	ticks := make(chan time.Time, 1)
-	ticks <- at.Add(time.Minute)
-	close(ticks)
-	runSoakFailureExpiry(context.Background(), ledger, evidence, ticks, nil,
-		withSoakFailureExpiryMetrics(metrics))
+	assert.Equal(t, float64(3), testutil.ToFloat64(metrics.FailureRecipientExpectations),
+		"the count must be current at scrape time, with no sweep tick in between")
 
-	assert.Equal(t, float64(3), testutil.ToFloat64(metrics.FailureRecipientExpectations))
+	require.Equal(t, 2, evidence.ForgetAll([]string{"op-1", "op-2"}))
+	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.FailureRecipientExpectations))
 }
 
 // The sweep frees ledger slots before ForgetAll frees the matching evidence, so

--- a/tools/loadgen/failure_recipient_expiry_test.go
+++ b/tools/loadgen/failure_recipient_expiry_test.go
@@ -160,3 +160,30 @@ func TestRunSoakFailureExpiry_PublishesTheRetainedExpectationCount(t *testing.T)
 
 	assert.Equal(t, float64(3), testutil.ToFloat64(metrics.FailureRecipientExpectations))
 }
+
+// A zero retention makes the cutoff equal to now, which would release every
+// expectation registered so far — including operations still inside their
+// deadline, turning verifiable deliveries into unverified ones. Config
+// validation forbids a zero SOAK_RECONCILE_DEADLINE, so this is a guard against
+// a caller mistake rather than a reachable configuration, and the sweep must
+// decline to expire rather than guess a window.
+func TestRunSoakFailureExpiry_DoesNotExpireWithoutARetentionWindow(t *testing.T) {
+	clock := time.Unix(1000, 0).UTC()
+	ledger, err := newFailureLedger(&failureLedgerConfig{
+		Capacity: 16, Now: func() time.Time { return clock },
+	})
+	require.NoError(t, err)
+
+	evidence := newExpiryTestEvidence(&clock)
+	require.NoError(t, evidence.ExpectDelivery(&recipientExpectationConfig{
+		OperationID: "op", Recipients: []string{"a"}, Complete: true,
+	}))
+
+	ticks := make(chan time.Time, 1)
+	ticks <- clock.Add(time.Hour)
+	close(ticks)
+	runSoakFailureExpiry(context.Background(), ledger, evidence, 0, ticks, nil)
+
+	assert.Equal(t, 1, evidence.Len(),
+		"no retention window means no basis to expire, not expire everything")
+}

--- a/tools/loadgen/generator_test.go
+++ b/tools/loadgen/generator_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -368,78 +369,66 @@ func dispatchPeak(t *testing.T, maxInFlight, rate int, window time.Duration, tri
 	return best
 }
 
-// pacedCeilingProbeRate is only used to measure what the serial ticker manages
-// on this host; the rate the two paths are then compared at is derived from
-// that measurement. pacedCeilingHeadroom is how far past the measured plateau
-// that derived rate sits.
 const (
-	pacedCeilingProbeRate = 100_000
-	pacedCeilingHeadroom  = 20
-	pacedCeilingWindow    = 200 * time.Millisecond
-	pacedCeilingTrials    = 3
+	pacedMeasureRate   = 100_000
+	pacedMeasureWindow = 200 * time.Millisecond
+	pacedMeasureTrials = 3
 )
 
-// pacedCeilingRateFrom turns a dispatch count measured over window into a rate
-// headroom times higher, falling back to the probe rate when the measurement
-// was empty.
-func pacedCeilingRateFrom(measured int, window time.Duration, headroom int) int {
-	if measured <= 0 {
-		return pacedCeilingProbeRate
-	}
-	return int(float64(measured)/window.Seconds()) * headroom
-}
-
-// Regression for the single-ticker RPS ceiling: the legacy serial path
-// (MaxInFlight=0) releases one event per delivered tick, and the runtime cannot
-// deliver a tick per microsecond, so it plateaus far below target. The batched
-// pacer releases rate*interval events per coarse tick and must out-dispatch it
-// by a wide margin. A relative comparison (same process, back to back) cancels
-// host-speed and race-detector overhead.
+// The regression that produced the batched pacer: the serial path releases one
+// event per delivered tick, and the runtime cannot deliver a tick per
+// microsecond, so it plateaus far below any high target. This is that property
+// with the timer taken out of it. pacedDispatchRateWithTicks accepts the tick
+// channel, so one tick can be shown to release the whole batch the rate is owed
+// — 200 events here — where a one-per-tick regression releases exactly one.
 //
-// The rate they are compared at is measured, not chosen. Both counts are only
-// ceilings while the target stays out of reach — a target the paced path can
-// reach reports the target instead, and the comparison stops being about the
-// pacer (see TestGenerator_PacedDispatchReportsAReachableTarget). A constant
-// cannot hold that open: the fastest host observed drove the serial ticker to
-// 78k/s, which is above the rate the slowest one could dispatch at all, so no
-// single number is simultaneously out of reach on one and in reach on the
-// other. Deriving it from this host's own plateau is.
-func TestGenerator_PacedRunBeatsSingleTickerCeiling(t *testing.T) {
-	plateau := dispatchPeak(t, 0, pacedCeilingProbeRate, pacedCeilingWindow, pacedCeilingTrials)
-	require.Positive(t, plateau, "the serial ticker dispatched nothing to scale from")
-	rate := pacedCeilingRateFrom(plateau, pacedCeilingWindow, pacedCeilingHeadroom)
+// This is the blocking assertion. The comparison against the serial path can
+// only be measured on real timers, and no measurement of it is safe to assert
+// on: the two paths degrade at completely different rates under load, so their
+// ratio has no upper bound to write a threshold against.
+func TestPacedDispatch_ReleasesTheWholeBatchOnOneTick(t *testing.T) {
+	start := time.Unix(0, 0).UTC()
+	pacer := newPacer(pacedMeasureRate, start)
+	require.Equal(t, minEmitInterval, pacer.interval,
+		"a target this high must clamp to the tick floor for a batch to exist")
+	require.Greater(t, pacer.perTick, 1.0)
 
-	serial := dispatchPeak(t, 0, rate, pacedCeilingWindow, pacedCeilingTrials)
-	paced := dispatchPeak(t, 5000, rate, pacedCeilingWindow, pacedCeilingTrials)
+	var dispatched atomic.Int64
+	ticks := make(chan time.Time)
+	done := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		defer close(done)
+		pacedDispatchRateWithTicks(ctx, pacer, ticks, 4096,
+			func(int) {}, func() {},
+			func(context.Context) { dispatched.Add(1) })
+	}()
 
-	require.Positive(t, serial)
-	t.Logf("plateau=%d derived rate=%d serial=%d paced=%d", plateau, rate, serial, paced)
-	require.Less(t, paced, int(float64(rate)*pacedCeilingWindow.Seconds()),
-		"this host dispatches more than %dx what its own serial ticker manages, so the margin below measures the target rather than the pacer: raise pacedCeilingHeadroom",
-		pacedCeilingHeadroom)
-	assert.Greater(t, float64(paced), float64(serial)*1.3,
-		"batched pacer (%d) should out-dispatch the serial ticker (%d) at %d rps",
-		paced, serial, rate)
+	// Unbuffered: the send returns only once the dispatch loop has taken the
+	// tick, so cancelling afterwards cannot race ahead of the batch it owes.
+	ticks <- start.Add(pacer.interval)
+	cancel()
+	<-done
+
+	assert.Equal(t, int64(pacer.perTick), dispatched.Load(),
+		"one tick must release the events the rate owes for that interval")
 }
 
-// The pacer releases rate*elapsed events and no more, so a target the host can
-// reach is what the count reports — the path's own ceiling stays invisible, and
-// the two paths converge on the same number. That is how the ceiling assertion
-// above failed on CI at 100k rps: the paced count clipped at exactly 20000
-// while the runner drove the serial ticker to 15586, which no 1.3x margin can
-// sit above. The failure mode belongs to a *faster* host, so it needs a test
-// that does not depend on host speed to surface it.
-func TestGenerator_PacedDispatchReportsAReachableTarget(t *testing.T) {
-	const rate = 5000
-	window := 200 * time.Millisecond
-	target := int(float64(rate) * window.Seconds())
+// A measurement, not an assertion. Both counts are host-dependent and the
+// review history of this file is three attempts to find a threshold that holds
+// across machines: a fixed target is reachable on a fast host and unreachable
+// on a slow one, and a target scaled from the serial plateau fails too, because
+// under load the serial ticker collapses far harder than the pool does
+// (observed: plateau 400, paced 8000 — a ratio of 20 where an idle host shows
+// 2.2). The numbers are logged because they are useful when tuning the pacer;
+// the only thing asserted is that both paths dispatched at all.
+func TestGenerator_MeasuresBothDispatchPaths(t *testing.T) {
+	serial := dispatchPeak(t, 0, pacedMeasureRate, pacedMeasureWindow, pacedMeasureTrials)
+	paced := dispatchPeak(t, 5000, pacedMeasureRate, pacedMeasureWindow, pacedMeasureTrials)
 
-	paced := dispatchPeak(t, 5000, rate, window, 2)
-
-	assert.LessOrEqual(t, paced, target,
-		"the pacer must never release more than the target rate allows")
-	assert.InDelta(t, target, paced, float64(target)*0.1,
-		"a reachable target caps the count, leaving nothing of the pacer's own ceiling to compare")
+	t.Logf("at %d rps over %s: serial=%d paced=%d", pacedMeasureRate, pacedMeasureWindow, serial, paced)
+	require.Positive(t, serial, "the serial ticker dispatched nothing")
+	require.Positive(t, paced, "the batched pacer dispatched nothing")
 }
 
 func TestParseInjectMode(t *testing.T) {
@@ -462,32 +451,6 @@ func TestParseInjectMode(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, got)
-		})
-	}
-}
-
-// The rate the ceiling comparison runs at is derived from what the serial
-// ticker managed on the host running the test, so the target scales with the
-// machine instead of being a constant that is too high on one and too low on
-// the next.
-func TestPacedCeilingRateFrom_ScalesPastTheMeasuredPlateau(t *testing.T) {
-	window := 200 * time.Millisecond
-
-	tests := []struct {
-		name     string
-		measured int
-		headroom int
-		want     int
-	}{
-		{name: "slow host", measured: 3000, headroom: 20, want: 300_000},
-		{name: "fast host", measured: 15586, headroom: 20, want: 1_558_600},
-		{name: "headroom of one is the plateau itself", measured: 3000, headroom: 1, want: 15_000},
-		{name: "a host that dispatched nothing still yields a usable rate",
-			measured: 0, headroom: 20, want: pacedCeilingProbeRate},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, pacedCeilingRateFrom(tc.measured, window, tc.headroom))
 		})
 	}
 }

--- a/tools/loadgen/generator_test.go
+++ b/tools/loadgen/generator_test.go
@@ -378,26 +378,24 @@ const (
 	pacedCeilingTrials = 3
 )
 
+// Regression for the single-ticker RPS ceiling: the legacy serial path
+// (MaxInFlight=0) releases one event per delivered tick, and the runtime cannot
+// deliver a tick per microsecond, so it plateaus far below target. The batched
+// pacer releases rate*interval events per coarse tick and must out-dispatch it
+// by a wide margin. A relative comparison (same process, back to back) cancels
+// host-speed and race-detector overhead.
 func TestGenerator_PacedRunBeatsSingleTickerCeiling(t *testing.T) {
-	// Regression for the single-ticker RPS ceiling: the legacy serial path
-	// (MaxInFlight=0) releases one event per delivered tick, and the runtime
-	// cannot deliver a tick per microsecond, so it plateaus far below target.
-	// The batched pacer releases rate*interval events per coarse tick and must
-	// out-dispatch it by a wide margin. A relative comparison (same process,
-	// back to back) cancels host-speed and race-detector overhead.
+	target := int(float64(pacedCeilingRate) * pacedCeilingWindow.Seconds())
+
 	serial := dispatchPeak(t, 0, pacedCeilingRate, pacedCeilingWindow, pacedCeilingTrials)
 	paced := dispatchPeak(t, 5000, pacedCeilingRate, pacedCeilingWindow, pacedCeilingTrials)
 
 	require.Positive(t, serial)
-	require.Less(t, paced, pacedCeilingTarget(),
-		"the target is within this host's reach, so the margin below measures the target, not the pacer: raise pacedCeilingRate")
+	require.Less(t, paced, target,
+		"the target is within this host's reach, so the margin below measures the target rather than the pacer: raise pacedCeilingRate")
 	assert.Greater(t, float64(paced), float64(serial)*1.3,
 		"batched pacer (%d) should out-dispatch the serial ticker (%d) at %d rps",
 		paced, serial, pacedCeilingRate)
-}
-
-func pacedCeilingTarget() int {
-	return int(float64(pacedCeilingRate) * pacedCeilingWindow.Seconds())
 }
 
 // The pacer releases rate*elapsed events and no more, so a target the host can

--- a/tools/loadgen/generator_test.go
+++ b/tools/loadgen/generator_test.go
@@ -337,51 +337,87 @@ func TestGenerator_PoolSaturationCountedAsError(t *testing.T) {
 	assert.Greater(t, saturated, float64(0), "expected saturated counter to increment under pool-full conditions")
 }
 
-func TestGenerator_PacedRunBeatsSingleTickerCeiling(t *testing.T) {
-	// Regression for the single-ticker RPS ceiling: the legacy serial path
-	// (MaxInFlight=0) releases one event per delivered tick, and the runtime
-	// cannot deliver 100k sub-millisecond ticks/sec, so it plateaus far below
-	// target. The batched pacer releases rate*interval events per coarse tick
-	// and must out-dispatch it by a wide margin. A relative comparison (same
-	// process, back to back) cancels host-speed and race-detector overhead.
-	//
-	// Both quantities are ceilings — the *most* each path can dispatch — so we
-	// measure the peak over a few short trials. A single 200ms sample is one
-	// GC pause or scheduler stall away from under-counting, which on a loaded
-	// CI runner can briefly compress the ratio below the margin; taking the
-	// best-of-N cancels those transient dips without changing what is asserted.
-	runAt := func(maxInFlight int) int {
+// dispatchPeak returns the highest number of publishes the generator completes
+// in window over trials short runs, at the given rate and MaxInFlight.
+//
+// Both callers measure a ceiling — the *most* a dispatch path can do — so the
+// peak, not the mean, is the meaningful sample: a single run is one GC pause or
+// scheduler stall away from under-counting.
+func dispatchPeak(t *testing.T, maxInFlight, rate int, window time.Duration, trials int) int {
+	t.Helper()
+	best := 0
+	for i := 0; i < trials; i++ {
 		p, _ := BuiltinPreset("small")
 		f := BuildFixtures(&p, 42, "site-local")
 		rp := &recordingPublisher{}
 		m := NewMetrics()
 		g := NewGenerator(&GeneratorConfig{
 			Preset: &p, Fixtures: f, SiteID: "site-local",
-			Rate: 100000, Inject: InjectFrontdoor,
+			Rate: rate, Inject: InjectFrontdoor,
 			Publisher: rp, Metrics: m, Collector: NewCollector(m, p.Name),
 			MaxInFlight: maxInFlight,
 		}, 1)
-		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-		defer cancel()
-		require.NoError(t, g.Run(ctx))
-		return rp.count()
-	}
-	// peakOf returns the highest dispatch count over trials short runs.
-	peakOf := func(maxInFlight, trials int) int {
-		best := 0
-		for i := 0; i < trials; i++ {
-			if c := runAt(maxInFlight); c > best {
-				best = c
-			}
+		ctx, cancel := context.WithTimeout(context.Background(), window)
+		err := g.Run(ctx)
+		cancel()
+		require.NoError(t, err)
+		if c := rp.count(); c > best {
+			best = c
 		}
-		return best
 	}
+	return best
+}
 
-	serial := peakOf(0, 3)   // legacy one-per-tick ceiling
-	paced := peakOf(5000, 3) // batched pacer
+// pacedCeilingRate has to stay out of reach of the host: only then does each
+// path report its own ceiling instead of the target they share. See
+// TestGenerator_PacedDispatchReportsAReachableTarget for what a reachable
+// target turns this measurement into.
+const (
+	pacedCeilingRate   = 1_000_000
+	pacedCeilingWindow = 200 * time.Millisecond
+	pacedCeilingTrials = 3
+)
+
+func TestGenerator_PacedRunBeatsSingleTickerCeiling(t *testing.T) {
+	// Regression for the single-ticker RPS ceiling: the legacy serial path
+	// (MaxInFlight=0) releases one event per delivered tick, and the runtime
+	// cannot deliver a tick per microsecond, so it plateaus far below target.
+	// The batched pacer releases rate*interval events per coarse tick and must
+	// out-dispatch it by a wide margin. A relative comparison (same process,
+	// back to back) cancels host-speed and race-detector overhead.
+	serial := dispatchPeak(t, 0, pacedCeilingRate, pacedCeilingWindow, pacedCeilingTrials)
+	paced := dispatchPeak(t, 5000, pacedCeilingRate, pacedCeilingWindow, pacedCeilingTrials)
+
 	require.Positive(t, serial)
+	require.Less(t, paced, pacedCeilingTarget(),
+		"the target is within this host's reach, so the margin below measures the target, not the pacer: raise pacedCeilingRate")
 	assert.Greater(t, float64(paced), float64(serial)*1.3,
-		"batched pacer (%d) should out-dispatch the serial ticker (%d) at 100k rps", paced, serial)
+		"batched pacer (%d) should out-dispatch the serial ticker (%d) at %d rps",
+		paced, serial, pacedCeilingRate)
+}
+
+func pacedCeilingTarget() int {
+	return int(float64(pacedCeilingRate) * pacedCeilingWindow.Seconds())
+}
+
+// The pacer releases rate*elapsed events and no more, so a target the host can
+// reach is what the count reports — the path's own ceiling stays invisible, and
+// the two paths converge on the same number. That is how the ceiling assertion
+// above failed on CI at 100k rps: the paced count clipped at exactly 20000
+// while the runner drove the serial ticker to 15586, which no 1.3x margin can
+// sit above. The failure mode belongs to a *faster* host, so it needs a test
+// that does not depend on host speed to surface it.
+func TestGenerator_PacedDispatchReportsAReachableTarget(t *testing.T) {
+	const rate = 5000
+	window := 200 * time.Millisecond
+	target := int(float64(rate) * window.Seconds())
+
+	paced := dispatchPeak(t, 5000, rate, window, 2)
+
+	assert.LessOrEqual(t, paced, target,
+		"the pacer must never release more than the target rate allows")
+	assert.InDelta(t, target, paced, float64(target)*0.1,
+		"a reachable target caps the count, leaving nothing of the pacer's own ceiling to compare")
 }
 
 func TestParseInjectMode(t *testing.T) {

--- a/tools/loadgen/generator_test.go
+++ b/tools/loadgen/generator_test.go
@@ -368,15 +368,26 @@ func dispatchPeak(t *testing.T, maxInFlight, rate int, window time.Duration, tri
 	return best
 }
 
-// pacedCeilingRate has to stay out of reach of the host: only then does each
-// path report its own ceiling instead of the target they share. See
-// TestGenerator_PacedDispatchReportsAReachableTarget for what a reachable
-// target turns this measurement into.
+// pacedCeilingProbeRate is only used to measure what the serial ticker manages
+// on this host; the rate the two paths are then compared at is derived from
+// that measurement. pacedCeilingHeadroom is how far past the measured plateau
+// that derived rate sits.
 const (
-	pacedCeilingRate   = 1_000_000
-	pacedCeilingWindow = 200 * time.Millisecond
-	pacedCeilingTrials = 3
+	pacedCeilingProbeRate = 100_000
+	pacedCeilingHeadroom  = 20
+	pacedCeilingWindow    = 200 * time.Millisecond
+	pacedCeilingTrials    = 3
 )
+
+// pacedCeilingRateFrom turns a dispatch count measured over window into a rate
+// headroom times higher, falling back to the probe rate when the measurement
+// was empty.
+func pacedCeilingRateFrom(measured int, window time.Duration, headroom int) int {
+	if measured <= 0 {
+		return pacedCeilingProbeRate
+	}
+	return int(float64(measured)/window.Seconds()) * headroom
+}
 
 // Regression for the single-ticker RPS ceiling: the legacy serial path
 // (MaxInFlight=0) releases one event per delivered tick, and the runtime cannot
@@ -384,18 +395,31 @@ const (
 // pacer releases rate*interval events per coarse tick and must out-dispatch it
 // by a wide margin. A relative comparison (same process, back to back) cancels
 // host-speed and race-detector overhead.
+//
+// The rate they are compared at is measured, not chosen. Both counts are only
+// ceilings while the target stays out of reach — a target the paced path can
+// reach reports the target instead, and the comparison stops being about the
+// pacer (see TestGenerator_PacedDispatchReportsAReachableTarget). A constant
+// cannot hold that open: the fastest host observed drove the serial ticker to
+// 78k/s, which is above the rate the slowest one could dispatch at all, so no
+// single number is simultaneously out of reach on one and in reach on the
+// other. Deriving it from this host's own plateau is.
 func TestGenerator_PacedRunBeatsSingleTickerCeiling(t *testing.T) {
-	target := int(float64(pacedCeilingRate) * pacedCeilingWindow.Seconds())
+	plateau := dispatchPeak(t, 0, pacedCeilingProbeRate, pacedCeilingWindow, pacedCeilingTrials)
+	require.Positive(t, plateau, "the serial ticker dispatched nothing to scale from")
+	rate := pacedCeilingRateFrom(plateau, pacedCeilingWindow, pacedCeilingHeadroom)
 
-	serial := dispatchPeak(t, 0, pacedCeilingRate, pacedCeilingWindow, pacedCeilingTrials)
-	paced := dispatchPeak(t, 5000, pacedCeilingRate, pacedCeilingWindow, pacedCeilingTrials)
+	serial := dispatchPeak(t, 0, rate, pacedCeilingWindow, pacedCeilingTrials)
+	paced := dispatchPeak(t, 5000, rate, pacedCeilingWindow, pacedCeilingTrials)
 
 	require.Positive(t, serial)
-	require.Less(t, paced, target,
-		"the target is within this host's reach, so the margin below measures the target rather than the pacer: raise pacedCeilingRate")
+	t.Logf("plateau=%d derived rate=%d serial=%d paced=%d", plateau, rate, serial, paced)
+	require.Less(t, paced, int(float64(rate)*pacedCeilingWindow.Seconds()),
+		"this host dispatches more than %dx what its own serial ticker manages, so the margin below measures the target rather than the pacer: raise pacedCeilingHeadroom",
+		pacedCeilingHeadroom)
 	assert.Greater(t, float64(paced), float64(serial)*1.3,
 		"batched pacer (%d) should out-dispatch the serial ticker (%d) at %d rps",
-		paced, serial, pacedCeilingRate)
+		paced, serial, rate)
 }
 
 // The pacer releases rate*elapsed events and no more, so a target the host can
@@ -438,6 +462,32 @@ func TestParseInjectMode(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// The rate the ceiling comparison runs at is derived from what the serial
+// ticker managed on the host running the test, so the target scales with the
+// machine instead of being a constant that is too high on one and too low on
+// the next.
+func TestPacedCeilingRateFrom_ScalesPastTheMeasuredPlateau(t *testing.T) {
+	window := 200 * time.Millisecond
+
+	tests := []struct {
+		name     string
+		measured int
+		headroom int
+		want     int
+	}{
+		{name: "slow host", measured: 3000, headroom: 20, want: 300_000},
+		{name: "fast host", measured: 15586, headroom: 20, want: 1_558_600},
+		{name: "headroom of one is the plateau itself", measured: 3000, headroom: 1, want: 15_000},
+		{name: "a host that dispatched nothing still yields a usable rate",
+			measured: 0, headroom: 20, want: pacedCeilingProbeRate},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, pacedCeilingRateFrom(tc.measured, window, tc.headroom))
 		})
 	}
 }

--- a/tools/loadgen/metrics.go
+++ b/tools/loadgen/metrics.go
@@ -71,6 +71,7 @@ type Metrics struct {
 	FailureObservations          *prometheus.CounterVec
 	FailureObservationReasons    *prometheus.CounterVec
 	FailureInflight              *prometheus.GaugeVec
+	FailureRecipientExpectations prometheus.Gauge
 	FailureRecovered             prometheus.Counter
 	FailureInvalidations         *prometheus.CounterVec
 	FailureJournalBytes          prometheus.Gauge
@@ -381,6 +382,12 @@ func NewMetrics() *Metrics {
 		},
 		[]string{"scenario", "lane"},
 	)
+	m.FailureRecipientExpectations = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "loadgen_failure_recipient_expectations",
+			Help: "Recipient expectations retained in memory; healthy runs track loadgen_failure_inflight.",
+		},
+	)
 	m.FailureRecovered = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "loadgen_failure_recovered_operations_total",
@@ -542,6 +549,7 @@ func NewMetrics() *Metrics {
 		m.SoakLaneAttempts,
 		m.SoakPresenceSignals, m.SoakPresenceChecks, m.SoakPresenceConnections,
 		m.FailureOperations, m.FailureObservations, m.FailureObservationReasons, m.FailureInflight,
+		m.FailureRecipientExpectations,
 		m.FailureRecovered, m.FailureInvalidations, m.FailureJournalBytes,
 		m.FailureUntracked, m.FailureDropped, m.FailureNotSent,
 		m.FailureWALAppendDuration, m.FailureWALAppends,

--- a/tools/loadgen/metrics.go
+++ b/tools/loadgen/metrics.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 	"sync"
+	"sync/atomic"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -11,8 +12,12 @@ import (
 
 // Metrics holds the Prometheus collectors used across loadgen components.
 type Metrics struct {
-	natsHealthMu          sync.Mutex
-	natsPoolHealth        map[string]*loadgenNATSPoolState
+	natsHealthMu   sync.Mutex
+	natsPoolHealth map[string]*loadgenNATSPoolState
+	// recipientExpectations is installed once the recipient evidence exists,
+	// which is well after the registry is built, and is read on the scrape
+	// goroutine.
+	recipientExpectations atomic.Pointer[func() int]
 	Registry              *prometheus.Registry
 	Published             *prometheus.CounterVec
 	PublishErrors         *prometheus.CounterVec
@@ -71,7 +76,7 @@ type Metrics struct {
 	FailureObservations          *prometheus.CounterVec
 	FailureObservationReasons    *prometheus.CounterVec
 	FailureInflight              *prometheus.GaugeVec
-	FailureRecipientExpectations prometheus.Gauge
+	FailureRecipientExpectations prometheus.GaugeFunc
 	FailureRecovered             prometheus.Counter
 	FailureInvalidations         *prometheus.CounterVec
 	FailureJournalBytes          prometheus.Gauge
@@ -382,11 +387,12 @@ func NewMetrics() *Metrics {
 		},
 		[]string{"scenario", "lane"},
 	)
-	m.FailureRecipientExpectations = prometheus.NewGauge(
+	m.FailureRecipientExpectations = prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
 			Name: "loadgen_failure_recipient_expectations",
 			Help: "Recipient expectations retained in memory; healthy runs track loadgen_failure_inflight.",
 		},
+		m.recipientExpectationCount,
 	)
 	m.FailureRecovered = prometheus.NewCounter(
 		prometheus.CounterOpts{
@@ -569,4 +575,30 @@ func NewMetrics() *Metrics {
 // Handler returns an http.Handler serving this metrics registry.
 func (m *Metrics) Handler() http.Handler {
 	return promhttp.HandlerFor(m.Registry, promhttp.HandlerOpts{})
+}
+
+// SetRecipientExpectationSource installs the count the expectation gauge reads.
+//
+// The gauge is collected at scrape time rather than written by the expiry
+// sweep: a sweep that publishes it makes the value depend on the sweep still
+// running, and a ledger stalled on its journal is precisely the condition the
+// gauge exists to expose. Published from there it would freeze at the last
+// healthy number and read as normal.
+func (m *Metrics) SetRecipientExpectationSource(source func() int) {
+	if m == nil || source == nil {
+		return
+	}
+	m.recipientExpectations.Store(&source)
+}
+
+// recipientExpectationCount reports zero until a source is installed, which is
+// the honest answer for a run with no recipient observer.
+func (m *Metrics) recipientExpectationCount() float64 {
+	if m == nil {
+		return 0
+	}
+	if source := m.recipientExpectations.Load(); source != nil {
+		return float64((*source)())
+	}
+	return 0
 }

--- a/tools/loadgen/soak_failure.go
+++ b/tools/loadgen/soak_failure.go
@@ -53,30 +53,13 @@ func soakFailureExpiryInterval(deadline time.Duration) time.Duration {
 	return min(30*time.Second, max(time.Second, deadline/10))
 }
 
-// soakFailureExpiryOption configures the sweep. Metrics are optional so the
-// tests that only assert expiry do not have to build a registry.
-type soakFailureExpiryOption func(*soakFailureExpirySettings)
-
-type soakFailureExpirySettings struct {
-	metrics *Metrics
-}
-
-func withSoakFailureExpiryMetrics(metrics *Metrics) soakFailureExpiryOption {
-	return func(s *soakFailureExpirySettings) { s.metrics = metrics }
-}
-
 func runSoakFailureExpiry(
 	ctx context.Context,
 	ledger *failureLedger,
 	evidence *recipientEvidence,
 	ticks <-chan time.Time,
 	onError func(error),
-	options ...soakFailureExpiryOption,
 ) {
-	settings := soakFailureExpirySettings{}
-	for _, option := range options {
-		option(&settings)
-	}
 	if ledger == nil || ticks == nil {
 		return
 	}
@@ -105,9 +88,6 @@ func runSoakFailureExpiry(
 			if err := ledger.MaybeCompact(at); err != nil {
 				reportSoakFailureSweepError(
 					onError, fmt.Errorf("compact failure journal: %w", err))
-			}
-			if settings.metrics != nil {
-				settings.metrics.FailureRecipientExpectations.Set(float64(evidence.Len()))
 			}
 		}
 	}

--- a/tools/loadgen/soak_failure.go
+++ b/tools/loadgen/soak_failure.go
@@ -380,9 +380,7 @@ func (t *soakFailureTracker) Start(pending *soakPendingSend) error {
 		),
 		Attributes: attributes,
 	}); err != nil {
-		if t.recipient != nil {
-			t.recipient.evidence.Forget(pending.MessageID)
-		}
+		t.forgetRecipientExpectation(pending.MessageID)
 		return fmt.Errorf("start soak failure operation: %w", err)
 	}
 	return nil
@@ -413,13 +411,28 @@ func (t *soakFailureTracker) AbandonUnsent(pending *soakPendingSend) error {
 	}
 	err := t.ledger.Abandon(pending.MessageID, failureResultNotSent, t.now().UTC())
 	if errors.Is(err, errFailureOperationNotActive) {
+		// Already finalized, so no sweep will ever report this ID again.
+		t.forgetRecipientExpectation(pending.MessageID)
 		t.countUntracked(failureUntrackedReasonAbandon)
 		return nil
 	}
 	if err != nil {
+		// The operation may still be active and reconcilable, and its evidence
+		// is the only record of what was delivered.
 		return fmt.Errorf("abandon unsent soak operation: %w", err)
 	}
+	// Abandoning finalizes the operation out of the ledger, which puts it
+	// beyond the reach of the expiry sweep that releases evidence by ID.
+	t.forgetRecipientExpectation(pending.MessageID)
 	return nil
+}
+
+// forgetRecipientExpectation releases an expectation the ledger will never
+// report, on the paths that retire an operation without going through expiry.
+func (t *soakFailureTracker) forgetRecipientExpectation(operationID string) {
+	if t.recipient != nil {
+		t.recipient.evidence.Forget(operationID)
+	}
 }
 
 func (t *soakFailureTracker) ObserveReply(result *soakSendReplyResult) error {

--- a/tools/loadgen/soak_failure.go
+++ b/tools/loadgen/soak_failure.go
@@ -53,12 +53,31 @@ func soakFailureExpiryInterval(deadline time.Duration) time.Duration {
 	return min(30*time.Second, max(time.Second, deadline/10))
 }
 
+// soakFailureExpiryOption configures the sweep. Metrics are optional so the
+// tests that only assert expiry do not have to build a registry.
+type soakFailureExpiryOption func(*soakFailureExpirySettings)
+
+type soakFailureExpirySettings struct {
+	metrics *Metrics
+}
+
+func withSoakFailureExpiryMetrics(metrics *Metrics) soakFailureExpiryOption {
+	return func(s *soakFailureExpirySettings) { s.metrics = metrics }
+}
+
 func runSoakFailureExpiry(
 	ctx context.Context,
 	ledger *failureLedger,
+	evidence *recipientEvidence,
+	retention time.Duration,
 	ticks <-chan time.Time,
 	onError func(error),
+	options ...soakFailureExpiryOption,
 ) {
+	settings := soakFailureExpirySettings{}
+	for _, option := range options {
+		option(&settings)
+	}
 	if ledger == nil || ticks == nil {
 		return
 	}
@@ -80,6 +99,17 @@ func runSoakFailureExpiry(
 			if err := ledger.MaybeCompact(at); err != nil {
 				reportSoakFailureSweepError(
 					onError, fmt.Errorf("compact failure journal: %w", err))
+			}
+			// The ledger's expiry removes the operation and never tells the
+			// recipient evidence, whose only other exit is Finalize inside the
+			// reconciler. Anything the reconciler never reaches was therefore
+			// retained for the life of the process — and each entry holds one
+			// route map per recipient, which is what made this the largest
+			// object graph in the run. Sweeping here bounds the evidence by the
+			// same deadline that bounds the ledger.
+			evidence.ExpireBefore(at.Add(-retention))
+			if settings.metrics != nil {
+				settings.metrics.FailureRecipientExpectations.Set(float64(evidence.Len()))
 			}
 		}
 	}

--- a/tools/loadgen/soak_failure.go
+++ b/tools/loadgen/soak_failure.go
@@ -69,7 +69,6 @@ func runSoakFailureExpiry(
 	ctx context.Context,
 	ledger *failureLedger,
 	evidence *recipientEvidence,
-	retention time.Duration,
 	ticks <-chan time.Time,
 	onError func(error),
 	options ...soakFailureExpiryOption,
@@ -89,37 +88,23 @@ func runSoakFailureExpiry(
 			if !ok {
 				return
 			}
-			ledgerExpired := true
-			if _, err := ledger.Expire(at); err != nil {
-				ledgerExpired = false
+			// The IDs the ledger actually finalized, which is not the same as
+			// "everything overdue": Expire stops at its batch limit and skips
+			// claimed operations mid-verification. Forgetting exactly these
+			// keeps the evidence and the ledger in step, and taking them after
+			// Expire returns creates no ordering between the two locks.
+			expired, err := ledger.Expire(at)
+			if err != nil {
 				reportSoakFailureSweepError(
 					onError, fmt.Errorf("expire failure operations: %w", err))
 			}
+			evidence.ForgetAll(expired)
 			// Reclaiming on the same tick means a run that finalizes nothing
 			// still bounds the journal; the finalize counter alone would let it
 			// grow until the next restart made recovery more expensive.
 			if err := ledger.MaybeCompact(at); err != nil {
 				reportSoakFailureSweepError(
 					onError, fmt.Errorf("compact failure journal: %w", err))
-			}
-			// The ledger's expiry removes the operation and never tells the
-			// recipient evidence, whose only other exit is Finalize inside the
-			// reconciler. Anything the reconciler never reaches was therefore
-			// retained for the life of the process — and each entry holds one
-			// route map per recipient, which is what made this the largest
-			// object graph in the run. Sweeping here bounds the evidence by the
-			// same deadline that bounds the ledger.
-			// Only after the ledger finalized what was due. A failed expiry
-			// leaves those operations live and still reconcilable, so
-			// releasing their evidence on the same tick would destroy the only
-			// record of what was delivered. The next tick retries both.
-			//
-			// A zero window would put the cutoff at now and release every
-			// expectation, including operations still inside their deadline.
-			// Config validation forbids a zero SOAK_RECONCILE_DEADLINE, so
-			// this guards a caller mistake rather than a reachable setting.
-			if ledgerExpired && retention > 0 {
-				evidence.ExpireBefore(at.Add(-retention))
 			}
 			if settings.metrics != nil {
 				settings.metrics.FailureRecipientExpectations.Set(float64(evidence.Len()))
@@ -370,10 +355,6 @@ func (t *soakFailureTracker) Start(pending *soakPendingSend) error {
 			Route:       route,
 			Source:      source,
 			Complete:    complete,
-			// The same deadline this operation is about to be started with, so
-			// the sweep releases the evidence exactly when the ledger releases
-			// the operation.
-			Deadline: startedAt.Add(t.deadline),
 		}); err != nil {
 			return fmt.Errorf("register soak recipient expectation: %w", err)
 		}

--- a/tools/loadgen/soak_failure.go
+++ b/tools/loadgen/soak_failure.go
@@ -107,7 +107,13 @@ func runSoakFailureExpiry(
 			// route map per recipient, which is what made this the largest
 			// object graph in the run. Sweeping here bounds the evidence by the
 			// same deadline that bounds the ledger.
-			evidence.ExpireBefore(at.Add(-retention))
+			// A zero window would put the cutoff at now and release every
+			// expectation, including operations still inside their deadline.
+			// Config validation forbids a zero SOAK_RECONCILE_DEADLINE, so
+			// this guards a caller mistake rather than a reachable setting.
+			if retention > 0 {
+				evidence.ExpireBefore(at.Add(-retention))
+			}
 			if settings.metrics != nil {
 				settings.metrics.FailureRecipientExpectations.Set(float64(evidence.Len()))
 			}

--- a/tools/loadgen/soak_failure.go
+++ b/tools/loadgen/soak_failure.go
@@ -410,20 +410,22 @@ func (t *soakFailureTracker) AbandonUnsent(pending *soakPendingSend) error {
 		return fmt.Errorf("soak pending send requires message ID")
 	}
 	err := t.ledger.Abandon(pending.MessageID, failureResultNotSent, t.now().UTC())
-	if errors.Is(err, errFailureOperationNotActive) {
-		// Already finalized, so no sweep will ever report this ID again.
+	// One decision, and the ledger makes it. Abandoning finalizes the operation
+	// out of the ledger, putting it beyond the expiry sweep that releases
+	// evidence by ID — but so does a failure that lands after the commit, so
+	// "did the call succeed" is the wrong question. An operation still held is
+	// still reconcilable and keeps its evidence; one the ledger has let go must
+	// release it here or nothing will.
+	if t.ledger.Retired(pending.MessageID) {
 		t.forgetRecipientExpectation(pending.MessageID)
+	}
+	if errors.Is(err, errFailureOperationNotActive) {
 		t.countUntracked(failureUntrackedReasonAbandon)
 		return nil
 	}
 	if err != nil {
-		// The operation may still be active and reconcilable, and its evidence
-		// is the only record of what was delivered.
 		return fmt.Errorf("abandon unsent soak operation: %w", err)
 	}
-	// Abandoning finalizes the operation out of the ledger, which puts it
-	// beyond the reach of the expiry sweep that releases evidence by ID.
-	t.forgetRecipientExpectation(pending.MessageID)
 	return nil
 }
 

--- a/tools/loadgen/soak_failure.go
+++ b/tools/loadgen/soak_failure.go
@@ -89,7 +89,9 @@ func runSoakFailureExpiry(
 			if !ok {
 				return
 			}
+			ledgerExpired := true
 			if _, err := ledger.Expire(at); err != nil {
+				ledgerExpired = false
 				reportSoakFailureSweepError(
 					onError, fmt.Errorf("expire failure operations: %w", err))
 			}
@@ -107,11 +109,16 @@ func runSoakFailureExpiry(
 			// route map per recipient, which is what made this the largest
 			// object graph in the run. Sweeping here bounds the evidence by the
 			// same deadline that bounds the ledger.
+			// Only after the ledger finalized what was due. A failed expiry
+			// leaves those operations live and still reconcilable, so
+			// releasing their evidence on the same tick would destroy the only
+			// record of what was delivered. The next tick retries both.
+			//
 			// A zero window would put the cutoff at now and release every
 			// expectation, including operations still inside their deadline.
 			// Config validation forbids a zero SOAK_RECONCILE_DEADLINE, so
 			// this guards a caller mistake rather than a reachable setting.
-			if retention > 0 {
+			if ledgerExpired && retention > 0 {
 				evidence.ExpireBefore(at.Add(-retention))
 			}
 			if settings.metrics != nil {
@@ -363,6 +370,10 @@ func (t *soakFailureTracker) Start(pending *soakPendingSend) error {
 			Route:       route,
 			Source:      source,
 			Complete:    complete,
+			// The same deadline this operation is about to be started with, so
+			// the sweep releases the evidence exactly when the ledger releases
+			// the operation.
+			Deadline: startedAt.Add(t.deadline),
 		}); err != nil {
 			return fmt.Errorf("register soak recipient expectation: %w", err)
 		}

--- a/tools/loadgen/soak_failure_test.go
+++ b/tools/loadgen/soak_failure_test.go
@@ -69,7 +69,7 @@ func TestSoakFailureExpiryLoop_FinalizesPastDeadline(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		runSoakFailureExpiry(ctx, ledger, nil, time.Minute, ticks, nil)
+		runSoakFailureExpiry(ctx, ledger, nil, ticks, nil)
 	}()
 	ticks <- now.Add(2 * time.Minute)
 
@@ -98,7 +98,7 @@ func TestSoakFailureExpiryLoop_ReportsPersistenceFailureAndStopsOnCancel(t *test
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		runSoakFailureExpiry(ctx, ledger, nil, time.Minute, ticks, func(err error) { errorsSeen <- err })
+		runSoakFailureExpiry(ctx, ledger, nil, ticks, func(err error) { errorsSeen <- err })
 	}()
 	ticks <- now.Add(2 * time.Minute)
 	require.ErrorContains(t, <-errorsSeen, "expire failure operations")

--- a/tools/loadgen/soak_failure_test.go
+++ b/tools/loadgen/soak_failure_test.go
@@ -69,7 +69,7 @@ func TestSoakFailureExpiryLoop_FinalizesPastDeadline(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		runSoakFailureExpiry(ctx, ledger, ticks, nil)
+		runSoakFailureExpiry(ctx, ledger, nil, time.Minute, ticks, nil)
 	}()
 	ticks <- now.Add(2 * time.Minute)
 
@@ -98,7 +98,7 @@ func TestSoakFailureExpiryLoop_ReportsPersistenceFailureAndStopsOnCancel(t *test
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		runSoakFailureExpiry(ctx, ledger, ticks, func(err error) { errorsSeen <- err })
+		runSoakFailureExpiry(ctx, ledger, nil, time.Minute, ticks, func(err error) { errorsSeen <- err })
 	}()
 	ticks <- now.Add(2 * time.Minute)
 	require.ErrorContains(t, <-errorsSeen, "expire failure operations")

--- a/tools/loadgen/soak_main.go
+++ b/tools/loadgen/soak_main.go
@@ -526,6 +526,7 @@ func runSoakWorkload(
 		ledger,
 		metrics,
 		cfg.Soak.RecipientObserverQueue,
+		cfg.Soak.LedgerCapacity,
 		cfg.Soak.LedgerDir,
 		now,
 	)

--- a/tools/loadgen/soak_main.go
+++ b/tools/loadgen/soak_main.go
@@ -521,15 +521,31 @@ func runSoakWorkload(
 			slog.Error("close Cassandra soak failure ledger", "error", err)
 		}
 	}()
+	observationRuntime := newSoakFailureObservationRuntime(
+		cfg.Soak.RecipientObserverEnabled,
+		ledger,
+		metrics,
+		cfg.Soak.RecipientObserverQueue,
+		cfg.Soak.LedgerDir,
+		now,
+	)
 	expiryCtx, stopExpiry := context.WithCancel(ctx)
 	expiryTicker := time.NewTicker(soakFailureExpiryInterval(cfg.Soak.ReconcileDeadline))
 	expiryDone := make(chan struct{})
 	go func() {
 		defer close(expiryDone)
 		defer expiryTicker.Stop()
-		runSoakFailureExpiry(expiryCtx, ledger, expiryTicker.C, func(err error) {
-			slog.Error("expire Cassandra soak failure evidence", "error", err)
-		})
+		runSoakFailureExpiry(
+			expiryCtx,
+			ledger,
+			observationRuntime.Evidence(),
+			cfg.Soak.ReconcileDeadline,
+			expiryTicker.C,
+			func(err error) {
+				slog.Error("expire Cassandra soak failure evidence", "error", err)
+			},
+			withSoakFailureExpiryMetrics(metrics),
+		)
 	}()
 	var expiryShutdownOnce sync.Once
 	shutdownExpiry := func() {
@@ -577,14 +593,6 @@ func runSoakWorkload(
 		})
 	}
 	defer shutdownConsumerSamplers()
-	observationRuntime := newSoakFailureObservationRuntime(
-		cfg.Soak.RecipientObserverEnabled,
-		ledger,
-		metrics,
-		cfg.Soak.RecipientObserverQueue,
-		cfg.Soak.LedgerDir,
-		now,
-	)
 	if cfg.Soak.RecipientObserverEnabled {
 		recipientObserver := observationRuntime.Recipient()
 		recipientSource := newPooledNATSFailureRecipientSource(

--- a/tools/loadgen/soak_main.go
+++ b/tools/loadgen/soak_main.go
@@ -540,7 +540,6 @@ func runSoakWorkload(
 			expiryCtx,
 			ledger,
 			observationRuntime.Evidence(),
-			cfg.Soak.ReconcileDeadline,
 			expiryTicker.C,
 			func(err error) {
 				slog.Error("expire Cassandra soak failure evidence", "error", err)

--- a/tools/loadgen/soak_main.go
+++ b/tools/loadgen/soak_main.go
@@ -530,6 +530,9 @@ func runSoakWorkload(
 		cfg.Soak.LedgerDir,
 		now,
 	)
+	// Collected at scrape time so a stalled expiry sweep cannot freeze the one
+	// number that would reveal the stall.
+	metrics.SetRecipientExpectationSource(observationRuntime.Evidence().Len)
 	expiryCtx, stopExpiry := context.WithCancel(ctx)
 	expiryTicker := time.NewTicker(soakFailureExpiryInterval(cfg.Soak.ReconcileDeadline))
 	expiryDone := make(chan struct{})
@@ -544,7 +547,6 @@ func runSoakWorkload(
 			func(err error) {
 				slog.Error("expire Cassandra soak failure evidence", "error", err)
 			},
-			withSoakFailureExpiryMetrics(metrics),
 		)
 	}()
 	var expiryShutdownOnce sync.Once

--- a/tools/loadgen/soak_roommember_test.go
+++ b/tools/loadgen/soak_roommember_test.go
@@ -727,7 +727,8 @@ func TestSoakRoomLanes_ReleasesReservationsTheLedgerExpired(t *testing.T) {
 	// deadline, so a reconcile slot is not guaranteed to be the path that ends
 	// an operation. The lane must still get its room lease back.
 	fixture.advance(2 * time.Minute)
-	expired, err := fixture.ledger.Expire(fixture.now)
+	expiredIDs, err := fixture.ledger.Expire(fixture.now)
+	expired := len(expiredIDs)
 	require.NoError(t, err)
 	require.Equal(t, 1, expired)
 


### PR DESCRIPTION
The soak pod is OOM-killed roughly hourly at 8GB with `GOMEMLIMIT` set. #317
removed the journal's growth and it kept dying, so the remaining ~5GB was
unaccounted for. A heap profile names it.

## The evidence

```
      flat  flat%   sum%
 2472.41MB 60.79% 60.79%  main.incrementRecipientRoute (inline)
  413.86MB 10.18% 70.97%  main.(*recipientEvidence).ExpectDelivery
```

Both serve exactly one structure: `recipientEvidence.operations`. 71% of the
live heap is one map.

## Why it could only grow

| | |
|---|---|
| **In** | `ExpectDelivery` — one entry per send, no cap |
| **Out** | `Finalize` only, and its single caller is inside `soakFailureReconciler.Try` |

`failureLedger.Expire` finalizes an operation at its deadline, marks the
unobserved observers `unverified`, drops it from `l.active` — and never told
the evidence. So any operation the reconciler did not claim left its
expectation behind permanently.

## The arithmetic says the same thing

`loadgen_failure_inflight` sat at **33K**, which is exactly
`SEND_RATE 55/s × RECONCILE_DEADLINE 10m`. The ledger is bounded and behaving
precisely as designed.

The evidence map held enough to account for **2886MB** — an order of magnitude
more entries than the ledger. It was holding operations the ledger had already
finalized and forgotten.

`incrementRecipientRoute` beating `ExpectDelivery` six to one is the same story
from the allocation side: it allocates **one `map[recipientDeliveryRoute]int`
per (operation, recipient) pair**, and a channel room has 100 recipients. At 55
sends/s that is roughly 20M small maps an hour, each with its own header and
bucket.

## The fix

One rule, applied everywhere: **an expectation is released exactly when the
ledger stops holding its operation.** Identity, not time — the evidence and the
ledger cannot disagree about which operations exist, because only one of them
decides.

`failureLedger.Expire` returns the IDs it retired and the sweep forgets those.
That the ledger decides matters, because "everything overdue" is a different
set: `Expire` stops at `LEDGER_EXPIRE_BATCH`, and it skips **claimed**
operations the reconciler is mid-verification on — the ordinary path, not a
configuration edge. Both return `nil`, so no flag derived from "did the sweep
succeed" can tell them apart. Only the list of IDs can.

The same rule covers the paths that retire an operation without going through
expiry, each of which review surfaced in turn:

- `Expire`'s own error path. `finalizeLocked` deletes from `l.active` and
  compacts afterwards, so a compaction failure returns an error on an operation
  it has already retired. `Expire` now reports by what left `l.active` rather
  than by whether the call succeeded — an ID it does not report can never be
  reported by a later sweep.
- `AbandonUnsent`, which finalizes the operation out of the ledger entirely.
  The expectation is registered before the publish is attempted, so every
  locally-failed publish used to leave one behind for the life of the run. It
  asks `failureLedger.Retired` and releases on that answer alone, so the
  compaction case is covered there too rather than being re-derived per branch.

It is still not driven from *inside* `finalizeLocked`. Calling
`evidence.Forget` there would put the evidence lock underneath the ledger lock,
while the observer already takes them the other way round (`r.mu` released,
then `l.mu` via `Invalidate`). Every release happens after the ledger lock is
gone, so the evidence lock is still taken alone and no ordering between the two
exists at all.

The map also gains the ceiling it never had, because forgetting only what the
ledger retires means a ledger that stops retiring stops bounding the map. It is
set to twice `LEDGER_CAPACITY`: one ledger generation of headroom, since a
sweep can retire the whole ledger before cleanup runs, and sizing the two
equally would refuse a send inside that window.

## Three attempts at the same bound

Worth recording, because the first two both looked right.

1. **Registration time + a retention window.** Rejected during review: a
   recovered operation re-registers at replay time, so a shortened
   `RECONCILE_DEADLINE` deletes evidence the ledger correctly keeps alive.
2. **The operation's own persisted deadline.** Rejected during review: it still
   deletes evidence for operations `Expire` deferred by its batch limit or
   skipped because they were claimed.
3. **The IDs the ledger reports.** This one.

The first two were clocks approximating what the ledger did. `Expire` has two
exceptions no clock can model, so the approximation could only ever be close.
The net change removes `registeredAt`, the injected clock, the per-entry
deadline, the optional `Deadline` config field and the retention parameter,
along with the guards that existed to make them safe.

## Observability

Adds `loadgen_failure_recipient_expectations`. Without it, the only way to see
this map growing again is a heap profile — which is exactly how it stayed
hidden through an entire OOM investigation. A healthy run tracks
`loadgen_failure_inflight`; climbing past it is this regressing.

Documented in `docs/specs/o11y/storage-dependency-metrics.md`.

## Also in this PR

`TestGenerator_PacedRunBeatsSingleTickerCeiling` was failing on CI on code this
branch does not touch. It compared the two dispatch paths over one 200ms window
and required `paced > serial × 1.3`, but the pacer releases `rate × elapsed` and
no more, so the paced count clipped at exactly the target while a fast runner
drove the serial ticker close to it — leaving no result that could pass.

Two attempts to rescue the comparison failed for the same underlying reason. A
higher fixed target is reachable on a fast host and unreachable on a slow one;
a target scaled from the measured serial plateau fails too, because under load
the serial ticker collapses far harder than the worker pool does (a run
measured plateau 400 against paced 8000 — a ratio of 20 where an idle host
shows 2.2). Both counts are properties of the host, and their ratio has no
upper bound to write a threshold against.

So the blocking assertion moved to the seam with no timer in it.
`pacedDispatchRateWithTicks` accepts the tick channel, so
`TestPacedDispatch_ReleasesTheWholeBatchOnOneTick` drives one synthetic tick
through the real dispatch loop and asserts it releases the whole batch the rate
owes — 200 events at 100k rps against the 2ms floor — where a one-per-tick
regression releases exactly one. Verified by making that regression: it reports
200 against 1.

What remains on real timers is a measurement. `TestGenerator_MeasuresBothDispatchPaths`
logs both counts, which is what makes it useful when tuning the pacer, and
asserts only that each path dispatched at all.

## What this does not fix

- **Reconciliation appears not to be running.** `inflight` sitting at exactly
  `rate × deadline` means essentially every operation reaches its deadline
  rather than being reconciled — even though capacity looks sufficient
  (`READ_RATE 110 × RECONCILE_READ_SHARE 0.75 = 82.5/s` against 55/s of sends).
  This PR makes that survivable rather than fatal; the reason reconcile is idle
  is a separate investigation.
- `subscription_list` p95 pinned at 5s — unrelated, and #320 added the probe
  for it.
- The hourly `thread_subscriptions` scan wave in MongoDB, which shares the OOM
  restart period. If it disappears once the pod stops restarting, it was a
  consequence; if it survives, it is its own problem.

## Verification

`make lint` clean (0 issues), full `tools/loadgen` suite green under `-race`
(316s), `go vet -tags integration` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UozmNGUfV2Jk3VZDikSwh4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Recipient expectation metrics now reflect current values at scrape time, even when cleanup is delayed.
  - Failure evidence is released reliably when operations complete, are abandoned, or are removed.
  - Evidence is preserved when cleanup is deferred or encounters errors, preventing premature data loss.
  - Improved pacing test reliability across different environments.

- **Documentation**
  - Simplified storage dependency metrics guidance and clarified telemetry, ledger coverage, and MongoDB support.
  - Documented recipient expectation metric collection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->