### PR TITLE
test(user-service): close the unit-coverage gaps the readiness audit found

### DIFF
--- a/user-service/historyclient/client_threadlist_test.go
+++ b/user-service/historyclient/client_threadlist_test.go
@@ -1,0 +1,163 @@
+package historyclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+// respondThreadList subscribes the site's thread-list subject with a canned raw
+// reply, capturing the request body the client put on the wire.
+func respondThreadList(t *testing.T, nc *o11ynats.Conn, siteID string, reply []byte) *[]byte {
+	t.Helper()
+	got := new([]byte)
+	sub, err := nc.Subscribe(context.Background(), subject.ThreadSubscriptionList(siteID), func(_ context.Context, m *nats.Msg) {
+		*got = append([]byte(nil), m.Data...)
+		_ = m.Respond(reply)
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+	return got
+}
+
+func TestClient_GetThreadList(t *testing.T) {
+	t.Run("happy path — request is marshaled and reply decodes", func(t *testing.T) {
+		nc := startTestNATS(t)
+
+		cursorAt := int64(1700000000000)
+		reply, err := json.Marshal(model.ThreadSubscriptionListResponse{
+			Items: []model.ThreadListItem{
+				{SiteID: "site-a", RoomID: "r1", ThreadRoomID: "t1", LastMsgAt: 42, TCount: 3, Unread: true},
+				{SiteID: "site-a", RoomID: "r2", ThreadRoomID: "t2", LastMsgAt: 41},
+			},
+			HasMore: true,
+		})
+		require.NoError(t, err)
+		gotBody := respondThreadList(t, nc, "site-a", reply)
+
+		out, err := New(nc).GetThreadList(context.Background(), "site-a", model.ThreadSubscriptionListRequest{
+			Account:            "alice",
+			CursorLastMsgAt:    &cursorAt,
+			CursorThreadRoomID: "t9",
+			Limit:              25,
+		})
+		require.NoError(t, err)
+
+		var sent model.ThreadSubscriptionListRequest
+		require.NoError(t, json.Unmarshal(*gotBody, &sent))
+		assert.Equal(t, "alice", sent.Account)
+		require.NotNil(t, sent.CursorLastMsgAt)
+		assert.Equal(t, cursorAt, *sent.CursorLastMsgAt)
+		assert.Equal(t, "t9", sent.CursorThreadRoomID)
+		assert.Equal(t, 25, sent.Limit)
+
+		require.Len(t, out.Items, 2)
+		assert.Equal(t, "t1", out.Items[0].ThreadRoomID)
+		assert.Equal(t, int64(42), out.Items[0].LastMsgAt)
+		assert.Equal(t, 3, out.Items[0].TCount)
+		assert.True(t, out.Items[0].Unread)
+		assert.Equal(t, "t2", out.Items[1].ThreadRoomID)
+		assert.True(t, out.HasMore)
+	})
+
+	t.Run("zero-value request — nil cursor is omitted from the wire body", func(t *testing.T) {
+		nc := startTestNATS(t)
+
+		reply, err := json.Marshal(model.ThreadSubscriptionListResponse{})
+		require.NoError(t, err)
+		gotBody := respondThreadList(t, nc, "site-a", reply)
+
+		out, err := New(nc).GetThreadList(context.Background(), "site-a", model.ThreadSubscriptionListRequest{})
+		require.NoError(t, err)
+		assert.Empty(t, out.Items)
+		assert.False(t, out.HasMore)
+
+		var raw map[string]any
+		require.NoError(t, json.Unmarshal(*gotBody, &raw))
+		assert.NotContains(t, raw, "cursorLastMsgAt")
+		assert.NotContains(t, raw, "cursorThreadRoomId")
+	})
+
+	t.Run("empty page — empty items decode to an empty, non-error response", func(t *testing.T) {
+		nc := startTestNATS(t)
+		respondThreadList(t, nc, "site-a", []byte(`{"items":[],"hasMore":false}`))
+
+		out, err := New(nc).GetThreadList(context.Background(), "site-a", model.ThreadSubscriptionListRequest{Account: "alice", Limit: 10})
+		require.NoError(t, err)
+		assert.Empty(t, out.Items)
+		assert.False(t, out.HasMore)
+	})
+
+	t.Run("errcode reply — remote classification is relayed via errcode.Parse", func(t *testing.T) {
+		nc := startTestNATS(t)
+		envelope, err := json.Marshal(errcode.NotFound("thread not found"))
+		require.NoError(t, err)
+		respondThreadList(t, nc, "site-a", envelope)
+
+		out, err := New(nc).GetThreadList(context.Background(), "site-a", model.ThreadSubscriptionListRequest{Account: "alice", Limit: 10})
+		require.Error(t, err)
+		var e *errcode.Error
+		require.True(t, errors.As(err, &e))
+		assert.Equal(t, errcode.CodeNotFound, e.Code)
+		assert.Equal(t, model.ThreadSubscriptionListResponse{}, out)
+	})
+
+	t.Run("malformed reply — non-JSON body surfaces a decode error", func(t *testing.T) {
+		nc := startTestNATS(t)
+		respondThreadList(t, nc, "site-a", []byte("not json at all"))
+
+		out, err := New(nc).GetThreadList(context.Background(), "site-a", model.ThreadSubscriptionListRequest{Account: "alice", Limit: 10})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "decode thread-list response")
+		assert.Equal(t, model.ThreadSubscriptionListResponse{}, out)
+	})
+
+	t.Run("type-mismatched reply — wrong JSON shape surfaces a decode error", func(t *testing.T) {
+		nc := startTestNATS(t)
+		respondThreadList(t, nc, "site-a", []byte(`{"items":"nope"}`))
+
+		_, err := New(nc).GetThreadList(context.Background(), "site-a", model.ThreadSubscriptionListRequest{Account: "alice", Limit: 10})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "decode thread-list response")
+	})
+
+	t.Run("no responder — request failure is classified unavailable", func(t *testing.T) {
+		nc := startTestNATS(t)
+		// Intentionally no subscriber on the thread-list subject.
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		out, err := New(nc).GetThreadList(ctx, "site-a", model.ThreadSubscriptionListRequest{Account: "alice", Limit: 10})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "thread-list rpc")
+		var e *errcode.Error
+		require.True(t, errors.As(err, &e))
+		assert.Equal(t, errcode.CodeUnavailable, e.Code)
+		assert.Equal(t, model.ThreadSubscriptionListResponse{}, out)
+	})
+
+	t.Run("wrong site — a responder on another site's subject is not reached", func(t *testing.T) {
+		nc := startTestNATS(t)
+		reply, err := json.Marshal(model.ThreadSubscriptionListResponse{HasMore: true})
+		require.NoError(t, err)
+		respondThreadList(t, nc, "site-b", reply)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err = New(nc).GetThreadList(ctx, "site-a", model.ThreadSubscriptionListRequest{Account: "alice", Limit: 10})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "thread-list rpc")
+	})
+}

