### PR TITLE
fix(drive): allow-list drive_host before attaching the Drive API token

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -688,6 +688,7 @@ See [Error envelope](#6-error-envelope-reference). HTTP statuses:
 | Status | `code` | `reason` | Example body |
 |---|---|---|---|
 | 400 | `bad_request` | — | `{ "code": "bad_request", "error": "drive_host is required" }` — also `roomId is required`, `fileId is required`. |
+| 400 | `bad_request` | — | `{ "code": "bad_request", "error": "drive_host is not a configured Drive host" }` — `drive_host` must be one of the Drive base URLs this deployment is configured for. Send back the value the upload response gave you; it is not a free-form URL. The rejected value is not echoed. |
 | 401 | `unauthenticated` | `invalid_sso_token` / `sso_token_expired` / `missing_fields` | `{ "code": "unauthenticated", "reason": "invalid_sso_token", "error": "invalid sso token" }` |
 | 403 | `forbidden` | `not_room_member` | `{ "code": "forbidden", "reason": "not_room_member", "error": "user alice is not in room abc123" }` |
 | 500 | `internal` | — | `{ "code": "internal", "error": "internal error" }` — user missing in context. |
@@ -736,6 +737,7 @@ See [Error envelope](#6-error-envelope-reference). HTTP statuses:
 | Status | `code` | `reason` | Example body |
 |---|---|---|---|
 | 400 | `bad_request` | — | `{ "code": "bad_request", "error": "drive_host is required" }` — also `roomId is required`, `fileId is required`. |
+| 400 | `bad_request` | — | `{ "code": "bad_request", "error": "drive_host is not a configured Drive host" }` — `drive_host` must be one of the Drive base URLs this deployment is configured for. Send back the value the upload response gave you; it is not a free-form URL. The rejected value is not echoed. |
 | 401 | `unauthenticated` | `invalid_sso_token` / `sso_token_expired` / `missing_fields` | `{ "code": "unauthenticated", "reason": "invalid_sso_token", "error": "invalid sso token" }` |
 | 403 | `forbidden` | `not_room_member` | `{ "code": "forbidden", "reason": "not_room_member", "error": "user alice is not in room abc123" }` |
 | 500 | `internal` | — | `{ "code": "internal", "error": "internal error" }` — user missing in context. |

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -152,7 +152,7 @@ part's declared `Content-Type` is used only when it is specific. See
 
 Downloads a protected file (image/audio/video/document). `ssoToken` (header, or the
 `ssoToken` cookie from `POST /api/v1/file/setCookie` for browser `<img>` downloads; header
-wins) **or** `x-user-id` + `x-auth-token`; caller must be a room member. `drive_host` query param required.
+wins) **or** `x-user-id` + `x-auth-token`; caller must be a room member. `drive_host` query param required, and must be one of the deployment's configured Drive base URLs (an unrecognised host is a 400, not a 503).
 Called with the `relativePath` (image upload) or `titleLink` (file upload)
 returned by the upload endpoints. See
 [../client-api.md §2.4](../client-api.md#get-apiv1fileroomsroomidfilefileid).
@@ -171,7 +171,7 @@ system version). Identical to `GET /api/v1/file/rooms/:roomId/file/:fileId` but
 proxied from a separate (legacy) Drive backend with its own credentials.
 `ssoToken` (header, or the `ssoToken` cookie from `POST /api/v1/file/setCookie` for
 browser `<img>` downloads; header wins) **or** `x-user-id` + `x-auth-token`; caller must
-be a room member. `drive_host` query param required. See
+be a room member. `drive_host` query param required, and must be one of the deployment's configured Drive base URLs (an unrecognised host is a 400, not a 503). See
 [../client-api.md §2.4](../client-api.md#get-apiv3roomsroomidprotected-imagefileid).
 
 **Emits:** `None — HTTP-only.`

--- a/pkg/drive/allowlist.go
+++ b/pkg/drive/allowlist.go
@@ -1,0 +1,61 @@
+package drive
+
+import (
+	"errors"
+	"strings"
+)
+
+// ErrHostNotAllowed reports a Drive host that is not one of the configured
+// base URLs. Callers that accept a host from a client map it to a 400 rather
+// than surfacing it as an upstream failure — the request is malformed, not the
+// dependency broken.
+var ErrHostNotAllowed = errors.New("drive host is not a configured Drive base URL")
+
+// hostAllowed reports whether host is one of the Drive base URLs this client is
+// configured for: the default URL, plus every non-empty entry of the
+// room-origin base URL map.
+//
+// This exists because a client-supplied host reaches fetchPresignedURL, which
+// attaches the Drive api-token to it — so without an allow-list the caller
+// chooses which server receives the credential. The check lives here, beside
+// the code that attaches the token, rather than in the HTTP handler: any future
+// method that takes a host is then covered by construction.
+//
+// Matching is exact after trimming trailing slashes, deliberately. An allow-list
+// that matched on prefix, suffix or "contains" would admit
+// https://evil.example/?u=https://drive.site-a.example and its many cousins;
+// the only safe comparison against an attacker-chosen string is equality with a
+// value an operator configured. The cost is that a host must be spelled exactly
+// as configured, which is the correct trade for a credential boundary.
+//
+// An empty BaseURLMap — what LoadBaseURLs falls back to on a missing or
+// malformed config file — leaves the default URL allowed and nothing else, so a
+// single-site deployment keeps working and a misconfigured one fails closed.
+func (c *Client) hostAllowed(host string) bool {
+	h := normalizeDriveHost(host)
+	if h == "" {
+		return false
+	}
+	if h == normalizeDriveHost(c.baseURL) {
+		return true
+	}
+	for _, u := range c.baseURLMap {
+		// Skip empty entries: they normalize to "" and would otherwise make the
+		// empty host allowed, which the h == "" guard above already refuses.
+		if u == "" {
+			continue
+		}
+		if h == normalizeDriveHost(u) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeDriveHost trims trailing slashes so a configured
+// "https://drive.example/" and a supplied "https://drive.example" compare equal.
+// It does no other rewriting — anything more would start reinterpreting an
+// attacker-supplied string rather than comparing it.
+func normalizeDriveHost(host string) string {
+	return strings.TrimRight(strings.TrimSpace(host), "/")
+}

--- a/pkg/drive/allowlist_test.go
+++ b/pkg/drive/allowlist_test.go
@@ -1,0 +1,115 @@
+package drive
+
+import (
+	"errors"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"net/http"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetGroupImage_UnlistedHostNeverReceivesTheAPIToken is the regression guard
+// for the credential leak: drive_host arrives verbatim from a client query
+// string and fetchPresignedURL attaches the Drive api-token to whatever host it
+// is handed. The client therefore chose which server received the credential.
+//
+// The assertion that matters is not the returned error — it is that the
+// attacker-controlled server was never contacted at all.
+func TestGetGroupImage_UnlistedHostNeverReceivesTheAPIToken(t *testing.T) {
+	var hits atomic.Int32
+	var sawToken atomic.Bool
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		if r.Header.Get("api-token") != "" {
+			sawToken.Store(true)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer attacker.Close()
+
+	c := NewClient(&Config{
+		URL:        "https://drive.internal.example",
+		Token:      "super-secret-drive-token",
+		BaseURLMap: map[string]string{"site-a": "https://drive.site-a.example"},
+	})
+
+	_, err := c.GetGroupImage(attacker.URL, "room-1", "file-1")
+
+	require.Error(t, err, "an unlisted host must be refused")
+	assert.ErrorIs(t, err, ErrHostNotAllowed)
+	assert.Zero(t, hits.Load(), "the unlisted host must never be contacted")
+	assert.False(t, sawToken.Load(), "the Drive api-token must never leave the process for an unlisted host")
+}
+
+func TestClient_hostAllowed(t *testing.T) {
+	c := NewClient(&Config{
+		URL:   "https://drive.internal.example",
+		Token: "t",
+		BaseURLMap: map[string]string{
+			"site-a": "https://drive.site-a.example",
+			"site-b": "https://drive.site-b.example/base",
+			"site-c": "", // an empty entry must not widen the allow-list
+		},
+	})
+
+	tests := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{"the configured default is allowed", "https://drive.internal.example", true},
+		{"a mapped host is allowed", "https://drive.site-a.example", true},
+		{"a mapped host with a path is allowed", "https://drive.site-b.example/base", true},
+		{"a trailing slash still matches", "https://drive.site-a.example/", true},
+
+		{"an unknown host is refused", "https://evil.example", false},
+		{"an empty host is refused", "", false},
+		{"an empty map entry does not allow the empty host", "", false},
+		{"userinfo prefixing an allowed host is refused", "https://drive.site-a.example@evil.example", false},
+		{"an allowed host in the query string is refused", "https://evil.example/?u=https://drive.site-a.example", false},
+		{"an allowed host as a path suffix is refused", "https://evil.example/https://drive.site-a.example", false},
+		{"a subdomain of an allowed host is refused", "https://drive.site-a.example.evil.example", false},
+		{"a prefix of an allowed host is refused", "https://drive.site-a.exampl", false},
+		{"scheme downgrade is refused", "http://drive.site-a.example", false},
+		{"a bare host without scheme is refused", "drive.site-a.example", false},
+		{"a path traversal off an allowed base is refused", "https://drive.site-b.example/base/../../evil", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, c.hostAllowed(tt.host))
+		})
+	}
+}
+
+// TestClient_hostAllowed_EmptyMapKeepsTheDefault covers the config-load failure
+// mode: LoadBaseURLs falls back to an empty map on a missing or malformed file.
+// The allow-list must still admit the configured default Drive URL, so a
+// single-site deployment keeps working, and must still admit nothing else.
+func TestClient_hostAllowed_EmptyMapKeepsTheDefault(t *testing.T) {
+	c := NewClient(&Config{URL: "https://drive.internal.example", Token: "t", BaseURLMap: map[string]string{}})
+
+	assert.True(t, c.hostAllowed("https://drive.internal.example"))
+	assert.False(t, c.hostAllowed("https://evil.example"))
+}
+
+// TestClient_hostAllowed_NoDefaultURL guards the degenerate config: with no
+// default URL and no map there is nothing legitimate to reach, and the empty
+// string must not become a wildcard.
+func TestClient_hostAllowed_NoDefaultURL(t *testing.T) {
+	c := NewClient(&Config{Token: "t"})
+
+	assert.False(t, c.hostAllowed(""))
+	assert.False(t, c.hostAllowed("https://evil.example"))
+}
+
+func TestErrHostNotAllowed_IsMatchable(t *testing.T) {
+	c := NewClient(&Config{URL: "https://drive.internal.example", Token: "t"})
+	_, err := c.GetGroupImage("https://evil.example", "g", "f")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrHostNotAllowed),
+		"the handler maps this to a 400, so it must survive wrapping")
+}

--- a/pkg/drive/uploader.go
+++ b/pkg/drive/uploader.go
@@ -131,6 +131,12 @@ func (c *Client) fetchPresignedURL(host, groupID, fileID string) (string, error)
 		URL   string `json:"url"`
 		Error string `json:"error,omitempty"`
 	}
