### PR TITLE
fix(loadgen): skip accounts a clientsim run cannot connect as, instead of failing the export

### DIFF
--- a/tools/clientsim/deploy/k8s-contract.md
+++ b/tools/clientsim/deploy/k8s-contract.md
@@ -199,8 +199,9 @@ healthy zero, and this is the last place that can say why.
 ### The manifest
 
 `pool-manifest.json` records `runId`, `siteId`, `configDigest`, the account
-count, `skippedAccounts` (present only when something was dropped), the limit,
-the query, and the export time. The artifact says *who*
+count, `skippedAccounts` (always written, including zero — and counting what
+this export walked past, not the site; see above), the limit, the query, and
+the export time. The artifact says *who*
 connected; the manifest says how that set was chosen, which is what makes a
 run reproducible months later rather than merely identifiable.
 

--- a/tools/clientsim/deploy/k8s-contract.md
+++ b/tools/clientsim/deploy/k8s-contract.md
@@ -84,8 +84,10 @@ subscriptions: {siteId, roomType: "channel", open: {$ne: false},
                 origin: {$ne: "teams"}}
              → group by u.account, isBot = $max(u.isBot)
              → match isBot != true          ← AFTER the group, see below
-             → match _id not empty and not matching /[.*>\s]/
-             → sort ascending, then limit
+             → match _id not null
+             → sort ascending
+   then, walking the cursor: keep the accounts a run can connect as,
+   stop at --limit, count the rest
 ```
 
 Mirrors user-service's own `subscription.list` match, narrowed to `channel`:
@@ -115,28 +117,45 @@ other condition above is legitimately true of it. clientsim cannot connect as
 one: bots authenticate over HTTP through `pkg/botauth`, not the user JWT path,
 and a dotted `.bot` account spans subject tokens, which panics
 `subject.UserSubscriptionList` before a request is made. The query drops them
-on the stored flag so the bulk never leaves the server; a second pass in Go
-drops them on the account shape, catching a row whose flag was never stored.
+on the stored flag so the bulk never leaves the server; the Go pass below
+catches a row whose flag was never stored, on the account's own shape.
 
-**The shape rule is the subject-token rule, not a `.bot` rule.** Any account
-carrying a dot, wildcard or whitespace rune panics the pod, and not all of them
-are bots: `k6.test-1.user` is a leftover subscription row from another load
-tool, with no `isBot` flag and no `.bot` suffix to mark it as anything else.
-Such a row used to fail the **whole** export at `pkg/poolartifact`'s validator —
-one stale record blocking every run against that site. It is now excluded like
-any other account clientsim cannot connect as: dropped, counted, and reported.
+**The shape rule runs in Go, not in the aggregation.** Any account carrying a
+dot, wildcard, whitespace or control rune panics `subject.UserSubscriptionList`
+inside the pod, and not all of them are bots: `k6.test-1.user` is a leftover
+subscription row from another load tool, with no `isBot` flag and no `.bot`
+suffix to mark it as anything else. Such a row used to fail the **whole** export
+at `pkg/poolartifact`'s validator — one stale record blocking every run against
+that site. It is now skipped like any other account clientsim cannot connect as.
 
-- The regex is the weaker half of `subject.IsValidAccountToken` on purpose
-  (`\s` is the ASCII spaces; the validator refuses every unicode space and
-  control rune), so the Go pass stays the belt. Weaker in that direction costs
-  a `--limit` slot; stronger would drop accounts the pods can serve.
-- Every exclusion sits **before** the `$limit`, because the bound counts
-  whatever reaches it: an account removed afterwards has already consumed a
-  slot, and `--limit N` quietly returns fewer than N.
-- What was dropped is visible, not silent: a `WARN` line with the count and up
-  to five examples, and `skippedAccounts` in the manifest. An export whose
-  entire population is unusable fails and names what it dropped, which is a
-  different fix from a site nobody uses.
+Why the rule is not a `$match` regex, which would keep those rows off the wire:
+
+- **A regex is a second dialect of `subject.IsValidAccountToken`**, evaluated by
+  another engine (MongoDB runs PCRE2, and `\s` does not mean the same thing in
+  every one). Two spellings of one rule can only drift, and the account that
+  panics a pod is exactly the one they disagree about.
+- **The layer that bounds `--limit` has to be the layer that judges
+  eligibility.** The bound counts whatever reaches it, so an account removed
+  afterwards has already consumed a slot and `--limit N` quietly delivers fewer.
+- **The layer that judges is the only one that can report.** Filtering
+  server-side hides the row from every counter downstream: the WARN, the result
+  and the manifest would all read zero while the pool silently shrank.
+
+So the cursor is walked rather than `$limit`ed — each account checked with the
+validator, usable ones accumulating until the bound, the rest counted with a
+bounded sample. The Job's heap holds the bound, not the population. The cost is
+a `$sort` the server cannot cap at top-N (over the grouped keys `$group` already
+materialised) and unusable rows crossing the wire, a rounding error beside the
+population itself.
+
+The `isBot` flag stays a query filter because it defines *which subscriptions
+count* — like `roomType`, `open` and `origin` — rather than judging an account
+string. What it removes is the population's definition, not a skip.
+
+**Skipping is not silent.** A `WARN` with the count and up to five examples,
+`skippedAccounts` in the manifest, and — when a site's whole population is
+unusable — a failure that names what was dropped, which is a different fix from
+a site nobody uses.
 
 The sort is load-bearing, not cosmetic — see the sharding note above.
 

--- a/tools/clientsim/deploy/k8s-contract.md
+++ b/tools/clientsim/deploy/k8s-contract.md
@@ -84,10 +84,9 @@ subscriptions: {siteId, roomType: "channel", open: {$ne: false},
                 origin: {$ne: "teams"}}
              → group by u.account, isBot = $max(u.isBot)
              → match isBot != true          ← AFTER the group, see below
-             → match _id not null
              → sort ascending
    then, walking the cursor: keep the accounts a run can connect as,
-   stop at --limit, count the rest
+   stop at --limit, count what it walked past
 ```
 
 Mirrors user-service's own `subscription.list` match, narrowed to `channel`:
@@ -153,9 +152,23 @@ count* — like `roomType`, `open` and `origin` — rather than judging an accou
 string. What it removes is the population's definition, not a skip.
 
 **Skipping is not silent.** A `WARN` with the count and up to five examples,
-`skippedAccounts` in the manifest, and — when a site's whole population is
-unusable — a failure that names what was dropped, which is a different fix from
-a site nobody uses.
+`skippedAccounts` in the manifest (always written, including zero — an absent
+field cannot tell a clean site from a version that never counted), and — when a
+site's whole population is unusable — a failure that names what was dropped,
+which is a different fix from a site nobody uses.
+
+Read the count as *what this export walked past*, not as a site total. A
+bounded export stops at `--limit` and never sees what sorts after the last
+account it took, so `skippedAccounts: 0` with a `limit` beside it means "none in
+the part that was read". Only an unbounded export walks the whole population,
+and only there is the count the site's. The alternative — walking on to total
+the junk — would make every run a full census of a collection the bound exists
+to avoid reading.
+
+A row whose `u.account` is absent or empty is counted like any other candidate
+(it groups under null, and the walk reads it as a pointer rather than letting a
+`$match` hide it), but never quoted in the sample: `""` names no leftover to
+clean up, sorts first, and would take a slot from the names that do.
 
 The sort is load-bearing, not cosmetic — see the sharding note above.
 

--- a/tools/clientsim/deploy/k8s-contract.md
+++ b/tools/clientsim/deploy/k8s-contract.md
@@ -84,7 +84,7 @@ subscriptions: {siteId, roomType: "channel", open: {$ne: false},
                 origin: {$ne: "teams"}}
              → group by u.account, isBot = $max(u.isBot)
              → match isBot != true          ← AFTER the group, see below
