### PR TITLE
fix(broadcast-worker): stop retrying a shedding downstream at 200ms

### DIFF
--- a/broadcast-worker/backoff.go
+++ b/broadcast-worker/backoff.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"errors"
+	"time"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/jsretry"
+)
+
+// settleBackoff picks the retry schedule a failed message calls for.
+//
+// broadcast-worker normally settles on LowLatencyBackoff, whose 200ms first
+// rung is the point: a sub-second blip must not be visible to a client waiting
+// on fan-out. That is the wrong curve for one case — a downstream that is
+// *shedding*.
+//
+// The thread-parent path issues a synchronous request to history-service, which
+// replies Unavailable ("service busy") once its admission cap is saturated.
+// Retrying that in 200ms aims more load at the service that is already failing,
+// so offered load rises as capacity falls. BackpressureBackoff exists for
+// exactly this — its doc notes "a one-second retry only feeds the overload that
+// caused the rejection" — and search-sync-worker already routes ES 429s to it.
+//
+// The delivery budget stays correct across both: MaxDeliver is derived once
+// from LowLatencyBackoff (the faster schedule, so the larger count), and both
+// schedules share a 10m repeating tail, so a message settling on the slower
+// curve still has enough deliveries to cover the outage window. A future change
+// that breaks that shared tail must re-derive the budget from the slower
+// schedule — TestSettleBackoff_TailMatchesDeliveryBudget guards it.
+func settleBackoff(err error) []time.Duration {
+	if isDownstreamShedding(err) {
+		return jsretry.BackpressureBackoff
+	}
+	return jsretry.LowLatencyBackoff
+}
+
+// isDownstreamShedding reports whether err is a dependency telling us it is over
+// capacity, as opposed to failing. historyParentFetcher propagates the typed
+// remote error precisely so it can be classified here, and natsutil.RequestFailure
+// maps a request timeout or a missing responder onto Unavailable too.
+func isDownstreamShedding(err error) bool {
+	var ee *errcode.Error
+	if !errors.As(err, &ee) {
+		return false
+	}
+	return ee.Code == errcode.CodeUnavailable || ee.Code == errcode.CodeTooManyRequests
+}

--- a/broadcast-worker/backoff_test.go
+++ b/broadcast-worker/backoff_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/jsretry"
+)
+
+func TestSettleBackoff(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want []time.Duration
+	}{
+		{
+			name: "a shedding downstream gets the slow curve",
+			err:  errcode.Unavailable("service busy"),
+			want: jsretry.BackpressureBackoff,
+		},
+		{
+			name: "an explicitly rate-limited downstream gets the slow curve",
+			err:  errcode.TooManyRequests("slow down"),
+			want: jsretry.BackpressureBackoff,
+		},
+		{
+			name: "the shedding signal survives wrapping",
+			err:  fmt.Errorf("fetch thread parent abc: %w", errcode.Unavailable("service busy")),
+			want: jsretry.BackpressureBackoff,
+		},
+		{
+			name: "an ordinary infra failure keeps the fan-out curve",
+			err:  errors.New("mongo: connection reset"),
+			want: jsretry.LowLatencyBackoff,
+		},
+		{
+			name: "an internal error is not backpressure",
+			err:  errcode.Internal("boom"),
+			want: jsretry.LowLatencyBackoff,
+		},
+		{
+			name: "a not-found is not backpressure",
+			err:  errcode.NotFound("no such message"),
+			want: jsretry.LowLatencyBackoff,
+		},
+		{
+			name: "success keeps the default curve",
+			err:  nil,
+			want: jsretry.LowLatencyBackoff,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, settleBackoff(tt.err))
+		})
+	}
+}
+
+// TestSettleBackoff_SheddingDoesNotRetryFast is the regression guard for the
+// amplification loop: history-service sheds with Unavailable, and retrying that
+// at LowLatencyBackoff's 200ms first rung aims more load at the service that is
+// already failing. Offered load must not rise as capacity falls.
+func TestSettleBackoff_SheddingDoesNotRetryFast(t *testing.T) {
+	shedding := settleBackoff(errcode.Unavailable("service busy"))
+	require.NotEmpty(t, shedding)
+	assert.GreaterOrEqual(t, shedding[0], 30*time.Second,
+		"a downstream that just shed load must not be retried in under 30s")
+
+	// The fan-out path keeps its near-immediate first retry for ordinary blips,
+	// which is the whole reason broadcast-worker uses LowLatencyBackoff.
+	ordinary := settleBackoff(errors.New("transient"))
+	require.NotEmpty(t, ordinary)
+	assert.Less(t, ordinary[0], time.Second,
+		"an ordinary transient failure must still retry fast")
+}
+
+// TestSettleBackoff_TailMatchesDeliveryBudget pins the coupling that
+// WithOutageRetryBudget depends on. MaxDeliver is derived once, from
+// LowLatencyBackoff, and must remain large enough to cover the outage window for
+// whichever schedule a message actually settles with. Both schedules share the
+// same repeating tail, so the derived count stays valid; if that ever stops
+// being true the budget must be re-derived from the slower schedule.
+func TestSettleBackoff_TailMatchesDeliveryBudget(t *testing.T) {
+	low := jsretry.LowLatencyBackoff
+	back := jsretry.BackpressureBackoff
+	require.NotEmpty(t, low)
+	require.NotEmpty(t, back)
+	assert.Equal(t, low[len(low)-1], back[len(back)-1],
+		"schedules must share a repeating tail or MaxDeliver stops covering the outage window")
+}