+	// The api-token below is attached to whatever host we are handed, and that
+	// host can originate in a client query string — so the allow-list check has
+	// to happen before the request is built, not at the caller.
+	if !c.hostAllowed(host) {
+		return "", ErrHostNotAllowed
+	}
 	var result presignedURL
 	resp, err := c.downloadClient.R().
 		SetHeader("api-token", c.apiToken).

--- a/upload-service/handler.go
+++ b/upload-service/handler.go
@@ -357,6 +357,16 @@ func (h *Handler) downloadFrom(c *gin.Context, dc driveClient) {
 
 	img, err := dc.GetGroupImage(driveHost, roomID, fileID)
 	if err != nil {
+		if errors.Is(err, drive.ErrHostNotAllowed) {
+			// A host outside the configured Drive base URLs is a malformed
+			// request, not a broken dependency — 400, not 503. The rejected
+			// value rides the log line (WithLogValues, so Classify still logs
+			// exactly once) because it is the signal that someone is probing
+			// the credential boundary; it is never echoed to the client.
+			ctx = errcode.WithLogValues(ctx, "drive_host", driveHost)
+			errhttp.Write(ctx, c, errcode.BadRequest("drive_host is not a configured Drive host"))
+			return
+		}
 		errhttp.Write(ctx, c, errcode.Unavailable("failed to retrieve file", errcode.WithCause(err)))
 		return
 	}

--- a/upload-service/handler_test.go
+++ b/upload-service/handler_test.go
@@ -1388,3 +1388,37 @@ func TestHandleUploadFile_DriveNoResponses(t *testing.T) {
 	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 	assert.Equal(t, "unavailable", decodeErr(t, w).Code)
 }
+
+// TestDownload_HostNotAllowed_400 pins the boundary between "the client sent a
+// host we will not send our credential to" and "the Drive is broken". Before the
+// allow-list every drive.ErrHostNotAllowed would have surfaced as a 503, which
+// reads as our outage rather than their bad request — and, more to the point,
+// the request would have been made at all.
+func TestDownload_HostNotAllowed_400(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
+	fd := &fakeDrive{getErr: fmt.Errorf("fetch presigned url: %w", drive.ErrHostNotAllowed)}
+	h := newHandler(store, fd)
+	c, w := newDownloadCtx(t, "r1", "f1", "https://evil.example", okUser())
+	h.HandleDownloadFile(c)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "bad_request", decodeErr(t, w).Code)
+	assert.NotContains(t, decodeErr(t, w).Error, "evil.example",
+		"the rejected host must not be reflected back to the caller")
+}
+
+// The legacy v3 endpoint shares downloadFrom but carries its own Drive client,
+// so its host is checked against the legacy config's base URLs.
+func TestDownloadV3_HostNotAllowed_400(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := NewMockStore(ctrl)
+	store.EXPECT().MemberSiteID(gomock.Any(), "r1", "alice").Return("site-x", true, nil)
+	legacy := &fakeDrive{getErr: fmt.Errorf("fetch presigned url: %w", drive.ErrHostNotAllowed)}
+	h := newHandler(store, &fakeDrive{})
+	h.legacyDrive = legacy
+	c, w := newDownloadCtx(t, "r1", "f1", "https://evil.example", okUser())
+	h.HandleDownloadProtectedImageV3(c)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "bad_request", decodeErr(t, w).Code)
+}


