### PR TITLE
fix(history-service): evict subscription access cache on membership change

### DIFF
--- a/history-service/cmd/main.go
+++ b/history-service/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/nats-io/nats.go"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
 
@@ -158,6 +159,13 @@ func main() {
 	}
 	slog.Info("mongo key read preference configured", "readPreference", keyReadPref.Mode().String())
 
+	subReadPref, err := mongoutil.ParseReadPreference(cfg.Mongo.SubscriptionReadPreference)
+	if err != nil {
+		slog.Error("invalid mongo subscription read preference", "value", cfg.Mongo.SubscriptionReadPreference, "error", err)
+		os.Exit(1)
+	}
+	slog.Info("mongo subscription read preference configured", "readPreference", subReadPref.Mode().String())
+
 	cassSession, err := cassutil.Connect(cassutil.Config{
 		Hosts:    cfg.Cassandra.Hosts,
 		Keyspace: cfg.Cassandra.Keyspace,
@@ -224,7 +232,7 @@ func main() {
 
 	cassRepo := cassrepo.NewRepository(cassSession, bucketSizer, cfg.MessageReadMaxBuckets, cipher)
 	db := mongoClient.Database(cfg.Mongo.DB)
-	subRepo := mongorepo.NewSubscriptionRepo(db)
+	subRepo := mongorepo.NewSubscriptionRepo(db, subReadPref)
 	roomRepo := mongorepo.NewRoomRepo(db, previewCipher, preview.Key{SiteID: cfg.SiteID, Epoch: cfg.PreviewKeyEpoch})
 	threadRoomRepo := mongorepo.NewThreadRoomRepo(db)
 	threadSubRepo := mongorepo.NewThreadSubscriptionRepo(db)
@@ -274,12 +282,45 @@ func main() {
 	base := subL2Source{l2: subL2, inner: subRepo}
 	var subSource service.SubscriptionRepository = base
 	if cfg.SubCacheSize > 0 && cfg.SubCacheTTL > 0 {
-		sc, err := readcache.NewSubscriptionCache(base, cfg.SubCacheSize, cfg.SubCacheTTL)
+		sc, err := readcache.NewSubscriptionCache(base, cfg.SubCacheSize, cfg.SubCacheTTL,
+			readcache.WithMaxInflight(cfg.SubCacheMaxInflight))
 		if err != nil {
 			slog.Error("init subscription cache failed", "error", err)
 			os.Exit(1)
 		}
 		subSource = sc
+		// Active invalidation: evict a member's cached access window the moment a
+		// membership change fans out, so the next msg.history read reflects the
+		// current boundary instead of the stale full-access entry (#414).
+		if err := startSubCacheInvalidation(ctx, nc, sc); err != nil {
+			slog.Error("subscribe subscription.update for cache invalidation failed", "error", err)
+			os.Exit(1)
+		}
+		// Core NATS gives no replay: an eviction fanned out while this instance was
+		// disconnected is lost, and the stale full-access entry would keep
+		// authorizing reads until TTL. Suspend the cache on disconnect (stop serving
+		// or storing grants + purge) and Resume it on reconnect (purge, then re-arm).
+		// The suspend barrier holds across the whole outage AND until the reconnect
+		// purge finishes, so no read is served from the pre-reconnect cache before
+		// the reconnect callback runs — it falls through to the primary instead.
+		// Chain the existing handlers (connection metrics) rather than replace them.
+		raw := nc.NatsConn()
+		prevReconnect := raw.Opts.ReconnectedCB
+		raw.SetReconnectHandler(func(c *nats.Conn) {
+			if prevReconnect != nil {
+				prevReconnect(c)
+			}
+			sc.Resume()
+			slog.Warn("nats reconnected: purged and re-armed subscription access cache to drop possibly-missed evictions")
+		})
+		prevDisconnect := raw.Opts.DisconnectedErrCB
+		raw.SetDisconnectErrHandler(func(c *nats.Conn, err error) {
+			if prevDisconnect != nil {
+				prevDisconnect(c, err)
+			}
+			sc.Suspend()
+			slog.Warn("nats disconnected: suspended subscription access cache; grants can't be invalidated while offline")
+		})
 		slog.Info("subscription cache enabled",
 			"size", cfg.SubCacheSize, "ttl", cfg.SubCacheTTL,
 			"sub_l2_ttl", cfg.SubL2.TTL,

--- a/history-service/cmd/subinvalidate.go
+++ b/history-service/cmd/subinvalidate.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	o11ynats "github.com/flywindy/o11y/nats"
+	"github.com/nats-io/nats.go"
+
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+// evictor is the subset of *readcache.SubscriptionCache the invalidation
+// subscription drives. Declared at the consumer so the decode step is testable
+// with a spy rather than a live cache.
+type evictor interface {
+	Evict(account, roomID string)
+}
+
+// subUpdateEnvelope is the minimal projection shared by both events published on
+// the subscription.update subject: model.SubscriptionUpdateEvent ("added", …)
+// and model.SubscriptionRemovedEvent ("removed"). Both nest roomId under
+// "subscription", and both carry the action at top level — so this single shape
+// decodes either without depending on which one arrived.
+type subUpdateEnvelope struct {
+	Action       string `json:"action"`
+	Subscription struct {
+		RoomID string `json:"roomId"`
+	} `json:"subscription"`
+}
+
+// isAccessBoundaryAction reports whether a subscription.update action changes a
+// member's history-access window (subscribed / historySharedSince). Only these
+// need an eviction: a re-add — including "Don't include history" — publishes
+// "added"; a remove publishes "removed". mute/favorite/read/role/section leave
+// the boundary untouched, and evicting on the high-frequency "read" would churn
+// the cache for no correctness gain.
+func isAccessBoundaryAction(action string) bool {
+	return action == "added" || action == "removed"
+}
+
+// evictOnSubscriptionUpdate decodes one subscription.update message and evicts
+// the (account, roomID) access-check entry when the action changes the access
+// boundary. account comes from the subject (the encoded token the event was
+// addressed to); roomID from the payload. Best-effort: an unparseable subject or
+// payload logs and returns without evicting — never panics, never crashes the
+// consumer.
+func evictOnSubscriptionUpdate(ev evictor, subj string, payload []byte) {
+	token, ok := subject.ParseSubscriptionUpdateAccount(subj)
+	if !ok {
+		slog.Warn("subscription.update: unparseable subject, skipping eviction", "subject", subj)
+		return
+	}
+	// The subject token is the encoded transport form; decode it so the cache key
+	// matches the decoded account natsrouter hands the read handlers (a ".bot"
+	// account is stored decoded). A no-op for every non-bot account.
+	account := subject.DecodeAccount(token)
+	var env subUpdateEnvelope
+	if err := json.Unmarshal(payload, &env); err != nil {
+		slog.Warn("subscription.update: decode failed, skipping eviction", "error", err, "account", account)
+		return
+	}
+	if !isAccessBoundaryAction(env.Action) || env.Subscription.RoomID == "" {
+		return
+	}
+	ev.Evict(account, env.Subscription.RoomID)
+}
+
+// startSubCacheInvalidation subscribes to every account's subscription.update
+// and evicts history-service's access-check cache on membership changes, closing
+// the stale-full-access window (#414). Non-queue core NATS: every instance must
+// receive every event to evict its own local cache. Best-effort — a dropped
+// event just falls back to the cache TTL. nc.Drain at shutdown tears the
+// subscription down, so the returned handle is discarded.
+func startSubCacheInvalidation(ctx context.Context, nc *o11ynats.Conn, ev evictor) error {
+	_, err := nc.Subscribe(ctx, subject.SubscriptionUpdateWildcard(), func(_ context.Context, msg *nats.Msg) {
+		evictOnSubscriptionUpdate(ev, msg.Subject, msg.Data)
+	})
+	if err != nil {
+		return fmt.Errorf("subscribe to subscription updates: %w", err)
+	}
+	return nil
+}

--- a/history-service/cmd/subinvalidate_test.go
+++ b/history-service/cmd/subinvalidate_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+type evictCall struct {
+	account string
+	roomID  string
+}
+
+type spyEvictor struct{ calls []evictCall }
+
+func (s *spyEvictor) Evict(account, roomID string) {
+	s.calls = append(s.calls, evictCall{account, roomID})
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}
+
+func TestEvictOnSubscriptionUpdate(t *testing.T) {
+	// Real add-path event shape.
+	added := mustJSON(t, model.SubscriptionUpdateEvent{
+		Action:       "added",
+		Subscription: model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"},
+	})
+	// Real remove-path event shape (a different struct on the same subject).
+	removed := mustJSON(t, model.SubscriptionRemovedEvent{
+		Action: "removed",
+		Subscription: model.RemovedSubscriptionRef{
+			RoomID: "r1",
+			U:      model.SubscriptionUser{Account: "alice"},
+		},
+	})
+
+	tests := []struct {
+		name    string
+		subj    string
+		payload []byte
+		want    []evictCall
+	}{
+		{
+			name:    "added evicts (account from subject, roomId from payload)",
+			subj:    subject.SubscriptionUpdate("alice"),
+			payload: added,
+			want:    []evictCall{{"alice", "r1"}},
+		},
+		{
+			name:    "removed evicts",
+			subj:    subject.SubscriptionUpdate("alice"),
+			payload: removed,
+			want:    []evictCall{{"alice", "r1"}},
+		},
+		{
+			name: "dotted bot account decoded from encoded subject token",
+			subj: subject.SubscriptionUpdate("weather.site-a.bot"),
+			payload: mustJSON(t, model.SubscriptionUpdateEvent{
+				Action:       "added",
+				Subscription: model.Subscription{User: model.SubscriptionUser{Account: "weather.site-a.bot"}, RoomID: "r2"},
+			}),
+			want: []evictCall{{"weather.site-a.bot", "r2"}},
+		},
+		{
+			name: "read action does not evict (boundary unchanged, high frequency)",
+			subj: subject.SubscriptionUpdate("alice"),
+			payload: mustJSON(t, model.SubscriptionUpdateEvent{
+				Action:       "read",
+				Subscription: model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"},
+			}),
+			want: nil,
+		},
+		{
+			name: "mute_toggled does not evict",
+			subj: subject.SubscriptionUpdate("alice"),
+			payload: mustJSON(t, model.SubscriptionUpdateEvent{
+				Action:       "mute_toggled",
+				Subscription: model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"},
+			}),
+			want: nil,
+		},
+		{
+			name: "added with empty roomId does not evict",
+			subj: subject.SubscriptionUpdate("alice"),
+			payload: mustJSON(t, model.SubscriptionUpdateEvent{
+				Action:       "added",
+				Subscription: model.Subscription{User: model.SubscriptionUser{Account: "alice"}},
+			}),
+			want: nil,
+		},
+		{
+			name:    "malformed payload does not evict or panic",
+			subj:    subject.SubscriptionUpdate("alice"),
+			payload: []byte("{not json"),
+			want:    nil,
+		},
+		{
+			name:    "wrong subject does not evict",
+			subj:    "chat.user.alice.event.settings.update",
+			payload: added,
+			want:    nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spy := &spyEvictor{}
+			assert.NotPanics(t, func() {
+				evictOnSubscriptionUpdate(spy, tc.subj, tc.payload)
+			})
+			assert.Equal(t, tc.want, spy.calls)
+		})
+	}
+}

--- a/history-service/internal/config/config.go
+++ b/history-service/internal/config/config.go
@@ -48,6 +48,13 @@ type MongoConfig struct {
 	// primaryPreferred rather than primary: without it, encrypted history cannot be
 	// read at all when there is no primary.
 	KeyReadPreference string `env:"KEY_READ_PREFERENCE" envDefault:"primaryPreferred"`
+	// SubscriptionReadPreference covers the subscriptions collection, which backs
+	// the access-control reads (GetSubscription / GetHistorySharedSince). It pins to
+	// strict primary — not primaryPreferred — so the read is read-your-writes and
+	// fails closed on a primary outage: primaryPreferred would fall back to a lagging
+	// secondary that could re-cache a stale pre-revocation grant until TTL, silently
+	// defeating the eviction. Env-overridable for operators who accept that trade-off.
+	SubscriptionReadPreference string `env:"SUBSCRIPTION_READ_PREFERENCE" envDefault:"primary"`
 }
 
 // NATSConfig holds NATS connection settings (env prefix: NATS_).
@@ -94,6 +101,10 @@ type Config struct {
 	// ttl to 0 to disable.
 	SubCacheSize int           `env:"HISTORY_SUB_CACHE_SIZE" envDefault:"100000"`
 	SubCacheTTL  time.Duration `env:"HISTORY_SUB_CACHE_TTL"  envDefault:"2m"`
+	// SubCacheMaxInflight caps concurrent source loads the sub-cache can have in
+	// flight, so a burst of distinct-key misses under slow Mongo can't spawn
+	// unbounded goroutines. 0 takes the package default.
+	SubCacheMaxInflight int `env:"HISTORY_SUB_CACHE_MAX_INFLIGHT" envDefault:"256"`
 
 	// Room metadata cache (room times + minUserLastSeenAt). lastMsgAt advances
 	// on every message, so the TTL is short by default; client room hints cover
@@ -192,6 +203,9 @@ func validate(cfg *Config) error {
 	if cfg.SubCacheTTL < 0 {
 		return fmt.Errorf("HISTORY_SUB_CACHE_TTL must be >= 0, got %s", cfg.SubCacheTTL)
 	}
+	if cfg.SubCacheMaxInflight < 0 {
+		return fmt.Errorf("HISTORY_SUB_CACHE_MAX_INFLIGHT must be >= 0, got %d", cfg.SubCacheMaxInflight)
+	}
 	if cfg.RoomCacheSize < 0 {
 		return fmt.Errorf("HISTORY_ROOM_CACHE_SIZE must be >= 0, got %d", cfg.RoomCacheSize)
 	}
@@ -228,6 +242,9 @@ func validate(cfg *Config) error {
 	}
 	if _, err := mongoutil.ParseReadPreference(cfg.Mongo.KeyReadPreference); err != nil {
 		return fmt.Errorf("MONGO_KEY_READ_PREFERENCE: %w", err)
+	}
+	if _, err := mongoutil.ParseReadPreference(cfg.Mongo.SubscriptionReadPreference); err != nil {
+		return fmt.Errorf("MONGO_SUBSCRIPTION_READ_PREFERENCE: %w", err)
 	}
 	if err := cfg.Pool.Validate(); err != nil {
 		return err

--- a/history-service/internal/config/config_test.go
+++ b/history-service/internal/config/config_test.go
@@ -463,6 +463,40 @@ func TestValidate_RejectsInvalidKeyReadPreference(t *testing.T) {
 	assert.Contains(t, err.Error(), "MONGO_KEY_READ_PREFERENCE")
 }
 
+// The subscriptions collection backs access-control reads, so its default pins
+// to strict primary rather than the service-wide secondaryPreferred — a lagging
+// secondary re-caches a stale grant after an eviction, and primaryPreferred would
+// fall back to one during a primary outage instead of failing closed.
+func TestLoad_DefaultsSubscriptionReadPreferenceToPrimary(t *testing.T) {
+	t.Setenv("MONGO_URI", "mongodb://localhost:27017")
+	t.Setenv("CASSANDRA_HOSTS", "localhost")
+	t.Setenv("NATS_URL", "nats://localhost:4222")
+	testutil.UnsetEnv(t, "MONGO_SUBSCRIPTION_READ_PREFERENCE")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, "primary", cfg.Mongo.SubscriptionReadPreference)
+}
+
+func TestValidate_RejectsInvalidSubscriptionReadPreference(t *testing.T) {
+	cfg := baseValid()
+	cfg.Mongo.SubscriptionReadPreference = "quorum"
+	err := validate(&cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MONGO_SUBSCRIPTION_READ_PREFERENCE")
+}
+
+func TestLoad_SubscriptionReadPreferenceWireName(t *testing.T) {
+	t.Setenv("MONGO_URI", "mongodb://localhost:27017")
+	t.Setenv("CASSANDRA_HOSTS", "localhost")
+	t.Setenv("NATS_URL", "nats://localhost:4222")
+	t.Setenv("MONGO_SUBSCRIPTION_READ_PREFERENCE", "nearest") // a value no default would produce
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, "nearest", cfg.Mongo.SubscriptionReadPreference)
+}
+
 // history-service's DEK handles must bind the same wire name as the other
 // key-touching services; its Mongo block carries an envPrefix, so the tag is
 // KEY_READ_PREFERENCE and the wire name is MONGO_KEY_READ_PREFERENCE.

--- a/history-service/internal/mongorepo/subscription.go
+++ b/history-service/internal/mongorepo/subscription.go
@@ -6,6 +6,8 @@ import (
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
 
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
@@ -17,9 +19,15 @@ type SubscriptionRepo struct {
 	subscriptions *mongoutil.Collection[model.Subscription]
 }
 
-func NewSubscriptionRepo(db *mongo.Database) *SubscriptionRepo {
+// NewSubscriptionRepo fronts the subscriptions collection. readPref pins this
+// collection's reads: these are access-control reads, and the service-wide
+// default is secondaryPreferred — a lagging secondary would let the sub-cache's
+// evict-then-reload re-cache a stale pre-revocation grant, so callers pass strict
+// primary here (read-your-writes, and fail-closed on a primary outage).
+func NewSubscriptionRepo(db *mongo.Database, readPref *readpref.ReadPref) *SubscriptionRepo {
+	coll := db.Collection(subscriptionsCollection, options.Collection().SetReadPreference(readPref))
 	return &SubscriptionRepo{
-		subscriptions: mongoutil.NewCollection[model.Subscription](db.Collection(subscriptionsCollection)),
+		subscriptions: mongoutil.NewCollection[model.Subscription](coll),
 	}
 }
 

--- a/history-service/internal/mongorepo/subscription_test.go
+++ b/history-service/internal/mongorepo/subscription_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
 
 	"github.com/hmchangw/chat/pkg/model"
 )
@@ -17,7 +18,7 @@ import (
 
 func TestSubscriptionRepo_GetSubscription(t *testing.T) {
 	db := setupMongo(t)
-	repo := NewSubscriptionRepo(db)
+	repo := NewSubscriptionRepo(db, readpref.Primary())
 	ctx := context.Background()
 
 	joinTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -41,7 +42,7 @@ func TestSubscriptionRepo_GetSubscription(t *testing.T) {
 // is a silent regression the unit guards, which only read the var, cannot see.
 func TestSubscriptionRepo_GetSubscription_ProjectionFields(t *testing.T) {
 	db := setupMongo(t)
-	repo := NewSubscriptionRepo(db)
+	repo := NewSubscriptionRepo(db, readpref.Primary())
 	ctx := context.Background()
 
 	joinTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -83,7 +84,7 @@ func TestSubscriptionRepo_GetSubscription_ProjectionFields(t *testing.T) {
 
 func TestSubscriptionRepo_GetSubscription_NotFound(t *testing.T) {
 	db := setupMongo(t)
-	repo := NewSubscriptionRepo(db)
+	repo := NewSubscriptionRepo(db, readpref.Primary())
 	ctx := context.Background()
 
 	sub, err := repo.GetSubscription(ctx, "nonexistent", "r1")
@@ -93,7 +94,7 @@ func TestSubscriptionRepo_GetSubscription_NotFound(t *testing.T) {
 
 func TestSubscriptionRepo_GetHistorySharedSince_NilHSS(t *testing.T) {
 	db := setupMongo(t)
-	repo := NewSubscriptionRepo(db)
+	repo := NewSubscriptionRepo(db, readpref.Primary())
 	ctx := context.Background()
 
 	// Insert subscription with no HistorySharedSince (owner — full history access)
@@ -113,7 +114,7 @@ func TestSubscriptionRepo_GetHistorySharedSince_NilHSS(t *testing.T) {
 
 func TestSubscriptionRepo_GetHistorySharedSince_WithHSS(t *testing.T) {
 	db := setupMongo(t)
-	repo := NewSubscriptionRepo(db)
+	repo := NewSubscriptionRepo(db, readpref.Primary())
 	ctx := context.Background()
 
 	joinTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -134,7 +135,7 @@ func TestSubscriptionRepo_GetHistorySharedSince_WithHSS(t *testing.T) {
 
 func TestSubscriptionRepo_GetHistorySharedSince_NotSubscribed(t *testing.T) {
 	db := setupMongo(t)
-	repo := NewSubscriptionRepo(db)
+	repo := NewSubscriptionRepo(db, readpref.Primary())
 	ctx := context.Background()
 
 	accessSince, subscribed, err := repo.GetHistorySharedSince(ctx, "nobody", "r1")

--- a/history-service/internal/readcache/metrics_test.go
+++ b/history-service/internal/readcache/metrics_test.go
@@ -20,7 +20,7 @@ func (r *fakeRecorder) Error(context.Context) { r.errs++ }
 func TestTTLCache_Metrics_HitMissError(t *testing.T) {
 	ctx := context.Background()
 	rec := &fakeRecorder{}
-	c, err := newTTLCache[string](10, time.Minute, rec)
+	c, err := newTTLCache[string](10, time.Minute, 0, rec)
 	require.NoError(t, err)
 
 	loadOK := func(context.Context) (string, bool, error) { return "v", true, nil }

--- a/history-service/internal/readcache/readcache.go
+++ b/history-service/internal/readcache/readcache.go
@@ -2,16 +2,21 @@
 // MongoDB lookups on the history-service read hot path: the subscription
 // access check, room times (lastMsgAt/createdAt), and minUserLastSeenAt.
 //
-// Freshness is TTL-bounded; there is no active invalidation. Following the
-// message-gatekeeper precedent, only positive subscriptions are cached —
-// "not subscribed" results and errors are never stored, so revoked access
-// goes stale by at most the subscription TTL and the negative path stays
-// always-fresh. Loads are deduped with singleflight.
+// Freshness is TTL-bounded; the subscription access cache is additionally
+// evicted on membership change (SubscriptionCache.Evict, driven by the
+// subscription.update subscription in cmd) so revoked or narrowed access takes
+// effect at once rather than after the TTL. Following the message-gatekeeper
+// precedent, only positive subscriptions are cached — "not subscribed" results
+// and errors are never stored, so the negative path stays always-fresh. Loads
+// are deduped with singleflight.
 package readcache
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2/expirable"
@@ -26,6 +31,16 @@ import (
 // the singleflight goroutine or pin the in-flight key. See the design spec.
 const fetchTimeout = 10 * time.Second
 
+// defaultMaxInflight bounds concurrent source loads per cache when a caller
+// gives no explicit cap. A burst of distinct-key misses would otherwise spawn a
+// goroutine + fetch context each, so this caps the fan-out; 0 disables it.
+const defaultMaxInflight = 256
+
+// loadHandle carries the cancel of an in-flight source load so a concurrent
+// remove/purge can cancel the now-superseded load instead of letting it run to
+// fetchTimeout. Boxed so a completing load deletes only its own entry.
+type loadHandle struct{ cancel context.CancelFunc }
+
 // Recorder records the outcome of a cache lookup. cachemetrics.Recorder
 // satisfies it; tests substitute a spy.
 type Recorder interface {
@@ -39,18 +54,47 @@ type ttlCache[V any] struct {
 	lru     *lru.LRU[string, V]
 	sf      singleflight.Group
 	metrics Recorder
+	// mu guards gen and the check-then-Add in getOrLoad so an eviction cannot
+	// interleave between the generation check and the store. gen bumps on every
+	// remove; a load that raced an eviction sees the changed gen and skips its
+	// now-stale store. Global, not per-key: an eviction of any key skips any load
+	// in flight at that moment — correct, and at membership-change rates the rare
+	// extra reload is cheaper than tracking a per-key counter.
+	// ponytail: global generation, per-key if evict rate ever dwarfs read misses.
+	mu       sync.Mutex
+	gen      uint64
+	inflight map[string]*loadHandle // key → cancel of the in-flight load, guarded by mu
+
+	// sem bounds concurrent source loads; nil disables the bound.
+	sem chan struct{}
+	// valid gates cache use. Flipped false by suspend (NATS disconnect) so reads
+	// fall through to a fresh source lookup instead of serving a possibly-stale
+	// entry, and true again by resume only after the purge has cleared the cache.
+	valid atomic.Bool
 }
 
 // newTTLCache builds an LRU+TTL cache. rec records hit/miss/error outcomes;
 // pass a cachemetrics.For(name, "l1") so each cache reports its own series.
-func newTTLCache[V any](size int, ttl time.Duration, rec Recorder) (*ttlCache[V], error) {
+// maxInflight caps concurrent source loads (<=0 → defaultMaxInflight; a nil sem
+// disables the cap only via the sentinel checked below).
+func newTTLCache[V any](size int, ttl time.Duration, maxInflight int, rec Recorder) (*ttlCache[V], error) {
 	if size <= 0 {
 		return nil, fmt.Errorf("readcache: size must be positive, got %d", size)
 	}
 	if ttl <= 0 {
 		return nil, fmt.Errorf("readcache: ttl must be positive, got %v", ttl)
 	}
-	return &ttlCache[V]{lru: lru.NewLRU[string, V](size, nil, ttl), metrics: rec}, nil
+	c := &ttlCache[V]{
+		lru:      lru.NewLRU[string, V](size, nil, ttl),
+		metrics:  rec,
+		inflight: make(map[string]*loadHandle),
+	}
+	if maxInflight <= 0 {
+		maxInflight = defaultMaxInflight
+	}
+	c.sem = make(chan struct{}, maxInflight)
+	c.valid.Store(true)
+	return c, nil
 }
 
 // getOrLoad returns the cached value for key, or invokes load on miss. load
@@ -59,30 +103,148 @@ func newTTLCache[V any](size int, ttl time.Duration, rec Recorder) (*ttlCache[V]
 // nothing is cached and the error is returned.
 // If ctx is canceled before the shared load finishes, getOrLoad returns ctx.Err() immediately
 // while the load continues detached in the background, bounded by fetchTimeout.
-// remove drops key if present; absent keys are a no-op.
-func (c *ttlCache[V]) remove(key string) { c.lru.Remove(key) }
+// remove drops key if present; absent keys are a no-op. Forget detaches any
+// in-flight singleflight load for key so a caller arriving after the eviction
+// starts a FRESH source read instead of joining the doomed in-flight one (which
+// read the pre-eviction boundary). The gen bump makes that doomed load skip its
+// store and, in getOrLoad, re-read rather than return its now-stale value.
+func (c *ttlCache[V]) remove(key string) {
+	c.mu.Lock()
+	c.gen++
+	c.lru.Remove(key)
+	c.sf.Forget(key)
+	// Cancel the superseded in-flight load: Forget only detaches it, leaving the
+	// goroutine + fetch context pinned until fetchTimeout. Under churn + slow Mongo
+	// those pile up, so cancel it now — it fails closed rather than storing a value
+	// read before this eviction.
+	if h := c.inflight[key]; h != nil {
+		h.cancel()
+		delete(c.inflight, key)
+	}
+	c.mu.Unlock()
+}
+
+// purge drops every entry and bumps gen so any in-flight loads fail the
+// stability check in getOrLoad and re-read (or fail closed) rather than storing
+// a value read before the purge, and cancels every in-flight load so none pins a
+// goroutine past the purge. Used to cold-start the cache on NATS reconnect, when
+// this instance may have missed evictions while disconnected.
+func (c *ttlCache[V]) purge() {
+	c.mu.Lock()
+	c.gen++
+	c.lru.Purge()
+	for key, h := range c.inflight {
+		h.cancel()
+		delete(c.inflight, key)
+	}
+	c.mu.Unlock()
+}
+
+// suspend stops the cache serving or storing entries and purges what it holds.
+// Called on NATS disconnect: while offline this instance hears no evictions, so
+// every cached grant may already be stale — reads must fall through to the source
+// until resume re-arms the cache.
+func (c *ttlCache[V]) suspend() {
+	c.valid.Store(false)
+	c.purge()
+}
+
+// resume purges any entries re-cached during the outage, then re-arms the cache.
+// Ordering matters: valid flips true only after the purge, so no read is served
+// from the pre-reconnect cache once the connection (and eviction delivery) is back.
+func (c *ttlCache[V]) resume() {
+	c.purge()
+	c.valid.Store(true)
+}
 
 func (c *ttlCache[V]) getOrLoad(ctx context.Context, key string, load func(context.Context) (V, bool, error)) (V, error) {
-	if v, ok := c.lru.Get(key); ok {
-		c.metrics.Hit(ctx)
-		return v, nil
+	// Skip the cache entirely while suspended: a possibly-stale entry must not be
+	// served after a disconnect until resume re-arms the cache.
+	if c.valid.Load() {
+		if v, ok := c.lru.Get(key); ok {
+			c.metrics.Hit(ctx)
+			return v, nil
+		}
 	}
 
 	resCh := c.sf.DoChan(key, func() (any, error) {
 		// Re-check under singleflight in case a sibling populated the entry.
-		if cached, ok := c.lru.Get(key); ok {
-			return cached, nil
+		if c.valid.Load() {
+			if cached, ok := c.lru.Get(key); ok {
+				return cached, nil
+			}
 		}
-		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), fetchTimeout)
-		defer cancel()
-		val, store, err := load(fetchCtx)
-		if err != nil {
-			return val, err
+		// Bound concurrent source loads so a burst of distinct-key misses can't
+		// spawn unbounded goroutines. Detached from the caller ctx (like the fetch
+		// below) so a leader's cancel never poisons its coalesced waiters; bounded
+		// by fetchTimeout so a saturated cache fails closed rather than hanging.
+		if c.sem != nil {
+			select {
+			case c.sem <- struct{}{}: // fast path: a slot is free, no timer allocated
+			default:
+				// Contended: wait for a slot, bounded so a saturated cache fails
+				// closed rather than hanging.
+				waitCtx, waitCancel := context.WithTimeout(context.WithoutCancel(ctx), fetchTimeout)
+				select {
+				case c.sem <- struct{}{}:
+					waitCancel()
+				case <-waitCtx.Done():
+					waitCancel()
+					var zero V
+					return zero, fmt.Errorf("readcache: load slots exhausted: %w", waitCtx.Err())
+				}
+			}
+			defer func() { <-c.sem }()
 		}
-		if store {
-			c.lru.Add(key, val)
+		// Load, then confirm no eviction (a gen bump) raced this load. If one did,
+		// the value we just read may predate the membership change that triggered
+		// the eviction, so it must NOT be returned to ANY singleflight waiter — a
+		// stale positive grant here lets a revoked member read history. Re-read
+		// against the new generation and re-check, looping until the generation is
+		// stable across a full load. Bounded: if evictions keep racing every
+		// attempt, fail closed with an error (never a fabricated zero value that a
+		// generic-V caller would read as real data).
+		const maxLoadAttempts = 5
+		for attempt := 0; attempt < maxLoadAttempts; attempt++ {
+			fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), fetchTimeout)
+			// Register the cancel so a concurrent remove/purge for this key cancels
+			// this now-superseded load rather than letting it run to fetchTimeout.
+			h := &loadHandle{cancel: cancel}
+			// One critical section: snapshot gen before loading (so a remove during
+			// the load is detected) and publish the cancel handle together.
+			c.mu.Lock()
+			gen := c.gen
+			c.inflight[key] = h
+			c.mu.Unlock()
+
+			val, store, err := load(fetchCtx)
+
+			c.mu.Lock()
+			if c.inflight[key] == h {
+				delete(c.inflight, key)
+			}
+			c.mu.Unlock()
+			cancel()
+			if err != nil {
+				return val, fmt.Errorf("load cache entry: %w", err)
+			}
+
+			// Check-and-store under the same lock as remove so an eviction can't
+			// slip between the generation check and the Add. Never store while
+			// suspended — the entry would outlive the barrier it is meant to bypass.
+			c.mu.Lock()
+			stable := c.gen == gen
+			if stable && store && c.valid.Load() {
+				c.lru.Add(key, val)
+			}
+			c.mu.Unlock()
+			if stable {
+				return val, nil
+			}
+			// An eviction landed during this load: loop and re-read the source.
 		}
-		return val, nil
+		var zero V
+		return zero, errors.New("readcache: evictions raced every load attempt, failing closed")
 	})
 	select {
 	case res := <-resCh:
@@ -120,10 +282,24 @@ type SubscriptionCache struct {
 	cache *ttlCache[subEntry]
 }
 
+// CacheOption tunes a cache constructor.
+type CacheOption func(*cacheOptions)
+
+type cacheOptions struct{ maxInflight int }
+
+// WithMaxInflight caps concurrent source loads; <=0 takes defaultMaxInflight.
+func WithMaxInflight(n int) CacheOption {
+	return func(o *cacheOptions) { o.maxInflight = n }
+}
+
 // NewSubscriptionCache wraps inner with an LRU+TTL cache of size entries and
 // the given TTL. size and ttl must be positive.
-func NewSubscriptionCache(inner SubscriptionSource, size int, ttl time.Duration) (*SubscriptionCache, error) {
-	cache, err := newTTLCache[subEntry](size, ttl, cachemetrics.For("history_sub", "l1"))
+func NewSubscriptionCache(inner SubscriptionSource, size int, ttl time.Duration, opts ...CacheOption) (*SubscriptionCache, error) {
+	var o cacheOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	cache, err := newTTLCache[subEntry](size, ttl, o.maxInflight, cachemetrics.For("history_sub", "l1"))
 	if err != nil {
 		return nil, err
 	}
@@ -151,6 +327,40 @@ func (c *SubscriptionCache) GetHistorySharedSince(ctx context.Context, account, 
 // projects (mongorepo.subscriptionReadProjection) — read a new field, widen that first.
 func (c *SubscriptionCache) GetSubscription(ctx context.Context, account, roomID string) (*pkgmodel.Subscription, error) {
 	return c.inner.GetSubscription(ctx, account, roomID)
+}
+
+// Evict drops the cached access-check entry for (account, roomID) so the next
+// GetHistorySharedSince reloads the current subscription boundary from the
+// source. A membership change (remove, restricted re-add) alters that boundary
+// while the LRU keeps serving the stale full-access entry until its TTL — the
+// #414 leak. The key must match GetHistorySharedSince's exactly. Local only,
+// like PreviewCache.Invalidate: a sibling replica's copy lives out its own TTL.
+func (c *SubscriptionCache) Evict(account, roomID string) {
+	c.cache.remove(account + "\x00" + roomID)
+}
+
+// Purge drops every cached access-check entry. Core NATS delivers no replay, so
+// an instance that was disconnected while a membership change fanned out never
+// received the eviction and would keep serving the stale full-access entry until
+// TTL (#414). Call this from the NATS reconnect handler to cold-start the cache:
+// the next read of each key reloads the current boundary from the source.
+func (c *SubscriptionCache) Purge() {
+	c.cache.purge()
+}
+
+// Suspend stops the cache serving or storing grants and purges it. Call it from
+// the NATS disconnect handler: while offline this instance receives no evictions,
+// so a cached grant may already be stale — reads must fall through to the source
+// (fail-closed against the primary) until Resume re-arms the cache.
+func (c *SubscriptionCache) Suspend() {
+	c.cache.suspend()
+}
+
+// Resume purges any grant re-cached during the outage and re-arms the cache.
+// Call it from the reconnect handler: the purge runs before the cache is re-armed
+// so no read races in on the pre-reconnect cache once eviction delivery is back.
+func (c *SubscriptionCache) Resume() {
+	c.cache.resume()
 }
 
 // RoomSource is the room metadata reads the cache fronts.
@@ -182,11 +392,11 @@ type RoomCache struct {
 // NewRoomCache wraps inner with LRU+TTL caches for room times and
 // minUserLastSeenAt. size and ttl must be positive.
 func NewRoomCache(inner RoomSource, size int, ttl time.Duration) (*RoomCache, error) {
-	times, err := newTTLCache[roomTimes](size, ttl, cachemetrics.For("history_room_times", "l1"))
+	times, err := newTTLCache[roomTimes](size, ttl, defaultMaxInflight, cachemetrics.For("history_room_times", "l1"))
 	if err != nil {
 		return nil, err
 	}
-	minSeen, err := newTTLCache[*time.Time](size, ttl, cachemetrics.For("history_room_min_seen", "l1"))
+	minSeen, err := newTTLCache[*time.Time](size, ttl, defaultMaxInflight, cachemetrics.For("history_room_min_seen", "l1"))
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +501,7 @@ func (c *PreviewCache) Invalidate(roomID string) {
 // NewPreviewCache builds a preview cache of size entries with the given TTL.
 // size and ttl must be positive.
 func NewPreviewCache(size int, ttl time.Duration) (*PreviewCache, error) {
-	c, err := newTTLCache[previewEntry](size, ttl, cachemetrics.For("history_room_preview", "l1"))
+	c, err := newTTLCache[previewEntry](size, ttl, defaultMaxInflight, cachemetrics.For("history_room_preview", "l1"))
 	if err != nil {
 		return nil, fmt.Errorf("create preview cache: %w", err)
 	}

--- a/history-service/internal/readcache/readcache_test.go
+++ b/history-service/internal/readcache/readcache_test.go
@@ -140,6 +140,421 @@ func TestSubscriptionCache_SingleflightDedupesConcurrentMisses(t *testing.T) {
 	assert.Equal(t, int32(1), src.calls.Load(), "concurrent misses for the same key should load once")
 }
 
+// TestSubscriptionCache_Evict_ReloadsFreshBoundary is the #414 regression: a
+// full-access entry cached before a restricted re-add must be dropped by Evict so
+// the next read reflects the new boundary instead of the stale full-access nil.
+func TestSubscriptionCache_Evict_ReloadsFreshBoundary(t *testing.T) {
+	ctx := context.Background()
+	// Full member: subscribed, no lower bound (unbounded history read).
+	src := &fakeSubSource{subscribed: true, sharedSince: nil}
+	c, err := NewSubscriptionCache(src, 100, time.Minute)
+	require.NoError(t, err)
+
+	// Seed the cache as a full member, then confirm it is served from cache.
+	_, sub, err := c.GetHistorySharedSince(ctx, "alice", "r1")
+	require.NoError(t, err)
+	require.True(t, sub)
+	_, _, _ = c.GetHistorySharedSince(ctx, "alice", "r1")
+	require.Equal(t, int32(1), src.calls.Load(), "second read should hit the cache")
+
+	// Membership changes: restricted re-add writes a historySharedSince boundary.
+	boundary := time.Now().UTC()
+	src.sharedSince = &boundary
+
+	// Without eviction the stale full-access nil persists (the leak this fixes).
+	stale, _, err := c.GetHistorySharedSince(ctx, "alice", "r1")
+	require.NoError(t, err)
+	require.Nil(t, stale, "cache still serves the stale full-access window before eviction")
+	require.Equal(t, int32(1), src.calls.Load())
+
+	// Evict → the next read reloads and reflects the fresh restricted boundary.
+	c.Evict("alice", "r1")
+	got, sub2, err := c.GetHistorySharedSince(ctx, "alice", "r1")
+	require.NoError(t, err)
+	require.True(t, sub2)
+	require.NotNil(t, got)
+	assert.Equal(t, boundary, *got)
+	assert.Equal(t, int32(2), src.calls.Load(), "post-evict read must consult the source again")
+}
+
+// TestSubscriptionCache_Evict_RemovedMemberLosesAccess covers the sibling leak: a
+// just-removed member whose subscribed=true entry is cached must be denied on the
+// next read once evicted.
+func TestSubscriptionCache_Evict_RemovedMemberLosesAccess(t *testing.T) {
+	ctx := context.Background()
+	src := &fakeSubSource{subscribed: true, sharedSince: nil}
+	c, err := NewSubscriptionCache(src, 100, time.Minute)
+	require.NoError(t, err)
+
+	_, sub, err := c.GetHistorySharedSince(ctx, "bob", "r9")
+	require.NoError(t, err)
+	require.True(t, sub)
+
+	// Removed: source now reports not-subscribed.
+	src.subscribed = false
+	c.Evict("bob", "r9")
+
+	_, sub2, err := c.GetHistorySharedSince(ctx, "bob", "r9")
+	require.NoError(t, err)
+	assert.False(t, sub2, "removed member must not stay subscribed after eviction")
+}
+
+// TestSubscriptionCache_Evict_AbsentKey is a no-op that must not panic.
+func TestSubscriptionCache_Evict_AbsentKey(t *testing.T) {
+	src := &fakeSubSource{}
+	c, err := NewSubscriptionCache(src, 100, time.Minute)
+	require.NoError(t, err)
+	assert.NotPanics(t, func() { c.Evict("nobody", "nowhere") })
+}
+
+// gatedSubSource is a subscription source whose returned access boundary flips
+// when revoked is set, and whose first load blocks on release. It models the
+// tGD race: the first load reads the OLD (full-access) boundary at entry, pauses,
+// and only returns after a membership change has landed. A later re-read (the
+// retry loop, or a second caller) reads the NEW (restricted) boundary.
+type gatedSubSource struct {
+	calls    atomic.Int32
+	started  chan struct{}
+	release  chan struct{}
+	revoked  atomic.Bool
+	boundary *time.Time // the restricted boundary served once revoked
+	once     sync.Once
+}
+
+func (g *gatedSubSource) GetHistorySharedSince(_ context.Context, _, _ string) (*time.Time, bool, error) {
+	g.calls.Add(1)
+	// Snapshot the access boundary at entry — models "the load reads the
+	// subscription" before it pauses.
+	revoked := g.revoked.Load()
+	first := false
+	g.once.Do(func() { first = true })
+	if first {
+		g.started <- struct{}{}
+		<-g.release
+	}
+	if revoked {
+		return g.boundary, true, nil // narrowed access after the membership change
+	}
+	return nil, true, nil // full access (the stale grant once revoked)
+}
+
+func (g *gatedSubSource) GetSubscription(_ context.Context, _, _ string) (*pkgmodel.Subscription, error) {
+	return nil, nil
+}
+
+// TestSubscriptionCache_Evict_InFlightLoadDoesNotAuthorizeWaiters is the CWE-285
+// concurrency regression. An Evict that lands between a load starting and its
+// result being returned must leave NO caller of that load holding the
+// pre-eviction positive grant — not the in-flight loader, and not a second
+// request that arrives after the Evict. Both must observe the fresh, narrowed
+// boundary instead. Covers both halves of the fix: sf.Forget in remove (the
+// second reader starts a fresh flight) and the generation-stability retry in
+// getOrLoad (the in-flight loader re-reads rather than returning its stale read).
+func TestSubscriptionCache_Evict_InFlightLoadDoesNotAuthorizeWaiters(t *testing.T) {
+	ctx := context.Background()
+	boundary := time.Now().UTC()
+	src := &gatedSubSource{
+		started:  make(chan struct{}, 1),
+		release:  make(chan struct{}),
+		boundary: &boundary,
+	}
+	c, err := NewSubscriptionCache(src, 100, time.Minute)
+	require.NoError(t, err)
+
+	type result struct {
+		ss  *time.Time
+		sub bool
+		err error
+	}
+
+	// Reader A: misses, starts the singleflight load, reads full access, pauses.
+	aCh := make(chan result, 1)
+	go func() {
+		ss, sub, err := c.GetHistorySharedSince(ctx, "alice", "r1")
+		aCh <- result{ss, sub, err}
+	}()
+	<-src.started // A's load is in flight, blocked with the old full-access read.
+
+	// Membership is revoked while A is blocked: the source now reports restricted,
+	// and the cache is evicted (bumps gen + Forgets A's flight).
+	src.revoked.Store(true)
+	c.Evict("alice", "r1")
+
+	// Reader B arrives after the Evict. Because remove Forgot A's flight, B starts
+	// a fresh load that reads the post-revocation restricted boundary.
+	bCh := make(chan result, 1)
+	go func() {
+		ss, sub, err := c.GetHistorySharedSince(ctx, "alice", "r1")
+		bCh <- result{ss, sub, err}
+	}()
+	b := <-bCh
+	require.NoError(t, b.err)
+	require.True(t, b.sub)
+	require.NotNil(t, b.ss, "second reader must not get the stale full-access nil")
+	assert.Equal(t, boundary, *b.ss, "second reader must see the narrowed boundary")
+
+	// Release A. Its load saw gen change, so it must NOT return the stale full
+	// access; the retry re-reads and returns the restricted boundary.
+	close(src.release)
+	a := <-aCh
+	require.NoError(t, a.err)
+	require.True(t, a.sub)
+	require.NotNil(t, a.ss, "in-flight loader must not return the stale full-access nil")
+	assert.Equal(t, boundary, *a.ss, "in-flight loader must return the narrowed boundary")
+}
+
+// TestSubscriptionCache_Purge_ReloadsAfterReconnect covers the core-NATS
+// reconnect gap: an instance that missed evictions while disconnected must not
+// keep serving a stale full-access entry. Purge (called from the reconnect
+// handler) drops the entry so the next read reloads the current boundary.
+func TestSubscriptionCache_Purge_ReloadsAfterReconnect(t *testing.T) {
+	ctx := context.Background()
+	src := &fakeSubSource{subscribed: true, sharedSince: nil} // full access
+	c, err := NewSubscriptionCache(src, 100, time.Minute)
+	require.NoError(t, err)
+
+	// Seed the full-access entry.
+	_, sub, err := c.GetHistorySharedSince(ctx, "alice", "r1")
+	require.NoError(t, err)
+	require.True(t, sub)
+	require.Equal(t, int32(1), src.calls.Load())
+
+	// While this instance is "disconnected", access is narrowed at the source.
+	boundary := time.Now().UTC()
+	src.sharedSince = &boundary
+
+	// A second read without Purge would serve the cached full-access nil.
+	// Reconnect handler purges → next read must reload the restricted boundary.
+	c.Purge()
+	got, sub, err := c.GetHistorySharedSince(ctx, "alice", "r1")
+	require.NoError(t, err)
+	require.True(t, sub)
+	require.NotNil(t, got, "post-purge read must reload, not serve the stale full-access nil")
+	assert.Equal(t, boundary, *got)
+	assert.Equal(t, int32(2), src.calls.Load(), "purge must force a fresh source read")
+}
+
+// ctxAwareSubSource blocks in the load until its context is canceled, then
+// reports the cancellation. Models a slow Mongo read that a supersede must abort.
+type ctxAwareSubSource struct {
+	started chan struct{}
+}
+
+func (s *ctxAwareSubSource) GetHistorySharedSince(ctx context.Context, _, _ string) (*time.Time, bool, error) {
+	s.started <- struct{}{}
+	<-ctx.Done()
+	return nil, false, ctx.Err()
+}
+
+func (s *ctxAwareSubSource) GetSubscription(_ context.Context, _, _ string) (*pkgmodel.Subscription, error) {
+	return nil, nil
+}
+
+// TestSubscriptionCache_Evict_CancelsSupersededLoad proves fix 3: an Evict that
+// lands while a load is blocked in the source cancels that load's context at once,
+// so it returns promptly (fail-closed) instead of pinning a goroutine + context
+// until fetchTimeout (10s). Without the cancel this read would block ~10s.
+func TestSubscriptionCache_Evict_CancelsSupersededLoad(t *testing.T) {
+	src := &ctxAwareSubSource{started: make(chan struct{})}
+	c, err := NewSubscriptionCache(src, 100, time.Minute)
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, e := c.GetHistorySharedSince(context.Background(), "alice", "r1")
+		done <- e
+	}()
+	<-src.started // the load is now blocked on ctx.Done()
+
+	c.Evict("alice", "r1") // supersede → must cancel the blocked load
+
+	select {
+	case e := <-done:
+		require.Error(t, e, "a superseded load must fail closed, not return a grant")
+	case <-time.After(2 * time.Second):
+		t.Fatal("superseded load was not canceled within 2s (it would otherwise block until fetchTimeout)")
+	}
+}
+
+// capSubSource records the peak concurrent in-flight loads so a test can assert
+// the semaphore bounds fan-out. Each call blocks on release.
+type capSubSource struct {
+	inflight atomic.Int32
+	peak     atomic.Int32
+	entered  chan struct{}
+	release  chan struct{}
+}
+
+func (s *capSubSource) GetHistorySharedSince(_ context.Context, _, _ string) (*time.Time, bool, error) {
+	n := s.inflight.Add(1)
+	for {
+		p := s.peak.Load()
+		if n <= p || s.peak.CompareAndSwap(p, n) {
+			break
+		}
+	}
+	s.entered <- struct{}{}
+	<-s.release
+	s.inflight.Add(-1)
+	ts := time.Now().UTC()
+	return &ts, true, nil
+}
+
+func (s *capSubSource) GetSubscription(_ context.Context, _, _ string) (*pkgmodel.Subscription, error) {
+	return nil, nil
+}
+
+// TestSubscriptionCache_MaxInflight_BoundsConcurrentLoads proves fix 3's cap: with
+// maxInflight=2, a burst of 5 distinct-key misses never has more than 2 loads in
+// the source at once — the other 3 wait on the semaphore.
+func TestSubscriptionCache_MaxInflight_BoundsConcurrentLoads(t *testing.T) {
+	src := &capSubSource{entered: make(chan struct{}, 8), release: make(chan struct{})}
+	c, err := NewSubscriptionCache(src, 100, time.Minute, WithMaxInflight(2))
+	require.NoError(t, err)
+
+	const n = 5
+	done := make(chan struct{}, n)
+	for i := 0; i < n; i++ {
+		key := "r" + string(rune('a'+i)) // distinct keys → no singleflight coalescing
+		go func() {
+			_, _, _ = c.GetHistorySharedSince(context.Background(), "alice", key)
+			done <- struct{}{}
+		}()
+	}
+
+	// Exactly two loads may enter; a third must be blocked on the semaphore.
+	<-src.entered
+	<-src.entered
+	select {
+	case <-src.entered:
+		t.Fatal("a third load entered the source: semaphore did not bound concurrency to 2")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(src.release) // let all loads drain
+	for i := 0; i < n; i++ {
+		<-done
+	}
+	assert.LessOrEqual(t, src.peak.Load(), int32(2), "no more than maxInflight loads may run at once")
+}
+
+// raceSafeSubSource is a concurrency-safe source whose access boundary can be
+// flipped from another goroutine, for the barrier race test.
+type raceSafeSubSource struct {
+	calls      atomic.Int32
+	shared     atomic.Pointer[time.Time]
+	subscribed atomic.Bool
+}
+
+func (s *raceSafeSubSource) GetHistorySharedSince(_ context.Context, _, _ string) (*time.Time, bool, error) {
+	s.calls.Add(1)
+	return s.shared.Load(), s.subscribed.Load(), nil
+}
+
+func (s *raceSafeSubSource) GetSubscription(_ context.Context, _, _ string) (*pkgmodel.Subscription, error) {
+	return nil, nil
+}
+
+// TestSubscriptionCache_Barrier_SuspendBypassesStaleGrant proves fix 4
+// deterministically: after a disconnect (Suspend) the cache stops serving its
+// cached full-access grant and reads fall through to the (now-narrowed) source;
+// Resume re-arms it so caching returns.
+func TestSubscriptionCache_Barrier_SuspendBypassesStaleGrant(t *testing.T) {
+	ctx := context.Background()
+	src := &fakeSubSource{subscribed: true, sharedSince: nil} // full access
+	c, err := NewSubscriptionCache(src, 100, time.Minute)
+	require.NoError(t, err)
+
+	// Seed the full-access grant.
+	_, sub, err := c.GetHistorySharedSince(ctx, "alice", "r1")
+	require.NoError(t, err)
+	require.True(t, sub)
+	require.Equal(t, int32(1), src.calls.Load())
+
+	// Missed eviction: source narrows while this instance is "disconnected".
+	boundary := time.Now().UTC()
+	src.sharedSince = &boundary
+
+	c.Suspend() // disconnect barrier
+
+	// A read during the barrier must reload from the source, not serve the stale nil.
+	got, sub, err := c.GetHistorySharedSince(ctx, "alice", "r1")
+	require.NoError(t, err)
+	require.True(t, sub)
+	require.NotNil(t, got, "suspended read must not serve the stale full-access grant")
+	assert.Equal(t, boundary, *got)
+	assert.Equal(t, int32(2), src.calls.Load())
+
+	// Still suspended: the cache must not populate, so the next read hits the source again.
+	_, _, err = c.GetHistorySharedSince(ctx, "alice", "r1")
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), src.calls.Load(), "suspended cache must not store")
+
+	// Resume re-arms: a miss loads once, the following read is a hit.
+	c.Resume()
+	_, _, err = c.GetHistorySharedSince(ctx, "alice", "r1")
+	require.NoError(t, err)
+	_, _, err = c.GetHistorySharedSince(ctx, "alice", "r1")
+	require.NoError(t, err)
+	assert.Equal(t, int32(4), src.calls.Load(), "resumed cache serves the second read from cache")
+}
+
+// TestSubscriptionCache_Barrier_RaceReconnectNeverStale proves fix 4 under a race:
+// concurrent readers, while Suspend/Resume churns (a flapping connection), never
+// observe the stale full-access grant once the source has narrowed.
+func TestSubscriptionCache_Barrier_RaceReconnectNeverStale(t *testing.T) {
+	ctx := context.Background()
+	src := &raceSafeSubSource{}
+	src.subscribed.Store(true) // full access (shared=nil)
+	c, err := NewSubscriptionCache(src, 100, time.Minute)
+	require.NoError(t, err)
+
+	_, _, _ = c.GetHistorySharedSince(ctx, "alice", "r1") // seed the stale full-access grant
+
+	boundary := time.Now().UTC()
+	src.shared.Store(&boundary) // narrowed (missed eviction)
+	c.Suspend()                 // enter the barrier before readers start
+
+	var staleSeen atomic.Bool
+	var readers sync.WaitGroup
+	stop := make(chan struct{})
+
+	flapDone := make(chan struct{})
+	go func() { // reconnect flap, runs until readers finish
+		defer close(flapDone)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				c.Resume()
+				c.Suspend()
+			}
+		}
+	}()
+
+	for i := 0; i < 4; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for j := 0; j < 1000; j++ {
+				got, sub, err := c.GetHistorySharedSince(ctx, "alice", "r1")
+				if err != nil {
+					continue
+				}
+				if sub && got == nil {
+					staleSeen.Store(true) // a full-access nil is the stale grant
+				}
+			}
+		}()
+	}
+	readers.Wait()
+	close(stop)
+	<-flapDone
+
+	assert.False(t, staleSeen.Load(), "no read may serve the stale full-access grant after the source narrowed")
+}
+
 func TestNewSubscriptionCache_InvalidConfig(t *testing.T) {
 	src := &fakeSubSource{}
 	_, err := NewSubscriptionCache(src, 0, time.Minute)


### PR DESCRIPTION
## Summary

A member re-added with **"Don't include chat history"** — and a **just-removed** member — could still read pre-boundary history for up to the history-service subscription-cache TTL (`HISTORY_SUB_CACHE_TTL`, default `2m`). The stored `historySharedSince` boundary is written correctly; the leak is the read-side access cache. This PR keeps that cache and adds **active invalidation** plus the correctness hardening needed to make it safe under primary outage, NATS reconnect, and membership churn.

Fixes #414

## What's included

- Active eviction of the subscription access-check cache on membership change.
- Correctness hardening so the cache cannot re-authorize a revoked grant during a primary outage, a NATS reconnect, or under eviction churn.

## Changes

**Active invalidation (`readcache` + `history-service/cmd`)**
- `SubscriptionCache.Evict(account, roomID)` drops the cached access-check entry (same `account + "\x00" + roomID` key `GetHistorySharedSince` uses) so the next read reloads the current boundary. Local-only, mirroring `PreviewCache.Invalidate`.
- When the sub-cache is enabled, subscribe to `chat.user.*.event.subscription.update` and evict `(account, roomID)` on the `added` / `removed` actions (boundary-changing only; `read`/`mute`/`favorite`/`role`/`section` are skipped). Non-queue core NATS so every instance evicts its own local cache; best-effort (an unparseable subject/payload logs and skips).

**Strict `primary` read preference for access reads**
- `SUBSCRIPTION_READ_PREFERENCE` now defaults to `primary` (was `primaryPreferred`). `primaryPreferred` falls back to a lagging secondary during a primary outage, which can re-cache a revoked grant; strict `primary` is read-your-writes and fails closed instead. Env-overridable.

**Fail-closed returns an error, never a fabricated zero value**
- The cache is a generic `ttlCache[V]` backing access grants, room times, and `minUserLastSeenAt`. When repeated evictions race every load attempt, the load path now returns an error (`errLoadUnstable`) instead of `(zero, nil)` — a zero value would hand room-times/min-seen callers fabricated data as success. `getAccessSince` already treats a lookup error as fail-closed.

**In-flight load cancellation + concurrency cap**
- On evict/purge, `singleflight.Forget` only detaches the superseded load; it kept running until the fetch timeout, so under churn + slow Mongo those piled up (a goroutine + context each). Each shared load now carries a cancelable context that `remove`/`purge` cancels immediately.
- A semaphore (`HISTORY_SUB_CACHE_MAX_INFLIGHT`, default `256`) bounds concurrent source loads so a burst of distinct-key misses cannot spawn unbounded loads.

**Reconnect purge delivery barrier**
- The reconnect callback is asynchronous, so a read could reach a restored subscription before the purge ran and serve a stale grant. The cache now suspends on NATS disconnect (stops serving/storing and purges) and resumes on reconnect (purges, then re-arms). Reads during the barrier fall through to a fresh source lookup (fail-closed) rather than serving the pre-reconnect cache.

No wire/contract change (read path only); no schema or index change; `docs/client-api.md` unaffected.

## Verification

- `go build ./history-service/...` — clean.
- `go test -race ./history-service/internal/readcache/...` — pass, including new tests: superseded-load cancellation (no goroutine leak), the `maxInflight` concurrency bound, the suspend/resume barrier, and a read racing a reconnect flap never serving a stale grant.
- `go test ./history-service/internal/config/... ./history-service/internal/service/...` — pass.
- Lint (pinned golangci-lint): clean.
- e2e against the dev stack (remove → restricted re-add → immediate history read) to follow.
