### PR TITLE
fix(natsrouter): reply response_too_large instead of timing out on oversize

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -6718,7 +6718,7 @@ Every error response — NATS reply subjects, JetStream async results, and HTTP 
 > **Malformed request bodies.** Any room request/reply RPC whose payload is not valid JSON for its schema is rejected uniformly with `code: bad_request` and the message `"invalid request payload"` — the transport layer rejects it before the handler runs. Treat this as a generic encoding error; do not pattern-match the message text.
 
 > [!IMPORTANT]
-> **Oversize replies.** If a successful response would exceed the transport's maximum payload size, the reply is returned as `code: internal` with `reason: response_too_large` instead of the success body. This is most likely on large history reads (e.g. Load History / Load Next / Load Surrounding / Get Thread Messages with a high `limit`); the client should retry with a smaller `limit`. Branch on `reason` (`response_too_large`), not the message text.
+> **Oversize replies.** If a reply would exceed the transport's maximum payload size, it is returned as `code: internal` with `reason: response_too_large` instead. This covers both a success body that is too large and an error envelope that is too large; either way the caller gets an answer rather than a timeout. This is most likely on large history reads (e.g. Load History / Load Next / Load Surrounding / Get Thread Messages with a high `limit`); the client should retry with a smaller `limit`. Branch on `reason` (`response_too_large`), not the message text.
 
 ### `reason` catalog (present today)
 

--- a/pkg/errcode/codes_platform.go
+++ b/pkg/errcode/codes_platform.go
@@ -25,4 +25,12 @@ const (
 	// NatsRequestTimeout marks a request that was delivered but not answered
 	// within the caller's timeout. Retryable.
 	NatsRequestTimeout Reason = "upstream_timeout"
+
+	// ResponseTooLarge marks a reply the transport refused because the
+	// marshalled response exceeds the broker's max_payload. Without the
+	// fallback envelope that carries this reason the request would simply
+	// time out, so the client cannot tell "too big" from "server down" —
+	// the two call for opposite recoveries. Retry with a narrower request
+	// (a smaller limit or page), never with the same one.
+	ResponseTooLarge Reason = "response_too_large"
 )

--- a/pkg/errcode/codes_test.go
+++ b/pkg/errcode/codes_test.go
@@ -18,7 +18,7 @@ var allReasons = []Reason{
 	UserAppNotFound, UserAppDisabled, UserSubscriptionNotFound, UserSSOTokenNotFound,
 	AuthTokenExpired, AuthInvalidToken, AuthInvalidRequest, AuthInvalidNKey, AuthMissingFields,
 	PortalAccountNotReady,
-	RequestIDRequired,
+	RequestIDRequired, NatsNoResponders, NatsRequestTimeout, ResponseTooLarge,
 	EmojiShortcodeReserved,
 	EmojiDeleteDisabled,
 	PermissionUnknownKey, PermissionInvalidSubjects, PermissionInvalidReason,
@@ -42,5 +42,14 @@ func TestReasons_Unique(t *testing.T) {
 			t.Errorf("duplicate reason: %q", r)
 		}
 		seen[r] = true
+	}
+}
+
+// The oversize fallback envelope is a wire contract documented in
+// docs/client-api.md §6: clients branch on this exact reason string rather
+// than on the message text, so a rename here is a breaking API change.
+func TestResponseTooLarge_WireValue(t *testing.T) {
+	if got := string(ResponseTooLarge); got != "response_too_large" {
+		t.Errorf("ResponseTooLarge = %q, want %q", got, "response_too_large")
 	}
 }

--- a/pkg/errcode/errnats/reply.go
+++ b/pkg/errcode/errnats/reply.go
@@ -2,6 +2,7 @@
 package errnats
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -13,6 +14,43 @@ import (
 )
 
 const fallback = `{"code":"internal","error":"internal error"}`
