### PR TITLE
perf(user-service): project the unread-badge query to the fields it reads

### DIFF
--- a/docs/superpowers/plans/2026-08-23-unread-count-projection-narrowing.md
+++ b/docs/superpowers/plans/2026-08-23-unread-count-projection-narrowing.md
@@ -1,0 +1,604 @@
+# Unread Count Projection Narrowing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop shipping a 41-field `model.EnrichedSubscription` per row from `GetActiveSubscriptions` when the unread badge reads five fields.
+
+**Architecture:** Add a terminal `$project` to the badge path's existing aggregation and decode into a new narrow row type. The pipeline's stages, filters, cap-before-join ordering and soft-delete drop are all unchanged — this removes fields from the *result*, not work from the *query*. A reflection-based unit test pins the projection to the row type's bson tags so the two cannot drift apart silently.
+
+**Tech Stack:** Go 1.25, MongoDB (`go.mongodb.org/mongo-driver/v2`), `go.uber.org/mock` (mockgen), `stretchr/testify`, `testcontainers-go` via `pkg/testutil`.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-unread-count-projection-narrowing-design.md`
+
+## Global Constraints
+
+- Go 1.25. Single `go.mod` at repo root.
+- **Always use `make` targets — never run raw `go` commands.** `make lint`, `make test SERVICE=user-service`, `make test-integration SERVICE=user-service`, `make generate SERVICE=user-service`, `make sast`.
+- **TDD is mandatory (Red-Green-Refactor), no exceptions.** Never write implementation before its test exists. Never skip the Red phase — if a test passes before implementation, the test is wrong.
+- All tests run with `-race` (the Makefile handles this).
+- Minimum 80% coverage per package; 90%+ for handlers, stores and `pkg/`.
+- Generated mocks (`user-service/service/mocks/mock_repository.go`) are **never** edited by hand — regenerate with `make generate SERVICE=user-service`.
+- Model structs carry both `json` and `bson` tags, `camelCase`, except `bson:"_id"`.
+- Errors always wrapped with context: `fmt.Errorf("short description: %w", err)`. Never a bare `err`.
+- MongoDB reads must project precisely — never fetch whole documents when a subset suffices.
+- Integration tests: `//go:build integration`, same package, containers from `pkg/testutil`. `user-service/mongorepo/main_test.go` already provides `TestMain`; do not add another.
+- A pre-commit hook runs lint and tests. Fix failures before retrying — never bypass it.
+- Branch: `claude/unread-path-optimization-sggzrk`, based on `main`. Never commit to `main`.
+- **No `docs/client-api.md` change:** this touches no client-facing handler, request/response struct or server→client event struct.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `user-service/models/subscription.go` | Service-owned types; gains the badge row type | Modify |
+| `user-service/mongorepo/subscriptions.go` | The aggregation: new collection handle, projection helper, changed return type | Modify |
+| `user-service/mongorepo/subscriptions_activeproj_test.go` | Unit: projection/row-type drift guard, row-size and no-key-material guards | Create |
+| `user-service/service/service.go` | Consumer-defined `SubscriptionRepository` interface | Modify |
+| `user-service/service/mocks/mock_repository.go` | Generated mocks | Regenerate |
+| `user-service/service/subscriptions.go` | `unreadRooms` — the only consumer of the result | Modify |
+| `user-service/service/subscriptions_test.go` | 22 mocked `GetActiveSubscriptions` returns | Modify |
+| `user-service/service/badge_test.go` | 7 mocked `GetActiveSubscriptions` returns | Modify |
+| `user-service/service/service_test.go` | 1 mocked `GetActiveSubscriptions` return | Modify |
+| `user-service/mongorepo/subscriptions_test.go` | Integration: 9 `GetActiveSubscriptions` call sites, 3 of which key on `sub.ID` | Modify |
+
+**Why `user-service/models/` and not `pkg/model/`:** `mongorepo` already imports `user-service/models` (`apps.go:13`, `users.go:15`), so the direction is established. The interface lives in `service/`, which cannot reference a `mongorepo` type without inverting the dependency, so the type must live in a package both can import.
+
+---
+
+### Task 1: The row type, the projection, and the drift guard
+
+Adds the type and the projection helper with their unit tests. Changes no production behavior — the helper is not wired in until Task 2, so this task compiles, tests green, and is independently reviewable.
+
+**Files:**
+- Modify: `user-service/models/subscription.go` (append at end of file)
+- Modify: `user-service/mongorepo/subscriptions.go` (append helper near `activeSubscriptionFilter`, around `:428`)
+- Create: `user-service/mongorepo/subscriptions_activeproj_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `models.ActiveSubscription` — struct with exported fields `RoomID string`, `SiteID string`, `LastSeenAt *time.Time`, `ThreadUnread []string`, `LastMsgAt *time.Time`.
+  - `mongorepo.activeSubscriptionProjection() bson.M` — unexported, returns the terminal `$project` document.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `user-service/mongorepo/subscriptions_activeproj_test.go`:
+
+```go
+package mongorepo
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/user-service/models"
+)
+
+// bsonTagKeys returns the stored bson field names of a flat struct, sorted.
+// Tag options like ",omitempty" are stripped so a differently written tag still
+// matches, and bson:"-" fields are skipped as never stored.
+func bsonTagKeys(t *testing.T, typ reflect.Type) []string {
+	t.Helper()
+	keys := []string{}
+	for i := 0; i < typ.NumField(); i++ {
+		tag := typ.Field(i).Tag.Get("bson")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		keys = append(keys, strings.Split(tag, ",")[0])
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// The badge path decodes into models.ActiveSubscription, so the terminal
+// $project must name exactly that struct's fields. Adding a field to the struct
+// without projecting it would decode as a zero value — a wrong badge with no
+// error anywhere — so the two are pinned to each other here.
+func TestActiveSubscriptionProjection_MatchesRowType(t *testing.T) {
+	proj := activeSubscriptionProjection()
+
+	idVal, hasID := proj["_id"]
+	require.True(t, hasID, "_id must be named explicitly (Mongo returns it by default)")
+	assert.Equal(t, 0, idVal, "_id must be excluded, not included")
+
+	got := []string{}
+	for k, v := range proj {
+		if k == "_id" {
+			continue
+		}
+		assert.Equal(t, 1, v, "projection %q must be an inclusion", k)
+		got = append(got, k)
+	}
+	sort.Strings(got)
+
+	assert.Equal(t, bsonTagKeys(t, reflect.TypeOf(models.ActiveSubscription{})), got,
+		"activeSubscriptionProjection and models.ActiveSubscription must name the same fields")
+}
+
+// The point of the narrow row is what it does NOT carry: the room's E2E key
+// slot, its counts, and the rest of the subscription document.
+func TestActiveSubscriptionRow_IsLeanAndCarriesNoKeyMaterial(t *testing.T) {
+	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+
+	lean, err := bson.Marshal(models.ActiveSubscription{
+		RoomID:       "01970a4f8c2d7c9aabcde01234567890",
+		SiteID:       "site-a",
+		LastSeenAt:   &now,
+		ThreadUnread: []string{"01970a4f8c2d7c9aabcde01234567891"},
+		LastMsgAt:    &now,
+	})
+	require.NoError(t, err)
+
+	fat, err := bson.Marshal(model.EnrichedSubscription{
+		Subscription: model.Subscription{
+			ID:       "01970a4f8c2d7c9aabcde01234567892",
+			User:     model.SubscriptionUser{ID: "01970a4f8c2d7c9aabcde01234567893", Account: "alice"},
+			RoomID:   "01970a4f8c2d7c9aabcde01234567890",
+			SiteID:   "site-a",
+			Roles:    []model.Role{model.RoleMember},
+			Name:     "engineering-general",
+			RoomType: model.RoomTypeChannel,
+			JoinedAt: now, LastSeenAt: &now,
+			ThreadUnread:      []string{"01970a4f8c2d7c9aabcde01234567891"},
+			Alert:             true,
+			Open:              true,
+			FavoriteUpdatedAt: &now, MuteUpdatedAt: &now, RolesUpdatedAt: &now,
+			NameUpdatedAt: &now, RestrictUpdatedAt: &now, SectionUpdatedAt: &now,
+		},
+		UserCount: 42, LastMsgAt: &now, LastMsgID: "01970a4f8c2d7c9aabcde0123456789a",
+		LastMentionAllAt: &now, MinUserLastSeenAt: &now, AppCount: 2,
+		RoomName:    "engineering-general",
+		RoomKeyPriv: make([]byte, 120),
+		RoomKeyVer:  3,
+	})
+	require.NoError(t, err)
+
+	// The number goes in the PR description; the assertion just guards the direction.
+	t.Logf("ActiveSubscription=%dB EnrichedSubscription=%dB ratio=%.1fx",
+		len(lean), len(fat), float64(len(fat))/float64(len(lean)))
+	assert.Less(t, len(lean), len(fat), "the badge row must be smaller than the enriched row")
+	assert.NotContains(t, string(lean), "encKey", "no room key material may reach the badge path")
+}
+
+// The row type's bson tags must match what the subscriptions collection actually
+// stores. The projection guard above only proves the projection and the struct
+// agree with each other — decoding a marshalled Subscription proves both name
+// real stored fields.
+func TestActiveSubscription_DecodesFromFullSubscriptionDocument(t *testing.T) {
+	seen := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+	sub := model.Subscription{
+		ID:           "01970a4f8c2d7c9aabcde01234567892",
+		User:         model.SubscriptionUser{Account: "alice"},
+		RoomID:       "01970a4f8c2d7c9aabcde01234567890",
+		SiteID:       "site-a",
+		RoomType:     model.RoomTypeChannel,
+		LastSeenAt:   &seen,
+		ThreadUnread: []string{"pm-1"},
+	}
+	b, err := bson.Marshal(&sub)
+	require.NoError(t, err)
+
+	var row models.ActiveSubscription
+	require.NoError(t, bson.Unmarshal(b, &row))
+	assert.Equal(t, sub.RoomID, row.RoomID)
+	assert.Equal(t, sub.SiteID, row.SiteID)
+	require.NotNil(t, row.LastSeenAt)
+	assert.Equal(t, seen.UTC(), row.LastSeenAt.UTC())
+	assert.Equal(t, sub.ThreadUnread, row.ThreadUnread)
+	assert.Nil(t, row.LastMsgAt, "lastMsgAt is added by the rooms join, never stored on the subscription")
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `make test SERVICE=user-service`
+
+Expected: FAIL to compile — `undefined: activeSubscriptionProjection` and `undefined: models.ActiveSubscription` (all three tests in the file). A compile failure is a valid Red phase in Go; do not proceed until you have seen it.
+
+- [ ] **Step 3: Add the row type**
+
+Append to `user-service/models/subscription.go` (the file already has `import "github.com/hmchangw/chat/pkg/model"`; add `"time"` to the import block, making it a parenthesized group):
+
+```go
+// ActiveSubscription is the badge path's row: the five fields unreadRooms reads
+// off each active subscription. GetActiveSubscriptions projects to exactly these,
+// so a field absent from this struct is a field the query does not fetch — the
+// narrow type is the contract, not a convenience. json tags are present per the
+// repo's struct-tag rule; nothing serializes this type to a client.
+type ActiveSubscription struct {
+	RoomID       string     `json:"roomId"                 bson:"roomId"`
+	SiteID       string     `json:"siteId"                 bson:"siteId"`
+	LastSeenAt   *time.Time `json:"lastSeenAt,omitempty"   bson:"lastSeenAt,omitempty"`
+	ThreadUnread []string   `json:"threadUnread,omitempty" bson:"threadUnread,omitempty"`
+	// LastMsgAt is the joined room's activity timestamp, added by roomsEnrichStages.
+	// Nil for a cross-site sub (no local room document) and for a room with no
+	// messages — unread() treats both as "not unread".
+	LastMsgAt *time.Time `json:"lastMsgAt,omitempty" bson:"lastMsgAt,omitempty"`
+}
+```
+
+- [ ] **Step 4: Add the projection helper**
+
+In `user-service/mongorepo/subscriptions.go`, directly after `activeSubscriptionFilter` (ends around `:443`):
+
+```go
+// activeSubscriptionProjection is the terminal $project for the badge path: the
+// exact fields models.ActiveSubscription decodes, and nothing else. Everything
+// roomsEnrichStages adds beyond lastMsgAt — the room's counts, its E2E key slot,
+// the sort key — is dropped here instead of being shipped and discarded.
+// TestActiveSubscriptionProjection_MatchesRowType pins it to the struct.
+func activeSubscriptionProjection() bson.M {
+	return bson.M{
+		"_id":          0,
+		"roomId":       1,
+		"siteId":       1,
+		"lastSeenAt":   1,
+		"threadUnread": 1,
+		"lastMsgAt":    1,
+	}
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `make test SERVICE=user-service`
+Expected: PASS. Note the byte numbers printed by `TestActiveSubscriptionRow_IsLeanAndCarriesNoKeyMaterial` — they are needed in Task 3.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+make lint
+git add user-service/models/subscription.go user-service/mongorepo/subscriptions.go user-service/mongorepo/subscriptions_activeproj_test.go
+git commit -m "feat(user-service): narrow row type and projection for the badge path
+
+models.ActiveSubscription names the five fields unreadRooms reads;
+activeSubscriptionProjection is pinned to it by a reflection test so a
+field added to one without the other fails the build rather than
+decoding as a silent zero value."
+```
+
+---
+
+### Task 2: Wire the projection into `GetActiveSubscriptions`
+
+The type change crosses the repo, the interface, the mocks and the service at once — `setup_test.go` asserts `_ service.SubscriptionRepository = (*SubscriptionRepo)(nil)` at compile time, so a partial switch does not build. This task is therefore atomic by necessity, and is the one a reviewer accepts or rejects as a whole.
+
+**Files:**
+- Modify: `user-service/mongorepo/subscriptions.go:22-56` (struct + constructor), `:467-479` (`GetActiveSubscriptions`)
+- Modify: `user-service/service/service.go:26-30` (interface entry)
+- Regenerate: `user-service/service/mocks/mock_repository.go`
+- Modify: `user-service/service/subscriptions.go:586-673` (`unreadRooms`)
+- Modify: `user-service/mongorepo/subscriptions_test.go` (integration, 9 call sites)
+- Modify: `user-service/service/subscriptions_test.go`, `user-service/service/badge_test.go`, `user-service/service/service_test.go`
+
+**Interfaces:**
+- Consumes: `models.ActiveSubscription`, `activeSubscriptionProjection()` from Task 1.
+- Produces: `SubscriptionRepo.GetActiveSubscriptions(ctx context.Context, account string, limit int) ([]models.ActiveSubscription, error)` — same name and parameters, new element type.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add to `user-service/mongorepo/subscriptions_test.go` (already `//go:build integration`, package `mongorepo`, and already importing `time`, `bson`, `assert` and `require`). Add one import to that file:
+
+```go
+	"github.com/hmchangw/chat/user-service/models"
+```
+
+
+```go
+// The badge path must come back with exactly the five fields it reads, correctly
+// populated for a local room, a room with no messages, and a cross-site sub with
+// no local room document at all.
+func TestGetActiveSubscriptions_ProjectsBadgeFields_Integration(t *testing.T) {
+	r, db := newTestSubscriptionRepo(t)
+	ctx := context.Background()
+	lastMsg := time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC)
+	seen := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+
+	seed(t, db, "rooms",
+		bson.M{"_id": "p-room", "name": "Eng", "siteId": "site-a", "lastMsgAt": lastMsg,
+			"userCount": 9, "appCount": 1, "encKey": bson.M{"priv": make([]byte, 120), "ver": 3}},
+		bson.M{"_id": "p-quiet", "name": "Quiet", "siteId": "site-a"},
+	)
+	seed(t, db, "subscriptions",
+		bson.M{"_id": "p-sub", "u": bson.M{"_id": "u-alice", "account": "alice"}, "name": "Eng",
+			"roomId": "p-room", "roomType": "channel", "siteId": "site-a",
+			"lastSeenAt": seen, "threadUnread": []string{"pm-1", "pm-2"}},
+		bson.M{"_id": "p-sub-quiet", "u": bson.M{"_id": "u-alice", "account": "alice"}, "name": "Quiet",
+			"roomId": "p-quiet", "roomType": "channel", "siteId": "site-a"},
+		bson.M{"_id": "p-sub-remote", "u": bson.M{"_id": "u-alice", "account": "alice"}, "name": "Remote",
+			"roomId": "p-remote", "roomType": "channel", "siteId": "site-b", "lastSeenAt": seen},
+	)
+
+	subs, err := r.GetActiveSubscriptions(ctx, "alice", 100)
+	require.NoError(t, err)
+
+	byRoom := map[string]models.ActiveSubscription{}
+	for _, s := range subs {
+		byRoom[s.RoomID] = s
+	}
+	require.Len(t, byRoom, 3)
+
+	local := byRoom["p-room"]
+	assert.Equal(t, "site-a", local.SiteID)
+	require.NotNil(t, local.LastSeenAt)
+	assert.Equal(t, seen.UTC(), local.LastSeenAt.UTC())
+	require.NotNil(t, local.LastMsgAt, "the joined room's lastMsgAt must survive the projection")
+	assert.Equal(t, lastMsg.UTC(), local.LastMsgAt.UTC())
+	assert.Equal(t, []string{"pm-1", "pm-2"}, local.ThreadUnread)
+
+	quiet := byRoom["p-quiet"]
+	assert.Nil(t, quiet.LastMsgAt, "a room with no messages has no lastMsgAt")
+	assert.Nil(t, quiet.LastSeenAt, "an unread-from-birth sub has no lastSeenAt")
+
+	remote := byRoom["p-remote"]
+	assert.Equal(t, "site-b", remote.SiteID)
+	assert.Nil(t, remote.LastMsgAt, "a cross-site sub has no local room document")
+	require.NotNil(t, remote.LastSeenAt)
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `make test-integration SERVICE=user-service`
+
+Expected: FAIL to compile — `GetActiveSubscriptions` still returns `[]model.EnrichedSubscription`, which has no such literal shape, and `models` is not imported in the test file. Confirm the failure before implementing.
+
+- [ ] **Step 3: Add the typed collection handle**
+
+In `user-service/mongorepo/subscriptions.go`, add the field to `SubscriptionRepo` (after `enrichedSecondary`, `:33`):
+
+```go
+	// activeSecondary decodes the badge path's narrow projection over the same
+	// subscriptions collection; routed to a secondary like the other read handles.
+	activeSecondary *mongoutil.Collection[models.ActiveSubscription]
+```
+
+In `NewSubscriptionRepo`, after `enriched := mongoutil.NewCollection[model.EnrichedSubscription](col)`:
+
+```go
+	active := mongoutil.NewCollection[models.ActiveSubscription](col)
+```
+
+and in the returned struct literal, after `enrichedSecondary: enriched.WithReadPreference(s.readPref),`:
+
+```go
+		activeSecondary:        active.WithReadPreference(s.readPref),
+```
+
+Add `"github.com/hmchangw/chat/user-service/models"` to the import block.
+
+- [ ] **Step 4: Switch the query**
+
+Replace `GetActiveSubscriptions` (`:467-479`) entirely with:
+
+```go
+// GetActiveSubscriptions returns the active set used by the unread count,
+// capped by limit. The cap runs before the rooms join so $lookup touches
+// ≤limit rows; the deleted-room filter runs after it, so a capped page can
+// come back slightly short — tolerable for the unread count, its only consumer.
+// The terminal projection returns only the fields unreadRooms reads: the room
+// baseline beyond lastMsgAt (counts, key slot, sort key) is dropped here rather
+// than decoded and discarded.
+func (r *SubscriptionRepo) GetActiveSubscriptions(ctx context.Context, account string, limit int) ([]models.ActiveSubscription, error) {
+	pipeline := bson.A{bson.M{"$match": activeSubscriptionFilter(account)}}
+	pipeline = append(pipeline, r.originFilterStage(account)...)
+	// MongoDB rejects $limit:0 — treat it as "no cap".
+	if limit > 0 {
+		pipeline = append(pipeline, bson.M{"$limit": int64(limit)})
+	}
+	pipeline = append(pipeline, roomsEnrichStages(true)...)
+	pipeline = append(pipeline, bson.M{"$project": activeSubscriptionProjection()})
+	return r.activeSecondary.Aggregate(ctx, pipeline)
+}
+```
+
+The `$project` goes **after** `roomsEnrichStages`: the `^Del-` `$match` inside those stages consumes `room.name`, and `originFilterStage` has already matched on `origin`, so neither filter can be affected by dropping those fields from the output.
+
+- [ ] **Step 5: Update the interface**
+
+In `user-service/service/service.go`, replace the `GetActiveSubscriptions` entry and its comment (`:26-30`) with:
+
+```go
+	// GetActiveSubscriptions returns up to limit active subscriptions, projected
+	// to the five fields the unread count reads. The cap is applied before the
+	// deleted-room filter, so a page whose capped slice contains soft-deleted
+	// rooms comes back slightly short of limit — fine for the unread count (its
+	// only consumer), not a general pagination surface.
+	GetActiveSubscriptions(ctx context.Context, account string, limit int) ([]models.ActiveSubscription, error)
+```
+
+`models` is already imported in this file.
+
+- [ ] **Step 6: Regenerate the mocks**
+
+Run: `make generate SERVICE=user-service`
+
+Never hand-edit `user-service/service/mocks/mock_repository.go`. Confirm the diff shows only the `GetActiveSubscriptions` return type changing.
+
+- [ ] **Step 7: Migrate `unreadRooms`**
+
+In `user-service/service/subscriptions.go`, inside `unreadRooms` (`:586`), change the one declaration that names the old type:
+
+```go
+	crossBySite := map[string][]model.EnrichedSubscription{}
+```
+
+to:
+
+```go
+	crossBySite := map[string][]models.ActiveSubscription{}
+```
+
+Every field access in the function (`subs[i].SiteID`, `.LastSeenAt`, `.LastMsgAt`, `.ThreadUnread`, `.RoomID`, and the same five on `siteSubs[j]`) is unchanged — the new type carries all of them with identical names and types. Verify `models` is imported in this file; add it if not.
+
+- [ ] **Step 8: Migrate the service unit tests**
+
+In `user-service/service/subscriptions_test.go` (22 sites), `user-service/service/badge_test.go` (7 sites) and `user-service/service/service_test.go` (1 site), rewrite each mocked return. The embedded-struct literal flattens:
+
+```go
+// before
+Return([]model.EnrichedSubscription{
+    {Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &newer},
+}, nil)
+
+// after
+Return([]models.ActiveSubscription{
+    {RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen, LastMsgAt: &newer},
+}, nil)
+```
+
+Empty and nil returns change type only: `[]model.EnrichedSubscription{}` → `[]models.ActiveSubscription{}`; `Return(nil, errors.New("db down"))` is untouched. Do not change any assertion or expected count — this migration must not alter a single test's meaning. If a test stops passing, the production change is wrong, not the test.
+
+- [ ] **Step 9: Migrate the integration tests that key on `sub.ID`**
+
+The projection drops `_id`, so three sites in `user-service/mongorepo/subscriptions_test.go` must key on `RoomID` instead. Use this fixture mapping:
+
+| subscription `_id` | `roomId` |
+|---|---|
+| `a-dm` | `r-dm` |
+| `a-ch` | `r-ch` |
+| `a-bot` | `r-bot` |
+| `x-ch` | `rx` |
+| `gone-ch` | `r-missing` |
+| `m-ch` | `r-noisy` |
+| `u-bot` | `r-offbot` |
+| `mu-bot` | `r-mutedbot` |
+| `del-ch` | `r-del` |
+| `closed-ch` | `r-closed` |
+| `open-ch` | `r-open` |
+| `sub-xsite-teams` | `r-xsite-teams` |
+| `sub-xsite-native` | `r-xsite-native` |
+
+**Site A** — `~:379`, the Teams-origin test: `unreadIDs[s.ID] = true` becomes `unreadIDs[s.RoomID] = true`, and the assertion becomes:
+
+```go
+	assert.False(t, unreadIDs["r-xsite-teams"], "unread set must exclude the cross-site Teams room")
+```
+
+**Site B** — `~:716`, the "closed rooms" subtest: `got[sub.ID] = true` becomes `got[sub.RoomID] = true`, then:
+
+```go
+		assert.False(t, got["r-closed"], "open:false must not count")
+		assert.True(t, got["r-open"], "open:true must count")
+		assert.True(t, got["r-ch"], "a sub with no open field must count")
+```
+
+**Site C** — `~:731`, the "get active returns the same set" subtest: `got[sub.ID] = true` becomes `got[sub.RoomID] = true`, then:
+
+```go
+		assert.True(t, got["r-dm"])
+		assert.True(t, got["r-ch"])
+		assert.True(t, got["r-bot"])
+		assert.True(t, got["rx"], "cross-site sub kept despite no local room")
+		assert.True(t, got["r-missing"], "missing local room now kept (empty enrichment) — siteID filter removed, deleted-filter is room.name-based")
+		assert.False(t, got["r-noisy"], "muted channel excluded from the active/count set")
+		assert.False(t, got["r-offbot"])
+		assert.False(t, got["r-mutedbot"], "muted botDM excluded by activeSubscriptionFilter before room lookup")
+		assert.False(t, got["r-del"], "local sub to a ^Del- room must be filtered out")
+```
+
+The remaining call sites (`~:748` limit cap, `~:756` zero limit, `~:771` empty set) assert only on `len(subs)` / emptiness and need no change.
+
+- [ ] **Step 10: Run the unit tests**
+
+Run: `make test SERVICE=user-service`
+Expected: PASS, with no assertion or expected-count changes from Step 8.
+
+- [ ] **Step 11: Run the integration tests**
+
+Run: `make test-integration SERVICE=user-service`
+Expected: PASS, including the new `TestGetActiveSubscriptions_ProjectsBadgeFields_Integration` from Step 1.
+
+Requires a running Docker daemon. If none is available in your environment, say so explicitly in the handoff rather than reporting the suite as passing — CI's `test-integration (user-service)` job is then the gate.
+
+- [ ] **Step 12: Lint and commit**
+
+```bash
+make lint
+git add user-service/mongorepo/subscriptions.go user-service/service/service.go user-service/service/mocks/mock_repository.go user-service/service/subscriptions.go user-service/service/subscriptions_test.go user-service/service/badge_test.go user-service/service/service_test.go user-service/mongorepo/subscriptions_test.go
+git commit -m "perf(user-service): project the badge path to the fields it reads
+
+GetActiveSubscriptions returned a full EnrichedSubscription per row — the
+whole subscription document plus eleven joined room fields including the
+room's E2E key slot — for the five fields unreadRooms reads. A terminal
+\$project and models.ActiveSubscription cut that to the read set.
+
+The pipeline is otherwise unchanged: same filters, same cap-before-join
+ordering, same soft-delete drop, so the short-page contract holds. The
+projection sits after the enrich stages, whose \$match consumes room.name
+before it is dropped."
+```
+
+---
+
+### Task 3: Verification sweep and measurement
+
+Produces the numbers the PR description needs and confirms the repo-wide gates.
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-08-23-unread-count-projection-narrowing-design.md` (§8, record the measured sizes)
+
+**Interfaces:**
+- Consumes: the byte figures logged by `TestActiveSubscriptionRow_IsLeanAndCarriesNoKeyMaterial` (Task 1, Step 5).
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Capture the measurement**
+
+Run: `make test SERVICE=user-service` and read the `t.Logf` line from `TestActiveSubscriptionRow_IsLeanAndCarriesNoKeyMaterial`.
+
+Record the two byte counts and the ratio. The `test` target (`Makefile:106-111`) is a
+bare `go test -race ./$(SERVICE)/...` with no verbose flag and no way to select a
+single test — there is no "Makefile's verbose path" to fall back to, and this plan's
+"never run raw `go` commands" rule rules out routing around `make test` with a
+hand-invoked `go test -v`. If `make test`'s output does not surface the `t.Logf`
+line for a passing test, take the figures from the implementer's own report of
+having seen them during Task 1 instead of trying to obtain them a second way here.
+
+- [ ] **Step 2: Record it in the spec**
+
+In `docs/superpowers/specs/2026-08-23-unread-count-projection-narrowing-design.md`, §8 currently says the row's exact size is a deliverable. Replace that sentence with the measured figures, in the form:
+
+```markdown
+Measured: `models.ActiveSubscription` <N> B against `model.EnrichedSubscription`
+<M> B on representative rows, <R>×. PR #197's 759 B figure for the enriched row
+is the same measurement on its own fixture.
+```
+
+- [ ] **Step 3: Run the full repo test suite**
+
+Run: `make test`
+Expected: PASS. `unreadRooms`'s type change is contained to user-service, but the whole suite is the gate for a store-interface change.
+
+- [ ] **Step 4: Run SAST**
+
+Run: `make sast`
+Expected: no medium-or-above findings. `gosec`, `govulncheck` and `semgrep` are a blocking CI gate. If `govulncheck` or the semgrep registry cannot reach their hosts from your environment, say so explicitly and rely on CI's `sast` job — do not report a scan you did not run.
+
+- [ ] **Step 5: Commit and push**
+
+```bash
+git add docs/superpowers/specs/2026-08-23-unread-count-projection-narrowing-design.md
+git commit -m "docs(user-service): record the measured badge-row sizes"
+git push -u origin claude/unread-path-optimization-sggzrk
+```
+
+Do **not** open a pull request unless asked.
+
+---
+
+## Notes for the reviewer of this plan
+
+- **No behavior change is intended anywhere.** Every filter, the cap-before-join order, the short-page contract, the per-site degradation semantics in `unreadRooms` and the `degraded` caching rule are untouched. If a pre-existing test needs its expectations changed, that is a signal the implementation is wrong.
+- **What this does not do:** the `$lookup` still fetches eleven room fields per row inside the pipeline, `encKey.priv` among them. The projection stops them crossing the wire and being decoded; it does not stop the read, and it saves no index seeks. Removing the read needs a caller-specific `$lookup` — deliberately out of scope (spec §11).
+- **Task 2 is atomic on purpose.** `setup_test.go`'s compile-time interface assertion means the repo, interface, mocks and service cannot change in separate commits.

--- a/docs/superpowers/specs/2026-08-23-unread-count-projection-narrowing-design.md
+++ b/docs/superpowers/specs/2026-08-23-unread-count-projection-narrowing-design.md
@@ -1,0 +1,231 @@
+# Unread Count: Projection Narrowing on the Badge Path
+
+**Date:** 2026-08-23
+**Status:** Proposed
+**Related:** `2026-08-19-badge-precise-read-invalidation-design.md` (§11, lever "A2"),
+PR #197 (`subscription.list` phased read), PR #353 (`Del-` filter removal, **merged** as `66324f6`)
+
+## 1. Problem
+
+`GetActiveSubscriptions` (`user-service/mongorepo/subscriptions.go:496`) serves the
+unread badge. It is reached from two call sites, both hot:
+
+- `CountSubscriptions` with `unread:true` (`user-service/service/subscriptions.go:565`),
+  which the desktop client refetches after every `markRoomRead` — opening a room is
+  the most frequent action in the product.
+- `BadgeCountBatch` (`user-service/service/badge.go:29`), per account, on the push
+  path, whenever the Valkey badge set misses.
+
+Both go through `unreadRooms` (`service/subscriptions.go:586`), which reads exactly
+**five** fields off each row: `RoomID`, `SiteID`, `LastSeenAt`, `ThreadUnread`, and
+the joined `LastMsgAt`.
+
+What it is handed instead is `model.EnrichedSubscription`: the whole subscription
+document — `u`, `roles`, `name`, `roomType`, `joinedAt`, `hasMention`, `alert`,
+`muted`, `favorite`, `sectionId`, `sectionOrder`, `open`, `restricted`,
+`externalAccess`, six `*UpdatedAt` fields, `origin`, `historySharedSince`,
+`isSubscribed` — plus all eleven fields the rooms join adds, including the room's
+E2E key material (`encKeyPriv`, `encKeyVer`).
+
+PR #197 measured this shape directly while optimizing the list path: 759 bytes per
+`EnrichedSubscription` row against 130 bytes for its narrowed equivalent, ≈5.8×.
+That measurement was never applied to the badge path.
+
+## 2. Scope
+
+**In:**
+
+- `GetActiveSubscriptions` (`mongorepo/subscriptions.go:496`) — one added stage and a
+  changed return type.
+- Its `SubscriptionRepository` entry (`service/service.go:30`) and the regenerated
+  `service/mocks/mock_repository.go`.
+- `unreadRooms`'s decode target (`service/subscriptions.go:586`).
+- A new row type in `user-service/models/`.
+
+**Out:**
+
+- `CountActiveSubscriptions` — PR #353 (merged) replaced its aggregation with a plain
+  `CountDocuments`, so there is no join left to narrow.
+- `roomsEnrichStages` (`:80`) — shared by four other callers; untouched.
+- `subscription.list`, the cross-site `GetRoomsMeta` lane, `pkg/badgecache`.
+- Every client-facing schema: no handler registration, request/response struct or
+  server→client event struct changes.
+
+## 3. Design
+
+### 3.1 The projection
+
+The pipeline keeps its current shape — `$match` → `originFilterStage` → `$limit` →
+`roomsEnrichStages(true)` — and gains one terminal `$project` naming the five
+consumed fields with `_id: 0`.
+
+Placement matters and is safe at both ends:
+
+- The `origin` exclusion is folded into `activeFilter` (#353) and applies in the
+  leading `$match`, so dropping `origin` from the output cannot affect filtering.
+- Nothing after `roomsEnrichStages` reads a room field other than `lastMsgAt`, which
+  `$addFields` hoists to the top level before the projection whitelists it.
+
+Behavior is unchanged in every respect. The cap still precedes the join, and since
+#353 removed the deleted-room drop, no stage after the cap can drop a row — the
+interface's "the page is exactly limit" contract holds verbatim.
+
+**Superseded by #353:** earlier drafts of this section argued the projection was
+safe because the `^Del-` `$match` consumed `room.name` inside `roomsEnrichStages`
+before the terminal stage dropped it. That filter no longer exists, so the argument
+is moot rather than wrong — the projection needs no such justification now.
+
+### 3.2 The row type
+
+`GetActiveSubscriptions` returns `[]models.ActiveSubscription` — a new five-field
+type in `user-service/models/subscription.go`, alongside the service's other owned
+types. `LastMsgAt` stays `*time.Time` so `timeutil.TimeToMillis` is unchanged.
+
+A narrow type rather than a narrowly-populated `EnrichedSubscription`: leaving the
+old type in place while filling five of its forty-one fields is a silent trap. A later
+reader of `sub.Room`, `sub.UserCount` or `sub.HasMention` on this result would get
+a zero value with nothing to signal that the field was never fetched. The narrow
+type makes the contract compile-time.
+
+Blast radius is contained — `unreadRooms` is the only consumer of this method's
+result.
+
+### 3.3 What this buys, and what it does not
+
+This is a **wire-and-decode** win, not a Mongo-CPU one. The `$lookup` still fetches
+eleven room fields per row inside the pipeline; the terminal `$project` stops ten of
+them from crossing the wire and being unmarshalled into a fat struct in
+user-service. This is the term PR #197 measured on its own path at 759 B → 130 B.
+Measured here: `models.ActiveSubscription` 167 B against `model.EnrichedSubscription`
+895 B on representative rows, 5.4×. `threadUnread` is a variable-length array, so
+the ratio differs from PR #197's.
+
+Stated plainly so nobody expects more: **`encKey.priv` is still read inside the
+pipeline. It is no longer shipped to user-service.** Eliminating the read requires a
+caller-specific `$lookup` projection, which means not sharing `roomsEnrichStages` —
+out of scope here, and one of the reasons the de-join remains worth revisiting.
+
+No seek relief. Counting unread requires `lastMsgAt` for every active room, so the
+per-row room lookups are irreducible without a cache or denormalization.
+
+## 4. Rejected alternatives
+
+**Return `[]string` of unread room IDs from the repo.** Leaner still, but it would
+move the unread comparison into repository code for local rows while the cross-site
+lane keeps folding it in `unreadRooms` via `unread()`. Two spellings of one
+predicate — including the subtle never-read (`LastSeenAt == nil`) and no-messages
+(`LastMsgAt == nil`) cases — is exactly the duplication this codebase has been
+consolidating away from.
+
+**Push the comparison into the pipeline** (`$expr: {$gt: [...]}`, count with
+`$count`). Same objection, plus `$expr` across a joined field is unindexable, so
+there is no compensating index win.
+
+**De-join into a projected subscriptions read plus a batched `rooms` `$in`.** The
+technique PR #197 applied to the list path. It saves per-row subpipeline setup,
+`$unwind` and `$addFields`, but not one index seek — the list path's win came from a
+page/N asymmetry (500 seeks to return 20 rows) that the unread path does not have,
+since every active room's `lastMsgAt` is genuinely needed. Deferred; see §9.
+
+## 5. Drift guard
+
+The hazard this change introduces is silent, not loud: someone adds a field to
+`unreadRooms`, forgets the `$project`, and reads a zero value instead of getting an
+error — a wrong badge with no failure anywhere.
+
+PR #197 hit the same hazard and solved it with a reflection helper (`bsonTagPaths`
+in `subscriptions_lite_test.go`) that derives the expected key set from a struct's
+bson tags. This design mirrors it: a unit test asserting the projection's key set
+equals `ActiveSubscription`'s bson tags exactly, so adding a field to the struct
+without projecting it fails the test. If #197 lands first, the two helpers converge
+into one.
+
+## 6. Error handling and degradation
+
+Unchanged. Same `Aggregate` call and the same `fmt.Errorf("...: %w", err)` wrap; no
+new failure mode. `unreadRooms`'s per-site degradation semantics, the `degraded`
+flag, and the rule that a degraded result is never cached are all untouched.
+
+## 7. Testing
+
+TDD throughout — every test written first and confirmed failing for the intended
+reason.
+
+**Unit:**
+
+- Projection/struct drift guard (§5).
+- `ActiveSubscription` decodes correctly from a full subscription document (it is a
+  subset of the same shape).
+- BSON-size assertion in PR #197's style: `bson.Marshal` one representative row of
+  each type and assert only the size *direction* (`assert.Less`), logging the ratio
+  via `t.Logf` rather than pinning it — a pinned ratio would be brittle against any
+  future `pkg/model` field addition.
+
+**Integration** (`//go:build integration`, `testutil.MongoDB`, under the package's
+existing `TestMain`):
+
+- One account fixture spanning local, cross-site, muted, closed and soft-deleted
+  rooms; assert the returned rows carry values identical to today's and that the
+  dropped fields are absent.
+- Cross-site row (no local room document) still comes back with a nil `LastMsgAt`
+  rather than being dropped.
+- `threadUnread` survives the projection.
+
+The bulk of the diff is existing service tests whose mocked `GetActiveSubscriptions`
+returns `[]model.EnrichedSubscription`, moving to the new type. Run `make generate`
+before testing — the store interface changes.
+
+## 8. Measurement
+
+No timed baseline exists for `subscription.count`, and this sandbox has no Docker
+daemon, so the byte measurement of §7, following the method PR #197 already used
+and published, is what stands in for it here.
+
+Measured: `models.ActiveSubscription` 167 B against `model.EnrichedSubscription`
+895 B on representative rows, 5.4×. PR #197's 759 B figure for the enriched row
+is the same measurement on its own fixture.
+
+Correctness is covered by CI's `test-integration (user-service)` job against a
+real MongoDB.
+
+Post-deploy confirmation: `subscription.count` latency traces, and user-service
+memory/GC pressure, which is where a 5.4× reduction in decoded document volume on a
+hot path should show up first.
+
+## 9. Interaction with PR #197 and PR #353
+
+**#353 has since merged** (`66324f6`) and this branch was rebased onto it; #197
+remains open. This design depends on neither.
+
+- **#353** removed `Del-` filtering entirely, dropping `roomsEnrichStages`'s
+  parameter and its regex `$match`, folding `originFilterStage` into `activeFilter`,
+  and deleting `SubscriptionRepo.siteID`. The rebase adopted all of it: this change
+  adds a stage *after* the enrich stages and calls no filter of its own. Two
+  consequences worth recording — the integration assertion that a `^Del-` room is
+  excluded became "no room name is filtered from the active set", and the
+  short-page caveat this document used to carry is obsolete.
+- **#197** rewrites `AggregateSubscriptions` and adds `NewSubscriptionRepo`
+  parameters, but leaves `GetActiveSubscriptions` untouched. Its out-of-scope note
+  argues the method needs no attention because `$limit` precedes the join. That
+  argument is correct about *seeks* and is why §4 defers the de-join — but it
+  reasons only about seek count, and does not address the document-volume term that
+  #197 itself led with, nor the fact that this path runs on far hotter triggers than
+  the list path.
+
+## 10. Documentation
+
+No `docs/client-api.md` obligation: no client-facing handler, request/response
+struct or event struct changes. The `SubscriptionRepository` doc comment on
+`GetActiveSubscriptions` is updated to name the new return type.
+
+## 11. Follow-ups (not in this change)
+
+- Removing the `encKey.priv` read from the badge path, which needs a
+  caller-specific `$lookup` rather than the shared stage.
+- The de-join, and/or reusing #197's `sortKeyCache` to serve `lastMsgAt` — the
+  latter carries a staleness asymmetry the list path does not have: a stale-old
+  `lastMsgAt` here is a false negative (a room that just received a message reads as
+  read) bounded by the cache TTL, tolerable only if the Valkey bump is the freshness
+  path, i.e. with `BADGE_COUNT_CACHE_FIRST=true`.
+- Lever "A3" from the 2026-08-19 spec: per-account singleflight and a recompute
+  cooldown for reconnect storms and deploys.

--- a/user-service/models/subscription.go
+++ b/user-service/models/subscription.go
@@ -1,6 +1,10 @@
 package models
 
-import "github.com/hmchangw/chat/pkg/model"
+import (
+	"time"
+
+	"github.com/hmchangw/chat/pkg/model"
+)
 
 // SubscriptionListRequest is the body of subscription.list.
 // Type ∈ {current, rooms, apps}. UpdatedWithinDays nil ⇒ no age filter.
@@ -67,4 +71,20 @@ type CountRequest struct {
 // CountResponse is returned by subscription.count.
 type CountResponse struct {
 	Count int `json:"count"`
+}
+
+// ActiveSubscription is the badge path's row: the five fields unreadRooms reads
+// off each active subscription. GetActiveSubscriptions projects to exactly these,
+// so a field absent from this struct is a field the query does not fetch — the
+// narrow type is the contract, not a convenience. json tags are present per the
+// repo's struct-tag rule; nothing serializes this type to a client.
+type ActiveSubscription struct {
+	RoomID       string     `json:"roomId"                 bson:"roomId"`
+	SiteID       string     `json:"siteId"                 bson:"siteId"`
+	LastSeenAt   *time.Time `json:"lastSeenAt,omitempty"   bson:"lastSeenAt,omitempty"`
+	ThreadUnread []string   `json:"threadUnread,omitempty" bson:"threadUnread,omitempty"`
+	// LastMsgAt is the joined room's activity timestamp, added by roomsEnrichStages.
+	// Nil for a cross-site sub (no local room document) and for a room with no
+	// messages — unread() treats both as "not unread".
+	LastMsgAt *time.Time `json:"lastMsgAt,omitempty" bson:"lastMsgAt,omitempty"`
 }

--- a/user-service/models/subscription.go
+++ b/user-service/models/subscription.go
@@ -73,18 +73,13 @@ type CountResponse struct {
 	Count int `json:"count"`
 }
 
-// ActiveSubscription is the badge path's row: the five fields unreadRooms reads
-// off each active subscription. GetActiveSubscriptions projects to exactly these,
-// so a field absent from this struct is a field the query does not fetch — the
-// narrow type is the contract, not a convenience. json tags are present per the
-// repo's struct-tag rule; nothing serializes this type to a client.
+// ActiveSubscription is the badge path's row: the five fields unreadRooms reads.
+// A field absent here is a field GetActiveSubscriptions does not fetch.
 type ActiveSubscription struct {
 	RoomID       string     `json:"roomId"                 bson:"roomId"`
 	SiteID       string     `json:"siteId"                 bson:"siteId"`
 	LastSeenAt   *time.Time `json:"lastSeenAt,omitempty"   bson:"lastSeenAt,omitempty"`
 	ThreadUnread []string   `json:"threadUnread,omitempty" bson:"threadUnread,omitempty"`
-	// LastMsgAt is the joined room's activity timestamp, added by roomsEnrichStages.
-	// Nil for a cross-site sub (no local room document) and for a room with no
-	// messages — unread() treats both as "not unread".
+	// Joined from the room; nil for a cross-site sub or a room with no messages.
 	LastMsgAt *time.Time `json:"lastMsgAt,omitempty" bson:"lastMsgAt,omitempty"`
 }

--- a/user-service/mongorepo/subscriptions.go
+++ b/user-service/mongorepo/subscriptions.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/user-service/models"
 )
 
 const subscriptionsCollection = "subscriptions"
@@ -28,6 +29,9 @@ type SubscriptionRepo struct {
 	// primary handle.
 	subscriptionsSecondary *mongoutil.Collection[model.Subscription]
 	enrichedSecondary      *mongoutil.Collection[model.EnrichedSubscription]
+	// activeSecondary decodes the badge path's narrow projection over the same
+	// subscriptions collection; routed to a secondary like the other read handles.
+	activeSecondary *mongoutil.Collection[models.ActiveSubscription]
 	// showTeamsRoom mirrors SHOW_TEAMS_ROOM: false (default) excludes
 	// Teams-migrated rooms (origin "teams") from list/count results.
 	showTeamsRoom bool
@@ -42,11 +46,13 @@ func NewSubscriptionRepo(db *mongo.Database, opts ...Option) *SubscriptionRepo {
 	col := db.Collection(subscriptionsCollection)
 	subscriptions := mongoutil.NewCollection[model.Subscription](col)
 	enriched := mongoutil.NewCollection[model.EnrichedSubscription](col)
+	active := mongoutil.NewCollection[models.ActiveSubscription](col)
 	return &SubscriptionRepo{
 		subscriptions:          subscriptions,
 		enriched:               enriched,
 		subscriptionsSecondary: subscriptions.WithReadPreference(s.readPref),
 		enrichedSecondary:      enriched.WithReadPreference(s.readPref),
+		activeSecondary:        active.WithReadPreference(s.readPref),
 		showTeamsRoom:          s.showTeamsRoom,
 		showTeamsAccounts:      s.showTeamsAccounts,
 	}
@@ -463,17 +469,32 @@ func (r *SubscriptionRepo) CountActiveSubscriptions(ctx context.Context, account
 	return int(n), nil
 }
 
-// GetActiveSubscriptions returns the active set used by the unread count, capped by
-// limit. The cap runs before the rooms join, so $lookup touches ≤limit rows and the
-// page is exactly limit — no stage after the cap can drop a row.
-func (r *SubscriptionRepo) GetActiveSubscriptions(ctx context.Context, account string, limit int) ([]model.EnrichedSubscription, error) {
+// activeSubscriptionPipeline builds the exact aggregation pipeline
+// GetActiveSubscriptions runs. It exists so the raw-BSON guard in
+// subscriptions_test.go (TestGetActiveSubscriptions_ProjectsBadgeFields_Integration)
+// can execute the identical pipeline instead of a hand-rebuilt copy: if the
+// terminal $project were ever dropped from production, that test's assertion
+// on the raw document's keys would fail immediately, because it would be
+// running production's own pipeline rather than a copy that could drift out
+// of sync with it.
+func (r *SubscriptionRepo) activeSubscriptionPipeline(account string, limit int) bson.A {
 	pipeline := bson.A{bson.M{"$match": r.activeFilter(account)}}
 	// MongoDB rejects $limit:0 — treat it as "no cap".
 	if limit > 0 {
 		pipeline = append(pipeline, bson.M{"$limit": int64(limit)})
 	}
 	pipeline = append(pipeline, roomsEnrichStages()...)
-	return r.enrichedSecondary.Aggregate(ctx, pipeline)
+	pipeline = append(pipeline, bson.M{"$project": activeSubscriptionProjection()})
+	return pipeline
+}
+
+// GetActiveSubscriptions returns the active set used by the unread count, capped by
+// limit. The cap runs before the rooms join, so $lookup touches ≤limit rows and the
+// page is exactly limit — no stage after the cap can drop a row. The terminal
+// projection returns only the fields unreadRooms reads: the room baseline beyond
+// lastMsgAt (counts, key slot, sort key) is dropped rather than decoded and discarded.
+func (r *SubscriptionRepo) GetActiveSubscriptions(ctx context.Context, account string, limit int) ([]models.ActiveSubscription, error) {
+	return r.activeSecondary.Aggregate(ctx, r.activeSubscriptionPipeline(account, limit))
 }
 
 // GetAppSubscription returns the requester's botDM subscription for botName, or (nil, nil).

--- a/user-service/mongorepo/subscriptions.go
+++ b/user-service/mongorepo/subscriptions.go
@@ -436,6 +436,22 @@ func (r *SubscriptionRepo) activeFilter(account string) bson.M {
 	return filter
 }
 
+// activeSubscriptionProjection is the terminal $project for the badge path: the
+// exact fields models.ActiveSubscription decodes, and nothing else. Everything
+// roomsEnrichStages adds beyond lastMsgAt — the room's counts, its E2E key slot,
+// the sort key — is dropped here instead of being shipped and discarded.
+// TestActiveSubscriptionProjection_MatchesRowType pins it to the struct.
+func activeSubscriptionProjection() bson.M {
+	return bson.M{
+		"_id":          0,
+		"roomId":       1,
+		"siteId":       1,
+		"lastSeenAt":   1,
+		"threadUnread": 1,
+		"lastMsgAt":    1,
+	}
+}
+
 // CountActiveSubscriptions counts the active set with a plain CountDocuments —
 // subscription state only, no room lookup. Room names carry no meaning here: no
 // name excludes a subscription from the count.

--- a/user-service/mongorepo/subscriptions.go
+++ b/user-service/mongorepo/subscriptions.go
@@ -442,11 +442,7 @@ func (r *SubscriptionRepo) activeFilter(account string) bson.M {
 	return filter
 }
 
-// activeSubscriptionProjection is the terminal $project for the badge path: the
-// exact fields models.ActiveSubscription decodes, and nothing else. Everything
-// roomsEnrichStages adds beyond lastMsgAt — the room's counts, its E2E key slot,
-// the sort key — is dropped here instead of being shipped and discarded.
-// TestActiveSubscriptionProjection_MatchesRowType pins it to the struct.
+// activeSubscriptionProjection is the terminal $project: exactly the fields models.ActiveSubscription decodes.
 func activeSubscriptionProjection() bson.M {
 	return bson.M{
 		"_id":          0,
@@ -469,14 +465,8 @@ func (r *SubscriptionRepo) CountActiveSubscriptions(ctx context.Context, account
 	return int(n), nil
 }
 
-// activeSubscriptionPipeline builds the exact aggregation pipeline
-// GetActiveSubscriptions runs. It exists so the raw-BSON guard in
-// subscriptions_test.go (TestGetActiveSubscriptions_ProjectsBadgeFields_Integration)
-// can execute the identical pipeline instead of a hand-rebuilt copy: if the
-// terminal $project were ever dropped from production, that test's assertion
-// on the raw document's keys would fail immediately, because it would be
-// running production's own pipeline rather than a copy that could drift out
-// of sync with it.
+// activeSubscriptionPipeline builds the pipeline GetActiveSubscriptions runs. The
+// raw-BSON guard runs this same builder, so a dropped $project fails a test.
 func (r *SubscriptionRepo) activeSubscriptionPipeline(account string, limit int) bson.A {
 	pipeline := bson.A{bson.M{"$match": r.activeFilter(account)}}
 	// MongoDB rejects $limit:0 — treat it as "no cap".
@@ -488,11 +478,7 @@ func (r *SubscriptionRepo) activeSubscriptionPipeline(account string, limit int)
 	return pipeline
 }
 
-// GetActiveSubscriptions returns the active set used by the unread count, capped by
-// limit. The cap runs before the rooms join, so $lookup touches ≤limit rows and the
-// page is exactly limit — no stage after the cap can drop a row. The terminal
-// projection returns only the fields unreadRooms reads: the room baseline beyond
-// lastMsgAt (counts, key slot, sort key) is dropped rather than decoded and discarded.
+// GetActiveSubscriptions returns the active set for the unread count, capped before the join.
 func (r *SubscriptionRepo) GetActiveSubscriptions(ctx context.Context, account string, limit int) ([]models.ActiveSubscription, error) {
 	return r.activeSecondary.Aggregate(ctx, r.activeSubscriptionPipeline(account, limit))
 }

--- a/user-service/mongorepo/subscriptions_activeproj_test.go
+++ b/user-service/mongorepo/subscriptions_activeproj_test.go
@@ -1,0 +1,140 @@
+package mongorepo
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/user-service/models"
+)
+
+// bsonTagKeys returns the stored bson field names of a flat struct, sorted.
+// Tag options like ",omitempty" are stripped so a differently written tag still
+// matches, and bson:"-" fields are skipped as never stored. A field with no
+// bson tag at all fails the test outright rather than being skipped: an
+// untagged field would still be stored under a driver-derived name, would not
+// be named in the projection, and would silently decode as a zero value — the
+// exact wrong-badge hazard this guard exists to catch.
+func bsonTagKeys(t *testing.T, typ reflect.Type) []string {
+	t.Helper()
+	keys := []string{}
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		tag := field.Tag.Get("bson")
+		if tag == "-" {
+			continue
+		}
+		require.NotEmpty(t, tag, "field %s.%s has no bson tag", typ.Name(), field.Name)
+		keys = append(keys, strings.Split(tag, ",")[0])
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// The badge path decodes into models.ActiveSubscription, so the terminal
+// $project must name exactly that struct's fields. Adding a field to the struct
+// without projecting it would decode as a zero value — a wrong badge with no
+// error anywhere — so the two are pinned to each other here.
+func TestActiveSubscriptionProjection_MatchesRowType(t *testing.T) {
+	proj := activeSubscriptionProjection()
+
+	idVal, hasID := proj["_id"]
+	require.True(t, hasID, "_id must be named explicitly (Mongo returns it by default)")
+	assert.Equal(t, 0, idVal, "_id must be excluded, not included")
+
+	got := []string{}
+	for k, v := range proj {
+		if k == "_id" {
+			continue
+		}
+		assert.Equal(t, 1, v, "projection %q must be an inclusion", k)
+		got = append(got, k)
+	}
+	sort.Strings(got)
+
+	assert.Equal(t, bsonTagKeys(t, reflect.TypeOf(models.ActiveSubscription{})), got,
+		"activeSubscriptionProjection and models.ActiveSubscription must name the same fields")
+}
+
+// Confirms the marshalled badge row is smaller than the marshalled enriched
+// row — a coarse size-direction check only. It cannot prove no key material
+// reaches the badge path, since both structs here are hardcoded literals, not
+// a real query result; that guarantee is what
+// TestGetActiveSubscriptions_ProjectsBadgeFields_Integration's raw-BSON
+// assertion in subscriptions_test.go actually covers.
+func TestActiveSubscriptionRow_IsLean(t *testing.T) {
+	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+
+	lean, err := bson.Marshal(models.ActiveSubscription{
+		RoomID:       "01970a4f8c2d7c9aabcde01234567890",
+		SiteID:       "site-a",
+		LastSeenAt:   &now,
+		ThreadUnread: []string{"01970a4f8c2d7c9aabcde01234567891"},
+		LastMsgAt:    &now,
+	})
+	require.NoError(t, err)
+
+	fat, err := bson.Marshal(model.EnrichedSubscription{
+		Subscription: model.Subscription{
+			ID:       "01970a4f8c2d7c9aabcde01234567892",
+			User:     model.SubscriptionUser{ID: "01970a4f8c2d7c9aabcde01234567893", Account: "alice"},
+			RoomID:   "01970a4f8c2d7c9aabcde01234567890",
+			SiteID:   "site-a",
+			Roles:    []model.Role{model.RoleMember},
+			Name:     "engineering-general",
+			RoomType: model.RoomTypeChannel,
+			JoinedAt: now, LastSeenAt: &now,
+			ThreadUnread:      []string{"01970a4f8c2d7c9aabcde01234567891"},
+			Alert:             true,
+			Open:              true,
+			FavoriteUpdatedAt: &now, MuteUpdatedAt: &now, RolesUpdatedAt: &now,
+			NameUpdatedAt: &now, RestrictUpdatedAt: &now, SectionUpdatedAt: &now,
+		},
+		UserCount: 42, LastMsgAt: &now, LastMsgID: "01970a4f8c2d7c9aabcde0123456789a",
+		LastMentionAllAt: &now, MinUserLastSeenAt: &now, AppCount: 2,
+		RoomName:    "engineering-general",
+		RoomKeyPriv: make([]byte, 120),
+		RoomKeyVer:  3,
+	})
+	require.NoError(t, err)
+
+	// The number goes in the PR description; the assertion just guards the direction.
+	t.Logf("ActiveSubscription=%dB EnrichedSubscription=%dB ratio=%.1fx",
+		len(lean), len(fat), float64(len(fat))/float64(len(lean)))
+	assert.Less(t, len(lean), len(fat), "the badge row must be smaller than the enriched row")
+}
+
+// The row type's bson tags must match what the subscriptions collection actually
+// stores. The projection guard above only proves the projection and the struct
+// agree with each other — decoding a marshalled Subscription proves both name
+// real stored fields.
+func TestActiveSubscription_DecodesFromFullSubscriptionDocument(t *testing.T) {
+	seen := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+	sub := model.Subscription{
+		ID:           "01970a4f8c2d7c9aabcde01234567892",
+		User:         model.SubscriptionUser{Account: "alice"},
+		RoomID:       "01970a4f8c2d7c9aabcde01234567890",
+		SiteID:       "site-a",
+		RoomType:     model.RoomTypeChannel,
+		LastSeenAt:   &seen,
+		ThreadUnread: []string{"pm-1"},
+	}
+	b, err := bson.Marshal(&sub)
+	require.NoError(t, err)
+
+	var row models.ActiveSubscription
+	require.NoError(t, bson.Unmarshal(b, &row))
+	assert.Equal(t, sub.RoomID, row.RoomID)
+	assert.Equal(t, sub.SiteID, row.SiteID)
+	require.NotNil(t, row.LastSeenAt)
+	assert.Equal(t, seen.UTC(), row.LastSeenAt.UTC())
+	assert.Equal(t, sub.ThreadUnread, row.ThreadUnread)
+	assert.Nil(t, row.LastMsgAt, "lastMsgAt is added by the rooms join, never stored on the subscription")
+}

--- a/user-service/mongorepo/subscriptions_activeproj_test.go
+++ b/user-service/mongorepo/subscriptions_activeproj_test.go
@@ -15,13 +15,8 @@ import (
 	"github.com/hmchangw/chat/user-service/models"
 )
 
-// bsonTagKeys returns the stored bson field names of a flat struct, sorted.
-// Tag options like ",omitempty" are stripped so a differently written tag still
-// matches, and bson:"-" fields are skipped as never stored. A field with no
-// bson tag at all fails the test outright rather than being skipped: an
-// untagged field would still be stored under a driver-derived name, would not
-// be named in the projection, and would silently decode as a zero value — the
-// exact wrong-badge hazard this guard exists to catch.
+// bsonTagKeys returns a flat struct's stored bson field names, sorted, skipping
+// bson:"-". An untagged field fails outright — it would decode as a silent zero.
 func bsonTagKeys(t *testing.T, typ reflect.Type) []string {
 	t.Helper()
 	keys := []string{}
@@ -38,10 +33,7 @@ func bsonTagKeys(t *testing.T, typ reflect.Type) []string {
 	return keys
 }
 
-// The badge path decodes into models.ActiveSubscription, so the terminal
-// $project must name exactly that struct's fields. Adding a field to the struct
-// without projecting it would decode as a zero value — a wrong badge with no
-// error anywhere — so the two are pinned to each other here.
+// $project and the struct must name the same fields, or a missing one decodes as a silent zero.
 func TestActiveSubscriptionProjection_MatchesRowType(t *testing.T) {
 	proj := activeSubscriptionProjection()
 
@@ -63,12 +55,7 @@ func TestActiveSubscriptionProjection_MatchesRowType(t *testing.T) {
 		"activeSubscriptionProjection and models.ActiveSubscription must name the same fields")
 }
 
-// Confirms the marshalled badge row is smaller than the marshalled enriched
-// row — a coarse size-direction check only. It cannot prove no key material
-// reaches the badge path, since both structs here are hardcoded literals, not
-// a real query result; that guarantee is what
-// TestGetActiveSubscriptions_ProjectsBadgeFields_Integration's raw-BSON
-// assertion in subscriptions_test.go actually covers.
+// Coarse size-direction check; the raw-BSON integration guard proves the no-leak claim.
 func TestActiveSubscriptionRow_IsLean(t *testing.T) {
 	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
 
@@ -111,10 +98,7 @@ func TestActiveSubscriptionRow_IsLean(t *testing.T) {
 	assert.Less(t, len(lean), len(fat), "the badge row must be smaller than the enriched row")
 }
 
-// The row type's bson tags must match what the subscriptions collection actually
-// stores. The projection guard above only proves the projection and the struct
-// agree with each other — decoding a marshalled Subscription proves both name
-// real stored fields.
+// Proves the tags name real stored fields, not just each other.
 func TestActiveSubscription_DecodesFromFullSubscriptionDocument(t *testing.T) {
 	seen := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
 	sub := model.Subscription{

--- a/user-service/mongorepo/subscriptions_test.go
+++ b/user-service/mongorepo/subscriptions_test.go
@@ -14,6 +14,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 
 	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/user-service/models"
 )
 
 func TestAggregateSubscriptions_Integration(t *testing.T) {
@@ -381,10 +382,10 @@ func TestAggregateSubscriptions_HidesCrossSiteTeamsRoom_Integration(t *testing.T
 	require.NoError(t, err)
 	unreadIDs := map[string]bool{}
 	for _, s := range subs {
-		unreadIDs[s.ID] = true
+		unreadIDs[s.RoomID] = true
 	}
-	assert.False(t, unreadIDs["sub-xsite-teams"], "unread set must exclude the cross-site Teams room")
-	assert.True(t, unreadIDs["sub-xsite-native"], "unread set must include the native cross-site room")
+	assert.False(t, unreadIDs["r-xsite-teams"], "unread set must exclude the cross-site Teams room")
+	assert.True(t, unreadIDs["r-xsite-native"], "unread set must include the native cross-site room")
 }
 
 // TestFindChannelsByMembers_CrossSite_Integration exercises the SEPARATE roomMatchStages
@@ -740,11 +741,11 @@ func TestCountAndGetActiveSubscriptions_Integration(t *testing.T) {
 		require.NoError(t, err)
 		got := map[string]bool{}
 		for _, sub := range subs {
-			got[sub.ID] = true
+			got[sub.RoomID] = true
 		}
-		assert.False(t, got["closed-ch"], "open:false must not count")
-		assert.True(t, got["open-ch"], "open:true must count")
-		assert.True(t, got["a-ch"], "a sub with no open field must count")
+		assert.False(t, got["r-closed"], "open:false must not count")
+		assert.True(t, got["r-open"], "open:true must count")
+		assert.True(t, got["r-ch"], "a sub with no open field must count")
 	})
 
 	t.Run("get active returns the same set", func(t *testing.T) {
@@ -752,17 +753,17 @@ func TestCountAndGetActiveSubscriptions_Integration(t *testing.T) {
 		require.NoError(t, err)
 		got := map[string]bool{}
 		for _, sub := range subs {
-			got[sub.ID] = true
+			got[sub.RoomID] = true
 		}
-		assert.True(t, got["a-dm"])
-		assert.True(t, got["a-ch"])
-		assert.True(t, got["a-bot"])
-		assert.True(t, got["x-ch"], "cross-site sub kept despite no local room")
-		assert.True(t, got["gone-ch"], "missing local room kept (empty enrichment)")
-		assert.False(t, got["m-ch"], "muted channel excluded from the active/count set")
-		assert.False(t, got["u-bot"])
-		assert.False(t, got["mu-bot"], "muted botDM excluded by activeSubscriptionFilter before room lookup")
-		assert.True(t, got["del-ch"], "no room name is filtered from the active set")
+		assert.True(t, got["r-dm"])
+		assert.True(t, got["r-ch"])
+		assert.True(t, got["r-bot"])
+		assert.True(t, got["rx"], "cross-site sub kept despite no local room")
+		assert.True(t, got["r-missing"], "missing local room kept (empty enrichment)")
+		assert.False(t, got["r-noisy"], "muted channel excluded from the active/count set")
+		assert.False(t, got["r-offbot"])
+		assert.False(t, got["r-mutedbot"], "muted botDM excluded by activeSubscriptionFilter before room lookup")
+		assert.True(t, got["r-del"], "no room name is filtered from the active set")
 	})
 
 	t.Run("limit caps active set exactly", func(t *testing.T) {
@@ -825,4 +826,84 @@ func TestAppSubscriptionRoundTrip_Integration(t *testing.T) {
 		assert.True(t, sub.IsSubscribed)
 		assert.True(t, sub.Muted)
 	})
+}
+
+// The badge path must come back with exactly the five fields it reads, correctly
+// populated for a local room, a room with no messages, and a cross-site sub with
+// no local room document at all.
+func TestGetActiveSubscriptions_ProjectsBadgeFields_Integration(t *testing.T) {
+	r, db := newTestSubscriptionRepo(t)
+	ctx := context.Background()
+	lastMsg := time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC)
+	seen := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+
+	seed(t, db, "rooms",
+		bson.M{"_id": "p-room", "name": "Eng", "siteId": "site-a", "lastMsgAt": lastMsg,
+			"userCount": 9, "appCount": 1, "encKey": bson.M{"priv": make([]byte, 120), "ver": 3}},
+		bson.M{"_id": "p-quiet", "name": "Quiet", "siteId": "site-a"},
+	)
+	seed(t, db, "subscriptions",
+		bson.M{"_id": "p-sub", "u": bson.M{"_id": "u-alice", "account": "alice"}, "name": "Eng",
+			"roomId": "p-room", "roomType": "channel", "siteId": "site-a",
+			"lastSeenAt": seen, "threadUnread": []string{"pm-1", "pm-2"}},
+		bson.M{"_id": "p-sub-quiet", "u": bson.M{"_id": "u-alice", "account": "alice"}, "name": "Quiet",
+			"roomId": "p-quiet", "roomType": "channel", "siteId": "site-a"},
+		bson.M{"_id": "p-sub-remote", "u": bson.M{"_id": "u-alice", "account": "alice"}, "name": "Remote",
+			"roomId": "p-remote", "roomType": "channel", "siteId": "site-b", "lastSeenAt": seen},
+	)
+
+	subs, err := r.GetActiveSubscriptions(ctx, "alice", 100)
+	require.NoError(t, err)
+
+	byRoom := map[string]models.ActiveSubscription{}
+	for _, s := range subs {
+		byRoom[s.RoomID] = s
+	}
+	require.Len(t, byRoom, 3)
+
+	local := byRoom["p-room"]
+	assert.Equal(t, "site-a", local.SiteID)
+	require.NotNil(t, local.LastSeenAt)
+	assert.Equal(t, seen.UTC(), local.LastSeenAt.UTC())
+	require.NotNil(t, local.LastMsgAt, "the joined room's lastMsgAt must survive the projection")
+	assert.Equal(t, lastMsg.UTC(), local.LastMsgAt.UTC())
+	assert.Equal(t, []string{"pm-1", "pm-2"}, local.ThreadUnread)
+
+	quiet := byRoom["p-quiet"]
+	assert.Nil(t, quiet.LastMsgAt, "a room with no messages has no lastMsgAt")
+	assert.Nil(t, quiet.LastSeenAt, "an unread-from-birth sub has no lastSeenAt")
+
+	remote := byRoom["p-remote"]
+	assert.Equal(t, "site-b", remote.SiteID)
+	assert.Nil(t, remote.LastMsgAt, "a cross-site sub has no local room document")
+	require.NotNil(t, remote.LastSeenAt)
+
+	// The joined room carries an E2E key slot (encKey) that the projection must
+	// not leak — but decoding into models.ActiveSubscription (five fields, no
+	// inline/catch-all) would silently discard any extra field Mongo actually
+	// returned, so that decode step can't be where this is proven. Re-run the
+	// identical pipeline through a raw handle and decode the p-room row — the
+	// row where all five projected fields are populated — into bson.M: an
+	// unregressed $project returns a document keyed by exactly those five
+	// names, while a regression that let encKey (or any other enrichment
+	// field) through the $project stage surfaces here as an extra map key.
+	pipeline := r.activeSubscriptionPipeline("alice", 100)
+	cur, err := db.Collection(subscriptionsCollection).Aggregate(ctx, pipeline)
+	require.NoError(t, err)
+	var rawRows []bson.M
+	require.NoError(t, cur.All(ctx, &rawRows))
+	var rawRoom bson.M
+	for _, d := range rawRows {
+		if d["roomId"] == "p-room" {
+			rawRoom = d
+			break
+		}
+	}
+	require.NotNil(t, rawRoom, "expected the p-room row in the raw projection output")
+	keys := make([]string, 0, len(rawRoom))
+	for k := range rawRoom {
+		keys = append(keys, k)
+	}
+	assert.ElementsMatch(t, []string{"roomId", "siteId", "lastSeenAt", "threadUnread", "lastMsgAt"}, keys,
+		"the raw $project output for p-room must contain exactly the five projected fields — no encKey or other room baseline field")
 }

--- a/user-service/mongorepo/subscriptions_test.go
+++ b/user-service/mongorepo/subscriptions_test.go
@@ -828,9 +828,7 @@ func TestAppSubscriptionRoundTrip_Integration(t *testing.T) {
 	})
 }
 
-// The badge path must come back with exactly the five fields it reads, correctly
-// populated for a local room, a room with no messages, and a cross-site sub with
-// no local room document at all.
+// The badge path must return exactly its five fields, across local, empty and cross-site rooms.
 func TestGetActiveSubscriptions_ProjectsBadgeFields_Integration(t *testing.T) {
 	r, db := newTestSubscriptionRepo(t)
 	ctx := context.Background()
@@ -878,15 +876,7 @@ func TestGetActiveSubscriptions_ProjectsBadgeFields_Integration(t *testing.T) {
 	assert.Nil(t, remote.LastMsgAt, "a cross-site sub has no local room document")
 	require.NotNil(t, remote.LastSeenAt)
 
-	// The joined room carries an E2E key slot (encKey) that the projection must
-	// not leak — but decoding into models.ActiveSubscription (five fields, no
-	// inline/catch-all) would silently discard any extra field Mongo actually
-	// returned, so that decode step can't be where this is proven. Re-run the
-	// identical pipeline through a raw handle and decode the p-room row — the
-	// row where all five projected fields are populated — into bson.M: an
-	// unregressed $project returns a document keyed by exactly those five
-	// names, while a regression that let encKey (or any other enrichment
-	// field) through the $project stage surfaces here as an extra map key.
+	// Assert on the raw document: decoding first would discard a leaked encKey.
 	pipeline := r.activeSubscriptionPipeline("alice", 100)
 	cur, err := db.Collection(subscriptionsCollection).Aggregate(ctx, pipeline)
 	require.NoError(t, err)

--- a/user-service/service/badge_test.go
+++ b/user-service/service/badge_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/user-service/models"
 	"github.com/hmchangw/chat/user-service/service/mocks"
 )
 
@@ -122,7 +123,7 @@ func TestBadgeCountBatch_MixedHitMiss_SingleBatchedBump(t *testing.T) {
 	subs := mocks.NewMockSubscriptionRepository(ctrl)
 	// Only the missed account (bob) reaches the repo.
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "bob", gomock.Any()).
-		Return([]model.EnrichedSubscription{}, nil)
+		Return([]models.ActiveSubscription{}, nil)
 	badge := &fakeBadgeCache{
 		bumpBatch: func(accounts []string, roomID string) map[string]int {
 			return map[string]int{"alice": 3} // bob misses
@@ -146,8 +147,8 @@ func TestBadgeCountBatch_Miss_SeedsWithTrigger(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	subs := mocks.NewMockSubscriptionRepository(ctrl)
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).
-		Return([]model.EnrichedSubscription{
-			{Subscription: model.Subscription{RoomID: "r2", SiteID: "site-a"}, LastMsgAt: ptrTime(100)},
+		Return([]models.ActiveSubscription{
+			{RoomID: "r2", SiteID: "site-a", LastMsgAt: ptrTime(100)},
 		}, nil).Times(1)
 	var gotIDs []string
 	var gotTrigger string
@@ -175,7 +176,7 @@ func TestBadgeCountBatch_UnreadRoomsError_AccountAbsent(t *testing.T) {
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).
 		Return(nil, errors.New("db down"))
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "bob", gomock.Any()).
-		Return([]model.EnrichedSubscription{}, nil)
+		Return([]models.ActiveSubscription{}, nil)
 	badge := &fakeBadgeCache{
 		seed: func(account string, roomIDs []string, trigger string) (int, bool) {
 			return 1, true
@@ -195,9 +196,9 @@ func TestBadgeCountBatch_CacheFullyDown_CappedUnionFallback(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	subs := mocks.NewMockSubscriptionRepository(ctrl)
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).
-		Return([]model.EnrichedSubscription{
-			{Subscription: model.Subscription{RoomID: "r2", SiteID: "site-a"}, LastMsgAt: ptrTime(100)},
-			{Subscription: model.Subscription{RoomID: "r3", SiteID: "site-a"}, LastMsgAt: ptrTime(100)},
+		Return([]models.ActiveSubscription{
+			{RoomID: "r2", SiteID: "site-a", LastMsgAt: ptrTime(100)},
+			{RoomID: "r3", SiteID: "site-a", LastMsgAt: ptrTime(100)},
 		}, nil)
 	badge := &fakeBadgeCache{} // Bump and Seed both default to (0, false)
 	svc := newBadgeService(t, subs, badge)
@@ -219,7 +220,7 @@ func TestBadgeCountBatch_Degraded_NoSeed(t *testing.T) {
 	failingRoomClient(rooms, "site-b")
 
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return(
-		[]model.EnrichedSubscription{crossSiteSub("r-remote", "site-b")}, nil)
+		[]models.ActiveSubscription{crossSiteSub("r-remote", "site-b")}, nil)
 
 	resp, err := svc.BadgeCountBatch(ctx("alice", "site-a"),
 		model.BadgeCountBatchRequest{RoomID: "r-trigger", Accounts: []string{"alice"}})

--- a/user-service/service/mocks/mock_repository.go
+++ b/user-service/service/mocks/mock_repository.go
@@ -91,10 +91,10 @@ func (mr *MockSubscriptionRepositoryMockRecorder) FindChannelsByMembers(ctx, acc
 }
 
 // GetActiveSubscriptions mocks base method.
-func (m *MockSubscriptionRepository) GetActiveSubscriptions(ctx context.Context, account string, limit int) ([]model.EnrichedSubscription, error) {
+func (m *MockSubscriptionRepository) GetActiveSubscriptions(ctx context.Context, account string, limit int) ([]models.ActiveSubscription, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetActiveSubscriptions", ctx, account, limit)
-	ret0, _ := ret[0].([]model.EnrichedSubscription)
+	ret0, _ := ret[0].([]models.ActiveSubscription)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/user-service/service/service.go
+++ b/user-service/service/service.go
@@ -23,12 +23,8 @@ type SubscriptionRepository interface {
 	GetDMSubscription(ctx context.Context, account, target string) (*model.EnrichedDMSubscription, error)
 	GetSubscriptionByRoomID(ctx context.Context, account, roomID string) (*model.EnrichedSubscription, error)
 	CountActiveSubscriptions(ctx context.Context, account string) (int, error)
-	// GetActiveSubscriptions returns the active set, capped at limit when limit > 0
-	// and uncapped otherwise, projected to the five fields the unread count reads.
-	// A capped result is never shortened by later filtering — no stage after the cap
-	// drops a row — but it is still shorter than limit when the account has fewer
-	// active subscriptions. Its only consumer is the unread count; not a general
-	// pagination surface.
+	// GetActiveSubscriptions returns the active set, capped at limit when limit > 0 and
+	// projected to the unread count's fields; no stage after the cap drops a row.
 	GetActiveSubscriptions(ctx context.Context, account string, limit int) ([]models.ActiveSubscription, error)
 	GetAppSubscription(ctx context.Context, account, botName string) (*model.Subscription, error)
 	SetAppSubscribed(ctx context.Context, account, botName string, subscribed, muted bool) error

--- a/user-service/service/service.go
+++ b/user-service/service/service.go
@@ -24,11 +24,12 @@ type SubscriptionRepository interface {
 	GetSubscriptionByRoomID(ctx context.Context, account, roomID string) (*model.EnrichedSubscription, error)
 	CountActiveSubscriptions(ctx context.Context, account string) (int, error)
 	// GetActiveSubscriptions returns the active set, capped at limit when limit > 0
-	// and uncapped otherwise. A capped result is never shortened by later filtering —
-	// no stage after the cap drops a row — but it is still shorter than limit when the
-	// account has fewer active subscriptions. Its only consumer is the unread count;
-	// not a general pagination surface.
-	GetActiveSubscriptions(ctx context.Context, account string, limit int) ([]model.EnrichedSubscription, error)
+	// and uncapped otherwise, projected to the five fields the unread count reads.
+	// A capped result is never shortened by later filtering — no stage after the cap
+	// drops a row — but it is still shorter than limit when the account has fewer
+	// active subscriptions. Its only consumer is the unread count; not a general
+	// pagination surface.
+	GetActiveSubscriptions(ctx context.Context, account string, limit int) ([]models.ActiveSubscription, error)
 	GetAppSubscription(ctx context.Context, account, botName string) (*model.Subscription, error)
 	SetAppSubscribed(ctx context.Context, account, botName string, subscribed, muted bool) error
 }

--- a/user-service/service/service_test.go
+++ b/user-service/service/service_test.go
@@ -10,9 +10,9 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/hmchangw/chat/pkg/errcode"
-	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/natsrouter"
 	"github.com/hmchangw/chat/user-service/config"
+	"github.com/hmchangw/chat/user-service/models"
 	"github.com/hmchangw/chat/user-service/service/mocks"
 )
 
@@ -45,30 +45,25 @@ func ctx(account, siteID string) *natsrouter.Context {
 	return natsrouter.NewContext(map[string]string{"account": account, "siteID": siteID})
 }
 
-// localUnreadSub returns an EnrichedSubscription for a room on siteID with an
+// localUnreadSub returns an ActiveSubscription for a room on siteID with an
 // unread baseline: LastMsgAt is newer than LastSeenAt and already populated by
 // the $lookup, so the caller's own-site rows count with no cross-site RPC.
 // account is accepted for call-site readability (it mirrors the account the
 // surrounding GetActiveSubscriptions mock is scoped to) though the fixture
 // itself carries no per-account field.
-func localUnreadSub(account, roomID, siteID string) model.EnrichedSubscription {
+func localUnreadSub(account, roomID, siteID string) models.ActiveSubscription {
 	_ = account
 	seen := time.UnixMilli(100).UTC()
 	newer := time.UnixMilli(200).UTC()
-	return model.EnrichedSubscription{
-		Subscription: model.Subscription{RoomID: roomID, SiteID: siteID, LastSeenAt: &seen},
-		LastMsgAt:    &newer,
-	}
+	return models.ActiveSubscription{RoomID: roomID, SiteID: siteID, LastSeenAt: &seen, LastMsgAt: &newer}
 }
 
-// crossSiteSub returns an EnrichedSubscription for a room on a remote siteID
+// crossSiteSub returns an ActiveSubscription for a room on a remote siteID
 // with no LastMsgAt baseline — unlike localUnreadSub, read state is unknown
 // until unreadRooms RPCs that site's RoomClient.GetRoomsMeta.
-func crossSiteSub(roomID, siteID string) model.EnrichedSubscription {
+func crossSiteSub(roomID, siteID string) models.ActiveSubscription {
 	seen := time.UnixMilli(100).UTC()
-	return model.EnrichedSubscription{
-		Subscription: model.Subscription{RoomID: roomID, SiteID: siteID, LastSeenAt: &seen},
-	}
+	return models.ActiveSubscription{RoomID: roomID, SiteID: siteID, LastSeenAt: &seen}
 }
 
 // failingRoomClient stubs rooms.GetRoomsMeta for siteID to return an error,

--- a/user-service/service/subscriptions.go
+++ b/user-service/service/subscriptions.go
@@ -535,7 +535,7 @@ func (s *UserService) unreadRooms(c *natsrouter.Context, account string) ([]stri
 
 	var ids []string
 	degraded := false
-	crossBySite := map[string][]model.EnrichedSubscription{}
+	crossBySite := map[string][]models.ActiveSubscription{}
 	roomIDsBySite := map[string][]string{}
 	for i := range subs {
 		if subs[i].SiteID == s.siteID {

--- a/user-service/service/subscriptions_test.go
+++ b/user-service/service/subscriptions_test.go
@@ -639,7 +639,7 @@ func TestCountUnread_Happy(t *testing.T) {
 	// No CountActiveSubscriptions expectation — the unread path must not fetch the total.
 	// LOCAL sub: lastMsgAt is on the $lookup baseline — counted with NO RPC.
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).
-		Return([]model.EnrichedSubscription{{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &newer}}, nil)
+		Return([]models.ActiveSubscription{{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen, LastMsgAt: &newer}}, nil)
 	rooms.EXPECT().GetRoomsMeta(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	yes := true
 	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
@@ -657,9 +657,9 @@ func TestCountUnread_FailedSiteSkipped(t *testing.T) {
 	newer := time.UnixMilli(200).UTC()
 	// One LOCAL unread (counted from the baseline) + one CROSS-SITE sub whose site's RPC fails.
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).
-		Return([]model.EnrichedSubscription{
-			{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &newer}, // local unread
-			{Subscription: model.Subscription{RoomID: "r2", SiteID: "site-b", LastSeenAt: &seen}},                    // cross-site, site fails
+		Return([]models.ActiveSubscription{
+			{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen, LastMsgAt: &newer}, // local unread
+			{RoomID: "r2", SiteID: "site-b", LastSeenAt: &seen},                    // cross-site, site fails
 		}, nil)
 	failingRoomClient(rooms, "site-b")
 	yes := true
@@ -673,9 +673,9 @@ func TestCountUnread_PartialFailureCountsHealthySites(t *testing.T) {
 	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	seen := time.UnixMilli(100).UTC()
 	newer := int64(200)
-	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return([]model.EnrichedSubscription{
-		{Subscription: model.Subscription{RoomID: "rb1", SiteID: "site-b", LastSeenAt: &seen}}, // healthy site, unread
-		{Subscription: model.Subscription{RoomID: "rc1", SiteID: "site-c", LastSeenAt: &seen}}, // failing site, skipped
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return([]models.ActiveSubscription{
+		{RoomID: "rb1", SiteID: "site-b", LastSeenAt: &seen}, // healthy site, unread
+		{RoomID: "rc1", SiteID: "site-c", LastSeenAt: &seen}, // failing site, skipped
 	}, nil)
 	rooms.EXPECT().GetRoomsMeta(gomock.Any(), "site-b", gomock.Any()).
 		Return([]model.RoomInfo{{RoomID: "rb1", Found: true, LastMsgAt: &newer}}, nil)
@@ -700,11 +700,11 @@ func TestCountUnread_MultiSite(t *testing.T) {
 	seen := time.UnixMilli(100).UTC()
 	newerT := time.UnixMilli(200).UTC()
 	newer := int64(200)
-	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return([]model.EnrichedSubscription{
-		{Subscription: model.Subscription{RoomID: "ra1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &newerT}, // local unread (baseline)
-		{Subscription: model.Subscription{RoomID: "ra2", SiteID: "site-a", LastSeenAt: &seen}},                     // local read (no lastMsgAt)
-		{Subscription: model.Subscription{RoomID: "rb1", SiteID: "site-b", LastSeenAt: &seen}},
-		{Subscription: model.Subscription{RoomID: "rb2", SiteID: "site-b", LastSeenAt: &seen}},
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return([]models.ActiveSubscription{
+		{RoomID: "ra1", SiteID: "site-a", LastSeenAt: &seen, LastMsgAt: &newerT}, // local unread (baseline)
+		{RoomID: "ra2", SiteID: "site-a", LastSeenAt: &seen},                     // local read (no lastMsgAt)
+		{RoomID: "rb1", SiteID: "site-b", LastSeenAt: &seen},
+		{RoomID: "rb2", SiteID: "site-b", LastSeenAt: &seen},
 	}, nil)
 	// Only the CROSS-SITE site is RPC'd; local rows are counted from the baseline.
 	rooms.EXPECT().GetRoomsMeta(gomock.Any(), "site-b", gomock.InAnyOrder([]string{"rb1", "rb2"})).
@@ -722,9 +722,9 @@ func TestCountUnread_AllRead(t *testing.T) {
 	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	seen := time.UnixMilli(300).UTC()
 	older := time.UnixMilli(100).UTC() // older than seen → not unread
-	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return([]model.EnrichedSubscription{
-		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
-		{Subscription: model.Subscription{RoomID: "r2", SiteID: "site-a", LastSeenAt: &seen}}, // no lastMsgAt → read
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return([]models.ActiveSubscription{
+		{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen, LastMsgAt: &older},
+		{RoomID: "r2", SiteID: "site-a", LastSeenAt: &seen}, // no lastMsgAt → read
 	}, nil)
 	rooms.EXPECT().GetRoomsMeta(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	yes := true
@@ -745,7 +745,7 @@ func TestCountUnread_AllRead(t *testing.T) {
 func TestCountUnread_GateOff_NoCacheRead(t *testing.T) {
 	svc, subs, _, _, _, _, _ := newSvc(t)
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).
-		Return([]model.EnrichedSubscription{}, nil)
+		Return([]models.ActiveSubscription{}, nil)
 	yes := true
 	_, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
 	require.NoError(t, err)
@@ -793,7 +793,7 @@ func TestCountUnread_CacheFirst_Stale_Computes(t *testing.T) {
 	svc.badgeCacheFirst = true
 	badge := svc.badge.(*fakeBadgeCache) // count defaults to (0, false) — stale
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).
-		Return([]model.EnrichedSubscription{localUnreadSub("alice", "r1", "site-a")}, nil)
+		Return([]models.ActiveSubscription{localUnreadSub("alice", "r1", "site-a")}, nil)
 	yes := true
 	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
 	require.NoError(t, err)
@@ -805,7 +805,7 @@ func TestCountUnread_CacheFirst_Stale_Computes(t *testing.T) {
 func TestCountUnread_EmptyActive(t *testing.T) {
 	svc, subs, _, _, _, _, _ := newSvc(t)
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).
-		Return([]model.EnrichedSubscription{}, nil)
+		Return([]models.ActiveSubscription{}, nil)
 	yes := true
 	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
 	require.NoError(t, err)
@@ -819,9 +819,9 @@ func TestUnreadRooms_ContextCancelled_SkipsRPC(t *testing.T) {
 	seen := time.UnixMilli(100).UTC()
 	newer := time.UnixMilli(200).UTC()
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).
-		Return([]model.EnrichedSubscription{
-			{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &newer}, // local unread
-			{Subscription: model.Subscription{RoomID: "r2", SiteID: "site-b", LastSeenAt: &seen}},                    // cross-site, must be skipped
+		Return([]models.ActiveSubscription{
+			{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen, LastMsgAt: &newer}, // local unread
+			{RoomID: "r2", SiteID: "site-b", LastSeenAt: &seen},                    // cross-site, must be skipped
 		}, nil)
 	rooms.EXPECT().GetRoomsMeta(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
@@ -853,7 +853,7 @@ func TestUnreadRooms_ContextCancelled_SkipsRPC(t *testing.T) {
 func TestUnreadRooms_ContextCancelledMultiSite_AllSitesDegraded(t *testing.T) {
 	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return(
-		[]model.EnrichedSubscription{
+		[]models.ActiveSubscription{
 			crossSiteSub("r1", "site-b"),
 			crossSiteSub("r2", "site-c"),
 			crossSiteSub("r3", "site-d"),
@@ -877,7 +877,7 @@ func TestUnreadRooms_CrossSiteNotFoundRoomNotCounted(t *testing.T) {
 	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	newer := int64(200) // newer than seen → WOULD count if the room resolved
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).
-		Return([]model.EnrichedSubscription{crossSiteSub("rd", "site-b")}, nil)
+		Return([]models.ActiveSubscription{crossSiteSub("rd", "site-b")}, nil)
 	rooms.EXPECT().GetRoomsMeta(gomock.Any(), "site-b", gomock.Any()).
 		Return([]model.RoomInfo{{RoomID: "rd", Found: false, LastMsgAt: &newer}}, nil)
 
@@ -895,7 +895,7 @@ func TestUnreadRooms_CrossSiteNotFoundRoomThreadNotCounted(t *testing.T) {
 	sub := crossSiteSub("rd", "site-b")
 	sub.ThreadUnread = []string{"p1"}
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).
-		Return([]model.EnrichedSubscription{sub}, nil)
+		Return([]models.ActiveSubscription{sub}, nil)
 	rooms.EXPECT().GetRoomsMeta(gomock.Any(), "site-b", gomock.Any()).
 		Return([]model.RoomInfo{{RoomID: "rd", Found: false, LastMsgAt: &older}}, nil)
 
@@ -911,7 +911,7 @@ func TestUnreadRooms_CrossSiteRoomNameIsNotAFilter(t *testing.T) {
 	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	newer := int64(200) // newer than seen → counts
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).
-		Return([]model.EnrichedSubscription{crossSiteSub("rd", "site-b")}, nil)
+		Return([]models.ActiveSubscription{crossSiteSub("rd", "site-b")}, nil)
 	rooms.EXPECT().GetRoomsMeta(gomock.Any(), "site-b", gomock.Any()).
 		Return([]model.RoomInfo{{RoomID: "rd", Found: true, Name: "Del-secret", LastMsgAt: &newer}}, nil)
 
@@ -933,7 +933,7 @@ func TestCountSubscriptions_Degraded_NoReseed(t *testing.T) {
 	failingRoomClient(rooms, "site-b")
 
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1000).Return(
-		[]model.EnrichedSubscription{crossSiteSub("r-remote", "site-b")}, nil)
+		[]models.ActiveSubscription{crossSiteSub("r-remote", "site-b")}, nil)
 
 	unread := true
 	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &unread})
@@ -950,7 +950,7 @@ func TestCountSubscriptions_NotDegraded_StillReseeds(t *testing.T) {
 	svc := newBadgeService(t, subs, badge)
 
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", 1000).Return(
-		[]model.EnrichedSubscription{localUnreadSub("alice", "r1", "site-a")}, nil)
+		[]models.ActiveSubscription{localUnreadSub("alice", "r1", "site-a")}, nil)
 
 	unread := true
 	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &unread})
@@ -966,8 +966,8 @@ func TestCountUnread_ReadRoomBumpedByUnreadThread(t *testing.T) {
 	svc, subs, _, _, _, _, _ := newSvc(t)
 	seen := time.UnixMilli(100).UTC()
 	older := time.UnixMilli(50).UTC()
-	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return([]model.EnrichedSubscription{
-		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen, ThreadUnread: []string{"p1"}}, LastMsgAt: &older},
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return([]models.ActiveSubscription{
+		{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen, ThreadUnread: []string{"p1"}, LastMsgAt: &older},
 	}, nil)
 	yes := true
 	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
@@ -981,8 +981,8 @@ func TestCountUnread_AlreadyUnreadRoomNotDoubleCounted(t *testing.T) {
 	svc, subs, _, _, _, _, _ := newSvc(t)
 	seen := time.UnixMilli(100).UTC()
 	newer := time.UnixMilli(300).UTC()
-	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return([]model.EnrichedSubscription{
-		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen, ThreadUnread: []string{"p1"}}, LastMsgAt: &newer},
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return([]models.ActiveSubscription{
+		{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen, ThreadUnread: []string{"p1"}, LastMsgAt: &newer},
 	}, nil)
 	yes := true
 	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
@@ -996,8 +996,8 @@ func TestCountUnread_MultipleUnreadThreadsCountOnce(t *testing.T) {
 	svc, subs, _, _, _, _, _ := newSvc(t)
 	seen := time.UnixMilli(100).UTC()
 	older := time.UnixMilli(50).UTC()
-	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return([]model.EnrichedSubscription{
-		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen, ThreadUnread: []string{"p1", "p2", "p3"}}, LastMsgAt: &older},
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return([]models.ActiveSubscription{
+		{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen, ThreadUnread: []string{"p1", "p2", "p3"}, LastMsgAt: &older},
 	}, nil)
 	yes := true
 	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})
@@ -1012,8 +1012,8 @@ func TestCountUnread_CrossSiteReadRoomBumpedByThread(t *testing.T) {
 	svc, subs, _, _, rooms, _, _ := newSvc(t)
 	seen := time.UnixMilli(100).UTC()
 	older := int64(50)
-	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return([]model.EnrichedSubscription{
-		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-b", LastSeenAt: &seen, ThreadUnread: []string{"p1"}}},
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return([]models.ActiveSubscription{
+		{RoomID: "r1", SiteID: "site-b", LastSeenAt: &seen, ThreadUnread: []string{"p1"}},
 	}, nil)
 	rooms.EXPECT().GetRoomsMeta(gomock.Any(), "site-b", []string{"r1"}).
 		Return([]model.RoomInfo{{RoomID: "r1", Found: true, LastMsgAt: &older}}, nil)
@@ -1031,8 +1031,8 @@ func TestCountUnread_MutedRoomThreadExcluded(t *testing.T) {
 	seen := time.UnixMilli(100).UTC()
 	older := time.UnixMilli(50).UTC()
 	// Only the unmuted, read r1 (no threads) is returned.
-	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return([]model.EnrichedSubscription{
-		{Subscription: model.Subscription{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen}, LastMsgAt: &older},
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "alice", gomock.Any()).Return([]models.ActiveSubscription{
+		{RoomID: "r1", SiteID: "site-a", LastSeenAt: &seen, LastMsgAt: &older},
 	}, nil)
 	yes := true
 	resp, err := svc.CountSubscriptions(ctx("alice", "site-a"), models.CountRequest{Unread: &yes})


### PR DESCRIPTION
`GetActiveSubscriptions` serves the unread badge and returned a full `model.EnrichedSubscription` per row — the whole subscription document plus eleven joined room fields, the room's E2E key slot among them — to serve the five fields `unreadRooms` actually reads. This adds a terminal `$project` and a narrow row type.

No API change, no write-path change, no schema change, no behavior change.

**Rebased onto `main` after #353 merged** — see *Reconciliation with #353* below for what that changed.

---

## Scope, and what it is not

This is lever **A2** from `2026-08-19-badge-precise-read-invalidation-design.md` §11, cut down after checking it against the other in-flight subscription PRs:

- **#353** (now merged) removed `CountActiveSubscriptions`' join outright, so that method is deliberately untouched here — there is nothing left to narrow.
- **#197** applies the de-join technique to `subscription.list`, and its out-of-scope note argues `GetActiveSubscriptions` needs no attention because `$limit` precedes the join. **That argument is correct about seeks and this PR does not contradict it.** Counting unread needs `lastMsgAt` for every active room, so those per-row lookups are irreducible without a cache. What the note does not address is *document volume* — the term #197 itself led with — which is untouched by the cap.

So this is a **wire-and-decode** change, not a Mongo-CPU one. Stated plainly in the spec (§3.3): the `$lookup` still fetches eleven room fields, `encKey.priv` included. They stop crossing the wire and being unmarshalled into a 41-field struct in user-service. No seek relief.

## Why it matters here

Two hot call sites reach this method, both through `unreadRooms`:

- `subscription.count {unread:true}` — the desktop client refetches after every `markRoomRead`, i.e. every room open.
- `BadgeCountBatch` — per account, on the push path, on every badge-set miss.

## The change

`user-service/mongorepo/subscriptions.go` — the pipeline keeps its shape (`$match` on `activeFilter` → `$limit` → `roomsEnrichStages`) and gains a terminal `$project`. It is placed last, after the enrich stages, whose `$addFields` hoists the joined `lastMsgAt` to the top level before the projection whitelists it. The cap still precedes the join, so #353's "the page is exactly limit — no stage after the cap can drop a row" contract holds unchanged.

`models.ActiveSubscription` (five fields) replaces `model.EnrichedSubscription` as the return type. A narrow type rather than a narrowly-populated fat one, deliberately: filling five of forty-one fields is a trap, because a later reader of `sub.HasMention` or `sub.Room` gets a zero value with nothing signalling the field was never fetched.

## Reconciliation with #353

The rebase adopted #353 wholesale: `roomsEnrichStages()` loses its parameter, `originFilterStage` is folded into `activeFilter`, and `SubscriptionRepo.siteID` stays deleted. Two things git could not merge on its own, both in the final commit:

- **An integration assertion inverted.** This branch asserted a `^Del-` room is excluded from the active set; #353 makes the opposite true — no room name filters anything — so the assertion now reads that way, keyed by `roomId`.
- **A test #353 added mocked the old return type.** `TestUnreadRooms_CrossSiteRoomNameIsNotAFilter` returns `[]model.EnrichedSubscription`, which this PR retypes.

The spec's original placement argument leaned on the `^Del-` `$match` consuming `room.name` before the projection dropped it. That filter no longer exists, so the argument is recorded as moot rather than quietly deleted, and the short-page caveat it carried is retired.

**Note for #361:** its scope section says it has zero overlap with this PR. There is one — `badge_test.go`. Its new test declares `DoAndReturn(func(...) ([]model.EnrichedSubscription, error)` and calls `localUnreadSub`, both of which this PR retypes. Whichever lands second needs that test updated; nothing else collides.

## Measured

`bson.Marshal` on representative rows: **167 B vs 895 B, 5.4×**. This is a document-size measurement, not a latency one — no timed baseline for `subscription.count` exists, and this environment could not produce one. Post-deploy, the place to look is `subscription.count` latency traces and user-service GC pressure.

## Two guards, and why the first two attempts did not count

The projection's failure mode is silent: add a field to the row type, forget the `$project`, get a zero value and a wrong badge with no error anywhere.

1. A reflection test pins `activeSubscriptionProjection()` to `ActiveSubscription`'s bson tags, so the two cannot drift. It fails on an untagged field rather than skipping it, which also enforces the repo's both-tags rule.
2. An integration test asserts the projection's **raw BSON** output has exactly the five keys, seeded against a room carrying a real 120-byte `encKey.priv`.

Guard 2 took three attempts. The first two asserted `NotContains(marshal(row), "encKey")` against a *decoded* `ActiveSubscription` — true by construction, since a five-field struct can never emit that key, and a regression would be silently discarded by the decoder before the assertion saw it. Review then caught that even the raw-BSON version rebuilt the pipeline itself, so deleting the `$project` from production left the whole branch green. Both call sites now go through one `activeSubscriptionPipeline` builder, so a dropped projection breaks the test.

## Testing

Re-run after the rebase: `make lint` 0 issues; whole-repo `make test` with `-race` green; `gosec` clean.

**Not run here, and worth knowing before merge:**

- **The integration tests have never executed anywhere** — no Docker daemon in the build environment. That covers the new projection test, the raw-BSON guard, and three re-keyed assertions (`sub.ID` → `sub.RoomID`, since the projection drops `_id`). The fixture mapping was verified statically — all 13 `_id`→`roomId` pairs, all `roomId`s distinct so re-keying cannot collapse rows — but `test-integration (user-service)` in CI is the first real execution. The post-rebase integration code compiles under `-tags integration`; it fails only at container bring-up.
- `govulncheck` and `semgrep` could not reach `vuln.go.dev` / `semgrep.dev` (403 through the proxy). CI's `sast` job is the gate.

Behavior preservation was checked mechanically rather than by eye: filtering the service diff to `assert.`/`require.`/`Times(`/`EXPECT` lines yields only the paired type-swap lines — no assertion, expected count or matcher changed — and test counts hold at 70→70, 9→9, 31→31 `t.Run`s, with one test added.

## Follow-ups (not here)

- Removing the `encKey.priv` read from the pipeline entirely needs a caller-specific `$lookup` rather than the shared stage.
- The de-join, and/or reusing #197's `sortKeyCache` for `lastMsgAt` — the latter carries a staleness asymmetry the list path does not have: a stale-old `lastMsgAt` here is a false negative (a room that just received a message reads as read), tolerable only if the Valkey bump is the freshness path.
- Lever A3: per-account singleflight and a recompute cooldown for reconnect storms.

Design: `docs/superpowers/specs/2026-08-23-unread-count-projection-narrowing-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfJYRCV84t1i5EDmxDge3p