### PR TITLE
Queue preview warm-backs off the request path

### DIFF
--- a/history-service/cmd/main.go
+++ b/history-service/cmd/main.go
@@ -54,6 +54,10 @@ func checkConfig(cfg *config.Config) {
 	}
 }
 
+// previewDrainTimeout caps the preview warm-back drain at shutdown, well inside the 25s
+// total so the closers after it keep their share.
+const previewDrainTimeout = 3 * time.Second
+
 func main() {
 	logctx.SetupDefault(os.Stdout)
 
@@ -259,7 +263,14 @@ func main() {
 		func(ctx context.Context) error { return router.Shutdown(ctx) },
 		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
 		// After the router stops (no new warm-backs queued), before Mongo closes under them.
-		func(ctx context.Context) error { return svc.Close(ctx) },
+		// On its own sub-budget: the drain is optional work, and letting a deep queue on a
+		// slow Mongo spend the shared window would starve the steps below it — Mongo,
+		// Cassandra, Vault, and the telemetry flush that reports this shutdown at all.
+		func(ctx context.Context) error {
+			ctx, cancel := context.WithTimeout(ctx, previewDrainTimeout)
+			defer cancel()
+			return svc.Close(ctx)
+		},
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, mongoClient); return nil },
 		func(ctx context.Context) error { cassutil.Close(cassSession); return nil },
 		func(ctx context.Context) error {

--- a/history-service/cmd/main.go
+++ b/history-service/cmd/main.go
@@ -258,6 +258,8 @@ func main() {
 	shutdown.Wait(ctx, 25*time.Second,
 		func(ctx context.Context) error { return router.Shutdown(ctx) },
 		func(ctx context.Context) error { return natsutil.Drain(ctx, nc) },
+		// After the router stops (no new warm-backs queued), before Mongo closes under them.
+		func(ctx context.Context) error { return svc.Close(ctx) },
 		func(ctx context.Context) error { mongoutil.Disconnect(ctx, mongoClient); return nil },
 		func(ctx context.Context) error { cassutil.Close(cassSession); return nil },
 		func(ctx context.Context) error {

--- a/history-service/internal/config/config.go
+++ b/history-service/internal/config/config.go
@@ -106,6 +106,14 @@ type Config struct {
 	UserCacheSize int           `env:"USER_CACHE_SIZE" envDefault:"10000"`
 	UserCacheTTL  time.Duration `env:"USER_CACHE_TTL"  envDefault:"5m"`
 
+	// Background writer that stores walk-resolved previews back onto the room doc,
+	// off the request path. Queue depth is what bounds the memory a burst of cold
+	// rooms can pin; overflow sheds the write, which the next read re-derives.
+	// Non-positive takes the built-in default for either — warm-back is what keeps
+	// the lazy walk from repeating forever, so there is no disable value.
+	PreviewWarmBackWorkers int `env:"PREVIEW_WARMBACK_WORKERS" envDefault:"8"`
+	PreviewWarmBackQueue   int `env:"PREVIEW_WARMBACK_QUEUE"   envDefault:"1024"`
+
 	Atrest atrest.Config      // env vars are already prefixed ATREST_*
 	Vault  atrest.VaultConfig // env vars are already prefixed (VAULT_*, ATREST_VAULT_*)
 
@@ -158,6 +166,14 @@ func validate(cfg *Config) error {
 	}
 	if cfg.UserCacheTTL < 0 {
 		return fmt.Errorf("USER_CACHE_TTL must be >= 0, got %s", cfg.UserCacheTTL)
+	}
+	// Non-positive means "take the default" here, not "disable", so only a negative
+	// is rejected — it would otherwise read as an intent the wiring cannot honour.
+	if cfg.PreviewWarmBackWorkers < 0 {
+		return fmt.Errorf("PREVIEW_WARMBACK_WORKERS must be >= 0, got %d", cfg.PreviewWarmBackWorkers)
+	}
+	if cfg.PreviewWarmBackQueue < 0 {
+		return fmt.Errorf("PREVIEW_WARMBACK_QUEUE must be >= 0, got %d", cfg.PreviewWarmBackQueue)
 	}
 	if _, err := mongoutil.ParseReadPreference(cfg.Mongo.ReadPreference); err != nil {
 		return fmt.Errorf("MONGO_READ_PREFERENCE: %w", err)

--- a/history-service/internal/config/config_test.go
+++ b/history-service/internal/config/config_test.go
@@ -24,8 +24,11 @@ func baseValid() Config {
 		PreviewKeyEpoch:  1,
 		PreviewCacheSize: 50000,
 		PreviewCacheTTL:  10 * time.Second,
-		Pool:             mongoutil.PoolConfig{MaxPoolSize: 500, MinPoolSize: 0},
-		Guard:            natsrouter.GuardConfig{MaxConcurrency: 256, RequestTimeout: 10 * time.Second},
+
+		PreviewWarmBackWorkers: 8,
+		PreviewWarmBackQueue:   1024,
+		Pool:                   mongoutil.PoolConfig{MaxPoolSize: 500, MinPoolSize: 0},
+		Guard:                  natsrouter.GuardConfig{MaxConcurrency: 256, RequestTimeout: 10 * time.Second},
 	}
 }
 
@@ -109,6 +112,46 @@ func TestValidate_RejectsNegativePreviewCacheTTL(t *testing.T) {
 	err := validate(&cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "HISTORY_PREVIEW_CACHE_TTL")
+}
+
+func TestValidate_RejectsNegativeWarmBackSizes(t *testing.T) {
+	tests := []struct {
+		name string
+		set  func(*Config)
+		want string
+	}{
+		{name: "workers", set: func(c *Config) { c.PreviewWarmBackWorkers = -1 }, want: "PREVIEW_WARMBACK_WORKERS"},
+		{name: "queue", set: func(c *Config) { c.PreviewWarmBackQueue = -1 }, want: "PREVIEW_WARMBACK_QUEUE"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseValid()
+			tc.set(&cfg)
+			err := validate(&cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+// Zero is "take the default", not "disable": warm-back is what stops the lazy walk
+// repeating forever, so the wiring never turns it off.
+func TestValidate_AcceptsZeroWarmBackSizesAsDefaults(t *testing.T) {
+	cfg := baseValid()
+	cfg.PreviewWarmBackWorkers = 0
+	cfg.PreviewWarmBackQueue = 0
+	require.NoError(t, validate(&cfg))
+}
+
+func TestLoad_WarmBackDefaults(t *testing.T) {
+	setRequiredEnv(t)
+	unsetEnv(t, "PREVIEW_WARMBACK_WORKERS")
+	unsetEnv(t, "PREVIEW_WARMBACK_QUEUE")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, 8, cfg.PreviewWarmBackWorkers)
+	assert.Equal(t, 1024, cfg.PreviewWarmBackQueue)
 }
 
 // The epoch is part of the preview DEK id, so a non-positive value mints a

--- a/history-service/internal/service/appname_test.go
+++ b/history-service/internal/service/appname_test.go
@@ -15,7 +15,7 @@ import (
 func newAppNameService(t *testing.T, apps AppStore) *HistoryService {
 	t.Helper()
 	ctrl := gomock.NewController(t)
-	return New(
+	return closeOnCleanupIn(t, New(
 		mocks.NewMockMessageRepository(ctrl),
 		mocks.NewMockSubscriptionRepository(ctrl),
 		mocks.NewMockRoomRepository(ctrl),
@@ -25,7 +25,7 @@ func newAppNameService(t *testing.T, apps AppStore) *HistoryService {
 		mocks.NewMockUserStore(ctrl),
 		apps,
 		&config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10},
-	)
+	))
 }
 
 // A bot's app name is stable, but a busy room renders the same bot on every reaction.

--- a/history-service/internal/service/integration_test.go
+++ b/history-service/internal/service/integration_test.go
@@ -183,12 +183,12 @@ func TestEditMessage_Integration(t *testing.T) {
 	session := setupCassandra(t)
 	repo := cassrepo.NewRepository(session, msgbucket.New(24*time.Hour), 365, nil)
 	pub := &recordingPublisher{}
-	svc := New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, pub, nil, nil, nil, nil, &config.Config{
+	svc := closeOnCleanupIn(t, New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, pub, nil, nil, nil, nil, &config.Config{
 		MessageHistoryFloorDays: 730,
 		LargeRoomThreshold:      500,
 		MaxPinnedPerRoom:        10,
 		PinEnabled:              true,
-	})
+	}))
 
 	sender := models.Participant{ID: "u1", Account: "alice"}
 	roomID := "r-integ"
@@ -247,12 +247,12 @@ func TestDeleteMessage_Integration(t *testing.T) {
 	session := setupCassandra(t)
 	repo := cassrepo.NewRepository(session, msgbucket.New(24*time.Hour), 365, nil)
 	pub := &recordingPublisher{}
-	svc := New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, pub, nil, nil, nil, nil, &config.Config{
+	svc := closeOnCleanupIn(t, New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, pub, nil, nil, nil, nil, &config.Config{
 		MessageHistoryFloorDays: 730,
 		LargeRoomThreshold:      500,
 		MaxPinnedPerRoom:        10,
 		PinEnabled:              true,
-	})
+	}))
 
 	sender := models.Participant{ID: "u1", Account: "alice"}
 	roomID := "r-del-integ"
@@ -309,12 +309,12 @@ func TestDeleteMessage_ParentWithReplies_NoCascade(t *testing.T) {
 	session := setupCassandra(t)
 	repo := cassrepo.NewRepository(session, msgbucket.New(24*time.Hour), 365, nil)
 	pub := &recordingPublisher{}
-	svc := New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, pub, nil, nil, nil, nil, &config.Config{
+	svc := closeOnCleanupIn(t, New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, pub, nil, nil, nil, nil, &config.Config{
 		MessageHistoryFloorDays: 730,
 		LargeRoomThreshold:      500,
 		MaxPinnedPerRoom:        10,
 		PinEnabled:              true,
-	})
+	}))
 
 	sender := models.Participant{ID: "u1", Account: "alice"}
 	roomID := "r-parent-cascade"
@@ -378,12 +378,12 @@ func TestDeleteMessage_Integration_ThreadReplyPublishesMetadataEvent(t *testing.
 	session := setupCassandra(t)
 	repo := cassrepo.NewRepository(session, msgbucket.New(24*time.Hour), 365, nil)
 	pub := &recordingPublisher{}
-	svc := New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, pub, nil, nil, nil, nil, &config.Config{
+	svc := closeOnCleanupIn(t, New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, pub, nil, nil, nil, nil, &config.Config{
 		MessageHistoryFloorDays: 730,
 		LargeRoomThreshold:      500,
 		MaxPinnedPerRoom:        10,
 		PinEnabled:              true,
-	})
+	}))
 
 	sender := models.Participant{ID: "u1", Account: "alice"}
 	roomID := "r-thread-meta-event"

--- a/history-service/internal/service/messages_lastmsgat_test.go
+++ b/history-service/internal/service/messages_lastmsgat_test.go
@@ -30,7 +30,7 @@ func TestLoadHistory_MissingLastMsgAt_ReturnsMessages(t *testing.T) {
 	users := mocks.NewMockUserStore(ctrl)
 	apps := mocks.NewMockAppStore(ctrl)
 	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true}
-	s := New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg)
+	s := closeOnCleanupIn(t, New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg))
 
 	createdAt := time.Now().UTC().Add(-120 * 24 * time.Hour)
 	rooms.EXPECT().GetRoomTimes(gomock.Any(), "r1").Return(time.Time{}, createdAt, nil)

--- a/history-service/internal/service/messages_test.go
+++ b/history-service/internal/service/messages_test.go
@@ -89,7 +89,7 @@ func newServiceWithRoomMock(t *testing.T, opts ...service.Option) (*service.Hist
 		MaxPinnedPerRoom:        10,
 		PinEnabled:              true,
 	}
-	return service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg, opts...), msgs, subs, rooms, pub, threadRooms, users, apps
+	return closeOnCleanup(t, service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg, opts...)), msgs, subs, rooms, pub, threadRooms, users, apps
 }
 
 // assertInternalErr verifies err collapses to the generic "internal error" envelope at the
