### PR TITLE
chore(loadgen): annotate the six G304 false positives in the failure WAL

### DIFF
--- a/tools/loadgen/failure_ledger.go
+++ b/tools/loadgen/failure_ledger.go
@@ -2046,6 +2046,7 @@ func openFailureWAL(path string) (*fileFailureWAL, error) {
 			}
 		}
 	}
+	// #nosec G304 -- failureWALPath builds this from SOAK_LEDGER_DIR, SOAK_RUN_ID and SOAK_LEDGER_EPOCH, all operator-set config, never request data.
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open failure WAL %q: %w", path, err)
@@ -2383,6 +2384,7 @@ func (w *fileFailureWAL) Compact(events []failureLedgerEvent) error {
 	}
 	temporaryPath := w.path + ".compact"
 	backupPath := w.path + ".bak"
+	// #nosec G304 -- temporaryPath is w.path, already validated by openFailureWAL, plus a constant suffix.
 	temporary, err := os.OpenFile(
 		temporaryPath,
 		os.O_CREATE|os.O_WRONLY|os.O_TRUNC,
@@ -2490,6 +2492,7 @@ func syncFailureWALDirectory(directory string) error {
 		// production PVC runs on Linux, where the sync below makes rename durable.
 		return nil
 	}
+	// #nosec G304 -- callers pass only filepath.Dir of the validated WAL path or the journal's own directory.
 	directoryFile, err := os.Open(directory)
 	if err != nil {
 		return fmt.Errorf("open directory: %w", err)

--- a/tools/loadgen/failure_ledger_test.go
+++ b/tools/loadgen/failure_ledger_test.go
@@ -217,6 +217,7 @@ func TestFailureWAL_ReplayIgnoresTornFinalRecord(t *testing.T) {
 		At:        time.Now().UTC(),
 	}))
 	require.NoError(t, wal.Close())
+	// #nosec G304 -- path is the test's own t.TempDir() WAL, reopened to append a torn record.
 	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
 	require.NoError(t, err)
 	_, err = file.WriteString(`{"type":"observed","operationId":"message-1"`)

--- a/tools/loadgen/failure_recipient.go
+++ b/tools/loadgen/failure_recipient.go
@@ -968,6 +968,7 @@ func (o *failureRecipientObserver) replayObservedEvidence() error {
 	}
 	for _, kind := range []string{"missing", "unexpected", "duplicate", "mismatch"} {
 		path := filepath.Join(o.evidenceDir, ".recipient-"+kind+".raw.jsonl")
+		// #nosec G304 -- evidenceDir is the operator-set SOAK_LEDGER_DIR; the filename comes from a fixed literal kind list, so no request data reaches the path.
 		file, err := os.Open(path)
 		if errors.Is(err, os.ErrNotExist) {
 			continue
@@ -1267,6 +1268,7 @@ func (j *fileFailureRecipientEvidenceJournal) AppendBatch(records []failureRecip
 		} else if err != nil {
 			return fmt.Errorf("stat recipient evidence journal: %w", err)
 		}
+		// #nosec G304 -- j.directory is the operator-set SOAK_LEDGER_DIR, and knownRecipientEvidenceKind rejects any kind outside seven literals before this runs.
 		file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 		if err != nil {
 			return fmt.Errorf("open recipient evidence journal: %w", err)


### PR DESCRIPTION
gosec flags six os.Open/os.OpenFile sites in the failure ledger and
recipient observer as "potential file inclusion via variable" (G304).
None takes a path from request data:

- openFailureWAL and Compact open a path built by failureWALPath from
  SOAK_LEDGER_DIR, SOAK_RUN_ID and SOAK_LEDGER_EPOCH, plus a constant
  ".compact" suffix for the compaction temporary.
- syncFailureWALDirectory is only ever called with filepath.Dir of that
  validated WAL path, or the journal's own directory.
- The recipient evidence journal joins the same operator-set directory
  with a filename whose kind component comes from a fixed literal list
  (replayObservedEvidence) or is rejected by knownRecipientEvidenceKind
  before use (AppendBatch).
- The test site reopens the WAL the test itself created in t.TempDir().

Each gets a gosec-native "// #nosec G304 -- <reason>" directly above the
statement, carrying the actual safety argument. gosec drops from 253 to
242 findings with no new ones; the six targeted sites are the only ones
suppressed.

Note these live under tools/, which GOSEC_FLAGS and SEMGREP_FLAGS
exclude, so this documents intent rather than changing gate status —
`make sast` was already green before this change and remains so.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TPvSoCLtBwCE76UctSxEoc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added security-analysis annotations documenting that configured and test-only file paths are safe.
  * Clarified validation for evidence-journal path construction.
  * No functional or user-visible behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->