### PR TITLE
fix(user-service): compile badge_test against the ActiveSubscription return type

### DIFF
--- a/user-service/service/badge_test.go
+++ b/user-service/service/badge_test.go
@@ -221,9 +221,9 @@ func TestBadgeCountBatch_BudgetSpentMidBatch_StopsAndRemainingAbsent(t *testing.
 	// Account "a" computes, then the shared budget expires (simulating the 15s
 	// handler deadline elapsing part-way through the batch).
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "a", gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, _ int) ([]model.EnrichedSubscription, error) {
+		DoAndReturn(func(_ context.Context, _ string, _ int) ([]models.ActiveSubscription, error) {
 			cancel()
-			return []model.EnrichedSubscription{localUnreadSub("a", "ra", "site-a")}, nil
+			return []models.ActiveSubscription{localUnreadSub("a", "ra", "site-a")}, nil
 		})
 	// "b" and "c" must NEVER reach the repo once the context is done.
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "b", gomock.Any()).Times(0)
@@ -257,9 +257,9 @@ func TestBadgeCountBatch_BudgetSpentMidBatch_LaterCacheHitStillServed(t *testing
 		seed: func(account string, roomIDs []string, trigger string) (int, bool) { return 1, true },
 	}
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "a", gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, _ int) ([]model.EnrichedSubscription, error) {
+		DoAndReturn(func(_ context.Context, _ string, _ int) ([]models.ActiveSubscription, error) {
 			cancel()
-			return []model.EnrichedSubscription{localUnreadSub("a", "ra", "site-a")}, nil
+			return []models.ActiveSubscription{localUnreadSub("a", "ra", "site-a")}, nil
 		})
 	// "b" misses and sits past the spent budget — its expensive recompute must be skipped.
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "b", gomock.Any()).Times(0)


### PR DESCRIPTION
## Summary

`main` currently fails the `ci / test` (and `lint`) job because `user-service/service/badge_test.go` does not compile: two `DoAndReturn` closures still declare the pre-rename return type `[]model.EnrichedSubscription`, while the real `SubscriptionRepository.GetActiveSubscriptions` signature returns `[]models.ActiveSubscription` (`user-service/service/service.go`, the mongorepo impl, and the generated mock all agree). This is a leftover from the type rename — 17 references were updated, these two closures were missed — so `go test ./user-service/service/...` fails to build and reds the whole `make test` run for every branch that rebases on `main`.

## Changes

- `user-service/service/badge_test.go`: change the two `GetActiveSubscriptions` `DoAndReturn` closure return types from `[]model.EnrichedSubscription` to `[]models.ActiveSubscription` (4 lines) so the test compiles against the current repository signature. Test-only; no production code changes.

## Verification

- `go vet ./user-service/service/` — passes (previously failed to compile).
- `go test ./user-service/service/ -run Badge` — passes.
- `golangci-lint` on `./user-service/...` — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated badge budget-exhaustion test scenarios to use the current subscription representation.
  * Preserved existing test behavior and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->