--- a/user-service/oidc_test.go
+++ b/user-service/oidc_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/user-service/config"
+)
+
+// newDiscoveryStub serves an in-process OIDC discovery document (loopback only,
+// no outbound network) — enough for pkgoidc.NewValidator, which fetches only the
+// well-known metadata at construction time; JWKS is fetched lazily on verify.
+func newDiscoveryStub(t *testing.T, withTokenEndpoint bool) string {
+	t.Helper()
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		doc := map[string]any{
+			"issuer":                                srv.URL,
+			"jwks_uri":                              srv.URL + "/keys",
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		}
+		if withTokenEndpoint {
+			doc["token_endpoint"] = srv.URL + "/token"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(doc))
+	})
+	return srv.URL
+}
+
+func TestOIDCValidator_Unconfigured(t *testing.T) {
+	t.Run("empty issuer URL yields a no-op validator, not an error", func(t *testing.T) {
+		v, r, err := oidcValidator(context.Background(), &config.Config{OIDCIssuerURL: ""})
+		require.NoError(t, err)
+		assert.Nil(t, v, "sso.set must reply unavailable when OIDC is unconfigured")
+		assert.Nil(t, r, "sso.refresh must reply unavailable when OIDC is unconfigured")
+	})
+
+	t.Run("empty issuer URL short-circuits before any other OIDC config is read", func(t *testing.T) {
+		// Audiences/ClientID/TLSSkipVerify are all set, but the unset issuer wins.
+		v, r, err := oidcValidator(context.Background(), &config.Config{
+			OIDCIssuerURL: "",
+			OIDCAudiences: []string{"nats-chat"},
+			OIDCClientID:  "nats-chat",
+			TLSSkipVerify: true,
+		})
+		require.NoError(t, err)
+		assert.Nil(t, v)
+		assert.Nil(t, r)
+	})
+}
+
+func TestOIDCValidator_ConstructionErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     config.Config
+		wantErr string
+	}{
+		{
+			// pkgoidc.NewValidator rejects an empty audience list before any I/O.
+			name:    "issuer set but no audiences",
+			cfg:     config.Config{OIDCIssuerURL: "https://issuer.invalid/realms/chat"},
+			wantErr: "init oidc validator",
+		},
+		{
+			name: "no audiences with TLS verification disabled",
+			cfg: config.Config{
+				OIDCIssuerURL: "https://issuer.invalid/realms/chat",
+				TLSSkipVerify: true,
+			},
+			wantErr: "init oidc validator",
+		},
+		{
+			name: "malformed issuer URL",
+			cfg: config.Config{
+				OIDCIssuerURL: "://not-a-url",
+				OIDCAudiences: []string{"nats-chat"},
+				OIDCClientID:  "nats-chat",
+			},
+			wantErr: "init oidc validator",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, r, err := oidcValidator(context.Background(), &tt.cfg)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tt.wantErr)
+			assert.Nil(t, v)
+			assert.Nil(t, r)
+		})
+	}
+}
+
+func TestOIDCValidator_Configured(t *testing.T) {
+	t.Run("reachable issuer returns the same value as validator and refresher", func(t *testing.T) {
+		issuer := newDiscoveryStub(t, true)
+
+		v, r, err := oidcValidator(context.Background(), &config.Config{
+			OIDCIssuerURL: issuer,
+			OIDCAudiences: []string{"nats-chat"},
+			OIDCClientID:  "nats-chat",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, v)
+		require.NotNil(t, r)
+		assert.Same(t, v, r, "validator and refresher must be the same *oidc.Validator")
+	})
+
+	t.Run("TLS verification disabled still builds a validator", func(t *testing.T) {
+		issuer := newDiscoveryStub(t, true)
+
+		v, r, err := oidcValidator(context.Background(), &config.Config{
+			OIDCIssuerURL: issuer,
+			OIDCAudiences: []string{"nats-chat"},
+			OIDCClientID:  "nats-chat",
+			TLSSkipVerify: true,
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, v)
+		assert.NotNil(t, r)
+	})
+
+	t.Run("issuer without token_endpoint but with client ID fails fast", func(t *testing.T) {
+		issuer := newDiscoveryStub(t, false)
+
+		v, r, err := oidcValidator(context.Background(), &config.Config{
+			OIDCIssuerURL: issuer,
+			OIDCAudiences: []string{"nats-chat"},
+			OIDCClientID:  "nats-chat",
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "init oidc validator")
+		assert.Nil(t, v)
+		assert.Nil(t, r)
+	})
+}

--- a/user-service/presenceclient/client_test.go
+++ b/user-service/presenceclient/client_test.go
@@ -1,0 +1,236 @@
+package presenceclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+// startTestNATS spins up an embedded, in-process NATS server (no Docker) for
+// request/reply unit tests.
+func startTestNATS(t *testing.T) *o11ynats.Conn {
+	t.Helper()
+	ns, err := natsserver.NewServer(&natsserver.Options{Port: -1})
+	require.NoError(t, err)
+	ns.Start()
+	require.True(t, ns.ReadyForConnections(5*time.Second), "nats server did not become ready")
+	t.Cleanup(ns.Shutdown)
+
+	nc, err := o11ynats.Connect(context.Background(), ns.ClientURL(), noop.NewTracerProvider(), propagation.TraceContext{})
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+	return nc
+}
+
+// stubResponder answers every request on subj with reply. Received messages are
+// pushed onto the returned buffered channel so a test can assert on the wire
+// request without sharing mutable state across goroutines.
+func stubResponder(t *testing.T, nc *o11ynats.Conn, subj string, reply []byte) <-chan *nats.Msg {
+	t.Helper()
+	got := make(chan *nats.Msg, 8)
+	sub, err := nc.Subscribe(context.Background(), subj, func(_ context.Context, m *nats.Msg) {
+		got <- m
+		_ = m.Respond(reply)
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+	return got
+}
+
+// silentResponder subscribes without ever replying, so the caller's ctx
+// deadline (not a bare missing subscriber) ends the request.
+func silentResponder(t *testing.T, nc *o11ynats.Conn, subj string) {
+	t.Helper()
+	sub, err := nc.Subscribe(context.Background(), subj, func(_ context.Context, _ *nats.Msg) {})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}
+
+// requireErrcode asserts err carries an *errcode.Error and returns it.
+func requireErrcode(t *testing.T, err error) *errcode.Error {
+	t.Helper()
+	require.Error(t, err)
+	var e *errcode.Error
+	require.True(t, errors.As(err, &e), "want *errcode.Error, got %T: %v", err, err)
+	return e
+}
+
+func TestNew(t *testing.T) {
+	nc := startTestNATS(t)
+	c := New(nc)
+	require.NotNil(t, c)
+	assert.Same(t, nc, c.nc)
+}
+
+func TestClient_QueryPresence_Subject(t *testing.T) {
+	nc := startTestNATS(t)
+	got := stubResponder(t, nc, "chat.server.request.presence.>", mustJSON(t, model.PresenceQueryResponse{}))
+
+	_, err := New(nc).QueryPresence(context.Background(), "site-a", []string{"alice", "bob"})
+	require.NoError(t, err)
+
+	m := <-got
+	assert.Equal(t, "chat.server.request.presence.site-a.query.batch", m.Subject)
+	assert.Equal(t, subject.PresenceQueryBatchPeer("site-a"), m.Subject)
+
+	var req model.PresenceQuery
+	require.NoError(t, json.Unmarshal(m.Data, &req))
+	assert.Equal(t, []string{"alice", "bob"}, req.Accounts)
+}
+
+func TestClient_QueryPresence_ReplyHandling(t *testing.T) {
+	tests := []struct {
+		name   string
+		reply  []byte
+		assert func(t *testing.T, states []model.PresenceState, err error)
+	}{
+		{
+			name: "happy path decodes states",
+			reply: mustJSON(t, model.PresenceQueryResponse{
+				States: []model.PresenceState{
+					{Account: "alice", SiteID: "site-a", Status: model.StatusOnline},
+					{Account: "bob", SiteID: "site-a", Status: model.StatusAway},
+				},
+				Timestamp: 1717000000000,
+			}),
+			assert: func(t *testing.T, states []model.PresenceState, err error) {
+				require.NoError(t, err)
+				require.Len(t, states, 2)
+				assert.Equal(t, "alice", states[0].Account)
+				assert.Equal(t, model.StatusOnline, states[0].Status)
+				assert.Equal(t, "bob", states[1].Account)
+				assert.Equal(t, model.StatusAway, states[1].Status)
+			},
+		},
+		{
+			name:  "empty success envelope yields no states and no error",
+			reply: []byte(`{}`),
+			assert: func(t *testing.T, states []model.PresenceState, err error) {
+				require.NoError(t, err)
+				assert.Empty(t, states)
+			},
+		},
+		{
+			name:  "errcode envelope is relayed with code and reason intact",
+			reply: mustJSON(t, errcode.BadRequest("batch exceeds max", errcode.WithReason(errcode.RequestIDRequired))),
+			assert: func(t *testing.T, _ []model.PresenceState, err error) {
+				e := requireErrcode(t, err)
+				assert.Equal(t, errcode.CodeBadRequest, e.Code)
+				assert.Equal(t, errcode.RequestIDRequired, e.Reason)
+				assert.Equal(t, "batch exceeds max", e.Message)
+			},
+		},
+		{
+			name:  "unknown remote code is relayed, not masked",
+			reply: []byte(`{"code":"upstream_only_code","error":"upstream boom"}`),
+			assert: func(t *testing.T, _ []model.PresenceState, err error) {
+				e := requireErrcode(t, err)
+				assert.Equal(t, "upstream boom", e.Message)
+				assert.Equal(t, errcode.Code("upstream_only_code"), e.Code)
+			},
+		},
+		{
+			name:  "non-JSON reply surfaces a wrapped decode error",
+			reply: []byte(`[`),
+			assert: func(t *testing.T, _ []model.PresenceState, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "decode presence-query response")
+			},
+		},
+		{
+			name:  "JSON of the wrong shape surfaces a wrapped decode error",
+			reply: []byte(`{"states":"not-an-array"}`),
+			assert: func(t *testing.T, _ []model.PresenceState, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "decode presence-query response")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nc := startTestNATS(t)
+			stubResponder(t, nc, subject.PresenceQueryBatchPeer("site-a"), tc.reply)
+
+			states, err := New(nc).QueryPresence(context.Background(), "site-a", []string{"alice"})
+			tc.assert(t, states, err)
+		})
+	}
+}
+
+func TestClient_QueryPresence_EmptyAccounts(t *testing.T) {
+	nc := startTestNATS(t)
+	got := stubResponder(t, nc, subject.PresenceQueryBatchPeer("site-a"), mustJSON(t, model.PresenceQueryResponse{}))
+
+	// The client does not short-circuit an empty batch — it still issues the RPC.
+	states, err := New(nc).QueryPresence(context.Background(), "site-a", nil)
+	require.NoError(t, err)
+	assert.Empty(t, states)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal((<-got).Data, &raw))
+	require.Contains(t, raw, "accounts")
+	assert.Nil(t, raw["accounts"])
+}
+
+func TestClient_QueryPresence_SiteIDRouting(t *testing.T) {
+	nc := startTestNATS(t)
+	// Only site-b has a responder: the query must target the siteID argument.
+	got := stubResponder(t, nc, subject.PresenceQueryBatchPeer("site-b"), mustJSON(t, model.PresenceQueryResponse{
+		States: []model.PresenceState{{Account: "bob", SiteID: "site-b", Status: model.StatusAway}},
+	}))
+
+	states, err := New(nc).QueryPresence(context.Background(), "site-b", []string{"bob"})
+	require.NoError(t, err)
+	require.Len(t, states, 1)
+	assert.Equal(t, model.StatusAway, states[0].Status)
+	assert.Equal(t, "chat.server.request.presence.site-b.query.batch", (<-got).Subject)
+}
+
+func TestClient_QueryPresence_NoResponder(t *testing.T) {
+	nc := startTestNATS(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := New(nc).QueryPresence(ctx, "site-a", []string{"alice"})
+	e := requireErrcode(t, err)
+	assert.Equal(t, errcode.CodeUnavailable, e.Code)
+	assert.Equal(t, errcode.NatsNoResponders, e.Reason)
+	assert.Contains(t, e.Message, "presence-query rpc")
+}
+
+func TestClient_QueryPresence_Timeout(t *testing.T) {
+	nc := startTestNATS(t)
+	silentResponder(t, nc, subject.PresenceQueryBatchPeer("site-a"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	_, err := New(nc).QueryPresence(ctx, "site-a", []string{"alice"})
+	e := requireErrcode(t, err)
+	assert.Equal(t, errcode.CodeUnavailable, e.Code)
+	assert.Equal(t, errcode.NatsRequestTimeout, e.Reason)
+	assert.Contains(t, e.Message, "presence-query rpc")
+}

--- a/user-service/publisher/publisher_test.go
+++ b/user-service/publisher/publisher_test.go
@@ -1,0 +1,267 @@
+package publisher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+
+	"github.com/hmchangw/chat/pkg/natsutil"
+	"github.com/hmchangw/chat/user-service/service"
+)
+
+// Compile-time assertion: both publishers must satisfy the consumer-defined
+// interface they are wired into in main.go.
+var (
+	_ service.EventPublisher = (*CorePublisher)(nil)
+	_ service.EventPublisher = (*Publisher)(nil)
+)
+
+const testRequestID = "01970a4f-8c2d-7c9a-abcd-e0123456789f"
+
+// startEmbeddedNATS boots an in-process NATS server with JetStream enabled (no
+// Docker) and returns a tracing-aware connection plus its JetStream context.
+// Server and connection are torn down via t.Cleanup.
+func startEmbeddedNATS(t *testing.T) (*o11ynats.Conn, o11ynats.JetStream) {
+	t.Helper()
+	opts := &natsserver.Options{Port: -1, JetStream: true, StoreDir: t.TempDir()}
+	ns, err := natsserver.NewServer(opts)
+	require.NoError(t, err)
+	ns.Start()
+	require.True(t, ns.ReadyForConnections(5*time.Second), "nats server did not become ready")
+	t.Cleanup(ns.Shutdown)
+
+	nc, err := o11ynats.Connect(context.Background(), ns.ClientURL(), noop.NewTracerProvider(), propagation.TraceContext{})
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+
+	js, err := nc.JetStream()
+	require.NoError(t, err)
+	return nc, js
+}
+
+// subscribeOne subscribes to subject and returns a channel delivering the first
+// messages received. The subscription is unsubscribed via t.Cleanup.
+func subscribeOne(t *testing.T, nc *o11ynats.Conn, subject string) <-chan *nats.Msg {
+	t.Helper()
+	got := make(chan *nats.Msg, 4)
+	sub, err := nc.Subscribe(context.Background(), subject, func(_ context.Context, m *nats.Msg) {
+		got <- m
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+	return got
+}
+
+// awaitMsg waits for one message or fails the test.
+func awaitMsg(t *testing.T, ch <-chan *nats.Msg) *nats.Msg {
+	t.Helper()
+	select {
+	case m := <-ch:
+		return m
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for published message")
+		return nil
+	}
+}
+
+func TestNewCore_UsesGivenConn(t *testing.T) {
+	nc, _ := startEmbeddedNATS(t)
+
+	p := NewCore(nc)
+
+	require.NotNil(t, p)
+	assert.Same(t, nc, p.nc, "NewCore must retain the connection it was given")
+}
+
+func TestNew_UsesGivenJetStream(t *testing.T) {
+	_, js := startEmbeddedNATS(t)
+
+	p := New(js)
+
+	require.NotNil(t, p)
+	assert.Same(t, js, p.js, "New must retain the JetStream context it was given")
+}
+
+func TestCorePublisher_Publish(t *testing.T) {
+	tests := []struct {
+		name          string
+		subject       string
+		data          []byte
+		requestID     string
+		wantRequestID string
+	}{
+		{
+			name:          "propagates request id from context",
+			subject:       "chat.user.alice.settings.update",
+			data:          []byte(`{"theme":"dark"}`),
+			requestID:     testRequestID,
+			wantRequestID: testRequestID,
+		},
+		{
+			name:          "no request id in context leaves header unset",
+			subject:       "chat.user.bob.settings.update",
+			data:          []byte(`{"theme":"light"}`),
+			requestID:     "",
+			wantRequestID: "",
+		},
+		{
+			name:          "empty payload is delivered as-is",
+			subject:       "chat.user.carol.settings.update",
+			data:          []byte{},
+			requestID:     testRequestID,
+			wantRequestID: testRequestID,
+		},
+		{
+			name:          "binary payload survives round trip",
+			subject:       "chat.user.dave.settings.update",
+			data:          []byte{0x00, 0xff, 0x10, 0x7f},
+			requestID:     testRequestID,
+			wantRequestID: testRequestID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nc, _ := startEmbeddedNATS(t)
+			received := subscribeOne(t, nc, tt.subject)
+
+			ctx := context.Background()
+			if tt.requestID != "" {
+				ctx = natsutil.WithRequestID(ctx, tt.requestID)
+			}
+
+			require.NoError(t, NewCore(nc).Publish(ctx, tt.subject, tt.data))
+
+			got := awaitMsg(t, received)
+			assert.Equal(t, tt.subject, got.Subject)
+			assert.Equal(t, tt.data, got.Data)
+			assert.Equal(t, tt.wantRequestID, got.Header.Get(natsutil.RequestIDHeader))
+		})
+	}
+}
+
+// A core publish is fire-and-forget: it must not be persisted by, or require,
+// any stream — that is the whole point of CorePublisher over Publisher.
+func TestCorePublisher_Publish_NoStreamRequired(t *testing.T) {
+	nc, js := startEmbeddedNATS(t)
+	received := subscribeOne(t, nc, "chat.user.erin.settings.update")
+
+	require.NoError(t, NewCore(nc).Publish(context.Background(), "chat.user.erin.settings.update", []byte(`{}`)))
+	awaitMsg(t, received)
+
+	_, err := js.Stream(context.Background(), "ANY")
+	assert.Error(t, err, "no stream exists; the core publish succeeded anyway")
+}
+
+func TestCorePublisher_Publish_ClosedConn_WrapsError(t *testing.T) {
+	nc, _ := startEmbeddedNATS(t)
+	nc.Close()
+
+	err := NewCore(nc).Publish(context.Background(), "chat.user.alice.settings.update", []byte(`{}`))
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "publish client event", "error must be wrapped with what the caller was doing")
+	assert.ErrorIs(t, err, nats.ErrConnectionClosed, "the underlying cause must stay unwrapped-able")
+}
+
+func TestPublisher_Publish(t *testing.T) {
+	const streamSubjects = "chat.inbox.site-b.external.>"
+
+	tests := []struct {
+		name          string
+		subject       string
+		data          []byte
+		requestID     string
+		wantRequestID string
+	}{
+		{
+			name:          "propagates request id onto the inbox event",
+			subject:       "chat.inbox.site-b.external.subscription_created",
+			data:          []byte(`{"roomId":"r1"}`),
+			requestID:     testRequestID,
+			wantRequestID: testRequestID,
+		},
+		{
+			name:          "no request id in context leaves header unset",
+			subject:       "chat.inbox.site-b.external.subscription_removed",
+			data:          []byte(`{"roomId":"r2"}`),
+			requestID:     "",
+			wantRequestID: "",
+		},
+		{
+			name:          "empty payload is delivered as-is",
+			subject:       "chat.inbox.site-b.external.user_status",
+			data:          []byte{},
+			requestID:     testRequestID,
+			wantRequestID: testRequestID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nc, js := startEmbeddedNATS(t)
+			ctx := context.Background()
+
+			_, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+				Name:     "TEST_INBOX",
+				Subjects: []string{streamSubjects},
+			})
+			require.NoError(t, err)
+
+			received := subscribeOne(t, nc, tt.subject)
+
+			pubCtx := ctx
+			if tt.requestID != "" {
+				pubCtx = natsutil.WithRequestID(pubCtx, tt.requestID)
+			}
+
+			require.NoError(t, New(js).Publish(pubCtx, tt.subject, tt.data))
+
+			got := awaitMsg(t, received)
+			assert.Equal(t, tt.subject, got.Subject)
+			assert.Equal(t, tt.data, got.Data)
+			assert.Equal(t, tt.wantRequestID, got.Header.Get(natsutil.RequestIDHeader))
+
+			// Publish blocks on the PubAck, so by now the event is stored.
+			st, err := js.Stream(ctx, "TEST_INBOX")
+			require.NoError(t, err)
+			info, err := st.Info(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, uint64(1), info.State.Msgs, "the event must be persisted in the destination stream")
+		})
+	}
+}
+
+// No stream owns the subject, so no PubAck ever arrives — the publish must fail
+// (rather than silently dropping a federation event) with a wrapped error.
+func TestPublisher_Publish_NoStreamForSubject_WrapsError(t *testing.T) {
+	_, js := startEmbeddedNATS(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	err := New(js).Publish(ctx, "chat.inbox.nowhere.external.user_status", []byte(`{}`))
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "publish inbox event")
+}
+
+func TestPublisher_Publish_ClosedConn_WrapsError(t *testing.T) {
+	nc, js := startEmbeddedNATS(t)
+	nc.Close()
+
+	err := New(js).Publish(context.Background(), "chat.inbox.site-b.external.user_status", []byte(`{}`))
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "publish inbox event", "error must be wrapped with what the caller was doing")
+}

