### PR TITLE
Decode attachments in thread-list responses

### DIFF
--- a/docs/superpowers/plans/2026-08-28-thread-list-attachment-decode.md
+++ b/docs/superpowers/plans/2026-08-28-thread-list-attachment-decode.md
@@ -1,0 +1,120 @@
+# Thread-List Attachment Decode — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `chat.user.{account}.request.user.{siteID}.thread.list` return each row's `parentMessage.attachments` and `lastMessage.attachments`, matching the shape every other history read path already emits and the contract `docs/client-api.md` already publishes.
+
+**Architecture:** `buildThreadItems` pre-marshals both message bodies into `json.RawMessage` before user-service forwards them verbatim. It is the only hydration path in the service that skips `decodeMessageAttachments`, so the decoded field is never filled and `omitempty` drops the key. The fix adds the existing decode pass at that one call site — no new helper, no signature change, no repository change.
+
+**Tech Stack:** Go 1.25, Cassandra (`gocql`), `go.uber.org/mock` (mockgen), `stretchr/testify`.
+
+**Spec:** No separate design doc — bounded change agreed in chat. The design is restated in full under "Design Decisions" below; executors read this file alone.
+
+## Global Constraints
+
+- Go 1.25. Single `go.mod` at repo root.
+- Never run raw `go` commands — always the root `Makefile` targets (`make test SERVICE=history-service`, `make lint`).
+- TDD is mandatory: write the failing test, run it, confirm it fails, then implement.
+- Minimum 80% coverage; target 90%+ for this service-layer logic.
+- All tests use `-race` (the Makefile handles it).
+- Unit tests never connect to a real database, NATS, or any external service.
+- Branch: `claude/thread-list-attachments-gi77e7`. Never push elsewhere.
+
+---
+
+## Root Cause
+
+`pkg/model/cassandra/message.go:84-85` splits the attachment column across two fields with deliberately opposite tags:
+
+```go
+Attachments        [][]byte     `json:"-"                     cql:"attachments"`
+DecodedAttachments []Attachment `json:"attachments,omitempty" cql:"-"`
+```
+
+The raw `LIST<BLOB>` column is scanned from Cassandra but never serialized. The field the client actually receives is `DecodedAttachments`, which Cassandra never fills — only `decodeMessageAttachments` (`attachments.go:24`) does.
+
+`buildThreadItems` (`threads.go:203`) marshals the hydrated rows directly:
+
+```go
+parentJSON, err := json.Marshal(&parent)   // threads.go:243
+lastJSON,   err := json.Marshal(&last)     // threads.go:250
+```
+
+`GetMessagesByIDs` **does** select the column (`baseColumns`, `messages_by_room.go:14`), so the blobs are present in memory — they are simply never decoded. Result: no `attachments` key at all in either body.
+
+Every sibling path already decodes — `GetThreadMessages` (`threads.go:61`, `:139`), `GetMessageByID` (`messages.go:441`), `msg.get.ids` (`messages.go:234`), and the room-list preview walk (`rooms.go:279`, whose comment reads *"The walk reads raw blobs; other paths decode via setDecodedAttachments"*). `buildThreadItems` is the single omission.
+
+Nothing downstream contributes: `ThreadListItem.ParentMessage`/`LastMessage` are `json.RawMessage` and user-service forwards them untouched (`pkg/model/threadlist.go:33-34`), so history-service's marshal output is exactly what reaches the client.
+
+---
+
+## Design Decisions (agreed, do not re-litigate)
+
+1. **Two decode calls, nothing more.** Add `decodeMessageAttachments(c, &parent)` and `decodeMessageAttachments(c, &last)` immediately before the two `json.Marshal` calls. Reuse the existing helper; do not add a thread-list-specific variant.
+
+2. **Placement.** After the `hasParent`/`hasLast` skip and after the `LastSeenAt` assignment, before the marshals. Decoding a row that is about to be skipped would be wasted work.
+
+3. **Mutation is safe.** `parent` and `last` are loop-local copies pulled out of the `msgByID` map by value, so mutating them cannot alias another row.
+
+4. **Quoted parents come free.** `decodeMessageAttachments` also decodes `m.QuotedParentMessage`, which the thread list needs for quoted-reply previews. This is a required behavior, not incidental — it gets its own test.
+
+5. **No `decodeMessageCard` — it does not exist and is not needed.** `Card`/`CardAction` are Cassandra UDTs with symmetric tags (`json:"card,omitempty" cql:"card"`), both present in `baseColumns`, so they already scan and marshal correctly on this path. Do not add a card decode function.
+
+6. **`resolveRemovedMemberName` is out of scope.** `GetMessageByID` runs it after decoding; `buildThreadItems` does not. That concerns legacy system-message display names, not attachments, and is explicitly excluded (confirmed in chat).
+
+7. **Leniency is inherited, not reimplemented.** `DecodeAttachments` skips malformed blobs and counts them; the helper logs the count at WARN. A bad blob must never drop the row from the page.
+
+8. **No `docs/client-api.md` change.** `docs/client-api.md:2910` already documents `attachments` on the Message schema, and thread.list's `parentMessage`/`lastMessage` are typed `[Message](#message-schema)` (`:5842-5843`). The server was violating its own published contract; the fix makes it conform. No schema, struct, or handler registration changes, so the derived views (`request-reply.md`, `events.md`) are untouched too.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `history-service/internal/service/threads.go` | Modify (`buildThreadItems`, ~`:240`) | Add the two decode calls before the marshals. |
+| `history-service/internal/service/threadlist_test.go` | Modify | Four new tests plus two local helpers. |
+
+No new files, no interface changes, no mock regeneration.
+
+---
+
+## Tasks
+
+### Task 1 — Red: tests that pin the missing decode
+
+- [ ] Add helper `attachmentBlobs(t, ...cassandra.Attachment) [][]byte` wrapping `cassandra.EncodeAttachments`, to build the raw column form.
+- [ ] Add helper `rawBody(t, json.RawMessage) map[string]any`, so key presence/absence is assertable (a decode into `models.Message` cannot distinguish "absent" from "null").
+- [ ] `TestHistoryService_ListThreadSubscriptions_DecodesAttachments` — parent and last each carry one encoded attachment; assert both bodies expose the decoded objects (id, title, fileType, imageUrl) and that raw blobs stay off the wire.
+- [ ] `TestHistoryService_ListThreadSubscriptions_DecodesQuotedParentAttachments` — the last message carries a `QuotedParentMessage` with its own attachment; assert it decodes.
+- [ ] `TestHistoryService_ListThreadSubscriptions_MalformedAttachmentSkipped` — one bad blob alongside one good; assert the good one ships and the row is **not** dropped.
+- [ ] `TestHistoryService_ListThreadSubscriptions_NoAttachmentsOmitsKey` — no attachments; assert the key is absent, not `null`. (This one passes before the fix — it is the regression guard against emitting `[]`/`null`.)
+- [ ] Run `make test SERVICE=history-service`. **Confirm the first three FAIL** with empty attachment slices. Do not proceed until the failure is observed.
+
+### Task 2 — Green: the decode calls
+
+- [ ] In `buildThreadItems`, before `json.Marshal(&parent)`, add:
+  ```go
+  // Both bodies ship pre-marshaled, so decode here: the raw blob column is
+  // json:"-" and only DecodedAttachments reaches the client.
+  decodeMessageAttachments(c, &parent)
+  decodeMessageAttachments(c, &last)
+  ```
+- [ ] Run `make test SERVICE=history-service` — all four green, no existing test regressed.
+
+### Task 3 — Verify
+
+- [ ] `make lint` → 0 issues.
+- [ ] `make test SERVICE=history-service` → all packages ok.
+- [ ] `make sast` → no new medium+ findings.
+- [ ] Commit on `claude/thread-list-attachments-gi77e7`.
+
+---
+
+## Risks
+
+| Risk | Assessment |
+|---|---|
+| Payload size growth | Real but bounded. Decoded attachments are larger than the omitted key, and `user-service` already trims oversize rows via `blankOversizeThread` / `fitThreadPage`, so an inflated row degrades to `truncated: true` rather than breaking the page. Behavior matches every other read path. |
+| Double decode | None. `buildThreadItems` is the only pass over these copies, and `DecodeAttachments` is a pure function of the raw column. |
+| Client breakage | None expected — this adds a documented, previously-missing field. A client ignoring `attachments` is unaffected. |

