### PR TITLE
Add cassandra-web to the local dev stack

### DIFF
--- a/docker-local/README.md
+++ b/docker-local/README.md
@@ -6,7 +6,7 @@ startable, and all five can run at once.
 
 | Stack | File | Targets | What |
 |---|---|---|---|
-| deps | `compose.deps.yaml` | `deps-up` / `deps-down` | NATS, MongoDB, Cassandra, Elasticsearch, Valkey, Keycloak, Vault, MinIO |
+| deps | `compose.deps.yaml` | `deps-up` / `deps-down` | NATS, MongoDB, Cassandra, cassandra-web, Elasticsearch, Valkey, Keycloak, Vault, MinIO |
 | services | `compose.services.yaml` | `up` / `up-detached` / `down` | Every Go microservice + the Traefik `/api/v1` gateway |
 | ui | `compose.ui.yaml` | `ui-up` / `ui-down` | chat-frontend, admin-frontend |
 | o11y | `compose.o11y.yaml` | `o11y-up` / `o11y-down` | OTLP collector, Tempo, Loki, Prometheus, Grafana |
@@ -354,6 +354,210 @@ brings it up first should check, and correct this README where reality differs:
    the parked forwards in `OUTBOX-site-local` should drain to ivan on their
    own — `outbox-worker` retries indefinitely (`MaxDeliver=-1`).
 