--- a/user-service/roomclient/client_test.go
+++ b/user-service/roomclient/client_test.go
@@ -1,0 +1,578 @@
+package roomclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+// startTestNATS spins up an embedded, in-process NATS server (no Docker) for
+// request/reply unit tests.
+func startTestNATS(t *testing.T) *o11ynats.Conn {
+	t.Helper()
+	ns, err := natsserver.NewServer(&natsserver.Options{Port: -1})
+	require.NoError(t, err)
+	ns.Start()
+	require.True(t, ns.ReadyForConnections(5*time.Second), "nats server did not become ready")
+	t.Cleanup(ns.Shutdown)
+
+	nc, err := o11ynats.Connect(context.Background(), ns.ClientURL(), noop.NewTracerProvider(), propagation.TraceContext{})
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+	return nc
+}
+
+// stubResponder answers every request on subj with reply. Received messages are
+// pushed onto the returned buffered channel so a test can assert on the wire
+// request without sharing mutable state across goroutines.
+func stubResponder(t *testing.T, nc *o11ynats.Conn, subj string, reply []byte) <-chan *nats.Msg {
+	t.Helper()
+	got := make(chan *nats.Msg, 8)
+	sub, err := nc.Subscribe(context.Background(), subj, func(_ context.Context, m *nats.Msg) {
+		got <- m
+		_ = m.Respond(reply)
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+	return got
+}
+
+// silentResponder subscribes without ever replying, so the caller's ctx
+// deadline (not a bare missing subscriber) ends the request.
+func silentResponder(t *testing.T, nc *o11ynats.Conn, subj string) {
+	t.Helper()
+	sub, err := nc.Subscribe(context.Background(), subj, func(_ context.Context, _ *nats.Msg) {})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}
+
+// requireErrcode asserts err carries an *errcode.Error and returns it.
+func requireErrcode(t *testing.T, err error) *errcode.Error {
+	t.Helper()
+	require.Error(t, err)
+	var e *errcode.Error
+	require.True(t, errors.As(err, &e), "want *errcode.Error, got %T: %v", err, err)
+	return e
+}
+
+func TestNew(t *testing.T) {
+	nc := startTestNATS(t)
+	c := New(nc, "site-a")
+	require.NotNil(t, c)
+	assert.Same(t, nc, c.nc)
+	assert.Equal(t, "site-a", c.siteID)
+}
+
+func TestClient_GetRoomsInfo_Subject(t *testing.T) {
+	nc := startTestNATS(t)
+	got := stubResponder(t, nc, "chat.server.request.room.>", mustJSON(t, model.RoomsInfoBatchResponse{}))
+
+	_, err := New(nc, "site-a").GetRoomsInfo(context.Background(), "site-a", []string{"r1"})
+	require.NoError(t, err)
+
+	m := <-got
+	assert.Equal(t, "chat.server.request.room.site-a.info.batch", m.Subject)
+	assert.Equal(t, subject.RoomsInfoBatch("site-a"), m.Subject)
+
+	var req model.RoomsInfoBatchRequest
+	require.NoError(t, json.Unmarshal(m.Data, &req))
+	assert.Equal(t, []string{"r1"}, req.RoomIDs)
+}
+
+func TestClient_GetRoomsInfo_ReplyHandling(t *testing.T) {
+	lastMsgAt := int64(1717000000000)
+	tests := []struct {
+		name   string
+		reply  []byte
+		assert func(t *testing.T, rooms []model.RoomInfo, err error)
+	}{
+		{
+			name: "happy path decodes rooms",
+			reply: mustJSON(t, model.RoomsInfoBatchResponse{Rooms: []model.RoomInfo{
+				{RoomID: "r1", Found: true, Name: "Eng", UserCount: 3, LastMsgAt: &lastMsgAt},
+			}}),
+			assert: func(t *testing.T, rooms []model.RoomInfo, err error) {
+				require.NoError(t, err)
+				require.Len(t, rooms, 1)
+				assert.Equal(t, "r1", rooms[0].RoomID)
+				assert.Equal(t, "Eng", rooms[0].Name)
+				assert.Equal(t, 3, rooms[0].UserCount)
+				require.NotNil(t, rooms[0].LastMsgAt)
+				assert.Equal(t, lastMsgAt, *rooms[0].LastMsgAt)
+			},
+		},
+		{
+			name:  "empty success envelope yields no rooms and no error",
+			reply: []byte(`{}`),
+			assert: func(t *testing.T, rooms []model.RoomInfo, err error) {
+				require.NoError(t, err)
+				assert.Empty(t, rooms)
+			},
+		},
+		{
+			name:  "errcode envelope is relayed with code and reason intact",
+			reply: mustJSON(t, errcode.NotFound("room not found", errcode.WithReason(errcode.RoomNotMember))),
+			assert: func(t *testing.T, _ []model.RoomInfo, err error) {
+				e := requireErrcode(t, err)
+				assert.Equal(t, errcode.CodeNotFound, e.Code)
+				assert.Equal(t, errcode.RoomNotMember, e.Reason)
+				assert.Equal(t, "room not found", e.Message)
+			},
+		},
+		{
+			name:  "unknown remote code is relayed, not masked",
+			reply: []byte(`{"code":"upstream_only_code","error":"upstream boom"}`),
+			assert: func(t *testing.T, _ []model.RoomInfo, err error) {
+				e := requireErrcode(t, err)
+				assert.Equal(t, "upstream boom", e.Message)
+				assert.Equal(t, errcode.Code("upstream_only_code"), e.Code)
+			},
+		},
+		{
+			name:  "non-JSON reply surfaces a wrapped decode error",
+			reply: []byte("not json at all"),
+			assert: func(t *testing.T, _ []model.RoomInfo, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "decode rooms-info response")
+			},
+		},
+		{
+			name:  "JSON of the wrong shape surfaces a wrapped decode error",
+			reply: []byte(`{"rooms":"not-an-array"}`),
+			assert: func(t *testing.T, _ []model.RoomInfo, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "decode rooms-info response")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nc := startTestNATS(t)
+			stubResponder(t, nc, subject.RoomsInfoBatch("site-a"), tc.reply)
+
+			rooms, err := New(nc, "site-a").GetRoomsInfo(context.Background(), "site-a", []string{"r1"})
+			tc.assert(t, rooms, err)
+		})
+	}
+}
+
+func TestClient_GetRoomsMeta_SetsSkipKeys(t *testing.T) {
+	nc := startTestNATS(t)
+	got := stubResponder(t, nc, subject.RoomsInfoBatch("site-a"), mustJSON(t, model.RoomsInfoBatchResponse{}))
+	c := New(nc, "site-a")
+
+	_, err := c.GetRoomsMeta(context.Background(), "site-a", []string{"r1"})
+	require.NoError(t, err)
+	_, err = c.GetRoomsInfo(context.Background(), "site-a", []string{"r1"})
+	require.NoError(t, err)
+
+	var meta, info model.RoomsInfoBatchRequest
+	require.NoError(t, json.Unmarshal((<-got).Data, &meta))
+	require.NoError(t, json.Unmarshal((<-got).Data, &info))
+	assert.True(t, meta.SkipKeys, "GetRoomsMeta must request skipKeys")
+	assert.False(t, info.SkipKeys, "GetRoomsInfo must not request skipKeys")
+}
+
+func TestClient_GetRoomsMeta_ReplyHandling(t *testing.T) {
+	t.Run("happy path decodes rooms", func(t *testing.T) {
+		nc := startTestNATS(t)
+		stubResponder(t, nc, subject.RoomsInfoBatch("site-a"), mustJSON(t, model.RoomsInfoBatchResponse{
+			Rooms: []model.RoomInfo{{RoomID: "r1", Found: true, Name: "Eng"}},
+		}))
+
+		rooms, err := New(nc, "site-a").GetRoomsMeta(context.Background(), "site-a", []string{"r1"})
+		require.NoError(t, err)
+		require.Len(t, rooms, 1)
+		assert.Equal(t, "Eng", rooms[0].Name)
+	})
+
+	t.Run("errcode envelope is relayed", func(t *testing.T) {
+		nc := startTestNATS(t)
+		stubResponder(t, nc, subject.RoomsInfoBatch("site-a"), mustJSON(t, errcode.Forbidden("nope")))
+
+		_, err := New(nc, "site-a").GetRoomsMeta(context.Background(), "site-a", []string{"r1"})
+		assert.Equal(t, errcode.CodeForbidden, requireErrcode(t, err).Code)
+	})
+}
+
+func TestClient_GetRoomsInfo_EmptyRoomIDs(t *testing.T) {
+	nc := startTestNATS(t)
+	got := stubResponder(t, nc, subject.RoomsInfoBatch("site-a"), mustJSON(t, model.RoomsInfoBatchResponse{}))
+
+	// The client does not short-circuit an empty batch — it still issues the RPC.
+	rooms, err := New(nc, "site-a").GetRoomsInfo(context.Background(), "site-a", nil)
+	require.NoError(t, err)
+	assert.Empty(t, rooms)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal((<-got).Data, &raw))
+	require.Contains(t, raw, "roomIds")
+	assert.Nil(t, raw["roomIds"])
+	assert.NotContains(t, raw, "skipKeys", "skipKeys is omitempty and must stay off the wire when false")
+}
+
+func TestClient_GetRoomsInfo_CrossSiteRouting(t *testing.T) {
+	nc := startTestNATS(t)
+	// Only site-b has a responder: proves the method routes on the siteID
+	// argument rather than the client's own siteID.
+	got := stubResponder(t, nc, subject.RoomsInfoBatch("site-b"), mustJSON(t, model.RoomsInfoBatchResponse{
+		Rooms: []model.RoomInfo{{RoomID: "r2", Found: true, Name: "Remote"}},
+	}))
+
+	rooms, err := New(nc, "site-a").GetRoomsInfo(context.Background(), "site-b", []string{"r2"})
+	require.NoError(t, err)
+	require.Len(t, rooms, 1)
+	assert.Equal(t, "Remote", rooms[0].Name)
+	assert.Equal(t, "chat.server.request.room.site-b.info.batch", (<-got).Subject)
+}
+
+func TestClient_GetRoomsInfo_NoResponder(t *testing.T) {
+	nc := startTestNATS(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := New(nc, "site-a").GetRoomsInfo(ctx, "site-a", []string{"r1"})
+	e := requireErrcode(t, err)
+	assert.Equal(t, errcode.CodeUnavailable, e.Code)
+	assert.Equal(t, errcode.NatsNoResponders, e.Reason)
+	assert.Contains(t, e.Message, "rooms-info rpc")
+}
+
+func TestClient_GetRoomsInfo_Timeout(t *testing.T) {
+	nc := startTestNATS(t)
+	silentResponder(t, nc, subject.RoomsInfoBatch("site-a"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	_, err := New(nc, "site-a").GetRoomsInfo(ctx, "site-a", []string{"r1"})
+	e := requireErrcode(t, err)
+	assert.Equal(t, errcode.CodeUnavailable, e.Code)
+	assert.Equal(t, errcode.NatsRequestTimeout, e.Reason)
+	assert.Contains(t, e.Message, "rooms-info rpc")
+}
+
+func TestClient_GetThreadRoomInfoBatch_Subject(t *testing.T) {
+	nc := startTestNATS(t)
+	got := stubResponder(t, nc, "chat.server.request.room.>", mustJSON(t, model.ThreadRoomInfoBatchResponse{}))
+
+	_, err := New(nc, "site-a").GetThreadRoomInfoBatch(context.Background(), "site-a", []string{"tr1"})
+	require.NoError(t, err)
+
+	m := <-got
+	assert.Equal(t, "chat.server.request.room.site-a.thread.info.batch", m.Subject)
+	var req model.ThreadRoomInfoBatchRequest
+	require.NoError(t, json.Unmarshal(m.Data, &req))
+	assert.Equal(t, []string{"tr1"}, req.ThreadRoomIDs)
+}
+
+func TestClient_GetThreadRoomInfoBatch_ReplyHandling(t *testing.T) {
+	tests := []struct {
+		name   string
+		reply  []byte
+		assert func(t *testing.T, threads []model.ThreadRoomInfo, err error)
+	}{
+		{
+			name: "happy path decodes threads",
+			reply: mustJSON(t, model.ThreadRoomInfoBatchResponse{Threads: []model.ThreadRoomInfo{
+				{ThreadRoomID: "tr1", Found: true, LastMsgAt: 42},
+			}}),
+			assert: func(t *testing.T, threads []model.ThreadRoomInfo, err error) {
+				require.NoError(t, err)
+				require.Len(t, threads, 1)
+				assert.Equal(t, "tr1", threads[0].ThreadRoomID)
+				assert.Equal(t, int64(42), threads[0].LastMsgAt)
+			},
+		},
+		{
+			name:  "empty success envelope yields no threads",
+			reply: []byte(`{}`),
+			assert: func(t *testing.T, threads []model.ThreadRoomInfo, err error) {
+				require.NoError(t, err)
+				assert.Empty(t, threads)
+			},
+		},
+		{
+			name:  "errcode envelope is relayed",
+			reply: mustJSON(t, errcode.BadRequest("bad batch", errcode.WithReason(errcode.RequestIDRequired))),
+			assert: func(t *testing.T, _ []model.ThreadRoomInfo, err error) {
+				e := requireErrcode(t, err)
+				assert.Equal(t, errcode.CodeBadRequest, e.Code)
+				assert.Equal(t, errcode.RequestIDRequired, e.Reason)
+			},
+		},
+		{
+			name:  "unknown remote code is relayed, not masked",
+			reply: []byte(`{"code":"upstream_only_code","error":"upstream boom"}`),
+			assert: func(t *testing.T, _ []model.ThreadRoomInfo, err error) {
+				assert.Equal(t, "upstream boom", requireErrcode(t, err).Message)
+			},
+		},
+		{
+			name:  "non-JSON reply surfaces a wrapped decode error",
+			reply: []byte(`[`),
+			assert: func(t *testing.T, _ []model.ThreadRoomInfo, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "decode thread-room-info response")
+			},
+		},
+		{
+			name:  "JSON of the wrong shape surfaces a wrapped decode error",
+			reply: []byte(`{"threads":7}`),
+			assert: func(t *testing.T, _ []model.ThreadRoomInfo, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "decode thread-room-info response")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nc := startTestNATS(t)
+			stubResponder(t, nc, subject.ThreadRoomInfoBatch("site-a"), tc.reply)
+
+			threads, err := New(nc, "site-a").GetThreadRoomInfoBatch(context.Background(), "site-a", []string{"tr1"})
+			tc.assert(t, threads, err)
+		})
+	}
+}
+
+func TestClient_GetThreadRoomInfoBatch_EmptyIDs(t *testing.T) {
+	nc := startTestNATS(t)
+	got := stubResponder(t, nc, subject.ThreadRoomInfoBatch("site-a"), mustJSON(t, model.ThreadRoomInfoBatchResponse{}))
+
+	threads, err := New(nc, "site-a").GetThreadRoomInfoBatch(context.Background(), "site-a", []string{})
+	require.NoError(t, err)
+	assert.Empty(t, threads)
+
+	var req model.ThreadRoomInfoBatchRequest
+	require.NoError(t, json.Unmarshal((<-got).Data, &req))
+	assert.Empty(t, req.ThreadRoomIDs)
+}
+
+func TestClient_GetThreadRoomInfoBatch_CrossSiteRouting(t *testing.T) {
+	nc := startTestNATS(t)
+	got := stubResponder(t, nc, subject.ThreadRoomInfoBatch("site-b"), mustJSON(t, model.ThreadRoomInfoBatchResponse{
+		Threads: []model.ThreadRoomInfo{{ThreadRoomID: "tr2", Found: true}},
+	}))
+
+	threads, err := New(nc, "site-a").GetThreadRoomInfoBatch(context.Background(), "site-b", []string{"tr2"})
+	require.NoError(t, err)
+	require.Len(t, threads, 1)
+	assert.Equal(t, "chat.server.request.room.site-b.thread.info.batch", (<-got).Subject)
+}
+
+func TestClient_GetThreadRoomInfoBatch_NoResponder(t *testing.T) {
+	nc := startTestNATS(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := New(nc, "site-a").GetThreadRoomInfoBatch(ctx, "site-a", []string{"tr1"})
+	e := requireErrcode(t, err)
+	assert.Equal(t, errcode.CodeUnavailable, e.Code)
+	assert.Equal(t, errcode.NatsNoResponders, e.Reason)
+	assert.Contains(t, e.Message, "thread-room-info rpc")
+}
+
+func TestClient_ClearAllThreadUnread_Subject(t *testing.T) {
+	nc := startTestNATS(t)
+	got := stubResponder(t, nc, "chat.server.request.room.>", mustJSON(t, model.RoomThreadReadAllResponse{}))
+
+	require.NoError(t, New(nc, "site-a").ClearAllThreadUnread(context.Background(), "site-a", "alice"))
+
+	m := <-got
+	assert.Equal(t, "chat.server.request.room.site-a.thread.read.all", m.Subject)
+	var req model.RoomThreadReadAllRequest
+	require.NoError(t, json.Unmarshal(m.Data, &req))
+	assert.Equal(t, "alice", req.Account)
+}
+
+func TestClient_ClearAllThreadUnread_ReplyHandling(t *testing.T) {
+	tests := []struct {
+		name   string
+		reply  []byte
+		assert func(t *testing.T, err error)
+	}{
+		{
+			name:   "empty ack means success",
+			reply:  mustJSON(t, model.RoomThreadReadAllResponse{}),
+			assert: func(t *testing.T, err error) { require.NoError(t, err) },
+		},
+		{
+			name:  "errcode envelope is relayed",
+			reply: mustJSON(t, errcode.Internal("boom")),
+			assert: func(t *testing.T, err error) {
+				assert.Equal(t, errcode.CodeInternal, requireErrcode(t, err).Code)
+			},
+		},
+		{
+			name:  "unknown remote code is relayed, not masked",
+			reply: []byte(`{"code":"upstream_only_code","error":"upstream boom"}`),
+			assert: func(t *testing.T, err error) {
+				assert.Equal(t, "upstream boom", requireErrcode(t, err).Message)
+			},
+		},
+		{
+			name: "non-JSON reply is treated as success",
+			// The RPC carries no success payload, so the client only inspects the
+			// reply for an error envelope; an undecodable body is not an error.
+			reply:  []byte("garbage"),
+			assert: func(t *testing.T, err error) { require.NoError(t, err) },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nc := startTestNATS(t)
+			stubResponder(t, nc, subject.RoomThreadReadAll("site-a"), tc.reply)
+
+			tc.assert(t, New(nc, "site-a").ClearAllThreadUnread(context.Background(), "site-a", "alice"))
+		})
+	}
+}
+
+func TestClient_ClearAllThreadUnread_CrossSiteRouting(t *testing.T) {
+	nc := startTestNATS(t)
+	got := stubResponder(t, nc, subject.RoomThreadReadAll("site-b"), mustJSON(t, model.RoomThreadReadAllResponse{}))
+
+	require.NoError(t, New(nc, "site-a").ClearAllThreadUnread(context.Background(), "site-b", "alice"))
+	assert.Equal(t, "chat.server.request.room.site-b.thread.read.all", (<-got).Subject)
+}
+
+func TestClient_ClearAllThreadUnread_NoResponder(t *testing.T) {
+	nc := startTestNATS(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	e := requireErrcode(t, New(nc, "site-a").ClearAllThreadUnread(ctx, "site-a", "alice"))
+	assert.Equal(t, errcode.CodeUnavailable, e.Code)
+	assert.Equal(t, errcode.NatsNoResponders, e.Reason)
+	assert.Contains(t, e.Message, "clear-all-thread-unread rpc")
+}
+
+func TestClient_CreateDMRoom_Subject(t *testing.T) {
+	nc := startTestNATS(t)
+	got := stubResponder(t, nc, "chat.server.request.room.>", mustJSON(t, model.SyncCreateDMReply{Success: true}))
+
+	// The client's own siteID (not a parameter) selects the create-dm subject.
+	_, err := New(nc, "site-a").CreateDMRoom(context.Background(), "alice", "bob", model.RoomTypeDM)
+	require.NoError(t, err)
+
+	m := <-got
+	assert.Equal(t, "chat.server.request.room.site-a.create.dm", m.Subject)
+	var req model.SyncCreateDMRequest
+	require.NoError(t, json.Unmarshal(m.Data, &req))
+	assert.Equal(t, model.RoomTypeDM, req.RoomType)
+	assert.Equal(t, "alice", req.RequesterAccount)
+	assert.Equal(t, "bob", req.OtherAccount)
+}
+
+func TestClient_CreateDMRoom_ReplyHandling(t *testing.T) {
+	tests := []struct {
+		name   string
+		reply  []byte
+		assert func(t *testing.T, sub model.Subscription, err error)
+	}{
+		{
+			name: "happy path returns the subscription",
+			reply: mustJSON(t, model.SyncCreateDMReply{
+				Success:      true,
+				Subscription: model.Subscription{ID: "sub-1", RoomID: "alicebob", SiteID: "site-a", Name: "bob"},
+			}),
+			assert: func(t *testing.T, sub model.Subscription, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, "sub-1", sub.ID)
+				assert.Equal(t, "alicebob", sub.RoomID)
+				assert.Equal(t, "site-a", sub.SiteID)
+				assert.Equal(t, "bob", sub.Name)
+			},
+		},
+		{
+			name:  "success=false without an envelope becomes an internal error",
+			reply: mustJSON(t, model.SyncCreateDMReply{Success: false}),
+			assert: func(t *testing.T, sub model.Subscription, err error) {
+				e := requireErrcode(t, err)
+				assert.Equal(t, errcode.CodeInternal, e.Code)
+				assert.Equal(t, "create-dm reported failure", e.Message)
+				assert.Equal(t, model.Subscription{}, sub)
+			},
+		},
+		{
+			name:  "errcode envelope is relayed with code and reason intact",
+			reply: mustJSON(t, errcode.Conflict("DM already exists", errcode.WithReason(errcode.RoomSelfDM))),
+			assert: func(t *testing.T, _ model.Subscription, err error) {
+				e := requireErrcode(t, err)
+				assert.Equal(t, errcode.CodeConflict, e.Code)
+				assert.Equal(t, errcode.RoomSelfDM, e.Reason)
+			},
+		},
+		{
+			name:  "unknown remote code is relayed, not masked",
+			reply: []byte(`{"code":"upstream_only_code","error":"upstream boom"}`),
+			assert: func(t *testing.T, _ model.Subscription, err error) {
+				assert.Equal(t, "upstream boom", requireErrcode(t, err).Message)
+			},
+		},
+		{
+			name:  "non-JSON reply surfaces a wrapped decode error",
+			reply: []byte("nope"),
+			assert: func(t *testing.T, _ model.Subscription, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "decode create-dm reply")
+			},
+		},
+		{
+			name:  "JSON of the wrong shape surfaces a wrapped decode error",
+			reply: []byte(`{"success":"yes"}`),
+			assert: func(t *testing.T, _ model.Subscription, err error) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "decode create-dm reply")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nc := startTestNATS(t)
+			stubResponder(t, nc, subject.RoomCreateDMSync("site-a"), tc.reply)
+
+			sub, err := New(nc, "site-a").CreateDMRoom(context.Background(), "alice", "bob", model.RoomTypeDM)
+			tc.assert(t, sub, err)
+		})
+	}
+}
+
+func TestClient_CreateDMRoom_NoResponder(t *testing.T) {
+	nc := startTestNATS(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := New(nc, "site-a").CreateDMRoom(ctx, "alice", "bob", model.RoomTypeDM)
+	e := requireErrcode(t, err)
+	assert.Equal(t, errcode.CodeUnavailable, e.Code)
+	assert.Equal(t, errcode.NatsNoResponders, e.Reason)
+	assert.Contains(t, e.Message, "create-dm rpc")
+}

--- a/user-service/service/appspublish_test.go
+++ b/user-service/service/appspublish_test.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/subject"
+	"github.com/hmchangw/chat/user-service/models"
+	"github.com/hmchangw/chat/user-service/service/mocks"
+)
+
+// The client fan-out of a botDM subscription.update is best-effort: a publish
+// failure is swallowed after the write has already landed, so the RPC still
+// reports success on both the removed and the added path.
+func TestSetAppSubscription_PublishFailureIsBestEffort(t *testing.T) {
+	tests := []struct {
+		name       string
+		subscribed bool
+		setup      func(subs *mocks.MockSubscriptionRepository, rooms *mocks.MockRoomClient)
+	}{
+		{
+			name:       "unsubscribe removed event",
+			subscribed: false,
+			setup: func(subs *mocks.MockSubscriptionRepository, _ *mocks.MockRoomClient) {
+				subs.EXPECT().GetAppSubscription(gomock.Any(), "alice", "helper.bot").Return(appSub(false), nil)
+				subs.EXPECT().SetAppSubscribed(gomock.Any(), "alice", "helper.bot", false, true).Return(nil)
+			},
+		},
+		{
+			name:       "reactivate added event",
+			subscribed: true,
+			setup: func(subs *mocks.MockSubscriptionRepository, rooms *mocks.MockRoomClient) {
+				subs.EXPECT().GetAppSubscription(gomock.Any(), "alice", "helper.bot").Return(appSub(true), nil)
+				subs.EXPECT().SetAppSubscribed(gomock.Any(), "alice", "helper.bot", true, false).Return(nil)
+				rooms.EXPECT().GetRoomsMeta(gomock.Any(), gomock.Any(), []string{"room1"}).
+					Return([]model.RoomInfo{{RoomID: "room1", Found: true, SiteID: "site-a", Name: "Test Bot"}}, nil)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, subs, _, apps, rooms, _, pub := newSvc(t)
+			apps.EXPECT().GetApp(gomock.Any(), "app1").Return(appWith(true), nil)
+			tt.setup(subs, rooms)
+			pub.EXPECT().Publish(gomock.Any(), subject.SubscriptionUpdate("alice"), gomock.Any()).
+				Return(errors.New("nats down"))
+
+			resp, err := svc.SetAppSubscription(ctx("alice", "site-a"), models.SetAppSubscriptionRequest{AppID: "app1", Subscribed: tt.subscribed})
+			require.NoError(t, err, "a failed client fan-out must not fail the RPC — the write already landed")
+			require.NotNil(t, resp)
+			assert.True(t, resp.Success)
+		})
+	}
+}

