### PR TITLE
fix(drive): revert upload mode from KeepBoth back to Normal

### DIFF
--- a/pkg/drive/uploader.go
+++ b/pkg/drive/uploader.go
@@ -86,7 +86,7 @@ func (c *Client) UploadGroupImages(userID, username, email, groupID, origin stri
 	for i, f := range files {
 		fields = append(fields,
 			formField{fmt.Sprintf("files[%d].fileName", i), f.Filename},
-			formField{fmt.Sprintf("files[%d].mode", i), "KeepBoth"})
+			formField{fmt.Sprintf("files[%d].mode", i), "Normal"})
 	}
 	body, err := buildStreamedBody(fields, files)
 	if err != nil {

--- a/pkg/drive/uploader_test.go
+++ b/pkg/drive/uploader_test.go
@@ -60,7 +60,7 @@ func TestClient_UploadGroupImages(t *testing.T) {
 	if gotBypass != "true" {
 		t.Fatalf("bypass query param = %q, want %q", gotBypass, "true")
 	}
-	if gotToken != "tok" || gotUserID != "alice" || gotFileName != "a.png" || gotMode != "KeepBoth" {
+	if gotToken != "tok" || gotUserID != "alice" || gotFileName != "a.png" || gotMode != "Normal" {
 		t.Fatalf("token=%q userId=%q fileName=%q mode=%q", gotToken, gotUserID, gotFileName, gotMode)
 	}
 }


### PR DESCRIPTION
PR #424 changed the drive upload `files[i].mode` form field from `Normal` to `KeepBoth` alongside its siteID fix. This reverts just the mode back to `Normal`; the siteID resolution changes from #424 are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated group image uploads to use the standard “Normal” file mode, improving compatibility with expected upload behavior.
* **Tests**
  * Updated upload validation to confirm the corrected file mode is sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->