### PR TITLE
feat(natsutil): put server-to-server replies on chat.server.response

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,7 @@ All commands are wrapped in the root Makefile. Always use `make` targets — nev
 ### NATS Subject Naming
 - Dot-delimited hierarchical subjects — use `pkg/subject` builders, never raw `fmt.Sprintf`
 - User-scoped: `chat.user.{account}.…`
+- Server-to-server replies: `chat.server.response.…` — `natsutil.Connect` sets `subject.ServerInboxPrefix` as every backend connection's inbox prefix, so backend request/reply never uses the library default `_INBOX`. Any NATS account or gateway permission that allow-lists `_INBOX.>` for backend traffic must allow `chat.server.response.>` instead.
 - Room-scoped: `chat.room.{roomID}.…`
 - MESSAGES-CANONICAL: `chat.msg.canonical.{siteID}.created` (`.edited`, `.deleted` for future)
 - Inbox (cross-site, remote-origin): `chat.inbox.{destSiteID}.external.{eventType}` — published directly into the destination site's INBOX

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -97,7 +97,7 @@ This doc covers the public client-facing API surface only.
 **Out of scope (backend-internal — clients never see these):**
 
 - Backend-only JetStream subjects (MESSAGES, MESSAGES-CANONICAL, INBOX, ROOMS, OUTBOX streams).
-- Server-to-server subjects (`chat.server.request.…`).
+- Server-to-server subjects (`chat.server.request.…`) and their replies (`chat.server.response.…`).
 
 Room-encryption key events that clients consume are documented under the RPC that triggers them (Create Room, Add Members, Remove Member) and in [§5 Room Encryption](#5-room-encryption). Multi-site federation is transparent to clients: a cross-site action delivers the **same** events on the same `chat.user.{account}.…` / `chat.room.…` subjects as a same-site action, so this doc does not distinguish them.
 

--- a/docs/nats-subject-naming.md
+++ b/docs/nats-subject-naming.md
@@ -14,6 +14,8 @@ All subjects are dot-delimited and organized into four namespaces:
 |--------|-------|-------------|
 | `chat.user.{account}.*` | Per-user | Events, streams, and requests scoped to a single user |
 | `chat.room.{roomID}.*` | Per-room | Events and streams scoped to a single room |
+| `chat.server.request.*` | Backend | Server-to-server RPC requests |
+| `chat.server.response.*` | Backend | Server-to-server RPC replies — every backend connection's inbox prefix (`natsutil.Connect`), so a reply is `chat.server.response.{nuid}.{token}` rather than the library default `_INBOX.{nuid}` |
 | `fanout.{siteID}.*` | Backend | Internal message fan-out (JetStream only) |
 | `chat.inbox.{siteID}.*` | Backend | Cross-site federation — direct inbox publish (JetStream only) |
 

--- a/pkg/natsutil/connect.go
+++ b/pkg/natsutil/connect.go
@@ -13,6 +13,8 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/hmchangw/chat/pkg/subject"
 )
 
 const (
@@ -78,6 +80,12 @@ func connect(ctx context.Context, url, credsFile string, tp trace.TracerProvider
 	connState := metrics.Connection()
 	baseOpts := []nats.Option{
 		nats.Name(name),
+		// Server-to-server replies ride chat.server.response.<nuid>.<token>
+		// rather than the library default _INBOX.<nuid>.<token>, so backend
+		// reply traffic is identifiable by subject. nats.go creates the mux
+		// lazily on the first Request, so a service that only consumes
+		// JetStream pays nothing for this.
+		nats.CustomInboxPrefix(subject.ServerInboxPrefix),
 		nats.MaxReconnects(-1),
 		nats.ReconnectWait(defaultReconnectWait),
 		nats.DrainTimeout(defaultDrainTimeout),

--- a/pkg/natsutil/continuity_integration_test.go
+++ b/pkg/natsutil/continuity_integration_test.go
@@ -4,9 +4,11 @@ package natsutil_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/propagation"
@@ -15,6 +17,7 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/hmchangw/chat/pkg/natsutil"
+	"github.com/hmchangw/chat/pkg/subject"
 	"github.com/hmchangw/chat/pkg/testutil"
 )
 
@@ -134,4 +137,46 @@ func hasLinkToTrace(spans []sdktrace.ReadOnlySpan, traceID oteltrace.TraceID) bo
 		}
 	}
 	return false