-             → match _id not empty and not matching /\.bot$/
+             → match _id not empty and not matching /[.*>\s]/
              → sort ascending, then limit
 ```
 
@@ -118,6 +118,26 @@ and a dotted `.bot` account spans subject tokens, which panics
 on the stored flag so the bulk never leaves the server; a second pass in Go
 drops them on the account shape, catching a row whose flag was never stored.
 
+**The shape rule is the subject-token rule, not a `.bot` rule.** Any account
+carrying a dot, wildcard or whitespace rune panics the pod, and not all of them
+are bots: `k6.test-1.user` is a leftover subscription row from another load
+tool, with no `isBot` flag and no `.bot` suffix to mark it as anything else.
+Such a row used to fail the **whole** export at `pkg/poolartifact`'s validator —
+one stale record blocking every run against that site. It is now excluded like
+any other account clientsim cannot connect as: dropped, counted, and reported.
+
+- The regex is the weaker half of `subject.IsValidAccountToken` on purpose
+  (`\s` is the ASCII spaces; the validator refuses every unicode space and
+  control rune), so the Go pass stays the belt. Weaker in that direction costs
+  a `--limit` slot; stronger would drop accounts the pods can serve.
+- Every exclusion sits **before** the `$limit`, because the bound counts
+  whatever reaches it: an account removed afterwards has already consumed a
+  slot, and `--limit N` quietly returns fewer than N.
+- What was dropped is visible, not silent: a `WARN` line with the count and up
+  to five examples, and `skippedAccounts` in the manifest. An export whose
+  entire population is unusable fails and names what it dropped, which is a
+  different fix from a site nobody uses.
+
 The sort is load-bearing, not cosmetic — see the sharding note above.
 
 ### Index
@@ -147,7 +167,8 @@ healthy zero, and this is the last place that can say why.
 ### The manifest
 
 `pool-manifest.json` records `runId`, `siteId`, `configDigest`, the account
-count, the limit, the query, and the export time. The artifact says *who*
+count, `skippedAccounts` (present only when something was dropped), the limit,
+the query, and the export time. The artifact says *who*
 connected; the manifest says how that set was chosen, which is what makes a
 run reproducible months later rather than merely identifiable.
 

--- a/tools/loadgen/poolexport.go
+++ b/tools/loadgen/poolexport.go
@@ -29,9 +29,15 @@ type poolCandidates struct {
 	// Accounts are usable, sorted, and already bounded by the caller's limit —
 	// bounded by USABLE accounts, so --limit N means N connections.
 	Accounts []string
-	// Skipped counts what was rejected as unusable and Sample quotes a few. A
-	// count and a sample rather than the whole list: a site can hold more junk
-	// rows than pool, and neither a log line nor an error should scale with it.
+	// Skipped counts what the source rejected as unusable and Sample quotes a
+	// few — a count and a bounded sample rather than the list, because a site
+	// can hold more junk rows than pool and neither a log line nor an error
+	// should scale with it.
+	//
+	// It counts what the source WALKED PAST, which is the whole population
+	// only for an unbounded export. A bounded one stops at the limit, so junk
+	// sorting after the last account taken is never seen — reading it as a
+	// site-wide total would overstate what the export can know.
 	Skipped int
 	Sample  []string
 }
@@ -45,13 +51,15 @@ type poolAccountSource interface {
 	channelSubscriberAccounts(ctx context.Context, siteID string, limit int) (poolCandidates, error)
 }
 
-// cursorLimit converts --limit into the server-side bound. The pipeline
-// filters bots before this bound applies, so the bound counts only accounts
-// that will survive to the artifact — no headroom needed.
+// cursorLimit converts --limit into the bound collectUsableAccounts stops at.
+// It is a count of USABLE accounts, not of rows: the aggregation carries no
+// $limit stage, deliberately, because only the client side knows which
+// candidates a run can connect as. Reinstating one there would bound rows that
+// are then dropped, and --limit N would quietly deliver fewer than N.
 //
 // An unbounded export still gets a bound: maxAccounts+1, so a population over
-// the artifact cap is still DETECTED (by the extra row) rather than silently
-// truncated to it.
+// the artifact cap is still DETECTED (by the extra account) rather than
+// silently truncated to it.
 func cursorLimit(limit int) int {
 	if limit > 0 && limit <= poolartifact.MaxAccounts {
 		return limit
@@ -103,7 +111,7 @@ const (
 // would connect cleanly and then measure nothing.
 const poolExportQuery = `subscriptions: match {siteId, roomType: "channel", open: {$ne: false}, origin: {$ne: "teams"}} ` +
 	`-> group by u.account with isBot = $max(u.isBot) ` +
-	`-> match {isBot: {$ne: true}, _id: not null} -> sort _id asc ` +
+	`-> match {isBot: {$ne: true}} -> sort _id asc ` +
 	`-> keep accounts usable as NATS subject tokens, until limit`
 
 type poolExportOptions struct {
@@ -121,9 +129,14 @@ type poolExportResult struct {
 	ConfigDigest string
 	ArtifactKey  string
 	ManifestKey  string
-	// Skipped counts every account excluded as unusable — by the source while
-	// it was bounding the run, and by the belt below it — and SkippedSample
-	// quotes a few of them, so the caller can say what shrank the pool.
+	// Skipped counts every account excluded as unusable while this pool was
+	// selected — by the source as it walked candidates, and by the belt below
+	// it — and SkippedSample quotes a few, so the caller can say what shrank
+	// the pool and which leftover to clean up.
+	//
+	// "While this pool was selected" is the exact claim: a bounded export stops
+	// at --limit and never sees what sorts after it. Only an unbounded export's
+	// count is the site's total.
 	Skipped       int
 	SkippedSample []string
 }
@@ -136,10 +149,15 @@ type poolManifest struct {
 	SiteID       string `json:"siteId"`
 	ConfigDigest string `json:"configDigest"`
 	Accounts     int    `json:"accounts"`
-	// SkippedAccounts closes the gap between the rows the source returned and
-	// the accounts published, so a shrinking pool is visible in the record
-	// rather than only in a log line nobody kept.
-	SkippedAccounts int       `json:"skippedAccounts,omitempty"`
+	// SkippedAccounts is how many unusable accounts this export walked past —
+	// the gap between the candidates read and the accounts published — so a
+	// shrinking pool is visible in the record rather than only in a log line
+	// nobody kept. Always written, including zero: an absent field cannot tell
+	// a clean site from a version that never counted.
+	//
+	// A bounded export stops at --limit, so this counts what it saw getting
+	// there, not the site. Limit is right beside it, which is what says which.
+	SkippedAccounts int       `json:"skippedAccounts"`
 	Limit           int       `json:"limit,omitempty"`
 	Query           string    `json:"query"`
 	Source          string    `json:"source"`
@@ -212,11 +230,17 @@ func dropUnusable(accounts []string) (kept, skipped []string) {
 // shape, which is what tells an operator WHICH leftover to clean up.
 const skipSample = 5
 
-func sampleAccounts(accounts []string) []string {
-	if len(accounts) > skipSample {
-		return accounts[:skipSample]
+// appendSkipSample adds account to a bounded sample of skipped accounts.
+//
+// Blank names are counted but never quoted. A row whose u.account is empty or
+// absent is malformed rather than misnamed: printing "" tells an operator
+// nothing and, since it sorts first, would take a slot from the names that do
+// — "k6.test-1.user" is the whole point of quoting any.
+func appendSkipSample(sample []string, account string) []string {
+	if account == "" || len(sample) >= skipSample {
+		return sample
 	}
-	return accounts
+	return append(sample, account)
 }
 
 // exportPool reads the population, publishes the artifact the fleet consumes
@@ -230,7 +254,17 @@ func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, o
 	// anything it let through. Summed, because either alone under-reports.
 	accounts, beltSkipped := dropUnusable(cand.Accounts)
 	skipped := cand.Skipped + len(beltSkipped)
-	sample := sampleAccounts(append(append([]string{}, cand.Sample...), beltSkipped...))
+	// The belt's catches take the sample slots first. They are the ones a
+	// source did NOT report, so they are evidence that its own filtering and
+	// its own counting disagree — appending them after a full source sample
+	// would drop exactly the names worth reading.
+	var sample []string
+	for _, a := range beltSkipped {
+		sample = appendSkipSample(sample, a)
+	}
+	for _, a := range cand.Sample {
+		sample = appendSkipSample(sample, a)
+	}
 	// The failure this export exists to prevent: a fleet that starts against
 	// nobody reports a healthy zero. Fail here, in the tool that can say why.
 	if len(accounts) == 0 {
@@ -351,10 +385,6 @@ func (m mongoPoolSource) channelSubscriberAccounts(ctx context.Context, siteID s
 		// kind is decided below, in Go, where it can also be counted.
 		{{Key: "$group", Value: bson.M{"_id": "$u.account", "isBot": bson.M{"$max": "$u.isBot"}}}},
 		{{Key: "$match", Value: bson.M{"isBot": bson.M{"$ne": true}}}},
-		// A row with no u.account groups under null, which is not an account
-		// at all — it decodes into no string and stands for no connection, so
-		// it is dropped here rather than counted as a skipped account.
-		{{Key: "$match", Value: bson.M{"_id": bson.M{"$ne": nil}}}},
 		{{Key: "$sort", Value: bson.M{"_id": 1}}},
 		// No $limit stage. The bound counts USABLE accounts, and only Go knows
 		// which those are, so bounding here would count rows that are then
@@ -401,24 +431,36 @@ type accountRows interface {
 func collectUsableAccounts(ctx context.Context, rows accountRows, want int) (poolCandidates, error) {
 	var out poolCandidates
 	for rows.Next(ctx) {
+		// A pointer, because a row whose u.account is absent groups under null
+		// and a string field cannot decode it. Reading it here rather than
+		// excluding it in the pipeline keeps the aggregation free of any
+		// judgement about the account — and a row with no account is then
+		// counted like any other candidate a run cannot connect as, instead of
+		// being the one kind that disappears silently.
 		var row struct {
-			Account string `bson:"_id"`
+			Account *string `bson:"_id"`
 		}
 		if err := rows.Decode(&row); err != nil {
 			return poolCandidates{}, fmt.Errorf("decode channel subscriber: %w", err)
 		}
-		if !accountUsable(row.Account) {
+		var account string
+		if row.Account != nil {
+			account = *row.Account
+		}
+		if !accountUsable(account) {
 			// Counted, not passed over in silence: this walk is the only place
 			// that ever sees "k6.test-1.user", so if it says nothing, nothing
 			// downstream can.
 			out.Skipped++
-			if len(out.Sample) < skipSample {
-				out.Sample = append(out.Sample, row.Account)
-			}
+			out.Sample = appendSkipSample(out.Sample, account)
 			continue
 		}
-		out.Accounts = append(out.Accounts, row.Account)
+		out.Accounts = append(out.Accounts, account)
 		if len(out.Accounts) >= want {
+			// The bound is the caller's, so the walk ends here — and with it
+			// what this export can claim to know: junk sorting after the last
+			// account taken is never read, and never counted. Walking on to
+			// total it would trade the caller's bound for a census.
 			break
 		}
 	}

--- a/tools/loadgen/poolexport.go
+++ b/tools/loadgen/poolexport.go
@@ -20,11 +20,29 @@ import (
 	"github.com/hmchangw/chat/pkg/subject"
 )
 
+// poolCandidates is what a source found: the accounts a run can connect as,
+// and what it left behind getting there. The two travel together because they
+// are decided together — a source that filtered for itself and reported
+// nothing would make the WARN and the manifest's skippedAccounts a fiction,
+// which is worse than not recording them at all.
+type poolCandidates struct {
+	// Accounts are usable, sorted, and already bounded by the caller's limit —
+	// bounded by USABLE accounts, so --limit N means N connections.
+	Accounts []string
+	// Skipped counts what was rejected as unusable and Sample quotes a few. A
+	// count and a sample rather than the whole list: a site can hold more junk
+	// rows than pool, and neither a log line nor an error should scale with it.
+	Skipped int
+	Sample  []string
+}
+
 // poolAccountSource yields the accounts a clientsim run should connect as.
-// limit is the caller's --limit (0 = unbounded); a source is free to push it
-// down rather than materialise the whole population first.
+// limit is the caller's --limit (0 = unbounded). A source applies both the
+// usability rule and the bound itself, in that order: whichever layer decides
+// what counts against the bound is the only one that can report what it
+// dropped, so they cannot be split without one of them lying.
 type poolAccountSource interface {
-	channelSubscriberAccounts(ctx context.Context, siteID string, limit int) ([]string, error)
+	channelSubscriberAccounts(ctx context.Context, siteID string, limit int) (poolCandidates, error)
 }
 
 // cursorLimit converts --limit into the server-side bound. The pipeline
@@ -85,8 +103,8 @@ const (
 // would connect cleanly and then measure nothing.
 const poolExportQuery = `subscriptions: match {siteId, roomType: "channel", open: {$ne: false}, origin: {$ne: "teams"}} ` +
 	`-> group by u.account with isBot = $max(u.isBot) ` +
-	`-> match {isBot: {$ne: true}, _id: not empty and not /[.*>\s]/} ` +
-	`-> sort _id asc -> limit`
+	`-> match {isBot: {$ne: true}, _id: not null} -> sort _id asc ` +
+	`-> keep accounts usable as NATS subject tokens, until limit`
 
 type poolExportOptions struct {
 	RunID  string
@@ -103,10 +121,11 @@ type poolExportResult struct {
 	ConfigDigest string
 	ArtifactKey  string
 	ManifestKey  string
-	// Skipped are the accounts the source returned that no clientsim pod can
-	// connect as. Normally empty — the query excludes them server-side — so a
-	// non-empty one says the query and the Go pass disagree about the rule.
-	Skipped []string
+	// Skipped counts every account excluded as unusable — by the source while
+	// it was bounding the run, and by the belt below it — and SkippedSample
+	// quotes a few of them, so the caller can say what shrank the pool.
+	Skipped       int
+	SkippedSample []string
 }
 
 // poolManifest explains an export. The artifact says WHO connected; this says
@@ -140,11 +159,12 @@ func poolDigest(accounts []string) string {
 	return hex.EncodeToString(h.Sum(nil)[:8])
 }
 
-// dropUnusable splits the population into the accounts a clientsim run can
-// connect as and the ones it cannot, so the caller can report the second set
-// rather than let it vanish.
+// accountUsable reports whether a clientsim run can connect as this account.
+// One predicate, used by the source that bounds --limit and by the belt that
+// re-checks it, so the layer doing the bounding and the layer doing the
+// reporting cannot disagree about what "usable" means.
 //
-// Three kinds are unusable, for one shared reason — the account becomes a NATS
+// Two kinds are not usable, for one shared reason — the account becomes a NATS
 // subject token:
 //
 //   - Bots. A bot that owns a room holds a genuine channel subscription
@@ -154,23 +174,30 @@ func poolDigest(accounts []string) string {
 //     cannot connect as one either way: bots authenticate over HTTP through
 //     pkg/botauth rather than the user JWT path.
 //   - Anything that is not a valid subject token — a dot, wildcard, whitespace
-//     or control rune. subject.UserSubscriptionList PANICS on one, so a single
-//     such account is not a degraded pod but a dead one. Real sites carry them:
-//     "k6.test-1.user" is a leftover subscription row from another load tool,
-//     with no isBot flag and no ".bot" suffix to mark it as anything else.
-//   - The empty account, which IsValidAccountToken already refuses: it builds
-//     subjects like chat.user..event.room, which subscribe cleanly and receive
-//     nothing.
+//     or control rune, and the empty account. subject.UserSubscriptionList
+//     PANICS on one, so such an account is not a degraded pod but a dead one.
+//     Real sites carry them: "k6.test-1.user" is a leftover subscription row
+//     from another load tool, with no isBot flag and no ".bot" suffix to mark
+//     it as anything else.
 //
-// Belt to the query's braces, and not redundant with it: the query keys on the
-// stored u.isBot flag and on the account's shape as a regex, this keys on the
-// same validator the subject builders use — so a row written without the flag,
-// or a rune the regex does not spell out, is caught only here. Cheap — the
-// population is already in memory and sorted.
+// The rule lives in Go rather than in the aggregation, deliberately. A regex
+// approximating subject.IsValidAccountToken is a second dialect of the same
+// rule — evaluated by a different engine, with its own reading of \s — and the
+// two can only ever drift apart. The cost is that unusable rows travel to the
+// client; they are a rounding error beside the population itself.
+func accountUsable(account string) bool {
+	return !model.IsBot(account) && subject.IsValidAccountToken(account)
+}
+
+// dropUnusable splits accounts by accountUsable. It is the belt under a source
+// that already applied the same rule: it must find nothing on the Mongo path,
+// and it keeps the guarantee for any source that does less. Whatever it does
+// find is returned rather than dropped quietly, so the caller's count stays
+// the whole truth.
 func dropUnusable(accounts []string) (kept, skipped []string) {
 	kept = accounts[:0:0]
 	for _, a := range accounts {
-		if model.IsBot(a) || !subject.IsValidAccountToken(a) {
+		if !accountUsable(a) {
 			skipped = append(skipped, a)
 			continue
 		}
@@ -178,18 +205,6 @@ func dropUnusable(accounts []string) (kept, skipped []string) {
 	}
 	return kept, skipped
 }
-
-// unusableAccountPattern is the server-side half of subject.IsValidAccountToken:
-// an account matching it cannot be a NATS subject token. Named rather than
-// inlined so a test can hold the two halves against each other — the pattern
-// and the validator disagreeing is exactly the drift that let "k6.test-1.user"
-// reach poolartifact and fail a whole export.
-//
-// It is deliberately the WEAKER half. Regex \s is the ASCII spaces, while the
-// validator refuses every unicode space and control rune, so the pipeline can
-// let through what the Go belt then removes. Weaker in that direction costs a
-// --limit slot; stronger would drop accounts the pods can serve.
-const unusableAccountPattern = `[.*>\s]`
 
 // skipSample bounds what a log line or an error quotes from a skipped set: a
 // site that churns out thousands of unusable rows must not turn one warning
@@ -207,21 +222,25 @@ func sampleAccounts(accounts []string) []string {
 // exportPool reads the population, publishes the artifact the fleet consumes
 // and the manifest that explains it.
 func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, opts poolExportOptions) (poolExportResult, error) {
-	accounts, err := src.channelSubscriberAccounts(ctx, opts.SiteID, opts.Limit)
+	cand, err := src.channelSubscriberAccounts(ctx, opts.SiteID, opts.Limit)
 	if err != nil {
 		return poolExportResult{}, fmt.Errorf("list channel subscribers for %s: %w", opts.SiteID, err)
 	}
-	accounts, skipped := dropUnusable(accounts)
+	// The source reports what it skipped while bounding the run; the belt adds
+	// anything it let through. Summed, because either alone under-reports.
+	accounts, beltSkipped := dropUnusable(cand.Accounts)
+	skipped := cand.Skipped + len(beltSkipped)
+	sample := sampleAccounts(append(append([]string{}, cand.Sample...), beltSkipped...))
 	// The failure this export exists to prevent: a fleet that starts against
 	// nobody reports a healthy zero. Fail here, in the tool that can say why.
 	if len(accounts) == 0 {
-		if len(skipped) > 0 {
+		if skipped > 0 {
 			// A different failure from an unused site, and a different fix:
 			// these rows exist, they are just unusable. Name them, or the
 			// operator is left guessing which tool left them behind.
 			return poolExportResult{}, fmt.Errorf(
-				"site %q has %d channel subscribers but none usable as a NATS subject token (e.g. %q)",
-				opts.SiteID, len(skipped), sampleAccounts(skipped))
+				"site %q has %d channel subscribers but none a clientsim run can connect as (e.g. %q)",
+				opts.SiteID, skipped, sample)
 		}
 		return poolExportResult{}, fmt.Errorf("site %q has no accounts with a channel subscription", opts.SiteID)
 	}
@@ -266,7 +285,7 @@ func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, o
 	manifestKey := pub.Key(opts.SiteID, opts.RunID, poolManifestName)
 	if err := pub.PutJSON(ctx, manifestKey, poolManifest{
 		RunID: opts.RunID, SiteID: opts.SiteID, ConfigDigest: digest,
-		Accounts: len(accounts), SkippedAccounts: len(skipped), Limit: opts.Limit,
+		Accounts: len(accounts), SkippedAccounts: skipped, Limit: opts.Limit,
 		Query: poolExportQuery, Source: "mongodb",
 		ExportedAt: time.Now().UTC(),
 	}); err != nil {
@@ -289,7 +308,7 @@ func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, o
 	return poolExportResult{
 		Accounts: len(accounts), ConfigDigest: digest,
 		ArtifactKey: artifactKey, ManifestKey: manifestKey,
-		Skipped: skipped,
+		Skipped: skipped, SkippedSample: sample,
 	}, nil
 }
 
@@ -297,7 +316,7 @@ func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, o
 // collection.
 type mongoPoolSource struct{ db *mongo.Database }
 
-func (m mongoPoolSource) channelSubscriberAccounts(ctx context.Context, siteID string, limit int) ([]string, error) {
+func (m mongoPoolSource) channelSubscriberAccounts(ctx context.Context, siteID string, limit int) (poolCandidates, error) {
 	// $group, not $lookup — no join, and it projects to the single field the
 	// export needs. $sort after the group makes the order stable, which is
 	// what shardSlice depends on: every clientsim pod slices the same array,
@@ -320,41 +339,29 @@ func (m mongoPoolSource) channelSubscriberAccounts(ctx context.Context, siteID s
 			// so it fails safe in the same direction as roomGlobal.
 			"origin": bson.M{"$ne": model.OriginTeams},
 		}}},
-		// Bots hold channel subscriptions like anyone else; see dropUnusable for
-		// why they cannot be in a clientsim pool. The exclusion runs AFTER the
-		// group, on the account, not before it on the row: an account with one
-		// flagged row and one row whose flag was never written would otherwise
-		// have the flagged row filtered out and survive on the other — the
-		// exact hole the two layers exist to close, reopened by filter order.
+		// Bots hold channel subscriptions like anyone else; see accountUsable
+		// for why they cannot be in a clientsim pool. The exclusion runs AFTER
+		// the group, on the account, not before it on the row: an account with
+		// one flagged row and one row whose flag was never written would
+		// otherwise have the flagged row filtered out and survive on the other.
 		// $max over the group returns true if ANY row carries the flag.
+		//
+		// This is the population's definition — which subscriptions count —
+		// not a judgement about the account string. Everything of that second
+		// kind is decided below, in Go, where it can also be counted.
 		{{Key: "$group", Value: bson.M{"_id": "$u.account", "isBot": bson.M{"$max": "$u.isBot"}}}},
 		{{Key: "$match", Value: bson.M{"isBot": bson.M{"$ne": true}}}},
-		// Everything clientsim cannot connect as is excluded HERE too, not only
-		// in dropUnusable, for one reason: the $limit below bounds whatever
-		// reaches it. An account removed afterwards has already consumed a
-		// --limit slot and then vanished — the caller asks for N, the site
-		// holds more than N eligible accounts, and the run still gets fewer.
-		// Filtering before the bound makes the bound mean what it says.
-		//
-		// The regex is the subject-token rule, not a ".bot" rule: any dot,
-		// wildcard or whitespace rune spans or breaks a token, and an account
-		// carrying one panics subject.UserSubscriptionList inside the pod. It
-		// subsumes the ".bot" suffix (a bot account is dotted by construction)
-		// and catches what no flag marks — "k6.test-1.user", left behind by
-		// another load tool, is a real row on a real staging site.
-		// dropUnusable stays as the belt: it runs the validator itself, so a
-		// control rune this pattern does not spell out is still caught, and the
-		// rule holds for any other source.
-		{{Key: "$match", Value: bson.M{
-			"_id": bson.M{"$nin": bson.A{"", nil}, "$not": bson.Regex{Pattern: unusableAccountPattern}},
-		}}},
+		// A row with no u.account groups under null, which is not an account
+		// at all — it decodes into no string and stands for no connection, so
+		// it is dropped here rather than counted as a skipped account.
+		{{Key: "$match", Value: bson.M{"_id": bson.M{"$ne": nil}}}},
 		{{Key: "$sort", Value: bson.M{"_id": 1}}},
-		// Bound the cursor server-side. cur.All materialises whatever comes
-		// back, so applying --limit only afterwards holds the WHOLE site
-		// population in the Job's heap first — and an unbounded export has no
-		// ceiling at all until the artifact's own account cap rejects it, long
-		// after the memory was spent. maxAccounts+1 keeps that cap detectable.
-		{{Key: "$limit", Value: int64(cursorLimit(limit))}},
+		// No $limit stage. The bound counts USABLE accounts, and only Go knows
+		// which those are, so bounding here would count rows that are then
+		// dropped — the caller asks for N and the run gets fewer. The cursor
+		// below stops early instead, so the Job's heap holds the bound, not
+		// the population. The cost is a $sort the server cannot cap at top-N;
+		// it sorts the grouped keys, which the $group already materialised.
 	}
 	// $group and $sort are blocking stages with a per-stage memory limit; a
 	// site large enough to be worth load-testing is exactly the one that
@@ -362,23 +369,75 @@ func (m mongoPoolSource) channelSubscriberAccounts(ctx context.Context, siteID s
 	cur, err := m.db.Collection("subscriptions").Aggregate(ctx, pipeline,
 		options.Aggregate().SetAllowDiskUse(true))
 	if err != nil {
-		return nil, fmt.Errorf("aggregate channel subscribers: %w", err)
+		return poolCandidates{}, fmt.Errorf("aggregate channel subscribers: %w", err)
 	}
 	defer cur.Close(ctx) //nolint:errcheck // read-only cursor
-	var rows []struct {
-		Account string `bson:"_id"`
+
+	// An unbounded export still gets a bound — maxAccounts+1, so a population
+	// over the artifact cap is DETECTED by the extra account rather than
+	// silently truncated to it.
+	return collectUsableAccounts(ctx, cur, cursorLimit(limit))
+}
+
+// accountRows is the slice of *mongo.Cursor collectUsableAccounts needs.
+// Declared here, in the consumer, so the walk that decides the bound and the
+// skip evidence can be tested without a database — it is the part of this file
+// most worth getting wrong quietly.
+type accountRows interface {
+	Next(ctx context.Context) bool
+	Decode(v any) error
+	Err() error
+}
+
+// collectUsableAccounts walks sorted candidates and stops once want USABLE
+// accounts are in hand, counting everything it passed over.
+//
+// The bound is applied here rather than as a $limit for two reasons that are
+// really one: only this layer knows which accounts a run can connect as, so a
+// server-side bound would count rows that are then dropped (--limit N quietly
+// delivering fewer), and a server-side filter would hide those rows from the
+// only layer that can report them. Stopping early keeps the Job's heap sized
+// by the bound rather than by the site.
+func collectUsableAccounts(ctx context.Context, rows accountRows, want int) (poolCandidates, error) {
+	var out poolCandidates
+	for rows.Next(ctx) {
+		var row struct {
+			Account string `bson:"_id"`
+		}
+		if err := rows.Decode(&row); err != nil {
+			return poolCandidates{}, fmt.Errorf("decode channel subscriber: %w", err)
+		}
+		if !accountUsable(row.Account) {
+			// Counted, not passed over in silence: this walk is the only place
+			// that ever sees "k6.test-1.user", so if it says nothing, nothing
+			// downstream can.
+			out.Skipped++
+			if len(out.Sample) < skipSample {
+				out.Sample = append(out.Sample, row.Account)
+			}
+			continue
+		}
+		out.Accounts = append(out.Accounts, row.Account)
+		if len(out.Accounts) >= want {
+			break
+		}
 	}
-	if err := cur.All(ctx, &rows); err != nil {
-		return nil, fmt.Errorf("read channel subscribers: %w", err)
+	if err := rows.Err(); err != nil {
+		return poolCandidates{}, fmt.Errorf("read channel subscribers: %w", err)
 	}
-	// Returned as the query selected them, unfiltered: dropUnusable is the one
-	// place that decides what a pod can connect as, so whatever slips past the
-	// pipeline is dropped AND counted there rather than vanishing here.
-	accounts := make([]string, 0, len(rows))
-	for _, r := range rows {
-		accounts = append(accounts, r.Account)
+	return out, nil
+}
+
+// logSkippedAccounts is the operator-facing half of the skip evidence. Not an
+// error — one stale row must not block a run the rest of the site can serve —
+// but not silent either: the day this count stops being a handful of load-tool
+// leftovers, the pool is quietly shrinking and this is where it shows.
+func logSkippedAccounts(siteID string, skipped int, sample []string) {
+	if skipped == 0 {
+		return
 	}
-	return accounts, nil
+	slog.Warn("skipped accounts a clientsim run cannot connect as",
+		"siteId", siteID, "skipped", skipped, "sample", sample)
 }
 
 func runPoolExport(ctx context.Context, cfg *config, args []string) int {
@@ -431,18 +490,10 @@ func runPoolExport(ctx context.Context, cfg *config, args []string) int {
 		slog.Error("pool export", "error", err)
 		return 1
 	}
-	if len(res.Skipped) > 0 {
-		// Not an error — one stale row must not block a run the rest of the
-		// site can serve — but not silent either: the day this count stops
-		// being a handful of load-tool leftovers, the pool is quietly shrinking
-		// and the operator has to be able to see it.
-		slog.Warn("skipped accounts that cannot be NATS subject tokens",
-			"siteId", cfg.SiteID, "skipped", len(res.Skipped),
-			"sample", sampleAccounts(res.Skipped))
-	}
+	logSkippedAccounts(cfg.SiteID, res.Skipped, res.SkippedSample)
 	slog.Info("pool exported",
 		"runId", *runID, "siteId", cfg.SiteID, "accounts", res.Accounts,
-		"skipped", len(res.Skipped),
+		"skipped", res.Skipped,
 		"configDigest", res.ConfigDigest,
 		"artifactKey", res.ArtifactKey, "manifestKey", res.ManifestKey)
 	return 0

--- a/tools/loadgen/poolexport.go
+++ b/tools/loadgen/poolexport.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/hmchangw/chat/pkg/model"
 	"github.com/hmchangw/chat/pkg/poolartifact"
+	"github.com/hmchangw/chat/pkg/subject"
 )
 
 // poolAccountSource yields the accounts a clientsim run should connect as.
@@ -84,7 +85,7 @@ const (
 // would connect cleanly and then measure nothing.
 const poolExportQuery = `subscriptions: match {siteId, roomType: "channel", open: {$ne: false}, origin: {$ne: "teams"}} ` +
 	`-> group by u.account with isBot = $max(u.isBot) ` +
-	`-> match {isBot: {$ne: true}, _id: not empty and not /\.bot$/} ` +
+	`-> match {isBot: {$ne: true}, _id: not empty and not /[.*>\s]/} ` +
 	`-> sort _id asc -> limit`
 
 type poolExportOptions struct {
@@ -102,20 +103,28 @@ type poolExportResult struct {
 	ConfigDigest string
 	ArtifactKey  string
 	ManifestKey  string
+	// Skipped are the accounts the source returned that no clientsim pod can
+	// connect as. Normally empty — the query excludes them server-side — so a
+	// non-empty one says the query and the Go pass disagree about the rule.
+	Skipped []string
 }
 
 // poolManifest explains an export. The artifact says WHO connected; this says
 // how that set was chosen, which is what makes the run reproducible rather
 // than merely identifiable.
 type poolManifest struct {
-	RunID        string    `json:"runId"`
-	SiteID       string    `json:"siteId"`
-	ConfigDigest string    `json:"configDigest"`
-	Accounts     int       `json:"accounts"`
-	Limit        int       `json:"limit,omitempty"`
-	Query        string    `json:"query"`
-	Source       string    `json:"source"`
-	ExportedAt   time.Time `json:"exportedAt"`
+	RunID        string `json:"runId"`
+	SiteID       string `json:"siteId"`
+	ConfigDigest string `json:"configDigest"`
+	Accounts     int    `json:"accounts"`
+	// SkippedAccounts closes the gap between the rows the source returned and
+	// the accounts published, so a shrinking pool is visible in the record
+	// rather than only in a log line nobody kept.
+	SkippedAccounts int       `json:"skippedAccounts,omitempty"`
+	Limit           int       `json:"limit,omitempty"`
+	Query           string    `json:"query"`
+	Source          string    `json:"source"`
+	ExportedAt      time.Time `json:"exportedAt"`
 }
 
 // poolDigest fingerprints the POPULATION, not the seed parameters: a Mongo
@@ -131,32 +140,68 @@ func poolDigest(accounts []string) string {
 	return hex.EncodeToString(h.Sum(nil)[:8])
 }
 
-// dropUnusable removes accounts a clientsim run cannot connect as. A bot that
-// owns a room holds a genuine channel subscription (bot-room-service/handler.go:213-216
-// writes IsBot:true with RoomTypeChannel, and its $setOnInsert never sets
-// `open`, so the open filter passes it too), so every condition the query
-// matches on is legitimately true of it.
+// dropUnusable splits the population into the accounts a clientsim run can
+// connect as and the ones it cannot, so the caller can report the second set
+// rather than let it vanish.
 //
-// clientsim cannot connect as one either way: bots authenticate over HTTP
-// through pkg/botauth rather than the user JWT path, and a dotted ".bot"
-// account spans subject tokens — subject.UserSubscriptionList panics on it
-// before a request is made.
+// Three kinds are unusable, for one shared reason — the account becomes a NATS
+// subject token:
+//
+//   - Bots. A bot that owns a room holds a genuine channel subscription
+//     (bot-room-service/handler.go:213-216 writes IsBot:true with
+//     RoomTypeChannel, and its $setOnInsert never sets `open`), so every
+//     condition the query matches on is legitimately true of it. clientsim
+//     cannot connect as one either way: bots authenticate over HTTP through
+//     pkg/botauth rather than the user JWT path.
+//   - Anything that is not a valid subject token — a dot, wildcard, whitespace
+//     or control rune. subject.UserSubscriptionList PANICS on one, so a single
+//     such account is not a degraded pod but a dead one. Real sites carry them:
+//     "k6.test-1.user" is a leftover subscription row from another load tool,
+//     with no isBot flag and no ".bot" suffix to mark it as anything else.
+//   - The empty account, which IsValidAccountToken already refuses: it builds
+//     subjects like chat.user..event.room, which subscribe cleanly and receive
+//     nothing.
 //
 // Belt to the query's braces, and not redundant with it: the query keys on the
-// stored u.isBot flag, this keys on the account shape, and a row written
-// without the flag is caught only here. Cheap — the population is already in
-// memory and sorted.
-func dropUnusable(accounts []string) []string {
-	kept := accounts[:0:0]
+// stored u.isBot flag and on the account's shape as a regex, this keys on the
+// same validator the subject builders use — so a row written without the flag,
+// or a rune the regex does not spell out, is caught only here. Cheap — the
+// population is already in memory and sorted.
+func dropUnusable(accounts []string) (kept, skipped []string) {
+	kept = accounts[:0:0]
 	for _, a := range accounts {
-		// An empty account builds subjects like chat.user..event.room, which
-		// subscribe cleanly and receive nothing; poolartifact refuses it too.
-		if a == "" || model.IsBot(a) {
+		if model.IsBot(a) || !subject.IsValidAccountToken(a) {
+			skipped = append(skipped, a)
 			continue
 		}
 		kept = append(kept, a)
 	}
-	return kept
+	return kept, skipped
+}
+
+// unusableAccountPattern is the server-side half of subject.IsValidAccountToken:
+// an account matching it cannot be a NATS subject token. Named rather than
+// inlined so a test can hold the two halves against each other — the pattern
+// and the validator disagreeing is exactly the drift that let "k6.test-1.user"
+// reach poolartifact and fail a whole export.
+//
+// It is deliberately the WEAKER half. Regex \s is the ASCII spaces, while the
+// validator refuses every unicode space and control rune, so the pipeline can
+// let through what the Go belt then removes. Weaker in that direction costs a
+// --limit slot; stronger would drop accounts the pods can serve.
+const unusableAccountPattern = `[.*>\s]`
+
+// skipSample bounds what a log line or an error quotes from a skipped set: a
+// site that churns out thousands of unusable rows must not turn one warning
+// into thousands of lines. The count carries the scale; the sample carries the
+// shape, which is what tells an operator WHICH leftover to clean up.
+const skipSample = 5
+
+func sampleAccounts(accounts []string) []string {
+	if len(accounts) > skipSample {
+		return accounts[:skipSample]
+	}
+	return accounts
 }
 
 // exportPool reads the population, publishes the artifact the fleet consumes
@@ -166,10 +211,18 @@ func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, o
 	if err != nil {
 		return poolExportResult{}, fmt.Errorf("list channel subscribers for %s: %w", opts.SiteID, err)
 	}
-	accounts = dropUnusable(accounts)
+	accounts, skipped := dropUnusable(accounts)
 	// The failure this export exists to prevent: a fleet that starts against
 	// nobody reports a healthy zero. Fail here, in the tool that can say why.
 	if len(accounts) == 0 {
+		if len(skipped) > 0 {
+			// A different failure from an unused site, and a different fix:
+			// these rows exist, they are just unusable. Name them, or the
+			// operator is left guessing which tool left them behind.
+			return poolExportResult{}, fmt.Errorf(
+				"site %q has %d channel subscribers but none usable as a NATS subject token (e.g. %q)",
+				opts.SiteID, len(skipped), sampleAccounts(skipped))
+		}
 		return poolExportResult{}, fmt.Errorf("site %q has no accounts with a channel subscription", opts.SiteID)
 	}
 	if opts.Limit > 0 && len(accounts) > opts.Limit {
@@ -213,7 +266,7 @@ func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, o
 	manifestKey := pub.Key(opts.SiteID, opts.RunID, poolManifestName)
 	if err := pub.PutJSON(ctx, manifestKey, poolManifest{
 		RunID: opts.RunID, SiteID: opts.SiteID, ConfigDigest: digest,
-		Accounts: len(accounts), Limit: opts.Limit,
+		Accounts: len(accounts), SkippedAccounts: len(skipped), Limit: opts.Limit,
 		Query: poolExportQuery, Source: "mongodb",
 		ExportedAt: time.Now().UTC(),
 	}); err != nil {
@@ -236,6 +289,7 @@ func exportPool(ctx context.Context, src poolAccountSource, pub poolPublisher, o
 	return poolExportResult{
 		Accounts: len(accounts), ConfigDigest: digest,
 		ArtifactKey: artifactKey, ManifestKey: manifestKey,
+		Skipped: skipped,
 	}, nil
 }
 
@@ -275,20 +329,24 @@ func (m mongoPoolSource) channelSubscriberAccounts(ctx context.Context, siteID s
 		// $max over the group returns true if ANY row carries the flag.
 		{{Key: "$group", Value: bson.M{"_id": "$u.account", "isBot": bson.M{"$max": "$u.isBot"}}}},
 		{{Key: "$match", Value: bson.M{"isBot": bson.M{"$ne": true}}}},
-		// The ".bot" suffix is excluded HERE too, not only in dropUnusable. The
-		// $limit below bounds whatever reaches it, so a legacy account the
-		// flag never marked would otherwise be counted against --limit and
-		// then dropped in Go — the caller asks for N, the site holds more than
-		// N eligible accounts, and the run still gets fewer. Filtering before
-		// the bound makes the bound mean what it says. dropUnusable stays as the
-		// belt for any other source.
-		// Both exclusions sit before the bound, for one reason: $limit counts
-		// whatever reaches it. An empty account sorts FIRST, so leaving it to
-		// the Go pass lets it consume a --limit slot and then vanish — a site
-		// with eligible accounts reports none. Same for a ".bot" suffix the
-		// flag never marked.
+		// Everything clientsim cannot connect as is excluded HERE too, not only
+		// in dropUnusable, for one reason: the $limit below bounds whatever
+		// reaches it. An account removed afterwards has already consumed a
+		// --limit slot and then vanished — the caller asks for N, the site
+		// holds more than N eligible accounts, and the run still gets fewer.
+		// Filtering before the bound makes the bound mean what it says.
+		//
+		// The regex is the subject-token rule, not a ".bot" rule: any dot,
+		// wildcard or whitespace rune spans or breaks a token, and an account
+		// carrying one panics subject.UserSubscriptionList inside the pod. It
+		// subsumes the ".bot" suffix (a bot account is dotted by construction)
+		// and catches what no flag marks — "k6.test-1.user", left behind by
+		// another load tool, is a real row on a real staging site.
+		// dropUnusable stays as the belt: it runs the validator itself, so a
+		// control rune this pattern does not spell out is still caught, and the
+		// rule holds for any other source.
 		{{Key: "$match", Value: bson.M{
-			"_id": bson.M{"$nin": bson.A{"", nil}, "$not": bson.Regex{Pattern: `\.bot$`}},
+			"_id": bson.M{"$nin": bson.A{"", nil}, "$not": bson.Regex{Pattern: unusableAccountPattern}},
 		}}},
 		{{Key: "$sort", Value: bson.M{"_id": 1}}},
 		// Bound the cursor server-side. cur.All materialises whatever comes
@@ -313,14 +371,11 @@ func (m mongoPoolSource) channelSubscriberAccounts(ctx context.Context, siteID s
 	if err := cur.All(ctx, &rows); err != nil {
 		return nil, fmt.Errorf("read channel subscribers: %w", err)
 	}
+	// Returned as the query selected them, unfiltered: dropUnusable is the one
+	// place that decides what a pod can connect as, so whatever slips past the
+	// pipeline is dropped AND counted there rather than vanishing here.
 	accounts := make([]string, 0, len(rows))
 	for _, r := range rows {
-		// An empty account builds subjects like chat.user..event.room, which
-		// subscribe cleanly and receive nothing. poolartifact.Write refuses
-		// them too; dropping here keeps the count in the manifest honest.
-		if r.Account == "" {
-			continue
-		}
 		accounts = append(accounts, r.Account)
 	}
 	return accounts, nil
@@ -376,8 +431,18 @@ func runPoolExport(ctx context.Context, cfg *config, args []string) int {
 		slog.Error("pool export", "error", err)
 		return 1
 	}
+	if len(res.Skipped) > 0 {
+		// Not an error — one stale row must not block a run the rest of the
+		// site can serve — but not silent either: the day this count stops
+		// being a handful of load-tool leftovers, the pool is quietly shrinking
+		// and the operator has to be able to see it.
+		slog.Warn("skipped accounts that cannot be NATS subject tokens",
+			"siteId", cfg.SiteID, "skipped", len(res.Skipped),
+			"sample", sampleAccounts(res.Skipped))
+	}
 	slog.Info("pool exported",
 		"runId", *runID, "siteId", cfg.SiteID, "accounts", res.Accounts,
+		"skipped", len(res.Skipped),
 		"configDigest", res.ConfigDigest,
 		"artifactKey", res.ArtifactKey, "manifestKey", res.ManifestKey)
 	return 0

--- a/tools/loadgen/poolexport_integration_test.go
+++ b/tools/loadgen/poolexport_integration_test.go
@@ -74,21 +74,19 @@ func TestIntegration_MongoPoolSource_SelectsChannelSubscribers(t *testing.T) {
 	// on: every pod slices the same array, so an unstable one would overlap
 	// or skip accounts across pods.
 	//
-	// legacy.site-a.bot is here on purpose. Bots are excluded at two layers
-	// and this is only the first: the query keys on the stored u.isBot flag,
-	// so it drops x7 and x8 but cannot see x9, whose flag was never written.
-	// Asserting it away here would hide which layer is carrying the rule.
-	// legacy.site-a.bot is gone from the source now: the pipeline excludes the
-	// ".bot" suffix too, because the server-side $limit bounds whatever
-	// reaches it and a bot counted against --limit under-delivers the run.
-	assert.Equal(t, []string{"anna", "bob", "carol"}, got)
+	// The query drops x7 and x8 on the stored u.isBot flag, and mixedbot on
+	// the grouped $max of it; those never leave the server and are the
+	// population's definition, not skipped accounts. legacy.site-a.bot and the
+	// empty account carry no flag, so the cursor walks them — and counts them.
+	assert.Equal(t, []string{"anna", "bob", "carol"}, got.Accounts)
+	assert.Equal(t, 2, got.Skipped)
+	assert.Equal(t, []string{"", "legacy.site-a.bot"}, got.Sample)
 
-	// dropUnusable is now a belt with nothing to remove on this path — which is
-	// the point: it stays for any other source, and composing it must not
-	// change what the Mongo source already returned.
-	kept, skipped := dropUnusable(got)
-	assert.Equal(t, got, kept)
-	assert.Empty(t, skipped)
+	// dropUnusable is the belt, and on this path it must find nothing:
+	// composing it cannot change what the source already returned.
+	kept, beltSkipped := dropUnusable(got.Accounts)
+	assert.Equal(t, got.Accounts, kept)
+	assert.Empty(t, beltSkipped)
 }
 
 // An account with BOTH a Teams room and an ordinary channel is still a valid
@@ -106,7 +104,7 @@ func TestIntegration_MongoPoolSource_KeepsAccountsWithANonTeamsChannel(t *testin
 
 	got, err := mongoPoolSource{db: db}.channelSubscriberAccounts(ctx, "site-a", 0)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"mixed"}, got)
+	assert.Equal(t, []string{"mixed"}, got.Accounts)
 }
 
 // A site with nobody must come back empty rather than erroring, so the caller
@@ -116,7 +114,8 @@ func TestIntegration_MongoPoolSource_EmptySite(t *testing.T) {
 	db := testutil.MongoDB(t, "poolexport-empty")
 	got, err := mongoPoolSource{db: db}.channelSubscriberAccounts(context.Background(), "site-none", 0)
 	require.NoError(t, err)
-	assert.Empty(t, got)
+	assert.Empty(t, got.Accounts)
+	assert.Zero(t, got.Skipped)
 }
 
 // The $limit bounds whatever reaches it, so anything the Go pass would remove
@@ -140,8 +139,9 @@ func TestIntegration_MongoPoolSource_LimitSkipsUnusableAccounts(t *testing.T) {
 
 	got, err := mongoPoolSource{db: db}.channelSubscriberAccounts(ctx, "site-a", 1)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"zoe"}, got,
+	assert.Equal(t, []string{"zoe"}, got.Accounts,
 		"limit=1 must return the first USABLE account, not the first row")
+	assert.Equal(t, 2, got.Skipped, "the two it walked past are counted, not forgotten")
 }
 
 // The failure that motivated this: a staging site holds "k6.test-1.user", a
@@ -150,10 +150,11 @@ func TestIntegration_MongoPoolSource_LimitSkipsUnusableAccounts(t *testing.T) {
 // tokens, so poolartifact refused the artifact and the whole export died on one
 // stale row.
 //
-// The exclusion is in the pipeline, not only in the Go pass, for the reason
-// the empty account and the ".bot" suffix are: $limit bounds whatever reaches
-// it, so an account removed afterwards has already consumed a slot.
-func TestIntegration_MongoPoolSource_ExcludesAccountsThatSpanSubjectTokens(t *testing.T) {
+// The rule runs in Go, on the rows this cursor walks, so the same layer that
+// bounds --limit is the one that counts what it passed over. A regex in the
+// pipeline would filter them where nothing can count them — and would be a
+// second dialect of subject.IsValidAccountToken, evaluated by another engine.
+func TestIntegration_MongoPoolSource_SkipsAndCountsUnusableAccounts(t *testing.T) {
 	db := testutil.MongoDB(t, "poolexporttokens")
 	ctx := context.Background()
 
@@ -166,20 +167,91 @@ func TestIntegration_MongoPoolSource_ExcludesAccountsThatSpanSubjectTokens(t *te
 			"u": bson.M{"account": "wild*card"}},
 		bson.M{"_id": "k4", "siteId": "site-a", "roomType": "channel",
 			"u": bson.M{"account": "tail>token"}},
-		bson.M{"_id": "k5", "siteId": "site-a", "roomType": "channel", "u": bson.M{"account": "anna"}},
-		bson.M{"_id": "k6", "siteId": "site-a", "roomType": "channel", "u": bson.M{"account": "zoe"}},
+		// The two a Mongo-side regex would have missed: \s in a pattern is the
+		// ASCII spaces, and neither engine spells out every control rune.
+		// Here they are just accounts the validator refuses, like any other.
+		bson.M{"_id": "k5", "siteId": "site-a", "roomType": "channel",
+			"u": bson.M{"account": "nbsp\u00a0user"}},
+		bson.M{"_id": "k6", "siteId": "site-a", "roomType": "channel",
+			"u": bson.M{"account": "ctrl\x07user"}},
+		// A row with no account at all: not an account, so not a skipped one.
+		bson.M{"_id": "k7", "siteId": "site-a", "roomType": "channel", "u": bson.M{}},
+		bson.M{"_id": "k8", "siteId": "site-a", "roomType": "channel", "u": bson.M{"account": "anna"}},
+		bson.M{"_id": "k9", "siteId": "site-a", "roomType": "channel", "u": bson.M{"account": "zoe"}},
 	})
 	require.NoError(t, err)
 
 	got, err := mongoPoolSource{db: db}.channelSubscriberAccounts(ctx, "site-a", 0)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"anna", "zoe"}, got)
+	assert.Equal(t, []string{"anna", "zoe"}, got.Accounts)
+	assert.Equal(t, 6, got.Skipped, "every unusable account is counted, whatever kind of rune broke it")
+	assert.Contains(t, got.Sample, "k6.test-1.user")
 
-	// "anna" is the only account before "k6.test-1.user" in sort order, so a
-	// pipeline that leaves the junk in returns it for limit=2 and the Go pass
-	// hands back one account for a --limit of two.
+	// The bound counts usable accounts. All six unusable rows sort between
+	// "anna" and "zoe", so a bound applied to ROWS would stop at "ctrl\x07user"
+	// and hand back one account for a --limit of two.
 	bounded, err := mongoPoolSource{db: db}.channelSubscriberAccounts(ctx, "site-a", 2)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"anna", "zoe"}, bounded,
+	assert.Equal(t, []string{"anna", "zoe"}, bounded.Accounts,
 		"--limit 2 must deliver 2 usable accounts, not 2 rows minus the unusable ones")
+}
+
+// The reviewer's question, asked of the real thing: does what Mongo returns
+// reach the artifact, the result and the manifest consistently? Every unit
+// test above this line runs against a fake source that could agree with a
+// wrong implementation.
+func TestIntegration_ExportPool_FromMongo_PublishesAndAccountsForEverySkip(t *testing.T) {
+	db := testutil.MongoDB(t, "poolexportend2end")
+	ctx := context.Background()
+
+	_, err := db.Collection("subscriptions").InsertMany(ctx, []any{
+		bson.M{"_id": "e1", "siteId": "site-a", "roomType": "channel", "u": bson.M{"account": "anna"}},
+		bson.M{"_id": "e2", "siteId": "site-a", "roomType": "channel", "u": bson.M{"account": "bob"}},
+		bson.M{"_id": "e3", "siteId": "site-a", "roomType": "channel",
+			"u": bson.M{"account": "k6.test-1.user"}},
+		bson.M{"_id": "e4", "siteId": "site-a", "roomType": "channel",
+			"u": bson.M{"account": "weather.site-a.bot", "isBot": true}},
+	})
+	require.NoError(t, err)
+
+	pub := newFakePublisher()
+	res, err := exportPool(ctx, mongoPoolSource{db: db}, pub, poolExportOptions{
+		RunID: "run-1", SiteID: "site-a",
+	})
+	require.NoError(t, err, "one leftover row must not fail an export the rest of the site can serve")
+
+	art := pub.artifacts[res.ArtifactKey]
+	require.NotNil(t, art)
+	assert.Equal(t, []string{"anna", "bob"}, art.Accounts)
+	assert.Equal(t, 2, res.Accounts)
+
+	// The evidence, end to end: the flagged bot never leaves the server, so it
+	// is the query's business and not a skip; "k6.test-1.user" is walked past
+	// by the cursor, counted there, and surfaces in all three places.
+	assert.Equal(t, 1, res.Skipped)
+	assert.Equal(t, []string{"k6.test-1.user"}, res.SkippedSample)
+	man, ok := pub.blobs[res.ManifestKey].(poolManifest)
+	require.True(t, ok)
+	assert.Equal(t, 1, man.SkippedAccounts)
+	assert.Equal(t, 2, man.Accounts)
+}
+
+// A site whose channel subscribers are all leftovers fails — and names one, so
+// the operator knows it is junk data to clean rather than a site nobody uses.
+func TestIntegration_ExportPool_FromMongo_FailsNamingAnUnusableSite(t *testing.T) {
+	db := testutil.MongoDB(t, "poolexportjunk")
+	ctx := context.Background()
+	_, err := db.Collection("subscriptions").InsertMany(ctx, []any{
+		bson.M{"_id": "j1", "siteId": "site-a", "roomType": "channel",
+			"u": bson.M{"account": "k6.test-1.user"}},
+		bson.M{"_id": "j2", "siteId": "site-a", "roomType": "channel",
+			"u": bson.M{"account": "k6.test-2.user"}},
+	})
+	require.NoError(t, err)
+
+	_, err = exportPool(ctx, mongoPoolSource{db: db}, newFakePublisher(), poolExportOptions{
+		RunID: "run-1", SiteID: "site-a",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "k6.test-1.user")
 }

--- a/tools/loadgen/poolexport_integration_test.go
+++ b/tools/loadgen/poolexport_integration_test.go
@@ -86,7 +86,9 @@ func TestIntegration_MongoPoolSource_SelectsChannelSubscribers(t *testing.T) {
 	// dropUnusable is now a belt with nothing to remove on this path — which is
 	// the point: it stays for any other source, and composing it must not
 	// change what the Mongo source already returned.
-	assert.Equal(t, got, dropUnusable(got))
+	kept, skipped := dropUnusable(got)
+	assert.Equal(t, got, kept)
+	assert.Empty(t, skipped)
 }
 
 // An account with BOTH a Teams room and an ordinary channel is still a valid
@@ -140,4 +142,44 @@ func TestIntegration_MongoPoolSource_LimitSkipsUnusableAccounts(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"zoe"}, got,
 		"limit=1 must return the first USABLE account, not the first row")
+}
+
+// The failure that motivated this: a staging site holds "k6.test-1.user", a
+// leftover subscription row from another load tool. No isBot flag, no ".bot"
+// suffix — nothing marks it as anything but a user — but its dots span subject
+// tokens, so poolartifact refused the artifact and the whole export died on one
+// stale row.
+//
+// The exclusion is in the pipeline, not only in the Go pass, for the reason
+// the empty account and the ".bot" suffix are: $limit bounds whatever reaches
+// it, so an account removed afterwards has already consumed a slot.
+func TestIntegration_MongoPoolSource_ExcludesAccountsThatSpanSubjectTokens(t *testing.T) {
+	db := testutil.MongoDB(t, "poolexporttokens")
+	ctx := context.Background()
+
+	_, err := db.Collection("subscriptions").InsertMany(ctx, []any{
+		bson.M{"_id": "k1", "siteId": "site-a", "roomType": "channel",
+			"u": bson.M{"account": "k6.test-1.user"}},
+		bson.M{"_id": "k2", "siteId": "site-a", "roomType": "channel",
+			"u": bson.M{"account": "has space"}},
+		bson.M{"_id": "k3", "siteId": "site-a", "roomType": "channel",
+			"u": bson.M{"account": "wild*card"}},
+		bson.M{"_id": "k4", "siteId": "site-a", "roomType": "channel",
+			"u": bson.M{"account": "tail>token"}},
+		bson.M{"_id": "k5", "siteId": "site-a", "roomType": "channel", "u": bson.M{"account": "anna"}},
+		bson.M{"_id": "k6", "siteId": "site-a", "roomType": "channel", "u": bson.M{"account": "zoe"}},
+	})
+	require.NoError(t, err)
+
+	got, err := mongoPoolSource{db: db}.channelSubscriberAccounts(ctx, "site-a", 0)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"anna", "zoe"}, got)
+
+	// "anna" is the only account before "k6.test-1.user" in sort order, so a
+	// pipeline that leaves the junk in returns it for limit=2 and the Go pass
+	// hands back one account for a --limit of two.
+	bounded, err := mongoPoolSource{db: db}.channelSubscriberAccounts(ctx, "site-a", 2)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"anna", "zoe"}, bounded,
+		"--limit 2 must deliver 2 usable accounts, not 2 rows minus the unusable ones")
 }

--- a/tools/loadgen/poolexport_integration_test.go
+++ b/tools/loadgen/poolexport_integration_test.go
@@ -80,7 +80,8 @@ func TestIntegration_MongoPoolSource_SelectsChannelSubscribers(t *testing.T) {
 	// empty account carry no flag, so the cursor walks them — and counts them.
 	assert.Equal(t, []string{"anna", "bob", "carol"}, got.Accounts)
 	assert.Equal(t, 2, got.Skipped)
-	assert.Equal(t, []string{"", "legacy.site-a.bot"}, got.Sample)
+	assert.Equal(t, []string{"legacy.site-a.bot"}, got.Sample,
+		"the empty account is counted, but naming it would tell an operator nothing")
 
 	// dropUnusable is the belt, and on this path it must find nothing:
 	// composing it cannot change what the source already returned.
@@ -174,7 +175,9 @@ func TestIntegration_MongoPoolSource_SkipsAndCountsUnusableAccounts(t *testing.T
 			"u": bson.M{"account": "nbsp\u00a0user"}},
 		bson.M{"_id": "k6", "siteId": "site-a", "roomType": "channel",
 			"u": bson.M{"account": "ctrl\x07user"}},
-		// A row with no account at all: not an account, so not a skipped one.
+		// A row with no account at all. It groups under null, which the walk
+		// reads as a candidate it cannot connect as — counted like the rest
+		// rather than filtered where nothing could count it.
 		bson.M{"_id": "k7", "siteId": "site-a", "roomType": "channel", "u": bson.M{}},
 		bson.M{"_id": "k8", "siteId": "site-a", "roomType": "channel", "u": bson.M{"account": "anna"}},
 		bson.M{"_id": "k9", "siteId": "site-a", "roomType": "channel", "u": bson.M{"account": "zoe"}},
@@ -184,7 +187,8 @@ func TestIntegration_MongoPoolSource_SkipsAndCountsUnusableAccounts(t *testing.T
 	got, err := mongoPoolSource{db: db}.channelSubscriberAccounts(ctx, "site-a", 0)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"anna", "zoe"}, got.Accounts)
-	assert.Equal(t, 6, got.Skipped, "every unusable account is counted, whatever kind of rune broke it")
+	assert.Equal(t, 7, got.Skipped,
+		"every unusable candidate is counted — every rune class, and the row with no account at all")
 	assert.Contains(t, got.Sample, "k6.test-1.user")
 
 	// The bound counts usable accounts. All six unusable rows sort between

--- a/tools/loadgen/poolexport_test.go
+++ b/tools/loadgen/poolexport_test.go
@@ -45,7 +45,11 @@ func (f *fakeAccountSource) channelSubscriberAccounts(_ context.Context, siteID 
 	if n := cursorLimit(limit); len(kept) > n {
 		kept = kept[:n]
 	}
-	return poolCandidates{Accounts: kept, Skipped: len(skipped), Sample: sampleAccounts(skipped)}, nil
+	var sample []string
+	for _, a := range skipped {
+		sample = appendSkipSample(sample, a)
+	}
+	return poolCandidates{Accounts: kept, Skipped: len(skipped), Sample: sample}, nil
 }
 
 type fakePublisher struct {
@@ -382,8 +386,8 @@ func TestExportPool_ReportsWhatItSkipped(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 3, res.Skipped, "every dropped account is counted, whatever disqualified it")
-	assert.Equal(t, []string{"k6.test-1.user", "weather.site-a.bot", ""}, res.SkippedSample,
-		"and quoted, so an operator knows which leftover to clean up")
+	assert.Equal(t, []string{"k6.test-1.user", "weather.site-a.bot"}, res.SkippedSample,
+		"and the ones worth quoting are quoted — an empty account names no leftover to clean up")
 
 	man, ok := pub.blobs["site-a/run-1/pool-manifest.json"].(poolManifest)
 	require.True(t, ok)
@@ -422,16 +426,19 @@ func TestExportPool_LimitIsHonouredWhenAnUnusableAccountSitsInTheHead(t *testing
 	assert.Equal(t, []string{"aaa", "ccc", "ddd"}, pub.artifacts[res.ArtifactKey].Accounts)
 }
 
-// The sample is what an operator acts on, and the cap is what keeps one bad
-// site from turning a warning into a wall of names. Both halves matter: a cap
-// that also truncated a short list would hide the only account there was.
-func TestSampleAccounts_CapsWithoutTruncatingShortLists(t *testing.T) {
-	short := []string{"a", "b"}
-	assert.Equal(t, short, sampleAccounts(short))
+// The sample is what an operator acts on, and its cap is what keeps one bad
+// site from turning a warning into a wall of names. The blank is the third
+// rule: it sorts first, so quoting it would cost a slot and say nothing.
+func TestAppendSkipSample(t *testing.T) {
+	var sample []string
+	for _, a := range []string{"", "k6.test-1.user", "", "has space"} {
+		sample = appendSkipSample(sample, a)
+	}
+	assert.Equal(t, []string{"k6.test-1.user", "has space"}, sample)
 
-	long := []string{"a", "b", "c", "d", "e", "f", "g"}
-	assert.Equal(t, []string{"a", "b", "c", "d", "e"}, sampleAccounts(long))
-	assert.Len(t, long, 7, "sampling must not modify the caller's slice")
+	full := []string{"a", "b", "c", "d", "e"}
+	assert.Equal(t, full, appendSkipSample(full, "f"), "the cap holds")
+	assert.Len(t, full, skipSample, "and does not grow the caller's slice")
 }
 
 // The belt's job, stated as a test: a source that hands over unusable accounts
@@ -465,7 +472,8 @@ func TestExportPool_SumsSkipsFromBothLayers(t *testing.T) {
 	res, err := exportPool(context.Background(), src, pub, poolExportOptions{RunID: "run-1", SiteID: "site-a"})
 	require.NoError(t, err)
 	assert.Equal(t, 2, res.Skipped, "the source's count and the belt's must both be in it")
-	assert.Equal(t, []string{"k6.test-1.user", "k6.test-2.user"}, res.SkippedSample)
+	assert.Equal(t, []string{"k6.test-2.user", "k6.test-1.user"}, res.SkippedSample,
+		"the belt's catch leads: it is the one the source did not report, so a full source sample must not crowd it out")
 	assert.Equal(t, 2, pub.blobs[res.ManifestKey].(poolManifest).SkippedAccounts)
 }
 
@@ -501,15 +509,26 @@ func TestLogSkippedAccounts(t *testing.T) {
 }
 
 // fakeRows is a cursor over a fixed, sorted candidate list — what the
-// aggregation hands the walk, without a database.
+// aggregation hands the walk, without a database. Accounts are pointers
+// because the real cursor yields null for a row whose u.account is absent,
+// and how the walk treats that is part of what these tests pin.
 type fakeRows struct {
-	accounts  []string
+	accounts  []*string
 	i         int
 	decodeErr error
 	err       error
 	// stopped records how far the walk read, which is the whole point of
 	// bounding client-side: the rest of the population is never transferred.
 	stopped int
+}
+
+// accts builds a row list of present accounts. A null row is appended as nil.
+func accts(names ...string) []*string {
+	out := make([]*string, len(names))
+	for i := range names {
+		out[i] = &names[i]
+	}
+	return out
 }
 
 func (f *fakeRows) Next(context.Context) bool {
@@ -526,7 +545,7 @@ func (f *fakeRows) Decode(v any) error {
 		return f.decodeErr
 	}
 	row, ok := v.(*struct {
-		Account string `bson:"_id"`
+		Account *string `bson:"_id"`
 	})
 	if !ok {
 		return fmt.Errorf("unexpected decode target %T", v)
@@ -542,7 +561,7 @@ func (f *fakeRows) Err() error { return f.err }
 // head holds leftovers, and hands back fewer accounts than asked while
 // eligible ones sit unread.
 func TestCollectUsableAccounts_BoundsOnUsableAccountsNotRows(t *testing.T) {
-	rows := &fakeRows{accounts: []string{"anna", "k6.test-1.user", "has space", "bob", "cleo", "dave"}}
+	rows := &fakeRows{accounts: accts("anna", "k6.test-1.user", "has space", "bob", "cleo", "dave")}
 
 	got, err := collectUsableAccounts(context.Background(), rows, 3)
 	require.NoError(t, err)
@@ -556,28 +575,69 @@ func TestCollectUsableAccounts_BoundsOnUsableAccountsNotRows(t *testing.T) {
 // spells out the same way in two engines — which is why the rule lives here
 // rather than in the aggregation.
 func TestCollectUsableAccounts_SkipsEveryUnusableShape(t *testing.T) {
-	rows := &fakeRows{accounts: []string{
-		"", "anna", "ctrl\x07name", "has space", "k6.test-1.user", "nbsp name",
-		"tail>token", "weather.site-a.bot", "wild*card",
-	}}
+	rows := &fakeRows{accounts: append(
+		// A blank account, then a row with no account at all (null).
+		append(accts(""), nil),
+		accts("anna", "ctrl\x07name", "has space", "k6.test-1.user", "nbsp name",
+			"tail>token", "weather.site-a.bot", "wild*card")...,
+	)}
 
 	got, err := collectUsableAccounts(context.Background(), rows, 100)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"anna"}, got.Accounts)
-	assert.Equal(t, 8, got.Skipped)
+	assert.Equal(t, 9, got.Skipped,
+		"the blank and the null row are candidates a run cannot connect as, like every other")
 	assert.Len(t, got.Sample, skipSample, "the sample is capped; the count carries the scale")
+	assert.NotContains(t, got.Sample, "", "and holds only names an operator can act on")
 }
 
 // A cursor that fails mid-walk must not look like a small population: an
 // export built on a truncated read would publish a pool nobody selected.
 func TestCollectUsableAccounts_PropagatesCursorErrors(t *testing.T) {
 	_, err := collectUsableAccounts(context.Background(),
-		&fakeRows{accounts: []string{"anna"}, err: errors.New("connection reset")}, 10)
+		&fakeRows{accounts: accts("anna"), err: errors.New("connection reset")}, 10)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "read channel subscribers")
 
 	_, err = collectUsableAccounts(context.Background(),
-		&fakeRows{accounts: []string{"anna"}, decodeErr: errors.New("type mismatch")}, 10)
+		&fakeRows{accounts: accts("anna"), decodeErr: errors.New("type mismatch")}, 10)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "decode channel subscriber")
+}
+
+// What the evidence claims, pinned: a bounded export counts what it walked
+// past on the way to the bound, not the site. Junk sorting after the last
+// account taken is never read — and the alternative, walking on to total it,
+// would turn the caller's --limit into a full census of every run.
+func TestCollectUsableAccounts_CountsOnlyWhatTheBoundLetItSee(t *testing.T) {
+	rows := &fakeRows{accounts: accts("anna", "bob", "k6.test-1.user", "k6.test-2.user")}
+
+	got, err := collectUsableAccounts(context.Background(), rows, 2)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"anna", "bob"}, got.Accounts)
+	assert.Zero(t, got.Skipped, "the two leftovers sort after the bound and were never read")
+	assert.Equal(t, 2, rows.stopped)
+
+	// The same site, unbounded: now the count is the site's.
+	all, err := collectUsableAccounts(context.Background(),
+		&fakeRows{accounts: accts("anna", "bob", "k6.test-1.user", "k6.test-2.user")}, 100)
+	require.NoError(t, err)
+	assert.Equal(t, 2, all.Skipped)
+}
+
+// The cap and the precedence together: a source that already filled the sample
+// must not be able to hide the accounts its own filtering missed.
+func TestExportPool_BeltNamesKeepTheirSampleSlotsAgainstAFullSourceSample(t *testing.T) {
+	src := &countingSource{
+		accounts: []string{"anna", "k6.belt-1.user", "k6.belt-2.user"},
+		skipped:  5,
+		sample:   []string{"src-1.user", "src-2.user", "src-3.user", "src-4.user", "src-5.user"},
+	}
+	pub := newFakePublisher()
+
+	res, err := exportPool(context.Background(), src, pub, poolExportOptions{RunID: "run-1", SiteID: "site-a"})
+	require.NoError(t, err)
+	assert.Equal(t, 7, res.Skipped)
+	assert.Equal(t, []string{"k6.belt-1.user", "k6.belt-2.user", "src-1.user", "src-2.user", "src-3.user"},
+		res.SkippedSample)
 }

--- a/tools/loadgen/poolexport_test.go
+++ b/tools/loadgen/poolexport_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hmchangw/chat/pkg/poolartifact"
+	"github.com/hmchangw/chat/pkg/subject"
 )
 
 type fakeAccountSource struct {
@@ -17,6 +19,12 @@ type fakeAccountSource struct {
 	accounts []string
 	err      error
 	gotSite  string
+	// raw models a source that does NOT filter for itself — the case the Go
+	// belt exists for. The Mongo source excludes unusable accounts in the
+	// pipeline, so on that path the belt has nothing left to remove and
+	// nothing to report; a test about what the belt catches has to come from
+	// a source that hands it something.
+	raw bool
 }
 
 // channelSubscriberAccounts mirrors the pipeline: bots are excluded BEFORE the
@@ -28,7 +36,10 @@ func (f *fakeAccountSource) channelSubscriberAccounts(_ context.Context, siteID 
 	if f.err != nil {
 		return nil, f.err
 	}
-	out := dropUnusable(f.accounts)
+	out := f.accounts
+	if !f.raw {
+		out, _ = dropUnusable(out)
+	}
 	if n := cursorLimit(limit); len(out) > n {
 		out = out[:n]
 	}
@@ -328,4 +339,116 @@ func TestPoolExportQuery_DescribesThePipelineItRuns(t *testing.T) {
 	assert.Contains(t, poolExportQuery, "group", "the exclusion runs after the group; the record must say so")
 	assert.NotContains(t, poolExportQuery, `u.isBot: {$ne: true}} ->`,
 		"that shape claims the flag is filtered on rows before dedup, which is the bug this pipeline fixed")
+}
+
+// The staging population holds leftovers from other load tools —
+// "k6.test-1.user" is a real one. Nothing about it is a bot: no isBot flag, no
+// ".bot" suffix. Its dots still span subject tokens, so it reached
+// poolartifact's validator and failed the WHOLE export: one stale row from a
+// tool nobody is running any more blocks every run against that site. It is
+// the same class as an empty account or a bot — an account clientsim cannot
+// connect as — and belongs in the same drop.
+func TestExportPool_DropsAccountsThatCannotBeSubjectTokens(t *testing.T) {
+	src := &fakeAccountSource{raw: true, accounts: []string{
+		"anna", "k6.test-1.user", "bob", "has space", "wild*card", "tail>token", "ctrl\x07name",
+	}}
+	pub := newFakePublisher()
+
+	res, err := exportPool(context.Background(), src, pub, poolExportOptions{
+		RunID: "run-1", SiteID: "site-a",
+	})
+	require.NoError(t, err, "one unusable account must not fail an export the rest of the site can serve")
+
+	art := pub.artifacts["site-a/run-1/pool.json.gz"]
+	require.NotNil(t, art)
+	assert.Equal(t, []string{"anna", "bob"}, art.Accounts)
+	assert.Equal(t, 2, res.Accounts)
+}
+
+// Skipping quietly is the other way to be wrong: the day the count goes from
+// one stale k6 row to the whole site, the operator has to be able to see it.
+// The export reports what it dropped so the caller can say so.
+func TestExportPool_ReportsWhatItSkipped(t *testing.T) {
+	src := &fakeAccountSource{raw: true, accounts: []string{"anna", "k6.test-1.user", "weather.site-a.bot", ""}}
+	pub := newFakePublisher()
+
+	res, err := exportPool(context.Background(), src, pub, poolExportOptions{
+		RunID: "run-1", SiteID: "site-a",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"k6.test-1.user", "weather.site-a.bot", ""}, res.Skipped,
+		"every dropped account is reported, whatever disqualified it")
+
+	man, ok := pub.blobs["site-a/run-1/pool-manifest.json"].(poolManifest)
+	require.True(t, ok)
+	assert.Equal(t, 3, man.SkippedAccounts,
+		"the manifest records the gap between the rows read and the accounts published")
+}
+
+// A site whose channel subscribers are ALL unusable is empty for clientsim,
+// and must fail — but not with the same bare "no accounts" as a site with no
+// subscriptions at all. The two need different fixes: one is a load-tool
+// leftover to clean up, the other is a site nobody uses.
+func TestExportPool_RejectsAPopulationOfOnlyUnusableAccounts(t *testing.T) {
+	src := &fakeAccountSource{raw: true, accounts: []string{"k6.test-1.user", "k6.test-2.user"}}
+
+	_, err := exportPool(context.Background(), src, newFakePublisher(), poolExportOptions{
+		RunID: "run-1", SiteID: "site-a",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "k6.test-1.user",
+		"an export that drops everything must name what it dropped")
+}
+
+// The same ordering rule the bot and the empty account already proved: $limit
+// bounds whatever reaches it, so an unusable account excluded only in Go
+// consumes a slot and then vanishes. "k6.test-1.user" sorts among the k's, so
+// this is not hypothetical on a site whose names run past it.
+func TestExportPool_LimitIsHonouredWhenAnUnusableAccountSitsInTheHead(t *testing.T) {
+	src := &fakeAccountSource{accounts: []string{"aaa", "bbb.test.user", "ccc", "ddd", "eee"}}
+	pub := newFakePublisher()
+
+	res, err := exportPool(context.Background(), src, pub, poolExportOptions{
+		RunID: "run-1", SiteID: "site-a", Limit: 3,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, res.Accounts)
+	assert.Equal(t, []string{"aaa", "ccc", "ddd"}, pub.artifacts[res.ArtifactKey].Accounts)
+}
+
+// The pipeline and the Go belt encode the same rule in two languages: a regex
+// Mongo evaluates, and the validator the subject builders use. They must agree
+// on every account either can see, or the layer that is wrong decides — and
+// which one that is depends on where the account came from.
+func TestUnusableAccountPattern_AgreesWithTheSubjectValidator(t *testing.T) {
+	re := regexp.MustCompile(unusableAccountPattern)
+
+	for _, account := range []string{
+		"anna", "p_admin", "user-1", "UPPER", "ac.count", "k6.test-1.user",
+		"weather.site-a.bot", "has space", "wild*card", "tail>token", "tab\tname",
+	} {
+		assert.Equal(t, !subject.IsValidAccountToken(account), re.MatchString(account),
+			"account %q must be judged the same by the pipeline regex and the validator", account)
+	}
+
+	// The one asymmetry, stated so it cannot be mistaken for a bug: the regex
+	// is the weaker half, so these reach the Go belt and are dropped there.
+	// Weaker in this direction costs a --limit slot; stronger would drop
+	// accounts the pods can serve.
+	for _, account := range []string{"ctrl\x07name", "nbsp\u00a0name"} {
+		assert.False(t, subject.IsValidAccountToken(account), "%q is not a usable account", account)
+		assert.False(t, re.MatchString(account), "%q is the belt's to catch, not the pipeline's", account)
+	}
+}
+
+// The sample is what an operator acts on, and the cap is what keeps one bad
+// site from turning a warning into a wall of names. Both halves matter: a cap
+// that also truncated a short list would hide the only account there was.
+func TestSampleAccounts_CapsWithoutTruncatingShortLists(t *testing.T) {
+	short := []string{"a", "b"}
+	assert.Equal(t, short, sampleAccounts(short))
+
+	long := []string{"a", "b", "c", "d", "e", "f", "g"}
+	assert.Equal(t, []string{"a", "b", "c", "d", "e"}, sampleAccounts(long))
+	assert.Len(t, long, 7, "sampling must not modify the caller's slice")
 }

--- a/tools/loadgen/poolexport_test.go
+++ b/tools/loadgen/poolexport_test.go
@@ -1,17 +1,17 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hmchangw/chat/pkg/poolartifact"
-	"github.com/hmchangw/chat/pkg/subject"
 )
 
 type fakeAccountSource struct {
@@ -19,31 +19,33 @@ type fakeAccountSource struct {
 	accounts []string
 	err      error
 	gotSite  string
-	// raw models a source that does NOT filter for itself — the case the Go
-	// belt exists for. The Mongo source excludes unusable accounts in the
-	// pipeline, so on that path the belt has nothing left to remove and
-	// nothing to report; a test about what the belt catches has to come from
-	// a source that hands it something.
+	// raw models a source that neither filters nor reports — the case the belt
+	// under it exists for. The Mongo source does both, so on that path the
+	// belt finds nothing; a test about what the belt catches needs a source
+	// that hands it something.
 	raw bool
 }
 
-// channelSubscriberAccounts mirrors the pipeline: bots are excluded BEFORE the
-// bound, so the bound counts only accounts that survive to the artifact. A fake
-// that ignored the bound would make every test about it vacuous.
-func (f *fakeAccountSource) channelSubscriberAccounts(_ context.Context, siteID string, limit int) ([]string, error) {
+// channelSubscriberAccounts mirrors the real source: it applies the usability
+// rule, bounds on what SURVIVES it, and reports what it dropped. A fake that
+// filtered without reporting would make every test about the skip evidence
+// pass while production reported nothing — the defect this contract exists to
+// prevent.
+func (f *fakeAccountSource) channelSubscriberAccounts(_ context.Context, siteID string, limit int) (poolCandidates, error) {
 	f.gotSite = siteID
 	f.gotLimit = limit
 	if f.err != nil {
-		return nil, f.err
+		return poolCandidates{}, f.err
 	}
-	out := f.accounts
-	if !f.raw {
-		out, _ = dropUnusable(out)
+	if f.raw {
+		// A source that does none of it, which is what the belt is for.
+		return poolCandidates{Accounts: f.accounts}, nil
 	}
-	if n := cursorLimit(limit); len(out) > n {
-		out = out[:n]
+	kept, skipped := dropUnusable(f.accounts)
+	if n := cursorLimit(limit); len(kept) > n {
+		kept = kept[:n]
 	}
-	return out, nil
+	return poolCandidates{Accounts: kept, Skipped: len(skipped), Sample: sampleAccounts(skipped)}, nil
 }
 
 type fakePublisher struct {
@@ -244,7 +246,8 @@ func TestExportPool_RejectsAPopulationOfOnlyBots(t *testing.T) {
 		RunID: "run-1", SiteID: "site-a",
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no accounts")
+	assert.Contains(t, err.Error(), "none a clientsim run can connect as")
+	assert.Contains(t, err.Error(), "weather.site-a.bot", "the failure must name what it dropped")
 }
 
 // --run-id was validated as a single path segment; siteId, its immediate
@@ -339,6 +342,8 @@ func TestPoolExportQuery_DescribesThePipelineItRuns(t *testing.T) {
 	assert.Contains(t, poolExportQuery, "group", "the exclusion runs after the group; the record must say so")
 	assert.NotContains(t, poolExportQuery, `u.isBot: {$ne: true}} ->`,
 		"that shape claims the flag is filtered on rows before dedup, which is the bug this pipeline fixed")
+	assert.Contains(t, poolExportQuery, "usable",
+		"the bound applies to usable accounts, and the record has to say which selection produced the pool")
 }
 
 // The staging population holds leftovers from other load tools —
@@ -369,15 +374,16 @@ func TestExportPool_DropsAccountsThatCannotBeSubjectTokens(t *testing.T) {
 // one stale k6 row to the whole site, the operator has to be able to see it.
 // The export reports what it dropped so the caller can say so.
 func TestExportPool_ReportsWhatItSkipped(t *testing.T) {
-	src := &fakeAccountSource{raw: true, accounts: []string{"anna", "k6.test-1.user", "weather.site-a.bot", ""}}
+	src := &fakeAccountSource{accounts: []string{"anna", "k6.test-1.user", "weather.site-a.bot", ""}}
 	pub := newFakePublisher()
 
 	res, err := exportPool(context.Background(), src, pub, poolExportOptions{
 		RunID: "run-1", SiteID: "site-a",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, []string{"k6.test-1.user", "weather.site-a.bot", ""}, res.Skipped,
-		"every dropped account is reported, whatever disqualified it")
+	assert.Equal(t, 3, res.Skipped, "every dropped account is counted, whatever disqualified it")
+	assert.Equal(t, []string{"k6.test-1.user", "weather.site-a.bot", ""}, res.SkippedSample,
+		"and quoted, so an operator knows which leftover to clean up")
 
 	man, ok := pub.blobs["site-a/run-1/pool-manifest.json"].(poolManifest)
 	require.True(t, ok)
@@ -390,7 +396,7 @@ func TestExportPool_ReportsWhatItSkipped(t *testing.T) {
 // subscriptions at all. The two need different fixes: one is a load-tool
 // leftover to clean up, the other is a site nobody uses.
 func TestExportPool_RejectsAPopulationOfOnlyUnusableAccounts(t *testing.T) {
-	src := &fakeAccountSource{raw: true, accounts: []string{"k6.test-1.user", "k6.test-2.user"}}
+	src := &fakeAccountSource{accounts: []string{"k6.test-1.user", "k6.test-2.user"}}
 
 	_, err := exportPool(context.Background(), src, newFakePublisher(), poolExportOptions{
 		RunID: "run-1", SiteID: "site-a",
@@ -416,31 +422,6 @@ func TestExportPool_LimitIsHonouredWhenAnUnusableAccountSitsInTheHead(t *testing
 	assert.Equal(t, []string{"aaa", "ccc", "ddd"}, pub.artifacts[res.ArtifactKey].Accounts)
 }
 
-// The pipeline and the Go belt encode the same rule in two languages: a regex
-// Mongo evaluates, and the validator the subject builders use. They must agree
-// on every account either can see, or the layer that is wrong decides — and
-// which one that is depends on where the account came from.
-func TestUnusableAccountPattern_AgreesWithTheSubjectValidator(t *testing.T) {
-	re := regexp.MustCompile(unusableAccountPattern)
-
-	for _, account := range []string{
-		"anna", "p_admin", "user-1", "UPPER", "ac.count", "k6.test-1.user",
-		"weather.site-a.bot", "has space", "wild*card", "tail>token", "tab\tname",
-	} {
-		assert.Equal(t, !subject.IsValidAccountToken(account), re.MatchString(account),
-			"account %q must be judged the same by the pipeline regex and the validator", account)
-	}
-
-	// The one asymmetry, stated so it cannot be mistaken for a bug: the regex
-	// is the weaker half, so these reach the Go belt and are dropped there.
-	// Weaker in this direction costs a --limit slot; stronger would drop
-	// accounts the pods can serve.
-	for _, account := range []string{"ctrl\x07name", "nbsp\u00a0name"} {
-		assert.False(t, subject.IsValidAccountToken(account), "%q is not a usable account", account)
-		assert.False(t, re.MatchString(account), "%q is the belt's to catch, not the pipeline's", account)
-	}
-}
-
 // The sample is what an operator acts on, and the cap is what keeps one bad
 // site from turning a warning into a wall of names. Both halves matter: a cap
 // that also truncated a short list would hide the only account there was.
@@ -451,4 +432,152 @@ func TestSampleAccounts_CapsWithoutTruncatingShortLists(t *testing.T) {
 	long := []string{"a", "b", "c", "d", "e", "f", "g"}
 	assert.Equal(t, []string{"a", "b", "c", "d", "e"}, sampleAccounts(long))
 	assert.Len(t, long, 7, "sampling must not modify the caller's slice")
+}
+
+// The belt's job, stated as a test: a source that hands over unusable accounts
+// without saying so must not be able to make the export lie. Whatever the belt
+// removes is added to the same count and sample the source contributes to.
+func TestExportPool_CountsWhatTheBeltCatchesFromAnUnreportingSource(t *testing.T) {
+	src := &fakeAccountSource{raw: true, accounts: []string{"anna", "k6.test-1.user", "bob"}}
+	pub := newFakePublisher()
+
+	res, err := exportPool(context.Background(), src, pub, poolExportOptions{
+		RunID: "run-1", SiteID: "site-a",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"anna", "bob"}, pub.artifacts[res.ArtifactKey].Accounts)
+	assert.Equal(t, 1, res.Skipped)
+	assert.Equal(t, []string{"k6.test-1.user"}, res.SkippedSample)
+
+	man := pub.blobs[res.ManifestKey].(poolManifest)
+	assert.Equal(t, 1, man.SkippedAccounts)
+}
+
+// Both layers can skip in the same export: the source drops what it saw while
+// bounding, the belt drops what the source let through. The count is the sum,
+// or one of them is invisible.
+func TestExportPool_SumsSkipsFromBothLayers(t *testing.T) {
+	// A source that reports one skip of its own, then hands over an account it
+	// did not check.
+	src := &countingSource{accounts: []string{"anna", "k6.test-2.user"}, skipped: 1, sample: []string{"k6.test-1.user"}}
+	pub := newFakePublisher()
+
+	res, err := exportPool(context.Background(), src, pub, poolExportOptions{RunID: "run-1", SiteID: "site-a"})
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.Skipped, "the source's count and the belt's must both be in it")
+	assert.Equal(t, []string{"k6.test-1.user", "k6.test-2.user"}, res.SkippedSample)
+	assert.Equal(t, 2, pub.blobs[res.ManifestKey].(poolManifest).SkippedAccounts)
+}
+
+type countingSource struct {
+	accounts []string
+	skipped  int
+	sample   []string
+}
+
+func (c *countingSource) channelSubscriberAccounts(_ context.Context, _ string, _ int) (poolCandidates, error) {
+	return poolCandidates{Accounts: c.accounts, Skipped: c.skipped, Sample: c.sample}, nil
+}
+
+// The WARN is the only place an operator sees the leftovers before the run
+// starts, so it is worth pinning: it fires when something was skipped, carries
+// the count and the sample, and stays quiet when nothing was.
+func TestLogSkippedAccounts(t *testing.T) {
+	capture := func(skipped int, sample []string) string {
+		var buf bytes.Buffer
+		prev := slog.Default()
+		slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+		t.Cleanup(func() { slog.SetDefault(prev) })
+		logSkippedAccounts("site-a", skipped, sample)
+		return buf.String()
+	}
+
+	line := capture(2, []string{"k6.test-1.user", ""})
+	assert.Contains(t, line, `"level":"WARN"`)
+	assert.Contains(t, line, `"skipped":2`)
+	assert.Contains(t, line, "k6.test-1.user", "the sample is what tells an operator which leftover to clean up")
+
+	assert.Empty(t, capture(0, nil), "an export that skipped nothing must not warn about it")
+}
+
+// fakeRows is a cursor over a fixed, sorted candidate list — what the
+// aggregation hands the walk, without a database.
+type fakeRows struct {
+	accounts  []string
+	i         int
+	decodeErr error
+	err       error
+	// stopped records how far the walk read, which is the whole point of
+	// bounding client-side: the rest of the population is never transferred.
+	stopped int
+}
+
+func (f *fakeRows) Next(context.Context) bool {
+	if f.i >= len(f.accounts) {
+		return false
+	}
+	f.i++
+	f.stopped = f.i
+	return true
+}
+
+func (f *fakeRows) Decode(v any) error {
+	if f.decodeErr != nil {
+		return f.decodeErr
+	}
+	row, ok := v.(*struct {
+		Account string `bson:"_id"`
+	})
+	if !ok {
+		return fmt.Errorf("unexpected decode target %T", v)
+	}
+	row.Account = f.accounts[f.i-1]
+	return nil
+}
+
+func (f *fakeRows) Err() error { return f.err }
+
+// The bound counts accounts a run can CONNECT AS. A bound applied to rows —
+// which is what a server-side $limit does — stops early on a site whose sorted
+// head holds leftovers, and hands back fewer accounts than asked while
+// eligible ones sit unread.
+func TestCollectUsableAccounts_BoundsOnUsableAccountsNotRows(t *testing.T) {
+	rows := &fakeRows{accounts: []string{"anna", "k6.test-1.user", "has space", "bob", "cleo", "dave"}}
+
+	got, err := collectUsableAccounts(context.Background(), rows, 3)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"anna", "bob", "cleo"}, got.Accounts, "--limit 3 must deliver 3 usable accounts")
+	assert.Equal(t, 2, got.Skipped)
+	assert.Equal(t, []string{"k6.test-1.user", "has space"}, got.Sample)
+	assert.Equal(t, 5, rows.stopped, "the walk stops at the bound rather than reading the whole site")
+}
+
+// Every rune class the validator refuses, including the two no practical regex
+// spells out the same way in two engines — which is why the rule lives here
+// rather than in the aggregation.
+func TestCollectUsableAccounts_SkipsEveryUnusableShape(t *testing.T) {
+	rows := &fakeRows{accounts: []string{
+		"", "anna", "ctrl\x07name", "has space", "k6.test-1.user", "nbsp name",
+		"tail>token", "weather.site-a.bot", "wild*card",
+	}}
+
+	got, err := collectUsableAccounts(context.Background(), rows, 100)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"anna"}, got.Accounts)
+	assert.Equal(t, 8, got.Skipped)
+	assert.Len(t, got.Sample, skipSample, "the sample is capped; the count carries the scale")
+}
+
+// A cursor that fails mid-walk must not look like a small population: an
+// export built on a truncated read would publish a pool nobody selected.
+func TestCollectUsableAccounts_PropagatesCursorErrors(t *testing.T) {
+	_, err := collectUsableAccounts(context.Background(),
+		&fakeRows{accounts: []string{"anna"}, err: errors.New("connection reset")}, 10)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read channel subscribers")
+
+	_, err = collectUsableAccounts(context.Background(),
+		&fakeRows{accounts: []string{"anna"}, decodeErr: errors.New("type mismatch")}, 10)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode channel subscriber")
 }


### PR DESCRIPTION
## Why

`loadgen pool-export` against a staging site died on **one row**: `k6.test-1.user`, left behind by another load tool. Nothing marks it as anything but a user — no `isBot` flag, no `.bot` suffix — but its dots span NATS subject tokens, so it reached `pkg/poolartifact`'s validator and failed the whole export. Every clientsim run against that site was blocked by a stale record from a tool nobody runs any more.

The validator is right: `subject.UserSubscriptionList` **panics** on such an account, so letting one through kills a pod rather than degrading it. What was wrong is *where* the rule was enforced — at the producer's last gate, as a hard failure, instead of during selection, where the empty account and the bot are already excluded. Same class of account, same treatment.

## What changed

```text
aggregation:  siteId / roomType / open / origin / grouped isBot / sort
              ↑ defines the POPULATION. It makes no judgement about an account string.

