### PR TITLE
Skip soft-deleted rooms and subscriptions in CDC migration

### DIFF
--- a/data-migration/CDC_COVERAGE.md
+++ b/data-migration/CDC_COVERAGE.md
@@ -31,14 +31,14 @@ The connector forwards raw change-stream events with **no `updateLookup`** and *
 | # | Source event | Op + payload | Source lookup (by `_id`) | Current-system facts | Handling / impact |
 |---|---|---|---|---|---|
 | **Rooms** |
-| 1 | Room create | `insert` — full doc | in payload | `t` ∈ `c,p,d,l,v`; `prid`⇒discussion; `teamId`/`teamMain`; `d` can have >2 users | ✅ map → `room_sync` (skip `l`,`v`,group-DM, soft-deleted) |
-| 2 | Room replace | `replace` — full doc | not needed | whole-doc rewrite; can cross type/exclusion boundary; **no delta** to tell which fields changed | ✅ re-classify → `room_renamed` + `room_restricted` + `room_sync` (skip soft-deleted; conservative — field events are idempotent + guarded; subs' denormalized name/visibility must not go stale) |
-| 3 | Room change | `update` — changed fields only | full current doc | — | ✅ re-read doc → `room_renamed` / `room_restricted` / `room_sync` (skip soft-deleted) |
+| 1 | Room create | `insert` — full doc | in payload | `t` ∈ `c,p,d,l,v`; `prid`⇒discussion; `teamId`/`teamMain`; `d` can have >2 users | ✅ map → `room_sync` (skip `l`,`v`,group-DM, already-soft-deleted) |
+| 2 | Room replace | `replace` — full doc | not needed | whole-doc rewrite; can cross type/exclusion boundary; **no delta** to tell which fields changed | ✅ re-classify → `room_renamed` + `room_restricted` + `room_sync` (skip already-soft-deleted; conservative — field events are idempotent + guarded; subs' denormalized name/visibility must not go stale) |
+| 3 | Room change | `update` — changed fields only | full current doc | — | ✅ re-read doc → `room_renamed` / `room_restricted` / `room_sync`; a rename INTO `Del-` **is** the delete and is applied, other changes on a `Del-` room are skipped |
 | 4 | Room delete | `delete` — `_id` only | nothing — doc gone | app has no room-delete operation | ❌ skip (no app deletion; un-actionable) |
 | **Subscriptions** |
-| 5 | Sub create | `insert` — full doc | in payload | `u`, `rid`, `roles[]`, `open`, `f`, `disableNotifications`, `ls`/`lr`, `alert` | ✅ `member_added` + state events (skip soft-deleted) |
-| 6 | Sub replace | `replace` — full doc | not needed | whole-doc rewrite | ✅ re-classify → `member_added` + state (skip soft-deleted) |
-| 7 | Sub change (incl. leave/rejoin) | `update` — changed fields only | full current doc | leaving sets `open:false` (not a row delete) | ✅ re-read doc → `open`-toggle → `member_added`/`member_removed`; mute/fav/role/read → matching event (skip soft-deleted) |
+| 5 | Sub create | `insert` — full doc | in payload | `u`, `rid`, `roles[]`, `open`, `f`, `disableNotifications`, `ls`/`lr`, `alert` | ✅ `member_added` + state events (skip subs to soft-deleted rooms) |
+| 6 | Sub replace | `replace` — full doc | not needed | whole-doc rewrite | ✅ re-classify → `member_added` + state (skip subs to soft-deleted rooms) |
+| 7 | Sub change (incl. leave/rejoin) | `update` — changed fields only | full current doc | leaving sets `open:false` (not a row delete) | ✅ re-read doc → `open`-toggle → `member_added`/`member_removed`; mute/fav/role/read → matching event (skip subs to soft-deleted rooms) |
 | 8 | Sub delete (true row removal) | `delete` — `_id` only | nothing — doc gone | destination subs key by generated `UUIDv7`, not source `_id`; removal needs `(roomID, account)` | ❌ skip (un-actionable; rare — leave is `open:false`) |
 | **Thread subscriptions** |
 | 9 | Follow / first reply | `insert` — full doc | in payload | keyed `(u._id, parentMessage._id)`; carries `rid`, `lastSeenAt`, `unreadMention` | ✅ resolve thread-room+user → `thread_subscription_upserted` |
@@ -56,17 +56,37 @@ The connector forwards raw change-stream events with **no `updateLookup`** and *
 
 ### Soft-deleted rooms (`Del-` prefix)
 
-The source "deletes" a room by renaming it — and every subscription's denormalized name — to
-`Del-`+name; there is no delete flag and no row removal. Rooms and subscriptions whose `name` **or**
-`fname` carries that exact prefix are **never imported**, on any op (`insert`/`replace`/`update`),
-metered as `room_soft_deleted` / `subscription_soft_deleted`. Only the exact `Del-` prefix counts
-(`delta`, `del-general`, `team-Del-old` are live rooms) — the same marker `user-service` filters
-subscription reads on.
+The source has no room-delete operation and no delete flag: "deleting" a room renames it — and the
+denormalized name on every subscription to it — to `Del-`+name. The destination honors the same
+marker (`user-service/mongorepo/subscriptions.go:21` filters `^Del-` rooms out of
+`subscription.list` / `getChannels` / `count`), but nothing in the new stack ever *writes* it, so
+this migration is its only producer. That makes the rename both the deletion **event** and the
+deletion **state**, handled differently per op:
 
-**Consequence:** a room soft-deleted *after* the CDC checkpoint arrives as a rename-into-`Del-`
-update, which is skipped like any other soft-deleted record — the destination room (imported while
-it was live) stays as it was. The new stack has no room deletion to apply, so this is the same
-end-state as row 4 (`Room delete` → skip).
+| Source event | Meaning | Handling |
+|---|---|---|
+| `insert` / `replace` of a `Del-` doc | born deleted — never existed downstream | ❌ skip (`room_soft_deleted`) |
+| `update` whose delta touches `name`/`fname`, doc now `Del-` | the deletion itself | ✅ apply → `room_renamed` + `room_sync`; the destination room takes the prefixed name and the `^Del-` filter hides it |
+| `update` touching anything else on a `Del-` doc | churn on a dead room | ❌ skip (`room_soft_deleted`) |
+| Any subscription op on a `Del-` sub | sub to a deleted room | ❌ skip (`subscription_soft_deleted`) |
+
+Only the exact prefix counts — `delta`, `del-general` and `team-Del-old` are live rooms.
+
+**Subscriptions never carry the deletion.** It rides the room lane: `room_renamed` →
+`UpdateSubscriptionNamesForRoom` already rewrites the name on *every* sub in the room, so subs
+imported while the room was live stay consistent. Letting sub-lane field events through instead
+would be actively harmful — `UpdateSubscriptionRoles`/mute/favorite/open treat a missing
+subscription as an error so the event redelivers until `member_added` lands
+(`inbox-worker/main.go:118`), which never comes for a sub whose insert this guard skipped.
+
+**DMs (`t:"d"`) are exempt on both lanes.** There `name`/`fname` hold the peer's username and
+display name, not a room name, so the prefix would match a user rather than a deletion. A
+soft-deleted DM that slips through is still hidden downstream — the `^Del-` room filter is
+type-agnostic.
+
+**Residual:** `UpsertRoom` upserts (`inbox-worker/main.go:85`), so applying the deletion rename for
+a room whose `insert` was skipped *creates* a hidden `Del-` room doc rather than no-op'ing.
+Invisible to users; avoiding it would cost a room-existence read per event.
 
 ## Direct-transfer collections (oplog-direct-transfer)
 

--- a/data-migration/CDC_COVERAGE.md
+++ b/data-migration/CDC_COVERAGE.md
@@ -31,14 +31,14 @@ The connector forwards raw change-stream events with **no `updateLookup`** and *
 | # | Source event | Op + payload | Source lookup (by `_id`) | Current-system facts | Handling / impact |
 |---|---|---|---|---|---|
 | **Rooms** |
-| 1 | Room create | `insert` — full doc | in payload | `t` ∈ `c,p,d,l,v`; `prid`⇒discussion; `teamId`/`teamMain`; `d` can have >2 users | ✅ map → `room_sync` (skip `l`,`v`,group-DM) |
-| 2 | Room replace | `replace` — full doc | not needed | whole-doc rewrite; can cross type/exclusion boundary; **no delta** to tell which fields changed | ✅ re-classify → `room_renamed` + `room_restricted` + `room_sync` (conservative — field events are idempotent + guarded; subs' denormalized name/visibility must not go stale) |
-| 3 | Room change | `update` — changed fields only | full current doc | — | ✅ re-read doc → `room_renamed` / `room_restricted` / `room_sync` |
+| 1 | Room create | `insert` — full doc | in payload | `t` ∈ `c,p,d,l,v`; `prid`⇒discussion; `teamId`/`teamMain`; `d` can have >2 users | ✅ map → `room_sync` (skip `l`,`v`,group-DM, soft-deleted) |
+| 2 | Room replace | `replace` — full doc | not needed | whole-doc rewrite; can cross type/exclusion boundary; **no delta** to tell which fields changed | ✅ re-classify → `room_renamed` + `room_restricted` + `room_sync` (skip soft-deleted; conservative — field events are idempotent + guarded; subs' denormalized name/visibility must not go stale) |
+| 3 | Room change | `update` — changed fields only | full current doc | — | ✅ re-read doc → `room_renamed` / `room_restricted` / `room_sync` (skip soft-deleted) |
 | 4 | Room delete | `delete` — `_id` only | nothing — doc gone | app has no room-delete operation | ❌ skip (no app deletion; un-actionable) |
 | **Subscriptions** |
-| 5 | Sub create | `insert` — full doc | in payload | `u`, `rid`, `roles[]`, `open`, `f`, `disableNotifications`, `ls`/`lr`, `alert` | ✅ `member_added` + state events |
-| 6 | Sub replace | `replace` — full doc | not needed | whole-doc rewrite | ✅ re-classify → `member_added` + state |
-| 7 | Sub change (incl. leave/rejoin) | `update` — changed fields only | full current doc | leaving sets `open:false` (not a row delete) | ✅ re-read doc → `open`-toggle → `member_added`/`member_removed`; mute/fav/role/read → matching event |
+| 5 | Sub create | `insert` — full doc | in payload | `u`, `rid`, `roles[]`, `open`, `f`, `disableNotifications`, `ls`/`lr`, `alert` | ✅ `member_added` + state events (skip soft-deleted) |
+| 6 | Sub replace | `replace` — full doc | not needed | whole-doc rewrite | ✅ re-classify → `member_added` + state (skip soft-deleted) |
+| 7 | Sub change (incl. leave/rejoin) | `update` — changed fields only | full current doc | leaving sets `open:false` (not a row delete) | ✅ re-read doc → `open`-toggle → `member_added`/`member_removed`; mute/fav/role/read → matching event (skip soft-deleted) |
 | 8 | Sub delete (true row removal) | `delete` — `_id` only | nothing — doc gone | destination subs key by generated `UUIDv7`, not source `_id`; removal needs `(roomID, account)` | ❌ skip (un-actionable; rare — leave is `open:false`) |
 | **Thread subscriptions** |
 | 9 | Follow / first reply | `insert` — full doc | in payload | keyed `(u._id, parentMessage._id)`; carries `rid`, `lastSeenAt`, `unreadMention` | ✅ resolve thread-room+user → `thread_subscription_upserted` |
@@ -53,6 +53,20 @@ The connector forwards raw change-stream events with **no `updateLookup`** and *
 | 16 | User deactivate / delete | `update` (`active:false`) or `delete` | `update`: full doc · `delete`: nothing | source sets `active:false` (no row deletion); no destination apply-path wired | ❌ deferred (out of scope) |
 | **All collections** |
 | 17 | Collection drop / rename | collection-level (`drop`/`rename`/`invalidate`) | n/a | terminates/invalidates the per-collection change stream | ⚠️ out of scope, deferred — connector re-point, not migration logic |
+
+### Soft-deleted rooms (`Del-` prefix)
+
+The source "deletes" a room by renaming it — and every subscription's denormalized name — to
+`Del-`+name; there is no delete flag and no row removal. Rooms and subscriptions whose `name` **or**
+`fname` carries that exact prefix are **never imported**, on any op (`insert`/`replace`/`update`),
+metered as `room_soft_deleted` / `subscription_soft_deleted`. Only the exact `Del-` prefix counts
+(`delta`, `del-general`, `team-Del-old` are live rooms) — the same marker `user-service` filters
+subscription reads on.
+
+**Consequence:** a room soft-deleted *after* the CDC checkpoint arrives as a rename-into-`Del-`
+update, which is skipped like any other soft-deleted record — the destination room (imported while
+it was live) stays as it was. The new stack has no room deletion to apply, so this is the same
+end-state as row 4 (`Room delete` → skip).
 
 ## Direct-transfer collections (oplog-direct-transfer)
 

--- a/data-migration/CDC_COVERAGE.md
+++ b/data-migration/CDC_COVERAGE.md
@@ -90,8 +90,11 @@ dead room — so the destination keeps the room under its **original, unprefixed
 holds (no `Del-` doc exists), but that room stays visible to its members. Applying the rename would
 hide it via user-service's `^Del-` filter, at the cost of writing exactly the doc this invariant
 forbids. **Removing such rooms is an ops backfill, not a CDC behaviour** — the destination has no
-room-delete path, and the affected ids are exactly those counted by
-`…_events_skipped_total{reason=room_soft_deleted}`.
+room-delete path. Identify the affected rooms by querying the **source** for docs whose `name` or
+`fname` carries the prefix, then reconcile against the destination `rooms` collection by `_id`. The
+`…_events_skipped_total{reason=room_soft_deleted}` counter reports skipped **event volume** only: it
+counts every event on a dead room, not unique rooms, and carries no room id (an unbounded metric
+label). The per-skip log line carries `roomId` for tracing an individual record.
 
 **DMs are not exempt.** For `t:"d"` the name fields hold the peer's username and display name rather
 than a room name, so a user literally named `Del-…` costs their DM. That is the deliberate price of

--- a/data-migration/CDC_COVERAGE.md
+++ b/data-migration/CDC_COVERAGE.md
@@ -31,9 +31,9 @@ The connector forwards raw change-stream events with **no `updateLookup`** and *
 | # | Source event | Op + payload | Source lookup (by `_id`) | Current-system facts | Handling / impact |
 |---|---|---|---|---|---|
 | **Rooms** |
-| 1 | Room create | `insert` — full doc | in payload | `t` ∈ `c,p,d,l,v`; `prid`⇒discussion; `teamId`/`teamMain`; `d` can have >2 users | ✅ map → `room_sync` (skip `l`,`v`,group-DM, already-soft-deleted) |
-| 2 | Room replace | `replace` — full doc | not needed | whole-doc rewrite; can cross type/exclusion boundary; **no delta** to tell which fields changed | ✅ re-classify → `room_renamed` + `room_restricted` + `room_sync` (a `Del-` doc is applied, not skipped — no delta to recognise the deletion by; conservative — field events are idempotent + guarded; subs' denormalized name/visibility must not go stale) |
-| 3 | Room change | `update` — changed fields only | full current doc | — | ✅ re-read doc → `room_renamed` / `room_restricted` / `room_sync`; a rename INTO `Del-` **is** the delete and is applied, other changes on a `Del-` room are skipped |
+| 1 | Room create | `insert` — full doc | in payload | `t` ∈ `c,p,d,l,v`; `prid`⇒discussion; `teamId`/`teamMain`; `d` can have >2 users | ✅ map → `room_sync` (skip `l`,`v`,group-DM, any `Del-` room) |
+| 2 | Room replace | `replace` — full doc | not needed | whole-doc rewrite; can cross type/exclusion boundary; **no delta** to tell which fields changed | ✅ re-classify → `room_renamed` + `room_restricted` + `room_sync` (skip any `Del-` room; conservative — field events are idempotent + guarded; subs' denormalized name/visibility must not go stale) |
+| 3 | Room change | `update` — changed fields only | full current doc | — | ✅ re-read doc → `room_renamed` / `room_restricted` / `room_sync`; skipped entirely once the doc is `Del-` prefixed, including the rename that deleted it |
 | 4 | Room delete | `delete` — `_id` only | nothing — doc gone | app has no room-delete operation | ❌ skip (no app deletion; un-actionable) |
 | **Subscriptions** |
 | 5 | Sub create | `insert` — full doc | in payload | `u`, `rid`, `roles[]`, `open`, `f`, `disableNotifications`, `ls`/`lr`, `alert` | ✅ `member_added` + state events (skip subs to soft-deleted rooms) |
@@ -56,70 +56,46 @@ The connector forwards raw change-stream events with **no `updateLookup`** and *
 
 ### Soft-deleted rooms (`Del-` prefix)
 
+**Invariant: a room or subscription carrying the `Del-` marker must never appear in the destination
+MongoDB — no doc, no rename, no denormalized copy.**
+
 The source has no room-delete operation and no delete flag: "deleting" a room renames it — and the
-denormalized name on every subscription to it — to `Del-`+name. The destination honors the same
-marker (`user-service/mongorepo/subscriptions.go:21` filters `^Del-` rooms out of
-`subscription.list` / `getChannels` / `count`), but nothing in the new stack ever *writes* it, so
-this migration is its only producer. That makes the rename both the deletion **event** and the
-deletion **state**, handled differently per op:
+denormalized name on every subscription to it — to `Del-`+name. Those records are legacy debris and
+are simply not migrated.
 
-| Source event | Meaning | Handling |
+Every name this transformer can write into Mongo comes from a published event, so the guard sits on
+the publish side of all three:
+
+| Event | What it writes | Guarded by |
 |---|---|---|
-| `insert` of a `Del-` doc | born deleted — never existed downstream | ❌ skip (`room_soft_deleted`) |
-| `update` whose delta touches `name`/`fname` (set **or** removed), doc now `Del-` | the deletion itself | ✅ apply → `room_renamed` + `room_sync` |
-| `replace` of a `Del-` doc | no delta, so the deletion cannot be recognised from the event | ✅ apply — a missed deletion leaves a room visible to its members, which is worse than the hidden room doc a spurious apply costs |
-| `update` touching anything else on a `Del-` doc | churn on a dead room | ❌ skip (`room_soft_deleted`) |
-| Any subscription op on a `Del-` sub | sub to a deleted room | ❌ skip (`subscription_soft_deleted`) |
+| `room_sync` | `rooms.name` | room lane (`rooms.go`) |
+| `room_renamed` | `subscriptions.name` for every sub in the room | room lane (`rooms.go`) |
+| `member_added` | the new subscription's name | subscription lane (`subscriptions.go`) |
 
-Every applied deletion increments `oplog_collections_transformer_soft_delete_applied_total{op}` —
-the cutover reconciliation counter to compare against the source's `Del-` room count. Skips are
-counted by `…_events_skipped_total{reason=room_soft_deleted|subscription_soft_deleted}`.
+`company_room_members` and `company_thread_subscriptions` carry no name field, so those lanes cannot
+violate the invariant and need no guard.
 
-**The applied name always carries the marker.** `user-service` hides a room by matching `^Del-` on
-the destination `rooms.name`, which maps from `fname` in preference to `name`. When the source
-renamed only the machine name, the mapped display name is re-prefixed on the way out
-(`rooms.destinationName()`) — otherwise the deletion would be applied and hide nothing.
+| Source event | Handling |
+|---|---|
+| Any op (`insert` / `replace` / `update`) on a room whose `name` **or** `fname` is `Del-` prefixed | ❌ skip (`room_soft_deleted`) |
+| Any op on a subscription whose `name` **or** `fname` is `Del-` prefixed | ❌ skip (`subscription_soft_deleted`) |
 
-**Room-type exclusion is classified first.** A `Del-` livechat/voip/group-DM room still meters
-`livechat`/`voip`/`group_dm`, and a malformed `updateDescription` on one still skips rather than
-terming as poison.
+Only the exact prefix counts — `delta`, `del-general` and `team-Del-old` are live rooms. The check
+is case-sensitive; `SOURCE_DATA.md` §3 carries the open question of whether the source ever writes
+another casing.
 
-Only the exact prefix counts — `delta`, `del-general` and `team-Del-old` are live rooms.
+**Rooms deleted after the CDC checkpoint keep their live name.** A room imported while live and
+soft-deleted later arrives as a rename into `Del-`, which is skipped like everything else about a
+dead room — so the destination keeps the room under its **original, unprefixed** name. The invariant
+holds (no `Del-` doc exists), but that room stays visible to its members. Applying the rename would
+hide it via user-service's `^Del-` filter, at the cost of writing exactly the doc this invariant
+forbids. **Removing such rooms is an ops backfill, not a CDC behaviour** — the destination has no
+room-delete path, and the affected ids are exactly those counted by
+`…_events_skipped_total{reason=room_soft_deleted}`.
 
-**Subscriptions never carry the deletion.** It rides the room lane: `room_renamed` →
-`UpdateSubscriptionNamesForRoom` already rewrites the name on *every* sub in the room, so subs
-imported while the room was live stay consistent. Letting sub-lane field events through instead
-would be actively harmful — `UpdateSubscriptionRoles`/mute/favorite/open treat a missing
-subscription as an error so the event redelivers until `member_added` lands
-(`inbox-worker/main.go:118`), which never comes for a sub whose insert this guard skipped.
-
-**DMs (`t:"d"`) are exempt on both lanes.** There `name`/`fname` hold the peer's username and
-display name, not a room name, so the prefix would match a user rather than a deletion. The trade
-is deliberate: dropping a live DM because its peer is named `Del-…` is unrecoverable, while a
-soft-deleted DM that slips through is not. Note the containment is partial — the `^Del-` room filter
-is type-agnostic, so such a DM is hidden **only if** the source prefixed `fname` (the field the
-destination name maps from); a `name`-only rename on a DM stays visible. Confirm with the source
-team whether DM docs are renamed at all before treating this as closed.
-
-**Residual — spurious apply.** `UpsertRoom` upserts (`inbox-worker/main.go:85`), so applying the
-deletion for a room whose `insert` was skipped *creates* a hidden `Del-` room doc rather than
-no-op'ing. Invisible to users; avoiding it would cost a room-existence read per event.
-
-**Residual — restore is not reconstructible from CDC.** If the source ever renames a room back out
-of `Del-`, the room re-appears (the rename passes the guard and syncs) but its subscriptions do not:
-their inserts were skipped while the room was dead, and the restore reaches the sub lane as a
-`name`/`fname` delta, which carries no membership. A restore is indistinguishable from an ordinary
-rename in the change stream (no `fullDocumentBeforeChange`, so the previous name is unknown), so
-rebuilding membership on every rename-shaped sub update would emit a `member_added` storm for every
-legitimate rename. **Repair is a targeted backfill, not a CDC behaviour:** the affected room ids are
-exactly those counted by `…_events_skipped_total{reason=room_soft_deleted}` — re-run the bulk
-subscription copy for them. The source is not known to support un-delete; confirm with the source
-team before relying on this.
-
-**Residual — name-less lanes are not filtered.** `company_room_members` and
-`company_thread_subscriptions` carry no denormalized room name, so members and thread subs of a
-soft-deleted room are still written. They are not user-visible through the filtered reads, so this
-is accepted rather than fixed.
+**DMs are not exempt.** For `t:"d"` the name fields hold the peer's username and display name rather
+than a room name, so a user literally named `Del-…` costs their DM. That is the deliberate price of
+a total invariant: type-scoping the check would let a `Del-` named DM doc into Mongo.
 
 ## Direct-transfer collections (oplog-direct-transfer)
 

--- a/data-migration/CDC_COVERAGE.md
+++ b/data-migration/CDC_COVERAGE.md
@@ -32,7 +32,7 @@ The connector forwards raw change-stream events with **no `updateLookup`** and *
 |---|---|---|---|---|---|
 | **Rooms** |
 | 1 | Room create | `insert` — full doc | in payload | `t` ∈ `c,p,d,l,v`; `prid`⇒discussion; `teamId`/`teamMain`; `d` can have >2 users | ✅ map → `room_sync` (skip `l`,`v`,group-DM, already-soft-deleted) |
-| 2 | Room replace | `replace` — full doc | not needed | whole-doc rewrite; can cross type/exclusion boundary; **no delta** to tell which fields changed | ✅ re-classify → `room_renamed` + `room_restricted` + `room_sync` (skip already-soft-deleted; conservative — field events are idempotent + guarded; subs' denormalized name/visibility must not go stale) |
+| 2 | Room replace | `replace` — full doc | not needed | whole-doc rewrite; can cross type/exclusion boundary; **no delta** to tell which fields changed | ✅ re-classify → `room_renamed` + `room_restricted` + `room_sync` (a `Del-` doc is applied, not skipped — no delta to recognise the deletion by; conservative — field events are idempotent + guarded; subs' denormalized name/visibility must not go stale) |
 | 3 | Room change | `update` — changed fields only | full current doc | — | ✅ re-read doc → `room_renamed` / `room_restricted` / `room_sync`; a rename INTO `Del-` **is** the delete and is applied, other changes on a `Del-` room are skipped |
 | 4 | Room delete | `delete` — `_id` only | nothing — doc gone | app has no room-delete operation | ❌ skip (no app deletion; un-actionable) |
 | **Subscriptions** |
@@ -65,10 +65,24 @@ deletion **state**, handled differently per op:
 
 | Source event | Meaning | Handling |
 |---|---|---|
-| `insert` / `replace` of a `Del-` doc | born deleted — never existed downstream | ❌ skip (`room_soft_deleted`) |
-| `update` whose delta touches `name`/`fname`, doc now `Del-` | the deletion itself | ✅ apply → `room_renamed` + `room_sync`; the destination room takes the prefixed name and the `^Del-` filter hides it |
+| `insert` of a `Del-` doc | born deleted — never existed downstream | ❌ skip (`room_soft_deleted`) |
+| `update` whose delta touches `name`/`fname` (set **or** removed), doc now `Del-` | the deletion itself | ✅ apply → `room_renamed` + `room_sync` |
+| `replace` of a `Del-` doc | no delta, so the deletion cannot be recognised from the event | ✅ apply — a missed deletion leaves a room visible to its members, which is worse than the hidden room doc a spurious apply costs |
 | `update` touching anything else on a `Del-` doc | churn on a dead room | ❌ skip (`room_soft_deleted`) |
 | Any subscription op on a `Del-` sub | sub to a deleted room | ❌ skip (`subscription_soft_deleted`) |
+
+Every applied deletion increments `oplog_collections_transformer_soft_delete_applied_total{op}` —
+the cutover reconciliation counter to compare against the source's `Del-` room count. Skips are
+counted by `…_events_skipped_total{reason=room_soft_deleted|subscription_soft_deleted}`.
+
+**The applied name always carries the marker.** `user-service` hides a room by matching `^Del-` on
+the destination `rooms.name`, which maps from `fname` in preference to `name`. When the source
+renamed only the machine name, the mapped display name is re-prefixed on the way out
+(`rooms.destinationName()`) — otherwise the deletion would be applied and hide nothing.
+
+**Room-type exclusion is classified first.** A `Del-` livechat/voip/group-DM room still meters
+`livechat`/`voip`/`group_dm`, and a malformed `updateDescription` on one still skips rather than
+terming as poison.
 
 Only the exact prefix counts — `delta`, `del-general` and `team-Del-old` are live rooms.
 
@@ -80,13 +94,32 @@ subscription as an error so the event redelivers until `member_added` lands
 (`inbox-worker/main.go:118`), which never comes for a sub whose insert this guard skipped.
 
 **DMs (`t:"d"`) are exempt on both lanes.** There `name`/`fname` hold the peer's username and
-display name, not a room name, so the prefix would match a user rather than a deletion. A
-soft-deleted DM that slips through is still hidden downstream — the `^Del-` room filter is
-type-agnostic.
+display name, not a room name, so the prefix would match a user rather than a deletion. The trade
+is deliberate: dropping a live DM because its peer is named `Del-…` is unrecoverable, while a
+soft-deleted DM that slips through is not. Note the containment is partial — the `^Del-` room filter
+is type-agnostic, so such a DM is hidden **only if** the source prefixed `fname` (the field the
+destination name maps from); a `name`-only rename on a DM stays visible. Confirm with the source
+team whether DM docs are renamed at all before treating this as closed.
 
-**Residual:** `UpsertRoom` upserts (`inbox-worker/main.go:85`), so applying the deletion rename for
-a room whose `insert` was skipped *creates* a hidden `Del-` room doc rather than no-op'ing.
-Invisible to users; avoiding it would cost a room-existence read per event.
+**Residual — spurious apply.** `UpsertRoom` upserts (`inbox-worker/main.go:85`), so applying the
+deletion for a room whose `insert` was skipped *creates* a hidden `Del-` room doc rather than
+no-op'ing. Invisible to users; avoiding it would cost a room-existence read per event.
+
+**Residual — restore is not reconstructible from CDC.** If the source ever renames a room back out
+of `Del-`, the room re-appears (the rename passes the guard and syncs) but its subscriptions do not:
+their inserts were skipped while the room was dead, and the restore reaches the sub lane as a
+`name`/`fname` delta, which carries no membership. A restore is indistinguishable from an ordinary
+rename in the change stream (no `fullDocumentBeforeChange`, so the previous name is unknown), so
+rebuilding membership on every rename-shaped sub update would emit a `member_added` storm for every
+legitimate rename. **Repair is a targeted backfill, not a CDC behaviour:** the affected room ids are
+exactly those counted by `…_events_skipped_total{reason=room_soft_deleted}` — re-run the bulk
+subscription copy for them. The source is not known to support un-delete; confirm with the source
+team before relying on this.
+
+**Residual — name-less lanes are not filtered.** `company_room_members` and
+`company_thread_subscriptions` carry no denormalized room name, so members and thread subs of a
+soft-deleted room are still written. They are not user-visible through the filtered reads, so this
+is accepted rather than fixed.
 
 ## Direct-transfer collections (oplog-direct-transfer)
 

--- a/data-migration/SOURCE_DATA.md
+++ b/data-migration/SOURCE_DATA.md
@@ -107,8 +107,8 @@ Example document (values rotated/sanitized):
 | `prid` | string (opt) | Parent room id — **present ⇒ discussion** (`t` is `p`) | ✅ |
 | `teamId` | string (opt) | Room belongs to a Team | ✅ |
 | `teamMain` | bool (opt) | True only on a team's **primary** room | ✅ |
-| `name` | string | Machine/handle name | ❓ |
-| `fname` | string | Friendly display name | ❓ |
+| `name` | string | Machine/handle name. **Soft delete renames it to `Del-`+name** — the app has no room-delete op and no delete flag. **Open:** is the prefix written to `name`, `fname`, or both? Is it ever un-done (restore)? Are DM (`t:d`) docs renamed too? | ❓ |
+| `fname` | string | Friendly display name (see `name` re: the `Del-` soft-delete rename) | ❓ |
 | `uids` / `usernames` | array | Members; for `t:d` length **can exceed 2** (group DM) | ✅ |
 | `u` | object | Creator (`u._id`, `u.username`) | ❓ |
 | `ts` / `_updatedAt` | date | Created / last-updated | ❓ |
@@ -140,7 +140,7 @@ One row per (user, room). ✅ Unique index `{ rid:1, 'u._id':1 }`.
 | `muteGroupMentions` | bool | `@all`/`@here` only (**not** our mute flag) | ✅ |
 | `f` | bool (opt) | Favorited (absent ⇒ false) | ✅ |
 | `favoritedAt` | date (opt) | Last favorite time. Exists at source (TKMS) but **unused by CDC** — per the agreed guard mapping below, all guards derive from `_updatedAt` | ✅ ⛔ |
-| `name` / `fname` | string | Machine name / friendly display name | ✅ |
+| `name` / `fname` | string | Machine name / friendly display name — carries the room's `Del-` soft-delete rename (denormalized copy) | ✅ ❓ |
 | `federation.origin` | string (opt) | Origin site (assumed consistent with room) | ✅ ❓ |
 
 Derived: "has mention" = `userMentions>0 || groupMentions>0`; "muted" = `disableNotifications`; **read timestamp (`lastSeenAt`) = `max(ls, lr)`** (resolved per design D1 — the furthest point consumed by either the scrolled cursor or the explicit mark-read).

--- a/data-migration/oplog-collections-transformer/classify.go
+++ b/data-migration/oplog-collections-transformer/classify.go
@@ -7,25 +7,13 @@ import (
 )
 
 // deletedNamePrefix is the source app's soft-delete marker: "deleting" a room renames it (and the
-// denormalized name on every subscription to it) to "Del-"+name — there is no delete flag and no
-// row removal.
+// denormalized name on every subscription to it) to "Del-"+name — there is no delete flag.
 const deletedNamePrefix = "Del-"
 
-// dmSourceType is the source room type for a direct message.
-const dmSourceType = "d"
-
-// isSoftDeletedRecord reports whether a source room or subscription doc carries the soft-delete
-// marker on any name field. The invariant it enforces is absolute — a "Del-" prefixed room or
-// subscription must never reach the destination Mongo — so the check is type-agnostic and covers
-// both fields: DMs are included even though their name fields hold the peer's username and display
-// name, which costs a live DM whose peer is literally named "Del-…" but keeps the invariant total.
-func isSoftDeletedRecord(names ...string) bool {
-	for _, n := range names {
-		if strings.HasPrefix(n, deletedNamePrefix) {
-			return true
-		}
-	}
-	return false
+// isSoftDeletedRecord reports whether a source room/subscription doc carries the marker on either
+// name field. Type-agnostic on purpose: a Del- named DM peer costs that DM, keeping the invariant total.
+func isSoftDeletedRecord(name, fname string) bool {
+	return strings.HasPrefix(name, deletedNamePrefix) || strings.HasPrefix(fname, deletedNamePrefix)
 }
 
 // roomClass is the result of classifying a source room.
@@ -47,7 +35,7 @@ func classifyRoom(t string, hasPrid, hasTeamID bool, hasBot bool, participantCou
 			return roomClass{Type: model.RoomTypeDiscussion}
 		}
 		return roomClass{Type: model.RoomTypeChannel}
-	case dmSourceType:
+	case "d":
 		if participantCount > 2 {
 			return roomClass{Excluded: true, Reason: "group_dm"}
 		}

--- a/data-migration/oplog-collections-transformer/classify.go
+++ b/data-migration/oplog-collections-transformer/classify.go
@@ -7,13 +7,21 @@ import (
 )
 
 // deletedNamePrefix is the source app's soft-delete marker: "deleting" a room renames it (and the
-// denormalized name on every subscription to it) to "Del-"+name. The new stack has no such rename,
-// so soft-deleted rooms and their subscriptions are never imported.
+// denormalized name on every subscription to it) to "Del-"+name — there is no delete flag and no
+// row removal. The destination honors the same marker: user-service filters ^Del- rooms out of
+// every subscription read.
 const deletedNamePrefix = "Del-"
 
-// isSoftDeletedName reports whether any of the source name fields carries the soft-delete prefix.
-// Both name and fname are checked: either one is enough to mark the record deleted.
-func isSoftDeletedName(names ...string) bool {
+// dmSourceType is the source room type for a direct message.
+const dmSourceType = "d"
+
+// isSoftDeletedRecord reports whether a source room or subscription doc carries the soft-delete
+// marker on either name field. DMs are exempt: for t:"d" both fields hold the PEER's username and
+// display name (see memberAddedEvent), so there the prefix marks a user, not a deletion.
+func isSoftDeletedRecord(t string, names ...string) bool {
+	if t == dmSourceType {
+		return false
+	}
 	for _, n := range names {
 		if strings.HasPrefix(n, deletedNamePrefix) {
 			return true
@@ -41,7 +49,7 @@ func classifyRoom(t string, hasPrid, hasTeamID bool, hasBot bool, participantCou
 			return roomClass{Type: model.RoomTypeDiscussion}
 		}
 		return roomClass{Type: model.RoomTypeChannel}
-	case "d":
+	case dmSourceType:
 		if participantCount > 2 {
 			return roomClass{Excluded: true, Reason: "group_dm"}
 		}

--- a/data-migration/oplog-collections-transformer/classify.go
+++ b/data-migration/oplog-collections-transformer/classify.go
@@ -1,6 +1,26 @@
 package main
 
-import "github.com/hmchangw/chat/pkg/model"
+import (
+	"strings"
+
+	"github.com/hmchangw/chat/pkg/model"
+)
+
+// deletedNamePrefix is the source app's soft-delete marker: "deleting" a room renames it (and the
+// denormalized name on every subscription to it) to "Del-"+name. The new stack has no such rename,
+// so soft-deleted rooms and their subscriptions are never imported.
+const deletedNamePrefix = "Del-"
+
+// isSoftDeletedName reports whether any of the source name fields carries the soft-delete prefix.
+// Both name and fname are checked: either one is enough to mark the record deleted.
+func isSoftDeletedName(names ...string) bool {
+	for _, n := range names {
+		if strings.HasPrefix(n, deletedNamePrefix) {
+			return true
+		}
+	}
+	return false
+}
 
 // roomClass is the result of classifying a source room.
 type roomClass struct {

--- a/data-migration/oplog-collections-transformer/classify.go
+++ b/data-migration/oplog-collections-transformer/classify.go
@@ -8,20 +8,18 @@ import (
 
 // deletedNamePrefix is the source app's soft-delete marker: "deleting" a room renames it (and the
 // denormalized name on every subscription to it) to "Del-"+name — there is no delete flag and no
-// row removal. The destination honors the same marker: user-service filters ^Del- rooms out of
-// every subscription read.
+// row removal.
 const deletedNamePrefix = "Del-"
 
 // dmSourceType is the source room type for a direct message.
 const dmSourceType = "d"
 
 // isSoftDeletedRecord reports whether a source room or subscription doc carries the soft-delete
-// marker on either name field. DMs are exempt: for t:"d" both fields hold the PEER's username and
-// display name (see memberAddedEvent), so there the prefix marks a user, not a deletion.
-func isSoftDeletedRecord(t string, names ...string) bool {
-	if t == dmSourceType {
-		return false
-	}
+// marker on any name field. The invariant it enforces is absolute — a "Del-" prefixed room or
+// subscription must never reach the destination Mongo — so the check is type-agnostic and covers
+// both fields: DMs are included even though their name fields hold the peer's username and display
+// name, which costs a live DM whose peer is literally named "Del-…" but keeps the invariant total.
+func isSoftDeletedRecord(names ...string) bool {
 	for _, n := range names {
 		if strings.HasPrefix(n, deletedNamePrefix) {
 			return true

--- a/data-migration/oplog-collections-transformer/invariant_test.go
+++ b/data-migration/oplog-collections-transformer/invariant_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hmchangw/chat/pkg/migration"
+)
+
+// TestNoDelPrefixEverReachesMongo is the invariant this guard exists for: a room or subscription
+// carrying the "Del-" soft-delete marker must never appear in the destination Mongo. Every name the
+// transformer can write comes from a published event — room_sync (rooms.name), room_renamed
+// (subscriptions.name for the whole room), member_added (the sub's name) — so it is enough to prove
+// no published payload ever contains the marker.
+func TestNoDelPrefixEverReachesMongo(t *testing.T) {
+	roomDocs := []struct {
+		name string
+		doc  string
+	}{
+		{"channel, both names prefixed", `{"_id":"r1","t":"c","name":"Del-general","fname":"Del-General","uids":["u1"]}`},
+		{"channel, only fname prefixed", `{"_id":"r1","t":"c","name":"general","fname":"Del-General","uids":["u1"]}`},
+		{"channel, only machine name prefixed", `{"_id":"r1","t":"c","name":"Del-general","fname":"General","uids":["u1"]}`},
+		{"channel, no fname at all", `{"_id":"r1","t":"c","name":"Del-general","uids":["u1"]}`},
+		{"private group", `{"_id":"r1","t":"p","name":"Del-secret","fname":"Del-Secret","uids":["u1"]}`},
+		{"discussion", `{"_id":"r1","t":"p","prid":"p1","name":"Del-topic","fname":"Del-Topic","uids":["u1"]}`},
+		{"dm", `{"_id":"r1","t":"d","name":"Del-bob","fname":"Del-Bob","uids":["u1","u2"]}`},
+	}
+	subDocs := []struct {
+		name string
+		doc  string
+	}{
+		{"channel sub, both names prefixed", `{"_id":"s1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"Del-general","fname":"Del-General","open":true}`},
+		{"channel sub, only fname prefixed", `{"_id":"s1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"general","fname":"Del-General","open":true}`},
+		{"channel sub, only name prefixed", `{"_id":"s1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"Del-general","fname":"General","open":true}`},
+		{"dm sub", `{"_id":"s1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"d","name":"Del-bob","fname":"Del-Bob","open":true}`},
+	}
+	// Every op, and for updates every delta shape — including the rename that carries the deletion
+	// and a name removal, which are the paths most likely to be re-opened by a future change.
+	deltas := []string{
+		`{"updatedFields":{"fname":"Del-General"}}`,
+		`{"updatedFields":{"name":"Del-general"}}`,
+		`{"updatedFields":{"restricted":true}}`,
+		`{"updatedFields":{"open":false}}`,
+		`{"updatedFields":{"roles":["owner"]}}`,
+		`{"removedFields":["fname"]}`,
+	}
+
+	assertNothingPublished := func(t *testing.T, pub *fakePublisher, err error) {
+		t.Helper()
+		assert.ErrorIs(t, err, migration.ErrSkipped, "a Del- record must be skipped")
+		for _, e := range pub.events {
+			assert.NotContains(t, string(e.Payload), "Del-",
+				"published %s carries the soft-delete marker into Mongo", e.Type)
+		}
+		assert.Empty(t, pub.events, "a Del- record must publish nothing at all")
+	}
+
+	for _, tc := range roomDocs {
+		t.Run("room/"+tc.name, func(t *testing.T) {
+			for _, op := range []string{"insert", "replace"} {
+				t.Run(op, func(t *testing.T) {
+					pub := &fakePublisher{}
+					h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{})
+					assertNothingPublished(t, pub, h.handleRoom(context.Background(), roomEv(op, tc.doc, "")))
+				})
+			}
+			for _, delta := range deltas {
+				t.Run("update "+delta, func(t *testing.T) {
+					pub := &fakePublisher{}
+					h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(tc.doc)})
+					assertNothingPublished(t, pub, h.handleRoom(context.Background(), roomEv("update", "", delta)))
+				})
+			}
+		})
+	}
+
+	for _, tc := range subDocs {
+		t.Run("subscription/"+tc.name, func(t *testing.T) {
+			for _, op := range []string{"insert", "replace"} {
+				t.Run(op, func(t *testing.T) {
+					pub := &fakePublisher{}
+					h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{})
+					assertNothingPublished(t, pub, h.handleSubscription(context.Background(), subEv(op, tc.doc, "")))
+				})
+			}
+			for _, delta := range deltas {
+				t.Run("update "+delta, func(t *testing.T) {
+					pub := &fakePublisher{}
+					h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(tc.doc)})
+					assertNothingPublished(t, pub, h.handleSubscription(context.Background(), subEv("update", "", delta)))
+				})
+			}
+		})
+	}
+}
+
+// TestLiveRecordsStillPublishTheirName guards the other side of the invariant: the guard must not
+// swallow rooms whose name merely resembles the marker.
+func TestLiveRecordsStillPublishTheirName(t *testing.T) {
+	for _, doc := range []string{
+		`{"_id":"r1","t":"c","name":"delta","fname":"Delta","uids":["u1"]}`,
+		`{"_id":"r1","t":"c","name":"del-general","fname":"del-General","uids":["u1"]}`,
+		`{"_id":"r1","t":"c","name":"team-Del-old","fname":"Team Del-old","uids":["u1"]}`,
+	} {
+		pub := &fakePublisher{}
+		h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{})
+		if err := h.handleRoom(context.Background(), roomEv("insert", doc, "")); err != nil {
+			t.Fatalf("live room skipped: %v", err)
+		}
+		assert.NotEmpty(t, pub.events)
+		assert.False(t, strings.HasPrefix(mustRoomName(t, pub), "Del-"))
+	}
+}
+
+func mustRoomName(t *testing.T, pub *fakePublisher) string {
+	t.Helper()
+	var room struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(pub.events[0].Payload, &room); err != nil {
+		t.Fatalf("unmarshal room_sync: %v", err)
+	}
+	return room.Name
+}

--- a/data-migration/oplog-collections-transformer/invariant_test.go
+++ b/data-migration/oplog-collections-transformer/invariant_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,14 +37,12 @@ func TestNoDelPrefixEverReachesMongo(t *testing.T) {
 		{"channel sub, only name prefixed", `{"_id":"s1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"Del-general","fname":"General","open":true}`},
 		{"dm sub", `{"_id":"s1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"d","name":"Del-bob","fname":"Del-Bob","open":true}`},
 	}
-	// Every op, and for updates every delta shape — including the rename that carries the deletion
-	// and a name removal, which are the paths most likely to be re-opened by a future change.
+	// The guard runs before any delta is decoded, so these differ only in what a future change might
+	// key on: the rename that carries the deletion, a name removal, and a membership leave.
 	deltas := []string{
 		`{"updatedFields":{"fname":"Del-General"}}`,
 		`{"updatedFields":{"name":"Del-general"}}`,
-		`{"updatedFields":{"restricted":true}}`,
 		`{"updatedFields":{"open":false}}`,
-		`{"updatedFields":{"roles":["owner"]}}`,
 		`{"removedFields":["fname"]}`,
 	}
 
@@ -96,33 +93,4 @@ func TestNoDelPrefixEverReachesMongo(t *testing.T) {
 			}
 		})
 	}
-}
-
-// TestLiveRecordsStillPublishTheirName guards the other side of the invariant: the guard must not
-// swallow rooms whose name merely resembles the marker.
-func TestLiveRecordsStillPublishTheirName(t *testing.T) {
-	for _, doc := range []string{
-		`{"_id":"r1","t":"c","name":"delta","fname":"Delta","uids":["u1"]}`,
-		`{"_id":"r1","t":"c","name":"del-general","fname":"del-General","uids":["u1"]}`,
-		`{"_id":"r1","t":"c","name":"team-Del-old","fname":"Team Del-old","uids":["u1"]}`,
-	} {
-		pub := &fakePublisher{}
-		h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{})
-		if err := h.handleRoom(context.Background(), roomEv("insert", doc, "")); err != nil {
-			t.Fatalf("live room skipped: %v", err)
-		}
-		assert.NotEmpty(t, pub.events)
-		assert.False(t, strings.HasPrefix(mustRoomName(t, pub), "Del-"))
-	}
-}
-
-func mustRoomName(t *testing.T, pub *fakePublisher) string {
-	t.Helper()
-	var room struct {
-		Name string `json:"name"`
-	}
-	if err := json.Unmarshal(pub.events[0].Payload, &room); err != nil {
-		t.Fatalf("unmarshal room_sync: %v", err)
-	}
-	return room.Name
 }

--- a/data-migration/oplog-collections-transformer/metrics.go
+++ b/data-migration/oplog-collections-transformer/metrics.go
@@ -20,6 +20,7 @@ type metrics struct {
 	userSeed    metric.Int64Counter
 	resolveMiss metric.Int64Counter
 	writes      metric.Int64Counter
+	softDelete  metric.Int64Counter
 }
 
 func newMetrics() (*metrics, error) {
@@ -64,9 +65,16 @@ func newMetrics() (*metrics, error) {
 	if err != nil {
 		return nil, fmt.Errorf("writes counter: %w", err)
 	}
+	softDelete, err := m.Int64Counter("oplog_collections_transformer_soft_delete_applied_total",
+		metric.WithDescription("source soft-delete (\"Del-\" rename) events propagated to the destination, by op"))
+	if err != nil {
+		return nil, fmt.Errorf("soft delete counter: %w", err)
+	}
+
 	return &metrics{
 		processed: processed, naks: naks, terms: terms, skipped: skipped,
 		exhausted: exhausted, userSeed: userSeed, resolveMiss: resolveMiss, writes: writes,
+		softDelete: softDelete,
 	}, nil
 }
 
@@ -129,6 +137,15 @@ func (m *metrics) onResolveMiss(ctx context.Context, kind string) {
 		return
 	}
 	m.resolveMiss.Add(ctx, 1, metric.WithAttributes(attribute.String("kind", kind)))
+}
+
+// onSoftDeleteApplied records a source soft-delete rename propagated to the destination (the room
+// doc takes the prefixed name and the read path hides it) — the cutover reconciliation counter.
+func (m *metrics) onSoftDeleteApplied(ctx context.Context, op string) {
+	if m == nil {
+		return
+	}
+	m.softDelete.Add(ctx, 1, metric.WithAttributes(attribute.String("op", op)))
 }
 
 // onWrite records a direct target write (room-member upsert/delete), labelled by collection and

--- a/data-migration/oplog-collections-transformer/metrics.go
+++ b/data-migration/oplog-collections-transformer/metrics.go
@@ -20,7 +20,6 @@ type metrics struct {
 	userSeed    metric.Int64Counter
 	resolveMiss metric.Int64Counter
 	writes      metric.Int64Counter
-	softDelete  metric.Int64Counter
 }
 
 func newMetrics() (*metrics, error) {
@@ -65,16 +64,9 @@ func newMetrics() (*metrics, error) {
 	if err != nil {
 		return nil, fmt.Errorf("writes counter: %w", err)
 	}
-	softDelete, err := m.Int64Counter("oplog_collections_transformer_soft_delete_applied_total",
-		metric.WithDescription("source soft-delete (\"Del-\" rename) events propagated to the destination, by op"))
-	if err != nil {
-		return nil, fmt.Errorf("soft delete counter: %w", err)
-	}
-
 	return &metrics{
 		processed: processed, naks: naks, terms: terms, skipped: skipped,
 		exhausted: exhausted, userSeed: userSeed, resolveMiss: resolveMiss, writes: writes,
-		softDelete: softDelete,
 	}, nil
 }
 
@@ -137,15 +129,6 @@ func (m *metrics) onResolveMiss(ctx context.Context, kind string) {
 		return
 	}
 	m.resolveMiss.Add(ctx, 1, metric.WithAttributes(attribute.String("kind", kind)))
-}
-
-// onSoftDeleteApplied records a source soft-delete rename propagated to the destination (the room
-// doc takes the prefixed name and the read path hides it) — the cutover reconciliation counter.
-func (m *metrics) onSoftDeleteApplied(ctx context.Context, op string) {
-	if m == nil {
-		return
-	}
-	m.softDelete.Add(ctx, 1, metric.WithAttributes(attribute.String("op", op)))
 }
 
 // onWrite records a direct target write (room-member upsert/delete), labelled by collection and

--- a/data-migration/oplog-collections-transformer/rooms.go
+++ b/data-migration/oplog-collections-transformer/rooms.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -57,6 +59,18 @@ func (r *sourceRoom) displayName() string {
 	return r.Name
 }
 
+// destinationName is the name the destination room doc takes: the display name, forced to carry the
+// soft-delete marker when the source set it on only one of the two name fields. user-service hides a
+// deleted room by matching ^Del- on this value, so dropping the marker here would apply a deletion
+// that hides nothing.
+func (r *sourceRoom) destinationName() string {
+	name := r.displayName()
+	if isSoftDeletedRecord(r.T, r.Name, r.FName) && !strings.HasPrefix(name, deletedNamePrefix) {
+		return deletedNamePrefix + name
+	}
+	return name
+}
+
 // handleRoom maps a rocketchat_rooms change event to an inbox InboxEvent (§4.2 / §4.0).
 // Returns migration.ErrSkipped for deletes, excluded room types, and update lookup misses.
 //
@@ -84,29 +98,37 @@ func (h *handler) handleRoom(ctx context.Context, ev oplogEvent) error {
 		return fmt.Errorf("%w: decode source room: %v", migration.ErrPoison, uerr) //nolint:errorlint // intentional single-%w sentinel wrap; decode err is informational only
 	}
 
-	desc, derr := roomUpdateDelta(&ev)
-	if derr != nil {
-		return derr
-	}
-
-	if isSoftDeletedRecord(sr.T, sr.Name, sr.FName) && !isDeletionRename(ev.Op, desc) {
-		// Already soft-deleted at source and this event isn't the deletion itself: an insert/replace
-		// would import a room the destination only ever hides, and a later field change is churn on
-		// a dead room. The rename INTO the prefix is the one event that must land (below).
-		slog.Debug("skip soft-deleted room",
-			"eventId", ev.EventID, "request_id", natsutil.RequestIDFromContext(ctx))
-		h.metrics.onSkipped(ctx, "room_soft_deleted")
-		return migration.ErrSkipped
-	}
-
 	// hasBot is unresolvable here without a user lookup (botDM detection deferred — see §4.2 /
 	// the design's botDM note); pass false so a 2-party bot DM classifies as a plain dm for now.
+	// Classification runs before the soft-delete guard so a never-migratable type keeps metering its
+	// own reason, and a malformed delta on one still Skips instead of Terming.
 	class := classifyRoom(sr.T, sr.Prid != "", sr.TeamID != "", false, sr.participantCount())
 	if class.Excluded {
 		slog.Debug("skip excluded room type",
 			"t", sr.T, "reason", class.Reason, "eventId", ev.EventID, "request_id", natsutil.RequestIDFromContext(ctx))
 		h.metrics.onSkipped(ctx, class.Reason)
 		return migration.ErrSkipped
+	}
+
+	desc, derr := roomUpdateDelta(ev.Op, ev.UpdateDescription)
+	if derr != nil {
+		return fmt.Errorf("room update delta: %w", derr)
+	}
+
+	softDeleted := isSoftDeletedRecord(sr.T, sr.Name, sr.FName)
+	if softDeleted && !isDeletionEvent(ev.Op, desc) {
+		// Already soft-deleted at source and this event can't be the deletion itself: an insert would
+		// import a room the destination only ever hides, and a later field change is churn on a dead
+		// room. The events that DO carry the deletion are applied below.
+		slog.DebugContext(ctx, "skip soft-deleted room",
+			"op", ev.Op, "t", sr.T, "eventId", ev.EventID, "request_id", natsutil.RequestIDFromContext(ctx))
+		h.metrics.onSkipped(ctx, "room_soft_deleted")
+		return migration.ErrSkipped
+	}
+	if softDeleted {
+		// The cutover reconciliation counter: how many source deletions actually reached the
+		// destination, to compare against the source's Del- room count.
+		h.metrics.onSoftDeleteApplied(ctx, ev.Op)
 	}
 
 	// Zero-guard an absent source timestamp with now() so the room doc never carries a year-0001
@@ -124,7 +146,7 @@ func (h *handler) handleRoom(ctx context.Context, ev oplogEvent) error {
 	room := model.Room{
 		ID:     sr.ID,
 		Type:   class.Type,
-		Name:   sr.displayName(),
+		Name:   sr.destinationName(),
 		SiteID: siteIDFromOrigin(sr.Federation.Origin, h.siteID),
 		// ExternalAccess source field is unconfirmed (SOURCE_DATA.md §3) — default false per design.
 		ExternalAccess: false,
@@ -181,22 +203,29 @@ func (h *handler) roomEvents(ev oplogEvent, room *model.Room, desc updateDescrip
 }
 
 // roomUpdateDelta decodes an update event's field delta; other ops carry none.
-func roomUpdateDelta(ev *oplogEvent) (updateDescription, error) {
+func roomUpdateDelta(op string, raw json.RawMessage) (updateDescription, error) {
 	var desc updateDescription
-	if ev.Op != "update" || len(ev.UpdateDescription) == 0 {
+	if op != "update" || len(raw) == 0 {
 		return desc, nil
 	}
-	if err := bson.UnmarshalExtJSON(ev.UpdateDescription, false, &desc); err != nil {
+	if err := bson.UnmarshalExtJSON(raw, false, &desc); err != nil {
 		return desc, fmt.Errorf("%w: decode room updateDescription: %v", migration.ErrPoison, err) //nolint:errorlint // intentional single-%w sentinel wrap; decode err is informational only
 	}
 	return desc, nil
 }
 
-// isDeletionRename reports whether this update is the soft-delete itself — a name/fname change on a
-// doc that now carries the prefix. That rename is the source's only delete signal, so it is applied
-// (the destination room takes the prefixed name, which user-service's ^Del- filter hides) rather
-// than skipped. A replace carries no delta and so can never qualify: the source deletes with $set.
-func isDeletionRename(op string, desc updateDescription) bool {
+// isDeletionEvent reports whether this event can be carrying the soft-delete of a doc that now has
+// the prefix — the source's only delete signal, so it is applied (the destination room takes the
+// prefixed name, which user-service's ^Del- filter hides) rather than skipped.
+//
+// An update qualifies when its delta touches a name field (set or removed — a removal changes the
+// mapped name too). A replace always qualifies: it carries no delta, so the deletion cannot be
+// recognised from the event, and leaving a deleted room visible is worse than the hidden room doc a
+// spurious apply costs (see CDC_COVERAGE.md "Residual").
+func isDeletionEvent(op string, desc updateDescription) bool {
+	if op == "replace" {
+		return true
+	}
 	return op == "update" && (changed(desc, "name") || changed(desc, "fname"))
 }
 

--- a/data-migration/oplog-collections-transformer/rooms.go
+++ b/data-migration/oplog-collections-transformer/rooms.go
@@ -84,10 +84,15 @@ func (h *handler) handleRoom(ctx context.Context, ev oplogEvent) error {
 		return fmt.Errorf("%w: decode source room: %v", migration.ErrPoison, uerr) //nolint:errorlint // intentional single-%w sentinel wrap; decode err is informational only
 	}
 
-	if isSoftDeletedName(sr.Name, sr.FName) {
-		// Soft-deleted at source ("Del-" rename) — never import it, on any op: an insert/replace
-		// would create a room the destination only ever hides, and a rename INTO the prefix is the
-		// deletion itself, which has no destination equivalent to apply.
+	desc, derr := roomUpdateDelta(&ev)
+	if derr != nil {
+		return derr
+	}
+
+	if isSoftDeletedRecord(sr.T, sr.Name, sr.FName) && !isDeletionRename(ev.Op, desc) {
+		// Already soft-deleted at source and this event isn't the deletion itself: an insert/replace
+		// would import a room the destination only ever hides, and a later field change is churn on
+		// a dead room. The rename INTO the prefix is the one event that must land (below).
 		slog.Debug("skip soft-deleted room",
 			"eventId", ev.EventID, "request_id", natsutil.RequestIDFromContext(ctx))
 		h.metrics.onSkipped(ctx, "room_soft_deleted")
@@ -131,11 +136,7 @@ func (h *handler) handleRoom(ctx context.Context, ev oplogEvent) error {
 		CreatedAt:      createdAt,
 	}
 
-	evts, err := h.roomEvents(ev, &room)
-	if err != nil {
-		return fmt.Errorf("build room events: %w", err)
-	}
-	for _, evt := range evts {
+	for _, evt := range h.roomEvents(ev, &room, desc) {
 		if err := h.pub.Publish(ctx, evt); err != nil {
 			return fmt.Errorf("publish room event %q: %w", evt.Type, err)
 		}
@@ -147,10 +148,10 @@ func (h *handler) handleRoom(ctx context.Context, ev oplogEvent) error {
 // (name/fname changed) and/or room_restricted (restricted changed) — both when one update changes both.
 //
 //nolint:gocritic // ev passed by value to mirror handle's signature; off the hot path.
-func (h *handler) roomEvents(ev oplogEvent, room *model.Room) ([]model.InboxEvent, error) {
+func (h *handler) roomEvents(ev oplogEvent, room *model.Room, desc updateDescription) []model.InboxEvent {
 	if ev.Op == "insert" {
 		// A brand-new room has no subscriptions yet — nothing to rename/re-restrict, sync suffices.
-		return []model.InboxEvent{h.roomSyncEvent(room)}, nil
+		return []model.InboxEvent{h.roomSyncEvent(room)}
 	}
 	if ev.Op != "update" {
 		// replace: a whole-doc rewrite carries NO updateDescription delta, so there is no way to
@@ -162,13 +163,6 @@ func (h *handler) roomEvents(ev oplogEvent, room *model.Room) ([]model.InboxEven
 			h.roomRenamedEvent(room),
 			h.roomRestrictedEvent(room),
 			h.roomSyncEvent(room),
-		}, nil
-	}
-
-	var desc updateDescription
-	if len(ev.UpdateDescription) > 0 {
-		if err := bson.UnmarshalExtJSON(ev.UpdateDescription, false, &desc); err != nil {
-			return nil, fmt.Errorf("%w: decode room updateDescription: %v", migration.ErrPoison, err) //nolint:errorlint // intentional single-%w sentinel wrap; decode err is informational only
 		}
 	}
 
@@ -183,7 +177,27 @@ func (h *handler) roomEvents(ev oplogEvent, room *model.Room) ([]model.InboxEven
 	}
 	// room_sync always trails so the room doc itself converges alongside the subscription-side events.
 	evts = append(evts, h.roomSyncEvent(room))
-	return evts, nil
+	return evts
+}
+
+// roomUpdateDelta decodes an update event's field delta; other ops carry none.
+func roomUpdateDelta(ev *oplogEvent) (updateDescription, error) {
+	var desc updateDescription
+	if ev.Op != "update" || len(ev.UpdateDescription) == 0 {
+		return desc, nil
+	}
+	if err := bson.UnmarshalExtJSON(ev.UpdateDescription, false, &desc); err != nil {
+		return desc, fmt.Errorf("%w: decode room updateDescription: %v", migration.ErrPoison, err) //nolint:errorlint // intentional single-%w sentinel wrap; decode err is informational only
+	}
+	return desc, nil
+}
+
+// isDeletionRename reports whether this update is the soft-delete itself — a name/fname change on a
+// doc that now carries the prefix. That rename is the source's only delete signal, so it is applied
+// (the destination room takes the prefixed name, which user-service's ^Del- filter hides) rather
+// than skipped. A replace carries no delta and so can never qualify: the source deletes with $set.
+func isDeletionRename(op string, desc updateDescription) bool {
+	return op == "update" && (changed(desc, "name") || changed(desc, "fname"))
 }
 
 // changed reports whether the named field appears in the update delta (set or removed).

--- a/data-migration/oplog-collections-transformer/rooms.go
+++ b/data-migration/oplog-collections-transformer/rooms.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -59,18 +57,6 @@ func (r *sourceRoom) displayName() string {
 	return r.Name
 }
 
-// destinationName is the name the destination room doc takes: the display name, forced to carry the
-// soft-delete marker when the source set it on only one of the two name fields. user-service hides a
-// deleted room by matching ^Del- on this value, so dropping the marker here would apply a deletion
-// that hides nothing.
-func (r *sourceRoom) destinationName() string {
-	name := r.displayName()
-	if isSoftDeletedRecord(r.T, r.Name, r.FName) && !strings.HasPrefix(name, deletedNamePrefix) {
-		return deletedNamePrefix + name
-	}
-	return name
-}
-
 // handleRoom maps a rocketchat_rooms change event to an inbox InboxEvent (§4.2 / §4.0).
 // Returns migration.ErrSkipped for deletes, excluded room types, and update lookup misses.
 //
@@ -101,7 +87,7 @@ func (h *handler) handleRoom(ctx context.Context, ev oplogEvent) error {
 	// hasBot is unresolvable here without a user lookup (botDM detection deferred — see §4.2 /
 	// the design's botDM note); pass false so a 2-party bot DM classifies as a plain dm for now.
 	// Classification runs before the soft-delete guard so a never-migratable type keeps metering its
-	// own reason, and a malformed delta on one still Skips instead of Terming.
+	// own exclusion reason rather than being counted as a soft delete.
 	class := classifyRoom(sr.T, sr.Prid != "", sr.TeamID != "", false, sr.participantCount())
 	if class.Excluded {
 		slog.Debug("skip excluded room type",
@@ -110,25 +96,14 @@ func (h *handler) handleRoom(ctx context.Context, ev oplogEvent) error {
 		return migration.ErrSkipped
 	}
 
-	desc, derr := roomUpdateDelta(ev.Op, ev.UpdateDescription)
-	if derr != nil {
-		return fmt.Errorf("room update delta: %w", derr)
-	}
-
-	softDeleted := isSoftDeletedRecord(sr.T, sr.Name, sr.FName)
-	if softDeleted && !isDeletionEvent(ev.Op, desc) {
-		// Already soft-deleted at source and this event can't be the deletion itself: an insert would
-		// import a room the destination only ever hides, and a later field change is churn on a dead
-		// room. The events that DO carry the deletion are applied below.
+	if isSoftDeletedRecord(sr.Name, sr.FName) {
+		// Soft-deleted at source: skipped on every op, and before the delta is even decoded. Nothing
+		// about this room may reach Mongo — not the doc, not a rename of it — because room_sync would
+		// write the "Del-" name onto rooms.name and room_renamed onto every subscription in the room.
 		slog.DebugContext(ctx, "skip soft-deleted room",
 			"op", ev.Op, "t", sr.T, "eventId", ev.EventID, "request_id", natsutil.RequestIDFromContext(ctx))
 		h.metrics.onSkipped(ctx, "room_soft_deleted")
 		return migration.ErrSkipped
-	}
-	if softDeleted {
-		// The cutover reconciliation counter: how many source deletions actually reached the
-		// destination, to compare against the source's Del- room count.
-		h.metrics.onSoftDeleteApplied(ctx, ev.Op)
 	}
 
 	// Zero-guard an absent source timestamp with now() so the room doc never carries a year-0001
@@ -146,7 +121,7 @@ func (h *handler) handleRoom(ctx context.Context, ev oplogEvent) error {
 	room := model.Room{
 		ID:     sr.ID,
 		Type:   class.Type,
-		Name:   sr.destinationName(),
+		Name:   sr.displayName(),
 		SiteID: siteIDFromOrigin(sr.Federation.Origin, h.siteID),
 		// ExternalAccess source field is unconfirmed (SOURCE_DATA.md §3) — default false per design.
 		ExternalAccess: false,
@@ -158,7 +133,11 @@ func (h *handler) handleRoom(ctx context.Context, ev oplogEvent) error {
 		CreatedAt:      createdAt,
 	}
 
-	for _, evt := range h.roomEvents(ev, &room, desc) {
+	evts, err := h.roomEvents(ev, &room)
+	if err != nil {
+		return fmt.Errorf("build room events: %w", err)
+	}
+	for _, evt := range evts {
 		if err := h.pub.Publish(ctx, evt); err != nil {
 			return fmt.Errorf("publish room event %q: %w", evt.Type, err)
 		}
@@ -170,10 +149,10 @@ func (h *handler) handleRoom(ctx context.Context, ev oplogEvent) error {
 // (name/fname changed) and/or room_restricted (restricted changed) — both when one update changes both.
 //
 //nolint:gocritic // ev passed by value to mirror handle's signature; off the hot path.
-func (h *handler) roomEvents(ev oplogEvent, room *model.Room, desc updateDescription) []model.InboxEvent {
+func (h *handler) roomEvents(ev oplogEvent, room *model.Room) ([]model.InboxEvent, error) {
 	if ev.Op == "insert" {
 		// A brand-new room has no subscriptions yet — nothing to rename/re-restrict, sync suffices.
-		return []model.InboxEvent{h.roomSyncEvent(room)}
+		return []model.InboxEvent{h.roomSyncEvent(room)}, nil
 	}
 	if ev.Op != "update" {
 		// replace: a whole-doc rewrite carries NO updateDescription delta, so there is no way to
@@ -185,6 +164,13 @@ func (h *handler) roomEvents(ev oplogEvent, room *model.Room, desc updateDescrip
 			h.roomRenamedEvent(room),
 			h.roomRestrictedEvent(room),
 			h.roomSyncEvent(room),
+		}, nil
+	}
+
+	var desc updateDescription
+	if len(ev.UpdateDescription) > 0 {
+		if err := bson.UnmarshalExtJSON(ev.UpdateDescription, false, &desc); err != nil {
+			return nil, fmt.Errorf("%w: decode room updateDescription: %v", migration.ErrPoison, err) //nolint:errorlint // intentional single-%w sentinel wrap; decode err is informational only
 		}
 	}
 
@@ -199,34 +185,7 @@ func (h *handler) roomEvents(ev oplogEvent, room *model.Room, desc updateDescrip
 	}
 	// room_sync always trails so the room doc itself converges alongside the subscription-side events.
 	evts = append(evts, h.roomSyncEvent(room))
-	return evts
-}
-
-// roomUpdateDelta decodes an update event's field delta; other ops carry none.
-func roomUpdateDelta(op string, raw json.RawMessage) (updateDescription, error) {
-	var desc updateDescription
-	if op != "update" || len(raw) == 0 {
-		return desc, nil
-	}
-	if err := bson.UnmarshalExtJSON(raw, false, &desc); err != nil {
-		return desc, fmt.Errorf("%w: decode room updateDescription: %v", migration.ErrPoison, err) //nolint:errorlint // intentional single-%w sentinel wrap; decode err is informational only
-	}
-	return desc, nil
-}
-
-// isDeletionEvent reports whether this event can be carrying the soft-delete of a doc that now has
-// the prefix — the source's only delete signal, so it is applied (the destination room takes the
-// prefixed name, which user-service's ^Del- filter hides) rather than skipped.
-//
-// An update qualifies when its delta touches a name field (set or removed — a removal changes the
-// mapped name too). A replace always qualifies: it carries no delta, so the deletion cannot be
-// recognised from the event, and leaving a deleted room visible is worse than the hidden room doc a
-// spurious apply costs (see CDC_COVERAGE.md "Residual").
-func isDeletionEvent(op string, desc updateDescription) bool {
-	if op == "replace" {
-		return true
-	}
-	return op == "update" && (changed(desc, "name") || changed(desc, "fname"))
+	return evts, nil
 }
 
 // changed reports whether the named field appears in the update delta (set or removed).

--- a/data-migration/oplog-collections-transformer/rooms.go
+++ b/data-migration/oplog-collections-transformer/rooms.go
@@ -84,6 +84,16 @@ func (h *handler) handleRoom(ctx context.Context, ev oplogEvent) error {
 		return fmt.Errorf("%w: decode source room: %v", migration.ErrPoison, uerr) //nolint:errorlint // intentional single-%w sentinel wrap; decode err is informational only
 	}
 
+	if isSoftDeletedName(sr.Name, sr.FName) {
+		// Soft-deleted at source ("Del-" rename) — never import it, on any op: an insert/replace
+		// would create a room the destination only ever hides, and a rename INTO the prefix is the
+		// deletion itself, which has no destination equivalent to apply.
+		slog.Debug("skip soft-deleted room",
+			"eventId", ev.EventID, "request_id", natsutil.RequestIDFromContext(ctx))
+		h.metrics.onSkipped(ctx, "room_soft_deleted")
+		return migration.ErrSkipped
+	}
+
 	// hasBot is unresolvable here without a user lookup (botDM detection deferred — see §4.2 /
 	// the design's botDM note); pass false so a 2-party bot DM classifies as a plain dm for now.
 	class := classifyRoom(sr.T, sr.Prid != "", sr.TeamID != "", false, sr.participantCount())

--- a/data-migration/oplog-collections-transformer/rooms.go
+++ b/data-migration/oplog-collections-transformer/rooms.go
@@ -100,8 +100,11 @@ func (h *handler) handleRoom(ctx context.Context, ev oplogEvent) error {
 		// Soft-deleted at source: skipped on every op, and before the delta is even decoded. Nothing
 		// about this room may reach Mongo — not the doc, not a rename of it — because room_sync would
 		// write the "Del-" name onto rooms.name and room_renamed onto every subscription in the room.
+		// roomId is logged so a skipped record is traceable to a specific room; the skip counter
+		// carries no id (an unbounded label) and cannot drive the reconciliation on its own.
 		slog.DebugContext(ctx, "skip soft-deleted room",
-			"op", ev.Op, "t", sr.T, "eventId", ev.EventID, "request_id", natsutil.RequestIDFromContext(ctx))
+			"roomId", sr.ID, "op", ev.Op, "t", sr.T,
+			"eventId", ev.EventID, "request_id", natsutil.RequestIDFromContext(ctx))
 		h.metrics.onSkipped(ctx, "room_soft_deleted")
 		return migration.ErrSkipped
 	}

--- a/data-migration/oplog-collections-transformer/rooms.go
+++ b/data-migration/oplog-collections-transformer/rooms.go
@@ -97,11 +97,8 @@ func (h *handler) handleRoom(ctx context.Context, ev oplogEvent) error {
 	}
 
 	if isSoftDeletedRecord(sr.Name, sr.FName) {
-		// Soft-deleted at source: skipped on every op, and before the delta is even decoded. Nothing
-		// about this room may reach Mongo — not the doc, not a rename of it — because room_sync would
-		// write the "Del-" name onto rooms.name and room_renamed onto every subscription in the room.
-		// roomId is logged so a skipped record is traceable to a specific room; the skip counter
-		// carries no id (an unbounded label) and cannot drive the reconciliation on its own.
+		// Skipped on every op: room_sync would write the "Del-" name onto rooms.name and room_renamed
+		// onto every subscription in the room. roomId is logged because the counter carries no id.
 		slog.DebugContext(ctx, "skip soft-deleted room",
 			"roomId", sr.ID, "op", ev.Op, "t", sr.T,
 			"eventId", ev.EventID, "request_id", natsutil.RequestIDFromContext(ctx))

--- a/data-migration/oplog-collections-transformer/rooms_test.go
+++ b/data-migration/oplog-collections-transformer/rooms_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"testing"
 	"time"
 
@@ -360,9 +359,8 @@ func TestHandleRoom_NonDegradedInsertWithoutFullDocument_Poisons(t *testing.T) {
 	assert.ErrorIs(t, h.handleRoom(context.Background(), ev), migration.ErrPoison)
 }
 
-// TestHandleRoom_SoftDeletedSkipped: a room already carrying the "Del-" soft-delete rename is never
-// imported. The events that can be carrying the deletion itself — the rename update and any replace
-// — are the exception, applied by the two tests below.
+// TestHandleRoom_SoftDeletedSkipped: a room carrying the "Del-" soft-delete rename is never
+// imported, on any op. See invariant_test.go for the exhaustive statement of the rule.
 func TestHandleRoom_SoftDeletedSkipped(t *testing.T) {
 	tests := []struct {
 		name string
@@ -375,13 +373,15 @@ func TestHandleRoom_SoftDeletedSkipped(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Run("insert", func(t *testing.T) {
-				pub := &fakePublisher{}
-				h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{})
-				err := h.handleRoom(context.Background(), roomEv("insert", tc.doc, ""))
-				assert.ErrorIs(t, err, migration.ErrSkipped)
-				assert.Empty(t, pub.events)
-			})
+			for _, op := range []string{"insert", "replace"} {
+				t.Run(op, func(t *testing.T) {
+					pub := &fakePublisher{}
+					h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{})
+					err := h.handleRoom(context.Background(), roomEv(op, tc.doc, ""))
+					assert.ErrorIs(t, err, migration.ErrSkipped)
+					assert.Empty(t, pub.events)
+				})
+			}
 			// An update that leaves the name alone is churn on an already-dead room.
 			for _, delta := range []string{`{"updatedFields":{"restricted":true}}`, `{"updatedFields":{"description":"hi"}}`} {
 				t.Run("update "+delta, func(t *testing.T) {
@@ -396,33 +396,8 @@ func TestHandleRoom_SoftDeletedSkipped(t *testing.T) {
 	}
 }
 
-// TestHandleRoom_SoftDeleteRenameApplied: the rename INTO "Del-" is the source's only delete
-// signal — apply it, so the destination room takes the prefixed name and user-service's ^Del-
-// filter hides it. Skipping it would leave a deleted room visible to every migrated member.
-func TestHandleRoom_SoftDeleteRenameApplied(t *testing.T) {
-	const deleted = `{"_id":"r1","t":"c","name":"Del-general","fname":"Del-General","uids":["u1"],"_updatedAt":{"$date":"2024-02-01T00:00:00.000Z"}}`
-
-	for _, delta := range []string{`{"updatedFields":{"fname":"Del-General"}}`, `{"updatedFields":{"name":"Del-general"}}`} {
-		pub := &fakePublisher{}
-		h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(deleted)})
-		require.NoError(t, h.handleRoom(context.Background(), roomEv("update", "", delta)), "delta %s", delta)
-
-		byType := eventsByType(pub.events)
-		require.Contains(t, byType, model.InboxRoomRenamed, "delta %s", delta)
-		require.Contains(t, byType, model.InboxEventType("room_sync"), "delta %s", delta)
-
-		var renamed model.RoomRenamedInboxPayload
-		require.NoError(t, json.Unmarshal(byType[model.InboxRoomRenamed].Payload, &renamed))
-		assert.Equal(t, "Del-General", renamed.NewName, "the subs' denormalized name must carry the prefix too")
-
-		var room model.Room
-		require.NoError(t, json.Unmarshal(byType[model.InboxEventType("room_sync")].Payload, &room))
-		assert.Equal(t, "Del-General", room.Name, "user-service filters on the rooms doc name")
-	}
-}
-
-// TestHandleRoom_NonDeletedNameKept: only the exact "Del-" prefix on a non-DM room marks a soft
-// delete. A DM's name fields hold the peer's username/display name, not a room name.
+// TestHandleRoom_NonDeletedNameKept: only the exact "Del-" prefix marks a soft delete — a name that
+// merely starts with those letters is a live room.
 func TestHandleRoom_NonDeletedNameKept(t *testing.T) {
 	tests := []struct {
 		name string
@@ -431,7 +406,6 @@ func TestHandleRoom_NonDeletedNameKept(t *testing.T) {
 		{"prefix without hyphen", `{"_id":"r1","t":"c","name":"delta","fname":"Delta","uids":["u1"]}`},
 		{"lowercase del-", `{"_id":"r1","t":"c","name":"del-general","fname":"del-General","uids":["u1"]}`},
 		{"prefix mid-name", `{"_id":"r1","t":"c","name":"team-Del-old","fname":"Team Del-old","uids":["u1"]}`},
-		{"dm with a Del- peer name", `{"_id":"r1","t":"d","name":"Del-bob","fname":"Del-Bob","uids":["u1","u2"]}`},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -443,77 +417,13 @@ func TestHandleRoom_NonDeletedNameKept(t *testing.T) {
 	}
 }
 
-// TestHandleRoom_MalformedUpdateDescriptionPoisons: the soft-delete guard needs the delta, so an
-// undecodable one on a migratable room poisons instead of being silently treated as "no rename".
+// TestHandleRoom_MalformedUpdateDescriptionPoisons: an undecodable delta on a migratable room
+// poisons rather than being silently treated as "no fields changed".
 func TestHandleRoom_MalformedUpdateDescriptionPoisons(t *testing.T) {
-	full := `{"_id":"r1","t":"c","name":"Del-general","fname":"Del-General","uids":["u1"]}`
+	full := `{"_id":"r1","t":"c","name":"general","fname":"General","uids":["u1"]}`
 	h := newTestHandler(&fakePublisher{}, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(full)})
 	err := h.handleRoom(context.Background(), roomEv("update", "", `{"updatedFields":`))
 	assert.ErrorIs(t, err, migration.ErrPoison)
-}
-
-// TestHandleRoom_DeletionAppliedCarriesPrefixedName: the destination hides a room by matching
-// ^Del- on the rooms doc name, and the mapped name prefers fname — so when the source renamed only
-// the machine name, the mapped name must still carry the marker or the deletion is a no-op.
-func TestHandleRoom_DeletionAppliedCarriesPrefixedName(t *testing.T) {
-	tests := []struct {
-		name     string
-		doc      string
-		delta    string
-		wantName string
-	}{
-		{
-			name:     "both fields prefixed",
-			doc:      `{"_id":"r1","t":"c","name":"Del-general","fname":"Del-General","uids":["u1"]}`,
-			delta:    `{"updatedFields":{"fname":"Del-General"}}`,
-			wantName: "Del-General",
-		},
-		{
-			name:     "only the machine name prefixed",
-			doc:      `{"_id":"r1","t":"c","name":"Del-general","fname":"General","uids":["u1"]}`,
-			delta:    `{"updatedFields":{"name":"Del-general"}}`,
-			wantName: "Del-General",
-		},
-		{
-			name:     "only the machine name prefixed, no fname at all",
-			doc:      `{"_id":"r1","t":"c","name":"Del-general","uids":["u1"]}`,
-			delta:    `{"updatedFields":{"name":"Del-general"}}`,
-			wantName: "Del-general",
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			pub := &fakePublisher{}
-			h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(tc.doc)})
-			require.NoError(t, h.handleRoom(context.Background(), roomEv("update", "", tc.delta)))
-
-			byType := eventsByType(pub.events)
-			var room model.Room
-			require.NoError(t, json.Unmarshal(byType[model.InboxEventType("room_sync")].Payload, &room))
-			assert.Equal(t, tc.wantName, room.Name, "user-service filters ^Del- on the rooms doc name")
-			assert.True(t, strings.HasPrefix(room.Name, "Del-"), "a deleted room must be hidden downstream")
-
-			var renamed model.RoomRenamedInboxPayload
-			require.NoError(t, json.Unmarshal(byType[model.InboxRoomRenamed].Payload, &renamed))
-			assert.Equal(t, tc.wantName, renamed.NewName, "subs' denormalized name must match the room doc")
-		})
-	}
-}
-
-// TestHandleRoom_SoftDeletedReplaceApplied: a replace carries no delta, so the deletion can't be
-// recognised from the event — apply it rather than drop it. Leaving a deleted room visible is worse
-// than an extra hidden room doc, and this is what the pre-guard code already did.
-func TestHandleRoom_SoftDeletedReplaceApplied(t *testing.T) {
-	doc := `{"_id":"r1","t":"c","name":"Del-general","fname":"Del-General","uids":["u1"]}`
-	pub := &fakePublisher{}
-	h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{})
-	require.NoError(t, h.handleRoom(context.Background(), roomEv("replace", doc, "")))
-
-	byType := eventsByType(pub.events)
-	require.Contains(t, byType, model.InboxRoomRenamed)
-	var room model.Room
-	require.NoError(t, json.Unmarshal(byType[model.InboxEventType("room_sync")].Payload, &room))
-	assert.Equal(t, "Del-General", room.Name)
 }
 
 // TestHandleRoom_ExcludedTypeWinsOverSoftDelete: exclusion is classified before the soft-delete
@@ -533,19 +443,4 @@ func TestHandleRoom_ExcludedTypeWinsOverSoftDelete(t *testing.T) {
 		assert.ErrorIs(t, err, migration.ErrSkipped)
 		assert.NotErrorIs(t, err, migration.ErrPoison)
 	})
-}
-
-// TestHandleRoom_DeletionAppliedOnRemovedNameField: a delta can REMOVE a name field as well as set
-// it, and a removal changes the mapped name too — so it counts as the deletion carrier.
-func TestHandleRoom_DeletionAppliedOnRemovedNameField(t *testing.T) {
-	doc := `{"_id":"r1","t":"c","name":"Del-general","uids":["u1"]}`
-	pub := &fakePublisher{}
-	h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(doc)})
-	require.NoError(t, h.handleRoom(context.Background(), roomEv("update", "", `{"removedFields":["fname"]}`)))
-
-	byType := eventsByType(pub.events)
-	require.Contains(t, byType, model.InboxRoomRenamed)
-	var room model.Room
-	require.NoError(t, json.Unmarshal(byType[model.InboxEventType("room_sync")].Payload, &room))
-	assert.Equal(t, "Del-general", room.Name)
 }

--- a/data-migration/oplog-collections-transformer/rooms_test.go
+++ b/data-migration/oplog-collections-transformer/rooms_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -359,8 +360,9 @@ func TestHandleRoom_NonDegradedInsertWithoutFullDocument_Poisons(t *testing.T) {
 	assert.ErrorIs(t, h.handleRoom(context.Background(), ev), migration.ErrPoison)
 }
 
-// TestHandleRoom_SoftDeletedSkipped: a room already carrying the "Del-" soft-delete rename is
-// never imported — the deletion transition itself is the one exception (see the test below).
+// TestHandleRoom_SoftDeletedSkipped: a room already carrying the "Del-" soft-delete rename is never
+// imported. The events that can be carrying the deletion itself — the rename update and any replace
+// — are the exception, applied by the two tests below.
 func TestHandleRoom_SoftDeletedSkipped(t *testing.T) {
 	tests := []struct {
 		name string
@@ -373,20 +375,22 @@ func TestHandleRoom_SoftDeletedSkipped(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			for _, op := range []string{"insert", "replace"} {
+			t.Run("insert", func(t *testing.T) {
 				pub := &fakePublisher{}
 				h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{})
-				err := h.handleRoom(context.Background(), roomEv(op, tc.doc, ""))
-				assert.ErrorIs(t, err, migration.ErrSkipped, "op %s", op)
-				assert.Empty(t, pub.events, "op %s", op)
-			}
+				err := h.handleRoom(context.Background(), roomEv("insert", tc.doc, ""))
+				assert.ErrorIs(t, err, migration.ErrSkipped)
+				assert.Empty(t, pub.events)
+			})
 			// An update that leaves the name alone is churn on an already-dead room.
 			for _, delta := range []string{`{"updatedFields":{"restricted":true}}`, `{"updatedFields":{"description":"hi"}}`} {
-				pub := &fakePublisher{}
-				h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(tc.doc)})
-				err := h.handleRoom(context.Background(), roomEv("update", "", delta))
-				assert.ErrorIs(t, err, migration.ErrSkipped, "delta %s", delta)
-				assert.Empty(t, pub.events, "delta %s", delta)
+				t.Run("update "+delta, func(t *testing.T) {
+					pub := &fakePublisher{}
+					h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(tc.doc)})
+					err := h.handleRoom(context.Background(), roomEv("update", "", delta))
+					assert.ErrorIs(t, err, migration.ErrSkipped)
+					assert.Empty(t, pub.events)
+				})
 			}
 		})
 	}
@@ -439,11 +443,109 @@ func TestHandleRoom_NonDeletedNameKept(t *testing.T) {
 	}
 }
 
-// TestHandleRoom_MalformedUpdateDescriptionPoisons: the delta is decoded before the soft-delete
-// guard needs it, so an undecodable one Terms rather than reaching the mapper.
+// TestHandleRoom_MalformedUpdateDescriptionPoisons: the soft-delete guard needs the delta, so an
+// undecodable one on a migratable room poisons instead of being silently treated as "no rename".
 func TestHandleRoom_MalformedUpdateDescriptionPoisons(t *testing.T) {
-	full := `{"_id":"r1","t":"c","fname":"General","uids":["u1"]}`
+	full := `{"_id":"r1","t":"c","name":"Del-general","fname":"Del-General","uids":["u1"]}`
 	h := newTestHandler(&fakePublisher{}, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(full)})
 	err := h.handleRoom(context.Background(), roomEv("update", "", `{"updatedFields":`))
 	assert.ErrorIs(t, err, migration.ErrPoison)
+}
+
+// TestHandleRoom_DeletionAppliedCarriesPrefixedName: the destination hides a room by matching
+// ^Del- on the rooms doc name, and the mapped name prefers fname — so when the source renamed only
+// the machine name, the mapped name must still carry the marker or the deletion is a no-op.
+func TestHandleRoom_DeletionAppliedCarriesPrefixedName(t *testing.T) {
+	tests := []struct {
+		name     string
+		doc      string
+		delta    string
+		wantName string
+	}{
+		{
+			name:     "both fields prefixed",
+			doc:      `{"_id":"r1","t":"c","name":"Del-general","fname":"Del-General","uids":["u1"]}`,
+			delta:    `{"updatedFields":{"fname":"Del-General"}}`,
+			wantName: "Del-General",
+		},
+		{
+			name:     "only the machine name prefixed",
+			doc:      `{"_id":"r1","t":"c","name":"Del-general","fname":"General","uids":["u1"]}`,
+			delta:    `{"updatedFields":{"name":"Del-general"}}`,
+			wantName: "Del-General",
+		},
+		{
+			name:     "only the machine name prefixed, no fname at all",
+			doc:      `{"_id":"r1","t":"c","name":"Del-general","uids":["u1"]}`,
+			delta:    `{"updatedFields":{"name":"Del-general"}}`,
+			wantName: "Del-general",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pub := &fakePublisher{}
+			h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(tc.doc)})
+			require.NoError(t, h.handleRoom(context.Background(), roomEv("update", "", tc.delta)))
+
+			byType := eventsByType(pub.events)
+			var room model.Room
+			require.NoError(t, json.Unmarshal(byType[model.InboxEventType("room_sync")].Payload, &room))
+			assert.Equal(t, tc.wantName, room.Name, "user-service filters ^Del- on the rooms doc name")
+			assert.True(t, strings.HasPrefix(room.Name, "Del-"), "a deleted room must be hidden downstream")
+
+			var renamed model.RoomRenamedInboxPayload
+			require.NoError(t, json.Unmarshal(byType[model.InboxRoomRenamed].Payload, &renamed))
+			assert.Equal(t, tc.wantName, renamed.NewName, "subs' denormalized name must match the room doc")
+		})
+	}
+}
+
+// TestHandleRoom_SoftDeletedReplaceApplied: a replace carries no delta, so the deletion can't be
+// recognised from the event — apply it rather than drop it. Leaving a deleted room visible is worse
+// than an extra hidden room doc, and this is what the pre-guard code already did.
+func TestHandleRoom_SoftDeletedReplaceApplied(t *testing.T) {
+	doc := `{"_id":"r1","t":"c","name":"Del-general","fname":"Del-General","uids":["u1"]}`
+	pub := &fakePublisher{}
+	h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{})
+	require.NoError(t, h.handleRoom(context.Background(), roomEv("replace", doc, "")))
+
+	byType := eventsByType(pub.events)
+	require.Contains(t, byType, model.InboxRoomRenamed)
+	var room model.Room
+	require.NoError(t, json.Unmarshal(byType[model.InboxEventType("room_sync")].Payload, &room))
+	assert.Equal(t, "Del-General", room.Name)
+}
+
+// TestHandleRoom_ExcludedTypeWinsOverSoftDelete: exclusion is classified before the soft-delete
+// guard, so a Del- livechat/voip room keeps metering its type reason and a malformed delta on one
+// still Skips rather than Terming.
+func TestHandleRoom_ExcludedTypeWinsOverSoftDelete(t *testing.T) {
+	t.Run("livechat insert", func(t *testing.T) {
+		h := newTestHandler(&fakePublisher{}, &fakeTarget{}, &fakeLookup{})
+		doc := `{"_id":"r1","t":"l","name":"Del-support","fname":"Del-Support"}`
+		assert.ErrorIs(t, h.handleRoom(context.Background(), roomEv("insert", doc, "")), migration.ErrSkipped)
+	})
+
+	t.Run("malformed delta on an excluded type skips, not poisons", func(t *testing.T) {
+		doc := `{"_id":"r1","t":"v","name":"Del-call"}`
+		h := newTestHandler(&fakePublisher{}, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(doc)})
+		err := h.handleRoom(context.Background(), roomEv("update", "", `{"updatedFields":`))
+		assert.ErrorIs(t, err, migration.ErrSkipped)
+		assert.NotErrorIs(t, err, migration.ErrPoison)
+	})
+}
+
+// TestHandleRoom_DeletionAppliedOnRemovedNameField: a delta can REMOVE a name field as well as set
+// it, and a removal changes the mapped name too — so it counts as the deletion carrier.
+func TestHandleRoom_DeletionAppliedOnRemovedNameField(t *testing.T) {
+	doc := `{"_id":"r1","t":"c","name":"Del-general","uids":["u1"]}`
+	pub := &fakePublisher{}
+	h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(doc)})
+	require.NoError(t, h.handleRoom(context.Background(), roomEv("update", "", `{"removedFields":["fname"]}`)))
+
+	byType := eventsByType(pub.events)
+	require.Contains(t, byType, model.InboxRoomRenamed)
+	var room model.Room
+	require.NoError(t, json.Unmarshal(byType[model.InboxEventType("room_sync")].Payload, &room))
+	assert.Equal(t, "Del-general", room.Name)
 }

--- a/data-migration/oplog-collections-transformer/rooms_test.go
+++ b/data-migration/oplog-collections-transformer/rooms_test.go
@@ -359,8 +359,8 @@ func TestHandleRoom_NonDegradedInsertWithoutFullDocument_Poisons(t *testing.T) {
 	assert.ErrorIs(t, h.handleRoom(context.Background(), ev), migration.ErrPoison)
 }
 
-// TestHandleRoom_SoftDeletedSkipped: the legacy app soft-deletes a room by renaming it to
-// "Del-"+name; such rooms must never be imported, on any op.
+// TestHandleRoom_SoftDeletedSkipped: a room already carrying the "Del-" soft-delete rename is
+// never imported — the deletion transition itself is the one exception (see the test below).
 func TestHandleRoom_SoftDeletedSkipped(t *testing.T) {
 	tests := []struct {
 		name string
@@ -370,7 +370,6 @@ func TestHandleRoom_SoftDeletedSkipped(t *testing.T) {
 		{"name carries the prefix", `{"_id":"r1","t":"c","name":"Del-general","fname":"General","uids":["u1"]}`},
 		{"both carry the prefix", `{"_id":"r1","t":"c","name":"Del-general","fname":"Del-General","uids":["u1"]}`},
 		{"discussion", `{"_id":"r1","t":"p","prid":"p1","fname":"Del-Topic","uids":["u1"]}`},
-		{"dm", `{"_id":"r1","t":"d","name":"Del-bob","uids":["u1","u2"]}`},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -381,18 +380,45 @@ func TestHandleRoom_SoftDeletedSkipped(t *testing.T) {
 				assert.ErrorIs(t, err, migration.ErrSkipped, "op %s", op)
 				assert.Empty(t, pub.events, "op %s", op)
 			}
-			// update re-reads the current source doc through the lookup.
-			pub := &fakePublisher{}
-			h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(tc.doc)})
-			err := h.handleRoom(context.Background(), roomEv("update", "", `{"updatedFields":{"fname":"x"}}`))
-			assert.ErrorIs(t, err, migration.ErrSkipped)
-			assert.Empty(t, pub.events)
+			// An update that leaves the name alone is churn on an already-dead room.
+			for _, delta := range []string{`{"updatedFields":{"restricted":true}}`, `{"updatedFields":{"description":"hi"}}`} {
+				pub := &fakePublisher{}
+				h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(tc.doc)})
+				err := h.handleRoom(context.Background(), roomEv("update", "", delta))
+				assert.ErrorIs(t, err, migration.ErrSkipped, "delta %s", delta)
+				assert.Empty(t, pub.events, "delta %s", delta)
+			}
 		})
 	}
 }
 
-// TestHandleRoom_NonDeletedNameKept: only the exact "Del-" prefix marks a soft delete — a name
-// that merely starts with those letters is a live room.
+// TestHandleRoom_SoftDeleteRenameApplied: the rename INTO "Del-" is the source's only delete
+// signal — apply it, so the destination room takes the prefixed name and user-service's ^Del-
+// filter hides it. Skipping it would leave a deleted room visible to every migrated member.
+func TestHandleRoom_SoftDeleteRenameApplied(t *testing.T) {
+	const deleted = `{"_id":"r1","t":"c","name":"Del-general","fname":"Del-General","uids":["u1"],"_updatedAt":{"$date":"2024-02-01T00:00:00.000Z"}}`
+
+	for _, delta := range []string{`{"updatedFields":{"fname":"Del-General"}}`, `{"updatedFields":{"name":"Del-general"}}`} {
+		pub := &fakePublisher{}
+		h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(deleted)})
+		require.NoError(t, h.handleRoom(context.Background(), roomEv("update", "", delta)), "delta %s", delta)
+
+		byType := eventsByType(pub.events)
+		require.Contains(t, byType, model.InboxRoomRenamed, "delta %s", delta)
+		require.Contains(t, byType, model.InboxEventType("room_sync"), "delta %s", delta)
+
+		var renamed model.RoomRenamedInboxPayload
+		require.NoError(t, json.Unmarshal(byType[model.InboxRoomRenamed].Payload, &renamed))
+		assert.Equal(t, "Del-General", renamed.NewName, "the subs' denormalized name must carry the prefix too")
+
+		var room model.Room
+		require.NoError(t, json.Unmarshal(byType[model.InboxEventType("room_sync")].Payload, &room))
+		assert.Equal(t, "Del-General", room.Name, "user-service filters on the rooms doc name")
+	}
+}
+
+// TestHandleRoom_NonDeletedNameKept: only the exact "Del-" prefix on a non-DM room marks a soft
+// delete. A DM's name fields hold the peer's username/display name, not a room name.
 func TestHandleRoom_NonDeletedNameKept(t *testing.T) {
 	tests := []struct {
 		name string
@@ -401,6 +427,7 @@ func TestHandleRoom_NonDeletedNameKept(t *testing.T) {
 		{"prefix without hyphen", `{"_id":"r1","t":"c","name":"delta","fname":"Delta","uids":["u1"]}`},
 		{"lowercase del-", `{"_id":"r1","t":"c","name":"del-general","fname":"del-General","uids":["u1"]}`},
 		{"prefix mid-name", `{"_id":"r1","t":"c","name":"team-Del-old","fname":"Team Del-old","uids":["u1"]}`},
+		{"dm with a Del- peer name", `{"_id":"r1","t":"d","name":"Del-bob","fname":"Del-Bob","uids":["u1","u2"]}`},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -410,4 +437,13 @@ func TestHandleRoom_NonDeletedNameKept(t *testing.T) {
 			assert.Len(t, pub.events, 1)
 		})
 	}
+}
+
+// TestHandleRoom_MalformedUpdateDescriptionPoisons: the delta is decoded before the soft-delete
+// guard needs it, so an undecodable one Terms rather than reaching the mapper.
+func TestHandleRoom_MalformedUpdateDescriptionPoisons(t *testing.T) {
+	full := `{"_id":"r1","t":"c","fname":"General","uids":["u1"]}`
+	h := newTestHandler(&fakePublisher{}, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(full)})
+	err := h.handleRoom(context.Background(), roomEv("update", "", `{"updatedFields":`))
+	assert.ErrorIs(t, err, migration.ErrPoison)
 }