+
+// oversizeEnvelope is built once at init: it is the reply of last resort after
+// a response already overflowed max_payload, so it must be small enough to
+// always fit (pinned under NATS' 1024-byte floor by a test).
+var oversizeEnvelope = MarshalQuiet(errcode.Internal(
+	"response payload exceeds maximum size",
+	errcode.WithReason(errcode.ResponseTooLarge),
+))
+
+// IsOversize reports whether err is the broker refusing a payload larger than
+// max_payload. nats.go rejects the publish synchronously, before anything
+// reaches the wire, so the reply subject is still live and a smaller envelope
+// can still be delivered.
+func IsOversize(err error) bool {
+	return errors.Is(err, nats.ErrMaxPayload)
+}
+
+// OversizeEnvelope returns the compact envelope to send in place of a response
+// that exceeded max_payload: code internal, reason response_too_large (see
+// docs/client-api.md §6). The copy is deliberate — Respond may retain the
+// slice, and a shared backing array would let one caller corrupt every later
+// fallback in the process.
+func OversizeEnvelope() []byte {
+	return bytes.Clone(oversizeEnvelope)
+}
+
+// respondOversize sends the fallback envelope after send failed with an
+// oversize rejection. A no-op for any other failure: those mean the reply
+// never left for a reason a second, smaller publish would hit as well.
+func respondOversize(sendErr error, send func([]byte) error, subject string) {
+	if !IsOversize(sendErr) {
+		return
+	}
+	if err := send(OversizeEnvelope()); err != nil {
+		slog.Error("oversize reply fallback failed", "error", err, "subject", subject)
+	}
+}
 
 // Marshal classifies err (logging it once) and returns the JSON envelope.
 func Marshal(ctx context.Context, err error) []byte {
@@ -41,6 +79,7 @@ func MarshalQuiet(err error) []byte {
 func Reply(ctx context.Context, msg *nats.Msg, err error) {
 	if rErr := msg.Respond(Marshal(ctx, err)); rErr != nil {
 		slog.ErrorContext(ctx, "error reply failed", "error", rErr, "subject", msg.Subject)
+		respondOversize(rErr, msg.Respond, msg.Subject)
 	}
 }
 
@@ -48,5 +87,6 @@ func Reply(ctx context.Context, msg *nats.Msg, err error) {
 func ReplyQuiet(msg *nats.Msg, err error) {
 	if rErr := msg.Respond(MarshalQuiet(err)); rErr != nil {
 		slog.Error("error reply failed", "error", rErr, "subject", msg.Subject)
+		respondOversize(rErr, msg.Respond, msg.Subject)
 	}
 }

--- a/pkg/errcode/errnats/reply_test.go
+++ b/pkg/errcode/errnats/reply_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -158,4 +159,133 @@ func TestReplyQuiet_RespondsButEmitsNoClassifyLine(t *testing.T) {
 	assert.Equal(t, "unavailable", got["code"])
 	assert.Equal(t, "service busy", got["error"])
 	assert.NotContains(t, buf.String(), "request failed", "ReplyQuiet must not emit a Classify log line")
+}
+
+// startTestNATSCapped is startTestNATS with a deliberately tiny max_payload so
+// an ordinary reply overflows the transport without allocating megabytes.
+func startTestNATSCapped(t *testing.T, maxPayload int32) *nats.Conn {
+	t.Helper()
+	opts := &natsserver.Options{Port: -1, MaxPayload: maxPayload}
+	ns, err := natsserver.NewServer(opts)
+	require.NoError(t, err)
+	ns.Start()
+	require.True(t, ns.ReadyForConnections(5*time.Second), "nats server did not become ready")
+	t.Cleanup(ns.Shutdown)
+
+	nc, err := nats.Connect(ns.ClientURL())
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+	return nc
+}
+
+func TestIsOversize(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"bare max payload", nats.ErrMaxPayload, true},
+		{"wrapped max payload", fmt.Errorf("respond to %q: %w", "_INBOX.x", nats.ErrMaxPayload), true},
+		{"doubly wrapped", fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", nats.ErrMaxPayload)), true},
+		{"unrelated transport error", nats.ErrConnectionClosed, false},
+		{"plain error", errors.New("boom"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsOversize(tt.err))
+		})
+	}
+}
+
+func TestOversizeEnvelope_CarriesTheDocumentedCodeAndReason(t *testing.T) {
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(OversizeEnvelope(), &got))
+	assert.Equal(t, "internal", got["code"])
+	assert.Equal(t, "response_too_large", got["reason"])
+	assert.NotEmpty(t, got["error"], "envelope must carry a human-readable message")
+}
+
+// The envelope is the last thing tried after a reply already overflowed, so it
+// has to fit under any max_payload a broker would realistically be configured
+// with. NATS' own floor is 1024 bytes.
+func TestOversizeEnvelope_FitsTheSmallestPlausibleMaxPayload(t *testing.T) {
+	assert.Less(t, len(OversizeEnvelope()), 1024,
+		"fallback envelope must clear the smallest max_payload a broker allows")
+}
+
+// Callers hand the returned slice to Respond, which is free to retain it. A
+// shared backing array would let one caller's mutation corrupt every later
+// fallback in the process.
+func TestOversizeEnvelope_ReturnsAnIndependentCopy(t *testing.T) {
+	first := OversizeEnvelope()
+	require.NotEmpty(t, first)
+	for i := range first {
+		first[i] = 'x'
+	}
+	assert.NotEqual(t, first, OversizeEnvelope(), "each call must return a fresh copy")
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(OversizeEnvelope(), &got), "envelope must survive a prior caller's mutation")
+	assert.Equal(t, "response_too_large", got["reason"])
+}
+
+// Without the fallback the oversize Respond fails client-side, nothing reaches
+// the wire, and the requester sees a bare timeout it cannot distinguish from a
+// dead service.
+func TestReply_OversizeFallsBackToTheCompactEnvelope(t *testing.T) {
+	ctx := ctxQuiet()
+	nc := startTestNATSCapped(t, 1024)
+
+	data := requestAndCaptureReply(t, nc, "test.reply.oversize", func(m *nats.Msg) {
+		Reply(ctx, m, errcode.Internal(strings.Repeat("x", 4096)))
+	})
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, "internal", got["code"])
+	assert.Equal(t, "response_too_large", got["reason"])
+}
+
+func TestReplyQuiet_OversizeFallsBackToTheCompactEnvelope(t *testing.T) {
+	nc := startTestNATSCapped(t, 1024)
+
+	data := requestAndCaptureReply(t, nc, "test.replyquiet.oversize", func(m *nats.Msg) {
+		ReplyQuiet(m, errcode.Internal(strings.Repeat("x", 4096)))
+	})
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, "internal", got["code"])
+	assert.Equal(t, "response_too_large", got["reason"])
+}
+
+// When even the fallback cannot be sent there is nothing left to tell the
+// caller, so the log line is the only trace an operator gets. It is also the
+// end of the line: respondOversize must not retry itself.
+func TestRespondOversize_LogsWhenTheFallbackItselfFails(t *testing.T) {
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	defer slog.SetDefault(old)
+
+	sends := 0
+	send := func([]byte) error {
+		sends++
+		return nats.ErrMaxPayload
+	}
+
+	respondOversize(nats.ErrMaxPayload, send, "chat.user.alice.request.rooms.info")
+
+	assert.Equal(t, 1, sends, "a failing fallback must not be retried")
+	assert.Contains(t, buf.String(), "oversize reply fallback failed")
+	assert.Contains(t, buf.String(), "chat.user.alice.request.rooms.info")
+}
+
+func TestRespondOversize_SkipsNonOversizeFailures(t *testing.T) {
+	sends := 0
+	send := func([]byte) error { sends++; return nil }
+
+	respondOversize(nats.ErrConnectionClosed, send, "chat.test")
+
+	assert.Zero(t, sends, "only an oversize rejection may trigger the fallback")
 }

