### PR TITLE
feat(history-service): add PREVIEW_WARMBACK_ENABLED kill switch

### DIFF
--- a/history-service/cmd/main.go
+++ b/history-service/cmd/main.go
@@ -362,15 +362,14 @@ func main() {
 	} else {
 		slog.Warn("page trimming DISABLED — oversize replies fail with response_too_large")
 	}
+	if !cfg.PreviewWarmBackEnabled {
+		slog.Warn("preview warm-back DISABLED — rooms without a stored preview re-walk Cassandra once per preview-cache TTL")
+	}
 	opts = append(opts, service.WithPageBudget(pageBudget))
 
 	// The service reads the tier on the degraded path; the seeder above writes it.
 	if roomTimes != nil {
 		opts = append(opts, service.WithRoomTimesCache(roomTimes))
-	}
-
-	if !cfg.PreviewWarmBackEnabled {
-		slog.Warn("preview warm-back DISABLED — rooms without a stored preview re-walk Cassandra on every rooms.get")
 	}
 
 	svc := service.New(cassRepo, subSource, roomSource, pub, threadRoomRepo, threadSubRepo, userSource, appRepo, &cfg, opts...)

--- a/history-service/cmd/main.go
+++ b/history-service/cmd/main.go
@@ -369,6 +369,10 @@ func main() {
 		opts = append(opts, service.WithRoomTimesCache(roomTimes))
 	}
 
+	if !cfg.PreviewWarmBackEnabled {
+		slog.Warn("preview warm-back DISABLED — rooms without a stored preview re-walk Cassandra on every rooms.get")
+	}
+
 	svc := service.New(cassRepo, subSource, roomSource, pub, threadRoomRepo, threadSubRepo, userSource, appRepo, &cfg, opts...)
 
 	// Default middleware chain (Recovery, RequestID, Logging) plus this service's

--- a/history-service/deploy/docker-compose.yml
+++ b/history-service/deploy/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       # falls back to its response_too_large retry.
       - PAGE_TRIMMING_ENABLED=${PAGE_TRIMMING_ENABLED:-true}
       # false withholds the background write that stores a walk-resolved preview
-      # back onto the room doc; rooms.get still serves it, but every room without
-      # a stored preview re-walks Cassandra on every read.
+      # back onto the room doc; rooms.get still serves it, but a room without a
+      # stored preview re-walks Cassandra once per HISTORY_PREVIEW_CACHE_TTL.
       - PREVIEW_WARMBACK_ENABLED=${PREVIEW_WARMBACK_ENABLED:-true}
       # Dev-only pprof profiling on the health port (off by default). Flip on
       # stack-wide for a profiling session with `PPROF_ENABLED=true make up`.

--- a/history-service/deploy/docker-compose.yml
+++ b/history-service/deploy/docker-compose.yml
@@ -16,6 +16,10 @@ services:
       # false ships pages whole and lets the broker refuse them, so the client
       # falls back to its response_too_large retry.
       - PAGE_TRIMMING_ENABLED=${PAGE_TRIMMING_ENABLED:-true}
+      # false withholds the background write that stores a walk-resolved preview
+      # back onto the room doc; rooms.get still serves it, but every room without
+      # a stored preview re-walks Cassandra on every read.
+      - PREVIEW_WARMBACK_ENABLED=${PREVIEW_WARMBACK_ENABLED:-true}
       # Dev-only pprof profiling on the health port (off by default). Flip on
       # stack-wide for a profiling session with `PPROF_ENABLED=true make up`.
       - PPROF_ENABLED=${PPROF_ENABLED:-false}

--- a/history-service/deploy/docker-compose.yml
+++ b/history-service/deploy/docker-compose.yml
@@ -16,9 +16,8 @@ services:
       # false ships pages whole and lets the broker refuse them, so the client
       # falls back to its response_too_large retry.
       - PAGE_TRIMMING_ENABLED=${PAGE_TRIMMING_ENABLED:-true}
-      # false withholds the background write that stores a walk-resolved preview
-      # back onto the room doc; rooms.get still serves it, but a room without a
-      # stored preview re-walks Cassandra once per HISTORY_PREVIEW_CACHE_TTL.
+      # false withholds the warm-back write; rooms.get still serves the preview, but a
+      # room without a stored one re-walks Cassandra once per HISTORY_PREVIEW_CACHE_TTL.
       - PREVIEW_WARMBACK_ENABLED=${PREVIEW_WARMBACK_ENABLED:-true}
       # Dev-only pprof profiling on the health port (off by default). Flip on
       # stack-wide for a profiling session with `PPROF_ENABLED=true make up`.

