### PR TITLE
Mark marshal failures as permanent to prevent futile retries

### DIFF
--- a/.semgrep/jsnak.yml
+++ b/.semgrep/jsnak.yml
@@ -50,3 +50,60 @@ rules:
           - pattern: $CC.BackOff = $X
           - pattern: |
               jetstream.ConsumerConfig{..., BackOff: $X, ...}
+
+  - id: jsretry-marshal-failure-must-be-permanent
+    languages: [go]
+    severity: ERROR
+    message: >
+      Marshaling a fixed struct is deterministic — a value the encoder rejects (a
+      NaN float, an erroring custom marshaler) is rejected identically on every
+      redelivery. A bare wrapped error here makes jsretry Nak a message that can
+      never succeed: it burns the consumer's MaxDeliver budget and then drops the
+      message silently, or head-of-line blocks a MaxDeliver=-1 lane forever. Use
+      errcode.MarshalFailed("<what>", err). If this marshal is NOT on a path that
+      reaches a jsretry settle point (best-effort fan-out, a fail-open read),
+      suppress with `// nosemgrep: jsretry-marshal-failure-must-be-permanent --
+      <reason>` on the line above.
+    paths:
+      # Only packages whose marshal errors can reach a jsretry settle decision.
+      # A worker added later must be added here too.
+      include:
+        - "broadcast-worker/"
+        - "bot-message-worker/"
+        - "hr-sync-worker/"
+        - "inbox-worker/"
+        - "message-gatekeeper/"
+        - "message-worker/"
+        - "notification-worker/"
+        - "outbox-worker/"
+        - "pkg/outbox/"
+        - "push-notification-service/"
+        - "room-worker/"
+      exclude:
+        - "**/*_test.go"
+    patterns:
+      - pattern-either:
+          - pattern: |
+              $D, $E := $P.Marshal(...)
+              if $E != nil {
+                ...
+                return fmt.Errorf(...)
+              }
+          - pattern: |
+              $D, $E := $P.Marshal(...)
+              if $E != nil {
+                ...
+                return $X, fmt.Errorf(...)
+              }
+          - pattern: |
+              $D, $E = $P.Marshal(...)
+              if $E != nil {
+                ...
+                return fmt.Errorf(...)
+              }
+          - pattern: |
+              $D, $E = $P.Marshal(...)
+              if $E != nil {
+                ...
+                return $X, fmt.Errorf(...)
+              }

