### PR TITLE
feat(sast): add the hardcoded-credential rule the local gate was missing

### DIFF
--- a/.semgrep/hardcoded-credentials.go
+++ b/.semgrep/hardcoded-credentials.go
@@ -57,6 +57,8 @@ const constFormPassword = "sup3rs3cr3t" // nosemgrep: gosec.G101-1
 // ruleid: hardcoded-credential-literal
 var varFormSecret = "sup3rs3cr3t" // nosemgrep: gosec.G101-1
 
+// declarationForms covers the two patterns that only appear inside a function
+// body. The package-level const and var above complete the set of four.
 func declarationForms() {
 	// ruleid: hardcoded-credential-literal
 	shortDeclPassword := "sup3rs3cr3t" // nosemgrep: gosec.G101-1
@@ -70,6 +72,8 @@ func declarationForms() {
 
 // --- positives: one line per alternative of the name regex ---
 
+// nameAlternatives gives each alternative of the rule's name regex its own line,
+// so dropping one from the pattern fails here instead of narrowing the gate.
 func nameAlternatives() {
 	// ruleid: hardcoded-credential-literal
 	password := "value-that-is-long-enough" // nosemgrep: gosec.G101-1
@@ -112,6 +116,9 @@ type config struct {
 	ClientSecret  string
 }
 
+// structLiteralFieldIsNotCovered is the negative assertion for the composite
+// literal: no ruleid annotation, so the test runner reports a match here as a
+// false positive if a pattern ever widens into that form.
 func structLiteralFieldIsNotCovered() config {
 	return config{ProxyPassword: "proxypass", ClientSecret: "s"} // nosemgrep: gosec.G101-1
 }

--- a/.semgrep/hardcoded-credentials.go
+++ b/.semgrep/hardcoded-credentials.go
@@ -1,0 +1,144 @@
+// Package testdata holds the fixtures for hardcoded-credentials.yml.
+//
+// The rule exists because the gate the repo runs and the gate the code is
+// judged by had drifted apart: an external Semgrep ruleset reported five
+// hard-coded passwords in pkg/msgraph/msgraph_test.go that `make sast` never
+// saw, because neither p/golang nor p/security-audit carries a Go
+// hardcoded-credential rule and gosec's G101 filters on entropy — "sup3rs3cr3t"
+// and "secret" fall under its threshold, so gosec stayed green too. PR #471 was
+// written from the green view and paired nosemgrep directives onto the sites
+// that already carried #nosec G101, which were not the reported ones; the five
+// findings moved down by the inserted lines and were otherwise untouched.
+//
+// `semgrep scan --test` reads the annotations: a `ruleid:` comment names every
+// rule that must fire on the following line. Lines with no annotation are
+// negative assertions — a rule firing there is reported as a false positive.
+// Both directions carry weight here. The positives pin the declaration forms
+// the rule covers, and the negatives pin the shapes it deliberately does not:
+// the struct-literal field form matches 252 sites repo-wide and is not what the
+// external ruleset reports, and an identifier that names a header, a cookie or
+// a collection holds a wire constant rather than a credential.
+//
+// Coverage is per independently editable branch: each syntactic form and each
+// alternative of the name regex gets its own line, so deleting any one of them
+// fails here rather than quietly narrowing the gate.
+//
+// The file sits beside hardcoded-credentials.yml because the test runner
+// matches a rule file to a target of the same basename and does not support a
+// separate tests directory. The Go toolchain ignores any directory beginning
+// with a dot, so it never reaches go build or golangci-lint. The scanners walk
+// the tree themselves and need telling: SEMGREP_FLAGS excludes .semgrep, and
+// GOSEC_FLAGS gained the matching -exclude-dir when this file's planted
+// credentials became the first fixture content gosec could see.
+package testdata
+
+// --- positives: one line per declaration form ---
+
+// ruleid: hardcoded-credential-literal
+const constFormPassword = "sup3rs3cr3t"
+
+// ruleid: hardcoded-credential-literal
+var varFormSecret = "sup3rs3cr3t"
+
+func declarationForms() {
+	// ruleid: hardcoded-credential-literal
+	shortDeclPassword := "sup3rs3cr3t"
+
+	var assignedSecret string
+	// ruleid: hardcoded-credential-literal
+	assignedSecret = "sup3rs3cr3t"
+
+	_, _ = shortDeclPassword, assignedSecret
+}
+
+// --- positives: one line per alternative of the name regex ---
+
+func nameAlternatives() {
+	// ruleid: hardcoded-credential-literal
+	password := "value-that-is-long-enough"
+	// ruleid: hardcoded-credential-literal
+	passwd := "value-that-is-long-enough"
+	// ruleid: hardcoded-credential-literal
+	pwd := "value-that-is-long-enough"
+	// ruleid: hardcoded-credential-literal
+	secret := "value-that-is-long-enough"
+	// ruleid: hardcoded-credential-literal
+	token := "value-that-is-long-enough"
+	// ruleid: hardcoded-credential-literal
+	apiKey := "value-that-is-long-enough"
+	// ruleid: hardcoded-credential-literal
+	credential := "value-that-is-long-enough"
+
+	_, _, _, _, _, _, _ = password, passwd, pwd, secret, token, apiKey, credential
+}
+
+// The match is on a substring of the identifier, not the whole of it, so a
+// qualified name still trips the rule. This is the shape msgraph_test.go's
+// findings actually take once a test names its fixture.
+func qualifiedNames() {
+	// ruleid: hardcoded-credential-literal
+	proxyPassword := "value-that-is-long-enough"
+	// ruleid: hardcoded-credential-literal
+	clientSecretValue := "value-that-is-long-enough"
+
+	_, _ = proxyPassword, clientSecretValue
+}
+
+// --- negatives: shapes the rule must not flag ---
+
+// A struct-literal field is deliberately out of scope. The form matches 252
+// sites repo-wide — every table-driven test that builds a Config — and the
+// external ruleset that prompted this rule does not report it either. Widening
+// to cover it would trade one real finding for hundreds of annotations.
+type config struct {
+	ProxyPassword string
+	ClientSecret  string
+}
+
+func structLiteralFieldIsNotCovered() config {
+	return config{ProxyPassword: "proxypass", ClientSecret: "s"}
+}
+
+// An identifier that names a header, cookie, collection or env var holds a
+// protocol constant, not a credential. These are the false positives the name
+// regex would otherwise produce against pkg/botauth, upload-service and
+// user-service.
+const (
+	headerAuthToken    = "x-auth-token"
+	ssoTokenName       = "ssoToken"
+	ssoTokenHeader     = "ssoToken"
+	ssoTokensCollection = "sso_tokens"
+	passwordFieldName  = "password"
+	tokenEnvVar        = "SSO_TOKEN"
+)
+
+// A Reason catalog constant is an error code, not a credential. pkg/errcode's
+// codes_*.go files hold nine of these.
+type Reason string
+
+const (
+	adminInvalidToken       Reason = "invalid_token"
+	adminInvalidCredentials Reason = "invalid_credentials"
+)
+
+// An empty string cannot be a credential; table-driven tests use it to assert
+// that a required setting was left unset.
+func emptyIsNotACredential() {
+	password := ""
+	_ = password
+}
+
+// A name without a credential word is out of scope however secret-looking the
+// value is. Entropy is gosec's job, and the whole reason this rule exists is
+// that entropy filtering is what let "secret" and "sup3rs3cr3t" through.
+func unrelatedName() {
+	roomID := "sup3rs3cr3t"
+	_ = roomID
+}
+
+// A value read from the environment is the shape the rule is steering toward,
+// so it must stay silent even under a credential-shaped name.
+func fromEnvIsFine(lookup func(string) string) {
+	password := lookup("GRAPH_PROXY_PASSWORD")
+	_ = password
+}

--- a/.semgrep/hardcoded-credentials.go
+++ b/.semgrep/hardcoded-credentials.go
@@ -101,8 +101,24 @@ func qualifiedNames() {
 	proxyPassword := "value-that-is-long-enough" // nosemgrep: gosec.G101-1
 	// ruleid: hardcoded-credential-literal
 	clientSecretValue := "value-that-is-long-enough" // nosemgrep: gosec.G101-1
+	// usernamePassword is the case that made the name exclusions anchored. An
+	// unanchored "name" matches the middle of this identifier and vetoed it.
+	// ruleid: hardcoded-credential-literal
+	usernamePassword := "value-that-is-long-enough" // nosemgrep: gosec.G101-1
 
-	_, _ = proxyPassword, clientSecretValue
+	_, _, _ = proxyPassword, clientSecretValue, usernamePassword
+}
+
+// valueForms pins the two literal shapes the value regex accepts. The escaped
+// case is the one a naive regex misses: an embedded quote must not end the
+// match, or `"p\"ass"` reads as a non-literal and walks straight past the gate.
+func valueForms() {
+	// ruleid: hardcoded-credential-literal
+	escapedPassword := "p\"ass" // nosemgrep: gosec.G101-1
+	// ruleid: hardcoded-credential-literal
+	rawSecret := `raw-string-secret` // nosemgrep: gosec.G101-1
+
+	_, _ = escapedPassword, rawSecret
 }
 
 // --- negatives: shapes the rule must not flag ---

--- a/.semgrep/hardcoded-credentials.go
+++ b/.semgrep/hardcoded-credentials.go
@@ -26,27 +26,44 @@
 // The file sits beside hardcoded-credentials.yml because the test runner
 // matches a rule file to a target of the same basename and does not support a
 // separate tests directory. The Go toolchain ignores any directory beginning
-// with a dot, so it never reaches go build or golangci-lint. The scanners walk
-// the tree themselves and need telling: SEMGREP_FLAGS excludes .semgrep, and
-// GOSEC_FLAGS gained the matching -exclude-dir when this file's planted
-// credentials became the first fixture content gosec could see.
+// with a dot, so it never reaches go build or golangci-lint. Every scanner
+// walks the tree itself and has to be told separately: SEMGREP_FLAGS excludes
+// .semgrep, .semgrepignore lists it, and GOSEC_FLAGS gained the matching
+// -exclude-dir when this file's planted credentials became the first fixture
+// content gosec could see.
+//
+// None of that reaches a scan outside this repo's Makefile. .semgrepignore
+// says why in its own header — "an explicit file path bypasses this file
+// entirely" — so a pipeline that scans a changed-file list rather than walking
+// the tree sees this file whatever the ignore list holds, and reported all
+// thirteen planted credentials the first time the branch went through one.
+// Hence the in-place `// nosemgrep: gosec.G101-1` on every line a
+// credential rule can reach, which is the same choice .semgrepignore already
+// documents for test fixtures. The trailing position is load-bearing: `ruleid:`
+// binds to the line directly below it, so a directive on its own line above the
+// code would take the slot the test runner needs.
+//
+// The annotation covers ten lines beyond the thirteen this file asserts as
+// positives — the negatives carry credential-shaped names too, and a rule
+// slightly wider than ours reaches them. Annotating only what a report happens
+// to name today is the mistake PR #471 made.
 package testdata
 
 // --- positives: one line per declaration form ---
 
 // ruleid: hardcoded-credential-literal
-const constFormPassword = "sup3rs3cr3t"
+const constFormPassword = "sup3rs3cr3t" // nosemgrep: gosec.G101-1
 
 // ruleid: hardcoded-credential-literal
-var varFormSecret = "sup3rs3cr3t"
+var varFormSecret = "sup3rs3cr3t" // nosemgrep: gosec.G101-1
 
 func declarationForms() {
 	// ruleid: hardcoded-credential-literal
-	shortDeclPassword := "sup3rs3cr3t"
+	shortDeclPassword := "sup3rs3cr3t" // nosemgrep: gosec.G101-1
 
 	var assignedSecret string
 	// ruleid: hardcoded-credential-literal
-	assignedSecret = "sup3rs3cr3t"
+	assignedSecret = "sup3rs3cr3t" // nosemgrep: gosec.G101-1
 
 	_, _ = shortDeclPassword, assignedSecret
 }
@@ -55,19 +72,19 @@ func declarationForms() {
 
 func nameAlternatives() {
 	// ruleid: hardcoded-credential-literal
-	password := "value-that-is-long-enough"
+	password := "value-that-is-long-enough" // nosemgrep: gosec.G101-1
 	// ruleid: hardcoded-credential-literal
-	passwd := "value-that-is-long-enough"
+	passwd := "value-that-is-long-enough" // nosemgrep: gosec.G101-1
 	// ruleid: hardcoded-credential-literal
-	pwd := "value-that-is-long-enough"
+	pwd := "value-that-is-long-enough" // nosemgrep: gosec.G101-1
 	// ruleid: hardcoded-credential-literal
-	secret := "value-that-is-long-enough"
+	secret := "value-that-is-long-enough" // nosemgrep: gosec.G101-1
 	// ruleid: hardcoded-credential-literal
-	token := "value-that-is-long-enough"
+	token := "value-that-is-long-enough" // nosemgrep: gosec.G101-1
 	// ruleid: hardcoded-credential-literal
-	apiKey := "value-that-is-long-enough"
+	apiKey := "value-that-is-long-enough" // nosemgrep: gosec.G101-1
 	// ruleid: hardcoded-credential-literal
-	credential := "value-that-is-long-enough"
+	credential := "value-that-is-long-enough" // nosemgrep: gosec.G101-1
 
 	_, _, _, _, _, _, _ = password, passwd, pwd, secret, token, apiKey, credential
 }
@@ -77,9 +94,9 @@ func nameAlternatives() {
 // findings actually take once a test names its fixture.
 func qualifiedNames() {
 	// ruleid: hardcoded-credential-literal
-	proxyPassword := "value-that-is-long-enough"
+	proxyPassword := "value-that-is-long-enough" // nosemgrep: gosec.G101-1
 	// ruleid: hardcoded-credential-literal
-	clientSecretValue := "value-that-is-long-enough"
+	clientSecretValue := "value-that-is-long-enough" // nosemgrep: gosec.G101-1
 
 	_, _ = proxyPassword, clientSecretValue
 }
@@ -96,7 +113,7 @@ type config struct {
 }
 
 func structLiteralFieldIsNotCovered() config {
-	return config{ProxyPassword: "proxypass", ClientSecret: "s"}
+	return config{ProxyPassword: "proxypass", ClientSecret: "s"} // nosemgrep: gosec.G101-1
 }
 
 // An identifier that names a header, cookie, collection or env var holds a
@@ -104,12 +121,12 @@ func structLiteralFieldIsNotCovered() config {
 // regex would otherwise produce against pkg/botauth, upload-service and
 // user-service.
 const (
-	headerAuthToken    = "x-auth-token"
-	ssoTokenName       = "ssoToken"
-	ssoTokenHeader     = "ssoToken"
-	ssoTokensCollection = "sso_tokens"
-	passwordFieldName  = "password"
-	tokenEnvVar        = "SSO_TOKEN"
+	headerAuthToken     = "x-auth-token" // nosemgrep: gosec.G101-1
+	ssoTokenName        = "ssoToken"     // nosemgrep: gosec.G101-1
+	ssoTokenHeader      = "ssoToken"     // nosemgrep: gosec.G101-1
+	ssoTokensCollection = "sso_tokens"   // nosemgrep: gosec.G101-1
+	passwordFieldName   = "password"     // nosemgrep: gosec.G101-1
+	tokenEnvVar         = "SSO_TOKEN"    // nosemgrep: gosec.G101-1
 )
 
 // A Reason catalog constant is an error code, not a credential. pkg/errcode's
@@ -117,14 +134,14 @@ const (
 type Reason string
 
 const (
-	adminInvalidToken       Reason = "invalid_token"
-	adminInvalidCredentials Reason = "invalid_credentials"
+	adminInvalidToken       Reason = "invalid_token"       // nosemgrep: gosec.G101-1
+	adminInvalidCredentials Reason = "invalid_credentials" // nosemgrep: gosec.G101-1
 )
 
 // An empty string cannot be a credential; table-driven tests use it to assert
 // that a required setting was left unset.
 func emptyIsNotACredential() {
-	password := ""
+	password := "" // nosemgrep: gosec.G101-1
 	_ = password
 }
 

--- a/.semgrep/hardcoded-credentials.yml
+++ b/.semgrep/hardcoded-credentials.yml
@@ -1,0 +1,47 @@
+rules:
+  - id: hardcoded-credential-literal
+    languages: [go]
+    severity: ERROR
+    message: >
+      Hard-coded credential literal. Credentials come from the environment via
+      caarlos0/env, never from a string literal in source — CLAUDE.md
+      "never default secrets or connection strings — mark them required".
+      A fixture credential in a test is the one legitimate exception. Annotate
+      it the way the rest of the repo does — a reason line, then
+      `// nosemgrep: gosec.G101-1, hardcoded-credential-literal` — and add
+      `// #nosec G101 -- reason` above that when gosec reports the line too.
+      Every scanner reads its own directive and names its own rule, so a
+      suppression that names one leaves the others reporting: that is exactly
+      how the five msgraph findings survived PR #471.
+    # Tests are in scope on purpose. Every other rule here excludes them, but
+    # the five findings this rule was written for are test fixtures, and an
+    # external Semgrep ruleset reports them while `make sast` did not — that
+    # gap is the defect. Scoping tests out would reproduce it.
+    patterns:
+      - pattern-either:
+          - pattern: const $NAME = $VAL
+          - pattern: var $NAME = $VAL
+          - pattern: $NAME := $VAL
+          - pattern: $NAME = $VAL
+      # A typed constant in an enum catalog is a wire code, not a credential:
+      # pkg/errcode/codes_*.go declares nine Reason values whose names carry
+      # "token" or "credentials" ("invalid_token", "invalid_credentials").
+      - pattern-not: const $NAME Reason = $VAL
+      # Composite-literal fields (ProxyPassword: "proxypass") are out of scope
+      # and need no exclusion — a field is not a declaration, so none of the
+      # four patterns above reaches one. Deliberate: the form matches 252 sites
+      # repo-wide, every table-driven test that builds a Config, and the
+      # external ruleset does not report it either. The fixture asserts the
+      # silence so widening a pattern into that form fails the rule tests.
+      - metavariable-regex:
+          metavariable: $NAME
+          # Must carry a credential word, and must not be the name OF something
+          # — a header, cookie, collection or env var holds a protocol constant.
+          regex: '(?i)^(?!.*(name|header|cookie|collection|prefix|env)).*(passwd|password|pwd|secret|token|apikey|credential).*$'
+      - metavariable-regex:
+          metavariable: $VAL
+          # A non-empty string literal, interpreted or raw. Anything else — a
+          # call, an identifier, "" — is not a hard-coded credential. No entropy
+          # filter: gosec's G101 has one, and it is why "secret" and
+          # "sup3rs3cr3t" reached main unreported.
+          regex: '^("[^"]+"|`[^`]+`)$'

--- a/.semgrep/hardcoded-credentials.yml
+++ b/.semgrep/hardcoded-credentials.yml
@@ -37,11 +37,16 @@ rules:
           metavariable: $NAME
           # Must carry a credential word, and must not be the name OF something
           # — a header, cookie, collection or env var holds a protocol constant.
-          regex: '(?i)^(?!.*(name|header|cookie|collection|prefix|env)).*(passwd|password|pwd|secret|token|apikey|credential).*$'
+          #
+          # The exclusions are anchored, not free substrings: those identifiers
+          # end in the qualifier (ssoTokenName, ssoTokensCollection, tokenEnvVar)
+          # or begin with it (headerAuthToken). An unanchored "name" also matches
+          # the middle of usernamePassword and vetoed a real credential.
+          regex: '(?i)^(?!header)(?!.*(?:name|header|cookie|collection|prefix|envvar)$).*(?:passwd|password|pwd|secret|token|apikey|credential).*$'
       - metavariable-regex:
           metavariable: $VAL
           # A non-empty string literal, interpreted or raw. Anything else — a
           # call, an identifier, "" — is not a hard-coded credential. No entropy
           # filter: gosec's G101 has one, and it is why "secret" and
           # "sup3rs3cr3t" reached main unreported.
-          regex: '^("[^"]+"|`[^`]+`)$'
+          regex: '^("(\\.|[^"\\])+"|`[^`]+`)$'

--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,16 @@ GOVULNCHECK := $(GOBIN_DIR)/govulncheck
 # (loadgen, nats-debug) that are not deployed services; chat-frontend is
 # JS. -tests=true scans *_test.go so PR gating catches issues in test code
 # too (mocks are filtered by -exclude-generated). Gate: medium+ severity.
+#
+# .semgrep holds the rule fixtures, whose whole purpose is to contain
+# deliberate violations — SEMGREP_FLAGS excludes it for the same reason. gosec
+# walks the tree itself rather than going through the Go toolchain, so a dot
+# directory does not fall out of scope the way it does for go build; the
+# exclusion has to be explicit or a fixture's planted credential reads as a
+# real G101.
 GOSEC_FLAGS := -quiet -severity medium -confidence low -tests=true \
-               -exclude-generated -exclude-dir=tools -exclude-dir=testdata
+               -exclude-generated -exclude-dir=tools -exclude-dir=testdata \
+               -exclude-dir=.semgrep
 
 # semgrep: fail on medium+ (WARNING/ERROR; INFO is informational/low).
 SEMGREP_FLAGS := --error --severity=WARNING --severity=ERROR --metrics=off \

--- a/admin-service/middleware_test.go
+++ b/admin-service/middleware_test.go
@@ -34,7 +34,7 @@ func newTestContext(method, path, authHeader string) (*gin.Context, *httptest.Re
 func TestRequireAdmin(t *testing.T) {
 	const (
 		// #nosec G101 -- fake fixture, not a live credential.
-		// nosemgrep: gosec.G101-1
+		// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 		rawToken       = "valid-raw-token-abc123"
 		configuredSite = "site-local"
 	)

--- a/admin-service/room_onduty_integration_test.go
+++ b/admin-service/room_onduty_integration_test.go
@@ -49,7 +49,7 @@ func newOnDutyRig(t *testing.T, siteID string, reply func(model.RoomRestrictedRe
 	require.NoError(t, store.EnsureIndexes(ctx))
 
 	// #nosec G101 -- fabricated test fixture, not a live credential
-	// nosemgrep: gosec.G101-1
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	const authToken = "onduty-test-token"
 	seedSession(t, db, session.Session{
 		ID:       sessiontoken.Hash(authToken),
@@ -197,7 +197,7 @@ func TestIntegration_SetRoomOnDuty_RPCTimeout(t *testing.T) {
 	require.NoError(t, store.EnsureIndexes(ctx))
 
 	// #nosec G101 -- fabricated test fixture, not a live credential
-	// nosemgrep: gosec.G101-1
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	const authToken = "onduty-timeout-token"
 	seedSession(t, db, session.Session{
 		ID: sessiontoken.Hash(authToken), UserID: "u-admin", Account: "p_admin",

--- a/botplatform-service/middleware_bot_test.go
+++ b/botplatform-service/middleware_bot_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestRequireBot(t *testing.T) {
 	// #nosec G101 -- fake fixture, not a live credential; hashed for the test below.
-	// nosemgrep: gosec.G101-1
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	const rawToken = "T3st-bot-tok"
 	hash := sessiontoken.Hash(rawToken)
 

--- a/botplatform-service/routes_bot_test.go
+++ b/botplatform-service/routes_bot_test.go
@@ -54,7 +54,7 @@ func TestRegisterBotRoutes_ChainWiring(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	// #nosec G101 -- fabricated test fixture, not a live credential
-	// nosemgrep: gosec.G101-1
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	const rawToken = "wire-test-token"
 	botSess := &session.Session{
 		ID:      sessiontoken.Hash(rawToken),
@@ -123,7 +123,7 @@ func TestRegisterBotRoutes_NoValkey(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	// #nosec G101 -- fabricated test fixture, not a live credential
-	// nosemgrep: gosec.G101-1
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	const rawToken = "no-valkey-token"
 	botSess := &session.Session{
 		ID:      sessiontoken.Hash(rawToken),
@@ -196,7 +196,7 @@ func TestRegisterBotRoutes_AuthUsesTheCachedStore(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	// #nosec G101 -- fabricated test fixture, not a live credential
-	// nosemgrep: gosec.G101-1
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	const rawToken = "cached-path-token"
 	botSess := &session.Session{
 		ID:      sessiontoken.Hash(rawToken),

--- a/client-update-service/config_test.go
+++ b/client-update-service/config_test.go
@@ -12,7 +12,7 @@ import (
 // validUploadTokens is a well-formed UPLOAD_TOKENS value for tests that need the
 // variable defined but are not testing it.
 // #nosec G101 -- fabricated fixture, not a live credential
-// nosemgrep: gosec.G101-1
+// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 const validUploadTokens = "admin-service:0123456789abcdef"
 
 func TestConfig_Defaults(t *testing.T) {
@@ -102,7 +102,7 @@ func TestValidateUploadTokens(t *testing.T) {
 
 func TestValidateUploadTokens_ErrorNeverLeaksTheToken(t *testing.T) {
 	// #nosec G101 -- fake fixture, not a live credential; the test asserts it never reaches the error.
-	// nosemgrep: gosec.G101-1
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	const secret = "supersecrettoken0123"
 	err := validateUploadTokens(map[string]string{"": secret})
 	require.Error(t, err)
@@ -116,7 +116,7 @@ func TestValidateUploadTokens_ErrorNeverLeaksTheToken(t *testing.T) {
 // the token value itself.
 func TestValidateUploadTokens_DuplicateToken_NamesAccountsNotToken(t *testing.T) {
 	// #nosec G101 -- fake fixture, not a live credential; the test asserts it never reaches the error.
-	// nosemgrep: gosec.G101-1
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	const secret = "duplicatetoken01234"
 	err := validateUploadTokens(map[string]string{"account-a": secret, "account-b": secret})
 	require.Error(t, err)

--- a/client-update-service/middleware_test.go
+++ b/client-update-service/middleware_test.go
@@ -156,7 +156,7 @@ func TestRequireServiceAccount_RejectionsAreIndistinguishable(t *testing.T) {
 
 func TestRequireServiceAccount_NeverEchoesTheToken(t *testing.T) {
 	// #nosec G101 -- fake fixture, not a live credential; the test asserts it never reaches the response.
-	// nosemgrep: gosec.G101-1
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	const secret = "0123456789abcdef"
 	r := gin.New()
 	r.Use(requireServiceAccount(map[string]string{"admin-service": secret}))

--- a/pkg/msgraph/msgraph_test.go
+++ b/pkg/msgraph/msgraph_test.go
@@ -1036,7 +1036,7 @@ func TestProxyCredentials_PasswordWithoutUsernameFails(t *testing.T) {
 // to the server log, and CLAUDE.md forbids logging passwords.
 func TestProxyCredentials_ErrorNeverLeaksPassword(t *testing.T) {
 	// Fixture proxy password; the test asserts it never reaches an error string.
-	// nosemgrep: hardcoded-credential-literal
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	const password = "sup3rs3cr3t"
 	for _, proxy := range []string{"://nope", "proxy.corp:8080", "http://"} {
 		t.Run(proxy, func(t *testing.T) {
@@ -1127,7 +1127,7 @@ func TestNewDirectoryClient_InvalidProxyURL(t *testing.T) {
 func TestProxyCredentials_MalformedURLNeverLeaksEmbeddedPassword(t *testing.T) {
 	// Fixture password embedded in a malformed proxy URL; the test asserts no parse
 	// error carries it.
-	// nosemgrep: hardcoded-credential-literal
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	const password = "sup3rs3cr3t"
 	for _, proxy := range []string{
 		"://user:" + password + "@proxy.corp:8080",
@@ -1259,7 +1259,7 @@ func TestApplyProxy_AllowsColonInSocksUsername(t *testing.T) {
 func TestProxyCredentials_SchemelessURLNeverLeaksPassword(t *testing.T) {
 	// Fixture password in a schemeless proxy URL; the test asserts the value never
 	// reaches the returned error.
-	// nosemgrep: hardcoded-credential-literal
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	const password = "supersecret"
 	for _, proxy := range []string{
 		"user:" + password + "@proxy.corp:8080",
@@ -1280,7 +1280,7 @@ func TestProxyCredentials_SchemelessURLNeverLeaksPassword(t *testing.T) {
 func TestApplyProxy_RejectsEmbeddedEmptyUsername(t *testing.T) {
 	// Fixture password in userinfo the constructor must reject; the test asserts the
 	// rejection does not carry it.
-	// nosemgrep: hardcoded-credential-literal
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	const password = "secret"
 	_, err := NewMeetingsClient(Config{
 		TenantID: "t", ClientID: "c", ClientSecret: "s",
@@ -1312,7 +1312,7 @@ func TestApplyProxy_RejectsPortWithoutHostname(t *testing.T) {
 func TestApplyProxy_WarnsOnUnencryptedCredentialHop(t *testing.T) {
 	// Fixture password for the unencrypted-hop warning; the test asserts the warning
 	// fires without quoting the credentials.
-	// nosemgrep: hardcoded-credential-literal
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	const password = "sup3rs3cr3t"
 	tests := []struct {
 		name     string

--- a/pkg/msgraph/msgraph_test.go
+++ b/pkg/msgraph/msgraph_test.go
@@ -922,7 +922,7 @@ func TestProxyCredentials_SentAsBasicAuth(t *testing.T) {
 // parsed host if it were inlined, so it must survive verbatim here.
 func TestProxyCredentials_SpecialCharactersNeedNoEncoding(t *testing.T) {
 	// #nosec G101 -- fixture password for a local httptest proxy, not a real credential
-	// nosemgrep: gosec.G101-1
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	const password = "p@ss:w/rd?#%"
 	c, err := NewMeetingsClient(Config{
 		TenantID: "t", ClientID: "c", ClientSecret: "s",
@@ -1035,6 +1035,8 @@ func TestProxyCredentials_PasswordWithoutUsernameFails(t *testing.T) {
 // proxy settings reach a log line. errcode.Classify writes construction errors
 // to the server log, and CLAUDE.md forbids logging passwords.
 func TestProxyCredentials_ErrorNeverLeaksPassword(t *testing.T) {
+	// Fixture proxy password; the test asserts it never reaches an error string.
+	// nosemgrep: hardcoded-credential-literal
 	const password = "sup3rs3cr3t"
 	for _, proxy := range []string{"://nope", "proxy.corp:8080", "http://"} {
 		t.Run(proxy, func(t *testing.T) {
@@ -1123,6 +1125,9 @@ func TestNewDirectoryClient_InvalidProxyURL(t *testing.T) {
 // in the returned error — and from there into the server log via
 // errcode.Classify. Redacted() cannot help, since it needs a parsed URL.
 func TestProxyCredentials_MalformedURLNeverLeaksEmbeddedPassword(t *testing.T) {
+	// Fixture password embedded in a malformed proxy URL; the test asserts no parse
+	// error carries it.
+	// nosemgrep: hardcoded-credential-literal
 	const password = "sup3rs3cr3t"
 	for _, proxy := range []string{
 		"://user:" + password + "@proxy.corp:8080",
@@ -1252,6 +1257,9 @@ func TestApplyProxy_AllowsColonInSocksUsername(t *testing.T) {
 // Opaque, leaving User nil — so Redacted(), which only masks a populated User,
 // returns the raw string password and all. No error may interpolate the value.
 func TestProxyCredentials_SchemelessURLNeverLeaksPassword(t *testing.T) {
+	// Fixture password in a schemeless proxy URL; the test asserts the value never
+	// reaches the returned error.
+	// nosemgrep: hardcoded-credential-literal
 	const password = "supersecret"
 	for _, proxy := range []string{
 		"user:" + password + "@proxy.corp:8080",
@@ -1270,6 +1278,9 @@ func TestProxyCredentials_SchemelessURLNeverLeaksPassword(t *testing.T) {
 // send ":secret", which an authenticating proxy answers with 407 — after
 // construction has already succeeded.
 func TestApplyProxy_RejectsEmbeddedEmptyUsername(t *testing.T) {
+	// Fixture password in userinfo the constructor must reject; the test asserts the
+	// rejection does not carry it.
+	// nosemgrep: hardcoded-credential-literal
 	const password = "secret"
 	_, err := NewMeetingsClient(Config{
 		TenantID: "t", ClientID: "c", ClientSecret: "s",
@@ -1299,6 +1310,9 @@ func TestApplyProxy_RejectsPortWithoutHostname(t *testing.T) {
 // deployment this setting exists for — so the warning is the whole mitigation
 // and must actually fire, without quoting the credentials.
 func TestApplyProxy_WarnsOnUnencryptedCredentialHop(t *testing.T) {
+	// Fixture password for the unencrypted-hop warning; the test asserts the warning
+	// fires without quoting the credentials.
+	// nosemgrep: hardcoded-credential-literal
 	const password = "sup3rs3cr3t"
 	tests := []struct {
 		name     string

--- a/pkg/testutil/vault.go
+++ b/pkg/testutil/vault.go
@@ -30,7 +30,7 @@ type VaultHandle struct {
 
 const (
 	// #nosec G101 -- root token for an ephemeral test container, not a production credential
-	// nosemgrep: gosec.G101-1
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	vaultRootToken    = "test-root-token"
 	vaultTransitMount = "transit"
 )

--- a/teams-hr-sync/config_test.go
+++ b/teams-hr-sync/config_test.go
@@ -134,6 +134,8 @@ func TestConfig_GraphProxy(t *testing.T) {
 	e := validEnv()
 	e["GRAPH_PROXY_URL"] = "http://proxy.corp:8080"
 	e["GRAPH_PROXY_USERNAME"] = "proxyuser"
+	// Fixture proxy password for a config-parsing test, not a live credential.
+	// nosemgrep: hardcoded-credential-literal
 	e["GRAPH_PROXY_PASSWORD"] = "p@ss:w/rd"
 
 	cfg, err := env.ParseAsWithOptions[config](env.Options{Environment: e})

--- a/tools/clientsim/client_test.go
+++ b/tools/clientsim/client_test.go
@@ -138,6 +138,9 @@ func TestSimClient_HealthTicksDoNotPostponeTheJWTRefresh(t *testing.T) {
 	// One second of life means the schedule fires at 800ms; postponed, it
 	// would not fire until ~999ms.
 	s.cache.mu.Lock()
+	// Not a credential: a sentinel marking the token cache primed, so the refresh
+	// schedule can be pinned without minting a JWT.
+	// nosemgrep: hardcoded-credential-literal
 	s.cache.token, s.cache.expiresAt = "primed", time.Now().Add(time.Second)
 	s.cache.mu.Unlock()
 

--- a/tools/seed-sample-data/fixtures.go
+++ b/tools/seed-sample-data/fixtures.go
@@ -32,7 +32,7 @@ var seedBaseTime = time.Date(2026, 5, 1, 9, 0, 0, 0, time.UTC)
 // expects (see botplatform-service/handler.go).
 const (
 	// #nosec G101 -- local dev sample-data seed, not a production credential
-	// nosemgrep: gosec.G101-1
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	demoAdminPassword   = "AdminDev123!"
 	demoAdminBcryptHash = "$2a$10$yqCFQ.M73mHH7yoHAtvHxuc61Q3yktq1TYMyiTTYBsBGPPABSDayK"
 )

--- a/user-service/integration_test.go
+++ b/user-service/integration_test.go
@@ -36,7 +36,7 @@ const (
 	testSiteID  = "site-a"
 	testAccount = "alice"
 	// #nosec G101 -- fabricated test fixture, not a live credential
-	// nosemgrep: gosec.G101-1
+	// nosemgrep: gosec.G101-1, hardcoded-credential-literal
 	testSSOToken = "tok-integration"
 )
 


### PR DESCRIPTION
## Problem

An external Semgrep ruleset reported five hard-coded passwords in `pkg/msgraph/msgraph_test.go` that `make sast` never saw. Two independent reasons:

- Neither `p/golang` nor `p/security-audit` ships a Go hardcoded-credential rule. The `gosec.G101-*` family that reports these is registry-only and not in the OSS `semgrep-rules` repo.
- gosec's own G101 filters on entropy, and `"sup3rs3cr3t"` / `"secret"` fall under its threshold, so gosec stayed green too.

#471 was written from that green view. It paired `nosemgrep` directives onto the sites that already carried `#nosec G101` — which were not the reported ones — so the five findings only moved down by the lines it inserted above them. Same file, same problem, different line numbers.

The underlying defect is that the gate the repo runs and the gate the code is judged by had drifted apart, with nothing to detect the drift.

## What this does

**A repo-owned rule** — `.semgrep/hardcoded-credential-literal`, ERROR. It covers `*_test.go` on purpose, unlike every other rule in `.semgrep/`, because the findings it exists for are test fixtures; scoping tests out would reproduce the defect. Declaration forms only: the composite-literal field form (`ProxyPassword: "proxypass"`) matches 252 sites repo-wide and the external ruleset does not report it either. No entropy filter, since that filter is what let these values past gosec.

**A fixture that pins both directions** — `.semgrep/hardcoded-credentials.go`, picked up automatically by `make sast-semgrep-test`. Positives cover each syntactic form and each alternative of the name regex; negatives pin the shapes deliberately left out (struct fields, an identifier naming a header/cookie/collection, an `errcode` `Reason` catalog constant, an empty string, a value read from the environment). Each `pattern-not` was mutation-tested — one that turned out to change nothing was removed rather than left as dead config.

**22 annotated sites.** Fifteen already carried `nosemgrep: gosec.G101-1` and gain the new id; seven are new, five of them the msgraph findings. The new seven get no `#nosec G101`, because gosec does not report them and a suppression for a finding that does not exist is dead config.

**Two exclusion gaps closed.** `GOSEC_FLAGS` gains `-exclude-dir=.semgrep`: gosec walks the tree itself rather than going through the Go toolchain, so the fixture directory does not fall out of scope the way it does for `go build`, and this is the first fixture holding credentials gosec could see. And the fixture annotates its own planted credentials in place, because all three exclusions (`SEMGREP_FLAGS`, `GOSEC_FLAGS`, `.semgrepignore`) are repo-local — `.semgrepignore`'s own header says why: *"an explicit file path bypasses this file entirely"*, so a pipeline scanning a changed-file list sees a new fixture whatever the ignore list holds. Twenty-three lines are annotated, not only the thirteen a scan reported, for the same reason #471 came up short.

## Notes on the rule id

`nosemgrep` matches a rule id by **exact suffix**, verified locally: `gosec.G101-1` does not suppress `gosec.G101-2`, and a prefix like `gosec.G101` suppresses neither. The `-1` variant was identified from a control in the same file — L926 is the identical shape, differs only by already carrying `gosec.G101-1`, and was absent from the five — then confirmed by an external re-scan of this branch.

In the fixture the directive is a trailing comment rather than its own line, because `ruleid:` binds to the line directly below it and would otherwise lose the slot the test runner needs. It names `gosec.G101-1` rather than being a bare `nosemgrep`, so `hardcoded-credential-literal` stays live on every line and the fixture's own assertions still fail if the rule regresses.

## Verification

- `make sast-semgrep-test` — 3/3 passed
- `make sast-gosec` — 0 findings
- Repo-owned semgrep scan — 20 rules over 1853 files, 0 findings
- `make lint` — 0 issues
- `go test -race` — green across every touched package
- External scan on this branch — clean

`make sast-vuln` and the registry half of `make sast` were not run locally (no network access to `vuln.go.dev` / `semgrep.dev` from the dev sandbox); CI covers both.

## Follow-up not in this PR

The CI workflow still carries the comment *"To make this a required check, add `sast` to the branch protection rules"*. If that is still outstanding, a red `sast` job does not block a merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8XgPts8YfzPs2kkka16LG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8XgPts8YfzPs2kkka16LG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Go security scan rule to detect hardcoded credential-like string literals and guide intentional exceptions.
  - Added comprehensive coverage for supported credential naming patterns, literal formats, and excluded cases.

- **Chores**
  - Updated scan configuration to exclude intentional rule fixtures.
  - Documented and suppressed intentional test credentials across affected test utilities and fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->