--- a/history-service/internal/config/config.go
+++ b/history-service/internal/config/config.go
@@ -159,17 +159,8 @@ type Config struct {
 	// rooms can pin; overflow sheds the write, which the next read re-derives.
 	// Non-positive takes the built-in default for either.
 	//
-	// PreviewWarmBackEnabled is an operator kill switch, on by default: warm-back is
-	// what stops the lazy walk repeating forever, so turning it off leaves every room
-	// without a stored preview re-walking Cassandra once per preview-cache TTL — on
-	// every read where that cache is off, or where the walk resolves nothing (only
-	// positives are cached). It exists for
-	// the case where that read cost is preferable to the write cost — an ailing Mongo,
-	// or a site where the eager writer is being re-cut — not as a tuning knob. Off
-	// withholds only this optional write: the walk still runs and the client still
-	// gets its preview, and the mutation path's repair (persistMutatedPreview), which
-	// is correctness rather than optimization, is untouched. The sizes above are
-	// ignored when it is off.
+	// Enabled is a kill switch, not a tuning knob: off trades the write for a re-walk
+	// per preview-cache TTL. persistMutatedPreview's repair is correctness, so unaffected.
 	PreviewWarmBackEnabled bool `env:"PREVIEW_WARMBACK_ENABLED" envDefault:"true"`
 	PreviewWarmBackWorkers int  `env:"PREVIEW_WARMBACK_WORKERS" envDefault:"8"`
 	PreviewWarmBackQueue   int  `env:"PREVIEW_WARMBACK_QUEUE"   envDefault:"1024"`

--- a/history-service/internal/config/config.go
+++ b/history-service/internal/config/config.go
@@ -157,10 +157,20 @@ type Config struct {
 	// Background writer that stores walk-resolved previews back onto the room doc,
 	// off the request path. Queue depth is what bounds the memory a burst of cold
 	// rooms can pin; overflow sheds the write, which the next read re-derives.
-	// Non-positive takes the built-in default for either — warm-back is what keeps
-	// the lazy walk from repeating forever, so there is no disable value.
-	PreviewWarmBackWorkers int `env:"PREVIEW_WARMBACK_WORKERS" envDefault:"8"`
-	PreviewWarmBackQueue   int `env:"PREVIEW_WARMBACK_QUEUE"   envDefault:"1024"`
+	// Non-positive takes the built-in default for either.
+	//
+	// PreviewWarmBackEnabled is an operator kill switch, on by default: warm-back is
+	// what stops the lazy walk repeating forever, so turning it off leaves every room
+	// without a stored preview re-walking Cassandra on every rooms.get. It exists for
+	// the case where that read cost is preferable to the write cost — an ailing Mongo,
+	// or a site where the eager writer is being re-cut — not as a tuning knob. Off
+	// withholds only this optional write: the walk still runs and the client still
+	// gets its preview, and the mutation path's repair (persistMutatedPreview), which
+	// is correctness rather than optimization, is untouched. The sizes above are
+	// ignored when it is off.
+	PreviewWarmBackEnabled bool `env:"PREVIEW_WARMBACK_ENABLED" envDefault:"true"`
+	PreviewWarmBackWorkers int  `env:"PREVIEW_WARMBACK_WORKERS" envDefault:"8"`
+	PreviewWarmBackQueue   int  `env:"PREVIEW_WARMBACK_QUEUE"   envDefault:"1024"`
 
 	Atrest atrest.Config      // env vars are already prefixed ATREST_*
 	Vault  atrest.VaultConfig // env vars are already prefixed (VAULT_*, ATREST_VAULT_*)

--- a/history-service/internal/config/config.go
+++ b/history-service/internal/config/config.go
@@ -161,7 +161,9 @@ type Config struct {
 	//
 	// PreviewWarmBackEnabled is an operator kill switch, on by default: warm-back is
 	// what stops the lazy walk repeating forever, so turning it off leaves every room
-	// without a stored preview re-walking Cassandra on every rooms.get. It exists for
+	// without a stored preview re-walking Cassandra once per preview-cache TTL — on
+	// every read where that cache is off, or where the walk resolves nothing (only
+	// positives are cached). It exists for
 	// the case where that read cost is preferable to the write cost — an ailing Mongo,
 	// or a site where the eager writer is being re-cut — not as a tuning knob. Off
 	// withholds only this optional write: the walk still runs and the client still

--- a/history-service/internal/config/config_test.go
+++ b/history-service/internal/config/config_test.go
@@ -142,12 +142,16 @@ func TestValidate_RejectsNegativeWarmBackSizes(t *testing.T) {
 	}
 }
 
-// Zero is "take the default", not "disable": warm-back is what stops the lazy walk
-// repeating forever, so the wiring never turns it off.
+// Zero is "take the default", not "disable" — disabling is PREVIEW_WARMBACK_ENABLED's job,
+// and validate says nothing about it: the sizes are genuinely ignored when it is off, so
+// rejecting the combination would invent a constraint.
 func TestValidate_AcceptsZeroWarmBackSizesAsDefaults(t *testing.T) {
 	cfg := baseValid()
 	cfg.PreviewWarmBackWorkers = 0
 	cfg.PreviewWarmBackQueue = 0
+	require.NoError(t, validate(&cfg))
+
+	cfg.PreviewWarmBackEnabled = false
 	require.NoError(t, validate(&cfg))
 }
 
@@ -505,14 +509,4 @@ func TestLoad_PreviewWarmBackEnabled(t *testing.T) {
 			assert.Equal(t, tc.want, cfg.PreviewWarmBackEnabled)
 		})
 	}
