### PR TITLE
feat(visibleto): store and surface the client-set visibility marker end-to-end

### DIFF
--- a/broadcast-worker/preview.go
+++ b/broadcast-worker/preview.go
@@ -19,11 +19,10 @@ import (
 
 // eligibleAsPreview reports whether an inserted message may become the room's preview.
 // deleted is false: a message on the created subject has never been deleted.
-// The canonical event carries no visible_to column, so "" here is a statement of what
-// this path can see, not a claim the message is unrestricted. preview.Eligible takes the
-// argument so whoever lands the write path has to answer for it at both call sites (#364).
+// VisibleTo is not consulted — a message with a visibility marker is still previewed and
+// carries it, leaving the client to honour the scope.
 func eligibleAsPreview(msg *model.Message) bool {
-	return preview.Eligible(false, msg.Type, "")
+	return preview.Eligible(false, msg.Type)
 }
 
 // previewSealTimeout bounds the seal's two external calls — the bot app-name read and
@@ -74,6 +73,7 @@ func (p *previewSealer) sealInserted(
 		CreatedAt:   msg.CreatedAt,
 		Attachments: decoded,
 		Mentions:    mentions,
+		VisibleTo:   msg.VisibleTo,
 	})
 	sealed, err := preview.Seal(ctx, p.cipher, p.key, msg.ID, pvw)
 	if err != nil {

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -1020,11 +1020,11 @@ document (`previewMessage` always omitted there). All fields are optional
 
 A room's most-recent **eligible** message, composed and stored when that message is
 delivered, and enriched for room-list rendering. Eligible = not soft-deleted and not a
-system message and not visibility-restricted (quoted replies are normal content and ARE
-eligible) — an ineligible newer message leaves the stored preview in place, so the room
-keeps showing its last real content; a room with only ineligible messages omits
-`previewMessage`. A restricted message is never previewed: one preview is stored per
-room, while visibility is per-user, so the room list has no way to honour the scope.
+system message (quoted replies are normal content and ARE eligible) — an ineligible newer
+message leaves the stored preview in place, so the room keeps showing its last real
+content; a room with only ineligible messages omits `previewMessage`. A message carrying a
+`visibleTo` marker **is** eligible and is previewed with the marker attached: the backend
+does not filter previews on `visibleTo`, so the client honours the scope.
 
 Editing or deleting a message also updates the stored preview: an edit to the previewed
 message refreshes it, and deleting it moves the preview back to the previous eligible
@@ -1062,6 +1062,7 @@ that preview.
 | `createdAt` | string | RFC 3339 timestamp. |
 | `attachments` | [Attachment](#attachment)[] | Optional. Omitted when the message has none. At most 10 — the room list renders a count, not the set. |
 | `mentions` | [Participant](#participant)[] | Optional. Mentioned users as wire Participants. Omitted when none. At most 20. |
+| `visibleTo` | string | Optional. The message's opaque visibility marker, surfaced verbatim; the backend does not filter the preview on it. |
 
 #### AppSubscription
 
@@ -2914,7 +2915,7 @@ Used by every history-service method that returns messages. Mirrors the Cassandr
 | `threadParentId` | string | Optional. Set when this message is a thread reply. |
 | `threadParentCreatedAt` | string | Optional. RFC 3339. |
 | `quotedParentMessage` | [QuotedParentMessage](#quotedparentmessage) | Optional. Embedded snapshot of the quoted message. |
-| `visibleTo` | string | Optional. Visibility scope. |
+| `visibleTo` | string | Optional. Opaque client-set visibility marker (set on `msg.send`). Stored and surfaced verbatim; the backend never filters delivery, reads, or previews on it — the client interprets the scope. |
 | `reactions` | map<emoji, [ReactionUser](#reactionuser)[]> | Optional. Omitted when absent; `{}` when present but empty. |
 | `deleted` | boolean | Optional. `true` for tombstoned messages. |
 | `type` | string | Optional. System-message type when set; regular messages omit it. Known values: `"room_created"`, `"members_added"`, `"member_removed"`, `"member_left"`, `"room_renamed"`. For all five, `msg` is populated with a server-rendered human-readable body and `sender.account` is the responsible actor (the requester for adds/removes-by-other / room-creates / renames, the leaving user for self-leave). `"room_restricted"` also appears on historical messages: it is no longer produced — a restriction change emits a [room event](client-api/events.md#room_restricted-roomrestrictedroomevent) instead — but rows written before that change remain readable. |
@@ -6302,6 +6303,7 @@ The same subject and request body cover three send variants: plain message, thre
 | `tshow` | boolean | no | The "Also send to channel" option. Only meaningful on a thread reply (`threadParentMessageId` set): the reply is persisted into the parent room's channel timeline as well as the thread (dual-write into `messages_by_room` in addition to `thread_messages_by_thread` + `messages_by_id`), and is surfaced with `tshow: true` on the persisted message. On a non-thread send the flag is **ignored and normalized to `false`** — the request is not rejected. |
 | `quotedParentMessageId` | string | no | Set when posting a quoted message. The gatekeeper fetches the authoritative parent snapshot from message history and embeds it in the persisted message. If that fetch fails *transiently* (history briefly unavailable), the message is not dropped: the gatekeeper inserts a placeholder snapshot for live delivery (body `"Content temporarily unavailable"`), and `message-worker` re-projects the authoritative snapshot (or drops the quote) from history before the durable write, so the placeholder never persists. A genuinely missing/forbidden parent is still rejected. |
 | `type` | string | no | Optional client-settable message type. The only accepted value is `"important"` (an important message — previews and notifies like a normal message). Any other value, including a system type (`room_created`, etc.), is rejected with `bad_request`. Omitted = a normal message. |
+| `visibleTo` | string | no | Optional opaque visibility marker, ≤ 4096 bytes. Stored and surfaced verbatim (on history reads and the room-list preview); the server never interprets it or filters delivery, reads, or previews on it — the client interprets visibility. Oversize is rejected with `bad_request`. |
 
 ##### Plain message
 
@@ -6368,6 +6370,7 @@ Delivered on `chat.user.{account}.response.{requestId}`. The body is the persist
 | `threadParentMessageCreatedAt` | string | Optional. RFC 3339. Server-resolved best-effort for a thread reply; absent when the parent's createdAt could not be resolved at send time. |
 | `tshow` | boolean | Present only when the request set `tshow: true` on a thread reply (absent when the flag was normalized away on a non-thread send). |
 | `quotedParentMessage` | [QuotedParentMessage](#quotedparentmessage) | Present only for a quoted send — the server-fetched snapshot of the quoted parent. |
+| `visibleTo` | string | Present only when the request set `visibleTo` — echoed verbatim. |
 
 The gatekeeper does **not** populate `mentions`, `editedAt`/`updatedAt`, `type`, or `sysMsgData` on this reply (all `omitempty`, so they are absent). Mention resolution and the enriched `sender` happen in the broadcast fan-out event ([§4 triggered events](#triggered-events--success-path)), not in this reply.
 
@@ -6395,6 +6398,7 @@ Delivered on `chat.user.{account}.response.{requestId}`. See [Error envelope](#6
 | `content must not be empty` | `bad_request` | — | Empty `content`. |
 | `invalid message type "…"` | `bad_request` | — | `type` is set to something other than `"important"` (e.g. a system type). |
 | `content exceeds maximum size of 20480 bytes` | `bad_request` | — | `content` > 20 KiB. |
+| `visibleTo exceeds maximum size of 4096 bytes` | `bad_request` | — | `visibleTo` > 4096 bytes. |
 | `not subscribed` | `forbidden` | `not_subscribed` | Sender is not a member of the room. |
 | `posting is restricted to owners and admins in this room` | `forbidden` | `large_room_post_restricted` | Non-owner/admin/bot posting a top-level message in a room above the large-room threshold (thread replies are exempt). |
 | `quoted parent {id} not found` | `not_found` | — | The quoted message lookup failed (deleted, cross-room, …). |

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -2278,6 +2278,7 @@ and quoted message; variant determined by optional fields.
 | `threadParentMessageId` | string | no | Thread reply: the parent's message ID (20-char base62). |
 | `tshow` | boolean | no | "Also send to channel". Only meaningful on a thread reply; ignored on non-thread sends. |
 | `quotedParentMessageId` | string | no | Quoted message: the parent's message ID. Server fetches and embeds the authoritative snapshot from message history. On a *transient* history outage the live copy gets a `"Content temporarily unavailable"` placeholder, re-projected to the authoritative snapshot (or dropped) before the durable write — the placeholder never persists. A genuinely missing/forbidden parent is still rejected. |
+| `visibleTo` | string | no | Opaque visibility marker, ≤ 4096 bytes. Stored and surfaced verbatim; the backend never filters on it. Oversize rejected with `bad_request`. |
 
 #### Async success response
 
@@ -2296,6 +2297,7 @@ Delivered on `chat.user.{account}.response.{requestId}`.
 | `threadParentMessageCreatedAt` | string | Optional. RFC 3339. Server-resolved best-effort; absent when unresolved at send time. |
 | `tshow` | boolean | Present only when `tshow: true` on a thread reply. |
 | `quotedParentMessage` | [QuotedParentMessage](../client-api.md#quotedparentmessage) | Present only for a quoted send. |
+| `visibleTo` | string | Present only when the request set `visibleTo` — echoed verbatim. |
 
 #### Async error response
 
@@ -2304,6 +2306,7 @@ error table. Key errors:
 
 - `"invalid requestId"` (`bad_request`)
 - `"content must not be empty"` / `"content exceeds maximum size of 20480 bytes"`
+- `"visibleTo exceeds maximum size of 4096 bytes"` (`bad_request`)
 - `"not subscribed"` (`forbidden`, `not_subscribed`)
 - `"posting is restricted to owners and admins in this room"` (`forbidden`, `large_room_post_restricted`)
 

--- a/history-service/internal/service/preview_walk_test.go
+++ b/history-service/internal/service/preview_walk_test.go
@@ -228,11 +228,12 @@ func TestPreviewWalk_Eligibility(t *testing.T) {
 			want: "m-1",
 		},
 		{
-			// The room list has one preview per room but visible_to is per-user, so a
-			// restricted message can never be the right thing to show every subscriber.
-			name: "a visibility-restricted message is skipped",
+			// Store-and-surface: visible_to is an opaque client-set marker the backend
+			// never filters on, so a message carrying it is a valid preview (the client
+			// interprets the scope).
+			name: "a visibility-marked message is eligible",
 			page: []models.Message{restricted(msgAt("m-3", 1), "u-9"), msgAt("m-1", 3)},
-			want: "m-1",
+			want: "m-3",
 		},
 		{
 			name: "an empty room reports gone",
@@ -257,6 +258,16 @@ func TestPreviewWalk_Eligibility(t *testing.T) {
 			assert.Equal(t, tc.want, got.MessageID)
 		})
 	}
+}
+
+// The surfaced preview carries the message's visible_to marker verbatim, so the client
+// can interpret the scope the backend never filters on.
+func TestPreviewWalk_SurfacesVisibleTo(t *testing.T) {
+	got, gone := walkedPreview(t, makePage([]models.Message{restricted(msgAt("m-3", 1), "u-9")}, false))
+	assert.False(t, gone)
+	require.NotNil(t, got)
+	assert.Equal(t, "m-3", got.MessageID)
+	assert.Equal(t, "u-9", got.VisibleTo)
 }
 
 // Enumerated, not sampled: a newly added system type fails here instead of shipping.

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -249,7 +249,7 @@ func (s *HistoryService) walkForPreview(ctx context.Context, roomID string, last
 		for i := range page.Data {
 			m := page.Data[i]
 			// Shared with the insert-side predicate so the two cannot disagree.
-			if !preview.Eligible(m.Deleted, m.Type, m.VisibleTo) {
+			if !preview.Eligible(m.Deleted, m.Type) {
 				continue
 			}
 			return previewWalk{
@@ -302,6 +302,7 @@ func (s *HistoryService) toPreviewMessage(ctx context.Context, m *models.Message
 		CreatedAt:   m.CreatedAt,
 		Attachments: m.DecodedAttachments,
 		Mentions:    mentions,
+		VisibleTo:   m.VisibleTo,
 	})
 }
 

--- a/message-gatekeeper/handler.go
+++ b/message-gatekeeper/handler.go
@@ -31,6 +31,11 @@ import (
 
 const maxContentBytes = 20 * 1024 // 20 KB
 
+// maxVisibleToBytes caps the opaque client-set VisibleTo marker. The value is never
+// interpreted here — the cap is a defensive bound so a client cannot store an unbounded
+// blob on the row.
+const maxVisibleToBytes = 4096
+
 // quotedParentUnavailablePlaceholder is the degraded-mode quoted-parent body used
 // when the authoritative fetch fails transiently. It never persists —
 // message-worker re-projects the real snapshot before the durable write.
@@ -359,6 +364,14 @@ func (h *Handler) processMessage(ctx context.Context, account, roomID, siteID st
 		return nil, errcode.BadRequest(fmt.Sprintf("invalid message type %q", req.Type))
 	}
 
+	// VisibleTo is opaque — validate only its size, never its content.
+	if len(req.VisibleTo) > maxVisibleToBytes {
+		return nil, errcode.BadRequest(
+			fmt.Sprintf("visibleTo exceeds maximum size of %d bytes", maxVisibleToBytes),
+			errcode.WithMetadata("maxVisibleToBytes", strconv.Itoa(maxVisibleToBytes), "attempted", strconv.Itoa(len(req.VisibleTo))),
+		)
+	}
+
 	// Verify subscription
 	sub, err := h.store.GetSubscription(ctx, account, roomID)
 	if err != nil {
@@ -455,6 +468,7 @@ func (h *Handler) processMessage(ctx context.Context, account, roomID, siteID st
 		QuotedParentMessage:          quotedSnapshot,
 		Attachments:                  req.Attachments,
 		Type:                         req.Type,
+		VisibleTo:                    req.VisibleTo,
 	}
 
 	// Publish MessageEvent to MESSAGES-CANONICAL. QuotedParentUnverified rides the

--- a/message-gatekeeper/handler_test.go
+++ b/message-gatekeeper/handler_test.go
@@ -298,6 +298,54 @@ func TestHandler_ProcessMessage(t *testing.T) {
 			wantInfra: false,
 		},
 		{
+			name:    "visibleTo passthrough — set verbatim on the canonical message",
+			account: validAccount,
+			roomID:  validRoomID,
+			siteID:  validSiteID,
+			buildData: func() []byte {
+				req := model.SendMessageRequest{ID: validID, Content: validContent, RequestID: validRequestID, VisibleTo: "u1,u2"}
+				data, _ := json.Marshal(req)
+				return data
+			},
+			setupStore: func(s *MockStore) {
+				s.EXPECT().GetSubscription(gomock.Any(), validAccount, validRoomID).Return(sub, nil)
+				s.EXPECT().GetRoomMeta(gomock.Any(), validRoomID).Return(roommetacache.Meta{ID: validRoomID, UserCount: 1}, nil)
+			},
+			setupPub: func() (publishFunc, *[]publishedMsg) {
+				var published []publishedMsg
+				return makePublishFunc(&published, nil), &published
+			},
+			wantErr: false,
+			checkResult: func(t *testing.T, data []byte, published []publishedMsg) {
+				var msg model.Message
+				require.NoError(t, json.Unmarshal(data, &msg))
+				assert.Equal(t, "u1,u2", msg.VisibleTo)
+				require.Len(t, published, 1)
+				var evt model.MessageEvent
+				require.NoError(t, json.Unmarshal(published[0].data, &evt))
+				assert.Equal(t, "u1,u2", evt.Message.VisibleTo)
+			},
+		},
+		{
+			name:    "visibleTo exceeds cap — rejected before publish",
+			account: validAccount,
+			roomID:  validRoomID,
+			siteID:  validSiteID,
+			buildData: func() []byte {
+				req := model.SendMessageRequest{ID: validID, Content: validContent, RequestID: validRequestID, VisibleTo: strings.Repeat("x", maxVisibleToBytes+1)}
+				data, _ := json.Marshal(req)
+				return data
+			},
+			setupStore: func(s *MockStore) {},
+			setupPub: func() (publishFunc, *[]publishedMsg) {
+				var published []publishedMsg
+				return makePublishFunc(&published, nil), &published
+			},
+			wantErr:       true,
+			wantInfra:     false,
+			wantNoPublish: true,
+		},
+		{
 			name:    "user not in room",
 			account: validAccount,
 			roomID:  validRoomID,

--- a/message-worker/integration_test.go
+++ b/message-worker/integration_test.go
@@ -114,6 +114,7 @@ func setupCassandra(t *testing.T) *gocql.Session {
 			type                  TEXT,
 			sys_msg_data          BLOB,
 			quoted_parent_message FROZEN<"QuotedParentMessage">,
+			visible_to            TEXT,
 			enc_payload           BLOB,
 			enc_meta              FROZEN<"EncMeta">,
 			PRIMARY KEY ((room_id, bucket), created_at, message_id)
@@ -140,6 +141,7 @@ func setupCassandra(t *testing.T) *gocql.Session {
 			type                     TEXT,
 			sys_msg_data             BLOB,
 			quoted_parent_message    FROZEN<"QuotedParentMessage">,
+			visible_to            TEXT,
 			enc_payload              BLOB,
 			enc_meta                 FROZEN<"EncMeta">,
 			PRIMARY KEY (message_id)
@@ -163,6 +165,7 @@ func setupCassandra(t *testing.T) *gocql.Session {
 			type                  TEXT,
 			sys_msg_data          BLOB,
 			quoted_parent_message FROZEN<"QuotedParentMessage">,
+			visible_to            TEXT,
 			enc_payload           BLOB,
 			enc_meta              FROZEN<"EncMeta">,
 			deleted               BOOLEAN,

--- a/message-worker/store_cassandra.go
+++ b/message-worker/store_cassandra.go
@@ -101,21 +101,21 @@ func (s *CassandraStore) SaveMessage(ctx context.Context, msg *model.Message, se
 		`INSERT INTO messages_by_room
 		   (room_id, bucket, created_at, message_id, sender, msg, site_id, updated_at,
 		    mentions, type, sys_msg_data, tshow, quoted_parent_message,
-		    attachments, card, card_action)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		    attachments, card, card_action, visible_to)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		msg.RoomID, b, msg.CreatedAt, msg.ID, sender, msg.Content, siteID, msg.CreatedAt,
 		mentions, msg.Type, msg.SysMsgData, msg.TShow, msg.QuotedParentMessage,
-		msg.Attachments, msg.Card, msg.CardAction,
+		msg.Attachments, msg.Card, msg.CardAction, msg.VisibleTo,
 	)
 	batch.Query(
 		`INSERT INTO messages_by_id
 		   (message_id, created_at, room_id, sender, msg, site_id, updated_at,
 		    mentions, type, sys_msg_data, tshow, quoted_parent_message,
-		    attachments, card, card_action)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		    attachments, card, card_action, visible_to)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		msg.ID, msg.CreatedAt, msg.RoomID, sender, msg.Content, siteID, msg.CreatedAt,
 		mentions, msg.Type, msg.SysMsgData, msg.TShow, msg.QuotedParentMessage,
-		msg.Attachments, msg.Card, msg.CardAction,
+		msg.Attachments, msg.Card, msg.CardAction, msg.VisibleTo,
 	)
 	if err := s.executeBatch(ctx, batch); err != nil {
 		return fmt.Errorf("save message %s: %w", msg.ID, err)
@@ -151,22 +151,22 @@ func (s *CassandraStore) saveMessageEncrypted(ctx context.Context, msg *model.Me
 	batch.Query(
 		`INSERT INTO messages_by_room
 		   (room_id, bucket, created_at, message_id, sender, site_id, updated_at,
-		    mentions, type, tshow, quoted_parent_message, sys_msg_data,
+		    mentions, type, tshow, quoted_parent_message, sys_msg_data, visible_to,
 		    msg, attachments, card, card_action,
 		    enc_payload, enc_meta)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, null, null, null, null, ?, ?)`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, null, null, null, null, ?, ?)`,
 		msg.RoomID, b, msg.CreatedAt, msg.ID, sender, siteID, msg.CreatedAt,
-		mentions, msg.Type, msg.TShow, cm.QuotedParentMessage, msg.SysMsgData, payload, encMeta,
+		mentions, msg.Type, msg.TShow, cm.QuotedParentMessage, msg.SysMsgData, msg.VisibleTo, payload, encMeta,
 	)
 	batch.Query(
 		`INSERT INTO messages_by_id
 		   (message_id, created_at, room_id, sender, site_id, updated_at,
-		    mentions, type, tshow, quoted_parent_message, sys_msg_data,
+		    mentions, type, tshow, quoted_parent_message, sys_msg_data, visible_to,
 		    msg, attachments, card, card_action,
 		    enc_payload, enc_meta)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, null, null, null, null, ?, ?)`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, null, null, null, null, ?, ?)`,
 		msg.ID, msg.CreatedAt, msg.RoomID, sender, siteID, msg.CreatedAt,
-		mentions, msg.Type, msg.TShow, cm.QuotedParentMessage, msg.SysMsgData, payload, encMeta,
+		mentions, msg.Type, msg.TShow, cm.QuotedParentMessage, msg.SysMsgData, msg.VisibleTo, payload, encMeta,
 	)
 	if err := s.executeBatch(ctx, batch); err != nil {
 		return fmt.Errorf("save message %s: %w", msg.ID, err)
@@ -195,22 +195,22 @@ func (s *CassandraStore) SaveThreadMessage(ctx context.Context, msg *model.Messa
 		`INSERT INTO messages_by_id
 		 (message_id, created_at, room_id, sender, msg, site_id, updated_at, mentions,
 		  thread_room_id, thread_parent_id, thread_parent_created_at, type, sys_msg_data, tshow, quoted_parent_message,
-		  attachments, card, card_action)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		  attachments, card, card_action, visible_to)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		msg.ID, msg.CreatedAt, msg.RoomID, sender, msg.Content, siteID, msg.CreatedAt, mentions,
 		threadRoomID, msg.ThreadParentMessageID, msg.ThreadParentMessageCreatedAt, msg.Type, msg.SysMsgData, msg.TShow, msg.QuotedParentMessage,
-		msg.Attachments, msg.Card, msg.CardAction,
+		msg.Attachments, msg.Card, msg.CardAction, msg.VisibleTo,
 	)
 	batch.Query(
 		`INSERT INTO thread_messages_by_thread
 		 (thread_room_id, created_at, message_id, room_id, thread_parent_id, sender, msg,
 		  site_id, updated_at, mentions, type, sys_msg_data, tshow, quoted_parent_message,
-		  attachments, card, card_action)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		  attachments, card, card_action, visible_to)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		threadRoomID, msg.CreatedAt, msg.ID, msg.RoomID, msg.ThreadParentMessageID,
 		sender, msg.Content, siteID, msg.CreatedAt, mentions,
 		msg.Type, msg.SysMsgData, msg.TShow, msg.QuotedParentMessage,
-		msg.Attachments, msg.Card, msg.CardAction,
+		msg.Attachments, msg.Card, msg.CardAction, msg.VisibleTo,
 	)
 	// TShow ("also send to channel"): dual-write the reply into messages_by_room
 	// so it shows up in the parent room's channel timeline on history loads.
@@ -225,11 +225,11 @@ func (s *CassandraStore) SaveThreadMessage(ctx context.Context, msg *model.Messa
 			`INSERT INTO messages_by_room
 			 (room_id, bucket, created_at, message_id, sender, msg, site_id, updated_at, mentions,
 			  thread_room_id, thread_parent_id, thread_parent_created_at, type, sys_msg_data, tshow, quoted_parent_message,
-			  attachments, card, card_action)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			  attachments, card, card_action, visible_to)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			msg.RoomID, s.bucket.Of(msg.CreatedAt), msg.CreatedAt, msg.ID, sender, msg.Content, siteID, msg.CreatedAt, mentions,
 			threadRoomID, msg.ThreadParentMessageID, msg.ThreadParentMessageCreatedAt, msg.Type, msg.SysMsgData, msg.TShow, msg.QuotedParentMessage,
-			msg.Attachments, msg.Card, msg.CardAction,
+			msg.Attachments, msg.Card, msg.CardAction, msg.VisibleTo,
 		)
 	}
 	if err := s.executeBatch(ctx, batch); err != nil {
@@ -266,23 +266,23 @@ func (s *CassandraStore) saveThreadMessageEncrypted(ctx context.Context, msg *mo
 		`INSERT INTO messages_by_id
 		 (message_id, created_at, room_id, sender, site_id, updated_at, mentions,
 		  thread_room_id, thread_parent_id, thread_parent_created_at, type, tshow,
-		  quoted_parent_message, sys_msg_data,
+		  quoted_parent_message, sys_msg_data, visible_to,
 		  msg, attachments, card, card_action,
 		  enc_payload, enc_meta)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, null, null, null, null, ?, ?)`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, null, null, null, null, ?, ?)`,
 		msg.ID, msg.CreatedAt, msg.RoomID, sender, siteID, msg.CreatedAt, mentions,
 		threadRoomID, msg.ThreadParentMessageID, msg.ThreadParentMessageCreatedAt, msg.Type, msg.TShow,
-		cm.QuotedParentMessage, msg.SysMsgData, payload, encMeta,
+		cm.QuotedParentMessage, msg.SysMsgData, msg.VisibleTo, payload, encMeta,
 	)
 	batch.Query(
 		`INSERT INTO thread_messages_by_thread
 		 (thread_room_id, created_at, message_id, room_id, thread_parent_id,
-		  sender, site_id, updated_at, mentions, type, tshow, quoted_parent_message, sys_msg_data,
+		  sender, site_id, updated_at, mentions, type, tshow, quoted_parent_message, sys_msg_data, visible_to,
 		  msg, attachments, card, card_action,
 		  enc_payload, enc_meta)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, null, null, null, null, ?, ?)`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, null, null, null, null, ?, ?)`,
 		threadRoomID, msg.CreatedAt, msg.ID, msg.RoomID, msg.ThreadParentMessageID,
-		sender, siteID, msg.CreatedAt, mentions, msg.Type, msg.TShow, cm.QuotedParentMessage, msg.SysMsgData,
+		sender, siteID, msg.CreatedAt, mentions, msg.Type, msg.TShow, cm.QuotedParentMessage, msg.SysMsgData, msg.VisibleTo,
 		payload, encMeta,
 	)
 	// TShow dual-write into messages_by_room — see SaveThreadMessage for the
@@ -294,13 +294,13 @@ func (s *CassandraStore) saveThreadMessageEncrypted(ctx context.Context, msg *mo
 			`INSERT INTO messages_by_room
 			 (room_id, bucket, created_at, message_id, sender, site_id, updated_at, mentions,
 			  thread_room_id, thread_parent_id, thread_parent_created_at, type, tshow,
-			  quoted_parent_message, sys_msg_data,
+			  quoted_parent_message, sys_msg_data, visible_to,
 			  msg, attachments, card, card_action,
 			  enc_payload, enc_meta)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, null, null, null, null, ?, ?)`,
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, null, null, null, null, ?, ?)`,
 			msg.RoomID, s.bucket.Of(msg.CreatedAt), msg.CreatedAt, msg.ID, sender, siteID, msg.CreatedAt, mentions,
 			threadRoomID, msg.ThreadParentMessageID, msg.ThreadParentMessageCreatedAt, msg.Type, msg.TShow,
-			cm.QuotedParentMessage, msg.SysMsgData, payload, encMeta,
+			cm.QuotedParentMessage, msg.SysMsgData, msg.VisibleTo, payload, encMeta,
 		)
 	}
 	if err := s.executeBatch(ctx, batch); err != nil {

--- a/pkg/model/message.go
+++ b/pkg/model/message.go
@@ -35,6 +35,10 @@ type Message struct {
 	QuotedParentMessage          *cassandra.QuotedParentMessage `json:"quotedParentMessage,omitempty"          bson:"quotedParentMessage,omitempty"`
 	PinnedAt                     *time.Time                     `json:"pinnedAt,omitempty"                     bson:"pinnedAt,omitempty"`
 	PinnedBy                     *Participant                   `json:"pinnedBy,omitempty"                     bson:"pinnedBy,omitempty"`
+	// VisibleTo is an opaque, client-set visibility marker: set on send, persisted,
+	// and surfaced on history reads and the room-list preview. The backend never
+	// filters delivery, reads, or previews on it — the client interprets visibility.
+	VisibleTo string `json:"visibleTo,omitempty" bson:"visibleTo,omitempty"`
 }
 
 // RoomRenamedSysData is the JSON payload stored in Message.SysMsgData
@@ -73,6 +77,10 @@ type SendMessageRequest struct {
 	// MessageTypeImportant; message-gatekeeper rejects any system type or unknown
 	// value so a client can't inject a system event. Empty = a normal message.
 	Type string `json:"type,omitempty"`
+	// VisibleTo is an opaque, client-set visibility marker copied verbatim onto the
+	// canonical Message. message-gatekeeper caps its size but never interprets it;
+	// the backend stores and surfaces it without filtering on it.
+	VisibleTo string `json:"visibleTo,omitempty"`
 }
 
 // SenderDisplayName returns the canonical render-ready name for the message's
@@ -117,9 +125,10 @@ type PreviewMessage struct {
 	CreatedAt   time.Time              `json:"createdAt"`
 	Attachments []cassandra.Attachment `json:"attachments,omitempty"`
 	Mentions    []Participant          `json:"mentions,omitempty"`
-	// No VisibleTo: one preview is stored per room but visibility is per-user, so a
-	// restricted message is preview-INELIGIBLE (preview.Eligible) rather than previewed
-	// with a scope the room list has no way to honour (#364).
+	// VisibleTo is the message's opaque visibility marker, surfaced verbatim so the
+	// client can interpret it. A message with a non-empty VisibleTo is still previewed —
+	// the backend does not filter previews on it (the client honours the scope).
+	VisibleTo string `json:"visibleTo,omitempty"`
 	// TODO(#106): forwardSource — wired after the Forwarded snapshot merges.
 }
 
@@ -132,6 +141,9 @@ type PreviewMeta struct {
 	Sender    Participant   `json:"sender"              bson:"sender"`
 	CreatedAt time.Time     `json:"createdAt"           bson:"createdAt"`
 	Mentions  []Participant `json:"mentions,omitempty"  bson:"mentions,omitempty"`
+	// VisibleTo is visibility metadata, so it rides the plaintext meta half alongside
+	// messageId/sender — never the sealed body — and is surfaced on the preview verbatim.
+	VisibleTo string `json:"visibleTo,omitempty" bson:"visibleTo,omitempty"`
 }
 
 // RoomsGetResponse maps each requested roomId that has a resolvable last message to

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -487,6 +487,27 @@ func TestMessageJSON(t *testing.T) {
 		assert.False(t, present, "threadParentMessageCreatedAt should be omitted when nil")
 	})
 
+	t.Run("visibleTo round-trip and omitempty", func(t *testing.T) {
+		m := model.Message{
+			ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice",
+			Content:   "hello",
+			CreatedAt: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+			VisibleTo: "u1,u2",
+		}
+		roundTrip(t, &m, &model.Message{})
+
+		bs, err := bson.Marshal(&m)
+		require.NoError(t, err)
+		var back model.Message
+		require.NoError(t, bson.Unmarshal(bs, &back))
+		assert.Equal(t, "u1,u2", back.VisibleTo)
+
+		empty := model.Message{ID: "m1", RoomID: "r1", UserID: "u1", UserAccount: "alice", Content: "hi", CreatedAt: m.CreatedAt}
+		data, err := json.Marshal(&empty)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), `"visibleTo"`, "empty VisibleTo must be omitted")
+	})
+
 	t.Run("editedAt + updatedAt round-trip", func(t *testing.T) {
 		edited := time.Date(2026, 1, 1, 12, 5, 0, 0, time.UTC)
 		updated := time.Date(2026, 1, 1, 12, 6, 0, 0, time.UTC)

--- a/pkg/model/room_preview_test.go
+++ b/pkg/model/room_preview_test.go
@@ -125,6 +125,7 @@ func TestPreviewMeta_BSONRoundTrip(t *testing.T) {
 		Sender:    Participant{Account: "alice"},
 		CreatedAt: time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC),
 		Mentions:  []Participant{{Account: "bob"}, {Account: "carol"}},
+		VisibleTo: "u1,u2",
 	}
 
 	raw, err := bson.Marshal(meta)

--- a/pkg/preview/preview.go
+++ b/pkg/preview/preview.go
@@ -62,8 +62,10 @@ func truncateContent(s string) string {
 
 // Eligible reports whether a message may represent its room — system and deleted ones
 // may not. Shared: a rule on one writer only would strand a preview the walk never picks.
-func Eligible(deleted bool, msgType, visibleTo string) bool {
-	return !deleted && !model.IsSystemMessageType(msgType) && visibleTo == ""
+// VisibleTo is deliberately NOT a gate: a message with a visibility marker is still
+// previewed and carries the marker, leaving the client to honour the scope.
+func Eligible(deleted bool, msgType string) bool {
+	return !deleted && !model.IsSystemMessageType(msgType)
 }
 
 // AppNameLookup resolves a bot account's app display name; ("", nil) means no match.

--- a/pkg/preview/seal.go
+++ b/pkg/preview/seal.go
@@ -60,6 +60,7 @@ func Seal(ctx context.Context, c atrest.Cipher, k Key, forMsgID string, p model.
 			Sender:    p.Sender,
 			CreatedAt: p.CreatedAt,
 			Mentions:  p.Mentions,
+			VisibleTo: p.VisibleTo,
 		},
 		Ciphertext: ciphertext,
 		Nonce:      meta.Nonce,
@@ -93,6 +94,7 @@ func Open(ctx context.Context, c atrest.Cipher, siteID string, s Sealed) (model.
 		CreatedAt:   s.Meta.CreatedAt,
 		Attachments: atts,
 		Mentions:    s.Meta.Mentions,
+		VisibleTo:   s.Meta.VisibleTo,
 	}, nil
 }
 

--- a/pkg/preview/seal_test.go
+++ b/pkg/preview/seal_test.go
@@ -87,8 +87,24 @@ func samplePreview() model.PreviewMessage {
 			FileType: "image/png", ImageURL: "/f1/img", ImageSize: 42,
 			ImageDimensions: &cassandra.ImageDimensions{Width: 10, Height: 20},
 		}},
-		Mentions: []model.Participant{{Account: "bob"}},
+		Mentions:  []model.Participant{{Account: "bob"}},
+		VisibleTo: "u1,u2",
 	}
+}
+
+// VisibleTo rides the plaintext Meta half (visibility metadata), never the sealed body,
+// and roundtrips through Seal/Open. It is deliberately NOT a preview-eligibility gate.
+func TestSeal_VisibleToInPlaintextMeta(t *testing.T) {
+	ctx := context.Background()
+	sealed, err := Seal(ctx, fakeCipher{}, Key{SiteID: "site-a", Epoch: 1}, "msg-1", samplePreview())
+	require.NoError(t, err)
+
+	assert.Equal(t, "u1,u2", sealed.Meta.VisibleTo)
+	assert.NotContains(t, string(sealed.Ciphertext), "u1,u2", "visibleTo must not be sealed into the body")
+
+	got, err := Open(ctx, fakeCipher{}, "site-a", sealed)
+	require.NoError(t, err)
+	assert.Equal(t, "u1,u2", got.VisibleTo)
 }
 
 func TestKey_ID(t *testing.T) {


### PR DESCRIPTION
## Summary

Make `visibleTo` a first-class, store-and-surface, client-interpreted message field.
It is settable on `msg.send`, persisted on every message write path, returned by
history reads, and carried on the room-list preview. The backend **stores and returns
it verbatim and never filters** delivery, reads, or previews on it — the client
interprets visibility.

This intentionally **reverses the earlier preview-exclusion of `visibleTo` messages**
(#222 made a `visibleTo` message preview-ineligible). Per the product decision,
`visibleTo` is opaque visibility metadata the client honours, so a message carrying it
is still previewed — with the marker attached.

## What's included

- `visibleTo` accepted on `msg.send`, size-capped, and copied verbatim onto the
  canonical message.
- Persisted to Cassandra on every write path (channel, thread, "also send to channel"
  mirror, and encrypted variants), in `messages_by_room`, `messages_by_id`, and
  `thread_messages_by_thread`.
- Returned on history reads and carried on the room-list preview (plaintext metadata,
  not the sealed body).
- Docs updated (`client-api.md` + the request/reply view).

## Changes

- `pkg/model/message.go`: add `SendMessageRequest.VisibleTo`; re-add `Message.VisibleTo`;
  add `VisibleTo` to `PreviewMessage` (wire) and `PreviewMeta` (plaintext storage half).
- `message-gatekeeper/handler.go`: `maxVisibleToBytes` cap + `bad_request` on oversize;
  set `VisibleTo` on the canonical `Message`.
- `message-worker/store_cassandra.go`: bind `visible_to` at all ten INSERT sites.
- `pkg/preview`: drop the `visibleTo` gate from `Eligible` (a marked message is eligible);
  route `VisibleTo` through `Seal`/`Open` via the plaintext `PreviewMeta`.
- `history-service`, `broadcast-worker`: carry `visibleTo` onto the surfaced preview.
- `docs/client-api.md`, `docs/client-api/request-reply.md`: document the field, the cap,
  and that the backend does not filter on it; correct the now-reversed preview-eligibility
  note.

`visibleTo` is stored as a plaintext metadata column (like `type` / `sys_msg_data` /
`tshow`), never sealed — visibility metadata, not user-authored body content.

## Verification

- Unit tests: gatekeeper maps `visibleTo` onto the canonical message + rejects oversize;
  preview seal/open round-trips `visibleTo` in the plaintext meta and keeps it out of the
  ciphertext; the preview walk now treats a `visibleTo` message as eligible and surfaces
  the marker; JSON + BSON round-trips for the new `Message` / `PreviewMeta` fields.
- `go vet` (incl. `-tags=integration`) and `golangci-lint` clean on all touched packages.
- Column/placeholder/bind counts verified balanced across all ten INSERT sites.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional `visibleTo` markers to sent messages, history results, and room previews.
  - Markers are preserved and returned unchanged so clients can determine visibility.
  - Sending supports `visibleTo` values up to 4096 bytes.

- **Bug Fixes**
  - Messages with visibility markers now appear in eligible previews.
  - Oversized `visibleTo` values are rejected with a clear bad-request error.
  - Deleted and system messages remain excluded from previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->