### PR TITLE
fix(mongo-indexes): non-fatal index ensure + single-owner shared indexes

### DIFF
--- a/admin-service/integration_test.go
+++ b/admin-service/integration_test.go
@@ -47,6 +47,14 @@ func TestIntegration_CreateUser_And_UniqueIndex(t *testing.T) {
 	st := newStoreMongo(db)
 	require.NoError(t, st.EnsureIndexes(context.Background()))
 
+	// users.account unique is owned by user-service; create it here so admin's
+	// duplicate-account path (ErrAccountExists) is exercised.
+	_, ierr := db.Collection("users").Indexes().CreateOne(context.Background(), mongo.IndexModel{
+		Keys:    bson.D{{Key: "account", Value: 1}},
+		Options: options.Index().SetUnique(true),
+	})
+	require.NoError(t, ierr)
+
 	u := &model.User{
 		ID:      idgen.GenerateUUIDv7(),
 		Account: "alice",
@@ -586,8 +594,7 @@ func TestIntegration_EnsureIndexes_Keys(t *testing.T) {
 	require.NoError(t, st.EnsureIndexes(context.Background()))
 
 	userKeys := testutil.IndexSpecs(t, db.Collection("users"))
-	require.Contains(t, userKeys, "account:1")
-	assert.True(t, userKeys["account:1"], "(account) must stay unique — shared with botplatform/user-service")
+	// users.account unique is owned by user-service now, not created here.
 	require.Contains(t, userKeys, "siteId:1,account:1")
 
 	auditKeys := testutil.IndexSpecs(t, db.Collection("admin_audit"))

--- a/admin-service/main.go
+++ b/admin-service/main.go
@@ -55,11 +55,11 @@ func run() error {
 	db := mongoClient.Database(cfg.MongoDB)
 	st := newStoreMongo(db)
 	if err := st.EnsureIndexes(ctx); err != nil {
-		return fmt.Errorf("ensure indexes: %w", err)
+		slog.Warn("ensure indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 	sessStore := session.NewMongoStore(db)
 	if err := sessStore.EnsureIndexes(ctx); err != nil {
-		return fmt.Errorf("ensure session indexes: %w", err)
+		slog.Warn("ensure session indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 
 	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)

--- a/admin-service/store_mongo.go
+++ b/admin-service/store_mongo.go
@@ -11,6 +11,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/mongoutil"
 	"github.com/hmchangw/chat/pkg/session"
 )
 
@@ -30,21 +31,15 @@ func newStoreMongo(db *mongo.Database) *storeMongo {
 
 // EnsureIndexes creates required indexes idempotently.
 func (s *storeMongo) EnsureIndexes(ctx context.Context) error {
-	// Matches botplatform's auto-named "account_1" unique index for idempotency on the shared collection.
-	_, err := s.users.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys:    bson.D{{Key: "account", Value: 1}},
-		Options: options.Index().SetUnique(true),
-	})
-	if err != nil {
-		return fmt.Errorf("create users account index: %w", err)
-	}
+	// users.account (unique) is owned by user-service; verify + warn only, never create.
+	mongoutil.WarnMissingIndexes(ctx, s.users, "account_1")
 
 	// Backs SearchUsers, whose only non-regex predicate is siteId: no other service
 	// declares a siteId-prefixed index on the shared users collection, so without
 	// this both the count and the paged find scan every user document. account
 	// trails so the unfiltered count is answered from the index alone (a q-filtered
 	// one still fetches, since engName/chineseName aren't in the key).
-	_, err = s.users.Indexes().CreateOne(ctx, mongo.IndexModel{
+	_, err := s.users.Indexes().CreateOne(ctx, mongo.IndexModel{
 		Keys: bson.D{{Key: "siteId", Value: 1}, {Key: "account", Value: 1}},
 	})
 	if err != nil {

--- a/bot-room-service/integration_test.go
+++ b/bot-room-service/integration_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/hmchangw/chat/pkg/idgen"
 	"github.com/hmchangw/chat/pkg/testutil"
@@ -41,11 +43,10 @@ func TestIntegration_EnsureIndexes_SubscriptionKeys(t *testing.T) {
 	require.NoError(t, st.EnsureIndexes(context.Background()))
 
 	specs := testutil.IndexSpecs(t, st.subs)
-	require.Contains(t, specs, "roomId:1,u.account:1")
-	assert.True(t, specs["roomId:1,u.account:1"], "must be unique — room-service declares it so on the shared collection")
 	require.Contains(t, specs, "roomId:1,u._id:1")
 	assert.False(t, specs["roomId:1,u._id:1"])
-	assert.Len(t, specs, 3, "_id plus the two declared indexes, no duplicates")
+	// {roomId,u.account} unique is owned by room-service now, not created here.
+	assert.Len(t, specs, 2, "_id plus the {roomId,u._id} index this service owns")
 }
 
 // -------------------------------------------------------------------------
@@ -72,6 +73,14 @@ func TestIntegration_UpsertSubscription_CreatesThenNoOps(t *testing.T) {
 func TestIntegration_UpsertSubscription_DuplicateAccountIsNotAnError(t *testing.T) {
 	st := newTestStore(t)
 	ctx := context.Background()
+
+	// subscriptions.{roomId,u.account} unique is owned by room-service; create it
+	// here so the duplicate-account dedup path is exercised.
+	_, err := st.subs.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys:    bson.D{{Key: "roomId", Value: 1}, {Key: "u.account", Value: 1}},
+		Options: options.Index().SetUnique(true),
+	})
+	require.NoError(t, err)
 
 	created, err := st.UpsertSubscription(ctx, newSub("room-1", "user-1", "alice"))
 	require.NoError(t, err)

--- a/bot-room-service/main.go
+++ b/bot-room-service/main.go
@@ -77,7 +77,7 @@ func run() error {
 	ensureCtx, ensureCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer ensureCancel()
 	if err := store.EnsureIndexes(ensureCtx); err != nil {
-		return fmt.Errorf("ensure store indexes: %w", err)
+		slog.Warn("ensure store indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 
 	if cfg.RoomKeyGracePeriod <= 0 {

--- a/bot-room-service/store_mongo.go
+++ b/bot-room-service/store_mongo.go
@@ -11,6 +11,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/mongoutil"
 )
 
 type storeMongo struct {
@@ -31,14 +32,8 @@ func newStoreMongo(db *mongo.Database) *storeMongo {
 // writes, and must be invoked once at startup. The rooms and users access here
 // (including the room-key store) is entirely _id-keyed, so neither needs one.
 func (s *storeMongo) EnsureIndexes(ctx context.Context) error {
-	// Mirrors room-service's declaration — same keys AND same unique option, or
-	// whichever service starts second hits IndexOptionsConflict on the shared collection.
-	if _, err := s.subs.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys:    bson.D{{Key: "roomId", Value: 1}, {Key: "u.account", Value: 1}},
-		Options: options.Index().SetUnique(true),
-	}); err != nil {
-		return fmt.Errorf("ensure subscriptions (roomId,u.account) unique index: %w", err)
-	}
+	// subscriptions.{roomId,u.account} (unique) is owned by room-service; verify + warn only, never create.
+	mongoutil.WarnMissingIndexes(ctx, s.subs, "roomId_1_u.account_1")
 	// Upsert and delete identify a subscription by u._id — the remove RPC carries
 	// user ids, not accounts — which the unique index above cannot serve.
 	if _, err := s.subs.Indexes().CreateOne(ctx, mongo.IndexModel{

--- a/botplatform-service/main.go
+++ b/botplatform-service/main.go
@@ -57,7 +57,7 @@ func run() error {
 	db := mongoClient.Database(cfg.MongoDB)
 	sessionStore := session.NewMongoStore(db)
 	if err := sessionStore.EnsureIndexes(ctx); err != nil {
-		return fmt.Errorf("ensure session indexes: %w", err)
+		slog.Warn("ensure session indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 	st := newStoreMongo(db)
 	subStore := newMongoSubscriptionStore(db)

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -137,8 +137,7 @@ func main() {
 	}
 	store := NewMongoStore(db.Collection("rooms"), db.Collection("subscriptions"), db.Collection("thread_rooms"), metaValkey, cfg.RoomMetaL2TTL)
 	if err := store.EnsureIndexes(ctx); err != nil {
-		slog.Error("ensure indexes failed", "error", err)
-		os.Exit(1)
+		slog.Warn("ensure indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 	cachedStore, err := newCachedMetaStore(store, cfg.RoomMetaCacheSize, cfg.RoomMetaCacheTTL)
 	if err != nil {

--- a/data-migration/oplog-collections-transformer/main.go
+++ b/data-migration/oplog-collections-transformer/main.go
@@ -92,10 +92,7 @@ func main() {
 	}
 	target := NewMongoTargetStore(targetClient.Database(cfg.TargetDB))
 	if err := target.EnsureIndexes(ctx); err != nil {
-		slog.Error("ensure target indexes failed", "error", err)
-		mongoutil.Disconnect(ctx, targetClient)
-		mongoutil.Disconnect(ctx, source)
-		os.Exit(1)
+		slog.Warn("ensure target indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 
 	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)

--- a/data-migration/oplog-collections-transformer/main.go
+++ b/data-migration/oplog-collections-transformer/main.go
@@ -91,8 +91,13 @@ func main() {
 		os.Exit(1)
 	}
 	target := NewMongoTargetStore(targetClient.Database(cfg.TargetDB))
+	// A one-shot migration must have its dedup index — availability doesn't apply,
+	// so this stays fatal (unlike the long-running services).
 	if err := target.EnsureIndexes(ctx); err != nil {
-		slog.Warn("ensure target indexes failed; continuing (indexes are best-effort)", "error", err)
+		slog.Error("ensure target indexes failed", "error", err)
+		mongoutil.Disconnect(ctx, targetClient)
+		mongoutil.Disconnect(ctx, source)
+		os.Exit(1)
 	}
 
 	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)

--- a/data-migration/oplog-collections-transformer/targetstore.go
+++ b/data-migration/oplog-collections-transformer/targetstore.go
@@ -10,6 +10,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/mongoutil"
 )
 
 // mongoTargetStore is the new-stack per-site Mongo access the transformer needs: user
@@ -36,7 +37,7 @@ func NewMongoTargetStore(db *mongo.Database) *mongoTargetStore {
 // EnsureIndexes creates the unique index on users.account — the insert-if-absent dedup key.
 // thread_rooms indexes are owned by message-worker and intentionally not touched here.
 func (s *mongoTargetStore) EnsureIndexes(ctx context.Context) error {
-	if _, err := s.users.Indexes().CreateOne(ctx, mongo.IndexModel{
+	if err := mongoutil.EnsureIndexWithRepair(ctx, s.users, mongo.IndexModel{
 		Keys:    bson.D{{Key: "account", Value: 1}},
 		Options: options.Index().SetUnique(true),
 	}); err != nil {

--- a/history-service/cmd/main.go
+++ b/history-service/cmd/main.go
@@ -158,12 +158,10 @@ func main() {
 	appRepo := mongorepo.NewAppRepo(db)
 
 	if err := threadRoomRepo.EnsureIndexes(ctx); err != nil {
-		slog.Error("ensure thread_rooms indexes failed", "error", err)
-		os.Exit(1)
+		slog.Warn("ensure thread_rooms indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 	if err := threadSubRepo.EnsureIndexes(ctx); err != nil {
-		slog.Error("ensure thread_subscriptions indexes failed", "error", err)
-		os.Exit(1)
+		slog.Warn("ensure thread_subscriptions indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 
 	// Front the per-request Mongo reads with process-local LRU+TTL caches.

--- a/history-service/internal/mongorepo/threadsubscription.go
+++ b/history-service/internal/mongorepo/threadsubscription.go
@@ -7,7 +7,6 @@ import (
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
-	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
@@ -48,16 +47,13 @@ func NewThreadSubscriptionRepo(db *mongo.Database) *ThreadSubscriptionRepo {
 // The (threadRoomId, userAccount) unique index is the one message-worker owns;
 // history-service ensures it independently so startup order doesn't matter.
 func (r *ThreadSubscriptionRepo) EnsureIndexes(ctx context.Context) error {
-	_, err := r.subs.Raw().Indexes().CreateMany(ctx, []mongo.IndexModel{
-		// Fronts ListUserThreadSubscriptions' userAccount $match.
-		{Keys: bson.D{{Key: "userAccount", Value: 1}}},
-		{
-			Keys:    bson.D{{Key: "threadRoomId", Value: 1}, {Key: "userAccount", Value: 1}},
-			Options: options.Index().SetUnique(true),
-		},
-	}, options.CreateIndexes())
-	if err != nil {
-		return fmt.Errorf("ensure thread_subscriptions indexes: %w", err)
+	// thread_subscriptions.{threadRoomId,userAccount} (unique) is owned by room-service; verify + warn only, never create.
+	mongoutil.WarnMissingIndexes(ctx, r.subs.Raw(), "threadRoomId_1_userAccount_1")
+	// Fronts ListUserThreadSubscriptions' userAccount $match.
+	if _, err := r.subs.Raw().Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{{Key: "userAccount", Value: 1}},
+	}); err != nil {
+		return fmt.Errorf("ensure thread_subscriptions (userAccount) index: %w", err)
 	}
 	return nil
 }

--- a/history-service/internal/mongorepo/threadsubscription.go
+++ b/history-service/internal/mongorepo/threadsubscription.go
@@ -43,9 +43,9 @@ func NewThreadSubscriptionRepo(db *mongo.Database) *ThreadSubscriptionRepo {
 	}
 }
 
-// EnsureIndexes creates the indexes the thread-inbox query needs. Idempotent.
-// The (threadRoomId, userAccount) unique index is the one message-worker owns;
-// history-service ensures it independently so startup order doesn't matter.
+// EnsureIndexes creates the (userAccount) index this service's thread-inbox query
+// needs. The (threadRoomId, userAccount) unique index is owned by room-service —
+// verified, not created here. Idempotent.
 func (r *ThreadSubscriptionRepo) EnsureIndexes(ctx context.Context) error {
 	// thread_subscriptions.{threadRoomId,userAccount} (unique) is owned by room-service; verify + warn only, never create.
 	mongoutil.WarnMissingIndexes(ctx, r.subs.Raw(), "threadRoomId_1_userAccount_1")

--- a/inbox-worker/integration_test.go
+++ b/inbox-worker/integration_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
-	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/stream"
@@ -1216,43 +1215,6 @@ func TestIntegration_HandleRoomVisibilityChanged(t *testing.T) {
 	assert.Equal(t, []model.Role{model.RoleOwner}, rolesByAccount["bob"], "bob should be owner")
 	assert.Equal(t, []model.Role{model.RoleMember}, rolesByAccount["alice"], "alice should be member")
 	assert.Equal(t, []model.Role{model.RoleMember}, rolesByAccount["carol"], "carol should be member")
-}
-
-// ensureIndexes must standardize on (threadRoomId, userAccount) — the same
-// natural key room-service, message-worker, and history-service create — and
-// drop the legacy (threadRoomId, userId) index that message-worker explicitly
-// removes. Otherwise the two services thrash the index across restarts and the
-// collection ends up with two conflicting unique constraints.
-func TestInboxStore_EnsureIndexes_DropsLegacyAndCreatesUserAccount_Integration(t *testing.T) {
-	db := setupMongo(t)
-	ctx := context.Background()
-	threadSubs := db.Collection("thread_subscriptions")
-	store := &mongoInboxStore{threadSubCol: threadSubs}
-
-	// Simulate a DB where the legacy index already exists (older inbox-worker).
-	_, err := threadSubs.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys:    bson.D{{Key: "threadRoomId", Value: 1}, {Key: "userId", Value: 1}},
-		Options: options.Index().SetUnique(true),
-	})
-	require.NoError(t, err)
-
-	require.NoError(t, store.ensureIndexes(ctx))
-
-	cur, err := threadSubs.Indexes().List(ctx)
-	require.NoError(t, err)
-	var idxs []bson.M
-	require.NoError(t, cur.All(ctx, &idxs))
-
-	names := make(map[string]bool, len(idxs))
-	for _, ix := range idxs {
-		if n, ok := ix["name"].(string); ok {
-			names[n] = true
-		}
-	}
-	assert.True(t, names["threadRoomId_1_userAccount_1"],
-		"ensureIndexes must create the canonical (threadRoomId, userAccount) unique index")
-	assert.False(t, names["threadRoomId_1_userId_1"],
-		"ensureIndexes must drop the legacy (threadRoomId, userId) index")
 }
 
 // Regression: a federated upsert for an existing (threadRoomId, userAccount)

--- a/inbox-worker/integration_test.go
+++ b/inbox-worker/integration_test.go
@@ -434,7 +434,7 @@ func TestInboxWorker_ThreadSubscriptionUpserted_Insert_Integration(t *testing.T)
 		userCol:      db.Collection("users"),
 		threadSubCol: db.Collection("thread_subscriptions"),
 	}
-	require.NoError(t, store.ensureIndexes(ctx))
+	store.ensureIndexes(ctx)
 
 	handler := NewHandler(store)
 
@@ -483,7 +483,7 @@ func TestInboxWorker_ThreadSubscription_DedupByUserAccount_Integration(t *testin
 		userCol:      db.Collection("users"),
 		threadSubCol: db.Collection("thread_subscriptions"),
 	}
-	require.NoError(t, store.ensureIndexes(ctx))
+	store.ensureIndexes(ctx)
 
 	now := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
 	first := model.ThreadSubscription{
@@ -520,7 +520,7 @@ func TestInboxWorker_ThreadSubscriptionUpserted_MonotonicMention_Integration(t *
 		userCol:      db.Collection("users"),
 		threadSubCol: db.Collection("thread_subscriptions"),
 	}
-	require.NoError(t, store.ensureIndexes(ctx))
+	store.ensureIndexes(ctx)
 
 	handler := NewHandler(store)
 	now := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
@@ -1229,7 +1229,7 @@ func TestInboxStore_UpsertThreadSubscription_DedupesByUserAccount_Integration(t 
 	ctx := context.Background()
 	threadSubs := db.Collection("thread_subscriptions")
 	store := &mongoInboxStore{threadSubCol: threadSubs}
-	require.NoError(t, store.ensureIndexes(ctx))
+	store.ensureIndexes(ctx)
 
 	now := time.Now().UTC().Truncate(time.Millisecond)
 

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -455,25 +455,13 @@ func (s *mongoInboxStore) UpdateSubscriptionRead(ctx context.Context, roomID, ac
 	return true, len(out.ThreadUnread), nil
 }
 
-// ensureIndexes creates the unique index on (threadRoomId, userAccount) used by
-// UpsertThreadSubscription. The shape matches what room-service, message-worker,
-// and history-service create so every service that touches thread_subscriptions
-// agrees on the natural key. userAccount is the stable cross-site identity;
-// userId is site-local, so keying on it would let federated upserts miss
-// existing documents and collide on this unique index.
+// ensureIndexes verifies the thread_subscriptions (threadRoomId, userAccount)
+// unique index that UpsertThreadSubscription relies on. The index is owned by
+// room-service (which also drops the legacy threadRoomId_1_userId_1 index); this
+// worker only warns if it is missing, never creates it — a divergent spec would
+// crashloop the shared collection, and a missing index must not take the worker down.
 func (s *mongoInboxStore) ensureIndexes(ctx context.Context) error {
-	// Best-effort: drop the legacy (threadRoomId, userId) unique index so the
-	// (threadRoomId, userAccount) index can be created without a key conflict.
-	// Mirrors message-worker's threadStoreMongo.EnsureIndexes; the index may not
-	// exist (fresh deploy / test container), so ignore all errors.
-	_ = s.threadSubCol.Indexes().DropOne(ctx, "threadRoomId_1_userId_1") //nolint:errcheck
-
-	if _, err := s.threadSubCol.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys:    bson.D{{Key: "threadRoomId", Value: 1}, {Key: "userAccount", Value: 1}},
-		Options: options.Index().SetUnique(true),
-	}); err != nil {
-		return fmt.Errorf("ensure thread_subscriptions (threadRoomId,userAccount) index: %w", err)
-	}
+	mongoutil.WarnMissingIndexes(ctx, s.threadSubCol, "threadRoomId_1_userAccount_1")
 	return nil
 }
 
@@ -700,8 +688,7 @@ func main() {
 		threadSubCol: db.Collection("thread_subscriptions"),
 	}
 	if err := store.ensureIndexes(ctx); err != nil {
-		slog.Error("ensure indexes failed", "error", err)
-		os.Exit(1)
+		slog.Warn("ensure indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 
 	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -460,9 +460,8 @@ func (s *mongoInboxStore) UpdateSubscriptionRead(ctx context.Context, roomID, ac
 // room-service (which also drops the legacy threadRoomId_1_userId_1 index); this
 // worker only warns if it is missing, never creates it — a divergent spec would
 // crashloop the shared collection, and a missing index must not take the worker down.
-func (s *mongoInboxStore) ensureIndexes(ctx context.Context) error {
+func (s *mongoInboxStore) ensureIndexes(ctx context.Context) {
 	mongoutil.WarnMissingIndexes(ctx, s.threadSubCol, "threadRoomId_1_userAccount_1")
-	return nil
 }
 
 // UpsertThreadSubscription inserts the subscription on first event for a
@@ -687,9 +686,7 @@ func main() {
 		userCol:      db.Collection("users"),
 		threadSubCol: db.Collection("thread_subscriptions"),
 	}
-	if err := store.ensureIndexes(ctx); err != nil {
-		slog.Warn("ensure indexes failed; continuing (indexes are best-effort)", "error", err)
-	}
+	store.ensureIndexes(ctx)
 
 	nc, err := natsutil.Connect(ctx, cfg.NatsURL, cfg.NatsCredsFile, sdk.TracerProvider(), sdk.Propagator, sdk.Toggles.Trace)
 	if err != nil {

--- a/media-service/main.go
+++ b/media-service/main.go
@@ -62,7 +62,7 @@ func run() error {
 	defer mongoutil.Disconnect(ctx, mongoClient)
 
 	if err := store.EnsureEmojiIndexes(ctx); err != nil {
-		return fmt.Errorf("ensure emoji indexes: %w", err)
+		slog.Warn("ensure emoji indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 
 	minioClient, err := minioutil.Connect(ctx, cfg.MinioEndpoint, cfg.MinioUseSSL, cfg.MinioAccessKey, cfg.MinioSecretKey, minioutil.WithObservability(sdk))

--- a/media-service/store_mongo.go
+++ b/media-service/store_mongo.go
@@ -10,6 +10,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/mongoutil"
 )
 
 type mongoStore struct {
@@ -126,11 +127,10 @@ func (s *mongoStore) SetBotAvatar(ctx context.Context, av *model.Avatar) error {
 // EnsureEmojiIndexes creates the (siteId, shortcode) unique index; idempotent.
 // media-service is the sole owner of the custom_emojis collection.
 func (s *mongoStore) EnsureEmojiIndexes(ctx context.Context) error {
-	_, err := s.customEmojis.Indexes().CreateOne(ctx, mongo.IndexModel{
+	if err := mongoutil.EnsureIndexWithRepair(ctx, s.customEmojis, mongo.IndexModel{
 		Keys:    bson.D{{Key: "siteId", Value: 1}, {Key: "shortcode", Value: 1}},
 		Options: options.Index().SetUnique(true).SetName("siteId_shortcode_unique"),
-	})
-	if err != nil {
+	}); err != nil {
 		return fmt.Errorf("ensure custom_emojis indexes: %w", err)
 	}
 	return nil

--- a/message-worker/integration_test.go
+++ b/message-worker/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/hmchangw/chat/pkg/atrest"
 	"github.com/hmchangw/chat/pkg/model"
@@ -883,6 +884,14 @@ func TestThreadStoreMongo_InsertThreadSubscription(t *testing.T) {
 	db := setupMongo(t)
 	store := newThreadStoreMongo(db)
 	require.NoError(t, store.EnsureIndexes(ctx))
+
+	// thread_subscriptions unique key is owned by room-service; create it here so
+	// the duplicate-insert path is exercised.
+	_, err := db.Collection("thread_subscriptions").Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys:    bson.D{{Key: "threadRoomId", Value: 1}, {Key: "userAccount", Value: 1}},
+		Options: options.Index().SetUnique(true),
+	})
+	require.NoError(t, err)
 
 	now := time.Now().UTC().Truncate(time.Millisecond)
 	sub := &model.ThreadSubscription{

--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -150,8 +150,7 @@ func main() {
 	store := NewCassandraStore(cassSession, bucketSizer, cipher)
 	threadStore := newThreadStoreMongo(db)
 	if err := threadStore.EnsureIndexes(ctx); err != nil {
-		slog.Error("ensure thread store indexes failed", "error", err)
-		os.Exit(1)
+		slog.Warn("ensure thread store indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 	handler := NewHandler(store, us, threadStore, cfg.SiteID, func(ctx context.Context, subj string, data []byte, msgID string) error {
 		// NewMsg re-stamps X-Request-ID and X-Debug from ctx so correlation and

--- a/message-worker/store_mongo.go
+++ b/message-worker/store_mongo.go
@@ -11,6 +11,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/mongoutil"
 )
 
 var (
@@ -44,17 +45,9 @@ func (s *threadStoreMongo) EnsureIndexes(ctx context.Context) error {
 		return fmt.Errorf("ensure thread_rooms parentMessageId index: %w", err)
 	}
 
-	// Best-effort: drop the legacy (threadRoomId, userId) unique index so the new
-	// (threadRoomId, userAccount) index can be created without a key conflict.
-	// The collection or index may not exist (fresh deploy / test container) — ignore all errors.
-	_ = s.threadSubscriptions.Indexes().DropOne(ctx, "threadRoomId_1_userId_1") //nolint:errcheck
-
-	if _, err := s.threadSubscriptions.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys:    bson.D{{Key: "threadRoomId", Value: 1}, {Key: "userAccount", Value: 1}},
-		Options: options.Index().SetUnique(true),
-	}); err != nil {
-		return fmt.Errorf("ensure thread_subscriptions (threadRoomId,userAccount) index: %w", err)
-	}
+	// thread_subscriptions.{threadRoomId,userAccount} (unique) is owned by room-service
+	// (which also drops the legacy threadRoomId_1_userId_1 index); verify + warn only, never create.
+	mongoutil.WarnMissingIndexes(ctx, s.threadSubscriptions, "threadRoomId_1_userAccount_1")
 
 	return nil
 }

--- a/message-worker/store_mongo.go
+++ b/message-worker/store_mongo.go
@@ -38,7 +38,7 @@ func newThreadStoreMongo(db *mongo.Database) *threadStoreMongo {
 
 // EnsureIndexes creates the unique indexes required by the thread store.
 func (s *threadStoreMongo) EnsureIndexes(ctx context.Context) error {
-	if _, err := s.threadRooms.Indexes().CreateOne(ctx, mongo.IndexModel{
+	if err := mongoutil.EnsureIndexWithRepair(ctx, s.threadRooms, mongo.IndexModel{
 		Keys:    bson.D{{Key: "parentMessageId", Value: 1}},
 		Options: options.Index().SetUnique(true),
 	}); err != nil {

--- a/pkg/mongoutil/indexes.go
+++ b/pkg/mongoutil/indexes.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -43,40 +44,54 @@ func WarnMissingIndexes(ctx context.Context, coll *mongo.Collection, names ...st
 	}
 }
 
+// indexRestoreTimeout bounds the best-effort restore of the old index after a
+// failed repair, on a context detached from the (possibly already-expired) caller.
+const indexRestoreTimeout = 10 * time.Second
+
 // EnsureIndexWithRepair creates model on coll and self-heals a pre-existing index
 // with the SAME keys but a conflicting spec (e.g. a non-unique index where model
 // is unique): it drops the conflicting index and recreates it from model.
 //
 // If the recreate fails — typically E11000 when the DATA holds duplicate values a
-// unique index can't be built over — the old index is restored so the collection
-// is never left without one, and the E11000 is returned so the caller can surface
-// the dedupe-preflight guidance.
+// unique index can't be built over — the old index is restored faithfully (its
+// full spec, under a fresh context since the caller's may be the one that just
+// expired) so the collection is never left without one, and the error is returned
+// so the caller can surface the dedupe-preflight guidance.
+//
+// ponytail: concurrent repair across replicas on the same dirty index is narrowed
+// (a retry before the destructive drop skips it once a peer has repaired, and a
+// drop of an already-absent index is tolerated) but not fully serialized — a
+// distributed lock is deliberately avoided for a one-time startup convergence; the
+// write-gating follow-up closes the residual window.
 func EnsureIndexWithRepair(ctx context.Context, coll *mongo.Collection, model mongo.IndexModel) error {
-	_, err := coll.Indexes().CreateOne(ctx, model)
-	if err == nil || !isIndexSpecConflict(err) {
+	if _, err := coll.Indexes().CreateOne(ctx, model); err == nil || !isIndexSpecConflict(err) {
 		return err
 	}
-	name := indexNameByKeys(ctx, coll, model.Keys)
-	if name == "" {
-		return err // can't identify the conflicting index; surface the original error
+	// A peer replica may have repaired it since the first attempt — retry before the
+	// destructive drop so we never drop a peer's freshly created correct index.
+	if _, err := coll.Indexes().CreateOne(ctx, model); err == nil || !isIndexSpecConflict(err) {
+		return err
 	}
-	// Best-effort: a peer replica may have already dropped it — the recreate below
-	// is the real check.
-	_ = coll.Indexes().DropOne(ctx, name) //nolint:errcheck
+	old := existingIndexByKeys(ctx, coll, model.Keys)
+	if old.name == "" {
+		return fmt.Errorf("repair index on %s: conflicting index not found", coll.Name())
+	}
+	if err := coll.Indexes().DropOne(ctx, old.name); err != nil && !IsIndexNotFound(err) {
+		return fmt.Errorf("repair index %q on %s: drop conflicting index: %w", old.name, coll.Name(), err)
+	}
 	if _, cerr := coll.Indexes().CreateOne(ctx, model); cerr != nil {
-		// Recreate failed (e.g. E11000: duplicate values block a unique index).
-		// Restore the old index so the collection is never left without one; the
-		// returned error still carries the cause so the caller surfaces its guidance.
-		if _, rerr := coll.Indexes().CreateOne(ctx, mongo.IndexModel{
-			Keys: model.Keys, Options: options.Index().SetName(name),
-		}); rerr != nil {
+		// Restore the old index — its full spec, on a fresh context — so the
+		// collection keeps an index; the returned error still carries the cause.
+		restoreCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), indexRestoreTimeout)
+		defer cancel()
+		if _, rerr := coll.Indexes().CreateOne(restoreCtx, old.model()); rerr != nil {
 			slog.WarnContext(ctx, "mongo: index repair failed and the old index could not be restored",
-				"collection", coll.Name(), "index", name, "error", rerr)
+				"collection", coll.Name(), "index", old.name, "error", rerr)
 		}
-		return fmt.Errorf("repair index %q on %s: %w", name, coll.Name(), cerr)
+		return fmt.Errorf("repair index %q on %s: %w", old.name, coll.Name(), cerr)
 	}
 	slog.WarnContext(ctx, "mongo: repaired a conflicting index (dropped and recreated to the expected spec)",
-		"collection", coll.Name(), "droppedIndex", name)
+		"collection", coll.Name(), "droppedIndex", old.name)
 	return nil
 }
 
@@ -87,16 +102,57 @@ func isIndexSpecConflict(err error) bool {
 	return errors.As(err, &se) && (se.HasErrorCode(85) || se.HasErrorCode(86))
 }
 
-// indexNameByKeys returns the name of the existing index on coll whose key spec
-// matches keys (order-sensitive), or "" if none/unreadable.
-func indexNameByKeys(ctx context.Context, coll *mongo.Collection, keys any) string {
+// IsIndexNotFound reports whether err is Mongo's IndexNotFound (27), so dropping an
+// index a peer already removed is not treated as a failure.
+func IsIndexNotFound(err error) bool {
+	var se mongo.ServerError
+	return errors.As(err, &se) && se.HasErrorCode(27)
+}
+
+// existingIndex is a pre-existing index captured for a faithful restore.
+type existingIndex struct {
+	name string
+	keys bson.D
+	spec bson.M
+}
+
+// model reconstructs an IndexModel reproducing the captured index, preserving the
+// correctness-relevant options (unique, sparse, hidden, TTL, partial filter) so a
+// restore never silently weakens the constraint. Collation is not reconstructed —
+// no repaired index in this repo uses it.
+func (e existingIndex) model() mongo.IndexModel {
+	opts := options.Index().SetName(e.name)
+	if v, _ := e.spec["unique"].(bool); v {
+		opts = opts.SetUnique(true)
+	}
+	if v, _ := e.spec["sparse"].(bool); v {
+		opts = opts.SetSparse(true)
+	}
+	if v, _ := e.spec["hidden"].(bool); v {
+		opts = opts.SetHidden(true)
+	}
+	switch v := e.spec["expireAfterSeconds"].(type) {
+	case int32:
+		opts = opts.SetExpireAfterSeconds(v)
+	case int64:
+		opts = opts.SetExpireAfterSeconds(int32(v))
+	}
+	if v, ok := e.spec["partialFilterExpression"]; ok {
+		opts = opts.SetPartialFilterExpression(v)
+	}
+	return mongo.IndexModel{Keys: e.keys, Options: opts}
+}
+
+// existingIndexByKeys returns the index on coll whose key spec matches keys
+// (order-sensitive), captured for restore, or a zero value if none/unreadable.
+func existingIndexByKeys(ctx context.Context, coll *mongo.Collection, keys any) existingIndex {
 	want := keySpec(keys)
 	if want == "" {
-		return ""
+		return existingIndex{}
 	}
 	cur, err := coll.Indexes().List(ctx)
 	if err != nil {
-		return ""
+		return existingIndex{}
 	}
 	defer func() { _ = cur.Close(ctx) }()
 	for cur.Next(ctx) {
@@ -104,11 +160,14 @@ func indexNameByKeys(ctx context.Context, coll *mongo.Collection, keys any) stri
 			Name string `bson:"name"`
 			Key  bson.D `bson:"key"`
 		}
-		if cur.Decode(&idx) == nil && keySpec(idx.Key) == want {
-			return idx.Name
+		if cur.Decode(&idx) != nil || keySpec(idx.Key) != want {
+			continue
 		}
+		var spec bson.M
+		_ = bson.Unmarshal(cur.Current, &spec)
+		return existingIndex{name: idx.Name, keys: idx.Key, spec: spec}
 	}
-	return ""
+	return existingIndex{}
 }
 
 // keySpec renders an index key document as "field:dir,..." preserving order, so

--- a/pkg/mongoutil/indexes.go
+++ b/pkg/mongoutil/indexes.go
@@ -1,0 +1,41 @@
+package mongoutil
+
+import (
+	"context"
+	"log/slog"
+
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// WarnMissingIndexes logs a warning for each named index absent from coll and
+// never returns an error. It is for services that DEPEND on an index another
+// service owns: a dependent must not create the shared index (a divergent spec
+// crashloops whichever service starts second) nor die when the owner has not
+// built it yet. names are the owner's resolved index names (e.g. "account_1",
+// "assistant_name_idx"); a name that drifts from the owner's spec only costs a
+// spurious warning, never a failure.
+func WarnMissingIndexes(ctx context.Context, coll *mongo.Collection, names ...string) {
+	cur, err := coll.Indexes().List(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "mongo: cannot list indexes to verify dependencies",
+			"collection", coll.Name(), "error", err)
+		return
+	}
+	defer func() { _ = cur.Close(ctx) }()
+
+	have := make(map[string]bool)
+	for cur.Next(ctx) {
+		var idx struct {
+			Name string `bson:"name"`
+		}
+		if err := cur.Decode(&idx); err == nil {
+			have[idx.Name] = true
+		}
+	}
+	for _, n := range names {
+		if !have[n] {
+			slog.WarnContext(ctx, "mongo: depended-on index missing; its owner service must create it",
+				"collection", coll.Name(), "index", n)
+		}
+	}
+}

--- a/pkg/mongoutil/indexes.go
+++ b/pkg/mongoutil/indexes.go
@@ -2,8 +2,12 @@ package mongoutil
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
+	"strings"
 
+	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
@@ -38,4 +42,82 @@ func WarnMissingIndexes(ctx context.Context, coll *mongo.Collection, names ...st
 				"collection", coll.Name(), "index", n)
 		}
 	}
+}
+
+// EnsureIndexWithRepair creates model on coll and self-heals a pre-existing index
+// that has the SAME keys but a conflicting spec/options — e.g. a non-unique index
+// where model is unique (the IndexOptionsConflict/IndexKeySpecsConflict, codes
+// 85/86, that used to crashloop the service). On that conflict it drops the
+// conflicting index and recreates it from model, so an environment carrying the
+// old wrong index converges to the expected spec on startup.
+//
+// A duplicate-key error (E11000: the DATA holds duplicate values) is returned
+// unchanged — dropping an index cannot fix duplicate data, and recreating a
+// unique index over it would fail the same way; the caller surfaces the
+// dedupe-preflight guidance. The drop+recreate runs at startup before the service
+// serves traffic; the drop is best-effort so a concurrent replica that already
+// dropped the index doesn't abort the repair.
+func EnsureIndexWithRepair(ctx context.Context, coll *mongo.Collection, model mongo.IndexModel) error {
+	_, err := coll.Indexes().CreateOne(ctx, model)
+	if err == nil || !isIndexSpecConflict(err) {
+		return err
+	}
+	name := indexNameByKeys(ctx, coll, model.Keys)
+	if name == "" {
+		return err // can't identify the conflicting index; surface the original error
+	}
+	// Best-effort: a peer replica may have already dropped it — the recreate below
+	// is the real check.
+	_ = coll.Indexes().DropOne(ctx, name) //nolint:errcheck
+	if _, cerr := coll.Indexes().CreateOne(ctx, model); cerr != nil {
+		return fmt.Errorf("repair index %q on %s: %w", name, coll.Name(), cerr)
+	}
+	slog.WarnContext(ctx, "mongo: repaired a conflicting index (dropped and recreated to the expected spec)",
+		"collection", coll.Name(), "droppedIndex", name)
+	return nil
+}
+
+// isIndexSpecConflict reports whether err is Mongo's IndexOptionsConflict (85) or
+// IndexKeySpecsConflict (86) — a same-keys index that differs in options or name.
+func isIndexSpecConflict(err error) bool {
+	var se mongo.ServerError
+	return errors.As(err, &se) && (se.HasErrorCode(85) || se.HasErrorCode(86))
+}
+
+// indexNameByKeys returns the name of the existing index on coll whose key spec
+// matches keys (order-sensitive), or "" if none/unreadable.
+func indexNameByKeys(ctx context.Context, coll *mongo.Collection, keys any) string {
+	want := keySpec(keys)
+	if want == "" {
+		return ""
+	}
+	cur, err := coll.Indexes().List(ctx)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = cur.Close(ctx) }()
+	for cur.Next(ctx) {
+		var idx struct {
+			Name string `bson:"name"`
+			Key  bson.D `bson:"key"`
+		}
+		if cur.Decode(&idx) == nil && keySpec(idx.Key) == want {
+			return idx.Name
+		}
+	}
+	return ""
+}
+
+// keySpec renders an index key document as "field:dir,..." preserving order, so
+// two key specs compare equal iff they are the same compound index.
+func keySpec(keys any) string {
+	d, ok := keys.(bson.D)
+	if !ok {
+		return ""
+	}
+	parts := make([]string, 0, len(d))
+	for _, e := range d {
+		parts = append(parts, fmt.Sprintf("%s:%v", e.Key, e.Value))
+	}
+	return strings.Join(parts, ",")
 }

--- a/pkg/mongoutil/indexes.go
+++ b/pkg/mongoutil/indexes.go
@@ -9,15 +9,14 @@ import (
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
-// WarnMissingIndexes logs a warning for each named index absent from coll and
-// never returns an error. It is for services that DEPEND on an index another
-// service owns: a dependent must not create the shared index (a divergent spec
-// crashloops whichever service starts second) nor die when the owner has not
-// built it yet. names are the owner's resolved index names (e.g. "account_1",
-// "assistant_name_idx"); a name that drifts from the owner's spec only costs a
-// spurious warning, never a failure.
+// WarnMissingIndexes warns (never errors) for each named index absent from coll.
+// For a service that DEPENDS on an index another owns: creating the shared index
+// with a divergent spec crashloops whichever service starts second, and a
+// not-yet-built index must not take the dependent down. names are the owner's
+// resolved names (e.g. "account_1").
 func WarnMissingIndexes(ctx context.Context, coll *mongo.Collection, names ...string) {
 	cur, err := coll.Indexes().List(ctx)
 	if err != nil {
@@ -45,18 +44,13 @@ func WarnMissingIndexes(ctx context.Context, coll *mongo.Collection, names ...st
 }
 
 // EnsureIndexWithRepair creates model on coll and self-heals a pre-existing index
-// that has the SAME keys but a conflicting spec/options — e.g. a non-unique index
-// where model is unique (the IndexOptionsConflict/IndexKeySpecsConflict, codes
-// 85/86, that used to crashloop the service). On that conflict it drops the
-// conflicting index and recreates it from model, so an environment carrying the
-// old wrong index converges to the expected spec on startup.
+// with the SAME keys but a conflicting spec (e.g. a non-unique index where model
+// is unique): it drops the conflicting index and recreates it from model.
 //
-// A duplicate-key error (E11000: the DATA holds duplicate values) is returned
-// unchanged — dropping an index cannot fix duplicate data, and recreating a
-// unique index over it would fail the same way; the caller surfaces the
-// dedupe-preflight guidance. The drop+recreate runs at startup before the service
-// serves traffic; the drop is best-effort so a concurrent replica that already
-// dropped the index doesn't abort the repair.
+// If the recreate fails — typically E11000 when the DATA holds duplicate values a
+// unique index can't be built over — the old index is restored so the collection
+// is never left without one, and the E11000 is returned so the caller can surface
+// the dedupe-preflight guidance.
 func EnsureIndexWithRepair(ctx context.Context, coll *mongo.Collection, model mongo.IndexModel) error {
 	_, err := coll.Indexes().CreateOne(ctx, model)
 	if err == nil || !isIndexSpecConflict(err) {
@@ -70,6 +64,15 @@ func EnsureIndexWithRepair(ctx context.Context, coll *mongo.Collection, model mo
 	// is the real check.
 	_ = coll.Indexes().DropOne(ctx, name) //nolint:errcheck
 	if _, cerr := coll.Indexes().CreateOne(ctx, model); cerr != nil {
+		// Recreate failed (e.g. E11000: duplicate values block a unique index).
+		// Restore the old index so the collection is never left without one; the
+		// returned error still carries the cause so the caller surfaces its guidance.
+		if _, rerr := coll.Indexes().CreateOne(ctx, mongo.IndexModel{
+			Keys: model.Keys, Options: options.Index().SetName(name),
+		}); rerr != nil {
+			slog.WarnContext(ctx, "mongo: index repair failed and the old index could not be restored",
+				"collection", coll.Name(), "index", name, "error", rerr)
+		}
 		return fmt.Errorf("repair index %q on %s: %w", name, coll.Name(), cerr)
 	}
 	slog.WarnContext(ctx, "mongo: repaired a conflicting index (dropped and recreated to the expected spec)",

--- a/pkg/mongoutil/indexes_integration_test.go
+++ b/pkg/mongoutil/indexes_integration_test.go
@@ -80,6 +80,8 @@ func TestEnsureIndexWithRepair_DirtyDataRestoresOldIndex(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.True(t, mongo.IsDuplicateKeyError(err), "duplicate data must surface E11000")
-	assert.Equal(t, "account_1", indexNameByKeys(ctx, coll, bson.D{{Key: "account", Value: 1}}),
-		"the old account index must be restored, not left dropped")
+	restored := existingIndexByKeys(ctx, coll, bson.D{{Key: "account", Value: 1}})
+	require.Equal(t, "account_1", restored.name, "the old account index must be restored, not left dropped")
+	u, _ := restored.spec["unique"].(bool)
+	assert.False(t, u, "the restored index must faithfully preserve the old (non-unique) spec")
 }

--- a/pkg/mongoutil/indexes_integration_test.go
+++ b/pkg/mongoutil/indexes_integration_test.go
@@ -17,13 +17,7 @@ import (
 
 func repairTestColl(t *testing.T, dbName string) *mongo.Collection {
 	t.Helper()
-	ctx := context.Background()
-	client, err := ConnectRead(ctx, testutil.MongoURI(t), "", "")
-	require.NoError(t, err)
-	t.Cleanup(func() { Disconnect(context.Background(), client) })
-	db := client.Database(dbName)
-	t.Cleanup(func() { _ = db.Drop(context.Background()) })
-	return db.Collection("users")
+	return testutil.MongoDB(t, dbName).Collection("users")
 }
 
 // EnsureIndexWithRepair upgrades a pre-existing non-unique index to the unique
@@ -65,4 +59,27 @@ func TestEnsureIndexWithRepair_DuplicateDataReturnsError(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.True(t, mongo.IsDuplicateKeyError(err), "duplicate data must surface E11000, not be silently repaired")
+}
+
+// The #159 dirty env — a non-unique index AND duplicate data — must not leave the
+// collection index-less: the unique recreate fails E11000, but the old index is
+// restored, and the error still surfaces so the caller shows dedupe guidance.
+func TestEnsureIndexWithRepair_DirtyDataRestoresOldIndex(t *testing.T) {
+	ctx := context.Background()
+	coll := repairTestColl(t, "mongoutil_index_repair_dirty_test")
+
+	_, err := coll.Indexes().CreateOne(ctx, mongo.IndexModel{Keys: bson.D{{Key: "account", Value: 1}}})
+	require.NoError(t, err)
+	_, err = coll.InsertMany(ctx, []any{
+		bson.M{"_id": "a", "account": "dup"}, bson.M{"_id": "b", "account": "dup"},
+	})
+	require.NoError(t, err)
+
+	err = EnsureIndexWithRepair(ctx, coll, mongo.IndexModel{
+		Keys: bson.D{{Key: "account", Value: 1}}, Options: options.Index().SetUnique(true),
+	})
+	require.Error(t, err)
+	assert.True(t, mongo.IsDuplicateKeyError(err), "duplicate data must surface E11000")
+	assert.Equal(t, "account_1", indexNameByKeys(ctx, coll, bson.D{{Key: "account", Value: 1}}),
+		"the old account index must be restored, not left dropped")
 }

--- a/pkg/mongoutil/indexes_integration_test.go
+++ b/pkg/mongoutil/indexes_integration_test.go
@@ -1,0 +1,68 @@
+//go:build integration
+
+package mongoutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/hmchangw/chat/pkg/testutil"
+)
+
+func repairTestColl(t *testing.T, dbName string) *mongo.Collection {
+	t.Helper()
+	ctx := context.Background()
+	client, err := ConnectRead(ctx, testutil.MongoURI(t), "", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { Disconnect(context.Background(), client) })
+	db := client.Database(dbName)
+	t.Cleanup(func() { _ = db.Drop(context.Background()) })
+	return db.Collection("users")
+}
+
+// EnsureIndexWithRepair upgrades a pre-existing non-unique index to the unique
+// spec it should have — the #159 conflict self-heals instead of crashlooping.
+func TestEnsureIndexWithRepair_UpgradesNonUniqueToUnique(t *testing.T) {
+	ctx := context.Background()
+	coll := repairTestColl(t, "mongoutil_index_repair_test")
+	unique := mongo.IndexModel{Keys: bson.D{{Key: "account", Value: 1}}, Options: options.Index().SetUnique(true)}
+
+	// Seed the wrong index: a NON-unique account_1.
+	_, err := coll.Indexes().CreateOne(ctx, mongo.IndexModel{Keys: bson.D{{Key: "account", Value: 1}}})
+	require.NoError(t, err)
+
+	require.NoError(t, EnsureIndexWithRepair(ctx, coll, unique), "a non-unique account_1 must be repaired to unique")
+
+	// Now unique: a duplicate account insert must fail.
+	_, err = coll.InsertOne(ctx, bson.M{"_id": "a", "account": "dup"})
+	require.NoError(t, err)
+	_, err = coll.InsertOne(ctx, bson.M{"_id": "b", "account": "dup"})
+	assert.True(t, mongo.IsDuplicateKeyError(err), "account_1 must be unique after repair")
+
+	// Idempotent: a second call with the correct spec is a no-op.
+	require.NoError(t, EnsureIndexWithRepair(ctx, coll, unique))
+}
+
+// E11000 (duplicate DATA) is not repairable by dropping an index — the error
+// propagates so the caller can surface the dedupe preflight.
+func TestEnsureIndexWithRepair_DuplicateDataReturnsError(t *testing.T) {
+	ctx := context.Background()
+	coll := repairTestColl(t, "mongoutil_index_repair_dup_test")
+
+	_, err := coll.InsertOne(ctx, bson.M{"_id": "a", "account": "dup"})
+	require.NoError(t, err)
+	_, err = coll.InsertOne(ctx, bson.M{"_id": "b", "account": "dup"})
+	require.NoError(t, err)
+
+	err = EnsureIndexWithRepair(ctx, coll, mongo.IndexModel{
+		Keys: bson.D{{Key: "account", Value: 1}}, Options: options.Index().SetUnique(true),
+	})
+	require.Error(t, err)
+	assert.True(t, mongo.IsDuplicateKeyError(err), "duplicate data must surface E11000, not be silently repaired")
+}

--- a/portal-service/main.go
+++ b/portal-service/main.go
@@ -112,7 +112,7 @@ func run() error {
 
 	store := newMongoDirectoryStore(mongoClient.Database(cfg.MongoDB))
 	if err := store.EnsureIndexes(ctx); err != nil {
-		return fmt.Errorf("ensure directory indexes: %w", err)
+		slog.Warn("ensure directory indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 
 	// Populate the directory cache in the background; /readyz stays

--- a/portal-service/store_mongo.go
+++ b/portal-service/store_mongo.go
@@ -8,6 +8,8 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/hmchangw/chat/pkg/mongoutil"
 )
 
 type mongoDirectoryStore struct {
@@ -25,7 +27,7 @@ func newMongoDirectoryStore(db *mongo.Database) *mongoDirectoryStore {
 // EnsureIndexes enforces account uniqueness on hr_employee so a buggy HR cron
 // write fails at insert time instead of publishing two home sites for one account.
 func (s *mongoDirectoryStore) EnsureIndexes(ctx context.Context) error {
-	if _, err := s.employees.Indexes().CreateOne(ctx, mongo.IndexModel{
+	if err := mongoutil.EnsureIndexWithRepair(ctx, s.employees, mongo.IndexModel{
 		Keys:    bson.D{{Key: "account", Value: 1}},
 		Options: options.Index().SetUnique(true),
 	}); err != nil {

--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -4254,63 +4254,38 @@ func TestBotAndAdminPredicate_GoAndMongoAgree_Integration(t *testing.T) {
 	}
 }
 
-// account is a user's identity, so EnsureIndexes makes users.account unique —
-// matching user-service's declaration on the shared collection. A second users
-// doc with the same account must violate the unique index.
-func TestEnsureIndexes_UsersAccountUnique_Integration(t *testing.T) {
-	db := setupMongo(t)
-	store := NewMongoStore(db)
-	ctx := context.Background()
-	require.NoError(t, store.EnsureIndexes(ctx))
-
-	users := db.Collection("users")
-	_, err := users.InsertOne(ctx, bson.M{"_id": "u1", "account": "alice"})
-	require.NoError(t, err)
-	_, err = users.InsertOne(ctx, bson.M{"_id": "u2", "account": "alice"})
-	require.True(t, mongo.IsDuplicateKeyError(err), "expected duplicate-key error, got %v", err)
-}
-
-// Building the users.account unique index against a collection that already holds
-// duplicate accounts (a dirty pre-rollout environment) must fail at startup with
-// an actionable error pointing operators at the dedupe preflight, not a bare
-// driver error.
-func TestEnsureIndexes_UsersAccountUnique_PreexistingDuplicates_Integration(t *testing.T) {
+// room-service owns the thread_subscriptions unique key: EnsureIndexes drops the
+// legacy (threadRoomId, userId) index and creates the canonical (threadRoomId,
+// userAccount) unique index. (The users.account unique index and its
+// operator-guidance errors moved to user-service, which owns the users collection.)
+func TestEnsureIndexes_ThreadSubsDropsLegacyAndCreatesUnique_Integration(t *testing.T) {
 	db := setupMongo(t)
 	store := NewMongoStore(db)
 	ctx := context.Background()
 
-	users := db.Collection("users")
-	_, err := users.InsertOne(ctx, bson.M{"_id": "u1", "account": "alice"})
-	require.NoError(t, err)
-	_, err = users.InsertOne(ctx, bson.M{"_id": "u2", "account": "alice"})
-	require.NoError(t, err)
-
-	err = store.EnsureIndexes(ctx)
-	require.Error(t, err)
-	require.True(t, mongo.IsDuplicateKeyError(err), "expected duplicate-key error, got %v", err)
-	require.Contains(t, err.Error(), "dedupe preflight", "error must direct operators to the dedupe preflight")
-}
-
-// A pre-existing NON-unique account_1 index conflicts with EnsureIndexes'
-// unique account_1 declaration (IndexOptionsConflict 85 / IndexKeySpecsConflict
-// 86 — the latter when the auto-generated name collides). The service must
-// surface an actionable error telling the operator to drop the old index rather
-// than a bare driver error.
-func TestEnsureIndexes_UsersAccountIndexOptionsConflict_Integration(t *testing.T) {
-	db := setupMongo(t)
-	store := NewMongoStore(db)
-	ctx := context.Background()
-
-	// Pre-create a non-unique index named account_1 with the same key spec.
-	_, err := db.Collection("users").Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys: bson.D{{Key: "account", Value: 1}},
+	// Simulate a DB where the legacy index already exists (older worker). The name
+	// is threadRoomId_1_userId_1 regardless of uniqueness, which is what the drop targets.
+	_, err := db.Collection("thread_subscriptions").Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{{Key: "threadRoomId", Value: 1}, {Key: "userId", Value: 1}},
 	})
 	require.NoError(t, err)
 
-	err = store.EnsureIndexes(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "drop the old non-unique account_1 index",
-		"error must direct operators to drop the conflicting non-unique index")
+	require.NoError(t, store.EnsureIndexes(ctx))
+
+	cur, err := db.Collection("thread_subscriptions").Indexes().List(ctx)
+	require.NoError(t, err)
+	var idxs []bson.M
+	require.NoError(t, cur.All(ctx, &idxs))
+	names := make(map[string]bool, len(idxs))
+	for _, ix := range idxs {
+		if n, ok := ix["name"].(string); ok {
+			names[n] = true
+		}
+	}
+	assert.True(t, names["threadRoomId_1_userAccount_1"],
+		"EnsureIndexes must create the canonical (threadRoomId, userAccount) unique index")
+	assert.False(t, names["threadRoomId_1_userId_1"],
+		"EnsureIndexes must drop the legacy (threadRoomId, userId) index")
 }
 
 func TestMongoStore_ClearThreadSubscriptionsForAccount_Integration(t *testing.T) {

--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -4277,13 +4277,18 @@ func TestEnsureIndexes_ThreadSubsDropsLegacyAndCreatesUnique_Integration(t *test
 	var idxs []bson.M
 	require.NoError(t, cur.All(ctx, &idxs))
 	names := make(map[string]bool, len(idxs))
+	unique := make(map[string]bool, len(idxs))
 	for _, ix := range idxs {
 		if n, ok := ix["name"].(string); ok {
 			names[n] = true
+			u, _ := ix["unique"].(bool)
+			unique[n] = u
 		}
 	}
 	assert.True(t, names["threadRoomId_1_userAccount_1"],
-		"EnsureIndexes must create the canonical (threadRoomId, userAccount) unique index")
+		"EnsureIndexes must create the canonical (threadRoomId, userAccount) index")
+	assert.True(t, unique["threadRoomId_1_userAccount_1"],
+		"the (threadRoomId, userAccount) index must be unique")
 	assert.False(t, names["threadRoomId_1_userId_1"],
 		"EnsureIndexes must drop the legacy (threadRoomId, userId) index")
 }

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -206,9 +206,7 @@ func main() {
 	// Bounded timeout so a hung createIndexes surfaces at startup.
 	ensureCtx, ensureCancel := context.WithTimeout(ctx, 30*time.Second)
 	if err := store.EnsureIndexes(ensureCtx); err != nil {
-		ensureCancel()
-		slog.Error("ensure store indexes failed", "error", err)
-		os.Exit(1)
+		slog.Warn("ensure store indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 	ensureCancel()
 

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -109,14 +109,14 @@ func (s *MongoStore) EnsureIndexes(ctx context.Context) error {
 	// ($setOnInsert keyed on (rid, member.type, member.id), see BulkCreateRoomMembers),
 	// so a redelivered or re-requested member.add matches the existing row and no-ops.
 	// Without this constraint a fresh _id per retry would silently insert duplicates.
-	if _, err := s.roomMembers.Indexes().CreateOne(ctx, mongo.IndexModel{
+	if err := mongoutil.EnsureIndexWithRepair(ctx, s.roomMembers, mongo.IndexModel{
 		Keys:    bson.D{{Key: "rid", Value: 1}, {Key: "member.type", Value: 1}, {Key: "member.id", Value: 1}},
 		Options: options.Index().SetUnique(true),
 	}); err != nil {
 		return fmt.Errorf("ensure room_members (rid,member.type,member.id) unique index: %w", err)
 	}
 	// Unique logical key for subscriptions. Same retry-idempotency rationale as room_members above.
-	if _, err := s.subscriptions.Indexes().CreateOne(ctx, mongo.IndexModel{
+	if err := mongoutil.EnsureIndexWithRepair(ctx, s.subscriptions, mongo.IndexModel{
 		Keys:    bson.D{{Key: "roomId", Value: 1}, {Key: "u.account", Value: 1}},
 		Options: options.Index().SetUnique(true),
 	}); err != nil {
@@ -183,7 +183,7 @@ func (s *MongoStore) EnsureIndexes(ctx context.Context) error {
 	// legacy (threadRoomId, userId) index first so (threadRoomId, userAccount) creates
 	// without a key conflict; it may not exist (fresh deploy) — ignore all errors.
 	_ = s.threadSubscriptions.Indexes().DropOne(ctx, "threadRoomId_1_userId_1") //nolint:errcheck
-	if _, err := s.threadSubscriptions.Indexes().CreateOne(ctx, mongo.IndexModel{
+	if err := mongoutil.EnsureIndexWithRepair(ctx, s.threadSubscriptions, mongo.IndexModel{
 		Keys:    bson.D{{Key: "threadRoomId", Value: 1}, {Key: "userAccount", Value: 1}},
 		Options: options.Index().SetUnique(true),
 	}); err != nil {

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -122,30 +122,8 @@ func (s *MongoStore) EnsureIndexes(ctx context.Context) error {
 	}); err != nil {
 		return fmt.Errorf("ensure subscriptions (roomId,u.account) unique index: %w", err)
 	}
-	// Unique: account is a user's identity, so at most one users doc per account.
-	// findUsersForDisplay already folds results into a map keyed by account, and
-	// user-service declares this index unique on the shared collection — both must
-	// agree or the second service's CreateOne hits IndexOptionsConflict.
-	if _, err := s.users.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys:    bson.D{{Key: "account", Value: 1}},
-		Options: options.Index().SetUnique(true),
-	}); err != nil {
-		// E11000 here means pre-existing duplicate account values (populated env
-		// pre-rollout) — point operators at the one-time dedupe preflight.
-		if mongo.IsDuplicateKeyError(err) {
-			return fmt.Errorf("ensure users (account) unique index: duplicate account values exist in the users "+
-				"collection — run the one-time dedupe preflight (group users by account, resolve n>1) before "+
-				"starting this service: %w", err)
-		}
-		// A pre-existing non-unique account_1 conflicts (85 IndexOptionsConflict /
-		// 86 IndexKeySpecsConflict); Mongo won't upgrade it — the operator must drop it.
-		if se := mongo.ServerError(nil); errors.As(err, &se) && (se.HasErrorCode(85) || se.HasErrorCode(86)) {
-			return fmt.Errorf("ensure users (account) unique index: a non-unique account_1 index already exists on "+
-				"the users collection — drop the old non-unique account_1 index (db.users.dropIndex(\"account_1\")) "+
-				"before starting this service so it can be recreated as unique: %w", err)
-		}
-		return fmt.Errorf("ensure users (account) unique index: %w", err)
-	}
+	// users.account (unique) is owned by user-service; verify + warn only, never create.
+	mongoutil.WarnMissingIndexes(ctx, s.users, "account_1")
 	if _, err := s.users.Indexes().CreateOne(ctx, mongo.IndexModel{
 		Keys: bson.D{{Key: "sectId", Value: 1}, {Key: "account", Value: 1}},
 	}); err != nil {
@@ -156,14 +134,8 @@ func (s *MongoStore) EnsureIndexes(ctx context.Context) error {
 	}); err != nil {
 		return fmt.Errorf("ensure users (deptId,account) index: %w", err)
 	}
-	// Lookup index for botDM creation: GetApp filters by assistant.name.
-	appsIndex := mongo.IndexModel{
-		Keys:    bson.D{{Key: "assistant.name", Value: 1}},
-		Options: options.Index().SetName("assistant_name_idx"),
-	}
-	if _, err := s.apps.Indexes().CreateOne(ctx, appsIndex); err != nil {
-		return fmt.Errorf("ensure apps index: %w", err)
-	}
+	// apps.assistant_name_idx is owned by user-service; verify + warn only, never create.
+	mongoutil.WarnMissingIndexes(ctx, s.apps, "assistant_name_idx")
 	if _, err := s.subscriptions.Indexes().CreateOne(ctx, mongo.IndexModel{
 		Keys: bson.D{{Key: "roomId", Value: 1}, {Key: "lastSeenAt", Value: 1}},
 	}); err != nil {
@@ -207,7 +179,10 @@ func (s *MongoStore) EnsureIndexes(ctx context.Context) error {
 	}); err != nil {
 		return fmt.Errorf("ensure subscriptions (roomId,roles) index: %w", err)
 	}
-	// Mirrors the unique index created by message-worker / history-service so per-service test DBs also enforce it.
+	// room-service owns the thread_subscriptions unique key. Best-effort drop of the
+	// legacy (threadRoomId, userId) index first so (threadRoomId, userAccount) creates
+	// without a key conflict; it may not exist (fresh deploy) — ignore all errors.
+	_ = s.threadSubscriptions.Indexes().DropOne(ctx, "threadRoomId_1_userId_1") //nolint:errcheck
 	if _, err := s.threadSubscriptions.Indexes().CreateOne(ctx, mongo.IndexModel{
 		Keys:    bson.D{{Key: "threadRoomId", Value: 1}, {Key: "userAccount", Value: 1}},
 		Options: options.Index().SetUnique(true),

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -146,7 +146,9 @@ func (s *MongoStore) EnsureIndexes(ctx context.Context) error {
 	// room-service owns the thread_subscriptions unique key. Best-effort legacy
 	// (threadRoomId, userId) drop first so the userAccount index creates without a
 	// key conflict; it may not exist (fresh deploy) — ignore all errors.
-	_ = s.threadSubscriptions.Indexes().DropOne(ctx, "threadRoomId_1_userId_1") //nolint:errcheck
+	if derr := s.threadSubscriptions.Indexes().DropOne(ctx, "threadRoomId_1_userId_1"); derr != nil && !mongoutil.IsIndexNotFound(derr) {
+		errs = append(errs, fmt.Errorf("drop legacy thread_subscriptions (threadRoomId,userId) index: %w", derr))
+	}
 	unique(s.threadSubscriptions, "thread_subscriptions (threadRoomId,userAccount)",
 		bson.D{{Key: "threadRoomId", Value: 1}, {Key: "userAccount", Value: 1}})
 	create(s.threadSubscriptions, "thread_subscriptions (parentMessageId,userAccount)",

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -229,7 +229,7 @@ func (s *MongoStore) EnsureIndexes(ctx context.Context) error {
 	// loser reads back the winner's record instead of inserting a duplicate (and
 	// thus publishing a second teams_meet_started system message). Same retry-safe
 	// rationale as the room_members / subscriptions unique indexes above.
-	if _, err := s.teamsMeetings.Indexes().CreateOne(ctx, mongo.IndexModel{
+	if err := mongoutil.EnsureIndexWithRepair(ctx, s.teamsMeetings, mongo.IndexModel{
 		Keys:    bson.D{{Key: "roomId", Value: 1}, {Key: "siteId", Value: 1}},
 		Options: options.Index().SetUnique(true),
 	}); err != nil {

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -100,142 +100,71 @@ func NewMongoStore(db *mongo.Database, opts ...StoreOption) *MongoStore {
 // Must be invoked once at startup. Mongo treats index creation as idempotent
 // when the key spec and options match.
 func (s *MongoStore) EnsureIndexes(ctx context.Context) error {
-	if _, err := s.roomMembers.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys: bson.D{{Key: "rid", Value: 1}},
-	}); err != nil {
-		return fmt.Errorf("ensure room_members (rid) index: %w", err)
+	// Each index is attempted independently; a failure is collected (and surfaced via
+	// the joined return) but never skips the rest — one transient error must not starve
+	// a later unique/correctness index this service solely owns.
+	var errs []error
+	create := func(coll *mongo.Collection, name string, keys bson.D) {
+		if _, err := coll.Indexes().CreateOne(ctx, mongo.IndexModel{Keys: keys}); err != nil {
+			errs = append(errs, fmt.Errorf("ensure %s index: %w", name, err))
+		}
 	}
-	// Unique logical key — room-worker upserts room_members on this key
-	// ($setOnInsert keyed on (rid, member.type, member.id), see BulkCreateRoomMembers),
-	// so a redelivered or re-requested member.add matches the existing row and no-ops.
-	// Without this constraint a fresh _id per retry would silently insert duplicates.
-	if err := mongoutil.EnsureIndexWithRepair(ctx, s.roomMembers, mongo.IndexModel{
-		Keys:    bson.D{{Key: "rid", Value: 1}, {Key: "member.type", Value: 1}, {Key: "member.id", Value: 1}},
-		Options: options.Index().SetUnique(true),
-	}); err != nil {
-		return fmt.Errorf("ensure room_members (rid,member.type,member.id) unique index: %w", err)
+	unique := func(coll *mongo.Collection, name string, keys bson.D) {
+		if err := mongoutil.EnsureIndexWithRepair(ctx, coll,
+			mongo.IndexModel{Keys: keys, Options: options.Index().SetUnique(true)}); err != nil {
+			errs = append(errs, fmt.Errorf("ensure %s unique index: %w", name, err))
+		}
 	}
-	// Unique logical key for subscriptions. Same retry-idempotency rationale as room_members above.
-	if err := mongoutil.EnsureIndexWithRepair(ctx, s.subscriptions, mongo.IndexModel{
-		Keys:    bson.D{{Key: "roomId", Value: 1}, {Key: "u.account", Value: 1}},
-		Options: options.Index().SetUnique(true),
-	}); err != nil {
-		return fmt.Errorf("ensure subscriptions (roomId,u.account) unique index: %w", err)
-	}
-	// users.account (unique) is owned by user-service; verify + warn only, never create.
+
+	create(s.roomMembers, "room_members (rid)", bson.D{{Key: "rid", Value: 1}})
+	// Unique logical key — room-worker upserts room_members with $setOnInsert on
+	// (rid, member.type, member.id), so a redelivered member.add no-ops instead of
+	// inserting a duplicate under a fresh _id.
+	unique(s.roomMembers, "room_members (rid,member.type,member.id)",
+		bson.D{{Key: "rid", Value: 1}, {Key: "member.type", Value: 1}, {Key: "member.id", Value: 1}})
+	// Unique logical key for subscriptions. Same retry-idempotency rationale.
+	unique(s.subscriptions, "subscriptions (roomId,u.account)",
+		bson.D{{Key: "roomId", Value: 1}, {Key: "u.account", Value: 1}})
+	// users.account + apps.assistant_name_idx are owned by user-service; verify + warn only.
 	mongoutil.WarnMissingIndexes(ctx, s.users, "account_1")
-	if _, err := s.users.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys: bson.D{{Key: "sectId", Value: 1}, {Key: "account", Value: 1}},
-	}); err != nil {
-		return fmt.Errorf("ensure users (sectId,account) index: %w", err)
-	}
-	if _, err := s.users.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys: bson.D{{Key: "deptId", Value: 1}, {Key: "account", Value: 1}},
-	}); err != nil {
-		return fmt.Errorf("ensure users (deptId,account) index: %w", err)
-	}
-	// apps.assistant_name_idx is owned by user-service; verify + warn only, never create.
 	mongoutil.WarnMissingIndexes(ctx, s.apps, "assistant_name_idx")
-	if _, err := s.subscriptions.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys: bson.D{{Key: "roomId", Value: 1}, {Key: "lastSeenAt", Value: 1}},
-	}); err != nil {
-		return fmt.Errorf("ensure subscriptions (roomId,lastSeenAt) index: %w", err)
-	}
-	// Backs room-worker's ReconcileMemberCounts, which counts bot vs non-bot
-	// subs per room off u.isBot — keeps both CountDocuments index-only instead
-	// of scanning every subscription in the room.
-	if _, err := s.subscriptions.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys: bson.D{{Key: "roomId", Value: 1}, {Key: "u.isBot", Value: 1}},
-	}); err != nil {
-		return fmt.Errorf("ensure subscriptions (roomId,u.isBot) index: %w", err)
-	}
-	// Lookup index for FindDMSubscription (filters on u.account+name).
-	// Without this index, FindDMSubscription falls back to a collection scan.
-	if _, err := s.subscriptions.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys: bson.D{{Key: "u.account", Value: 1}, {Key: "name", Value: 1}},
-	}); err != nil {
-		return fmt.Errorf("ensure subscriptions (u.account,name) index: %w", err)
-	}
-	// Backs ComputeSectionOrder + section rebalance (filter u.account+sectionId,
-	// sort sectionOrder); without it, section moves fall back to an in-memory sort.
-	if _, err := s.subscriptions.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys: bson.D{{Key: "u.account", Value: 1}, {Key: "sectionId", Value: 1}, {Key: "sectionOrder", Value: 1}},
-	}); err != nil {
-		return fmt.Errorf("ensure subscriptions (u.account,sectionId,sectionOrder) index: %w", err)
-	}
-	// Backs getRoomSubscriptions: filter roomId, sort {joinedAt, _id} with
-	// skip/limit pagination. Including the sort keys lets Mongo return ordered
-	// pages from the index instead of an in-memory sort that risks the 32MB
-	// sort limit on large rooms.
-	if _, err := s.subscriptions.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys: bson.D{{Key: "roomId", Value: 1}, {Key: "joinedAt", Value: 1}, {Key: "_id", Value: 1}},
-	}); err != nil {
-		return fmt.Errorf("ensure subscriptions (roomId,joinedAt,_id) index: %w", err)
-	}
-	// Backs CountOwners (filters on roomId+roles) so owner counts stay
-	// index-only instead of scanning every subscription in the room.
-	if _, err := s.subscriptions.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys: bson.D{{Key: "roomId", Value: 1}, {Key: "roles", Value: 1}},
-	}); err != nil {
-		return fmt.Errorf("ensure subscriptions (roomId,roles) index: %w", err)
-	}
-	// room-service owns the thread_subscriptions unique key. Best-effort drop of the
-	// legacy (threadRoomId, userId) index first so (threadRoomId, userAccount) creates
-	// without a key conflict; it may not exist (fresh deploy) — ignore all errors.
+	create(s.users, "users (sectId,account)", bson.D{{Key: "sectId", Value: 1}, {Key: "account", Value: 1}})
+	create(s.users, "users (deptId,account)", bson.D{{Key: "deptId", Value: 1}, {Key: "account", Value: 1}})
+	create(s.subscriptions, "subscriptions (roomId,lastSeenAt)", bson.D{{Key: "roomId", Value: 1}, {Key: "lastSeenAt", Value: 1}})
+	// Backs ReconcileMemberCounts (bot vs non-bot counts) index-only.
+	create(s.subscriptions, "subscriptions (roomId,u.isBot)", bson.D{{Key: "roomId", Value: 1}, {Key: "u.isBot", Value: 1}})
+	// Lookup for FindDMSubscription (u.account+name); else a collection scan.
+	create(s.subscriptions, "subscriptions (u.account,name)", bson.D{{Key: "u.account", Value: 1}, {Key: "name", Value: 1}})
+	// Backs ComputeSectionOrder + section rebalance (filter u.account+sectionId, sort sectionOrder).
+	create(s.subscriptions, "subscriptions (u.account,sectionId,sectionOrder)",
+		bson.D{{Key: "u.account", Value: 1}, {Key: "sectionId", Value: 1}, {Key: "sectionOrder", Value: 1}})
+	// Backs getRoomSubscriptions paginated {joinedAt,_id} sort from the index (avoids the 32MB sort limit).
+	create(s.subscriptions, "subscriptions (roomId,joinedAt,_id)",
+		bson.D{{Key: "roomId", Value: 1}, {Key: "joinedAt", Value: 1}, {Key: "_id", Value: 1}})
+	// Backs CountOwners (roomId+roles) index-only.
+	create(s.subscriptions, "subscriptions (roomId,roles)", bson.D{{Key: "roomId", Value: 1}, {Key: "roles", Value: 1}})
+	// room-service owns the thread_subscriptions unique key. Best-effort legacy
+	// (threadRoomId, userId) drop first so the userAccount index creates without a
+	// key conflict; it may not exist (fresh deploy) — ignore all errors.
 	_ = s.threadSubscriptions.Indexes().DropOne(ctx, "threadRoomId_1_userId_1") //nolint:errcheck
-	if err := mongoutil.EnsureIndexWithRepair(ctx, s.threadSubscriptions, mongo.IndexModel{
-		Keys:    bson.D{{Key: "threadRoomId", Value: 1}, {Key: "userAccount", Value: 1}},
-		Options: options.Index().SetUnique(true),
-	}); err != nil {
-		return fmt.Errorf("ensure thread_subscriptions (threadRoomId,userAccount) unique index: %w", err)
-	}
-	if _, err := s.threadSubscriptions.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys: bson.D{{Key: "parentMessageId", Value: 1}, {Key: "userAccount", Value: 1}},
-	}); err != nil {
-		return fmt.Errorf("ensure thread_subscriptions (parentMessageId,userAccount) index: %w", err)
-	}
-	// Backs MinThreadSubscriptionLastSeenByThreadRoomID: covered index seek on
-	// (threadRoomId, lastSeenAt ASC) returns the subscriber with the smallest
-	// lastSeenAt in one seek — same algorithm as the (roomId, lastSeenAt) index
-	// on subscriptions that backs MinSubscriptionLastSeenByRoomID.
-	if _, err := s.threadSubscriptions.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys: bson.D{{Key: "threadRoomId", Value: 1}, {Key: "lastSeenAt", Value: 1}},
-	}); err != nil {
-		return fmt.Errorf("ensure thread_subscriptions (threadRoomId,lastSeenAt) index: %w", err)
-	}
-	// Backs per-user, per-site thread_subscriptions lookups on {userAccount,
-	// siteId}. No existing thread_subscriptions index has userAccount as a prefix.
-	if _, err := s.threadSubscriptions.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys: bson.D{{Key: "userAccount", Value: 1}, {Key: "siteId", Value: 1}},
-	}); err != nil {
-		return fmt.Errorf("ensure thread_subscriptions (userAccount,siteId) index: %w", err)
-	}
-	if _, err := s.apps.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys: bson.D{
-			{Key: "channelTab.default", Value: 1},
-			{Key: "channelTab.enabled", Value: 1},
-			{Key: "channelTab.name", Value: 1},
-		},
-	}); err != nil {
-		return fmt.Errorf("ensure apps (channelTab.default,enabled,name) index: %w", err)
-	}
-	if _, err := s.botCmdMenus.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys: bson.D{{Key: "activeStatus", Value: 1}, {Key: "name", Value: 1}},
-	}); err != nil {
-		return fmt.Errorf("ensure bot_cmd_menu (activeStatus,name) index: %w", err)
-	}
-	// Unique logical key for teams_meetings — the per-room idempotency record for
-	// the meetings RPC. A concurrent second create hits this constraint and the
-	// loser reads back the winner's record instead of inserting a duplicate (and
-	// thus publishing a second teams_meet_started system message). Same retry-safe
-	// rationale as the room_members / subscriptions unique indexes above.
-	if err := mongoutil.EnsureIndexWithRepair(ctx, s.teamsMeetings, mongo.IndexModel{
-		Keys:    bson.D{{Key: "roomId", Value: 1}, {Key: "siteId", Value: 1}},
-		Options: options.Index().SetUnique(true),
-	}); err != nil {
-		return fmt.Errorf("ensure teams_meetings (roomId,siteId) unique index: %w", err)
-	}
-	return nil
+	unique(s.threadSubscriptions, "thread_subscriptions (threadRoomId,userAccount)",
+		bson.D{{Key: "threadRoomId", Value: 1}, {Key: "userAccount", Value: 1}})
+	create(s.threadSubscriptions, "thread_subscriptions (parentMessageId,userAccount)",
+		bson.D{{Key: "parentMessageId", Value: 1}, {Key: "userAccount", Value: 1}})
+	// Backs MinThreadSubscriptionLastSeenByThreadRoomID (covered seek on threadRoomId,lastSeenAt).
+	create(s.threadSubscriptions, "thread_subscriptions (threadRoomId,lastSeenAt)",
+		bson.D{{Key: "threadRoomId", Value: 1}, {Key: "lastSeenAt", Value: 1}})
+	// Backs per-user, per-site lookups; no other thread_subscriptions index prefixes userAccount.
+	create(s.threadSubscriptions, "thread_subscriptions (userAccount,siteId)",
+		bson.D{{Key: "userAccount", Value: 1}, {Key: "siteId", Value: 1}})
+	create(s.apps, "apps (channelTab.default,enabled,name)",
+		bson.D{{Key: "channelTab.default", Value: 1}, {Key: "channelTab.enabled", Value: 1}, {Key: "channelTab.name", Value: 1}})
+	create(s.botCmdMenus, "bot_cmd_menu (activeStatus,name)", bson.D{{Key: "activeStatus", Value: 1}, {Key: "name", Value: 1}})
+	// Unique per-room idempotency record for the meetings RPC: a concurrent second
+	// create reads back the winner instead of publishing a duplicate teams_meet_started.
+	unique(s.teamsMeetings, "teams_meetings (roomId,siteId)", bson.D{{Key: "roomId", Value: 1}, {Key: "siteId", Value: 1}})
+
+	return errors.Join(errs...)
 }
 
 // GetTeamsMeeting fast-path reads the room's existing Teams meeting record.

--- a/search-service/main.go
+++ b/search-service/main.go
@@ -215,9 +215,7 @@ func main() {
 
 	ensureCtx, ensureCancel := context.WithTimeout(ctx, 30*time.Second)
 	if err := mongoStore.ensureIndexes(ensureCtx); err != nil {
-		ensureCancel()
-		slog.Error("ensure mongo indexes failed", "error", err)
-		os.Exit(1)
+		slog.Warn("ensure mongo indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 	ensureCancel()
 	handler := newHandler(store, mongoStore, usersClient, cache, &handlerConfig{

--- a/search-service/store_mongo.go
+++ b/search-service/store_mongo.go
@@ -9,6 +9,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/mongoutil"
 )
 
 // mongoStore is the Mongo-backed implementation of MongoStore.
@@ -43,22 +44,10 @@ func (s *mongoStore) ensureIndexes(ctx context.Context) error {
 	}); err != nil {
 		return fmt.Errorf("ensure subscriptions (u.account, roomId) index: %w", err)
 	}
-	// users.account is owned by user-service and is UNIQUE — match that spec so
-	// the shared account_1 index doesn't conflict (a non-unique one collides).
-	if _, err := s.users.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys:    bson.D{{Key: "account", Value: 1}},
-		Options: options.Index().SetUnique(true),
-	}); err != nil {
-		return fmt.Errorf("ensure users (account) index: %w", err)
-	}
-	// apps.assistant.name is owned by user-service with the explicit name
-	// assistant_name_idx — match it (auto-naming here collides on the same keys).
-	if _, err := s.apps.Indexes().CreateOne(ctx, mongo.IndexModel{
-		Keys:    bson.D{{Key: "assistant.name", Value: 1}},
-		Options: options.Index().SetName("assistant_name_idx"),
-	}); err != nil {
-		return fmt.Errorf("ensure apps (assistant.name) index: %w", err)
-	}
+	// users.account (unique) and apps.assistant_name_idx are owned by user-service;
+	// verify + warn only, never create (a divergent spec would crashloop the shared collection).
+	mongoutil.WarnMissingIndexes(ctx, s.users, "account_1")
+	mongoutil.WarnMissingIndexes(ctx, s.apps, "assistant_name_idx")
 	return nil
 }
 

--- a/search-service/store_mongo.go
+++ b/search-service/store_mongo.go
@@ -45,7 +45,7 @@ func (s *mongoStore) ensureIndexes(ctx context.Context) error {
 		return fmt.Errorf("ensure subscriptions (u.account, roomId) index: %w", err)
 	}
 	// users.account (unique) and apps.assistant_name_idx are owned by user-service;
-	// verify + warn only, never create (a divergent spec would crashloop the shared collection).
+	// verify + warn only, never create.
 	mongoutil.WarnMissingIndexes(ctx, s.users, "account_1")
 	mongoutil.WarnMissingIndexes(ctx, s.apps, "assistant_name_idx")
 	return nil

--- a/tcard-service/main.go
+++ b/tcard-service/main.go
@@ -69,7 +69,7 @@ func run() error {
 
 	store := newMongoCardStore(mongoClient.Database(cfg.MongoDB))
 	if err := store.EnsureIndexes(ctx); err != nil {
-		return fmt.Errorf("ensure cards indexes: %w", err)
+		slog.Warn("ensure cards indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 
 	// Populate the card cache in the background; /readyz stays unavailable

--- a/tcard-service/store_mongo.go
+++ b/tcard-service/store_mongo.go
@@ -8,6 +8,8 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/hmchangw/chat/pkg/mongoutil"
 )
 
 type mongoCardStore struct {
@@ -21,7 +23,7 @@ func newMongoCardStore(db *mongo.Database) *mongoCardStore {
 // EnsureIndexes enforces (path, _tcardVersion) uniqueness so two docs can't
 // claim one version. The data-type `version` field is unrelated, not indexed.
 func (s *mongoCardStore) EnsureIndexes(ctx context.Context) error {
-	if _, err := s.cards.Indexes().CreateOne(ctx, mongo.IndexModel{
+	if err := mongoutil.EnsureIndexWithRepair(ctx, s.cards, mongo.IndexModel{
 		Keys:    bson.D{{Key: "path", Value: 1}, {Key: "_tcardVersion", Value: 1}},
 		Options: options.Index().SetUnique(true),
 	}); err != nil {

--- a/teams-chat-sync/main.go
+++ b/teams-chat-sync/main.go
@@ -107,7 +107,7 @@ func run() error {
 
 	store := newMongoStore(mongoClient.Database(cfg.MongoDB))
 	if err := store.EnsureIndexes(ctx); err != nil {
-		return fmt.Errorf("ensure indexes: %w", err)
+		slog.Warn("ensure indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 
 	graph, err := msgraph.NewChatsClient(msgraph.Config{

--- a/user-service/main.go
+++ b/user-service/main.go
@@ -121,24 +121,19 @@ func main() {
 	threadSubRepo := mongorepo.NewThreadSubscriptionRepo(db)
 	ssoTokenRepo := mongorepo.NewSSOTokenRepo(db)
 	if err := subRepo.EnsureIndexes(ctx); err != nil {
-		slog.Error("ensure indexes failed", "error", err)
-		os.Exit(1)
+		slog.Warn("ensure subscription indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 	if err := userRepo.EnsureIndexes(ctx); err != nil {
-		slog.Error("ensure indexes failed", "error", err)
-		os.Exit(1)
+		slog.Warn("ensure user indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 	if err := appRepo.EnsureIndexes(ctx); err != nil {
-		slog.Error("ensure indexes failed", "error", err)
-		os.Exit(1)
+		slog.Warn("ensure app indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 	if err := threadSubRepo.EnsureIndexes(ctx); err != nil {
-		slog.Error("ensure indexes failed", "error", err)
-		os.Exit(1)
+		slog.Warn("ensure thread subscription indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 	if err := ssoTokenRepo.EnsureIndexes(ctx); err != nil {
-		slog.Error("ensure indexes failed", "error", err)
-		os.Exit(1)
+		slog.Warn("ensure sso token indexes failed; continuing (indexes are best-effort)", "error", err)
 	}
 
 	tokenValidator, tokenRefresher, err := oidcValidator(ctx, &cfg)

--- a/user-service/mongorepo/apps.go
+++ b/user-service/mongorepo/apps.go
@@ -64,11 +64,10 @@ func NewAppRepo(db *mongo.Database, opts ...Option) *AppRepo {
 // to avoid IndexOptionsConflict) and the fab_domain_mapping {name, _id} index —
 // compound so it can back the {name:1, _id:1} sort, which a lone {name:1} cannot.
 func (r *AppRepo) EnsureIndexes(ctx context.Context) error {
-	appsIndex := mongo.IndexModel{
+	if err := mongoutil.EnsureIndexWithRepair(ctx, r.apps.Raw(), mongo.IndexModel{
 		Keys:    bson.D{{Key: "assistant.name", Value: 1}},
 		Options: options.Index().SetName("assistant_name_idx"),
-	}
-	if _, err := r.apps.Raw().Indexes().CreateOne(ctx, appsIndex); err != nil {
+	}); err != nil {
 		return fmt.Errorf("ensure apps index: %w", err)
 	}
 	categoryIndex := mongo.IndexModel{

--- a/user-service/mongorepo/apps.go
+++ b/user-service/mongorepo/apps.go
@@ -60,9 +60,9 @@ func NewAppRepo(db *mongo.Database, opts ...Option) *AppRepo {
 	}
 }
 
-// EnsureIndexes creates the assistant.name index (shared name with room-service
-// to avoid IndexOptionsConflict) and the fab_domain_mapping {name, _id} index —
-// compound so it can back the {name:1, _id:1} sort, which a lone {name:1} cannot.
+// EnsureIndexes creates the assistant_name_idx index (user-service owns it) and
+// the fab_domain_mapping {name, _id} index — compound so it can back the
+// {name:1, _id:1} sort, which a lone {name:1} cannot.
 func (r *AppRepo) EnsureIndexes(ctx context.Context) error {
 	if err := mongoutil.EnsureIndexWithRepair(ctx, r.apps.Raw(), mongo.IndexModel{
 		Keys:    bson.D{{Key: "assistant.name", Value: 1}},

--- a/user-service/mongorepo/indexes_test.go
+++ b/user-service/mongorepo/indexes_test.go
@@ -80,7 +80,8 @@ func TestUserEnsureIndexes_DuplicateAccounts_Integration(t *testing.T) {
 	require.Contains(t, err.Error(), "dedupe preflight")
 }
 
-// A pre-existing non-unique account_1 index conflicts (code 85); error must tell the operator to drop it.
+// A pre-existing non-unique account_1 index is self-healed: EnsureIndexes drops it
+// and recreates it unique (the #159 conflict no longer needs operator action).
 func TestUserEnsureIndexes_NonUniqueAccountConflict_Integration(t *testing.T) {
 	db := testutil.MongoDB(t, "user-service")
 	ctx := context.Background()
@@ -88,9 +89,14 @@ func TestUserEnsureIndexes_NonUniqueAccountConflict_Integration(t *testing.T) {
 		Keys: bson.D{{Key: "account", Value: 1}},
 	})
 	require.NoError(t, err)
-	err = NewUserRepo(db).EnsureIndexes(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "drop the old non-unique account_1 index")
+
+	require.NoError(t, NewUserRepo(db).EnsureIndexes(ctx), "a non-unique account_1 must be repaired, not fatal")
+
+	// account_1 is now unique: a duplicate account insert must fail.
+	_, err = db.Collection(usersCollection).InsertOne(ctx, bson.M{"_id": "u1", "account": "dup"})
+	require.NoError(t, err)
+	_, err = db.Collection(usersCollection).InsertOne(ctx, bson.M{"_id": "u2", "account": "dup"})
+	require.True(t, mongo.IsDuplicateKeyError(err), "account_1 must be unique after repair")
 }
 
 // The apps index backs assistant.name lookups (GetAppsByAssistants / the bot-DM

--- a/user-service/mongorepo/indexes_test.go
+++ b/user-service/mongorepo/indexes_test.go
@@ -60,25 +60,11 @@ func TestEnsureIndexes_Integration(t *testing.T) {
 	// {u.account, roomType} serves the account+roomType match on every list/count
 	// path. (The retention window keys on room.lastMsgAt, not a subscription field.)
 	require.Contains(t, subKeys, "u.account:1,roomType:1")
-	require.Contains(t, subKeys, "roomId:1,u.account:1")
 	require.Contains(t, subKeys, "name:1,roomType:1")
+	// roomId:1,u.account:1 (unique) is owned by room-service now, not created here.
 
 	userKeys := indexKeySpecs(t, userRepo.users.Raw())
 	require.Contains(t, userKeys, "account:1")
-}
-
-// A user holds at most one subscription per room — (roomId, u.account) is the unique key shared with room-service.
-func TestSubscriptionUniqueIndex_Integration(t *testing.T) {
-	subRepo, _ := newTestSubscriptionRepo(t)
-	ctx := context.Background()
-	col := subRepo.subscriptions.Raw()
-	doc := func(id string) bson.M {
-		return bson.M{"_id": id, "roomId": "r1", "u": bson.M{"account": "alice"}}
-	}
-	_, err := col.InsertOne(ctx, doc("sub-1"))
-	require.NoError(t, err)
-	_, err = col.InsertOne(ctx, doc("sub-2"))
-	require.True(t, mongo.IsDuplicateKeyError(err), "expected duplicate-key error, got %v", err)
 }
 
 // Duplicate accounts cause E11000 on unique-index creation; error must point the operator at the dedupe preflight.

--- a/user-service/mongorepo/ssotokens.go
+++ b/user-service/mongorepo/ssotokens.go
@@ -41,10 +41,9 @@ func NewSSOTokenRepo(db *mongo.Database) *SSOTokenRepo {
 
 // EnsureIndexes creates the unique username index.
 func (r *SSOTokenRepo) EnsureIndexes(ctx context.Context) error {
-	_, err := r.col.Indexes().CreateOne(ctx, mongo.IndexModel{
+	if err := mongoutil.EnsureIndexWithRepair(ctx, r.col, mongo.IndexModel{
 		Keys: bson.D{{Key: "username", Value: 1}}, Options: options.Index().SetUnique(true),
-	})
-	if err != nil {
+	}); err != nil {
 		return fmt.Errorf("create sso token index: %w", err)
 	}
 	return nil

--- a/user-service/mongorepo/subscriptions.go
+++ b/user-service/mongorepo/subscriptions.go
@@ -7,7 +7,6 @@ import (
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
-	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
@@ -60,13 +59,12 @@ func NewSubscriptionRepo(db *mongo.Database, siteID string, opts ...Option) *Sub
 
 // EnsureIndexes creates the subscription indexes this service queries on.
 func (r *SubscriptionRepo) EnsureIndexes(ctx context.Context) error {
+	// subscriptions.{roomId,u.account} (unique) is owned by room-service; verify + warn only, never create.
+	mongoutil.WarnMissingIndexes(ctx, r.subscriptions.Raw(), "roomId_1_u.account_1")
 	if _, err := r.subscriptions.Raw().Indexes().CreateMany(ctx, []mongo.IndexModel{
 		// Serves the account+roomType match on every list/count path; the retention
 		// window keys on room.lastMsgAt (a room field), so no trailing time key.
 		{Keys: bson.D{{Key: "u.account", Value: 1}, {Key: "roomType", Value: 1}}},
-		// Unique logical key (one subscription per room per user). Must match
-		// room-service's declaration on the shared collection (mismatch → conflict).
-		{Keys: bson.D{{Key: "roomId", Value: 1}, {Key: "u.account", Value: 1}}, Options: options.Index().SetUnique(true)},
 		{Keys: bson.D{{Key: "name", Value: 1}, {Key: "roomType", Value: 1}}},
 	}); err != nil {
 		return fmt.Errorf("create subscription indexes: %w", err)

--- a/user-service/mongorepo/users.go
+++ b/user-service/mongorepo/users.go
@@ -35,11 +35,9 @@ func NewUserRepo(db *mongo.Database, opts ...Option) *UserRepo {
 	}
 }
 
-// EnsureIndexes creates the unique users.account index (user-service owns it). A
-// pre-existing non-unique account_1 — the #159 conflict that used to crashloop the
-// service — is self-healed: EnsureIndexWithRepair drops it and recreates it unique.
-// Duplicate account VALUES (E11000) can't be fixed by dropping an index, so that
-// case surfaces the one-time dedupe preflight.
+// EnsureIndexes creates the unique users.account index (user-service owns it).
+// A pre-existing non-unique account_1 (the #159 conflict) self-heals; duplicate
+// account VALUES surface the dedupe-preflight error.
 func (r *UserRepo) EnsureIndexes(ctx context.Context) error {
 	err := mongoutil.EnsureIndexWithRepair(ctx, r.users.Raw(), mongo.IndexModel{
 		Keys: bson.D{{Key: "account", Value: 1}}, Options: options.Index().SetUnique(true),

--- a/user-service/mongorepo/users.go
+++ b/user-service/mongorepo/users.go
@@ -35,26 +35,23 @@ func NewUserRepo(db *mongo.Database, opts ...Option) *UserRepo {
 	}
 }
 
-// EnsureIndexes creates user indexes. The unique account index is shared with room-service; failure messages guide the operator to the same fix.
+// EnsureIndexes creates the unique users.account index (user-service owns it). A
+// pre-existing non-unique account_1 — the #159 conflict that used to crashloop the
+// service — is self-healed: EnsureIndexWithRepair drops it and recreates it unique.
+// Duplicate account VALUES (E11000) can't be fixed by dropping an index, so that
+// case surfaces the one-time dedupe preflight.
 func (r *UserRepo) EnsureIndexes(ctx context.Context) error {
-	_, err := r.users.Raw().Indexes().CreateOne(ctx, mongo.IndexModel{
+	err := mongoutil.EnsureIndexWithRepair(ctx, r.users.Raw(), mongo.IndexModel{
 		Keys: bson.D{{Key: "account", Value: 1}}, Options: options.Index().SetUnique(true),
 	})
-	if err == nil {
-		return nil
-	}
-	// E11000: pre-existing duplicate accounts (populated env pre-rollout) — point operators at the one-time dedupe preflight.
 	if mongo.IsDuplicateKeyError(err) {
 		return fmt.Errorf("create user index: duplicate account values exist in the users collection — run the "+
 			"one-time dedupe preflight (group users by account, resolve n>1) before starting this service: %w", err)
 	}
-	// A pre-existing non-unique account_1 conflicts (85 IndexOptionsConflict / 86 IndexKeySpecsConflict); Mongo won't upgrade it — the operator must drop it.
-	if se := mongo.ServerError(nil); errors.As(err, &se) && (se.HasErrorCode(85) || se.HasErrorCode(86)) {
-		return fmt.Errorf("create user index: a non-unique account_1 index already exists on the users collection — "+
-			"drop the old non-unique account_1 index (db.users.dropIndex(\"account_1\")) before starting this service "+
-			"so it can be recreated as unique: %w", err)
+	if err != nil {
+		return fmt.Errorf("create user index: %w", err)
 	}
-	return fmt.Errorf("create user index: %w", err)
+	return nil
 }
 
 // activeUserFilter matches active users. Missing `active` is treated as active ({$ne:false}); only explicit false excludes.


### PR DESCRIPTION
Refs #332

## Summary

Index creation at service startup is currently fatal: every `EnsureIndexes` failure
calls `os.Exit(1)` (or returns an error that aborts `run()`), so a single index problem —
most often a cross-service spec conflict on a shared collection — crashloops the service.

This makes index ensure **non-fatal** everywhere (log-and-continue), and **consolidates each
shared/unique index to a single owning service**. Services that only depend on a shared index
no longer create it; they verify-and-warn, so they can neither conflict with the owner's spec
nor die when the index is briefly absent.

## What's included

- **Non-fatal index ensure (all services).** Every `EnsureIndexes`/`ensureIndexes` call site
  now logs a warning and continues instead of exiting. Indexes are best-effort at startup; a
  build failure no longer takes the service down.
- **Single-owner shared indexes.** The indexes previously created by more than one service are
  now created by exactly one owner:
  - `users.account` (unique) and `apps.assistant_name_idx` → **user-service**
  - `subscriptions.{roomId,u.account}` (unique) → **room-service**
  - `thread_subscriptions.{threadRoomId,userAccount}` (unique), plus the legacy
    `threadRoomId_1_userId_1` drop → **room-service**
- **Dependents check-and-log.** A service that depends on an owned index no longer creates it;
  it calls the new `mongoutil.WarnMissingIndexes` helper, which warns if the index is absent
  (its owner builds it) and never errors.
- **Owners self-heal a wrong-spec index.** Owner uniques go through the new
  `mongoutil.EnsureIndexWithRepair`: if an index with the same keys but a conflicting spec
  already exists (`IndexOptionsConflict`/`IndexKeySpecsConflict` — e.g. a non-unique `account_1`,
  the #159 case), it drops the conflicting index and recreates it to the expected spec at
  startup, so an environment carrying the old wrong index converges without operator action.
  A duplicate-*data* failure (E11000) is not repairable by an index drop and still surfaces the
  one-time dedupe-preflight guidance. Applied to `users.account`, `apps.assistant_name_idx`,
  `subscriptions.{roomId,u.account}`, `thread_subscriptions.{threadRoomId,userAccount}`, `room_members`.
- Service-specific, non-shared indexes stay with their service. `thread_rooms` and `sessions`
  keep their existing creators — they have no divergent-spec duplicate, so consolidating them
  would add cross-service coupling with no conflict to prevent; the non-fatal change covers them.

## Changes

- `pkg/mongoutil/indexes.go` — new `WarnMissingIndexes(ctx, coll, names...)` (list-and-warn,
  never returns an error).
- ~20 `EnsureIndexes` call sites across `*/main.go` → warn + continue (no `os.Exit`, no aborting
  error return).
- Owner stores keep their creates; dependent stores (room-service, search-service, admin-service,
  bot-room-service, user-service, message-worker, inbox-worker, history-service) drop the shared
  create and warn instead. The `users.account` operator-guidance errors (E11000 dedupe preflight,
  non-unique conflict) now live only on the owner, user-service.
- Tests moved to the new ownership: the unique-constraint and operator-guidance assertions moved
  to the owning service's tests.

## Rollout note

Because a unique index now has a single creator, the guarantee it enforces depends on the owner
service having built it. On a brand-new environment, deploy the owner ahead of its dependents
(or accept a brief startup window where the index is not yet present). Existing environments
already carry these indexes, so this only affects a from-scratch bring-up.

## Verification

- `go build` green across all touched services.
- `go vet -tags integration` green (integration tests updated to the new ownership).
- golangci-lint clean.
- Index ensure is exercised by the per-service testcontainer integration tests (real Mongo),
  which is where this behavior is covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Services and workers now continue starting when database index setup encounters errors, while logging warnings.
  * Index initialization proceeds independently, reducing disruption from individual setup failures.

* **Data Integrity**
  * Conflicting indexes can be repaired automatically while preserving safeguards against duplicate data.
  * Shared indexes are verified consistently, with warnings when required indexes are missing.

* **Bug Fixes**
  * Updated index ownership and migration behavior to prevent competing services from managing the same indexes.
  * Improved duplicate-account and subscription constraint validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->