### PR TITLE
fix: resolve mentionable page size from config, not stale room counts

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -1980,7 +1980,7 @@ Used by the message composer's `@…` mention autocomplete. Returns subscription
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `limit` | number | no | When omitted, the server uses `min(3, room.userCount + room.appCount)` (small rooms cap automatically, empty rooms return an empty list). When supplied, must be `> 0`; a value larger than `room.userCount + room.appCount` is clamped to that cap (not rejected). |
+| `limit` | number | no | When omitted, the server uses a configured default page size (`MENTIONABLE_DEFAULT_LIMIT`, default `3`). When supplied, must be `> 0`; a value above the configured maximum (`MENTIONABLE_MAX_LIMIT`, default `50`) is clamped to that maximum (not rejected). The page size is independent of the room's member counts. |
 | `filter` | string | no | Defaults to `""` (matches everything). Treated as a literal substring; regex metacharacters are escaped server-side. Matched case-insensitively against a dash-joined keyword built from `account`, `engName`, `chineseName`, `app.name`, and `app.assistant.name`. |
 
 ```json
@@ -2037,7 +2037,7 @@ Used by the message composer's `@…` mention autocomplete. Returns subscription
 See [Error envelope](#6-error-envelope-reference). Common errors:
 
 - `"only room members can perform this action"` — caller has no subscription in the room.
-- `"limit must be > 0 and <= room user count + app count"` — limit was `0` or negative. (A positive limit larger than the room's combined user + app population is clamped to that cap, not rejected.)
+- `"limit must be > 0"` — limit was `0` or negative. (A positive limit larger than the configured maximum is clamped to that maximum, not rejected.)
 
 ##### Triggered events — success path
 

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -565,7 +565,7 @@ ordinary, mentionable users). Returns `user` and `app` rows.
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `limit` | number | no | Default: `min(3, room.userCount + room.appCount)`. Must be > 0 and ≤ combined count. |
+| `limit` | number | no | Default: configured `MENTIONABLE_DEFAULT_LIMIT` (3). Must be > 0; clamped to `MENTIONABLE_MAX_LIMIT` (50). Independent of room member counts. |
 | `filter` | string | no | Literal substring, case-insensitive. Matched against account, names, app name. |
 
 #### Success response
@@ -575,7 +575,7 @@ ordinary, mentionable users). Returns `user` and `app` rows.
 
 #### Errors
 
-`"only room members can perform this action"`, `"limit must be > 0 and <= room user count + app count"` (fires only for a non-positive limit; an over-cap positive limit is clamped).
+`"only room members can perform this action"`, `"limit must be > 0"` (fires only for a non-positive limit; an over-max positive limit is clamped).
 
 **Emits:** None — reply only.
 

--- a/room-service/config_test.go
+++ b/room-service/config_test.go
@@ -124,15 +124,16 @@ func TestConfig_MentionableLimits(t *testing.T) {
 		assert.Equal(t, 200, cfg.MentionableMaxLimit)
 	})
 
-	// The > 0 startup gate (fail-fast in main) rejects a non-positive value; env
-	// parsing itself accepts it, so the guard is what must catch it.
-	t.Run("non-positive rejected by startup guard", func(t *testing.T) {
-		t.Setenv("MENTIONABLE_DEFAULT_LIMIT", "0")
-		t.Setenv("MENTIONABLE_MAX_LIMIT", "-1")
-		cfg, err := env.ParseAs[config]()
-		require.NoError(t, err)
-		assert.False(t, cfg.MentionableDefaultLimit > 0, "0 must fail the > 0 startup check")
-		assert.False(t, cfg.MentionableMaxLimit > 0, "-1 must fail the > 0 startup check")
+	// The startup guard (fail-fast in main via validateMentionableLimits) is what
+	// rejects bad values — env parsing itself accepts them. Exercise the guard
+	// directly so this test fails if it is removed or inverted.
+	t.Run("validateMentionableLimits", func(t *testing.T) {
+		require.NoError(t, validateMentionableLimits(3, 50))
+		require.NoError(t, validateMentionableLimits(50, 50)) // default == max is allowed
+		assert.Error(t, validateMentionableLimits(0, 50))     // default not positive
+		assert.Error(t, validateMentionableLimits(-1, 50))
+		assert.Error(t, validateMentionableLimits(3, 0))    // max not positive
+		assert.Error(t, validateMentionableLimits(100, 50)) // default exceeds max
 	})
 }
 

--- a/room-service/config_test.go
+++ b/room-service/config_test.go
@@ -94,6 +94,40 @@ func TestConfig_ValkeyAddrsParsed(t *testing.T) {
 	assert.Equal(t, "hunter2", cfg.ValkeyPassword)
 }
 
+func TestConfig_MentionableLimits(t *testing.T) {
+	t.Setenv("NATS_URL", "nats://localhost:4222")
+	t.Setenv("MONGO_URI", "mongodb://localhost:27017")
+
+	t.Run("defaults", func(t *testing.T) {
+		require.NoError(t, os.Unsetenv("MENTIONABLE_DEFAULT_LIMIT"))
+		require.NoError(t, os.Unsetenv("MENTIONABLE_MAX_LIMIT"))
+		cfg, err := env.ParseAs[config]()
+		require.NoError(t, err)
+		assert.Equal(t, 3, cfg.MentionableDefaultLimit)
+		assert.Equal(t, 50, cfg.MentionableMaxLimit)
+	})
+
+	t.Run("override", func(t *testing.T) {
+		t.Setenv("MENTIONABLE_DEFAULT_LIMIT", "10")
+		t.Setenv("MENTIONABLE_MAX_LIMIT", "200")
+		cfg, err := env.ParseAs[config]()
+		require.NoError(t, err)
+		assert.Equal(t, 10, cfg.MentionableDefaultLimit)
+		assert.Equal(t, 200, cfg.MentionableMaxLimit)
+	})
+
+	// The > 0 startup gate (fail-fast in main) rejects a non-positive value; env
+	// parsing itself accepts it, so the guard is what must catch it.
+	t.Run("non-positive rejected by startup guard", func(t *testing.T) {
+		t.Setenv("MENTIONABLE_DEFAULT_LIMIT", "0")
+		t.Setenv("MENTIONABLE_MAX_LIMIT", "-1")
+		cfg, err := env.ParseAs[config]()
+		require.NoError(t, err)
+		assert.False(t, cfg.MentionableDefaultLimit > 0, "0 must fail the > 0 startup check")
+		assert.False(t, cfg.MentionableMaxLimit > 0, "-1 must fail the > 0 startup check")
+	})
+}
+
 func TestConfig_BadgeCacheTTL(t *testing.T) {
 	t.Setenv("NATS_URL", "nats://localhost:4222")
 	t.Setenv("MONGO_URI", "mongodb://localhost:27017")

--- a/room-service/config_test.go
+++ b/room-service/config_test.go
@@ -99,8 +99,16 @@ func TestConfig_MentionableLimits(t *testing.T) {
 	t.Setenv("MONGO_URI", "mongodb://localhost:27017")
 
 	t.Run("defaults", func(t *testing.T) {
-		require.NoError(t, os.Unsetenv("MENTIONABLE_DEFAULT_LIMIT"))
-		require.NoError(t, os.Unsetenv("MENTIONABLE_MAX_LIMIT"))
+		// Unset both and restore the caller's env after the subtest so later
+		// tests don't observe defaults instead of their configured values.
+		for _, k := range []string{"MENTIONABLE_DEFAULT_LIMIT", "MENTIONABLE_MAX_LIMIT"} {
+			if v, ok := os.LookupEnv(k); ok {
+				t.Cleanup(func() { _ = os.Setenv(k, v) })
+			} else {
+				t.Cleanup(func() { _ = os.Unsetenv(k) })
+			}
+			require.NoError(t, os.Unsetenv(k))
+		}
 		cfg, err := env.ParseAs[config]()
 		require.NoError(t, err)
 		assert.Equal(t, 3, cfg.MentionableDefaultLimit)

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -649,7 +649,7 @@ func (h *Handler) listMentionableSubscriptions(c *natsrouter.Context) (*model.Me
 	if err != nil {
 		return nil, fmt.Errorf("list mentionable subscriptions: %w", err)
 	}
-	return &model.MentionableSubscriptionsResponse{Subscriptions: subs}, nil
+	return boundedReply(h, &model.MentionableSubscriptionsResponse{Subscriptions: subs})
 }
 
 func (h *Handler) removeMember(c *natsrouter.Context, req model.RemoveMemberRequest) (*model.StatusReply, error) { //nolint:gocritic // hugeParam: req is passed by value to satisfy the natsrouter.Register handler signature

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -83,6 +83,12 @@ type Handler struct {
 	teamsEmailDomain     string
 	roomMembersLimit     int
 	roomMembersCallLimit int
+	// mentionableDefaultLimit / mentionableMaxLimit bound the @-mention
+	// autocomplete page size (MENTIONABLE_DEFAULT_LIMIT / MENTIONABLE_MAX_LIMIT),
+	// resolved independently of the room's denormalized member counts (which can
+	// lag at 0 and would otherwise hide a populated room). Both validated > 0 at startup.
+	mentionableDefaultLimit int
+	mentionableMaxLimit     int
 	// routeMode gates the namespace(s) same-site room .event uses (ROOM_SUBJECT_MODE); cross-site is always global.
 	routeMode subject.RoomRouteMode
 }
@@ -511,10 +517,7 @@ func (h *Handler) getRoomKey(c *natsrouter.Context) (*model.RoomKeyGetResponse, 
 	}, nil
 }
 
-const (
-	defaultMemberStatusesLimit = 3
-	defaultMentionableLimit    = 3
-)
+const defaultMemberStatusesLimit = 3
 
 // requireMembershipAndGetRoom checks the requester's room membership and
 // loads the room document in parallel — both reads are independent and the
@@ -617,24 +620,25 @@ func (h *Handler) listMentionableSubscriptions(c *natsrouter.Context) (*model.Me
 		}
 	}
 
-	room, err := h.requireMembershipAndGetRoom(ctx, requesterAccount, roomID)
-	if err != nil {
-		return nil, err
+	// Membership gate only — the page size comes from config, not the room's
+	// denormalized userCount/appCount (which can be stale/0 and would wrongly
+	// hide a populated room), so GetRoom is not needed here.
+	if err := h.store.CheckMembership(ctx, requesterAccount, roomID); err != nil {
+		if errors.Is(err, model.ErrSubscriptionNotFound) {
+			return nil, errNotRoomMember
+		}
+		return nil, fmt.Errorf("check room membership: %w", err)
 	}
 
-	mentionableCap := room.UserCount + room.AppCount
-	if mentionableCap == 0 {
-		return &model.MentionableSubscriptionsResponse{Subscriptions: []model.MentionableSubscription{}}, nil
-	}
-	var limit int
-	if req.Limit == nil {
-		limit = min(defaultMentionableLimit, mentionableCap)
-	} else {
-		limit = *req.Limit
-		if limit <= 0 {
+	// Startup validation guarantees both bounds are > 0, so the resolved limit is
+	// always >= 1: a nil request-limit yields the default, an explicit one is
+	// rejected when <= 0 and otherwise clamped to the configured max.
+	limit := h.mentionableDefaultLimit
+	if req.Limit != nil {
+		if *req.Limit <= 0 {
 			return nil, errMentionableLimitInvalid
 		}
-		limit = min(limit, mentionableCap) // clamp over-cap instead of rejecting
+		limit = min(*req.Limit, h.mentionableMaxLimit)
 	}
 
 	// Filter is a literal substring. QuoteMeta escapes regex metacharacters

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -7511,13 +7511,11 @@ func TestHandler_ListMentionableSubscriptions(t *testing.T) {
 		want      want
 	}{
 		{
-			name: "default limit 3, empty filter, happy path",
+			name: "default limit, empty filter, happy path",
 			body: nil,
 			setupMock: func(s *MockRoomStore) {
 				s.EXPECT().CheckMembership(gomock.Any(), requester, roomID).
 					Return(nil)
-				s.EXPECT().GetRoom(gomock.Any(), roomID).
-					Return(&model.Room{ID: roomID, UserCount: 5, AppCount: 2}, nil)
 				s.EXPECT().
 					ListMentionableSubscriptions(gomock.Any(), roomID, requester, "", 3).
 					Return(stub, nil)
@@ -7525,33 +7523,20 @@ func TestHandler_ListMentionableSubscriptions(t *testing.T) {
 			want: want{subs: stub},
 		},
 		{
-			// Nil-Limit clamps to UserCount+AppCount (the cap), not the default 3.
-			// A small room with 1 user + 1 app would otherwise spuriously fail
-			// validation with the default 3 vs cap 2.
-			name: "nil limit clamped to small UserCount+AppCount",
+			// Regression (#419): a populated room whose denormalized userCount/
+			// appCount are stale/0 must still return its members. The handler no
+			// longer reads the counts (GetRoom is not expected here) — it queries
+			// subscriptions directly with the config-resolved default limit.
+			name: "stale zero counts still returns members",
 			body: nil,
 			setupMock: func(s *MockRoomStore) {
 				s.EXPECT().CheckMembership(gomock.Any(), requester, roomID).
 					Return(nil)
-				s.EXPECT().GetRoom(gomock.Any(), roomID).
-					Return(&model.Room{ID: roomID, UserCount: 1, AppCount: 1}, nil)
 				s.EXPECT().
-					ListMentionableSubscriptions(gomock.Any(), roomID, requester, "", 2).
+					ListMentionableSubscriptions(gomock.Any(), roomID, requester, "", 3).
 					Return(stub, nil)
 			},
 			want: want{subs: stub},
-		},
-		{
-			// Empty-room short-circuit: skip the store call, return empty.
-			name: "nil limit + empty room returns empty without store call",
-			body: nil,
-			setupMock: func(s *MockRoomStore) {
-				s.EXPECT().CheckMembership(gomock.Any(), requester, roomID).
-					Return(nil)
-				s.EXPECT().GetRoom(gomock.Any(), roomID).
-					Return(&model.Room{ID: roomID, UserCount: 0, AppCount: 0}, nil)
-			},
-			want: want{subs: []model.MentionableSubscription{}},
 		},
 		{
 			name: "explicit limit and filter passed through",
@@ -7559,8 +7544,6 @@ func TestHandler_ListMentionableSubscriptions(t *testing.T) {
 			setupMock: func(s *MockRoomStore) {
 				s.EXPECT().CheckMembership(gomock.Any(), requester, roomID).
 					Return(nil)
-				s.EXPECT().GetRoom(gomock.Any(), roomID).
-					Return(&model.Room{ID: roomID, UserCount: 5, AppCount: 2}, nil)
 				s.EXPECT().
 					ListMentionableSubscriptions(gomock.Any(), roomID, requester, "bo", 3).
 					Return(stub, nil)
@@ -7573,8 +7556,6 @@ func TestHandler_ListMentionableSubscriptions(t *testing.T) {
 			setupMock: func(s *MockRoomStore) {
 				s.EXPECT().CheckMembership(gomock.Any(), requester, roomID).
 					Return(nil)
-				s.EXPECT().GetRoom(gomock.Any(), roomID).
-					Return(&model.Room{ID: roomID, UserCount: 5, AppCount: 2}, nil)
 				s.EXPECT().
 					ListMentionableSubscriptions(gomock.Any(), roomID, requester, `a\.b\(c`, 3).
 					Return([]model.MentionableSubscription{}, nil)
@@ -7582,121 +7563,66 @@ func TestHandler_ListMentionableSubscriptions(t *testing.T) {
 			want: want{subs: []model.MentionableSubscription{}},
 		},
 		{
-			// GetRoom is dispatched in parallel with GetSubscription; it may
-			// or may not be invoked depending on goroutine timing before
-			// errgroup observes the membership error. AnyTimes() accepts
-			// both racing outcomes.
 			name: "requester not a member",
 			body: nil,
 			setupMock: func(s *MockRoomStore) {
 				s.EXPECT().CheckMembership(gomock.Any(), requester, roomID).
 					Return(fmt.Errorf("missing: %w", model.ErrSubscriptionNotFound))
-				s.EXPECT().GetRoom(gomock.Any(), roomID).
-					Return(&model.Room{ID: roomID, UserCount: 5, AppCount: 2}, nil).AnyTimes()
 			},
 			want: want{errIs: errNotRoomMember},
 		},
 		{
-			// Precedence regression: when BOTH the membership probe and the
-			// room read fail concurrently, errNotRoomMember must still win.
-			// Plain errgroup.Group (no WithContext) prevents GetRoom's failure
-			// from cancelling GetSubscription mid-flight and surfacing as
-			// context.Canceled, which would mask the not-member signal.
-			name: "not-member takes precedence over GetRoom error",
-			body: nil,
-			setupMock: func(s *MockRoomStore) {
-				s.EXPECT().CheckMembership(gomock.Any(), requester, roomID).
-					Return(fmt.Errorf("missing: %w", model.ErrSubscriptionNotFound))
-				s.EXPECT().GetRoom(gomock.Any(), roomID).
-					Return(nil, fmt.Errorf("mongo exploded"))
-			},
-			want: want{errIs: errNotRoomMember},
-		},
-		{
-			name: "GetSubscription infra error",
+			name: "membership check infra error",
 			body: nil,
 			setupMock: func(s *MockRoomStore) {
 				s.EXPECT().CheckMembership(gomock.Any(), requester, roomID).
 					Return(fmt.Errorf("mongo exploded"))
-				s.EXPECT().GetRoom(gomock.Any(), roomID).
-					Return(&model.Room{ID: roomID, UserCount: 5, AppCount: 2}, nil).AnyTimes()
 			},
 			want: want{errContains: "check room membership"},
 		},
 		{
-			name: "limit zero",
+			name: "limit zero rejected before store call",
 			body: []byte(`{"limit":0}`),
 			setupMock: func(s *MockRoomStore) {
 				s.EXPECT().CheckMembership(gomock.Any(), requester, roomID).
 					Return(nil)
-				s.EXPECT().GetRoom(gomock.Any(), roomID).
-					Return(&model.Room{ID: roomID, UserCount: 5, AppCount: 2}, nil)
 			},
 			want: want{errIs: errMentionableLimitInvalid},
 		},
 		{
-			name: "limit negative",
+			name: "limit negative rejected before store call",
 			body: []byte(`{"limit":-1}`),
 			setupMock: func(s *MockRoomStore) {
 				s.EXPECT().CheckMembership(gomock.Any(), requester, roomID).
 					Return(nil)
-				s.EXPECT().GetRoom(gomock.Any(), roomID).
-					Return(&model.Room{ID: roomID, UserCount: 5, AppCount: 2}, nil)
 			},
 			want: want{errIs: errMentionableLimitInvalid},
 		},
 		{
-			// Regression (#464): an over-cap explicit limit must clamp to the
-			// cap like the nil-limit branch does, not hard-reject.
-			name: "limit exceeds UserCount + AppCount clamps instead of rejecting",
-			body: []byte(`{"limit":8}`),
+			// An explicit over-max limit clamps to MENTIONABLE_MAX_LIMIT (50 here),
+			// never rejected and never passed through unbounded.
+			name: "explicit limit over max clamps to max",
+			body: []byte(`{"limit":100}`),
 			setupMock: func(s *MockRoomStore) {
 				s.EXPECT().CheckMembership(gomock.Any(), requester, roomID).
 					Return(nil)
-				s.EXPECT().GetRoom(gomock.Any(), roomID).
-					Return(&model.Room{ID: roomID, UserCount: 5, AppCount: 2}, nil)
 				s.EXPECT().
-					ListMentionableSubscriptions(gomock.Any(), roomID, requester, "", 7).
+					ListMentionableSubscriptions(gomock.Any(), roomID, requester, "", 50).
 					Return(stub, nil)
 			},
 			want: want{subs: stub},
 		},
 		{
-			// Empty room + explicit over-cap limit must still short-circuit
-			// to empty (no store call), never send $limit:0 to the store.
-			name: "explicit limit with empty room returns empty without store call",
-			body: []byte(`{"limit":5}`),
-			setupMock: func(s *MockRoomStore) {
-				s.EXPECT().CheckMembership(gomock.Any(), requester, roomID).
-					Return(nil)
-				s.EXPECT().GetRoom(gomock.Any(), roomID).
-					Return(&model.Room{ID: roomID, UserCount: 0, AppCount: 0}, nil)
-			},
-			want: want{subs: []model.MentionableSubscription{}},
-		},
-		{
-			name: "limit at cap is accepted",
+			name: "explicit limit under max passes through",
 			body: []byte(`{"limit":7}`),
 			setupMock: func(s *MockRoomStore) {
 				s.EXPECT().CheckMembership(gomock.Any(), requester, roomID).
 					Return(nil)
-				s.EXPECT().GetRoom(gomock.Any(), roomID).
-					Return(&model.Room{ID: roomID, UserCount: 5, AppCount: 2}, nil)
 				s.EXPECT().
 					ListMentionableSubscriptions(gomock.Any(), roomID, requester, "", 7).
 					Return(stub, nil)
 			},
 			want: want{subs: stub},
-		},
-		{
-			name: "GetRoom errors",
-			body: nil,
-			setupMock: func(s *MockRoomStore) {
-				s.EXPECT().CheckMembership(gomock.Any(), requester, roomID).
-					Return(nil)
-				s.EXPECT().GetRoom(gomock.Any(), roomID).Return(nil, fmt.Errorf("mongo exploded"))
-			},
-			want: want{errContains: "get room"},
 		},
 		{
 			name: "store errors",
@@ -7704,8 +7630,6 @@ func TestHandler_ListMentionableSubscriptions(t *testing.T) {
 			setupMock: func(s *MockRoomStore) {
 				s.EXPECT().CheckMembership(gomock.Any(), requester, roomID).
 					Return(nil)
-				s.EXPECT().GetRoom(gomock.Any(), roomID).
-					Return(&model.Room{ID: roomID, UserCount: 5, AppCount: 2}, nil)
 				s.EXPECT().
 					ListMentionableSubscriptions(gomock.Any(), roomID, requester, "", 3).
 					Return(nil, fmt.Errorf("mongo exploded"))
@@ -7713,8 +7637,8 @@ func TestHandler_ListMentionableSubscriptions(t *testing.T) {
 			want: want{errContains: "list mentionable subscriptions"},
 		},
 		{
-			// Body parse now precedes the parallel store dispatch; a malformed
-			// body short-circuits before any read.
+			// Body parse precedes the membership check; a malformed body
+			// short-circuits before any read.
 			name:      "malformed JSON body",
 			body:      []byte("{not json"),
 			setupMock: func(s *MockRoomStore) {},
@@ -7728,7 +7652,7 @@ func TestHandler_ListMentionableSubscriptions(t *testing.T) {
 			store := NewMockRoomStore(ctrl)
 			tc.setupMock(store)
 
-			h := &Handler{store: store, siteID: siteID}
+			h := &Handler{store: store, siteID: siteID, mentionableDefaultLimit: 3, mentionableMaxLimit: 50}
 			c := ctxParams(map[string]string{"account": requester, "roomID": roomID})
 			c.Msg = &nats.Msg{Data: tc.body}
 			resp, err := h.listMentionableSubscriptions(c)

--- a/room-service/helper.go
+++ b/room-service/helper.go
@@ -74,7 +74,7 @@ var (
 
 	// Sentinels for member.statuses + subscription.mentionable limit validation.
 	errMemberStatusesLimitInvalid = errcode.BadRequest("limit must be > 0 and <= room user count")
-	errMentionableLimitInvalid    = errcode.BadRequest("limit must be > 0 and <= room user count + app count")
+	errMentionableLimitInvalid    = errcode.BadRequest("limit must be > 0")
 
 	// errRoomKeyAbsent is returned when the requested key version is not held
 	// by the key store (either the current key is missing or the historical

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -117,6 +117,22 @@ type config struct {
 	RoomLocalityGrace time.Duration `env:"ROOM_LOCALITY_GRACE" envDefault:"168h"`
 }
 
+// validateMentionableLimits enforces the mentionable page-size invariants at
+// startup: both bounds positive, and the no-limit default never exceeding the
+// max (otherwise a limit-less request would bypass the configured cap).
+func validateMentionableLimits(defaultLimit, maxLimit int) error {
+	switch {
+	case defaultLimit <= 0:
+		return fmt.Errorf("MENTIONABLE_DEFAULT_LIMIT must be > 0, got %d", defaultLimit)
+	case maxLimit <= 0:
+		return fmt.Errorf("MENTIONABLE_MAX_LIMIT must be > 0, got %d", maxLimit)
+	case defaultLimit > maxLimit:
+		return fmt.Errorf("MENTIONABLE_DEFAULT_LIMIT (%d) must be <= MENTIONABLE_MAX_LIMIT (%d)", defaultLimit, maxLimit)
+	default:
+		return nil
+	}
+}
+
 // legacyRoomOrigin maps a site to its legacy origin URL (incl. scheme).
 type legacyRoomOrigin struct {
 	SiteID string `json:"siteID"`
@@ -175,12 +191,8 @@ func main() {
 		slog.Error("invalid RESTRICTED_ROOM_MIN_MEMBERS: must be > 0", "value", cfg.RestrictedRoomMinMembers)
 		os.Exit(1)
 	}
-	if cfg.MentionableDefaultLimit <= 0 {
-		slog.Error("invalid MENTIONABLE_DEFAULT_LIMIT: must be > 0", "value", cfg.MentionableDefaultLimit)
-		os.Exit(1)
-	}
-	if cfg.MentionableMaxLimit <= 0 {
-		slog.Error("invalid MENTIONABLE_MAX_LIMIT: must be > 0", "value", cfg.MentionableMaxLimit)
+	if err := validateMentionableLimits(cfg.MentionableDefaultLimit, cfg.MentionableMaxLimit); err != nil {
+		slog.Error("invalid mentionable limits", "error", err)
 		os.Exit(1)
 	}
 	roomRouteMode, err := subject.ParseRoomRouteMode(cfg.RoomSubjectMode)

--- a/room-service/main.go
+++ b/room-service/main.go
@@ -92,6 +92,11 @@ type config struct {
 	GraphProxyURL        string `env:"GRAPH_PROXY_URL" envDefault:""`
 	RoomMembersLimit     int    `env:"ROOM_MEMBERS_LIMIT"       envDefault:"500"`
 	RoomMembersCallLimit int    `env:"ROOM_MEMBERS_CALL_LIMIT"  envDefault:"20"`
+	// Mentionable @-autocomplete page size. Default applies when the client sends
+	// no limit; Max clamps an explicit over-large limit. Both are validated > 0 at
+	// startup and are independent of a room's denormalized member counts.
+	MentionableDefaultLimit int `env:"MENTIONABLE_DEFAULT_LIMIT" envDefault:"3"`
+	MentionableMaxLimit     int `env:"MENTIONABLE_MAX_LIMIT"     envDefault:"50"`
 	// Atrest/Vault drive eager at-rest DEK provisioning at room creation.
 	// When Atrest.Enabled is false the DEK is created lazily by message-worker.
 	Atrest   atrest.Config      // env vars already prefixed ATREST_*
@@ -168,6 +173,14 @@ func main() {
 	}
 	if cfg.RestrictedRoomMinMembers <= 0 {
 		slog.Error("invalid RESTRICTED_ROOM_MIN_MEMBERS: must be > 0", "value", cfg.RestrictedRoomMinMembers)
+		os.Exit(1)
+	}
+	if cfg.MentionableDefaultLimit <= 0 {
+		slog.Error("invalid MENTIONABLE_DEFAULT_LIMIT: must be > 0", "value", cfg.MentionableDefaultLimit)
+		os.Exit(1)
+	}
+	if cfg.MentionableMaxLimit <= 0 {
+		slog.Error("invalid MENTIONABLE_MAX_LIMIT: must be > 0", "value", cfg.MentionableMaxLimit)
 		os.Exit(1)
 	}
 	roomRouteMode, err := subject.ParseRoomRouteMode(cfg.RoomSubjectMode)
@@ -362,6 +375,8 @@ func main() {
 	handler.teamsEmailDomain = cfg.TeamsEmailDomain
 	handler.roomMembersLimit = cfg.RoomMembersLimit
 	handler.roomMembersCallLimit = cfg.RoomMembersCallLimit
+	handler.mentionableDefaultLimit = cfg.MentionableDefaultLimit
+	handler.mentionableMaxLimit = cfg.MentionableMaxLimit
 
 	router := natsrouter.DefaultGuarded(nc, "room-service", cfg.Guard)
 	handler.Register(router)


### PR DESCRIPTION
## Summary

`subscription.mentionable` returned an empty list for a populated room when the room's denormalized `userCount`/`appCount` were stale or `0`. The handler derived both an early empty-return and its page-size limit from `cap = room.UserCount + room.AppCount`, so a `0` cap short-circuited to `[]` and `@`-mention autocomplete showed nothing — even though the room had members.

Fixes #419.

## Changes

- **room-service/handler.go** — `listMentionableSubscriptions` no longer reads the room's member counts:
  - Removed the `cap == 0` early-return and the count-based limit clamp.
  - Resolve the page size from config instead: nil request-limit → `MENTIONABLE_DEFAULT_LIMIT`; explicit limit `<= 0` → rejected; otherwise clamped to `MENTIONABLE_MAX_LIMIT`.
  - Gate on membership alone via `CheckMembership` and drop the `GetRoom` round-trip (the room document was only used for the counts). The parallel `requireMembershipAndGetRoom` helper is retained — `listMemberStatuses` still uses it.
  - Removed the now-unused `defaultMentionableLimit` const.
- **room-service/main.go** — added `MENTIONABLE_DEFAULT_LIMIT` (default `3`) and `MENTIONABLE_MAX_LIMIT` (default `50`) to `config`, each validated `> 0` at startup (mirrors the existing `RESTRICTED_ROOM_MIN_MEMBERS` fail-fast), wired onto the handler.
- **room-service/helper.go** — `errMentionableLimitInvalid` message narrowed to `"limit must be > 0"` (it no longer references the room counts).
- **docs/client-api.md** + **docs/client-api/request-reply.md** — updated the `limit` semantics and the error string.
- Tests updated/added (see below).

The store method `ListMentionableSubscriptions` already applies `$limit` to the real subscription rows, so a populated room now returns its members regardless of the denormalized counts. The resolved limit is always `>= 1` (startup validation guarantees the bounds are `> 0`).

## Verification

- Red→green TDD: the mentionable handler tests were rewritten for the count-independent design and fail to compile against the old code (they reference the new config/handler fields); they pass after the change.
- `go test ./room-service/...` — pass (unit).
- `go vet ./room-service/` and `go vet -tags integration ./room-service/` — clean.
- `golangci-lint run ./room-service/...` — 0 issues.
- Key tests:
  - `TestHandler_ListMentionableSubscriptions/stale_zero_counts_still_returns_members` — the #419 regression: a populated room with no `GetRoom` call still returns members.
  - `TestHandler_ListMentionableSubscriptions/explicit_limit_over_max_clamps_to_max`, `.../limit_zero_rejected_before_store_call`, `.../limit_negative_rejected_before_store_call`, `.../default_limit,_empty_filter,_happy_path` — env-limit resolution + reject/clamp, store never called with limit 0.
  - `TestConfig_MentionableLimits` — the two env vars parse (defaults + override) and the `> 0` startup guard rejects non-positive values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable default and maximum page sizes for mention autocomplete.
  - Pagination limits now operate independently of room membership counts.

- **Bug Fixes**
  - Positive limits are accepted and capped at the configured maximum.
  - Invalid pagination settings are rejected during service startup.

- **Documentation**
  - Updated API documentation and error descriptions to reflect the revised pagination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->