### PR TITLE
Add subscription-list max-rps workload to loadgen

### DIFF
--- a/tools/loadgen/README.md
+++ b/tools/loadgen/README.md
@@ -537,6 +537,83 @@ make -C tools/loadgen/deploy teardown-roomread PRESET=medium
 - Presets are the messages presets (`small`/`medium`/`large`/`realistic`); room
   size distribution drives floor-write contention.
 
+## Subscription-list workload (sidebar cold-open benchmark)
+
+Finds the maximum sustainable RPS for `subscription.list`
+(`user-service.ListSubscriptions`, the
+`chat.user.{account}.request.user.{siteID}.subscription.list` request/reply
+RPC). Every request is the call a client makes on connect — `type=current`,
+`limit=200`, `includeLastMessage=true`, `offset=0` — because the reconnect
+burst, not steady browsing, is what this endpoint has to survive.
+
+Accounts are picked **uniformly**, unlike the room-read workload's Zipf skew: a
+client cold-opens its sidebar once per connect, so there is no hot-account
+concentration to model. The skew that matters is across rooms *within* one
+account's page, and the preset fixtures already carry it.
+
+### Quick start
+
+```
+make -C tools/loadgen/deploy up
+make -C tools/loadgen/deploy seed-sublist PRESET=medium
+make -C tools/loadgen/deploy run-max-rps WORKLOAD=subscription-list PRESET=medium
+```
+
+Override the ramp with `STEPS` (default `200,500,1000,2000,5000`):
+
+```
+make -C tools/loadgen/deploy run-max-rps WORKLOAD=subscription-list PRESET=medium STEPS=500,1k,2k,5k
+```
+
+Tear down the fixtures:
+
+```
+make -C tools/loadgen/deploy teardown-sublist PRESET=medium
+```
+
+### Why this workload seeds its own fixtures
+
+`seed --workload=subscription-list` is **not** interchangeable with the plain
+`seed`. `BuildFixtures` leaves three fields at their zero value that
+`subscription.list`'s match filter reads, and a miss on any of them returns an
+empty page rather than an error — so the stock fixtures would produce a ramp
+measuring the cost of finding nothing:
+
+| Field | Why the zero value fails |
+|---|---|
+| `open` | no bson `omitempty`, so `false` persists as `open:false` and `match["open"]={$ne:false}` drops the row |
+| `roomType` | the `current` match needs `dm`/`channel` (or a subscribed `botDM`); `""` matches no branch |
+| `name` | `subLite` projects it for the self-DM pin and the name tiebreak |
+
+The seeder also spreads each room's `lastMsgAt` and each member's `lastSeenAt`.
+Both matter: an all-equal sort key would collapse the list comparator onto its
+name tiebreak and hide the real sort cost, and a uniform `lastSeenAt` would make
+every row resolve `hasUnread` the same way.
+
+### Notes
+
+- Synchronous request/reply: gated on p95/p99 latency and error rate only (no
+  consumer-pending signal). Defaults: `--slo-p95=100ms`, `--slo-p99=250ms`,
+  `--slo-error-rate=0.001`.
+- **Empty pages count as failures.** Every seeded account owns subscriptions, so
+  a zero-row reply means the fixtures or `--list-type` are wrong. An empty page
+  is also the fastest possible reply, so scoring it as a success would let a
+  misconfigured run report a record-breaking ramp. A service error envelope and
+  a `{}` body are kept distinct from it — both decode to zero rows, and folding
+  them together would report an outage as a healthy empty sidebar.
+- **`--list-limit=200` can exceed the NATS payload ceiling.** `docs/client-api.md`
+  recommends 200 for the HTTP form, which has no ceiling; the NATS reply is
+  capped at 128 KB and the handler does not truncate. When a page overflows, the
+  service cannot publish the reply and the request times out — so a ramp that
+  reports timeouts at *every* step, including the lowest, is likely hitting the
+  cap rather than a capacity limit. Lower `--list-limit` to confirm.
+- The NATS page is additionally capped server-side by `MAX_SUBSCRIPTION_LIMIT`
+  (default 1000), so `--list-limit` above that is silently clamped.
+- Single-site only: all seeded users are local.
+- Presets are the messages presets (`small`/`medium`/`large`/`realistic`).
+  `realistic` is the most representative — its mixed room sizes and DM rows
+  exercise the per-row app/HR enrichment branches that a uniform preset skips.
+
 ## History workload (LoadHistory / GetThreadMessages benchmark)
 
 Benchmarks the synchronous read path:
@@ -746,7 +823,7 @@ list of steps, holds at each step for a measurement window, evaluates SLO
 signals, and reports the largest step at which every signal passed.
 
 ```bash
-loadgen max-rps --workload=messages|history|read-receipt|room-read|thread-read|login|search --preset=<name> [flags]
+loadgen max-rps --workload=messages|history|read-receipt|room-read|thread-read|subscription-list|login|search --preset=<name> [flags]
 ```
 
 ### Quick start
@@ -768,6 +845,10 @@ loadgen max-rps --workload=login --preset=medium
 
 # search: drive search-service request/reply (reads the existing index)
 loadgen max-rps --workload=search --preset=medium
+
+# subscription-list: seed the list-shaped fixtures first, then ramp
+loadgen seed --workload=subscription-list --preset=medium
+loadgen max-rps --workload=subscription-list --preset=medium --steps=200,500,1k,2k
 ```
 
 Via the deploy Makefile:
@@ -781,10 +862,13 @@ make -C tools/loadgen/deploy run-max-rps WORKLOAD=history PRESET=history-medium 
 
 | Flag | Default | Notes |
 |------|---------|-------|
-| `--workload` | `messages` | `messages`, `history`, `read-receipt`, `room-read`, `thread-read`, `login`, or `search` |
+| `--workload` | `messages` | `messages`, `history`, `read-receipt`, `room-read`, `thread-read`, `subscription-list`, `login`, or `search` |
 | `--preset` | (required) | an existing preset for the chosen workload (`read-receipt` reuses the history presets; `login` and `search` reuse the message presets for their account set) |
-| `--steps` | messages `500,1k,2k,5k,10k` / history+read-receipt `200,500,1k,2k,5k` / login `50,100,200,500,1k` / search `100,200,500,1k,2k` | explicit ordered RPS list; `k` suffix = ×1000 |
-| `--request-timeout` | `5s` | **history / read-receipt / room-read / thread-read / login / search**: per-request reply timeout |
+| `--steps` | messages `500,1k,2k,5k,10k` / history+read-receipt+subscription-list `200,500,1k,2k,5k` / login `50,100,200,500,1k` / search `100,200,500,1k,2k` | explicit ordered RPS list; `k` suffix = ×1000 |
+| `--request-timeout` | `5s` | **history / read-receipt / room-read / thread-read / subscription-list / login / search**: per-request reply timeout |
+| `--list-type` | `current` | **subscription-list only**: `current`, `rooms`, or `apps` |
+| `--list-limit` | `200` | **subscription-list only**: page size; see the NATS payload-ceiling note above |
+| `--include-last-message` | `true` | **subscription-list only**: request the per-room `previewMessage` enrichment; `=false` isolates the query from the enrichment cost |
 | `--auth-url` | `$AUTH_URL` | **login only**: auth-service base URL |
 | `--login-key-pool` | `256` | **login only**: pre-generated NKey pool size |
 | `--search-mix` | `messages:60,rooms:30,users:10` | **search only**: endpoint mix |

--- a/tools/loadgen/README.md
+++ b/tools/loadgen/README.md
@@ -542,9 +542,11 @@ make -C tools/loadgen/deploy teardown-roomread PRESET=medium
 Finds the maximum sustainable RPS for `subscription.list`
 (`user-service.ListSubscriptions`, the
 `chat.user.{account}.request.user.{siteID}.subscription.list` request/reply
-RPC). Every request is the call a client makes on connect — `type=current`,
-`limit=200`, `includeLastMessage=true`, `offset=0` — because the reconnect
-burst, not steady browsing, is what this endpoint has to survive.
+RPC). By default every request is the call a client makes on connect —
+`type=current`, `limit=200`, `includeLastMessage=true`, `offset=0` — because the
+reconnect burst, not steady browsing, is what this endpoint has to survive.
+`--list-type`, `--list-limit` and `--include-last-message` change that shape;
+`offset` is always 0, since a cold open asks for the first page.
 
 Accounts are picked **uniformly**, unlike the room-read workload's Zipf skew: a
 client cold-opens its sidebar once per connect, so there is no hot-account
@@ -553,7 +555,7 @@ account's page, and the preset fixtures already carry it.
 
 ### Quick start
 
-```
+```sh
 make -C tools/loadgen/deploy up
 make -C tools/loadgen/deploy seed-sublist PRESET=realistic
 make -C tools/loadgen/deploy run-max-rps WORKLOAD=subscription-list PRESET=realistic
@@ -563,13 +565,13 @@ make -C tools/loadgen/deploy run-max-rps WORKLOAD=subscription-list PRESET=reali
 
 Override the ramp with `STEPS` (default `200,500,1000,2000,5000`):
 
-```
+```sh
 make -C tools/loadgen/deploy run-max-rps WORKLOAD=subscription-list PRESET=realistic STEPS=500,1k,2k,5k
 ```
 
 Tear down the fixtures:
 
-```
+```sh
 make -C tools/loadgen/deploy teardown-sublist PRESET=realistic
 ```
 

--- a/tools/loadgen/README.md
+++ b/tools/loadgen/README.md
@@ -555,20 +555,22 @@ account's page, and the preset fixtures already carry it.
 
 ```
 make -C tools/loadgen/deploy up
-make -C tools/loadgen/deploy seed-sublist PRESET=medium
-make -C tools/loadgen/deploy run-max-rps WORKLOAD=subscription-list PRESET=medium
+make -C tools/loadgen/deploy seed-sublist PRESET=realistic
+make -C tools/loadgen/deploy run-max-rps WORKLOAD=subscription-list PRESET=realistic
 ```
+
+`realistic` is not incidental here — see the preset note below.
 
 Override the ramp with `STEPS` (default `200,500,1000,2000,5000`):
 
 ```
-make -C tools/loadgen/deploy run-max-rps WORKLOAD=subscription-list PRESET=medium STEPS=500,1k,2k,5k
+make -C tools/loadgen/deploy run-max-rps WORKLOAD=subscription-list PRESET=realistic STEPS=500,1k,2k,5k
 ```
 
 Tear down the fixtures:
 
 ```
-make -C tools/loadgen/deploy teardown-sublist PRESET=medium
+make -C tools/loadgen/deploy teardown-sublist PRESET=realistic
 ```
 
 ### Why this workload seeds its own fixtures
@@ -610,9 +612,15 @@ every row resolve `hasUnread` the same way.
 - The NATS page is additionally capped server-side by `MAX_SUBSCRIPTION_LIMIT`
   (default 1000), so `--list-limit` above that is silently clamped.
 - Single-site only: all seeded users are local.
-- Presets are the messages presets (`small`/`medium`/`large`/`realistic`).
-  `realistic` is the most representative — its mixed room sizes and DM rows
-  exercise the per-row app/HR enrichment branches that a uniform preset skips.
+- **Use `--preset=realistic`.** The uniform presets (`small`/`medium`/`large`)
+  put every account in exactly one room, so each reply carries a single row — a
+  ramp over them measures the latency of a one-row page, which is fast and says
+  nothing about the endpoint under real sidebars. Only `realistic` has the mixed
+  room sizes that give an account several rooms (mean ~3, max ~9), and its DM
+  rows are also what exercise the per-row HR-enrichment branch. The workload logs
+  a startup warning when the chosen preset averages under two subscriptions per
+  account, and logs the mean rows per page at every step, so a degenerate run is
+  visible in the output rather than silently fast.
 
 ## History workload (LoadHistory / GetThreadMessages benchmark)
 
@@ -847,8 +855,9 @@ loadgen max-rps --workload=login --preset=medium
 loadgen max-rps --workload=search --preset=medium
 
 # subscription-list: seed the list-shaped fixtures first, then ramp
-loadgen seed --workload=subscription-list --preset=medium
-loadgen max-rps --workload=subscription-list --preset=medium --steps=200,500,1k,2k
+# (realistic is the only preset whose accounts hold more than one room)
+loadgen seed --workload=subscription-list --preset=realistic
+loadgen max-rps --workload=subscription-list --preset=realistic --steps=200,500,1k,2k
 ```
 
 Via the deploy Makefile:

--- a/tools/loadgen/README.md
+++ b/tools/loadgen/README.md
@@ -598,7 +598,7 @@ every row resolve `hasUnread` the same way.
   consumer-pending signal). Defaults: `--slo-p95=100ms`, `--slo-p99=250ms`,
   `--slo-error-rate=0.001`.
 - **Empty pages count as failures.** Every seeded account owns subscriptions, so
-  a zero-row reply means the fixtures or `--list-type` are wrong. An empty page
+  a zero-row reply means the fixtures are wrong. An empty page
   is also the fastest possible reply, so scoring it as a success would let a
   misconfigured run report a record-breaking ramp. A service error envelope and
   a `{}` body are kept distinct from it — both decode to zero rows, and folding
@@ -875,7 +875,7 @@ make -C tools/loadgen/deploy run-max-rps WORKLOAD=history PRESET=history-medium 
 | `--preset` | (required) | an existing preset for the chosen workload (`read-receipt` reuses the history presets; `login` and `search` reuse the message presets for their account set) |
 | `--steps` | messages `500,1k,2k,5k,10k` / history+read-receipt+subscription-list `200,500,1k,2k,5k` / login `50,100,200,500,1k` / search `100,200,500,1k,2k` | explicit ordered RPS list; `k` suffix = ×1000 |
 | `--request-timeout` | `5s` | **history / read-receipt / room-read / thread-read / subscription-list / login / search**: per-request reply timeout |
-| `--list-type` | `current` | **subscription-list only**: `current`, `rooms`, or `apps` |
+| `--list-type` | `current` | **subscription-list only**: `current` or `rooms`. `apps` is rejected — user-service serves it, but it matches subscribed `botDM` rows alone and these fixtures seed none, so every page would come back empty |
 | `--list-limit` | `200` | **subscription-list only**: page size; see the NATS payload-ceiling note above |
 | `--include-last-message` | `true` | **subscription-list only**: request the per-room `previewMessage` enrichment; `=false` isolates the query from the enrichment cost |
 | `--auth-url` | `$AUTH_URL` | **login only**: auth-service base URL |

--- a/tools/loadgen/deploy/Makefile
+++ b/tools/loadgen/deploy/Makefile
@@ -14,7 +14,7 @@ export ENCRYPTION_ENABLED ?= true
 # invalid because the service has neither image nor build).
 export MAX_ROOM_SIZE ?= 6000
 
-.PHONY: up stack-up overlay-up image seed teardown run run-dashboards run-max-rps run-daily down logs seed-members teardown-members reset-members run-sustained run-capacity seed-roomread teardown-roomread seed-botroom teardown-botroom run-max-room-size soak-seed soak-run soak-teardown
+.PHONY: up stack-up overlay-up image seed teardown run run-dashboards run-max-rps run-daily down logs seed-members teardown-members reset-members run-sustained run-capacity seed-roomread teardown-roomread seed-sublist teardown-sublist seed-botroom teardown-botroom run-max-room-size soak-seed soak-run soak-teardown
 
 up: stack-up overlay-up
 
@@ -78,6 +78,14 @@ teardown-roomread:
 	@test -n "$(PRESET)" || (echo "PRESET=<name> required" && exit 1)
 	$(COMPOSE) exec -T loadgen /loadgen teardown --workload=room-read --preset=$(PRESET)
 
