### PR TITLE
feat(admin-frontend): deploy-gate the Updates tab behind UPDATES_ENABLED

### DIFF
--- a/admin-frontend/README.md
+++ b/admin-frontend/README.md
@@ -17,6 +17,7 @@ chat client.
 |---|---|---|
 | `VITE_ADMIN_SERVICE_URL` | admin-service base URL (REST API) | `http://localhost:8082` |
 | `VITE_PERMISSIONS_ENABLED` | shows the Permissions tab when the literal string `true` | unset (hidden) |
+| `VITE_UPDATES_ENABLED` | shows the Updates tab when the literal string `true` | unset (hidden) |
 
 **Container (nginx runtime, `/config.js` rendered by `deploy/30-render-config.sh`)**:
 
@@ -24,6 +25,7 @@ chat client.
 |---|---|---|
 | `ADMIN_SERVICE_URL` | admin-service base URL | yes — container fails to start if unset |
 | `PERMISSIONS_ENABLED` | shows the Permissions tab when the literal string `true` | no — defaults to `false` (tab hidden) |
+| `UPDATES_ENABLED` | shows the Updates tab when the literal string `true` | no — defaults to `false` (tab hidden) |
 
 `src/lib/runtimeConfig.js` reads `window.__APP_CONFIG__` first (prod), falling
 back to the `VITE_*` env vars (dev), falling back to the literal defaults

--- a/admin-frontend/deploy/30-render-config.sh
+++ b/admin-frontend/deploy/30-render-config.sh
@@ -7,10 +7,11 @@ set -eu
 : "${ADMIN_SERVICE_URL:?ADMIN_SERVICE_URL is required (admin-service base URL)}"
 # Deploy-gated sections default off; only the literal string "true" enables.
 : "${PERMISSIONS_ENABLED:=false}"
-export ADMIN_SERVICE_URL PERMISSIONS_ENABLED
+: "${UPDATES_ENABLED:=false}"
+export ADMIN_SERVICE_URL PERMISSIONS_ENABLED UPDATES_ENABLED
 
-envsubst '${ADMIN_SERVICE_URL} ${PERMISSIONS_ENABLED}' \
+envsubst '${ADMIN_SERVICE_URL} ${PERMISSIONS_ENABLED} ${UPDATES_ENABLED}' \
   < /etc/config.js.template \
   > /usr/share/nginx/html/config.js
 
-echo "rendered /config.js  ADMIN_SERVICE_URL=$ADMIN_SERVICE_URL PERMISSIONS_ENABLED=$PERMISSIONS_ENABLED"
+echo "rendered /config.js  ADMIN_SERVICE_URL=$ADMIN_SERVICE_URL PERMISSIONS_ENABLED=$PERMISSIONS_ENABLED UPDATES_ENABLED=$UPDATES_ENABLED"

--- a/admin-frontend/deploy/config.js.template
+++ b/admin-frontend/deploy/config.js.template
@@ -1,5 +1,6 @@
 // Generated at container start — edit template, not output.
 window.__APP_CONFIG__ = {
   ADMIN_SERVICE_URL: "${ADMIN_SERVICE_URL}",
-  PERMISSIONS_ENABLED: "${PERMISSIONS_ENABLED}"
+  PERMISSIONS_ENABLED: "${PERMISSIONS_ENABLED}",
+  UPDATES_ENABLED: "${UPDATES_ENABLED}"
 };

--- a/admin-frontend/deploy/docker-compose.yml
+++ b/admin-frontend/deploy/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       ADMIN_SERVICE_URL: ${ADMIN_SERVICE_URL:-http://localhost:${ADMIN_SERVICE_HOST_PORT:-8082}}
       PERMISSIONS_ENABLED: ${PERMISSIONS_ENABLED:-false}
+      UPDATES_ENABLED: ${UPDATES_ENABLED:-false}
     ports:
       - "${ADMIN_FRONTEND_HOST_PORT:-3001}:80"
     networks:

--- a/admin-frontend/src/components/AppShell/AppShell.jsx
+++ b/admin-frontend/src/components/AppShell/AppShell.jsx
@@ -21,7 +21,7 @@ const SECTIONS = [
   },
 ]
 
