### PR TITLE
feat(clientsim): take the account pool from MongoDB through an object store

### DIFF
--- a/pkg/poolartifact/main_test.go
+++ b/pkg/poolartifact/main_test.go
@@ -1,0 +1,11 @@
+//go:build integration
+
+package poolartifact
+
+import (
+	"testing"
+
+	"github.com/hmchangw/chat/pkg/testutil"
+)
+
+func TestMain(m *testing.M) { testutil.RunTests(m) }

--- a/pkg/poolartifact/poolartifact.go
+++ b/pkg/poolartifact/poolartifact.go
@@ -13,6 +13,8 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	"github.com/hmchangw/chat/pkg/subject"
 )
 
 // SchemaVersion is the artifact schema this package reads and writes.
@@ -46,6 +48,14 @@ func validateAccounts(accounts []string) error {
 		// subscribe cleanly and receive nothing.
 		if account == "" {
 			return fmt.Errorf("pool artifact account %d is empty", i)
+		}
+		// The account becomes a NATS subject token. subject.UserSubscriptionList
+		// PANICS on one carrying a dot, wildcard, whitespace or control rune, so
+		// letting it through here does not degrade a clientsim pod — it kills it
+		// at startup. Same validator the subject builders use, so the artifact
+		// contract and the subject contract cannot drift.
+		if !subject.IsValidAccountToken(account) {
+			return fmt.Errorf("pool artifact account %d (%q) is not a valid NATS subject token", i, account)
 		}
 		if first, dup := seen[account]; dup {
 			return fmt.Errorf("pool artifact has duplicate account %q at positions %d and %d", account, first, i)
@@ -98,6 +108,13 @@ func marshalArtifact(a *Artifact) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("marshal pool artifact: %w", err)
 	}
+	// Symmetric with readCapped, for the same reason the account cap is
+	// symmetric with Load: a producer that can publish what every consumer
+	// refuses turns one bad export into a failure at every pod's startup,
+	// hours later and in the wrong tool.
+	if int64(len(data)) > maxArtifactBytes {
+		return nil, fmt.Errorf("write pool artifact: %d bytes, above the %d-byte cap", len(data), maxArtifactBytes)
+	}
 	return data, nil
 }
 
@@ -128,7 +145,11 @@ const maxArtifactBytes = 64 << 20
 // thing would then take a site down instead of testing it. One million is
 // ten times the largest pool the tooling is designed for, so it can only ever
 // catch a mistake.
-const maxAccounts = 1_000_000
+const maxAccounts = MaxAccounts
+
+// MaxAccounts is the decoded-pool cap, exported so a producer can bound its
+// own query by the same number instead of discovering it after the fact.
+const MaxAccounts = 1_000_000
 
 // isGzipPath decides compression from the name alone, so the two ends of the
 // contract cannot disagree: whatever Write compressed, Load decompresses.
