### PR TITLE
fix(search-sync-worker): bind bot collection to its own stream's subject

### DIFF
--- a/search-sync-worker/messages.go
+++ b/search-sync-worker/messages.go
@@ -36,20 +36,23 @@ type teamsUserResolver interface {
 	ResolveIdentities(ctx context.Context, teamsUserIDs []string) (map[string]teamsIdentity, error)
 }
 
-// messageCollection implements Collection for message search sync; streamCfg + consumerName are
-// parameterized so one type consumes user, bot, or Teams-migration canonical streams. syncFrom is
-// the legacy-replay cutoff (zero disables it).
+// messageCollection implements Collection for message search sync; streamCfg, filterSubjs +
+// consumerName are parameterized so one type consumes user, bot, or Teams-migration canonical
+// streams. syncFrom is the legacy-replay cutoff (zero disables it).
 type messageCollection struct {
 	indexPrefix string
 	siteID      string // for .teams.batch index docs (the normal path reads evt.SiteID per message)
 	syncFrom    time.Time
 	devMode     bool
-	// teamsOnly switches this collection to the Teams-migration-only wiring: it binds
-	// MESSAGES-TEAMS instead of a canonical stream, filters to only the teams batch
-	// subject, and skips the template/mapping pushes the primary (user) collection
-	// already owns for the same indexPrefix.
-	teamsOnly      bool
-	streamCfg      func(siteID string) jetstream.StreamConfig
+	// teamsOnly switches this collection to the Teams-migration-only wiring: it decodes
+	// batch envelopes instead of single MessageEvents, and skips the template/mapping
+	// pushes the primary (user) collection already owns for the same indexPrefix.
+	teamsOnly bool
+	streamCfg func(siteID string) jetstream.StreamConfig
+	// filterSubjs is set alongside streamCfg so a collection's consumer filter cannot drift
+	// off the stream it binds — a filter outside the stream's interest fails consumer
+	// creation at startup, which exits the service.
+	filterSubjs    func(siteID string) []string
 	consumerName   string
 	parentResolver parentCreatedAtResolver
 	// teamsUsers resolves migrated senders' account + user _id; nil on collections that
@@ -66,6 +69,7 @@ func newMessageCollection(indexPrefix, siteID string, syncFrom time.Time, devMod
 		syncFrom:     syncFrom,
 		devMode:      devMode,
 		streamCfg:    userMessagesStreamCfg,
+		filterSubjs:  userMessageFilterSubjects,
 		consumerName: "message-sync",
 	}
 }
@@ -76,6 +80,7 @@ func newBotMessageCollection(indexPrefix string, devMode bool) *messageCollectio
 		indexPrefix:  indexPrefix,
 		devMode:      devMode,
 		streamCfg:    botMessagesStreamCfg,
+		filterSubjs:  botMessageFilterSubjects,
 		consumerName: "bot-message-sync",
 	}
 }
@@ -92,6 +97,7 @@ func newTeamsMessageCollection(indexPrefix, siteID string, devMode bool) *messag
 		devMode:      devMode,
 		teamsOnly:    true,
 		streamCfg:    teamsMessagesStreamCfg,
+		filterSubjs:  teamsMessageFilterSubjects,
 		consumerName: "message-sync-teams",
 	}
 }
@@ -111,6 +117,23 @@ func teamsMessagesStreamCfg(siteID string) jetstream.StreamConfig {
 	return jetstream.StreamConfig{Name: cfg.Name, Subjects: cfg.Subjects}
 }
 
+// Single-token message events (created/updated/deleted/...); the teams batch subject
+// lives on its own stream (see newTeamsMessageCollection).
+func userMessageFilterSubjects(siteID string) []string {
+	return []string{subject.MsgCanonicalMessageWildcard(siteID)}
+}
+
+// bot-message-handler and bot-room-service publish only .created onto
+// BOT-MESSAGES-CANONICAL; bot-message-worker binds the same leaf.
+func botMessageFilterSubjects(siteID string) []string {
+	return []string{subject.BotCanonicalCreated(siteID)}
+}
+
+// Own stream (MESSAGES-TEAMS), own subject — no message wildcard here.
+func teamsMessageFilterSubjects(siteID string) []string {
+	return []string{subject.MsgTeamsCanonicalBatch(siteID)}
+}
+
 func (c *messageCollection) StreamConfig(siteID string) jetstream.StreamConfig {
 	return c.streamCfg(siteID)
 }
