### PR TITLE
fix(history-service): persist re-resolved mentions on message edit

### DIFF
--- a/_internal/notes/audits/fix-history-subcache-invalidate-on-membership-94759ea4.md
+++ b/_internal/notes/audits/fix-history-subcache-invalidate-on-membership-94759ea4.md
@@ -1,0 +1,6 @@
+# pr-self-audit record
+pr: 415
+branch: fix-history-subcache-invalidate-on-membership
+sha: 94759ea4
+audited_at: 2026-08-31T01:11:16Z
+verdict: re-synced onto origin/main@6eb3b518 (incl #437). build+unit+integration-compile+lint green. Jacob go for ready.

--- a/_internal/notes/audits/fix-member-list-name-compat-alias-7c1da9be.md
+++ b/_internal/notes/audits/fix-member-list-name-compat-alias-7c1da9be.md
@@ -1,0 +1,6 @@
+# pr-self-audit record
+pr: 437
+branch: fix/member-list-name-compat-alias
+sha: 7c1da9be
+audited_at: 2026-08-31T01:00:00Z
+verdict: rebased onto fixed origin/main@9cdeb3fe. name alias of appName. build+unit+lint green.

--- a/_internal/notes/audits/fix-restricted-inherit-via-roommeta-6c8f77e7.md
+++ b/_internal/notes/audits/fix-restricted-inherit-via-roommeta-6c8f77e7.md
@@ -1,0 +1,6 @@
+# pr-self-audit record
+pr: 418
+branch: fix-restricted-inherit-via-roommeta
+sha: 6c8f77e7
+audited_at: 2026-08-31T01:11:16Z
+verdict: re-synced onto origin/main@6eb3b518 (incl #437). build+unit+integration-compile+lint green. Jacob go for ready.

--- a/history-service/internal/cassrepo/pin_integration_test.go
+++ b/history-service/internal/cassrepo/pin_integration_test.go
@@ -272,7 +272,7 @@ func TestRepository_GetPinnedMessages_EditedEncryptedPin(t *testing.T) {
 	toEdit, err := repo.GetMessageByID(ctx, "m1")
 	require.NoError(t, err)
 	require.NotNil(t, toEdit.PinnedAt, "the edit only touches the pinned mirror when PinnedAt is set")
-	require.NoError(t, repo.UpdateMessageContent(ctx, toEdit, "edited body", created.Add(2*time.Hour)))
+	require.NoError(t, repo.UpdateMessageContent(ctx, toEdit, "edited body", nil, created.Add(2*time.Hour)))
 
 	page, err := repo.GetPinnedMessages(ctx, roomID, PageRequest{PageSize: 10})
 	require.NoError(t, err)

--- a/history-service/internal/cassrepo/write.go
+++ b/history-service/internal/cassrepo/write.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hmchangw/chat/history-service/internal/models"
 	"github.com/hmchangw/chat/pkg/atrest"
+	pkgmodel "github.com/hmchangw/chat/pkg/model"
 	cassmodel "github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/pkg/threadcount"
 )
@@ -21,10 +22,10 @@ const (
 	// are plain (non-LWT) UPDATEs: the service layer's findMessage already
 	// gates existence and the not-deleted check before this is reached, and
 	// messages are only edited by their owner, so a CAS gate isn't warranted.
-	editMsgByID   = `UPDATE messages_by_id SET msg = ?, enc_payload = null, enc_meta = null, edited_at = ?, updated_at = ? WHERE message_id = ?`
-	editMsgByRoom = `UPDATE messages_by_room SET msg = ?, enc_payload = null, enc_meta = null, edited_at = ?, updated_at = ? WHERE room_id = ? AND bucket = ? AND created_at = ? AND message_id = ?`
-	editThreadMsg = `UPDATE thread_messages_by_thread SET msg = ?, enc_payload = null, enc_meta = null, edited_at = ?, updated_at = ? WHERE thread_room_id = ? AND created_at = ? AND message_id = ?`
-	editPinnedMsg = `UPDATE pinned_messages_by_room SET msg = ?, enc_payload = null, enc_meta = null, edited_at = ?, updated_at = ? WHERE room_id = ? AND pinned_at = ? AND message_id = ?`
+	editMsgByID   = `UPDATE messages_by_id SET msg = ?, mentions = ?, enc_payload = null, enc_meta = null, edited_at = ?, updated_at = ? WHERE message_id = ?`
+	editMsgByRoom = `UPDATE messages_by_room SET msg = ?, mentions = ?, enc_payload = null, enc_meta = null, edited_at = ?, updated_at = ? WHERE room_id = ? AND bucket = ? AND created_at = ? AND message_id = ?`
+	editThreadMsg = `UPDATE thread_messages_by_thread SET msg = ?, mentions = ?, enc_payload = null, enc_meta = null, edited_at = ?, updated_at = ? WHERE thread_room_id = ? AND created_at = ? AND message_id = ?`
+	editPinnedMsg = `UPDATE pinned_messages_by_room SET msg = ?, mentions = ?, enc_payload = null, enc_meta = null, edited_at = ?, updated_at = ? WHERE room_id = ? AND pinned_at = ? AND message_id = ?`
 
 	// Encrypted-path edits null the encrypted legacy body columns (msg,
 	// attachments, card, card_action) — buildEditPayload has promoted those
@@ -33,10 +34,10 @@ const (
 	// only its body sub-fields move into the bundle, while its non-sensitive
 	// metadata (message_id, sender, …) must stay in the plaintext column or a
 	// read-back can't restore it. sys_msg_data is NOT encrypted, so it is preserved.
-	editMsgByIDEncrypted   = `UPDATE messages_by_id SET enc_payload = ?, enc_meta = ?, msg = null, attachments = null, card = null, card_action = null, quoted_parent_message = ?, edited_at = ?, updated_at = ? WHERE message_id = ?`
-	editMsgByRoomEncrypted = `UPDATE messages_by_room SET enc_payload = ?, enc_meta = ?, msg = null, attachments = null, card = null, card_action = null, quoted_parent_message = ?, edited_at = ?, updated_at = ? WHERE room_id = ? AND bucket = ? AND created_at = ? AND message_id = ?`
-	editThreadMsgEncrypted = `UPDATE thread_messages_by_thread SET enc_payload = ?, enc_meta = ?, msg = null, attachments = null, card = null, card_action = null, quoted_parent_message = ?, edited_at = ?, updated_at = ? WHERE thread_room_id = ? AND created_at = ? AND message_id = ?`
-	editPinnedMsgEncrypted = `UPDATE pinned_messages_by_room SET enc_payload = ?, enc_meta = ?, msg = null, attachments = null, card = null, card_action = null, quoted_parent_message = ?, edited_at = ?, updated_at = ? WHERE room_id = ? AND pinned_at = ? AND message_id = ?`
+	editMsgByIDEncrypted   = `UPDATE messages_by_id SET enc_payload = ?, enc_meta = ?, mentions = ?, msg = null, attachments = null, card = null, card_action = null, quoted_parent_message = ?, edited_at = ?, updated_at = ? WHERE message_id = ?`
+	editMsgByRoomEncrypted = `UPDATE messages_by_room SET enc_payload = ?, enc_meta = ?, mentions = ?, msg = null, attachments = null, card = null, card_action = null, quoted_parent_message = ?, edited_at = ?, updated_at = ? WHERE room_id = ? AND bucket = ? AND created_at = ? AND message_id = ?`
+	editThreadMsgEncrypted = `UPDATE thread_messages_by_thread SET enc_payload = ?, enc_meta = ?, mentions = ?, msg = null, attachments = null, card = null, card_action = null, quoted_parent_message = ?, edited_at = ?, updated_at = ? WHERE thread_room_id = ? AND created_at = ? AND message_id = ?`
+	editPinnedMsgEncrypted = `UPDATE pinned_messages_by_room SET enc_payload = ?, enc_meta = ?, mentions = ?, msg = null, attachments = null, card = null, card_action = null, quoted_parent_message = ?, edited_at = ?, updated_at = ? WHERE room_id = ? AND pinned_at = ? AND message_id = ?`
 
 	deleteMsgByIDCAS = `UPDATE messages_by_id SET deleted = true, enc_payload = null, enc_meta = null, updated_at = ? WHERE message_id = ? IF deleted != true`
 	deleteMsgByRoom  = `UPDATE messages_by_room SET deleted = true, enc_payload = null, enc_meta = null, updated_at = ? WHERE room_id = ? AND bucket = ? AND created_at = ? AND message_id = ?`
@@ -75,6 +76,10 @@ type editPayload struct {
 	plain   string
 	payload []byte             // nil when cipher is disabled
 	meta    *cassmodel.EncMeta // nil when cipher is disabled
+	// mentions is the @-mentions re-resolved from the edited content, bound to
+	// the plaintext `mentions` column on both paths (mentions is never encrypted).
+	// nil clears the column, so an edit that drops all @mentions drops them here.
+	mentions []cassmodel.Participant
 	// quotedMeta is the existing quoted-parent UDT with its body sub-fields
 	// blanked (the body moves into payload). Bound to the encrypted UPDATE's
 	// quoted_parent_message column so the parent's metadata survives the edit;
@@ -88,9 +93,10 @@ type editPayload struct {
 // previously-encrypted fields (attachments, card, sysMsgData, quoted
 // parent body) are preserved. Editing a legacy plaintext row produces a
 // fresh bundle containing just Msg.
-func (r *Repository) buildEditPayload(ctx context.Context, msg *models.Message, newMsg string) (editPayload, error) {
+func (r *Repository) buildEditPayload(ctx context.Context, msg *models.Message, newMsg string, mentions []pkgmodel.Participant) (editPayload, error) {
+	mentionSet := toMentionSet(mentions)
 	if r.cipher == nil {
-		return editPayload{plain: newMsg}, nil
+		return editPayload{plain: newMsg, mentions: mentionSet}, nil
 	}
 	fields, quoted, err := r.readEncryptedFields(ctx, msg)
 	if err != nil {
@@ -105,8 +111,27 @@ func (r *Repository) buildEditPayload(ctx context.Context, msg *models.Message, 
 		plain:      newMsg,
 		payload:    payload,
 		meta:       &cassmodel.EncMeta{Nonce: meta.Nonce},
+		mentions:   mentionSet,
 		quotedMeta: blankQuotedBody(quoted),
 	}, nil
+}
+
+// toMentionSet converts resolved wire participants to the Cassandra
+// SET<FROZEN<"Participant">> element type. nil in → nil out (column cleared).
+func toMentionSet(mentions []pkgmodel.Participant) []cassmodel.Participant {
+	if len(mentions) == 0 {
+		return nil
+	}
+	out := make([]cassmodel.Participant, len(mentions))
+	for i, m := range mentions {
+		out[i] = cassmodel.Participant{
+			ID:          m.UserID,
+			EngName:     m.EngName,
+			CompanyName: m.ChineseName,
+			Account:     m.Account,
+		}
+	}
+	return out
 }
 
 // blankQuotedBody returns a copy of the quoted-parent UDT with only its body
@@ -188,37 +213,37 @@ func (r *Repository) readEncryptedFields(ctx context.Context, msg *models.Messag
 }
 
 // editOne runs the appropriate plaintext or encrypted UPDATE for one of
-// the four message tables. plainQ binds (newMsg, editedAt, editedAt,
-// whereArgs...); encQ binds (encPayload, encMeta, quotedMeta, editedAt,
+// the four message tables. plainQ binds (newMsg, mentions, editedAt, editedAt,
+// whereArgs...); encQ binds (encPayload, encMeta, mentions, quotedMeta, editedAt,
 // editedAt, whereArgs...).
-func (r *Repository) editOne(ctx context.Context, plainQ, encQ string, ep editPayload, editedAt time.Time, whereArgs ...any) error {
+func (r *Repository) editOne(ctx context.Context, plainQ, encQ string, ep *editPayload, editedAt time.Time, whereArgs ...any) error {
 	if ep.payload == nil {
-		args := append([]any{ep.plain, editedAt, editedAt}, whereArgs...)
+		args := append([]any{ep.plain, ep.mentions, editedAt, editedAt}, whereArgs...)
 		return r.session.Query(plainQ, args...).WithContext(ctx).Exec()
 	}
-	args := append([]any{ep.payload, ep.meta, ep.quotedMeta, editedAt, editedAt}, whereArgs...)
+	args := append([]any{ep.payload, ep.meta, ep.mentions, ep.quotedMeta, editedAt, editedAt}, whereArgs...)
 	return r.session.Query(encQ, args...).WithContext(ctx).Exec()
 }
 
 // editInMessagesByID runs the edit on the canonical row. Existence and the
 // not-deleted check are already enforced by the service layer's findMessage,
 // so this is a plain UPDATE rather than an LWT.
-func (r *Repository) editInMessagesByID(ctx context.Context, msg *models.Message, ep editPayload, editedAt time.Time) error {
+func (r *Repository) editInMessagesByID(ctx context.Context, msg *models.Message, ep *editPayload, editedAt time.Time) error {
 	return r.editOne(ctx, editMsgByID, editMsgByIDEncrypted, ep, editedAt, msg.MessageID)
 }
 
-func (r *Repository) editInMessagesByRoom(ctx context.Context, msg *models.Message, ep editPayload, editedAt time.Time) error {
+func (r *Repository) editInMessagesByRoom(ctx context.Context, msg *models.Message, ep *editPayload, editedAt time.Time) error {
 	b := r.bucket.Of(msg.CreatedAt)
 	return r.editOne(ctx, editMsgByRoom, editMsgByRoomEncrypted, ep, editedAt, msg.RoomID, b, msg.CreatedAt, msg.MessageID)
 }
 
 // editInThreadMessagesByThread edits the thread mirror row. thread_messages_by_thread
 // is partitioned by thread_room_id alone, so room_id/bucket no longer enter the key.
-func (r *Repository) editInThreadMessagesByThread(ctx context.Context, msg *models.Message, ep editPayload, editedAt time.Time) error {
+func (r *Repository) editInThreadMessagesByThread(ctx context.Context, msg *models.Message, ep *editPayload, editedAt time.Time) error {
 	return r.editOne(ctx, editThreadMsg, editThreadMsgEncrypted, ep, editedAt, msg.ThreadRoomID, msg.CreatedAt, msg.MessageID)
 }
 
-func (r *Repository) editInPinnedMessagesByRoom(ctx context.Context, msg *models.Message, ep editPayload, editedAt time.Time) error {
+func (r *Repository) editInPinnedMessagesByRoom(ctx context.Context, msg *models.Message, ep *editPayload, editedAt time.Time) error {
 	return r.editOne(ctx, editPinnedMsg, editPinnedMsgEncrypted, ep, editedAt, msg.RoomID, *msg.PinnedAt, msg.MessageID)
 }
 
@@ -231,7 +256,7 @@ func (r *Repository) deleteInPinnedMessagesByRoom(ctx context.Context, q string,
 	return r.session.Query(q, deletedAt, msg.RoomID, *msg.PinnedAt, msg.MessageID).WithContext(ctx).Exec()
 }
 
-func (r *Repository) UpdateMessageContent(ctx context.Context, msg *models.Message, newMsg string, editedAt time.Time) error {
+func (r *Repository) UpdateMessageContent(ctx context.Context, msg *models.Message, newMsg string, mentions []pkgmodel.Participant, editedAt time.Time) error {
 	if msg.ThreadParentID != "" && msg.ThreadRoomID == "" {
 		return fmt.Errorf("edit thread message %s: ThreadParentID %q is set but ThreadRoomID is empty", msg.MessageID, msg.ThreadParentID)
 	}
@@ -242,7 +267,7 @@ func (r *Repository) UpdateMessageContent(ctx context.Context, msg *models.Messa
 	// cipher-enabled path, buildEditPayload still reads the canonical row to
 	// re-encrypt while preserving the other encrypted fields; a missing row
 	// there surfaces as ErrMessageNotFound.
-	ep, err := r.buildEditPayload(ctx, msg, newMsg)
+	ep, err := r.buildEditPayload(ctx, msg, newMsg, mentions)
 	if err != nil {
 		if errors.Is(err, ErrMessageNotFound) {
 			return fmt.Errorf("edit message %s: %w", msg.MessageID, ErrMessageNotFound)
@@ -250,16 +275,16 @@ func (r *Repository) UpdateMessageContent(ctx context.Context, msg *models.Messa
 		return fmt.Errorf("prepare edit payload for message %s: %w", msg.MessageID, err)
 	}
 
-	if err := r.editInMessagesByID(ctx, msg, ep, editedAt); err != nil {
+	if err := r.editInMessagesByID(ctx, msg, &ep, editedAt); err != nil {
 		return fmt.Errorf("update messages_by_id for message %s: %w", msg.MessageID, err)
 	}
 
 	if msg.ThreadParentID == "" {
-		if err := r.editInMessagesByRoom(ctx, msg, ep, editedAt); err != nil {
+		if err := r.editInMessagesByRoom(ctx, msg, &ep, editedAt); err != nil {
 			return fmt.Errorf("update messages_by_room for message %s in room %s: %w", msg.MessageID, msg.RoomID, err)
 		}
 	} else {
-		if err := r.editInThreadMessagesByThread(ctx, msg, ep, editedAt); err != nil {
+		if err := r.editInThreadMessagesByThread(ctx, msg, &ep, editedAt); err != nil {
 			return fmt.Errorf("update thread_messages_by_thread for message %s thread %s: %w", msg.MessageID, msg.ThreadRoomID, err)
 		}
 		// A TShow ("also send to channel") thread reply is dual-written into
@@ -267,14 +292,14 @@ func (r *Repository) UpdateMessageContent(ctx context.Context, msg *models.Messa
 		// the channel-timeline copy goes stale. Additive on top of the thread
 		// edit — same shape as the PinnedAt branch below.
 		if msg.TShow {
-			if err := r.editInMessagesByRoom(ctx, msg, ep, editedAt); err != nil {
+			if err := r.editInMessagesByRoom(ctx, msg, &ep, editedAt); err != nil {
 				return fmt.Errorf("update messages_by_room for tshow thread message %s in room %s: %w", msg.MessageID, msg.RoomID, err)
 			}
 		}
 	}
 
 	if msg.PinnedAt != nil {
-		if err := r.editInPinnedMessagesByRoom(ctx, msg, ep, editedAt); err != nil {
+		if err := r.editInPinnedMessagesByRoom(ctx, msg, &ep, editedAt); err != nil {
 			return fmt.Errorf("update pinned_messages_by_room for message %s in room %s: %w", msg.MessageID, msg.RoomID, err)
 		}
 	}

--- a/history-service/internal/cassrepo/write_integration_test.go
+++ b/history-service/internal/cassrepo/write_integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hmchangw/chat/history-service/internal/models"
 	"github.com/hmchangw/chat/pkg/atrest"
+	pkgmodel "github.com/hmchangw/chat/pkg/model"
 	cassmodel "github.com/hmchangw/chat/pkg/model/cassandra"
 	"github.com/hmchangw/chat/pkg/msgbucket"
 )
@@ -46,7 +47,7 @@ func TestRepository_UpdateMessageContent_TopLevel(t *testing.T) {
 		ThreadParentID: "",
 	}
 	editedAt := createdAt.Add(time.Minute)
-	require.NoError(t, repo.UpdateMessageContent(ctx, msg, "edited", editedAt))
+	require.NoError(t, repo.UpdateMessageContent(ctx, msg, "edited", nil, editedAt))
 
 	// messages_by_id updated
 	var gotMsg string
@@ -102,7 +103,7 @@ func TestRepository_UpdateMessageContent_ThreadReply(t *testing.T) {
 		ThreadRoomID:   threadRoomID,
 	}
 	editedAt := createdAt.Add(time.Minute)
-	require.NoError(t, repo.UpdateMessageContent(ctx, msg, "edited", editedAt))
+	require.NoError(t, repo.UpdateMessageContent(ctx, msg, "edited", nil, editedAt))
 
 	// messages_by_id updated
 	var gotMsg string
@@ -165,7 +166,7 @@ func TestRepository_UpdateMessageContent_Pinned(t *testing.T) {
 		PinnedAt:       &pinnedAt,
 	}
 	editedAt := createdAt.Add(time.Minute)
-	require.NoError(t, repo.UpdateMessageContent(ctx, msg, "edited", editedAt))
+	require.NoError(t, repo.UpdateMessageContent(ctx, msg, "edited", nil, editedAt))
 
 	// All three affected tables updated
 	var gotMsg string
@@ -672,7 +673,7 @@ func TestRepository_UpdateMessageContent_MissingThreadRoomID_ReturnsError(t *tes
 		ThreadParentID: "m-parent",
 		ThreadRoomID:   "",
 	}
-	err := repo.UpdateMessageContent(ctx, msg, "edited", createdAt.Add(time.Minute))
+	err := repo.UpdateMessageContent(ctx, msg, "edited", nil, createdAt.Add(time.Minute))
 	require.Error(t, err, "expected error when ThreadRoomID is empty for a thread reply")
 
 	// Validation must fire before any DB write — messages_by_id must be unchanged.
@@ -844,16 +845,24 @@ func TestRepository_UpdateMessageContent_RoundTrip(t *testing.T) {
 		ThreadParentID: "",
 	}
 	editedAt := createdAt.Add(time.Minute)
-	require.NoError(t, repo.UpdateMessageContent(ctx, msg, "updated content", editedAt))
+	// An edit that adds an @mention must persist the resolved mentions column so
+	// history reads return the post-edit mentions (the bug this test guards).
+	mentions := []pkgmodel.Participant{{UserID: "bob-id", Account: "bob", EngName: "Bob", ChineseName: "鮑勃"}}
+	require.NoError(t, repo.UpdateMessageContent(ctx, msg, "updated content @bob", mentions, editedAt))
 
 	got, err := repo.GetMessageByID(ctx, msgID)
 	require.NoError(t, err)
 	require.NotNil(t, got)
-	assert.Equal(t, "updated content", got.Msg)
+	assert.Equal(t, "updated content @bob", got.Msg)
 	require.NotNil(t, got.EditedAt)
 	assert.Equal(t, editedAt.UTC(), got.EditedAt.UTC())
 	require.NotNil(t, got.UpdatedAt)
 	assert.Equal(t, editedAt.UTC(), got.UpdatedAt.UTC())
+	require.Len(t, got.Mentions, 1)
+	assert.Equal(t, "bob", got.Mentions[0].Account)
+	assert.Equal(t, "bob-id", got.Mentions[0].ID)
+	assert.Equal(t, "Bob", got.Mentions[0].EngName)
+	assert.Equal(t, "鮑勃", got.Mentions[0].CompanyName)
 }
 
 // TestRepository_SoftDeleteMessage_RoundTrip verifies that after soft-deleting
@@ -1113,7 +1122,7 @@ func TestEditMessage_EncryptsBody(t *testing.T) {
 	editedAt := now.Add(time.Minute)
 	require.NoError(t, repo.UpdateMessageContent(ctx, &models.Message{
 		RoomID: roomID, MessageID: "m1", CreatedAt: now,
-	}, "new body", editedAt))
+	}, "new body", nil, editedAt))
 
 	// Direct CQL: msg column is null, enc_payload is non-nil and decrypts to "new body".
 	var (
@@ -1168,7 +1177,7 @@ func TestEditMessage_PreservesOtherEncryptedFields(t *testing.T) {
 	editedAt := now.Add(time.Minute)
 	require.NoError(t, repo.UpdateMessageContent(ctx, &models.Message{
 		RoomID: roomID, MessageID: "m1", CreatedAt: now,
-	}, "new body", editedAt))
+	}, "new body", nil, editedAt))
 
 	var (
 		encPayload []byte
@@ -1223,7 +1232,7 @@ func TestEditMessage_LegacyRow_PreservesPlaintextAttachments(t *testing.T) {
 	editedAt := now.Add(time.Minute)
 	require.NoError(t, repo.UpdateMessageContent(ctx, &models.Message{
 		RoomID: roomID, MessageID: "m-legacy", CreatedAt: now,
-	}, "edited body", editedAt))
+	}, "edited body", nil, editedAt))
 
 	// Decrypt directly to verify the re-encrypted bundle carries the
 	// legacy plaintext fields forward.
@@ -1315,7 +1324,7 @@ func TestUpdateMessageContent_NonExistent_CipherEnabled_ReturnsErrMessageNotFoun
 
 	err := repo.UpdateMessageContent(ctx, &models.Message{
 		RoomID: "r-ghost", MessageID: "m-ghost-enc", CreatedAt: now,
-	}, "should not land", now.Add(time.Minute))
+	}, "should not land", nil, now.Add(time.Minute))
 	require.ErrorIs(t, err, ErrMessageNotFound, "edit of non-existent message must surface ErrMessageNotFound on the cipher path")
 
 	// No ghost row was materialised.
@@ -1362,7 +1371,7 @@ func TestEditMessage_Encrypted_NullsLegacyPlaintextColumns(t *testing.T) {
 
 	require.NoError(t, repo.UpdateMessageContent(ctx, &models.Message{
 		RoomID: roomID, MessageID: "m-null", CreatedAt: now,
-	}, "edited", now.Add(time.Minute)))
+	}, "edited", nil, now.Add(time.Minute)))
 
 	for _, table := range []struct {
 		name string
@@ -1438,7 +1447,7 @@ func TestEditMessage_Encrypted_PreservesQuotedParentMetadata(t *testing.T) {
 
 	require.NoError(t, repo.UpdateMessageContent(ctx, &models.Message{
 		RoomID: roomID, MessageID: "m-child", CreatedAt: now,
-	}, "edited child body", now.Add(time.Minute)))
+	}, "edited child body", nil, now.Add(time.Minute)))
 
 	// Read back through the history read path (decrypt + struct scan).
 	got, err := repo.GetMessageByID(ctx, "m-child")
@@ -1491,7 +1500,7 @@ func TestEditMessage_Plaintext_NullsEncryptedColumns(t *testing.T) {
 	repo := NewRepository(session, sizer, 365, nil)
 	require.NoError(t, repo.UpdateMessageContent(ctx, &models.Message{
 		RoomID: roomID, MessageID: "m-rb", CreatedAt: now,
-	}, "v2", now.Add(time.Minute)))
+	}, "v2", nil, now.Add(time.Minute)))
 
 	for _, table := range []struct {
 		name string
@@ -1564,7 +1573,7 @@ func TestEditMessage_Encrypted_PreservesLegacyQuotedParentMetadata(t *testing.T)
 
 	require.NoError(t, repo.UpdateMessageContent(ctx, &models.Message{
 		RoomID: roomID, MessageID: "m-q", CreatedAt: now,
-	}, "edited body", now.Add(time.Minute)))
+	}, "edited body", nil, now.Add(time.Minute)))
 
 	for _, table := range []struct {
 		name string
@@ -1643,7 +1652,7 @@ func TestRepository_UpdateMessageContent_TShowThreadReply(t *testing.T) {
 		TShow:          true,
 	}
 	editedAt := createdAt.Add(time.Minute)
-	require.NoError(t, repo.UpdateMessageContent(ctx, msg, "edited", editedAt))
+	require.NoError(t, repo.UpdateMessageContent(ctx, msg, "edited", nil, editedAt))
 
 	var gotMsg string
 	var gotEditedAt time.Time

--- a/history-service/internal/service/integration_test.go
+++ b/history-service/internal/service/integration_test.go
@@ -185,11 +185,20 @@ func (stubRoomRepo) ClearPreview(_ context.Context, _ string, _ int64) (bool, er
 	return true, nil
 }
 
+type stubUserStore struct{}
+
+func (stubUserStore) FindUserByAccount(_ context.Context, _ string) (*model.User, error) {
+	return nil, nil
+}
+func (stubUserStore) FindUsersByAccounts(_ context.Context, _ []string) ([]model.User, error) {
+	return nil, nil
+}
+
 func TestEditMessage_Integration(t *testing.T) {
 	session := setupCassandra(t)
 	repo := cassrepo.NewRepository(session, msgbucket.New(24*time.Hour), 365, nil)
 	pub := &recordingPublisher{}
-	svc := closeOnCleanupIn(t, New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, pub, nil, nil, nil, nil, &config.Config{
+	svc := closeOnCleanupIn(t, New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, pub, nil, nil, stubUserStore{}, nil, &config.Config{
 		MessageHistoryFloorDays: 730,
 		LargeRoomThreshold:      500,
 		MaxPinnedPerRoom:        10,
@@ -253,7 +262,7 @@ func TestDeleteMessage_Integration(t *testing.T) {
 	session := setupCassandra(t)
 	repo := cassrepo.NewRepository(session, msgbucket.New(24*time.Hour), 365, nil)
 	pub := &recordingPublisher{}
-	svc := closeOnCleanupIn(t, New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, pub, nil, nil, nil, nil, &config.Config{
+	svc := closeOnCleanupIn(t, New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, pub, nil, nil, stubUserStore{}, nil, &config.Config{
 		MessageHistoryFloorDays: 730,
 		LargeRoomThreshold:      500,
 		MaxPinnedPerRoom:        10,
@@ -315,7 +324,7 @@ func TestDeleteMessage_ParentWithReplies_NoCascade(t *testing.T) {
 	session := setupCassandra(t)
 	repo := cassrepo.NewRepository(session, msgbucket.New(24*time.Hour), 365, nil)
 	pub := &recordingPublisher{}
-	svc := closeOnCleanupIn(t, New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, pub, nil, nil, nil, nil, &config.Config{
+	svc := closeOnCleanupIn(t, New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, pub, nil, nil, stubUserStore{}, nil, &config.Config{
 		MessageHistoryFloorDays: 730,
 		LargeRoomThreshold:      500,
 		MaxPinnedPerRoom:        10,
@@ -384,7 +393,7 @@ func TestDeleteMessage_Integration_ThreadReplyPublishesMetadataEvent(t *testing.
 	session := setupCassandra(t)
 	repo := cassrepo.NewRepository(session, msgbucket.New(24*time.Hour), 365, nil)
 	pub := &recordingPublisher{}
-	svc := closeOnCleanupIn(t, New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, pub, nil, nil, nil, nil, &config.Config{
+	svc := closeOnCleanupIn(t, New(repo, alwaysSubscribedRepo{}, stubRoomRepo{}, pub, nil, nil, stubUserStore{}, nil, &config.Config{
 		MessageHistoryFloorDays: 730,
 		LargeRoomThreshold:      500,
 		MaxPinnedPerRoom:        10,

--- a/history-service/internal/service/messages.go
+++ b/history-service/internal/service/messages.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hmchangw/chat/history-service/internal/cassrepo"
 	"github.com/hmchangw/chat/history-service/internal/models"
 	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/mention"
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/natsrouter"
 	"github.com/hmchangw/chat/pkg/natsutil"
@@ -519,8 +520,17 @@ func (s *HistoryService) EditMessage(c *natsrouter.Context, siteID string, req m
 		return nil, errcode.BadRequest("newMsg exceeds maximum size")
 	}
 
+	// Re-resolve @mentions from the edited content so the persisted row, the
+	// canonical event and search-sync all reflect the post-edit mentions.
+	// Degrade on lookup error (mirrors broadcast-worker): a mention we can't
+	// resolve drops to plain text, the edit still lands.
+	resolved, err := mention.Resolve(c, req.NewMsg, s.users.FindUsersByAccounts)
+	if err != nil {
+		slog.WarnContext(c, "resolving edited mentions", "error", err, "room_id", roomID, "message_id", req.MessageID)
+	}
+
 	editedAt := time.Now().UTC()
-	if err := s.msgWriter.UpdateMessageContent(c, msg, req.NewMsg, editedAt); err != nil {
+	if err := s.msgWriter.UpdateMessageContent(c, msg, req.NewMsg, resolved.Participants, editedAt); err != nil {
 		// A TOCTOU between findMessage and the CAS edit is a benign race, not a server
 		// fault — map it to 4xx so it doesn't pollute 5xx telemetry.
 		if errors.Is(err, cassrepo.ErrMessageNotFound) {
@@ -532,7 +542,8 @@ func (s *HistoryService) EditMessage(c *natsrouter.Context, siteID string, req m
 	editedAtMs := editedAt.UnixMilli()
 
 	// search-sync-worker reindexes the FULL doc, so attachments/card must ride
-	// along or edits wipe them. Mentions omitted: broadcast-worker re-resolves.
+	// along or edits wipe them. Mentions carry the re-resolved set so the stored
+	// row, the event and search-sync agree on the post-edit mentions.
 	canonicalEvt := model.MessageEvent{
 		Event: model.EventUpdated,
 		Message: model.Message{
@@ -543,6 +554,7 @@ func (s *HistoryService) EditMessage(c *natsrouter.Context, siteID string, req m
 			Content:                      req.NewMsg,
 			Attachments:                  msg.Attachments,
 			Card:                         msg.Card,
+			Mentions:                     resolved.Participants,
 			CreatedAt:                    msg.CreatedAt,
 			EditedAt:                     &editedAt,
 			UpdatedAt:                    &editedAt,

--- a/history-service/internal/service/messages.go
+++ b/history-service/internal/service/messages.go
@@ -521,12 +521,12 @@ func (s *HistoryService) EditMessage(c *natsrouter.Context, siteID string, req m
 	}
 
 	// Re-resolve @mentions from the edited content so the persisted row, the
-	// canonical event and search-sync all reflect the post-edit mentions.
-	// Degrade on lookup error (mirrors broadcast-worker): a mention we can't
-	// resolve drops to plain text, the edit still lands.
+	// canonical event and search-sync all reflect the post-edit mentions. Fail
+	// closed on a lookup error: a partial/empty set would be written over (or
+	// clear) the stored mentions, permanently losing them. A retry resolves clean.
 	resolved, err := mention.Resolve(c, req.NewMsg, s.users.FindUsersByAccounts)
 	if err != nil {
-		slog.WarnContext(c, "resolving edited mentions", "error", err, "room_id", roomID, "message_id", req.MessageID)
+		return nil, fmt.Errorf("resolve edited mentions for %s: %w", req.MessageID, err)
 	}
 
 	editedAt := time.Now().UTC()

--- a/history-service/internal/service/messages_test.go
+++ b/history-service/internal/service/messages_test.go
@@ -1576,7 +1576,10 @@ func TestHistoryService_EditMessage_ResolvesAndPersistsMentions(t *testing.T) {
 
 // A user-lookup failure degrades: the edit still succeeds, persisting no
 // individual mentions rather than failing the whole edit.
-func TestHistoryService_EditMessage_MentionLookupError_StillEdits(t *testing.T) {
+// A mention-lookup failure must fail the edit closed — persisting a partial or
+// empty mention set would overwrite (or clear) the stored mentions and lose
+// them permanently. No write, no publish; a retry resolves cleanly.
+func TestHistoryService_EditMessage_MentionLookupError_FailsClosed(t *testing.T) {
 	svc, msgs, subs, rooms, pub, _, users, _ := newServiceWithRoomMock(t)
 	c := testContext()
 
@@ -1599,15 +1602,13 @@ func TestHistoryService_EditMessage_MentionLookupError_StillEdits(t *testing.T) 
 		Return(nil, errors.New("mongo down")).
 		Times(1)
 
-	// Degrade: no individual mentions resolved, but the edit persists and publishes.
-	msgs.EXPECT().
-		UpdateMessageContent(gomock.Any(), hydrated, "hey @bob", []model.Participant(nil), gomock.Any()).
-		Return(nil)
-	pub.EXPECT().Publish(gomock.Any(), subject.MsgCanonicalUpdated("site-test"), gomock.Any(), gomock.Any()).Return(nil)
+	// No persist, no publish — the edit fails before either.
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	pub.EXPECT().Publish(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 	resp, err := svc.EditMessage(c, "site-test", models.EditMessageRequest{MessageID: "msg-1", NewMsg: "hey @bob"})
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	require.Error(t, err)
+	require.Nil(t, resp)
 }
 
 // .updated is a full-doc replace: it must carry attachments and card,

--- a/history-service/internal/service/messages_test.go
+++ b/history-service/internal/service/messages_test.go
@@ -1455,7 +1455,7 @@ func TestHistoryService_EditMessage_UpdateFails(t *testing.T) {
 	}
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "m-abc").Return(hydrated, nil)
 	msgs.EXPECT().
-		UpdateMessageContent(gomock.Any(), hydrated, "new content", gomock.Any()).
+		UpdateMessageContent(gomock.Any(), hydrated, "new content", gomock.Any(), gomock.Any()).
 		Return(fmt.Errorf("cassandra timeout"))
 
 	// The publisher mock expects no calls — gomock fails the test if the failed UPDATE still publishes.
@@ -1480,7 +1480,7 @@ func TestHistoryService_EditMessage_RaceWithDelete_MapsToNotFound(t *testing.T) 
 	}
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "m-race").Return(hydrated, nil)
 	msgs.EXPECT().
-		UpdateMessageContent(gomock.Any(), hydrated, "new content", gomock.Any()).
+		UpdateMessageContent(gomock.Any(), hydrated, "new content", gomock.Any(), gomock.Any()).
 		Return(fmt.Errorf("edit message m-race: %w", cassrepo.ErrMessageNotFound))
 
 	resp, err := svc.EditMessage(c, "site-test", models.EditMessageRequest{MessageID: "m-race", NewMsg: "new content"})
@@ -1501,7 +1501,7 @@ func TestHistoryService_EditMessage_PublishesCanonicalUpdatedEvent(t *testing.T)
 		Msg:       "original content",
 	}
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
-	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "updated content", gomock.Any()).Return(nil)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "updated content", gomock.Any(), gomock.Any()).Return(nil)
 
 	pub.EXPECT().
 		Publish(gomock.Any(), subject.MsgCanonicalUpdated("site-test"), gomock.Any(), gomock.Any()).
@@ -1529,6 +1529,87 @@ func TestHistoryService_EditMessage_PublishesCanonicalUpdatedEvent(t *testing.T)
 	require.NotNil(t, resp)
 }
 
+// An edit that changes @mentions must resolve them and persist the resolved set
+// (so history reads return post-edit mentions) AND carry them on the canonical event.
+func TestHistoryService_EditMessage_ResolvesAndPersistsMentions(t *testing.T) {
+	svc, msgs, subs, rooms, pub, _, users, _ := newServiceWithRoomMock(t)
+	c := testContext()
+
+	// Permissive preview-walk stubs (empty room → ClearPreview).
+	rooms.EXPECT().ClearPreview(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+	rooms.EXPECT().InvalidatePreviewKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	expectEmptyPreviewWalk(msgs)
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
+	hydrated := &models.Message{
+		MessageID: "msg-1",
+		RoomID:    "r1",
+		Sender:    models.Participant{Account: "u1", ID: "u1-id"},
+		CreatedAt: time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC),
+		Msg:       "original content",
+	}
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
+
+	users.EXPECT().
+		FindUsersByAccounts(gomock.Any(), []string{"bob"}).
+		Return([]model.User{{ID: "bob-id", Account: "bob", SiteID: "site-test", EngName: "Bob", ChineseName: "鮑勃"}}, nil).
+		Times(1)
+
+	wantMentions := []model.Participant{{UserID: "bob-id", Account: "bob", SiteID: "site-test", ChineseName: "鮑勃", EngName: "Bob"}}
+	msgs.EXPECT().
+		UpdateMessageContent(gomock.Any(), hydrated, "hey @bob", wantMentions, gomock.Any()).
+		Return(nil)
+
+	pub.EXPECT().
+		Publish(gomock.Any(), subject.MsgCanonicalUpdated("site-test"), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, data []byte, _ string) error {
+			var evt model.MessageEvent
+			require.NoError(t, json.Unmarshal(data, &evt))
+			assert.Equal(t, wantMentions, evt.Message.Mentions)
+			return nil
+		})
+
+	resp, err := svc.EditMessage(c, "site-test", models.EditMessageRequest{MessageID: "msg-1", NewMsg: "hey @bob"})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+// A user-lookup failure degrades: the edit still succeeds, persisting no
+// individual mentions rather than failing the whole edit.
+func TestHistoryService_EditMessage_MentionLookupError_StillEdits(t *testing.T) {
+	svc, msgs, subs, rooms, pub, _, users, _ := newServiceWithRoomMock(t)
+	c := testContext()
+
+	rooms.EXPECT().ClearPreview(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+	rooms.EXPECT().InvalidatePreviewKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	expectEmptyPreviewWalk(msgs)
+
+	subs.EXPECT().GetHistorySharedSince(gomock.Any(), "u1", "r1").Return(nil, true, nil)
+	hydrated := &models.Message{
+		MessageID: "msg-1",
+		RoomID:    "r1",
+		Sender:    models.Participant{Account: "u1", ID: "u1-id"},
+		CreatedAt: time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC),
+		Msg:       "original content",
+	}
+	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
+
+	users.EXPECT().
+		FindUsersByAccounts(gomock.Any(), []string{"bob"}).
+		Return(nil, errors.New("mongo down")).
+		Times(1)
+
+	// Degrade: no individual mentions resolved, but the edit persists and publishes.
+	msgs.EXPECT().
+		UpdateMessageContent(gomock.Any(), hydrated, "hey @bob", []model.Participant(nil), gomock.Any()).
+		Return(nil)
+	pub.EXPECT().Publish(gomock.Any(), subject.MsgCanonicalUpdated("site-test"), gomock.Any(), gomock.Any()).Return(nil)
+
+	resp, err := svc.EditMessage(c, "site-test", models.EditMessageRequest{MessageID: "msg-1", NewMsg: "hey @bob"})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
 // .updated is a full-doc replace: it must carry attachments and card,
 // or the re-index wipes those fields from the search document.
 func TestHistoryService_EditMessage_CarriesAttachmentsAndCard(t *testing.T) {
@@ -1551,7 +1632,7 @@ func TestHistoryService_EditMessage_CarriesAttachmentsAndCard(t *testing.T) {
 		CardAction:  cardAction,
 	}
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
-	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "updated content", gomock.Any()).Return(nil)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "updated content", gomock.Any(), gomock.Any()).Return(nil)
 
 	pub.EXPECT().
 		Publish(gomock.Any(), subject.MsgCanonicalUpdated("site-test"), gomock.Any(), gomock.Any()).
@@ -1590,7 +1671,7 @@ func TestHistoryService_EditMessage_PublishFailureDoesNotFailRPC(t *testing.T) {
 		Msg:       "original content",
 	}
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
-	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "updated content", gomock.Any()).Return(nil)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "updated content", gomock.Any(), gomock.Any()).Return(nil)
 
 	pub.EXPECT().
 		Publish(gomock.Any(), subject.MsgCanonicalUpdated("site-test"), gomock.Any(), gomock.Any()).
@@ -1621,7 +1702,7 @@ func TestHistoryService_EditMessage_PassesDedupMessageID(t *testing.T) {
 		Msg:       "original",
 	}
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
-	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "updated", gomock.Any()).Return(nil)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "updated", gomock.Any(), gomock.Any()).Return(nil)
 
 	pub.EXPECT().
 		Publish(gomock.Any(), subject.MsgCanonicalUpdated("site-test"), gomock.Any(), gomock.Any()).
@@ -1952,7 +2033,7 @@ func TestHistoryService_EditMessage_EmbedsRefreshedPreview(t *testing.T) {
 		Msg:       "original content",
 	}
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
-	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "updated content", gomock.Any()).Return(nil)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "updated content", gomock.Any(), gomock.Any()).Return(nil)
 	// roomLastMessage walk: the refreshed preview is the edited message itself.
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{
@@ -2204,7 +2285,7 @@ func TestHistoryService_EditMessage_PreviewWriteFails_WithdrawsTheFreshnessKey(t
 		Msg:       "before",
 	}
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
-	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "after", gomock.Any()).Return(nil)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "after", gomock.Any(), gomock.Any()).Return(nil)
 	expectSurvivorWalk(msgs)
 	pub.EXPECT().
 		Publish(gomock.Any(), subject.MsgCanonicalUpdated("site-test"), gomock.Any(), gomock.Any()).
@@ -2270,7 +2351,7 @@ func TestHistoryService_EditMessage_HiddenThreadReply_SkipsPreviewWalk(t *testin
 		TShow:                 false,
 	}
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "reply-1").Return(hydrated, nil)
-	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "edited reply", gomock.Any()).Return(nil)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "edited reply", gomock.Any(), gomock.Any()).Return(nil)
 	// No GetMessagesBefore expectation: the walk must be skipped for hidden thread replies.
 
 	pub.EXPECT().
@@ -2305,7 +2386,7 @@ func TestHistoryService_EditMessage_TShowThreadReply_EmbedsPreview(t *testing.T)
 		TShow:                 true,
 	}
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "reply-1").Return(hydrated, nil)
-	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "edited reply", gomock.Any()).Return(nil)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "edited reply", gomock.Any(), gomock.Any()).Return(nil)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{
 			{MessageID: "m-latest", RoomID: "r1", Sender: models.Participant{Account: "u1", ID: "u1-id"}, Msg: "latest", CreatedAt: hydrated.CreatedAt},
@@ -2344,7 +2425,7 @@ func TestHistoryService_EditMessage_ThreadReply_CarriesThreadFields(t *testing.T
 		TShow:                 false,
 	}
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "reply-1").Return(hydrated, nil)
-	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "edited reply", gomock.Any()).Return(nil)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), hydrated, "edited reply", gomock.Any(), gomock.Any()).Return(nil)
 	// No GetMessagesBefore expectation: thread replies skip the preview walk.
 
 	pub.EXPECT().

--- a/history-service/internal/service/migration.go
+++ b/history-service/internal/service/migration.go
@@ -66,14 +66,18 @@ func (s *HistoryService) MigrationEditMessage(c *natsrouter.Context, siteID stri
 	evt := model.MessageEvent{
 		Event: model.EventUpdated,
 		Message: model.Message{
-			ID:                           msg.MessageID,
-			RoomID:                       msg.RoomID,
-			UserID:                       msg.Sender.ID,
-			UserAccount:                  msg.Sender.Account,
-			CreatedAt:                    msg.CreatedAt,
-			Content:                      req.Content,
-			Attachments:                  msg.Attachments,
-			Card:                         msg.Card,
+			ID:          msg.MessageID,
+			RoomID:      msg.RoomID,
+			UserID:      msg.Sender.ID,
+			UserAccount: msg.Sender.Account,
+			CreatedAt:   msg.CreatedAt,
+			Content:     req.Content,
+			Attachments: msg.Attachments,
+			Card:        msg.Card,
+			// Carry the preserved mentions: canonical consumers rebuild the full
+			// doc, so omitting them would erase mentions from search on a
+			// content-only migration edit while Cassandra keeps them.
+			Mentions:                     existingMentions,
 			EditedAt:                     &editedAt,
 			UpdatedAt:                    &editedAt,
 			ThreadParentMessageID:        msg.ThreadParentID,

--- a/history-service/internal/service/migration.go
+++ b/history-service/internal/service/migration.go
@@ -46,7 +46,14 @@ func (s *HistoryService) MigrationEditMessage(c *natsrouter.Context, siteID stri
 		return nil, errcode.NotFound("message not found in room")
 	}
 
-	if err := s.msgWriter.UpdateMessageContent(c, msg, req.Content, req.EditedAt); err != nil {
+	// Preserve the row's existing mentions: a migration edit replaces content
+	// from the legacy source, which carries no resolved mentions, so re-writing
+	// the column with its current value keeps this a content-only change.
+	existingMentions := make([]model.Participant, len(msg.Mentions))
+	for i := range msg.Mentions {
+		existingMentions[i] = toWireParticipant(&msg.Mentions[i])
+	}
+	if err := s.msgWriter.UpdateMessageContent(c, msg, req.Content, existingMentions, req.EditedAt); err != nil {
 		// Row vanished between read and update (hard-missing on the
 		// cipher-path read) — benign, retryable.
 		if errors.Is(err, cassrepo.ErrMessageNotFound) {

--- a/history-service/internal/service/migration_test.go
+++ b/history-service/internal/service/migration_test.go
@@ -50,6 +50,7 @@ func TestHistoryService_MigrationEditMessage_Success(t *testing.T) {
 		Msg:         "old body",
 		Attachments: attachments,
 		Card:        &models.Card{Template: "legacy-card-v1"},
+		Mentions:    []models.Participant{{Account: "carol", ID: "carol-id"}},
 	}
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
 
@@ -75,6 +76,9 @@ func TestHistoryService_MigrationEditMessage_Success(t *testing.T) {
 			assert.Equal(t, attachments, evt.Message.Attachments)
 			require.NotNil(t, evt.Message.Card)
 			assert.Equal(t, "legacy-card-v1", evt.Message.Card.Template)
+			// Preserved mentions ride the event so search-sync's full-doc replace keeps them.
+			require.Len(t, evt.Message.Mentions, 1)
+			assert.Equal(t, "carol", evt.Message.Mentions[0].Account)
 			// Event-level Timestamp is publish-time (now), distinct from the historical
 			// domain editedAt carried inside Message.
 			assert.Greater(t, evt.Timestamp, editedAt.UnixMilli())

--- a/history-service/internal/service/migration_test.go
+++ b/history-service/internal/service/migration_test.go
@@ -54,7 +54,7 @@ func TestHistoryService_MigrationEditMessage_Success(t *testing.T) {
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(hydrated, nil)
 
 	msgs.EXPECT().
-		UpdateMessageContent(gomock.Any(), migrationLocator("msg-1", "r1", createdAt), "new body", editedAt).
+		UpdateMessageContent(gomock.Any(), migrationLocator("msg-1", "r1", createdAt), "new body", gomock.Any(), editedAt).
 		Return(nil)
 
 	pub.EXPECT().
@@ -103,7 +103,7 @@ func TestHistoryService_MigrationEditMessage_AlreadyDeletedAcksOK(t *testing.T) 
 	createdAt := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").
 		Return(&models.Message{MessageID: "msg-1", RoomID: "r1", CreatedAt: createdAt, Deleted: true}, nil)
-	msgs.EXPECT().UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	pub.EXPECT().PublishMigration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 	ack, err := svc.MigrationEditMessage(c, "site-test", model.MigrationEditRequest{
@@ -124,7 +124,7 @@ func TestHistoryService_MigrationEditMessage_RoomMismatchRejected(t *testing.T) 
 	createdAt := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").
 		Return(&models.Message{MessageID: "msg-1", RoomID: "r-actual", CreatedAt: createdAt}, nil)
-	msgs.EXPECT().UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	pub.EXPECT().PublishMigration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 	ack, err := svc.MigrationEditMessage(c, "site-test", model.MigrationEditRequest{
@@ -144,7 +144,7 @@ func TestHistoryService_MigrationEditMessage_ReaderErrorPropagates(t *testing.T)
 
 	readerErr := errors.New("cassandra down")
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").Return(nil, readerErr)
-	msgs.EXPECT().UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	msgs.EXPECT().UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	pub.EXPECT().PublishMigration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 	_, err := svc.MigrationEditMessage(c, "site-test", model.MigrationEditRequest{
@@ -164,7 +164,7 @@ func TestHistoryService_MigrationEditMessage_RowVanishesRetries(t *testing.T) {
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").
 		Return(&models.Message{MessageID: "msg-1", RoomID: "r1", CreatedAt: createdAt}, nil)
 	msgs.EXPECT().
-		UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(fmt.Errorf("edit message msg-1: %w", cassrepo.ErrMessageNotFound))
 	pub.EXPECT().PublishMigration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
@@ -187,7 +187,7 @@ func TestHistoryService_MigrationEditMessage_WriterError(t *testing.T) {
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-1").
 		Return(&models.Message{MessageID: "msg-1", RoomID: "r1", CreatedAt: createdAt}, nil)
 	msgs.EXPECT().
-		UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(errors.New("cassandra down"))
 	// No publish on writer failure.
 	pub.EXPECT().PublishMigration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
@@ -323,7 +323,7 @@ func TestHistoryService_MigrationEditMessage_AbsentRowRetries(t *testing.T) {
 	// update and no publish happen.
 	msgs.EXPECT().GetMessageByID(gomock.Any(), "msg-5").Return(nil, nil)
 	msgs.EXPECT().
-		UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		UpdateMessageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(0)
 	pub.EXPECT().PublishMigration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 

--- a/history-service/internal/service/mocks/mock_repository.go
+++ b/history-service/internal/service/mocks/mock_repository.go
@@ -280,17 +280,17 @@ func (mr *MockMessageWriterMockRecorder) UnpinMessage(ctx, msg any) *gomock.Call
 }
 
 // UpdateMessageContent mocks base method.
-func (m *MockMessageWriter) UpdateMessageContent(ctx context.Context, msg *models.Message, newMsg string, editedAt time.Time) error {
+func (m *MockMessageWriter) UpdateMessageContent(ctx context.Context, msg *models.Message, newMsg string, mentions []model.Participant, editedAt time.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateMessageContent", ctx, msg, newMsg, editedAt)
+	ret := m.ctrl.Call(m, "UpdateMessageContent", ctx, msg, newMsg, mentions, editedAt)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateMessageContent indicates an expected call of UpdateMessageContent.
-func (mr *MockMessageWriterMockRecorder) UpdateMessageContent(ctx, msg, newMsg, editedAt any) *gomock.Call {
+func (mr *MockMessageWriterMockRecorder) UpdateMessageContent(ctx, msg, newMsg, mentions, editedAt any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMessageContent", reflect.TypeOf((*MockMessageWriter)(nil).UpdateMessageContent), ctx, msg, newMsg, editedAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMessageContent", reflect.TypeOf((*MockMessageWriter)(nil).UpdateMessageContent), ctx, msg, newMsg, mentions, editedAt)
 }
 
 // MockMessageRepository is a mock of MessageRepository interface.
@@ -527,17 +527,17 @@ func (mr *MockMessageRepositoryMockRecorder) UnpinMessage(ctx, msg any) *gomock.
 }
 
 // UpdateMessageContent mocks base method.
-func (m *MockMessageRepository) UpdateMessageContent(ctx context.Context, msg *models.Message, newMsg string, editedAt time.Time) error {
+func (m *MockMessageRepository) UpdateMessageContent(ctx context.Context, msg *models.Message, newMsg string, mentions []model.Participant, editedAt time.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateMessageContent", ctx, msg, newMsg, editedAt)
+	ret := m.ctrl.Call(m, "UpdateMessageContent", ctx, msg, newMsg, mentions, editedAt)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateMessageContent indicates an expected call of UpdateMessageContent.
-func (mr *MockMessageRepositoryMockRecorder) UpdateMessageContent(ctx, msg, newMsg, editedAt any) *gomock.Call {
+func (mr *MockMessageRepositoryMockRecorder) UpdateMessageContent(ctx, msg, newMsg, mentions, editedAt any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMessageContent", reflect.TypeOf((*MockMessageRepository)(nil).UpdateMessageContent), ctx, msg, newMsg, editedAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMessageContent", reflect.TypeOf((*MockMessageRepository)(nil).UpdateMessageContent), ctx, msg, newMsg, mentions, editedAt)
 }
 
 // MockSubscriptionRepository is a mock of SubscriptionRepository interface.

--- a/history-service/internal/service/service.go
+++ b/history-service/internal/service/service.go
@@ -31,7 +31,7 @@ type MessageReader interface {
 }
 
 type MessageWriter interface {
-	UpdateMessageContent(ctx context.Context, msg *models.Message, newMsg string, editedAt time.Time) error
+	UpdateMessageContent(ctx context.Context, msg *models.Message, newMsg string, mentions []pkgmodel.Participant, editedAt time.Time) error
 	// SoftDeleteMessage performs a Cassandra LWT on messages_by_id and only
 	// runs the mirror-table and parent-tcount work when the LWT applies.
 	// Returns the updated_at value now persisted (the deletedAt argument when

--- a/notes/audits/feat-subscription-count-http-46e7b9cb.md
+++ b/notes/audits/feat-subscription-count-http-46e7b9cb.md
@@ -1,0 +1,5 @@
+# pr-self-audit record
+branch: feat/subscription-count-http
+sha: 46e7b9cb
+audited_at: 2026-08-31T02:28:14Z
+verdict: HTTP count endpoint (unread filter); shared CountSubscriptionsFor; build+unit+integration-compile+lint green; docs + test.

--- a/notes/audits/fix-member-list-name-compat-alias-587a7cd1.md
+++ b/notes/audits/fix-member-list-name-compat-alias-587a7cd1.md
@@ -1,0 +1,5 @@
+# pr-self-audit record
+branch: fix/member-list-name-compat-alias
+sha: 587a7cd1
+audited_at: 2026-08-31T00:46:52Z
+verdict: restore name as deprecated alias of appName on RoomMemberEntry (emit both, same value). build+unit tests+integration-compile+lint green. doc-ratchet client-api.md RoomMemberEntry table. Draft; raise with mliu33 (fixes FE contract break from #431 rename).

--- a/notes/audits/fix-restricted-inherit-via-roommeta-b75f8b74.md
+++ b/notes/audits/fix-restricted-inherit-via-roommeta-b75f8b74.md
@@ -1,0 +1,6 @@
+# pr-self-audit record
+pr: 418
+branch: fix/restricted-inherit-via-roommeta
+sha: b75f8b74
+audited_at: 2026-08-31T02:45:13Z
+verdict: reshaped to denorm-only core (roommetacache Meta restricted/externalAccess projection so GetRoomMeta serves them; newSub denorm already on main #298). 3 files +67/-21; machinery deferred to planning #37. build+unit+integration-compile+lint green. tGD disposition posted.


### PR DESCRIPTION
## Summary

Editing a message to change its `@mentions` updated the content but **not** the stored `mentions`, so `getMessages` / `getThreadMessages` returned the stale create-time mentions. The live edit event was already correct (broadcast-worker re-resolves for the event), so only the persisted/history view diverged.

Root cause: history-service is the edit handler and persists edits, but its edit UPDATE statements omitted the `mentions` column, and the handler explicitly skipped resolving mentions ("broadcast-worker re-resolves") — which only fixes the live event, never storage or the search reindex.

## What's included

- The edit handler re-resolves `@mentions` from the new content (`mention.Resolve`, degrading to plain text on a lookup error — the edit never fails on it).
- The re-resolved mentions are persisted across every edit target — `messages_by_id`, `messages_by_room`, `thread_messages_by_thread`, `pinned_messages_by_room`, on both the plaintext and encrypted paths (mentions are metadata, written plaintext on both).
- The same set is placed on the canonical `EventUpdated` event so the stored row, the event, and search-sync all agree.

## Changes

- `history-service/internal/service/messages.go` — resolve edited mentions; pass to the writer; set on the canonical event.
- `history-service/internal/cassrepo/write.go` — `mentions = ?` added to the 8 edit UPDATE statements; `mentions` threaded through `editPayload` / `buildEditPayload` / `editOne` / `UpdateMessageContent`.
- `history-service/internal/service/service.go` — `UpdateMessageContent` signature.
- `history-service/internal/service/migration.go` — preserves the row's existing mentions (legacy source carries none), keeping migration a content-only change.
- Mock regenerated; unit + integration tests added.

## Verification

`go build`, unit tests (new: edit resolves + persists mentions, + the degrade path), `go vet -tags integration`, and golangci-lint are all green for history-service. Verified on our test environment: sending a message mentioning one user then editing it to mention another returns the **new** mention on a subsequent history read (previously returned the stale original).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Edited messages now correctly preserve and update `@mentions`.
  * Mention details remain consistent across message history and update events.
  * Edits now stop safely when mention lookup fails, preventing incomplete mention data from being saved.
  * Content-only migration edits preserve existing mentions.
  * Encrypted pinned-message edits remain compatible with updated message handling.
* **Tests**
  * Added coverage for mention resolution, persistence, event updates, lookup failures, migrations, and pinned-message edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->