### PR TITLE
fix(notification-worker): carry attachment fileName/fileType on the push payload

### DIFF
--- a/docs/notification-worker-downstream-contracts.md
+++ b/docs/notification-worker-downstream-contracts.md
@@ -51,8 +51,6 @@ for future siblings (`.silent`, `.priority`) without restructuring the stream.
     "type": "c",
     "sender": { "account": "bob", "userId": "u-bob", "displayName": "Bob Chen 陳大寶" },
     "threadMessageId": "",
-    "fileName": "",
-    "fileType": "",
     "parentRoomId": "",
     "pushTime": "2026-05-28T00:00:00Z",
     "alsoSendToChannel": false
@@ -77,6 +75,7 @@ Field notes:
 
   Names come from the `users` collection through an LRU+TTL cache (`pkg/userstore`, `USER_CACHE_SIZE` / `USER_CACHE_TTL`), bounded by `MENTION_NAMES_TIMEOUT` and gated by `MENTION_NAMES_ENABLED`. A renamed user can therefore show a stale name for up to `USER_CACHE_TTL`. The lookup runs once per message, only when the content has mentions **and** at least one recipient survived the filters, and it **fails open**: a Mongo error or timeout sends the unsubstituted body rather than dropping the push. Substitution is not idempotent or reversible — consumers must treat `body` as display text, not as a parseable mention source.
 - **`data.type`** is the short room type: `"c"` channel, `"d"` DM/botDM, `"p"` discussion.
+- **`data.fileName` / `data.fileType`** carry the push file info of the message's **first decodable attachment** — `Attachment.Title` (file name) and its MIME `fileType`. Both are omitted from the payload (`omitempty`) when the message has no attachment or no blob decodes — the example above is a text message, so neither key appears. Malformed blobs are skipped, so a malformed first attachment falls through to the next one.
 - **`data.sender`** is a `Participant` carrying `account`, `userId`, and `displayName`. **`displayName` is pre-composed by `message-gatekeeper`** at canonical-message write time via `pkg/displayfmt.CombineWithFallback(engName, chineseName, account)` (same helper already used by `room-worker/sysmsg.go`, `room-service/store_mongo.go`, and reaction rendering — one source of truth for display formatting across the system). The composition happens once per message regardless of downstream consumer count and never on the push hot path; push-service renders `sender.displayName` verbatim. Empty `displayName` (legacy in-flight canonical messages predating the field) falls back to `sender.account` in `notification-worker`. `engName` / `chineseName` are deliberately not propagated on the push event since the composed string is the only render-time input.
 - **`timestamp`** is event publish time (UnixMilli); **`data.pushTime`** is the RFC3339 domain send time. They are distinct fields.
 - **`unreadCounts`** (optional) is per-recipient badge counts stamped at notify time — see § Badge counts below. Omitted entirely (not an empty object) when the badge phase is disabled or produced no counts for this batch.