+seed-sublist:
+	@test -n "$(PRESET)" || (echo "PRESET=<name> required" && exit 1)
+	$(COMPOSE) exec -T loadgen /loadgen seed --workload=subscription-list --preset=$(PRESET)
+
+teardown-sublist:
+	@test -n "$(PRESET)" || (echo "PRESET=<name> required" && exit 1)
+	$(COMPOSE) exec -T loadgen /loadgen teardown --workload=subscription-list --preset=$(PRESET)
+
 reset-members:
 	@test -n "$(PRESET)" || (echo "PRESET=<members-*> required" && exit 1)
 	$(MAKE) teardown-members PRESET=$(PRESET)
@@ -114,7 +122,7 @@ run-dashboards:
 	$(COMPOSE) --profile dashboards up -d
 	$(MAKE) run PRESET=$(PRESET) RATE=$(RATE) DURATION=$(DURATION)
 
-run-max-rps: ## Ramp RPS to find the max under SLO (WORKLOAD=messages|thread|history|room-read|read-receipt PRESET=.. STEPS=..)
+run-max-rps: ## Ramp RPS to find the max under SLO (WORKLOAD=messages|thread|history|room-read|read-receipt|subscription-list PRESET=.. STEPS=..)
 	@test -n "$(PRESET)" || (echo "PRESET=<name> required" && exit 1)
 	$(COMPOSE) --profile dashboards up -d cadvisor prometheus
 	$(COMPOSE) exec -T loadgen /loadgen max-rps \