@@ -120,13 +143,7 @@ func (c *messageCollection) ConsumerName() string {
 }
 
 func (c *messageCollection) FilterSubjects(siteID string) []string {
-	if c.teamsOnly {
-		// Own stream (MESSAGES-TEAMS), own subject — no message wildcard here.
-		return []string{subject.MsgTeamsCanonicalBatch(siteID)}
-	}
-	// Single-token message events (created/updated/deleted/...); the teams batch
-	// subject now lives on a separate stream (see newTeamsMessageCollection).
-	return []string{subject.MsgCanonicalMessageWildcard(siteID)}
+	return c.filterSubjs(siteID)
 }
 
 func (c *messageCollection) TemplateName() string {

--- a/search-sync-worker/messages_test.go
+++ b/search-sync-worker/messages_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -619,7 +620,8 @@ func TestMessageCollection_FilterSubjects(t *testing.T) {
 	assert.Equal(t, []string{"chat.msg.canonical.site-a.*"}, user.FilterSubjects("site-a"))
 
 	bot := newBotMessageCollection("msgs-v1", false)
-	assert.Equal(t, []string{"chat.msg.canonical.site-a.*"}, bot.FilterSubjects("site-a"))
+	assert.Equal(t, []string{"chat.bot.canonical.site-a.created"}, bot.FilterSubjects("site-a"),
+		"the bot collection binds BOT-MESSAGES-CANONICAL, which carries only chat.bot.canonical.{siteID}.>")
 
 	teams := newTeamsMessageCollection("msgs-v1", "site-a", false)
 	assert.Equal(t, []string{"chat.teams.msg.canonical.site-a.batch"}, teams.FilterSubjects("site-a"))
@@ -628,6 +630,59 @@ func TestMessageCollection_FilterSubjects(t *testing.T) {
 	pattern, body := teams.MappingUpdate()
 	assert.Empty(t, pattern)
 	assert.Nil(t, body)
+}
+
+// subjectMatches reports whether a NATS subject matches a filter pattern, per the
+// server's token rules: "*" matches exactly one token, ">" matches one or more
+// trailing tokens.
+func subjectMatches(pattern, subj string) bool {
+	pt := strings.Split(pattern, ".")
+	st := strings.Split(subj, ".")
+	for i, tok := range pt {
+		if tok == ">" {
+			return i < len(st)
+		}
+		if i >= len(st) {
+			return false
+		}
+		if tok != "*" && tok != st[i] {
+			return false
+		}
+	}
+	return len(pt) == len(st)
+}
+
+// A consumer's filter subject must be a subset of its own stream's interest, or
+// CreateOrUpdateConsumer fails at startup and the service exits. This guards the whole
+// class: any collection whose stream and filter drift apart fails here, not at rollout.
+func TestMessageCollection_FilterSubjectsAreOnTheirOwnStream(t *testing.T) {
+	const siteID = "site-a"
+	tests := []struct {
+		name string
+		coll *messageCollection
+	}{
+		{"user", newMessageCollection("msgs-v1", siteID, time.Time{}, false)},
+		{"bot", newBotMessageCollection("msgs-v1", false)},
+		{"teams", newTeamsMessageCollection("msgs-v1", siteID, false)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			streamSubjects := tt.coll.StreamConfig(siteID).Subjects
+			require.NotEmpty(t, streamSubjects)
+			for _, filter := range tt.coll.FilterSubjects(siteID) {
+				matched := false
+				for _, streamSubj := range streamSubjects {
+					if subjectMatches(streamSubj, filter) {
+						matched = true
+						break
+					}
+				}
+				assert.True(t, matched,
+					"filter %q is not carried by stream %q (subjects %v)",
+					filter, tt.coll.StreamConfig(siteID).Name, streamSubjects)
+			}
+		})
+	}
 }
 
 // fakeTeamsUserResolver returns a fixed id→identity map (nil error).


### PR DESCRIPTION
## Problem

The bot message collection binds `BOT-MESSAGES-CANONICAL-{siteID}` (`messages.go:104-107`), whose only subject is `chat.bot.canonical.{siteID}.>` (`pkg/stream/stream.go:97`). But `FilterSubjects` returned the **user** stream's `chat.msg.canonical.{siteID}.*` for every non-teams collection:

```go
func (c *messageCollection) FilterSubjects(siteID string) []string {
	if c.teamsOnly {
		return []string{subject.MsgTeamsCanonicalBatch(siteID)}
	}
	return []string{subject.MsgCanonicalMessageWildcard(siteID)} // ← also hit by the bot collection
}
```

A consumer filter that is not a subset of its stream's interest is rejected by `js.CreateOrUpdateConsumer`, and `main.go:348-355` treats that as fatal:

- Where the bot stream exists, the pod **exits at startup in `default` mode** — crashloop.
- Where it does not, bot messages are **silently never indexed**.

`messages_test.go:622` asserted the wrong string, so the test suite agreed with the bug.

## Fix

Filter subjects are now parameterized per collection alongside `streamCfg`, mirroring how this file already parameterizes the stream config and consumer name. The stream and its filter are set in the same place, so they cannot drift apart:

| Collection | Stream | Filter |
|---|---|---|
| user | `MESSAGES-CANONICAL-{site}` | `chat.msg.canonical.{site}.*` |
| bot | `BOT-MESSAGES-CANONICAL-{site}` | `chat.bot.canonical.{site}.created` |
| teams | `MESSAGES-TEAMS-{site}` | `chat.teams.msg.canonical.{site}.batch` |

`chat.bot.canonical.{siteID}.created` is the only subject published onto that stream (`bot-message-handler/handler.go:199`, `bot-room-service/sysmsg.go:65`) and the same leaf the sibling consumer binds (`bot-message-worker/main.go:208`).

`FilterSubjects` now just delegates, which also drops the `teamsOnly` branch from it. `teamsOnly` still gates payload decoding and the template/mapping pushes, unchanged.

## Tests

Written first, both confirmed failing against the old code:

1. `TestMessageCollection_FilterSubjects` — corrected the bot assertion. Failed with `expected: ["chat.bot.canonical.site-a.created"] / actual: ["chat.msg.canonical.site-a.*"]`.
2. `TestMessageCollection_FilterSubjectsAreOnTheirOwnStream` — new table-driven guard asserting each collection's filter subjects are matched by its own stream's subjects, using NATS token rules (`*` = one token, `>` = one or more trailing). Failed only on the `bot` subtest (`filter "chat.msg.canonical.site-a.*" is not carried by stream "BOT-MESSAGES-CANONICAL-site-a"`), with `user` and `teams` passing — which isolates the defect and confirms the matcher itself is sound.

This second test is the real regression guard: any future stream/filter mismatch in this service now fails in CI rather than at rollout.

## Verification

| Gate | Result |
|---|---|
| `make test SERVICE=search-sync-worker` | ok, 2.097s (`-race`) |
| `make test` (full repo) | 124 packages ok, 0 failures |
| `make lint` | 0 issues |
| `make sast-gosec` | exit 0, no findings |

`govulncheck` and `semgrep` could not run in this sandbox (`vuln.go.dev` blocked by the agent proxy; `semgrep` not installed) — they need to pass in CI.

## Scope

Production change is confined to `search-sync-worker/messages.go`. No client-facing handler or `pkg/model` struct changed, so `docs/client-api.md` needs no update. No new dependencies.

Found by the production-readiness audit of this service, where it was the sole `critical` finding.

---
_Generated by [Claude Code](https://claude.ai/code/session_018kfXTCHTVMSrBxwJvHHoNK)_