### PR TITLE
feat(broadcast-worker): per-thread viewer lane for non-follower thread delivery

### DIFF
--- a/.semgrep/room-subject.yml
+++ b/.semgrep/room-subject.yml
@@ -7,7 +7,7 @@ rules:
       publishRoomEvent / publishMemberEvent helper, which fans out over
       subject.RoomEventTargets / RoomMemberEventTargets(roomID, crossSite,
       crossSiteAt, mode, now). Passing a subject built inline by subject.RoomEvent /
-      RoomMsgStream / RoomMetadataUpdate / RoomMemberEvent to a publish call skips the
+      RoomMsgStream / RoomMetadataUpdate / RoomMemberEvent / ThreadEvent to a publish call skips the
       ROOM_SUBJECT_MODE global/local routing, so same-site rooms silently miss
       delivery once local mode is enabled (and dual mode loses its global
       safety-net publish). See pkg/subject.RoomEventTargets and each service's
@@ -32,3 +32,6 @@ rules:
           - pattern: $X.Publish($CTX, subject.RoomMemberEvent(...), ...)
           - pattern: $X.publishCore($CTX, subject.RoomMemberEvent(...), ...)
           - pattern: $X.publish($CTX, subject.RoomMemberEvent(...), ...)
+          - pattern: $X.Publish($CTX, subject.ThreadEvent(...), ...)
+          - pattern: $X.publishCore($CTX, subject.ThreadEvent(...), ...)
+          - pattern: $X.publish($CTX, subject.ThreadEvent(...), ...)

--- a/broadcast-worker/deploy/bot/docker-compose.yml
+++ b/broadcast-worker/deploy/bot/docker-compose.yml
@@ -36,6 +36,9 @@ services:
       # true like the user variants — false means verify-and-exit, and the bot
       # streams' creator (bot-message-handler) is not in compose.services.yaml.
       - BOOTSTRAP_STREAMS=${BOOTSTRAP_STREAMS:-true}
+      # Off by default: channel and thread message content (including the thread
+      # viewer lane) goes plaintext on chat.room.> subjects, which any authenticated
+      # user's JWT can subscribe to.
       - ENCRYPTION_ENABLED=${ENCRYPTION_ENABLED:-false}
       # Dev-only X-Debug verbose logging. DEBUG_LOG_PAYLOADS gates full
       # request/reply/consumed body capture (pair with the X-Debug-Payload header).

--- a/broadcast-worker/deploy/user/docker-compose.yml
+++ b/broadcast-worker/deploy/user/docker-compose.yml
@@ -33,6 +33,9 @@ services:
       - VALKEY_ADDRS=${VALKEY_ADDRS:-valkey:6379}
       - ROOM_META_L2_TTL=${ROOM_META_L2_TTL:-15m}
       - BOOTSTRAP_STREAMS=${BOOTSTRAP_STREAMS:-true}
+      # Off by default: channel and thread message content (including the thread
+      # viewer lane) goes plaintext on chat.room.> subjects, which any authenticated
+      # user's JWT can subscribe to.
       - ENCRYPTION_ENABLED=${ENCRYPTION_ENABLED:-false}
       # Dev-only X-Debug verbose logging. DEBUG_LOG_PAYLOADS gates full
       # request/reply/consumed body capture (pair with the X-Debug-Payload header).

--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -261,10 +261,11 @@ func (h *Handler) handleThreadCreated(ctx context.Context, evt *model.MessageEve
 			return fmt.Errorf("channel thread fan-out for parent %s: %w", parentMsgID, err)
 		}
 		if len(fanOut) == 0 {
+			// No per-account recipients (e.g. a bot-authored reply), but the
+			// thread lane below still serves viewers with the pane open.
 			slog.DebugContext(ctx, "no thread subscribers to notify for thread reply",
 				"parentMessageID", parentMsgID,
 				"request_id", natsutil.RequestIDFromContext(ctx))
-			return nil
 		}
 	}
 
@@ -297,7 +298,14 @@ func (h *Handler) handleThreadCreated(ctx context.Context, evt *model.MessageEve
 		if err != nil {
 			return fmt.Errorf("marshal thread created event for parent %s: %w", parentMsgID, err)
 		}
-		return h.publishToThreadAccounts(ctx, fanOut, payload, parentMsgID)
+		if err := h.publishToThreadAccounts(ctx, fanOut, payload, parentMsgID); err != nil {
+			return fmt.Errorf("publish thread created event for parent %s: %w", parentMsgID, err)
+		}
+		// Thread lane: same event, encrypted, for viewers who do not follow the
+		// thread. Encrypt a copy AFTER the plaintext publish above —
+		// encryptRoomEvent nils Message in place.
+		h.publishThreadLaneCreated(ctx, &meta, clientMsg, parentMsgID, roomEvt)
+		return nil
 	case model.RoomTypeDM, model.RoomTypeBotDM:
 		// DM thread replies fan out to all members. The thread-sub mention badge is
 		// owned by message-worker (markThreadMentions), so broadcast-worker doesn't
@@ -310,6 +318,32 @@ func (h *Handler) handleThreadCreated(ctx context.Context, evt *model.MessageEve
 			"room_id", meta.ID,
 			"request_id", natsutil.RequestIDFromContext(ctx))
 		return nil
+	}
+}
+
+// publishThreadLaneCreated sends the encrypted twin of a thread reply on the
+// per-thread lane. Best-effort: errors are logged, never returned, because the
+// per-account lane above is the delivery guarantee and failing the handler
+// would re-fan-out that lane on redelivery.
+func (h *Handler) publishThreadLaneCreated(ctx context.Context, meta *roommetacache.Meta, clientMsg *model.ClientMessage, parentMsgID string, plain model.RoomEvent) { //nolint:gocritic // hugeParam: plain is taken by value so encryptRoomEvent's in-place mutation doesn't touch the caller's roomEvt
+	laneEvt := plain
+	if err := h.encryptRoomEvent(ctx, meta.ID, clientMsg, &laneEvt); err != nil {
+		slog.ErrorContext(ctx, "encrypt thread lane event failed",
+			"error", err, "room_id", meta.ID, "parentMessageID", parentMsgID,
+			"request_id", natsutil.RequestIDFromContext(ctx))
+		return
+	}
+	lanePayload, err := sonic.Marshal(laneEvt)
+	if err != nil {
+		slog.ErrorContext(ctx, "marshal thread lane event failed",
+			"error", err, "room_id", meta.ID, "parentMessageID", parentMsgID,
+			"request_id", natsutil.RequestIDFromContext(ctx))
+		return
+	}
+	if err := h.publishThreadLaneEvent(ctx, meta.ID, parentMsgID, meta.CrossSite, meta.CrossSiteAt, lanePayload, "thread create"); err != nil {
+		slog.ErrorContext(ctx, "publish thread lane event failed",
+			"error", err, "room_id", meta.ID, "parentMessageID", parentMsgID,
+			"request_id", natsutil.RequestIDFromContext(ctx))
 	}
 }
 

--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -412,16 +412,21 @@ func (h *Handler) handleThreadUpdated(ctx context.Context, evt *model.MessageEve
 			return fmt.Errorf("channel thread fan-out for thread update of parent %s: %w", parentMsgID, err)
 		}
 		if len(fanOut) == 0 {
+			// No per-account recipients, but the thread lane below still serves
+			// viewers with the pane open.
 			slog.DebugContext(ctx, "no thread subscribers to notify for thread update",
 				"parentMessageID", parentMsgID,
 				"request_id", natsutil.RequestIDFromContext(ctx))
-			return nil
 		}
 		payload, err := sonic.Marshal(&edit)
 		if err != nil {
 			return fmt.Errorf("marshal thread edit event for parent %s: %w", parentMsgID, err)
 		}
-		return h.publishToThreadAccounts(ctx, fanOut, payload, parentMsgID)
+		if err := h.publishToThreadAccounts(ctx, fanOut, payload, parentMsgID); err != nil {
+			return fmt.Errorf("publish thread edit event for parent %s: %w", parentMsgID, err)
+		}
+		h.publishThreadLaneEdit(ctx, room, parentMsgID, edit)
+		return nil
 	case model.RoomTypeDM, model.RoomTypeBotDM:
 		// DM thread replies are visible to every member, so edits fan out to
 		// all members (consistent with handleThreadCreated), not just thread
@@ -433,6 +438,35 @@ func (h *Handler) handleThreadUpdated(ctx context.Context, evt *model.MessageEve
 			"room_id", room.ID,
 			"request_id", natsutil.RequestIDFromContext(ctx))
 		return nil
+	}
+}
+
+// publishThreadLaneEdit sends the encrypted twin of a thread-reply edit on the
+// per-thread lane. Best-effort, like publishThreadLaneCreated.
+//
+// encryptEditedContent does not check h.encrypt itself (unlike
+// encryptRoomEvent), so the guard is explicit here — matching handleUpdated.
+func (h *Handler) publishThreadLaneEdit(ctx context.Context, room *model.Room, parentMsgID string, plain model.EditRoomEvent) { //nolint:gocritic // hugeParam: plain is taken by value so encryptEditedContent's in-place mutation doesn't touch the caller's edit
+	laneEdit := plain
+	if h.encrypt {
+		if err := h.encryptEditedContent(ctx, room.ID, &laneEdit); err != nil {
+			slog.ErrorContext(ctx, "encrypt thread lane edit failed",
+				"error", err, "room_id", room.ID, "parentMessageID", parentMsgID,
+				"request_id", natsutil.RequestIDFromContext(ctx))
+			return
+		}
+	}
+	lanePayload, err := sonic.Marshal(&laneEdit)
+	if err != nil {
+		slog.ErrorContext(ctx, "marshal thread lane edit failed",
+			"error", err, "room_id", room.ID, "parentMessageID", parentMsgID,
+			"request_id", natsutil.RequestIDFromContext(ctx))
+		return
+	}
+	if err := h.publishThreadLaneEvent(ctx, room.ID, parentMsgID, room.CrossSite, room.CrossSiteAt, lanePayload, "thread edit"); err != nil {
+		slog.ErrorContext(ctx, "publish thread lane edit failed",
+			"error", err, "room_id", room.ID, "parentMessageID", parentMsgID,
+			"request_id", natsutil.RequestIDFromContext(ctx))
 	}
 }
 

--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -498,14 +498,21 @@ func (h *Handler) handleThreadDeleted(ctx context.Context, evt *model.MessageEve
 		if err != nil {
 			return fmt.Errorf("channel thread fan-out for thread delete of parent %s: %w", parentMsgID, err)
 		}
+		payload, err := sonic.Marshal(&del)
+		if err != nil {
+			return fmt.Errorf("marshal thread delete event for parent %s: %w", parentMsgID, err)
+		}
 		if len(fanOut) > 0 {
-			payload, err := sonic.Marshal(&del)
-			if err != nil {
-				return fmt.Errorf("marshal thread delete event for parent %s: %w", parentMsgID, err)
-			}
 			if err := h.publishToThreadAccounts(ctx, fanOut, payload, parentMsgID); err != nil {
 				return fmt.Errorf("publish thread delete event for parent %s: %w", parentMsgID, err)
 			}
+		}
+		// Thread lane: DeleteRoomEvent carries no message content, so the same
+		// payload serves both lanes — no encryption, no second marshal.
+		if err := h.publishThreadLaneEvent(ctx, room.ID, parentMsgID, room.CrossSite, room.CrossSiteAt, payload, "thread delete"); err != nil {
+			slog.ErrorContext(ctx, "publish thread lane delete failed",
+				"error", err, "room_id", room.ID, "parentMessageID", parentMsgID,
+				"request_id", natsutil.RequestIDFromContext(ctx))
 		}
 	case model.RoomTypeDM, model.RoomTypeBotDM:
 		// DM thread replies are visible to every member, so deletes fan out to

--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -298,8 +298,10 @@ func (h *Handler) handleThreadCreated(ctx context.Context, evt *model.MessageEve
 		if err != nil {
 			return fmt.Errorf("marshal thread created event for parent %s: %w", parentMsgID, err)
 		}
-		if err := h.publishToThreadAccounts(ctx, fanOut, payload, parentMsgID); err != nil {
-			return fmt.Errorf("publish thread created event for parent %s: %w", parentMsgID, err)
+		if len(fanOut) > 0 {
+			if err := h.publishToThreadAccounts(ctx, fanOut, payload, parentMsgID); err != nil {
+				return fmt.Errorf("publish thread created event for parent %s: %w", parentMsgID, err)
+			}
 		}
 		// Thread lane: same event, encrypted, for viewers who do not follow the
 		// thread. Encrypt a copy AFTER the plaintext publish above —
@@ -422,8 +424,10 @@ func (h *Handler) handleThreadUpdated(ctx context.Context, evt *model.MessageEve
 		if err != nil {
 			return fmt.Errorf("marshal thread edit event for parent %s: %w", parentMsgID, err)
 		}
-		if err := h.publishToThreadAccounts(ctx, fanOut, payload, parentMsgID); err != nil {
-			return fmt.Errorf("publish thread edit event for parent %s: %w", parentMsgID, err)
+		if len(fanOut) > 0 {
+			if err := h.publishToThreadAccounts(ctx, fanOut, payload, parentMsgID); err != nil {
+				return fmt.Errorf("publish thread edit event for parent %s: %w", parentMsgID, err)
+			}
 		}
 		h.publishThreadLaneEdit(ctx, room, parentMsgID, edit)
 		return nil
@@ -995,7 +999,7 @@ func (h *Handler) publishThreadLaneEvent(ctx context.Context, roomID, parentMsgI
 	// and an invented number is worse than none.
 	slog.Log(ctx, logctx.LevelFlow, "broadcast fan-out", "phase", "fanout",
 		"request_id", natsutil.RequestIDFromContext(ctx), "room_id", roomID,
-		"parent_message_id", parentMsgID, "delivery", "thread-lane")
+		"parentMessageID", parentMsgID, "delivery", "thread-lane")
 	return pubErr
 }
 

--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -894,6 +894,36 @@ func (h *Handler) publishRoomEvent(ctx context.Context, roomID string, crossSite
 	return pubErr
 }
 
+// publishThreadLaneEvent fans a channel thread's create/edit/delete out on the
+// per-thread lane, which viewers subscribe to while a thread pane is open.
+//
+// Mirrors publishRoomEvent, not publishToThreadAccounts: this is one subject
+// (two in dual mode), not a per-recipient fan-out, so there is nothing to
+// parallelize and no "all recipients failed" rule to apply. Deliveries are
+// attributed to roomThreadLane because the lane's audience is unobservable —
+// unlike the per-account thread fan-out, whose recipient count is exact.
+//
+// Callers MUST treat a returned error as best-effort: the per-account lane is
+// the delivery guarantee, and failing the handler here would re-fan-out that
+// lane on redelivery.
+func (h *Handler) publishThreadLaneEvent(ctx context.Context, roomID, parentMsgID string, crossSite *bool, crossSiteAt *time.Time, payload []byte, op string) error {
+	labels := broadcastLabels(ctx)
+	ctx = withBroadcastMetricLabels(ctx, roomThreadLane, labels.eventType)
+	now := time.Now().UTC()
+	var pubErr error
+	for _, subj := range subject.ThreadEventTargets(roomID, parentMsgID, crossSite, crossSiteAt, h.routeMode, now) {
+		if err := h.pub.Publish(ctx, subj, payload); err != nil {
+			pubErr = fmt.Errorf("publish %s for thread %s in room %s to %s: %w", op, parentMsgID, roomID, subj, err)
+		}
+	}
+	// No audience figure: the lane's subscriber count is unobservable from here,
+	// and an invented number is worse than none.
+	slog.Log(ctx, logctx.LevelFlow, "broadcast fan-out", "phase", "fanout",
+		"request_id", natsutil.RequestIDFromContext(ctx), "room_id", roomID,
+		"parent_message_id", parentMsgID, "delivery", "thread-lane")
+	return pubErr
+}
+
 // debugFlowFanout emits the flow-rung outcome of a per-recipient fan-out:
 // recipients = individual deliveries attempted in this hop, failed = how many of
 // those errored (delivered = recipients - failed). Metadata only. The room-stream

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -2877,11 +2877,15 @@ func TestHandleThreadUpdated_ChannelRoom_FansOutToFollowers(t *testing.T) {
 	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
-	// bob and carol (followers) + alice (sender) included for multi-device parity
-	require.Len(t, pub.records, 3)
+	// bob and carol (followers) + alice (sender) included for multi-device parity,
+	// plus the thread lane for viewers with the pane open.
+	require.Len(t, pub.records, 4)
 	subjects := map[string]bool{}
 	for _, r := range pub.records {
 		subjects[r.subject] = true
+		if r.subject == "chat.room.r1.thread.parent-1.event" {
+			continue
+		}
 		var roomEvt model.EditRoomEvent
 		require.NoError(t, json.Unmarshal(r.data, &roomEvt))
 		assert.Equal(t, model.RoomEventMessageEdited, roomEvt.Type)
@@ -2895,6 +2899,7 @@ func TestHandleThreadUpdated_ChannelRoom_FansOutToFollowers(t *testing.T) {
 	assert.True(t, subjects[subject.UserRoomEvent("alice")])
 	assert.True(t, subjects[subject.UserRoomEvent("bob")])
 	assert.True(t, subjects[subject.UserRoomEvent("carol")])
+	assert.True(t, subjects["chat.room.r1.thread.parent-1.event"])
 }
 
 func TestHandleThreadUpdated_ChannelExcludesRestrictedAndNonMemberMentions(t *testing.T) {
@@ -3033,6 +3038,130 @@ func TestHandleThreadUpdated_ChannelRoom_GetThreadFollowersError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "thread fan-out")
 	assert.Empty(t, pub.records)
+}
+
+// TestHandleThreadUpdated_ChannelRoom_PublishesThreadLane verifies an edit
+// reaches viewers, so a viewer never sits on stale content a follower has seen
+// corrected.
+func TestHandleThreadUpdated_ChannelRoom_PublishesThreadLane(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{"bob": {}}, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventUpdated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "r1", UserAccount: "alice", Content: "edited reply",
+			CreatedAt: msgTime, EditedAt: &msgTime, UpdatedAt: &msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	var lane *publishRecord
+	for i := range pub.records {
+		if pub.records[i].subject == "chat.room.r1.thread.parent-1.event" {
+			lane = &pub.records[i]
+		}
+	}
+	require.NotNil(t, lane, "thread lane must receive the edit")
+
+	var laneEvt model.EditRoomEvent
+	require.NoError(t, json.Unmarshal(lane.data, &laneEvt))
+	assert.Equal(t, model.RoomEventMessageEdited, laneEvt.Type)
+	assert.Equal(t, "reply-1", laneEvt.MessageID)
+	assert.Equal(t, "edited reply", laneEvt.NewContent, "encryption off: plaintext")
+}
+
+// TestHandleThreadUpdated_ThreadLaneEncrypted verifies the edit's new content is
+// encrypted on the lane and cleared from the plaintext field, while the
+// per-account copy keeps plaintext.
+func TestHandleThreadUpdated_ThreadLaneEncrypted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{"bob": {}}, nil)
+	keyStore.EXPECT().Get(gomock.Any(), "r1").Return(testRoomKey(t), nil).AnyTimes()
+
+	evt := model.MessageEvent{
+		Event: model.EventUpdated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "r1", UserAccount: "alice", Content: "secret edit",
+			CreatedAt: msgTime, EditedAt: &msgTime, UpdatedAt: &msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	var lane, perAccount *publishRecord
+	for i := range pub.records {
+		switch pub.records[i].subject {
+		case "chat.room.r1.thread.parent-1.event":
+			lane = &pub.records[i]
+		case subject.UserRoomEvent("bob"):
+			perAccount = &pub.records[i]
+		}
+	}
+	require.NotNil(t, lane)
+	require.NotNil(t, perAccount)
+
+	assert.NotContains(t, string(lane.data), "secret edit")
+
+	var laneEvt, acctEvt model.EditRoomEvent
+	require.NoError(t, json.Unmarshal(lane.data, &laneEvt))
+	require.NoError(t, json.Unmarshal(perAccount.data, &acctEvt))
+	assert.Empty(t, laneEvt.NewContent, "lane copy must clear plaintext newContent")
+	assert.NotEmpty(t, laneEvt.EncryptedNewContent)
+	assert.Equal(t, "secret edit", acctEvt.NewContent, "per-account copy stays plaintext")
+}
+
+// TestHandleThreadUpdated_DMRoom_NoThreadLane verifies DM edits skip the lane.
+func TestHandleThreadUpdated_DMRoom_NoThreadLane(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	room := &model.Room{ID: "dm1", Type: model.RoomTypeDM, SiteID: "site-a", Accounts: []string{"alice", "bob"}}
+	store.EXPECT().GetRoom(gomock.Any(), "dm1").Return(room, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventUpdated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "dm1", UserAccount: "alice", Content: "edited",
+			CreatedAt: msgTime, EditedAt: &msgTime, UpdatedAt: &msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	for _, r := range pub.records {
+		assert.NotContains(t, r.subject, ".thread.")
+	}
 }
 
 func TestHandleThreadUpdated_DMRoom_FansOutToAllMembers(t *testing.T) {

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -2489,6 +2489,14 @@ func TestHandleThreadCreated_ChannelRoom_NoFollowers_SendsToSenderOnly(t *testin
 	// No other followers → sender still receives their own echo (multi-device
 	// parity), plus the thread lane copy.
 	require.Len(t, pub.records, 2)
+	// Deterministic order: publishToThreadAccounts (records[0], alice's
+	// per-account plaintext publish) blocks on wg.Wait() before returning, and
+	// the thread-lane publish (records[1], encrypted copy) only happens after
+	// that call returns. This ordering is what keeps encryptRoomEvent's
+	// in-place Message = nil from ever reaching the per-account (follower)
+	// copy — pin it explicitly, not just via membership.
+	assert.Equal(t, subject.UserRoomEvent("alice"), pub.records[0].subject)
+	assert.Equal(t, "chat.room.room-1.thread.parent-1.event", pub.records[1].subject)
 	subjects := map[string]bool{}
 	for _, r := range pub.records {
 		subjects[r.subject] = true
@@ -3616,7 +3624,7 @@ func TestHandleThreadCreated_ThreadLaneKeepsMentions(t *testing.T) {
 		Event: model.EventCreated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
 		Message: model.Message{
 			ID: "reply-1", RoomID: "room-1", UserID: "u-alice", UserAccount: "alice",
-			Content: "hey @bob", CreatedAt: msgTime,
+			Content: "hey @all @bob", CreatedAt: msgTime,
 			ThreadParentMessageID: "parent-1", TShow: false,
 		},
 	}
@@ -3636,6 +3644,7 @@ func TestHandleThreadCreated_ThreadLaneKeepsMentions(t *testing.T) {
 	var laneEvt model.RoomEvent
 	require.NoError(t, json.Unmarshal(lane.data, &laneEvt))
 	assert.NotEmpty(t, laneEvt.Mentions, "mentions drive frontend styling and must reach viewers")
+	assert.True(t, laneEvt.MentionAll, "MentionAll must survive on the lane copy alongside Mentions")
 }
 
 // TestHandleThreadCreated_DMRoom_NoThreadLane verifies DM rooms publish nothing
@@ -3708,6 +3717,47 @@ func TestHandleThreadCreated_ThreadLaneFailure_Swallowed(t *testing.T) {
 	}
 	assert.True(t, subjects[subject.UserRoomEvent("alice")], "per-account fan-out must still happen")
 	assert.True(t, subjects[subject.UserRoomEvent("bob")])
+}
+
+// TestHandleThreadCreated_ThreadLaneEncryptFailure_Swallowed verifies an
+// encryption failure on the lane copy neither fails the handler nor blocks
+// the per-account fan-out, and — critically — never falls through to
+// publishing the plaintext copy on the lane subject. encryptRoomEvent's
+// failure must be a hard stop, not a silent downgrade to plaintext.
+func TestHandleThreadCreated_ThreadLaneEncryptFailure_Swallowed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{"bob": {}}, nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"alice"}).Return([]model.User{testUsers[0]}, nil)
+	keyStore.EXPECT().Get(gomock.Any(), "room-1").Return(nil, errors.New("key store down")).AnyTimes()
+
+	evt := model.MessageEvent{
+		Event: model.EventCreated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "room-1", UserID: "u-alice", UserAccount: "alice",
+			Content: "secret thread reply", CreatedAt: msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data), "encrypt failure must not fail the handler")
+
+	subjects := map[string]bool{}
+	for _, r := range pub.records {
+		subjects[r.subject] = true
+	}
+	assert.True(t, subjects[subject.UserRoomEvent("alice")], "per-account fan-out must still happen")
+	assert.True(t, subjects[subject.UserRoomEvent("bob")])
+	assert.False(t, subjects["chat.room.room-1.thread.parent-1.event"],
+		"an encrypt failure must never fall through to publishing plaintext on the lane")
 }
 
 // TestHandleThreadCreated_EmptyFanOut_StillPublishesThreadLane covers a

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -51,6 +51,20 @@ func (m *mockPublisher) Publish(_ context.Context, subj string, data []byte) err
 	return m.failOn[subj]
 }
 
+// labelCapturingPublisher records the room-kind label each Publish call carries
+// on its context, so tests can assert metric attribution without a real meter.
+type labelCapturingPublisher struct {
+	mu   sync.Mutex
+	seen []roomKindLabel
+}
+
+func (p *labelCapturingPublisher) Publish(ctx context.Context, _ string, _ []byte) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.seen = append(p.seen, broadcastLabels(ctx).roomKind)
+	return nil
+}
+
 // stubParentFetcher is a ParentFetcher test double: FetchParent returns a fixed
 // parent (or error) regardless of arguments. The zero value returns an empty
 // ParentMessageInfo — fine for tests that exercise only the follower/sender
@@ -3394,4 +3408,80 @@ func terminalCountFor(t *testing.T, reason string, fn func(context.Context)) int
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(context.Background(), &rm))
 	return sumOf(t, rm, "chat.nats.terminal.failures", map[string]string{"reason": reason})