@@ -342,7 +342,7 @@ func TestHistoryService_LoadHistory_AccessErrorTakesPrecedence(t *testing.T) {
 		MaxPinnedPerRoom:        10,
 		PinEnabled:              true,
 	}
-	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg)
+	svc := closeOnCleanup(t, service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg))
 	c := testContext()
 
 	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, false, errors.New("access db error"))

--- a/history-service/internal/service/pagefit_integration_test.go
+++ b/history-service/internal/service/pagefit_integration_test.go
@@ -28,9 +28,9 @@ func TestLoadHistory_TrimmedPagination_Integration(t *testing.T) {
 
 	// A budget that admits only a handful of these rows, so the walk takes
 	// several trimmed pages rather than one.
-	svc := New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, &recordingPublisher{}, nil, nil, nil, nil,
+	svc := closeOnCleanupIn(t, New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, &recordingPublisher{}, nil, nil, nil, nil,
 		&config.Config{MessageHistoryFloorDays: 730, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true},
-		WithPageBudget(pagefit.NewBudget(8<<10, 0)))
+		WithPageBudget(pagefit.NewBudget(8<<10, 0))))
 
 	const (
 		roomID  = "r-pagefit"
@@ -95,9 +95,9 @@ func TestLoadHistory_TrimmedPagination_Integration(t *testing.T) {
 func TestLoadHistory_EqualTimestampsSurviveTrimming_Integration(t *testing.T) {
 	session := setupCassandra(t)
 	repo := cassrepo.NewRepository(session, msgbucket.New(24*time.Hour), 365, nil)
-	svc := New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, &recordingPublisher{}, nil, nil, nil, nil,
+	svc := closeOnCleanupIn(t, New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, &recordingPublisher{}, nil, nil, nil, nil,
 		&config.Config{MessageHistoryFloorDays: 730, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true},
-		WithPageBudget(pagefit.NewBudget(6<<10, 0)))
+		WithPageBudget(pagefit.NewBudget(6<<10, 0))))
 
 	const (
 		roomID  = "r-ties"

--- a/history-service/internal/service/pin_test.go
+++ b/history-service/internal/service/pin_test.go
@@ -59,7 +59,7 @@ func newPinTestService(t *testing.T) (*service.HistoryService, *mocks.MockMessag
 		MaxPinnedPerRoom:        testMaxPinnedPerRoom,
 		PinEnabled:              true,
 	}
-	return service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg), msgs, subs, rooms, pub, threadRooms
+	return closeOnCleanup(t, service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg)), msgs, subs, rooms, pub, threadRooms
 }
 
 // testMaxPinnedPerRoom: kept small (3) so fixtures stay short.
