### PR TITLE
perf(room-worker): remove the large-room cliffs on the membership paths

### DIFF
--- a/pkg/jsretry/heartbeat.go
+++ b/pkg/jsretry/heartbeat.go
@@ -7,20 +7,16 @@ import (
 	"time"
 )
 
-// minHeartbeatInterval floors the derived interval so a short AckWait cannot
-// produce a heartbeat so frequent it becomes its own load.
+// minHeartbeatInterval stops a short AckWait making the heartbeat its own load.
 const minHeartbeatInterval = time.Second
 
 // InProgressMsg is the subset of the JetStream message API the heartbeat needs.
-// jetstream.Msg satisfies it, as do the wrappers that embed it.
 type InProgressMsg interface {
 	InProgress() error
 }
 
-// HeartbeatInterval derives a heartbeat period from a consumer's AckWait: a
-// third of the budget, so two consecutive heartbeats can be lost before the
-// server considers the message un-acked. A non-positive AckWait returns 0,
-// which disables the heartbeat.
+// HeartbeatInterval derives a heartbeat period from AckWait: a third of the
+// budget, so two ticks can be lost before the message counts as un-acked.
 func HeartbeatInterval(ackWait time.Duration) time.Duration {
 	if ackWait <= 0 {
 		return 0
@@ -28,18 +24,8 @@ func HeartbeatInterval(ackWait time.Duration) time.Duration {
 	return max(ackWait/3, minHeartbeatInterval)
 }
 
-// Heartbeat extends msg's ack deadline every interval until the returned stop
-// is called or ctx is done, and returns stop. Callers must defer stop so the
-// goroutine always terminates, including on the panic path.
-//
-// Without this, a handler that runs longer than the consumer's AckWait is
-// redelivered while it is still working, and a second worker begins executing
-// the same job concurrently — for room mutations that means duplicate key
-// rotations and duplicate fan-out. A non-positive interval disables it.
-//
-// A failing InProgress ends the loop: it means the message is no longer live
-// (already settled, or the consumer is gone), so retrying every interval would
-// only spam the log.
+// Heartbeat extends msg's ack deadline until stop (defer it) or ctx is done, so
+// a slow handler is not redelivered into a second worker running the same job.
 func Heartbeat(ctx context.Context, msg InProgressMsg, every time.Duration) (stop func()) {
 	if every <= 0 {
 		return func() {}

--- a/pkg/jsretry/heartbeat.go
+++ b/pkg/jsretry/heartbeat.go
@@ -31,12 +31,20 @@ func Heartbeat(ctx context.Context, msg InProgressMsg, every time.Duration) (sto
 		return func() {}
 	}
 	done := make(chan struct{})
+	exited := make(chan struct{})
 	var once sync.Once
-	stop = func() { once.Do(func() { close(done) }) }
+	// stop waits for the goroutine: callers settle the message immediately
+	// after, and an InProgress landing past the Ack would race it.
+	stop = func() {
+		once.Do(func() { close(done) })
+		<-exited
+	}
 
 	go func() {
+		defer close(exited)
 		ticker := time.NewTicker(every)
 		defer ticker.Stop()
+		var reported bool
 		for {
 			select {
 			case <-done:
@@ -44,9 +52,12 @@ func Heartbeat(ctx context.Context, msg InProgressMsg, every time.Duration) (sto
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if err := msg.InProgress(); err != nil {
-					slog.DebugContext(ctx, "ack heartbeat stopped; message no longer in flight", "error", err)
-					return
+				// InProgress cannot distinguish a settled message from a
+				// transport blip, so keep extending and log only the first
+				// failure rather than giving the deadline up silently.
+				if err := msg.InProgress(); err != nil && !reported {
+					reported = true
+					slog.DebugContext(ctx, "ack heartbeat failed; still retrying", "error", err)
 				}
 			}
 		}

--- a/pkg/jsretry/heartbeat.go
+++ b/pkg/jsretry/heartbeat.go
@@ -1,0 +1,69 @@
+package jsretry
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// minHeartbeatInterval floors the derived interval so a short AckWait cannot
+// produce a heartbeat so frequent it becomes its own load.
+const minHeartbeatInterval = time.Second
+
+// InProgressMsg is the subset of the JetStream message API the heartbeat needs.
+// jetstream.Msg satisfies it, as do the wrappers that embed it.
+type InProgressMsg interface {
+	InProgress() error
+}
+
+// HeartbeatInterval derives a heartbeat period from a consumer's AckWait: a
+// third of the budget, so two consecutive heartbeats can be lost before the
+// server considers the message un-acked. A non-positive AckWait returns 0,
+// which disables the heartbeat.
+func HeartbeatInterval(ackWait time.Duration) time.Duration {
+	if ackWait <= 0 {
+		return 0
+	}
+	return max(ackWait/3, minHeartbeatInterval)
+}
+
+// Heartbeat extends msg's ack deadline every interval until the returned stop
+// is called or ctx is done, and returns stop. Callers must defer stop so the
+// goroutine always terminates, including on the panic path.
+//
+// Without this, a handler that runs longer than the consumer's AckWait is
+// redelivered while it is still working, and a second worker begins executing
+// the same job concurrently — for room mutations that means duplicate key
+// rotations and duplicate fan-out. A non-positive interval disables it.
+//
+// A failing InProgress ends the loop: it means the message is no longer live
+// (already settled, or the consumer is gone), so retrying every interval would
+// only spam the log.
+func Heartbeat(ctx context.Context, msg InProgressMsg, every time.Duration) (stop func()) {
+	if every <= 0 {
+		return func() {}
+	}
+	done := make(chan struct{})
+	var once sync.Once
+	stop = func() { once.Do(func() { close(done) }) }
+
+	go func() {
+		ticker := time.NewTicker(every)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := msg.InProgress(); err != nil {
+					slog.DebugContext(ctx, "ack heartbeat stopped; message no longer in flight", "error", err)
+					return
+				}
+			}
+		}
+	}()
+	return stop
+}

--- a/pkg/jsretry/heartbeat_test.go
+++ b/pkg/jsretry/heartbeat_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -69,16 +70,6 @@ func TestHeartbeat_CancelledContextStops(t *testing.T) {
 	}, time.Second, 25*time.Millisecond)
 }
 
-// A failing InProgress means the message is gone; retrying would spam the log.
-func TestHeartbeat_StopsAfterFailure(t *testing.T) {
-	msg := &countingHeartbeatMsg{fail: errors.New("consumer deleted")}
-	stop := Heartbeat(context.Background(), msg, 2*time.Millisecond)
-	t.Cleanup(stop)
-
-	require.Eventually(t, func() bool { return msg.calls() >= 1 }, time.Second, time.Millisecond)
-	assert.Never(t, func() bool { return msg.calls() > 1 }, 50*time.Millisecond, 5*time.Millisecond)
-}
-
 func TestHeartbeat_NonPositiveIntervalIsDisabled(t *testing.T) {
 	for _, every := range []time.Duration{0, -time.Second} {
 		msg := &countingHeartbeatMsg{}
@@ -106,4 +97,49 @@ func TestHeartbeatInterval(t *testing.T) {
 			assert.Equal(t, tt.want, HeartbeatInterval(tt.ackWait))
 		})
 	}
+}
+
+type funcHeartbeatMsg struct{ fn func() error }
+
+func (m *funcHeartbeatMsg) InProgress() error { return m.fn() }
+
+// stop is what main defers before settling the message, so it must not return
+// while a heartbeat is still in flight — otherwise InProgress races the Ack.
+func TestHeartbeat_StopWaitsForInFlightHeartbeat(t *testing.T) {
+	var once sync.Once
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var returned atomic.Bool
+
+	msg := &funcHeartbeatMsg{fn: func() error {
+		once.Do(func() { close(entered) })
+		<-release
+		returned.Store(true)
+		return nil
+	}}
+	stop := Heartbeat(context.Background(), msg, time.Millisecond)
+	<-entered
+
+	stopped := make(chan struct{})
+	go func() { stop(); close(stopped) }()
+
+	select {
+	case <-stopped:
+		t.Fatal("stop returned while a heartbeat was still running")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	<-stopped
+	assert.True(t, returned.Load(), "stop must wait for the in-flight heartbeat to finish")
+}
+
+// InProgress cannot say whether a failure is terminal or a transport blip, so
+// the safe reading is transient: keep extending rather than silently stop.
+func TestHeartbeat_RetriesAfterTransientFailure(t *testing.T) {
+	msg := &countingHeartbeatMsg{fail: errors.New("connection reset")}
+	stop := Heartbeat(context.Background(), msg, 2*time.Millisecond)
+	t.Cleanup(stop)
+
+	require.Eventually(t, func() bool { return msg.calls() >= 3 }, time.Second, time.Millisecond,
+		"a failing InProgress must not end the heartbeat")
 }

--- a/pkg/jsretry/heartbeat_test.go
+++ b/pkg/jsretry/heartbeat_test.go
@@ -44,8 +44,7 @@ func TestHeartbeat_ExtendsDeadlineUntilStopped(t *testing.T) {
 		"no heartbeat may fire after stop — the message is already settled")
 }
 
-// stop is the only termination path callers have; it must be safe to call from
-// a defer that also runs on the panic path.
+// stop is the only termination path, so it must be safe on the panic path too.
 func TestHeartbeat_StopIsIdempotent(t *testing.T) {
 	msg := &countingHeartbeatMsg{}
 	stop := Heartbeat(context.Background(), msg, time.Millisecond)
@@ -62,8 +61,7 @@ func TestHeartbeat_CancelledContextStops(t *testing.T) {
 	require.Eventually(t, func() bool { return msg.calls() >= 1 }, time.Second, time.Millisecond)
 	cancel()
 
-	// Settle, then assert quiescence: a cancelled context must not leave a
-	// ticker goroutine running.
+	// A cancelled context must not leave a ticker goroutine running.
 	require.Eventually(t, func() bool {
 		n := msg.calls()
 		time.Sleep(20 * time.Millisecond)
@@ -71,8 +69,7 @@ func TestHeartbeat_CancelledContextStops(t *testing.T) {
 	}, time.Second, 25*time.Millisecond)
 }
 
-// A failing InProgress means the message is no longer live (already settled, or
-// the consumer is gone). Retrying would just spam the log every interval.
+// A failing InProgress means the message is gone; retrying would spam the log.
 func TestHeartbeat_StopsAfterFailure(t *testing.T) {
 	msg := &countingHeartbeatMsg{fail: errors.New("consumer deleted")}
 	stop := Heartbeat(context.Background(), msg, 2*time.Millisecond)

--- a/pkg/jsretry/heartbeat_test.go
+++ b/pkg/jsretry/heartbeat_test.go
@@ -1,0 +1,112 @@
+package jsretry
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type countingHeartbeatMsg struct {
+	mu   sync.Mutex
+	n    int
+	fail error
+}
+
+func (m *countingHeartbeatMsg) InProgress() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.n++
+	return m.fail
+}
+
+func (m *countingHeartbeatMsg) calls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.n
+}
+
+func TestHeartbeat_ExtendsDeadlineUntilStopped(t *testing.T) {
+	msg := &countingHeartbeatMsg{}
+	stop := Heartbeat(context.Background(), msg, 5*time.Millisecond)
+	t.Cleanup(stop)
+
+	require.Eventually(t, func() bool { return msg.calls() >= 2 }, time.Second, time.Millisecond,
+		"a handler outliving the interval must have its ack deadline extended")
+
+	stop()
+	settled := msg.calls()
+	assert.Never(t, func() bool { return msg.calls() > settled }, 50*time.Millisecond, 5*time.Millisecond,
+		"no heartbeat may fire after stop — the message is already settled")
+}
+
+// stop is the only termination path callers have; it must be safe to call from
+// a defer that also runs on the panic path.
+func TestHeartbeat_StopIsIdempotent(t *testing.T) {
+	msg := &countingHeartbeatMsg{}
+	stop := Heartbeat(context.Background(), msg, time.Millisecond)
+	stop()
+	assert.NotPanics(t, stop)
+}
+
+func TestHeartbeat_CancelledContextStops(t *testing.T) {
+	msg := &countingHeartbeatMsg{}
+	ctx, cancel := context.WithCancel(context.Background())
+	stop := Heartbeat(ctx, msg, 5*time.Millisecond)
+	t.Cleanup(stop)
+
+	require.Eventually(t, func() bool { return msg.calls() >= 1 }, time.Second, time.Millisecond)
+	cancel()
+
+	// Settle, then assert quiescence: a cancelled context must not leave a
+	// ticker goroutine running.
+	require.Eventually(t, func() bool {
+		n := msg.calls()
+		time.Sleep(20 * time.Millisecond)
+		return msg.calls() == n
+	}, time.Second, 25*time.Millisecond)
+}
+
+// A failing InProgress means the message is no longer live (already settled, or
+// the consumer is gone). Retrying would just spam the log every interval.
+func TestHeartbeat_StopsAfterFailure(t *testing.T) {
+	msg := &countingHeartbeatMsg{fail: errors.New("consumer deleted")}
+	stop := Heartbeat(context.Background(), msg, 2*time.Millisecond)
+	t.Cleanup(stop)
+
+	require.Eventually(t, func() bool { return msg.calls() >= 1 }, time.Second, time.Millisecond)
+	assert.Never(t, func() bool { return msg.calls() > 1 }, 50*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestHeartbeat_NonPositiveIntervalIsDisabled(t *testing.T) {
+	for _, every := range []time.Duration{0, -time.Second} {
+		msg := &countingHeartbeatMsg{}
+		stop := Heartbeat(context.Background(), msg, every)
+		t.Cleanup(stop)
+		assert.Never(t, func() bool { return msg.calls() > 0 }, 30*time.Millisecond, 5*time.Millisecond,
+			"interval %s must disable the heartbeat entirely", every)
+	}
+}
+
+func TestHeartbeatInterval(t *testing.T) {
+	tests := []struct {
+		name    string
+		ackWait time.Duration
+		want    time.Duration
+	}{
+		{"thirty second ack wait heartbeats at a third", 30 * time.Second, 10 * time.Second},
+		{"one minute ack wait heartbeats at a third", 60 * time.Second, 20 * time.Second},
+		{"short ack wait is floored, never zero", 100 * time.Millisecond, minHeartbeatInterval},
+		{"zero ack wait disables the heartbeat", 0, 0},
+		{"negative ack wait disables the heartbeat", -time.Second, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, HeartbeatInterval(tt.ackWait))
+		})
+	}
+}

--- a/pkg/mongoutil/bulk.go
+++ b/pkg/mongoutil/bulk.go
@@ -1,10 +1,12 @@
 package mongoutil
 
 import (
+	"context"
 	"fmt"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // BulkResult mirrors mongo.BulkWriteResult; bulk methods return (nil, nil) on empty input.
@@ -58,4 +60,75 @@ func bsonSetWithoutID(item any) (set bson.M, id any, err error) {
 	id = m["_id"]
 	delete(m, "_id")
 	return m, id, nil
+}
+
+// MaxBulkChunk is the default number of write models sent in one BulkWrite.
+// It bounds the command each round trip has to build and hold in memory, so a
+// caller that assembled tens of thousands of models does not turn them into a
+// single outsized request.
+const MaxBulkChunk = 1000
+
+// chunkWriteModels splits models into batches of at most size, preserving order.
+// A non-positive size falls back to MaxBulkChunk.
+func chunkWriteModels(models []mongo.WriteModel, size int) [][]mongo.WriteModel {
+	if size <= 0 {
+		size = MaxBulkChunk
+	}
+	if len(models) == 0 {
+		return nil
+	}
+	chunks := make([][]mongo.WriteModel, 0, (len(models)+size-1)/size)
+	for start := 0; start < len(models); start += size {
+		end := min(start+size, len(models))
+		chunks = append(chunks, models[start:end])
+	}
+	return chunks
+}
+
+// merge folds one chunk's driver result into the accumulator. base is the
+// chunk's offset within the whole input, used to rebase UpsertedIDs ordinals so
+// each chunk's index 0 does not overwrite the previous chunk's.
+func (r *BulkResult) merge(res *mongo.BulkWriteResult, base int) {
+	if res == nil {
+		return
+	}
+	r.Matched += res.MatchedCount
+	r.Modified += res.ModifiedCount
+	r.Upserted += res.UpsertedCount
+	r.Inserted += res.InsertedCount
+	r.Deleted += res.DeletedCount
+	if !res.Acknowledged {
+		r.Acknowledged = false
+	}
+	for ordinal, id := range res.UpsertedIDs {
+		if r.UpsertedIDs == nil {
+			r.UpsertedIDs = make(map[int64]any, len(res.UpsertedIDs))
+		}
+		r.UpsertedIDs[int64(base)+ordinal] = id
+	}
+}
+
+// ChunkedBulkWrite issues models as a sequence of unordered BulkWrites of at
+// most size each (MaxBulkChunk when size is non-positive), returning the merged
+// result. Empty input is a no-op returning (nil, nil).
+//
+// Chunks are not atomic with respect to one another: an error reports how far
+// the write got, so callers must be idempotent — which the upsert-shaped models
+// this package builds already are.
+func ChunkedBulkWrite(ctx context.Context, coll *mongo.Collection, models []mongo.WriteModel, size int) (*BulkResult, error) {
+	if len(models) == 0 {
+		return nil, nil
+	}
+	opts := options.BulkWrite().SetOrdered(false)
+	out := &BulkResult{Acknowledged: true}
+	base := 0
+	for _, chunk := range chunkWriteModels(models, size) {
+		res, err := coll.BulkWrite(ctx, chunk, opts)
+		if err != nil {
+			return out, fmt.Errorf("bulk write models %d-%d of %d: %w", base, base+len(chunk), len(models), err)
+		}
+		out.merge(res, base)
+		base += len(chunk)
+	}
+	return out, nil
 }

--- a/pkg/mongoutil/bulk.go
+++ b/pkg/mongoutil/bulk.go
@@ -2,6 +2,7 @@ package mongoutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -74,7 +75,7 @@ func chunkWriteModels(models []mongo.WriteModel, size int) [][]mongo.WriteModel 
 	if len(models) == 0 {
 		return nil
 	}
-	chunks := make([][]mongo.WriteModel, 0, (len(models)+size-1)/size)
+	chunks := make([][]mongo.WriteModel, 0, 1+(len(models)-1)/size)
 	for start := 0; start < len(models); start += size {
 		end := min(start+size, len(models))
 		chunks = append(chunks, models[start:end])
@@ -104,22 +105,43 @@ func (r *BulkResult) merge(res *mongo.BulkWriteResult, base int) {
 	}
 }
 
+// terminalBulkError reports whether a chunk failure should stop the remaining
+// chunks. Per-model write errors must not: an unordered BulkWrite would have
+// carried on past them, and chunking may not turn one bad model into a barrier.
+func terminalBulkError(ctx context.Context, err error) bool {
+	if ctx.Err() != nil {
+		return true
+	}
+	var bwe mongo.BulkWriteException
+	if !errors.As(err, &bwe) {
+		return true
+	}
+	return bwe.WriteConcernError != nil || len(bwe.WriteErrors) == 0
+}
+
 // ChunkedBulkWrite issues models as unordered BulkWrites of at most size each,
-// merged into one result. Chunks are not atomic, so callers must be idempotent.
+// merging every chunk's result even on error. Callers must be idempotent.
 func ChunkedBulkWrite(ctx context.Context, coll *mongo.Collection, models []mongo.WriteModel, size int) (*BulkResult, error) {
 	if len(models) == 0 {
 		return nil, nil
 	}
 	opts := options.BulkWrite().SetOrdered(false)
 	out := &BulkResult{Acknowledged: true}
+	var writeErrs error
 	base := 0
 	for _, chunk := range chunkWriteModels(models, size) {
 		res, err := coll.BulkWrite(ctx, chunk, opts)
-		if err != nil {
-			return out, fmt.Errorf("bulk write models %d-%d of %d: %w", base, base+len(chunk), len(models), err)
-		}
+		// Merge first: a failed unordered chunk still returns the models it did
+		// write, and dropping them would understate what actually landed.
 		out.merge(res, base)
+		if err != nil {
+			err = fmt.Errorf("bulk write models %d-%d of %d: %w", base, base+len(chunk), len(models), err)
+			if terminalBulkError(ctx, err) {
+				return out, err
+			}
+			writeErrs = errors.Join(writeErrs, err)
+		}
 		base += len(chunk)
 	}
-	return out, nil
+	return out, writeErrs
 }

--- a/pkg/mongoutil/bulk.go
+++ b/pkg/mongoutil/bulk.go
@@ -62,14 +62,11 @@ func bsonSetWithoutID(item any) (set bson.M, id any, err error) {
 	return m, id, nil
 }
 
-// MaxBulkChunk is the default number of write models sent in one BulkWrite.
-// It bounds the command each round trip has to build and hold in memory, so a
-// caller that assembled tens of thousands of models does not turn them into a
-// single outsized request.
+// MaxBulkChunk is the default number of write models sent in one BulkWrite,
+// bounding what a caller with tens of thousands of models builds in memory.
 const MaxBulkChunk = 1000
 
-// chunkWriteModels splits models into batches of at most size, preserving order.
-// A non-positive size falls back to MaxBulkChunk.
+// chunkWriteModels splits models into ordered batches of size (MaxBulkChunk if <=0).
 func chunkWriteModels(models []mongo.WriteModel, size int) [][]mongo.WriteModel {
 	if size <= 0 {
 		size = MaxBulkChunk
@@ -85,9 +82,8 @@ func chunkWriteModels(models []mongo.WriteModel, size int) [][]mongo.WriteModel 
 	return chunks
 }
 
-// merge folds one chunk's driver result into the accumulator. base is the
-// chunk's offset within the whole input, used to rebase UpsertedIDs ordinals so
-// each chunk's index 0 does not overwrite the previous chunk's.
+// merge folds a chunk's result into the accumulator, rebasing UpsertedIDs
+// ordinals by base so each chunk's index 0 does not overwrite the last.
 func (r *BulkResult) merge(res *mongo.BulkWriteResult, base int) {
 	if res == nil {
 		return
@@ -108,13 +104,8 @@ func (r *BulkResult) merge(res *mongo.BulkWriteResult, base int) {
 	}
 }
 
-// ChunkedBulkWrite issues models as a sequence of unordered BulkWrites of at
-// most size each (MaxBulkChunk when size is non-positive), returning the merged
-// result. Empty input is a no-op returning (nil, nil).
-//
-// Chunks are not atomic with respect to one another: an error reports how far
-// the write got, so callers must be idempotent — which the upsert-shaped models
-// this package builds already are.
+// ChunkedBulkWrite issues models as unordered BulkWrites of at most size each,
+// merged into one result. Chunks are not atomic, so callers must be idempotent.
 func ChunkedBulkWrite(ctx context.Context, coll *mongo.Collection, models []mongo.WriteModel, size int) (*BulkResult, error) {
 	if len(models) == 0 {
 		return nil, nil

--- a/pkg/mongoutil/bulk_test.go
+++ b/pkg/mongoutil/bulk_test.go
@@ -174,8 +174,7 @@ func TestBulkResult_Merge(t *testing.T) {
 	assert.Equal(t, int64(33), acc.Upserted)
 	assert.Equal(t, int64(44), acc.Inserted)
 	assert.Equal(t, int64(55), acc.Deleted)
-	// Ordinals are rebased onto the whole input so the second chunk's index 0
-	// does not overwrite the first chunk's.
+	// Rebased onto the whole input, so chunk two's index 0 does not overwrite.
 	assert.Equal(t, map[int64]any{0: "a", 1000: "b"}, acc.UpsertedIDs)
 }
 

--- a/pkg/mongoutil/bulk_test.go
+++ b/pkg/mongoutil/bulk_test.go
@@ -1,6 +1,10 @@
 package mongoutil
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -184,4 +188,55 @@ func TestBulkResult_MergeUnacknowledged(t *testing.T) {
 	acc.merge(&mongo.BulkWriteResult{Acknowledged: true}, 0)
 	acc.merge(&mongo.BulkWriteResult{Acknowledged: false}, 10)
 	assert.False(t, acc.Acknowledged)
+}
+
+// A size larger than the input must yield one chunk, not overflow the capacity
+// computation into a negative make().
+func TestChunkWriteModels_HugeSizeDoesNotOverflow(t *testing.T) {
+	// Two or more models are needed: len+size-1 is what wraps past MaxInt.
+	models := []mongo.WriteModel{
+		UpsertModel(bson.M{"_id": 1}, bson.M{"$set": bson.M{"n": 1}}),
+		UpsertModel(bson.M{"_id": 2}, bson.M{"$set": bson.M{"n": 2}}),
+	}
+
+	assert.NotPanics(t, func() {
+		chunks := chunkWriteModels(models, math.MaxInt)
+		require.Len(t, chunks, 1)
+		assert.Len(t, chunks[0], 2)
+	})
+}
+
+// Unordered BulkWrite keeps going past per-model write errors, so chunking must
+// not turn one bad model into a barrier for every later chunk.
+func TestTerminalBulkError(t *testing.T) {
+	writeErr := mongo.BulkWriteException{WriteErrors: []mongo.BulkWriteError{{}}}
+	wcErr := mongo.BulkWriteException{
+		WriteErrors:       []mongo.BulkWriteError{{}},
+		WriteConcernError: &mongo.WriteConcernError{Name: "wc"},
+	}
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{"per-model write errors keep unordered semantics", context.Background(), writeErr, false},
+		{"wrapped per-model write errors are still per-model", context.Background(), fmt.Errorf("chunk: %w", writeErr), false},
+		{"a write-concern failure is terminal", context.Background(), wcErr, true},
+		{"an exception carrying no write errors is terminal", context.Background(), mongo.BulkWriteException{}, true},
+		{"a transport error is terminal", context.Background(), errors.New("connection reset"), true},
+		{"a cancelled context is terminal whatever the error", canceledCtx(), writeErr, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, terminalBulkError(tt.ctx, tt.err))
+		})
+	}
+}
+
+func canceledCtx() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
 }

--- a/pkg/mongoutil/bulk_test.go
+++ b/pkg/mongoutil/bulk_test.go
@@ -101,3 +101,88 @@ func TestBsonSetWithoutID_MarshalError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "bson marshal")
 }
+
+func TestChunkWriteModels(t *testing.T) {
+	model := func(i int) mongo.WriteModel {
+		return UpsertModel(bson.M{"_id": i}, bson.M{"$set": bson.M{"n": i}})
+	}
+	models := func(n int) []mongo.WriteModel {
+		out := make([]mongo.WriteModel, 0, n)
+		for i := range n {
+			out = append(out, model(i))
+		}
+		return out
+	}
+
+	tests := []struct {
+		name       string
+		models     []mongo.WriteModel
+		size       int
+		wantChunks []int // length of each chunk
+	}{
+		{"empty input yields no chunks", nil, 10, nil},
+		{"fewer than one chunk", models(3), 10, []int{3}},
+		{"exact multiple", models(20), 10, []int{10, 10}},
+		{"trailing partial chunk", models(25), 10, []int{10, 10, 5}},
+		{"single element chunks", models(3), 1, []int{1, 1, 1}},
+		{"zero size falls back to the default", models(2), 0, []int{2}},
+		{"negative size falls back to the default", models(2), -5, []int{2}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := chunkWriteModels(tt.models, tt.size)
+			require.Len(t, got, len(tt.wantChunks))
+
+			var seen int
+			for i, chunk := range got {
+				assert.Len(t, chunk, tt.wantChunks[i])
+				seen += len(chunk)
+			}
+			assert.Equal(t, len(tt.models), seen, "chunking must not drop or duplicate models")
+		})
+	}
+}
+
+// A chunk never exceeds the cap, whatever the input size.
+func TestChunkWriteModels_RespectsCap(t *testing.T) {
+	models := make([]mongo.WriteModel, 0, MaxBulkChunk*2+7)
+	for i := range MaxBulkChunk*2 + 7 {
+		models = append(models, UpsertModel(bson.M{"_id": i}, bson.M{"$set": bson.M{"n": i}}))
+	}
+	chunks := chunkWriteModels(models, MaxBulkChunk)
+
+	require.Len(t, chunks, 3)
+	for _, c := range chunks {
+		assert.LessOrEqual(t, len(c), MaxBulkChunk)
+	}
+	assert.Len(t, chunks[2], 7)
+}
+
+func TestBulkResult_Merge(t *testing.T) {
+	acc := &BulkResult{Acknowledged: true}
+	acc.merge(&mongo.BulkWriteResult{
+		MatchedCount: 1, ModifiedCount: 2, UpsertedCount: 3, InsertedCount: 4, DeletedCount: 5,
+		UpsertedIDs: map[int64]any{0: "a"}, Acknowledged: true,
+	}, 0)
+	acc.merge(&mongo.BulkWriteResult{
+		MatchedCount: 10, ModifiedCount: 20, UpsertedCount: 30, InsertedCount: 40, DeletedCount: 50,
+		UpsertedIDs: map[int64]any{0: "b"}, Acknowledged: true,
+	}, 1000)
+
+	assert.Equal(t, int64(11), acc.Matched)
+	assert.Equal(t, int64(22), acc.Modified)
+	assert.Equal(t, int64(33), acc.Upserted)
+	assert.Equal(t, int64(44), acc.Inserted)
+	assert.Equal(t, int64(55), acc.Deleted)
+	// Ordinals are rebased onto the whole input so the second chunk's index 0
+	// does not overwrite the first chunk's.
+	assert.Equal(t, map[int64]any{0: "a", 1000: "b"}, acc.UpsertedIDs)
+}
+
+// One unacknowledged chunk makes the whole result unacknowledged.
+func TestBulkResult_MergeUnacknowledged(t *testing.T) {
+	acc := &BulkResult{Acknowledged: true}
+	acc.merge(&mongo.BulkWriteResult{Acknowledged: true}, 0)
+	acc.merge(&mongo.BulkWriteResult{Acknowledged: false}, 10)
+	assert.False(t, acc.Acknowledged)
+}

--- a/room-worker/consumer_config_test.go
+++ b/room-worker/consumer_config_test.go
@@ -82,10 +82,8 @@ func TestConsumedSubjectsClassifyToBoundedEventTypes(t *testing.T) {
 	}
 }
 