+}
+
+// TestPublishThreadLaneEvent_GlobalRoom verifies the helper publishes to the
+// global thread subject for a cross-site room.
+func TestPublishThreadLaneEvent_GlobalRoom(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+
+	crossSite := true
+	err := h.publishThreadLaneEvent(context.Background(), "r1", "p1", &crossSite, nil, []byte(`{"type":"new_thread_message"}`), "thread create")
+
+	require.NoError(t, err)
+	require.Len(t, pub.records, 1)
+	assert.Equal(t, "chat.room.r1.thread.p1.event", pub.records[0].subject)
+}
+
+// TestPublishThreadLaneEvent_DualMode verifies both namespaces receive the
+// event for a same-site room in dual mode, matching publishRoomEvent.
+func TestPublishThreadLaneEvent_DualMode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteDual)
+
+	sameSite := false
+	err := h.publishThreadLaneEvent(context.Background(), "r1", "p1", &sameSite, nil, []byte(`{}`), "thread create")
+
+	require.NoError(t, err)
+	require.Len(t, pub.records, 2)
+	assert.Equal(t, "chat.local.room.r1.thread.p1.event", pub.records[0].subject)
+	assert.Equal(t, "chat.room.r1.thread.p1.event", pub.records[1].subject)
+}
+
+// TestPublishThreadLaneEvent_PublishError_ReturnsError verifies a failed target
+// surfaces as an error to the caller, which is responsible for swallowing it.
+func TestPublishThreadLaneEvent_PublishError_ReturnsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{failOn: map[string]error{
+		"chat.room.r1.thread.p1.event": errors.New("nats down"),
+	}}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+
+	crossSite := true
+	err := h.publishThreadLaneEvent(context.Background(), "r1", "p1", &crossSite, nil, []byte(`{}`), "thread create")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "chat.room.r1.thread.p1.event")
+	assert.Len(t, pub.records, 1, "the attempt is still recorded")
+}
+
+// TestPublishThreadLaneEvent_LabelsAsThreadLane verifies deliveries are
+// attributed to the thread_lane kind, not channel (publishRoomEvent's label)
+// and not thread (the per-account fan-out's label, whose fanout/deliveries
+// pair is documented as directly comparable).
+func TestPublishThreadLaneEvent_LabelsAsThreadLane(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &labelCapturingPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+
+	crossSite := true
+	require.NoError(t, h.publishThreadLaneEvent(context.Background(), "r1", "p1", &crossSite, nil, []byte(`{}`), "thread create"))
+
+	require.Len(t, pub.seen, 1)
+	assert.Equal(t, roomThreadLane, pub.seen[0])
 }

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -2883,9 +2883,6 @@ func TestHandleThreadUpdated_ChannelRoom_FansOutToFollowers(t *testing.T) {
 	subjects := map[string]bool{}
 	for _, r := range pub.records {
 		subjects[r.subject] = true
-		if r.subject == "chat.room.r1.thread.parent-1.event" {
-			continue
-		}
 		var roomEvt model.EditRoomEvent
 		require.NoError(t, json.Unmarshal(r.data, &roomEvt))
 		assert.Equal(t, model.RoomEventMessageEdited, roomEvt.Type)
@@ -3134,6 +3131,86 @@ func TestHandleThreadUpdated_ThreadLaneEncrypted(t *testing.T) {
 	assert.Equal(t, "secret edit", acctEvt.NewContent, "per-account copy stays plaintext")
 }
 
+// TestHandleThreadUpdated_ThreadLaneFailure_Swallowed verifies a lane publish
+// failure on the edit path neither fails the handler nor blocks the
+// per-account fan-out, mirroring TestHandleThreadCreated_ThreadLaneFailure_Swallowed.
+// Failing here would NAK the canonical message and re-fan-out the per-account
+// lane, turning one viewer's cosmetic miss into duplicate delivery for everyone.
+func TestHandleThreadUpdated_ThreadLaneFailure_Swallowed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{failOn: map[string]error{
+		"chat.room.r1.thread.parent-1.event": errors.New("nats down"),
+	}}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{"bob": {}}, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventUpdated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "r1", UserAccount: "alice", Content: "edited reply",
+			CreatedAt: msgTime, EditedAt: &msgTime, UpdatedAt: &msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data), "lane failure must not fail the handler")
+
+	subjects := map[string]bool{}
+	for _, r := range pub.records {
+		subjects[r.subject] = true
+	}
+	assert.True(t, subjects[subject.UserRoomEvent("alice")], "per-account fan-out must still happen")
+	assert.True(t, subjects[subject.UserRoomEvent("bob")])
+}
+
+// TestHandleThreadUpdated_ThreadLaneEncryptFailure_Swallowed verifies an
+// encryption failure on the edit lane copy neither fails the handler nor
+// blocks the per-account fan-out, and never falls through to publishing the
+// plaintext edit on the lane subject.
+func TestHandleThreadUpdated_ThreadLaneEncryptFailure_Swallowed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{"bob": {}}, nil)
+	keyStore.EXPECT().Get(gomock.Any(), "r1").Return(nil, errors.New("key store down")).AnyTimes()
+
+	evt := model.MessageEvent{
+		Event: model.EventUpdated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "r1", UserAccount: "alice", Content: "secret edit",
+			CreatedAt: msgTime, EditedAt: &msgTime, UpdatedAt: &msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data), "encrypt failure must not fail the handler")
+
+	subjects := map[string]bool{}
+	for _, r := range pub.records {
+		subjects[r.subject] = true
+	}
+	assert.True(t, subjects[subject.UserRoomEvent("alice")], "per-account fan-out must still happen")
+	assert.True(t, subjects[subject.UserRoomEvent("bob")])
+	assert.False(t, subjects["chat.room.r1.thread.parent-1.event"],
+		"an encrypt failure must never fall through to publishing plaintext on the lane")
+}
+
 // TestHandleThreadUpdated_DMRoom_NoThreadLane verifies DM edits skip the lane.
 func TestHandleThreadUpdated_DMRoom_NoThreadLane(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -3338,6 +3415,60 @@ func TestHandleThreadDeleted_ChannelRoom_WithBadgeUpdate(t *testing.T) {
 	assert.True(t, deleteSubjects[subject.UserRoomEvent("alice")], "delete event must be published to sender for multi-device parity")
 	assert.True(t, deleteSubjects["chat.room.r1.thread.parent-1.event"], "delete event must reach the thread lane")
 	assert.True(t, sawBadge, "badge update must be published to room channel")
+}
+
+// TestHandleThreadDeleted_ThreadLaneFailure_Swallowed verifies a lane publish
+// failure on the delete path neither fails the handler nor blocks the
+// per-account fan-out or the separate thread_metadata_updated badge publish.
+// Failing here would NAK the canonical message and re-fan-out the per-account
+// lane, turning one viewer's cosmetic miss into duplicate delivery for everyone.
+func TestHandleThreadDeleted_ThreadLaneFailure_Swallowed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{failOn: map[string]error{
+		"chat.room.r1.thread.parent-1.event": errors.New("nats down"),
+	}}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	deletedAt := msgTime.Add(time.Minute)
+	tcount := 4
+	survivingTlm := msgTime.Add(-time.Hour)
+
+	room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{"bob": {}}, nil)
+
+	evt := model.MessageEvent{
+		Event:              model.EventDeleted,
+		SiteID:             "site-a",
+		Timestamp:          deletedAt.UnixMilli(),
+		NewTCount:          &tcount,
+		NewThreadLastMsgAt: &survivingTlm,
+		Message: model.Message{
+			ID:                    "reply-1",
+			RoomID:                "r1",
+			UserAccount:           "alice",
+			CreatedAt:             msgTime,
+			UpdatedAt:             &deletedAt,
+			ThreadParentMessageID: "parent-1",
+			TShow:                 false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data), "lane failure must not fail the handler")
+
+	subjects := map[string]bool{}
+	for _, r := range pub.records {
+		subjects[r.subject] = true
+	}
+	assert.True(t, subjects[subject.UserRoomEvent("alice")], "per-account fan-out must still happen")
+	assert.True(t, subjects[subject.UserRoomEvent("bob")])
+	assert.True(t, subjects[subject.RoomEvent("r1", true)],
+		"the separate thread_metadata_updated badge publish must still happen")
 }
 
 func TestHandleThreadDeleted_DMRoom_FansOutToAllMembers(t *testing.T) {

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -3255,8 +3255,9 @@ func TestHandleThreadDeleted_ChannelRoom_FansOutToFollowers(t *testing.T) {
 	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
-	// bob and carol (followers) + alice (sender) included for multi-device parity
-	require.Len(t, pub.records, 3)
+	// bob and carol (followers) + alice (sender) included for multi-device parity,
+	// plus the thread lane copy.
+	require.Len(t, pub.records, 4)
 	subjects := map[string]bool{}
 	for _, r := range pub.records {
 		subjects[r.subject] = true
@@ -3270,6 +3271,7 @@ func TestHandleThreadDeleted_ChannelRoom_FansOutToFollowers(t *testing.T) {
 	assert.True(t, subjects[subject.UserRoomEvent("alice")])
 	assert.True(t, subjects[subject.UserRoomEvent("bob")])
 	assert.True(t, subjects[subject.UserRoomEvent("carol")])
+	assert.True(t, subjects["chat.room.r1.thread.parent-1.event"])
 }
 
 func TestHandleThreadDeleted_ChannelRoom_WithBadgeUpdate(t *testing.T) {
@@ -3311,8 +3313,9 @@ func TestHandleThreadDeleted_ChannelRoom_WithBadgeUpdate(t *testing.T) {
 	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
-	// delete events to bob (follower) + alice (sender, multi-device parity) + 1 badge update (to room channel)
-	require.Len(t, pub.records, 3)
+	// delete events to bob (follower) + alice (sender, multi-device parity) + the
+	// thread lane copy + 1 badge update (to room channel)
+	require.Len(t, pub.records, 4)
 	var sawBadge bool
 	deleteSubjects := map[string]bool{}
 	for _, r := range pub.records {
@@ -3333,6 +3336,7 @@ func TestHandleThreadDeleted_ChannelRoom_WithBadgeUpdate(t *testing.T) {
 	}
 	assert.True(t, deleteSubjects[subject.UserRoomEvent("bob")], "delete event must be published to follower")
 	assert.True(t, deleteSubjects[subject.UserRoomEvent("alice")], "delete event must be published to sender for multi-device parity")
+	assert.True(t, deleteSubjects["chat.room.r1.thread.parent-1.event"], "delete event must reach the thread lane")
 	assert.True(t, sawBadge, "badge update must be published to room channel")
 }
 
@@ -3923,4 +3927,119 @@ func TestHandleThreadCreated_EmptyFanOut_StillPublishesThreadLane(t *testing.T) 
 		}
 	}
 	assert.True(t, found, "an empty per-account fan-out must not suppress the thread lane")
+}
+
+// TestHandleThreadDeleted_ChannelRoom_PublishesThreadLane verifies a delete
+// reaches viewers, so a viewer does not keep rendering a removed reply.
+func TestHandleThreadDeleted_ChannelRoom_PublishesThreadLane(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{"bob": {}}, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventDeleted, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "r1", UserAccount: "alice",
+			CreatedAt: msgTime, UpdatedAt: &msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	var lane *publishRecord
+	for i := range pub.records {
+		if pub.records[i].subject == "chat.room.r1.thread.parent-1.event" {
+			lane = &pub.records[i]
+		}
+	}
+	require.NotNil(t, lane, "thread lane must receive the delete")
+
+	var laneEvt model.DeleteRoomEvent
+	require.NoError(t, json.Unmarshal(lane.data, &laneEvt))
+	assert.Equal(t, model.RoomEventMessageDeleted, laneEvt.Type)
+	assert.Equal(t, "reply-1", laneEvt.MessageID)
+	assert.Equal(t, "parent-1", laneEvt.ThreadParentMessageID)
+}
+
+// TestHandleThreadDeleted_ThreadLaneNotEncrypted verifies the delete payload is
+// identical on both lanes: it carries no message content, so there is nothing
+// to encrypt and no reason to build a second payload.
+func TestHandleThreadDeleted_ThreadLaneNotEncrypted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{"bob": {}}, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventDeleted, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "r1", UserAccount: "alice",
+			CreatedAt: msgTime, UpdatedAt: &msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	var lane, perAccount *publishRecord
+	for i := range pub.records {
+		switch pub.records[i].subject {
+		case "chat.room.r1.thread.parent-1.event":
+			lane = &pub.records[i]
+		case subject.UserRoomEvent("bob"):
+			perAccount = &pub.records[i]
+		}
+	}
+	require.NotNil(t, lane)
+	require.NotNil(t, perAccount)
+	assert.JSONEq(t, string(perAccount.data), string(lane.data),
+		"delete carries no content, so both lanes send the same payload")
+}
+
+// TestHandleThreadDeleted_DMRoom_NoThreadLane verifies DM deletes skip the lane.
+func TestHandleThreadDeleted_DMRoom_NoThreadLane(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	room := &model.Room{ID: "dm1", Type: model.RoomTypeDM, SiteID: "site-a", Accounts: []string{"alice", "bob"}}
+	store.EXPECT().GetRoom(gomock.Any(), "dm1").Return(room, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventDeleted, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "dm1", UserAccount: "alice",
+			CreatedAt: msgTime, UpdatedAt: &msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	for _, r := range pub.records {
+		assert.NotContains(t, r.subject, ".thread.")
+	}
 }

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -2437,8 +2437,8 @@ func TestHandleThreadCreated_ChannelRoom_FansOutToFollowers(t *testing.T) {
 	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
 
-	// bob and carol (followers) + alice (sender) included for multi-device parity
-	require.Len(t, pub.records, 3)
+	// bob and carol (followers) + alice (sender) + the thread lane copy.
+	require.Len(t, pub.records, 4)
 	subjects := map[string]bool{}
 	for _, r := range pub.records {
 		subjects[r.subject] = true
@@ -2451,6 +2451,7 @@ func TestHandleThreadCreated_ChannelRoom_FansOutToFollowers(t *testing.T) {
 	assert.True(t, subjects[subject.UserRoomEvent("alice")])
 	assert.True(t, subjects[subject.UserRoomEvent("bob")])
 	assert.True(t, subjects[subject.UserRoomEvent("carol")])
+	assert.True(t, subjects["chat.room.room-1.thread.parent-1.event"])
 }
 
 func TestHandleThreadCreated_ChannelRoom_NoFollowers_SendsToSenderOnly(t *testing.T) {
@@ -2485,9 +2486,15 @@ func TestHandleThreadCreated_ChannelRoom_NoFollowers_SendsToSenderOnly(t *testin
 
 	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
 	require.NoError(t, h.HandleMessage(context.Background(), data))
-	// No other followers → sender still receives their own echo (multi-device parity).
-	require.Len(t, pub.records, 1)
-	assert.Equal(t, subject.UserRoomEvent("alice"), pub.records[0].subject)
+	// No other followers → sender still receives their own echo (multi-device
+	// parity), plus the thread lane copy.
+	require.Len(t, pub.records, 2)
+	subjects := map[string]bool{}
+	for _, r := range pub.records {
+		subjects[r.subject] = true
+	}
+	assert.True(t, subjects[subject.UserRoomEvent("alice")])
+	assert.True(t, subjects["chat.room.room-1.thread.parent-1.event"])
 }
 
 // Race regression guard: on the first reply thread_rooms may not exist yet, so
@@ -2535,9 +2542,10 @@ func TestHandleThreadCreated_ChannelRoom_ParentAuthorFannedOutBeforeThreadRoomEx
 	for _, r := range pub.records {
 		got[r.subject] = true
 	}
-	require.Len(t, pub.records, 2)
+	require.Len(t, pub.records, 3)
 	assert.True(t, got[subject.UserRoomEvent("alice")], "reply sender receives their own echo")
 	assert.True(t, got[subject.UserRoomEvent("carol")], "parent author receives the reply despite empty replyAccounts")
+	assert.True(t, got["chat.room.room-1.thread.parent-1.event"])
 }
 
 func TestHandleThreadCreated_DMRoom_FansOutToAllMembers(t *testing.T) {
@@ -3484,4 +3492,256 @@ func TestPublishThreadLaneEvent_LabelsAsThreadLane(t *testing.T) {
 
 	require.Len(t, pub.seen, 1)
 	assert.Equal(t, roomThreadLane, pub.seen[0])
+}
+
+// TestHandleThreadCreated_ChannelRoom_PublishesThreadLane verifies a viewer
+// subscribed to the per-thread subject receives the reply, alongside the
+// unchanged per-account fan-out to followers.
+func TestHandleThreadCreated_ChannelRoom_PublishesThreadLane(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{"bob": {}}, nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"alice"}).Return([]model.User{testUsers[0]}, nil)
+
+	evt := model.MessageEvent{
+		Event:     model.EventCreated,
+		SiteID:    "site-a",
+		Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "room-1", UserID: "u-alice", UserAccount: "alice",
+			Content: "a thread reply", CreatedAt: msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	var lane *publishRecord
+	for i := range pub.records {
+		if pub.records[i].subject == "chat.room.room-1.thread.parent-1.event" {
+			lane = &pub.records[i]
+		}
+	}
+	require.NotNil(t, lane, "thread lane must receive the reply")
+
+	var laneEvt model.RoomEvent
+	require.NoError(t, json.Unmarshal(lane.data, &laneEvt))
+	assert.Equal(t, model.RoomEventNewThreadMessage, laneEvt.Type)
+	assert.Equal(t, "room-1", laneEvt.RoomID)
+	require.NotNil(t, laneEvt.Message, "encryption off: content stays plaintext")
+	assert.Equal(t, "reply-1", laneEvt.Message.ID)
+}
+
+// TestHandleThreadCreated_ThreadLaneEncrypted verifies the lane copy is
+// encrypted while the per-account copy stays plaintext, and that the two
+// otherwise agree. The lane rides chat.room.>, which any authenticated user
+// may subscribe to, so plaintext there would be readable by non-members.
+func TestHandleThreadCreated_ThreadLaneEncrypted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{}, nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"alice"}).Return([]model.User{testUsers[0]}, nil)
+	keyStore.EXPECT().Get(gomock.Any(), "room-1").Return(testRoomKey(t), nil).AnyTimes()
+
+	evt := model.MessageEvent{
+		Event: model.EventCreated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "room-1", UserID: "u-alice", UserAccount: "alice",
+			Content: "secret thread reply", CreatedAt: msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	var lane, perAccount *publishRecord
+	for i := range pub.records {
+		switch pub.records[i].subject {
+		case "chat.room.room-1.thread.parent-1.event":
+			lane = &pub.records[i]
+		case subject.UserRoomEvent("alice"):
+			perAccount = &pub.records[i]
+		}
+	}
+	require.NotNil(t, lane)
+	require.NotNil(t, perAccount)
+
+	assert.NotContains(t, string(lane.data), "secret thread reply",
+		"thread-lane payload must not carry plaintext content")
+
+	var laneEvt, acctEvt model.RoomEvent
+	require.NoError(t, json.Unmarshal(lane.data, &laneEvt))
+	require.NoError(t, json.Unmarshal(perAccount.data, &acctEvt))
+	assert.Nil(t, laneEvt.Message, "lane copy carries encryptedMessage, not message")
+	assert.NotEmpty(t, laneEvt.EncryptedMessage)
+	require.NotNil(t, acctEvt.Message, "per-account copy must stay plaintext")
+	assert.Equal(t, "secret thread reply", acctEvt.Message.Content)
+}
+
+// TestHandleThreadCreated_ThreadLaneKeepsMentions verifies mentions survive on
+// the lane copy: the frontend renders them with dedicated styling from this
+// resolved Participant list, so a viewer must see what a follower sees.
+func TestHandleThreadCreated_ThreadLaneKeepsMentions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{}, nil)
+	store.EXPECT().GetHistorySharedSince(gomock.Any(), "room-1", []string{"bob"}).
+		Return(map[string]*time.Time{"bob": nil}, nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).
+		Return([]model.User{testUsers[0], testUsers[1]}, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventCreated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "room-1", UserID: "u-alice", UserAccount: "alice",
+			Content: "hey @bob", CreatedAt: msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	var lane *publishRecord
+	for i := range pub.records {
+		if pub.records[i].subject == "chat.room.room-1.thread.parent-1.event" {
+			lane = &pub.records[i]
+		}
+	}
+	require.NotNil(t, lane)
+
+	var laneEvt model.RoomEvent
+	require.NoError(t, json.Unmarshal(lane.data, &laneEvt))
+	assert.NotEmpty(t, laneEvt.Mentions, "mentions drive frontend styling and must reach viewers")
+}
+
+// TestHandleThreadCreated_DMRoom_NoThreadLane verifies DM rooms publish nothing
+// to the lane: DM thread replies already reach every member, so a lane publish
+// would be pure duplication.
+func TestHandleThreadCreated_DMRoom_NoThreadLane(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "dm-1").Return(metaOf(testDMRoom), nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return([]model.User{testUsers[0]}, nil)
+	store.EXPECT().ListSubscriptions(gomock.Any(), "dm-1").Return(testDMSubs, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventCreated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "dm-1", UserID: "u-alice", UserAccount: "alice",
+			Content: "dm thread reply", CreatedAt: msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	for _, r := range pub.records {
+		assert.NotContains(t, r.subject, ".thread.", "DM rooms must not use the thread lane")
+	}
+}
+
+// TestHandleThreadCreated_ThreadLaneFailure_Swallowed verifies a lane publish
+// failure neither fails the handler nor blocks the per-account fan-out. Failing
+// here would NAK the canonical message and re-fan-out the per-account lane,
+// turning one viewer's cosmetic miss into duplicate delivery for everyone.
+func TestHandleThreadCreated_ThreadLaneFailure_Swallowed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{failOn: map[string]error{
+		"chat.room.room-1.thread.parent-1.event": errors.New("nats down"),
+	}}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{"bob": {}}, nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"alice"}).Return([]model.User{testUsers[0]}, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventCreated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "room-1", UserID: "u-alice", UserAccount: "alice",
+			Content: "a thread reply", CreatedAt: msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data), "lane failure must not fail the handler")
+
+	subjects := map[string]bool{}
+	for _, r := range pub.records {
+		subjects[r.subject] = true
+	}
+	assert.True(t, subjects[subject.UserRoomEvent("alice")], "per-account fan-out must still happen")
+	assert.True(t, subjects[subject.UserRoomEvent("bob")])
+}
+
+// TestHandleThreadCreated_EmptyFanOut_StillPublishesThreadLane covers a
+// bot-authored reply: threadFanOutAccounts drops bots, so the per-account set
+// is empty, but a viewer with the pane open must still receive the reply.
+func TestHandleThreadCreated_EmptyFanOut_StillPublishesThreadLane(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{}, nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	evt := model.MessageEvent{
+		Event: model.EventCreated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "room-1", UserAccount: "helper.bot", Content: "bot reply",
+			CreatedAt: msgTime, ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	var found bool
+	for _, r := range pub.records {
+		if r.subject == "chat.room.room-1.thread.parent-1.event" {
+			found = true
+		}
+	}
+	assert.True(t, found, "an empty per-account fan-out must not suppress the thread lane")
 }

--- a/broadcast-worker/nats_metrics.go
+++ b/broadcast-worker/nats_metrics.go
@@ -15,14 +15,15 @@ import (
 type roomKindLabel string
 
 const (
-	roomChannel roomKindLabel = "channel"
-	roomDM      roomKindLabel = "dm"
-	roomBotDM   roomKindLabel = "bot_dm"
-	roomThread  roomKindLabel = "thread"
-	roomUnknown roomKindLabel = "unknown"
+	roomChannel    roomKindLabel = "channel"
+	roomDM         roomKindLabel = "dm"
+	roomBotDM      roomKindLabel = "bot_dm"
+	roomThread     roomKindLabel = "thread"
+	roomThreadLane roomKindLabel = "thread_lane"
+	roomUnknown    roomKindLabel = "unknown"
 )
 
-var allRoomKinds = []roomKindLabel{roomChannel, roomDM, roomBotDM, roomThread, roomUnknown}
+var allRoomKinds = []roomKindLabel{roomChannel, roomDM, roomBotDM, roomThread, roomThreadLane, roomUnknown}
 
 type deliveryResult string
 
@@ -52,6 +53,9 @@ type deliveryKey struct {
 // records one attempt. Per-recipient delivery evidence for channels comes from
 // the loadgen recipient observer, not from these counters. For DM, bot-DM, and
 // thread fan-out the two are directly comparable — one publish per recipient.
+// thread_lane is one publish to a subject whose subscribers the publisher
+// cannot enumerate, so it records deliveries only — like the channel
+// room-stream case, its two families are NOT a ratio.
 type broadcastMetrics struct {
 	fanout       metric.Int64Histogram
 	deliveries   metric.Int64Counter
@@ -103,7 +107,7 @@ var allBroadcastEvents = []natsmetrics.EventType{
 
 func normalizeRoomKind(value roomKindLabel) roomKindLabel {
 	switch value {
-	case roomChannel, roomDM, roomBotDM, roomThread:
+	case roomChannel, roomDM, roomBotDM, roomThread, roomThreadLane:
 		return value
 	default:
 		return roomUnknown

--- a/broadcast-worker/nats_metrics_test.go
+++ b/broadcast-worker/nats_metrics_test.go
@@ -137,3 +137,23 @@ func TestBroadcastMetrics_Record_NilReceiverIsSafe(t *testing.T) {
 	metrics.Fanout(context.Background(), roomChannel, natsmetrics.EventCreated, 1)
 	metrics.Delivery(context.Background(), roomChannel, natsmetrics.EventCreated, nil)
 }
+
+// TestNormalizeRoomKind_ThreadLane guards the closed-enum contract: a room kind
+// missing from normalizeRoomKind's whitelist silently collapses to "unknown",
+// which would send every thread-lane delivery to the wrong series.
+func TestNormalizeRoomKind_ThreadLane(t *testing.T) {
+	assert.Equal(t, roomThreadLane, normalizeRoomKind(roomThreadLane))
+	assert.Contains(t, allRoomKinds, roomThreadLane,
+		"thread_lane must be in allRoomKinds or its measurement options are never pre-built")
+	assert.Equal(t, roomKindLabel("thread_lane"), roomThreadLane)
+}
+
+// TestThreadLaneLabelsSurviveContext verifies the label round-trips through the
+// context the publisher decorator reads, so Delivery is recorded under
+// thread_lane rather than unknown.
+func TestThreadLaneLabelsSurviveContext(t *testing.T) {
+	ctx := withBroadcastMetricLabels(context.Background(), roomThreadLane, natsmetrics.EventCreated)
+	labels := broadcastLabels(ctx)
+	assert.Equal(t, roomThreadLane, labels.roomKind)
+	assert.Equal(t, natsmetrics.EventCreated, labels.eventType)
+}

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -175,6 +175,7 @@ Permissions and connection limits come from the auth-service account's scoped si
 
 - `chat.user.{account}.>` — captures every personal event including async replies, per-user room events (DM messages, edits, deletes), room-key events, subscription updates, and settings updates.
 - the room-event subject for each channel room in the user's sidebar — receives new messages plus edit/delete events for that channel. Pick the subject by the room's `crossSite` flag (from `subscription.list`): `chat.room.{roomID}.event` when `crossSite: true`, `chat.local.room.{roomID}.event` when `crossSite: false`. **Absent/unknown `crossSite` defaults to the global `chat.room.{roomID}.event`** (fail-safe — a global room misrouted to the local subject would silently miss cross-site delivery).
+- `chat.room.{roomID}.thread.{parentMessageId}.event` (or `chat.local.room.…`, by `crossSite`) — subscribe only while a thread pane is open, for a channel room's per-thread viewer lane; see [§4.2 Thread Viewer Lane](#42-thread-viewer-lane).
 
 The exact event subjects a client may receive as a result of an RPC are listed under each method's "Triggered events" sections in §2.2, §3, and §4.
 
@@ -6369,7 +6370,7 @@ Delivered on `chat.user.{account}.response.{requestId}`. See [Error envelope](#6
 
 #### Triggered events — success path
 
-After a successful send, `broadcast-worker` fans out a `RoomEvent`. The subject depends on room type. A thread reply (`threadParentMessageId` set) publishes `type: "new_thread_message"` instead of `"new_message"` — same `RoomEvent` shape but a **different delivery path** (per-subscriber on `chat.user.{account}.event.room`, not the room subject), see [events.md#new_thread_message-roomevent](client-api/events.md#new_thread_message-roomevent). For a channel-room thread reply (`tshow` false), the same event is **also** published on the per-thread viewer lane described in [§4.2 Thread Viewer Lane](#42-thread-viewer-lane); a follower with the thread pane open receives both copies and must deduplicate by `message.id`. **A `botDM` fans out to its human participant, not the bot:** `broadcast-worker` handles `botDM` via the same DM path (`publishDMEvents`) — it publishes the `RoomEvent` to each **non-bot** member on `chat.user.{account}.event.room` and skips the bot account (`isBot`). This applies to both an ordinary `new_message` and a thread reply's `new_thread_message`. (The bot side consumes messages through a separate backend path.)
+After a successful send, `broadcast-worker` fans out a `RoomEvent`. The subject depends on room type. A `tshow: false` thread reply (`threadParentMessageId` set) publishes `type: "new_thread_message"` instead of `"new_message"` — same `RoomEvent` shape but a **different delivery path** (per-subscriber on `chat.user.{account}.event.room`, not the room subject), see [events.md#new_thread_message-roomevent](client-api/events.md#new_thread_message-roomevent). A `tshow: true` thread reply instead goes through the same `publishChannelEvent` path as an ordinary message and publishes `type: "new_message"` on the room subject. For a channel-room `tshow: false` thread reply, the `new_thread_message` event is **also** published on the per-thread viewer lane described in [§4.2 Thread Viewer Lane](#42-thread-viewer-lane); a follower with the thread pane open receives both copies and must deduplicate by `message.id`. **A `botDM` fans out to its human participant, not the bot:** `broadcast-worker` handles `botDM` via the same DM path (`publishDMEvents`) — it publishes the `RoomEvent` to each **non-bot** member on `chat.user.{account}.event.room` and skips the bot account (`isBot`). This applies to both an ordinary `new_message` and a thread reply's `new_thread_message`. (The bot side consumes messages through a separate backend path.)
 
 **1. For channel rooms — `chat.room.{roomID}.event`** (`publishChannelEvent`)
 
@@ -6617,6 +6618,12 @@ the `chat.room.` or `chat.local.room.` prefix from the room's `crossSite` value 
 state — subscribing does **not** make you a thread follower, does not create a thread subscription,
 does not accrue unread, and does not place the thread in your thread list. Closing the pane ends
 delivery.
+
+**The lane carries only `tshow: false` thread replies.** A `tshow: true` reply — plus its edits and
+deletes — never publishes here: it goes through `publishChannelEvent` and arrives on the room
+subject `chat.room.{roomID}.event` as an ordinary `new_message`/`message_edited`/`message_deleted`
+event instead. A client rendering the pane from the lane alone will silently drop `tshow: true`
+replies in a mixed thread — it must also merge matching events from the room subject.
 
 ---
 

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -3391,6 +3391,11 @@ An `EditRoomEvent` is fanned out by `broadcast-worker`. The subject depends on r
 - **Channel rooms — `chat.room.{roomID}.event`** — one publish to the room stream.
 - **DM/botDM rooms — `chat.user.{recipient}.event.room`** — published once per non-bot member.
 
+**Thread-reply edits (channel rooms, `threadParentMessageId` set, `tshow` false) also publish on
+the per-thread viewer lane** — see [§4.2 Thread Viewer Lane](#42-thread-viewer-lane) — in addition
+to the per-subscriber subject above. The thread-lane copy carries `encryptedNewContent` instead of
+`newContent` when room encryption is enabled.
+
 The payload is flat (no zero-valued room fields):
 
 | Field | Type | Notes |
@@ -3488,6 +3493,11 @@ A `DeleteRoomEvent` is fanned out by `broadcast-worker` (not published when the 
 - **Thread reply (TShow=false) in a channel** — `chat.user.{recipient}.event.room` — published once per thread subscriber (followers + @-mentioned accounts). Non-subscribers do not receive this event.
 - **Thread reply (TShow=true) in a channel** — `chat.room.{roomID}.event` — visible in the main channel, so the full room stream receives it.
 - **DM/botDM message — `chat.user.{recipient}.event.room`** — published once per non-bot member.
+
+**Thread reply (TShow=false) in a channel also publishes on the per-thread viewer lane** — see
+[§4.2 Thread Viewer Lane](#42-thread-viewer-lane) — in addition to the per-subscriber subject
+above. `DeleteRoomEvent` carries no message content, so this lane copy is **not encrypted** — the
+same payload serves both lanes.
 
 The payload is flat:
 
@@ -6359,7 +6369,7 @@ Delivered on `chat.user.{account}.response.{requestId}`. See [Error envelope](#6
 
 #### Triggered events — success path
 
-After a successful send, `broadcast-worker` fans out a `RoomEvent`. The subject depends on room type. A thread reply (`threadParentMessageId` set) publishes `type: "new_thread_message"` instead of `"new_message"` — same `RoomEvent` shape but a **different delivery path** (per-subscriber on `chat.user.{account}.event.room`, not the room subject), see [events.md#new_thread_message-roomevent](client-api/events.md#new_thread_message-roomevent). **A `botDM` fans out to its human participant, not the bot:** `broadcast-worker` handles `botDM` via the same DM path (`publishDMEvents`) — it publishes the `RoomEvent` to each **non-bot** member on `chat.user.{account}.event.room` and skips the bot account (`isBot`). This applies to both an ordinary `new_message` and a thread reply's `new_thread_message`. (The bot side consumes messages through a separate backend path.)
+After a successful send, `broadcast-worker` fans out a `RoomEvent`. The subject depends on room type. A thread reply (`threadParentMessageId` set) publishes `type: "new_thread_message"` instead of `"new_message"` — same `RoomEvent` shape but a **different delivery path** (per-subscriber on `chat.user.{account}.event.room`, not the room subject), see [events.md#new_thread_message-roomevent](client-api/events.md#new_thread_message-roomevent). For a channel-room thread reply (`tshow` false), the same event is **also** published on the per-thread viewer lane described in [§4.2 Thread Viewer Lane](#42-thread-viewer-lane); a follower with the thread pane open receives both copies and must deduplicate by `message.id`. **A `botDM` fans out to its human participant, not the bot:** `broadcast-worker` handles `botDM` via the same DM path (`publishDMEvents`) — it publishes the `RoomEvent` to each **non-bot** member on `chat.user.{account}.event.room` and skips the bot account (`isBot`). This applies to both an ordinary `new_message` and a thread reply's `new_thread_message`. (The bot side consumes messages through a separate backend path.)
 
 **1. For channel rooms — `chat.room.{roomID}.event`** (`publishChannelEvent`)
 
@@ -6554,6 +6564,59 @@ Pushed by `broadcast-worker` whenever a thread reply is **created** (`action: "r
 #### Client handling
 
 Apply `newTcount` directly to the parent message's badge — do not compute a delta. Apply `newThreadLastMsgAt` to the parent message's thread-freshness timestamp (or clear it when absent). Events for the same parent may arrive out of order due to JetStream redelivery; when `eventTimestamp` is present, prefer the event with the larger `eventTimestamp`. Fall back to `timestamp` only for legacy events that omit `eventTimestamp`.
+
+---
+
+## 4.2 Thread Viewer Lane
+
+A dedicated per-thread NATS subject that lets any channel-room member see a thread's replies,
+edits, and deletes live while its pane is open — without becoming a thread follower. **Channel
+rooms only**; DM and botDM rooms already deliver every thread event to every member and do not use
+this lane.
+
+#### Subjects
+
+| Room type | Subject |
+|-----------|---------|
+| Channel | `chat.room.{roomID}.thread.{parentMessageId}.event` (or `chat.local.room.{roomID}.thread.{parentMessageId}.event` for same-site rooms, by `crossSite`) |
+| DM / botDM | Not used. |
+
+Choose the `chat.room.` / `chat.local.room.` prefix from the room's `crossSite` value exactly as
+for `chat.room.{roomID}.event`.
+
+#### Delivery model
+
+`new_thread_message`, `message_edited`, and `message_deleted` for a channel thread reply
+(`threadParentMessageId` set, `tshow` false) each publish on **two lanes**:
+
+1. **Per-subscriber**, on `chat.user.{account}.event.room` — the reply sender, the parent-message
+   author, thread followers, and history-gated @-mentioned accounts. Plaintext.
+2. **Per-thread**, on the subject above — any subscribed client, follower or not, while the pane is
+   open.
+
+| Event | Thread-lane encryption |
+|---|---|
+| `new_thread_message` | Goes through the same room-key encryption as `new_message` (`encryptedMessage` set, `message` nil) when room encryption is enabled. |
+| `message_edited` | Goes through the same encryption as a channel edit (`encryptedNewContent` set, `newContent` empty) when room encryption is enabled. |
+| `message_deleted` | Carries no message content, so the lane copy is **not encrypted** — the same payload serves both lanes. |
+
+The per-subscriber copy always stays plaintext regardless of encryption settings — only the
+thread-lane copy is encrypted. `mentions` and `mentionAll` are retained on the thread-lane copy of
+`new_thread_message`, identical to the per-subscriber copy — the frontend renders mentions from
+this resolved participant list, so a viewer's pane must match a follower's.
+
+**A follower who opens the thread receives each event on both lanes.** This is required regardless
+of the lane, since delivery is at-least-once: clients must deduplicate by `message.id` (create) or
+`messageId` (edit/delete), never append blindly.
+
+#### Subscribing to a thread
+
+Opening a thread pane: subscribe to `chat.room.{roomID}.thread.{parentMessageId}.event`, choosing
+the `chat.room.` or `chat.local.room.` prefix from the room's `crossSite` value exactly as for
+`chat.room.{roomID}.event`. Closing the pane: unsubscribe. There is no RPC and no server-side
+state — subscribing does **not** make you a thread follower, does not create a thread subscription,
+does not accrue unread, and does not place the thread in your thread list. Closing the pane ends
+delivery.
 
 ---
 

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -50,7 +50,7 @@ For connection, auth, and error details see [../client-api.md](../client-api.md)
 | `chat.user.{account}.event.room.key` | RoomKeyEvent |
 | `chat.room.{roomID}.event` | new_message, message_edited, message_deleted, message_pinned/unpinned, message_reacted, thread_metadata_updated, message_read, thread_message_read, room_renamed, room_restricted |
 | `chat.user.{account}.event.room` | same event types as above (per-user fan-out for DM/botDM rooms); **plus `new_thread_message`** — channel thread replies fan out per-subscriber on this subject, not the room subject |
-| `chat.room.{roomID}.thread.{parentMessageId}.event` (or `chat.local.room.…`, by `crossSite`) | new_thread_message, message_edited, message_deleted — **channel rooms only**; subscribe while a thread pane is open |
+| `chat.room.{roomID}.thread.{parentMessageId}.event` (or `chat.local.room.…`, by `crossSite`) | new_thread_message, message_edited, message_deleted for `tshow: false` replies only — **channel rooms only**; subscribe while a thread pane is open. `tshow: true` replies (and their edits/deletes) never reach this lane — they arrive as ordinary new_message/message_edited/message_deleted on `chat.room.{roomID}.event`, which the pane must also merge from. |
 | `chat.room.{roomID}.event.member` (or `chat.local.room.{roomID}.event.member` for same-site rooms, by `crossSite`) | member_added, member_left / member_removed |
 | `chat.user.{account}.notification` | NotificationEvent (reaction only) |
 | `chat.user.presence.state.{account}` | PresenceState |

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -50,6 +50,7 @@ For connection, auth, and error details see [../client-api.md](../client-api.md)
 | `chat.user.{account}.event.room.key` | RoomKeyEvent |
 | `chat.room.{roomID}.event` | new_message, message_edited, message_deleted, message_pinned/unpinned, message_reacted, thread_metadata_updated, message_read, thread_message_read, room_renamed, room_restricted |
 | `chat.user.{account}.event.room` | same event types as above (per-user fan-out for DM/botDM rooms); **plus `new_thread_message`** — channel thread replies fan out per-subscriber on this subject, not the room subject |
+| `chat.room.{roomID}.thread.{parentMessageId}.event` (or `chat.local.room.…`, by `crossSite`) | new_thread_message, message_edited, message_deleted — **channel rooms only**; subscribe while a thread pane is open |
 | `chat.room.{roomID}.event.member` (or `chat.local.room.{roomID}.event.member` for same-site rooms, by `crossSite`) | member_added, member_left / member_removed |
 | `chat.user.{account}.notification` | NotificationEvent (reaction only) |
 | `chat.user.presence.state.{account}` | PresenceState |
@@ -486,11 +487,23 @@ is set. Thread edits/deletes still publish `message_edited` / `message_deleted`;
 create event gets the distinct type.
 
 **Delivery differs from `new_message`.** A channel thread reply is **not** published room-wide on
-`chat.room.{roomID}.event`; it fans out **per-subscriber** on `chat.user.{account}.event.room` to the
-reply sender, the parent-message author, thread followers (anyone who has replied in the thread), and
-history-gated @-mentioned accounts. DM/botDM thread replies fan out **per member** on the same
-`chat.user.{account}.event.room` subject — the bot account is skipped (`isBot`), same as an ordinary
-`new_message` in a botDM.
+`chat.room.{roomID}.event`. It travels two lanes:
+
+1. **Per-subscriber**, on `chat.user.{account}.event.room`, to the reply sender, the parent-message
+   author, thread followers (anyone who has replied in the thread), and history-gated @-mentioned
+   accounts. Plaintext.
+2. **Per-thread**, on `chat.room.{roomID}.thread.{parentMessageId}.event` (or
+   `chat.local.room.{roomID}.thread.{parentMessageId}.event`, by `crossSite`), for clients that
+   subscribe while the thread pane is open — including users who do not follow the thread.
+   Encrypted with the room key when room encryption is enabled, exactly like `new_message` on the
+   room lane. `mentions` / `mentionAll` are retained on this copy, identical to the per-subscriber
+   copy.
+
+A follower who has the thread open receives the event on **both** lanes. Deduplicate by
+`message.id` — required regardless, since delivery is at-least-once.
+
+DM/botDM thread replies fan out **per member** on `chat.user.{account}.event.room` and do **not**
+use the thread lane; every member already receives them. The bot account is skipped (`isBot`).
 
 | Field | Type | Notes |
 |---|---|---|
@@ -537,6 +550,13 @@ Flat event — no zero-valued `RoomEvent` base fields. Triggered by
 
 **Subjects:** channel rooms → `chat.room.{roomID}.event`; DM/botDM rooms →
 `chat.user.{recipient}.event.room` per non-bot member.
+
+**Thread-reply edits (channel rooms, `threadParentMessageId` set, `tshow` false) also publish on
+the per-thread lane** — `chat.room.{roomID}.thread.{parentMessageId}.event` (or
+`chat.local.room.…`, by `crossSite`) — for clients with the thread pane open, in addition to the
+subject above. The thread-lane copy carries `encryptedNewContent` instead of `newContent` when room
+encryption is enabled. A thread follower with the pane open receives both copies; deduplicate by
+`messageId`.
 
 | Field | Type | Notes |
 |---|---|---|
@@ -590,6 +610,13 @@ Flat event. Triggered by [Delete Message](request-reply.md#delete-message).
 
 Thread-reply deletes **additionally** emit a
 [`thread_metadata_updated`](#thread_metadata_updated-threadmetadataupdatedevent) event.
+
+**Thread-reply deletes (channel rooms, `threadParentMessageId` set, `tshow` false) also publish on
+the per-thread lane** — `chat.room.{roomID}.thread.{parentMessageId}.event` (or
+`chat.local.room.…`, by `crossSite`) — for clients with the thread pane open, in addition to the
+per-subscriber subject above. `DeleteRoomEvent` carries no message content, so this lane copy is
+**not encrypted** — the same payload serves both lanes. A thread follower with the pane open
+receives both copies; deduplicate by `messageId`.
 
 | Field | Type | Notes |
 |---|---|---|

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -1108,7 +1108,7 @@ Only the original sender may edit.
 `"only the sender can edit"` (`forbidden`), `"message not found"` (`not_found`),
 `"newMsg must not be empty"`, `"newMsg exceeds maximum size"`.
 
-**Emits:** [`message_edited`](events.md#message_edited-editroomevent) → [events.md](events.md)
+**Emits:** [`message_edited`](events.md#message_edited-editroomevent) — a channel thread-reply edit (`threadParentMessageId` set, `tshow` false) also publishes on the [per-thread viewer lane](../client-api.md#42-thread-viewer-lane), `encryptedNewContent` in place of `newContent` when room encryption is enabled → [events.md](events.md)
 
 ---
 
@@ -1136,7 +1136,7 @@ Soft-delete (row preserved for audit). Only the original sender may delete. Idem
 
 `"only the sender can delete"` (`forbidden`), `"message not found"` (`not_found`).
 
-**Emits:** [`message_deleted`](events.md#message_deleted-deleteroomevent), [`thread_metadata_updated`](events.md#thread_metadata_updated-threadmetadataupdatedevent) (thread replies only) → [events.md](events.md)
+**Emits:** [`message_deleted`](events.md#message_deleted-deleteroomevent) — a channel thread-reply delete (`threadParentMessageId` set, `tshow` false) also publishes on the [per-thread viewer lane](../client-api.md#42-thread-viewer-lane), unencrypted since the delete event carries no content, [`thread_metadata_updated`](events.md#thread_metadata_updated-threadmetadataupdatedevent) (thread replies only) → [events.md](events.md)
 
 ---
 
@@ -2276,7 +2276,7 @@ error table. Key errors:
 - `"not subscribed"` (`forbidden`, `not_subscribed`)
 - `"posting is restricted to owners and admins in this room"` (`forbidden`, `large_room_post_restricted`)
 
-**Emits:** [`new_message`](events.md#new_message-roomevent) `RoomEvent` (channel: `chat.room.{roomID}.event`; DM: `chat.user.{recipient}.event.room` per non-bot member), [`thread_metadata_updated`](events.md#thread_metadata_updated-threadmetadataupdatedevent) (thread replies only) → [events.md](events.md)
+**Emits:** [`new_message`](events.md#new_message-roomevent) `RoomEvent` (channel: `chat.room.{roomID}.event`; DM: `chat.user.{recipient}.event.room` per non-bot member) — a thread reply (`threadParentMessageId` set) carries `type: "new_thread_message"` instead, delivered per-subscriber on `chat.user.{account}.event.room`, and for a channel-room reply (`tshow` false) **also** on the [per-thread viewer lane](../client-api.md#42-thread-viewer-lane) (`chat.room.{roomID}.thread.{parentMessageId}.event`, encrypted when room encryption is enabled) — a follower with the pane open gets both copies and must dedupe by `message.id`; [`thread_metadata_updated`](events.md#thread_metadata_updated-threadmetadataupdatedevent) (thread replies only) → [events.md](events.md)
 
 ---
 

--- a/docs/superpowers/plans/2026-08-23-thread-viewer-lane.md
+++ b/docs/superpowers/plans/2026-08-23-thread-viewer-lane.md
@@ -1,0 +1,1401 @@
+# Thread Viewer Lane Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish channel thread replies, edits, and deletes to a per-thread NATS subject so a user who opens a thread they never participated in receives them live, without becoming a thread follower.
+
+**Architecture:** `broadcast-worker`'s three channel thread handlers each gain one additional publish to a new `chat.{local.,}room.{roomID}.thread.{parentMessageId}.event` subject, carrying the encrypted equivalent of the payload already sent per-account to followers. The existing per-account lane is untouched. No new persisted state, no new RPC, no NATS permission change — clients already hold a wildcard `chat.room.>` subscribe grant, and the client subscribes on thread open and unsubscribes on close.
+
+**Tech Stack:** Go 1.25, NATS core (`nats.go`), `sonic` JSON codec, `go.uber.org/mock`, `testify`, OpenTelemetry metrics.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-thread-viewer-lane-design.md`
+
+## Global Constraints
+
+- **TDD is mandatory.** Red → Green → Refactor → Commit. Never write implementation before its failing test exists. (CLAUDE.md §4)
+- **Never run raw `go` commands.** Use `make` targets only: `make test SERVICE=<name>`, `make lint`, `make fmt`, `make generate`, `make sast`. (CLAUDE.md §2)
+- **Always `-race`.** The `make test` target already supplies it.
+- **Error wrapping:** `fmt.Errorf("short description: %w", err)` describing what the *current* function was doing. Never bare `err`, never `fmt.Errorf("error: %w", err)`.
+- **Logging:** `log/slog` only, structured key-value fields, never interpolated strings. Never log message content, tokens, or passwords.
+- **Subjects:** built only via `pkg/subject` builders, never inline `fmt.Sprintf`. (CLAUDE.md §6)
+- **Coverage floor:** 80% minimum; 90%+ target for handlers and `pkg/`.
+- **Test package:** tests live in the same package (`package main` for services, `package subject_test` where the existing file already does so).
+- **Commit after each task**, only once that task's tests pass. Pre-commit hooks run lint and tests.
+- **Branch:** `claude/thread-metadata-event-5065r0`. Never push elsewhere.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `pkg/subject/subject.go` | Subject construction + routing | Add `ThreadEvent`, `ThreadEventTargets` |
+| `pkg/subject/subject_test.go` | Subject unit tests | Add routing matrix tests |
+| `broadcast-worker/nats_metrics.go` | Metric label enums + publisher decorator | Add `roomThreadLane` kind |
+| `broadcast-worker/nats_metrics_test.go` | Metric label tests | Add normalization test |
+| `broadcast-worker/handler.go` | All fan-out logic | Add `publishThreadLaneEvent`; wire into 3 handlers |
+| `broadcast-worker/handler_test.go` | Handler unit tests | New tests + fix 6 existing count assertions |
+| `.semgrep/room-subject.yml` | Subject-routing guard rule | Add `subject.ThreadEvent` |
+| `docs/client-api.md` | Canonical client API doc | New subject + delivery notes |
+| `docs/client-api/events.md` | Derived events view | Mirror |
+| `docs/client-api/request-reply.md` | Derived RPC view | Mirror |
+
+**Two findings the spec did not anticipate — both are handled below, do not skip them:**
+
+1. **Six existing tests assert exact publish counts** and WILL fail when a fourth publish appears. The spec's claim that "every existing thread test must pass untouched" is wrong. Each is updated in the task that breaks it, with the count change justified in the diff.
+2. **`handleThreadCreated` and `handleThreadUpdated` early-return when the fan-out set is empty** (`handler.go:263`, `handler.go:380`), before any payload is built. A bot-authored thread reply produces an empty fan-out (`threadFanOutAccounts` skips bots via `isBot`), so without a fix a viewer watching a bot reply would receive nothing. Tasks 4 and 5 remove those early returns.
+
+---
+
+## Task 1: Subject builders
+
+**Files:**
+- Modify: `pkg/subject/subject.go` (add after `RoomMemberEventTargets`, around line 462)
+- Test: `pkg/subject/subject_test.go`
+
+**Interfaces:**
+- Consumes: existing unexported `roomBase(roomID string, global bool) string` (`subject.go:155`) and `roomRouteGlobals(crossSite *bool, crossSiteAt *time.Time, mode RoomRouteMode, now time.Time) []bool` (`subject.go:421`).
+- Produces:
+  - `subject.ThreadEvent(roomID, parentMessageID string, global bool) string`
+  - `subject.ThreadEventTargets(roomID, parentMessageID string, crossSite *bool, crossSiteAt *time.Time, mode RoomRouteMode, now time.Time) []string`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `pkg/subject/subject_test.go`:
+
+```go
+func TestThreadEvent(t *testing.T) {
+	assert.Equal(t, "chat.room.r1.thread.p1.event", subject.ThreadEvent("r1", "p1", true))
+	assert.Equal(t, "chat.local.room.r1.thread.p1.event", subject.ThreadEvent("r1", "p1", false))
+}
+
+// TestThreadEventTargets verifies the thread lane routes on exactly the same
+// namespaces as RoomEventTargets — they share roomRouteGlobals, so a same-site
+// room's thread events land on the local namespace once local mode is enabled.
+func TestThreadEventTargets(t *testing.T) {
+	g := "chat.room.r1.thread.p1.event"
+	l := "chat.local.room.r1.thread.p1.event"
+	trueP, falseP := true, false
+	now := time.Unix(1_700_000_000, 0).UTC()
+
+	// cross-site rooms with no flip time (born cross-site) are ALWAYS global.
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", &trueP, nil, subject.RouteGlobal, now))
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", &trueP, nil, subject.RouteDual, now))
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", &trueP, nil, subject.RouteLocal, now))
+
+	// same-site rooms vary by mode.
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", &falseP, nil, subject.RouteGlobal, now))
+	assert.Equal(t, []string{l, g}, subject.ThreadEventTargets("r1", "p1", &falseP, nil, subject.RouteDual, now))
+	assert.Equal(t, []string{l}, subject.ThreadEventTargets("r1", "p1", &falseP, nil, subject.RouteLocal, now))
+
+	// nil locality is ALWAYS global — the fail-safe.
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", nil, nil, subject.RouteGlobal, now))
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", nil, nil, subject.RouteDual, now))
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", nil, nil, subject.RouteLocal, now))
+}
+
+// TestThreadEventTargets_TransitionGrace covers the post-flip grace window: a
+// room that just flipped same-site -> cross-site keeps a LOCAL copy for the
+// window in local/dual mode, so members still on the local subject don't go
+// dark on thread events until they re-subscribe.
+func TestThreadEventTargets_TransitionGrace(t *testing.T) {
+	g := "chat.room.r1.thread.p1.event"
+	l := "chat.local.room.r1.thread.p1.event"
+	trueP := true
+	flip := time.Unix(1_700_000_000, 0).UTC()
+	within := flip.Add(subject.DefaultRoomLocalityGrace - time.Minute)
+	after := flip.Add(subject.DefaultRoomLocalityGrace + time.Minute)
+
+	assert.Equal(t, []string{l, g}, subject.ThreadEventTargets("r1", "p1", &trueP, &flip, subject.RouteLocal, within))
+	assert.Equal(t, []string{l, g}, subject.ThreadEventTargets("r1", "p1", &trueP, &flip, subject.RouteDual, within))
+	// Within grace but global mode: no local audience -> global only.
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", &trueP, &flip, subject.RouteGlobal, within))
+	// After grace: global only.
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", &trueP, &flip, subject.RouteLocal, after))
+	// Exactly at the boundary is already expired (now.Before is strict).
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", &trueP, &flip, subject.RouteLocal, flip.Add(subject.DefaultRoomLocalityGrace)))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `make test SERVICE=pkg/subject`
+Expected: FAIL — `undefined: subject.ThreadEvent`, `undefined: subject.ThreadEventTargets`
+
+- [ ] **Step 3: Write the implementation**
+
+In `pkg/subject/subject.go`, immediately after `RoomMemberEventTargets` (ends at line 462):
+
+```go
+// ThreadEvent returns the per-thread live lane for a channel room's thread —
+// the subject a client subscribes to while a thread pane is open, so a viewer
+// who does not follow the thread still receives its replies.
+func ThreadEvent(roomID, parentMessageID string, global bool) string {
+	return roomBase(roomID, global) + ".thread." + parentMessageID + ".event"
+}
+
+// ThreadEventTargets returns the thread-lane subject(s) to publish a thread
+// create/edit/delete to. Routes identically to RoomEventTargets (shared
+// roomRouteGlobals) so the thread lane follows the room's own namespace: a
+// same-site room's thread events land on the local prefix once local mode is
+// enabled, and a flipped room dual-publishes during the grace window.
+func ThreadEventTargets(roomID, parentMessageID string, crossSite *bool, crossSiteAt *time.Time, mode RoomRouteMode, now time.Time) []string {
+	globals := roomRouteGlobals(crossSite, crossSiteAt, mode, now)
+	out := make([]string, len(globals))
+	for i, g := range globals {
+		out[i] = ThreadEvent(roomID, parentMessageID, g)
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test SERVICE=pkg/subject`
+Expected: PASS, all three new tests green, no existing subject test broken.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+make fmt
+make lint
+git add pkg/subject/subject.go pkg/subject/subject_test.go
+git commit -m "feat(subject): add per-thread event lane builders
+
+ThreadEvent/ThreadEventTargets construct the subject a client subscribes to
+while a thread pane is open. Routing delegates to roomRouteGlobals so the
+thread lane follows the room's own local/global namespace and grace window."
+```
+
+---
+
+## Task 2: `thread_lane` metric room kind
+
+**Files:**
+- Modify: `broadcast-worker/nats_metrics.go:15-25` (enum + `allRoomKinds`), `:104-110` (`normalizeRoomKind`)
+- Test: `broadcast-worker/nats_metrics_test.go`
+
+**Interfaces:**
+- Produces: `roomThreadLane roomKindLabel = "thread_lane"`, usable by Task 3 as `withBroadcastMetricLabels(ctx, roomThreadLane, ...)`.
+
+**Why a new kind rather than reusing `roomThread`:** the `broadcastMetrics` doc comment (`nats_metrics.go:46-55`) promises that for `thread` fan-out, `broadcast_worker_fanout_recipients` and `broadcast_worker_recipient_deliveries_total` are directly comparable, because there is one publish per recipient. The thread lane is one publish to an audience the publisher cannot observe — the channel room-stream shape the same comment explicitly excludes from that ratio. Reusing `thread` would corrupt a series documented as comparable.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `broadcast-worker/nats_metrics_test.go`:
+
+```go
+// TestNormalizeRoomKind_ThreadLane guards the closed-enum contract: a room kind
+// missing from normalizeRoomKind's whitelist silently collapses to "unknown",
+// which would send every thread-lane delivery to the wrong series.
+func TestNormalizeRoomKind_ThreadLane(t *testing.T) {
+	assert.Equal(t, roomThreadLane, normalizeRoomKind(roomThreadLane))
+	assert.Contains(t, allRoomKinds, roomThreadLane,
+		"thread_lane must be in allRoomKinds or its measurement options are never pre-built")
+	assert.Equal(t, roomKindLabel("thread_lane"), roomThreadLane)
+}
+
+// TestThreadLaneLabelsSurviveContext verifies the label round-trips through the
+// context the publisher decorator reads, so Delivery is recorded under
+// thread_lane rather than unknown.
+func TestThreadLaneLabelsSurviveContext(t *testing.T) {
+	ctx := withBroadcastMetricLabels(context.Background(), roomThreadLane, natsmetrics.EventCreated)
+	labels := broadcastLabels(ctx)
+	assert.Equal(t, roomThreadLane, labels.roomKind)
+	assert.Equal(t, natsmetrics.EventCreated, labels.eventType)
+}
+```
+
+If `broadcast-worker/nats_metrics_test.go` does not exist, create it with:
+
+```go
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hmchangw/chat/pkg/natsmetrics"
+)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make test SERVICE=broadcast-worker`
+Expected: FAIL — `undefined: roomThreadLane`
+
+- [ ] **Step 3: Write the implementation**
+
+In `broadcast-worker/nats_metrics.go`, extend the enum block (currently lines 17-23):
+
+```go
+const (
+	roomChannel    roomKindLabel = "channel"
+	roomDM         roomKindLabel = "dm"
+	roomBotDM      roomKindLabel = "bot_dm"
+	roomThread     roomKindLabel = "thread"
+	roomThreadLane roomKindLabel = "thread_lane"
+	roomUnknown    roomKindLabel = "unknown"
+)
+
+var allRoomKinds = []roomKindLabel{roomChannel, roomDM, roomBotDM, roomThread, roomThreadLane, roomUnknown}
+```
+
+And extend `normalizeRoomKind` (line 104) — **this is the step that is easy to miss; without it the label collapses to `unknown`:**
+
+```go
+func normalizeRoomKind(value roomKindLabel) roomKindLabel {
+	switch value {
+	case roomChannel, roomDM, roomBotDM, roomThread, roomThreadLane:
+		return value
+	default:
+		return roomUnknown
+	}
+}
+```
+
+Update the `broadcastMetrics` doc comment (line 46-55) so the new kind's semantics are documented alongside the existing ones. Append this sentence to the existing paragraph:
+
+```go
+// thread_lane is one publish to a subject whose subscribers the publisher
+// cannot enumerate, so it records deliveries only — like the channel
+// room-stream case, its two families are NOT a ratio.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test SERVICE=broadcast-worker`
+Expected: PASS — both new tests green, every existing metrics test still green.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+make fmt
+make lint
+git add broadcast-worker/nats_metrics.go broadcast-worker/nats_metrics_test.go
+git commit -m "feat(broadcast-worker): add thread_lane metric room kind
+
+The thread lane is one publish to an unobservable audience, so it cannot
+share the thread kind, whose fanout/deliveries pair is documented as
+directly comparable. Records deliveries only."
+```
+
+---
+
+## Task 3: `publishThreadLaneEvent` helper
+
+**Files:**
+- Modify: `broadcast-worker/handler.go` (add after `publishRoomEvent`, which ends around line 896)
+- Modify: `.semgrep/room-subject.yml`
+- Test: `broadcast-worker/handler_test.go`
+
+**Interfaces:**
+- Consumes: `subject.ThreadEventTargets` (Task 1), `roomThreadLane` (Task 2), existing `h.pub.Publish`, `h.routeMode`, `broadcastLabels`, `withBroadcastMetricLabels`.
+- Produces: `func (h *Handler) publishThreadLaneEvent(ctx context.Context, roomID, parentMsgID string, crossSite *bool, crossSiteAt *time.Time, payload []byte, op string) error` — used by Tasks 4, 5, 6.
+
+**Shape rationale:** this mirrors `publishRoomEvent` (`handler.go:884`), NOT `publishToThreadAccounts` (`handler.go:1021`). The lane is one subject (two only in `RouteDual`), so the per-account helper's goroutine-per-recipient fan-out and its "all N publishes failed" error rule are both meaningless here. Three consequences, all asserted by tests below: label with `roomThreadLane`; never call `natsmetrics.MarkTerminalFromContext`; log no audience count.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `broadcast-worker/handler_test.go`:
+
+```go
+// TestPublishThreadLaneEvent_GlobalRoom verifies the helper publishes to the
+// global thread subject for a cross-site room.
+func TestPublishThreadLaneEvent_GlobalRoom(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+
+	crossSite := true
+	err := h.publishThreadLaneEvent(context.Background(), "r1", "p1", &crossSite, nil, []byte(`{"type":"new_thread_message"}`), "thread create")
+
+	require.NoError(t, err)
+	require.Len(t, pub.records, 1)
+	assert.Equal(t, "chat.room.r1.thread.p1.event", pub.records[0].subject)
+}
+
+// TestPublishThreadLaneEvent_DualMode verifies both namespaces receive the
+// event for a same-site room in dual mode, matching publishRoomEvent.
+func TestPublishThreadLaneEvent_DualMode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteDual)
+
+	sameSite := false
+	err := h.publishThreadLaneEvent(context.Background(), "r1", "p1", &sameSite, nil, []byte(`{}`), "thread create")
+
+	require.NoError(t, err)
+	require.Len(t, pub.records, 2)
+	assert.Equal(t, "chat.local.room.r1.thread.p1.event", pub.records[0].subject)
+	assert.Equal(t, "chat.room.r1.thread.p1.event", pub.records[1].subject)
+}
+
+// TestPublishThreadLaneEvent_PublishError_ReturnsError verifies a failed target
+// surfaces as an error to the caller, which is responsible for swallowing it.
+func TestPublishThreadLaneEvent_PublishError_ReturnsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{failOn: map[string]error{
+		"chat.room.r1.thread.p1.event": errors.New("nats down"),
+	}}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+
+	crossSite := true
+	err := h.publishThreadLaneEvent(context.Background(), "r1", "p1", &crossSite, nil, []byte(`{}`), "thread create")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "chat.room.r1.thread.p1.event")
+	assert.Len(t, pub.records, 1, "the attempt is still recorded")
+}
+
+// TestPublishThreadLaneEvent_LabelsAsThreadLane verifies deliveries are
+// attributed to the thread_lane kind, not channel (publishRoomEvent's label)
+// and not thread (the per-account fan-out's label, whose fanout/deliveries
+// pair is documented as directly comparable).
+func TestPublishThreadLaneEvent_LabelsAsThreadLane(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &labelCapturingPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+
+	crossSite := true
+	require.NoError(t, h.publishThreadLaneEvent(context.Background(), "r1", "p1", &crossSite, nil, []byte(`{}`), "thread create"))
+
+	require.Len(t, pub.seen, 1)
+	assert.Equal(t, roomThreadLane, pub.seen[0])
+}
+```
+
+Add this test double next to `mockPublisher` (around `handler_test.go:39`):
+
+```go
+// labelCapturingPublisher records the room-kind label each Publish call carries
+// on its context, so tests can assert metric attribution without a real meter.
+type labelCapturingPublisher struct {
+	mu   sync.Mutex
+	seen []roomKindLabel
+}
+
+func (p *labelCapturingPublisher) Publish(ctx context.Context, _ string, _ []byte) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.seen = append(p.seen, broadcastLabels(ctx).roomKind)
+	return nil
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `make test SERVICE=broadcast-worker`
+Expected: FAIL — `h.publishThreadLaneEvent undefined`
+
+- [ ] **Step 3: Write the implementation**
+
+In `broadcast-worker/handler.go`, immediately after `publishRoomEvent`:
+
+```go
+// publishThreadLaneEvent fans a channel thread's create/edit/delete out on the
+// per-thread lane, which viewers subscribe to while a thread pane is open.
+//
+// Mirrors publishRoomEvent, not publishToThreadAccounts: this is one subject
+// (two in dual mode), not a per-recipient fan-out, so there is nothing to
+// parallelize and no "all recipients failed" rule to apply. Deliveries are
+// attributed to roomThreadLane because the lane's audience is unobservable —
+// unlike the per-account thread fan-out, whose recipient count is exact.
+//
+// Callers MUST treat a returned error as best-effort: the per-account lane is
+// the delivery guarantee, and failing the handler here would re-fan-out that
+// lane on redelivery.
+func (h *Handler) publishThreadLaneEvent(ctx context.Context, roomID, parentMsgID string, crossSite *bool, crossSiteAt *time.Time, payload []byte, op string) error {
+	labels := broadcastLabels(ctx)
+	ctx = withBroadcastMetricLabels(ctx, roomThreadLane, labels.eventType)
+	now := time.Now().UTC()
+	var pubErr error
+	for _, subj := range subject.ThreadEventTargets(roomID, parentMsgID, crossSite, crossSiteAt, h.routeMode, now) {
+		if err := h.pub.Publish(ctx, subj, payload); err != nil {
+			pubErr = fmt.Errorf("publish %s for thread %s in room %s to %s: %w", op, parentMsgID, roomID, subj, err)
+		}
+	}
+	// No audience figure: the lane's subscriber count is unobservable from here,
+	// and an invented number is worse than none.
+	slog.Log(ctx, logctx.LevelFlow, "broadcast fan-out", "phase", "fanout",
+		"request_id", natsutil.RequestIDFromContext(ctx), "room_id", roomID,
+		"parent_message_id", parentMsgID, "delivery", "thread-lane")
+	return pubErr
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `make test SERVICE=broadcast-worker`
+Expected: PASS — four new tests green.
+
+- [ ] **Step 5: Extend the semgrep rule**
+
+Open `.semgrep/room-subject.yml`. The `room-subject-publish-must-route` rule lists the subject builders that must not be passed inline to a publish call. Add `subject.ThreadEvent` alongside the existing `subject.RoomEvent` / `RoomMsgStream` / `RoomMetadataUpdate` / `RoomMemberEvent` patterns, following the exact pattern syntax already used in the file, and add `subject.ThreadEvent` to the rule's message text listing the guarded builders.
+
+Run: `make sast-semgrep`
+Expected: PASS — no findings. (The helper calls `ThreadEventTargets`, not `ThreadEvent`, so it does not trip its own rule.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+make fmt
+make lint
+git add broadcast-worker/handler.go broadcast-worker/handler_test.go .semgrep/room-subject.yml
+git commit -m "feat(broadcast-worker): add publishThreadLaneEvent helper
+
+One subject per thread (two in dual mode), routed through
+ThreadEventTargets. Deliveries attributed to thread_lane so the thread
+kind's comparable fanout/deliveries pair stays intact. Semgrep rule
+extended so nobody inlines subject.ThreadEvent past the router."
+```
+
+---
+
+## Task 4: Wire `handleThreadCreated`
+
+**Files:**
+- Modify: `broadcast-worker/handler.go:241-312` (`handleThreadCreated`)
+- Test: `broadcast-worker/handler_test.go` — new tests + update 3 existing count assertions
+
+**Interfaces:**
+- Consumes: `publishThreadLaneEvent` (Task 3), existing `encryptRoomEvent(ctx, roomID string, clientMsg *model.ClientMessage, evt *model.RoomEvent) error` (`handler.go:835`).
+- Produces: nothing new.
+
+**Two behavioral changes in this task:**
+
+1. The channel branch gains a thread-lane publish carrying an **encrypted** copy of the same `RoomEvent`. `encryptRoomEvent` mutates its argument (sets `EncryptedMessage`, nils `Message`) and no-ops when `h.encrypt` is false, so the plaintext payload must be marshaled and published to the per-account lane **first**, then a copy encrypted for the lane.
+2. **The `len(fanOut) == 0` early return (line 263) is removed.** It skips the user lookup when nobody follows the thread — but a bot-authored reply produces an empty fan-out (`threadFanOutAccounts` drops bots), and a viewer watching that thread must still receive it. `publishToThreadAccounts` already no-ops on an empty account list (`handler.go:1025`), so removing the early return is safe; it costs one user lookup in the rare all-bot case.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `broadcast-worker/handler_test.go`:
+
+```go
+// TestHandleThreadCreated_ChannelRoom_PublishesThreadLane verifies a viewer
+// subscribed to the per-thread subject receives the reply, alongside the
+// unchanged per-account fan-out to followers.
+func TestHandleThreadCreated_ChannelRoom_PublishesThreadLane(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{"bob": {}}, nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"alice"}).Return([]model.User{testUsers[0]}, nil)
+
+	evt := model.MessageEvent{
+		Event:     model.EventCreated,
+		SiteID:    "site-a",
+		Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "room-1", UserID: "u-alice", UserAccount: "alice",
+			Content: "a thread reply", CreatedAt: msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	var lane *publishRecord
+	for i := range pub.records {
+		if pub.records[i].subject == "chat.room.room-1.thread.parent-1.event" {
+			lane = &pub.records[i]
+		}
+	}
+	require.NotNil(t, lane, "thread lane must receive the reply")
+
+	var laneEvt model.RoomEvent
+	require.NoError(t, json.Unmarshal(lane.data, &laneEvt))
+	assert.Equal(t, model.RoomEventNewThreadMessage, laneEvt.Type)
+	assert.Equal(t, "room-1", laneEvt.RoomID)
+	require.NotNil(t, laneEvt.Message, "encryption off: content stays plaintext")
+	assert.Equal(t, "reply-1", laneEvt.Message.ID)
+}
+
+// TestHandleThreadCreated_ThreadLaneEncrypted verifies the lane copy is
+// encrypted while the per-account copy stays plaintext, and that the two
+// otherwise agree. The lane rides chat.room.>, which any authenticated user
+// may subscribe to, so plaintext there would be readable by non-members.
+func TestHandleThreadCreated_ThreadLaneEncrypted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{}, nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"alice"}).Return([]model.User{testUsers[0]}, nil)
+	keyStore.EXPECT().Get(gomock.Any(), "room-1").Return(testRoomKey(t), nil).AnyTimes()
+
+	evt := model.MessageEvent{
+		Event: model.EventCreated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "room-1", UserID: "u-alice", UserAccount: "alice",
+			Content: "secret thread reply", CreatedAt: msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	var lane, perAccount *publishRecord
+	for i := range pub.records {
+		switch pub.records[i].subject {
+		case "chat.room.room-1.thread.parent-1.event":
+			lane = &pub.records[i]
+		case subject.UserRoomEvent("alice"):
+			perAccount = &pub.records[i]
+		}
+	}
+	require.NotNil(t, lane)
+	require.NotNil(t, perAccount)
+
+	assert.NotContains(t, string(lane.data), "secret thread reply",
+		"thread-lane payload must not carry plaintext content")
+
+	var laneEvt, acctEvt model.RoomEvent
+	require.NoError(t, json.Unmarshal(lane.data, &laneEvt))
+	require.NoError(t, json.Unmarshal(perAccount.data, &acctEvt))
+	assert.Nil(t, laneEvt.Message, "lane copy carries encryptedMessage, not message")
+	assert.NotEmpty(t, laneEvt.EncryptedMessage)
+	require.NotNil(t, acctEvt.Message, "per-account copy must stay plaintext")
+	assert.Equal(t, "secret thread reply", acctEvt.Message.Content)
+}
+
+// TestHandleThreadCreated_ThreadLaneKeepsMentions verifies mentions survive on
+// the lane copy: the frontend renders them with dedicated styling from this
+// resolved Participant list, so a viewer must see what a follower sees.
+func TestHandleThreadCreated_ThreadLaneKeepsMentions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{}, nil)
+	store.EXPECT().GetHistorySharedSince(gomock.Any(), "room-1", []string{"bob"}).
+		Return(map[string]*time.Time{"bob": nil}, nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).
+		Return([]model.User{testUsers[0], testUsers[1]}, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventCreated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "room-1", UserID: "u-alice", UserAccount: "alice",
+			Content: "hey @bob", CreatedAt: msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	var lane *publishRecord
+	for i := range pub.records {
+		if pub.records[i].subject == "chat.room.room-1.thread.parent-1.event" {
+			lane = &pub.records[i]
+		}
+	}
+	require.NotNil(t, lane)
+
+	var laneEvt model.RoomEvent
+	require.NoError(t, json.Unmarshal(lane.data, &laneEvt))
+	assert.NotEmpty(t, laneEvt.Mentions, "mentions drive frontend styling and must reach viewers")
+}
+
+// TestHandleThreadCreated_DMRoom_NoThreadLane verifies DM rooms publish nothing
+// to the lane: DM thread replies already reach every member, so a lane publish
+// would be pure duplication.
+func TestHandleThreadCreated_DMRoom_NoThreadLane(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "dm-1").Return(metaOf(testDMRoom), nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return([]model.User{testUsers[0]}, nil)
+	store.EXPECT().ListSubscriptions(gomock.Any(), "dm-1").Return(testDMSubs, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventCreated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "dm-1", UserID: "u-alice", UserAccount: "alice",
+			Content: "dm thread reply", CreatedAt: msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	for _, r := range pub.records {
+		assert.NotContains(t, r.subject, ".thread.", "DM rooms must not use the thread lane")
+	}
+}
+
+// TestHandleThreadCreated_ThreadLaneFailure_Swallowed verifies a lane publish
+// failure neither fails the handler nor blocks the per-account fan-out. Failing
+// here would NAK the canonical message and re-fan-out the per-account lane,
+// turning one viewer's cosmetic miss into duplicate delivery for everyone.
+func TestHandleThreadCreated_ThreadLaneFailure_Swallowed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{failOn: map[string]error{
+		"chat.room.room-1.thread.parent-1.event": errors.New("nats down"),
+	}}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{"bob": {}}, nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"alice"}).Return([]model.User{testUsers[0]}, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventCreated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "room-1", UserID: "u-alice", UserAccount: "alice",
+			Content: "a thread reply", CreatedAt: msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data), "lane failure must not fail the handler")
+
+	subjects := map[string]bool{}
+	for _, r := range pub.records {
+		subjects[r.subject] = true
+	}
+	assert.True(t, subjects[subject.UserRoomEvent("alice")], "per-account fan-out must still happen")
+	assert.True(t, subjects[subject.UserRoomEvent("bob")])
+}
+
+// TestHandleThreadCreated_EmptyFanOut_StillPublishesThreadLane covers a
+// bot-authored reply: threadFanOutAccounts drops bots, so the per-account set
+// is empty, but a viewer with the pane open must still receive the reply.
+func TestHandleThreadCreated_EmptyFanOut_StillPublishesThreadLane(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{}, nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	evt := model.MessageEvent{
+		Event: model.EventCreated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "room-1", UserAccount: "helper.bot", Content: "bot reply",
+			CreatedAt: msgTime, ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	var found bool
+	for _, r := range pub.records {
+		if r.subject == "chat.room.room-1.thread.parent-1.event" {
+			found = true
+		}
+	}
+	assert.True(t, found, "an empty per-account fan-out must not suppress the thread lane")
+}
+```
+
+**Fixtures used above, all already in `handler_test.go`:** `testRoomKey(t)` (line 177 shows the call form — it takes `t`), `metaOf(testChannelRoom)` / `metaOf(testDMRoom)`, `testUsers`, `testDMSubs`, `defaultParentFetcher`, `mockPublisher`, `publishRecord`. Nothing new to declare.
+
+**Watch the room id.** `testChannelRoom.ID` is `"room-1"` and `testDMRoom.ID` is `"dm-1"` (`handler_test.go:86-96`). The lane subject is built from `meta.ID`, so it is `chat.room.room-1.thread.parent-1.event`. Note that some existing tests pass `"room-1"` as the `GetRoomMeta` mock argument while returning `metaOf(testChannelRoom)`, whose ID is `"room-1"` — they get away with it because per-account subjects carry no room id. The lane subject does, so use `"room-1"` throughout.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `make test SERVICE=broadcast-worker`
+Expected: FAIL — the new tests fail on the missing lane publish. Three existing tests also now fail on their count assertions; that is expected and fixed in Step 4.
+
+- [ ] **Step 3: Write the implementation**
+
+Replace the channel branch of `handleThreadCreated`. Delete the early return at lines 263-268:
+
+```go
+		if len(fanOut) == 0 {
+			slog.DebugContext(ctx, "no thread subscribers to notify for thread reply",
+				"parentMessageID", parentMsgID,
+				"request_id", natsutil.RequestIDFromContext(ctx))
+			return nil
+		}
+```
+
+Replace it with a debug log that does not return, so the thread-lane publish below still runs:
+
+```go
+		if len(fanOut) == 0 {
+			// No per-account recipients (e.g. a bot-authored reply), but the
+			// thread lane below still serves viewers with the pane open.
+			slog.DebugContext(ctx, "no thread subscribers to notify for thread reply",
+				"parentMessageID", parentMsgID,
+				"request_id", natsutil.RequestIDFromContext(ctx))
+		}
+```
+
+Then replace the channel `switch` arm (currently ending `return h.publishToThreadAccounts(...)`) with:
+
+```go
+	case model.RoomTypeChannel:
+		// Do NOT call SetSubscriptionMentions here: TShow=false replies are invisible
+		// in the main channel, so a room-level mention badge would appear with no
+		// visible message to explain it.
+		roomEvt := buildRoomEvent(&meta, clientMsg, evt.Timestamp)
+		roomEvt.Type = model.RoomEventNewThreadMessage
+		roomEvt.MentionAll = resolved.MentionAll
+		if len(resolved.Participants) > 0 {
+			roomEvt.Mentions = resolved.Participants
+		}
+		payload, err := sonic.Marshal(roomEvt)
+		if err != nil {
+			return fmt.Errorf("marshal thread created event for parent %s: %w", parentMsgID, err)
+		}
+		if err := h.publishToThreadAccounts(ctx, fanOut, payload, parentMsgID); err != nil {
+			return fmt.Errorf("publish thread created event for parent %s: %w", parentMsgID, err)
+		}
+		// Thread lane: same event, encrypted, for viewers who do not follow the
+		// thread. Encrypt a copy AFTER the plaintext publish above —
+		// encryptRoomEvent nils Message in place.
+		h.publishThreadLaneCreated(ctx, &meta, clientMsg, parentMsgID, roomEvt)
+		return nil
+```
+
+Add the companion method immediately after `handleThreadCreated`:
+
+```go
+// publishThreadLaneCreated sends the encrypted twin of a thread reply on the
+// per-thread lane. Best-effort: errors are logged, never returned, because the
+// per-account lane above is the delivery guarantee and failing the handler
+// would re-fan-out that lane on redelivery.
+func (h *Handler) publishThreadLaneCreated(ctx context.Context, meta *roommetacache.Meta, clientMsg *model.ClientMessage, parentMsgID string, plain model.RoomEvent) {
+	laneEvt := plain
+	if err := h.encryptRoomEvent(ctx, meta.ID, clientMsg, &laneEvt); err != nil {
+		slog.ErrorContext(ctx, "encrypt thread lane event failed",
+			"error", err, "room_id", meta.ID, "parentMessageID", parentMsgID,
+			"request_id", natsutil.RequestIDFromContext(ctx))
+		return
+	}
+	lanePayload, err := sonic.Marshal(laneEvt)
+	if err != nil {
+		slog.ErrorContext(ctx, "marshal thread lane event failed",
+			"error", err, "room_id", meta.ID, "parentMessageID", parentMsgID,
+			"request_id", natsutil.RequestIDFromContext(ctx))
+		return
+	}
+	if err := h.publishThreadLaneEvent(ctx, meta.ID, parentMsgID, meta.CrossSite, meta.CrossSiteAt, lanePayload, "thread create"); err != nil {
+		slog.ErrorContext(ctx, "publish thread lane event failed",
+			"error", err, "room_id", meta.ID, "parentMessageID", parentMsgID,
+			"request_id", natsutil.RequestIDFromContext(ctx))
+	}
+}
+```
+
+- [ ] **Step 4: Update the three existing count assertions**
+
+These tests assert an exact `pub.records` length that is now one higher on the channel path. Update each, and extend each with an assertion naming the new record so the count change is self-documenting rather than a bare number bump:
+
+- `TestHandleThreadCreated_ChannelRoom_FansOutToFollowers` (~line 2427): `require.Len(t, pub.records, 3)` → `4`. The existing loop asserts every record unmarshals as a `RoomEvent` with type `new_thread_message`, which the lane record also satisfies, so only the count and the subject-set assertions need changing: add `assert.True(t, subjects["chat.room.room-1.thread.parent-1.event"])`.
+- `TestHandleThreadCreated_ChannelRoom_NoFollowers_SendsToSenderOnly` (~line 2475): `1` → `2`, plus the same subject assertion.
+- `TestHandleThreadCreated_ChannelRoom_ParentAuthorFannedOutBeforeThreadRoomExists` (~line 2524): `2` → `3`, plus the same subject assertion.
+
+Leave every DM/BotDM thread test untouched — they must still pass unchanged, which is the proof that DM behavior did not move.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `make test SERVICE=broadcast-worker`
+Expected: PASS — all new tests green, the three updated tests green, every DM test green with no edit.
+
+- [ ] **Step 6: Commit**
+
+```bash
+make fmt
+make lint
+git add broadcast-worker/handler.go broadcast-worker/handler_test.go
+git commit -m "feat(broadcast-worker): publish thread replies to the thread lane
+
+Channel thread replies now also go out encrypted on the per-thread
+subject, so a viewer who does not follow the thread receives them live.
+The per-account follower lane is unchanged and stays plaintext.
+
+Removes the empty-fan-out early return: a bot-authored reply has no
+per-account recipients but must still reach viewers."
+```
+
+---
+
+## Task 5: Wire `handleThreadUpdated`
+
+**Files:**
+- Modify: `broadcast-worker/handler.go:356-402` (`handleThreadUpdated`)
+- Test: `broadcast-worker/handler_test.go` — new tests + update 1 existing count assertion
+
+**Interfaces:**
+- Consumes: `publishThreadLaneEvent` (Task 3), existing `encryptEditedContent(ctx context.Context, roomID string, edited *model.EditRoomEvent) error` (`handler.go:802`).
+
+**Note the difference from Task 4:** `encryptEditedContent` does **not** check `h.encrypt` internally (unlike `encryptRoomEvent`). `handleUpdated` guards it explicitly at line 336. The lane path must guard the same way, or an unencrypted deployment will fail on a missing room key.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `broadcast-worker/handler_test.go`:
+
+```go
+// TestHandleThreadUpdated_ChannelRoom_PublishesThreadLane verifies an edit
+// reaches viewers, so a viewer never sits on stale content a follower has seen
+// corrected.
+func TestHandleThreadUpdated_ChannelRoom_PublishesThreadLane(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{"bob": {}}, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventUpdated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "r1", UserAccount: "alice", Content: "edited reply",
+			CreatedAt: msgTime, EditedAt: &msgTime, UpdatedAt: &msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	var lane *publishRecord
+	for i := range pub.records {
+		if pub.records[i].subject == "chat.room.r1.thread.parent-1.event" {
+			lane = &pub.records[i]
+		}
+	}
+	require.NotNil(t, lane, "thread lane must receive the edit")
+
+	var laneEvt model.EditRoomEvent
+	require.NoError(t, json.Unmarshal(lane.data, &laneEvt))
+	assert.Equal(t, model.RoomEventMessageEdited, laneEvt.Type)
+	assert.Equal(t, "reply-1", laneEvt.MessageID)
+	assert.Equal(t, "edited reply", laneEvt.NewContent, "encryption off: plaintext")
+}
+
+// TestHandleThreadUpdated_ThreadLaneEncrypted verifies the edit's new content is
+// encrypted on the lane and cleared from the plaintext field, while the
+// per-account copy keeps plaintext.
+func TestHandleThreadUpdated_ThreadLaneEncrypted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{"bob": {}}, nil)
+	keyStore.EXPECT().Get(gomock.Any(), "r1").Return(testRoomKey(t), nil).AnyTimes()
+
+	evt := model.MessageEvent{
+		Event: model.EventUpdated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "r1", UserAccount: "alice", Content: "secret edit",
+			CreatedAt: msgTime, EditedAt: &msgTime, UpdatedAt: &msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	var lane, perAccount *publishRecord
+	for i := range pub.records {
+		switch pub.records[i].subject {
+		case "chat.room.r1.thread.parent-1.event":
+			lane = &pub.records[i]
+		case subject.UserRoomEvent("bob"):
+			perAccount = &pub.records[i]
+		}
+	}
+	require.NotNil(t, lane)
+	require.NotNil(t, perAccount)
+
+	assert.NotContains(t, string(lane.data), "secret edit")
+
+	var laneEvt, acctEvt model.EditRoomEvent
+	require.NoError(t, json.Unmarshal(lane.data, &laneEvt))
+	require.NoError(t, json.Unmarshal(perAccount.data, &acctEvt))
+	assert.Empty(t, laneEvt.NewContent, "lane copy must clear plaintext newContent")
+	assert.NotEmpty(t, laneEvt.EncryptedNewContent)
+	assert.Equal(t, "secret edit", acctEvt.NewContent, "per-account copy stays plaintext")
+}
+
+// TestHandleThreadUpdated_DMRoom_NoThreadLane verifies DM edits skip the lane.
+func TestHandleThreadUpdated_DMRoom_NoThreadLane(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	room := &model.Room{ID: "dm1", Type: model.RoomTypeDM, SiteID: "site-a", Accounts: []string{"alice", "bob"}}
+	store.EXPECT().GetRoom(gomock.Any(), "dm1").Return(room, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventUpdated, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "dm1", UserAccount: "alice", Content: "edited",
+			CreatedAt: msgTime, EditedAt: &msgTime, UpdatedAt: &msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	for _, r := range pub.records {
+		assert.NotContains(t, r.subject, ".thread.")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `make test SERVICE=broadcast-worker`
+Expected: FAIL — no lane record found. `TestHandleThreadUpdated_ChannelRoom_FansOutToFollowers` also fails on its count; fixed in Step 4.
+
+- [ ] **Step 3: Write the implementation**
+
+In `handleThreadUpdated`, make the empty fan-out non-terminal (same reasoning as Task 4) and add the lane publish. Replace the channel arm:
+
+```go
+	case model.RoomTypeChannel:
+		parsed := mention.Parse(msg.Content)
+		fanOut, err := h.channelThreadFanOut(ctx, room.ID, room.SiteID, parentMsgID, msg.UserAccount, parsed.Accounts, msg.ThreadParentMessageCreatedAt, evt.ThreadParentSenderAccount)
+		if err != nil {
+			return fmt.Errorf("channel thread fan-out for thread update of parent %s: %w", parentMsgID, err)
+		}
+		if len(fanOut) == 0 {
+			// No per-account recipients, but the thread lane below still serves
+			// viewers with the pane open.
+			slog.DebugContext(ctx, "no thread subscribers to notify for thread update",
+				"parentMessageID", parentMsgID,
+				"request_id", natsutil.RequestIDFromContext(ctx))
+		}
+		payload, err := sonic.Marshal(&edit)
+		if err != nil {
+			return fmt.Errorf("marshal thread edit event for parent %s: %w", parentMsgID, err)
+		}
+		if err := h.publishToThreadAccounts(ctx, fanOut, payload, parentMsgID); err != nil {
+			return fmt.Errorf("publish thread edit event for parent %s: %w", parentMsgID, err)
+		}
+		h.publishThreadLaneEdit(ctx, room, parentMsgID, edit)
+		return nil
+```
+
+Add the companion method immediately after `handleThreadUpdated`:
+
+```go
+// publishThreadLaneEdit sends the encrypted twin of a thread-reply edit on the
+// per-thread lane. Best-effort, like publishThreadLaneCreated.
+//
+// encryptEditedContent does not check h.encrypt itself (unlike
+// encryptRoomEvent), so the guard is explicit here — matching handleUpdated.
+func (h *Handler) publishThreadLaneEdit(ctx context.Context, room *model.Room, parentMsgID string, plain model.EditRoomEvent) {
+	laneEdit := plain
+	if h.encrypt {
+		if err := h.encryptEditedContent(ctx, room.ID, &laneEdit); err != nil {
+			slog.ErrorContext(ctx, "encrypt thread lane edit failed",
+				"error", err, "room_id", room.ID, "parentMessageID", parentMsgID,
+				"request_id", natsutil.RequestIDFromContext(ctx))
+			return
+		}
+	}
+	lanePayload, err := sonic.Marshal(&laneEdit)
+	if err != nil {
+		slog.ErrorContext(ctx, "marshal thread lane edit failed",
+			"error", err, "room_id", room.ID, "parentMessageID", parentMsgID,
+			"request_id", natsutil.RequestIDFromContext(ctx))
+		return
+	}
+	if err := h.publishThreadLaneEvent(ctx, room.ID, parentMsgID, room.CrossSite, room.CrossSiteAt, lanePayload, "thread edit"); err != nil {
+		slog.ErrorContext(ctx, "publish thread lane edit failed",
+			"error", err, "room_id", room.ID, "parentMessageID", parentMsgID,
+			"request_id", natsutil.RequestIDFromContext(ctx))
+	}
+}
+```
+
+- [ ] **Step 4: Update the existing count assertion**
+
+`TestHandleThreadUpdated_ChannelRoom_FansOutToFollowers` (~line 2851): `require.Len(t, pub.records, 3)` → `4`, and add `assert.True(t, subjects["chat.room.r1.thread.parent-1.event"])` (adjusting the ids to whatever that test uses). Leave `TestHandleThreadUpdated_DMRoom_FansOutToAllMembers` untouched.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `make test SERVICE=broadcast-worker`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+make fmt
+make lint
+git add broadcast-worker/handler.go broadcast-worker/handler_test.go
+git commit -m "feat(broadcast-worker): publish thread edits to the thread lane
+
+Without this a viewer keeps rendering content a follower has already seen
+corrected. Guards encryptEditedContent on h.encrypt explicitly, matching
+handleUpdated — unlike encryptRoomEvent it does not check internally."
+```
+
+---
+
+## Task 6: Wire `handleThreadDeleted`
+
+**Files:**
+- Modify: `broadcast-worker/handler.go:405-462` (`handleThreadDeleted`)
+- Test: `broadcast-worker/handler_test.go` — new tests + update 2 existing count assertions
+
+**Interfaces:**
+- Consumes: `publishThreadLaneEvent` (Task 3).
+
+**Simplest of the three:** `DeleteRoomEvent` carries no message content (`buildDeleteRoomEvent`, `handler.go:782`), so there is no encryption step and the same payload serves both lanes.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `broadcast-worker/handler_test.go`:
+
+```go
+// TestHandleThreadDeleted_ChannelRoom_PublishesThreadLane verifies a delete
+// reaches viewers, so a viewer does not keep rendering a removed reply.
+func TestHandleThreadDeleted_ChannelRoom_PublishesThreadLane(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{"bob": {}}, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventDeleted, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "r1", UserAccount: "alice",
+			CreatedAt: msgTime, UpdatedAt: &msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	var lane *publishRecord
+	for i := range pub.records {
+		if pub.records[i].subject == "chat.room.r1.thread.parent-1.event" {
+			lane = &pub.records[i]
+		}
+	}
+	require.NotNil(t, lane, "thread lane must receive the delete")
+
+	var laneEvt model.DeleteRoomEvent
+	require.NoError(t, json.Unmarshal(lane.data, &laneEvt))
+	assert.Equal(t, model.RoomEventMessageDeleted, laneEvt.Type)
+	assert.Equal(t, "reply-1", laneEvt.MessageID)
+	assert.Equal(t, "parent-1", laneEvt.ThreadParentMessageID)
+}
+
+// TestHandleThreadDeleted_ThreadLaneNotEncrypted verifies the delete payload is
+// identical on both lanes: it carries no message content, so there is nothing
+// to encrypt and no reason to build a second payload.
+func TestHandleThreadDeleted_ThreadLaneNotEncrypted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	room := &model.Room{ID: "r1", Type: model.RoomTypeChannel, SiteID: "site-a"}
+	store.EXPECT().GetRoom(gomock.Any(), "r1").Return(room, nil)
+	store.EXPECT().GetThreadFollowers(gomock.Any(), "parent-1").Return(map[string]struct{}{"bob": {}}, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventDeleted, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "r1", UserAccount: "alice",
+			CreatedAt: msgTime, UpdatedAt: &msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, true, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	var lane, perAccount *publishRecord
+	for i := range pub.records {
+		switch pub.records[i].subject {
+		case "chat.room.r1.thread.parent-1.event":
+			lane = &pub.records[i]
+		case subject.UserRoomEvent("bob"):
+			perAccount = &pub.records[i]
+		}
+	}
+	require.NotNil(t, lane)
+	require.NotNil(t, perAccount)
+	assert.JSONEq(t, string(perAccount.data), string(lane.data),
+		"delete carries no content, so both lanes send the same payload")
+}
+
+// TestHandleThreadDeleted_DMRoom_NoThreadLane verifies DM deletes skip the lane.
+func TestHandleThreadDeleted_DMRoom_NoThreadLane(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	msgTime := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	room := &model.Room{ID: "dm1", Type: model.RoomTypeDM, SiteID: "site-a", Accounts: []string{"alice", "bob"}}
+	store.EXPECT().GetRoom(gomock.Any(), "dm1").Return(room, nil)
+
+	evt := model.MessageEvent{
+		Event: model.EventDeleted, SiteID: "site-a", Timestamp: msgTime.UnixMilli(),
+		Message: model.Message{
+			ID: "reply-1", RoomID: "dm1", UserAccount: "alice",
+			CreatedAt: msgTime, UpdatedAt: &msgTime,
+			ThreadParentMessageID: "parent-1", TShow: false,
+		},
+	}
+	data, _ := json.Marshal(evt)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	for _, r := range pub.records {
+		assert.NotContains(t, r.subject, ".thread.")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `make test SERVICE=broadcast-worker`
+Expected: FAIL — no lane record. Two existing tests also fail on counts; fixed in Step 4.
+
+- [ ] **Step 3: Write the implementation**
+
+In `handleThreadDeleted`'s channel arm, after the existing `publishToThreadAccounts` call, add the lane publish. The existing arm already tolerates an empty fan-out (it guards with `if len(fanOut) > 0` rather than returning), so no early-return change is needed here — but the lane publish must sit **outside** that guard:
+
+```go
+	case model.RoomTypeChannel:
+		// Parse @-mentions from the deleted message so that non-follower
+		// recipients who received the create event (via mention fan-out) also
+		// receive the delete. Only the channel path uses mentions; the DM path
+		// fans out to all members.
+		parsed := mention.Parse(msg.Content)
+		fanOut, err := h.channelThreadFanOut(ctx, room.ID, room.SiteID, parentMsgID, msg.UserAccount, parsed.Accounts, msg.ThreadParentMessageCreatedAt, evt.ThreadParentSenderAccount)
+		if err != nil {
+			return fmt.Errorf("channel thread fan-out for thread delete of parent %s: %w", parentMsgID, err)
+		}
+		payload, err := sonic.Marshal(&del)
+		if err != nil {
+			return fmt.Errorf("marshal thread delete event for parent %s: %w", parentMsgID, err)
+		}
+		if len(fanOut) > 0 {
+			if err := h.publishToThreadAccounts(ctx, fanOut, payload, parentMsgID); err != nil {
+				return fmt.Errorf("publish thread delete event for parent %s: %w", parentMsgID, err)
+			}
+		}
+		// Thread lane: DeleteRoomEvent carries no message content, so the same
+		// payload serves both lanes — no encryption, no second marshal.
+		if err := h.publishThreadLaneEvent(ctx, room.ID, parentMsgID, room.CrossSite, room.CrossSiteAt, payload, "thread delete"); err != nil {
+			slog.ErrorContext(ctx, "publish thread lane delete failed",
+				"error", err, "room_id", room.ID, "parentMessageID", parentMsgID,
+				"request_id", natsutil.RequestIDFromContext(ctx))
+		}
+```
+
+Note the `payload` marshal moved above the `len(fanOut) > 0` guard so the lane publish can reuse it.
+
+- [ ] **Step 4: Update the two existing count assertions**
+
+- `TestHandleThreadDeleted_ChannelRoom_FansOutToFollowers` (~line 3100): `require.Len(t, pub.records, 3)` → `4`, plus a subject assertion for the lane.
+- `TestHandleThreadDeleted_ChannelRoom_WithBadgeUpdate` (~line 3156): `require.Len(t, pub.records, 3)` → `4`. This test also asserts the badge (`thread_metadata_updated`) publish; keep that assertion unchanged — the badge is orthogonal to the lane.
+
+Leave `TestHandleThreadDeleted_DMRoom_FansOutToAllMembers` untouched.
+
+- [ ] **Step 5: Run the full unit suite**
+
+Run: `make test`
+Expected: PASS across every package — this is the first point where all three handlers are wired, so run the whole suite, not just `broadcast-worker`.
+
+- [ ] **Step 6: Run SAST**
+
+Run: `make sast`
+Expected: PASS, no medium-or-higher findings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+make fmt
+make lint
+git add broadcast-worker/handler.go broadcast-worker/handler_test.go
+git commit -m "feat(broadcast-worker): publish thread deletes to the thread lane
+
+Completes the viewer lane: a viewer no longer keeps rendering a reply that
+has been removed. DeleteRoomEvent carries no content, so one payload
+serves both lanes."
+```
+
+---
+
+## Task 7: Client API documentation
+
+**Files:**
+- Modify: `docs/client-api.md`
+- Modify: `docs/client-api/events.md`
+- Modify: `docs/client-api/request-reply.md`
+
+**Required by CLAUDE.md §5:** any change to how a client-facing event is delivered must update `docs/client-api.md` and its derived views in the same PR. The derived views must never drift from the canonical doc.
+
+There is no test cycle for this task; its gate is a careful read against the shipped behavior.
+
+- [ ] **Step 1: Update the subject-patterns table**
+
+In `docs/client-api/events.md`, the table under "Subject patterns" (around line 44) lists each subject and the events it carries. Add a row:
+
+| Subject | Events delivered |
+|---|---|
+| `chat.room.{roomID}.thread.{parentMessageId}.event` (or `chat.local.room.…`, by `crossSite`) | new_thread_message, message_edited, message_deleted — **channel rooms only**; subscribe while a thread pane is open |
+
+Mirror this row into the equivalent table in `docs/client-api.md`.
+
+- [ ] **Step 2: Update the `new_thread_message` delivery note**
+
+`docs/client-api/events.md:488-493` currently states delivery is per-subscriber only. Replace that paragraph with text covering both lanes:
+
+> **Delivery differs from `new_message`.** A channel thread reply is **not** published room-wide on
+> `chat.room.{roomID}.event`. It travels two lanes:
+>
+> 1. **Per-subscriber**, on `chat.user.{account}.event.room`, to the reply sender, the parent-message
+>    author, thread followers (anyone who has replied in the thread), and history-gated @-mentioned
+>    accounts. Plaintext.
+> 2. **Per-thread**, on `chat.room.{roomID}.thread.{parentMessageId}.event`, for clients that
+>    subscribe while the thread pane is open — including users who do not follow the thread.
+>    Encrypted with the room key when room encryption is enabled, exactly like `new_message` on the
+>    room lane.
+>
+> A follower who has the thread open receives the event on **both** lanes. Deduplicate by
+> `message.id` — required regardless, since delivery is at-least-once.
+>
+> DM/botDM thread replies fan out **per member** on `chat.user.{account}.event.room` and do **not**
+> use the thread lane; every member already receives them. The bot account is skipped (`isBot`).
+
+- [ ] **Step 3: Add the same second-lane note to `message_edited` and `message_deleted`**
+
+Both event sections in `docs/client-api/events.md` need a short paragraph stating that when the
+message is a thread reply in a channel room (`threadParentMessageId` set, `tshow` false), the event
+is also published on `chat.room.{roomID}.thread.{parentMessageId}.event` for thread viewers, and that
+the `message_edited` lane copy carries `encryptedNewContent` rather than `newContent` when encryption
+is enabled.
+
+- [ ] **Step 4: Document the subscribe lifecycle**
+
+Add a short subsection to `docs/client-api.md` near the thread event documentation:
+
+> **Subscribing to a thread.** Opening a thread pane: subscribe to
+> `chat.room.{roomID}.thread.{parentMessageId}.event`, choosing the `chat.room.` or
+> `chat.local.room.` prefix from the room's `crossSite` value exactly as for
+> `chat.room.{roomID}.event`. Closing the pane: unsubscribe. There is no RPC and no server-side
+> state — subscribing does **not** make you a thread follower, does not create a thread
+> subscription, does not accrue unread, and does not place the thread in your thread list. Closing
+> the pane ends delivery.
+
+- [ ] **Step 5: Update `request-reply.md`'s Send Message emits line**
+
+`docs/client-api/request-reply.md:2279` lists what Send Message emits. Extend the
+`new_thread_message` reference so it names both lanes, matching the events.md wording.
+
+- [ ] **Step 6: Verify the three docs agree**
+
+Re-read the three files' thread sections side by side. Every subject string, event name, and
+encryption statement must match exactly. A derived view that disagrees with `client-api.md` is a
+CLAUDE.md violation.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/client-api.md docs/client-api/events.md docs/client-api/request-reply.md
+git commit -m "docs(client-api): document the per-thread viewer lane
+
+Adds the new subject, the two-lane delivery model for channel thread
+replies/edits/deletes, the dedupe-by-message-id requirement, and the
+subscribe-on-open lifecycle. Mirrors into both derived views."
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full unit suite:** `make test` — all packages green.
+- [ ] **Lint:** `make lint` — clean.
+- [ ] **SAST:** `make sast` — no medium-or-higher findings.
+- [ ] **Confirm DM tests were never edited:** `git diff master...HEAD -- broadcast-worker/handler_test.go | grep -c "DMRoom"` should show only additions from the new `_NoThreadLane` tests, never edits to existing DM assertions. DM behavior not moving is the core regression guarantee.
+- [ ] **Confirm the branch:** `git branch --show-current` is `claude/thread-metadata-event-5065r0`.
+- [ ] **Push:** `git push -u origin claude/thread-metadata-event-5065r0`
+
+## Out of scope
+
+Per the spec's §11, do NOT implement in this plan: a follow/unfollow RPC, exposing the follower set
+to clients, viewer unread/badge/notification behavior, `thread_message_read` on the lane (already
+room-wide), or repairing the `ThreadSubscription` / `replyAccounts` non-atomic split.

--- a/docs/superpowers/specs/2026-08-23-thread-viewer-lane-design.md
+++ b/docs/superpowers/specs/2026-08-23-thread-viewer-lane-design.md
@@ -136,12 +136,38 @@ func (h *Handler) publishThreadLaneEvent(ctx context.Context, roomID, parentMsgI
 ```
 
 It loops `subject.ThreadEventTargets(...)` and publishes each target, with the
-same error aggregation and flow-logging shape as `publishRoomEvent`. The
+same sequential loop and last-error-wins aggregation as `publishRoomEvent`. The
 signature mirrors `publishRoomEvent`'s deliberately: `handleThreadCreated`
 holds a `roommetacache.Meta` (from `GetRoomMeta`) while `handleThreadUpdated`
 and `handleThreadDeleted` hold a `*model.Room` (from `GetRoom`). Taking the
 `crossSite` / `crossSiteAt` pair as parameters lets all three call it without
 converting between the two types.
+
+**Not `publishToThreadAccounts`'s shape.** That helper
+(`handler.go:1021`) fans out to N accounts with one goroutine per account, a
+`WaitGroup`, and an all-N-failed error rule. The thread lane is a single
+subject (two only during `RouteDual`), so goroutines would be overhead and
+"all publishes failed" would be meaningless. Three specifics follow from that:
+
+- **Metrics label: a new `thread_lane` room kind, not `thread`.** The
+  `roomKindLabel` enum (`broadcast-worker/nats_metrics.go:15`) is closed, and
+  its doc comment states an invariant for `thread`: fan-out recipients and
+  delivery attempts are directly comparable because there is one publish per
+  recipient. The thread lane is one publish to an audience the publisher cannot
+  observe — the same shape as the channel room-stream case the comment
+  explicitly excludes from that ratio. Reusing `thread` would corrupt a series
+  that is documented as comparable. Add `roomThreadLane roomKindLabel =
+  "thread_lane"` to the enum and to `allRoomKinds`. Record **deliveries only**;
+  do not record a fan-out recipient count, because there is no honest number to
+  record.
+- **Never call `natsmetrics.MarkTerminalFromContext`.** `publishToThreadAccounts`
+  marks `TerminalPublishExhausted` on partial failure. That is a terminal
+  disposition on the underlying canonical JetStream message. The thread lane is
+  best-effort and must not influence how that message's redelivery is accounted.
+- **Flow log carries no audience count.** The channel path logs
+  `"audience", meta.UserCount` at its call site. The thread lane has no such
+  number (see below). Log `delivery="thread-lane"` with the room and parent
+  message ids and no recipient figure — an invented count is worse than none.
 
 **Failure isolation.** A thread-lane publish failure MUST NOT fail the handler
 or block the per-account fan-out — it is logged and swallowed, the way
@@ -150,6 +176,47 @@ publishes. The per-account lane remains the delivery guarantee for followers;
 the thread lane is a convenience for viewers whose pane is open right now. A
 NAK-and-redeliver on a thread-lane failure would re-fan-out the per-account
 copy too, turning a cosmetic miss into duplicate delivery for everyone.
+
+### Cost when nobody is subscribed
+
+Core NATS is interest-based: with no subscriber registered for the subject, the
+server discards the message on arrival. The publisher is unaffected in every
+way that would matter operationally — `Publish` is fire-and-forget
+(at-most-once), so there is **no error, no blocking, no queue growth, and no
+back-pressure**. A thread nobody has open cannot break or slow the worker.
+
+The cost that *is* paid on every channel thread reply, watched or not:
+
+1. `sonic.Marshal` of the `ClientMessage`
+2. the AES encode inside `encryptRoomEvent`
+3. `sonic.Marshal` of the encrypted envelope
+4. the write into the connection buffer and its syscall
+
+So each thread reply carries roughly two extra marshals and one encryption
+whether or not a single person is watching — and most threads are unwatched
+most of the time. For scale: the same handler already performs N per-account
+publishes (N = fan-out size) plus one or two badge publishes, so this is one
+more publish on a path that already does several. It is a real cost on the
+message hot path, not a rounding error, but it is proportionate.
+
+**There is no cheap way to avoid it.** Core NATS gives a publisher no API to
+ask whether a subject currently has subscribers, so "check before publishing"
+is not available. The only designs that avoid the wasted work are a config flag
+to disable the lane per deployment, or the viewer-registry approach rejected in
+§2 — publishing only to known-live viewers is precisely that approach's one
+advantage, bought with server state and heartbeats.
+
+**Recommendation: accept the cost, but make it observable.** The `thread_lane`
+delivery counter above is what makes a later decision data-driven rather than
+speculative. Revisit only if it shows the lane is a material share of
+broadcast-worker's publish volume.
+
+**Cross-site.** For a `crossSite=true` room the subject is the global
+`chat.room.>` namespace. NATS gateways propagate on interest, so a thread with
+no subscriber anywhere should not generate sustained cross-gateway traffic.
+Confirm this with the platform team before rollout rather than treating it as
+established — it depends on the supercluster's gateway configuration, which is
+outside this repo.
 
 **Extend `.semgrep/room-subject.yml`.** The `room-subject-publish-must-route`
 rule (`.semgrep/room-subject.yml:2`) exists to stop anyone passing an inline
@@ -282,6 +349,10 @@ global).
 - DM and BotDM rooms publish **nothing** to the thread lane
 - a thread-lane publish error is logged and swallowed: the handler returns nil
   and the per-account fan-out still happened
+- a thread-lane publish error does **not** mark the canonical message terminal
+  (no `MarkTerminalFromContext`), so redelivery accounting is unaffected
+- thread-lane deliveries are recorded under the `thread_lane` room kind, and no
+  fan-out recipient count is recorded for it
 
 Every existing thread test must pass untouched. That is the regression proof
 that this change is purely additive.

--- a/docs/superpowers/specs/2026-08-23-thread-viewer-lane-design.md
+++ b/docs/superpowers/specs/2026-08-23-thread-viewer-lane-design.md
@@ -181,11 +181,14 @@ requires the payload-level lock.
    `handler.go:782`) — no encryption step, one payload serves both lanes.
 4. The per-account copy stays **plaintext**. Encrypting it would change the
    wire format for existing clients on a lane that does not need it.
-5. **Strip `Mentions` and `MentionAll` from the thread-lane copy.** These stay
-   plaintext on the encrypted channel lane today, so on the thread lane they
-   would reveal who was @-mentioned in a thread to any subscriber. Nothing is
-   lost: any account that needs mention information is in the fan-out set and
-   receives the per-account copy, which keeps both fields.
+5. **Keep `Mentions` and `MentionAll` on the thread-lane copy**, identical to
+   the per-account copy. The frontend renders mentions with dedicated styling
+   driven by this resolved `Participant` list (account -> display name), so
+   dropping it would make a viewer's thread pane render mentions differently
+   from a follower's — breaking the equivalence this design exists to provide.
+   These two fields are already plaintext on the encrypted channel lane for
+   every ordinary message, so carrying them on the thread lane extends an
+   accepted exposure rather than creating a new one.
 
 **Consequence: two encodings.** Both encryption helpers mutate their event in
 place and clear the plaintext field, so the implementation must marshal and
@@ -207,9 +210,9 @@ thread content is no longer better-protected than channel content.
 
 Fields that remain plaintext on the thread lane, matching the existing channel
 lane: `roomId`, `roomName`, `roomType`, `siteId`, `userCount`, `lastMsgAt`,
-`lastMsgId`, `timestamp`, `eventTimestamp`, and on edits/deletes the message id
-and actor account. No new field is exposed that the channel lane does not
-already expose.
+`lastMsgId`, `timestamp`, `eventTimestamp`, `mentions`, `mentionAll`, and on
+edits/deletes the message id and actor account. No new field is exposed that
+the channel lane does not already expose.
 
 ## 6. Client contract
 
@@ -275,8 +278,7 @@ global).
   nil (edits: `encryptedNewContent` set, `newContent` empty); per-account copy
   still plaintext
 - `encrypt=false`: thread-lane copy is plaintext
-- `Mentions` / `MentionAll` present on the per-account copy, absent on the
-  thread-lane copy
+- `Mentions` / `MentionAll` present and identical on both copies
 - DM and BotDM rooms publish **nothing** to the thread lane
 - a thread-lane publish error is logged and swallowed: the handler returns nil
   and the per-account fan-out still happened
@@ -290,8 +292,7 @@ Required in the same PR by CLAUDE.md §5:
 
 - `docs/client-api.md` — new subject in the subject-patterns table; delivery
   notes on `new_thread_message`, `message_edited`, `message_deleted`
-  describing the viewer lane and the subscribe-on-open lifecycle; a note that
-  the thread lane omits `mentions` / `mentionAll`.
+  describing the viewer lane and the subscribe-on-open lifecycle.
 - `docs/client-api/events.md` and `docs/client-api/request-reply.md` — the
   derived views, updated to match.
 

--- a/docs/superpowers/specs/2026-08-23-thread-viewer-lane-design.md
+++ b/docs/superpowers/specs/2026-08-23-thread-viewer-lane-design.md
@@ -1,0 +1,331 @@
+# Thread Viewer Lane — live thread events for non-followers
+
+**Date:** 2026-08-23
+**Status:** Proposed
+**Related:** `2026-05-28-broadcast-worker-thread-handling-design.md`, `2026-07-28-local-global-room-subjects.md`
+
+A user who opens a thread they have never participated in receives no live
+reply events. This adds a per-thread NATS subject that any room member can
+subscribe to while the thread pane is open, and unsubscribe from when it
+closes. It is a delivery change only: no new persisted state, no change to who
+counts as a thread follower.
+
+## 1. Problem
+
+In a channel room, a thread reply is **not** published room-wide. It fans out
+per-account on `chat.user.{account}.event.room` to a recipient set built by
+`threadFanOutAccounts` (`broadcast-worker/handler.go:1081`):
+
+1. the reply author,
+2. the thread parent's author,
+3. thread followers — `thread_rooms.replyAccounts` (`broadcast-worker/store_mongo.go:162`),
+4. history-gated @-mentioned accounts.
+
+Everyone else in the room receives only `ThreadMetadataUpdatedEvent`
+(`pkg/model/event.go:434`), a content-free badge carrying `newTcount`,
+`parentMessageId`, `replyMessageId` and `action`. It is enough to update a
+reply-count badge and nothing else.
+
+Nothing makes a viewer a follower. There is no follow/subscribe RPC; `Get
+Thread Messages` emits nothing, and `Mark Thread as Read` is an idempotent
+no-op for a caller with no `ThreadSubscription`. Membership in the fan-out set
+is earned only by replying, authoring the parent, or being @-mentioned
+(`message-worker/handler.go:330`, `:370`, `:635`).
+
+So a user reading a thread they have not participated in sees a static
+transcript. The reply count ticks up; the replies never arrive.
+
+The same gap applies to edits and deletes of thread replies
+(`handleThreadUpdated` at `broadcast-worker/handler.go:356`,
+`handleThreadDeleted` at `:405`) — both fan out to followers only. A viewer can
+sit on content that has since been edited or deleted.
+
+**Not affected:** DM and BotDM rooms, where thread replies already reach every
+non-bot member (`publishDMEvents` for creates, `publishMutation` for
+edits/deletes). Reactions are also already room-wide for thread replies —
+`handleReacted` routes through `publishMutation` regardless of thread status.
+
+## 2. Decisions taken
+
+Recorded here because each closes off a design space that would otherwise be
+reopened during implementation.
+
+**Ephemeral, not durable.** Opening a thread grants live delivery for as long
+as the pane is open. It writes nothing: no `ThreadSubscription`, no
+`replyAccounts` entry, no thread-list row, no unread accumulation, no
+notification, no effect on `tcount`. Auto-follow-on-view was considered and
+rejected — it conflates "I glanced at this" with "keep telling me about this",
+and it would put every glanced-at thread into the user's thread list.
+
+**A subject the client subscribes to, not a server-side viewer registry.** The
+alternative was a "viewing thread X" RPC with a Valkey TTL set and heartbeats,
+with broadcast-worker unioning live viewers into the per-account fan-out. That
+keeps content on the already-authenticated per-account lane, but introduces
+per-viewer server state, heartbeat traffic, TTL expiry semantics, and a store
+dependency on the message hot path — to deliver a feature whose entire
+lifetime is "while a UI panel is open". A subject costs none of that.
+
+**A dedicated per-thread subject, not the existing room subject.** Publishing
+`new_thread_message` room-wide on `chat.room.{roomID}.event` would be a
+smaller diff, but every member's socket would then carry every thread reply in
+the room. A per-thread subject delivers only to sockets that asked for that
+thread.
+
+**Full content on the new lane, encrypted.** See §5.
+
+## 3. Subject and routing
+
+New builders in `pkg/subject`:
+
+```go
+// ThreadEvent returns the per-thread live lane for a channel room's thread.
+func ThreadEvent(roomID, parentMessageID string, global bool) string {
+	return roomBase(roomID, global) + ".thread." + parentMessageID + ".event"
+}
+
+// ThreadEventTargets returns the thread-lane subject(s) to publish to, routing
+// identically to RoomEventTargets.
+func ThreadEventTargets(roomID, parentMessageID string, crossSite *bool,
+	crossSiteAt *time.Time, mode RoomRouteMode, now time.Time) []string
+```
+
+Resulting subjects:
+
+- global: `chat.room.{roomID}.thread.{parentMessageId}.event`
+- local: `chat.local.room.{roomID}.thread.{parentMessageId}.event`
+
+`ThreadEventTargets` MUST delegate to the existing `roomRouteGlobals`
+(`pkg/subject/subject.go:421`), the same helper behind `RoomEventTargets` and
+`RoomMemberEventTargets`. This is not cosmetic reuse: it is what makes the
+thread lane honor `ROOM_SUBJECT_MODE`, the sticky `crossSite` flag, and the
+post-flip locality grace window. A hand-rolled subject would silently lose
+delivery for same-site rooms the moment local mode is enabled, and would lose
+dual mode's global safety-net publish.
+
+**Permissions: no change required.** The client JWT already grants
+`Sub allow: chat.user.{account}.>, chat.room.>, chat.local.room.>, _INBOX.>,
+chat.user.presence.state.*` (documented at `auth-service/handler.go:313`).
+Because the new subject sits under `roomBase`, it falls inside the existing
+`chat.room.>` / `chat.local.room.>` grants. No platform-team signing-template
+change, no `docker-local/setup.sh` change.
+
+**Cardinality.** One subject per (room, thread parent). NATS subjects are
+interest-based and cost nothing when nobody is subscribed, so an inactive
+thread's subject is free. A client holds at most one such subscription at a
+time (the open pane).
+
+## 4. broadcast-worker changes
+
+Each of the three thread handlers gains one additional publish **after** its
+existing per-account fan-out. The existing lane is untouched.
+
+| Handler | Existing (unchanged) | Added |
+|---|---|---|
+| `handleThreadCreated` (`handler.go:241`) | `new_thread_message` → `publishToThreadAccounts` | encrypted copy → thread lane |
+| `handleThreadUpdated` (`handler.go:356`) | `message_edited` → `publishToThreadAccounts` | encrypted copy → thread lane |
+| `handleThreadDeleted` (`handler.go:405`) | `message_deleted` → `publishToThreadAccounts` | same payload → thread lane |
+
+Only the `model.RoomTypeChannel` branch of each handler is touched. The
+DM/BotDM branches already reach every member and are left alone.
+
+New helper, mirroring `publishRoomEvent` (`handler.go:884`):
+
+```go
+func (h *Handler) publishThreadLaneEvent(ctx context.Context, roomID, parentMsgID string,
+	crossSite *bool, crossSiteAt *time.Time, payload []byte, op string) error
+```
+
+It loops `subject.ThreadEventTargets(...)` and publishes each target, with the
+same error aggregation and flow-logging shape as `publishRoomEvent`. The
+signature mirrors `publishRoomEvent`'s deliberately: `handleThreadCreated`
+holds a `roommetacache.Meta` (from `GetRoomMeta`) while `handleThreadUpdated`
+and `handleThreadDeleted` hold a `*model.Room` (from `GetRoom`). Taking the
+`crossSite` / `crossSiteAt` pair as parameters lets all three call it without
+converting between the two types.
+
+**Failure isolation.** A thread-lane publish failure MUST NOT fail the handler
+or block the per-account fan-out — it is logged and swallowed, the way
+`publishThreadBadge` (`handler.go:562`) already treats best-effort badge
+publishes. The per-account lane remains the delivery guarantee for followers;
+the thread lane is a convenience for viewers whose pane is open right now. A
+NAK-and-redeliver on a thread-lane failure would re-fan-out the per-account
+copy too, turning a cosmetic miss into duplicate delivery for everyone.
+
+**Extend `.semgrep/room-subject.yml`.** The `room-subject-publish-must-route`
+rule (`.semgrep/room-subject.yml:2`) exists to stop anyone passing an inline
+`subject.RoomEvent(...)` to a publish call and bypassing routing. Add
+`subject.ThreadEvent` to that rule so the thread lane inherits the same
+protection.
+
+## 5. Encryption and what is visible on the open lane
+
+`chat.room.>` is subscribable by **any** authenticated user, member or not.
+Room-lane confidentiality does not come from the subject; it comes from the
+payload. `publishChannelEvent` runs `encryptRoomEvent` (`handler.go:835`)
+before publishing, which encrypts the `ClientMessage` with the room key and
+sets `evt.Message = nil`. Room keys reach members only, via
+`chat.user.{account}.event.room.key`.
+
+Thread replies are plaintext today precisely because the per-account subject is
+scoped by the recipient's own JWT. Moving them to the room namespace therefore
+requires the payload-level lock.
+
+**Rules:**
+
+1. The thread-lane copy of `new_thread_message` MUST go through
+   `encryptRoomEvent`, exactly as `publishChannelEvent` does.
+2. The thread-lane copy of `message_edited` MUST go through
+   `encryptEditedContent` (`handler.go:802`), which sets `EncryptedNewContent`
+   and clears `NewContent`.
+3. `message_deleted` carries no message content (`buildDeleteRoomEvent`,
+   `handler.go:782`) — no encryption step, one payload serves both lanes.
+4. The per-account copy stays **plaintext**. Encrypting it would change the
+   wire format for existing clients on a lane that does not need it.
+5. **Strip `Mentions` and `MentionAll` from the thread-lane copy.** These stay
+   plaintext on the encrypted channel lane today, so on the thread lane they
+   would reveal who was @-mentioned in a thread to any subscriber. Nothing is
+   lost: any account that needs mention information is in the fan-out set and
+   receives the per-account copy, which keeps both fields.
+
+**Consequence: two encodings.** Both encryption helpers mutate their event in
+place and clear the plaintext field, so the implementation must marshal and
+publish the plaintext copy to the per-account lane **first**, then encrypt a
+separate value for the thread lane. Cost per thread reply when encryption is
+on: one extra `sonic.Marshal` plus one `Encode`. The room key comes from
+`currentRoomKey` (`handler.go:821`), already served by the key store's cache —
+no additional DB read.
+
+**Consequence: `ENCRYPTION_ENABLED=false` deployments.** The flag defaults to
+`false` (`broadcast-worker/main.go:37`). With it off, `encryptRoomEvent`
+returns early and thread-lane content is plaintext on a lane any authenticated
+user can subscribe to. This is the same exposure ordinary channel messages
+already have in that configuration — it is not a new class of leak — but it
+**is** a reduction for thread replies specifically, which are currently the
+best-protected message content in the system. Production runs with encryption
+enabled. Anyone standing up a deployment with it disabled must understand that
+thread content is no longer better-protected than channel content.
+
+Fields that remain plaintext on the thread lane, matching the existing channel
+lane: `roomId`, `roomName`, `roomType`, `siteId`, `userCount`, `lastMsgAt`,
+`lastMsgId`, `timestamp`, `eventTimestamp`, and on edits/deletes the message id
+and actor account. No new field is exposed that the channel lane does not
+already expose.
+
+## 6. Client contract
+
+Opening a thread:
+
+```
+subscribe chat.room.{roomID}.thread.{parentMessageId}.event
+```
+
+using the same `crossSite`-derived local/global prefix the client already uses
+to choose between `chat.room.{roomID}.event` and
+`chat.local.room.{roomID}.event`. No new locality concept.
+
+Closing the thread: unsubscribe. That is the whole lifecycle — no RPC, no
+server state, no TTL, no heartbeat, nothing to clean up if the client
+disconnects.
+
+Payloads are the existing `RoomEvent` / `EditRoomEvent` / `DeleteRoomEvent`
+shapes, with the encryption and mention-stripping rules of §5. No new event
+type and no new model struct.
+
+## 7. Duplicates and ordering
+
+**A follower who opens the thread receives every event twice** — once on
+`chat.user.{account}.event.room`, once on the thread lane. A NATS publish
+cannot exclude subscribers, so this is structural, not a defect to engineer
+around.
+
+It costs nothing to handle because clients must already deduplicate:
+broadcast-worker consumes MESSAGES-CANONICAL with `AckExplicitPolicy`
+(`pkg/stream/consumer.go:38`), so any redelivery re-runs the whole fan-out.
+At-least-once was already the contract.
+
+**Client rule: every message insert is an upsert keyed by `message.id`, never
+an append.** The two copies of one reply differ in encoding — one plaintext,
+one encrypted — so the client must key on id, not on payload equality. Whichever
+arrives second overwrites the first with identical decoded content.
+
+`thread_metadata_updated` is unchanged and still room-wide. With the pane open
+the viewer now gets replies live, so refetch-on-badge becomes the closed-pane
+fallback rather than the primary path. The client should refetch only when
+`replyMessageId` is absent from its cache.
+
+Ordering across the two lanes is not guaranteed. Clients already order by
+`eventTimestamp` (the canonical publish time) in preference to `timestamp`;
+that rule is unchanged and sufficient.
+
+## 8. Testing
+
+TDD per CLAUDE.md §4 — tests first, confirmed red, then implementation.
+
+**`pkg/subject/subject_test.go`** — table-driven `ThreadEventTargets` over the
+`crossSite` (nil / true / false) × `RoomRouteMode` (global / dual / local) ×
+grace-window (inside / outside) matrix, mirroring the existing
+`RoomEventTargets` cases, asserting subject strings and ordering (local before
+global).
+
+**`broadcast-worker/handler_test.go`**, for each of the three handlers:
+
+- thread lane receives the event, on the correct subject(s)
+- per-account lane still receives its existing payload, byte-for-byte unchanged
+- `encrypt=true`: thread-lane copy has `encryptedMessage` set and `message`
+  nil (edits: `encryptedNewContent` set, `newContent` empty); per-account copy
+  still plaintext
+- `encrypt=false`: thread-lane copy is plaintext
+- `Mentions` / `MentionAll` present on the per-account copy, absent on the
+  thread-lane copy
+- DM and BotDM rooms publish **nothing** to the thread lane
+- a thread-lane publish error is logged and swallowed: the handler returns nil
+  and the per-account fan-out still happened
+
+Every existing thread test must pass untouched. That is the regression proof
+that this change is purely additive.
+
+## 9. Documentation
+
+Required in the same PR by CLAUDE.md §5:
+
+- `docs/client-api.md` — new subject in the subject-patterns table; delivery
+  notes on `new_thread_message`, `message_edited`, `message_deleted`
+  describing the viewer lane and the subscribe-on-open lifecycle; a note that
+  the thread lane omits `mentions` / `mentionAll`.
+- `docs/client-api/events.md` and `docs/client-api/request-reply.md` — the
+  derived views, updated to match.
+
+No `pkg/model` struct changes, so no model-doc churn beyond the delivery
+description.
+
+## 10. Rollout and risk
+
+Additive and independently deployable. Deploying broadcast-worker with the new
+publish before any client subscribes produces publishes with no subscribers,
+which NATS discards — no cost, no behavior change. Clients can adopt the
+subscription whenever they ship.
+
+Reverting is a broadcast-worker rollback; clients subscribed to the thread lane
+simply stop receiving on it and fall back to the `thread_metadata_updated`
+refetch path they use today.
+
+**Residual risks:**
+
+- A deployment running `ENCRYPTION_ENABLED=false` puts thread content plaintext
+  on an openly-subscribable lane (§5).
+- A client that appends rather than upserts will show duplicate replies to
+  followers who open the thread (§7). This is the one client-side change that
+  is mandatory rather than optional.
+
+## 11. Out of scope
+
+- Any durable follow/unfollow API, and exposing the follower set to clients
+  (`thread_rooms.replyAccounts` remains server-only).
+- Unread, badge, and notification behavior for viewers — unchanged; a viewer
+  accrues nothing.
+- `thread_message_read` on the thread lane. It is already published room-wide,
+  so viewers receive it today; no change needed.
+- The `ThreadSubscription` / `replyAccounts` split (two collections written
+  non-atomically, so a client's "am I following" signal and the actual fan-out
+  set can diverge). Real, pre-existing, and unaffected by this change — the
+  viewer lane does not consult either.

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -459,6 +459,27 @@ func RoomMemberEventTargets(roomID string, crossSite *bool, crossSiteAt *time.Ti
 	return out
 }
 
+// ThreadEvent returns the per-thread live lane for a channel room's thread —
+// the subject a client subscribes to while a thread pane is open, so a viewer
+// who does not follow the thread still receives its replies.
+func ThreadEvent(roomID, parentMessageID string, global bool) string {
+	return roomBase(roomID, global) + ".thread." + parentMessageID + ".event"
+}
+
+// ThreadEventTargets returns the thread-lane subject(s) to publish a thread
+// create/edit/delete to. Routes identically to RoomEventTargets (shared
+// roomRouteGlobals) so the thread lane follows the room's own namespace: a
+// same-site room's thread events land on the local prefix once local mode is
+// enabled, and a flipped room dual-publishes during the grace window.
+func ThreadEventTargets(roomID, parentMessageID string, crossSite *bool, crossSiteAt *time.Time, mode RoomRouteMode, now time.Time) []string {
+	globals := roomRouteGlobals(crossSite, crossSiteAt, mode, now)
+	out := make([]string, len(globals))
+	for i, g := range globals {
+		out[i] = ThreadEvent(roomID, parentMessageID, g)
+	}
+	return out
+}
+
 func UserRoomEvent(account string) string {
 	return fmt.Sprintf("chat.user.%s.event.room", account)
 }

--- a/pkg/subject/subject_test.go
+++ b/pkg/subject/subject_test.go
@@ -1312,3 +1312,55 @@ func TestIsClientFacing(t *testing.T) {
 		})
 	}
 }
+
+func TestThreadEvent(t *testing.T) {
+	assert.Equal(t, "chat.room.r1.thread.p1.event", subject.ThreadEvent("r1", "p1", true))
+	assert.Equal(t, "chat.local.room.r1.thread.p1.event", subject.ThreadEvent("r1", "p1", false))
+}
+
+// TestThreadEventTargets verifies the thread lane routes on exactly the same
+// namespaces as RoomEventTargets — they share roomRouteGlobals, so a same-site
+// room's thread events land on the local namespace once local mode is enabled.
+func TestThreadEventTargets(t *testing.T) {
+	g := "chat.room.r1.thread.p1.event"
+	l := "chat.local.room.r1.thread.p1.event"
+	trueP, falseP := true, false
+	now := time.Unix(1_700_000_000, 0).UTC()
+
+	// cross-site rooms with no flip time (born cross-site) are ALWAYS global.
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", &trueP, nil, subject.RouteGlobal, now))
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", &trueP, nil, subject.RouteDual, now))
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", &trueP, nil, subject.RouteLocal, now))
+
+	// same-site rooms vary by mode.
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", &falseP, nil, subject.RouteGlobal, now))
+	assert.Equal(t, []string{l, g}, subject.ThreadEventTargets("r1", "p1", &falseP, nil, subject.RouteDual, now))
+	assert.Equal(t, []string{l}, subject.ThreadEventTargets("r1", "p1", &falseP, nil, subject.RouteLocal, now))
+
+	// nil locality is ALWAYS global — the fail-safe.
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", nil, nil, subject.RouteGlobal, now))
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", nil, nil, subject.RouteDual, now))
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", nil, nil, subject.RouteLocal, now))
+}
+
+// TestThreadEventTargets_TransitionGrace covers the post-flip grace window: a
+// room that just flipped same-site -> cross-site keeps a LOCAL copy for the
+// window in local/dual mode, so members still on the local subject don't go
+// dark on thread events until they re-subscribe.
+func TestThreadEventTargets_TransitionGrace(t *testing.T) {
+	g := "chat.room.r1.thread.p1.event"
+	l := "chat.local.room.r1.thread.p1.event"
+	trueP := true
+	flip := time.Unix(1_700_000_000, 0).UTC()
+	within := flip.Add(subject.DefaultRoomLocalityGrace - time.Minute)
+	after := flip.Add(subject.DefaultRoomLocalityGrace + time.Minute)
+
+	assert.Equal(t, []string{l, g}, subject.ThreadEventTargets("r1", "p1", &trueP, &flip, subject.RouteLocal, within))
+	assert.Equal(t, []string{l, g}, subject.ThreadEventTargets("r1", "p1", &trueP, &flip, subject.RouteDual, within))
+	// Within grace but global mode: no local audience -> global only.
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", &trueP, &flip, subject.RouteGlobal, within))
+	// After grace: global only.
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", &trueP, &flip, subject.RouteLocal, after))
+	// Exactly at the boundary is already expired (now.Before is strict).
+	assert.Equal(t, []string{g}, subject.ThreadEventTargets("r1", "p1", &trueP, &flip, subject.RouteLocal, flip.Add(subject.DefaultRoomLocalityGrace)))
+}


### PR DESCRIPTION
## Problem

Opening a channel thread you have never participated in gives you a static transcript. The reply count ticks up; the replies never arrive.

Channel thread replies fan out **per-account** to a recipient set built by `threadFanOutAccounts` — the reply author, the parent author, thread followers (`thread_rooms.replyAccounts`), and history-gated @-mentioned accounts. Everyone else in the room receives only `ThreadMetadataUpdatedEvent`, a content-free badge. Nothing makes a viewer a follower: there is no follow RPC, `Get Thread Messages` emits nothing, and `Mark Thread as Read` is a no-op for a non-subscriber.

The same gap applied to edits and deletes, so a viewer could sit on content that had since been corrected or removed.

## Approach

Channel thread creates, edits, and deletes are now **also** published to a new per-thread subject:

```
chat.room.{roomID}.thread.{parentMessageId}.event
chat.local.room.{roomID}.thread.{parentMessageId}.event   (same-site rooms)
```

A client subscribes while a thread pane is open and unsubscribes when it closes. That is the entire lifecycle — no RPC, no server-side state, no TTL, no heartbeat. Subscribing does **not** make you a follower: no thread subscription is created, no unread accrues, and the thread does not enter your thread list.

`ThreadEventTargets` delegates to the existing `roomRouteGlobals`, so the lane honours `ROOM_SUBJECT_MODE`, the sticky `crossSite` flag, and the post-flip locality grace window identically to `.event` and `.event.member`.

The pre-existing per-account follower lane is **unchanged and still plaintext** — this is purely additive. DM and BotDM rooms are excluded; they already deliver thread events to every member.

Design doc: `docs/superpowers/specs/2026-08-23-thread-viewer-lane-design.md`

## Confidentiality

This is the part worth reviewing carefully. Client JWTs carry a wildcard `chat.room.>` subscribe grant, so room-lane confidentiality comes from the payload, not the subject. Thread replies were previously plaintext precisely because the per-account subject is JWT-scoped to one recipient; moving content onto the room namespace requires the payload-level lock.

- Create and edit lane copies go through `encryptRoomEvent` / `encryptEditedContent` when `ENCRYPTION_ENABLED=true`, clearing the corresponding plaintext field.
- An encryption failure returns before any publish — no path falls through to plaintext on the lane.
- Deletes carry no message content (`DeleteRoomEvent`, with `PreviewMessage` nil for `tshow=false` replies), so one payload serves both lanes with no encryption step.
- `mentions` / `mentionAll` are deliberately **retained** on the lane copy — the frontend renders mention styling from that resolved participant list, and both fields are already plaintext on `chat.room.{roomID}.event` for every ordinary message.

With `ENCRYPTION_ENABLED=false` thread content is plaintext on an openly-subscribable lane — the same exposure ordinary channel messages already have in that configuration, but a reduction for thread content specifically. A warning comment now sits beside that env var in both deploy compose files.

## Client-visible changes

- **Deduplicate by `message.id`.** A follower who opens the thread receives each event on both lanes. Required regardless — broadcast-worker consumes MESSAGES-CANONICAL with `AckExplicitPolicy`, so redelivery already made delivery at-least-once.
- **The lane carries only `tshow=false` replies.** `tshow=true` thread replies and their edits/deletes bypass the thread handlers entirely and ride `chat.room.{roomID}.event` as ordinary `new_message` / `message_edited` / `message_deleted`. A pane rendered from the lane alone would silently drop them. Documented in §4.2.
- No new event type, no new model struct, no NATS permission change — the subject sits under `roomBase`, inside the existing grant.

## Changes

| Area | What |
|---|---|
| `pkg/subject` | `ThreadEvent`, `ThreadEventTargets` |
| `broadcast-worker/nats_metrics.go` | new `thread_lane` room kind — the lane is one publish to an unobservable audience, so it cannot share `thread`, whose fanout/deliveries pair is documented as directly comparable |
| `broadcast-worker/handler.go` | `publishThreadLaneEvent` + wiring into all three thread handlers |
| `.semgrep/room-subject.yml` | `subject.ThreadEvent` added to the routing guard |
| `docs/client-api.md` + both derived views | new subject, two-lane delivery, dedupe requirement, subscribe lifecycle |
| deploy compose files | encryption warning beside `ENCRYPTION_ENABLED` |

Also removes the empty-fan-out early return in the create and edit handlers: a bot-authored reply produces an empty per-account set, and a viewer with the pane open must still receive it.

## Testing

TDD throughout. `make test` green across every package; `make lint` clean; `gosec` and the repo's own offline semgrep rules clean.

Coverage includes both lanes per handler, encryption on and off, the encrypt-failure branch asserting **nothing** reaches the lane, failure-swallow at all three publish sites, empty fan-out still publishing to the lane, and DM/BotDM publishing nothing to it. Six pre-existing count assertions were bumped, each paired with a new assertion naming the lane record; no existing DM/BotDM test was modified — that is the regression guarantee.

> [!IMPORTANT]
> **The registry-backed SAST checks could not run in the authoring environment** — the sandbox network policy returns 403 for `semgrep.dev` and `vuln.go.dev`, so `make sast-semgrep` and `make sast-vuln` could not fetch their configs. The repo's own `.semgrep` rules and `gosec` were run and are clean. CI's blocking `sast` job needs to cover the rest before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2KmtQP7RtDj5zGzPrqvSw

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2KmtQP7RtDj5zGzPrqvSw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live per-thread event delivery for channel thread viewers, including new, edited, and deleted replies.
  - Thread updates now remain available even when there are no per-account recipients.
  - Added support for encrypted thread-lane messages and appropriate routing across local and global streams.

- **Documentation**
  - Documented subscription behavior, encryption, duplicate-event handling, and thread viewer lifecycle.
  - Clarified that direct room replies and private-message threads use existing delivery paths.

- **Bug Fixes**
  - Prevented thread-lane delivery failures from interrupting standard message delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->