--- a/data-migration/oplog-collections-transformer/rooms_test.go
+++ b/data-migration/oplog-collections-transformer/rooms_test.go
@@ -358,3 +358,56 @@ func TestHandleRoom_NonDegradedInsertWithoutFullDocument_Poisons(t *testing.T) {
 	ev := oplogEvent{Op: "insert", Collection: roomsColl, DocumentKey: json.RawMessage(`{"_id":"r1"}`)}
 	assert.ErrorIs(t, h.handleRoom(context.Background(), ev), migration.ErrPoison)
 }
+
+// TestHandleRoom_SoftDeletedSkipped: the legacy app soft-deletes a room by renaming it to
+// "Del-"+name; such rooms must never be imported, on any op.
+func TestHandleRoom_SoftDeletedSkipped(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+	}{
+		{"fname carries the prefix", `{"_id":"r1","t":"c","name":"general","fname":"Del-General","uids":["u1"]}`},
+		{"name carries the prefix", `{"_id":"r1","t":"c","name":"Del-general","fname":"General","uids":["u1"]}`},
+		{"both carry the prefix", `{"_id":"r1","t":"c","name":"Del-general","fname":"Del-General","uids":["u1"]}`},
+		{"discussion", `{"_id":"r1","t":"p","prid":"p1","fname":"Del-Topic","uids":["u1"]}`},
+		{"dm", `{"_id":"r1","t":"d","name":"Del-bob","uids":["u1","u2"]}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, op := range []string{"insert", "replace"} {
+				pub := &fakePublisher{}
+				h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{})
+				err := h.handleRoom(context.Background(), roomEv(op, tc.doc, ""))
+				assert.ErrorIs(t, err, migration.ErrSkipped, "op %s", op)
+				assert.Empty(t, pub.events, "op %s", op)
+			}
+			// update re-reads the current source doc through the lookup.
+			pub := &fakePublisher{}
+			h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(tc.doc)})
+			err := h.handleRoom(context.Background(), roomEv("update", "", `{"updatedFields":{"fname":"x"}}`))
+			assert.ErrorIs(t, err, migration.ErrSkipped)
+			assert.Empty(t, pub.events)
+		})
+	}
+}
+
+// TestHandleRoom_NonDeletedNameKept: only the exact "Del-" prefix marks a soft delete — a name
+// that merely starts with those letters is a live room.
+func TestHandleRoom_NonDeletedNameKept(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+	}{
+		{"prefix without hyphen", `{"_id":"r1","t":"c","name":"delta","fname":"Delta","uids":["u1"]}`},
+		{"lowercase del-", `{"_id":"r1","t":"c","name":"del-general","fname":"del-General","uids":["u1"]}`},
+		{"prefix mid-name", `{"_id":"r1","t":"c","name":"team-Del-old","fname":"Team Del-old","uids":["u1"]}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pub := &fakePublisher{}
+			h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{})
+			require.NoError(t, h.handleRoom(context.Background(), roomEv("insert", tc.doc, "")))
+			assert.Len(t, pub.events, 1)
+		})
+	}
+}

