### PR TITLE
fix: make engName/chineseName fully optional for room create and DM

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -1276,7 +1276,6 @@ See [Error envelope](#6-error-envelope-reference). Returned synchronously on val
 - `"channel name is required"` / `"channel name must be at most 100 characters"`
 - `"bots cannot be added to a channel"` / `"bot not available"` (botDM target whose assistant is disabled)
 - `user "<account>": user not found` / `org "<orgId>": invalid org` (each wrapped with the offending account/org ID)
-- `"user is missing required name fields"` — rejected only when BOTH `engName` and `chineseName` are empty (either one alone is sufficient)
 - `"exceeds maximum capacity (N): would create M members"`
 
 ```json

--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"sync/atomic"
+
+	"github.com/hmchangw/chat/pkg/displayfmt"
 )
 
 // UserRole is a platform-level role flag on the User record.
@@ -175,17 +177,11 @@ func IsBot(account string) bool {
 }
 
 // DisplayName renders the user's display label for Drive ownership metadata:
-// the account when either name is missing, the English name when both names are
-// identical, otherwise "<engName> <chineseName>".
+// the single present name when only one is set, the account when both are empty,
+// the English name when both names are identical, otherwise "<engName> <chineseName>".
 func (u *User) DisplayName() string {
-	switch {
-	case u == nil:
+	if u == nil {
 		return ""
-	case u.EngName == "" || u.ChineseName == "":
-		return u.Account
-	case u.EngName == u.ChineseName:
-		return u.EngName
-	default:
-		return u.EngName + " " + u.ChineseName
 	}
+	return displayfmt.CombineWithFallback(u.EngName, u.ChineseName, u.Account)
 }

--- a/pkg/model/user_test.go
+++ b/pkg/model/user_test.go
@@ -17,8 +17,8 @@ func TestUser_DisplayName(t *testing.T) {
 	}{
 		{"nil user", nil, ""},
 		{"both names empty -> account", &User{Account: "alice", EngName: "", ChineseName: ""}, "alice"},
-		{"eng empty -> account", &User{Account: "alice", EngName: "", ChineseName: "陳"}, "alice"},
-		{"chinese empty -> account", &User{Account: "alice", EngName: "Alice", ChineseName: ""}, "alice"},
+		{"eng only -> eng", &User{Account: "alice", EngName: "Alice", ChineseName: ""}, "Alice"},
+		{"chinese only -> chinese", &User{Account: "alice", EngName: "", ChineseName: "陳"}, "陳"},
 		{"equal names -> eng", &User{Account: "alice", EngName: "Same", ChineseName: "Same"}, "Same"},
 		{"distinct names -> joined", &User{Account: "alice", EngName: "Alice", ChineseName: "陳"}, "Alice 陳"},
 	}

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -161,10 +161,6 @@ func (h *Handler) createRoom(c *natsrouter.Context, req model.CreateRoomRequest)
 		}
 		return nil, fmt.Errorf("get requester: %w", err)
 	}
-	if requester.EngName == "" && requester.ChineseName == "" {
-		return nil, errInvalidUserData
-	}
-
 	// A DM with no post-strip counterpart is a self-DM (classifyAndValidate only
 	// emits RoomTypeDM with empty Users for that case). Handle it before the switch
 	// so each switch case stays single-purpose.
@@ -265,13 +261,6 @@ func (h *Handler) handleCreateRoomDMOrBotDM(ctx context.Context, req *model.Crea
 		}
 		return nil, fmt.Errorf("get counterpart: %w", err)
 	}
-	if roomType == model.RoomTypeDM && (other.EngName == "" && other.ChineseName == "") {
-		// botDMs counterpart is an app/bot whose users-collection record
-		// typically has empty name fields; the GetApp + Assistant.Enabled
-		// check below is the right validation for that case.
-		return nil, errInvalidUserData
-	}
-
 	req.RoomID = idgen.BuildDMRoomID(requester.ID, other.ID)
 	// DM/BotDM resolved set matches the literal counterpart list — there is no expansion.
 	req.ResolvedUsers = append([]string(nil), req.Users...)

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -2822,58 +2822,49 @@ func TestHandleCreateRoom_RequesterNotFound(t *testing.T) {
 	assert.True(t, errcode.HasReason(err, errcode.RoomUserNotFound), "want RoomUserNotFound, got %v", err)
 }
 
-// TestHandleCreateRoom_RequesterNameFields covers #244: the creator check
-// rejects only when BOTH EngName and ChineseName are empty; either alone is
-// sufficient. Bot-requester exemption isn't exercised here (bots don't call
-// createRoom as requester); the DM counterpart's bot exemption is covered by
-// TestHandleCreateRoom_BotDM_AppCounterpartNoNameFields (roomType != DM skips
-// this check entirely for botDM).
+// TestHandleCreateRoom_RequesterNameFields covers #421: engName/chineseName are
+// fully optional for the creator — any combination (including both empty) creates
+// a room. Bot-requester exemption isn't exercised here (bots don't call createRoom
+// as requester).
 func TestHandleCreateRoom_RequesterNameFields(t *testing.T) {
 	tests := []struct {
 		name      string
 		requester *model.User
-		wantErr   bool
 	}{
-		{"engName only", &model.User{ID: "u-alice", Account: "alice", EngName: "Alice"}, false},
-		{"chineseName only", &model.User{ID: "u-alice", Account: "alice", ChineseName: "愛麗絲"}, false},
-		{"both present", &model.User{ID: "u-alice", Account: "alice", EngName: "Alice", ChineseName: "愛麗絲"}, false},
-		{"neither", &model.User{ID: "u-alice", Account: "alice"}, true},
+		{"engName only", &model.User{ID: "u-alice", Account: "alice", EngName: "Alice"}},
+		{"chineseName only", &model.User{ID: "u-alice", Account: "alice", ChineseName: "愛麗絲"}},
+		{"both present", &model.User{ID: "u-alice", Account: "alice", EngName: "Alice", ChineseName: "愛麗絲"}},
+		{"neither", &model.User{ID: "u-alice", Account: "alice"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			store := NewMockRoomStore(ctrl)
 			store.EXPECT().GetUser(gomock.Any(), "alice").Return(tt.requester, nil)
-			if !tt.wantErr {
-				store.EXPECT().GetUser(gomock.Any(), "bob").Return(bobUser(), nil)
-				store.EXPECT().FindDMSubscription(gomock.Any(), "alice", "bob").
-					Return(&model.Subscription{RoomID: "existing-dm-room"}, nil)
-			}
+			store.EXPECT().GetUser(gomock.Any(), "bob").Return(bobUser(), nil)
+			store.EXPECT().FindDMSubscription(gomock.Any(), "alice", "bob").
+				Return(&model.Subscription{RoomID: "existing-dm-room"}, nil)
 			h := &Handler{store: store, siteID: "site-a", maxRoomSize: 1000}
 
 			_, err := h.createRoom(ctxParams(map[string]string{"account": "alice"}), model.CreateRoomRequest{Users: []string{"bob"}})
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.True(t, errors.Is(err, errInvalidUserData))
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, err)
 		})
 	}
 }
 
-// TestHandleCreateRoom_DMCounterpartNameFields covers #244 for the DM
-// counterpart check: rejects only when BOTH fields are empty on `other`.
+// TestHandleCreateRoom_DMCounterpartNameFields covers #421 for the DM
+// counterpart: a human counterpart with any name combination (including both
+// empty) can be DMed. BotDM path is unchanged — its app counterpart is validated
+// by GetApp/Assistant.Enabled (see TestHandleCreateRoom_BotDM_AppCounterpartNoNameFields).
 func TestHandleCreateRoom_DMCounterpartNameFields(t *testing.T) {
 	tests := []struct {
-		name    string
-		other   *model.User
-		wantErr bool
+		name  string
+		other *model.User
 	}{
-		{"engName only", &model.User{ID: "u-bob", Account: "bob", EngName: "Bob"}, false},
-		{"chineseName only", &model.User{ID: "u-bob", Account: "bob", ChineseName: "陳博"}, false},
-		{"both present", bobUser(), false},
-		{"neither", &model.User{ID: "u-bob", Account: "bob"}, true},
+		{"engName only", &model.User{ID: "u-bob", Account: "bob", EngName: "Bob"}},
+		{"chineseName only", &model.User{ID: "u-bob", Account: "bob", ChineseName: "陳博"}},
+		{"both present", bobUser()},
+		{"neither", &model.User{ID: "u-bob", Account: "bob"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2881,19 +2872,12 @@ func TestHandleCreateRoom_DMCounterpartNameFields(t *testing.T) {
 			store := NewMockRoomStore(ctrl)
 			store.EXPECT().GetUser(gomock.Any(), "alice").Return(aliceUser(), nil)
 			store.EXPECT().GetUser(gomock.Any(), "bob").Return(tt.other, nil)
-			if !tt.wantErr {
-				store.EXPECT().FindDMSubscription(gomock.Any(), "alice", "bob").
-					Return(&model.Subscription{RoomID: "existing-dm-room"}, nil)
-			}
+			store.EXPECT().FindDMSubscription(gomock.Any(), "alice", "bob").
+				Return(&model.Subscription{RoomID: "existing-dm-room"}, nil)
 			h := &Handler{store: store, siteID: "site-a", maxRoomSize: 1000}
 
 			_, err := h.createRoom(ctxParams(map[string]string{"account": "alice"}), model.CreateRoomRequest{Users: []string{"bob"}})
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.True(t, errors.Is(err, errInvalidUserData))
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/room-service/helper.go
+++ b/room-service/helper.go
@@ -52,7 +52,6 @@ var (
 	errBotNotAvailable    = errcode.NotFound("bot not available", errcode.WithReason(errcode.RoomBotNotAvailable))
 	// Bots hold plain member roles only.
 	errBotCannotBeOwner    = errcode.BadRequest("bots cannot be room owners", errcode.WithReason(errcode.RoomBotCannotBeOwner))
-	errInvalidUserData     = errcode.BadRequest("user is missing required name fields")
 	errChannelNameRequired = errcode.BadRequest("channel name is required")
 	errChannelNameTooLong  = errcode.BadRequest("channel name must be at most 100 characters")
 

--- a/room-service/helper_test.go
+++ b/room-service/helper_test.go
@@ -113,7 +113,6 @@ func TestSentinelCodesAndReasons(t *testing.T) {
 		{"bot in channel", errBotInChannel, errcode.CodeBadRequest, errcode.RoomBotInChannel},
 		{"bot not available", errBotNotAvailable, errcode.CodeNotFound, errcode.RoomBotNotAvailable},
 		{"bot cannot be owner", errBotCannotBeOwner, errcode.CodeBadRequest, errcode.RoomBotCannotBeOwner},
-		{"invalid user data", errInvalidUserData, errcode.CodeBadRequest, ""},
 		{"channel name required", errChannelNameRequired, errcode.CodeBadRequest, ""},
 		{"channel name too long", errChannelNameTooLong, errcode.CodeBadRequest, ""},
 		{"message not found", errMessageNotFound, errcode.CodeNotFound, ""},
@@ -142,7 +141,6 @@ func TestNewSentinelErrorsExist(t *testing.T) {
 	assert.Equal(t, "request must include at least one of users, orgs, channels, or name", errEmptyCreateRequest.Error())
 	assert.Equal(t, "bots cannot be added to a channel", errBotInChannel.Error())
 	assert.Equal(t, "bot not available", errBotNotAvailable.Error())
-	assert.Equal(t, "user is missing required name fields", errInvalidUserData.Error())
 	assert.Equal(t, "channel name is required", errChannelNameRequired.Error())
 	assert.Equal(t, "channel name must be at most 100 characters", errChannelNameTooLong.Error())
 }


### PR DESCRIPTION
## Summary

Makes `engName` / `chineseName` fully optional. A user with neither name could not create a room or be DMed — `room-service` returned a 400 when both name fields were empty, on both the creator and the human DM counterpart. Names are optional user attributes, so the check was too strict. This also fixes single-name users rendering as their account instead of the name they do have.

Fixes #421

## Changes

- **room-service** (`handler.go`, `helper.go`): remove the both-names-empty reject in `createRoom` (creator) and in the DM counterpart check; delete the now-unused `errInvalidUserData` sentinel. The botDM path is unchanged — its app counterpart is validated by `GetApp` / `Assistant.Enabled`, never by name fields (that check sat below the removed block and is untouched).
- **pkg/model** (`user.go`): `User.DisplayName()` now routes through `displayfmt.CombineWithFallback(engName, chineseName, account)`, so a single-name user renders that name. Previously it fell back to the account whenever *either* name was missing. Both-empty still falls back to the account; identical names render once; both present render `"<eng> <chinese>"`.
- **docs/client-api.md**: drop the retired `"user is missing required name fields"` 400 from the room-create error list (doc-ratchet).

## Verification

- `go build ./room-service/... ./pkg/model/...` — clean.
- `go test ./room-service/... ./pkg/model/...` — pass.
- `golangci-lint` on both packages — 0 issues.
- TDD red→green: `TestUser_DisplayName` (eng-only → eng, chinese-only → chinese, both → joined, equal → the name, both-empty → account, nil → ""), and `TestHandleCreateRoom_RequesterNameFields` / `TestHandleCreateRoom_DMCounterpartNameFields` now assert success for the both-empty case.