@@ -116,12 +116,12 @@ func TestPinMessage_KillSwitchDisabled(t *testing.T) {
 		Return(defaultRoomLastMsgAt, defaultRoomCreatedAt, nil).
 		MinTimes(0)
 	rooms.EXPECT().GetMinUserLastSeenAt(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
-	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, &config.Config{
+	svc := closeOnCleanup(t, service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, &config.Config{
 		MessageHistoryFloorDays: 90,
 		LargeRoomThreshold:      500,
 		MaxPinnedPerRoom:        testMaxPinnedPerRoom,
 		PinEnabled:              false,
-	})
+	}))
 
 	_, err := svc.PinMessage(testContext(), "site-a", models.PinMessageRequest{MessageID: "m1"})
 

--- a/history-service/internal/service/preview_repair_test.go
+++ b/history-service/internal/service/preview_repair_test.go
@@ -29,7 +29,7 @@ func newRepairFixture(t *testing.T) *repairFixture {
 	rooms := mocks.NewMockRoomRepository(ctrl)
 	return &repairFixture{
 		rooms: rooms,
-		svc: New(
+		svc: closeOnCleanupIn(t, New(
 			mocks.NewMockMessageRepository(ctrl),
 			mocks.NewMockSubscriptionRepository(ctrl),
 			rooms,
@@ -39,7 +39,7 @@ func newRepairFixture(t *testing.T) *repairFixture {
 			mocks.NewMockUserStore(ctrl),
 			mocks.NewMockAppStore(ctrl),
 			&config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10},
-		),
+		)),
 	}
 }
 
@@ -113,4 +113,14 @@ func TestPersistMutatedPreview_SkippedWalkTouchesNothing(t *testing.T) {
 	f := newRepairFixture(t)
 	f.svc.persistMutatedPreview(natsrouter.NewContext(nil), "r1", "m1",
 		&previewWalk{State: previewSkipped}, time.Now().UTC())
+}
+
+// closeOnCleanupIn drains the service's background preview writer when the test ends. New
+// starts those workers, so every construction needs a termination path. The in-package
+// twin of closeOnCleanup in rooms_test.go; this file is untagged, so the integration
+// build sees it too.
+func closeOnCleanupIn(t *testing.T, svc *HistoryService) *HistoryService {
+	t.Helper()
+	t.Cleanup(func() { _ = svc.Close(context.Background()) })
+	return svc
 }

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -27,12 +27,9 @@ const (
 	lastMsgWalkMaxScan   = 250
 	lastMsgWalkMaxPage   = cassrepo.MaxPageSize
 
-	// Bounds the optional write: it runs before the reply, so a stall can't eat the deadline.
+	// Bounds one preview write. Shared with the mutation path's repair (persistMutatedPreview),
+	// which stays inline because withdrawing a stale preview is correctness, not optimization.
 	warmBackTimeout = 2 * time.Second
-	// warmBackReserve is the budget left for the reply itself. Below timeout+reserve the
-	// warm-back is skipped: it holds one of maxRoomsGetConcurrency slots for its whole
-	// run, so on a cold batch the waves compound and would otherwise overrun the request.
-	warmBackReserve = 250 * time.Millisecond
 )
 
 // RoomsGet returns each room's list preview from the doc, falling back to the walk so a