### PR DESCRIPTION
## The vulnerability

The two download endpoints take `drive_host` **verbatim from a client query string**:

```go
// upload-service/handler.go:342
driveHost := c.Query("drive_host")
...
img, err := dc.GetGroupImage(driveHost, roomID, fileID)
```

and `GetGroupImage` → `fetchPresignedURL` attaches the Drive credential to whatever host it is handed:

```go
// pkg/drive/uploader.go — before
c.downloadClient.R().
    SetHeader("api-token", c.apiToken).            // ← the credential
    Get(fmt.Sprintf("%s/api/v1/groups/{groupId}/files/{fileId}", host))  // ← client-chosen
```

**An authenticated room member could choose which server received the service's Drive API token**, and have the response streamed back to them. Credential exfiltration with a request-forgery primitive attached. This was the only `critical` security finding in the 35-service audit.

## The fix

The allow-list already existed and simply was not consulted. `drive.Config` carries `BaseURLMap` (room-origin siteID → Drive base URL) plus the default `URL`; together those are exactly the set of legitimate Drive hosts. `hostAllowed` checks against that set before the request is built.

**Placement is deliberate.** The check lives in `pkg/drive`, beside the code that attaches the token — not in the HTTP handler. Any future method taking a host is then covered by construction rather than by someone remembering.

