### PR TITLE
fix(user-service): stop the badge-batch unread cascade on a spent request budget

### DIFF
--- a/user-service/service/badge.go
+++ b/user-service/service/badge.go
@@ -26,6 +26,18 @@ func (s *UserService) BadgeCountBatch(c *natsrouter.Context, req model.BadgeCoun
 			resp.Counts[account] = n
 			continue
 		}
+		// Once the shared request budget is spent, skip the EXPENSIVE unread
+		// recompute for this account: run against a dead context it would only hit
+		// the heavy aggregate, fail at connection checkout with a misleading pool
+		// error, and degrade to absence anyway. Skipping (not returning) keeps the
+		// loop going so any remaining cache hits — already in memory from BumpBatch
+		// — are still served; only the misses past the deadline degrade to absence,
+		// as any per-account failure does (the badge push must never block).
+		select {
+		case <-c.Done():
+			continue
+		default:
+		}
 		ids, degraded, err := s.unreadRooms(c, account)
 		if err != nil {
 			slog.WarnContext(c, "badge seed degraded", "account", account, "room_id", req.RoomID, "request_id", natsutil.RequestIDFromContext(c), "error", err)

--- a/user-service/service/badge_test.go
+++ b/user-service/service/badge_test.go
@@ -206,6 +206,70 @@ func TestBadgeCountBatch_CacheFullyDown_CappedUnionFallback(t *testing.T) {
 	assert.Equal(t, 3, resp.Counts["alice"], "r1 (trigger) + r2 + r3, cache down entirely")
 }
 
+// Once the shared request budget (HANDLER_TIMEOUT) is spent mid-batch, the loop
+// must STOP issuing further per-account unread computations rather than fire
+// aggregates against an already-dead context (which return instantly at
+// connection checkout with a misleading pool error). The accounts it never
+// reaches degrade to absence, as any other per-account failure would.
+func TestBadgeCountBatch_BudgetSpentMidBatch_StopsAndRemainingAbsent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	subs := mocks.NewMockSubscriptionRepository(ctrl)
+	cctx, cancel := context.WithCancel(context.Background())
+	c := ctx("", "site-a")
+	c.SetContext(cctx)
+	// Account "a" computes, then the shared budget expires (simulating the 15s
+	// handler deadline elapsing part-way through the batch).
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "a", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ int) ([]model.EnrichedSubscription, error) {
+			cancel()
+			return []model.EnrichedSubscription{localUnreadSub("a", "ra", "site-a")}, nil
+		})
+	// "b" and "c" must NEVER reach the repo once the context is done.
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "b", gomock.Any()).Times(0)
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "c", gomock.Any()).Times(0)
+	badge := &fakeBadgeCache{
+		seed: func(account string, roomIDs []string, trigger string) (int, bool) { return 1, true },
+	}
+	svc := newBadgeService(t, subs, badge)
+	resp, err := svc.BadgeCountBatch(c, model.BadgeCountBatchRequest{RoomID: "r1", Accounts: []string{"a", "b", "c"}})
+	require.NoError(t, err, "a spent budget degrades the rest — it must not fail the whole batch")
+	assert.Contains(t, resp.Counts, "a", "the account computed before the budget was spent still answers")
+	assert.NotContains(t, resp.Counts, "b", "an account past the spent budget degrades to absence")
+	assert.NotContains(t, resp.Counts, "c", "an account past the spent budget degrades to absence")
+}
+
+// A spent budget must only skip the EXPENSIVE recompute path. Cache hits are
+// already in memory (BumpBatch computed them up front), so an account that hit
+// the cache must still be served even when it sits after the account that spent
+// the budget — dropping a ready answer would needlessly absent a correct count.
+func TestBadgeCountBatch_BudgetSpentMidBatch_LaterCacheHitStillServed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	subs := mocks.NewMockSubscriptionRepository(ctrl)
+	cctx, cancel := context.WithCancel(context.Background())
+	c := ctx("", "site-a")
+	c.SetContext(cctx)
+	// "a" misses and recomputes, spending the budget; "c" is a cache hit; "b" misses.
+	badge := &fakeBadgeCache{
+		bumpBatch: func(accounts []string, roomID string) map[string]int {
+			return map[string]int{"c": 7} // only c hits the cache
+		},
+		seed: func(account string, roomIDs []string, trigger string) (int, bool) { return 1, true },
+	}
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "a", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ int) ([]model.EnrichedSubscription, error) {
+			cancel()
+			return []model.EnrichedSubscription{localUnreadSub("a", "ra", "site-a")}, nil
+		})
+	// "b" misses and sits past the spent budget — its expensive recompute must be skipped.
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "b", gomock.Any()).Times(0)
+	svc := newBadgeService(t, subs, badge)
+	resp, err := svc.BadgeCountBatch(c, model.BadgeCountBatchRequest{RoomID: "r1", Accounts: []string{"a", "b", "c"}})
+	require.NoError(t, err)
+	assert.Contains(t, resp.Counts, "a", "the account computed before the budget was spent still answers")
+	assert.NotContains(t, resp.Counts, "b", "a MISS past the spent budget is skipped")
+	assert.Equal(t, 7, resp.Counts["c"], "a cache HIT past the spent budget must still be served from memory")
+}
+
 // A failing cross-site RPC still answers from the best-effort ids ∪ trigger,
 // but must not Seed the cache — that would stamp the freshness marker on a
 // knowingly-incomplete set.


