### PR TITLE
refactor(preview): drop the 500-rune content cap on room-list previews

### DIFF
--- a/broadcast-worker/preview_test.go
+++ b/broadcast-worker/preview_test.go
@@ -89,16 +89,13 @@ func TestPreviewSealer_SealInserted_CarriesTheMessageWithoutReadingAnything(t *t
 	assert.NotContains(t, string(body), "hello", "the body must not leak into the plaintext meta")
 }
 
-func TestPreviewSealer_SealInserted_TruncatesLongContent(t *testing.T) {
-	long := make([]rune, preview.MaxContentRunes+50)
-	for i := range long {
-		long[i] = 'x'
-	}
-	msg := &model.Message{ID: "m-1", Content: string(long), CreatedAt: time.Now().UTC()}
+func TestPreviewSealer_SealInserted_KeepsLongContent(t *testing.T) {
+	long := strings.Repeat("x", 5000)
+	msg := &model.Message{ID: "m-1", Content: long, CreatedAt: time.Now().UTC()}
 
 	sealed, err := testSealer(fakeCipher{}).sealInserted(context.Background(), msg, nil, nil)
 	require.NoError(t, err)
-	assert.Len(t, []rune(openSealed(t, sealed).Msg), preview.MaxContentRunes)
+	assert.Equal(t, long, openSealed(t, sealed).Msg, "the sealed body is the full content, never a snippet")
 }
 
 func TestPreviewSealer_SealInserted_RejectsUndecodableAttachment(t *testing.T) {

--- a/broadcast-worker/preview_test.go
+++ b/broadcast-worker/preview_test.go
@@ -90,7 +90,7 @@ func TestPreviewSealer_SealInserted_CarriesTheMessageWithoutReadingAnything(t *t
 }
 
 func TestPreviewSealer_SealInserted_KeepsLongContent(t *testing.T) {
-	long := strings.Repeat("x", 5000)
+	long := strings.Repeat("x", 600)
 	msg := &model.Message{ID: "m-1", Content: long, CreatedAt: time.Now().UTC()}
 
 	sealed, err := testSealer(fakeCipher{}).sealInserted(context.Background(), msg, nil, nil)

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -1064,7 +1064,7 @@ that preview.
 |---|---|---|
 | `messageId` | string | |
 | `sender` | [Participant](#participant) | `chineseName` is the sender's company name; `displayName` is the composed render-ready name (a bot sender's is its app name). |
-| `content` | string | Message content snippet, capped at 500 runes (longer bodies are truncated). On `subscription.list` (both transports) it is truncated further to a short preview — 50 characters by default, whole characters only, no ellipsis appended. |
+| `content` | string | Full message content (never truncated server-side beyond the message size limit). On `subscription.list` (both transports) it is truncated to a short preview — 50 characters by default, whole characters only, no ellipsis appended. |
 | `createdAt` | string | RFC 3339 timestamp. |
 | `attachments` | [Attachment](#attachment)[] | Optional. Omitted when the message has none. At most 10 — the room list renders a count, not the set. |
 | `mentions` | [Participant](#participant)[] | Optional. Mentioned users as wire Participants. Omitted when none. At most 20. |
@@ -3479,7 +3479,7 @@ The payload is flat (no zero-valued room fields):
 | `updatedAt` | string | RFC 3339 timestamp. |
 | `threadParentMessageId` | string | Optional. Set when the edited message is a thread reply — its presence lets the client tell a thread-reply edit from a top-level one. Omitted for top-level messages. |
 | `tshow` | boolean | Optional. For a thread reply, whether it is also shown in the main room timeline. Omitted when `false`. |
-| `previewMessage` | [PreviewMessage](#previewmessage) | Optional. The room's current preview after this edit (same resolution as `subscription.list`; `content` carries the 500-rune snippet, which list rows truncate further). **Omitted** for hidden thread-reply edits (`threadParentMessageId` set with `tshow` not true — not shown in the room timeline), or when the recompute could not complete. An edit never empties a room, so unlike `message_deleted` an omission here never means "no eligible message left". See [Reacting to a preview change](#reacting-to-a-preview-change). |
+| `previewMessage` | [PreviewMessage](#previewmessage) | Optional. The room's current preview after this edit (same resolution as `subscription.list`; `content` carries the full body, which list rows truncate). **Omitted** for hidden thread-reply edits (`threadParentMessageId` set with `tshow` not true — not shown in the room timeline), or when the recompute could not complete. An edit never empties a room, so unlike `message_deleted` an omission here never means "no eligible message left". See [Reacting to a preview change](#reacting-to-a-preview-change). |
 
 ```json
 {
@@ -3575,7 +3575,7 @@ The payload is flat:
 | `updatedAt` | string | RFC 3339 timestamp. |
 | `threadParentMessageId` | string | Optional. Set when the deleted message is a thread reply — its presence lets the client tell a thread-reply delete from a top-level one. Omitted for top-level messages. |
 | `tshow` | boolean | Optional. For a thread reply, whether it is also shown in the main room timeline. Omitted when `false`. |
-| `previewMessage` | [PreviewMessage](#previewmessage) | Optional. The room's current preview after this delete (same resolution as `subscription.list`; `content` carries the 500-rune snippet, which list rows truncate further). **Omitted** for hidden thread-reply deletes (`threadParentMessageId` set with `tshow` not true — not shown in the room timeline), when the room has no eligible message left (e.g. the deleted message was the last one), or when the recompute could not complete. See [Reacting to a preview change](#reacting-to-a-preview-change). |
+| `previewMessage` | [PreviewMessage](#previewmessage) | Optional. The room's current preview after this delete (same resolution as `subscription.list`; `content` carries the full body, which list rows truncate). **Omitted** for hidden thread-reply deletes (`threadParentMessageId` set with `tshow` not true — not shown in the room timeline), when the room has no eligible message left (e.g. the deleted message was the last one), or when the recompute could not complete. See [Reacting to a preview change](#reacting-to-a-preview-change). |
 
 ```json
 {

--- a/docs/client-api/events.md
+++ b/docs/client-api/events.md
@@ -620,7 +620,7 @@ Flat event — no zero-valued `RoomEvent` base fields. Triggered by
 | `updatedAt` | string | RFC 3339 timestamp. |
 | `threadParentMessageId` | string | Optional. Set when the edited message is a thread reply — lets the client tell a thread-reply edit from a top-level one. Omitted for top-level messages. |
 | `tshow` | boolean | Optional. For a thread reply, whether it is also shown in the main room timeline. Omitted when `false`. |
-| `previewMessage` | [PreviewMessage](../client-api.md#previewmessage) | Optional. The room's current preview after this edit (same resolution as `subscription.list`; `content` carries the 500-rune snippet, which list rows truncate further). **Omitted** for hidden thread-reply edits (`threadParentMessageId` set with `tshow` not true), or when the recompute could not complete. An edit never empties a room, so unlike `message_deleted` an omission here never means "no eligible message left". See [Reacting to a preview change](../client-api.md#reacting-to-a-preview-change). |
+| `previewMessage` | [PreviewMessage](../client-api.md#previewmessage) | Optional. The room's current preview after this edit (same resolution as `subscription.list`; `content` carries the full body, which list rows truncate). **Omitted** for hidden thread-reply edits (`threadParentMessageId` set with `tshow` not true), or when the recompute could not complete. An edit never empties a room, so unlike `message_deleted` an omission here never means "no eligible message left". See [Reacting to a preview change](../client-api.md#reacting-to-a-preview-change). |
 
 ```json
 {
@@ -671,7 +671,7 @@ Thread-reply deletes **additionally** emit a
 | `updatedAt` | string | RFC 3339 timestamp. |
 | `threadParentMessageId` | string | Optional. Set when the deleted message is a thread reply — lets the client tell a thread-reply delete from a top-level one. Omitted for top-level messages. |
 | `tshow` | boolean | Optional. For a thread reply, whether it is also shown in the main room timeline. Omitted when `false`. |
-| `previewMessage` | [PreviewMessage](../client-api.md#previewmessage) | Optional. The room's current preview after this delete (same resolution as `subscription.list`; `content` carries the 500-rune snippet, which list rows truncate further). **Omitted** for hidden thread-reply deletes (`threadParentMessageId` set with `tshow` not true), when the room has no eligible message left (e.g. the deleted message was the last one), or when the recompute could not complete. See [Reacting to a preview change](../client-api.md#reacting-to-a-preview-change). |
+| `previewMessage` | [PreviewMessage](../client-api.md#previewmessage) | Optional. The room's current preview after this delete (same resolution as `subscription.list`; `content` carries the full body, which list rows truncate). **Omitted** for hidden thread-reply deletes (`threadParentMessageId` set with `tshow` not true), when the room has no eligible message left (e.g. the deleted message was the last one), or when the recompute could not complete. See [Reacting to a preview change](../client-api.md#reacting-to-a-preview-change). |
 
 ```json
 {

--- a/history-service/internal/service/preview_walk_test.go
+++ b/history-service/internal/service/preview_walk_test.go
@@ -364,7 +364,7 @@ func TestPreviewWalk_ReadFailure_IsNotGone(t *testing.T) {
 	assert.False(t, gone)
 }
 
-// The preview carries render-ready enrichment: mapped participants, content capped.
+// The preview carries render-ready enrichment: mapped participants, full content.
 func TestPreviewWalk_EnrichesAndKeepsFullContent(t *testing.T) {
 	m := msgAt("m-1", 1)
 	m.Msg = strings.Repeat("x", 900)

--- a/history-service/internal/service/preview_walk_test.go
+++ b/history-service/internal/service/preview_walk_test.go
@@ -365,7 +365,7 @@ func TestPreviewWalk_ReadFailure_IsNotGone(t *testing.T) {
 }
 
 // The preview carries render-ready enrichment: mapped participants, content capped.
-func TestPreviewWalk_EnrichesAndTruncates(t *testing.T) {
+func TestPreviewWalk_EnrichesAndKeepsFullContent(t *testing.T) {
 	m := msgAt("m-1", 1)
 	m.Msg = strings.Repeat("x", 900)
 	m.Sender = models.Participant{ID: "u-1", Account: "alice", EngName: "Alice", CompanyName: "愛麗絲"}
@@ -379,7 +379,7 @@ func TestPreviewWalk_EnrichesAndTruncates(t *testing.T) {
 	assert.Equal(t, "Alice 愛麗絲", got.Sender.DisplayName)
 	require.Len(t, got.Mentions, 1)
 	assert.Equal(t, "bob", got.Mentions[0].Account)
-	assert.Len(t, []rune(got.Content), 500, "the room list renders a snippet, not the whole body")
+	assert.Equal(t, strings.Repeat("x", 900), got.Content, "the preview carries the full body; only user-service narrows it at read time")
 }
 
 // A quoted reply is ordinary user content and previews like any other message.

--- a/history-service/internal/service/rooms.go
+++ b/history-service/internal/service/rooms.go
@@ -296,7 +296,7 @@ func (s *HistoryService) toPreviewMessage(ctx context.Context, m *models.Message
 		}
 	}
 
-	// Through preview.Build, as the insert path does: otherwise a room's snippet length
+	// Through preview.Build, as the insert path does: otherwise a room's preview shape
 	// would depend on whether its preview last came from an insert or an edit.
 	return preview.Build(models.PreviewMessage{
 		MessageID:   m.MessageID,

--- a/pkg/model/message.go
+++ b/pkg/model/message.go
@@ -134,9 +134,9 @@ type RoomsGetRequest struct {
 }
 
 // PreviewMessage is a room's most-recent eligible message, enriched for the room-list
-// preview. Content is a snippet capped at preview.MaxContentRunes (500 runes) — no longer
-// the full body, so user-service's PREVIEW_CONTENT_CHARS truncation now narrows an
-// already-capped snippet. Sender/mentions carry render-ready wire Participants (a bot
+// preview. Content is the full message body (bounded only by the gatekeeper's message size
+// limit); user-service's PREVIEW_CONTENT_CHARS truncation is the only read-time narrowing.
+// Sender/mentions carry render-ready wire Participants (a bot
 // sender's displayName is its app name). Shared wire type: history-service's rooms.get RPC
 // produces it, user-service's subscription.list embeds it (SubscriptionRoom.PreviewMessage).
 // It is never stored — the room doc holds the split PreviewMeta + sealed body instead.

--- a/pkg/model/message.go
+++ b/pkg/model/message.go
@@ -134,10 +134,10 @@ type RoomsGetRequest struct {
 }
 
 // PreviewMessage is a room's most-recent eligible message, enriched for the room-list
-// preview. Content is the full message body (bounded only by the gatekeeper's message size
-// limit); user-service's PREVIEW_CONTENT_CHARS truncation is the only read-time narrowing.
-// Sender/mentions carry render-ready wire Participants (a bot
-// sender's displayName is its app name). Shared wire type: history-service's rooms.get RPC
+// preview. Content is the full message body, bounded only by the 20 KB message size limit;
+// user-service's PREVIEW_CONTENT_CHARS truncation is the only read-time narrowing.
+// Sender/mentions carry render-ready wire Participants (a bot sender's displayName is its
+// app name). Shared wire type: history-service's rooms.get RPC
 // produces it, user-service's subscription.list embeds it (SubscriptionRoom.PreviewMessage).
 // It is never stored — the room doc holds the split PreviewMeta + sealed body instead.
 type PreviewMessage struct {

--- a/pkg/preview/preview.go
+++ b/pkg/preview/preview.go
@@ -13,25 +13,23 @@ import (
 	"github.com/hmchangw/chat/pkg/model/cassandra"
 )
 
-// MaxContentRunes caps PreviewMessage.Content: the room list renders a snippet only.
-const MaxContentRunes = 500
-
 // MaxAttachments and MaxMentions cap the collections the room list renders as a count or
-// a couple of chips. Capping Content alone bounded the one field that was already the
-// smallest risk: attachments and mentions ride uncapped from the message, so a single
-// wide message could size the coalescer's buffered entry, the stored document and every
-// reader's materialization of it at once. One cap at compose time bounds all three (#290).
+// a couple of chips. Content is deliberately NOT capped: the room list gets the full body
+// (bounded upstream by the gatekeeper's message size limit). Attachments and mentions ride
+// uncapped from the message, so a single wide message could size the coalescer's buffered
+// entry, the stored document and every reader's materialization of it at once. One cap at
+// compose time bounds both (#290).
 const (
 	MaxAttachments = 10
 	MaxMentions    = 20
 )
 
-// Build normalizes a composed preview: truncated content, UTC timestamp. Takes
-// PreviewMessage itself so a new field cannot silently default on every write path.
+// Build normalizes a composed preview: capped collections, UTC timestamp. Content passes
+// through untouched. Takes PreviewMessage itself so a new field cannot silently default on
+// every write path.
 //
 //nolint:gocritic // hugeParam: PreviewMessage is the stored/wire shape itself; by-value keeps callers simple and the copy cost is negligible.
 func Build(p model.PreviewMessage) model.PreviewMessage {
-	p.Content = truncateContent(p.Content)
 	// Copy, don't reslice. Reslicing keeps the ORIGINAL backing array reachable, tail
 	// included, and this value is retained by Sealed.Meta and by the read cache — so the
 	// cap would bound the length while pinning exactly the memory it exists to bound.
@@ -43,21 +41,6 @@ func Build(p model.PreviewMessage) model.PreviewMessage {
 	}
 	p.CreatedAt = p.CreatedAt.UTC()
 	return p
-}
-
-// truncateContent caps s at MaxContentRunes runes (never splitting a rune).
-func truncateContent(s string) string {
-	// Byte length bounds rune count, so the common short message needs no scan.
-	if len(s) <= MaxContentRunes {
-		return s
-	}
-	r := []rune(s)
-	if len(r) <= MaxContentRunes {
-		// Multi-byte but within the cap — return s rather than re-encoding it.
-		return s
-	}
-	// string() copies deliberately: slicing would pin the whole 20KB body in cache.
-	return string(r[:MaxContentRunes])
 }
 
 // Eligible reports whether a message may represent its room — system and deleted ones

--- a/pkg/preview/preview.go
+++ b/pkg/preview/preview.go
@@ -14,11 +14,9 @@ import (
 )
 
 // MaxAttachments and MaxMentions cap the collections the room list renders as a count or
-// a couple of chips. Content is deliberately NOT capped: the room list gets the full body
-// (bounded upstream by the gatekeeper's message size limit). Attachments and mentions ride
-// uncapped from the message, so a single wide message could size the coalescer's buffered
-// entry, the stored document and every reader's materialization of it at once. One cap at
-// compose time bounds both (#290).
+// a couple of chips. They ride uncapped from the message, so a single wide message could
+// size the coalescer's buffered entry, the stored document and every reader's
+// materialization of it at once. One cap at compose time bounds both (#290).
 const (
 	MaxAttachments = 10
 	MaxMentions    = 20

--- a/pkg/preview/preview_test.go
+++ b/pkg/preview/preview_test.go
@@ -17,33 +17,10 @@ import (
 	"github.com/hmchangw/chat/pkg/model/cassandra"
 )
 
-func TestTruncateContent_RuneBoundaries(t *testing.T) {
-	tests := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{"short passes through", "hello", "hello"},
-		{"exactly at cap unchanged", strings.Repeat("a", MaxContentRunes), strings.Repeat("a", MaxContentRunes)},
-		{"over cap truncated", strings.Repeat("a", MaxContentRunes+1), strings.Repeat("a", MaxContentRunes)},
-		{"multi-byte runes counted as runes not bytes", strings.Repeat("好", MaxContentRunes+3), strings.Repeat("好", MaxContentRunes)},
-		// 3 bytes per rune, so this is 3x over the cap in BYTES but exactly at it
-		// in runes: it must come back untouched.
-		{"multi-byte exactly at cap unchanged", strings.Repeat("好", MaxContentRunes), strings.Repeat("好", MaxContentRunes)},
-		{"multi-byte over the byte cap but under the rune cap", strings.Repeat("好", 200), strings.Repeat("好", 200)},
-		{"empty stays empty", "", ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, truncateContent(tt.in))
-		})
-	}
-}
-
-func TestBuild_TruncatesAndNormalizesUTC(t *testing.T) {
+func TestBuild_KeepsContentAndNormalizesUTC(t *testing.T) {
 	loc, err := time.LoadLocation("Asia/Taipei")
 	require.NoError(t, err)
-	long := strings.Repeat("x", MaxContentRunes+50)
+	long := strings.Repeat("好", 5000)
 	got := Build(model.PreviewMessage{
 		MessageID: "m1",
 		Sender:    model.Participant{Account: "alice"},
@@ -51,7 +28,7 @@ func TestBuild_TruncatesAndNormalizesUTC(t *testing.T) {
 		CreatedAt: time.Date(2026, 8, 5, 18, 0, 0, 0, loc),
 	})
 	assert.Equal(t, "m1", got.MessageID)
-	assert.Equal(t, strings.Repeat("x", MaxContentRunes), got.Content)
+	assert.Equal(t, long, got.Content, "content is never truncated: the room list gets the full body")
 	assert.Equal(t, time.UTC, got.CreatedAt.Location())
 }
 

--- a/pkg/preview/preview_test.go
+++ b/pkg/preview/preview_test.go
@@ -20,7 +20,7 @@ import (
 func TestBuild_KeepsContentAndNormalizesUTC(t *testing.T) {
 	loc, err := time.LoadLocation("Asia/Taipei")
 	require.NoError(t, err)
-	long := strings.Repeat("好", 5000)
+	long := strings.Repeat("好", 600)
 	got := Build(model.PreviewMessage{
 		MessageID: "m1",
 		Sender:    model.Participant{Account: "alice"},


### PR DESCRIPTION
## Summary

- `pkg/preview.Build` no longer truncates `Content` to 500 runes. Both writers route through it — `broadcast-worker`'s `sealInserted` (insert path) and `history-service`'s `toPreviewMessage` (the `rooms.get` walk that `user-service` consumes, plus warm-back and the `message_edited` / `message_deleted` event previews) — so removing the one implementation clears every path.
- Preview `content` is now the full message body, bounded only by the 20 KB message size limit.
- `user-service`'s read-time `PREVIEW_CONTENT_CHARS` narrowing (default 50, `0` disables) is deliberately **kept** as the only remaining truncation.
- Tests rewritten to assert content passes through untouched; `docs/client-api.md` and `docs/client-api/events.md` updated (five "500 runes" mentions).

## Things to know

- **Oversize `rooms.get` replies** are already handled: natsrouter turns a `max_payload` overflow into `ResponseTooLarge`, and `user-service`'s `roomsGetSplitting` halves and retries on it. Cost is a few extra RPCs in the extreme case, not lost previews.
- **`message_edited` / `message_deleted`** events embedding a preview top out around 40 KB, well under the 128 KB broker limit.
- **Memory ceiling** of `history-service`'s `PreviewCache` (`HISTORY_PREVIEW_CACHE_SIZE`, default 50000) and `broadcast-worker`'s pending-preview buffer scales with body size; the pathological worst case is ~10x the previous bound. Lower the cache size via env if that matters for a deployment — no code change needed.
- **Stored data**: previews already sealed at 500 runes stay readable and refresh on the room's next message.

## Test plan

- [x] `make test SERVICE=pkg/preview`
- [x] `make test SERVICE=broadcast-worker`
- [x] `make test SERVICE=history-service`
- [x] `make test SERVICE=user-service`
- [x] `make lint` — the only remaining issue (`user-service/mongorepo/subscriptions_lite_test.go:70`, govet inline) is pre-existing on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Full message content is now preserved in message previews, up to the standard message size limit.
  * Message list rows continue to display shortened content where applicable.
  * Updated message event and client API documentation to reflect full-content previews.
* **Bug Fixes**
  * Long messages in previews are no longer truncated prematurely, including messages containing multi-byte characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->