### PR TITLE
feat: fleet-wide MongoDB pool + request-guard config helpers

### DIFF
--- a/admin-service/config.go
+++ b/admin-service/config.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/caarlos0/env/v11"
+
+	"github.com/hmchangw/chat/pkg/mongoutil"
 )
 
 // httpWriteTimeout bounds a response write measured from the request, so in-handler
@@ -44,6 +46,14 @@ type Config struct {
 	// AllSiteIDs lists every site in the federation (including this one); empty means
 	// no cross-site fanout — correct for single-site dev.
 	AllSiteIDs []string `env:"ALL_SITE_IDS" envSeparator:"," envDefault:""`
+
+	// Pool caps the Mongo connection pool. NOTE: admin-service deliberately takes
+	// NO shared HTTP request-timeout (ginutil.TimeoutConfig): its permission
+	// handlers pin their own budget via withRequestBudget (requestBudget, just
+	// under httpWriteTimeout) and the cross-site fanout self-limits to
+	// min(FanoutTimeout, request deadline). A blanket router timeout shorter than
+	// FanoutTimeout would silently shrink the fanout — see applyBaseMiddleware.
+	Pool mongoutil.PoolConfig
 }
 
 func loadConfig() (Config, error) {
@@ -55,6 +65,9 @@ func loadConfig() (Config, error) {
 		return Config{}, err
 	}
 	if err := checkHandlerTimeout("FANOUT_TIMEOUT", c.FanoutTimeout); err != nil {
+		return Config{}, err
+	}
+	if err := c.Pool.Validate(); err != nil {
 		return Config{}, err
 	}
 	return c, nil

--- a/admin-service/config_test.go
+++ b/admin-service/config_test.go
@@ -76,3 +76,12 @@ func TestLoadConfig_RejectsUnusableHandlerTimeouts(t *testing.T) {
 		}
 	}
 }
+
+func TestLoadConfig_ZeroMaxPoolSizeFails(t *testing.T) {
+	t.Setenv("SITE_ID", "site-local")
+	t.Setenv("MONGO_URI", "mongodb://x")
+	t.Setenv("NATS_URL", "nats://x:4222")
+	t.Setenv("MONGO_MAX_POOL_SIZE", "0")
+	_, err := loadConfig()
+	assert.Error(t, err)
+}

--- a/admin-service/main.go
+++ b/admin-service/main.go
@@ -28,6 +28,24 @@ func main() {
 	}
 }
 
+// applyBaseMiddleware installs admin-service's cross-cutting HTTP middleware.
+// obsMW is the observability chain (empty in tests).
+//
+// It deliberately installs NO blanket per-request timeout. admin-service manages
+// its own per-request deadline: the permission handlers pin requestBudget via
+// withRequestBudget (just under httpWriteTimeout), and the cross-site permission
+// fanout self-limits to min(FanoutTimeout, request deadline). A router timeout
+// shorter than FanoutTimeout — e.g. the fleet's shared 10s REQUEST_TIMEOUT —
+// would silently cap the fanout and abort multi-site permission changes early
+// (see permissions.go:publishPermissionFanout). Keep this timeout-free.
+func applyBaseMiddleware(r *gin.Engine, obsMW []gin.HandlerFunc) {
+	r.Use(ginutil.CORS())
+	r.Use(obsMW...)
+	r.Use(gin.Recovery())
+	r.Use(ginutil.RequestID())
+	r.Use(ginutil.AccessLog())
+}
+
 func run() error {
 	ctx := context.Background()
 
@@ -47,7 +65,7 @@ func run() error {
 			"site", cfg.SiteID, "all_site_ids", cfg.AllSiteIDs)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk))
 	if err != nil {
 		return fmt.Errorf("connect mongo: %w", err)
 	}