--- a/pkg/natsrouter/context.go
+++ b/pkg/natsrouter/context.go
@@ -259,16 +259,30 @@ func (c *Context) respond(data []byte) {
 		slog.ErrorContext(c, "reply failed", "error", "nil NATS message")
 		return
 	}
-	var err error
+	err := c.send(data)
+	if err == nil {
+		return
+	}
+	c.requestResult = natsmetrics.RequestInternal
+	slog.ErrorContext(c, "reply failed", "error", err, "subject", c.Msg.Subject)
+	// An oversize reply is rejected before it reaches the wire, so the reply
+	// subject is still live and a compact envelope beats leaving the caller to
+	// time out on a failure it would read as a dead service. Sent through send
+	// rather than respond so a failing fallback cannot recurse.
+	if errnats.IsOversize(err) {
+		if fErr := c.send(errnats.OversizeEnvelope()); fErr != nil {
+			slog.ErrorContext(c, "oversize reply fallback failed", "error", fErr, "subject", c.Msg.Subject)
+		}
+	}
+}
+
+// send puts data on the reply subject, preferring the router's instrumented
+// responder and falling back to the raw message for a bare Context.
+func (c *Context) send(data []byte) error {
 	if c.reply != nil {
-		err = c.reply.Respond(c, c.Msg, data)
-	} else {
-		err = c.Msg.Respond(data)
+		return c.reply.Respond(c, c.Msg, data)
 	}
-	if err != nil {
-		c.requestResult = natsmetrics.RequestInternal
-		slog.ErrorContext(c, "reply failed", "error", err, "subject", c.Msg.Subject)
-	}
+	return c.Msg.Respond(data)
 }
 
 func requestResultFromError(err error) natsmetrics.RequestResult {

--- a/pkg/natsrouter/context_test.go
+++ b/pkg/natsrouter/context_test.go
@@ -3,7 +3,9 @@ package natsrouter
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -12,8 +14,10 @@ import (
 
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/natsmetrics"
 )
 
 // TestContext_WithLogValues_NoCycleAndEnriches verifies the seam derives from
@@ -222,4 +226,89 @@ func (r *capturingResponder) Respond(_ context.Context, msg *nats.Msg, data []by
 	r.msg = msg
 	r.data = append([]byte(nil), data...)
 	return nil
+}
+
+// oversizeResponder rejects the first n sends with a wrapped nats.ErrMaxPayload
+// (mirroring how o11ynats.Conn.Respond wraps it) and records every attempt.
+type oversizeResponder struct {
+	failFirst int
+	sends     [][]byte
+}
+
+func (r *oversizeResponder) Respond(_ context.Context, _ *nats.Msg, data []byte) error {
+	r.sends = append(r.sends, append([]byte(nil), data...))
+	if len(r.sends) <= r.failFirst {
+		return fmt.Errorf("nats respond to %q: %w", "_INBOX.reply", nats.ErrMaxPayload)
+	}
+	return nil
+}
+
+func newOversizeContext(reply responder) *Context {
+	msg := &nats.Msg{Subject: "chat.user.alice.request.rooms.info", Reply: "_INBOX.reply"}
+	return acquireContext(context.Background(), msg, Params{}, nil, reply)
+}
+
+// Every client-facing RPC replies through this chokepoint. Without the
+// fallback an oversize response never reaches the wire and the caller sees a
+// bare timeout, indistinguishable from a dead service.
+func TestContext_ReplyJSONOversizeSendsFallbackEnvelope(t *testing.T) {
+	reply := &oversizeResponder{failFirst: 1}
+	c := newOversizeContext(reply)
+	defer releaseContext(c)
+
+	c.ReplyJSON(map[string]string{"huge": "payload"})
+
+	require.Len(t, reply.sends, 2, "oversize send must be followed by exactly one fallback")
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(reply.sends[1], &got))
+	assert.Equal(t, "internal", got["code"])
+	assert.Equal(t, "response_too_large", got["reason"])
+	assert.Equal(t, natsmetrics.RequestInternal, c.requestResult)
+}
+
+func TestContext_ReplyErrorOversizeSendsFallbackEnvelope(t *testing.T) {
+	reply := &oversizeResponder{failFirst: 1}
+	c := newOversizeContext(reply)
+	defer releaseContext(c)
+
+	c.ReplyError(errcode.NotFound("room not found"))
+
+	require.Len(t, reply.sends, 2)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(reply.sends[1], &got))
+	assert.Equal(t, "response_too_large", got["reason"])
+}
+
+// A dropped connection or a closed subscription would fail a second publish
+// exactly as it failed the first; retrying only burns a send.
+func TestContext_RespondDoesNotRetryOnNonOversizeFailure(t *testing.T) {
+	reply := &failingResponder{err: nats.ErrConnectionClosed}
+	c := newOversizeContext(reply)
+	defer releaseContext(c)
+
+	c.ReplyJSON(map[string]string{"ok": "true"})
+
+	assert.Equal(t, 1, reply.calls, "non-oversize failures must not trigger the fallback")
+}
+
+// The fallback is itself sent through respond(); if that path retried on its
+// own failure it would recurse without bound.
+func TestContext_RespondRetriesFallbackAtMostOnce(t *testing.T) {
+	reply := &oversizeResponder{failFirst: 10}
+	c := newOversizeContext(reply)
+	defer releaseContext(c)
+
+	c.ReplyJSON(map[string]string{"huge": "payload"})
+
+	assert.Len(t, reply.sends, 2, "a failing fallback must not be retried again")
+}
+
+type failingResponder struct {
+	err   error
+	calls int
+}
+
+func (r *failingResponder) Respond(_ context.Context, _ *nats.Msg, _ []byte) error {
+	r.calls++
+	return r.err
 }

