### PR TITLE
fix(inbox-worker): stop a membership backlog stalling the whole INBOX

### DIFF
--- a/inbox-worker/lanes.go
+++ b/inbox-worker/lanes.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"sync"
+
+	"github.com/hmchangw/chat/pkg/natsmetrics"
+)
+
+// membershipLaneFloor bounds the sequential lane when MaxAckPending carries no
+// usable number — unlimited (-1 or 0, which JetStream normalizes to unlimited)
+// or a budget so small that a buffer sized from it would fill on a trivial
+// burst. It is a memory bound, not a throughput one: laneMsg is two words plus
+// the message the server has already delivered to this process.
+const membershipLaneFloor = 1024
+
+// membershipLaneCap sizes the sequential membership lane so the dispatcher can
+// never block on it.
+//
+// Every message sitting in that buffer is un-acked, so it counts against the
+// consumer's MaxAckPending budget. Sizing the buffer at the budget means the
+// server stops delivering before the channel can fill — the send in
+// dispatchLanes is therefore non-blocking in every reachable state, and a slow
+// membership write can no longer stop the pump that also feeds the concurrent
+// lane. Backpressure still exists; it just lands on iter.Next(), where having
+// nothing to hand the concurrent lane is the truth rather than an artifact.
+func membershipLaneCap(maxAckPending int) int {
+	if maxAckPending < membershipLaneFloor {
+		return membershipLaneFloor
+	}
+	return maxAckPending
+}
+
+// dispatchLanes pumps iter and routes each message to one of two lanes:
+// membership events onto the caller's sequential channel, everything else onto
+// a bounded worker pool. It returns when the iterator reports a terminal error,
+// closing membershipCh so the sequential drainer can finish.
+//
+// The membership send is deliberately a plain send rather than a select with a
+// default: dropping or NAKing on a full lane would reorder add/remove for the
+// same (room, account), which is the one thing the sequential lane exists to
+// prevent. It is safe to block on because membershipLaneCap sizes the channel
+// past the delivery budget — see that function.
+func dispatchLanes(
+	iter natsmetrics.Iterator,
+	isMembership func(subject string) bool,
+	membershipCh chan<- laneMsg,
+	sem chan struct{},
+	wg *sync.WaitGroup,
+	process func(laneMsg),
+) {
+	defer close(membershipCh)
+	for {
+		msgCtx, msg, err := iter.Next()
+		if err != nil {
+			return
+		}
+		m := laneMsg{ctx: msgCtx, msg: msg}
+		if isMembership(msg.Subject()) {
+			membershipCh <- m
+			continue
+		}
+		sem <- struct{}{}
+		wg.Add(1)
+		go func() {
+			defer func() {
+				<-sem
+				wg.Done()
+			}()
+			process(m)
+		}()
+	}
+}