--- a/history-service/internal/service/threadlist_test.go
+++ b/history-service/internal/service/threadlist_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hmchangw/chat/history-service/internal/service/mocks"
 	"github.com/hmchangw/chat/pkg/errcode"
 	pkgmodel "github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/model/cassandra"
 )
 
 // decodeThreadMsg decodes an opaque ThreadListItem body back into a message for
@@ -367,4 +368,131 @@ func TestHistoryService_ListThreadSubscriptions_CursorConverted(t *testing.T) {
 	require.NotNil(t, gotTs)
 	assert.Equal(t, base.UnixMilli(), gotTs.UnixMilli())
 	assert.Equal(t, "tr-9", gotID)
+}
+
+// attachmentBlobs encodes attachments into the raw LIST<BLOB> column form the
+// hydrated Cassandra rows carry.
+func attachmentBlobs(t *testing.T, atts ...cassandra.Attachment) [][]byte {
+	t.Helper()
+	raw := cassandra.EncodeAttachments(atts)
+	require.Len(t, raw, len(atts))
+	return raw
+}
+
+// rawBody unmarshals an opaque item body into its wire form. Assert on this map
+// rather than models.Message so key presence/absence is observable.
+func rawBody(t *testing.T, body json.RawMessage) map[string]any {
+	t.Helper()
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	return raw
+}
+
+// The list bodies must carry decoded attachments: the raw LIST<BLOB> column is
+// json:"-", so a body built without decoding reaches the client with no
+// attachments key at all.
+func TestHistoryService_ListThreadSubscriptions_DecodesAttachments(t *testing.T) {
+	svc, msgs, _, _, threadSubs := newThreadListService(t)
+	base := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	rows := []mongorepo.ThreadSubRow{
+		{ThreadRoomID: "tr-1", RoomID: "r1", SiteID: "site-a", ParentMessageID: "p1", LastMsgID: "m1", LastMsgAt: base.Add(5 * time.Hour)},
+	}
+	threadSubs.EXPECT().ListUserThreadSubscriptions(gomock.Any(), "alice", gomock.Any(), gomock.Any(), gomock.Any()).Return(rows, false, nil)
+	msgs.EXPECT().GetMessagesByIDs(gomock.Any(), gomock.Any()).Return([]models.Message{
+		{MessageID: "p1", RoomID: "r1", Msg: "parent", Attachments: attachmentBlobs(t,
+			cassandra.Attachment{ID: "f-1", Title: "spec.pdf", Type: "file", TitleLink: "/d/f-1", FileType: "application/pdf"},
+		)},
+		{MessageID: "m1", RoomID: "r1", Msg: "last", Attachments: attachmentBlobs(t,
+			cassandra.Attachment{ID: "f-2", Title: "shot.png", Type: "file", TitleLink: "/d/f-2", ImageURL: "/i/f-2"},
+		)},
+	}, nil)
+
+	resp, err := svc.ListThreadSubscriptions(testContext(), pkgmodel.ThreadSubscriptionListRequest{Account: "alice", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, resp.Items, 1)
+
+	parent := decodeThreadMsg(t, resp.Items[0].ParentMessage)
+	require.Len(t, parent.DecodedAttachments, 1)
+	assert.Equal(t, "f-1", parent.DecodedAttachments[0].ID)
+	assert.Equal(t, "spec.pdf", parent.DecodedAttachments[0].Title)
+	assert.Equal(t, "application/pdf", parent.DecodedAttachments[0].FileType)
+
+	last := decodeThreadMsg(t, resp.Items[0].LastMessage)
+	require.Len(t, last.DecodedAttachments, 1)
+	assert.Equal(t, "f-2", last.DecodedAttachments[0].ID)
+	assert.Equal(t, "/i/f-2", last.DecodedAttachments[0].ImageURL)
+
+	// The raw blob column stays off the wire; only the decoded form ships.
+	assert.Contains(t, rawBody(t, resp.Items[0].ParentMessage), "attachments")
+	assert.Empty(t, parent.Attachments, "raw blobs are never serialized")
+}
+
+// A quoted parent carries its own attachments column; the decode must reach it
+// too or quoted-reply previews render without their files.
+func TestHistoryService_ListThreadSubscriptions_DecodesQuotedParentAttachments(t *testing.T) {
+	svc, msgs, _, _, threadSubs := newThreadListService(t)
+	base := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	rows := []mongorepo.ThreadSubRow{
+		{ThreadRoomID: "tr-1", RoomID: "r1", SiteID: "site-a", ParentMessageID: "p1", LastMsgID: "m1", LastMsgAt: base.Add(5 * time.Hour)},
+	}
+	threadSubs.EXPECT().ListUserThreadSubscriptions(gomock.Any(), "alice", gomock.Any(), gomock.Any(), gomock.Any()).Return(rows, false, nil)
+	msgs.EXPECT().GetMessagesByIDs(gomock.Any(), gomock.Any()).Return([]models.Message{
+		{MessageID: "p1", RoomID: "r1", Msg: "parent"},
+		{MessageID: "m1", RoomID: "r1", Msg: "last", QuotedParentMessage: &models.QuotedParentMessage{
+			MessageID: "q1", RoomID: "r1", CreatedAt: base, Msg: "quoted",
+			Attachments: attachmentBlobs(t, cassandra.Attachment{ID: "f-3", Title: "quoted.pdf", Type: "file", TitleLink: "/d/f-3"}),
+		}},
+	}, nil)
+
+	resp, err := svc.ListThreadSubscriptions(testContext(), pkgmodel.ThreadSubscriptionListRequest{Account: "alice", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, resp.Items, 1)
+
+	last := decodeThreadMsg(t, resp.Items[0].LastMessage)
+	require.NotNil(t, last.QuotedParentMessage)
+	require.Len(t, last.QuotedParentMessage.DecodedAttachments, 1)
+	assert.Equal(t, "f-3", last.QuotedParentMessage.DecodedAttachments[0].ID)
+}
+
+// Decoding is lenient: a malformed blob is skipped, the good ones still ship,
+// and the row is never dropped from the page.
+func TestHistoryService_ListThreadSubscriptions_MalformedAttachmentSkipped(t *testing.T) {
+	svc, msgs, _, _, threadSubs := newThreadListService(t)
+	base := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	rows := []mongorepo.ThreadSubRow{
+		{ThreadRoomID: "tr-1", RoomID: "r1", SiteID: "site-a", ParentMessageID: "p1", LastMsgID: "m1", LastMsgAt: base.Add(5 * time.Hour)},
+	}
+	good := attachmentBlobs(t, cassandra.Attachment{ID: "f-1", Title: "ok.pdf", Type: "file", TitleLink: "/d/f-1"})
+	threadSubs.EXPECT().ListUserThreadSubscriptions(gomock.Any(), "alice", gomock.Any(), gomock.Any(), gomock.Any()).Return(rows, false, nil)
+	msgs.EXPECT().GetMessagesByIDs(gomock.Any(), gomock.Any()).Return([]models.Message{
+		{MessageID: "p1", RoomID: "r1", Msg: "parent", Attachments: [][]byte{[]byte("{not json"), good[0]}},
+		{MessageID: "m1", RoomID: "r1", Msg: "last"},
+	}, nil)
+
+	resp, err := svc.ListThreadSubscriptions(testContext(), pkgmodel.ThreadSubscriptionListRequest{Account: "alice", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, resp.Items, 1, "a bad blob must not drop the row")
+	parent := decodeThreadMsg(t, resp.Items[0].ParentMessage)
+	require.Len(t, parent.DecodedAttachments, 1)
+	assert.Equal(t, "f-1", parent.DecodedAttachments[0].ID)
+}
+
+// A message with no attachments omits the key entirely rather than emitting null.
+func TestHistoryService_ListThreadSubscriptions_NoAttachmentsOmitsKey(t *testing.T) {
+	svc, msgs, _, _, threadSubs := newThreadListService(t)
+	base := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	rows := []mongorepo.ThreadSubRow{
+		{ThreadRoomID: "tr-1", RoomID: "r1", SiteID: "site-a", ParentMessageID: "p1", LastMsgID: "m1", LastMsgAt: base.Add(5 * time.Hour)},
+	}
+	threadSubs.EXPECT().ListUserThreadSubscriptions(gomock.Any(), "alice", gomock.Any(), gomock.Any(), gomock.Any()).Return(rows, false, nil)
+	msgs.EXPECT().GetMessagesByIDs(gomock.Any(), gomock.Any()).Return([]models.Message{
+		{MessageID: "p1", RoomID: "r1", Msg: "parent"},
+		{MessageID: "m1", RoomID: "r1", Msg: "last"},
+	}, nil)
+
+	resp, err := svc.ListThreadSubscriptions(testContext(), pkgmodel.ThreadSubscriptionListRequest{Account: "alice", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, resp.Items, 1)
+	assert.NotContains(t, rawBody(t, resp.Items[0].ParentMessage), "attachments")
+	assert.NotContains(t, rawBody(t, resp.Items[0].LastMessage), "attachments")
 }

--- a/history-service/internal/service/threads.go
+++ b/history-service/internal/service/threads.go
@@ -244,6 +244,10 @@ func (s *HistoryService) buildThreadItems(c *natsrouter.Context, rows []mongorep
 			ms := row.LastSeenAt.UTC().UnixMilli()
 			item.LastSeenAt = &ms
 		}
+		// Both bodies ship pre-marshaled, so decode here: the raw blob column is
+		// json:"-" and only DecodedAttachments reaches the client.
+		decodeMessageAttachments(c, &parent)
+		decodeMessageAttachments(c, &last)
 		parentJSON, err := json.Marshal(&parent)
 		if err != nil {
 			slog.WarnContext(c, "thread-list: marshaling parent message, skipping row",


### PR DESCRIPTION
## Summary

Thread-list responses (`ListThreadSubscriptions`) were omitting the `attachments` field from parent and last messages, violating the published API contract. The raw Cassandra `LIST<BLOB>` column was present in memory but never decoded to the `DecodedAttachments` field that clients receive.

This fix adds two `decodeMessageAttachments` calls in `buildThreadItems` to decode both the parent and last message attachments before marshaling, matching the behavior of all other message read paths in the service.

## Changes

- **`history-service/internal/service/threads.go`** — Added attachment decoding for parent and last messages immediately before JSON marshaling in `buildThreadItems` (~line 247).

- **`history-service/internal/service/threadlist_test.go`** — Added four comprehensive test cases:
  - `TestHistoryService_ListThreadSubscriptions_DecodesAttachments` — Verifies parent and last message attachments are decoded and exposed in the response body.
  - `TestHistoryService_ListThreadSubscriptions_DecodesQuotedParentAttachments` — Verifies quoted-reply parent attachments are also decoded.
  - `TestHistoryService_ListThreadSubscriptions_MalformedAttachmentSkipped` — Confirms malformed blobs are skipped without dropping the row.
  - `TestHistoryService_ListThreadSubscriptions_NoAttachmentsOmitsKey` — Confirms messages without attachments omit the key entirely (not `null`).
  
  Added two helper functions:
  - `attachmentBlobs` — Encodes attachments into raw `LIST<BLOB>` form for test setup.
  - `rawBody` — Unmarshals opaque message bodies to `map[string]any` for key presence/absence assertions.

- **`docs/superpowers/plans/2026-08-28-thread-list-attachment-decode.md`** — Implementation plan documenting root cause, design decisions, file structure, and task breakdown.

## Implementation Details

- **Placement:** Decoding happens after the `hasParent`/`hasLast` skip and `LastSeenAt` assignment, before marshaling — avoiding wasted work on skipped rows.
- **Mutation safety:** `parent` and `last` are loop-local copies, so mutation cannot alias other rows.
- **Quoted parents:** `decodeMessageAttachments` also decodes `m.QuotedParentMessage`, which is required for quoted-reply previews in the thread list.
- **Leniency:** Malformed blobs are skipped (inherited from `DecodeAttachments`); the row is never dropped from the page.
- **No schema change:** `docs/client-api.md` already documents `attachments` on the Message schema; this fix makes the server conform to its published contract.

All tests pass with `-race` enabled; coverage remains above 80%.

https://claude.ai/code/session_01TekPFHSgLsszJahoCbfH9e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Thread lists now include decoded attachments for parent messages and latest messages.
  * Attachments in quoted parent messages are also displayed correctly.
  * Malformed attachment data no longer prevents thread rows from loading.
  * Messages without attachments continue to omit the attachment field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->