--- a/tools/loadgen/main.go
+++ b/tools/loadgen/main.go
@@ -162,7 +162,7 @@ func dispatch(ctx context.Context, cfg *config) int {
 
 func runSeed(ctx context.Context, cfg *config, args []string) int {
 	fs := flag.NewFlagSet("seed", flag.ExitOnError)
-	workload := fs.String("workload", "messages", "messages|thread|members|history|read-receipt|room-read|thread-read|botroom|soak")
+	workload := fs.String("workload", "messages", "messages|thread|members|history|read-receipt|room-read|thread-read|subscription-list|botroom|soak")
 	preset := fs.String("preset", "", "preset name")
 	seed := fs.Int64("seed", 42, "RNG seed")
 	readRatio := fs.Float64("read-ratio", 0.7, "read-receipt only: fraction of each room's subscribers to mark as readers")
@@ -202,6 +202,8 @@ func runSeed(ctx context.Context, cfg *config, args []string) int {
 		return runSeedReadReceipt(ctx, cfg, *preset, *seed, *readRatio)
 	case "room-read":
 		return runSeedRoomRead(ctx, cfg, *preset, *seed)
+	case "subscription-list":
+		return runSeedSubscriptionList(ctx, cfg, *preset, *seed)
 	case "thread-read":
 		return runSeedHistory(ctx, cfg, *preset, *seed)
 	case "botroom":
@@ -340,7 +342,7 @@ func runTeardownBotRoom(ctx context.Context, cfg *config, preset string, seed in
 
 func runTeardown(ctx context.Context, cfg *config, args []string) int {
 	fs := flag.NewFlagSet("teardown", flag.ExitOnError)
-	workload := fs.String("workload", "messages", "messages|thread|members|history|room-read|thread-read|botroom|soak")
+	workload := fs.String("workload", "messages", "messages|thread|members|history|room-read|thread-read|subscription-list|botroom|soak")
 	preset := fs.String("preset", "", "preset name (required to identify which room keys to delete)")
 	seed := fs.Int64("seed", 42, "RNG seed (must match the seed used at seed time)")
 	_ = fs.Parse(args)
@@ -362,6 +364,8 @@ func runTeardown(ctx context.Context, cfg *config, args []string) int {
 		return runTeardownHistory(ctx, cfg, *preset, *seed)
 	case "room-read":
 		return runTeardownRoomRead(ctx, cfg, *preset, *seed)
+	case "subscription-list":
+		return runTeardownSubscriptionList(ctx, cfg, *preset, *seed)
 	case "thread-read":
 		return runTeardownHistory(ctx, cfg, *preset, *seed)
 	case "botroom":
@@ -529,6 +533,50 @@ func runTeardownRoomRead(ctx context.Context, cfg *config, preset string, seed i
 		return 1
 	}
 	slog.Info("teardown complete (room-read)", "preset", preset)
+	return 0
+}
+
+func runSeedSubscriptionList(ctx context.Context, cfg *config, preset string, seed int64) int {
+	p, ok := BuiltinPreset(preset)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "unknown preset: %s\n", preset)
+		return 2
+	}
+	db, _, cleanup, err := connectStores(ctx, cfg)
+	if err != nil {
+		return 1
+	}
+	defer cleanup()
+	fixtures := BuildSubscriptionListFixtures(&p, seed, cfg.SiteID, time.Now().UTC())
+	// No SeedRoomKeys: the list path never decrypts, so no room keys are written.
+	if err := Seed(ctx, db, &fixtures); err != nil {
+		slog.Error("seed", "error", err)
+		return 1
+	}
+	slog.Info("seed complete (subscription-list)",
+		"preset", p.Name,
+		"users", len(fixtures.Users),
+		"rooms", len(fixtures.Rooms),
+		"subs", len(fixtures.Subscriptions))
+	return 0
+}
+
+func runTeardownSubscriptionList(ctx context.Context, cfg *config, preset string, seed int64) int {
+	if _, ok := BuiltinPreset(preset); !ok {
+		fmt.Fprintf(os.Stderr, "unknown preset: %s\n", preset)
+		return 2
+	}
+	db, _, cleanup, err := connectStores(ctx, cfg)
+	if err != nil {
+		return 1
+	}
+	defer cleanup()
+	// No TeardownRoomKeys: runSeedSubscriptionList writes no room keys.
+	if err := Teardown(ctx, db); err != nil {
+		slog.Error("teardown", "error", err)
+		return 1
+	}
+	slog.Info("teardown complete (subscription-list)", "preset", preset)
 	return 0
 }
 

--- a/tools/loadgen/main.go
+++ b/tools/loadgen/main.go
@@ -365,7 +365,7 @@ func runTeardown(ctx context.Context, cfg *config, args []string) int {
 	case "room-read":
 		return runTeardownRoomRead(ctx, cfg, *preset, *seed)
 	case "subscription-list":
-		return runTeardownSubscriptionList(ctx, cfg, *preset, *seed)
+		return runTeardownSubscriptionList(ctx, cfg, *preset)
 	case "thread-read":
 		return runTeardownHistory(ctx, cfg, *preset, *seed)
 	case "botroom":
@@ -561,7 +561,9 @@ func runSeedSubscriptionList(ctx context.Context, cfg *config, preset string, se
 	return 0
 }
 
-func runTeardownSubscriptionList(ctx context.Context, cfg *config, preset string, seed int64) int {
+// No seed parameter: teardown drops the seeded collections wholesale, so unlike
+// the seeding side it does not depend on which fixtures were generated.
+func runTeardownSubscriptionList(ctx context.Context, cfg *config, preset string) int {
 	if _, ok := BuiltinPreset(preset); !ok {
 		fmt.Fprintf(os.Stderr, "unknown preset: %s\n", preset)
 		return 2

--- a/tools/loadgen/maxrps.go
+++ b/tools/loadgen/maxrps.go
@@ -114,7 +114,7 @@ func runMaxRPS(ctx context.Context, cfg *config, args []string) int {
 	// search-only tunable:
 	searchMixFlag := fs.String("search-mix", "messages:60,rooms:30,users:10", "search only: endpoint mix")
 	// subscription-list-only tunables:
-	listType := fs.String("list-type", "current", "subscription-list only: current|rooms|apps")
+	listType := fs.String("list-type", "current", "subscription-list only: current|rooms (apps needs botDM fixtures this workload does not seed)")
 	listLimit := fs.Int("list-limit", 200, "subscription-list only: page size (docs/client-api.md recommends 200)")
 	includeLastMessage := fs.Bool("include-last-message", true, "subscription-list only: request the per-room previewMessage enrichment")
 	csvPath := fs.String("csv", "", "optional CSV output path")
@@ -305,8 +305,12 @@ func runMaxRPS(ctx context.Context, cfg *config, args []string) int {
 			fmt.Fprintf(os.Stderr, "unknown preset: %s\n", *preset)
 			return 2
 		}
-		if !validSubscriptionListTypes[*listType] {
-			fmt.Fprintln(os.Stderr, "--list-type must be one of current|rooms|apps")
+		if !workloadSupportedListTypes[*listType] {
+			if validSubscriptionListTypes[*listType] {
+				fmt.Fprintf(os.Stderr, "--list-type=%s is not supported by this workload: its fixtures seed no botDM rows, so every page would come back empty\n", *listType)
+				return 2
+			}
+			fmt.Fprintln(os.Stderr, "--list-type must be one of current|rooms")
 			return 2
 		}
 		if *listLimit <= 0 {

--- a/tools/loadgen/maxrps.go
+++ b/tools/loadgen/maxrps.go
@@ -11,7 +11,7 @@ import (
 
 func defaultSteps(workload string) string {
 	switch workload {
-	case "history", "read-receipt", "room-read", "thread-read":
+	case "history", "read-receipt", "room-read", "thread-read", "subscription-list":
 		return "200,500,1000,2000,5000"
 	case "login":
 		// Login is a low-rate journey — one per session, not per message — and
@@ -85,7 +85,7 @@ func validateSLORatio(name string, r sloRatio, wantBound bool) bool {
 // the report. Returns the process exit code.
 func runMaxRPS(ctx context.Context, cfg *config, args []string) int {
 	fs := flag.NewFlagSet("max-rps", flag.ExitOnError)
-	workload := fs.String("workload", "messages", "messages|thread|history|read-receipt|room-read|thread-read|login|search")
+	workload := fs.String("workload", "messages", "messages|thread|history|read-receipt|room-read|thread-read|subscription-list|login|search")
 	preset := fs.String("preset", "", "preset name")
 	seed := fs.Int64("seed", 42, "RNG seed")
 	stepsFlag := fs.String("steps", "", "ascending RPS list, e.g. 500,1k,2k,5k,10k (default depends on workload)")
@@ -107,12 +107,16 @@ func runMaxRPS(ctx context.Context, cfg *config, args []string) int {
 	beforeModeFlag := fs.String("before-mode", "open:70,scrollback:30", "history only: before-cursor mix")
 	scrollbackPages := fs.Int("scrollback-pages", 5, "history only: pages per scrollback chain")
 	pageLimit := fs.Int("page-limit", 20, "history only: page limit")
-	requestTimeout := fs.Duration("request-timeout", 5*time.Second, "history/read-receipt/room-read/thread-read/login/search: per-request timeout")
+	requestTimeout := fs.Duration("request-timeout", 5*time.Second, "history/read-receipt/room-read/thread-read/subscription-list/login/search: per-request timeout")
 	// login-only tunables:
 	authURL := fs.String("auth-url", "", "login only: auth-service base URL (default AUTH_URL)")
 	loginKeyPool := fs.Int("login-key-pool", 256, "login only: pre-generated NKey pool size")
 	// search-only tunable:
 	searchMixFlag := fs.String("search-mix", "messages:60,rooms:30,users:10", "search only: endpoint mix")
+	// subscription-list-only tunables:
+	listType := fs.String("list-type", "current", "subscription-list only: current|rooms|apps")
+	listLimit := fs.Int("list-limit", 200, "subscription-list only: page size (docs/client-api.md recommends 200)")
+	includeLastMessage := fs.Bool("include-last-message", true, "subscription-list only: request the per-room previewMessage enrichment")
 	csvPath := fs.String("csv", "", "optional CSV output path")
 	_ = fs.Parse(args)
 
@@ -295,6 +299,33 @@ func runMaxRPS(ctx context.Context, cfg *config, args []string) int {
 			return 1
 		}
 		w, cleanup, presetID = rw, clean, p.Name
+	case "subscription-list":
+		p, ok := BuiltinPreset(*preset)
+		if !ok {
+			fmt.Fprintf(os.Stderr, "unknown preset: %s\n", *preset)
+			return 2
+		}
+		if !validSubscriptionListTypes[*listType] {
+			fmt.Fprintln(os.Stderr, "--list-type must be one of current|rooms|apps")
+			return 2
+		}
+		if *listLimit <= 0 {
+			fmt.Fprintln(os.Stderr, "--list-limit must be > 0")
+			return 2
+		}
+		if *requestTimeout <= 0 {
+			fmt.Fprintln(os.Stderr, "--request-timeout must be > 0")
+			return 2
+		}
+		slw, clean, err := newSubscriptionListWorkload(ctx, cfg, &p, *seed, subscriptionListParams{
+			ListType: *listType, Limit: *listLimit,
+			IncludeLastMessage: includeLastMessage, RequestTimeout: *requestTimeout,
+		})
+		if err != nil {
+			slog.Error("init subscription-list workload", "error", err)
+			return 1
+		}
+		w, cleanup, presetID = slw, clean, p.Name
 	case "thread-read":
 		p, ok := BuiltinHistoryPreset(*preset)
 		if !ok {

--- a/tools/loadgen/maxrps_subscriptionlist.go
+++ b/tools/loadgen/maxrps_subscriptionlist.go
@@ -49,11 +49,9 @@ func buildSubscriptionListInputs(targetRPS int, hold time.Duration, c *Subscript
 // captured by the cleanup closure, not stored on the struct.
 type subscriptionListWorkload struct {
 	cfg                *config
-	preset             *Preset
 	fixtures           Fixtures
 	seed               int64
 	requestTimeout     time.Duration
-	metrics            *Metrics
 	requester          SubscriptionListRequester
 	listType           string
 	limit              int
@@ -97,11 +95,9 @@ func newSubscriptionListWorkload(ctx context.Context, cfg *config, preset *Prese
 	}
 	w := &subscriptionListWorkload{
 		cfg:                cfg,
-		preset:             preset,
 		fixtures:           fixtures,
 		seed:               seed,
 		requestTimeout:     p.RequestTimeout,
-		metrics:            metrics,
 		requester:          newNATSHistoryRequester(nc.NatsConn()),
 		listType:           p.ListType,
 		limit:              p.Limit,
@@ -116,8 +112,9 @@ func newSubscriptionListWorkload(ctx context.Context, cfg *config, preset *Prese
 	return w, cleanup, nil
 }
 
-func (w *subscriptionListWorkload) newGenerator(collector *SubscriptionListCollector, targetRPS int) *subscriptionListGenerator {
+func (w *subscriptionListWorkload) newGenerator(runCtx context.Context, collector *SubscriptionListCollector, targetRPS int) *subscriptionListGenerator {
 	return newSubscriptionListGenerator(&subscriptionListGeneratorConfig{
+		RunCtx:             runCtx,
 		Fixtures:           &w.fixtures,
 		SiteID:             w.cfg.SiteID,
 		Rate:               targetRPS,
@@ -155,12 +152,12 @@ func runSubscriptionListFor(ctx context.Context, gen *subscriptionListGenerator,
 func (w *subscriptionListWorkload) RunStep(ctx context.Context, targetRPS int, warmup, hold time.Duration) (rpsStepInputs, error) {
 	if warmup > 0 {
 		warmCollector := NewSubscriptionListCollector()
-		if err := runSubscriptionListFor(ctx, w.newGenerator(warmCollector, targetRPS), warmup); err != nil {
+		if err := runSubscriptionListFor(ctx, w.newGenerator(ctx, warmCollector, targetRPS), warmup); err != nil {
 			return rpsStepInputs{}, err
 		}
 	}
 	collector := NewSubscriptionListCollector()
-	if err := runSubscriptionListFor(ctx, w.newGenerator(collector, targetRPS), hold); err != nil {
+	if err := runSubscriptionListFor(ctx, w.newGenerator(ctx, collector, targetRPS), hold); err != nil {
 		return rpsStepInputs{}, err
 	}
 	// rpsStepInputs carries no row counts, so without this the page size actually
@@ -170,17 +167,26 @@ func (w *subscriptionListWorkload) RunStep(ctx context.Context, targetRPS int, w
 	return buildSubscriptionListInputs(targetRPS, hold, collector), nil
 }
 
-// logStepPageShape reports the page size the step actually measured, so a run's
-// output answers "was this a real sidebar?" without re-deriving it from the preset.
+// logStepPageShape reports what the step actually measured: the page size, so a
+// run answers "was this a real sidebar?" without re-deriving it from the preset,
+// and the failure classes split out. rpsStepInputs carries only a summed
+// FailedOps, so without this a broker timeout, a protocol incompatibility and
+// bad fixtures all render as the same number — three problems needing three
+// different responses.
 func logStepPageShape(targetRPS int, c *SubscriptionListCollector) {
 	samples := c.Samples()
-	if len(samples) == 0 {
+	timeouts, replies := c.TimeoutErrors(), c.ReplyErrors()
+	bad, empty := c.BadReplyCount(), c.EmptyPageCount()
+	if len(samples) == 0 && timeouts+replies+bad+empty == 0 {
 		return
 	}
-	slog.Info("subscription-list page shape",
+	slog.Info("subscription-list step shape",
 		"rps", targetRPS,
 		"pages", len(samples),
 		"mean_rows", c.MeanRows(),
 		"has_more_pages", c.HasMoreCount(),
-		"empty_pages", c.EmptyPageCount())
+		"timeout_errors", timeouts,
+		"service_errors", replies,
+		"bad_replies", bad,
+		"empty_pages", empty)
 }

--- a/tools/loadgen/maxrps_subscriptionlist.go
+++ b/tools/loadgen/maxrps_subscriptionlist.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// subscriptionListLatencies extracts the latency tape from a sample slice.
+func subscriptionListLatencies(samples []SubscriptionListSample) []time.Duration {
+	out := make([]time.Duration, len(samples))
+	for i := range samples {
+		out[i] = samples[i].Latency
+	}
+	return out
+}
+
+// buildSubscriptionListInputs assembles normalized step inputs from a
+// (hold-only) collector. subscription.list is synchronous request/reply, so
+// there is no consumer queue and Pending stays empty; the single
+// "subscription-list" latency series gates.
+//
+// Empty pages join the failure count. Every seeded account owns subscriptions,
+// so a zero-row reply means the fixtures or the list type are wrong — and since
+// an empty page is also the fastest possible reply, scoring it as a success
+// would let a misconfigured run report a record-breaking ramp.
+func buildSubscriptionListInputs(targetRPS int, hold time.Duration, c *SubscriptionListCollector) rpsStepInputs {
+	samples := c.Samples()
+	failed := c.TimeoutErrors() + c.ReplyErrors() + c.BadReplyCount() + c.EmptyPageCount()
+	return rpsStepInputs{
+		TargetRPS:    targetRPS,
+		Hold:         hold,
+		AttemptedOps: len(samples) + failed,
+		FailedOps:    failed,
+		Saturation:   c.SaturationCount(),
+		EmitUnderrun: c.UnderrunCount(),
+		Latencies: []seriesSamples{
+			{Name: "subscription-list", Samples: subscriptionListLatencies(samples)},
+		},
+	}
+}
+
+// subscriptionListWorkload drives subscription.list requests at a given RPS. As
+// with the other workloads the natsutil connection and metrics server are
+// captured by the cleanup closure, not stored on the struct.
+type subscriptionListWorkload struct {
+	cfg                *config
+	preset             *Preset
+	fixtures           Fixtures
+	seed               int64
+	requestTimeout     time.Duration
+	metrics            *Metrics
+	requester          SubscriptionListRequester
+	listType           string
+	limit              int
+	includeLastMessage *bool
+}
+
+func (w *subscriptionListWorkload) Label() string { return "subscription-list" }
+
+// subscriptionListParams are the request-shape knobs runMaxRPS passes through.
+type subscriptionListParams struct {
+	ListType           string
+	Limit              int
+	IncludeLastMessage *bool
+	RequestTimeout     time.Duration
+}
+
+// newSubscriptionListWorkload connects NATS, starts the metrics server, and
+// builds the fixtures used for account selection. Only subscription accounts
+// are read from the fixtures (deterministic on seed), so selection stays
+// consistent with whatever `loadgen seed --workload=subscription-list` wrote.
+func newSubscriptionListWorkload(ctx context.Context, cfg *config, preset *Preset, seed int64, p subscriptionListParams) (*subscriptionListWorkload, func(), error) {
+	nc, err := dialNATS(cfg.NatsURL, cfg.NatsCredsFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("nats connect: %w", err)
+	}
+	metrics := NewMetrics()
+	srv := &http.Server{Addr: cfg.MetricsAddr, Handler: metrics.Handler(), ReadHeaderTimeout: 5 * time.Second}
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Warn("metrics server stopped", "error", err)
+		}
+	}()
+	w := &subscriptionListWorkload{
+		cfg:                cfg,
+		preset:             preset,
+		fixtures:           BuildSubscriptionListFixtures(preset, seed, cfg.SiteID, time.Now().UTC()),
+		seed:               seed,
+		requestTimeout:     p.RequestTimeout,
+		metrics:            metrics,
+		requester:          newNATSHistoryRequester(nc.NatsConn()),
+		listType:           p.ListType,
+		limit:              p.Limit,
+		includeLastMessage: p.IncludeLastMessage,
+	}
+	cleanup := func() {
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = srv.Shutdown(shutCtx)
+		cancel()
+		_ = nc.Drain()
+	}
+	return w, cleanup, nil
+}
+
+func (w *subscriptionListWorkload) newGenerator(collector *SubscriptionListCollector, targetRPS int) *subscriptionListGenerator {
+	return newSubscriptionListGenerator(&subscriptionListGeneratorConfig{
+		Fixtures:           &w.fixtures,
+		SiteID:             w.cfg.SiteID,
+		Rate:               targetRPS,
+		RequestTimeout:     w.requestTimeout,
+		Requester:          w.requester,
+		Collector:          collector,
+		MaxInFlight:        w.cfg.MaxInFlight,
+		ListType:           w.listType,
+		Limit:              w.limit,
+		IncludeLastMessage: w.includeLastMessage,
+	}, w.seed)
+}
+
+// runSubscriptionListFor runs gen.Run for d (or until ctx cancels), then stops
+// it and waits for all in-flight requests to drain. Mirrors
+// maxrps_roomread.go's runRoomReadFor for this generator type.
+func runSubscriptionListFor(ctx context.Context, gen *subscriptionListGenerator, d time.Duration) error {
+	genCtx, cancel := context.WithCancel(ctx)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = gen.Run(genCtx)
+	}()
+	err := waitOrCancel(ctx, d)
+	cancel()
+	wg.Wait()
+	return err
+}
+
+// RunStep runs warmup (discarded) then hold (measured) as two sequential
+// generator runs so the hold collector contains only hold-window data. No
+// post-hold sleep is needed: runSubscriptionListFor's wg.Wait already drains
+// every in-flight synchronous request into the collector before RunStep returns.
+func (w *subscriptionListWorkload) RunStep(ctx context.Context, targetRPS int, warmup, hold time.Duration) (rpsStepInputs, error) {
+	if warmup > 0 {
+		warmCollector := NewSubscriptionListCollector()
+		if err := runSubscriptionListFor(ctx, w.newGenerator(warmCollector, targetRPS), warmup); err != nil {
+			return rpsStepInputs{}, err
+		}
+	}
+	collector := NewSubscriptionListCollector()
+	if err := runSubscriptionListFor(ctx, w.newGenerator(collector, targetRPS), hold); err != nil {
+		return rpsStepInputs{}, err
+	}
+	return buildSubscriptionListInputs(targetRPS, hold, collector), nil
+}

--- a/tools/loadgen/maxrps_subscriptionlist.go
+++ b/tools/loadgen/maxrps_subscriptionlist.go
@@ -86,10 +86,19 @@ func newSubscriptionListWorkload(ctx context.Context, cfg *config, preset *Prese
 			slog.Warn("metrics server stopped", "error", err)
 		}
 	}()
+	fixtures := BuildSubscriptionListFixtures(preset, seed, cfg.SiteID, time.Now().UTC())
+	// Warned, not rejected: measuring a one-row page is a legitimate thing to
+	// want, as long as it is on purpose. Silently doing it is the failure mode —
+	// the ramp would report the latency of a reply that is not a sidebar.
+	if degeneratePageFixtures(&fixtures) {
+		slog.Warn("preset yields about one subscription per account; this ramp measures a one-row page, not a sidebar cold-open — use --preset=realistic for a representative page",
+			"preset", preset.Name,
+			"subs_per_account", subscriptionsPerAccount(&fixtures))
+	}
 	w := &subscriptionListWorkload{
 		cfg:                cfg,
 		preset:             preset,
-		fixtures:           BuildSubscriptionListFixtures(preset, seed, cfg.SiteID, time.Now().UTC()),
+		fixtures:           fixtures,
 		seed:               seed,
 		requestTimeout:     p.RequestTimeout,
 		metrics:            metrics,
@@ -154,5 +163,24 @@ func (w *subscriptionListWorkload) RunStep(ctx context.Context, targetRPS int, w
 	if err := runSubscriptionListFor(ctx, w.newGenerator(collector, targetRPS), hold); err != nil {
 		return rpsStepInputs{}, err
 	}
+	// rpsStepInputs carries no row counts, so without this the page size actually
+	// measured is invisible in the report — and a ramp over one-row pages looks
+	// identical to a ramp over sidebar-sized ones.
+	logStepPageShape(targetRPS, collector)
 	return buildSubscriptionListInputs(targetRPS, hold, collector), nil
+}
+
+// logStepPageShape reports the page size the step actually measured, so a run's
+// output answers "was this a real sidebar?" without re-deriving it from the preset.
+func logStepPageShape(targetRPS int, c *SubscriptionListCollector) {
+	samples := c.Samples()
+	if len(samples) == 0 {
+		return
+	}
+	slog.Info("subscription-list page shape",
+		"rps", targetRPS,
+		"pages", len(samples),
+		"mean_rows", c.MeanRows(),
+		"has_more_pages", c.HasMoreCount(),
+		"empty_pages", c.EmptyPageCount())
 }

--- a/tools/loadgen/maxrps_subscriptionlist_test.go
+++ b/tools/loadgen/maxrps_subscriptionlist_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time check: subscriptionListWorkload satisfies rpsWorkload.
+var _ rpsWorkload = (*subscriptionListWorkload)(nil)
+
+func TestBuildSubscriptionListInputs_MapsCollector(t *testing.T) {
+	c := NewSubscriptionListCollector()
+	c.RecordSample(SubscriptionListSample{Latency: 4 * time.Millisecond, Rows: 40})
+	c.RecordSample(SubscriptionListSample{Latency: 6 * time.Millisecond, Rows: 20})
+	c.RecordError(errClassTimeout, time.Millisecond)
+	c.RecordError(errClassReply, time.Millisecond)
+	c.RecordBadReply(time.Millisecond)
+	c.RecordSaturation()
+
+	in := buildSubscriptionListInputs(1000, 30*time.Second, c)
+
+	assert.Equal(t, 1000, in.TargetRPS)
+	assert.Equal(t, 30*time.Second, in.Hold)
+	assert.Equal(t, 3, in.FailedOps)    // 1 timeout + 1 reply + 1 bad reply
+	assert.Equal(t, 5, in.AttemptedOps) // 2 samples + 3 failed
+	assert.Equal(t, 1, in.Saturation)
+	assert.Empty(t, in.Pending, "synchronous RPC has no pending durables")
+	require.Len(t, in.Latencies, 1)
+	assert.Equal(t, "subscription-list", in.Latencies[0].Name)
+	assert.Len(t, in.Latencies[0].Samples, 2)
+}
+
+// An empty page is a broken run, not a fast one: it must gate the ramp rather
+// than be averaged away as a very quick success.
+func TestBuildSubscriptionListInputs_EmptyPagesCountAsFailures(t *testing.T) {
+	c := NewSubscriptionListCollector()
+	c.RecordSample(SubscriptionListSample{Latency: time.Millisecond, Rows: 5})
+	c.RecordEmptyPage(time.Millisecond)
+	c.RecordEmptyPage(time.Millisecond)
+
+	in := buildSubscriptionListInputs(500, 10*time.Second, c)
+
+	assert.Equal(t, 2, in.FailedOps)
+	assert.Equal(t, 3, in.AttemptedOps)
+	assert.Len(t, in.Latencies[0].Samples, 1, "an empty page contributes no latency")
+}
+
+func TestBuildSubscriptionListInputs_PopulatesEmitUnderrun(t *testing.T) {
+	c := NewSubscriptionListCollector()
+	c.RecordUnderrun(7)
+	c.RecordUnderrun(3)
+	in := buildSubscriptionListInputs(2000, 30*time.Second, c)
+	assert.Equal(t, 10, in.EmitUnderrun)
+}
+
+func TestSubscriptionListWorkload_Label(t *testing.T) {
+	w := &subscriptionListWorkload{}
+	assert.Equal(t, "subscription-list", w.Label())
+}
+
+func TestDefaultSteps_SubscriptionList(t *testing.T) {
+	assert.Equal(t, "200,500,1000,2000,5000", defaultSteps("subscription-list"))
+}
+
+// newTestSubListWorkload builds the workload without newSubscriptionListWorkload,
+// which dials NATS. Everything below the constructor — generator wiring, the
+// warmup/hold split and the drain — is exercised against a fake requester.
+func newTestSubListWorkload(t *testing.T, req SubscriptionListRequester) *subscriptionListWorkload {
+	t.Helper()
+	p, ok := BuiltinPreset("small")
+	require.True(t, ok)
+	include := true
+	return &subscriptionListWorkload{
+		cfg:                &config{SiteID: "site-a", MaxInFlight: 4},
+		preset:             &p,
+		fixtures:           BuildSubscriptionListFixtures(&p, 42, "site-a", time.Now().UTC()),
+		seed:               42,
+		requestTimeout:     time.Second,
+		requester:          req,
+		listType:           "current",
+		limit:              200,
+		includeLastMessage: &include,
+	}
+}
+
+func TestSubscriptionListWorkload_RunStepMeasuresHoldOnly(t *testing.T) {
+	req := &fakeSubListRequester{reply: okSubListReply(t, 12, false)}
+	w := newTestSubListWorkload(t, req)
+
+	in, err := w.RunStep(context.Background(), 200, 40*time.Millisecond, 60*time.Millisecond)
+	require.NoError(t, err)
+
+	assert.Equal(t, 200, in.TargetRPS)
+	assert.Equal(t, 60*time.Millisecond, in.Hold)
+	require.Len(t, in.Latencies, 1)
+	assert.Equal(t, "subscription-list", in.Latencies[0].Name)
+	assert.NotEmpty(t, in.Latencies[0].Samples, "the hold window must produce samples")
+
+	// The warmup ran against the same requester, so it dispatched more requests
+	// than the hold window alone reports as samples.
+	subjects, _ := req.seen()
+	assert.Greater(t, len(subjects), len(in.Latencies[0].Samples),
+		"warmup requests are dispatched but discarded from the measured inputs")
+}
+
+func TestSubscriptionListWorkload_RunStepWithoutWarmup(t *testing.T) {
+	req := &fakeSubListRequester{reply: okSubListReply(t, 5, false)}
+	w := newTestSubListWorkload(t, req)
+
+	in, err := w.RunStep(context.Background(), 200, 0, 60*time.Millisecond)
+	require.NoError(t, err)
+	assert.NotEmpty(t, in.Latencies[0].Samples)
+}
+
+func TestSubscriptionListWorkload_RunStepPropagatesCancellation(t *testing.T) {
+	req := &fakeSubListRequester{reply: okSubListReply(t, 5, false)}
+	w := newTestSubListWorkload(t, req)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := w.RunStep(ctx, 200, 0, time.Minute)
+	assert.Error(t, err, "a cancelled run must not report a completed step")
+}
+
+func TestSubscriptionListWorkload_NewGeneratorCarriesRequestShape(t *testing.T) {
+	req := &fakeSubListRequester{reply: okSubListReply(t, 1, false)}
+	w := newTestSubListWorkload(t, req)
+
+	g := w.newGenerator(NewSubscriptionListCollector(), 750)
+
+	assert.Equal(t, 750, g.cfg.Rate)
+	assert.Equal(t, "current", g.cfg.ListType)
+	assert.Equal(t, 200, g.cfg.Limit)
+	assert.Equal(t, "site-a", g.cfg.SiteID)
+	assert.Equal(t, 4, g.cfg.MaxInFlight)
+	require.NotNil(t, g.cfg.IncludeLastMessage)
+	assert.True(t, *g.cfg.IncludeLastMessage)
+}

--- a/tools/loadgen/maxrps_subscriptionlist_test.go
+++ b/tools/loadgen/maxrps_subscriptionlist_test.go
@@ -141,3 +141,21 @@ func TestSubscriptionListWorkload_NewGeneratorCarriesRequestShape(t *testing.T) 
 	require.NotNil(t, g.cfg.IncludeLastMessage)
 	assert.True(t, *g.cfg.IncludeLastMessage)
 }
+
+func TestLogStepPageShape_SkipsEmptyCollector(t *testing.T) {
+	// No samples means nothing was measured; logging a zero-row page shape would
+	// read as a degenerate ramp rather than an absent one.
+	assert.NotPanics(t, func() { logStepPageShape(500, NewSubscriptionListCollector()) })
+}
+
+func TestLogStepPageShape_ReportsMeasuredPages(t *testing.T) {
+	c := NewSubscriptionListCollector()
+	c.RecordSample(SubscriptionListSample{Latency: time.Millisecond, Rows: 4, HasMore: true})
+	c.RecordSample(SubscriptionListSample{Latency: time.Millisecond, Rows: 2})
+	c.RecordEmptyPage(time.Millisecond)
+
+	assert.NotPanics(t, func() { logStepPageShape(500, c) })
+	assert.InDelta(t, 3.0, c.MeanRows(), 0.001)
+	assert.Equal(t, 1, c.HasMoreCount())
+	assert.Equal(t, 1, c.EmptyPageCount())
+}

--- a/tools/loadgen/maxrps_subscriptionlist_test.go
+++ b/tools/loadgen/maxrps_subscriptionlist_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -76,7 +80,6 @@ func newTestSubListWorkload(t *testing.T, req SubscriptionListRequester) *subscr
 	include := true
 	return &subscriptionListWorkload{
 		cfg:                &config{SiteID: "site-a", MaxInFlight: 4},
-		preset:             &p,
 		fixtures:           BuildSubscriptionListFixtures(&p, 42, "site-a", time.Now().UTC()),
 		seed:               42,
 		requestTimeout:     time.Second,
@@ -131,7 +134,7 @@ func TestSubscriptionListWorkload_NewGeneratorCarriesRequestShape(t *testing.T) 
 	req := &fakeSubListRequester{reply: okSubListReply(t, 1, false)}
 	w := newTestSubListWorkload(t, req)
 
-	g := w.newGenerator(NewSubscriptionListCollector(), 750)
+	g := w.newGenerator(context.Background(), NewSubscriptionListCollector(), 750)
 
 	assert.Equal(t, 750, g.cfg.Rate)
 	assert.Equal(t, "current", g.cfg.ListType)
@@ -148,14 +151,66 @@ func TestLogStepPageShape_SkipsEmptyCollector(t *testing.T) {
 	assert.NotPanics(t, func() { logStepPageShape(500, NewSubscriptionListCollector()) })
 }
 
+// Asserts the emitted record, not the collector: the point of this function is
+// the log line, so reading the collector back would pass even if it emitted
+// nothing or emitted the wrong values.
 func TestLogStepPageShape_ReportsMeasuredPages(t *testing.T) {
 	c := NewSubscriptionListCollector()
 	c.RecordSample(SubscriptionListSample{Latency: time.Millisecond, Rows: 4, HasMore: true})
 	c.RecordSample(SubscriptionListSample{Latency: time.Millisecond, Rows: 2})
 	c.RecordEmptyPage(time.Millisecond)
+	c.RecordError(errClassTimeout, time.Millisecond)
+	c.RecordError(errClassReply, time.Millisecond)
+	c.RecordBadReply(time.Millisecond)
 
-	assert.NotPanics(t, func() { logStepPageShape(500, c) })
-	assert.InDelta(t, 3.0, c.MeanRows(), 0.001)
-	assert.Equal(t, 1, c.HasMoreCount())
-	assert.Equal(t, 1, c.EmptyPageCount())
+	attrs := captureLogAttrs(t, func() { logStepPageShape(500, c) })
+
+	assert.Equal(t, float64(500), attrs["rps"])
+	assert.Equal(t, float64(2), attrs["pages"])
+	assert.InDelta(t, 3.0, attrs["mean_rows"], 0.001)
+	assert.Equal(t, float64(1), attrs["has_more_pages"])
+	assert.Equal(t, float64(1), attrs["timeout_errors"])
+	assert.Equal(t, float64(1), attrs["service_errors"])
+	assert.Equal(t, float64(1), attrs["bad_replies"])
+	assert.Equal(t, float64(1), attrs["empty_pages"])
+}
+
+// A step that produced nothing at all must stay silent: a zero-row line would
+// read as a degenerate ramp rather than an absent one.
+func TestLogStepPageShape_EmitsNothingWhenNothingHappened(t *testing.T) {
+	attrs := captureLogAttrs(t, func() { logStepPageShape(500, NewSubscriptionListCollector()) })
+	assert.Empty(t, attrs)
+}
+
+// A step with only failures still reports, or a fully failing step would be as
+// quiet as one that never ran.
+func TestLogStepPageShape_ReportsFailureOnlySteps(t *testing.T) {
+	c := NewSubscriptionListCollector()
+	c.RecordEmptyPage(time.Millisecond)
+
+	attrs := captureLogAttrs(t, func() { logStepPageShape(500, c) })
+
+	require.NotEmpty(t, attrs)
+	assert.Equal(t, float64(0), attrs["pages"])
+	assert.Equal(t, float64(1), attrs["empty_pages"])
+}
+
+// captureLogAttrs swaps in a JSON slog handler for the duration of fn and
+// returns the attributes of the single record it emitted, or an empty map.
+func captureLogAttrs(t *testing.T, fn func()) map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	fn()
+
+	line := strings.TrimSpace(buf.String())
+	if line == "" {
+		return map[string]any{}
+	}
+	var attrs map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &attrs))
+	return attrs
 }

--- a/tools/loadgen/subscriptionlist_collector.go
+++ b/tools/loadgen/subscriptionlist_collector.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+// errClassEmptyPage marks a well-formed reply carrying no rows. Every seeded
+// account owns subscriptions, so an empty page means the fixtures or the list
+// type are wrong, not that the service is fast — counting it as a success would
+// report a healthy ramp measuring nothing.
+const errClassEmptyPage errClass = "empty_page"
+
+// SubscriptionListSample captures one completed subscription.list round-trip.
+// Rows and HasMore are kept so the report can show the page size actually
+// measured: a ramp over 3-row pages is not a ramp over sidebar-sized ones.
+type SubscriptionListSample struct {
+	Latency time.Duration
+	Rows    int
+	HasMore bool
+}
+
+// SubscriptionListCollector aggregates samples and errors across a workload
+// run. All methods are safe for concurrent use. Reuses the package-shared
+// errClass consts (errClassTimeout / errClassReply / errClassBadReply).
+type SubscriptionListCollector struct {
+	mu         sync.Mutex
+	samples    []SubscriptionListSample
+	errors     map[errClass]int
+	totalRows  int
+	hasMore    int
+	saturation int
+	underrun   int
+}
+
+// NewSubscriptionListCollector returns an empty collector.
+func NewSubscriptionListCollector() *SubscriptionListCollector {
+	return &SubscriptionListCollector{errors: map[errClass]int{}}
+}
+
+// RecordSample stores one completed-call sample and folds in its row stats.
+func (c *SubscriptionListCollector) RecordSample(s SubscriptionListSample) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.samples = append(c.samples, s)
+	c.totalRows += s.Rows
+	if s.HasMore {
+		c.hasMore++
+	}
+}
+
+// RecordError tallies a per-class transport/reply error.
+func (c *SubscriptionListCollector) RecordError(class errClass, _ time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.errors[class]++
+}
+
+// RecordBadReply tallies a reply that could not be decoded.
+func (c *SubscriptionListCollector) RecordBadReply(_ time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.errors[errClassBadReply]++
+}
+
+// RecordEmptyPage tallies a decodable reply with zero rows.
+func (c *SubscriptionListCollector) RecordEmptyPage(_ time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.errors[errClassEmptyPage]++
+}
+
+// RecordSaturation tallies a tick that fired while the in-flight semaphore was full.
+func (c *SubscriptionListCollector) RecordSaturation() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.saturation++
+}
+
+// RecordUnderrun adds n events the pacer could not release on schedule. n<=0
+// ticks are no-ops.
+func (c *SubscriptionListCollector) RecordUnderrun(n int) {
+	if n <= 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.underrun += n
+}
+
+// Samples returns a defensive copy of the sample tape.
+func (c *SubscriptionListCollector) Samples() []SubscriptionListSample {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]SubscriptionListSample, len(c.samples))
+	copy(out, c.samples)
+	return out
+}
+
+// TotalRows returns the summed row count across every successful page.
+func (c *SubscriptionListCollector) TotalRows() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.totalRows
+}
+
+// MeanRows returns the mean rows per successful page, or 0 when none completed.
+func (c *SubscriptionListCollector) MeanRows() float64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.samples) == 0 {
+		return 0
+	}
+	return float64(c.totalRows) / float64(len(c.samples))
+}
+
+// HasMoreCount returns how many pages reported a further page behind them.
+func (c *SubscriptionListCollector) HasMoreCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.hasMore
+}
+
+// TimeoutErrors returns the timeout-class error count.
+func (c *SubscriptionListCollector) TimeoutErrors() int { return c.errCount(errClassTimeout) }
+
+// ReplyErrors returns the reply-class error count.
+func (c *SubscriptionListCollector) ReplyErrors() int { return c.errCount(errClassReply) }
+
+// BadReplyCount returns the count of undecodable replies.
+func (c *SubscriptionListCollector) BadReplyCount() int { return c.errCount(errClassBadReply) }
+
+// EmptyPageCount returns the count of zero-row replies.
+func (c *SubscriptionListCollector) EmptyPageCount() int { return c.errCount(errClassEmptyPage) }
+
+func (c *SubscriptionListCollector) errCount(class errClass) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.errors[class]
+}
+
+// SaturationCount returns the count of saturation events.
+func (c *SubscriptionListCollector) SaturationCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.saturation
+}
+
+// UnderrunCount returns the total emit-underrun events.
+func (c *SubscriptionListCollector) UnderrunCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.underrun
+}

--- a/tools/loadgen/subscriptionlist_collector_test.go
+++ b/tools/loadgen/subscriptionlist_collector_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscriptionListCollector_RecordsSamplesAndRowStats(t *testing.T) {
+	c := NewSubscriptionListCollector()
+	c.RecordSample(SubscriptionListSample{Latency: 10 * time.Millisecond, Rows: 40, HasMore: true})
+	c.RecordSample(SubscriptionListSample{Latency: 30 * time.Millisecond, Rows: 20, HasMore: false})
+
+	samples := c.Samples()
+	require.Len(t, samples, 2)
+	assert.Equal(t, 60, c.TotalRows())
+	assert.InDelta(t, 30.0, c.MeanRows(), 0.001)
+	assert.Equal(t, 1, c.HasMoreCount())
+}
+
+func TestSubscriptionListCollector_MeanRowsOnEmptyCollectorIsZero(t *testing.T) {
+	c := NewSubscriptionListCollector()
+	assert.Equal(t, 0, c.TotalRows())
+	assert.InDelta(t, 0.0, c.MeanRows(), 0.001)
+}
+
+func TestSubscriptionListCollector_ErrorClassesAreCountedSeparately(t *testing.T) {
+	c := NewSubscriptionListCollector()
+	c.RecordError(errClassTimeout, time.Millisecond)
+	c.RecordError(errClassTimeout, time.Millisecond)
+	c.RecordError(errClassReply, time.Millisecond)
+	c.RecordBadReply(time.Millisecond)
+	c.RecordEmptyPage(time.Millisecond)
+
+	assert.Equal(t, 2, c.TimeoutErrors())
+	assert.Equal(t, 1, c.ReplyErrors())
+	assert.Equal(t, 1, c.BadReplyCount())
+	assert.Equal(t, 1, c.EmptyPageCount())
+	// An empty page never lands in the latency tape: it is not a measurement of
+	// the work the endpoint is supposed to be doing.
+	assert.Empty(t, c.Samples())
+}
+
+func TestSubscriptionListCollector_SaturationAndUnderrun(t *testing.T) {
+	c := NewSubscriptionListCollector()
+	c.RecordSaturation()
+	c.RecordSaturation()
+	c.RecordUnderrun(5)
+	c.RecordUnderrun(0)
+	c.RecordUnderrun(-3)
+
+	assert.Equal(t, 2, c.SaturationCount())
+	assert.Equal(t, 5, c.UnderrunCount(), "non-positive underrun ticks are no-ops")
+}
+
+func TestSubscriptionListCollector_SamplesReturnsDefensiveCopy(t *testing.T) {
+	c := NewSubscriptionListCollector()
+	c.RecordSample(SubscriptionListSample{Latency: time.Millisecond, Rows: 1})
+
+	got := c.Samples()
+	got[0].Rows = 999
+	assert.Equal(t, 1, c.Samples()[0].Rows)
+}
+
+func TestSubscriptionListCollector_ConcurrentUseIsSafe(t *testing.T) {
+	c := NewSubscriptionListCollector()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.RecordSample(SubscriptionListSample{Latency: time.Millisecond, Rows: 2})
+			c.RecordError(errClassTimeout, time.Millisecond)
+			c.RecordEmptyPage(time.Millisecond)
+			c.RecordSaturation()
+			c.RecordUnderrun(1)
+		}()
+	}
+	wg.Wait()
+
+	assert.Len(t, c.Samples(), 50)
+	assert.Equal(t, 100, c.TotalRows())
+	assert.Equal(t, 50, c.TimeoutErrors())
+	assert.Equal(t, 50, c.EmptyPageCount())
+	assert.Equal(t, 50, c.SaturationCount())
+	assert.Equal(t, 50, c.UnderrunCount())
+}

--- a/tools/loadgen/subscriptionlist_generator.go
+++ b/tools/loadgen/subscriptionlist_generator.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand" // #nosec G404 -- load generator randomness, never used for secrets // nosemgrep: math-random-used
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/idgen"
+	"github.com/hmchangw/chat/pkg/natsutil"
+	"github.com/hmchangw/chat/pkg/subject"
+)
+
+// validSubscriptionListTypes mirrors user-service's own accepted set. An
+// unknown type is rejected there as a 400, so every request in the ramp would
+// fail identically — worth catching at flag-parse time instead.
+var validSubscriptionListTypes = map[string]bool{"current": true, "rooms": true, "apps": true}
+
+// SubscriptionListRequester is the narrow request/reply transport seam. The
+// production implementation reuses newNATSHistoryRequester (from
+// history_main.go) — both interfaces share the same Request method signature;
+// tests inject a recorder.
+type SubscriptionListRequester interface {
+	Request(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error)
+}
+
+// subscriptionListGeneratorConfig bundles every dependency the generator needs.
+// ListType/Limit/IncludeLastMessage shape the request body; a nil
+// IncludeLastMessage is omitted from the wire, which user-service reads as true.
+type subscriptionListGeneratorConfig struct {
+	Fixtures           *Fixtures
+	SiteID             string
+	Rate               int
+	RequestTimeout     time.Duration
+	Requester          SubscriptionListRequester
+	Collector          *SubscriptionListCollector
+	MaxInFlight        int
+	ListType           string
+	Limit              int
+	IncludeLastMessage *bool
+}
+
+// subscriptionListGenerator drives the open-loop subscription.list
+// request/reply loop. Accounts are picked uniformly rather than with the Zipf
+// skew room-read uses: a client cold-opens its sidebar once per connect, so
+// there is no hot-account concentration to model — the skew that matters here
+// is across rooms within one account's page, and the fixtures already carry it.
+type subscriptionListGenerator struct {
+	cfg subscriptionListGeneratorConfig
+
+	rngMu sync.Mutex
+	rng   *rand.Rand
+
+	accounts []string
+	// body is identical for every request, so it is marshalled once. Re-encoding
+	// it per call would put the load box's CPU on the critical path and surface
+	// as emit underrun — an INCONCLUSIVE ramp rather than a measurement.
+	body    []byte
+	bodyErr error
+}
+
+// newSubscriptionListGenerator constructs a generator seeded from `seed`. The
+// account set is sorted before use so a given seed replays the same sequence
+// regardless of fixture iteration order.
+func newSubscriptionListGenerator(cfg *subscriptionListGeneratorConfig, seed int64) *subscriptionListGenerator {
+	seen := make(map[string]struct{}, len(cfg.Fixtures.Subscriptions))
+	var accounts []string
+	for i := range cfg.Fixtures.Subscriptions {
+		account := cfg.Fixtures.Subscriptions[i].User.Account
+		if _, ok := seen[account]; ok || account == "" {
+			continue
+		}
+		seen[account] = struct{}{}
+		accounts = append(accounts, account)
+	}
+	sort.Strings(accounts)
+
+	body, err := json.Marshal(soakSubscriptionListRequest{
+		Type:               cfg.ListType,
+		Limit:              cfg.Limit,
+		IncludeLastMessage: cfg.IncludeLastMessage,
+	})
+
+	return &subscriptionListGenerator{
+		cfg:      *cfg,
+		rng:      rand.New(rand.NewSource(seed)),
+		accounts: accounts,
+		body:     body,
+		bodyErr:  err,
+	}
+}
+
+// Run drives the open-loop requester until ctx cancels. Mirrors
+// roomReadGenerator.Run: MaxInFlight>0 uses the batched pacer (so achieved RPS
+// is not capped by single-ticker resolution); MaxInFlight<=0 selects the legacy
+// serial path, retained for bisection.
+func (g *subscriptionListGenerator) Run(ctx context.Context) error {
+	if g.cfg.Rate <= 0 {
+		return fmt.Errorf("rate must be > 0")
+	}
+	// Reported once here rather than as one bad reply per request: a body that
+	// cannot be built is a configuration fault, not a service failure.
+	if g.bodyErr != nil {
+		return fmt.Errorf("marshal subscription.list body: %w", g.bodyErr)
+	}
+	if g.cfg.MaxInFlight <= 0 {
+		serialDispatch(ctx, g.cfg.Rate, g.requestOne)
+		return nil
+	}
+	pacedDispatch(ctx, g.cfg.Rate, g.cfg.MaxInFlight,
+		g.cfg.Collector.RecordUnderrun, g.cfg.Collector.RecordSaturation, g.requestOne)
+	return nil
+}
+
+func (g *subscriptionListGenerator) requestOne(ctx context.Context) {
+	account := g.pickAccount()
+	if account == "" {
+		return
+	}
+	g.doList(ctx, account)
+}
+
+func (g *subscriptionListGenerator) doList(ctx context.Context, account string) {
+	subj := subject.UserSubscriptionList(account, g.cfg.SiteID)
+	// Mint a fresh X-Request-ID per request, like a real client, so server-side
+	// logs and traces for benchmark traffic are correlatable.
+	ctx = natsutil.WithRequestID(ctx, idgen.GenerateRequestID())
+
+	start := time.Now()
+	reply, err := g.cfg.Requester.Request(ctx, subj, g.body, g.cfg.RequestTimeout)
+	latency := time.Since(start)
+
+	if err != nil {
+		// Run-level cancellation isn't a real failure — the run is draining.
+		if ctx.Err() != nil {
+			return
+		}
+		g.cfg.Collector.RecordError(classifyRequesterError(err), latency)
+		return
+	}
+	g.classifyReply(reply, latency)
+}
+
+// classifyReply splits a delivered reply four ways. The distinction that earns
+// its keep is the last one: an errcode envelope and a `{}` both decode to zero
+// rows, and folding either into "empty page" would report a service outage or a
+// contract break as a fast, healthy, empty sidebar.
+func (g *subscriptionListGenerator) classifyReply(reply []byte, latency time.Duration) {
+	if _, ok := errcode.Parse(reply); ok {
+		g.cfg.Collector.RecordError(errClassReply, latency)
+		return
+	}
+	var parsed soakSubscriptionListResponse
+	// Presence of the collection, not its length: a genuinely empty sidebar
+	// replies with an empty array, while `{}` leaves it nil and is a contract
+	// violation.
+	if err := json.Unmarshal(reply, &parsed); err != nil || parsed.Subscriptions == nil {
+		g.cfg.Collector.RecordBadReply(latency)
+		return
+	}
+	if len(parsed.Subscriptions) == 0 {
+		g.cfg.Collector.RecordEmptyPage(latency)
+		return
+	}
+	g.cfg.Collector.RecordSample(SubscriptionListSample{
+		Latency: latency,
+		Rows:    len(parsed.Subscriptions),
+		HasMore: parsed.HasMore,
+	})
+}
+
+func (g *subscriptionListGenerator) pickAccount() string {
+	if len(g.accounts) == 0 {
+		return ""
+	}
+	g.rngMu.Lock()
+	defer g.rngMu.Unlock()
+	return g.accounts[g.rng.Intn(len(g.accounts))]
+}

--- a/tools/loadgen/subscriptionlist_generator.go
+++ b/tools/loadgen/subscriptionlist_generator.go
@@ -20,6 +20,15 @@ import (
 // fail identically — worth catching at flag-parse time instead.
 var validSubscriptionListTypes = map[string]bool{"current": true, "rooms": true, "apps": true}
 
+// workloadSupportedListTypes is the subset these fixtures can actually serve.
+// `apps` is missing deliberately: BuildFixtures creates only channel and dm
+// rooms, while `apps` matches subscribed botDM rows alone, so every reply would
+// be an empty page — recorded as a failure and contributing no latency, which
+// reports a 100% failure rate against a healthy service. Seeding botDM rows
+// needs bot users and app records, a different fixture family; until then the
+// flag rejects the value instead of measuring nothing.
+var workloadSupportedListTypes = map[string]bool{"current": true, "rooms": true}
+
 // SubscriptionListRequester is the narrow request/reply transport seam. The
 // production implementation reuses newNATSHistoryRequester (from
 // history_main.go) — both interfaces share the same Request method signature;

--- a/tools/loadgen/subscriptionlist_generator.go
+++ b/tools/loadgen/subscriptionlist_generator.go
@@ -51,6 +51,14 @@ type subscriptionListGeneratorConfig struct {
 	ListType           string
 	Limit              int
 	IncludeLastMessage *bool
+	// RunCtx is the run-level context requests execute under. It is deliberately
+	// NOT the per-window context the pacer dispatches with: cancelling a window
+	// must stop new dispatches, not abort requests already admitted into the
+	// measured window. Those are disproportionately the slow ones, so aborting
+	// them erases the tail from both AttemptedOps and FailedOps and biases the
+	// step's latency and error rate downward. Nil falls back to the dispatch
+	// context, preserving the old behaviour for callers that do not set it.
+	RunCtx context.Context
 }
 
 // subscriptionListGenerator drives the open-loop subscription.list
@@ -125,12 +133,23 @@ func (g *subscriptionListGenerator) Run(ctx context.Context) error {
 	return nil
 }
 
-func (g *subscriptionListGenerator) requestOne(ctx context.Context) {
+func (g *subscriptionListGenerator) requestOne(dispatchCtx context.Context) {
 	account := g.pickAccount()
 	if account == "" {
 		return
 	}
-	g.doList(ctx, account)
+	g.doList(g.requestCtx(dispatchCtx), account)
+}
+
+// requestCtx returns the context an admitted request runs under: the run-level
+// one when configured, so a window boundary stops dispatch without erasing
+// in-flight work. A genuine run cancellation still aborts and discards, which is
+// what the ctx.Err() check in doList is for.
+func (g *subscriptionListGenerator) requestCtx(dispatchCtx context.Context) context.Context {
+	if g.cfg.RunCtx != nil {
+		return g.cfg.RunCtx
+	}
+	return dispatchCtx
 }
 
 func (g *subscriptionListGenerator) doList(ctx context.Context, account string) {
@@ -158,22 +177,40 @@ func (g *subscriptionListGenerator) doList(ctx context.Context, account string) 
 // its keep is the last one: an errcode envelope and a `{}` both decode to zero
 // rows, and folding either into "empty page" would report a service outage or a
 // contract break as a fast, healthy, empty sidebar.
+//
+// The success payload is decoded first and errcode.Parse runs only when the
+// collection is absent. Parsing every reply twice would burn load-box CPU on the
+// hot path — a 200-row page approaches the 128 KB ceiling, and the parse happens
+// before the in-flight slot is released, so it shows up as saturation below the
+// service's real capacity.
 func (g *subscriptionListGenerator) classifyReply(reply []byte, latency time.Duration) {
-	if _, ok := errcode.Parse(reply); ok {
-		g.cfg.Collector.RecordError(errClassReply, latency)
+	var parsed soakSubscriptionListResponse
+	if err := json.Unmarshal(reply, &parsed); err != nil {
+		g.cfg.Collector.RecordBadReply(latency)
 		return
 	}
-	var parsed soakSubscriptionListResponse
 	// Presence of the collection, not its length: a genuinely empty sidebar
-	// replies with an empty array, while `{}` leaves it nil and is a contract
-	// violation.
-	if err := json.Unmarshal(reply, &parsed); err != nil || parsed.Subscriptions == nil {
+	// replies with an empty array, while `{}` and an errcode envelope both leave
+	// it nil.
+	if parsed.Subscriptions == nil {
+		if _, ok := errcode.Parse(reply); ok {
+			g.cfg.Collector.RecordError(errClassReply, latency)
+			return
+		}
 		g.cfg.Collector.RecordBadReply(latency)
 		return
 	}
 	if len(parsed.Subscriptions) == 0 {
 		g.cfg.Collector.RecordEmptyPage(latency)
 		return
+	}
+	// A row without a room is a row a client cannot render — the same contract
+	// break as the top-level `{}`, and just as fast to return.
+	for i := range parsed.Subscriptions {
+		if parsed.Subscriptions[i].RoomID == "" {
+			g.cfg.Collector.RecordBadReply(latency)
+			return
+		}
 	}
 	g.cfg.Collector.RecordSample(SubscriptionListSample{
 		Latency: latency,

--- a/tools/loadgen/subscriptionlist_generator_test.go
+++ b/tools/loadgen/subscriptionlist_generator_test.go
@@ -1,0 +1,389 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/errcode"
+	"github.com/hmchangw/chat/pkg/model"
+	usermodels "github.com/hmchangw/chat/user-service/models"
+)
+
+// fakeSubListRequester records every request and replies with a scripted body.
+type fakeSubListRequester struct {
+	mu       sync.Mutex
+	subjects []string
+	bodies   [][]byte
+	reply    []byte
+	err      error
+}
+
+func (f *fakeSubListRequester) Request(_ context.Context, subj string, data []byte, _ time.Duration) ([]byte, error) {
+	f.mu.Lock()
+	f.subjects = append(f.subjects, subj)
+	f.bodies = append(f.bodies, append([]byte(nil), data...))
+	f.mu.Unlock()
+	return f.reply, f.err
+}
+
+func (f *fakeSubListRequester) seen() ([]string, [][]byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.subjects...), append([][]byte(nil), f.bodies...)
+}
+
+func okSubListReply(t *testing.T, rows int, hasMore bool) []byte {
+	t.Helper()
+	subs := make([]map[string]any, rows)
+	for i := range subs {
+		subs[i] = map[string]any{"roomId": "room-1"}
+	}
+	b, err := json.Marshal(map[string]any{"subscriptions": subs, "hasMore": hasMore})
+	require.NoError(t, err)
+	return b
+}
+
+func newTestSubListGenerator(t *testing.T, req SubscriptionListRequester, c *SubscriptionListCollector) *subscriptionListGenerator {
+	t.Helper()
+	p, ok := BuiltinPreset("small")
+	require.True(t, ok)
+	f := BuildSubscriptionListFixtures(&p, 42, "site-a", time.Now().UTC())
+	include := true
+	return newSubscriptionListGenerator(&subscriptionListGeneratorConfig{
+		Fixtures:           &f,
+		SiteID:             "site-a",
+		Rate:               10,
+		RequestTimeout:     time.Second,
+		Requester:          req,
+		Collector:          c,
+		MaxInFlight:        4,
+		ListType:           "current",
+		Limit:              200,
+		IncludeLastMessage: &include,
+	}, 42)
+}
+
+func TestSubscriptionListGenerator_RequestShapeAndSubject(t *testing.T) {
+	req := &fakeSubListRequester{reply: okSubListReply(t, 40, true)}
+	c := NewSubscriptionListCollector()
+	g := newTestSubListGenerator(t, req, c)
+
+	g.requestOne(context.Background())
+
+	subjects, bodies := req.seen()
+	require.Len(t, subjects, 1)
+	assert.Regexp(t, `^chat\.user\.user-\d+\.request\.user\.site-a\.subscription\.list$`, subjects[0])
+
+	var sent soakSubscriptionListRequest
+	require.NoError(t, json.Unmarshal(bodies[0], &sent))
+	assert.Equal(t, "current", sent.Type)
+	assert.Equal(t, 200, sent.Limit)
+	require.NotNil(t, sent.IncludeLastMessage)
+	assert.True(t, *sent.IncludeLastMessage)
+}
+
+func TestSubscriptionListGenerator_RecordsSuccessfulPage(t *testing.T) {
+	req := &fakeSubListRequester{reply: okSubListReply(t, 40, true)}
+	c := NewSubscriptionListCollector()
+	g := newTestSubListGenerator(t, req, c)
+
+	g.requestOne(context.Background())
+
+	samples := c.Samples()
+	require.Len(t, samples, 1)
+	assert.Equal(t, 40, samples[0].Rows)
+	assert.True(t, samples[0].HasMore)
+	assert.Positive(t, samples[0].Latency)
+}
+
+func TestSubscriptionListGenerator_ClassifiesReplies(t *testing.T) {
+	errEnvelope, err := json.Marshal(errcode.Error{Code: errcode.CodeUnavailable, Message: "subscription list timed out, please retry"})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		reply      []byte
+		wantSample int
+		check      func(t *testing.T, c *SubscriptionListCollector)
+	}{
+		{
+			name:  "service error envelope is a reply error, never an empty page",
+			reply: errEnvelope,
+			check: func(t *testing.T, c *SubscriptionListCollector) {
+				assert.Equal(t, 1, c.ReplyErrors())
+				assert.Equal(t, 0, c.EmptyPageCount())
+			},
+		},
+		{
+			name:  "undecodable body is a bad reply",
+			reply: []byte("not json"),
+			check: func(t *testing.T, c *SubscriptionListCollector) {
+				assert.Equal(t, 1, c.BadReplyCount())
+			},
+		},
+		{
+			name:  "missing collection is a contract violation, not an empty page",
+			reply: []byte(`{}`),
+			check: func(t *testing.T, c *SubscriptionListCollector) {
+				assert.Equal(t, 1, c.BadReplyCount())
+				assert.Equal(t, 0, c.EmptyPageCount())
+			},
+		},
+		{
+			name:  "present but empty collection is an empty page",
+			reply: []byte(`{"subscriptions":[],"hasMore":false}`),
+			check: func(t *testing.T, c *SubscriptionListCollector) {
+				assert.Equal(t, 1, c.EmptyPageCount())
+				assert.Equal(t, 0, c.BadReplyCount())
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &fakeSubListRequester{reply: tc.reply}
+			c := NewSubscriptionListCollector()
+			g := newTestSubListGenerator(t, req, c)
+
+			g.requestOne(context.Background())
+
+			assert.Len(t, c.Samples(), tc.wantSample)
+			tc.check(t, c)
+		})
+	}
+}
+
+func TestSubscriptionListGenerator_TransportErrorIsClassified(t *testing.T) {
+	req := &fakeSubListRequester{err: context.DeadlineExceeded}
+	c := NewSubscriptionListCollector()
+	g := newTestSubListGenerator(t, req, c)
+
+	g.requestOne(context.Background())
+
+	assert.Equal(t, 1, c.TimeoutErrors())
+	assert.Empty(t, c.Samples())
+}
+
+// A cancelled run is draining, not failing: counting those would inflate the
+// error tally at every step boundary.
+func TestSubscriptionListGenerator_CancelledRunRecordsNothing(t *testing.T) {
+	req := &fakeSubListRequester{err: context.Canceled}
+	c := NewSubscriptionListCollector()
+	g := newTestSubListGenerator(t, req, c)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	g.requestOne(ctx)
+
+	assert.Empty(t, c.Samples())
+	assert.Equal(t, 0, c.TimeoutErrors())
+	assert.Equal(t, 0, c.ReplyErrors())
+}
+
+func TestSubscriptionListGenerator_RunRejectsNonPositiveRate(t *testing.T) {
+	req := &fakeSubListRequester{reply: okSubListReply(t, 1, false)}
+	c := NewSubscriptionListCollector()
+	g := newTestSubListGenerator(t, req, c)
+	g.cfg.Rate = 0
+
+	assert.Error(t, g.Run(context.Background()))
+}
+
+func TestSubscriptionListGenerator_PicksOnlySeededAccountsAndIsDeterministic(t *testing.T) {
+	p, ok := BuiltinPreset("small")
+	require.True(t, ok)
+	f := BuildSubscriptionListFixtures(&p, 42, "site-a", time.Now().UTC())
+	seeded := map[string]bool{}
+	for i := range f.Subscriptions {
+		seeded[f.Subscriptions[i].User.Account] = true
+	}
+
+	pick := func() []string {
+		req := &fakeSubListRequester{reply: okSubListReply(t, 1, false)}
+		g := newTestSubListGenerator(t, req, NewSubscriptionListCollector())
+		for i := 0; i < 30; i++ {
+			g.requestOne(context.Background())
+		}
+		accounts, _ := g.cfg.Requester.(*fakeSubListRequester).seen()
+		return accounts
+	}
+
+	first := pick()
+	require.Len(t, first, 30)
+	for _, subj := range first {
+		parts := strings.Split(subj, ".")
+		require.Greater(t, len(parts), 2, "subject %q is not account-scoped", subj)
+		assert.True(t, seeded[parts[2]],
+			"account %q was addressed but owns no seeded subscriptions, so its page would come back empty", parts[2])
+	}
+	assert.Equal(t, first, pick(), "same seed must replay the same account sequence")
+}
+
+func TestSubscriptionListGenerator_EmptyFixturesRecordNothing(t *testing.T) {
+	req := &fakeSubListRequester{reply: okSubListReply(t, 1, false)}
+	c := NewSubscriptionListCollector()
+	empty := Fixtures{}
+	include := true
+	g := newSubscriptionListGenerator(&subscriptionListGeneratorConfig{
+		Fixtures: &empty, SiteID: "site-a", Rate: 10, RequestTimeout: time.Second,
+		Requester: req, Collector: c, MaxInFlight: 1,
+		ListType: "current", Limit: 200, IncludeLastMessage: &include,
+	}, 42)
+
+	g.requestOne(context.Background())
+
+	subjects, _ := req.seen()
+	assert.Empty(t, subjects, "no accounts means no request at all")
+	assert.Empty(t, c.Samples())
+}
+
+// The ramp's whole request shape rides on these three keys landing in
+// user-service's own body type. A silent mismatch would not error: an unknown
+// type is a 400 on every request, and a dropped limit quietly re-sizes the page
+// the ramp thinks it is measuring.
+func TestSubscriptionListRequest_MatchesUserServiceWireBody(t *testing.T) {
+	include := false
+	encoded, err := json.Marshal(soakSubscriptionListRequest{
+		Type: "current", Limit: 200, IncludeLastMessage: &include,
+	})
+	require.NoError(t, err)
+
+	var real usermodels.SubscriptionListRequest
+	require.NoError(t, json.Unmarshal(encoded, &real))
+	assert.Equal(t, "current", real.Type)
+	assert.Equal(t, 200, real.Limit)
+	require.NotNil(t, real.IncludeLastMessage)
+	assert.False(t, *real.IncludeLastMessage)
+}
+
+// An unset IncludeLastMessage must stay off the wire: user-service reads a
+// missing key as true, so sending an explicit false would change the workload.
+func TestSubscriptionListRequest_OmitsUnsetOptionalFields(t *testing.T) {
+	encoded, err := json.Marshal(soakSubscriptionListRequest{Type: "current"})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"type":"current"}`, string(encoded))
+}
+
+// Mirrors user-service's validListTypes; a drift here rejects a type the
+// service accepts, or lets through one it 400s on every request.
+func TestValidSubscriptionListTypes_MatchesUserService(t *testing.T) {
+	assert.Equal(t, map[string]bool{"current": true, "rooms": true, "apps": true}, validSubscriptionListTypes)
+}
+
+func TestSubscriptionListGenerator_RunDispatchesOnBothPaths(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		maxInFlight int
+	}{
+		{"paced dispatch", 4},
+		{"serial dispatch (bisection path)", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &fakeSubListRequester{reply: okSubListReply(t, 3, false)}
+			c := NewSubscriptionListCollector()
+			g := newTestSubListGenerator(t, req, c)
+			g.cfg.MaxInFlight = tc.maxInFlight
+			g.cfg.Rate = 200
+
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+			require.NoError(t, g.Run(ctx))
+
+			subjects, _ := req.seen()
+			assert.NotEmpty(t, subjects, "the run must have dispatched at least one request")
+		})
+	}
+}
+
+func TestSubListRowName(t *testing.T) {
+	channel := &model.Room{Type: model.RoomTypeChannel, Name: "engineering"}
+	dm := &model.Room{Type: model.RoomTypeDM, Name: "room-7"}
+
+	tests := []struct {
+		name    string
+		room    *model.Room
+		members []string
+		account string
+		want    string
+	}{
+		{"channel carries the room name", channel, []string{"alice", "bob"}, "alice", "engineering"},
+		{"dm carries the counterpart account", dm, []string{"alice", "bob"}, "alice", "bob"},
+		{"dm from the other side", dm, []string{"alice", "bob"}, "bob", "alice"},
+		{"self-dm falls back to the room name", dm, []string{"alice"}, "alice", "room-7"},
+		{"dm with no members falls back", dm, nil, "alice", "room-7"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, subListRowName(tc.room, tc.members, tc.account))
+		})
+	}
+}
+
+// The realistic preset's last 10% of rooms are DMs, so it is the preset that
+// exercises the counterpart-naming branch end to end.
+func TestBuildSubscriptionListFixtures_NamesDMRowsAfterTheCounterpart(t *testing.T) {
+	p, ok := BuiltinPreset("realistic")
+	require.True(t, ok)
+	f := BuildSubscriptionListFixtures(&p, 42, "site-a", time.Now().UTC())
+
+	roomType := map[string]model.RoomType{}
+	for i := range f.Rooms {
+		roomType[f.Rooms[i].ID] = f.Rooms[i].Type
+	}
+	dmRows := 0
+	for i := range f.Subscriptions {
+		s := &f.Subscriptions[i]
+		if roomType[s.RoomID] != model.RoomTypeDM {
+			continue
+		}
+		dmRows++
+		assert.NotEqual(t, s.User.Account, s.Name, "a DM row is named after the counterpart, not the subscriber")
+		assert.NotEmpty(t, s.Name)
+	}
+	require.Positive(t, dmRows, "the realistic preset must produce DM rows")
+}
+
+// The body is marshalled once at construction, so a request must still carry
+// the full shape on every call — not just the first.
+func TestSubscriptionListGenerator_ReusesTheSameBodyAcrossRequests(t *testing.T) {
+	req := &fakeSubListRequester{reply: okSubListReply(t, 2, false)}
+	g := newTestSubListGenerator(t, req, NewSubscriptionListCollector())
+
+	for i := 0; i < 3; i++ {
+		g.requestOne(context.Background())
+	}
+
+	_, bodies := req.seen()
+	require.Len(t, bodies, 3)
+	for _, b := range bodies {
+		var sent soakSubscriptionListRequest
+		require.NoError(t, json.Unmarshal(b, &sent))
+		assert.Equal(t, "current", sent.Type)
+		assert.Equal(t, 200, sent.Limit)
+		require.NotNil(t, sent.IncludeLastMessage)
+	}
+}
+
+// A body that cannot be built is a configuration fault, so it must surface once
+// from Run rather than as one bad reply per request.
+func TestSubscriptionListGenerator_RunReportsBodyMarshalFailureOnce(t *testing.T) {
+	req := &fakeSubListRequester{reply: okSubListReply(t, 1, false)}
+	c := NewSubscriptionListCollector()
+	g := newTestSubListGenerator(t, req, c)
+	g.bodyErr = assert.AnError
+
+	err := g.Run(context.Background())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, assert.AnError)
+	assert.Equal(t, 0, c.BadReplyCount())
+	subjects, _ := req.seen()
+	assert.Empty(t, subjects, "no request is dispatched when the body could not be built")
+}

--- a/tools/loadgen/subscriptionlist_generator_test.go
+++ b/tools/loadgen/subscriptionlist_generator_test.go
@@ -277,6 +277,39 @@ func TestValidSubscriptionListTypes_MatchesUserService(t *testing.T) {
 	assert.Equal(t, map[string]bool{"current": true, "rooms": true, "apps": true}, validSubscriptionListTypes)
 }
 
+// apps is a type user-service serves but these fixtures cannot: BuildFixtures
+// creates only channel and dm rooms, while apps matches subscribed botDM rows
+// alone. Accepting it would make every request return an empty page — recorded
+// as a failure, contributing no latency — so the ramp would report a total
+// failure rate against a perfectly healthy service.
+func TestWorkloadSupportedListTypes_ExcludesAppsWithoutBotDMFixtures(t *testing.T) {
+	assert.Equal(t, map[string]bool{"current": true, "rooms": true}, workloadSupportedListTypes)
+
+	for listType := range workloadSupportedListTypes {
+		assert.True(t, validSubscriptionListTypes[listType],
+			"%q must also be a type user-service accepts", listType)
+	}
+	assert.True(t, validSubscriptionListTypes["apps"],
+		"apps stays valid for the service; it is only this workload's fixtures that cannot serve it")
+	assert.False(t, workloadSupportedListTypes["apps"])
+}
+
+// The fixtures the workload seeds must contain no botDM rows, which is the
+// reason apps is unsupported. If that ever changes, apps can be supported and
+// this test says so.
+func TestBuildSubscriptionListFixtures_ContainNoBotDMRows(t *testing.T) {
+	for _, name := range []string{"small", "medium", "realistic"} {
+		t.Run(name, func(t *testing.T) {
+			p, ok := BuiltinPreset(name)
+			require.True(t, ok)
+			f := BuildSubscriptionListFixtures(&p, 42, "site-a", time.Now().UTC())
+			for i := range f.Subscriptions {
+				assert.NotEqual(t, model.RoomTypeBotDM, f.Subscriptions[i].RoomType)
+			}
+		})
+	}
+}
+
 func TestSubscriptionListGenerator_RunDispatchesOnBothPaths(t *testing.T) {
 	for _, tc := range []struct {
 		name        string

--- a/tools/loadgen/subscriptionlist_generator_test.go
+++ b/tools/loadgen/subscriptionlist_generator_test.go
@@ -52,6 +52,11 @@ func okSubListReply(t *testing.T, rows int, hasMore bool) []byte {
 
 func newTestSubListGenerator(t *testing.T, req SubscriptionListRequester, c *SubscriptionListCollector) *subscriptionListGenerator {
 	t.Helper()
+	return newTestSubListGeneratorWithRunCtx(t, req, c, context.Background())
+}
+
+func newTestSubListGeneratorWithRunCtx(t *testing.T, req SubscriptionListRequester, c *SubscriptionListCollector, runCtx context.Context) *subscriptionListGenerator {
+	t.Helper()
 	p, ok := BuiltinPreset("small")
 	require.True(t, ok)
 	f := BuildSubscriptionListFixtures(&p, 42, "site-a", time.Now().UTC())
@@ -67,6 +72,7 @@ func newTestSubListGenerator(t *testing.T, req SubscriptionListRequester, c *Sub
 		ListType:           "current",
 		Limit:              200,
 		IncludeLastMessage: &include,
+		RunCtx:             runCtx,
 	}, 42)
 }
 
@@ -169,22 +175,6 @@ func TestSubscriptionListGenerator_TransportErrorIsClassified(t *testing.T) {
 
 	assert.Equal(t, 1, c.TimeoutErrors())
 	assert.Empty(t, c.Samples())
-}
-
-// A cancelled run is draining, not failing: counting those would inflate the
-// error tally at every step boundary.
-func TestSubscriptionListGenerator_CancelledRunRecordsNothing(t *testing.T) {
-	req := &fakeSubListRequester{err: context.Canceled}
-	c := NewSubscriptionListCollector()
-	g := newTestSubListGenerator(t, req, c)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	g.requestOne(ctx)
-
-	assert.Empty(t, c.Samples())
-	assert.Equal(t, 0, c.TimeoutErrors())
-	assert.Equal(t, 0, c.ReplyErrors())
 }
 
 func TestSubscriptionListGenerator_RunRejectsNonPositiveRate(t *testing.T) {
@@ -419,4 +409,81 @@ func TestSubscriptionListGenerator_RunReportsBodyMarshalFailureOnce(t *testing.T
 	assert.Equal(t, 0, c.BadReplyCount())
 	subjects, _ := req.seen()
 	assert.Empty(t, subjects, "no request is dispatched when the body could not be built")
+}
+
+// A row a client cannot use is a contract failure, the same as the top-level
+// `{}` case — and it is also the fastest possible reply, so accepting it would
+// contribute a fast successful sample.
+func TestSubscriptionListGenerator_RejectsRowsMissingRoomID(t *testing.T) {
+	tests := []struct {
+		name        string
+		reply       string
+		wantSamples int
+		wantBad     int
+	}{
+		{"row without roomId", `{"subscriptions":[{}],"hasMore":false}`, 0, 1},
+		{"one good row, one malformed", `{"subscriptions":[{"roomId":"r1"},{}]}`, 0, 1},
+		{"all rows well formed", `{"subscriptions":[{"roomId":"r1"},{"roomId":"r2"}]}`, 1, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &fakeSubListRequester{reply: []byte(tc.reply)}
+			c := NewSubscriptionListCollector()
+			g := newTestSubListGenerator(t, req, c)
+
+			g.requestOne(context.Background())
+
+			assert.Len(t, c.Samples(), tc.wantSamples)
+			assert.Equal(t, tc.wantBad, c.BadReplyCount())
+		})
+	}
+}
+
+// The window context stops new dispatches; it must not abort and erase requests
+// already admitted into the measured window. Those are disproportionately the
+// slow ones, so dropping them biases latency and error rate downward.
+func TestSubscriptionListGenerator_AdmittedRequestSurvivesDispatchCancellation(t *testing.T) {
+	req := &fakeSubListRequester{reply: okSubListReply(t, 3, false)}
+	c := NewSubscriptionListCollector()
+	g := newTestSubListGenerator(t, req, c)
+
+	dispatchCtx, cancelDispatch := context.WithCancel(context.Background())
+	cancelDispatch()
+
+	g.requestOne(dispatchCtx)
+
+	assert.Len(t, c.Samples(), 1,
+		"a request admitted before the boundary must still be measured")
+}
+
+// Outer cancellation is the run genuinely ending, and must still discard.
+func TestSubscriptionListGenerator_OuterCancellationStillDiscards(t *testing.T) {
+	req := &fakeSubListRequester{err: context.Canceled}
+	c := NewSubscriptionListCollector()
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	g := newTestSubListGeneratorWithRunCtx(t, req, c, runCtx)
+	cancelRun()
+
+	g.requestOne(context.Background())
+
+	assert.Empty(t, c.Samples())
+	assert.Equal(t, 0, c.TimeoutErrors())
+}
+
+// An unset RunCtx falls back to the dispatch context, so a caller that does not
+// thread the run context keeps the previous behaviour rather than losing
+// cancellation entirely.
+func TestSubscriptionListGenerator_RequestCtxFallsBackToDispatchCtx(t *testing.T) {
+	req := &fakeSubListRequester{reply: okSubListReply(t, 1, false)}
+	g := newTestSubListGenerator(t, req, NewSubscriptionListCollector())
+
+	type ctxKey string
+	dispatchCtx := context.WithValue(context.Background(), ctxKey("k"), "v")
+
+	g.cfg.RunCtx = nil
+	assert.Equal(t, "v", g.requestCtx(dispatchCtx).Value(ctxKey("k")))
+
+	runCtx := context.WithValue(context.Background(), ctxKey("k"), "run")
+	g.cfg.RunCtx = runCtx
+	assert.Equal(t, "run", g.requestCtx(dispatchCtx).Value(ctxKey("k")))
 }

--- a/tools/loadgen/subscriptionlist_integration_test.go
+++ b/tools/loadgen/subscriptionlist_integration_test.go
@@ -79,9 +79,9 @@ func TestSubscriptionListFixtures_ListTypesBehaveAsTheWorkloadAssumes(t *testing
 		assert.NotEmpty(t, res.Data)
 	})
 
-	// The seeder writes no botDM rows, so apps is legitimately empty. Pinned so a
-	// future --list-type=apps ramp is understood as measuring an empty page
-	// rather than a fast endpoint.
+	// The seeder writes no botDM rows, so apps is legitimately empty — which is
+	// why the workload rejects --list-type=apps rather than measuring it. Pinned
+	// here so that guard can be lifted the day botDM fixtures exist.
 	t.Run("apps is empty because the seeder writes no botDM rows", func(t *testing.T) {
 		res, err := repo.AggregateSubscriptions(ctx, account, "apps", false, nil, page)
 		require.NoError(t, err)

--- a/tools/loadgen/subscriptionlist_integration_test.go
+++ b/tools/loadgen/subscriptionlist_integration_test.go
@@ -1,0 +1,125 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/mongoutil"
+	"github.com/hmchangw/chat/pkg/testutil"
+	"github.com/hmchangw/chat/user-service/mongorepo"
+)
+
+// The whole workload rests on one assumption the unit tests can only approximate:
+// that fixtures written by the seeder survive user-service's own match filter.
+// Three zero-valued fields (open, roomType, name) each make the query return an
+// empty page rather than an error, so a regression here is silent — the ramp
+// would report excellent latency for the cost of finding nothing. This drives
+// the real repository against real Mongo.
+func TestSubscriptionListFixtures_ProduceNonEmptyPagesThroughUserService(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	db := testutil.MongoDB(t, "sublist")
+	p, ok := BuiltinPreset("small")
+	require.True(t, ok)
+	fixtures := BuildSubscriptionListFixtures(&p, 42, "site-a", time.Now().UTC())
+	require.NoError(t, Seed(ctx, db, &fixtures))
+
+	repo := mongorepo.NewSubscriptionRepo(db, 1024, time.Minute)
+	require.NoError(t, repo.EnsureIndexes(ctx))
+
+	accounts := map[string]struct{}{}
+	for i := range fixtures.Subscriptions {
+		accounts[fixtures.Subscriptions[i].User.Account] = struct{}{}
+	}
+	require.NotEmpty(t, accounts)
+
+	page := mongoutil.OffsetPageRequest{Offset: 0, Limit: 200}
+	for account := range accounts {
+		res, err := repo.AggregateSubscriptions(ctx, account, "current", false, nil, page)
+		require.NoError(t, err, "account %s", account)
+		assert.NotEmpty(t, res.Data, "account %s must get a non-empty page: an empty one means the seeded fixtures no longer match user-service's filter", account)
+	}
+}
+
+// The generator picks accounts uniformly from the same fixture set, so every
+// account it can address must resolve. This pins the list type the workload
+// defaults to; a type the fixtures cannot satisfy is a silent empty ramp.
+func TestSubscriptionListFixtures_ListTypesBehaveAsTheWorkloadAssumes(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	db := testutil.MongoDB(t, "sublisttypes")
+	p, ok := BuiltinPreset("realistic")
+	require.True(t, ok)
+	fixtures := BuildSubscriptionListFixtures(&p, 42, "site-a", time.Now().UTC())
+	require.NoError(t, Seed(ctx, db, &fixtures))
+
+	repo := mongorepo.NewSubscriptionRepo(db, 1024, time.Minute)
+	require.NoError(t, repo.EnsureIndexes(ctx))
+
+	account := fixtures.Subscriptions[0].User.Account
+	page := mongoutil.OffsetPageRequest{Offset: 0, Limit: 200}
+
+	t.Run("current returns rows", func(t *testing.T) {
+		res, err := repo.AggregateSubscriptions(ctx, account, "current", false, nil, page)
+		require.NoError(t, err)
+		assert.NotEmpty(t, res.Data)
+	})
+
+	t.Run("rooms returns rows", func(t *testing.T) {
+		res, err := repo.AggregateSubscriptions(ctx, account, "rooms", false, nil, page)
+		require.NoError(t, err)
+		assert.NotEmpty(t, res.Data)
+	})
+
+	// The seeder writes no botDM rows, so apps is legitimately empty. Pinned so a
+	// future --list-type=apps ramp is understood as measuring an empty page
+	// rather than a fast endpoint.
+	t.Run("apps is empty because the seeder writes no botDM rows", func(t *testing.T) {
+		res, err := repo.AggregateSubscriptions(ctx, account, "apps", false, nil, page)
+		require.NoError(t, err)
+		assert.Empty(t, res.Data)
+	})
+}
+
+// hasMore drives nothing in the ramp's verdict but is recorded per sample, so a
+// page smaller than the account's subscription count must report it.
+func TestSubscriptionListFixtures_HasMoreReflectsPaging(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	db := testutil.MongoDB(t, "sublistpaging")
+	p, ok := BuiltinPreset("small")
+	require.True(t, ok)
+	fixtures := BuildSubscriptionListFixtures(&p, 42, "site-a", time.Now().UTC())
+	require.NoError(t, Seed(ctx, db, &fixtures))
+
+	repo := mongorepo.NewSubscriptionRepo(db, 1024, time.Minute)
+	require.NoError(t, repo.EnsureIndexes(ctx))
+
+	byAccount := map[string]int{}
+	for i := range fixtures.Subscriptions {
+		byAccount[fixtures.Subscriptions[i].User.Account]++
+	}
+	var account string
+	for a, n := range byAccount {
+		if n > 1 {
+			account = a
+			break
+		}
+	}
+	require.NotEmpty(t, account, "the preset must give some account more than one subscription")
+
+	res, err := repo.AggregateSubscriptions(ctx, account, "current", false, nil,
+		mongoutil.OffsetPageRequest{Offset: 0, Limit: 1})
+	require.NoError(t, err)
+	assert.Len(t, res.Data, 1)
+	assert.True(t, res.HasMore, "a truncated page must report hasMore")
+}

--- a/tools/loadgen/subscriptionlist_integration_test.go
+++ b/tools/loadgen/subscriptionlist_integration_test.go
@@ -96,7 +96,9 @@ func TestSubscriptionListFixtures_HasMoreReflectsPaging(t *testing.T) {
 	defer cancel()
 
 	db := testutil.MongoDB(t, "sublistpaging")
-	p, ok := BuiltinPreset("small")
+	// realistic, not small: the uniform presets put every account in exactly one
+	// room, so no account there can have a second page to report.
+	p, ok := BuiltinPreset("realistic")
 	require.True(t, ok)
 	fixtures := BuildSubscriptionListFixtures(&p, 42, "site-a", time.Now().UTC())
 	require.NoError(t, Seed(ctx, db, &fixtures))

--- a/tools/loadgen/subscriptionlist_seed.go
+++ b/tools/loadgen/subscriptionlist_seed.go
@@ -12,11 +12,15 @@ import (
 // work; an all-equal key would collapse every comparison onto the name tiebreak.
 const subListActivitySpread = 30 * 24 * time.Hour
 
-// subListLastSeenSpread bounds how far behind a room's activity a member's
-// LastSeenAt may sit. hasUnread is computed per row by comparing the two, so a
-// spread means a page carries a realistic mix of read and unread rows rather
-// than resolving the same way for every one.
+// subListLastSeenSpread bounds how far a member's LastSeenAt sits from the
+// room's activity, in either direction. hasUnread is computed per row by
+// comparing the two, so the sign is what decides the branch.
 const subListLastSeenSpread = 14 * 24 * time.Hour
+
+// subListCaughtUpShare is the fraction of subscriptions seeded at or after their
+// room's activity, i.e. read. Drawing LastSeenAt only from behind made every row
+// unread, so the caught-up branch never ran and every row resolved the same way.
+const subListCaughtUpShare = 0.4
 
 // BuildSubscriptionListFixtures reuses the messages preset fixtures and stamps
 // the three fields subscription.list's match filter reads and BuildFixtures
@@ -68,11 +72,22 @@ func BuildSubscriptionListFixtures(p *Preset, seed int64, siteID string, now tim
 		s.RoomType = room.Type
 		s.Name = subListRowName(room, membersByRoom[s.RoomID], s.User.Account)
 
-		behind := time.Duration(r.Int63n(int64(subListLastSeenSpread)))
-		lastSeenAt := room.LastMsgAt.Add(-behind).UTC()
-		s.LastSeenAt = &lastSeenAt
+		s.LastSeenAt = seededLastSeenAt(r, *room.LastMsgAt)
 	}
 	return f
+}
+
+// seededLastSeenAt places a member either at/after the room's activity (read) or
+// behind it (unread), so a page carries both. Ahead is capped well short of the
+// activity spread so a caught-up member cannot be dragged past `now`.
+func seededLastSeenAt(r *rand.Rand, lastMsgAt time.Time) *time.Time {
+	offset := time.Duration(r.Int63n(int64(subListLastSeenSpread)))
+	at := lastMsgAt.Add(-offset).UTC()
+	if r.Float64() < subListCaughtUpShare {
+		// Equal counts as read, so a zero offset is a legitimate draw here.
+		at = lastMsgAt.Add(offset % time.Hour).UTC()
+	}
+	return &at
 }
 
 // subListRowName mirrors how the service names a row: a channel carries the

--- a/tools/loadgen/subscriptionlist_seed.go
+++ b/tools/loadgen/subscriptionlist_seed.go
@@ -90,3 +90,31 @@ func subListRowName(room *model.Room, members []string, account string) string {
 	}
 	return room.Name
 }
+
+// minSidebarSubsPerAccount is the mean below which a preset stops modelling a
+// sidebar. The uniform presets (small/medium/large) put every account in exactly
+// one room, so their pages carry a single row: a ramp over them reports the
+// latency of a one-row reply, which is fast and says nothing about the endpoint
+// under real sidebars. Only `realistic` has the mixed room sizes that give an
+// account several rooms.
+const minSidebarSubsPerAccount = 2.0
+
+// subscriptionsPerAccount returns the mean subscriptions per distinct account,
+// or 0 when there are none.
+func subscriptionsPerAccount(f *Fixtures) float64 {
+	accounts := make(map[string]struct{}, len(f.Subscriptions))
+	for i := range f.Subscriptions {
+		accounts[f.Subscriptions[i].User.Account] = struct{}{}
+	}
+	if len(accounts) == 0 {
+		return 0
+	}
+	return float64(len(f.Subscriptions)) / float64(len(accounts))
+}
+
+// degeneratePageFixtures reports whether these fixtures would make the ramp
+// measure a page too small to mean anything. Warned about rather than rejected:
+// measuring the floor is a legitimate thing to want, as long as it is on purpose.
+func degeneratePageFixtures(f *Fixtures) bool {
+	return subscriptionsPerAccount(f) < minSidebarSubsPerAccount
+}

--- a/tools/loadgen/subscriptionlist_seed.go
+++ b/tools/loadgen/subscriptionlist_seed.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"math/rand" // #nosec G404 -- load generator randomness, never used for secrets // nosemgrep: math-random-used
+	"time"
+
+	"github.com/hmchangw/chat/pkg/model"
+)
+
+// subListActivitySpread bounds how far back a room's last-message time may sit.
+// The list sorts on this key, so a spread is what makes the comparator do real
+// work; an all-equal key would collapse every comparison onto the name tiebreak.
+const subListActivitySpread = 30 * 24 * time.Hour
+
+// subListLastSeenSpread bounds how far behind a room's activity a member's
+// LastSeenAt may sit. hasUnread is computed per row by comparing the two, so a
+// spread means a page carries a realistic mix of read and unread rows rather
+// than resolving the same way for every one.
+const subListLastSeenSpread = 14 * 24 * time.Hour
+
+// BuildSubscriptionListFixtures reuses the messages preset fixtures and stamps
+// the three fields subscription.list's match filter reads and BuildFixtures
+// leaves at their zero value:
+//
+//   - Open, because it has no bson omitempty — a false persists as open:false
+//     and match["open"]={$ne:false} drops the row.
+//   - RoomType, because the "current" match needs dm/channel (or a subscribed
+//     botDM) and "" matches no branch.
+//   - Name, which subLite projects for the self-DM pin and the name tiebreak.
+//
+// A miss on any of them returns an empty page rather than an error, so a ramp
+// would measure the cost of finding nothing. Room activity keys and member
+// LastSeenAt are spread so the sort and the hasUnread computation both do real
+// work. Deterministic for a given seed.
+func BuildSubscriptionListFixtures(p *Preset, seed int64, siteID string, now time.Time) Fixtures {
+	f := BuildFixtures(p, seed, siteID)
+	r := rand.New(rand.NewSource(seed))
+	now = now.UTC()
+
+	roomByID := make(map[string]*model.Room, len(f.Rooms))
+	for i := range f.Rooms {
+		room := &f.Rooms[i]
+		roomByID[room.ID] = room
+		at := now.Add(-time.Duration(r.Int63n(int64(subListActivitySpread)))).UTC()
+		lastMsgAt := at
+		room.LastMsgAt = &lastMsgAt
+		// The unread reference is LastUserMsgAt ?? LastMsgAt; the fixtures carry
+		// no system messages, so the two coincide.
+		lastUserMsgAt := at
+		room.LastUserMsgAt = &lastUserMsgAt
+	}
+
+	// A DM row's name is the counterpart's account, so collect each room's
+	// members before naming — a channel needs only the room itself.
+	membersByRoom := make(map[string][]string, len(f.Rooms))
+	for i := range f.Subscriptions {
+		s := &f.Subscriptions[i]
+		membersByRoom[s.RoomID] = append(membersByRoom[s.RoomID], s.User.Account)
+	}
+
+	for i := range f.Subscriptions {
+		s := &f.Subscriptions[i]
+		room, ok := roomByID[s.RoomID]
+		if !ok {
+			continue
+		}
+		s.Open = true
+		s.RoomType = room.Type
+		s.Name = subListRowName(room, membersByRoom[s.RoomID], s.User.Account)
+
+		behind := time.Duration(r.Int63n(int64(subListLastSeenSpread)))
+		lastSeenAt := room.LastMsgAt.Add(-behind).UTC()
+		s.LastSeenAt = &lastSeenAt
+	}
+	return f
+}
+
+// subListRowName mirrors how the service names a row: a channel carries the
+// room's name, a DM the counterpart's account. A DM whose counterpart is
+// missing (or a self-DM) falls back to the room name rather than empty, which
+// the name tiebreak would sort inconsistently.
+func subListRowName(room *model.Room, members []string, account string) string {
+	if room.Type != model.RoomTypeDM {
+		return room.Name
+	}
+	for _, m := range members {
+		if m != account {
+			return m
+		}
+	}
+	return room.Name
+}

--- a/tools/loadgen/subscriptionlist_seed_test.go
+++ b/tools/loadgen/subscriptionlist_seed_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/model"
+)
+
+// The subscription.list match filter is unforgiving about two fields BuildFixtures
+// leaves at their zero value, and a miss on either returns an empty page rather
+// than an error — a ramp would then measure the cost of finding nothing. These
+// tests pin both, plus the sort-key spread the list's comparator needs.
+func TestBuildSubscriptionListFixtures_SubscriptionsSurviveTheListFilter(t *testing.T) {
+	p, ok := BuiltinPreset("small")
+	require.True(t, ok)
+	f := BuildSubscriptionListFixtures(&p, 42, "site-a", time.Now().UTC())
+
+	require.NotEmpty(t, f.Subscriptions)
+	roomType := map[string]model.RoomType{}
+	for i := range f.Rooms {
+		roomType[f.Rooms[i].ID] = f.Rooms[i].Type
+	}
+	for i := range f.Subscriptions {
+		s := &f.Subscriptions[i]
+		// match["open"] = {$ne: false}: Open has no bson omitempty, so a false
+		// here persists as open:false and the row is filtered out.
+		assert.True(t, s.Open, "subscription %s must be open", s.ID)
+		// match on current: roomType must be one of dm/channel; "" matches neither.
+		assert.Contains(t, []model.RoomType{model.RoomTypeChannel, model.RoomTypeDM}, s.RoomType)
+		assert.Equal(t, roomType[s.RoomID], s.RoomType, "roomType must mirror the room")
+		// subLite projects name for the self-DM pin and the name tiebreak.
+		assert.NotEmpty(t, s.Name)
+	}
+}
+
+func TestBuildSubscriptionListFixtures_RoomsCarrySpreadSortKeys(t *testing.T) {
+	p, ok := BuiltinPreset("medium")
+	require.True(t, ok)
+	now := time.Now().UTC()
+	f := BuildSubscriptionListFixtures(&p, 42, "site-a", now)
+
+	require.NotEmpty(t, f.Rooms)
+	seen := map[time.Time]bool{}
+	for i := range f.Rooms {
+		require.NotNil(t, f.Rooms[i].LastMsgAt, "room %s needs a sort key", f.Rooms[i].ID)
+		assert.False(t, f.Rooms[i].LastMsgAt.After(now), "sort keys stay in the past")
+		seen[*f.Rooms[i].LastMsgAt] = true
+	}
+	// An all-equal LastMsgAt would collapse the comparator onto its name
+	// tiebreak and hide the real sort cost, so require a genuine spread.
+	assert.Greater(t, len(seen), len(f.Rooms)/2, "LastMsgAt must be spread across rooms")
+}
+
+func TestBuildSubscriptionListFixtures_DeterministicForSeed(t *testing.T) {
+	p, ok := BuiltinPreset("small")
+	require.True(t, ok)
+	now := time.Now().UTC()
+
+	a := BuildSubscriptionListFixtures(&p, 7, "site-a", now)
+	b := BuildSubscriptionListFixtures(&p, 7, "site-a", now)
+	assert.Equal(t, a.Rooms, b.Rooms)
+	assert.Equal(t, a.Subscriptions, b.Subscriptions)
+
+	c := BuildSubscriptionListFixtures(&p, 8, "site-a", now)
+	assert.NotEqual(t, a.Rooms, c.Rooms, "a different seed must move the sort keys")
+}
+
+// Every account the generator can pick must own at least one row, or the ramp
+// silently measures empty pages for that slice of its account space.
+func TestBuildSubscriptionListFixtures_AccountsHaveSubscriptions(t *testing.T) {
+	p, ok := BuiltinPreset("small")
+	require.True(t, ok)
+	f := BuildSubscriptionListFixtures(&p, 42, "site-a", time.Now().UTC())
+
+	byAccount := map[string]int{}
+	for i := range f.Subscriptions {
+		byAccount[f.Subscriptions[i].User.Account]++
+	}
+	assert.NotEmpty(t, byAccount)
+	for acct, n := range byAccount {
+		assert.Positive(t, n, "account %s has no subscriptions", acct)
+	}
+}

--- a/tools/loadgen/subscriptionlist_seed_test.go
+++ b/tools/loadgen/subscriptionlist_seed_test.go
@@ -124,3 +124,36 @@ func TestSubscriptionsPerAccount_EmptyFixturesAreDegenerate(t *testing.T) {
 	assert.InDelta(t, 0.0, subscriptionsPerAccount(&empty), 0.001)
 	assert.True(t, degeneratePageFixtures(&empty))
 }
+
+// hasUnread is computed per row by comparing the room's activity to the
+// member's lastSeenAt. Drawing lastSeenAt only from [lastMsgAt-spread, lastMsgAt]
+// made every row unread, so the branch that resolves a caught-up room never ran.
+func TestBuildSubscriptionListFixtures_ProduceBothReadAndUnreadRows(t *testing.T) {
+	p, ok := BuiltinPreset("realistic")
+	require.True(t, ok)
+	f := BuildSubscriptionListFixtures(&p, 42, "site-a", time.Now().UTC())
+
+	activity := map[string]time.Time{}
+	for i := range f.Rooms {
+		require.NotNil(t, f.Rooms[i].LastMsgAt)
+		activity[f.Rooms[i].ID] = *f.Rooms[i].LastMsgAt
+	}
+
+	caughtUp, unread := 0, 0
+	for i := range f.Subscriptions {
+		s := &f.Subscriptions[i]
+		require.NotNil(t, s.LastSeenAt)
+		if s.LastSeenAt.Before(activity[s.RoomID]) {
+			unread++
+		} else {
+			caughtUp++
+		}
+	}
+
+	assert.Positive(t, unread, "no unread rows: the unread branch would never run")
+	assert.Positive(t, caughtUp, "no caught-up rows: hasUnread resolves the same way for every row")
+	// Neither state should be a rounding error, or the rarer branch is barely exercised.
+	total := caughtUp + unread
+	assert.Greater(t, float64(caughtUp)/float64(total), 0.2)
+	assert.Greater(t, float64(unread)/float64(total), 0.2)
+}

--- a/tools/loadgen/subscriptionlist_seed_test.go
+++ b/tools/loadgen/subscriptionlist_seed_test.go
@@ -85,3 +85,42 @@ func TestBuildSubscriptionListFixtures_AccountsHaveSubscriptions(t *testing.T) {
 		assert.Positive(t, n, "account %s has no subscriptions", acct)
 	}
 }
+
+// The uniform presets give every account exactly one subscription, so a ramp on
+// them measures a one-row page rather than a sidebar cold-open — fast, and
+// meaningless. This pins the numbers the workload's startup warning keys on, so
+// a preset change that quietly degrades the workload fails here.
+func TestSubscriptionsPerAccount_SeparatesSidebarPresetsFromDegenerateOnes(t *testing.T) {
+	tests := []struct {
+		preset       string
+		wantSidebar  bool
+		atLeastCount float64
+	}{
+		{preset: "small", wantSidebar: false},
+		{preset: "medium", wantSidebar: false},
+		{preset: "realistic", wantSidebar: true, atLeastCount: 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.preset, func(t *testing.T) {
+			p, ok := BuiltinPreset(tc.preset)
+			require.True(t, ok)
+			f := BuildSubscriptionListFixtures(&p, 42, "site-a", time.Now().UTC())
+
+			mean := subscriptionsPerAccount(&f)
+			assert.Positive(t, mean)
+			if tc.wantSidebar {
+				assert.GreaterOrEqual(t, mean, tc.atLeastCount)
+				assert.False(t, degeneratePageFixtures(&f))
+			} else {
+				assert.Less(t, mean, minSidebarSubsPerAccount)
+				assert.True(t, degeneratePageFixtures(&f))
+			}
+		})
+	}
+}
+
+func TestSubscriptionsPerAccount_EmptyFixturesAreDegenerate(t *testing.T) {
+	empty := Fixtures{}
+	assert.InDelta(t, 0.0, subscriptionsPerAccount(&empty), 0.001)
+	assert.True(t, degeneratePageFixtures(&empty))
+}


### PR DESCRIPTION
Adds a ninth `max-rps` workload driving `subscription.list` over NATS request/reply, so the sidebar cold-open path gets the capacity ramp the soak and daily programs already assume but never measured.

```bash
loadgen seed     --workload=subscription-list --preset=realistic
loadgen max-rps  --workload=subscription-list --preset=realistic
loadgen teardown --workload=subscription-list --preset=realistic
```

Scope is NATS only. An HTTP arm against `GET /api/v1/subscriptions` was considered and deliberately deferred — it needs a real Keycloak token per fixture account, and the realm ships only `alice`/`bob`, so it wants its own design.

## Workload shape

Every request is the call a client makes on connect — `type=current`, `limit=200`, `includeLastMessage=true`, `offset=0` — because the reconnect burst, not steady browsing, is what this endpoint has to survive.

Accounts are picked **uniformly**, unlike `room-read`'s Zipf skew: a client cold-opens its sidebar once per connect, so there is no hot-account concentration to model. The skew that matters is across rooms *within* one account's page, which the `realistic` fixtures carry.

## Use `--preset=realistic`

Not incidental. The uniform presets put every account in **exactly one room**:

| preset | accounts | max subs/account | accounts with 2+ |
|---|---|---|---|
| `small` / `medium` / `large` | 10 / 1000 / 10000 | **1** | **0** |
| `realistic` | 955 | 9 | 794 |

A ramp on `medium` measures a one-row reply — fast, and silent about the endpoint under real sidebars. The workload warns at startup when the preset averages under two subscriptions per account, and logs mean rows per page at every step, so a degenerate run is visible in the output instead of just looking quick.

## Why it seeds its own fixtures

`seed --workload=subscription-list` is not interchangeable with the plain `seed`. `BuildFixtures` leaves three fields at their zero value that `subscription.list`'s match filter reads, and a miss on any of them returns an **empty page rather than an error** — so the stock fixtures would have produced a ramp measuring the cost of finding nothing:

| Field | Why the zero value fails |
|---|---|
| `open` | no bson `omitempty`, so `false` persists as `open:false` and `match["open"]={$ne:false}` drops the row |
| `roomType` | the `current` match needs `dm`/`channel` (or a subscribed `botDM`); `""` matches no branch |
| `name` | `subLite` projects it for the self-DM pin and the name tiebreak |

The seeder also spreads each room's `lastMsgAt` and each member's `lastSeenAt`. An all-equal sort key would collapse the list comparator onto its name tiebreak and hide the real sort cost; a uniform `lastSeenAt` would make every row resolve `hasUnread` the same way.

## Reply classification

Four outcomes are kept apart. An errcode envelope and a `{}` body both decode to zero rows, so folding either into "empty page" would report a service outage or a contract break as a fast, healthy, empty sidebar. The `{}` check is on presence of the collection, not its length — a genuinely empty sidebar replies with an empty array.

Empty pages **count as failures**. Every seeded account owns subscriptions, so a zero-row reply means the fixtures are wrong — and since an empty page is also the fastest possible reply, scoring it as a success would let a misconfigured run report a record-breaking ramp.

## Note for whoever runs this first

`--list-limit=200` can exceed the NATS payload ceiling. `docs/client-api.md` recommends 200, but that advice is for the HTTP form, which has no ceiling; the NATS reply caps at 128 KB and the handler does not truncate. When a page overflows, the service cannot publish the reply and the request times out. **A ramp reporting timeouts at every step, including the lowest, is likely hitting the cap rather than a capacity limit** — lower `--list-limit` to confirm. The default is left at 200 rather than quietly lowered, since surfacing this is arguably the more useful result. Documented in the README.

`--list-type` accepts `current` and `rooms`. `apps` is rejected with a specific reason: user-service serves it, but it matches subscribed `botDM` rows alone and these fixtures seed none, so every page would come back empty.

## Files

| File | |
|---|---|
| `subscriptionlist_seed.go` | fixtures builder, degenerate-preset detection, `seed`/`teardown` wiring |
| `subscriptionlist_collector.go` | samples, error classes, row stats |
| `subscriptionlist_generator.go` | account pick, request build, reply classification |
| `maxrps_subscriptionlist.go` | `rpsWorkload` adapter |
| `maxrps.go` / `main.go` / `deploy/Makefile` / `README.md` | wiring and docs |

Each with a table-driven test file, written first. The request body is marshalled once at construction — re-encoding per call would put the load box's CPU on the critical path and surface as emit underrun.

No `docs/client-api.md` change: this only reads existing endpoints, it does not touch a handler.

## Verification

- All five CI checks green, **including `test-integration (tools)`** — the integration test drives user-service's real `SubscriptionRepo` against real Mongo to prove the seeded fixtures survive its match filter.
- `make lint`: 0 issues. `go test ./tools/loadgen/ -race`: pass. `gosec` and the repo-owned semgrep rules: 0 findings.
- CLI validation confirmed against the built binary — bad `--list-type`, `--list-type=apps`, zero `--list-limit`, unknown preset and zero `--request-timeout` all exit 2 before the NATS dial.
- Coverage on new code is 87–100%, except `newSubscriptionListWorkload` at 0%: it dials NATS, the same untested boundary as `newRoomReadWorkload` and every sibling constructor.

### Review history

Two defects were found after the first push and fixed in place, both worth knowing about when reading the diff:

1. **CI caught the degenerate-preset problem** (7302123). The paging integration test failed a precondition on `small`; investigating it surfaced that three of four presets give one subscription per account, and that the docs recommended one of them. Fixed with the startup warning, per-step row logging, and the preset guidance above.
2. **CodeRabbit caught `--list-type=apps`** (fa39b7c) accepting a value the fixtures cannot serve — every page empty, every request a failure. Now rejected with a reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8S2JxAqtUKQ5pd2FosCkw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `subscription-list` workload for benchmarking subscription-list requests.
  * Added options for list type, page size, and last-message inclusion.
  * Added commands to seed and tear down subscription-list fixtures.
  * Added reporting for latency, returned rows, paging, errors, empty pages, and pacing metrics.

* **Documentation**
  * Documented setup, usage, configuration, realistic fixture requirements, and workload limitations, including unsupported app listings.

* **Tests**
  * Added coverage for workload execution, fixture generation, request handling, metrics, paging, and integration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->