### PR DESCRIPTION
## The incident

```
unread rooms: decoding subscriptions aggregate: timed out while checking out
a connection from connection pool: context deadline exceeded;
total connections: 37, maxPoolSize: 100, idle connections: 0.
```

**This is not pool exhaustion.** The log proves it: `total connections: 37, maxPoolSize: 100` — the pool is healthy with room for 63 more connections, and the driver would happily open #38. The tell is the wait duration in the fuller log: **~1.6µs**. That is not contention — it means the request's `context` was *already expired* the instant the aggregate tried to check out a connection, so the driver returned immediately without waiting or opening anything.

So the real question is: what consumed the whole request budget *before* the aggregate ran?

## Root cause

`BadgeCountBatch` runs under a single `HANDLER_TIMEOUT` budget (15s), set once at handler entry and shared across its **sequential per-account loop**. Every cache-missing account runs the heavy `GetActiveSubscriptions` aggregate (a `$lookup` over up to `MAX_SUBSCRIPTION_LIMIT` active subscriptions on a `secondaryPreferred` read).

When that budget is consumed part-way through the batch — many accounts and/or a slow secondary — the loop **kept firing aggregates against an already-dead context**. Each one returned instantly at connection checkout with the misleading pool message above, one per remaining account: N doomed round trips and N confusing errors, none of which is a pool problem.

## The fix

Break the loop once the request context is done. Cache hits already in memory still answer; the accounts the loop never reaches degrade to absence — exactly the existing per-account degradation contract (*"Per-account failures degrade to absence — the push must never block"*). This bounds a spent-budget batch to **at most one** doomed aggregate (the one running when the budget expired) instead of one per remaining account.

```go
for _, account := range req.Accounts {
    if n, ok := hits[account]; ok {   // cache hits stay served
        resp.Counts[account] = n
        continue
    }
    select {                          // budget spent → stop firing new aggregates
    case <-c.Done():
        return resp, nil
    default:
    }
    ids, degraded, err := s.unreadRooms(c, account)
    ...
}
```

The non-blocking `<-c.Done()` check (rather than `c.Err() != nil`) is deliberate: it expresses "is the budget spent?" without pairing an error-non-nil test with a `return nil`, which the `nilerr` linter flags.

## Scope notes

- **Service-layer only.** No change to `GetActiveSubscriptions`, `roomsEnrichStages`, or any repo pipeline — so this has zero overlap with the other in-flight subscription PRs (#197, #353, #360).
- **Not pool sizing.** The evidence (37/100) rules out enlarging the pool; that would not touch the shared-budget cascade.
- **What this does not do:** it does not lean the unread projection (that is #360) or de-duplicate concurrent recomputes (the separately-tracked singleflight/cooldown lever). Those are complementary, not substitutes.

## Testing

- TDD, Red→Green: `TestBadgeCountBatch_BudgetSpentMidBatch_StopsAndRemainingAbsent` fails on `main` (the loop fires aggregates for accounts past the spent budget) and passes with the fix; the account computed before the budget was spent still answers, the rest are absent.
- `make test SERVICE=user-service` green with `-race`; full service suite unchanged.
- `make lint` 0 issues; `gosec` clean.
- No `docs/client-api.md` change: `badge.count.batch` is a `chat.server.request.*` server-side subject (not client-facing), and no request/response schema changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPvrymfGp2UVpS3wH9RKaJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPvrymfGp2UVpS3wH9RKaJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved badge count requests with limited time budgets by stopping unnecessary unread-room calculations when the request is canceled or expires.
  * Preserved available cached results while allowing unavailable results to be omitted without failing the entire batch.
* **Tests**
  * Added coverage for request cancellation during batch processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->