@@ -154,24 +151,22 @@ func (s *HistoryService) resolvePreview(ctx context.Context, roomID string, rt m
 
 // warmBackPreview stores a walk-resolved preview, making an eager-path miss self-healing.
 // asOf is walk time: on createdAt, an edited room would reject this write forever.
+//
+// Queued rather than written here: the write is optional and the reply is not, and sharing
+// the request's budget skipped it exactly where it mattered — a cold batch is what leaves
+// no budget, and a room that never warms back is what makes the next batch cold. See
+// previewWarmer.
 func (s *HistoryService) warmBackPreview(ctx context.Context, roomID string, w *previewWalk, now time.Time) {
 	// No observed id means no key to invalidate against later.
 	if w.NewestObservedID == "" {
 		return
 	}
-	// Storing the preview is optional; returning it is not. A skipped warm-back costs one
-	// re-walk on a later read, when the budget may be whole — overrunning costs the reply.
-	if dl, ok := ctx.Deadline(); ok && time.Until(dl) < warmBackTimeout+warmBackReserve {
-		slog.DebugContext(ctx, "room preview warm-back skipped; too little request budget left",
-			"room_id", roomID, "request_id", natsutil.RequestIDFromContext(ctx))
-		return
-	}
-	wctx, cancel := context.WithTimeout(ctx, warmBackTimeout)
-	defer cancel()
-	if err := s.rooms.SetPreviewMessage(wctx, roomID, w.Preview, w.NewestObservedID, now.UnixMilli()); err != nil {
-		slog.WarnContext(ctx, "room preview warm-back failed", "room_id", roomID,
-			"request_id", natsutil.RequestIDFromContext(ctx), "error", err)
-	}
+	s.warmer.Submit(ctx, &warmBackJob{
+		roomID:   roomID,
+		preview:  w.Preview,
+		forMsgID: w.NewestObservedID,
+		asOf:     now.UnixMilli(),
+	})
 }
 
 // previewResolveState separates previewEmpty (safe to clear) from previewDegraded (unknown).

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,10 +22,19 @@ import (
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/pkg/natsrouter"
+	"github.com/hmchangw/chat/pkg/natsutil"
 )
 
 // newRoomsService builds a service with bare mocks; WithPreviewCache exercises the cache.
 func newRoomsService(t *testing.T, opts ...service.Option) (*service.HistoryService, *mocks.MockMessageRepository, *mocks.MockRoomRepository) {
+	return newRoomsServiceWithWarmer(t, 0, 0, opts...)
+}
+
+// newRoomsServiceWithWarmer sizes the background preview writer, for the tests that assert
+// on saturation; non-positive values take the production defaults. Warm-backs are queued,
+// so every caller drains on cleanup — that is what makes the mock's call count
+// deterministic. Registered after gomock's own cleanup so it runs first (LIFO).
+func newRoomsServiceWithWarmer(t *testing.T, warmWorkers, warmQueue int, opts ...service.Option) (*service.HistoryService, *mocks.MockMessageRepository, *mocks.MockRoomRepository) {
 	ctrl := gomock.NewController(t)
 	msgs := mocks.NewMockMessageRepository(ctrl)
 	subs := mocks.NewMockSubscriptionRepository(ctrl)
@@ -34,9 +44,22 @@ func newRoomsService(t *testing.T, opts ...service.Option) (*service.HistoryServ
 	threadSubs := mocks.NewMockThreadSubscriptionRepository(ctrl)
 	users := mocks.NewMockUserStore(ctrl)
 	apps := mocks.NewMockAppStore(ctrl)
-	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true}
-	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg, opts...)
+	cfg := &config.Config{
+		MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true,
+		PreviewWarmBackWorkers: warmWorkers, PreviewWarmBackQueue: warmQueue,
+	}
+	svc := closeOnCleanup(t, service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg, opts...))
 	return svc, msgs, rooms
+}
+
+// closeOnCleanup drains the service's background preview writer when the test ends. New
+// starts those workers, so every construction needs a termination path — and draining is
+// also what makes a queued warm-back's call count deterministic for the mock. Registered
+// after gomock's own cleanup so it runs first (LIFO).
+func closeOnCleanup(t *testing.T, svc *service.HistoryService) *service.HistoryService {
+	t.Helper()
+	t.Cleanup(func() { _ = svc.Close(context.Background()) })
+	return svc
 }
 
 func roomsCtx() *natsrouter.Context {
@@ -107,6 +130,7 @@ func TestHistoryService_RoomsGet_WarmBackIsOrderedByWalkTimeNotMessageAge(t *tes
 
 	_, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
 	require.NoError(t, err)
+	require.NoError(t, svc.Close(context.Background()), "the warm-back is queued; drain before reading what it wrote")
 
 	assert.GreaterOrEqual(t, gotAsOf, before, "the watermark must be the walk's own clock")
 	assert.NotEqual(t, old.CreatedAt.UnixMilli(), gotAsOf, "ordering by the message's age deadlocks against mutation watermarks")
@@ -410,10 +434,11 @@ func TestHistoryService_RoomsGet_TooManyHints_BadRequest(t *testing.T) {
 	require.Error(t, err)
 }
 
-// The warm-back is optional and holds one of the 16 lazy slots while it runs. When the
-// request budget cannot absorb it, serving the preview must beat storing it: a skipped
-// warm-back costs one re-walk on a later read, an overrun costs the whole response.
-func TestHistoryService_RoomsGet_SkipsWarmBackWhenTheRequestBudgetCannotAbsorbIt(t *testing.T) {
+// A spent request budget must not decide whether a room ever heals. The warm-back is
+// queued, not written inline, so the write keeps its own clock: the rooms that most need
+// repair are exactly the ones whose walk left no budget behind, and skipping them there
+// made the miss permanent — the next read re-walks, stays slow, and skips again.
+func TestHistoryService_RoomsGet_WarmsBackEvenWhenTheRequestBudgetIsSpent(t *testing.T) {
 	svc, msgs, rooms := newRoomsService(t)
 	walked := walkedMsg("r1", "m-walked", "resolved lazily")
 
@@ -421,7 +446,11 @@ func TestHistoryService_RoomsGet_SkipsWarmBackWhenTheRequestBudgetCannotAbsorbIt
 		Return(map[string]mongorepo.RoomTimes{"r1": storedRow(nil)}, nil)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{walked}, false), nil)
-	// No SetPreviewMessage expectation: a warm-back on this budget fails the test.
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), "r1", gomock.Any(), "m-walked", gomock.Any()).
+		DoAndReturn(func(ctx context.Context, _ string, _ model.PreviewMessage, _ string, _ int64) error {
+			assert.NoError(t, ctx.Err(), "the queued write must not inherit the request's exhausted budget")
+			return nil
+		}).Times(1)
 
 	rc := roomsCtx()
 	deadlined, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