--- a/notification-worker/handler.go
+++ b/notification-worker/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/mention"
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
@@ -72,6 +73,18 @@ type Handler struct {
 // safe-by-default as long as they join IsSystemMessageType (the single membership list).
 func isNotifiable(msgType string) bool {
 	return !model.IsSystemMessageType(msgType)
+}
+
+// attachmentFileInfo returns the push file info (title, MIME type) of the first
+// decodable attachment; both empty when the message carries none. Malformed blobs
+// are skipped, matching DecodeAttachments' lenient decode — the skipped count is
+// discarded because a push carrying no file info is the intended degraded result.
+func attachmentFileInfo(attachments [][]byte) (fileName, fileType string) {
+	atts, _ := cassandra.DecodeAttachments(attachments)
+	if len(atts) == 0 {
+		return "", ""
+	}
+	return atts[0].Title, atts[0].FileType
 }
 
 func NewHandler(deps HandlerDeps) *Handler { //nolint:gocritic // hugeParam: one-time constructor arg
@@ -273,6 +286,7 @@ func (h *Handler) HandleMessage(ctx context.Context, data []byte) (retErr error)
 	}
 
 	now := time.Now().UTC()
+	fileName, fileType := attachmentFileInfo(msg.Attachments)
 	// Template carries fields shared across every batch — only ID and Accounts change per batch.
 	pushEvt := model.PushNotificationEvent{
 		RoomID: msg.RoomID,
@@ -284,6 +298,8 @@ func (h *Handler) HandleMessage(ctx context.Context, data []byte) (retErr error)
 			Type:              shortRoomType(roomType),
 			Sender:            sender,
 			ThreadMessageID:   msg.ThreadParentMessageID,
+			FileName:          fileName,
+			FileType:          fileType,
 			PushTime:          now.Format(time.RFC3339),
 			AlsoSendToChannel: msg.TShow,
 		},

--- a/notification-worker/handler.go
+++ b/notification-worker/handler.go
@@ -79,12 +79,15 @@ func isNotifiable(msgType string) bool {
 // decodable attachment; both empty when the message carries none. Malformed blobs
 // are skipped, matching DecodeAttachments' lenient decode — the skipped count is
 // discarded because a push carrying no file info is the intended degraded result.
+// Decodes one blob at a time so reading the first entry never materializes the rest.
 func attachmentFileInfo(attachments [][]byte) (fileName, fileType string) {
-	atts, _ := cassandra.DecodeAttachments(attachments)
-	if len(atts) == 0 {
-		return "", ""
+	for i := range attachments {
+		atts, _ := cassandra.DecodeAttachments(attachments[i : i+1])
+		if len(atts) != 0 {
+			return atts[0].Title, atts[0].FileType
+		}
 	}
-	return atts[0].Title, atts[0].FileType
+	return "", ""
 }
 
 func NewHandler(deps HandlerDeps) *Handler { //nolint:gocritic // hugeParam: one-time constructor arg

--- a/notification-worker/handler_test.go
+++ b/notification-worker/handler_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hmchangw/chat/pkg/errcode"
 	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/pkg/natsmetrics"
 	"github.com/hmchangw/chat/pkg/roommetacache"
 	"github.com/hmchangw/chat/pkg/roomsubcache"
@@ -2036,4 +2037,47 @@ type deliveryCountMsg struct {
 
 func (m *deliveryCountMsg) Metadata() (*jetstream.MsgMetadata, error) {
 	return &jetstream.MsgMetadata{NumDelivered: m.numDelivered}, nil
+}
+
+func TestHandle_Attachment_PushPayloadFileInfo(t *testing.T) {
+	imgBlob, err := json.Marshal(cassandra.Attachment{
+		ID: "dl2qge1k5g7h", Title: "a_001.jpeg", Type: "file", FileType: "image/jpeg",
+	})
+	require.NoError(t, err)
+	fileBlob, err := json.Marshal(cassandra.Attachment{
+		ID: "f2", Title: "doc.pdf", Type: "file", FileType: "application/pdf",
+	})
+	require.NoError(t, err)
+
+	cases := []struct {
+		name         string
+		attachments  [][]byte
+		wantFile     string
+		wantFileType string
+	}{
+		{"no attachment", nil, "", ""},
+		{"single image", [][]byte{imgBlob}, "a_001.jpeg", "image/jpeg"},
+		{"first attachment wins", [][]byte{imgBlob, fileBlob}, "a_001.jpeg", "image/jpeg"},
+		{"malformed first blob skipped", [][]byte{[]byte("{not json"), fileBlob}, "doc.pdf", "application/pdf"},
+		{"all blobs malformed", [][]byte{[]byte("{not json")}, "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			members := &stubMembers{out: map[string][]roomsubcache.Member{
+				"r1": {{ID: "alice", Account: "alice"}, {ID: "bob", Account: "bob"}},
+			}}
+			emit := &recordingEmitter{}
+			h := newTestHandler(members, &stubFollowers{}, noopPresenceSnapshotter{}, noopVetoer{}, emit)
+
+			require.NoError(t, h.HandleMessage(context.Background(), msgEvent(&model.Message{
+				ID: "m1", RoomID: "r1", UserID: "alice", UserAccount: "alice",
+				Content: "hi", Attachments: tc.attachments, CreatedAt: time.Now(),
+			})))
+
+			require.Len(t, emit.emitted, 1, "one batch for the single non-sender recipient")
+			assert.Equal(t, tc.wantFile, emit.emitted[0].Data.FileName, "fileName")
+			assert.Equal(t, tc.wantFileType, emit.emitted[0].Data.FileType, "fileType")
+		})
+	}
 }


### PR DESCRIPTION
Closes https://github.com/hmchangw/newchat/issues/439

## Problem

`PushNotificationData` has declared `FileName` and `FileType` since it was written, but `HandleMessage` never populated them. A file message therefore pushed only `roomId`/`messageId`/`type`/`sender`/`senderDisplayName`/`title`/`pushTime`, leaving the client with no way to render the attachment:

```
userInfo = [AnyHashable("userDefined"): {
    messageId = VhUCnHsctgeDYQbNTHVk;
    pushTime = "2026-08-31T01:20:33Z";
    sender = account;
    senderDisplayName = "Display Name";
    title = ttqq;
    type = c;
}]
```

## Change

`attachmentFileInfo` (beside `isNotifiable`) resolves the push file info from the message's first decodable attachment — `Attachment.Title` as the file name, plus its MIME `FileType` — and `HandleMessage` sets both on the push template.

Two details worth a reviewer's attention:

- **It decodes via `cassandra.DecodeAttachments` rather than a local `json.Unmarshal`.** That path also runs `normalizeAttachment`, so pre-migration snake_case blobs yield a real title instead of an empty string. A raw unmarshal would have silently regressed legacy attachments.
- **Malformed blobs are skipped, not fatal.** This matches the lenient decode already used on history loads and live delivery, so a bad first attachment falls through to the next one rather than blanking the file info for the whole message.

Both fields keep `omitempty`: a message with no attachment (or none that decodes) omits the keys entirely rather than sending empty strings. The contract doc's JSON example claimed the opposite — it showed `"fileName": ""` / `"fileType": ""` as always-present, which was wrong both before and after this change — so the example is corrected and the semantics documented beside `data.type`.

Scoped to `notification-worker`. `push-notification-service` forwards `evt.Data` to the dispatcher untouched, so nothing downstream needed a change, and `pkg/model/push.go` already had the fields. Push is not a `chat.user.*` RPC, so `docs/client-api.md` does not apply.

## Testing

TDD: the five-case table test was written first and confirmed red — `single image`, `first attachment wins` and `malformed first blob skipped` all failed with `actual: ""` (field never populated), while `no attachment` and `all blobs malformed` passed trivially. All five pass after the change.

| Check | Result |
|---|---|
| `make test SERVICE=notification-worker` | ok, race enabled |
| `make test` (full repo) | pass |
| `make lint` | `0 issues.` |
| `make sast-gosec` | pass |
| `make sast-semgrep-test` | 2/2 rule tests pass |
| repo-owned semgrep rules on `notification-worker/` | 15 rules, 0 findings |

`govulncheck` and the full `semgrep scan` could not run in the authoring environment — its network policy returns 403 on `vuln.go.dev` and on the `p/golang` registry pack from `semgrep.dev`. Neither is affected by this diff (`go.mod` is untouched, so govulncheck has no new dependency to scan), but both should be judged by the CI `sast` job rather than taken on faith here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HM23tUZyLXttbqnM9AL3Qq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Push notifications now include the file name and MIME type of the first valid attachment.
  - Invalid attachments are skipped, and file details are omitted when no valid attachment is available.

- **Documentation**
  - Updated the notification payload contract with the new attachment metadata behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->