--- a/inbox-worker/lanes_test.go
+++ b/inbox-worker/lanes_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/model"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+// stubLaneMsg is the minimum jetstream.Msg the lane dispatcher touches: it
+// routes on Subject() and never disposes the message itself.
+type stubLaneMsg struct{ subject string }
+
+func (s stubLaneMsg) Metadata() (*jetstream.MsgMetadata, error) {
+	return &jetstream.MsgMetadata{NumDelivered: 1}, nil
+}
+func (s stubLaneMsg) Data() []byte                     { return nil }
+func (s stubLaneMsg) Headers() nats.Header             { return nats.Header{} }
+func (s stubLaneMsg) Subject() string                  { return s.subject }
+func (s stubLaneMsg) Reply() string                    { return "" }
+func (s stubLaneMsg) Ack() error                       { return nil }
+func (s stubLaneMsg) DoubleAck(context.Context) error  { return nil }
+func (s stubLaneMsg) Nak() error                       { return nil }
+func (s stubLaneMsg) NakWithDelay(time.Duration) error { return nil }
+func (s stubLaneMsg) InProgress() error                { return nil }
+func (s stubLaneMsg) Term() error                      { return nil }
+func (s stubLaneMsg) TermWithReason(string) error      { return nil }
+
+// scriptedIter yields a fixed sequence and then reports a terminal error, which
+// is how dispatchLanes is told to stop.
+type scriptedIter struct {
+	msgs []jetstream.Msg
+	i    int
+}
+
+func (s *scriptedIter) Next(...jetstream.NextOpt) (context.Context, jetstream.Msg, error) {
+	if s.i >= len(s.msgs) {
+		return nil, nil, errors.New("iterator closed")
+	}
+	m := s.msgs[s.i]
+	s.i++
+	return context.Background(), m, nil
+}
+
+func TestMembershipLaneCap(t *testing.T) {
+	tests := []struct {
+		name          string
+		maxAckPending int
+		want          int
+	}{
+		{"a budget above the floor is honoured exactly", 4096, 4096},
+		{"the repo-default budget is raised to the floor", 1000, membershipLaneFloor},
+		{"a small budget is raised to the floor", 20, membershipLaneFloor},
+		{"unlimited (-1) falls back to the floor", -1, membershipLaneFloor},
+		{"unlimited (0) falls back to the floor", 0, membershipLaneFloor},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := membershipLaneCap(tt.maxAckPending)
+			assert.Equal(t, tt.want, got)
+			// The invariant the fix rests on: the lane is never smaller than the
+			// delivery budget, so it cannot fill before the server stops
+			// delivering. Without this the dispatcher can park on a full lane.
+			assert.GreaterOrEqual(t, got, tt.maxAckPending,
+				"lane must be at least the ack-pending budget")
+			assert.GreaterOrEqual(t, got, membershipLaneFloor)
+		})
+	}
+}
+
+// TestDispatchLanes_MembershipBacklogDoesNotStallConcurrentLane is the
+// regression guard for the head-of-line stall: a membership backlog that nobody
+// is draining must not stop the pump that also feeds the concurrent lane.
+//
+// Every queued membership message is un-acked and so counts against the
+// consumer's MaxAckPending budget. A lane sized at that budget therefore cannot
+// fill before the server stops delivering, which is what keeps the send
+// non-blocking.
+func TestDispatchLanes_MembershipBacklogDoesNotStallConcurrentLane(t *testing.T) {
+	const (
+		siteID        = "site-a"
+		maxAckPending = 20
+		maxWorkers    = 4
+	)
+
+	msgs := make([]jetstream.Msg, 0, maxAckPending+1)
+	for i := 0; i < maxAckPending; i++ {
+		msgs = append(msgs, stubLaneMsg{subject: subject.InboxExternal(siteID, model.InboxMemberAdded)})
+	}
+	// The one message the concurrent lane must still receive.
+	msgs = append(msgs, stubLaneMsg{subject: subject.InboxExternal(siteID, model.InboxSubscriptionRead)})
+
+	concurrent := make(chan string, 1)
+	process := func(m laneMsg) { concurrent <- m.msg.Subject() }
+
+	// Deliberately never drained, standing in for a membership lane blocked on a
+	// slow Mongo write.
+	membershipCh := make(chan laneMsg, membershipLaneCap(maxAckPending))
+	sem := make(chan struct{}, maxWorkers)
+	var wg sync.WaitGroup
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		dispatchLanes(&scriptedIter{msgs: msgs},
+			func(subj string) bool { return isMembershipSubject(subj, siteID) },
+			membershipCh, sem, &wg, process)
+	}()
+
+	select {
+	case got := <-concurrent:
+		assert.Equal(t, subject.InboxExternal(siteID, model.InboxSubscriptionRead), got,
+			"the concurrent lane must keep flowing while membership is backed up")
+	case <-time.After(2 * time.Second):
+		t.Fatal("pump stalled: the concurrent lane was starved by an undrained membership backlog")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("dispatchLanes did not return after the iterator reported a terminal error")
+	}
+
+	require.Len(t, membershipCh, maxAckPending, "every membership message should be queued, none dropped")
+	wg.Wait()
+}
+
+// TestDispatchLanes_RoutesBySubject pins the split itself: membership goes to
+// the sequential lane, everything else to the worker pool.
+func TestDispatchLanes_RoutesBySubject(t *testing.T) {
+	const siteID = "site-a"
+
+	tests := []struct {
+		name          string
+		eventType     string
+		wantSequenced bool
+	}{
+		{"member added is sequenced", model.InboxMemberAdded, true},
+		{"member removed is sequenced", model.InboxMemberRemoved, true},
+		{"subscription read is concurrent", model.InboxSubscriptionRead, false},
+		{"role updated is concurrent", model.InboxRoleUpdated, false},
+		{"room renamed is concurrent", model.InboxRoomRenamed, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subj := subject.InboxExternal(siteID, tt.eventType)
+			processed := make(chan string, 1)
+
+			membershipCh := make(chan laneMsg, 1)
+			sem := make(chan struct{}, 1)
+			var wg sync.WaitGroup
+
+			dispatchLanes(&scriptedIter{msgs: []jetstream.Msg{stubLaneMsg{subject: subj}}},
+				func(s string) bool { return isMembershipSubject(s, siteID) },
+				membershipCh, sem, &wg, func(m laneMsg) { processed <- m.msg.Subject() })
+			wg.Wait()
+
+			if tt.wantSequenced {
+				require.Len(t, membershipCh, 1, "expected the message on the sequential lane")
+				assert.Empty(t, processed, "a sequenced message must not run on the worker pool")
+				return
+			}
+			require.Empty(t, membershipCh, "a concurrent message must not be sequenced")
+			select {
+			case got := <-processed:
+				assert.Equal(t, subj, got)
+			case <-time.After(2 * time.Second):
+				t.Fatal("concurrent message was never processed")
+			}
+		})
+	}
+}

