### PR TITLE
fix(history-service): project GetSubscription to its call-site field set

### DIFF
--- a/history-service/internal/mongorepo/subscription.go
+++ b/history-service/internal/mongorepo/subscription.go
@@ -23,20 +23,11 @@ func NewSubscriptionRepo(db *mongo.Database) *SubscriptionRepo {
 	}
 }
 
-// subscriptionReadProjection is the field set GetSubscription returns — the
-// union of every Subscription field its call sites read: canBypassLargeRoomPin
-// (roles, u.account) and the PinnedBy participant (u._id, u.account).
-// model.Subscription carries ~30 fields including the unbounded threadUnread
-// list, and this sits on the pin/unpin path uncached, so the rest is decode
-// cost for nothing. The top-level _id is excluded because no call site reads
-// sub.ID; the user id is a separate path (u._id, tagged bson:"_id" on
-// SubscriptionUser) and rides along with the whole u subdocument. Keep in
-// sync with the Subscription field reads in service/pin.go; the unit tests in
-// subscription_unit_test.go and the projection-field integration test guard drift.
+// subscriptionReadProjection trims the ~30-field doc to what service/pin.go reads.
+// The excluded top-level _id is not sub.User.ID — that is u._id, inside u.
 var subscriptionReadProjection = bson.M{"u": 1, "roles": 1, "_id": 0}
 
