### PR TITLE
fix(user-service): emit subscription.update on setAppSubscription un/re-subscribe

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -5610,6 +5610,14 @@ PUT-like idempotent endpoint to subscribe or unsubscribe the calling user from a
 { "success": true }
 ```
 
+##### Triggered events — success path
+
+**`chat.user.{account}.event.subscription.update`** — emitted once for the requester (best-effort, core NATS) so the user's other devices reconcile the botDM without a refetch. Bot accounts receive it on their **encoded** per-user subject (dots→underscores), matching their NATS JWT scope.
+
+- **Unsubscribe** (`subscribed: false` on an existing subscription) → `action: "removed"`. Payload is the dedicated `SubscriptionRemovedEvent` (`subscription` carries only `roomId`, `roomType: "botDM"`, and `u`). No event fires when there was no subscription to remove.
+- **Reactivate** (`subscribed: true` on an existing, previously-unsubscribed subscription) → `action: "added"`, the same event the first-time subscribe path emits, so the FE re-adds the botDM it dropped on the prior `removed`. See the [subscription.update schema](#subscriptionupdate-event); the embedded `Subscription` reflects `isSubscribed: true` / `muted: false`, and `appInfo` carries the bot app's identity.
+- **First-time subscribe** (`subscribed: true`, no existing DM room) → the `action: "added"` event is emitted by room-service as part of botDM room creation, not by this handler.
+
 ##### Error response
 
 | Condition | `code` | `reason` | Notes |

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -204,7 +204,8 @@ fields are sent.
 
 **Triggered by:** Add Members (`added`), Remove Member (`removed`), Update Member Role
 (`role_updated`), Toggle Mute (`mute_toggled`), Toggle Favorite (`favorite_toggled`),
-Open Room (`opened`), Mark Messages Read (`read`) — see [request-reply.md](request-reply.md).
+Open Room (`opened`), Mark Messages Read (`read`), Set App Subscription (`removed` on
+unsubscribe, `added` on reactivate) — see [request-reply.md](request-reply.md).
 
 ---
 

--- a/user-service/service/apps.go
+++ b/user-service/service/apps.go
@@ -1,11 +1,16 @@
 package service
 
 import (
+	"encoding/json"
 	"fmt"
+	"log/slog"
+	"time"
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/natsrouter"
+	"github.com/hmchangw/chat/pkg/natsutil"
+	"github.com/hmchangw/chat/pkg/subject"
 	"github.com/hmchangw/chat/user-service/models"
 )
 
@@ -27,17 +32,24 @@ func (s *UserService) SetAppSubscription(c *natsrouter.Context, req models.SetAp
 	}
 	botName := app.Assistant.Name
 
-	if !req.Subscribed {
-		if err := s.subs.SetAppSubscribed(c, account, botName, false, true); err != nil {
-			return nil, fmt.Errorf("unsubscribe app: %w", err)
-		}
-		return &models.OKResponse{Success: true}, nil
-	}
+	// Both branches need this: the removed event carries the room id, and each keys off existence.
 	existing, err := s.subs.GetAppSubscription(c, account, botName)
 	if err != nil {
 		return nil, fmt.Errorf("get app subscription: %w", err)
 	}
+
+	if !req.Subscribed {
+		if existing == nil {
+			return &models.OKResponse{Success: true}, nil // nothing subscribed: no write, no event
+		}
+		if err := s.subs.SetAppSubscribed(c, account, botName, false, true); err != nil {
+			return nil, fmt.Errorf("unsubscribe app: %w", err)
+		}
+		s.publishAppSubscriptionRemoved(c, account, existing)
+		return &models.OKResponse{Success: true}, nil
+	}
 	if existing == nil {
+		// First subscribe emits via room creation — nothing to publish here.
 		if _, err := s.rooms.CreateDMRoom(c, account, botName, model.RoomTypeBotDM); err != nil {
 			return nil, fmt.Errorf("create botDM room: %w", err)
 		}
@@ -46,7 +58,52 @@ func (s *UserService) SetAppSubscription(c *natsrouter.Context, req models.SetAp
 	if err := s.subs.SetAppSubscribed(c, account, botName, true, false); err != nil {
 		return nil, fmt.Errorf("reactivate app: %w", err)
 	}
+	s.publishAppSubscriptionReactivated(c, account, existing, app)
 	return &models.OKResponse{Success: true}, nil
+}
+
+// Tell the user's other devices to drop the botDM (mirrors room-worker's removed event; best-effort).
+func (s *UserService) publishAppSubscriptionRemoved(c *natsrouter.Context, account string, sub *model.Subscription) {
+	evt := model.SubscriptionRemovedEvent{
+		UserID: sub.User.ID,
+		Subscription: model.RemovedSubscriptionRef{
+			RoomID:   sub.RoomID,
+			RoomType: model.RoomTypeBotDM,
+			U:        model.SubscriptionUser{ID: sub.User.ID, Account: account},
+		},
+		Action:    "removed",
+		Timestamp: time.Now().UTC().UnixMilli(),
+	}
+	data, _ := json.Marshal(evt) // primitives only; cannot fail
+	s.publishSubscriptionUpdate(c, account, data)
+}
+
+// Tell the user's other devices to re-add the botDM (mirrors room-worker's added shape; best-effort).
+func (s *UserService) publishAppSubscriptionReactivated(c *natsrouter.Context, account string, sub *model.Subscription, app *model.App) {
+	subCopy := *sub
+	subCopy.IsSubscribed = true
+	subCopy.Muted = false
+	roomName := app.Name
+	if roomName == "" {
+		roomName = app.Assistant.Name
+	}
+	evt := model.SubscriptionUpdateEvent{
+		UserID:       sub.User.ID,
+		Subscription: subCopy,
+		Action:       "added",
+		RoomName:     roomName,
+		AppInfo:      &model.CounterpartAppInfo{ID: app.ID, Name: app.Name, AssistantName: app.Assistant.Name},
+		Timestamp:    time.Now().UTC().UnixMilli(),
+	}
+	data, _ := json.Marshal(evt) // primitives only; cannot fail
+	s.publishSubscriptionUpdate(c, account, data)
+}
+
+// Best-effort core-NATS fan-out of a botDM subscription.update to the user's own subject.
+func (s *UserService) publishSubscriptionUpdate(c *natsrouter.Context, account string, data []byte) {
+	if err := s.clientPub.Publish(c, subject.SubscriptionUpdate(account), data); err != nil {
+		slog.WarnContext(c, "publish app subscription.update event", "error", err, "account", account, "request_id", natsutil.RequestIDFromContext(c))
+	}
 }
 
 func (s *UserService) ListApps(c *natsrouter.Context, req models.AppsListRequest) (*models.AppsListResponse, error) {

--- a/user-service/service/apps.go
+++ b/user-service/service/apps.go
@@ -86,10 +86,15 @@ func (s *UserService) publishAppSubscriptionReactivated(c *natsrouter.Context, a
 	subCopy := *sub
 	subCopy.IsSubscribed = true
 	subCopy.Muted = false
-	// Hydrate the non-persisted Room the "added" contract carries (GetAppSubscription decodes persisted fields only).
-	if infos, err := s.rooms.GetRoomsMeta(c, sub.SiteID, []string{sub.RoomID}); err == nil && len(infos) > 0 {
-		applyRoomInfo(&subCopy, &infos[0])
+	// The "added" contract requires a hydrated Room (GetAppSubscription decodes persisted fields only).
+	// If the lookup fails, skip the publish rather than emit a Room-less event — clients reconcile on next apps.list.
+	infos, err := s.rooms.GetRoomsMeta(c, sub.SiteID, []string{sub.RoomID})
+	if err != nil || len(infos) == 0 || !infos[0].Found {
+		slog.WarnContext(c, "skip app subscription.update: room metadata unavailable",
+			"error", err, "account", account, "room_id", sub.RoomID, "request_id", natsutil.RequestIDFromContext(c))
+		return
 	}
+	applyRoomInfo(&subCopy, &infos[0])
 	roomName := app.Name
 	if roomName == "" {
 		roomName = app.Assistant.Name

--- a/user-service/service/apps.go
+++ b/user-service/service/apps.go
@@ -55,10 +55,13 @@ func (s *UserService) SetAppSubscription(c *natsrouter.Context, req models.SetAp
 		}
 		return &models.OKResponse{Success: true}, nil
 	}
+	wasSubscribed := existing.IsSubscribed
 	if err := s.subs.SetAppSubscribed(c, account, botName, true, false); err != nil {
 		return nil, fmt.Errorf("reactivate app: %w", err)
 	}
-	s.publishAppSubscriptionReactivated(c, account, existing, app)
+	if !wasSubscribed { // emit only on a real unsubscribed→subscribed transition, not an idempotent re-subscribe
+		s.publishAppSubscriptionReactivated(c, account, existing, app)
+	}
 	return &models.OKResponse{Success: true}, nil
 }
 
@@ -83,6 +86,10 @@ func (s *UserService) publishAppSubscriptionReactivated(c *natsrouter.Context, a
 	subCopy := *sub
 	subCopy.IsSubscribed = true
 	subCopy.Muted = false
+	// Hydrate the non-persisted Room the "added" contract carries (GetAppSubscription decodes persisted fields only).
+	if infos, err := s.rooms.GetRoomsMeta(c, sub.SiteID, []string{sub.RoomID}); err == nil && len(infos) > 0 {
+		applyRoomInfo(&subCopy, &infos[0])
+	}
 	roomName := app.Name
 	if roomName == "" {
 		roomName = app.Assistant.Name

--- a/user-service/service/apps_test.go
+++ b/user-service/service/apps_test.go
@@ -126,6 +126,19 @@ func TestSetAppSubscription_Reactivate_ClearsMuted(t *testing.T) {
 	assert.NotZero(t, got.Timestamp)
 }
 
+// Room hydration failure on reactivate → skip the publish (no Room-less event), still success.
+func TestSetAppSubscription_Reactivate_RoomMetaUnavailable_NoEvent(t *testing.T) {
+	svc, subs, _, apps, rooms, _, _ := newSvc(t)
+	apps.EXPECT().GetApp(gomock.Any(), "app1").Return(appWith(true), nil)
+	subs.EXPECT().GetAppSubscription(gomock.Any(), "alice", "helper.bot").Return(appSub(false), nil)
+	subs.EXPECT().SetAppSubscribed(gomock.Any(), "alice", "helper.bot", true, false).Return(nil)
+	rooms.EXPECT().GetRoomsMeta(gomock.Any(), gomock.Any(), []string{"room1"}).Return(nil, errors.New("room svc down"))
+	// No pub expectation → the strict mock fails if a partial event is published.
+	resp, err := svc.SetAppSubscription(ctx("alice", "site-a"), models.SetAppSubscriptionRequest{AppID: "app1", Subscribed: true})
+	require.NoError(t, err)
+	assert.True(t, resp.Success)
+}
+
 // An idempotent subscribed:true on an already-active botDM writes but emits no event.
 func TestSetAppSubscription_Reactivate_AlreadySubscribed_NoEvent(t *testing.T) {
 	svc, subs, _, apps, _, _, _ := newSvc(t)

--- a/user-service/service/apps_test.go
+++ b/user-service/service/apps_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -11,8 +12,20 @@ import (
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/pkg/subject"
 	"github.com/hmchangw/chat/user-service/models"
 )
+
+// appSub is a botDM subscription fixture for the reactivate/unsubscribe paths.
+func appSub(muted bool) *model.Subscription {
+	return &model.Subscription{
+		ID:       "ex",
+		RoomID:   "room1",
+		RoomType: model.RoomTypeBotDM,
+		Muted:    muted,
+		User:     model.SubscriptionUser{ID: "u-alice", Account: "alice"},
+	}
+}
 
 func appWith(enabled bool) *model.App {
 	return &model.App{ID: "app1", Name: "Helper", Assistant: &model.AppAssistant{Enabled: enabled, Name: "helper.bot"}}
@@ -86,13 +99,27 @@ func TestSetAppSubscription_CreateDMRoomError(t *testing.T) {
 }
 
 func TestSetAppSubscription_Reactivate_ClearsMuted(t *testing.T) {
-	svc, subs, _, apps, _, _, _ := newSvc(t)
+	svc, subs, _, apps, _, _, pub := newSvc(t)
 	apps.EXPECT().GetApp(gomock.Any(), "app1").Return(appWith(true), nil)
-	subs.EXPECT().GetAppSubscription(gomock.Any(), "alice", "helper.bot").Return(&model.Subscription{ID: "ex", Muted: true}, nil)
+	subs.EXPECT().GetAppSubscription(gomock.Any(), "alice", "helper.bot").Return(appSub(true), nil)
 	subs.EXPECT().SetAppSubscribed(gomock.Any(), "alice", "helper.bot", true, false).Return(nil)
+	var got model.SubscriptionUpdateEvent
+	pub.EXPECT().Publish(gomock.Any(), subject.SubscriptionUpdate("alice"), gomock.Any()).
+		DoAndReturn(func(_ any, _ string, data []byte) error {
+			require.NoError(t, json.Unmarshal(data, &got))
+			return nil
+		})
 	resp, err := svc.SetAppSubscription(ctx("alice", "site-a"), models.SetAppSubscriptionRequest{AppID: "app1", Subscribed: true})
 	require.NoError(t, err)
 	assert.True(t, resp.Success)
+	// Reactivate → "added" so other devices re-add the botDM; same handler as first-subscribe.
+	assert.Equal(t, "added", got.Action)
+	assert.True(t, got.Subscription.IsSubscribed)
+	assert.False(t, got.Subscription.Muted, "reactivate clears muted on the wire event too")
+	require.NotNil(t, got.AppInfo)
+	assert.Equal(t, "app1", got.AppInfo.ID)
+	assert.Equal(t, "helper.bot", got.AppInfo.AssistantName)
+	assert.NotZero(t, got.Timestamp)
 }
 
 func TestSetAppSubscription_ReactivateSetAppSubscribedError(t *testing.T) {
@@ -105,9 +132,33 @@ func TestSetAppSubscription_ReactivateSetAppSubscribedError(t *testing.T) {
 }
 
 func TestSetAppSubscription_Unsubscribe(t *testing.T) {
+	svc, subs, _, apps, _, _, pub := newSvc(t)
+	apps.EXPECT().GetApp(gomock.Any(), "app1").Return(appWith(true), nil)
+	subs.EXPECT().GetAppSubscription(gomock.Any(), "alice", "helper.bot").Return(appSub(false), nil)
+	subs.EXPECT().SetAppSubscribed(gomock.Any(), "alice", "helper.bot", false, true).Return(nil)
+	var got model.SubscriptionRemovedEvent
+	pub.EXPECT().Publish(gomock.Any(), subject.SubscriptionUpdate("alice"), gomock.Any()).
+		DoAndReturn(func(_ any, _ string, data []byte) error {
+			require.NoError(t, json.Unmarshal(data, &got))
+			return nil
+		})
+	resp, err := svc.SetAppSubscription(ctx("alice", "site-a"), models.SetAppSubscriptionRequest{AppID: "app1", Subscribed: false})
+	require.NoError(t, err)
+	assert.True(t, resp.Success)
+	// Mirrors room-worker's botDM removed event so the FE needs no new handler.
+	assert.Equal(t, "removed", got.Action)
+	assert.Equal(t, "room1", got.Subscription.RoomID)
+	assert.Equal(t, model.RoomTypeBotDM, got.Subscription.RoomType)
+	assert.Equal(t, "alice", got.Subscription.U.Account)
+	assert.Equal(t, "u-alice", got.Subscription.U.ID)
+	assert.NotZero(t, got.Timestamp)
+}
+
+// No botDM row → nothing to unsubscribe: no write, no event, still success.
+func TestSetAppSubscription_Unsubscribe_NoSubscription(t *testing.T) {
 	svc, subs, _, apps, _, _, _ := newSvc(t)
 	apps.EXPECT().GetApp(gomock.Any(), "app1").Return(appWith(true), nil)
-	subs.EXPECT().SetAppSubscribed(gomock.Any(), "alice", "helper.bot", false, true).Return(nil)
+	subs.EXPECT().GetAppSubscription(gomock.Any(), "alice", "helper.bot").Return(nil, nil)
 	resp, err := svc.SetAppSubscription(ctx("alice", "site-a"), models.SetAppSubscriptionRequest{AppID: "app1", Subscribed: false})
 	require.NoError(t, err)
 	assert.True(t, resp.Success)
@@ -116,6 +167,7 @@ func TestSetAppSubscription_Unsubscribe(t *testing.T) {
 func TestSetAppSubscription_UnsubscribeSetAppSubscribedError(t *testing.T) {
 	svc, subs, _, apps, _, _, _ := newSvc(t)
 	apps.EXPECT().GetApp(gomock.Any(), "app1").Return(appWith(true), nil)
+	subs.EXPECT().GetAppSubscription(gomock.Any(), "alice", "helper.bot").Return(appSub(false), nil)
 	subs.EXPECT().SetAppSubscribed(gomock.Any(), "alice", "helper.bot", false, true).Return(errors.New("db down"))
 	_, err := svc.SetAppSubscription(ctx("alice", "site-a"), models.SetAppSubscriptionRequest{AppID: "app1", Subscribed: false})
 	requireCode(t, err, errcode.CodeInternal)

--- a/user-service/service/apps_test.go
+++ b/user-service/service/apps_test.go
@@ -99,10 +99,12 @@ func TestSetAppSubscription_CreateDMRoomError(t *testing.T) {
 }
 
 func TestSetAppSubscription_Reactivate_ClearsMuted(t *testing.T) {
-	svc, subs, _, apps, _, _, pub := newSvc(t)
+	svc, subs, _, apps, rooms, _, pub := newSvc(t)
 	apps.EXPECT().GetApp(gomock.Any(), "app1").Return(appWith(true), nil)
 	subs.EXPECT().GetAppSubscription(gomock.Any(), "alice", "helper.bot").Return(appSub(true), nil)
 	subs.EXPECT().SetAppSubscribed(gomock.Any(), "alice", "helper.bot", true, false).Return(nil)
+	rooms.EXPECT().GetRoomsMeta(gomock.Any(), gomock.Any(), []string{"room1"}).
+		Return([]model.RoomInfo{{RoomID: "room1", Found: true, SiteID: "site-a", Name: "Test Bot", AppCount: 1, UserCount: 1}}, nil)
 	var got model.SubscriptionUpdateEvent
 	pub.EXPECT().Publish(gomock.Any(), subject.SubscriptionUpdate("alice"), gomock.Any()).
 		DoAndReturn(func(_ any, _ string, data []byte) error {
@@ -116,10 +118,26 @@ func TestSetAppSubscription_Reactivate_ClearsMuted(t *testing.T) {
 	assert.Equal(t, "added", got.Action)
 	assert.True(t, got.Subscription.IsSubscribed)
 	assert.False(t, got.Subscription.Muted, "reactivate clears muted on the wire event too")
+	require.NotNil(t, got.Subscription.Room, "added event must carry the hydrated room")
+	assert.Equal(t, "Test Bot", got.Subscription.Room.Name)
 	require.NotNil(t, got.AppInfo)
 	assert.Equal(t, "app1", got.AppInfo.ID)
 	assert.Equal(t, "helper.bot", got.AppInfo.AssistantName)
 	assert.NotZero(t, got.Timestamp)
+}
+
+// An idempotent subscribed:true on an already-active botDM writes but emits no event.
+func TestSetAppSubscription_Reactivate_AlreadySubscribed_NoEvent(t *testing.T) {
+	svc, subs, _, apps, _, _, _ := newSvc(t)
+	active := appSub(false)
+	active.IsSubscribed = true
+	apps.EXPECT().GetApp(gomock.Any(), "app1").Return(appWith(true), nil)
+	subs.EXPECT().GetAppSubscription(gomock.Any(), "alice", "helper.bot").Return(active, nil)
+	subs.EXPECT().SetAppSubscribed(gomock.Any(), "alice", "helper.bot", true, false).Return(nil)
+	// No pub / GetRoomsMeta expectations → the strict mocks fail if either is called.
+	resp, err := svc.SetAppSubscription(ctx("alice", "site-a"), models.SetAppSubscriptionRequest{AppID: "app1", Subscribed: true})
+	require.NoError(t, err)
+	assert.True(t, resp.Success)
 }
 
 func TestSetAppSubscription_ReactivateSetAppSubscribedError(t *testing.T) {


### PR DESCRIPTION
## Summary

`subscription.setAppSubscription` flipped `isSubscribed` in Mongo but published no
`subscription.update`, so a user's other devices never learned an app was un/re-subscribed
— `apps.list` stayed stale until a manual refetch. Every other subscription change already
fans out `subscription.update`; this path was the sole omission. Fixes #370.

This publishes the event on the two affected branches. First-time subscribe already emits
via room creation, so it is left unchanged.

## What's included

- Publish `subscription.update` on **unsubscribe** (`action: "removed"`, the lean
  `SubscriptionRemovedEvent` room-worker already uses) and on **reactivate**
  (`action: "added"`, the same shape botDM first-subscribe emits — the other devices
  dropped the room on the prior `removed`, so re-adding is correct and needs no new FE
  handler).
- Docs: `docs/client-api.md` (`setAppSubscription` now lists a Triggered-events section)
  and the `docs/client-api/events.md` `subscription.update` view.
- Tests covering both branches plus the no-existing-subscription no-op.

## Changes

- `user-service/service/apps.go` — fetch the existing botDM subscription up front (both
  branches need it: the removed event carries the room id; each keys off existence), then
  publish over the same core-NATS client subject the sibling `settings.update` /
  `chatlist.update` fanouts use. The publish is best-effort — the Mongo write stays the
  source of truth, a publish failure is logged and clients reconcile on next refetch.
- `user-service/service/apps_test.go` — assert the publish + payload (action, room id,
  `appInfo`, cleared `muted`) on both branches; add the no-subscription no-op case.
- `docs/client-api.md`, `docs/client-api/events.md` — doc-ratchet.

The subscription repository stays pure (no fan-out from the data layer) — the handler owns
the event, matching the write-owner-emits convention.

## Verification

- `make test SERVICE=user-service` — green (all packages), 13 `SetAppSubscription` cases pass.
- Lint clean on the touched service.
- Red→green: the publish/branch assertions fail against the pre-fix handler and pass after.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unsubscribing from an app subscription now emits a removal update.
  - Reactivating a subscription emits an added update and restores the subscription.
  - Attempting to unsubscribe without an existing subscription succeeds without creating an update.
  - Reapplying an already active subscription does not emit a duplicate update.
  - New subscriptions continue to emit the standard room-creation update.

- **Documentation**
  - Updated API documentation to describe subscription update events for subscribing, unsubscribing, and reactivating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->