### PR TITLE
fix(upload-service): resolve room siteID from the subscription so cross-site uploads work

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -574,7 +574,6 @@ A whole-request failure (not a per-file rejection) uses the
 | 400 | `bad_request` | — | `{ "code": "bad_request", "error": "too many files" }` — also `roomId is required`, `request must be multipart/form-data`. |
 | 401 | `unauthenticated` | `invalid_sso_token` / `sso_token_expired` / `missing_fields` | `{ "code": "unauthenticated", "reason": "invalid_sso_token", "error": "invalid sso token" }` |
 | 403 | `forbidden` | `not_room_member` | `{ "code": "forbidden", "reason": "not_room_member", "error": "user alice is not in room abc123" }` |
-| 404 | `not_found` | — | `{ "code": "not_found", "error": "room not found" }` |
 | 500 | `internal` | — | `{ "code": "internal", "error": "internal error" }` — user missing in context, no email on the account, or a Drive/store fault; real cause logged server-side only. |
 
 #### Triggered events — success path
@@ -644,7 +643,6 @@ Uses the [§6](#6-error-envelope-reference) envelope. HTTP statuses:
 | 400 | `bad_request` | — | `{ "code": "bad_request", "error": "file type is not allowed" }` — also `roomId is required`, `request must be multipart/form-data`, `file is required`, `too many files`, `file size exceeds limit`. |
 | 401 | `unauthenticated` | `invalid_sso_token` / `sso_token_expired` / `missing_fields` | `{ "code": "unauthenticated", "reason": "invalid_sso_token", "error": "invalid sso token" }` |
 | 403 | `forbidden` | `not_room_member` | `{ "code": "forbidden", "reason": "not_room_member", "error": "user alice is not in room abc123" }` |
-| 404 | `not_found` | — | `{ "code": "not_found", "error": "room not found" }` |
 | 500 | `internal` | — | `{ "code": "internal", "error": "internal error" }` — user missing in context, no email on the account, or a read fault; real cause logged server-side only. |
 | 503 | `unavailable` | — | `{ "code": "unavailable", "error": "drive upload failed" }` |
 

--- a/pkg/drive/uploader.go
+++ b/pkg/drive/uploader.go
@@ -86,7 +86,7 @@ func (c *Client) UploadGroupImages(userID, username, email, groupID, origin stri
 	for i, f := range files {
 		fields = append(fields,
 			formField{fmt.Sprintf("files[%d].fileName", i), f.Filename},
-			formField{fmt.Sprintf("files[%d].mode", i), "Normal"})
+			formField{fmt.Sprintf("files[%d].mode", i), "KeepBoth"})
 	}
 	body, err := buildStreamedBody(fields, files)
 	if err != nil {

--- a/pkg/drive/uploader_test.go
+++ b/pkg/drive/uploader_test.go
@@ -60,7 +60,7 @@ func TestClient_UploadGroupImages(t *testing.T) {
 	if gotBypass != "true" {
 		t.Fatalf("bypass query param = %q, want %q", gotBypass, "true")
 	}
-	if gotToken != "tok" || gotUserID != "alice" || gotFileName != "a.png" || gotMode != "Normal" {
+	if gotToken != "tok" || gotUserID != "alice" || gotFileName != "a.png" || gotMode != "KeepBoth" {
 		t.Fatalf("token=%q userId=%q fileName=%q mode=%q", gotToken, gotUserID, gotFileName, gotMode)
 	}
 }

--- a/upload-service/handler.go
+++ b/upload-service/handler.go
@@ -153,17 +153,8 @@ func (h *Handler) HandleUploadImages(c *gin.Context) {
 		return
 	}
 
-	if !h.requireMembership(ctx, c, roomID, user.Account) {
-		return
-	}
-
-	siteID, err := h.store.GetRoomSiteID(ctx, roomID)
-	if err != nil {
-		if errIsRoomNotFound(err) {
-			errhttp.Write(ctx, c, errcode.NotFound("room not found"))
-			return
-		}
-		errhttp.Write(ctx, c, fmt.Errorf("get room: %w", err))
+	siteID, ok := h.requireMembership(ctx, c, roomID, user.Account)
+	if !ok {
 		return
 	}
 
@@ -238,17 +229,8 @@ func (h *Handler) HandleUploadFile(c *gin.Context) {
 		return
 	}
 
-	if !h.requireMembership(ctx, c, roomID, user.Account) {
-		return
-	}
-
-	siteID, err := h.store.GetRoomSiteID(ctx, roomID)
-	if err != nil {
-		if errIsRoomNotFound(err) {
-			errhttp.Write(ctx, c, errcode.NotFound("room not found"))
-			return
-		}
-		errhttp.Write(ctx, c, fmt.Errorf("get room: %w", err))
+	siteID, ok := h.requireMembership(ctx, c, roomID, user.Account)
+	if !ok {
 		return
 	}
 
@@ -369,7 +351,7 @@ func (h *Handler) downloadFrom(c *gin.Context, dc driveClient) {
 		return
 	}
 
-	if !h.requireMembership(ctx, c, roomID, user.Account) {
+	if _, ok := h.requireMembership(ctx, c, roomID, user.Account); !ok {
 		return
 	}
 
@@ -420,7 +402,7 @@ func (h *Handler) HandleDownloadMinioS3File(c *gin.Context) {
 		return
 	}
 
-	if !h.requireMembership(ctx, c, up.RID, user.Account) {
+	if _, ok := h.requireMembership(ctx, c, up.RID, user.Account); !ok {
 		return
 	}
 
@@ -446,21 +428,22 @@ func (h *Handler) HandleDownloadMinioS3File(c *gin.Context) {
 }
 
 // requireMembership verifies the account is a member of roomID, writing the
-// appropriate error response and returning false when it is not (or on a store
-// error). Both room-scoped handlers gate on this.
-func (h *Handler) requireMembership(ctx context.Context, c *gin.Context, roomID, account string) bool {
-	member, err := h.store.IsMember(ctx, roomID, account)
+// appropriate error response and returning ok=false when it is not (or on a
+// store error). On success it also returns the room's home siteID from the
+// subscription — the local source that exists even for cross-site rooms.
+func (h *Handler) requireMembership(ctx context.Context, c *gin.Context, roomID, account string) (string, bool) {
+	siteID, member, err := h.store.MemberSiteID(ctx, roomID, account)
 	if err != nil {
 		errhttp.Write(ctx, c, fmt.Errorf("check room membership: %w", err))
-		return false
+		return "", false
 	}
 	if !member {
 		errhttp.Write(ctx, c, errcode.Forbidden(
 			fmt.Sprintf("user %s is not in room %s", account, roomID),
 			errcode.WithReason(errcode.RoomNotMember)))
-		return false
+		return "", false
 	}
-	return true
+	return siteID, true
 }
 
 // preprocessFiles runs the per-file size/extension/open checks. Rejected files

--- a/upload-service/handler_test.go
+++ b/upload-service/handler_test.go
@@ -131,8 +131,7 @@ func TestUpload_SessionCaller_NoEmail_Succeeds(t *testing.T) {
 	// no email is the normal case, because bots have no directory record.
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alerts.sa.bot").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "r1").Return("site-a", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alerts.sa.bot").Return("site-a", true, nil)
 	fd := &fakeDrive{uploadResp: driveOKResponse()}
 	h := newHandler(store, fd)
 
@@ -149,8 +148,7 @@ func TestUpload_SessionCaller_NoEmail_Succeeds(t *testing.T) {
 func TestUpload_SessionCaller_SynthesizedEmail_ReachesDrive(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alerts.sa.bot").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "r1").Return("site-a", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alerts.sa.bot").Return("site-a", true, nil)
 	fd := &fakeDrive{uploadResp: driveOKResponse()}
 	h := newHandler(store, fd)
 
@@ -207,7 +205,7 @@ func TestUpload_NoEmail_500(t *testing.T) {
 func TestUpload_NotMember_403(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(false, nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("", false, nil)
 	h := newHandler(store, &fakeDrive{})
 	body, ct := multipartBody(t, "images", map[string][]byte{"a.png": []byte("x")})
 	c, w := newUploadCtx(t, "r1", body, ct, okUser())
@@ -218,24 +216,38 @@ func TestUpload_NotMember_403(t *testing.T) {
 	assert.Equal(t, "not_room_member", env.Reason)
 }
 
-func TestUpload_RoomNotFound_404(t *testing.T) {
+// A cross-site room has no local rooms doc — only the mirrored subscription.
+// The upload must resolve the room's home site from it, not 404.
+func TestUpload_CrossSiteRoom_UsesSubscriptionSiteID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "r1").Return("", ErrRoomNotFound)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-remote", true, nil)
+	fd := &fakeDrive{uploadResp: driveOKResponse()}
+	h := newHandler(store, fd)
+	body, ct := multipartBody(t, "images", map[string][]byte{"a.png": []byte("x")})
+	c, w := newUploadCtx(t, "r1", body, ct, okUser())
+	h.HandleUploadImages(c)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "site-remote", fd.uploadGot.origin, "drive upload must target the room's home site")
+}
+
+// A membership store failure is infra, not a 403/404.
+func TestUpload_MemberSiteIDError_500(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("", false, errors.New("mongo boom"))
 	h := newHandler(store, &fakeDrive{})
 	body, ct := multipartBody(t, "images", map[string][]byte{"a.png": []byte("x")})
 	c, w := newUploadCtx(t, "r1", body, ct, okUser())
 	h.HandleUploadImages(c)
-	assert.Equal(t, http.StatusNotFound, w.Code)
-	assert.Equal(t, "not_found", decodeErr(t, w).Code)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, "internal", decodeErr(t, w).Code)
 }
 
 func TestUpload_NotMultipart_400(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "r1").Return("site-x", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	h := newHandler(store, &fakeDrive{})
 	c, w := newUploadCtx(t, "r1", bytes.NewBufferString("not-multipart"), "text/plain", okUser())
 	h.HandleUploadImages(c)
@@ -246,8 +258,7 @@ func TestUpload_NotMultipart_400(t *testing.T) {
 func TestUpload_TooManyFiles_400(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "r1").Return("site-x", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	h := NewHandler(store, &fakeDrive{}, &fakeS3{}, 1, testMaxAttachments, testMaxImageSize, 0, nil, testCacheMaxAge, true, &fakeDrive{}) // image limit 1
 	body, ct := multipartBody(t, "images", map[string][]byte{"a.png": []byte("x"), "b.png": []byte("y")})
 	c, w := newUploadCtx(t, "r1", body, ct, okUser())
@@ -259,8 +270,7 @@ func TestUpload_TooManyFiles_400(t *testing.T) {
 func TestUpload_AllRejected_EarlyExit_NoDriveCall(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "r1").Return("site-x", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	fd := &fakeDrive{}
 	h := newHandler(store, fd)
 	// .exe is an invalid type -> rejected in preprocessing.
@@ -281,8 +291,7 @@ func TestUpload_AllRejected_EarlyExit_NoDriveCall(t *testing.T) {
 func TestUpload_OversizeRejectedPerFile(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "r1").Return("site-x", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	fd := &fakeDrive{}
 	h := NewHandler(store, fd, &fakeS3{}, testMaxImages, testMaxAttachments, 4, 0, nil, testCacheMaxAge, true, &fakeDrive{}) // 4-byte per-image ceiling
 	body, ct := multipartBody(t, "images", map[string][]byte{"a.png": []byte("0123456789")})
@@ -302,8 +311,7 @@ func TestUpload_OversizeRejectedPerFile(t *testing.T) {
 func TestUpload_MixedSuccessAndFailure_Merges(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "r1").Return("site-x", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	fd := &fakeDrive{
 		baseURL: "https://drive.example.com",
 		uploadResp: []drive.UploadGroupImageResponse{
@@ -345,8 +353,7 @@ func TestUpload_MixedSuccessAndFailure_Merges(t *testing.T) {
 func TestUpload_DriveError_500(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "r1").Return("site-x", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	fd := &fakeDrive{uploadErr: errors.New("boom")}
 	h := newHandler(store, fd)
 	body, ct := multipartBody(t, "images", map[string][]byte{"a.png": []byte("x")})
@@ -387,8 +394,7 @@ func TestHandleHealth(t *testing.T) {
 func TestHandleUploadImages_MultiFileBatch_ResultsMatchSendOrder(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "r1").Return("site-x", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	fd := &fakeDrive{
 		baseURL: "https://drive.example.com",
 		uploadResp: []drive.UploadGroupImageResponse{
@@ -432,8 +438,7 @@ func TestHandleUploadImages_MultiFileBatch_ResultsMatchSendOrder(t *testing.T) {
 func TestHandleUploadImages_SendsOriginalName(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "r1").Return("site-x", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	fd := &fakeDrive{
 		baseURL: "https://drive.example.com",
 		uploadResp: []drive.UploadGroupImageResponse{
@@ -462,8 +467,7 @@ func TestHandleUploadImages_SendsOriginalName(t *testing.T) {
 func TestHandleUploadImages_DriveErrorEmptyFilename_KeepsOriginalName(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "r1").Return("site-x", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	// Drive reports a per-file failure: status "failure", empty File (so
 	// resp.File.Filename == "").
 	fd := &fakeDrive{
@@ -493,8 +497,7 @@ func TestHandleUploadImages_DriveErrorEmptyFilename_KeepsOriginalName(t *testing
 func TestHandleUploadFile_SendsOriginalName(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "r1").Return("site-x", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	fd := &fakeDrive{
 		baseURL: "http://drive",
 		uploadResp: []drive.UploadGroupImageResponse{
@@ -650,7 +653,7 @@ func TestDownload_NoUser_500(t *testing.T) {
 func TestDownload_NotMember_403(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(false, nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("", false, nil)
 	h := newHandler(store, &fakeDrive{})
 	c, w := newDownloadCtx(t, "r1", "f1", "https://d.example.com", okUser())
 	h.HandleDownloadFile(c)
@@ -663,7 +666,7 @@ func TestDownload_NotMember_403(t *testing.T) {
 func TestDownload_DriveError_503(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	fd := &fakeDrive{getErr: errors.New("image not found")}
 	h := newHandler(store, fd)
 	c, w := newDownloadCtx(t, "r1", "f1", "https://d.example.com", okUser())
@@ -759,7 +762,7 @@ func TestS3Download_NotMember_403(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
 	store.EXPECT().GetUpload(gomock.Any(), "f1").Return(sampleUpload(), nil)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(false, nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("", false, nil)
 	h := newHandler(store, &fakeDrive{})
 	c, w := newS3DownloadCtx(t, "f1", "x.pdf", okUser())
 	h.HandleDownloadMinioS3File(c)
@@ -773,7 +776,7 @@ func TestS3Download_S3Error_503(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
 	store.EXPECT().GetUpload(gomock.Any(), "f1").Return(sampleUpload(), nil)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	h := NewHandler(store, &fakeDrive{}, &fakeS3{err: errors.New("no such key")}, testMaxImages, testMaxAttachments, testMaxImageSize, 0, nil, testCacheMaxAge, true, &fakeDrive{})
 	c, w := newS3DownloadCtx(t, "f1", "x.pdf", okUser())
 	h.HandleDownloadMinioS3File(c)
@@ -785,7 +788,7 @@ func TestS3Download_Success_StreamsWithHeaders(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
 	store.EXPECT().GetUpload(gomock.Any(), "f1").Return(sampleUpload(), nil)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	s3 := &fakeS3{body: "PDFDATA"}
 	h := NewHandler(store, &fakeDrive{}, s3, testMaxImages, testMaxAttachments, testMaxImageSize, 0, nil, testCacheMaxAge, true, &fakeDrive{})
 	c, w := newS3DownloadCtx(t, "f1", "x.pdf", okUser())
@@ -808,7 +811,7 @@ func TestS3Download_EmptyType_DefaultsOctetStream(t *testing.T) {
 	up := sampleUpload()
 	up.Type = ""
 	store.EXPECT().GetUpload(gomock.Any(), "f1").Return(up, nil)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	h := NewHandler(store, &fakeDrive{}, &fakeS3{body: "PDFDATA"}, testMaxImages, testMaxAttachments, testMaxImageSize, 0, nil, testCacheMaxAge, true, &fakeDrive{})
 	c, w := newS3DownloadCtx(t, "f1", "x.pdf", okUser())
 	h.HandleDownloadMinioS3File(c)
@@ -819,7 +822,7 @@ func TestS3Download_EmptyType_DefaultsOctetStream(t *testing.T) {
 func TestDownload_Success_StreamsBinary(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	fd := &fakeDrive{getResp: &drive.GetGroupImageResponse{
 		Reader:        readCloser{strings.NewReader("PNGDATA")},
 		ContentType:   "image/png",
@@ -844,7 +847,7 @@ func TestDownload_Success_StreamsBinary(t *testing.T) {
 func TestDownload_Success_NoFilename(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	fd := &fakeDrive{getResp: &drive.GetGroupImageResponse{
 		Reader:        readCloser{strings.NewReader("PNGDATA")},
 		ContentType:   "image/png",
@@ -905,7 +908,7 @@ func TestDownloadV3_NoUser_500(t *testing.T) {
 func TestDownloadV3_NotMember_403(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(false, nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("", false, nil)
 	h := newHandler(store, &fakeDrive{})
 	c, w := newDownloadCtx(t, "r1", "f1", "https://legacy.example.com", okUser())
 	h.HandleDownloadProtectedImageV3(c)
@@ -918,7 +921,7 @@ func TestDownloadV3_NotMember_403(t *testing.T) {
 func TestDownloadV3_DriveError_503(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	legacy := &fakeDrive{getErr: errors.New("image not found")}
 	h := newHandlerWithLegacy(store, &fakeDrive{}, legacy)
 	c, w := newDownloadCtx(t, "r1", "f1", "https://legacy.example.com", okUser())
@@ -932,7 +935,7 @@ func TestDownloadV3_DriveError_503(t *testing.T) {
 func TestDownloadV3_UsesLegacyDrive(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "r1", "alice").Return(true, nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
 	primary := &fakeDrive{getResp: &drive.GetGroupImageResponse{
 		Reader: readCloser{strings.NewReader("PRIMARY")}, ContentType: "image/png", ContentLength: 7,
 	}}
@@ -1005,8 +1008,7 @@ func okFileDrive() *fakeDrive {
 func TestHandleUploadFile_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "room-1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "room-1").Return("site-a", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "room-1", "alice").Return("site-a", true, nil)
 
 	body, ct := multipartTyped(t, "file", "report.pdf", []byte("pdfbytes"), "application/pdf", map[string]string{"description": "Q2"})
 	c, w := newUploadCtx(t, "room-1", body, ct, okUser())
@@ -1033,8 +1035,7 @@ func TestHandleUploadFile_Success(t *testing.T) {
 func TestHandleUploadFile_SessionCaller_NoEmail_Succeeds(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "room-1", "alerts.sa.bot").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "room-1").Return("site-a", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "room-1", "alerts.sa.bot").Return("site-a", true, nil)
 	fd := okFileDrive()
 
 	body, ct := multipartTyped(t, "file", "report.pdf", []byte("pdfbytes"), "application/pdf", nil)
@@ -1049,8 +1050,7 @@ func TestHandleUploadFile_SessionCaller_NoEmail_Succeeds(t *testing.T) {
 func TestHandleUploadFile_ImageSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "room-1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "room-1").Return("site-a", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "room-1", "alice").Return("site-a", true, nil)
 
 	body, ct := multipartTyped(t, "file", "photo.png", png64x48, "image/png", nil)
 	c, w := newUploadCtx(t, "room-1", body, ct, okUser())
@@ -1076,29 +1076,30 @@ func TestHandleUploadFile_ImageSuccess(t *testing.T) {
 func TestHandleUploadFile_NotMember(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "room-1", "alice").Return(false, nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "room-1", "alice").Return("", false, nil)
 	body, ct := multipartTyped(t, "file", "report.pdf", []byte("x"), "application/pdf", nil)
 	c, w := newUploadCtx(t, "room-1", body, ct, okUser())
 	fileHandler(store, okFileDrive()).HandleUploadFile(c)
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
-func TestHandleUploadFile_RoomNotFound(t *testing.T) {
+// Cross-site: the subscription's siteID (room's home site) drives the upload.
+func TestHandleUploadFile_CrossSiteRoom_UsesSubscriptionSiteID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "room-1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "room-1").Return("", ErrRoomNotFound)
+	store.EXPECT().MemberSiteID(gomock.Any(), "room-1", "alice").Return("site-remote", true, nil)
+	fd := okFileDrive()
 	body, ct := multipartTyped(t, "file", "report.pdf", []byte("x"), "application/pdf", nil)
 	c, w := newUploadCtx(t, "room-1", body, ct, okUser())
-	fileHandler(store, okFileDrive()).HandleUploadFile(c)
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	fileHandler(store, fd).HandleUploadFile(c)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "site-remote", fd.uploadGot.origin, "drive upload must target the room's home site")
 }
 
 func TestHandleUploadFile_BlockedMIME(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "room-1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "room-1").Return("site-a", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "room-1", "alice").Return("site-a", true, nil)
 	body, ct := multipartTyped(t, "file", "x.svg", []byte("<svg/>"), "image/svg+xml", nil)
 	c, w := newUploadCtx(t, "room-1", body, ct, okUser())
 	fileHandler(store, okFileDrive()).HandleUploadFile(c)
@@ -1108,8 +1109,7 @@ func TestHandleUploadFile_BlockedMIME(t *testing.T) {
 func TestHandleUploadFile_OverSize(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "room-1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "room-1").Return("site-a", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "room-1", "alice").Return("site-a", true, nil)
 	h := NewHandler(store, &fakeDrive{baseURL: "http://drive"}, &fakeS3{}, 0, testMaxAttachments, 0, 4, newMediaTypeFilter("", ""), testCacheMaxAge, true, &fakeDrive{})
 	body, ct := multipartTyped(t, "file", "big.pdf", []byte("morethan4"), "application/pdf", nil)
 	c, w := newUploadCtx(t, "room-1", body, ct, okUser())
@@ -1120,8 +1120,7 @@ func TestHandleUploadFile_OverSize(t *testing.T) {
 func TestHandleUploadFile_DriveError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "room-1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "room-1").Return("site-a", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "room-1", "alice").Return("site-a", true, nil)
 	fd := &fakeDrive{baseURL: "http://drive", uploadErr: fmt.Errorf("drive boom")}
 	h := fileHandler(store, fd)
 	body, ct := multipartTyped(t, "file", "report.pdf", []byte("x"), "application/pdf", nil)
@@ -1133,8 +1132,7 @@ func TestHandleUploadFile_DriveError(t *testing.T) {
 func TestHandleUploadFile_DriveStatusFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "room-1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "room-1").Return("site-a", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "room-1", "alice").Return("site-a", true, nil)
 	fd := &fakeDrive{baseURL: "http://drive", uploadResp: []drive.UploadGroupImageResponse{
 		{Status: "failure", Error: "quota exceeded"},
 	}}
@@ -1194,8 +1192,7 @@ func multipartFileParts(t *testing.T, n int) (*bytes.Buffer, string) {
 func TestHandleUploadFile_TooManyFiles(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "room-1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "room-1").Return("site-a", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "room-1", "alice").Return("site-a", true, nil)
 	fd := okFileDrive()
 	h := fileHandler(store, fd) // maxAttachments == testMaxAttachments == 1
 
@@ -1211,8 +1208,7 @@ func TestHandleUploadFile_TooManyFiles(t *testing.T) {
 func TestHandleUploadFile_MissingFile(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "room-1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "room-1").Return("site-a", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "room-1", "alice").Return("site-a", true, nil)
 	body, ct := multipartTyped(t, "other", "x.txt", []byte("x"), "text/plain", nil)
 	c, w := newUploadCtx(t, "room-1", body, ct, okUser())
 	fileHandler(store, okFileDrive()).HandleUploadFile(c)
@@ -1281,8 +1277,7 @@ func TestHandler_HandleSetCookie_NoToken(t *testing.T) {
 func TestHandleUploadFile_OctetStreamResolvesFromBytes(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "room-1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "room-1").Return("site-a", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "room-1", "alice").Return("site-a", true, nil)
 
 	body, ct := multipartTyped(t, "file", "photo.png", png64x48, "application/octet-stream", nil)
 	c, w := newUploadCtx(t, "room-1", body, ct, okUser())
@@ -1307,8 +1302,7 @@ func TestHandleUploadFile_OctetStreamResolvesFromBytes(t *testing.T) {
 func TestHandleUploadFile_OctetStreamResolvesFromExtension(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "room-1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "room-1").Return("site-a", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "room-1", "alice").Return("site-a", true, nil)
 
 	body, ct := multipartTyped(t, "file", "report.docx", zipBytes, "application/octet-stream", nil)
 	c, w := newUploadCtx(t, "room-1", body, ct, okUser())
@@ -1330,8 +1324,7 @@ func TestHandleUploadFile_OctetStreamResolvesFromExtension(t *testing.T) {
 func TestHandleUploadFile_BlockedAfterResolution(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "room-1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "room-1").Return("site-a", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "room-1", "alice").Return("site-a", true, nil)
 	fd := okFileDrive()
 
 	body, ct := multipartTyped(t, "file", "logo.svg", svgBytes, "application/octet-stream", nil)
@@ -1346,8 +1339,7 @@ func TestHandleUploadFile_BlockedAfterResolution(t *testing.T) {
 func TestHandleUploadFile_SpecificDeclaredTypeIsKept(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "room-1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "room-1").Return("site-a", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "room-1", "alice").Return("site-a", true, nil)
 
 	body, ct := multipartTyped(t, "file", "data.bin", []byte("a,b\n1,2"), "text/csv", nil)
 	c, w := newUploadCtx(t, "room-1", body, ct, okUser())
@@ -1373,12 +1365,11 @@ func TestHandleUploadFile_RoomIDRequired(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-// A generic GetRoomSiteID failure (not ErrRoomNotFound) is infra, not a 404.
-func TestHandleUploadFile_GetRoomSiteIDError(t *testing.T) {
+// A generic MemberSiteID failure is infra, not a 403/404.
+func TestHandleUploadFile_MemberSiteIDError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "room-1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "room-1").Return("", errors.New("mongo boom"))
+	store.EXPECT().MemberSiteID(gomock.Any(), "room-1", "alice").Return("", false, errors.New("mongo boom"))
 	body, ct := multipartTyped(t, "file", "report.pdf", []byte("x"), "application/pdf", nil)
 	c, w := newUploadCtx(t, "room-1", body, ct, okUser())
 	fileHandler(store, okFileDrive()).HandleUploadFile(c)
@@ -1389,8 +1380,7 @@ func TestHandleUploadFile_GetRoomSiteIDError(t *testing.T) {
 func TestHandleUploadFile_DriveNoResponses(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), "room-1", "alice").Return(true, nil)
-	store.EXPECT().GetRoomSiteID(gomock.Any(), "room-1").Return("site-a", nil)
+	store.EXPECT().MemberSiteID(gomock.Any(), "room-1", "alice").Return("site-a", true, nil)
 	fd := &fakeDrive{baseURL: "http://drive", uploadResp: []drive.UploadGroupImageResponse{}}
 	body, ct := multipartTyped(t, "file", "report.pdf", []byte("x"), "application/pdf", nil)
 	c, w := newUploadCtx(t, "room-1", body, ct, okUser())

--- a/upload-service/integration_test.go
+++ b/upload-service/integration_test.go
@@ -19,34 +19,47 @@ import (
 
 func TestMain(m *testing.M) { testutil.RunTests(m) }
 
-func TestMongoStore_IsMemberAndGetRoomSiteID(t *testing.T) {
+func TestMongoStore_MemberSiteID(t *testing.T) {
 	db := testutil.MongoDB(t, "uploadsvc")
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	// Local room: subscription carries the room's siteId.
 	_, err := db.Collection("subscriptions").InsertOne(ctx, bson.M{
-		"_id": "sub1", "roomId": "r1", "u": bson.M{"_id": "u1", "account": "alice"},
+		"_id": "sub1", "roomId": "r1", "siteId": "site-x", "u": bson.M{"_id": "u1", "account": "alice"},
 	})
 	require.NoError(t, err)
-	_, err = db.Collection("rooms").InsertOne(ctx, bson.M{"_id": "r1", "name": "Room 1", "siteId": "site-x"})
+	// Cross-site room: only the mirrored subscription exists — no rooms doc at all.
+	_, err = db.Collection("subscriptions").InsertOne(ctx, bson.M{
+		"_id": "sub2", "roomId": "r-remote", "siteId": "site-remote", "u": bson.M{"_id": "u1", "account": "alice"},
+	})
+	require.NoError(t, err)
+	// Legacy subscription without siteId decodes to "".
+	_, err = db.Collection("subscriptions").InsertOne(ctx, bson.M{
+		"_id": "sub3", "roomId": "r-legacy", "u": bson.M{"_id": "u1", "account": "alice"},
+	})
 	require.NoError(t, err)
 
 	s := NewMongoStore(db)
 
-	member, err := s.IsMember(ctx, "r1", "alice")
+	siteID, member, err := s.MemberSiteID(ctx, "r1", "alice")
 	require.NoError(t, err)
 	require.True(t, member)
-
-	member, err = s.IsMember(ctx, "r1", "bob")
-	require.NoError(t, err)
-	require.False(t, member)
-
-	siteID, err := s.GetRoomSiteID(ctx, "r1")
-	require.NoError(t, err)
 	require.Equal(t, "site-x", siteID)
 
-	_, err = s.GetRoomSiteID(ctx, "missing")
-	require.True(t, errors.Is(err, ErrRoomNotFound))
+	siteID, member, err = s.MemberSiteID(ctx, "r-remote", "alice")
+	require.NoError(t, err)
+	require.True(t, member)
+	require.Equal(t, "site-remote", siteID)
+
+	siteID, member, err = s.MemberSiteID(ctx, "r-legacy", "alice")
+	require.NoError(t, err)
+	require.True(t, member)
+	require.Empty(t, siteID)
+
+	_, member, err = s.MemberSiteID(ctx, "r1", "bob")
+	require.NoError(t, err)
+	require.False(t, member)
 }
 
 func TestMongoStore_GetUpload(t *testing.T) {

--- a/upload-service/mock_store_test.go
+++ b/upload-service/mock_store_test.go
@@ -40,21 +40,6 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
 }
 
-// GetRoomSiteID mocks base method.
-func (m *MockStore) GetRoomSiteID(ctx context.Context, roomID string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRoomSiteID", ctx, roomID)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRoomSiteID indicates an expected call of GetRoomSiteID.
-func (mr *MockStoreMockRecorder) GetRoomSiteID(ctx, roomID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRoomSiteID", reflect.TypeOf((*MockStore)(nil).GetRoomSiteID), ctx, roomID)
-}
-
 // GetUpload mocks base method.
 func (m *MockStore) GetUpload(ctx context.Context, fileID string) (*upload, error) {
 	m.ctrl.T.Helper()
@@ -70,17 +55,18 @@ func (mr *MockStoreMockRecorder) GetUpload(ctx, fileID any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpload", reflect.TypeOf((*MockStore)(nil).GetUpload), ctx, fileID)
 }
 
-// IsMember mocks base method.
-func (m *MockStore) IsMember(ctx context.Context, roomID, account string) (bool, error) {
+// MemberSiteID mocks base method.
+func (m *MockStore) MemberSiteID(ctx context.Context, roomID, account string) (string, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsMember", ctx, roomID, account)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "MemberSiteID", ctx, roomID, account)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
-// IsMember indicates an expected call of IsMember.
-func (mr *MockStoreMockRecorder) IsMember(ctx, roomID, account any) *gomock.Call {
+// MemberSiteID indicates an expected call of MemberSiteID.
+func (mr *MockStoreMockRecorder) MemberSiteID(ctx, roomID, account any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMember", reflect.TypeOf((*MockStore)(nil).IsMember), ctx, roomID, account)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MemberSiteID", reflect.TypeOf((*MockStore)(nil).MemberSiteID), ctx, roomID, account)
 }

--- a/upload-service/store.go
+++ b/upload-service/store.go
@@ -5,9 +5,6 @@ import (
 	"errors"
 )
 
-// ErrRoomNotFound is returned by GetRoomSiteID when no room matches the given ID.
-var ErrRoomNotFound = errors.New("room not found")
-
 // ErrUploadNotFound is returned by GetUpload when no upload matches the given ID.
 var ErrUploadNotFound = errors.New("upload not found")
 
@@ -29,16 +26,15 @@ type upload struct {
 
 // Store is the subset of persistence the upload handlers need.
 type Store interface {
-	// IsMember reports whether account has a subscription to roomID.
-	IsMember(ctx context.Context, roomID, account string) (bool, error)
-	// GetRoomSiteID returns the room's siteID, or ErrRoomNotFound (wrapped) when absent.
-	GetRoomSiteID(ctx context.Context, roomID string) (string, error)
+	// MemberSiteID resolves account's subscription to roomID, returning the
+	// room's home siteID as stamped on the subscription (member=false, siteID
+	// empty when no subscription exists). The subscription — not the rooms
+	// collection — is the source, because a cross-site room has no local rooms
+	// doc: federation mirrors only subscriptions to a member's site.
+	MemberSiteID(ctx context.Context, roomID, account string) (siteID string, member bool, err error)
 	// GetUpload returns the upload metadata for fileID, or ErrUploadNotFound (wrapped) when absent.
 	GetUpload(ctx context.Context, fileID string) (*upload, error)
 }
-
-// errIsRoomNotFound reports whether err wraps ErrRoomNotFound.
-func errIsRoomNotFound(err error) bool { return errors.Is(err, ErrRoomNotFound) }
 
 // errIsUploadNotFound reports whether err wraps ErrUploadNotFound.
 func errIsUploadNotFound(err error) bool { return errors.Is(err, ErrUploadNotFound) }

--- a/upload-service/store_mongo.go
+++ b/upload-service/store_mongo.go
@@ -12,50 +12,32 @@ import (
 
 type mongoStore struct {
 	subscriptions *mongo.Collection
-	rooms         *mongo.Collection
 	uploads       *mongo.Collection
 }
 
-// NewMongoStore returns a Store backed by the subscriptions, rooms, and uploads collections.
+// NewMongoStore returns a Store backed by the subscriptions and uploads collections.
 func NewMongoStore(db *mongo.Database) *mongoStore {
 	return &mongoStore{
 		subscriptions: db.Collection("subscriptions"),
-		rooms:         db.Collection("rooms"),
 		uploads:       db.Collection("uploads"),
 	}
 }
 
-func (s *mongoStore) IsMember(ctx context.Context, roomID, account string) (bool, error) {
-	// Existence check — a projected FindOne is lighter than CountDocuments
-	// (which runs an aggregation) and stops at the first index match.
-	err := s.subscriptions.FindOne(ctx,
-		bson.M{"roomId": roomID, "u.account": account},
-		options.FindOne().SetProjection(bson.M{"_id": 1}),
-	).Err()
-	if err != nil {
-		if errors.Is(err, mongo.ErrNoDocuments) {
-			return false, nil
-		}
-		return false, fmt.Errorf("find subscription for room %s: %w", roomID, err)
-	}
-	return true, nil
-}
-
-func (s *mongoStore) GetRoomSiteID(ctx context.Context, roomID string) (string, error) {
-	var room struct {
+func (s *mongoStore) MemberSiteID(ctx context.Context, roomID, account string) (string, bool, error) {
+	var sub struct {
 		SiteID string `bson:"siteId"`
 	}
-	err := s.rooms.FindOne(ctx,
-		bson.M{"_id": roomID},
-		options.FindOne().SetProjection(bson.M{"siteId": 1}),
-	).Decode(&room)
+	err := s.subscriptions.FindOne(ctx,
+		bson.M{"roomId": roomID, "u.account": account},
+		options.FindOne().SetProjection(bson.M{"siteId": 1, "_id": 0}),
+	).Decode(&sub)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
-			return "", fmt.Errorf("get room %s: %w", roomID, ErrRoomNotFound)
+			return "", false, nil
 		}
-		return "", fmt.Errorf("get room %s: %w", roomID, err)
+		return "", false, fmt.Errorf("find subscription for room %s: %w", roomID, err)
 	}
-	return room.SiteID, nil
+	return sub.SiteID, true, nil
 }
 
 func (s *mongoStore) GetUpload(ctx context.Context, fileID string) (*upload, error) {

--- a/upload-service/upload_stream_test.go
+++ b/upload-service/upload_stream_test.go
@@ -31,8 +31,7 @@ func uploadStack(t *testing.T) string {
 
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
-	store.EXPECT().IsMember(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
-	store.EXPECT().GetRoomSiteID(gomock.Any(), gomock.Any()).Return("site1", nil).AnyTimes()
+	store.EXPECT().MemberSiteID(gomock.Any(), gomock.Any(), gomock.Any()).Return("site1", true, nil).AnyTimes()
 
 	h := NewHandler(store, drive.NewClient(&drive.Config{URL: driveSrv.URL, Token: "tok"}), &fakeS3{},
 		0, 1, 0, 200<<20, newMediaTypeFilter("", "image/svg+xml"), testCacheMaxAge, true, &fakeDrive{})


### PR DESCRIPTION
## Problem

A user uploading a file to a room homed on another site got:

```
404 {"code": "not_found", "error": "room not found"}
```

## Root cause

The upload handlers resolved the room's home siteID (used to pick the target tdrive endpoint) from the **local `rooms` collection**. Federation never replicates `rooms` docs to a member's site — only `subscriptions` are mirrored (inbox-worker `member_added`). So for a cross-site room:

1. `requireMembership` passes — the subscription IS mirrored locally
2. `GetRoomSiteID` finds no local `rooms` doc → 404

The 404 branch was only reachable in exactly this state: a nonexistent room already returns 403 at the membership gate, which runs first.

## Fix

The subscription itself carries the room's home `siteId` on every replica (`room-worker` `newSub` locally, `inbox-worker` `member_added` remotely — both stamp `room.SiteID`). The membership check already does a `FindOne` on that exact document, so the two lookups merge into one:

- `Store.IsMember` + `Store.GetRoomSiteID` → single `Store.MemberSiteID(ctx, roomID, account) (siteID, member, err)` — one `FindOne` on `subscriptions {roomId, u.account}` projecting `{siteId: 1, "_id": 0}`, served by the existing compound index
- `requireMembership` now returns `(siteID, ok)`; the two upload handlers consume the siteID, the three download handlers discard it
- The dead 404 branch, `ErrRoomNotFound`, and the store's `rooms` collection handle are deleted
- The resolved siteID feeds the existing `GetBaseURLFromRoomOrigin`, so the upload lands on the room's own tdrive endpoint (unknown/empty siteID keeps the pre-existing default-URL fallback)

Same pattern as `media-service.RoomSite` and `botplatform-service`, which already resolve a room's site from subscriptions for the same reason.

Also in this PR: Drive bulk-upload `files[i].mode` changed `Normal` → `KeepBoth`, so filename collisions keep both files (upload-service is the only `UploadGroupImages` consumer).

## Behavior changes

| Scenario | Before | After |
|---|---|---|
| Cross-site member uploads | 404 room not found | 200, upload goes to the room's home-site tdrive |
| Non-member / nonexistent room | 403 `not_room_member` | unchanged |
| Mongo queries per upload | 2 (`subscriptions` + `rooms`) | 1 (`subscriptions`) |

`docs/client-api.md`: removed the now-unreachable 404 rows from both upload endpoints' error tables.

## Testing

- New regression tests: cross-site upload (images + file paths) asserts the Drive call targets the room's home site; membership-store-error → 500
- Store integration test covers: local room, cross-site room (subscription only, no `rooms` doc), legacy subscription without `siteId` (decodes to `""` → default-URL fallback), non-member
- `make test SERVICE=upload-service`, `make test-integration SERVICE=upload-service`, `golangci-lint` (0 issues), `make sast` (gosec/govulncheck/semgrep all PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk image uploads now preserve both versions of files when duplicates exist.
  * Cross-site rooms correctly use their subscription’s home site for uploads and downloads.
* **Bug Fixes**
  * Improved room membership and site resolution during file operations.
  * Updated error handling for membership lookup failures.
* **Documentation**
  * Removed outdated “room not found” errors from upload API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->