### PR TITLE
perf(user-service): serve subscription.list sort keys from a secondary

### DIFF
--- a/user-service/mongorepo/readpref_test.go
+++ b/user-service/mongorepo/readpref_test.go
@@ -39,8 +39,7 @@ func TestSubscriptionRepo_ReadPreferenceRouting(t *testing.T) {
 		assert.NotSame(t, r.subscriptions.Raw(), r.subscriptionsSecondary.Raw())
 		// GetAppSubscription (dedup guard) must keep using the primary handle.
 		assert.NotSame(t, r.subscriptions.Raw(), r.subscriptionsSecondary.Raw())
-		// The sort-key read is already allowed to lag by SUBS_SORTKEY_CACHE_TTL, so it
-		// takes the secondary; the page baseline read stays on the primary handle.
+		// The sort-key read takes the secondary; the page baseline read does not.
 		assert.NotSame(t, r.rooms, r.roomsSecondary)
 	})
 }

--- a/user-service/mongorepo/readpref_test.go
+++ b/user-service/mongorepo/readpref_test.go
@@ -30,6 +30,7 @@ func TestSubscriptionRepo_ReadPreferenceRouting(t *testing.T) {
 		r := NewSubscriptionRepo(db, 0, 0)
 		assert.Same(t, r.enriched, r.enrichedSecondary)
 		assert.Same(t, r.subscriptions, r.subscriptionsSecondary)
+		assert.Same(t, r.rooms, r.roomsSecondary)
 	})
 
 	t.Run("secondary preference clones read handles but not the primary ones", func(t *testing.T) {
@@ -38,6 +39,9 @@ func TestSubscriptionRepo_ReadPreferenceRouting(t *testing.T) {
 		assert.NotSame(t, r.subscriptions.Raw(), r.subscriptionsSecondary.Raw())
 		// GetAppSubscription (dedup guard) must keep using the primary handle.
 		assert.NotSame(t, r.subscriptions.Raw(), r.subscriptionsSecondary.Raw())
+		// The sort-key read is already allowed to lag by SUBS_SORTKEY_CACHE_TTL, so it
+		// takes the secondary; the page baseline read stays on the primary handle.
+		assert.NotSame(t, r.rooms, r.roomsSecondary)
 	})
 }
 

--- a/user-service/mongorepo/subscriptions.go
+++ b/user-service/mongorepo/subscriptions.go
@@ -41,10 +41,16 @@ type SubscriptionRepo struct {
 	// showTeamsAccounts (SHOW_TEAMS_ROOM_ACCOUNTS) allowlists accounts that see
 	// Teams rooms even when showTeamsRoom is false.
 	showTeamsAccounts map[string]bool
-	// rooms backs the list path's batched reads: sort keys and page data. The
-	// collection belongs to room-service; we only name it.
-	rooms    *mongo.Collection
-	sortKeys *sortKeyCache
+	// rooms backs the page baseline read, which both seeds the sort-key cache and
+	// produces the row's user-visible room fields. The collection belongs to
+	// room-service; we only name it.
+	rooms *mongo.Collection
+	// roomsSecondary serves the sort-key read alone — the one rooms read whose $in
+	// is sized by the account's whole subscription set rather than by the page, and
+	// one whose value the cache already lets lag by its TTL. resolveSortKeys
+	// documents what a replica adds on top of that.
+	roomsSecondary *mongo.Collection
+	sortKeys       *sortKeyCache
 }
 
 // NewSubscriptionRepo builds a SubscriptionRepo over db. sortKeyCacheSize and