Go (collectUsableAccounts): walk the sorted cursor, keep what accountUsable accepts
                            until the bound, count what it walked past.
```

**Eligibility, the `--limit` bound and the skip evidence are one layer**, because they cannot be split without one of them lying:

- The layer that bounds has to be the layer that judges. A `$limit` counts whatever reaches it, so an account removed afterwards has already consumed a slot and `--limit N` quietly delivers fewer.
- The layer that judges is the only one that can report. A server-side filter hides the row from every counter downstream.

**No shape regex.** A `$match` regex would be a second dialect of `subject.IsValidAccountToken`, evaluated by another engine (MongoDB runs PCRE2, Go's `regexp` is RE2, and `\s` is not the same set in every one). Two spellings of one rule can only drift, and the account that panics a pod is exactly the one they disagree about. The cost is unusable rows crossing the wire — a rounding error beside the population — and a `$sort` the server cannot cap at top-N, over keys `$group` already materialised. The cursor stops early, so the Job's heap holds the bound, not the site.

The `isBot` flag stays a query filter: it defines *which subscriptions count*, like `roomType`, `open` and `origin`, rather than judging an account string. What it removes is the population's definition, not a skip.

## What the evidence claims

A `WARN` with the count and up to five examples, `skippedAccounts` in the manifest (always written, including zero — an absent field cannot tell a clean site from a version that never counted), and a failure that **names** what it dropped when a site's whole population is unusable, which is a different fix from a site nobody uses.

Read the count as *what this export walked past*, not a site total: a bounded export stops at `--limit` and never sees what sorts after the last account it took. Totalling the junk would turn every run into a census of the collection the bound exists to avoid reading. `limit` sits beside the count in the manifest, which is what says which reading applies.

Two smaller rules, both pinned by tests: a row whose `u.account` is absent or empty is counted like any other unusable candidate (the walk decodes `*string`, so a null row is read rather than filtered where nothing could count it) but never quoted — `""` names no leftover to clean up and would take a sample slot from a name that does; and the belt's catches lead the sample, because they are the accounts a source filtered *without* reporting.

## Review

Two rounds on the branch, both on the evidence rather than the selection, and both are in the history rather than squashed away:

| | |
|---|---|
| **The first version filtered in the pipeline and reported in Go** | So `k6.test-1.user` never reached the counter: `res.Skipped`, the WARN and `skippedAccounts` all read zero while the commit message claimed "dropped, counted, reported". The regex was also only an approximation — a unicode space or control rune passed it, consumed a `--limit` slot, and was dropped afterwards in Go. |
| **The second still overstated what it knew** | The count was presented as a site total though the walk stops at the bound; `cursorLimit`'s doc still described a server-side `$limit`; a null account was filtered while an empty string was counted; and a full source sample could crowd out every belt-caught name. |

## Verification

`make lint` clean · `make test SERVICE=tools/loadgen` green with `-race` · gosec and the repo's semgrep rule tests clean (`govulncheck` and the semgrep registry are unreachable from the authoring sandbox — CI covers them).

The walk sits behind a consumer-side `accountRows` interface, so bounding and counting are **unit**-tested rather than reachable only through a database — and mutation-tested: bound on rows, keep the unusable, stop counting, drop the null row, quote blanks, or reorder the sample, and a named test goes red for each. `collectUsableAccounts`, `accountUsable`, `dropUnusable`, `appendSkipSample` and `logSkippedAccounts` are at 100%.

Integration tests (CI only — no Docker in the sandbox) drive **real Mongo → `exportPool`** and assert the artifact, the result and the manifest together, including the unicode-space and control-rune accounts no regex could have caught, and the all-leftovers site that must fail naming `k6.test-1.user`.

No client-facing handler, NATS subject or `pkg/model` wire struct is touched, so `docs/client-api.md` needs no change.

## Note on the data

`k6.test-1.user` is junk left in `subscriptions` by k6 and worth cleaning up separately. Tolerating it here is so one dirty row cannot block a load test — not so it can live there forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HG2exSamSDTyxcxje1TuzZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG2exSamSDTyxcxje1TuzZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account selection during exports by validating account usability before inclusion.
  * Export limits now apply to usable accounts, ensuring requested account counts are met when possible.
  * Exports now handle invalid or unusable accounts more reliably, including clearer errors when no usable accounts remain.

* **Reporting**
  * Manifests, logs, and results now report skipped accounts and may include sample details for rejected accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->