### PR TITLE
fix(mongo-indexes): bound a captured TTL before narrowing it to int32

### DIFF
--- a/pkg/mongoutil/indexes.go
+++ b/pkg/mongoutil/indexes.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"strings"
 	"time"
 
@@ -84,7 +85,7 @@ func EnsureIndexWithRepair(ctx context.Context, coll *mongo.Collection, model mo
 		// collection keeps an index; the returned error still carries the cause.
 		restoreCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), indexRestoreTimeout)
 		defer cancel()
-		if _, rerr := coll.Indexes().CreateOne(restoreCtx, old.model()); rerr != nil {
+		if _, rerr := coll.Indexes().CreateOne(restoreCtx, old.model(ctx)); rerr != nil {
 			slog.WarnContext(ctx, "mongo: index repair failed and the old index could not be restored",
 				"collection", coll.Name(), "index", old.name, "error", rerr)
 		}
@@ -120,7 +121,7 @@ type existingIndex struct {
 // correctness-relevant options (unique, sparse, hidden, TTL, partial filter) so a
 // restore never silently weakens the constraint. Collation is not reconstructed —
 // no repaired index in this repo uses it.
-func (e existingIndex) model() mongo.IndexModel {
+func (e existingIndex) model(ctx context.Context) mongo.IndexModel {
 	opts := options.Index().SetName(e.name)
 	if v, _ := e.spec["unique"].(bool); v {
 		opts = opts.SetUnique(true)
@@ -131,16 +132,36 @@ func (e existingIndex) model() mongo.IndexModel {
 	if v, _ := e.spec["hidden"].(bool); v {
 		opts = opts.SetHidden(true)
 	}
-	switch v := e.spec["expireAfterSeconds"].(type) {
-	case int32:
-		opts = opts.SetExpireAfterSeconds(v)
-	case int64:
-		opts = opts.SetExpireAfterSeconds(int32(v))
+	if raw, ok := e.spec["expireAfterSeconds"]; ok {
+		if ttl, ok := ttlSeconds(raw); ok {
+			opts = opts.SetExpireAfterSeconds(ttl)
+		} else {
+			slog.WarnContext(ctx, "mongo: captured index TTL is not a usable expireAfterSeconds; restoring the index without it",
+				"index", e.name, "expireAfterSeconds", raw)
+		}
 	}
 	if v, ok := e.spec["partialFilterExpression"]; ok {
 		opts = opts.SetPartialFilterExpression(v)
 	}
 	return mongo.IndexModel{Keys: e.keys, Options: opts}
+}
+
+// ttlSeconds narrows a captured expireAfterSeconds to the int32 the driver takes.
+// Mongo hands it back as int32 or int64, and a live TTL always fits in [0,
+// MaxInt32]; anything outside that is reported unusable rather than narrowed,
+// because a wrapped value would restore an index expiring documents on a
+// schedule the original never had.
+func ttlSeconds(raw any) (int32, bool) {
+	switch v := raw.(type) {
+	case int32:
+		return v, v >= 0
+	case int64:
+		if v < 0 || v > math.MaxInt32 {
+			return 0, false
+		}
+		return int32(v), true
+	}
+	return 0, false
 }
 
 // existingIndexByKeys returns the index on coll whose key spec matches keys

--- a/pkg/mongoutil/indexes_test.go
+++ b/pkg/mongoutil/indexes_test.go
@@ -1,0 +1,132 @@
+package mongoutil
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+// resolveIndexOptions materializes a builder's setters into the options struct
+// the driver would send, so a test can assert on what a restore requests.
+func resolveIndexOptions(t *testing.T, m mongo.IndexModel) *options.IndexOptions {
+	t.Helper()
+	var got options.IndexOptions
+	for _, set := range m.Options.List() {
+		require.NoError(t, set(&got))
+	}
+	return &got
+}
+
+func TestExistingIndex_Model_TTL(t *testing.T) {
+	tests := []struct {
+		name string
+		spec bson.M
+		want *int32
+	}{
+		{
+			name: "no ttl",
+			spec: bson.M{},
+			want: nil,
+		},
+		{
+			name: "int32 ttl preserved",
+			spec: bson.M{"expireAfterSeconds": int32(3600)},
+			want: ptr(int32(3600)),
+		},
+		{
+			name: "int64 ttl preserved",
+			spec: bson.M{"expireAfterSeconds": int64(3600)},
+			want: ptr(int32(3600)),
+		},
+		{
+			name: "int64 ttl at int32 max preserved",
+			spec: bson.M{"expireAfterSeconds": int64(math.MaxInt32)},
+			want: ptr(int32(math.MaxInt32)),
+		},
+		{
+			name: "int64 ttl above int32 max dropped, never wrapped",
+			spec: bson.M{"expireAfterSeconds": int64(math.MaxInt32) + 1},
+			want: nil,
+		},
+		{
+			name: "negative int64 ttl dropped",
+			spec: bson.M{"expireAfterSeconds": int64(-1)},
+			want: nil,
+		},
+		{
+			name: "negative int32 ttl dropped",
+			spec: bson.M{"expireAfterSeconds": int32(-1)},
+			want: nil,
+		},
+		{
+			name: "non-numeric ttl dropped",
+			spec: bson.M{"expireAfterSeconds": "3600"},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := existingIndex{name: "createdAt_1", keys: bson.D{{Key: "createdAt", Value: 1}}, spec: tt.spec}
+
+			got := resolveIndexOptions(t, e.model(context.Background()))
+
+			if tt.want == nil {
+				assert.Nil(t, got.ExpireAfterSeconds)
+				return
+			}
+			require.NotNil(t, got.ExpireAfterSeconds)
+			assert.Equal(t, *tt.want, *got.ExpireAfterSeconds)
+		})
+	}
+}
+
+func TestExistingIndex_Model_PreservesSpec(t *testing.T) {
+	keys := bson.D{{Key: "account", Value: 1}, {Key: "siteId", Value: -1}}
+	filter := bson.M{"deleted": false}
+	e := existingIndex{
+		name: "account_1_siteId_-1",
+		keys: keys,
+		spec: bson.M{
+			"unique":                  true,
+			"sparse":                  true,
+			"hidden":                  true,
+			"partialFilterExpression": filter,
+		},
+	}
+
+	m := e.model(context.Background())
+	got := resolveIndexOptions(t, m)
+
+	assert.Equal(t, keys, m.Keys)
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "account_1_siteId_-1", *got.Name)
+	assert.Equal(t, ptr(true), got.Unique)
+	assert.Equal(t, ptr(true), got.Sparse)
+	assert.Equal(t, ptr(true), got.Hidden)
+	assert.Equal(t, filter, got.PartialFilterExpression)
+}
+
+func TestExistingIndex_Model_OmitsUnsetOptions(t *testing.T) {
+	e := existingIndex{
+		name: "account_1",
+		keys: bson.D{{Key: "account", Value: 1}},
+		spec: bson.M{"unique": false, "sparse": false, "hidden": false},
+	}
+
+	got := resolveIndexOptions(t, e.model(context.Background()))
+
+	assert.Nil(t, got.Unique)
+	assert.Nil(t, got.Sparse)
+	assert.Nil(t, got.Hidden)
+	assert.Nil(t, got.PartialFilterExpression)
+	assert.Nil(t, got.ExpireAfterSeconds)
+}
+
+func ptr[T any](v T) *T { return &v }


### PR DESCRIPTION
The `sast` job has been red on `main` since #333. gosec fails the gate on one finding:

```
[pkg/mongoutil/indexes.go:138] - G115 (CWE-190): integer overflow conversion int64 -> int32
    137: 	case int64:
  > 138: 		opts = opts.SetExpireAfterSeconds(int32(v))
```

It is a real defect, not a false positive. `existingIndex.model` rebuilds the index that `EnsureIndexWithRepair` restores after a failed repair, from the spec Mongo handed back — where `expireAfterSeconds` arrives as either `int32` or `int64`. An `int64` outside int32 range wrapped silently, and a wrapped value does not fail the restore: it recreates the index carrying a TTL the original never had, so documents start expiring on a schedule nobody chose. That is the opposite of what the restore path exists to do.

## Changes

- `ttlSeconds` reports anything outside `[0, MaxInt32]` as unusable instead of narrowing it; only an in-range value reaches `SetExpireAfterSeconds`.
- `model` takes a `ctx` and logs the dropped TTL, so a restore that loses one is visible rather than silent. Previously a negative or oversized value either wrapped or was dropped with no trace.
- New `pkg/mongoutil/indexes_test.go` covers both numeric widths, the int32-max boundary, out-of-range and negative values, a non-numeric spec, and the untouched unique / sparse / hidden / partial-filter options.

The test was written first and confirmed failing against the old conversion (the out-of-range case restored a wrapped `-2147483648`); `model` and `ttlSeconds` are at 100% statement coverage.

## Verification

- `gosec -quiet -severity medium -confidence medium -tests=true -exclude-generated -exclude-dir=tools -exclude-dir=testdata ./...` — exit 0, no findings (was 2).
- `make test` (`go test -race ./...`) — exit 0.
- `golangci-lint run ./...` — 0 issues; `go vet -tags integration ./pkg/mongoutil/...` clean.
- semgrep local ruleset (`.semgrep/`) — 0 findings. The registry rulesets (`p/golang`, `p/security-audit`) and govulncheck could not run in this sandbox — `semgrep.dev` and `vuln.go.dev` are blocked by the environment's network policy. Both passed on this base commit in CI and this change adds no dependencies; the `sast` job re-runs them here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7FYdt6SF3GRTVwzeS8Thj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MongoDB index restoration reliability by safely validating TTL settings.
  - Unsupported, negative, or out-of-range TTL values are now skipped with a warning instead of causing invalid restoration.
  - Valid TTL values are restored accurately.
  - Preserved index names, keys, and configured options while omitting unset options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->