### PR TITLE
fix(model): classify legacy migrated member types as system messages

### DIFF
--- a/data-migration/es-index-migrator/runner_test.go
+++ b/data-migration/es-index-migrator/runner_test.go
@@ -84,6 +84,12 @@ func TestRunMessages_SkipsSystemMessages(t *testing.T) {
 				{MessageID: "m1", RoomID: "room1", CreatedAt: now},
 				{MessageID: "sys1", RoomID: "room1", CreatedAt: now, Type: model.MessageTypeMembersAdded},
 				{MessageID: "sys2", RoomID: "room1", CreatedAt: now, Type: model.MessageTypeRoomRenamed},
+				// Migrated rows. The backfill streams Cassandra directly, so these
+				// arrive with their stored plural type and must be filtered like any
+				// other membership notice — the live path never indexes their modern
+				// equivalents, and the backfill has to match.
+				{MessageID: "sys3", RoomID: "room1", CreatedAt: now, Type: model.MessageTypeLegacyMembersRemoved},
+				{MessageID: "sys4", RoomID: "room1", CreatedAt: now, Type: model.MessageTypeLegacyMembersLeft},
 				{MessageID: "m2", RoomID: "room1", CreatedAt: now, Type: model.MessageTypeImportant},
 			} {
 				if err := fn(m); err != nil {

--- a/history-service/internal/service/preview_walk_test.go
+++ b/history-service/internal/service/preview_walk_test.go
@@ -280,6 +280,10 @@ func TestPreviewWalk_SkipsEverySystemType(t *testing.T) {
 		model.MessageTypeRoomRenamed,
 		model.MessageTypeRoomRestricted,
 		model.MessageTypeTeamsMeetStarted,
+		// Migrated rows. The walk reads Cassandra directly, so it classifies by the
+		// STORED type — the wire-side rewrite in normalizeLegacySysMsgs never runs here.
+		model.MessageTypeLegacyMembersRemoved,
+		model.MessageTypeLegacyMembersLeft,
 	}
 	for _, st := range systemTypes {
 		t.Run(st, func(t *testing.T) {

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -726,6 +726,21 @@ const (
 	MessageTypeTeamsMeetStarted = "teams_meet_started"
 )
 
+// Legacy member types exist only on migrated Cassandra rows — nothing in this repo
+// produces them, and the plural shape is not the tell (MessageTypeMembersAdded is
+// current). history-service rewrites them to their modern equivalents on the wire, so
+// clients never see them; these constants are for classifying the STORED type.
+//
+// A replay tool that ever republished historical rows onto MESSAGES-CANONICAL would
+// put them on the live paths too, where they would classify as system messages —
+// correct, but worth knowing before building one.
+const (
+	// MessageTypeLegacyMembersRemoved is the migrated form of MessageTypeMemberRemoved.
+	MessageTypeLegacyMembersRemoved = "members_removed"
+	// MessageTypeLegacyMembersLeft is the migrated form of MessageTypeMemberLeft.
+	MessageTypeLegacyMembersLeft = "members_left"
+)
+
 // systemMessageTypes is the set of system/event Message.Type values (not user content),
 // for fast membership checks. Keep in sync with the MessageType* constants above.
 var systemMessageTypes = map[string]struct{}{
@@ -736,6 +751,11 @@ var systemMessageTypes = map[string]struct{}{
 	MessageTypeRoomRenamed:      {},
 	MessageTypeRoomRestricted:   {},
 	MessageTypeTeamsMeetStarted: {},
+	// Legacy types belong here too: the readers that classify by stored type are the
+	// preview walk and the search backfill, and both must treat a migrated membership
+	// notice as the system message it is.
+	MessageTypeLegacyMembersRemoved: {},
+	MessageTypeLegacyMembersLeft:    {},
 }
 
 // IsSystemMessageType reports whether t is a known system-message type. A normal

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -5288,6 +5288,25 @@ func TestIsSystemMessageType(t *testing.T) {
 	assert.False(t, model.IsSystemMessageType("unknown"), "unknown is not a system type")
 }
 
+// Migrated rows carry plural member types nothing produces any more. They are still
+// system messages, and the paths that read Cassandra directly — the room-list preview
+// walk and the search backfill — classify by the STORED type, so leaving them out
+// makes a membership notice eligible as a room preview and as searchable content.
+func TestIsSystemMessageType_LegacyMigratedTypes(t *testing.T) {
+	for _, st := range []string{
+		model.MessageTypeLegacyMembersRemoved,
+		model.MessageTypeLegacyMembersLeft,
+	} {
+		assert.True(t, model.IsSystemMessageType(st), "%q is a legacy system type", st)
+	}
+	assert.Equal(t, "members_removed", model.MessageTypeLegacyMembersRemoved)
+	assert.Equal(t, "members_left", model.MessageTypeLegacyMembersLeft)
+
+	// members_added is NOT legacy despite being plural — it is the current type for
+	// an add, so the plural/singular shape is not the rule.
+	assert.Equal(t, "members_added", model.MessageTypeMembersAdded)
+}
+
 func TestSendMessageRequest_TypeRoundTripAndOmitEmpty(t *testing.T) {
 	// omitempty: absent Type serializes to no "type" key (json + bson).
 	jbytes, err := json.Marshal(&model.SendMessageRequest{ID: "m1", Content: "hi", RequestID: "r1"})


### PR DESCRIPTION
Follow-up to #451, which flagged this as out of scope. Independent of it — this branch is cut from `main` and touches neither `sysmsgname.go` nor `pkg/preview`.

## The bug

The migration wrote member removals and self-leaves into Cassandra as `members_removed` / `members_left`. Nothing in this repo produces those types any more, but `IsSystemMessageType` doesn't recognise them — so the two paths that classify by the **stored** type treat a membership notice as ordinary user content:

- **`history-service/internal/service/rooms.go:255`** — the lazy room-list preview walk can select a legacy member row as a room's preview. The walk reads Cassandra directly, so the wire-side type rewrite in #451 never runs on it.
- **`data-migration/es-index-migrator/runner.go:63`** — the backfill indexes legacy member rows as searchable content. Its own comment says "Sys-messages are dropped on the live path […]; the backfill must match or it re-introduces them" — it currently doesn't.

## The fix

Two named constants, added to `systemMessageTypes`.

## Why this is safe to put in the shared map

`IsSystemMessageType` has 8 call sites. Five read the type off MESSAGES-CANONICAL, where these values **can never appear** — no producer emits them, and the migration wrote them straight into Cassandra without republishing. So this is a no-op on all of them:

| consumer | what it gates | reachable by a legacy type? |
|---|---|---|
| `message-worker` (nil-sender fallback, metric label) | sender resolution, metrics | no — live only |
| `notification-worker` `isNotifiable` | push notifications | no — live only |
| `search-sync-worker` | live index filter | no — live only |
| `roomlist-worker` | `SystemMsg` wire flag | no — live only |
| `broadcast-worker/preview.go` | insert-side preview eligibility | no — live only |
| **`history-service` preview walk** | preview eligibility | **yes — fixed** |
| **`es-index-migrator`** | backfill index filter | **yes — fixed** |

Keeping one membership list also matters: `notification-worker`'s comment states new system types are "safe-by-default as long as they join `IsSystemMessageType` (the single membership list)". A preview-only legacy set would have fixed the walk, left the backfill broken, and created the second concept that comment warns against. It would also have split the predicate `rooms.go:254` deliberately shares with the insert side ("so the two cannot disagree").

**The caveat, stated in the code:** "legacy types never reach live paths" is a claim about data, not code. It holds today because no producer emits them — but a replay tool that republished historical rows onto MESSAGES-CANONICAL would put them on the live paths, where they'd classify as system messages. Correct, but worth knowing before building one. The constants carry that note.

**Also worth knowing:** the plural shape is not the tell — `members_added` is a *current* type, not a legacy one. Asserted in the test so nobody "fixes" it by pattern.

## Why making rows ineligible can't wrongly clear a preview

`previewEmpty` is destructive (`previewAfterMutation` clears the stored preview on it), so excluding more rows deserves a second look. The walk only returns `previewEmpty` on `!page.HasNext` — genuine end of history. An ineligible tail that exhausts the scan budget returns `previewDegraded` instead: "a survivor may exist, so unknown, never a clear." So a room whose recent tail is all legacy member rows degrades to unknown rather than losing its preview.

## Operational note: this stops recurrence, it does not clean up

If a backfill has **already completed** against a persistent index, the legacy member documents are in it and this PR leaves them there. The job only ever upserts — `buildMessageAction` emits `ActionIndex` with `DocID: msg.MessageID`, externally versioned — so a skipped row is simply not written, never retracted. On a fresh site, or a run into a new versioned index, this PR is sufficient by itself.

They also cannot be removed by a `delete_by_query` on type: `searchindex.MessageFields` carries no `type` field, so in ES a legacy member document is indistinguishable from an ordinary message except by its content text.

Two cleanup routes, both deliberately out of scope here:

- **Reindex into a fresh index** — the shape the job was designed for ("every write is versioned/idempotent … so a re-run or overlap with live traffic converges"). With this change the new index never receives them; the alias cuts over. No delete logic needed.
- **A targeted delete pass** re-deriving the affected `message_id`s from Cassandra `messages_by_room` and issuing bulk deletes against the existing index. Only needed if reindexing isn't an option.

A data-cleanup job wants its own operational review, so it isn't bundled here.

## Testing

TDD — the red phase was verified by removing the map entries and confirming the two new preview-walk subtests fail on `IsSystemMessageType`, then restoring.

- `pkg/model`: both types classify as system; constant values pinned; `members_added` asserted still current.
- `history-service`: both added to the existing `TestPreviewWalk_SkipsEverySystemType` table, so the walk provably steps over a legacy row to the next eligible message.
- `es-index-migrator`: both added to `TestRunMessages_SkipsSystemMessages`, asserting they're filtered rather than counted as build failures.

`make test` (full repo, `-race`) pass · `make lint` 0 issues · `gosec` pass · semgrep repo rules 0 findings. govulncheck and semgrep's registry ruleset are network-blocked in the dev environment and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKU3KzpKzseUknJKgfL3Xv