### PR TITLE
feat(media-service): add DEFAULT_AVATAR_ENABLED toggle for the generated default avatar

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -6875,6 +6875,8 @@ HTTP endpoints served by `media-service` — the three GETs are public, the two 
 
 **Default image:** when no custom image exists (and for users with no `employeeId`), the service returns a deterministic SVG "initials" avatar (`Content-Type: image/svg+xml`) generated on the fly — never stored. The SVG is cacheable: it carries a stable `ETag` and `Cache-Control: public, max-age=<cfg>`.
 
+**Default-avatar toggle:** the generated default is gated by `DEFAULT_AVATAR_ENABLED` (default `true`). When disabled, every avatar endpoint returns `404 not_found` instead of synthesizing the SVG (for rooms, users with no `employeeId`, and bots), and the client MUST render its own fallback on image-load failure — the same `<img onerror>` contract as the employee-photo `404` case below.
+
 **Frontend-default contract for user avatars:** after a `307` to the employee-photo host, a user who has an `employeeId` but no actual photo on that host receives a `404` from the external service. The client MUST render its own fallback on image-load failure (`<img onerror>`). The server-side default (initials SVG) only covers users with no `employeeId`, bots, and rooms.
 
 ### GET /api/v1/avatar/:accountName

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -6875,7 +6875,7 @@ HTTP endpoints served by `media-service` — the three GETs are public, the two 
 
 **Default image:** when no custom image exists (and for users with no `employeeId`), the service returns a deterministic SVG "initials" avatar (`Content-Type: image/svg+xml`) generated on the fly — never stored. The SVG is cacheable: it carries a stable `ETag` and `Cache-Control: public, max-age=<cfg>`.
 
-**Default-avatar toggle:** the generated default is gated by `DEFAULT_AVATAR_ENABLED` (default `true`). When disabled, every avatar endpoint returns `404 not_found` instead of synthesizing the SVG (for rooms, users with no `employeeId`, and bots), and the client MUST render its own fallback on image-load failure — the same `<img onerror>` contract as the employee-photo `404` case below.
+**Default-avatar toggle:** the generated default is gated by `DEFAULT_AVATAR_ENABLED` (default `true`). When disabled, every avatar endpoint returns `404 not_found` instead of synthesizing the SVG (for rooms, users with no `employeeId`, and bots), and the client MUST render its own fallback on image-load failure — the same `<img onerror>` contract as the employee-photo `404` case below. Both the SVG and the disabled `404` carry the same `Cache-Control: public, max-age=<cfg>`, so **a toggle change propagates to shared/browser caches within that window** (default 6h); purge those caches to apply it immediately.
 
 **Frontend-default contract for user avatars:** after a `307` to the employee-photo host, a user who has an `employeeId` but no actual photo on that host receives a `404` from the external service. The client MUST render its own fallback on image-load failure (`<img onerror>`). The server-side default (initials SVG) only covers users with no `employeeId`, bots, and rooms.
 

--- a/media-service/avatar_toggle_test.go
+++ b/media-service/avatar_toggle_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/hmchangw/chat/pkg/model"
+)
+
+// newDisabledAvatarRouter builds the avatar router with DEFAULT_AVATAR_ENABLED=false.
+func newDisabledAvatarRouter(t *testing.T) (*gin.Engine, *MockavatarStore) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	store := NewMockavatarStore(ctrl)
+	h := newHandler(store, NewMockemojiStore(ctrl), &fakeBlobStore{}, &config{
+		SiteID:               "s1",
+		EmployeePhotoBaseURL: "https://photos.example.com",
+		CacheMaxAgeSeconds:   3600,
+		DefaultAvatarEnabled: false,
+		MinioBucket:          "avatars",
+		EIDCacheCapacity:     1000,
+		EIDCacheTTL:          time.Minute,
+	})
+	r := gin.New()
+	registerRoutes(r, h, &fakeSessionValidator{principal: adminPrincipal()}, testSiteID)
+	return r, store
+}
+
+func get(t *testing.T, r *gin.Engine, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+	return w
+}
+
+// With the default disabled, every generated-default path returns 404 instead of an SVG.
+func TestDefaultAvatarDisabled_User_404(t *testing.T) {
+	r, store := newDisabledAvatarRouter(t)
+	store.EXPECT().EmployeeID(gomock.Any(), "alice").Return("", false, nil)
+	w := get(t, r, "/api/v1/avatar/alice")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.NotContains(t, w.Body.String(), "<svg")
+	assert.Contains(t, w.Body.String(), "not_found")
+}
+
+func TestDefaultAvatarDisabled_Bot_404(t *testing.T) {
+	r, store := newDisabledAvatarRouter(t)
+	store.EXPECT().BotSite(gomock.Any(), "helper.bot").Return("", false, nil)
+	w := get(t, r, "/api/v1/avatar/helper.bot")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.NotContains(t, w.Body.String(), "<svg")
+}
+
+func TestDefaultAvatarDisabled_Room_404(t *testing.T) {
+	r, store := newDisabledAvatarRouter(t)
+	store.EXPECT().RoomSite(gomock.Any(), "room1").Return("", model.RoomType(""), "", false, nil)
+	w := get(t, r, "/api/v1/avatar/room/room1")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.NotContains(t, w.Body.String(), "<svg")
+}
+
+// Enabled (default) still serves the SVG — the toggle is the only difference.
+func TestDefaultAvatarEnabled_User_SVG(t *testing.T) {
+	r, store, _ := newTestRouter(t)
+	store.EXPECT().EmployeeID(gomock.Any(), "alice").Return("", false, nil)
+	w := get(t, r, "/api/v1/avatar/alice")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "image/svg+xml", w.Header().Get("Content-Type"))
+	assert.Contains(t, w.Body.String(), "<svg")
+}