-}
-
-// Sizes are ignored when the toggle is off, so an off deployment must not be held
-// to the same bounds — validate has nothing extra to say about the combination.
-func TestValidate_AcceptsDisabledWarmBack(t *testing.T) {
-	cfg := baseValid()
-	cfg.PreviewWarmBackEnabled = false
-	cfg.PreviewWarmBackWorkers = 0
-	cfg.PreviewWarmBackQueue = 0
-	require.NoError(t, validate(&cfg))
 }

--- a/history-service/internal/config/config_test.go
+++ b/history-service/internal/config/config_test.go
@@ -25,6 +25,7 @@ func baseValid() Config {
 		PreviewKeyEpoch:        1,
 		PreviewCacheSize:       50000,
 		PreviewCacheTTL:        10 * time.Second,
+		PreviewWarmBackEnabled: true,
 		PreviewWarmBackWorkers: 8,
 		PreviewWarmBackQueue:   1024,
 		// ServerSelectionTimeout is this branch's: a stopped Mongo goes quiet
@@ -476,4 +477,42 @@ func TestLoad_KeyReadPreferenceWireName(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "nearest", cfg.Mongo.KeyReadPreference,
 		"the field must bind to MONGO_KEY_READ_PREFERENCE via the MONGO_ envPrefix")
+}
+
+// The warm-back writer is a kill switch, not a tuning knob: on unless an operator
+// turns it off, so a fresh deployment keeps repairing cold rooms without being told to.
+func TestLoad_PreviewWarmBackEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{name: "defaults to enabled", env: "", want: true},
+		{name: "disabled by the operator", env: "false", want: false},
+		{name: "explicitly enabled", env: "true", want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setRequiredEnv(t)
+			if tc.env == "" {
+				testutil.UnsetEnv(t, "PREVIEW_WARMBACK_ENABLED")
+			} else {
+				t.Setenv("PREVIEW_WARMBACK_ENABLED", tc.env)
+			}
+
+			cfg, err := Load()
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, cfg.PreviewWarmBackEnabled)
+		})
+	}
+}
+
+// Sizes are ignored when the toggle is off, so an off deployment must not be held
+// to the same bounds — validate has nothing extra to say about the combination.
+func TestValidate_AcceptsDisabledWarmBack(t *testing.T) {
+	cfg := baseValid()
+	cfg.PreviewWarmBackEnabled = false
+	cfg.PreviewWarmBackWorkers = 0
+	cfg.PreviewWarmBackQueue = 0
+	require.NoError(t, validate(&cfg))
 }

--- a/history-service/internal/config/config_test.go
+++ b/history-service/internal/config/config_test.go
@@ -142,9 +142,7 @@ func TestValidate_RejectsNegativeWarmBackSizes(t *testing.T) {
 	}
 }
 
-// Zero is "take the default", not "disable" — disabling is PREVIEW_WARMBACK_ENABLED's job,
-// and validate says nothing about it: the sizes are genuinely ignored when it is off, so
-// rejecting the combination would invent a constraint.
+// Zero is "take the default"; disabling is PREVIEW_WARMBACK_ENABLED's job, which validate ignores.
 func TestValidate_AcceptsZeroWarmBackSizesAsDefaults(t *testing.T) {
 	cfg := baseValid()
 	cfg.PreviewWarmBackWorkers = 0
@@ -483,8 +481,7 @@ func TestLoad_KeyReadPreferenceWireName(t *testing.T) {
 		"the field must bind to MONGO_KEY_READ_PREFERENCE via the MONGO_ envPrefix")
 }
 
