### PR TITLE
fix(broadcast-worker): carry the mention roster on DM room events

### DIFF
--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -226,7 +226,7 @@ func (h *Handler) handleCreated(ctx context.Context, evt *model.MessageEvent) er
 
 	switch meta.Type {
 	case model.RoomTypeChannel:
-		return h.publishChannelEvent(ctx, &meta, clientMsg, evt.Timestamp, resolved.MentionAll, resolved.Participants)
+		return h.publishChannelEvent(ctx, &meta, clientMsg, evt.Timestamp, resolved)
 	case model.RoomTypeDM, model.RoomTypeBotDM:
 		return h.publishDMEvents(ctx, &meta, clientMsg, evt.Timestamp, resolved, model.RoomEventNewMessage)
 	default:
@@ -287,12 +287,8 @@ func (h *Handler) handleThreadCreated(ctx context.Context, evt *model.MessageEve
 		// Do NOT call SetSubscriptionMentions here: TShow=false replies are invisible
 		// in the main channel, so a room-level mention badge would appear with no
 		// visible message to explain it.
-		roomEvt := buildRoomEvent(&meta, clientMsg, evt.Timestamp)
+		roomEvt := buildRoomEvent(&meta, clientMsg, evt.Timestamp, resolved)
 		roomEvt.Type = model.RoomEventNewThreadMessage
-		roomEvt.MentionAll = resolved.MentionAll
-		if len(resolved.Participants) > 0 {
-			roomEvt.Mentions = resolved.Participants
-		}
 		payload, err := sonic.Marshal(roomEvt)
 		if err != nil {
 			return fmt.Errorf("marshal thread created event for parent %s: %w", parentMsgID, err)
@@ -857,12 +853,8 @@ func (h *Handler) encryptRoomEvent(ctx context.Context, roomID string, clientMsg
 	return nil
 }
 
-func (h *Handler) publishChannelEvent(ctx context.Context, meta *roommetacache.Meta, clientMsg *model.ClientMessage, timestamp int64, mentionAll bool, mentions []model.Participant) error {
-	evt := buildRoomEvent(meta, clientMsg, timestamp)
-	evt.MentionAll = mentionAll
-	if len(mentions) > 0 {
-		evt.Mentions = mentions
-	}
+func (h *Handler) publishChannelEvent(ctx context.Context, meta *roommetacache.Meta, clientMsg *model.ClientMessage, timestamp int64, resolved *mention.ResolveResult) error {
+	evt := buildRoomEvent(meta, clientMsg, timestamp, resolved)
 	if err := h.encryptRoomEvent(ctx, meta.ID, clientMsg, &evt); err != nil {
 		return fmt.Errorf("encrypt channel event for room %s: %w", meta.ID, err)
 	}
@@ -912,11 +904,8 @@ func debugTraceDelivered(ctx context.Context, account, roomID string) {
 		"request_id", natsutil.RequestIDFromContext(ctx), "account", account, "room_id", roomID)
 }
 
-// publishDMEvents fans a DM/botDM room event out per non-bot member. resolved
-// carries the mention roster: the per-recipient hasMention flag comes from its
-// accounts, and the roster itself rides on every event so a client can render a
-// mentioned person's name instead of the raw @account token (the desktop banner
-// is computed client-side from this event).
+// publishDMEvents fans a DM/botDM room event out per non-bot member; only
+// hasMention differs between the copies.
 func (h *Handler) publishDMEvents(ctx context.Context, meta *roommetacache.Meta, clientMsg *model.ClientMessage, timestamp int64, resolved *mention.ResolveResult, roomEventType model.RoomEventType) error {
 	labels := broadcastLabels(ctx)
 	ctx = withBroadcastMetricLabels(ctx, roomKind(meta.Type), labels.eventType)
@@ -941,13 +930,9 @@ func (h *Handler) publishDMEvents(ctx context.Context, meta *roommetacache.Meta,
 		}
 		_, hasMention := mentionSet[account]
 
-		evt := buildRoomEvent(meta, clientMsg, timestamp)
+		evt := buildRoomEvent(meta, clientMsg, timestamp, resolved)
 		evt.Type = roomEventType
 		evt.HasMention = hasMention
-		evt.MentionAll = resolved.MentionAll
-		if len(resolved.Participants) > 0 {
-			evt.Mentions = resolved.Participants
-		}
 
 		payload, err := sonic.Marshal(evt)
 		if err != nil {
@@ -978,7 +963,10 @@ func (h *Handler) publishDMEvents(ctx context.Context, meta *roommetacache.Meta,
 	return nil
 }
 
-func buildRoomEvent(meta *roommetacache.Meta, clientMsg *model.ClientMessage, eventTimestamp int64) model.RoomEvent {
+// buildRoomEvent is the only constructor of model.RoomEvent, so stamping the
+// mention roster here is what keeps a publish path from shipping without one.
+// resolved must be non-nil — every caller passes mention.ResolveFromParsed's result.
+func buildRoomEvent(meta *roommetacache.Meta, clientMsg *model.ClientMessage, eventTimestamp int64, resolved *mention.ResolveResult) model.RoomEvent {
 	return model.RoomEvent{
 		Type:           model.RoomEventNewMessage,
 		RoomID:         meta.ID,
@@ -991,6 +979,8 @@ func buildRoomEvent(meta *roommetacache.Meta, clientMsg *model.ClientMessage, ev
 		LastMsgAt:      clientMsg.CreatedAt,
 		LastMsgID:      clientMsg.ID,
 		Message:        clientMsg,
+		MentionAll:     resolved.MentionAll,
+		Mentions:       resolved.Participants,
 	}
 }
 

--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -228,7 +228,7 @@ func (h *Handler) handleCreated(ctx context.Context, evt *model.MessageEvent) er
 	case model.RoomTypeChannel:
 		return h.publishChannelEvent(ctx, &meta, clientMsg, evt.Timestamp, resolved.MentionAll, resolved.Participants)
 	case model.RoomTypeDM, model.RoomTypeBotDM:
-		return h.publishDMEvents(ctx, &meta, clientMsg, evt.Timestamp, resolved.Accounts, model.RoomEventNewMessage)
+		return h.publishDMEvents(ctx, &meta, clientMsg, evt.Timestamp, resolved, model.RoomEventNewMessage)
 	default:
 		slog.WarnContext(ctx, "unknown room type, skipping fan-out",
 			"type", meta.Type,
@@ -303,7 +303,7 @@ func (h *Handler) handleThreadCreated(ctx context.Context, evt *model.MessageEve
 		// owned by message-worker (markThreadMentions), so broadcast-worker doesn't
 		// touch subscriptions here. lastMsgAt is intentionally NOT updated (would
 		// wrongly mark hasUnread for non-participants).
-		return h.publishDMEvents(ctx, &meta, clientMsg, evt.Timestamp, resolved.Accounts, model.RoomEventNewThreadMessage)
+		return h.publishDMEvents(ctx, &meta, clientMsg, evt.Timestamp, resolved, model.RoomEventNewThreadMessage)
 	default:
 		slog.WarnContext(ctx, "unknown room type, skipping thread fan-out",
 			"type", meta.Type,
@@ -912,7 +912,12 @@ func debugTraceDelivered(ctx context.Context, account, roomID string) {
 		"request_id", natsutil.RequestIDFromContext(ctx), "account", account, "room_id", roomID)
 }
 
-func (h *Handler) publishDMEvents(ctx context.Context, meta *roommetacache.Meta, clientMsg *model.ClientMessage, timestamp int64, mentionedAccounts []string, roomEventType model.RoomEventType) error {
+// publishDMEvents fans a DM/botDM room event out per non-bot member. resolved
+// carries the mention roster: the per-recipient hasMention flag comes from its
+// accounts, and the roster itself rides on every event so a client can render a
+// mentioned person's name instead of the raw @account token (the desktop banner
+// is computed client-side from this event).
+func (h *Handler) publishDMEvents(ctx context.Context, meta *roommetacache.Meta, clientMsg *model.ClientMessage, timestamp int64, resolved *mention.ResolveResult, roomEventType model.RoomEventType) error {
 	labels := broadcastLabels(ctx)
 	ctx = withBroadcastMetricLabels(ctx, roomKind(meta.Type), labels.eventType)
 	subs, err := h.store.ListSubscriptions(ctx, meta.ID)
@@ -920,8 +925,8 @@ func (h *Handler) publishDMEvents(ctx context.Context, meta *roommetacache.Meta,
 		return fmt.Errorf("list subscriptions for DM room %s: %w", meta.ID, err)
 	}
 
-	mentionSet := make(map[string]struct{}, len(mentionedAccounts))
-	for _, name := range mentionedAccounts {
+	mentionSet := make(map[string]struct{}, len(resolved.Accounts))
+	for _, name := range resolved.Accounts {
 		mentionSet[name] = struct{}{}
 	}
 
@@ -939,6 +944,10 @@ func (h *Handler) publishDMEvents(ctx context.Context, meta *roommetacache.Meta,
 		evt := buildRoomEvent(meta, clientMsg, timestamp)
 		evt.Type = roomEventType
 		evt.HasMention = hasMention
+		evt.MentionAll = resolved.MentionAll
+		if len(resolved.Participants) > 0 {
+			evt.Mentions = resolved.Participants
+		}
 
 		payload, err := sonic.Marshal(evt)
 		if err != nil {

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -408,6 +408,148 @@ func TestHandler_HandleMessage_DMRoom(t *testing.T) {
 	}
 }
 
+// A DM's desktop banner is computed client-side from this event, so the mention
+// roster has to ride along exactly as it does on the channel path — without it a
+// client can only render the raw @account token instead of the person's name.
+func TestHandler_HandleMessage_DMRoom_CarriesMentionRoster(t *testing.T) {
+	msgTime := time.Date(2026, 8, 21, 11, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name           string
+		content        string
+		lookupAccounts []string
+		lookupUsers    []model.User
+		wantSetMention []string
+		wantMentionAll bool
+		wantMentions   []model.Participant
+	}{
+		{
+			name:           "no mentions",
+			content:        "hey bob",
+			lookupAccounts: []string{"alice"},
+			lookupUsers:    []model.User{testUsers[0]},
+		},
+		{
+			name:           "account mention",
+			content:        "hey @bob",
+			lookupAccounts: []string{"alice", "bob"},
+			lookupUsers:    testUsers,
+			wantSetMention: []string{"bob"},
+			wantMentions: []model.Participant{
+				{UserID: "u-bob", Account: "bob", SiteID: "site-a", ChineseName: "鮑勃", EngName: "Bob Chen"},
+			},
+		},
+		{
+			name:           "mention all",
+			content:        "@all standup",
+			lookupAccounts: []string{"alice"},
+			lookupUsers:    []model.User{testUsers[0]},
+			wantMentionAll: true,
+			wantMentions:   []model.Participant{{Account: "all", EngName: "all"}},
+		},
+		{
+			name:           "account mention and all",
+			content:        "@bob @all standup",
+			lookupAccounts: []string{"alice", "bob"},
+			lookupUsers:    testUsers,
+			wantSetMention: []string{"bob"},
+			wantMentionAll: true,
+			wantMentions: []model.Participant{
+				{UserID: "u-bob", Account: "bob", SiteID: "site-a", ChineseName: "鮑勃", EngName: "Bob Chen"},
+				{Account: "all", EngName: "all"},
+			},
+		},
+		{
+			name:           "unknown account keeps no participant",
+			content:        "hey @nobody",
+			lookupAccounts: []string{"alice", "nobody"},
+			lookupUsers:    []model.User{testUsers[0]},
+			wantSetMention: []string{"nobody"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			store := NewMockStore(ctrl)
+			us := NewMockUserStore(ctrl)
+			pub := &mockPublisher{}
+			keyStore := NewMockRoomKeyProvider(ctrl)
+
+			store.EXPECT().UpdateRoomLastMessage(gomock.Any(), "dm-1", "msg-1", msgTime, tc.wantMentionAll).Return(nil)
+			store.EXPECT().AdvanceSubscriptionLastSeen(gomock.Any(), "dm-1", "alice", msgTime).Return(nil)
+			store.EXPECT().GetRoomMeta(gomock.Any(), "dm-1").Return(metaOf(testDMRoom), nil)
+			store.EXPECT().ListSubscriptions(gomock.Any(), "dm-1").Return(testDMSubs, nil)
+			if len(tc.wantSetMention) > 0 {
+				store.EXPECT().SetSubscriptionMentions(gomock.Any(), "dm-1", gomock.InAnyOrder(tc.wantSetMention), msgTime).Return(nil)
+			}
+			us.EXPECT().FindUsersByAccounts(gomock.Any(), tc.lookupAccounts).Return(tc.lookupUsers, nil)
+
+			evt := model.MessageEvent{
+				Event:     model.EventCreated,
+				SiteID:    "site-a",
+				Timestamp: msgTime.UnixMilli(),
+				Message: model.Message{
+					ID: "msg-1", RoomID: "dm-1", UserID: "u-alice", UserAccount: "alice",
+					Content: tc.content, CreatedAt: msgTime,
+				},
+			}
+			data, _ := json.Marshal(evt)
+
+			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+			require.NoError(t, h.HandleMessage(context.Background(), data))
+
+			require.Len(t, pub.records, 2)
+			for _, rec := range pub.records {
+				roomEvt := decodeRoomEvent(t, rec.data)
+				assert.Equal(t, tc.wantMentionAll, roomEvt.MentionAll, "subject %s", rec.subject)
+				assert.Equal(t, tc.wantMentions, roomEvt.Mentions, "subject %s", rec.subject)
+			}
+		})
+	}
+}
+
+// The DM thread-reply lane publishes through the same helper, so it carries the
+// roster too — a thread reply banner names the mentioned person as well.
+func TestHandleThreadCreated_DMRoom_CarriesMentionRoster(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 8, 21, 11, 0, 0, 0, time.UTC)
+
+	store.EXPECT().GetRoomMeta(gomock.Any(), "dm-1").Return(metaOf(testDMRoom), nil)
+	store.EXPECT().ListSubscriptions(gomock.Any(), "dm-1").Return(testDMSubs, nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"alice", "bob"}).Return(testUsers, nil)
+
+	evt := model.MessageEvent{
+		Event:     model.EventCreated,
+		SiteID:    "site-a",
+		Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "dm-1", UserID: "u-alice", UserAccount: "alice",
+			Content: "hey @bob", CreatedAt: msgTime,
+			ThreadParentMessageID: "parent-dm", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	require.Len(t, pub.records, 2)
+	want := []model.Participant{
+		{UserID: "u-bob", Account: "bob", SiteID: "site-a", ChineseName: "鮑勃", EngName: "Bob Chen"},
+	}
+	for _, rec := range pub.records {
+		roomEvt := decodeRoomEvent(t, rec.data)
+		assert.Equal(t, model.RoomEventNewThreadMessage, roomEvt.Type)
+		assert.Equal(t, want, roomEvt.Mentions, "subject %s", rec.subject)
+	}
+}
+
 func TestHandler_HandleMessage_Errors(t *testing.T) {
 	msgTime := time.Date(2026, 3, 26, 12, 0, 0, 0, time.UTC)
 

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -312,28 +312,55 @@ func TestHandler_HandleMessage_ChannelRoom(t *testing.T) {
 func TestHandler_HandleMessage_DMRoom(t *testing.T) {
 	msgTime := time.Date(2026, 3, 26, 11, 0, 0, 0, time.UTC)
 
+	bobParticipant := model.Participant{UserID: "u-bob", Account: "bob", SiteID: "site-a", ChineseName: "鮑勃", EngName: "Bob Chen"}
+	allParticipant := model.Participant{Account: "all", EngName: "all"}
+
 	tests := []struct {
 		name            string
 		content         string
-		wantSetMentions bool
 		mentionedUsers  []string
+		lookupUsers     []model.User
 		aliceHasMention bool
 		bobHasMention   bool
+		// The roster rides every copy so a client renders a name, not the raw @token.
+		wantMentionAll bool
+		wantMentions   []model.Participant
 	}{
 		{
-			name:            "no mentions",
-			content:         "hey bob",
-			wantSetMentions: false,
-			aliceHasMention: false,
-			bobHasMention:   false,
+			name:        "no mentions",
+			content:     "hey bob",
+			lookupUsers: []model.User{testUsers[0]},
 		},
 		{
-			name:            "with mention",
-			content:         "hey @bob",
-			wantSetMentions: true,
-			mentionedUsers:  []string{"bob"},
-			aliceHasMention: false,
-			bobHasMention:   true,
+			name:           "with mention",
+			content:        "hey @bob",
+			mentionedUsers: []string{"bob"},
+			lookupUsers:    testUsers,
+			bobHasMention:  true,
+			wantMentions:   []model.Participant{bobParticipant},
+		},
+		{
+			name:           "mention all",
+			content:        "@all standup",
+			lookupUsers:    []model.User{testUsers[0]},
+			wantMentionAll: true,
+			wantMentions:   []model.Participant{allParticipant},
+		},
+		{
+			name:           "mention and all",
+			content:        "@bob @all standup",
+			mentionedUsers: []string{"bob"},
+			lookupUsers:    testUsers,
+			bobHasMention:  true,
+			wantMentionAll: true,
+			wantMentions:   []model.Participant{bobParticipant, allParticipant},
+		},
+		{
+			// An unresolvable account is omitted from the roster, so the client keeps its raw @token.
+			name:           "unknown account",
+			content:        "hey @nobody",
+			mentionedUsers: []string{"nobody"},
+			lookupUsers:    []model.User{testUsers[0]},
 		},
 	}
 
@@ -355,24 +382,18 @@ func TestHandler_HandleMessage_DMRoom(t *testing.T) {
 			}
 			data, _ := json.Marshal(evt)
 
-			store.EXPECT().UpdateRoomLastMessage(gomock.Any(), "dm-1", "msg-1", msgTime, false).Return(nil)
+			store.EXPECT().UpdateRoomLastMessage(gomock.Any(), "dm-1", "msg-1", msgTime, tc.wantMentionAll).Return(nil)
 			store.EXPECT().AdvanceSubscriptionLastSeen(gomock.Any(), "dm-1", "alice", msgTime).Return(nil)
 			store.EXPECT().GetRoomMeta(gomock.Any(), "dm-1").Return(metaOf(testDMRoom), nil)
 			store.EXPECT().ListSubscriptions(gomock.Any(), "dm-1").Return(testDMSubs, nil)
 
-			if tc.wantSetMentions {
+			if len(tc.mentionedUsers) > 0 {
 				store.EXPECT().SetSubscriptionMentions(gomock.Any(), "dm-1", gomock.InAnyOrder(tc.mentionedUsers), msgTime).Return(nil)
 			}
 
 			// Single user lookup: sender first, then mentioned accounts.
-			if tc.wantSetMentions {
-				wantAccounts := append([]string{"alice"}, tc.mentionedUsers...)
-				us.EXPECT().FindUsersByAccounts(gomock.Any(), wantAccounts).
-					Return([]model.User{testUsers[0], testUsers[1]}, nil)
-			} else {
-				us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"alice"}).
-					Return([]model.User{testUsers[0]}, nil)
-			}
+			wantAccounts := append([]string{"alice"}, tc.mentionedUsers...)
+			us.EXPECT().FindUsersByAccounts(gomock.Any(), wantAccounts).Return(tc.lookupUsers, nil)
 
 			keyStore := NewMockRoomKeyProvider(ctrl)
 			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
@@ -404,149 +425,12 @@ func TestHandler_HandleMessage_DMRoom(t *testing.T) {
 			assert.Equal(t, "msg-1", bobEvt.Message.ID)
 			require.NotNil(t, bobEvt.Message.Sender)
 			assert.Equal(t, tc.bobHasMention, bobEvt.HasMention)
-		})
-	}
-}
 
-// A DM's desktop banner is computed client-side from this event, so the mention
-// roster has to ride along exactly as it does on the channel path — without it a
-// client can only render the raw @account token instead of the person's name.
-func TestHandler_HandleMessage_DMRoom_CarriesMentionRoster(t *testing.T) {
-	msgTime := time.Date(2026, 8, 21, 11, 0, 0, 0, time.UTC)
-
-	tests := []struct {
-		name           string
-		content        string
-		lookupAccounts []string
-		lookupUsers    []model.User
-		wantSetMention []string
-		wantMentionAll bool
-		wantMentions   []model.Participant
-	}{
-		{
-			name:           "no mentions",
-			content:        "hey bob",
-			lookupAccounts: []string{"alice"},
-			lookupUsers:    []model.User{testUsers[0]},
-		},
-		{
-			name:           "account mention",
-			content:        "hey @bob",
-			lookupAccounts: []string{"alice", "bob"},
-			lookupUsers:    testUsers,
-			wantSetMention: []string{"bob"},
-			wantMentions: []model.Participant{
-				{UserID: "u-bob", Account: "bob", SiteID: "site-a", ChineseName: "鮑勃", EngName: "Bob Chen"},
-			},
-		},
-		{
-			name:           "mention all",
-			content:        "@all standup",
-			lookupAccounts: []string{"alice"},
-			lookupUsers:    []model.User{testUsers[0]},
-			wantMentionAll: true,
-			wantMentions:   []model.Participant{{Account: "all", EngName: "all"}},
-		},
-		{
-			name:           "account mention and all",
-			content:        "@bob @all standup",
-			lookupAccounts: []string{"alice", "bob"},
-			lookupUsers:    testUsers,
-			wantSetMention: []string{"bob"},
-			wantMentionAll: true,
-			wantMentions: []model.Participant{
-				{UserID: "u-bob", Account: "bob", SiteID: "site-a", ChineseName: "鮑勃", EngName: "Bob Chen"},
-				{Account: "all", EngName: "all"},
-			},
-		},
-		{
-			name:           "unknown account keeps no participant",
-			content:        "hey @nobody",
-			lookupAccounts: []string{"alice", "nobody"},
-			lookupUsers:    []model.User{testUsers[0]},
-			wantSetMention: []string{"nobody"},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			store := NewMockStore(ctrl)
-			us := NewMockUserStore(ctrl)
-			pub := &mockPublisher{}
-			keyStore := NewMockRoomKeyProvider(ctrl)
-
-			store.EXPECT().UpdateRoomLastMessage(gomock.Any(), "dm-1", "msg-1", msgTime, tc.wantMentionAll).Return(nil)
-			store.EXPECT().AdvanceSubscriptionLastSeen(gomock.Any(), "dm-1", "alice", msgTime).Return(nil)
-			store.EXPECT().GetRoomMeta(gomock.Any(), "dm-1").Return(metaOf(testDMRoom), nil)
-			store.EXPECT().ListSubscriptions(gomock.Any(), "dm-1").Return(testDMSubs, nil)
-			if len(tc.wantSetMention) > 0 {
-				store.EXPECT().SetSubscriptionMentions(gomock.Any(), "dm-1", gomock.InAnyOrder(tc.wantSetMention), msgTime).Return(nil)
-			}
-			us.EXPECT().FindUsersByAccounts(gomock.Any(), tc.lookupAccounts).Return(tc.lookupUsers, nil)
-
-			evt := model.MessageEvent{
-				Event:     model.EventCreated,
-				SiteID:    "site-a",
-				Timestamp: msgTime.UnixMilli(),
-				Message: model.Message{
-					ID: "msg-1", RoomID: "dm-1", UserID: "u-alice", UserAccount: "alice",
-					Content: tc.content, CreatedAt: msgTime,
-				},
-			}
-			data, _ := json.Marshal(evt)
-
-			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
-			require.NoError(t, h.HandleMessage(context.Background(), data))
-
-			require.Len(t, pub.records, 2)
-			for _, rec := range pub.records {
-				roomEvt := decodeRoomEvent(t, rec.data)
-				assert.Equal(t, tc.wantMentionAll, roomEvt.MentionAll, "subject %s", rec.subject)
-				assert.Equal(t, tc.wantMentions, roomEvt.Mentions, "subject %s", rec.subject)
+			for subj, e := range evtBySubject {
+				assert.Equal(t, tc.wantMentionAll, e.MentionAll, "subject %s", subj)
+				assert.Equal(t, tc.wantMentions, e.Mentions, "subject %s", subj)
 			}
 		})
-	}
-}
-
-// The DM thread-reply lane publishes through the same helper, so it carries the
-// roster too — a thread reply banner names the mentioned person as well.
-func TestHandleThreadCreated_DMRoom_CarriesMentionRoster(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	store := NewMockStore(ctrl)
-	us := NewMockUserStore(ctrl)
-	pub := &mockPublisher{}
-	keyStore := NewMockRoomKeyProvider(ctrl)
-
-	msgTime := time.Date(2026, 8, 21, 11, 0, 0, 0, time.UTC)
-
-	store.EXPECT().GetRoomMeta(gomock.Any(), "dm-1").Return(metaOf(testDMRoom), nil)
-	store.EXPECT().ListSubscriptions(gomock.Any(), "dm-1").Return(testDMSubs, nil)
-	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"alice", "bob"}).Return(testUsers, nil)
-
-	evt := model.MessageEvent{
-		Event:     model.EventCreated,
-		SiteID:    "site-a",
-		Timestamp: msgTime.UnixMilli(),
-		Message: model.Message{
-			ID: "reply-1", RoomID: "dm-1", UserID: "u-alice", UserAccount: "alice",
-			Content: "hey @bob", CreatedAt: msgTime,
-			ThreadParentMessageID: "parent-dm", TShow: false,
-		},
-	}
-	data, _ := json.Marshal(evt)
-
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
-	require.NoError(t, h.HandleMessage(context.Background(), data))
-
-	require.Len(t, pub.records, 2)
-	want := []model.Participant{
-		{UserID: "u-bob", Account: "bob", SiteID: "site-a", ChineseName: "鮑勃", EngName: "Bob Chen"},
-	}
-	for _, rec := range pub.records {
-		roomEvt := decodeRoomEvent(t, rec.data)
-		assert.Equal(t, model.RoomEventNewThreadMessage, roomEvt.Type)
-		assert.Equal(t, want, roomEvt.Mentions, "subject %s", rec.subject)
 	}
 }
 
@@ -2788,6 +2672,12 @@ func TestHandleThreadCreated_DMRoom_WithMention_NoSubscriptionWrite(t *testing.T
 	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 	require.Len(t, pub.records, 2)
+
+	// The roster still rides the thread lane, so a reply banner can name the person.
+	want := []model.Participant{{UserID: "u-bob", Account: "bob", SiteID: "site-a", ChineseName: "鮑勃", EngName: "Bob Chen"}}
+	for _, rec := range pub.records {
+		assert.Equal(t, want, decodeRoomEvent(t, rec.data).Mentions, "subject %s", rec.subject)
+	}
 }
 
 func TestHandleThreadCreated_ChannelExcludesRestrictedAndNonMemberMentions(t *testing.T) {

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -6377,7 +6377,7 @@ A `RoomEvent`. Recipients: every client subscribed to the room (which includes t
 | `userCount` | number | |
 | `lastMsgAt` | string | RFC 3339. |
 | `lastMsgId` | string | The new message's ID. |
-| `mentions` | [Participant](#participant)[] | Optional. |
+| `mentions` | [Participant](#participant)[] | Optional. The mentioned users (`account` plus `engName`/`chineseName`), so a client renders a name instead of the raw `@account` token. Sent on channel and DM events alike; `@all` adds an `{"account": "all"}` entry. An account with no matching user is omitted and keeps its raw token. |
 | `mentionAll` | boolean | Optional. `true` if the message mentioned `@all` or `@here`. |
 | `hasMention` | boolean | Optional. Per-recipient flag (DM event only). Always absent on channel events. |
 | `message` | [ClientMessage](#clientmessage) | Optional. Set for unencrypted rooms. |
@@ -6434,7 +6434,7 @@ The canonical broadcast message (distinct from the history [Message schema](#mes
 
 **2. For DM rooms — `chat.user.{recipient}.event.room`** (`publishDMEvents`)
 
-A `RoomEvent` (same struct as above) published once per DM participant. Recipients: each user subscribed to the DM. The `hasMention` field is set per-recipient. DM events carry `message` (plaintext); they do not use `encryptedMessage`.
+A `RoomEvent` (same struct as above) published once per DM participant. Recipients: each user subscribed to the DM. The `hasMention` field is set per-recipient; `mentions` / `mentionAll` are identical on every copy. DM events carry `message` (plaintext); they do not use `encryptedMessage`.
 
 ```json
 {

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -385,7 +385,7 @@ messages through a separate backend path.
 | `userCount` | number | |
 | `lastMsgAt` | string | RFC 3339. |
 | `lastMsgId` | string | The new message's ID. |
-| `mentions` | [Participant](../client-api.md#participant)[] | Optional. |
+| `mentions` | [Participant](../client-api.md#participant)[] | Optional. The mentioned users (`account` plus `engName`/`chineseName`), so a client renders a name instead of the raw `@account` token. Sent on channel and DM events alike; `@all` adds an `{"account": "all"}` entry. An account with no matching user is omitted and keeps its raw token. |
 | `mentionAll` | boolean | Optional. `true` if `@all` or `@here` was used. |
 | `hasMention` | boolean | Optional. Per-recipient flag — present only on DM events. |
 | `message` | [ClientMessage](#clientmessage) | Optional. Set for unencrypted rooms. |


### PR DESCRIPTION
## Problem

Desktop notification banners show the raw `@account` token instead of the mentioned person's name.

Desktop banners are computed **client-side** from the broadcast-worker room-event stream (`docs/client-api.md`: *"Desktop banners are computed client-side from the broadcast-worker room-event stream — no server-side desktop publish exists"*). A client resolves an `@token` to a display name from the event's `mentions` roster.

- `publishChannelEvent` sends `mentions` / `mentionAll`. ✅
- `publishDMEvents` sent only the per-recipient `hasMention` flag — **no roster at all**. ❌

The embedded `message.mentions` is no fallback either: message-gatekeeper does not populate `Message.Mentions` on the canonical wire (message-worker resolves them independently on its own persistence path), so it is empty on the broadcast event.

Result: in a DM, a botDM, or a DM thread reply, a client has nothing to substitute with and renders `@account` verbatim — in the desktop banner and in the sidebar preview alike.

Not to be confused with #297, which fixed the same symptom on the *mobile push* body (`notification-worker.resolveBody`). That is a separate lane and is unaffected here.

## Change

`broadcast-worker/handler.go`:

- `publishDMEvents` now takes the whole `*mention.ResolveResult` instead of just `resolved.Accounts`. Both call sites (`handleCreated`, `handleThreadCreated`) already had it in hand.
- Every DM copy gets `evt.Mentions` and `evt.MentionAll`, exactly as the channel lane sets them. The per-recipient `hasMention` flag is unchanged.

Participants carry `account` + `engName`/`chineseName`, the same shape the channel lane already sends — **no new field on the wire**.

`mentionAll` is included because `UpdateRoomLastMessage` already records `lastMentionAllAt` for DM rooms. Previously the live event omitted the flag, so a `@all` group badge in a DM only appeared after a reconnect; live and restored state now agree.

## Tests

Written Red → Green. The new tests failed on the four mention-bearing cases before the implementation change and passed after; the two roster-free cases (`no mentions`, `unknown account`) were green throughout, confirming they pin the fallback rather than the fix.

- `TestHandler_HandleMessage_DMRoom_CarriesMentionRoster` — table-driven: no mentions, `@bob`, `@all`, `@bob @all`, and an unresolvable account (omitted from the roster so the client keeps the raw token).
- `TestHandleThreadCreated_DMRoom_CarriesMentionRoster` — the DM thread-reply lane.

## Docs

`docs/client-api.md` and its derived view `docs/client-api/events.md`: the `mentions` field note now states the roster is sent on channel and DM events alike, what it carries, and how an unresolvable account behaves. The DM section notes that `mentions` / `mentionAll` are identical on every per-recipient copy.

## Verification

| Check | Result |
|---|---|
| `make lint` | 0 issues |
| `make test` (whole repo, `-race`) | pass |
| `publishDMEvents` coverage | 94.1% |
| `make sast-gosec` | pass |
| semgrep, repo-local rules (`.semgrep/`) | 7 rules, 0 findings |

`govulncheck` and the semgrep registry packs (`p/golang`, `p/security-audit`) could not run in this sandbox — the egress proxy returns 403 for `vuln.go.dev` and `semgrep.dev`. No dependency changes in this PR; the CI `sast` gate covers them.

---
_Generated by [Claude Code](https://claude.ai/code/session_017DRteZKH4topYRLeq5T4xH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Direct messages and thread replies now include complete mention metadata, including `@all` mentions and participant details.
  * Each recipient’s event accurately indicates whether they were individually mentioned.
  * Unresolved accounts are omitted from mention details.
  * Mention information is now consistent across channel, thread, and direct-message events.

* **Documentation**
  * Updated message event documentation to clarify enriched mention data and consistent direct-message recipient payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->