@@ -430,8 +459,159 @@ func TestHistoryService_RoomsGet_SkipsWarmBackWhenTheRequestBudgetCannotAbsorbIt
 
 	resp, err := svc.RoomsGet(rc, models.RoomsGetRequest{RoomIDs: []string{"r1"}})
 	require.NoError(t, err)
-	assert.Equal(t, "m-walked", resp.Rooms["r1"].MessageID,
-		"the resolved preview is still served when its warm-back is skipped")
+	assert.Equal(t, "m-walked", resp.Rooms["r1"].MessageID)
+	require.NoError(t, svc.Close(context.Background()))
+}
+
+// The client hanging up cancels the request, never the repair it already paid for: the
+// walk has run, and dropping its result would make the next reader run it again.
+func TestHistoryService_RoomsGet_WarmBackSurvivesRequestCancellation(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+	walked := walkedMsg("r1", "m-walked", "resolved lazily")
+
+	rc := roomsCtx()
+	cancellable, cancel := context.WithCancel(context.Background())
+	rc.SetContext(cancellable)
+
+	rooms.EXPECT().GetRoomTimesByIDs(gomock.Any(), gomock.Any()).
+		Return(map[string]mongorepo.RoomTimes{"r1": storedRow(nil)}, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{walked}, false), nil)
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), "r1", gomock.Any(), "m-walked", gomock.Any()).
+		DoAndReturn(func(ctx context.Context, _ string, _ model.PreviewMessage, _ string, _ int64) error {
+			assert.NoError(t, ctx.Err(), "a cancelled request must not cancel the queued write")
+			return nil
+		}).Times(1)
+
+	_, err := svc.RoomsGet(rc, models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	cancel()
+	require.NoError(t, svc.Close(context.Background()))
+}
+
+// Detaching from the request must not detach from its logs: the write is still that
+// request's work, and a warm-back failure is only diagnosable if it names the read.
+func TestHistoryService_RoomsGet_WarmBackCarriesTheRequestID(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+	walked := walkedMsg("r1", "m-walked", "resolved lazily")
+
+	rc := roomsCtx()
+	rc.SetContext(natsutil.WithRequestID(context.Background(), "01970a4f-8c2d-7c9a-abcd-e0123456789f"))
+
+	rooms.EXPECT().GetRoomTimesByIDs(gomock.Any(), gomock.Any()).
+		Return(map[string]mongorepo.RoomTimes{"r1": storedRow(nil)}, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{walked}, false), nil)
+	var gotID string
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), "r1", gomock.Any(), "m-walked", gomock.Any()).
+		DoAndReturn(func(ctx context.Context, _ string, _ model.PreviewMessage, _ string, _ int64) error {
+			gotID = natsutil.RequestIDFromContext(ctx)
+			return nil
+		}).Times(1)
+
+	_, err := svc.RoomsGet(rc, models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.NoError(t, svc.Close(context.Background()))
+	assert.Equal(t, "01970a4f-8c2d-7c9a-abcd-e0123456789f", gotID)
+}
+
+// Saturation drops the write, never the reply. Queueing is what decouples the two, so an
+// unbounded queue would trade the old latency problem for a memory one; a dropped
+// warm-back is self-correcting, since the next read re-walks and re-submits.
+func TestHistoryService_RoomsGet_WarmBackDropsWhenTheWriterIsSaturated(t *testing.T) {
+	svc, msgs, rooms := newRoomsServiceWithWarmer(t, 1, 1)
+	release := make(chan struct{})
+	var writes atomic.Int32
+
+	rooms.EXPECT().GetRoomTimesByIDs(gomock.Any(), gomock.Any()).
+		Return(map[string]mongorepo.RoomTimes{
+			"r1": storedRow(nil), "r2": storedRow(nil), "r3": storedRow(nil), "r4": storedRow(nil),
+		}, nil).AnyTimes()
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, roomID string, _, _ time.Time, _ cassrepo.PageRequest) (cassrepo.Page[models.Message], error) {
+			return makePage([]models.Message{walkedMsg(roomID, "m-"+roomID, "resolved lazily")}, false), nil
+		}).AnyTimes()
+	// The single worker parks on the first write, so the queue fills and the rest are shed.
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(context.Context, string, model.PreviewMessage, string, int64) error {
+			writes.Add(1)
+			<-release
+			return nil
+		}).AnyTimes()
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1", "r2", "r3", "r4"}})
+	require.NoError(t, err)
+	assert.Len(t, resp.Rooms, 4, "every preview is served even when its warm-back is shed")
+
+	close(release)
+	require.NoError(t, svc.Close(context.Background()))
+	assert.LessOrEqual(t, int(writes.Load()), 2, "a saturated writer sheds rather than queues without bound")
+}
+
+// Close is the queue's termination path: shutdown must flush what it accepted, so a
+// warm-back is not silently lost to a deploy.
+func TestHistoryService_Close_DrainsPendingWarmBacks(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+	walked := walkedMsg("r1", "m-walked", "resolved lazily")
+
+	rooms.EXPECT().GetRoomTimesByIDs(gomock.Any(), gomock.Any()).
+		Return(map[string]mongorepo.RoomTimes{"r1": storedRow(nil)}, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{walked}, false), nil)
+	var written atomic.Bool
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), "r1", gomock.Any(), "m-walked", gomock.Any()).
+		DoAndReturn(func(context.Context, string, model.PreviewMessage, string, int64) error {
+			written.Store(true)
+			return nil
+		}).Times(1)
+
+	_, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	require.NoError(t, svc.Close(context.Background()))
+	assert.True(t, written.Load(), "Close must flush the queue it accepted work into")
+}
+
+// A read still in flight when shutdown starts must not send on the closed queue: the
+// warm-back is dropped, and the reply it belongs to is served as normal.
+func TestHistoryService_RoomsGet_WarmBackAfterCloseIsDroppedNotFatal(t *testing.T) {
+	svc, msgs, rooms := newRoomsService(t)
+
+	rooms.EXPECT().GetRoomTimesByIDs(gomock.Any(), gomock.Any()).
+		Return(map[string]mongorepo.RoomTimes{"r1": storedRow(nil)}, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{walkedMsg("r1", "m-walked", "resolved lazily")}, false), nil)
+	// No SetPreviewMessage expectation: the writer is shut, so the job is shed.
+
+	require.NoError(t, svc.Close(context.Background()))
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	assert.Equal(t, "m-walked", resp.Rooms["r1"].MessageID)
+}
+
+// Close is wired into a shutdown chain that may already be out of budget; it must give up
+// on the optional writes rather than hold the whole shutdown past its deadline.
+func TestHistoryService_Close_AbandonsTheDrainOnAnExpiredBudget(t *testing.T) {
+	svc, msgs, rooms := newRoomsServiceWithWarmer(t, 1, 8)
+	release := make(chan struct{})
+	defer close(release)
+
+	rooms.EXPECT().GetRoomTimesByIDs(gomock.Any(), gomock.Any()).
+		Return(map[string]mongorepo.RoomTimes{"r1": storedRow(nil)}, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{walkedMsg("r1", "m-walked", "resolved lazily")}, false), nil)
+	rooms.EXPECT().SetPreviewMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(context.Context, string, model.PreviewMessage, string, int64) error {
+			<-release
+			return nil
+		}).AnyTimes()
+
+	_, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+
+	expired, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	require.Error(t, svc.Close(expired), "an over-budget drain reports rather than blocks")
 }
 
 // Cancellation after the last lazy worker launches must not read as "these rooms have no

