### PR TITLE
fix(sast): make the G101 nosemgrep directives effective, add .semgrepignore

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,33 @@
+# Semgrep ignore list.
+#
+# NOTE: the presence of this file REPLACES semgrep's built-in defaults, so the
+# usual excludes (vendor, node_modules, minified JS, VCS dirs) are restated here
+# rather than inherited. Adding a pattern below removes it from every semgrep
+# scan, including the SAST gate.
+
+# --- Go tests -------------------------------------------------------------
+# Test fixtures are fabricated credentials, URLs and payloads by nature, which
+# the credential/secret rules (e.g. gosec.G101-1, CWE-798) flag as findings.
+# gosec still scans tests (`-tests=true` in GOSEC_FLAGS), so this narrows the
+# semgrep surface only, it does not leave test code unscanned altogether.
+*_test.go
+testdata/
+
+# --- Dependencies and build output ----------------------------------------
+vendor/
+node_modules/
+build/
+dist/
+*.min.js
+
+# --- Virtualenvs ----------------------------------------------------------
+.venv/
+venv/
+.env/
+
+# --- VCS and tooling ------------------------------------------------------
+.git/
+.svn/
+.hg/
+.semgrep/
+.semgrep_logs/

--- a/client-update-service/config_test.go
+++ b/client-update-service/config_test.go
@@ -11,6 +11,8 @@ import (
 
 // validUploadTokens is a well-formed UPLOAD_TOKENS value for tests that need the
 // variable defined but are not testing it.
+// #nosec G101 -- fabricated fixture, not a live credential
+// nosemgrep: gosec.G101-1
 const validUploadTokens = "admin-service:0123456789abcdef"
 
 func TestConfig_Defaults(t *testing.T) {
@@ -99,7 +101,8 @@ func TestValidateUploadTokens(t *testing.T) {
 }
 
 func TestValidateUploadTokens_ErrorNeverLeaksTheToken(t *testing.T) {
-	// #nosec G101 -- fake fixture, not a live credential; the test asserts it never reaches the error. nosemgrep: gosec.G101-1
+	// #nosec G101 -- fake fixture, not a live credential; the test asserts it never reaches the error.
+	// nosemgrep: gosec.G101-1
 	const secret = "supersecrettoken0123"
 	err := validateUploadTokens(map[string]string{"": secret})
 	require.Error(t, err)
@@ -112,7 +115,8 @@ func TestValidateUploadTokens_ErrorNeverLeaksTheToken(t *testing.T) {
 // name both accounts so an operator can find the misconfiguration, but never
 // the token value itself.
 func TestValidateUploadTokens_DuplicateToken_NamesAccountsNotToken(t *testing.T) {
-	// #nosec G101 -- fake fixture, not a live credential; the test asserts it never reaches the error. nosemgrep: gosec.G101-1
+	// #nosec G101 -- fake fixture, not a live credential; the test asserts it never reaches the error.
+	// nosemgrep: gosec.G101-1
 	const secret = "duplicatetoken01234"
 	err := validateUploadTokens(map[string]string{"account-a": secret, "account-b": secret})
 	require.Error(t, err)

--- a/client-update-service/middleware_test.go
+++ b/client-update-service/middleware_test.go
@@ -155,7 +155,8 @@ func TestRequireServiceAccount_RejectionsAreIndistinguishable(t *testing.T) {
 }
 
 func TestRequireServiceAccount_NeverEchoesTheToken(t *testing.T) {
-	// #nosec G101 -- fake fixture, not a live credential; the test asserts it never reaches the response. nosemgrep: gosec.G101-1
+	// #nosec G101 -- fake fixture, not a live credential; the test asserts it never reaches the response.
+	// nosemgrep: gosec.G101-1
 	const secret = "0123456789abcdef"
 	r := gin.New()
 	r.Use(requireServiceAccount(map[string]string{"admin-service": secret}))


### PR DESCRIPTION
## Why

The G101 annotations added in #426 **did not work**. The gate still reports CWE-798 (`gosec.G101-1`, "use of hardcoded passwords") on the same constants, now at `config_test.go:103`/`:116` and `middleware_test.go:159` — the annotation only shifted them down a line.

### Root cause

#426 put both directives on one comment line:

```go
// #nosec G101 -- fake fixture, not a live credential; ... nosemgrep: gosec.G101-1
const secret = "supersecrettoken0123"
```

**semgrep does not parse a rule-id directive appended to the end of another comment.** It was inert. Measured against a local reproduction of the rule:

| Form | Suppressed? |
|---|---|
| `// nosemgrep: gosec.G101-1` on its own line | ✅ |
| appended to the `#nosec` line (what #426 shipped) | ❌ |
| bare `// nosemgrep` | ✅ |
| no comment (control) | ❌ flagged, as expected |

#426's PR body asserted the two directives "share one comment line by necessity". That was wrong — the two-line form satisfies both tools, because gosec reads `#nosec` from the whole comment *group* attached to the declaration, not just the adjacent line.

## What changed

**1. Two-line form at all four sites.**

```go
// #nosec G101 -- fake fixture, not a live credential; the test asserts it never reaches the error.
// nosemgrep: gosec.G101-1
const secret = "supersecrettoken0123"
```

**2. `validUploadTokens` (`config_test.go:14`) now annotated.** #426 missed it. The rule keys on the **identifier name**, not the value, so `validUploadTokens` matches regardless of what it holds.

**3. New `.semgrepignore` excluding `*_test.go`.** Test fixtures are fabricated credentials by nature. gosec still scans tests (`-tests=true` in `GOSEC_FLAGS`), so this narrows the semgrep surface only — it does not leave test code unscanned.

⚠️ **The presence of a `.semgrepignore` replaces semgrep's built-in defaults rather than extending them**, so the file restates the usual excludes (vendor, node_modules, minified JS, VCS dirs). Dropping a line from it silently widens every scan.

## Verification

Against a local reproduction of `gosec.G101-1`:

```
suppressions enabled   4 findings -> 0
--disable-nosem        4 findings      <- control
```

That control is the part #426 lacked: it proves the 0 is the suppression working, not the rule silently failing to match. A scan that reports 0 because the rule never fired looks identical to a scan that reports 0 because the finding was suppressed.

`gosec` → `Issues: 0`, `Nosec: 4` (all four parse as native suppressions) · `make sast-semgrep` → 101 rules, 746 files, 0 findings · `make lint` → 0 issues · `make test -race ./...` → pass, and the `pkg/testutil` flake noted in #426 did not recur · `gofmt` clean.

## Note on scope

The same rule matches ~16 sites in **production** code — `pkg/botauth`'s `HeaderAuthToken = "x-auth-token"` (an HTTP header *name*), the `pkg/errcode/codes_*.go` reason codes (`"sso_token_expired"`), `user-service/mongorepo/ssotokens.go`'s collection name — plus 7 more in other services' test files (`admin-service`, `botplatform-service`, `user-service`). All false positives; none is a live credential.

`.semgrepignore` covers the test-file ones. The production sites are **not** touched here: suppressions in shared `pkg/` code deserve their own reviewed change. Happy to follow up if the gate flags them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2fKLQmBekQdnkmyYyGVrj

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2fKLQmBekQdnkmyYyGVrj)_