--- a/pkg/natsrouter/oversize_integration_test.go
+++ b/pkg/natsrouter/oversize_integration_test.go
@@ -1,0 +1,160 @@
+//go:build integration
+
+package natsrouter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/testutil/testimages"
+)
+
+// cappedMaxPayload is small enough that an ordinary reply overflows it without
+// allocating megabytes, and above the 1024-byte floor NATS enforces.
+const cappedMaxPayload = 4096
+
+// startCappedNATS runs a dedicated NATS container whose max_payload is capped.
+// The process-shared testutil.NATS cannot be used here: its cap is the 1 MiB
+// default and lowering it would apply to every other test in the run.
+func startCappedNATS(t *testing.T) string {
+	t.Helper()
+	ctx := context.Background()
+
+	// max_payload is config-file-only; nats-server exposes no CLI flag for it.
+	conf := fmt.Sprintf("listen: 0.0.0.0:4222\nmax_payload: %d\n", cappedMaxPayload)
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        testimages.NATS,
+			ExposedPorts: []string{"4222/tcp"},
+			Cmd:          []string{"--config", "/nats.conf"},
+			Files: []testcontainers.ContainerFile{{
+				Reader:            strings.NewReader(conf),
+				ContainerFilePath: "/nats.conf",
+				FileMode:          0o644,
+			}},
+			WaitingFor: wait.ForLog("Server is ready").WithStartupTimeout(60 * time.Second),
+		},
+		Started: true,
+	})
+	require.NoError(t, err, "start capped NATS container")
+	t.Cleanup(func() { _ = container.Terminate(context.Background()) })
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, "4222")
+	require.NoError(t, err)
+	return fmt.Sprintf("nats://%s:%s", host, port.Port())
+}
+
+func connectCapped(t *testing.T, url string) *o11ynats.Conn {
+	t.Helper()
+	nc, err := o11ynats.Connect(context.Background(), url, noop.NewTracerProvider(), propagation.TraceContext{})
+	require.NoError(t, err, "connect to capped NATS")
+	t.Cleanup(nc.Close)
+	return nc
+}
+
+type bulkReq struct {
+	Limit int `json:"limit"`
+}
+
+type bulkResp struct {
+	Items []string `json:"items"`
+}
+
+// End-to-end proof of the oversize contract over a real broker: a real
+// natsrouter route, a real o11y connection, a real request from a separate
+// client. The handler succeeds and returns a response that simply does not fit,
+// which before the fallback left the caller with nothing to read but a timeout
+// — the one failure it cannot tell apart from a dead service.
+func TestIntegration_OversizeReplyReturnsErrorEnvelope(t *testing.T) {
+	url := startCappedNATS(t)
+	r := Default(connectCapped(t, url), "integration-oversize")
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = r.Shutdown(ctx)
+	})
+
+	const subject = "chat.user.alice.request.history.load"
+	Register(r, "chat.user.{account}.request.history.load",
+		func(c *Context, req bulkReq) (*bulkResp, error) {
+			items := make([]string, req.Limit)
+			for i := range items {
+				items[i] = strings.Repeat("m", 64)
+			}
+			return &bulkResp{Items: items}, nil
+		})
+
+	client, err := nats.Connect(url)
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	t.Run("oversize reply returns response_too_large instead of timing out", func(t *testing.T) {
+		reply, err := client.Request(subject, []byte(`{"limit":500}`), 5*time.Second)
+		require.NoError(t, err, "the caller must get an answer, not a timeout")
+
+		var got errcode.Error
+		require.NoError(t, json.Unmarshal(reply.Data, &got))
+		assert.Equal(t, errcode.CodeInternal, got.Code)
+		assert.Equal(t, errcode.ResponseTooLarge, got.Reason)
+		assert.Less(t, len(reply.Data), cappedMaxPayload, "the fallback envelope must itself fit")
+	})
+
+	// The fallback must not fire on replies that fit — otherwise it would mask
+	// successful responses rather than rescue failed ones.
+	t.Run("reply that fits is unaffected", func(t *testing.T) {
+		reply, err := client.Request(subject, []byte(`{"limit":2}`), 5*time.Second)
+		require.NoError(t, err)
+
+		var got bulkResp
+		require.NoError(t, json.Unmarshal(reply.Data, &got))
+		assert.Len(t, got.Items, 2)
+	})
+}
+
+// The same guarantee on the error lane: an errcode reply too large to send
+// still has to reach the caller as an error envelope.
+func TestIntegration_OversizeErrorReplyReturnsErrorEnvelope(t *testing.T) {
+	url := startCappedNATS(t)
+	r := Default(connectCapped(t, url), "integration-oversize-err")
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = r.Shutdown(ctx)
+	})
+
+	const subject = "chat.user.bob.request.rooms.info"
+	Register(r, "chat.user.{account}.request.rooms.info",
+		func(c *Context, _ bulkReq) (*bulkResp, error) {
+			return nil, errcode.BadRequest(strings.Repeat("y", cappedMaxPayload*2))
+		})
+
+	client, err := nats.Connect(url)
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	reply, err := client.Request(subject, []byte(`{}`), 5*time.Second)
+	require.NoError(t, err, "the caller must get an answer, not a timeout")
+
+	var got errcode.Error
+	require.NoError(t, json.Unmarshal(reply.Data, &got))
+	assert.Equal(t, errcode.CodeInternal, got.Code)
+	assert.Equal(t, errcode.ResponseTooLarge, got.Reason)
+}

