### PR TITLE
fix(broadcast-worker): carry @all on the message_edited event

### DIFF
--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -403,10 +403,11 @@ func (h *Handler) handleUpdated(ctx context.Context, evt *model.MessageEvent) er
 
 	// Resolve mentionees once: the same participants render on the edit event
 	// and route the cross-site badge, so we avoid a second FindUsersByAccounts.
-	participants := h.resolveEditMentions(ctx, parsed)
+	participants, mentionAll := h.resolveEditMentions(ctx, parsed)
 
 	edit := buildEditRoomEvent(room, evt)
 	edit.Mentions = participants
+	edit.MentionAll = mentionAll
 	if room.Type == model.RoomTypeChannel && h.encrypt {
 		if err := h.encryptEditedContent(ctx, room.ID, &edit); err != nil {
 			return fmt.Errorf("encrypt edit content for room %s: %w", room.ID, err)
@@ -508,17 +509,21 @@ func (h *Handler) federateMentions(ctx context.Context, roomID, msgID string, pa
 // SetSubscriptionMentions and newContent still carries the raw @account, so on a
 // user-lookup error we drop the mentions[] enrichment entirely (return nil)
 // rather than emitting a partial set or failing/retrying the edit. nil when none.
-func (h *Handler) resolveEditMentions(ctx context.Context, parsed mention.ParseResult) []model.Participant {
+// Returns the resolved participants and MentionAll. MentionAll is parse-derived and
+// independent of the per-account lookup, so an edit that only adds @all (no individual
+// mentions) — or one whose lookup fails — still carries the flag.
+func (h *Handler) resolveEditMentions(ctx context.Context, parsed mention.ParseResult) ([]model.Participant, bool) {
 	if len(parsed.Accounts) == 0 {
-		return nil
+		return nil, parsed.MentionAll
 	}
 	users, err := h.userStore.FindUsersByAccounts(ctx, parsed.Accounts)
 	if err != nil {
 		slog.WarnContext(ctx, "user lookup failed resolving edit mentions, dropping edit mentions",
 			"error", err, "request_id", natsutil.RequestIDFromContext(ctx))
-		return nil
+		return nil, parsed.MentionAll
 	}
-	return mention.ResolveFromParsed(parsed, usersByAccount(users)).Participants
+	resolved := mention.ResolveFromParsed(parsed, usersByAccount(users))
+	return resolved.Participants, resolved.MentionAll
 }
 
 func (h *Handler) handleThreadUpdated(ctx context.Context, evt *model.MessageEvent) error {
@@ -538,7 +543,7 @@ func (h *Handler) handleThreadUpdated(ctx context.Context, evt *model.MessageEve
 
 	parsed := mention.Parse(msg.Content)
 	edit := buildEditRoomEvent(room, evt)
-	edit.Mentions = h.resolveEditMentions(ctx, parsed)
+	edit.Mentions, edit.MentionAll = h.resolveEditMentions(ctx, parsed)
 
 	switch room.Type {
 	case model.RoomTypeChannel:

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -2946,7 +2946,7 @@ func TestHandleThreadUpdated_ChannelRoom_FansOutToFollowers(t *testing.T) {
 
 // The thread-edit event must carry resolved mentions[] just like the top-level
 // edit (TestHandleUpdated_AttachesMentionsToEditEvent) — without this a regression
-// dropping edit.Mentions from handleThreadUpdated would go unnoticed.
+// dropping edit.Mentions or edit.MentionAll from handleThreadUpdated would go unnoticed.
 func TestHandleThreadUpdated_AttachesMentionsToEditEvent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
@@ -2970,7 +2970,7 @@ func TestHandleThreadUpdated_AttachesMentionsToEditEvent(t *testing.T) {
 		Event: model.EventUpdated, SiteID: "site-a", Timestamp: editedAt.UnixMilli(),
 		Message: model.Message{
 			ID: "reply-1", RoomID: "r1", UserAccount: "alice",
-			Content: "@bob thread edit", CreatedAt: msgTime,
+			Content: "@bob @all thread edit", CreatedAt: msgTime,
 			EditedAt: &editedAt, UpdatedAt: &editedAt,
 			ThreadParentMessageID: "parent-1", TShow: false,
 		},
@@ -2983,8 +2983,12 @@ func TestHandleThreadUpdated_AttachesMentionsToEditEvent(t *testing.T) {
 	require.NotEmpty(t, pub.records)
 	var roomEvt model.EditRoomEvent
 	require.NoError(t, json.Unmarshal(pub.records[0].data, &roomEvt))
-	require.Len(t, roomEvt.Mentions, 1, "thread edit event must carry the resolved mention")
-	assert.Equal(t, "bob", roomEvt.Mentions[0].Account)
+	mentionedAccounts := make([]string, len(roomEvt.Mentions))
+	for i, m := range roomEvt.Mentions {
+		mentionedAccounts[i] = m.Account
+	}
+	assert.Contains(t, mentionedAccounts, "bob", "thread edit event must carry the resolved mention")
+	assert.True(t, roomEvt.MentionAll, "thread edit with @all must carry MentionAll (guards the thread branch's assignment)")
 }
 
 func TestHandleThreadUpdated_ChannelExcludesRestrictedAndNonMemberMentions(t *testing.T) {

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -873,6 +873,41 @@ func TestHandleUpdated_AttachesMentionsToEditEvent(t *testing.T) {
 	require.NoError(t, json.Unmarshal(pub.records[0].data, &roomEvt))
 	require.Len(t, roomEvt.Mentions, 1, "edit event must carry the resolved mention")
 	assert.Equal(t, "bob", roomEvt.Mentions[0].Account)
+	assert.False(t, roomEvt.MentionAll, "no @all in the edited content")
+}
+
+// An edit whose content adds @all carries MentionAll on the message_edited event
+// (mirrors the create/new-thread events), even with no individual mentions.
+func TestHandleUpdated_AttachesMentionAllToEditEvent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	us := NewMockUserStore(ctrl)
+	pub := &mockPublisher{}
+	keyStore := NewMockRoomKeyProvider(ctrl)
+
+	roomID := "r1"
+	store.EXPECT().GetRoom(gomock.Any(), roomID).Return(&model.Room{ID: roomID, Type: model.RoomTypeChannel, SiteID: "site-a"}, nil)
+	// Pure @all: no individual accounts → no user lookup, no per-account badge.
+
+	edited := time.Date(2026, 5, 14, 12, 5, 0, 0, time.UTC)
+	evt := model.MessageEvent{
+		Event: model.EventUpdated, SiteID: "site-a", Timestamp: edited.UnixMilli(),
+		Message: model.Message{
+			ID: "msg-1", RoomID: roomID, UserID: "u-alice", UserAccount: "alice",
+			Content: "heads up @all", CreatedAt: edited.Add(-time.Hour),
+			EditedAt: &edited, UpdatedAt: &edited,
+		},
+	}
+	data, err := json.Marshal(&evt)
+	require.NoError(t, err)
+
+	h := NewHandler(store, us, pub, keyStore, defaultParentFetcher, false, subject.RouteGlobal)
+	require.NoError(t, h.HandleMessage(context.Background(), data))
+
+	require.Len(t, pub.records, 1)
+	var roomEvt model.EditRoomEvent
+	require.NoError(t, json.Unmarshal(pub.records[0].data, &roomEvt))
+	assert.True(t, roomEvt.MentionAll, "edit that adds @all must carry MentionAll")
 }
 
 func TestHandleUpdated_RelaysPreviewObject(t *testing.T) {

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -3449,6 +3449,7 @@ The payload is flat (no zero-valued room fields):
 | `newContent` | string | Optional. New plaintext content. Present for DMs and unencrypted channels. Omitted for encrypted channels — see `encryptedNewContent`. |
 | `encryptedNewContent` | [EncryptedMessage](#encryptedmessage) | Optional. For encrypted channel rooms. Omitted otherwise. |
 | `mentions` | [Participant](#participant)[] | Optional. `@`-mentions resolved from the edited content, so an edit that adds a mention renders like a fresh message. Omitted when none. |
+| `mentionAll` | boolean | Optional. `true` if the edited content mentions `@all` (or `@here`), so an edit that adds or removes `@all` conveys it like a fresh message. Omitted when `false`. |
 | `editedBy` | string | The sender's account. |
 | `editedAt` | string | RFC 3339 timestamp. Domain time of the edit. |
 | `updatedAt` | string | RFC 3339 timestamp. |

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -613,6 +613,7 @@ Flat event — no zero-valued `RoomEvent` base fields. Triggered by
 | `newContent` | string | Optional. New plaintext content. Present for DMs and unencrypted channels. |
 | `encryptedNewContent` | [EncryptedMessage](../client-api.md#encryptedmessage) | Optional. For encrypted channel rooms. Decrypt with the room key to obtain the new content string. |
 | `mentions` | [Participant](../client-api.md#participant)[] | Optional. `@`-mentions resolved from the edited content, so an edit that adds a mention renders like a fresh message. Omitted when none. |
+| `mentionAll` | boolean | Optional. `true` when the edited content mentions `@all`, mirroring the new-message / new-thread events so an edit that adds or removes `@all` conveys it. Omitted when `false`. |
 | `editedBy` | string | The sender's account. |
 | `editedAt` | string | RFC 3339 timestamp. Domain time of the edit. |
 | `updatedAt` | string | RFC 3339 timestamp. |

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -416,10 +416,13 @@ type EditRoomEvent struct {
 	EncryptedNewContent json.RawMessage `json:"encryptedNewContent,omitempty" bson:"encryptedNewContent,omitempty"`
 	// Mentions are the @-mentions resolved from the edited content, so an edit that
 	// adds a mention renders it the same as a freshly-sent message. Omitted when none.
-	Mentions  []Participant `json:"mentions,omitempty" bson:"mentions,omitempty"`
-	EditedBy  string        `json:"editedBy" bson:"editedBy"`
-	EditedAt  time.Time     `json:"editedAt" bson:"editedAt"`
-	UpdatedAt time.Time     `json:"updatedAt" bson:"updatedAt"`
+	Mentions []Participant `json:"mentions,omitempty" bson:"mentions,omitempty"`
+	// MentionAll reflects the edited content's @all, mirroring the create/new-thread events
+	// so an edit that adds or removes @all conveys it. Omitted when false.
+	MentionAll bool      `json:"mentionAll,omitempty" bson:"mentionAll,omitempty"`
+	EditedBy   string    `json:"editedBy" bson:"editedBy"`
+	EditedAt   time.Time `json:"editedAt" bson:"editedAt"`
+	UpdatedAt  time.Time `json:"updatedAt" bson:"updatedAt"`
 	// ThreadParentMessageID is set when the edited message is a thread reply; its presence lets
 	// clients tell a thread-reply edit from a top-level one. Omitted for top-level messages.
 	ThreadParentMessageID string `json:"threadParentMessageId,omitempty" bson:"threadParentMessageId,omitempty"`


### PR DESCRIPTION
## Summary

Editing a message to add or remove `@all` conveyed nothing to clients. The prior work that attached individual `@`-mentions to `message_edited` did not carry `@all`: `EditRoomEvent` had no `mentionAll` field, and the edit-mention resolver returned only the resolved participants — dropping the parse's `MentionAll`. This adds the flag so an edited `@all` is reflected, mirroring the new-message and new-thread-message events.

## What's included

- `EditRoomEvent.MentionAll` (`omitempty`), and the edit-mention resolver now returns it. `MentionAll` is parse-derived and independent of the per-account user lookup, so an edit that adds `@all` with no individual mentions — or one whose lookup fails — still carries the flag. On a lookup failure it drops the individual mentions (no partial set) but keeps the flag.
- Both edit paths (top-level and thread-reply) set `MentionAll` on the emitted event.
- A test asserting an edited-in `@all` carries `mentionAll: true` (and the existing edit test asserts `false` when absent).
- `docs/client-api/events.md` `message_edited` table documents the field.

## Changes

- `pkg/model/event.go` — add `MentionAll` to `EditRoomEvent`.
- `broadcast-worker/handler.go` — `resolveEditMentions` returns `(participants, mentionAll)`; both callers set `edit.MentionAll`.
- `broadcast-worker/handler_test.go` — new pure-`@all` edit test + a negative assertion on the existing one.
- `docs/client-api/events.md` — field row.

## Scope note

This carries the **event flag** only. Whether editing a message to add `@all` should also raise the **group-mention badge** for members is a separate call: on new messages that badge flows through the room's `lastMentionAllAt` (a "room's newest `@all`" concept), which doesn't cleanly map to editing an arbitrary older message. Left as a follow-up rather than decided here.

## Verification

- `go test ./broadcast-worker/... ./pkg/model/...` — green.
- `go vet -tags=integration ./broadcast-worker/...` clean; lint clean.
- Additive, `omitempty` field — no schema/subject change; an older consumer simply omits it (same as any new event field).
