### PR TITLE
Fix preview staleness on re-login and resync

### DIFF
--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.cache.test.jsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.cache.test.jsx
@@ -191,27 +191,16 @@ describe('RoomEventsProvider: subscription cache', () => {
       content,
       createdAt,
     })
-    seedCache(
-      {
-        r1: sub('r1', {
-          room: {
-            userCount: 3,
-            lastMsgAt: '2026-08-01T00:00:00Z',
-            crossSite: false,
-            previewMessage: previewMessage('m-old', 'last session', '2026-08-01T00:00:00Z'),
-          },
-        }),
-      },
-      // What last session's write-through left behind for that same row.
-      {
-        previews: {
-          r1: {
-            messageId: 'm-old', senderName: 'Bob Lin', text: 'last session',
-            createdAt: '2026-08-01T00:00:00Z',
-          },
+    seedCache({
+      r1: sub('r1', {
+        room: {
+          userCount: 3,
+          lastMsgAt: '2026-08-01T00:00:00Z',
+          crossSite: false,
+          previewMessage: previewMessage('m-old', 'last session', '2026-08-01T00:00:00Z'),
         },
-      },
-    )
+      }),
+    })
     render(wrap(mockNats()))
     expect(screen.getByTestId('previews').textContent).toBe('r1:last session')
 
@@ -263,74 +252,6 @@ describe('RoomEventsProvider: subscription cache', () => {
     )
     render(wrap(mockNats()))
     expect(screen.getByTestId('previews').textContent).toBe('r1:arrived while I was logged in')
-  })
-
-  it("takes the server's survivor when the cached message was deleted while logged out", async () => {
-    // The delete broadcast never reached this client, so both the cached preview
-    // and the cached row still name the deleted message.
-    const cachedRoom = {
-      userCount: 3,
-      lastMsgAt: '2026-08-02T00:00:00Z',
-      crossSite: false,
-      previewMessage: {
-        messageId: 'm-deleted',
-        sender: { account: 'bob', displayName: 'Bob Lin' },
-        content: 'deleted while away',
-        createdAt: '2026-08-02T00:00:00Z',
-      },
-    }
-    seedCache({ r1: sub('r1', { room: cachedRoom }) }, {
-      previews: {
-        r1: {
-          messageId: 'm-deleted', senderName: 'Bob Lin', text: 'deleted while away',
-          createdAt: '2026-08-02T00:00:00Z',
-        },
-      },
-    })
-    const request = bucketRequest({
-      favorites: [],
-      apps: [],
-      rooms: [sub('r1', {
-        room: {
-          ...cachedRoom,
-          previewMessage: {
-            messageId: 'm-older',
-            sender: { account: 'alice', displayName: 'Alice Chen' },
-            content: 'the earlier survivor',
-            createdAt: '2026-08-01T00:00:00Z',
-          },
-        },
-      })],
-    })
-    render(wrap(mockNats({ request })))
-    await waitFor(() =>
-      expect(screen.getByTestId('previews').textContent).toBe('r1:the earlier survivor'),
-    )
-  })
-
-  it('does not resurrect a preview whose message was deleted last session', () => {
-    // The delete broadcast cleared state.previews, but the cached subscription
-    // row still names the deleted message as its previewMessage.
-    seedCache(
-      {
-        r1: sub('r1', {
-          room: {
-            userCount: 3,
-            lastMsgAt: '2026-08-01T00:00:00Z',
-            crossSite: false,
-            previewMessage: {
-              messageId: 'm-deleted',
-              sender: { account: 'bob', displayName: 'Bob Lin' },
-              content: 'this was deleted',
-              createdAt: '2026-08-01T00:00:00Z',
-            },
-          },
-        }),
-      },
-      { previews: {} },
-    )
-    render(wrap(mockNats()))
-    expect(screen.getByTestId('previews').textContent).toBe('r1:')
   })
 
   it('persists the previews it holds for the next session', async () => {

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.cache.test.jsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.cache.test.jsx
@@ -265,6 +265,49 @@ describe('RoomEventsProvider: subscription cache', () => {
     expect(screen.getByTestId('previews').textContent).toBe('r1:arrived while I was logged in')
   })
 
+  it("takes the server's survivor when the cached message was deleted while logged out", async () => {
+    // The delete broadcast never reached this client, so both the cached preview
+    // and the cached row still name the deleted message.
+    const cachedRoom = {
+      userCount: 3,
+      lastMsgAt: '2026-08-02T00:00:00Z',
+      crossSite: false,
+      previewMessage: {
+        messageId: 'm-deleted',
+        sender: { account: 'bob', displayName: 'Bob Lin' },
+        content: 'deleted while away',
+        createdAt: '2026-08-02T00:00:00Z',
+      },
+    }
+    seedCache({ r1: sub('r1', { room: cachedRoom }) }, {
+      previews: {
+        r1: {
+          messageId: 'm-deleted', senderName: 'Bob Lin', text: 'deleted while away',
+          createdAt: '2026-08-02T00:00:00Z',
+        },
+      },
+    })
+    const request = bucketRequest({
+      favorites: [],
+      apps: [],
+      rooms: [sub('r1', {
+        room: {
+          ...cachedRoom,
+          previewMessage: {
+            messageId: 'm-older',
+            sender: { account: 'alice', displayName: 'Alice Chen' },
+            content: 'the earlier survivor',
+            createdAt: '2026-08-01T00:00:00Z',
+          },
+        },
+      })],
+    })
+    render(wrap(mockNats({ request })))
+    await waitFor(() =>
+      expect(screen.getByTestId('previews').textContent).toBe('r1:the earlier survivor'),
+    )
+  })
+
   it('does not resurrect a preview whose message was deleted last session', () => {
     // The delete broadcast cleared state.previews, but the cached subscription
     // row still names the deleted message as its previewMessage.

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.cache.test.jsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.cache.test.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { NatsContext } from '../NatsContext/NatsContext'
-import { RoomEventsProvider, useRoomSummaries } from './RoomEventsContext'
+import { RoomEventsProvider, useRoomSummaries, useSidebarSections } from './RoomEventsContext'
 import { CACHE_KEY, loadSubscriptionCache, saveSubscriptionCache } from '@/lib/subscriptionCache'
 
 vi.mock('@/context/RoomKeysContext', () => ({
@@ -55,9 +55,16 @@ function mockNats({ request, subscribe } = {}) {
 
 function Probe() {
   const { summaries, error } = useRoomSummaries()
+  const sections = useSidebarSections()
+  const previews = sections
+    .flatMap((s) => s.rooms)
+    .map((r) => `${r.id}:${r.preview?.text ?? ''}`)
+    .sort()
+    .join(',')
   return (
     <div>
       <div data-testid="ids">{summaries.map((r) => r.id).sort().join(',')}</div>
+      <div data-testid="previews">{previews}</div>
       <div data-testid="error">{error ?? ''}</div>
     </div>
   )
@@ -172,6 +179,44 @@ describe('RoomEventsProvider: subscription cache', () => {
     unmount()
     await new Promise((r) => setTimeout(r, 1100))
     expect(Object.keys(loadSubscriptionCache(USER)?.subscriptions ?? {})).toEqual(['r1'])
+  })
+
+  it('replaces a cached preview with the fresher one the bootstrap fetched', async () => {
+    // Re-login regression: hydration seeds previews from the PREVIOUS session's
+    // cached previewMessage, so the sidebar must still take the newer snippet
+    // `subscription.list` returns rather than keeping the stale one.
+    const previewMessage = (messageId, content, createdAt) => ({
+      messageId,
+      sender: { account: 'bob', displayName: 'Bob Lin' },
+      content,
+      createdAt,
+    })
+    seedCache({
+      r1: sub('r1', {
+        room: {
+          userCount: 3,
+          lastMsgAt: '2026-08-01T00:00:00Z',
+          crossSite: false,
+          previewMessage: previewMessage('m-old', 'last session', '2026-08-01T00:00:00Z'),
+        },
+      }),
+    })
+    render(wrap(mockNats()))
+    expect(screen.getByTestId('previews').textContent).toBe('r1:last session')
+
+    const fresh = sub('r1', {
+      room: {
+        userCount: 3,
+        lastMsgAt: '2026-08-02T00:00:00Z',
+        crossSite: false,
+        previewMessage: previewMessage('m-new', 'newest message', '2026-08-02T00:00:00Z'),
+      },
+    })
+    const request = bucketRequest({ favorites: [], apps: [], rooms: [fresh] })
+    render(wrap(mockNats({ request })))
+    await waitFor(() =>
+      expect(screen.getAllByTestId('previews').at(-1).textContent).toBe('r1:newest message'),
+    )
   })
 
   it('writes nothing when storage is unavailable', async () => {

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.cache.test.jsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.cache.test.jsx
@@ -219,6 +219,66 @@ describe('RoomEventsProvider: subscription cache', () => {
     )
   })
 
+  it('paints last session\'s newest snippet on the very first render', async () => {
+    // The cached subscription's previewMessage is the bootstrap snapshot from
+    // the previous session; the persisted preview is where its live messages
+    // landed. The warm paint must show the latter.
+    seedCache(
+      {
+        r1: sub('r1', {
+          room: {
+            userCount: 3,
+            lastMsgAt: '2026-08-01T00:00:00Z',
+            crossSite: false,
+            previewMessage: {
+              messageId: 'm-old',
+              sender: { account: 'bob', displayName: 'Bob Lin' },
+              content: 'bootstrap snapshot',
+              createdAt: '2026-08-01T00:00:00Z',
+            },
+          },
+        }),
+      },
+      {
+        previews: {
+          r1: {
+            messageId: 'm-live',
+            senderName: 'Bob Lin',
+            text: 'arrived while I was logged in',
+            createdAt: '2026-08-02T00:00:00Z',
+          },
+        },
+      },
+    )
+    render(wrap(mockNats()))
+    expect(screen.getByTestId('previews').textContent).toBe('r1:arrived while I was logged in')
+  })
+
+  it('persists the previews it holds for the next session', async () => {
+    const request = bucketRequest({
+      favorites: [],
+      apps: [],
+      rooms: [sub('r1', {
+        room: {
+          userCount: 3,
+          lastMsgAt: '2026-08-02T00:00:00Z',
+          crossSite: false,
+          previewMessage: {
+            messageId: 'm-new',
+            sender: { account: 'bob', displayName: 'Bob Lin' },
+            content: 'newest message',
+            createdAt: '2026-08-02T00:00:00Z',
+          },
+        },
+      })],
+    })
+    render(wrap(mockNats({ request })))
+    await waitFor(
+      () => expect(loadSubscriptionCache(USER)?.previews?.r1?.text).toBe('newest message'),
+      { timeout: 3000 },
+    )
+  })
+
   it('writes nothing when storage is unavailable', async () => {
     const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
       throw new Error('storage disabled')

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.cache.test.jsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.cache.test.jsx
@@ -191,16 +191,27 @@ describe('RoomEventsProvider: subscription cache', () => {
       content,
       createdAt,
     })
-    seedCache({
-      r1: sub('r1', {
-        room: {
-          userCount: 3,
-          lastMsgAt: '2026-08-01T00:00:00Z',
-          crossSite: false,
-          previewMessage: previewMessage('m-old', 'last session', '2026-08-01T00:00:00Z'),
+    seedCache(
+      {
+        r1: sub('r1', {
+          room: {
+            userCount: 3,
+            lastMsgAt: '2026-08-01T00:00:00Z',
+            crossSite: false,
+            previewMessage: previewMessage('m-old', 'last session', '2026-08-01T00:00:00Z'),
+          },
+        }),
+      },
+      // What last session's write-through left behind for that same row.
+      {
+        previews: {
+          r1: {
+            messageId: 'm-old', senderName: 'Bob Lin', text: 'last session',
+            createdAt: '2026-08-01T00:00:00Z',
+          },
         },
-      }),
-    })
+      },
+    )
     render(wrap(mockNats()))
     expect(screen.getByTestId('previews').textContent).toBe('r1:last session')
 
@@ -252,6 +263,31 @@ describe('RoomEventsProvider: subscription cache', () => {
     )
     render(wrap(mockNats()))
     expect(screen.getByTestId('previews').textContent).toBe('r1:arrived while I was logged in')
+  })
+
+  it('does not resurrect a preview whose message was deleted last session', () => {
+    // The delete broadcast cleared state.previews, but the cached subscription
+    // row still names the deleted message as its previewMessage.
+    seedCache(
+      {
+        r1: sub('r1', {
+          room: {
+            userCount: 3,
+            lastMsgAt: '2026-08-01T00:00:00Z',
+            crossSite: false,
+            previewMessage: {
+              messageId: 'm-deleted',
+              sender: { account: 'bob', displayName: 'Bob Lin' },
+              content: 'this was deleted',
+              createdAt: '2026-08-01T00:00:00Z',
+            },
+          },
+        }),
+      },
+      { previews: {} },
+    )
+    render(wrap(mockNats()))
+    expect(screen.getByTestId('previews').textContent).toBe('r1:')
   })
 
   it('persists the previews it holds for the next session', async () => {

--- a/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
+++ b/chat-frontend/src/context/RoomEventsContext/RoomEventsContext.tsx
@@ -214,8 +214,15 @@ function hydrateFromCache(user: Nats['user']): RoomEventsState {
     subscriptions: cached.subscriptions,
     rooms,
   })
-  if (!cached.chatlist) return seeded as RoomEventsState
-  return roomEventsReducer(seeded, {
+  // Overlay the previews the last session ended on — the cached subscriptions
+  // only carry the previewMessage its bootstrap saw, so a message that arrived
+  // afterwards lives here.
+  const withPreviews = roomEventsReducer(seeded, {
+    type: 'PREVIEWS_HYDRATED',
+    previews: cached.previews,
+  })
+  if (!cached.chatlist) return withPreviews as RoomEventsState
+  return roomEventsReducer(withPreviews, {
     type: 'CHATLIST_LOADED',
     chatlist: cached.chatlist,
   }) as RoomEventsState
@@ -271,22 +278,23 @@ export function RoomEventsProvider({ children }: { children: ReactNode }) {
     seedKeys,
   )
 
-  // Write-through to the browser cache. Keyed by reference on the five
-  // persisted slices: message traffic churns roomState / summaries /
-  // msgRecvSeq but never these, so this stays quiet during a busy session.
+  // Write-through to the browser cache, keyed by reference on the persisted
+  // slices. `previews` is the one that message traffic churns, and the trailing
+  // debounce is what keeps a busy room from writing per message: the timer
+  // restarts on each change, so a burst costs one write once it settles.
   //
   // The identity check is the teardown guard. `RESET` returns the
   // `initialState` OBJECT, so `=== initialState.subscriptions` is an exact
   // "we've been reset" test — without it, logout (and StrictMode's
   // double-mount) would persist the empty post-RESET state over a good cache.
-  const { subscriptions, favoriteIds, appIds, channelDmIds, chatlist } = state
+  const { subscriptions, favoriteIds, appIds, channelDmIds, chatlist, previews } = state
   useEffect(() => {
     if (subscriptions === initialState.subscriptions) return undefined
     const timer = setTimeout(() => {
-      saveSubscriptionCache(user, { subscriptions, favoriteIds, appIds, channelDmIds, chatlist })
+      saveSubscriptionCache(user, { subscriptions, favoriteIds, appIds, channelDmIds, chatlist, previews })
     }, CACHE_WRITE_DEBOUNCE_MS)
     return () => clearTimeout(timer)
-  }, [user, subscriptions, favoriteIds, appIds, channelDmIds, chatlist])
+  }, [user, subscriptions, favoriteIds, appIds, channelDmIds, chatlist, previews])
 
   const loadHistory = useCallback(
     async (roomId: string) => {

--- a/chat-frontend/src/context/RoomEventsContext/reducer.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.js
@@ -210,6 +210,23 @@ function storedPreviewWins(cur, next) {
   return isOlderPreview(next.createdAt, cur.createdAt)
 }
 
+// Same question for a `subscription.list` row, which is the server's read-time
+// resolve rather than one event's view — so plain recency is the wrong test.
+// A delete never rolls `room.lastMsgAt` back, so a stored preview at or before
+// it is inside the window the row already accounts for and the row supersedes
+// it; only a message that POSTDATES the row (one that arrived live after it was
+// resolved) survives. Recency alone would pin a message deleted while this
+// client was away: the survivor the server returns is older, forever.
+// Falls back to the recency rule when either timestamp is missing.
+function rowPreviewWins(cur, next, rowLastMsgAt) {
+  if (!cur) return false
+  if (cur.encrypted && cur.messageId === next.messageId) return true
+  const curT = Date.parse(cur.createdAt ?? '')
+  const rowT = Date.parse(rowLastMsgAt ?? '')
+  if (Number.isNaN(curT) || Number.isNaN(rowT)) return isOlderPreview(next.createdAt, cur.createdAt)
+  return curT > rowT
+}
+
 /**
  * Apply the server's per-user subscription record onto a summary.
  *
@@ -363,11 +380,11 @@ export function roomEventsReducer(state, action) {
     }
     case 'BUCKETS_LOADED': {
       const subs = action.subscriptions ?? {}
-      // Take the server's preview unless what's stored wins on recency (a live
-      // message that landed before this fetch resolved) or is an encrypted
-      // placeholder for the same message — NOT a fill-if-absent seed: hydration
-      // replays this action with the previous session's cached previewMessage,
-      // so on a re-login every room already has a stale entry to replace.
+      // Take the server's preview unless what's stored postdates the row or is
+      // an encrypted placeholder for the same message (see rowPreviewWins) —
+      // NOT a fill-if-absent seed: hydration replays this action with the
+      // previous session's cached previewMessage, so on a re-login every room
+      // already has a stale entry to replace.
       // Shared by both paths: a degraded bootstrap still carries real previews
       // for the buckets it did reach.
       let previews = state.previews
@@ -377,7 +394,7 @@ export function roomEventsReducer(state, action) {
         const cur = previews[roomId]
         // samePreview keeps the map reference stable on a no-op resync, which
         // would otherwise re-render every row in the sidebar.
-        if (storedPreviewWins(cur, preview) || samePreview(cur, preview)) continue
+        if (rowPreviewWins(cur, preview, sub?.room?.lastMsgAt) || samePreview(cur, preview)) continue
         if (previews === state.previews) previews = { ...state.previews }
         previews[roomId] = preview
       }

--- a/chat-frontend/src/context/RoomEventsContext/reducer.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.js
@@ -448,6 +448,21 @@ export function roomEventsReducer(state, action) {
         previews,
       }
     }
+    case 'PREVIEWS_HYDRATED': {
+      // The previous session's previews, overlaid on what BUCKETS_LOADED just
+      // seeded from the cached subscriptions. Live messages update previews but
+      // never the subscription's previewMessage, so either side can be the
+      // fresher one — the same take-if-newer rule picks the winner.
+      let previews = state.previews
+      for (const [roomId, preview] of Object.entries(action.previews ?? {})) {
+        if (!preview?.messageId) continue
+        const cur = previews[roomId]
+        if (storedPreviewWins(cur, preview) || samePreview(cur, preview)) continue
+        if (previews === state.previews) previews = { ...state.previews }
+        previews[roomId] = preview
+      }
+      return previews === state.previews ? state : { ...state, previews }
+    }
     case 'SUBSCRIPTION_UPSERTED': {
       // Upsert a single subscription record (live delta from
       // `subscription.update` events). Spreads the new fields on top

--- a/chat-frontend/src/context/RoomEventsContext/reducer.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.js
@@ -210,23 +210,6 @@ function storedPreviewWins(cur, next) {
   return isOlderPreview(next.createdAt, cur.createdAt)
 }
 
-// Same question against a `subscription.list` row, which is the server's
-// read-time resolve rather than one event's view — so plain recency is the
-// wrong test. A delete never rolls `room.lastMsgAt` back, so a stored preview
-// at or before it is inside the window the row already accounts for and the
-// row supersedes it; only a stored preview that POSTDATES the row (a message
-// that arrived live after it was resolved) wins. Recency alone would pin a
-// message deleted while this client was away: the survivor the server returns
-// is older, forever. Falls back to recency when either timestamp is missing.
-function storedBeatsRow(cur, next, rowLastMsgAt) {
-  if (!cur) return false
-  if (cur.encrypted && cur.messageId === next.messageId) return true
-  const curT = Date.parse(cur.createdAt ?? '')
-  const rowT = Date.parse(rowLastMsgAt ?? '')
-  if (Number.isNaN(curT) || Number.isNaN(rowT)) return isOlderPreview(next.createdAt, cur.createdAt)
-  return curT > rowT
-}
-
 /**
  * Apply the server's per-user subscription record onto a summary.
  *
@@ -380,11 +363,11 @@ export function roomEventsReducer(state, action) {
     }
     case 'BUCKETS_LOADED': {
       const subs = action.subscriptions ?? {}
-      // Take the server's preview unless what's stored postdates the row or is
-      // an encrypted placeholder for the same message (see storedBeatsRow) —
-      // NOT a fill-if-absent seed: hydration replays this action with the
-      // previous session's cached previewMessage, so on a re-login every room
-      // already has a stale entry to replace.
+      // Take the server's preview unless what's stored wins on recency (a live
+      // message that landed before this fetch resolved) or is an encrypted
+      // placeholder for the same message — NOT a fill-if-absent seed: hydration
+      // replays this action with the previous session's cached previewMessage,
+      // so on a re-login every room already has a stale entry to replace.
       // Shared by both paths: a degraded bootstrap still carries real previews
       // for the buckets it did reach.
       let previews = state.previews
@@ -394,7 +377,7 @@ export function roomEventsReducer(state, action) {
         const cur = previews[roomId]
         // samePreview keeps the map reference stable on a no-op resync, which
         // would otherwise re-render every row in the sidebar.
-        if (storedBeatsRow(cur, preview, sub?.room?.lastMsgAt) || samePreview(cur, preview)) continue
+        if (storedPreviewWins(cur, preview) || samePreview(cur, preview)) continue
         if (previews === state.previews) previews = { ...state.previews }
         previews[roomId] = preview
       }
@@ -466,18 +449,19 @@ export function roomEventsReducer(state, action) {
       }
     }
     case 'PREVIEWS_HYDRATED': {
-      // The previous session's previews, REPLACING what BUCKETS_LOADED just
-      // seeded from the cached subscriptions. The two live in one cache record
-      // written together, and this map is the later snapshot of the same
-      // client's state — so an absent room means "the delete cleared it", not
-      // "unknown", and the subscription row must not put the message back.
-      // An action with no map at all says nothing and leaves state alone.
-      if (!action.previews) return state
-      const previews = {}
-      for (const [roomId, preview] of Object.entries(action.previews)) {
-        if (preview?.messageId) previews[roomId] = preview
+      // The previous session's previews, overlaid on what BUCKETS_LOADED just
+      // seeded from the cached subscriptions. Live messages update previews but
+      // never the subscription's previewMessage, so either side can be the
+      // fresher one — the same take-if-newer rule picks the winner.
+      let previews = state.previews
+      for (const [roomId, preview] of Object.entries(action.previews ?? {})) {
+        if (!preview?.messageId) continue
+        const cur = previews[roomId]
+        if (storedPreviewWins(cur, preview) || samePreview(cur, preview)) continue
+        if (previews === state.previews) previews = { ...state.previews }
+        previews[roomId] = preview
       }
-      return { ...state, previews }
+      return previews === state.previews ? state : { ...state, previews }
     }
     case 'SUBSCRIPTION_UPSERTED': {
       // Upsert a single subscription record (live delta from
@@ -1072,12 +1056,6 @@ export function roomEventsReducer(state, action) {
       const next = previewFromWire(previewMessage)
       if (next) {
         const cur = state.previews[roomId]
-        // The message on display was just deleted, so neither guard below
-        // applies: the server's replacement is the room's earlier survivor
-        // (older by definition) and the placeholder has nothing left to
-        // protect. Without this the sidebar keeps a deleted message.
-        const retired = !!deletedMessageId && cur?.messageId === deletedMessageId
-        if (retired) return { ...state, previews: { ...state.previews, [roomId]: next } }
         // Fix 3: the live path already knows this message can't be decrypted
         // and stored the "[encrypted message]" placeholder. history-service /
         // broadcast-worker relay previewMessage.content unencrypted, so a

--- a/chat-frontend/src/context/RoomEventsContext/reducer.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.js
@@ -210,15 +210,15 @@ function storedPreviewWins(cur, next) {
   return isOlderPreview(next.createdAt, cur.createdAt)
 }
 
-// Same question for a `subscription.list` row, which is the server's read-time
-// resolve rather than one event's view — so plain recency is the wrong test.
-// A delete never rolls `room.lastMsgAt` back, so a stored preview at or before
-// it is inside the window the row already accounts for and the row supersedes
-// it; only a message that POSTDATES the row (one that arrived live after it was
-// resolved) survives. Recency alone would pin a message deleted while this
-// client was away: the survivor the server returns is older, forever.
-// Falls back to the recency rule when either timestamp is missing.
-function rowPreviewWins(cur, next, rowLastMsgAt) {
+// Same question against a `subscription.list` row, which is the server's
+// read-time resolve rather than one event's view — so plain recency is the
+// wrong test. A delete never rolls `room.lastMsgAt` back, so a stored preview
+// at or before it is inside the window the row already accounts for and the
+// row supersedes it; only a stored preview that POSTDATES the row (a message
+// that arrived live after it was resolved) wins. Recency alone would pin a
+// message deleted while this client was away: the survivor the server returns
+// is older, forever. Falls back to recency when either timestamp is missing.
+function storedBeatsRow(cur, next, rowLastMsgAt) {
   if (!cur) return false
   if (cur.encrypted && cur.messageId === next.messageId) return true
   const curT = Date.parse(cur.createdAt ?? '')
@@ -381,7 +381,7 @@ export function roomEventsReducer(state, action) {
     case 'BUCKETS_LOADED': {
       const subs = action.subscriptions ?? {}
       // Take the server's preview unless what's stored postdates the row or is
-      // an encrypted placeholder for the same message (see rowPreviewWins) —
+      // an encrypted placeholder for the same message (see storedBeatsRow) —
       // NOT a fill-if-absent seed: hydration replays this action with the
       // previous session's cached previewMessage, so on a re-login every room
       // already has a stale entry to replace.
@@ -394,7 +394,7 @@ export function roomEventsReducer(state, action) {
         const cur = previews[roomId]
         // samePreview keeps the map reference stable on a no-op resync, which
         // would otherwise re-render every row in the sidebar.
-        if (rowPreviewWins(cur, preview, sub?.room?.lastMsgAt) || samePreview(cur, preview)) continue
+        if (storedBeatsRow(cur, preview, sub?.room?.lastMsgAt) || samePreview(cur, preview)) continue
         if (previews === state.previews) previews = { ...state.previews }
         previews[roomId] = preview
       }

--- a/chat-frontend/src/context/RoomEventsContext/reducer.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.js
@@ -449,19 +449,18 @@ export function roomEventsReducer(state, action) {
       }
     }
     case 'PREVIEWS_HYDRATED': {
-      // The previous session's previews, overlaid on what BUCKETS_LOADED just
-      // seeded from the cached subscriptions. Live messages update previews but
-      // never the subscription's previewMessage, so either side can be the
-      // fresher one — the same take-if-newer rule picks the winner.
-      let previews = state.previews
-      for (const [roomId, preview] of Object.entries(action.previews ?? {})) {
-        if (!preview?.messageId) continue
-        const cur = previews[roomId]
-        if (storedPreviewWins(cur, preview) || samePreview(cur, preview)) continue
-        if (previews === state.previews) previews = { ...state.previews }
-        previews[roomId] = preview
+      // The previous session's previews, REPLACING what BUCKETS_LOADED just
+      // seeded from the cached subscriptions. The two live in one cache record
+      // written together, and this map is the later snapshot of the same
+      // client's state — so an absent room means "the delete cleared it", not
+      // "unknown", and the subscription row must not put the message back.
+      // An action with no map at all says nothing and leaves state alone.
+      if (!action.previews) return state
+      const previews = {}
+      for (const [roomId, preview] of Object.entries(action.previews)) {
+        if (preview?.messageId) previews[roomId] = preview
       }
-      return previews === state.previews ? state : { ...state, previews }
+      return { ...state, previews }
     }
     case 'SUBSCRIPTION_UPSERTED': {
       // Upsert a single subscription record (live delta from
@@ -1056,6 +1055,12 @@ export function roomEventsReducer(state, action) {
       const next = previewFromWire(previewMessage)
       if (next) {
         const cur = state.previews[roomId]
+        // The message on display was just deleted, so neither guard below
+        // applies: the server's replacement is the room's earlier survivor
+        // (older by definition) and the placeholder has nothing left to
+        // protect. Without this the sidebar keeps a deleted message.
+        const retired = !!deletedMessageId && cur?.messageId === deletedMessageId
+        if (retired) return { ...state, previews: { ...state.previews, [roomId]: next } }
         // Fix 3: the live path already knows this message can't be decrypted
         // and stored the "[encrypted message]" placeholder. history-service /
         // broadcast-worker relay previewMessage.content unencrypted, so a

--- a/chat-frontend/src/context/RoomEventsContext/reducer.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.js
@@ -201,6 +201,15 @@ function isOlderPreview(nextCreatedAt, curCreatedAt) {
   return nextT < curT
 }
 
+// Whether the stored preview wins over an incoming wire preview. Two reasons
+// it can: the live path stored an encrypted placeholder for that same message
+// (Fix 3), or the wire preview is strictly older than what's displayed (Fix 7).
+function storedPreviewWins(cur, next) {
+  if (!cur) return false
+  if (cur.encrypted && cur.messageId === next.messageId) return true
+  return isOlderPreview(next.createdAt, cur.createdAt)
+}
+
 /**
  * Apply the server's per-user subscription record onto a summary.
  *
@@ -354,17 +363,21 @@ export function roomEventsReducer(state, action) {
     }
     case 'BUCKETS_LOADED': {
       const subs = action.subscriptions ?? {}
-      // Seed only rooms with no preview yet. A live message can land before
-      // fetchSidebarBuckets resolves (the DM subscription goes live first), and
-      // that message is NEWER than this list snapshot — overwriting it would show
-      // an older message in the sidebar than the room itself displays.
+      // Take the server's preview unless what's stored wins on recency (a live
+      // message that landed before this fetch resolved) or is an encrypted
+      // placeholder for the same message — NOT a fill-if-absent seed: hydration
+      // replays this action with the previous session's cached previewMessage,
+      // so on a re-login every room already has a stale entry to replace.
       // Shared by both paths: a degraded bootstrap still carries real previews
       // for the buckets it did reach.
       let previews = state.previews
       for (const [roomId, sub] of Object.entries(subs)) {
-        if (previews[roomId]) continue
         const preview = previewFromWire(sub?.room?.previewMessage)
         if (!preview) continue
+        const cur = previews[roomId]
+        // samePreview keeps the map reference stable on a no-op resync, which
+        // would otherwise re-render every row in the sidebar.
+        if (storedPreviewWins(cur, preview) || samePreview(cur, preview)) continue
         if (previews === state.previews) previews = { ...state.previews }
         previews[roomId] = preview
       }
@@ -1039,13 +1052,12 @@ export function roomEventsReducer(state, action) {
         // bootstrap still shows the server's plaintext — fully closing that
         // needs a backend change (withholding plaintext for encrypted rooms
         // server-side), not something this guard can fix client-side.
-        if (cur?.encrypted && cur.messageId === next.messageId) return state
         // Fix 7: broadcast-worker processes canonical messages concurrently,
         // so an edit/delete's server-resolved preview can be computed before
         // a genuinely newer message and still arrive after it — reject only
         // a STRICTLY older write; missing/unparseable timestamps are
         // accepted rather than dropped (see isOlderPreview).
-        if (isOlderPreview(next.createdAt, cur?.createdAt)) return state
+        if (storedPreviewWins(cur, next)) return state
         return { ...state, previews: { ...state.previews, [roomId]: next } }
       }
       // No preview on the event. For a delete that means nothing eligible is

--- a/chat-frontend/src/context/RoomEventsContext/reducer.test.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.test.js
@@ -1824,6 +1824,58 @@ describe('roomEventsReducer previews', () => {
     })
   })
 
+  it('BUCKETS_LOADED takes an older server preview when the stored message predates the row', () => {
+    // A delete this client never received (logged out, or core NATS at-most-once)
+    // leaves the deleted message stored. The row resolves the earlier survivor,
+    // and `room.lastMsgAt` — which a delete never rolls back — proves the stored
+    // message is inside the window the server just resolved over.
+    const seeded = {
+      ...initialState,
+      previews: {
+        r1: { messageId: 'm-deleted', senderName: 'Bob Lin', text: 'deleted while away', createdAt: '2026-08-14T12:00:00Z' },
+      },
+    }
+    const next = roomEventsReducer(seeded, {
+      type: 'BUCKETS_LOADED',
+      favoriteIds: [], appIds: [], channelDmIds: ['r1'],
+      rooms: [{ id: 'r1', name: 'General', type: 'channel', siteId: 'site-A', userCount: 2 }],
+      subscriptions: {
+        r1: {
+          roomId: 'r1',
+          room: {
+            lastMsgAt: '2026-08-14T12:00:00Z',
+            previewMessage: wirePreview({ messageId: 'm-older', createdAt: '2026-08-14T11:00:00Z' }),
+          },
+        },
+      },
+    })
+    expect(next.previews.r1.messageId).toBe('m-older')
+  })
+
+  it('BUCKETS_LOADED keeps a live preview that postdates the row', () => {
+    // The other side of the same rule: a message that arrived after the row was
+    // resolved is newer than its lastMsgAt, so the snapshot cannot supersede it.
+    const live = {
+      messageId: 'm-live', senderName: 'Live Sender', text: 'beat the fetch',
+      createdAt: '2026-08-14T13:00:00Z',
+    }
+    const next = roomEventsReducer({ ...initialState, previews: { r1: live } }, {
+      type: 'BUCKETS_LOADED',
+      favoriteIds: [], appIds: [], channelDmIds: ['r1'],
+      rooms: [{ id: 'r1', name: 'General', type: 'channel', siteId: 'site-A', userCount: 2 }],
+      subscriptions: {
+        r1: {
+          roomId: 'r1',
+          room: {
+            lastMsgAt: '2026-08-14T12:00:00Z',
+            previewMessage: wirePreview({ messageId: 'm-snapshot', createdAt: '2026-08-14T12:00:00Z' }),
+          },
+        },
+      },
+    })
+    expect(next.previews.r1).toEqual(live)
+  })
+
   it('BUCKETS_LOADED keeps an encrypted placeholder for the same message', () => {
     // Fix 3 parity: a resync's wire preview relays the body unencrypted, and
     // must not flip a row the timeline is deliberately refusing to render.

--- a/chat-frontend/src/context/RoomEventsContext/reducer.test.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.test.js
@@ -1898,22 +1898,42 @@ describe('roomEventsReducer previews', () => {
     expect(next.previews.r2).toEqual(cached)
   })
 
-  it('PREVIEWS_HYDRATED keeps a newer seeded preview', () => {
-    const wire = { messageId: 'm-wire', senderName: 'Alice Chen', text: 'newer', createdAt: '2026-08-14T12:00:00Z' }
-    const seeded = { ...initialState, previews: { r1: wire } }
-    const next = roomEventsReducer(seeded, {
-      type: 'PREVIEWS_HYDRATED',
-      previews: { r1: { messageId: 'm-old', senderName: 'Bob Lin', text: 'older', createdAt: '2026-08-14T10:00:00Z' } },
-    })
-    expect(next.previews.r1).toEqual(wire)
+  it('PREVIEWS_HYDRATED wins over the seeded map even when it looks older', () => {
+    // The cached previews map is written in the same record as the cached
+    // subscriptions and is a LATER snapshot of the same client's state, so it
+    // is authoritative — including when a delete rolled the room back to an
+    // earlier message than the subscription row's previewMessage.
+    const cached = { messageId: 'm-older', senderName: 'Bob Lin', text: 'survivor', createdAt: '2026-08-14T10:00:00Z' }
+    const seeded = {
+      ...initialState,
+      previews: {
+        r1: { messageId: 'm-deleted', senderName: 'Alice Chen', text: 'deleted', createdAt: '2026-08-14T12:00:00Z' },
+      },
+    }
+    const next = roomEventsReducer(seeded, { type: 'PREVIEWS_HYDRATED', previews: { r1: cached } })
+    expect(next.previews.r1).toEqual(cached)
   })
 
-  it('PREVIEWS_HYDRATED leaves the map alone when there is nothing to apply', () => {
+  it('PREVIEWS_HYDRATED drops a seeded preview the cache no longer holds', () => {
+    // A delete last session cleared the entry; the cached subscription row it
+    // was seeded from still names the deleted message, so absence has to win.
+    const seeded = {
+      ...initialState,
+      previews: {
+        r1: { messageId: 'm-deleted', senderName: 'Alice Chen', text: 'deleted', createdAt: '2026-08-14T12:00:00Z' },
+      },
+    }
+    const next = roomEventsReducer(seeded, { type: 'PREVIEWS_HYDRATED', previews: {} })
+    expect(next.previews).toEqual({})
+  })
+
+  it('PREVIEWS_HYDRATED without a payload leaves the map alone', () => {
+    // No previews map in the action means "this record carries none to apply",
+    // which is not the same statement as "this room has no preview".
     const seeded = {
       ...initialState,
       previews: { r1: { messageId: 'm1', senderName: 'A', text: 'x', createdAt: '2026-08-14T10:00:00Z' } },
     }
-    expect(roomEventsReducer(seeded, { type: 'PREVIEWS_HYDRATED', previews: {} }).previews).toBe(seeded.previews)
     expect(roomEventsReducer(seeded, { type: 'PREVIEWS_HYDRATED' }).previews).toBe(seeded.previews)
   })
 
@@ -2145,6 +2165,75 @@ describe('roomEventsReducer previews', () => {
         type: 'ROOM_PREVIEW_UPDATED', roomId: 'r1', deletedMessageId: 'm1',
       })
       expect(next.previews.r1).toBeUndefined()
+    })
+
+    it('takes the earlier survivor when the message on display is the one deleted', () => {
+      // Deleting the newest message resolves the room's preview to an EARLIER
+      // one, so the replacement is strictly older than what's stored. The
+      // recency guard must not apply — the stored message no longer exists.
+      const state = {
+        ...initialState,
+        previews: {
+          r1: { messageId: 'm-newest', senderName: 'Bob Lin', text: 'deleted', createdAt: '2026-08-14T12:00:00Z' },
+        },
+      }
+      const next = roomEventsReducer(state, {
+        type: 'ROOM_PREVIEW_UPDATED',
+        roomId: 'r1',
+        deletedMessageId: 'm-newest',
+        previewMessage: {
+          messageId: 'm-older',
+          sender: { account: 'alice', displayName: 'Alice Chen' },
+          content: 'the earlier survivor',
+          createdAt: '2026-08-14T11:00:00Z',
+        },
+      })
+      expect(next.previews.r1).toEqual({
+        messageId: 'm-older', senderName: 'Alice Chen', text: 'the earlier survivor',
+        createdAt: '2026-08-14T11:00:00Z',
+      })
+    })
+
+    it('still rejects an older preview when the delete is for a message not on display', () => {
+      const cur = { messageId: 'm-newest', senderName: 'Bob Lin', text: 'stays', createdAt: '2026-08-14T12:00:00Z' }
+      const next = roomEventsReducer({ ...initialState, previews: { r1: cur } }, {
+        type: 'ROOM_PREVIEW_UPDATED',
+        roomId: 'r1',
+        deletedMessageId: 'm-some-other',
+        previewMessage: {
+          messageId: 'm-older',
+          sender: { account: 'alice', displayName: 'Alice Chen' },
+          content: 'an older one',
+          createdAt: '2026-08-14T11:00:00Z',
+        },
+      })
+      expect(next.previews.r1).toEqual(cur)
+    })
+
+    it('replaces an encrypted placeholder when that very message is deleted', () => {
+      // Fix 3 protects a placeholder from the server's plaintext for the same
+      // message — but a delete of that message retires it either way.
+      const state = {
+        ...initialState,
+        previews: {
+          r1: {
+            messageId: 'm-enc', senderName: 'Alice Chen', text: '[encrypted message]',
+            createdAt: '2026-08-14T15:00:00Z', encrypted: true,
+          },
+        },
+      }
+      const next = roomEventsReducer(state, {
+        type: 'ROOM_PREVIEW_UPDATED',
+        roomId: 'r1',
+        deletedMessageId: 'm-enc',
+        previewMessage: {
+          messageId: 'm-older',
+          sender: { account: 'bob', displayName: 'Bob Lin' },
+          content: 'the earlier survivor',
+          createdAt: '2026-08-14T14:00:00Z',
+        },
+      })
+      expect(next.previews.r1.messageId).toBe('m-older')
     })
 
     it('does NOT clear when the deleted message is a different one', () => {

--- a/chat-frontend/src/context/RoomEventsContext/reducer.test.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.test.js
@@ -1784,23 +1784,87 @@ describe('roomEventsReducer previews', () => {
     // resolves, so a live message can land and be written to previews via
     // MESSAGE_RECEIVED before this dispatch fires. That live entry is NEWER
     // than the list snapshot's previewMessage and must survive.
-    const seeded = {
-      ...initialState,
-      previews: { r1: { messageId: 'm-live', senderName: 'Live Sender', text: 'just arrived' } },
+    const live = {
+      messageId: 'm-live', senderName: 'Live Sender', text: 'just arrived',
+      createdAt: '2026-08-14T11:00:00Z',
     }
+    const seeded = { ...initialState, previews: { r1: live } }
     const next = roomEventsReducer(seeded, {
       type: 'BUCKETS_LOADED',
       favoriteIds: [], appIds: [], channelDmIds: ['r1'],
       rooms: [{ id: 'r1', name: 'General', type: 'channel', siteId: 'site-A', userCount: 2 }],
       subscriptions: { r1: { roomId: 'r1', name: 'General', room: { previewMessage: wirePreview({ messageId: 'm-stale' }) } } },
     })
-    expect(next.previews.r1).toEqual({ messageId: 'm-live', senderName: 'Live Sender', text: 'just arrived' })
+    expect(next.previews.r1).toEqual(live)
+  })
+
+  it('BUCKETS_LOADED replaces a stale stored preview with a newer wire one', () => {
+    // Regression: `hydrateFromCache` replays BUCKETS_LOADED with LAST session's
+    // cached previewMessage, so by the time the network bootstrap lands every
+    // room already has an entry. A fill-if-absent seed drops the fresh server
+    // preview and the sidebar keeps showing the previous session's message.
+    const seeded = {
+      ...initialState,
+      previews: {
+        r1: {
+          messageId: 'm-cached', senderName: 'Alice Chen', text: 'from last session',
+          createdAt: '2026-08-13T09:00:00Z',
+        },
+      },
+    }
+    const next = roomEventsReducer(seeded, {
+      type: 'BUCKETS_LOADED',
+      favoriteIds: [], appIds: [], channelDmIds: ['r1'],
+      rooms: [{ id: 'r1', name: 'General', type: 'channel', siteId: 'site-A', userCount: 2 }],
+      subscriptions: { r1: { roomId: 'r1', name: 'General', room: { previewMessage: wirePreview({ messageId: 'm-newest' }) } } },
+    })
+    expect(next.previews.r1).toEqual({
+      messageId: 'm-newest', senderName: 'Alice Chen', text: 'hello there',
+      createdAt: '2026-08-14T10:00:00Z',
+    })
+  })
+
+  it('BUCKETS_LOADED keeps an encrypted placeholder for the same message', () => {
+    // Fix 3 parity: a resync's wire preview relays the body unencrypted, and
+    // must not flip a row the timeline is deliberately refusing to render.
+    const placeholder = {
+      messageId: 'm1', senderName: 'Alice Chen', text: '[encrypted message]',
+      createdAt: '2026-08-14T10:00:00Z', encrypted: true,
+    }
+    const seeded = { ...initialState, previews: { r1: placeholder } }
+    const next = roomEventsReducer(seeded, {
+      type: 'BUCKETS_LOADED',
+      favoriteIds: [], appIds: [], channelDmIds: ['r1'],
+      rooms: [{ id: 'r1', name: 'General', type: 'channel', siteId: 'site-A', userCount: 2 }],
+      subscriptions: { r1: { roomId: 'r1', name: 'General', room: { previewMessage: wirePreview() } } },
+    })
+    expect(next.previews.r1).toEqual(placeholder)
+  })
+
+  it('BUCKETS_LOADED keeps the previews reference stable when nothing changes', () => {
+    const stored = {
+      messageId: 'm1', senderName: 'Alice Chen', text: 'hello there',
+      createdAt: '2026-08-14T10:00:00Z',
+    }
+    const seeded = { ...initialState, previews: { r1: stored } }
+    const next = roomEventsReducer(seeded, {
+      type: 'BUCKETS_LOADED',
+      favoriteIds: [], appIds: [], channelDmIds: ['r1'],
+      rooms: [{ id: 'r1', name: 'General', type: 'channel', siteId: 'site-A', userCount: 2 }],
+      subscriptions: { r1: { roomId: 'r1', name: 'General', room: { previewMessage: wirePreview() } } },
+    })
+    expect(next.previews).toBe(seeded.previews)
   })
 
   it('BUCKETS_LOADED still seeds a room with no prior preview alongside one that is guarded', () => {
     const seeded = {
       ...initialState,
-      previews: { r1: { messageId: 'm-live', senderName: 'Live Sender', text: 'just arrived' } },
+      previews: {
+        r1: {
+          messageId: 'm-live', senderName: 'Live Sender', text: 'just arrived',
+          createdAt: '2026-08-14T11:00:00Z',
+        },
+      },
     }
     const next = roomEventsReducer(seeded, {
       type: 'BUCKETS_LOADED',

--- a/chat-frontend/src/context/RoomEventsContext/reducer.test.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.test.js
@@ -1883,6 +1883,40 @@ describe('roomEventsReducer previews', () => {
     expect(next.previews.r2.messageId).toBe('m-new-r2')
   })
 
+  it('PREVIEWS_HYDRATED takes the cached preview when it is newer', () => {
+    // Live messages update state.previews but never the cached subscription's
+    // previewMessage, so the cache carries the fresher snippet of the two.
+    const seeded = {
+      ...initialState,
+      previews: {
+        r1: { messageId: 'm-wire', senderName: 'Alice Chen', text: 'older', createdAt: '2026-08-14T10:00:00Z' },
+      },
+    }
+    const cached = { messageId: 'm-live', senderName: 'Bob Lin', text: 'newer', createdAt: '2026-08-14T12:00:00Z' }
+    const next = roomEventsReducer(seeded, { type: 'PREVIEWS_HYDRATED', previews: { r1: cached, r2: cached } })
+    expect(next.previews.r1).toEqual(cached)
+    expect(next.previews.r2).toEqual(cached)
+  })
+
+  it('PREVIEWS_HYDRATED keeps a newer seeded preview', () => {
+    const wire = { messageId: 'm-wire', senderName: 'Alice Chen', text: 'newer', createdAt: '2026-08-14T12:00:00Z' }
+    const seeded = { ...initialState, previews: { r1: wire } }
+    const next = roomEventsReducer(seeded, {
+      type: 'PREVIEWS_HYDRATED',
+      previews: { r1: { messageId: 'm-old', senderName: 'Bob Lin', text: 'older', createdAt: '2026-08-14T10:00:00Z' } },
+    })
+    expect(next.previews.r1).toEqual(wire)
+  })
+
+  it('PREVIEWS_HYDRATED leaves the map alone when there is nothing to apply', () => {
+    const seeded = {
+      ...initialState,
+      previews: { r1: { messageId: 'm1', senderName: 'A', text: 'x', createdAt: '2026-08-14T10:00:00Z' } },
+    }
+    expect(roomEventsReducer(seeded, { type: 'PREVIEWS_HYDRATED', previews: {} }).previews).toBe(seeded.previews)
+    expect(roomEventsReducer(seeded, { type: 'PREVIEWS_HYDRATED' }).previews).toBe(seeded.previews)
+  })
+
   it('MESSAGE_RECEIVED overwrites the preview for a room with no message buffer', () => {
     const next = roomEventsReducer(initialState, {
       type: 'MESSAGE_RECEIVED',

--- a/chat-frontend/src/context/RoomEventsContext/reducer.test.js
+++ b/chat-frontend/src/context/RoomEventsContext/reducer.test.js
@@ -1824,58 +1824,6 @@ describe('roomEventsReducer previews', () => {
     })
   })
 
-  it('BUCKETS_LOADED takes an older server preview when the stored message predates the row', () => {
-    // A delete this client never received (logged out, or core NATS at-most-once)
-    // leaves the deleted message stored. The row resolves the earlier survivor,
-    // and `room.lastMsgAt` — which a delete never rolls back — proves the stored
-    // message is inside the window the server just resolved over.
-    const seeded = {
-      ...initialState,
-      previews: {
-        r1: { messageId: 'm-deleted', senderName: 'Bob Lin', text: 'deleted while away', createdAt: '2026-08-14T12:00:00Z' },
-      },
-    }
-    const next = roomEventsReducer(seeded, {
-      type: 'BUCKETS_LOADED',
-      favoriteIds: [], appIds: [], channelDmIds: ['r1'],
-      rooms: [{ id: 'r1', name: 'General', type: 'channel', siteId: 'site-A', userCount: 2 }],
-      subscriptions: {
-        r1: {
-          roomId: 'r1',
-          room: {
-            lastMsgAt: '2026-08-14T12:00:00Z',
-            previewMessage: wirePreview({ messageId: 'm-older', createdAt: '2026-08-14T11:00:00Z' }),
-          },
-        },
-      },
-    })
-    expect(next.previews.r1.messageId).toBe('m-older')
-  })
-
-  it('BUCKETS_LOADED keeps a live preview that postdates the row', () => {
-    // The other side of the same rule: a message that arrived after the row was
-    // resolved is newer than its lastMsgAt, so the snapshot cannot supersede it.
-    const live = {
-      messageId: 'm-live', senderName: 'Live Sender', text: 'beat the fetch',
-      createdAt: '2026-08-14T13:00:00Z',
-    }
-    const next = roomEventsReducer({ ...initialState, previews: { r1: live } }, {
-      type: 'BUCKETS_LOADED',
-      favoriteIds: [], appIds: [], channelDmIds: ['r1'],
-      rooms: [{ id: 'r1', name: 'General', type: 'channel', siteId: 'site-A', userCount: 2 }],
-      subscriptions: {
-        r1: {
-          roomId: 'r1',
-          room: {
-            lastMsgAt: '2026-08-14T12:00:00Z',
-            previewMessage: wirePreview({ messageId: 'm-snapshot', createdAt: '2026-08-14T12:00:00Z' }),
-          },
-        },
-      },
-    })
-    expect(next.previews.r1).toEqual(live)
-  })
-
   it('BUCKETS_LOADED keeps an encrypted placeholder for the same message', () => {
     // Fix 3 parity: a resync's wire preview relays the body unencrypted, and
     // must not flip a row the timeline is deliberately refusing to render.
@@ -1950,42 +1898,22 @@ describe('roomEventsReducer previews', () => {
     expect(next.previews.r2).toEqual(cached)
   })
 
-  it('PREVIEWS_HYDRATED wins over the seeded map even when it looks older', () => {
-    // The cached previews map is written in the same record as the cached
-    // subscriptions and is a LATER snapshot of the same client's state, so it
-    // is authoritative — including when a delete rolled the room back to an
-    // earlier message than the subscription row's previewMessage.
-    const cached = { messageId: 'm-older', senderName: 'Bob Lin', text: 'survivor', createdAt: '2026-08-14T10:00:00Z' }
-    const seeded = {
-      ...initialState,
-      previews: {
-        r1: { messageId: 'm-deleted', senderName: 'Alice Chen', text: 'deleted', createdAt: '2026-08-14T12:00:00Z' },
-      },
-    }
-    const next = roomEventsReducer(seeded, { type: 'PREVIEWS_HYDRATED', previews: { r1: cached } })
-    expect(next.previews.r1).toEqual(cached)
+  it('PREVIEWS_HYDRATED keeps a newer seeded preview', () => {
+    const wire = { messageId: 'm-wire', senderName: 'Alice Chen', text: 'newer', createdAt: '2026-08-14T12:00:00Z' }
+    const seeded = { ...initialState, previews: { r1: wire } }
+    const next = roomEventsReducer(seeded, {
+      type: 'PREVIEWS_HYDRATED',
+      previews: { r1: { messageId: 'm-old', senderName: 'Bob Lin', text: 'older', createdAt: '2026-08-14T10:00:00Z' } },
+    })
+    expect(next.previews.r1).toEqual(wire)
   })
 
-  it('PREVIEWS_HYDRATED drops a seeded preview the cache no longer holds', () => {
-    // A delete last session cleared the entry; the cached subscription row it
-    // was seeded from still names the deleted message, so absence has to win.
-    const seeded = {
-      ...initialState,
-      previews: {
-        r1: { messageId: 'm-deleted', senderName: 'Alice Chen', text: 'deleted', createdAt: '2026-08-14T12:00:00Z' },
-      },
-    }
-    const next = roomEventsReducer(seeded, { type: 'PREVIEWS_HYDRATED', previews: {} })
-    expect(next.previews).toEqual({})
-  })
-
-  it('PREVIEWS_HYDRATED without a payload leaves the map alone', () => {
-    // No previews map in the action means "this record carries none to apply",
-    // which is not the same statement as "this room has no preview".
+  it('PREVIEWS_HYDRATED leaves the map alone when there is nothing to apply', () => {
     const seeded = {
       ...initialState,
       previews: { r1: { messageId: 'm1', senderName: 'A', text: 'x', createdAt: '2026-08-14T10:00:00Z' } },
     }
+    expect(roomEventsReducer(seeded, { type: 'PREVIEWS_HYDRATED', previews: {} }).previews).toBe(seeded.previews)
     expect(roomEventsReducer(seeded, { type: 'PREVIEWS_HYDRATED' }).previews).toBe(seeded.previews)
   })
 
@@ -2217,75 +2145,6 @@ describe('roomEventsReducer previews', () => {
         type: 'ROOM_PREVIEW_UPDATED', roomId: 'r1', deletedMessageId: 'm1',
       })
       expect(next.previews.r1).toBeUndefined()
-    })
-
-    it('takes the earlier survivor when the message on display is the one deleted', () => {
-      // Deleting the newest message resolves the room's preview to an EARLIER
-      // one, so the replacement is strictly older than what's stored. The
-      // recency guard must not apply — the stored message no longer exists.
-      const state = {
-        ...initialState,
-        previews: {
-          r1: { messageId: 'm-newest', senderName: 'Bob Lin', text: 'deleted', createdAt: '2026-08-14T12:00:00Z' },
-        },
-      }
-      const next = roomEventsReducer(state, {
-        type: 'ROOM_PREVIEW_UPDATED',
-        roomId: 'r1',
-        deletedMessageId: 'm-newest',
-        previewMessage: {
-          messageId: 'm-older',
-          sender: { account: 'alice', displayName: 'Alice Chen' },
-          content: 'the earlier survivor',
-          createdAt: '2026-08-14T11:00:00Z',
-        },
-      })
-      expect(next.previews.r1).toEqual({
-        messageId: 'm-older', senderName: 'Alice Chen', text: 'the earlier survivor',
-        createdAt: '2026-08-14T11:00:00Z',
-      })
-    })
-
-    it('still rejects an older preview when the delete is for a message not on display', () => {
-      const cur = { messageId: 'm-newest', senderName: 'Bob Lin', text: 'stays', createdAt: '2026-08-14T12:00:00Z' }
-      const next = roomEventsReducer({ ...initialState, previews: { r1: cur } }, {
-        type: 'ROOM_PREVIEW_UPDATED',
-        roomId: 'r1',
-        deletedMessageId: 'm-some-other',
-        previewMessage: {
-          messageId: 'm-older',
-          sender: { account: 'alice', displayName: 'Alice Chen' },
-          content: 'an older one',
-          createdAt: '2026-08-14T11:00:00Z',
-        },
-      })
-      expect(next.previews.r1).toEqual(cur)
-    })
-
-    it('replaces an encrypted placeholder when that very message is deleted', () => {
-      // Fix 3 protects a placeholder from the server's plaintext for the same
-      // message — but a delete of that message retires it either way.
-      const state = {
-        ...initialState,
-        previews: {
-          r1: {
-            messageId: 'm-enc', senderName: 'Alice Chen', text: '[encrypted message]',
-            createdAt: '2026-08-14T15:00:00Z', encrypted: true,
-          },
-        },
-      }
-      const next = roomEventsReducer(state, {
-        type: 'ROOM_PREVIEW_UPDATED',
-        roomId: 'r1',
-        deletedMessageId: 'm-enc',
-        previewMessage: {
-          messageId: 'm-older',
-          sender: { account: 'bob', displayName: 'Bob Lin' },
-          content: 'the earlier survivor',
-          createdAt: '2026-08-14T14:00:00Z',
-        },
-      })
-      expect(next.previews.r1.messageId).toBe('m-older')
     })
 
     it('does NOT clear when the deleted message is a different one', () => {

--- a/chat-frontend/src/lib/subscriptionCache.js
+++ b/chat-frontend/src/lib/subscriptionCache.js
@@ -31,8 +31,13 @@ export const CACHE_KEY = 'chat.subscriptionCache.v1'
 
 /** Bumped whenever the stored shape changes. A record written by an older
  *  (or newer) build is ignored rather than migrated — the bootstrap fetch
- *  refills it within a second. */
-export const CACHE_VERSION = 1
+ *  refills it within a second.
+ *
+ *  v2 added `previews`, which hydration reads as the room's whole preview
+ *  truth (an absent room means a delete cleared it). A v1 record has no such
+ *  map, and reading its absence as "everything was deleted" would blank the
+ *  warm paint — hence a bump rather than a tolerated missing field. */
+export const CACHE_VERSION = 2
 
 /** How many subscriptions a quota-failed write retries with, keeping the
  *  most recently active rooms. A truncated cache is fine: it only shortens

--- a/chat-frontend/src/lib/subscriptionCache.js
+++ b/chat-frontend/src/lib/subscriptionCache.js
@@ -31,13 +31,8 @@ export const CACHE_KEY = 'chat.subscriptionCache.v1'
 
 /** Bumped whenever the stored shape changes. A record written by an older
  *  (or newer) build is ignored rather than migrated — the bootstrap fetch
- *  refills it within a second.
- *
- *  v2 added `previews`, which hydration reads as the room's whole preview
- *  truth (an absent room means a delete cleared it). A v1 record has no such
- *  map, and reading its absence as "everything was deleted" would blank the
- *  warm paint — hence a bump rather than a tolerated missing field. */
-export const CACHE_VERSION = 2
+ *  refills it within a second. */
+export const CACHE_VERSION = 1
 
 /** How many subscriptions a quota-failed write retries with, keeping the
  *  most recently active rooms. A truncated cache is fine: it only shortens

--- a/chat-frontend/src/lib/subscriptionCache.js
+++ b/chat-frontend/src/lib/subscriptionCache.js
@@ -24,6 +24,7 @@
  * @property {string[]} appIds
  * @property {string[]} channelDmIds
  * @property {ChatlistState} [chatlist]
+ * @property {Record<string, object>} previews
  */
 
 export const CACHE_KEY = 'chat.subscriptionCache.v1'
@@ -46,6 +47,32 @@ function withoutPrivateKey(sub) {
   if (!sub?.room || !('privateKey' in sub.room)) return sub
   const { privateKey, ...room } = sub.room
   return { ...sub, room }
+}
+
+/** Keep each room's sidebar snippet, minus any encrypted placeholder. That
+ *  placeholder records "this client could not decrypt it THEN"; after a reload
+ *  the room key is seeded from `subscription.list` and the message may well
+ *  render, so it must not outlive the session. */
+function persistablePreviews(previews) {
+  const out = {}
+  for (const [roomId, preview] of Object.entries(previews ?? {})) {
+    if (!preview?.messageId || preview.encrypted) continue
+    out[roomId] = preview
+  }
+  return out
+}
+
+/** localStorage is user-editable, so a tampered previews map (or a record
+ *  written before previews were persisted) degrades to "no previews" rather
+ *  than reaching the reducer. */
+function readPreviews(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  const out = {}
+  for (const [roomId, preview] of Object.entries(value)) {
+    if (!preview || typeof preview !== 'object' || typeof preview.messageId !== 'string') continue
+    out[roomId] = preview
+  }
+  return out
 }
 
 /** The bucket ids live in state as Sets, and `JSON.stringify(new Set(…))`
@@ -86,9 +113,10 @@ function write(record) {
  *   appIds?: Iterable<string>,
  *   channelDmIds?: Iterable<string>,
  *   chatlist?: ChatlistState,
+ *   previews?: Record<string, object>,
  * }} slices
  */
-export function saveSubscriptionCache(user, { subscriptions, favoriteIds, appIds, channelDmIds, chatlist }) {
+export function saveSubscriptionCache(user, { subscriptions, favoriteIds, appIds, channelDmIds, chatlist, previews }) {
   if (!user?.account || !user?.siteId) return
   const record = {
     v: CACHE_VERSION,
@@ -102,6 +130,7 @@ export function saveSubscriptionCache(user, { subscriptions, favoriteIds, appIds
     appIds: toIdArray(appIds),
     channelDmIds: toIdArray(channelDmIds),
     chatlist,
+    previews: persistablePreviews(previews),
   }
   try {
     write(record)
@@ -110,7 +139,14 @@ export function saveSubscriptionCache(user, { subscriptions, favoriteIds, appIds
     // Fall through to the trimmed retry.
   }
   try {
-    write({ ...record, subscriptions: trimToRecent(record.subscriptions, QUOTA_RETRY_LIMIT) })
+    const trimmed = trimToRecent(record.subscriptions, QUOTA_RETRY_LIMIT)
+    // Previews follow the rooms they belong to — keeping the dropped ones would
+    // spend the quota this retry is trying to free.
+    const keptPreviews = {}
+    for (const roomId of Object.keys(trimmed)) {
+      if (record.previews[roomId]) keptPreviews[roomId] = record.previews[roomId]
+    }
+    write({ ...record, subscriptions: trimmed, previews: keptPreviews })
   } catch {
     clearSubscriptionCache()
   }
@@ -150,6 +186,7 @@ export function loadSubscriptionCache(user) {
     appIds: ids(record.appIds),
     channelDmIds: ids(record.channelDmIds),
     chatlist: record.chatlist,
+    previews: readPreviews(record.previews),
   }
 }
 

--- a/chat-frontend/src/lib/subscriptionCache.test.js
+++ b/chat-frontend/src/lib/subscriptionCache.test.js
@@ -25,6 +25,16 @@ function sub(roomId, overrides = {}) {
   }
 }
 
+function preview(over = {}) {
+  return {
+    messageId: 'm1',
+    senderName: 'Alice Chen',
+    text: 'the latest message',
+    createdAt: '2026-08-14T10:00:00Z',
+    ...over,
+  }
+}
+
 function payload(overrides = {}) {
   return {
     subscriptions: { r1: sub('r1') },
@@ -32,6 +42,7 @@ function payload(overrides = {}) {
     appIds: [],
     channelDmIds: ['r1'],
     chatlist: { sectionOrder: ['favorites'], sections: {}, sortMode: 'recent' },
+    previews: { r1: preview() },
     ...overrides,
   }
 }
@@ -124,6 +135,39 @@ describe('subscriptionCache', () => {
     expect(loadSubscriptionCache(USER).favoriteIds).toEqual([])
   })
 
+  it('drops an encrypted placeholder rather than pinning it past a reload', () => {
+    // The placeholder means "this client could not decrypt it THEN". After a
+    // reload the room key is seeded from subscription.list and the message may
+    // well render, so the stored snippet must not outlive the session.
+    saveSubscriptionCache(USER, payload({
+      previews: { r1: preview({ text: '[encrypted message]', encrypted: true }), r2: preview() },
+    }))
+    expect(loadSubscriptionCache(USER).previews).toEqual({ r2: preview() })
+  })
+
+  it('drops preview entries that are malformed', () => {
+    saveSubscriptionCache(USER, payload({
+      previews: { r1: preview(), r2: null, r3: { senderName: 'No Id' }, r4: 'nope' },
+    }))
+    expect(loadSubscriptionCache(USER).previews).toEqual({ r1: preview() })
+  })
+
+  it('falls back to empty previews for a record that has none', () => {
+    saveSubscriptionCache(USER, payload())
+    const record = JSON.parse(window.localStorage.getItem(CACHE_KEY))
+    delete record.previews
+    window.localStorage.setItem(CACHE_KEY, JSON.stringify(record))
+    expect(loadSubscriptionCache(USER).previews).toEqual({})
+  })
+
+  it('falls back to empty previews when the stored value is not an object', () => {
+    saveSubscriptionCache(USER, payload())
+    const record = JSON.parse(window.localStorage.getItem(CACHE_KEY))
+    record.previews = 'tampered'
+    window.localStorage.setItem(CACHE_KEY, JSON.stringify(record))
+    expect(loadSubscriptionCache(USER).previews).toEqual({})
+  })
+
   it('clearSubscriptionCache removes the record', () => {
     saveSubscriptionCache(USER, payload())
     clearSubscriptionCache()
@@ -152,6 +196,29 @@ describe('subscriptionCache', () => {
     // The five oldest rooms are the ones dropped.
     expect(loaded.subscriptions.r0).toBeUndefined()
     expect(loaded.subscriptions[`r${QUOTA_RETRY_LIMIT + 4}`]).toBeDefined()
+  })
+
+  it('trims previews to the rooms the quota retry kept', () => {
+    const subscriptions = {}
+    const previews = {}
+    for (let i = 0; i < QUOTA_RETRY_LIMIT + 5; i++) {
+      subscriptions[`r${i}`] = sub(`r${i}`, {
+        room: { lastMsgAt: new Date(1_700_000_000_000 + i * 1000).toISOString() },
+      })
+      previews[`r${i}`] = preview({ messageId: `m${i}` })
+    }
+    const quotaErr = new Error('quota')
+    quotaErr.name = 'QuotaExceededError'
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementationOnce(() => {
+      throw quotaErr
+    })
+    saveSubscriptionCache(USER, payload({ subscriptions, previews }))
+    setItem.mockRestore()
+
+    const loaded = loadSubscriptionCache(USER)
+    expect(Object.keys(loaded.previews)).toHaveLength(QUOTA_RETRY_LIMIT)
+    expect(loaded.previews.r0).toBeUndefined()
+    expect(loaded.previews[`r${QUOTA_RETRY_LIMIT + 4}`]).toBeDefined()
   })
 
   it('clears the record when even the trimmed retry exceeds quota', () => {

--- a/outbox-worker/integration_test.go
+++ b/outbox-worker/integration_test.go
@@ -54,6 +54,20 @@ func createStream(t *testing.T, js jetstream.JetStream, cfg stream.Config) {
 	require.NoError(t, err)
 }
 
+// stopConsumer ends a test's consume loop and WAITS for it to finish, before
+// the connection cleanup registered earlier closes nc underneath it. Stop()
+// only unsubscribes — a callback still awaiting its forward's PubAck then fails
+// with "nats: connection closed" and fails a test whose assertions all passed.
+func stopConsumer(t *testing.T, cc jetstream.ConsumeContext) {
+	t.Helper()
+	cc.Drain()
+	select {
+	case <-cc.Closed():
+	case <-time.After(10 * time.Second):
+		t.Log("consume loop still draining after 10s; closing the connection under it")
+	}
+}
+
 // jsPublish is the same publish shape main.go wires into the handler: a
 // PubAck-blocking JetStream publish carrying msgID as the Nats-Msg-Id.
 func jsPublish(js jetstream.JetStream) PublishFunc {
@@ -138,7 +152,7 @@ func assertConcurrentLaneForwards(t *testing.T, siteID, destSiteID, roomID, even
 		_ = msg.Ack()
 	})
 	require.NoError(t, err)
-	t.Cleanup(cc.Stop)
+	t.Cleanup(func() { stopConsumer(t, cc) })
 
 	// Publish the relay event onto the OUTBOX stream's destination-scoped subject.
 	_, err = js.Publish(ctx, subject.Outbox(siteID, destSiteID, eventType), relayEvt)
@@ -239,7 +253,7 @@ func TestIntegration_ConcurrentLanePerDestinationIsolation(t *testing.T) {
 			jsretry.Settle(ctx, msg, []time.Duration{50 * time.Millisecond}, h.HandleEvent(ctx, msg.Subject(), msg.Data()))
 		})
 		require.NoError(t, err)
-		t.Cleanup(cc.Stop)
+		t.Cleanup(func() { stopConsumer(t, cc) })
 	}
 
 	// The healthy peer's event forwards despite the down peer's forever-retrying
@@ -310,7 +324,7 @@ func TestIntegration_OrderedLaneFIFOThroughOutage(t *testing.T) {
 		jsretry.Settle(ctx, msg, []time.Duration{50 * time.Millisecond}, h.HandleEvent(ctx, msg.Subject(), msg.Data()))
 	})
 	require.NoError(t, err)
-	t.Cleanup(cc.Stop)
+	t.Cleanup(func() { stopConsumer(t, cc) })
 
 	// While the destination is down nothing advances: the head member_added
 	// keeps failing (nothing captures the forward, PubAck times out) and holds
@@ -399,7 +413,7 @@ func TestIntegration_OrderedLaneKeepsRenameBehindMemberAdded(t *testing.T) {
 		jsretry.Settle(ctx, msg, jsretry.DefaultBackoff, h.HandleEvent(ctx, msg.Subject(), msg.Data()))
 	})
 	require.NoError(t, err)
-	t.Cleanup(cc.Stop)
+	t.Cleanup(func() { stopConsumer(t, cc) })
 
 	inboxStream, err := js.Stream(ctx, inboxCfg.Name)
 	require.NoError(t, err)

--- a/outbox-worker/integration_test.go
+++ b/outbox-worker/integration_test.go
@@ -64,7 +64,10 @@ func stopConsumer(t *testing.T, cc jetstream.ConsumeContext) {
 	select {
 	case <-cc.Closed():
 	case <-time.After(10 * time.Second):
-		t.Log("consume loop still draining after 10s; closing the connection under it")
+		// Returning here puts the connection cleanup back on top of a live
+		// callback — the very race this helper exists to close — so a drain
+		// that never finishes is a teardown failure, not a note.
+		t.Errorf("consume loop still draining after 10s; connection would close under a live callback")
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes a regression where cached previews from a previous session would persist in the sidebar after re-login, and ensures that encrypted message placeholders are not overwritten by unencrypted wire previews during resync.

## Key Changes

- **Refactored preview comparison logic** into a new `storedPreviewWins()` helper that consolidates two conditions:
  - Encrypted placeholders for the same message ID are preserved (Fix 3)
  - Stored previews newer than incoming wire previews are kept (Fix 7)

- **Changed BUCKETS_LOADED behavior** from fill-if-absent to always compare incoming previews:
  - Previously only seeded rooms with no prior preview, allowing stale cached entries to persist
  - Now compares all incoming previews against stored ones and replaces them unless the stored version wins
  - Prevents re-login from showing the previous session's messages in the sidebar

- **Added reference stability optimization** via `samePreview()` check:
  - Avoids unnecessary object mutations when a resync carries the same preview
  - Prevents sidebar re-renders on no-op syncs

- **Updated MESSAGE_RECEIVED** to use the consolidated `storedPreviewWins()` logic for consistency

- **Added comprehensive test coverage**:
  - Test for preserving live messages that arrive before BUCKETS_LOADED resolves
  - Test for replacing stale cached previews with fresher server ones
  - Test for keeping encrypted placeholders when the same message is resync'd
  - Test for reference stability when nothing changes
  - Integration test verifying the re-login scenario end-to-end

## Implementation Details

The fix addresses the hydration regression where `hydrateFromCache` replays BUCKETS_LOADED with the previous session's cached `previewMessage`. By the time the network bootstrap lands, every room already has a stale entry. The old fill-if-absent logic would skip updating these rooms, leaving the sidebar showing outdated messages.

The new approach compares timestamps (`createdAt`) to determine which preview is fresher, with special handling for encrypted messages to avoid flipping rows that the timeline deliberately refuses to render.

https://claude.ai/code/session_01DwBSL6i3tBedQAS8E6tAhb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room preview synchronization when loading rooms.
  * Stale cached previews are now replaced by newer messages.
  * Preserved newer live previews and encrypted message placeholders.
  * Ensured rooms without existing previews still display their latest available preview.
  * Prevented deleted messages from remaining pinned in the room list.
  * Restored room previews across sessions while removing invalid or outdated cached entries.
  * Improved preview handling when cached messages are deleted while offline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->