### PR TITLE
fix(room-service): return 404 for a missing room instead of 500

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -1370,7 +1370,7 @@ The fields `requesterId`, `requesterAccount`, `timestamp`, and `historySharedSin
 
 ##### Error response
 
-See [Error envelope](#6-error-envelope-reference). Returned synchronously when validation or authorization fails (e.g. requester not in room, room is full, room is restricted and requester is not owner, unrecognized `history.mode`). A `users` entry that is a bot is rejected with `"bot not available"` (`bot_not_available`) when it has no app record or its assistant is disabled; a bot whose home site differs from the room's site is admitted (cross-site bot membership is allowed). Any `orgs` entry that matches zero users (no user with `sectId == orgId` or `deptId == orgId`) is rejected with `org "<orgId>": invalid org`, and any `users` entry that has no matching user document is rejected with `user "<account>": user not found` (each wrapped with the offending account/org ID) — in both cases the request is not queued and no members are added. Bots resolved from `channels` / `orgs` expansion are silently filtered (only explicitly listed bots are added).
+See [Error envelope](#6-error-envelope-reference). Returned synchronously when validation or authorization fails (e.g. requester not in room, room is full, room is restricted and requester is not owner, unrecognized `history.mode`). A `users` entry that is a bot is rejected with `"bot not available"` (`bot_not_available`) when it has no app record or its assistant is disabled; a bot whose home site differs from the room's site is admitted (cross-site bot membership is allowed). Any `orgs` entry that matches zero users (no user with `sectId == orgId` or `deptId == orgId`) is rejected with `org "<orgId>": invalid org`, and any `users` entry that has no matching user document is rejected with `user "<account>": user not found` (each wrapped with the offending account/org ID) — in both cases the request is not queued and no members are added. Bots resolved from `channels` / `orgs` expansion are silently filtered (only explicitly listed bots are added). When no room matches the subject `{roomID}` the reply is `"room not found"` (`not_found`).
 
 ```json
 { "code": "conflict", "reason": "max_room_size_reached", "error": "room is at maximum capacity" }
@@ -1560,7 +1560,7 @@ Exactly one of `account` or `orgId` must be set. The fields `requester`, `roomTy
 
 ##### Error response
 
-See [Error envelope](#6-error-envelope-reference). Returned synchronously when validation or authorization fails (e.g. neither or both of `account`/`orgId` set, requester is not an owner, target is the last member, or org member cannot leave individually). The last-member guard counts **human** members only: removing the last human is rejected even when bot members remain, while removing a bot never trips the guard.
+See [Error envelope](#6-error-envelope-reference). Returned synchronously when validation or authorization fails (e.g. neither or both of `account`/`orgId` set, requester is not an owner, target is the last member, or org member cannot leave individually). The last-member guard counts **human** members only: removing the last human is rejected even when bot members remain, while removing a bot never trips the guard. When no room matches the subject `{roomID}` the reply is `"room not found"` (`not_found`).
 
 ```json
 { "code": "bad_request", "error": "exactly one of account or orgId must be set" }
