### PR TITLE
fix(bot-message-handler): resolve bot sender display name from the app name

### DIFF
--- a/bot-message-handler/handler.go
+++ b/bot-message-handler/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hmchangw/chat/pkg/idgen"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/natsrouter"
+	"github.com/hmchangw/chat/pkg/preview"
 	"github.com/hmchangw/chat/pkg/subject"
 )
 
@@ -45,13 +46,14 @@ func (j JetStreamPublisher) PublishWithMsgID(ctx context.Context, subj string, d
 }
 
 type handler struct {
-	store  Store
-	pub    Publisher
-	siteID string
+	store   Store
+	pub     Publisher
+	siteID  string
+	appName preview.AppNameLookup
 }
 
-func newHandler(store Store, pub Publisher, siteID string) *handler {
-	return &handler{store: store, pub: pub, siteID: siteID}
+func newHandler(store Store, pub Publisher, siteID string, appName preview.AppNameLookup) *handler {
+	return &handler{store: store, pub: pub, siteID: siteID, appName: appName}
 }
 
 // verifyRoomExists is a defence-in-depth local-Mongo check. BP routes to the room's home site, so a miss indicates a dangling subscription.
@@ -110,7 +112,7 @@ func (h *handler) handleSendDM(c *natsrouter.Context, req BotSendRoomRequest) (*
 	msg := model.Message{
 		ID: messageID, RoomID: roomID,
 		UserID: ident.ID, UserAccount: ident.Account,
-		UserDisplayName: displayfmt.CombineWithFallback(ident.EngName, ident.ChineseName, ident.Account),
+		UserDisplayName: preview.BotAwareDisplayName(c, h.appName, ident.EngName, ident.ChineseName, ident.Account),
 		Content:         req.Content, Card: req.Card, Mentions: mentions,
 		CreatedAt:                    createdAt,
 		ThreadParentMessageID:        req.ThreadParentMessageID,
@@ -165,7 +167,7 @@ func (h *handler) handleSendRoom(c *natsrouter.Context, req BotSendRoomRequest) 
 		RoomID:                       roomID,
 		UserID:                       ident.ID,
 		UserAccount:                  ident.Account,
-		UserDisplayName:              displayfmt.CombineWithFallback(ident.EngName, ident.ChineseName, ident.Account),
+		UserDisplayName:              preview.BotAwareDisplayName(c, h.appName, ident.EngName, ident.ChineseName, ident.Account),
 		Content:                      req.Content,
 		Card:                         req.Card,
 		Mentions:                     mentions,

--- a/bot-message-handler/handler_test.go
+++ b/bot-message-handler/handler_test.go
@@ -28,6 +28,14 @@ type fakeStore struct {
 	FindRoomFn         func(ctx context.Context, roomID string) (*Room, error)
 	ListMemberIDsFn    func(ctx context.Context, roomID string) ([]string, error)
 	FindUserFn         func(ctx context.Context, userID string) (*model.User, error)
+	AppNameByAccountFn func(ctx context.Context, botAccount string) (string, error)
+}
+
+func (f *fakeStore) AppNameByAccount(ctx context.Context, botAccount string) (string, error) {
+	if f.AppNameByAccountFn == nil {
+		return "", nil
+	}
+	return f.AppNameByAccountFn(ctx, botAccount)
 }
 
 func (f *fakeStore) FindSubscription(ctx context.Context, roomID, userID string) (*Subscription, error) {
@@ -107,7 +115,7 @@ func TestHandleSendRoom_HappyPath(t *testing.T) {
 		},
 	}
 	pub := &fakePublisher{}
-	h := newHandler(store, pub, "site-a")
+	h := newHandler(store, pub, "site-a", nil)
 
 	msgID := idgen.GenerateMessageID()
 	created := time.Now().UnixMilli()
@@ -137,6 +145,35 @@ func TestHandleSendRoom_HappyPath(t *testing.T) {
 	assert.Equal(t, created, evt.Timestamp)
 }
 
+// TestHandleSendRoom_DisplayNameFromAppName: a real bot identity carries no
+// EngName/ChineseName (the header stamps only id/account/siteId), so the sender
+// display name must resolve from the app name, not fall back to the raw account.
+func TestHandleSendRoom_DisplayNameFromAppName(t *testing.T) {
+	store := &fakeStore{
+		FindSubscriptionFn: func(_ context.Context, _, _ string) (*Subscription, error) {
+			return &Subscription{RoomID: "r1", UserID: "bot-1", SiteID: "site-a"}, nil
+		},
+		FindRoomFn: func(_ context.Context, _ string) (*Room, error) {
+			return &Room{ID: "r1", Type: "c", SiteID: "site-a"}, nil
+		},
+		AppNameByAccountFn: func(_ context.Context, account string) (string, error) {
+			assert.Equal(t, "myapp.bot", account)
+			return "Payroll Assistant", nil
+		},
+	}
+	pub := &fakePublisher{}
+	h := newHandler(store, pub, "site-a", store.AppNameByAccount)
+
+	// Bare identity: no EngName/ChineseName, as the live X-Bot-Identity header carries.
+	id := BotIdentity{ID: "bot-1", Account: "myapp.bot", SiteID: "site-a"}
+	c := newCtx(t, "r1", validHeaders(t, id, idgen.GenerateMessageID(), time.Now().UnixMilli()), nil)
+
+	resp, err := h.handleSendRoom(c, BotSendRoomRequest{Content: "hi"})
+	require.NoError(t, err)
+	assert.Equal(t, "Payroll Assistant", resp.Message.UserDisplayName,
+		"bot sender name resolves from the app name, not the raw account")
+}
+
 func TestHandleSendRoom_SubscriptionMissing(t *testing.T) {
 	store := &fakeStore{
 		FindSubscriptionFn: func(_ context.Context, _, _ string) (*Subscription, error) {
@@ -144,7 +181,7 @@ func TestHandleSendRoom_SubscriptionMissing(t *testing.T) {
 		},
 	}
 	pub := &fakePublisher{}
-	h := newHandler(store, pub, "site-a")
+	h := newHandler(store, pub, "site-a", nil)
 
 	c := newCtx(t, "r1", validHeaders(t, botIdent(), idgen.GenerateMessageID(), 1), nil)
 	_, err := h.handleSendRoom(c, BotSendRoomRequest{Content: "hi"})
@@ -159,7 +196,7 @@ func TestHandleSendRoom_RoomMissing(t *testing.T) {
 		},
 		FindRoomFn: func(_ context.Context, _ string) (*Room, error) { return nil, ErrNotFound },
 	}
-	h := newHandler(store, &fakePublisher{}, "site-a")
+	h := newHandler(store, &fakePublisher{}, "site-a", nil)
 
 	c := newCtx(t, "r1", validHeaders(t, botIdent(), idgen.GenerateMessageID(), 1), nil)
 	_, err := h.handleSendRoom(c, BotSendRoomRequest{Content: "hi"})
@@ -185,7 +222,7 @@ func TestHandleSendRoom_ContentValidation(t *testing.T) {
 					return &Room{ID: "r1", Type: "c", SiteID: "site-a"}, nil
 				},
 			}
-			h := newHandler(store, &fakePublisher{}, "site-a")
+			h := newHandler(store, &fakePublisher{}, "site-a", nil)
 			c := newCtx(t, "r1", validHeaders(t, botIdent(), idgen.GenerateMessageID(), 1), nil)
 			_, err := h.handleSendRoom(c, BotSendRoomRequest{Content: tc.content})
 			requireErrcode(t, err, errcode.CodeBadRequest, tc.reason)
@@ -202,7 +239,7 @@ func TestHandleSendRoom_HeaderValidation(t *testing.T) {
 			return &Room{ID: "r1", Type: "c", SiteID: "site-a"}, nil
 		},
 	}
-	h := newHandler(store, &fakePublisher{}, "site-a")
+	h := newHandler(store, &fakePublisher{}, "site-a", nil)
 
 	tests := []struct {
 		name    string
@@ -261,7 +298,7 @@ func TestHandleSendRoom_MentionCanonicalization(t *testing.T) {
 			return &model.User{ID: id, Account: "alice.true", SiteID: "site-a", EngName: "Alice True"}, nil
 		},
 	}
-	h := newHandler(store, &fakePublisher{}, "site-a")
+	h := newHandler(store, &fakePublisher{}, "site-a", nil)
 
 	c := newCtx(t, "r1", validHeaders(t, botIdent(), idgen.GenerateMessageID(), 1), nil)
 	req := BotSendRoomRequest{
@@ -293,7 +330,7 @@ func TestHandleSendRoom_MentionNonMemberRejected(t *testing.T) {
 			return []string{"bot-1"}, nil
 		},
 	}
-	h := newHandler(store, &fakePublisher{}, "site-a")
+	h := newHandler(store, &fakePublisher{}, "site-a", nil)
 
 	c := newCtx(t, "r1", validHeaders(t, botIdent(), idgen.GenerateMessageID(), 1), nil)
 	req := BotSendRoomRequest{
@@ -313,7 +350,7 @@ func TestHandleSendRoom_ThreadReplyFieldsCopied(t *testing.T) {
 			return &Room{ID: "r1", Type: "c", SiteID: "site-a"}, nil
 		},
 	}
-	h := newHandler(store, &fakePublisher{}, "site-a")
+	h := newHandler(store, &fakePublisher{}, "site-a", nil)
 
 	parentCreated := time.Now().UTC()
 	c := newCtx(t, "r1", validHeaders(t, botIdent(), idgen.GenerateMessageID(), 1), nil)
@@ -339,7 +376,7 @@ func TestHandleSendRoom_TShowIgnoredOnNonThread(t *testing.T) {
 			return &Room{ID: "r1", Type: "c", SiteID: "site-a"}, nil
 		},
 	}
-	h := newHandler(store, &fakePublisher{}, "site-a")
+	h := newHandler(store, &fakePublisher{}, "site-a", nil)
 	c := newCtx(t, "r1", validHeaders(t, botIdent(), idgen.GenerateMessageID(), 1), nil)
 	resp, err := h.handleSendRoom(c, BotSendRoomRequest{Content: "hi", TShow: true})
 	require.NoError(t, err)
@@ -356,7 +393,7 @@ func TestHandleSendRoom_PublishError(t *testing.T) {
 		},
 	}
 	pub := &fakePublisher{err: errors.New("nats down")}