--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -363,7 +363,7 @@ func (h *Handler) handleThreadCreated(ctx context.Context, evt *model.MessageEve
 		}
 		payload, err := sonic.Marshal(roomEvt)
 		if err != nil {
-			return fmt.Errorf("marshal thread created event for parent %s: %w", parentMsgID, err)
+			return errcode.MarshalFailed("thread created event", err)
 		}
 		viewPayload := h.sealThreadViewPayload(ctx, meta.ID, payload, func() (any, error) {
 			sealed := roomEvt
@@ -564,7 +564,7 @@ func (h *Handler) handleThreadUpdated(ctx context.Context, evt *model.MessageEve
 		}
 		payload, err := sonic.Marshal(&edit)
 		if err != nil {
-			return fmt.Errorf("marshal thread edit event for parent %s: %w", parentMsgID, err)
+			return errcode.MarshalFailed("thread edit event", err)
 		}
 		viewPayload := h.sealThreadViewPayload(ctx, room.ID, payload, func() (any, error) {
 			sealed := edit
@@ -619,7 +619,7 @@ func (h *Handler) handleThreadDeleted(ctx context.Context, evt *model.MessageEve
 		}
 		payload, err := sonic.Marshal(&del)
 		if err != nil {
-			return fmt.Errorf("marshal thread delete event for parent %s: %w", parentMsgID, err)
+			return errcode.MarshalFailed("thread delete event", err)
 		}
 		// A delete carries ids and timestamps, no body, so both lanes share it.
 		if err := h.publishChannelThreadEvent(ctx, room.ID, parentMsgID, room.CrossSite, room.CrossSiteAt, payload, payload, fanOut); err != nil {
@@ -689,7 +689,7 @@ func (h *Handler) publishThreadMetadata(ctx context.Context, room *model.Room, n
 	}
 	payload, err := sonic.Marshal(evt)
 	if err != nil {
-		return fmt.Errorf("marshal thread metadata event for room %s: %w", room.ID, err)
+		return errcode.MarshalFailed("thread metadata event", err)
 	}
 	switch room.Type {
 	case model.RoomTypeChannel:
@@ -901,7 +901,7 @@ func (h *Handler) publishMutation(ctx context.Context, room *model.Room, roomEvt
 	ctx = withBroadcastMetricLabels(ctx, roomKind(room.Type), labels.eventType)
 	payload, err := sonic.Marshal(evt)
 	if err != nil {
-		return fmt.Errorf("marshal %s event: %w", roomEvtType, err)
+		return errcode.MarshalFailed(string(roomEvtType)+" event", err)
 	}
 
 	switch room.Type {
@@ -998,7 +998,7 @@ func (h *Handler) encryptEditedContent(ctx context.Context, roomID string, edite
 	}
 	encJSON, err := sonic.Marshal(encrypted)
 	if err != nil {
-		return fmt.Errorf("marshal encrypted edit content: %w", err)
+		return errcode.MarshalFailed("encrypted edit content", err)
 	}
 	edited.EncryptedNewContent = json.RawMessage(encJSON)
 	edited.NewContent = ""
@@ -1026,7 +1026,7 @@ func (h *Handler) encryptRoomEvent(ctx context.Context, roomID string, clientMsg
 	}
 	msgJSON, err := sonic.Marshal(clientMsg)
 	if err != nil {
-		return fmt.Errorf("marshal client message for room %s: %w", roomID, err)
+		return errcode.MarshalFailed("client message", err)
 	}
 	key, err := h.currentRoomKey(ctx, roomID)
 	if err != nil {
@@ -1038,7 +1038,7 @@ func (h *Handler) encryptRoomEvent(ctx context.Context, roomID string, clientMsg
 	}
 	encJSON, err := sonic.Marshal(encrypted)
 	if err != nil {
-		return fmt.Errorf("marshal encrypted message for room %s: %w", roomID, err)
+		return errcode.MarshalFailed("encrypted message", err)
 	}
 	evt.EncryptedMessage = json.RawMessage(encJSON)
 	evt.Message = nil
@@ -1056,7 +1056,7 @@ func (h *Handler) publishChannelEvent(ctx context.Context, meta *roommetacache.M
 	}
 	payload, err := sonic.Marshal(evt)
 	if err != nil {
-		return fmt.Errorf("marshal channel event: %w", err)
+		return errcode.MarshalFailed("channel event", err)
 	}
 	// flow: one room-stream publish; NATS fans out to subscribers downstream, so
 	// this reports the room audience, not per-recipient deliveries from here.
@@ -1190,7 +1190,7 @@ func (h *Handler) publishDMEvents(ctx context.Context, meta *roommetacache.Meta,
 
 		payload, err := sonic.Marshal(evt)
 		if err != nil {
-			return fmt.Errorf("marshal DM event for user %s: %w", account, err)
+			return errcode.MarshalFailed("DM event", err)
 		}
 		recipients++
 		// Publish errors are intentionally swallowed here (log-and-continue). DM thread

--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/nats-io/nats.go"
 	"go.opentelemetry.io/otel"
 
 	"github.com/hmchangw/chat/pkg/errcode"
@@ -1076,6 +1077,13 @@ func (h *Handler) publishRoomEvent(ctx context.Context, roomID string, crossSite
 	var pubErr error
 	for _, subj := range subject.RoomEventTargets(roomID, crossSite, crossSiteAt, h.routeMode, now) {
 		if err := h.pub.Publish(ctx, subj, payload); err != nil {
+			if errors.Is(err, nats.ErrMaxPayload) {
+				// Rejected client-side before the wire: the same payload is oversized
+				// for every remaining target and every redelivery, so stop here rather
+				// than spend the consumer's budget on a publish that cannot land.
+				return errcode.Permanent(errcode.Internal(
+					fmt.Sprintf("%s for room %s exceeds broker max_payload", op, roomID)))
+			}
 			pubErr = fmt.Errorf("publish %s for room %s to %s: %w", op, roomID, subj, err)
 		}
 	}

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -4197,3 +4197,24 @@ func TestHandler_PublishMutation_MarshalFailureIsPermanent(t *testing.T) {
 	require.True(t, perm, "a marshal failure can never succeed on redelivery")
 	assert.Equal(t, errcode.CodeInternal, ec.Code, "a marshal fault is a server fault, not a client error")
 }
+
+// An oversized room event is rejected client-side before the wire, so every
+// target subject and every redelivery fails identically. Retrying only holds an
+// ack-pending slot until MaxDeliver drops it anyway.
+func TestHandler_PublishRoomEvent_OversizedPayloadIsPermanent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	roomID := "room-1"
+	pub := &mockPublisher{failOn: map[string]error{}}
+	for _, subj := range subject.RoomEventTargets(roomID, nil, nil, subject.RouteGlobal, time.Now().UTC()) {
+		pub.failOn[subj] = nats.ErrMaxPayload
+	}
+	h := NewHandler(NewMockStore(ctrl), NewMockUserStore(ctrl), pub,
+		NewMockRoomKeyProvider(ctrl), defaultParentFetcher, true, subject.RouteGlobal)
+
+	err := h.publishRoomEvent(context.Background(), roomID, nil, nil, []byte(`{}`), "message_deleted event")
+
+	require.Error(t, err)
+	ec, perm := errcode.IsPermanent(err)
+	require.True(t, perm, "an oversized publish can never succeed on redelivery")
+	assert.Equal(t, errcode.CodeInternal, ec.Code)
+}

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -4179,3 +4179,21 @@ type deliveryCountMsg struct {
 func (m *deliveryCountMsg) Metadata() (*jetstream.MsgMetadata, error) {
 	return &jetstream.MsgMetadata{NumDelivered: m.numDelivered}, nil
 }
+
+// A value the encoder rejects fails identically on every redelivery, so the
+// marshal failure must be permanent — jsretry Ack-drops it instead of spending
+// the consumer's whole MaxDeliver budget on a doomed retry.
+func TestHandler_PublishMutation_MarshalFailureIsPermanent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := NewHandler(NewMockStore(ctrl), NewMockUserStore(ctrl), &mockPublisher{},
+		NewMockRoomKeyProvider(ctrl), defaultParentFetcher, true, subject.RouteGlobal)
+	room := &model.Room{ID: "room-1", Type: model.RoomTypeChannel}
+
+	// A channel is unrepresentable in JSON: the encoder rejects it every time.
+	err := h.publishMutation(context.Background(), room, model.RoomEventMessageDeleted, "msg-1", make(chan int))
+
+	require.Error(t, err)
+	ec, perm := errcode.IsPermanent(err)
+	require.True(t, perm, "a marshal failure can never succeed on redelivery")
+	assert.Equal(t, errcode.CodeInternal, ec.Code, "a marshal fault is a server fault, not a client error")
+}

--- a/broadcast-worker/parent_fetcher.go
+++ b/broadcast-worker/parent_fetcher.go
@@ -55,7 +55,7 @@ type parentMessageProjection struct {
 func (f *historyParentFetcher) FetchParent(ctx context.Context, account, roomID, siteID, messageID string) (*ParentMessageInfo, error) {
 	reqBytes, err := sonic.Marshal(getMessageByIDRequest{MessageID: messageID})
 	if err != nil {
-		return nil, fmt.Errorf("marshal GetMessageByID request: %w", err)
+		return nil, errcode.MarshalFailed("GetMessageByID request", err)
 	}
 	started := time.Now()
 	msg, err := f.nc.Request(ctx, subject.MsgGet(account, roomID, siteID), reqBytes, parentFetchTimeout)

--- a/broadcast-worker/roomactivity.go
+++ b/broadcast-worker/roomactivity.go
@@ -181,6 +181,9 @@ func roomActivityPublisher(p Publisher, siteID string, peers []string) func(cont
 			LastMsgAt: r.at.UTC().UnixMilli(),
 			Timestamp: time.Now().UTC().UnixMilli(),
 		}
+		// The coalescer flush owns this error; there is no message and no ack
+		// decision on this lane.
+		// nosemgrep: jsretry-marshal-failure-must-be-permanent
 		data, err := json.Marshal(evt)
 		if err != nil {
 			return fmt.Errorf("marshal room activity event: %w", err)

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -294,6 +294,15 @@ return fmt.Errorf("%w and %w", errcodeA, errcodeB)                 // Classify p
 | `errcode-no-multi-wrap-errcode`            | ERROR    | `fmt.Errorf("%w … %w")` mixing typed errors |
 | `errcode-prefer-named-constructor`         | WARNING  | `errcode.New(errcode.CodeX, msg)` literal |
 
+`.semgrep/jsnak.yml` enforces the JetStream settle rules (see §9a):
+
+| Rule                                          | Severity | What it catches |
+|-----------------------------------------------|----------|-----------------|
+| `jsretry-no-bare-nak`                         | ERROR    | `msg.Nak()` — instant redelivery, ignores `BackOff` |
+| `jsretry-no-zero-nak-delay`                   | ERROR    | `NakWithDelay(0)` — the same thing on the wire |
+| `jsretry-no-hardcoded-consumer-backoff`       | ERROR    | Assigning `ConsumerConfig.BackOff` directly |
+| `jsretry-marshal-failure-must-be-permanent`   | ERROR    | A marshal error returned as a bare wrapped error on a settle path |
+
 CI runs `make sast` on every PR.
 
 ---
@@ -338,15 +347,16 @@ if err := h.store.Save(ctx, &row); err != nil {
 }
 ```
 
-The consume loop in `main.go` reads the marker:
+The consume loop hands the error to `pkg/jsretry`, which reads the marker:
 
 ```go
-if _, ok := errcode.IsPermanent(err); ok {
-    msg.Ack() // poison-pill drop; client already got the AsyncJobResult.
-    return
-}
-msg.Nak() // transient — retry.
+// Ack on nil, Ack-drop on Permanent, NakWithDelay(backoff) otherwise.
+jsretry.Settle(ctx, msg, jsretry.DefaultBackoff, h.HandleMessage(ctx, msg.Data()))
 ```
+
+Never call `msg.Nak()` or `NakWithDelay(0)` directly: a bare Nak redelivers
+instantly and ignores the consumer's `BackOff`, so a sub-second blip burns
+`MaxDeliver` in milliseconds. `.semgrep/jsnak.yml` fails CI on both.
 
 `Permanent` wraps an `*errcode.Error` so `fillAsyncError` can still extract
 `Code` / `Reason` for the `AsyncJobResult` envelope; the wrapper is invisible
@@ -356,6 +366,102 @@ the sentinel-style match if you don't need the wrapped `*Error`.
 **Don't** infer permanence from `Code`: an `Internal` can be either a poison-
 pill (bad payload classified to internal by Classify) or a retryable
 infra-down condition. Wrap explicitly at the call site.
+
+---
+
+## 9a. Which errors are permanent — classification reference
+
+### The test
+
+An error is **permanent** if its outcome depends only on the **message bytes
+and the code**. It is **transient** if it depends on the **state of the world**,
+because that state can differ on the next delivery.
+
+Everything below follows from that one question. When a case is not listed,
+ask it rather than pattern-matching on a similar-looking entry.
+
+### Permanent — Ack-drop
+
+| Class | Examples | Construct with |
+|---|---|---|
+| Serialization out | `Marshal` of a fixed struct | `errcode.MarshalFailed("<what>", err)` |
+| Serialization in | Unmarshal/decode of the inbound envelope or payload | `Permanent(BadRequest("unmarshal X", WithCause(err)))` |
+| Round-trip of our own bytes | `bson.Unmarshal` of this function's own `bson.Marshal` output | `Permanent(Internal(…, WithCause(err)))` |
+| Payload validation | Missing required field, unknown event type, malformed subject, invalid ID format | `Permanent(BadRequest("…"))` |
+| Oversized publish | `nats.ErrMaxPayload` — rejected client-side before the wire (`nats.go:4345`) | `Permanent(Internal("… exceeds broker max_payload"))` |
+| Remote terminal reply | `not_found`, `forbidden`, `bad_request`, `conflict` from an RPC — a fact about *this* message | `errcode.Terminal` → `Permanent(ee)` |
+| Backend rejected the document | Elasticsearch bulk item `400` | `searchengine.IsBulkItemPermanent` |
+
+Attaching the decoder error via `WithCause` is right for `encoding/json`, whose
+errors name the offending character and Go type/field names. It is **not** safe
+for `sonic`, which embeds a window of the input — see §2's cause rules.
+
+### Transient — Nak with backoff
+
+| Class | Examples |
+|---|---|
+| Datastore unavailability | Timeouts, no reachable hosts, primary election/failover, write-concern failures |
+| Publish failures other than oversize | `ErrConnectionClosed`, `ErrConnectionDraining` (normal at shutdown), no stream response |
+| Remote non-terminal reply | `unavailable`, `internal`, `too_many_requests`, `unauthenticated` — `errcode.Terminal` excludes these deliberately |
+| Ordering races | A thread parent not yet persisted; `member_added` before the user replicates; subscription-state before `member_added` |
+| Backpressure | ES `429`, `es_rejected_execution`, `circuit_breaking` — pair with `jsretry.BackpressureBackoff` |
+| Key and secret fetches | Room-key store reads |
+
+`unauthenticated` is transient on purpose: a credential problem hits every
+message at once, so dropping is mass data loss rather than poison rejection.
+
+Bound a race that has a known short window rather than spending the whole
+budget on it — see `parentResolveExhausted` in broadcast-worker and
+notification-worker, which retries twice and then drops with a terminal metric.
+
+### Do not classify these
+
+| Case | Why not |
+|---|---|
+| Mongo duplicate key (`E11000`) | A domain signal, not a failure. Every site has its own right answer — swallow as idempotent, retry without upsert, or translate to a sentinel. A blanket "permanent" is wrong at all of them. |
+| Mongo cursor decode (`cursor.All`) | Fails from either a BSON decode error (deterministic) or a network error mid-cursor (transient), and the error does not distinguish them. Splitting needs `errors.As` on the driver type. |
+| `jetstream.ErrNoStreamResponse` | A destination stream that does not exist and a peer that is briefly unreachable produce the identical error. |
+| Best-effort paths | A handler that logs and continues has no ack decision to get wrong. Leave the bare error and say so in a comment. |
+
+### The asymmetry — why transient is the default
+
+The two mistakes do not cost the same:
+
+- **Wrong-transient** burns `MaxDeliver`, holds an ack-pending slot, then drops
+  silently. Wasteful, but bounded.
+- **Wrong-permanent** drops a message immediately that a retry would have
+  delivered. Unbounded data loss during any real outage.
+
+So a bare `fmt.Errorf` — transient — is the correct default to fail toward.
+Reach for `Permanent` when you can name the reason the outcome cannot change,
+not because a retry looks unlikely to help.
+
+### Where the decision lives
+
+At the **leaf**, where the error is first constructed. `%w` wrappers propagate
+permanence untouched, so a wrapper must not re-decide:
+
+```go
+// leaf — decides
+return errcode.Permanent(errcode.BadRequest("unmarshal member_added payload", errcode.WithCause(err)))
+
+// wrapper — propagates, decides nothing
+return fmt.Errorf("handle thread room and subscriptions: %w", err)
+```
+
+Before classifying a site, read its caller. An error that the caller discards
+is not a classification decision at all.
+
+### Lanes without a retry budget change the calculus
+
+`hr-sync-worker` and `outbox-worker`'s per-peer lanes run `MaxDeliver=-1` with
+`MaxAckPending=1`. There a non-resolving error never drops — it blocks the lane
+forever, and every later message behind it.
+
+Classification cannot rescue an unclassifiable error on such a lane. The policy
+is to keep blocking (losing an HR row or a federated event is worse than a
+stalled lane) and to **alert on the stall**, so a parked lane is distinguishable
+from a healthy idle one.
 
 ---
 

--- a/hr-sync-worker/handler.go
+++ b/hr-sync-worker/handler.go
@@ -23,7 +23,7 @@ func (h *Handler) HandleMessage(ctx context.Context, subj string, data []byte) e
 	case strings.HasSuffix(subj, ".employees.upsert"):
 		var employees []model.IEmployeeWithChange
 		if err := json.Unmarshal(data, &employees); err != nil {
-			return errcode.Permanent(errcode.BadRequest(fmt.Sprintf("malformed employees.upsert payload: %s", err.Error())))
+			return errcode.Permanent(errcode.BadRequest("malformed employees.upsert payload", errcode.WithCause(err)))
 		}
 		if len(employees) == 0 {
 			return nil
@@ -34,7 +34,7 @@ func (h *Handler) HandleMessage(ctx context.Context, subj string, data []byte) e
 	case strings.HasSuffix(subj, ".users.upsert"):
 		var users []model.IUserWithChange
 		if err := json.Unmarshal(data, &users); err != nil {
-			return errcode.Permanent(errcode.BadRequest(fmt.Sprintf("malformed users.upsert payload: %s", err.Error())))
+			return errcode.Permanent(errcode.BadRequest("malformed users.upsert payload", errcode.WithCause(err)))
 		}
 		if len(users) == 0 {
 			return nil
@@ -45,7 +45,7 @@ func (h *Handler) HandleMessage(ctx context.Context, subj string, data []byte) e
 	case strings.HasSuffix(subj, ".employees.quit"):
 		var batch model.IHRSyncEmployeeQuitBatch
 		if err := json.Unmarshal(data, &batch); err != nil {
-			return errcode.Permanent(errcode.BadRequest(fmt.Sprintf("malformed employees.quit payload: %s", err.Error())))
+			return errcode.Permanent(errcode.BadRequest("malformed employees.quit payload", errcode.WithCause(err)))
 		}
 		if len(batch.Accounts) == 0 {
 			return nil

--- a/hr-sync-worker/handler_test.go
+++ b/hr-sync-worker/handler_test.go
@@ -83,3 +83,31 @@ func TestHandleMessage_StoreErrorIsTransient(t *testing.T) {
 	var perm *errcode.PermanentError
 	assert.False(t, errors.As(err, &perm), "store failures must Nak-retry, not Ack-drop")
 }
+
+// The errcode message must be a fixed string, never derived from the parse
+// error: the decoder's text is attacker-shaped and unbounded, and this message
+// reaches the server log on every poison drop.
+func TestHandler_HandleMessage_MalformedPayload_MessageIsConstant(t *testing.T) {
+	for _, subj := range []string{
+		"chat.hr.site-a.employees.upsert",
+		"chat.hr.site-a.users.upsert",
+		"chat.hr.site-a.employees.quit",
+	} {
+		t.Run(subj, func(t *testing.T) {
+			h := NewHandler(NewMockStore(gomock.NewController(t)))
+
+			// Two payloads that fail differently: a bad literal names the offending
+			// character, a type mismatch names a Go struct field.
+			err1 := h.HandleMessage(context.Background(), subj, []byte(`[{"account":"a","x":SECRET}]`))
+			err2 := h.HandleMessage(context.Background(), subj, []byte(`"not-an-array-SECRET"`))
+
+			require.Error(t, err1)
+			require.Error(t, err2)
+			assert.Equal(t, err1.Error(), err2.Error(), "the message must not vary with the decoder's error")
+			assert.NotContains(t, err1.Error(), "SECRET")
+			assert.NotContains(t, err2.Error(), "SECRET")
+			_, perm := errcode.IsPermanent(err1)
+			assert.True(t, perm, "a malformed payload stays permanent")
+		})
+	}
+}

--- a/hr-sync-worker/main.go
+++ b/hr-sync-worker/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 	"time"
@@ -125,7 +124,7 @@ func startSiteConsumer(ctx context.Context, js o11ynats.JetStream, handler *Hand
 			data, err := natsutil.DecodePayload(msg)
 			if err != nil {
 				// a bad frame won't decode on redelivery → poison
-				jsretry.Settle(handlerCtx, msg, jsretry.DefaultBackoff, errcode.Permanent(errcode.BadRequest(fmt.Sprintf("decode payload: %s", err.Error()))))
+				jsretry.Settle(handlerCtx, msg, jsretry.DefaultBackoff, errcode.Permanent(errcode.BadRequest("decode payload", errcode.WithCause(err))))
 				return
 			}
 			jsretry.Settle(handlerCtx, msg, jsretry.DefaultBackoff, handler.HandleMessage(handlerCtx, msg.Subject(), data))

--- a/inbox-worker/handler.go
+++ b/inbox-worker/handler.go
@@ -219,7 +219,7 @@ func (h *Handler) HandleRoomActivity(ctx context.Context, data []byte) error {
 func (h *Handler) HandleEvent(ctx context.Context, data []byte) error {
 	var evt model.InboxEvent
 	if err := json.Unmarshal(data, &evt); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal inbox event"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal inbox event", errcode.WithCause(err)))
 	}
 
 	switch evt.Type {
@@ -276,7 +276,7 @@ func (h *Handler) HandleEvent(ctx context.Context, data []byte) error {
 func (h *Handler) handleMemberAdded(ctx context.Context, evt *model.InboxEvent) error {
 	var event model.MemberAddEvent
 	if err := json.Unmarshal(evt.Payload, &event); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal member_added payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal member_added payload", errcode.WithCause(err)))
 	}
 
 	roomType := event.RoomType
@@ -375,7 +375,7 @@ func (h *Handler) handleMemberAdded(ctx context.Context, evt *model.InboxEvent) 
 func (h *Handler) handleMemberJoinedAtRefreshed(ctx context.Context, evt *model.InboxEvent) error {
 	var event model.MemberAddEvent
 	if err := json.Unmarshal(evt.Payload, &event); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal member_joinedat_refreshed payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal member_joinedat_refreshed payload", errcode.WithCause(err)))
 	}
 	if len(event.Accounts) == 0 {
 		return nil
@@ -394,7 +394,7 @@ func (h *Handler) handleMemberJoinedAtRefreshed(ctx context.Context, evt *model.
 func (h *Handler) handleMemberRemoved(ctx context.Context, evt *model.InboxEvent) error {
 	var memberEvt model.MemberRemoveEvent
 	if err := json.Unmarshal(evt.Payload, &memberEvt); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal member removed payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal member removed payload", errcode.WithCause(err)))
 	}
 	if len(memberEvt.Accounts) == 0 {
 		return nil
@@ -436,7 +436,7 @@ func (h *Handler) handleMemberRemoved(ctx context.Context, evt *model.InboxEvent
 func (h *Handler) handleRoomSync(ctx context.Context, evt *model.InboxEvent) error {
 	var room model.Room
 	if err := json.Unmarshal(evt.Payload, &room); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal room_sync payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal room_sync payload", errcode.WithCause(err)))
 	}
 
 	if err := h.store.UpsertRoom(ctx, &room); err != nil {
@@ -452,7 +452,7 @@ func (h *Handler) handleRoomSync(ctx context.Context, evt *model.InboxEvent) err
 func (h *Handler) handleRoleUpdated(ctx context.Context, evt *model.InboxEvent) error {
 	var subEvt model.SubscriptionUpdateEvent
 	if err := json.Unmarshal(evt.Payload, &subEvt); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal role_updated payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal role_updated payload", errcode.WithCause(err)))
 	}
 	account := subEvt.Subscription.User.Account
 	roomID := subEvt.Subscription.RoomID
@@ -479,7 +479,7 @@ func (h *Handler) handleRoleUpdated(ctx context.Context, evt *model.InboxEvent) 
 func (h *Handler) handleSubscriptionRead(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.SubscriptionReadEvent
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal subscription_read payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal subscription_read payload", errcode.WithCause(err)))
 	}
 	lastSeenAt := time.UnixMilli(e.LastSeenAt).UTC()
 	applied, threadUnread, err := h.store.UpdateSubscriptionRead(ctx, e.RoomID, e.Account, lastSeenAt, e.Alert)
@@ -499,7 +499,7 @@ func (h *Handler) handleSubscriptionRead(ctx context.Context, evt *model.InboxEv
 func (h *Handler) handleSubscriptionMuteToggled(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.SubscriptionMuteToggledEvent
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal subscription_mute_toggled payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal subscription_mute_toggled payload", errcode.WithCause(err)))
 	}
 	if err := h.store.UpdateSubscriptionMute(ctx, e.RoomID, e.Account, e.Muted, time.UnixMilli(e.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("update subscription mute for %q in room %q: %w", e.Account, e.RoomID, err)
@@ -520,7 +520,7 @@ func (h *Handler) handleSubscriptionMuteToggled(ctx context.Context, evt *model.
 func (h *Handler) handleSubscriptionFavoriteToggled(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.SubscriptionFavoriteToggledEvent
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal subscription_favorite_toggled payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal subscription_favorite_toggled payload", errcode.WithCause(err)))
 	}
 	if err := h.store.UpdateSubscriptionFavorite(ctx, e.RoomID, e.Account, e.Favorite, time.UnixMilli(e.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("update subscription favorite for %q in room %q: %w", e.Account, e.RoomID, err)
@@ -532,7 +532,7 @@ func (h *Handler) handleSubscriptionFavoriteToggled(ctx context.Context, evt *mo
 func (h *Handler) handleSubscriptionOpened(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.SubscriptionOpenedEvent
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal subscription_opened payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal subscription_opened payload", errcode.WithCause(err)))
 	}
 	if err := h.store.UpdateSubscriptionOpen(ctx, e.RoomID, e.Account, e.Open); err != nil {
 		return fmt.Errorf("update subscription open for %q in room %q: %w", e.Account, e.RoomID, err)
@@ -547,7 +547,7 @@ func (h *Handler) handleSubscriptionOpened(ctx context.Context, evt *model.Inbox
 func (h *Handler) handleThreadSubscriptionUpserted(ctx context.Context, evt *model.InboxEvent) error {
 	var sub model.ThreadSubscription
 	if err := json.Unmarshal(evt.Payload, &sub); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal thread_subscription_upserted payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal thread_subscription_upserted payload", errcode.WithCause(err)))
 	}
 	if err := h.store.UpsertThreadSubscription(ctx, &sub); err != nil {
 		return fmt.Errorf("upsert thread subscription (threadRoomID %q, userID %q): %w",
@@ -559,7 +559,7 @@ func (h *Handler) handleThreadSubscriptionUpserted(ctx context.Context, evt *mod
 func (h *Handler) handleThreadRead(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.ThreadReadEvent
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal thread_read payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal thread_read payload", errcode.WithCause(err)))
 	}
 	lastSeenAt := time.UnixMilli(e.LastSeenAt).UTC()
 	if err := h.store.ApplyThreadRead(ctx, e.RoomID, e.ThreadRoomID, e.Account, e.ParentMessageID, lastSeenAt); err != nil {
@@ -578,7 +578,7 @@ func (h *Handler) handleThreadRead(ctx context.Context, evt *model.InboxEvent) e
 func (h *Handler) handleThreadReadAll(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.ThreadReadAllEvent
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal thread_read_all payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal thread_read_all payload", errcode.WithCause(err)))
 	}
 	lastSeenAt := time.UnixMilli(e.LastSeenAt).UTC()
 	if err := h.store.ApplyThreadReadAll(ctx, e.Account, lastSeenAt); err != nil {
@@ -596,7 +596,7 @@ func (h *Handler) handleThreadReadAll(ctx context.Context, evt *model.InboxEvent
 func (h *Handler) handleThreadUnreadAdded(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.ThreadUnreadAddedEvent
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal thread_unread_added payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal thread_unread_added payload", errcode.WithCause(err)))
 	}
 	if err := h.store.AddThreadUnread(ctx, e.RoomID, e.ParentMessageID, e.Accounts); err != nil {
 		return fmt.Errorf("add thread unread %q in room %q: %w", e.ParentMessageID, e.RoomID, err)
@@ -610,7 +610,7 @@ func (h *Handler) handleThreadUnreadAdded(ctx context.Context, evt *model.InboxE
 func (h *Handler) handleSubscriptionMention(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.SubscriptionMentionEvent
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal subscription_mention payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal subscription_mention payload", errcode.WithCause(err)))
 	}
 	// Poison payload: a blank room matches nothing, an empty account list has no
 	// destination, and a zero mentionedAt badges as 1970 — which makes the read
@@ -630,7 +630,7 @@ func (h *Handler) handleSubscriptionMention(ctx context.Context, evt *model.Inbo
 func (h *Handler) handleRoomRenamed(ctx context.Context, evt *model.InboxEvent) error {
 	var p model.RoomRenamedInboxPayload
 	if err := json.Unmarshal(evt.Payload, &p); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal room_renamed payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal room_renamed payload", errcode.WithCause(err)))
 	}
 	if err := h.store.UpdateSubscriptionNamesForRoom(ctx, p.RoomID, p.NewName, time.UnixMilli(p.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("update subscription names for room %s: %w", p.RoomID, err)
@@ -641,7 +641,7 @@ func (h *Handler) handleRoomRenamed(ctx context.Context, evt *model.InboxEvent) 
 func (h *Handler) handleRoomVisibilityChanged(ctx context.Context, evt *model.InboxEvent) error {
 	var p model.RoomRestrictedInboxPayload
 	if err := json.Unmarshal(evt.Payload, &p); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal room_restricted payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal room_restricted payload", errcode.WithCause(err)))
 	}
 	if err := h.store.ApplySubscriptionRestriction(ctx, p.RoomID, p.Restricted, p.ExternalAccess, p.OwnerAccount, time.UnixMilli(p.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("apply subscription visibility for room %s: %w", p.RoomID, err)
@@ -671,7 +671,7 @@ func (h *Handler) handleRoomVisibilityChanged(ctx context.Context, evt *model.In
 func (h *Handler) handleUserStatusUpdated(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.UserStatusUpdated
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal user_status_updated payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal user_status_updated payload", errcode.WithCause(err)))
 	}
 	if err := h.store.UpdateUserStatus(ctx, e.Account, e.StatusText, e.StatusIsShow, time.UnixMilli(e.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("update user status for %q: %w", e.Account, err)
@@ -684,7 +684,7 @@ func (h *Handler) handleUserStatusUpdated(ctx context.Context, evt *model.InboxE
 func (h *Handler) handleUserSettingsUpdated(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.UserSettingsUpdated
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal user_settings_updated payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal user_settings_updated payload", errcode.WithCause(err)))
 	}
 	if err := h.store.UpdateUserSettings(ctx, e.Account, &e.Settings, time.UnixMilli(e.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("update user settings for %q: %w", e.Account, err)
@@ -697,7 +697,7 @@ func (h *Handler) handleUserSettingsUpdated(ctx context.Context, evt *model.Inbo
 func (h *Handler) handleUserPermissionsUpdated(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.UserPermissionsUpdated
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal user_permissions_updated payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal user_permissions_updated payload", errcode.WithCause(err)))
 	}
 	if _, ok := model.PermissionFieldName(e.Permission); !ok {
 		// A future permission key reaching a not-yet-upgraded site: retrying cannot
@@ -716,7 +716,7 @@ func (h *Handler) handleUserPermissionsUpdated(ctx context.Context, evt *model.I
 func (h *Handler) handleUserChatlistUpdated(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.UserChatlistUpdated
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal user_chatlist_updated payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal user_chatlist_updated payload", errcode.WithCause(err)))
 	}
 	if err := h.store.UpdateUserChatlist(ctx, e.Account, &e.Chatlist, e.Timestamp); err != nil {
 		return fmt.Errorf("update user chatlist for %q: %w", e.Account, err)
@@ -729,7 +729,7 @@ func (h *Handler) handleUserChatlistUpdated(ctx context.Context, evt *model.Inbo
 func (h *Handler) handleUserAccountUpdated(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.UserAccountUpdated
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal user_account_updated payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal user_account_updated payload", errcode.WithCause(err)))
 	}
 	if err := h.store.UpsertUserAccount(ctx, &e, time.UnixMilli(e.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("upsert user account for %q: %w", e.Account, err)
@@ -742,7 +742,7 @@ func (h *Handler) handleUserAccountUpdated(ctx context.Context, evt *model.Inbox
 func (h *Handler) handleSubscriptionSectionMoved(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.SubscriptionSectionMovedEvent
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return errcode.Permanent(errcode.BadRequest("unmarshal subscription_section_moved payload"))
+		return errcode.Permanent(errcode.BadRequest("unmarshal subscription_section_moved payload", errcode.WithCause(err)))
 	}
 	if err := h.store.UpdateSubscriptionSection(ctx, e.RoomID, e.Account, e.SectionID, e.SectionOrder, time.UnixMilli(e.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("update subscription section for %q in room %q: %w", e.Account, e.RoomID, err)

--- a/inbox-worker/handler.go
+++ b/inbox-worker/handler.go
@@ -219,7 +219,7 @@ func (h *Handler) HandleRoomActivity(ctx context.Context, data []byte) error {
 func (h *Handler) HandleEvent(ctx context.Context, data []byte) error {
 	var evt model.InboxEvent
 	if err := json.Unmarshal(data, &evt); err != nil {
-		return fmt.Errorf("unmarshal inbox event: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal inbox event"))
 	}
 
 	switch evt.Type {
@@ -276,7 +276,7 @@ func (h *Handler) HandleEvent(ctx context.Context, data []byte) error {
 func (h *Handler) handleMemberAdded(ctx context.Context, evt *model.InboxEvent) error {
 	var event model.MemberAddEvent
 	if err := json.Unmarshal(evt.Payload, &event); err != nil {
-		return fmt.Errorf("unmarshal member_added payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal member_added payload"))
 	}
 
 	roomType := event.RoomType
@@ -375,7 +375,7 @@ func (h *Handler) handleMemberAdded(ctx context.Context, evt *model.InboxEvent) 
 func (h *Handler) handleMemberJoinedAtRefreshed(ctx context.Context, evt *model.InboxEvent) error {
 	var event model.MemberAddEvent
 	if err := json.Unmarshal(evt.Payload, &event); err != nil {
-		return fmt.Errorf("unmarshal member_joinedat_refreshed payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal member_joinedat_refreshed payload"))
 	}
 	if len(event.Accounts) == 0 {
 		return nil
@@ -394,7 +394,7 @@ func (h *Handler) handleMemberJoinedAtRefreshed(ctx context.Context, evt *model.
 func (h *Handler) handleMemberRemoved(ctx context.Context, evt *model.InboxEvent) error {
 	var memberEvt model.MemberRemoveEvent
 	if err := json.Unmarshal(evt.Payload, &memberEvt); err != nil {
-		return fmt.Errorf("unmarshal member removed payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal member removed payload"))
 	}
 	if len(memberEvt.Accounts) == 0 {
 		return nil
@@ -436,7 +436,7 @@ func (h *Handler) handleMemberRemoved(ctx context.Context, evt *model.InboxEvent
 func (h *Handler) handleRoomSync(ctx context.Context, evt *model.InboxEvent) error {
 	var room model.Room
 	if err := json.Unmarshal(evt.Payload, &room); err != nil {
-		return fmt.Errorf("unmarshal room_sync payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal room_sync payload"))
 	}
 
 	if err := h.store.UpsertRoom(ctx, &room); err != nil {
@@ -452,7 +452,7 @@ func (h *Handler) handleRoomSync(ctx context.Context, evt *model.InboxEvent) err
 func (h *Handler) handleRoleUpdated(ctx context.Context, evt *model.InboxEvent) error {
 	var subEvt model.SubscriptionUpdateEvent
 	if err := json.Unmarshal(evt.Payload, &subEvt); err != nil {
-		return fmt.Errorf("unmarshal role_updated payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal role_updated payload"))
 	}
 	account := subEvt.Subscription.User.Account
 	roomID := subEvt.Subscription.RoomID
@@ -479,7 +479,7 @@ func (h *Handler) handleRoleUpdated(ctx context.Context, evt *model.InboxEvent) 
 func (h *Handler) handleSubscriptionRead(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.SubscriptionReadEvent
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return fmt.Errorf("unmarshal subscription_read payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal subscription_read payload"))
 	}
 	lastSeenAt := time.UnixMilli(e.LastSeenAt).UTC()
 	applied, threadUnread, err := h.store.UpdateSubscriptionRead(ctx, e.RoomID, e.Account, lastSeenAt, e.Alert)
@@ -499,7 +499,7 @@ func (h *Handler) handleSubscriptionRead(ctx context.Context, evt *model.InboxEv
 func (h *Handler) handleSubscriptionMuteToggled(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.SubscriptionMuteToggledEvent
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return fmt.Errorf("unmarshal subscription_mute_toggled payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal subscription_mute_toggled payload"))
 	}
 	if err := h.store.UpdateSubscriptionMute(ctx, e.RoomID, e.Account, e.Muted, time.UnixMilli(e.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("update subscription mute for %q in room %q: %w", e.Account, e.RoomID, err)
@@ -520,7 +520,7 @@ func (h *Handler) handleSubscriptionMuteToggled(ctx context.Context, evt *model.
 func (h *Handler) handleSubscriptionFavoriteToggled(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.SubscriptionFavoriteToggledEvent
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return fmt.Errorf("unmarshal subscription_favorite_toggled payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal subscription_favorite_toggled payload"))
 	}
 	if err := h.store.UpdateSubscriptionFavorite(ctx, e.RoomID, e.Account, e.Favorite, time.UnixMilli(e.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("update subscription favorite for %q in room %q: %w", e.Account, e.RoomID, err)
@@ -532,7 +532,7 @@ func (h *Handler) handleSubscriptionFavoriteToggled(ctx context.Context, evt *mo
 func (h *Handler) handleSubscriptionOpened(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.SubscriptionOpenedEvent
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return fmt.Errorf("unmarshal subscription_opened payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal subscription_opened payload"))
 	}
 	if err := h.store.UpdateSubscriptionOpen(ctx, e.RoomID, e.Account, e.Open); err != nil {
 		return fmt.Errorf("update subscription open for %q in room %q: %w", e.Account, e.RoomID, err)
@@ -547,7 +547,7 @@ func (h *Handler) handleSubscriptionOpened(ctx context.Context, evt *model.Inbox
 func (h *Handler) handleThreadSubscriptionUpserted(ctx context.Context, evt *model.InboxEvent) error {
 	var sub model.ThreadSubscription
 	if err := json.Unmarshal(evt.Payload, &sub); err != nil {
-		return fmt.Errorf("unmarshal thread_subscription_upserted payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal thread_subscription_upserted payload"))
 	}
 	if err := h.store.UpsertThreadSubscription(ctx, &sub); err != nil {
 		return fmt.Errorf("upsert thread subscription (threadRoomID %q, userID %q): %w",
@@ -559,7 +559,7 @@ func (h *Handler) handleThreadSubscriptionUpserted(ctx context.Context, evt *mod
 func (h *Handler) handleThreadRead(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.ThreadReadEvent
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return fmt.Errorf("unmarshal thread_read payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal thread_read payload"))
 	}
 	lastSeenAt := time.UnixMilli(e.LastSeenAt).UTC()
 	if err := h.store.ApplyThreadRead(ctx, e.RoomID, e.ThreadRoomID, e.Account, e.ParentMessageID, lastSeenAt); err != nil {
@@ -578,7 +578,7 @@ func (h *Handler) handleThreadRead(ctx context.Context, evt *model.InboxEvent) e
 func (h *Handler) handleThreadReadAll(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.ThreadReadAllEvent
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return fmt.Errorf("unmarshal thread_read_all payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal thread_read_all payload"))
 	}
 	lastSeenAt := time.UnixMilli(e.LastSeenAt).UTC()
 	if err := h.store.ApplyThreadReadAll(ctx, e.Account, lastSeenAt); err != nil {
@@ -596,7 +596,7 @@ func (h *Handler) handleThreadReadAll(ctx context.Context, evt *model.InboxEvent
 func (h *Handler) handleThreadUnreadAdded(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.ThreadUnreadAddedEvent
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return fmt.Errorf("unmarshal thread_unread_added payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal thread_unread_added payload"))
 	}
 	if err := h.store.AddThreadUnread(ctx, e.RoomID, e.ParentMessageID, e.Accounts); err != nil {
 		return fmt.Errorf("add thread unread %q in room %q: %w", e.ParentMessageID, e.RoomID, err)
@@ -671,7 +671,7 @@ func (h *Handler) handleRoomVisibilityChanged(ctx context.Context, evt *model.In
 func (h *Handler) handleUserStatusUpdated(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.UserStatusUpdated
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return fmt.Errorf("unmarshal user_status_updated payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal user_status_updated payload"))
 	}
 	if err := h.store.UpdateUserStatus(ctx, e.Account, e.StatusText, e.StatusIsShow, time.UnixMilli(e.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("update user status for %q: %w", e.Account, err)
@@ -684,7 +684,7 @@ func (h *Handler) handleUserStatusUpdated(ctx context.Context, evt *model.InboxE
 func (h *Handler) handleUserSettingsUpdated(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.UserSettingsUpdated
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return fmt.Errorf("unmarshal user_settings_updated payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal user_settings_updated payload"))
 	}
 	if err := h.store.UpdateUserSettings(ctx, e.Account, &e.Settings, time.UnixMilli(e.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("update user settings for %q: %w", e.Account, err)
@@ -697,7 +697,7 @@ func (h *Handler) handleUserSettingsUpdated(ctx context.Context, evt *model.Inbo
 func (h *Handler) handleUserPermissionsUpdated(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.UserPermissionsUpdated
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return fmt.Errorf("unmarshal user_permissions_updated payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal user_permissions_updated payload"))
 	}
 	if _, ok := model.PermissionFieldName(e.Permission); !ok {
 		// A future permission key reaching a not-yet-upgraded site: retrying cannot
@@ -716,7 +716,7 @@ func (h *Handler) handleUserPermissionsUpdated(ctx context.Context, evt *model.I
 func (h *Handler) handleUserChatlistUpdated(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.UserChatlistUpdated
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return fmt.Errorf("unmarshal user_chatlist_updated payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal user_chatlist_updated payload"))
 	}
 	if err := h.store.UpdateUserChatlist(ctx, e.Account, &e.Chatlist, e.Timestamp); err != nil {
 		return fmt.Errorf("update user chatlist for %q: %w", e.Account, err)
@@ -729,7 +729,7 @@ func (h *Handler) handleUserChatlistUpdated(ctx context.Context, evt *model.Inbo
 func (h *Handler) handleUserAccountUpdated(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.UserAccountUpdated
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return fmt.Errorf("unmarshal user_account_updated payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal user_account_updated payload"))
 	}
 	if err := h.store.UpsertUserAccount(ctx, &e, time.UnixMilli(e.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("upsert user account for %q: %w", e.Account, err)
@@ -742,7 +742,7 @@ func (h *Handler) handleUserAccountUpdated(ctx context.Context, evt *model.Inbox
 func (h *Handler) handleSubscriptionSectionMoved(ctx context.Context, evt *model.InboxEvent) error {
 	var e model.SubscriptionSectionMovedEvent
 	if err := json.Unmarshal(evt.Payload, &e); err != nil {
-		return fmt.Errorf("unmarshal subscription_section_moved payload: %w", err)
+		return errcode.Permanent(errcode.BadRequest("unmarshal subscription_section_moved payload"))
 	}
 	if err := h.store.UpdateSubscriptionSection(ctx, e.RoomID, e.Account, e.SectionID, e.SectionOrder, time.UnixMilli(e.Timestamp).UTC()); err != nil {
 		return fmt.Errorf("update subscription section for %q in room %q: %w", e.Account, e.RoomID, err)

--- a/inbox-worker/handler_test.go
+++ b/inbox-worker/handler_test.go
@@ -3424,3 +3424,60 @@ func TestSubscriptionRowType(t *testing.T) {
 		})
 	}
 }
+
+// A payload that cannot be parsed cannot be parsed on redelivery either, so every
+// event type must return a permanent error: jsretry Ack-drops the poison instead
+// of holding an ack-pending slot for the full MaxDeliver budget and then dropping
+// it silently anyway.
+func TestHandler_HandleEvent_MalformedPayload_IsPermanent(t *testing.T) {
+	for _, eventType := range []model.InboxEventType{
+		model.InboxMemberAdded,
+		model.InboxMemberRemoved,
+		model.InboxMemberJoinedAtRefreshed,
+		"room_sync", // no model constant; the dispatch switch uses the literal
+		model.InboxRoleUpdated,
+		model.InboxSubscriptionRead,
+		model.InboxSubscriptionMuteToggled,
+		model.InboxSubscriptionFavoriteToggled,
+		model.InboxSubscriptionOpened,
+		model.InboxThreadSubscriptionUpserted,
+		model.InboxThreadRead,
+		model.InboxThreadReadAll,
+		model.InboxThreadUnreadAdded,
+		model.InboxRoomRenamed,
+		model.InboxRoomRestricted,
+		model.InboxUserStatusUpdated,
+		model.InboxUserSettingsUpdated,
+		model.InboxUserPermissionsUpdated,
+		model.InboxUserChatlistUpdated,
+		model.InboxUserAccountUpdated,
+		model.InboxSubscriptionSectionMoved,
+		model.InboxSubscriptionMention,
+	} {
+		t.Run(eventType, func(t *testing.T) {
+			h := NewHandler(&stubInboxStore{})
+			evt := model.InboxEvent{Type: eventType, SiteID: "site-a", DestSiteID: "site-b", Payload: []byte("not-json")}
+			data, err := json.Marshal(evt)
+			require.NoError(t, err)
+
+			err = h.HandleEvent(context.Background(), data)
+
+			require.Error(t, err)
+			ec, perm := errcode.IsPermanent(err)
+			require.True(t, perm, "a malformed %s payload must Ack-drop, not retry to MaxDeliver", eventType)
+			assert.Equal(t, errcode.CodeBadRequest, ec.Code)
+		})
+	}
+}
+
+// The envelope itself is poison on the same argument as its payload.
+func TestHandler_HandleEvent_MalformedEnvelope_IsPermanent(t *testing.T) {
+	h := NewHandler(&stubInboxStore{})
+
+	err := h.HandleEvent(context.Background(), []byte("{not json"))
+
+	require.Error(t, err)
+	ec, perm := errcode.IsPermanent(err)
+	require.True(t, perm, "an unparseable inbox envelope must Ack-drop")
+	assert.Equal(t, errcode.CodeBadRequest, ec.Code)
+}

--- a/inbox-worker/handler_test.go
+++ b/inbox-worker/handler_test.go
@@ -3466,6 +3466,7 @@ func TestHandler_HandleEvent_MalformedPayload_IsPermanent(t *testing.T) {
 			ec, perm := errcode.IsPermanent(err)
 			require.True(t, perm, "a malformed %s payload must Ack-drop, not retry to MaxDeliver", eventType)
 			assert.Equal(t, errcode.CodeBadRequest, ec.Code)
+			assert.NotNil(t, errors.Unwrap(ec), "the decoder error must ride as the cause for the server-side log")
 		})
 	}
 }

--- a/message-gatekeeper/fetcher_history.go
+++ b/message-gatekeeper/fetcher_history.go
@@ -74,7 +74,7 @@ func (f *historyParentFetcher) FetchQuotedParent(
 ) (*cassandra.QuotedParentMessage, error) {
 	reqBytes, err := sonic.Marshal(getMessageByIDRequest{MessageID: messageID})
 	if err != nil {
-		return nil, fmt.Errorf("marshal GetMessageByID request: %w", err)
+		return nil, errcode.MarshalFailed("GetMessageByID request", err)
 	}
 
 	subj := subject.MsgGet(account, roomID, siteID)

--- a/message-gatekeeper/handler.go
+++ b/message-gatekeeper/handler.go
@@ -517,7 +517,7 @@ func (h *Handler) processMessage(ctx context.Context, account, roomID, siteID st
 	evt := model.MessageEvent{Event: model.EventCreated, Message: msg, SiteID: siteID, Timestamp: now.UnixMilli(), QuotedParentUnverified: quotedUnverified, ThreadParentSenderAccount: threadParentSenderAccount}
 	evtData, err := sonic.Marshal(evt)
 	if err != nil {
-		return nil, fmt.Errorf("marshal message event: %w", err)
+		return nil, errcode.MarshalFailed("message event", err)
 	}
 
 	canonicalSubj := subject.MsgCanonicalCreated(siteID)
@@ -529,7 +529,11 @@ func (h *Handler) processMessage(ctx context.Context, account, roomID, siteID st
 	slog.Log(ctx, logctx.LevelFlow, "gatekeeper published to canonical",
 		"phase", "published", "request_id", req.RequestID, "subject", canonicalSubj, "bytes", len(evtData))
 
-	return sonic.Marshal(msg)
+	replyData, err := sonic.Marshal(msg)
+	if err != nil {
+		return nil, errcode.MarshalFailed("send message reply", err)
+	}
+	return replyData, nil
 }
 
 // resolveThreadParent resolves the thread parent's createdAt and sender account

--- a/message-gatekeeper/handler.go
+++ b/message-gatekeeper/handler.go
@@ -523,6 +523,13 @@ func (h *Handler) processMessage(ctx context.Context, account, roomID, siteID st
 	canonicalSubj := subject.MsgCanonicalCreated(siteID)
 	canonicalMsg := natsutil.NewMsg(ctx, canonicalSubj, evtData)
 	if _, err := h.publish(ctx, canonicalMsg, jetstream.WithMsgID(natsutil.CanonicalDedupID(&evt))); err != nil {
+		if errors.Is(err, nats.ErrMaxPayload) {
+			// Rejected client-side before the wire. The caps this handler enforces
+			// (content, attachments) are meant to keep a message under max_payload,
+			// so reaching this is a misconfiguration, not a client error — but the
+			// message can never be published, so reply and drop rather than retry.
+			return nil, errcode.Permanent(errcode.Internal("canonical message exceeds broker max_payload"))
+		}
 		return nil, fmt.Errorf("publish to MESSAGES-CANONICAL: %w", errors.Join(errCanonicalPublish, err))
 	}
 	// flow: the message cleared the gate and was handed off to MESSAGES-CANONICAL.

--- a/message-gatekeeper/handler.go
+++ b/message-gatekeeper/handler.go
@@ -195,12 +195,25 @@ func (h *Handler) HandleJetStreamMsg(ctx context.Context, msg jetstream.Msg) {
 	// account — so decode here. No-op for every non-bot account.
 	replyData, err := h.processMessage(ctx, requester, roomID, siteID, &req)
 	if err != nil {
-		// Typed *errcode.Error → client-facing validation/permanence: reply + Ack.
+		// Permanent → server-side fault that cannot succeed on redelivery: reply + Ack, counted failed.
+		// Typed *errcode.Error → client-facing validation: reply + Ack, counted rejected.
 		// Bare error (raw fmt.Errorf) → transient infra failure: Nak for redelivery.
 		// errnats.Marshal runs Classify which logs once at category-aware level —
-		// validation branch must NOT also log here. Infra branch owns its log.
+		// the two Ack branches must NOT also log here. Infra branch owns its log.
 		var ee *errcode.Error
-		if errors.As(err, &ee) {
+		if pe, isPermanent := errcode.IsPermanent(err); isPermanent {
+			// A permanent server-side fault (a value that cannot be marshaled) is
+			// undeliverable work, not a client rejection: Ack, because redelivering
+			// identical bytes can only fail identically, but count it as failed so
+			// the rejected series stays a pure client-error signal.
+			natsmetrics.MarkTerminalFromContext(ctx, natsmetrics.TerminalPermanent)
+			h.metrics.Record(ctx, resultFailed, reasonInternal)
+			debugFlowRejected(ctx, req.RequestID, string(pe.Code))
+			h.sendReply(ctx, account, &req, errnats.Marshal(ctx, err))
+			if ackErr := msg.Ack(); ackErr != nil {
+				slog.ErrorContext(ctx, "failed to ack permanent message", "error", ackErr, "request_id", req.RequestID)
+			}
+		} else if errors.As(err, &ee) {
 			// A validation or policy rejection is an ordinary client error, not
 			// undeliverable work: the sender receives an error reply and the
 			// rejection is already counted by message_gatekeeper_messages_total.

--- a/message-gatekeeper/nats_metrics.go
+++ b/message-gatekeeper/nats_metrics.go
@@ -31,12 +31,15 @@ const (
 	reasonRoomRestricted   gatekeeperReasonCode = "room_restricted"
 	reasonCanonicalPublish gatekeeperReasonCode = "canonical_publish"
 	reasonDependency       gatekeeperReasonCode = "dependency"
-	reasonUnknown          gatekeeperReasonCode = "unknown"
+	// reasonInternal is a permanent server-side fault (a value that cannot be
+	// marshaled): undeliverable work, never a client rejection.
+	reasonInternal gatekeeperReasonCode = "internal"
+	reasonUnknown  gatekeeperReasonCode = "unknown"
 )
 
 var allGatekeeperReasons = []gatekeeperReasonCode{
 	reasonNone, reasonInvalidSubject, reasonInvalidPayload, reasonNotSubscribed,
-	reasonRoomRestricted, reasonCanonicalPublish, reasonDependency, reasonUnknown,
+	reasonRoomRestricted, reasonCanonicalPublish, reasonDependency, reasonInternal, reasonUnknown,
 }
 
 type gatekeeperMetrics struct {

--- a/message-gatekeeper/nats_metrics_test.go
+++ b/message-gatekeeper/nats_metrics_test.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.uber.org/mock/gomock"
 
+	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/idgen"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/natsmetrics"
@@ -133,4 +134,34 @@ func TestHandler_HandleJetStreamMsg_RecordsAcceptedAndRetryOutcomes(t *testing.T
 func TestGatekeeperMetrics_Record_NilReceiverIsSafe(t *testing.T) {
 	var metrics *gatekeeperMetrics
 	metrics.Record(context.Background(), resultAccepted, reasonNone)
+}
+
+// A permanent server-side fault (e.g. a value that cannot be marshaled) is
+// undeliverable work, not a client rejection: it must Ack — retrying can never
+// succeed — but count as failed/internal so the rejection series stays a pure
+// signal of client errors.
+func TestHandler_HandleJetStreamMsg_PermanentFault_RecordsFailedNotRejected(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	metrics := newGatekeeperMetrics(mp.Meter("test"))
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	store.EXPECT().GetSubscription(gomock.Any(), "alice", "room-1").
+		Return(nil, errcode.MarshalFailed("message event", errors.New("json: unsupported value: NaN")))
+
+	h := NewHandler(store, nil, nil, func(context.Context, *nats.Msg) error { return nil },
+		"site-a", nil, 500, 1, 8192, "", withGatekeeperMetrics(metrics))
+	request := model.SendMessageRequest{
+		ID: idgen.GenerateMessageID(), Content: "hello",
+		RequestID: "01970a4f-8c2d-7c9a-abcd-e0123456789f",
+	}
+	data, err := json.Marshal(request)
+	require.NoError(t, err)
+	msg := &fakeJSMsg{subject: "chat.user.alice.room.room-1.site-a.msg.send", data: data}
+
+	h.HandleJetStreamMsg(context.Background(), msg)
+
+	assert.True(t, msg.acked, "a permanent fault can never succeed on redelivery — Ack-drop it")
+	assert.False(t, msg.naked)
+	assert.Equal(t, map[string]int64{"failed/internal": 1}, gatekeeperCounts(t, reader))
 }

--- a/message-gatekeeper/nats_metrics_test.go
+++ b/message-gatekeeper/nats_metrics_test.go
@@ -165,3 +165,33 @@ func TestHandler_HandleJetStreamMsg_PermanentFault_RecordsFailedNotRejected(t *t
 	assert.False(t, msg.naked)
 	assert.Equal(t, map[string]int64{"failed/internal": 1}, gatekeeperCounts(t, reader))
 }
+
+// A canonical publish rejected for exceeding max_payload fails identically on
+// every redelivery: Ack-drop it (with a reply) instead of Nakking to MaxDeliver.
+func TestHandler_HandleJetStreamMsg_OversizedCanonicalPublish_IsPermanent(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	metrics := newGatekeeperMetrics(mp.Meter("test"))
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	store.EXPECT().GetSubscription(gomock.Any(), "weather.bot", "room-1").Return(&model.Subscription{
+		User:  model.SubscriptionUser{ID: "u-bot", Account: "weather.bot"},
+		Roles: []model.Role{model.RoleMember},
+	}, nil)
+	h := NewHandler(store, nil, makePublishFunc(nil, nats.ErrMaxPayload),
+		func(context.Context, *nats.Msg) error { return nil }, "site-a", nil, 500, 1, 8192, "",
+		withGatekeeperMetrics(metrics))
+	request := model.SendMessageRequest{
+		ID: idgen.GenerateMessageID(), Content: "hello",
+		RequestID: "01970a4f-8c2d-7c9a-abcd-e0123456789f",
+	}
+	data, err := json.Marshal(request)
+	require.NoError(t, err)
+	msg := &fakeJSMsg{subject: "chat.user.weather_bot.room.room-1.site-a.msg.send", data: data}
+
+	h.HandleJetStreamMsg(context.Background(), msg)
+
+	assert.True(t, msg.acked, "an oversized message can never be published — Ack-drop it")
+	assert.False(t, msg.naked)
+	assert.Equal(t, map[string]int64{"failed/internal": 1}, gatekeeperCounts(t, reader))
+}

--- a/message-worker/handler.go
+++ b/message-worker/handler.go
@@ -753,7 +753,7 @@ func (h *Handler) fanOutThreadUnread(ctx context.Context, roomID, parentMessageI
 			RoomID: roomID, ParentMessageID: parentMessageID, Accounts: accs, Timestamp: now,
 		})
 		if err != nil {
-			return fmt.Errorf("marshal thread_unread_added: %w", err)
+			return errcode.MarshalFailed("thread_unread_added event", err)
 		}
 		dedupID := fmt.Sprintf("thread-unread:%s:%s:%s", parentMessageID, msgID, site)
 		if err := outbox.Publish(ctx, h.publish, h.siteID, roomID, site, model.InboxThreadUnreadAdded, payload, dedupID, now); err != nil {
@@ -785,7 +785,7 @@ func (h *Handler) publishThreadSubInboxIfRemote(ctx context.Context, sub *model.
 
 	payload, err := sonic.Marshal(sub)
 	if err != nil {
-		return fmt.Errorf("marshal thread subscription: %w", err)
+		return errcode.MarshalFailed("thread subscription", err)
 	}
 	// Dedup-ID seed (threadRoomID + userID + msg.ID + hasMention + destSiteID):
 	// msg.ID is stable across MESSAGES-CANONICAL redeliveries so the same publish
@@ -822,7 +822,7 @@ func (h *Handler) publishThreadReplyEvent(ctx context.Context, msg *model.Messag
 	}
 	data, err := sonic.Marshal(evt)
 	if err != nil {
-		return fmt.Errorf("marshal thread reply event: %w", err)
+		return errcode.MarshalFailed("thread reply event", err)
 	}
 	return h.publish(ctx, subject.ServerBroadcastThreadTCount(h.siteID), data, "")
 }

--- a/message-worker/main.go
+++ b/message-worker/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hmchangw/chat/pkg/atrest"
 	"github.com/hmchangw/chat/pkg/cassutil"
 	"github.com/hmchangw/chat/pkg/circuitbreaker"
+	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/health"
 	"github.com/hmchangw/chat/pkg/jobguard"
 	"github.com/hmchangw/chat/pkg/jsretry"
@@ -265,7 +266,7 @@ func main() {
 		func(ctx context.Context, users []model.IUserWithChange) error {
 			data, err := json.Marshal(users)
 			if err != nil {
-				return fmt.Errorf("marshal user identity fanout: %w", err)
+				return errcode.MarshalFailed("user identity fanout", err)
 			}
 			_, err = js.PublishMsg(ctx, natsutil.NewMsg(ctx, subject.OrgSyncUsersUpsert(cfg.SiteID), data))
 			publishMetrics.Failure(ctx, natsmetrics.DestinationUserSync, natsmetrics.OperationTeamsUserUpsert, err)

--- a/notification-worker/badge_client.go
+++ b/notification-worker/badge_client.go
@@ -40,6 +40,9 @@ func newNatsBadgeClient(nc *o11ynats.Conn) *natsBadgeClient {
 // responder, remote errcode envelope, unmarshal) is wrapped and returned so the caller
 // can decide how to degrade — the badge phase must never NAK the push on its behalf.
 func (c *natsBadgeClient) Counts(ctx context.Context, siteID, roomID string, accounts []string) (map[string]int, error) {
+	// fetchUnreadCounts is fail-open and discards this error, so it never reaches
+	// a settle decision.
+	// nosemgrep: jsretry-marshal-failure-must-be-permanent
 	reqBytes, err := sonic.Marshal(model.BadgeCountBatchRequest{RoomID: roomID, Accounts: accounts})
 	if err != nil {
 		return nil, fmt.Errorf("marshal badge count batch request for site %s: %w", siteID, err)

--- a/notification-worker/emit.go
+++ b/notification-worker/emit.go
@@ -41,7 +41,7 @@ func newMobileEmitter(pub publisher, sendSubject string, maxPayloadBytes int) *m
 func (e *mobileEmitter) Emit(ctx context.Context, evt model.PushNotificationEvent) error { //nolint:gocritic // hugeParam: spec requires value semantics for Emitter interface
 	data, err := sonic.Marshal(evt)
 	if err != nil {
-		return fmt.Errorf("marshal push batch %s: %w", evt.ID, err)
+		return errcode.MarshalFailed("push batch", err)
 	}
 	if e.maxPayloadBytes > 0 && len(data) > e.maxPayloadBytes {
 		// Deterministic: the handler sorts survivors so batch N carries the same

--- a/notification-worker/parent_fetcher.go
+++ b/notification-worker/parent_fetcher.go
@@ -69,7 +69,7 @@ type parentMessageProjection struct {
 func (f *historyParentFetcher) FetchParent(ctx context.Context, account, roomID, siteID, messageID string) (*ParentMessageInfo, error) {
 	reqBytes, err := sonic.Marshal(getMessageByIDRequest{MessageID: messageID})
 	if err != nil {
-		return nil, fmt.Errorf("marshal GetMessageByID request: %w", err)
+		return nil, errcode.MarshalFailed("GetMessageByID request", err)
 	}
 	started := time.Now()
 	msg, err := f.nc.Request(ctx, subject.MsgGet(account, roomID, siteID), reqBytes, parentFetchTimeout)

--- a/outbox-worker/handler.go
+++ b/outbox-worker/handler.go
@@ -3,9 +3,12 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
+
+	"github.com/nats-io/nats.go"
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
@@ -57,6 +60,14 @@ func (h *Handler) HandleEvent(ctx context.Context, subj string, data []byte) err
 	pubCtx, cancel := context.WithTimeout(ctx, federationForwardTimeout)
 	defer cancel()
 	if err := h.publish(pubCtx, subject.InboxExternal(destSiteID, eventType), evt.Envelope, evt.DedupID); err != nil {
+		if errors.Is(err, nats.ErrMaxPayload) {
+			// Rejected client-side before the wire, so every redelivery fails the
+			// same way. This lane is MaxDeliver=-1 with MaxAckPending=1 per peer:
+			// a Nak would park every later event for that peer behind this one
+			// forever, so drop the single oversized event instead.
+			return errcode.Permanent(errcode.Internal(
+				fmt.Sprintf("outbox %s event for %s exceeds broker max_payload", eventType, destSiteID)))
+		}
 		return fmt.Errorf("forward outbox event to %s: %w", destSiteID, err)
 	}
 	return nil

--- a/outbox-worker/handler_test.go
+++ b/outbox-worker/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -91,4 +92,22 @@ func TestHandleEvent_SkipsEventMissingDedupID(t *testing.T) {
 	data, _ := outboxEvent(t, "site-b", model.InboxSubscriptionRead, "")
 	require.NoError(t, h.HandleEvent(context.Background(), subj, data))
 	assert.False(t, published, "event with empty DedupID must be skipped, never forwarded without dedup")
+}
+
+// An oversized envelope is rejected client-side before the wire, so it fails
+// identically on every redelivery. This lane is MaxDeliver=-1/MaxAckPending=1
+// per peer, so a Nak parks every later event for that peer behind it forever —
+// drop the one event instead of wedging the whole federation lane.
+func TestHandleEvent_OversizedPayloadIsPermanent(t *testing.T) {
+	h := NewHandler(func(_ context.Context, _ string, _ []byte, _ string) error {
+		return nats.ErrMaxPayload
+	})
+	subj := subject.Outbox("site-a", "site-b", model.InboxSubscriptionRead)
+	data, _ := outboxEvent(t, "site-b", model.InboxSubscriptionRead, "d")
+
+	err := h.HandleEvent(context.Background(), subj, data)
+
+	require.Error(t, err)
+	_, permanent := errcode.IsPermanent(err)
+	assert.True(t, permanent, "an oversized forward can never succeed — Ack-drop it, don't wedge the lane")
 }

--- a/pkg/errcode/permanent.go
+++ b/pkg/errcode/permanent.go
@@ -81,3 +81,14 @@ func Terminal(err error) (*Error, bool) {
 		return ee, true
 	}
 }
+
+// MarshalFailed marks a serialization failure non-retryable. Marshaling a fixed
+// struct is deterministic — a value the encoder rejects (a NaN float, an erroring
+// custom marshaler) is rejected identically on every redelivery — so a JetStream
+// worker Ack-drops it instead of spending its MaxDeliver budget on a doomed retry.
+//
+// what names the value being marshaled; the encoder error rides as the cause, so
+// Classify logs it once server-side and it never reaches the client.
+func MarshalFailed(what string, cause error) error {
+	return Permanent(Internal("marshal "+what, WithCause(cause)))
+}

--- a/pkg/errcode/permanent_test.go
+++ b/pkg/errcode/permanent_test.go
@@ -108,3 +108,45 @@ func TestTerminal(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshalFailed_IsPermanentInternal(t *testing.T) {
+	cause := errors.New("json: unsupported value: NaN")
+	err := MarshalFailed("message event", cause)
+
+	if !errors.Is(err, ErrPermanent) {
+		t.Fatal("a marshal failure must be permanent so the worker Ack-drops it")
+	}
+	ec, ok := IsPermanent(err)
+	if !ok {
+		t.Fatal("IsPermanent must unwrap MarshalFailed")
+	}
+	if ec.Code != CodeInternal {
+		t.Fatalf("Code = %v, want %v (a marshal fault is a server fault)", ec.Code, CodeInternal)
+	}
+}
+
+func TestMarshalFailed_MessageNamesTheValueOnly(t *testing.T) {
+	cause := errors.New("json: error calling MarshalJSON: secret-body-abc")
+	err := MarshalFailed("message event", cause)
+
+	const want = "marshal message event"
+	if got := err.Error(); got != want {
+		t.Fatalf("Error() = %q, want %q — the cause must never reach the client message", got, want)
+	}
+}
+
+func TestMarshalFailed_CauseReachableForServerLogs(t *testing.T) {
+	cause := errors.New("json: unsupported value: NaN")
+	err := MarshalFailed("thread reply event", cause)
+
+	if !errors.Is(err, cause) {
+		t.Fatal("the encoder error must stay reachable as the cause for Classify's server-side log")
+	}
+}
+
+func TestMarshalFailed_NilCause(t *testing.T) {
+	err := MarshalFailed("room activity event", nil)
+	if !errors.Is(err, ErrPermanent) {
+		t.Fatal("a nil cause must still yield a permanent error, not a panic")
+	}
+}

--- a/pkg/outbox/outbox.go
+++ b/pkg/outbox/outbox.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/subject"
 )
@@ -100,7 +101,7 @@ func Publish(ctx context.Context, publish func(ctx context.Context, subj string,
 		Timestamp:  ts,
 	})
 	if err != nil {
-		return fmt.Errorf("marshal inbox event envelope: %w", err)
+		return errcode.MarshalFailed("inbox event envelope", err)
 	}
 	data, err := json.Marshal(model.OutboxEvent{
 		RoomID:    roomID,
@@ -109,7 +110,7 @@ func Publish(ctx context.Context, publish func(ctx context.Context, subj string,
 		Timestamp: time.Now().UTC().UnixMilli(),
 	})
 	if err != nil {
-		return fmt.Errorf("marshal outbox event: %w", err)
+		return errcode.MarshalFailed("outbox event", err)
 	}
 	if err := publish(ctx, subject.Outbox(originSiteID, destSiteID, eventType), data, dedupID); err != nil {
 		return fmt.Errorf("publish outbox event for %s: %w", destSiteID, err)

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -1916,7 +1916,7 @@ func (h *Handler) publishChannelSysMessages(ctx context.Context, req *model.Crea
 		AddedUsersCount: addedUsersCount,
 	})
 	if err != nil {
-		return fmt.Errorf("marshal room_created sys data: %w", err)
+		return errcode.MarshalFailed("room_created sys data", err)
 	}
 	msg1 := model.Message{
 		ID:          idgen.MessageIDFromRequestID(requestID, "room_created"),
@@ -1946,7 +1946,7 @@ func (h *Handler) publishChannelSysMessages(ctx context.Context, req *model.Crea
 		AddedUsersCount: addedUsersCount,
 	})
 	if err != nil {
-		return fmt.Errorf("marshal members_added sys data: %w", err)
+		return errcode.MarshalFailed("members_added sys data", err)
 	}
 	content := addedContent(requester, req.ResolvedUsers, req.ResolvedOrgs, func(a string) *model.User {
 		return userByAccount[a]
@@ -1976,7 +1976,7 @@ func (h *Handler) publishCanonical(ctx context.Context, msg *model.Message, site
 	}
 	data, err := json.Marshal(evt)
 	if err != nil {
-		return fmt.Errorf("marshal MessageEvent: %w", err)
+		return errcode.MarshalFailed("MessageEvent", err)
 	}
 	return h.publish(ctx, subject.MsgCanonicalCreated(siteID), data, natsutil.CanonicalDedupID(&evt))
 }
@@ -2324,7 +2324,7 @@ func (h *Handler) processRoomRename(ctx context.Context, data []byte) (err error
 
 	sysData, err := json.Marshal(model.RoomRenamedSysData{NewName: req.NewName, ByAccount: req.Account})
 	if err != nil {
-		return fmt.Errorf("marshal sys data: %w", err)
+		return errcode.MarshalFailed("room_renamed sys data", err)
 	}
 	requester, err := h.store.GetUser(ctx, req.Account)
 	if err != nil && !errors.Is(err, ErrUserNotFound) {
@@ -2367,7 +2367,7 @@ func (h *Handler) processRoomRename(ctx context.Context, data []byte) (err error
 		RoomID: req.RoomID, NewName: req.NewName, Timestamp: req.Timestamp,
 	})
 	if err != nil {
-		return fmt.Errorf("marshal rename inbox payload: %w", err)
+		return errcode.MarshalFailed("rename inbox payload", err)
 	}
 	now := time.Now().UTC().UnixMilli()
 	// Same-site search feed: search-sync re-indexes the room name from this
@@ -2383,7 +2383,7 @@ func (h *Handler) processRoomRename(ctx context.Context, data []byte) (err error
 	}
 	internalRenameData, err := json.Marshal(internalRename)
 	if err != nil {
-		return fmt.Errorf("marshal internal rename event: %w", err)
+		return errcode.MarshalFailed("internal rename event", err)
 	}
 	// Best-effort: log, don't Nak. Returning here would redeliver the whole
 	// handler, and UpdateRoomName / UpdateSubscriptionNamesForRoom (already
@@ -2503,7 +2503,7 @@ func (h *Handler) publishSyncDMInbox(ctx context.Context, room *model.Room, requ
 	}
 	pData, err := json.Marshal(memberEvt)
 	if err != nil {
-		return fmt.Errorf("marshal member_added inbox payload: %w", err)
+		return errcode.MarshalFailed("member_added inbox payload", err)
 	}
 	// Dedup keys on intrinsic room identity (stable across retries and
 	// re-subscribes) plus the destination site, NOT the request ID — the router

--- a/room-worker/main.go
+++ b/room-worker/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/hmchangw/chat/pkg/atrest"
+	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/health"
 	"github.com/hmchangw/chat/pkg/idgen"
 	"github.com/hmchangw/chat/pkg/logctx"
@@ -266,7 +267,7 @@ func main() {
 	handler.publishUsers = func(ctx context.Context, users []model.IUserWithChange) error {
 		data, err := json.Marshal(users)
 		if err != nil {
-			return fmt.Errorf("marshal user identity fanout: %w", err)
+			return errcode.MarshalFailed("user identity fanout", err)
 		}
 		subj := subject.OrgSyncUsersUpsert(cfg.SiteID)
 		if _, err = js.PublishMsg(ctx, natsutil.NewMsg(ctx, subj, data)); err != nil {

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -238,7 +238,9 @@ func (s *MongoStore) CreateRoom(ctx context.Context, room *model.Room, key *room
 	}
 	var doc bson.M
 	if err := bson.Unmarshal(raw, &doc); err != nil {
-		return false, fmt.Errorf("unmarshal room doc: %w", err)
+		// raw is the bson.Marshal output from the line above: round-tripping our own
+		// bytes cannot fail transiently, so a redelivery can only fail identically.
+		return false, errcode.Permanent(errcode.Internal("unmarshal room doc", errcode.WithCause(err)))
 	}
 	// _id is supplied by the filter; $setOnInsert must not also set it.
 	delete(doc, "_id")

--- a/room-worker/store_mongo.go
+++ b/room-worker/store_mongo.go
@@ -10,6 +10,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
+	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
 	"github.com/hmchangw/chat/pkg/orgdisplay"
@@ -233,7 +234,7 @@ func (s *MongoStore) CreateRoom(ctx context.Context, room *model.Room, key *room
 	// encKey field can be attached and the whole thing written in one upsert.
 	raw, err := bson.Marshal(room)
 	if err != nil {
-		return false, fmt.Errorf("marshal room: %w", err)
+		return false, errcode.MarshalFailed("room", err)
 	}
 	var doc bson.M
 	if err := bson.Unmarshal(raw, &doc); err != nil {

--- a/room-worker/teamsroomcreate.go
+++ b/room-worker/teamsroomcreate.go
@@ -291,7 +291,7 @@ func (h *Handler) federateTeamsMembership(ctx context.Context, room *model.Room,
 	}
 	payload, err := json.Marshal(evt)
 	if err != nil {
-		return fmt.Errorf("marshal membership event: %w", err)
+		return errcode.MarshalFailed("membership event", err)
 	}
 	// Envelope for the internal lane only — outbox.Publish builds its own below.
 	// Timestamp is acceptedAt, not time.Now(): it becomes the ES external doc
@@ -304,7 +304,7 @@ func (h *Handler) federateTeamsMembership(ctx context.Context, room *model.Room,
 		Timestamp:  acceptedAt.UnixMilli(),
 	})
 	if err != nil {
-		return fmt.Errorf("marshal internal inbox envelope: %w", err)
+		return errcode.MarshalFailed("internal inbox envelope", err)
 	}
 	seed := fmt.Sprintf("%s:%s:%d", room.ID, eventType, acceptedAt.UnixMilli())
 	if err := h.publish(ctx, subject.InboxInternal(h.siteID, eventType), internalData, natsutil.InboxDedupID(ctx, h.siteID, seed)); err != nil {
@@ -322,7 +322,7 @@ func (h *Handler) federateTeamsMembership(ctx context.Context, room *model.Room,
 		siteEvt.Accounts = siteAccounts
 		siteData, err := json.Marshal(siteEvt)
 		if err != nil {
-			return fmt.Errorf("marshal federated membership event (dest %s): %w", destSite, err)
+			return errcode.MarshalFailed("federated membership event", err)
 		}
 		dedupID := natsutil.InboxDedupID(ctx, destSite, seed)
 		if err := h.federate(ctx, room.ID, destSite, eventType, siteData, dedupID, acceptedAt.UnixMilli()); err != nil {
@@ -356,7 +356,7 @@ func (h *Handler) federateJoinedAtRefresh(ctx context.Context, room *model.Room,
 
 	allPayload, err := json.Marshal(evt)
 	if err != nil {
-		return fmt.Errorf("marshal joinedAt-refresh event: %w", err)
+		return errcode.MarshalFailed("joinedAt-refresh event", err)
 	}
 	// Local internal lane → room-site spotlight (inbox-worker doesn't consume it;
 	// the room-site Mongo copy was already updated by the caller).
@@ -368,7 +368,7 @@ func (h *Handler) federateJoinedAtRefresh(ctx context.Context, room *model.Room,
 		Timestamp:  acceptedAt.UnixMilli(),
 	})
 	if err != nil {
-		return fmt.Errorf("marshal internal joinedAt-refresh envelope: %w", err)
+		return errcode.MarshalFailed("internal joinedAt-refresh envelope", err)
 	}
 	if err := h.publish(ctx, subject.InboxInternal(h.siteID, model.InboxMemberJoinedAtRefreshed), internalData, natsutil.InboxDedupID(ctx, h.siteID, seed)); err != nil {
 		return fmt.Errorf("local inbox joinedAt-refresh publish: %w", err)
@@ -386,7 +386,7 @@ func (h *Handler) federateJoinedAtRefresh(ctx context.Context, room *model.Room,
 		siteEvt.Accounts = siteAccounts
 		payload, err := json.Marshal(siteEvt)
 		if err != nil {
-			return fmt.Errorf("marshal joinedAt-refresh event (dest %s): %w", destSite, err)
+			return errcode.MarshalFailed("federated joinedAt-refresh event", err)
 		}
 		dedupID := natsutil.InboxDedupID(ctx, destSite, seed)
 		if err := h.federate(ctx, room.ID, destSite, model.InboxMemberJoinedAtRefreshed, payload, dedupID, acceptedAt.UnixMilli()); err != nil {


### PR DESCRIPTION
## Summary

Introduces `errcode.MarshalFailed()` to mark serialization failures as permanent, non-retryable errors. When a value cannot be marshaled (e.g., NaN float, erroring custom marshaler), it fails identically on every redelivery, so JetStream workers should Ack-drop it instead of exhausting their `MaxDeliver` budget on doomed retries.

## Key Changes

- **New API**: `errcode.MarshalFailed(what string, cause error)` wraps a marshal error as permanent with code `CodeInternal`. The cause is logged server-side by `Classify` but never reaches the client; the message names only the value being marshaled (e.g., "marshal message event").

- **Message Gatekeeper**: 
  - Detects permanent errors via `errcode.IsPermanent()` before checking for typed `*errcode.Error`
  - Records permanent faults as `resultFailed/reasonInternal` (not `resultRejected`) so the rejection series stays a pure client-error signal
  - Ack-drops permanent faults instead of Nak-ing them for redelivery
  - Replaces bare `fmt.Errorf` marshal errors with `MarshalFailed` calls

- **Broadcast Worker**: Replaces all `fmt.Errorf("marshal …: %w", err)` patterns with `errcode.MarshalFailed()` calls across thread events, mutations, encryption, and channel events

- **Room Worker**: Replaces marshal error wrapping in federation, room creation, and rename handlers with `MarshalFailed` calls

- **Message Worker**: Replaces marshal error wrapping in thread unread, subscription, and reply event handlers with `MarshalFailed` calls

- **Notification Worker**: Replaces marshal error wrapping in push batch emission with `MarshalFailed` calls

- **Metrics**: Adds `reasonInternal` to gatekeeper reason codes to distinguish permanent server faults from client rejections

## Implementation Details

- `MarshalFailed` uses `Permanent(Internal(…))` to compose the permanent marker with an internal error code
- The cause is attached via `WithCause()` so it's available for server-side logging but excluded from client replies
- Tests verify: permanent classification, client message sanitization (no cause leakage), cause reachability for logs, and nil-cause safety
- Integration test confirms broadcast-worker's `publishMutation` correctly marks marshal failures as permanent

https://claude.ai/code/session_017nKyc2rJv8pLJnpLUosk6C

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Serialization failures are now consistently classified as permanent internal errors.
  * Messages that cannot succeed are acknowledged instead of repeatedly retried.
  * Oversized events are dropped promptly rather than blocking subsequent processing.
  * Monitoring records these failures as internal errors instead of validation rejections.
  * Client-facing error responses no longer expose underlying serialization details.
  * Malformed input remains safely rejected with consistent, non-sensitive messages.

* **Documentation**
  * Added guidance for handling permanent and temporary processing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->