### PR TITLE
fix(federation): key the inbox dedup ID by event type

### DIFF
--- a/broadcast-worker/handler.go
+++ b/broadcast-worker/handler.go
@@ -482,7 +482,7 @@ func (h *Handler) federateMentions(ctx context.Context, roomID, msgID string, pa
 		// at separates an edit from the send; an edit is its own canonical event
 		// carrying its own request ID, so two same-ms edits can't collide.
 		seed := fmt.Sprintf("%s:%s:%d", roomID, msgID, at.UnixMilli())
-		dedupID := natsutil.InboxDedupID(ctx, destSiteID, seed)
+		dedupID := natsutil.InboxDedupID(ctx, destSiteID, model.InboxSubscriptionMention, seed)
 		select {
 		case sem <- struct{}{}:
 		case <-fanoutCtx.Done():

--- a/broadcast-worker/handler_test.go
+++ b/broadcast-worker/handler_test.go
@@ -3770,14 +3770,14 @@ func TestHandler_HandleCreated_FederatesMentions(t *testing.T) {
 			wantRecords: []outboxRecord{
 				{
 					subject: "chat.outbox.site-a.site-b.subscription_mention",
-					msgID:   testMentionRequestID + ":site-b",
+					msgID:   testMentionRequestID + ":" + model.InboxSubscriptionMention + ":site-b",
 					event: model.SubscriptionMentionEvent{
 						RoomID: "room-1", Accounts: []string{"bob"}, MentionedAt: msgTime.UnixMilli(),
 					},
 				},
 				{
 					subject: "chat.outbox.site-a.site-c.subscription_mention",
-					msgID:   testMentionRequestID + ":site-c",
+					msgID:   testMentionRequestID + ":" + model.InboxSubscriptionMention + ":site-c",
 					event: model.SubscriptionMentionEvent{
 						RoomID: "room-1", Accounts: []string{"carol"}, MentionedAt: msgTime.UnixMilli(),
 					},
@@ -3919,7 +3919,7 @@ func TestHandler_HandleUpdated_FederatesMentions(t *testing.T) {
 			require.Len(t, got, 1)
 			assert.Equal(t, "chat.outbox.site-a.site-b.subscription_mention", got[0].subject)
 			// An edit is its own canonical event, so it carries its own request ID.
-			assert.Equal(t, testMentionRequestID+":site-b", got[0].msgID)
+			assert.Equal(t, testMentionRequestID+":"+model.InboxSubscriptionMention+":site-b", got[0].msgID)
 			assert.Equal(t, tc.wantAccounts, got[0].event.Accounts)
 			assert.Equal(t, editedAt.UnixMilli(), got[0].event.MentionedAt)
 		})

--- a/broadcast-worker/integration_test.go
+++ b/broadcast-worker/integration_test.go
@@ -638,7 +638,7 @@ func TestBroadcastWorker_MentionFederation_Integration(t *testing.T) {
 
 	relay, envelope, payload := unwrapOutbox(t, got[0].Data)
 	assert.Equal(t, "r-fed", relay.RoomID)
-	assert.Equal(t, testMentionRequestID+":site-b", relay.DedupID)
+	assert.Equal(t, testMentionRequestID+":"+model.InboxSubscriptionMention+":site-b", relay.DedupID)
 	assert.Equal(t, model.InboxSubscriptionMention, envelope.Type)
 	assert.Equal(t, "site-a", envelope.SiteID)
 	assert.Equal(t, "site-b", envelope.DestSiteID)

--- a/pkg/natsutil/request_id.go
+++ b/pkg/natsutil/request_id.go
@@ -143,14 +143,26 @@ func RequireRequestID(ctx context.Context, headers nats.Header, subject string) 
 	return WithRequestID(ctx, inbound), inbound, nil
 }
 
-// InboxDedupID composes a JetStream Nats-Msg-Id as base+":"+destSiteID. base
-// is the X-Request-ID from ctx; falls back to payloadSeed when ctx carries no
-// request ID, with a warn log so partial-deployment cases are observable.
-func InboxDedupID(ctx context.Context, destSiteID, payloadSeed string) string {
+// InboxDedupID composes a JetStream Nats-Msg-Id as
+// base+":"+eventType+":"+destSiteID. base is the X-Request-ID from ctx; falls
+// back to payloadSeed when ctx carries no request ID, with a warn log so
+// partial-deployment cases are observable.
+//
+// eventType is part of the key because one handler pass routinely publishes
+// several event types to the same peer under the same request ID — room-worker's
+// Teams membership sync emits a joinedAt refresh, then member_added, then
+// member_removed, same ctx, same destination. Without it all three carried an
+// identical Nats-Msg-Id and JetStream's stream-level dedup silently dropped
+// every publish after the first, so departed members were never removed at
+// their home site. It is a parameter rather than something the caller folds
+// into payloadSeed so a new federated publish cannot forget it: the seed is
+// only consulted on the no-request-ID fallback path.
+func InboxDedupID(ctx context.Context, destSiteID, eventType, payloadSeed string) string {
 	base := RequestIDFromContext(ctx)
 	if base == "" {
-		slog.Warn("missing X-Request-ID; falling back to payload-derived inbox dedup base", "destSiteID", destSiteID)
+		slog.Warn("missing X-Request-ID; falling back to payload-derived inbox dedup base",
+			"destSiteID", destSiteID, "eventType", eventType)
 		base = payloadSeed
 	}
-	return base + ":" + destSiteID
+	return base + ":" + eventType + ":" + destSiteID
 }

--- a/pkg/natsutil/request_id_test.go
+++ b/pkg/natsutil/request_id_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/natsutil"
 )
 
@@ -173,4 +174,52 @@ func TestNewMsgEncoded_KeepsRequestIDHeader(t *testing.T) {
 func TestNewMsgEncoded_EmptyEncodingMatchesNewMsg(t *testing.T) {
 	msg := natsutil.NewMsgEncoded(context.Background(), "chat.foo", []byte("p"), "")
 	assert.Nil(t, msg.Header)
+}
+
+// TestInboxDedupID_DistinguishesEventTypes is the regression guard for a silent
+// federation data-loss bug: one handler pass publishing several event types to
+// the same peer under the same request ID produced one identical Nats-Msg-Id
+// for all of them, so JetStream's stream-level dedup dropped every publish after
+// the first.
+//
+// room-worker's Teams membership sync does exactly that — joinedAt refresh, then
+// member_added, then member_removed, same ctx, same destination — so departed
+// members were never removed at their home site.
+func TestInboxDedupID_DistinguishesEventTypes(t *testing.T) {
+	ctx := natsutil.WithRequestID(context.Background(), "01970a4f-8c2d-7c9a-abcd-e0123456789f")
+
+	refreshed := natsutil.InboxDedupID(ctx, "site-b", model.InboxMemberJoinedAtRefreshed, "seed")
+	added := natsutil.InboxDedupID(ctx, "site-b", model.InboxMemberAdded, "seed")
+	removed := natsutil.InboxDedupID(ctx, "site-b", model.InboxMemberRemoved, "seed")
+
+	assert.NotEqual(t, added, removed,
+		"member_added and member_removed to one peer in one pass must not collide")
+	assert.NotEqual(t, added, refreshed)
+	assert.NotEqual(t, removed, refreshed)
+}
+
+// TestInboxDedupID_StableForRedelivery pins the property the dedup ID exists
+// for: the same logical publish, retried, must produce the same ID so the
+// destination stores it once.
+func TestInboxDedupID_StableForRedelivery(t *testing.T) {
+	ctx := natsutil.WithRequestID(context.Background(), "01970a4f-8c2d-7c9a-abcd-e0123456789f")
+
+	first := natsutil.InboxDedupID(ctx, "site-b", model.InboxMemberAdded, "seed")
+	second := natsutil.InboxDedupID(ctx, "site-b", model.InboxMemberAdded, "seed")
+	assert.Equal(t, first, second, "a redelivery of the same event must dedup")
+
+	other := natsutil.InboxDedupID(ctx, "site-c", model.InboxMemberAdded, "seed")
+	assert.NotEqual(t, first, other, "different destinations must not dedup against each other")
+}
+
+// TestInboxDedupID_FallsBackToPayloadSeed keeps the partial-deployment path
+// distinguishable too: with no request ID on ctx the seed carries the identity,
+// and the event type must still separate the lanes.
+func TestInboxDedupID_FallsBackToPayloadSeed(t *testing.T) {
+	ctx := context.Background()
+
+	added := natsutil.InboxDedupID(ctx, "site-b", model.InboxMemberAdded, "seed-1")
+	removed := natsutil.InboxDedupID(ctx, "site-b", model.InboxMemberRemoved, "seed-1")
+	assert.NotEqual(t, added, removed)
+	assert.Contains(t, added, "seed-1", "the payload seed must still carry the identity")
 }

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -880,7 +880,7 @@ func (h *Handler) publishSubscriptionUpdate(ctx context.Context, account, action
 // client retry can't double-enqueue the same (destination, event) into the
 // outbox.
 func (h *Handler) federateOne(ctx context.Context, roomID, destSiteID string, eventType model.InboxEventType, payload []byte, dedupSeed string, ts int64) error {
-	dedupID := natsutil.InboxDedupID(ctx, destSiteID, dedupSeed)
+	dedupID := natsutil.InboxDedupID(ctx, destSiteID, eventType, dedupSeed)
 	return outbox.Publish(ctx, h.publishToStream, h.siteID, roomID, destSiteID, eventType, payload, dedupID, ts)
 }
 

--- a/room-worker/handler.go
+++ b/room-worker/handler.go
@@ -505,7 +505,7 @@ func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.Remove
 	}
 	internalData, _ := json.Marshal(internalEvt)
 	inboxSeed := fmt.Sprintf("%s:%s:%d", req.RoomID, req.Account, req.Timestamp)
-	if err := h.publish(ctx, subject.InboxInternal(h.siteID, model.InboxMemberRemoved), internalData, natsutil.InboxDedupID(ctx, h.siteID, inboxSeed)); err != nil {
+	if err := h.publish(ctx, subject.InboxInternal(h.siteID, model.InboxMemberRemoved), internalData, natsutil.InboxDedupID(ctx, h.siteID, model.InboxMemberRemoved, inboxSeed)); err != nil {
 		slog.ErrorContext(ctx, "local inbox member_removed publish failed", "error", err, "room_id", req.RoomID)
 	}
 
@@ -566,7 +566,7 @@ func (h *Handler) processRemoveIndividual(ctx context.Context, req *model.Remove
 	// matching the add/create/DM paths.
 	if user.SiteID != "" && user.SiteID != h.siteID {
 		payloadSeed := fmt.Sprintf("%s:%s:%d", req.RoomID, req.Account, req.Timestamp)
-		dedupID := natsutil.InboxDedupID(ctx, user.SiteID, payloadSeed)
+		dedupID := natsutil.InboxDedupID(ctx, user.SiteID, model.InboxMemberRemoved, payloadSeed)
 		if err := h.federate(ctx, req.RoomID, user.SiteID, model.InboxMemberRemoved, memberEvtData, dedupID, now.UnixMilli()); err != nil {
 			return err
 		}
@@ -718,7 +718,7 @@ func (h *Handler) processRemoveOrg(ctx context.Context, req *model.RemoveMemberR
 		}
 		internalData, _ := json.Marshal(internalEvt)
 		inboxSeed := fmt.Sprintf("%s:%s:%d", req.RoomID, req.OrgID, req.Timestamp)
-		if err := h.publish(ctx, subject.InboxInternal(h.siteID, model.InboxMemberRemoved), internalData, natsutil.InboxDedupID(ctx, h.siteID, inboxSeed)); err != nil {
+		if err := h.publish(ctx, subject.InboxInternal(h.siteID, model.InboxMemberRemoved), internalData, natsutil.InboxDedupID(ctx, h.siteID, model.InboxMemberRemoved, inboxSeed)); err != nil {
 			slog.ErrorContext(ctx, "local inbox member_removed publish failed", "error", err, "room_id", req.RoomID)
 		}
 	}
@@ -779,7 +779,7 @@ func (h *Handler) processRemoveOrg(ctx context.Context, req *model.RemoveMemberR
 			Timestamp: now.UnixMilli(),
 		}
 		payloadSeed := fmt.Sprintf("%s:%s:%d", req.RoomID, req.OrgID, req.Timestamp)
-		dedupID := natsutil.InboxDedupID(ctx, destSiteID, payloadSeed)
+		dedupID := natsutil.InboxDedupID(ctx, destSiteID, model.InboxMemberRemoved, payloadSeed)
 		if err := h.federate(ctx, req.RoomID, destSiteID, model.InboxMemberRemoved, mustMarshal(evt), dedupID, now.UnixMilli()); err != nil {
 			return err
 		}
@@ -1235,7 +1235,7 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 			}
 			internalData, _ := json.Marshal(internalEvt)
 			inboxSeed := fmt.Sprintf("%s:%s:%d", req.RoomID, req.RequesterAccount, req.Timestamp)
-			if err := h.publish(ctx, subject.InboxInternal(room.SiteID, model.InboxMemberAdded), internalData, natsutil.InboxDedupID(ctx, room.SiteID, inboxSeed)); err != nil {
+			if err := h.publish(ctx, subject.InboxInternal(room.SiteID, model.InboxMemberAdded), internalData, natsutil.InboxDedupID(ctx, room.SiteID, model.InboxMemberAdded, inboxSeed)); err != nil {
 				slog.ErrorContext(ctx, "local inbox member_added publish failed",
 					"error", err,
 					"room_id", req.RoomID,
@@ -1321,7 +1321,7 @@ func (h *Handler) processAddMembers(ctx context.Context, data []byte) (err error
 		}
 		siteEvtData, _ := json.Marshal(siteEvt)
 		payloadSeed := fmt.Sprintf("%s:%s:%d", req.RoomID, req.RequesterAccount, req.Timestamp)
-		dedupID := natsutil.InboxDedupID(ctx, destSiteID, payloadSeed)
+		dedupID := natsutil.InboxDedupID(ctx, destSiteID, model.InboxMemberAdded, payloadSeed)
 		if err := h.federate(ctx, req.RoomID, destSiteID, model.InboxMemberAdded, siteEvtData, dedupID, now.UnixMilli()); err != nil {
 			return err
 		}
@@ -1901,7 +1901,7 @@ func (h *Handler) finishCreateRoom(ctx context.Context, req *model.CreateRoomReq
 	}
 	internalData, _ := json.Marshal(internalEvt)
 	payloadSeed := fmt.Sprintf("%s:%s:%d", room.ID, requester.Account, req.Timestamp)
-	if err := h.publish(ctx, subject.InboxInternal(room.SiteID, model.InboxMemberAdded), internalData, natsutil.InboxDedupID(ctx, room.SiteID, payloadSeed)); err != nil {
+	if err := h.publish(ctx, subject.InboxInternal(room.SiteID, model.InboxMemberAdded), internalData, natsutil.InboxDedupID(ctx, room.SiteID, model.InboxMemberAdded, payloadSeed)); err != nil {
 		slog.ErrorContext(ctx, "local inbox member_added publish failed", "error", err, "room_id", room.ID, "request_id", requestID)
 	}
 
@@ -1923,7 +1923,7 @@ func (h *Handler) finishCreateRoom(ctx context.Context, req *model.CreateRoomReq
 		}
 		memberData, _ := json.Marshal(memberEvt)
 		memberSeed := fmt.Sprintf("%s:%s:%d", room.ID, requester.Account, req.Timestamp)
-		if err := h.federate(ctx, room.ID, destSiteID, model.InboxMemberAdded, memberData, natsutil.InboxDedupID(ctx, destSiteID, memberSeed), now.UnixMilli()); err != nil {
+		if err := h.federate(ctx, room.ID, destSiteID, model.InboxMemberAdded, memberData, natsutil.InboxDedupID(ctx, destSiteID, model.InboxMemberAdded, memberSeed), now.UnixMilli()); err != nil {
 			return err
 		}
 	}
@@ -2420,7 +2420,7 @@ func (h *Handler) processRoomRename(ctx context.Context, data []byte) (err error
 	// would revert newer canonical state. The spotlight re-index is a derived
 	// cache; a rare missed publish self-corrects on the next rename/membership
 	// event and is far cheaper than risking source-of-truth reversion.
-	if err := h.publish(ctx, subject.InboxInternal(h.siteID, model.InboxRoomRenamed), internalRenameData, natsutil.InboxDedupID(ctx, h.siteID, requestID)); err != nil {
+	if err := h.publish(ctx, subject.InboxInternal(h.siteID, model.InboxRoomRenamed), internalRenameData, natsutil.InboxDedupID(ctx, h.siteID, model.InboxRoomRenamed, requestID)); err != nil {
 		slog.ErrorContext(ctx, "local inbox room_renamed publish failed (best-effort)", "error", err, "room_id", req.RoomID)
 	}
 	// Relay room_renamed through the OUTBOX ordered lane (not a direct INBOX
@@ -2433,7 +2433,7 @@ func (h *Handler) processRoomRename(ctx context.Context, data []byte) (err error
 	// awaits producer per-room lanes / reconciliation (design doc §5, §7).
 	for _, remoteSiteID := range remoteSites {
 		if err := h.federate(ctx, req.RoomID, remoteSiteID, model.InboxRoomRenamed,
-			renamedPayload, natsutil.InboxDedupID(ctx, remoteSiteID, requestID), now); err != nil {
+			renamedPayload, natsutil.InboxDedupID(ctx, remoteSiteID, model.InboxRoomRenamed, requestID), now); err != nil {
 			return err
 		}
 	}

--- a/room-worker/handler_test.go
+++ b/room-worker/handler_test.go
@@ -4865,8 +4865,8 @@ func TestProcessCreateRoom_DM_PublishesLocalInbox(t *testing.T) {
 	assert.Equal(t, "site-A", inner.SiteID)
 	assert.Nil(t, inner.HistorySharedSince, "HistorySharedSince must be nil at create-time")
 
-	wantMsgID := natsutil.InboxDedupID(ctx, "site-A", "room-dm-inbox:alice:"+strconv.FormatInt(ts, 10))
-	assert.Equal(t, wantMsgID, got.msgID, "Nats-Msg-Id must be natsutil.InboxDedupID(ctx, originSite, payloadSeed)")
+	wantMsgID := natsutil.InboxDedupID(ctx, "site-A", model.InboxMemberAdded, "room-dm-inbox:alice:"+strconv.FormatInt(ts, 10))
+	assert.Equal(t, wantMsgID, got.msgID, "Nats-Msg-Id must be natsutil.InboxDedupID(ctx, originSite, eventType, payloadSeed)")
 }
 
 func TestProcessCreateRoom_Channel_PublishesLocalInbox(t *testing.T) {
@@ -4918,7 +4918,7 @@ func TestProcessCreateRoom_Channel_PublishesLocalInbox(t *testing.T) {
 	assert.Equal(t, "site-A", inner.SiteID)
 	assert.Nil(t, inner.HistorySharedSince, "create-time event must be unrestricted regardless of req.History")
 
-	wantMsgID := natsutil.InboxDedupID(ctx, "site-A", "room-ch-inbox:alice:"+strconv.FormatInt(ts, 10))
+	wantMsgID := natsutil.InboxDedupID(ctx, "site-A", model.InboxMemberAdded, "room-ch-inbox:alice:"+strconv.FormatInt(ts, 10))
 	assert.Equal(t, wantMsgID, got.msgID)
 }
 

--- a/room-worker/integration_test.go
+++ b/room-worker/integration_test.go
@@ -1207,7 +1207,7 @@ func TestProcessAddMembers_PublishesLocalInbox_Integration(t *testing.T) {
 	assert.ElementsMatch(t, []string{"charlie", "bob"}, inner.Accounts,
 		"local INBOX must carry full add set — same-site (charlie) + remote (bob)")
 	assert.Equal(t, reqID+":site-A", pubs[0].msgID,
-		"Nats-Msg-Id must be natsutil.InboxDedupID(ctx, originSite, payloadSeed) so JetStream dedups self-loop replays")
+		"Nats-Msg-Id must be natsutil.InboxDedupID(ctx, originSite, eventType, payloadSeed) so JetStream dedups self-loop replays")
 
 	// members_added sys-message: requester is the sender, Content is server-rendered.
 	sysPubs := cap.publishesOnPrefix(subject.MsgCanonicalCreated("site-A"))

--- a/room-worker/integration_test.go
+++ b/room-worker/integration_test.go
@@ -954,7 +954,7 @@ func TestProcessCreateRoomChannel_InboxPerRemoteSite(t *testing.T) {
 	assert.Equal(t, "site-A", memberPayloadB.SiteID)
 	assert.Equal(t, "alice", memberPayloadB.RequesterAccount)
 	assert.Nil(t, memberPayloadB.HistorySharedSince)
-	assert.Equal(t, reqID+":site-B", memberB[0].msgID)
+	assert.Equal(t, reqID+":"+model.InboxMemberAdded+":site-B", memberB[0].msgID)
 
 	_, memberEnvC := unwrapOutbox(t, memberC[0].data)
 	var memberPayloadC model.MemberAddEvent
@@ -965,7 +965,7 @@ func TestProcessCreateRoomChannel_InboxPerRemoteSite(t *testing.T) {
 	assert.Equal(t, "site-A", memberPayloadC.SiteID)
 	assert.Equal(t, "alice", memberPayloadC.RequesterAccount)
 	assert.Nil(t, memberPayloadC.HistorySharedSince)
-	assert.Equal(t, reqID+":site-C", memberC[0].msgID)
+	assert.Equal(t, reqID+":"+model.InboxMemberAdded+":site-C", memberC[0].msgID)
 }
 
 func TestProcessCreateRoomDM_InboxToCounterpartSite(t *testing.T) {
@@ -1022,7 +1022,7 @@ func TestProcessCreateRoomDM_InboxToCounterpartSite(t *testing.T) {
 	assert.ElementsMatch(t, []string{"bob"}, memberPayload.Accounts)
 	assert.Equal(t, "alice", memberPayload.RequesterAccount, "DM counterpart resolution depends on this")
 	assert.Equal(t, "site-A", memberPayload.SiteID)
-	assert.Equal(t, reqID+":site-B", memberB[0].msgID)
+	assert.Equal(t, reqID+":"+model.InboxMemberAdded+":site-B", memberB[0].msgID)
 }
 
 func TestProcessAddMembers_InboxPerRemoteSite(t *testing.T) {
@@ -1104,7 +1104,7 @@ func TestProcessAddMembers_InboxPerRemoteSite(t *testing.T) {
 	assert.ElementsMatch(t, []string{"bob"}, evtB.Accounts)
 	assert.Equal(t, roomName, evtB.RoomName)
 	assert.Equal(t, "site-A", evtB.SiteID)
-	assert.Equal(t, reqID+":site-B", pubsB[0].msgID)
+	assert.Equal(t, reqID+":"+model.InboxMemberAdded+":site-B", pubsB[0].msgID)
 
 	_, envC := unwrapOutbox(t, pubsC[0].data)
 	var evtC model.MemberAddEvent
@@ -1112,7 +1112,7 @@ func TestProcessAddMembers_InboxPerRemoteSite(t *testing.T) {
 	assert.ElementsMatch(t, []string{"ian"}, evtC.Accounts)
 	assert.Equal(t, roomName, evtC.RoomName)
 	assert.Equal(t, "site-A", evtC.SiteID)
-	assert.Equal(t, reqID+":site-C", pubsC[0].msgID)
+	assert.Equal(t, reqID+":"+model.InboxMemberAdded+":site-C", pubsC[0].msgID)
 }
 
 func TestProcessCreateRoomIdempotentRedelivery(t *testing.T) {
@@ -1206,7 +1206,7 @@ func TestProcessAddMembers_PublishesLocalInbox_Integration(t *testing.T) {
 	assert.Equal(t, "site-A", inner.SiteID)
 	assert.ElementsMatch(t, []string{"charlie", "bob"}, inner.Accounts,
 		"local INBOX must carry full add set — same-site (charlie) + remote (bob)")
-	assert.Equal(t, reqID+":site-A", pubs[0].msgID,
+	assert.Equal(t, reqID+":"+model.InboxMemberAdded+":site-A", pubs[0].msgID,
 		"Nats-Msg-Id must be natsutil.InboxDedupID(ctx, originSite, eventType, payloadSeed) so JetStream dedups self-loop replays")
 
 	// members_added sys-message: requester is the sender, Content is server-rendered.
@@ -1440,7 +1440,7 @@ func TestProcessRemoveIndividual_PublishesLocalInbox_Integration(t *testing.T) {
 	assert.Equal(t, "member_removed", inner.Type, "admin-remove: inner type is member_removed")
 	assert.Equal(t, roomID, inner.RoomID)
 	assert.Equal(t, []string{"bob"}, inner.Accounts)
-	assert.Equal(t, reqID+":site-A", pubs[0].msgID)
+	assert.Equal(t, reqID+":"+model.InboxMemberRemoved+":site-A", pubs[0].msgID)
 
 	// member_removed sys-message: requester is the sender, Content is server-rendered.
 	sysPubs := cap.publishesOnPrefix(subject.MsgCanonicalCreated("site-A"))

--- a/room-worker/teamsroomcreate.go
+++ b/room-worker/teamsroomcreate.go
@@ -307,7 +307,7 @@ func (h *Handler) federateTeamsMembership(ctx context.Context, room *model.Room,
 		return errcode.MarshalFailed("internal inbox envelope", err)
 	}
 	seed := fmt.Sprintf("%s:%s:%d", room.ID, eventType, acceptedAt.UnixMilli())
-	if err := h.publish(ctx, subject.InboxInternal(h.siteID, eventType), internalData, natsutil.InboxDedupID(ctx, h.siteID, seed)); err != nil {
+	if err := h.publish(ctx, subject.InboxInternal(h.siteID, eventType), internalData, natsutil.InboxDedupID(ctx, h.siteID, eventType, seed)); err != nil {
 		return fmt.Errorf("local inbox publish: %w", err)
 	}
 
@@ -324,7 +324,7 @@ func (h *Handler) federateTeamsMembership(ctx context.Context, room *model.Room,
 		if err != nil {
 			return errcode.MarshalFailed("federated membership event", err)
 		}
-		dedupID := natsutil.InboxDedupID(ctx, destSite, seed)
+		dedupID := natsutil.InboxDedupID(ctx, destSite, eventType, seed)
 		if err := h.federate(ctx, room.ID, destSite, eventType, siteData, dedupID, acceptedAt.UnixMilli()); err != nil {
 			return fmt.Errorf("federate to %s: %w", destSite, err)
 		}
@@ -370,7 +370,7 @@ func (h *Handler) federateJoinedAtRefresh(ctx context.Context, room *model.Room,
 	if err != nil {
 		return errcode.MarshalFailed("internal joinedAt-refresh envelope", err)
 	}
-	if err := h.publish(ctx, subject.InboxInternal(h.siteID, model.InboxMemberJoinedAtRefreshed), internalData, natsutil.InboxDedupID(ctx, h.siteID, seed)); err != nil {
+	if err := h.publish(ctx, subject.InboxInternal(h.siteID, model.InboxMemberJoinedAtRefreshed), internalData, natsutil.InboxDedupID(ctx, h.siteID, model.InboxMemberJoinedAtRefreshed, seed)); err != nil {
 		return fmt.Errorf("local inbox joinedAt-refresh publish: %w", err)
 	}
 
@@ -388,7 +388,7 @@ func (h *Handler) federateJoinedAtRefresh(ctx context.Context, room *model.Room,
 		if err != nil {
 			return errcode.MarshalFailed("federated joinedAt-refresh event", err)
 		}
-		dedupID := natsutil.InboxDedupID(ctx, destSite, seed)
+		dedupID := natsutil.InboxDedupID(ctx, destSite, model.InboxMemberJoinedAtRefreshed, seed)
 		if err := h.federate(ctx, room.ID, destSite, model.InboxMemberJoinedAtRefreshed, payload, dedupID, acceptedAt.UnixMilli()); err != nil {
 			return fmt.Errorf("federate joinedAt refresh to %s: %w", destSite, err)
 		}


### PR DESCRIPTION
## The bug

`InboxDedupID` composed the JetStream `Nats-Msg-Id` with no event type in it:

```go
// pkg/natsutil/request_id.go:149 (before)
func InboxDedupID(ctx context.Context, destSiteID, payloadSeed string) string {
    base := RequestIDFromContext(ctx)
    if base == "" { base = payloadSeed }   // fallback only
    return base + ":" + destSiteID
}
```

One handler pass routinely publishes **several event types to the same peer under one request ID**, so all of them carry an identical `Nats-Msg-Id` and JetStream's stream-level dedup drops every publish after the first.

`room-worker`'s Teams membership sync is the reachable case — three publishes, same `ctx`, same destination:

```go
h.federateJoinedAtRefresh(ctx, room, joinedAtFixes, memberSite, acceptedAt)
h.federateTeamsMembership(ctx, room, added,   model.InboxMemberAdded,   memberSite, acceptedAt)
h.federateTeamsMembership(ctx, room, removed, model.InboxMemberRemoved, memberSite, acceptedAt)
```

The 2nd and 3rd were discarded. **Departed Teams members were never removed at their home site.** The three *internal*-lane publishes in the same pass collide identically, so `search-sync` lost two of three as well.

The `payloadSeed` argument that would have disambiguated these is a **fallback used only when ctx carries no request ID**, and `room-worker/main.go:415-425` guarantees one always exists — so it never applied.

## The fix

`base + ":" + eventType + ":" + destSiteID`.

Added as a **parameter** rather than folded into the caller's seed, deliberately: every call site becomes a compile error, so a new federated publish cannot forget it, and `payloadSeed` keeps its narrow fallback role. All 16 call sites now supply the type they are actually publishing — each verified individually against the `subject.InboxExternal`/`InboxInternal`/`federate` call on the same or next line:

| Site | Event type |
|---|---|
| `room-service/handler.go:883` (`federateOne`) | `eventType` (param) |
| `broadcast-worker/handler.go:485` | `InboxSubscriptionMention` |
| `room-worker/handler.go` ×10 | `InboxMemberAdded` / `InboxMemberRemoved` / `InboxRoomRenamed` |
| `room-worker/teamsroomcreate.go` ×4 | `eventType` (param) / `InboxMemberJoinedAtRefreshed` |

## Tests

`TestInboxDedupID_DistinguishesEventTypes` reproduces the exact three-publish shape and asserts the IDs differ. Confirmed RED before the fix — it would not even compile against the old signature, and the assertion it encodes was false by construction.

Two more pin the properties the key must *keep*, so a future change can't fix this by making the ID unique per call:

- `TestInboxDedupID_StableForRedelivery` — the same logical publish, retried, still dedups; different destinations still don't collide.
- `TestInboxDedupID_FallsBackToPayloadSeed` — the no-request-ID path stays distinguishable too.

Existing assertions in `broadcast-worker/handler_test.go` and `room-worker/handler_test.go` encoded the old `{requestID}:{destSiteID}` format and were updated — the format changed by design.

## Deploy note

During rollout, a message published under the old format and republished under the new one inside the duplicate window will not dedup against itself. Every destination handler is `$max`/`$setOnInsert`/`$lt`-guarded, so a duplicate is idempotent — worth knowing rather than discovering.

## Verification

- `go test ./pkg/natsutil/ ./room-worker/ ./room-service/ ./broadcast-worker/ ./pkg/outbox/` — all pass (these are every package the change touches)
- `make lint` — `0 issues`
- `make sast-gosec` — clean
- Not a client-facing contract: this is an internal `Nats-Msg-Id` on the federation lane, so `docs/client-api.md` does not apply

## Deliberately not in this PR

The audit paired this with a second dedup defect: **`Duplicates` is never set on any stream** (zero occurrences in `pkg/stream`), so the window is JetStream's 2-minute default while every retry tail is 10 minutes — a redelivery on the 3rd/4th rung lands outside the window and duplicates at the destination.

Setting it means adding a field to `stream.Config`, and CLAUDE.md is explicit that a bootstrap helper sets **only** `Name + Subjects` — stream policy is an ops/IaC concern. So that half belongs in your IaC, pinned to comfortably exceed the backoff tail (≥15m).

The two defects are opposite failures of the same key: **this PR stops distinct events being silently merged; the window setting stops one event being silently duplicated.** This one causes the data loss.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxZYPse6BHHNiL53bcP6py)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event delivery reliability by distinguishing duplicate-prevention keys for different inbox event types.
  * Prevented unrelated membership, room, mention, and synchronization events from being incorrectly treated as duplicates.
  * Preserved consistent handling of redelivered events while maintaining separate processing across destination sites.
* **Tests**
  * Expanded coverage for event-type-specific deduplication, redelivery stability, and cross-site delivery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->