--- a/user-service/service/chatlist_test.go
+++ b/user-service/service/chatlist_test.go
@@ -1,100 +1,667 @@
 package service
 
 import (
+	"encoding/json"
+	"errors"
+	"slices"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
 	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/idgen"
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/subject"
+	"github.com/hmchangw/chat/user-service/models"
+	"github.com/hmchangw/chat/user-service/service/mocks"
 )
 
+// customSection builds a client-created (non-built-in) section definition.
+func customSection(id, name, sortMode string) model.ChatlistSection {
+	return model.ChatlistSection{ID: id, Name: name, BuiltIn: false, SortMode: sortMode}
+}
+
+// storedChatlist is a customized chatlist: the four built-ins plus one custom
+// section "Work" (c1) sitting between "teams" and "chats".
+func storedChatlist() *model.ChatlistState {
+	return &model.ChatlistState{
+		SectionOrder: []string{model.SectionFavorites, model.SectionApps, model.SectionTeams, "c1", model.SectionChats},
+		Sections:     append(model.DefaultChatlistState().Sections, customSection("c1", "Work", model.SortModeCustom)),
+	}
+}
+
+// expectChatlistFanout allows both post-mutation publishes (client event +
+// cross-site inbox) for tests that assert on the persisted state, not the fanout.
+func expectChatlistFanout(pub *mocks.MockEventPublisher, account string) {
+	pub.EXPECT().Publish(gomock.Any(), subject.ChatlistUpdate(account), gomock.Any()).Return(nil).AnyTimes()
+	pub.EXPECT().Publish(gomock.Any(), subject.InboxExternal("site-b", model.InboxUserChatlistUpdated), gomock.Any()).
+		Return(nil).AnyTimes()
+}
+
+// echoChatlistUpdate stubs the repo write to return the state it was handed —
+// what Mongo's whole-object $set with return-new does — and captures it.
+func echoChatlistUpdate(users *mocks.MockUserRepository, account string, got **model.ChatlistState) {
+	users.EXPECT().UpdateUserChatlist(gomock.Any(), account, gomock.Any()).
+		DoAndReturn(func(_ any, _ string, st *model.ChatlistState) (*model.User, error) {
+			*got = st
+			return &model.User{Account: account, Chatlist: st}, nil
+		})
+}
+
+func TestGetChatlist(t *testing.T) {
+	tests := []struct {
+		name string
+		user *model.User
+		err  error
+		want *model.ChatlistState
+		code errcode.Code
+	}{
+		{name: "never customized falls back to the built-in default", user: &model.User{Account: "alice"}, want: model.DefaultChatlistState()},
+		{name: "stored state is returned verbatim", user: &model.User{Account: "alice", Chatlist: storedChatlist()}, want: storedChatlist()},
+		{name: "unknown account is not found", user: nil, code: errcode.CodeNotFound},
+		{name: "repository error", err: errors.New("db unavailable"), code: errcode.CodeInternal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _, users, _, _, _, _ := newSvc(t)
+			users.EXPECT().GetUserChatlist(gomock.Any(), "alice").Return(tt.user, tt.err)
+			got, err := svc.GetChatlist(ctx("alice", "site-a"))
+			if tt.code != "" {
+				requireCode(t, err, tt.code)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetChatlist_StoreErrorStaysRaw(t *testing.T) {
+	svc, _, users, _, _, _, _ := newSvc(t)
+	users.EXPECT().GetUserChatlist(gomock.Any(), "alice").Return(nil, errors.New("db unavailable"))
+	_, err := svc.GetChatlist(ctx("alice", "site-a"))
+	require.Error(t, err)
+	var ee *errcode.Error
+	assert.False(t, errors.As(err, &ee), "infra errors must stay raw, not be dressed up as an errcode")
+}
+
+func TestCreateChatlistSection_PlacesNewSectionAboveChats(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	expectChatlistFanout(pub, "alice")
+	users.EXPECT().GetUserChatlist(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
+	var stored *model.ChatlistState
+	echoChatlistUpdate(users, "alice", &stored)
+
+	got, err := svc.CreateChatlistSection(ctx("alice", "site-a"), models.ChatlistSectionCreateRequest{Name: "Work"})
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, stored, got, "the handler returns the persisted state")
+
+	require.Len(t, stored.Sections, 5)
+	created := stored.Sections[4]
+	assert.Equal(t, "Work", created.Name)
+	assert.False(t, created.BuiltIn, "client-created sections are never built-in")
+	assert.True(t, idgen.IsValidUUIDv7(created.ID), "section id must be a UUIDv7 hex, got %q", created.ID)
+
+	idx := slices.Index(stored.SectionOrder, created.ID)
+	require.GreaterOrEqual(t, idx, 0, "new section missing from SectionOrder: %v", stored.SectionOrder)
+	assert.Equal(t, model.SectionChats, stored.SectionOrder[idx+1], "new section must sit directly above chats")
+	assert.Positive(t, stored.LastUpdatedAt, "the write must stamp the high-water mark")
+}
+
+func TestCreateChatlistSection_SortMode(t *testing.T) {
+	tests := []struct {
+		name string
+		req  string
+		want string
+	}{
+		{name: "omitted defaults to custom", req: "", want: model.SortModeCustom},
+		{name: "custom honored", req: model.SortModeCustom, want: model.SortModeCustom},
+		{name: "mostRecent honored", req: model.SortModeMostRecent, want: model.SortModeMostRecent},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _, users, _, _, _, pub := newSvc(t)
+			expectChatlistFanout(pub, "alice")
+			users.EXPECT().GetUserChatlist(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
+			var stored *model.ChatlistState
+			echoChatlistUpdate(users, "alice", &stored)
+
+			_, err := svc.CreateChatlistSection(ctx("alice", "site-a"),
+				models.ChatlistSectionCreateRequest{Name: "Work", SortMode: tt.req})
+			require.NoError(t, err)
+			require.Len(t, stored.Sections, 5)
+			assert.Equal(t, tt.want, stored.Sections[4].SortMode)
+		})
+	}
+}
+
+func TestCreateChatlistSection_TrimsName(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	expectChatlistFanout(pub, "alice")
+	users.EXPECT().GetUserChatlist(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
+	var stored *model.ChatlistState
+	echoChatlistUpdate(users, "alice", &stored)
+
+	_, err := svc.CreateChatlistSection(ctx("alice", "site-a"), models.ChatlistSectionCreateRequest{Name: "  Work  "})
+	require.NoError(t, err)
+	assert.Equal(t, "Work", stored.Sections[4].Name, "surrounding whitespace is stripped before validation and storage")
+}
+
+// Rejected input must never reach the repository: newSvc's users mock has no
+// expectations here, so gomock fails the test if a lookup or write happens.
+func TestCreateChatlistSection_InvalidInput(t *testing.T) {
+	tests := []struct {
+		name   string
+		req    models.ChatlistSectionCreateRequest
+		code   errcode.Code
+		reason errcode.Reason
+	}{
+		{name: "empty name", req: models.ChatlistSectionCreateRequest{Name: ""}, code: errcode.CodeBadRequest, reason: errcode.UserChatlistInvalidName},
+		{name: "whitespace-only name trims to empty", req: models.ChatlistSectionCreateRequest{Name: "   "}, code: errcode.CodeBadRequest, reason: errcode.UserChatlistInvalidName},
+		{name: "name over 50 runes", req: models.ChatlistSectionCreateRequest{Name: strings.Repeat("x", 51)}, code: errcode.CodeBadRequest, reason: errcode.UserChatlistInvalidName},
+		{name: "consecutive spaces", req: models.ChatlistSectionCreateRequest{Name: "a  b"}, code: errcode.CodeBadRequest, reason: errcode.UserChatlistInvalidName},
+		{name: "disallowed character", req: models.ChatlistSectionCreateRequest{Name: "bad!"}, code: errcode.CodeBadRequest, reason: errcode.UserChatlistInvalidName},
+		{name: "unknown sortMode", req: models.ChatlistSectionCreateRequest{Name: "Work", SortMode: "weird"}, code: errcode.CodeBadRequest, reason: errcode.UserChatlistInvalidSortMode},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _, _, _, _, _, _ := newSvc(t)
+			_, err := svc.CreateChatlistSection(ctx("alice", "site-a"), tt.req)
+			requireCode(t, err, tt.code)
+			assert.True(t, errcode.HasReason(err, tt.reason), "want reason %q, got %v", tt.reason, err)
+		})
+	}
+}
+
+// A 50-rune name is the inclusive upper bound.
+func TestCreateChatlistSection_MaxLengthNameAccepted(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	expectChatlistFanout(pub, "alice")
+	name := strings.Repeat("x", model.MaxSectionName)
+	users.EXPECT().GetUserChatlist(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
+	var stored *model.ChatlistState
+	echoChatlistUpdate(users, "alice", &stored)
+	_, err := svc.CreateChatlistSection(ctx("alice", "site-a"), models.ChatlistSectionCreateRequest{Name: name})
+	require.NoError(t, err)
+	assert.Equal(t, name, stored.Sections[4].Name)
+}
+
+func TestCreateChatlistSection_DuplicateCustomName(t *testing.T) {
+	svc, _, users, _, _, _, _ := newSvc(t)
+	// The write is never expected: the duplicate is caught inside the mutation.
+	users.EXPECT().GetUserChatlist(gomock.Any(), "alice").
+		Return(&model.User{Account: "alice", Chatlist: storedChatlist()}, nil)
+	_, err := svc.CreateChatlistSection(ctx("alice", "site-a"), models.ChatlistSectionCreateRequest{Name: "Work"})
+	requireCode(t, err, errcode.CodeConflict)
+	assert.True(t, errcode.HasReason(err, errcode.UserChatlistDuplicateName))
+}
+
+// Uniqueness is scoped to custom sections, so a built-in's display name is not
+// reserved — "Chats" may be reused for a custom section.
+func TestCreateChatlistSection_BuiltinNameIsNotReserved(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	expectChatlistFanout(pub, "alice")
+	users.EXPECT().GetUserChatlist(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
+	var stored *model.ChatlistState
+	echoChatlistUpdate(users, "alice", &stored)
+	_, err := svc.CreateChatlistSection(ctx("alice", "site-a"), models.ChatlistSectionCreateRequest{Name: "Chats"})
+	require.NoError(t, err)
+	assert.Equal(t, "Chats", stored.Sections[4].Name)
+}
+
+// Names differing only in case are distinct — uniqueness is case-sensitive.
+func TestCreateChatlistSection_CaseDifferingNameAllowed(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	expectChatlistFanout(pub, "alice")
+	users.EXPECT().GetUserChatlist(gomock.Any(), "alice").
+		Return(&model.User{Account: "alice", Chatlist: storedChatlist()}, nil)
+	var stored *model.ChatlistState
+	echoChatlistUpdate(users, "alice", &stored)
+	_, err := svc.CreateChatlistSection(ctx("alice", "site-a"), models.ChatlistSectionCreateRequest{Name: "work"})
+	require.NoError(t, err)
+	assert.Len(t, stored.Sections, 6)
+}
+
+// mutateChatlist's read-modify-write failure modes, exercised through create.
+func TestCreateChatlistSection_RepositoryFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		getUser    *model.User
+		getErr     error
+		expectSet  bool
+		updateUser *model.User
+		updateErr  error
+		code       errcode.Code
+	}{
+		{name: "read fails", getErr: errors.New("db unavailable"), code: errcode.CodeInternal},
+		{name: "unknown account on read", getUser: nil, code: errcode.CodeNotFound},
+		{name: "write fails", getUser: &model.User{Account: "alice"}, expectSet: true, updateErr: errors.New("write failed"), code: errcode.CodeInternal},
+		{name: "account vanished between read and write", getUser: &model.User{Account: "alice"}, expectSet: true, updateUser: nil, code: errcode.CodeNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// No publish expectations: a failed mutation must fan nothing out.
+			svc, _, users, _, _, _, _ := newSvc(t)
+			users.EXPECT().GetUserChatlist(gomock.Any(), "alice").Return(tt.getUser, tt.getErr)
+			if tt.expectSet {
+				users.EXPECT().UpdateUserChatlist(gomock.Any(), "alice", gomock.Any()).Return(tt.updateUser, tt.updateErr)
+			}
+			_, err := svc.CreateChatlistSection(ctx("alice", "site-a"), models.ChatlistSectionCreateRequest{Name: "Work"})
+			requireCode(t, err, tt.code)
+		})
+	}
+}
+
+// The repo is the source of truth for the reply: a write that returns a state
+// different from the one sent must be what the caller and the fanouts see.
+func TestCreateChatlistSection_ReturnsRepositoryState(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	expectChatlistFanout(pub, "alice")
+	persisted := storedChatlist()
+	users.EXPECT().GetUserChatlist(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
+	users.EXPECT().UpdateUserChatlist(gomock.Any(), "alice", gomock.Any()).
+		Return(&model.User{Account: "alice", Chatlist: persisted}, nil)
+	got, err := svc.CreateChatlistSection(ctx("alice", "site-a"), models.ChatlistSectionCreateRequest{Name: "Work"})
+	require.NoError(t, err)
+	assert.Equal(t, persisted, got)
+}
+
+// A write that comes back with no chatlist sub-document (defensive: Mongo always
+// returns it after a whole-object $set) still replies with the state just applied.
+func TestCreateChatlistSection_WriteReturnsUserWithoutChatlist(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	expectChatlistFanout(pub, "alice")
+	users.EXPECT().GetUserChatlist(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
+	users.EXPECT().UpdateUserChatlist(gomock.Any(), "alice", gomock.Any()).
+		Return(&model.User{Account: "alice"}, nil)
+	got, err := svc.CreateChatlistSection(ctx("alice", "site-a"), models.ChatlistSectionCreateRequest{Name: "Work"})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got.Sections, 5)
+	assert.Equal(t, "Work", got.Sections[4].Name, "the locally applied state is the fallback reply")
+}
+
+func TestDeleteChatlistSection_RemovesCustomSection(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	expectChatlistFanout(pub, "alice")
+	users.EXPECT().GetUserChatlist(gomock.Any(), "alice").
+		Return(&model.User{Account: "alice", Chatlist: storedChatlist()}, nil)
+	var stored *model.ChatlistState
+	echoChatlistUpdate(users, "alice", &stored)
+
+	_, err := svc.DeleteChatlistSection(ctx("alice", "site-a"), models.ChatlistSectionDeleteRequest{SectionID: "c1"})
+	require.NoError(t, err)
+	assert.Nil(t, findSection(stored, "c1"), "deleted section must be gone from Sections")
+	assert.NotContains(t, stored.SectionOrder, "c1", "deleted section must be gone from SectionOrder")
+	assert.Equal(t, []string{model.SectionFavorites, model.SectionApps, model.SectionTeams, model.SectionChats},
+		stored.SectionOrder, "the surviving order keeps its relative sequence")
+}
+
+func TestDeleteChatlistSection_Rejected(t *testing.T) {
+	tests := []struct {
+		name      string
+		sectionID string
+		state     *model.ChatlistState
+		code      errcode.Code
+		reason    errcode.Reason
+	}{
+		{name: "unknown section id", sectionID: "nope", state: storedChatlist(), code: errcode.CodeNotFound, reason: errcode.UserChatlistSectionNotFound},
+		{name: "empty section id", sectionID: "", state: storedChatlist(), code: errcode.CodeNotFound, reason: errcode.UserChatlistSectionNotFound},
+		{name: "built-in section", sectionID: model.SectionChats, state: storedChatlist(), code: errcode.CodeBadRequest, reason: errcode.UserChatlistBuiltinImmutable},
+		{name: "custom section on a never-customized chatlist", sectionID: "c1", state: nil, code: errcode.CodeNotFound, reason: errcode.UserChatlistSectionNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// No UpdateUserChatlist expectation: a rejected mutation must not write.
+			svc, _, users, _, _, _, _ := newSvc(t)
+			users.EXPECT().GetUserChatlist(gomock.Any(), "alice").
+				Return(&model.User{Account: "alice", Chatlist: tt.state}, nil)
+			_, err := svc.DeleteChatlistSection(ctx("alice", "site-a"), models.ChatlistSectionDeleteRequest{SectionID: tt.sectionID})
+			requireCode(t, err, tt.code)
+			assert.True(t, errcode.HasReason(err, tt.reason), "want reason %q, got %v", tt.reason, err)
+		})
+	}
+}
+
+func TestRenameChatlistSection_RenamesCustomSection(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	expectChatlistFanout(pub, "alice")
+	users.EXPECT().GetUserChatlist(gomock.Any(), "alice").
+		Return(&model.User{Account: "alice", Chatlist: storedChatlist()}, nil)
+	var stored *model.ChatlistState
+	echoChatlistUpdate(users, "alice", &stored)
+
+	_, err := svc.RenameChatlistSection(ctx("alice", "site-a"),
+		models.ChatlistSectionRenameRequest{SectionID: "c1", Name: "  Projects  "})
+	require.NoError(t, err)
+	sec := findSection(stored, "c1")
+	require.NotNil(t, sec)
+	assert.Equal(t, "Projects", sec.Name, "the new name is trimmed before storage")
+	assert.Equal(t, model.SortModeCustom, sec.SortMode, "rename must not disturb sortMode")
+}
+
+// Renaming a section to the name it already has is a no-op, not a self-collision.
+func TestRenameChatlistSection_ToItsOwnNameSucceeds(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	expectChatlistFanout(pub, "alice")
+	users.EXPECT().GetUserChatlist(gomock.Any(), "alice").
+		Return(&model.User{Account: "alice", Chatlist: storedChatlist()}, nil)
+	var stored *model.ChatlistState
+	echoChatlistUpdate(users, "alice", &stored)
+	_, err := svc.RenameChatlistSection(ctx("alice", "site-a"),
+		models.ChatlistSectionRenameRequest{SectionID: "c1", Name: "Work"})
+	require.NoError(t, err)
+	assert.Equal(t, "Work", findSection(stored, "c1").Name)
+}
+
+func TestRenameChatlistSection_Rejected(t *testing.T) {
+	twoCustom := storedChatlist()
+	twoCustom.Sections = append(twoCustom.Sections, customSection("c2", "Personal", model.SortModeCustom))
+	twoCustom.SectionOrder = append(twoCustom.SectionOrder, "c2")
+
+	tests := []struct {
+		name      string
+		req       models.ChatlistSectionRenameRequest
+		state     *model.ChatlistState
+		expectGet bool
+		code      errcode.Code
+		reason    errcode.Reason
+	}{
+		{name: "invalid name is rejected before any lookup", req: models.ChatlistSectionRenameRequest{SectionID: "c1", Name: "bad!"}, code: errcode.CodeBadRequest, reason: errcode.UserChatlistInvalidName},
+		{name: "blank name is rejected before any lookup", req: models.ChatlistSectionRenameRequest{SectionID: "c1", Name: "  "}, code: errcode.CodeBadRequest, reason: errcode.UserChatlistInvalidName},
+		{name: "unknown section id", req: models.ChatlistSectionRenameRequest{SectionID: "nope", Name: "Projects"}, state: storedChatlist(), expectGet: true, code: errcode.CodeNotFound, reason: errcode.UserChatlistSectionNotFound},
+		{name: "built-in section", req: models.ChatlistSectionRenameRequest{SectionID: model.SectionTeams, Name: "Squads"}, state: storedChatlist(), expectGet: true, code: errcode.CodeBadRequest, reason: errcode.UserChatlistBuiltinImmutable},
+		{name: "name taken by another custom section", req: models.ChatlistSectionRenameRequest{SectionID: "c2", Name: "Work"}, state: twoCustom, expectGet: true, code: errcode.CodeConflict, reason: errcode.UserChatlistDuplicateName},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _, users, _, _, _, _ := newSvc(t)
+			if tt.expectGet {
+				users.EXPECT().GetUserChatlist(gomock.Any(), "alice").
+					Return(&model.User{Account: "alice", Chatlist: tt.state}, nil)
+			}
+			_, err := svc.RenameChatlistSection(ctx("alice", "site-a"), tt.req)
+			requireCode(t, err, tt.code)
+			assert.True(t, errcode.HasReason(err, tt.reason), "want reason %q, got %v", tt.reason, err)
+		})
+	}
+}
+
+func TestReorderChatlistSections_ReplacesOrder(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	expectChatlistFanout(pub, "alice")
+	users.EXPECT().GetUserChatlist(gomock.Any(), "alice").
+		Return(&model.User{Account: "alice", Chatlist: storedChatlist()}, nil)
+	var stored *model.ChatlistState
+	echoChatlistUpdate(users, "alice", &stored)
+
+	want := []string{"c1", model.SectionChats, model.SectionTeams, model.SectionApps, model.SectionFavorites}
+	_, err := svc.ReorderChatlistSections(ctx("alice", "site-a"), models.ChatlistSectionReorderRequest{SectionOrder: want})
+	require.NoError(t, err)
+	assert.Equal(t, want, stored.SectionOrder)
+	assert.Len(t, stored.Sections, 5, "reordering must not add or drop definitions")
+}
+
+// Reordering a never-customized chatlist works off the default order.
+func TestReorderChatlistSections_OnDefaultState(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	expectChatlistFanout(pub, "alice")
+	users.EXPECT().GetUserChatlist(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
+	var stored *model.ChatlistState
+	echoChatlistUpdate(users, "alice", &stored)
+	want := []string{model.SectionChats, model.SectionTeams, model.SectionApps, model.SectionFavorites}
+	_, err := svc.ReorderChatlistSections(ctx("alice", "site-a"), models.ChatlistSectionReorderRequest{SectionOrder: want})
+	require.NoError(t, err)
+	assert.Equal(t, want, stored.SectionOrder)
+}
+
+func TestReorderChatlistSections_NonPermutation(t *testing.T) {
+	full := []string{model.SectionFavorites, model.SectionApps, model.SectionTeams, "c1", model.SectionChats}
+	tests := []struct {
+		name  string
+		order []string
+	}{
+		{name: "nil order", order: nil},
+		{name: "empty order", order: []string{}},
+		{name: "missing a section", order: full[:4]},
+		{name: "unknown section id", order: []string{model.SectionFavorites, model.SectionApps, model.SectionTeams, "c1", "ghost"}},
+		{name: "duplicate section id", order: []string{model.SectionFavorites, model.SectionApps, model.SectionTeams, "c1", "c1"}},
+		{name: "extra section id", order: append(slices.Clone(full), "extra")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// No write expectation: an invalid order must be rejected before persisting.
+			svc, _, users, _, _, _, _ := newSvc(t)
+			users.EXPECT().GetUserChatlist(gomock.Any(), "alice").
+				Return(&model.User{Account: "alice", Chatlist: storedChatlist()}, nil)
+			_, err := svc.ReorderChatlistSections(ctx("alice", "site-a"), models.ChatlistSectionReorderRequest{SectionOrder: tt.order})
+			requireCode(t, err, errcode.CodeBadRequest)
+			assert.True(t, errcode.HasReason(err, errcode.UserChatlistInvalidOrder), "want invalid-order reason, got %v", err)
+		})
+	}
+}
+
+func TestSetChatlistSectionSortMode(t *testing.T) {
+	tests := []struct {
+		name      string
+		sectionID string
+		mode      string
+	}{
+		{name: "custom section to mostRecent", sectionID: "c1", mode: model.SortModeMostRecent},
+		{name: "built-in section to custom", sectionID: model.SectionChats, mode: model.SortModeCustom},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _, users, _, _, _, pub := newSvc(t)
+			expectChatlistFanout(pub, "alice")
+			users.EXPECT().GetUserChatlist(gomock.Any(), "alice").
+				Return(&model.User{Account: "alice", Chatlist: storedChatlist()}, nil)
+			var stored *model.ChatlistState
+			echoChatlistUpdate(users, "alice", &stored)
+
+			_, err := svc.SetChatlistSectionSortMode(ctx("alice", "site-a"),
+				models.ChatlistSectionSetSortModeRequest{SectionID: tt.sectionID, SortMode: tt.mode})
+			require.NoError(t, err)
+			sec := findSection(stored, tt.sectionID)
+			require.NotNil(t, sec)
+			assert.Equal(t, tt.mode, sec.SortMode)
+		})
+	}
+}
+
+func TestSetChatlistSectionSortMode_Rejected(t *testing.T) {
+	tests := []struct {
+		name      string
+		req       models.ChatlistSectionSetSortModeRequest
+		expectGet bool
+		code      errcode.Code
+		reason    errcode.Reason
+	}{
+		{name: "unknown sortMode is rejected before any lookup", req: models.ChatlistSectionSetSortModeRequest{SectionID: "c1", SortMode: "weird"}, code: errcode.CodeBadRequest, reason: errcode.UserChatlistInvalidSortMode},
+		{name: "empty sortMode is rejected before any lookup", req: models.ChatlistSectionSetSortModeRequest{SectionID: "c1", SortMode: ""}, code: errcode.CodeBadRequest, reason: errcode.UserChatlistInvalidSortMode},
+		{name: "unknown section id", req: models.ChatlistSectionSetSortModeRequest{SectionID: "nope", SortMode: model.SortModeCustom}, expectGet: true, code: errcode.CodeNotFound, reason: errcode.UserChatlistSectionNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _, users, _, _, _, _ := newSvc(t)
+			if tt.expectGet {
+				users.EXPECT().GetUserChatlist(gomock.Any(), "alice").
+					Return(&model.User{Account: "alice", Chatlist: storedChatlist()}, nil)
+			}
+			_, err := svc.SetChatlistSectionSortMode(ctx("alice", "site-a"), tt.req)
+			requireCode(t, err, tt.code)
+			assert.True(t, errcode.HasReason(err, tt.reason), "want reason %q, got %v", tt.reason, err)
+		})
+	}
+}
+
+// Both fanouts carry the full post-update state and one shared timestamp, which
+// is also the stored high-water mark — client event and cross-site replica must
+// agree on ordering. site-a is self and gets no inbox event.
+func TestChatlistMutation_FansOutOnceToClientAndOtherSites(t *testing.T) {
+	svc, _, users, _, _, _, pub := newSvc(t)
+	users.EXPECT().GetUserChatlist(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
+	var stored *model.ChatlistState
+	echoChatlistUpdate(users, "alice", &stored)
+
+	var clientEvt model.ChatlistUpdateEvent
+	pub.EXPECT().Publish(gomock.Any(), subject.ChatlistUpdate("alice"), gomock.Any()).
+		DoAndReturn(func(_ any, _ string, data []byte) error {
+			require.NoError(t, json.Unmarshal(data, &clientEvt))
+			return nil
+		})
+	var inboxPayload model.UserChatlistUpdated
+	pub.EXPECT().Publish(gomock.Any(), subject.InboxExternal("site-b", model.InboxUserChatlistUpdated), gomock.Any()).
+		DoAndReturn(func(_ any, _ string, data []byte) error {
+			var evt model.InboxEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			assert.Equal(t, model.InboxUserChatlistUpdated, evt.Type)
+			assert.Equal(t, "site-a", evt.SiteID)
+			assert.Equal(t, "site-b", evt.DestSiteID)
+			require.NoError(t, json.Unmarshal(evt.Payload, &inboxPayload))
+			return nil
+		})
+
+	_, err := svc.CreateChatlistSection(ctx("alice", "site-a"), models.ChatlistSectionCreateRequest{Name: "Work"})
+	require.NoError(t, err)
+
+	assert.Equal(t, *stored, clientEvt.Chatlist, "the client event carries the full post-update state")
+	assert.Equal(t, "alice", inboxPayload.Account)
+	assert.Equal(t, *stored, inboxPayload.Chatlist, "the replica event carries the full post-update state")
+	assert.NotZero(t, clientEvt.Timestamp)
+	assert.Equal(t, clientEvt.Timestamp, inboxPayload.Timestamp, "both fanouts share one timestamp")
+	assert.Equal(t, clientEvt.Timestamp, stored.LastUpdatedAt, "the stored high-water mark is that same timestamp")
+}
+
+func TestChatlistMutation_PublishFailuresAreBestEffort(t *testing.T) {
+	tests := []struct {
+		name      string
+		clientErr error
+		inboxErr  error
+	}{
+		{name: "client fanout fails", clientErr: errors.New("nats down")},
+		{name: "inbox fanout fails", inboxErr: errors.New("no responders")},
+		{name: "both fail", clientErr: errors.New("nats down"), inboxErr: errors.New("no responders")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _, users, _, _, _, pub := newSvc(t)
+			users.EXPECT().GetUserChatlist(gomock.Any(), "alice").
+				Return(&model.User{Account: "alice", Chatlist: storedChatlist()}, nil)
+			var stored *model.ChatlistState
+			echoChatlistUpdate(users, "alice", &stored)
+			pub.EXPECT().Publish(gomock.Any(), subject.ChatlistUpdate("alice"), gomock.Any()).Return(tt.clientErr)
+			pub.EXPECT().Publish(gomock.Any(), subject.InboxExternal("site-b", model.InboxUserChatlistUpdated), gomock.Any()).
+				Return(tt.inboxErr)
+
+			got, err := svc.DeleteChatlistSection(ctx("alice", "site-a"), models.ChatlistSectionDeleteRequest{SectionID: "c1"})
+			require.NoError(t, err, "a fanout failure must not fail the mutation")
+			assert.Equal(t, stored, got)
+		})
+	}
+}
+
+// The inbox fanout skips this site and any blank entry in ALL_SITE_IDS, and
+// publishes once per remaining peer.
+func TestPublishChatlistInbox_SkipsSelfAndBlankSites(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	pub := mocks.NewMockEventPublisher(ctrl)
+	svc := &UserService{pub: pub, siteID: "site-a", allSiteIDs: []string{"site-a", "", "site-b", "site-c"}}
+
+	var subjects []string
+	pub.EXPECT().Publish(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).
+		DoAndReturn(func(_ any, subj string, _ []byte) error {
+			subjects = append(subjects, subj)
+			return nil
+		})
+	svc.publishChatlistInbox(ctx("alice", "site-a"), "alice", model.DefaultChatlistState(), 42)
+	assert.ElementsMatch(t, []string{
+		subject.InboxExternal("site-b", model.InboxUserChatlistUpdated),
+		subject.InboxExternal("site-c", model.InboxUserChatlistUpdated),
+	}, subjects)
+}
+
+// A single-site deployment has no peers, so no inbox event is published at all.
+func TestPublishChatlistInbox_SingleSitePublishesNothing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	pub := mocks.NewMockEventPublisher(ctrl)
+	// pub has no Publish expectation: gomock fails the test if one is attempted.
+	svc := &UserService{pub: pub, siteID: "site-a", allSiteIDs: []string{"site-a"}}
+	svc.publishChatlistInbox(ctx("alice", "site-a"), "alice", model.DefaultChatlistState(), 42)
+}
+
 func TestValidateSectionName(t *testing.T) {
-	ok := []string{"Work", "團隊", "a-b_c.d/(e)", "A B", repeat("x", 50)}
-	for _, n := range ok {
-		if err := validateSectionName(n); err != nil {
-			t.Errorf("validateSectionName(%q) = %v, want nil", n, err)
+	t.Run("accepted", func(t *testing.T) {
+		for _, n := range []string{"Work", "團隊", "a-b_c.d/(e)", "A B", strings.Repeat("x", model.MaxSectionName)} {
+			assert.NoError(t, validateSectionName(n), "name %q must be accepted", n)
 		}
-	}
-	bad := []string{"", repeat("x", 51), "a  b", "bad!", "no@sign", "semi;colon"}
-	for _, n := range bad {
-		if err := validateSectionName(n); err == nil {
-			t.Errorf("validateSectionName(%q) = nil, want error", n)
-		} else if !errcode.HasReason(err, errcode.UserChatlistInvalidName) {
-			t.Errorf("validateSectionName(%q) reason mismatch: %v", n, err)
+	})
+	t.Run("rejected", func(t *testing.T) {
+		for _, n := range []string{"", strings.Repeat("x", model.MaxSectionName+1), "a  b", "bad!", "no@sign", "semi;colon"} {
+			err := validateSectionName(n)
+			require.Error(t, err, "name %q must be rejected", n)
+			assert.True(t, errcode.HasReason(err, errcode.UserChatlistInvalidName), "name %q: wrong reason: %v", n, err)
 		}
-	}
+	})
 }
 
 func TestValidateSortMode(t *testing.T) {
-	if err := validateSortMode(model.SortModeCustom); err != nil {
-		t.Errorf("custom rejected: %v", err)
-	}
-	if err := validateSortMode(model.SortModeMostRecent); err != nil {
-		t.Errorf("mostRecent rejected: %v", err)
-	}
-	if err := validateSortMode("weird"); err == nil {
-		t.Error("weird accepted, want error")
-	}
+	assert.NoError(t, validateSortMode(model.SortModeCustom))
+	assert.NoError(t, validateSortMode(model.SortModeMostRecent))
+	err := validateSortMode("weird")
+	require.Error(t, err)
+	assert.True(t, errcode.HasReason(err, errcode.UserChatlistInvalidSortMode))
 }
 
 func TestIsPermutation(t *testing.T) {
-	if !isPermutation([]string{"a", "b", "c"}, []string{"c", "a", "b"}) {
-		t.Error("valid permutation rejected")
-	}
-	if isPermutation([]string{"a", "b"}, []string{"a", "a"}) {
-		t.Error("dup accepted as permutation")
-	}
-	if isPermutation([]string{"a", "b"}, []string{"a"}) {
-		t.Error("short list accepted as permutation")
-	}
+	assert.True(t, isPermutation([]string{"a", "b", "c"}, []string{"c", "a", "b"}))
+	assert.False(t, isPermutation([]string{"a", "b"}, []string{"a", "a"}), "duplicates are not a permutation")
+	assert.False(t, isPermutation([]string{"a", "b"}, []string{"a"}), "a short list is not a permutation")
 }
 
 func TestInsertAboveChatsAndRemove(t *testing.T) {
 	st := model.DefaultChatlistState()
 	insertAboveChats(st, "sec-1")
-	// sec-1 must land immediately before "chats".
-	idx := indexOf(st.SectionOrder, "sec-1")
-	if idx < 0 || st.SectionOrder[idx+1] != model.SectionChats {
-		t.Fatalf("sec-1 not above chats: %v", st.SectionOrder)
-	}
+	idx := slices.Index(st.SectionOrder, "sec-1")
+	require.GreaterOrEqual(t, idx, 0, "sec-1 missing from order: %v", st.SectionOrder)
+	assert.Equal(t, model.SectionChats, st.SectionOrder[idx+1], "sec-1 must land directly above chats")
+
 	st.Sections = append(st.Sections, model.ChatlistSection{ID: "sec-1", Name: "S1"})
 	removeSection(st, "sec-1")
-	if indexOf(st.SectionOrder, "sec-1") >= 0 || findSection(st, "sec-1") != nil {
-		t.Fatalf("sec-1 not removed: %v", st.SectionOrder)
-	}
+	assert.NotContains(t, st.SectionOrder, "sec-1")
+	assert.Nil(t, findSection(st, "sec-1"))
+}
+
+// With no built-in "chats" section to anchor on, a new id appends to the tail.
+func TestInsertAboveChats_NoChatsSection(t *testing.T) {
+	st := &model.ChatlistState{SectionOrder: []string{model.SectionFavorites, model.SectionTeams}}
+	insertAboveChats(st, "sec-1")
+	assert.Equal(t, []string{model.SectionFavorites, model.SectionTeams, "sec-1"}, st.SectionOrder)
+}
+
+func TestFindSection(t *testing.T) {
+	st := storedChatlist()
+	sec := findSection(st, "c1")
+	require.NotNil(t, sec)
+	assert.Equal(t, "Work", sec.Name)
+	sec.Name = "Renamed"
+	assert.Equal(t, "Renamed", st.Sections[4].Name, "findSection must return a mutable pointer into the state")
+	assert.Nil(t, findSection(st, "missing"))
+	assert.Nil(t, findSection(&model.ChatlistState{}, "c1"), "an empty chatlist finds nothing")
 }
 
 func TestHasCustomName(t *testing.T) {
 	st := &model.ChatlistState{Sections: []model.ChatlistSection{
 		{ID: "b1", Name: "Chats", BuiltIn: true},
-		{ID: "c1", Name: "Work", BuiltIn: false},
+		customSection("c1", "Work", model.SortModeCustom),
 	}}
-	if !hasCustomName(st, "Work", "") {
-		t.Error("existing custom name not detected")
-	}
-	if hasCustomName(st, "Work", "c1") {
-		t.Error("self-exclusion failed on rename")
-	}
-	if hasCustomName(st, "work", "") {
-		t.Error("name match should be case-sensitive")
-	}
-	if hasCustomName(st, "Chats", "") {
-		t.Error("built-in name should not collide with custom uniqueness")
-	}
-}
-
-func repeat(r string, n int) string {
-	out := ""
-	for i := 0; i < n; i++ {
-		out += r
-	}
-	return out
-}
-
-func indexOf(s []string, v string) int {
-	for i, x := range s {
-		if x == v {
-			return i
-		}
-	}
-	return -1
+	assert.True(t, hasCustomName(st, "Work", ""), "an existing custom name collides")
+	assert.False(t, hasCustomName(st, "Work", "c1"), "a section never collides with itself on rename")
+	assert.False(t, hasCustomName(st, "work", ""), "name matching is case-sensitive")
+	assert.False(t, hasCustomName(st, "Chats", ""), "built-in names are not reserved for custom sections")
 }

--- a/user-service/service/register_test.go
+++ b/user-service/service/register_test.go
@@ -1,0 +1,126 @@
+package service
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+
+	"github.com/hmchangw/chat/pkg/natsrouter"
+)
+
+// registerTestQueue is the queue group the router under test subscribes with.
+// Subsz results are filtered on it so only routes this test registered are
+// asserted on.
+const registerTestQueue = "user-service-test"
+
+// registeredSubjects boots an embedded in-process NATS server, wires
+// RegisterHandlers onto a real Router against it, and returns the NATS
+// wildcard subjects the server actually holds subscriptions for.
+//
+// The server is the observation seam: Router keeps its subscription list
+// unexported, but every route it registers becomes a real SUB on the wire, so
+// the broker's own view is both accessible and closer to production truth than
+// any in-process accessor would be.
+func registeredSubjects(t *testing.T, siteID string) []string {
+	t.Helper()
+
+	ns, err := natsserver.NewServer(&natsserver.Options{Port: -1})
+	require.NoError(t, err)
+	ns.Start()
+	require.True(t, ns.ReadyForConnections(5*time.Second), "nats server did not become ready")
+	t.Cleanup(ns.Shutdown)
+
+	nc, err := o11ynats.Connect(context.Background(), ns.ClientURL(), noop.NewTracerProvider(), propagation.TraceContext{})
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+
+	// RegisterHandlers only reads s.siteID and binds method values, so a
+	// dependency-free UserService exercises the real registration path.
+	svc := &UserService{siteID: siteID}
+	svc.RegisterHandlers(natsrouter.New(nc, registerTestQueue))
+
+	// Flush round-trips the connection so every SUB has reached the server
+	// before Subsz is read — no polling, no sleep.
+	require.NoError(t, nc.NatsConn().Flush())
+
+	sz, err := ns.Subsz(&natsserver.SubszOptions{Subscriptions: true, Limit: 1000})
+	require.NoError(t, err)
+
+	subjects := make([]string, 0, len(sz.Subs))
+	for _, sub := range sz.Subs {
+		if sub.Queue != registerTestQueue {
+			continue
+		}
+		subjects = append(subjects, sub.Subject)
+	}
+	sort.Strings(subjects)
+	return subjects
+}
+
+// TestUserService_RegisterHandlers_SubjectSet pins the exact set of NATS
+// subjects user-service subscribes to. A dropped, renamed, or accidentally
+// added registration fails here rather than shipping silently.
+func TestUserService_RegisterHandlers_SubjectSet(t *testing.T) {
+	want := []string{
+		"chat.server.request.user.site-a.badge.count.batch",
+		"chat.user.*.request.user.site-a.apps.categories",
+		"chat.user.*.request.user.site-a.apps.list",
+		"chat.user.*.request.user.site-a.chatlist.get",
+		"chat.user.*.request.user.site-a.chatlist.section.create",
+		"chat.user.*.request.user.site-a.chatlist.section.delete",
+		"chat.user.*.request.user.site-a.chatlist.section.rename",
+		"chat.user.*.request.user.site-a.chatlist.section.reorder",
+		"chat.user.*.request.user.site-a.chatlist.section.setsortmode",
+		"chat.user.*.request.user.site-a.me",
+		"chat.user.*.request.user.site-a.profile.getByName",
+		"chat.user.*.request.user.site-a.settings.get",
+		"chat.user.*.request.user.site-a.settings.priorityContacts.add",
+		"chat.user.*.request.user.site-a.settings.priorityContacts.get",
+		"chat.user.*.request.user.site-a.settings.priorityContacts.remove",
+		"chat.user.*.request.user.site-a.settings.set",
+		"chat.user.*.request.user.site-a.sso.refresh",
+		"chat.user.*.request.user.site-a.sso.set",
+		"chat.user.*.request.user.site-a.status.getByName",
+		"chat.user.*.request.user.site-a.status.set",
+		"chat.user.*.request.user.site-a.subscription.count",
+		"chat.user.*.request.user.site-a.subscription.getByRoomID",
+		"chat.user.*.request.user.site-a.subscription.getChannels",
+		"chat.user.*.request.user.site-a.subscription.getDM",
+		"chat.user.*.request.user.site-a.subscription.list",
+		"chat.user.*.request.user.site-a.subscription.setAppSubscription",
+		"chat.user.*.request.user.site-a.thread.list",
+		"chat.user.*.request.user.site-a.thread.read.all",
+		"chat.user.*.request.user.site-a.thread.unread.summary",
+	}
+
+	got := registeredSubjects(t, "site-a")
+
+	assert.ElementsMatch(t, want, got,
+		"registered subject set drifted; update this golden set only alongside a deliberate RegisterHandlers change")
+}
+
+// TestUserService_RegisterHandlers_SiteScoped guards the doc comment's claim
+// that siteID is a literal token in every pattern: a subject that lost its site
+// token (or carried a wildcard there) would subscribe this instance to other
+// sites' traffic.
+func TestUserService_RegisterHandlers_SiteScoped(t *testing.T) {
+	const siteID = "zz9-site"
+
+	got := registeredSubjects(t, siteID)
+	require.NotEmpty(t, got, "no subjects registered; the seam is not observing RegisterHandlers")
+
+	for _, subj := range got {
+		assert.Contains(t, strings.Split(subj, "."), siteID,
+			"subject %q does not pin siteID as a literal token — cross-site subscription leak", subj)
+	}
+}

--- a/user-service/service/threadfanout_test.go
+++ b/user-service/service/threadfanout_test.go
@@ -1,0 +1,190 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/user-service/config"
+	"github.com/hmchangw/chat/user-service/service/mocks"
+)
+
+// newTopologyThreadSvc builds a UserService whose thread fan-out set is exactly
+// allSiteIDs, so a test can pick the topology (local-only, or several remotes)
+// instead of the fixed site-a/site-b pair newThreadSvc hardcodes.
+func newTopologyThreadSvc(t *testing.T, siteID string, allSiteIDs []string) (*UserService, *mocks.MockHistoryClient) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	history := mocks.NewMockHistoryClient(ctrl)
+	cfg := &config.Config{SiteID: siteID, AllSiteIDs: allSiteIDs, MaxSubscriptionLimit: 1000, MaxAccountNames: 100, MaxSiteFanout: 8}
+	svc := New(
+		mocks.NewMockSubscriptionRepository(ctrl),
+		mocks.NewMockUserRepository(ctrl),
+		mocks.NewMockAppRepository(ctrl),
+		mocks.NewMockThreadSubscriptionRepository(ctrl),
+		mocks.NewMockRoomClient(ctrl),
+		history,
+		mocks.NewMockPresenceClient(ctrl),
+		mocks.NewMockEventPublisher(ctrl),
+		mocks.NewMockEventPublisher(ctrl),
+		&fakeBadgeCache{},
+		nil, nil, nil,
+		cfg,
+	)
+	return svc, history
+}
+
+// The caller's own site is served directly, so its failure degrades the same
+// way a remote one does: the site is reported unavailable and the surviving
+// sites still contribute their rows.
+func TestUserService_ListUserThreads_LocalSiteFailureDegrades(t *testing.T) {
+	svc, history, _, _ := newThreadSvc(t)
+	history.EXPECT().GetThreadList(gomock.Any(), "site-a", gomock.Any()).
+		Return(model.ThreadSubscriptionListResponse{}, errors.New("local history down"))
+	expectThreadList(history, "site-b", []model.ThreadListItem{item("site-b", "tb1", 40), item("site-b", "tb2", 30)}, true)
+
+	resp, err := svc.ListUserThreads(ctx("alice", "site-a"), model.ThreadListRequest{Limit: 10})
+	require.NoError(t, err, "a failed local site must degrade, not fail the request")
+	assert.Equal(t, []string{"tb1", "tb2"}, ids(resp.Items), "only the healthy site contributes rows")
+	assert.Equal(t, []string{"site-a"}, resp.UnavailableSites)
+	assert.True(t, resp.HasNext, "the healthy site's hasMore still drives pagination")
+}
+
+// Both sites down: every row is lost, both are reported, and the empty page is
+// still a well-formed success.
+func TestUserService_ListUserThreads_AllSitesFailDegrades(t *testing.T) {
+	svc, history, _, _ := newThreadSvc(t)
+	history.EXPECT().GetThreadList(gomock.Any(), "site-a", gomock.Any()).
+		Return(model.ThreadSubscriptionListResponse{}, errors.New("local history down"))
+	history.EXPECT().GetThreadList(gomock.Any(), "site-b", gomock.Any()).
+		Return(model.ThreadSubscriptionListResponse{}, errors.New("site-b down"))
+
+	resp, err := svc.ListUserThreads(ctx("alice", "site-a"), model.ThreadListRequest{Limit: 10})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Items)
+	assert.NotNil(t, resp.Items, "never nil — JSON [] not null")
+	assert.Equal(t, []string{"site-a", "site-b"}, resp.UnavailableSites)
+	assert.False(t, resp.HasNext)
+	assert.Empty(t, resp.NextCursor)
+}
+
+// A single-site deployment has no remote peers: the fan-out machinery is
+// skipped entirely and the local rows are served on their own.
+func TestUserService_ListUserThreads_LocalOnlyTopology(t *testing.T) {
+	tests := []struct {
+		name       string
+		allSiteIDs []string
+	}{
+		{"local site is the only configured site", []string{"site-a"}},
+		{"no federation sites configured", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, history := newTopologyThreadSvc(t, "site-a", tt.allSiteIDs)
+			// The strict mock has one expectation: any cross-site RPC fails the test.
+			expectThreadList(history, "site-a", []model.ThreadListItem{item("site-a", "ta1", 50)}, false)
+
+			resp, err := svc.ListUserThreads(ctx("alice", "site-a"), model.ThreadListRequest{Limit: 10})
+			require.NoError(t, err)
+			assert.Equal(t, []string{"ta1"}, ids(resp.Items))
+			assert.Empty(t, resp.UnavailableSites)
+			assert.False(t, resp.HasNext)
+		})
+	}
+}
+
+// A context already cancelled when the fan-out starts admits no remote site:
+// each is marked unavailable without an RPC, while the direct local read still
+// returns its rows.
+func TestUserService_ListUserThreads_CancelledContextSkipsRemoteSites(t *testing.T) {
+	svc, history := newTopologyThreadSvc(t, "site-a", []string{"site-a", "site-b", "site-c"})
+	// Only the local read is expected — a remote RPC on a cancelled context fails the test.
+	expectThreadList(history, "site-a", []model.ThreadListItem{item("site-a", "ta1", 50)}, false)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	c := ctx("alice", "site-a")
+	c.SetContext(cancelled)
+
+	resp, err := svc.ListUserThreads(c, model.ThreadListRequest{Limit: 10})
+	require.NoError(t, err, "cancellation degrades the remote sites, it does not fail the request")
+	assert.Equal(t, []string{"ta1"}, ids(resp.Items))
+	assert.Equal(t, []string{"site-b", "site-c"}, resp.UnavailableSites)
+}
+
+// cancelAfterCtx stays live for the first `remaining` Err() observations and is
+// cancelled from then on. It lets a test land a cancellation strictly between
+// the fan-out's admission check and the worker goroutine's re-check, which real
+// wall-clock cancellation could only hit by luck.
+type cancelAfterCtx struct {
+	context.Context
+	mu        sync.Mutex
+	remaining int
+}
+
+func (c *cancelAfterCtx) Err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.remaining > 0 {
+		c.remaining--
+		return nil
+	}
+	return context.Canceled
+}
+
+// A site admitted into the fan-out but cancelled before its goroutine runs is
+// abandoned at the re-check: no RPC is issued and the site is marked failed, so
+// the caller reports it unavailable rather than silently returning zero rows
+// for it.
+func TestUserService_EnrichCrossSiteThreads_CancelledAfterAdmission(t *testing.T) {
+	// No GetThreadList expectation at all: the strict mock fails if the
+	// abandoned site is still dialled.
+	svc, _ := newTopologyThreadSvc(t, "site-a", []string{"site-a", "site-b"})
+
+	c := ctx("alice", "site-a")
+	// One live observation covers the admission check; the goroutine's re-check
+	// then sees a cancelled context.
+	c.SetContext(&cancelAfterCtx{Context: context.Background(), remaining: 1})
+
+	sites := []string{"site-a", "site-b"}
+	results := make([]threadSiteResult, len(sites))
+	svc.enrichCrossSiteThreads(c, sites, results, []int{1}, model.ThreadSubscriptionListRequest{Account: "alice", Limit: 10})
+
+	assert.True(t, results[1].failed, "the abandoned site must be marked failed")
+	assert.Empty(t, results[1].items)
+	assert.False(t, results[1].hasMore)
+	assert.Equal(t, threadSiteResult{}, results[0], "the local slot is untouched by the cross-site pass")
+}
+
+// With no remote sites in the index set the fan-out is a no-op: it leaves every
+// result slot at its zero value (available, empty) rather than marking sites
+// failed.
+func TestUserService_EnrichCrossSiteThreads_NoRemoteSites(t *testing.T) {
+	svc, _ := newTopologyThreadSvc(t, "site-a", []string{"site-a"})
+
+	sites := []string{"site-a"}
+	results := []threadSiteResult{{items: []model.ThreadListItem{item("site-a", "ta1", 50)}, hasMore: true}}
+	svc.enrichCrossSiteThreads(ctx("alice", "site-a"), sites, results, nil, model.ThreadSubscriptionListRequest{Account: "alice"})
+
+	require.Len(t, results, 1)
+	assert.False(t, results[0].failed)
+	assert.Equal(t, []string{"ta1"}, ids(results[0].items), "the local result survives the no-op pass")
+	assert.True(t, results[0].hasMore)
+}
+
+// enrichLocalThreads with nothing to serve leaves the results untouched — the
+// aggregator relies on that when the caller's own site is absent from the set.
+func TestUserService_EnrichLocalThreads_NoLocalSite(t *testing.T) {
+	svc, _ := newTopologyThreadSvc(t, "site-a", []string{"site-a", "site-b"})
+
+	results := make([]threadSiteResult, 2)
+	svc.enrichLocalThreads(ctx("alice", "site-a"), []string{"site-a", "site-b"}, results, nil, model.ThreadSubscriptionListRequest{Account: "alice"})
+
+	assert.Equal(t, make([]threadSiteResult, 2), results)
+}


