### PR TITLE
docs(design): analyze new-room → first-message race and recommend a fix

### DIFF
--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -73,6 +73,7 @@ type Handler struct {
 	metrics       *broadcastMetrics
 	joinGrace     time.Duration
 	now           func() time.Time
+	joins         *joinRegistry
 }
 
 type handlerOption func(*handlerOptions)
@@ -120,6 +121,7 @@ func NewHandler(store Store, userStore userstore.UserStore, pub Publisher, keySt
 		metrics:       opts.metrics,
 		joinGrace:     opts.joinGrace,
 		now:           opts.now,
+		joins:         newJoinRegistry(opts.joinGrace, opts.now),
 	}
 }
 
@@ -910,34 +912,46 @@ func (h *Handler) publishChannelEvent(ctx context.Context, meta *roommetacache.M
 // Best-effort: the room-subject publish has already happened, so returning an error
 // here would only produce a duplicate on JetStream redelivery.
 func (h *Handler) fanOutToFreshMembers(ctx context.Context, roomID string, payload []byte) {
-	if h.joinGrace <= 0 {
+	// The steady-state cost of the join window is exactly this: one map lookup
+	// that misses. No roster query, no extra round trip - a channel message
+	// stays a single publish to the room subject.
+	accounts := h.joins.Fresh(roomID)
+	if len(accounts) == 0 {
 		return
 	}
-	subs, err := h.store.ListSubscriptions(ctx, roomID)
-	if err != nil {
-		slog.WarnContext(ctx, "join-grace roster lookup failed",
-			"error", err, "room_id", roomID,
-			"request_id", natsutil.RequestIDFromContext(ctx))
-		return
-	}
-	cutoff := h.now().Add(-h.joinGrace)
-	fresh := 0
-	for i := range subs {
-		account := subs[i].User.Account
-		if subs[i].User.IsBot || isBot(account) || subs[i].JoinedAt.Before(cutoff) {
+	sent := 0
+	for _, account := range accounts {
+		if isBot(account) {
 			continue
 		}
-		fresh++
+		sent++
 		if err := h.pub.Publish(ctx, subject.UserRoomEvent(account), payload); err != nil {
 			slog.WarnContext(ctx, "join-grace delivery failed",
 				"error", err, "account", account, "room_id", roomID,
 				"request_id", natsutil.RequestIDFromContext(ctx))
 		}
 	}
-	if fresh > 0 {
+	if sent > 0 {
 		slog.Log(ctx, logctx.LevelFlow, "broadcast join-grace fan-out", "phase", "fanout",
-			"request_id", natsutil.RequestIDFromContext(ctx), "room_id", roomID, "recipients", fresh)
+			"request_id", natsutil.RequestIDFromContext(ctx), "room_id", roomID, "recipients", sent)
 	}
+}
+
+// HandleJoinGraceNotice records a room-worker join notice. Fire-and-forget: a
+// dropped notice costs this replica the window for that join, nothing more.
+func (h *Handler) HandleJoinGraceNotice(ctx context.Context, data []byte) {
+	var evt model.JoinGraceEvent
+	if err := json.Unmarshal(data, &evt); err != nil {
+		slog.WarnContext(ctx, "malformed join-grace notice", "error", err)
+		return
+	}
+	joinedAt := h.now()
+	if evt.JoinedAt > 0 {
+		joinedAt = time.UnixMilli(evt.JoinedAt).UTC()
+	}
+	h.joins.Record(evt.RoomID, evt.Accounts, joinedAt)
+	slog.DebugContext(ctx, "join-grace notice recorded",
+		"room_id", evt.RoomID, "accounts", len(evt.Accounts))
 }
 
 // publishRoomEvent fans a channel room's .event out via subject.RoomEventTargets — the

--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -71,16 +71,30 @@ type Handler struct {
 	encoder       *roomcrypto.Encoder
 	routeMode     subject.RoomRouteMode
 	metrics       *broadcastMetrics
+	joinGrace     time.Duration
+	now           func() time.Time
 }
 
 type handlerOption func(*handlerOptions)
 
 type handlerOptions struct {
 	metrics *broadcastMetrics
+	// joinGrace: how long after joining a channel a member also receives the
+	// room's events on their own user subject. 0 disables it.
+	joinGrace time.Duration
+	now       func() time.Time
 }
 
 func withBroadcastMetrics(metrics *broadcastMetrics) handlerOption {
 	return func(opts *handlerOptions) { opts.metrics = metrics }
+}
+
+func withJoinGrace(d time.Duration) handlerOption {
+	return func(opts *handlerOptions) { opts.joinGrace = d }
+}
+
+func withClock(now func() time.Time) handlerOption {
+	return func(opts *handlerOptions) { opts.now = now }
 }
 
 func NewHandler(store Store, userStore userstore.UserStore, pub Publisher, keyStore RoomKeyProvider, parentFetcher ParentFetcher, encrypt bool, routeMode subject.RoomRouteMode, options ...handlerOption) *Handler {
@@ -90,6 +104,9 @@ func NewHandler(store Store, userStore userstore.UserStore, pub Publisher, keySt
 	}
 	if opts.metrics == nil {
 		opts.metrics = newBroadcastMetrics(otel.Meter("broadcast-worker"))
+	}
+	if opts.now == nil {
+		opts.now = func() time.Time { return time.Now().UTC() }
 	}
 	return &Handler{
 		store:         store,
@@ -101,6 +118,8 @@ func NewHandler(store Store, userStore userstore.UserStore, pub Publisher, keySt
 		encoder:       roomcrypto.NewEncoder(),
 		routeMode:     routeMode,
 		metrics:       opts.metrics,
+		joinGrace:     opts.joinGrace,
+		now:           opts.now,
 	}
 }
 
@@ -876,7 +895,49 @@ func (h *Handler) publishChannelEvent(ctx context.Context, meta *roommetacache.M
 		"request_id", natsutil.RequestIDFromContext(ctx), "room_id", meta.ID,
 		"type", string(meta.Type), "delivery", "room-stream", "audience", meta.UserCount)
 	h.metrics.Fanout(ctx, roomChannel, broadcastLabels(ctx).eventType, meta.UserCount)
-	return h.publishRoomEvent(ctx, meta.ID, meta.CrossSite, meta.CrossSiteAt, payload, "channel event")
+	err = h.publishRoomEvent(ctx, meta.ID, meta.CrossSite, meta.CrossSiteAt, payload, "channel event")
+	h.fanOutToFreshMembers(ctx, meta.ID, payload)
+	return err
+}
+
+// fanOutToFreshMembers also delivers a channel event on the user subject of every
+// member who joined within the grace window. Those members cannot yet be relied on
+// to hold chat.room.{id}.event — they only learned about the room moments ago, and
+// NATS exposes no signal for when a subscription is live cluster-wide — but they
+// have held their own user subject since login, so this delivery cannot race.
+// Clients dedupe by message id.
+//
+// Best-effort: the room-subject publish has already happened, so returning an error
+// here would only produce a duplicate on JetStream redelivery.
+func (h *Handler) fanOutToFreshMembers(ctx context.Context, roomID string, payload []byte) {
+	if h.joinGrace <= 0 {
+		return
+	}
+	subs, err := h.store.ListSubscriptions(ctx, roomID)
+	if err != nil {
+		slog.WarnContext(ctx, "join-grace roster lookup failed",
+			"error", err, "room_id", roomID,
+			"request_id", natsutil.RequestIDFromContext(ctx))
+		return
+	}
+	cutoff := h.now().Add(-h.joinGrace)
+	fresh := 0
+	for i := range subs {
+		account := subs[i].User.Account
+		if subs[i].User.IsBot || isBot(account) || subs[i].JoinedAt.Before(cutoff) {
+			continue
+		}
+		fresh++
+		if err := h.pub.Publish(ctx, subject.UserRoomEvent(account), payload); err != nil {
+			slog.WarnContext(ctx, "join-grace delivery failed",
+				"error", err, "account", account, "room_id", roomID,
+				"request_id", natsutil.RequestIDFromContext(ctx))
+		}
+	}
+	if fresh > 0 {
+		slog.Log(ctx, logctx.LevelFlow, "broadcast join-grace fan-out", "phase", "fanout",
+			"request_id", natsutil.RequestIDFromContext(ctx), "room_id", roomID, "recipients", fresh)
+	}
 }
 
 // publishRoomEvent fans a channel room's .event out via subject.RoomEventTargets — the

--- a/broadcast-worker/joingrace_test.go
+++ b/broadcast-worker/joingrace_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+// A member who has just joined a channel has not had time to subscribe to
+// chat.room.{id}.event, and NATS offers no way to know when that subscription
+// is live. Within the grace window the event is therefore also published to
+// each fresh member's own user subject, which they have held since login.
+func TestPublishChannelEvent_JoinGraceWindow(t *testing.T) {
+	msgTime := time.Date(2026, 3, 26, 9, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		grace        time.Duration
+		joinedAt     map[string]time.Time
+		wantSubjects []string
+	}{
+		{
+			name:         "grace disabled publishes only to the room subject",
+			grace:        0,
+			wantSubjects: []string{subject.RoomEvent("room-1", true)},
+		},
+		{
+			name:  "fresh member also gets a copy on their user subject",
+			grace: 30 * time.Second,
+			joinedAt: map[string]time.Time{
+				"alice": msgTime.Add(-2 * time.Second),
+				"bob":   msgTime.Add(-time.Hour),
+			},
+			wantSubjects: []string{
+				subject.RoomEvent("room-1", true),
+				subject.UserRoomEvent("alice"),
+			},
+		},
+		{
+			name:  "every member fresh, every member gets a copy",
+			grace: 30 * time.Second,
+			joinedAt: map[string]time.Time{
+				"alice": msgTime.Add(-time.Second),
+				"bob":   msgTime.Add(-3 * time.Second),
+			},
+			wantSubjects: []string{
+				subject.RoomEvent("room-1", true),
+				subject.UserRoomEvent("alice"),
+				subject.UserRoomEvent("bob"),
+			},
+		},
+		{
+			name:  "no member fresh, no extra publish",
+			grace: 30 * time.Second,
+			joinedAt: map[string]time.Time{
+				"alice": msgTime.Add(-time.Hour),
+				"bob":   msgTime.Add(-time.Hour),
+			},
+			wantSubjects: []string{subject.RoomEvent("room-1", true)},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			store := NewMockStore(ctrl)
+			us := NewMockUserStore(ctrl)
+			keyStore := NewMockRoomKeyProvider(ctrl)
+			pub := &mockPublisher{}
+
+			store.EXPECT().UpdateRoomLastMessage(gomock.Any(), "room-1", "msg-1", msgTime, false).Return(nil)
+			store.EXPECT().AdvanceSubscriptionLastSeen(gomock.Any(), "room-1", "sender", msgTime).Return(nil)
+			store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
+			us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"sender"}).Return(nil, nil)
+			if tc.grace > 0 {
+				store.EXPECT().ListSubscriptions(gomock.Any(), "room-1").Return(subsJoinedAt(tc.joinedAt), nil)
+			}
+
+			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal,
+				withJoinGrace(tc.grace), withClock(func() time.Time { return msgTime }))
+			require.NoError(t, h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hello", msgTime)))
+
+			var got []string
+			for _, r := range pub.records {
+				got = append(got, r.subject)
+			}
+			assert.ElementsMatch(t, tc.wantSubjects, got)
+
+			for _, r := range pub.records {
+				var evt model.RoomEvent
+				require.NoError(t, json.Unmarshal(r.data, &evt))
+				assert.Equal(t, model.RoomEventNewMessage, evt.Type)
+				assert.Equal(t, "msg-1", evt.LastMsgID)
+			}
+		})
+	}
+}
+
+// A failed roster lookup must not fail the handler: the room-subject publish
+// already happened, and a JetStream redelivery would duplicate it.
+func TestPublishChannelEvent_JoinGrace_ListSubscriptionsError(t *testing.T) {
+	msgTime := time.Date(2026, 3, 26, 9, 0, 0, 0, time.UTC)
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	keyStore := NewMockRoomKeyProvider(ctrl)
+	pub := &mockPublisher{}
+
+	store.EXPECT().UpdateRoomLastMessage(gomock.Any(), "room-1", "msg-1", msgTime, false).Return(nil)
+	store.EXPECT().AdvanceSubscriptionLastSeen(gomock.Any(), "room-1", "sender", msgTime).Return(nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"sender"}).Return(nil, nil)
+	store.EXPECT().ListSubscriptions(gomock.Any(), "room-1").Return(nil, errors.New("db down"))
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal,
+		withJoinGrace(30*time.Second), withClock(func() time.Time { return msgTime }))
+	require.NoError(t, h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hello", msgTime)))
+
+	require.Len(t, pub.records, 1)
+	assert.Equal(t, subject.RoomEvent("room-1", true), pub.records[0].subject)
+}
+
+// Bots receive messages through their own integration, never the websocket
+// event channel — the same rule publishDMEvents follows.
+func TestPublishChannelEvent_JoinGrace_SkipsBots(t *testing.T) {
+	msgTime := time.Date(2026, 3, 26, 9, 0, 0, 0, time.UTC)
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	keyStore := NewMockRoomKeyProvider(ctrl)
+	pub := &mockPublisher{}
+
+	store.EXPECT().UpdateRoomLastMessage(gomock.Any(), "room-1", "msg-1", msgTime, false).Return(nil)
+	store.EXPECT().AdvanceSubscriptionLastSeen(gomock.Any(), "room-1", "sender", msgTime).Return(nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
+	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"sender"}).Return(nil, nil)
+	store.EXPECT().ListSubscriptions(gomock.Any(), "room-1").Return([]model.Subscription{
+		{User: model.SubscriptionUser{Account: "alice"}, JoinedAt: msgTime.Add(-time.Second)},
+		{User: model.SubscriptionUser{Account: "weather.bot", IsBot: true}, JoinedAt: msgTime.Add(-time.Second)},
+	}, nil)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal,
+		withJoinGrace(30*time.Second), withClock(func() time.Time { return msgTime }))
+	require.NoError(t, h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hello", msgTime)))
+
+	var got []string
+	for _, r := range pub.records {
+		got = append(got, r.subject)
+	}
+	assert.ElementsMatch(t, []string{subject.RoomEvent("room-1", true), subject.UserRoomEvent("alice")}, got)
+}
+
+func subsJoinedAt(joined map[string]time.Time) []model.Subscription {
+	out := make([]model.Subscription, 0, len(joined))
+	for account, at := range joined {
+		out = append(out, model.Subscription{
+			User:     model.SubscriptionUser{Account: account},
+			RoomID:   "room-1",
+			JoinedAt: at,
+		})
+	}
+	return out
+}

--- a/broadcast-worker/joingrace_test.go
+++ b/broadcast-worker/joingrace_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"testing"
 	"time"
 
@@ -15,30 +14,39 @@ import (
 	"github.com/hmchangw/chat/pkg/subject"
 )
 
-// A member who has just joined a channel has not had time to subscribe to
-// chat.room.{id}.event, and NATS offers no way to know when that subscription
-// is live. Within the grace window the event is therefore also published to
-// each fresh member's own user subject, which they have held since login.
+// A member who has just joined a channel cannot yet be relied on to hold
+// chat.room.{id}.event: their subscribe causally follows the subscription.update
+// that told them the room exists, and NATS exposes no signal for when a
+// subscription is live cluster-wide. Inside the grace window the event is
+// therefore also published to each fresh member's own user subject, which they
+// have held since connect. The roster comes from room-worker's join notices, so
+// a channel message stays one publish plus one map lookup.
 func TestPublishChannelEvent_JoinGraceWindow(t *testing.T) {
 	msgTime := time.Date(2026, 3, 26, 9, 0, 0, 0, time.UTC)
 
 	tests := []struct {
 		name         string
 		grace        time.Duration
-		joinedAt     map[string]time.Time
+		notices      []model.JoinGraceEvent
 		wantSubjects []string
 	}{
 		{
 			name:         "grace disabled publishes only to the room subject",
 			grace:        0,
+			notices:      []model.JoinGraceEvent{{RoomID: "room-1", Accounts: []string{"alice"}, JoinedAt: msgTime.UnixMilli()}},
+			wantSubjects: []string{subject.RoomEvent("room-1", true)},
+		},
+		{
+			name:         "no notice for this room, no extra publish",
+			grace:        30 * time.Second,
+			notices:      []model.JoinGraceEvent{{RoomID: "other-room", Accounts: []string{"alice"}, JoinedAt: msgTime.UnixMilli()}},
 			wantSubjects: []string{subject.RoomEvent("room-1", true)},
 		},
 		{
 			name:  "fresh member also gets a copy on their user subject",
 			grace: 30 * time.Second,
-			joinedAt: map[string]time.Time{
-				"alice": msgTime.Add(-2 * time.Second),
-				"bob":   msgTime.Add(-time.Hour),
+			notices: []model.JoinGraceEvent{
+				{RoomID: "room-1", Accounts: []string{"alice"}, JoinedAt: msgTime.Add(-2 * time.Second).UnixMilli()},
 			},
 			wantSubjects: []string{
 				subject.RoomEvent("room-1", true),
@@ -46,11 +54,10 @@ func TestPublishChannelEvent_JoinGraceWindow(t *testing.T) {
 			},
 		},
 		{
-			name:  "every member fresh, every member gets a copy",
+			name:  "every fresh member gets a copy",
 			grace: 30 * time.Second,
-			joinedAt: map[string]time.Time{
-				"alice": msgTime.Add(-time.Second),
-				"bob":   msgTime.Add(-3 * time.Second),
+			notices: []model.JoinGraceEvent{
+				{RoomID: "room-1", Accounts: []string{"alice", "bob"}, JoinedAt: msgTime.Add(-time.Second).UnixMilli()},
 			},
 			wantSubjects: []string{
 				subject.RoomEvent("room-1", true),
@@ -59,13 +66,23 @@ func TestPublishChannelEvent_JoinGraceWindow(t *testing.T) {
 			},
 		},
 		{
-			name:  "no member fresh, no extra publish",
+			name:  "a join older than the window is gone",
 			grace: 30 * time.Second,
-			joinedAt: map[string]time.Time{
-				"alice": msgTime.Add(-time.Hour),
-				"bob":   msgTime.Add(-time.Hour),
+			notices: []model.JoinGraceEvent{
+				{RoomID: "room-1", Accounts: []string{"alice"}, JoinedAt: msgTime.Add(-time.Hour).UnixMilli()},
 			},
 			wantSubjects: []string{subject.RoomEvent("room-1", true)},
+		},
+		{
+			name:  "bots are skipped - they consume messages server-side",
+			grace: 30 * time.Second,
+			notices: []model.JoinGraceEvent{
+				{RoomID: "room-1", Accounts: []string{"alice", "weather.site-a.bot"}, JoinedAt: msgTime.UnixMilli()},
+			},
+			wantSubjects: []string{
+				subject.RoomEvent("room-1", true),
+				subject.UserRoomEvent("alice"),
+			},
 		},
 	}
 
@@ -81,12 +98,15 @@ func TestPublishChannelEvent_JoinGraceWindow(t *testing.T) {
 			store.EXPECT().AdvanceSubscriptionLastSeen(gomock.Any(), "room-1", "sender", msgTime).Return(nil)
 			store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
 			us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"sender"}).Return(nil, nil)
-			if tc.grace > 0 {
-				store.EXPECT().ListSubscriptions(gomock.Any(), "room-1").Return(subsJoinedAt(tc.joinedAt), nil)
-			}
 
 			h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal,
 				withJoinGrace(tc.grace), withClock(func() time.Time { return msgTime }))
+			for _, n := range tc.notices {
+				data, err := json.Marshal(n)
+				require.NoError(t, err)
+				h.HandleJoinGraceNotice(context.Background(), data)
+			}
+
 			require.NoError(t, h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hello", msgTime)))
 
 			var got []string
@@ -105,68 +125,14 @@ func TestPublishChannelEvent_JoinGraceWindow(t *testing.T) {
 	}
 }
 
-// A failed roster lookup must not fail the handler: the room-subject publish
-// already happened, and a JetStream redelivery would duplicate it.
-func TestPublishChannelEvent_JoinGrace_ListSubscriptionsError(t *testing.T) {
+// A malformed notice must not take the worker down or poison the registry.
+func TestHandleJoinGraceNotice_Malformed(t *testing.T) {
 	msgTime := time.Date(2026, 3, 26, 9, 0, 0, 0, time.UTC)
 	ctrl := gomock.NewController(t)
-	store := NewMockStore(ctrl)
-	us := NewMockUserStore(ctrl)
-	keyStore := NewMockRoomKeyProvider(ctrl)
-	pub := &mockPublisher{}
-
-	store.EXPECT().UpdateRoomLastMessage(gomock.Any(), "room-1", "msg-1", msgTime, false).Return(nil)
-	store.EXPECT().AdvanceSubscriptionLastSeen(gomock.Any(), "room-1", "sender", msgTime).Return(nil)
-	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
-	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"sender"}).Return(nil, nil)
-	store.EXPECT().ListSubscriptions(gomock.Any(), "room-1").Return(nil, errors.New("db down"))
-
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal,
+	h := NewHandler(NewMockStore(ctrl), NewMockUserStore(ctrl), &mockPublisher{}, NewMockRoomKeyProvider(ctrl),
+		defaultParentFetcher, false, subject.RouteGlobal,
 		withJoinGrace(30*time.Second), withClock(func() time.Time { return msgTime }))
-	require.NoError(t, h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hello", msgTime)))
 
-	require.Len(t, pub.records, 1)
-	assert.Equal(t, subject.RoomEvent("room-1", true), pub.records[0].subject)
-}
-
-// Bots receive messages through their own integration, never the websocket
-// event channel — the same rule publishDMEvents follows.
-func TestPublishChannelEvent_JoinGrace_SkipsBots(t *testing.T) {
-	msgTime := time.Date(2026, 3, 26, 9, 0, 0, 0, time.UTC)
-	ctrl := gomock.NewController(t)
-	store := NewMockStore(ctrl)
-	us := NewMockUserStore(ctrl)
-	keyStore := NewMockRoomKeyProvider(ctrl)
-	pub := &mockPublisher{}
-
-	store.EXPECT().UpdateRoomLastMessage(gomock.Any(), "room-1", "msg-1", msgTime, false).Return(nil)
-	store.EXPECT().AdvanceSubscriptionLastSeen(gomock.Any(), "room-1", "sender", msgTime).Return(nil)
-	store.EXPECT().GetRoomMeta(gomock.Any(), "room-1").Return(metaOf(testChannelRoom), nil)
-	us.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"sender"}).Return(nil, nil)
-	store.EXPECT().ListSubscriptions(gomock.Any(), "room-1").Return([]model.Subscription{
-		{User: model.SubscriptionUser{Account: "alice"}, JoinedAt: msgTime.Add(-time.Second)},
-		{User: model.SubscriptionUser{Account: "weather.bot", IsBot: true}, JoinedAt: msgTime.Add(-time.Second)},
-	}, nil)
-
-	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal,
-		withJoinGrace(30*time.Second), withClock(func() time.Time { return msgTime }))
-	require.NoError(t, h.HandleMessage(context.Background(), makeMessageEvent("room-1", "hello", msgTime)))
-
-	var got []string
-	for _, r := range pub.records {
-		got = append(got, r.subject)
-	}
-	assert.ElementsMatch(t, []string{subject.RoomEvent("room-1", true), subject.UserRoomEvent("alice")}, got)
-}
-
-func subsJoinedAt(joined map[string]time.Time) []model.Subscription {
-	out := make([]model.Subscription, 0, len(joined))
-	for account, at := range joined {
-		out = append(out, model.Subscription{
-			User:     model.SubscriptionUser{Account: account},
-			RoomID:   "room-1",
-			JoinedAt: at,
-		})
-	}
-	return out
+	h.HandleJoinGraceNotice(context.Background(), []byte("{not json"))
+	assert.Zero(t, h.joins.Len())
 }

--- a/broadcast-worker/joinregistry.go
+++ b/broadcast-worker/joinregistry.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+// joinRegistry remembers who joined which channel recently, so the channel
+// fan-out can find them without a roster query.
+//
+// A channel message is one publish to the room subject by design, and that
+// must stay true: the steady-state cost here is a single map lookup that
+// misses. Entries arrive as join notices from room-worker, expire with the
+// grace window, and are swept whenever a notice arrives - joins are rare
+// relative to messages, so the sweep never lands on the message path.
+type joinRegistry struct {
+	mu    sync.RWMutex
+	ttl   time.Duration
+	now   func() time.Time
+	rooms map[string]map[string]time.Time
+}
+
+func newJoinRegistry(ttl time.Duration, now func() time.Time) *joinRegistry {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &joinRegistry{ttl: ttl, now: now, rooms: map[string]map[string]time.Time{}}
+}
+
+// Record notes that accounts joined roomID at joinedAt, and sweeps rooms whose
+// entries have all expired.
+func (r *joinRegistry) Record(roomID string, accounts []string, joinedAt time.Time) {
+	if r.ttl <= 0 || roomID == "" || len(accounts) == 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	room := r.rooms[roomID]
+	if room == nil {
+		room = make(map[string]time.Time, len(accounts))
+		r.rooms[roomID] = room
+	}
+	for _, account := range accounts {
+		if account != "" {
+			room[account] = joinedAt
+		}
+	}
+	r.sweepLocked()
+}
+
+// Fresh returns the accounts still inside the grace window for roomID. The
+// miss path - every message in every room with no recent join - takes a read
+// lock and one map lookup.
+func (r *joinRegistry) Fresh(roomID string) []string {
+	if r.ttl <= 0 {
+		return nil
+	}
+	r.mu.RLock()
+	room, ok := r.rooms[roomID]
+	if !ok {
+		r.mu.RUnlock()
+		return nil
+	}
+	cutoff := r.now().Add(-r.ttl)
+	out := make([]string, 0, len(room))
+	expired := false
+	for account, at := range room {
+		if at.Before(cutoff) {
+			expired = true
+			continue
+		}
+		out = append(out, account)
+	}
+	r.mu.RUnlock()
+
+	if expired {
+		r.mu.Lock()
+		r.sweepLocked()
+		r.mu.Unlock()
+	}
+	return out
+}
+
+// Len reports how many rooms are being tracked.
+func (r *joinRegistry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.rooms)
+}
+
+func (r *joinRegistry) sweepLocked() {
+	cutoff := r.now().Add(-r.ttl)
+	for roomID, room := range r.rooms {
+		for account, at := range room {
+			if at.Before(cutoff) {
+				delete(room, account)
+			}
+		}
+		if len(room) == 0 {
+			delete(r.rooms, roomID)
+		}
+	}
+}