--- a/media-service/avatar_toggle_test.go
+++ b/media-service/avatar_toggle_test.go
@@ -48,6 +48,8 @@ func TestDefaultAvatarDisabled_User_404(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 	assert.NotContains(t, w.Body.String(), "<svg")
 	assert.Contains(t, w.Body.String(), "not_found")
+	// Bounded negative-cache so a disabled default doesn't force a per-render backend lookup.
+	assert.Equal(t, "public, max-age=3600", w.Header().Get("Cache-Control"))
 }
 
 func TestDefaultAvatarDisabled_Bot_404(t *testing.T) {

--- a/media-service/config.go
+++ b/media-service/config.go
@@ -77,6 +77,11 @@ type config struct {
 	MaxUploadBytes     int64 `env:"MAX_UPLOAD_BYTES" envDefault:"1048576"`
 	CacheMaxAgeSeconds int   `env:"CACHE_MAX_AGE_SECONDS" envDefault:"21600"`
 
+	// DefaultAvatarEnabled gates the generated "initials" default avatar. When
+	// false, the avatar endpoints return 404 instead of synthesizing an SVG, so
+	// the client renders its own fallback.
+	DefaultAvatarEnabled bool `env:"DEFAULT_AVATAR_ENABLED" envDefault:"true"`
+
 	// Custom-emoji upload limits. Bytes cap the raw body; dimension caps the
 	// decoded width AND height independently.
 	EmojiMaxUploadBytes int64 `env:"EMOJI_MAX_UPLOAD_BYTES" envDefault:"262144"`

--- a/media-service/config_test.go
+++ b/media-service/config_test.go
@@ -93,6 +93,32 @@ func TestConfig_MaxConcurrency(t *testing.T) {
 	})
 }
 
