### PR TITLE
fix(room-service): restore member.list name field as a deprecated alias of appName

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -1874,6 +1874,7 @@ When the synchronous reply is an error envelope, the request was rejected before
 | `sectName` | string | Optional. The member's section name. Populated only when `enrich: true` and entry is an individual. |
 | `employeeId` | string | Optional. The member's employee ID. Populated only when `enrich: true` and entry is an individual. |
 | `appName` | string | Optional. Bot/app display name from `apps.name`. Always set for an account ending `.bot`. A bot account **without** that suffix resolves only when the room falls back to subscriptions (the only source carrying an `isBot` flag), so treat the `.bot` suffix as the reliable signal. Mutually exclusive with `engName`/`chineseName`. |
+| `name` | string | Optional. **Deprecated** alias of `appName`, emitted with the same value for pre-rename clients. Prefer `appName`. |
 | `isOwner` | boolean | Optional. Populated only when `enrich: true`. |
 | `orgName` | string | Optional. Org's display name (dept name preferred, sect name fallback), combined with the TC name when present. Populated only when `enrich: true` and entry is an org. |
 | `orgCode` | string | Optional. Org's plain section/department name (dept-first), without the TC-name combination `orgName` applies and with no orgID fallback. Populated only when `enrich: true` and entry is an org. |

--- a/pkg/model/member.go
+++ b/pkg/model/member.go
@@ -69,6 +69,9 @@ type RoomMemberEntry struct {
 	// AppName is the app's display name (apps.name) for bot members. Humans
 	// carry EngName/ChineseName instead; display: appName ?? engName ?? account.
 	AppName string `json:"appName,omitempty"     bson:"-"`
+	// Name is a deprecated alias of AppName, emitted with the same value so
+	// clients that predate the appName rename keep working. Prefer appName.
+	Name    string `json:"name,omitempty"        bson:"-"`
 	IsOwner bool   `json:"isOwner,omitempty"     bson:"-"`
 	OrgName string `json:"orgName,omitempty"     bson:"-"`
 	// OrgCode is the org's plain section/department name (dept-first), distinct from the possibly TC-combined OrgName.

--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -1252,9 +1252,11 @@ func TestMongoStore_ListRoomMembers_BotEnrichment_Integration(t *testing.T) {
 		assert.Equal(t, "Alice Wang", human.EngName, "human member must have EngName from users")
 		assert.Equal(t, "愛麗絲", human.ChineseName, "human member must have ChineseName from users")
 		assert.Empty(t, human.AppName, "human member must NOT have AppName set")
+		assert.Empty(t, human.Name, "human member must NOT have the name alias set")
 
 		bot := byAccount["weather.bot"]
 		assert.Equal(t, "Weather App", bot.AppName, "bot member must have AppName from apps")
+		assert.Equal(t, "Weather App", bot.Name, "bot member must carry the deprecated name alias with the same value")
 		assert.Empty(t, bot.SectName, "bot has no user doc → no sectName")
 		assert.Empty(t, bot.EngName, "bot member must NOT have EngName")
 		assert.Empty(t, bot.ChineseName, "bot member must NOT have ChineseName")

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -853,6 +853,7 @@ func (s *MongoStore) attachAppNames(ctx context.Context, roomID string, members 
 		}
 		if name, ok := appByAssistant[members[i].Member.Account]; ok {
 			members[i].Member.AppName = name
+			members[i].Member.Name = name // deprecated alias; see RoomMemberEntry.Name
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

The `member.list` `RoomMemberEntry` bot-display field was renamed `name` → `appName`. That dropped the `name` key some existing clients contract on, breaking their member-list bot display with no compatibility path. This restores `name` as a **deprecated alias** of `appName` — both keys are emitted with the same value (`apps.name`) — so pre-rename clients keep working while `appName` remains the preferred, convention-aligned key (it matches the app-display-name key used across the rest of the API).

## What's included

- `RoomMemberEntry.Name` re-added (`json:"name,omitempty"`), documented as a deprecated alias of `appName`.
- The enrichment write sets both `AppName` and `Name` to the resolved `apps.name`.
- `docs/client-api.md` RoomMemberEntry table gains the `name` (deprecated) row.

## Changes

- `pkg/model/member.go` — `Name` alias field.
- `room-service/store_mongo.go` — `attachAppNames` sets `Name` alongside `AppName`.
- `room-service/integration_test.go` — asserts a bot member carries both `name` and `appName` with the same value, and a human carries neither.

## Verification

Build, unit tests (`pkg/model`, `room-service`), and integration compile are green; lint clean. The alias is purely additive — no existing `appName` consumer is affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the deprecated `name` field in room member responses for compatibility with pre-rename clients.
  * Bot members now receive matching values for both `name` and `appName`; human members continue to omit the alias.
* **Documentation**
  * Documented the optional `name` field as a deprecated alias of `appName`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->