### PR DESCRIPTION
Tests only — **no production code is touched anywhere in this PR**. Closes the `critical` and both `high` coverage findings from the `user-service` production-readiness audit.

## Coverage

| Measure | Before | After |
|---|---|---|
| Raw `go test -coverprofile` total | 53.0% | **63.1%** |
| Excluding generated mocks (`service/mocks`, 306 stmts) | 61.0% | **72.8%** |
| …and excluding `mongorepo` (integration-only) | 76.6% | **87.4%** |

Per package:

| Package | Before | After |
|---|---|---|
| `service` | 85.3% | **97.7%** |
| `publisher` | 0.0% *(no test files)* | **100.0%** |
| `roomclient` | 0.0% *(no test files)* | **92.0%** |
| `presenceclient` | 0.0% *(no test files)* | **92.3%** |
| `historyclient` | 44.0% | **88.0%** |
| `user-service` (root) | 26.2% | **30.6%** |
| `config` | 95.7% | 95.7% |
| `mongorepo` | 16.3% | 19.0% |

### Read the headline number carefully

**63.1% is not the service's real coverage, and neither was 53.0%.** Two distortions, both present before and after:

1. **`service/mocks` (306 generated statements) is counted.** It can never be executed. No `-exclude` is applied because no coverage gate exists for this service.
2. **`mongorepo` reads 19.0% but has 88 integration tests** behind `//go:build integration`, which need Docker and did not run here. Its real coverage is far higher; writing unit tests for it would duplicate that suite, so this PR deliberately does not.