-	h := newHandler(store, pub, "site-a")
+	h := newHandler(store, pub, "site-a", nil)
 
 	c := newCtx(t, "r1", validHeaders(t, botIdent(), idgen.GenerateMessageID(), 1), nil)
 	_, err := h.handleSendRoom(c, BotSendRoomRequest{Content: "hi"})

--- a/bot-message-handler/main.go
+++ b/bot-message-handler/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hmchangw/chat/pkg/natsrouter"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/obs"
+	"github.com/hmchangw/chat/pkg/preview"
 	"github.com/hmchangw/chat/pkg/shutdown"
 )
 
@@ -94,7 +95,8 @@ func run() error {
 	store := newStoreMongo(mongoClient.Database(cfg.MongoDB))
 
 	pub := JetStreamPublisher{JS: js}
-	h := newHandler(store, pub, cfg.SiteID)
+	appName := preview.CachedAppNameLookup(store.AppNameByAccount)
+	h := newHandler(store, pub, cfg.SiteID, appName)
 
 	publishMetrics := natsmetrics.NewFromProviderIfEnabled(sdk.MeterProvider(), sdk.Toggles.Metrics).Publisher(cfg.SiteID)
 	router := natsrouter.DefaultGuarded(nc, "bot-message-handler", guard,

--- a/bot-message-handler/store.go
+++ b/bot-message-handler/store.go
@@ -20,6 +20,10 @@ type Store interface {
 
 	// FindUser returns the users doc used to canonicalize mention Participants.
 	FindUser(ctx context.Context, userID string) (*model.User, error)
+
+	// AppNameByAccount returns the app display name for a bot account, or ("", nil)
+	// when no app matches. Used to stamp a bot message's sender display name.
+	AppNameByAccount(ctx context.Context, botAccount string) (string, error)
 }
 
 // ErrNotFound is returned by store lookups when the requested document does not exist.

--- a/bot-message-handler/store_mongo.go
+++ b/bot-message-handler/store_mongo.go
@@ -16,6 +16,7 @@ type storeMongo struct {
 	subscriptions *mongo.Collection
 	rooms         *mongo.Collection
 	users         *mongo.Collection
+	apps          *mongo.Collection
 }
 
 func newStoreMongo(db *mongo.Database) *storeMongo {
@@ -23,7 +24,25 @@ func newStoreMongo(db *mongo.Database) *storeMongo {
 		subscriptions: db.Collection("subscriptions"),
 		rooms:         db.Collection("rooms"),
 		users:         db.Collection("users"),
+		apps:          db.Collection("apps"),
 	}
+}
+
+// AppNameByAccount resolves a bot account (assistant.name) to its app display name,
+// returning ("", nil) when no app matches. Mirrors history-service's AppRepo.
+func (s *storeMongo) AppNameByAccount(ctx context.Context, botAccount string) (string, error) {
+	var app struct {
+		Name string `bson:"name"`
+	}
+	err := s.apps.FindOne(ctx, bson.M{"assistant.name": botAccount},
+		options.FindOne().SetProjection(bson.M{"name": 1, "_id": 0})).Decode(&app)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("find app by account %q: %w", botAccount, err)
+	}
+	return app.Name, nil
 }
 
 func (s *storeMongo) FindSubscription(ctx context.Context, roomID, userID string) (*Subscription, error) {


### PR DESCRIPTION
## Summary

A bot message's stored `UserDisplayName` came from `CombineWithFallback(EngName, ChineseName, Account)`, but a bot identity — parsed from the `X-Bot-Identity` header — carries **none** of the name fields (only `id`/`account`/`siteId`), so it fell back to the raw bot account (e.g. `myapp.bot`). Every other surface (room-list preview, history, member.list) resolves the friendly app name via an `AppNameByAccount` lookup, so a bot's message row showed the raw account while those surfaces showed the app name — a visible mismatch.

This resolves the app name at write time through the shared `preview.BotAwareDisplayName` helper (the same one preview/history use), falling back to the composed name when no app matches.

## What's included

- `bot-message-handler` gains a cached `AppNameByAccount` lookup (`preview.CachedAppNameLookup`), wired once at startup.
- Both bot send paths (`handleSendDM`, `handleSendRoom`) compose the sender display name via `preview.BotAwareDisplayName`.
- Regression test: a bare bot identity (no `EngName`, as the live header carries) resolves the display name from the app name, not the raw account.

## Changes

- `bot-message-handler/store.go`, `store_mongo.go` — add `AppNameByAccount(ctx, botAccount)` (queries `apps` by `assistant.name`, precise projection).
- `bot-message-handler/handler.go` — `handler` holds a `preview.AppNameLookup`; the two `UserDisplayName` compositions use `preview.BotAwareDisplayName`.
- `bot-message-handler/main.go` — build the cached lookup and inject it.

No wire-struct change: `UserDisplayName` already exists on the message and its meaning is unchanged — only its value source is corrected — so no `docs/client-api.md` change is needed.

## Verification

`go build`, unit tests (incl. the new resolution test), `go vet -tags integration`, and golangci-lint are all green for `bot-message-handler`.