--- a/data-migration/oplog-collections-transformer/rooms_test.go
+++ b/data-migration/oplog-collections-transformer/rooms_test.go
@@ -359,43 +359,6 @@ func TestHandleRoom_NonDegradedInsertWithoutFullDocument_Poisons(t *testing.T) {
 	assert.ErrorIs(t, h.handleRoom(context.Background(), ev), migration.ErrPoison)
 }
 
-// TestHandleRoom_SoftDeletedSkipped: a room carrying the "Del-" soft-delete rename is never
-// imported, on any op. See invariant_test.go for the exhaustive statement of the rule.
-func TestHandleRoom_SoftDeletedSkipped(t *testing.T) {
-	tests := []struct {
-		name string
-		doc  string
-	}{
-		{"fname carries the prefix", `{"_id":"r1","t":"c","name":"general","fname":"Del-General","uids":["u1"]}`},
-		{"name carries the prefix", `{"_id":"r1","t":"c","name":"Del-general","fname":"General","uids":["u1"]}`},
-		{"both carry the prefix", `{"_id":"r1","t":"c","name":"Del-general","fname":"Del-General","uids":["u1"]}`},
-		{"discussion", `{"_id":"r1","t":"p","prid":"p1","fname":"Del-Topic","uids":["u1"]}`},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			for _, op := range []string{"insert", "replace"} {
-				t.Run(op, func(t *testing.T) {
-					pub := &fakePublisher{}
-					h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{})
-					err := h.handleRoom(context.Background(), roomEv(op, tc.doc, ""))
-					assert.ErrorIs(t, err, migration.ErrSkipped)
-					assert.Empty(t, pub.events)
-				})
-			}
-			// An update that leaves the name alone is churn on an already-dead room.
-			for _, delta := range []string{`{"updatedFields":{"restricted":true}}`, `{"updatedFields":{"description":"hi"}}`} {
-				t.Run("update "+delta, func(t *testing.T) {
-					pub := &fakePublisher{}
-					h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(tc.doc)})
-					err := h.handleRoom(context.Background(), roomEv("update", "", delta))
-					assert.ErrorIs(t, err, migration.ErrSkipped)
-					assert.Empty(t, pub.events)
-				})
-			}
-		})
-	}
-}
-
 // TestHandleRoom_NonDeletedNameKept: only the exact "Del-" prefix marks a soft delete — a name that
 // merely starts with those letters is a live room.
 func TestHandleRoom_NonDeletedNameKept(t *testing.T) {

--- a/data-migration/oplog-collections-transformer/subscriptions.go
+++ b/data-migration/oplog-collections-transformer/subscriptions.go
@@ -106,10 +106,11 @@ func (h *handler) handleSubscription(ctx context.Context, ev oplogEvent) error {
 		return fmt.Errorf("%w: decode source subscription: %v", migration.ErrPoison, uerr) //nolint:errorlint // intentional single-%w sentinel wrap; decode err is informational only
 	}
 
-	if isSoftDeletedName(ss.Name, ss.FName) {
-		// The source renames every subscription's denormalized name along with its room's when the
-		// room is soft-deleted, so the prefix marks a subscription to a deleted room — skip it on
-		// any op, matching the room path.
+	if isSoftDeletedRecord(ss.T, ss.Name, ss.FName) {
+		// A subscription to a soft-deleted room, whose denormalized name the source renamed along
+		// with the room's. Skipped on every op: the deletion state rides the room lane (room_renamed
+		// rewrites the name on every sub that exists), and the field events here would Nak-retry to
+		// exhaustion against a subscription whose insert this same guard skipped.
 		slog.Debug("skip subscription to soft-deleted room",
 			"eventId", ev.EventID, "request_id", natsutil.RequestIDFromContext(ctx))
 		h.metrics.onSkipped(ctx, "subscription_soft_deleted")

--- a/data-migration/oplog-collections-transformer/subscriptions.go
+++ b/data-migration/oplog-collections-transformer/subscriptions.go
@@ -106,6 +106,16 @@ func (h *handler) handleSubscription(ctx context.Context, ev oplogEvent) error {
 		return fmt.Errorf("%w: decode source subscription: %v", migration.ErrPoison, uerr) //nolint:errorlint // intentional single-%w sentinel wrap; decode err is informational only
 	}
 
+	if isSoftDeletedName(ss.Name, ss.FName) {
+		// The source renames every subscription's denormalized name along with its room's when the
+		// room is soft-deleted, so the prefix marks a subscription to a deleted room — skip it on
+		// any op, matching the room path.
+		slog.Debug("skip subscription to soft-deleted room",
+			"eventId", ev.EventID, "request_id", natsutil.RequestIDFromContext(ctx))
+		h.metrics.onSkipped(ctx, "subscription_soft_deleted")
+		return migration.ErrSkipped
+	}
+
 	if ev.Op == "update" {
 		return h.handleSubscriptionUpdate(ctx, ev, &ss)
 	}

--- a/data-migration/oplog-collections-transformer/subscriptions.go
+++ b/data-migration/oplog-collections-transformer/subscriptions.go
@@ -113,7 +113,8 @@ func (h *handler) handleSubscription(ctx context.Context, ev oplogEvent) error {
 		// tidy — inbox-worker treats a missing subscription as a redelivery signal, so they would
 		// Nak-retry to exhaustion against a subscription whose insert this same guard skipped.
 		slog.DebugContext(ctx, "skip subscription to soft-deleted room",
-			"op", ev.Op, "eventId", ev.EventID, "request_id", natsutil.RequestIDFromContext(ctx))
+			"roomId", ss.RID, "op", ev.Op,
+			"eventId", ev.EventID, "request_id", natsutil.RequestIDFromContext(ctx))
 		h.metrics.onSkipped(ctx, "subscription_soft_deleted")
 		return migration.ErrSkipped
 	}

--- a/data-migration/oplog-collections-transformer/subscriptions.go
+++ b/data-migration/oplog-collections-transformer/subscriptions.go
@@ -111,8 +111,8 @@ func (h *handler) handleSubscription(ctx context.Context, ev oplogEvent) error {
 		// with the room's. Skipped on every op: the deletion state rides the room lane (room_renamed
 		// rewrites the name on every sub that exists), and the field events here would Nak-retry to
 		// exhaustion against a subscription whose insert this same guard skipped.
-		slog.Debug("skip subscription to soft-deleted room",
-			"eventId", ev.EventID, "request_id", natsutil.RequestIDFromContext(ctx))
+		slog.DebugContext(ctx, "skip subscription to soft-deleted room",
+			"op", ev.Op, "eventId", ev.EventID, "request_id", natsutil.RequestIDFromContext(ctx))
 		h.metrics.onSkipped(ctx, "subscription_soft_deleted")
 		return migration.ErrSkipped
 	}

--- a/data-migration/oplog-collections-transformer/subscriptions.go
+++ b/data-migration/oplog-collections-transformer/subscriptions.go
@@ -106,11 +106,12 @@ func (h *handler) handleSubscription(ctx context.Context, ev oplogEvent) error {
 		return fmt.Errorf("%w: decode source subscription: %v", migration.ErrPoison, uerr) //nolint:errorlint // intentional single-%w sentinel wrap; decode err is informational only
 	}
 
-	if isSoftDeletedRecord(ss.T, ss.Name, ss.FName) {
+	if isSoftDeletedRecord(ss.Name, ss.FName) {
 		// A subscription to a soft-deleted room, whose denormalized name the source renamed along
-		// with the room's. Skipped on every op: the deletion state rides the room lane (room_renamed
-		// rewrites the name on every sub that exists), and the field events here would Nak-retry to
-		// exhaustion against a subscription whose insert this same guard skipped.
+		// with the room's. Skipped on every op so no "Del-" name reaches Mongo: member_added would
+		// create the subscription carrying it. Skipping the field events too is required, not just
+		// tidy — inbox-worker treats a missing subscription as a redelivery signal, so they would
+		// Nak-retry to exhaustion against a subscription whose insert this same guard skipped.
 		slog.DebugContext(ctx, "skip subscription to soft-deleted room",
 			"op", ev.Op, "eventId", ev.EventID, "request_id", natsutil.RequestIDFromContext(ctx))
 		h.metrics.onSkipped(ctx, "subscription_soft_deleted")

--- a/data-migration/oplog-collections-transformer/subscriptions.go
+++ b/data-migration/oplog-collections-transformer/subscriptions.go
@@ -107,11 +107,9 @@ func (h *handler) handleSubscription(ctx context.Context, ev oplogEvent) error {
 	}
 
 	if isSoftDeletedRecord(ss.Name, ss.FName) {
-		// A subscription to a soft-deleted room, whose denormalized name the source renamed along
-		// with the room's. Skipped on every op so no "Del-" name reaches Mongo: member_added would
-		// create the subscription carrying it. Skipping the field events too is required, not just
-		// tidy — inbox-worker treats a missing subscription as a redelivery signal, so they would
-		// Nak-retry to exhaustion against a subscription whose insert this same guard skipped.
+		// Sub to a soft-deleted room (the source renames the denormalized name too), so member_added
+		// would carry the marker. Field events must be skipped as well — inbox-worker would Nak-retry
+		// them to exhaustion against a subscription this guard never created.
 		slog.DebugContext(ctx, "skip subscription to soft-deleted room",
 			"roomId", ss.RID, "op", ev.Op,
 			"eventId", ev.EventID, "request_id", natsutil.RequestIDFromContext(ctx))

--- a/data-migration/oplog-collections-transformer/subscriptions_test.go
+++ b/data-migration/oplog-collections-transformer/subscriptions_test.go
@@ -417,3 +417,56 @@ func TestHandleSubscription_RolesCleared_EmitsRoleUpdated(t *testing.T) {
 	assert.Equal(t, []model.Role{model.RoleMember}, su.Subscription.Roles,
 		"a demotion (cleared roles) must map to the [member] floor so it survives inbox-worker")
 }
+
+// TestHandleSubscription_SoftDeletedSkipped: a subscription to a soft-deleted room carries the
+// room's "Del-" renamed name/fname — never import it, on any op.
+func TestHandleSubscription_SoftDeletedSkipped(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+	}{
+		{"fname carries the prefix", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"general","fname":"Del-General","open":true}`},
+		{"name carries the prefix", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"Del-general","fname":"General","open":true}`},
+		{"dm", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"d","name":"Del-bob","fname":"Del-Bob","open":true}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, op := range []string{"insert", "replace"} {
+				pub := &fakePublisher{}
+				h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{})
+				err := h.handleSubscription(context.Background(), subEv(op, tc.doc, ""))
+				assert.ErrorIs(t, err, migration.ErrSkipped, "op %s", op)
+				assert.Empty(t, pub.events, "op %s", op)
+			}
+			// update re-reads the current source doc; neither a leave (open) nor a field delta
+			// may emit for a soft-deleted room.
+			for _, delta := range []string{`{"updatedFields":{"open":false}}`, `{"updatedFields":{"f":true}}`} {
+				pub := &fakePublisher{}
+				h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(tc.doc)})
+				err := h.handleSubscription(context.Background(), subEv("update", "", delta))
+				assert.ErrorIs(t, err, migration.ErrSkipped, "delta %s", delta)
+				assert.Empty(t, pub.events, "delta %s", delta)
+			}
+		})
+	}
+}
+
+// TestHandleSubscription_NonDeletedNameKept: only the exact "Del-" prefix marks a soft delete.
+func TestHandleSubscription_NonDeletedNameKept(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+	}{
+		{"prefix without hyphen", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"delta","fname":"Delta","open":true}`},
+		{"lowercase del-", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"del-general","fname":"del-General","open":true}`},
+		{"prefix mid-name", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"team-Del-old","fname":"Team Del-old","open":true}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pub := &fakePublisher{}
+			h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{})
+			require.NoError(t, h.handleSubscription(context.Background(), subEv("insert", tc.doc, "")))
+			assert.NotEmpty(t, pub.events)
+		})
+	}
+}