--- a/pkg/natsutil/reply.go
+++ b/pkg/natsutil/reply.go
@@ -7,16 +7,12 @@ package natsutil
 
 import (
 	"encoding/json"
-	"errors"
 	"log/slog"
 
 	"github.com/nats-io/nats.go"
-)
 
-// oversizeEnvelope is the small fallback reply when a response exceeds max_payload —
-// it always fits, so the client gets an error instead of a silent timeout. The
-// stable reason lets clients branch on it without parsing the message text.
-const oversizeEnvelope = `{"code":"internal","reason":"response_too_large","error":"response payload exceeds maximum size"}`
+	"github.com/hmchangw/chat/pkg/errcode/errnats"
+)
 
 // MarshalResponse encodes a value as JSON for NATS responses.
 func MarshalResponse(v any) ([]byte, error) {
@@ -40,8 +36,8 @@ func ReplyJSON(msg *nats.Msg, v any) {
 		slog.Error("reply failed", "error", err, "subject", msg.Subject)
 		// An oversize reply never went on the wire — fall back to a compact
 		// error envelope so the client gets an error, not a silent timeout.
-		if errors.Is(err, nats.ErrMaxPayload) {
-			if rErr := msg.Respond([]byte(oversizeEnvelope)); rErr != nil {
+		if errnats.IsOversize(err) {
+			if rErr := msg.Respond(errnats.OversizeEnvelope()); rErr != nil {
 				slog.Error("oversize reply fallback failed", "error", rErr, "subject", msg.Subject)
 			}
 		}

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -6905,6 +6905,22 @@ func TestHandler_marshalBounded(t *testing.T) {
 	}
 }
 
+// room-service catches an oversize reply proactively, before the transport
+// does, so its error must carry the same reason the router's reactive fallback
+// emits — otherwise the same condition reaches the client two different ways
+// and the documented `response_too_large` branch (docs/client-api.md §6)
+// silently misses this one.
+func TestHandler_marshalBounded_OversizeCarriesTheDocumentedReason(t *testing.T) {
+	h := &Handler{maxResponseBytes: 8}
+
+	_, err := h.marshalBounded(map[string]string{"hello": strings.Repeat("x", 64)})
+
+	var coded *errcode.Error
+	require.ErrorAs(t, err, &coded)
+	assert.Equal(t, errcode.CodeInternal, coded.Code)
+	assert.Equal(t, errcode.ResponseTooLarge, coded.Reason)
+}
+
 func TestHandler_authorizeRoomAppRead(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/room-service/helper.go
+++ b/room-service/helper.go
@@ -106,7 +106,8 @@ var (
 	// caller is neither a room member nor a platform admin; Internal when a
 	// reply would exceed the negotiated NATS max_payload.
 	errAppAccessDenied  = errcode.Forbidden("not authorized to access this room's apps", errcode.WithReason(errcode.RoomNotMember))
-	errResponseTooLarge = errcode.Internal("response payload exceeds maximum size")
+	errResponseTooLarge = errcode.Internal("response payload exceeds maximum size",
+		errcode.WithReason(errcode.ResponseTooLarge))
 )
 
 // platformAdminRegex matches the platform-admin pseudo-account by its configured

--- a/tools/loadgen/soak_rpc.go
+++ b/tools/loadgen/soak_rpc.go
@@ -155,11 +155,9 @@ func parseSoakErrorEnvelope(data []byte) error {
 	return parsed
 }
 
-// soakReasonResponseTooLarge mirrors the reason in pkg/natsutil's oversize
-// reply envelope. Declared here rather than in pkg/errcode so this change stays
-// inside tools/loadgen; if a named constant is ever added upstream, this should
-// become an alias for it.
-const soakReasonResponseTooLarge errcode.Reason = "response_too_large"
+// soakReasonResponseTooLarge aliases the platform reason carried by the
+// oversize reply envelope, so the harness cannot drift from the wire contract.
+const soakReasonResponseTooLarge = errcode.ResponseTooLarge
 
 // soakErrorReason is the service-supplied errcode reason, kept beside the
 // collapsed class because the two forbidden answers a soak read can get need


### PR DESCRIPTION
## Problem

`docs/client-api.md` §6 already promises that **any** RPC whose reply exceeds the transport `max_payload` comes back as `internal` / `response_too_large`. The live path did not deliver it.

Every client-facing request/reply goes through `pkg/natsrouter` (confirmed — no raw `QueueSubscribe` request/reply handlers remain outside the router). Its `Context.respond` logged `"reply failed"` and returned, so the caller got a **bare timeout** — indistinguishable from a dead service, even though the two call for opposite recoveries: narrow the request vs. retry as-is.

The only implementation of the fallback sat in `natsutil.ReplyJSON`, which has had **no production caller** since the router migration. Meanwhile `room-service`'s proactive size guard returned its oversize error with **no `reason` at all**, so even the one path that caught the condition early missed the documented branch.

Three separate spellings of the reason string existed, none of them a registered constant.

## Change

| File | Change |
|---|---|
| `pkg/natsrouter/context.go` | **The fix.** `respond()` retries once with a compact envelope on `nats.ErrMaxPayload`. Sent through a new `send()` rather than `respond()` so a failing fallback cannot recurse. |
| `pkg/errcode/codes_platform.go` | New `ResponseTooLarge` reason |
| `pkg/errcode/errnats/reply.go` | `IsOversize`, `OversizeEnvelope` (built once at init, returned as a fresh copy), plus the fallback in `Reply`/`ReplyQuiet` |
| `pkg/natsutil/reply.go`, `room-service/helper.go`, `tools/loadgen/soak_rpc.go` | Point the three literals at the shared constant |
| `docs/client-api.md` | Widened one sentence: the fallback now covers the error lane too, not only success bodies |

### Why reactive rather than a pre-marshal size check

`nats.go` refuses an oversize publish **synchronously, before anything reaches the wire**, so the reply subject is still live and a compact envelope still gets through. The broker's limit also counts the trace headers the o11y facade injects, which a byte count over the response alone would miss.

## Verification

Built test-first; each test was watched failing for the right reason before the implementation existed.

**End-to-end** (`pkg/natsrouter/oversize_integration_test.go`, `//go:build integration`) — real NATS container capped at 4 KiB `max_payload`, real router route, real client request:

| | Without the fix | With the fix |
|---|---|---|
| oversize success body | `FAIL` — "the caller must get an answer, not a timeout" @ **5.61s** | `PASS` @ **0.49s** |
| oversize error envelope | `FAIL` — same @ **5.46s** | `PASS` @ **0.46s** |
| reply that fits | `PASS` (unaffected) | `PASS` (unaffected) |

The "reply that fits" case is asserted separately so the fallback cannot mask successful responses. Inline `testcontainers` rather than `testutil.NATS(t)` because the shared broker is process-wide at the 1 MiB default and lowering it would affect every other test; the container ref is stored and `t.Cleanup(Terminate)` registered.

Reverting the fix also reproduced the equivalent 2.01s timeout in the `errnats` unit tests.

**Gates:**
- `make lint` → 0 issues
- `make test` (all 112 packages, `-race`) → exit 0, 0 failures
- `make test-integration` for `pkg/natsrouter`, `pkg/errcode`, `pkg/natsutil`, `room-service` → all ok
- `make sast` → gosec **PASS**, govulncheck **PASS**, semgrep **PASS**

**Coverage:** `IsOversize`, `OversizeEnvelope`, `respondOversize` at **100%**; packages at 91.3% / 88.9% / 87.9%, all clear of the 80% floor.

## Notes for reviewers

- No handler registration, request/reply struct, or event struct changed, so no new `docs/client-api.md` rows are needed — the docs were already the promise; this makes the code keep it. The one doc edit is a precision fix.
- `natsutil.ReplyJSON` is left in place (still no production callers) rather than deleted — removing it is a separate cleanup.

---
_Generated by [Claude Code](https://claude.ai/code/session_012vGY47HWtztTUL36YcEHpz)_