### PR TITLE
fix(room-worker): render bot app name in member add/remove system messages

### DIFF
--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/orgdisplay"
 	"github.com/hmchangw/chat/pkg/outbox"
+	"github.com/hmchangw/chat/pkg/preview"
 	"github.com/hmchangw/chat/pkg/roomkeymetrics"
 	"github.com/hmchangw/chat/pkg/roomkeysender"
 	"github.com/hmchangw/chat/pkg/roomkeystore"
@@ -369,6 +370,26 @@ func (h *Handler) cleanupThreadMembership(ctx context.Context, roomID string, ac
 	return nil
 }
 
+// appNameLookup adapts store.GetApp to preview.AppNameLookup: no match is ("", nil)
+// so BotAwareDisplayName degrades to the composed name.
+func (h *Handler) appNameLookup(ctx context.Context, botAccount string) (string, error) {
+	app, err := h.store.GetApp(ctx, botAccount)
+	if errors.Is(err, ErrAppNotFound) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return app.Name, nil
+}
+
+// memberDisplayName renders a sys-msg member's name, substituting the registered app
+// name for a bot account. Only member-side names are bot-aware — the requester keeps
+// displayName() unchanged.
+func (h *Handler) memberDisplayName(ctx context.Context, u *model.User) string {
+	return preview.BotAwareDisplayName(ctx, h.appNameLookup, u.EngName, u.ChineseName, u.Account)
+}
+
 func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.RemoveMemberRequest, currentPair *roomkeystore.VersionedKeyPair) (err error) {
 	if req.Timestamp <= 0 {
 		req.Timestamp = time.Now().UTC().UnixMilli()
@@ -509,9 +530,9 @@ func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.Remove
 		fmt.Sprintf("%s:%s:%d", req.RoomID, req.Account, req.Timestamp))
 	var content string
 	if isSelfLeave {
-		content = formatLeft(&user.User)
+		content = formatLeft(h.memberDisplayName(ctx, &user.User))
 	} else {
-		content = formatRemovedUser(requester, &user.User)
+		content = formatRemovedUser(requester, h.memberDisplayName(ctx, &user.User))
 	}
 	sysMsg := model.Message{
 		ID:          idgen.MessageIDFromRequestID(seed, "rmindiv"),
@@ -1234,11 +1255,11 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 			sysMsgData, _ := json.Marshal(membersAdded)
 			seed := messageDedupSeed(ctx, "processAddMembers", req.RoomID,
 				fmt.Sprintf("%s:%s:%d", req.RoomID, req.RequesterAccount, req.Timestamp))
-			content := addedContent(requester, sysIndividuals, req.Orgs, func(a string) *model.User {
+			content := addedContent(requester, sysIndividuals, req.Orgs, func(a string) string {
 				if u, ok := userMap[a]; ok {
-					return &u
+					return h.memberDisplayName(ctx, &u)
 				}
-				return nil
+				return ""
 			})
 			sysMsg := model.Message{
 				ID:          idgen.MessageIDFromRequestID(seed, "addmembers"),
@@ -1948,8 +1969,11 @@ func (h *Handler) publishChannelSysMessages(ctx context.Context, req *model.Crea
 	if err != nil {
 		return fmt.Errorf("marshal members_added sys data: %w", err)
 	}
-	content := addedContent(requester, req.ResolvedUsers, req.ResolvedOrgs, func(a string) *model.User {
-		return userByAccount[a]
+	content := addedContent(requester, req.ResolvedUsers, req.ResolvedOrgs, func(a string) string {
+		if u, ok := userByAccount[a]; ok {
+			return h.memberDisplayName(ctx, u)
+		}
+		return ""
 	})
 	msg2 := model.Message{
 		ID:          idgen.MessageIDFromRequestID(requestID, "members_added"),

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -80,10 +80,13 @@ type Handler struct {
 	publishUsers func(ctx context.Context, users []model.IUserWithChange) error
 	// routeMode (ROOM_SUBJECT_MODE) gates same-site room .event namespaces; cross-site always global.
 	routeMode subject.RoomRouteMode
+	// appName is the cached bot app-name lookup (wraps appNameLookup); nil-safe
+	// because BotAwareDisplayName skips a nil lookup.
+	appName preview.AppNameLookup
 }
 
 func NewHandler(store SubscriptionStore, siteID string, publish PublishFunc, keyStore RoomKeyStore, keySender *roomkeysender.Sender, routeMode subject.RoomRouteMode) *Handler {
-	return &Handler{
+	h := &Handler{
 		store:            store,
 		siteID:           siteID,
 		publish:          publish,
@@ -92,6 +95,8 @@ func NewHandler(store SubscriptionStore, siteID string, publish PublishFunc, key
 		keyFanoutWorkers: defaultKeyFanoutWorkers,
 		routeMode:        routeMode,
 	}
+	h.appName = preview.CachedAppNameLookup(h.appNameLookup)
+	return h
 }
 
 // bustRoomMeta best-effort invalidates a room's L2 (Valkey) metadata entry
@@ -387,7 +392,7 @@ func (h *Handler) appNameLookup(ctx context.Context, botAccount string) (string,
 // name for a bot account. Only member-side names are bot-aware — the requester keeps
 // displayName() unchanged.
 func (h *Handler) memberDisplayName(ctx context.Context, u *model.User) string {
-	return preview.BotAwareDisplayName(ctx, h.appNameLookup, u.EngName, u.ChineseName, u.Account)
+	return preview.BotAwareDisplayName(ctx, h.appName, u.EngName, u.ChineseName, u.Account)
 }
 
 func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.RemoveMemberRequest, currentPair *roomkeystore.VersionedKeyPair) (err error) {

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hmchangw/chat/pkg/natsrouter"
 	"github.com/hmchangw/chat/pkg/natsutil"
 	"github.com/hmchangw/chat/pkg/orgdisplay"
+	"github.com/hmchangw/chat/pkg/preview"
 	"github.com/hmchangw/chat/pkg/roomkeysender"
 	"github.com/hmchangw/chat/pkg/roomkeystore"
 	"github.com/hmchangw/chat/pkg/roommetacache"
@@ -5765,6 +5766,7 @@ func TestHandler_ProcessAddMembers_Content_SingleBot(t *testing.T) {
 		published = append(published, publishedMsg{subj: subj, data: data})
 		return nil
 	}, keyStore: testKeyStore, keySender: testKeySender}
+	h.appName = preview.CachedAppNameLookup(h.appNameLookup)
 
 	req := model.AddMembersRequest{
 		RoomID: roomID, RequesterID: "u_a", RequesterAccount: "alice",
@@ -6115,6 +6117,7 @@ func TestHandler_ProcessRemoveIndividual_RemovedByOther_BotContent(t *testing.T)
 		published = append(published, publishedMsg{subj: subj, data: data})
 		return nil
 	}, keyStore: testKeyStore, keySender: testKeySender}
+	h.appName = preview.CachedAppNameLookup(h.appNameLookup)
 
 	req := model.RemoveMemberRequest{RoomID: roomID, Requester: "alice", Account: "helper.bot", Timestamp: 1}
 	require.NoError(t, h.processRemoveIndividual(context.Background(), &req, nil))
@@ -6123,99 +6126,72 @@ func TestHandler_ProcessRemoveIndividual_RemovedByOther_BotContent(t *testing.T)
 	assert.Equal(t, `"Alice 愛" removed "Helper Bot" from the chatroom`, sysMsg.Content)
 }
 
-// Self-leave by a bot: Content uses the registered app name.
+// Self-leave by a bot: Content uses the registered app name when GetApp resolves it,
+// and degrades to the composed name / raw account (bot has no EngName/ChineseName, so
+// it falls all the way back to the account) when GetApp misses or errors. An infra
+// error is — unlike ErrAppNotFound, which is silent — logged, but the flow still
+// succeeds end to end either way.
 func TestHandler_ProcessRemoveIndividual_SelfLeave_BotContent(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	store := NewMockSubscriptionStore(ctrl)
-	expectThreadCleanupAny(store)
+	tests := []struct {
+		name        string
+		setupApp    func(store *MockSubscriptionStore)
+		wantContent string
+	}{
+		{
+			name: "app found",
+			setupApp: func(store *MockSubscriptionStore) {
+				store.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(&model.App{Name: "Helper Bot"}, nil)
+			},
+			wantContent: `"Helper Bot" left the chatroom`,
+		},
+		{
+			name: "app not found",
+			setupApp: func(store *MockSubscriptionStore) {
+				store.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(nil, ErrAppNotFound)
+			},
+			wantContent: `"helper.bot" left the chatroom`,
+		},
+		{
+			name: "app lookup error",
+			setupApp: func(store *MockSubscriptionStore) {
+				store.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(nil, fmt.Errorf("mongo timeout"))
+			},
+			wantContent: `"helper.bot" left the chatroom`,
+		},
+	}
 
-	roomID := "r1"
-	store.EXPECT().GetUserWithMembership(gomock.Any(), roomID, "helper.bot").
-		Return(&UserWithMembership{
-			User:  model.User{ID: "u_bot", Account: "helper.bot", SiteID: "site-a"},
-			Roles: []model.Role{model.RoleUser},
-		}, nil)
-	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u_bot").Return(nil)
-	store.EXPECT().DeleteSubscription(gomock.Any(), roomID, "helper.bot").Return(int64(1), nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
-	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{}, nil)
-	store.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(&model.App{Name: "Helper Bot"}, nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			store := NewMockSubscriptionStore(ctrl)
+			expectThreadCleanupAny(store)
 
-	var published []publishedMsg
-	h := &Handler{store: store, siteID: "site-a", publish: func(_ context.Context, subj string, data []byte, _ string) error {
-		published = append(published, publishedMsg{subj: subj, data: data})
-		return nil
-	}, keyStore: testKeyStore, keySender: testKeySender}
+			roomID := "r1"
+			store.EXPECT().GetUserWithMembership(gomock.Any(), roomID, "helper.bot").
+				Return(&UserWithMembership{
+					User:  model.User{ID: "u_bot", Account: "helper.bot", SiteID: "site-a"},
+					Roles: []model.Role{model.RoleUser},
+				}, nil)
+			store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u_bot").Return(nil)
+			store.EXPECT().DeleteSubscription(gomock.Any(), roomID, "helper.bot").Return(int64(1), nil)
+			store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+			store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{}, nil)
+			tt.setupApp(store)
 
-	req := model.RemoveMemberRequest{RoomID: roomID, Requester: "helper.bot", Account: "helper.bot", Timestamp: 1}
-	require.NoError(t, h.processRemoveIndividual(context.Background(), &req, nil))
+			var published []publishedMsg
+			h := &Handler{store: store, siteID: "site-a", publish: func(_ context.Context, subj string, data []byte, _ string) error {
+				published = append(published, publishedMsg{subj: subj, data: data})
+				return nil
+			}, keyStore: testKeyStore, keySender: testKeySender}
+			h.appName = preview.CachedAppNameLookup(h.appNameLookup)
 
-	sysMsg := findSysMsg(t, published, "site-a", "member_left")
-	assert.Equal(t, `"Helper Bot" left the chatroom`, sysMsg.Content)
-}
+			req := model.RemoveMemberRequest{RoomID: roomID, Requester: "helper.bot", Account: "helper.bot", Timestamp: 1}
+			require.NoError(t, h.processRemoveIndividual(context.Background(), &req, nil))
 
-// ErrAppNotFound degrades to the composed name / raw account (current behavior) —
-// bot has no EngName/ChineseName so it falls all the way back to the account.
-func TestHandler_ProcessRemoveIndividual_SelfLeave_BotContent_AppNotFound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	store := NewMockSubscriptionStore(ctrl)
-	expectThreadCleanupAny(store)
-
-	roomID := "r1"
-	store.EXPECT().GetUserWithMembership(gomock.Any(), roomID, "helper.bot").
-		Return(&UserWithMembership{
-			User:  model.User{ID: "u_bot", Account: "helper.bot", SiteID: "site-a"},
-			Roles: []model.Role{model.RoleUser},
-		}, nil)
-	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u_bot").Return(nil)
-	store.EXPECT().DeleteSubscription(gomock.Any(), roomID, "helper.bot").Return(int64(1), nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
-	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{}, nil)
-	store.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(nil, ErrAppNotFound)
-
-	var published []publishedMsg
-	h := &Handler{store: store, siteID: "site-a", publish: func(_ context.Context, subj string, data []byte, _ string) error {
-		published = append(published, publishedMsg{subj: subj, data: data})
-		return nil
-	}, keyStore: testKeyStore, keySender: testKeySender}
-
-	req := model.RemoveMemberRequest{RoomID: roomID, Requester: "helper.bot", Account: "helper.bot", Timestamp: 1}
-	require.NoError(t, h.processRemoveIndividual(context.Background(), &req, nil))
-
-	sysMsg := findSysMsg(t, published, "site-a", "member_left")
-	assert.Equal(t, `"helper.bot" left the chatroom`, sysMsg.Content)
-}
-
-// An infra error from GetApp also degrades to the composed name/account, and — unlike
-// ErrAppNotFound, which is silent — is logged, but the flow still succeeds end to end.
-func TestHandler_ProcessRemoveIndividual_SelfLeave_BotContent_AppLookupError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	store := NewMockSubscriptionStore(ctrl)
-	expectThreadCleanupAny(store)
-
-	roomID := "r1"
-	store.EXPECT().GetUserWithMembership(gomock.Any(), roomID, "helper.bot").
-		Return(&UserWithMembership{
-			User:  model.User{ID: "u_bot", Account: "helper.bot", SiteID: "site-a"},
-			Roles: []model.Role{model.RoleUser},
-		}, nil)
-	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u_bot").Return(nil)
-	store.EXPECT().DeleteSubscription(gomock.Any(), roomID, "helper.bot").Return(int64(1), nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
-	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{}, nil)
-	store.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(nil, fmt.Errorf("mongo timeout"))
-
-	var published []publishedMsg
-	h := &Handler{store: store, siteID: "site-a", publish: func(_ context.Context, subj string, data []byte, _ string) error {
-		published = append(published, publishedMsg{subj: subj, data: data})
-		return nil
-	}, keyStore: testKeyStore, keySender: testKeySender}
-
-	req := model.RemoveMemberRequest{RoomID: roomID, Requester: "helper.bot", Account: "helper.bot", Timestamp: 1}
-	require.NoError(t, h.processRemoveIndividual(context.Background(), &req, nil))
-
-	sysMsg := findSysMsg(t, published, "site-a", "member_left")
-	assert.Equal(t, `"helper.bot" left the chatroom`, sysMsg.Content)
+			sysMsg := findSysMsg(t, published, "site-a", "member_left")
+			assert.Equal(t, tt.wantContent, sysMsg.Content)
+		})
+	}
 }
 
 // C3: org remove with every member also having individual subs (toRemove empty)

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -181,6 +181,8 @@ func TestHandler_ProcessRemoveMember_BotTarget_RotatesAndSubUpdate(t *testing.T)
 	// Rotation now runs for a bot removal too — the survivor fan-out reads accounts.
 	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return(nil, nil)
 	store.EXPECT().GetUser(gomock.Any(), requester).Return(&model.User{ID: "u1", Account: requester, SiteID: siteID, EngName: "Alice"}, nil)
+	// Removed member is a bot: sys-msg content resolution looks up its app name.
+	store.EXPECT().GetApp(gomock.Any(), botAcct).Return(nil, ErrAppNotFound)
 
 	var published []publishedMsg
 	h := NewHandler(store, siteID, func(_ context.Context, subj string, data []byte, _ string) error {
@@ -5738,6 +5740,44 @@ func TestHandler_ProcessAddMembers_Content_Single(t *testing.T) {
 	assert.Equal(t, `"Alice 愛" added "U1 一" to the chatroom`, sysMsg.Content)
 }
 
+// Single added individual is a bot: Content substitutes the registered app name.
+func TestHandler_ProcessAddMembers_Content_SingleBot(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+
+	roomID := "r1"
+	store.EXPECT().GetRoomMeta(gomock.Any(), roomID).
+		Return(&model.Room{ID: roomID, Name: "Chan", SiteID: "site-a", Type: model.RoomTypeChannel}, nil)
+	store.EXPECT().ListAddMemberCandidates(gomock.Any(), []string(nil), []string{"helper.bot"}, roomID).
+		Return([]AddMemberCandidate{{Account: "helper.bot"}}, nil)
+	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"helper.bot"}).
+		Return([]model.User{{ID: "bot_id", Account: "helper.bot", SiteID: "site-a"}}, nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").
+		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
+	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
+	expectGetRoom(store, roomID, "Chan")
+	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+	store.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(&model.App{Name: "Helper Bot"}, nil)
+
+	var published []publishedMsg
+	h := &Handler{store: store, siteID: "site-a", publish: func(_ context.Context, subj string, data []byte, _ string) error {
+		published = append(published, publishedMsg{subj: subj, data: data})
+		return nil
+	}, keyStore: testKeyStore, keySender: testKeySender}
+
+	req := model.AddMembersRequest{
+		RoomID: roomID, RequesterID: "u_a", RequesterAccount: "alice",
+		Users: []string{"helper.bot"}, Timestamp: 1,
+	}
+	data, _ := json.Marshal(req)
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+	require.NoError(t, h.processAddMembers(ctx, data))
+
+	sysMsg := findSysMsg(t, published, "site-a", "members_added")
+	assert.True(t, strings.HasSuffix(sysMsg.Content, `added "Helper Bot" to the chatroom`))
+}
+
 // B2: len(subs)>=2 → multi form.
 func TestHandler_ProcessAddMembers_Content_Multi(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -6048,6 +6088,134 @@ func TestHandler_ProcessRemoveIndividual_RemovedByOther_Content(t *testing.T) {
 	assert.Equal(t, "alice", sysMsg.UserAccount)
 	assert.Equal(t, "u_a", sysMsg.UserID, "forced removal sets sender to requester")
 	assert.Equal(t, `"Alice 愛" removed "Bob 鮑" from the chatroom`, sysMsg.Content)
+}
+
+// Removed member is a bot: Content substitutes the registered app name for the
+// raw bot account. The requester side stays composed-name as always.
+func TestHandler_ProcessRemoveIndividual_RemovedByOther_BotContent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	expectThreadCleanupAny(store)
+
+	roomID := "r1"
+	store.EXPECT().GetUserWithMembership(gomock.Any(), roomID, "helper.bot").
+		Return(&UserWithMembership{
+			User: model.User{ID: "u_bot", Account: "helper.bot", SiteID: "site-a"},
+		}, nil)
+	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u_bot").Return(nil)
+	store.EXPECT().DeleteSubscription(gomock.Any(), roomID, "helper.bot").Return(int64(1), nil)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{}, nil)
+	store.EXPECT().GetUser(gomock.Any(), "alice").
+		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
+	store.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(&model.App{Name: "Helper Bot"}, nil)
+
+	var published []publishedMsg
+	h := &Handler{store: store, siteID: "site-a", publish: func(_ context.Context, subj string, data []byte, _ string) error {
+		published = append(published, publishedMsg{subj: subj, data: data})
+		return nil
+	}, keyStore: testKeyStore, keySender: testKeySender}
+
+	req := model.RemoveMemberRequest{RoomID: roomID, Requester: "alice", Account: "helper.bot", Timestamp: 1}
+	require.NoError(t, h.processRemoveIndividual(context.Background(), &req, nil))
+
+	sysMsg := findSysMsg(t, published, "site-a", "member_removed")
+	assert.Equal(t, `"Alice 愛" removed "Helper Bot" from the chatroom`, sysMsg.Content)
+}
+
+// Self-leave by a bot: Content uses the registered app name.
+func TestHandler_ProcessRemoveIndividual_SelfLeave_BotContent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	expectThreadCleanupAny(store)
+
+	roomID := "r1"
+	store.EXPECT().GetUserWithMembership(gomock.Any(), roomID, "helper.bot").
+		Return(&UserWithMembership{
+			User:  model.User{ID: "u_bot", Account: "helper.bot", SiteID: "site-a"},
+			Roles: []model.Role{model.RoleUser},
+		}, nil)
+	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u_bot").Return(nil)
+	store.EXPECT().DeleteSubscription(gomock.Any(), roomID, "helper.bot").Return(int64(1), nil)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{}, nil)
+	store.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(&model.App{Name: "Helper Bot"}, nil)
+
+	var published []publishedMsg
+	h := &Handler{store: store, siteID: "site-a", publish: func(_ context.Context, subj string, data []byte, _ string) error {
+		published = append(published, publishedMsg{subj: subj, data: data})
+		return nil
+	}, keyStore: testKeyStore, keySender: testKeySender}
+
+	req := model.RemoveMemberRequest{RoomID: roomID, Requester: "helper.bot", Account: "helper.bot", Timestamp: 1}
+	require.NoError(t, h.processRemoveIndividual(context.Background(), &req, nil))
+
+	sysMsg := findSysMsg(t, published, "site-a", "member_left")
+	assert.Equal(t, `"Helper Bot" left the chatroom`, sysMsg.Content)
+}
+
+// ErrAppNotFound degrades to the composed name / raw account (current behavior) —
+// bot has no EngName/ChineseName so it falls all the way back to the account.
+func TestHandler_ProcessRemoveIndividual_SelfLeave_BotContent_AppNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	expectThreadCleanupAny(store)
+
+	roomID := "r1"
+	store.EXPECT().GetUserWithMembership(gomock.Any(), roomID, "helper.bot").
+		Return(&UserWithMembership{
+			User:  model.User{ID: "u_bot", Account: "helper.bot", SiteID: "site-a"},
+			Roles: []model.Role{model.RoleUser},
+		}, nil)
+	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u_bot").Return(nil)
+	store.EXPECT().DeleteSubscription(gomock.Any(), roomID, "helper.bot").Return(int64(1), nil)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{}, nil)
+	store.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(nil, ErrAppNotFound)
+
+	var published []publishedMsg
+	h := &Handler{store: store, siteID: "site-a", publish: func(_ context.Context, subj string, data []byte, _ string) error {
+		published = append(published, publishedMsg{subj: subj, data: data})
+		return nil
+	}, keyStore: testKeyStore, keySender: testKeySender}
+
+	req := model.RemoveMemberRequest{RoomID: roomID, Requester: "helper.bot", Account: "helper.bot", Timestamp: 1}
+	require.NoError(t, h.processRemoveIndividual(context.Background(), &req, nil))
+
+	sysMsg := findSysMsg(t, published, "site-a", "member_left")
+	assert.Equal(t, `"helper.bot" left the chatroom`, sysMsg.Content)
+}
+
+// An infra error from GetApp also degrades to the composed name/account, and — unlike
+// ErrAppNotFound, which is silent — is logged, but the flow still succeeds end to end.
+func TestHandler_ProcessRemoveIndividual_SelfLeave_BotContent_AppLookupError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockSubscriptionStore(ctrl)
+	expectThreadCleanupAny(store)
+
+	roomID := "r1"
+	store.EXPECT().GetUserWithMembership(gomock.Any(), roomID, "helper.bot").
+		Return(&UserWithMembership{
+			User:  model.User{ID: "u_bot", Account: "helper.bot", SiteID: "site-a"},
+			Roles: []model.Role{model.RoleUser},
+		}, nil)
+	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u_bot").Return(nil)
+	store.EXPECT().DeleteSubscription(gomock.Any(), roomID, "helper.bot").Return(int64(1), nil)
+	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{}, nil)
+	store.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(nil, fmt.Errorf("mongo timeout"))
+
+	var published []publishedMsg
+	h := &Handler{store: store, siteID: "site-a", publish: func(_ context.Context, subj string, data []byte, _ string) error {
+		published = append(published, publishedMsg{subj: subj, data: data})
+		return nil
+	}, keyStore: testKeyStore, keySender: testKeySender}
+
+	req := model.RemoveMemberRequest{RoomID: roomID, Requester: "helper.bot", Account: "helper.bot", Timestamp: 1}
+	require.NoError(t, h.processRemoveIndividual(context.Background(), &req, nil))
+
+	sysMsg := findSysMsg(t, published, "site-a", "member_left")
+	assert.Equal(t, `"helper.bot" left the chatroom`, sysMsg.Content)
 }
 
 // C3: org remove with every member also having individual subs (toRemove empty)