+}
+
+// TestConnectSetsServerInboxPrefix pins the reply namespace every backend
+// connection uses. Without it, replies fall back to the library default
+// _INBOX.<nuid>, which is indistinguishable from client reply traffic and
+// cannot be scoped by a future per-service credential.
+func TestConnectSetsServerInboxPrefix(t *testing.T) {
+	tp := sdktrace.NewTracerProvider()
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	conn, err := natsutil.Connect(context.Background(), testutil.NATS(t), "", tp, propagation.TraceContext{}, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.NatsConn().Close() })
+
+	nc := conn.NatsConn()
+	require.Equal(t, subject.ServerInboxPrefix, nc.Opts.InboxPrefix)
+
+	// The option is only useful if nats.go actually builds the reply subject
+	// from it — assert on a real round trip, not just the stored option.
+	gotReply := make(chan string, 1)
+	sub, err := nc.Subscribe("chat.server.request.test.ping", func(m *nats.Msg) {
+		select {
+		case gotReply <- m.Reply:
+		default:
+		}
+		_ = m.Respond([]byte("pong"))
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+	require.NoError(t, nc.Flush())
+
+	resp, err := nc.Request("chat.server.request.test.ping", []byte("ping"), 5*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "pong", string(resp.Data))
+
+	select {
+	case reply := <-gotReply:
+		require.True(t, strings.HasPrefix(reply, subject.ServerInboxPrefix+"."),
+			"reply subject %q must sit under %q", reply, subject.ServerInboxPrefix)
+	case <-time.After(5 * time.Second):
+		t.Fatal("responder never observed the request")
+	}
 }

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -138,6 +138,18 @@ func MsgGetIDs(account, roomID, siteID string) string {
 	return fmt.Sprintf("chat.user.%s.request.room.%s.%s.msg.get.ids", account, roomID, siteID)
 }
 
+// ServerInboxPrefix is the reply namespace for server-to-server request/reply.
+// natsutil.Connect sets it as every backend connection's inbox prefix, so a
+// reply lands on chat.server.response.<nuid>.<token> instead of the library
+// default _INBOX.<nuid>.<token>.
+//
+// It is a plain constant, not a builder, because nats.go takes the prefix once
+// per connection and appends the per-request tokens itself. Nothing subscribes
+// to a chat.server wildcard, so this cannot collide with the
+// chat.server.request.… subjects it sits beside; the per-connection nuid keeps
+// services from colliding with each other.
+const ServerInboxPrefix = "chat.server.response"
+
 // RoomsGet is the server-to-server request subject for the rooms.get batch RPC:
 // user-service asks history-service for each room's last message. Account-agnostic
 // (roomIds batch in the body); the publish and subscribe forms are identical, like

--- a/pkg/subject/subject_test.go
+++ b/pkg/subject/subject_test.go
@@ -1352,3 +1352,16 @@ func TestRoomThreadEventTargets_TransitionGrace(t *testing.T) {
 	after := flip.Add(subject.DefaultRoomLocalityGrace + time.Minute)
 	assert.Equal(t, []string{g}, subject.RoomThreadEventTargets("r1", "p1", &trueP, &flip, subject.RouteLocal, after))
 }
+
+func TestServerInboxPrefix(t *testing.T) {
+	// Server-to-server request/reply replies ride this prefix, so a backend
+	// connection's inbox is chat.server.response.<nuid>.<token>. It sits under
+	// the chat.server namespace alongside chat.server.request.…, and nothing
+	// subscribes to a chat.server wildcard, so it cannot collide.
+	assert.Equal(t, "chat.server.response", subject.ServerInboxPrefix)
+
+	// Must be a valid inbox prefix for nats.go: no wildcards, no trailing dot.
+	assert.NotContains(t, subject.ServerInboxPrefix, "*")
+	assert.NotContains(t, subject.ServerInboxPrefix, ">")
+	assert.False(t, strings.HasSuffix(subject.ServerInboxPrefix, "."))
+}


### PR DESCRIPTION
Split out of [#378](https://github.com/hmchangw/newchat/pull/378) so the client-side inbox change can land on its own. **Draft, because the deployment question below is unresolved** — the code is complete and green.

## What this does

`natsutil.Connect` sets `subject.ServerInboxPrefix` (`chat.server.response`) as every backend connection's inbox prefix, so a server-to-server reply lands on `chat.server.response.<nuid>.<token>` instead of the library default `_INBOX.<nuid>.<token>`.

One chokepoint covers the fleet: every production service dials through `natsutil.Connect`. Only diagnostic tools (`tools/nats-debug`, `tools/cdc-verify`) and `pkg/testutil` construct their own connections, and they are deliberately left alone.

## Why

Backend replies are currently indistinguishable from client reply traffic by subject. Putting them in their own namespace makes them greppable in traffic inspection and, more importantly, makes them *scopeable* — a future per-service backend credential can grant a reply namespace, which is impossible while everything shares `_INBOX`.

There is no security change today: `backend.creds` grants `>` in both directions, so nothing is newly permitted or denied.

## Verification

`TestConnectSetsServerInboxPrefix` asserts the option is stored **and** that a real round trip produces a reply subject under the prefix — the option alone would not prove nats.go builds the subject from it.

Checked for collisions before committing: every server-to-server subject is a specific `chat.server.request.…`, and nothing in the repo subscribes to a `chat.server` wildcard, so the new namespace cannot be captured by an existing subscriber. nats.go creates the request mux lazily, so a service that only consumes JetStream pays nothing.

Local: `make test SERVICE=pkg/subject`, `make test-integration SERVICE=pkg/natsutil`, `make lint` (0 issues).

## The open question — why this is a draft

**Any NATS account or gateway permission that allow-lists `_INBOX.>` for backend traffic will drop every backend reply the moment this deploys.** Dev and CI cannot catch it, because `backend.creds` grants `>`.

This is not hypothetical: `docs/specs/botplatform/traffic-isolation.md` carries a gateway config in exactly that shape, allow-listing `_INBOX.>` for cross-site traffic.

Before merging, one of:

1. **Confirm the production account and gateway permissions** allow `chat.server.response.>` — then this merges as-is.
2. **Put the prefix behind an env toggle** so it can be rolled out and reverted without a redeploy. Say the word and I will add it.
3. **Leave it parked** until the permission side is ready.

Option 1 is the cleanest if the answer is easy to get; the change is otherwise low-risk and self-contained.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNz8HWf47Tyg2sqqzDbUeb)_