### PR TITLE
Normalize legacy "member" role to "user" on wire and in storage

### DIFF
--- a/broadcast-worker/sonic_wire_test.go
+++ b/broadcast-worker/sonic_wire_test.go
@@ -155,3 +155,18 @@ func TestSonic_EncryptedRawMessageEmbedding(t *testing.T) {
 	require.NoError(t, stdjson.Unmarshal(son, &viaStd))
 	assert.JSONEq(t, string(ev.EncryptedMessage), string(viaStd.EncryptedMessage))
 }
+
+// Role carries a custom MarshalJSON that rewrites the legacy "member" spelling
+// to "user". sonic must honor it, or a subscription forwarded through a
+// sonic-encoded event would leak the pre-cutover value to clients.
+func TestSonic_RoleNormalizationHonored(t *testing.T) {
+	sub := model.Subscription{ID: "s1", RoomID: "r1", Roles: []model.Role{model.RoleMember, model.RoleOwner}}
+
+	sonicOut, err := sonic.Marshal(sub)
+	require.NoError(t, err)
+	stdOut, err := stdjson.Marshal(sub)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(sonicOut), `"roles":["user","owner"]`)
+	assert.Contains(t, string(stdOut), `"roles":["user","owner"]`)
+}

--- a/chat-frontend/src/api/types.ts
+++ b/chat-frontend/src/api/types.ts
@@ -11,8 +11,9 @@
 /** Mirrors model.RoomType. */
 export type RoomType = 'channel' | 'dm' | 'botDM' | 'discussion'
 
-/** Mirrors model.Role. */
-export type Role = 'owner' | 'admin' | 'member'
+/** Mirrors model.Role. The server normalizes the legacy 'member' spelling to
+ *  'user' on every response, so 'member' never arrives on the wire. */
+export type Role = 'owner' | 'admin' | 'user'
 
 /** Mirrors pkg/model.SubscriptionHRInfo — the counterpart's HR record
  *  attached to a DM subscription. All three fields are required strings

--- a/chat-frontend/src/api/updateMemberRole/index.ts
+++ b/chat-frontend/src/api/updateMemberRole/index.ts
@@ -1,7 +1,8 @@
 import { memberRoleUpdate } from '../_transport/subjects'
 import type { Nats, AsyncJobOptions, AsyncJobResult } from '../types'
 
-export type MemberRole = 'owner' | 'member'
+/** 'member' is the legacy spelling of 'user'; the server still accepts it. */
+export type MemberRole = 'owner' | 'user' | 'member'
 
 export interface UpdateMemberRoleArgs {
   roomId: string

--- a/chat-frontend/src/lib/constants.js
+++ b/chat-frontend/src/lib/constants.js
@@ -5,7 +5,10 @@
 //   pkg/model/event.go        (CreateRoomStatusExists)
 
 export const ROLE_OWNER = 'owner'
+// Legacy spelling of the plain-user role; the server normalizes it to 'user' on
+// read and still accepts it as a role-update input.
 export const ROLE_MEMBER = 'member'
+export const ROLE_USER = 'user'
 
 export const HISTORY_MODE_ALL = 'all'
 export const HISTORY_MODE_NONE = 'none'

--- a/data-migration/oplog-collections-transformer/subscriptions.go
+++ b/data-migration/oplog-collections-transformer/subscriptions.go
@@ -306,20 +306,20 @@ func (h *handler) readEvent(ss *sourceSubscription, siteID string) model.InboxEv
 }
 
 // mapSubscriptionRoles maps RocketChat role strings to model.Role: "owner" → RoleOwner; everything