@@ -1671,6 +1671,7 @@ See [Error envelope](#6-error-envelope-reference). Returned synchronously when v
 - Last-owner guard: an owner cannot demote themselves if they are the only owner.
 - Promote attempt on a bot account — rejected with `"bots cannot be room owners"` (demoting a bot stays allowed).
 - Promote attempt on an org-only member (individual subscription required).
+- `"room not found"` (`not_found`) — no room matches the subject `{roomID}`.
 
 ```json
 { "code": "forbidden", "error": "only owners can update roles" }
@@ -1984,6 +1985,7 @@ See [Error envelope](#6-error-envelope-reference). Common errors:
 
 - `"only room members can perform this action"` — caller has no subscription in the room (sentinel reused across membership-gated RPCs).
 - `"limit must be > 0 and <= room user count"` — limit was `0`, negative, or larger than the room's current `userCount`.
+- `"room not found"` — no room matches the subject `{roomID}`.
 
 ##### Triggered events — success path
 
@@ -2105,6 +2107,7 @@ The subject already carries `account` and `roomID`, so no body fields are requir
 See [Error envelope](#6-error-envelope-reference). Common errors:
 
 - `"only room members can perform this action"` — the user has no subscription in the room (sentinel reused across membership-gated RPCs).
+- `"room not found"` — no room matches the subject `{roomID}`.
 - A malformed subject surfaces as a generic `"internal error"` (the specific reason is sanitized away). Not normally reachable — the wildcard subscription guarantees a well-formed subject.
 
 ```json

--- a/docs/client-api/request-reply.md
+++ b/docs/client-api/request-reply.md
@@ -403,7 +403,7 @@ The `requesterId`, `requesterAccount`, `timestamp`, and `historySharedSince` fie
 
 Synchronous: requester not in room, room full, restricted + not owner, bot not
 available (no app record / disabled assistant), user/org not found, unrecognized
-`history.mode` (`history.mode must be "none" or "all"`, `bad_request`).
+`history.mode` (`history.mode must be "none" or "all"`, `bad_request`); `"room not found"` (`not_found`).
 
 ```json
 { "code": "conflict", "reason": "max_room_size_reached", "error": "room is at maximum capacity" }
@@ -438,7 +438,7 @@ Exactly one of `account` or `orgId` must be set.
 
 Synchronous: neither/both of `account`/`orgId` set; requester not an owner; target is
 last **human** member (bots don't count, and a bot target skips the guard); org member
-cannot leave individually.
+cannot leave individually; `"room not found"` (`not_found`).
 
 **Emits:** [`AsyncJobResult`](events.md#asyncjobresult--async-completion) (`operation: "room.member.remove"` or `"room.member.remove_org"`), [`subscription.update`](events.md#subscriptionupdate--membership--state-changes) (`action: "removed"` — one per removed account, bots included on their encoded per-user subject), [`room.key`](events.md#roomkey--room-encryption-key-delivery) (channel rooms — key rotated; surviving members receive new event), [`member_left` / `member_removed`](events.md#member_left--member_removed-memberremoveevent) (on `chat.room.{roomID}.event.member`, or `chat.local.room.{roomID}.event.member` for same-site rooms by `crossSite`), `new_message` system message → [events.md](events.md#new_message-roomevent)
 
@@ -465,7 +465,7 @@ cannot leave individually.
 
 #### Errors
 
-Not an owner; target not a member; invalid `newRole`; already owner (promote); bot account cannot be promoted to owner (demote stays allowed); not owner (demote); last-owner guard; org-only member cannot be promoted.
+Not an owner; target not a member; invalid `newRole`; already owner (promote); bot account cannot be promoted to owner (demote stays allowed); not owner (demote); last-owner guard; org-only member cannot be promoted; `"room not found"` (`not_found`).
 
 **Emits:** [`subscription.update`](events.md#subscriptionupdate--membership--state-changes) (`action: "role_updated"` — to the target user only) → [events.md](events.md#subscriptionupdate--membership--state-changes)
 
@@ -551,7 +551,7 @@ See `MemberStatus` schema in [../client-api.md §3.1](../client-api.md#get-membe
 
 #### Errors
 
-`"only room members can perform this action"`, `"limit must be > 0 and <= room user count"`.
+`"only room members can perform this action"`, `"limit must be > 0 and <= room user count"`, `"room not found"`.
 
 **Emits:** None — reply only.
 
@@ -600,7 +600,7 @@ Synchronous RPC. Advances the caller's `lastSeenAt` and clears the per-subscript
 
 #### Errors
 
-`"only room members can perform this action"` (`forbidden`, `not_room_member`).
+`"only room members can perform this action"` (`forbidden`, `not_room_member`), `"room not found"` (`not_found`).
 
 **Emits:** [`subscription.update`](events.md#subscriptionupdate--membership--state-changes) (`action: "read"` — to the reader, non-bot only; not fired on early-return paths), [`message_read`](events.md#message_read-messagereadevent) (floor advance events — only when `Room.MinUserLastSeenAt` changes) → [events.md](events.md)
 

--- a/room-service/handler.go
+++ b/room-service/handler.go
@@ -551,6 +551,9 @@ func (h *Handler) requireMembershipAndGetRoom(ctx context.Context, account, room
 		return nil, fmt.Errorf("check room membership: %w", subErr)
 	}
 	if roomErr != nil {
+		if errors.Is(roomErr, ErrRoomNotFound) {
+			return nil, errRoomNotFound
+		}
 		return nil, fmt.Errorf("get room: %w", roomErr)
 	}
 	return room, nil
@@ -665,6 +668,9 @@ func (h *Handler) removeMember(c *natsrouter.Context, req model.RemoveMemberRequ
 	// Channel-only: DM/botDM removals are not supported.
 	room, err := h.store.GetRoom(ctx, roomID)
 	if err != nil {
+		if errors.Is(err, ErrRoomNotFound) {
+			return nil, errRoomNotFound
+		}
 		return nil, fmt.Errorf("get room: %w", err)
 	}
 	if room.Type != model.RoomTypeChannel {
@@ -762,6 +768,9 @@ func (h *Handler) updateRole(c *natsrouter.Context, req model.UpdateRoleRequest)
 	}
 	room, err := h.store.GetRoom(ctx, roomID)
 	if err != nil {
+		if errors.Is(err, ErrRoomNotFound) {
+			return nil, errRoomNotFound
+		}
 		return nil, fmt.Errorf("get room: %w", err)
 	}
 	if room.Type != model.RoomTypeChannel {
@@ -904,6 +913,9 @@ func (h *Handler) addMembers(c *natsrouter.Context, req model.AddMembersRequest)
 	// 3. Get room and guard on type
 	room, err := h.store.GetRoom(ctx, roomID)
 	if err != nil {
+		if errors.Is(err, ErrRoomNotFound) {
+			return nil, errRoomNotFound
+		}
 		return nil, fmt.Errorf("get room: %w", err)
 	}
 	if room.Type != model.RoomTypeChannel {
@@ -1411,6 +1423,9 @@ func (h *Handler) messageRead(c *natsrouter.Context) (*model.StatusReply, error)
 		return nil
 	})
 	if err := g.Wait(); err != nil {
+		if errors.Is(err, ErrRoomNotFound) {
+			return nil, errRoomNotFound
+		}
 		return nil, err
 	}
 
@@ -1996,7 +2011,7 @@ func (h *Handler) roomRename(c *natsrouter.Context, req model.RoomRenameRequest)
 
 	room, err := h.store.GetRoom(ctx, roomID)
 	if err != nil {
-		if errors.Is(err, mongo.ErrNoDocuments) {
+		if errors.Is(err, ErrRoomNotFound) {
 			return nil, errRoomNotFound
 		}
 		return nil, fmt.Errorf("get room: %w", err)
@@ -2068,7 +2083,7 @@ func (h *Handler) roomRestricted(c *natsrouter.Context, req model.RoomRestricted
 
 	room, err := h.store.GetRoom(ctx, req.RoomID)
 	if err != nil {
-		if errors.Is(err, mongo.ErrNoDocuments) {
+		if errors.Is(err, ErrRoomNotFound) {
 			return nil, errRoomNotFound
 		}
 		return nil, fmt.Errorf("get room: %w", err)
@@ -2523,7 +2538,9 @@ func (h *Handler) authorizeRoomAppRead(ctx context.Context, account, roomID stri
 	}
 	room, err := h.store.GetRoomAppRead(ctx, roomID)
 	if err != nil {
-		if errors.Is(err, mongo.ErrNoDocuments) {
+		// Deliberately not errRoomNotFound: a non-member must not learn
+		// whether the room exists.
+		if errors.Is(err, ErrRoomNotFound) {
 			return nil, errAppAccessDenied
 		}
 		return nil, fmt.Errorf("get room for app read: %w", err)

--- a/room-service/handler_test.go
+++ b/room-service/handler_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.uber.org/mock/gomock"
 
 	"github.com/hmchangw/chat/pkg/errcode"
@@ -5699,7 +5698,7 @@ func TestHandleRoomRename_Validation(t *testing.T) {
 			newName: "new-name",
 			setupStore: func(s *MockRoomStore) {
 				s.EXPECT().GetUser(gomock.Any(), "alice").Return(&model.User{Account: "alice"}, nil)
-				s.EXPECT().GetRoom(gomock.Any(), "r1").Return(nil, mongo.ErrNoDocuments)
+				s.EXPECT().GetRoom(gomock.Any(), "r1").Return(nil, fmt.Errorf("room %q: %w", "r1", ErrRoomNotFound))
 			},
 			wantErr: errRoomNotFound,
 		},
@@ -5837,7 +5836,7 @@ func TestHandleRoomRestricted_Validation(t *testing.T) {
 			req:  model.RoomRestrictedRequest{RoomID: "r1", Account: "admin1", Restricted: true},
 			setupStore: func(s *MockRoomStore) {
 				s.EXPECT().GetUser(gomock.Any(), "admin1").Return(&model.User{Account: "admin1", Roles: []model.UserRole{model.UserRoleAdmin}}, nil)
-				s.EXPECT().GetRoom(gomock.Any(), "r1").Return(nil, mongo.ErrNoDocuments)
+				s.EXPECT().GetRoom(gomock.Any(), "r1").Return(nil, fmt.Errorf("room %q: %w", "r1", ErrRoomNotFound))
 			},
 			wantErr: errRoomNotFound,
 		},
@@ -7110,7 +7109,7 @@ func TestHandler_authorizeRoomAppRead(t *testing.T) {
 						RoomID: "r1",
 					}, nil)
 				s.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
-					Return(nil, fmt.Errorf("room %q not found: %w", "r1", mongo.ErrNoDocuments))
+					Return(nil, fmt.Errorf("room %q: %w", "r1", ErrRoomNotFound))
 			},
 			wantErr: errAppAccessDenied,
 		},
@@ -7457,7 +7456,7 @@ func TestHandler_handleGetRoomAppTabs_RoomNotFound(t *testing.T) {
 	store.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
 		Return(&model.Subscription{User: model.SubscriptionUser{Account: "alice"}, RoomID: "r1"}, nil)
 	store.EXPECT().GetRoomAppRead(gomock.Any(), "r1").
-		Return(nil, fmt.Errorf("room %q not found: %w", "r1", mongo.ErrNoDocuments))
+		Return(nil, fmt.Errorf("room %q: %w", "r1", ErrRoomNotFound))
 
 	_, err := h.getRoomAppTabs(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
 	assert.ErrorIs(t, err, errAppAccessDenied)
@@ -8168,4 +8167,100 @@ func TestHandleCreateRoom_BotRequester_BotCounterpart_ChecksAppGate(t *testing.T
 		model.CreateRoomRequest{Users: []string{"helper.bot"}})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, errBotNotAvailable))
+}
+
+// A missing room must surface as errRoomNotFound (404) from every RPC that
+// loads one, not as an internal 500. The store signals it with ErrRoomNotFound;
+// these cases pin the mapping at each call site.
+func TestHandler_RoomNotFound_MapsTo404(t *testing.T) {
+	newTestHandler := func(store *MockRoomStore) *Handler {
+		return NewHandler(store, nil, nil, nil, "site-a", 1000, 500, 5*time.Second, 5,
+			func(context.Context, string, []byte, string) error { return nil },
+			nil, nil, 0, subject.RouteGlobal)
+	}
+	notFound := fmt.Errorf("room %q: %w", "r1", ErrRoomNotFound)
+
+	tests := []struct {
+		name       string
+		setupStore func(*MockRoomStore)
+		invoke     func(*Handler) error
+	}{
+		{
+			name: "removeMember",
+			setupStore: func(s *MockRoomStore) {
+				s.EXPECT().GetRoom(gomock.Any(), "r1").Return(nil, notFound)
+			},
+			invoke: func(h *Handler) error {
+				_, err := h.removeMember(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}),
+					model.RemoveMemberRequest{RoomID: "r1", Account: "alice"})
+				return err
+			},
+		},
+		{
+			name: "updateRole",
+			setupStore: func(s *MockRoomStore) {
+				s.EXPECT().GetRoom(gomock.Any(), "r1").Return(nil, notFound)
+			},
+			invoke: func(h *Handler) error {
+				_, err := h.updateRole(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}),
+					model.UpdateRoleRequest{RoomID: "r1", Account: "bob", NewRole: model.RoleUser})
+				return err
+			},
+		},
+		{
+			name: "addMembers",
+			setupStore: func(s *MockRoomStore) {
+				s.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
+					Return(&model.Subscription{RoomID: "r1", Roles: []model.Role{model.RoleOwner}}, nil)
+				s.EXPECT().GetRoom(gomock.Any(), "r1").Return(nil, notFound)
+			},
+			invoke: func(h *Handler) error {
+				_, err := h.addMembers(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}),
+					model.AddMembersRequest{RoomID: "r1", Users: []string{"bob"}})
+				return err
+			},
+		},
+		{
+			name: "messageRead",
+			setupStore: func(s *MockRoomStore) {
+				s.EXPECT().GetSubscription(gomock.Any(), "alice", "r1").
+					Return(&model.Subscription{RoomID: "r1"}, nil)
+				s.EXPECT().UpdateSubscriptionRead(gomock.Any(), "r1", "alice", gomock.Any()).
+					Return(0, nil).AnyTimes()
+				s.EXPECT().GetUserSiteID(gomock.Any(), "alice").Return("site-a", nil).AnyTimes()
+				s.EXPECT().GetRoom(gomock.Any(), "r1").Return(nil, notFound)
+			},
+			invoke: func(h *Handler) error {
+				_, err := h.messageRead(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+				return err
+			},
+		},
+		{
+			name: "listMemberStatuses",
+			setupStore: func(s *MockRoomStore) {
+				s.EXPECT().CheckMembership(gomock.Any(), "alice", "r1").Return(nil)
+				s.EXPECT().GetRoom(gomock.Any(), "r1").Return(nil, notFound)
+			},
+			invoke: func(h *Handler) error {
+				_, err := h.listMemberStatuses(ctxParams(map[string]string{"account": "alice", "roomID": "r1"}))
+				return err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			store := NewMockRoomStore(ctrl)
+			tc.setupStore(store)
+
+			err := tc.invoke(newTestHandler(store))
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, errRoomNotFound, "a missing room must map to the 404 sentinel, not a 500")
+			var ec *errcode.Error
+			require.ErrorAs(t, err, &ec)
+			assert.Equal(t, errcode.CodeNotFound, ec.Code, "wire code must be not_found")
+		})
+	}
 }

--- a/room-service/integration_test.go
+++ b/room-service/integration_test.go
@@ -162,6 +162,24 @@ func TestMongoStore_GetRoomAppRead_ProjectionFields_Integration(t *testing.T) {
 	assert.Zero(t, got.UserCount)
 }
 
+// A missing room must come back as the ErrRoomNotFound sentinel, never a raw
+// driver error — handlers map the sentinel to a 404 and would otherwise 500.
+func TestMongoStore_GetRoom_MissingRoom_Integration(t *testing.T) {
+	ctx := context.Background()
+	db := setupMongo(t)
+	store := NewMongoStore(db)
+
+	_, err := store.GetRoom(ctx, "nope")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrRoomNotFound)
+	assert.NotErrorIs(t, err, mongo.ErrNoDocuments, "the driver error must not leak past the store boundary")
+
+	_, err = store.GetRoomAppRead(ctx, "nope")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrRoomNotFound)
+	assert.NotErrorIs(t, err, mongo.ErrNoDocuments, "the driver error must not leak past the store boundary")
+}
+
 // TestMongoStore_GetSubscription_ProjectionFields_Integration pins the field
 // set that GetSubscription's projection must return: every Subscription field
 // read by any handler call site. Same guard rationale as the GetRoom variant.

--- a/room-service/store.go
+++ b/room-service/store.go
@@ -12,7 +12,7 @@ import (
 var (
 	ErrUserNotFound       = errors.New("user not found")                        // GetUser: no matching account
 	ErrAppNotFound        = errors.New("app not found")                         // GetApp: no matching bot account
-	ErrRoomNotFound       = errors.New("room not found")                        // UpdateRoomVisibility: no matching room
+	ErrRoomNotFound       = errors.New("room not found")                        // GetRoom/GetRoomAppRead/UpdateRoomVisibility: no matching room
 	ErrOwnerNotSubscribed = errors.New("owner account is no longer subscribed") // ApplySubscriptionRestriction: owner left
 )
 
@@ -59,6 +59,7 @@ type RoomBotAppEntry struct {
 }
 
 type RoomStore interface {
+	// GetRoom returns ErrRoomNotFound when no room matches; any other error is infra.
 	GetRoom(ctx context.Context, id string) (*model.Room, error)
 	// GetRoomAppRead fetches only _id/type/siteId; same error contract as GetRoom.
 	GetRoomAppRead(ctx context.Context, id string) (*model.Room, error)

--- a/room-service/store_mongo.go
+++ b/room-service/store_mongo.go
@@ -234,7 +234,10 @@ func (s *MongoStore) GetRoom(ctx context.Context, id string) (*model.Room, error
 	var room model.Room
 	opts := options.FindOne().SetProjection(roomReadProjection)
 	if err := s.rooms.FindOne(ctx, bson.M{"_id": id}, opts).Decode(&room); err != nil {
-		return nil, fmt.Errorf("room %q not found: %w", id, err)
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, fmt.Errorf("room %q: %w", id, ErrRoomNotFound)
+		}
+		return nil, fmt.Errorf("get room %q: %w", id, err)
 	}
 	return &room, nil
 }
@@ -243,7 +246,10 @@ func (s *MongoStore) GetRoomAppRead(ctx context.Context, id string) (*model.Room
 	var room model.Room
 	opts := options.FindOne().SetProjection(roomAppReadProjection)
 	if err := s.rooms.FindOne(ctx, bson.M{"_id": id}, opts).Decode(&room); err != nil {
-		return nil, fmt.Errorf("room %q not found: %w", id, err)
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, fmt.Errorf("room %q: %w", id, ErrRoomNotFound)
+		}
+		return nil, fmt.Errorf("get room %q for app read: %w", id, err)
 	}
 	return &room, nil
 }


### PR DESCRIPTION
## Problem

`GetRoom` wrapped **every** failure — Mongo timeouts and network errors included — in a `"room %q not found"` message and handed the raw driver error to callers:

```go
if err := s.rooms.FindOne(ctx, bson.M{"_id": id}, opts).Decode(&room); err != nil {
    return nil, fmt.Errorf("room %q not found: %w", id, err)
}
```

Two consequences:

1. An infra failure was labelled "not found", so a timeout read as a missing room in logs.
2. Callers had nothing to branch on but the driver's own `mongo.ErrNoDocuments`. Four RPCs didn't, and surfaced a genuinely missing room as `internal` (500), while two others returned 404 for the identical case. Clients could not distinguish "room gone" from "server broken".

`GetSubscription`, immediately below in the same file, already did this correctly.

## Change

Both `GetRoom` and `GetRoomAppRead` now branch on `mongo.ErrNoDocuments` and return the existing `ErrRoomNotFound` sentinel (`store.go:15`); infra failures keep a description of what the store was doing rather than a misleading "not found".

Every room-service call site maps the sentinel:

| Call site | Before | After |
|---|---|---|
| `removeMember`, `updateRole`, `addMembers`, `messageRead`, `requireMembershipAndGetRoom` (member.statuses) | 500 `internal` | **404 `not_found`** |
| `roomRename`, `roomRestricted` | 404, keyed off `mongo.ErrNoDocuments` | 404, keyed off the sentinel |
| `authorizeRoomAppRead` | `errAppAccessDenied` | unchanged — a non-member must not learn whether the room exists |

`publishThreadMessageReadEvent` is best-effort and only logs, so it is untouched.

A side effect worth noting: `handler_test.go` no longer imports the Mongo driver at all.

## Tests

TDD, and the red phase was genuinely observed this time — these are handler unit tests over a mock store, so they run in the normal gate. Before the fix, `TestHandler_RoomNotFound_MapsTo404` failed on all five subtests with chains like:

```
get room: room "r1": room not found      ← no *errcode.Error, collapses to 500
```

The test asserts both `errors.Is(err, errRoomNotFound)` and that the wire code is `errcode.CodeNotFound`.

Four pre-existing stubs encoded the *old* store contract (`GetRoom` returning `mongo.ErrNoDocuments`) and were updated to the new one — that's the contract change showing up where it should.

An integration test pins the store boundary itself: `ErrRoomNotFound` is returned and `mongo.ErrNoDocuments` does **not** leak past it. As with the last PR, integration tests could not be executed here — no Docker in this environment — so that one is compile-verified only. `make test-integration SERVICE=room-service` on a Docker-capable machine is worth running before merge.

## Docs

Five RPCs change wire behaviour (500 → 404), so per CLAUDE.md §5 both `docs/client-api.md` and its derived `docs/client-api/request-reply.md` document the new `not_found` case for Add Members, Remove Member, Update Member Role, Get Member Statuses and Mark Messages Read.

## Verification

- `make test SERVICE=room-service` — passes (`-race`)
- `make lint` — 0 issues
- `go vet` — clean under both tag sets
- `gosec` — clean

## Not included

`handler.go:789` and `:2026` still carry `errors.Is(err, mongo.ErrNoDocuments)` belt-and-braces checks, but those are on the *subscription* path, not this one. Removing them belongs with the broader store-boundary driver-leak cleanup rather than here.

This addresses two of the `high` findings from the room-service production-readiness audit (#410).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZFrWJvqo8jwe68736JmvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZFrWJvqo8jwe68736JmvB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Missing rooms are now consistently reported as a “room not found” error.
  - Room-related actions return the correct 404 response instead of an internal server error.
  - Access checks continue to protect room existence information from unauthorized members.

- **Documentation**
  - Documented “room not found” errors for membership, role, status, and message-read operations.
  - Clarified room lookup error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->