-// Top-level authed layout: nav to switch Users/Audit, header with signed-in account + logout.
+// Top-level authed layout: nav to switch sections, header with signed-in account + logout.
 export default function AppShell() {
   const { session, logout } = useAuth()
   const [section, setSection] = useState('users')
@@ -31,9 +31,8 @@ export default function AppShell() {
   }
 
   // A section carrying a `gate` is deploy-gated: it exists only where the runtime
-  // config enables it (PERMISSIONS_ENABLED / UPDATES_ENABLED, rendered by nginx
-  // from env). Ungated sections are always present.
-  const sections = SECTIONS.filter((s) => s.gate?.() ?? true)
+  // config enables it (PERMISSIONS_ENABLED / UPDATES_ENABLED, rendered by nginx from env).
+  const sections = SECTIONS.filter((s) => !s.gate || s.gate())
   const { Component } = sections.find((s) => s.key === section) ?? sections[0]
 
   return (

--- a/admin-frontend/src/components/AppShell/AppShell.jsx
+++ b/admin-frontend/src/components/AppShell/AppShell.jsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useState } from 'react'
 import { useAuth } from '@/context/AuthContext'
-import { permissionsEnabled } from '@/lib/runtimeConfig'
+import { permissionsEnabled, updatesEnabled } from '@/lib/runtimeConfig'
 import LazyFallback from '@/components/shared/LazyFallback'
 import './style.css'
 
@@ -11,11 +11,13 @@ const SECTIONS = [
     key: 'permissions',
     label: 'Permissions',
     Component: lazy(() => import('@/components/PermissionsView')),
+    gate: permissionsEnabled,
   },
   {
     key: 'updates',
     label: 'Updates',
     Component: lazy(() => import('@/components/UpdatesConsole')),
+    gate: updatesEnabled,
   },
 ]
 
@@ -28,9 +30,10 @@ export default function AppShell() {
     logout()
   }
 