+## Browsing Cassandra
+
+`cassandra-web` ships with the deps stack at **http://localhost:8083** —
+keyspaces, tables, schema, a row browser and a CQL Query page. It is a
+prebuilt upstream image wired up with a handful of environment variables;
+there is no code of ours behind it.
+
+It is a community project, not an official Apache or DataStax tool — no such
+web UI exists. `ipushc/cassandra-web:v1.1.6` is the newest release; `latest`
+and `v1.1.5` resolve to the same image content, and the pinned version tag is
+preferred over `latest` for the usual reasons. Upstream has been quiet since
+August 2024, and the binary is built on Go 1.20.2, which
+`govulncheck -mode=binary` flags for 59 reachable stdlib advisories (mostly
+DoS-class in `net/http` and `html/template`). That is why the port is bound to
+`127.0.0.1` rather than every interface: it is a local viewer, not a service.
+If that trade stops being acceptable, Apache Zeppelin's Cassandra interpreter
+is the nearest maintained substitute, at a much larger footprint.
+
+Nothing seeds the Cassandra tables, so on a fresh stack they are empty until
+messages flow through the services. `make seed` populates MongoDB and Valkey
+only.
+
+**Which tab reads what** — the tool has two ways to show rows, and they do not
+have the same reach:
+
+| | Row browser (click a table) | Query page (type CQL) |
+|---|---|---|
+| `pinned_messages_by_room`, non-message tables | works | works |
+| `messages_by_room`, `messages_by_id`, `thread_messages_by_thread` | renders empty, always | works |
+| the `reactions` column | never | works, via `SELECT JSON` / `toJson` |
+
+So reactions **are** readable in the browser; they are just not readable from
+the row browser tab, which is the tab that cannot open those three tables at
+all. Both sections below say one half of that.
+
+> **An empty row browser proves nothing.** For those three tables the failure
+> mode and the genuinely-empty case render identically — a table with no rows
+> and no error. Never read it as "Cassandra has no messages". Confirm a count
+> from the Query page or `cqlsh` instead:
+>
+> ```sql
+> SELECT count(*) FROM chat.messages_by_id WHERE message_id = '<id>';
+> ```
+>
+> Or unrestricted, accepting the scan, only because the local dataset is tiny:
+> `docker exec chat-local-cassandra cqlsh -e "SELECT count(*) FROM chat.messages_by_id"`.
+
+`READ_ONLY` is **off** by default. This build rejects every Query-page
+statement when it is on — plain `SELECT`s included, with
+`"Update/Insert action are not allowed"` — and the Query page is the only path
+that reads the message tables (below). Set `CASSANDRA_WEB_READ_ONLY=true` in
+`docker-local/.env` to keep the UI's truncate/import/delete buttons away from
+real data, accepting that the Query page stops working.
+
+### Why the row browser cannot list the three message tables
+
+The row browser issues `SELECT *`, and that is what fails — not reactions
+specifically, and not the Query page. It fails *silently*, which is the part
+that bites: see the warning above before concluding a table is empty.
+
+This is not fixable from our side without owning a fork. The image is prebuilt
+upstream, the row browser has no per-table opt-out, and it surfaces a dropped
+connection as an empty result rather than an error. Patching it to select
+columns explicitly, or to render the failure, means maintaining a fork of a
+project last released in August 2024 — see the provenance note above. The
+documented Query-page route is the trade we took instead.
+
+`messages_by_room`, `messages_by_id` and `thread_messages_by_thread` carry
+`reactions MAP<FROZEN<reaction_key>, FROZEN<reactor_info>>`. Any generic
+browser has to read rows through gocql's untyped API (`Iter.SliceMap`), which
+builds the Go map type with `reflect.MapOf` — and a UDT decodes to
+`map[string]interface{}`, which is not a valid Go map key. The request panics
+server-side, the connection drops, and the table renders **empty with no
+error**. The other tabs (columns, definition) work normally.
+
+This is not a version lag, and bumping the driver does not fix it: the panic
+reproduces identically on gocql `v1.7.0` (what this repo pins) and on the
+newest `apache/cassandra-gocql-driver v2.1.2`. Our own services are unaffected
+because they scan the column into a typed `map[ReactionKey]ReactorInfo`, which
+gocql handles fine — the limitation is specific to the untyped path.
+
+`pinned_messages_by_room` has no reactions column, so `SELECT *` succeeds and
+it browses normally.
+
+### Reading the message tables, reactions included
+
+This is the part that works. Use the **Query** page and let *Cassandra* serialize the row, so the driver
+only ever sees `TEXT`. This is the standard way to read a UDT-keyed map from a
+driver that cannot represent one, and it needs no patched driver:
+
+Restrict every example to its full partition key — `message_id` for
+`messages_by_id`, `room_id` plus `bucket` for `messages_by_room`. A bare
+`LIMIT` caps the rows returned, not the token ranges and tombstones Cassandra
+walks to find them, so an unrestricted read is a cluster-wide scan even when it
+comes back empty:
+
+```sql
+-- whole rows, every column, reactions included
+SELECT JSON * FROM chat.messages_by_id WHERE message_id = '<id>';
+SELECT JSON * FROM chat.messages_by_room WHERE room_id = 'r-general' AND bucket = 1776816000000;
+
+-- or keep the row tabular and JSON-ify just the awkward column
+SELECT message_id, msg, sender, toJson(reactions) AS reactions_json
+  FROM chat.messages_by_id WHERE message_id = '<id>';
+```
+
+`SELECT JSON *` returns one `[json]` column holding the whole row. Only a bare
+`SELECT reactions` or `SELECT *` hits the panic — naming other columns
+explicitly is fine too:
+
+```sql
+SELECT room_id, created_at, message_id, msg, sender, tcount
+  FROM chat.messages_by_room WHERE room_id = 'r-general' AND bucket = 1776816000000;
+```
+
+`bucket` is `floor(created_at_unix_ms / windowMs) * windowMs`; the window comes
+from `MESSAGE_BUCKET_HOURS` (default 360) and the math lives in
+`pkg/msgbucket`. To find a room's populated buckets without scanning, read
+`lastMsgAt` off the room document in MongoDB and convert, or take the
+`message_id` from there and point-read `messages_by_id`.
+
+### Connecting to a Cassandra that needs auth
+
+The local Cassandra runs `AllowAllAuthenticator`, so no credentials are passed
+and none are needed. Pointing the stack at a cluster with
+`PasswordAuthenticator` needs the service-wide pair in `docker-local/.env`:
+
+```sh
+CASSANDRA_USERNAME=chatapp
+CASSANDRA_PASSWORD=...
+```
+
+Those are the names the Go services already read (`pkg/cassutil`), and
+cassandra-web falls back to them, so one pair is enough to get everything
+connected. The compose entry forwards them explicitly, because that container
+takes no `env_file`.
+
+The viewer also has its own pair, which takes precedence when set:
+
+```sh
+CASSANDRA_WEB_USERNAME=browser
+CASSANDRA_WEB_PASSWORD=...
+```
+
+Use it whenever the browser should not have the services' privileges — see the
+SELECT-only role below, which is exactly that case. `CASSANDRA_WEB_HOST` and
+`CASSANDRA_WEB_PORT` work the same way for the endpoint, defaulting to the
+`cassandra` container; without them, repointing the services with
+`CASSANDRA_HOSTS` would leave the viewer reading the old cluster and quietly
+showing stale state.
+
+Getting it wrong fails loudly rather than quietly: with auth on and no
+credentials the container **exits 1** during startup with
+`gocql: unable to create session: ... authentication required (using
+"org.apache.cassandra.auth.PasswordAuthenticator")`, so `make deps-up` stops
+on it instead of handing you a broken UI.
+
+**A SELECT-only role is a better lock than `READ_ONLY`.** `READ_ONLY=true`
+disables the Query page, which is the only way to read the message tables.
+Granting the browser's role reads alone keeps the Query page working and still
+refuses every write — Cassandra rejects it, and the UI surfaces the refusal:
+
+```sql
+CREATE ROLE browser WITH PASSWORD = '...' AND LOGIN = true;
+GRANT SELECT ON KEYSPACE chat TO browser;
+```
+
+Give that role to `CASSANDRA_WEB_USERNAME`/`CASSANDRA_WEB_PASSWORD`, **not** to
+the service-wide pair. The services share those, and message-worker needs
+`MODIFY`; pointing the whole stack at a SELECT-only role locks the browser down
+and stops every write in the system.
+
+A `TRUNCATE` or `INSERT` typed into the Query page then comes back as
+`User browser has no MODIFY permission on <table chat.messages_by_room>`,
+with nothing written. This needs `authorizer: CassandraAuthorizer`; with
+`AllowAllAuthorizer` every authenticated role can write regardless of grants.
+
+### Messages reach Cassandra encrypted
+
+`ATREST_ENABLED` defaults to **true** (`pkg/atrest`, wired in
+`message-worker/deploy/docker-compose.yml` and `history-service`'s), so
+message-worker writes the body to `enc_payload` as AES-GCM ciphertext with the
+nonce in `enc_meta` and leaves `msg` NULL. No browser can decrypt that —
+cassandra-web shows a base64 blob, which is the point of the feature. Every
+other column (sender, timestamps, thread counters, reactions) is plaintext and
+reads normally.
+
+To get readable bodies, put `ATREST_ENABLED=false` in `docker-local/.env` and
+restart the services — then message-worker takes the plaintext path. Vault also
+has to be reachable for the encrypted path to work at all; see "Vault and
+encrypted rooms" below for the DEK reset after a Vault restart.
+
+`cqlsh` is the other way in, and renders UDTs and maps directly with no JSON
+wrapper:
+
+```sh
+docker exec chat-local-cassandra cqlsh -e \
+  "SELECT message_id, reactions FROM chat.messages_by_id WHERE message_id='...'"
+```
+
+Under the federated stack one `cassandra-web` serves both sites, since
+`compose.fed-deps.yaml` homes `chat` and `chat_remote` in the one shared
+Cassandra.
+
 ## Logging in
 
 `make seed` writes `chat.users` and the `chat.hr_employee` enrichment rows that
@@ -431,6 +635,7 @@ the `local` column, since both sites run at once.
 | 7778 | | NATS Prometheus exporter | localhost-only |
 | 8080 | **8190** | auth-service | also reachable as `{baseUrl}/api/v1/auth`; site-remote is `+110`, not `+100`, because 8180 is Keycloak |
 | 8082 | 8182 | admin-service | admin-frontend talks here directly |
+| 8083 | shared | cassandra-web | Cassandra data browser; localhost-only |
 | 8085 | 8185 | portal-service | portal-direct, deliberately not behind the gateway |
 | 8086 | 8186 | upload-service | also `{baseUrl}/api/v1/file` |
 | 8087 | 8187 | tcard-service | |

--- a/docker-local/compose.deps.yaml
+++ b/docker-local/compose.deps.yaml
@@ -112,6 +112,85 @@ services:
     networks:
       - chat-local
 
+  # Browse the Cassandra data at http://localhost:8083 — keyspaces, tables,
+  # schema, row browser and a CQL Query page. Nothing seeds these tables, so on
+  # a fresh stack they are empty until messages flow through the services.
+  #
+  # `chat.pinned_messages_by_room` is the message table to open first in the row
+  # browser: it has no reactions column, so it lists normally.
+  #
+  # KNOWN LIMITATION — the *row browser* cannot list chat.messages_by_room,
+  # chat.messages_by_id or chat.thread_messages_by_thread. Those carry
+  # `reactions MAP<FROZEN<reaction_key>, FROZEN<reactor_info>>`, and gocql's
+  # untyped row API (Iter.SliceMap, which any generic browser must use) builds
+  # the Go map type with reflect.MapOf — a UDT decodes to map[string]interface{},
+  # which is not a valid Go map key, so the request panics and the table renders
+  # empty with no error — indistinguishable from a genuinely empty table, so
+  # never read it as "Cassandra has no messages". This is not a version lag: it
+  # reproduces identically on
+  # gocql v1.7.0 (the version this repo pins) and on the newest
+  # apache/cassandra-gocql-driver v2.1.2, so no driver bump fixes it.
+  #
+  # The Query page reads those tables fine, reactions included, by asking
+  # Cassandra to serialize server-side so the driver only ever sees TEXT:
+  #   SELECT JSON * FROM chat.messages_by_room WHERE room_id='r-general' AND bucket=...;
+  #   SELECT message_id, msg, toJson(reactions) FROM chat.messages_by_id LIMIT 20;
+  # Only a bare `SELECT reactions`/`SELECT *` hits the panic.
+  #
+  # Message bodies do not arrive readable: ATREST_ENABLED defaults to true, so
+  # message-worker puts the body in enc_payload as ciphertext and leaves msg
+  # NULL. See the README's "Messages reach Cassandra encrypted".
+  #
+  # READ_ONLY is off by default: the build rejects *every* Query-page statement
+  # when it is on, plain SELECTs included, which would disable the one path that
+  # reads these tables. Set CASSANDRA_WEB_READ_ONLY=true in docker-local/.env to
+  # keep the UI's truncate/import/delete buttons from reaching real data, at the
+  # cost of the Query page. Against a cluster with auth, a SELECT-only role is
+  # the better lock: Cassandra refuses the write and the Query page keeps
+  # working. See the README's "Connecting to a Cassandra that needs auth".
+  cassandra-web:
+    image: ipushc/cassandra-web:v1.1.6
+    container_name: chat-local-cassandra-web
+    # Bound to 127.0.0.1, following the same rule the obs stack uses for its
+    # dev-only UIs. Upstream's last release is Aug 2024, built on Go 1.20.2;
+    # `govulncheck -mode=binary` reports 59 reachable stdlib advisories in it,
+    # mostly DoS-class in net/http and html/template. Fine for a viewer only
+    # the developer can reach, not something to expose on a shared network.
+    ports:
+      - "127.0.0.1:${CASSANDRA_WEB_HOST_PORT:-8083}:8083"
+    environment:
+      # Browser-specific endpoint, defaulting to the container above. Pointing
+      # the Go services at another cluster via CASSANDRA_HOSTS would otherwise
+      # leave the viewer reading the local one and showing stale or empty state
+      # with no error. CASSANDRA_HOSTS is a comma-separated host:port list and
+      # this image takes a single host plus port, so it gets its own pair
+      # rather than a parse of that one.
+      - CASSANDRA_HOST=${CASSANDRA_WEB_HOST:-cassandra}
+      - CASSANDRA_PORT=${CASSANDRA_WEB_PORT:-9042}
+      - HOST_PORT=:8083
+      # Dedicated credentials, falling back to the service-wide pair. They are
+      # separate because the roles differ: the browser wants SELECT only, while
+      # message-worker and the other writers need MODIFY. Sharing one pair
+      # forces a choice between a write-capable browser and a stack that cannot
+      # write. Empty is correct for the local Cassandra, which runs
+      # AllowAllAuthenticator; against an authenticating cluster the container
+      # exits 1 at startup with "authentication required" rather than serving a
+      # broken UI.
+      - CASSANDRA_USERNAME=${CASSANDRA_WEB_USERNAME:-${CASSANDRA_USERNAME:-}}
+      - CASSANDRA_PASSWORD=${CASSANDRA_WEB_PASSWORD:-${CASSANDRA_PASSWORD:-}}
+      - READ_ONLY=${CASSANDRA_WEB_READ_ONLY:-false}
+    depends_on:
+      cassandra:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8083/keyspace >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    networks:
+      - chat-local
+
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
     container_name: chat-local-elasticsearch

--- a/docker-local/compose.fed-deps.yaml
+++ b/docker-local/compose.fed-deps.yaml
@@ -114,6 +114,13 @@ services:
     container_name: chat-fed-cassandra
     networks: [chat-site-remote]
 
+  # One viewer for both sites: it browses whole keyspaces, and fed-deps homes
+  # `chat` and `chat_remote` in the single shared Cassandra above.
+  cassandra-web:
+    extends: { file: ./compose.deps.yaml, service: cassandra-web }
+    container_name: chat-fed-cassandra-web
+    networks: [chat-site-remote]
+
   elasticsearch:
     extends: { file: ./compose.deps.yaml, service: elasticsearch }
     container_name: chat-fed-elasticsearch

--- a/docker-local/setup.sh
+++ b/docker-local/setup.sh
@@ -167,6 +167,12 @@ DEV_MODE=true
 #UPLOAD_SERVICE_HOST_PORT=8086
 #TCARD_SERVICE_HOST_PORT=8087
 #SEARCH_SERVICE_HOST_PORT=19090
+#CASSANDRA_WEB_HOST_PORT=8083     # Cassandra data browser (bound to 127.0.0.1)
+#CASSANDRA_WEB_READ_ONLY=false    # true protects data but disables the Query page
+#CASSANDRA_WEB_HOST=cassandra     # viewer endpoint; defaults to the local container
+#CASSANDRA_WEB_PORT=9042
+#CASSANDRA_WEB_USERNAME=          # viewer-only role (e.g. SELECT-only); falls
+#CASSANDRA_WEB_PASSWORD=          # back to CASSANDRA_USERNAME/PASSWORD
 #
 # Stack-wide settings.
 #SITE_ID=site-local            # also drives ES index names, buckets, site URLs
@@ -178,6 +184,8 @@ DEV_MODE=true
 #MONGO_URI=mongodb://mongodb:27017
 #MONGO_DB=chat
 #CASSANDRA_HOSTS=cassandra
+#CASSANDRA_USERNAME=            # set both if the cluster needs auth;
+#CASSANDRA_PASSWORD=            # services and cassandra-web share them
 #CASSANDRA_KEYSPACE=chat
 #VALKEY_ADDRS=valkey:6379
 #SEARCH_URL=http://elasticsearch:9200


### PR DESCRIPTION
## Why

Nothing in the local stack showed what was in Cassandra. Reading the message tables meant opening a `cqlsh` session.

## What

`cassandra-web` at **http://127.0.0.1:8083**, in both the single-site and federated deps stacks. It is a prebuilt upstream image wired up with environment variables only — no code of ours, no Dockerfile, no build step. One instance serves both sites, since `compose.fed-deps.yaml` homes `chat` and `chat_remote` in the one shared Cassandra.

The whole change is four files in `docker-local/`: the service block, a 4-line federated entry, commented env knobs in `setup.sh`, and the README section.

Knobs, all optional and all defaulting to the local stack:

| Variable | Default | Purpose |
|---|---|---|
| `CASSANDRA_WEB_HOST_PORT` | `8083` | published port, bound to `127.0.0.1` |
| `CASSANDRA_WEB_HOST` / `_PORT` | `cassandra` / `9042` | viewer's endpoint, independent of the services' `CASSANDRA_HOSTS` |
| `CASSANDRA_WEB_USERNAME` / `_PASSWORD` | falls back to `CASSANDRA_USERNAME` / `_PASSWORD` | viewer-only role, so a SELECT-only browser does not disarm the writers |
| `CASSANDRA_WEB_READ_ONLY` | `false` | see below |

`READ_ONLY` is off because this build rejects every Query-page statement while it is on — plain `SELECT`s included, with `Update/Insert action are not allowed` — and the Query page is the only path that reads the three message tables. For locking the viewer down, a SELECT-only Cassandra role is the better tool: it refuses writes *and* keeps the Query page working. Verified both.

The port is bound to loopback rather than every interface. Upstream's last release is Aug 2024 on Go 1.20.2, and `govulncheck -mode=binary` reports 59 reachable stdlib advisories in it, mostly DoS-class in `net/http` and `html/template`. Acceptable for a viewer only the developer can reach; not something to expose on a shared network.

## Two behaviours documented rather than worked around

**The row browser cannot list `messages_by_room`, `messages_by_id` or `thread_messages_by_thread`.** Those carry `reactions MAP<FROZEN<reaction_key>, FROZEN<reactor_info>>`, and gocql's untyped row API builds the Go map type with `reflect.MapOf`; a UDT decodes to `map[string]interface{}`, which is not a valid Go map key. The request panics server-side and the table renders empty with no error.

That silence is the real hazard, so the README says it outright: **an empty row browser proves nothing** for those three tables, and it is never evidence that Cassandra has no messages. Confirm with a count from the Query page or `cqlsh` instead.

No driver bump fixes the panic. I verified it reproduces identically on gocql `v1.7.0` (what this repo pins) and on the newest `apache/cassandra-gocql-driver v2.1.2`. Our own services are unaffected because they scan the column into a typed `map[ReactionKey]ReactorInfo`.

The Query page reads those tables fine, reactions included, by asking Cassandra to serialize server-side so the driver only ever sees `TEXT`. Examples are restricted to the full partition key, since `LIMIT` caps rows returned rather than token ranges walked:

```sql
SELECT JSON * FROM chat.messages_by_id WHERE message_id = '<id>';
SELECT message_id, msg, sender, toJson(reactions) AS reactions_json
  FROM chat.messages_by_id WHERE message_id = '<id>';
```

`pinned_messages_by_room` has no reactions column and browses normally.

**Message bodies arrive encrypted.** `ATREST_ENABLED` defaults to true, so message-worker writes the body to `enc_payload` as ciphertext and leaves `msg` NULL. No browser can decrypt that; every other column reads normally, and `ATREST_ENABLED=false` is the escape hatch.

## Scope note

An earlier revision of this branch also seeded the Cassandra message tables so the UI had data on a fresh stack. That was dropped at the author's request — this PR is the viewer only. The tables stay empty until messages flow through the services, and `make seed` still populates MongoDB and Valkey only.

## Review round

Five findings from `tGDBot` and two from CodeRabbit. Four fixed in `5c44614`: dedicated viewer credentials (following the old README advice would have stopped every service write), a parameterized endpoint, partition-key-restricted query examples, and the silent-failure warning above.

One I declined with evidence, and left the thread open for a human to arbitrate: the blocking finding claimed the image reads `CASSANDRA_HOST_IP` rather than `CASSANDRA_HOST` and cannot reach Cassandra at all. It does read `CASSANDRA_HOST`, and applying the suggestion would have broken the stack. The image's own `/config.yaml` declares that key, `CASSANDRA_HOST_IP` appears nowhere in it, and a crossed A/B test settles it:

| Env | Result |
|---|---|
| `CASSANDRA_HOST=bogus` + `CASSANDRA_HOST_IP=cassandra` | exits 1, `failed to resolve` |
| `CASSANDRA_HOST=cassandra` + `CASSANDRA_HOST_IP=bogus` | runs, `/keyspace` → 200 |

The two CodeRabbit findings target the removed seeder; one was already fixed, the other no longer applies to this diff.

## Verification

Run against real containers:

- `docker compose --wait cassandra-web` reports healthy, so the healthcheck does not stall `make deps-up`. I confirmed the image ships busybox `wget` before relying on it.
- Keyspace, table and column listing verified against a live Cassandra, including with the tables empty.
- Query page verified returning rows, and returning cleanly on empty tables.
- The row-browser panic and the `SELECT JSON` / `toJson` workaround both reproduced end to end in the browser UI.
- Authentication tested by switching the local Cassandra to `PasswordAuthenticator` + `CassandraAuthorizer`: no credentials → container exits 1 with a clear `authentication required`; with credentials → connects; SELECT-only role → writes refused by Cassandra with the Query page still working. Reverted afterwards.
- Both credential and endpoint fallback chains verified with `docker compose config`.
- `docker compose config` clean on both the single-site and federated files.

No Go code changes, so lint, tests and SAST are untouched by this diff; `make lint` and the full unit suite were run green anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hn2kikZ43XKnLDP1p88z2X