@@ -83,11 +101,8 @@ func run() error {
 
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
-	r.Use(ginutil.CORS())
-	r.Use(o11ygin.Middleware("admin-service", sdk.TracerProvider(), sdk.MeterProvider(), obs.PublicIngressPropagator(), o11ygin.WithSkipPaths())...)
-	r.Use(gin.Recovery())
-	r.Use(ginutil.RequestID())
-	r.Use(ginutil.AccessLog())
+	obsMW := o11ygin.Middleware("admin-service", sdk.TracerProvider(), sdk.MeterProvider(), obs.PublicIngressPropagator(), o11ygin.WithSkipPaths())
+	applyBaseMiddleware(r, obsMW)
 	registerRoutes(r, h, sessStore, cfg.SiteID)
 
 	srv := &http.Server{

--- a/admin-service/router_test.go
+++ b/admin-service/router_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// The cross-site permission fanout budgets itself to min(FanoutTimeout, request
+// deadline) (permissions.go:publishPermissionFanout). So admin-service's base
+// middleware must NOT impose a per-request context deadline: a router timeout
+// shorter than FanoutTimeout (e.g. the fleet's shared 10s REQUEST_TIMEOUT) would
+// silently shrink the fanout and abort a multi-site permission change early.
+// This guards against re-introducing such a timeout into applyBaseMiddleware.
+func TestApplyBaseMiddleware_ImposesNoRequestDeadline(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	applyBaseMiddleware(r, nil) // nil observability chain — irrelevant to the deadline
+
+	var sawDeadline bool
+	r.GET("/probe", func(c *gin.Context) {
+		_, sawDeadline = c.Request.Context().Deadline()
+		c.Status(200)
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "/probe", nil))
+
+	assert.Equal(t, 200, rec.Code)
+	assert.False(t, sawDeadline,
+		"admin base middleware must not deadline the request: the permission fanout relies on the full FanoutTimeout being available")
+}

--- a/bot-message-handler/main.go
+++ b/bot-message-handler/main.go
@@ -26,8 +26,13 @@ type config struct {
 	MongoUsername string `env:"MONGO_USERNAME"`
 	MongoPassword string `env:"MONGO_PASSWORD"`
 
-	// MaxConcurrency caps in-flight req/reply handlers across all routes.
-	MaxConcurrency int `env:"MAX_CONCURRENCY" envDefault:"200"`
+	// Pool caps the Mongo connection pool. MaxConcurrency bounds in-flight
+	// handlers — kept at this service's historical 200 default (below the fleet
+	// 256) — and RequestTimeout bounds each handler, so a burst or slow
+	// dependency can't saturate the pool with unbounded work.
+	Pool           mongoutil.PoolConfig
+	MaxConcurrency int           `env:"MAX_CONCURRENCY" envDefault:"200"`
+	RequestTimeout time.Duration `env:"REQUEST_TIMEOUT" envDefault:"10s"`
 
 	HealthAddr   string          `env:"HEALTH_ADDR"    envDefault:":8081"`
 	PProfEnabled bool            `env:"PPROF_ENABLED"  envDefault:"false"`
@@ -47,6 +52,13 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("parse config: %w", err)
 	}
+	if err := cfg.Pool.Validate(); err != nil {
+		return fmt.Errorf("validate pool config: %w", err)
+	}
+	guard := natsrouter.GuardConfig{MaxConcurrency: cfg.MaxConcurrency, RequestTimeout: cfg.RequestTimeout}
+	if err := guard.Validate(); err != nil {
+		return fmt.Errorf("validate guard config: %w", err)
+	}
 
 	sdk, obsShutdown, err := obs.Init(ctx)
 	if err != nil {
@@ -65,7 +77,8 @@ func run() error {
 		return fmt.Errorf("bootstrap streams: %w", err)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk))
 	if err != nil {
 		return fmt.Errorf("connect mongo: %w", err)
 	}
@@ -74,8 +87,7 @@ func run() error {
 	pub := JetStreamPublisher{JS: js}
 	h := newHandler(store, pub, cfg.SiteID)
 
-	router := natsrouter.New(nc, "bot-message-handler", natsrouter.WithMaxConcurrency(cfg.MaxConcurrency), natsrouter.WithSiteID(cfg.SiteID))
-	router.Use(natsrouter.Recovery(), natsrouter.RequestID(), natsrouter.Logging())
+	router := natsrouter.DefaultGuarded(nc, "bot-message-handler", guard)
 	h.Register(router)
 
 	healthStop, err := health.ServeWithPprof(cfg.HealthAddr, 5*time.Second, cfg.PProfEnabled,

--- a/bot-message-worker/main.go
+++ b/bot-message-worker/main.go
@@ -43,6 +43,7 @@ type config struct {
 	MongoDB       string `env:"MONGO_DB"       envDefault:"chat"`
 	MongoUsername string `env:"MONGO_USERNAME"`
 	MongoPassword string `env:"MONGO_PASSWORD"`
+	Pool          mongoutil.PoolConfig
 	Atrest        atrest.Config
 	Vault         atrest.VaultConfig `envPrefix:"VAULT_"`
 
@@ -63,6 +64,10 @@ func run() error {
 	cfg, err := env.ParseAs[config]()
 	if err != nil {
 		return fmt.Errorf("parse config: %w", err)
+	}
+
+	if err := cfg.Pool.Validate(); err != nil {
+		return fmt.Errorf("validate mongo pool config: %w", err)
 	}
 
 	sdk, obsShutdown, err := obs.Init(ctx)
@@ -98,7 +103,7 @@ func run() error {
 		if cfg.MongoURI == "" {
 			return fmt.Errorf("ATREST_ENABLED=true requires MONGO_URI for the DEK collection")
 		}
-		mc, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+		mc, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk))
 		if err != nil {
 			return fmt.Errorf("connect mongo: %w", err)
 		}

--- a/bot-room-service/main.go
+++ b/bot-room-service/main.go
@@ -38,9 +38,16 @@ type config struct {
 	// RoomKeyRetiredTTL: retention for rotated-out keys; see roomkeystore.WithRetiredKeys for the 2x-cache-TTL rule.
 	RoomKeyRetiredTTL time.Duration `env:"ROOM_KEY_RETIRED_TTL" envDefault:"20m"`
 
-	MaxConcurrency int    `env:"MAX_CONCURRENCY" envDefault:"200"`
-	HealthAddr     string `env:"HEALTH_ADDR"     envDefault:":8081"`
-	PProfEnabled   bool   `env:"PPROF_ENABLED"   envDefault:"false"`
+	// Pool caps the Mongo connection pool. MaxConcurrency bounds in-flight
+	// handlers — kept at this service's historical 200 default (below the fleet
+	// 256) — and RequestTimeout bounds each handler, so a burst or slow
+	// dependency can't saturate the pool with unbounded work.
+	Pool           mongoutil.PoolConfig
+	MaxConcurrency int           `env:"MAX_CONCURRENCY" envDefault:"200"`
+	RequestTimeout time.Duration `env:"REQUEST_TIMEOUT" envDefault:"10s"`
+
+	HealthAddr   string `env:"HEALTH_ADDR"     envDefault:":8081"`
+	PProfEnabled bool   `env:"PPROF_ENABLED"   envDefault:"false"`
 }
 
 func main() {
@@ -55,6 +62,13 @@ func run() error {
 	cfg, err := env.ParseAs[config]()
 	if err != nil {
 		return fmt.Errorf("parse config: %w", err)
+	}
+	if err := cfg.Pool.Validate(); err != nil {
+		return fmt.Errorf("validate pool config: %w", err)
+	}
+	guard := natsrouter.GuardConfig{MaxConcurrency: cfg.MaxConcurrency, RequestTimeout: cfg.RequestTimeout}
+	if err := guard.Validate(); err != nil {
+		return fmt.Errorf("validate guard config: %w", err)
 	}
 
 	sdk, obsShutdown, err := obs.Init(ctx)
@@ -71,7 +85,8 @@ func run() error {
 		return fmt.Errorf("init jetstream: %w", err)
 	}
 
-	mc, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mc, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk))
 	if err != nil {
 		return fmt.Errorf("connect mongo: %w", err)
 	}
@@ -101,8 +116,7 @@ func run() error {
 	// LOCAL sysmsg emission on create/add/remove; never federated cross-site.
 	h.sysmsgPub = jsPublishAdapter{js: js}
 
-	router := natsrouter.New(nc, "bot-room-service", natsrouter.WithMaxConcurrency(cfg.MaxConcurrency), natsrouter.WithSiteID(cfg.SiteID))
-	router.Use(natsrouter.Recovery(), natsrouter.RequestID(), natsrouter.Logging())
+	router := natsrouter.DefaultGuarded(nc, "bot-room-service", guard)
 	h.Register(router)
 
 	healthStop, err := health.ServeWithPprof(cfg.HealthAddr, 5*time.Second, cfg.PProfEnabled,

--- a/botplatform-service/config.go
+++ b/botplatform-service/config.go
@@ -1,6 +1,11 @@
 package main
 
-import "time"
+import (
+	"time"
+
+	"github.com/hmchangw/chat/pkg/ginutil"
+	"github.com/hmchangw/chat/pkg/mongoutil"
+)
 
 type config struct {
 	Port string `env:"PORT" envDefault:"8080"`
@@ -12,6 +17,9 @@ type config struct {
 	MongoDB       string `env:"MONGO_DB"       envDefault:"chat"`
 	MongoUsername string `env:"MONGO_USERNAME"`
 	MongoPassword string `env:"MONGO_PASSWORD"`
+
+	Pool mongoutil.PoolConfig
+	HTTP ginutil.TimeoutConfig
 
 	// SessionsMaxPerAccount is the per-user FIFO cap; excess sessions are evicted oldest-first.
 	SessionsMaxPerAccount int `env:"SESSIONS_MAX_PER_ACCOUNT" envDefault:"100"`

--- a/botplatform-service/main.go
+++ b/botplatform-service/main.go
@@ -43,13 +43,19 @@ func run() error {
 	if cfg.BcryptCost < 4 || cfg.BcryptCost > 31 {
 		return fmt.Errorf("BCRYPT_COST must be in [4, 31], got %d", cfg.BcryptCost)
 	}
+	if err := cfg.Pool.Validate(); err != nil {
+		return fmt.Errorf("validate mongo pool: %w", err)
+	}
+	if err := cfg.HTTP.Validate(); err != nil {
+		return fmt.Errorf("validate http timeout: %w", err)
+	}
 
 	sdk, obsShutdown, err := obs.Init(ctx)
 	if err != nil {
 		return fmt.Errorf("init observability: %w", err)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk))
 	if err != nil {
 		return fmt.Errorf("connect mongo: %w", err)
 	}
@@ -100,6 +106,7 @@ func run() error {
 	r.Use(o11ygin.Middleware("botplatform-service", sdk.TracerProvider(), sdk.MeterProvider(), obs.PublicIngressPropagator(), o11ygin.WithSkipPaths())...)
 	r.Use(gin.Recovery())
 	r.Use(ginutil.RequestID())
+	r.Use(cfg.HTTP.Middleware())
 	r.Use(accessLogMiddleware())
 	registerRoutes(r, h)
 	registerBotRoutes(r, sessionStore, valkey, &cfg, h)

--- a/broadcast-worker/config_test.go
+++ b/broadcast-worker/config_test.go
@@ -94,3 +94,17 @@ func TestConfig_ThreadViewSubjectEnabled(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, cfg.ThreadViewSubjectEnabled)
 }
+
+func TestConfig_PoolValidate(t *testing.T) {
+	t.Setenv("MODE", "user")
+
+	t.Setenv("MONGO_MAX_POOL_SIZE", "0")
+	cfg, err := env.ParseAs[config]()
+	require.NoError(t, err)
+	require.Error(t, cfg.Pool.Validate()) // zero max is unbounded to the driver — must be rejected
+
+	require.NoError(t, os.Unsetenv("MONGO_MAX_POOL_SIZE"))
+	cfg, err = env.ParseAs[config]()
+	require.NoError(t, err)
+	require.NoError(t, cfg.Pool.Validate()) // envDefault applies
+}

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -51,7 +51,8 @@ type config struct {
 	MongoPassword string   `env:"MONGO_PASSWORD"            envDefault:""`
 	// MongoReadPreference: reads only; writes always hit the primary. secondaryPreferred
 	// offloads reads (a just-joined member is recovered via history).
-	MongoReadPreference  string        `env:"MONGO_READ_PREFERENCE"     envDefault:"secondaryPreferred"`
+	MongoReadPreference  string `env:"MONGO_READ_PREFERENCE"     envDefault:"secondaryPreferred"`
+	Pool                 mongoutil.PoolConfig
 	MaxWorkers           int           `env:"MAX_WORKERS"               envDefault:"100"`
 	LastMsgFlushInterval time.Duration `env:"LAST_MSG_FLUSH_INTERVAL"   envDefault:"250ms"`
 	// RoomActivityRefreshInterval caps how often one room's position is announced
@@ -100,6 +101,11 @@ func main() {
 	}
 	logctx.Configure(cfg.DebugLog)
 
+	if err := cfg.Pool.Validate(); err != nil {
+		slog.Error("invalid config", "error", err)
+		os.Exit(1)
+	}
+
 	if err := model.SetPlatformAdminAccountPrefix(cfg.AdminAcctPrefix); err != nil {
 		slog.Error("invalid ADMIN_ACCT_PREFIX", "error", err)
 		os.Exit(1)
@@ -129,7 +135,7 @@ func main() {
 		os.Exit(1)
 	}
 	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
-		mongoutil.WithObservability(sdk), mongoutil.WithReadPreference(readPref))
+		mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk), mongoutil.WithReadPreference(readPref))
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)

--- a/history-service/cmd/main.go
+++ b/history-service/cmd/main.go
@@ -108,10 +108,9 @@ func main() {
 		os.Exit(1)
 	}
 	mongoClient, err := mongoutil.Connect(ctx, cfg.Mongo.URI, cfg.Mongo.Username, cfg.Mongo.Password,
+		mongoutil.WithPool(cfg.Pool),
 		mongoutil.WithObservability(sdk),
 		mongoutil.WithReadPreference(readPref),
-		mongoutil.WithMaxPoolSize(cfg.Mongo.MaxPoolSize),
-		mongoutil.WithMinPoolSize(cfg.Mongo.MinPoolSize),
 	)
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
@@ -210,32 +209,17 @@ func main() {
 	opts = append(opts, service.WithPageBudget(pageBudget))
 	svc := service.New(cassRepo, subSource, roomSource, pub, threadRoomRepo, threadSubRepo, userStore, appRepo, &cfg, opts...)
 
-	// Bound in-flight handlers so a burst is shed at the door instead of piling
-	// unbounded concurrent work onto the (now explicitly capped) Mongo pool.
-	routerOpts := []natsrouter.Option{natsrouter.WithSiteID(cfg.SiteID), natsrouter.WithMetrics(publishMetrics)}
-	if cfg.MaxConcurrency > 0 {
-		routerOpts = append(routerOpts, natsrouter.WithMaxConcurrency(cfg.MaxConcurrency))
-	}
-	router := natsrouter.New(nc, "history-service", routerOpts...)
-	router.Use(natsrouter.Recovery())
-	// RequestID must precede any handler that reads request_id from ctx —
-	// otherwise Classify's log line records an empty value.
-	router.Use(natsrouter.RequestID())
-	router.Use(natsrouter.Logging())
-	// Deadline every request so a slow Mongo/Cassandra op is cancelled and its
-	// pooled connection released rather than held until the pool starves.
-	if cfg.RequestTimeout > 0 {
-		router.Use(natsrouter.HandlerTimeout(cfg.RequestTimeout))
-	}
+	// Default middleware chain (Recovery, RequestID, Logging) plus this service's
+	// per-site + metrics router options and the guard's admission cap; the
+	// per-request timeout (free a connection stuck on a slow op) is applied after.
+	routerOpts := append([]natsrouter.Option{
+		natsrouter.WithSiteID(cfg.SiteID),
+		natsrouter.WithMetrics(publishMetrics),
+	}, cfg.Guard.Options()...)
+	router := natsrouter.Default(nc, "history-service", routerOpts...)
+	router.Use(cfg.Guard.TimeoutMiddleware()...)
 
 	svc.RegisterHandlers(router, cfg.SiteID)
-
-	slog.Info("connection guards configured",
-		"maxPoolSize", cfg.Mongo.MaxPoolSize,
-		"minPoolSize", cfg.Mongo.MinPoolSize,
-		"maxConcurrency", cfg.MaxConcurrency,
-		"requestTimeout", cfg.RequestTimeout,
-	)
 
 	healthStop, err := health.ServeWithPprof(cfg.HealthAddr, 5*time.Second, cfg.PProfEnabled,
 		natsutil.HealthCheck(nc),

--- a/history-service/deploy/docker-compose.yml
+++ b/history-service/deploy/docker-compose.yml
@@ -23,6 +23,12 @@ services:
       - MONGO_DB=${MONGO_DB:-chat}
       # Read preference; secondaryPreferred offloads the primary, no-op without a replica set.
       - MONGO_READ_PREFERENCE=${MONGO_READ_PREFERENCE:-secondaryPreferred}
+      # Above the 150 fleet default: history-service is read-heavy with
+      # MAX_CONCURRENCY=256, so it wants pool headroom at/above that cap. 384 is
+      # 1.5x the concurrency cap (enough that in-flight handlers never starve at
+      # checkout, with burst headroom) and ~= a 3-node replica set's aggregate
+      # read-ticket capacity (3 x 128). Set the same in the production deployment.
+      - MONGO_MAX_POOL_SIZE=${MONGO_MAX_POOL_SIZE:-384}
       - CASSANDRA_HOSTS=${CASSANDRA_HOSTS:-cassandra}
       - CASSANDRA_KEYSPACE=${CASSANDRA_KEYSPACE:-chat}
       - ATREST_ENABLED=${ATREST_ENABLED:-true}

--- a/history-service/internal/config/config.go
+++ b/history-service/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hmchangw/chat/pkg/atrest"
 	"github.com/hmchangw/chat/pkg/logctx"
 	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/pkg/natsrouter"
 )
 
 // CassandraConfig holds Cassandra connection settings (env prefix: CASSANDRA_).
@@ -21,7 +22,8 @@ type CassandraConfig struct {
 	NumConns int `env:"NUM_CONNS" envDefault:"8"`
 }
 
-// MongoConfig holds MongoDB connection settings (env prefix: MONGO_).
+// MongoConfig holds MongoDB connection settings (env prefix: MONGO_). Pool
+// sizing lives in the shared Config.Pool (mongoutil.PoolConfig).
 type MongoConfig struct {
 	URI      string `env:"URI"      required:"true"`
 	DB       string `env:"DB"       envDefault:"chat"`
@@ -30,16 +32,6 @@ type MongoConfig struct {
 	// ReadPreference is the client-level read preference; secondaryPreferred offloads
 	// history reads. DEK reads pin to primary in code regardless.
 	ReadPreference string `env:"READ_PREFERENCE" envDefault:"secondaryPreferred"`
-	// MaxPoolSize caps connections per server. This is authoritative — it is
-	// always applied to the client, overriding any maxPoolSize in the URI — so
-	// the pool ceiling is explicit rather than the driver default of 100.
-	// Connections are created lazily and are further gated by MAX_CONCURRENCY
-	// (a handler holds at most one at a time), so this is a generous headroom
-	// ceiling, not a count of connections that get opened. Operators must keep
-	// pods × MaxPoolSize under the cluster's connection limit.
-	MaxPoolSize uint64 `env:"MAX_POOL_SIZE" envDefault:"500"`
-	// MinPoolSize keeps a warm connection floor; 0 lets the pool drain to empty.
-	MinPoolSize uint64 `env:"MIN_POOL_SIZE" envDefault:"0"`
 }
 
 // NATSConfig holds NATS connection settings (env prefix: NATS_).
@@ -56,25 +48,22 @@ type Config struct {
 	MetricsAddr             string          `env:"METRICS_ADDR"               envDefault:":9090"`
 	Cassandra               CassandraConfig `envPrefix:"CASSANDRA_"`
 	Mongo                   MongoConfig     `envPrefix:"MONGO_"`
-	NATS                    NATSConfig      `envPrefix:"NATS_"`
-	MessageBucketHours      int             `env:"MESSAGE_BUCKET_HOURS"        envDefault:"360"`
-	MessageReadMaxBuckets   int             `env:"MESSAGE_READ_MAX_BUCKETS"    envDefault:"122"`
-	MessageHistoryFloorDays int             `env:"MESSAGE_HISTORY_FLOOR_DAYS"  envDefault:"730"`
-	LargeRoomThreshold      int             `env:"LARGE_ROOM_THRESHOLD"        envDefault:"500"`
-	MaxPinnedPerRoom        int             `env:"MAX_PINNED_PER_ROOM"         envDefault:"10"`
-	PinEnabled              bool            `env:"PIN_ENABLED"                 envDefault:"true"`
+	Pool                    mongoutil.PoolConfig
+	NATS                    NATSConfig `envPrefix:"NATS_"`
+	MessageBucketHours      int        `env:"MESSAGE_BUCKET_HOURS"        envDefault:"360"`
+	MessageReadMaxBuckets   int        `env:"MESSAGE_READ_MAX_BUCKETS"    envDefault:"122"`
+	MessageHistoryFloorDays int        `env:"MESSAGE_HISTORY_FLOOR_DAYS"  envDefault:"730"`
+	LargeRoomThreshold      int        `env:"LARGE_ROOM_THRESHOLD"        envDefault:"500"`
+	MaxPinnedPerRoom        int        `env:"MAX_PINNED_PER_ROOM"         envDefault:"10"`
+	PinEnabled              bool       `env:"PIN_ENABLED"                 envDefault:"true"`
 
 	// AdminAcctPrefix overrides the platform-admin account prefix (ADMIN_ACCT_PREFIX); keep it identical across services.
 	AdminAcctPrefix string `env:"ADMIN_ACCT_PREFIX" envDefault:"p_admin"`
 
-	// MaxConcurrency caps in-flight request handlers so a burst is shed at the
-	// door (ErrUnavailable) instead of piling unbounded work onto MongoDB. 0
-	// disables the cap (unbounded spawn — the previous behavior).
-	MaxConcurrency int `env:"MAX_CONCURRENCY" envDefault:"256"`
-	// RequestTimeout bounds each request handler so a slow MongoDB/Cassandra op
-	// is cancelled and its pooled connection returned instead of held. 0
-	// disables the per-request deadline.
-	RequestTimeout time.Duration `env:"REQUEST_TIMEOUT" envDefault:"10s"`
+	// Guard bounds in-flight request handlers (MAX_CONCURRENCY) and per-request
+	// duration (REQUEST_TIMEOUT) so a burst or a slow dependency can't saturate
+	// the Mongo pool with unbounded, indefinitely-held work.
+	Guard natsrouter.GuardConfig
 	// MaxResponseBytes caps a paginated reply so it is trimmed to fit rather
 	// than refused by the broker. 0 derives the cap from the broker's
 	// advertised max_payload.
@@ -146,18 +135,11 @@ func validate(cfg *Config) error {
 	if _, err := mongoutil.ParseReadPreference(cfg.Mongo.ReadPreference); err != nil {
 		return fmt.Errorf("MONGO_READ_PREFERENCE: %w", err)
 	}
-	// 0 makes the driver treat the pool as unbounded — reject it so the cap stays explicit.
-	if cfg.Mongo.MaxPoolSize < 1 {
-		return fmt.Errorf("MONGO_MAX_POOL_SIZE must be >= 1, got %d", cfg.Mongo.MaxPoolSize)
+	if err := cfg.Pool.Validate(); err != nil {
+		return err
 	}
-	if cfg.Mongo.MinPoolSize > cfg.Mongo.MaxPoolSize {
-		return fmt.Errorf("MONGO_MIN_POOL_SIZE (%d) must be <= MONGO_MAX_POOL_SIZE (%d)", cfg.Mongo.MinPoolSize, cfg.Mongo.MaxPoolSize)
-	}
-	if cfg.MaxConcurrency < 0 {
-		return fmt.Errorf("MAX_CONCURRENCY must be >= 0, got %d", cfg.MaxConcurrency)
-	}
-	if cfg.RequestTimeout < 0 {
-		return fmt.Errorf("REQUEST_TIMEOUT must be >= 0, got %s", cfg.RequestTimeout)
+	if err := cfg.Guard.Validate(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/history-service/internal/config/config_test.go
+++ b/history-service/internal/config/config_test.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/pkg/natsrouter"
 )
 
 // baseValid returns a Config with all tunable knobs at valid values so each test
@@ -20,12 +23,8 @@ func baseValid() Config {
 		RoomCacheTTL:     10 * time.Second,
 		PreviewCacheSize: 50000,
 		PreviewCacheTTL:  10 * time.Second,
-		MaxConcurrency:   256,
-		RequestTimeout:   10 * time.Second,
-		Mongo: MongoConfig{
-			MaxPoolSize: 100,
-			MinPoolSize: 0,
-		},
+		Pool:             mongoutil.PoolConfig{MaxPoolSize: 500, MinPoolSize: 0},
+		Guard:            natsrouter.GuardConfig{MaxConcurrency: 256, RequestTimeout: 10 * time.Second},
 	}
 }
 
@@ -77,61 +76,24 @@ func TestValidate_RejectsNegativeRoomCacheTTL(t *testing.T) {
 	assert.Contains(t, err.Error(), "HISTORY_ROOM_CACHE_TTL")
 }
 
-// maxPoolSize=0 makes the driver treat the pool as unbounded — the opposite of
-// an explicit cap — so it is rejected rather than silently uncapping the pool.
-func TestValidate_RejectsZeroMaxPoolSize(t *testing.T) {
+// validate() delegates pool checks to mongoutil.PoolConfig.Validate — the
+// exhaustive cases live in that package's tests; this just proves it's wired.
+func TestValidate_DelegatesPoolValidation(t *testing.T) {
 	cfg := baseValid()
-	cfg.Mongo.MaxPoolSize = 0
+	cfg.Pool.MaxPoolSize = 0
 	err := validate(&cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "MONGO_MAX_POOL_SIZE")
 }
 
-func TestValidate_RejectsMinPoolSizeAboveMax(t *testing.T) {
+// validate() delegates the concurrency/timeout checks to
+// natsrouter.GuardConfig.Validate — again just proving the wiring.
+func TestValidate_DelegatesGuardValidation(t *testing.T) {
 	cfg := baseValid()
-	cfg.Mongo.MaxPoolSize = 100
-	cfg.Mongo.MinPoolSize = 200
-	err := validate(&cfg)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "MONGO_MIN_POOL_SIZE")
-}
-
-func TestValidate_AcceptsMinPoolSizeEqualToMax(t *testing.T) {
-	cfg := baseValid()
-	cfg.Mongo.MaxPoolSize = 100
-	cfg.Mongo.MinPoolSize = 100
-	require.NoError(t, validate(&cfg))
-}
-
-// 0 disables the concurrency cap (unbounded spawn); it is the documented
-// disable value, so it must validate.
-func TestValidate_AcceptsZeroMaxConcurrencyAsDisable(t *testing.T) {
-	cfg := baseValid()
-	cfg.MaxConcurrency = 0
-	require.NoError(t, validate(&cfg))
-}
-
-func TestValidate_RejectsNegativeMaxConcurrency(t *testing.T) {
-	cfg := baseValid()
-	cfg.MaxConcurrency = -1
+	cfg.Guard.MaxConcurrency = -1
 	err := validate(&cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "MAX_CONCURRENCY")
-}
-
-// 0 disables the per-request timeout; it is the documented disable value.
-func TestValidate_AcceptsZeroRequestTimeoutAsDisable(t *testing.T) {
-	cfg := baseValid()
-	cfg.RequestTimeout = 0
-	require.NoError(t, validate(&cfg))
-}
-
-func TestValidate_RejectsNegativeRequestTimeout(t *testing.T) {
-	cfg := baseValid()
-	cfg.RequestTimeout = -1 * time.Second
-	err := validate(&cfg)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "REQUEST_TIMEOUT")
 }
 
 func TestValidate_RejectsNegativePreviewCacheSize(t *testing.T) {

--- a/hr-sync-worker/config.go
+++ b/hr-sync-worker/config.go
@@ -1,6 +1,9 @@
 package main
 
-import "github.com/hmchangw/chat/pkg/stream"
+import (
+	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/pkg/stream"
+)
 
 // config is hr-sync-worker's environment configuration. One durable consumer
 // per entry in SITE_IDS (each site's HR-{siteID} stream).
@@ -14,6 +17,7 @@ type config struct {
 	MongoWriteUsername string `env:"MONGO_WRITE_USERNAME" envDefault:""`
 	MongoWritePassword string `env:"MONGO_WRITE_PASSWORD" envDefault:""`
 	MongoWriteDB       string `env:"MONGO_WRITE_DB" envDefault:"chat"`
+	Pool               mongoutil.PoolConfig
 
 	Consumer   stream.ConsumerSettings `envPrefix:"CONSUMER_"`
 	Bootstrap  bootstrapConfig         `envPrefix:"BOOTSTRAP_"`

--- a/hr-sync-worker/main.go
+++ b/hr-sync-worker/main.go
@@ -34,6 +34,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := cfg.Pool.Validate(); err != nil {
+		slog.Error("invalid mongo pool config", "error", err)
+		os.Exit(1)
+	}
+
 	ctx := context.Background()
 
 	sdk, obsShutdown, err := obs.Init(ctx)
@@ -42,7 +47,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoWriteURI, cfg.MongoWriteUsername, cfg.MongoWritePassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoWriteURI, cfg.MongoWriteUsername, cfg.MongoWritePassword, mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk))
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)

--- a/inbox-worker/consumer_config_test.go
+++ b/inbox-worker/consumer_config_test.go
@@ -62,6 +62,13 @@ func TestConfig_ValkeyAddrsParsed(t *testing.T) {
 	assert.Equal(t, "hunter2", cfg.ValkeyPassword)
 }
 
+func TestConfig_PoolValidate_RejectsZeroMaxPoolSize(t *testing.T) {
+	t.Setenv("MONGO_MAX_POOL_SIZE", "0")
+	cfg, err := env.ParseAs[config]()
+	require.NoError(t, err)
+	assert.Error(t, cfg.Pool.Validate())
+}
+
 func TestIsMembershipSubject(t *testing.T) {
 	const siteID = "site-a"
 	t.Run("member_added is membership", func(t *testing.T) {

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -39,7 +39,8 @@ type config struct {
 	MongoDB       string `env:"MONGO_DB"        envDefault:"chat"`
 	MongoUsername string `env:"MONGO_USERNAME"  envDefault:""`
 	MongoPassword string `env:"MONGO_PASSWORD"  envDefault:""`
-	MaxWorkers    int    `env:"MAX_WORKERS"     envDefault:"100"`
+	Pool          mongoutil.PoolConfig
+	MaxWorkers    int `env:"MAX_WORKERS"     envDefault:"100"`
 	// RoomSubCache memoizes the room-membership check on the activity-refresh
 	// lane, which would otherwise cost a Mongo read per broadcast message.
 	// Either value non-positive disables it.
@@ -745,6 +746,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := cfg.Pool.Validate(); err != nil {
+		slog.Error("invalid mongo pool config", "error", err)
+		os.Exit(1)
+	}
+
 	if err := model.SetPlatformAdminAccountPrefix(cfg.AdminAcctPrefix); err != nil {
 		slog.Error("invalid ADMIN_ACCT_PREFIX", "error", err)
 		os.Exit(1)
@@ -758,7 +764,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk))
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)

--- a/media-service/config.go
+++ b/media-service/config.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/pkg/natsrouter"
 )
 
 // clusterDomain maps a site to its media-service base URL (incl. scheme).
@@ -58,6 +61,10 @@ type config struct {
 	MongoUsername string `env:"MONGO_USERNAME"`
 	MongoPassword string `env:"MONGO_PASSWORD"`
 
+	// Pool bounds the shared Mongo client's connection pool
+	// (MONGO_MAX_POOL_SIZE / MONGO_MIN_POOL_SIZE).
+	Pool mongoutil.PoolConfig
+
 	MinioEndpoint  string `env:"MINIO_ENDPOINT,required"`
 	MinioAccessKey string `env:"MINIO_ACCESS_KEY,required"`
 	MinioSecretKey string `env:"MINIO_SECRET_KEY,required"`
@@ -91,10 +98,9 @@ type config struct {
 	// the service must not start in a configuration that serves the writes anonymously.
 	BotplatformURL string `env:"BOTPLATFORM_URL,required,notEmpty"`
 
-	// MaxConcurrency caps in-flight request handlers so a burst is shed at the
-	// door (ErrUnavailable) instead of piling unbounded work onto MongoDB/MinIO.
-	// 0 disables the cap (unbounded spawn).
-	MaxConcurrency int `env:"MAX_CONCURRENCY" envDefault:"256"`
+	// Guard bounds in-flight NATS request handlers (MAX_CONCURRENCY) and
+	// per-request duration (REQUEST_TIMEOUT) on the NATS request/reply side.
+	Guard natsrouter.GuardConfig
 }
 
 // clusterBaseURL returns the configured base URL for a site, or "" if unknown.

--- a/media-service/config_test.go
+++ b/media-service/config_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/caarlos0/env/v11"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/natsrouter"
 )
 
 func TestClusterBaseURL(t *testing.T) {
@@ -80,14 +82,14 @@ func TestConfig_MaxConcurrency(t *testing.T) {
 		require.NoError(t, os.Unsetenv("MAX_CONCURRENCY"))
 		cfg, err := env.ParseAs[config]()
 		require.NoError(t, err)
-		assert.Equal(t, 256, cfg.MaxConcurrency)
+		assert.Equal(t, 256, cfg.Guard.MaxConcurrency)
 	})
 
 	t.Run("override", func(t *testing.T) {
 		t.Setenv("MAX_CONCURRENCY", "64")
 		cfg, err := env.ParseAs[config]()
 		require.NoError(t, err)
-		assert.Equal(t, 64, cfg.MaxConcurrency)
+		assert.Equal(t, 64, cfg.Guard.MaxConcurrency)
 	})
 }
 
@@ -141,4 +143,10 @@ func TestConfig_NATSURLRequired(t *testing.T) {
 	_, err := env.ParseAs[config]()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "NATS_URL")
+}
+
+func TestConfig_GuardsDelegateValidation(t *testing.T) {
+	assert.Error(t, config{}.Pool.Validate(), "zero MaxPoolSize must fail")
+	assert.Error(t, config{Guard: natsrouter.GuardConfig{MaxConcurrency: -1}}.Guard.Validate(),
+		"negative MaxConcurrency must fail")
 }

--- a/media-service/main.go
+++ b/media-service/main.go
@@ -48,13 +48,20 @@ func run() error {
 	if cfg.EIDCacheTTL <= 0 {
 		return fmt.Errorf("EID_CACHE_TTL must be positive, got %s", cfg.EIDCacheTTL)
 	}
+	if err := cfg.Pool.Validate(); err != nil {
+		return err
+	}
+	if err := cfg.Guard.Validate(); err != nil {
+		return err
+	}
 
 	sdk, obsShutdown, err := obs.Init(ctx)
 	if err != nil {
 		return fmt.Errorf("init observability: %w", err)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk))
 	if err != nil {
 		return fmt.Errorf("connect mongo: %w", err)
 	}
@@ -78,14 +85,7 @@ func run() error {
 
 	h := newHandler(store, store, blobs, &cfg)
 
-	// Bound in-flight handlers so a burst is shed at the door (ErrUnavailable)
-	// instead of piling unbounded work onto MongoDB/MinIO. MAX_CONCURRENCY=0 disables.
-	routerOpts := []natsrouter.Option{natsrouter.WithSiteID(cfg.SiteID)}
-	if cfg.MaxConcurrency > 0 {
-		routerOpts = append(routerOpts, natsrouter.WithMaxConcurrency(cfg.MaxConcurrency))
-	}
-	router := natsrouter.New(nc, "media-service", routerOpts...)
-	router.Use(natsrouter.Recovery(), natsrouter.RequestID(), natsrouter.Logging())
+	router := natsrouter.DefaultGuarded(nc, "media-service", cfg.Guard)
 	registerEmojiNATS(router, h, cfg.SiteID)
 
 	gin.SetMode(gin.ReleaseMode)
@@ -95,6 +95,10 @@ func run() error {
 	r.Use(gin.Recovery())
 	r.Use(requestIDMiddleware())
 	r.Use(accessLogMiddleware())
+	// No blanket HTTP timeout: the avatar/emoji GET routes stream blobs via
+	// c.DataFromReader and the PUT routes accept uploads, both bound to the
+	// request context — a short deadline would cancel a slow up/download
+	// mid-stream. (The NATS request/reply side still uses cfg.Guard.)
 	sessions := botauth.NewValidator(
 		restyutil.New("", restyutil.WithTimeout(5*time.Second), restyutil.WithMaxIdleConns(32)), cfg.BotplatformURL)
 	registerRoutes(r, h, sessions, cfg.SiteID)

--- a/message-gatekeeper/main.go
+++ b/message-gatekeeper/main.go
@@ -26,13 +26,14 @@ import (
 )
 
 type config struct {
-	NatsURL            string                  `env:"NATS_URL,required"`
-	NatsCredsFile      string                  `env:"NATS_CREDS_FILE" envDefault:""`
-	SiteID             string                  `env:"SITE_ID,required"`
-	MongoURI           string                  `env:"MONGO_URI,required"`
-	MongoDB            string                  `env:"MONGO_DB"        envDefault:"chat"`
-	MongoUsername      string                  `env:"MONGO_USERNAME"  envDefault:""`
-	MongoPassword      string                  `env:"MONGO_PASSWORD"  envDefault:""`
+	NatsURL            string `env:"NATS_URL,required"`
+	NatsCredsFile      string `env:"NATS_CREDS_FILE" envDefault:""`
+	SiteID             string `env:"SITE_ID,required"`
+	MongoURI           string `env:"MONGO_URI,required"`
+	MongoDB            string `env:"MONGO_DB"        envDefault:"chat"`
+	MongoUsername      string `env:"MONGO_USERNAME"  envDefault:""`
+	MongoPassword      string `env:"MONGO_PASSWORD"  envDefault:""`
+	Pool               mongoutil.PoolConfig
 	MaxWorkers         int                     `env:"MAX_WORKERS"     envDefault:"100"`
 	LargeRoomThreshold int                     `env:"LARGE_ROOM_THRESHOLD" envDefault:"500"`
 	MaxAttachments     int                     `env:"MAX_ATTACHMENTS"      envDefault:"1"`
@@ -71,6 +72,11 @@ func main() {
 	}
 	logctx.Configure(cfg.DebugLog)
 
+	if err := cfg.Pool.Validate(); err != nil {
+		slog.Error("invalid config", "error", err)
+		os.Exit(1)
+	}
+
 	if err := model.SetPlatformAdminAccountPrefix(cfg.AdminAcctPrefix); err != nil {
 		slog.Error("invalid ADMIN_ACCT_PREFIX", "error", err)
 		os.Exit(1)
@@ -98,7 +104,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk))
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)

--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -33,21 +33,22 @@ type config struct {
 	// Mode selects which stream/consumer this pod binds: "default" runs the live
 	// .created feed off MESSAGES-CANONICAL; "teams" runs the Teams-migration batch
 	// feed off MESSAGES-TEAMS. Two deploys of the same binary, gated by env only.
-	Mode               string                  `env:"MODE"                 envDefault:"default"`
-	NatsURL            string                  `env:"NATS_URL,required"`
-	NatsCredsFile      string                  `env:"NATS_CREDS_FILE"      envDefault:""`
-	SiteID             string                  `env:"SITE_ID,required"`
-	CassandraHosts     string                  `env:"CASSANDRA_HOSTS"      envDefault:"localhost"`
-	CassandraKeyspace  string                  `env:"CASSANDRA_KEYSPACE"   envDefault:"chat"`
-	CassandraUsername  string                  `env:"CASSANDRA_USERNAME"   envDefault:""`
-	CassandraPassword  string                  `env:"CASSANDRA_PASSWORD"   envDefault:""`
-	CassandraNumConns  int                     `env:"CASSANDRA_NUM_CONNS"  envDefault:"8"`
-	MaxWorkers         int                     `env:"MAX_WORKERS"          envDefault:"100"`
-	MessageBucketHours int                     `env:"MESSAGE_BUCKET_HOURS" envDefault:"360"`
-	MongoURI           string                  `env:"MONGO_URI,required"`
-	MongoDB            string                  `env:"MONGO_DB"             envDefault:"chat"`
-	MongoUsername      string                  `env:"MONGO_USERNAME"       envDefault:""`
-	MongoPassword      string                  `env:"MONGO_PASSWORD"       envDefault:""`
+	Mode               string `env:"MODE"                 envDefault:"default"`
+	NatsURL            string `env:"NATS_URL,required"`
+	NatsCredsFile      string `env:"NATS_CREDS_FILE"      envDefault:""`
+	SiteID             string `env:"SITE_ID,required"`
+	CassandraHosts     string `env:"CASSANDRA_HOSTS"      envDefault:"localhost"`
+	CassandraKeyspace  string `env:"CASSANDRA_KEYSPACE"   envDefault:"chat"`
+	CassandraUsername  string `env:"CASSANDRA_USERNAME"   envDefault:""`
+	CassandraPassword  string `env:"CASSANDRA_PASSWORD"   envDefault:""`
+	CassandraNumConns  int    `env:"CASSANDRA_NUM_CONNS"  envDefault:"8"`
+	MaxWorkers         int    `env:"MAX_WORKERS"          envDefault:"100"`
+	MessageBucketHours int    `env:"MESSAGE_BUCKET_HOURS" envDefault:"360"`
+	MongoURI           string `env:"MONGO_URI,required"`
+	MongoDB            string `env:"MONGO_DB"             envDefault:"chat"`
+	MongoUsername      string `env:"MONGO_USERNAME"       envDefault:""`
+	MongoPassword      string `env:"MONGO_PASSWORD"       envDefault:""`
+	Pool               mongoutil.PoolConfig
 	UserCacheSize      int                     `env:"USER_CACHE_SIZE"      envDefault:"10000"`
 	UserCacheTTL       time.Duration           `env:"USER_CACHE_TTL"       envDefault:"5m"`
 	HealthAddr         string                  `env:"HEALTH_ADDR"          envDefault:":8081"`
@@ -73,6 +74,11 @@ func main() {
 
 	if cfg.Mode != "default" && cfg.Mode != "teams" {
 		slog.Error("invalid config", "MODE", cfg.Mode, "reason", `must be "default" or "teams"`)
+		os.Exit(1)
+	}
+
+	if err := cfg.Pool.Validate(); err != nil {
+		slog.Error("invalid config", "error", err)
 		os.Exit(1)
 	}
 
@@ -118,7 +124,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk))
 	if err != nil {
 		slog.Error("mongodb connect failed", "error", err)
 		os.Exit(1)

--- a/notification-worker/config_test.go
+++ b/notification-worker/config_test.go
@@ -114,3 +114,18 @@ func TestConfig_MentionNamesKillSwitch(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, cfg.MentionNamesEnabled)
 }
+
+func TestConfig_PoolValidate(t *testing.T) {
+	t.Setenv("VALKEY_ADDRS", "valkey:6379")
+	t.Setenv("MODE", "user")
+
+	t.Setenv("MONGO_MAX_POOL_SIZE", "0")
+	cfg, err := env.ParseAs[config]()
+	require.NoError(t, err)
+	require.Error(t, cfg.Pool.Validate()) // zero max is unbounded to the driver — must be rejected
+
+	require.NoError(t, os.Unsetenv("MONGO_MAX_POOL_SIZE"))
+	cfg, err = env.ParseAs[config]()
+	require.NoError(t, err)
+	require.NoError(t, cfg.Pool.Validate()) // envDefault applies
+}

--- a/notification-worker/main.go
+++ b/notification-worker/main.go
@@ -45,7 +45,8 @@ type config struct {
 	MongoPassword string `env:"MONGO_PASSWORD"            envDefault:""`
 	// MongoReadPreference: read-only service (fan-out lookups); secondaryPreferred
 	// offloads the primary.
-	MongoReadPreference    string                  `env:"MONGO_READ_PREFERENCE"     envDefault:"secondaryPreferred"`
+	MongoReadPreference    string `env:"MONGO_READ_PREFERENCE"     envDefault:"secondaryPreferred"`
+	Pool                   mongoutil.PoolConfig
 	MaxWorkers             int                     `env:"MAX_WORKERS"               envDefault:"100"`
 	LargeRoomThreshold     int                     `env:"LARGE_ROOM_THRESHOLD"      envDefault:"500"`
 	PushRecipientBatchSize int                     `env:"PUSH_RECIPIENT_BATCH_SIZE" envDefault:"100"`
@@ -188,6 +189,10 @@ func main() {
 		slog.Error("VALKEY_ADDRS required")
 		os.Exit(1)
 	}
+	if err := cfg.Pool.Validate(); err != nil {
+		slog.Error("invalid config", "error", err)
+		os.Exit(1)
+	}
 
 	ctx := context.Background()
 
@@ -206,7 +211,7 @@ func main() {
 		os.Exit(1)
 	}
 	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
-		mongoutil.WithObservability(sdk), mongoutil.WithReadPreference(readPref))
+		mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk), mongoutil.WithReadPreference(readPref))
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)

--- a/pkg/ginutil/timeout.go
+++ b/pkg/ginutil/timeout.go
@@ -1,0 +1,25 @@
+package ginutil
+
+import (
+	"context"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Timeout bounds each request by deriving a context deadline on the request, so
+// a slow downstream op (e.g. a MongoDB query) is cancelled and its pooled
+// connection released rather than held until the pool starves. It complements
+// the http.Server read/write timeouts, which bound the socket but do not cancel
+// the handler's context. A non-positive duration is a no-op.
+func Timeout(d time.Duration) gin.HandlerFunc {
+	if d <= 0 {
+		return func(c *gin.Context) { c.Next() }
+	}
+	return func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), d)
+		defer cancel()
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	}
+}

--- a/pkg/ginutil/timeout_test.go
+++ b/pkg/ginutil/timeout_test.go
@@ -1,0 +1,45 @@
+package ginutil
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeout_SetsDeadlineOnRequestContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(Timeout(50 * time.Millisecond))
+
+	var hadDeadline bool
+	r.GET("/x", func(c *gin.Context) {
+		_, hadDeadline = c.Request.Context().Deadline()
+		c.Status(200)
+	})
+
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/x", nil))
+	require.True(t, hadDeadline, "handler context must carry a deadline")
+}
+
+func TestTimeout_DoneFiresAfterExpiry(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(Timeout(20 * time.Millisecond))
+
+	var cancelled bool
+	r.GET("/x", func(c *gin.Context) {
+		select {
+		case <-c.Request.Context().Done():
+			cancelled = true
+		case <-time.After(2 * time.Second):
+		}
+		c.Status(200)
+	})
+
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/x", nil))
+	assert.True(t, cancelled, "context must be cancelled after the timeout elapses")
+}

--- a/pkg/ginutil/timeoutconfig.go
+++ b/pkg/ginutil/timeoutconfig.go
@@ -1,0 +1,32 @@
+package ginutil
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TimeoutConfig is an env-tagged per-request HTTP timeout, the Gin-side parallel
+// of natsrouter.GuardConfig's timeout half. Add it as a named field to an HTTP
+// service's config, call Validate() during config load, and Use(Middleware()) on
+// the engine — so the field, its validation, and the wiring live in one place
+// instead of being re-declared per service.
+type TimeoutConfig struct {
+	// RequestTimeout bounds each request so a slow downstream op is cancelled and
+	// its connection released; 0 disables the deadline.
+	RequestTimeout time.Duration `env:"REQUEST_TIMEOUT" envDefault:"10s"`
+}
+
+// Validate rejects a negative timeout; zero is the documented disable value.
+func (c TimeoutConfig) Validate() error {
+	if c.RequestTimeout < 0 {
+		return fmt.Errorf("REQUEST_TIMEOUT must be >= 0, got %s", c.RequestTimeout)
+	}
+	return nil
+}
+
+// Middleware returns the per-request timeout middleware (a no-op when disabled).
+func (c TimeoutConfig) Middleware() gin.HandlerFunc {
+	return Timeout(c.RequestTimeout)
+}

--- a/pkg/ginutil/timeoutconfig_test.go
+++ b/pkg/ginutil/timeoutconfig_test.go
@@ -1,0 +1,34 @@
+package ginutil
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeoutConfig_Validate(t *testing.T) {
+	require.NoError(t, TimeoutConfig{RequestTimeout: 10 * time.Second}.Validate())
+	require.NoError(t, TimeoutConfig{RequestTimeout: 0}.Validate(), "zero disables, not invalid")
+
+	err := TimeoutConfig{RequestTimeout: -1}.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "REQUEST_TIMEOUT")
+}
+
+func TestTimeoutConfig_Middleware_SetsDeadline(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(TimeoutConfig{RequestTimeout: 50 * time.Millisecond}.Middleware())
+
+	var hadDeadline bool
+	r.GET("/x", func(c *gin.Context) {
+		_, hadDeadline = c.Request.Context().Deadline()
+		c.Status(200)
+	})
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/x", nil))
+	require.True(t, hadDeadline)
+}

--- a/pkg/mongoutil/poolconfig.go
+++ b/pkg/mongoutil/poolconfig.go
@@ -1,0 +1,50 @@
+package mongoutil
+
+import "fmt"
+
+// PoolConfig is an env-tagged MongoDB connection-pool configuration. Add it as a
+// named field to a service's config (e.g. `Pool mongoutil.PoolConfig`), call
+// Validate() during config load, and pass WithPool(cfg.Pool) to Connect — so
+// every service's pool ceiling is explicit and tunable rather than the driver
+// default of 100. The env tags carry the full MONGO_ prefix so the field works
+// whether it sits in a flat config or alongside a MONGO_-prefixed block.
+//
+// The 150 default sits just above a mongod node's ~128 WiredTiger read-ticket
+// ceiling: enough headroom to keep tickets saturated without over-provisioning
+// connections fleet-wide. A high-throughput service whose in-flight handler cap
+// exceeds this (e.g. history-service, MAX_CONCURRENCY=256) should raise
+// MONGO_MAX_POOL_SIZE in its own deployment. Connections are created lazily and,
+// in a request/reply service, further gated by the handler cap, so this is a
+// ceiling, not a count of connections opened. Size pods × MaxPoolSize under the
+// cluster's connection limit — and note a service that opens separate read and
+// write clients applies this cap to each, so its ceiling is 2 × MaxPoolSize.
+type PoolConfig struct {
+	MaxPoolSize uint64 `env:"MONGO_MAX_POOL_SIZE" envDefault:"150"`
+	MinPoolSize uint64 `env:"MONGO_MIN_POOL_SIZE" envDefault:"0"`
+}
+
+// WithPool is a Connect option that applies this pool configuration, so call
+// sites read `Connect(ctx, uri, u, p, mongoutil.WithPool(cfg.Pool), ...)` rather
+// than hand-splicing pool options into the variadic. MaxPoolSize is always
+// applied (authoritative, validated >= 1); MinPoolSize is applied only when > 0,
+// so an unset floor leaves a minPoolSize from the URI (or the driver default)
+// intact rather than forcing it to 0.
+func WithPool(p PoolConfig) Option {
+	return func(c *connectConfig) {
+		c.maxPoolSize = &p.MaxPoolSize
+		if p.MinPoolSize > 0 {
+			c.minPoolSize = &p.MinPoolSize
+		}
+	}
+}
+
+// Validate rejects a zero max (the driver reads 0 as unbounded) and a min above max.
+func (p PoolConfig) Validate() error {
+	if p.MaxPoolSize < 1 {
+		return fmt.Errorf("MONGO_MAX_POOL_SIZE must be >= 1, got %d", p.MaxPoolSize)
+	}
+	if p.MinPoolSize > p.MaxPoolSize {
+		return fmt.Errorf("MONGO_MIN_POOL_SIZE (%d) must be <= MONGO_MAX_POOL_SIZE (%d)", p.MinPoolSize, p.MaxPoolSize)
+	}
+	return nil
+}

--- a/pkg/mongoutil/poolconfig_test.go
+++ b/pkg/mongoutil/poolconfig_test.go
@@ -1,0 +1,48 @@
+package mongoutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+func TestWithPool_AppliesToClient(t *testing.T) {
+	clientOpts := options.Client()
+	newConnectConfig(WithPool(PoolConfig{MaxPoolSize: 300, MinPoolSize: 20})).applyTuning(clientOpts)
+
+	require.NotNil(t, clientOpts.MaxPoolSize)
+	require.NotNil(t, clientOpts.MinPoolSize)
+	assert.Equal(t, uint64(300), *clientOpts.MaxPoolSize)
+	assert.Equal(t, uint64(20), *clientOpts.MinPoolSize)
+}
+
+// MinPoolSize=0 (the default) must NOT emit a min option — otherwise it clobbers
+// a minPoolSize supplied via the connection URI, defeating the nil-skip contract
+// in tuning.go. Max stays authoritative (always applied).
+func TestWithPool_OmitsMinPoolSizeWhenZero(t *testing.T) {
+	clientOpts := options.Client()
+	newConnectConfig(WithPool(PoolConfig{MaxPoolSize: 500, MinPoolSize: 0})).applyTuning(clientOpts)
+
+	require.NotNil(t, clientOpts.MaxPoolSize)
+	assert.Equal(t, uint64(500), *clientOpts.MaxPoolSize)
+	assert.Nil(t, clientOpts.MinPoolSize, "zero MinPoolSize must leave a URI/driver value intact")
+}
+
+func TestPoolConfig_Validate_AcceptsValid(t *testing.T) {
+	require.NoError(t, PoolConfig{MaxPoolSize: 500, MinPoolSize: 0}.Validate())
+	require.NoError(t, PoolConfig{MaxPoolSize: 100, MinPoolSize: 100}.Validate())
+}
+
+func TestPoolConfig_Validate_RejectsZeroMax(t *testing.T) {
+	err := PoolConfig{MaxPoolSize: 0}.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MONGO_MAX_POOL_SIZE")
+}
+
+func TestPoolConfig_Validate_RejectsMinAboveMax(t *testing.T) {
+	err := PoolConfig{MaxPoolSize: 100, MinPoolSize: 200}.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MONGO_MIN_POOL_SIZE")
+}

--- a/pkg/natsrouter/guard.go
+++ b/pkg/natsrouter/guard.go
@@ -1,0 +1,67 @@
+package natsrouter
+
+import (
+	"fmt"
+	"time"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+)
+
+// GuardConfig is an env-tagged bundle of the two request/reply overload guards:
+// an in-flight handler cap and a per-request timeout. Add it as a named field to
+// a service's config (e.g. `Guard natsrouter.GuardConfig`), call Validate()
+// during config load, pass Options() to New, and Use() the TimeoutMiddleware()
+// after the standard middleware.
+//
+// Together they keep a burst or a slow dependency from spawning unbounded
+// handlers and holding pooled connections: excess requests are shed with
+// ErrUnavailable, and a stalled op is cancelled so its connection is returned.
+type GuardConfig struct {
+	// MaxConcurrency caps concurrent in-flight handlers; 0 disables the cap.
+	MaxConcurrency int `env:"MAX_CONCURRENCY" envDefault:"256"`
+	// RequestTimeout bounds each handler so a slow dependency op is cancelled
+	// and its connection released; 0 disables the deadline.
+	RequestTimeout time.Duration `env:"REQUEST_TIMEOUT" envDefault:"10s"`
+}
+
+// Validate rejects negative values; zero is the documented disable value for both.
+func (g GuardConfig) Validate() error {
+	if g.MaxConcurrency < 0 {
+		return fmt.Errorf("MAX_CONCURRENCY must be >= 0, got %d", g.MaxConcurrency)
+	}
+	if g.RequestTimeout < 0 {
+		return fmt.Errorf("REQUEST_TIMEOUT must be >= 0, got %s", g.RequestTimeout)
+	}
+	return nil
+}
+
+// Options returns the router construction options for this guard (the admission
+// cap when MaxConcurrency > 0, none otherwise).
+func (g GuardConfig) Options() []Option {
+	var opts []Option
+	if g.MaxConcurrency > 0 {
+		opts = append(opts, WithMaxConcurrency(g.MaxConcurrency))
+	}
+	return opts
+}
+
+// TimeoutMiddleware returns the per-request timeout middleware (empty when
+// RequestTimeout is 0), suitable for spreading into Use().
+func (g GuardConfig) TimeoutMiddleware() []HandlerFunc {
+	if g.RequestTimeout > 0 {
+		return []HandlerFunc{HandlerTimeout(g.RequestTimeout)}
+	}
+	return nil
+}
+
+// DefaultGuarded builds a Router with the standard middleware chain (Default:
+// Recovery, RequestID, Logging) plus this guard's admission cap and per-request
+// timeout, wired in the correct order. It exists so a service can't apply only
+// half of the overload protection — the cap (a construction option) and the
+// timeout (post-middleware) are otherwise two separate calls that are easy to
+// forget one of. Services needing a non-standard middleware order keep New.
+func DefaultGuarded(nc *o11ynats.Conn, queue string, g GuardConfig) *Router {
+	r := Default(nc, queue, g.Options()...)
+	r.Use(g.TimeoutMiddleware()...)
+	return r
+}

--- a/pkg/natsrouter/guard_test.go
+++ b/pkg/natsrouter/guard_test.go
@@ -1,0 +1,69 @@
+package natsrouter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGuardConfig_Validate(t *testing.T) {
+	require.NoError(t, GuardConfig{MaxConcurrency: 256, RequestTimeout: 10 * time.Second}.Validate())
+	require.NoError(t, GuardConfig{MaxConcurrency: 0, RequestTimeout: 0}.Validate(), "zero disables, not invalid")
+
+	err := GuardConfig{MaxConcurrency: -1}.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MAX_CONCURRENCY")
+
+	err = GuardConfig{MaxConcurrency: 1, RequestTimeout: -1}.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "REQUEST_TIMEOUT")
+}
+
+func TestGuardConfig_Options_InstallsSemaphoreWhenPositive(t *testing.T) {
+	r := &Router{}
+	for _, o := range (GuardConfig{MaxConcurrency: 8}).Options() {
+		o(r)
+	}
+	require.NotNil(t, r.sem, "positive MaxConcurrency installs an admission semaphore")
+	assert.Equal(t, 8, cap(r.sem))
+}
+
+func TestGuardConfig_Options_NoneWhenZero(t *testing.T) {
+	r := &Router{}
+	for _, o := range (GuardConfig{MaxConcurrency: 0}).Options() {
+		o(r)
+	}
+	assert.Nil(t, r.sem, "zero MaxConcurrency leaves the router unbounded")
+}
+
+func TestDefaultGuarded_AppliesCapAndTimeout(t *testing.T) {
+	g := GuardConfig{MaxConcurrency: 8, RequestTimeout: 50 * time.Millisecond}
+	r := DefaultGuarded(nil, "svc", g)
+
+	require.NotNil(t, r.sem, "admission cap installed from the guard")
+	assert.Equal(t, 8, cap(r.sem))
+	// Default's 3 middleware (Recovery, RequestID, Logging) + the guard timeout.
+	assert.Len(t, r.middleware, 4)
+}
+
+func TestDefaultGuarded_NoCapWhenZero(t *testing.T) {
+	r := DefaultGuarded(nil, "svc", GuardConfig{MaxConcurrency: 0, RequestTimeout: 0})
+	assert.Nil(t, r.sem, "zero concurrency leaves the router unbounded")
+	assert.Len(t, r.middleware, 3, "no timeout middleware when RequestTimeout is 0")
+}
+
+func TestGuardConfig_TimeoutMiddleware(t *testing.T) {
+	assert.Empty(t, (GuardConfig{RequestTimeout: 0}).TimeoutMiddleware(), "zero disables the timeout middleware")
+
+	mws := GuardConfig{RequestTimeout: 50 * time.Millisecond}.TimeoutMiddleware()
+	require.Len(t, mws, 1)
+
+	// The middleware must put a deadline on the handler's context.
+	c := &Context{ctx: t.Context(), chain: &chainState{index: -1}}
+	var ok bool
+	c.chain.handlers = []HandlerFunc{mws[0], func(c *Context) { _, ok = c.Deadline() }}
+	c.Next()
+	assert.True(t, ok, "timeout middleware sets a context deadline")
+}

--- a/portal-service/main.go
+++ b/portal-service/main.go
@@ -61,6 +61,9 @@ type config struct {
 	// offloads the primary.
 	MongoReadPreference string `env:"MONGO_READ_PREFERENCE" envDefault:"secondaryPreferred"`
 
+	Pool mongoutil.PoolConfig
+	HTTP ginutil.TimeoutConfig
+
 	// BotLoginEnabled gates portal's bot-role password login. Flip to false
 	// once the dedicated bot-devs client (which talks to botplatform directly)
 	// ships — then bot accounts can no longer log in via chat-frontend.
@@ -78,6 +81,12 @@ func run() error {
 	cfg, err := env.ParseAs[config]()
 	if err != nil {
 		return fmt.Errorf("parse config: %w", err)
+	}
+	if err := cfg.Pool.Validate(); err != nil {
+		return fmt.Errorf("validate pool config: %w", err)
+	}
+	if err := cfg.HTTP.Validate(); err != nil {
+		return fmt.Errorf("validate http timeout: %w", err)
 	}
 
 	sites, err := parseSiteURLs(cfg.SiteURLs)
@@ -104,7 +113,7 @@ func run() error {
 		return fmt.Errorf("parse mongo read preference %q: %w", cfg.MongoReadPreference, err)
 	}
 	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
-		mongoutil.WithObservability(sdk), mongoutil.WithReadPreference(readPref))
+		mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk), mongoutil.WithReadPreference(readPref))
 	if err != nil {
 		return fmt.Errorf("connect mongo: %w", err)
 	}
@@ -145,6 +154,7 @@ func run() error {
 	r.Use(gin.Recovery())
 	r.Use(ginutil.RequestID())
 	r.Use(ginutil.AccessLog())
+	r.Use(cfg.HTTP.Middleware())
 	registerRoutes(r, handler)
 
 	addr := fmt.Sprintf(":%s", cfg.Port)

--- a/room-service/config_test.go
+++ b/room-service/config_test.go
@@ -9,8 +9,27 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/pkg/natsrouter"
 	"github.com/hmchangw/chat/pkg/subject"
 )
+
+// main wires cfg.Pool.Validate / cfg.Guard.Validate; the exhaustive cases live
+// in those packages' tests — these just prove the fields are on config and are
+// validated.
+func TestConfig_DelegatesPoolValidation(t *testing.T) {
+	cfg := config{Pool: mongoutil.PoolConfig{MaxPoolSize: 0}}
+	err := cfg.Pool.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MONGO_MAX_POOL_SIZE")
+}
+
+func TestConfig_DelegatesGuardValidation(t *testing.T) {
+	cfg := config{Guard: natsrouter.GuardConfig{MaxConcurrency: -1}}
+	err := cfg.Guard.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MAX_CONCURRENCY")
+}
 
 func TestLegacyRoomOrigins_UnmarshalText(t *testing.T) {
 	var l legacyRoomOrigins
@@ -101,21 +120,21 @@ func TestConfig_MaxConcurrency(t *testing.T) {
 		require.NoError(t, os.Unsetenv("MAX_CONCURRENCY"))
 		cfg, err := env.ParseAs[config]()
 		require.NoError(t, err)
-		assert.Equal(t, 256, cfg.MaxConcurrency)
+		assert.Equal(t, 256, cfg.Guard.MaxConcurrency)
 	})
 
 	t.Run("override", func(t *testing.T) {
 		t.Setenv("MAX_CONCURRENCY", "64")
 		cfg, err := env.ParseAs[config]()
 		require.NoError(t, err)
-		assert.Equal(t, 64, cfg.MaxConcurrency)
+		assert.Equal(t, 64, cfg.Guard.MaxConcurrency)
 	})
 
 	t.Run("zero_disables", func(t *testing.T) {
 		t.Setenv("MAX_CONCURRENCY", "0")
 		cfg, err := env.ParseAs[config]()
 		require.NoError(t, err)
-		assert.Equal(t, 0, cfg.MaxConcurrency)
+		assert.Equal(t, 0, cfg.Guard.MaxConcurrency)
 	})
 }
 

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -43,11 +43,19 @@ type config struct {
 	MongoPassword     string            `env:"MONGO_PASSWORD"            envDefault:""`
 	// MongoReadPreference routes the store's display/list reads to secondaries; the
 	// client stays on primary for authz/dedup/read-after-write.
-	MongoReadPreference string        `env:"MONGO_READ_PREFERENCE" envDefault:"secondaryPreferred"`
-	MaxRoomSize         int           `env:"MAX_ROOM_SIZE"             envDefault:"1000"`
-	MaxBatchSize        int           `env:"MAX_BATCH_SIZE"            envDefault:"1000"`
-	MemberListTimeout   time.Duration `env:"MEMBER_LIST_TIMEOUT"       envDefault:"5s"`
-	RoomKeyGracePeriod  time.Duration `env:"ROOM_KEY_GRACE_PERIOD"     envDefault:"24h"`
+	MongoReadPreference string `env:"MONGO_READ_PREFERENCE" envDefault:"secondaryPreferred"`
+	// Pool caps the Mongo connection pool (MONGO_MAX_POOL_SIZE/MONGO_MIN_POOL_SIZE)
+	// so a burst can't open unbounded connections. Env tags already carry the
+	// MONGO_ prefix, so this stays a top-level field (never under envPrefix:"MONGO_").
+	Pool mongoutil.PoolConfig
+	// Guard bounds in-flight request handlers (MAX_CONCURRENCY) and per-request
+	// duration (REQUEST_TIMEOUT) so a burst or slow dependency can't saturate the
+	// Mongo pool with unbounded, indefinitely-held work.
+	Guard              natsrouter.GuardConfig
+	MaxRoomSize        int           `env:"MAX_ROOM_SIZE"             envDefault:"1000"`
+	MaxBatchSize       int           `env:"MAX_BATCH_SIZE"            envDefault:"1000"`
+	MemberListTimeout  time.Duration `env:"MEMBER_LIST_TIMEOUT"       envDefault:"5s"`
+	RoomKeyGracePeriod time.Duration `env:"ROOM_KEY_GRACE_PERIOD"     envDefault:"24h"`
 	// RoomKeyRetiredTTL: retention for rotated-out keys; see roomkeystore.WithRetiredKeys for the 2x-cache-TTL rule.
 	RoomKeyRetiredTTL        time.Duration   `env:"ROOM_KEY_RETIRED_TTL"      envDefault:"20m"`
 	HealthAddr               string          `env:"HEALTH_ADDR" envDefault:":8081"`
@@ -94,10 +102,6 @@ type config struct {
 	BadgeCacheTTL time.Duration `env:"BADGE_CACHE_TTL" envDefault:"24h"`
 	// RoomLocalityGrace: post-flip dual-publish window. Must match across all publisher services.
 	RoomLocalityGrace time.Duration `env:"ROOM_LOCALITY_GRACE" envDefault:"168h"`
-	// MaxConcurrency caps in-flight request handlers so a burst is shed at the
-	// door (ErrUnavailable) instead of piling unbounded work onto MongoDB. 0
-	// disables the cap (unbounded spawn).
-	MaxConcurrency int `env:"MAX_CONCURRENCY" envDefault:"256"`
 }
 
 // legacyRoomOrigin maps a site to its legacy origin URL (incl. scheme).
@@ -138,6 +142,14 @@ func main() {
 		os.Exit(1)
 	}
 	logctx.Configure(cfg.DebugLog)
+	if err := cfg.Pool.Validate(); err != nil {
+		slog.Error("invalid mongo pool config", "error", err)
+		os.Exit(1)
+	}
+	if err := cfg.Guard.Validate(); err != nil {
+		slog.Error("invalid guard config", "error", err)
+		os.Exit(1)
+	}
 	if err := model.SetPlatformAdminAccountPrefix(cfg.AdminAcctPrefix); err != nil {
 		slog.Error("invalid ADMIN_ACCT_PREFIX", "error", err)
 		os.Exit(1)
@@ -178,7 +190,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk))
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)
@@ -328,14 +341,7 @@ func main() {
 	handler.roomMembersLimit = cfg.RoomMembersLimit
 	handler.roomMembersCallLimit = cfg.RoomMembersCallLimit
 
-	// Bound in-flight handlers so a burst is shed at the door (ErrUnavailable)
-	// instead of piling unbounded work onto MongoDB. MAX_CONCURRENCY=0 disables.
-	routerOpts := []natsrouter.Option{natsrouter.WithSiteID(cfg.SiteID), natsrouter.WithMetrics(publishMetrics)}
-	if cfg.MaxConcurrency > 0 {
-		routerOpts = append(routerOpts, natsrouter.WithMaxConcurrency(cfg.MaxConcurrency))
-	}
-	router := natsrouter.New(nc, "room-service", routerOpts...)
-	router.Use(natsrouter.Recovery(), natsrouter.RequestID(), natsrouter.Logging())
+	router := natsrouter.DefaultGuarded(nc, "room-service", cfg.Guard)
 	handler.Register(router)
 
 	healthStop, err := health.ServeWithPprof(cfg.HealthAddr, 5*time.Second, cfg.PProfEnabled,

--- a/room-worker/config_test.go
+++ b/room-worker/config_test.go
@@ -9,8 +9,27 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/pkg/natsrouter"
 	"github.com/hmchangw/chat/pkg/subject"
 )
+
+// main wires cfg.Pool.Validate / cfg.Guard.Validate; the exhaustive cases live
+// in those packages' tests — these just prove the fields are on config and are
+// validated.
+func TestConfig_DelegatesPoolValidation(t *testing.T) {
+	cfg := config{Pool: mongoutil.PoolConfig{MaxPoolSize: 0}}
+	err := cfg.Pool.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MONGO_MAX_POOL_SIZE")
+}
+
+func TestConfig_DelegatesGuardValidation(t *testing.T) {
+	cfg := config{Guard: natsrouter.GuardConfig{MaxConcurrency: -1}}
+	err := cfg.Guard.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MAX_CONCURRENCY")
+}
 
 func TestConfig_RoomSubjectMode(t *testing.T) {
 	cases := []struct {

--- a/room-worker/main.go
+++ b/room-worker/main.go
@@ -34,14 +34,22 @@ type config struct {
 	// Mode selects which stream/consumer this pod binds: "default" runs the ROOMS
 	// member/create/rename ops; "teams" runs the Teams-migration room-create batch
 	// off ROOMS-TEAMS. Two deploys of the same binary, gated by env only.
-	Mode              string                  `env:"MODE"            envDefault:"default"`
-	NatsURL           string                  `env:"NATS_URL"        envDefault:"nats://localhost:4222"`
-	NatsCredsFile     string                  `env:"NATS_CREDS_FILE" envDefault:""`
-	SiteID            string                  `env:"SITE_ID"         envDefault:"site-local"`
-	MongoURI          string                  `env:"MONGO_URI"       envDefault:"mongodb://localhost:27017"`
-	MongoDB           string                  `env:"MONGO_DB"        envDefault:"chat"`
-	MongoUsername     string                  `env:"MONGO_USERNAME"  envDefault:""`
-	MongoPassword     string                  `env:"MONGO_PASSWORD"  envDefault:""`
+	Mode          string `env:"MODE"            envDefault:"default"`
+	NatsURL       string `env:"NATS_URL"        envDefault:"nats://localhost:4222"`
+	NatsCredsFile string `env:"NATS_CREDS_FILE" envDefault:""`
+	SiteID        string `env:"SITE_ID"         envDefault:"site-local"`
+	MongoURI      string `env:"MONGO_URI"       envDefault:"mongodb://localhost:27017"`
+	MongoDB       string `env:"MONGO_DB"        envDefault:"chat"`
+	MongoUsername string `env:"MONGO_USERNAME"  envDefault:""`
+	MongoPassword string `env:"MONGO_PASSWORD"  envDefault:""`
+	// Pool caps the Mongo connection pool (MONGO_MAX_POOL_SIZE/MONGO_MIN_POOL_SIZE)
+	// so a burst can't open unbounded connections. Env tags already carry the
+	// MONGO_ prefix, so this stays a top-level field (never under envPrefix:"MONGO_").
+	Pool mongoutil.PoolConfig
+	// Guard bounds in-flight request handlers (MAX_CONCURRENCY) and per-request
+	// duration (REQUEST_TIMEOUT) for the serverCreateDM RPC so a burst can't
+	// saturate the Mongo pool with unbounded, indefinitely-held work.
+	Guard             natsrouter.GuardConfig
 	MaxWorkers        int                     `env:"MAX_WORKERS"        envDefault:"100"`
 	KeyFanoutWorkers  int                     `env:"KEY_FANOUT_WORKERS" envDefault:"32"` // see defaultKeyFanoutWorkers in handler.go
 	UserCacheSize     int                     `env:"USER_CACHE_SIZE"    envDefault:"10000"`
@@ -100,6 +108,14 @@ func main() {
 		slog.Error("invalid config", "MODE", cfg.Mode, "reason", `must be "default" or "teams"`)
 		os.Exit(1)
 	}
+	if err := cfg.Pool.Validate(); err != nil {
+		slog.Error("invalid mongo pool config", "error", err)
+		os.Exit(1)
+	}
+	if err := cfg.Guard.Validate(); err != nil {
+		slog.Error("invalid guard config", "error", err)
+		os.Exit(1)
+	}
 
 	if err := model.SetPlatformAdminAccountPrefix(cfg.AdminAcctPrefix); err != nil {
 		slog.Error("invalid ADMIN_ACCT_PREFIX", "error", err)
@@ -135,7 +151,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword,
+		mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk))
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)
@@ -255,8 +272,7 @@ func main() {
 	handler.valkey = metaValkey
 	handler.reconcileTTL = cfg.MemberCountReconcileTTL
 
-	router := natsrouter.New(nc, "room-worker", natsrouter.WithSiteID(cfg.SiteID), natsrouter.WithMetrics(publishMetrics))
-	router.Use(natsrouter.Recovery(), natsrouter.RequestID(), natsrouter.Logging())
+	router := natsrouter.DefaultGuarded(nc, "room-worker", cfg.Guard)
 	natsrouter.Register(router, subject.RoomCreateDMSync(cfg.SiteID), handler.serverCreateDM)
 
 	sem := make(chan struct{}, cfg.MaxWorkers)

--- a/search-service/config_test.go
+++ b/search-service/config_test.go
@@ -71,13 +71,13 @@ func TestConfig_MaxConcurrency(t *testing.T) {
 		require.NoError(t, os.Unsetenv("MAX_CONCURRENCY"))
 		cfg, err := env.ParseAs[Config]()
 		require.NoError(t, err)
-		assert.Equal(t, 256, cfg.MaxConcurrency)
+		assert.Equal(t, 256, cfg.Guard.MaxConcurrency)
 	})
 
 	t.Run("override", func(t *testing.T) {
 		t.Setenv("MAX_CONCURRENCY", "64")
 		cfg, err := env.ParseAs[Config]()
 		require.NoError(t, err)
-		assert.Equal(t, 64, cfg.MaxConcurrency)
+		assert.Equal(t, 64, cfg.Guard.MaxConcurrency)
 	})
 }

--- a/search-service/main.go
+++ b/search-service/main.go
@@ -97,10 +97,6 @@ type Config struct {
 	UserRoomIndex     string `env:"USER_ROOM_INDEX,required,notEmpty"`
 	SpotlightIndex    string `env:"SPOTLIGHT_INDEX,required,notEmpty"`
 	SpotlightOrgIndex string `env:"SPOTLIGHT_ORG_INDEX,required,notEmpty"`
-	// MaxConcurrency caps in-flight request handlers so a burst is shed at the
-	// door (ErrUnavailable) instead of piling unbounded work onto Elasticsearch/
-	// MongoDB. 0 disables the cap (unbounded spawn).
-	MaxConcurrency int `env:"MAX_CONCURRENCY" envDefault:"256"`
 	// ShowTeamsRoom controls whether Teams-migrated rooms/messages (origin
 	// "teams") appear in search results; false hides them (reversible read-time
 	// filter — see pkg/model.OriginTeams).
@@ -108,6 +104,11 @@ type Config struct {
 	// ShowTeamsAccounts allowlists accounts that see Teams rooms/messages even when
 	// ShowTeamsRoom is false — an ops-managed set, comma-separated.
 	ShowTeamsAccounts []string `env:"SHOW_TEAMS_ROOM_ACCOUNTS" envSeparator:","`
+	// Pool caps the Mongo connection pool (MONGO_MAX_POOL_SIZE / MONGO_MIN_POOL_SIZE).
+	Pool mongoutil.PoolConfig
+	// Guard bounds in-flight handlers (MAX_CONCURRENCY) and per-request duration
+	// (REQUEST_TIMEOUT) so a burst can't saturate the Mongo pool.
+	Guard natsrouter.GuardConfig
 }
 
 // teamsAccountSet builds a lookup set from the SHOW_TEAMS_ROOM_ACCOUNTS list, dropping blanks.
@@ -130,6 +131,14 @@ func main() {
 	cfg, err := env.ParseAs[Config]()
 	if err != nil {
 		slog.Error("parse config", "error", err)
+		os.Exit(1)
+	}
+	if err := cfg.Pool.Validate(); err != nil {
+		slog.Error("invalid config", "error", err)
+		os.Exit(1)
+	}
+	if err := cfg.Guard.Validate(); err != nil {
+		slog.Error("invalid config", "error", err)
 		os.Exit(1)
 	}
 	logctx.Configure(cfg.DebugLog)
@@ -195,7 +204,7 @@ func main() {
 		os.Exit(1)
 	}
 	mongoClient, err := mongoutil.Connect(ctx, cfg.Mongo.URI, cfg.Mongo.Username, cfg.Mongo.Password,
-		mongoutil.WithObservability(sdk), mongoutil.WithReadPreference(readPref))
+		mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk), mongoutil.WithReadPreference(readPref))
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)
@@ -233,17 +242,11 @@ func main() {
 	})
 	handler.room = newRoomClient(nc)
 