Excluding both distortions, the genuinely unit-testable surface is at **87.4%**, over the CLAUDE.md §4 floor. The audit's actual conclusion stands: the deeper problem is that **nobody measures this service** — `tools/coveragecheck` is wired only for `tools/loadgen`. A gate at `-min 80 -exclude service/mocks` measured with `-tags integration` is the real fix and is **not** in this PR.

## What was added

- **`service/chatlist.go`** — six client-facing `chat.user.*` RPCs were at 0%. Now 100% each (`publishChatlistInbox` 81.8%): happy paths, section placement, UUIDv7 ids, name trimming and the 50-rune boundary, duplicate-name conflict, built-in immutability, unknown/empty section ids, six non-permutation reorder shapes, pre-lookup rejection that must not reach the repo, all four repository failure modes, and both cross-site fanouts agreeing on one timestamp. The file's five pre-existing helper tests were also converted off raw `t.Errorf` onto testify, matching the other 49 files.
- **`service.RegisterHandlers`** — 0% → 100%. Pins all 29 subjects with `ElementsMatch` so both a dropped *and* an added registration fail, and asserts `siteID` appears as a literal token in every subject, guarding the cross-site-leak claim in its doc comment.
- **Thread fan-out and app publish error paths** — `enrichLocalThreads` 57.1% → 100%, `enrichCrossSiteThreads` 79.2% → 100%, `publishSubscriptionUpdate` 50% → 100%. Branches were identified from `count 0` blocks in the coverage profile rather than guessed.
- **`publisher`, `roomclient`, `presenceclient`** — had integration-tagged tests only, so a default `make test` validated none of their marshalling or error mapping. Now unit-tested without Docker.
- **`historyclient.GetThreadList`** — 0% → 91.7%, reusing the `startTestNATS` helper its sibling `RoomsGet` already used.
- **`oidcValidator`** — 0% → 100%, including the `TLSSkipVerify` warn path, reached locally with no network.