--- a/data-migration/oplog-collections-transformer/subscriptions_test.go
+++ b/data-migration/oplog-collections-transformer/subscriptions_test.go
@@ -427,6 +427,7 @@ func TestHandleSubscription_SoftDeletedSkipped(t *testing.T) {
 	}{
 		{"fname carries the prefix", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"general","fname":"Del-General","open":true}`},
 		{"name carries the prefix", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"Del-general","fname":"General","open":true}`},
+		{"dm sub", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"d","name":"Del-bob","fname":"Del-Bob","open":true}`},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -450,8 +451,7 @@ func TestHandleSubscription_SoftDeletedSkipped(t *testing.T) {
 	}
 }
 
-// TestHandleSubscription_NonDeletedNameKept: only the exact "Del-" prefix on a non-DM sub marks
-// a soft delete.
+// TestHandleSubscription_NonDeletedNameKept: only the exact "Del-" prefix marks a soft delete.
 func TestHandleSubscription_NonDeletedNameKept(t *testing.T) {
 	tests := []struct {
 		name string
@@ -460,9 +460,6 @@ func TestHandleSubscription_NonDeletedNameKept(t *testing.T) {
 		{"prefix without hyphen", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"delta","fname":"Delta","open":true}`},
 		{"lowercase del-", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"del-general","fname":"del-General","open":true}`},
 		{"prefix mid-name", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"team-Del-old","fname":"Team Del-old","open":true}`},
