### PR TITLE
perf(user-service): unblock the badge notification hot path

### DIFF
--- a/user-service/config/config.go
+++ b/user-service/config/config.go
@@ -84,6 +84,12 @@ type Config struct {
 	// large page issue several per site, so this is the knob that throttles the
 	// resulting downstream load without a rebuild.
 	MaxSiteFanout int `env:"MAX_SITE_FANOUT" envDefault:"8"`
+	// MaxBadgeSeedFanout bounds concurrent per-account badge seeds within one
+	// badge.count.batch. Each seed runs the unread aggregate (one Mongo
+	// connection) and opens its own MaxSiteFanout-bounded cross-site fan-out, so
+	// the worst-case concurrent RPC count is the product of the two — keep this
+	// at or below the Mongo pool size.
+	MaxBadgeSeedFanout int `env:"MAX_BADGE_SEED_FANOUT" envDefault:"8"`
 	// Room sort-key cache for subscription.list (see
 	// mongorepo.NewSubscriptionRepo). An entry is at most TTL old and staleness
 	// only affects ordering; zero or less for either knob turns the cache off.
@@ -235,6 +241,9 @@ func Load() (Config, error) {
 	}
 	if cfg.MaxSiteFanout < 1 {
 		return Config{}, fmt.Errorf("MAX_SITE_FANOUT must be >= 1, got %d", cfg.MaxSiteFanout)
+	}
+	if cfg.MaxBadgeSeedFanout < 1 {
+		return Config{}, fmt.Errorf("MAX_BADGE_SEED_FANOUT must be >= 1, got %d", cfg.MaxBadgeSeedFanout)
 	}
 	if cfg.RoomBatchChunk < 1 || cfg.RoomBatchChunk > 100 {
 		return Config{}, fmt.Errorf("ROOM_BATCH_CHUNK must be in [1,100], got %d", cfg.RoomBatchChunk)

--- a/user-service/config/config.go
+++ b/user-service/config/config.go
@@ -84,11 +84,14 @@ type Config struct {
 	// large page issue several per site, so this is the knob that throttles the
 	// resulting downstream load without a rebuild.
 	MaxSiteFanout int `env:"MAX_SITE_FANOUT" envDefault:"8"`
-	// MaxBadgeSeedFanout bounds concurrent per-account badge seeds within one
-	// badge.count.batch. Each seed runs the unread aggregate (one Mongo
-	// connection) and opens its own MaxSiteFanout-bounded cross-site fan-out, so
-	// the worst-case concurrent RPC count is the product of the two — keep this
-	// at or below the Mongo pool size.
+	// MaxBadgeSeedFanout bounds concurrent per-account badge seeds within ONE
+	// badge.count.batch, and nothing rate-limits that subject: the reachable peak
+	// is this times MaxConcurrency, since every admitted handler may be a badge
+	// batch, with each seed opening its own MaxSiteFanout cross-site fan-out on
+	// top. A seed holds a Mongo connection only for the unread aggregate, not for
+	// the RPC half, and that pool ceiling is per replica-set member and shared
+	// with every other NATS handler. So this is NOT a knob to raise toward the
+	// pool size — single digits is the intended range.
 	MaxBadgeSeedFanout int `env:"MAX_BADGE_SEED_FANOUT" envDefault:"8"`
 	// Room sort-key cache for subscription.list (see
 	// mongorepo.NewSubscriptionRepo). An entry is at most TTL old and staleness

--- a/user-service/config/config_test.go
+++ b/user-service/config/config_test.go
@@ -711,3 +711,34 @@ func TestValidate_RejectsInvalidClientReadPreference(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "MONGO_CLIENT_READ_PREFERENCE")
 }
+
+func TestLoad_BadgeSeedFanoutDefault(t *testing.T) {
+	t.Setenv("MONGO_URI", "mongodb://x")
+	t.Setenv("NATS_URL", "nats://x")
+	t.Setenv("SITE_ID", "site-a")
+	unsetEnv(t, "MAX_BADGE_SEED_FANOUT")
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.Equal(t, 8, cfg.MaxBadgeSeedFanout)
+}
+
+func TestLoad_BadgeSeedFanoutOverride(t *testing.T) {
+	t.Setenv("MONGO_URI", "mongodb://x")
+	t.Setenv("NATS_URL", "nats://x")
+	t.Setenv("SITE_ID", "site-a")
+	t.Setenv("MAX_BADGE_SEED_FANOUT", "4")
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.Equal(t, 4, cfg.MaxBadgeSeedFanout)
+}
+
+// Zero would make the seed semaphore an unbuffered channel whose send blocks
+// forever, so it must be rejected at startup rather than deadlock a handler.
+func TestLoad_BadgeSeedFanoutInvalidRejected(t *testing.T) {
+	t.Setenv("MONGO_URI", "mongodb://x")
+	t.Setenv("NATS_URL", "nats://x")
+	t.Setenv("SITE_ID", "site-a")
+	t.Setenv("MAX_BADGE_SEED_FANOUT", "0")
+	_, err := Load()
+	require.ErrorContains(t, err, "MAX_BADGE_SEED_FANOUT")
+}

--- a/user-service/deploy/docker-compose.yml
+++ b/user-service/deploy/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       # Truncates each preview body; a page holds 400 and a body may reach 20 KB.
       - PREVIEW_CONTENT_CHARS=${PREVIEW_CONTENT_CHARS:-50}
       - MAX_SITE_FANOUT=${MAX_SITE_FANOUT:-8}
+      - MAX_BADGE_SEED_FANOUT=${MAX_BADGE_SEED_FANOUT:-8}
       - HEALTH_ADDR=${HEALTH_ADDR:-:8081}
       # Unset leaves HTTP auth on ssoToken only.
       - BOTPLATFORM_URL=${BOTPLATFORM_URL:-}

--- a/user-service/mongorepo/subscriptions.go
+++ b/user-service/mongorepo/subscriptions.go
@@ -823,9 +823,31 @@ func (r *SubscriptionRepo) activeSubscriptionPipeline(account string, limit int)
 	if limit > 0 {
 		pipeline = append(pipeline, bson.M{"$limit": int64(limit)})
 	}
-	pipeline = append(pipeline, roomsEnrichStages()...)
+	pipeline = append(pipeline, activeRoomsEnrichStages()...)
 	pipeline = append(pipeline, bson.M{"$project": activeSubscriptionProjection()})
 	return pipeline
+}
+
+// activeRoomsEnrichStages is the badge path's rooms join. It deliberately does NOT
+// reuse roomsEnrichStages: the badge count reads exactly one room field, so joining
+// the list path's eleven (the encKey blob among them) would materialize ten per
+// joined room for the terminal $project to discard — once per account in a
+// notification batch. A cross-site subscription has no local room document and,
+// as in the list path, simply yields no lastMsgAt.
+func activeRoomsEnrichStages() bson.A {
+	return bson.A{
+		bson.M{"$lookup": bson.M{
+			"from": roomsCollection,
+			"let":  bson.M{"rid": "$roomId"},
+			"pipeline": bson.A{
+				bson.M{"$match": bson.M{"$expr": bson.M{"$eq": bson.A{"$_id", "$$rid"}}}},
+				bson.M{"$project": bson.M{"_id": 0, "lastMsgAt": 1}},
+			},
+			"as": "room",
+		}},
+		bson.M{"$unwind": bson.M{"path": "$room", "preserveNullAndEmptyArrays": true}},
+		bson.M{"$addFields": bson.M{"lastMsgAt": "$room.lastMsgAt"}},
+	}
 }
 
 // GetActiveSubscriptions returns the active set for the unread count, capped before the join.

--- a/user-service/mongorepo/subscriptions.go
+++ b/user-service/mongorepo/subscriptions.go
@@ -836,6 +836,14 @@ func (r *SubscriptionRepo) activeSubscriptionPipeline(account string, limit int)
 // as in the list path, simply yields no lastMsgAt.
 func activeRoomsEnrichStages() bson.A {
 	return bson.A{
+		// $lookup justification: the unread test compares the room's lastMsgAt
+		// against the subscription's own lastSeenAt, so both sides must meet
+		// somewhere. Composing app-side would add a second round trip per account
+		// — an $in over the whole active set — on a path that already runs once
+		// per account in a notification batch. The $limit above caps the join at
+		// maxSubs rows, and the correlated $expr matches on the rooms _id index.
+		// The cross-site half of this same computation necessarily uses the
+		// separate-query shape (GetRoomsMeta), there being no local room document.
 		bson.M{"$lookup": bson.M{
 			"from": roomsCollection,
 			"let":  bson.M{"rid": "$roomId"},

--- a/user-service/mongorepo/subscriptions_activeproj_test.go
+++ b/user-service/mongorepo/subscriptions_activeproj_test.go
@@ -122,3 +122,74 @@ func TestActiveSubscription_DecodesFromFullSubscriptionDocument(t *testing.T) {
 	assert.Equal(t, sub.ThreadUnread, row.ThreadUnread)
 	assert.Nil(t, row.LastMsgAt, "lastMsgAt is added by the rooms join, never stored on the subscription")
 }
+
+// lookupSubPipeline returns the sub-pipeline of the single $lookup in pipeline.
+func lookupSubPipeline(t *testing.T, pipeline bson.A) bson.A {
+	t.Helper()
+	for _, stage := range pipeline {
+		m, ok := stage.(bson.M)
+		if !ok {
+			continue
+		}
+		spec, ok := m["$lookup"].(bson.M)
+		if !ok {
+			continue
+		}
+		sub, ok := spec["pipeline"].(bson.A)
+		require.True(t, ok, "$lookup must use a sub-pipeline, not a plain foreignField join")
+		return sub
+	}
+	t.Fatal("no $lookup stage in pipeline")
+	return nil
+}
+
+// projectedKeys returns the inclusion keys of the first $project in pipeline, sorted.
+func projectedKeys(t *testing.T, pipeline bson.A) []string {
+	t.Helper()
+	for _, stage := range pipeline {
+		m, ok := stage.(bson.M)
+		if !ok {
+			continue
+		}
+		proj, ok := m["$project"].(bson.M)
+		if !ok {
+			continue
+		}
+		keys := []string{}
+		for k, v := range proj {
+			if k == "_id" && v == 0 {
+				continue
+			}
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		return keys
+	}
+	t.Fatal("no $project stage in pipeline")
+	return nil
+}
+
+// The badge pipeline keeps exactly one room field (lastMsgAt), so its rooms join
+// must fetch exactly that. Reusing the list path's 11-field enrichment
+// materializes ten fields per joined room — including the encKey blob — that the
+// terminal $project then discards, once per account in a notification batch.
+func TestActiveSubscriptionPipeline_JoinsOnlyLastMsgAt(t *testing.T) {
+	r := &SubscriptionRepo{}
+
+	sub := lookupSubPipeline(t, r.activeSubscriptionPipeline("alice", 100))
+
+	assert.Equal(t, []string{"lastMsgAt"}, projectedKeys(t, sub),
+		"the badge join must project only the room field the terminal $project keeps")
+}
+
+// The join must not carry the E2E key into the working set: it is the largest
+// field in the enrichment set and the badge count never reads it.
+func TestActiveSubscriptionPipeline_JoinOmitsRoomKey(t *testing.T) {
+	r := &SubscriptionRepo{}
+
+	sub := lookupSubPipeline(t, r.activeSubscriptionPipeline("alice", 100))
+
+	for _, k := range projectedKeys(t, sub) {
+		assert.NotContains(t, k, "encKey", "the badge join must not fetch the room E2E key")
+	}
+}

--- a/user-service/service/badge.go
+++ b/user-service/service/badge.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"log/slog"
+	"sync"
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
@@ -12,8 +13,8 @@ import (
 // BadgeCountBatch returns each account's badge unread-room count (capped at
 // BADGE_COUNT_CAP) for a notification in req.RoomID. Cache hit: one pipelined SADD+SCARD
 // batch for all accounts. Miss: seed from unreadRooms (Mongo + cross-site
-// room RPCs) ∪ the trigger room. Per-account failures degrade to absence —
-// the push must never block.
+// room RPCs), MAX_BADGE_SEED_FANOUT accounts at a time, ∪ the trigger room.
+// Per-account failures degrade to absence — the push must never block.
 // NATS: chat.server.request.user.{siteID}.badge.count.batch
 func (s *UserService) BadgeCountBatch(c *natsrouter.Context, req model.BadgeCountBatchRequest) (*model.BadgeCountBatchResponse, error) {
 	if len(req.Accounts) == 0 || req.RoomID == "" {
@@ -21,40 +22,73 @@ func (s *UserService) BadgeCountBatch(c *natsrouter.Context, req model.BadgeCoun
 	}
 	resp := &model.BadgeCountBatchResponse{Counts: make(map[string]int, len(req.Accounts))}
 	hits := s.badge.BumpBatch(c, req.Accounts, req.RoomID)
+	misses := make([]string, 0, len(req.Accounts))
 	for _, account := range req.Accounts {
+		// A hit is already in memory from BumpBatch — serve it whatever happens to
+		// the recompute path below, including a budget spent part-way through.
 		if n, ok := hits[account]; ok {
 			resp.Counts[account] = n
 			continue
 		}
-		// Once the shared request budget is spent, skip the EXPENSIVE unread
-		// recompute for this account: run against a dead context it would only hit
-		// the heavy aggregate, fail at connection checkout with a misleading pool
-		// error, and degrade to absence anyway. Skipping (not returning) keeps the
-		// loop going so any remaining cache hits — already in memory from BumpBatch
-		// — are still served; only the misses past the deadline degrade to absence,
-		// as any per-account failure does (the badge push must never block).
-		select {
-		case <-c.Done():
-			continue
-		default:
+		misses = append(misses, account)
+	}
+
+	// Each miss costs a rooms aggregate plus that account's own cross-site RPCs.
+	// Run them concurrently — serialized, a batch's latency is the SUM of every
+	// miss against one shared handler deadline. The bound matters as much as the
+	// concurrency: each seed holds a Mongo connection and opens its own per-site
+	// fan-out, so the two bounds multiply.
+	// counts[i]/answered[i] are each written by exactly one goroutine, so the
+	// merge below needs no lock. WaitGroup, not errgroup: one account's failure
+	// must not cancel its siblings.
+	counts := make([]int, len(misses))
+	answered := make([]bool, len(misses))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, s.badgeSeedFanout())
+	for i, account := range misses {
+		// Once the shared request budget is spent, stop STARTING recomputes: run
+		// against a dead context they would only hit the heavy aggregate, fail at
+		// connection checkout with a misleading pool error, and degrade to absence
+		// anyway. Seeds already in flight finish and still answer.
+		if c.Err() != nil {
+			break
 		}
-		ids, degraded, err := s.unreadRooms(c, account)
-		if err != nil {
-			slog.WarnContext(c, "badge seed degraded", "account", account, "room_id", req.RoomID, "request_id", natsutil.RequestIDFromContext(c), "error", err)
-			continue
+		wg.Add(1)
+		// Acquire before spawning so the live goroutine COUNT, not just the
+		// concurrency, stays within the bound (as fanOutChunks does).
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			// Re-check after parking on the semaphore: the budget may have been
+			// spent while this account waited its turn.
+			if c.Err() != nil {
+				return
+			}
+			ids, degraded, err := s.unreadRooms(c, account)
+			if err != nil {
+				slog.WarnContext(c, "badge seed degraded", "account", account, "room_id", req.RoomID, "request_id", natsutil.RequestIDFromContext(c), "error", err)
+				return
+			}
+			// A partial result must not be cached (it would stamp the freshness
+			// marker); answer from it directly instead.
+			if degraded {
+				counts[i], answered[i] = cappedUnion(ids, req.RoomID, s.badgeCap), true
+				return
+			}
+			if n, ok := s.badge.Seed(c, account, ids, req.RoomID); ok {
+				counts[i], answered[i] = n, true
+				return
+			}
+			// Cache down entirely: compute without it (ids ∪ trigger, capped).
+			counts[i], answered[i] = cappedUnion(ids, req.RoomID, s.badgeCap), true
+		}()
+	}
+	wg.Wait()
+	for i, account := range misses {
+		if answered[i] {
+			resp.Counts[account] = counts[i]
 		}
-		// A partial result must not be cached (it would stamp the freshness
-		// marker); answer from it directly instead.
-		if degraded {
-			resp.Counts[account] = cappedUnion(ids, req.RoomID, s.badgeCap)
-			continue
-		}
-		if n, ok := s.badge.Seed(c, account, ids, req.RoomID); ok {
-			resp.Counts[account] = n
-			continue
-		}
-		// Cache down entirely: compute without it (ids ∪ trigger, capped).
-		resp.Counts[account] = cappedUnion(ids, req.RoomID, s.badgeCap)
 	}
 	return resp, nil
 }

--- a/user-service/service/badge.go
+++ b/user-service/service/badge.go
@@ -49,7 +49,11 @@ func (s *UserService) BadgeCountBatch(c *natsrouter.Context, req model.BadgeCoun
 		// Once the shared request budget is spent, stop STARTING recomputes: run
 		// against a dead context they would only hit the heavy aggregate, fail at
 		// connection checkout with a misleading pool error, and degrade to absence
-		// anyway. Seeds already in flight finish and still answer.
+		// anyway. Seeds already in flight are left to finish, and how far along
+		// they are decides the outcome: one past the aggregate still answers (a
+		// dead context only marks its cross-site half degraded), while one still
+		// inside the aggregate fails on it and degrades to absence — logging the
+		// same misleading pool error this guard avoids for the unstarted.
 		if c.Err() != nil {
 			break
 		}

--- a/user-service/service/badge_test.go
+++ b/user-service/service/badge_test.go
@@ -3,7 +3,9 @@ package service
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -11,6 +13,7 @@ import (
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/user-service/config"
 	"github.com/hmchangw/chat/user-service/models"
 	"github.com/hmchangw/chat/user-service/service/mocks"
 )
@@ -20,6 +23,9 @@ import (
 // are optional overrides (nil ⇒ default all-miss/no-op); the call slices record
 // which accounts each method was invoked for, in order.
 type fakeBadgeCache struct {
+	// mu guards the call records: BadgeCountBatch seeds misses concurrently, so
+	// Seed lands from many goroutines at once.
+	mu        sync.Mutex
 	bumpBatch func(accounts []string, roomID string) map[string]int
 	seed      func(account string, roomIDs []string, trigger string) (int, bool)
 	reseed    func(account string, roomIDs []string)
@@ -38,7 +44,9 @@ type fakeBadgeCache struct {
 }
 
 func (f *fakeBadgeCache) BumpBatch(_ context.Context, accounts []string, roomID string) map[string]int {
+	f.mu.Lock()
 	f.bumpCalls = append(f.bumpCalls, accounts)
+	f.mu.Unlock()
 	if f.bumpBatch != nil {
 		return f.bumpBatch(accounts, roomID)
 	}
@@ -46,7 +54,9 @@ func (f *fakeBadgeCache) BumpBatch(_ context.Context, accounts []string, roomID 
 }
 
 func (f *fakeBadgeCache) Seed(_ context.Context, account string, roomIDs []string, trigger string) (int, bool) {
+	f.mu.Lock()
 	f.seedCalls = append(f.seedCalls, account)
+	f.mu.Unlock()
 	if f.seed != nil {
 		return f.seed(account, roomIDs, trigger)
 	}
@@ -54,7 +64,9 @@ func (f *fakeBadgeCache) Seed(_ context.Context, account string, roomIDs []strin
 }
 
 func (f *fakeBadgeCache) Count(_ context.Context, account string) (int, bool) {
+	f.mu.Lock()
 	f.countCalls = append(f.countCalls, account)
+	f.mu.Unlock()
 	if f.count != nil {
 		return f.count(account)
 	}
@@ -62,8 +74,10 @@ func (f *fakeBadgeCache) Count(_ context.Context, account string) (int, bool) {
 }
 
 func (f *fakeBadgeCache) Reseed(_ context.Context, account string, roomIDs []string) {
+	f.mu.Lock()
 	f.reseedCalls = append(f.reseedCalls, account)
 	f.reseedRoomIDs = append(f.reseedRoomIDs, roomIDs)
+	f.mu.Unlock()
 	if f.reseed != nil {
 		f.reseed(account, roomIDs)
 	}
@@ -232,6 +246,10 @@ func TestBadgeCountBatch_BudgetSpentMidBatch_StopsAndRemainingAbsent(t *testing.
 		seed: func(account string, roomIDs []string, trigger string) (int, bool) { return 1, true },
 	}
 	svc := newBadgeService(t, subs, badge)
+	// Serialized: with one seed in flight at a time, an account the loop has not
+	// reached is exactly an account not yet started. The concurrent equivalent is
+	// TestBadgeCountBatch_BudgetSpentMidBatch_UnstartedSeedsSkipped.
+	svc.badgeFanout = 1
 	resp, err := svc.BadgeCountBatch(c, model.BadgeCountBatchRequest{RoomID: "r1", Accounts: []string{"a", "b", "c"}})
 	require.NoError(t, err, "a spent budget degrades the rest — it must not fail the whole batch")
 	assert.Contains(t, resp.Counts, "a", "the account computed before the budget was spent still answers")
@@ -264,6 +282,10 @@ func TestBadgeCountBatch_BudgetSpentMidBatch_LaterCacheHitStillServed(t *testing
 	// "b" misses and sits past the spent budget — its expensive recompute must be skipped.
 	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), "b", gomock.Any()).Times(0)
 	svc := newBadgeService(t, subs, badge)
+	// Serialized: with one seed in flight at a time, an account the loop has not
+	// reached is exactly an account not yet started. The concurrent equivalent is
+	// TestBadgeCountBatch_BudgetSpentMidBatch_UnstartedSeedsSkipped.
+	svc.badgeFanout = 1
 	resp, err := svc.BadgeCountBatch(c, model.BadgeCountBatchRequest{RoomID: "r1", Accounts: []string{"a", "b", "c"}})
 	require.NoError(t, err)
 	assert.Contains(t, resp.Counts, "a", "the account computed before the budget was spent still answers")
@@ -313,4 +335,178 @@ func TestCappedUnion(t *testing.T) {
 			assert.Equal(t, tc.want, cappedUnion(tc.ids, tc.trigger, tc.cap))
 		})
 	}
+}
+
+// seedBarrier blocks every GetActiveSubscriptions call until `width` of them are
+// in flight at once, then releases all of them. It records the peak concurrency
+// so a test can assert both that seeds overlap and that they stay within the
+// configured bound. Serialized code never reaches `width`, so waitFull fails.
+type seedBarrier struct {
+	mu       sync.Mutex
+	inFlight int
+	peak     int
+	arrived  chan struct{}
+	release  chan struct{}
+	width    int
+}
+
+func newSeedBarrier(width int) *seedBarrier {
+	return &seedBarrier{arrived: make(chan struct{}, 64), release: make(chan struct{}), width: width}
+}
+
+// enter records one in-flight call and blocks until the barrier is released.
+func (b *seedBarrier) enter() {
+	b.mu.Lock()
+	b.inFlight++
+	if b.inFlight > b.peak {
+		b.peak = b.inFlight
+	}
+	b.mu.Unlock()
+	b.arrived <- struct{}{}
+	<-b.release
+	b.mu.Lock()
+	b.inFlight--
+	b.mu.Unlock()
+}
+
+// waitFull waits for `width` concurrent arrivals, then releases them all.
+func (b *seedBarrier) waitFull(t *testing.T) {
+	t.Helper()
+	for i := 0; i < b.width; i++ {
+		select {
+		case <-b.arrived:
+		case <-time.After(5 * time.Second):
+			close(b.release)
+			t.Fatalf("only %d of %d seeds were in flight at once — misses are being computed serially", i, b.width)
+		}
+	}
+	close(b.release)
+}
+
+func (b *seedBarrier) peakConcurrency() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.peak
+}
+
+// expectBarrieredSeeds wires every GetActiveSubscriptions call through the barrier.
+func expectBarrieredSeeds(subs *mocks.MockSubscriptionRepository, b *seedBarrier) {
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, account string, _ int) ([]models.ActiveSubscription, error) {
+			b.enter()
+			return []models.ActiveSubscription{localUnreadSub(account, "r-"+account, "site-a")}, nil
+		}).AnyTimes()
+}
+
+// Each cache miss costs a rooms aggregate plus per-site RPCs. Computing them one
+// after another makes a notification batch's latency the SUM of every miss,
+// against a single shared handler deadline — so the misses must overlap.
+func TestBadgeCountBatch_SeedsMissesConcurrently(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	subs := mocks.NewMockSubscriptionRepository(ctrl)
+	accounts := []string{"a", "b", "c", "d"}
+	barrier := newSeedBarrier(len(accounts))
+	expectBarrieredSeeds(subs, barrier)
+	badge := &fakeBadgeCache{
+		seed: func(string, []string, string) (int, bool) { return 1, true },
+	}
+	svc := newBadgeService(t, subs, badge)
+	svc.badgeFanout = len(accounts)
+
+	done := make(chan *model.BadgeCountBatchResponse, 1)
+	go func() {
+		resp, err := svc.BadgeCountBatch(ctx("", "site-a"), model.BadgeCountBatchRequest{RoomID: "r1", Accounts: accounts})
+		assert.NoError(t, err)
+		done <- resp
+	}()
+	barrier.waitFull(t)
+
+	resp := <-done
+	require.NotNil(t, resp)
+	assert.Equal(t, map[string]int{"a": 1, "b": 1, "c": 1, "d": 1}, resp.Counts,
+		"every account must still be answered when the misses run concurrently")
+}
+
+// The overlap must stay inside MAX_BADGE_SEED_FANOUT: each concurrent seed holds
+// a Mongo connection and fires cross-site RPCs, so an unbounded fan-out would
+// trade a latency problem for pool exhaustion.
+func TestBadgeCountBatch_SeedConcurrencyNeverExceedsFanout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	subs := mocks.NewMockSubscriptionRepository(ctrl)
+	const fanout = 2
+	accounts := []string{"a", "b", "c", "d", "e", "f"}
+	barrier := newSeedBarrier(fanout)
+	expectBarrieredSeeds(subs, barrier)
+	badge := &fakeBadgeCache{
+		seed: func(string, []string, string) (int, bool) { return 1, true },
+	}
+	svc := newBadgeService(t, subs, badge)
+	svc.badgeFanout = fanout
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, err := svc.BadgeCountBatch(ctx("", "site-a"), model.BadgeCountBatchRequest{RoomID: "r1", Accounts: accounts})
+		assert.NoError(t, err)
+	}()
+	barrier.waitFull(t)
+	<-done
+
+	assert.LessOrEqual(t, barrier.peakConcurrency(), fanout,
+		"concurrent seeds must never exceed the configured fanout")
+}
+
+// A spent budget stops seeds that have not STARTED yet; ones already in flight
+// run to completion and still answer. This is the concurrent counterpart of
+// TestBadgeCountBatch_BudgetSpentMidBatch_StopsAndRemainingAbsent.
+func TestBadgeCountBatch_BudgetSpentMidBatch_UnstartedSeedsSkipped(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	subs := mocks.NewMockSubscriptionRepository(ctrl)
+	cctx, cancel := context.WithCancel(context.Background())
+	c := ctx("", "site-a")
+	c.SetContext(cctx)
+	var mu sync.Mutex
+	started := map[string]bool{}
+	subs.EXPECT().GetActiveSubscriptions(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, account string, _ int) ([]models.ActiveSubscription, error) {
+			mu.Lock()
+			started[account] = true
+			mu.Unlock()
+			cancel() // the shared handler deadline elapses during the first seed
+			return []models.ActiveSubscription{localUnreadSub(account, "r-"+account, "site-a")}, nil
+		}).AnyTimes()
+	badge := &fakeBadgeCache{
+		seed: func(string, []string, string) (int, bool) { return 1, true },
+	}
+	svc := newBadgeService(t, subs, badge)
+	svc.badgeFanout = 1
+
+	resp, err := svc.BadgeCountBatch(c, model.BadgeCountBatchRequest{RoomID: "r1", Accounts: []string{"a", "b", "c", "d"}})
+
+	require.NoError(t, err, "a spent budget degrades the remainder — it must not fail the batch")
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Len(t, started, 1, "no seed may start once the budget is spent")
+	for account := range resp.Counts {
+		assert.True(t, started[account], "only an account whose seed actually ran may be answered")
+	}
+}
+
+// The seed semaphore sends before spawning its receiver, so a capacity of zero
+// is an unbuffered channel that blocks forever — the same hazard fanout() guards.
+func TestBadgeSeedFanout_NormalisesNonPositive(t *testing.T) {
+	for _, n := range []int{0, -1} {
+		assert.Equal(t, defaultBadgeSeedFanout, (&UserService{badgeFanout: n}).badgeSeedFanout())
+	}
+	assert.Equal(t, 3, (&UserService{badgeFanout: 3}).badgeSeedFanout())
+}
+
+// The operator-facing knob must actually reach the seed bound; left unwired,
+// every deployment would silently run the default.
+func TestNew_WiresBadgeSeedFanoutFromConfig(t *testing.T) {
+	cfg := &config.Config{SiteID: "site-a", MaxBadgeSeedFanout: 3}
+
+	svc := New(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, cfg)
+
+	assert.Equal(t, 3, svc.badgeSeedFanout())
 }

--- a/user-service/service/service.go
+++ b/user-service/service/service.go
@@ -159,7 +159,11 @@ type UserService struct {
 	// at 20 KB, but not a 400-row page at 400 of them.
 	previewChars int
 	// maxFanout bounds concurrent enrichment RPCs per request (MAX_SITE_FANOUT).
-	maxFanout       int
+	maxFanout int
+	// badgeFanout bounds concurrent per-account badge seeds in one batch
+	// (MAX_BADGE_SEED_FANOUT). Each seed holds a Mongo connection for the unread
+	// aggregate and fans out its own cross-site RPCs, so the two bounds multiply.
+	badgeFanout     int
 	maxApps         int
 	defaultApps     int
 	maxAccountNames int
@@ -201,6 +205,7 @@ func New(subs SubscriptionRepository, users UserRepository, apps AppRepository, 
 		roomBatchChunk:   cfg.RoomBatchChunk,
 		previewChars:     cfg.PreviewContentChars,
 		maxFanout:        cfg.MaxSiteFanout,
+		badgeFanout:      cfg.MaxBadgeSeedFanout,
 		defaultLimit:     cfg.DefaultSubscriptionLimit,
 		maxApps:          cfg.MaxAppsLimit,
 		defaultApps:      cfg.DefaultAppsLimit,
@@ -225,6 +230,19 @@ func (s *UserService) fanout() int {
 		return defaultSiteFanout
 	}
 	return s.maxFanout
+}
+
+// defaultBadgeSeedFanout is the fallback when badgeFanout is unset.
+const defaultBadgeSeedFanout = 8
+
+// badgeSeedFanout is the per-batch bound on concurrent account seeds. It
+// normalises a non-positive value for the same reason fanout does: the
+// semaphore sized by it sends before spawning its receiver.
+func (s *UserService) badgeSeedFanout() int {
+	if s.badgeFanout < 1 {
+		return defaultBadgeSeedFanout
+	}
+	return s.badgeFanout
 }
 
 // RegisterHandlers wires all UserService endpoints onto the router.


### PR DESCRIPTION
Two fixes to `badge.count.batch`, the path a notification fan-out calls to get each recipient's badge count. Both were found by a production-readiness audit of `user-service` and tagged `high`.

## 1. Join only `lastMsgAt` on the badge unread pipeline

`activeSubscriptionPipeline` reused `roomsEnrichStages()` — the list path's eleven-field rooms join — while its terminal `$project` keeps exactly one room field. Every joined room therefore materialized eleven fields (the `encKey` blob among them) and `$addFields` copied eight onto the document, for the projection to discard all but `lastMsgAt`. That ran once per account in a batch, over up to `MAX_SUBSCRIPTION_LIMIT` rows each.

The badge path now has its own join projecting only `lastMsgAt`, carrying the inline `$lookup` justification CLAUDE.md requires.

**Output is unchanged.** The terminal inclusion projection already emitted the same five fields; this only shrinks the server-side working set. The existing raw-BSON integration guard in `subscriptions_test.go` pins that output and is the check to watch in CI.

## 2. Seed cache misses concurrently

`BadgeCountBatch` computed each cache-missing account's unread set one after another. Each miss is a rooms aggregate plus that account's own cross-site `GetRoomsMeta` RPCs, so a batch's latency was the **sum** of every miss against one shared `HANDLER_TIMEOUT` — worst on a cold cache, where every account misses. With `VALKEY_ADDRS` empty (the Phase-A default installs `noopBadgeCache`), *every* batch is 100% misses, so that is the steady state rather than an edge case.

Misses are now seeded concurrently behind a semaphore, following the existing `fanOutChunks` idiom: per-index result slots so the merge needs no lock, `WaitGroup` rather than `errgroup` so one account's failure cannot cancel its siblings, and the semaphore acquired before spawning so the goroutine *count* stays bounded.

### New knob: `MAX_BADGE_SEED_FANOUT` (default 8)

Validated at startup (`>= 1`) and added to the local compose file.

The first version of this field's comment reasoned about a single in-flight request and advised keeping the bound "at or below the Mongo pool size." That was wrong and worth calling out: the bound is **per request**, nothing rate-limits `badge.count.batch`, and every one of the 256 `MAX_CONCURRENCY` handler slots may be a badge batch — so an operator following that advice would authorize 150 concurrent aggregates per request against a 150-connection pool. The comment now states the multiplier, notes that a seed holds a connection only for the aggregate (not the RPC half) and that the pool ceiling is per replica-set member and shared with every other NATS handler, and names single digits as the intended range. **The default of 8 is unchanged and the code path is unaffected** — this was a documentation defect.

An independent review confirmed the multiplier arithmetic but found the accompanying "a saturated batch returns zero counts" concern **overstated**: `BadgeCountBatch` returns a *partial* map and never writes 0, notification-worker never fails a push on a badge failure (`handler.go:349`), and `UnreadCounts` is `omitempty` with the documented degradation "clients refresh the true count on open" (`pkg/model/push.go:14-17`). A saturated batch means a push shipped without the field, not a wrong badge.

### Behaviour change worth reviewing

Cancellation narrows from *"the loop stops issuing work"* to *"no further seed starts"*. Seeds already in flight are left to finish, and how far along they are decides the outcome: one past the aggregate still answers, because a dead context only marks its cross-site half degraded; one still inside the aggregate fails on it and degrades to absence. Cache hits resolved up front by `BumpBatch` are served unconditionally, as before, and per-account failures still degrade to absence.

The two existing budget tests assert the strictly sequential guarantee, so they are pinned to `badgeFanout = 1` — where "not yet started" and "not yet reached by the loop" are the same thing — and a concurrent counterpart test was added alongside rather than weakening them.

## Follow-up noted, deliberately not in this PR

`notification-worker`'s `badgeFetchTimeout` is 5s (`badge_client.go:19`) while `user-service`'s `HANDLER_TIMEOUT` is 15s. NATS request/reply carries no cancellation, so an abandoned batch keeps its seeds and its handler slot alive for ~10s after the caller gave up — the `c.Err()` guard cannot fire until 15s. That orphan window predates this change, but this change makes it wider. Aligning the two deadlines would do more for pool pressure than any change to the fan-out.

## Testing

Written test-first; each test was watched failing for the right reason before implementing (the concurrency tests failed with `only 1 of 4 seeds were in flight at once — misses are being computed serially`).

- `go test ./user-service/... -race` — all packages pass
- `golangci-lint run ./...` — 0 issues
- `gosec` — clean
- `make generate` — no mock drift
- `go vet -tags=integration ./user-service/...` — compiles

**Not run:** the Docker-gated integration tests, including the raw-BSON guard that pins the projection change. Docker was unavailable in the authoring environment, so that guard needs to be green in CI before merge.

No client-facing surface changed — `badge.count.batch` is on the `chat.server.` lane, so `docs/client-api.md` needs no update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Badge count lookups now process cache misses concurrently, improving response times while limiting resource usage.
  * Added configuration for controlling badge lookup concurrency, defaulting to 8 simultaneous operations.
* **Bug Fixes**
  * Active subscription data now retrieves only the latest message timestamp, avoiding unnecessary room details.
  * Requests that exceed their available processing budget stop starting additional badge lookups while allowing active operations to finish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->