--- a/history-service/internal/service/service.go
+++ b/history-service/internal/service/service.go
@@ -180,6 +180,8 @@ type HistoryService struct {
 	maxPinnedPerRoom   int
 	pinEnabled         bool // from PIN_ENABLED env var; false disables pin/unpin globally
 	previewCache       PreviewCache
+	// warmer stores walk-resolved previews off the request path; Close drains it.
+	warmer *previewWarmer
 	// pageBudget caps a paginated reply so it is trimmed to fit the broker
 	// rather than refused by it. Zero value disables trimming.
 	pageBudget pagefit.Budget
@@ -212,6 +214,7 @@ func New(
 		maxPinnedPerRoom:   cfg.MaxPinnedPerRoom,
 		pinEnabled:         cfg.PinEnabled,
 	}
+	s.warmer = newPreviewWarmer(rooms, cfg.PreviewWarmBackWorkers, cfg.PreviewWarmBackQueue, warmBackTimeout)
 	// A method value derefs its receiver where written, so this is guarded, not eager.
 	if apps != nil {
 		s.appName = preview.CachedAppNameLookup(apps.AppNameByAccount)
@@ -220,6 +223,13 @@ func New(
 		opt(s)
 	}
 	return s
+}
+
+// Close stops the background preview writer and waits for its queue to drain. Call once
+// the router has stopped accepting requests and before the Mongo client closes; ctx bounds
+// the drain, and an expired one abandons the remaining writes rather than holding shutdown.
+func (s *HistoryService) Close(ctx context.Context) error {
+	return s.warmer.Close(ctx)
 }
 
 // RegisterHandlers wires all NATS endpoints. Panics on subscription failure (fatal at startup).

--- a/history-service/internal/service/sysmsgname_test.go
+++ b/history-service/internal/service/sysmsgname_test.go
@@ -95,7 +95,7 @@ func TestExtractRemovedAccount(t *testing.T) {
 func newSysMsgNameService(t *testing.T, users UserStore) *HistoryService {
 	t.Helper()
 	ctrl := gomock.NewController(t)
-	return New(
+	return closeOnCleanupIn(t, New(
 		mocks.NewMockMessageRepository(ctrl),
 		mocks.NewMockSubscriptionRepository(ctrl),
 		mocks.NewMockRoomRepository(ctrl),
@@ -105,7 +105,7 @@ func newSysMsgNameService(t *testing.T, users UserStore) *HistoryService {
 		users,
 		mocks.NewMockAppStore(ctrl),
 		&config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10},
-	)
+	))
 }
 
 // legacyRemoved builds a legacy members_removed row for the given account.

--- a/history-service/internal/service/threadlist_test.go
+++ b/history-service/internal/service/threadlist_test.go
@@ -46,7 +46,7 @@ func newThreadListService(t *testing.T) (
 	users := mocks.NewMockUserStore(ctrl)
 	apps := mocks.NewMockAppStore(ctrl)
 	cfg := &config.Config{MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true}
-	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg)
+	svc := closeOnCleanup(t, service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg))
 	return svc, msgs, subs, rooms, threadSubs
 }
 

--- a/history-service/internal/service/threads_test.go
+++ b/history-service/internal/service/threads_test.go
@@ -383,7 +383,7 @@ func TestHistoryService_GetThreadMessages_NoRoomTimesDependency(t *testing.T) {
 		MaxPinnedPerRoom:        10,
 		PinEnabled:              true,
 	}