-		// A DM sub's name/fname are the PEER's username and display name (see memberAddedEvent),
-		// not a room name — the prefix there marks a user, never a deletion.
-		{"dm with a Del- peer name", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"d","name":"Del-bob","fname":"Del-Bob","open":true}`},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/data-migration/oplog-collections-transformer/subscriptions_test.go
+++ b/data-migration/oplog-collections-transformer/subscriptions_test.go
@@ -418,39 +418,6 @@ func TestHandleSubscription_RolesCleared_EmitsRoleUpdated(t *testing.T) {
 		"a demotion (cleared roles) must map to the [member] floor so it survives inbox-worker")
 }
 
-// TestHandleSubscription_SoftDeletedSkipped: a subscription to a soft-deleted room carries the
-// room's "Del-" renamed name/fname — never import it, on any op.
-func TestHandleSubscription_SoftDeletedSkipped(t *testing.T) {
-	tests := []struct {
-		name string
-		doc  string
-	}{
-		{"fname carries the prefix", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"general","fname":"Del-General","open":true}`},
-		{"name carries the prefix", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"Del-general","fname":"General","open":true}`},
-		{"dm sub", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"d","name":"Del-bob","fname":"Del-Bob","open":true}`},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			for _, op := range []string{"insert", "replace"} {
-				pub := &fakePublisher{}
-				h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{})
-				err := h.handleSubscription(context.Background(), subEv(op, tc.doc, ""))
-				assert.ErrorIs(t, err, migration.ErrSkipped, "op %s", op)
-				assert.Empty(t, pub.events, "op %s", op)
-			}
-			// update re-reads the current source doc; neither a leave (open) nor a field delta
-			// may emit for a soft-deleted room.
-			for _, delta := range []string{`{"updatedFields":{"open":false}}`, `{"updatedFields":{"f":true}}`} {
-				pub := &fakePublisher{}
-				h := newTestHandler(pub, &fakeTarget{}, &fakeLookup{doc: json.RawMessage(tc.doc)})
-				err := h.handleSubscription(context.Background(), subEv("update", "", delta))
-				assert.ErrorIs(t, err, migration.ErrSkipped, "delta %s", delta)
-				assert.Empty(t, pub.events, "delta %s", delta)
-			}
-		})
-	}
-}
-
 // TestHandleSubscription_NonDeletedNameKept: only the exact "Del-" prefix marks a soft delete.
 func TestHandleSubscription_NonDeletedNameKept(t *testing.T) {
 	tests := []struct {

--- a/data-migration/oplog-collections-transformer/subscriptions_test.go
+++ b/data-migration/oplog-collections-transformer/subscriptions_test.go
@@ -427,7 +427,6 @@ func TestHandleSubscription_SoftDeletedSkipped(t *testing.T) {
 	}{
 		{"fname carries the prefix", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"general","fname":"Del-General","open":true}`},
 		{"name carries the prefix", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"Del-general","fname":"General","open":true}`},
-		{"dm", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"d","name":"Del-bob","fname":"Del-Bob","open":true}`},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -451,7 +450,8 @@ func TestHandleSubscription_SoftDeletedSkipped(t *testing.T) {
 	}
 }
 
-// TestHandleSubscription_NonDeletedNameKept: only the exact "Del-" prefix marks a soft delete.
+// TestHandleSubscription_NonDeletedNameKept: only the exact "Del-" prefix on a non-DM sub marks
+// a soft delete.
 func TestHandleSubscription_NonDeletedNameKept(t *testing.T) {
 	tests := []struct {
 		name string
@@ -460,6 +460,9 @@ func TestHandleSubscription_NonDeletedNameKept(t *testing.T) {
 		{"prefix without hyphen", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"delta","fname":"Delta","open":true}`},
 		{"lowercase del-", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"del-general","fname":"del-General","open":true}`},
 		{"prefix mid-name", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"c","name":"team-Del-old","fname":"Team Del-old","open":true}`},