+func TestConfig_DefaultAvatarEnabled(t *testing.T) {
+	t.Setenv("SITE_ID", "s1")
+	t.Setenv("CLUSTER_DOMAINS", `[{"siteID":"s1","domain":"http://localhost:8080"}]`)
+	t.Setenv("EMPLOYEE_PHOTO_BASE_URL", "https://photos.example.com")
+	t.Setenv("MONGO_URI", "mongodb://localhost:27017")
+	t.Setenv("MINIO_ENDPOINT", "localhost:9000")
+	t.Setenv("MINIO_ACCESS_KEY", "k")
+	t.Setenv("MINIO_SECRET_KEY", "s")
+	t.Setenv("NATS_URL", "nats://localhost:4222")
+	t.Setenv("BOTPLATFORM_URL", "https://botplatform.example.com")
+
+	t.Run("default true", func(t *testing.T) {
+		require.NoError(t, os.Unsetenv("DEFAULT_AVATAR_ENABLED"))
+		cfg, err := env.ParseAs[config]()
+		require.NoError(t, err)
+		assert.True(t, cfg.DefaultAvatarEnabled)
+	})
+
+	t.Run("override false", func(t *testing.T) {
+		t.Setenv("DEFAULT_AVATAR_ENABLED", "false")
+		cfg, err := env.ParseAs[config]()
+		require.NoError(t, err)
+		assert.False(t, cfg.DefaultAvatarEnabled)
+	})
+}
+
 // TestConfig_BotplatformURLRequired guards the tag that keeps the write endpoints
 // from ever being served anonymously: absent and empty must both refuse to start.
 func TestConfig_BotplatformURLRequired(t *testing.T) {

--- a/media-service/config_test.go
+++ b/media-service/config_test.go
@@ -105,7 +105,13 @@ func TestConfig_DefaultAvatarEnabled(t *testing.T) {
 	t.Setenv("BOTPLATFORM_URL", "https://botplatform.example.com")
 
 	t.Run("default true", func(t *testing.T) {
+		orig, had := os.LookupEnv("DEFAULT_AVATAR_ENABLED")
 		require.NoError(t, os.Unsetenv("DEFAULT_AVATAR_ENABLED"))
+		t.Cleanup(func() {
+			if had {
+				_ = os.Setenv("DEFAULT_AVATAR_ENABLED", orig)
+			}
+		})
 		cfg, err := env.ParseAs[config]()
 		require.NoError(t, err)
 		assert.True(t, cfg.DefaultAvatarEnabled)

--- a/media-service/handler.go
+++ b/media-service/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/errcode/errhttp"
 	"github.com/hmchangw/chat/pkg/model"
 )
@@ -48,6 +49,12 @@ func (h *handler) setImageCacheHeaders(c *gin.Context, etag string) {
 
 func (h *handler) serveDefault(c *gin.Context, kind, seed, name string) {
 	c.Set("media_kind", kind)
+	if !h.cfg.DefaultAvatarEnabled {
+		// Default generated avatar disabled: 404 so the client renders its own fallback.
+		c.Set("media_outcome", "disabled")
+		errhttp.Write(c.Request.Context(), c, errcode.NotFound("avatar not found"))
+		return
+	}
 	c.Set("media_outcome", "default")
 	etag := defaultETag(seed, name)
 	h.setImageCacheHeaders(c, etag)

--- a/media-service/handler.go
+++ b/media-service/handler.go
@@ -50,8 +50,11 @@ func (h *handler) setImageCacheHeaders(c *gin.Context, etag string) {
 func (h *handler) serveDefault(c *gin.Context, kind, seed, name string) {
 	c.Set("media_kind", kind)
 	if !h.cfg.DefaultAvatarEnabled {
-		// Default generated avatar disabled: 404 so the client renders its own fallback.
+		// Default generated avatar disabled: a cacheable 404 (same bounded max-age as the
+		// SVG) so the client renders its own fallback without re-hitting the backend on
+		// every render; a toggle change propagates within that window.
 		c.Set("media_outcome", "disabled")
+		h.setImageCacheHeaders(c, "")
 		errhttp.Write(c.Request.Context(), c, errcode.NotFound("avatar not found"))
 		return
 	}

--- a/media-service/handler_test.go
+++ b/media-service/handler_test.go
@@ -34,6 +34,7 @@ func newEmojiTestRouter(t *testing.T) (*gin.Engine, *MockavatarStore, *Mockemoji
 		SiteID:               "s1",
 		EmployeePhotoBaseURL: "https://photos.example.com",
 		CacheMaxAgeSeconds:   3600,
+		DefaultAvatarEnabled: true,
 		MinioBucket:          "avatars",
 		ClusterDomains:       clusterDomains{byID: map[string]string{"s2": "https://avatar-s2"}}, // keep the original s2 value — existing avatar tests assert on it
 		MaxUploadBytes:       1048576,


### PR DESCRIPTION
## Summary

Add a config toggle to enable/disable the **generated default avatar** — the on-the-fly "initials" SVG media-service synthesizes when no custom image exists. When disabled, the avatar endpoints return `404 not_found` instead of the SVG, so the client renders its own fallback (the same `<img onerror>` contract already documented for the employee-photo `404` case). Default **on**, preserving current behavior.

## What's included

- New env flag `DEFAULT_AVATAR_ENABLED` (default `true`).
- A single guard in `serveDefault` — the one chokepoint every no-custom-image path routes through (rooms, DM/botDM, users without an `employeeId`, bots, and the blob-missing fallback) — so the toggle covers all of them consistently.
- Docs: the avatar section of `docs/client-api.md` documents the disabled `404` behavior.
- Unit tests: disabled → `404` for room / user / bot; enabled → SVG (contrast).

## Changes

- `media-service/config.go` — add `DefaultAvatarEnabled bool` (`DEFAULT_AVATAR_ENABLED`, default `true`).
- `media-service/handler.go` — `serveDefault` returns `errcode.NotFound("avatar not found")` (via `errhttp.Write`) when the flag is off, before synthesizing the SVG. No route or storage change.
- `media-service/avatar_toggle_test.go` — disabled-path tests (room/user/bot → 404) + an enabled-path contrast test.
- `media-service/handler_test.go` — set the flag in the shared test config so existing default-SVG tests keep their current behavior.
- `docs/client-api.md` — avatar section note.

## Verification

- `go test ./media-service/...` — green (full package).
- Lint clean on the touched service.
- Enabled (default) path unchanged: SVG served with the existing `ETag`/`Cache-Control`/`304` behavior. Disabled path returns `404 not_found` across rooms, users-without-`employeeId`, and bots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable or disable server-generated default avatar initials.
  * When disabled, avatar requests return a cacheable `404`, allowing clients to display their own fallback image.
  * Default avatar generation remains enabled by default.
  * Avatar responses include cache controls so configuration changes take effect after the cache period or an explicit purge.

* **Documentation**
  * Documented the configuration option, caching behavior, and client fallback handling.

* **Tests**
  * Added coverage for enabled and disabled behavior across user, bot, and room avatars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->