## Notable testing decisions

**`RegisterHandlers` uses the NATS server as the seam.** `natsrouter.Router` keeps `subs` unexported and offers no accessor, and the parameter is a concrete `*Router` so no fake is substitutable. Rather than add an exported accessor to production code, the test boots an embedded in-process server and queries `Subsz` for the subjects actually subscribed — closer to production truth than any in-process accessor, and it exercises the real `Register` → `QueueSubscribe` path.

**Embedded in-process NATS, not testcontainers.** Every client test uses the `startTestNATS` pattern already established in `historyclient/client_test.go` and `broadcast-worker/consumeloop_test.go`. Embedded JetStream works (`Options{JetStream: true, StoreDir: t.TempDir()}`), so `publisher`'s JetStream path needed no fallback. No new `TestMain` was added where an integration file already defines one.

**Red phase, honestly.** The production code already existed, so "write a failing test first" could not apply literally. Instead each agent verified its assertions by mutation: deliberately breaking an expectation, confirming the specific test failed with the real value, then restoring. Tests assert observable behavior — persisted state, wire payloads, decoded results — not mock call counts.

## Known gaps left in place

Every remaining sub-100% figure in the touched packages is the same unreachable construct: a `json.Marshal` error return on a struct that cannot fail to marshal (only strings, ints, bools, slices, and `json.RawMessage` we produced). Sites: `chatlist.go:213-217`, `historyclient/client.go:35-37`, `roomclient/client.go:42,65,87,107`, `presenceclient/client.go:34`. Covering them needs an injected marshaller — a production change, deliberately out of scope.

`user-service` (root) stays at 30.6%: the rest is `main.go` wiring and the Docker-gated `integration_test.go`.

## Verification

- `go test ./user-service/... -race -count=1` — all packages pass
- `golangci-lint run ./...` — 0 issues
- `go vet -tags=integration ./user-service/...` — compiles, so the integration build is not broken by the new untagged files
- No production files modified (`git diff --stat` against `main` shows `_test.go` files only)

**Not run:** the Docker-gated integration suites, unavailable in the authoring environment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuhqJuKeDMECbxxJponH1A)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for thread lists, presence, room operations, publishing, OIDC validation, chatlists, handler registration, and thread fan-out.
  * Verified routing, validation, response handling, timeouts, cancellation, empty results, and remote error scenarios.
  * Confirmed subscription changes remain successful when optional event notifications cannot be published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->