-// else (RC "moderator"/"leader"/"user", which the new model lacks) → RoleMember. Empty source roles
-// (a RocketChat demotion clears the array) map to the [member] floor — the new stack's invariant is
-// roles are never empty (room-service writes ["member"] after a live demotion), and inbox-worker
+// else (RC "moderator"/"leader"/"user", which the new model lacks) → RoleUser. Empty source roles
+// (a RocketChat demotion clears the array) map to the [user] floor — the new stack's invariant is
+// roles are never empty (room-service writes ["user"] after a live demotion), and inbox-worker
 // permanently drops a role_updated with no roles, so an empty mapping would silently lose demotions.
 func mapSubscriptionRoles(roles []string) []model.Role {
 	if len(roles) == 0 {
-		return []model.Role{model.RoleMember}
+		return []model.Role{model.RoleUser}
 	}
 	out := make([]model.Role, 0, len(roles))
 	for _, r := range roles {
 		if r == string(model.RoleOwner) {
 			out = append(out, model.RoleOwner)
 		} else {
-			out = append(out, model.RoleMember)
+			out = append(out, model.RoleUser)
 		}
 	}
 	return out

--- a/data-migration/oplog-collections-transformer/subscriptions_test.go
+++ b/data-migration/oplog-collections-transformer/subscriptions_test.go
@@ -414,7 +414,7 @@ func TestHandleSubscription_RolesCleared_EmitsRoleUpdated(t *testing.T) {
 	// Cleared source roles must land as [member], never empty: inbox-worker permanently drops a
 	// role_updated with no roles (malformed-event guard), and the new-stack floor is [member]
 	// (room-service writes ["member"] after a live demotion — the migration must match).
-	assert.Equal(t, []model.Role{model.RoleMember}, su.Subscription.Roles,
+	assert.Equal(t, []model.Role{model.RoleUser}, su.Subscription.Roles,
 		"a demotion (cleared roles) must map to the [member] floor so it survives inbox-worker")
 }
 

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -973,7 +973,7 @@ it is absent on every other action.
 | `siteId` | string | The room's home site. |
 | `roomType` | string | `"channel"`, `"dm"`, `"botDM"`, or `"discussion"` — **as seen by this subscriber** (see [Effective room type](#effective-room-type)). |
 | `name` | string | Display name per room type (see above). |
-| `roles` | string[] | The user's roles in the room (e.g. `["member"]`, `["owner"]`). |
+| `roles` | string[] | The user's roles in the room (e.g. `["user"]`, `["owner"]`). Subscriptions written before the role cutover store the legacy value `"member"`; the server normalizes it to `"user"` on every response, so clients never see `"member"`. |
 | `joinedAt` | RFC3339 timestamp | When the user joined. |
 | `hasMention` | boolean | Whether the user has an unread mention. Authoritative subscription state maintained by the write path (set when the user is @-mentioned, cleared on read); **not** modified by read enrichment. For a mentionee homed on another site, `broadcast-worker` also relays a cross-site `subscription_mention` event so the badge lands on the site that serves their `subscription.list`. |
 | `hasUnread` | boolean | Whether the room has unread messages — computed at read time by comparing the room's `lastMsgAt` to the subscription's `lastSeenAt` (not persisted). System messages (member added/removed, rename, …) never set it; a member who has never opened the room sees it true whenever the room has any activity to compare against. **Deployment note:** while the `broadcast-worker` fleet is mixed, a room can briefly read as caught-up when it is not (and, before any writer is upgraded, a system message still marks it unread — the pre-change behavior). Drain the old writers before deploying the readers. |
@@ -1423,7 +1423,7 @@ On `added` / `role_updated` / `mute_toggled` / `favorite_toggled` / `opened` the
     "roomId": "01970a4f8c2d7c9aQ",
     "roomType": "channel",
     "siteId": "siteA",
-    "roles": ["member"],
+    "roles": ["user"],
     "joinedAt": "2026-05-06T08:01:23Z",
     "room": {
       "siteId": "siteA",
@@ -1643,7 +1643,7 @@ Platform admins (`model.UserRoleAdmin`, same site) bypass the room owner/member 
 |---|---|---|---|
 | `roomId` | string | no | Server derives from subject; non-matching values are rejected. |
 | `account` | string | yes | The account of the user whose role is being changed. |
-| `newRole` | string | yes | Either `"owner"` (promote) or `"member"` (demote). |
+| `newRole` | string | yes | Either `"owner"` (promote) or `"user"` (demote). The legacy spelling `"member"` is still accepted and treated as `"user"`. |
 
 The `timestamp` field on the Go `UpdateRoleRequest` is server-set — the client should omit it.
 
@@ -1667,7 +1667,7 @@ See [Error envelope](#6-error-envelope-reference). Returned synchronously when v
 
 - Requester is not an owner of the room.
 - Target account is not a member of the room.
-- `newRole` is neither `"owner"` nor `"member"`.
+- `newRole` is neither `"owner"` nor `"user"` (nor the legacy alias `"member"`).
 - Promote attempt when the target is already an owner.
 - Demote attempt when the target is not an owner.
 - Last-owner guard: an owner cannot demote themselves if they are the only owner.
@@ -1693,7 +1693,7 @@ See [Error envelope](#6-error-envelope-reference). Returned synchronously when v
     "roomId": "01970a4f8c2d7c9aQ",
     "roomType": "channel",
     "siteId": "siteA",
-    "roles": ["member", "owner"],
+    "roles": ["user", "owner"],
     "joinedAt": "2026-05-06T08:01:23Z"
   },
   "action": "role_updated",
@@ -1809,7 +1809,7 @@ When the synchronous reply is an error envelope, the request was rejected before
 > - `account` — the admin caller; carried as `byAccount` on the room event and recorded in room-service's log line
 > - `restricted` — whether the room is members-only
 > - `externalAccess` — whether the room is reachable from outside the company network (e.g. internet-side / off-VPN clients). This is a network-access gate, NOT a cross-site federation flag
-> - `ownerAccount` — **required** on the `false → true` transition. Whenever it is supplied together with `restricted: true` — transition or not — that account is promoted to **sole** owner and every other member is reset to plain member, so an already-restricted room can have its owner rotated. Omit it to change the flags without touching anyone's roles
+> - `ownerAccount` — **required** on the `false → true` transition. Whenever it is supplied together with `restricted: true` — transition or not — that account is promoted to **sole** owner and every other member is reset to the plain `user` role, so an already-restricted room can have its owner rotated. Omit it to change the flags without touching anyone's roles
 >
 > room-service does the Mongo writes, emits one `OutboxEvent` on the OUTBOX stream per remote federated site, and replies `{"status":"ok","requestId":"…"}` once the work is committed. `outbox-worker` forwards the cross-site `room_restricted` event (at-least-once) to each remote site's `chat.inbox.{remoteSiteID}.external.room_restricted`. No `AsyncJobResult` is emitted — the reply *is* the result.
 >
@@ -5305,7 +5305,7 @@ The example below shows one record of each type in order (`channel`, `dm`, `botD
       "roomId": "01970a4f8c2d7c9aQ",
       "siteId": "siteA",
       "roomType": "channel",
-      "roles": ["member"],
+      "roles": ["user"],
       "name": "engineering-general",
       "joinedAt": "2026-05-06T08:01:23Z",
       "hasMention": false,
@@ -5344,7 +5344,7 @@ The example below shows one record of each type in order (`channel`, `dm`, `botD
       "roomId": "alice_bob",
       "siteId": "siteA",
       "roomType": "dm",
-      "roles": ["member"],
+      "roles": ["user"],
       "name": "bob",
       "joinedAt": "2026-04-01T09:00:00Z",
       "hasMention": false,
@@ -5365,7 +5365,7 @@ The example below shows one record of each type in order (`channel`, `dm`, `botD
       "roomId": "alice_helper.bot",
       "siteId": "siteA",
       "roomType": "botDM",
-      "roles": ["member"],
+      "roles": ["user"],
       "name": "Helper",
       "isSubscribed": true,
       "joinedAt": "2026-03-15T11:00:00Z",
@@ -5444,7 +5444,7 @@ Same paginated shape as `subscription.list` — `{ "subscriptions": [...], "hasM
       "roomId": "01970a4f8c2d7c9aQ",
       "siteId": "siteA",
       "roomType": "channel",
-      "roles": ["member"],
+      "roles": ["user"],
       "name": "engineering-general",
       "joinedAt": "2026-05-06T08:01:23Z",
       "hasMention": false,
@@ -5516,7 +5516,7 @@ Returns the calling user's DM subscription with the named counterpart. The reply
     "roomId": "alice_bob",
     "siteId": "siteA",
     "roomType": "dm",
-    "roles": ["member"],
+    "roles": ["user"],
     "name": "bob",
     "joinedAt": "2026-04-01T09:00:00Z",
     "alert": false,
@@ -5579,7 +5579,7 @@ Same shape as `subscription.list` — a (here, at most one) list:
       "roomId": "alice_bob",
       "siteId": "siteA",
       "roomType": "dm",
-      "roles": ["member"],
+      "roles": ["user"],
       "name": "bob",
       "joinedAt": "2026-04-01T09:00:00Z",
       "alert": false,
@@ -7778,7 +7778,7 @@ Toggles a channel room's on-duty state. On-duty staff work off the company netwo
 
 **Nothing is displayed.** A restriction change publishes no system message, so no chat entry appears in the room and no notification is sent. Clients are still told: a flat `room_restricted` **room event** carries the new flags on the room's event subject, so open sessions refresh their state without a re-fetch and without rendering anything. No audit row is written — room-service's `processing room.restricted` log line, carrying actor, room, both flags and the designated owner, is the only durable server-side record.
 
-Turning duty **on** designates `ownerAccount` as the room's owner: that account becomes the sole owner and every other member is reset to plain member. Turning duty **off** sends no owner, so roles are left exactly as they are.
+Turning duty **on** designates `ownerAccount` as the room's owner: that account becomes the sole owner and every other member is reset to the plain `user` role. Turning duty **off** sends no owner, so roles are left exactly as they are.
 
 Channel rooms only. The caller must also hold the platform `admin` user role, which room-service verifies independently of the session check.
 
@@ -8946,7 +8946,7 @@ Identical to the NATS reply — see [`subscription.list`](#subscriptionlist) for
       "roomId": "01970a4f8c2d7c9aQ",
       "siteId": "siteA",
       "roomType": "channel",
-      "roles": ["member"],
+      "roles": ["user"],
       "name": "engineering-general",
       "joinedAt": "2026-05-06T08:01:23Z",
       "hasMention": false,

--- a/docs/superpowers/plans/2026-08-30-subscription-role-user.md
+++ b/docs/superpowers/plans/2026-08-30-subscription-role-user.md
@@ -1,0 +1,164 @@
+# Subscription Role `member` → `user` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Status:** Shipped in [hmchangw/newchat#435](https://github.com/hmchangw/newchat/pull/435). All tasks below are checked; the plan is kept as the design record.
+
+**Goal:** New subscriptions are created with the non-owner role `"user"` instead of `"member"`, and every response or event that carries subscription roles hands the client `"user"` even when the stored document still holds the pre-cutover `"member"`.
+
+**Architecture:** Two halves that must not be confused.
+
+1. **Write side** — every producer of a non-owner role writes `model.RoleUser`. That covers subscription *creation* (room-worker channel create / `member.add` / Teams migration, inbox-worker's federated create) and the two *mutation* paths that also stamp a role (`SetOwnerRole` demote, the restrict-transition roles rewrite in both room-service and inbox-worker), plus the oplog migration transformer and the dev seed tools. After this, no writer produces `"member"` again.
+2. **Read side** — documents written before the cutover keep `"member"` in Mongo. Rather than sprinkling a normalizer across every response builder, `model.Role` normalizes at the **JSON boundary**: `MarshalJSON` emits `"user"` for the legacy value, `UnmarshalJSON` accepts either spelling and stores the normalized one. All client traffic (NATS request/reply, HTTP, server→client events) and all cross-site federation payloads are JSON, so one choke point covers them. BSON is deliberately left alone — storage is never rewritten behind a reader's back, and a backfill stays a separate, explicit decision.
+
+`UnmarshalJSON` also buys input compatibility for free: a client still sending `newRole: "member"` to the role-update RPC decodes to `RoleUser`, so the handler compares against one value only.
+
+**Tech stack:** Go 1.25, NATS + JetStream, MongoDB, `go.uber.org/mock`, `stretchr/testify`, `testcontainers-go`.
+
+---
+
+## Conventions
+
+- One task = one commit. Don't squash mid-implementation.
+- Commands: `make test SERVICE=<dir>` (unit, race), `make test-integration SERVICE=<dir>` (Docker), `make lint`, `make sast`.
+- TDD throughout: for the write-side tasks the RED step is flipping the existing assertion to `RoleUser` and watching it fail; for the read-side tasks it is a new test that fails until the normalizer exists.
+- `RoleMember` is **not** deleted. It stays as the named legacy constant so tests, migrations and the normalizer can refer to the stored value by name.
+
+---
+
+## Decisions taken up front
+
+| Question | Decision |
+|----------|----------|
+| Which writers change? | **All of them**, not just creation. Leaving demote/restrict writing `"member"` would keep minting dirty data that the read side has to paper over forever. |
+| Does the role-update RPC still accept `"member"`? | **Yes.** Both spellings are accepted, normalized to `"user"` internally. Rejecting `"member"` would break every client already in the field. |
+| Where does read normalization live? | **Everything returned to a client**, via the JSON boundary — not just user-service's `subscription.list`. One client must never see two spellings depending on which endpoint answered. |
+| Is stored data backfilled? | **No.** Out of scope here. The read normalizer makes a backfill optional rather than urgent; `SetOwnerRole` heals a document opportunistically when a role actually changes. |
+
+---
+
+## File map
+
+| File | What changes |
+|------|--------------|
+| `pkg/model/subscription.go` | `RoleUser` const; `RoleMember` re-documented as legacy; `NormalizeRole` / `NormalizeRoles`; `Role.MarshalJSON` / `Role.UnmarshalJSON` |
+| `pkg/model/model_test.go` | Normalizer + JSON-boundary tests; existing fixtures moved to `RoleUser` |
+| `room-worker/handler.go` | `buildChannelSubs` invitees and `processAddMembers` write `RoleUser` |
+| `room-worker/teamsroomcreate.go` | Migrated members write `[owner, user]` / `[user]` |
+| `inbox-worker/handler.go` | `rolesForType` returns `[user]` |
+| `inbox-worker/main.go` | Restrict-transition `$cond` writes `"user"` in the else branch |
+| `room-service/store_mongo.go` | `SetOwnerRole` maps `"member"`→`"user"` inside the pipeline, both branches; `ApplySubscriptionRestriction` else branch writes `"user"` |
+| `room-service/handler.go` | `updateRole` normalizes `req.NewRole` once, then compares against `RoleOwner`/`RoleUser` |
+| `room-service/helper.go`, `store.go` | Error text and interface doc-comment |
+| `data-migration/oplog-collections-transformer/subscriptions.go` | `mapSubscriptionRoles` maps non-owner → `RoleUser` |
+| `tools/loadgen/*`, `tools/seed-sample-data/fixtures.go` | Seeded roles |
+| `broadcast-worker/sonic_wire_test.go` | Proves sonic honors the custom `Role` marshaler |
+| `user-service/service/subscriptions_test.go` | Legacy-`member`-in-Mongo → `"user"` on the wire, for `subscription.list` and `getByRoomID` |
+| `docs/client-api.md` | `roles` field, `newRole` values, restrict/duty prose, all JSON examples |
+| `chat-frontend/src/api/types.ts`, `api/updateMemberRole/index.ts`, `lib/constants.js` | Type unions widened; `ROLE_USER` added |
+
+---
+
+## Phase 1: Model + normalization
+
+### Task 1: `RoleUser` and the JSON boundary
+
+**Files:** `pkg/model/subscription.go`, `pkg/model/model_test.go`.
+
+- [x] **1.1 Write failing tests** — append to `pkg/model/model_test.go`: `TestNormalizeRole` (table: member→user, user/owner/admin/unknown/empty pass through), `TestNormalizeRoles` (nil→nil, empty→empty, order preserved), `TestNormalizeRoles_DoesNotMutateInput`, `TestRoleJSON_LegacyMemberMarshalsAsUser`, `TestRoleJSON_LegacyMemberUnmarshalsAsUser`, `TestRoleJSON_RejectsNonString`, `TestRoleJSON_OtherRolesRoundTrip`, `TestSubscriptionJSON_LegacyRolesSerializeAsUser`, and `TestSubscriptionBSON_LegacyRolesStoredVerbatim`.
+
+  The BSON test is the guard rail for the whole design: it fails loudly if someone later "helpfully" adds a `bson.Marshaler` and starts rewriting storage.
+
+- [x] **1.2 Verify RED** — `go test ./pkg/model/` fails to build on `undefined: model.RoleUser`.
+
+- [x] **1.3 Implement** — add `RoleUser Role = "user"`, keep `RoleMember Role = "member"` with a comment saying no writer produces it, add `NormalizeRole` / `NormalizeRoles` and the two JSON methods (`UnmarshalJSON` wraps its decode error as `decode role: %w`).
+
+- [x] **1.4 Verify GREEN + fix fallout** — existing round-trip fixtures in `model_test.go` that used `RoleMember` now normalize; move them to `RoleUser` and extend `TestRoleValues` to assert both constants.
+
+### Task 2: Prove sonic honors the marshaler
+
+**Files:** `broadcast-worker/sonic_wire_test.go`.
+
+- [x] **2.1** `TestSonic_RoleNormalizationHonored` — `sonic.Marshal` and `encoding/json.Marshal` of a `Subscription` holding `[member, owner]` must both produce `"roles":["user","owner"]`. The hot-path workers encode with sonic, so a codec that ignored `json.Marshaler` would leak the legacy value on exactly the highest-volume path.
+
+---
+
+## Phase 2: Write paths
+
+Each task is RED-first by flipping the service's existing assertion to `RoleUser` and watching it fail before touching production code.
+
+### Task 3: room-worker
+
+**Files:** `room-worker/handler.go`, `room-worker/teamsroomcreate.go`, and their `_test.go`.
+
+- [x] **3.1** Flip assertions in `handler_test.go` / `teamsroomcreate_test.go` to `RoleUser`; confirm `TestHandler_ProcessAddMembers`, `TestProcessCreateRoom_Channel_BuildsSubsAndMembers`, `TestActorSubscriptionIsPreRead`, and the two Teams tests fail.
+- [x] **3.2** `buildChannelSubs` invitees and `processAddMembers` pass `[]model.Role{model.RoleUser}`; Teams migration passes `[owner, user]` (human) / `[user]` (bot, platform admin). Update the stale "member-only" comment.
+
+### Task 4: inbox-worker
+
+**Files:** `inbox-worker/handler.go`, `inbox-worker/main.go`, `_test.go`, `integration_test.go`.
+
+- [x] **4.1** `rolesForType(channel)` returns `[user]`; the restrict `$cond` else branch writes `string(model.RoleUser)`.
+- [x] **4.2** Integration expectations updated: the federated `member_added` create, and the two restrict-rewrite tests. The "roles untouched" case keeps its `RoleMember` seed — that path must not rewrite anything.
+
+### Task 5: room-service store
+
+**Files:** `room-service/store_mongo.go`, `store.go`, `integration_test.go`.
+
+- [x] **5.1** Update `TestMongoStore_SetOwnerRole_Integration`: it already seeds a legacy `["member"]` document, so the new expectations are promote → `[user, owner]` and demote → `[user]`, i.e. the write heals the document instead of producing `["member","owner"]`.
+- [x] **5.2** `SetOwnerRole` wraps `$roles` in a `$map` that rewrites `"member"`→`"user"` before the promote/demote `$cond`; the demote branch's "ensure the non-owner role survives" check now tests for `RoleUser`.
+- [x] **5.3** `ApplySubscriptionRestriction`'s else branch writes `"user"`; update `TestMongoStore_ApplySubscriptionRestriction_*` accordingly.
+
+### Task 6: migration + dev tools
+
+**Files:** `data-migration/oplog-collections-transformer/subscriptions.go`, `tools/loadgen/*`, `tools/seed-sample-data/fixtures.go`.
+
+- [x] **6.1** `mapSubscriptionRoles`: RC `"owner"` → `RoleOwner`, everything else (and the empty-roles floor) → `RoleUser`.
+- [x] **6.2** Seeded roles in loadgen and seed-sample-data.
+
+---
+
+## Phase 3: Role-update RPC
+
+**Files:** `room-service/handler.go`, `helper.go`, `handler_test.go`.
+
+- [x] **7.1 Write failing tests** — `TestHandler_UpdateRole_DemoteToUser` (canonical `newRole: "user"`) and `TestHandler_UpdateRole_RejectsUnknownRole` (`"admin"`, `"moderator"`, `""`). The pre-existing `TestHandler_UpdateRole_Demote_Success` keeps sending `"member"` and becomes the backward-compatibility test.
+- [x] **7.2 Implement** — `req.NewRole = model.NormalizeRole(req.NewRole)` at the top of `updateRole`, then every comparison is against `RoleOwner` / `RoleUser`. Normalizing in the handler (not relying on `UnmarshalJSON`) keeps direct in-process callers and handler unit tests on the same rules as the wire.
+- [x] **7.3** Error text → `invalid role: must be owner or user`.
+
+Note the assertions on `evt.Subscription.Roles` in the existing tests: the event is marshaled then unmarshaled, so they now read `RoleUser` — that is the wire normalizer being exercised end-to-end, not a fixture change.
+
+---
+
+## Phase 4: Read path coverage
+
+**Files:** `user-service/service/subscriptions_test.go`.
+
+- [x] **8.1** `TestListSubscriptions_LegacyMemberRoleSerializesAsUser` and `TestGetByRoomID_LegacyMemberRoleSerializesAsUser`: the mocked repository returns a subscription holding `RoleMember`, the marshaled response must contain `"roles":["user"]` and must not contain `"member"`.
+- [x] **8.2** Because the implementation landed in Phase 1, verify the RED explicitly: temporarily stub `NormalizeRole` to a no-op, watch both tests fail with `"roles":["member"]` in the diff, restore.
+
+---
+
+## Phase 5: Docs and frontend
+
+- [x] **9.1** `docs/client-api.md`: `roles` field description states the normalization; `newRole` documents `"owner"` / `"user"` and the accepted legacy alias; the restrict and duty-owner prose says "reset to the plain `user` role"; every `"roles": ["member"]` example becomes `["user"]`. (There is no `docs/client-api/` derived-view directory in this repo, so nothing else to keep in sync.)
+- [x] **9.2** Frontend, type-level only: `Role` becomes `'owner' | 'admin' | 'user'`, `MemberRole` keeps `'member'` as the documented legacy input, `ROLE_USER` added alongside `ROLE_MEMBER`. No runtime change — the existing demote call still sends `"member"`, which the server accepts.
+
+---
+
+## Verification
+
+- [x] `go test -race ./...` — clean.
+- [x] `make lint` — 0 issues.
+- [x] `go vet -tags integration ./...` — integration tests compile.
+- [x] `make sast` — gosec PASS. govulncheck and semgrep could not run in the dev container (`vuln.go.dev` blocked by the egress proxy; semgrep not installed) — CI is the gate for those.
+- [x] `pkg/model` coverage: the four new functions at 100%.
+- [ ] `make test-integration` — **not run locally** (no Docker in the container). Integration assertions were updated by inspection for the four write paths that produce roles; CI is the real check.
+
+---
+
+## Follow-ups (deliberately not in this change)
+
+- **Backfill.** A one-off `updateMany` rewriting stored `"member"` → `"user"` would let the JSON normalizer be retired later. Not urgent while the normalizer stands, and it wants its own migration + rollout plan.
+- **Frontend runtime.** `ROLE_MEMBER` is still what `MemberRoster` sends on demote. Switching it to `ROLE_USER` is a one-line change plus its test, worth doing when the frontend is next touched.
+- **Retiring `RoleMember`.** Only after the backfill lands and no producer or stored document can carry the legacy value.

--- a/inbox-worker/handler.go
+++ b/inbox-worker/handler.go
@@ -95,7 +95,7 @@ type InboxStore interface {
 	// in the room, each guarded by its own restrictUpdatedAt so an out-of-order
 	// visibility change cannot regress the flags/roles. When restricted=true and
 	// ownerAccount is non-empty, a $cond pipeline demotes all accounts except
-	// ownerAccount to RoleMember.
+	// ownerAccount to RoleUser.
 	ApplySubscriptionRestriction(ctx context.Context, roomID string, restricted, externalAccess bool, ownerAccount string, restrictUpdatedAt time.Time) error
 	// UpdateUserStatus replicates a cross-site status change onto the local users doc keyed by
 	// account, guarded by statusUpdatedAt (the event publish time): an older/equal high-water
@@ -714,7 +714,7 @@ func (h *Handler) handleSubscriptionSectionMoved(ctx context.Context, evt *model
 
 func rolesForType(t model.RoomType) []model.Role {
 	if t == model.RoomTypeChannel {
-		return []model.Role{model.RoleMember}
+		return []model.Role{model.RoleUser}
 	}
 	return nil
 }

--- a/inbox-worker/handler_test.go
+++ b/inbox-worker/handler_test.go
@@ -799,8 +799,8 @@ func TestHandleEvent_MemberAdded(t *testing.T) {
 	if sub.SiteID != "site-b" {
 		t.Errorf("subscription SiteID = %q, want %q", sub.SiteID, "site-b")
 	}
-	if len(sub.Roles) != 1 || sub.Roles[0] != model.RoleMember {
-		t.Errorf("subscription Roles = %v, want [%q]", sub.Roles, model.RoleMember)
+	if len(sub.Roles) != 1 || sub.Roles[0] != model.RoleUser {
+		t.Errorf("subscription Roles = %v, want [%q]", sub.Roles, model.RoleUser)
 	}
 	if sub.RoomType != model.RoomTypeChannel {
 		t.Errorf("subscription RoomType = %q, want %q", sub.RoomType, model.RoomTypeChannel)
@@ -1202,8 +1202,8 @@ func TestHandleEvent_MemberAdded_EventSourcedFields(t *testing.T) {
 		if !sub.HistorySharedSince.Equal(historyShared) {
 			t.Errorf("sub[%d] HistorySharedSince = %v, want %v", i, *sub.HistorySharedSince, historyShared)
 		}
-		if len(sub.Roles) != 1 || sub.Roles[0] != model.RoleMember {
-			t.Errorf("sub[%d] Roles = %v, want [%q]", i, sub.Roles, model.RoleMember)
+		if len(sub.Roles) != 1 || sub.Roles[0] != model.RoleUser {
+			t.Errorf("sub[%d] Roles = %v, want [%q]", i, sub.Roles, model.RoleUser)
 		}
 	}
 
@@ -1369,7 +1369,7 @@ func TestHandleEvent_MemberRemoved(t *testing.T) {
 	store.mu.Lock()
 	store.subscriptions = append(store.subscriptions, model.Subscription{
 		ID: "s1", User: model.SubscriptionUser{ID: "u2", Account: "bob"},
-		RoomID: "r1", SiteID: "site-a", Roles: []model.Role{model.RoleMember},
+		RoomID: "r1", SiteID: "site-a", Roles: []model.Role{model.RoleUser},
 	})
 	store.mu.Unlock()
 
@@ -1444,8 +1444,8 @@ func TestHandleEvent_MemberRemoved_MultipleAccounts(t *testing.T) {
 	// Pre-populate subscriptions for both accounts
 	store.mu.Lock()
 	store.subscriptions = append(store.subscriptions,
-		model.Subscription{ID: "s1", User: model.SubscriptionUser{ID: "u1", Account: "alice"}, RoomID: "r2", Roles: []model.Role{model.RoleMember}},
-		model.Subscription{ID: "s2", User: model.SubscriptionUser{ID: "u2", Account: "dave"}, RoomID: "r2", Roles: []model.Role{model.RoleMember}},
+		model.Subscription{ID: "s1", User: model.SubscriptionUser{ID: "u1", Account: "alice"}, RoomID: "r2", Roles: []model.Role{model.RoleUser}},
+		model.Subscription{ID: "s2", User: model.SubscriptionUser{ID: "u2", Account: "dave"}, RoomID: "r2", Roles: []model.Role{model.RoleUser}},
 	)
 	store.mu.Unlock()
 
@@ -1864,7 +1864,7 @@ func TestHandleEvent_MemberAdded_PartialUsers_CreatesPresentAndErrors(t *testing
 }
 
 func TestRolesForType(t *testing.T) {
-	assert.Equal(t, []model.Role{model.RoleMember}, rolesForType(model.RoomTypeChannel))
+	assert.Equal(t, []model.Role{model.RoleUser}, rolesForType(model.RoomTypeChannel))
 	assert.Nil(t, rolesForType(model.RoomTypeDM))
 	assert.Nil(t, rolesForType(model.RoomTypeBotDM))
 }
@@ -2009,7 +2009,7 @@ func TestHandleMemberAdded_Channel_BuildsChannelSub(t *testing.T) {
 	require.Len(t, subs, 2)
 	for _, s := range subs {
 		assert.Equal(t, "deal team", s.Name)
-		assert.Equal(t, []model.Role{model.RoleMember}, s.Roles)
+		assert.Equal(t, []model.Role{model.RoleUser}, s.Roles)
 		assert.Equal(t, model.RoomTypeChannel, s.RoomType)
 		assert.Equal(t, "site-A", s.SiteID)
 	}
@@ -2042,7 +2042,7 @@ func TestHandleMemberAdded_EmptyRoomType_DefaultsToChannel(t *testing.T) {
 	subs := store.bulkSubscriptions
 	require.Len(t, subs, 1)
 	assert.Equal(t, model.RoomTypeChannel, subs[0].RoomType, "empty RoomType must default to channel")
-	assert.Equal(t, []model.Role{model.RoleMember}, subs[0].Roles)
+	assert.Equal(t, []model.Role{model.RoleUser}, subs[0].Roles)
 }
 
 func TestHandleMemberAdded_DuplicateKey_IsIdempotent(t *testing.T) {

--- a/inbox-worker/integration_test.go
+++ b/inbox-worker/integration_test.go
@@ -97,8 +97,8 @@ func TestInboxWorker_MemberAdded_Integration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("subscription not found: %v", err)
 	}
-	if len(sub.Roles) == 0 || sub.Roles[0] != model.RoleMember {
-		t.Errorf("Roles = %v, want [member]", sub.Roles)
+	if len(sub.Roles) == 0 || sub.Roles[0] != model.RoleUser {
+		t.Errorf("Roles = %v, want [user]", sub.Roles)
 	}
 
 	// handleMemberAdded does not publish SubscriptionUpdateEvent — room-worker
@@ -1031,8 +1031,8 @@ func TestMongoInboxStore_ApplySubscriptionRestriction(t *testing.T) {
 		subs := loadSubs(t, db)
 		roles := rolesByAccount(subs)
 		assert.Equal(t, []model.Role{model.RoleOwner}, roles["bob"], "bob should be owner")
-		assert.Equal(t, []model.Role{model.RoleMember}, roles["alice"], "alice should be member")
-		assert.Equal(t, []model.Role{model.RoleMember}, roles["carol"], "carol should be member")
+		assert.Equal(t, []model.Role{model.RoleUser}, roles["alice"], "alice should be demoted to user")
+		assert.Equal(t, []model.Role{model.RoleUser}, roles["carol"], "carol should be demoted to user")
 		for _, sub := range subs {
 			assert.True(t, sub.Restricted, "sub %s Restricted should be true", sub.ID)
 			assert.False(t, sub.ExternalAccess, "sub %s ExternalAccess should be false", sub.ID)
@@ -1170,10 +1170,10 @@ func TestIntegration_HandleRoomVisibilityChanged(t *testing.T) {
 		assert.False(t, sub.ExternalAccess, "sub %s ExternalAccess should be false", sub.ID)
 	}
 
-	// bob promoted to owner, alice demoted to member, carol stays member.
+	// bob promoted to owner, alice and carol reset to the plain user role.
 	assert.Equal(t, []model.Role{model.RoleOwner}, rolesByAccount["bob"], "bob should be owner")
-	assert.Equal(t, []model.Role{model.RoleMember}, rolesByAccount["alice"], "alice should be member")
-	assert.Equal(t, []model.Role{model.RoleMember}, rolesByAccount["carol"], "carol should be member")
+	assert.Equal(t, []model.Role{model.RoleUser}, rolesByAccount["alice"], "alice should be user")
+	assert.Equal(t, []model.Role{model.RoleUser}, rolesByAccount["carol"], "carol should be user")
 }
 
 // Regression: a federated upsert for an existing (threadRoomId, userAccount)
@@ -1471,7 +1471,7 @@ func TestInbox_ApplySubscriptionRestriction_NewerApplies(t *testing.T) {
 	assert.True(t, alice.Restricted)
 	assert.True(t, bob.Restricted)
 	assert.Equal(t, []model.Role{model.RoleOwner}, bob.Roles)
-	assert.Equal(t, []model.Role{model.RoleMember}, alice.Roles)
+	assert.Equal(t, []model.Role{model.RoleUser}, alice.Roles)
 }
 
 func TestInbox_UpsertRoom_OlderUpdatedAtSkipped(t *testing.T) {

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -664,7 +664,7 @@ func (s *mongoInboxStore) ApplySubscriptionRestriction(ctx context.Context, room
 				"roles": bson.M{"$cond": bson.M{
 					"if":   bson.M{"$eq": bson.A{"$u.account", ownerAccount}},
 					"then": bson.A{string(model.RoleOwner)},
-					"else": bson.A{string(model.RoleMember)},
+					"else": bson.A{string(model.RoleUser)},
 				}},
 			}}},
 		}

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -813,7 +813,7 @@ func TestSubscriptionJSON(t *testing.T) {
 			RoomID:   "r1",
 			RoomType: model.RoomTypeChannel,
 			SiteID:   "site-a",
-			Roles:    []model.Role{model.RoleMember},
+			Roles:    []model.Role{model.RoleUser},
 			JoinedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		}
 
@@ -842,7 +842,7 @@ func TestSubscriptionJSON_AlertAlwaysPresent(t *testing.T) {
 		RoomID:   "r1",
 		RoomType: model.RoomTypeChannel,
 		SiteID:   "site-a",
-		Roles:    []model.Role{model.RoleMember},
+		Roles:    []model.Role{model.RoleUser},
 		JoinedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 	}
 
@@ -882,7 +882,7 @@ func TestDMSubscriptionJSON_EmbeddedFlattensWithHRInfo(t *testing.T) {
 			User:     model.SubscriptionUser{ID: "u-alice", Account: "alice"},
 			RoomID:   "r-dm-1",
 			SiteID:   "site-A",
-			Roles:    []model.Role{model.RoleMember},
+			Roles:    []model.Role{model.RoleUser},
 			Name:     "bob-dm",
 			RoomType: model.RoomTypeDM,
 			JoinedAt: time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC),
@@ -921,7 +921,7 @@ func TestDMSubscriptionJSON_HRInfoOmittedWhenNil(t *testing.T) {
 			User:     model.SubscriptionUser{ID: "u-alice", Account: "alice"},
 			RoomID:   "r-c-1",
 			SiteID:   "site-A",
-			Roles:    []model.Role{model.RoleMember},
+			Roles:    []model.Role{model.RoleUser},
 			RoomType: model.RoomTypeChannel,
 			JoinedAt: time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC),
 		},
@@ -1008,6 +1008,9 @@ func TestRoleValues(t *testing.T) {
 	}
 	if model.RoleAdmin != "admin" {
 		t.Errorf("RoleAdmin = %q", model.RoleAdmin)
+	}
+	if model.RoleUser != "user" {
+		t.Errorf("RoleUser = %q", model.RoleUser)
 	}
 	if model.RoleMember != "member" {
 		t.Errorf("RoleMember = %q", model.RoleMember)
@@ -1324,7 +1327,7 @@ func TestSubscriptionUpdateEventJSON(t *testing.T) {
 			User:     model.SubscriptionUser{ID: "u1", Account: "alice"},
 			RoomID:   "r1",
 			SiteID:   "site-a",
-			Roles:    []model.Role{model.RoleMember},
+			Roles:    []model.Role{model.RoleUser},
 			JoinedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		},
 		Action:    "added",
@@ -4223,7 +4226,7 @@ func TestSubscriptionJSON_RestrictedAndExternalAccess(t *testing.T) {
 	s := model.Subscription{
 		ID: "s1", User: model.SubscriptionUser{ID: "u1", Account: "alice"},
 		RoomID: "r1", SiteID: "site-a",
-		Roles: []model.Role{model.RoleMember}, Name: "x", RoomType: model.RoomTypeChannel,
+		Roles: []model.Role{model.RoleUser}, Name: "x", RoomType: model.RoomTypeChannel,
 		JoinedAt:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		Restricted: true, ExternalAccess: true,
 	}
@@ -4867,7 +4870,7 @@ func TestSubscriptionEnrichmentFields_RoundTrip(t *testing.T) {
 		User:     model.SubscriptionUser{ID: "u1", Account: "alice"},
 		RoomID:   "r1",
 		SiteID:   "site-a",
-		Roles:    []model.Role{model.RoleMember},
+		Roles:    []model.Role{model.RoleUser},
 		JoinedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		Room: &model.SubscriptionRoom{
 			SiteID:    "site-a",
@@ -4891,7 +4894,7 @@ func TestSubscriptionBaseMetadata_RoundTrip(t *testing.T) {
 		User:              model.SubscriptionUser{ID: "u1", Account: "alice"},
 		RoomID:            "r1",
 		SiteID:            "site-a",
-		Roles:             []model.Role{model.RoleMember},
+		Roles:             []model.Role{model.RoleUser},
 		RoomType:          model.RoomTypeChannel,
 		JoinedAt:          time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		HasUnread:         true,
@@ -5367,7 +5370,7 @@ func TestSubscriptionJSON_ThreadUnreadRoundTrip(t *testing.T) {
 	s := model.Subscription{
 		ID: "s1", User: model.SubscriptionUser{ID: "u1", Account: "alice"},
 		RoomID: "r1", RoomType: model.RoomTypeChannel, SiteID: "site-a",
-		Roles: []model.Role{model.RoleMember}, JoinedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Roles: []model.Role{model.RoleUser}, JoinedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		ThreadUnread: []string{"p1", "p2"},
 	}
 	roundTrip(t, &s, &model.Subscription{})
@@ -5643,4 +5646,105 @@ func TestRoomAndSubscriptionTypesDisagreeOnABotDM(t *testing.T) {
 	assert.Equal(t, model.RoomTypeBotDM, model.DMRoomType("alice", "weather.bot"))
 	assert.Equal(t, model.RoomTypeBotDM, model.SubscriptionRoomType("weather.bot")) // alice's row
 	assert.Equal(t, model.RoomTypeDM, model.SubscriptionRoomType("alice"))          // the bot's row
+}
+
+func TestNormalizeRole(t *testing.T) {
+	tests := []struct {
+		name string
+		in   model.Role
+		want model.Role
+	}{
+		{"legacy member becomes user", model.RoleMember, model.RoleUser},
+		{"user passes through", model.RoleUser, model.RoleUser},
+		{"owner passes through", model.RoleOwner, model.RoleOwner},
+		{"admin passes through", model.RoleAdmin, model.RoleAdmin},
+		{"unknown role passes through", model.Role("auditor"), model.Role("auditor")},
+		{"empty passes through", model.Role(""), model.Role("")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, model.NormalizeRole(tt.in))
+		})
+	}
+}
+
+func TestNormalizeRoles(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []model.Role
+		want []model.Role
+	}{
+		{"nil stays nil", nil, nil},
+		{"empty stays empty", []model.Role{}, []model.Role{}},
+		{"legacy member rewritten", []model.Role{model.RoleMember}, []model.Role{model.RoleUser}},
+		{
+			"mixed slice keeps order",
+			[]model.Role{model.RoleOwner, model.RoleMember, model.RoleAdmin},
+			[]model.Role{model.RoleOwner, model.RoleUser, model.RoleAdmin},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, model.NormalizeRoles(tt.in))
+		})
+	}
+}
+
+func TestNormalizeRoles_DoesNotMutateInput(t *testing.T) {
+	in := []model.Role{model.RoleMember}
+	_ = model.NormalizeRoles(in)
+	assert.Equal(t, []model.Role{model.RoleMember}, in)
+}
+
+func TestRoleJSON_LegacyMemberMarshalsAsUser(t *testing.T) {
+	b, err := json.Marshal(model.RoleMember)
+	require.NoError(t, err)
+	assert.JSONEq(t, `"user"`, string(b))
+}
+
+func TestRoleJSON_LegacyMemberUnmarshalsAsUser(t *testing.T) {
+	var r model.Role
+	require.NoError(t, json.Unmarshal([]byte(`"member"`), &r))
+	assert.Equal(t, model.RoleUser, r)
+}
+
+func TestRoleJSON_RejectsNonString(t *testing.T) {
+	var r model.Role
+	err := json.Unmarshal([]byte(`{"role":"owner"}`), &r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode role")
+}
+
+func TestRoleJSON_OtherRolesRoundTrip(t *testing.T) {
+	for _, role := range []model.Role{model.RoleOwner, model.RoleAdmin, model.RoleUser} {
+		b, err := json.Marshal(role)
+		require.NoError(t, err)
+		var got model.Role
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.Equal(t, role, got)
+	}
+}
+
+func TestSubscriptionJSON_LegacyRolesSerializeAsUser(t *testing.T) {
+	sub := model.Subscription{
+		ID:     "s1",
+		RoomID: "r1",
+		Roles:  []model.Role{model.RoleMember, model.RoleOwner},
+	}
+	b, err := json.Marshal(sub)
+	require.NoError(t, err)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(b, &got))
+	assert.Equal(t, []any{"user", "owner"}, got["roles"])
+}
+
+func TestSubscriptionBSON_LegacyRolesStoredVerbatim(t *testing.T) {
+	sub := model.Subscription{ID: "s1", RoomID: "r1", Roles: []model.Role{model.RoleMember}}
+	b, err := bson.Marshal(sub)
+	require.NoError(t, err)
+	var got struct {
+		Roles []string `bson:"roles"`
+	}
+	require.NoError(t, bson.Unmarshal(b, &got))
+	assert.Equal(t, []string{"member"}, got.Roles, "storage must not be rewritten by the JSON normalizer")
 }

--- a/pkg/model/subscription.go
+++ b/pkg/model/subscription.go
@@ -1,21 +1,71 @@
 package model
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 )
 
 // ErrSubscriptionNotFound is returned when a subscription lookup finds no matching document.
 var ErrSubscriptionNotFound = errors.New("subscription not found")
 
+// Role is a per-room role carried on a subscription. Values cross the wire
+// normalized: the legacy "member" spelling is rewritten to RoleUser by
+// MarshalJSON/UnmarshalJSON, so clients only ever see "user" and may send
+// either. BSON is deliberately left alone — normalizing storage would rewrite
+// documents behind the reader's back.
 type Role string
 
 const (
 	RoleOwner Role = "owner"
 	// RoleAdmin is recognized by message-gatekeeper's large-room bypass but not yet assignable via role-update RPC.
-	RoleAdmin  Role = "admin"
+	RoleAdmin Role = "admin"
+	// RoleUser is the non-owner role every subscription is created with.
+	RoleUser Role = "user"
+	// RoleMember is the pre-cutover spelling of RoleUser. No writer produces it
+	// any more; it survives on stored subscriptions, so reads normalize it.
 	RoleMember Role = "member"
 )
+
+// NormalizeRole maps the legacy RoleMember spelling onto RoleUser; every other
+// role, known or not, passes through unchanged.
+func NormalizeRole(r Role) Role {
+	if r == RoleMember {
+		return RoleUser
+	}
+	return r
+}
+
+// NormalizeRoles returns roles with every legacy RoleMember rewritten to
+// RoleUser, preserving order. nil in, nil out; the input is never mutated.
+func NormalizeRoles(roles []Role) []Role {
+	if roles == nil {
+		return nil
+	}
+	out := make([]Role, len(roles))
+	for i, r := range roles {
+		out[i] = NormalizeRole(r)
+	}
+	return out
+}
+
+// MarshalJSON emits the normalized role so no client ever sees the legacy
+// "member" left on subscriptions written before the cutover.
+func (r Role) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(NormalizeRole(r)))
+}
+
+// UnmarshalJSON accepts either spelling and stores the normalized one, so a
+// client still sending "member" needs no special case downstream.
+func (r *Role) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("decode role: %w", err)
+	}
+	*r = NormalizeRole(Role(s))
+	return nil
+}
 
 type SubscriptionUser struct {
 	ID      string `json:"id" bson:"_id"`

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -744,10 +744,13 @@ func (h *Handler) updateRole(c *natsrouter.Context, req model.UpdateRoleRequest)
 		return nil, errRoomIDMismatch
 	}
 	req.RoomID = roomID
-	if req.NewRole != model.RoleOwner && req.NewRole != model.RoleMember {
+	// Clients may still send the legacy "member" spelling; normalize once so the
+	// rest of the handler compares against RoleUser only.
+	req.NewRole = model.NormalizeRole(req.NewRole)
+	if req.NewRole != model.RoleOwner && req.NewRole != model.RoleUser {
 		return nil, errInvalidRole
 	}
-	// Promote-only guard: demoting a legacy bot-owner back to member stays
+	// Promote-only guard: demoting a legacy bot-owner back to a plain user stays
 	// allowed so operators can repair such rooms.
 	if req.NewRole == model.RoleOwner && (model.IsBot(req.Account) || model.IsPlatformAdminAccount(req.Account)) {
 		return nil, errBotCannotBeOwner
@@ -778,7 +781,7 @@ func (h *Handler) updateRole(c *natsrouter.Context, req model.UpdateRoleRequest)
 	if req.NewRole == model.RoleOwner && hasRole(target.Subscription.Roles, model.RoleOwner) {
 		return nil, errAlreadyOwner
 	}
-	if req.NewRole == model.RoleMember && !hasRole(target.Subscription.Roles, model.RoleOwner) {
+	if req.NewRole == model.RoleUser && !hasRole(target.Subscription.Roles, model.RoleOwner) {
 		return nil, errNotOwner
 	}
 	// Reject only provably org-only members; subscription-only members (both flags false) are promotable.
@@ -786,7 +789,7 @@ func (h *Handler) updateRole(c *natsrouter.Context, req model.UpdateRoleRequest)
 		return nil, errPromoteRequiresIndividual
 	}
 	// Last-owner guard only needed on self-demotion; rule #5 ensures requester is an owner.
-	if req.NewRole == model.RoleMember && req.Account == requester {
+	if req.NewRole == model.RoleUser && req.Account == requester {
 		count, err := h.store.CountOwners(ctx, roomID)
 		if err != nil {
 			return nil, fmt.Errorf("count owners: %w", err)

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -91,7 +91,7 @@ func TestHandler_UpdateRole_Success(t *testing.T) {
 	var evt model.SubscriptionUpdateEvent
 	require.NoError(t, json.Unmarshal(coreData, &evt))
 	assert.Equal(t, "role_updated", evt.Action)
-	assert.Equal(t, []model.Role{model.RoleMember, model.RoleOwner}, evt.Subscription.Roles)
+	assert.Equal(t, []model.Role{model.RoleUser, model.RoleOwner}, evt.Subscription.Roles)
 	assert.Equal(t, "general", evt.RoomName, "role_updated carries the channel name")
 }
 
@@ -293,7 +293,53 @@ func TestHandler_UpdateRole_Demote_Success(t *testing.T) {
 	var evt model.SubscriptionUpdateEvent
 	require.NoError(t, json.Unmarshal(coreData, &evt))
 	assert.Equal(t, "role_updated", evt.Action)
-	assert.Equal(t, []model.Role{model.RoleMember}, evt.Subscription.Roles)
+	assert.Equal(t, []model.Role{model.RoleUser}, evt.Subscription.Roles)
+}
+
+// TestHandler_UpdateRole_DemoteToUser is the canonical demote: newRole "user".
+// The legacy "member" spelling is covered by TestHandler_UpdateRole_Demote_Success.
+func TestHandler_UpdateRole_DemoteToUser(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockRoomStore(ctrl)
+
+	store.EXPECT().GetRoom(gomock.Any(), "r1").
+		Return(&model.Room{ID: "r1", Name: "general", Type: model.RoomTypeChannel}, nil)
+	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
+		Return(&model.Subscription{User: model.SubscriptionUser{ID: "u1", Account: "alice"}, RoomID: "r1", Roles: []model.Role{model.RoleUser, model.RoleOwner}}, nil)
+	store.EXPECT().GetSubscriptionWithMembership(gomock.Any(), "r1", "bob").
+		Return(&SubscriptionWithMembership{
+			Subscription:            &model.Subscription{User: model.SubscriptionUser{ID: "u2", Account: "bob"}, RoomID: "r1", Roles: []model.Role{model.RoleUser, model.RoleOwner}},
+			HasIndividualMembership: true,
+		}, nil)
+	store.EXPECT().SetOwnerRole(gomock.Any(), "r1", "bob", false, gomock.Any()).
+		Return(&model.Subscription{User: model.SubscriptionUser{ID: "u2", Account: "bob"}, RoomID: "r1", Roles: []model.Role{model.RoleUser}}, nil)
+	store.EXPECT().GetUserSiteID(gomock.Any(), "bob").Return("site-a", nil)
+
+	var coreData []byte
+	h := &Handler{store: store, siteID: "site-a", maxRoomSize: 1000,
+		publishCore: func(_ context.Context, _ string, data []byte) error { coreData = data; return nil },
+	}
+
+	req := model.UpdateRoleRequest{Account: "bob", NewRole: model.RoleUser}
+
+	resp, err := h.updateRole(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), req)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp.Status)
+	require.NotNil(t, coreData)
+	var evt model.SubscriptionUpdateEvent
+	require.NoError(t, json.Unmarshal(coreData, &evt))
+	assert.Equal(t, []model.Role{model.RoleUser}, evt.Subscription.Roles)
+}
+
+func TestHandler_UpdateRole_RejectsUnknownRole(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := &Handler{store: NewMockRoomStore(ctrl), siteID: "site-a", maxRoomSize: 1000}
+
+	for _, role := range []model.Role{"admin", "moderator", ""} {
+		req := model.UpdateRoleRequest{Account: "bob", NewRole: role}
+		_, err := h.updateRole(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}), req)
+		require.ErrorIs(t, err, errInvalidRole, "role %q must be rejected", role)
+	}
 }
 
 func TestHandler_UpdateRole_CrossSiteInbox(t *testing.T) {
@@ -346,7 +392,7 @@ func TestHandler_UpdateRole_CrossSiteInbox(t *testing.T) {
 	assert.Equal(t, "site-b", inboxEnv.DestSiteID)
 	var evt model.SubscriptionUpdateEvent
 	require.NoError(t, json.Unmarshal(inboxEnv.Payload, &evt))
-	assert.Equal(t, []model.Role{model.RoleMember, model.RoleOwner}, evt.Subscription.Roles)
+	assert.Equal(t, []model.Role{model.RoleUser, model.RoleOwner}, evt.Subscription.Roles)
 	// The origin doc's rolesUpdatedAt and the published event timestamp must be the
 	// same instant so remote replicas guard against one high-water mark.
 	assert.False(t, roleTs.IsZero())

--- a/room-service/helper.go
+++ b/room-service/helper.go
@@ -22,7 +22,7 @@ import (
 // reason matching, and construct fresh *Error values via the named
 // constructors when a caller needs a wrapped message or extra metadata.
 var (
-	errInvalidRole           = errcode.BadRequest("invalid role: must be owner or member")
+	errInvalidRole           = errcode.BadRequest("invalid role: must be owner or user")
 	errOnlyOwners            = errcode.Forbidden("only owners can update roles", errcode.WithReason(errcode.RoomNotOwner))
 	errOnlyOwnersCanRemove   = errcode.Forbidden("only owners can remove members", errcode.WithReason(errcode.RoomNotOwner))
 	errOnlyOwnersCanAddToRes = errcode.Forbidden("only owners can add members to a restricted room", errcode.WithReason(errcode.RoomNotOwner))
@@ -50,7 +50,7 @@ var (
 	errEmptyCreateRequest = errcode.BadRequest("request must include at least one of users, orgs, channels, or name")
 	errBotInChannel       = errcode.BadRequest("bots cannot be added to a channel", errcode.WithReason(errcode.RoomBotInChannel))
 	errBotNotAvailable    = errcode.NotFound("bot not available", errcode.WithReason(errcode.RoomBotNotAvailable))
-	// Bots hold plain member roles only.
+	// Bots hold the plain user role only.
 	errBotCannotBeOwner    = errcode.BadRequest("bots cannot be room owners", errcode.WithReason(errcode.RoomBotCannotBeOwner))
 	errChannelNameRequired = errcode.BadRequest("channel name is required")
 	errChannelNameTooLong  = errcode.BadRequest("channel name must be at most 100 characters")

--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -3351,7 +3351,7 @@ func TestMongoStore_ApplySubscriptionRestriction_NamedOwnerRewritesRoles(t *test
 	for _, account := range []string{"alice", "carol", "dave"} {
 		got, err := store.GetSubscription(ctx, account, "r1")
 		require.NoError(t, err)
-		assert.Equal(t, []model.Role{model.RoleMember}, got.Roles, "%s: flattened to member by the rewrite", account)
+		assert.Equal(t, []model.Role{model.RoleUser}, got.Roles, "%s: flattened to user by the rewrite", account)
 	}
 }
 
@@ -3400,16 +3400,17 @@ func TestMongoStore_SetOwnerRole_Integration(t *testing.T) {
 	}
 	mustInsertSub(t, db, sub)
 
-	// Promote: owner appended, member retained, order preserved.
+	// Promote: owner appended, the legacy "member" already on the doc rewritten to
+	// "user", order preserved.
 	roleTs := time.Now().UTC()
 	got, err := store.SetOwnerRole(ctx, "r1", "alice", true, roleTs)
 	require.NoError(t, err)
 	require.NotNil(t, got)
-	assert.Equal(t, []model.Role{model.RoleMember, model.RoleOwner}, got.Roles)
+	assert.Equal(t, []model.Role{model.RoleUser, model.RoleOwner}, got.Roles)
 
 	persisted, err := store.GetSubscription(ctx, "alice", "r1")
 	require.NoError(t, err)
-	assert.Equal(t, []model.Role{model.RoleMember, model.RoleOwner}, persisted.Roles)
+	assert.Equal(t, []model.Role{model.RoleUser, model.RoleOwner}, persisted.Roles)
 	// rolesUpdatedAt is stamped at the supplied instant (BSON ms precision) so the
 	// origin doc shares the federated event's high-water mark.
 	assert.Equal(t, roleTs.UnixMilli(), subTimeField(t, db, "r1", "alice", "rolesUpdatedAt").UnixMilli())
@@ -3417,20 +3418,20 @@ func TestMongoStore_SetOwnerRole_Integration(t *testing.T) {
 	// Promote again is idempotent — no duplicate owner.
 	got, err = store.SetOwnerRole(ctx, "r1", "alice", true, time.Now().UTC())
 	require.NoError(t, err)
-	assert.Equal(t, []model.Role{model.RoleMember, model.RoleOwner}, got.Roles)
+	assert.Equal(t, []model.Role{model.RoleUser, model.RoleOwner}, got.Roles)
 
-	// Demote: owner removed, member retained.
+	// Demote: owner removed, user retained.
 	got, err = store.SetOwnerRole(ctx, "r1", "alice", false, time.Now().UTC())
 	require.NoError(t, err)
-	assert.Equal(t, []model.Role{model.RoleMember}, got.Roles)
+	assert.Equal(t, []model.Role{model.RoleUser}, got.Roles)
 
 	// Demote again is idempotent.
 	got, err = store.SetOwnerRole(ctx, "r1", "alice", false, time.Now().UTC())
 	require.NoError(t, err)
-	assert.Equal(t, []model.Role{model.RoleMember}, got.Roles)
+	assert.Equal(t, []model.Role{model.RoleUser}, got.Roles)
 
-	// Channel-creator parity: an owner seeded WITHOUT member (roles ["owner"], as
-	// processCreateRoom assigns the creator) must demote to ["member"], never [].
+	// Channel-creator parity: an owner seeded WITHOUT a second role (roles ["owner"],
+	// as processCreateRoom assigns the creator) must demote to ["user"], never [].
 	creator := &model.Subscription{
 		ID:       idgen.GenerateUUIDv7(),
 		User:     model.SubscriptionUser{ID: "u2", Account: "carol"},
@@ -3444,7 +3445,7 @@ func TestMongoStore_SetOwnerRole_Integration(t *testing.T) {
 
 	got, err = store.SetOwnerRole(ctx, "r1", "carol", false, time.Now().UTC())
 	require.NoError(t, err)
-	assert.Equal(t, []model.Role{model.RoleMember}, got.Roles, "demoting an owner-only creator must yield [member], never []")
+	assert.Equal(t, []model.Role{model.RoleUser}, got.Roles, "demoting an owner-only creator must yield [user], never []")
 
 	// Missing subscription → ErrSubscriptionNotFound (wrapped).
 	gotNil, err := store.SetOwnerRole(ctx, "missing", "alice", true, time.Now().UTC())

--- a/room-service/store.go
+++ b/room-service/store.go
@@ -169,7 +169,8 @@ type RoomStore interface {
 	OpenSubscription(ctx context.Context, roomID, account string) (*model.Subscription, error)
 	// SetOwnerRole atomically grants (makeOwner=true) or revokes (makeOwner=false)
 	// the owner role on the subscription keyed by (roomID, account) via a single
-	// FindOneAndUpdate. Other roles (e.g. member) are retained. Stamps rolesUpdatedAt
+	// FindOneAndUpdate. Other roles are retained, with the legacy "member" spelling
+	// rewritten to "user" on the way through. Stamps rolesUpdatedAt
 	// so the origin doc carries the same high-water mark the federated event publishes
 	// (inbox-worker guards remote applies against it). Returns the updated
 	// subscription, or model.ErrSubscriptionNotFound (wrapped) when no match.

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -1319,11 +1319,20 @@ func (s *MongoStore) OpenSubscription(ctx context.Context, roomID, account strin
 
 // SetOwnerRole atomically grants or revokes the owner role, returning the updated
 // subscription. Promote appends "owner" only when absent; demote filters "owner"
-// out. Any other roles (e.g. "member") are preserved and array order stays stable.
+// out. Any other roles are preserved and array order stays stable — except the
+// legacy "member" spelling, which both branches rewrite to "user" so the write
+// heals the doc instead of leaving a mix behind.
 // rolesUpdatedAt is stamped from the same instant the caller publishes as the event
 // timestamp, keeping the origin doc and every federated replica on one high-water mark.
 func (s *MongoStore) SetOwnerRole(ctx context.Context, roomID, account string, makeOwner bool, rolesUpdatedAt time.Time) (*model.Subscription, error) {
-	currentRoles := bson.M{"$ifNull": bson.A{"$roles", bson.A{}}}
+	currentRoles := bson.M{"$map": bson.M{
+		"input": bson.M{"$ifNull": bson.A{"$roles", bson.A{}}},
+		"in": bson.M{"$cond": bson.M{
+			"if":   bson.M{"$eq": bson.A{"$$this", string(model.RoleMember)}},
+			"then": string(model.RoleUser),
+			"else": "$$this",
+		}},
+	}}
 	var rolesExpr bson.M
 	if makeOwner {
 		rolesExpr = bson.M{"$cond": bson.M{
@@ -1332,17 +1341,17 @@ func (s *MongoStore) SetOwnerRole(ctx context.Context, roomID, account string, m
 			"else": bson.M{"$concatArrays": bson.A{currentRoles, bson.A{model.RoleOwner}}},
 		}}
 	} else {
-		// Remove owner, then ensure member is still present. Mirrors the worker's
-		// old "AddRole(member) before RemoveRole(owner)" guard so a channel creator
-		// (seeded roles ["owner"] only) demotes to ["member"], never an empty array.
+		// Remove owner, then ensure user is still present. Mirrors the worker's
+		// old "AddRole before RemoveRole(owner)" guard so a channel creator
+		// (seeded roles ["owner"] only) demotes to ["user"], never an empty array.
 		withoutOwner := bson.M{"$filter": bson.M{
 			"input": currentRoles,
 			"cond":  bson.M{"$ne": bson.A{"$$this", model.RoleOwner}},
 		}}
 		rolesExpr = bson.M{"$cond": bson.M{
-			"if":   bson.M{"$in": bson.A{model.RoleMember, withoutOwner}},
+			"if":   bson.M{"$in": bson.A{model.RoleUser, withoutOwner}},
 			"then": withoutOwner,
-			"else": bson.M{"$concatArrays": bson.A{withoutOwner, bson.A{model.RoleMember}}},
+			"else": bson.M{"$concatArrays": bson.A{withoutOwner, bson.A{model.RoleUser}}},
 		}}
 	}
 	return s.findOneAndUpdateSub(ctx, roomID, account, "set owner role", bson.M{
@@ -1956,7 +1965,7 @@ func (s *MongoStore) ApplySubscriptionRestriction(ctx context.Context, roomID st
 				"roles": bson.M{"$cond": bson.M{
 					"if":   bson.M{"$eq": bson.A{"$u.account", ownerAccount}},
 					"then": bson.A{string(model.RoleOwner)},
-					"else": bson.A{string(model.RoleMember)},
+					"else": bson.A{string(model.RoleUser)},
 				}},
 			}}},
 		}

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -980,7 +980,7 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 		user := userMap[c.Account]
 		// newSub stamps u.isBot from the account; room is the channel fetched by
 		// req.RoomID so RoomType/SiteID/Name/ID all match the prior inline build.
-		sub := newSub(idgen.GenerateUUIDv7(), &user, room, []model.Role{model.RoleMember}, room.Name, false, acceptedAt)
+		sub := newSub(idgen.GenerateUUIDv7(), &user, room, []model.Role{model.RoleUser}, room.Name, false, acceptedAt)
 		// Pre-resolved above the candidate debug log; shared pointer is safe —
 		// nothing mutates through it after this point.
 		sub.HistorySharedSince = historySharedSinceAt
@@ -1373,7 +1373,7 @@ func buildChannelSubs(requester *model.User, users []model.User, room *model.Roo
 	subs = append(subs, preRead(newSub(idgen.GenerateUUIDv7(), requester, room, []model.Role{model.RoleOwner}, room.Name, false, acceptedAt), acceptedAt))
 	for i := range users {
 		u := &users[i]
-		subs = append(subs, newSub(idgen.GenerateUUIDv7(), u, room, []model.Role{model.RoleMember}, room.Name, false, acceptedAt))
+		subs = append(subs, newSub(idgen.GenerateUUIDv7(), u, room, []model.Role{model.RoleUser}, room.Name, false, acceptedAt))
 	}
 	return subs
 }

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -219,7 +219,7 @@ func TestHandler_ProcessRemoveMember_SelfLeave_DualMembership(t *testing.T) {
 			ChineseName: "愛",
 		},
 		HasOrgMembership: true,
-		Roles:            []model.Role{model.RoleMember},
+		Roles:            []model.Role{model.RoleUser},
 	}
 
 	// Only DeleteRoomMember(individual) called — no subscription delete, no events,
@@ -340,7 +340,7 @@ func TestHandler_ProcessRemoveMember_DualMembership_OwnerDemoted(t *testing.T) {
 			userResult := &UserWithMembership{
 				User:             model.User{ID: "u1", Account: account, SiteID: siteID, EngName: "Alice", ChineseName: "愛"},
 				HasOrgMembership: true,
-				Roles:            []model.Role{model.RoleOwner, model.RoleMember},
+				Roles:            []model.Role{model.RoleOwner, model.RoleUser},
 			}
 
 			gomock.InOrder(
@@ -500,7 +500,7 @@ func TestHandler_ProcessAddMembers(t *testing.T) {
 			for _, s := range subs {
 				assert.Equal(t, "site-a", s.SiteID)
 				assert.Equal(t, model.RoomTypeChannel, s.RoomType)
-				assert.Equal(t, []model.Role{model.RoleMember}, s.Roles)
+				assert.Equal(t, []model.Role{model.RoleUser}, s.Roles)
 				require.NotNil(t, s.HistorySharedSince)
 				assert.Equal(t, s.JoinedAt, *s.HistorySharedSince)
 			}
@@ -1843,7 +1843,7 @@ func TestHandler_ProcessRemoveIndividual_DeleteRoomMemberError(t *testing.T) {
 		GetUserWithMembership(gomock.Any(), "r1", "alice").
 		Return(&UserWithMembership{
 			User:  model.User{ID: "u1", Account: "alice", EngName: "Alice", ChineseName: "愛"},
-			Roles: []model.Role{model.RoleMember},
+			Roles: []model.Role{model.RoleUser},
 		}, nil)
 	store.EXPECT().
 		DeleteRoomMember(gomock.Any(), "r1", model.RoomMemberIndividual, "u1").
@@ -1866,7 +1866,7 @@ func TestHandler_ProcessRemoveIndividual_DualDemoteError(t *testing.T) {
 		Return(&UserWithMembership{
 			User:             model.User{ID: "u1", Account: "alice", EngName: "Alice", ChineseName: "愛"},
 			HasOrgMembership: true,
-			Roles:            []model.Role{model.RoleOwner, model.RoleMember},
+			Roles:            []model.Role{model.RoleOwner, model.RoleUser},
 		}, nil)
 	store.EXPECT().
 		DeleteRoomMember(gomock.Any(), "r1", model.RoomMemberIndividual, "u1").
@@ -1891,7 +1891,7 @@ func TestHandler_ProcessRemoveIndividual_DeleteSubscriptionError(t *testing.T) {
 		GetUserWithMembership(gomock.Any(), "r1", "alice").
 		Return(&UserWithMembership{
 			User:  model.User{ID: "u1", Account: "alice", EngName: "Alice", ChineseName: "愛"},
-			Roles: []model.Role{model.RoleMember},
+			Roles: []model.Role{model.RoleUser},
 		}, nil)
 	store.EXPECT().
 		DeleteRoomMember(gomock.Any(), "r1", model.RoomMemberIndividual, "u1").
@@ -1917,7 +1917,7 @@ func TestHandler_ProcessRemoveIndividual_ReconcileMemberCountsError(t *testing.T
 		GetUserWithMembership(gomock.Any(), "r1", "alice").
 		Return(&UserWithMembership{
 			User:  model.User{ID: "u1", Account: "alice", EngName: "Alice", ChineseName: "愛"},
-			Roles: []model.Role{model.RoleMember},
+			Roles: []model.Role{model.RoleUser},
 		}, nil)
 	store.EXPECT().
 		DeleteRoomMember(gomock.Any(), "r1", model.RoomMemberIndividual, "u1").
@@ -3503,7 +3503,7 @@ func TestProcessCreateRoom_Channel_BuildsSubsAndMembers(t *testing.T) {
 	assert.Equal(t, "Deal Team", ownerSub.Name)
 
 	memberSub := capturedSubs[1]
-	assert.Equal(t, []model.Role{model.RoleMember}, memberSub.Roles)
+	assert.Equal(t, []model.Role{model.RoleUser}, memberSub.Roles)
 
 	// 4 room_members: 2 individuals (bob+carol) + 1 org + 1 owner (alice)
 	require.Len(t, capturedMembers, 4)
@@ -5927,7 +5927,7 @@ func TestHandler_ProcessRemoveIndividual_SelfLeave_Content(t *testing.T) {
 		Return(&UserWithMembership{
 			User:             model.User{ID: "u_b", Account: "bob", SiteID: "site-a", EngName: "Bob", ChineseName: "鮑"},
 			HasOrgMembership: false,
-			Roles:            []model.Role{model.RoleMember},
+			Roles:            []model.Role{model.RoleUser},
 		}, nil)
 	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u_b").Return(nil)
 	store.EXPECT().DeleteSubscription(gomock.Any(), roomID, "bob").Return(int64(1), nil)
@@ -7597,7 +7597,7 @@ func TestActorSubscriptionIsPreRead(t *testing.T) {
 		assert.True(t, subs[0].LastSeenAt.Equal(at))
 		assert.Equal(t, []model.Role{model.RoleOwner}, subs[0].Roles)
 		assert.Nil(t, subs[1].LastSeenAt, "invited member starts unread")
-		assert.Equal(t, []model.Role{model.RoleMember}, subs[1].Roles)
+		assert.Equal(t, []model.Role{model.RoleUser}, subs[1].Roles)
 	})
 }
 

--- a/room-worker/teamsroomcreate.go
+++ b/room-worker/teamsroomcreate.go
@@ -129,9 +129,9 @@ func (h *Handler) reconcileTeamsRoom(ctx context.Context, chat *model.TeamsRoomC
 		memberSite[member.Account] = user.SiteID
 		// Human members get owner+member so they can admin the migrated room; bot
 		// and platform-admin accounts stay member-only.
-		roles := []model.Role{model.RoleOwner, model.RoleMember}
+		roles := []model.Role{model.RoleOwner, model.RoleUser}
 		if model.IsBot(member.Account) || model.IsPlatformAdminAccount(member.Account) {
-			roles = []model.Role{model.RoleMember}
+			roles = []model.Role{model.RoleUser}
 		}
 		// JoinedAt = the chat's creation time, a meaningful historical value, not the
 		// migration run time (acceptedAt). Teams exposes no per-member add time; this is

--- a/room-worker/teamsroomcreate_test.go
+++ b/room-worker/teamsroomcreate_test.go
@@ -94,7 +94,7 @@ func TestProcessTeamsRoomCreate_AddOnly(t *testing.T) {
 			for _, s := range subs {
 				assert.Equal(t, idgen.DeterministicID([]byte("chat1")), s.RoomID)
 				assert.Equal(t, model.RoomTypeChannel, s.RoomType)
-				assert.Equal(t, []model.Role{model.RoleOwner, model.RoleMember}, s.Roles)
+				assert.Equal(t, []model.Role{model.RoleOwner, model.RoleUser}, s.Roles)
 				assert.Equal(t, model.OriginTeams, s.Origin)
 			}
 			return nil
@@ -138,7 +138,7 @@ func TestProcessTeamsRoomCreate_BotMemberStaysMemberOnly(t *testing.T) {
 	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, subs []*model.Subscription) error {
 			require.Len(t, subs, 1)
-			assert.Equal(t, []model.Role{model.RoleMember}, subs[0].Roles)
+			assert.Equal(t, []model.Role{model.RoleUser}, subs[0].Roles)
 			return nil
 		})
 	store.EXPECT().ReconcileMemberCounts(gomock.Any(), gomock.Any()).Return(nil)

--- a/tools/loadgen/history.go
+++ b/tools/loadgen/history.go
@@ -157,7 +157,7 @@ func BuildHistoryFixtures(p *HistoryPreset, seed int64, siteID string, now time.
 		members := make([]model.User, size)
 		for j, idx := range perm {
 			members[j] = users[idx]
-			roles := []model.Role{model.RoleMember}
+			roles := []model.Role{model.RoleUser}
 			if j == 0 {
 				roles = []model.Role{model.RoleOwner}
 			}

--- a/tools/loadgen/members.go
+++ b/tools/loadgen/members.go
@@ -118,7 +118,7 @@ func BuildMembersFixtures(p *MembersPreset, seed int64, siteID string) (Fixtures
 		candidateSlice := chosen[p.BaselineSize:need]
 
 		for j, idx := range memberSlice {
-			roles := []model.Role{model.RoleMember}
+			roles := []model.Role{model.RoleUser}
 			if j == 0 {
 				roles = []model.Role{model.RoleOwner}
 			}

--- a/tools/loadgen/preset.go
+++ b/tools/loadgen/preset.go
@@ -175,7 +175,7 @@ func BuildFixtures(p *Preset, seed int64, siteID string) Fixtures {
 				User:     model.SubscriptionUser{ID: members[j].ID, Account: members[j].Account},
 				RoomID:   rooms[i].ID,
 				SiteID:   siteID,
-				Roles:    []model.Role{model.RoleMember},
+				Roles:    []model.Role{model.RoleUser},
 				JoinedAt: now,
 			})
 		}
@@ -310,7 +310,7 @@ func buildBandedFixtures(p *Preset, r *rand.Rand, users []model.User, siteID str
 					ID:     fmt.Sprintf("sub-%s-%s", roomID, uA.ID),
 					User:   model.SubscriptionUser{ID: uA.ID, Account: uA.Account},
 					RoomID: roomID, SiteID: siteID,
-					Roles:    []model.Role{model.RoleMember},
+					Roles:    []model.Role{model.RoleUser},
 					JoinedAt: now,
 				})
 				if uA.ID != uB.ID { // skip duplicate sub on unfixable self-loop
@@ -318,7 +318,7 @@ func buildBandedFixtures(p *Preset, r *rand.Rand, users []model.User, siteID str
 						ID:     fmt.Sprintf("sub-%s-%s", roomID, uB.ID),
 						User:   model.SubscriptionUser{ID: uB.ID, Account: uB.Account},
 						RoomID: roomID, SiteID: siteID,
-						Roles:    []model.Role{model.RoleMember},
+						Roles:    []model.Role{model.RoleUser},
 						JoinedAt: now,
 					})
 				}
@@ -385,7 +385,7 @@ func buildBandedFixtures(p *Preset, r *rand.Rand, users []model.User, siteID str
 				ID:     fmt.Sprintf("sub-%s-%s", roomID, u.ID),
 				User:   model.SubscriptionUser{ID: u.ID, Account: u.Account},
 				RoomID: roomID, SiteID: siteID,
-				Roles:    []model.Role{model.RoleMember},
+				Roles:    []model.Role{model.RoleUser},
 				JoinedAt: now,
 			})
 		}

--- a/tools/loadgen/seed_botroom.go
+++ b/tools/loadgen/seed_botroom.go
@@ -117,7 +117,7 @@ func BuildBotRoomFixtures(p *BotRoomPreset, seed int64, siteID string) (Fixtures
 					User:     model.SubscriptionUser{ID: m.ID, Account: m.Account},
 					RoomID:   roomID,
 					SiteID:   siteID,
-					Roles:    []model.Role{model.RoleMember},
+					Roles:    []model.Role{model.RoleUser},
 					JoinedAt: now,
 				})
 			}

--- a/tools/loadgen/soak_roomstate_test.go
+++ b/tools/loadgen/soak_roomstate_test.go
@@ -37,7 +37,7 @@ func soakRoomStateTestTopology(candidates int) *soakTopology {
 			},
 			{
 				RoomID: "room-1", User: model.SubscriptionUser{ID: users[1].ID, Account: users[1].Account},
-				Roles: []model.Role{model.RoleMember}, RoomType: model.RoomTypeChannel,
+				Roles: []model.Role{model.RoleUser}, RoomType: model.RoomTypeChannel,
 			},
 		},
 	}
@@ -390,7 +390,7 @@ func TestSoakRoomStatePool_RejectsInvalidConstruction(t *testing.T) {
 
 func TestSoakRoomStatePool_SkipsRoomsWithoutOwner(t *testing.T) {
 	topology := soakRoomStateTestTopology(3)
-	topology.Subscriptions[0].Roles = []model.Role{model.RoleMember}
+	topology.Subscriptions[0].Roles = []model.Role{model.RoleUser}
 
 	_, err := newSoakRoomStatePool(topology, 8, NewMetrics(), rand.New(rand.NewSource(5)))
 

--- a/tools/loadgen/soak_seed_integration_test.go
+++ b/tools/loadgen/soak_seed_integration_test.go
@@ -626,7 +626,7 @@ func insertRoomServiceCreatedRoom(
 
 	documents := make([]any, 0, len(accounts))
 	for i, account := range accounts {
-		roles := []model.Role{model.RoleMember}
+		roles := []model.Role{model.RoleUser}
 		if i == 0 {
 			roles = []model.Role{model.RoleOwner}
 		}

--- a/tools/loadgen/soak_topology.go
+++ b/tools/loadgen/soak_topology.go
@@ -330,7 +330,7 @@ func buildSoakSubscriptions(
 ) []model.Subscription {
 	subscriptions := make([]model.Subscription, len(members))
 	for i := range members {
-		roles := []model.Role{model.RoleMember}
+		roles := []model.Role{model.RoleUser}
 		name := room.Name
 		if room.Type == model.RoomTypeChannel && i == 0 {
 			roles = []model.Role{model.RoleOwner}

--- a/tools/loadgen/soak_topology_test.go
+++ b/tools/loadgen/soak_topology_test.go
@@ -100,7 +100,7 @@ func TestBuildSoakTopology_ChannelDMSplitMembershipAndRoles(t *testing.T) {
 			assert.False(t, duplicate)
 			dmIDs[room.ID] = struct{}{}
 			for _, sub := range subs {
-				assert.Equal(t, []model.Role{model.RoleMember}, sub.Roles)
+				assert.Equal(t, []model.Role{model.RoleUser}, sub.Roles)
 			}
 		default:
 			t.Fatalf("unexpected room type %q", room.Type)

--- a/tools/seed-sample-data/fixtures.go
+++ b/tools/seed-sample-data/fixtures.go
@@ -440,7 +440,7 @@ var roomOwners = map[string]string{
 // is a member of. DM subscriptions are emitted as plain Subscription rows
 // with Name set to the counterpart's account (matches how dm rooms are
 // labeled on the client). Roles are ["owner"] for the seeded owner of
-// each channel and ["member"] otherwise; DM members get ["member"].
+// each channel and ["user"] otherwise; DM members get ["user"].
 func BuildSubscriptions() []model.Subscription {
 	users := usersByAccount()
 	rooms := BuildRooms()
@@ -449,7 +449,7 @@ func BuildSubscriptions() []model.Subscription {
 		r := &rooms[ri]
 		for i, account := range r.Accounts {
 			u := users[account]
-			roles := []model.Role{model.RoleMember}
+			roles := []model.Role{model.RoleUser}
 			if owner, ok := roomOwners[r.ID]; ok && owner == account {
 				roles = []model.Role{model.RoleOwner}
 			}

--- a/user-service/service/subscriptions_test.go
+++ b/user-service/service/subscriptions_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -1521,4 +1522,37 @@ func TestDistinctListNames_SplitsAppRoomsFromDMs(t *testing.T) {
 
 	assert.Equal(t, []string{"weather.bot"}, bots, "only real apps drive the app lookup")
 	assert.Equal(t, []string{"alice", "p_admin_ops", "bob"}, dms, "every DM drives the HR lookup")
+}
+
+// Subscriptions written before the role cutover still store the legacy "member"
+// spelling; every user-service read must hand the client "user" instead.
+func TestListSubscriptions_LegacyMemberRoleSerializesAsUser(t *testing.T) {
+	svc, subs, _, _, rooms, _, _ := newSvc(t)
+	subs.EXPECT().AggregateSubscriptions(gomock.Any(), "alice", "current", false, gomock.Any(), gomock.Any()).
+		Return(mongoutil.OffsetPageHasMore[model.EnrichedSubscription]{Data: []model.EnrichedSubscription{
+			{Subscription: model.Subscription{ID: "s1", RoomID: "r1", RoomType: model.RoomTypeChannel, Roles: []model.Role{model.RoleMember}}},
+		}}, nil)
+	rooms.EXPECT().GetRoomsInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	resp, err := svc.ListSubscriptions(ctx("alice", "site-a"), models.SubscriptionListRequest{Type: "current"})
+	require.NoError(t, err)
+	body, err := json.Marshal(resp)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"roles":["user"]`)
+	assert.NotContains(t, string(body), `"member"`)
+}
+
+func TestGetByRoomID_LegacyMemberRoleSerializesAsUser(t *testing.T) {
+	svc, subs, _, _, rooms, _, _ := newSvc(t)
+	subs.EXPECT().GetSubscriptionByRoomID(gomock.Any(), "alice", "r1").
+		Return(&model.EnrichedSubscription{Subscription: model.Subscription{
+			ID: "s1", RoomID: "r1", RoomType: model.RoomTypeChannel, Roles: []model.Role{model.RoleMember, model.RoleOwner},
+		}}, nil)
+	rooms.EXPECT().GetRoomsInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	resp, err := svc.GetByRoomID(ctx("alice", "site-a"), models.GetByRoomIDRequest{RoomID: "r1"})
+	require.NoError(t, err)
+	body, err := json.Marshal(resp)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"roles":["user","owner"]`)
 }


### PR DESCRIPTION
## Summary
Introduces a new `RoleUser` constant and normalizes the legacy `RoleMember` spelling across the system. The server now rewrites `"member"` to `"user"` on every JSON response (via custom `MarshalJSON`/`UnmarshalJSON`), accepts both spellings on input, and heals stored subscriptions by rewriting legacy roles during role updates. Clients never see `"member"` on the wire, and the frontend type definitions are updated accordingly.

## Key Changes

- **New role constant**: Added `RoleUser = "user"` as the canonical non-owner role; `RoleMember = "member"` retained for backward compatibility with stored documents.

- **Wire normalization**: Implemented `Role.MarshalJSON()` and `Role.UnmarshalJSON()` to normalize `"member"` ↔ `"user"` bidirectionally:
  - Outbound: legacy `"member"` on stored subscriptions serializes as `"user"` so clients never see the old spelling
  - Inbound: clients sending either `"member"` or `"user"` are normalized to `RoleUser` before processing
  - BSON (storage) is deliberately left alone to avoid rewriting documents behind the reader's back

- **Helper functions**: Added `NormalizeRole()` and `NormalizeRoles()` to map legacy roles; input slices are never mutated.

- **Storage healing**: Updated `SetOwnerRole()` in `room-service/store_mongo.go` to rewrite legacy `"member"` to `"user"` during promotion/demotion, so the write path gradually heals pre-cutover documents.

- **Role validation**: Updated `room-service/handler.go` to normalize the incoming `NewRole` once, then validate against `RoleUser` and `RoleOwner` only; rejects unknown roles (`"admin"`, `"moderator"`, etc.).

- **Test coverage**: Added comprehensive tests for role normalization, JSON marshaling/unmarshaling, and storage round-trips; updated all existing test fixtures to expect `RoleUser` instead of `RoleMember`.

- **Frontend alignment**: Updated TypeScript type definitions to reflect `'user'` as the canonical role; added comments explaining the legacy `'member'` spelling is normalized server-side.

- **Documentation**: Updated `docs/client-api.md` to clarify that subscriptions written before the cutover store `"member"` but the server normalizes it to `"user"` on every response; updated role-update API docs to accept both spellings.

## Implementation Details

- Role normalization is applied at the JSON boundary (request/response), not in the domain model, so internal code can still detect and handle legacy values if needed.
- The `sonic` JSON encoder honors custom `MarshalJSON` implementations, so subscriptions forwarded through sonic-encoded events are correctly normalized.
- All test fixtures and integration tests updated to use `RoleUser` as the expected value, ensuring consistent behavior across the system.
- The migration is backward-compatible: existing stored subscriptions with `"member"` continue to work and are gradually healed as they are updated.

https://claude.ai/code/session_016mYyxoKxDRYs4TPPJDVWYq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `user` as the canonical role for standard room members.
  - Role responses now normalize legacy `member` values to `user`.
  - Role updates support demotion to `user`, while continuing to accept `member` for compatibility.
  - Non-owner members are consistently assigned the `user` role across room, channel, migration, and seeded data workflows.

- **Bug Fixes**
  - Improved role validation and handling for unknown role values.
  - Updated API documentation and examples to reflect the normalized role names.

- **Tests**
  - Added coverage for role normalization, serialization, compatibility, and role-update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->