@@ -53,6 +59,7 @@ type SubscriptionRepo struct {
 func NewSubscriptionRepo(db *mongo.Database, sortKeyCacheSize int, sortKeyCacheTTL time.Duration, opts ...Option) *SubscriptionRepo {
 	s := applyOptions(opts)
 	col := db.Collection(subscriptionsCollection)
+	roomsCol := db.Collection(roomsCollection)
 	subscriptions := mongoutil.NewCollection[model.Subscription](col)
 	enriched := mongoutil.NewCollection[model.EnrichedSubscription](col)
 	active := mongoutil.NewCollection[models.ActiveSubscription](col)
@@ -64,7 +71,8 @@ func NewSubscriptionRepo(db *mongo.Database, sortKeyCacheSize int, sortKeyCacheT
 		activeSecondary:        active.WithReadPreference(s.readPref),
 		showTeamsRoom:          s.showTeamsRoom,
 		showTeamsAccounts:      s.showTeamsAccounts,
-		rooms:                  db.Collection(roomsCollection),
+		rooms:                  roomsCol,
+		roomsSecondary:         mongoutil.CollectionWithReadPreference(roomsCol, s.readPref),
 		sortKeys:               newSortKeyCache(sortKeyCacheSize, sortKeyCacheTTL),
 	}
 }
@@ -265,9 +273,11 @@ func dedupeStrings(in []string) []string {
 //  4. Two reads sized to the page: its rooms and its full subscription
 //     documents. Only rows that made the page are fetched in full.
 //
-// Only the ordering may lag, by up to the cache TTL. A cached key that falls
-// outside the window is re-read first, and the fresh room read drops any room
-// soft-deleted meanwhile.
+// Only the ordering may lag, by up to the cache TTL plus the replication lag of
+// the secondary the sort-key read is served from. Whether a subscription appears
+// is decided by the two subscription reads, which keep the client preference. A
+// cached key that falls outside the window is re-read first, and the fresh room
+// read drops any room soft-deleted meanwhile.
 func (r *SubscriptionRepo) AggregateSubscriptions(ctx context.Context, account, listType string, favorite bool, withinDays *int, page mongoutil.OffsetPageRequest) (mongoutil.OffsetPageHasMore[model.EnrichedSubscription], error) {
 	var zero mongoutil.OffsetPageHasMore[model.EnrichedSubscription]
 	match := bson.M{"u.account": account}
@@ -294,8 +304,9 @@ func (r *SubscriptionRepo) AggregateSubscriptions(ctx context.Context, account, 
 	if f := r.originFilter(account); f != nil {
 		match["origin"] = f
 	}
-	// All primary: the list must show a subscription the caller just changed,
-	// and the page's rows come from fresh room reads. Only sort keys may lag.
+	// Both subscription reads keep the client preference: they decide whether a row
+	// appears at all, and the list must show a subscription the caller just changed.
+	// Only the sort-key read is routed to a secondary.
 	cur, err := r.subscriptions.Raw().Find(ctx, match,
 		options.Find().SetProjection(subscriptionLiteProjection()))
 	if err != nil {
@@ -483,8 +494,17 @@ func fillBatchSize(need, collected, candidates int64) int64 {
 //
 // A cached key outside the activity window is treated as a miss and read again.
 // lastMsgAt only moves forward, so a key that passes the window is still in it,
-// but one that fails may have just gone stale. Ordering may lag the TTL;
-// whether a room appears at all may not.
+// but one that fails may have just gone stale. Ordering may lag the TTL; whether
+// a subscription appears at all is not decided here — except under a withinDays
+// window, which drops undated rows.
+//
+// This read is served from a secondary (roomsSecondary), so its absences are not
+// authoritative: a room created within the replica's lag reads as absent, and the
+// Missing caching below then holds that verdict for the TTL. Undated rows sort
+// last, so the visible cost is a just-created room at the bottom of the sidebar
+// until the entry expires — or, under a window, out of it. The page baseline read
+// keeps the primary preference and writes the real key back for any such room that
+// reaches the page.
 //
 // Rooms the read doesn't return are cached as Missing, so rooms owned by another
 // site aren't queried on every list. Those are never re-read — there is no local
@@ -511,7 +531,7 @@ func (r *SubscriptionRepo) resolveSortKeys(ctx context.Context, subs []subLite, 
 	if len(misses) == 0 {
 		return keys, nil
 	}
-	cur, err := r.rooms.Find(ctx, bson.M{"_id": bson.M{"$in": misses}},
+	cur, err := r.roomsSecondary.Find(ctx, bson.M{"_id": bson.M{"$in": misses}},
 		options.Find().SetProjection(bson.M{"lastMsgAt": 1, "lastUserMsgAt": 1, "createdAt": 1}))
 	if err != nil {
 		return nil, fmt.Errorf("find room sort keys: %w", err)

--- a/user-service/mongorepo/subscriptions.go
+++ b/user-service/mongorepo/subscriptions.go
@@ -41,14 +41,11 @@ type SubscriptionRepo struct {
 	// showTeamsAccounts (SHOW_TEAMS_ROOM_ACCOUNTS) allowlists accounts that see
 	// Teams rooms even when showTeamsRoom is false.
 	showTeamsAccounts map[string]bool
-	// rooms backs the page baseline read, which both seeds the sort-key cache and
-	// produces the row's user-visible room fields. The collection belongs to
-	// room-service; we only name it.
+	// rooms backs the page baseline read, which seeds both the sort-key cache and
+	// the row's room fields. Owned by room-service; we only name it.
 	rooms *mongo.Collection
-	// roomsSecondary serves the sort-key read alone — the one rooms read whose $in
-	// is sized by the account's whole subscription set rather than by the page, and
-	// one whose value the cache already lets lag by its TTL. resolveSortKeys
-	// documents what a replica adds on top of that.
+	// roomsSecondary serves the sort-key read alone: the one rooms read sized by the
+	// account's whole set, and already lag-tolerant. See resolveSortKeys.
 	roomsSecondary *mongo.Collection
 	sortKeys       *sortKeyCache
 }
@@ -273,11 +270,10 @@ func dedupeStrings(in []string) []string {
 //  4. Two reads sized to the page: its rooms and its full subscription
 //     documents. Only rows that made the page are fetched in full.
 //
-// Only the ordering may lag, by up to the cache TTL plus the replication lag of
-// the secondary the sort-key read is served from. Whether a subscription appears
-// is decided by the two subscription reads, which keep the client preference. A
-// cached key that falls outside the window is re-read first, and the fresh room
-// read drops any room soft-deleted meanwhile.
+// Only the ordering may lag: the cache TTL plus the sort-key read's replica lag.
+// Visibility is the two subscription reads', which keep the client preference. A
+// cached key outside the window is re-read first, and the fresh room read drops
+// any room soft-deleted meanwhile.
 func (r *SubscriptionRepo) AggregateSubscriptions(ctx context.Context, account, listType string, favorite bool, withinDays *int, page mongoutil.OffsetPageRequest) (mongoutil.OffsetPageHasMore[model.EnrichedSubscription], error) {
 	var zero mongoutil.OffsetPageHasMore[model.EnrichedSubscription]
 	match := bson.M{"u.account": account}
@@ -305,8 +301,7 @@ func (r *SubscriptionRepo) AggregateSubscriptions(ctx context.Context, account, 
 		match["origin"] = f
 	}
 	// Both subscription reads keep the client preference: they decide whether a row
-	// appears at all, and the list must show a subscription the caller just changed.
-	// Only the sort-key read is routed to a secondary.
+	// appears, and must show a subscription the caller just changed.
 	cur, err := r.subscriptions.Raw().Find(ctx, match,
 		options.Find().SetProjection(subscriptionLiteProjection()))
 	if err != nil {
@@ -494,17 +489,11 @@ func fillBatchSize(need, collected, candidates int64) int64 {
 //
 // A cached key outside the activity window is treated as a miss and read again.
 // lastMsgAt only moves forward, so a key that passes the window is still in it,
-// but one that fails may have just gone stale. Ordering may lag the TTL; whether
-// a subscription appears at all is not decided here — except under a withinDays
-// window, which drops undated rows.
+// but one that fails may have just gone stale. Ordering may lag the TTL; so may
+// inclusion, but only under a withinDays window, which drops undated rows.
 //
-// This read is served from a secondary (roomsSecondary), so its absences are not
-// authoritative: a room created within the replica's lag reads as absent, and the
-// Missing caching below then holds that verdict for the TTL. Undated rows sort
-// last, so the visible cost is a just-created room at the bottom of the sidebar
-// until the entry expires — or, under a window, out of it. The page baseline read
-// keeps the primary preference and writes the real key back for any such room that
-// reaches the page.
+// Served from a secondary, so absences are not authoritative: a room created
+// inside the replica's lag caches as Missing for the TTL and sorts last.
 //
 // Rooms the read doesn't return are cached as Missing, so rooms owned by another
 // site aren't queried on every list. Those are never re-read — there is no local


### PR DESCRIPTION
AggregateSubscriptions runs four reads and all four inherited the client
preference. One of them does not need it.

resolveSortKeys' $in over the account's cache misses is the only rooms read
sized by the whole subscription set rather than by the page, and its value is
already allowed to lag by SUBS_SORTKEY_CACHE_TTL — a hit serves a 15s-old key
without comment, so insisting a miss be fresher was self-contradictory. It now
goes through roomsSecondary, built from the repo's existing MONGO_READ_PREFERENCE
option like every other *Secondary handle.

The page baseline read keeps the plain handle. It is the freshening read: it
seeds the sort-key cache and produces the row's user-visible room fields, so a
lagging value there would be written back into the cache for every later reader
of that room. It is also page-sized, so offloading it buys little.

Both subscription reads are untouched. They are what decide whether a row appears
at all, so visibility cannot lag; only ordering can.

What a replica adds beyond the TTL, recorded on resolveSortKeys: its absences are
not authoritative. A room created inside the replica's lag reads as absent and the
existing Missing caching then holds that verdict for the TTL, so a just-created
room can sort last — or, under a withinDays window, drop out — until the entry
expires. The page baseline read writes the real key back for any such room that
reaches the page.

Corrects two comments the change invalidates, and one it does not: the reads were
never pinned to primary. MONGO_CLIENT_READ_PREFERENCE has defaulted to
primaryPreferred since #394, so "All primary" described an invariant the code did
not have.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VPWJds4zc6jD8vpPXY8W6y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription sorting reads by routing sort-key lookups according to the configured database read preference.
  * Kept page baseline reads on the primary database for more consistent results.
  * Clarified behavior when no secondary read preference is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->