### PR TITLE
fix(clientsim): dial with the per-user reply-inbox prefix

### DIFF
--- a/auth-service/handler.go
+++ b/auth-service/handler.go
@@ -309,8 +309,13 @@ func (h *AuthHandler) handleDevAuth(ctx context.Context, c *gin.Context, req aut
 // Effective grants (kept in sync with docker-local/setup.sh and
 // docs/client-api.md §2.1 — a platform-team template change must mirror both):
 //
-//	Pub allow: chat.user.{account}.>, _INBOX.>, chat.user.presence.*.query.batch (+allow-pub-response)
-//	Sub allow: chat.user.{account}.>, chat.room.>, chat.local.room.>, _INBOX.>, chat.user.presence.state.*
+//	Pub allow: chat.user.{account}.>, chat.user.presence.*.query.batch (+allow-pub-response)
+//	Sub allow: chat.user.{account}.>, chat.room.>, chat.local.room.>, chat.user.presence.state.*
+//
+// There is deliberately no _INBOX grant on either side: a client sets its
+// request/reply inbox prefix to chat.user.{account} (subject.UserInboxPrefix),
+// so replies ride the user namespace already granted above. Re-adding one
+// would hand every authenticated user the whole reply namespace.
 //
 // The list above is documentation only (the live grant is the platform-team
 // template); the leaf node denies chat.local.> cross-gateway, so it stays site-local.

--- a/docs/superpowers/specs/2026-08-25-per-user-inbox-prefix-design.md
+++ b/docs/superpowers/specs/2026-08-25-per-user-inbox-prefix-design.md
@@ -138,7 +138,14 @@ throughput but never dials NATS with it; bots authenticate over HTTP through
 > The prefix now lives in `subject.UserInboxPrefix(account)` (returning
 > `chat.user.{account}`, per §9 — **not** §4's superseded `_INBOX.{account}`),
 > and clientsim passes it through `nats.CustomInboxPrefix`
-> (`tools/clientsim/conn.go`, `dialOptions`).
+> (`tools/clientsim/conn.go`, `dialOptions`). It encodes the account through
+> `EncodeAccount`, as `SubscriptionUpdate` and `RoomKeyUpdate` do: a dotted
+> `.bot` account spans subject tokens, and auth-service encodes it before
+> stamping the JWT's `account:` tag (`auth-service/handler.go:247`), so
+> `{{tag(account)}}` is evaluated against the encoded form. §3's claim that "an
+> account is always exactly one safe subject token" is true only of the encoded
+> account — the raw one can carry dots, and the validator §3 cites rejects
+> them.
 >
 > The rule the original reasoning missed, and which any future Go client should
 > read off this line: **the prefix belongs to the JWT template, not to the

--- a/docs/superpowers/specs/2026-08-25-per-user-inbox-prefix-design.md
+++ b/docs/superpowers/specs/2026-08-25-per-user-inbox-prefix-design.md
@@ -118,8 +118,35 @@ Two call sites:
 No Go production client is affected. `tools/loadgen` connects with `backend.creds`
 (`daily_pool.go:183-186`); `maxrps_login.go:167` mints a JWT to measure login
 throughput but never dials NATS with it; bots authenticate over HTTP through
-`pkg/botauth`. The prefix string is therefore needed in JS only — nothing is added
-to `pkg/subject`, where it would be an exported function with no production caller.
+`pkg/botauth`.
+
+> **Amended 2026-09-09.** The original text concluded from the above that the
+> prefix was needed in JS only, and that nothing be added to `pkg/subject`
+> because it would have no Go caller. That held on 2026-08-25 and no longer
+> does: `tools/clientsim` (PR #444, merged 2026-09-03) dials NATS over
+> WebSocket with a JWT minted from this very template — one connection per
+> account — and so is bound by the same grants as the browser.
+>
+> Left on nats.go's default `_INBOX` prefix, its response mux subscribes
+> `_INBOX.<nuid>.*`. Under §9's scheme the template grants no `_INBOX` subject
+> at all, so that subscription is denied outright: the broker answers with a
+> permissions violation, nats.go tears the mux down and recreates it — denied
+> again — and the connection is closed under a client that never completes its
+> first `subscription.list` page. That is how the gap surfaced, in a staging
+> run.
+>
+> The prefix now lives in `subject.UserInboxPrefix(account)` (returning
+> `chat.user.{account}`, per §9 — **not** §4's superseded `_INBOX.{account}`),
+> and clientsim passes it through `nats.CustomInboxPrefix`
+> (`tools/clientsim/conn.go`, `dialOptions`).
+>
+> The rule the original reasoning missed, and which any future Go client should
+> read off this line: **the prefix belongs to the JWT template, not to the
+> browser.** Anything dialling with a user JWT minted from it — production
+> client, tool, or test harness — has to set the same prefix. The remaining Go
+> dials are unaffected for the reason given above, not by luck: `tools/loadgen`,
+> `tools/nats-debug` and `tools/cdc-verify` all connect with a creds file for a
+> non-scoped account, so no `{{tag(account)}}` template applies to them.
 
 ### 5.1 Failure handling
 

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -282,6 +282,35 @@ func Notification(account string) string {
 	return fmt.Sprintf("chat.user.%s.notification", account)
 }
 
+// UserInboxPrefix is the request/reply inbox prefix a NATS client must dial
+// with: its own user namespace, `chat.user.{account}`. Replies land on
+// `chat.user.{account}.{nuid}.{token}`.
+//
+// Unrelated to the INBOX JetStream stream below, and deliberately NOT under
+// `_INBOX`: the scoped signing-key template grants no `_INBOX` subject at all
+// (`docker-local/setup.sh`, design
+// `docs/superpowers/specs/2026-08-25-per-user-inbox-prefix-design.md` §9), so a
+// client left on nats.go's default `_INBOX` prefix has its response-mux
+// subscription (`_INBOX.<nuid>.*`) denied, logs a permissions violation per
+// request, and has the connection closed under it. Riding the user namespace
+// instead means the reply subjects are covered by the `chat.user.{{tag(account)}}.>`
+// grant that already exists — no client can read or forge another account's
+// replies, because neither grant reaches a different namespace.
+//
+// Pass the result to `nats.CustomInboxPrefix`; nats.go appends its own
+// `.<nuid>` token and subscribes the mux at `<prefix>.<nuid>.*`.
+//
+// Panics on a token carrying a NATS wildcard: a `*` or `>` account would put
+// the mux subscription across every user's namespace, which is exactly what
+// the per-user prefix exists to prevent — and it is a programming error, never
+// user input, since the account comes from the client's own credentials.
+func UserInboxPrefix(account string) string {
+	if !isValidAccountToken(account) {
+		panic("invalid account token: contains NATS wildcard characters")
+	}
+	return "chat.user." + account
+}
+
 // InboxExternal is the subject a service uses to publish a cross-site
 // (remote-origin) federation event directly into the destination site's INBOX
 // stream: `chat.inbox.{siteID}.external.{eventType}`. The JetStream publish is

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -300,15 +300,24 @@ func Notification(account string) string {
 // Pass the result to `nats.CustomInboxPrefix`; nats.go appends its own
 // `.<nuid>` token and subscribes the mux at `<prefix>.<nuid>.*`.
 //
-// Panics on a token carrying a NATS wildcard: a `*` or `>` account would put
-// the mux subscription across every user's namespace, which is exactly what
-// the per-user prefix exists to prevent — and it is a programming error, never
-// user input, since the account comes from the client's own credentials.
+// The account is encoded the same way the fanout subjects encode it
+// (SubscriptionUpdate, RoomKeyUpdate): a dotted ".bot" account spans subject
+// tokens, and auth-service encodes it before stamping the JWT's `account:` tag
+// (`auth-service/handler.go:247`), so `{{tag(account)}}` is evaluated against
+// the encoded form. An unencoded prefix would be a five-token subject that the
+// grant cannot match.
+//
+// Panics on a token still carrying a NATS wildcard AFTER encoding: a `*` or
+// `>` account would put the mux subscription across every user's namespace,
+// which is exactly what the per-user prefix exists to prevent — and it is a
+// programming error, never user input, since the account comes from the
+// client's own credentials.
 func UserInboxPrefix(account string) string {
-	if !isValidAccountToken(account) {
+	encoded := EncodeAccount(account)
+	if !isValidAccountToken(encoded) {
 		panic("invalid account token: contains NATS wildcard characters")
 	}
-	return "chat.user." + account
+	return "chat.user." + encoded
 }
 
 // InboxExternal is the subject a service uses to publish a cross-site

--- a/pkg/subject/subject_test.go
+++ b/pkg/subject/subject_test.go
@@ -1352,3 +1352,26 @@ func TestRoomThreadEventTargets_TransitionGrace(t *testing.T) {
 	after := flip.Add(subject.DefaultRoomLocalityGrace + time.Minute)
 	assert.Equal(t, []string{g}, subject.RoomThreadEventTargets("r1", "p1", &trueP, &flip, subject.RouteLocal, after))
 }
+
+// The reply inbox rides the client's own user namespace (design 2026-08-25
+// §9): the signing-key template grants no `_INBOX` subject at all, so a client
+// on nats.go's default prefix has its response-mux subscription denied and
+// every request/reply RPC fails. Any Go client dialling with a minted user JWT
+// needs the same prefix the frontend uses.
+func TestUserInboxPrefix(t *testing.T) {
+	assert.Equal(t, "chat.user.alice", subject.UserInboxPrefix("alice"))
+
+	// Never `_INBOX`: that namespace is granted to nobody.
+	assert.False(t, strings.HasPrefix(subject.UserInboxPrefix("alice"), "_INBOX"))
+
+	// nats.go appends ".<nuid>" and subscribes the mux at "<inbox>.*", so the
+	// generated subjects sit inside the account's own branch and are covered by
+	// the `chat.user.{{tag(account)}}.>` grant at any depth.
+	assert.True(t, strings.HasPrefix(subject.UserInboxPrefix("alice")+".nuid.token", "chat.user.alice."))
+
+	// A wildcard would subscribe the mux across every account's namespace —
+	// exactly what the per-user prefix exists to stop.
+	assert.Panics(t, func() { subject.UserInboxPrefix("*") })
+	assert.Panics(t, func() { subject.UserInboxPrefix(">") })
+	assert.Panics(t, func() { subject.UserInboxPrefix("") })
+}

--- a/pkg/subject/subject_test.go
+++ b/pkg/subject/subject_test.go
@@ -1369,6 +1369,20 @@ func TestUserInboxPrefix(t *testing.T) {
 	// the `chat.user.{{tag(account)}}.>` grant at any depth.
 	assert.True(t, strings.HasPrefix(subject.UserInboxPrefix("alice")+".nuid.token", "chat.user.alice."))
 
+	// A dotted ".bot" account spans subject tokens, and auth-service encodes it
+	// before stamping the JWT's account: tag (handler.go:247), so the grant is
+	// evaluated against the encoded form. An unencoded prefix would be a
+	// five-token subject that `chat.user.weather_site-a_bot.>` cannot match —
+	// and the wildcard guard, which rejects ".", would panic the process before
+	// the broker ever got to deny it.
+	assert.Equal(t, "chat.user.weather_site-a_bot", subject.UserInboxPrefix("weather.site-a.bot"))
+	assert.Equal(t, subject.SubscriptionUpdate("weather.site-a.bot"),
+		subject.UserInboxPrefix("weather.site-a.bot")+".event.subscription.update",
+		"the inbox prefix must encode the account the same way the fanout subjects do")
+
+	// "-" is already a legal NATS token rune, so it passes through untouched.
+	assert.Equal(t, "chat.user.some-user", subject.UserInboxPrefix("some-user"))
+
 	// A wildcard would subscribe the mux across every account's namespace —
 	// exactly what the per-user prefix exists to stop.
 	assert.Panics(t, func() { subject.UserInboxPrefix("*") })

--- a/tools/clientsim/README.md
+++ b/tools/clientsim/README.md
@@ -127,6 +127,18 @@ tooling that splits on the first dash keeps working. The `clientsim-` prefix
 is the whole contract — filter on it — and it is deliberately **not**
 configurable: a knob there would let a fleet disguise itself.
 
+### Reply inbox prefix
+
+clientsim dials with `inboxPrefix = chat.user.{account}`, the same prefix the
+browser client uses. The scoped signing-key template grants no `_INBOX`
+subject at all, so a client left on nats.go's default prefix has its
+request/reply response mux (`_INBOX.<nuid>.*`) denied: the broker answers with
+a permissions violation, nats.go rebuilds the mux, is denied again, and the
+connection is closed under a client that never finishes its first
+`subscription.list` page. If you see that pattern in a run, the prefix is the
+first thing to check. See `docs/client-api.md` §2.1 and
+`docs/superpowers/specs/2026-08-25-per-user-inbox-prefix-design.md` §9.
+
 ## Readiness and asynchronous faults
 
 A subscription permission violation arrives *after* `Subscribe()` already

--- a/tools/clientsim/conn.go
+++ b/tools/clientsim/conn.go
@@ -126,7 +126,18 @@ func reconnectDelay(attempt int) time.Duration {
 
 // realDial opens the production WebSocket connection.
 func (s *simClient) realDial(ctx context.Context) (simConn, error) {
-	nc, err := nats.Connect(s.cfg.NATSWSURL,
+	nc, err := nats.Connect(s.cfg.NATSWSURL, s.dialOptions(ctx)...)
+	if err != nil {
+		return nil, err
+	}
+	return &realConn{nc: nc, pendingMsgs: s.cfg.SubPendingMsgs, pendingBytes: s.cfg.SubPendingBytes}, nil
+}
+
+// dialOptions is realDial's option set, split out so tests can assert on the
+// connection contract (which the broker enforces but a fake conn cannot)
+// without standing up a server.
+func (s *simClient) dialOptions(ctx context.Context) []nats.Option {
+	return []nats.Option{
 		nats.UserJWT(s.userCB, s.sigCB),
 		nats.Name(connName(s.account, s.runID, s.cfg.ShardIndex)),
 		nats.MaxReconnects(-1),
@@ -160,11 +171,15 @@ func (s *simClient) realDial(ctx context.Context) (simConn, error) {
 		nats.ErrorHandler(func(_ *nats.Conn, sub *nats.Subscription, err error) {
 			s.handleAsyncError(ctx, sub, err)
 		}),
-	)
-	if err != nil {
-		return nil, err
+		// The signing-key template grants no `_INBOX` subject at all — replies
+		// ride the client's own `chat.user.{account}` namespace instead. On
+		// nats.go's default prefix the response mux (`_INBOX.<nuid>.*`) is
+		// therefore denied: the broker answers with a permissions violation,
+		// nats.go retries the mux, and the connection is closed under a fleet
+		// that never gets past its first subscription.list page. The browser
+		// client passes the same prefix on connect.
+		nats.CustomInboxPrefix(subject.UserInboxPrefix(s.account)),
 	}
-	return &realConn{nc: nc, pendingMsgs: s.cfg.SubPendingMsgs, pendingBytes: s.cfg.SubPendingBytes}, nil
 }
 
 // nextReconnectDelay is nats.go's CustomReconnectDelay callback. Its own

--- a/tools/clientsim/conn_test.go
+++ b/tools/clientsim/conn_test.go
@@ -275,3 +275,28 @@ func TestUserCB_AFailedForcedRefreshKeepsTheBrokerVerdict(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), mint.calls.Load(), "and not re-armed afterwards")
 }
+
+// The signing-key template grants no `_INBOX` subject
+// (docs/superpowers/specs/2026-08-25-per-user-inbox-prefix-design.md §9):
+// replies ride the client's own user namespace. On nats.go's default prefix
+// the response mux subscribes `_INBOX.<nuid>.*`, which the server denies — the
+// broker answers every request with a permissions violation and then closes
+// the connection, so a fleet never gets past its first subscription.list page.
+func TestRealDial_SubscribesItsReplyInboxUnderTheAccountsOwnPrefix(t *testing.T) {
+	s := newTestSimClient(t, "user-inbox", jwtModeExpiry, &countingMinter{
+		jwt: func() string { return mintTestJWT(t, time.Now().Add(2*time.Hour)) },
+	})
+	// nats.go smoke-tests the user JWT callback while applying options.
+	require.NoError(t, s.primeJWT(context.Background()))
+
+	var opts nats.Options
+	for _, opt := range s.dialOptions(context.Background()) {
+		require.NoError(t, opt(&opts))
+	}
+
+	assert.Equal(t, "chat.user.user-inbox", opts.InboxPrefix,
+		"the reply inbox must sit in the account namespace the JWT grants")
+	// nats.go appends its own token, so what actually reaches the server is
+	// covered by the granted `chat.user.<account>.>` at any depth.
+	assert.True(t, strings.HasPrefix(opts.InboxPrefix+".nuid.*", "chat.user.user-inbox."))
+}


### PR DESCRIPTION
## What's broken

clientsim dials NATS on nats.go's default `_INBOX` prefix. The scoped signing-key template grants **no `_INBOX` subject at all** — clients set their inbox prefix to their own `chat.user.{account}` namespace instead (per-user-inbox design §9, `docker-local/setup.sh:57`).

So the response-mux subscription `_INBOX.<nuid>.*` is denied. And nats.go doesn't stop there: on a denied mux it tears the mux down and rebuilds it, which is denied again. The result in a staging run is a flood of permission-denied subscribe errors with connections dropping behind them — a client never completes its first `subscription.list` page, so a fleet never reaches readiness.

## The fix

- `subject.UserInboxPrefix(account)` → `chat.user.{account}`.
- `realDial` passes it through `nats.CustomInboxPrefix`.
- `realDial`'s option list is split into `dialOptions()`. The prefix is a contract the *broker* enforces; a fake conn can't see it, so without the split there is nowhere to assert it short of standing up a server.

### The account is encoded, not raw (`a40611e`)

The first cut of `UserInboxPrefix` validated and returned the raw account. Review caught that it must go through `EncodeAccount`, like `SubscriptionUpdate` and `RoomKeyUpdate` do — and the consequence was worse than a mismatched subject.

`auth-service/handler.go:247` encodes the account *before* stamping the JWT's `account:` tag, so `chat.user.{{tag(account)}}.>` is evaluated against the encoded form: a bot account `weather.site-a.bot` is granted `chat.user.weather_site-a_bot.>`. An unencoded prefix would be a five-token subject the grant cannot match — but it never got that far, because `isValidAccountToken` rejects `.`, so the guard **panicked the process** rather than letting the broker deny it.

Encode first, then validate the encoded token — the same order auth-service itself uses. (`-` needs nothing; `EncodeAccount` only maps `.`.) A test pins the two builders together, so they cannot drift:

```go
assert.Equal(t, subject.SubscriptionUpdate("weather.site-a.bot"),
    subject.UserInboxPrefix("weather.site-a.bot")+".event.subscription.update")
```

## Two documentation corrections in the same change

**`auth-service/handler.go:312-313`** documented the effective grants as including `_INBOX.>` on both pub *and* sub, and claimed to be "kept in sync with `docker-local/setup.sh` and `docs/client-api.md` §2.1" — both of which say the opposite. A platform-team template change made from that comment would have re-opened the wildcard reply grant the design closed. (Flagged `medium` in two review reports under `docs/reviews/`; unfixed until now.)

**The design doc's §5** concluded that no Go client was affected and that nothing be added to `pkg/subject` "where it would be an exported function with no production caller". True on 2026-08-25 — clientsim did not exist yet. Amended in place with the rule the original reasoning missed: **the prefix belongs to the JWT template, not to the browser.** Anything dialling with a JWT minted from it has to set the same prefix. §3's "an account is always exactly one safe subject token" is corrected too — that holds for the *encoded* account only.

The remaining Go dials are unaffected for a stated reason rather than by luck: `tools/loadgen`, `tools/nats-debug` and `tools/cdc-verify` all connect with a creds file for a non-scoped account, so no `{{tag(account)}}` template applies to them.

## Known gap, deliberately not widened here

`pkg/subject` is inconsistent about this encoding: `SubscriptionUpdate` and `RoomKeyUpdate` encode; `UserRoomEvent` and `UserSubscriptionList` do not — and `UserSubscriptionList` panics on a dotted account for exactly the reason above. clientsim calls all three (`subscriptions.go:52,58,282`). That is pre-existing on `main` and touches call sites well beyond clientsim, so it is not folded into this PR. Filed as the next thing to look at.

## Verification

| | |
|---|---|
| TDD | Red → Green on every new test |
| Mutation | Removing the wildcard `panic`, removing `CustomInboxPrefix`, dropping `EncodeAccount`, and validating the raw account instead of the encoded one — each turns its own test red |
| `make lint` | 0 issues |
| gosec + repo semgrep rules | clean |
| Coverage | `pkg/subject` 90.0%, `tools/clientsim` 89.0% |

`docs/client-api.md` §2.1 already documents the `chat.user.{account}` inbox prefix correctly and needed no change. No client-facing handler or `pkg/model` wire struct is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HG2exSamSDTyxcxje1TuzZ