### PR TITLE
fix(room-worker): render bot app name for the requester in system messages

### DIFF
--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -388,10 +388,9 @@ func (h *Handler) appNameLookup(ctx context.Context, botAccount string) (string,
 	return app.Name, nil
 }
 
-// memberDisplayName renders a sys-msg member's name, substituting the registered app
-// name for a bot account. Only member-side names are bot-aware — the requester keeps
-// displayName() unchanged.
-func (h *Handler) memberDisplayName(ctx context.Context, u *model.User) string {
+// botAwareName renders a sys-msg participant's name (member or requester),
+// substituting the registered app name for a bot account.
+func (h *Handler) botAwareName(ctx context.Context, u *model.User) string {
 	return preview.BotAwareDisplayName(ctx, h.appName, u.EngName, u.ChineseName, u.Account)
 }
 
@@ -535,9 +534,9 @@ func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.Remove
 		fmt.Sprintf("%s:%s:%d", req.RoomID, req.Account, req.Timestamp))
 	var content string
 	if isSelfLeave {
-		content = formatLeft(h.memberDisplayName(ctx, &user.User))
+		content = formatLeft(h.botAwareName(ctx, &user.User))
 	} else {
-		content = formatRemovedUser(requester, h.memberDisplayName(ctx, &user.User))
+		content = formatRemovedUser(h.botAwareName(ctx, requester), h.botAwareName(ctx, &user.User))
 	}
 	sysMsg := model.Message{
 		ID:          idgen.MessageIDFromRequestID(seed, "rmindiv"),
@@ -744,7 +743,7 @@ func (h *Handler) processRemoveOrg(ctx context.Context, req *model.RemoveMemberR
 		UserID:      requester.ID,
 		UserAccount: requester.Account,
 		Type:        model.MessageTypeMemberRemoved,
-		Content:     formatRemovedOrg(requester, name, tcName, req.OrgID),
+		Content:     formatRemovedOrg(h.botAwareName(ctx, requester), name, tcName, req.OrgID),
 		SysMsgData:  sysMsgPayload,
 		CreatedAt:   now,
 	}
@@ -1260,9 +1259,9 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 			sysMsgData, _ := json.Marshal(membersAdded)
 			seed := messageDedupSeed(ctx, "processAddMembers", req.RoomID,
 				fmt.Sprintf("%s:%s:%d", req.RoomID, req.RequesterAccount, req.Timestamp))
-			content := addedContent(requester, sysIndividuals, req.Orgs, func(a string) string {
+			content := addedContent(h.botAwareName(ctx, requester), sysIndividuals, req.Orgs, func(a string) string {
 				if u, ok := userMap[a]; ok {
-					return h.memberDisplayName(ctx, &u)
+					return h.botAwareName(ctx, &u)
 				}
 				return ""
 			})
@@ -1974,9 +1973,9 @@ func (h *Handler) publishChannelSysMessages(ctx context.Context, req *model.Crea
 	if err != nil {
 		return errcode.MarshalFailed("members_added sys data", err)
 	}
-	content := addedContent(requester, req.ResolvedUsers, req.ResolvedOrgs, func(a string) string {
+	content := addedContent(h.botAwareName(ctx, requester), req.ResolvedUsers, req.ResolvedOrgs, func(a string) string {
 		if u, ok := userByAccount[a]; ok {
-			return h.memberDisplayName(ctx, u)
+			return h.botAwareName(ctx, u)
 		}
 		return ""
 	})
@@ -2361,7 +2360,7 @@ func (h *Handler) processRoomRename(ctx context.Context, data []byte) (err error
 	}
 	requesterLabel := req.Account
 	if requester != nil {
-		requesterLabel = displayName(requester)
+		requesterLabel = h.botAwareName(ctx, requester)
 	}
 	msg := model.Message{
 		ID:          idgen.MessageIDFromRequestID(requestID, "room_renamed"),

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -5741,43 +5741,68 @@ func TestHandler_ProcessAddMembers_Content_Single(t *testing.T) {
 	assert.Equal(t, `"Alice 愛" added "U1 一" to the chatroom`, sysMsg.Content)
 }
 
-// Single added individual is a bot: Content substitutes the registered app name.
-func TestHandler_ProcessAddMembers_Content_SingleBot(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	store := NewMockSubscriptionStore(ctrl)
-
-	roomID := "r1"
-	store.EXPECT().GetRoomMeta(gomock.Any(), roomID).
-		Return(&model.Room{ID: roomID, Name: "Chan", SiteID: "site-a", Type: model.RoomTypeChannel}, nil)
-	store.EXPECT().ListAddMemberCandidates(gomock.Any(), []string(nil), []string{"helper.bot"}, roomID).
-		Return([]AddMemberCandidate{{Account: "helper.bot"}}, nil)
-	store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{"helper.bot"}).
-		Return([]model.User{{ID: "bot_id", Account: "helper.bot", SiteID: "site-a"}}, nil)
-	store.EXPECT().GetUser(gomock.Any(), "alice").
-		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
-	store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
-	expectGetRoom(store, roomID, "Chan")
-	store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
-	store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
-	store.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(&model.App{Name: "Helper Bot"}, nil)
-
-	var published []publishedMsg
-	h := &Handler{store: store, siteID: "site-a", publish: func(_ context.Context, subj string, data []byte, _ string) error {
-		published = append(published, publishedMsg{subj: subj, data: data})
-		return nil
-	}, keyStore: testKeyStore, keySender: testKeySender}
-	h.appName = preview.CachedAppNameLookup(h.appNameLookup)
-
-	req := model.AddMembersRequest{
-		RoomID: roomID, RequesterID: "u_a", RequesterAccount: "alice",
-		Users: []string{"helper.bot"}, Timestamp: 1,
+// Bot on either side of a single add: Content substitutes the registered app
+// name for whichever participant (member or requester) is the bot.
+func TestHandler_ProcessAddMembers_Content_BotAware(t *testing.T) {
+	botUser := model.User{ID: "u_bot", Account: "helper.bot", SiteID: "site-a"}
+	tests := []struct {
+		name      string
+		requester model.User
+		member    model.User
+		want      string
+	}{
+		{
+			name:      "bot member",
+			requester: model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice"},
+			member:    botUser,
+			want:      `"Alice" added "Helper Bot" to the chatroom`,
+		},
+		{
+			name:      "bot requester",
+			requester: botUser,
+			member:    model.User{ID: "u1_id", Account: "u1", SiteID: "site-a", EngName: "U1"},
+			want:      `"Helper Bot" added "U1" to the chatroom`,
+		},
 	}
-	data, _ := json.Marshal(req)
-	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
-	require.NoError(t, h.processAddMembers(ctx, data))
 
-	sysMsg := findSysMsg(t, published, "site-a", "members_added")
-	assert.True(t, strings.HasSuffix(sysMsg.Content, `added "Helper Bot" to the chatroom`))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			store := NewMockSubscriptionStore(ctrl)
+
+			roomID := "r1"
+			store.EXPECT().GetRoomMeta(gomock.Any(), roomID).
+				Return(&model.Room{ID: roomID, Name: "Chan", SiteID: "site-a", Type: model.RoomTypeChannel}, nil)
+			store.EXPECT().ListAddMemberCandidates(gomock.Any(), []string(nil), []string{tt.member.Account}, roomID).
+				Return([]AddMemberCandidate{{Account: tt.member.Account}}, nil)
+			store.EXPECT().FindUsersByAccounts(gomock.Any(), []string{tt.member.Account}).
+				Return([]model.User{tt.member}, nil)
+			store.EXPECT().GetUser(gomock.Any(), tt.requester.Account).Return(&tt.requester, nil)
+			store.EXPECT().HasAnyRoomMembers(gomock.Any(), roomID).Return(false, nil)
+			expectGetRoom(store, roomID, "Chan")
+			store.EXPECT().BulkCreateSubscriptions(gomock.Any(), gomock.Any()).Return(nil)
+			store.EXPECT().ApplyMemberCountDelta(gomock.Any(), roomID, gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+			store.EXPECT().GetApp(gomock.Any(), botUser.Account).Return(&model.App{Name: "Helper Bot"}, nil)
+
+			var published []publishedMsg
+			h := &Handler{store: store, siteID: "site-a", publish: func(_ context.Context, subj string, data []byte, _ string) error {
+				published = append(published, publishedMsg{subj: subj, data: data})
+				return nil
+			}, keyStore: testKeyStore, keySender: testKeySender}
+			h.appName = preview.CachedAppNameLookup(h.appNameLookup)
+
+			req := model.AddMembersRequest{
+				RoomID: roomID, RequesterID: tt.requester.ID, RequesterAccount: tt.requester.Account,
+				Users: []string{tt.member.Account}, Timestamp: 1,
+			}
+			data, _ := json.Marshal(req)
+			ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+			require.NoError(t, h.processAddMembers(ctx, data))
+
+			sysMsg := findSysMsg(t, published, "site-a", "members_added")
+			assert.Equal(t, tt.want, sysMsg.Content)
+		})
+	}
 }
 
 // B2: len(subs)>=2 → multi form.
@@ -6092,38 +6117,60 @@ func TestHandler_ProcessRemoveIndividual_RemovedByOther_Content(t *testing.T) {
 	assert.Equal(t, `"Alice 愛" removed "Bob 鮑" from the chatroom`, sysMsg.Content)
 }
 
-// Removed member is a bot: Content substitutes the registered app name for the
-// raw bot account. The requester side stays composed-name as always.
-func TestHandler_ProcessRemoveIndividual_RemovedByOther_BotContent(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	store := NewMockSubscriptionStore(ctrl)
-	expectThreadCleanupAny(store)
+// Bot on either side of a forced removal: Content substitutes the registered
+// app name for whichever participant (removed member or requester) is the bot.
+func TestHandler_ProcessRemoveIndividual_RemovedByOther_BotAware(t *testing.T) {
+	botUser := model.User{ID: "u_bot", Account: "helper.bot", SiteID: "site-a"}
+	tests := []struct {
+		name      string
+		requester model.User
+		removed   model.User
+		want      string
+	}{
+		{
+			name:      "bot removed",
+			requester: model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice"},
+			removed:   botUser,
+			want:      `"Alice" removed "Helper Bot" from the chatroom`,
+		},
+		{
+			name:      "bot requester",
+			requester: botUser,
+			removed:   model.User{ID: "u_b", Account: "bob", SiteID: "site-a", EngName: "Bob"},
+			want:      `"Helper Bot" removed "Bob" from the chatroom`,
+		},
+	}
 
-	roomID := "r1"
-	store.EXPECT().GetUserWithMembership(gomock.Any(), roomID, "helper.bot").
-		Return(&UserWithMembership{
-			User: model.User{ID: "u_bot", Account: "helper.bot", SiteID: "site-a"},
-		}, nil)
-	store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, "u_bot").Return(nil)
-	store.EXPECT().DeleteSubscription(gomock.Any(), roomID, "helper.bot").Return(int64(1), nil)
-	store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
-	store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{}, nil)
-	store.EXPECT().GetUser(gomock.Any(), "alice").
-		Return(&model.User{ID: "u_a", Account: "alice", SiteID: "site-a", EngName: "Alice", ChineseName: "愛"}, nil)
-	store.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(&model.App{Name: "Helper Bot"}, nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			store := NewMockSubscriptionStore(ctrl)
+			expectThreadCleanupAny(store)
 
-	var published []publishedMsg
-	h := &Handler{store: store, siteID: "site-a", publish: func(_ context.Context, subj string, data []byte, _ string) error {
-		published = append(published, publishedMsg{subj: subj, data: data})
-		return nil
-	}, keyStore: testKeyStore, keySender: testKeySender}
-	h.appName = preview.CachedAppNameLookup(h.appNameLookup)
+			roomID := "r1"
+			store.EXPECT().GetUserWithMembership(gomock.Any(), roomID, tt.removed.Account).
+				Return(&UserWithMembership{User: tt.removed}, nil)
+			store.EXPECT().DeleteRoomMember(gomock.Any(), roomID, model.RoomMemberIndividual, tt.removed.ID).Return(nil)
+			store.EXPECT().DeleteSubscription(gomock.Any(), roomID, tt.removed.Account).Return(int64(1), nil)
+			store.EXPECT().ReconcileMemberCounts(gomock.Any(), roomID).Return(nil)
+			store.EXPECT().GetSubscriptionAccounts(gomock.Any(), roomID).Return([]string{}, nil)
+			store.EXPECT().GetUser(gomock.Any(), tt.requester.Account).Return(&tt.requester, nil)
+			store.EXPECT().GetApp(gomock.Any(), botUser.Account).Return(&model.App{Name: "Helper Bot"}, nil)
 
-	req := model.RemoveMemberRequest{RoomID: roomID, Requester: "alice", Account: "helper.bot", Timestamp: 1}
-	require.NoError(t, h.processRemoveIndividual(context.Background(), &req, nil))
+			var published []publishedMsg
+			h := &Handler{store: store, siteID: "site-a", publish: func(_ context.Context, subj string, data []byte, _ string) error {
+				published = append(published, publishedMsg{subj: subj, data: data})
+				return nil
+			}, keyStore: testKeyStore, keySender: testKeySender}
+			h.appName = preview.CachedAppNameLookup(h.appNameLookup)
 
-	sysMsg := findSysMsg(t, published, "site-a", "member_removed")
-	assert.Equal(t, `"Alice 愛" removed "Helper Bot" from the chatroom`, sysMsg.Content)
+			req := model.RemoveMemberRequest{RoomID: roomID, Requester: tt.requester.Account, Account: tt.removed.Account, Timestamp: 1}
+			require.NoError(t, h.processRemoveIndividual(context.Background(), &req, nil))
+
+			sysMsg := findSysMsg(t, published, "site-a", "member_removed")
+			assert.Equal(t, tt.want, sysMsg.Content)
+		})
+	}
 }
 
 // Self-leave by a bot: Content uses the registered app name when GetApp resolves it,
@@ -7021,6 +7068,39 @@ func TestProcessRoomRename_TransientSubscriptionUpdateError(t *testing.T) {
 	err := h.processRoomRename(ctx, body)
 	require.Error(t, err)
 	assert.False(t, errors.Is(err, errPermanent), "expected transient (non-permanent) error, got %v", err)
+}
+
+// Rename requested by a bot: the sys-message label substitutes the registered app name.
+func TestProcessRoomRename_BotRequester_Content(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	store := NewMockSubscriptionStore(ctrl)
+
+	const roomID, newName = "r1", "renamed"
+
+	store.EXPECT().UpdateRoomName(gomock.Any(), roomID, newName).Return(nil)
+	store.EXPECT().UpdateSubscriptionNamesForRoom(gomock.Any(), roomID, newName, gomock.Any()).Return(nil)
+	store.EXPECT().GetUser(gomock.Any(), "helper.bot").
+		Return(&model.User{ID: "u_bot", Account: "helper.bot", SiteID: "site-a"}, nil)
+	store.EXPECT().GetApp(gomock.Any(), "helper.bot").Return(&model.App{Name: "Helper Bot"}, nil)
+	store.EXPECT().ListByRoom(gomock.Any(), roomID).Return(nil, nil)
+	store.EXPECT().GetRoomMeta(gomock.Any(), roomID).Return(&model.Room{ID: roomID}, nil)
+
+	var published []publishedMsg
+	h := &Handler{store: store, siteID: "site-a", publish: func(_ context.Context, subj string, data []byte, _ string) error {
+		published = append(published, publishedMsg{subj: subj, data: data})
+		return nil
+	}}
+	h.appName = preview.CachedAppNameLookup(h.appNameLookup)
+
+	ctx := natsutil.WithRequestID(context.Background(), testRequestID)
+	body, _ := json.Marshal(model.RenameRoomRequest{
+		RoomID: roomID, NewName: newName, Account: "helper.bot", Timestamp: 1700000000000,
+	})
+	require.NoError(t, h.processRoomRename(ctx, body))
+
+	sysMsg := findSysMsg(t, published, "site-a", "room_renamed")
+	assert.Equal(t, `"Helper Bot" renamed the channel to "renamed"`, sysMsg.Content)
 }
 
 func TestProcessRoomRename_PublishesRoomRenamedEvent(t *testing.T) {

--- a/room-worker/sysmsg.go
+++ b/room-worker/sysmsg.go
@@ -27,14 +27,14 @@ func plural(n int, singular, pluralForm string) string {
 	return strconv.Itoa(n) + " " + pluralForm
 }
 
-func formatAddedSingle(requester *model.User, addedName string) string {
-	return quoted(displayName(requester)) + " added " + quoted(addedName) + " to the chatroom"
+func formatAddedSingle(requesterName, addedName string) string {
+	return quoted(requesterName) + " added " + quoted(addedName) + " to the chatroom"
 }
 
 // formatAddedCounts renders the count form. At least one of people/orgs is > 0
 // (callers skip emitting the message when both are zero).
-func formatAddedCounts(requester *model.User, people, orgs int) string {
-	who := quoted(displayName(requester))
+func formatAddedCounts(requesterName string, people, orgs int) string {
+	who := quoted(requesterName)
 	switch {
 	case people > 0 && orgs > 0:
 		return who + " added " + plural(people, "person", "people") +
@@ -48,13 +48,13 @@ func formatAddedCounts(requester *model.User, people, orgs int) string {
 
 // addedContent renders members_added Content for both add and create: named form
 // for a lone individual (no orgs), else counts. nameOf returns "" if unresolved.
-func addedContent(requester *model.User, individuals, orgs []string, nameOf func(string) string) string {
+func addedContent(requesterName string, individuals, orgs []string, nameOf func(string) string) string {
 	if len(individuals) == 1 && len(orgs) == 0 {
 		if name := nameOf(individuals[0]); name != "" {
-			return formatAddedSingle(requester, name)
+			return formatAddedSingle(requesterName, name)
 		}
 	}
-	return formatAddedCounts(requester, len(individuals), len(orgs))
+	return formatAddedCounts(requesterName, len(individuals), len(orgs))
 }
 
 // nonNil returns s, or a non-nil empty slice so JSON marshals "[]" not "null".
@@ -77,12 +77,12 @@ func withoutAccount(accounts []string, account string) []string {
 	return out
 }
 
-func formatRemovedUser(requester *model.User, removedName string) string {
-	return quoted(displayName(requester)) + " removed " + quoted(removedName) + " from the chatroom"
+func formatRemovedUser(requesterName, removedName string) string {
+	return quoted(requesterName) + " removed " + quoted(removedName) + " from the chatroom"
 }
 
-func formatRemovedOrg(requester *model.User, name, tcName, orgID string) string {
-	return quoted(displayName(requester)) + " removed " + quoted(displayOrg(name, tcName, orgID)) + " from the chatroom"
+func formatRemovedOrg(requesterName, name, tcName, orgID string) string {
+	return quoted(requesterName) + " removed " + quoted(displayOrg(name, tcName, orgID)) + " from the chatroom"
 }
 
 func formatLeft(name string) string {

--- a/room-worker/sysmsg_test.go
+++ b/room-worker/sysmsg_test.go
@@ -9,15 +9,12 @@ import (
 )
 
 func TestFormatAddedSingle(t *testing.T) {
-	got := formatAddedSingle(
-		&model.User{EngName: "Alice", ChineseName: "愛麗絲"},
-		"Bob 鮑勃",
-	)
+	got := formatAddedSingle("Alice 愛麗絲", "Bob 鮑勃")
 	assert.Equal(t, `"Alice 愛麗絲" added "Bob 鮑勃" to the chatroom`, got)
 }
 
 func TestFormatAddedCounts(t *testing.T) {
-	alice := &model.User{EngName: "Alice", ChineseName: "愛麗絲"}
+	alice := "Alice 愛麗絲"
 	cases := []struct {
 		name         string
 		people, orgs int
@@ -38,7 +35,7 @@ func TestFormatAddedCounts(t *testing.T) {
 }
 
 func TestAddedContent(t *testing.T) {
-	alice := &model.User{EngName: "Alice", ChineseName: "愛"}
+	alice := "Alice 愛"
 	lookup := func(a string) string {
 		if a == "bob" {
 			return "Bob 鮑"
@@ -77,15 +74,12 @@ func TestWithoutAccount(t *testing.T) {
 }
 
 func TestFormatRemovedUser(t *testing.T) {
-	got := formatRemovedUser(
-		&model.User{EngName: "Alice", ChineseName: "愛"},
-		"Bob 鮑勃",
-	)
+	got := formatRemovedUser("Alice 愛", "Bob 鮑勃")
 	assert.Equal(t, `"Alice 愛" removed "Bob 鮑勃" from the chatroom`, got)
 }
 
 func TestFormatRemovedOrg(t *testing.T) {
-	got := formatRemovedOrg(&model.User{EngName: "Alice", ChineseName: "愛"}, "Engineering", "", "orgX")
+	got := formatRemovedOrg("Alice 愛", "Engineering", "", "orgX")
 	assert.Equal(t, `"Alice 愛" removed "Engineering" from the chatroom`, got)
 }
 
@@ -149,10 +143,7 @@ func TestFormatLeft_FallsBackToAccount(t *testing.T) {
 }
 
 func TestFormatAddedSingle_SingleNameSide(t *testing.T) {
-	got := formatAddedSingle(
-		&model.User{EngName: "Alice"},
-		"鮑勃",
-	)
+	got := formatAddedSingle("Alice", "鮑勃")
 	assert.Equal(t, `"Alice" added "鮑勃" to the chatroom`, got)
 }
 
@@ -172,7 +163,6 @@ func TestDisplayOrg(t *testing.T) {
 }
 
 func TestFormatRemovedOrg_Fallbacks(t *testing.T) {
-	alice := &model.User{EngName: "Alice", ChineseName: "愛"}
-	assert.Equal(t, `"Alice 愛" removed "Eng 工程部" from the chatroom`, formatRemovedOrg(alice, "Eng", "工程部", "orgX"))
-	assert.Equal(t, `"Alice 愛" removed "orgX" from the chatroom`, formatRemovedOrg(alice, "", "", "orgX"))
+	assert.Equal(t, `"Alice 愛" removed "Eng 工程部" from the chatroom`, formatRemovedOrg("Alice 愛", "Eng", "工程部", "orgX"))
+	assert.Equal(t, `"Alice 愛" removed "orgX" from the chatroom`, formatRemovedOrg("Alice 愛", "", "", "orgX"))
 }


### PR DESCRIPTION
## Summary

PR #446 made the **member** side of member add/remove system messages bot-aware (a bot account renders as its registered app name), but deliberately left the **requester** side on the composed EngName/ChineseName. A bot can invoke user RPCs with its own NATS credentials, so a bot requester rendered as its raw account (`"helper.bot" added ...`) instead of its app name — inconsistent with the member side.

## Changes

- **sysmsg.go**: the five format helpers (`formatAddedSingle`, `formatAddedCounts`, `addedContent`, `formatRemovedUser`, `formatRemovedOrg`) now take a pre-rendered requester name string instead of `*model.User`; name resolution moves up to the handler.
- **handler.go**: all five requester call sites (add members, create channel, remove individual, remove org, rename) route the requester label through `h.botAwareName(ctx, requester)` — bots resolve to the registered app name via the existing cached lookup (LRU + singleflight from #446); human accounts are short-circuited by `IsBot()` at zero extra cost. The helper is renamed from `memberDisplayName` since it no longer serves only the member side.
- **Tests**: new bot-requester cases for add / remove / rename; the bot-member and bot-requester variants of the add/remove sysmsg tests are folded into table-driven pairs keyed by which side is the bot.

## Behavior

- Bot-initiated membership changes and renames now render e.g. `"Helper Bot" added "U1 一" to the chatroom`, consistent with the member side.
- Output for human requesters is unchanged.
- No wire-schema change: `Content` remains a server-rendered string, so `docs/client-api.md` needs no update (same as #446).

## Verification

- `make test SERVICE=room-worker` green (race detector on)
- `golangci-lint run ./room-worker/...` — 0 issues
- Reviewed via 5 parallel lenses (reuse / simplification / efficiency / altitude / correctness); the only findings were the test duplication, addressed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System messages now consistently display a bot’s registered app name when the bot adds, removes, or renames members, channels, or rooms.
  * Improved name handling for both bot participants and bot requesters across membership and room activity notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->