### PR TITLE
feat(user-service): return the full app on setAppSubscription

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -5638,12 +5638,16 @@ PUT-like idempotent endpoint to subscribe or unsubscribe the calling user from a
 
 ##### Success response
 
-| Field     | Type    | Notes |
-|-----------|---------|-------|
-| `success` | boolean | Always `true`. |
+| Field     | Type            | Notes |
+|-----------|-----------------|-------|
+| `success` | boolean         | Always `true`. |
+| `app`     | [App](#app)     | The full app record (same shape as an `apps.list` item without `isSubscribed`), so the client has the app's details without a follow-up `apps.list`. |
 
 ```json
-{ "success": true }
+{
+  "success": true,
+  "app": { "id": "calendar-app", "name": "Calendar", "assistant": { "enabled": true, "name": "calendar.bot" } }
+}
 ```
 
 ##### Triggered events — success path

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -1971,7 +1971,7 @@ per-site thread RPC.
 
 **Subject:** `chat.user.{account}.request.user.{siteID}.subscription.setAppSubscription`
 
-PUT-like idempotent endpoint to subscribe or unsubscribe from a bot app.
+PUT-like idempotent endpoint to subscribe or unsubscribe from a bot app. The success reply returns the full `app` record so the client needs no follow-up `apps.list`.
 
 #### Request body
 
@@ -1979,7 +1979,7 @@ PUT-like idempotent endpoint to subscribe or unsubscribe from a bot app.
 
 #### Success response
 
-`{ "success": true }`
+`{ "success": true, "app": { …full App record… } }`
 
 #### Errors
 

--- a/user-service/models/app.go
+++ b/user-service/models/app.go
@@ -28,9 +28,16 @@ type AppsListResponse struct {
 	HasMore bool          `json:"hasMore"`
 }
 
-// OKResponse is the generic success body (subscription.setAppSubscription).
+// OKResponse is the generic success body (sso.set).
 type OKResponse struct {
 	Success bool `json:"success"`
+}
+
+// SetAppSubscriptionResponse is the subscription.setAppSubscription success body: the
+// full app is returned so the client has its details without a follow-up apps.list.
+type SetAppSubscriptionResponse struct {
+	Success bool       `json:"success"`
+	App     *model.App `json:"app,omitempty"`
 }
 
 // AppCategory maps a fab/domain name to its site. ID is the hex form of the

--- a/user-service/service/apps.go
+++ b/user-service/service/apps.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hmchangw/chat/user-service/models"
 )
 
-func (s *UserService) SetAppSubscription(c *natsrouter.Context, req models.SetAppSubscriptionRequest) (*models.OKResponse, error) {
+func (s *UserService) SetAppSubscription(c *natsrouter.Context, req models.SetAppSubscriptionRequest) (*models.SetAppSubscriptionResponse, error) {
 	account := c.Param("account")
 	c.WithLogValues("account", account)
 	if req.AppID == "" {
@@ -40,20 +40,20 @@ func (s *UserService) SetAppSubscription(c *natsrouter.Context, req models.SetAp
 
 	if !req.Subscribed {
 		if existing == nil {
-			return &models.OKResponse{Success: true}, nil // nothing subscribed: no write, no event
+			return &models.SetAppSubscriptionResponse{Success: true, App: app}, nil // nothing subscribed: no write, no event
 		}
 		if err := s.subs.SetAppSubscribed(c, account, botName, false, true); err != nil {
 			return nil, fmt.Errorf("unsubscribe app: %w", err)
 		}
 		s.publishAppSubscriptionRemoved(c, account, existing)
-		return &models.OKResponse{Success: true}, nil
+		return &models.SetAppSubscriptionResponse{Success: true, App: app}, nil
 	}
 	if existing == nil {
 		// First subscribe emits via room creation — nothing to publish here.
 		if _, err := s.rooms.CreateDMRoom(c, account, botName, model.RoomTypeBotDM); err != nil {
 			return nil, fmt.Errorf("create botDM room: %w", err)
 		}
-		return &models.OKResponse{Success: true}, nil
+		return &models.SetAppSubscriptionResponse{Success: true, App: app}, nil
 	}
 	wasSubscribed := existing.IsSubscribed
 	if err := s.subs.SetAppSubscribed(c, account, botName, true, false); err != nil {
@@ -62,7 +62,7 @@ func (s *UserService) SetAppSubscription(c *natsrouter.Context, req models.SetAp
 	if !wasSubscribed { // emit only on a real unsubscribed→subscribed transition, not an idempotent re-subscribe
 		s.publishAppSubscriptionReactivated(c, account, existing, app)
 	}
-	return &models.OKResponse{Success: true}, nil
+	return &models.SetAppSubscriptionResponse{Success: true, App: app}, nil
 }
 
 // Tell the user's other devices to drop the botDM (mirrors room-worker's removed event; best-effort).

--- a/user-service/service/apps_test.go
+++ b/user-service/service/apps_test.go
@@ -79,6 +79,10 @@ func TestSetAppSubscription_SubscribeNew(t *testing.T) {
 	resp, err := svc.SetAppSubscription(ctx("alice", "site-a"), models.SetAppSubscriptionRequest{AppID: "app1", Subscribed: true})
 	require.NoError(t, err)
 	assert.True(t, resp.Success)
+	// The full app is returned so the client needs no follow-up apps.list.
+	require.NotNil(t, resp.App)
+	assert.Equal(t, "app1", resp.App.ID)
+	assert.Equal(t, "Helper", resp.App.Name)
 }
 
 func TestSetAppSubscription_GetAppSubscriptionStoreError(t *testing.T) {


### PR DESCRIPTION
## Summary

`subscription.setAppSubscription` previously replied with just `{ "success": true }`, so a client that wanted the app's details after subscribing had to make a follow-up `apps.list` call. This returns the **full app record** in the response so the client has everything in one round-trip.

## What's included

- A dedicated `SetAppSubscriptionResponse` (`success` + the full `app`); the generic `OKResponse` stays with `sso.set`, which shares it.
- The full app is returned on **every** success path (subscribe, reactivate, idempotent already-subscribed, and the unsubscribe/no-op paths) — the handler already fetches the app up front, so it's free.
- Docs updated: the `subscription.setAppSubscription` success response in `docs/client-api.md` and its derived `docs/client-api/request-reply.md` view.

## Changes

- `user-service/models/app.go` — add `SetAppSubscriptionResponse{ success, app }`; retag `OKResponse` as the `sso.set` body.
- `user-service/service/apps.go` — return type → `*SetAppSubscriptionResponse`; return the fetched `app` on all success returns.
- `user-service/service/apps_test.go` — assert the response carries the full app.
- `docs/client-api.md`, `docs/client-api/request-reply.md` — response schema + example.

## Verification

- `go test ./user-service/service/... ./user-service/models/...` — green.
- `go vet ./user-service/...` clean; lint clean on the touched service.
- No NATS-subject, event, or schema change — this only widens the RPC's success reply (additive; `app` is `omitempty`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription updates now return the complete app details along with the success status.
  * Clients can access app information immediately without making a follow-up app listing request.

* **Documentation**
  * Updated API references and response examples to reflect the expanded subscription response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->