@@ -165,7 +186,12 @@ func gzipBytes(data []byte) ([]byte, error) {
 // closed for plain JSON, reopened by compression.
 func readCapped(r io.Reader, gzipped bool) ([]byte, error) {
 	if gzipped {
-		zr, err := gzip.NewReader(r)
+		// Bound the COMPRESSED stream too. The decompressed cap alone lets a
+		// stream that never expands past it be read forever — a stall rather
+		// than a heap blow-up, but a pod that hangs at startup instead of
+		// failing is worse to diagnose. The artifact compresses well, so a
+		// compressed body at the decompressed cap is already absurd.
+		zr, err := gzip.NewReader(io.LimitReader(r, maxArtifactBytes+1))
 		if err != nil {
 			return nil, fmt.Errorf("open gzip pool artifact: %w", err)
 		}

--- a/pkg/poolartifact/poolartifact.go
+++ b/pkg/poolartifact/poolartifact.go
@@ -60,34 +60,50 @@ func validateAccounts(accounts []string) error {
 // rename), so a concurrent Load from another process never sees a
 // truncated file.
 func Write(path string, a *Artifact) error {
-	switch {
-	case len(a.Accounts) == 0:
-		return errors.New("write pool artifact: empty accounts")
-	// Symmetric with Load: a seeder that can emit an artifact the consumer
-	// refuses at startup turns a bad --users value into a failure hours later,
-	// in the wrong tool.
-	case len(a.Accounts) > maxAccounts:
-		return fmt.Errorf("write pool artifact: %d accounts, above the %d cap", len(a.Accounts), maxAccounts)
-	case a.SiteID == "":
-		return errors.New("write pool artifact: empty siteID")
-	case a.RunID == "":
-		return errors.New("write pool artifact: empty runID")
-	case a.ConfigDigest == "":
-		return errors.New("write pool artifact: empty configDigest — the artifact would be unmatchable to its run")
-	}
-	if err := validateAccounts(a.Accounts); err != nil {
-		return fmt.Errorf("write pool artifact: %w", err)
-	}
-	a.SchemaVersion = SchemaVersion
-	data, err := json.MarshalIndent(a, "", "  ")
+	data, err := marshalArtifact(a)
 	if err != nil {
-		return fmt.Errorf("marshal pool artifact: %w", err)
+		return err
 	}
 	if isGzipPath(path) {
 		if data, err = gzipBytes(data); err != nil {
 			return fmt.Errorf("compress pool artifact: %w", err)
 		}
 	}
+	return writeAtomic(path, data)
+}
+
+// marshalArtifact is the producer-side contract, shared by the file and
+// object-store writers: whatever one refuses, the other refuses too.
+func marshalArtifact(a *Artifact) ([]byte, error) {
+	switch {
+	case len(a.Accounts) == 0:
+		return nil, errors.New("write pool artifact: empty accounts")
+	// Symmetric with Load: a seeder that can emit an artifact the consumer
+	// refuses at startup turns a bad --users value into a failure hours later,
+	// in the wrong tool.
+	case len(a.Accounts) > maxAccounts:
+		return nil, fmt.Errorf("write pool artifact: %d accounts, above the %d cap", len(a.Accounts), maxAccounts)
+	case a.SiteID == "":
+		return nil, errors.New("write pool artifact: empty siteID")
+	case a.RunID == "":
+		return nil, errors.New("write pool artifact: empty runID")
+	case a.ConfigDigest == "":
+		return nil, errors.New("write pool artifact: empty configDigest — the artifact would be unmatchable to its run")
+	}
+	if err := validateAccounts(a.Accounts); err != nil {
+		return nil, fmt.Errorf("write pool artifact: %w", err)
+	}
+	a.SchemaVersion = SchemaVersion
+	data, err := json.MarshalIndent(a, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal pool artifact: %w", err)
+	}
+	return data, nil
+}
+
+// writeAtomic persists through tmp + rename, so a concurrent Load from
+// another process never sees a truncated file.
+func writeAtomic(path string, data []byte) error {
 	tmp := path + ".tmp"
 	// #nosec G306 -- the artifact is a non-secret account list deliberately
 	// world-readable: it is mounted into clientsim/issuer containers that run
@@ -181,6 +197,13 @@ func Load(path, wantSiteID string) (*Artifact, error) {
 	if err != nil {
 		return nil, err
 	}
+	return decodeAndValidate(data, wantSiteID)
+}
+
+// decodeAndValidate is the consumer-side contract, shared by the file and
+// object-store readers. Unknown schema, wrong site, or an empty pool are
+// startup errors for the consumer — fail fast, never limp.
+func decodeAndValidate(data []byte, wantSiteID string) (*Artifact, error) {
 	a, err := decodeArtifact(data)
 	if err != nil {
 		return nil, err

--- a/pkg/poolartifact/poolartifact.go
+++ b/pkg/poolartifact/poolartifact.go
@@ -6,11 +6,13 @@ package poolartifact
 
 import (
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 
 // SchemaVersion is the artifact schema this package reads and writes.
@@ -81,6 +83,11 @@ func Write(path string, a *Artifact) error {
 	if err != nil {
 		return fmt.Errorf("marshal pool artifact: %w", err)
 	}
+	if isGzipPath(path) {
+		if data, err = gzipBytes(data); err != nil {
+			return fmt.Errorf("compress pool artifact: %w", err)
+		}
+	}
 	tmp := path + ".tmp"
 	// #nosec G306 -- the artifact is a non-secret account list deliberately
 	// world-readable: it is mounted into clientsim/issuer containers that run
@@ -107,6 +114,58 @@ const maxArtifactBytes = 64 << 20
 // catch a mistake.
 const maxAccounts = 1_000_000
 
+// isGzipPath decides compression from the name alone, so the two ends of the
+// contract cannot disagree: whatever Write compressed, Load decompresses.
+func isGzipPath(path string) bool { return strings.HasSuffix(path, ".gz") }
+
+// gzipBytes compresses at the best ratio available. The artifact is written
+// once per run and read once per pod, so the CPU is irrelevant beside the
+// bytes: a 30k-account pool of real account names goes from ~1.1 MiB to a few
+// hundred KiB, which is the difference between fitting a transport hop and not.
+func gzipBytes(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	zw, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	if err != nil {
+		return nil, fmt.Errorf("init gzip writer: %w", err)
+	}
+	if _, err := zw.Write(data); err != nil {
+		return nil, fmt.Errorf("gzip pool artifact: %w", err)
+	}
+	// Closed explicitly, not deferred: Close flushes the trailer, and a
+	// deferred one would run after buf was already read.
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("finish gzip pool artifact: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// readCapped reads the artifact, decompressing first when it is gzipped.
+//
+// Cap the read itself rather than a prior Stat: a Stat-then-read lets a file
+// that grows in between — or a fifo, which has no meaningful size — past the
+// limit entirely. And the cap binds the DECOMPRESSED stream, because bounding
+// the compressed bytes would let a few KiB of gzip expand into gigabytes of
+// heap before any count check could run — the hazard the streaming decoder
+// closed for plain JSON, reopened by compression.
+func readCapped(r io.Reader, gzipped bool) ([]byte, error) {
+	if gzipped {
+		zr, err := gzip.NewReader(r)
+		if err != nil {
+			return nil, fmt.Errorf("open gzip pool artifact: %w", err)
+		}
+		defer zr.Close() //nolint:errcheck // read-only handle
+		r = zr
+	}
+	data, err := io.ReadAll(io.LimitReader(r, maxArtifactBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read pool artifact: %w", err)
+	}
+	if int64(len(data)) > maxArtifactBytes {
+		return nil, fmt.Errorf("pool artifact exceeds the %d-byte cap", maxArtifactBytes)
+	}
+	return data, nil
+}
+
 // Load reads and validates an artifact. Unknown schema, wrong site, or an
 // empty pool are startup errors for the consumer — fail fast, never limp.
 func Load(path, wantSiteID string) (*Artifact, error) {
@@ -118,15 +177,9 @@ func Load(path, wantSiteID string) (*Artifact, error) {
 		return nil, fmt.Errorf("open pool artifact: %w", err)
 	}
 	defer f.Close() //nolint:errcheck // read-only handle
-	// Cap the read itself rather than a prior Stat: a Stat-then-read lets a
-	// file that grows in between — or a fifo, which has no meaningful size —
-	// past the limit entirely.
-	data, err := io.ReadAll(io.LimitReader(f, maxArtifactBytes+1))
+	data, err := readCapped(f, isGzipPath(path))
 	if err != nil {
-		return nil, fmt.Errorf("read pool artifact: %w", err)
-	}
-	if int64(len(data)) > maxArtifactBytes {
-		return nil, fmt.Errorf("pool artifact exceeds the %d-byte cap", maxArtifactBytes)
+		return nil, err
 	}
 	a, err := decodeArtifact(data)
 	if err != nil {

--- a/pkg/poolartifact/poolartifact_test.go
+++ b/pkg/poolartifact/poolartifact_test.go
@@ -2,6 +2,7 @@ package poolartifact
 
 import (
 	"bytes"
+	"compress/gzip"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -271,4 +272,114 @@ func TestWrite_RejectsWhatLoadRejects(t *testing.T) {
 			assert.True(t, os.IsNotExist(statErr), "a rejected artifact must not be written")
 		})
 	}
+}
+
+// The artifact has to travel through a ConfigMap-sized or object-store hop,
+// and 30k real account names run past 1 MiB uncompressed. Writing and reading
+// .gz keeps the same contract on both ends.
+func TestWriteLoad_GzipRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pool.json.gz")
+	want := &Artifact{
+		RunID: "r1", SiteID: "site-a", ConfigDigest: "d1",
+		Accounts: []string{"alice", "bob", "carol"},
+	}
+	require.NoError(t, Write(path, want))
+
+	// #nosec G304 -- reads the test's own TempDir fixture
+	// nosemgrep: gosec.G304-1 -- reads the test's own TempDir fixture
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x1f, 0x8b}, raw[:2], "a .gz path must produce gzip bytes, not plain JSON")
+
+	got, err := Load(path, "site-a")
+	require.NoError(t, err)
+	assert.Equal(t, want.Accounts, got.Accounts)
+	assert.Equal(t, SchemaVersion, got.SchemaVersion)
+	assert.Equal(t, "r1", got.RunID)
+	assert.Equal(t, "d1", got.ConfigDigest)
+}
+
+// The byte cap has to bind the DECOMPRESSED stream. Bounding the file instead
+// would let a few KiB of gzip expand into gigabytes of heap before any count
+// check runs — the same hazard the streaming decoder closed for plain JSON,
+// reopened by compression.
+func TestLoad_GzipCapsTheDecompressedStream(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bomb.json.gz")
+	// #nosec G304 -- writes the test's own TempDir fixture
+	// nosemgrep: gosec.G304-1 -- writes the test's own TempDir fixture
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	zw := gzip.NewWriter(f)
+	// Highly compressible filler: tiny on disk, far past the cap expanded.
+	chunk := bytes.Repeat([]byte{'a'}, 1<<20)
+	for written := int64(0); written <= maxArtifactBytes; written += int64(len(chunk)) {
+		_, err := zw.Write(chunk)
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+	require.NoError(t, f.Close())
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Less(t, info.Size(), int64(maxArtifactBytes),
+		"the fixture must be small on disk, or it would not be testing the bomb case")
+
+	_, err = Load(path, "site-a")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "cap")
+}
+
+// A truncated or non-gzip file under a .gz name is a deployment mistake, and
+// it must say so rather than surfacing as a JSON parse error.
+func TestLoad_RejectsCorruptGzip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "corrupt.json.gz")
+	require.NoError(t, os.WriteFile(path, []byte("this is not gzip"), 0o600))
+	_, err := Load(path, "site-a")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "gzip")
+}
+
+// writeGzipFiller writes a .gz whose DECOMPRESSED size is about n bytes, from
+// filler that compresses hard — so the file on disk stays tiny however large
+// n is. That gap is the whole point: it is what a byte cap on the compressed
+// stream would fail to see.
+func writeGzipFiller(t *testing.T, n int64) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "filler.json.gz")
+	// #nosec G304 -- writes the test's own TempDir fixture
+	// nosemgrep: gosec.G304-1 -- writes the test's own TempDir fixture
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	zw := gzip.NewWriter(f)
+	chunk := bytes.Repeat([]byte{'a'}, 1<<20)
+	for written := int64(0); written < n; written += int64(len(chunk)) {
+		_, err := zw.Write(chunk)
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+	require.NoError(t, f.Close())
+	return path
+}
+
+// The same promise as TestLoad_DecodeCostTracksTheCapNotTheFile, one layer
+// out. Compression breaks the file-size proxy the plain path relied on: a few
+// KiB of gzip expands to whatever the writer chose, so a reader that
+// decompresses first and checks the size afterwards pays for the ATTACKER's
+// number, not the cap's. Reading through a bounded reader makes the cost
+// track the cap again.
+func TestLoad_GzipRejectionCostTracksTheCapNotTheExpansion(t *testing.T) {
+	measure := func(path string) uint64 {
+		var before, after runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&before)
+		_, err := Load(path, "s")
+		require.Error(t, err)
+		runtime.ReadMemStats(&after)
+		return after.TotalAlloc - before.TotalAlloc
+	}
+	justOver := measure(writeGzipFiller(t, maxArtifactBytes+(1<<20)))
+	farOver := measure(writeGzipFiller(t, maxArtifactBytes*3))
+
+	assert.Less(t, farOver, justOver*2,
+		"rejecting a bomb that expands to three times the cap must not cost three times as much")
 }

--- a/pkg/poolartifact/poolartifact_test.go
+++ b/pkg/poolartifact/poolartifact_test.go
@@ -3,6 +3,7 @@ package poolartifact
 import (
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -382,4 +383,40 @@ func TestLoad_GzipRejectionCostTracksTheCapNotTheExpansion(t *testing.T) {
 
 	assert.Less(t, farOver, justOver*2,
 		"rejecting a bomb that expands to three times the cap must not cost three times as much")
+}
+
+// The pool's accounts become NATS subject tokens. subject.UserSubscriptionList
+// PANICS on one carrying a dot, wildcard, whitespace or control rune, so an
+// artifact holding one takes the clientsim pod down at startup rather than
+// failing it cleanly. Reject at both ends, using the same validator the
+// subject builders use, so the two cannot drift.
+func TestValidateAccounts_RejectsUnsafeSubjectTokens(t *testing.T) {
+	for _, bad := range []string{"weather.site-a.bot", "*", ">", "has space", "ctl\x01"} {
+		err := Write(filepath.Join(t.TempDir(), "p.json"), &Artifact{
+			RunID: "r", SiteID: "s", ConfigDigest: "d", Accounts: []string{"ok", bad},
+		})
+		require.Error(t, err, "account %q must be refused by the producer", bad)
+		assert.Contains(t, err.Error(), "subject token")
+	}
+}
+
+// The account cap is symmetric between Write and Load for a stated reason —
+// a producer that can emit what the consumer refuses turns a bad input into a
+// failure hours later, in the wrong tool. That rule was applied to the count
+// and not to the byte size, leaving one window open: a population inside the
+// account cap whose names are long enough to blow the byte cap. Narrow, but
+// the consequence is every pod refusing an artifact that published cleanly.
+func TestWrite_RefusesAnArtifactAboveTheReadCap(t *testing.T) {
+	// Few accounts, each enormous: the account cap cannot fire here, so this
+	// isolates the byte cap rather than passing through the other guard.
+	long := strings.Repeat("a", 100_000)
+	accounts := make([]string, 0, 700)
+	for i := range 700 {
+		accounts = append(accounts, fmt.Sprintf("%s%06d", long, i))
+	}
+	err := Write(filepath.Join(t.TempDir(), "p.json"), &Artifact{
+		RunID: "r", SiteID: "s", ConfigDigest: "d", Accounts: accounts,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cap")
 }

--- a/pkg/poolartifact/store.go
+++ b/pkg/poolartifact/store.go
@@ -1,0 +1,179 @@
+package poolartifact
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+// StoreConfig locates the object store the pool artifact travels through:
+// the producer writes it there, every consumer pod reads it back.
+//
+// Declared here rather than in each tool because both ends read it, and the
+// two must agree on bucket and prefix or the consumer reads an object that
+// does not exist. Nothing here has a safe default except the layout knobs —
+// a half-configured store pointed at the wrong bucket would surface as an
+// empty pool hours into a run, so Validate refuses one.
+type StoreConfig struct {
+	Endpoint  string `env:"POOL_S3_ENDPOINT"`
+	AccessKey string `env:"POOL_S3_ACCESS_KEY"`
+	SecretKey string `env:"POOL_S3_SECRET_KEY"`
+	Bucket    string `env:"POOL_S3_BUCKET"`
+	// Prefix keeps pool artifacts in their own keyspace when the bucket is
+	// shared with something else. A dedicated bucket is still the better
+	// answer: the artifact is a list of real accounts.
+	Prefix string `env:"POOL_S3_PREFIX" envDefault:"clientsim"`
+	UseSSL bool   `env:"POOL_S3_USE_SSL" envDefault:"true"`
+}
+
+// Configured reports whether the store is in use at all. Both tools accept a
+// file path instead, so an unset store is a valid configuration — only a
+// PARTLY set one is an error.
+func (c *StoreConfig) Configured() bool {
+	return c.Endpoint != "" || c.AccessKey != "" || c.SecretKey != "" || c.Bucket != ""
+}
+
+// Validate names the missing env var rather than the struct field, because
+// the operator setting it is reading a chart, not this source.
+func (c *StoreConfig) Validate() error {
+	var missing []string
+	for _, f := range []struct {
+		env, val string
+	}{
+		{"POOL_S3_ENDPOINT", c.Endpoint},
+		{"POOL_S3_ACCESS_KEY", c.AccessKey},
+		{"POOL_S3_SECRET_KEY", c.SecretKey},
+		{"POOL_S3_BUCKET", c.Bucket},
+	} {
+		if f.val == "" {
+			missing = append(missing, f.env)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("pool object store is missing %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// objects is the slice of an object store this package needs.
+//
+// Defined here rather than reusing minioutil.ObjectStore because that one
+// returns *minio.Object — a concrete type a test cannot fabricate, which
+// would force every store test through a container.
+type objects interface {
+	put(ctx context.Context, bucket, key string, r io.Reader, size int64) error
+	get(ctx context.Context, bucket, key string) (io.ReadCloser, error)
+}
+
+// Store reads and writes pool artifacts in an object store.
+type Store struct {
+	objects objects
+	bucket  string
+	prefix  string
+}
+
+type minioObjects struct{ c *minio.Client }
+
+func (m minioObjects) put(ctx context.Context, bucket, key string, r io.Reader, size int64) error {
+	_, err := m.c.PutObject(ctx, bucket, key, r, size, minio.PutObjectOptions{
+		ContentType: "application/gzip",
+	})
+	if err != nil {
+		return fmt.Errorf("put %s/%s: %w", bucket, key, err)
+	}
+	return nil
+}
+
+func (m minioObjects) get(ctx context.Context, bucket, key string) (io.ReadCloser, error) {
+	obj, err := m.c.GetObject(ctx, bucket, key, minio.GetObjectOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("get %s/%s: %w", bucket, key, err)
+	}
+	return obj, nil
+}
+
+// NewStore connects to the configured object store.
+func NewStore(cfg *StoreConfig) (*Store, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	c, err := minio.New(cfg.Endpoint, &minio.Options{
+		Creds:  credentials.NewStaticV4(cfg.AccessKey, cfg.SecretKey, ""),
+		Secure: cfg.UseSSL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("connect pool object store: %w", err)
+	}
+	return newStore(minioObjects{c: c}, cfg.Bucket, cfg.Prefix), nil
+}
+
+func newStore(o objects, bucket, prefix string) *Store {
+	return &Store{objects: o, bucket: bucket, prefix: prefix}
+}
+
+// Key is the run-scoped layout: <prefix>/<siteID>/<runID>/<name>. Scoping by
+// run is what lets the store double as the record of which accounts a given
+// run connected as, months after the pods are gone.
+func (s *Store) Key(siteID, runID, name string) string {
+	return path.Join(s.prefix, siteID, runID, name)
+}
+
+// Put validates the artifact exactly as Write does — a producer must not be
+// able to publish something the consumer will refuse — then stores it,
+// gzipped when the key says .gz.
+func (s *Store) Put(ctx context.Context, key string, a *Artifact) error {
+	data, err := marshalArtifact(a)
+	if err != nil {
+		return err
+	}
+	if isGzipPath(key) {
+		if data, err = gzipBytes(data); err != nil {
+			return fmt.Errorf("compress pool artifact: %w", err)
+		}
+	}
+	return s.objects.put(ctx, s.bucket, key, bytes.NewReader(data), int64(len(data)))
+}
+
+// Load fetches and validates an artifact, applying the same caps as the file
+// path — including the decompressed-byte cap, which is what keeps a hostile
+// or corrupt object from expanding into the consumer's heap.
+func (s *Store) Load(ctx context.Context, key, wantSiteID string) (*Artifact, error) {
+	r, err := s.objects.get(ctx, s.bucket, key)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close() //nolint:errcheck // read-only handle
+	data, err := readCapped(r, isGzipPath(key))
+	if err != nil {
+		return nil, err
+	}
+	return decodeAndValidate(data, wantSiteID)
+}
+
+// ParsePoolURL splits an s3://bucket/key URL. The bucket travels with the URL
+// so one env var names the whole location; StoreConfig.Bucket is the fallback
+// for callers that address objects by key alone.
+func ParsePoolURL(raw string) (bucket, key string, err error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", "", fmt.Errorf("parse pool URL %q: %w", raw, err)
+	}
+	if u.Scheme != "s3" {
+		return "", "", fmt.Errorf("pool URL %q must use the s3:// scheme, got %q", raw, u.Scheme)
+	}
+	if u.Host == "" {
+		return "", "", fmt.Errorf("pool URL %q names no bucket", raw)
+	}
+	key = strings.TrimPrefix(u.Path, "/")
+	if key == "" {
+		return "", "", fmt.Errorf("pool URL %q names no object key", raw)
+	}
+	return u.Host, key, nil
+}

--- a/pkg/poolartifact/store.go
+++ b/pkg/poolartifact/store.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"path"
+	"regexp"
 	"strings"
 
 	"github.com/minio/minio-go/v7"
@@ -70,7 +72,9 @@ func (c *StoreConfig) Validate() error {
 // returns *minio.Object — a concrete type a test cannot fabricate, which
 // would force every store test through a container.
 type objects interface {
-	put(ctx context.Context, bucket, key string, r io.Reader, size int64, contentType string) error
+	// put overwrites. ifAbsent makes it a conditional create — the write
+	// fails with ErrObjectExists rather than replacing an existing object.
+	put(ctx context.Context, bucket, key string, r io.Reader, size int64, contentType string, ifAbsent bool) error
 	get(ctx context.Context, bucket, key string) (io.ReadCloser, error)
 }
 
@@ -78,6 +82,11 @@ type objects interface {
 // store. The exporter treats the first as a normal first run and anything
 // else as a failure, and it cannot tell them apart from an opaque string.
 var ErrObjectNotFound = errors.New("pool object not found")
+
+// ErrObjectExists reports a lost create-if-absent race: another writer claimed
+// the key first. The loser must reconcile against what is actually stored, not
+// overwrite it.
+var ErrObjectExists = errors.New("pool object already exists")
 
 // contentTypeFor follows the key, exactly as compression does, so the two
 // cannot disagree: a plain-JSON manifest labelled application/gzip is
@@ -98,14 +107,30 @@ type Store struct {
 
 type minioObjects struct{ c *minio.Client }
 
-func (m minioObjects) put(ctx context.Context, bucket, key string, r io.Reader, size int64, contentType string) error {
-	_, err := m.c.PutObject(ctx, bucket, key, r, size, minio.PutObjectOptions{
-		ContentType: contentType,
-	})
+func (m minioObjects) put(ctx context.Context, bucket, key string, r io.Reader, size int64, contentType string, ifAbsent bool) error {
+	opts := minio.PutObjectOptions{ContentType: contentType}
+	if ifAbsent {
+		// If-None-Match: * — the server rejects the write if the key exists,
+		// so the claim IS the write. A Load-then-Put check cannot do this:
+		// two exporters both read "absent" and both go on to write.
+		opts.SetMatchETagExcept("*")
+	}
+	_, err := m.c.PutObject(ctx, bucket, key, r, size, opts)
 	if err != nil {
-		return fmt.Errorf("put %s/%s: %w", bucket, key, err)
+		return fmt.Errorf("put %s/%s: %w", bucket, key, asAlreadyExists(err))
 	}
 	return nil
+}
+
+// asAlreadyExists maps the conditional write's rejection onto the package
+// sentinel. Same errors.As discipline as asNotFound, and for the same reason.
+func asAlreadyExists(err error) error {
+	var resp minio.ErrorResponse
+	if errors.As(err, &resp) &&
+		(resp.Code == "PreconditionFailed" || resp.StatusCode == http.StatusPreconditionFailed) {
+		return fmt.Errorf("%w: %s", ErrObjectExists, err)
+	}
+	return err
 }
 
 func (m minioObjects) get(ctx context.Context, bucket, key string) (io.ReadCloser, error) {
@@ -119,8 +144,15 @@ func (m minioObjects) get(ctx context.Context, bucket, key string) (io.ReadClose
 // asNotFound maps the object store's own missing-key code onto the package
 // sentinel. GetObject is lazy — it does not reach the server until the first
 // read — so this has to be applied on the read path too.
+//
+// errors.As, not minio.ToErrorResponse: the latter is a plain type switch
+// (minio-go v7 api-error-response.go) and cannot see an ErrorResponse through
+// the %w wrapping readCapped applies on the read path. Classifying with it
+// silently failed to recognise a missing object, and the first pool-export of
+// any run ID then died on its own overwrite guard.
 func asNotFound(err error) error {
-	if minio.ToErrorResponse(err).Code == "NoSuchKey" {
+	var resp minio.ErrorResponse
+	if errors.As(err, &resp) && resp.Code == "NoSuchKey" {
 		return fmt.Errorf("%w: %s", ErrObjectNotFound, err)
 	}
 	return err
@@ -148,6 +180,26 @@ func newStore(o objects, bucket, prefix string) *Store {
 // Key is the run-scoped layout: <prefix>/<siteID>/<runID>/<name>. Scoping by
 // run is what lets the store double as the record of which accounts a given
 // run connected as, months after the pods are gone.
+// keySegmentPattern is the shape a single object-key segment may take. It
+// mirrors loadgen's run-ID rule so the two halves of one path cannot disagree
+// about what is safe.
+var keySegmentPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+
+// ValidateKeySegment rejects anything that would not survive path.Join as one
+// literal segment. Key joins prefix/siteID/runID/name, and path.Join
+// NORMALISES "..", so an unchecked segment can write the artifact into another
+// site's scope or out of the prefix entirely — silently overwriting a pool a
+// fleet may already be reading. Both segments come from deployment config, so
+// this catches a typo or a copied env rather than an attacker; the damage is
+// the same either way.
+func ValidateKeySegment(s string) error {
+	if s == "." || s == ".." || !keySegmentPattern.MatchString(s) {
+		return fmt.Errorf("%q is not a valid object-key segment: it must match %s and not be \".\" or \"..\"",
+			s, keySegmentPattern.String())
+	}
+	return nil
+}
+
 func (s *Store) Key(siteID, runID, name string) string {
 	return path.Join(s.prefix, siteID, runID, name)
 }
@@ -156,6 +208,22 @@ func (s *Store) Key(siteID, runID, name string) string {
 // able to publish something the consumer will refuse — then stores it,
 // gzipped when the key says .gz.
 func (s *Store) Put(ctx context.Context, key string, a *Artifact) error {
+	return s.putArtifact(ctx, key, a, false)
+}
+
+// PutIfAbsent claims the key with the write itself, returning ErrObjectExists
+// if another writer got there first. A run ID names one immutable population,
+// and a Load-then-Put check cannot enforce that: two exporters both read the
+// run as unpublished and both write, so a fleet mid-run can be reading one
+// population while pods that restart read the other — overlapping or disjoint
+// shards, every pod still reporting ready.
+func (s *Store) PutIfAbsent(ctx context.Context, key string, a *Artifact) error {
+	return s.putArtifact(ctx, key, a, true)
+}
+
+func (s *Store) putArtifact(ctx context.Context, key string, a *Artifact, ifAbsent bool) error {
+	// Marshal (and its validation) before the claim, so a rejected artifact
+	// never burns a run ID.
 	data, err := marshalArtifact(a)
 	if err != nil {
 		return err
@@ -165,7 +233,7 @@ func (s *Store) Put(ctx context.Context, key string, a *Artifact) error {
 			return fmt.Errorf("compress pool artifact: %w", err)
 		}
 	}
-	return s.objects.put(ctx, s.bucket, key, bytes.NewReader(data), int64(len(data)), contentTypeFor(key))
+	return s.objects.put(ctx, s.bucket, key, bytes.NewReader(data), int64(len(data)), contentTypeFor(key), ifAbsent)
 }
 
 // PutJSON stores an arbitrary JSON document beside the artifact — the export
@@ -182,7 +250,7 @@ func (s *Store) PutJSON(ctx context.Context, key string, v any) error {
 			return fmt.Errorf("compress %s: %w", key, err)
 		}
 	}
-	return s.objects.put(ctx, s.bucket, key, bytes.NewReader(data), int64(len(data)), contentTypeFor(key))
+	return s.objects.put(ctx, s.bucket, key, bytes.NewReader(data), int64(len(data)), contentTypeFor(key), false)
 }
 
 // Load fetches and validates an artifact, applying the same caps as the file

--- a/pkg/poolartifact/store.go
+++ b/pkg/poolartifact/store.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -185,6 +186,31 @@ func newStore(o objects, bucket, prefix string) *Store {
 // about what is safe.
 var keySegmentPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
 
+// PlaintextEndpoint reports a store access that crosses a network
+// unencrypted. Loopback is excluded: that is the documented local MinIO
+// workflow, and a warning that fires on every local run is one operators learn
+// to skip — which would cost the deployed case the visibility it exists for.
+//
+// It lives here rather than in either tool because the exposure is the same at
+// both ends: pool-export uploads the account list, clientsim downloads it, and
+// both carry the store's access key ID.
+func (c *StoreConfig) PlaintextEndpoint() bool {
+	if c.UseSSL {
+		return false
+	}
+	host := c.Endpoint
+	if h, _, err := net.SplitHostPort(c.Endpoint); err == nil {
+		host = h
+	}
+	if host == "localhost" {
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return false
+	}
+	return true
+}
+
 // ValidateKeySegment rejects anything that would not survive path.Join as one
 // literal segment. Key joins prefix/siteID/runID/name, and path.Join
 // NORMALISES "..", so an unchecked segment can write the artifact into another
@@ -193,8 +219,10 @@ var keySegmentPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
 // this catches a typo or a copied env rather than an attacker; the damage is
 // the same either way.
 func ValidateKeySegment(s string) error {
-	if s == "." || s == ".." || !keySegmentPattern.MatchString(s) {
-		return fmt.Errorf("%q is not a valid object-key segment: it must match %s and not be \".\" or \"..\"",
+	// No explicit "."/".." case: the pattern requires an alphanumeric first
+	// rune, so neither can match.
+	if !keySegmentPattern.MatchString(s) {
+		return fmt.Errorf("%q is not a valid object-key segment: it must match %s ",
 			s, keySegmentPattern.String())
 	}
 	return nil

--- a/pkg/poolartifact/store.go
+++ b/pkg/poolartifact/store.go
@@ -3,6 +3,7 @@ package poolartifact
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -136,6 +137,23 @@ func (s *Store) Put(ctx context.Context, key string, a *Artifact) error {
 	if isGzipPath(key) {
 		if data, err = gzipBytes(data); err != nil {
 			return fmt.Errorf("compress pool artifact: %w", err)
+		}
+	}
+	return s.objects.put(ctx, s.bucket, key, bytes.NewReader(data), int64(len(data)))
+}
+
+// PutJSON stores an arbitrary JSON document beside the artifact — the export
+// manifest, which records HOW a pool was produced. It carries no artifact
+// validation because it is not an artifact: nothing reads it back to connect
+// with, it exists so a run can be explained months later.
+func (s *Store) PutJSON(ctx context.Context, key string, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", key, err)
+	}
+	if isGzipPath(key) {
+		if data, err = gzipBytes(data); err != nil {
+			return fmt.Errorf("compress %s: %w", key, err)
 		}
 	}
 	return s.objects.put(ctx, s.bucket, key, bytes.NewReader(data), int64(len(data)))

--- a/pkg/poolartifact/store.go
+++ b/pkg/poolartifact/store.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -69,8 +70,23 @@ func (c *StoreConfig) Validate() error {
 // returns *minio.Object — a concrete type a test cannot fabricate, which
 // would force every store test through a container.
 type objects interface {
-	put(ctx context.Context, bucket, key string, r io.Reader, size int64) error
+	put(ctx context.Context, bucket, key string, r io.Reader, size int64, contentType string) error
 	get(ctx context.Context, bucket, key string) (io.ReadCloser, error)
+}
+
+// ErrObjectNotFound distinguishes "nothing published yet" from a broken
+// store. The exporter treats the first as a normal first run and anything
+// else as a failure, and it cannot tell them apart from an opaque string.
+var ErrObjectNotFound = errors.New("pool object not found")
+
+// contentTypeFor follows the key, exactly as compression does, so the two
+// cannot disagree: a plain-JSON manifest labelled application/gzip is
+// unparseable to anything reading object metadata.
+func contentTypeFor(key string) string {
+	if isGzipPath(key) {
+		return "application/gzip"
+	}
+	return "application/json"
 }
 
 // Store reads and writes pool artifacts in an object store.
@@ -82,9 +98,9 @@ type Store struct {
 
 type minioObjects struct{ c *minio.Client }
 
-func (m minioObjects) put(ctx context.Context, bucket, key string, r io.Reader, size int64) error {
+func (m minioObjects) put(ctx context.Context, bucket, key string, r io.Reader, size int64, contentType string) error {
 	_, err := m.c.PutObject(ctx, bucket, key, r, size, minio.PutObjectOptions{
-		ContentType: "application/gzip",
+		ContentType: contentType,
 	})
 	if err != nil {
 		return fmt.Errorf("put %s/%s: %w", bucket, key, err)
@@ -95,9 +111,19 @@ func (m minioObjects) put(ctx context.Context, bucket, key string, r io.Reader, 
 func (m minioObjects) get(ctx context.Context, bucket, key string) (io.ReadCloser, error) {
 	obj, err := m.c.GetObject(ctx, bucket, key, minio.GetObjectOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("get %s/%s: %w", bucket, key, err)
+		return nil, fmt.Errorf("get %s/%s: %w", bucket, key, asNotFound(err))
 	}
 	return obj, nil
+}
+
+// asNotFound maps the object store's own missing-key code onto the package
+// sentinel. GetObject is lazy — it does not reach the server until the first
+// read — so this has to be applied on the read path too.
+func asNotFound(err error) error {
+	if minio.ToErrorResponse(err).Code == "NoSuchKey" {
+		return fmt.Errorf("%w: %s", ErrObjectNotFound, err)
+	}
+	return err
 }
 
 // NewStore connects to the configured object store.
@@ -139,7 +165,7 @@ func (s *Store) Put(ctx context.Context, key string, a *Artifact) error {
 			return fmt.Errorf("compress pool artifact: %w", err)
 		}
 	}
-	return s.objects.put(ctx, s.bucket, key, bytes.NewReader(data), int64(len(data)))
+	return s.objects.put(ctx, s.bucket, key, bytes.NewReader(data), int64(len(data)), contentTypeFor(key))
 }
 
 // PutJSON stores an arbitrary JSON document beside the artifact — the export
@@ -156,7 +182,7 @@ func (s *Store) PutJSON(ctx context.Context, key string, v any) error {
 			return fmt.Errorf("compress %s: %w", key, err)
 		}
 	}
-	return s.objects.put(ctx, s.bucket, key, bytes.NewReader(data), int64(len(data)))
+	return s.objects.put(ctx, s.bucket, key, bytes.NewReader(data), int64(len(data)), contentTypeFor(key))
 }
 
 // Load fetches and validates an artifact, applying the same caps as the file
@@ -170,7 +196,7 @@ func (s *Store) Load(ctx context.Context, key, wantSiteID string) (*Artifact, er
 	defer r.Close() //nolint:errcheck // read-only handle
 	data, err := readCapped(r, isGzipPath(key))
 	if err != nil {
-		return nil, err
+		return nil, asNotFound(err)
 	}
 	return decodeAndValidate(data, wantSiteID)
 }

--- a/pkg/poolartifact/store_integration_test.go
+++ b/pkg/poolartifact/store_integration_test.go
@@ -57,9 +57,12 @@ func TestIntegration_Store_LargePoolRoundTrip(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Dot-free: an account carrying one is not a usable NATS subject token,
+	// and this fixture asserting otherwise was the artifact validator's first
+	// catch. Real non-bot accounts have no dots, and bots never reach a pool.
 	accounts := make([]string, 30_000)
 	for i := range accounts {
-		accounts[i] = "stg.employee." + strconv.Itoa(i)
+		accounts[i] = "stg-employee-" + strconv.Itoa(i)
 	}
 	ctx := context.Background()
 	key := s.Key("site-a", "run-large", "pool.json.gz")

--- a/pkg/poolartifact/store_integration_test.go
+++ b/pkg/poolartifact/store_integration_test.go
@@ -73,3 +73,23 @@ func TestIntegration_Store_LargePoolRoundTrip(t *testing.T) {
 	assert.Equal(t, accounts[0], got.Accounts[0])
 	assert.Equal(t, accounts[len(accounts)-1], got.Accounts[len(accounts)-1])
 }
+
+// The conditional write is the whole overwrite guard, and MinIO's If-None-Match
+// is a server-side extension — the fake cannot prove the server honours it.
+func TestIntegration_Store_PutIfAbsentClaimsOnce(t *testing.T) {
+	client, bucket := testutil.MinIO(t, "poolartifact")
+	s := newStore(minioObjects{c: client}, bucket, "p")
+	key := s.Key("site-a", "run-1", "pool.json.gz")
+	ctx := context.Background()
+
+	first := &Artifact{RunID: "run-1", SiteID: "site-a", ConfigDigest: "d1", Accounts: []string{"anna", "bob"}}
+	require.NoError(t, s.PutIfAbsent(ctx, key, first))
+
+	second := &Artifact{RunID: "run-1", SiteID: "site-a", ConfigDigest: "d2", Accounts: []string{"mallory"}}
+	err := s.PutIfAbsent(ctx, key, second)
+	require.ErrorIs(t, err, ErrObjectExists, "the server must reject the second claim")
+
+	got, err := s.Load(ctx, key, "site-a")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"anna", "bob"}, got.Accounts, "the first writer's population must survive")
+}

--- a/pkg/poolartifact/store_integration_test.go
+++ b/pkg/poolartifact/store_integration_test.go
@@ -1,0 +1,75 @@
+//go:build integration
+
+package poolartifact
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/testutil"
+)
+
+// The unit tests run against a fake object store, so nothing there exercises
+// the real client: the content type, the size argument, and gzip bytes
+// surviving a round trip through S3 are all only true if MinIO agrees.
+func TestIntegration_Store_RoundTrip(t *testing.T) {
+	_, bucket := testutil.MinIO(t, "poolartifact")
+	endpoint, accessKey, secretKey := testutil.MinIOEndpoint(t)
+
+	s, err := NewStore(&StoreConfig{
+		Endpoint: endpoint, AccessKey: accessKey, SecretKey: secretKey,
+		Bucket: bucket, Prefix: "clientsim", UseSSL: false,
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	key := s.Key("site-a", "run-int", "pool.json.gz")
+	want := &Artifact{
+		RunID: "run-int", SiteID: "site-a", ConfigDigest: "dig",
+		Accounts: []string{"alice", "bob", "carol"},
+	}
+	require.NoError(t, s.Put(ctx, key, want))
+
+	got, err := s.Load(ctx, key, "site-a")
+	require.NoError(t, err)
+	assert.Equal(t, want.Accounts, got.Accounts)
+	assert.Equal(t, want.RunID, got.RunID)
+	assert.Equal(t, SchemaVersion, got.SchemaVersion)
+
+	// A key that was never written must fail loudly, not yield an empty pool.
+	_, err = s.Load(ctx, s.Key("site-a", "no-such-run", "pool.json.gz"), "site-a")
+	assert.Error(t, err)
+}
+
+// A pool of realistic size is the case that matters for the transport hop:
+// it is why the artifact is gzipped at all.
+func TestIntegration_Store_LargePoolRoundTrip(t *testing.T) {
+	_, bucket := testutil.MinIO(t, "poolartifact-large")
+	endpoint, accessKey, secretKey := testutil.MinIOEndpoint(t)
+
+	s, err := NewStore(&StoreConfig{
+		Endpoint: endpoint, AccessKey: accessKey, SecretKey: secretKey,
+		Bucket: bucket, UseSSL: false,
+	})
+	require.NoError(t, err)
+
+	accounts := make([]string, 30_000)
+	for i := range accounts {
+		accounts[i] = "stg.employee." + strconv.Itoa(i)
+	}
+	ctx := context.Background()
+	key := s.Key("site-a", "run-large", "pool.json.gz")
+	require.NoError(t, s.Put(ctx, key, &Artifact{
+		RunID: "run-large", SiteID: "site-a", ConfigDigest: "dig", Accounts: accounts,
+	}))
+
+	got, err := s.Load(ctx, key, "site-a")
+	require.NoError(t, err)
+	require.Len(t, got.Accounts, len(accounts))
+	assert.Equal(t, accounts[0], got.Accounts[0])
+	assert.Equal(t, accounts[len(accounts)-1], got.Accounts[len(accounts)-1])
+}

--- a/pkg/poolartifact/store_test.go
+++ b/pkg/poolartifact/store_test.go
@@ -347,3 +347,49 @@ func TestStore_PutIfAbsentValidatesBeforeClaiming(t *testing.T) {
 	require.NoError(t, s.PutIfAbsent(context.Background(), key, testArtifact()),
 		"the rejected write must not have claimed the key")
 }
+
+// The exposure is identical at both ends — pool-export uploads the account
+// list, clientsim downloads it, and both carry the access key ID — so the rule
+// lives here rather than being written twice and drifting.
+func TestStoreConfig_PlaintextEndpoint(t *testing.T) {
+	cases := []struct {
+		name     string
+		endpoint string
+		useSSL   bool
+		want     bool
+	}{
+		{"tls anywhere is fine", "minio.svc.cluster.local:9000", true, false},
+		{"plaintext to a remote host warns", "minio.svc.cluster.local:9000", false, true},
+		{"plaintext to localhost is the dev loop", "localhost:9000", false, false},
+		{"plaintext to 127.0.0.1 is the dev loop", "127.0.0.1:9000", false, false},
+		{"plaintext to ::1 is the dev loop", "[::1]:9000", false, false},
+		{"a bare remote host with no port still warns", "minio.example.com", false, true},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			c := StoreConfig{Endpoint: tt.endpoint, UseSSL: tt.useSSL}
+			assert.Equal(t, tt.want, c.PlaintextEndpoint())
+		})
+	}
+}
+
+// asAlreadyExists is the other half of the conditional write: without it a
+// lost claim reads as an opaque transport failure and exportPool aborts
+// instead of reconciling.
+func TestAsAlreadyExists(t *testing.T) {
+	assert.ErrorIs(t, asAlreadyExists(fmt.Errorf("put: %w",
+		minio.ErrorResponse{Code: "PreconditionFailed"})), ErrObjectExists)
+	assert.ErrorIs(t, asAlreadyExists(fmt.Errorf("put: %w",
+		minio.ErrorResponse{StatusCode: 412})), ErrObjectExists)
+
+	other := errors.New("connection reset")
+	assert.NotErrorIs(t, asAlreadyExists(other), ErrObjectExists)
+	assert.ErrorIs(t, asAlreadyExists(other), other, "an unrelated error must pass through unchanged")
+}
+
+// asNotFound must not claim every minio error is a missing object.
+func TestAsNotFound_OnlyClassifiesNoSuchKey(t *testing.T) {
+	denied := fmt.Errorf("get: %w", minio.ErrorResponse{Code: "AccessDenied"})
+	assert.NotErrorIs(t, asNotFound(denied), ErrObjectNotFound)
+	assert.ErrorIs(t, asNotFound(denied), denied)
+}

--- a/pkg/poolartifact/store_test.go
+++ b/pkg/poolartifact/store_test.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
+
+	"github.com/minio/minio-go/v7"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,9 +26,14 @@ func newFakeObjects() *fakeObjects {
 	return &fakeObjects{data: map[string][]byte{}, contentTypes: map[string]string{}}
 }
 
-func (f *fakeObjects) put(_ context.Context, bucket, key string, r io.Reader, _ int64, contentType string) error {
+func (f *fakeObjects) put(_ context.Context, bucket, key string, r io.Reader, _ int64, contentType string, ifAbsent bool) error {
 	if f.putErr != nil {
 		return f.putErr
+	}
+	if ifAbsent {
+		if _, exists := f.data[bucket+"/"+key]; exists {
+			return fmt.Errorf("%w: %s/%s", ErrObjectExists, bucket, key)
+		}
 	}
 	b, err := io.ReadAll(r)
 	if err != nil {
@@ -36,16 +44,29 @@ func (f *fakeObjects) put(_ context.Context, bucket, key string, r io.Reader, _ 
 	return nil
 }
 
+// get models minio's real shape for a missing object, which is the whole
+// point of the fake: GetObject does NOT fail eagerly, it hands back a reader
+// whose first Read returns the NoSuchKey ErrorResponse. A fake that returned
+// ErrObjectNotFound from get itself would exercise a path minio never takes —
+// and would let a classifier that cannot see through the read path's %w
+// wrapping pass.
 func (f *fakeObjects) get(_ context.Context, bucket, key string) (io.ReadCloser, error) {
 	if f.getErr != nil {
 		return nil, f.getErr
 	}
 	b, ok := f.data[bucket+"/"+key]
 	if !ok {
-		return nil, ErrObjectNotFound
+		return io.NopCloser(errReader{minio.ErrorResponse{
+			Code: "NoSuchKey", Message: "The specified key does not exist.",
+		}}), nil
 	}
 	return io.NopCloser(bytes.NewReader(b)), nil
 }
+
+// errReader fails on the first Read, the way minio's lazy object does.
+type errReader struct{ err error }
+
+func (e errReader) Read([]byte) (int, error) { return 0, e.err }
 
 func testArtifact() *Artifact {
 	return &Artifact{
@@ -271,4 +292,58 @@ func TestStore_LoadReportsAMissingObject(t *testing.T) {
 	_, err := s.Load(context.Background(), "never-written.json.gz", "site-a")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrObjectNotFound)
+}
+
+// Key composes prefix/siteID/runID/name with path.Join, which NORMALISES
+// "..": a segment that escapes writes the artifact into another site's scope,
+// or out of the prefix entirely. Both segments come from deployment config,
+// so this is a guard against a typo or a copied env, not an attacker — but a
+// pool silently published over another site's is exactly the failure the run
+// digest exists to prevent, arriving by a different door.
+func TestValidateKeySegment(t *testing.T) {
+	for _, ok := range []string{"site-a", "run-1", "a.b_c-1", "S1"} {
+		assert.NoError(t, ValidateKeySegment(ok), "%q is a legal segment", ok)
+	}
+	for _, bad := range []string{"", ".", "..", "../other", "a/b", "-lead", "a b", "sit/e"} {
+		assert.Error(t, ValidateKeySegment(bad), "%q must be rejected", bad)
+	}
+}
+
+// The escape has to be impossible at the composer, not merely unlikely at the
+// callers: Key is exported and a future caller will not re-derive the rule.
+func TestStore_KeyStaysUnderThePrefix(t *testing.T) {
+	s := newStore(newFakeObjects(), "b", "clientsim")
+	assert.Equal(t, "clientsim/site-a/run-1/pool.json.gz", s.Key("site-a", "run-1", "pool.json.gz"))
+}
+
+// The overwrite guard was Load-then-Put: two exporters can both see the run
+// unpublished and both write, and the loser's population is what a fleet
+// reads. The claim has to be the write itself.
+func TestStore_PutIfAbsentClaimsTheKeyExactlyOnce(t *testing.T) {
+	f := newFakeObjects()
+	s := newStore(f, "b", "p")
+	key := s.Key("site-a", "run-1", "pool.json.gz")
+
+	require.NoError(t, s.PutIfAbsent(context.Background(), key, testArtifact()))
+
+	second := testArtifact()
+	second.Accounts = []string{"carol"}
+	err := s.PutIfAbsent(context.Background(), key, second)
+	require.ErrorIs(t, err, ErrObjectExists, "the second claim must lose, not overwrite")
+
+	got, err := s.Load(context.Background(), key, "site-a")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alice", "bob"}, got.Accounts, "the first writer's population must survive")
+}
+
+// A producer-side rejection must happen before the key is claimed, or a bad
+// artifact burns a run ID nothing can reuse.
+func TestStore_PutIfAbsentValidatesBeforeClaiming(t *testing.T) {
+	f := newFakeObjects()
+	s := newStore(f, "b", "p")
+	key := s.Key("site-a", "run-1", "pool.json.gz")
+
+	require.Error(t, s.PutIfAbsent(context.Background(), key, &Artifact{RunID: "r", SiteID: "s"}))
+	require.NoError(t, s.PutIfAbsent(context.Background(), key, testArtifact()),
+		"the rejected write must not have claimed the key")
 }

--- a/pkg/poolartifact/store_test.go
+++ b/pkg/poolartifact/store_test.go
@@ -13,14 +13,17 @@ import (
 
 // fakeObjects is an in-memory object store keyed by "bucket/key".
 type fakeObjects struct {
-	data   map[string][]byte
-	putErr error
-	getErr error
+	data         map[string][]byte
+	contentTypes map[string]string
+	putErr       error
+	getErr       error
 }
 
-func newFakeObjects() *fakeObjects { return &fakeObjects{data: map[string][]byte{}} }
+func newFakeObjects() *fakeObjects {
+	return &fakeObjects{data: map[string][]byte{}, contentTypes: map[string]string{}}
+}
 
-func (f *fakeObjects) put(_ context.Context, bucket, key string, r io.Reader, _ int64) error {
+func (f *fakeObjects) put(_ context.Context, bucket, key string, r io.Reader, _ int64, contentType string) error {
 	if f.putErr != nil {
 		return f.putErr
 	}
@@ -29,6 +32,7 @@ func (f *fakeObjects) put(_ context.Context, bucket, key string, r io.Reader, _ 
 		return err
 	}
 	f.data[bucket+"/"+key] = b
+	f.contentTypes[bucket+"/"+key] = contentType
 	return nil
 }
 
@@ -38,7 +42,7 @@ func (f *fakeObjects) get(_ context.Context, bucket, key string) (io.ReadCloser,
 	}
 	b, ok := f.data[bucket+"/"+key]
 	if !ok {
-		return nil, errors.New("no such object")
+		return nil, ErrObjectNotFound
 	}
 	return io.NopCloser(bytes.NewReader(b)), nil
 }
@@ -239,4 +243,32 @@ func TestStore_UncompressedKeyRoundTrips(t *testing.T) {
 	got, err := s.Load(context.Background(), "plain.json", "site-a")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"alice", "bob"}, got.Accounts)
+}
+
+// The manifest is plain JSON under a plain key, so labelling every object
+// application/gzip made tooling that reads object metadata unable to parse
+// it without guessing. Content type follows the key, like compression does.
+func TestStore_ContentTypeFollowsTheKey(t *testing.T) {
+	f := newFakeObjects()
+	s := newStore(f, "b", "p")
+	ctx := context.Background()
+
+	require.NoError(t, s.Put(ctx, "pool.json.gz", testArtifact()))
+	assert.Equal(t, "application/gzip", f.contentTypes["b/pool.json.gz"])
+
+	require.NoError(t, s.PutJSON(ctx, "pool-manifest.json", map[string]string{"a": "b"}))
+	assert.Equal(t, "application/json", f.contentTypes["b/pool-manifest.json"])
+
+	require.NoError(t, s.PutJSON(ctx, "big-manifest.json.gz", map[string]string{"a": "b"}))
+	assert.Equal(t, "application/gzip", f.contentTypes["b/big-manifest.json.gz"])
+}
+
+// A missing object has to be distinguishable from a broken one: the exporter
+// treats "nothing published yet" as the normal first run and any other
+// failure as an error, and it cannot tell them apart from an opaque string.
+func TestStore_LoadReportsAMissingObject(t *testing.T) {
+	s := newStore(newFakeObjects(), "b", "p")
+	_, err := s.Load(context.Background(), "never-written.json.gz", "site-a")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrObjectNotFound)
 }

--- a/pkg/poolartifact/store_test.go
+++ b/pkg/poolartifact/store_test.go
@@ -1,0 +1,242 @@
+package poolartifact
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeObjects is an in-memory object store keyed by "bucket/key".
+type fakeObjects struct {
+	data   map[string][]byte
+	putErr error
+	getErr error
+}
+
+func newFakeObjects() *fakeObjects { return &fakeObjects{data: map[string][]byte{}} }
+
+func (f *fakeObjects) put(_ context.Context, bucket, key string, r io.Reader, _ int64) error {
+	if f.putErr != nil {
+		return f.putErr
+	}
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	f.data[bucket+"/"+key] = b
+	return nil
+}
+
+func (f *fakeObjects) get(_ context.Context, bucket, key string) (io.ReadCloser, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	b, ok := f.data[bucket+"/"+key]
+	if !ok {
+		return nil, errors.New("no such object")
+	}
+	return io.NopCloser(bytes.NewReader(b)), nil
+}
+
+func testArtifact() *Artifact {
+	return &Artifact{
+		RunID: "run-1", SiteID: "site-a", ConfigDigest: "dig-1",
+		Accounts: []string{"alice", "bob"},
+	}
+}
+
+// The object store is a transport hop, so the contract on both ends must be
+// the one Load already enforces for files: same validation, same gzip rule.
+func TestStore_PutLoadRoundTrip(t *testing.T) {
+	f := newFakeObjects()
+	s := newStore(f, "pool-bucket", "clientsim")
+	key := s.Key("site-a", "run-1", "pool.json.gz")
+
+	require.NoError(t, s.Put(context.Background(), key, testArtifact()))
+
+	stored := f.data["pool-bucket/"+key]
+	require.NotEmpty(t, stored)
+	assert.Equal(t, []byte{0x1f, 0x8b}, stored[:2], "a .gz key must store gzip bytes")
+
+	got, err := s.Load(context.Background(), key, "site-a")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alice", "bob"}, got.Accounts)
+	assert.Equal(t, "run-1", got.RunID)
+}
+
+// Run-scoped keys are what make the object store double as the record of
+// which accounts a given run used.
+func TestStore_KeyIsRunScoped(t *testing.T) {
+	s := newStore(newFakeObjects(), "b", "clientsim")
+	assert.Equal(t, "clientsim/site-a/run-1/pool.json.gz", s.Key("site-a", "run-1", "pool.json.gz"))
+
+	bare := newStore(newFakeObjects(), "b", "")
+	assert.Equal(t, "site-a/run-1/pool.json.gz", bare.Key("site-a", "run-1", "pool.json.gz"),
+		"an empty prefix must not leave a leading slash")
+}
+
+// The consumer must refuse an artifact belonging to another site as loudly
+// over the wire as it does from a file — a mismatched pool connects accounts
+// that do not exist on the site under test.
+func TestStore_LoadRejectsAnotherSitesArtifact(t *testing.T) {
+	f := newFakeObjects()
+	s := newStore(f, "b", "p")
+	key := s.Key("site-a", "run-1", "pool.json.gz")
+	require.NoError(t, s.Put(context.Background(), key, testArtifact()))
+
+	_, err := s.Load(context.Background(), key, "site-b")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "site")
+}
+
+// Credentials and location have no safe default: a half-configured store that
+// silently pointed at the wrong bucket would surface as an empty pool hours
+// into a run.
+func TestStoreConfig_Validate(t *testing.T) {
+	full := StoreConfig{Endpoint: "e", AccessKey: "a", SecretKey: "s", Bucket: "b"}
+	require.NoError(t, full.Validate())
+
+	tests := []struct {
+		name string
+		mut  func(*StoreConfig)
+		want string
+	}{
+		{name: "no endpoint", mut: func(c *StoreConfig) { c.Endpoint = "" }, want: "POOL_S3_ENDPOINT"},
+		{name: "no access key", mut: func(c *StoreConfig) { c.AccessKey = "" }, want: "POOL_S3_ACCESS_KEY"},
+		{name: "no secret key", mut: func(c *StoreConfig) { c.SecretKey = "" }, want: "POOL_S3_SECRET_KEY"},
+		{name: "no bucket", mut: func(c *StoreConfig) { c.Bucket = "" }, want: "POOL_S3_BUCKET"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := full
+			tt.mut(&cfg)
+			err := cfg.Validate()
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+// The URL is what a deployment sets, so its parse errors are startup errors.
+func TestParsePoolURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          string
+		bucket, key string
+		wantErr     string
+	}{
+		{name: "bucket and key", in: "s3://my-bucket/clientsim/site-a/run-1/pool.json.gz",
+			bucket: "my-bucket", key: "clientsim/site-a/run-1/pool.json.gz"},
+		{name: "nested key", in: "s3://b/a/b/c.json.gz", bucket: "b", key: "a/b/c.json.gz"},
+		{name: "no key", in: "s3://only-bucket", wantErr: "object key"},
+		{name: "empty key", in: "s3://only-bucket/", wantErr: "object key"},
+		{name: "wrong scheme", in: "http://host/key", wantErr: "s3://"},
+		{name: "not a url", in: "::::", wantErr: "parse"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bucket, key, err := ParsePoolURL(tt.in)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.bucket, bucket)
+			assert.Equal(t, tt.key, key)
+		})
+	}
+}
+
+// Both tools accept a file path instead, so an unset store is a valid
+// configuration. Configured is what lets them tell "not using S3" apart from
+// "using S3, badly configured" — the second must fail at startup.
+func TestStoreConfig_Configured(t *testing.T) {
+	var unset StoreConfig
+	assert.False(t, unset.Configured(), "an entirely unset store is not in use")
+	defaultsOnly := StoreConfig{Prefix: "clientsim", UseSSL: true}
+	assert.False(t, defaultsOnly.Configured(),
+		"layout knobs carry envDefaults, so they cannot signal intent on their own")
+
+	partial := StoreConfig{Bucket: "b"}
+	assert.True(t, partial.Configured(), "one field set means someone meant to use it")
+	assert.Error(t, partial.Validate(), "...and a partial config must then fail loudly")
+}
+
+func TestNewStore_RejectsIncompleteConfig(t *testing.T) {
+	_, err := NewStore(&StoreConfig{Endpoint: "localhost:9000"})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "POOL_S3_ACCESS_KEY")
+}
+
+// Constructing the client must not dial: a consumer that only fails on the
+// first read gives a clearer error than one that fails at startup for an
+// endpoint that is merely slow to come up.
+func TestNewStore_DoesNotDial(t *testing.T) {
+	s, err := NewStore(&StoreConfig{
+		Endpoint: "127.0.0.1:1", AccessKey: "a", SecretKey: "s", Bucket: "b", Prefix: "p",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "p/site-a/run-1/pool.json.gz", s.Key("site-a", "run-1", "pool.json.gz"))
+}
+
+// A producer must not be able to publish something the consumer will refuse.
+// Put runs the same validation Write does, before it touches the network.
+func TestStore_PutRejectsWhatLoadWouldRefuse(t *testing.T) {
+	f := newFakeObjects()
+	s := newStore(f, "b", "p")
+	tests := []struct {
+		name string
+		a    *Artifact
+		want string
+	}{
+		{name: "no accounts", a: &Artifact{RunID: "r", SiteID: "s", ConfigDigest: "d"}, want: "empty accounts"},
+		{name: "no runID", a: &Artifact{SiteID: "s", ConfigDigest: "d", Accounts: []string{"a"}}, want: "empty runID"},
+		{name: "duplicate account", a: &Artifact{RunID: "r", SiteID: "s", ConfigDigest: "d",
+			Accounts: []string{"a", "a"}}, want: "duplicate"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := s.Put(context.Background(), "k.json.gz", tt.a)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.want)
+			assert.Empty(t, f.data, "nothing may be stored when validation failed")
+		})
+	}
+}
+
+// Transport failures reach the caller rather than yielding an empty pool: a
+// consumer that started on a silently-missing artifact would connect nobody
+// and report a healthy-looking zero.
+func TestStore_PropagatesTransportErrors(t *testing.T) {
+	boom := errors.New("network is unreachable")
+
+	f := newFakeObjects()
+	f.putErr = boom
+	err := newStore(f, "b", "p").Put(context.Background(), "k.json.gz", testArtifact())
+	assert.ErrorIs(t, err, boom)
+
+	g := newFakeObjects()
+	g.getErr = boom
+	_, err = newStore(g, "b", "p").Load(context.Background(), "k.json.gz", "site-a")
+	assert.ErrorIs(t, err, boom)
+}
+
+// An object stored under a key without .gz is plain JSON on both ends. The
+// filename is the only thing deciding it, so the two directions cannot
+// disagree — the same rule the file path uses.
+func TestStore_UncompressedKeyRoundTrips(t *testing.T) {
+	f := newFakeObjects()
+	s := newStore(f, "b", "p")
+	require.NoError(t, s.Put(context.Background(), "plain.json", testArtifact()))
+
+	assert.Equal(t, byte('{'), f.data["b/plain.json"][0], "a key without .gz stores plain JSON")
+	got, err := s.Load(context.Background(), "plain.json", "site-a")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alice", "bob"}, got.Accounts)
+}

--- a/tools/clientsim/README.md
+++ b/tools/clientsim/README.md
@@ -75,7 +75,8 @@ the local YAML in this repo.
 | `CLIENTSIM_AUTH_URL` | required | side issuer base URL |
 | `CLIENTSIM_POOL_FILE` | — | pool artifact path (`pkg/poolartifact`); `.gz` is decompressed. **Exactly one** of this and `_POOL_URL` |
 | `CLIENTSIM_POOL_URL` | — | `s3://bucket/key` the artifact is fetched from at startup — the k8s path, no initContainer needed |
-| `POOL_S3_ENDPOINT` / `_ACCESS_KEY` / `_SECRET_KEY` / `_BUCKET` | — | object store, required when `_POOL_URL` is set. Declared in `pkg/poolartifact` because `loadgen pool-export` writes with the same knobs |
+| `POOL_S3_ENDPOINT` / `_ACCESS_KEY` / `_SECRET_KEY` | — | object store, required when `_POOL_URL` is set. Declared in `pkg/poolartifact` because `loadgen pool-export` writes with the same knobs |
+| `POOL_S3_BUCKET` | — | required only for `loadgen pool-export`; clientsim ignores it, because `CLIENTSIM_POOL_URL` must name its bucket and that one wins |
 | `POOL_S3_PREFIX` / `_USE_SSL` | `clientsim` / `true` | key prefix and TLS |
 | `CLIENTSIM_SITE_ID` | required | site for `subscription.list` + subjects; must match the artifact |
 | `CLIENTSIM_TARGET_CONNS` | pool size | `T = min(target, pool)`; floor-partitioned across shards |

--- a/tools/clientsim/README.md
+++ b/tools/clientsim/README.md
@@ -73,7 +73,10 @@ the local YAML in this repo.
 |---|---|---|
 | `CLIENTSIM_NATS_WS_URL` | required | `ws(s)://` endpoint clients dial |
 | `CLIENTSIM_AUTH_URL` | required | side issuer base URL |
-| `CLIENTSIM_POOL_FILE` | required | pool artifact path (`pkg/poolartifact`) |
+| `CLIENTSIM_POOL_FILE` | — | pool artifact path (`pkg/poolartifact`); `.gz` is decompressed. **Exactly one** of this and `_POOL_URL` |
+| `CLIENTSIM_POOL_URL` | — | `s3://bucket/key` the artifact is fetched from at startup — the k8s path, no initContainer needed |
+| `POOL_S3_ENDPOINT` / `_ACCESS_KEY` / `_SECRET_KEY` / `_BUCKET` | — | object store, required when `_POOL_URL` is set. Declared in `pkg/poolartifact` because `loadgen pool-export` writes with the same knobs |
+| `POOL_S3_PREFIX` / `_USE_SSL` | `clientsim` / `true` | key prefix and TLS |
 | `CLIENTSIM_SITE_ID` | required | site for `subscription.list` + subjects; must match the artifact |
 | `CLIENTSIM_TARGET_CONNS` | pool size | `T = min(target, pool)`; floor-partitioned across shards |
 | `CLIENTSIM_SHARD_INDEX` / `_SHARD_COUNT` | `0` / `1` | replica slice |
@@ -252,17 +255,41 @@ fleet never reached its target, so the window measured nothing. Use
 
 ## Kubernetes (test / staging)
 
-Manifests live with the clusters' existing service manifests (ops-owned),
-not in this repo. The load-bearing points:
+The chart is ops-owned and lives outside this repo. What this repo owns is
+the contract it has to satisfy — written out in
+[`deploy/k8s-contract.md`](deploy/k8s-contract.md), including the full env
+list and the shape of each object.
 
+The chain, and why it is shaped this way:
+
+```text
+Job:         loadgen pool-export   MongoDB ──► pool.json.gz + pool-manifest.json ──► object store
+StatefulSet: clientsim             object store ──► every pod reads the SAME object
+```
+
+- **One querier, one snapshot, one object.** Each pod could query MongoDB for
+  itself, and that would be wrong: `shardSlice` hands every pod the same array
+  and slices it by ordinal, so two pods whose queries returned slightly
+  different sets (staging churns while the run is live) would claim
+  overlapping or disjoint ranges — accounts connected twice or not at all,
+  with every pod still reporting green.
+- **Why an object store and not the obvious alternatives.** A shared PVC needs
+  `ReadWriteMany`, which SAN-backed block storage cannot give a multi-replica
+  StatefulSet. A ConfigMap caps at 1 MiB and 30k real account names are
+  1.14 MiB before compression — and in a GitOps repo it would also commit a
+  list of real identities to git history permanently.
 - **clientsim is a StatefulSet**: pod ordinal → `CLIENTSIM_SHARD_INDEX` via
   the downward API; replicas = `CLIENTSIM_SHARD_COUNT`. No coordination
   service needed.
+  > ⚠️ **Never change `CLIENTSIM_SHARD_COUNT` under a running fleet.**
+  > Ownership is `index mod count` with no fencing, so a rolling rescale runs
+  > the old and new partitionings at once and double-connects the overlap.
+  > Scale to zero, then back up.
 - **Side issuer**: a second auth-service Deployment with `DEV_MODE=true`,
   reachable only in-cluster — **ClusterIP, no ingress and no VirtualService**
   — with a NetworkPolicy admitting only the clientsim and loadgen pods.
   clientsim reaches it by service DNS and nothing else changes in the code:
-  `CLIENTSIM_AUTH_URL=http://dev-auth-service.<ns>.svc.cluster.local:8080`.
+  `CLIENTSIM_AUTH_URL=http://dev-auth-service.NAMESPACE.svc.cluster.local:8080`.
   > ⚠️ **Test and staging only.** Dev mode mints a NATS JWT for *any*
   > account the caller names, so anything that can reach this Deployment can
   > impersonate any user of that site. That is acceptable against synthetic
@@ -271,6 +298,10 @@ not in this repo. The load-bearing points:
   > network boundary by default — the NetworkPolicy is what makes the
   > isolation real, and `kubectl port-forward` bypasses it for anyone who
   > holds that permission.
+- **The pool bucket holds real account names.** Give it its own bucket (or at
+  least its own prefix and credentials) rather than sharing one with
+  application uploads, and set a lifecycle rule — soak runs are frequent and
+  nothing prunes old artifacts on its own.
 - **OS limits**: raise `ulimit -n` well above conns × (2 + rooms); one
   (srcIP → dstIP:port) tuple caps at ~60k ephemeral ports — beyond that add
   replicas (each pod has its own IP) or NATS endpoint IPs.

--- a/tools/clientsim/README.md
+++ b/tools/clientsim/README.md
@@ -291,6 +291,10 @@ StatefulSet: clientsim             object store ──► every pod reads the SA
   — with a NetworkPolicy admitting only the clientsim and loadgen pods.
   clientsim reaches it by service DNS and nothing else changes in the code:
   `CLIENTSIM_AUTH_URL=http://dev-auth-service.NAMESPACE.svc.cluster.local:8080`.
+  > The NetworkPolicy controls who can reach the issuer, not whether the wire
+  > is readable — and what comes back is a NATS user JWT. Under a service mesh
+  > with mTLS that is covered; without one, terminate TLS on the issuer and use
+  > `https://`. See `deploy/k8s-contract.md`.
   > ⚠️ **Test and staging only.** Dev mode mints a NATS JWT for *any*
   > account the caller names, so anything that can reach this Deployment can
   > impersonate any user of that site. That is acceptable against synthetic

--- a/tools/clientsim/config_test.go
+++ b/tools/clientsim/config_test.go
@@ -345,6 +345,14 @@ func TestValidateConfig_PoolSourceIsExactlyOne(t *testing.T) {
 			c.PoolFile = ""
 			c.PoolURL = "s3://b/k.json.gz"
 		}, "POOL_S3_ENDPOINT"},
+		// The URL names the bucket, and the contract says POOL_S3_BUCKET is
+		// then unnecessary. Validating the raw config first demanded it
+		// anyway, so the documented k8s setup could not start at all.
+		{"url supplies the bucket", func(c *config) {
+			c.PoolFile = ""
+			c.PoolURL = "s3://from-url/k.json.gz"
+			c.Pool = poolartifact.StoreConfig{Endpoint: "e", AccessKey: "a", SecretKey: "s"}
+		}, ""},
 		{"url that is not s3", func(c *config) {
 			c.PoolFile = ""
 			c.PoolURL = "https://example.com/pool.json"

--- a/tools/clientsim/config_test.go
+++ b/tools/clientsim/config_test.go
@@ -180,6 +180,7 @@ func TestValidateConfig_ReadyRatioBounds(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &config{NATSWSURL: "wss://x", JWTMode: jwtModeProactive,
+				PoolFile:       "p",
 				MinReadyRatio:  tt.ratio,
 				SubPendingMsgs: 1, SubPendingBytes: 1, ShardCount: 1,
 				RampRate: 1, ReconnectBufBytes: 1, PingInterval: time.Minute}
@@ -197,6 +198,7 @@ func TestValidateConfig_RequiresEncryptedTransportUnlessOptedIn(t *testing.T) {
 	base := func() *config {
 		return &config{
 			NATSWSURL: "wss://nats.example:443", JWTMode: jwtModeProactive,
+			PoolFile:      "p",
 			MinReadyRatio: 0.95, SubPendingMsgs: 512, SubPendingBytes: 1 << 17,
 			RampRate: 50, ChurnRate: 0, ReconnectBufBytes: 1 << 16,
 			PingInterval: 2 * time.Minute,
@@ -276,7 +278,7 @@ func TestServeMetrics_ShutdownIsNotAFailure(t *testing.T) {
 func TestValidateConfig_RejectsNonWebSocketSchemesEvenWithTheOptIn(t *testing.T) {
 	base := func() *config {
 		return &config{
-			JWTMode: jwtModeProactive, MinReadyRatio: 0.95,
+			JWTMode: jwtModeProactive, MinReadyRatio: 0.95, PoolFile: "p",
 			SubPendingMsgs: 512, SubPendingBytes: 1 << 17,
 			RampRate: 50, ReconnectBufBytes: 1 << 16, PingInterval: 2 * time.Minute,
 		}
@@ -312,4 +314,82 @@ func TestValidateConfig_RejectsNonWebSocketSchemesEvenWithTheOptIn(t *testing.T)
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})
 	}
+}
+
+// The pool reaches a k8s fleet through an object store, because the two
+// alternatives are out: a shared PVC needs ReadWriteMany, and a ConfigMap
+// caps below a real 30k-account pool. Exactly one source must be set — a
+// fleet that silently preferred one over the other could measure the wrong
+// population with nothing in the logs saying so.
+func TestValidateConfig_PoolSourceIsExactlyOne(t *testing.T) {
+	store := poolartifact.StoreConfig{
+		Endpoint: "e", AccessKey: "a", SecretKey: "s", Bucket: "b",
+	}
+	cases := []struct {
+		name    string
+		mutate  func(*config)
+		wantErr string
+	}{
+		{"file only", func(*config) {}, ""},
+		{"url only", func(c *config) {
+			c.PoolFile = ""
+			c.PoolURL = "s3://b/k.json.gz"
+			c.Pool = store
+		}, ""},
+		{"neither", func(c *config) { c.PoolFile = "" }, "CLIENTSIM_POOL_FILE"},
+		{"both", func(c *config) {
+			c.PoolURL = "s3://b/k.json.gz"
+			c.Pool = store
+		}, "not both"},
+		{"url without store config", func(c *config) {
+			c.PoolFile = ""
+			c.PoolURL = "s3://b/k.json.gz"
+		}, "POOL_S3_ENDPOINT"},
+		{"url that is not s3", func(c *config) {
+			c.PoolFile = ""
+			c.PoolURL = "https://example.com/pool.json"
+			c.Pool = store
+		}, "s3://"},
+		{"partially configured store with a file source", func(c *config) {
+			c.Pool = poolartifact.StoreConfig{Bucket: "b"}
+		}, "POOL_S3_ENDPOINT"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validTestConfig()
+			tc.mutate(&cfg)
+			err := validateConfig(&cfg)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// The file branch is the local and docker-compose path; the object-store
+// branch is covered by pkg/poolartifact's own tests. What is worth pinning
+// here is that the two do not cross: a file source must never reach for the
+// network, and a malformed URL must fail before any connection is attempted.
+func TestLoadPool_ReadsTheConfiguredSource(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pool.json")
+	require.NoError(t, poolartifact.Write(path, &poolartifact.Artifact{
+		RunID: "r", SiteID: "site-a", ConfigDigest: "d",
+		Accounts: []string{"anna", "bob"},
+	}))
+
+	cfg := validTestConfig()
+	cfg.PoolFile = path
+	cfg.SiteID = "site-a"
+	got, err := loadPool(context.Background(), &cfg)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"anna", "bob"}, got.Accounts)
+
+	cfg.PoolFile = ""
+	cfg.PoolURL = "s3://bucket"
+	_, err = loadPool(context.Background(), &cfg)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "object key")
 }

--- a/tools/clientsim/config_test.go
+++ b/tools/clientsim/config_test.go
@@ -401,3 +401,27 @@ func TestLoadPool_ReadsTheConfiguredSource(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "object key")
 }
+
+// The pool is a list of real employee accounts and the fetch carries the
+// store's access key ID, so a plaintext endpoint is a real exposure — but
+// rejecting it outright would break the documented docker-compose loop, which
+// runs MinIO over HTTP on localhost. Make the posture visible instead of
+// silent, and only where it is actually a network hop.
+func TestWarnPlaintextObjectStore(t *testing.T) {
+	cases := []struct {
+		name     string
+		endpoint string
+		useSSL   bool
+		want     bool
+	}{
+		{"tls anywhere is fine", "minio.svc.cluster.local:9000", true, false},
+		{"plaintext to a remote host warns", "minio.svc.cluster.local:9000", false, true},
+		{"plaintext to localhost is the dev loop", "localhost:9000", false, false},
+		{"plaintext to 127.0.0.1 is the dev loop", "127.0.0.1:9000", false, false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, plaintextObjectStore(tt.endpoint, tt.useSSL))
+		})
+	}
+}

--- a/tools/clientsim/config_test.go
+++ b/tools/clientsim/config_test.go
@@ -421,7 +421,8 @@ func TestWarnPlaintextObjectStore(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, plaintextObjectStore(tt.endpoint, tt.useSSL))
+			cfg := poolartifact.StoreConfig{Endpoint: tt.endpoint, UseSSL: tt.useSSL}
+			assert.Equal(t, tt.want, cfg.PlaintextEndpoint())
 		})
 	}
 }

--- a/tools/clientsim/deploy/k8s-contract.md
+++ b/tools/clientsim/deploy/k8s-contract.md
@@ -155,10 +155,20 @@ Image: **clientsim**. Replicas = `CLIENTSIM_SHARD_COUNT`.
 | `POOL_S3_ENDPOINT` / `_ACCESS_KEY` / `_SECRET_KEY` | ✅ | same store the Job wrote to. Read-only credentials are enough |
 | `POOL_S3_BUCKET` | | ignored on this path — `CLIENTSIM_POOL_URL` must name its bucket, and that one wins |
 | `CLIENTSIM_NATS_WS_URL` | ✅ | `wss://…` |
-| `CLIENTSIM_AUTH_URL` | ✅ | `http://dev-auth-service.<ns>.svc.cluster.local:8080` |
+| `CLIENTSIM_AUTH_URL` | ✅ | `http://dev-auth-service.<ns>.svc.cluster.local:8080` — see the note below before keeping `http://` |
 | `CLIENTSIM_SITE_ID` | ✅ | must match the artifact, or startup fails |
 | `CLIENTSIM_SHARD_INDEX` | ✅ | pod ordinal, via the downward API |
 | `CLIENTSIM_SHARD_COUNT` | ✅ | = replicas |
+
+> **The side issuer returns NATS user JWTs, so `http://` is a real trade-off.**
+> The ClusterIP-plus-NetworkPolicy posture above controls *who can reach* the
+> issuer; it does not encrypt what crosses the pod network, and a JWT on that
+> wire is a credential anyone with packet capture in the namespace can replay
+> until it expires. If the cluster already runs a service mesh with mTLS, that
+> covers it and `http://` is fine. If it does not, terminate TLS on the side
+> issuer and use `https://` — clientsim needs no code change, only the URL and
+> the issuer's CA in the pod's trust store. Deciding this is the chart owner's
+> call, which is why it is written here rather than enforced in the tool.
 
 Everything else has a default — see the Configuration table in the README.
 

--- a/tools/clientsim/deploy/k8s-contract.md
+++ b/tools/clientsim/deploy/k8s-contract.md
@@ -84,7 +84,7 @@ subscriptions: {siteId, roomType: "channel", open: {$ne: false},
                 origin: {$ne: "teams"}}
              → group by u.account, isBot = $max(u.isBot)
              → match isBot != true          ← AFTER the group, see below
-             → match _id not matching /\.bot$/
+             → match _id not empty and not matching /\.bot$/
              → sort ascending, then limit
 ```
 

--- a/tools/clientsim/deploy/k8s-contract.md
+++ b/tools/clientsim/deploy/k8s-contract.md
@@ -24,8 +24,17 @@ reasons behind the parts that look optional but are not.
   └──────────────────────────────┘
 ```
 
-Run the Job before the StatefulSet. `pool-export` is idempotent for a given
-`--run-id`: re-running it overwrites the same two objects.
+Run the Job before the StatefulSet.
+
+**A run ID names one immutable population.** Re-running `pool-export` with the
+same `--run-id` succeeds only while the population is unchanged — a retried
+Job is safe. If the accounts have changed, it **fails** and tells you to use a
+new run ID, because overwriting a pool a fleet may already be reading is the
+one thing that breaks the invariant below: pods that started before and pods
+that restart after would slice different arrays.
+
+`--run-id` becomes a path segment, so it must match
+`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$` and be neither `.` nor `..`.
 
 ## Why not each pod querying MongoDB itself
 
@@ -71,7 +80,8 @@ Env — all of these already exist in the loadgen half of the chart except the
 ### What it exports
 
 ```text
-subscriptions: {siteId, roomType: "channel", open: {$ne: false}}
+subscriptions: {siteId, roomType: "channel", open: {$ne: false},
+                origin: {$ne: "teams"}}
              → distinct u.account, sorted ascending
 ```
 
@@ -80,7 +90,32 @@ clientsim opens room lanes only for channels, because DM traffic arrives on
 the user lane instead. An account with no channel subscription would connect
 cleanly and then measure nothing.
 
+The **`origin` exclusion matters for the same reason**. user-service hides
+Teams-origin rooms from `subscription.list` unless `SHOW_TEAMS_ROOM` (default
+`false`) or the account is allowlisted. Without it, an account whose only
+channel subscriptions are Teams rooms is exported, walks to an *empty* plan,
+and reports ready while subscribing to nothing. It is applied unconditionally
+rather than mirroring the per-account allowlist: for a load pool,
+under-selecting costs a few connections and over-selecting costs silent
+measurement loss.
+
 The sort is load-bearing, not cosmetic — see the sharding note above.
+
+### Index
+
+The query starts on `siteId + roomType + open`, and the subscriptions
+collection carries no index for that shape (`u.account + roomType` and
+`name + roomType` today). Note that an index would help here by being
+**covering**, not by being selective: on a single-site deployment the query
+legitimately needs most of the channel subscriptions, so the win is skipping
+the document fetches, not the scan.
+
+A covering index would be `{siteId: 1, roomType: 1, open: 1, "u.account": 1}`.
+It is **not** created by this tool — a load tool must not mutate the schema of
+the database under test, and the write amplification on a hot collection is
+the subscriptions owner's call. Until it exists, expect the Job to do a
+collection scan; measure with `explain("executionStats")` against a
+production-sized collection before deciding.
 
 An empty result **fails the Job**. A fleet started against nobody reports a
 healthy zero, and this is the last place that can say why.

--- a/tools/clientsim/deploy/k8s-contract.md
+++ b/tools/clientsim/deploy/k8s-contract.md
@@ -81,8 +81,9 @@ Env — all of these already exist in the loadgen half of the chart except the
 
 ```text
 subscriptions: {siteId, roomType: "channel", open: {$ne: false},
-                origin: {$ne: "teams"}}
+                origin: {$ne: "teams"}, u.isBot: {$ne: true}}
              → distinct u.account, sorted ascending
+             → ".bot" accounts dropped
 ```
 
 Mirrors user-service's own `subscription.list` match, narrowed to `channel`:
@@ -98,6 +99,16 @@ and reports ready while subscribing to nothing. It is applied unconditionally
 rather than mirroring the per-account allowlist: for a load pool,
 under-selecting costs a few connections and over-selecting costs silent
 measurement loss.
+
+**Bots are excluded twice, on purpose.** A bot that owns a room holds a
+genuine channel subscription — `bot-room-service` writes `u.isBot: true` with
+`roomType: "channel"`, and its `$setOnInsert` never sets `open` — so every
+other condition above is legitimately true of it. clientsim cannot connect as
+one: bots authenticate over HTTP through `pkg/botauth`, not the user JWT path,
+and a dotted `.bot` account spans subject tokens, which panics
+`subject.UserSubscriptionList` before a request is made. The query drops them
+on the stored flag so the bulk never leaves the server; a second pass in Go
+drops them on the account shape, catching a row whose flag was never stored.
 
 The sort is load-bearing, not cosmetic — see the sharding note above.
 

--- a/tools/clientsim/deploy/k8s-contract.md
+++ b/tools/clientsim/deploy/k8s-contract.md
@@ -121,7 +121,10 @@ collection carries no index for that shape (`u.account + roomType` and
 legitimately needs most of the channel subscriptions, so the win is skipping
 the document fetches, not the scan.
 
-A covering index would be `{siteId: 1, roomType: 1, open: 1, "u.account": 1}`.
+A covering index has to carry **every** predicate, or MongoDB fetches the
+documents anyway and the one benefit is gone. With the `origin` and `u.isBot`
+exclusions that is
+`{siteId: 1, roomType: 1, open: 1, origin: 1, "u.isBot": 1, "u.account": 1}`.
 It is **not** created by this tool — a load tool must not mutate the schema of
 the database under test, and the write amplification on a hot collection is
 the subscriptions owner's call. Until it exists, expect the Job to do a
@@ -150,7 +153,7 @@ Image: **clientsim**. Replicas = `CLIENTSIM_SHARD_COUNT`.
 |---|---|---|
 | `CLIENTSIM_POOL_URL` | ✅ | `s3://<bucket>/<prefix>/<siteId>/<runId>/pool.json.gz` |
 | `POOL_S3_ENDPOINT` / `_ACCESS_KEY` / `_SECRET_KEY` | ✅ | same store the Job wrote to. Read-only credentials are enough |
-| `POOL_S3_BUCKET` | | the URL's bucket wins; set it only if the URL omits one |
+| `POOL_S3_BUCKET` | | ignored on this path — `CLIENTSIM_POOL_URL` must name its bucket, and that one wins |
 | `CLIENTSIM_NATS_WS_URL` | ✅ | `wss://…` |
 | `CLIENTSIM_AUTH_URL` | ✅ | `http://dev-auth-service.<ns>.svc.cluster.local:8080` |
 | `CLIENTSIM_SITE_ID` | ✅ | must match the artifact, or startup fails |

--- a/tools/clientsim/deploy/k8s-contract.md
+++ b/tools/clientsim/deploy/k8s-contract.md
@@ -81,8 +81,10 @@ Env — all of these already exist in the loadgen half of the chart except the
 
 ```text
 subscriptions: {siteId, roomType: "channel", open: {$ne: false},
-                origin: {$ne: "teams"}, u.isBot: {$ne: true}}
-             → distinct u.account, sorted ascending
+                origin: {$ne: "teams"}}
+             → group by u.account, isBot = $max(u.isBot)
+             → match isBot != true          ← AFTER the group, see below
+             → sort ascending, limit
              → ".bot" accounts dropped
 ```
 
@@ -99,6 +101,12 @@ and reports ready while subscribing to nothing. It is applied unconditionally
 rather than mirroring the per-account allowlist: for a load pool,
 under-selecting costs a few connections and over-selecting costs silent
 measurement loss.
+
+**The bot exclusion runs after the group, not before it.** Filtering rows
+first looks equivalent and is not: an account with one flagged row and one row
+whose flag was never written has the flagged row removed and survives on the
+other. Grouping first and taking `$max` of the flag means any flagged row
+disqualifies the whole account.
 
 **Bots are excluded twice, on purpose.** A bot that owns a room holds a
 genuine channel subscription — `bot-room-service` writes `u.isBot: true` with
@@ -124,7 +132,9 @@ the document fetches, not the scan.
 A covering index has to carry **every** predicate, or MongoDB fetches the
 documents anyway and the one benefit is gone. With the `origin` and `u.isBot`
 exclusions that is
-`{siteId: 1, roomType: 1, open: 1, origin: 1, "u.isBot": 1, "u.account": 1}`.
+`{siteId: 1, roomType: 1, open: 1, origin: 1, "u.account": 1, "u.isBot": 1}` —
+`u.isBot` is no longer a match predicate but is still read per row by the
+group, so it has to be in the index for the query to stay covered.
 It is **not** created by this tool — a load tool must not mutate the schema of
 the database under test, and the write amplification on a hot collection is
 the subscriptions owner's call. Until it exists, expect the Job to do a

--- a/tools/clientsim/deploy/k8s-contract.md
+++ b/tools/clientsim/deploy/k8s-contract.md
@@ -84,8 +84,8 @@ subscriptions: {siteId, roomType: "channel", open: {$ne: false},
                 origin: {$ne: "teams"}}
              → group by u.account, isBot = $max(u.isBot)
              → match isBot != true          ← AFTER the group, see below
-             → sort ascending, limit
-             → ".bot" accounts dropped
+             → match _id not matching /\.bot$/
+             → sort ascending, then limit
 ```
 
 Mirrors user-service's own `subscription.list` match, narrowed to `channel`:

--- a/tools/clientsim/deploy/k8s-contract.md
+++ b/tools/clientsim/deploy/k8s-contract.md
@@ -1,0 +1,156 @@
+# clientsim on Kubernetes — the chart contract
+
+The Helm chart is ops-owned and lives outside this repo. This file is the
+contract it has to satisfy: the objects, the env each one needs, and the
+reasons behind the parts that look optional but are not.
+
+## The chain
+
+```text
+  ┌──────────────────────────────┐
+  │ Job (PreSync / pre-install)  │   loadgen pool-export --run-id=<runId>
+  │ image: loadgen               │
+  └───────────┬──────────────────┘
+              │  MongoDB: accounts with a channel subscription on this site
+              ▼
+      object store (MinIO)
+      <prefix>/<siteId>/<runId>/pool.json.gz         ← the fleet reads this
+      <prefix>/<siteId>/<runId>/pool-manifest.json   ← how it was produced
+              │
+              ▼
+  ┌──────────────────────────────┐
+  │ StatefulSet: clientsim       │   every pod fetches the SAME object
+  │ replicas = SHARD_COUNT       │   at startup — no initContainer
+  └──────────────────────────────┘
+```
+
+Run the Job before the StatefulSet. `pool-export` is idempotent for a given
+`--run-id`: re-running it overwrites the same two objects.
+
+## Why not each pod querying MongoDB itself
+
+`shardSlice` hands every pod the same array and slices it by ordinal. Two
+pods whose queries returned slightly different sets — staging churns while
+the run is live — would claim overlapping or disjoint ranges: accounts
+connected twice or not at all, with every pod still reporting ready. One
+querier, one snapshot, one object is what makes the sharding safe.
+
+## Why an object store rather than a PVC or a ConfigMap
+
+| | why not |
+|---|---|
+| shared PVC | needs `ReadWriteMany`; SAN-backed block storage cannot give that to a multi-replica StatefulSet |
+| ConfigMap | caps at 1 MiB — 30k real account names are 1.14 MiB uncompressed. In a GitOps repo it also commits a list of real identities to git history, permanently |
+
+## Object 1 — the export Job
+
+Image: **loadgen**. Command: `loadgen pool-export --run-id=<runId>`.
+
+| flag | default | meaning |
+|---|---|---|
+| `--run-id` | required | the run the artifact is filed under |
+| `--limit` | `0` | cap the exported accounts (`0` = the whole population) |
+| `--out` | — | also write the artifact to a local path |
+
+Env — all of these already exist in the loadgen half of the chart except the
+`POOL_S3_*` group:
+
+| env | required | meaning |
+|---|---|---|
+| `MONGO_URI` | ✅ | operational MongoDB; a read-only user is enough |
+| `MONGO_DB` | | database (default `chat`) |
+| `MONGO_USERNAME` / `MONGO_PASSWORD` | | when the URI does not carry them |
+| `SITE_ID` | ✅ | the site to export; must match clientsim's |
+| `NATS_URL` | ✅ | loadgen requires it at startup even though `pool-export` does not use it |
+| `POOL_S3_ENDPOINT` | ✅ | object store host:port |
+| `POOL_S3_ACCESS_KEY` / `POOL_S3_SECRET_KEY` | ✅ | credentials |
+| `POOL_S3_BUCKET` | ✅ | bucket |
+| `POOL_S3_PREFIX` | | key prefix (default `clientsim`) |
+| `POOL_S3_USE_SSL` | | default `true` |
+
+### What it exports
+
+```text
+subscriptions: {siteId, roomType: "channel", open: {$ne: false}}
+             → distinct u.account, sorted ascending
+```
+
+Mirrors user-service's own `subscription.list` match, narrowed to `channel`:
+clientsim opens room lanes only for channels, because DM traffic arrives on
+the user lane instead. An account with no channel subscription would connect
+cleanly and then measure nothing.
+
+The sort is load-bearing, not cosmetic — see the sharding note above.
+
+An empty result **fails the Job**. A fleet started against nobody reports a
+healthy zero, and this is the last place that can say why.
+
+### The manifest
+
+`pool-manifest.json` records `runId`, `siteId`, `configDigest`, the account
+count, the limit, the query, and the export time. The artifact says *who*
+connected; the manifest says how that set was chosen, which is what makes a
+run reproducible months later rather than merely identifiable.
+
+`configDigest` fingerprints the **population** (a Mongo export has no preset
+or RNG seed to hash), so two runs against the same accounts share a digest
+and one changed account is visible.
+
+## Object 2 — the clientsim StatefulSet
+
+Image: **clientsim**. Replicas = `CLIENTSIM_SHARD_COUNT`.
+
+| env | required | meaning |
+|---|---|---|
+| `CLIENTSIM_POOL_URL` | ✅ | `s3://<bucket>/<prefix>/<siteId>/<runId>/pool.json.gz` |
+| `POOL_S3_ENDPOINT` / `_ACCESS_KEY` / `_SECRET_KEY` | ✅ | same store the Job wrote to. Read-only credentials are enough |
+| `POOL_S3_BUCKET` | | the URL's bucket wins; set it only if the URL omits one |
+| `CLIENTSIM_NATS_WS_URL` | ✅ | `wss://…` |
+| `CLIENTSIM_AUTH_URL` | ✅ | `http://dev-auth-service.<ns>.svc.cluster.local:8080` |
+| `CLIENTSIM_SITE_ID` | ✅ | must match the artifact, or startup fails |
+| `CLIENTSIM_SHARD_INDEX` | ✅ | pod ordinal, via the downward API |
+| `CLIENTSIM_SHARD_COUNT` | ✅ | = replicas |
+
+Everything else has a default — see the Configuration table in the README.
+
+`CLIENTSIM_POOL_FILE` and `CLIENTSIM_POOL_URL` are mutually exclusive: set
+exactly one. A **partly** set `POOL_S3_*` group fails startup even on the file
+path, because it means someone meant to use the object store and mistyped.
+
+### Pod ordinal → shard index
+
+```yaml
+env:
+  - name: POD_NAME
+    valueFrom:
+      fieldRef: { fieldPath: metadata.name }
+  # CLIENTSIM_SHARD_INDEX = the ordinal suffix of POD_NAME
+```
+
+The downward API exposes the pod name, not the ordinal, so the chart has to
+split the suffix (an initContainer, a shell prefix in `command`, or whatever
+the chart already does for other StatefulSets).
+
+## Sizing
+
+- **Room-queue memory** is the one that bites: worst case retained per pod is
+  `CLIENTSIM_TARGET_CONNS × CLIENTSIM_SUB_PENDING_MSGS × event size`
+  (10k × 512 × ~2 KiB ≈ 10 GB if every pump stalled at once).
+  `CLIENTSIM_SUB_PENDING_BYTES` does **not** bound this lane.
+- **`ulimit -n`** well above `conns × (2 + rooms)`.
+- One `(srcIP → dstIP:port)` tuple caps at ~60k ephemeral ports — beyond that
+  add replicas (each pod has its own IP) or NATS endpoint IPs.
+
+## Operational rules
+
+- **Never change `CLIENTSIM_SHARD_COUNT` under a running fleet.** Ownership is
+  `index mod count` with no fencing, so a rolling rescale runs both
+  partitionings at once and double-connects the overlap. Scale to zero first.
+- **The pool bucket holds real account names.** Give it its own bucket — or at
+  least its own prefix and credentials — rather than sharing one with
+  application uploads, and set a lifecycle rule: soak runs are frequent and
+  nothing prunes old artifacts on its own.
+- **The dev-mode auth-service mints a JWT for any account it is asked for.**
+  ClusterIP, no ingress, NetworkPolicy limited to the clientsim and loadgen
+  pods, test/staging only. A namespace is not a network boundary by default,
+  and `kubectl port-forward` bypasses network controls entirely.

--- a/tools/clientsim/main.go
+++ b/tools/clientsim/main.go
@@ -29,15 +29,24 @@ type config struct {
 	// the NATS user JWT crosses the wire on connect: against anything shared
 	// that is a credential in the clear, and a warning is too easy to miss in
 	// a soak's log stream. The local throwaway stack sets it explicitly.
-	AllowInsecureWS bool    `env:"CLIENTSIM_ALLOW_INSECURE_WS" envDefault:"false"`
-	AuthURL         string  `env:"CLIENTSIM_AUTH_URL,required"`
-	PoolFile        string  `env:"CLIENTSIM_POOL_FILE,required"`
-	SiteID          string  `env:"CLIENTSIM_SITE_ID,required"`
-	TargetConns     int     `env:"CLIENTSIM_TARGET_CONNS" envDefault:"0"`
-	ShardIndex      int     `env:"CLIENTSIM_SHARD_INDEX" envDefault:"0"`
-	ShardCount      int     `env:"CLIENTSIM_SHARD_COUNT" envDefault:"1"`
-	RampRate        float64 `env:"CLIENTSIM_RAMP_RATE" envDefault:"50"`
-	ChurnRate       float64 `env:"CLIENTSIM_CHURN_RATE" envDefault:"0"`
+	AllowInsecureWS bool   `env:"CLIENTSIM_ALLOW_INSECURE_WS" envDefault:"false"`
+	AuthURL         string `env:"CLIENTSIM_AUTH_URL,required"`
+	// PoolFile and PoolURL are the two ways the pool reaches this process,
+	// and exactly one must be set. A file is the local and docker-compose
+	// path; an s3:// URL is the k8s one, because a shared PVC needs
+	// ReadWriteMany and a ConfigMap caps below a real 30k-account pool.
+	PoolFile string `env:"CLIENTSIM_POOL_FILE"`
+	PoolURL  string `env:"CLIENTSIM_POOL_URL"`
+	// Pool is the object store PoolURL is read from. Declared in poolartifact
+	// because loadgen writes with the same knobs: two copies of the tags is
+	// how the producer and consumer end up on different buckets.
+	Pool        poolartifact.StoreConfig
+	SiteID      string  `env:"CLIENTSIM_SITE_ID,required"`
+	TargetConns int     `env:"CLIENTSIM_TARGET_CONNS" envDefault:"0"`
+	ShardIndex  int     `env:"CLIENTSIM_SHARD_INDEX" envDefault:"0"`
+	ShardCount  int     `env:"CLIENTSIM_SHARD_COUNT" envDefault:"1"`
+	RampRate    float64 `env:"CLIENTSIM_RAMP_RATE" envDefault:"50"`
+	ChurnRate   float64 `env:"CLIENTSIM_CHURN_RATE" envDefault:"0"`
 	// expiry is the DEFAULT because it is what the real client does: it never
 	// refreshes on its own, it holds the JWT until the server drops the
 	// connection at expiry and re-mints on the reconnect. proactive is a
@@ -88,7 +97,7 @@ func run(ctx context.Context) error {
 		return err
 	}
 
-	pool, err := poolartifact.Load(cfg.PoolFile, cfg.SiteID)
+	pool, err := loadPool(ctx, &cfg)
 	if err != nil {
 		return fmt.Errorf("load pool artifact: %w", err)
 	}
@@ -199,6 +208,56 @@ func serveMetrics(srv *http.Server, lis net.Listener) <-chan error {
 
 // validateConfig rejects value combinations that would silently void a
 // spec-required control instead of limping with surprising semantics.
+// loadPool reads the artifact from whichever source is configured. The object
+// store is the k8s path: a Job publishes the pool once and every pod reads
+// that one object, which is what keeps the sharding safe — each pod slicing
+// its own query result would give two pods different arrays.
+func loadPool(ctx context.Context, cfg *config) (*poolartifact.Artifact, error) {
+	if cfg.PoolFile != "" {
+		return poolartifact.Load(cfg.PoolFile, cfg.SiteID)
+	}
+	bucket, key, err := poolartifact.ParsePoolURL(cfg.PoolURL)
+	if err != nil {
+		return nil, err
+	}
+	// The URL names the bucket, so it wins over POOL_S3_BUCKET: one env var
+	// locates the whole object, and the two cannot then disagree.
+	store := cfg.Pool
+	store.Bucket = bucket
+	s, err := poolartifact.NewStore(&store)
+	if err != nil {
+		return nil, err
+	}
+	return s.Load(ctx, key, cfg.SiteID)
+}
+
+// validatePoolSource enforces exactly one pool source. Preferring one over
+// the other when both are set would let a fleet measure a different
+// population than the operator configured, with nothing in the logs saying
+// which one won.
+func validatePoolSource(cfg *config) error {
+	switch {
+	case cfg.PoolFile == "" && cfg.PoolURL == "":
+		return errors.New("set exactly one of CLIENTSIM_POOL_FILE or CLIENTSIM_POOL_URL")
+	case cfg.PoolFile != "" && cfg.PoolURL != "":
+		return errors.New("set CLIENTSIM_POOL_FILE or CLIENTSIM_POOL_URL, not both")
+	}
+	// A partly-set store is an error even on the file path: it means someone
+	// meant to use the object store and mistyped, and staying silent would
+	// hand them a run against the wrong pool.
+	if cfg.PoolURL != "" || cfg.Pool.Configured() {
+		if err := cfg.Pool.Validate(); err != nil {
+			return err
+		}
+	}
+	if cfg.PoolURL != "" {
+		if _, _, err := poolartifact.ParsePoolURL(cfg.PoolURL); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func validateConfig(cfg *config) error {
 	// The NATS user JWT crosses the wire on connect, so cleartext has to be a
 	// deliberate act rather than a typo in a URL. Opting in still warns: on a
@@ -207,6 +266,9 @@ func validateConfig(cfg *config) error {
 	// CLEARTEXT WEBSOCKET on a throwaway stack, never a different protocol. A
 	// nats:// URL would connect over plain TCP and quietly measure a transport
 	// the real client does not ship.
+	if err := validatePoolSource(cfg); err != nil {
+		return err
+	}
 	u, err := url.Parse(cfg.NATSWSURL)
 	if err != nil {
 		// Same message as a wrong scheme: an operator who set a bare host:port

--- a/tools/clientsim/main.go
+++ b/tools/clientsim/main.go
@@ -216,19 +216,31 @@ func loadPool(ctx context.Context, cfg *config) (*poolartifact.Artifact, error) 
 	if cfg.PoolFile != "" {
 		return poolartifact.Load(cfg.PoolFile, cfg.SiteID)
 	}
-	bucket, key, err := poolartifact.ParsePoolURL(cfg.PoolURL)
+	store, key, err := poolStoreFor(cfg)
 	if err != nil {
 		return nil, err
 	}
-	// The URL names the bucket, so it wins over POOL_S3_BUCKET: one env var
-	// locates the whole object, and the two cannot then disagree.
-	store := cfg.Pool
-	store.Bucket = bucket
-	s, err := poolartifact.NewStore(&store)
+	s, err := poolartifact.NewStore(store)
 	if err != nil {
 		return nil, err
 	}
 	return s.Load(ctx, key, cfg.SiteID)
+}
+
+// poolStoreFor resolves the object-store config the URL implies. One function
+// so validation and loading cannot disagree: validating the raw config first
+// demanded POOL_S3_BUCKET even when the URL already named the bucket, which
+// made the documented k8s setup fail to start.
+func poolStoreFor(cfg *config) (*poolartifact.StoreConfig, string, error) {
+	bucket, key, err := poolartifact.ParsePoolURL(cfg.PoolURL)
+	if err != nil {
+		return nil, "", err
+	}
+	// The URL wins over POOL_S3_BUCKET: one env var locates the whole object,
+	// and the two cannot then disagree.
+	store := cfg.Pool
+	store.Bucket = bucket
+	return &store, key, nil
 }
 
 // validatePoolSource enforces exactly one pool source. Preferring one over
@@ -245,15 +257,19 @@ func validatePoolSource(cfg *config) error {
 	// A partly-set store is an error even on the file path: it means someone
 	// meant to use the object store and mistyped, and staying silent would
 	// hand them a run against the wrong pool.
-	if cfg.PoolURL != "" || cfg.Pool.Configured() {
-		if err := cfg.Pool.Validate(); err != nil {
-			return err
-		}
-	}
 	if cfg.PoolURL != "" {
-		if _, _, err := poolartifact.ParsePoolURL(cfg.PoolURL); err != nil {
+		// Resolve first, validate second: the URL supplies the bucket.
+		store, _, err := poolStoreFor(cfg)
+		if err != nil {
 			return err
 		}
+		return store.Validate()
+	}
+	// A partly-set store is an error even on the file path: it means someone
+	// meant to use the object store and mistyped, and staying silent would
+	// hand them a run against the wrong pool.
+	if cfg.Pool.Configured() {
+		return cfg.Pool.Validate()
 	}
 	return nil
 }

--- a/tools/clientsim/main.go
+++ b/tools/clientsim/main.go
@@ -220,7 +220,7 @@ func loadPool(ctx context.Context, cfg *config) (*poolartifact.Artifact, error) 
 	if err != nil {
 		return nil, err
 	}
-	if plaintextObjectStore(store.Endpoint, store.UseSSL) {
+	if store.PlaintextEndpoint() {
 		// Not fatal: the documented docker-compose loop runs MinIO over HTTP,
 		// and this tool has to stay runnable there. But the artifact is a list
 		// of real employee accounts and the request carries the store's access
@@ -234,26 +234,6 @@ func loadPool(ctx context.Context, cfg *config) (*poolartifact.Artifact, error) 
 		return nil, err
 	}
 	return s.Load(ctx, key, cfg.SiteID)
-}
-
-// plaintextObjectStore reports a pool fetch that crosses a network unencrypted.
-// A loopback endpoint is the local development loop, not an exposure, so it is
-// excluded — warning there would train the operator to ignore the warning.
-func plaintextObjectStore(endpoint string, useSSL bool) bool {
-	if useSSL {
-		return false
-	}
-	host := endpoint
-	if h, _, err := net.SplitHostPort(endpoint); err == nil {
-		host = h
-	}
-	if host == "localhost" || host == "::1" {
-		return false
-	}
-	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
-		return false
-	}
-	return true
 }
 
 // poolStoreFor resolves the object-store config the URL implies. One function

--- a/tools/clientsim/main.go
+++ b/tools/clientsim/main.go
@@ -220,11 +220,40 @@ func loadPool(ctx context.Context, cfg *config) (*poolartifact.Artifact, error) 
 	if err != nil {
 		return nil, err
 	}
+	if plaintextObjectStore(store.Endpoint, store.UseSSL) {
+		// Not fatal: the documented docker-compose loop runs MinIO over HTTP,
+		// and this tool has to stay runnable there. But the artifact is a list
+		// of real employee accounts and the request carries the store's access
+		// key ID, so the operator should see the trade-off they configured
+		// rather than have it stay silent.
+		slog.Warn("fetching the pool over plaintext HTTP — the account list and the store access key ID cross the network in the clear; set POOL_S3_USE_SSL=true outside local development",
+			"endpoint", store.Endpoint)
+	}
 	s, err := poolartifact.NewStore(store)
 	if err != nil {
 		return nil, err
 	}
 	return s.Load(ctx, key, cfg.SiteID)
+}
+
+// plaintextObjectStore reports a pool fetch that crosses a network unencrypted.
+// A loopback endpoint is the local development loop, not an exposure, so it is
+// excluded — warning there would train the operator to ignore the warning.
+func plaintextObjectStore(endpoint string, useSSL bool) bool {
+	if useSSL {
+		return false
+	}
+	host := endpoint
+	if h, _, err := net.SplitHostPort(endpoint); err == nil {
+		host = h
+	}
+	if host == "localhost" || host == "::1" {
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return false
+	}
+	return true
 }
 
 // poolStoreFor resolves the object-store config the URL implies. One function

--- a/tools/loadgen/main.go
+++ b/tools/loadgen/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/mongoutil"
 	"github.com/hmchangw/chat/pkg/natsutil"
+	"github.com/hmchangw/chat/pkg/poolartifact"
 	"github.com/hmchangw/chat/pkg/roomkeystore"
 	"github.com/hmchangw/chat/pkg/stream"
 	"github.com/hmchangw/chat/pkg/subject"
@@ -87,6 +88,12 @@ type config struct {
 	// when it is empty.
 	AuthURL string `env:"AUTH_URL" envDefault:""`
 
+	// Pool is the object store the clientsim pool artifact is published to.
+	// Declared in poolartifact because clientsim reads the same knobs: two
+	// copies of the tags is how the two ends end up on different buckets.
+	// Unset is valid — only pool-export requires it.
+	Pool poolartifact.StoreConfig
+
 	Bottleneck bottleneckConfig `envPrefix:"BOTTLENECK_"`
 	Soak       soakConfig       `envPrefix:"SOAK_"`
 }
@@ -94,7 +101,7 @@ type config struct {
 func main() {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: loadgen <seed|run|teardown|soak|members-sustained|members-capacity|history-sustained|max-rps|daily|max-room-size|presence-sustained|presence-storm|presence-capacity> [flags]")
+		fmt.Fprintln(os.Stderr, "usage: loadgen <seed|pool-export|run|teardown|soak|members-sustained|members-capacity|history-sustained|max-rps|daily|max-room-size|presence-sustained|presence-storm|presence-capacity> [flags]")
 		os.Exit(2)
 	}
 	cfg, err := env.ParseAs[config]()
@@ -127,6 +134,8 @@ func dispatch(ctx context.Context, cfg *config) int {
 		return runTeardown(ctx, cfg, os.Args[2:])
 	case "soak":
 		return runSoak(ctx, cfg, os.Args[2:])
+	case "pool-export":
+		return runPoolExport(ctx, cfg, os.Args[2:])
 	case "members-sustained":
 		return runMembersSustained(ctx, cfg, os.Args[2:])
 	case "members-capacity":

--- a/tools/loadgen/poolexport.go
+++ b/tools/loadgen/poolexport.go
@@ -131,10 +131,8 @@ func poolDigest(accounts []string) string {
 	return hex.EncodeToString(h.Sum(nil)[:8])
 }
 
-// exportPool reads the population, publishes the artifact the fleet consumes
-// and the manifest that explains it.
-// dropUnusable removes accounts a clientsim run cannot connect as. A bot that owns a room
-// holds a genuine channel subscription (bot-room-service/handler.go:213-216
+// dropUnusable removes accounts a clientsim run cannot connect as. A bot that
+// owns a room holds a genuine channel subscription (bot-room-service/handler.go:213-216
 // writes IsBot:true with RoomTypeChannel, and its $setOnInsert never sets
 // `open`, so the open filter passes it too), so every condition the query
 // matches on is legitimately true of it.
@@ -161,6 +159,8 @@ func dropUnusable(accounts []string) []string {
 	return kept
 }
 
+// exportPool reads the population, publishes the artifact the fleet consumes
+// and the manifest that explains it.
 func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, opts poolExportOptions) (poolExportResult, error) {
 	accounts, err := src.channelSubscriberAccounts(ctx, opts.SiteID, opts.Limit)
 	if err != nil {
@@ -217,7 +217,15 @@ func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, o
 		Query: poolExportQuery, Source: "mongodb",
 		ExportedAt: time.Now().UTC(),
 	}); err != nil {
-		return poolExportResult{}, fmt.Errorf("publish pool manifest: %w", err)
+		// The artifact is already claimed and immutable at this point. Re-running
+		// repairs this ONLY while the population is unchanged — the retry loses
+		// the claim, matches the digest, and falls through to write the manifest.
+		// If the site churns first, the digest no longer matches and the run ID
+		// is spent: the artifact is readable but has no record of how it was
+		// selected. Say so, rather than leave the operator to discover it.
+		return poolExportResult{}, fmt.Errorf(
+			"publish pool manifest for run %q (the artifact is already claimed — re-run promptly to repair it, or use a new --run-id if the population may have changed since): %w",
+			opts.RunID, err)
 	}
 
 	if opts.OutFile != "" {

--- a/tools/loadgen/poolexport.go
+++ b/tools/loadgen/poolexport.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+
+	"github.com/hmchangw/chat/pkg/poolartifact"
+)
+
+// poolAccountSource yields the accounts a clientsim run should connect as.
+type poolAccountSource interface {
+	channelSubscriberAccounts(ctx context.Context, siteID string) ([]string, error)
+}
+
+// poolPublisher is the object-store slice the export needs.
+type poolPublisher interface {
+	Key(siteID, runID, name string) string
+	Put(ctx context.Context, key string, a *poolartifact.Artifact) error
+	PutJSON(ctx context.Context, key string, v any) error
+}
+
+const (
+	poolArtifactName = "pool.json.gz"
+	poolManifestName = "pool-manifest.json"
+)
+
+// poolExportQuery is recorded in the manifest verbatim, so a reader can tell
+// which population an export described without reading this source.
+//
+// Derived from user-service's own subscription.list match (mongorepo
+// listMatch: roomType in [dm, channel] with open != false), narrowed to
+// channel: clientsim opens room lanes only for channels, because DM traffic
+// arrives on the user lane instead. An account with no channel subscription
+// would connect cleanly and then measure nothing.
+const poolExportQuery = `subscriptions: {siteId, roomType: "channel", open: {$ne: false}} -> distinct u.account, sorted`
+
+type poolExportOptions struct {
+	RunID  string
+	SiteID string
+	// Limit truncates the sorted list. Zero means the whole population.
+	Limit int
+	// OutFile optionally also writes the artifact locally, for a run driven
+	// from a laptop rather than a Job.
+	OutFile string
+}
+
+type poolExportResult struct {
+	Accounts     int
+	ConfigDigest string
+	ArtifactKey  string
+	ManifestKey  string
+}
+
+// poolManifest explains an export. The artifact says WHO connected; this says
+// how that set was chosen, which is what makes the run reproducible rather
+// than merely identifiable.
+type poolManifest struct {
+	RunID        string    `json:"runId"`
+	SiteID       string    `json:"siteId"`
+	ConfigDigest string    `json:"configDigest"`
+	Accounts     int       `json:"accounts"`
+	Limit        int       `json:"limit,omitempty"`
+	Query        string    `json:"query"`
+	Source       string    `json:"source"`
+	ExportedAt   time.Time `json:"exportedAt"`
+}
+
+// poolDigest fingerprints the POPULATION, not the seed parameters: a Mongo
+// export has no preset or RNG seed to hash. Two exports of the same accounts
+// agree, and one changed account does not — so a reader can tell whether two
+// runs measured the same fleet.
+func poolDigest(accounts []string) string {
+	h := sha256.New()
+	for _, a := range accounts {
+		_, _ = h.Write([]byte(a))
+		_, _ = h.Write([]byte{0}) // separator: "ab","c" must not hash as "a","bc"
+	}
+	return hex.EncodeToString(h.Sum(nil)[:8])
+}
+
+// exportPool reads the population, publishes the artifact the fleet consumes
+// and the manifest that explains it.
+func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, opts poolExportOptions) (poolExportResult, error) {
+	accounts, err := src.channelSubscriberAccounts(ctx, opts.SiteID)
+	if err != nil {
+		return poolExportResult{}, fmt.Errorf("list channel subscribers for %s: %w", opts.SiteID, err)
+	}
+	// The failure this export exists to prevent: a fleet that starts against
+	// nobody reports a healthy zero. Fail here, in the tool that can say why.
+	if len(accounts) == 0 {
+		return poolExportResult{}, fmt.Errorf("site %q has no accounts with a channel subscription", opts.SiteID)
+	}
+	if opts.Limit > 0 && len(accounts) > opts.Limit {
+		// From the head of a sorted list, so a repeated export with the same
+		// limit picks the same accounts rather than an arbitrary sample.
+		accounts = accounts[:opts.Limit]
+	}
+
+	digest := poolDigest(accounts)
+	art := &poolartifact.Artifact{
+		RunID: opts.RunID, SiteID: opts.SiteID, ConfigDigest: digest, Accounts: accounts,
+	}
+	artifactKey := pub.Key(opts.SiteID, opts.RunID, poolArtifactName)
+	if err := pub.Put(ctx, artifactKey, art); err != nil {
+		return poolExportResult{}, fmt.Errorf("publish pool artifact: %w", err)
+	}
+
+	manifestKey := pub.Key(opts.SiteID, opts.RunID, poolManifestName)
+	if err := pub.PutJSON(ctx, manifestKey, poolManifest{
+		RunID: opts.RunID, SiteID: opts.SiteID, ConfigDigest: digest,
+		Accounts: len(accounts), Limit: opts.Limit,
+		Query: poolExportQuery, Source: "mongodb",
+		ExportedAt: time.Now().UTC(),
+	}); err != nil {
+		return poolExportResult{}, fmt.Errorf("publish pool manifest: %w", err)
+	}
+
+	if opts.OutFile != "" {
+		if err := poolartifact.Write(opts.OutFile, art); err != nil {
+			return poolExportResult{}, fmt.Errorf("write local pool copy: %w", err)
+		}
+	}
+	return poolExportResult{
+		Accounts: len(accounts), ConfigDigest: digest,
+		ArtifactKey: artifactKey, ManifestKey: manifestKey,
+	}, nil
+}
+
+// mongoPoolSource reads the population from the operational subscriptions
+// collection.
+type mongoPoolSource struct{ db *mongo.Database }
+
+func (m mongoPoolSource) channelSubscriberAccounts(ctx context.Context, siteID string) ([]string, error) {
+	// $group, not $lookup — no join, and it projects to the single field the
+	// export needs. $sort after the group makes the order stable, which is
+	// what shardSlice depends on: every clientsim pod slices the same array,
+	// so an unstable order would overlap or skip accounts across pods.
+	pipeline := mongo.Pipeline{
+		{{Key: "$match", Value: bson.M{
+			"siteId":   siteID,
+			"roomType": "channel",
+			"open":     bson.M{"$ne": false},
+		}}},
+		{{Key: "$group", Value: bson.M{"_id": "$u.account"}}},
+		{{Key: "$sort", Value: bson.M{"_id": 1}}},
+	}
+	cur, err := m.db.Collection("subscriptions").Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate channel subscribers: %w", err)
+	}
+	defer cur.Close(ctx) //nolint:errcheck // read-only cursor
+	var rows []struct {
+		Account string `bson:"_id"`
+	}
+	if err := cur.All(ctx, &rows); err != nil {
+		return nil, fmt.Errorf("read channel subscribers: %w", err)
+	}
+	accounts := make([]string, 0, len(rows))
+	for _, r := range rows {
+		// An empty account builds subjects like chat.user..event.room, which
+		// subscribe cleanly and receive nothing. poolartifact.Write refuses
+		// them too; dropping here keeps the count in the manifest honest.
+		if r.Account == "" {
+			continue
+		}
+		accounts = append(accounts, r.Account)
+	}
+	return accounts, nil
+}
+
+func runPoolExport(ctx context.Context, cfg *config, args []string) int {
+	fs := flag.NewFlagSet("pool-export", flag.ExitOnError)
+	runID := fs.String("run-id", "", "run identifier the artifact is filed under (required)")
+	limit := fs.Int("limit", 0, "cap the exported accounts (0 = the whole population)")
+	outFile := fs.String("out", "", "also write the artifact to this local path")
+	_ = fs.Parse(args)
+	if *runID == "" {
+		fmt.Fprintln(os.Stderr, "--run-id required")
+		return 2
+	}
+	if *limit < 0 {
+		fmt.Fprintf(os.Stderr, "--limit must be >= 0, got %d\n", *limit)
+		return 2
+	}
+	if err := cfg.Pool.Validate(); err != nil {
+		slog.Error("pool export configuration", "error", err)
+		return 2
+	}
+	store, err := poolartifact.NewStore(&cfg.Pool)
+	if err != nil {
+		slog.Error("connect pool object store", "error", err)
+		return 1
+	}
+	db, _, cleanup, err := connectStores(ctx, cfg)
+	if err != nil {
+		return 1
+	}
+	defer cleanup()
+
+	res, err := exportPool(ctx, mongoPoolSource{db: db}, store, poolExportOptions{
+		RunID: *runID, SiteID: cfg.SiteID, Limit: *limit, OutFile: *outFile,
+	})
+	if err != nil {
+		slog.Error("pool export", "error", err)
+		return 1
+	}
+	slog.Info("pool exported",
+		"runId", *runID, "siteId", cfg.SiteID, "accounts", res.Accounts,
+		"configDigest", res.ConfigDigest,
+		"artifactKey", res.ArtifactKey, "manifestKey", res.ManifestKey)
+	return 0
+}

--- a/tools/loadgen/poolexport.go
+++ b/tools/loadgen/poolexport.go
@@ -55,7 +55,7 @@ const (
 // channel: clientsim opens room lanes only for channels, because DM traffic
 // arrives on the user lane instead. An account with no channel subscription
 // would connect cleanly and then measure nothing.
-const poolExportQuery = `subscriptions: {siteId, roomType: "channel", open: {$ne: false}, origin: {$ne: "teams"}} -> distinct u.account, sorted`
+const poolExportQuery = `subscriptions: {siteId, roomType: "channel", open: {$ne: false}, origin: {$ne: "teams"}, u.isBot: {$ne: true}} -> distinct u.account, sorted, then ".bot" accounts dropped`
 
 type poolExportOptions struct {
 	RunID  string
@@ -103,11 +103,38 @@ func poolDigest(accounts []string) string {
 
 // exportPool reads the population, publishes the artifact the fleet consumes
 // and the manifest that explains it.
+// dropBots removes bot accounts from a population. A bot that owns a room
+// holds a genuine channel subscription (bot-room-service/handler.go:213-216
+// writes IsBot:true with RoomTypeChannel, and its $setOnInsert never sets
+// `open`, so the open filter passes it too), so every condition the query
+// matches on is legitimately true of it.
+//
+// clientsim cannot connect as one either way: bots authenticate over HTTP
+// through pkg/botauth rather than the user JWT path, and a dotted ".bot"
+// account spans subject tokens — subject.UserSubscriptionList panics on it
+// before a request is made.
+//
+// Belt to the query's braces, and not redundant with it: the query keys on the
+// stored u.isBot flag, this keys on the account shape, and a row written
+// without the flag is caught only here. Cheap — the population is already in
+// memory and sorted.
+func dropBots(accounts []string) []string {
+	kept := accounts[:0:0]
+	for _, a := range accounts {
+		if model.IsBot(a) {
+			continue
+		}
+		kept = append(kept, a)
+	}
+	return kept
+}
+
 func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, opts poolExportOptions) (poolExportResult, error) {
 	accounts, err := src.channelSubscriberAccounts(ctx, opts.SiteID)
 	if err != nil {
 		return poolExportResult{}, fmt.Errorf("list channel subscribers for %s: %w", opts.SiteID, err)
 	}
+	accounts = dropBots(accounts)
 	// The failure this export exists to prevent: a fleet that starts against
 	// nobody reports a healthy zero. Fail here, in the tool that can say why.
 	if len(accounts) == 0 {
@@ -192,6 +219,11 @@ func (m mongoPoolSource) channelSubscriberAccounts(ctx context.Context, siteID s
 			// connections and over-selecting costs silent measurement loss,
 			// so it fails safe in the same direction as roomGlobal.
 			"origin": bson.M{"$ne": model.OriginTeams},
+			// Bots hold channel subscriptions like anyone else; see dropBots
+			// for why they cannot be in a clientsim pool. Dropped here so the
+			// bulk never leaves the server, and again in Go on the account
+			// shape, for a row whose flag was never stored.
+			"u.isBot": bson.M{"$ne": true},
 		}}},
 		{{Key: "$group", Value: bson.M{"_id": "$u.account"}}},
 		{{Key: "$sort", Value: bson.M{"_id": 1}}},

--- a/tools/loadgen/poolexport.go
+++ b/tools/loadgen/poolexport.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -13,6 +14,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 
+	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/poolartifact"
 )
 
@@ -26,6 +28,18 @@ type poolPublisher interface {
 	Key(siteID, runID, name string) string
 	Put(ctx context.Context, key string, a *poolartifact.Artifact) error
 	PutJSON(ctx context.Context, key string, v any) error
+	Load(ctx context.Context, key, wantSiteID string) (*poolartifact.Artifact, error)
+}
+
+// validatePoolRunID keeps the run ID a single safe path segment. It becomes
+// one, and path.Join normalises "..", so an unvalidated value could write the
+// artifact into another site's scope. Same pattern the soak ledger uses.
+func validatePoolRunID(runID string) error {
+	if !failureRunIDPattern.MatchString(runID) || runID == "." || runID == ".." {
+		return fmt.Errorf("--run-id must be a single path segment matching %s, got %q",
+			failureRunIDPattern.String(), runID)
+	}
+	return nil
 }
 
 const (
@@ -41,7 +55,7 @@ const (
 // channel: clientsim opens room lanes only for channels, because DM traffic
 // arrives on the user lane instead. An account with no channel subscription
 // would connect cleanly and then measure nothing.
-const poolExportQuery = `subscriptions: {siteId, roomType: "channel", open: {$ne: false}} -> distinct u.account, sorted`
+const poolExportQuery = `subscriptions: {siteId, roomType: "channel", open: {$ne: false}, origin: {$ne: "teams"}} -> distinct u.account, sorted`
 
 type poolExportOptions struct {
 	RunID  string
@@ -110,6 +124,23 @@ func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, o
 		RunID: opts.RunID, SiteID: opts.SiteID, ConfigDigest: digest, Accounts: accounts,
 	}
 	artifactKey := pub.Key(opts.SiteID, opts.RunID, poolArtifactName)
+
+	// A run ID names one immutable population. Overwriting it with a
+	// different one breaks the invariant the single object exists to hold:
+	// pods that started before and pods that restart after would slice
+	// different arrays, so shardSlice hands out overlapping or disjoint
+	// ranges — accounts connected twice or not at all, every pod still ready.
+	// Re-exporting the SAME population stays a safe retry.
+	switch existing, err := pub.Load(ctx, artifactKey, opts.SiteID); {
+	case errors.Is(err, poolartifact.ErrObjectNotFound):
+	case err != nil:
+		return poolExportResult{}, fmt.Errorf("check the published pool for run %q: %w", opts.RunID, err)
+	case existing.ConfigDigest != digest:
+		return poolExportResult{}, fmt.Errorf(
+			"run %q already holds a pool of %d accounts (digest %s); this export is a different population of %d (digest %s) — use a new --run-id rather than overwrite a pool a fleet may already be reading",
+			opts.RunID, len(existing.Accounts), existing.ConfigDigest, len(accounts), digest)
+	}
+
 	if err := pub.Put(ctx, artifactKey, art); err != nil {
 		return poolExportResult{}, fmt.Errorf("publish pool artifact: %w", err)
 	}
@@ -149,6 +180,18 @@ func (m mongoPoolSource) channelSubscriberAccounts(ctx context.Context, siteID s
 			"siteId":   siteID,
 			"roomType": "channel",
 			"open":     bson.M{"$ne": false},
+			// user-service hides Teams-origin rooms from subscription.list
+			// unless SHOW_TEAMS_ROOM (default false) or the account is
+			// allowlisted. Without this an account whose only channel
+			// subscriptions are Teams rooms is exported, walks to an EMPTY
+			// plan, and reports ready while subscribing to nothing — exactly
+			// the failure the readiness design exists to prevent.
+			//
+			// Applied unconditionally rather than mirroring the per-account
+			// allowlist: for a load pool, under-selecting costs a few
+			// connections and over-selecting costs silent measurement loss,
+			// so it fails safe in the same direction as roomGlobal.
+			"origin": bson.M{"$ne": model.OriginTeams},
 		}}},
 		{{Key: "$group", Value: bson.M{"_id": "$u.account"}}},
 		{{Key: "$sort", Value: bson.M{"_id": 1}}},
@@ -185,6 +228,10 @@ func runPoolExport(ctx context.Context, cfg *config, args []string) int {
 	_ = fs.Parse(args)
 	if *runID == "" {
 		fmt.Fprintln(os.Stderr, "--run-id required")
+		return 2
+	}
+	if err := validatePoolRunID(*runID); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		return 2
 	}
 	if *limit < 0 {

--- a/tools/loadgen/poolexport.go
+++ b/tools/loadgen/poolexport.go
@@ -26,9 +26,13 @@ type poolAccountSource interface {
 	channelSubscriberAccounts(ctx context.Context, siteID string, limit int) ([]string, error)
 }
 
-// cursorLimit converts --limit into the server-side bound. An unbounded export
-// still gets one: maxAccounts+1, so a population over the artifact cap is
-// still DETECTED (the extra row) rather than silently truncated to it.
+// cursorLimit converts --limit into the server-side bound. The pipeline
+// filters bots before this bound applies, so the bound counts only accounts
+// that will survive to the artifact — no headroom needed.
+//
+// An unbounded export still gets a bound: maxAccounts+1, so a population over
+// the artifact cap is still DETECTED (by the extra row) rather than silently
+// truncated to it.
 func cursorLimit(limit int) int {
 	if limit > 0 && limit <= poolartifact.MaxAccounts {
 		return limit
@@ -258,6 +262,14 @@ func (m mongoPoolSource) channelSubscriberAccounts(ctx context.Context, siteID s
 		// $max over the group returns true if ANY row carries the flag.
 		{{Key: "$group", Value: bson.M{"_id": "$u.account", "isBot": bson.M{"$max": "$u.isBot"}}}},
 		{{Key: "$match", Value: bson.M{"isBot": bson.M{"$ne": true}}}},
+		// The ".bot" suffix is excluded HERE too, not only in dropBots. The
+		// $limit below bounds whatever reaches it, so a legacy account the
+		// flag never marked would otherwise be counted against --limit and
+		// then dropped in Go — the caller asks for N, the site holds more than
+		// N eligible accounts, and the run still gets fewer. Filtering before
+		// the bound makes the bound mean what it says. dropBots stays as the
+		// belt for any other source.
+		{{Key: "$match", Value: bson.M{"_id": bson.M{"$not": bson.Regex{Pattern: `\.bot$`}}}}},
 		{{Key: "$sort", Value: bson.M{"_id": 1}}},
 		// Bound the cursor server-side. cur.All materialises whatever comes
 		// back, so applying --limit only afterwards holds the WHOLE site

--- a/tools/loadgen/poolexport.go
+++ b/tools/loadgen/poolexport.go
@@ -13,6 +13,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/poolartifact"
@@ -26,18 +27,28 @@ type poolAccountSource interface {
 // poolPublisher is the object-store slice the export needs.
 type poolPublisher interface {
 	Key(siteID, runID, name string) string
-	Put(ctx context.Context, key string, a *poolartifact.Artifact) error
+	PutIfAbsent(ctx context.Context, key string, a *poolartifact.Artifact) error
 	PutJSON(ctx context.Context, key string, v any) error
 	Load(ctx context.Context, key, wantSiteID string) (*poolartifact.Artifact, error)
 }
 
-// validatePoolRunID keeps the run ID a single safe path segment. It becomes
-// one, and path.Join normalises "..", so an unvalidated value could write the
-// artifact into another site's scope. Same pattern the soak ledger uses.
+// validatePoolRunID keeps the run ID a single safe path segment. The rule
+// itself lives in pkg/poolartifact beside Key, which composes the path, so the
+// composer and its callers cannot drift on what is safe.
 func validatePoolRunID(runID string) error {
-	if !failureRunIDPattern.MatchString(runID) || runID == "." || runID == ".." {
-		return fmt.Errorf("--run-id must be a single path segment matching %s, got %q",
-			failureRunIDPattern.String(), runID)
+	if err := poolartifact.ValidateKeySegment(runID); err != nil {
+		return fmt.Errorf("--run-id must be a single safe path segment: %w", err)
+	}
+	return nil
+}
+
+// validatePoolSiteID guards the segment NEXT TO the run ID in the same
+// path.Join. Guarding one and not the other is not a guard at all: SITE_ID
+// escapes the prefix exactly the way an unchecked --run-id would, and lands
+// the artifact in another site's scope where a fleet may already be reading.
+func validatePoolSiteID(siteID string) error {
+	if err := poolartifact.ValidateKeySegment(siteID); err != nil {
+		return fmt.Errorf("SITE_ID must be a single safe path segment: %w", err)
 	}
 	return nil
 }
@@ -152,23 +163,26 @@ func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, o
 	}
 	artifactKey := pub.Key(opts.SiteID, opts.RunID, poolArtifactName)
 
-	// A run ID names one immutable population. Overwriting it with a
-	// different one breaks the invariant the single object exists to hold:
-	// pods that started before and pods that restart after would slice
-	// different arrays, so shardSlice hands out overlapping or disjoint
-	// ranges — accounts connected twice or not at all, every pod still ready.
-	// Re-exporting the SAME population stays a safe retry.
-	switch existing, err := pub.Load(ctx, artifactKey, opts.SiteID); {
-	case errors.Is(err, poolartifact.ErrObjectNotFound):
-	case err != nil:
-		return poolExportResult{}, fmt.Errorf("check the published pool for run %q: %w", opts.RunID, err)
-	case existing.ConfigDigest != digest:
-		return poolExportResult{}, fmt.Errorf(
-			"run %q already holds a pool of %d accounts (digest %s); this export is a different population of %d (digest %s) — use a new --run-id rather than overwrite a pool a fleet may already be reading",
-			opts.RunID, len(existing.Accounts), existing.ConfigDigest, len(accounts), digest)
-	}
-
-	if err := pub.Put(ctx, artifactKey, art); err != nil {
+	// A run ID names one immutable population. The claim is the write, not a
+	// preceding Load: two exporters can both read the run as unpublished and
+	// both go on to publish, and then pods that started before and pods that
+	// restart after slice different arrays — accounts connected twice or not
+	// at all, every pod still reporting ready. Re-exporting the SAME
+	// population stays a safe retry, reconciled below against what is
+	// actually stored rather than against what we read a moment ago.
+	switch err := pub.PutIfAbsent(ctx, artifactKey, art); {
+	case err == nil:
+	case errors.Is(err, poolartifact.ErrObjectExists):
+		existing, loadErr := pub.Load(ctx, artifactKey, opts.SiteID)
+		if loadErr != nil {
+			return poolExportResult{}, fmt.Errorf("read the pool that already holds run %q: %w", opts.RunID, loadErr)
+		}
+		if existing.ConfigDigest != digest {
+			return poolExportResult{}, fmt.Errorf(
+				"run %q already holds a pool of %d accounts (digest %s); this export is a different population of %d (digest %s) — use a new --run-id rather than overwrite a pool a fleet may already be reading",
+				opts.RunID, len(existing.Accounts), existing.ConfigDigest, len(accounts), digest)
+		}
+	default:
 		return poolExportResult{}, fmt.Errorf("publish pool artifact: %w", err)
 	}
 
@@ -228,7 +242,11 @@ func (m mongoPoolSource) channelSubscriberAccounts(ctx context.Context, siteID s
 		{{Key: "$group", Value: bson.M{"_id": "$u.account"}}},
 		{{Key: "$sort", Value: bson.M{"_id": 1}}},
 	}
-	cur, err := m.db.Collection("subscriptions").Aggregate(ctx, pipeline)
+	// $group and $sort are blocking stages with a per-stage memory limit; a
+	// site large enough to be worth load-testing is exactly the one that
+	// exceeds it, so let the server spill rather than fail the export.
+	cur, err := m.db.Collection("subscriptions").Aggregate(ctx, pipeline,
+		options.Aggregate().SetAllowDiskUse(true))
 	if err != nil {
 		return nil, fmt.Errorf("aggregate channel subscribers: %w", err)
 	}
@@ -263,6 +281,10 @@ func runPoolExport(ctx context.Context, cfg *config, args []string) int {
 		return 2
 	}
 	if err := validatePoolRunID(*runID); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	if err := validatePoolSiteID(cfg.SiteID); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 2
 	}

--- a/tools/loadgen/poolexport.go
+++ b/tools/loadgen/poolexport.go
@@ -20,8 +20,20 @@ import (
 )
 
 // poolAccountSource yields the accounts a clientsim run should connect as.
+// limit is the caller's --limit (0 = unbounded); a source is free to push it
+// down rather than materialise the whole population first.
 type poolAccountSource interface {
-	channelSubscriberAccounts(ctx context.Context, siteID string) ([]string, error)
+	channelSubscriberAccounts(ctx context.Context, siteID string, limit int) ([]string, error)
+}
+
+// cursorLimit converts --limit into the server-side bound. An unbounded export
+// still gets one: maxAccounts+1, so a population over the artifact cap is
+// still DETECTED (the extra row) rather than silently truncated to it.
+func cursorLimit(limit int) int {
+	if limit > 0 && limit <= poolartifact.MaxAccounts {
+		return limit
+	}
+	return poolartifact.MaxAccounts + 1
 }
 
 // poolPublisher is the object-store slice the export needs.
@@ -141,7 +153,7 @@ func dropBots(accounts []string) []string {
 }
 
 func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, opts poolExportOptions) (poolExportResult, error) {
-	accounts, err := src.channelSubscriberAccounts(ctx, opts.SiteID)
+	accounts, err := src.channelSubscriberAccounts(ctx, opts.SiteID, opts.Limit)
 	if err != nil {
 		return poolExportResult{}, fmt.Errorf("list channel subscribers for %s: %w", opts.SiteID, err)
 	}
@@ -177,7 +189,10 @@ func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, o
 		if loadErr != nil {
 			return poolExportResult{}, fmt.Errorf("read the pool that already holds run %q: %w", opts.RunID, loadErr)
 		}
-		if existing.ConfigDigest != digest {
+		// Recompute rather than trust: ConfigDigest is what the stored object
+		// says about ITSELF, so an artifact whose accounts no longer match it
+		// would be waved through as "the same population".
+		if poolDigest(existing.Accounts) != digest || existing.ConfigDigest != digest {
 			return poolExportResult{}, fmt.Errorf(
 				"run %q already holds a pool of %d accounts (digest %s); this export is a different population of %d (digest %s) — use a new --run-id rather than overwrite a pool a fleet may already be reading",
 				opts.RunID, len(existing.Accounts), existing.ConfigDigest, len(accounts), digest)
@@ -211,7 +226,7 @@ func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, o
 // collection.
 type mongoPoolSource struct{ db *mongo.Database }
 
-func (m mongoPoolSource) channelSubscriberAccounts(ctx context.Context, siteID string) ([]string, error) {
+func (m mongoPoolSource) channelSubscriberAccounts(ctx context.Context, siteID string, limit int) ([]string, error) {
 	// $group, not $lookup — no join, and it projects to the single field the
 	// export needs. $sort after the group makes the order stable, which is
 	// what shardSlice depends on: every clientsim pod slices the same array,
@@ -233,14 +248,23 @@ func (m mongoPoolSource) channelSubscriberAccounts(ctx context.Context, siteID s
 			// connections and over-selecting costs silent measurement loss,
 			// so it fails safe in the same direction as roomGlobal.
 			"origin": bson.M{"$ne": model.OriginTeams},
-			// Bots hold channel subscriptions like anyone else; see dropBots
-			// for why they cannot be in a clientsim pool. Dropped here so the
-			// bulk never leaves the server, and again in Go on the account
-			// shape, for a row whose flag was never stored.
-			"u.isBot": bson.M{"$ne": true},
 		}}},
-		{{Key: "$group", Value: bson.M{"_id": "$u.account"}}},
+		// Bots hold channel subscriptions like anyone else; see dropBots for
+		// why they cannot be in a clientsim pool. The exclusion runs AFTER the
+		// group, on the account, not before it on the row: an account with one
+		// flagged row and one row whose flag was never written would otherwise
+		// have the flagged row filtered out and survive on the other — the
+		// exact hole the two layers exist to close, reopened by filter order.
+		// $max over the group returns true if ANY row carries the flag.
+		{{Key: "$group", Value: bson.M{"_id": "$u.account", "isBot": bson.M{"$max": "$u.isBot"}}}},
+		{{Key: "$match", Value: bson.M{"isBot": bson.M{"$ne": true}}}},
 		{{Key: "$sort", Value: bson.M{"_id": 1}}},
+		// Bound the cursor server-side. cur.All materialises whatever comes
+		// back, so applying --limit only afterwards holds the WHOLE site
+		// population in the Job's heap first — and an unbounded export has no
+		// ceiling at all until the artifact's own account cap rejects it, long
+		// after the memory was spent. maxAccounts+1 keeps that cap detectable.
+		{{Key: "$limit", Value: int64(cursorLimit(limit))}},
 	}
 	// $group and $sort are blocking stages with a per-stage memory limit; a
 	// site large enough to be worth load-testing is exactly the one that
@@ -295,6 +319,12 @@ func runPoolExport(ctx context.Context, cfg *config, args []string) int {
 	if err := cfg.Pool.Validate(); err != nil {
 		slog.Error("pool export configuration", "error", err)
 		return 2
+	}
+	if cfg.Pool.PlaintextEndpoint() {
+		// Same exposure as clientsim's fetch, in the other direction: this
+		// UPLOADS the account list, and the request carries the access key ID.
+		slog.Warn("publishing the pool over plaintext HTTP — the account list and the store access key ID cross the network in the clear; set POOL_S3_USE_SSL=true outside local development",
+			"endpoint", cfg.Pool.Endpoint)
 	}
 	store, err := poolartifact.NewStore(&cfg.Pool)
 	if err != nil {

--- a/tools/loadgen/poolexport.go
+++ b/tools/loadgen/poolexport.go
@@ -82,7 +82,10 @@ const (
 // channel: clientsim opens room lanes only for channels, because DM traffic
 // arrives on the user lane instead. An account with no channel subscription
 // would connect cleanly and then measure nothing.
-const poolExportQuery = `subscriptions: {siteId, roomType: "channel", open: {$ne: false}, origin: {$ne: "teams"}, u.isBot: {$ne: true}} -> distinct u.account, sorted, then ".bot" accounts dropped`
+const poolExportQuery = `subscriptions: match {siteId, roomType: "channel", open: {$ne: false}, origin: {$ne: "teams"}} ` +
+	`-> group by u.account with isBot = $max(u.isBot) ` +
+	`-> match {isBot: {$ne: true}, _id: not empty and not /\.bot$/} ` +
+	`-> sort _id asc -> limit`
 
 type poolExportOptions struct {
 	RunID  string
@@ -130,7 +133,7 @@ func poolDigest(accounts []string) string {
 
 // exportPool reads the population, publishes the artifact the fleet consumes
 // and the manifest that explains it.
-// dropBots removes bot accounts from a population. A bot that owns a room
+// dropUnusable removes accounts a clientsim run cannot connect as. A bot that owns a room
 // holds a genuine channel subscription (bot-room-service/handler.go:213-216
 // writes IsBot:true with RoomTypeChannel, and its $setOnInsert never sets
 // `open`, so the open filter passes it too), so every condition the query
@@ -145,10 +148,12 @@ func poolDigest(accounts []string) string {
 // stored u.isBot flag, this keys on the account shape, and a row written
 // without the flag is caught only here. Cheap — the population is already in
 // memory and sorted.
-func dropBots(accounts []string) []string {
+func dropUnusable(accounts []string) []string {
 	kept := accounts[:0:0]
 	for _, a := range accounts {
-		if model.IsBot(a) {
+		// An empty account builds subjects like chat.user..event.room, which
+		// subscribe cleanly and receive nothing; poolartifact refuses it too.
+		if a == "" || model.IsBot(a) {
 			continue
 		}
 		kept = append(kept, a)
@@ -161,7 +166,7 @@ func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, o
 	if err != nil {
 		return poolExportResult{}, fmt.Errorf("list channel subscribers for %s: %w", opts.SiteID, err)
 	}
-	accounts = dropBots(accounts)
+	accounts = dropUnusable(accounts)
 	// The failure this export exists to prevent: a fleet that starts against
 	// nobody reports a healthy zero. Fail here, in the tool that can say why.
 	if len(accounts) == 0 {
@@ -253,7 +258,7 @@ func (m mongoPoolSource) channelSubscriberAccounts(ctx context.Context, siteID s
 			// so it fails safe in the same direction as roomGlobal.
 			"origin": bson.M{"$ne": model.OriginTeams},
 		}}},
-		// Bots hold channel subscriptions like anyone else; see dropBots for
+		// Bots hold channel subscriptions like anyone else; see dropUnusable for
 		// why they cannot be in a clientsim pool. The exclusion runs AFTER the
 		// group, on the account, not before it on the row: an account with one
 		// flagged row and one row whose flag was never written would otherwise
@@ -262,14 +267,21 @@ func (m mongoPoolSource) channelSubscriberAccounts(ctx context.Context, siteID s
 		// $max over the group returns true if ANY row carries the flag.
 		{{Key: "$group", Value: bson.M{"_id": "$u.account", "isBot": bson.M{"$max": "$u.isBot"}}}},
 		{{Key: "$match", Value: bson.M{"isBot": bson.M{"$ne": true}}}},
-		// The ".bot" suffix is excluded HERE too, not only in dropBots. The
+		// The ".bot" suffix is excluded HERE too, not only in dropUnusable. The
 		// $limit below bounds whatever reaches it, so a legacy account the
 		// flag never marked would otherwise be counted against --limit and
 		// then dropped in Go — the caller asks for N, the site holds more than
 		// N eligible accounts, and the run still gets fewer. Filtering before
-		// the bound makes the bound mean what it says. dropBots stays as the
+		// the bound makes the bound mean what it says. dropUnusable stays as the
 		// belt for any other source.
-		{{Key: "$match", Value: bson.M{"_id": bson.M{"$not": bson.Regex{Pattern: `\.bot$`}}}}},
+		// Both exclusions sit before the bound, for one reason: $limit counts
+		// whatever reaches it. An empty account sorts FIRST, so leaving it to
+		// the Go pass lets it consume a --limit slot and then vanish — a site
+		// with eligible accounts reports none. Same for a ".bot" suffix the
+		// flag never marked.
+		{{Key: "$match", Value: bson.M{
+			"_id": bson.M{"$nin": bson.A{"", nil}, "$not": bson.Regex{Pattern: `\.bot$`}},
+		}}},
 		{{Key: "$sort", Value: bson.M{"_id": 1}}},
 		// Bound the cursor server-side. cur.All materialises whatever comes
 		// back, so applying --limit only afterwards holds the WHOLE site

--- a/tools/loadgen/poolexport_integration_test.go
+++ b/tools/loadgen/poolexport_integration_test.go
@@ -1,0 +1,59 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/hmchangw/chat/pkg/testutil"
+)
+
+// The unit tests run against a fake source, so the query itself — the filter
+// mirroring user-service's own subscription.list match, and the sort that
+// clientsim's sharding depends on — is only ever exercised here.
+func TestIntegration_MongoPoolSource_SelectsChannelSubscribers(t *testing.T) {
+	db := testutil.MongoDB(t, "poolexport")
+	ctx := context.Background()
+
+	docs := []any{
+		// Wanted: channel subscriptions on the site under test.
+		bson.M{"_id": "s1", "siteId": "site-a", "roomType": "channel", "u": bson.M{"account": "carol"}},
+		bson.M{"_id": "s2", "siteId": "site-a", "roomType": "channel", "u": bson.M{"account": "anna"}},
+		// Same account, second room: the account must appear once.
+		bson.M{"_id": "s3", "siteId": "site-a", "roomType": "channel", "u": bson.M{"account": "anna"}},
+		// open:true is still open — only an explicit false is excluded.
+		bson.M{"_id": "s4", "siteId": "site-a", "roomType": "channel", "open": true, "u": bson.M{"account": "bob"}},
+
+		// Unwanted, each for its own reason.
+		bson.M{"_id": "x1", "siteId": "site-b", "roomType": "channel", "u": bson.M{"account": "otherSite"}},
+		bson.M{"_id": "x2", "siteId": "site-a", "roomType": "dm", "u": bson.M{"account": "dmOnly"}},
+		bson.M{"_id": "x3", "siteId": "site-a", "roomType": "botDM", "u": bson.M{"account": "botOnly"}},
+		bson.M{"_id": "x4", "siteId": "site-a", "roomType": "channel", "open": false, "u": bson.M{"account": "closed"}},
+		bson.M{"_id": "x5", "siteId": "site-a", "roomType": "channel", "u": bson.M{"account": ""}},
+	}
+	_, err := db.Collection("subscriptions").InsertMany(ctx, docs)
+	require.NoError(t, err)
+
+	got, err := mongoPoolSource{db: db}.channelSubscriberAccounts(ctx, "site-a")
+	require.NoError(t, err)
+
+	// Sorted and de-duplicated. The order is the contract shardSlice relies
+	// on: every pod slices the same array, so an unstable one would overlap
+	// or skip accounts across pods.
+	assert.Equal(t, []string{"anna", "bob", "carol"}, got)
+}
+
+// A site with nobody must come back empty rather than erroring, so the caller
+// can report the population it found — exportPool is what turns that into the
+// loud failure.
+func TestIntegration_MongoPoolSource_EmptySite(t *testing.T) {
+	db := testutil.MongoDB(t, "poolexport-empty")
+	got, err := mongoPoolSource{db: db}.channelSubscriberAccounts(context.Background(), "site-none")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}

--- a/tools/loadgen/poolexport_integration_test.go
+++ b/tools/loadgen/poolexport_integration_test.go
@@ -35,6 +35,11 @@ func TestIntegration_MongoPoolSource_SelectsChannelSubscribers(t *testing.T) {
 		bson.M{"_id": "x3", "siteId": "site-a", "roomType": "botDM", "u": bson.M{"account": "botOnly"}},
 		bson.M{"_id": "x4", "siteId": "site-a", "roomType": "channel", "open": false, "u": bson.M{"account": "closed"}},
 		bson.M{"_id": "x5", "siteId": "site-a", "roomType": "channel", "u": bson.M{"account": ""}},
+		// Teams-origin: hidden from subscription.list under the default
+		// SHOW_TEAMS_ROOM=false, so this account would walk to an empty plan
+		// and report ready while measuring nothing.
+		bson.M{"_id": "x6", "siteId": "site-a", "roomType": "channel",
+			"origin": "teams", "u": bson.M{"account": "teamsOnly"}},
 	}
 	_, err := db.Collection("subscriptions").InsertMany(ctx, docs)
 	require.NoError(t, err)
@@ -46,6 +51,24 @@ func TestIntegration_MongoPoolSource_SelectsChannelSubscribers(t *testing.T) {
 	// on: every pod slices the same array, so an unstable one would overlap
 	// or skip accounts across pods.
 	assert.Equal(t, []string{"anna", "bob", "carol"}, got)
+}
+
+// An account with BOTH a Teams room and an ordinary channel is still a valid
+// pool member: it has something to walk. Only Teams-only accounts drop out.
+func TestIntegration_MongoPoolSource_KeepsAccountsWithANonTeamsChannel(t *testing.T) {
+	db := testutil.MongoDB(t, "poolexport-mixed")
+	ctx := context.Background()
+	_, err := db.Collection("subscriptions").InsertMany(ctx, []any{
+		bson.M{"_id": "m1", "siteId": "site-a", "roomType": "channel",
+			"origin": "teams", "u": bson.M{"account": "mixed"}},
+		bson.M{"_id": "m2", "siteId": "site-a", "roomType": "channel",
+			"u": bson.M{"account": "mixed"}},
+	})
+	require.NoError(t, err)
+
+	got, err := mongoPoolSource{db: db}.channelSubscriberAccounts(ctx, "site-a")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"mixed"}, got)
 }
 
 // A site with nobody must come back empty rather than erroring, so the caller

--- a/tools/loadgen/poolexport_integration_test.go
+++ b/tools/loadgen/poolexport_integration_test.go
@@ -65,7 +65,16 @@ func TestIntegration_MongoPoolSource_SelectsChannelSubscribers(t *testing.T) {
 	// Sorted and de-duplicated. The order is the contract shardSlice relies
 	// on: every pod slices the same array, so an unstable one would overlap
 	// or skip accounts across pods.
-	assert.Equal(t, []string{"anna", "bob", "carol"}, got)
+	//
+	// legacy.site-a.bot is here on purpose. Bots are excluded at two layers
+	// and this is only the first: the query keys on the stored u.isBot flag,
+	// so it drops x7 and x8 but cannot see x9, whose flag was never written.
+	// Asserting it away here would hide which layer is carrying the rule.
+	assert.Equal(t, []string{"anna", "bob", "carol", "legacy.site-a.bot"}, got)
+
+	// The second layer, composed with the first exactly as exportPool applies
+	// them. This is the population a fleet actually connects as.
+	assert.Equal(t, []string{"anna", "bob", "carol"}, dropBots(got))
 }
 
 // An account with BOTH a Teams room and an ordinary channel is still a valid

--- a/tools/loadgen/poolexport_integration_test.go
+++ b/tools/loadgen/poolexport_integration_test.go
@@ -78,11 +78,15 @@ func TestIntegration_MongoPoolSource_SelectsChannelSubscribers(t *testing.T) {
 	// and this is only the first: the query keys on the stored u.isBot flag,
 	// so it drops x7 and x8 but cannot see x9, whose flag was never written.
 	// Asserting it away here would hide which layer is carrying the rule.
-	assert.Equal(t, []string{"anna", "bob", "carol", "legacy.site-a.bot"}, got)
+	// legacy.site-a.bot is gone from the source now: the pipeline excludes the
+	// ".bot" suffix too, because the server-side $limit bounds whatever
+	// reaches it and a bot counted against --limit under-delivers the run.
+	assert.Equal(t, []string{"anna", "bob", "carol"}, got)
 
-	// The second layer, composed with the first exactly as exportPool applies
-	// them. This is the population a fleet actually connects as.
-	assert.Equal(t, []string{"anna", "bob", "carol"}, dropBots(got))
+	// dropBots is now a belt with nothing to remove on this path — which is
+	// the point: it stays for any other source, and composing it must not
+	// change what the Mongo source already returned.
+	assert.Equal(t, got, dropBots(got))
 }
 
 // An account with BOTH a Teams room and an ordinary channel is still a valid

--- a/tools/loadgen/poolexport_integration_test.go
+++ b/tools/loadgen/poolexport_integration_test.go
@@ -55,11 +55,19 @@ func TestIntegration_MongoPoolSource_SelectsChannelSubscribers(t *testing.T) {
 			"u": bson.M{"account": "p_admin", "isBot": true}},
 		bson.M{"_id": "x9", "siteId": "site-a", "roomType": "channel",
 			"u": bson.M{"account": "legacy.site-a.bot"}},
+		// The case a pre-group filter cannot see: ONE account, two rows, only
+		// one carrying the flag. Filtering rows before the group drops the
+		// flagged row and lets the account through on the other — and this
+		// name has no ".bot" suffix, so the Go pass cannot catch it either.
+		bson.M{"_id": "x10", "siteId": "site-a", "roomType": "channel",
+			"u": bson.M{"account": "mixedbot", "isBot": true}},
+		bson.M{"_id": "x11", "siteId": "site-a", "roomType": "channel",
+			"u": bson.M{"account": "mixedbot"}},
 	}
 	_, err := db.Collection("subscriptions").InsertMany(ctx, docs)
 	require.NoError(t, err)
 
-	got, err := mongoPoolSource{db: db}.channelSubscriberAccounts(ctx, "site-a")
+	got, err := mongoPoolSource{db: db}.channelSubscriberAccounts(ctx, "site-a", 0)
 	require.NoError(t, err)
 
 	// Sorted and de-duplicated. The order is the contract shardSlice relies
@@ -90,7 +98,7 @@ func TestIntegration_MongoPoolSource_KeepsAccountsWithANonTeamsChannel(t *testin
 	})
 	require.NoError(t, err)
 
-	got, err := mongoPoolSource{db: db}.channelSubscriberAccounts(ctx, "site-a")
+	got, err := mongoPoolSource{db: db}.channelSubscriberAccounts(ctx, "site-a", 0)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"mixed"}, got)
 }
@@ -100,7 +108,7 @@ func TestIntegration_MongoPoolSource_KeepsAccountsWithANonTeamsChannel(t *testin
 // loud failure.
 func TestIntegration_MongoPoolSource_EmptySite(t *testing.T) {
 	db := testutil.MongoDB(t, "poolexport-empty")
-	got, err := mongoPoolSource{db: db}.channelSubscriberAccounts(context.Background(), "site-none")
+	got, err := mongoPoolSource{db: db}.channelSubscriberAccounts(context.Background(), "site-none", 0)
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }

--- a/tools/loadgen/poolexport_integration_test.go
+++ b/tools/loadgen/poolexport_integration_test.go
@@ -40,6 +40,21 @@ func TestIntegration_MongoPoolSource_SelectsChannelSubscribers(t *testing.T) {
 		// and report ready while measuring nothing.
 		bson.M{"_id": "x6", "siteId": "site-a", "roomType": "channel",
 			"origin": "teams", "u": bson.M{"account": "teamsOnly"}},
+		// A bot that owns a room holds a real channel subscription
+		// (bot-room-service/handler.go:213-216 writes IsBot:true with
+		// RoomTypeChannel, and its $setOnInsert never sets `open`, so the
+		// open filter passes it through). clientsim cannot connect as one:
+		// bots authenticate over HTTP through pkg/botauth, not the user JWT
+		// path, and a dotted ".bot" account spans subject tokens — it panics
+		// subject.UserSubscriptionList before any request is made.
+		bson.M{"_id": "x7", "siteId": "site-a", "roomType": "channel",
+			"u": bson.M{"account": "weather.site-a.bot", "isBot": true}},
+		// isBot without the suffix, and the suffix without the flag: either
+		// alone disqualifies, so neither filter carries the rule by itself.
+		bson.M{"_id": "x8", "siteId": "site-a", "roomType": "channel",
+			"u": bson.M{"account": "p_admin", "isBot": true}},
+		bson.M{"_id": "x9", "siteId": "site-a", "roomType": "channel",
+			"u": bson.M{"account": "legacy.site-a.bot"}},
 	}
 	_, err := db.Collection("subscriptions").InsertMany(ctx, docs)
 	require.NoError(t, err)

--- a/tools/loadgen/poolexport_integration_test.go
+++ b/tools/loadgen/poolexport_integration_test.go
@@ -83,10 +83,10 @@ func TestIntegration_MongoPoolSource_SelectsChannelSubscribers(t *testing.T) {
 	// reaches it and a bot counted against --limit under-delivers the run.
 	assert.Equal(t, []string{"anna", "bob", "carol"}, got)
 
-	// dropBots is now a belt with nothing to remove on this path — which is
+	// dropUnusable is now a belt with nothing to remove on this path — which is
 	// the point: it stays for any other source, and composing it must not
 	// change what the Mongo source already returned.
-	assert.Equal(t, got, dropBots(got))
+	assert.Equal(t, got, dropUnusable(got))
 }
 
 // An account with BOTH a Teams room and an ordinary channel is still a valid
@@ -115,4 +115,29 @@ func TestIntegration_MongoPoolSource_EmptySite(t *testing.T) {
 	got, err := mongoPoolSource{db: db}.channelSubscriberAccounts(context.Background(), "site-none", 0)
 	require.NoError(t, err)
 	assert.Empty(t, got)
+}
+
+// The $limit bounds whatever reaches it, so anything the Go pass would remove
+// has to be excluded in the pipeline first. The empty account sorts before
+// every real one, so with limit=1 a pipeline that leaves it in returns the
+// empty string, the Go pass drops it, and a site full of eligible accounts
+// reports none.
+func TestIntegration_MongoPoolSource_LimitSkipsUnusableAccounts(t *testing.T) {
+	db := testutil.MongoDB(t, "poolexportlimit")
+	ctx := context.Background()
+
+	_, err := db.Collection("subscriptions").InsertMany(ctx, []any{
+		// Sorts first, and is unusable.
+		bson.M{"_id": "e1", "siteId": "site-a", "roomType": "channel", "u": bson.M{"account": ""}},
+		// Sorts second, and is unusable for the other reason.
+		bson.M{"_id": "e2", "siteId": "site-a", "roomType": "channel",
+			"u": bson.M{"account": ".bot"}},
+		bson.M{"_id": "e3", "siteId": "site-a", "roomType": "channel", "u": bson.M{"account": "zoe"}},
+	})
+	require.NoError(t, err)
+
+	got, err := mongoPoolSource{db: db}.channelSubscriberAccounts(ctx, "site-a", 1)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"zoe"}, got,
+		"limit=1 must return the first USABLE account, not the first row")
 }

--- a/tools/loadgen/poolexport_test.go
+++ b/tools/loadgen/poolexport_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,9 +40,14 @@ func (f *fakePublisher) Key(siteID, runID, name string) string {
 	return siteID + "/" + runID + "/" + name
 }
 
-func (f *fakePublisher) Put(_ context.Context, key string, a *poolartifact.Artifact) error {
+// PutIfAbsent models the store's conditional write: the claim is the write,
+// so a second writer loses rather than overwriting.
+func (f *fakePublisher) PutIfAbsent(_ context.Context, key string, a *poolartifact.Artifact) error {
 	if f.putErr != nil {
 		return f.putErr
+	}
+	if _, exists := f.artifacts[key]; exists {
+		return fmt.Errorf("%w: %s", poolartifact.ErrObjectExists, key)
 	}
 	f.artifacts[key] = a
 	return nil
@@ -219,4 +225,34 @@ func TestExportPool_RejectsAPopulationOfOnlyBots(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no accounts")
+}
+
+// --run-id was validated as a single path segment; siteId, its immediate
+// neighbour in the same path.Join, was not. One guarded segment beside an
+// unguarded one is not a guard: SITE_ID=../other escapes the same way.
+func TestValidatePoolSegments_GuardsBothPathSegments(t *testing.T) {
+	assert.NoError(t, validatePoolRunID("run-1"))
+	assert.NoError(t, validatePoolSiteID("site-a"))
+
+	for _, bad := range []string{"..", "../other", "a/b", ""} {
+		assert.Error(t, validatePoolRunID(bad), "--run-id %q must be rejected", bad)
+		assert.Error(t, validatePoolSiteID(bad), "SITE_ID %q must be rejected", bad)
+	}
+}
+
+// The claim is now the write, so the retry path has to be proven rather than
+// assumed: a Job that reruns on the same population must succeed, not trip
+// its own guard.
+func TestExportPool_SamePopulationIsAnIdempotentRetry(t *testing.T) {
+	src := &fakeAccountSource{accounts: []string{"anna", "bob"}}
+	pub := newFakePublisher()
+	opts := poolExportOptions{RunID: "run-1", SiteID: "site-a"}
+
+	first, err := exportPool(context.Background(), src, pub, opts)
+	require.NoError(t, err)
+
+	second, err := exportPool(context.Background(), src, pub, opts)
+	require.NoError(t, err, "re-exporting the same population must be a safe retry")
+	assert.Equal(t, first.ConfigDigest, second.ConfigDigest)
+	assert.Equal(t, []string{"anna", "bob"}, pub.artifacts[first.ArtifactKey].Accounts)
 }

--- a/tools/loadgen/poolexport_test.go
+++ b/tools/loadgen/poolexport_test.go
@@ -182,3 +182,41 @@ func TestValidatePoolRunID(t *testing.T) {
 		assert.Error(t, validatePoolRunID(bad), bad)
 	}
 }
+
+// A bot that owns a room holds a genuine channel subscription
+// (bot-room-service/handler.go:213-216 writes IsBot:true with RoomTypeChannel),
+// so the Mongo filter alone is one flag away from letting one through. It must
+// not reach the artifact: clientsim authenticates on the user JWT path bots
+// never take, and a dotted ".bot" account spans subject tokens — it panics
+// subject.UserSubscriptionList before a request is ever made. The drop is here
+// rather than only in the query so it holds for any source, and so a row whose
+// isBot was never stored is still caught.
+func TestExportPool_DropsBotAccounts(t *testing.T) {
+	src := &fakeAccountSource{accounts: []string{
+		"anna", "legacy.site-a.bot", "bob", "weather.site-a.bot",
+	}}
+	pub := newFakePublisher()
+
+	res, err := exportPool(context.Background(), src, pub, poolExportOptions{
+		RunID: "run-1", SiteID: "site-a",
+	})
+	require.NoError(t, err)
+
+	art := pub.artifacts["site-a/run-1/pool.json.gz"]
+	require.NotNil(t, art)
+	assert.Equal(t, []string{"anna", "bob"}, art.Accounts)
+	assert.Equal(t, 2, res.Accounts, "the reported count is the population that will connect")
+}
+
+// A site whose only channel subscribers are bots is empty for clientsim's
+// purposes. It must fail like any other empty population rather than publish
+// an artifact no pod can use.
+func TestExportPool_RejectsAPopulationOfOnlyBots(t *testing.T) {
+	src := &fakeAccountSource{accounts: []string{"weather.site-a.bot", "alerts.site-a.bot"}}
+
+	_, err := exportPool(context.Background(), src, newFakePublisher(), poolExportOptions{
+		RunID: "run-1", SiteID: "site-a",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no accounts")
+}

--- a/tools/loadgen/poolexport_test.go
+++ b/tools/loadgen/poolexport_test.go
@@ -47,6 +47,14 @@ func (f *fakePublisher) Put(_ context.Context, key string, a *poolartifact.Artif
 	return nil
 }
 
+func (f *fakePublisher) Load(_ context.Context, key, _ string) (*poolartifact.Artifact, error) {
+	a, ok := f.artifacts[key]
+	if !ok {
+		return nil, poolartifact.ErrObjectNotFound
+	}
+	return a, nil
+}
+
 func (f *fakePublisher) PutJSON(_ context.Context, key string, v any) error {
 	if f.putErr != nil {
 		return f.putErr
@@ -138,4 +146,39 @@ func TestExportPool_PropagatesSourceAndSinkErrors(t *testing.T) {
 	_, err = exportPool(context.Background(), &fakeAccountSource{accounts: []string{"a"}}, pub,
 		poolExportOptions{RunID: "r", SiteID: "s"})
 	assert.ErrorIs(t, err, boom)
+}
+
+// Overwriting a run ID with a DIFFERENT population breaks the invariant the
+// single object exists to hold. Pods that started before the overwrite and
+// pods that restart after would slice different arrays, so shardSlice would
+// hand out overlapping or disjoint ranges — accounts connected twice or not
+// at all, with every pod still reporting ready.
+func TestExportPool_RefusesToOverwriteADifferentPopulation(t *testing.T) {
+	pub := newFakePublisher()
+	opts := poolExportOptions{RunID: "run-1", SiteID: "site-a"}
+
+	_, err := exportPool(context.Background(), &fakeAccountSource{accounts: []string{"anna", "bob"}}, pub, opts)
+	require.NoError(t, err)
+
+	// The same population is genuinely idempotent: a retried Job must not fail.
+	_, err = exportPool(context.Background(), &fakeAccountSource{accounts: []string{"anna", "bob"}}, pub, opts)
+	require.NoError(t, err, "re-exporting the same population is a safe retry")
+
+	// A changed one is not.
+	_, err = exportPool(context.Background(), &fakeAccountSource{accounts: []string{"anna", "carol"}}, pub, opts)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "--run-id")
+	assert.Equal(t, []string{"anna", "bob"}, pub.artifacts["site-a/run-1/pool.json.gz"].Accounts,
+		"the published pool must be left as it was")
+}
+
+// The run ID becomes a path segment. path.Join normalises "..", so an
+// unvalidated one could write the artifact into another site's scope.
+func TestValidatePoolRunID(t *testing.T) {
+	for _, ok := range []string{"run-1", "soak20260908a", "a.b_c-d"} {
+		assert.NoError(t, validatePoolRunID(ok), ok)
+	}
+	for _, bad := range []string{"", "..", ".", "../site-b/r", "a/b", "-leading", "with space"} {
+		assert.Error(t, validatePoolRunID(bad), bad)
+	}
 }

--- a/tools/loadgen/poolexport_test.go
+++ b/tools/loadgen/poolexport_test.go
@@ -13,17 +13,26 @@ import (
 )
 
 type fakeAccountSource struct {
+	gotLimit int
 	accounts []string
 	err      error
 	gotSite  string
 }
 
-func (f *fakeAccountSource) channelSubscriberAccounts(_ context.Context, siteID string, _ int) ([]string, error) {
+// channelSubscriberAccounts mirrors the pipeline: bots are excluded BEFORE the
+// bound, so the bound counts only accounts that survive to the artifact. A fake
+// that ignored the bound would make every test about it vacuous.
+func (f *fakeAccountSource) channelSubscriberAccounts(_ context.Context, siteID string, limit int) ([]string, error) {
 	f.gotSite = siteID
+	f.gotLimit = limit
 	if f.err != nil {
 		return nil, f.err
 	}
-	return f.accounts, nil
+	out := dropBots(f.accounts)
+	if n := cursorLimit(limit); len(out) > n {
+		out = out[:n]
+	}
+	return out, nil
 }
 
 type fakePublisher struct {
@@ -275,4 +284,23 @@ func TestExportPool_RetryVerifiesTheStoredAccountsNotItsSelfReportedDigest(t *te
 
 	_, err = exportPool(context.Background(), src, pub, opts)
 	require.Error(t, err, "a stored artifact whose accounts contradict its digest must not be accepted")
+}
+
+// The server-side bound must apply to the population that SURVIVES bot
+// removal, not before it. Bounding first and filtering after silently
+// under-delivers --limit whenever a legacy ".bot" account sits in the sorted
+// head: the caller asks for N, the site holds more than N eligible accounts,
+// and the run still gets fewer.
+func TestExportPool_LimitIsHonouredWhenABotSitsInTheHead(t *testing.T) {
+	src := &fakeAccountSource{accounts: []string{
+		"aaa", "bbb.bot", "ccc", "ddd", "eee", "fff",
+	}}
+	pub := newFakePublisher()
+
+	res, err := exportPool(context.Background(), src, pub, poolExportOptions{
+		RunID: "run-1", SiteID: "site-a", Limit: 3,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, res.Accounts, "--limit 3 must deliver 3 eligible accounts, not 3-minus-the-bots")
+	assert.Equal(t, []string{"aaa", "ccc", "ddd"}, pub.artifacts[res.ArtifactKey].Accounts)
 }

--- a/tools/loadgen/poolexport_test.go
+++ b/tools/loadgen/poolexport_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hmchangw/chat/pkg/poolartifact"
+)
+
+type fakeAccountSource struct {
+	accounts []string
+	err      error
+	gotSite  string
+}
+
+func (f *fakeAccountSource) channelSubscriberAccounts(_ context.Context, siteID string) ([]string, error) {
+	f.gotSite = siteID
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.accounts, nil
+}
+
+type fakePublisher struct {
+	artifacts map[string]*poolartifact.Artifact
+	blobs     map[string]any
+	putErr    error
+}
+
+func newFakePublisher() *fakePublisher {
+	return &fakePublisher{artifacts: map[string]*poolartifact.Artifact{}, blobs: map[string]any{}}
+}
+
+func (f *fakePublisher) Key(siteID, runID, name string) string {
+	return siteID + "/" + runID + "/" + name
+}
+
+func (f *fakePublisher) Put(_ context.Context, key string, a *poolartifact.Artifact) error {
+	if f.putErr != nil {
+		return f.putErr
+	}
+	f.artifacts[key] = a
+	return nil
+}
+
+func (f *fakePublisher) PutJSON(_ context.Context, key string, v any) error {
+	if f.putErr != nil {
+		return f.putErr
+	}
+	f.blobs[key] = v
+	return nil
+}
+
+// The export publishes two objects under one run: the artifact the fleet
+// reads, and a manifest that says how it was produced. The manifest is what
+// makes the run reproducible months later — the artifact alone says who
+// connected, not why those accounts.
+func TestExportPool_PublishesArtifactAndManifest(t *testing.T) {
+	src := &fakeAccountSource{accounts: []string{"anna", "bob", "cleo"}}
+	pub := newFakePublisher()
+
+	res, err := exportPool(context.Background(), src, pub, poolExportOptions{
+		RunID: "run-1", SiteID: "site-a",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "site-a", src.gotSite)
+	assert.Equal(t, 3, res.Accounts)
+
+	art := pub.artifacts["site-a/run-1/pool.json.gz"]
+	require.NotNil(t, art, "the artifact must land under the run-scoped key")
+	assert.Equal(t, []string{"anna", "bob", "cleo"}, art.Accounts)
+	assert.Equal(t, "run-1", art.RunID)
+	assert.NotEmpty(t, art.ConfigDigest)
+
+	man, ok := pub.blobs["site-a/run-1/pool-manifest.json"].(poolManifest)
+	require.True(t, ok, "the manifest must land beside it")
+	assert.Equal(t, 3, man.Accounts)
+	assert.Equal(t, art.ConfigDigest, man.ConfigDigest, "both halves must name the same population")
+	assert.NotEmpty(t, man.Query, "the manifest records the query, or the run is not reproducible")
+}
+
+// The digest fingerprints the POPULATION, not the seed parameters — a Mongo
+// export has no preset or RNG seed to hash. Two exports of the same accounts
+// must agree, and one changed account must not.
+func TestExportPool_DigestTracksThePopulation(t *testing.T) {
+	digestOf := func(accounts []string) string {
+		pub := newFakePublisher()
+		_, err := exportPool(context.Background(), &fakeAccountSource{accounts: accounts}, pub,
+			poolExportOptions{RunID: "r", SiteID: "s"})
+		require.NoError(t, err)
+		return pub.artifacts["s/r/pool.json.gz"].ConfigDigest
+	}
+	base := digestOf([]string{"anna", "bob"})
+	assert.Equal(t, base, digestOf([]string{"anna", "bob"}), "the same population is the same digest")
+	assert.NotEqual(t, base, digestOf([]string{"anna", "carol"}), "a changed population must be visible")
+	assert.NotEqual(t, base, digestOf([]string{"anna", "bob", "cleo"}))
+}
+
+// A limit lets a run target a slice of a large site without connecting all of
+// it. Truncation is from the head of a sorted list, so it is stable across
+// exports rather than an arbitrary sample.
+func TestExportPool_LimitTruncatesDeterministically(t *testing.T) {
+	src := &fakeAccountSource{accounts: []string{"anna", "bob", "cleo", "dan"}}
+	pub := newFakePublisher()
+
+	res, err := exportPool(context.Background(), src, pub, poolExportOptions{
+		RunID: "r", SiteID: "s", Limit: 2,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.Accounts)
+	assert.Equal(t, []string{"anna", "bob"}, pub.artifacts["s/r/pool.json.gz"].Accounts)
+}
+
+// An empty result is the failure this whole export exists to prevent: a fleet
+// that starts against nobody reports a healthy zero. It must fail here, in
+// the tool that can still say why.
+func TestExportPool_RejectsAnEmptyPopulation(t *testing.T) {
+	pub := newFakePublisher()
+	_, err := exportPool(context.Background(), &fakeAccountSource{}, pub,
+		poolExportOptions{RunID: "r", SiteID: "s"})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no accounts")
+	assert.Empty(t, pub.artifacts, "nothing may be published for an empty population")
+}
+
+func TestExportPool_PropagatesSourceAndSinkErrors(t *testing.T) {
+	boom := errors.New("mongo is down")
+	_, err := exportPool(context.Background(), &fakeAccountSource{err: boom}, newFakePublisher(),
+		poolExportOptions{RunID: "r", SiteID: "s"})
+	assert.ErrorIs(t, err, boom)
+
+	pub := newFakePublisher()
+	pub.putErr = boom
+	_, err = exportPool(context.Background(), &fakeAccountSource{accounts: []string{"a"}}, pub,
+		poolExportOptions{RunID: "r", SiteID: "s"})
+	assert.ErrorIs(t, err, boom)
+}

--- a/tools/loadgen/poolexport_test.go
+++ b/tools/loadgen/poolexport_test.go
@@ -28,7 +28,7 @@ func (f *fakeAccountSource) channelSubscriberAccounts(_ context.Context, siteID 
 	if f.err != nil {
 		return nil, f.err
 	}
-	out := dropBots(f.accounts)
+	out := dropUnusable(f.accounts)
 	if n := cursorLimit(limit); len(out) > n {
 		out = out[:n]
 	}
@@ -303,4 +303,29 @@ func TestExportPool_LimitIsHonouredWhenABotSitsInTheHead(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 3, res.Accounts, "--limit 3 must deliver 3 eligible accounts, not 3-minus-the-bots")
 	assert.Equal(t, []string{"aaa", "ccc", "ddd"}, pub.artifacts[res.ArtifactKey].Accounts)
+}
+
+// The empty account is the other half of the same ordering defect. It sorts
+// FIRST (""), so it consumes a --limit slot before the Go pass drops it: a
+// site whose rows include one empty account reports "no accounts" for
+// --limit=1 while holding plenty of eligible ones.
+func TestExportPool_AnEmptyAccountDoesNotConsumeALimitSlot(t *testing.T) {
+	src := &fakeAccountSource{accounts: []string{"", "aaa", "bbb"}}
+	pub := newFakePublisher()
+
+	res, err := exportPool(context.Background(), src, pub, poolExportOptions{
+		RunID: "run-1", SiteID: "site-a", Limit: 1,
+	})
+	require.NoError(t, err, "a leading empty account must not empty the population")
+	assert.Equal(t, 1, res.Accounts)
+	assert.Equal(t, []string{"aaa"}, pub.artifacts[res.ArtifactKey].Accounts)
+}
+
+// The manifest is what makes a run reproducible months later. A recorded query
+// that describes a different selection than the pipeline runs is worse than no
+// record: it looks authoritative and is wrong.
+func TestPoolExportQuery_DescribesThePipelineItRuns(t *testing.T) {
+	assert.Contains(t, poolExportQuery, "group", "the exclusion runs after the group; the record must say so")
+	assert.NotContains(t, poolExportQuery, `u.isBot: {$ne: true}} ->`,
+		"that shape claims the flag is filtered on rows before dedup, which is the bug this pipeline fixed")
 }

--- a/tools/loadgen/poolexport_test.go
+++ b/tools/loadgen/poolexport_test.go
@@ -18,7 +18,7 @@ type fakeAccountSource struct {
 	gotSite  string
 }
 
-func (f *fakeAccountSource) channelSubscriberAccounts(_ context.Context, siteID string) ([]string, error) {
+func (f *fakeAccountSource) channelSubscriberAccounts(_ context.Context, siteID string, _ int) ([]string, error) {
 	f.gotSite = siteID
 	if f.err != nil {
 		return nil, f.err
@@ -255,4 +255,24 @@ func TestExportPool_SamePopulationIsAnIdempotentRetry(t *testing.T) {
 	require.NoError(t, err, "re-exporting the same population must be a safe retry")
 	assert.Equal(t, first.ConfigDigest, second.ConfigDigest)
 	assert.Equal(t, []string{"anna", "bob"}, pub.artifacts[first.ArtifactKey].Accounts)
+}
+
+// The retry path compared existing.ConfigDigest — a field the stored artifact
+// reports about ITSELF. An artifact whose digest disagrees with its accounts
+// (a truncated write, a hand-edited object) would be accepted as "the same
+// population" and the fleet would connect to something nobody exported.
+func TestExportPool_RetryVerifiesTheStoredAccountsNotItsSelfReportedDigest(t *testing.T) {
+	src := &fakeAccountSource{accounts: []string{"anna", "bob"}}
+	pub := newFakePublisher()
+	opts := poolExportOptions{RunID: "run-1", SiteID: "site-a"}
+
+	first, err := exportPool(context.Background(), src, pub, opts)
+	require.NoError(t, err)
+
+	// The stored digest still claims the original population; the accounts no
+	// longer match it.
+	pub.artifacts[first.ArtifactKey].Accounts = []string{"mallory"}
+
+	_, err = exportPool(context.Background(), src, pub, opts)
+	require.Error(t, err, "a stored artifact whose accounts contradict its digest must not be accepted")
 }


### PR DESCRIPTION
## Why

clientsim's account pool arrived as a file on disk. That works locally and does not work on the target cluster:

- **Staging is Helm-chart-only, synced by ArgoCD — no `kubectl`.** The pool can't be a hand-created ConfigMap.
- **The storage class is `natapp-san-ssd`** (SAN/block → ReadWriteOnce). No shared read-many volume across the StatefulSet's pods.
- **A ConfigMap caps at 1 MiB.** 30k real account names are ~1.14 MiB raw; gzipped they fit, but 100k does not — close enough to be a trap rather than a solution.
- **The pool is real user accounts**, not `user-N` fixtures, so it can't be generated in-pod. Committing it into the chart was considered and dropped: 30k employee accounts in a GitOps repo's history is permanent.

## The chain

```
Job:  loadgen pool-export   →   object store   →   StatefulSet: clientsim (N pods)
      (Mongo → account list)    (one artifact)      (each pod GETs the same object)
```

**Why not query Mongo per pod.** `shardSlice` hands every pod the same array and slices it by ordinal. Two pods whose queries returned slightly different sets — staging churns while a run is live — would claim overlapping or disjoint ranges: accounts connected twice or not at all, every pod still reporting ready. The single published artifact is what makes the sharding *correct*, not merely convenient.

## What it exports

```text
subscriptions: {siteId, roomType: "channel", open: {$ne: false}, origin: {$ne: "teams"}}
             → group by u.account, isBot = $max(u.isBot)
             → match isBot != true        ← after the group, deliberately
             → match _id not matching /\.bot$/
             → sort ascending, then limit
```

Three exclusions, each with its own reason:

- **Teams origin** — user-service hides Teams rooms from `subscription.list`, so an account whose only channels are Teams rooms walks to an *empty* plan and reports ready while measuring nothing.
- **Bots** — a bot that owns a room holds a genuine channel subscription (`bot-room-service` writes `IsBot:true` with `RoomTypeChannel`, and its `$setOnInsert` never sets `open`), so every other condition is legitimately true of it. clientsim can't connect as one: bots authenticate over HTTP through `pkg/botauth`, and a dotted `.bot` account **panics** `subject.UserSubscriptionList`.
- **The ordering is load-bearing.** Filtering `u.isBot` on rows *before* the group lets an account with one flagged row and one unflagged row survive on the unflagged one. Filtering after the `$limit` lets a bot consume a slot and then vanish, under-delivering `--limit`. Both were real bugs found in review; both are pinned by tests.

## Also in `pkg/poolartifact`

- gzip read/write chosen by the `.gz` suffix alone, so the two ends can't disagree.
- **Both** the compressed and decompressed streams are bounded. Capping only compressed bytes lets a few KiB expand into gigabytes of heap; capping only decompressed bytes lets a body that never expands hang a pod at startup.
- Accounts validated with `subject.IsValidAccountToken` at both ends — the same validator the subject builders use, so the artifact contract and the subject contract can't drift.
- `PutIfAbsent` (`If-None-Match: *`): the claim **is** the write. A Load-then-Put check can't enforce one immutable population per run ID — two exporters both read "absent" and both write.
- `ValidateKeySegment` guards *both* path segments. `Key` joins `prefix/siteID/runID/name` and `path.Join` normalises `..`; guarding the run ID and not its neighbour is not a guard.

## Review

Two rounds, 15 findings between them (CodeRabbit ×6, @julianshen ×9 valid). Every one was checked against the code before acting. The two that could take a pod down:

| | |
|---|---|
| **`asNotFound` never fired** | `minio.ToErrorResponse` is a plain type switch and `GetObject` is lazy, so the NoSuchKey arrived already wrapped by `readCapped`. The **first** `pool-export` of any run ID died on its own overwrite guard. The unit fake had modelled a shape minio never produces, which is why it stayed green. |
| **A pool account could panic clientsim** | Nothing validated accounts as subject tokens. The guard's first CI run turned red on this repo's own 30k-account fixture (`stg.employee.N`) — a shape no pod could survive, asserted by a test. |

Declined, with reasons on the threads: manifest recovery (already satisfied — the `ErrObjectExists` branch falls through to the manifest write), and the NATS finding (`pool-export` never connects to NATS; the real issue is `NATS_URL` being `required` on the shared config struct, which is a config-structure change for every subcommand — **flagged as a follow-up, not fixed here**).

Two deviations from a reviewer's suggested fix, argued on the threads rather than silently: `POOL_S3_USE_SSL=false` warns instead of rejecting (rejecting breaks the documented docker-compose loop; loopback is excluded so the warning stays meaningful), and the `--limit` headroom suggestion was replaced with pipeline-side filtering, which makes the bound exact rather than merely likely.

## Open, for @hmchangw

**`CLIENTSIM_AUTH_URL` uses `http://`.** The side issuer returns NATS user JWTs; a NetworkPolicy controls who can reach it, not whether the wire is readable. Under a service mesh with mTLS that's covered; without one, terminate TLS on the issuer and use `https://` — clientsim needs no code change, only the URL and the issuer's CA. Documented in both deployment files; the decision is a deployment one.

## Verification

`make lint` clean · gosec + repo semgrep rules clean · `-race` throughout · `pkg/poolartifact` 85.3%, `tools/clientsim` 88.9% · every new guard mutation-tested (revert it, its own test goes red).

Integration tests run only in CI (no Docker in the authoring sandbox) and earned their place: they caught the layer-boundary mistake in the first bot-exclusion push and the unusable fixture above. All green on the current head, including real-MinIO `PutIfAbsent` double-claim and real-Mongo `pool-export` with the Teams, bot, and mixed-flag cases.

No client-facing handler, NATS subject, or `pkg/model` wire struct is touched, so `docs/client-api.md` needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HG2exSamSDTyxcxje1TuzZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added gzip-compressed pool artifact support.
  - Added S3-compatible object storage for publishing and loading pool artifacts.
  - Added the `pool-export` command to generate and publish client simulation pools and manifests.
  - Clientsim can now load pools from either a local file or an object-store URL.
  - Added atomic publishing to prevent conflicting overwrites.

- **Bug Fixes**
  - Improved validation for unsafe account names, oversized artifacts, invalid paths, and unusable accounts.
  - Added safeguards against excessive decompression and plaintext remote storage warnings.

- **Documentation**
  - Documented pool export, object-store configuration, and Kubernetes deployment requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->