+		// A DM sub's name/fname are the PEER's username and display name (see memberAddedEvent),
+		// not a room name — the prefix there marks a user, never a deletion.
+		{"dm with a Del- peer name", `{"_id":"sub1","u":{"_id":"u1","username":"alice"},"rid":"r1","t":"d","name":"Del-bob","fname":"Del-Bob","open":true}`},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

The legacy source app has no room-delete operation and no delete flag: "deleting" a room renames it — and the denormalized name on every subscription to it — to `Del-`+name. This branch keeps those records out of the migration.

**Invariant: a room or subscription carrying the `Del-` marker must never appear in the destination MongoDB — no doc, no rename, no denormalized copy.**

## Changes

- **`isSoftDeletedRecord`** (`classify.go`): reports whether a source room or subscription carries the marker on `name` **or** `fname`. Only the exact prefix counts — `delta`, `del-general` and `team-Del-old` are live rooms.
- **Room lane** (`rooms.go`): any op (`insert` / `replace` / `update`) on a `Del-` room is skipped with `migration.ErrSkipped`, metered `room_soft_deleted`. Room-type classification runs first so a `Del-` livechat/voip/group-DM room keeps metering its own exclusion reason.
- **Subscription lane** (`subscriptions.go`): same, metered `subscription_soft_deleted`. Skipping the field events is required rather than merely tidy — `inbox-worker` treats a missing subscription as a redelivery signal (`UpdateSubscriptionRoles`/mute/favorite/open), so `role_updated` and friends would Nak-retry to exhaustion against a subscription whose insert this guard skipped.
- **Docs**: `CDC_COVERAGE.md` states the invariant, the per-op table, and the residuals; `SOURCE_DATA.md` records the `Del-` convention and the open questions it rests on.