**Matching is exact**, after trimming trailing slashes. Prefix, suffix or `strings.Contains` matching would admit `https://evil.example/?u=https://drive.site-a.example` and its many cousins. Against an attacker-chosen string the only safe comparison is equality with a value an operator configured. The cost — a host must be spelled as configured — is the right trade at a credential boundary.

**Fail-closed on a broken config.** `LoadBaseURLs` falls back to an empty map on a missing or malformed file. With the map empty the allow-list is just the configured default URL: a single-site deployment keeps working, and a misconfigured multi-site one now refuses cross-site hosts rather than silently misrouting them at the local Drive.

## Handler behaviour

`ErrHostNotAllowed` maps to **400, not the previous 503** — an unrecognised host is a malformed request, not a broken dependency. The rejected value goes onto the log line via `errcode.WithLogValues` (so `Classify` still logs exactly once, per CLAUDE.md's never-log-and-return rule) because it is the signal that someone is probing the boundary. It is **never echoed back to the caller**.

Both documented endpoints — `/api/v1/file/...` and the legacy `/api/v3/...` — share `downloadFrom` and each passes its own Drive client, so the legacy host is validated against the **legacy** Drive's own configured base URLs.

## Tests

The load-bearing one asserts the credential never leaves the process, not merely that an error is returned:

```
TestGetGroupImage_UnlistedHostNeverReceivesTheAPIToken
  – stands up an httptest server as the attacker host
  – asserts hits == 0 and that no request carried an api-token header
```

Verified it has teeth. With the check removed:

```
--- FAIL: TestGetGroupImage_UnlistedHostNeverReceivesTheAPIToken
    Messages: the unlisted host must never be contacted
    Messages: the Drive api-token must never leave the process for an unlisted host
```

And with the handler mapping removed: `expected: 400, actual: 503`.

`TestClient_hostAllowed` is a 15-case table covering the bypass shapes an exact-match list must refuse — userinfo (`https://drive.ok@evil.example`), query-string, path-suffix, subdomain, prefix, scheme downgrade, bare host, path traversal — plus the legitimate forms (default URL, mapped host, mapped host with a path, trailing slash). Two further tests pin the empty-map and no-default-URL configurations.

## Verification

- `go test ./pkg/drive/ ./upload-service/ -race` — pass
- **`go test ./...` — 0 failures** (`pkg/drive` is shared, so the whole repo was run)
- **`go vet -tags integration ./...` — clean.** Explicitly checked this time: PR #456 was broken by assertions in `//go:build integration` files that `go vet` and `make test` do not compile
- `make lint` — `0 issues`; `make sast-gosec` — no findings

## Docs

Both download error tables in `docs/client-api.md` gain the 400 row, and the derived `docs/client-api/request-reply.md` entries move with them.

## Deliberately not in this PR

`LoadBaseURLs` still logs-and-continues on a missing or malformed config file. Now that the map is a security control that is worth revisiting — but making it fatal changes startup behaviour for every deployment, so it belongs in its own change. The fix above is safe under that failure mode: the fallback allow-list is the configured default URL alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxZYPse6BHHNiL53bcP6py)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - File-download requests now accept only configured Drive hosts.
  - Invalid or unrecognized Drive hosts are rejected with a clear `400 Bad Request` response.
  - Rejected host values are not included in responses.

- **Documentation**
  - Updated API references to describe the required `drive_host` value and error behavior for current and legacy download endpoints.

- **Bug Fixes**
  - Prevented requests to unapproved Drive hosts, improving download security and avoiding incorrect server errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->