--- a/broadcast-worker/joinregistry_test.go
+++ b/broadcast-worker/joinregistry_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJoinRegistry(t *testing.T) {
+	base := time.Date(2026, 3, 26, 9, 0, 0, 0, time.UTC)
+
+	t.Run("unknown room is empty and allocates nothing", func(t *testing.T) {
+		r := newJoinRegistry(30*time.Second, func() time.Time { return base })
+		assert.Empty(t, r.Fresh("room-1"))
+		assert.Zero(t, r.Len())
+	})
+
+	t.Run("recorded joins are fresh inside the window", func(t *testing.T) {
+		now := base
+		r := newJoinRegistry(30*time.Second, func() time.Time { return now })
+		r.Record("room-1", []string{"alice", "bob"}, base)
+
+		now = base.Add(29 * time.Second)
+		assert.ElementsMatch(t, []string{"alice", "bob"}, r.Fresh("room-1"))
+	})
+
+	t.Run("joins expire once the window passes", func(t *testing.T) {
+		now := base
+		r := newJoinRegistry(30*time.Second, func() time.Time { return now })
+		r.Record("room-1", []string{"alice"}, base)
+
+		now = base.Add(31 * time.Second)
+		assert.Empty(t, r.Fresh("room-1"))
+		assert.Zero(t, r.Len(), "an emptied room must be dropped, not left behind")
+	})
+
+	t.Run("a later join extends only that account", func(t *testing.T) {
+		now := base
+		r := newJoinRegistry(30*time.Second, func() time.Time { return now })
+		r.Record("room-1", []string{"alice"}, base)
+		r.Record("room-1", []string{"bob"}, base.Add(20*time.Second))
+
+		now = base.Add(35 * time.Second)
+		assert.ElementsMatch(t, []string{"bob"}, r.Fresh("room-1"))
+	})
+
+	t.Run("recording sweeps rooms that went quiet", func(t *testing.T) {
+		now := base
+		r := newJoinRegistry(30*time.Second, func() time.Time { return now })
+		r.Record("room-1", []string{"alice"}, base)
+
+		now = base.Add(time.Hour)
+		r.Record("room-2", []string{"bob"}, now)
+		assert.Equal(t, 1, r.Len(), "the stale room must not survive an unrelated join")
+		assert.Empty(t, r.Fresh("room-1"))
+		assert.ElementsMatch(t, []string{"bob"}, r.Fresh("room-2"))
+	})
+
+	t.Run("disabled registry records nothing", func(t *testing.T) {
+		r := newJoinRegistry(0, func() time.Time { return base })
+		r.Record("room-1", []string{"alice"}, base)
+		assert.Empty(t, r.Fresh("room-1"))
+	})
+
+	t.Run("empty account list is a no-op", func(t *testing.T) {
+		r := newJoinRegistry(30*time.Second, func() time.Time { return base })
+		r.Record("room-1", nil, base)
+		assert.Zero(t, r.Len())
+	})
+}

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -66,6 +66,11 @@ type config struct {
 	MetricsAddr          string          `env:"METRICS_ADDR"             envDefault:":9090"`
 	Mode                 stream.Pipeline `env:"MODE,required"` // user | bot; drives all stream/subject wiring via pkg/stream.Resolve
 	RoomSubjectMode      string          `env:"ROOM_SUBJECT_MODE"        envDefault:"global"`
+	// JoinGrace: how long after joining a channel a member also receives that
+	// room's events on their own user subject, which they have held since login.
+	// Covers the window where they cannot yet be relied on to hold
+	// chat.room.{id}.event. 0 disables it.
+	JoinGrace time.Duration `env:"JOIN_GRACE" envDefault:"0"`
 	// RoomLocalityGrace: post-flip dual-publish window. Must match across all publisher services.
 	RoomLocalityGrace time.Duration           `env:"ROOM_LOCALITY_GRACE"      envDefault:"168h"`
 	Consumer          stream.ConsumerSettings `envPrefix:"CONSUMER_"`
@@ -223,7 +228,7 @@ func main() {
 	}
 
 	parentFetcher := newHistoryParentFetcher(nc, publishMetrics)
-	handler := NewHandler(coalescer, us, publisher, keyProvider, parentFetcher, cfg.Encryption.Enabled, roomRouteMode, withBroadcastMetrics(domainMetrics))
+	handler := NewHandler(coalescer, us, publisher, keyProvider, parentFetcher, cfg.Encryption.Enabled, roomRouteMode, withBroadcastMetrics(domainMetrics), withJoinGrace(cfg.JoinGrace))
 
 	// Core-NATS queue subscriber for server-broadcast events (e.g. thread tcount badge).
 	// Fire-and-forget: errors are logged inside HandleServerBroadcast; no retry path.

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -244,6 +244,20 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Join notices are NOT queue-subscribed: every replica keeps its own registry,
+	// so all of them must see every notice.
+	var joinSub *nats.Subscription
+	if cfg.JoinGrace > 0 {
+		joinSub, err = nc.Subscribe(ctx, subject.JoinGraceNotice(cfg.SiteID),
+			func(msgCtx context.Context, msg *nats.Msg) {
+				handler.HandleJoinGraceNotice(msgCtx, msg.Data)
+			})
+		if err != nil {
+			slog.Error("subscribe join-grace failed", "error", err)
+			os.Exit(1)
+		}
+	}
+
 	iter, err := cons.Messages(ctx, jetstream.PullMaxMessages(2*cfg.MaxWorkers))
 	if err != nil {
 		slog.Error("messages failed", "error", err)
@@ -269,6 +283,12 @@ func main() {
 	hooks := []func(context.Context) error{
 		func(_ context.Context) error {
 			return broadcastSub.Unsubscribe()
+		},
+		func(_ context.Context) error {
+			if joinSub == nil {
+				return nil
+			}
+			return joinSub.Unsubscribe()
 		},
 		func(ctx context.Context) error {
 			consumerMetrics.LoopStopped(ctx)

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -176,6 +176,23 @@ Permissions and connection limits come from the auth-service account's scoped si
 - `chat.user.{account}.>` — captures every personal event including async replies, per-user room events (DM messages, edits, deletes), room-key events, subscription updates, and settings updates.
 - the room-event subject for each channel room in the user's sidebar — receives new messages plus edit/delete events for that channel. Pick the subject by the room's `crossSite` flag (from `subscription.list`): `chat.room.{roomID}.event` when `crossSite: true`, `chat.local.room.{roomID}.event` when `crossSite: false`. **Absent/unknown `crossSite` defaults to the global `chat.room.{roomID}.event`** (fail-safe — a global room misrouted to the local subject would silently miss cross-site delivery).
 
+**Join grace window.** For a short period after a client joins a **channel** (server-configured;
+disabled by default), that channel's `new_message` events are delivered **twice**: once on the
+room-event subject above, and once on `chat.user.{account}.event.room`. A member who has just
+learned about a room cannot yet be relied on to hold `chat.room.{roomID}.event` — NATS gives no
+signal for when a subscription is live across the cluster — so the copy on the user subject,
+which the client has held since connect, is what makes the first messages in a new room reliable.
+
+Two consequences for clients:
+
+- **Deduplicate by `message.id`.** During the window the same message can arrive on both subjects.
+- **Accept a room event for a room you do not know yet.** The copy can arrive before the
+  `subscription.update` that introduces the room; render it from the event payload rather than
+  discarding it.
+
+Both are worth doing regardless of whether the window is enabled — neither subject is ordered
+against the other.
+
 The exact event subjects a client may receive as a result of an RPC are listed under each method's "Triggered events" sections in §2.2, §3, and §4.
 
 ### 2.2 HTTP — POST /api/v1/auth

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -356,10 +356,20 @@ Retain past versions for history scrolling (server grace window: at least 24h).
 | Room type | Subject |
 |---|---|
 | Channel | `chat.room.{roomID}.event` |
+| Channel, within the join grace window | **also** `chat.user.{account}.event.room`, per non-bot member who joined recently |
 | DM / botDM | `chat.user.{account}.event.room` — published per non-bot member |
 
 The `type` field discriminates the event. All payloads carry `type`, `roomId`,
 `siteId`, and `timestamp`.
+
+**Join grace window.** For a server-configured period after a member joins a channel
+(disabled by default), that channel's `new_message` events are also published to the member's
+own user subject. A client that has just learned about a room cannot yet be relied on to hold
+`chat.room.{roomID}.event`, and NATS gives no signal for when a subscription is live across the
+cluster; the user subject has been held since connect, so it cannot race. Clients must
+**deduplicate by `message.id`** and must **accept a room event for a room they do not know yet**
+— the copy can arrive before the `subscription.update` that introduces the room. See
+[../client-api.md §2.1](../client-api.md#21-nats-connection).
 
 ---
 

--- a/docs/design/2026-08-22-new-room-first-message-race.md
+++ b/docs/design/2026-08-22-new-room-first-message-race.md
@@ -14,9 +14,16 @@
 | | Where the message is lost | Fixable with today's architecture? |
 |---|---|---|
 | **Problem 1 — DM** | NATS delivers it to client B; **B's client discards it** because the room isn't in local state yet | **Yes, client-only.** No backend change. |
-| **Problem 2 — channel** | NATS drops it: nobody is subscribed to `chat.room.{id}.event` yet | **Yes, client-only** via subscribe → backfill over the existing `msg.history` RPC. A small server change upgrades that from *recovered* to *delivered live*. |
+| **Problem 2 — channel** | Two independent losses: NATS drops the live event (nobody is subscribed to `chat.room.{id}.event` yet), **and** `msg.history` cannot see the just-sent message | **Yes, client-only** — but backfill alone is *not* enough: the history call must carry the documented `meta.lastMsgAt` hint. Verified end-to-end. |
 
 The measured, decisive fact:
+
+**A second, separate defect surfaced once the full stack was run** (see "What the end-to-end run added" below): `msg.history`
+ceilings its Cassandra scan at the room document's `lastMsgAt`, which is advanced
+asynchronously. A message sent moments ago is therefore invisible to a plain history
+load — and **retrying does not help**, because history-service caches the stale ceiling
+for `HISTORY_ROOM_CACHE_TTL` (10 s by default). Measured: 55 retries over 3.5 s still
+returned 2 of 3 messages. This is why "just backfill" is not on its own a fix.
 
 > **The race window is dominated by the client, not by NATS.**
 > With an instant client, the channel window is under 1 ms. With a realistic 30 ms
@@ -149,13 +156,61 @@ Three things the measurements settle:
    NATS exposes no cluster-wide "interest is live" signal — [nats-server#1142](https://github.com/nats-io/nats-server/issues/1142)
    is still open on exactly this.
 
-### Fix A — client backfill (works today, zero backend change)
+### What the end-to-end run added (`tools/roomrace/e2e`)
+
+Running the real services changed the picture in two ways. Full numbers in
+`tools/roomrace/RESULTS-e2e.md`.
+
+**The creator learns about her own room ~500 ms after everyone else.**
+`room-worker.finishCreateRoom` publishes `subscription.update` to every member,
+*then* the `room_created` / `members_added` system messages, *then* the deferred
+`publishAsyncJobResult`. Measured: members get `subscription.update` at 23 ms, the
+system messages are broadcast at 29 ms, and the creator's async job result lands at
+**529 ms**. A creator who waits for that result before subscribing has already missed
+both system messages — which is exactly the reported symptom. Subscribing on the
+client's *own* `subscription.update` instead (24 ms) catches them.
+
+**`msg.history` cannot see a just-sent message, and retrying does not help.**
+This is the more important finding, and it invalidates "backfill alone" as a fix.
+
+`history-service.walkBounds` sets the scan ceiling to the room document's `lastMsgAt`,
+and `LoadHistory` caps `before` at that value. Anything newer than the room document
+is therefore invisible. Two delays stack:
+
+* `broadcast-worker` advances `room.lastMsgAt` on a **batched flush**
+  (`LAST_MSG_FLUSH_INTERVAL`, default 250 ms);
+* `history-service` then **caches** the resolved room times
+  (`HISTORY_ROOM_CACHE_TTL`, default 10 s), pinning the stale ceiling.
+
+Measured, with all three messages confirmed present in Cassandra:
+
+| run | alice history | bob history |
+|---|---|---|
+| baseline | 2 of 3 | 2 of 3 |
+| retry until it appears (55 tries / 3.5 s) | **2 of 3** | **2 of 3** |
+| same retry, `HISTORY_ROOM_CACHE_SIZE=0` | 3 of 3 (5 tries, ~200 ms) | 3 of 3 (1 try) |
+| `meta.lastMsgAt` hint, cache enabled | **3 of 3, first try** | **3 of 3, first try** |
+
+The last row is the fix and it needs no backend change: `msg.history` already accepts
+`meta.lastMsgAt` (documented in `docs/client-api.md`, Common request fields). The doc
+presents it as a way to skip a MongoDB lookup; it is *also* the scan ceiling, so a
+client that supplies a fresh value sees its own just-sent message. Values up to one
+hour ahead pass sanitisation, so `Date.now()` is accepted.
+
+**Server-side follow-up worth doing anyway.** Ceiling-at-`lastMsgAt` is an optimisation
+to avoid scanning empty buckets, but for a *newest-page* request (no `before` supplied)
+it costs nothing to ceiling at `max(lastMsgAt, now)` instead — with
+`MESSAGE_BUCKET_HOURS=360` that is almost always the same partition, just a wider
+clustering-range upper bound. That removes the sharp edge for every client, including
+ones that never send the hint.
+
+### Fix A — client backfill **with a freshness hint** (works today, zero backend change)
 
 On `subscription.update{added}` for a channel: **subscribe first, then read the durable log,
 then merge by message ID.**
 
 ```
-open chat.room.{id}.event  →  Flush()  →  msg.history{limit:N}  →  merge, dedupe by messageId
+open chat.room.{id}.event  →  Flush()  →  msg.history{limit:N, meta:{lastMsgAt: now}}  →  merge, dedupe by messageId
 ```
 
 `msg.history` already exists —
@@ -167,7 +222,9 @@ The ordering is the whole point, and it is Zulip's documented guarantee applied 
 register the listener before reading state, so anything that arrives during the read is
 still delivered. Backfill-then-subscribe re-opens the window.
 
-**One caveat the harness is optimistic about.** It persists before fanning out. In
+**The `meta` hint is not optional — see the end-to-end section above.** Without it this recovers nothing for up to 10 s.
+
+**One caveat the NATS-level harness was optimistic about.** It persists before fanning out. In
 production `message-worker` and `broadcast-worker` are **separate durable consumers of
 MESSAGES-CANONICAL** and run concurrently, so a backfill issued milliseconds after the
 fan-out can read Cassandra *before* the write lands. Backfill therefore needs a companion:
@@ -246,9 +303,11 @@ For reference, neither Slack nor Zulip built a compound endpoint: both made DM c
 | # | Change | Side | Fixes | Evidence |
 |---|---|---|---|---|
 | 1 | `new_message` upserts the room from the event payload instead of dropping it | client | **Problem 1, completely** | `dm / client buffers unknown room`: 0% at every delay |
-| 2 | On channel join: subscribe → flush → `msg.history` → merge by message id | client | **Problem 2**, recovered | `channel / … + backfill`: 0% at every delay |
+| 1b | Subscribe to the room subject on the client's **own** `subscription.update`, not on the create job result or on room-open | client | the creator missing her own room's system messages | E2E: subscribed at 24 ms vs system messages at 29 ms; the job result lands at 529 ms |
+| 2 | On channel join: subscribe → flush → `msg.history` **with `meta.lastMsgAt`** → merge by message id | client | **Problem 2**, recovered | `channel / … + backfill`: 0% at every delay; E2E: 3 of 3 on the first try |
 | 3 | Gap detection on `lastMsgId` + reconcile on reconnect | client | the `message-worker`/`broadcast-worker` write race, and every event lost to a disconnect | see §4 caveat |
 | 4 | Join grace window: dual-publish to the per-user subject for members joined < N s ago, gated on `Meta.LastJoinAt` | server | **Problem 2**, delivered live | `channel / server join grace window`: 0% at every delay |
+| 4b | `msg.history` newest-page ceiling at `max(lastMsgAt, now)` | server | removes the stale-ceiling edge for every client, hint or not | E2E: cache disabled → 3 of 3 |
 | 5 | *(optional)* combined DM create+send as a thin orchestrator | server | latency/UX only | §5 |
 
 Steps 1–3 need no backend change at all. Step 4 is one cache field plus a gated lookup, and

--- a/docs/design/2026-08-22-new-room-first-message-race.md
+++ b/docs/design/2026-08-22-new-room-first-message-race.md
@@ -14,9 +14,18 @@
 | | Where the message is lost | Fixable with today's architecture? |
 |---|---|---|
 | **Problem 1 — DM** | NATS delivers it to client B; **B's client discards it** because the room isn't in local state yet | **Yes, client-only.** No backend change. |
-| **Problem 2 — channel** | Two independent losses: NATS drops the live event (nobody is subscribed to `chat.room.{id}.event` yet), **and** `msg.history` cannot see the just-sent message | **Yes, client-only** — but backfill alone is *not* enough: the history call must carry the documented `meta.lastMsgAt` hint. Verified end-to-end. |
+| **Problem 2 — channel** | Two independent losses: NATS drops the live event (nobody is subscribed to `chat.room.{id}.event` yet), **and** `msg.history` cannot see the just-sent message | **Not fully.** The client fix (subscribe → flush → hinted read → merge) narrows it but loses everything when the write path lags. Closing it needs the server-side join grace window. |
 
 The measured, decisive fact:
+
+**The client cannot close Problem 2 on its own.** Subscribe → flush → hinted read → merge
+narrows the window but does not close it: with `message-worker` stalled and a 12 ms client
+delay, **67% of messages were lost from both paths** — missed live because the client was late,
+missed in history because they were not written yet. The client cannot even detect this (no
+per-room sequence number). The fix that measures 0% at every client delay, and 0% even with the
+write path stalled, is the **join grace window** (§4, Fix B): deliver on the per-user subject
+the client has held since login, which no join can race. It is now implemented behind
+`JOIN_GRACE` (default off). See `tools/roomrace/RESULTS-e2e.md`.
 
 **A second, separate defect surfaced once the full stack was run** (see "What the end-to-end run added" below): `msg.history`
 ceilings its Cassandra scan at the room document's `lastMsgAt`, which is advanced
@@ -232,7 +241,7 @@ gap detection on `lastMsgId` (already on every `RoomEvent` and on `SubscriptionR
 the id doesn't chain onto what the client holds, re-fetch. Without it, a backfill can come
 back one message short and stay short.
 
-### Fix B — server join grace window (small change, delivers live)
+### Fix B — server join grace window (implemented behind `JOIN_GRACE`; the only race-free path)
 
 Have `broadcast-worker` **also** publish a channel's room event to
 `chat.user.{X}.event.room` for members whose `joinedAt` is inside a grace window (say 30 s).
@@ -306,13 +315,19 @@ For reference, neither Slack nor Zulip built a compound endpoint: both made DM c
 | 1b | Subscribe to the room subject on the client's **own** `subscription.update`, not on the create job result or on room-open | client | the creator missing her own room's system messages | E2E: subscribed at 24 ms vs system messages at 29 ms; the job result lands at 529 ms |
 | 2 | On channel join: subscribe → flush → `msg.history` **with `meta.lastMsgAt`** → merge by message id | client | **Problem 2**, recovered | `channel / … + backfill`: 0% at every delay; E2E: 3 of 3 on the first try |
 | 3 | Gap detection on `lastMsgId` + reconcile on reconnect | client | the `message-worker`/`broadcast-worker` write race, and every event lost to a disconnect | see §4 caveat |
-| 4 | Join grace window: dual-publish to the per-user subject for members joined < N s ago, gated on `Meta.LastJoinAt` | server | **Problem 2**, delivered live | `channel / server join grace window`: 0% at every delay |
+| 4 | Join grace window: dual-publish to the per-user subject for members joined < N s ago (`JOIN_GRACE`, default off) | server | **Problem 2**, delivered live — and the only fix that survives a lagging `message-worker` | 0% live loss at client delays 0 ms–1 s; 0% lost with `message-worker` stalled |
 | 4b | `msg.history` newest-page ceiling at `max(lastMsgAt, now)` | server | removes the stale-ceiling edge for every client, hint or not | E2E: cache disabled → 3 of 3 |
 | 5 | *(optional)* combined DM create+send as a thin orchestrator | server | latency/UX only | §5 |
 
-Steps 1–3 need no backend change at all. Step 4 is one cache field plus a gated lookup, and
-is worth doing because it turns Problem 2 from "recovered a beat later" into "never
-happened" — but it is strictly dependent on step 1.
+Steps 1–3 need no backend change at all, and they are still worth doing — they cover DMs,
+reconnects, and everything outside the join window. But step 4 is the one that makes Problem 2
+go away rather than shrink, and it remains strictly dependent on step 1: a client that discards
+a room event for an unknown room discards the grace copy too (measured: 100% still lost).
+
+The shipped prototype does the roster lookup on every channel message while `JOIN_GRACE > 0`.
+Before enabling it on a busy site, gate the lookup on a cached `LastJoinAt` in
+`roommetacache.Meta` (which already carries `CrossSiteAt` for an analogous grace window) so a
+room with no recent join pays only a nil check.
 
 Do **not** start with step 4 alone: measured, it fixes nothing.
 

--- a/docs/design/2026-08-22-new-room-first-message-race.md
+++ b/docs/design/2026-08-22-new-room-first-message-race.md
@@ -1,0 +1,393 @@
+# New-room → first-message race: analysis and recommendation
+
+**Status:** analysis / recommendation (no code changed)
+**Date:** 2026-08-22
+**Scope:** `room-service`, `room-worker`, `message-gatekeeper`, `broadcast-worker`, client event contract
+
+---
+
+## 1. TL;DR
+
+The reported symptom ("B gets the subscription event but misses `new_message`") is not one race —
+it is **three independent races** stacked on the same transition, and they have different fixes:
+
+| # | Race | Who loses | Applies to |
+|---|------|-----------|-----------|
+| **R1** | A sends before `room-worker` materialized the subscription → `message-gatekeeper` rejects with *not subscribed* | the **sender** | DM + channel |
+| **R2** | B has not yet issued `SUB chat.room.{id}.event` (and NATS has not yet propagated that interest) when `broadcast-worker` publishes | the **recipient** | **channel only** |
+| **R3** | B receives `new_message` on a subject it *is* subscribed to, but its local store has no room yet, so the client drops/misfiles the event | the **recipient** | DM + channel |
+
+A combined "create room + send message" RPC — the proposed idea — **fully closes R1**, and closes
+R3 *if and only if* the combined event carries the message payload on a subject the recipient is
+already subscribed to. **It does not close R2 at all**, and R2 is the only one of the three that is
+structurally unfixable on the client side alone.
+
+**Recommendation (layered, in priority order):**
+
+1. **Client contract fix (today, no server change):** the client must wait for the *phase-2* async
+   job result before sending, and must tolerate a `new_message` for a room it does not know yet.
+2. **Server, small:** on the `subscription.update{action:"added"}` event, populate the already-existing
+   `subscription.room.lastMsgId` / `previewMessage` fields so the recipient can render and detect a gap.
+3. **Server, targeted — the actual R2 fix:** a **join grace window** in `broadcast-worker` — additionally
+   publish a channel's room event to `chat.user.{account}.event.room` for members whose `joinedAt` is
+   within N seconds. This mirrors the `roomLocalityGrace` pattern already in `pkg/subject`.
+4. **Client, structural:** subscribe-then-backfill on every room entry, dedupe by message ID
+   (the Zulip guarantee, adapted). This also fixes the strictly larger bug class: events lost while
+   the client was disconnected.
+5. **Optional, and only for DMs:** the proposed combined RPC — but built as a *thin orchestrator over
+   the existing synchronous DM-create RPC*, not as a second implementation of create + send.
+
+---
+
+## 2. What the code does today
+
+### 2.1 Create
+
+`chat.user.{A}.request.room.{siteID}.room.create` → `room-service` `Handler.createRoom`
+(`room-service/handler.go`):
+
+1. `classifyAndValidate` → `RoomTypeDM` (empty name, one counterpart).
+2. `handleCreateRoomDMOrBotDM` → `idgen.BuildDMRoomID(requester.ID, other.ID)` (deterministic),
+   `FindDMSubscription` dedup (returns `status:"exists"` when the DM already exists).
+3. `publishCreateRoom` → `EnsureDEK`, then JetStream publish to `chat.room.canonical.{site}.create`.
+4. Replies **`{status:"accepted", roomId, roomType}`** — this is only an *acknowledgement of handoff*.
+   No room document and no subscription exists yet at this point.
+
+`room-worker` `processCreateRoom` then does the real work asynchronously:
+room insert → `BulkCreateSubscriptions` → `finishCreateRoom` → `publishSubscriptionAdded`
+(core publish, per member, to `chat.user.{X}.event.subscription.update`) → federation →
+**`defer publishAsyncJobResult`** to `chat.user.{A}.response.{requestID}` (phase 2).
+
+So the ordering guarantee that *does* exist server-side is:
+`subscriptions written` → `subscription.update` published to B → `async job result` published to A.
+
+### 2.2 Send
+
+`chat.user.{A}.room.{roomID}.{siteID}.msg.send` → MESSAGES stream → `message-gatekeeper.processMessage`,
+which validates and then:
+
+```go
+sub, err := h.store.GetSubscription(ctx, account, roomID)
+if errors.Is(err, errNotSubscribed) { return nil, err }   // → rejected
+```
+
+→ MESSAGES-CANONICAL → `broadcast-worker`.
+
+### 2.3 Fan-out (the decisive detail)
+
+`broadcast-worker/handler.go` has **two different delivery shapes**:
+
+| Room type | Function | Subject |
+|---|---|---|
+| DM / botDM | `publishDMEvents` | **`chat.user.{account}.event.room`** — one publish per member |
+| channel | `publishChannelEvent` → `publishRoomEvent` | **`chat.room.{roomID}.event`** (or `chat.local.room.…`) |
+
+And the reference client (`chat-frontend/src/context/RoomEventsContext/useRoomSubscriptions.js`):
+
+* subscribes **once at login** to `chat.user.{me}.event.room`, `…event.subscription.update`,
+  `…event.room.metadata.update`, `…event.room.key`;
+* subscribes **lazily, per room** to `chat.room.{id}.event` — and only for channels:
+  `if (sub.roomType === 'channel') openChannelSub(sub.roomId, room.crossSite)`, driven by the
+  `subscription.update{added}` event. Its own test asserts
+  `expect(subjects).not.toContain('chat.room.d1.event')` for a DM.
+
+**Consequence:** for a *DM*, B's client is already listening on the delivery subject before the room
+even exists. There is no transport-level race for DMs. Which means the reported DM symptom is
+**R1 and/or R3, not R2** — unless the desktop client (unlike the reference frontend) subscribes
+per-room for DMs too. This is worth confirming before building anything.
+
+---
+
+## 3. The three races in detail
+
+### R1 — sender-side: "room not ready"
+
+A gets `{status:"accepted"}` and sends immediately. `room-worker` has not yet written the
+subscription, so `GetSubscription` returns `errNotSubscribed` and the message is **rejected outright**
+(it never reaches MESSAGES-CANONICAL — it is not merely delayed).
+
+Window: one JetStream hop + `GetUser` + room insert + `BulkCreateSubscriptions` + reconcile — typically
+tens of ms, but unbounded under load or Mongo pressure.
+
+The contract already provides the fix: `createRoom` is a **two-phase async job**
+(`requestWithAsyncResult` in `chat-frontend/src/api/createRoom/index.ts`). A client that sends on the
+*sync* reply instead of the *async job result* has this bug by construction.
+
+### R2 — transport-side: "no interest yet" (channels only)
+
+B learns about the room, then calls `nc.subscribe("chat.room.{id}.event")`. That subscription must
+reach B's NATS server and be gossiped to every other server (and across gateways, for cross-site).
+Core NATS is **at-most-once with no replay**: anything published into that window is gone from the
+live path permanently.
+
+NATS gives you **no signal for this**. From
+[nats-server#1142](https://github.com/nats-io/nats-server/issues/1142): *"there is no guarantee that
+in the moment when the 'server' is publishing the message 'data.xyz', the subscription (RS+) from
+'nats-server-A' has been propagated to 'nats-server-B'"* — and the issue is still open, with no
+"subscription is now live cluster-wide" primitive. `flush()` only confirms *your own* server processed
+the SUB; it says nothing about the rest of the cluster or the gateways.
+
+This is why **no amount of server-side atomicity fixes R2**. Even a perfect single combined
+operation that emits the subscription event and the message event in one breath still publishes the
+message before B has finished subscribing, because B's subscribe *causally follows* the event it is
+reacting to.
+
+### R3 — application-state-side: "unknown room"
+
+`subscription.update` (from `room-worker`) and the room event (from `broadcast-worker`) are published
+by **different processes on different subjects**. There is no ordering guarantee between them —
+neither NATS nor the code provides one. B can legitimately receive `new_message` for a room it has
+never heard of.
+
+The reference frontend survives this: `MESSAGE_RECEIVED` uses
+`state.roomState[roomId] ?? emptyRoomState()` and records a preview regardless. A client that
+requires the room to exist first will silently drop the event.
+
+### The common root cause
+
+> The system delivers live events over an **at-most-once transport whose subscription set is derived
+> from state the client learns over that same at-most-once transport.**
+
+That circularity guarantees a window between *"you are a member"* and *"you are listening"*. Only two
+things remove it: (a) don't require a per-room subscription, or (b) reconcile against the durable log
+after subscribing. Everything else just narrows the window.
+
+Worth noting the same reasoning covers a strictly larger bug: `publishSubscriptionUpdate` and
+`publishDMEvents` are **best-effort core publishes** (both log-and-continue on error). If B is
+mid-reconnect, the events are lost with no race involved at all. Whatever you build should fix that
+too, or you will be back here.
+
+---
+
+## 4. How comparable systems solve this
+
+| System | Mechanism | Takeaway |
+|---|---|---|
+| **Zulip** | `POST /register` creates the event queue **before** the initial state is fetched; events that arrive during the fetch are replayed onto the fetched state via `apply_events`. Documented goal: the client sees *either* old state + event, *or* new state + no event — never a mix. ([events-system](https://zulip.readthedocs.io/en/stable/subsystems/events-system.html)) | **Subscribe first, fetch second, merge.** Solve it once on the server side of the contract, not in N clients. |
+| **Zulip (DMs)** | There is no "create DM" call at all: `POST /messages` with `type:"direct"`, `to:[user_ids]` — the conversation is implicit. ([send-message](https://zulip.com/api/send-message)) | If DM identity is deterministic, "create" is a redundant step you can delete. |
+| **Slack** | `conversations.open` exists, but `chat.postMessage` with a user ID as `channel` **opens the DM if it isn't open already**. ([conversations.open](https://docs.slack.dev/reference/methods/conversations.open/), [chat.postMessage](https://api.slack.com/methods/chat.postMessage)) | Same conclusion, from the biggest product in the category. |
+| **Matrix** | `/sync` with a `since` token; clients are told to **de-duplicate by event ID** because ordering across APIs can produce duplicates. ([spec](https://spec.matrix.org/latest/client-server-api/)) | Idempotent merge by ID is the price of admission for any backfill design. |
+| **Discord** | Every gateway event carries a sequence `s`; `RESUME` replays from the last `s`. Replay is **bounded** — overflow → `INVALID_SESSION` → full re-fetch. ([gateway](https://docs.discord.com/developers/events/gateway)) | Gap detection + bounded replay + full-resync fallback. |
+| **General chat architecture** | The live pub/sub path is best-effort; the durable per-conversation log is the source of truth; clients re-read on reconnect. | The message is already durable in Cassandra here. The fix belongs in *reconciliation*, not in making the live event perfect. |
+
+Not one of these systems solves this with a compound "create + send" endpoint. Slack and Zulip
+converge on **implicit creation on send**; everyone converges on **subscribe-then-backfill with
+idempotent merge**.
+
+---
+
+## 5. Solution catalogue
+
+### S1 — Client waits for the phase-2 async job result before sending
+
+* **Fixes:** R1 only.
+* **Pros:** zero server change; it is already the documented contract and what the reference client does.
+* **Cons:** adds the full create latency to the first send; nothing else improves.
+* **Verdict:** mandatory baseline, not a solution on its own.
+
+### S2 — Combined `create room + send message` RPC (the proposal)
+
+Server creates the room, writes the message, emits one combined fan-out.
+
+* **Fixes:** R1 completely (the room provably exists before the message is accepted).
+  R3 **only if** the combined event carries the message and lands on a subject B already holds.
+  R2: **not at all**.
+* **Pros:**
+  * One round trip; best possible latency for "start a conversation" — the single most latency-visible
+    action in the product.
+  * Creates a **server-side ordering point**: subscription-added can be published *after* the message
+    exists, so the event can carry `room.lastMsgId` / `previewMessage` — B renders the DM with its
+    first message from a single event.
+  * Matches Slack/Zulip product semantics.
+  * Message IDs are client-supplied 20-char base62, so a retry is naturally idempotent.
+* **Cons:**
+  * **Only fixes the first message.** A second message 50 ms later hits the identical R2/R3 window in a
+    channel. The race is not about *the first* message; it is about *any* message that arrives before
+    the recipient is listening.
+  * If it re-implements create and send, it duplicates: validation, attachments/quote/thread
+    resolution, mention extraction, large-room gating, encryption, DEK provisioning, sys-messages,
+    federation. Two code paths that must not drift — exactly the failure mode CLAUDE.md's
+    "define interfaces in the consumer" discipline exists to avoid.
+  * If instead it publishes into MESSAGES, the send is async again and the "single atomic fan-out" is
+    gone (which is fine — see the recommendation).
+  * Combinatorial API growth: create-channel+message, add-member+message, …
+  * A synchronous RPC now covers Vault (DEK), Mongo writes, fan-out and federation — the reply timeout
+    budget has to cover the slowest of those, and partial failure ("room created, message rejected")
+    needs an explicit reply shape.
+
+### S3 — Fat `subscription.update{added}` event (embed the first message)
+
+`SubscriptionRoom` **already has** `LastMsgID`, `LastMsgAt` and `PreviewMessage`; they are simply not
+populated at create time (there is no message yet). Combined with S2's ordering point they can be.
+
+* **Fixes:** R3 for the first message.
+* **Pros:** tiny delta; no new subjects; no new RPC; helps every client immediately.
+* **Cons:** covers only what is known at publish time. Not a general fix.
+
+### S4 — Client: subscribe-then-backfill, dedupe by message ID (the Zulip pattern)
+
+On `subscription.update{added}` — and on every room entry: (1) open the room subscription first,
+(2) buffer incoming events, (3) `loadHistory` since `joinedAt`/`historySharedSince`, (4) merge and
+dedupe by message ID.
+
+* **Fixes:** R2 and R3, generally — plus everything lost to disconnects.
+* **Pros:** the industry-standard answer; no API surface change; self-healing; the durable message is
+  already in Cassandra and `history-service` already exposes it.
+* **Cons:** frontend work in every client; one extra history RPC per new room; must be genuinely
+  idempotent (Matrix's warning). Does not by itself close the sub-millisecond interest-propagation
+  gap — the backfill must run *after* the subscribe, which is exactly why the ordering matters.
+
+### S5 — Gap detection from `lastMsgId`
+
+`RoomEvent` already carries `LastMsgID`/`LastMsgAt` (`buildRoomEvent`). Keep a per-room
+`lastKnownMsgId`; when an event's `lastMsgId` doesn't chain, backfill. Re-reconcile on reconnect.
+
+* **Fixes:** all three, after the fact (self-healing rather than preventive).
+* **Pros:** cheap; makes every loss cause recoverable, not just this one; Discord's model.
+* **Cons:** eventually-consistent — the user may see the message a beat late; needs a per-room cursor.
+
+### S6 — Durable per-user delivery (JetStream consumer per client)
+
+* **Fixes:** everything, including offline delivery.
+* **Cons:** a consumer per connected user does not scale the way core-NATS fan-out does; ack/state
+  management; replaces the deliberate core-NATS FE design. Long-term option, not this fix.
+
+### S7 — Route channel events per-user (or: a **join grace window**)
+
+Full version: deliver channel events on `chat.user.{X}.event.room` like DMs, so no per-room
+subscription ever exists. Fixes R2 by deleting it — but moves fan-out cost from NATS into
+`broadcast-worker` (N publishes per message), against the direction of the current
+`chat.local.room.>` traffic-reduction work.
+
+**Narrow version — recommended:** publish the channel room event **additionally** to
+`chat.user.{X}.event.room` for members whose `joinedAt` is within a grace window (e.g. 30 s).
+
+* **Fixes:** R2, precisely, for exactly the members who can be affected by it.
+* **Pros:** steady-state fan-out cost unchanged; there is already a grace-window precedent in
+  `pkg/subject` (`roomLocalityGrace` dual-publishes during the local/global flip so
+  not-yet-resubscribed clients keep receiving) — this is the same idea applied to the join transition.
+  Clients dedupe by message ID, which S4/S5 require anyway.
+* **Cons:** duplicate delivery during the window (harmless once dedupe exists); needs `joinedAt` in the
+  fan-out path (`ListSubscriptions` already returns subscriptions; room-meta cache may need the field).
+
+### S8 — Implicit DM creation on send (Zulip/Slack semantics)
+
+Client sends to the deterministic DM room ID; `message-gatekeeper`, on `errNotSubscribed` for a
+well-formed DM room ID that includes the sender, calls the **existing synchronous**
+`chat.server.request.room.{site}.create.dm` RPC (`room-worker.serverCreateDM`, already implemented and
+already used by `user-service/roomclient`), then proceeds.
+
+* **Fixes:** R1; deletes the "create" step from the client flow entirely.
+* **Pros:** no new client API; reuses one create implementation and the whole existing send pipeline;
+  matches Slack/Zulip.
+* **Cons:** the client must compute the DM room ID, which is `sortedConcat(userA.ID, userB.ID)` — that
+  leaks an ID-construction rule into clients (and `docs/client-api.md` currently describes it as a
+  concat of *accounts*, which does not match `idgen.BuildDMRoomID`; that doc drift needs fixing either
+  way). Also puts a synchronous room-create in the gatekeeper hot path — needs a guard so it can only
+  fire for DM-shaped IDs.
+
+---
+
+## 6. Verdict on the proposed combined RPC
+
+**It is a good idea for the sender's problem and a decent idea for the product, but it is not the fix
+for the recipient's problem.** Specifically:
+
+* ✅ It removes R1 by construction — the strongest argument for it.
+* ✅ It creates the ordering point that lets `subscription.update{added}` carry the first message (S3),
+  which closes R3 for the common case.
+* ❌ It does nothing for R2. For a channel, B still has to subscribe to `chat.room.{id}.event` *after*
+  processing the combined event, and NATS provides no way to know when that subscription is live
+  ([nats-server#1142](https://github.com/nats-io/nats-server/issues/1142)).
+* ❌ It fixes exactly one message. The same race recurs on message #2, and on *every* add-member +
+  immediate-post in a channel.
+
+If you build it, build it as a **thin orchestrator, not a second implementation**:
+
+1. Call the existing synchronous `RoomCreateDMSync` (`room-worker.serverCreateDM`) — it already does
+   deterministic ID, idempotent insert, dup-key reconcile, DEK provisioning, subscription pair
+   creation, `subscription.update` fan-out, and cross-site inbox.
+2. Then publish the client's message to MESSAGES exactly as `msg.send` would, so it flows through
+   `message-gatekeeper` → MESSAGES-CANONICAL → `broadcast-worker` unchanged.
+3. Reply with `{roomId, subscription, messageAccepted}` — and define the partial-failure shape
+   explicitly (room created + message rejected must not read as total failure).
+
+That gets one round trip and zero duplicated logic. It does **not** get a single combined fan-out
+event — and it shouldn't try to: the message must go through the canonical pipeline so that
+`message-worker` (Cassandra), `notification-worker`, and `search-sync-worker` all see it.
+
+---
+
+## 7. Recommended plan
+
+**Phase 0 — confirm which race you actually have (do this first).**
+For a DM, `broadcast-worker` delivers on `chat.user.{B}.event.room`, which B holds from login. So
+either the desktop client subscribes per-room for DMs (unlike the reference frontend), or it is
+dropping a `new_message` for an unknown room (R3), or it is sending on the sync `accepted` reply (R1).
+These have different fixes; picking one blind risks building the wrong thing. Add a client-side counter
+for "room event received for unknown room" and a `message-gatekeeper` metric for `errNotSubscribed`
+rejections within N seconds of a room create.
+
+**Phase 1 — cheap, no new API.**
+* Client: send only after the **phase-2 async job result** (fixes R1).
+* Client: accept `new_message` for an unknown room — synthesize the room and refetch the subscription
+  (fixes R3, matching the reference frontend's reducer).
+* Client: on `subscription.update{added}` for a channel, **open the room subscription before** applying
+  state, then backfill (S4 ordering).
+
+**Phase 2 — the actual R2 fix.**
+* `broadcast-worker`: join grace window (S7 narrow) — dual-publish channel events to
+  `chat.user.{X}.event.room` for members with `joinedAt` inside the window.
+* Client: dedupe by message ID (required by the dual publish; also required by Phase 3).
+
+**Phase 3 — make it self-healing.**
+* Client: gap detection on `lastMsgId` (S5) + full reconcile on reconnect. This retires the whole bug
+  class, including best-effort publishes lost while disconnected.
+
+**Phase 4 — optional product/latency work.**
+* The combined DM RPC as a thin orchestrator (S2 + S3), or the implicit-create-on-send variant (S8).
+  Do this for the UX win, once Phases 1–3 mean it is not load-bearing for correctness.
+
+**Explicitly not recommended now:** S6 (per-user JetStream consumers) and full S7 (all channel events
+per-user). Both are large, and Phases 1–3 make them unnecessary.
+
+---
+
+## 8. Things to get right
+
+* **Idempotency.** Message IDs are client-supplied 20-char base62 — dedupe on that everywhere. Matrix
+  makes this explicit for exactly this reason.
+* **Ordering assumptions.** Do not assume `subscription.update` precedes the room event. Different
+  publishers, different subjects, no guarantee. Write the client so either order works.
+* **Federation.** A cross-site B receives the same events via INBOX. The grace window must key off the
+  *subscription's* `joinedAt` at the delivering site, not wall-clock at the origin.
+* **Docs.** Any change to a client-facing subject or to a `pkg/model` client-facing struct requires
+  updating `docs/client-api.md` **and** both derived views in the same PR (CLAUDE.md §5). Note the
+  existing drift: §"ID formats" describes the DM room ID as a concat of *accounts*, but
+  `idgen.BuildDMRoomID` concatenates `user.ID` values.
+* **TDD.** All of the above is new behaviour — tests first (CLAUDE.md §4).
+
+---
+
+## 9. Open questions
+
+1. Does the desktop client subscribe per-room for **DMs**, or only for channels like the reference
+   frontend? This determines whether the reported bug is R2 or R3.
+2. Does the desktop client send the first message on the **sync** `accepted` reply or on the **async
+   job result**? This determines whether R1 is in play.
+3. Is "create channel + immediately post" (not just DM) a real flow in the product? If yes, R2 is
+   in scope and Phase 2 is required, not optional.
+
+---
+
+## References
+
+* [NATS — cannot say when a subscription is registered across the entire cluster (nats-server#1142)](https://github.com/nats-io/nats-server/issues/1142)
+* [NATS — Publish-Subscribe (core NATS is at-most-once)](https://docs.nats.io/nats-concepts/core-nats/pubsub)
+* [NATS — Super-cluster with Gateways](https://docs.nats.io/running-a-nats-service/configuration/gateways)
+* [Zulip — Real-time push and events (queue-before-fetch atomicity, `apply_events`)](https://zulip.readthedocs.io/en/stable/subsystems/events-system.html)
+* [Zulip — Send a message (`type:"direct"`, implicit conversation)](https://zulip.com/api/send-message)
+* [Slack — `conversations.open`](https://docs.slack.dev/reference/methods/conversations.open/)
+* [Slack — `chat.postMessage` (opens the DM if not already open)](https://api.slack.com/methods/chat.postMessage)
+* [Matrix — Client-Server API `/sync`, de-duplicate by event ID](https://spec.matrix.org/latest/client-server-api/)
+* [Discord — Gateway sequence numbers and `RESUME`](https://docs.discord.com/developers/events/gateway)

--- a/docs/design/2026-08-22-new-room-first-message-race.md
+++ b/docs/design/2026-08-22-new-room-first-message-race.md
@@ -324,10 +324,18 @@ reconnects, and everything outside the join window. But step 4 is the one that m
 go away rather than shrink, and it remains strictly dependent on step 1: a client that discards
 a room event for an unknown room discards the grace copy too (measured: 100% still lost).
 
-The shipped prototype does the roster lookup on every channel message while `JOIN_GRACE > 0`.
-Before enabling it on a busy site, gate the lookup on a cached `LastJoinAt` in
-`roommetacache.Meta` (which already carries `CrossSiteAt` for an analogous grace window) so a
-room with no recent join pays only a nil check.
+**The window costs nothing per message.** A channel message must stay one publish to the room
+subject — that is the whole reason the room subject exists — so the fan-out does **not** query
+the roster. `room-worker` publishes a join notice to `chat.server.joingrace.{siteID}` (core
+NATS, *not* queue-subscribed: every `broadcast-worker` replica needs it), each replica holds
+the joiners in memory for the window, and the message path does one map lookup that misses in
+the steady state. No Mongo read, no Valkey read, no extra round trip.
+
+Two alternatives were rejected. A roster query per message is what the room subject exists to
+avoid. Gating that query on a `LastJoinAt` in `roommetacache.Meta` looks cheaper but is
+unreliable: the L1 meta cache is per-replica with its own TTL (`ROOM_META_CACHE_TTL`, 2 m) and
+`bustRoomMeta` clears only L2, so a member added to an *active* channel — where the entry is
+warm — would not be seen until the window had already passed.
 
 Do **not** start with step 4 alone: measured, it fixes nothing.
 

--- a/docs/design/2026-08-22-new-room-first-message-race.md
+++ b/docs/design/2026-08-22-new-room-first-message-race.md
@@ -170,7 +170,21 @@ Three things the measurements settle:
 Running the real services changed the picture in two ways. Full numbers in
 `tools/roomrace/RESULTS-e2e.md`.
 
-**The creator learns about her own room ~500 ms after everyone else.**
+**Correction — the 500 ms creator gap was a harness artifact, not production.**
+Earlier runs showed the creator's async job result arriving ~500 ms after the system messages.
+That was caused by the minimal test stack omitting `inbox-worker`: `finishCreateRoom`
+JetStream-publishes to `chat.inbox.{siteID}.internal.member_added`, the INBOX stream did not
+exist, and the publish blocked until its PubAck timed out (`nats: no response from stream`),
+delaying the deferred `publishAsyncJobResult`. With `inbox-worker` running the async result
+lands at **23–25 ms**. In production INBOX exists, so the real gap is tens of milliseconds.
+
+This makes the client's job **harder**, not easier: the whole first exchange — subscription
+events, both system messages, and the first user message — now happens inside ~30 ms, so a
+client that takes even 12 ms to subscribe misses most or all of it live (measured: the invited
+member missed 97–100% of live events at a 12–30 ms delay). The history read carries the load,
+which makes its freshness the whole ballgame.
+
+**The original ordering point still stands.**
 `room-worker.finishCreateRoom` publishes `subscription.update` to every member,
 *then* the `room_created` / `members_added` system messages, *then* the deferred
 `publishAsyncJobResult`. Measured: members get `subscription.update` at 23 ms, the
@@ -312,7 +326,7 @@ For reference, neither Slack nor Zulip built a compound endpoint: both made DM c
 | # | Change | Side | Fixes | Evidence |
 |---|---|---|---|---|
 | 1 | `new_message` upserts the room from the event payload instead of dropping it | client | **Problem 1, completely** | `dm / client buffers unknown room`: 0% at every delay |
-| 1b | Subscribe to the room subject on the client's **own** `subscription.update`, not on the create job result or on room-open | client | the creator missing her own room's system messages | E2E: subscribed at 24 ms vs system messages at 29 ms; the job result lands at 529 ms |
+| 1b | Subscribe to the room subject on the client's **own** `subscription.update`, not on the create job result or on room-open | client | the creator missing her own room's system messages | E2E: the whole first exchange completes inside ~30 ms, so this is the only moment early enough to catch any of it |
 | 2 | On channel join: subscribe → flush → `msg.history` **with `meta.lastMsgAt`** → merge by message id | client | **Problem 2**, recovered | `channel / … + backfill`: 0% at every delay; E2E: 3 of 3 on the first try |
 | 3 | Gap detection on `lastMsgId` + reconcile on reconnect | client | the `message-worker`/`broadcast-worker` write race, and every event lost to a disconnect | see §4 caveat |
 | 4 | Join grace window: dual-publish to the per-user subject for members joined < N s ago (`JOIN_GRACE`, default off) | server | **Problem 2**, delivered live — and the only fix that survives a lagging `message-worker` | 0% live loss at client delays 0 ms–1 s; 0% lost with `message-worker` stalled |

--- a/docs/design/2026-08-22-new-room-first-message-race.md
+++ b/docs/design/2026-08-22-new-room-first-message-race.md
@@ -1,393 +1,294 @@
-# New-room → first-message race: analysis and recommendation
+# New-room → first-message race: analysis, measurements, recommendation
 
-**Status:** analysis / recommendation (no code changed)
+**Status:** analysis + reproduction (no production code changed)
 **Date:** 2026-08-22
-**Scope:** `room-service`, `room-worker`, `message-gatekeeper`, `broadcast-worker`, client event contract
+**Repro:** `./tools/roomrace/run.sh` (real NATS in Docker, production subjects from `pkg/subject`)
+**Scope:** `room-worker`, `broadcast-worker`, `message-gatekeeper`, client event contract
 
 ---
 
-## 1. TL;DR
+## 1. Answer up front
 
-The reported symptom ("B gets the subscription event but misses `new_message`") is not one race —
-it is **three independent races** stacked on the same transition, and they have different fixes:
+**Can the current architecture solve these two problems? Yes — both. Neither needs a new RPC.**
 
-| # | Race | Who loses | Applies to |
-|---|------|-----------|-----------|
-| **R1** | A sends before `room-worker` materialized the subscription → `message-gatekeeper` rejects with *not subscribed* | the **sender** | DM + channel |
-| **R2** | B has not yet issued `SUB chat.room.{id}.event` (and NATS has not yet propagated that interest) when `broadcast-worker` publishes | the **recipient** | **channel only** |
-| **R3** | B receives `new_message` on a subject it *is* subscribed to, but its local store has no room yet, so the client drops/misfiles the event | the **recipient** | DM + channel |
+| | Where the message is lost | Fixable with today's architecture? |
+|---|---|---|
+| **Problem 1 — DM** | NATS delivers it to client B; **B's client discards it** because the room isn't in local state yet | **Yes, client-only.** No backend change. |
+| **Problem 2 — channel** | NATS drops it: nobody is subscribed to `chat.room.{id}.event` yet | **Yes, client-only** via subscribe → backfill over the existing `msg.history` RPC. A small server change upgrades that from *recovered* to *delivered live*. |
 
-A combined "create room + send message" RPC — the proposed idea — **fully closes R1**, and closes
-R3 *if and only if* the combined event carries the message payload on a subject the recipient is
-already subscribed to. **It does not close R2 at all**, and R2 is the only one of the three that is
-structurally unfixable on the client side alone.
+The measured, decisive fact:
 
-**Recommendation (layered, in priority order):**
-
-1. **Client contract fix (today, no server change):** the client must wait for the *phase-2* async
-   job result before sending, and must tolerate a `new_message` for a room it does not know yet.
-2. **Server, small:** on the `subscription.update{action:"added"}` event, populate the already-existing
-   `subscription.room.lastMsgId` / `previewMessage` fields so the recipient can render and detect a gap.
-3. **Server, targeted — the actual R2 fix:** a **join grace window** in `broadcast-worker` — additionally
-   publish a channel's room event to `chat.user.{account}.event.room` for members whose `joinedAt` is
-   within N seconds. This mirrors the `roomLocalityGrace` pattern already in `pkg/subject`.
-4. **Client, structural:** subscribe-then-backfill on every room entry, dedupe by message ID
-   (the Zulip guarantee, adapted). This also fixes the strictly larger bug class: events lost while
-   the client was disconnected.
-5. **Optional, and only for DMs:** the proposed combined RPC — but built as a *thin orchestrator over
-   the existing synchronous DM-create RPC*, not as a second implementation of create + send.
+> **The race window is dominated by the client, not by NATS.**
+> With an instant client, the channel window is under 1 ms. With a realistic 30 ms
+> render-then-subscribe, it is 30 ms — a 30–1000× larger target. Making the client
+> subscribe faster narrows the window; only a backfill or a per-user delivery path closes it.
 
 ---
 
-## 2. What the code does today
+## 2. Reproduction
 
-### 2.1 Create
+`tools/roomrace` drives a real NATS server using the production subject builders, so the
+topology under test is the one the services publish on:
 
-`chat.user.{A}.request.room.{siteID}.room.create` → `room-service` `Handler.createRoom`
-(`room-service/handler.go`):
+| Actor | Modelled as |
+|---|---|
+| `room-worker` | publish `subscription.update{added}` → `chat.user.{B}.event.subscription.update` |
+| `broadcast-worker` | DM → `chat.user.{B}.event.room` (per member); channel → `chat.room.{id}.event` |
+| `message-worker` | persists the message before fan-out (so a backfill can find it) |
+| `history-service` | request/reply stub on the real `…msg.history` subject |
+| desktop client B | login-time subs to its own user subjects; per-room sub opened only when it handles `subscription.update`, after a render delay |
 
-1. `classifyAndValidate` → `RoomTypeDM` (empty name, one counterpart).
-2. `handleCreateRoomDMOrBotDM` → `idgen.BuildDMRoomID(requester.ID, other.ID)` (deterministic),
-   `FindDMSubscription` dedup (returns `status:"exists"` when the DM already exists).
-3. `publishCreateRoom` → `EnsureDEK`, then JetStream publish to `chat.room.canonical.{site}.create`.
-4. Replies **`{status:"accepted", roomId, roomType}`** — this is only an *acknowledgement of handoff*.
-   No room document and no subscription exists yet at this point.
+The DM/channel split is not an assumption — it is what `broadcast-worker` does
+(`publishDMEvents` vs `publishChannelEvent`) and what its own tests already assert
+(`subject.UserRoomEvent("alice")` vs `subject.RoomEvent("room-1", true)` in
+`broadcast-worker/handler_test.go`). Those tests were re-run and pass.
 
-`room-worker` `processCreateRoom` then does the real work asynchronously:
-room insert → `BulkCreateSubscriptions` → `finishCreateRoom` → `publishSubscriptionAdded`
-(core publish, per member, to `chat.user.{X}.event.subscription.update`) → federation →
-**`defer publishAsyncJobResult`** to `chat.user.{A}.response.{requestID}` (phase 2).
+### 2.1 Realistic client (30 ms to render + subscribe)
 
-So the ordering guarantee that *does* exist server-side is:
-`subscriptions written` → `subscription.update` published to B → `async job result` published to A.
+Cell = % of first messages user B never saw. Columns = delay between `subscription.update`
+and the first message. 40 iterations per cell.
 
-### 2.2 Send
+**Single NATS server**
 
-`chat.user.{A}.room.{roomID}.{siteID}.msg.send` → MESSAGES stream → `message-gatekeeper.processMessage`,
-which validates and then:
+| scenario | +0ms | +10ms | +20ms | +25ms | +28ms | +30ms | +32ms | +35ms |
+|---|---|---|---|---|---|---|---|---|
+| dm / client drops unknown room | 100% | 100% | 100% | 100% | 98% | 0% | 0% | 0% |
+| dm / client buffers unknown room | 0% | 0% | 0% | 0% | 0% | 0% | 0% | 0% |
+| channel / subscribe on update | 100% | 100% | 100% | 100% | 100% | 70% | 0% | 0% |
+| channel / subscribe + flush | 100% | 100% | 100% | 100% | 100% | 60% | 0% | 0% |
+| channel / subscribe + flush + backfill | 0% | 0% | 0% | 0% | 0% | 0% | 0% | 0% |
+| channel / server join grace window | 0% | 0% | 0% | 0% | 0% | 0% | 0% | 0% |
+| channel / grace window, client still drops | 100% | 100% | 100% | 100% | 92% | 12% | 0% | 0% |
 
-```go
-sub, err := h.store.GetSubscription(ctx, account, roomID)
-if errors.Is(err, errNotSubscribed) { return nil, err }   // → rejected
+**3-node cluster (B on node a, services on node b)** — same shape, wider:
+`channel / subscribe on update` stays at 100% through +28ms and is still 98% at +30ms.
+
+### 2.2 Instant client (render delay 0) — isolating the transport
+
+| scenario | +0ms | +1ms | +2ms | +3ms | +5ms |
+|---|---|---|---|---|---|
+| channel / subscribe on update — single server | 78% | 0% | 0% | 0% | 0% |
+| channel / subscribe on update — 3-node cluster | 98% | 0% | 0% | 0% | 0% |
+| dm (any client behaviour) — both topologies | 0% | 0% | 0% | 0% | 0% |
+
+Subscription interest window (`Subscribe()` returns → a publisher actually reaches it),
+measured with ~0.5 ms probe granularity, so read these as upper bounds:
+
+| topology | median | p95 | max | `Flush()` RTT |
+|---|---|---|---|---|
+| single server | 40–67 µs | ~1.5 ms | 1.6 ms | ~290 µs |
+| 3-node cluster (publisher on another node) | ~1.44 ms | ~1.8 ms | 5.0 ms | ~250 µs |
+
+Gateways (their real supercluster) were **not** measured; route propagation across a
+gateway is slower than an intra-cluster route, so treat the cluster column as a floor.
+
+---
+
+## 3. Problem 1 — DM
+
+### What actually happens
+
+```
+room-worker  ──► chat.user.B.event.subscription.update      (B is subscribed from login)
+             ──► async job result ──► A ──► msg.send ──► gatekeeper ──► CANONICAL
+broadcast-worker ──► chat.user.B.event.room                 (B is subscribed from login)
 ```
 
-→ MESSAGES-CANONICAL → `broadcast-worker`.
+`broadcast-worker.publishDMEvents` fans a DM out **per member on the user subject**. B holds
+that subject from login and never opens a per-room subscription for a DM — the reference
+frontend's own test asserts this (`expect(subjects).not.toContain('chat.room.d1.event')`).
 
-### 2.3 Fan-out (the decisive detail)
+So the `new_message` event **is delivered to B's connection**. Your own description says as
+much — *"new_message event is already arrived"*. What follows is a client decision: the
+handler runs, finds no room in local state, and discards the event.
 
-`broadcast-worker/handler.go` has **two different delivery shapes**:
+The harness isolates exactly this. Same transport, same timing, two client behaviours:
 
-| Room type | Function | Subject |
-|---|---|---|
-| DM / botDM | `publishDMEvents` | **`chat.user.{account}.event.room`** — one publish per member |
-| channel | `publishChannelEvent` → `publishRoomEvent` | **`chat.room.{roomID}.event`** (or `chat.local.room.…`) |
+* `dm / client drops unknown room` → **100% lost** whenever the message beats the render.
+* `dm / client buffers unknown room` → **0% lost, at every delay, on both topologies.**
 
-And the reference client (`chat-frontend/src/context/RoomEventsContext/useRoomSubscriptions.js`):
+### Fix — client only, no backend change
 
-* subscribes **once at login** to `chat.user.{me}.event.room`, `…event.subscription.update`,
-  `…event.room.metadata.update`, `…event.room.key`;
-* subscribes **lazily, per room** to `chat.room.{id}.event` — and only for channels:
-  `if (sub.roomType === 'channel') openChannelSub(sub.roomId, room.crossSite)`, driven by the
-  `subscription.update{added}` event. Its own test asserts
-  `expect(subjects).not.toContain('chat.room.d1.event')` for a DM.
+Make the `new_message` handler **upsert the room from the event payload** instead of
+requiring it to pre-exist. `model.RoomEvent` already carries everything a sidebar row and a
+first bubble need: `roomId`, `roomName`, `roomType`, `siteId`, `userCount`, `lastMsgAt`,
+`lastMsgId`, and the full `message`. When `subscription.update` lands (before or after), it
+reconciles the row with the authoritative subscription record.
 
-**Consequence:** for a *DM*, B's client is already listening on the delivery subject before the room
-even exists. There is no transport-level race for DMs. Which means the reported DM symptom is
-**R1 and/or R3, not R2** — unless the desktop client (unlike the reference frontend) subscribes
-per-room for DMs too. This is worth confirming before building anything.
+Upsert beats "buffer and replay" because it also survives the case where
+`subscription.update` is **lost outright** — `room-worker.publishSubscriptionUpdate` is a
+best-effort core publish that logs and continues, so a B that is mid-reconnect never sees it.
 
----
-
-## 3. The three races in detail
-
-### R1 — sender-side: "room not ready"
-
-A gets `{status:"accepted"}` and sends immediately. `room-worker` has not yet written the
-subscription, so `GetSubscription` returns `errNotSubscribed` and the message is **rejected outright**
-(it never reaches MESSAGES-CANONICAL — it is not merely delayed).
-
-Window: one JetStream hop + `GetUser` + room insert + `BulkCreateSubscriptions` + reconcile — typically
-tens of ms, but unbounded under load or Mongo pressure.
-
-The contract already provides the fix: `createRoom` is a **two-phase async job**
-(`requestWithAsyncResult` in `chat-frontend/src/api/createRoom/index.ts`). A client that sends on the
-*sync* reply instead of the *async job result* has this bug by construction.
-
-### R2 — transport-side: "no interest yet" (channels only)
-
-B learns about the room, then calls `nc.subscribe("chat.room.{id}.event")`. That subscription must
-reach B's NATS server and be gossiped to every other server (and across gateways, for cross-site).
-Core NATS is **at-most-once with no replay**: anything published into that window is gone from the
-live path permanently.
-
-NATS gives you **no signal for this**. From
-[nats-server#1142](https://github.com/nats-io/nats-server/issues/1142): *"there is no guarantee that
-in the moment when the 'server' is publishing the message 'data.xyz', the subscription (RS+) from
-'nats-server-A' has been propagated to 'nats-server-B'"* — and the issue is still open, with no
-"subscription is now live cluster-wide" primitive. `flush()` only confirms *your own* server processed
-the SUB; it says nothing about the rest of the cluster or the gateways.
-
-This is why **no amount of server-side atomicity fixes R2**. Even a perfect single combined
-operation that emits the subscription event and the message event in one breath still publishes the
-message before B has finished subscribing, because B's subscribe *causally follows* the event it is
-reacting to.
-
-### R3 — application-state-side: "unknown room"
-
-`subscription.update` (from `room-worker`) and the room event (from `broadcast-worker`) are published
-by **different processes on different subjects**. There is no ordering guarantee between them —
-neither NATS nor the code provides one. B can legitimately receive `new_message` for a room it has
-never heard of.
-
-The reference frontend survives this: `MESSAGE_RECEIVED` uses
-`state.roomState[roomId] ?? emptyRoomState()` and records a preview regardless. A client that
-requires the room to exist first will silently drop the event.
-
-### The common root cause
-
-> The system delivers live events over an **at-most-once transport whose subscription set is derived
-> from state the client learns over that same at-most-once transport.**
-
-That circularity guarantees a window between *"you are a member"* and *"you are listening"*. Only two
-things remove it: (a) don't require a per-room subscription, or (b) reconcile against the durable log
-after subscribing. Everything else just narrows the window.
-
-Worth noting the same reasoning covers a strictly larger bug: `publishSubscriptionUpdate` and
-`publishDMEvents` are **best-effort core publishes** (both log-and-continue on error). If B is
-mid-reconnect, the events are lost with no race involved at all. Whatever you build should fix that
-too, or you will be back here.
+One caveat: cross-site. `subscription.update` is published on the origin site and routed to
+B's home site over the supercluster (`inbox-worker.handleMemberAdded` deliberately does not
+re-publish it). Both events then cross a gateway on different subjects with no ordering
+guarantee between them, so the arrival order can genuinely invert. The upsert fix handles
+that too; a buffer-and-replay fix keyed on "subscription first" does not.
 
 ---
 
-## 4. How comparable systems solve this
+## 4. Problem 2 — channel
 
-| System | Mechanism | Takeaway |
-|---|---|---|
-| **Zulip** | `POST /register` creates the event queue **before** the initial state is fetched; events that arrive during the fetch are replayed onto the fetched state via `apply_events`. Documented goal: the client sees *either* old state + event, *or* new state + no event — never a mix. ([events-system](https://zulip.readthedocs.io/en/stable/subsystems/events-system.html)) | **Subscribe first, fetch second, merge.** Solve it once on the server side of the contract, not in N clients. |
-| **Zulip (DMs)** | There is no "create DM" call at all: `POST /messages` with `type:"direct"`, `to:[user_ids]` — the conversation is implicit. ([send-message](https://zulip.com/api/send-message)) | If DM identity is deterministic, "create" is a redundant step you can delete. |
-| **Slack** | `conversations.open` exists, but `chat.postMessage` with a user ID as `channel` **opens the DM if it isn't open already**. ([conversations.open](https://docs.slack.dev/reference/methods/conversations.open/), [chat.postMessage](https://api.slack.com/methods/chat.postMessage)) | Same conclusion, from the biggest product in the category. |
-| **Matrix** | `/sync` with a `since` token; clients are told to **de-duplicate by event ID** because ordering across APIs can produce duplicates. ([spec](https://spec.matrix.org/latest/client-server-api/)) | Idempotent merge by ID is the price of admission for any backfill design. |
-| **Discord** | Every gateway event carries a sequence `s`; `RESUME` replays from the last `s`. Replay is **bounded** — overflow → `INVALID_SESSION` → full re-fetch. ([gateway](https://docs.discord.com/developers/events/gateway)) | Gap detection + bounded replay + full-resync fallback. |
-| **General chat architecture** | The live pub/sub path is best-effort; the durable per-conversation log is the source of truth; clients re-read on reconnect. | The message is already durable in Cassandra here. The fix belongs in *reconciliation*, not in making the live event perfect. |
+Your description matches the code exactly, and the harness confirms it is real — and worse
+than intuition suggests.
 
-Not one of these systems solves this with a compound "create + send" endpoint. Slack and Zulip
-converge on **implicit creation on send**; everyone converges on **subscribe-then-backfill with
-idempotent merge**.
+`broadcast-worker.publishChannelEvent` publishes **once** to `chat.room.{id}.event`. B only
+subscribes to that subject inside its `subscription.update` handler. Everything published
+before that subscription is live is gone: core NATS is at-most-once with no replay.
 
----
+Three things the measurements settle:
 
-## 5. Solution catalogue
+1. **It is not a narrow window.** With a 30 ms render-then-subscribe, every message sent
+   within ~30 ms of the subscription event is lost — 100%, not "occasionally".
+2. **`Flush()` does not fix it.** 100% → 100% at short delays; it only helps in the
+   coin-flip millisecond at the boundary (70% → 60%). `Flush()` confirms your *own* server
+   processed the SUB; it says nothing about the publisher's server. On the cluster it
+   barely moves (98% → 95%).
+3. **Even an instantaneous client loses.** Render delay 0, message at +0 ms: 78% lost on one
+   server, 98% on a cluster. There is no client-side "subscribe faster" that reaches 0%.
+   NATS exposes no cluster-wide "interest is live" signal — [nats-server#1142](https://github.com/nats-io/nats-server/issues/1142)
+   is still open on exactly this.
 
-### S1 — Client waits for the phase-2 async job result before sending
+### Fix A — client backfill (works today, zero backend change)
 
-* **Fixes:** R1 only.
-* **Pros:** zero server change; it is already the documented contract and what the reference client does.
-* **Cons:** adds the full create latency to the first send; nothing else improves.
-* **Verdict:** mandatory baseline, not a solution on its own.
+On `subscription.update{added}` for a channel: **subscribe first, then read the durable log,
+then merge by message ID.**
 
-### S2 — Combined `create room + send message` RPC (the proposal)
+```
+open chat.room.{id}.event  →  Flush()  →  msg.history{limit:N}  →  merge, dedupe by messageId
+```
 
-Server creates the room, writes the message, emits one combined fan-out.
+`msg.history` already exists —
+`chat.user.{account}.request.room.{roomID}.{siteID}.msg.history`, documented in
+`docs/client-api.md`. Harness result: **0% lost at every delay on both topologies** (215 and
+241 messages recovered that the live path had dropped).
 
-* **Fixes:** R1 completely (the room provably exists before the message is accepted).
-  R3 **only if** the combined event carries the message and lands on a subject B already holds.
-  R2: **not at all**.
-* **Pros:**
-  * One round trip; best possible latency for "start a conversation" — the single most latency-visible
-    action in the product.
-  * Creates a **server-side ordering point**: subscription-added can be published *after* the message
-    exists, so the event can carry `room.lastMsgId` / `previewMessage` — B renders the DM with its
-    first message from a single event.
-  * Matches Slack/Zulip product semantics.
-  * Message IDs are client-supplied 20-char base62, so a retry is naturally idempotent.
-* **Cons:**
-  * **Only fixes the first message.** A second message 50 ms later hits the identical R2/R3 window in a
-    channel. The race is not about *the first* message; it is about *any* message that arrives before
-    the recipient is listening.
-  * If it re-implements create and send, it duplicates: validation, attachments/quote/thread
-    resolution, mention extraction, large-room gating, encryption, DEK provisioning, sys-messages,
-    federation. Two code paths that must not drift — exactly the failure mode CLAUDE.md's
-    "define interfaces in the consumer" discipline exists to avoid.
-  * If instead it publishes into MESSAGES, the send is async again and the "single atomic fan-out" is
-    gone (which is fine — see the recommendation).
-  * Combinatorial API growth: create-channel+message, add-member+message, …
-  * A synchronous RPC now covers Vault (DEK), Mongo writes, fan-out and federation — the reply timeout
-    budget has to cover the slowest of those, and partial failure ("room created, message rejected")
-    needs an explicit reply shape.
+The ordering is the whole point, and it is Zulip's documented guarantee applied per room:
+register the listener before reading state, so anything that arrives during the read is
+still delivered. Backfill-then-subscribe re-opens the window.
 
-### S3 — Fat `subscription.update{added}` event (embed the first message)
+**One caveat the harness is optimistic about.** It persists before fanning out. In
+production `message-worker` and `broadcast-worker` are **separate durable consumers of
+MESSAGES-CANONICAL** and run concurrently, so a backfill issued milliseconds after the
+fan-out can read Cassandra *before* the write lands. Backfill therefore needs a companion:
+gap detection on `lastMsgId` (already on every `RoomEvent` and on `SubscriptionRoom`) — if
+the id doesn't chain onto what the client holds, re-fetch. Without it, a backfill can come
+back one message short and stay short.
 
-`SubscriptionRoom` **already has** `LastMsgID`, `LastMsgAt` and `PreviewMessage`; they are simply not
-populated at create time (there is no message yet). Combined with S2's ordering point they can be.
+### Fix B — server join grace window (small change, delivers live)
 
-* **Fixes:** R3 for the first message.
-* **Pros:** tiny delta; no new subjects; no new RPC; helps every client immediately.
-* **Cons:** covers only what is known at publish time. Not a general fix.
+Have `broadcast-worker` **also** publish a channel's room event to
+`chat.user.{X}.event.room` for members whose `joinedAt` is inside a grace window (say 30 s).
+Harness result: **0% lost at every delay on both topologies** — and delivered *live*, with
+no backfill round trip and no empty-room flicker.
 
-### S4 — Client: subscribe-then-backfill, dedupe by message ID (the Zulip pattern)
+Cost is the obvious objection, and it is answerable. The channel path today does exactly one
+publish and never lists subscriptions — that is the point of the room subject. Listing
+subscriptions per message would be a real regression for large rooms. Avoid it by gating on
+room metadata:
 
-On `subscription.update{added}` — and on every room entry: (1) open the room subscription first,
-(2) buffer incoming events, (3) `loadHistory` since `joinedAt`/`historySharedSince`, (4) merge and
-dedupe by message ID.
+```go
+if meta.LastJoinAt != nil && now.Before(meta.LastJoinAt.Add(joinGrace)) {
+    // only now pay for the subscription lookup
+}
+```
 
-* **Fixes:** R2 and R3, generally — plus everything lost to disconnects.
-* **Pros:** the industry-standard answer; no API surface change; self-healing; the durable message is
-  already in Cassandra and `history-service` already exposes it.
-* **Cons:** frontend work in every client; one extra history RPC per new room; must be genuinely
-  idempotent (Matrix's warning). Does not by itself close the sub-millisecond interest-propagation
-  gap — the backfill must run *after* the subscribe, which is exactly why the ordering matters.
+`roommetacache.Meta` already carries `CrossSiteAt` for a structurally identical grace window
+(`pkg/subject.RoomEventTargets` dual-publishes during the local/global flip so
+not-yet-resubscribed clients keep receiving). Adding `LastJoinAt` follows that precedent
+exactly. Steady state — no recent joins — costs one nil check and nothing else. Only rooms
+with a join in the last N seconds pay for the lookup, and `broadcast-worker.Store` already
+exposes `ListSubscriptions`.
 
-### S5 — Gap detection from `lastMsgId`
+**Fix B requires Fix (Problem 1) first.** The grace-window copy arrives on the per-user
+subject, so a client that still discards unknown rooms discards it too. The harness makes
+this explicit: `channel / grace window, client still drops` = **100% lost**. Server-side
+delivery cannot rescue a client that throws the event away.
 
-`RoomEvent` already carries `LastMsgID`/`LastMsgAt` (`buildRoomEvent`). Keep a per-room
-`lastKnownMsgId`; when an event's `lastMsgId` doesn't chain, backfill. Re-reconcile on reconnect.
-
-* **Fixes:** all three, after the fact (self-healing rather than preventive).
-* **Pros:** cheap; makes every loss cause recoverable, not just this one; Discord's model.
-* **Cons:** eventually-consistent — the user may see the message a beat late; needs a per-room cursor.
-
-### S6 — Durable per-user delivery (JetStream consumer per client)
-
-* **Fixes:** everything, including offline delivery.
-* **Cons:** a consumer per connected user does not scale the way core-NATS fan-out does; ack/state
-  management; replaces the deliberate core-NATS FE design. Long-term option, not this fix.
-
-### S7 — Route channel events per-user (or: a **join grace window**)
-
-Full version: deliver channel events on `chat.user.{X}.event.room` like DMs, so no per-room
-subscription ever exists. Fixes R2 by deleting it — but moves fan-out cost from NATS into
-`broadcast-worker` (N publishes per message), against the direction of the current
-`chat.local.room.>` traffic-reduction work.
-
-**Narrow version — recommended:** publish the channel room event **additionally** to
-`chat.user.{X}.event.room` for members whose `joinedAt` is within a grace window (e.g. 30 s).
-
-* **Fixes:** R2, precisely, for exactly the members who can be affected by it.
-* **Pros:** steady-state fan-out cost unchanged; there is already a grace-window precedent in
-  `pkg/subject` (`roomLocalityGrace` dual-publishes during the local/global flip so
-  not-yet-resubscribed clients keep receiving) — this is the same idea applied to the join transition.
-  Clients dedupe by message ID, which S4/S5 require anyway.
-* **Cons:** duplicate delivery during the window (harmless once dedupe exists); needs `joinedAt` in the
-  fan-out path (`ListSubscriptions` already returns subscriptions; room-meta cache may need the field).
-
-### S8 — Implicit DM creation on send (Zulip/Slack semantics)
-
-Client sends to the deterministic DM room ID; `message-gatekeeper`, on `errNotSubscribed` for a
-well-formed DM room ID that includes the sender, calls the **existing synchronous**
-`chat.server.request.room.{site}.create.dm` RPC (`room-worker.serverCreateDM`, already implemented and
-already used by `user-service/roomclient`), then proceeds.
-
-* **Fixes:** R1; deletes the "create" step from the client flow entirely.
-* **Pros:** no new client API; reuses one create implementation and the whole existing send pipeline;
-  matches Slack/Zulip.
-* **Cons:** the client must compute the DM room ID, which is `sortedConcat(userA.ID, userB.ID)` — that
-  leaks an ID-construction rule into clients (and `docs/client-api.md` currently describes it as a
-  concat of *accounts*, which does not match `idgen.BuildDMRoomID`; that doc drift needs fixing either
-  way). Also puts a synchronous room-create in the gatekeeper hot path — needs a guard so it can only
-  fire for DM-shaped IDs.
+Fix B also produces duplicates by construction (both the room subject and the user subject
+carry the message) — 142 and 300 in the runs above. **Dedupe by message ID is mandatory.**
 
 ---
 
-## 6. Verdict on the proposed combined RPC
+## 5. On the combined create-room + send-message RPC
 
-**It is a good idea for the sender's problem and a decent idea for the product, but it is not the fix
-for the recipient's problem.** Specifically:
+The idea is directionally right, and the measurements show what it is really doing.
 
-* ✅ It removes R1 by construction — the strongest argument for it.
-* ✅ It creates the ordering point that lets `subscription.update{added}` carry the first message (S3),
-  which closes R3 for the common case.
-* ❌ It does nothing for R2. For a channel, B still has to subscribe to `chat.room.{id}.event` *after*
-  processing the combined event, and NATS provides no way to know when that subscription is live
-  ([nats-server#1142](https://github.com/nats-io/nats-server/issues/1142)).
-* ❌ It fixes exactly one message. The same race recurs on message #2, and on *every* add-member +
-  immediate-post in a channel.
+Its value is not "one RPC instead of two". It is that the server gets to put the first
+message on **a subject the recipient already holds** instead of one they have to go
+subscribe to. That is the same mechanism as Fix B — the grace window is simply that idea
+generalised from *the first message* to *every message in the vulnerable window*.
 
-If you build it, build it as a **thin orchestrator, not a second implementation**:
+Which exposes the limitation: the combined RPC covers message #1. Message #2, sent 40 ms
+later, is back to 100% loss (row 3 of the table). Same for every add-member-then-post in an
+existing channel, which the combined RPC does not touch at all.
 
-1. Call the existing synchronous `RoomCreateDMSync` (`room-worker.serverCreateDM`) — it already does
-   deterministic ID, idempotent insert, dup-key reconcile, DEK provisioning, subscription pair
-   creation, `subscription.update` fan-out, and cross-site inbox.
-2. Then publish the client's message to MESSAGES exactly as `msg.send` would, so it flows through
-   `message-gatekeeper` → MESSAGES-CANONICAL → `broadcast-worker` unchanged.
-3. Reply with `{roomId, subscription, messageAccepted}` — and define the partial-failure shape
-   explicitly (room created + message rejected must not read as total failure).
+There is also a construction problem. For the combined event to carry the message, the
+server must build the payload itself rather than let it flow through MESSAGES-CANONICAL. But
+the message has to reach that pipeline anyway — `message-worker` (Cassandra), `notification-worker`,
+`search-sync-worker` all consume it — and `broadcast-worker` will then emit its own
+`new_message`. So you end up with two events regardless, and Problem 2 is untouched.
 
-That gets one round trip and zero duplicated logic. It does **not** get a single combined fan-out
-event — and it shouldn't try to: the message must go through the canonical pipeline so that
-`message-worker` (Cassandra), `notification-worker`, and `search-sync-worker` all see it.
+**Recommendation:** build it if you want the round-trip latency win on "start a
+conversation", and build it as a *thin orchestrator* — call the existing synchronous
+`chat.server.request.room.{site}.create.dm` (`room-worker.serverCreateDM`, already used by
+`user-service/roomclient`), then publish the message into MESSAGES exactly as `msg.send`
+does. Zero duplicated validation. But do not schedule it as the fix for either problem.
 
----
-
-## 7. Recommended plan
-
-**Phase 0 — confirm which race you actually have (do this first).**
-For a DM, `broadcast-worker` delivers on `chat.user.{B}.event.room`, which B holds from login. So
-either the desktop client subscribes per-room for DMs (unlike the reference frontend), or it is
-dropping a `new_message` for an unknown room (R3), or it is sending on the sync `accepted` reply (R1).
-These have different fixes; picking one blind risks building the wrong thing. Add a client-side counter
-for "room event received for unknown room" and a `message-gatekeeper` metric for `errNotSubscribed`
-rejections within N seconds of a room create.
-
-**Phase 1 — cheap, no new API.**
-* Client: send only after the **phase-2 async job result** (fixes R1).
-* Client: accept `new_message` for an unknown room — synthesize the room and refetch the subscription
-  (fixes R3, matching the reference frontend's reducer).
-* Client: on `subscription.update{added}` for a channel, **open the room subscription before** applying
-  state, then backfill (S4 ordering).
-
-**Phase 2 — the actual R2 fix.**
-* `broadcast-worker`: join grace window (S7 narrow) — dual-publish channel events to
-  `chat.user.{X}.event.room` for members with `joinedAt` inside the window.
-* Client: dedupe by message ID (required by the dual publish; also required by Phase 3).
-
-**Phase 3 — make it self-healing.**
-* Client: gap detection on `lastMsgId` (S5) + full reconcile on reconnect. This retires the whole bug
-  class, including best-effort publishes lost while disconnected.
-
-**Phase 4 — optional product/latency work.**
-* The combined DM RPC as a thin orchestrator (S2 + S3), or the implicit-create-on-send variant (S8).
-  Do this for the UX win, once Phases 1–3 mean it is not load-bearing for correctness.
-
-**Explicitly not recommended now:** S6 (per-user JetStream consumers) and full S7 (all channel events
-per-user). Both are large, and Phases 1–3 make them unnecessary.
+For reference, neither Slack nor Zulip built a compound endpoint: both made DM creation
+*implicit on send* ([Slack `chat.postMessage`](https://api.slack.com/methods/chat.postMessage),
+[Zulip `POST /messages type=direct`](https://zulip.com/api/send-message)).
 
 ---
+
+## 6. Recommended plan
+
+| # | Change | Side | Fixes | Evidence |
+|---|---|---|---|---|
+| 1 | `new_message` upserts the room from the event payload instead of dropping it | client | **Problem 1, completely** | `dm / client buffers unknown room`: 0% at every delay |
+| 2 | On channel join: subscribe → flush → `msg.history` → merge by message id | client | **Problem 2**, recovered | `channel / … + backfill`: 0% at every delay |
+| 3 | Gap detection on `lastMsgId` + reconcile on reconnect | client | the `message-worker`/`broadcast-worker` write race, and every event lost to a disconnect | see §4 caveat |
+| 4 | Join grace window: dual-publish to the per-user subject for members joined < N s ago, gated on `Meta.LastJoinAt` | server | **Problem 2**, delivered live | `channel / server join grace window`: 0% at every delay |
+| 5 | *(optional)* combined DM create+send as a thin orchestrator | server | latency/UX only | §5 |
+
+Steps 1–3 need no backend change at all. Step 4 is one cache field plus a gated lookup, and
+is worth doing because it turns Problem 2 from "recovered a beat later" into "never
+happened" — but it is strictly dependent on step 1.
+
+Do **not** start with step 4 alone: measured, it fixes nothing.
+
+## 7. Non-recommendations
+
+* **Per-user JetStream consumers for client delivery.** Solves everything including offline,
+  but a consumer per connected user does not scale the way core-NATS fan-out does, and it
+  replaces a deliberate design.
+* **A short-TTL JetStream replay buffer for room events** (Discord's `RESUME` model). More
+  general than the grace window, but it puts a JetStream write on the message hot path.
+* **Routing all channel events per-user.** Deletes Problem 2 outright, but moves fan-out
+  cost from NATS into `broadcast-worker` for every message in every room — the opposite
+  direction from the current `chat.local.room.>` traffic-reduction work.
+* **"Just subscribe faster / add a Flush."** Measured: 100% → 100%.
 
 ## 8. Things to get right
 
-* **Idempotency.** Message IDs are client-supplied 20-char base62 — dedupe on that everywhere. Matrix
-  makes this explicit for exactly this reason.
-* **Ordering assumptions.** Do not assume `subscription.update` precedes the room event. Different
-  publishers, different subjects, no guarantee. Write the client so either order works.
-* **Federation.** A cross-site B receives the same events via INBOX. The grace window must key off the
-  *subscription's* `joinedAt` at the delivering site, not wall-clock at the origin.
-* **Docs.** Any change to a client-facing subject or to a `pkg/model` client-facing struct requires
-  updating `docs/client-api.md` **and** both derived views in the same PR (CLAUDE.md §5). Note the
-  existing drift: §"ID formats" describes the DM room ID as a concat of *accounts*, but
-  `idgen.BuildDMRoomID` concatenates `user.ID` values.
-* **TDD.** All of the above is new behaviour — tests first (CLAUDE.md §4).
-
----
-
-## 9. Open questions
-
-1. Does the desktop client subscribe per-room for **DMs**, or only for channels like the reference
-   frontend? This determines whether the reported bug is R2 or R3.
-2. Does the desktop client send the first message on the **sync** `accepted` reply or on the **async
-   job result**? This determines whether R1 is in play.
-3. Is "create channel + immediately post" (not just DM) a real flow in the product? If yes, R2 is
-   in scope and Phase 2 is required, not optional.
-
----
+* **Dedupe by message ID everywhere.** Steps 2 and 4 both produce duplicates by design.
+* **Never assume `subscription.update` precedes `new_message`.** Different services,
+  different subjects, no ordering guarantee — and cross-site they cross a gateway
+  independently.
+* **Grace window keys off the local subscription's `joinedAt`**, not origin wall-clock, or
+  federated members get the wrong window.
+* **Docs.** A new `Meta` field is internal, but any client-facing subject or `pkg/model`
+  change requires `docs/client-api.md` plus both derived views in the same PR (CLAUDE.md §5).
+* **Pre-existing doc drift**, unrelated but worth fixing: `docs/client-api.md` §"ID formats"
+  describes the DM room ID as a concat of *accounts*; `idgen.BuildDMRoomID` concatenates
+  `user.ID` values.
 
 ## References
 
-* [NATS — cannot say when a subscription is registered across the entire cluster (nats-server#1142)](https://github.com/nats-io/nats-server/issues/1142)
-* [NATS — Publish-Subscribe (core NATS is at-most-once)](https://docs.nats.io/nats-concepts/core-nats/pubsub)
-* [NATS — Super-cluster with Gateways](https://docs.nats.io/running-a-nats-service/configuration/gateways)
-* [Zulip — Real-time push and events (queue-before-fetch atomicity, `apply_events`)](https://zulip.readthedocs.io/en/stable/subsystems/events-system.html)
-* [Zulip — Send a message (`type:"direct"`, implicit conversation)](https://zulip.com/api/send-message)
-* [Slack — `conversations.open`](https://docs.slack.dev/reference/methods/conversations.open/)
-* [Slack — `chat.postMessage` (opens the DM if not already open)](https://api.slack.com/methods/chat.postMessage)
-* [Matrix — Client-Server API `/sync`, de-duplicate by event ID](https://spec.matrix.org/latest/client-server-api/)
-* [Discord — Gateway sequence numbers and `RESUME`](https://docs.discord.com/developers/events/gateway)
+* [nats-server#1142 — no signal for cluster-wide subscription registration](https://github.com/nats-io/nats-server/issues/1142)
+* [NATS — core NATS is at-most-once](https://docs.nats.io/nats-concepts/core-nats/pubsub)
+* [Zulip — register the event queue before fetching state](https://zulip.readthedocs.io/en/stable/subsystems/events-system.html)
+* [Zulip — send a direct message (implicit conversation)](https://zulip.com/api/send-message)
+* [Slack — `chat.postMessage` opens the DM if needed](https://api.slack.com/methods/chat.postMessage)
+* [Matrix — de-duplicate by event ID](https://spec.matrix.org/latest/client-server-api/)
+* [Discord — gateway sequence numbers and `RESUME`](https://docs.discord.com/developers/events/gateway)

--- a/docs/nats-subject-naming.md
+++ b/docs/nats-subject-naming.md
@@ -218,6 +218,21 @@ Stream wildcard: `chat.server.notification.push.{siteID}.>` (wildcard accommodat
 
 This is a server-only, backend stream. Clients never interact with it.
 
+### Join-grace notice (core NATS, no stream)
+
+| Subject | Publisher | Consumer | Purpose |
+|---------|-----------|----------|---------|
+| `chat.server.joingrace.{siteID}` | room-worker | broadcast-worker | "these accounts just joined this channel" |
+
+Deliberately **outside** `chat.server.broadcast.{siteID}.>`, which broadcast-worker
+queue-subscribes: every replica must see every join notice, not one of them. Each replica
+keeps the joiners in memory for the `JOIN_GRACE` window and, while a member is inside it,
+also delivers that channel's events to their own user subject — the subject the client has
+held since connect, which no join can race. Fire-and-forget: a dropped notice costs that
+replica the window for that join, and the client's history read still covers it.
+
+Server-only. Clients never interact with it.
+
 ### INBOX Stream (`INBOX-{siteID}`)
 
 Cross-site federation events are published **directly** into a site's INBOX —

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -749,3 +749,17 @@ type StatusWithRequestReply struct {
 type RoomRenameRequest struct {
 	NewName string `json:"newName"`
 }
+
+// JoinGraceEvent tells broadcast-worker that Accounts just joined RoomID, so a
+// channel's events can also reach them on their own user subject while they are
+// too new to be relied on to hold the room subject. Core NATS, fan-out to every
+// broadcast-worker replica (not a queue group).
+type JoinGraceEvent struct {
+	RoomID   string   `json:"roomId"`
+	Accounts []string `json:"accounts"`
+	JoinedAt int64    `json:"joinedAt"`
+	SiteID   string   `json:"siteId"`
+	// Timestamp is when the notice was published (event-level), distinct from
+	// JoinedAt which is the domain-level join time.
+	Timestamp int64 `json:"timestamp" bson:"timestamp"`
+}

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -1689,6 +1689,14 @@ func ServerBroadcastThreadTCount(siteID string) string {
 	return fmt.Sprintf("chat.server.broadcast.%s.thread.tcount", siteID)
 }
 
+// JoinGraceNotice carries room-worker's "these accounts just joined" notice to
+// broadcast-worker. Deliberately OUTSIDE chat.server.broadcast.{siteID}.> so it
+// is not swallowed by that wildcard's queue group: every broadcast-worker
+// replica needs this notice, not one of them.
+func JoinGraceNotice(siteID string) string {
+	return fmt.Sprintf("chat.server.joingrace.%s", siteID)
+}
+
 // ServerBroadcastWildcard is the queue-subscribe subject used by broadcast-worker
 // to receive all server-broadcast events for a site.
 func ServerBroadcastWildcard(siteID string) string {

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -106,6 +106,32 @@ func (h *Handler) bustRoomMeta(ctx context.Context, roomID string) {
 	roommetacache.BustMeta(bustCtx, h.valkey, roomID)
 }
 
+// publishJoinGrace tells broadcast-worker which accounts just joined a channel,
+// so its fan-out can also reach them on their own user subject while they are
+// too new to be relied on to hold the room subject. Core NATS, best-effort: a
+// dropped notice costs those members the window, and the client's history read
+// still covers them.
+func (h *Handler) publishJoinGrace(ctx context.Context, roomID string, accounts []string, joinedAt time.Time) {
+	if len(accounts) == 0 {
+		return
+	}
+	evt := model.JoinGraceEvent{
+		RoomID:    roomID,
+		Accounts:  accounts,
+		JoinedAt:  joinedAt.UTC().UnixMilli(),
+		SiteID:    h.siteID,
+		Timestamp: time.Now().UTC().UnixMilli(),
+	}
+	data, err := json.Marshal(evt)
+	if err != nil {
+		slog.ErrorContext(ctx, "marshal join-grace notice failed", "error", err, "room_id", roomID)
+		return
+	}
+	if err := h.publish(ctx, subject.JoinGraceNotice(h.siteID), data, ""); err != nil {
+		slog.WarnContext(ctx, "publish join-grace notice failed", "error", err, "room_id", roomID)
+	}
+}
+
 // publishSubscriptionUpdate fans out the per-user subscription.update event for the FE; best-effort.
 func (h *Handler) publishSubscriptionUpdate(ctx context.Context, account string, subEvtData []byte) {
 	if err := h.publish(ctx, subject.SubscriptionUpdate(account), subEvtData, ""); err != nil {
@@ -1034,6 +1060,11 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 		if err := h.store.BulkCreateSubscriptions(ctx, subs); err != nil {
 			return fmt.Errorf("bulk create subscriptions: %w", err)
 		}
+		joined := make([]string, 0, len(subs))
+		for _, sub := range subs {
+			joined = append(joined, sub.User.Account)
+		}
+		h.publishJoinGrace(ctx, req.RoomID, joined, acceptedAt)
 	}
 
 	// Collect all room_member docs to write in a single bulk insert:
@@ -1825,6 +1856,9 @@ func (h *Handler) finishCreateRoom(ctx context.Context, req *model.CreateRoomReq
 	accounts := make([]string, 0, len(subs))
 	for _, sub := range subs {
 		accounts = append(accounts, sub.User.Account)
+	}
+	if room.Type == model.RoomTypeChannel {
+		h.publishJoinGrace(ctx, room.ID, accounts, now)
 	}
 	inner := model.MemberAddEvent{
 		Type:               model.InboxMemberAdded,

--- a/tools/roomrace/README.md
+++ b/tools/roomrace/README.md
@@ -1,0 +1,49 @@
+# roomrace
+
+Reproduces and measures the two "new room → first message" races against a real
+NATS server, using the production subject builders from `pkg/subject` so the
+topology under test is the one the services actually publish on.
+
+```sh
+./tools/roomrace/run.sh
+```
+
+## What it models
+
+| Actor | Modelled as |
+|---|---|
+| `room-worker` | publishes `subscription.update{action:"added"}` on `chat.user.{B}.event.subscription.update` |
+| `broadcast-worker` | DM → `chat.user.{B}.event.room` (per member); channel → `chat.room.{id}.event` |
+| `message-worker` | persists the message before the fan-out, so a backfill can recover it |
+| `history-service` | request/reply stub on the real `…msg.history` subject |
+| desktop client B | login-time subs to its own user subjects; per-room sub opened only when it handles `subscription.update`, after a configurable render delay |
+
+`-render-ms` is how long client B takes to render the new chat and open the room
+subscription. `-send-ms` sweeps the delay between `subscription.update` and the
+first message — the axis the race turns on.
+
+## Scenarios
+
+| Scenario | What it shows |
+|---|---|
+| `dm / client drops unknown room` | Problem 1 as reported: the event is delivered, the client discards it |
+| `dm / client buffers unknown room` | Problem 1 is fixable client-side, no backend change |
+| `channel / subscribe on update` | Problem 2 as reported |
+| `channel / subscribe + flush` | `Flush()` alone does not close it |
+| `channel / subscribe + flush + backfill` | backfill over the existing `msg.history` RPC closes it |
+| `channel / server join grace window` | server dual-publishes to `chat.user.{B}.event.room` for fresh members |
+| `channel / grace window, client still drops` | the server fix needs the client fix; alone it does nothing |
+
+## Interest window
+
+Before the scenarios, the harness measures how long after `Subscribe()` returns a
+publisher actually starts reaching the new subscription. That is the floor under
+Problem 2 — no client can subscribe faster than this — and it is the number that
+grows when the publisher sits on a different server (cluster) or a different site
+(gateway).
+
+## Topologies
+
+`docker-compose.yml` starts one standalone server (`:4222`) and a 3-node full-mesh
+cluster (`:4223`, `:4224`, `:4225`). Point `-sub-url` and `-pub-url` at different
+cluster nodes to include route propagation, which is the production shape.

--- a/tools/roomrace/RESULTS-e2e.md
+++ b/tools/roomrace/RESULTS-e2e.md
@@ -1,0 +1,70 @@
+# End-to-end results — channel create + first message (2026-08-22)
+
+Real stack: `room-service`, `room-worker`, `message-gatekeeper`, `broadcast-worker`,
+`message-worker`, `history-service` against NATS 2.11 / MongoDB 8.2 / Cassandra 5 /
+Valkey 8.1. Driver: `go run ./tools/roomrace/e2e`.
+
+The room should contain three messages: `room_created` (sys), `members_added` (sys),
+and alice's `first message`. All three are confirmed present in Cassandra.
+
+## Summary
+
+| run | alice live | alice history | bob live | bob history |
+|---|---|---|---|---|
+| baseline (today) | **1 of 3** | **2 of 3** | 3 of 3 | **2 of 3** |
+| `-early-sub` | 3 of 3 | **2 of 3** | 3 of 3 | **2 of 3** |
+| `-hint` | 1 of 3 | 3 of 3 | 3 of 3 | 3 of 3 |
+| `-early-sub -hint` | 3 of 3 | 3 of 3 | 3 of 3 | 3 of 3 |
+| `-retry-history` (55 tries over 3.5 s) | 1 of 3 | **2 of 3** | 3 of 3 | **2 of 3** |
+| `-retry-history`, `HISTORY_ROOM_CACHE_SIZE=0` | 1 of 3 | 3 of 3 (5 tries) | 3 of 3 | 3 of 3 (1 try) |
+
+## Baseline timeline
+
+```
+   13ms  alice  rpc            room.create sync reply accepted
+   23ms  alice  user-subject   subscription.update added
+   23ms  bob    user-subject   subscription.update added
+   24ms  bob    room-subject   subscribed
+   29ms  bob    room-subject   new_message [members_added]
+   29ms  bob    room-subject   new_message [room_created]
+  529ms  alice  rpc            create-room async result ok      <-- 500ms after the sys messages
+  534ms  alice  rpc            msg.send reply ok
+  534ms  alice  room-subject   subscribed                        <-- too late for the sys messages
+  539ms  bob    room-subject   new_message first message
+  539ms  alice  room-subject   new_message first message
+  543ms  alice  history        msg.history returned 2 (tries 1)  <-- her own message missing
+  548ms  bob    history        msg.history returned 2 (tries 1)
+```
+
+## Findings
+
+**1. The creator is told about her own room ~500 ms after everyone else.**
+`room-worker.finishCreateRoom` publishes `subscription.update` to every member,
+*then* the system messages, *then* the deferred `publishAsyncJobResult`. A client
+that waits for the async result before subscribing has already missed the system
+messages. Subscribing on the client's own `subscription.update` (`-early-sub`)
+catches them: subscribed at 24 ms, system messages at 27 ms.
+
+**2. `msg.history` cannot see a just-sent message, and retrying does not help.**
+Both users' history returns 2 of 3 even though all three rows are in Cassandra.
+`history-service.walkBounds` ceilings the scan at the room document's `lastMsgAt`,
+and `LoadHistory` caps `before` at that value — so anything newer than the room
+doc is invisible. Two stacked delays:
+
+* `broadcast-worker` advances `room.lastMsgAt` on a batched flush
+  (`LAST_MSG_FLUSH_INTERVAL`, default **250 ms**);
+* `history-service` then caches the resolved room times
+  (`HISTORY_ROOM_CACHE_TTL`, default **10 s**), pinning the stale ceiling.
+
+Controlled isolation: with the cache on, **55 retries over 3.5 s still returned 2**.
+With `HISTORY_ROOM_CACHE_SIZE=0`, the same retry loop returned 3 after **5 tries
+(~200 ms)** — the residual 200 ms is the `lastMsgAt` flush. A probe of the same
+room after the TTL expired returned 3.
+
+**3. The documented `meta.lastMsgAt` hint fixes the read.**
+`msg.history` accepts `meta.lastMsgAt` (documented in `docs/client-api.md` under
+Common request fields). It is the scan ceiling, so supplying `now` returns all
+three on the first try, with the cache still enabled — and skips the Mongo lookup.
+
+**4. The two fixes are independent and both are needed.** `-early-sub` fixes the
+live path for the creator; `-hint` fixes the read path for everyone.

--- a/tools/roomrace/RESULTS-e2e.md
+++ b/tools/roomrace/RESULTS-e2e.md
@@ -27,7 +27,7 @@ and alice's `first message`. All three are confirmed present in Cassandra.
    24ms  bob    room-subject   subscribed
    29ms  bob    room-subject   new_message [members_added]
    29ms  bob    room-subject   new_message [room_created]
-  529ms  alice  rpc            create-room async result ok      <-- 500ms after the sys messages
+  529ms  alice  rpc            create-room async result ok      <-- harness artifact, see the correction below
   534ms  alice  rpc            msg.send reply ok
   534ms  alice  room-subject   subscribed                        <-- too late for the sys messages
   539ms  bob    room-subject   new_message first message
@@ -38,7 +38,9 @@ and alice's `first message`. All three are confirmed present in Cassandra.
 
 ## Findings
 
-**1. The creator is told about her own room ~500 ms after everyone else.**
+**1. The creator is told about her own room after everyone else.** (The ~500 ms figure in these
+early runs was a harness artifact — see the correction at the end of this file. The ordering
+holds; the gap is tens of milliseconds.)
 `room-worker.finishCreateRoom` publishes `subscription.update` to every member,
 *then* the system messages, *then* the deferred `publishAsyncJobResult`. A client
 that waits for the async result before subscribing has already missed the system
@@ -229,3 +231,52 @@ message has not reached; that member loses it permanently.
 The flow's correctness rests on the read covering what the live path dropped. When the write
 path lags, neither has it. The grace window is what removes that dependency (0% lost under the
 same stall).
+
+
+---
+
+# Correction: the 500 ms creator gap was a harness artifact (2026-08-24)
+
+`room-worker.finishCreateRoom` JetStream-publishes to `chat.inbox.{siteID}.internal.member_added`.
+The minimal stack omitted `inbox-worker`, which **owns the INBOX stream**, so that publish had
+nothing to ack it and blocked until its PubAck timed out:
+
+```
+ERROR local inbox member_added publish failed
+      error="publish to \"chat.inbox.site-local.internal.member_added\": nats: no response from stream"
+```
+
+`publishAsyncJobResult` is deferred, so the timeout pushed the creator's async result out to
+~525 ms. With `inbox-worker` started, the same measurement three times in a row:
+
+| | sync `accepted` | async job result |
+|---|---|---|
+| run 1 | 11 ms | **23 ms** |
+| run 2 | 12 ms | **23 ms** |
+| run 3 | 14 ms | **25 ms** |
+
+**In production INBOX exists, so the real gap is ~10 ms, not 500 ms.**
+
+## What that changes
+
+The whole first exchange now completes inside ~30 ms, which removes the cushion the client-only
+flow was leaning on. Re-measured with realistic timing, grace window off, 10 rooms per delay:
+
+| client subscribe delay | alice missing live | bob missing live | **lost** |
+|---|---|---|---|
+| 0 ms | 0% | 0% | **0%** |
+| 5 ms | 27% | 27% | **0%** |
+| 12 ms | 43% | **97%** | **0%** |
+| 30 ms | 53% | **100%** | **0%** |
+
+The invited member now misses essentially the entire conversation on the live path, and the
+history read is the only thing holding it up. Nothing is lost while the write path is healthy.
+
+When it is not — `message-worker` stalled, 12 ms delay:
+
+| | missing live | missing read | **lost** | with `JOIN_GRACE=30s` |
+|---|---|---|---|---|
+| alice | 0% | 100% | **0%** | 0% |
+| bob | **100%** | 100% | **100%** | **0%** |
+
+Bob sees a completely empty room. The grace window returns him to 0%.

--- a/tools/roomrace/RESULTS-e2e.md
+++ b/tools/roomrace/RESULTS-e2e.md
@@ -144,3 +144,33 @@ The live path can only be made race-free by delivering on a subject the client s
 **before the room existed**. Everything else — subscribing faster, flushing, reading history —
 narrows the window without closing it, because the client's subscribe causally follows the
 event that tells it the room exists.
+
+
+---
+
+# Zero-cost join window (2026-08-23, revised)
+
+The first cut of the window queried the roster on every channel message. That is exactly what
+the single room-subject publish exists to avoid, so it was replaced: `room-worker` publishes a
+join notice on `chat.server.joingrace.{siteID}` (core NATS, not queue-subscribed, so every
+`broadcast-worker` replica sees it), each replica keeps the joiners in memory for the window,
+and the message path does one map lookup. No roster query — the unit tests set no
+`ListSubscriptions` expectation, and gomock fails on an unexpected call.
+
+Re-verified end-to-end, 8 rooms per delay:
+
+| client subscribe delay | `JOIN_GRACE` off | `JOIN_GRACE=30s` |
+|---|---|---|
+| 0 ms | 0% live loss | **0%** |
+| 12 ms | **67% live loss** | **0%** |
+| 100 ms | — | **0%** |
+| 1 s | — | **0%** |
+
+Control at 12 ms with the window off reproduces the 67% loss, so the registry is what closes it.
+
+With `message-worker` stalled (history read returns nothing) and a 12 ms client delay:
+
+| | missing from live | missing from read | **missing from both** |
+|---|---|---|---|
+| alice | **0%** | 100% | **0%** |
+| bob | **0%** | 100% | **0%** |

--- a/tools/roomrace/RESULTS-e2e.md
+++ b/tools/roomrace/RESULTS-e2e.md
@@ -174,3 +174,58 @@ With `message-worker` stalled (history read returns nothing) and a 12 ms client 
 |---|---|---|---|
 | alice | **0%** | 100% | **0%** |
 | bob | **0%** | 100% | **0%** |
+
+
+---
+
+# The client-only flow, tested (2026-08-23)
+
+Sequence under test, with the server-side grace window **off**:
+
+1. `room.create` on the user's "send" click
+2. on `subscription.update` → subscribe to the room subject immediately
+3. buffer any system-message live events
+4. `msg.send` after the create async job result
+5. on the gatekeeper reply → enter the room → `msg.history` → merge with the buffer
+6. own message arrives live → merge
+7. both are on screen
+
+10 rooms per delay, `-early-sub -hint -history-at open`:
+
+| client subscribe delay | missing from live | missing from read | **lost** |
+|---|---|---|---|
+| 0 ms | 0% | 0–13% | **0%** |
+| 5 ms | 50% | 0% | **0%** |
+| 12 ms | 67% | 0–7% | **0%** |
+| 30 ms | 67% | 0–7% | **0%** |
+| 100 ms | 67% | 0–10% | **0%** |
+
+It works. Past ~5 ms the live path loses both system messages exactly as step 3 anticipates,
+and step 5's read covers them every time. What makes it work is the ~500 ms between room
+creation and the first user message — the create async job result round trip — which is far
+longer than the write lag, so by the time history is read the system messages are durable.
+
+## The hint is required, not optional
+
+A member slow enough to miss the *user* message live too (`-client-delay 600ms`):
+
+| | missing from live | missing from read | **lost** |
+|---|---|---|---|
+| bob, no hint | 100% | 17% | **17%** |
+| bob, with `meta.lastMsgAt` | 100% | 0% | **0%** |
+
+Without the hint the scan ceiling is the room document's `lastMsgAt`, which the just-sent
+message has not reached; that member loses it permanently.
+
+## The one hole
+
+`message-worker` stalled, 12 ms delay, grace window off:
+
+| | missing from live | missing from read | **lost** |
+|---|---|---|---|
+| alice | 67% | 100% | **67%** |
+| bob | 67% | 100% | **67%** |
+
+The flow's correctness rests on the read covering what the live path dropped. When the write
+path lags, neither has it. The grace window is what removes that dependency (0% lost under the
+same stall).

--- a/tools/roomrace/RESULTS-e2e.md
+++ b/tools/roomrace/RESULTS-e2e.md
@@ -280,3 +280,73 @@ When it is not — `message-worker` stalled, 12 ms delay:
 | bob | **100%** | 100% | **100%** | **0%** |
 
 Bob sees a completely empty room. The grace window returns him to 0%.
+
+---
+
+# DM vs channel, on the current backend (2026-08-24)
+
+Grace window **off** — these runs describe the backend exactly as it ships today.
+
+## DM
+
+`publishChannelSysMessages` is gated on `room.Type == RoomTypeChannel`, so a DM create emits
+**no system messages at all**. The first message fans out per member on
+`chat.user.{account}.event.room`, a subject both clients have held since login.
+
+```
+ 263ms  alice  rpc         room.create sync reply "accepted"   roomId = u-aliceu-carol
+ 356ms  alice  user subj   subscription.update added
+ 356ms  carol  user subj   subscription.update added
+ 357ms  alice  rpc         create-room async job result ok
+1060ms  alice  rpc         msg.send accepted by gatekeeper
+1069ms  alice  user subj   new_message "first message"
+1069ms  carol  user subj   new_message "first message"
+1133ms  alice  history     msg.history -> 0     <-- write lag; she has it live only
+1186ms  carol  history     msg.history -> 1
+```
+
+| | missed live | lost |
+|---|---|---|
+| client subscribes in 12 ms | 0% | **0%** |
+| client takes 300 ms | 0% | **0%** |
+
+**No race exists.** Alice's own history read returned zero, which is why merge-never-replace
+is mandatory even here.
+
+Also found: alice and bob already had a seeded DM, and `room.create` answered
+`status:"exists"` **without publishing a canonical event**, so no async job result ever
+arrives on that branch. A client that waits for one hangs until timeout.
+
+## Channel
+
+Two system messages (`room_created`, `members_added`) plus the user message, all on
+`chat.room.{roomId}.event`.
+
+```
+  16ms  alice  rpc         room.create sync reply "accepted"
+  29ms  alice  user subj   subscription.update added
+  29ms  bob    user subj   subscription.update added
+ ~30ms  ----   room subj   new_message [room_created]   <-- nobody subscribed yet; lost live
+  31ms  alice  rpc         create-room async job result ok
+  40ms  alice  rpc         msg.send accepted by gatekeeper
+  40ms  alice  room subj   SUBSCRIBED
+  42ms  bob    room subj   SUBSCRIBED
+  46ms  both   room subj   new_message "first message"
+  48ms  both   room subj   new_message [members_added]  <-- arrives AFTER the message it precedes
+  96ms  alice  history     msg.history -> 3
+ 146ms  bob    history     msg.history -> 3
+```
+
+Two things this pins down. `room_created` is broadcast before any client can subscribe and is
+unrecoverable from the live stream — the hinted history read is the only path to the screen.
+And live arrival order does not match `createdAt` order, so clients must sort on `createdAt`.
+A second run under identical conditions missed *both* system messages live.
+
+| | missed live | lost |
+|---|---|---|
+| instant client | 0% | **0%** |
+| 5 ms | 27% | **0%** |
+| 12 ms | 43% / 97% (creator / invitee) | **0%** |
+| 30 ms | 53% / 100% | **0%** |
+| slow member, no `meta.lastMsgAt` | 100% | **17%** |
+| write path lagging | 100% | **100%** |

--- a/tools/roomrace/RESULTS-e2e.md
+++ b/tools/roomrace/RESULTS-e2e.md
@@ -68,3 +68,79 @@ three on the first try, with the cache still enabled — and skips the Mongo loo
 
 **4. The two fixes are independent and both are needed.** `-early-sub` fixes the
 live path for the creator; `-hint` fixes the read path for everyone.
+
+---
+
+# Residual race and the fix (2026-08-23)
+
+The client-side algorithm is *subscribe → flush → hinted read → merge*. The question this
+round answers: the client cannot subscribe instantly, so can a message be missed by **both**
+paths — delivered before the subscription was live, and not yet readable when history was read?
+
+`-client-delay` models the time a client spends between receiving `subscription.update` and
+having a live subscription; the client then reads history immediately, as the recommended
+algorithm says. 12 rooms per delay, `-early-sub -hint`.
+
+## Without the grace window
+
+| client delay | missing from live | missing from read | **missing from both** |
+|---|---|---|---|
+| 0 ms | 0% | 58–64% | **0%** |
+| 2 ms | 0–6% | 33–36% | **0%** |
+| 5 ms | 53% | 33% | **0%** |
+| 8 ms | 56% | 33% | **0%** |
+| 12 ms | 67% | 33% | **0%** |
+| 20 ms | 67% | 33% | **0%** |
+| 40 ms | 67% | 33% | **0%** |
+
+The live path degrades exactly as expected — past ~5 ms both system messages are gone — and
+the read covers it. Across 84 rooms nothing was lost. But that is a property of an idle
+machine: `send → readable in history` measured **avg 51 ms, max 74 ms**, so the hole exists,
+it just never opened here.
+
+## Forcing the hole: a lagging `message-worker`
+
+`message-worker` and `broadcast-worker` are independent consumers of MESSAGES-CANONICAL, so a
+backlog on the writer does not stop the fan-out. SIGSTOP on `message-worker`, `-client-delay 12ms`:
+
+| | missing from live | missing from read | **missing from both** |
+|---|---|---|---|
+| alice | 67% | 100% | **67%** |
+| bob | 67% | 100% | **67%** |
+
+Both system messages lost outright — missed live because the client was 12 ms late, missed in
+history because they were not written yet. **Subscribe-then-read is not sufficient.** And the
+client cannot even detect it: there is no per-room sequence number, so a client has no way to
+know two messages are missing from the middle of what it holds.
+
+## With the grace window (`JOIN_GRACE=30s`)
+
+`broadcast-worker` also publishes a channel's events to the user subject of every member who
+joined within the window — a subject the client has held since login, so there is no
+subscription to race.
+
+| client delay | missing from live | **missing from both** |
+|---|---|---|
+| 0 ms | **0%** | **0%** |
+| 5 ms | **0%** | **0%** |
+| 12 ms | **0%** | **0%** |
+| 30 ms | **0%** | **0%** |
+| 100 ms | **0%** | **0%** |
+| 1 s | **0%** | **0%** |
+
+And the case that defeated the client-side fix:
+
+| `message-worker` STALLED, delay 12 ms | missing from live | missing from read | **missing from both** |
+|---|---|---|---|
+| alice | **0%** | 100% | **0%** |
+| bob | **0%** | 100% | **0%** |
+
+The read still returns nothing — nothing has been persisted — and nothing is lost, because
+delivery no longer depends on either the room subject or the read.
+
+## Conclusion
+
+The live path can only be made race-free by delivering on a subject the client subscribed to
+**before the room existed**. Everything else — subscribing faster, flushing, reading history —
+narrows the window without closing it, because the client's subscribe causally follows the
+event that tells it the room exists.

--- a/tools/roomrace/RESULTS.md
+++ b/tools/roomrace/RESULTS.md
@@ -1,0 +1,121 @@
+# roomrace — recorded runs (2026-08-22)
+
+Verbatim output of `./tools/roomrace/run.sh` plus an instant-client (`-render-ms 0`) sweep.
+Host: 4 vCPU, NATS 2.11-alpine in Docker.
+
+## Realistic client (`-render-ms 30`)
+
+```
+### SINGLE SERVER ###
+
+=== roomrace: single-server ===
+client B  -> nats://127.0.0.1:4222
+services  -> nats://127.0.0.1:4222
+iterations per point: 40   client render delay: 30ms
+
+subscription interest window (Subscribe() -> publisher actually reaches it)
+  samples 40, delivered 40 | median 40us  p95 1538us  max 1598us | Flush() RTT median 295us
+
+scenario                                       fix                       +0ms   +10ms   +20ms   +25ms   +28ms   +30ms   +32ms   +35ms   +40ms
+---------------------------------------------------------------------------------------------------------------------------------------------
+dm / client drops unknown room                 none (today)              100%    100%    100%    100%     98%      0%      0%      0%      0%
+dm / client buffers unknown room               client tolerates            0%      0%      0%      0%      0%      0%      0%      0%      0%
+channel / subscribe on update                  none (today)              100%    100%    100%    100%    100%     70%      0%      0%      0%
+channel / subscribe + flush                    client flush              100%    100%    100%    100%    100%     60%      0%      0%      0%
+channel / subscribe + flush + backfill         client backfill             0%      0%      0%      0%      0%      0%      0%      0%      0%
+channel / server join grace window             server grace window         0%      0%      0%      0%      0%      0%      0%      0%      0%
+channel / grace window, client still drops     server only               100%    100%    100%    100%     92%     12%      0%      0%      0%
+
+(cell = % of first messages user B never saw; columns = delay between
+ subscription.update and the first message)
+
+detail (totals across all delays)                  live  recover   missed  dropped    dupes
+-------------------------------------------------------------------------------------------
+dm / client drops unknown room                      161        0      199      199        0
+dm / client buffers unknown room                    360        0        0        0        0
+channel / subscribe on update                       132        0      228        0        0
+channel / subscribe + flush                         136        0      224        0        0
+channel / subscribe + flush + backfill              145      215        0        0        0
+channel / server join grace window                  360        0        0        0      142
+channel / grace window, client still drops          158        0      202      202      138
+
+
+### 3-NODE CLUSTER (client on node a, services on node b) ###
+
+=== roomrace: 3-node cluster (B on a, services on b) ===
+client B  -> nats://127.0.0.1:4223
+services  -> nats://127.0.0.1:4224
+iterations per point: 40   client render delay: 30ms
+
+subscription interest window (Subscribe() -> publisher actually reaches it)
+  samples 40, delivered 40 | median 1446us  p95 1809us  max 4968us | Flush() RTT median 254us
+
+scenario                                       fix                       +0ms   +10ms   +20ms   +25ms   +28ms   +30ms   +32ms   +35ms   +40ms
+---------------------------------------------------------------------------------------------------------------------------------------------
+dm / client drops unknown room                 none (today)              100%    100%    100%    100%    100%      0%      0%      0%      0%
+dm / client buffers unknown room               client tolerates            0%      0%      0%      0%      0%      0%      0%      0%      0%
+channel / subscribe on update                  none (today)              100%    100%    100%    100%    100%     98%      0%      0%      0%
+channel / subscribe + flush                    client flush              100%    100%    100%    100%    100%     95%      0%      0%      0%
+channel / subscribe + flush + backfill         client backfill             0%      0%      0%      0%      0%      0%      0%      0%      0%
+channel / server join grace window             server grace window         0%      0%      0%      0%      0%      0%      0%      0%      0%
+channel / grace window, client still drops     server only               100%    100%    100%    100%    100%      0%      0%      0%      0%
+
+(cell = % of first messages user B never saw; columns = delay between
+ subscription.update and the first message)
+
+detail (totals across all delays)                  live  recover   missed  dropped    dupes
+-------------------------------------------------------------------------------------------
+dm / client drops unknown room                      160        0      200      200        0
+dm / client buffers unknown room                    360        0        0        0        0
+channel / subscribe on update                       121        0      239        0        0
+channel / subscribe + flush                         122        0      238        0        0
+channel / subscribe + flush + backfill              119      241        0        0        0
+channel / server join grace window                  360        0        0        0      121
+channel / grace window, client still drops          160        0      200      200      120
+
+DONE
+
+[exited with code 0]
+```
+
+## Instant client (`-render-ms 0`) — isolates the transport window
+
+```
+=== roomrace: instant client, single server ===
+client B  -> nats://127.0.0.1:4222
+services  -> nats://127.0.0.1:4222
+iterations per point: 60   client render delay: 0ms
+
+
+=== roomrace: instant client, 3-node cluster (B on a, services on b) ===
+client B  -> nats://127.0.0.1:4223
+services  -> nats://127.0.0.1:4224
+iterations per point: 60   client render delay: 0ms
+
+subscription interest window (Subscribe() -> publisher actually reaches it)
+  samples 40, delivered 40 | median 1443us  p95 1610us  max 1676us | Flush() RTT median 251us
+
+scenario                                       fix                       +0ms    +1ms    +2ms    +3ms    +5ms   +10ms
+---------------------------------------------------------------------------------------------------------------------
+dm / client drops unknown room                 none (today)                0%      0%      0%      0%      0%      0%
+dm / client buffers unknown room               client tolerates            0%      0%      0%      0%      0%      0%
+channel / subscribe on update                  none (today)               98%      0%      0%      0%      0%      0%
+channel / subscribe + flush                    client flush              100%      0%      0%      0%      0%      0%
+channel / subscribe + flush + backfill         client backfill             0%      0%      0%      0%      0%      0%
+channel / server join grace window             server grace window         0%      0%      0%      0%      0%      0%
+channel / grace window, client still drops     server only                 2%      0%      0%      0%      0%      0%
+
+(cell = % of first messages user B never saw; columns = delay between
+ subscription.update and the first message)
+
+detail (totals across all delays)                  live  recover   missed  dropped    dupes
+-------------------------------------------------------------------------------------------
+dm / client drops unknown room                      360        0        0        0        0
+dm / client buffers unknown room                    360        0        0        0        0
+channel / subscribe on update                       301        0       59        0        0
+channel / subscribe + flush                         300        0       60        0        0
+channel / subscribe + flush + backfill              283       77        0        0       15
+channel / server join grace window                  360        0        0        0      300
+channel / grace window, client still drops          359        0        1        1      300
+
+```

--- a/tools/roomrace/client.go
+++ b/tools/roomrace/client.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+// roomState is client B's per-room view for one iteration.
+type roomState struct {
+	known     bool
+	seen      map[string]bool
+	live      bool
+	recovered bool
+	dropped   int
+	dupes     int
+	done      chan struct{}
+}
+
+// clientB models the desktop client: login-time subscriptions to its own user
+// subjects, plus a per-room subscription opened when a channel subscription
+// arrives.
+type clientB struct {
+	nc          *nats.Conn
+	sc          scenario
+	renderDelay time.Duration
+
+	mu    sync.Mutex
+	rooms map[string]*roomState
+
+	loginSubs []*nats.Subscription
+	roomSubs  []*nats.Subscription
+}
+
+func newClientB(url string, sc scenario, renderDelay time.Duration) (*clientB, error) {
+	nc, err := nats.Connect(url, nats.Name("roomrace-client-b"))
+	if err != nil {
+		return nil, fmt.Errorf("connect %s: %w", url, err)
+	}
+	c := &clientB{nc: nc, sc: sc, renderDelay: renderDelay, rooms: map[string]*roomState{}}
+
+	updSub, err := nc.Subscribe(subject.SubscriptionUpdate(accountB), c.onSubscriptionUpdate)
+	if err != nil {
+		nc.Close()
+		return nil, fmt.Errorf("subscribe subscription.update: %w", err)
+	}
+	userRoomSub, err := nc.Subscribe(subject.UserRoomEvent(accountB), c.onUserRoomEvent)
+	if err != nil {
+		nc.Close()
+		return nil, fmt.Errorf("subscribe user room event: %w", err)
+	}
+	c.loginSubs = []*nats.Subscription{updSub, userRoomSub}
+	if err := nc.Flush(); err != nil {
+		nc.Close()
+		return nil, fmt.Errorf("flush login subscriptions: %w", err)
+	}
+	// Warm the request inbox before the run: nats.go registers the reply
+	// subscription lazily, and on a cluster that interest has to reach the
+	// responder's server, which would otherwise time out the first backfill.
+	if _, err := nc.Request(subject.MsgHistory(accountB, "warmup", siteID), nil, 2*time.Second); err != nil {
+		nc.Close()
+		return nil, fmt.Errorf("warm request inbox: %w", err)
+	}
+	return c, nil
+}
+
+func (c *clientB) close() {
+	for _, s := range c.roomSubs {
+		_ = s.Unsubscribe()
+	}
+	for _, s := range c.loginSubs {
+		_ = s.Unsubscribe()
+	}
+	_ = c.nc.Drain()
+}
+
+func (c *clientB) expect(roomID string) *roomState {
+	st := &roomState{seen: map[string]bool{}, done: make(chan struct{})}
+	c.mu.Lock()
+	c.rooms[roomID] = st
+	c.mu.Unlock()
+	return st
+}
+
+func (c *clientB) state(roomID string) *roomState {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.rooms[roomID]
+}
+
+// onSubscriptionUpdate is the client's "a new chat appeared" handler: render
+// the row, then (channels only) open the room subscription.
+func (c *clientB) onSubscriptionUpdate(m *nats.Msg) {
+	var evt subUpdate
+	if err := json.Unmarshal(m.Data, &evt); err != nil {
+		return
+	}
+	st := c.state(evt.RoomID)
+	if st == nil {
+		return
+	}
+	defer close(st.done)
+
+	time.Sleep(c.renderDelay) // render the sidebar row / mount the room
+
+	c.mu.Lock()
+	st.known = true
+	c.mu.Unlock()
+
+	if !c.sc.subscribeOnUpdate || roomKind(evt.Kind) != kindChannel {
+		return
+	}
+	sub, err := c.nc.Subscribe(subject.RoomEvent(evt.RoomID, true), c.onRoomEvent)
+	if err != nil {
+		return
+	}
+	c.mu.Lock()
+	c.roomSubs = append(c.roomSubs, sub)
+	c.mu.Unlock()
+
+	if c.sc.flushAfterSub {
+		_ = c.nc.Flush()
+	}
+	if c.sc.backfillAfterSub {
+		c.backfill(evt.RoomID)
+	}
+}
+
+// backfill is the Zulip-style catch-up: subscribe first, then read the durable
+// log, then merge by message id.
+func (c *clientB) backfill(roomID string) {
+	reply, err := c.nc.Request(subject.MsgHistory(accountB, roomID, siteID), nil, time.Second)
+	if err != nil {
+		return
+	}
+	var out struct {
+		Messages []string `json:"messages"`
+	}
+	if err := json.Unmarshal(reply.Data, &out); err != nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	st := c.rooms[roomID]
+	if st == nil {
+		return
+	}
+	for _, id := range out.Messages {
+		if st.seen[id] {
+			continue
+		}
+		st.seen[id] = true
+		st.recovered = true
+	}
+}
+
+func (c *clientB) onUserRoomEvent(m *nats.Msg) { c.record(m, true) }
+
+func (c *clientB) onRoomEvent(m *nats.Msg) { c.record(m, false) }
+
+// record applies an inbound room event. onUserRoom=true is the per-user subject
+// (DM fan-out, and the grace-window copy); false is the per-room subject.
+func (c *clientB) record(m *nats.Msg, onUserRoom bool) {
+	var evt roomEvent
+	if err := json.Unmarshal(m.Data, &evt); err != nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	st := c.rooms[evt.RoomID]
+	if st == nil {
+		return
+	}
+	if onUserRoom && !st.known && c.sc.dropsUnknownRoom {
+		st.dropped++
+		return
+	}
+	if st.seen[evt.LastMsgID] {
+		st.dupes++
+		return
+	}
+	st.seen[evt.LastMsgID] = true
+	st.live = true
+}
+
+// roomSeq keeps every room id in a process unique, so a late event from an
+// earlier iteration can never be mistaken for the current one.
+var roomSeq atomic.Uint64
+
+type outcome struct {
+	SendMS     int     `json:"sendMs"`
+	Iterations int     `json:"iterations"`
+	Live       int     `json:"live"`
+	Recovered  int     `json:"recovered"`
+	Missed     int     `json:"missed"`
+	Dropped    int     `json:"droppedUnknownRoom"`
+	Duplicates int     `json:"duplicates"`
+	MissRate   float64 `json:"missRate"`
+}
+
+func runScenario(opt *options, svc *services, sc scenario, sendDelay time.Duration) (outcome, error) {
+	c, err := newClientB(opt.subURL, sc, time.Duration(opt.renderMS)*time.Millisecond)
+	if err != nil {
+		return outcome{}, err
+	}
+	defer c.close()
+
+	settle := time.Duration(opt.settleMS) * time.Millisecond
+	o := outcome{Iterations: opt.iterations}
+
+	for i := range opt.iterations {
+		roomID := fmt.Sprintf("rr%08d", roomSeq.Add(1))
+		msgID := fmt.Sprintf("msg%017d", i)
+		st := c.expect(roomID)
+
+		if err := svc.publishSubscriptionAdded(roomID, sc.kind); err != nil {
+			return outcome{}, err
+		}
+		time.Sleep(sendDelay)
+
+		svc.persist(roomID, msgID)
+		if err := svc.publishNewMessage(roomID, msgID, sc); err != nil {
+			return outcome{}, err
+		}
+
+		select {
+		case <-st.done:
+		case <-time.After(15 * time.Second):
+			return outcome{}, fmt.Errorf("client handler stalled on room %s", roomID)
+		}
+		time.Sleep(settle)
+
+		c.mu.Lock()
+		switch {
+		case st.live:
+			o.Live++
+		case st.recovered:
+			o.Recovered++
+		default:
+			o.Missed++
+		}
+		o.Dropped += st.dropped
+		o.Duplicates += st.dupes
+		delete(c.rooms, roomID)
+		c.mu.Unlock()
+	}
+	o.MissRate = float64(o.Missed) / float64(o.Iterations)
+	return o, nil
+}

--- a/tools/roomrace/docker-compose.yml
+++ b/tools/roomrace/docker-compose.yml
@@ -1,0 +1,65 @@
+name: roomrace
+
+# NATS topologies for the new-room -> first-message race harness.
+#   nats-single      : one server            -> host :4222
+#   nats-a/b/c       : 3-node full mesh      -> host :4223 / :4224 / :4225
+#
+# The cluster exists to measure interest propagation: the harness subscribes on
+# one server and publishes from another, which is the production shape (clients
+# and workers land on different servers of the cluster/supercluster).
+#
+# Core NATS only - the room/user event subjects under test are core publishes,
+# not JetStream, so JetStream would add nothing to the measurement.
+
+services:
+  nats-single:
+    image: nats:2.11-alpine
+    container_name: roomrace-nats-single
+    command: ["-p", "4222", "-m", "8222", "-server_name", "single"]
+    ports:
+      - "4222:4222"
+      - "8222:8222"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8222/healthz || exit 1"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+
+  nats-a:
+    image: nats:2.11-alpine
+    container_name: roomrace-nats-a
+    command: ["-p","4222","-m","8222","-server_name","a","-cluster_name","roomrace","-cluster","nats://0.0.0.0:6222","-routes","nats://nats-b:6222,nats://nats-c:6222"]
+    ports:
+      - "4223:4222"
+      - "8223:8222"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8222/healthz || exit 1"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+
+  nats-b:
+    image: nats:2.11-alpine
+    container_name: roomrace-nats-b
+    command: ["-p","4222","-m","8222","-server_name","b","-cluster_name","roomrace","-cluster","nats://0.0.0.0:6222","-routes","nats://nats-a:6222,nats://nats-c:6222"]
+    ports:
+      - "4224:4222"
+      - "8224:8222"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8222/healthz || exit 1"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+
+  nats-c:
+    image: nats:2.11-alpine
+    container_name: roomrace-nats-c
+    command: ["-p","4222","-m","8222","-server_name","c","-cluster_name","roomrace","-cluster","nats://0.0.0.0:6222","-routes","nats://nats-a:6222,nats://nats-b:6222"]
+    ports:
+      - "4225:4222"
+      - "8225:8222"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8222/healthz || exit 1"]
+      interval: 2s
+      timeout: 2s
+      retries: 15

--- a/tools/roomrace/e2e/README.md
+++ b/tools/roomrace/e2e/README.md
@@ -1,0 +1,46 @@
+# roomrace/e2e
+
+Drives the reported channel scenario against a **real stack** — `room-service`,
+`room-worker`, `message-gatekeeper`, `broadcast-worker`, `message-worker`,
+`history-service` on real NATS / MongoDB / Cassandra / Valkey — and prints, with
+timestamps, what each client would have on screen.
+
+```sh
+./tools/roomrace/e2e/stack.sh up     # deps + seed + the six services
+go run ./tools/roomrace/e2e          # baseline: today's client behaviour
+./tools/roomrace/e2e/stack.sh down
+```
+
+Services run as host processes against containerised deps — much faster than
+building six images, and the binaries are the real ones. Vault and room
+encryption are switched off (`ATREST_ENABLED=false`, `ENCRYPTION_ENABLED=false`)
+so the harness can read the payloads; nothing else is altered.
+
+## The scenario
+
+1. `alice` creates a channel with `bob`, and waits for the **async job result**.
+2. `alice` sends the first message and waits for the `msg.send` reply.
+3. `alice`'s UI "jumps into" the room: subscribe + `msg.history`.
+4. `bob` subscribes on `subscription.update`, as the frontend does, then `msg.history`.
+
+`room-worker` also emits two system messages (`room_created`, `members_added`)
+into MESSAGES-CANONICAL, so the room should show three messages.
+
+## Flags
+
+| Flag | What it changes |
+|---|---|
+| *(none)* | today's behaviour |
+| `-early-sub` | alice subscribes to the room subject on her own `subscription.update` instead of when she opens the room |
+| `-hint` | `msg.history` carries `meta.lastMsgAt = now`, so the scan ceiling is not the stale room document |
+| `-retry-history` | retry `msg.history` until the just-sent message appears |
+| `-probe-room <id>` | just load history for a room and exit |
+
+## What it found
+
+See `../RESULTS-e2e.md`. In short: `bob` gets everything live, `alice` misses both
+system messages (her async job result lands ~500 ms *after* they were broadcast),
+and `msg.history` returns 2 of 3 for **both** users — the just-sent message is
+excluded by a stale scan ceiling, and retrying does not help until the
+history-service room cache expires. `-hint` fixes the history side; `-early-sub`
+fixes alice's live side.

--- a/tools/roomrace/e2e/client.go
+++ b/tools/roomrace/e2e/client.go
@@ -228,6 +228,9 @@ func (c *client) createChannel(name, other string) (string, error) {
 	req := nats.NewMsg(subject.RoomCreate(c.account, *siteID))
 	req.Data = body
 	req.Header.Set("X-Request-ID", requestID)
+	if *debugFlow {
+		req.Header.Set("X-Debug", "flow")
+	}
 
 	reply, err := c.nc.RequestMsg(req, rpcTimeout)
 	if err != nil {

--- a/tools/roomrace/e2e/client.go
+++ b/tools/roomrace/e2e/client.go
@@ -36,6 +36,7 @@ type client struct {
 	rec     *recorder
 
 	subscribeOnUpdate bool
+	readHistoryOnJoin bool
 	renderDelay       time.Duration
 
 	mu           sync.Mutex
@@ -79,8 +80,11 @@ func (c *client) onUserEvent(m *nats.Msg) {
 		if c.subscribeOnUpdate {
 			time.Sleep(c.renderDelay)
 			c.openRoom(evt.Subscription.RoomID)
-			// subscribe -> flush -> read, immediately, the way the recommended
-			// client does it. Reading here is what exposes the double-miss.
+			if !c.readHistoryOnJoin {
+				// The proposed flow buffers live events here and reads history
+				// later, when the UI actually enters the room.
+				return
+			}
 			msgs, _ := c.loadHistory(evt.Subscription.RoomID, false, "")
 			c.mu.Lock()
 			c.joinHist[evt.Subscription.RoomID] = msgs

--- a/tools/roomrace/e2e/client.go
+++ b/tools/roomrace/e2e/client.go
@@ -245,6 +245,13 @@ func (c *client) createChannel(name, other string) (string, error) {
 	}
 	c.rec.add(c.account, "rpc", "room.create sync reply "+accepted.Status, "", accepted.RoomID)
 
+	// "exists" is the DM open-or-create short-circuit: room-service answers from
+	// the dedup check without publishing a canonical event, so no async job
+	// result will ever arrive. The room is already usable.
+	if accepted.Status == model.CreateRoomStatusExists {
+		return accepted.RoomID, nil
+	}
+
 	msg, err := resultSub.NextMsg(rpcTimeout)
 	if err != nil {
 		return "", fmt.Errorf("await create async result: %w", err)

--- a/tools/roomrace/e2e/client.go
+++ b/tools/roomrace/e2e/client.go
@@ -36,11 +36,13 @@ type client struct {
 	rec     *recorder
 
 	subscribeOnUpdate bool
+	renderDelay       time.Duration
 
 	mu           sync.Mutex
 	liveMessages []string
 	roomSubs     []*nats.Subscription
 	roomOpen     map[string]bool
+	joinHist     map[string][]histMsg
 }
 
 func newClient(account string, nc *nats.Conn, rec *recorder) *client {
@@ -49,6 +51,7 @@ func newClient(account string, nc *nats.Conn, rec *recorder) *client {
 		nc:       nc,
 		rec:      rec,
 		roomOpen: map[string]bool{},
+		joinHist: map[string][]histMsg{},
 	}
 }
 
@@ -74,14 +77,20 @@ func (c *client) onUserEvent(m *nats.Msg) {
 			return
 		}
 		if c.subscribeOnUpdate {
+			time.Sleep(c.renderDelay)
 			c.openRoom(evt.Subscription.RoomID)
+			// subscribe -> flush -> read, immediately, the way the recommended
+			// client does it. Reading here is what exposes the double-miss.
+			msgs, _ := c.loadHistory(evt.Subscription.RoomID, false, "")
+			c.mu.Lock()
+			c.joinHist[evt.Subscription.RoomID] = msgs
+			c.mu.Unlock()
+			c.rec.add(c.account, "history", fmt.Sprintf("join-time msg.history returned %d", len(msgs)), "", "")
 		}
 	case strings.HasSuffix(m.Subject, ".event.room"):
-		var evt model.RoomEvent
-		if err := json.Unmarshal(m.Data, &evt); err != nil {
-			return
-		}
-		c.rec.add(c.account, "user-subject", string(evt.Type), evt.LastMsgID, "")
+		// DM fan-out and the join-grace copy both land here, on a subject held
+		// since login. Counted as a live delivery, deduped with the room subject.
+		c.record(m, "user-subject")
 	}
 }
 
@@ -123,7 +132,47 @@ func (c *client) waitRoomOpen(roomID string, d time.Duration) {
 	}
 }
 
-func (c *client) onRoomEvent(m *nats.Msg) {
+// joinHistory returns what the join-time history read saw, if one happened.
+func (c *client) joinHistory(roomID string) ([]histMsg, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	msgs, ok := c.joinHist[roomID]
+	return msgs, ok
+}
+
+// liveSet returns the message ids this client received on the live path.
+func (c *client) liveSet() map[string]bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]bool, len(c.liveMessages))
+	for _, id := range c.liveMessages {
+		out[id] = true
+	}
+	return out
+}
+
+// measureWriteLag polls hinted history until msgID is readable, so the gap
+// between "the send was accepted" and "the read can see it" is a measured
+// number rather than an assumption.
+func (c *client) measureWriteLag(roomID, msgID string) (time.Duration, int) {
+	start := time.Now()
+	for probes := 1; ; probes++ {
+		msgs, _ := c.loadHistoryHinted(roomID, true)
+		for _, m := range msgs {
+			if m.MessageID == msgID {
+				return time.Since(start), probes
+			}
+		}
+		if time.Since(start) > 5*time.Second {
+			return time.Since(start), probes
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func (c *client) onRoomEvent(m *nats.Msg) { c.record(m, "room-subject") }
+
+func (c *client) record(m *nats.Msg, source string) {
 	var evt model.RoomEvent
 	if err := json.Unmarshal(m.Data, &evt); err != nil {
 		return
@@ -152,7 +201,7 @@ func (c *client) onRoomEvent(m *nats.Msg) {
 	if dup {
 		return
 	}
-	c.rec.add(c.account, "room-subject", string(evt.Type), id, body)
+	c.rec.add(c.account, source, string(evt.Type), id, body)
 }
 
 // createChannel runs the two-phase create: the sync accept, then the async job
@@ -237,14 +286,22 @@ func (c *client) send(roomID, msgID, content string) error {
 
 // loadHistory issues the msg.history RPC. When retry is set it keeps asking
 // until wantMsgID shows up, which is what a gap-detecting client would do.
+func (c *client) loadHistoryHinted(roomID string, forceHint bool) ([]histMsg, int) {
+	return c.history(roomID, false, "", forceHint)
+}
+
 func (c *client) loadHistory(roomID string, retry bool, wantMsgID string) ([]histMsg, int) {
+	return c.history(roomID, retry, wantMsgID, false)
+}
+
+func (c *client) history(roomID string, retry bool, wantMsgID string, forceHint bool) ([]histMsg, int) {
 	deadline := time.Now().Add(3 * time.Second)
 	tries := 0
 	var last []histMsg
 	for {
 		tries++
 		req := map[string]any{"limit": 50}
-		if *hint {
+		if *hint || forceHint {
 			// A hint the client already holds: the room is at least as fresh as
 			// the event it just received. Without it the scan ceiling is the room
 			// doc's lastMsgAt, which the just-sent message has not reached yet.

--- a/tools/roomrace/e2e/client.go
+++ b/tools/roomrace/e2e/client.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/hmchangw/chat/pkg/idgen"
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+const rpcTimeout = 10 * time.Second
+
+type histMsg struct {
+	MessageID string `json:"messageId"`
+	Msg       string `json:"msg"`
+	Type      string `json:"t"`
+	CreatedAt string `json:"createdAt"`
+}
+
+type historyReply struct {
+	Messages []histMsg `json:"messages"`
+}
+
+// client is one desktop client: the login-time subscriptions to its own user
+// subjects, plus a room subscription opened at the moment the behaviour under
+// test says it opens.
+type client struct {
+	account string
+	nc      *nats.Conn
+	rec     *recorder
+
+	subscribeOnUpdate bool
+
+	mu           sync.Mutex
+	liveMessages []string
+	roomSubs     []*nats.Subscription
+	roomOpen     map[string]bool
+}
+
+func newClient(account string, nc *nats.Conn, rec *recorder) *client {
+	return &client{
+		account:  account,
+		nc:       nc,
+		rec:      rec,
+		roomOpen: map[string]bool{},
+	}
+}
+
+// login mirrors what the frontend subscribes to at connect time.
+func (c *client) login() error {
+	sub, err := c.nc.Subscribe(fmt.Sprintf("chat.user.%s.event.>", c.account), c.onUserEvent)
+	if err != nil {
+		return fmt.Errorf("subscribe user events for %s: %w", c.account, err)
+	}
+	c.roomSubs = append(c.roomSubs, sub)
+	return c.nc.Flush()
+}
+
+func (c *client) onUserEvent(m *nats.Msg) {
+	switch {
+	case strings.HasSuffix(m.Subject, ".event.subscription.update"):
+		var evt model.SubscriptionUpdateEvent
+		if err := json.Unmarshal(m.Data, &evt); err != nil {
+			return
+		}
+		c.rec.add(c.account, "user-subject", "subscription.update "+evt.Action, "", evt.Subscription.RoomID)
+		if evt.Action != "added" || evt.Subscription.RoomID == "" {
+			return
+		}
+		if c.subscribeOnUpdate {
+			c.openRoom(evt.Subscription.RoomID)
+		}
+	case strings.HasSuffix(m.Subject, ".event.room"):
+		var evt model.RoomEvent
+		if err := json.Unmarshal(m.Data, &evt); err != nil {
+			return
+		}
+		c.rec.add(c.account, "user-subject", string(evt.Type), evt.LastMsgID, "")
+	}
+}
+
+// openRoom subscribes to the room's event subject. ROOM_SUBJECT_MODE=dual means
+// a same-site room publishes on both lanes, so both are opened and deduped.
+func (c *client) openRoom(roomID string) {
+	c.mu.Lock()
+	if c.roomOpen[roomID] {
+		c.mu.Unlock()
+		return
+	}
+	c.roomOpen[roomID] = true
+	c.mu.Unlock()
+
+	for _, subj := range []string{subject.RoomEvent(roomID, false), subject.RoomEvent(roomID, true)} {
+		sub, err := c.nc.Subscribe(subj, c.onRoomEvent)
+		if err != nil {
+			c.rec.add(c.account, "room-subject", "SUBSCRIBE FAILED "+subj, "", err.Error())
+			continue
+		}
+		c.mu.Lock()
+		c.roomSubs = append(c.roomSubs, sub)
+		c.mu.Unlock()
+	}
+	_ = c.nc.Flush()
+	c.rec.add(c.account, "room-subject", "subscribed", "", roomID)
+}
+
+func (c *client) waitRoomOpen(roomID string, d time.Duration) {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		c.mu.Lock()
+		open := c.roomOpen[roomID]
+		c.mu.Unlock()
+		if open {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func (c *client) onRoomEvent(m *nats.Msg) {
+	var evt model.RoomEvent
+	if err := json.Unmarshal(m.Data, &evt); err != nil {
+		return
+	}
+	id := evt.LastMsgID
+	body := ""
+	if evt.Message != nil {
+		id = evt.Message.ID
+		body = evt.Message.Content
+		if evt.Message.Type != "" {
+			body = "[" + evt.Message.Type + "]"
+		}
+	}
+	c.mu.Lock()
+	dup := false
+	for _, seen := range c.liveMessages {
+		if seen == id {
+			dup = true
+			break
+		}
+	}
+	if !dup && id != "" {
+		c.liveMessages = append(c.liveMessages, id)
+	}
+	c.mu.Unlock()
+	if dup {
+		return
+	}
+	c.rec.add(c.account, "room-subject", string(evt.Type), id, body)
+}
+
+// createChannel runs the two-phase create: the sync accept, then the async job
+// result on chat.user.{account}.response.{requestId}.
+func (c *client) createChannel(name, other string) (string, error) {
+	requestID := idgen.GenerateRequestID()
+	resultSub, err := c.nc.SubscribeSync(subject.UserResponse(c.account, requestID))
+	if err != nil {
+		return "", fmt.Errorf("subscribe async result: %w", err)
+	}
+	defer func() { _ = resultSub.Unsubscribe() }()
+	if err := c.nc.Flush(); err != nil {
+		return "", fmt.Errorf("flush async result sub: %w", err)
+	}
+
+	body, err := json.Marshal(model.CreateRoomRequest{Name: name, Users: []string{other}})
+	if err != nil {
+		return "", fmt.Errorf("marshal create request: %w", err)
+	}
+	req := nats.NewMsg(subject.RoomCreate(c.account, *siteID))
+	req.Data = body
+	req.Header.Set("X-Request-ID", requestID)
+
+	reply, err := c.nc.RequestMsg(req, rpcTimeout)
+	if err != nil {
+		return "", fmt.Errorf("room.create rpc: %w", err)
+	}
+	var accepted model.CreateRoomReply
+	if err := json.Unmarshal(reply.Data, &accepted); err != nil {
+		return "", fmt.Errorf("decode create reply %s: %w", reply.Data, err)
+	}
+	if accepted.RoomID == "" {
+		return "", fmt.Errorf("create rejected: %s", reply.Data)
+	}
+	c.rec.add(c.account, "rpc", "room.create sync reply "+accepted.Status, "", accepted.RoomID)
+
+	msg, err := resultSub.NextMsg(rpcTimeout)
+	if err != nil {
+		return "", fmt.Errorf("await create async result: %w", err)
+	}
+	var res model.AsyncJobResult
+	if err := json.Unmarshal(msg.Data, &res); err != nil {
+		return "", fmt.Errorf("decode async result: %w", err)
+	}
+	if res.Status != model.AsyncJobStatusOK {
+		return "", fmt.Errorf("create job failed: %s", msg.Data)
+	}
+	return accepted.RoomID, nil
+}
+
+// send publishes on the client msg.send subject and waits for the async reply.
+func (c *client) send(roomID, msgID, content string) error {
+	requestID := idgen.GenerateRequestID()
+	replySub, err := c.nc.SubscribeSync(subject.UserResponse(c.account, requestID))
+	if err != nil {
+		return fmt.Errorf("subscribe send reply: %w", err)
+	}
+	defer func() { _ = replySub.Unsubscribe() }()
+	if err := c.nc.Flush(); err != nil {
+		return fmt.Errorf("flush send reply sub: %w", err)
+	}
+
+	body, err := json.Marshal(model.SendMessageRequest{ID: msgID, Content: content, RequestID: requestID})
+	if err != nil {
+		return fmt.Errorf("marshal send request: %w", err)
+	}
+	if err := c.nc.Publish(subject.MsgSend(c.account, roomID, *siteID), body); err != nil {
+		return fmt.Errorf("publish msg.send: %w", err)
+	}
+	if err := c.nc.Flush(); err != nil {
+		return fmt.Errorf("flush msg.send: %w", err)
+	}
+	reply, err := replySub.NextMsg(rpcTimeout)
+	if err != nil {
+		return fmt.Errorf("await send reply: %w", err)
+	}
+	if strings.Contains(string(reply.Data), `"code"`) {
+		return fmt.Errorf("send rejected: %s", reply.Data)
+	}
+	return nil
+}
+
+// loadHistory issues the msg.history RPC. When retry is set it keeps asking
+// until wantMsgID shows up, which is what a gap-detecting client would do.
+func (c *client) loadHistory(roomID string, retry bool, wantMsgID string) ([]histMsg, int) {
+	deadline := time.Now().Add(3 * time.Second)
+	tries := 0
+	var last []histMsg
+	for {
+		tries++
+		req := map[string]any{"limit": 50}
+		if *hint {
+			// A hint the client already holds: the room is at least as fresh as
+			// the event it just received. Without it the scan ceiling is the room
+			// doc's lastMsgAt, which the just-sent message has not reached yet.
+			req["meta"] = map[string]any{"lastMsgAt": time.Now().UTC().UnixMilli()}
+		}
+		body, err := json.Marshal(req)
+		if err != nil {
+			return nil, tries
+		}
+		reply, err := c.nc.Request(subject.MsgHistory(c.account, roomID, *siteID), body, rpcTimeout)
+		if err != nil {
+			c.rec.add(c.account, "history", "msg.history FAILED", "", err.Error())
+			return last, tries
+		}
+		var out historyReply
+		if err := json.Unmarshal(reply.Data, &out); err != nil {
+			c.rec.add(c.account, "history", "msg.history undecodable", "", trimTo(string(reply.Data), 60))
+			return last, tries
+		}
+		last = out.Messages
+		if !retry || wantMsgID == "" {
+			return last, tries
+		}
+		for _, m := range last {
+			if m.MessageID == wantMsgID {
+				return last, tries
+			}
+		}
+		if time.Now().After(deadline) {
+			return last, tries
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/tools/roomrace/e2e/main.go
+++ b/tools/roomrace/e2e/main.go
@@ -1,55 +1,59 @@
 // Command e2e drives the reported channel scenario against a real stack
 // (room-service, room-worker, message-gatekeeper, broadcast-worker,
-// message-worker, history-service) and reports, with timestamps, what each
-// client would have on screen.
+// message-worker, history-service) and reports what each client would have
+// on screen.
 //
-//	A creates a channel with B  ->  A waits for the async job result
-//	->  A sends the first message  ->  A "jumps into" the room
-//	->  what do A and B actually see, live and from history?
+//	alice creates a channel with bob  ->  alice waits for the async job result
+//	->  alice sends the first message  ->  alice "jumps into" the room
 //
-// Two client behaviours are run for A: subscribing to the room subject when it
-// opens the room (today), and subscribing as soon as its own subscription.update
-// arrives (the fix). B always subscribes on subscription.update, as the frontend does.
+// room-worker also emits two system messages (room_created, members_added), so
+// a correct client shows three messages.
+//
+// The point of -client-delay is the residual race: a client cannot subscribe
+// instantly, so with any delay at all the live path is lossy. What matters then
+// is whether the read path recovers every message, or whether a message can fall
+// between the two - delivered before the subscription was live, and not yet
+// readable when history was read.
 package main
 
 import (
-	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/nats-io/nats.go"
 
 	"github.com/hmchangw/chat/pkg/idgen"
-	"github.com/hmchangw/chat/pkg/model"
-	"github.com/hmchangw/chat/pkg/subject"
 )
 
 var (
-	natsURL   = flag.String("nats", "nats://localhost:4222", "NATS URL")
-	credsFile = flag.String("creds", "docker-local/backend.creds", "NATS creds file")
-	siteID    = flag.String("site", "site-local", "site id")
-	userA     = flag.String("a", "alice", "creator account")
-	userB     = flag.String("b", "bob", "invited account")
-	earlySub  = flag.Bool("early-sub", false, "A subscribes to the room subject on its own subscription.update instead of on room open")
-	backfill  = flag.Bool("retry-history", false, "retry the history load until it contains what the room's lastMsgId promises")
-	settle    = flag.Duration("settle", 3*time.Second, "how long to keep listening after the send")
-	hint      = flag.Bool("hint", false, "pass meta.lastMsgAt=now on msg.history so the scan ceiling is not the stale room doc")
-	probeRoom = flag.String("probe-room", "", "just load history for this room id and exit")
+	natsURL     = flag.String("nats", "nats://localhost:4222", "NATS URL")
+	credsFile   = flag.String("creds", "docker-local/backend.creds", "NATS creds file")
+	siteID      = flag.String("site", "site-local", "site id")
+	userA       = flag.String("a", "alice", "creator account")
+	userB       = flag.String("b", "bob", "invited account")
+	earlySub    = flag.Bool("early-sub", false, "clients subscribe to the room subject on subscription.update rather than on room open")
+	clientDelay = flag.Duration("client-delay", 0, "how long a client spends rendering before it subscribes")
+	backfill    = flag.Bool("retry-history", false, "retry the history load until it contains the sent message")
+	hint        = flag.Bool("hint", false, "pass meta.lastMsgAt=now on msg.history so the scan ceiling is not the stale room doc")
+	settle      = flag.Duration("settle", time.Second, "how long to keep listening after the send")
+	iterations  = flag.Int("iterations", 1, "how many rooms to run")
+	probeRoom   = flag.String("probe-room", "", "just load history for this room id and exit")
+	writeLag    = flag.Bool("write-lag", false, "after the send, poll hinted history every 5ms to measure when the message becomes readable")
+	verbose     = flag.Bool("v", false, "print the per-iteration timeline")
 )
 
-// ev is one observed event, with the offset from t0 at which it landed.
 type ev struct {
-	at      time.Duration
-	who     string
-	source  string
-	kind    string
-	msgID   string
-	content string
+	at     time.Duration
+	who    string
+	source string
+	kind   string
+	msgID  string
+	detail string
 }
 
 type recorder struct {
@@ -58,10 +62,10 @@ type recorder struct {
 	evs []ev
 }
 
-func (r *recorder) add(who, source, kind, msgID, content string) {
+func (r *recorder) add(who, source, kind, msgID, detail string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.evs = append(r.evs, ev{at: time.Since(r.t0), who: who, source: source, kind: kind, msgID: msgID, content: content})
+	r.evs = append(r.evs, ev{at: time.Since(r.t0), who: who, source: source, kind: kind, msgID: msgID, detail: detail})
 }
 
 func (r *recorder) snapshot() []ev {
@@ -72,9 +76,39 @@ func (r *recorder) snapshot() []ev {
 	return out
 }
 
+// seen is one user's outcome for one room.
+type seen struct {
+	live      map[string]bool
+	history   map[string]bool
+	writeLag  time.Duration
+	lagProbes int
+}
+
+func (s seen) union() map[string]bool {
+	out := map[string]bool{}
+	for k := range s.live {
+		out[k] = true
+	}
+	for k := range s.history {
+		out[k] = true
+	}
+	return out
+}
+
+type tally struct {
+	rooms        int
+	liveMissing  int
+	histMissing  int
+	doubleMissed int
+	expected     int
+	lagSum       time.Duration
+	lagMax       time.Duration
+	lagSamples   int
+}
+
 func main() {
 	flag.Parse()
-	if err := run(); err != nil {
+	if err := runAll(); err != nil {
 		fmt.Fprintf(os.Stderr, "e2e: %v\n", err)
 		os.Exit(1)
 	}
@@ -88,20 +122,36 @@ func connect(name string) (*nats.Conn, error) {
 	return nc, nil
 }
 
-func run() error {
-	rec := &recorder{t0: time.Now()}
-
+func runAll() error {
 	if *probeRoom != "" {
-		nc, err := connect("e2e-probe")
-		if err != nil {
+		return probe()
+	}
+
+	aTally, bTally := &tally{}, &tally{}
+	for i := range *iterations {
+		if err := runOne(i, aTally, bTally); err != nil {
 			return err
 		}
-		defer nc.Close()
-		c := newClient(*userA, nc, rec)
-		msgs, _ := c.loadHistory(*probeRoom, false, "")
-		fmt.Printf("probe room %s: msg.history returned %d %v\n", *probeRoom, len(msgs), summarize(msgs))
-		return nil
 	}
+	report(*userA, aTally)
+	report(*userB, bTally)
+	return nil
+}
+
+func probe() error {
+	nc, err := connect("e2e-probe")
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+	c := newClient(*userA, nc, &recorder{t0: time.Now()})
+	msgs, _ := c.loadHistory(*probeRoom, false, "")
+	fmt.Printf("probe room %s: msg.history returned %d %v\n", *probeRoom, len(msgs), summarize(msgs))
+	return nil
+}
+
+func runOne(i int, aTally, bTally *tally) error {
+	rec := &recorder{t0: time.Now()}
 
 	aConn, err := connect("e2e-" + *userA)
 	if err != nil {
@@ -116,6 +166,10 @@ func run() error {
 
 	a := newClient(*userA, aConn, rec)
 	b := newClient(*userB, bConn, rec)
+	a.renderDelay = *clientDelay
+	b.renderDelay = *clientDelay
+	a.subscribeOnUpdate = *earlySub
+	b.subscribeOnUpdate = true
 	if err := a.login(); err != nil {
 		return err
 	}
@@ -123,72 +177,116 @@ func run() error {
 		return err
 	}
 
-	if *earlySub {
-		a.subscribeOnUpdate = true
-	}
-	b.subscribeOnUpdate = true
-
-	roomName := fmt.Sprintf("e2e-%d", time.Now().UnixMilli())
-	roomID, err := a.createChannel(roomName, *userB)
+	roomID, err := a.createChannel(fmt.Sprintf("e2e-%d-%d", time.Now().UnixMilli(), i), *userB)
 	if err != nil {
 		return fmt.Errorf("create channel: %w", err)
 	}
-	rec.add(*userA, "rpc", "create-room async result ok", "", roomID)
 
 	msgID := idgen.GenerateMessageID()
 	if err := a.send(roomID, msgID, "first message"); err != nil {
 		return fmt.Errorf("send first message: %w", err)
 	}
-	rec.add(*userA, "rpc", "msg.send reply ok", msgID, "")
 
-	// "A's UI jumps into the room": subscribe (if it hasn't already) and load history.
+	var lag time.Duration
+	var probes int
+	if *writeLag {
+		lag, probes = a.measureWriteLag(roomID, msgID)
+	}
+
 	a.openRoom(roomID)
-	b.waitRoomOpen(roomID, 2*time.Second)
+	b.waitRoomOpen(roomID, 3*time.Second)
 
-	aHist, aTries := a.loadHistory(roomID, *backfill, msgID)
-	rec.add(*userA, "history", fmt.Sprintf("msg.history returned %d (tries %d)", len(aHist), aTries), "", "")
-	bHist, bTries := b.loadHistory(roomID, *backfill, msgID)
-	rec.add(*userB, "history", fmt.Sprintf("msg.history returned %d (tries %d)", len(bHist), bTries), "", "")
+	aHist, _ := a.loadHistory(roomID, *backfill, msgID)
+	bHist, _ := b.loadHistory(roomID, *backfill, msgID)
+	// When the client joined via subscription.update it already read history
+	// there; that earlier read is the one whose freshness is under test.
+	if jh, ok := a.joinHistory(roomID); ok {
+		aHist = jh
+	}
+	if jh, ok := b.joinHistory(roomID); ok {
+		bHist = jh
+	}
 
 	time.Sleep(*settle)
 
-	finalA, _ := a.loadHistory(roomID, false, "")
-	finalB, _ := b.loadHistory(roomID, false, "")
+	// Authority for "what should be on screen": every message the room actually holds.
+	final, _ := a.loadHistory(roomID, false, "")
+	expected := map[string]bool{}
+	for _, m := range final {
+		expected[m.MessageID] = true
+	}
+	expected[msgID] = true
 
-	printTimeline(rec.snapshot())
-	printScreen(*userA, a, aHist, finalA)
-	printScreen(*userB, b, bHist, finalB)
+	aSeen := seen{live: a.liveSet(), history: idSet(aHist), writeLag: lag, lagProbes: probes}
+	bSeen := seen{live: b.liveSet(), history: idSet(bHist)}
+	accumulate(aTally, expected, aSeen)
+	accumulate(bTally, expected, bSeen)
+
+	if *verbose {
+		printTimeline(rec.snapshot())
+	}
 	return nil
+}
+
+func accumulate(t *tally, expected map[string]bool, s seen) {
+	t.rooms++
+	t.expected += len(expected)
+	union := s.union()
+	for id := range expected {
+		if !s.live[id] {
+			t.liveMissing++
+		}
+		if !s.history[id] {
+			t.histMissing++
+		}
+		if !union[id] {
+			t.doubleMissed++
+		}
+	}
+	if s.lagProbes > 0 {
+		t.lagSamples++
+		t.lagSum += s.writeLag
+		if s.writeLag > t.lagMax {
+			t.lagMax = s.writeLag
+		}
+	}
+}
+
+func report(who string, t *tally) {
+	fmt.Printf("\n=== %s over %d room(s), %d expected message(s) ===\n", who, t.rooms, t.expected)
+	fmt.Printf("  missing from the live path      : %d (%.0f%%)\n", t.liveMissing, pct(t.liveMissing, t.expected))
+	fmt.Printf("  missing from the history read   : %d (%.0f%%)\n", t.histMissing, pct(t.histMissing, t.expected))
+	fmt.Printf("  MISSING FROM BOTH (lost)        : %d (%.0f%%)\n", t.doubleMissed, pct(t.doubleMissed, t.expected))
+	if t.lagSamples > 0 {
+		fmt.Printf("  send -> readable in history     : avg %v, max %v over %d sample(s)\n",
+			(t.lagSum / time.Duration(t.lagSamples)).Round(time.Millisecond), t.lagMax.Round(time.Millisecond), t.lagSamples)
+	}
+}
+
+func pct(n, d int) float64 {
+	if d == 0 {
+		return 0
+	}
+	return 100 * float64(n) / float64(d)
+}
+
+func idSet(ms []histMsg) map[string]bool {
+	out := map[string]bool{}
+	for _, m := range ms {
+		out[m.MessageID] = true
+	}
+	return out
 }
 
 func printTimeline(evs []ev) {
 	fmt.Printf("\n=== timeline ===\n")
 	for _, e := range evs {
-		detail := e.content
+		detail := e.detail
 		if e.msgID != "" {
-			detail = fmt.Sprintf("%s %s", e.msgID, e.content)
+			detail = e.msgID + " " + e.detail
 		}
 		fmt.Printf("  %7.0fms  %-6s %-14s %s\n", float64(e.at.Microseconds())/1000, e.who, e.source, trimTo(e.kind+" "+detail, 90))
 	}
-}
-
-func printScreen(who string, c *client, hist []histMsg, final []histMsg) {
-	c.mu.Lock()
-	live := append([]string(nil), c.liveMessages...)
-	c.mu.Unlock()
-
-	fmt.Printf("\n=== what %s has on screen ===\n", who)
-	fmt.Printf("  live room events received : %d %v\n", len(live), live)
-	fmt.Printf("  history at room-open      : %d %v\n", len(hist), summarize(hist))
-	fmt.Printf("  history after settle      : %d %v\n", len(final), summarize(final))
-	visible := map[string]bool{}
-	for _, m := range live {
-		visible[m] = true
-	}
-	for _, m := range hist {
-		visible[m.MessageID] = true
-	}
-	fmt.Printf("  VISIBLE when the room opens: %d message(s)\n", len(visible))
 }
 
 func summarize(ms []histMsg) []string {
@@ -210,7 +308,4 @@ func trimTo(s string, n int) string {
 	return s[:n-1] + "~"
 }
 
-var _ = context.Background
-var _ = model.CreateRoomRequest{}
-var _ = subject.RoomEvent
-var _ = json.Marshal
+var _ = strings.TrimSpace

--- a/tools/roomrace/e2e/main.go
+++ b/tools/roomrace/e2e/main.go
@@ -45,6 +45,7 @@ var (
 	probeRoom   = flag.String("probe-room", "", "just load history for this room id and exit")
 	writeLag    = flag.Bool("write-lag", false, "after the send, poll hinted history every 5ms to measure when the message becomes readable")
 	verbose     = flag.Bool("v", false, "print the per-iteration timeline")
+	historyAt   = flag.String("history-at", "join", "when the client reads history: join (on subscription.update) or open (after the send is accepted, i.e. when the UI enters the room)")
 )
 
 type ev struct {
@@ -170,6 +171,8 @@ func runOne(i int, aTally, bTally *tally) error {
 	b.renderDelay = *clientDelay
 	a.subscribeOnUpdate = *earlySub
 	b.subscribeOnUpdate = true
+	a.readHistoryOnJoin = *historyAt == "join"
+	b.readHistoryOnJoin = *historyAt == "join"
 	if err := a.login(); err != nil {
 		return err
 	}
@@ -182,10 +185,13 @@ func runOne(i int, aTally, bTally *tally) error {
 		return fmt.Errorf("create channel: %w", err)
 	}
 
+	rec.add(*userA, "rpc", "create-room async job result ok", "", roomID)
+
 	msgID := idgen.GenerateMessageID()
 	if err := a.send(roomID, msgID, "first message"); err != nil {
 		return fmt.Errorf("send first message: %w", err)
 	}
+	rec.add(*userA, "rpc", "msg.send accepted by gatekeeper", msgID, "")
 
 	var lag time.Duration
 	var probes int
@@ -197,7 +203,9 @@ func runOne(i int, aTally, bTally *tally) error {
 	b.waitRoomOpen(roomID, 3*time.Second)
 
 	aHist, _ := a.loadHistory(roomID, *backfill, msgID)
+	rec.add(*userA, "history", fmt.Sprintf("room-open msg.history returned %d", len(aHist)), "", "")
 	bHist, _ := b.loadHistory(roomID, *backfill, msgID)
+	rec.add(*userB, "history", fmt.Sprintf("room-open msg.history returned %d", len(bHist)), "", "")
 	// When the client joined via subscription.update it already read history
 	// there; that earlier read is the one whose freshness is under test.
 	if jh, ok := a.joinHistory(roomID); ok {

--- a/tools/roomrace/e2e/main.go
+++ b/tools/roomrace/e2e/main.go
@@ -45,6 +45,7 @@ var (
 	probeRoom   = flag.String("probe-room", "", "just load history for this room id and exit")
 	writeLag    = flag.Bool("write-lag", false, "after the send, poll hinted history every 5ms to measure when the message becomes readable")
 	verbose     = flag.Bool("v", false, "print the per-iteration timeline")
+	debugFlow   = flag.Bool("debug-flow", false, "set X-Debug: flow on room.create so the services emit flow-rung timing breadcrumbs")
 	historyAt   = flag.String("history-at", "join", "when the client reads history: join (on subscription.update) or open (after the send is accepted, i.e. when the UI enters the room)")
 )
 

--- a/tools/roomrace/e2e/main.go
+++ b/tools/roomrace/e2e/main.go
@@ -45,6 +45,7 @@ var (
 	probeRoom   = flag.String("probe-room", "", "just load history for this room id and exit")
 	writeLag    = flag.Bool("write-lag", false, "after the send, poll hinted history every 5ms to measure when the message becomes readable")
 	verbose     = flag.Bool("v", false, "print the per-iteration timeline")
+	asDM        = flag.Bool("dm", false, "create a DM instead of a channel (no name -> room-service classifies it as a DM)")
 	debugFlow   = flag.Bool("debug-flow", false, "set X-Debug: flow on room.create so the services emit flow-rung timing breadcrumbs")
 	historyAt   = flag.String("history-at", "join", "when the client reads history: join (on subscription.update) or open (after the send is accepted, i.e. when the UI enters the room)")
 )
@@ -181,7 +182,11 @@ func runOne(i int, aTally, bTally *tally) error {
 		return err
 	}
 
-	roomID, err := a.createChannel(fmt.Sprintf("e2e-%d-%d", time.Now().UnixMilli(), i), *userB)
+	name := fmt.Sprintf("e2e-%d-%d", time.Now().UnixMilli(), i)
+	if *asDM {
+		name = "" // room-service classifies an unnamed single-counterpart create as a DM
+	}
+	roomID, err := a.createChannel(name, *userB)
 	if err != nil {
 		return fmt.Errorf("create channel: %w", err)
 	}

--- a/tools/roomrace/e2e/main.go
+++ b/tools/roomrace/e2e/main.go
@@ -1,0 +1,216 @@
+// Command e2e drives the reported channel scenario against a real stack
+// (room-service, room-worker, message-gatekeeper, broadcast-worker,
+// message-worker, history-service) and reports, with timestamps, what each
+// client would have on screen.
+//
+//	A creates a channel with B  ->  A waits for the async job result
+//	->  A sends the first message  ->  A "jumps into" the room
+//	->  what do A and B actually see, live and from history?
+//
+// Two client behaviours are run for A: subscribing to the room subject when it
+// opens the room (today), and subscribing as soon as its own subscription.update
+// arrives (the fix). B always subscribes on subscription.update, as the frontend does.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/hmchangw/chat/pkg/idgen"
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+var (
+	natsURL   = flag.String("nats", "nats://localhost:4222", "NATS URL")
+	credsFile = flag.String("creds", "docker-local/backend.creds", "NATS creds file")
+	siteID    = flag.String("site", "site-local", "site id")
+	userA     = flag.String("a", "alice", "creator account")
+	userB     = flag.String("b", "bob", "invited account")
+	earlySub  = flag.Bool("early-sub", false, "A subscribes to the room subject on its own subscription.update instead of on room open")
+	backfill  = flag.Bool("retry-history", false, "retry the history load until it contains what the room's lastMsgId promises")
+	settle    = flag.Duration("settle", 3*time.Second, "how long to keep listening after the send")
+	hint      = flag.Bool("hint", false, "pass meta.lastMsgAt=now on msg.history so the scan ceiling is not the stale room doc")
+	probeRoom = flag.String("probe-room", "", "just load history for this room id and exit")
+)
+
+// ev is one observed event, with the offset from t0 at which it landed.
+type ev struct {
+	at      time.Duration
+	who     string
+	source  string
+	kind    string
+	msgID   string
+	content string
+}
+
+type recorder struct {
+	mu  sync.Mutex
+	t0  time.Time
+	evs []ev
+}
+
+func (r *recorder) add(who, source, kind, msgID, content string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.evs = append(r.evs, ev{at: time.Since(r.t0), who: who, source: source, kind: kind, msgID: msgID, content: content})
+}
+
+func (r *recorder) snapshot() []ev {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := append([]ev(nil), r.evs...)
+	sort.SliceStable(out, func(i, j int) bool { return out[i].at < out[j].at })
+	return out
+}
+
+func main() {
+	flag.Parse()
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "e2e: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func connect(name string) (*nats.Conn, error) {
+	nc, err := nats.Connect(*natsURL, nats.Name(name), nats.UserCredentials(*credsFile))
+	if err != nil {
+		return nil, fmt.Errorf("connect %s: %w", name, err)
+	}
+	return nc, nil
+}
+
+func run() error {
+	rec := &recorder{t0: time.Now()}
+
+	if *probeRoom != "" {
+		nc, err := connect("e2e-probe")
+		if err != nil {
+			return err
+		}
+		defer nc.Close()
+		c := newClient(*userA, nc, rec)
+		msgs, _ := c.loadHistory(*probeRoom, false, "")
+		fmt.Printf("probe room %s: msg.history returned %d %v\n", *probeRoom, len(msgs), summarize(msgs))
+		return nil
+	}
+
+	aConn, err := connect("e2e-" + *userA)
+	if err != nil {
+		return err
+	}
+	defer aConn.Close()
+	bConn, err := connect("e2e-" + *userB)
+	if err != nil {
+		return err
+	}
+	defer bConn.Close()
+
+	a := newClient(*userA, aConn, rec)
+	b := newClient(*userB, bConn, rec)
+	if err := a.login(); err != nil {
+		return err
+	}
+	if err := b.login(); err != nil {
+		return err
+	}
+
+	if *earlySub {
+		a.subscribeOnUpdate = true
+	}
+	b.subscribeOnUpdate = true
+
+	roomName := fmt.Sprintf("e2e-%d", time.Now().UnixMilli())
+	roomID, err := a.createChannel(roomName, *userB)
+	if err != nil {
+		return fmt.Errorf("create channel: %w", err)
+	}
+	rec.add(*userA, "rpc", "create-room async result ok", "", roomID)
+
+	msgID := idgen.GenerateMessageID()
+	if err := a.send(roomID, msgID, "first message"); err != nil {
+		return fmt.Errorf("send first message: %w", err)
+	}
+	rec.add(*userA, "rpc", "msg.send reply ok", msgID, "")
+
+	// "A's UI jumps into the room": subscribe (if it hasn't already) and load history.
+	a.openRoom(roomID)
+	b.waitRoomOpen(roomID, 2*time.Second)
+
+	aHist, aTries := a.loadHistory(roomID, *backfill, msgID)
+	rec.add(*userA, "history", fmt.Sprintf("msg.history returned %d (tries %d)", len(aHist), aTries), "", "")
+	bHist, bTries := b.loadHistory(roomID, *backfill, msgID)
+	rec.add(*userB, "history", fmt.Sprintf("msg.history returned %d (tries %d)", len(bHist), bTries), "", "")
+
+	time.Sleep(*settle)
+
+	finalA, _ := a.loadHistory(roomID, false, "")
+	finalB, _ := b.loadHistory(roomID, false, "")
+
+	printTimeline(rec.snapshot())
+	printScreen(*userA, a, aHist, finalA)
+	printScreen(*userB, b, bHist, finalB)
+	return nil
+}
+
+func printTimeline(evs []ev) {
+	fmt.Printf("\n=== timeline ===\n")
+	for _, e := range evs {
+		detail := e.content
+		if e.msgID != "" {
+			detail = fmt.Sprintf("%s %s", e.msgID, e.content)
+		}
+		fmt.Printf("  %7.0fms  %-6s %-14s %s\n", float64(e.at.Microseconds())/1000, e.who, e.source, trimTo(e.kind+" "+detail, 90))
+	}
+}
+
+func printScreen(who string, c *client, hist []histMsg, final []histMsg) {
+	c.mu.Lock()
+	live := append([]string(nil), c.liveMessages...)
+	c.mu.Unlock()
+
+	fmt.Printf("\n=== what %s has on screen ===\n", who)
+	fmt.Printf("  live room events received : %d %v\n", len(live), live)
+	fmt.Printf("  history at room-open      : %d %v\n", len(hist), summarize(hist))
+	fmt.Printf("  history after settle      : %d %v\n", len(final), summarize(final))
+	visible := map[string]bool{}
+	for _, m := range live {
+		visible[m] = true
+	}
+	for _, m := range hist {
+		visible[m.MessageID] = true
+	}
+	fmt.Printf("  VISIBLE when the room opens: %d message(s)\n", len(visible))
+}
+
+func summarize(ms []histMsg) []string {
+	out := make([]string, 0, len(ms))
+	for _, m := range ms {
+		label := m.Msg
+		if m.Type != "" {
+			label = "[" + m.Type + "]"
+		}
+		out = append(out, label)
+	}
+	return out
+}
+
+func trimTo(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "~"
+}
+
+var _ = context.Background
+var _ = model.CreateRoomRequest{}
+var _ = subject.RoomEvent
+var _ = json.Marshal

--- a/tools/roomrace/e2e/stack.sh
+++ b/tools/roomrace/e2e/stack.sh
@@ -16,7 +16,10 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 RUN=${RUN_DIR:-/tmp/roomrace-e2e}
 BIN=$RUN/bin
 LOGS=$RUN/logs
-SERVICES="room-service room-worker message-gatekeeper broadcast-worker message-worker history-service"
+# inbox-worker owns the INBOX stream. Without it, room-worker's create path blocks
+# on a PubAck that never comes and the creator's async job result is ~500ms late -
+# an artifact that makes the client flow look far safer than it is.
+SERVICES="room-service room-worker message-gatekeeper broadcast-worker message-worker history-service inbox-worker"
 
 export NATS_URL=nats://localhost:4222
 export NATS_CREDS_FILE=$ROOT/docker-local/backend.creds
@@ -44,6 +47,7 @@ port_for() {
     broadcast-worker) echo 18084 ;;
     message-worker) echo 18085 ;;
     history-service) echo 18086 ;;
+    inbox-worker) echo 18087 ;;
   esac
 }
 

--- a/tools/roomrace/e2e/stack.sh
+++ b/tools/roomrace/e2e/stack.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Brings up a minimal real stack for the channel first-message E2E:
+#   deps      : NATS (operator JWT), MongoDB, Cassandra, Valkey
+#   services  : room-service, room-worker, message-gatekeeper,
+#               broadcast-worker, message-worker, history-service
+#
+# Services run as host processes against the containerised deps - far quicker
+# than building six images, and the binaries are the real ones.
+#
+#   ./tools/roomrace/e2e/stack.sh up      # deps + seed + services
+#   ./tools/roomrace/e2e/stack.sh down
+#   ./tools/roomrace/e2e/stack.sh logs <service>
+set -euo pipefail
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
+RUN=${RUN_DIR:-/tmp/roomrace-e2e}
+BIN=$RUN/bin
+LOGS=$RUN/logs
+SERVICES="room-service room-worker message-gatekeeper broadcast-worker message-worker history-service"
+
+export NATS_URL=nats://localhost:4222
+export NATS_CREDS_FILE=$ROOT/docker-local/backend.creds
+export SITE_ID=site-local
+export ALL_SITE_IDS=site-local
+export MONGO_URI="mongodb://localhost:27017/?directConnection=true"
+export MONGO_DB=chat
+# primary, not secondaryPreferred: this test measures read-after-write timing and
+# a secondary read would add staleness that is not the effect under study.
+export MONGO_READ_PREFERENCE=primary
+export CASSANDRA_HOSTS=localhost
+export CASSANDRA_KEYSPACE=chat
+export VALKEY_ADDRS=localhost:6379
+export BOOTSTRAP_STREAMS=true
+export ATREST_ENABLED=false      # skips Vault
+export ENCRYPTION_ENABLED=false  # plaintext room events, so the E2E client can read them
+export ROOM_SUBJECT_MODE=dual    # compose default: same-site rooms publish local AND global
+export O11Y_ENABLED=false
+
+port_for() {
+  case $1 in
+    room-service) echo 18081 ;;
+    room-worker) echo 18082 ;;
+    message-gatekeeper) echo 18083 ;;
+    broadcast-worker) echo 18084 ;;
+    message-worker) echo 18085 ;;
+    history-service) echo 18086 ;;
+  esac
+}
+
+up() {
+  mkdir -p "$BIN" "$LOGS"
+
+  grep -qE "^127\.0\.0\.1 .*valkey" /etc/hosts || \
+    echo "127.0.0.1 valkey mongodb cassandra nats" >> /etc/hosts
+
+  [ -f "$ROOT/docker-local/backend.creds" ] || "$ROOT/docker-local/setup.sh"
+
+  docker compose -f "$ROOT/docker-local/compose.deps.yaml" up -d --wait nats mongodb cassandra valkey
+  # A warm Cassandra volume makes the init report "already exists"; that is fine.
+  docker compose -f "$ROOT/docker-local/compose.deps.yaml" --profile init run --rm cassandra-init || true
+  (cd "$ROOT" && go run ./tools/seed-sample-data)
+
+  for s in $SERVICES; do
+    pkg=./$s
+    [ "$s" = history-service ] && pkg=./history-service/cmd
+    (cd "$ROOT" && go build -o "$BIN/$s" "$pkg")
+  done
+
+  for s in $SERVICES; do
+    p=$(port_for "$s")
+    env HEALTH_ADDR=":$p" METRICS_ADDR=":$((p + 100))" \
+        $( [ "$s" = broadcast-worker ] && echo MODE=user ) \
+        "$BIN/$s" > "$LOGS/$s.log" 2>&1 &
+    echo $! > "$RUN/$s.pid"
+  done
+
+  echo "waiting for services to report healthy..."
+  for s in $SERVICES; do
+    p=$(port_for "$s")
+    for _ in $(seq 1 60); do
+      curl -sf "http://127.0.0.1:$p/healthz" >/dev/null 2>&1 && break
+      sleep 1
+    done
+    printf '  %-20s %s\n' "$s" "$(curl -sf "http://127.0.0.1:$p/healthz" >/dev/null 2>&1 && echo healthy || echo UNHEALTHY)"
+  done
+}
+
+down() {
+  for s in $SERVICES; do
+    [ -f "$RUN/$s.pid" ] && kill "$(cat "$RUN/$s.pid")" 2>/dev/null || true
+    rm -f "$RUN/$s.pid"
+  done
+  docker compose -f "$ROOT/docker-local/compose.deps.yaml" down -v
+}
+
+case "${1:-up}" in
+  up) up ;;
+  down) down ;;
+  logs) tail -n 100 -f "$LOGS/${2:?service name}.log" ;;
+  *) echo "usage: $0 {up|down|logs <service>}" >&2; exit 1 ;;
+esac

--- a/tools/roomrace/interest.go
+++ b/tools/roomrace/interest.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+// interestWindow is how long after Subscribe() returns a publisher on the
+// services connection actually starts reaching the new subscription. This is
+// the floor under Problem 2: no client can subscribe faster than this.
+type interestWindow struct {
+	Samples       int   `json:"samples"`
+	Delivered     int   `json:"delivered"`
+	MedianMicros  int64 `json:"medianMicros"`
+	P95Micros     int64 `json:"p95Micros"`
+	MaxMicros     int64 `json:"maxMicros"`
+	FlushRTTMicro int64 `json:"flushRttMicros"`
+}
+
+func measureInterestWindow(subURL string, pub *nats.Conn, samples int) (interestWindow, error) {
+	sc, err := nats.Connect(subURL, nats.Name("roomrace-interest"))
+	if err != nil {
+		return interestWindow{}, fmt.Errorf("connect %s: %w", subURL, err)
+	}
+	defer sc.Close()
+
+	out := interestWindow{Samples: samples}
+	windows := make([]time.Duration, 0, samples)
+	flushes := make([]time.Duration, 0, samples)
+
+	for i := range samples {
+		subj := fmt.Sprintf("roomrace.interest.%d.%d", time.Now().UnixNano(), i)
+		stop := make(chan struct{})
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			buf := make([]byte, 8)
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				binary.BigEndian.PutUint64(buf, uint64(time.Now().UnixNano()))
+				if err := pub.Publish(subj, buf); err != nil {
+					return
+				}
+				if err := pub.Flush(); err != nil {
+					return
+				}
+				time.Sleep(200 * time.Microsecond)
+			}
+		}()
+
+		first := make(chan int64, 1)
+		t0 := time.Now()
+		sub, err := sc.Subscribe(subj, func(m *nats.Msg) {
+			if len(m.Data) != 8 {
+				return
+			}
+			select {
+			case first <- int64(binary.BigEndian.Uint64(m.Data)):
+			default:
+			}
+		})
+		if err != nil {
+			close(stop)
+			<-done
+			return interestWindow{}, fmt.Errorf("subscribe probe: %w", err)
+		}
+
+		select {
+		case ns := <-first:
+			d := time.Duration(ns - t0.UnixNano())
+			if d < 0 {
+				d = 0
+			}
+			windows = append(windows, d)
+			out.Delivered++
+		case <-time.After(3 * time.Second):
+		}
+
+		tf := time.Now()
+		_ = sc.Flush()
+		flushes = append(flushes, time.Since(tf))
+
+		close(stop)
+		<-done
+		_ = sub.Unsubscribe()
+	}
+
+	out.MedianMicros = quantileMicros(windows, 0.5)
+	out.P95Micros = quantileMicros(windows, 0.95)
+	out.MaxMicros = quantileMicros(windows, 1.0)
+	out.FlushRTTMicro = quantileMicros(flushes, 0.5)
+	return out, nil
+}
+
+func quantileMicros(ds []time.Duration, q float64) int64 {
+	if len(ds) == 0 {
+		return 0
+	}
+	sorted := append([]time.Duration(nil), ds...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	idx := int(q * float64(len(sorted)-1))
+	return sorted[idx].Microseconds()
+}

--- a/tools/roomrace/main.go
+++ b/tools/roomrace/main.go
@@ -1,0 +1,129 @@
+// Command roomrace reproduces and measures the two new-room -> first-message
+// races against a real NATS server, using the production subject builders from
+// pkg/subject so the topology under test matches what the services publish.
+//
+//	problem 1 (DM)      : new_message rides chat.user.{B}.event.room, which B
+//	                      holds from login. Loss is decided by the CLIENT.
+//	problem 2 (channel) : new_message rides chat.room.{id}.event, which B only
+//	                      subscribes to after handling subscription.update.
+//	                      Loss is decided by the TRANSPORT.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+type options struct {
+	subURL     string
+	pubURL     string
+	label      string
+	iterations int
+	renderMS   int
+	sendMS     string
+	settleMS   int
+	jsonOut    bool
+}
+
+func main() {
+	var opt options
+	flag.StringVar(&opt.subURL, "sub-url", nats.DefaultURL, "NATS URL the simulated client B connects to")
+	flag.StringVar(&opt.pubURL, "pub-url", "", "NATS URL the simulated services publish from (default: same as -sub-url)")
+	flag.StringVar(&opt.label, "label", "single-server", "label for this topology in the report")
+	flag.IntVar(&opt.iterations, "iterations", 200, "iterations per data point")
+	flag.IntVar(&opt.renderMS, "render-ms", 30, "client B: ms spent rendering the new room before it subscribes / accepts messages")
+	flag.StringVar(&opt.sendMS, "send-ms", "0,1,5,10,25,50,100", "comma-separated delays between subscription.update and the first message")
+	flag.IntVar(&opt.settleMS, "settle-ms", 400, "ms to wait for late delivery before declaring a message lost")
+	flag.BoolVar(&opt.jsonOut, "json", false, "emit JSON instead of tables")
+	flag.Parse()
+
+	if opt.pubURL == "" {
+		opt.pubURL = opt.subURL
+	}
+
+	rep, err := run(&opt)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "roomrace: %v\n", err)
+		os.Exit(1)
+	}
+
+	if opt.jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(rep); err != nil {
+			fmt.Fprintf(os.Stderr, "roomrace: encode report: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	rep.print()
+}
+
+func parseDelays(s string) ([]time.Duration, error) {
+	parts := strings.Split(s, ",")
+	out := make([]time.Duration, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, fmt.Errorf("parse send delay %q: %w", p, err)
+		}
+		out = append(out, time.Duration(n)*time.Millisecond)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no send delays given")
+	}
+	return out, nil
+}
+
+func run(opt *options) (*report, error) {
+	delays, err := parseDelays(opt.sendMS)
+	if err != nil {
+		return nil, err
+	}
+
+	svc, err := newServices(opt.pubURL)
+	if err != nil {
+		return nil, fmt.Errorf("connect services conn: %w", err)
+	}
+	defer svc.close()
+
+	rep := &report{
+		Topology:   opt.label,
+		SubURL:     opt.subURL,
+		PubURL:     opt.pubURL,
+		Iterations: opt.iterations,
+		RenderMS:   opt.renderMS,
+	}
+
+	rep.InterestWindow, err = measureInterestWindow(opt.subURL, svc.nc, 40)
+	if err != nil {
+		return nil, fmt.Errorf("measure interest window: %w", err)
+	}
+
+	for _, sc := range scenarios() {
+		row := scenarioResult{Scenario: sc.name, Kind: string(sc.kind), Fix: sc.fix}
+		for _, d := range delays {
+			o, err := runScenario(opt, svc, sc, d)
+			if err != nil {
+				return nil, fmt.Errorf("scenario %s at %s: %w", sc.name, d, err)
+			}
+			o.SendMS = int(d / time.Millisecond)
+			row.Points = append(row.Points, o)
+		}
+		rep.Scenarios = append(rep.Scenarios, row)
+	}
+	return rep, nil
+}

--- a/tools/roomrace/report.go
+++ b/tools/roomrace/report.go
@@ -1,0 +1,82 @@
+package main
+
+import "fmt"
+
+type scenarioResult struct {
+	Scenario string    `json:"scenario"`
+	Kind     string    `json:"kind"`
+	Fix      string    `json:"fix"`
+	Points   []outcome `json:"points"`
+}
+
+type report struct {
+	Topology       string           `json:"topology"`
+	SubURL         string           `json:"subUrl"`
+	PubURL         string           `json:"pubUrl"`
+	Iterations     int              `json:"iterations"`
+	RenderMS       int              `json:"renderMs"`
+	InterestWindow interestWindow   `json:"interestWindow"`
+	Scenarios      []scenarioResult `json:"scenarios"`
+}
+
+func (r *report) print() {
+	fmt.Printf("\n=== roomrace: %s ===\n", r.Topology)
+	fmt.Printf("client B  -> %s\n", r.SubURL)
+	fmt.Printf("services  -> %s\n", r.PubURL)
+	fmt.Printf("iterations per point: %d   client render delay: %dms\n\n", r.Iterations, r.RenderMS)
+
+	iw := r.InterestWindow
+	fmt.Printf("subscription interest window (Subscribe() -> publisher actually reaches it)\n")
+	fmt.Printf("  samples %d, delivered %d | median %dus  p95 %dus  max %dus | Flush() RTT median %dus\n\n",
+		iw.Samples, iw.Delivered, iw.MedianMicros, iw.P95Micros, iw.MaxMicros, iw.FlushRTTMicro)
+
+	if len(r.Scenarios) == 0 {
+		return
+	}
+	header := r.Scenarios[0].Points
+	fmt.Printf("%-46s %-22s", "scenario", "fix")
+	for _, p := range header {
+		fmt.Printf(" %7s", fmt.Sprintf("+%dms", p.SendMS))
+	}
+	fmt.Printf("\n%s\n", dashes(46+1+22+8*len(header)))
+
+	for _, s := range r.Scenarios {
+		fmt.Printf("%-46s %-22s", trunc(s.Scenario, 46), trunc(s.Fix, 22))
+		for _, p := range s.Points {
+			fmt.Printf(" %6.0f%%", p.MissRate*100)
+		}
+		fmt.Println()
+	}
+	fmt.Printf("\n(cell = %% of first messages user B never saw; columns = delay between\n")
+	fmt.Printf(" subscription.update and the first message)\n\n")
+
+	fmt.Printf("%-46s %8s %8s %8s %8s %8s\n", "detail (totals across all delays)", "live", "recover", "missed", "dropped", "dupes")
+	fmt.Printf("%s\n", dashes(46+5*9))
+	for _, s := range r.Scenarios {
+		var live, rec, miss, drop, dup int
+		for _, p := range s.Points {
+			live += p.Live
+			rec += p.Recovered
+			miss += p.Missed
+			drop += p.Dropped
+			dup += p.Duplicates
+		}
+		fmt.Printf("%-46s %8d %8d %8d %8d %8d\n", trunc(s.Scenario, 46), live, rec, miss, drop, dup)
+	}
+	fmt.Println()
+}
+
+func dashes(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = '-'
+	}
+	return string(b)
+}
+
+func trunc(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "~"
+}

--- a/tools/roomrace/run.sh
+++ b/tools/roomrace/run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+# Reproduces the two new-room -> first-message races against real NATS.
+#
+#   ./tools/roomrace/run.sh            # single server + 3-node cluster
+#   ./tools/roomrace/run.sh --keep     # leave the NATS containers running
+#
+# Requires a running Docker daemon. Nothing else in the stack is needed: the
+# harness speaks the production subjects (pkg/subject) directly.
+set -e
+
+DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+ROOT=$(CDPATH= cd -- "$DIR/../.." && pwd)
+DELAYS=${DELAYS:-0,10,20,25,28,30,32,35,40}
+ITER=${ITER:-40}
+RENDER=${RENDER:-30}
+
+cleanup() {
+  [ "$1" = "--keep" ] && return 0
+  docker compose -f "$DIR/docker-compose.yml" down -v >/dev/null 2>&1 || true
+}
+trap 'cleanup "$1"' EXIT
+
+docker compose -f "$DIR/docker-compose.yml" up -d --wait
+
+echo "### single server ###"
+(cd "$ROOT" && go run ./tools/roomrace \
+  -label "single-server" \
+  -sub-url nats://127.0.0.1:4222 -pub-url nats://127.0.0.1:4222 \
+  -iterations "$ITER" -render-ms "$RENDER" -settle-ms 120 -send-ms "$DELAYS")
+
+echo
+echo "### 3-node cluster (client B on node a, services on node b) ###"
+(cd "$ROOT" && go run ./tools/roomrace \
+  -label "3-node cluster (B on a, services on b)" \
+  -sub-url nats://127.0.0.1:4223 -pub-url nats://127.0.0.1:4224 \
+  -iterations "$ITER" -render-ms "$RENDER" -settle-ms 120 -send-ms "$DELAYS")

--- a/tools/roomrace/scenario.go
+++ b/tools/roomrace/scenario.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+const (
+	accountB = "bob"
+	siteID   = "site-local"
+)
+
+type roomKind string
+
+const (
+	kindDM      roomKind = "dm"
+	kindChannel roomKind = "channel"
+)
+
+// scenario models one (transport shape, client behaviour) pair.
+type scenario struct {
+	name string
+	kind roomKind
+	fix  string
+
+	// dropsUnknownRoom: the client discards a room event whose room is not in
+	// local state yet - the behaviour Problem 1 describes.
+	dropsUnknownRoom bool
+	// subscribeOnUpdate: the client opens chat.room.{id}.event when it handles
+	// subscription.update - the behaviour Problem 2 describes.
+	subscribeOnUpdate bool
+	flushAfterSub     bool
+	backfillAfterSub  bool
+	// graceWindow: the SERVER additionally publishes the channel room event to
+	// chat.user.{account}.event.room for freshly joined members.
+	graceWindow bool
+}
+
+func scenarios() []scenario {
+	return []scenario{
+		{name: "dm / client drops unknown room", kind: kindDM, fix: "none (today)", dropsUnknownRoom: true},
+		{name: "dm / client buffers unknown room", kind: kindDM, fix: "client tolerates", dropsUnknownRoom: false},
+
+		{name: "channel / subscribe on update", kind: kindChannel, fix: "none (today)", subscribeOnUpdate: true},
+		{name: "channel / subscribe + flush", kind: kindChannel, fix: "client flush", subscribeOnUpdate: true, flushAfterSub: true},
+		{name: "channel / subscribe + flush + backfill", kind: kindChannel, fix: "client backfill", subscribeOnUpdate: true, flushAfterSub: true, backfillAfterSub: true},
+		{name: "channel / server join grace window", kind: kindChannel, fix: "server grace window", subscribeOnUpdate: true, flushAfterSub: true, graceWindow: true},
+		{name: "channel / grace window, client still drops", kind: kindChannel, fix: "server only", subscribeOnUpdate: true, flushAfterSub: true, graceWindow: true, dropsUnknownRoom: true},
+	}
+}
+
+// roomEvent is the shape the harness publishes; only the fields the race turns
+// on are modelled (pkg/model.RoomEvent carries far more).
+type roomEvent struct {
+	Type      string `json:"type"`
+	RoomID    string `json:"roomId"`
+	LastMsgID string `json:"lastMsgId"`
+}
+
+type subUpdate struct {
+	Action string `json:"action"`
+	RoomID string `json:"roomId"`
+	Kind   string `json:"roomType"`
+}
+
+// services is the server side: room-worker's subscription.update publish,
+// broadcast-worker's fan-out, and a history-service stand-in that serves the
+// backfill on the real msg.history subject.
+type services struct {
+	nc      *nats.Conn
+	mu      sync.Mutex
+	stored  map[string][]string
+	histSub *nats.Subscription
+}
+
+func newServices(url string) (*services, error) {
+	nc, err := nats.Connect(url, nats.Name("roomrace-services"))
+	if err != nil {
+		return nil, fmt.Errorf("connect %s: %w", url, err)
+	}
+	s := &services{nc: nc, stored: map[string][]string{}}
+	sub, err := nc.Subscribe(subject.MsgHistoryWildcard(siteID), func(m *nats.Msg) {
+		_, roomID, ok := subject.ParseUserRoomSubject(m.Subject)
+		if !ok {
+			return
+		}
+		s.mu.Lock()
+		ids := append([]string(nil), s.stored[roomID]...)
+		s.mu.Unlock()
+		data, err := json.Marshal(map[string]any{"messages": ids})
+		if err != nil {
+			return
+		}
+		_ = m.Respond(data)
+	})
+	if err != nil {
+		nc.Close()
+		return nil, fmt.Errorf("subscribe history stub: %w", err)
+	}
+	s.histSub = sub
+	if err := nc.Flush(); err != nil {
+		nc.Close()
+		return nil, fmt.Errorf("flush history stub: %w", err)
+	}
+	return s, nil
+}
+
+func (s *services) close() {
+	if s.histSub != nil {
+		_ = s.histSub.Unsubscribe()
+	}
+	_ = s.nc.Drain()
+}
+
+// persist models message-worker writing to Cassandra: the message is durable
+// server-side, which is what makes a backfill able to recover it.
+func (s *services) persist(roomID, msgID string) {
+	s.mu.Lock()
+	s.stored[roomID] = append(s.stored[roomID], msgID)
+	s.mu.Unlock()
+}
+
+func (s *services) publishSubscriptionAdded(roomID string, kind roomKind) error {
+	data, err := json.Marshal(subUpdate{Action: "added", RoomID: roomID, Kind: string(kind)})
+	if err != nil {
+		return fmt.Errorf("marshal subscription.update: %w", err)
+	}
+	if err := s.nc.Publish(subject.SubscriptionUpdate(accountB), data); err != nil {
+		return fmt.Errorf("publish subscription.update: %w", err)
+	}
+	return s.nc.Flush()
+}
+
+// publishNewMessage mirrors broadcast-worker: DMs fan out per member on the
+// user subject, channels go once to the room subject.
+func (s *services) publishNewMessage(roomID, msgID string, sc scenario) error {
+	data, err := json.Marshal(roomEvent{Type: "new_message", RoomID: roomID, LastMsgID: msgID})
+	if err != nil {
+		return fmt.Errorf("marshal room event: %w", err)
+	}
+	if sc.kind == kindDM {
+		if err := s.nc.Publish(subject.UserRoomEvent(accountB), data); err != nil {
+			return fmt.Errorf("publish dm event: %w", err)
+		}
+		return s.nc.Flush()
+	}
+	if err := s.nc.Publish(subject.RoomEvent(roomID, true), data); err != nil {
+		return fmt.Errorf("publish room event: %w", err)
+	}
+	if sc.graceWindow {
+		if err := s.nc.Publish(subject.UserRoomEvent(accountB), data); err != nil {
+			return fmt.Errorf("publish grace-window copy: %w", err)
+		}
+	}
+	return s.nc.Flush()
+}


### PR DESCRIPTION
Breaks the reported "B misses new_message after DM create" symptom into three
distinct races (sender-side gatekeeper rejection, channel room-subject interest
propagation, client unknown-room drop), documents which delivery path each
applies to, compares seven solution shapes against how Zulip/Slack/Matrix/
Discord solve it, evaluates the proposed combined create+send RPC, and
recommends a phased plan.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LYFshq6qDzRpktMQ91Za5V

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional, configurable join-grace window for channel events.
  - Recently joined members may receive new messages through both room and personal event streams, improving first-message delivery reliability.
  - Bot accounts are excluded from additional delivery.
  - Malformed join notices are safely ignored without disrupting message delivery.

- **Documentation**
  - Documented the disabled-by-default `JOIN_GRACE` behavior.
  - Clients should deduplicate events by message ID and accept room events before receiving the corresponding room subscription update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->