-	svc := service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg)
+	svc := closeOnCleanup(t, service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg))
 	c := testContext()
 
 	parent := &models.Message{MessageID: "m-parent", RoomID: "r1", CreatedAt: joinTime.Add(5 * time.Minute), ThreadRoomID: "tr-1", TCount: intPtr(1)}

--- a/history-service/internal/service/warmback.go
+++ b/history-service/internal/service/warmback.go
@@ -1,0 +1,133 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/hmchangw/chat/history-service/internal/models"
+	"github.com/hmchangw/chat/pkg/natsutil"
+)
+
+const (
+	defaultWarmBackWorkers = 8
+	defaultWarmBackQueue   = 1024
+)
+
+// warmBackJob is one resolved preview waiting to be stored. Queued by pointer: it is
+// allocated once at the submit site and read by exactly one worker, so the alternative is
+// copying its embedded preview through the channel. It carries the request id
+// rather than the request context: a queued job outlives its request, and holding that
+// context would pin the whole *natsrouter.Context — including the inbound message body —
+// for as long as the job sits in the queue.
+type warmBackJob struct {
+	roomID    string
+	preview   models.PreviewMessage
+	forMsgID  string
+	asOf      int64
+	requestID string
+}
+
+// previewWarmer stores walk-resolved previews off the request path.
+//
+// The write is optional; the reply is not. Running it inline made the two share a budget,
+// so it was skipped whenever the request had less than a couple of seconds left — which is
+// exactly the case a cold, slow batch produces. A room that never warms back re-walks on
+// the next read, stays slow, and skips again: the repair switched itself off precisely
+// where it was needed. Queued, the write keeps its own clock and a spent request budget no
+// longer decides whether a room ever heals.
+//
+// Bounded on both axes, because unbounded background work would trade the latency problem
+// for a memory one: workers cap concurrent writes, the queue caps what a burst can pin, and
+// a full queue sheds the job rather than blocking the reply behind it.
+type previewWarmer struct {
+	rooms   RoomRepository
+	jobs    chan *warmBackJob
+	wg      sync.WaitGroup
+	timeout time.Duration
+
+	// Guards jobs against a send racing Close's close(). Read-locked on the hot path,
+	// so submits contend only with shutdown.
+	mu     sync.RWMutex
+	closed bool
+}
+
+// newPreviewWarmer starts the writer's workers. Non-positive sizes take the defaults:
+// warm-back is what stops the lazy walk repeating forever, so "off" is not an option the
+// wiring offers.
+func newPreviewWarmer(rooms RoomRepository, workers, queue int, timeout time.Duration) *previewWarmer {
+	if workers <= 0 {
+		workers = defaultWarmBackWorkers
+	}
+	if queue <= 0 {
+		queue = defaultWarmBackQueue
+	}
+	w := &previewWarmer{rooms: rooms, jobs: make(chan *warmBackJob, queue), timeout: timeout}
+	w.wg.Add(workers)
+	for range workers {
+		go w.run()
+	}
+	return w
+}
+
+// Submit queues a warm-back, dropping it when the writer is saturated. Never blocks: the
+// reply it precedes must not wait on an optional write, and a dropped job is self-
+// correcting — the next read re-walks the room and submits again.
+func (w *previewWarmer) Submit(ctx context.Context, job *warmBackJob) {
+	job.requestID = natsutil.RequestIDFromContext(ctx)
+
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	if w.closed {
+		return
+	}
+	select {
+	case w.jobs <- job:
+	default:
+		slog.DebugContext(ctx, "room preview warm-back dropped; writer queue full",
+			"room_id", job.roomID, "request_id", job.requestID)
+	}
+}
+
+func (w *previewWarmer) run() {
+	defer w.wg.Done()
+	for job := range w.jobs {
+		w.store(job)
+	}
+}
+
+// store performs one write on a fresh budget, detached from the request that produced it.
+func (w *previewWarmer) store(job *warmBackJob) {
+	ctx, cancel := context.WithTimeout(natsutil.WithRequestID(context.Background(), job.requestID), w.timeout)
+	defer cancel()
+	if err := w.rooms.SetPreviewMessage(ctx, job.roomID, job.preview, job.forMsgID, job.asOf); err != nil {
+		slog.WarnContext(ctx, "room preview warm-back failed", "room_id", job.roomID,
+			"request_id", job.requestID, "error", err)
+	}
+}
+
+// Close stops accepting work and waits for the queue to drain, giving up when ctx expires
+// so a wedged Mongo cannot hold the whole shutdown past its deadline — the writes are
+// optional, and a later read re-derives what they would have stored. Idempotent.
+func (w *previewWarmer) Close(ctx context.Context) error {
+	w.mu.Lock()
+	if !w.closed {
+		w.closed = true
+		close(w.jobs)
+	}
+	w.mu.Unlock()
+
+	// The workers' own timeout bounds every in-flight write, so this goroutine always ends.
+	drained := make(chan struct{})
+	go func() {
+		w.wg.Wait()
+		close(drained)
+	}()
+	select {
+	case <-drained:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/history-service/internal/service/warmback.go
+++ b/history-service/internal/service/warmback.go
@@ -6,6 +6,10 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+
 	"github.com/hmchangw/chat/history-service/internal/models"
 	"github.com/hmchangw/chat/pkg/natsutil"
 )
@@ -27,6 +31,35 @@ type warmBackJob struct {
 	forMsgID  string
 	asOf      int64
 	requestID string
+}
+
+// warmBackMetrics counts what the queue would otherwise hide. A shed job and a failed
+// write are both ways a room silently stays on the lazy walk, which is the failure this
+// whole path exists to end — and at saturation they arrive too fast to log one by one.
+// Instruments are no-ops without a MeterProvider, so recording is always safe.
+type warmBackMetrics struct {
+	stored  metric.Int64Counter
+	dropped metric.Int64Counter
+	failed  metric.Int64Counter
+}
+
+var warmBackCounters = newWarmBackMetrics(otel.Meter("history_preview_warmback"))
+
+func newWarmBackMetrics(m metric.Meter) warmBackMetrics {
+	stored, sErr := m.Int64Counter("preview_warmback_stored_total",
+		metric.WithDescription("Walk-resolved room previews written back to the room document."))
+	dropped, dErr := m.Int64Counter("preview_warmback_dropped_total",
+		metric.WithDescription("Room preview warm-backs shed because the writer queue was full."))
+	failed, fErr := m.Int64Counter("preview_warmback_failed_total",
+		metric.WithDescription("Room preview warm-backs that reached the store and failed to write."))
+	if sErr != nil || dErr != nil || fErr != nil {
+		// Recording must never be conditional on the meter having accepted the instruments.
+		n := noop.NewMeterProvider().Meter("history_preview_warmback")
+		stored, _ = n.Int64Counter("preview_warmback_stored_total")
+		dropped, _ = n.Int64Counter("preview_warmback_dropped_total")
+		failed, _ = n.Int64Counter("preview_warmback_failed_total")
+	}
+	return warmBackMetrics{stored: stored, dropped: dropped, failed: failed}
 }
 
 // previewWarmer stores walk-resolved previews off the request path.
@@ -85,6 +118,7 @@ func (w *previewWarmer) Submit(ctx context.Context, job *warmBackJob) {
 	select {
 	case w.jobs <- job:
 	default:
+		warmBackCounters.dropped.Add(ctx, 1)
 		slog.DebugContext(ctx, "room preview warm-back dropped; writer queue full",
 			"room_id", job.roomID, "request_id", job.requestID)
 	}
@@ -102,9 +136,12 @@ func (w *previewWarmer) store(job *warmBackJob) {
 	ctx, cancel := context.WithTimeout(natsutil.WithRequestID(context.Background(), job.requestID), w.timeout)
 	defer cancel()
 	if err := w.rooms.SetPreviewMessage(ctx, job.roomID, job.preview, job.forMsgID, job.asOf); err != nil {
+		warmBackCounters.failed.Add(ctx, 1)
 		slog.WarnContext(ctx, "room preview warm-back failed", "room_id", job.roomID,
 			"request_id", job.requestID, "error", err)
+		return
 	}
+	warmBackCounters.stored.Add(ctx, 1)
 }
 
 // Close stops accepting work and waits for the queue to drain, giving up when ctx expires


### PR DESCRIPTION
## Summary

Decouples the optional preview warm-back write from the request path by introducing a background worker queue. Previously, warm-backs were written inline and skipped when the request budget was exhausted — exactly the scenario (cold batches with no budget) where they were most needed. Now they're queued asynchronously, keeping their own clock and allowing rooms to self-heal even when the originating request times out.

## Key Changes

- **New `previewWarmer` type** (`warmback.go`): Background worker pool that stores walk-resolved previews off the request path. Bounded on both axes (configurable workers and queue depth) to prevent unbounded memory growth. Drops jobs when saturated rather than blocking the reply, since a dropped write is self-correcting — the next read re-walks and resubmits.

- **Configuration** (`config.go`): Added `PreviewWarmBackWorkers` and `PreviewWarmBackQueue` with defaults (8 workers, 1024 queue depth). Non-positive values take the defaults; negative values are rejected. Warm-back is mandatory (no disable option) since it's what prevents the lazy walk from repeating forever.

- **Service integration** (`service.go`): `HistoryService` now owns a `previewWarmer` instance. `New()` constructs it with configured sizes; `Close()` drains the queue on shutdown, ensuring no warm-backs are silently lost to a deploy.

- **Request path simplification** (`rooms.go`): `warmBackPreview()` now submits to the queue instead of writing inline. Removed the budget-check logic (`warmBackTimeout + warmBackReserve`) that was skipping writes on cold batches. The write gets a fresh timeout and carries the request ID for observability.

- **Test infrastructure** (`rooms_test.go`): 
  - Refactored `newRoomsService()` to call `newRoomsServiceWithWarmer()`, allowing tests to configure worker/queue sizes
  - Added `closeOnCleanup()` helper to drain the warmer on test cleanup (LIFO ordering ensures it runs before gomock cleanup)
  - New test cases:
    - `TestHistoryService_RoomsGet_WarmsBackEvenWhenTheRequestBudgetIsSpent`: Verifies warm-backs proceed with a fresh budget even when the request is exhausted
    - `TestHistoryService_RoomsGet_WarmBackSurvivesRequestCancellation`: Confirms cancellation doesn't cancel the queued write
    - `TestHistoryService_RoomsGet_WarmBackCarriesTheRequestID`: Ensures request ID propagates for logging
    - `TestHistoryService_RoomsGet_WarmBackDropsWhenTheWriterIsSaturated`: Validates saturation drops jobs without blocking replies
    - `TestHistoryService_Close_DrainsPendingWarmBacks`: Confirms shutdown flushes the queue
    - `TestHistoryService_RoomsGet_WarmBackAfterCloseIsDroppedNotFatal`: Verifies in-flight reads after close don't panic
    - `TestHistoryService_Close_AbandonsTheDrainOnAnExpiredBudget`: Ensures shutdown respects its own deadline

- **Shutdown integration** (`main.go`): Warmer drain added to the shutdown chain after the router stops, so no new warm-backs are queued during shutdown.

- **Other test files** (`pin_test.go`, `messages_test.go`, `threadlist_test.go`, `threads_test.go`): Updated to use `closeOnCleanup()` for consistent cleanup.

## Implementation Details

- **Job structure**: `warmBackJob` carries room ID, preview, message ID, timestamp, and request ID. Allocated once at submit and read by exactly one worker to avoid copying the preview through the channel.

- **Context handling**: Warm-back jobs detach from the request context (which may expire) but preserve the request ID via `natsutil.WithRequestID()` for tracing. Each write gets its own timeout (`warmBackTimeout = 2s`).

- **Saturation strategy**: Non-blocking submit with `select` on the channel. Dropped jobs are logged at debug level and

https://claude.ai/code/session_011o5A8dMtG2TGXWa3pYiKBF