--- a/room-worker/sysmsg.go
+++ b/room-worker/sysmsg.go
@@ -27,8 +27,8 @@ func plural(n int, singular, pluralForm string) string {
 	return strconv.Itoa(n) + " " + pluralForm
 }
 
-func formatAddedSingle(requester, added *model.User) string {
-	return quoted(displayName(requester)) + " added " + quoted(displayName(added)) + " to the chatroom"
+func formatAddedSingle(requester *model.User, addedName string) string {
+	return quoted(displayName(requester)) + " added " + quoted(addedName) + " to the chatroom"
 }
 
 // formatAddedCounts renders the count form. At least one of people/orgs is > 0
@@ -47,11 +47,11 @@ func formatAddedCounts(requester *model.User, people, orgs int) string {
 }
 
 // addedContent renders members_added Content for both add and create: named form
-// for a lone individual (no orgs), else counts. lookup returns nil if unresolved.
-func addedContent(requester *model.User, individuals, orgs []string, lookup func(string) *model.User) string {
+// for a lone individual (no orgs), else counts. nameOf returns "" if unresolved.
+func addedContent(requester *model.User, individuals, orgs []string, nameOf func(string) string) string {
 	if len(individuals) == 1 && len(orgs) == 0 {
-		if u := lookup(individuals[0]); u != nil {
-			return formatAddedSingle(requester, u)
+		if name := nameOf(individuals[0]); name != "" {
+			return formatAddedSingle(requester, name)
 		}
 	}
 	return formatAddedCounts(requester, len(individuals), len(orgs))
@@ -77,14 +77,14 @@ func withoutAccount(accounts []string, account string) []string {
 	return out
 }
 
-func formatRemovedUser(requester, removed *model.User) string {
-	return quoted(displayName(requester)) + " removed " + quoted(displayName(removed)) + " from the chatroom"
+func formatRemovedUser(requester *model.User, removedName string) string {
+	return quoted(displayName(requester)) + " removed " + quoted(removedName) + " from the chatroom"
 }
 
 func formatRemovedOrg(requester *model.User, name, tcName, orgID string) string {
 	return quoted(displayName(requester)) + " removed " + quoted(displayOrg(name, tcName, orgID)) + " from the chatroom"
 }
 
-func formatLeft(user *model.User) string {
-	return quoted(displayName(user)) + " left the chatroom"
+func formatLeft(name string) string {
+	return quoted(name) + " left the chatroom"
 }

--- a/room-worker/sysmsg_test.go
+++ b/room-worker/sysmsg_test.go
@@ -11,7 +11,7 @@ import (
 func TestFormatAddedSingle(t *testing.T) {
 	got := formatAddedSingle(
 		&model.User{EngName: "Alice", ChineseName: "愛麗絲"},
-		&model.User{EngName: "Bob", ChineseName: "鮑勃"},
+		"Bob 鮑勃",
 	)
 	assert.Equal(t, `"Alice 愛麗絲" added "Bob 鮑勃" to the chatroom`, got)
 }
@@ -39,12 +39,11 @@ func TestFormatAddedCounts(t *testing.T) {
 
 func TestAddedContent(t *testing.T) {
 	alice := &model.User{EngName: "Alice", ChineseName: "愛"}
-	bob := &model.User{EngName: "Bob", ChineseName: "鮑"}
-	lookup := func(a string) *model.User {
+	lookup := func(a string) string {
 		if a == "bob" {
-			return bob
+			return "Bob 鮑"
 		}
-		return nil
+		return ""
 	}
 	assert.Equal(t, `"Alice 愛" added "Bob 鮑" to the chatroom`,
 		addedContent(alice, []string{"bob"}, nil, lookup))
@@ -80,7 +79,7 @@ func TestWithoutAccount(t *testing.T) {
 func TestFormatRemovedUser(t *testing.T) {
 	got := formatRemovedUser(
 		&model.User{EngName: "Alice", ChineseName: "愛"},
-		&model.User{EngName: "Bob", ChineseName: "鮑勃"},
+		"Bob 鮑勃",
 	)
 	assert.Equal(t, `"Alice 愛" removed "Bob 鮑勃" from the chatroom`, got)
 }
@@ -91,7 +90,7 @@ func TestFormatRemovedOrg(t *testing.T) {
 }
 
 func TestFormatLeft(t *testing.T) {
-	got := formatLeft(&model.User{EngName: "Bob", ChineseName: "鮑勃"})
+	got := formatLeft("Bob 鮑勃")
 	assert.Equal(t, `"Bob 鮑勃" left the chatroom`, got)
 }
 
@@ -145,14 +144,14 @@ func TestDisplayName(t *testing.T) {
 }
 
 func TestFormatLeft_FallsBackToAccount(t *testing.T) {
-	got := formatLeft(&model.User{Account: "alice"})
+	got := formatLeft("alice")
 	assert.Equal(t, `"alice" left the chatroom`, got)
 }
 
 func TestFormatAddedSingle_SingleNameSide(t *testing.T) {
 	got := formatAddedSingle(
 		&model.User{EngName: "Alice"},
-		&model.User{ChineseName: "鮑勃"},
+		"鮑勃",
 	)
 	assert.Equal(t, `"Alice" added "鮑勃" to the chatroom`, got)
 }


### PR DESCRIPTION
## Problem

Member add/remove/self-leave system messages compose the member's display name from the `users` collection fields (`EngName`/`ChineseName`/`Account`) with no bot override. A bot's user record has no human names, so the composer falls back to the raw `.bot` account string — e.g. `"helper.bot" left the chatroom`.

Every other member-name-rendering path (room-list preview, reactions, live bot messages) goes through the shared `preview.BotAwareDisplayName`, which substitutes the bot's registered app name from the `apps` collection. This sys-message write path in `room-worker` was the only one missing it.

## Fix

- Route the member side of all four sys-message composition sites (self-leave, forced remove, add members, room-create members_added) through a new `Handler.memberDisplayName`, which delegates to the shared `preview.BotAwareDisplayName`.
- Adapt the existing `store.GetApp` to the `preview.AppNameLookup` contract (`ErrAppNotFound` → `("", nil)`), wrapped in the existing `preview.CachedAppNameLookup` (TTL LRU + singleflight) at `NewHandler`, matching how broadcast-worker and history-service consume the same lookup.
- `sysmsg.go` format helpers now take a pre-resolved member name string; the sentence templates are unchanged.

Degradation: app not found or Mongo error falls back to today's composed name (raw account for bots) and the message still publishes — a display name is never worth failing a membership flow over.

## Scope (deliberate)

- Requester names are unchanged (bot-initiated flows go through bot-room-service, which emits no Content).
- `SysMsgData` wire shape unchanged; no client-facing schema change, so no `docs/client-api.md` update needed.
- No backfill of historical messages already persisted in Cassandra.

## Testing

- TDD: new handler-level tests for bot removed / bot self-leave (table-driven: found / not-found / lookup-error) / single bot added, all red before the fix.
- Human paths keep their exact expected strings; gomock's no-expectation rule enforces `GetApp` is never called for non-bot members.
- `make test SERVICE=room-worker` (race) green; `golangci-lint run ./room-worker/...` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bot-related member-added and member-removed messages now display the registered app name.
  * Improved fallback behavior when an app name is unavailable or lookup fails.
  * Self-leave messages now consistently use the account name when no app name can be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->