-// The consumer loop derives its ack heartbeat from the consumer's own AckWait,
-// so the two can never disagree. Two heartbeats must fit inside the budget:
-// that is the headroom which lets a lost tick pass without the server deciding
-// the message went un-acked and redelivering it into a second worker.
+// The heartbeat derives from the consumer's own AckWait, so the two cannot
+// disagree; two ticks must fit inside the budget to survive a lost one.
 func TestHeartbeatIntervalLeavesHeadroomUnderAckWait(t *testing.T) {
 	for _, ackWait := range []time.Duration{30 * time.Second, time.Minute, 5 * time.Minute} {
 		cc := buildConsumerConfig(stream.ConsumerSettings{
@@ -98,8 +96,7 @@ func TestHeartbeatIntervalLeavesHeadroomUnderAckWait(t *testing.T) {
 	}
 }
 
-// An unset AckWait means the server picks the deadline, so there is no local
-// budget to pace against: disable the heartbeat rather than invent an interval.
+// No local budget to pace against, so disable rather than invent an interval.
 func TestHeartbeatDisabledWhenAckWaitUnset(t *testing.T) {
 	cc := buildConsumerConfig(stream.ConsumerSettings{MaxDeliver: 5}, "default")
 	assert.Zero(t, jsretry.HeartbeatInterval(cc.AckWait))

--- a/room-worker/consumer_config_test.go
+++ b/room-worker/consumer_config_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/hmchangw/chat/pkg/jsretry"
 	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/stream"
 	"github.com/hmchangw/chat/pkg/subject"
@@ -79,4 +80,27 @@ func TestConsumedSubjectsClassifyToBoundedEventTypes(t *testing.T) {
 			assert.NotEqual(t, natsmetrics.EventUnknown, got, "a dispatched subject must not fall back to unknown")
 		})
 	}
+}
+
+// The consumer loop derives its ack heartbeat from the consumer's own AckWait,
+// so the two can never disagree. Two heartbeats must fit inside the budget:
+// that is the headroom which lets a lost tick pass without the server deciding
+// the message went un-acked and redelivering it into a second worker.
+func TestHeartbeatIntervalLeavesHeadroomUnderAckWait(t *testing.T) {
+	for _, ackWait := range []time.Duration{30 * time.Second, time.Minute, 5 * time.Minute} {
+		cc := buildConsumerConfig(stream.ConsumerSettings{
+			AckWait: ackWait, MaxDeliver: 5, MaxWaiting: 512, MaxAckPending: 1000,
+		}, "default")
+
+		every := jsretry.HeartbeatInterval(cc.AckWait)
+		assert.Positive(t, every, "AckWait %s must produce a live heartbeat", ackWait)
+		assert.Less(t, 2*every, cc.AckWait, "two heartbeats must fit inside AckWait %s", ackWait)
+	}
+}
+
+// An unset AckWait means the server picks the deadline, so there is no local
+// budget to pace against: disable the heartbeat rather than invent an interval.
+func TestHeartbeatDisabledWhenAckWaitUnset(t *testing.T) {
+	cc := buildConsumerConfig(stream.ConsumerSettings{MaxDeliver: 5}, "default")
+	assert.Zero(t, jsretry.HeartbeatInterval(cc.AckWait))
 }

--- a/room-worker/debug_log_test.go
+++ b/room-worker/debug_log_test.go
@@ -134,7 +134,7 @@ func TestProcessRemoveMember_DebugEdge(t *testing.T) {
 		store.EXPECT().GetUserWithMembership(gomock.Any(), roomID, account).Return(userResult, nil).AnyTimes()
 		store.EXPECT().DeleteSubscription(gomock.Any(), roomID, account).Return(int64(1), nil).AnyTimes()
 		store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u1").Return(nil).AnyTimes()
-		store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil).AnyTimes()
+		store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
 		store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil).AnyTimes()
 		expectThreadCleanupAny(store)
 		h := NewHandler(store, siteID, func(context.Context, string, []byte, string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -2378,14 +2378,11 @@ func (h *Handler) processRoomRename(ctx context.Context, data []byte) (err error
 	// Single room-scoped event (the room_renamed sys message published above)
 	// is sufficient — clients update their subscription state from the room
 	// event without per-subscription fan-out.
-	subs, err := h.store.ListByRoom(ctx, req.RoomID)
+	// Projected: the fan-out below only needs accounts, so a full-document read
+	// of every subscription in the room is pure waste on large channels.
+	accounts, err := h.store.GetSubscriptionAccounts(ctx, req.RoomID)
 	if err != nil {
-		return fmt.Errorf("list subscriptions: %w", err)
-	}
-
-	accounts := make([]string, 0, len(subs))
-	for i := range subs {
-		accounts = append(accounts, subs[i].User.Account)
+		return fmt.Errorf("list subscription accounts: %w", err)
 	}
 	remoteSites, err := h.findRemoteSitesForAccounts(ctx, accounts)
 	if err != nil {

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -427,9 +427,10 @@ func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.Remove
 		return nil
 	}
 
-	// Individual-only: delete sub, reconcile userCount, publish leave/removed events.
-	if _, err := h.store.DeleteSubscription(ctx, req.RoomID, req.Account); err != nil {
-		return fmt.Errorf("delete subscription: %w", err)
+	// Individual-only: delete sub, adjust userCount, publish leave/removed events.
+	deleted, delErr := h.store.DeleteSubscription(ctx, req.RoomID, req.Account)
+	if delErr != nil {
+		return fmt.Errorf("delete subscription: %w", delErr)
 	}
 	// Bust AFTER the write: a removed member's cached positive decision must
 	// die immediately, not linger for the L2 TTL (the security case this
@@ -442,12 +443,21 @@ func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.Remove
 		return err
 	}
 
-	if err := h.store.ReconcileMemberCounts(ctx, req.RoomID); err != nil {
-		return fmt.Errorf("reconcile member counts: %w", err)
+	// deleted==0 means a redelivery found the subscription already gone: the
+	// counter was decremented on the first delivery, so decrementing again
+	// would drift it.
+	if deleted > 0 {
+		userDelta, appDelta := -1, 0
+		if subIsBot(req.Account) {
+			userDelta, appDelta = 0, -1
+		}
+		if err := h.applyMemberRemovalCounts(ctx, req.RoomID, userDelta, appDelta); err != nil {
+			return err
+		}
 	}
 	h.bustRoomMeta(ctx, req.RoomID)
 
-	// Rotate after delete + reconcile; survivors are the post-deletion accounts.
+	// Rotate after delete + count adjustment; survivors are the post-deletion accounts.
 	// Bots hold keys too, so a bot removal rotates like any other member.
 	survivorAccounts, listErr := h.store.GetSubscriptionAccounts(ctx, req.RoomID)
 	if listErr != nil {
@@ -637,10 +647,13 @@ func (h *Handler) processRemoveOrg(ctx context.Context, req *model.RemoveMemberR
 		accounts[i] = m.Account
 	}
 
+	var deletedSubs int64
 	if len(accounts) > 0 {
-		if _, err := h.store.DeleteSubscriptionsByAccounts(ctx, req.RoomID, accounts); err != nil {
-			return fmt.Errorf("delete subscriptions by accounts: %w", err)
+		n, delErr := h.store.DeleteSubscriptionsByAccounts(ctx, req.RoomID, accounts)
+		if delErr != nil {
+			return fmt.Errorf("delete subscriptions by accounts: %w", delErr)
 		}
+		deletedSubs = n
 		// Bust AFTER the write, in one batched round trip: each removed
 		// account's cached positive decision must die immediately, not linger
 		// for the L2 TTL.
@@ -656,8 +669,31 @@ func (h *Handler) processRemoveOrg(ctx context.Context, req *model.RemoveMemberR
 		return fmt.Errorf("delete room member (org): %w", err)
 	}
 
-	if err := h.store.ReconcileMemberCounts(ctx, req.RoomID); err != nil {
-		return fmt.Errorf("reconcile member counts: %w", err)
+	// Counters follow what the delete actually removed, never a full recompute
+	// per removal — dropping a 5k-person department otherwise costs two whole-room
+	// CountDocuments on top of the delete itself.
+	switch {
+	case len(accounts) == 0:
+		// Every org member survives via another source: nothing left the room.
+	case int(deletedSubs) == len(accounts):
+		var removedUsers, removedApps int
+		for _, acc := range accounts {
+			if subIsBot(acc) {
+				removedApps++
+			} else {
+				removedUsers++
+			}
+		}
+		if err := h.applyMemberRemovalCounts(ctx, req.RoomID, -removedUsers, -removedApps); err != nil {
+			return err
+		}
+	default:
+		// Fewer documents deleted than accounts targeted (a concurrent removal,
+		// or a partially-applied redelivery): the target set no longer describes
+		// what left, so fall back to the authoritative recompute.
+		if err := h.store.ReconcileMemberCounts(ctx, req.RoomID); err != nil {
+			return fmt.Errorf("reconcile member counts: %w", err)
+		}
 	}
 	h.bustRoomMeta(ctx, req.RoomID)
 
@@ -1519,13 +1555,41 @@ func subscriptionRoomFor(room *model.Room, pair *roomkeystore.VersionedKeyPair) 
 	return sr
 }
 
+// subIsBot is the single definition of the u.isBot flag stamped at subscription
+// creation. The remove paths derive their count deltas from it, so the counter
+// they decrement is the one the add path incremented.
+func subIsBot(account string) bool {
+	return model.IsBot(account) || model.IsPlatformAdminAccount(account)
+}
+
+// applyMemberRemovalCounts $inc's the room's counters by an exact delta, running
+// the full recompute only when the TTL clock says a drift check is due.
+// ReconcileMemberCounts is two CountDocuments over the entire room, so it must
+// never be the per-removal default: on a 50k-member room that is two full index
+// scans to record the departure of one member.
+func (h *Handler) applyMemberRemovalCounts(ctx context.Context, roomID string, userDelta, appDelta int) error {
+	if userDelta == 0 && appDelta == 0 {
+		return nil
+	}
+	reconcileDue, err := h.store.ApplyMemberCountDelta(ctx, roomID, userDelta, appDelta, h.reconcileTTL)
+	if err != nil {
+		return fmt.Errorf("apply member count delta: %w", err)
+	}
+	if reconcileDue {
+		if err := h.store.ReconcileMemberCounts(ctx, roomID); err != nil {
+			return fmt.Errorf("reconcile member counts: %w", err)
+		}
+	}
+	return nil
+}
+
 // newSub constructs a Subscription carrying the room's own type. A DM pair
 // overrides RoomType per row — see buildDMPairSubs.
 func newSub(id string, user *model.User, room *model.Room, roles []model.Role,
 	name string, isSubscribed bool, joinedAt time.Time) *model.Subscription {
 	return &model.Subscription{
 		ID:           id,
-		User:         model.SubscriptionUser{ID: user.ID, Account: user.Account, IsBot: model.IsBot(user.Account) || model.IsPlatformAdminAccount(user.Account)},
+		User:         model.SubscriptionUser{ID: user.ID, Account: user.Account, IsBot: subIsBot(user.Account)},
 		RoomID:       room.ID,
 		SiteID:       room.SiteID,
 		Roles:        roles,

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -427,7 +427,6 @@ func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.Remove
 		return nil
 	}
 
-	// Individual-only: delete sub, adjust userCount, publish leave/removed events.
 	deleted, delErr := h.store.DeleteSubscription(ctx, req.RoomID, req.Account)
 	if delErr != nil {
 		return fmt.Errorf("delete subscription: %w", delErr)
@@ -443,9 +442,7 @@ func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.Remove
 		return err
 	}
 
-	// deleted==0 means a redelivery found the subscription already gone: the
-	// counter was decremented on the first delivery, so decrementing again
-	// would drift it.
+	// deleted==0 is a redelivery: the first delivery already decremented.
 	if deleted > 0 {
 		userDelta, appDelta := -1, 0
 		if subIsBot(req.Account) {
@@ -457,7 +454,7 @@ func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.Remove
 	}
 	h.bustRoomMeta(ctx, req.RoomID)
 
-	// Rotate after delete + count adjustment; survivors are the post-deletion accounts.
+	// Survivors are the post-deletion accounts.
 	// Bots hold keys too, so a bot removal rotates like any other member.
 	survivorAccounts, listErr := h.store.GetSubscriptionAccounts(ctx, req.RoomID)
 	if listErr != nil {
@@ -669,9 +666,7 @@ func (h *Handler) processRemoveOrg(ctx context.Context, req *model.RemoveMemberR
 		return fmt.Errorf("delete room member (org): %w", err)
 	}
 
-	// Counters follow what the delete actually removed, never a full recompute
-	// per removal — dropping a 5k-person department otherwise costs two whole-room
-	// CountDocuments on top of the delete itself.
+	// Keyed on what the delete actually removed, so a redelivery is a no-op.
 	switch {
 	case len(accounts) == 0:
 		// Every org member survives via another source: nothing left the room.
@@ -688,9 +683,7 @@ func (h *Handler) processRemoveOrg(ctx context.Context, req *model.RemoveMemberR
 			return err
 		}
 	default:
-		// Fewer documents deleted than accounts targeted (a concurrent removal,
-		// or a partially-applied redelivery): the target set no longer describes
-		// what left, so fall back to the authoritative recompute.
+		// Fewer deleted than targeted, so recompute rather than trust that set.
 		if err := h.store.ReconcileMemberCounts(ctx, req.RoomID); err != nil {
 			return fmt.Errorf("reconcile member counts: %w", err)
 		}
@@ -1555,18 +1548,14 @@ func subscriptionRoomFor(room *model.Room, pair *roomkeystore.VersionedKeyPair) 
 	return sr
 }
 
-// subIsBot is the single definition of the u.isBot flag stamped at subscription
-// creation. The remove paths derive their count deltas from it, so the counter
-// they decrement is the one the add path incremented.
+// subIsBot is the one definition of the u.isBot flag stamped at sub creation, so
+// removals decrement the counter the add path incremented.
 func subIsBot(account string) bool {
 	return model.IsBot(account) || model.IsPlatformAdminAccount(account)
 }
 
-// applyMemberRemovalCounts $inc's the room's counters by an exact delta, running
-// the full recompute only when the TTL clock says a drift check is due.
-// ReconcileMemberCounts is two CountDocuments over the entire room, so it must
-// never be the per-removal default: on a 50k-member room that is two full index
-// scans to record the departure of one member.
+// applyMemberRemovalCounts $inc's an exact delta, recomputing only when the TTL
+// says drift is due: ReconcileMemberCounts scans the whole room twice.
 func (h *Handler) applyMemberRemovalCounts(ctx context.Context, roomID string, userDelta, appDelta int) error {
 	if userDelta == 0 && appDelta == 0 {
 		return nil
@@ -2442,8 +2431,6 @@ func (h *Handler) processRoomRename(ctx context.Context, data []byte) (err error
 	// Single room-scoped event (the room_renamed sys message published above)
 	// is sufficient — clients update their subscription state from the room
 	// event without per-subscription fan-out.
-	// Projected: the fan-out below only needs accounts, so a full-document read
-	// of every subscription in the room is pure waste on large channels.
 	accounts, err := h.store.GetSubscriptionAccounts(ctx, req.RoomID)
 	if err != nil {
 		return fmt.Errorf("list subscription accounts: %w", err)

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -442,7 +442,6 @@ func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.Remove
 		return err
 	}
 
-	// deleted==0 is a redelivery: the first delivery already decremented.
 	if deleted > 0 {
 		userDelta, appDelta := -1, 0
 		if subIsBot(req.Account) {
@@ -451,6 +450,10 @@ func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.Remove
 		if err := h.applyMemberRemovalCounts(ctx, req.RoomID, userDelta, appDelta); err != nil {
 			return err
 		}
+	} else if err := h.store.ReconcileMemberCounts(ctx, req.RoomID); err != nil {
+		// A zero delete cannot tell a completed prior delivery from one that
+		// failed before counting, so recompute instead of assuming.
+		return fmt.Errorf("reconcile member counts: %w", err)
 	}
 	h.bustRoomMeta(ctx, req.RoomID)
 
@@ -1557,9 +1560,6 @@ func subIsBot(account string) bool {
 // applyMemberRemovalCounts $inc's an exact delta, recomputing only when the TTL
 // says drift is due: ReconcileMemberCounts scans the whole room twice.
 func (h *Handler) applyMemberRemovalCounts(ctx context.Context, roomID string, userDelta, appDelta int) error {
-	if userDelta == 0 && appDelta == 0 {
-		return nil
-	}
 	reconcileDue, err := h.store.ApplyMemberCountDelta(ctx, roomID, userDelta, appDelta, h.reconcileTTL)
 	if err != nil {
 		return fmt.Errorf("apply member count delta: %w", err)

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -8236,14 +8236,28 @@ func TestHandler_ProcessRemoveIndividual_ReconcilesWhenDeltaReportsDue(t *testin
 	require.NoError(t, runRemoveIndividual(t, store, roomID, account, siteID))
 }
 
-// A redelivery finds the sub already gone; a second decrement would drift it.
-func TestHandler_ProcessRemoveIndividual_RedeliveryAppliesNoDelta(t *testing.T) {
+// A zero delete cannot distinguish a completed prior delivery from one that
+// failed before adjusting the counters, so it must recompute authoritatively
+// rather than assume the first delivery already decremented.
+func TestHandler_ProcessRemoveIndividual_ZeroDeleteReconcilesAuthoritatively(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	const roomID, account, siteID = "room-1", "alice", "site-a"
 	store := removeIndividualStore(t, ctrl, roomID, account, siteID, 0)
-	// No count expectations at all: either call fails as unexpected.
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	// No ApplyMemberCountDelta: a second decrement would drift the counter.
 
 	require.NoError(t, runRemoveIndividual(t, store, roomID, account, siteID))
+}
+
+func TestHandler_ProcessRemoveIndividual_ZeroDeleteReconcileErrorPropagates(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	const roomID, account, siteID = "room-1", "alice", "site-a"
+	store := removeIndividualStore(t, ctrl, roomID, account, siteID, 0)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(fmt.Errorf("write failed"))
+
+	err := runRemoveIndividual(t, store, roomID, account, siteID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reconcile member counts")
 }
 
 func TestHandler_ProcessRemoveOrg_AppliesCountDeltaForDeletedAccounts(t *testing.T) {

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -102,7 +102,7 @@ func TestHandler_ProcessRemoveMember_SelfLeave_IndividualOnly(t *testing.T) {
 		DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u1").
 		Return(nil)
 	store.EXPECT().
-		ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+		ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().
 		GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 
@@ -175,7 +175,7 @@ func TestHandler_ProcessRemoveMember_BotTarget_RotatesAndSubUpdate(t *testing.T)
 	}, nil)
 	store.EXPECT().DeleteSubscription(gomock.Any(), roomID, botAcct).Return(int64(1), nil)
 	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u_bot").Return(nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	// The departed bot must be scrubbed from thread followers + subs (#308).
 	store.EXPECT().PullThreadFollowers(gomock.Any(), roomID, []string{botAcct}).Return(nil)
 	store.EXPECT().DeleteThreadSubscriptions(gomock.Any(), roomID, []string{botAcct}).Return(nil)
@@ -279,7 +279,7 @@ func TestHandler_ProcessRemoveIndividual_CleansThreadState(t *testing.T) {
 	// The departed member must be scrubbed from thread followers + subs (#308).
 	store.EXPECT().PullThreadFollowers(gomock.Any(), roomID, []string{account}).Return(nil)
 	store.EXPECT().DeleteThreadSubscriptions(gomock.Any(), roomID, []string{account}).Return(nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 
 	h := NewHandler(store, siteID, func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
@@ -311,7 +311,7 @@ func TestHandler_ProcessRemoveOrg_CleansThreadStateForRemovedOnly(t *testing.T) 
 	store.EXPECT().PullThreadFollowers(gomock.Any(), roomID, gomock.InAnyOrder([]string{"carol", "dave"})).Return(nil)
 	store.EXPECT().DeleteThreadSubscriptions(gomock.Any(), roomID, gomock.InAnyOrder([]string{"carol", "dave"})).Return(nil)
 	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberOrg, orgID).Return(nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 	store.EXPECT().GetUser(gomock.Any(), requester).Return(&model.User{ID: "u_alice", Account: requester, SiteID: siteID, EngName: "Alice", ChineseName: "愛"}, nil)
 
@@ -411,7 +411,7 @@ func TestHandler_ProcessRemoveMember_OwnerRemovesIndividual(t *testing.T) {
 		DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u2").
 		Return(nil)
 	store.EXPECT().
-		ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+		ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().
 		GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 	store.EXPECT().
@@ -1713,7 +1713,7 @@ func TestHandler_ProcessRemoveMember_OwnerRemovesOrg(t *testing.T) {
 		DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberOrg, orgID).
 		Return(nil)
 	store.EXPECT().
-		ReconcileMemberCounts(gomock.Any(), roomID).Return(nil) // recount after removal
+		ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil) // recount after removal
 	store.EXPECT().
 		GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 	store.EXPECT().
@@ -1788,7 +1788,7 @@ func TestHandler_ProcessRemoveMember_CrossSiteInbox(t *testing.T) {
 		DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u1").
 		Return(nil)
 	store.EXPECT().
-		ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+		ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().
 		GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 
@@ -1914,7 +1914,7 @@ func TestHandler_ProcessRemoveIndividual_DeleteSubscriptionError(t *testing.T) {
 	assert.Contains(t, err.Error(), "delete subscription")
 }
 
-func TestHandler_ProcessRemoveIndividual_ReconcileMemberCountsError(t *testing.T) {
+func TestHandler_ProcessRemoveIndividual_CountDeltaError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
 	expectThreadCleanupAny(store)
@@ -1931,14 +1931,28 @@ func TestHandler_ProcessRemoveIndividual_ReconcileMemberCountsError(t *testing.T
 		DeleteSubscription(gomock.Any(), "r1", "alice").
 		Return(int64(1), nil)
 	store.EXPECT().
-		ReconcileMemberCounts(gomock.Any(), "r1").
-		Return(fmt.Errorf("write failed"))
+		ApplyMemberCountDelta(gomock.Any(), "r1", -1, 0, gomock.Any()).
+		Return(false, fmt.Errorf("write failed"))
 
 	h := NewHandler(store, "site-a", func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
 	req := model.RemoveMemberRequest{RoomID: "r1", Requester: "alice", Account: "alice", Timestamp: 1000, RoomType: model.RoomTypeChannel}
 	data, _ := json.Marshal(req)
 
 	err := h.processRemoveMember(context.Background(), data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "apply member count delta")
+}
+
+// When the TTL says a drift check is due, the full recompute still runs on the
+// remove path and its failure must still propagate.
+func TestHandler_ProcessRemoveIndividual_ReconcileOnDueError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	const roomID, account, siteID = "r1", "alice", "site-a"
+	store := removeIndividualStore(t, ctrl, roomID, account, siteID, 1)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, -1, 0, gomock.Any()).Return(true, nil)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(fmt.Errorf("write failed"))
+
+	err := runRemoveIndividual(t, store, roomID, account, siteID)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "reconcile member counts")
 }
@@ -2131,7 +2145,7 @@ func TestHandler_ProcessRemoveIndividual_InboxFailurePropagates(t *testing.T) {
 		DeleteSubscription(gomock.Any(), roomID, account).
 		Return(int64(1), nil)
 	store.EXPECT().
-		ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+		ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().
 		GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 
@@ -2172,7 +2186,7 @@ func TestHandler_ProcessRemoveOrg_InboxFailurePropagates(t *testing.T) {
 	store.EXPECT().GetOrgMembersWithIndividualStatus(gomock.Any(), roomID, orgID).Return(orgMembers, nil)
 	store.EXPECT().DeleteSubscriptionsByAccounts(gomock.Any(), roomID, []string{"carol"}).Return(int64(1), nil)
 	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberOrg, orgID).Return(nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 	store.EXPECT().GetUser(gomock.Any(), requester).
 		Return(&model.User{ID: "u_alice", Account: requester, SiteID: localSite, EngName: "Alice", ChineseName: "愛"}, nil)
@@ -6066,7 +6080,7 @@ func TestHandler_ProcessRemoveIndividual_SelfLeave_Content(t *testing.T) {
 		}, nil)
 	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u_b").Return(nil)
 	store.EXPECT().DeleteSubscription(gomock.Any(), roomID, "bob").Return(int64(1), nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{}, nil)
 
 	var published []publishedMsg
@@ -6097,7 +6111,7 @@ func TestHandler_ProcessRemoveIndividual_RemovedByOther_Content(t *testing.T) {
 		}, nil)
 	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u_b").Return(nil)
 	store.EXPECT().DeleteSubscription(gomock.Any(), roomID, "bob").Return(int64(1), nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{}, nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
@@ -6152,7 +6166,7 @@ func TestHandler_ProcessRemoveIndividual_RemovedByOther_BotAware(t *testing.T) {
 				Return(&UserWithMembership{User: tt.removed}, nil)
 			store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, tt.removed.ID).Return(nil)
 			store.EXPECT().DeleteSubscription(gomock.Any(), roomID, tt.removed.Account).Return(int64(1), nil)
-			store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+			store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 			store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{}, nil)
 			store.EXPECT().GetUser(gomock.Any(), tt.requester.Account).Return(&tt.requester, nil)
 			store.EXPECT().GetApp(gomock.Any(), botUser.Account).Return(&model.App{Name: "Helper Bot"}, nil)
@@ -6221,7 +6235,7 @@ func TestHandler_ProcessRemoveIndividual_SelfLeave_BotContent(t *testing.T) {
 				}, nil)
 			store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u_bot").Return(nil)
 			store.EXPECT().DeleteSubscription(gomock.Any(), roomID, "helper.bot").Return(int64(1), nil)
-			store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+			store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 			store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{}, nil)
 			tt.setupApp(store)
 
@@ -6255,7 +6269,8 @@ func TestHandler_ProcessRemoveOrg_AllOverlap_SectNameFromUnfiltered(t *testing.T
 		}, nil)
 	// toRemove is empty → no DeleteSubscriptionsByAccounts call expected.
 	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberOrg, "o1").Return(nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	// Nothing was deleted, so the counters are untouched — no delta and no
+	// full recompute (an org removal that frees no member must cost neither).
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
 
@@ -6289,7 +6304,8 @@ func TestHandler_ProcessRemoveOrg_AllSectNamesEmpty(t *testing.T) {
 		}, nil)
 	// toRemove is empty (the member has individual membership) → no DeleteSubscriptionsByAccounts expected.
 	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberOrg, "o1").Return(nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	// Nothing was deleted, so the counters are untouched — no delta and no
+	// full recompute (an org removal that frees no member must cost neither).
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
 
@@ -6337,7 +6353,8 @@ func TestHandler_ProcessRemoveOrg_OtherOrgCovers_PreservesSub(t *testing.T) {
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), gomock.Any()).Times(0)
 	// The X org row still gets deleted; the count gets reconciled.
 	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberOrg, "X").Return(nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	// Nothing was deleted, so the counters are untouched — no delta and no
+	// full recompute (an org removal that frees no member must cost neither).
 	store.EXPECT().GetUser(gomock.Any(), "alice-req").
 		Return(&model.User{ID: "u_r", Account: "alice-req", SiteID: "site-a", EngName: "Req", ChineseName: "求"}, nil)
 
@@ -6790,7 +6807,8 @@ func TestHandler_ProcessRemoveOrg_DeptFirstTiebreak(t *testing.T) {
 			store.EXPECT().GetOrgMembersWithIndividualStatus(gomock.Any(), roomID, "o1").Return(tc.members, nil)
 			// toRemove is empty (all members have individual membership) → no DeleteSubscriptionsByAccounts expected.
 			store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberOrg, "o1").Return(nil)
-			store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+			// Nothing was deleted, so the counters are untouched — no delta and no
+			// full recompute (an org removal that frees no member must cost neither).
 			store.EXPECT().GetUser(gomock.Any(), "alice").
 				Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
 
@@ -7504,7 +7522,7 @@ func TestHandler_ProcessRemoveIndividual_BustsSubL2(t *testing.T) {
 	store.EXPECT().GetUserWithMembership(gomock.Any(), roomID, account).Return(userResult, nil)
 	store.EXPECT().DeleteSubscription(gomock.Any(), roomID, account).Return(int64(1), nil)
 	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u1").Return(nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 
 	fake := valkeyfake.New()
@@ -7573,7 +7591,7 @@ func TestHandler_ProcessRemoveOrg_BustsSubL2ForEachRemovedAccount(t *testing.T) 
 	store.EXPECT().PullThreadFollowers(gomock.Any(), roomID, gomock.InAnyOrder([]string{"carol", "dave"})).Return(nil)
 	store.EXPECT().DeleteThreadSubscriptions(gomock.Any(), roomID, gomock.InAnyOrder([]string{"carol", "dave"})).Return(nil)
 	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberOrg, orgID).Return(nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 	store.EXPECT().GetUser(gomock.Any(), requester).Return(&model.User{ID: "u_alice", Account: requester, SiteID: siteID, EngName: "Alice", ChineseName: "愛"}, nil)
 
@@ -8166,4 +8184,149 @@ func TestProcessRoomRename_UsesProjectedAccountsQuery(t *testing.T) {
 	})
 
 	require.NoError(t, h.processRoomRename(ctx, body))
+}
+
+// --- member-count deltas on the remove paths -------------------------------
+//
+// Removing one member used to trigger ReconcileMemberCounts, which runs two
+// CountDocuments over the whole room — two full index scans of a 50k-member
+// room to record a delta of one. The remove paths now $inc an exact delta and
+// fall back to the full recompute only when the TTL says a drift check is due
+// or the delete was partial.
+
+func removeIndividualStore(t *testing.T, ctrl *gomock.Controller, roomID, account, siteID string, deleted int64) *MockSubscriptionStore {
+	t.Helper()
+	store := NewMockSubscriptionStore(ctrl)
+	store.EXPECT().GetUserWithMembership(gomock.Any(), roomID, account).Return(&UserWithMembership{
+		User: model.User{ID: "u1", Account: account, SiteID: siteID},
+	}, nil)
+	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u1").Return(nil)
+	store.EXPECT().DeleteSubscription(gomock.Any(), roomID, account).Return(deleted, nil)
+	store.EXPECT().PullThreadFollowers(gomock.Any(), roomID, []string{account}).Return(nil)
+	store.EXPECT().DeleteThreadSubscriptions(gomock.Any(), roomID, []string{account}).Return(nil)
+	// Key fan-out is downstream of the counter work these tests assert on, and
+	// an error case returns before reaching it.
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil).AnyTimes()
+	// Only a bot account reaches the app-name lookup; no registration is fine.
+	store.EXPECT().GetApp(gomock.Any(), gomock.Any()).Return(nil, ErrAppNotFound).AnyTimes()
+	return store
+}
+
+func runRemoveIndividual(t *testing.T, store *MockSubscriptionStore, roomID, account, siteID string) error {
+	t.Helper()
+	h := NewHandler(store, siteID, func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
+	data, _ := json.Marshal(model.RemoveMemberRequest{
+		RoomID: roomID, Requester: account, Account: account, Timestamp: 1, RoomType: model.RoomTypeChannel,
+	})
+	return h.processRemoveMember(context.Background(), data)
+}
+
+func TestHandler_ProcessRemoveIndividual_AppliesUserCountDelta(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	const roomID, account, siteID = "room-1", "alice", "site-a"
+	store := removeIndividualStore(t, ctrl, roomID, account, siteID, 1)
+	// Exact -1 user delta, and no full recompute because the TTL is not due.
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, -1, 0, gomock.Any()).Return(false, nil)
+
+	require.NoError(t, runRemoveIndividual(t, store, roomID, account, siteID))
+}
+
+func TestHandler_ProcessRemoveIndividual_BotRemovalDecrementsAppCount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	const roomID, account, siteID = "room-1", "helper.bot", "site-a"
+	store := removeIndividualStore(t, ctrl, roomID, account, siteID, 1)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, 0, -1, gomock.Any()).Return(false, nil)
+
+	require.NoError(t, runRemoveIndividual(t, store, roomID, account, siteID))
+}
+
+func TestHandler_ProcessRemoveIndividual_ReconcilesWhenDeltaReportsDue(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	const roomID, account, siteID = "room-1", "alice", "site-a"
+	store := removeIndividualStore(t, ctrl, roomID, account, siteID, 1)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, -1, 0, gomock.Any()).Return(true, nil)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+
+	require.NoError(t, runRemoveIndividual(t, store, roomID, account, siteID))
+}
+
+// A redelivery finds the subscription already gone. The counter was decremented
+// on the first delivery, so a second decrement would drift it: apply nothing.
+func TestHandler_ProcessRemoveIndividual_RedeliveryAppliesNoDelta(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	const roomID, account, siteID = "room-1", "alice", "site-a"
+	store := removeIndividualStore(t, ctrl, roomID, account, siteID, 0)
+	// No ApplyMemberCountDelta and no ReconcileMemberCounts expectation: either
+	// call is an unexpected-call failure.
+
+	require.NoError(t, runRemoveIndividual(t, store, roomID, account, siteID))
+}
+
+func TestHandler_ProcessRemoveOrg_AppliesCountDeltaForDeletedAccounts(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	const roomID, orgID, requester, siteID = "room-1", "org-1", "alice", "site-a"
+
+	orgMembers := []OrgMemberStatus{
+		{Account: "carol", SiteID: siteID, Name: "Engineering"},
+		{Account: "svc.bot", SiteID: siteID, Name: "Engineering"},
+		{Account: "eve", SiteID: siteID, Name: "Engineering", HasIndividualMembership: true},
+	}
+	store.EXPECT().GetOrgMembersWithIndividualStatus(gomock.Any(), roomID, orgID).Return(orgMembers, nil)
+	store.EXPECT().DeleteSubscriptionsByAccounts(gomock.Any(), roomID, gomock.InAnyOrder([]string{"carol", "svc.bot"})).Return(int64(2), nil)
+	store.EXPECT().PullThreadFollowers(gomock.Any(), roomID, gomock.InAnyOrder([]string{"carol", "svc.bot"})).Return(nil)
+	store.EXPECT().DeleteThreadSubscriptions(gomock.Any(), roomID, gomock.InAnyOrder([]string{"carol", "svc.bot"})).Return(nil)
+	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberOrg, orgID).Return(nil)
+	// One human + one bot left, so the split must be exact, not lumped.
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, -1, -1, gomock.Any()).Return(false, nil)
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
+	store.EXPECT().GetUser(gomock.Any(), requester).Return(&model.User{ID: "u_alice", Account: requester, SiteID: siteID}, nil)
+
+	h := NewHandler(store, siteID, func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
+	data, _ := json.Marshal(model.RemoveMemberRequest{RoomID: roomID, Requester: requester, OrgID: orgID, Timestamp: 1000, RoomType: model.RoomTypeChannel})
+	require.NoError(t, h.processRemoveMember(context.Background(), data))
+}
+
+// Fewer documents deleted than accounts targeted means the delta cannot be
+// derived from the target set (a concurrent remove, or a partial redelivery),
+// so fall back to the authoritative full recompute.
+func TestHandler_ProcessRemoveOrg_PartialDeleteFallsBackToReconcile(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	const roomID, orgID, requester, siteID = "room-1", "org-1", "alice", "site-a"
+
+	orgMembers := []OrgMemberStatus{
+		{Account: "carol", SiteID: siteID, Name: "Engineering"},
+		{Account: "dave", SiteID: siteID, Name: "Engineering"},
+	}
+	store.EXPECT().GetOrgMembersWithIndividualStatus(gomock.Any(), roomID, orgID).Return(orgMembers, nil)
+	store.EXPECT().DeleteSubscriptionsByAccounts(gomock.Any(), roomID, gomock.Any()).Return(int64(1), nil)
+	store.EXPECT().PullThreadFollowers(gomock.Any(), roomID, gomock.Any()).Return(nil)
+	store.EXPECT().DeleteThreadSubscriptions(gomock.Any(), roomID, gomock.Any()).Return(nil)
+	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberOrg, orgID).Return(nil)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
+	store.EXPECT().GetUser(gomock.Any(), requester).Return(&model.User{ID: "u_alice", Account: requester, SiteID: siteID}, nil)
+
+	h := NewHandler(store, siteID, func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
+	data, _ := json.Marshal(model.RemoveMemberRequest{RoomID: roomID, Requester: requester, OrgID: orgID, Timestamp: 1000, RoomType: model.RoomTypeChannel})
+	require.NoError(t, h.processRemoveMember(context.Background(), data))
+}
+
+// An org whose members all survive via individual rows deletes nothing, so it
+// must not touch the counters at all — least of all with a full recompute.
+func TestHandler_ProcessRemoveOrg_NoDeletionsSkipsCountWork(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	const roomID, orgID, requester, siteID = "room-1", "org-1", "alice", "site-a"
+
+	store.EXPECT().GetOrgMembersWithIndividualStatus(gomock.Any(), roomID, orgID).Return([]OrgMemberStatus{
+		{Account: "eve", SiteID: siteID, Name: "Engineering", HasIndividualMembership: true},
+	}, nil)
+	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberOrg, orgID).Return(nil)
+	store.EXPECT().GetUser(gomock.Any(), requester).Return(&model.User{ID: "u_alice", Account: requester, SiteID: siteID}, nil)
+
+	h := NewHandler(store, siteID, func(_ context.Context, _ string, _ []byte, _ string) error { return nil }, testKeyStore, testKeySender, subject.RouteGlobal)
+	data, _ := json.Marshal(model.RemoveMemberRequest{RoomID: roomID, Requester: requester, OrgID: orgID, Timestamp: 1000, RoomType: model.RoomTypeChannel})
+	require.NoError(t, h.processRemoveMember(context.Background(), data))
 }

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -1943,8 +1943,7 @@ func TestHandler_ProcessRemoveIndividual_CountDeltaError(t *testing.T) {
 	assert.Contains(t, err.Error(), "apply member count delta")
 }
 
-// When the TTL says a drift check is due, the full recompute still runs on the
-// remove path and its failure must still propagate.
+// A due drift check still recomputes, and its failure must still propagate.
 func TestHandler_ProcessRemoveIndividual_ReconcileOnDueError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	const roomID, account, siteID = "r1", "alice", "site-a"
@@ -6269,8 +6268,7 @@ func TestHandler_ProcessRemoveOrg_AllOverlap_SectNameFromUnfiltered(t *testing.T
 		}, nil)
 	// toRemove is empty → no DeleteSubscriptionsByAccounts call expected.
 	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberOrg, "o1").Return(nil)
-	// Nothing was deleted, so the counters are untouched — no delta and no
-	// full recompute (an org removal that frees no member must cost neither).
+	// Nothing deleted: no delta and no recompute.
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
 
@@ -6304,8 +6302,7 @@ func TestHandler_ProcessRemoveOrg_AllSectNamesEmpty(t *testing.T) {
 		}, nil)
 	// toRemove is empty (the member has individual membership) → no DeleteSubscriptionsByAccounts expected.
 	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberOrg, "o1").Return(nil)
-	// Nothing was deleted, so the counters are untouched — no delta and no
-	// full recompute (an org removal that frees no member must cost neither).
+	// Nothing deleted: no delta and no recompute.
 	store.EXPECT().GetUser(gomock.Any(), "alice").
 		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
 
@@ -6353,8 +6350,7 @@ func TestHandler_ProcessRemoveOrg_OtherOrgCovers_PreservesSub(t *testing.T) {
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), gomock.Any()).Times(0)
 	// The X org row still gets deleted; the count gets reconciled.
 	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberOrg, "X").Return(nil)
-	// Nothing was deleted, so the counters are untouched — no delta and no
-	// full recompute (an org removal that frees no member must cost neither).
+	// Nothing deleted: no delta and no recompute.
 	store.EXPECT().GetUser(gomock.Any(), "alice-req").
 		Return(&model.User{ID: "u_r", Account: "alice-req", SiteID: "site-a", EngName: "Req", ChineseName: "求"}, nil)
 
@@ -6807,8 +6803,7 @@ func TestHandler_ProcessRemoveOrg_DeptFirstTiebreak(t *testing.T) {
 			store.EXPECT().GetOrgMembersWithIndividualStatus(gomock.Any(), roomID, "o1").Return(tc.members, nil)
 			// toRemove is empty (all members have individual membership) → no DeleteSubscriptionsByAccounts expected.
 			store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberOrg, "o1").Return(nil)
-			// Nothing was deleted, so the counters are untouched — no delta and no
-			// full recompute (an org removal that frees no member must cost neither).
+			// Nothing deleted: no delta and no recompute.
 			store.EXPECT().GetUser(gomock.Any(), "alice").
 				Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
 
@@ -8155,10 +8150,8 @@ func TestProcessCreateRoom_BotRequester_DoesNotSubscribeTheHuman(t *testing.T) {
 		"only setAppSubscription initiated by Alice may set isSubscribed")
 }
 
-// Rename only needs member accounts for the cross-site fan-out, so it must use
-// the projected GetSubscriptionAccounts rather than reading every full
-// subscription document in the room (a 5k-member rename otherwise ships 5k
-// documents to extract two string fields).
+// Rename needs accounts only, so it must use the projected query: a 5k-member
+// rename otherwise ships 5k documents to extract two string fields.
 func TestProcessRoomRename_UsesProjectedAccountsQuery(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -8169,8 +8162,7 @@ func TestProcessRoomRename_UsesProjectedAccountsQuery(t *testing.T) {
 	store.EXPECT().UpdateRoomName(gomock.Any(), roomID, newName).Return(nil)
 	store.EXPECT().UpdateSubscriptionNamesForRoom(gomock.Any(), roomID, newName, gomock.Any()).Return(nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
-	// The projected read — and no ListByRoom expectation, so a full-document
-	// read fails the test as an unexpected call.
+	// No ListByRoom expectation, so a full-document read fails as unexpected.
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{"alice", "bob"}, nil)
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return([]model.User{
 		{Account: "alice", SiteID: "site-a"}, {Account: "bob", SiteID: "site-a"},
@@ -8186,13 +8178,8 @@ func TestProcessRoomRename_UsesProjectedAccountsQuery(t *testing.T) {
 	require.NoError(t, h.processRoomRename(ctx, body))
 }
 
-// --- member-count deltas on the remove paths -------------------------------
-//
-// Removing one member used to trigger ReconcileMemberCounts, which runs two
-// CountDocuments over the whole room — two full index scans of a 50k-member
-// room to record a delta of one. The remove paths now $inc an exact delta and
-// fall back to the full recompute only when the TTL says a drift check is due
-// or the delete was partial.
+// Remove paths $inc an exact delta, falling back to the whole-room recompute
+// only when the TTL says drift is due or the delete was partial.
 
 func removeIndividualStore(t *testing.T, ctrl *gomock.Controller, roomID, account, siteID string, deleted int64) *MockSubscriptionStore {
 	t.Helper()
@@ -8204,8 +8191,7 @@ func removeIndividualStore(t *testing.T, ctrl *gomock.Controller, roomID, accoun
 	store.EXPECT().DeleteSubscription(gomock.Any(), roomID, account).Return(deleted, nil)
 	store.EXPECT().PullThreadFollowers(gomock.Any(), roomID, []string{account}).Return(nil)
 	store.EXPECT().DeleteThreadSubscriptions(gomock.Any(), roomID, []string{account}).Return(nil)
-	// Key fan-out is downstream of the counter work these tests assert on, and
-	// an error case returns before reaching it.
+	// Downstream of the counter work asserted here; error cases never reach it.
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil).AnyTimes()
 	// Only a bot account reaches the app-name lookup; no registration is fine.
 	store.EXPECT().GetApp(gomock.Any(), gomock.Any()).Return(nil, ErrAppNotFound).AnyTimes()
@@ -8250,14 +8236,12 @@ func TestHandler_ProcessRemoveIndividual_ReconcilesWhenDeltaReportsDue(t *testin
 	require.NoError(t, runRemoveIndividual(t, store, roomID, account, siteID))
 }
 
-// A redelivery finds the subscription already gone. The counter was decremented
-// on the first delivery, so a second decrement would drift it: apply nothing.
+// A redelivery finds the sub already gone; a second decrement would drift it.
 func TestHandler_ProcessRemoveIndividual_RedeliveryAppliesNoDelta(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	const roomID, account, siteID = "room-1", "alice", "site-a"
 	store := removeIndividualStore(t, ctrl, roomID, account, siteID, 0)
-	// No ApplyMemberCountDelta and no ReconcileMemberCounts expectation: either
-	// call is an unexpected-call failure.
+	// No count expectations at all: either call fails as unexpected.
 
 	require.NoError(t, runRemoveIndividual(t, store, roomID, account, siteID))
 }
@@ -8287,9 +8271,8 @@ func TestHandler_ProcessRemoveOrg_AppliesCountDeltaForDeletedAccounts(t *testing
 	require.NoError(t, h.processRemoveMember(context.Background(), data))
 }
 
-// Fewer documents deleted than accounts targeted means the delta cannot be
-// derived from the target set (a concurrent remove, or a partial redelivery),
-// so fall back to the authoritative full recompute.
+// Fewer deleted than targeted means the delta cannot come from the target set,
+// so the authoritative recompute must run instead.
 func TestHandler_ProcessRemoveOrg_PartialDeleteFallsBackToReconcile(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)
@@ -8313,8 +8296,7 @@ func TestHandler_ProcessRemoveOrg_PartialDeleteFallsBackToReconcile(t *testing.T
 	require.NoError(t, h.processRemoveMember(context.Background(), data))
 }
 
-// An org whose members all survive via individual rows deletes nothing, so it
-// must not touch the counters at all — least of all with a full recompute.
+// An org whose members all survive deletes nothing, so it must not count.
 func TestHandler_ProcessRemoveOrg_NoDeletionsSkipsCountWork(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockSubscriptionStore(ctrl)

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -7083,7 +7083,7 @@ func TestProcessRoomRename_BotRequester_Content(t *testing.T) {
 	store.EXPECT().GetUser(gomock.Any(), "helper.bot").
 		Return(&model.User{ID: "u_bot", Account: "helper.bot", SiteID: "site-a"}, nil)
 	store.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(&model.App{Name: "Helper Bot"}, nil)
-	store.EXPECT().ListByRoom(gomock.Any(), roomID).Return(nil, nil)
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 	store.EXPECT().GetRoomMeta(gomock.Any(), roomID).Return(&model.Room{ID: roomID}, nil)
 
 	var published []publishedMsg
@@ -7115,7 +7115,7 @@ func TestProcessRoomRename_PublishesRoomRenamedEvent(t *testing.T) {
 	store.EXPECT().UpdateRoomName(gomock.Any(), roomID, newName).Return(nil)
 	store.EXPECT().UpdateSubscriptionNamesForRoom(gomock.Any(), roomID, newName, gomock.Any()).Return(nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
-	store.EXPECT().ListByRoom(gomock.Any(), roomID).Return(nil, nil)
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 	store.EXPECT().GetRoomMeta(gomock.Any(), roomID).Return(&model.Room{ID: roomID}, nil)
 
 	var roomEvts [][]byte
@@ -7161,7 +7161,7 @@ func TestProcessRoomRename_PublishesInternalSearchFeed(t *testing.T) {
 	store.EXPECT().UpdateRoomName(gomock.Any(), roomID, newName).Return(nil)
 	store.EXPECT().UpdateSubscriptionNamesForRoom(gomock.Any(), roomID, newName, gomock.Any()).Return(nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
-	store.EXPECT().ListByRoom(gomock.Any(), roomID).Return(nil, nil)
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 	store.EXPECT().GetRoomMeta(gomock.Any(), roomID).Return(&model.Room{ID: roomID}, nil)
 
 	var feed [][]byte
@@ -7199,15 +7199,12 @@ func TestProcessRoomRename_HappyPathNoRemoteSites(t *testing.T) {
 	const roomID, newName = "r1", "renamed"
 	requestID := testRequestID
 
-	subs := []model.Subscription{
-		{ID: "s1", User: model.SubscriptionUser{ID: "u1", Account: "alice"}, RoomID: roomID},
-		{ID: "s2", User: model.SubscriptionUser{ID: "u2", Account: "bob"}, RoomID: roomID},
-	}
+	accounts := []string{"alice", "bob"}
 
 	store.EXPECT().UpdateRoomName(gomock.Any(), roomID, newName).Return(nil)
 	store.EXPECT().UpdateSubscriptionNamesForRoom(gomock.Any(), roomID, newName, gomock.Any()).Return(nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
-	store.EXPECT().ListByRoom(gomock.Any(), roomID).Return(subs, nil)
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(accounts, nil)
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return([]model.User{
 		{Account: "alice", SiteID: "site-a"}, {Account: "bob", SiteID: "site-a"},
 	}, nil)
@@ -7245,15 +7242,12 @@ func TestProcessRoomRename_HappyPathWithRemoteSite(t *testing.T) {
 	requestID := testRequestID
 	ts := int64(1700000000000)
 
-	subs := []model.Subscription{
-		{ID: "s1", User: model.SubscriptionUser{ID: "u1", Account: "alice"}, RoomID: roomID},
-		{ID: "s2", User: model.SubscriptionUser{ID: "u2", Account: "bob"}, RoomID: roomID},
-	}
+	accounts := []string{"alice", "bob"}
 
 	store.EXPECT().UpdateRoomName(gomock.Any(), roomID, newName).Return(nil)
 	store.EXPECT().UpdateSubscriptionNamesForRoom(gomock.Any(), roomID, newName, gomock.Any()).Return(nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
-	store.EXPECT().ListByRoom(gomock.Any(), roomID).Return(subs, nil)
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(accounts, nil)
 	// Bob is on a remote site.
 	store.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return([]model.User{
 		{Account: "alice", SiteID: "site-a"},
@@ -7319,8 +7313,8 @@ func TestProcessRoomRename_ErrorThenOkRetrySequence(t *testing.T) {
 	store.EXPECT().UpdateRoomName(gomock.Any(), "r1", "x").Return(nil)
 	store.EXPECT().UpdateSubscriptionNamesForRoom(gomock.Any(), "r1", "x", gomock.Any()).Return(nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
-	// Empty subs → accounts is empty → findRemoteSitesForAccounts short-circuits (no FindUsersByAccounts call).
-	store.EXPECT().ListByRoom(gomock.Any(), "r1").Return([]model.Subscription{}, nil)
+	// Empty accounts → findRemoteSitesForAccounts short-circuits (no FindUsersByAccounts call).
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), "r1").Return([]string{}, nil)
 	store.EXPECT().GetRoomMeta(gomock.Any(), "r1").Return(&model.Room{ID: "r1"}, nil)
 
 	var asyncResults []model.AsyncJobResult
@@ -7360,7 +7354,7 @@ func newRoomRenameRoutingFixture(t *testing.T, crossSite bool) (*Handler, *MockS
 	store.EXPECT().UpdateRoomName(gomock.Any(), roomID, newName).Return(nil)
 	store.EXPECT().UpdateSubscriptionNamesForRoom(gomock.Any(), roomID, newName, gomock.Any()).Return(nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
-	store.EXPECT().ListByRoom(gomock.Any(), roomID).Return(nil, nil)
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 	store.EXPECT().GetRoomMeta(gomock.Any(), roomID).Return(&model.Room{ID: roomID, CrossSite: ptrBool(crossSite)}, nil)
 
 	var roomEvts [][]byte
@@ -7442,7 +7436,7 @@ func TestProcessRoomRename_GetRoomFails_FallsBackToGlobal(t *testing.T) {
 	store.EXPECT().UpdateRoomName(gomock.Any(), roomID, newName).Return(nil)
 	store.EXPECT().UpdateSubscriptionNamesForRoom(gomock.Any(), roomID, newName, gomock.Any()).Return(nil)
 	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
-	store.EXPECT().ListByRoom(gomock.Any(), roomID).Return(nil, nil)
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 	store.EXPECT().GetRoomMeta(gomock.Any(), roomID).Return(nil, errors.New("mongo down"))
 
 	var roomEvts []string
@@ -8141,4 +8135,35 @@ func TestProcessCreateRoom_BotRequester_DoesNotSubscribeTheHuman(t *testing.T) {
 	assert.Equal(t, model.RoomTypeBotDM, byAccount["alice"].RoomType)
 	assert.False(t, byAccount["alice"].IsSubscribed,
 		"only setAppSubscription initiated by Alice may set isSubscribed")
+}
+
+// Rename only needs member accounts for the cross-site fan-out, so it must use
+// the projected GetSubscriptionAccounts rather than reading every full
+// subscription document in the room (a 5k-member rename otherwise ships 5k
+// documents to extract two string fields).
+func TestProcessRoomRename_UsesProjectedAccountsQuery(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	store := NewMockSubscriptionStore(ctrl)
+
+	const roomID, newName = "r1", "renamed"
+
+	store.EXPECT().UpdateRoomName(gomock.Any(), roomID, newName).Return(nil)
+	store.EXPECT().UpdateSubscriptionNamesForRoom(gomock.Any(), roomID, newName, gomock.Any()).Return(nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
+	// The projected read — and no ListByRoom expectation, so a full-document
+	// read fails the test as an unexpected call.
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{"alice", "bob"}, nil)
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), gomock.Any()).Return([]model.User{
+		{Account: "alice", SiteID: "site-a"}, {Account: "bob", SiteID: "site-a"},
+	}, nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), roomID).Return(&model.Room{ID: roomID}, nil)
+
+	h := &Handler{store: store, siteID: "site-a", publish: func(_ context.Context, _ string, _ []byte, _ string) error { return nil }}
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+	body, _ := json.Marshal(model.RenameRoomRequest{
+		RoomID: roomID, NewName: newName, Account: "alice", Timestamp: time.Now().UTC().UnixMilli(),
+	})
+
+	require.NoError(t, h.processRoomRename(ctx, body))
 }

--- a/room-worker/main.go
+++ b/room-worker/main.go
@@ -308,6 +308,14 @@ func main() {
 	}
 	consumerMetrics.LoopStarted(ctx)
 
+	// Pace the heartbeat off the deadline the server actually applied, not the
+	// one we asked for: the two differ whenever AckWait is unset or clamped.
+	ackWait := consumerCfg.AckWait
+	if info := cons.CachedInfo(); info != nil {
+		ackWait = info.Config.AckWait
+	}
+	heartbeatEvery := jsretry.HeartbeatInterval(ackWait)
+
 	wg.Add(1)
 	go func() {
 		// The loop itself is counted so shutdown, which stops the iterator and
@@ -320,13 +328,15 @@ func main() {
 				consumerMetrics.LoopFailed(context.Background(), err)
 				return
 			}
+			// Heartbeat from delivery, not from when a worker frees up: a
+			// message queued on the semaphore is already spending its ack
+			// deadline, and a large-room mutation can outrun what is left.
+			stopHeartbeat := jsretry.Heartbeat(msgCtx, msg, heartbeatEvery)
 			sem <- struct{}{}
 			wg.Add(1)
-			go func(msgCtx context.Context, msg jetstream.Msg) {
+			go func(msgCtx context.Context, msg jetstream.Msg, stopHeartbeat func()) {
 				tracked := consumerMetrics.Track(msgCtx, msg, natsmetrics.RoomEventTypeFromSubject(msg.Subject()), consumerCfg.MaxDeliver)
 				msgCtx = tracked.Context(msgCtx)
-				// A large-room mutation can outrun AckWait; redelivery double-runs it.
-				stopHeartbeat := jsretry.Heartbeat(msgCtx, tracked, jsretry.HeartbeatInterval(consumerCfg.AckWait))
 				// runJobWithRecovery contains handler panics (it Acks — drops — the
 				// poison message) so this async goroutine, which runs outside
 				// natsrouter's recovery middleware, can't crash the worker.
@@ -337,7 +347,7 @@ func main() {
 					wg.Done()
 				}()
 				runJobWithRecovery(msgCtx, handler, tracked)
-			}(msgCtx, msg)
+			}(msgCtx, msg, stopHeartbeat)
 		}
 	}()
 

--- a/room-worker/main.go
+++ b/room-worker/main.go
@@ -325,11 +325,7 @@ func main() {
 			go func(msgCtx context.Context, msg jetstream.Msg) {
 				tracked := consumerMetrics.Track(msgCtx, msg, natsmetrics.RoomEventTypeFromSubject(msg.Subject()), consumerCfg.MaxDeliver)
 				msgCtx = tracked.Context(msgCtx)
-				// Keep the ack deadline alive for the duration of the handler.
-				// Room mutations on a large room (org removal, key rotation and
-				// fan-out over every survivor) can outrun AckWait, and a
-				// redelivery mid-flight would run the whole job a second time
-				// concurrently with the first.
+				// A large-room mutation can outrun AckWait; redelivery double-runs it.
 				stopHeartbeat := jsretry.Heartbeat(msgCtx, tracked, jsretry.HeartbeatInterval(consumerCfg.AckWait))
 				// runJobWithRecovery contains handler panics (it Acks — drops — the
 				// poison message) so this async goroutine, which runs outside

--- a/room-worker/main.go
+++ b/room-worker/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/health"
 	"github.com/hmchangw/chat/pkg/idgen"
+	"github.com/hmchangw/chat/pkg/jsretry"
 	"github.com/hmchangw/chat/pkg/logctx"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
@@ -324,10 +325,17 @@ func main() {
 			go func(msgCtx context.Context, msg jetstream.Msg) {
 				tracked := consumerMetrics.Track(msgCtx, msg, natsmetrics.RoomEventTypeFromSubject(msg.Subject()), consumerCfg.MaxDeliver)
 				msgCtx = tracked.Context(msgCtx)
+				// Keep the ack deadline alive for the duration of the handler.
+				// Room mutations on a large room (org removal, key rotation and
+				// fan-out over every survivor) can outrun AckWait, and a
+				// redelivery mid-flight would run the whole job a second time
+				// concurrently with the first.
+				stopHeartbeat := jsretry.Heartbeat(msgCtx, tracked, jsretry.HeartbeatInterval(consumerCfg.AckWait))
 				// runJobWithRecovery contains handler panics (it Acks — drops — the
 				// poison message) so this async goroutine, which runs outside
 				// natsrouter's recovery middleware, can't crash the worker.
 				defer func() {
+					stopHeartbeat()
 					tracked.Finish(msgCtx)
 					<-sem
 					wg.Done()

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -558,8 +558,9 @@ func (s *MongoStore) BulkCreateSubscriptions(ctx context.Context, subs []*model.
 		filter := bson.M{"roomId": sub.RoomID, "u.account": sub.User.Account}
 		models = append(models, mongoutil.UpsertModel(filter, bson.M{"$setOnInsert": sub}))
 	}
-	opts := options.BulkWrite().SetOrdered(false)
-	if _, err := s.subscriptions.BulkWrite(ctx, models, opts); err != nil {
+	// Chunked: an org add can present tens of thousands of candidates, and one
+	// BulkWrite carrying all of them is a single outsized command.
+	if _, err := mongoutil.ChunkedBulkWrite(ctx, s.subscriptions, models, mongoutil.MaxBulkChunk); err != nil {
 		return fmt.Errorf("bulk create %d subscriptions: %w", len(subs), err)
 	}
 	return nil
@@ -580,7 +581,7 @@ func (s *MongoStore) BulkRefreshJoinedAt(ctx context.Context, roomID string, joi
 			SetFilter(bson.M{"roomId": roomID, "u.account": account}).
 			SetUpdate(bson.M{"$set": bson.M{"joinedAt": joinedAt}}))
 	}
-	if _, err := s.subscriptions.BulkWrite(ctx, models, options.BulkWrite().SetOrdered(false)); err != nil {
+	if _, err := mongoutil.ChunkedBulkWrite(ctx, s.subscriptions, models, mongoutil.MaxBulkChunk); err != nil {
 		return fmt.Errorf("bulk refresh joinedAt for %d subs: %w", len(models), err)
 	}
 	return nil
@@ -603,7 +604,7 @@ func (s *MongoStore) BulkCreateRoomMembers(ctx context.Context, members []*model
 		filter := bson.M{"rid": m.RoomID, "member.type": m.Member.Type, "member.id": m.Member.ID}
 		writes[i] = mongoutil.UpsertModel(filter, bson.M{"$setOnInsert": set})
 	}
-	if _, err := s.roomMembers.BulkWrite(ctx, writes, options.BulkWrite().SetOrdered(false)); err != nil {
+	if _, err := mongoutil.ChunkedBulkWrite(ctx, s.roomMembers, writes, mongoutil.MaxBulkChunk); err != nil {
 		return fmt.Errorf("bulk upsert %d room members: %w", len(members), err)
 	}
 	return nil

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -83,10 +83,10 @@ func (s *MongoStore) EnableRoomMetaCache(size int, ttl time.Duration) error {
 	return nil
 }
 
-// ListByRoom returns all subscriptions for roomID across every site. Not part
-// of SubscriptionStore — the handler's hot paths only need accounts (see
-// GetSubscriptionAccounts); this full-document read is retained for integration
-// test verification.
+// ListByRoom returns all subscriptions for roomID across every site. Only the
+// Teams reconcile path uses it, because it diffs per-subscription state
+// (joinedAt) rather than just membership; every other path needs accounts alone
+// and must use the projected GetSubscriptionAccounts instead.
 func (s *MongoStore) ListByRoom(ctx context.Context, roomID string) ([]model.Subscription, error) {
 	cursor, err := s.subscriptions.Find(ctx, bson.M{"roomId": roomID})
 	if err != nil {

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -83,10 +83,8 @@ func (s *MongoStore) EnableRoomMetaCache(size int, ttl time.Duration) error {
 	return nil
 }
 
-// ListByRoom returns all subscriptions for roomID across every site. Only the
-// Teams reconcile path uses it, because it diffs per-subscription state
-// (joinedAt) rather than just membership; every other path needs accounts alone
-// and must use the projected GetSubscriptionAccounts instead.
+// ListByRoom returns every subscription in roomID. Only the Teams reconcile path
+// needs full documents; other callers must use projected GetSubscriptionAccounts.
 func (s *MongoStore) ListByRoom(ctx context.Context, roomID string) ([]model.Subscription, error) {
 	cursor, err := s.subscriptions.Find(ctx, bson.M{"roomId": roomID})
 	if err != nil {
@@ -329,10 +327,8 @@ func (s *MongoStore) GetUserWithMembership(ctx context.Context, roomID, account 
 		// has member.id = deptId. Checking only sectId would miss that case
 		// and report HasOrgMembership=false, causing the remove flow to drop
 		// the user's subscription even though they are still org-attached.
-		// $lookup justification: single-document read whose two joins resolve
-		// one user's membership and subscription in one round trip, each
-		// sub-pipeline $limit 1. Splitting it would triple the round trips on
-		// the remove path's first call.
+		// $lookup justification: resolves one user's membership and subscription
+		// in a single round trip; splitting it would triple them.
 		{{Key: "$lookup", Value: bson.M{
 			"from": "room_members",
 			"let":  bson.M{"sectId": "$sectId", "deptId": "$deptId"},
@@ -349,8 +345,7 @@ func (s *MongoStore) GetUserWithMembership(ctx context.Context, roomID, account 
 			},
 			"as": "orgMembership",
 		}}},
-		// $lookup justification: see above — same single-user, single-round-trip
-		// read; this half answers "does the user still hold a subscription".
+		// $lookup justification: see above; this half checks for a live subscription.
 		{{Key: "$lookup", Value: bson.M{
 			"from": "subscriptions",
 			"let":  bson.M{"acct": "$account"},
@@ -391,18 +386,15 @@ func (s *MongoStore) GetUserWithMembership(ctx context.Context, roomID, account 
 	return &result, nil
 }
 
-// orgMembersPipeline builds the org-member status aggregation. It is separated
-// from the query so the stage order — in particular that the narrowing $project
-// precedes the two correlated $lookups — is unit-testable without Mongo.
+// orgMembersPipeline builds the org-member status aggregation, split from the
+// query so stage order stays unit-testable without Mongo.
 func orgMembersPipeline(roomID, orgID string) mongo.Pipeline {
 	return mongo.Pipeline{
 		{{Key: "$match", Value: bson.M{"$or": bson.A{
 			bson.M{"sectId": orgID},
 			bson.M{"deptId": orgID},
 		}}}},
-		// Narrow before the joins: both lookups run once per matched user, so a
-		// full user document here is carried through the whole pipeline. Only the
-		// fields later stages actually read survive (_id is implicit).
+		// Narrow first: both joins run per matched user, multiplying every byte kept.
 		{{Key: "$project", Value: bson.M{
 			"account":    1,
 			"siteId":     1,
@@ -420,9 +412,8 @@ func orgMembersPipeline(roomID, orgID string) mongo.Pipeline {
 			"tcName": bson.M{"$cond": bson.A{
 				bson.M{"$eq": bson.A{"$deptId", orgID}}, "$deptTCName", "$sectTCName"}},
 		}}},
-		// $lookup justification: the individual-membership flag must be computed
-		// per user in the same pass. The alternative is one extra round trip per
-		// org member; this join's sub-pipeline is $limit 1 projecting only _id.
+		// $lookup justification: per-user membership flag in the same pass; the
+		// alternative is one round trip per org member.
 		{{Key: "$lookup", Value: bson.M{
 			"from": "room_members",
 			"let":  bson.M{"uid": "$_id"},
@@ -443,9 +434,8 @@ func orgMembersPipeline(roomID, orgID string) mongo.Pipeline {
 		// being removed)? If yes, the user remains a member via that sibling
 		// even after the current org is dropped, so processRemoveOrg must NOT
 		// delete their subscription.
-		// $lookup justification: same-pass sibling-org check. It cannot be
-		// denormalised onto the user because the answer depends on the room being
-		// modified, and a per-member query would be one round trip per member.
+		// $lookup justification: sibling-org check depends on the room being
+		// modified, so it cannot be denormalised onto the user.
 		{{Key: "$lookup", Value: bson.M{
 			"from": "room_members",
 			"let":  bson.M{"sectId": "$sectId", "deptId": "$deptId"},
@@ -558,8 +548,7 @@ func (s *MongoStore) BulkCreateSubscriptions(ctx context.Context, subs []*model.
 		filter := bson.M{"roomId": sub.RoomID, "u.account": sub.User.Account}
 		models = append(models, mongoutil.UpsertModel(filter, bson.M{"$setOnInsert": sub}))
 	}
-	// Chunked: an org add can present tens of thousands of candidates, and one
-	// BulkWrite carrying all of them is a single outsized command.
+	// Chunked: an org add can present tens of thousands of candidates.
 	if _, err := mongoutil.ChunkedBulkWrite(ctx, s.subscriptions, models, mongoutil.MaxBulkChunk); err != nil {
 		return fmt.Errorf("bulk create %d subscriptions: %w", len(subs), err)
 	}

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -329,6 +329,10 @@ func (s *MongoStore) GetUserWithMembership(ctx context.Context, roomID, account 
 		// has member.id = deptId. Checking only sectId would miss that case
 		// and report HasOrgMembership=false, causing the remove flow to drop
 		// the user's subscription even though they are still org-attached.
+		// $lookup justification: single-document read whose two joins resolve
+		// one user's membership and subscription in one round trip, each
+		// sub-pipeline $limit 1. Splitting it would triple the round trips on
+		// the remove path's first call.
 		{{Key: "$lookup", Value: bson.M{
 			"from": "room_members",
 			"let":  bson.M{"sectId": "$sectId", "deptId": "$deptId"},
@@ -345,6 +349,8 @@ func (s *MongoStore) GetUserWithMembership(ctx context.Context, roomID, account 
 			},
 			"as": "orgMembership",
 		}}},
+		// $lookup justification: see above — same single-user, single-round-trip
+		// read; this half answers "does the user still hold a subscription".
 		{{Key: "$lookup", Value: bson.M{
 			"from": "subscriptions",
 			"let":  bson.M{"acct": "$account"},
@@ -385,12 +391,28 @@ func (s *MongoStore) GetUserWithMembership(ctx context.Context, roomID, account 
 	return &result, nil
 }
 
-func (s *MongoStore) GetOrgMembersWithIndividualStatus(ctx context.Context, roomID, orgID string) ([]OrgMemberStatus, error) {
-	pipeline := mongo.Pipeline{
+// orgMembersPipeline builds the org-member status aggregation. It is separated
+// from the query so the stage order — in particular that the narrowing $project
+// precedes the two correlated $lookups — is unit-testable without Mongo.
+func orgMembersPipeline(roomID, orgID string) mongo.Pipeline {
+	return mongo.Pipeline{
 		{{Key: "$match", Value: bson.M{"$or": bson.A{
 			bson.M{"sectId": orgID},
 			bson.M{"deptId": orgID},
 		}}}},
+		// Narrow before the joins: both lookups run once per matched user, so a
+		// full user document here is carried through the whole pipeline. Only the
+		// fields later stages actually read survive (_id is implicit).
+		{{Key: "$project", Value: bson.M{
+			"account":    1,
+			"siteId":     1,
+			"sectId":     1,
+			"deptId":     1,
+			"deptName":   1,
+			"sectName":   1,
+			"deptTCName": 1,
+			"sectTCName": 1,
+		}}},
 		{{Key: "$addFields", Value: bson.M{
 			"isDept": bson.M{"$eq": bson.A{"$deptId", orgID}},
 			"name": bson.M{"$cond": bson.A{
@@ -398,6 +420,9 @@ func (s *MongoStore) GetOrgMembersWithIndividualStatus(ctx context.Context, room
 			"tcName": bson.M{"$cond": bson.A{
 				bson.M{"$eq": bson.A{"$deptId", orgID}}, "$deptTCName", "$sectTCName"}},
 		}}},
+		// $lookup justification: the individual-membership flag must be computed
+		// per user in the same pass. The alternative is one extra round trip per
+		// org member; this join's sub-pipeline is $limit 1 projecting only _id.
 		{{Key: "$lookup", Value: bson.M{
 			"from": "room_members",
 			"let":  bson.M{"uid": "$_id"},
@@ -418,6 +443,9 @@ func (s *MongoStore) GetOrgMembersWithIndividualStatus(ctx context.Context, room
 		// being removed)? If yes, the user remains a member via that sibling
 		// even after the current org is dropped, so processRemoveOrg must NOT
 		// delete their subscription.
+		// $lookup justification: same-pass sibling-org check. It cannot be
+		// denormalised onto the user because the answer depends on the room being
+		// modified, and a per-member query would be one round trip per member.
 		{{Key: "$lookup", Value: bson.M{
 			"from": "room_members",
 			"let":  bson.M{"sectId": "$sectId", "deptId": "$deptId"},
@@ -447,7 +475,10 @@ func (s *MongoStore) GetOrgMembersWithIndividualStatus(ctx context.Context, room
 			"hasOtherOrgMembership":   bson.M{"$gt": bson.A{bson.M{"$size": "$otherOrgMembership"}, 0}},
 		}}},
 	}
-	cursor, err := s.users.Aggregate(ctx, pipeline)
+}
+
+func (s *MongoStore) GetOrgMembersWithIndividualStatus(ctx context.Context, roomID, orgID string) ([]OrgMemberStatus, error) {
+	cursor, err := s.users.Aggregate(ctx, orgMembersPipeline(roomID, orgID))
 	if err != nil {
 		return nil, fmt.Errorf("aggregate org members: %w", err)
 	}

--- a/room-worker/store_pipeline_test.go
+++ b/room-worker/store_pipeline_test.go
@@ -28,9 +28,8 @@ func indexOf(names []string, want string) int {
 	return -1
 }
 
-// The two correlated $lookups run once per matched user, so every byte carried
-// into them is multiplied. Narrowing the document before the joins is what keeps
-// a 5k-person department from dragging 5k full user documents through both.
+// Both $lookups run once per matched user, so narrowing first is what keeps a
+// 5k-person department from dragging 5k full documents through them.
 func TestOrgMembersPipeline_NarrowsDocumentBeforeLookups(t *testing.T) {
 	names := stageNames(t, orgMembersPipeline("room-1", "org-1"))
 
@@ -44,16 +43,14 @@ func TestOrgMembersPipeline_NarrowsDocumentBeforeLookups(t *testing.T) {
 	assert.Equal(t, "$match", names[0], "the indexed $match selects the org before anything else runs")
 }
 
-// The early projection is only safe if it keeps every field the later stages
-// read; dropping one would silently blank a name or break the sibling-org join.
+// Dropping a field here would silently blank a name or break the sibling join.
 func TestOrgMembersPipeline_EarlyProjectionKeepsFieldsLaterStagesRead(t *testing.T) {
 	p := orgMembersPipeline("room-1", "org-1")
 	names := stageNames(t, p)
 	early, ok := p[indexOf(names, "$project")][0].Value.(bson.M)
 	require.True(t, ok, "early $project is a bson.M")
 
-	// _id feeds the individual-membership lookup; sectId/deptId feed the
-	// sibling-org lookup and the isDept/name/tcName computations.
+	// _id feeds the membership lookup; sectId/deptId feed the sibling-org join.
 	for _, field := range []string{"account", "siteId", "sectId", "deptId", "deptName", "sectName", "deptTCName", "sectTCName"} {
 		assert.Contains(t, early, field, "early projection must keep %q for a later stage", field)
 	}

--- a/room-worker/store_pipeline_test.go
+++ b/room-worker/store_pipeline_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// stageNames returns each pipeline stage's operator, in order.
+func stageNames(t *testing.T, p []bson.D) []string {
+	t.Helper()
+	names := make([]string, 0, len(p))
+	for _, stage := range p {
+		require.Len(t, stage, 1, "each aggregation stage carries exactly one operator")
+		names = append(names, stage[0].Key)
+	}
+	return names
+}
+
+func indexOf(names []string, want string) int {
+	for i, n := range names {
+		if n == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// The two correlated $lookups run once per matched user, so every byte carried
+// into them is multiplied. Narrowing the document before the joins is what keeps
+// a 5k-person department from dragging 5k full user documents through both.
+func TestOrgMembersPipeline_NarrowsDocumentBeforeLookups(t *testing.T) {
+	names := stageNames(t, orgMembersPipeline("room-1", "org-1"))
+
+	firstProject := indexOf(names, "$project")
+	firstLookup := indexOf(names, "$lookup")
+
+	require.NotEqual(t, -1, firstProject, "pipeline must project")
+	require.NotEqual(t, -1, firstLookup, "pipeline must join room_members")
+	assert.Less(t, firstProject, firstLookup,
+		"an early $project must narrow the user document before the correlated lookups: got order %v", names)
+	assert.Equal(t, "$match", names[0], "the indexed $match selects the org before anything else runs")
+}
+
+// The early projection is only safe if it keeps every field the later stages
+// read; dropping one would silently blank a name or break the sibling-org join.
+func TestOrgMembersPipeline_EarlyProjectionKeepsFieldsLaterStagesRead(t *testing.T) {
+	p := orgMembersPipeline("room-1", "org-1")
+	names := stageNames(t, p)
+	early, ok := p[indexOf(names, "$project")][0].Value.(bson.M)
+	require.True(t, ok, "early $project is a bson.M")
+
+	// _id feeds the individual-membership lookup; sectId/deptId feed the
+	// sibling-org lookup and the isDept/name/tcName computations.
+	for _, field := range []string{"account", "siteId", "sectId", "deptId", "deptName", "sectName", "deptTCName", "sectTCName"} {
+		assert.Contains(t, early, field, "early projection must keep %q for a later stage", field)
+	}
+	assert.NotContains(t, early, "_id", "_id is retained implicitly; excluding it would break the membership lookup")
+}


### PR DESCRIPTION
Fixes the `critical` and all four `high` performance findings from a production-readiness audit of `room-worker`. Every change is behaviour-preserving except where noted, and each was written test-first.

## The defects

**`critical` — nothing extended the ack deadline.** `AckWait` is 30s (`pkg/stream/consumer.go:17`) and no handler in the repo called `InProgress()`. Any handler that ran longer was redelivered mid-flight, so a second worker began the same job concurrently — for a large-room removal that means a duplicate key rotation and a duplicate fan-out to every survivor. Removing a member from a ~5k-member room, or reconciling a Teams batch of more than about twenty chats, crosses that line.

**`high` — rename read every subscription document in the room.** `processRoomRename` called `ListByRoom` and used only `sub.User.Account`. A 5k-member rename shipped 5k full documents (roles, read state, timestamps) to extract one string each.

**`high` — the remove paths ran an unconditional full-room double count.** `ReconcileMemberCounts` is two `CountDocuments` over the whole room, called on every removal. Dropping one member from a 50k-member room cost two full index scans; an org removal that freed nobody paid the same price for a no-op.

**`high` — the org-member aggregation carried whole user documents into two correlated `$lookup`s.** Projection was the last stage, so removing a 5,000-person department dragged 5k full user docs through both joins inside one 30s `AckWait`.

**`high` — bulk writes were unchunked.** `BulkCreateSubscriptions` and `BulkCreateRoomMembers` built one `WriteModel` per candidate and sent them as a single `BulkWrite`; a 20k-user org add became one 20k-model command held whole in memory.

## The changes

| Area | Change |
|---|---|
| `pkg/jsretry/heartbeat.go` | New `Heartbeat` (per-message ticker calling `InProgress` until stopped) and `HeartbeatInterval` (`AckWait/3`, so two ticks fit in the budget and one lost tick is survivable). A non-positive `AckWait` disables it rather than inventing an interval; a failing `InProgress` ends the loop instead of spamming the log. |
| `room-worker/main.go` | Consumer loop starts the heartbeat and stops it from the same defer that finishes the tracked message, so the goroutine terminates on the panic path too. |
| `room-worker/handler.go` | Rename uses the already-projected `GetSubscriptionAccounts`. Both remove paths `$inc` an exact delta via `ApplyMemberCountDelta` and recompute only when the TTL reports a drift check due. |
| `room-worker/store_mongo.go` | Narrowing `$project` moved ahead of the two `$lookup`s; the pipeline is extracted to `orgMembersPipeline` so stage order is unit-testable without Mongo. |
| `pkg/mongoutil/bulk.go` | New `ChunkedBulkWrite`: unordered batches of `MaxBulkChunk` (1000), results merged with `UpsertedIDs` ordinals rebased onto the whole input so per-chunk indexes cannot collide. |

### Redelivery safety

The remove-path deltas are keyed on what the delete **actually removed**, never on what it targeted:

- individual: `DeletedCount == 0` (a redelivery finding the sub already gone) applies nothing
- org: a partial delete falls back to the authoritative full recompute, since the target set no longer describes what left

`finishCreateRoom` and the Teams reconcile deliberately keep `ReconcileMemberCounts`. Those paths pass the full intended set rather than a live-state diff, so a delta there would double-count on redelivery — recompute-and-`$set` is what makes them idempotent.

The user/bot split comes from a new `subIsBot`, extracted so the flag stamped at subscription creation has exactly one definition and the counter being decremented is the one the add path incremented.

Chunks are not atomic with respect to one another; that is safe here because every model these paths build is an upsert, so a retry re-applies cleanly.

## Also included

The four `$lookup` sites carried explanatory prose but not the `// $lookup justification:` marker CLAUDE.md requires — now added. `ListByRoom`'s doc comment claimed it was test-only, which stopped being true when the Teams reconcile path started using it (it genuinely needs full documents to diff `joinedAt`); the comment now says so.

## Deliberately not included

- **"Drop the second `FindUsersByAccounts` on the add path"** — I disagree with this audit recommendation. `lookupAccounts` is a *subset* of candidates, so widening `ListAddMemberCandidates` to full user projections trades one round trip for a wider query over a superset; on a re-add where most candidates already hold subs it is a net regression.
- **Mongo `SetTimeout`** (`pkg/mongoutil`) and a **`thread_subscriptions (roomId, userAccount)` index** — both land outside `room-worker` and change behaviour for every service; they want their own change.
- **`fanOutKey` worker pool** — concurrency is already semaphore-bounded by `keyFanoutWorkers`; a rewrite would save goroutine-creation cost only.

## Verification

- `make test` — full repo pass, `-race`
- `golangci-lint run ./...` — 0 issues
- `make sast-gosec` — exit 0, no findings
- `room-worker` coverage 62.9% → 63.3% (still under the 80% floor; that is a separate audit finding, not in this PR's scope)
- `govulncheck` and semgrep's registry ruleset are proxy-blocked (403) in this environment, so CI remains authoritative for those two

Test-first throughout: each red test was confirmed failing before its implementation landed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBGxDVzzDGJ8VfWxz5rhzy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added heartbeat support to keep message processing active during long-running tasks.
  * Added chunked bulk database writes for large operations.
* **Bug Fixes**
  * Improved room member and organization removal counts, including safer redelivery handling.
  * Optimized room rename and membership queries.
  * Improved handling of partial bulk operations and large organization updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->