### PR TITLE
feat(user-service): serve subscription.count over HTTP

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -87,7 +87,7 @@ paths.
 12. [Client Update Service](#12-client-update-service)
     - [POST /api/v1/version](#post-apiv1version) · [GET /api/v1/version/:fileName](#get-apiv1versionfilename)
 13. [User Service HTTP API](#13-user-service-http-api)
-    - [13.1 Authentication](#131-authentication) · [13.2 GET /api/v1/subscriptions](#132-http--get-apiv1subscriptions)
+    - [13.1 Authentication](#131-authentication) · [13.2 GET /api/v1/subscriptions](#132-http--get-apiv1subscriptions) · [13.3 GET /api/v1/subscriptions/count](#133-http--get-apiv1subscriptionscount)
 
 ---
 
@@ -5614,6 +5614,8 @@ Same shape as `subscription.list` — a (here, at most one) list:
 
 Returns the count of active subscriptions, optionally filtered to unread rooms only.
 
+> Also available over HTTP with no payload ceiling: [GET /api/v1/subscriptions/count](#133-http--get-apiv1subscriptionscount).
+
 **Active set:** an active subscription is a non-muted, **open** DM or channel, **or** a botDM that is non-muted, open **and** subscribed (`isSubscribed: true`). Excluded from the count: unsubscribed botDMs, muted rooms of any type, and rooms the user has closed (`open: false`) — closed rooms are hidden from `subscription.list`, so counting them would put the badge and the list permanently out of step. A missing `open` field (legacy documents) counts as open. Membership in the active set is decided from subscription state alone — no room document is consulted, and no room name is filtered. That holds for the whole request when `unread` is absent or `false`; `unread: true` then narrows the set using each room's activity (the local `$lookup` baseline, and `GetRoomsMeta` for cross-site rows) — see **Unread count behavior** below.
 
 ##### Request body
@@ -9012,3 +9014,32 @@ X-Request-ID: 01970a4f-8c2d-7c9a-abcd-e0123456789f
 ```
 
 **Client contract:** honour `Retry-After` and retry with jitter. A 429 means *this pod* is momentarily full, not that the request was wrong — an immediate uniform retry from every client re-creates the burst that caused it. Do not treat it as a fatal error or force re-login.
+
+### 13.3 HTTP — GET /api/v1/subscriptions/count
+
+The HTTP form of [`subscription.count`](#subscriptioncount). Same active-set semantics, same unread-count behavior and staleness bounds, same `{count}` response.
+
+#### Query parameters
+
+| Parameter | Type | Required | Notes |
+|---|---|---|---|
+| `unread` | boolean | no | When `true`, returns the number of active rooms with unread messages or unread followed threads (degrades per-site for cross-site rooms, as with the NATS form). Omitted or `false` ⇒ the total active-subscription count. |
+
+```http
+GET /api/v1/subscriptions/count?unread=true HTTP/1.1
+ssoToken: <oidc-access-token>
+```
+
+#### Success response
+
+Identical to the NATS reply — see [`subscription.count`](#subscriptioncount).
+
+| Field | Type | Notes |
+|---|---|---|
+| `count` | number | The subscription count (total or unread depending on `unread`). |
+
+```json
+{ "count": 5 }
+```
+
+The response is marked `Cache-Control: private, no-store` (per-account data behind a non-standard credential header).

--- a/user-service/handler.go
+++ b/user-service/handler.go
@@ -62,3 +62,31 @@ func (h *handler) ListSubscriptions(c *gin.Context) {
 	c.Header("Cache-Control", "private, no-store")
 	c.JSON(http.StatusOK, resp)
 }
+
+// countQuery mirrors models.CountRequest. Unread is a pointer so an omitted
+// param stays distinct from false (both mean total, but the service owns that).
+type countQuery struct {
+	Unread *bool `form:"unread"`
+}
+
+// CountSubscriptions serves GET /api/v1/subscriptions/count for the
+// authenticated caller. unread=true returns the unread-badge count; omitted or
+// false returns the total active-subscription count. Shares the service logic
+// with the NATS handler.
+func (h *handler) CountSubscriptions(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	var q countQuery
+	if err := c.ShouldBindQuery(&q); err != nil {
+		errhttp.Write(ctx, c, errcode.BadRequest("invalid query parameters", errcode.WithCause(err)))
+		return
+	}
+
+	resp, err := h.subs.CountSubscriptionsFor(ctx, accountFromContext(c), models.CountRequest{Unread: q.Unread})
+	if err != nil {
+		errhttp.Write(ctx, c, err)
+		return
+	}
+	c.Header("Cache-Control", "private, no-store")
+	c.JSON(http.StatusOK, resp)
+}

--- a/user-service/handler_test.go
+++ b/user-service/handler_test.go
@@ -34,7 +34,9 @@ func handlerEngine(t *testing.T, lister subscriptionLister, account string) *gin
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	r.Use(func(c *gin.Context) { c.Set(ctxAccountKey, account) })
-	r.GET("/api/v1/subscriptions", newHandler(lister, testDefaultLimit, testMaxLimit).ListSubscriptions)
+	h := newHandler(lister, testDefaultLimit, testMaxLimit)
+	r.GET("/api/v1/subscriptions", h.ListSubscriptions)
+	r.GET("/api/v1/subscriptions/count", h.CountSubscriptions)
 	return r
 }
 
@@ -235,4 +237,32 @@ func gunzipBody(t *testing.T, w *httptest.ResponseRecorder) string {
 	out, err := io.ReadAll(zr)
 	require.NoError(t, err)
 	return string(out)
+}
+
+// TestHandler_CountBindsUnread pins the unread query → CountRequest mapping
+// (omitted stays nil, distinct from false) and delegates to the shared count.
+func TestHandler_CountBindsUnread(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  models.CountRequest
+	}{
+		{"unread true", "unread=true", models.CountRequest{Unread: boolPtr(true)}},
+		{"unread false", "unread=false", models.CountRequest{Unread: boolPtr(false)}},
+		{"unread omitted stays nil", "", models.CountRequest{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lister := NewMocksubscriptionLister(gomock.NewController(t))
+			lister.EXPECT().
+				CountSubscriptionsFor(gomock.Any(), "alice", tc.want).
+				Return(&models.CountResponse{Count: 3}, nil)
+
+			w := httptest.NewRecorder()
+			handlerEngine(t, lister, "alice").ServeHTTP(w,
+				httptest.NewRequest(http.MethodGet, "/api/v1/subscriptions/count?"+tc.query, nil))
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.JSONEq(t, `{"count":3}`, w.Body.String())
+		})
+	}
 }

--- a/user-service/mock_store_test.go
+++ b/user-service/mock_store_test.go
@@ -41,6 +41,21 @@ func (m *MocksubscriptionLister) EXPECT() *MocksubscriptionListerMockRecorder {
 	return m.recorder
 }
 
+// CountSubscriptionsFor mocks base method.
+func (m *MocksubscriptionLister) CountSubscriptionsFor(ctx context.Context, account string, req models.CountRequest) (*models.CountResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountSubscriptionsFor", ctx, account, req)
+	ret0, _ := ret[0].(*models.CountResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountSubscriptionsFor indicates an expected call of CountSubscriptionsFor.
+func (mr *MocksubscriptionListerMockRecorder) CountSubscriptionsFor(ctx, account, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountSubscriptionsFor", reflect.TypeOf((*MocksubscriptionLister)(nil).CountSubscriptionsFor), ctx, account, req)
+}
+
 // ListSubscriptionsFor mocks base method.
 func (m *MocksubscriptionLister) ListSubscriptionsFor(ctx context.Context, account string, req models.SubscriptionListRequest, defaultLimit, maxLimit int) (*models.PagedSubscriptionListResponse, error) {
 	m.ctrl.T.Helper()

--- a/user-service/routes.go
+++ b/user-service/routes.go
@@ -28,4 +28,5 @@ func registerRoutes(r *gin.Engine, h *handler, auth authDeps, d httpDeps) {
 	api.Use(authMiddleware(auth))
 
 	api.GET("/subscriptions", h.ListSubscriptions)
+	api.GET("/subscriptions/count", h.CountSubscriptions)
 }

--- a/user-service/service/subscriptions.go
+++ b/user-service/service/subscriptions.go
@@ -732,8 +732,15 @@ func (s *UserService) GetByRoomID(c *natsrouter.Context, req models.GetByRoomIDR
 func (s *UserService) CountSubscriptions(c *natsrouter.Context, req models.CountRequest) (*models.CountResponse, error) {
 	account := c.Param("account")
 	c.WithLogValues("account", account)
+	return s.CountSubscriptionsFor(c, account, req)
+}
+
+// CountSubscriptionsFor is the transport-agnostic count both the NATS handler
+// and the HTTP endpoint share. Unread nil/false ⇒ total active subs; true ⇒
+// the unread-badge count (cache-first when gated).
+func (s *UserService) CountSubscriptionsFor(ctx context.Context, account string, req models.CountRequest) (*models.CountResponse, error) {
 	if req.Unread == nil || !*req.Unread {
-		total, err := s.subs.CountActiveSubscriptions(c, account)
+		total, err := s.subs.CountActiveSubscriptions(ctx, account)
 		if err != nil {
 			return nil, fmt.Errorf("count subscriptions: %w", err)
 		}
@@ -743,11 +750,11 @@ func (s *UserService) CountSubscriptions(c *natsrouter.Context, req models.Count
 	// miss/stale falls through to the Mongo compute, whose Reseed rewrites the
 	// set and marker.
 	if s.badgeCacheFirst {
-		if n, fresh := s.badge.Count(c, account); fresh {
+		if n, fresh := s.badge.Count(ctx, account); fresh {
 			return &models.CountResponse{Count: n}, nil
 		}
 	}
-	ids, degraded, err := s.unreadRooms(c, account)
+	ids, degraded, err := s.unreadRooms(ctx, account)
 	if err != nil {
 		return nil, err
 	}
@@ -755,7 +762,7 @@ func (s *UserService) CountSubscriptions(c *natsrouter.Context, req models.Count
 	// skipped when degraded, since caching a partial set would stamp the
 	// freshness marker on data we already know is incomplete.
 	if !degraded {
-		s.badge.Reseed(c, account, ids)
+		s.badge.Reseed(ctx, account, ids)
 	}
 	return &models.CountResponse{Count: len(ids)}, nil
 }
@@ -768,8 +775,8 @@ func (s *UserService) CountSubscriptions(c *natsrouter.Context, req models.Count
 // the freshness marker on a knowingly-incomplete set.
 // Local subs read lastMsgAt from the $lookup; cross-site subs fetch it via
 // per-site GetRoomsMeta (rooms the remote site cannot resolve are excluded).
-func (s *UserService) unreadRooms(c *natsrouter.Context, account string) ([]string, bool, error) {
-	subs, err := s.subs.GetActiveSubscriptions(c, account, s.maxSubs)
+func (s *UserService) unreadRooms(ctx context.Context, account string) ([]string, bool, error) {
+	subs, err := s.subs.GetActiveSubscriptions(ctx, account, s.maxSubs)
 	if err != nil {
 		return nil, false, fmt.Errorf("unread rooms: %w", err)
 	}
@@ -808,7 +815,7 @@ func (s *UserService) unreadRooms(c *natsrouter.Context, account string) ([]stri
 			// Client already gone — stop firing further ~5s RPCs. The remaining sites'
 			// rooms will never be counted, so mark them (and this one) degraded rather
 			// than let a cancelled request be cached as if it were complete.
-			if c.Err() != nil {
+			if ctx.Err() != nil {
 				for j := i; j < len(sites); j++ {
 					failed[j] = true
 				}
@@ -819,14 +826,14 @@ func (s *UserService) unreadRooms(c *natsrouter.Context, account string) ([]stri
 			go func() {
 				defer wg.Done()
 				defer func() { <-sem }()
-				if c.Err() != nil {
+				if ctx.Err() != nil {
 					failed[i] = true
 					return
 				}
-				infos, err := s.rooms.GetRoomsMeta(c, site, roomIDsBySite[site])
+				infos, err := s.rooms.GetRoomsMeta(ctx, site, roomIDsBySite[site])
 				if err != nil {
 					// Skip this site rather than nuking the whole result.
-					slog.WarnContext(c, "unread count degraded for site", "account", account, "site", site, "request_id", natsutil.RequestIDFromContext(c), "error", err)
+					slog.WarnContext(ctx, "unread count degraded for site", "account", account, "site", site, "request_id", natsutil.RequestIDFromContext(ctx), "error", err)
 					failed[i] = true
 					return
 				}

--- a/user-service/store.go
+++ b/user-service/store.go
@@ -12,4 +12,5 @@ import (
 // Declared in the consumer so the handler can be tested without the service.
 type subscriptionLister interface {
 	ListSubscriptionsFor(ctx context.Context, account string, req models.SubscriptionListRequest, defaultLimit, maxLimit int) (*models.PagedSubscriptionListResponse, error)
+	CountSubscriptionsFor(ctx context.Context, account string, req models.CountRequest) (*models.CountResponse, error)
 }


### PR DESCRIPTION
## Summary

Add `GET /api/v1/subscriptions/count` — the HTTP form of the `subscription.count` RPC — with the `unread` filter. Mirrors the existing `subscription.list` HTTP split: a transport-agnostic core method is shared by the NATS handler and the new HTTP handler, so both stay identical.

## What's included

- `CountSubscriptionsFor(ctx, account, req)` extracted from the NATS `CountSubscriptions` handler as the shared core; `unreadRooms` retyped to take `context.Context` (it used no NATS-specific methods).
- `GET /api/v1/subscriptions/count?unread=true|false` handler + route; auth via the same credential-header path as the list endpoint; `Cache-Control: private, no-store`.
- Handler test for the `unread` query → request mapping (omitted stays nil, distinct from false).
- `docs/client-api.md` §13.3 for the HTTP endpoint + a pointer from the `subscription.count` section.

## Changes

- `user-service/service/subscriptions.go` — extract `CountSubscriptionsFor`; `unreadRooms` takes `context.Context`.
- `user-service/store.go` — add `CountSubscriptionsFor` to the `subscriptionLister` interface (+ regenerated mock).
- `user-service/handler.go`, `routes.go` — HTTP handler + route.
- `user-service/handler_test.go`, `docs/client-api.md`.

## Verification

`go build`, unit tests, `go vet -tags integration` compile, and lint are all green. No behavior change to the NATS RPC — it now delegates to the shared method.