--- a/inbox-worker/main.go
+++ b/inbox-worker/main.go
@@ -934,7 +934,10 @@ func main() {
 	}
 
 	sem := make(chan struct{}, cfg.MaxWorkers)
-	membershipCh := make(chan laneMsg, cfg.MaxWorkers)
+	// Sized from the delivery budget, not MaxWorkers, so the dispatcher can
+	// never park on a full lane and starve the concurrent one — see
+	// membershipLaneCap.
+	membershipCh := make(chan laneMsg, membershipLaneCap(cfg.Consumer.MaxAckPending))
 	var wg sync.WaitGroup
 
 	process := func(m laneMsg) {
@@ -959,29 +962,9 @@ func main() {
 		}
 	}()
 
-	go func() {
-		defer close(membershipCh)
-		for {
-			msgCtx, msg, err := iter.Next()
-			if err != nil {
-				return
-			}
-			m := laneMsg{ctx: msgCtx, msg: msg}
-			if isMembershipSubject(msg.Subject(), cfg.SiteID) {
-				membershipCh <- m
-				continue
-			}
-			sem <- struct{}{}
-			wg.Add(1)
-			go func() {
-				defer func() {
-					<-sem
-					wg.Done()
-				}()
-				process(m)
-			}()
-		}
-	}()
+	go dispatchLanes(iter,
+		func(subj string) bool { return isMembershipSubject(subj, cfg.SiteID) },
+		membershipCh, sem, &wg, process)
 
 	healthStop, err := health.ServeWithPprof(cfg.HealthAddr, 5*time.Second, cfg.PProfEnabled,
 		natsutil.HealthCheck(nc),


### PR DESCRIPTION
## The bug

`inbox-worker` splits INBOX into two lanes: membership events (`member_added`/`member_removed`) run on **one** sequential worker so add/remove for the same `(room, account)` apply in arrival order, and everything else fans out across `MAX_WORKERS`.

The dispatcher pumped `iter.Next()` and, for a membership subject, did a **blocking** send onto `membershipCh` — capacity `MAX_WORKERS` (100), drained by that single worker:

```go
// inbox-worker/main.go:963-975 (before)
msgCtx, msg, err := iter.Next()
...
if isMembershipSubject(msg.Subject(), cfg.SiteID) {
    membershipCh <- m   // blocking, from the pump goroutine
    continue
}
sem <- struct{}{}       // concurrent lane, never reached once the send parks
```

Once the lane filled — a Mongo slowdown on the membership write, or a peer running a bulk member sync — **the send parked the pump, so nothing was read from INBOX at all.** Read receipts, mute/favourite toggles, role updates, thread subscriptions and mention badges, from *every* peer site, stalled behind a lane that carries a tiny fraction of the traffic.

**It degrades into silent loss.** The consumer takes plain `DurableConsumerDefaults` (`MaxDeliver=6`, BackOff `{30s,1m,2m,4m,8m}`), so the ~200 already-prefetched messages age past `AckWait` while the pump is parked, redeliver, and after **23m30s of unbroken stall** are dropped — with no log line at all.

> **Correction.** An earlier version of this section gave that as "~6.3 minutes guaranteed", and said the drop came "with only a WARN". Both are wrong.
>
> **The figure came from the wrong ladder.** 6.3 min is the jittered floor of the *client-side* `jsretry.DefaultBackoff`, which never fires in this scenario — the pump is parked, so the handler never runs and never NAKs. What spaces these redeliveries is the *server-side* consumer `BackOff`, which is unjittered, so the real number is deterministic rather than a floor.
>
> The server indexes `BackOff` by redelivery count and clamps to the last entry (`nats-server@v2.12.6`, `server/consumer.go:5599-5601`), so a message nobody ever acks gets six deliveries spaced `30s, 1m, 2m, 4m, 8m, 8m`, then `hasMaxDeliveries` (`:2164`) evicts it. Replayed against an embedded JetStream server at 1/150 scale (`AckWait=200ms`, same shape, `MaxDeliver=6`), the deliveries landed at 1/203/603/1403/3004/6205 ms and the `MAX_DELIVERIES` advisory fired at 9406 ms — the clamped sum exactly, which is **23m30s** at the real settings. Measured, not derived.
>
> **And nothing logs it.** The drop is not a WARN: the handler never executes, so no application code observes the message at all. The server emits a `MAX_DELIVERIES` advisory, and nothing in the repo subscribes to `$JS.EVENT.ADVISORY.>`. The loss is completely silent.
>
> Net effect on this PR: the stall takes ~4x longer to turn into loss than first stated, and is that much harder to notice when it does. The bug and the fix are unchanged.

The comment above the code is the tell — it reasons correctly about *throughput* ("membership traffic is a tiny fraction of the lane, so serializing it costs negligible throughput") and never considers that a blocking send couples the serial lane to the concurrent one. The serialisation is right; the coupling is the bug.

`outbox-worker` spends real complexity isolating federation lanes per peer at the origin so a down peer cannot affect a healthy one. The destination re-merged every peer's membership traffic into one serial lane and then dropped on overflow.

## The fix

Size the lane from `MaxAckPending` rather than `MAX_WORKERS`.

Every message queued in that buffer is un-acked, so it counts against the consumer's delivery budget. A lane sized at the budget **cannot fill before the server stops delivering** — the send is non-blocking in every reachable state. Backpressure still exists; it lands on `iter.Next()`, where having nothing to hand the concurrent lane is the truth rather than an artifact.

Kept as a plain send rather than a `select` with `default`: **dropping or NAKing on a full lane would reorder add/remove for the same `(room, account)`**, which is the one thing the sequential lane exists to prevent. These events carry no high-water mark, so a reorder resurrects a removed membership.

`membershipLaneFloor` (1024) covers `MaxAckPending` being unlimited (`-1`/`0`) or small enough that a buffer sized from it would fill on a trivial burst. It is a memory bound, not a throughput one.

## Why there is a refactor in a bug fix

The pump was inline in `main()`, which is why no test covered it. `dispatchLanes` is the same loop, extracted so the behaviour can be asserted — no logic change beyond the channel sizing.

## Tests

`TestDispatchLanes_MembershipBacklogDoesNotStallConcurrentLane` is the regression guard: it queues a full budget of membership messages with **nobody draining them**, then asserts a following concurrent message is still processed.

Verified it has teeth — with the old `MAX_WORKERS` sizing it fails exactly as the bug predicts:

```
--- FAIL: TestDispatchLanes_MembershipBacklogDoesNotStallConcurrentLane (2.00s)
    lanes_test.go:124: pump stalled: the concurrent lane was starved by an undrained membership backlog
```

Also `TestMembershipLaneCap` (table-driven, asserts the `cap >= maxAckPending` invariant the fix rests on) and `TestDispatchLanes_RoutesBySubject` (pins the split itself).

## Verification

- `go test ./inbox-worker/ -race` — pass
- `make lint` — `0 issues`
- No store interface changed, so no `make generate` needed
- No client-facing handler or `pkg/model` wire struct touched, so no `docs/client-api.md` change
- **Rebased onto `main` at `3ec5822`** — replayed with no conflicts. `go build ./...`, `go vet ./...` and the full `go test ./... -race` pass on the result.

## Scope

Deliberately not in this PR, though the audit flagged them on the same consumer:
- `inbox-worker` keeps `MaxDeliver=6` while OUTBOX runs `MaxDeliver=-1` — federation is durable at the origin and lossy at the destination.
- `room_renamed` is not on the sequential lane, so it can overtake the `member_added` that creates the subscription it renames.

Both are separate changes with their own risk; this PR is the stall alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxZYPse6BHHNiL53bcP6py)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inbox message processing so membership events continue through their sequential lane without blocking unrelated messages.
  * Updated message routing to better respect the configured JetStream delivery capacity.
  * Preserved bounded concurrent processing for non-membership events while ensuring the sequential lane completes cleanly when message delivery ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