## Why the invariant is provable, not just asserted

Every name this transformer can write into Mongo arrives via a published event:

| Event | Writes | Guarded by |
|---|---|---|
| `room_sync` | `rooms.name` | room lane |
| `room_renamed` | `subscriptions.name`, for every sub in the room | room lane |
| `member_added` | the new subscription's name | subscription lane |

`invariant_test.go` therefore proves the rule by asserting that no `Del-` source doc — across every doc shape, both lanes, every op, and six update-delta shapes — publishes anything at all: **99 cases**. The `company_room_members` and `company_thread_subscriptions` lanes carry no name field and cannot violate it.

## Known consequences (documented, not coded around)

- **A room soft-deleted after the CDC checkpoint keeps its original, unprefixed name** and stays visible to its members. Hiding it would mean writing the very document the invariant forbids, and the destination has no room-delete path (no `inbox-worker` handler, no room-delete RPC). Removal is an ops backfill: query the **source** for `Del-` prefixed names and reconcile against the destination `rooms` collection by `_id`. Building a destination delete path is separate, deliberately-scoped work.
- **DMs are not exempt.** For `t:"d"` the name fields hold the peer's username and display name, so a user literally named `Del-…` costs their DM. That is the deliberate price of a total invariant — type-scoping the check would let a `Del-` named DM document into Mongo.
- The `…_events_skipped_total{reason=room_soft_deleted}` counter reports skipped **event volume** only — it counts every event on a dead room, not unique rooms, and carries no room id. The per-skip log line carries `roomId` for tracing an individual record.

## Verification

`make lint` 0 issues · `gosec` clean · `go test -race ./data-migration/...` green · CI green on the head commit, including `sast` and `test-integration (data-migration)`.

https://claude.ai/code/session_013vDkcvPJaoXQdEkK9rupXC