### PR TITLE
fix(msgraph): pair the G101 suppressions with their semgrep directives

### DIFF
--- a/pkg/msgraph/msgraph_test.go
+++ b/pkg/msgraph/msgraph_test.go
@@ -922,6 +922,7 @@ func TestProxyCredentials_SentAsBasicAuth(t *testing.T) {
 // parsed host if it were inlined, so it must survive verbatim here.
 func TestProxyCredentials_SpecialCharactersNeedNoEncoding(t *testing.T) {
 	// #nosec G101 -- fixture password for a local httptest proxy, not a real credential
+	// nosemgrep: gosec.G101-1
 	const password = "p@ss:w/rd?#%"
 	c, err := NewMeetingsClient(Config{
 		TenantID: "t", ClientID: "c", ClientSecret: "s",
@@ -945,6 +946,7 @@ func TestProxyCredentials_SpecialCharactersNeedNoEncoding(t *testing.T) {
 // password means changing one secret rather than two settings that can drift.
 func TestProxyCredentials_OverrideEmbeddedUserinfo(t *testing.T) {
 	// #nosec G101 -- fixture userinfo; the test exists to prove it is overridden
+	// nosemgrep: gosec.G101-1
 	c, err := NewMeetingsClient(Config{
 		TenantID: "t", ClientID: "c", ClientSecret: "s",
 		ProxyURL:      "http://olduser:oldpass@proxy.corp:8080",
@@ -965,6 +967,7 @@ func TestProxyCredentials_OverrideEmbeddedUserinfo(t *testing.T) {
 // keep working when the new vars are unset.
 func TestProxyCredentials_EmbeddedUserinfoPreserved(t *testing.T) {
 	// #nosec G101 -- fixture userinfo; the test exists to prove it is preserved
+	// nosemgrep: gosec.G101-1
 	c, err := NewMeetingsClient(Config{
 		TenantID: "t", ClientID: "c", ClientSecret: "s",
 		ProxyURL: "http://embedded:secret@proxy.corp:8080",
@@ -1168,15 +1171,19 @@ func TestApplyProxy_AcceptsEverySupportedScheme(t *testing.T) {
 // (`invalid URL escape "%zz"`). A password beginning with a bad escape would
 // still reach the log, so no parse failure may carry any part of the value.
 func TestProxyCredentials_MalformedEscapeNeverLeaksPassword(t *testing.T) {
-	// #nosec G101 -- deliberately malformed fixture URLs; the test asserts none of
-	// them reaches an error message
 	tests := []struct {
 		name   string
 		proxy  string
 		secret string
 	}{
+		// #nosec G101 -- deliberately malformed fixture URL; the test asserts none of it reaches an error message
+		// nosemgrep: gosec.G101-1
 		{name: "bad escape starts the password", proxy: "http://user:%zzsecret@proxy.corp", secret: "zz"},
+		// #nosec G101 -- deliberately malformed fixture URL; the test asserts none of it reaches an error message
+		// nosemgrep: gosec.G101-1
 		{name: "bad escape inside the password", proxy: "http://user:pw%GGtail@proxy.corp", secret: "GG"},
+		// #nosec G101 -- deliberately malformed fixture URL; the test asserts none of it reaches an error message
+		// nosemgrep: gosec.G101-1
 		{name: "bad escape in the username", proxy: "http://%QQuser:pw@proxy.corp", secret: "QQ"},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
The proxy-credential tests added in #390 carry fixture passwords and
userinfo-bearing proxy URLs. They were suppressed for gosec only, so the
semgrep half of the SAST gate still reported hard-coded credentials in
pkg/msgraph/msgraph_test.go — the one file in the repo whose `#nosec
G101` sites had no matching `nosemgrep: gosec.G101-1`.

The malformed-escape table's directives move onto the rows they cover:
semgrep honours a directive only on the line directly above the finding,
so a pair hoisted above the `tests :=` statement would not have reached
the literals inside it.

Fixture values are unchanged; every flagged value is a throwaway
credential for a local httptest proxy, and the tests exist to prove none
of them reaches a log or an error message.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CdCgkKYpwQipEHtCGC9WU9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security-scanner annotations in test fixtures to prevent false-positive findings.
  * No changes to application behavior or test logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->