-	// Bound in-flight handlers so a burst is shed at the door (ErrUnavailable)
-	// instead of piling unbounded work onto Elasticsearch/MongoDB.
-	// MAX_CONCURRENCY=0 disables.
-	routerOpts := []natsrouter.Option{natsrouter.WithSiteID(cfg.SiteID)}
-	if cfg.MaxConcurrency > 0 {
-		routerOpts = append(routerOpts, natsrouter.WithMaxConcurrency(cfg.MaxConcurrency))
-	}
-	router := natsrouter.New(nc, "search-service", routerOpts...)
+	router := natsrouter.New(nc, "search-service", cfg.Guard.Options()...)
 	router.Use(natsrouter.RequestID())
 	router.Use(natsrouter.Recovery())
 	router.Use(natsrouter.Logging())
+	router.Use(cfg.Guard.TimeoutMiddleware()...)
 	handler.Register(router)
 
 	// Health-only listener. All four timeouts guard against hung probes tying

--- a/search-sync-worker/config_test.go
+++ b/search-sync-worker/config_test.go
@@ -23,6 +23,14 @@ func setRequiredConfigEnv(t *testing.T) {
 	t.Setenv("MONGO_URI", "mongodb://localhost:27017")
 }
 
+func TestConfig_PoolValidate_RejectsZeroMaxPoolSize(t *testing.T) {
+	setRequiredConfigEnv(t)
+	t.Setenv("MONGO_MAX_POOL_SIZE", "0")
+	cfg, err := env.ParseAs[config]()
+	require.NoError(t, err)
+	assert.Error(t, cfg.Pool.Validate())
+}
+
 func TestConfig_HRJetStreamDomain(t *testing.T) {
 	t.Run("defaults to empty when unset", func(t *testing.T) {
 		setRequiredConfigEnv(t)

--- a/search-sync-worker/main.go
+++ b/search-sync-worker/main.go
@@ -44,6 +44,7 @@ type config struct {
 	MongoDB             string `env:"MONGO_DB"      envDefault:"chat"`
 	MongoUsername       string `env:"MONGO_USERNAME" envDefault:""`
 	MongoPassword       string `env:"MONGO_PASSWORD" envDefault:""`
+	Pool                mongoutil.PoolConfig
 	SearchURL           string `env:"SEARCH_URL,required"`
 	SearchBackend       string `env:"SEARCH_BACKEND"         envDefault:"elasticsearch"`
 	SearchUsername      string `env:"SEARCH_USERNAME"        envDefault:""`
@@ -98,6 +99,11 @@ func main() {
 
 	if err := model.SetPlatformAdminAccountPrefix(cfg.AdminAcctPrefix); err != nil {
 		slog.Error("invalid ADMIN_ACCT_PREFIX", "error", err)
+		os.Exit(1)
+	}
+
+	if err := cfg.Pool.Validate(); err != nil {
+		slog.Error("invalid mongo pool config", "error", err)
 		os.Exit(1)
 	}
 
@@ -163,7 +169,7 @@ func main() {
 	}
 
 	// Mongo backs the migrated-Teams-history author lookup (teams_user → account → user _id).
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk))
 	if err != nil {
 		slog.Error("mongodb connect failed", "error", err)
 		os.Exit(1)

--- a/tcard-service/main.go
+++ b/tcard-service/main.go
@@ -35,6 +35,9 @@ type config struct {
 	MongoDB       string `env:"MONGO_DB"       envDefault:"chat"`
 	MongoUsername string `env:"MONGO_USERNAME" envDefault:""`
 	MongoPassword string `env:"MONGO_PASSWORD" envDefault:""`
+
+	Pool mongoutil.PoolConfig
+	HTTP ginutil.TimeoutConfig
 }
 
 func main() {
@@ -49,6 +52,12 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("parse config: %w", err)
 	}
+	if err := cfg.Pool.Validate(); err != nil {
+		return fmt.Errorf("validate pool config: %w", err)
+	}
+	if err := cfg.HTTP.Validate(); err != nil {
+		return fmt.Errorf("validate http timeout: %w", err)
+	}
 
 	refreshAt, err := parseRefreshAt(cfg.CacheRefreshAt)
 	if err != nil {
@@ -62,7 +71,7 @@ func run() error {
 		return fmt.Errorf("init observability: %w", err)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk))
 	if err != nil {
 		return fmt.Errorf("connect mongo: %w", err)
 	}
@@ -95,6 +104,7 @@ func run() error {
 	r.Use(gin.Recovery())
 	r.Use(ginutil.RequestID())
 	r.Use(ginutil.AccessLog())
+	r.Use(cfg.HTTP.Middleware())
 	registerRoutes(r, handler)
 
 	addr := fmt.Sprintf(":%s", cfg.Port)

--- a/teams-chat-member-sync/main.go
+++ b/teams-chat-member-sync/main.go
@@ -29,6 +29,8 @@ type Config struct {
 	MongoDB       string `env:"MONGO_DB" envDefault:"chat"`
 	MongoUsername string `env:"MONGO_USERNAME" envDefault:""`
 	MongoPassword string `env:"MONGO_PASSWORD" envDefault:""`
+	// Pool caps the MongoDB connection pool for both the read and write clients.
+	Pool mongoutil.PoolConfig
 
 	MaxWorkers int `env:"MAX_WORKERS" envDefault:"8"`
 
@@ -63,6 +65,9 @@ func validateConfig(cfg Config) error {
 	if cfg.MaxWorkers <= 0 {
 		return fmt.Errorf("invalid config: MAX_WORKERS must be positive")
 	}
+	if err := cfg.Pool.Validate(); err != nil {
+		return fmt.Errorf("invalid config: %w", err)
+	}
 	return nil
 }
 
@@ -83,13 +88,13 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	readClient, err := mongoutil.ConnectRead(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword)
+	readClient, err := mongoutil.ConnectRead(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithPool(cfg.Pool))
 	if err != nil {
 		return fmt.Errorf("mongo read connect: %w", err)
 	}
 	defer mongoutil.Disconnect(context.Background(), readClient)
 
-	writeClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword)
+	writeClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithPool(cfg.Pool))
 	if err != nil {
 		return fmt.Errorf("mongo write connect: %w", err)
 	}

--- a/teams-chat-member-sync/main_test.go
+++ b/teams-chat-member-sync/main_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/caarlos0/env/v11"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/mongoutil"
 )
 
 func setRequiredEnv(t *testing.T) {
@@ -46,6 +48,7 @@ func TestConfig_MissingRequired(t *testing.T) {
 func baseConfig() Config {
 	return Config{
 		MongoURI: "mongodb://localhost:27017", MongoDB: "chat",
+		Pool:          mongoutil.PoolConfig{MaxPoolSize: 500},
 		MaxWorkers:    8,
 		GraphTenantID: "tenant", GraphClientID: "client", GraphClientSecret: "secret",
 	}
@@ -59,6 +62,7 @@ func TestValidateConfig(t *testing.T) {
 	}{
 		{"valid", func(c *Config) {}, false},
 		{"zero max workers", func(c *Config) { c.MaxWorkers = 0 }, true},
+		{"zero max pool size", func(c *Config) { c.Pool.MaxPoolSize = 0 }, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/teams-chat-sync/main.go
+++ b/teams-chat-sync/main.go
@@ -26,6 +26,8 @@ type Config struct {
 	MongoDB       string `env:"MONGO_DB" envDefault:"chat"`
 	MongoUsername string `env:"MONGO_USERNAME" envDefault:""`
 	MongoPassword string `env:"MONGO_PASSWORD" envDefault:""`
+	// Pool caps the MongoDB connection pool for the sync client.
+	Pool mongoutil.PoolConfig
 
 	MaxWorkers int `env:"MAX_WORKERS" envDefault:"8"`
 	// DefaultFrom is the RFC3339 UTC watermark used for users that have never
@@ -74,6 +76,9 @@ func validateConfig(cfg Config) (time.Time, error) {
 	if cfg.GraphChatsPageSize <= 0 {
 		return time.Time{}, fmt.Errorf("invalid config: GRAPH_CHATS_PAGE_SIZE must be positive")
 	}
+	if err := cfg.Pool.Validate(); err != nil {
+		return time.Time{}, fmt.Errorf("invalid config: %w", err)
+	}
 	defaultFrom, err := time.Parse(time.RFC3339, cfg.DefaultFrom)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("parse SYNC_DEFAULT_FROM: %w", err)
@@ -99,7 +104,7 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword)
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithPool(cfg.Pool))
 	if err != nil {
 		return fmt.Errorf("mongo connect: %w", err)
 	}

--- a/teams-chat-sync/main_test.go
+++ b/teams-chat-sync/main_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/caarlos0/env/v11"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/mongoutil"
 )
 
 func setRequiredEnv(t *testing.T) {
@@ -62,6 +64,7 @@ func TestConfig_MissingDefaultSiteID(t *testing.T) {
 func baseConfig() Config {
 	return Config{
 		MongoURI: "mongodb://localhost:27017", MongoDB: "chat",
+		Pool:               mongoutil.PoolConfig{MaxPoolSize: 500},
 		MaxWorkers:         8,
 		DefaultFrom:        "2026-04-01T00:00:00Z",
 		GraphTenantID:      "tenant",
@@ -111,6 +114,11 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name:    "empty default from",
 			mutate:  func(c *Config) { c.DefaultFrom = "" },
+			wantErr: true,
+		},
+		{
+			name:    "zero max pool size",
+			mutate:  func(c *Config) { c.Pool.MaxPoolSize = 0 },
 			wantErr: true,
 		},
 	}

--- a/teams-hr-sync/config.go
+++ b/teams-hr-sync/config.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/hmchangw/chat/pkg/mongoutil"
 )
 
 // config is teams-hr-sync's environment configuration. The binary runs
@@ -39,6 +41,8 @@ type config struct {
 	MongoReadUsername string `env:"MONGO_READ_USERNAME" envDefault:""`
 	MongoReadPassword string `env:"MONGO_READ_PASSWORD" envDefault:""`
 	MongoReadDB       string `env:"MONGO_READ_DB" envDefault:"chat"`
+	// Pool caps the MongoDB connection pool for the read and direct-write clients.
+	Pool mongoutil.PoolConfig
 
 	NatsURL       string `env:"NATS_URL,required,notEmpty"`
 	NatsCredsFile string `env:"NATS_CREDS_FILE" envDefault:""`

--- a/teams-hr-sync/config_test.go
+++ b/teams-hr-sync/config_test.go
@@ -31,6 +31,14 @@ func TestConfig_Defaults(t *testing.T) {
 	assert.Equal(t, "chat", cfg.DirectWriteDB)
 }
 
+func TestConfig_ZeroMaxPoolSizeFails(t *testing.T) {
+	e := validEnv()
+	e["MONGO_MAX_POOL_SIZE"] = "0"
+	cfg, err := env.ParseAsWithOptions[config](env.Options{Environment: e})
+	require.NoError(t, err)
+	assert.Error(t, cfg.Pool.Validate(), "a zero MONGO_MAX_POOL_SIZE must be rejected")
+}
+
 func TestConfig_DirectModeRequiresWriteURI(t *testing.T) {
 	e := validEnv()
 	e["HR_SYNC_MODE"] = modeDirect

--- a/teams-hr-sync/main.go
+++ b/teams-hr-sync/main.go
@@ -50,6 +50,9 @@ func run() error {
 	if cfg.HRSyncMode != modeStream && cfg.HRSyncMode != modeDirect {
 		return fmt.Errorf("HR_SYNC_MODE must be %q or %q, got %q", modeStream, modeDirect, cfg.HRSyncMode)
 	}
+	if err := cfg.Pool.Validate(); err != nil {
+		return fmt.Errorf("invalid mongo pool config: %w", err)
+	}
 	// DIRECT_WRITE_URI has no env "required" tag because it's conditional on
 	// mode — env doesn't support cross-field required, so enforce it here.
 	if cfg.HRSyncMode == modeDirect && cfg.DirectWriteURI == "" {
@@ -124,7 +127,7 @@ func run() error {
 // runStreamMode connects the diff-state Mongo read + JetStream, then runs the
 // existing publish-a-delta pipeline. Behavior unchanged from pre-mode-flag.
 func runStreamMode(ctx context.Context, cfg *config, graph msgraph.GroupReader, mapper transform.Mapper, groups []syncGroup, siteOverrides map[string]string) (runStats, error) {
-	readClient, err := mongoutil.ConnectRead(ctx, cfg.MongoReadURI, cfg.MongoReadUsername, cfg.MongoReadPassword)
+	readClient, err := mongoutil.ConnectRead(ctx, cfg.MongoReadURI, cfg.MongoReadUsername, cfg.MongoReadPassword, mongoutil.WithPool(cfg.Pool))
 	if err != nil {
 		return runStats{}, fmt.Errorf("connect mongo read client: %w", err)
 	}
@@ -159,7 +162,7 @@ func runStreamMode(ctx context.Context, cfg *config, graph msgraph.GroupReader, 
 // diff-state store, never NATS) and writes the full collected set straight
 // through the WriteStore.
 func runDirectMode(ctx context.Context, cfg *config, graph msgraph.GroupReader, mapper transform.Mapper, groups []syncGroup, siteOverrides map[string]string) (runStats, error) {
-	writeClient, err := mongoutil.Connect(ctx, cfg.DirectWriteURI, cfg.DirectWriteUsername, cfg.DirectWritePassword)
+	writeClient, err := mongoutil.Connect(ctx, cfg.DirectWriteURI, cfg.DirectWriteUsername, cfg.DirectWritePassword, mongoutil.WithPool(cfg.Pool))
 	if err != nil {
 		return runStats{}, fmt.Errorf("connect mongo direct-write client: %w", err)
 	}

--- a/teams-room-creation/config.go
+++ b/teams-room-creation/config.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+
+	"github.com/hmchangw/chat/pkg/mongoutil"
 )
 
 // Config is the job's environment configuration. One replica-set serves both
@@ -13,6 +15,8 @@ type Config struct {
 	MongoDB       string `env:"MONGO_DB" envDefault:"chat"`
 	MongoUsername string `env:"MONGO_USERNAME" envDefault:""`
 	MongoPassword string `env:"MONGO_PASSWORD" envDefault:""`
+	// Pool caps the MongoDB connection pool for both the read and write clients.
+	Pool mongoutil.PoolConfig
 
 	NatsURL       string `env:"NATS_URL,required,notEmpty"`
 	NatsCredsFile string `env:"NATS_CREDS_FILE" envDefault:""`
@@ -35,6 +39,9 @@ func validateConfig(cfg Config) error {
 	}
 	if cfg.MaxWorkers <= 0 {
 		return fmt.Errorf("invalid config: MAX_WORKERS must be positive")
+	}
+	if err := cfg.Pool.Validate(); err != nil {
+		return fmt.Errorf("invalid config: %w", err)
 	}
 	return nil
 }

--- a/teams-room-creation/config_test.go
+++ b/teams-room-creation/config_test.go
@@ -5,10 +5,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/mongoutil"
 )
 
 func baseConfig() Config {
-	return Config{BatchSize: 100, MaxWorkers: 8}
+	return Config{BatchSize: 100, MaxWorkers: 8, Pool: mongoutil.PoolConfig{MaxPoolSize: 500}}
 }
 
 func TestValidateConfig(t *testing.T) {
@@ -22,6 +24,7 @@ func TestValidateConfig(t *testing.T) {
 		{"negative batch size", func(c *Config) { c.BatchSize = -1 }, true},
 		{"zero workers", func(c *Config) { c.MaxWorkers = 0 }, true},
 		{"negative workers", func(c *Config) { c.MaxWorkers = -3 }, true},
+		{"zero max pool size", func(c *Config) { c.Pool.MaxPoolSize = 0 }, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/teams-room-creation/main.go
+++ b/teams-room-creation/main.go
@@ -48,13 +48,13 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	readClient, err := mongoutil.ConnectRead(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword)
+	readClient, err := mongoutil.ConnectRead(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithPool(cfg.Pool))
 	if err != nil {
 		return fmt.Errorf("mongo read connect: %w", err)
 	}
 	defer mongoutil.Disconnect(context.Background(), readClient)
 
-	writeClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword)
+	writeClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithPool(cfg.Pool))
 	if err != nil {
 		return fmt.Errorf("mongo write connect: %w", err)
 	}

--- a/teams-user-sync/config.go
+++ b/teams-user-sync/config.go
@@ -1,5 +1,7 @@
 package main
 
+import "github.com/hmchangw/chat/pkg/mongoutil"
+
 // config is teams-user-sync's environment configuration. The binary runs
 // exactly one sync per invocation — scheduling and overlap prevention are
 // owned by the Kubernetes CronJob that triggers it (concurrencyPolicy:
@@ -29,6 +31,11 @@ type config struct {
 	// may be identical in dev).
 	MongoRead  mongoConfig `envPrefix:"MONGO_READ_"`
 	MongoWrite mongoConfig `envPrefix:"MONGO_WRITE_"`
+
+	// Pool caps the MongoDB connection pool for both the read and write clients.
+	// Kept at the top level (not inside a MONGO_-prefixed block) so its env tags
+	// carry the MONGO_ prefix exactly once.
+	Pool mongoutil.PoolConfig
 }
 
 // mongoConfig is one Mongo lane's connection settings. The connection string

--- a/teams-user-sync/config_test.go
+++ b/teams-user-sync/config_test.go
@@ -56,6 +56,15 @@ func TestConfig_Overrides(t *testing.T) {
 	assert.Equal(t, mongoConfig{URI: "mongodb://write:27017", DB: "writedb", Username: "writer", Password: "writepw"}, cfg.MongoWrite)
 }
 
+func TestConfig_ZeroMaxPoolSizeFails(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("MONGO_MAX_POOL_SIZE", "0")
+
+	cfg, err := env.ParseAs[config]()
+	require.NoError(t, err)
+	assert.Error(t, cfg.Pool.Validate(), "a zero MONGO_MAX_POOL_SIZE must be rejected")
+}
+
 func TestConfig_MissingRequiredFails(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/teams-user-sync/main.go
+++ b/teams-user-sync/main.go
@@ -40,18 +40,21 @@ func run() error {
 	if cfg.GraphPageSize <= 0 || cfg.GraphPageSize > 999 {
 		return fmt.Errorf("GRAPH_PAGE_SIZE must be in 1..999, got %d", cfg.GraphPageSize)
 	}
+	if err := cfg.Pool.Validate(); err != nil {
+		return fmt.Errorf("invalid mongo pool config: %w", err)
+	}
 
 	// SIGTERM/SIGINT (pod deletion, Job activeDeadlineSeconds) cancels the run
 	// so it aborts between operations instead of being killed mid-batch.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	readClient, err := mongoutil.ConnectRead(ctx, cfg.MongoRead.URI, cfg.MongoRead.Username, cfg.MongoRead.Password)
+	readClient, err := mongoutil.ConnectRead(ctx, cfg.MongoRead.URI, cfg.MongoRead.Username, cfg.MongoRead.Password, mongoutil.WithPool(cfg.Pool))
 	if err != nil {
 		return fmt.Errorf("connect mongo read client: %w", err)
 	}
 	defer disconnect(readClient)
-	writeClient, err := mongoutil.Connect(ctx, cfg.MongoWrite.URI, cfg.MongoWrite.Username, cfg.MongoWrite.Password)
+	writeClient, err := mongoutil.Connect(ctx, cfg.MongoWrite.URI, cfg.MongoWrite.Username, cfg.MongoWrite.Password, mongoutil.WithPool(cfg.Pool))
 	if err != nil {
 		return fmt.Errorf("connect mongo write client: %w", err)
 	}

--- a/upload-service/main.go
+++ b/upload-service/main.go
@@ -37,6 +37,11 @@ type config struct {
 	MongoUsername string `env:"MONGO_USERNAME"  envDefault:""`
 	MongoPassword string `env:"MONGO_PASSWORD"  envDefault:""`
 
+	Pool mongoutil.PoolConfig
+	// No blanket request timeout here: upload-service streams potentially-large
+	// file downloads bounded by MinioDownloadTimeout and the server WriteTimeout
+	// (both 5m); a short per-request context deadline would cancel those streams.
+
 	// MaxImages caps the number of images per image-upload request.
 	MaxImages int `env:"MAX_IMAGES" envDefault:"10"`
 	// MaxAttachments caps the number of files the single-file upload endpoint accepts.
@@ -93,6 +98,9 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("parse config: %w", err)
 	}
+	if err := cfg.Pool.Validate(); err != nil {
+		return fmt.Errorf("validate mongo pool: %w", err)
+	}
 
 	ctx := context.Background()
 	cfg.Drive.LoadBaseURLs()
@@ -103,7 +111,7 @@ func run() error {
 		return fmt.Errorf("init observability: %w", err)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.MongoURI, cfg.MongoUsername, cfg.MongoPassword, mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk))
 	if err != nil {
 		return fmt.Errorf("mongo connect: %w", err)
 	}

--- a/user-presence-service/main.go
+++ b/user-presence-service/main.go
@@ -34,6 +34,9 @@ type MongoConfig struct {
 	DB       string `env:"DB" envDefault:"chat"`
 	Username string `env:"USERNAME"`
 	Password string `env:"PASSWORD"`
+	// ReadPreference routes staleness-tolerant reads to secondaries per read site;
+	// the client stays on primary for dedup/read-after-write.
+	ReadPreference string `env:"READ_PREFERENCE" envDefault:"secondaryPreferred"`
 }
 
 type PresenceConfig struct {
@@ -53,6 +56,13 @@ type Config struct {
 	Valkey        ValkeyConfig   `envPrefix:"VALKEY_"`
 	Mongo         MongoConfig    `envPrefix:"MONGO_"`
 	Presence      PresenceConfig `envPrefix:"PRESENCE_"`
+
+	// Pool caps the Mongo connection pool. RequestTimeout bounds each handler so
+	// a slow op frees its connection. No concurrency cap: the presence routes are
+	// fire-and-forget (RegisterVoid), which admission control would silently drop
+	// under saturation — so this service takes only the timeout knob.
+	Pool           mongoutil.PoolConfig
+	RequestTimeout time.Duration `env:"REQUEST_TIMEOUT" envDefault:"10s"`
 }
 
 // Compile-time guarantee that the extracted store satisfies the daemon's
@@ -63,6 +73,14 @@ func main() {
 	cfg, err := env.ParseAs[Config]()
 	if err != nil {
 		slog.Error("parse config", "error", err)
+		os.Exit(1)
+	}
+	if err := cfg.Pool.Validate(); err != nil {
+		slog.Error("invalid pool config", "error", err)
+		os.Exit(1)
+	}
+	if cfg.RequestTimeout < 0 {
+		slog.Error("invalid REQUEST_TIMEOUT", "value", cfg.RequestTimeout)
 		os.Exit(1)
 	}
 	// Fail fast on non-positive tunables: a zero/negative SweepInterval panics
@@ -101,7 +119,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.Mongo.URI, cfg.Mongo.Username, cfg.Mongo.Password, mongoutil.WithObservability(sdk))
+	readPref, err := mongoutil.ParseReadPreference(cfg.Mongo.ReadPreference)
+	if err != nil {
+		slog.Error("invalid mongo read preference", "value", cfg.Mongo.ReadPreference, "error", err)
+		os.Exit(1)
+	}
+
+	mongoClient, err := mongoutil.Connect(ctx, cfg.Mongo.URI, cfg.Mongo.Username, cfg.Mongo.Password,
+		mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk), mongoutil.WithReadPreference(readPref))
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)
@@ -128,7 +153,15 @@ func main() {
 	peer := NewNATSPeerPresenceClient(nc.NatsConn(), cfg.Presence.PeerTimeout)
 	handler := NewHandler(store, userDir, peer, publish, cfg.SiteID, cfg.Presence.BatchMax)
 
+	// No admission cap here: Hello/Ping/Activity/Bye are fire-and-forget
+	// (RegisterVoid), and under a saturated concurrency semaphore those are
+	// silently dropped (no reply, no redelivery) — a reconnect storm would lose
+	// presence updates and strand users online/offline. Only the per-request
+	// timeout is applied.
 	router := natsrouter.Default(nc, "user-presence-service", natsrouter.WithSiteID(cfg.SiteID))
+	if cfg.RequestTimeout > 0 {
+		router.Use(natsrouter.HandlerTimeout(cfg.RequestTimeout))
+	}
 	natsrouter.RegisterVoid(router, subject.PresenceHelloPattern(cfg.SiteID), handler.Hello)
 	natsrouter.RegisterVoid(router, subject.PresencePingPattern(cfg.SiteID), handler.Ping)
 	natsrouter.RegisterVoid(router, subject.PresenceActivityPattern(cfg.SiteID), handler.Activity)

--- a/user-service/config/config.go
+++ b/user-service/config/config.go
@@ -88,6 +88,8 @@ type Config struct {
 	BadgeCountCacheFirst bool        `env:"BADGE_COUNT_CACHE_FIRST" envDefault:"false"`
 	Mongo                MongoConfig `envPrefix:"MONGO_"`
 	NATS                 NATSConfig  `envPrefix:"NATS_"`
+	// Pool caps the Mongo connection pool (MONGO_MAX_POOL_SIZE / MONGO_MIN_POOL_SIZE).
+	Pool mongoutil.PoolConfig
 	// ShowTeamsRoom controls whether Teams-migrated rooms (origin "teams")
 	// appear in the subscription list/count; false hides them (reversible
 	// read-time filter — see pkg/model.OriginTeams).
@@ -149,6 +151,9 @@ func Load() (Config, error) {
 	}
 	if _, err := mongoutil.ParseReadPreference(cfg.Mongo.ReadPreference); err != nil {
 		return Config{}, fmt.Errorf("MONGO_READ_PREFERENCE: %w", err)
+	}
+	if err := cfg.Pool.Validate(); err != nil {
+		return Config{}, err
 	}
 	return cfg, nil
 }

--- a/user-service/config/config_test.go
+++ b/user-service/config/config_test.go
@@ -315,6 +315,27 @@ func TestLoad_BadgeCountCacheFirst(t *testing.T) {
 	require.True(t, cfg.BadgeCountCacheFirst)
 }
 
+// Load delegates pool checks to mongoutil.PoolConfig.Validate — exhaustive
+// cases live in that package; this just proves the wiring.
+func TestLoad_DelegatesPoolValidation(t *testing.T) {
+	t.Setenv("MONGO_URI", "mongodb://x")
+	t.Setenv("NATS_URL", "nats://x")
+	t.Setenv("SITE_ID", "site-a")
+	t.Setenv("MONGO_MAX_POOL_SIZE", "0")
+	_, err := Load()
+	require.ErrorContains(t, err, "MONGO_MAX_POOL_SIZE")
+}
+
+// Load rejects a negative MAX_CONCURRENCY (user-service's bespoke concurrency knob).
+func TestLoad_RejectsNegativeMaxConcurrency(t *testing.T) {
+	t.Setenv("MONGO_URI", "mongodb://x")
+	t.Setenv("NATS_URL", "nats://x")
+	t.Setenv("SITE_ID", "site-a")
+	t.Setenv("MAX_CONCURRENCY", "-1")
+	_, err := Load()
+	require.ErrorContains(t, err, "MAX_CONCURRENCY")
+}
+
 func TestLoad_SSORefreshWindowMustBePositive(t *testing.T) {
 	t.Setenv("MONGO_URI", "mongodb://x")
 	t.Setenv("NATS_URL", "nats://x")

--- a/user-service/main.go
+++ b/user-service/main.go
@@ -99,7 +99,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	mongoClient, err := mongoutil.Connect(ctx, cfg.Mongo.URI, cfg.Mongo.Username, cfg.Mongo.Password, mongoutil.WithObservability(sdk))
+	mongoClient, err := mongoutil.Connect(ctx, cfg.Mongo.URI, cfg.Mongo.Username, cfg.Mongo.Password,
+		mongoutil.WithPool(cfg.Pool), mongoutil.WithObservability(sdk))
 	if err != nil {
 		slog.Error("mongo connect failed", "error", err)
 		os.Exit(1)
@@ -195,7 +196,9 @@ func main() {
 	router.Use(natsrouter.RequestID())
 	router.Use(natsrouter.Logging())
 	// After Logging so the timeout wraps the handler chain; bounds the Mongo
-	// aggregations from hanging past the configured deadline.
+	// aggregations from hanging past the configured deadline. user-service uses
+	// its own HANDLER_TIMEOUT (not REQUEST_TIMEOUT) as the single per-request
+	// deadline.
 	router.Use(natsrouter.HandlerTimeout(cfg.HandlerTimeout))
 
 	svc.RegisterHandlers(router)


### PR DESCRIPTION
## Summary

Follow-up to #176 (which added the initial history-service pool guards, now merged). That work is generalized into shared, env-tagged config helpers and rolled out to **every long-running service that connects to MongoDB**, so each service has an explicit connection-pool cap, and the request/reply + HTTP services additionally bound in-flight concurrency and per-request duration.

Rebased onto current `main`, so it also reconciles with the read-preference feature main added in the meantime (both are preserved everywhere).

## Shared helpers (`pkg/`)

- **`mongoutil.PoolConfig` + `WithPool`** — `MONGO_MAX_POOL_SIZE` (default **150**) / `MONGO_MIN_POOL_SIZE`, applied via `mongoutil.WithPool(cfg.Pool)`; min is applied only when > 0 so a URI-provided `minPoolSize` survives.
- **`natsrouter.GuardConfig` + `DefaultGuarded`** — `MAX_CONCURRENCY` (default 256, 0 disables) / `REQUEST_TIMEOUT` (default 10s, 0 disables); `DefaultGuarded` wires the standard middleware chain + admission cap + timeout in one call so a service can't apply only half.
- **`ginutil.Timeout` + `TimeoutConfig`** — per-request context deadline for HTTP services.

## Rollout (by transport)

- **Request/reply (natsrouter)** → pool + concurrency cap + timeout: history-service, room-service, room-worker, search-service, bot-message-handler, bot-room-service, user-service, user-presence-service, media-service (NATS side).
- **HTTP (Gin)** → pool + request timeout: botplatform-service, portal-service, tcard-service. **admin-service, upload-service, and media-service's blob routes get the pool cap only** — upload/media stream large up/downloads that a short deadline would cancel; admin-service manages its own longer per-request budget (see below).
- **Workers** → explicit pool cap only (concurrency already bounded by `MAX_WORKERS`): message-worker, broadcast-worker, notification-worker, message-gatekeeper, inbox-worker, search-sync-worker, hr-sync-worker, bot-message-worker, and the teams-* sync services (applied to both read and write clients where split).

## Notable per-service decisions

- **Pool default 150** sits just above a mongod node's ~128 read-ticket ceiling. **history-service overrides to 384** in its deployment (read-heavy, `MAX_CONCURRENCY=256`): 384 is 1.5× the concurrency cap (in-flight handlers never starve at checkout, with burst headroom) and ≈ a 3-node replica set's aggregate read-ticket capacity (3×128). NOTE: the prod manifest must set `MONGO_MAX_POOL_SIZE=384` — the code default is 150.
- **admin-service** takes the pool cap but **no shared request timeout**: its permission handlers pin their own `requestBudget` (just under the 40s HTTP write timeout) and the cross-site permission fanout self-limits to `min(FANOUT_TIMEOUT=30s, request deadline)`. The fleet's 10s `REQUEST_TIMEOUT` default would silently cap that 30s fanout and abort multi-site permission changes early, so admin-service is deliberately timeout-free at the router (guarded by a regression test in `admin-service/router_test.go`).
- **bot-message-handler / bot-room-service** keep a bespoke `MAX_CONCURRENCY=200` default (their historical value), not the shared 256.
- **user-service** keeps its existing `HANDLER_TIMEOUT` as the single per-request deadline and takes only the concurrency cap.
- **user-presence-service** takes pool + timeout but **no admission cap** — its presence routes are fire-and-forget and would be silently dropped under a saturated semaphore.
- **search-service** keeps its existing (non-standard) middleware order rather than `DefaultGuarded`.

## Testing

- Shared helpers: TDD, race-tested, lint-clean.
- Whole repo builds (`go build ./...`); unit tests pass across all changed packages; `golangci-lint` clean.
- No client-facing handler or `pkg/model` struct changed, so `docs/client-api.md` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)