--- a/broadcast-worker/main.go
+++ b/broadcast-worker/main.go
@@ -536,7 +536,11 @@ func broadcastProcessor(handler *Handler) messageProcessor {
 				"phase", "received", "request_id", natsutil.RequestIDFromContext(handlerCtx),
 				"subject", msg.Subject(), "bytes", len(msg.Data()), "stream_wait_ms", streamWaitMs)
 		}
-		jsretry.Settle(handlerCtx, msg, jsretry.LowLatencyBackoff, handler.HandleMessage(handlerCtx, msg.Data()))
+		// The schedule is chosen from the error, not fixed: a downstream that is
+		// shedding must not be retried at LowLatencyBackoff's 200ms first rung.
+		// See settleBackoff.
+		err := handler.HandleMessage(handlerCtx, msg.Data())
+		jsretry.Settle(handlerCtx, msg, settleBackoff(err), err)
 	}
 }
 


### PR DESCRIPTION
## The bug

`broadcast-worker` settles every failure on `LowLatencyBackoff`:

```go
// broadcast-worker/main.go:539 (before)
jsretry.Settle(handlerCtx, msg, jsretry.LowLatencyBackoff, handler.HandleMessage(handlerCtx, msg.Data()))
```

The 200ms first rung is deliberate and correct for fan-out — a sub-second blip must not be visible to a client waiting on delivery. It is the wrong curve for one case: **a downstream that is shedding rather than failing.**

The thread-parent path issues a synchronous request to `history-service`, which replies `Unavailable` ("service busy") once its admission cap saturates. Retrying that in 200ms aims more load at the service that is already failing. And `MaxDeliver` is sized by `WithOutageRetryBudget` to cover a one-hour window — against `LowLatencyBackoff`'s jittered minimums that is **~18 deliveries, the first five inside 78 seconds.**

So one degraded `history-service` turns every thread reply into up to 18 requests against it. **Offered load rises as capacity falls**, and the brownout does not self-limit.

### Why it compounds

There is a two-hop correlated path. When `message-gatekeeper` soft-fails parent resolution it publishes the canonical event *without* `ThreadParentMessageCreatedAt`/`ThreadParentSenderAccount` — which is precisely the condition that makes this fetch fire. So a `history-service` failure produces *more* `history-service` requests, from a second service.

The existing escape hatch does not catch it: `parentResolveExhausted` is gated on `errcode.Terminal(err)`, and `Terminal` returns `false` for `CodeUnavailable`. The Ack-drop added for exactly this ack-pending reason never fires on a shedding downstream.

## The fix

Pick the schedule from the error, mirroring `search-sync-worker.itemBackoff` for ES 429s:

```go
err := handler.HandleMessage(handlerCtx, msg.Data())
jsretry.Settle(handlerCtx, msg, settleBackoff(err), err)
```

`jsretry.BackpressureBackoff` already exists for this and its own doc says why:

> a backend that just rejected the write needs time to drain, and a one-second retry only feeds the overload that caused the rejection

Ordinary transient failures keep the 200ms rung, so the fan-out latency property that motivated `LowLatencyBackoff` is unchanged.

## The delivery budget stays correct

Worth stating because `pkg/stream/consumer.go` documents a past incident of exactly this shape — a budget sized against one schedule applied to a consumer settling with another, giving ~4 minutes instead of the intended hour.

`MaxDeliver` is derived once from `LowLatencyBackoff` — the *faster* schedule, so the *larger* count — and both schedules share a 10m repeating tail. A message settling on the slower curve therefore still has enough deliveries to cover the outage window; it simply uses fewer of them per unit time.

`TestSettleBackoff_TailMatchesDeliveryBudget` pins that coupling, so a future change to either tail fails loudly rather than silently shortening the real retry window.

## Tests

- `TestSettleBackoff` — table-driven over shedding / rate-limited / wrapped / ordinary / internal / not-found / nil.
- `TestSettleBackoff_SheddingDoesNotRetryFast` — the regression guard: asserts a shed error's first rung is ≥30s **and** that an ordinary failure still retries in under a second, so a future "simplification" to one schedule fails either way.
- `TestSettleBackoff_TailMatchesDeliveryBudget` — the budget coupling above.

## Verification

- `go test ./broadcast-worker/ -race` — pass
- `make lint` — `0 issues`
- No store interface, client-facing handler, or `pkg/model` wire struct touched

## Deliberately not in this PR

The audit found the other half of this interaction: **`history-service` defaults to `REQUEST_TIMEOUT=10s` while all three of its hot-path callers request with a hardcoded 2s** (`broadcast-worker/parent_fetcher.go:19`, `message-gatekeeper/fetcher_history.go:19`, `room-service/reader_history.go:18`). NATS request/reply carries no cancellation, so the responder keeps an admission slot and a DB connection for 8 seconds past the caller's departure — effective capacity `256/2s → 256/10s ≈ 25 req/s`.

Fixing that properly means propagating the caller's deadline over the request so the responder can bound itself to `min(configured, caller)`. That touches `pkg/natsrouter`, `pkg/natsutil` and every RPC in the fleet — a design change that deserves its own review, not a rider on a hot-path bug fix. Lowering `history-service`'s guard to 2s instead would truncate `user-service`, which legitimately calls it with a 5s budget.

**This PR breaks the amplification loop, which is the half that turns a brownout into an outage.** The wasted-capacity half remains and is worth doing next.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxZYPse6BHHNiL53bcP6py)_