-  // Permissions is deploy-gated: the section exists only where the runtime
-  // config enables it (PERMISSIONS_ENABLED, rendered by nginx from env).
-  const sections = SECTIONS.filter((s) => s.key !== 'permissions' || permissionsEnabled())
+  // A section carrying a `gate` is deploy-gated: it exists only where the runtime
+  // config enables it (PERMISSIONS_ENABLED / UPDATES_ENABLED, rendered by nginx
+  // from env). Ungated sections are always present.
+  const sections = SECTIONS.filter((s) => s.gate?.() ?? true)
   const { Component } = sections.find((s) => s.key === section) ?? sections[0]
 
   return (

--- a/admin-frontend/src/components/AppShell/AppShell.test.jsx
+++ b/admin-frontend/src/components/AppShell/AppShell.test.jsx
@@ -19,9 +19,9 @@ import { listUsers, listAudit, listPermissions } from '@/api'
 
 beforeEach(() => {
   vi.clearAllMocks()
-  // Default the runtime flag on so the pre-existing Permissions-tab tests keep
-  // exercising the section; the gating tests below override it.
-  window.__APP_CONFIG__ = { PERMISSIONS_ENABLED: 'true' }
+  // Default both deploy gates on so the pre-existing Permissions/Updates tab
+  // tests keep exercising those sections; the gating tests below override them.
+  window.__APP_CONFIG__ = { PERMISSIONS_ENABLED: 'true', UPDATES_ENABLED: 'true' }
   useAuth.mockReturnValue({
     session: { authToken: 'tok', account: 'root', siteId: 'site-1' },
     logout: vi.fn(),
@@ -113,5 +113,33 @@ describe('AppShell permissions gating', () => {
     window.__APP_CONFIG__ = { PERMISSIONS_ENABLED: 'true' }
     render(<AppShell />)
     expect(screen.getByRole('button', { name: 'Permissions' })).toBeInTheDocument()
+  })
+})
+
+describe('AppShell updates gating', () => {
+  it('hides the Updates tab when the runtime flag is absent', () => {
+    window.__APP_CONFIG__ = {}
+    render(<AppShell />)
+    expect(screen.queryByRole('button', { name: 'Updates' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Users' })).toBeInTheDocument()
+  })
+
+  it('hides the Updates tab when the runtime flag is not the string "true"', () => {
+    window.__APP_CONFIG__ = { UPDATES_ENABLED: 'false' }
+    render(<AppShell />)
+    expect(screen.queryByRole('button', { name: 'Updates' })).toBeNull()
+  })
+
+  it('shows the Updates tab when the runtime flag is "true"', () => {
+    window.__APP_CONFIG__ = { UPDATES_ENABLED: 'true' }
+    render(<AppShell />)
+    expect(screen.getByRole('button', { name: 'Updates' })).toBeInTheDocument()
+  })
+
+  it('gates Updates independently of Permissions', () => {
+    window.__APP_CONFIG__ = { PERMISSIONS_ENABLED: 'true', UPDATES_ENABLED: 'false' }
+    render(<AppShell />)
+    expect(screen.getByRole('button', { name: 'Permissions' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Updates' })).toBeNull()
   })
 })

--- a/admin-frontend/src/lib/runtimeConfig.js
+++ b/admin-frontend/src/lib/runtimeConfig.js
@@ -1,19 +1,22 @@
 // Runtime config: window.__APP_CONFIG__ in prod (nginx envsubst), import.meta.env.VITE_*
 // in `vite dev`, literal defaults as last resort. Mirrors chat-frontend's read chain.
 
-const runtime = (typeof window !== 'undefined' && window.__APP_CONFIG__) || {}
+const runtimeConfig = () => (typeof window !== 'undefined' && window.__APP_CONFIG__) || {}
 
 export const ADMIN_SERVICE_URL =
-  runtime.ADMIN_SERVICE_URL || import.meta.env.VITE_ADMIN_SERVICE_URL || 'http://localhost:8082'
+  runtimeConfig().ADMIN_SERVICE_URL ||
+  import.meta.env.VITE_ADMIN_SERVICE_URL ||
+  'http://localhost:8082'
 
-// Read at call time (not module load) so the nginx-rendered config.js and tests
-// can both flip it. envsubst renders strings, so only the string 'true' enables.
-export const permissionsEnabled = () => {
-  const runtimeNow = (typeof window !== 'undefined' && window.__APP_CONFIG__) || {}
-  return (runtimeNow.PERMISSIONS_ENABLED ?? import.meta.env.VITE_PERMISSIONS_ENABLED) === 'true'
-}
+// envsubst renders strings, so only the literal 'true' enables. Deliberately
+// case-sensitive, unlike chat-frontend's boolConfig.
+const flagEnabled = (value) => value === 'true'
 
-export const updatesEnabled = () => {
-  const runtimeNow = (typeof window !== 'undefined' && window.__APP_CONFIG__) || {}
-  return (runtimeNow.UPDATES_ENABLED ?? import.meta.env.VITE_UPDATES_ENABLED) === 'true'
-}
+// Deploy gates read at call time (not module load) so the nginx-rendered config.js
+// and tests can both flip them. Take the VITE_ fallback as a value: Vite statically
+// replaces only literal `import.meta.env.VITE_X`, never a computed key.
+export const permissionsEnabled = () =>
+  flagEnabled(runtimeConfig().PERMISSIONS_ENABLED ?? import.meta.env.VITE_PERMISSIONS_ENABLED)
+
+export const updatesEnabled = () =>
+  flagEnabled(runtimeConfig().UPDATES_ENABLED ?? import.meta.env.VITE_UPDATES_ENABLED)

--- a/admin-frontend/src/lib/runtimeConfig.js
+++ b/admin-frontend/src/lib/runtimeConfig.js
@@ -12,3 +12,8 @@ export const permissionsEnabled = () => {
   const runtimeNow = (typeof window !== 'undefined' && window.__APP_CONFIG__) || {}
   return (runtimeNow.PERMISSIONS_ENABLED ?? import.meta.env.VITE_PERMISSIONS_ENABLED) === 'true'
 }
+
+export const updatesEnabled = () => {
+  const runtimeNow = (typeof window !== 'undefined' && window.__APP_CONFIG__) || {}
+  return (runtimeNow.UPDATES_ENABLED ?? import.meta.env.VITE_UPDATES_ENABLED) === 'true'
+}

--- a/admin-frontend/src/lib/runtimeConfig.test.js
+++ b/admin-frontend/src/lib/runtimeConfig.test.js
@@ -45,10 +45,18 @@ describe('runtimeConfig', () => {
     expect(updatesEnabled()).toBe(false)
   })
 
-  it('updatesEnabled reads at call time, independent of permissionsEnabled', async () => {
-    window.__APP_CONFIG__ = { PERMISSIONS_ENABLED: 'true', UPDATES_ENABLED: 'false' }
+  // The nginx-rendered config.js lands before the bundle, but tests flip the flag
+  // after import — so the read must happen per call, not once at module load.
+  it('the gates read window.__APP_CONFIG__ at call time, not at module load', async () => {
     const { permissionsEnabled, updatesEnabled } = await import('./runtimeConfig.js')
-    expect(permissionsEnabled()).toBe(true)
     expect(updatesEnabled()).toBe(false)
+
+    window.__APP_CONFIG__ = { PERMISSIONS_ENABLED: 'true', UPDATES_ENABLED: 'true' }
+    expect(updatesEnabled()).toBe(true)
+    expect(permissionsEnabled()).toBe(true)
+
+    window.__APP_CONFIG__ = { PERMISSIONS_ENABLED: 'true', UPDATES_ENABLED: 'false' }
+    expect(updatesEnabled()).toBe(false)
+    expect(permissionsEnabled()).toBe(true)
   })
 })

--- a/admin-frontend/src/lib/runtimeConfig.test.js
+++ b/admin-frontend/src/lib/runtimeConfig.test.js
@@ -16,4 +16,39 @@ describe('runtimeConfig', () => {
     const { ADMIN_SERVICE_URL } = await import('./runtimeConfig.js')
     expect(ADMIN_SERVICE_URL).toBe('https://admin.example.com')
   })
+
+  it('permissionsEnabled is false when the runtime flag is absent', async () => {
+    window.__APP_CONFIG__ = {}
+    const { permissionsEnabled } = await import('./runtimeConfig.js')
+    expect(permissionsEnabled()).toBe(false)
+  })
+
+  it('permissionsEnabled is true only for the literal string "true"', async () => {
+    window.__APP_CONFIG__ = { PERMISSIONS_ENABLED: 'true' }
+    const { permissionsEnabled } = await import('./runtimeConfig.js')
+    expect(permissionsEnabled()).toBe(true)
+    window.__APP_CONFIG__ = { PERMISSIONS_ENABLED: 'True' }
+    expect(permissionsEnabled()).toBe(false)
+  })
+
+  it('updatesEnabled is false when the runtime flag is absent', async () => {
+    window.__APP_CONFIG__ = {}
+    const { updatesEnabled } = await import('./runtimeConfig.js')
+    expect(updatesEnabled()).toBe(false)
+  })
+
+  it('updatesEnabled is true only for the literal string "true"', async () => {
+    window.__APP_CONFIG__ = { UPDATES_ENABLED: 'true' }
+    const { updatesEnabled } = await import('./runtimeConfig.js')
+    expect(updatesEnabled()).toBe(true)
+    window.__APP_CONFIG__ = { UPDATES_ENABLED: 'True' }
+    expect(updatesEnabled()).toBe(false)
+  })
+
+  it('updatesEnabled reads at call time, independent of permissionsEnabled', async () => {
+    window.__APP_CONFIG__ = { PERMISSIONS_ENABLED: 'true', UPDATES_ENABLED: 'false' }
+    const { permissionsEnabled, updatesEnabled } = await import('./runtimeConfig.js')
+    expect(permissionsEnabled()).toBe(true)
+    expect(updatesEnabled()).toBe(false)
+  })
 })

--- a/docs/superpowers/specs/2026-08-26-client-update-admin-upload-design.md
+++ b/docs/superpowers/specs/2026-08-26-client-update-admin-upload-design.md
@@ -338,6 +338,17 @@ convention used by `UsersConsole`, `AuditView` and `PermissionsView`.
 `AppShell.jsx`'s nav gains `{ key: 'updates', label: 'Updates', Component: lazy(() => import('@/components/UpdatesConsole')) }`,
 lazy-loaded like its siblings.
 
+**Deploy-gated** (added 2026-09-01): the section carries `gate: updatesEnabled`, so
+the tab renders only where the runtime config flag `UPDATES_ENABLED` is the literal
+string `"true"` (nginx envsubst renders it from the container env; default `false`,
+dev compose included). This mirrors `PERMISSIONS_ENABLED` and gates the UI section
+only — `admin-service`'s `POST /v1/admin/client-updates` is unchanged and stays
+reachable with an admin token. To actually disable uploads for a site, leave
+`client-update-service`'s `UPLOAD_TOKENS` empty (§1.1) — an empty table is a valid
+config meaning "uploads disabled". Clearing `admin-service`'s `CLIENT_UPDATE_TOKEN`
+is not an alternative: it is `required` and rejected when empty, so admin-service
+fails to start.
+
 States: idle → both files chosen → uploading (percentage) → success / error.
 Upload is disabled until both files are chosen. Error copy goes through
 `formatAsyncJobError`.


### PR DESCRIPTION
## What

Adds a deploy-time toggle `UPDATES_ENABLED` that gates the **Updates** ("Client updates") nav section in the admin console, mirroring the existing `PERMISSIONS_ENABLED` gate. Defaults to `false` everywhere, so the tab is hidden unless a deploy opts in.

| Layer | Change |
|---|---|
| `src/lib/runtimeConfig.js` | new `updatesEnabled()` — reads `window.__APP_CONFIG__.UPDATES_ENABLED`, falling back to `VITE_UPDATES_ENABLED`; only the literal string `'true'` enables |
| `src/components/AppShell/AppShell.jsx` | Updates section gated |
| `deploy/config.js.template` | renders `UPDATES_ENABLED` into `/config.js` |
| `deploy/30-render-config.sh` | `: "${UPDATES_ENABLED:=false}"`, exported, added to the `envsubst` allowlist and the startup echo |
| `deploy/docker-compose.yml` | `UPDATES_ENABLED: ${UPDATES_ENABLED:-false}` |
| `README.md` | both env-var tables |
| `docs/superpowers/specs/2026-08-26-client-update-admin-upload-design.md` | records the gate (the spec still described the nav entry as ungated) |

## Notes for review

**The gate moved onto the section entry.** The filter was `SECTIONS.filter((s) => s.key !== 'permissions' || permissionsEnabled())` — a hardcoded key special-case that would grow a clause per flag. Each gated section now carries `gate: <fn>` and the filter is `SECTIONS.filter((s) => !s.gate || s.gate())`. Permissions behaviour is unchanged and its existing gating tests pass untouched.

**The flag-parsing rule is now named once.** `permissionsEnabled` and `updatesEnabled` were byte-identical but for the variable name, so `flagEnabled` and `runtimeConfig()` were factored out — the same move `chat-frontend/src/lib/runtimeConfig.js:6` already made with `boolConfig` at its second flag. Two deliberate differences from that sibling: admin's check stays case-sensitive (`'True'` → `false`, pinned by tests), and the `VITE_` fallback is passed in as a value because Vite statically replaces only a literal `import.meta.env.VITE_X`, never a computed key.

**This is a UI gate only.** `admin-service`'s `POST /v1/admin/client-updates` is unchanged and stays reachable with an admin token — the same property the `PERMISSIONS_ENABLED` gate has, recorded as R6 in `2026-08-19-admin-user-fanout-design.md`. The lever that actually disables uploads is an empty `UPLOAD_TOKENS` on `client-update-service` (an empty table is a valid config meaning "uploads disabled"). Clearing `admin-service`'s `CLIENT_UPDATE_TOKEN` is *not* an alternative — it is `required` and rejected when empty, so the service fails to start. The spec text now says this.

## Testing

TDD: tests written first, Red confirmed (6 failures — 3 for the missing `updatesEnabled` export, 3 for the ungated tab), then implemented to Green.

- `npm test` → **265 passed (265)**, 25 files
- `npm run typecheck` → exit 0
- `npm run build` → succeeds

Beyond the unit tests, since neither the shell script nor nginx is covered by vitest:

- Ran `deploy/30-render-config.sh` under `sh` with a stubbed `envsubst`: unset → `UPDATES_ENABLED: "false"`; `UPDATES_ENABLED=true` → `"true"`; a missing `ADMIN_SERVICE_URL` still hard-fails (exit 2).
- Drove the built `dist/` in Chromium against both rendered configs: flag off → nav is `[Users, Audit]`; flag on → `[Users, Audit, Updates]`.
- The "reads at call time" test was verified red-green against a variant that hoists the read to module load, so it actually exercises the contract its name claims.

Docker Compose itself could not be exercised in this environment — the image registry blob CDN is blocked by network policy (403 on CONNECT), so no base image can be pulled. The compose file change is a one-line env addition beside its `PERMISSIONS_ENABLED` twin, and the render script it feeds was tested directly as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoE1ifFqPRy68XQanLxeBy

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoE1ifFqPRy68XQanLxeBy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deployment-controlled Updates tab in the admin interface.
  * The tab is shown only when `UPDATES_ENABLED` is set to `true`; it is hidden by default.

* **Documentation**
  * Documented configuration options for enabling the Updates tab in development and container deployments.
  * Clarified how update uploads can be disabled through deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->