### PR TITLE
fix(room-worker): inherit room restriction on added members via room meta

### DIFF
--- a/pkg/roommetacache/roommetacache.go
+++ b/pkg/roommetacache/roommetacache.go
@@ -48,6 +48,12 @@ type Meta struct {
 	// CrossSiteAt mirrors Room.CrossSiteAt — the flip time driving the post-flip
 	// grace window (nil for rooms born cross-site). See pkg/subject.RoomEventTargets.
 	CrossSiteAt *time.Time `json:"crossSiteAt,omitempty"`
+	// Restricted / ExternalAccess mirror Room.{Restricted,ExternalAccess} so the
+	// add-member path (room-worker newSub) denorms the room's real access state
+	// onto new subscriptions instead of a dropped false (#416). omitempty keeps
+	// old L2 (Valkey) entries decodable, matching CrossSite.
+	Restricted     bool `json:"restricted,omitempty"`
+	ExternalAccess bool `json:"externalAccess,omitempty"`
 }
 
 // Loader fetches a fresh Meta for the given roomID. The cache calls
@@ -191,32 +197,38 @@ func (w *Wrapper[S]) GetRoomMeta(ctx context.Context, roomID string) (Meta, erro
 // safe to errors.Is-check.
 func FetchFromMongo(ctx context.Context, rooms *mongo.Collection, roomID string) (Meta, error) {
 	opts := options.FindOne().SetProjection(bson.M{
-		"type":        1,
-		"name":        1,
-		"siteId":      1,
-		"userCount":   1,
-		"crossSite":   1,
-		"crossSiteAt": 1,
+		"type":           1,
+		"name":           1,
+		"siteId":         1,
+		"userCount":      1,
+		"crossSite":      1,
+		"crossSiteAt":    1,
+		"restricted":     1,
+		"externalAccess": 1,
 	})
 	var doc struct {
-		ID          string         `bson:"_id"`
-		Type        model.RoomType `bson:"type"`
-		Name        string         `bson:"name"`
-		SiteID      string         `bson:"siteId"`
-		UserCount   int            `bson:"userCount"`
-		CrossSite   *bool          `bson:"crossSite"`
-		CrossSiteAt *time.Time     `bson:"crossSiteAt"`
+		ID             string         `bson:"_id"`
+		Type           model.RoomType `bson:"type"`
+		Name           string         `bson:"name"`
+		SiteID         string         `bson:"siteId"`
+		UserCount      int            `bson:"userCount"`
+		CrossSite      *bool          `bson:"crossSite"`
+		CrossSiteAt    *time.Time     `bson:"crossSiteAt"`
+		Restricted     bool           `bson:"restricted"`
+		ExternalAccess bool           `bson:"externalAccess"`
 	}
 	if err := rooms.FindOne(ctx, bson.M{"_id": roomID}, opts).Decode(&doc); err != nil {
 		return Meta{}, fmt.Errorf("fetch room meta %s: %w", roomID, err)
 	}
 	return Meta{
-		ID:          doc.ID,
-		Type:        doc.Type,
-		Name:        doc.Name,
-		SiteID:      doc.SiteID,
-		UserCount:   doc.UserCount,
-		CrossSite:   doc.CrossSite,
-		CrossSiteAt: doc.CrossSiteAt,
+		ID:             doc.ID,
+		Type:           doc.Type,
+		Name:           doc.Name,
+		SiteID:         doc.SiteID,
+		UserCount:      doc.UserCount,
+		CrossSite:      doc.CrossSite,
+		CrossSiteAt:    doc.CrossSiteAt,
+		Restricted:     doc.Restricted,
+		ExternalAccess: doc.ExternalAccess,
 	}, nil
 }

--- a/pkg/roommetacache/roommetacache_test.go
+++ b/pkg/roommetacache/roommetacache_test.go
@@ -2,6 +2,7 @@ package roommetacache_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sync"
 	"sync/atomic"
@@ -14,6 +15,39 @@ import (
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/roommetacache"
 )
+
+// TestMeta_RestrictedJSONRoundTrip pins the L2 (Valkey) wire format for the
+// Restricted/ExternalAccess denorm: set values survive a marshal/unmarshal so
+// GetRoomMeta serves the room's real access state to newSub (#416), and the
+// zero value stays omitempty-absent (an old cached entry decodes to false).
+func TestMeta_RestrictedJSONRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name                       string
+		restricted, externalAccess bool
+	}{
+		{"both false", false, false},
+		{"both true", true, true},
+		{"restricted only", true, false},
+		{"externalAccess only", false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			in := roommetacache.Meta{ID: "r1", SiteID: "site-a", Restricted: tc.restricted, ExternalAccess: tc.externalAccess}
+			b, err := json.Marshal(in)
+			require.NoError(t, err)
+
+			var out roommetacache.Meta
+			require.NoError(t, json.Unmarshal(b, &out))
+			assert.Equal(t, tc.restricted, out.Restricted)
+			assert.Equal(t, tc.externalAccess, out.ExternalAccess)
+		})
+	}
+
+	// A pre-#416 cached entry (no restricted/externalAccess keys) decodes to false.
+	var legacy roommetacache.Meta
+	require.NoError(t, json.Unmarshal([]byte(`{"id":"r1","siteId":"site-a"}`), &legacy))
+	assert.False(t, legacy.Restricted)
+	assert.False(t, legacy.ExternalAccess)
+}
 
 // stubProvider is a minimal MetaProvider used by WrapStore tests.
 type stubProvider struct {

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -194,7 +194,7 @@ func (s *MongoStore) GetRoomMeta(ctx context.Context, roomID string) (*model.Roo
 	if err != nil {
 		return nil, err
 	}
-	return &model.Room{ID: meta.ID, Type: meta.Type, Name: meta.Name, SiteID: meta.SiteID, UserCount: meta.UserCount, CrossSite: meta.CrossSite, CrossSiteAt: meta.CrossSiteAt}, nil
+	return &model.Room{ID: meta.ID, Type: meta.Type, Name: meta.Name, SiteID: meta.SiteID, UserCount: meta.UserCount, CrossSite: meta.CrossSite, CrossSiteAt: meta.CrossSiteAt, Restricted: meta.Restricted, ExternalAccess: meta.ExternalAccess}, nil
 }
 
 func (s *MongoStore) GetUser(ctx context.Context, account string) (*model.User, error) {


### PR DESCRIPTION
## Summary

A member added to an already-restricted room received a subscription with `restricted=false`, so `subscription.list` dropped them from the room (#416/#298). `newSub` already denorms `room.{Restricted, ExternalAccess}` onto the new subscription, but `room-worker`'s `GetRoomMeta` served those flags back as `false` because the shared room-meta cache projection did not carry them.

This is the minimal same-site denorm fix: carry `restricted`/`externalAccess` through the room-meta cache so `newSub` sees the room's real access state.

Cross-site federation, last-write-wins version ordering, and a one-off backfill are deferred to a follow-up (planning ticket #37) and are intentionally not in this PR.

## What's included

- `roommetacache.Meta` gains `Restricted` / `ExternalAccess` (json `omitempty`, so old L2/Valkey entries stay decodable, matching `CrossSite`).
- `FetchFromMongo` projects, decodes, and populates the two fields.
- `room-worker` `GetRoomMeta` maps them onto the returned `Room`, so `newSub` inherits them on same-site add-member.

## Changes

- `pkg/roommetacache/roommetacache.go` — `Meta` fields + projection/decode/populate.
- `room-worker/store_mongo.go` — map `meta.{Restricted,ExternalAccess}` onto `model.Room`.
- `pkg/roommetacache/roommetacache_test.go` — JSON round-trip test (set values survive; legacy entry decodes to false).

(`newSub` inheriting the flags and its `TestNewSub_InheritsRoomRestriction` are already on `main`.)

## Verification

- `go build ./pkg/roommetacache/... ./room-worker/... ./pkg/model/...`
- `go test ./room-worker/... ./pkg/roommetacache/... ./pkg/model/...` — pass
- `go vet -tags integration ./room-worker/... ./pkg/roommetacache/...` — compiles
- golangci-lint — 0 issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Room metadata now includes restricted-access and external-access status.
  * These access states are preserved when retrieving room information from cache or storage.
* **Bug Fixes**
  * Improved consistency of room access metadata across cached and direct retrievals.
* **Tests**
  * Added coverage for saving and restoring access states, including compatibility with older cached entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->