-// GetSubscription returns a call-site-projected subscription for a user in a
-// room (see subscriptionReadProjection), or (nil, nil) when not subscribed.
+// GetSubscription returns a projected subscription, or (nil, nil) when not subscribed.
 func (r *SubscriptionRepo) GetSubscription(ctx context.Context, account, roomID string) (*model.Subscription, error) {
 	return r.subscriptions.FindOne(ctx,
 		bson.M{"u.account": account, "roomId": roomID},

--- a/history-service/internal/mongorepo/subscription.go
+++ b/history-service/internal/mongorepo/subscription.go
@@ -23,9 +23,23 @@ func NewSubscriptionRepo(db *mongo.Database) *SubscriptionRepo {
 	}
 }
 
-// GetSubscription returns the full subscription for a user in a room, or (nil, nil) when not subscribed.
+// subscriptionReadProjection is the field set GetSubscription returns — the
+// union of every Subscription field its call sites read: canBypassLargeRoomPin
+// (roles, u.account) and the PinnedBy participant (u.id, u.account).
+// model.Subscription carries ~30 fields including the unbounded threadUnread
+// list, and this sits on the pin/unpin path uncached, so the rest is decode
+// cost for nothing. _id is excluded because no call site reads sub.ID. Keep in
+// sync with the Subscription field reads in service/pin.go; the unit tests in
+// subscription_unit_test.go and the projection-field integration test guard drift.
+var subscriptionReadProjection = bson.M{"u": 1, "roles": 1, "_id": 0}
+
+// GetSubscription returns a call-site-projected subscription for a user in a
+// room (see subscriptionReadProjection), or (nil, nil) when not subscribed.
 func (r *SubscriptionRepo) GetSubscription(ctx context.Context, account, roomID string) (*model.Subscription, error) {
-	return r.subscriptions.FindOne(ctx, bson.M{"u.account": account, "roomId": roomID})
+	return r.subscriptions.FindOne(ctx,
+		bson.M{"u.account": account, "roomId": roomID},
+		mongoutil.WithProjection(subscriptionReadProjection),
+	)
 }
 
 // GetHistorySharedSince returns (nil, true, nil) = full access; (&t, true, nil) = restricted; (nil, false, nil) = not subscribed.

--- a/history-service/internal/mongorepo/subscription.go
+++ b/history-service/internal/mongorepo/subscription.go
@@ -25,10 +25,12 @@ func NewSubscriptionRepo(db *mongo.Database) *SubscriptionRepo {
 
 // subscriptionReadProjection is the field set GetSubscription returns — the
 // union of every Subscription field its call sites read: canBypassLargeRoomPin
-// (roles, u.account) and the PinnedBy participant (u.id, u.account).
+// (roles, u.account) and the PinnedBy participant (u._id, u.account).
 // model.Subscription carries ~30 fields including the unbounded threadUnread
 // list, and this sits on the pin/unpin path uncached, so the rest is decode
-// cost for nothing. _id is excluded because no call site reads sub.ID. Keep in
+// cost for nothing. The top-level _id is excluded because no call site reads
+// sub.ID; the user id is a separate path (u._id, tagged bson:"_id" on
+// SubscriptionUser) and rides along with the whole u subdocument. Keep in
 // sync with the Subscription field reads in service/pin.go; the unit tests in
 // subscription_unit_test.go and the projection-field integration test guard drift.
 var subscriptionReadProjection = bson.M{"u": 1, "roles": 1, "_id": 0}

--- a/history-service/internal/mongorepo/subscription_test.go
+++ b/history-service/internal/mongorepo/subscription_test.go
@@ -37,10 +37,8 @@ func TestSubscriptionRepo_GetSubscription(t *testing.T) {
 	assert.Equal(t, []model.Role{model.RoleMember}, sub.Roles)
 }
 
-// TestSubscriptionRepo_GetSubscription_ProjectionFields pins subscriptionReadProjection
-// against a real Mongo decode: the fields service/pin.go reads come back populated,
-// and the ones it does not are absent from the wire rather than merely unused.
-// A widened projection is a silent regression the unit tests cannot see.
+// Pins subscriptionReadProjection against a real Mongo decode — a widened projection
+// is a silent regression the unit guards, which only read the var, cannot see.
 func TestSubscriptionRepo_GetSubscription_ProjectionFields(t *testing.T) {
 	db := setupMongo(t)
 	repo := NewSubscriptionRepo(db)
@@ -71,8 +69,7 @@ func TestSubscriptionRepo_GetSubscription_ProjectionFields(t *testing.T) {
 	assert.True(t, sub.User.IsBot)
 	assert.Equal(t, []model.Role{model.RoleOwner, model.RoleMember}, sub.Roles)
 
-	// Not read by any call site — must not be fetched. threadUnread is the
-	// expensive one: an unbounded parent-ID list on an uncached hot path.
+	// Not read by any call site — must not be fetched; threadUnread is the costly one.
 	assert.Empty(t, sub.ThreadUnread, "threadUnread must stay out of the projection")
 	assert.Empty(t, sub.ID, "_id must stay out of the projection")
 	assert.Empty(t, sub.RoomID)

--- a/history-service/internal/mongorepo/subscription_test.go
+++ b/history-service/internal/mongorepo/subscription_test.go
@@ -33,9 +33,55 @@ func TestSubscriptionRepo_GetSubscription(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, sub)
 	assert.Equal(t, "u1", sub.User.ID)
-	assert.Equal(t, "r1", sub.RoomID)
-	require.NotNil(t, sub.HistorySharedSince)
-	assert.Equal(t, joinTime.UTC(), sub.HistorySharedSince.UTC())
+	assert.Equal(t, "u1", sub.User.Account)
+	assert.Equal(t, []model.Role{model.RoleMember}, sub.Roles)
+}
+
+// TestSubscriptionRepo_GetSubscription_ProjectionFields pins subscriptionReadProjection
+// against a real Mongo decode: the fields service/pin.go reads come back populated,
+// and the ones it does not are absent from the wire rather than merely unused.
+// A widened projection is a silent regression the unit tests cannot see.
+func TestSubscriptionRepo_GetSubscription_ProjectionFields(t *testing.T) {
+	db := setupMongo(t)
+	repo := NewSubscriptionRepo(db)
+	ctx := context.Background()
+
+	joinTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	_, err := db.Collection("subscriptions").InsertOne(ctx, model.Subscription{
+		ID:     "sproj",
+		User:   model.SubscriptionUser{ID: "u9", Account: "carol", IsBot: true},
+		RoomID: "rproj", SiteID: "site-local",
+		Roles:              []model.Role{model.RoleOwner, model.RoleMember},
+		Name:               "Room Name",
+		RoomType:           model.RoomTypeChannel,
+		ThreadUnread:       []string{"t1", "t2"},
+		HistorySharedSince: &joinTime,
+		LastSeenAt:         &joinTime,
+		JoinedAt:           joinTime,
+	})
+	require.NoError(t, err)
+
+	sub, err := repo.GetSubscription(ctx, "carol", "rproj")
+	require.NoError(t, err)
+	require.NotNil(t, sub)
+
+	// Read by canBypassLargeRoomPin and the PinnedBy participant.
+	assert.Equal(t, "u9", sub.User.ID)
+	assert.Equal(t, "carol", sub.User.Account)
+	assert.True(t, sub.User.IsBot)
+	assert.Equal(t, []model.Role{model.RoleOwner, model.RoleMember}, sub.Roles)
+
+	// Not read by any call site — must not be fetched. threadUnread is the
+	// expensive one: an unbounded parent-ID list on an uncached hot path.
+	assert.Empty(t, sub.ThreadUnread, "threadUnread must stay out of the projection")
+	assert.Empty(t, sub.ID, "_id must stay out of the projection")
+	assert.Empty(t, sub.RoomID)
+	assert.Empty(t, sub.SiteID)
+	assert.Empty(t, sub.Name)
+	assert.Empty(t, sub.RoomType)
+	assert.Nil(t, sub.HistorySharedSince, "GetHistorySharedSince is the projected accessor for this field")
+	assert.Nil(t, sub.LastSeenAt)
+	assert.True(t, sub.JoinedAt.IsZero())
 }
 
 func TestSubscriptionRepo_GetSubscription_NotFound(t *testing.T) {

--- a/history-service/internal/mongorepo/subscription_unit_test.go
+++ b/history-service/internal/mongorepo/subscription_unit_test.go
@@ -11,9 +11,7 @@ import (
 	"github.com/hmchangw/chat/pkg/model"
 )
 
-// subscriptionBSONFields returns the top-level bson field names on
-// model.Subscription, so a projection can be checked against the real schema
-// rather than against a hand-copied list.
+// subscriptionBSONFields reads model.Subscription's bson field names off the struct tags.
 func subscriptionBSONFields(t *testing.T) map[string]bool {
 	t.Helper()
 	fields := map[string]bool{}
@@ -28,10 +26,7 @@ func subscriptionBSONFields(t *testing.T) map[string]bool {
 	return fields
 }
 
-// TestSubscriptionReadProjection_NamesRealFields catches the silent failure
-// mode of a projection typo: Mongo does not reject an unknown field name, it
-// just returns nothing for it, so "role" instead of "roles" would strip the
-// pin-bypass roles with no error anywhere.
+// Mongo ignores an unknown projection field, so "role" for "roles" would silently strip pin-bypass.
 func TestSubscriptionReadProjection_NamesRealFields(t *testing.T) {
 	schema := subscriptionBSONFields(t)
 	require.NotEmpty(t, schema, "reflection over model.Subscription found no bson tags")
@@ -42,26 +37,17 @@ func TestSubscriptionReadProjection_NamesRealFields(t *testing.T) {
 	}
 }
 
-// TestSubscriptionReadProjection_CoversCallSiteReads pins the projection to the
-// fields GetSubscription's callers actually read. Dropping one of these returns
-// a zero value with no error — canBypassLargeRoomPin would silently stop
-// honoring owner/admin/bot bypass, and PinnedBy would carry an empty user.
+// Dropping either yields a zero value, not an error — pin-bypass would stop honoring owners.
 func TestSubscriptionReadProjection_CoversCallSiteReads(t *testing.T) {
-	// Read at internal/service/pin.go: canBypassLargeRoomPin (sub.Roles,
-	// sub.User.Account) and the PinnedBy participant (sub.User.ID,
-	// sub.User.Account).
+	// Read by canBypassLargeRoomPin and the PinnedBy participant in service/pin.go.
 	for _, field := range []string{"u", "roles"} {
 		assert.Equal(t, 1, subscriptionReadProjection[field],
 			"call sites read %q, so it must be included in the projection", field)
 	}
 }
 
-// knownUnreadSubscriptionFields are the model.Subscription bson fields that no
-// GetSubscription call site reads, and which the projection therefore leaves
-// out. Listed exhaustively rather than sampled so that adding a field to
-// model.Subscription fails this test until someone decides which side it falls
-// on — an unprojected field decodes as a zero value with no error, so silent
-// drift here is invisible at runtime.
+// knownUnreadSubscriptionFields is exhaustive rather than sampled: a field added to
+// model.Subscription then fails PartitionsTheSchema until someone classifies it.
 var knownUnreadSubscriptionFields = []string{
 	"roomId", "siteId", "name", "roomType", "isSubscribed", "historySharedSince",
 	"joinedAt", "lastSeenAt", "hasMention", "threadUnread", "alert", "muted",
@@ -70,10 +56,6 @@ var knownUnreadSubscriptionFields = []string{
 	"restrictUpdatedAt", "sectionUpdatedAt", "origin",
 }
 
-// TestSubscriptionReadProjection_PartitionsTheSchema keeps the projection from
-// drifting back toward the whole document, and keeps this guard honest as
-// model.Subscription grows: every bson field must be either projected or
-// explicitly classified as unread.
 func TestSubscriptionReadProjection_PartitionsTheSchema(t *testing.T) {
 	unread := map[string]bool{}
 	for _, f := range knownUnreadSubscriptionFields {
@@ -94,15 +76,9 @@ func TestSubscriptionReadProjection_PartitionsTheSchema(t *testing.T) {
 			"no call site reads %q; leave it out so the pin hot path does not decode it", field)
 	}
 
-	// _id must be suppressed explicitly: an inclusion projection returns the
-	// top-level _id by default, and no call site reads sub.ID. (The user id is
-	// u._id and rides along with the u subdocument — a different path.)
 	assert.Equal(t, 0, subscriptionReadProjection["_id"], "_id must be explicitly excluded")
 }
 
-// TestSubscriptionReadProjection_IsInclusionProjection guards the shape itself:
-// mixing 0s and 1s (beyond the _id special case) is a Mongo error at query
-// time, which would break pin/unpin at runtime rather than in CI.
 func TestSubscriptionReadProjection_IsInclusionProjection(t *testing.T) {
 	for field, value := range subscriptionReadProjection {
 		if field == "_id" {

--- a/history-service/internal/mongorepo/subscription_unit_test.go
+++ b/history-service/internal/mongorepo/subscription_unit_test.go
@@ -37,9 +37,6 @@ func TestSubscriptionReadProjection_NamesRealFields(t *testing.T) {
 	require.NotEmpty(t, schema, "reflection over model.Subscription found no bson tags")
 
 	for field := range subscriptionReadProjection {
-		if field == "_id" {
-			continue // _id is implicit on every document, not a struct-tag field
-		}
 		assert.True(t, schema[field],
 			"projection names %q, which is not a bson field on model.Subscription", field)
 	}
@@ -59,18 +56,47 @@ func TestSubscriptionReadProjection_CoversCallSiteReads(t *testing.T) {
 	}
 }
 
-// TestSubscriptionReadProjection_ExcludesUnreadFields keeps the projection from
-// drifting back toward the whole document. model.Subscription carries ~30
-// fields; these are the expensive ones no call site reads.
-func TestSubscriptionReadProjection_ExcludesUnreadFields(t *testing.T) {
-	for _, field := range []string{"threadUnread", "name", "roomType", "historySharedSince", "lastSeenAt", "joinedAt"} {
+// knownUnreadSubscriptionFields are the model.Subscription bson fields that no
+// GetSubscription call site reads, and which the projection therefore leaves
+// out. Listed exhaustively rather than sampled so that adding a field to
+// model.Subscription fails this test until someone decides which side it falls
+// on — an unprojected field decodes as a zero value with no error, so silent
+// drift here is invisible at runtime.
+var knownUnreadSubscriptionFields = []string{
+	"roomId", "siteId", "name", "roomType", "isSubscribed", "historySharedSince",
+	"joinedAt", "lastSeenAt", "hasMention", "threadUnread", "alert", "muted",
+	"favorite", "sectionId", "sectionOrder", "open", "restricted", "externalAccess",
+	"favoriteUpdatedAt", "muteUpdatedAt", "rolesUpdatedAt", "nameUpdatedAt",
+	"restrictUpdatedAt", "sectionUpdatedAt", "origin",
+}
+
+// TestSubscriptionReadProjection_PartitionsTheSchema keeps the projection from
+// drifting back toward the whole document, and keeps this guard honest as
+// model.Subscription grows: every bson field must be either projected or
+// explicitly classified as unread.
+func TestSubscriptionReadProjection_PartitionsTheSchema(t *testing.T) {
+	unread := map[string]bool{}
+	for _, f := range knownUnreadSubscriptionFields {
+		unread[f] = true
+	}
+
+	for field := range subscriptionBSONFields(t) {
+		_, projected := subscriptionReadProjection[field]
+		assert.True(t, projected || unread[field],
+			"model.Subscription field %q is neither projected nor listed in "+
+				"knownUnreadSubscriptionFields; if a call site now reads it, add it to "+
+				"the projection, otherwise list it as unread", field)
+	}
+
+	for _, field := range knownUnreadSubscriptionFields {
 		_, present := subscriptionReadProjection[field]
 		assert.False(t, present,
 			"no call site reads %q; leave it out so the pin hot path does not decode it", field)
 	}
 
-	// _id must be suppressed explicitly: an inclusion projection returns it by
-	// default, and no call site reads sub.ID.
+	// _id must be suppressed explicitly: an inclusion projection returns the
+	// top-level _id by default, and no call site reads sub.ID. (The user id is
+	// u._id and rides along with the u subdocument — a different path.)
 	assert.Equal(t, 0, subscriptionReadProjection["_id"], "_id must be explicitly excluded")
 }
 

--- a/history-service/internal/mongorepo/subscription_unit_test.go
+++ b/history-service/internal/mongorepo/subscription_unit_test.go
@@ -1,0 +1,88 @@
+package mongorepo
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/model"
+)
+
+// subscriptionBSONFields returns the top-level bson field names on
+// model.Subscription, so a projection can be checked against the real schema
+// rather than against a hand-copied list.
+func subscriptionBSONFields(t *testing.T) map[string]bool {
+	t.Helper()
+	fields := map[string]bool{}
+	rt := reflect.TypeOf(model.Subscription{})
+	for i := range rt.NumField() {
+		tag := rt.Field(i).Tag.Get("bson")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		fields[strings.Split(tag, ",")[0]] = true
+	}
+	return fields
+}
+
+// TestSubscriptionReadProjection_NamesRealFields catches the silent failure
+// mode of a projection typo: Mongo does not reject an unknown field name, it
+// just returns nothing for it, so "role" instead of "roles" would strip the
+// pin-bypass roles with no error anywhere.
+func TestSubscriptionReadProjection_NamesRealFields(t *testing.T) {
+	schema := subscriptionBSONFields(t)
+	require.NotEmpty(t, schema, "reflection over model.Subscription found no bson tags")
+
+	for field := range subscriptionReadProjection {
+		if field == "_id" {
+			continue // _id is implicit on every document, not a struct-tag field
+		}
+		assert.True(t, schema[field],
+			"projection names %q, which is not a bson field on model.Subscription", field)
+	}
+}
+
+// TestSubscriptionReadProjection_CoversCallSiteReads pins the projection to the
+// fields GetSubscription's callers actually read. Dropping one of these returns
+// a zero value with no error — canBypassLargeRoomPin would silently stop
+// honoring owner/admin/bot bypass, and PinnedBy would carry an empty user.
+func TestSubscriptionReadProjection_CoversCallSiteReads(t *testing.T) {
+	// Read at internal/service/pin.go: canBypassLargeRoomPin (sub.Roles,
+	// sub.User.Account) and the PinnedBy participant (sub.User.ID,
+	// sub.User.Account).
+	for _, field := range []string{"u", "roles"} {
+		assert.Equal(t, 1, subscriptionReadProjection[field],
+			"call sites read %q, so it must be included in the projection", field)
+	}
+}
+
+// TestSubscriptionReadProjection_ExcludesUnreadFields keeps the projection from
+// drifting back toward the whole document. model.Subscription carries ~30
+// fields; these are the expensive ones no call site reads.
+func TestSubscriptionReadProjection_ExcludesUnreadFields(t *testing.T) {
+	for _, field := range []string{"threadUnread", "name", "roomType", "historySharedSince", "lastSeenAt", "joinedAt"} {
+		_, present := subscriptionReadProjection[field]
+		assert.False(t, present,
+			"no call site reads %q; leave it out so the pin hot path does not decode it", field)
+	}
+
+	// _id must be suppressed explicitly: an inclusion projection returns it by
+	// default, and no call site reads sub.ID.
+	assert.Equal(t, 0, subscriptionReadProjection["_id"], "_id must be explicitly excluded")
+}
+
+// TestSubscriptionReadProjection_IsInclusionProjection guards the shape itself:
+// mixing 0s and 1s (beyond the _id special case) is a Mongo error at query
+// time, which would break pin/unpin at runtime rather than in CI.
+func TestSubscriptionReadProjection_IsInclusionProjection(t *testing.T) {
+	for field, value := range subscriptionReadProjection {
+		if field == "_id" {
+			continue
+		}
+		assert.Equal(t, 1, value,
+			"field %q must be an inclusion (1); mixing exclusions into an inclusion projection is a query-time error", field)
+	}
+}

--- a/history-service/internal/readcache/readcache.go
+++ b/history-service/internal/readcache/readcache.go
@@ -145,8 +145,10 @@ func (c *SubscriptionCache) GetHistorySharedSince(ctx context.Context, account, 
 }
 
 // GetSubscription bypasses the access-window cache and delegates to the
-// underlying source. Pin/unpin paths need the full subscription doc (roles,
-// account) which we don't cache.
+// underlying source, which projects to the roles and user fields the pin/unpin
+// paths read (see mongorepo.subscriptionReadProjection). Reading any further
+// Subscription field on this path means widening that projection first — an
+// unprojected field decodes as a zero value, not an error.
 func (c *SubscriptionCache) GetSubscription(ctx context.Context, account, roomID string) (*pkgmodel.Subscription, error) {
 	return c.inner.GetSubscription(ctx, account, roomID)
 }

--- a/history-service/internal/readcache/readcache.go
+++ b/history-service/internal/readcache/readcache.go
@@ -144,11 +144,8 @@ func (c *SubscriptionCache) GetHistorySharedSince(ctx context.Context, account, 
 	return entry.sharedSince, entry.subscribed, nil
 }
 
-// GetSubscription bypasses the access-window cache and delegates to the
-// underlying source, which projects to the roles and user fields the pin/unpin
-// paths read (see mongorepo.subscriptionReadProjection). Reading any further
-// Subscription field on this path means widening that projection first — an
-// unprojected field decodes as a zero value, not an error.
+// GetSubscription bypasses the access-window cache and delegates to the source, which
+// projects (mongorepo.subscriptionReadProjection) — read a new field, widen that first.
 func (c *SubscriptionCache) GetSubscription(ctx context.Context, account, roomID string) (*pkgmodel.Subscription, error) {
 	return c.inner.GetSubscription(ctx, account, roomID)
 }


### PR DESCRIPTION
## What

`SubscriptionRepo.GetSubscription` was the only projection-free read in `history-service`. It fetched the whole ~30-field `model.Subscription` document — including the unbounded `threadUnread` parent-ID list — on the uncached pin/unpin path, in order to read three fields. This violates the "always project precisely" rule in CLAUDE.md §6.

This projects it to the fields its call sites actually read:

```go
var subscriptionReadProjection = bson.M{"u": 1, "roles": 1, "_id": 0}
```

Code only. The audit report that surfaced this finding is a separate PR (#397).

## Why these fields

The complete set read from this method's result anywhere in the service, all in `internal/service/pin.go`:

| Field | Read by |
|---|---|
| `sub.Roles` | `canBypassLargeRoomPin` (`pin.go:23`) |
| `sub.User.Account` | `canBypassLargeRoomPin` (`pin.go:28`), `PinnedBy` (`pin.go:119,134,176`) |
| `sub.User.ID` | `PinnedBy` (`pin.go:119,134,176`) |

There is one call site (`pin.go:38`) plus a pass-through in `internal/readcache`, which deliberately does not cache this method. The top-level `_id` is suppressed because no call site reads `sub.ID`.

Worth knowing while reading the projection: `SubscriptionUser.ID` is itself tagged `bson:"_id"`, so the user id is at `u._id` — a different path from the excluded top-level `_id`, and it rides along with the projected `u` subdocument. `PinnedBy` still populates.

This mirrors two existing patterns: `subscriptionReadProjection` in `room-service/store_mongo.go:222` (including its projection-drift integration test), and the already-projected `GetHistorySharedSince` immediately below in the same file.

## Tests

Written before the implementation; Red confirmed as `undefined: subscriptionReadProjection` across 5 sites.

**`subscription_unit_test.go`** (new, untagged — no Docker needed):
- Reflects over `model.Subscription`'s real `bson` tags and asserts every projected name is a genuine field. This catches the failure mode that actually bites here: Mongo does not reject an unknown projection field, it silently returns nothing for it, so `"role"` instead of `"roles"` would strip owner/admin/bot pin-bypass with no error anywhere.
- **Partitions the schema**: every `model.Subscription` bson field must be either projected or listed in `knownUnreadSubscriptionFields`, so adding a field to the model fails the test until someone classifies it. Verified by temporarily adding a field to `model.Subscription` and confirming the failure message names it.
- Asserts the projection is inclusion-only — mixing exclusions into an inclusion projection is a query-time error, which would break pin/unpin at runtime rather than in CI.

**`TestSubscriptionRepo_GetSubscription_ProjectionFields`** (integration): pins the contract against a real Mongo decode — projected fields populated, non-projected fields absent from the wire.

## Notes for reviewers

- `TestSubscriptionRepo_GetSubscription` previously asserted `sub.RoomID` and `sub.HistorySharedSince`, neither of which any call site reads. Rather than widening the projection to keep that test green, the test now asserts the fields the projection is contracted to return. `HistorySharedSince` already has its own projected accessor (`GetHistorySharedSince`) three lines below, so no caller loses that path.
- `readcache.SubscriptionCache.GetSubscription`'s doc comment claimed the pin/unpin paths "need the full subscription doc", which this change makes false. Left alone it would be a trap, since an unprojected field decodes as a zero value rather than an error — so it now states what is projected and that reading further fields means widening the projection first.

## Verification

- `make test SERVICE=history-service` — all 8 packages pass
- `make lint` — 0 issues
- `go vet -tags integration ./history-service/...` — clean
- `make sast-gosec` — clean

The integration test compiles and vets but **was not executed** — Docker was unavailable in the authoring environment, so its assertions are unverified against a real Mongo and should be confirmed by CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Subscription lookups now retrieve only the user and role information needed by pin/unpin actions, reducing unnecessary data retrieval.

* **Documentation**
  * Clarified which subscription details are available through this lookup and documented the behavior of fields not included in the response.

* **Tests**
  * Added coverage to verify returned fields and ensure projection behavior remains consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->