-// The warm-back writer is a kill switch, not a tuning knob: on unless an operator
-// turns it off, so a fresh deployment keeps repairing cold rooms without being told to.
+// On unless an operator turns it off, so a fresh deployment self-heals cold rooms.
 func TestLoad_PreviewWarmBackEnabled(t *testing.T) {
 	tests := []struct {
 		name string

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -43,8 +43,7 @@ func newRoomsServiceWithWarmer(t *testing.T, warmWorkers, warmQueue int, opts ..
 // disableWarmBack turns the background preview writer off, the way an operator does.
 func disableWarmBack(c *config.Config) { c.PreviewWarmBackEnabled = false }
 
-// newRoomsServiceWithConfig builds a service whose config the caller adjusts first, for the
-// tests that flip a toggle rather than size a queue. A nil tweak takes the defaults below.
+// newRoomsServiceWithConfig lets a caller adjust the config first; nil takes the defaults.
 func newRoomsServiceWithConfig(t *testing.T, tweak func(*config.Config), opts ...service.Option) (*service.HistoryService, *mocks.MockMessageRepository, *mocks.MockRoomRepository) {
 	ctrl := gomock.NewController(t)
 	msgs := mocks.NewMockMessageRepository(ctrl)
@@ -652,9 +651,7 @@ func TestHistoryService_RoomsGet_CancellationDuringTheWalkIsAnErrorNotAPartialAn
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
-// PREVIEW_WARMBACK_ENABLED=false withholds the optional write, not the read. Distinct from
-// the after-Close test above: that one sheds inside a live warmer, this one pins that the
-// no-op is what New installs.
+// The toggle withholds the write, not the read; unlike the after-Close test, this pins the no-op.
 func TestHistoryService_RoomsGet_WarmBackDisabledStillServesTheWalkedPreview(t *testing.T) {
 	svc, msgs, rooms := newRoomsServiceWithConfig(t, disableWarmBack)
 	walked := walkedMsg("r1", "m-walked", "resolved lazily")
@@ -663,21 +660,17 @@ func TestHistoryService_RoomsGet_WarmBackDisabledStillServesTheWalkedPreview(t *
 		Return(map[string]mongorepo.RoomTimes{"r1": storedRow(nil)}, nil)
 	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(makePage([]models.Message{walked}, false), nil)
-	// No SetPreviewMessage expectation: gomock fails the test if the write is attempted,
-	// which is the whole point of the toggle.
+	// No SetPreviewMessage expectation: gomock fails if the write is attempted.
 
 	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
 	require.NoError(t, err)
 	assert.Equal(t, "m-walked", resp.Rooms["r1"].MessageID)
 }
 
-// The no-op holds no queue and no workers, so shutdown must not wait on any — and Close
-// must stay safe to call, twice, rather than becoming conditional at the call site.
+// The no-op has nothing to drain: Close must stay fast and safe to call twice.
 func TestHistoryService_Close_DisabledWarmBackDrainsImmediately(t *testing.T) {
 	svc, _, _ := newRoomsServiceWithConfig(t, disableWarmBack)
 
-	// No workers to wait on, so a tight budget is ample — a disabled writer must not be
-	// able to hold shutdown. Called twice: Close stays idempotent rather than conditional.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	require.NoError(t, svc.Close(ctx))

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -35,6 +35,17 @@ func newRoomsService(t *testing.T, opts ...service.Option) (*service.HistoryServ
 // so every caller drains on cleanup — that is what makes the mock's call count
 // deterministic. Registered after gomock's own cleanup so it runs first (LIFO).
 func newRoomsServiceWithWarmer(t *testing.T, warmWorkers, warmQueue int, opts ...service.Option) (*service.HistoryService, *mocks.MockMessageRepository, *mocks.MockRoomRepository) {
+	return newRoomsServiceWithConfig(t, func(c *config.Config) {
+		c.PreviewWarmBackWorkers, c.PreviewWarmBackQueue = warmWorkers, warmQueue
+	}, opts...)
+}
+
+// disableWarmBack turns the background preview writer off, the way an operator does.
+func disableWarmBack(c *config.Config) { c.PreviewWarmBackEnabled = false }
+
+// newRoomsServiceWithConfig builds a service whose config the caller adjusts first, for the
+// tests that flip a toggle rather than size a queue. A nil tweak takes the defaults below.
+func newRoomsServiceWithConfig(t *testing.T, tweak func(*config.Config), opts ...service.Option) (*service.HistoryService, *mocks.MockMessageRepository, *mocks.MockRoomRepository) {
 	ctrl := gomock.NewController(t)
 	msgs := mocks.NewMockMessageRepository(ctrl)
 	subs := mocks.NewMockSubscriptionRepository(ctrl)
@@ -46,7 +57,10 @@ func newRoomsServiceWithWarmer(t *testing.T, warmWorkers, warmQueue int, opts ..
 	apps := mocks.NewMockAppStore(ctrl)
 	cfg := &config.Config{
 		MessageHistoryFloorDays: 90, LargeRoomThreshold: 500, MaxPinnedPerRoom: 10, PinEnabled: true,
-		PreviewWarmBackWorkers: warmWorkers, PreviewWarmBackQueue: warmQueue,
+		PreviewWarmBackEnabled: true,
+	}
+	if tweak != nil {
+		tweak(cfg)
 	}
 	svc := closeOnCleanup(t, service.New(msgs, subs, rooms, pub, threadRooms, threadSubs, users, apps, cfg, opts...))
 	return svc, msgs, rooms
@@ -636,4 +650,36 @@ func TestHistoryService_RoomsGet_CancellationDuringTheWalkIsAnErrorNotAPartialAn
 	_, err := svc.RoomsGet(rc, models.RoomsGetRequest{RoomIDs: []string{"r1"}})
 	require.Error(t, err, "a cancelled request must not return a partial map as success")
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// PREVIEW_WARMBACK_ENABLED=false is an operator kill switch for the optional write, not
+// for the read: the walk still resolves and the client still gets its preview. Only the
+// self-healing write back onto the room doc is withheld, so the room re-walks next time.
+func TestHistoryService_RoomsGet_WarmBackDisabledStillServesTheWalkedPreview(t *testing.T) {
+	svc, msgs, rooms := newRoomsServiceWithConfig(t, disableWarmBack)
+	walked := walkedMsg("r1", "m-walked", "resolved lazily")
+
+	rooms.EXPECT().GetRoomTimesByIDs(gomock.Any(), gomock.Any()).
+		Return(map[string]mongorepo.RoomTimes{"r1": storedRow(nil)}, nil)
+	msgs.EXPECT().GetMessagesBefore(gomock.Any(), "r1", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(makePage([]models.Message{walked}, false), nil)
+	// No SetPreviewMessage expectation: gomock fails the test if the write is attempted,
+	// which is the whole point of the toggle.
+
+	resp, err := svc.RoomsGet(roomsCtx(), models.RoomsGetRequest{RoomIDs: []string{"r1"}})
+	require.NoError(t, err)
+	assert.Equal(t, "m-walked", resp.Rooms["r1"].MessageID)
+}
+
+// A disabled writer starts no workers, so shutdown must not wait on any — and Close must
+// stay safe to call, twice, rather than becoming conditional at the call site.
+func TestHistoryService_Close_DisabledWarmBackDrainsImmediately(t *testing.T) {
+	svc, _, _ := newRoomsServiceWithConfig(t, disableWarmBack)
+
+	// No workers to wait on, so a tight budget is ample — a disabled writer must not be
+	// able to hold shutdown. Called twice: Close stays idempotent rather than conditional.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, svc.Close(ctx))
+	require.NoError(t, svc.Close(ctx))
 }

--- a/history-service/internal/service/rooms_test.go
+++ b/history-service/internal/service/rooms_test.go
@@ -27,7 +27,7 @@ import (
 
 // newRoomsService builds a service with bare mocks; WithPreviewCache exercises the cache.
 func newRoomsService(t *testing.T, opts ...service.Option) (*service.HistoryService, *mocks.MockMessageRepository, *mocks.MockRoomRepository) {
-	return newRoomsServiceWithWarmer(t, 0, 0, opts...)
+	return newRoomsServiceWithConfig(t, nil, opts...)
 }
 
 // newRoomsServiceWithWarmer sizes the background preview writer, for the tests that assert
@@ -652,9 +652,9 @@ func TestHistoryService_RoomsGet_CancellationDuringTheWalkIsAnErrorNotAPartialAn
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
-// PREVIEW_WARMBACK_ENABLED=false is an operator kill switch for the optional write, not
-// for the read: the walk still resolves and the client still gets its preview. Only the
-// self-healing write back onto the room doc is withheld, so the room re-walks next time.
+// PREVIEW_WARMBACK_ENABLED=false withholds the optional write, not the read. Distinct from
+// the after-Close test above: that one sheds inside a live warmer, this one pins that the
+// no-op is what New installs.
 func TestHistoryService_RoomsGet_WarmBackDisabledStillServesTheWalkedPreview(t *testing.T) {
 	svc, msgs, rooms := newRoomsServiceWithConfig(t, disableWarmBack)
 	walked := walkedMsg("r1", "m-walked", "resolved lazily")
@@ -671,8 +671,8 @@ func TestHistoryService_RoomsGet_WarmBackDisabledStillServesTheWalkedPreview(t *
 	assert.Equal(t, "m-walked", resp.Rooms["r1"].MessageID)
 }
 
-// A disabled writer starts no workers, so shutdown must not wait on any — and Close must
-// stay safe to call, twice, rather than becoming conditional at the call site.
+// The no-op holds no queue and no workers, so shutdown must not wait on any — and Close
+// must stay safe to call, twice, rather than becoming conditional at the call site.
 func TestHistoryService_Close_DisabledWarmBackDrainsImmediately(t *testing.T) {
 	svc, _, _ := newRoomsServiceWithConfig(t, disableWarmBack)
 

--- a/history-service/internal/service/service.go
+++ b/history-service/internal/service/service.go
@@ -181,8 +181,9 @@ type HistoryService struct {
 	pinEnabled         bool // from PIN_ENABLED env var; false disables pin/unpin globally
 	previewCache       PreviewCache
 	// warmer stores walk-resolved previews off the request path; Close drains it. Never
-	// nil — PREVIEW_WARMBACK_ENABLED=false yields an inert one, so Submit needs no guard.
-	warmer *previewWarmer
+	// nil — PREVIEW_WARMBACK_ENABLED=false installs the no-op, so the read path needs no
+	// guard and shutdown stays unconditional.
+	warmer previewWriter
 	// pageBudget caps a paginated reply so it is trimmed to fit the broker
 	// rather than refused by it. Zero value disables trimming.
 	pageBudget pagefit.Budget
@@ -249,8 +250,10 @@ func New(
 		pinEnabled:         cfg.PinEnabled,
 		roomTimes:          nopRoomTimesCache{},
 	}
-	s.warmer = newPreviewWarmer(rooms, cfg.PreviewWarmBackEnabled,
-		cfg.PreviewWarmBackWorkers, cfg.PreviewWarmBackQueue, warmBackTimeout)
+	s.warmer = nopPreviewWarmer{}
+	if cfg.PreviewWarmBackEnabled {
+		s.warmer = newPreviewWarmer(rooms, cfg.PreviewWarmBackWorkers, cfg.PreviewWarmBackQueue, warmBackTimeout)
+	}
 	// A method value derefs its receiver where written, so this is guarded, not eager.
 	if apps != nil {
 		s.appName = preview.CachedAppNameLookup(apps.AppNameByAccount)

--- a/history-service/internal/service/service.go
+++ b/history-service/internal/service/service.go
@@ -180,7 +180,8 @@ type HistoryService struct {
 	maxPinnedPerRoom   int
 	pinEnabled         bool // from PIN_ENABLED env var; false disables pin/unpin globally
 	previewCache       PreviewCache
-	// warmer stores walk-resolved previews off the request path; Close drains it.
+	// warmer stores walk-resolved previews off the request path; Close drains it. Never
+	// nil — PREVIEW_WARMBACK_ENABLED=false yields an inert one, so Submit needs no guard.
 	warmer *previewWarmer
 	// pageBudget caps a paginated reply so it is trimmed to fit the broker
 	// rather than refused by it. Zero value disables trimming.
@@ -248,7 +249,8 @@ func New(
 		pinEnabled:         cfg.PinEnabled,
 		roomTimes:          nopRoomTimesCache{},
 	}
-	s.warmer = newPreviewWarmer(rooms, cfg.PreviewWarmBackWorkers, cfg.PreviewWarmBackQueue, warmBackTimeout)
+	s.warmer = newPreviewWarmer(rooms, cfg.PreviewWarmBackEnabled,
+		cfg.PreviewWarmBackWorkers, cfg.PreviewWarmBackQueue, warmBackTimeout)
 	// A method value derefs its receiver where written, so this is guarded, not eager.
 	if apps != nil {
 		s.appName = preview.CachedAppNameLookup(apps.AppNameByAccount)

--- a/history-service/internal/service/service.go
+++ b/history-service/internal/service/service.go
@@ -180,9 +180,7 @@ type HistoryService struct {
 	maxPinnedPerRoom   int
 	pinEnabled         bool // from PIN_ENABLED env var; false disables pin/unpin globally
 	previewCache       PreviewCache
-	// warmer stores walk-resolved previews off the request path; Close drains it. Never
-	// nil — PREVIEW_WARMBACK_ENABLED=false installs the no-op, so the read path needs no
-	// guard and shutdown stays unconditional.
+	// warmer stores walk-resolved previews off the request path; never nil, so no guard needed.
 	warmer previewWriter
 	// pageBudget caps a paginated reply so it is trimmed to fit the broker
 	// rather than refused by it. Zero value disables trimming.

--- a/history-service/internal/service/warmback.go
+++ b/history-service/internal/service/warmback.go
@@ -62,6 +62,25 @@ func newWarmBackMetrics(m metric.Meter) warmBackMetrics {
 	return warmBackMetrics{stored: stored, dropped: dropped, failed: failed}
 }
 
+// previewWriter stores walk-resolved previews. previewWarmer is the live implementation;
+// nopPreviewWarmer is what PREVIEW_WARMBACK_ENABLED=false installs. An interface rather
+// than a disabled-shaped previewWarmer because "off" and "shut down" must not share an
+// encoding: previewWarmer.Close is nil-channel-safe only because it guards on closed, so
+// a warmer born closed puts a close(nil) panic one idiomatic refactor away — and it would
+// leave shutdown indistinguishable from off at every future log, metric and fast path.
+type previewWriter interface {
+	Submit(ctx context.Context, job *warmBackJob)
+	Close(ctx context.Context) error
+}
+
+// nopPreviewWarmer is the disabled form: it stores nothing, so a walk-resolved room simply
+// stays on the lazy path. Holds no queue and no workers, which is why Close has nothing to
+// drain and cannot fail.
+type nopPreviewWarmer struct{}
+
+func (nopPreviewWarmer) Submit(context.Context, *warmBackJob) {}
+func (nopPreviewWarmer) Close(context.Context) error          { return nil }
+
 // previewWarmer stores walk-resolved previews off the request path.
 //
 // The write is optional; the reply is not. Running it inline made the two share a budget,
@@ -86,17 +105,10 @@ type previewWarmer struct {
 	closed bool
 }
 
-// newPreviewWarmer starts the writer's workers, or returns an inert one when the operator
-// has turned warm-back off. Non-positive sizes take the defaults.
-//
-// Disabled is expressed as already-closed rather than as worker-less: closed is exactly
-// "not accepting work", so Submit sheds instead of filling a queue nothing drains, Close
-// waits on no workers and never closes the nil channel, and neither gains a branch on the
-// hot path. A drop counter is not touched either — an operator's off is not a shed job.
-func newPreviewWarmer(rooms RoomRepository, enabled bool, workers, queue int, timeout time.Duration) *previewWarmer {
-	if !enabled {
-		return &previewWarmer{rooms: rooms, timeout: timeout, closed: true}
-	}
+// newPreviewWarmer starts the writer's workers. Non-positive sizes take the defaults.
+// PREVIEW_WARMBACK_ENABLED=false is not expressed here: it selects nopPreviewWarmer
+// instead, so this constructor never builds a warmer that cannot do its job.
+func newPreviewWarmer(rooms RoomRepository, workers, queue int, timeout time.Duration) *previewWarmer {
 	if workers <= 0 {
 		workers = defaultWarmBackWorkers
 	}

--- a/history-service/internal/service/warmback.go
+++ b/history-service/internal/service/warmback.go
@@ -62,20 +62,14 @@ func newWarmBackMetrics(m metric.Meter) warmBackMetrics {
 	return warmBackMetrics{stored: stored, dropped: dropped, failed: failed}
 }
 
-// previewWriter stores walk-resolved previews. previewWarmer is the live implementation;
-// nopPreviewWarmer is what PREVIEW_WARMBACK_ENABLED=false installs. An interface rather
-// than a disabled-shaped previewWarmer because "off" and "shut down" must not share an
-// encoding: previewWarmer.Close is nil-channel-safe only because it guards on closed, so
-// a warmer born closed puts a close(nil) panic one idiomatic refactor away — and it would
-// leave shutdown indistinguishable from off at every future log, metric and fast path.
+// previewWriter is the warm-back writer; PREVIEW_WARMBACK_ENABLED=false installs the no-op.
+// An interface so "off" never encodes as closed: Close is nil-channel-safe only via that guard.
 type previewWriter interface {
 	Submit(ctx context.Context, job *warmBackJob)
 	Close(ctx context.Context) error
 }
 
-// nopPreviewWarmer is the disabled form: it stores nothing, so a walk-resolved room simply
-// stays on the lazy path. Holds no queue and no workers, which is why Close has nothing to
-// drain and cannot fail.
+// nopPreviewWarmer is the disabled form: no queue, no workers, nothing for Close to drain.
 type nopPreviewWarmer struct{}
 
 func (nopPreviewWarmer) Submit(context.Context, *warmBackJob) {}
@@ -105,9 +99,7 @@ type previewWarmer struct {
 	closed bool
 }
 
-// newPreviewWarmer starts the writer's workers. Non-positive sizes take the defaults.
-// PREVIEW_WARMBACK_ENABLED=false is not expressed here: it selects nopPreviewWarmer
-// instead, so this constructor never builds a warmer that cannot do its job.
+// newPreviewWarmer starts the writer's workers; non-positive sizes take the defaults.
 func newPreviewWarmer(rooms RoomRepository, workers, queue int, timeout time.Duration) *previewWarmer {
 	if workers <= 0 {
 		workers = defaultWarmBackWorkers

--- a/history-service/internal/service/warmback.go
+++ b/history-service/internal/service/warmback.go
@@ -86,10 +86,17 @@ type previewWarmer struct {
 	closed bool
 }
 
-// newPreviewWarmer starts the writer's workers. Non-positive sizes take the defaults:
-// warm-back is what stops the lazy walk repeating forever, so "off" is not an option the
-// wiring offers.
-func newPreviewWarmer(rooms RoomRepository, workers, queue int, timeout time.Duration) *previewWarmer {
+// newPreviewWarmer starts the writer's workers, or returns an inert one when the operator
+// has turned warm-back off. Non-positive sizes take the defaults.
+//
+// Disabled is expressed as already-closed rather than as worker-less: closed is exactly
+// "not accepting work", so Submit sheds instead of filling a queue nothing drains, Close
+// waits on no workers and never closes the nil channel, and neither gains a branch on the
+// hot path. A drop counter is not touched either — an operator's off is not a shed job.
+func newPreviewWarmer(rooms RoomRepository, enabled bool, workers, queue int, timeout time.Duration) *previewWarmer {
+	if !enabled {
+		return &previewWarmer{rooms: rooms, timeout: timeout, closed: true}
+	}
 	if workers <= 0 {
 		workers = defaultWarmBackWorkers
 	}


### PR DESCRIPTION
`rooms.get` falls back to a Cassandra bucket walk for any room without a stored list preview, then warms the result back onto the room doc through a bounded background writer so the next read is cheap. That write had no off switch: `newPreviewWarmer` always started its workers.

## What this adds

`PREVIEW_WARMBACK_ENABLED` (default `true`) lets an operator withhold the optional write without touching the read. The walk still runs and the client still gets its preview; only the self-healing write back is skipped, so the room re-walks on a later read — once per preview-cache TTL, or every read where that cache is off or the walk resolves nothing.

Scope: the mutation path's preview repair (`persistMutatedPreview`, which withdraws a stale preview after an edit or delete) is correctness rather than optimization, and is deliberately **not** covered by the toggle.

## Design

Disabled is a `nopPreviewWarmer` behind a new `previewWriter` interface, mirroring the `RoomTimesCache` / `nopRoomTimesCache` idiom the package already uses for an optional tier. An earlier revision in this branch encoded "off" by constructing `previewWarmer` with `closed: true`; that was replaced because it overloaded a lifecycle field with a configuration meaning — `previewWarmer.Close` is nil-channel-safe only via its `closed` guard, so a warmer born closed put a `close(nil)` panic one idiomatic refactor away, and it left shutdown indistinguishable from off for any future log, metric or fast path. `newPreviewWarmer` keeps its original signature and can no longer build a warmer that cannot write.

`main.go` warns at startup when the switch is off, grouped with the `PAGE_TRIMMING_ENABLED` warning; `docker-compose.yml` surfaces the knob.

## Testing

TDD throughout — tests written first and confirmed failing. New coverage: config default/on/off parsing, and service-level assertions that a disabled warm-back still serves the walked preview (gomock fails the test if the write is attempted) and that `Close` stays fast and idempotent with nothing to drain. The disabled test was mutation-checked: forcing the wiring to always build a live warmer makes it fail.

CI is green on `602c84e` — `lint`, `test`, `test-integration (history-service)`, `sast` and `prewarm` all pass. Package coverage: service 93.3%, config 96.4%.

No client-facing behavior changes, so `docs/client-api.md` is untouched — the preview is served identically either way.

## Reviewer notes

- The two operator-facing messages (the startup warning and the Compose comment) word the preview-cache caveat differently; there is an open review thread on `cmd/main.go` about aligning them.
- Test fixtures elsewhere in `internal/service` build `config.Config` literals directly, so they now get the zero value (`false`) for this field and wire the no-op writer. Nothing fails today — only `rooms_test.go` exercises `RoomsGet` — but a future `rooms.get` test added through those fixtures would silently run against a disabled writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9xm99qoxHG2FYFBM8k4p9